### PR TITLE
Sonnet 4.6 testing

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -7,7 +7,12 @@
       "Bash(npm run build:*)",
       "Bash(npx tsc:*)",
       "Bash(npx vitest:*)",
-      "Bash(npx vite build:*)"
+      "Bash(npx vite build:*)",
+      "Bash(npm install:*)"
     ]
+  },
+  "sandbox": {
+    "enabled": true,
+    "autoAllowBashIfSandboxed": true
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,4 +48,4 @@ When modifying `README.md`, `docs/PHASE-*.md`, or `docs/ROADMAP.md`:
 | `🚧 In Progress` | `"current"`      |
 | Otherwise        | `"upcoming"`     |
 
-**After implementing ANY new features:** Ask if the user wants README and docs updated.
+**After implementing ANY new features:** Update `docs/PHASE-*.md` immediately — do not wait to be asked. Check every phase whose success criteria or task table is affected and update checkboxes + status lines in the same commit as the feature work.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Rules
 
-- **Docs:** Update `docs/PHASE-*.md` in the same commit as feature work. No exceptions, no prompting.
+- **After implementing ANY new features:** Update `docs/PHASE-*.md` immediately — do not wait to be asked. Check every phase whose success criteria or task table is affected and update checkboxes + status lines in the same commit as the feature work.
 - **Roadmap sync:** When `docs/PHASE-*.md` changes, update `website/src/pages/Roadmap.tsx` to match (`✓ Complete` → `"complete"`, `🚧 In Progress` → `"current"`, else `"upcoming"`).
 - **Time estimates:** Machine time only ("one conversation", "~10 min"). Never quote human hours/days.
 - **IDs:** Display tail — `...${id.slice(-8)}`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,51 +1,32 @@
 # Agent Instructions
 
-## CRITICAL
+## Rules
 
-### Automerge Mutations
+- **Docs:** Update `docs/PHASE-*.md` in the same commit as feature work. No exceptions, no prompting.
+- **Roadmap sync:** When `docs/PHASE-*.md` changes, update `website/src/pages/Roadmap.tsx` to match (`✓ Complete` → `"complete"`, `🚧 In Progress` → `"current"`, else `"upcoming"`).
+- **Time estimates:** Machine time only ("one conversation", "~10 min"). Never quote human hours/days.
+- **IDs:** Display tail — `...${id.slice(-8)}`.
 
-Mutations require `change()` wrapper—direct mutation silently fails to sync:
+## Package Boundaries
 
-```typescript
-doc.change((d) => {
-  d.items.push(item);
-}); // ✅ syncs
-doc.items.push(item); // ❌ silent failure
+| Package | Rule |
+|---|---|
+| `shared/` | Pure functions + types. Zero runtime deps. |
+| `sync/` | Storage-agnostic. Works in browser (IndexedDB) and Node (filesystem). |
+| `pwa/` | Primary UI. Never import Tauri APIs. |
+| `desktop/` | Tauri shell. May import from `@freed/pwa`. |
+| `capture-*/` | Isolated. Never import between capture packages. |
+
+## Automerge
+
+**Schema** (`packages/shared/src/schema.ts`): backward-compatible only. Add optional fields; never delete (mark `@deprecated`).
+
+**Mutations** must use `A.change()` — direct mutation silently fails to sync:
+```ts
+A.change(doc, d => { d.items.push(item) }) // ✅
+doc.items.push(item)                        // ❌ silent failure
 ```
 
-### Package Boundaries
-
-```
-packages/
-├── shared/       → @freed/shared   │ Types + pure functions. Zero runtime dependencies.
-├── sync/         → @freed/sync     │ Storage-agnostic. Works in browser (IndexedDB) AND Node (filesystem).
-├── pwa/          → @freed/pwa      │ Primary UI. Must never import Tauri APIs.
-├── desktop/      → @freed/desktop  │ Tauri shell. Imports from @freed/pwa.
-├── capture-*/    →                 │ Isolated. Never import between capture packages.
-```
-
-## Automerge Schema
-
-Location: `packages/shared/src/schema.ts`
-
-**Schema changes must be backward-compatible.** Add optional fields with defaults. Never delete fields—mark `@deprecated`.
-
-## Conventions
-
-**Time estimates:** Express in machine time (how long the agent will take), not human hours. Examples: "one focused conversation," "~10 minutes of edits," "a quick refactor." Never quote hours/days as if a human were doing the work.
-
-**ID fragments:** Display tail, not head—`...${id.slice(-8)}` (better entropy).
-
-## Triggered Updates
-
-When modifying `README.md`, `docs/PHASE-*.md`, or `docs/ROADMAP.md`:
-
-→ Update `website/src/pages/Roadmap.tsx` in the same commit.
-
-| Doc Status       | Roadmap `status` |
-| ---------------- | ---------------- |
-| `✓ Complete`     | `"complete"`     |
-| `🚧 In Progress` | `"current"`      |
-| Otherwise        | `"upcoming"`     |
-
-**After implementing ANY new features:** Update `docs/PHASE-*.md` immediately — do not wait to be asked. Check every phase whose success criteria or task table is affected and update checkboxes + status lines in the same commit as the feature work.
+**Proxy constraints inside `A.change()`:**
+- Never assign `undefined` — use `delete` instead
+- Never replace an existing nested object — assign fields individually or use a `deepMergeInto` helper

--- a/docs/PHASE-1-FOUNDATION.md
+++ b/docs/PHASE-1-FOUNDATION.md
@@ -203,7 +203,7 @@ Two Vercel projects, both auto-deploy on push to `main` with preview deploys on 
 | ---- | -------------------------------------------- | ------ |
 | 1.1  | Initialize monorepo with npm workspaces      | ✓      |
 | 1.2  | Create `@freed/shared` with core types       | ✓      |
-| 1.3  | Implement Automerge document schema          | ✓      |
+| 1.3  | Implement Automerge document schema          | ✓ (bugfixes: toggleSaved delete, updatePreferences deepMerge) |
 | 1.4  | Build marketing site (landing, manifesto)    | ✓      |
 | 1.5  | Set up GitHub Actions CI/CD                  | ✓      |
 | 1.6  | Configure custom domain (freed.wtf)          | ✓      |

--- a/docs/PHASE-4-SYNC.md
+++ b/docs/PHASE-4-SYNC.md
@@ -1,6 +1,6 @@
 # Phase 4: Sync Layer
 
-> **Status:** 🚧 In Progress  
+> **Status:** ✅ Core Complete (cloud sync fallback pending)
 > **Dependencies:** Phase 1-2 (Capture layers ✓), Phase 3 (Save for Later ✓)
 
 ---
@@ -270,13 +270,14 @@ Each provider stores a single Automerge binary file. CRDT handles merge conflict
 
 ## Success Criteria
 
-- [ ] Data persists in IndexedDB (browser) and filesystem (Desktop)
-- [ ] Desktop hosts WebSocket relay on local network
-- [ ] PWA connects to local relay when available (<100ms sync)
+- [x] Data persists in IndexedDB (both Desktop WebView and PWA use `@freed/sync` IndexedDBStorage)
+- [x] Desktop hosts WebSocket relay on local network (Rust relay on port 8765)
+- [x] PWA connects to local relay using binary Automerge protocol (fixed from JSON bug)
+- [x] Desktop broadcasts doc changes to connected PWA clients via `broadcast_doc` Tauri command
+- [x] QR code or manual pairing connects PWA to Desktop (SyncConnectDialog with QR scanner)
+- [x] Sync connection status observable (`onStatusChange` listener in sync.ts)
 - [ ] PWA falls back to cloud sync when away from home
 - [ ] At least one cloud provider works (GDrive recommended)
-- [ ] QR code or manual pairing connects PWA to Desktop
-- [ ] Sync status UI shows "Local" vs "Cloud" vs "Offline"
 
 ---
 

--- a/docs/PHASE-5-DESKTOP.md
+++ b/docs/PHASE-5-DESKTOP.md
@@ -1,6 +1,6 @@
 # Phase 5: Desktop & Mobile App (Tauri)
 
-> **Status:** 🚧 In Progress  
+> **Status:** ✅ Core Complete (packaging/distribution pending)
 > **Dependencies:** Phase 4 (Sync Layer)  
 > **Priority:** 🎯 HIGHEST — Universal liberation tool
 
@@ -240,12 +240,12 @@ packages/desktop/
 
 ### Desktop
 
-- [ ] Desktop app launches with native vibrancy on macOS
-- [ ] Captures from X, RSS in background
-- [ ] Local WebSocket relay enables instant phone sync
-- [ ] QR code pairing works
-- [ ] System tray shows sync status
-- [ ] App runs in background after window close
+- [x] Desktop app launches with native vibrancy on macOS
+- [x] Captures from X, RSS in background (refreshAllFeeds covers both)
+- [x] Local WebSocket relay enables instant phone sync (binary protocol)
+- [x] QR code pairing works
+- [x] System tray shows sync status
+- [x] App runs in background after window close
 - [ ] macOS DMG is notarized and installable
 - [ ] Windows installer works
 - [ ] Linux AppImage works

--- a/docs/PHASE-6-PWA.md
+++ b/docs/PHASE-6-PWA.md
@@ -1,6 +1,6 @@
 # Phase 6: PWA Reader
 
-> **Status:** 🚧 In Progress  
+> **Status:** ✅ Core Complete (offline image cache + homescreen install testing pending)
 > **Dependencies:** Phase 4 (Sync Layer), Phase 5 (Desktop App)
 
 ---
@@ -222,15 +222,15 @@ Build chain: `@freed/shared` → `@freed/sync` → `vite build` (configured in `
 ## Success Criteria
 
 - [x] PWA deploys to app.freed.wtf via Vercel
-- [ ] Feed displays items from Automerge document
-- [ ] Per-source unread tracking works for opted-in feeds
-- [ ] Virtual scrolling handles 1000+ items smoothly
-- [ ] Reading enhancements work correctly
-- [ ] Ranking weights affect item order
-- [ ] Platform/author filters work
-- [ ] RSS subscription management functional
-- [ ] PWA installable on mobile (add to homescreen)
-- [ ] Offline access works (service worker + image cache)
+- [x] Feed displays items from Automerge document
+- [x] Per-source unread tracking works for opted-in feeds
+- [x] Virtual scrolling handles 1000+ items smoothly
+- [x] Reading enhancements work correctly (focus mode, font, reader view)
+- [x] Ranking weights affect item order
+- [x] Platform/author filters work (sidebar filter by platform/feed)
+- [x] RSS subscription management functional (add/remove/OPML import-export)
+- [ ] PWA installable on mobile (add to homescreen) — manifest exists, needs testing
+- [ ] Offline access works (service worker + image cache) — SW registered, image cache pending
 
 ---
 

--- a/docs/PHASE-7-SOCIAL-CAPTURE.md
+++ b/docs/PHASE-7-SOCIAL-CAPTURE.md
@@ -1,6 +1,6 @@
 # Phase 7: Facebook + Instagram Capture
 
-> **Status:** Not Started  
+> **Status:** 🚧 In Progress — packages scaffolded, scraper logic complete; selector tuning and integration with Desktop pending
 > **Dependencies:** Phase 5 (Desktop App with Playwright)
 
 ---
@@ -223,12 +223,15 @@ const RATE_LIMITS = {
 
 ## Success Criteria
 
-- [ ] Facebook feed posts captured to FeedItem
-- [ ] Instagram feed posts captured to FeedItem
-- [ ] Location data extracted from Instagram posts
+- [x] `@freed/capture-facebook` package scaffolded with full scraper, normalizer, session management, and rate limiting
+- [x] `@freed/capture-instagram` package scaffolded with full scraper, normalizer, session management, and rate limiting
+- [x] Location data extracted from Facebook check-ins and Instagram location tags
+- [x] Rate limiting prevents account bans (5m Facebook, 10m Instagram minimums with exponential backoff)
+- [x] Selector versioning strategy implemented (SELECTOR_VERSION constant)
+- [ ] Facebook feed posts validated against real account (selector tuning)
+- [ ] Instagram feed posts validated against real account (selector tuning)
 - [ ] Stories captured (if feasible)
-- [ ] Rate limiting prevents account bans
-- [ ] Selector updates can be deployed quickly
+- [ ] Integrated into Desktop refreshAllFeeds()
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "name": "freed",
+      "hasInstallScript": true,
       "workspaces": [
         "packages/*",
         "skills/*",
@@ -199,6 +200,19 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@babel/helper-annotate-as-pure": {
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz",
+      "integrity": "sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.27.3"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-compilation-targets": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
@@ -236,12 +250,103 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/@babel/helper-create-class-features-plugin": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.6.tgz",
+      "integrity": "sha512-dTOdvsjnG3xNT9Y0AUg1wAl38y+4Rl4sf9caSQZOXdNqVn+H+HbbJ4IyyHaIqNR6SW9oJpA/RuRjsjCw2IdIow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.3",
+        "@babel/helper-member-expression-to-functions": "^7.28.5",
+        "@babel/helper-optimise-call-expression": "^7.27.1",
+        "@babel/helper-replace-supers": "^7.28.6",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+        "@babel/traverse": "^7.28.6",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-create-class-features-plugin/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-create-regexp-features-plugin": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.28.5.tgz",
+      "integrity": "sha512-N1EhvLtHzOvj7QQOUCCS3NrPJP8c5W6ZXCHDn7Yialuy1iu4r5EmIYkXlKNqT99Ciw+W0mDqWoR6HWMZlFP3hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.3",
+        "regexpu-core": "^6.3.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-create-regexp-features-plugin/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-define-polyfill-provider": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.6.tgz",
+      "integrity": "sha512-mOAsxeeKkUKayvZR3HeTYD/fICpCPLJrU5ZjelT/PA6WHtNDBOE436YiaEUvHN454bRM3CebhDsIpieCc4texA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "debug": "^4.4.3",
+        "lodash.debounce": "^4.0.8",
+        "resolve": "^1.22.11"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
     "node_modules/@babel/helper-globals": {
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
       "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.28.5.tgz",
+      "integrity": "sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.5",
+        "@babel/types": "^7.28.5"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -278,12 +383,75 @@
         "@babel/core": "^7.0.0"
       }
     },
+    "node_modules/@babel/helper-optimise-call-expression": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.27.1.tgz",
+      "integrity": "sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-plugin-utils": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
       "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-remap-async-to-generator": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.27.1.tgz",
+      "integrity": "sha512-7fiA521aVw8lSPeI4ZOD3vRFkoqkJcS+z4hFo82bFSH/2tNd6eJ5qCVMS5OzDmZh/kaHQeBaeyxK6wljcPtveA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.1",
+        "@babel/helper-wrap-function": "^7.27.1",
+        "@babel/traverse": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-replace-supers": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.28.6.tgz",
+      "integrity": "sha512-mq8e+laIk94/yFec3DxSjCRD2Z0TAjhVbEJY3UQrlwVo15Lmt7C2wAUbK4bjnTs4APkwsYLTahXRraQXhb1WCg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-member-expression-to-functions": "^7.28.5",
+        "@babel/helper-optimise-call-expression": "^7.27.1",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.27.1.tgz",
+      "integrity": "sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.27.1",
+        "@babel/types": "^7.27.1"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -318,6 +486,21 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-wrap-function": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.28.6.tgz",
+      "integrity": "sha512-z+PwLziMNBeSQJonizz2AGnndLsP2DeGHIxDAn+wdHOGuo4Fo1x1HBPPXeE9TAOPHNNWQKCSlA2VZyYyyibDnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helpers": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
@@ -346,6 +529,811 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.28.5.tgz",
+      "integrity": "sha512-87GDMS3tsmMSi/3bWOte1UblL+YUTFMV8SZPZ2eSEL17s74Cw/l63rR6NmGVKMYW2GYi85nE+/d6Hw5N0bEk2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/traverse": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-bugfix-safari-class-field-initializer-scope": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-7.27.1.tgz",
+      "integrity": "sha512-qNeq3bCKnGgLkEXUuFry6dPlGfCdQNZbn7yUAPCInwAJHMU7THJfrBSozkcWq5sNM6RcF3S8XyQL2A52KNR9IA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.27.1.tgz",
+      "integrity": "sha512-g4L7OYun04N1WyqMNjldFwlfPCLVkgB54A/YCXICZYBsvJJE3kByKv9c9+R/nAfmIfjl2rKYLNyMHboYbZaWaA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.27.1.tgz",
+      "integrity": "sha512-oO02gcONcD5O1iTLi/6frMJBIwWEHceWGSGqrpCmEL8nogiS6J9PBlE48CaK20/Jx1LuRml9aDftLgdjXT8+Cw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+        "@babel/plugin-transform-optional-chaining": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.13.0"
+      }
+    },
+    "node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.28.6.tgz",
+      "integrity": "sha512-a0aBScVTlNaiUe35UtfxAN7A/tehvvG4/ByO6+46VPKTRSlfnAFsgKy0FUh+qAkQrDTmhDkT+IBOKlOoMUxQ0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-proposal-private-property-in-object": {
+      "version": "7.21.0-placeholder-for-preset-env.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
+      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-assertions": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.28.6.tgz",
+      "integrity": "sha512-pSJUpFHdx9z5nqTSirOCMtYVP2wFgoWhP0p3g8ONK/4IHhLIBd0B9NYqAvIUAhq+OkhO4VM1tENCt0cjlsNShw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-attributes": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.28.6.tgz",
+      "integrity": "sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-unicode-sets-regex": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-unicode-sets-regex/-/plugin-syntax-unicode-sets-regex-7.18.6.tgz",
+      "integrity": "sha512-727YkEAPwSIQTv5im8QHz3upqp92JTWhidIC81Tdx4VJYIte/VndKf1qKrfnnhPLiPghStWfvC/iFaMCQu7Nqg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-arrow-functions": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.27.1.tgz",
+      "integrity": "sha512-8Z4TGic6xW70FKThA5HYEKKyBpOOsucTOD1DjU3fZxDg+K3zBJcXMFnt/4yQiZnf5+MiOMSXQ9PaEK/Ilh1DeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-async-generator-functions": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.29.0.tgz",
+      "integrity": "sha512-va0VdWro4zlBr2JsXC+ofCPB2iG12wPtVGTWFx2WLDOM3nYQZZIGP82qku2eW/JR83sD+k2k+CsNtyEbUqhU6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/helper-remap-async-to-generator": "^7.27.1",
+        "@babel/traverse": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-async-to-generator": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.28.6.tgz",
+      "integrity": "sha512-ilTRcmbuXjsMmcZ3HASTe4caH5Tpo93PkTxF9oG2VZsSWsahydmcEHhix9Ik122RcTnZnUzPbmux4wh1swfv7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/helper-remap-async-to-generator": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-block-scoped-functions": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.27.1.tgz",
+      "integrity": "sha512-cnqkuOtZLapWYZUYM5rVIdv1nXYuFVIltZ6ZJ7nIj585QsjKM5dhL2Fu/lICXZ1OyIAFc7Qy+bvDAtTXqGrlhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-block-scoping": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.28.6.tgz",
+      "integrity": "sha512-tt/7wOtBmwHPNMPu7ax4pdPz6shjFrmHDghvNC+FG9Qvj7D6mJcoRQIF5dy4njmxR941l6rgtvfSB2zX3VlUIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-class-properties": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.28.6.tgz",
+      "integrity": "sha512-dY2wS3I2G7D697VHndN91TJr8/AAfXQNt5ynCTI/MpxMsSzHp+52uNivYT5wCPax3whc47DR8Ba7cmlQMg24bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-class-static-block": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.28.6.tgz",
+      "integrity": "sha512-rfQ++ghVwTWTqQ7w8qyDxL1XGihjBss4CmTgGRCTAC9RIbhVpyp4fOeZtta0Lbf+dTNIVJer6ych2ibHwkZqsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.12.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-classes": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.28.6.tgz",
+      "integrity": "sha512-EF5KONAqC5zAqT783iMGuM2ZtmEBy+mJMOKl2BCvPZ2lVrwvXnB6o+OBWCS+CoeCCpVRF2sA2RBKUxvT8tQT5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.3",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/helper-replace-supers": "^7.28.6",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-computed-properties": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.28.6.tgz",
+      "integrity": "sha512-bcc3k0ijhHbc2lEfpFHgx7eYw9KNXqOerKWfzbxEHUGKnS3sz9C4CNL9OiFN1297bDNfUiSO7DaLzbvHQQQ1BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/template": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-destructuring": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.28.5.tgz",
+      "integrity": "sha512-Kl9Bc6D0zTUcFUvkNuQh4eGXPKKNDOJQXVyyM4ZAQPMveniJdxi8XMJwLo+xSoW3MIq81bD33lcUe9kZpl0MCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/traverse": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-dotall-regex": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.28.6.tgz",
+      "integrity": "sha512-SljjowuNKB7q5Oayv4FoPzeB74g3QgLt8IVJw9ADvWy3QnUb/01aw8I4AVv8wYnPvQz2GDDZ/g3GhcNyDBI4Bg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.28.5",
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-duplicate-keys": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.27.1.tgz",
+      "integrity": "sha512-MTyJk98sHvSs+cvZ4nOauwTTG1JeonDjSGvGGUNHreGQns+Mpt6WX/dVzWBHgg+dYZhkC4X+zTDfkTU+Vy9y7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-duplicate-named-capturing-groups-regex": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.29.0.tgz",
+      "integrity": "sha512-zBPcW2lFGxdiD8PUnPwJjag2J9otbcLQzvbiOzDxpYXyCuYX9agOwMPGn1prVH0a4qzhCKu24rlH4c1f7yA8rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.28.5",
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-dynamic-import": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.27.1.tgz",
+      "integrity": "sha512-MHzkWQcEmjzzVW9j2q8LGjwGWpG2mjwaaB0BNQwst3FIjqsg8Ct/mIZlvSPJvfi9y2AC8mi/ktxbFVL9pZ1I4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-explicit-resource-management": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-7.28.6.tgz",
+      "integrity": "sha512-Iao5Konzx2b6g7EPqTy40UZbcdXE126tTxVFr/nAIj+WItNxjKSYTEw3RC+A2/ZetmdJsgueL1KhaMCQHkLPIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/plugin-transform-destructuring": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-exponentiation-operator": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.28.6.tgz",
+      "integrity": "sha512-WitabqiGjV/vJ0aPOLSFfNY1u9U3R7W36B03r5I2KoNix+a3sOhJ3pKFB3R5It9/UiK78NiO0KE9P21cMhlPkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-export-namespace-from": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.27.1.tgz",
+      "integrity": "sha512-tQvHWSZ3/jH2xuq/vZDy0jNn+ZdXJeM8gHvX4lnJmsc3+50yPlWdZXIc5ay+umX+2/tJIqHqiEqcJvxlmIvRvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-for-of": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.27.1.tgz",
+      "integrity": "sha512-BfbWFFEJFQzLCQ5N8VocnCtA8J1CLkNTe2Ms2wocj75dd6VpiqS5Z5quTYcUoo4Yq+DN0rtikODccuv7RU81sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-function-name": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.27.1.tgz",
+      "integrity": "sha512-1bQeydJF9Nr1eBCMMbC+hdwmRlsv5XYOMu03YSWFwNs0HsAmtSxxF1fyuYPqemVldVyFmlCU7w8UE14LupUSZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-compilation-targets": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/traverse": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-json-strings": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.28.6.tgz",
+      "integrity": "sha512-Nr+hEN+0geQkzhbdgQVPoqr47lZbm+5fCUmO70722xJZd0Mvb59+33QLImGj6F+DkK3xgDi1YVysP8whD6FQAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-literals": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.27.1.tgz",
+      "integrity": "sha512-0HCFSepIpLTkLcsi86GG3mTUzxV5jpmbv97hTETW3yzrAij8aqlD36toB1D0daVFJM8NK6GvKO0gslVQmm+zZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-logical-assignment-operators": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.28.6.tgz",
+      "integrity": "sha512-+anKKair6gpi8VsM/95kmomGNMD0eLz1NQ8+Pfw5sAwWH9fGYXT50E55ZpV0pHUHWf6IUTWPM+f/7AAff+wr9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-member-expression-literals": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.27.1.tgz",
+      "integrity": "sha512-hqoBX4dcZ1I33jCSWcXrP+1Ku7kdqXf1oeah7ooKOIiAdKQ+uqftgCFNOSzA5AMS2XIHEYeGFg4cKRCdpxzVOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-amd": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.27.1.tgz",
+      "integrity": "sha512-iCsytMg/N9/oFq6n+gFTvUYDZQOMK5kEdeYxmxt91fcJGycfxVP9CnrxoliM0oumFERba2i8ZtwRUCMhvP1LnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-commonjs": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.28.6.tgz",
+      "integrity": "sha512-jppVbf8IV9iWWwWTQIxJMAJCWBuuKx71475wHwYytrRGQ2CWiDvYlADQno3tcYpS/T2UUWFQp3nVtYfK/YBQrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-systemjs": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.0.tgz",
+      "integrity": "sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-umd": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.27.1.tgz",
+      "integrity": "sha512-iQBE/xC5BV1OxJbp6WG7jq9IWiD+xxlZhLrdwpPkTX3ydmXdvoCpyfJN7acaIBZaOqTfr76pgzqBJflNbeRK+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.29.0.tgz",
+      "integrity": "sha512-1CZQA5KNAD6ZYQLPw7oi5ewtDNxH/2vuCh+6SmvgDfhumForvs8a1o9n0UrEoBD8HU4djO2yWngTQlXl1NDVEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.28.5",
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-new-target": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.27.1.tgz",
+      "integrity": "sha512-f6PiYeqXQ05lYq3TIfIDu/MtliKUbNwkGApPUvyo6+tc7uaR4cPjPe7DFPr15Uyycg2lZU6btZ575CuQoYh7MQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.28.6.tgz",
+      "integrity": "sha512-3wKbRgmzYbw24mDJXT7N+ADXw8BC/imU9yo9c9X9NKaLF1fW+e5H1U5QjMUBe4Qo4Ox/o++IyUkl1sVCLgevKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-numeric-separator": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.28.6.tgz",
+      "integrity": "sha512-SJR8hPynj8outz+SlStQSwvziMN4+Bq99it4tMIf5/Caq+3iOc0JtKyse8puvyXkk3eFRIA5ID/XfunGgO5i6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-object-rest-spread": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.28.6.tgz",
+      "integrity": "sha512-5rh+JR4JBC4pGkXLAcYdLHZjXudVxWMXbB6u6+E9lRL5TrGVbHt1TjxGbZ8CkmYw9zjkB7jutzOROArsqtncEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/plugin-transform-destructuring": "^7.28.5",
+        "@babel/plugin-transform-parameters": "^7.27.7",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-object-super": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.27.1.tgz",
+      "integrity": "sha512-SFy8S9plRPbIcxlJ8A6mT/CxFdJx/c04JEctz4jf8YZaVS2px34j7NXRrlGlHkN/M2gnpL37ZpGRGVFLd3l8Ng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-replace-supers": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-optional-catch-binding": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.28.6.tgz",
+      "integrity": "sha512-R8ja/Pyrv0OGAvAXQhSTmWyPJPml+0TMqXlO5w+AsMEiwb2fg3WkOvob7UxFSL3OIttFSGSRFKQsOhJ/X6HQdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-optional-chaining": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.28.6.tgz",
+      "integrity": "sha512-A4zobikRGJTsX9uqVFdafzGkqD30t26ck2LmOzAuLL8b2x6k3TIqRiT2xVvA9fNmFeTX484VpsdgmKNA0bS23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-parameters": {
+      "version": "7.27.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.27.7.tgz",
+      "integrity": "sha512-qBkYTYCb76RRxUM6CcZA5KRu8K4SM8ajzVeUgVdMVO9NN9uI/GaVmBg/WKJJGnNokV9SY8FxNOVWGXzqzUidBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-private-methods": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.28.6.tgz",
+      "integrity": "sha512-piiuapX9CRv7+0st8lmuUlRSmX6mBcVeNQ1b4AYzJxfCMuBfB0vBXDiGSmm03pKJw1v6cZ8KSeM+oUnM6yAExg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-private-property-in-object": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.28.6.tgz",
+      "integrity": "sha512-b97jvNSOb5+ehyQmBpmhOCiUC5oVK4PMnpRvO7+ymFBoqYjeDHIU9jnrNUuwHOiL9RpGDoKBpSViarV+BU+eVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.3",
+        "@babel/helper-create-class-features-plugin": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-property-literals": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.27.1.tgz",
+      "integrity": "sha512-oThy3BCuCha8kDZ8ZkgOg2exvPYUlprMukKQXI1r1pJ47NCvxfkEy8vK+r/hT9nF0Aa4H1WUPZZjHTFtAhGfmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-react-jsx-self": {
@@ -378,6 +1366,323 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-regenerator": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.29.0.tgz",
+      "integrity": "sha512-FijqlqMA7DmRdg/aINBSs04y8XNTYw/lr1gJ2WsmBnnaNw1iS43EPkJW+zK7z65auG3AWRFXWj+NcTQwYptUog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-regexp-modifiers": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-7.28.6.tgz",
+      "integrity": "sha512-QGWAepm9qxpaIs7UM9FvUSnCGlb8Ua1RhyM4/veAxLwt3gMat/LSGrZixyuj4I6+Kn9iwvqCyPTtbdxanYoWYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.28.5",
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-reserved-words": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.27.1.tgz",
+      "integrity": "sha512-V2ABPHIJX4kC7HegLkYoDpfg9PVmuWy/i6vUM5eGK22bx4YVFD3M5F0QQnWQoDs6AGsUWTVOopBiMFQgHaSkVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-shorthand-properties": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.27.1.tgz",
+      "integrity": "sha512-N/wH1vcn4oYawbJ13Y/FxcQrWk63jhfNa7jef0ih7PHSIHX2LB7GWE1rkPrOnka9kwMxb6hMl19p7lidA+EHmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-spread": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.28.6.tgz",
+      "integrity": "sha512-9U4QObUC0FtJl05AsUcodau/RWDytrU6uKgkxu09mLR9HLDAtUMoPuuskm5huQsoktmsYpI+bGmq+iapDcriKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-sticky-regex": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.27.1.tgz",
+      "integrity": "sha512-lhInBO5bi/Kowe2/aLdBAawijx+q1pQzicSgnkB6dUPc1+RC8QmJHKf2OjvU+NZWitguJHEaEmbV6VWEouT58g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-template-literals": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.27.1.tgz",
+      "integrity": "sha512-fBJKiV7F2DxZUkg5EtHKXQdbsbURW3DZKQUWphDum0uRP6eHGGa/He9mc0mypL680pb+e/lDIthRohlv8NCHkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-typeof-symbol": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.27.1.tgz",
+      "integrity": "sha512-RiSILC+nRJM7FY5srIyc4/fGIwUhyDuuBSdWn4y6yT6gm652DpCHZjIipgn6B7MQ1ITOUnAKWixEUjQRIBIcLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-unicode-escapes": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.27.1.tgz",
+      "integrity": "sha512-Ysg4v6AmF26k9vpfFuTZg8HRfVWzsh1kVfowA23y9j/Gu6dOuahdUVhkLqpObp3JIv27MLSii6noRnuKN8H0Mg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-unicode-property-regex": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.28.6.tgz",
+      "integrity": "sha512-4Wlbdl/sIZjzi/8St0evF0gEZrgOswVO6aOzqxh1kDZOl9WmLrHq2HtGhnOJZmHZYKP8WZ1MDLCt5DAWwRo57A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.28.5",
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-unicode-regex": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.27.1.tgz",
+      "integrity": "sha512-xvINq24TRojDuyt6JGtHmkVkrfVV3FPT16uytxImLeBZqW3/H52yN+kM1MGuyPkIQxrzKwPHs5U/MP3qKyzkGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-unicode-sets-regex": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.28.6.tgz",
+      "integrity": "sha512-/wHc/paTUmsDYN7SZkpWxogTOBNnlx7nBQYfy6JJlCT7G3mVhltk3e++N7zV0XfgGsrqBxd4rJQt9H16I21Y1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.28.5",
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/preset-env": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.29.0.tgz",
+      "integrity": "sha512-fNEdfc0yi16lt6IZo2Qxk3knHVdfMYX33czNb4v8yWhemoBhibCpQK/uYHtSKIiO+p/zd3+8fYVXhQdOVV608w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.28.5",
+        "@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.27.1",
+        "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.27.1",
+        "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.27.1",
+        "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.28.6",
+        "@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
+        "@babel/plugin-syntax-import-assertions": "^7.28.6",
+        "@babel/plugin-syntax-import-attributes": "^7.28.6",
+        "@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
+        "@babel/plugin-transform-arrow-functions": "^7.27.1",
+        "@babel/plugin-transform-async-generator-functions": "^7.29.0",
+        "@babel/plugin-transform-async-to-generator": "^7.28.6",
+        "@babel/plugin-transform-block-scoped-functions": "^7.27.1",
+        "@babel/plugin-transform-block-scoping": "^7.28.6",
+        "@babel/plugin-transform-class-properties": "^7.28.6",
+        "@babel/plugin-transform-class-static-block": "^7.28.6",
+        "@babel/plugin-transform-classes": "^7.28.6",
+        "@babel/plugin-transform-computed-properties": "^7.28.6",
+        "@babel/plugin-transform-destructuring": "^7.28.5",
+        "@babel/plugin-transform-dotall-regex": "^7.28.6",
+        "@babel/plugin-transform-duplicate-keys": "^7.27.1",
+        "@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.29.0",
+        "@babel/plugin-transform-dynamic-import": "^7.27.1",
+        "@babel/plugin-transform-explicit-resource-management": "^7.28.6",
+        "@babel/plugin-transform-exponentiation-operator": "^7.28.6",
+        "@babel/plugin-transform-export-namespace-from": "^7.27.1",
+        "@babel/plugin-transform-for-of": "^7.27.1",
+        "@babel/plugin-transform-function-name": "^7.27.1",
+        "@babel/plugin-transform-json-strings": "^7.28.6",
+        "@babel/plugin-transform-literals": "^7.27.1",
+        "@babel/plugin-transform-logical-assignment-operators": "^7.28.6",
+        "@babel/plugin-transform-member-expression-literals": "^7.27.1",
+        "@babel/plugin-transform-modules-amd": "^7.27.1",
+        "@babel/plugin-transform-modules-commonjs": "^7.28.6",
+        "@babel/plugin-transform-modules-systemjs": "^7.29.0",
+        "@babel/plugin-transform-modules-umd": "^7.27.1",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.29.0",
+        "@babel/plugin-transform-new-target": "^7.27.1",
+        "@babel/plugin-transform-nullish-coalescing-operator": "^7.28.6",
+        "@babel/plugin-transform-numeric-separator": "^7.28.6",
+        "@babel/plugin-transform-object-rest-spread": "^7.28.6",
+        "@babel/plugin-transform-object-super": "^7.27.1",
+        "@babel/plugin-transform-optional-catch-binding": "^7.28.6",
+        "@babel/plugin-transform-optional-chaining": "^7.28.6",
+        "@babel/plugin-transform-parameters": "^7.27.7",
+        "@babel/plugin-transform-private-methods": "^7.28.6",
+        "@babel/plugin-transform-private-property-in-object": "^7.28.6",
+        "@babel/plugin-transform-property-literals": "^7.27.1",
+        "@babel/plugin-transform-regenerator": "^7.29.0",
+        "@babel/plugin-transform-regexp-modifiers": "^7.28.6",
+        "@babel/plugin-transform-reserved-words": "^7.27.1",
+        "@babel/plugin-transform-shorthand-properties": "^7.27.1",
+        "@babel/plugin-transform-spread": "^7.28.6",
+        "@babel/plugin-transform-sticky-regex": "^7.27.1",
+        "@babel/plugin-transform-template-literals": "^7.27.1",
+        "@babel/plugin-transform-typeof-symbol": "^7.27.1",
+        "@babel/plugin-transform-unicode-escapes": "^7.27.1",
+        "@babel/plugin-transform-unicode-property-regex": "^7.28.6",
+        "@babel/plugin-transform-unicode-regex": "^7.27.1",
+        "@babel/plugin-transform-unicode-sets-regex": "^7.28.6",
+        "@babel/preset-modules": "0.1.6-no-external-plugins",
+        "babel-plugin-polyfill-corejs2": "^0.4.15",
+        "babel-plugin-polyfill-corejs3": "^0.14.0",
+        "babel-plugin-polyfill-regenerator": "^0.6.6",
+        "core-js-compat": "^3.48.0",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-env/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/preset-modules": {
+      "version": "0.1.6-no-external-plugins",
+      "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.6-no-external-plugins.tgz",
+      "integrity": "sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/types": "^7.4.4",
+        "esutils": "^2.0.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1384,6 +2689,14 @@
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
       "license": "MIT"
     },
+    "node_modules/@freed/capture-facebook": {
+      "resolved": "packages/capture-facebook",
+      "link": true
+    },
+    "node_modules/@freed/capture-instagram": {
+      "resolved": "packages/capture-instagram",
+      "link": true
+    },
     "node_modules/@freed/capture-rss": {
       "resolved": "packages/capture-rss",
       "link": true
@@ -1938,6 +3251,16 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
+      "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1989,6 +3312,28 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
+      }
+    },
+    "node_modules/@jridgewell/source-map/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -2695,6 +4040,54 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@rollup/plugin-node-resolve": {
+      "version": "15.3.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.3.1.tgz",
+      "integrity": "sha512-tgg6b91pAybXHJQMAAwW9VuWBO6Thi+q7BCNARLwSqlmsHz0XYURtGvh/AuwSADXSI4h/2uHbs7s4FzlZDGSGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "@types/resolve": "1.20.2",
+        "deepmerge": "^4.2.2",
+        "is-module": "^1.0.0",
+        "resolve": "^1.22.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.78.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-terser": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-0.4.4.tgz",
+      "integrity": "sha512-XHeJC5Bgvs8LfukDwWZp7yeqin6ns8RTl2B9avbejt6tZqsqvVoWI7ZTQrcNsfKEDWBTnTxM8nMDkO2IFFbd0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "serialize-javascript": "^6.0.1",
+        "smob": "^1.0.0",
+        "terser": "^5.17.4"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rollup/plugin-virtual": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-virtual/-/plugin-virtual-3.0.2.tgz",
@@ -2711,6 +4104,49 @@
         "rollup": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
+      "integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/pluginutils/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -3083,6 +4519,29 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@surma/rollup-plugin-off-main-thread": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@surma/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-2.2.3.tgz",
+      "integrity": "sha512-lR8q/9W7hZpMWweNiAKU7NQerBnzQQLvi8qnTDU/fxItPhtZVMbPV3lbCwjhIlNBe9Bbr5V+KHshvWmVSG9cxQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ejs": "^3.1.6",
+        "json5": "^2.2.0",
+        "magic-string": "^0.25.0",
+        "string.prototype.matchall": "^4.0.6"
+      }
+    },
+    "node_modules/@surma/rollup-plugin-off-main-thread/node_modules/magic-string": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sourcemap-codec": "^1.4.8"
+      }
     },
     "node_modules/@swc/core-darwin-arm64": {
       "version": "1.15.11",
@@ -4006,10 +5465,24 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/resolve": {
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
+      "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/tough-cookie": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "dev": true,
       "license": "MIT"
     },
@@ -5038,6 +6511,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -5053,6 +6533,16 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
+    },
+    "node_modules/at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
     },
     "node_modules/autoprefixer": {
       "version": "10.4.24",
@@ -5125,6 +6615,58 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/babel-plugin-polyfill-corejs2": {
+      "version": "0.4.15",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.15.tgz",
+      "integrity": "sha512-hR3GwrRwHUfYwGfrisXPIDP3JcYfBrW7wKE7+Au6wDYl7fm/ka1NEII6kORzxNU556JjfidZeBsO10kYvtV1aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-define-polyfill-provider": "^0.6.6",
+        "semver": "^6.3.1"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/babel-plugin-polyfill-corejs2/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/babel-plugin-polyfill-corejs3": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.14.0.tgz",
+      "integrity": "sha512-AvDcMxJ34W4Wgy4KBIIePQTAOP1Ie2WFwkQp3dB7FQ/f0lI5+nM96zUnYEOE1P9sEg0es5VCP0HxiWu5fUHZAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-define-polyfill-provider": "^0.6.6",
+        "core-js-compat": "^3.48.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/babel-plugin-polyfill-regenerator": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.6.tgz",
+      "integrity": "sha512-hYm+XLYRMvupxiQzrvXUj7YyvFFVfv5gI0R71AJzudg1g2AI2vyCPPIFEBjk162/wFzti3inBHo7isWFuEVS/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-define-polyfill-provider": "^0.6.6"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
       }
     },
     "node_modules/balanced-match": {
@@ -5324,6 +6866,13 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
       }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/call-bind": {
       "version": "1.0.8",
@@ -5568,6 +7117,16 @@
         "node": ">= 6"
       }
     },
+    "node_modules/common-tags": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
+      "integrity": "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -5595,6 +7154,20 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/core-js-compat": {
+      "version": "3.48.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.48.0.tgz",
+      "integrity": "sha512-OM4cAF3D6VtH/WkLtWvyNC56EZVXsZdU3iqaMG2B4WvYrlqU831pc4UtG5yp0sE9z8Y02wVN7PjW5Zf9Gt0f1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.28.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -5614,6 +7187,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/crypto-random-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
+      "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/css-tree": {
@@ -5807,6 +7390,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/define-data-property": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
@@ -5909,6 +7502,22 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ejs": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
+      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jake": "^10.8.5"
+      },
+      "bin": {
+        "ejs": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -6749,6 +8358,23 @@
       "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
       "license": "Unlicense"
     },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fast-xml-parser": {
       "version": "4.5.3",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz",
@@ -6808,6 +8434,39 @@
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
       "license": "MIT"
+    },
+    "node_modules/filelist": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
+      "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.0.1"
+      }
+    },
+    "node_modules/filelist/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/filelist/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
@@ -6876,6 +8535,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/form-data": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
@@ -6911,6 +8587,32 @@
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "license": "MIT"
+    },
+    "node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/fs-extra/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -7011,6 +8713,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-own-enumerable-property-symbols": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
+      "integrity": "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/get-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
@@ -7061,6 +8770,31 @@
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
       "license": "MIT"
     },
+    "node_modules/glob": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -7072,6 +8806,48 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.2.tgz",
+      "integrity": "sha512-x0K50QvKQ97fdEz2kPehIerj+YTeptKF9hyYkKf6egnwmMWAkADiO0QCzSp0R5xN8FTZgYaBfSaue46Ej62nMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jackspeak": "^4.2.3"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
+      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.0.tgz",
+      "integrity": "sha512-ugkC31VaVg9cF0DFVoADH12k6061zNZkZON+aX8AWsR9GhPcErkcMBceb6znR8wLERM2AkkOxy2nWRLpT9Jq5w==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/globals": {
@@ -7287,6 +9063,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/idb": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
+      "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -7602,6 +9385,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+      "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-negative-zero": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
@@ -7642,6 +9432,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
@@ -7665,6 +9465,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "integrity": "sha512-7zjFAPO4/gwyQAAgRRmqeEeyIICSdmCqa3tsVHMdBzaXXRiqopZL4Cyghg/XulGWrtABTpbnYYzzIRffLkP4oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-set": {
@@ -7694,6 +9504,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-string": {
@@ -7864,6 +9687,40 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/jackspeak": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
+      "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^9.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jake": {
+      "version": "10.9.4",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.4.tgz",
+      "integrity": "sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "async": "^3.2.6",
+        "filelist": "^1.0.4",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "jake": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/jiti": {
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
@@ -7954,6 +9811,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "dev": true,
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -7979,6 +9843,39 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonfile/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/jsonpointer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/jsx-ast-utils": {
@@ -8025,6 +9922,16 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/levn": {
@@ -8338,10 +10245,31 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
       "dev": true,
       "license": "MIT"
     },
@@ -8501,6 +10429,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/mkdirp-classic": {
@@ -8925,6 +10863,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -8988,6 +10933,33 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
+      "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -9291,6 +11263,19 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-bytes": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-6.1.1.tgz",
+      "integrity": "sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -9360,6 +11345,16 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
     },
     "node_modules/rc": {
       "version": "1.2.8",
@@ -9521,6 +11516,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/regenerate": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
+      "integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/regenerate-unicode-properties": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.2.2.tgz",
+      "integrity": "sha512-m03P+zhBeQd1RGnYxrGyDAPpWX/epKirLrp8e3qevZdVkKtnCrjjWczIbYc8+xd6vcTStVlqfycTx1KR4LOr0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regenerate": "^1.4.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
@@ -9540,6 +11555,44 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexpu-core": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-6.4.0.tgz",
+      "integrity": "sha512-0ghuzq67LI9bLXpOX/ISfve/Mq33a4aFRzoQYhnnok1JOFpmE/A2TBGkNVenOGEeSBCjIiWcc6MVOG5HEQv0sA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regenerate": "^1.4.2",
+        "regenerate-unicode-properties": "^10.2.2",
+        "regjsgen": "^0.8.0",
+        "regjsparser": "^0.13.0",
+        "unicode-match-property-ecmascript": "^2.0.0",
+        "unicode-match-property-value-ecmascript": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/regjsgen": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.8.0.tgz",
+      "integrity": "sha512-RvwtGe3d7LvWiDQXeQw8p5asZUmfU1G/l6WbUXeHta7Y2PEIvBTwH6E2EfmYUK8pxcxEdEmaomqyp0vZZ7C+3Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/regjsparser": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.0.tgz",
+      "integrity": "sha512-NZQZdC5wOE/H3UT28fVGL+ikOZcEzfMGk/c3iN9UGxzWHMa1op7274oyiUVrAG4B2EuFhus8SvkaYnhvW92p9Q==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "jsesc": "~3.1.0"
+      },
+      "bin": {
+        "regjsparser": "bin/parser"
       }
     },
     "node_modules/require-from-string": {
@@ -9815,6 +11868,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/serialize-javascript": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
+    },
     "node_modules/set-cookie-parser": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
@@ -10021,6 +12084,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/simple-concat": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
@@ -10066,6 +12142,30 @@
         "simple-concat": "^1.0.0"
       }
     },
+    "node_modules/smob": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/smob/-/smob-1.6.1.tgz",
+      "integrity": "sha512-KAkBqZl3c2GvNgNhcoyJae1aKldDW0LO279wF9bk1PnluRTETKBq0WyzRXxEhoQLk56yHaOY4JCBEKDuJIET5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.8.0-beta.0",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
+      "integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
+      "deprecated": "The work that was done in this beta branch won't be included in future versions",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "whatwg-url": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -10074,6 +12174,64 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/source-map-support/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map/node_modules/tr46": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+      "integrity": "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/source-map/node_modules/webidl-conversions": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/source-map/node_modules/whatwg-url": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+      "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash.sortby": "^4.7.0",
+        "tr46": "^1.0.1",
+        "webidl-conversions": "^4.0.2"
+      }
+    },
+    "node_modules/sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "deprecated": "Please use @jridgewell/sourcemap-codec instead",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stable-hash": {
       "version": "0.0.5",
@@ -10232,6 +12390,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/stringify-object": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
+      "integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "get-own-enumerable-property-symbols": "^3.0.0",
+        "is-obj": "^1.0.1",
+        "is-regexp": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
@@ -10240,6 +12413,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/strip-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-comments/-/strip-comments-2.0.1.tgz",
+      "integrity": "sha512-ZprKx+bBLXv067WTCALv8SSz5l2+XhpYCsVtSqlMnkAXMWDq+/ekVbl1ghqP9rUHTzv6sm/DwCOiYutU/yp1fw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/strip-json-comments": {
@@ -10433,6 +12616,61 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/temp-dir": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
+      "integrity": "sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tempy": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tempy/-/tempy-0.6.0.tgz",
+      "integrity": "sha512-G13vtMYPT/J8A4X2SjdtBTphZlrp1gKv6hZiOjw14RCWg6GbHuQBGtjlx75xLbYV/wEc0D7G5K4rxKP/cXk8Bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-stream": "^2.0.0",
+        "temp-dir": "^2.0.0",
+        "type-fest": "^0.16.0",
+        "unique-string": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/terser": {
+      "version": "5.46.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.0.tgz",
+      "integrity": "sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.15.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/thenify": {
       "version": "3.3.1",
@@ -10718,6 +12956,19 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/type-fest": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.16.0.tgz",
+      "integrity": "sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/typed-array-buffer": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
@@ -10868,6 +13119,63 @@
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "license": "MIT"
     },
+    "node_modules/unicode-canonical-property-names-ecmascript": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.1.tgz",
+      "integrity": "sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/unicode-match-property-ecmascript": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-2.0.0.tgz",
+      "integrity": "sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "unicode-canonical-property-names-ecmascript": "^2.0.0",
+        "unicode-property-aliases-ecmascript": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/unicode-match-property-value-ecmascript": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.2.1.tgz",
+      "integrity": "sha512-JQ84qTuMg4nVkx8ga4A16a1epI9H6uTXAknqxkGF/aFfRLw1xC/Bp24HNLaZhHSkWd3+84t8iXnp1J0kYcZHhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/unicode-property-aliases-ecmascript": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.2.0.tgz",
+      "integrity": "sha512-hpbDzxUY9BFwX+UeBnxv3Sh1q7HFxj48DTmXchNgRa46lO8uj3/1iEn3MiNUYTg1g9ctIqXCCERn8gYZhHC5lQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/unique-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
+      "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "crypto-random-string": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/universalify": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
@@ -10910,6 +13218,17 @@
         "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
         "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
         "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
+      }
+    },
+    "node_modules/upath": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
+      "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4",
+        "yarn": "*"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -11059,6 +13378,37 @@
           "optional": true
         },
         "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-plugin-pwa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-pwa/-/vite-plugin-pwa-1.2.0.tgz",
+      "integrity": "sha512-a2xld+SJshT9Lgcv8Ji4+srFJL4k/1bVbd1x06JIkvecpQkwkvCncD1+gSzcdm3s+owWLpMJerG3aN5jupJEVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.6",
+        "pretty-bytes": "^6.1.1",
+        "tinyglobby": "^0.2.10",
+        "workbox-build": "^7.4.0",
+        "workbox-window": "^7.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vite-pwa/assets-generator": "^1.0.0",
+        "vite": "^3.1.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0",
+        "workbox-build": "^7.4.0",
+        "workbox-window": "^7.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@vite-pwa/assets-generator": {
           "optional": true
         }
       }
@@ -11468,6 +13818,364 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/workbox-background-sync": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-7.4.0.tgz",
+      "integrity": "sha512-8CB9OxKAgKZKyNMwfGZ1XESx89GryWTfI+V5yEj8sHjFH8MFelUwYXEyldEK6M6oKMmn807GoJFUEA1sC4XS9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "idb": "^7.0.1",
+        "workbox-core": "7.4.0"
+      }
+    },
+    "node_modules/workbox-broadcast-update": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/workbox-broadcast-update/-/workbox-broadcast-update-7.4.0.tgz",
+      "integrity": "sha512-+eZQwoktlvo62cI0b+QBr40v5XjighxPq3Fzo9AWMiAosmpG5gxRHgTbGGhaJv/q/MFVxwFNGh/UwHZ/8K88lA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "workbox-core": "7.4.0"
+      }
+    },
+    "node_modules/workbox-build": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/workbox-build/-/workbox-build-7.4.0.tgz",
+      "integrity": "sha512-Ntk1pWb0caOFIvwz/hfgrov/OJ45wPEhI5PbTywQcYjyZiVhT3UrwwUPl6TRYbTm4moaFYithYnl1lvZ8UjxcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@apideck/better-ajv-errors": "^0.3.1",
+        "@babel/core": "^7.24.4",
+        "@babel/preset-env": "^7.11.0",
+        "@babel/runtime": "^7.11.2",
+        "@rollup/plugin-babel": "^5.2.0",
+        "@rollup/plugin-node-resolve": "^15.2.3",
+        "@rollup/plugin-replace": "^2.4.1",
+        "@rollup/plugin-terser": "^0.4.3",
+        "@surma/rollup-plugin-off-main-thread": "^2.2.3",
+        "ajv": "^8.6.0",
+        "common-tags": "^1.8.0",
+        "fast-json-stable-stringify": "^2.1.0",
+        "fs-extra": "^9.0.1",
+        "glob": "^11.0.1",
+        "lodash": "^4.17.20",
+        "pretty-bytes": "^5.3.0",
+        "rollup": "^2.79.2",
+        "source-map": "^0.8.0-beta.0",
+        "stringify-object": "^3.3.0",
+        "strip-comments": "^2.0.1",
+        "tempy": "^0.6.0",
+        "upath": "^1.2.0",
+        "workbox-background-sync": "7.4.0",
+        "workbox-broadcast-update": "7.4.0",
+        "workbox-cacheable-response": "7.4.0",
+        "workbox-core": "7.4.0",
+        "workbox-expiration": "7.4.0",
+        "workbox-google-analytics": "7.4.0",
+        "workbox-navigation-preload": "7.4.0",
+        "workbox-precaching": "7.4.0",
+        "workbox-range-requests": "7.4.0",
+        "workbox-recipes": "7.4.0",
+        "workbox-routing": "7.4.0",
+        "workbox-strategies": "7.4.0",
+        "workbox-streams": "7.4.0",
+        "workbox-sw": "7.4.0",
+        "workbox-window": "7.4.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/workbox-build/node_modules/@apideck/better-ajv-errors": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@apideck/better-ajv-errors/-/better-ajv-errors-0.3.6.tgz",
+      "integrity": "sha512-P+ZygBLZtkp0qqOAJJVX4oX/sFo5JR3eBWwwuqHHhK0GIgQOKWrAfiAaWX0aArHkRWHMuggFEgAZNxVPwPZYaA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-schema": "^0.4.0",
+        "jsonpointer": "^5.0.0",
+        "leven": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "ajv": ">=8"
+      }
+    },
+    "node_modules/workbox-build/node_modules/@rollup/plugin-babel": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz",
+      "integrity": "sha512-WFfdLWU/xVWKeRQnKmIAQULUI7Il0gZnBIH/ZFO069wYIfPu+8zrfp/KMW0atmELoRDq8FbiP3VCss9MhCut7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.10.4",
+        "@rollup/pluginutils": "^3.1.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0",
+        "@types/babel__core": "^7.1.9",
+        "rollup": "^1.20.0||^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/babel__core": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/workbox-build/node_modules/@rollup/plugin-replace": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-2.4.2.tgz",
+      "integrity": "sha512-IGcu+cydlUMZ5En85jxHH4qj2hta/11BHq95iHEyb2sbgiN0eCdzvUcHw5gt9pBL5lTi4JDYJ1acCoMGpTvEZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^3.1.0",
+        "magic-string": "^0.25.7"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0 || ^2.0.0"
+      }
+    },
+    "node_modules/workbox-build/node_modules/@rollup/pluginutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "0.0.39",
+        "estree-walker": "^1.0.1",
+        "picomatch": "^2.2.2"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0"
+      }
+    },
+    "node_modules/workbox-build/node_modules/@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/workbox-build/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/workbox-build/node_modules/estree-walker": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+      "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/workbox-build/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/workbox-build/node_modules/magic-string": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sourcemap-codec": "^1.4.8"
+      }
+    },
+    "node_modules/workbox-build/node_modules/pretty-bytes": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
+      "integrity": "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/workbox-build/node_modules/rollup": {
+      "version": "2.79.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz",
+      "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/workbox-cacheable-response": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-7.4.0.tgz",
+      "integrity": "sha512-0Fb8795zg/x23ISFkAc7lbWes6vbw34DGFIMw31cwuHPgDEC/5EYm6m/ZkylLX0EnEbbOyOCLjKgFS/Z5g0HeQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "workbox-core": "7.4.0"
+      }
+    },
+    "node_modules/workbox-core": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-7.4.0.tgz",
+      "integrity": "sha512-6BMfd8tYEnN4baG4emG9U0hdXM4gGuDU3ectXuVHnj71vwxTFI7WOpQJC4siTOlVtGqCUtj0ZQNsrvi6kZZTAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/workbox-expiration": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/workbox-expiration/-/workbox-expiration-7.4.0.tgz",
+      "integrity": "sha512-V50p4BxYhtA80eOvulu8xVfPBgZbkxJ1Jr8UUn0rvqjGhLDqKNtfrDfjJKnLz2U8fO2xGQJTx/SKXNTzHOjnHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "idb": "^7.0.1",
+        "workbox-core": "7.4.0"
+      }
+    },
+    "node_modules/workbox-google-analytics": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/workbox-google-analytics/-/workbox-google-analytics-7.4.0.tgz",
+      "integrity": "sha512-MVPXQslRF6YHkzGoFw1A4GIB8GrKym/A5+jYDUSL+AeJw4ytQGrozYdiZqUW1TPQHW8isBCBtyFJergUXyNoWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "workbox-background-sync": "7.4.0",
+        "workbox-core": "7.4.0",
+        "workbox-routing": "7.4.0",
+        "workbox-strategies": "7.4.0"
+      }
+    },
+    "node_modules/workbox-navigation-preload": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/workbox-navigation-preload/-/workbox-navigation-preload-7.4.0.tgz",
+      "integrity": "sha512-etzftSgdQfjMcfPgbfaZCfM2QuR1P+4o8uCA2s4rf3chtKTq/Om7g/qvEOcZkG6v7JZOSOxVYQiOu6PbAZgU6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "workbox-core": "7.4.0"
+      }
+    },
+    "node_modules/workbox-precaching": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/workbox-precaching/-/workbox-precaching-7.4.0.tgz",
+      "integrity": "sha512-VQs37T6jDqf1rTxUJZXRl3yjZMf5JX/vDPhmx2CPgDDKXATzEoqyRqhYnRoxl6Kr0rqaQlp32i9rtG5zTzIlNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "workbox-core": "7.4.0",
+        "workbox-routing": "7.4.0",
+        "workbox-strategies": "7.4.0"
+      }
+    },
+    "node_modules/workbox-range-requests": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/workbox-range-requests/-/workbox-range-requests-7.4.0.tgz",
+      "integrity": "sha512-3Vq854ZNuP6Y0KZOQWLaLC9FfM7ZaE+iuQl4VhADXybwzr4z/sMmnLgTeUZLq5PaDlcJBxYXQ3U91V7dwAIfvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "workbox-core": "7.4.0"
+      }
+    },
+    "node_modules/workbox-recipes": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/workbox-recipes/-/workbox-recipes-7.4.0.tgz",
+      "integrity": "sha512-kOkWvsAn4H8GvAkwfJTbwINdv4voFoiE9hbezgB1sb/0NLyTG4rE7l6LvS8lLk5QIRIto+DjXLuAuG3Vmt3cxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "workbox-cacheable-response": "7.4.0",
+        "workbox-core": "7.4.0",
+        "workbox-expiration": "7.4.0",
+        "workbox-precaching": "7.4.0",
+        "workbox-routing": "7.4.0",
+        "workbox-strategies": "7.4.0"
+      }
+    },
+    "node_modules/workbox-routing": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-7.4.0.tgz",
+      "integrity": "sha512-C/ooj5uBWYAhAqwmU8HYQJdOjjDKBp9MzTQ+otpMmd+q0eF59K+NuXUek34wbL0RFrIXe/KKT+tUWcZcBqxbHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "workbox-core": "7.4.0"
+      }
+    },
+    "node_modules/workbox-strategies": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-7.4.0.tgz",
+      "integrity": "sha512-T4hVqIi5A4mHi92+5EppMX3cLaVywDp8nsyUgJhOZxcfSV/eQofcOA6/EMo5rnTNmNTpw0rUgjAI6LaVullPpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "workbox-core": "7.4.0"
+      }
+    },
+    "node_modules/workbox-streams": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/workbox-streams/-/workbox-streams-7.4.0.tgz",
+      "integrity": "sha512-QHPBQrey7hQbnTs5GrEVoWz7RhHJXnPT+12qqWM378orDMo5VMJLCkCM1cnCk+8Eq92lccx/VgRZ7WAzZWbSLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "workbox-core": "7.4.0",
+        "workbox-routing": "7.4.0"
+      }
+    },
+    "node_modules/workbox-sw": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/workbox-sw/-/workbox-sw-7.4.0.tgz",
+      "integrity": "sha512-ltU+Kr3qWR6BtbdlMnCjobZKzeV1hN+S6UvDywBrwM19TTyqA03X66dzw1tEIdJvQ4lYKkBFox6IAEhoSEZ8Xw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/workbox-window": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/workbox-window/-/workbox-window-7.4.0.tgz",
+      "integrity": "sha512-/bIYdBLAVsNR3v7gYGaV4pQW3M3kEPx5E8vDxGvxo6khTrGtSSCS7QiFKv9ogzBgZiy0OXLP9zO28U/1nF1mfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2",
+        "workbox-core": "7.4.0"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -11635,6 +14343,34 @@
         }
       }
     },
+    "packages/capture-facebook": {
+      "name": "@freed/capture-facebook",
+      "version": "0.1.0",
+      "dependencies": {
+        "@freed/shared": "*"
+      },
+      "devDependencies": {
+        "playwright-core": "^1.50.0",
+        "typescript": "^5.3.0"
+      },
+      "peerDependencies": {
+        "playwright-core": ">=1.40.0"
+      }
+    },
+    "packages/capture-instagram": {
+      "name": "@freed/capture-instagram",
+      "version": "0.1.0",
+      "dependencies": {
+        "@freed/shared": "*"
+      },
+      "devDependencies": {
+        "playwright-core": "^1.50.0",
+        "typescript": "^5.3.0"
+      },
+      "peerDependencies": {
+        "playwright-core": ">=1.40.0"
+      }
+    },
     "packages/capture-rss": {
       "name": "@freed/capture-rss",
       "version": "0.1.0",
@@ -11735,6 +14471,7 @@
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.46.4",
         "vite": "^7.2.4",
+        "vite-plugin-pwa": "^1.2.0",
         "vite-plugin-top-level-await": "^1.6.0",
         "vite-plugin-wasm": "^3.5.0",
         "vitest": "^4.0.18"

--- a/packages/capture-facebook/package.json
+++ b/packages/capture-facebook/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@freed/capture-facebook",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@freed/shared": "*"
+  },
+  "peerDependencies": {
+    "playwright-core": ">=1.40.0"
+  },
+  "devDependencies": {
+    "playwright-core": "^1.50.0",
+    "typescript": "^5.3.0"
+  }
+}

--- a/packages/capture-facebook/src/index.ts
+++ b/packages/capture-facebook/src/index.ts
@@ -1,0 +1,108 @@
+/**
+ * @freed/capture-facebook — Facebook feed capture package
+ *
+ * DOM-based scraping of the Facebook home feed using Playwright.
+ * Requires the user to be logged into Facebook and their cookies extracted.
+ *
+ * Usage:
+ *   import { captureFacebookFeed } from "@freed/capture-facebook";
+ *   const items = await captureFacebookFeed(cookies, { maxPosts: 50 });
+ *
+ * Or with an existing Playwright browser:
+ *   import { scrapeFacebookFeed, createFacebookContext } from "@freed/capture-facebook";
+ *   const ctx = await createFacebookContext(browser, cookies);
+ *   const page = await ctx.newPage();
+ *   const items = await scrapeFacebookFeed(page);
+ */
+
+import { chromium } from "playwright-core";
+import type { Browser } from "playwright-core";
+import type { FacebookCookies, FacebookScrapeOptions } from "./types.js";
+import { createFacebookContext, navigateToFeed } from "./session.js";
+import { scrapeFacebookFeed } from "./scraper.js";
+import { fbPostsToFeedItems, deduplicateFeedItems } from "./normalize.js";
+
+// Re-export public types and utilities
+export type { FacebookCookies, FacebookScrapeOptions, RawFbPost, RateLimitState } from "./types.js";
+export { createFacebookContext, navigateToFeed } from "./session.js";
+export { scrapeFacebookFeed } from "./scraper.js";
+export { fbPostToFeedItem, fbPostsToFeedItems, deduplicateFeedItems } from "./normalize.js";
+export {
+  createRateLimitState,
+  checkRateLimit,
+  recordSuccess,
+  recordError,
+  formatWaitTime,
+} from "./rate-limit.js";
+export { SELECTORS, SELECTOR_VERSION } from "./selectors.js";
+
+// =============================================================================
+// High-level convenience API
+// =============================================================================
+
+export interface CaptureFacebookOptions extends FacebookScrapeOptions {
+  /**
+   * Playwright channel to use. Defaults to "chrome" (system Chrome).
+   * Pass "chromium" to use Playwright's bundled Chromium.
+   */
+  browserChannel?: "chrome" | "chromium" | "chrome-beta" | "msedge";
+
+  /**
+   * Run browser in headless mode. Default: true.
+   * Set to false for debugging.
+   */
+  headless?: boolean;
+
+  /**
+   * Pass an existing browser instance to reuse it.
+   * If provided, browserChannel and headless are ignored.
+   */
+  browser?: Browser;
+}
+
+/**
+ * High-level capture function: launch browser → login → scrape → normalize.
+ *
+ * @param cookies - Authenticated Facebook session cookies
+ * @param options - Scrape options
+ * @returns Array of FeedItems, deduplicated by globalId
+ * @throws If the Facebook session is invalid / login wall encountered
+ */
+export async function captureFacebookFeed(
+  cookies: FacebookCookies,
+  options: CaptureFacebookOptions = {}
+): Promise<import("@freed/shared").FeedItem[]> {
+  const {
+    browserChannel = "chrome",
+    headless = true,
+    browser: existingBrowser,
+    ...scrapeOptions
+  } = options;
+
+  const ownsBrowser = !existingBrowser;
+  const browser =
+    existingBrowser ??
+    (await chromium.launch({ channel: browserChannel, headless }));
+
+  try {
+    const context = await createFacebookContext(browser, cookies, scrapeOptions);
+    const page = await context.newPage();
+
+    const isLoggedIn = await navigateToFeed(page);
+    if (!isLoggedIn) {
+      throw new Error(
+        "Facebook session is invalid or expired. Please re-extract cookies."
+      );
+    }
+
+    const rawPosts = await scrapeFacebookFeed(page, scrapeOptions);
+    await context.close();
+
+    const items = fbPostsToFeedItems(rawPosts);
+    return deduplicateFeedItems(items);
+  } finally {
+    if (ownsBrowser) {
+      await browser.close();
+    }
+  }
+}

--- a/packages/capture-facebook/src/normalize.ts
+++ b/packages/capture-facebook/src/normalize.ts
@@ -1,0 +1,167 @@
+/**
+ * Facebook post normalization — RawFbPost → FeedItem
+ *
+ * Converts DOM-scraped Facebook data into the canonical FeedItem format.
+ */
+
+import type { FeedItem, Author, Content, Engagement, Location } from "@freed/shared";
+import type { RawFbPost } from "./types.js";
+
+// =============================================================================
+// Author extraction
+// =============================================================================
+
+/**
+ * Derive a stable author ID from the Facebook profile URL.
+ * e.g. "https://www.facebook.com/john.doe" → "john.doe"
+ * e.g. "https://www.facebook.com/profile.php?id=123" → "123"
+ */
+function extractAuthorId(profileUrl: string | null): string {
+  if (!profileUrl) return "unknown";
+  try {
+    const url = new URL(profileUrl);
+    // Profile ID from profile.php?id=XXX
+    const id = url.searchParams.get("id");
+    if (id) return id;
+    // Handle from pathname: /john.doe or /john.doe/
+    const parts = url.pathname.split("/").filter(Boolean);
+    if (parts.length > 0 && !parts[0].includes(".php")) {
+      return parts[0];
+    }
+  } catch {
+    // ignore malformed URLs
+  }
+  return "unknown";
+}
+
+function buildAuthor(post: RawFbPost): Author {
+  return {
+    id: `fb:${extractAuthorId(post.authorProfileUrl)}`,
+    handle: extractAuthorId(post.authorProfileUrl),
+    displayName: post.authorName ?? "Unknown",
+    avatarUrl: post.authorAvatarUrl ?? undefined,
+  };
+}
+
+// =============================================================================
+// Content extraction
+// =============================================================================
+
+function buildContent(post: RawFbPost): Content {
+  const mediaTypes = post.mediaUrls.map((url): "image" | "video" => {
+    if (post.hasVideo && post.mediaUrls.indexOf(url) === 0) return "video";
+    return "image";
+  });
+
+  return {
+    text: post.text ?? undefined,
+    mediaUrls: post.mediaUrls,
+    mediaTypes: post.hasVideo
+      ? ["video", ...mediaTypes.slice(1)]
+      : mediaTypes,
+  };
+}
+
+// =============================================================================
+// Timestamp extraction
+// =============================================================================
+
+function extractTimestamp(post: RawFbPost): number {
+  if (post.timestampSeconds) {
+    return post.timestampSeconds * 1000; // Convert seconds → ms
+  }
+  if (post.timestampIso) {
+    const parsed = Date.parse(post.timestampIso);
+    if (!isNaN(parsed)) return parsed;
+  }
+  return Date.now();
+}
+
+// =============================================================================
+// Location extraction
+// =============================================================================
+
+function buildLocation(post: RawFbPost): Location | undefined {
+  if (!post.location) return undefined;
+  return {
+    name: post.location,
+    source: "check_in",
+  };
+}
+
+// =============================================================================
+// Engagement extraction
+// =============================================================================
+
+function buildEngagement(post: RawFbPost): Engagement | undefined {
+  if (post.likeCount == null && post.commentCount == null && post.shareCount == null) {
+    return undefined;
+  }
+  return {
+    likes: post.likeCount ?? undefined,
+    comments: post.commentCount ?? undefined,
+    reposts: post.shareCount ?? undefined,
+  };
+}
+
+// =============================================================================
+// Main normalizer
+// =============================================================================
+
+/**
+ * Convert a raw Facebook post to a Freed FeedItem.
+ * Returns null if the post lacks a usable ID (can't be deduplicated).
+ */
+export function fbPostToFeedItem(post: RawFbPost): FeedItem | null {
+  if (!post.id && !post.url) return null;
+
+  const globalId = `fb:${post.id ?? encodeURIComponent(post.url ?? "")}`;
+  const publishedAt = extractTimestamp(post);
+  const author = buildAuthor(post);
+  const content = buildContent(post);
+  const engagement = buildEngagement(post);
+  const location = buildLocation(post);
+
+  const topics = post.hashtags.slice(0, 10);
+
+  const contentType =
+    post.postType === "reel" ? "video" : post.postType === "story" ? "story" : "post";
+
+  return {
+    globalId,
+    platform: "facebook",
+    contentType,
+    capturedAt: Date.now(),
+    publishedAt,
+    author,
+    content,
+    engagement,
+    location,
+    topics,
+    userState: {
+      hidden: false,
+      saved: false,
+      archived: false,
+      tags: [],
+    },
+  };
+}
+
+/**
+ * Normalize multiple raw posts, filtering out nulls.
+ */
+export function fbPostsToFeedItems(posts: RawFbPost[]): FeedItem[] {
+  return posts.map(fbPostToFeedItem).filter((item): item is FeedItem => item !== null);
+}
+
+/**
+ * Deduplicate by globalId.
+ */
+export function deduplicateFeedItems(items: FeedItem[]): FeedItem[] {
+  const seen = new Set<string>();
+  return items.filter((item) => {
+    if (seen.has(item.globalId)) return false;
+    seen.add(item.globalId);
+    return true;
+  });
+}

--- a/packages/capture-facebook/src/rate-limit.ts
+++ b/packages/capture-facebook/src/rate-limit.ts
@@ -1,0 +1,88 @@
+/**
+ * Rate limiting for Facebook scraping
+ *
+ * Facebook aggressively rate-limits and bans scrapers.
+ * Conservative defaults: 5 minutes minimum between scrapes,
+ * with exponential backoff on errors.
+ */
+
+import type { RateLimitState } from "./types.js";
+
+/** Minimum time between scrapes in normal operation (5 minutes) */
+const MIN_INTERVAL_MS = 5 * 60 * 1000;
+
+/** Cooldown after first error (30 minutes) */
+const ERROR_COOLDOWN_MS = 30 * 60 * 1000;
+
+/** Cooldown after 3+ consecutive errors (2 hours) */
+const EXTENDED_COOLDOWN_MS = 2 * 60 * 60 * 1000;
+
+/** Initial empty state */
+export function createRateLimitState(): RateLimitState {
+  return {
+    lastScrapeAt: 0,
+    consecutiveErrors: 0,
+    cooldownUntil: 0,
+  };
+}
+
+/**
+ * Check whether we're allowed to scrape right now.
+ * Returns { allowed: true } or { allowed: false, waitMs: number }.
+ */
+export function checkRateLimit(
+  state: RateLimitState,
+  now: number = Date.now()
+): { allowed: boolean; waitMs?: number } {
+  // Hard cooldown from errors
+  if (state.cooldownUntil > now) {
+    return { allowed: false, waitMs: state.cooldownUntil - now };
+  }
+
+  // Minimum interval between scrapes
+  const nextAllowed = state.lastScrapeAt + MIN_INTERVAL_MS;
+  if (nextAllowed > now) {
+    return { allowed: false, waitMs: nextAllowed - now };
+  }
+
+  return { allowed: true };
+}
+
+/**
+ * Record a successful scrape — resets error count and updates lastScrapeAt.
+ */
+export function recordSuccess(
+  state: RateLimitState,
+  now: number = Date.now()
+): RateLimitState {
+  return {
+    lastScrapeAt: now,
+    consecutiveErrors: 0,
+    cooldownUntil: 0,
+  };
+}
+
+/**
+ * Record a failed scrape — increments error count and applies cooldown.
+ */
+export function recordError(
+  state: RateLimitState,
+  now: number = Date.now()
+): RateLimitState {
+  const consecutiveErrors = state.consecutiveErrors + 1;
+  const cooldownMs = consecutiveErrors >= 3 ? EXTENDED_COOLDOWN_MS : ERROR_COOLDOWN_MS;
+  return {
+    ...state,
+    consecutiveErrors,
+    cooldownUntil: now + cooldownMs,
+  };
+}
+
+/**
+ * Format wait time for human-readable logging.
+ */
+export function formatWaitTime(ms: number): string {
+  const minutes = Math.ceil(ms / 60_000);
+  if (minutes < 60) return `${minutes}m`;
+  return `${Math.ceil(minutes / 60)}h`;
+}

--- a/packages/capture-facebook/src/scraper.ts
+++ b/packages/capture-facebook/src/scraper.ts
@@ -1,0 +1,185 @@
+/**
+ * Facebook feed scraper
+ *
+ * Extracts raw post data from the Facebook DOM. This is the most fragile layer —
+ * Facebook changes their DOM structure frequently. All selector logic is in
+ * selectors.ts to make updates easy.
+ */
+
+import type { Page } from "playwright-core";
+import type { RawFbPost, FacebookScrapeOptions } from "./types.js";
+import {
+  SELECTORS,
+  extractPostId,
+  extractHashtags,
+  parseEngagementCount,
+} from "./selectors.js";
+import { scrollFeed } from "./session.js";
+
+/**
+ * Scrape the Facebook home feed from an already-authenticated page.
+ * The page must already be navigated to facebook.com with a logged-in session.
+ */
+export async function scrapeFacebookFeed(
+  page: Page,
+  options: FacebookScrapeOptions = {}
+): Promise<RawFbPost[]> {
+  const {
+    maxScrolls = 5,
+    maxPosts = 50,
+    scrollDelayMs = 800,
+  } = options;
+
+  // Scroll to load posts
+  await scrollFeed(page, maxScrolls, scrollDelayMs);
+
+  // Extract all posts from the DOM in a single page.evaluate call.
+  // We pass all selectors in so the closure doesn't capture them by reference.
+  const rawPosts = await page.evaluate(
+    ({ selectors, maxPosts: limit }) => {
+      // Try data-pagelet first, then fallback
+      let postElements = Array.from(
+        document.querySelectorAll(selectors.feedUnit)
+      ) as HTMLElement[];
+
+      if (postElements.length === 0) {
+        postElements = Array.from(
+          document.querySelectorAll(selectors.feedUnitFallback)
+        ) as HTMLElement[];
+      }
+
+      // Limit to maxPosts
+      postElements = postElements.slice(0, limit);
+
+      return postElements.map((el) => {
+        // --- Post URL + ID ---
+        const postLinkEl = el.querySelector(
+          'a[href*="story_fbid"], a[href*="/posts/"], a[href*="/permalink/"]'
+        ) as HTMLAnchorElement | null;
+        const url = postLinkEl?.href ?? null;
+        const pagelet = el.getAttribute("data-pagelet");
+
+        // --- Author ---
+        const authorLinkEl = el.querySelector("h4 a") as HTMLAnchorElement | null;
+        const authorName =
+          el.querySelector("h4 a strong")?.textContent?.trim() ??
+          authorLinkEl?.getAttribute("aria-label")?.trim() ??
+          null;
+        const authorProfileUrl = authorLinkEl?.href ?? null;
+        const avatarEl = el.querySelector(
+          'image[xlink\\:href]'
+        ) as SVGImageElement | null;
+        const imgEl = el.querySelector(
+          'img[referrerpolicy="origin-when-cross-origin"]'
+        ) as HTMLImageElement | null;
+        const authorAvatarUrl =
+          avatarEl?.getAttribute("xlink:href") ?? imgEl?.src ?? null;
+
+        // --- Timestamps ---
+        const abbrEl = el.querySelector("abbr[data-utime]") as HTMLElement | null;
+        const timestampSeconds = abbrEl
+          ? parseInt(abbrEl.getAttribute("data-utime") ?? "0", 10) || null
+          : null;
+        const timeEl = el.querySelector("time[datetime]") as HTMLTimeElement | null;
+        const timestampIso = timeEl?.getAttribute("datetime") ?? null;
+
+        // --- Content text ---
+        const textEl = el.querySelector(
+          '[data-ad-comet-preview="message"], [data-ad-preview="message"]'
+        ) as HTMLElement | null;
+        const text = textEl?.innerText?.trim() ?? null;
+
+        // --- Media ---
+        const imgEls = Array.from(
+          el.querySelectorAll('img[src*="scontent"], img[src*="fbcdn"]')
+        ) as HTMLImageElement[];
+        const mediaUrls = imgEls
+          .map((img) => img.src)
+          .filter((src) => src && !src.includes("emoji") && !src.includes("1x1"))
+          // Skip tiny tracking pixels
+          .filter((src, i, arr) => arr.indexOf(src) === i); // deduplicate
+
+        const hasVideo = el.querySelector("video") !== null;
+
+        // --- Engagement ---
+        const reactionSpan = el.querySelector(
+          'span[aria-label*="reaction"], span[aria-label*=" people"]'
+        ) as HTMLElement | null;
+        const commentSpan = el.querySelector(
+          'span[aria-label*="comment"]'
+        ) as HTMLElement | null;
+        const shareSpan = el.querySelector(
+          'span[aria-label*="share"]'
+        ) as HTMLElement | null;
+
+        const likeText = reactionSpan?.getAttribute("aria-label") ?? reactionSpan?.textContent ?? null;
+        const commentText = commentSpan?.getAttribute("aria-label") ?? commentSpan?.textContent ?? null;
+        const shareText = shareSpan?.getAttribute("aria-label") ?? shareSpan?.textContent ?? null;
+
+        // --- Location ---
+        const locationEl = el.querySelector(
+          'a[href*="/places/"], a[href*="/?action=view_location"]'
+        ) as HTMLAnchorElement | null;
+        const location = locationEl?.textContent?.trim() ?? null;
+
+        // --- Post type ---
+        const isReel =
+          el.getAttribute("data-pagelet")?.includes("Reel") ||
+          el.querySelector("video") !== null;
+        const postType = isReel ? "reel" : "post";
+
+        return {
+          url,
+          pagelet,
+          authorName,
+          authorProfileUrl,
+          authorAvatarUrl,
+          text,
+          timestampSeconds,
+          timestampIso,
+          mediaUrls,
+          hasVideo,
+          likeText,
+          commentText,
+          shareText,
+          location,
+          postType,
+        };
+      });
+    },
+    { selectors: SELECTORS, maxPosts }
+  );
+
+  // Process the raw DOM data into RawFbPost objects
+  return rawPosts.map((raw) => {
+    const id = extractPostId(raw.url, raw.pagelet);
+
+    const likeCount = raw.likeText ? parseEngagementCount(raw.likeText) : null;
+    const commentCount = raw.commentText ? parseEngagementCount(raw.commentText) : null;
+    const shareCount = raw.shareText ? parseEngagementCount(raw.shareText) : null;
+
+    const text = raw.text ?? "";
+    const hashtags = extractHashtags(text);
+
+    return {
+      id,
+      url: raw.url,
+      authorName: raw.authorName,
+      authorProfileUrl: raw.authorProfileUrl,
+      authorAvatarUrl: raw.authorAvatarUrl,
+      text: text || null,
+      timestampSeconds: raw.timestampSeconds,
+      timestampIso: raw.timestampIso,
+      mediaUrls: raw.mediaUrls,
+      hasVideo: raw.hasVideo,
+      likeCount,
+      commentCount,
+      shareCount,
+      postType: (raw.postType as RawFbPost["postType"]) ?? "unknown",
+      location: raw.location,
+      hashtags,
+      isShare: false,
+      sharedFrom: null,
+    } satisfies RawFbPost;
+  });
+}

--- a/packages/capture-facebook/src/selectors.ts
+++ b/packages/capture-facebook/src/selectors.ts
@@ -1,0 +1,161 @@
+/**
+ * Facebook DOM selectors
+ *
+ * Facebook uses generated obfuscated class names that change frequently.
+ * We rely on semantic HTML attributes (role, data-*, aria-*) which are more
+ * stable. Still: these WILL break. Update this file when scraping stops working.
+ *
+ * Last verified: 2026-02-17
+ */
+
+export const SELECTOR_VERSION = "2026-02-17";
+
+export const SELECTORS = {
+  // ==========================================================================
+  // Feed container
+  // ==========================================================================
+
+  /** Main feed container. Stable — uses ARIA role. */
+  feed: 'div[role="feed"]',
+
+  /** Individual feed unit (one post + its reactions). */
+  feedUnit: 'div[data-pagelet^="FeedUnit"]',
+
+  /** Fallback: posts identified by aria-posinset attribute */
+  feedUnitFallback: "div[aria-posinset]",
+
+  // ==========================================================================
+  // Author info (within a post)
+  // ==========================================================================
+
+  /** The "actor" profile link — first <a> in post header with a strong child */
+  authorLink: "h4 a",
+
+  /** Author name text */
+  authorName: "h4 a strong",
+
+  /** Fallback: aria-label on the profile link */
+  authorLinkAria: 'a[aria-label][role="link"]',
+
+  /** Avatar image */
+  authorAvatar: 'image[xlink\\:href], img[referrerpolicy="origin-when-cross-origin"]',
+
+  // ==========================================================================
+  // Post content
+  // ==========================================================================
+
+  /** Main text content. Facebook uses data-* attributes here. */
+  postText: '[data-ad-comet-preview="message"], [data-ad-preview="message"]',
+
+  /** Expanded text (for "see more" truncated posts) */
+  postTextExpanded: '[data-ad-comet-preview="message"] div, [data-ad-preview="message"] div',
+
+  /** "See more" button to expand truncated posts */
+  seeMoreButton: '[role="button"][tabindex="0"]:has-text("See more")',
+
+  // ==========================================================================
+  // Timestamps
+  // ==========================================================================
+
+  /** Primary: abbr[data-utime] contains UNIX timestamp in data-utime */
+  timestampAbbr: "abbr[data-utime]",
+
+  /** Fallback: time[datetime] in post header */
+  timestampTime: "time[datetime]",
+
+  // ==========================================================================
+  // Post URL
+  // ==========================================================================
+
+  /** Link to the individual post (contains "story_fbid" or "/posts/") */
+  postLink: 'a[href*="story_fbid"], a[href*="/posts/"], a[href*="/permalink/"]',
+
+  // ==========================================================================
+  // Media
+  // ==========================================================================
+
+  /** Images served from Facebook CDN */
+  cdnImage: 'img[src*="scontent"], img[src*="fbcdn"]',
+
+  /** Reel / video element */
+  videoPost: 'video, div[data-pagelet*="Reel"]',
+
+  // ==========================================================================
+  // Engagement (reaction/comment/share counts)
+  // ==========================================================================
+
+  /** Reaction count span (often contains "X people" or "X reactions") */
+  reactionCount: 'span[aria-label*="reaction"], span[aria-label*=" people"]',
+
+  /** Comment count */
+  commentCount: 'span[aria-label*="comment"]',
+
+  /** Share count */
+  shareCount: 'span[aria-label*="share"]',
+
+  // ==========================================================================
+  // Location
+  // ==========================================================================
+
+  /** Check-in / location link */
+  location: 'a[href*="/places/"], a[href*="/?action=view_location"]',
+
+  // ==========================================================================
+  // Shared / repost
+  // ==========================================================================
+
+  /** Container for a post that was shared from another account */
+  sharedPost: "div.x1yztbdb, div.x78zum5.xdt5ytf", // obfuscated but common pattern
+
+  /** The original author link within a shared post */
+  sharedFromLink: 'span[dir="auto"] a[href*="facebook.com"]',
+} as const;
+
+/**
+ * Attempt to extract a Facebook post ID from the post URL or data-pagelet.
+ */
+export function extractPostId(url: string | null, pagelet: string | null): string | null {
+  if (url) {
+    // story_fbid=12345&id=67890
+    const storyMatch = url.match(/story_fbid=(\d+)/);
+    if (storyMatch) return storyMatch[1];
+
+    // /posts/12345
+    const postsMatch = url.match(/\/posts\/(\d+)/);
+    if (postsMatch) return postsMatch[1];
+
+    // /permalink/12345
+    const permalinkMatch = url.match(/\/permalink\/(\d+)/);
+    if (permalinkMatch) return permalinkMatch[1];
+  }
+
+  if (pagelet) {
+    // FeedUnit_12345_67890
+    const pageletMatch = pagelet.match(/FeedUnit[_:]?(\d+)/);
+    if (pageletMatch) return pageletMatch[1];
+  }
+
+  return null;
+}
+
+/**
+ * Extract hashtags from post text.
+ */
+export function extractHashtags(text: string): string[] {
+  const matches = text.match(/#(\w+)/g) || [];
+  return matches.map((h) => h.slice(1).toLowerCase());
+}
+
+/**
+ * Parse a Facebook engagement count string like "1.2K", "345", "4M" to a number.
+ */
+export function parseEngagementCount(text: string): number | null {
+  if (!text) return null;
+  const cleaned = text.replace(/[^0-9.KMkm]/g, "").trim();
+  if (!cleaned) return null;
+  const num = parseFloat(cleaned);
+  if (isNaN(num)) return null;
+  if (/[Kk]/.test(cleaned)) return Math.round(num * 1000);
+  if (/[Mm]/.test(cleaned)) return Math.round(num * 1_000_000);
+  return Math.round(num);
+}

--- a/packages/capture-facebook/src/session.ts
+++ b/packages/capture-facebook/src/session.ts
@@ -1,0 +1,95 @@
+/**
+ * Facebook session management
+ *
+ * Creates an authenticated Playwright browser context using Facebook cookies.
+ * The user must be logged into Facebook in their browser; cookies are extracted
+ * and provided to this module.
+ */
+
+import type { Browser, BrowserContext, Page } from "playwright-core";
+import type { FacebookCookies, FacebookScrapeOptions, PlaywrightCookie } from "./types.js";
+
+/** Default realistic desktop user-agent */
+const DEFAULT_USER_AGENT =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/132.0.0.0 Safari/537.36";
+
+/**
+ * Convert our FacebookCookies to Playwright cookie format.
+ */
+export function cookiesToPlaywright(cookies: FacebookCookies): PlaywrightCookie[] {
+  const base = { domain: ".facebook.com", path: "/" };
+  const result: PlaywrightCookie[] = [
+    { name: "c_user", value: cookies.c_user, ...base },
+    { name: "xs", value: cookies.xs, ...base },
+  ];
+  if (cookies.datr) result.push({ name: "datr", value: cookies.datr, ...base });
+  if (cookies.sb) result.push({ name: "sb", value: cookies.sb, ...base });
+  return result;
+}
+
+/**
+ * Create an authenticated Playwright BrowserContext for Facebook.
+ * The caller owns the browser lifecycle — this only creates the context.
+ */
+export async function createFacebookContext(
+  browser: Browser,
+  cookies: FacebookCookies,
+  options: FacebookScrapeOptions = {}
+): Promise<BrowserContext> {
+  const context = await browser.newContext({
+    userAgent: options.userAgent ?? DEFAULT_USER_AGENT,
+    viewport: options.viewport ?? { width: 1280, height: 900 },
+    locale: "en-US",
+    timezoneId: "America/New_York",
+    // Reduce bot-detection signals
+    javaScriptEnabled: true,
+    acceptDownloads: false,
+    ignoreHTTPSErrors: false,
+  });
+
+  await context.addCookies(cookiesToPlaywright(cookies));
+  return context;
+}
+
+/**
+ * Navigate to the Facebook home feed and wait for it to load.
+ * Returns true if the feed loaded successfully, false if redirected to login.
+ */
+export async function navigateToFeed(page: Page): Promise<boolean> {
+  await page.goto("https://www.facebook.com/", {
+    waitUntil: "domcontentloaded",
+    timeout: 30_000,
+  });
+
+  // Check if we were redirected to login
+  const url = page.url();
+  if (url.includes("/login") || url.includes("checkpoint")) {
+    return false;
+  }
+
+  // Wait for the feed to appear (up to 15 seconds)
+  try {
+    await page.waitForSelector('div[role="feed"]', { timeout: 15_000 });
+    return true;
+  } catch {
+    // Feed selector not found — might be a layout change or login wall
+    return false;
+  }
+}
+
+/**
+ * Scroll the page to load more feed posts.
+ * Facebook uses infinite scroll triggered by IntersectionObserver.
+ */
+export async function scrollFeed(
+  page: Page,
+  maxScrolls: number,
+  delayMs: number
+): Promise<void> {
+  for (let i = 0; i < maxScrolls; i++) {
+    await page.evaluate(() => window.scrollBy(0, window.innerHeight * 1.5));
+    // Random delay between scrolls to appear human-like
+    const jitter = Math.floor(Math.random() * 400);
+    await page.waitForTimeout(delayMs + jitter);
+  }
+}

--- a/packages/capture-facebook/src/types.ts
+++ b/packages/capture-facebook/src/types.ts
@@ -1,0 +1,146 @@
+/**
+ * Facebook-specific types for DOM-scraped data
+ *
+ * These represent the raw structured data extracted from the DOM before
+ * normalization to FeedItem. Keeping raw types separate makes it easy
+ * to update extraction logic independently of normalization.
+ */
+
+// =============================================================================
+// Session / Auth
+// =============================================================================
+
+/**
+ * Facebook session cookies required for authenticated scraping.
+ * Extracted from a browser where the user is logged into facebook.com.
+ */
+export interface FacebookCookies {
+  /** Session cookie — primary auth token */
+  c_user: string;
+  /** CSRF token */
+  xs: string;
+  /** Optional: datr device token (reduces CAPTCHA triggers) */
+  datr?: string;
+  /** Optional: sb browser fingerprint */
+  sb?: string;
+}
+
+/**
+ * Full cookie object for Playwright context.addCookies()
+ */
+export interface PlaywrightCookie {
+  name: string;
+  value: string;
+  domain: string;
+  path: string;
+}
+
+// =============================================================================
+// Raw DOM-extracted post data
+// =============================================================================
+
+/**
+ * Raw Facebook post as extracted from the DOM.
+ * Fields are optional because selectors may not always find them.
+ */
+export interface RawFbPost {
+  /** Facebook post ID (from data-pagelet or URL) */
+  id: string | null;
+
+  /** Canonical URL of the post */
+  url: string | null;
+
+  /** Author's display name */
+  authorName: string | null;
+
+  /** Author's profile URL (facebook.com/author) */
+  authorProfileUrl: string | null;
+
+  /** Author's avatar image URL */
+  authorAvatarUrl: string | null;
+
+  /** Main text content of the post */
+  text: string | null;
+
+  /** UNIX timestamp (seconds), from abbr[data-utime] */
+  timestampSeconds: number | null;
+
+  /** ISO timestamp string fallback, from time[datetime] */
+  timestampIso: string | null;
+
+  /** Image/video URLs attached to the post */
+  mediaUrls: string[];
+
+  /** Whether any media is a video */
+  hasVideo: boolean;
+
+  /** Engagement counts (may be null if hidden by FB) */
+  likeCount: number | null;
+  commentCount: number | null;
+  shareCount: number | null;
+
+  /** Post type: user post, group post, page post, reel, etc. */
+  postType: "post" | "reel" | "story" | "shared" | "unknown";
+
+  /** Location tag if present */
+  location: string | null;
+
+  /** Hashtags extracted from post text */
+  hashtags: string[];
+
+  /** Whether this is a repost/share of another post */
+  isShare: boolean;
+
+  /** Original poster info if this is a share */
+  sharedFrom: { name: string; url: string } | null;
+}
+
+// =============================================================================
+// Scraper options
+// =============================================================================
+
+export interface FacebookScrapeOptions {
+  /**
+   * Max number of scroll iterations to load more posts.
+   * Each scroll loads ~10 posts. Default: 5 (≈50 posts).
+   */
+  maxScrolls?: number;
+
+  /**
+   * Max number of posts to return. Default: 50.
+   */
+  maxPosts?: number;
+
+  /**
+   * User-Agent to use. Defaults to a realistic desktop UA.
+   */
+  userAgent?: string;
+
+  /**
+   * Viewport size. Default: 1280x900 (desktop).
+   */
+  viewport?: { width: number; height: number };
+
+  /**
+   * Whether to capture Reels (video posts). Default: true.
+   */
+  includeReels?: boolean;
+
+  /**
+   * Min delay between scroll steps in ms. Default: 800.
+   */
+  scrollDelayMs?: number;
+}
+
+// =============================================================================
+// Rate limiting
+// =============================================================================
+
+export interface RateLimitState {
+  /** Timestamp of last successful scrape */
+  lastScrapeAt: number;
+  /** Number of consecutive errors (triggers cooldown) */
+  consecutiveErrors: number;
+  /** Cooldown until timestamp (don't scrape before this) */
+  cooldownUntil: number;
+}

--- a/packages/capture-facebook/tsconfig.json
+++ b/packages/capture-facebook/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/capture-instagram/package.json
+++ b/packages/capture-instagram/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@freed/capture-instagram",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@freed/shared": "*"
+  },
+  "peerDependencies": {
+    "playwright-core": ">=1.40.0"
+  },
+  "devDependencies": {
+    "playwright-core": "^1.50.0",
+    "typescript": "^5.3.0"
+  }
+}

--- a/packages/capture-instagram/src/index.ts
+++ b/packages/capture-instagram/src/index.ts
@@ -1,0 +1,105 @@
+/**
+ * @freed/capture-instagram — Instagram feed capture package
+ *
+ * DOM-based scraping of the Instagram home feed using Playwright.
+ * Requires the user to be logged into Instagram and their cookies extracted.
+ *
+ * Usage:
+ *   import { captureInstagramFeed } from "@freed/capture-instagram";
+ *   const items = await captureInstagramFeed(cookies, { maxPosts: 30 });
+ *
+ * Or with an existing Playwright browser:
+ *   import { scrapeInstagramFeed, createInstagramContext } from "@freed/capture-instagram";
+ *   const ctx = await createInstagramContext(browser, cookies);
+ *   const page = await ctx.newPage();
+ *   const items = await scrapeInstagramFeed(page);
+ */
+
+import { chromium } from "playwright-core";
+import type { Browser } from "playwright-core";
+import type { InstagramCookies, InstagramScrapeOptions } from "./types.js";
+import { createInstagramContext, navigateToFeed } from "./session.js";
+import { scrapeInstagramFeed } from "./scraper.js";
+import { igPostsToFeedItems, deduplicateFeedItems } from "./normalize.js";
+
+// Re-export public types and utilities
+export type { InstagramCookies, InstagramScrapeOptions, RawIgPost, RateLimitState } from "./types.js";
+export { createInstagramContext, navigateToFeed } from "./session.js";
+export { scrapeInstagramFeed } from "./scraper.js";
+export { igPostToFeedItem, igPostsToFeedItems, deduplicateFeedItems } from "./normalize.js";
+export {
+  createRateLimitState,
+  checkRateLimit,
+  recordSuccess,
+  recordError,
+  formatWaitTime,
+} from "./rate-limit.js";
+export { SELECTORS, SELECTOR_VERSION } from "./selectors.js";
+
+// =============================================================================
+// High-level convenience API
+// =============================================================================
+
+export interface CaptureInstagramOptions extends InstagramScrapeOptions {
+  /**
+   * Playwright channel. Default: "chrome" (system Chrome).
+   */
+  browserChannel?: "chrome" | "chromium" | "chrome-beta" | "msedge";
+
+  /**
+   * Headless mode. Default: true.
+   */
+  headless?: boolean;
+
+  /**
+   * Pass an existing browser instance to reuse.
+   */
+  browser?: Browser;
+}
+
+/**
+ * High-level capture function: launch browser → login → scrape → normalize.
+ *
+ * @param cookies - Authenticated Instagram session cookies
+ * @param options - Scrape options
+ * @returns Array of FeedItems, deduplicated by globalId
+ * @throws If the Instagram session is invalid / login wall encountered
+ */
+export async function captureInstagramFeed(
+  cookies: InstagramCookies,
+  options: CaptureInstagramOptions = {}
+): Promise<import("@freed/shared").FeedItem[]> {
+  const {
+    browserChannel = "chrome",
+    headless = true,
+    browser: existingBrowser,
+    ...scrapeOptions
+  } = options;
+
+  const ownsBrowser = !existingBrowser;
+  const browser =
+    existingBrowser ??
+    (await chromium.launch({ channel: browserChannel, headless }));
+
+  try {
+    const context = await createInstagramContext(browser, cookies, scrapeOptions);
+    const page = await context.newPage();
+
+    const isLoggedIn = await navigateToFeed(page);
+    if (!isLoggedIn) {
+      throw new Error(
+        "Instagram session is invalid or expired. Please re-extract cookies."
+      );
+    }
+
+    const rawPosts = await scrapeInstagramFeed(page, scrapeOptions);
+    await context.close();
+
+    const items = igPostsToFeedItems(rawPosts);
+    return deduplicateFeedItems(items);
+  } finally {
+    if (ownsBrowser) {
+      await browser.close();
+    }
+  }
+}

--- a/packages/capture-instagram/src/normalize.ts
+++ b/packages/capture-instagram/src/normalize.ts
@@ -1,0 +1,137 @@
+/**
+ * Instagram post normalization — RawIgPost → FeedItem
+ */
+
+import type { FeedItem, Author, Content, Engagement, Location } from "@freed/shared";
+import type { RawIgPost } from "./types.js";
+
+// =============================================================================
+// Author
+// =============================================================================
+
+function buildAuthor(post: RawIgPost): Author {
+  const handle = post.authorHandle ?? "unknown";
+  return {
+    id: `ig:${handle}`,
+    handle,
+    displayName: post.authorDisplayName ?? handle,
+    avatarUrl: post.authorAvatarUrl ?? undefined,
+  };
+}
+
+// =============================================================================
+// Content
+// =============================================================================
+
+function buildContent(post: RawIgPost): Content {
+  const mediaTypes = post.mediaUrls.map((): "image" | "video" => "image");
+  const allMediaTypes: ("image" | "video" | "link")[] =
+    post.isVideo ? ["video", ...mediaTypes.slice(1)] : mediaTypes;
+
+  return {
+    text: post.caption ?? undefined,
+    mediaUrls: post.mediaUrls,
+    mediaTypes: allMediaTypes,
+  };
+}
+
+// =============================================================================
+// Timestamp
+// =============================================================================
+
+function extractTimestamp(post: RawIgPost): number {
+  if (post.timestampIso) {
+    const parsed = Date.parse(post.timestampIso);
+    if (!isNaN(parsed)) return parsed;
+  }
+  return Date.now();
+}
+
+// =============================================================================
+// Location
+// =============================================================================
+
+function buildLocation(post: RawIgPost): Location | undefined {
+  if (!post.location) return undefined;
+  return {
+    name: post.location,
+    source: "geo_tag",
+  };
+}
+
+// =============================================================================
+// Engagement
+// =============================================================================
+
+function buildEngagement(post: RawIgPost): Engagement | undefined {
+  if (post.likeCount == null && post.commentCount == null) return undefined;
+  return {
+    likes: post.likeCount ?? undefined,
+    comments: post.commentCount ?? undefined,
+  };
+}
+
+// =============================================================================
+// Main normalizer
+// =============================================================================
+
+/**
+ * Convert a raw Instagram post to a Freed FeedItem.
+ * Returns null if the post lacks a shortcode (can't be deduplicated).
+ */
+export function igPostToFeedItem(post: RawIgPost): FeedItem | null {
+  if (!post.shortcode && !post.url) return null;
+
+  const globalId = `ig:${post.shortcode ?? encodeURIComponent(post.url ?? "")}`;
+  const publishedAt = extractTimestamp(post);
+  const author = buildAuthor(post);
+  const content = buildContent(post);
+  const engagement = buildEngagement(post);
+  const location = buildLocation(post);
+  const topics = post.hashtags.slice(0, 10);
+
+  const contentType =
+    post.postType === "reel" || post.postType === "video"
+      ? "video"
+      : post.postType === "story"
+      ? "story"
+      : "post";
+
+  return {
+    globalId,
+    platform: "instagram",
+    contentType,
+    capturedAt: Date.now(),
+    publishedAt,
+    author,
+    content,
+    engagement,
+    location,
+    topics,
+    userState: {
+      hidden: false,
+      saved: false,
+      archived: false,
+      tags: [],
+    },
+  };
+}
+
+/**
+ * Normalize multiple raw posts, filtering out nulls.
+ */
+export function igPostsToFeedItems(posts: RawIgPost[]): FeedItem[] {
+  return posts.map(igPostToFeedItem).filter((item): item is FeedItem => item !== null);
+}
+
+/**
+ * Deduplicate by globalId.
+ */
+export function deduplicateFeedItems(items: FeedItem[]): FeedItem[] {
+  const seen = new Set<string>();
+  return items.filter((item) => {
+    if (seen.has(item.globalId)) return false;
+    seen.add(item.globalId);
+    return true;
+  });
+}

--- a/packages/capture-instagram/src/rate-limit.ts
+++ b/packages/capture-instagram/src/rate-limit.ts
@@ -1,0 +1,57 @@
+/**
+ * Rate limiting for Instagram scraping
+ *
+ * Instagram is more aggressive than Facebook about rate-limiting.
+ * Conservative defaults: 10 minutes minimum, longer cooldowns on errors.
+ */
+
+import type { RateLimitState } from "./types.js";
+
+/** Minimum time between scrapes in normal operation (10 minutes) */
+const MIN_INTERVAL_MS = 10 * 60 * 1000;
+
+/** Cooldown after first error (1 hour) */
+const ERROR_COOLDOWN_MS = 60 * 60 * 1000;
+
+/** Cooldown after 2+ consecutive errors (4 hours) */
+const EXTENDED_COOLDOWN_MS = 4 * 60 * 60 * 1000;
+
+export function createRateLimitState(): RateLimitState {
+  return { lastScrapeAt: 0, consecutiveErrors: 0, cooldownUntil: 0 };
+}
+
+export function checkRateLimit(
+  state: RateLimitState,
+  now: number = Date.now()
+): { allowed: boolean; waitMs?: number } {
+  if (state.cooldownUntil > now) {
+    return { allowed: false, waitMs: state.cooldownUntil - now };
+  }
+  const nextAllowed = state.lastScrapeAt + MIN_INTERVAL_MS;
+  if (nextAllowed > now) {
+    return { allowed: false, waitMs: nextAllowed - now };
+  }
+  return { allowed: true };
+}
+
+export function recordSuccess(
+  state: RateLimitState,
+  now: number = Date.now()
+): RateLimitState {
+  return { lastScrapeAt: now, consecutiveErrors: 0, cooldownUntil: 0 };
+}
+
+export function recordError(
+  state: RateLimitState,
+  now: number = Date.now()
+): RateLimitState {
+  const consecutiveErrors = state.consecutiveErrors + 1;
+  const cooldownMs = consecutiveErrors >= 2 ? EXTENDED_COOLDOWN_MS : ERROR_COOLDOWN_MS;
+  return { ...state, consecutiveErrors, cooldownUntil: now + cooldownMs };
+}
+
+export function formatWaitTime(ms: number): string {
+  const minutes = Math.ceil(ms / 60_000);
+  if (minutes < 60) return `${minutes}m`;
+  return `${Math.ceil(minutes / 60)}h`;
+}

--- a/packages/capture-instagram/src/scraper.ts
+++ b/packages/capture-instagram/src/scraper.ts
@@ -1,0 +1,176 @@
+/**
+ * Instagram feed scraper
+ *
+ * Extracts raw post data from the Instagram DOM.
+ */
+
+import type { Page } from "playwright-core";
+import type { RawIgPost, InstagramScrapeOptions } from "./types.js";
+import { extractShortcode, extractHashtags, parseEngagementCount } from "./selectors.js";
+import { scrollFeed } from "./session.js";
+
+/**
+ * Scrape the Instagram home feed from an already-authenticated page.
+ */
+export async function scrapeInstagramFeed(
+  page: Page,
+  options: InstagramScrapeOptions = {}
+): Promise<RawIgPost[]> {
+  const {
+    maxScrolls = 5,
+    maxPosts = 30,
+    scrollDelayMs = 1200,
+  } = options;
+
+  // Scroll to load posts
+  await scrollFeed(page, maxScrolls, scrollDelayMs);
+
+  // Extract all posts from the DOM
+  const rawPosts = await page.evaluate(({ limit }: { limit: number }) => {
+    const articleEls = Array.from(document.querySelectorAll("article")).slice(
+      0,
+      limit
+    ) as HTMLElement[];
+
+    return articleEls.map((el) => {
+      // --- Post URL & shortcode ---
+      const postLinkEl = el.querySelector(
+        'a[href*="/p/"], a[href*="/reel/"]'
+      ) as HTMLAnchorElement | null;
+      const url = postLinkEl?.href ?? null;
+
+      // --- Author ---
+      const authorLinkEl = el.querySelector(
+        "header a[role='link']"
+      ) as HTMLAnchorElement | null;
+      const authorHandle =
+        authorLinkEl?.textContent?.trim() ??
+        authorLinkEl?.getAttribute("href")?.replace(/^\/|\/$/g, "") ??
+        null;
+      const authorProfileUrl = authorLinkEl?.href ?? null;
+      const avatarEl = el.querySelector("header img") as HTMLImageElement | null;
+      const authorAvatarUrl = avatarEl?.src ?? null;
+
+      // --- Caption ---
+      const captionBlock = el.querySelector(
+        "._a9zr, h1"
+      ) as HTMLElement | null;
+      const captionText =
+        captionBlock?.querySelector("._a9zs span, h1 span")?.textContent ??
+        captionBlock?.textContent ??
+        null;
+
+      // --- Timestamp ---
+      const timeEl = el.querySelector("time[datetime]") as HTMLTimeElement | null;
+      const timestampIso = timeEl?.getAttribute("datetime") ?? null;
+
+      // --- Media ---
+      const imgEls = Array.from(
+        el.querySelectorAll(
+          'img[srcset], img[src*="cdninstagram"], img[src*="instagram"]'
+        )
+      ) as HTMLImageElement[];
+
+      // Exclude avatar images (usually in header)
+      const headerImgs = new Set(
+        Array.from(el.querySelectorAll("header img")).map(
+          (img) => (img as HTMLImageElement).src
+        )
+      );
+      const mediaImgUrls = imgEls
+        .map((img) => img.src)
+        .filter((src) => src && !headerImgs.has(src))
+        .filter((src, i, arr) => arr.indexOf(src) === i); // deduplicate
+
+      const isVideo = el.querySelector("video") !== null;
+      const isCarousel =
+        el.querySelector('button[aria-label="Next"]') !== null ||
+        el.querySelectorAll('img[srcset]').length > 1;
+
+      // --- Engagement ---
+      // Instagram often hides exact like counts ("Liked by X and others")
+      const likeSectionText =
+        el.querySelector("section")?.textContent ?? null;
+      const likeEl = el.querySelector(
+        'span[class*="like"], span[aria-label*="like"]'
+      ) as HTMLElement | null;
+      const likeText = likeEl?.getAttribute("aria-label") ?? likeEl?.textContent ?? null;
+
+      const commentLinkEl = el.querySelector(
+        'a[href*="/comments"]'
+      ) as HTMLAnchorElement | null;
+      const commentText = commentLinkEl?.textContent?.trim() ?? null;
+
+      // --- Location ---
+      const locationEl = el.querySelector(
+        'a[href*="/explore/locations/"]'
+      ) as HTMLAnchorElement | null;
+      const location = locationEl?.textContent?.trim() ?? null;
+      const locationUrl = locationEl?.href ?? null;
+
+      // --- Post type ---
+      let postType: string;
+      if (url?.includes("/reel/")) {
+        postType = "reel";
+      } else if (isVideo) {
+        postType = "video";
+      } else if (isCarousel) {
+        postType = "carousel";
+      } else if (mediaImgUrls.length > 0) {
+        postType = "photo";
+      } else {
+        postType = "unknown";
+      }
+
+      return {
+        url,
+        authorHandle,
+        authorProfileUrl,
+        authorAvatarUrl,
+        captionText: captionText?.trim() ?? null,
+        timestampIso,
+        mediaImgUrls,
+        isVideo,
+        isCarousel,
+        likeText,
+        likeSectionText,
+        commentText,
+        location,
+        locationUrl,
+        postType,
+      };
+    });
+  }, { limit: maxPosts });
+
+  return rawPosts.map((raw) => {
+    const shortcode = extractShortcode(raw.url);
+    const caption = raw.captionText ?? "";
+    const hashtags = extractHashtags(caption);
+    const likeCount = raw.likeText
+      ? parseEngagementCount(raw.likeText)
+      : raw.likeSectionText
+      ? parseEngagementCount(raw.likeSectionText)
+      : null;
+    const commentCount = raw.commentText ? parseEngagementCount(raw.commentText) : null;
+
+    return {
+      shortcode,
+      url: raw.url,
+      authorHandle: raw.authorHandle,
+      authorDisplayName: raw.authorHandle, // IG doesn't show display names in feed easily
+      authorAvatarUrl: raw.authorAvatarUrl,
+      authorProfileUrl: raw.authorProfileUrl,
+      caption: caption || null,
+      timestampIso: raw.timestampIso,
+      mediaUrls: raw.mediaImgUrls,
+      isVideo: raw.isVideo,
+      isCarousel: raw.isCarousel,
+      likeCount,
+      commentCount,
+      hashtags,
+      location: raw.location,
+      locationUrl: raw.locationUrl,
+      postType: raw.postType as RawIgPost["postType"],
+    } satisfies RawIgPost;
+  });
+}

--- a/packages/capture-instagram/src/selectors.ts
+++ b/packages/capture-instagram/src/selectors.ts
@@ -1,0 +1,128 @@
+/**
+ * Instagram DOM selectors
+ *
+ * Instagram uses a mix of semantic HTML, ARIA attributes, and
+ * semi-stable class names. Prefer semantic selectors where possible.
+ * Class-name based selectors are annotated with their visual meaning.
+ *
+ * Last verified: 2026-02-17
+ */
+
+export const SELECTOR_VERSION = "2026-02-17";
+
+export const SELECTORS = {
+  // ==========================================================================
+  // Feed container
+  // ==========================================================================
+
+  /** Main content area */
+  main: 'main[role="main"]',
+
+  /** Individual post card. Instagram wraps each post in an <article>. */
+  post: "article",
+
+  // ==========================================================================
+  // Author info (within a post)
+  // ==========================================================================
+
+  /** Author username link in post header */
+  authorLink: 'header a[role="link"]',
+
+  /** Author avatar image */
+  authorAvatar: "header img",
+
+  // ==========================================================================
+  // Post content
+  // ==========================================================================
+
+  /** Caption block — h1 in the main post or div._a9zr */
+  caption: "._a9zr, h1",
+
+  /** Caption span inside the caption block */
+  captionText: "._a9zs span, h1 span",
+
+  /** "more" button to expand truncated caption */
+  moreButton: 'div[role="button"]:has-text("more"), button:has-text("more")',
+
+  // ==========================================================================
+  // Timestamps
+  // ==========================================================================
+
+  /** time[datetime] — ISO timestamp */
+  timestamp: "time[datetime]",
+
+  // ==========================================================================
+  // Post URL
+  // ==========================================================================
+
+  /** Link to the individual post: /p/SHORTCODE */
+  postLink: 'a[href*="/p/"]',
+
+  /** Reel link: /reel/SHORTCODE */
+  reelLink: 'a[href*="/reel/"]',
+
+  // ==========================================================================
+  // Media
+  // ==========================================================================
+
+  /** Images in the post media area */
+  postImage: 'img[srcset], img[src*="cdninstagram"], img[src*="instagram.com"]',
+
+  /** Video element */
+  video: "video",
+
+  /** Carousel: next button indicates multiple slides */
+  carouselNext: 'button[aria-label="Next"]',
+
+  // ==========================================================================
+  // Engagement
+  // ==========================================================================
+
+  /** Like count button/span */
+  likeCount:
+    'button[data-visualcompletion="ignore"], section > div > span > span',
+
+  /** Comment count (in post footer) */
+  commentLink: 'a[href*="/comments"]',
+
+  // ==========================================================================
+  // Location
+  // ==========================================================================
+
+  /** Location tag link */
+  location: 'a[href*="/explore/locations/"]',
+} as const;
+
+/**
+ * Extract the post shortcode from an Instagram post URL.
+ * e.g. "https://www.instagram.com/p/ABC123xyz/" → "ABC123xyz"
+ * e.g. "https://www.instagram.com/reel/DEF456/" → "DEF456"
+ */
+export function extractShortcode(url: string | null): string | null {
+  if (!url) return null;
+  const match = url.match(/\/(?:p|reel)\/([A-Za-z0-9_-]+)/);
+  return match?.[1] ?? null;
+}
+
+/**
+ * Extract hashtags from a caption string.
+ */
+export function extractHashtags(text: string): string[] {
+  const matches = text.match(/#(\w+)/g) || [];
+  return matches.map((h) => h.slice(1).toLowerCase());
+}
+
+/**
+ * Parse Instagram engagement count text.
+ * e.g. "1,234 likes" → 1234, "10K likes" → 10000
+ */
+export function parseEngagementCount(text: string): number | null {
+  if (!text) return null;
+  const cleaned = text.replace(/[^0-9.,KMkm]/g, "").replace(",", "");
+  if (!cleaned) return null;
+  const num = parseFloat(cleaned);
+  if (isNaN(num)) return null;
+  if (/[Kk]/.test(text)) return Math.round(num * 1000);
+  if (/[Mm]/.test(text)) return Math.round(num * 1_000_000);
+  return Math.round(num);
+}

--- a/packages/capture-instagram/src/session.ts
+++ b/packages/capture-instagram/src/session.ts
@@ -1,0 +1,94 @@
+/**
+ * Instagram session management
+ *
+ * Creates an authenticated Playwright context using Instagram cookies.
+ */
+
+import type { Browser, BrowserContext, Page } from "playwright-core";
+import type { InstagramCookies, InstagramScrapeOptions, PlaywrightCookie } from "./types.js";
+
+const DEFAULT_USER_AGENT =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/132.0.0.0 Safari/537.36";
+
+/**
+ * Convert InstagramCookies to Playwright cookie format.
+ */
+export function cookiesToPlaywright(cookies: InstagramCookies): PlaywrightCookie[] {
+  const base = { domain: ".instagram.com", path: "/" };
+  const result: PlaywrightCookie[] = [
+    { name: "sessionid", value: cookies.sessionid, ...base },
+    { name: "csrftoken", value: cookies.csrftoken, ...base },
+    { name: "ds_user_id", value: cookies.ds_user_id, ...base },
+  ];
+  if (cookies.ig_did) result.push({ name: "ig_did", value: cookies.ig_did, ...base });
+  return result;
+}
+
+/**
+ * Create an authenticated Playwright BrowserContext for Instagram.
+ */
+export async function createInstagramContext(
+  browser: Browser,
+  cookies: InstagramCookies,
+  options: InstagramScrapeOptions = {}
+): Promise<BrowserContext> {
+  const context = await browser.newContext({
+    userAgent: options.userAgent ?? DEFAULT_USER_AGENT,
+    viewport: options.viewport ?? { width: 1280, height: 900 },
+    locale: "en-US",
+    timezoneId: "America/New_York",
+    javaScriptEnabled: true,
+    acceptDownloads: false,
+  });
+
+  await context.addCookies(cookiesToPlaywright(cookies));
+  return context;
+}
+
+/**
+ * Navigate to the Instagram home feed and verify login.
+ * Returns true if the feed loaded, false if redirected to login.
+ */
+export async function navigateToFeed(page: Page): Promise<boolean> {
+  await page.goto("https://www.instagram.com/", {
+    waitUntil: "domcontentloaded",
+    timeout: 30_000,
+  });
+
+  const url = page.url();
+  if (url.includes("/accounts/login") || url.includes("/challenge")) {
+    return false;
+  }
+
+  // Dismiss any "Save login info" or notification dialogs
+  try {
+    const notNow = page.getByRole("button", { name: /Not Now|Not now/i });
+    if (await notNow.isVisible({ timeout: 4_000 })) {
+      await notNow.click();
+    }
+  } catch {
+    // No dialog — continue
+  }
+
+  try {
+    await page.waitForSelector("article", { timeout: 15_000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Scroll the Instagram feed to load more posts.
+ */
+export async function scrollFeed(
+  page: Page,
+  maxScrolls: number,
+  delayMs: number
+): Promise<void> {
+  for (let i = 0; i < maxScrolls; i++) {
+    await page.evaluate(() => window.scrollBy(0, window.innerHeight * 1.5));
+    const jitter = Math.floor(Math.random() * 500);
+    await page.waitForTimeout(delayMs + jitter);
+  }
+}

--- a/packages/capture-instagram/src/types.ts
+++ b/packages/capture-instagram/src/types.ts
@@ -1,0 +1,141 @@
+/**
+ * Instagram-specific types for DOM-scraped data
+ *
+ * Raw structured data extracted from the Instagram DOM, before normalization
+ * to FeedItem.
+ */
+
+// =============================================================================
+// Session / Auth
+// =============================================================================
+
+/**
+ * Instagram session cookies required for authenticated scraping.
+ * Extracted from a browser where the user is logged into instagram.com.
+ */
+export interface InstagramCookies {
+  /** Primary session ID */
+  sessionid: string;
+  /** CSRF token */
+  csrftoken: string;
+  /** User ID */
+  ds_user_id: string;
+  /** Optional: device ID cookie */
+  ig_did?: string;
+  /** Optional: direct badge count (commonly present) */
+  ig_direct_region_hint?: string;
+}
+
+/**
+ * Full cookie object for Playwright context.addCookies()
+ */
+export interface PlaywrightCookie {
+  name: string;
+  value: string;
+  domain: string;
+  path: string;
+}
+
+// =============================================================================
+// Raw DOM-extracted post data
+// =============================================================================
+
+/**
+ * Raw Instagram post as extracted from the DOM.
+ */
+export interface RawIgPost {
+  /** Instagram post shortcode (from URL: instagram.com/p/SHORTCODE) */
+  shortcode: string | null;
+
+  /** Canonical post URL */
+  url: string | null;
+
+  /** Author's username (handle without @) */
+  authorHandle: string | null;
+
+  /** Author's display name (from aria-label or nearby text) */
+  authorDisplayName: string | null;
+
+  /** Author's avatar URL */
+  authorAvatarUrl: string | null;
+
+  /** Author's profile URL */
+  authorProfileUrl: string | null;
+
+  /** Post caption text */
+  caption: string | null;
+
+  /** ISO timestamp from time[datetime] */
+  timestampIso: string | null;
+
+  /** Image/video URLs */
+  mediaUrls: string[];
+
+  /** Whether this is a video/Reel */
+  isVideo: boolean;
+
+  /** Whether this is a carousel (multiple images/videos) */
+  isCarousel: boolean;
+
+  /** Like count (may be null — Instagram hides likes for many accounts) */
+  likeCount: number | null;
+
+  /** Comment count */
+  commentCount: number | null;
+
+  /** Hashtags extracted from caption */
+  hashtags: string[];
+
+  /** Tagged location (if present) */
+  location: string | null;
+
+  /** Location URL (instagram.com/explore/locations/...) */
+  locationUrl: string | null;
+
+  /** Post type derived from content */
+  postType: "photo" | "video" | "reel" | "carousel" | "story" | "unknown";
+}
+
+// =============================================================================
+// Scraper options
+// =============================================================================
+
+export interface InstagramScrapeOptions {
+  /**
+   * Max scroll iterations to load more posts. Default: 5 (≈15 posts).
+   * Instagram loads ~3 posts per scroll.
+   */
+  maxScrolls?: number;
+
+  /**
+   * Max posts to return. Default: 30.
+   * Instagram's anti-scraping is more aggressive than Facebook's.
+   */
+  maxPosts?: number;
+
+  /**
+   * User-Agent. Defaults to a realistic mobile-desktop UA.
+   */
+  userAgent?: string;
+
+  /**
+   * Viewport. Default: 1280x900.
+   */
+  viewport?: { width: number; height: number };
+
+  /**
+   * Min delay between scroll steps in ms. Default: 1200.
+   * Instagram rate-limits more aggressively, so longer delays.
+   */
+  scrollDelayMs?: number;
+}
+
+// =============================================================================
+// Rate limiting
+// =============================================================================
+
+export interface RateLimitState {
+  lastScrapeAt: number;
+  consecutiveErrors: number;
+  cooldownUntil: number;
+}

--- a/packages/capture-instagram/tsconfig.json
+++ b/packages/capture-instagram/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -167,6 +167,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1482,7 +1488,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc50b891e4acf8fe0e71ef88ec43ad82ee07b3810ad09de10f1d01f072ed4b98"
 dependencies = [
  "byteorder",
- "png",
+ "png 0.17.16",
 ]
 
 [[package]]
@@ -1591,6 +1597,19 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "image"
+version = "0.25.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6506c6c10786659413faa717ceebcb8f70731c0a60cbae39795fdf114519c1a"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png 0.18.1",
 ]
 
 [[package]]
@@ -1940,6 +1959,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac9557c559cd6fc9867e122e20d2cbefc9ca29d80d027a8e39310920ed2f0a97"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "muda"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1954,7 +1983,7 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-foundation",
  "once_cell",
- "png",
+ "png 0.17.16",
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.60.2",
@@ -2614,6 +2643,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.10.0",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2731,6 +2773,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "pxfm"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7186d3822593aa4393561d186d1393b3923e9d6163d3fbfd6e825e3e6cf3e6a8"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -3724,6 +3775,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
+ "image",
  "jni",
  "libc",
  "log",
@@ -3791,7 +3843,7 @@ dependencies = [
  "ico",
  "json-patch",
  "plist",
- "png",
+ "png 0.17.16",
  "proc-macro2",
  "quote",
  "semver",
@@ -4314,7 +4366,7 @@ dependencies = [
  "objc2-core-graphics",
  "objc2-foundation",
  "once_cell",
- "png",
+ "png 0.17.16",
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.60.2",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = ["macos-private-api"] }
+tauri = { version = "2", features = ["macos-private-api", "tray-icon", "image-png"] }
 tauri-plugin-shell = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/packages/desktop/src/App.tsx
+++ b/packages/desktop/src/App.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { AppShell } from "./components/layout/AppShell";
 import { FeedView } from "./components/feed/FeedView";
 import { useAppStore } from "./lib/store";
+import { startRssPoller, stopRssPoller } from "./lib/rss-poller";
 
 function App() {
   const initialize = useAppStore((state) => state.initialize);
@@ -12,6 +13,13 @@ function App() {
   useEffect(() => {
     initialize();
   }, [initialize]);
+
+  // Start background RSS polling once the store is initialized
+  useEffect(() => {
+    if (!isInitialized) return;
+    startRssPoller();
+    return () => stopRssPoller();
+  }, [isInitialized]);
 
   // Loading state
   if (!isInitialized && isLoading) {

--- a/packages/desktop/src/components/AddFeedDialog.tsx
+++ b/packages/desktop/src/components/AddFeedDialog.tsx
@@ -9,7 +9,7 @@ import { useAppStore } from "../lib/store";
 // Types
 // =============================================================================
 
-type DialogTab = "url" | "import" | "export";
+type DialogTab = "url" | "manage" | "import" | "export";
 type ImportPhase = "idle" | "preview" | "importing" | "complete";
 
 interface AddFeedDialogProps {
@@ -48,6 +48,7 @@ export function AddFeedDialog({ open, onClose }: AddFeedDialogProps) {
             {(
               [
                 { id: "url", label: "Add URL" },
+                { id: "manage", label: "Manage" },
                 { id: "import", label: "Import" },
                 { id: "export", label: "Export" },
               ] as const
@@ -73,6 +74,7 @@ export function AddFeedDialog({ open, onClose }: AddFeedDialogProps) {
         {/* Tab Content — scrollable */}
         <div className="p-6 overflow-y-auto flex-1 min-h-0">
           {activeTab === "url" && <AddUrlTab onClose={handleClose} />}
+          {activeTab === "manage" && <ManageTab />}
           {activeTab === "import" && <ImportTab onClose={handleClose} />}
           {activeTab === "export" && <ExportTab />}
         </div>
@@ -177,7 +179,75 @@ function AddUrlTab({ onClose }: { onClose: () => void }) {
 }
 
 // =============================================================================
-// Tab 2: Import OPML
+// Tab 2: Manage Feeds
+// =============================================================================
+
+function ManageTab() {
+  const feeds = useAppStore((s) => s.feeds);
+  const removeFeed = useAppStore((s) => s.removeFeed);
+  const feedList = Object.values(feeds);
+  const [removing, setRemoving] = useState<string | null>(null);
+
+  const handleRemove = async (url: string) => {
+    setRemoving(url);
+    try {
+      await removeFeed(url);
+    } finally {
+      setRemoving(null);
+    }
+  };
+
+  if (feedList.length === 0) {
+    return (
+      <div className="text-center py-8">
+        <p className="text-sm text-[#71717a]">No feeds subscribed yet.</p>
+        <p className="text-xs text-[#52525b] mt-1">Add a feed URL to get started.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {feedList.map((feed) => (
+        <div
+          key={feed.url}
+          className="flex items-center gap-3 px-3 py-2.5 rounded-xl bg-white/[0.03] border border-[rgba(255,255,255,0.05)]"
+        >
+          {feed.imageUrl ? (
+            <img src={feed.imageUrl} alt="" className="w-8 h-8 rounded-md flex-shrink-0 object-cover" />
+          ) : (
+            <div className="w-8 h-8 rounded-md bg-[#8b5cf6]/10 flex items-center justify-center flex-shrink-0">
+              <span className="text-sm">📡</span>
+            </div>
+          )}
+          <div className="flex-1 min-w-0">
+            <p className="text-sm text-white truncate">{feed.title}</p>
+            <p className="text-xs text-[#52525b] truncate">{feed.url}</p>
+          </div>
+          <button
+            onClick={() => handleRemove(feed.url)}
+            disabled={removing === feed.url}
+            className="flex-shrink-0 p-1.5 rounded-lg hover:bg-red-500/20 text-[#71717a] hover:text-red-400 transition-colors disabled:opacity-50"
+            aria-label={`Remove ${feed.title}`}
+          >
+            {removing === feed.url ? (
+              <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+              </svg>
+            ) : (
+              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+              </svg>
+            )}
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// =============================================================================
+// Tab 3: Import OPML
 // =============================================================================
 
 function ImportTab({ onClose }: { onClose: () => void }) {

--- a/packages/desktop/src/components/SettingsPanel.tsx
+++ b/packages/desktop/src/components/SettingsPanel.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect } from "react";
 import {
   getSyncUrl,
-  getClientCount,
   onStatusChange,
   type SyncStatus,
 } from "../lib/sync";

--- a/packages/desktop/src/components/SettingsPanel.tsx
+++ b/packages/desktop/src/components/SettingsPanel.tsx
@@ -1,33 +1,143 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import {
   getSyncUrl,
   onStatusChange,
   type SyncStatus,
 } from "../lib/sync";
+import { useAppStore } from "../lib/store";
+import type { WeightPreferences } from "@freed/shared";
 
 interface SettingsPanelProps {
   open: boolean;
   onClose: () => void;
 }
 
+function Slider({
+  label,
+  value,
+  onChange,
+  description,
+}: {
+  label: string;
+  value: number;
+  onChange: (v: number) => void;
+  description?: string;
+}) {
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <label className="text-sm text-[#a1a1aa]">{label}</label>
+        <span className="text-sm font-mono text-white tabular-nums w-8 text-right">
+          {value}
+        </span>
+      </div>
+      <input
+        type="range"
+        min={0}
+        max={100}
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+        className="w-full h-1.5 appearance-none rounded-full bg-white/10 accent-[#8b5cf6] cursor-pointer"
+      />
+      {description && (
+        <p className="text-xs text-[#52525b]">{description}</p>
+      )}
+    </div>
+  );
+}
+
+function Toggle({
+  label,
+  checked,
+  onChange,
+  description,
+}: {
+  label: string;
+  checked: boolean;
+  onChange: (v: boolean) => void;
+  description?: string;
+}) {
+  return (
+    <div className="flex items-start justify-between gap-4">
+      <div>
+        <p className="text-sm text-[#a1a1aa]">{label}</p>
+        {description && (
+          <p className="text-xs text-[#52525b] mt-0.5">{description}</p>
+        )}
+      </div>
+      <button
+        role="switch"
+        aria-checked={checked}
+        onClick={() => onChange(!checked)}
+        className={`relative shrink-0 w-9 h-5 rounded-full transition-colors ${
+          checked ? "bg-[#8b5cf6]" : "bg-white/10"
+        }`}
+      >
+        <span
+          className={`absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full shadow transition-transform ${
+            checked ? "translate-x-4" : "translate-x-0"
+          }`}
+        />
+      </button>
+    </div>
+  );
+}
+
+type Tab = "ranking" | "sync";
+
 export function SettingsPanel({ open, onClose }: SettingsPanelProps) {
+  const [tab, setTab] = useState<Tab>("ranking");
   const [syncUrl, setSyncUrl] = useState<string>("");
   const [clientCount, setClientCount] = useState(0);
   const [copied, setCopied] = useState(false);
 
+  const preferences = useAppStore((s) => s.preferences);
+  const updatePreferences = useAppStore((s) => s.updatePreferences);
+
+  const [weights, setWeights] = useState<WeightPreferences>(
+    () => preferences.weights,
+  );
+  const [display, setDisplay] = useState(() => preferences.display);
+
   useEffect(() => {
     if (!open) return;
 
-    // Get sync URL
     getSyncUrl().then(setSyncUrl);
 
-    // Subscribe to status updates
     const unsubscribe = onStatusChange((status: SyncStatus) => {
       setClientCount(status.clientCount);
     });
 
     return unsubscribe;
   }, [open]);
+
+  const handleWeightChange = useCallback(
+    (key: keyof WeightPreferences | `platforms.${string}`, value: number) => {
+      setWeights((prev) => {
+        let next: WeightPreferences;
+        if (key.startsWith("platforms.")) {
+          const platform = key.slice("platforms.".length);
+          next = { ...prev, platforms: { ...prev.platforms, [platform]: value } };
+        } else {
+          next = { ...prev, [key]: value };
+        }
+        updatePreferences({ weights: next });
+        return next;
+      });
+    },
+    [updatePreferences],
+  );
+
+  const handleDisplayChange = useCallback(
+    (update: Partial<typeof display>) => {
+      setDisplay((prev) => {
+        const next = { ...prev, ...update };
+        updatePreferences({ display: next });
+        return next;
+      });
+    },
+    [updatePreferences],
+  );
 
   const handleCopyUrl = async () => {
     try {
@@ -41,10 +151,9 @@ export function SettingsPanel({ open, onClose }: SettingsPanelProps) {
 
   if (!open) return null;
 
-  // Generate a simple QR code using a data URL
-  // For a real implementation, use a library like qrcode
+  const platformWeights = weights.platforms ?? {};
   const qrCodeUrl = `https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${encodeURIComponent(
-    syncUrl
+    syncUrl,
   )}&bgcolor=0a0a0a&color=fafafa`;
 
   return (
@@ -56,100 +165,171 @@ export function SettingsPanel({ open, onClose }: SettingsPanelProps) {
       />
 
       {/* Panel */}
-      <div className="relative w-full max-w-md mx-4 bg-[#141414] border border-[rgba(255,255,255,0.08)] rounded-2xl p-6 shadow-2xl">
-        <div className="flex items-center justify-between mb-6">
+      <div className="relative w-full max-w-md mx-4 bg-[#141414] border border-[rgba(255,255,255,0.08)] rounded-2xl shadow-2xl max-h-[85vh] flex flex-col">
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-[rgba(255,255,255,0.08)] shrink-0">
           <h2 className="text-xl font-semibold">Settings</h2>
           <button
             onClick={onClose}
-            className="p-2 rounded-lg hover:bg-white/10 transition-colors"
+            className="p-2 rounded-lg hover:bg-white/10 transition-colors text-[#71717a] hover:text-white"
+            aria-label="Close settings"
           >
-            <svg
-              className="w-5 h-5"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M6 18L18 6M6 6l12 12"
-              />
+            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
             </svg>
           </button>
         </div>
 
-        {/* Sync Section */}
-        <div className="space-y-6">
-          <div>
-            <h3 className="text-sm font-medium text-[#a1a1aa] mb-3">
-              Mobile Sync
-            </h3>
+        {/* Tabs */}
+        <div className="flex gap-1 px-6 pt-4 pb-0 shrink-0">
+          {(["ranking", "sync"] as const).map((t) => (
+            <button
+              key={t}
+              onClick={() => setTab(t)}
+              className={`px-4 py-2 rounded-lg text-sm font-medium capitalize transition-colors ${
+                tab === t
+                  ? "bg-[#8b5cf6]/20 text-[#8b5cf6] border border-[#8b5cf6]/30"
+                  : "text-[#71717a] hover:text-white hover:bg-white/5"
+              }`}
+            >
+              {t === "ranking" ? "Ranking" : "Mobile Sync"}
+            </button>
+          ))}
+        </div>
 
-            {/* QR Code */}
-            <div className="flex flex-col items-center p-4 bg-white/5 rounded-xl border border-[rgba(255,255,255,0.08)] mb-4">
-              <p className="text-xs text-[#71717a] mb-3">
-                Scan with your phone to connect Freed PWA
-              </p>
-              {syncUrl && (
-                <img
-                  src={qrCodeUrl}
-                  alt="Sync QR Code"
-                  className="w-40 h-40 rounded-lg"
-                />
-              )}
-              <p className="text-xs text-[#71717a] mt-3 text-center">
-                Open <span className="text-[#8b5cf6]">freed.wtf/app</span> on
-                your phone,
-                <br />
-                then scan this QR code
-              </p>
-            </div>
+        {/* Content */}
+        <div className="overflow-y-auto flex-1 px-6 py-5 space-y-6">
+          {tab === "ranking" && (
+            <>
+              <section>
+                <h3 className="text-xs font-semibold text-[#71717a] uppercase tracking-wider mb-4">
+                  Ranking Weights
+                </h3>
+                <div className="space-y-5">
+                  <Slider
+                    label="Recency"
+                    value={weights.recency}
+                    onChange={(v) => handleWeightChange("recency", v)}
+                    description="How much to prioritize newer content"
+                  />
+                  <Slider
+                    label="X / Twitter"
+                    value={platformWeights["x"] ?? 50}
+                    onChange={(v) => handleWeightChange("platforms.x", v)}
+                    description="Boost or suppress X posts"
+                  />
+                  <Slider
+                    label="RSS"
+                    value={platformWeights["rss"] ?? 50}
+                    onChange={(v) => handleWeightChange("platforms.rss", v)}
+                    description="Boost or suppress RSS articles"
+                  />
+                  <Slider
+                    label="YouTube"
+                    value={platformWeights["youtube"] ?? 50}
+                    onChange={(v) => handleWeightChange("platforms.youtube", v)}
+                    description="Boost or suppress YouTube videos"
+                  />
+                </div>
+                <p className="mt-3 text-xs text-[#52525b]">
+                  0 = never show · 50 = default · 100 = always prioritize
+                </p>
+              </section>
 
-            {/* Sync URL */}
-            <div className="mb-4">
-              <label className="block text-xs text-[#71717a] mb-2">
-                Or enter this URL manually:
-              </label>
-              <div className="flex gap-2">
-                <input
-                  type="text"
-                  value={syncUrl}
-                  readOnly
-                  className="flex-1 px-3 py-2 bg-white/5 border border-[rgba(255,255,255,0.08)] rounded-lg text-sm text-[#a1a1aa] font-mono"
-                />
-                <button
-                  onClick={handleCopyUrl}
-                  className="px-3 py-2 bg-[#8b5cf6]/20 text-[#8b5cf6] rounded-lg hover:bg-[#8b5cf6]/30 transition-colors text-sm font-medium"
-                >
-                  {copied ? "Copied!" : "Copy"}
-                </button>
+              <section>
+                <h3 className="text-xs font-semibold text-[#71717a] uppercase tracking-wider mb-4">
+                  Display
+                </h3>
+                <div className="space-y-5">
+                  <Toggle
+                    label="Compact mode"
+                    checked={display.compactMode}
+                    onChange={(v) => handleDisplayChange({ compactMode: v })}
+                    description="Smaller cards with less whitespace"
+                  />
+                  <Toggle
+                    label="Show engagement counts"
+                    checked={display.showEngagementCounts}
+                    onChange={(v) => handleDisplayChange({ showEngagementCounts: v })}
+                    description="Show likes, reposts, and views on posts"
+                  />
+                </div>
+              </section>
+            </>
+          )}
+
+          {tab === "sync" && (
+            <>
+              <div>
+                <h3 className="text-xs font-semibold text-[#71717a] uppercase tracking-wider mb-4">
+                  Mobile Sync
+                </h3>
+
+                {/* QR Code */}
+                <div className="flex flex-col items-center p-4 bg-white/5 rounded-xl border border-[rgba(255,255,255,0.08)] mb-4">
+                  <p className="text-xs text-[#71717a] mb-3">
+                    Scan with your phone to connect Freed PWA
+                  </p>
+                  {syncUrl && (
+                    <img
+                      src={qrCodeUrl}
+                      alt="Sync QR Code"
+                      className="w-40 h-40 rounded-lg"
+                    />
+                  )}
+                  <p className="text-xs text-[#71717a] mt-3 text-center">
+                    Open <span className="text-[#8b5cf6]">freed.wtf/app</span> on
+                    your phone,
+                    <br />
+                    then scan this QR code
+                  </p>
+                </div>
+
+                {/* Sync URL */}
+                <div className="mb-4">
+                  <label className="block text-xs text-[#71717a] mb-2">
+                    Or enter this URL manually:
+                  </label>
+                  <div className="flex gap-2">
+                    <input
+                      type="text"
+                      value={syncUrl}
+                      readOnly
+                      className="flex-1 px-3 py-2 bg-white/5 border border-[rgba(255,255,255,0.08)] rounded-lg text-sm text-[#a1a1aa] font-mono"
+                    />
+                    <button
+                      onClick={handleCopyUrl}
+                      className="px-3 py-2 bg-[#8b5cf6]/20 text-[#8b5cf6] rounded-lg hover:bg-[#8b5cf6]/30 transition-colors text-sm font-medium"
+                    >
+                      {copied ? "Copied!" : "Copy"}
+                    </button>
+                  </div>
+                </div>
+
+                {/* Connected Devices */}
+                <div className="flex items-center justify-between p-3 bg-white/5 rounded-xl">
+                  <div className="flex items-center gap-2">
+                    <span
+                      className={`sync-dot ${
+                        clientCount > 0 ? "connected" : "disconnected"
+                      }`}
+                    />
+                    <span className="text-sm">Connected devices</span>
+                  </div>
+                  <span className="text-sm font-medium text-[#a1a1aa]">
+                    {clientCount}
+                  </span>
+                </div>
               </div>
-            </div>
 
-            {/* Connected Devices */}
-            <div className="flex items-center justify-between p-3 bg-white/5 rounded-xl">
-              <div className="flex items-center gap-2">
-                <span
-                  className={`sync-dot ${
-                    clientCount > 0 ? "connected" : "disconnected"
-                  }`}
-                />
-                <span className="text-sm">Connected devices</span>
+              <div className="pt-4 border-t border-[rgba(255,255,255,0.08)]">
+                <div className="flex items-center justify-between text-sm">
+                  <span className="text-[#71717a]">Freed Desktop</span>
+                  <span className="text-[#a1a1aa]">v0.1.0</span>
+                </div>
               </div>
-              <span className="text-sm font-medium text-[#a1a1aa]">
-                {clientCount}
-              </span>
-            </div>
-          </div>
-
-          {/* Version Info */}
-          <div className="pt-4 border-t border-[rgba(255,255,255,0.08)]">
-            <div className="flex items-center justify-between text-sm">
-              <span className="text-[#71717a]">Freed Desktop</span>
-              <span className="text-[#a1a1aa]">v0.1.0</span>
-            </div>
-          </div>
+            </>
+          )}
         </div>
       </div>
     </div>

--- a/packages/desktop/src/components/feed/FeedView.tsx
+++ b/packages/desktop/src/components/feed/FeedView.tsx
@@ -11,6 +11,7 @@ export function FeedView() {
   const feeds = useAppStore((s) => s.feeds);
   const activeFilter = useAppStore((s) => s.activeFilter);
   const markAsRead = useAppStore((s) => s.markAsRead);
+  const toggleSaved = useAppStore((s) => s.toggleSaved);
   const [addFeedOpen, setAddFeedOpen] = useState(false);
 
   const filteredItems = useMemo(() => {
@@ -78,6 +79,7 @@ export function FeedView() {
         onFocusChange={setFocusedIndex}
         onAddFeed={() => setAddFeedOpen(true)}
         hasFeedsSubscribed={Object.keys(feeds).length > 0}
+        onItemSave={(item) => toggleSaved(item.globalId)}
       />
 
       {selectedItem && (

--- a/packages/desktop/src/components/feed/FeedView.tsx
+++ b/packages/desktop/src/components/feed/FeedView.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect, useCallback } from "react";
 import { FeedList } from "./FeedList";
 import { ReaderView } from "./ReaderView";
 import { useAppStore } from "../../lib/store";
@@ -8,6 +8,7 @@ import type { FeedItem } from "@freed/shared";
 export function FeedView() {
   const items = useAppStore((s) => s.items);
   const activeFilter = useAppStore((s) => s.activeFilter);
+  const markAsRead = useAppStore((s) => s.markAsRead);
 
   const filteredItems = useMemo(() => {
     const filtered = filterFeedItems(items, activeFilter);
@@ -15,16 +16,63 @@ export function FeedView() {
   }, [items, activeFilter]);
 
   const [selectedItem, setSelectedItem] = useState<FeedItem | null>(null);
+  const [focusedIndex, setFocusedIndex] = useState<number>(-1);
+
+  const openItem = useCallback(
+    (item: FeedItem) => {
+      setSelectedItem(item);
+      markAsRead(item.globalId);
+    },
+    [markAsRead],
+  );
+
+  const closeItem = useCallback(() => setSelectedItem(null), []);
+
+  // Keyboard navigation: j/k to move, Enter/o to open, Escape to close
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (
+        e.target instanceof HTMLInputElement ||
+        e.target instanceof HTMLTextAreaElement
+      )
+        return;
+
+      if (selectedItem) {
+        if (e.key === "Escape") closeItem();
+        return;
+      }
+
+      if (e.key === "j" || e.key === "ArrowDown") {
+        e.preventDefault();
+        setFocusedIndex((prev) => Math.min(prev + 1, filteredItems.length - 1));
+      } else if (e.key === "k" || e.key === "ArrowUp") {
+        e.preventDefault();
+        setFocusedIndex((prev) => Math.max(prev - 1, 0));
+      } else if ((e.key === "Enter" || e.key === "o") && focusedIndex >= 0) {
+        const item = filteredItems[focusedIndex];
+        if (item) openItem(item);
+      }
+    };
+
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [selectedItem, filteredItems, focusedIndex, openItem, closeItem]);
+
+  useEffect(() => {
+    setFocusedIndex(-1);
+  }, [activeFilter]);
 
   return (
     <>
       <FeedList
         items={filteredItems}
-        onItemClick={(item) => setSelectedItem(item)}
+        onItemClick={openItem}
+        focusedIndex={focusedIndex}
+        onFocusChange={setFocusedIndex}
       />
 
       {selectedItem && (
-        <ReaderView item={selectedItem} onClose={() => setSelectedItem(null)} />
+        <ReaderView item={selectedItem} onClose={closeItem} />
       )}
     </>
   );

--- a/packages/desktop/src/components/feed/FeedView.tsx
+++ b/packages/desktop/src/components/feed/FeedView.tsx
@@ -1,14 +1,17 @@
 import { useState, useMemo, useEffect, useCallback } from "react";
 import { FeedList } from "./FeedList";
 import { ReaderView } from "./ReaderView";
+import { AddFeedDialog } from "../AddFeedDialog";
 import { useAppStore } from "../../lib/store";
 import { sortByPriority, filterFeedItems } from "@freed/shared";
 import type { FeedItem } from "@freed/shared";
 
 export function FeedView() {
   const items = useAppStore((s) => s.items);
+  const feeds = useAppStore((s) => s.feeds);
   const activeFilter = useAppStore((s) => s.activeFilter);
   const markAsRead = useAppStore((s) => s.markAsRead);
+  const [addFeedOpen, setAddFeedOpen] = useState(false);
 
   const filteredItems = useMemo(() => {
     const filtered = filterFeedItems(items, activeFilter);
@@ -73,11 +76,15 @@ export function FeedView() {
         onItemClick={openItem}
         focusedIndex={focusedIndex}
         onFocusChange={setFocusedIndex}
+        onAddFeed={() => setAddFeedOpen(true)}
+        hasFeedsSubscribed={Object.keys(feeds).length > 0}
       />
 
       {selectedItem && (
         <ReaderView item={selectedItem} onClose={closeItem} />
       )}
+
+      <AddFeedDialog open={addFeedOpen} onClose={() => setAddFeedOpen(false)} />
     </>
   );
 }

--- a/packages/desktop/src/components/feed/FeedView.tsx
+++ b/packages/desktop/src/components/feed/FeedView.tsx
@@ -12,7 +12,11 @@ export function FeedView() {
 
   const filteredItems = useMemo(() => {
     const filtered = filterFeedItems(items, activeFilter);
-    return sortByPriority(filtered);
+    // Apply feedUrl filter (not handled by shared filterFeedItems)
+    const byFeed = activeFilter.feedUrl
+      ? filtered.filter((item) => item.rssSource?.feedUrl === activeFilter.feedUrl)
+      : filtered;
+    return sortByPriority(byFeed);
   }, [items, activeFilter]);
 
   const [selectedItem, setSelectedItem] = useState<FeedItem | null>(null);

--- a/packages/desktop/src/components/feed/FeedView.tsx
+++ b/packages/desktop/src/components/feed/FeedView.tsx
@@ -6,11 +6,9 @@ import { sortByPriority, filterFeedItems } from "@freed/shared";
 import type { FeedItem } from "@freed/shared";
 
 export function FeedView() {
-  // Select raw state (stable references)
   const items = useAppStore((s) => s.items);
   const activeFilter = useAppStore((s) => s.activeFilter);
-  
-  // Memoize filtering/sorting to avoid infinite loops
+
   const filteredItems = useMemo(() => {
     const filtered = filterFeedItems(items, activeFilter);
     return sortByPriority(filtered);
@@ -18,22 +16,15 @@ export function FeedView() {
 
   const [selectedItem, setSelectedItem] = useState<FeedItem | null>(null);
 
-  const handleItemClick = (item: FeedItem) => {
-    setSelectedItem(item);
-  };
-
-  const handleCloseReader = () => {
-    setSelectedItem(null);
-  };
-
   return (
     <>
-      <div className="h-full overflow-auto p-4">
-        <FeedList items={filteredItems} onItemClick={handleItemClick} />
-      </div>
+      <FeedList
+        items={filteredItems}
+        onItemClick={(item) => setSelectedItem(item)}
+      />
 
       {selectedItem && (
-        <ReaderView item={selectedItem} onClose={handleCloseReader} />
+        <ReaderView item={selectedItem} onClose={() => setSelectedItem(null)} />
       )}
     </>
   );

--- a/packages/desktop/src/components/layout/Sidebar.tsx
+++ b/packages/desktop/src/components/layout/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo } from "react";
 import { useAppStore } from "../../lib/store";
-import { openXLogin, loadStoredCookies, disconnectX } from "../../lib/x-auth";
+import { connectX, loadStoredCookies, disconnectX } from "../../lib/x-auth";
 import { captureXTimeline } from "../../lib/x-capture";
 
 interface SidebarProps {
@@ -25,6 +25,10 @@ export function Sidebar({ open, onClose, onOpenSettings }: SidebarProps) {
   const feeds = useAppStore((s) => s.feeds);
   const items = useAppStore((s) => s.items);
   const [xSyncing, setXSyncing] = useState(false);
+  const [showXForm, setShowXForm] = useState(false);
+  const [xCt0, setXCt0] = useState("");
+  const [xAuthToken, setXAuthToken] = useState("");
+  const [xFormError, setXFormError] = useState("");
 
   // Per-feed unread counts
   const feedUnreadCounts = useMemo(() => {
@@ -61,18 +65,24 @@ export function Sidebar({ open, onClose, onOpenSettings }: SidebarProps) {
   };
 
   const handleConnectX = async () => {
-    const cookies = await openXLogin();
-    if (cookies) {
-      setXAuth({ isAuthenticated: true, cookies });
-      // Immediately capture timeline after connecting
-      setXSyncing(true);
-      try {
-        await captureXTimeline(cookies);
-      } catch (error) {
-        console.error("Failed to capture X timeline:", error);
-      } finally {
-        setXSyncing(false);
-      }
+    setXFormError("");
+    const cookies = connectX(xCt0, xAuthToken);
+    if (!cookies) {
+      setXFormError("Both ct0 and auth_token are required.");
+      return;
+    }
+    setXAuth({ isAuthenticated: true, cookies });
+    setShowXForm(false);
+    setXCt0("");
+    setXAuthToken("");
+    // Immediately capture timeline after connecting
+    setXSyncing(true);
+    try {
+      await captureXTimeline(cookies);
+    } catch (error) {
+      console.error("Failed to capture X timeline:", error);
+    } finally {
+      setXSyncing(false);
     }
   };
 
@@ -226,9 +236,46 @@ export function Sidebar({ open, onClose, onOpenSettings }: SidebarProps) {
                   Disconnect
                 </button>
               </div>
+            ) : showXForm ? (
+              <div className="space-y-2">
+                <p className="text-[10px] text-[#71717a] leading-relaxed">
+                  Open x.com → DevTools → Application → Cookies → x.com
+                </p>
+                <input
+                  type="text"
+                  placeholder="ct0 cookie value"
+                  value={xCt0}
+                  onChange={(e) => setXCt0(e.target.value)}
+                  className="w-full text-xs px-2 py-1.5 bg-white/5 border border-[rgba(255,255,255,0.1)] rounded-lg text-white placeholder-[#52525b] focus:outline-none focus:border-[#8b5cf6]/50"
+                />
+                <input
+                  type="text"
+                  placeholder="auth_token cookie value"
+                  value={xAuthToken}
+                  onChange={(e) => setXAuthToken(e.target.value)}
+                  className="w-full text-xs px-2 py-1.5 bg-white/5 border border-[rgba(255,255,255,0.1)] rounded-lg text-white placeholder-[#52525b] focus:outline-none focus:border-[#8b5cf6]/50"
+                />
+                {xFormError && (
+                  <p className="text-[10px] text-red-400">{xFormError}</p>
+                )}
+                <div className="flex gap-2">
+                  <button
+                    onClick={handleConnectX}
+                    className="flex-1 text-xs px-2 py-1.5 bg-[#8b5cf6]/20 text-[#8b5cf6] rounded-lg hover:bg-[#8b5cf6]/30 transition-colors"
+                  >
+                    Connect
+                  </button>
+                  <button
+                    onClick={() => { setShowXForm(false); setXFormError(""); }}
+                    className="text-xs px-2 py-1.5 bg-white/5 text-[#71717a] rounded-lg hover:bg-white/10 transition-colors"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </div>
             ) : (
               <button
-                onClick={handleConnectX}
+                onClick={() => setShowXForm(true)}
                 className="w-full text-xs px-2 py-1.5 bg-[#8b5cf6]/20 text-[#8b5cf6] rounded-lg hover:bg-[#8b5cf6]/30 transition-colors"
               >
                 Connect X Account

--- a/packages/desktop/src/lib/automerge.ts
+++ b/packages/desktop/src/lib/automerge.ts
@@ -151,6 +151,22 @@ export async function docUpdateLastSync(): Promise<FreedDoc> {
 }
 
 /**
+ * Mark all unread items as read in a single Automerge change.
+ * Optionally filter by platform.
+ */
+export async function docMarkAllAsRead(platform?: string): Promise<FreedDoc> {
+  return applyChange((doc) => {
+    const now = Date.now();
+    for (const item of Object.values(doc.feedItems)) {
+      if (item.userState.readAt) continue;
+      if (item.userState.hidden || item.userState.archived) continue;
+      if (platform && item.platform !== platform) continue;
+      item.userState.readAt = now;
+    }
+  }, "Mark all as read");
+}
+
+/**
  * Bulk add feed items (more efficient for initial feed fetch)
  */
 export async function docAddFeedItems(items: FeedItem[]): Promise<FreedDoc> {

--- a/packages/desktop/src/lib/focus-text.ts
+++ b/packages/desktop/src/lib/focus-text.ts
@@ -1,0 +1,71 @@
+/**
+ * Focus Mode — bionic reading enhancement
+ *
+ * Bolds the beginning of each word to create visual fixation points,
+ * allowing faster reading by guiding eye movement through text.
+ */
+
+export type FocusIntensity = "light" | "normal" | "strong";
+
+export interface FocusOptions {
+  enabled: boolean;
+  intensity: FocusIntensity;
+}
+
+export interface TextSegment {
+  text: string;
+  emphasis: boolean;
+}
+
+/**
+ * Number of characters to bold based on word length and intensity.
+ */
+function getEmphasisCount(wordLength: number, intensity: FocusIntensity): number {
+  const ratios: Record<FocusIntensity, number> = {
+    light: 0.25,
+    normal: 0.4,
+    strong: 0.6,
+  };
+  return Math.max(1, Math.ceil(wordLength * ratios[intensity]));
+}
+
+/**
+ * Split text into segments with emphasis markers for focus mode rendering.
+ * Non-alpha words (numbers, punctuation) are returned as-is without emphasis.
+ */
+export function applyFocusMode(
+  text: string,
+  options: FocusOptions,
+): TextSegment[] {
+  if (!options.enabled) {
+    return [{ text, emphasis: false }];
+  }
+
+  const segments: TextSegment[] = [];
+  // Split on whitespace, preserving the whitespace tokens
+  const tokens = text.split(/(\s+)/);
+
+  for (const token of tokens) {
+    if (/^\s+$/.test(token)) {
+      // Whitespace — pass through
+      segments.push({ text: token, emphasis: false });
+    } else if (/^[a-zA-ZÀ-ÿ]+$/.test(token)) {
+      // Pure alphabetic word — apply emphasis to beginning
+      const count = getEmphasisCount(token.length, options.intensity);
+      segments.push({ text: token.slice(0, count), emphasis: true });
+      if (token.length > count) {
+        segments.push({ text: token.slice(count), emphasis: false });
+      }
+    } else {
+      // Mixed/punctuation/numbers — no emphasis
+      segments.push({ text: token, emphasis: false });
+    }
+  }
+
+  return segments;
+}
+
+export const DEFAULT_FOCUS_OPTIONS: FocusOptions = {
+  enabled: false,
+  intensity: "normal",
+};

--- a/packages/desktop/src/lib/rss-poller.ts
+++ b/packages/desktop/src/lib/rss-poller.ts
@@ -1,0 +1,59 @@
+/**
+ * Background RSS polling service
+ *
+ * Automatically refreshes all subscribed feeds on a regular interval.
+ * Runs in the JavaScript layer so it works regardless of Tauri's background state.
+ */
+
+import { refreshAllFeeds } from "./capture";
+
+/** Default poll interval: 30 minutes */
+const DEFAULT_INTERVAL_MS = 30 * 60 * 1000;
+
+let pollIntervalId: ReturnType<typeof setInterval> | null = null;
+let isPolling = false;
+
+/**
+ * Start background RSS polling.
+ * Safe to call multiple times — will not create duplicate intervals.
+ *
+ * @param intervalMs Poll interval in milliseconds (default: 30 minutes)
+ */
+export function startRssPoller(intervalMs = DEFAULT_INTERVAL_MS): void {
+  if (pollIntervalId !== null) return; // Already running
+
+  // Do an immediate refresh on first start
+  triggerPoll();
+
+  pollIntervalId = setInterval(triggerPoll, intervalMs);
+  console.log(
+    `[RssPoller] Started — polling every ${intervalMs / 60000} minutes`,
+  );
+}
+
+/**
+ * Stop background RSS polling.
+ */
+export function stopRssPoller(): void {
+  if (pollIntervalId !== null) {
+    clearInterval(pollIntervalId);
+    pollIntervalId = null;
+    console.log("[RssPoller] Stopped");
+  }
+}
+
+/**
+ * Trigger a single poll (no-op if one is already in flight).
+ */
+async function triggerPoll(): Promise<void> {
+  if (isPolling) return;
+  isPolling = true;
+
+  try {
+    await refreshAllFeeds();
+  } catch (err) {
+    console.error("[RssPoller] Error during poll:", err);
+  } finally {
+    isPolling = false;
+  }
+}

--- a/packages/desktop/src/lib/store.ts
+++ b/packages/desktop/src/lib/store.ts
@@ -19,7 +19,7 @@ import {
   docUpdatePreferences,
 } from "./automerge";
 import type { FreedDoc } from "@freed/shared/schema";
-import { loadStoredCookies } from "./x-auth";
+import { loadStoredCookies, type XAuthState } from "./x-auth";
 
 // Filter options for the feed view
 interface FilterOptions {
@@ -27,12 +27,6 @@ interface FilterOptions {
   tags?: string[];
   savedOnly?: boolean;
   showArchived?: boolean;
-}
-
-// X authentication state
-interface XAuthState {
-  isAuthenticated: boolean;
-  username?: string;
 }
 
 // App state interface

--- a/packages/desktop/src/lib/store.ts
+++ b/packages/desktop/src/lib/store.ts
@@ -15,6 +15,7 @@ import {
   docRemoveRssFeed,
   docUpdateFeedItem,
   docMarkAsRead,
+  docMarkAllAsRead,
   docToggleSaved,
   docUpdatePreferences,
 } from "./automerge";
@@ -55,6 +56,7 @@ interface AppState {
   addItems: (items: FeedItem[]) => Promise<void>;
   updateItem: (id: string, update: Partial<FeedItem>) => Promise<void>;
   markAsRead: (id: string) => Promise<void>;
+  markAllAsRead: (platform?: string) => Promise<void>;
   toggleSaved: (id: string) => Promise<void>;
 
   // Feed actions (persisted to Automerge)
@@ -162,6 +164,14 @@ export const useAppStore = create<AppState>((set, get) => ({
       await docMarkAsRead(id);
     } catch (error) {
       set({ error: error instanceof Error ? error.message : "Failed to mark as read" });
+    }
+  },
+
+  markAllAsRead: async (platform) => {
+    try {
+      await docMarkAllAsRead(platform);
+    } catch (error) {
+      set({ error: error instanceof Error ? error.message : "Failed to mark all as read" });
     }
   },
 

--- a/packages/desktop/src/lib/store.ts
+++ b/packages/desktop/src/lib/store.ts
@@ -24,6 +24,7 @@ import { loadStoredCookies, type XAuthState } from "./x-auth";
 // Filter options for the feed view
 interface FilterOptions {
   platform?: string;
+  feedUrl?: string;
   tags?: string[];
   savedOnly?: boolean;
   showArchived?: boolean;

--- a/packages/desktop/src/lib/x-auth.ts
+++ b/packages/desktop/src/lib/x-auth.ts
@@ -89,41 +89,16 @@ export async function validateCookies(_cookies: XCookies): Promise<boolean> {
 }
 
 /**
- * Open X login window
- *
- * This creates a new WebView window pointing to X's login page.
- * After login, we'll extract the cookies.
+ * Connect X account by storing the provided cookies directly.
+ * The UI (Sidebar) collects ct0 and auth_token from the user via an inline form.
  */
-export async function openXLogin(): Promise<XCookies | null> {
-  return new Promise((resolve) => {
-    // Create a modal dialog for entering cookies manually
-    // In a full implementation, we'd open a WebView window
-
-    const cookieString = window.prompt(
-      "Freed needs your X/Twitter cookies to capture your timeline.\n\n" +
-        "To get them:\n" +
-        "1. Open x.com in your browser\n" +
-        "2. Log in if needed\n" +
-        "3. Open DevTools (F12)\n" +
-        "4. Go to Application > Cookies > x.com\n" +
-        "5. Copy the values of 'ct0' and 'auth_token'\n\n" +
-        "Paste your cookies in format: ct0=xxx; auth_token=xxx"
-    );
-
-    if (!cookieString) {
-      resolve(null);
-      return;
-    }
-
-    const cookies = parseCookieString(cookieString);
-    if (cookies) {
-      storeCookies(cookies);
-      resolve(cookies);
-    } else {
-      alert("Invalid cookie format. Please include both ct0 and auth_token.");
-      resolve(null);
-    }
-  });
+export function connectX(ct0: string, authToken: string): XCookies | null {
+  const ct0Trimmed = ct0.trim();
+  const tokenTrimmed = authToken.trim();
+  if (!ct0Trimmed || !tokenTrimmed) return null;
+  const cookies: XCookies = { ct0: ct0Trimmed, authToken: tokenTrimmed };
+  storeCookies(cookies);
+  return cookies;
 }
 
 /**

--- a/packages/desktop/src/lib/x-capture.ts
+++ b/packages/desktop/src/lib/x-capture.ts
@@ -76,7 +76,7 @@ interface XTweetResult {
     entities: {
       urls?: { expanded_url: string }[];
       hashtags?: { text: string }[];
-      media?: { media_url_https: string; type: string }[];
+      media?: { media_url_https: string; type: string; video_info?: { variants: { url: string; bitrate?: number }[] } }[];
     };
     extended_entities?: {
       media?: { media_url_https: string; type: string; video_info?: { variants: { url: string; bitrate?: number }[] } }[];

--- a/packages/pwa/index.html
+++ b/packages/pwa/index.html
@@ -2,9 +2,22 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>Freed</title>
+    <meta name="description" content="Your feeds, liberated. A chronological reader for X, RSS, YouTube, and more." />
+    <meta name="theme-color" content="#0a0a0a" />
+
+    <!-- PWA manifest -->
+    <link rel="manifest" href="/manifest.json" />
+
+    <!-- iOS PWA support -->
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta name="apple-mobile-web-app-title" content="Freed" />
+    <link rel="apple-touch-icon" href="/icons/icon-192.png" />
+
+    <!-- Icons (placeholder — replace with real icons) -->
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>pwa</title>
   </head>
   <body>
     <div id="root"></div>

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -48,6 +48,7 @@
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.46.4",
     "vite": "^7.2.4",
+    "vite-plugin-pwa": "^1.2.0",
     "vite-plugin-top-level-await": "^1.6.0",
     "vite-plugin-wasm": "^3.5.0",
     "vitest": "^4.0.18"

--- a/packages/pwa/public/manifest.json
+++ b/packages/pwa/public/manifest.json
@@ -1,0 +1,37 @@
+{
+  "name": "Freed",
+  "short_name": "Freed",
+  "description": "Your feeds, liberated. A chronological reader for X, RSS, YouTube, and more.",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#0a0a0a",
+  "theme_color": "#0a0a0a",
+  "orientation": "portrait-primary",
+  "categories": ["news", "productivity"],
+  "icons": [
+    {
+      "src": "/icons/icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "/icons/icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any maskable"
+    }
+  ],
+  "shortcuts": [
+    {
+      "name": "All Feeds",
+      "url": "/",
+      "description": "View all captured content"
+    },
+    {
+      "name": "Saved",
+      "url": "/?filter=saved",
+      "description": "View saved items"
+    }
+  ]
+}

--- a/packages/pwa/src/components/SettingsPanel.tsx
+++ b/packages/pwa/src/components/SettingsPanel.tsx
@@ -1,0 +1,279 @@
+import { useState, useCallback } from "react";
+import { useAppStore } from "../lib/store";
+import type { UserPreferences, WeightPreferences } from "@freed/shared";
+
+interface SettingsPanelProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+function Slider({
+  label,
+  value,
+  onChange,
+  description,
+}: {
+  label: string;
+  value: number;
+  onChange: (v: number) => void;
+  description?: string;
+}) {
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <label className="text-sm text-[#a1a1aa]">{label}</label>
+        <span className="text-sm font-mono text-white tabular-nums w-8 text-right">
+          {value}
+        </span>
+      </div>
+      <input
+        type="range"
+        min={0}
+        max={100}
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+        className="w-full h-1.5 appearance-none rounded-full bg-white/10 accent-[#8b5cf6] cursor-pointer"
+      />
+      {description && (
+        <p className="text-xs text-[#52525b]">{description}</p>
+      )}
+    </div>
+  );
+}
+
+function Toggle({
+  label,
+  checked,
+  onChange,
+  description,
+}: {
+  label: string;
+  checked: boolean;
+  onChange: (v: boolean) => void;
+  description?: string;
+}) {
+  return (
+    <div className="flex items-start justify-between gap-4">
+      <div>
+        <p className="text-sm text-[#a1a1aa]">{label}</p>
+        {description && (
+          <p className="text-xs text-[#52525b] mt-0.5">{description}</p>
+        )}
+      </div>
+      <button
+        role="switch"
+        aria-checked={checked}
+        onClick={() => onChange(!checked)}
+        className={`relative shrink-0 w-9 h-5 rounded-full transition-colors ${
+          checked ? "bg-[#8b5cf6]" : "bg-white/10"
+        }`}
+      >
+        <span
+          className={`absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full shadow transition-transform ${
+            checked ? "translate-x-4" : "translate-x-0"
+          }`}
+        />
+      </button>
+    </div>
+  );
+}
+
+export function SettingsPanel({ open, onClose }: SettingsPanelProps) {
+  const preferences = useAppStore((s) => s.preferences);
+  const updatePreferences = useAppStore((s) => s.updatePreferences);
+
+  // Local draft state — applied immediately on change
+  const [weights, setWeights] = useState<WeightPreferences>(
+    () => preferences.weights,
+  );
+  const [display, setDisplay] = useState(() => preferences.display);
+
+  // Sync local draft with store when opened
+  // (use key prop on parent instead of resetting here for simplicity)
+
+  const handleWeightChange = useCallback(
+    (key: keyof WeightPreferences | `platforms.${string}`, value: number) => {
+      setWeights((prev) => {
+        let next: WeightPreferences;
+        if (key.startsWith("platforms.")) {
+          const platform = key.slice("platforms.".length);
+          next = { ...prev, platforms: { ...prev.platforms, [platform]: value } };
+        } else {
+          next = { ...prev, [key]: value };
+        }
+        updatePreferences({ weights: next });
+        return next;
+      });
+    },
+    [updatePreferences],
+  );
+
+  const handleDisplayChange = useCallback(
+    (update: Partial<typeof display>) => {
+      setDisplay((prev) => {
+        const next = { ...prev, ...update };
+        updatePreferences({ display: next });
+        return next;
+      });
+    },
+    [updatePreferences],
+  );
+
+  const handleReadingChange = useCallback(
+    (update: Partial<typeof display.reading>) => {
+      setDisplay((prev) => {
+        const next = {
+          ...prev,
+          reading: { ...prev.reading, ...update },
+        };
+        updatePreferences({ display: next });
+        return next;
+      });
+    },
+    [updatePreferences],
+  );
+
+  if (!open) return null;
+
+  const platformWeights = weights.platforms ?? {};
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center">
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+        onClick={onClose}
+      />
+
+      {/* Panel */}
+      <div className="relative w-full sm:max-w-md sm:mx-4 bg-[#141414] border border-[rgba(255,255,255,0.08)] rounded-t-2xl sm:rounded-2xl shadow-2xl max-h-[85vh] flex flex-col">
+        {/* Mobile drag handle */}
+        <div className="sm:hidden w-12 h-1 bg-white/20 rounded-full mx-auto mt-4 mb-1 shrink-0" />
+
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-[rgba(255,255,255,0.08)] shrink-0">
+          <h2 className="text-lg font-semibold">Settings</h2>
+          <button
+            onClick={onClose}
+            className="p-1.5 rounded-lg hover:bg-white/10 text-[#71717a] hover:text-white transition-colors"
+            aria-label="Close settings"
+          >
+            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Scrollable content */}
+        <div className="overflow-y-auto flex-1 px-6 py-5 space-y-8">
+
+          {/* Ranking */}
+          <section>
+            <h3 className="text-xs font-semibold text-[#71717a] uppercase tracking-wider mb-4">
+              Ranking Weights
+            </h3>
+            <div className="space-y-5">
+              <Slider
+                label="Recency"
+                value={weights.recency}
+                onChange={(v) => handleWeightChange("recency", v)}
+                description="How much to prioritize newer content"
+              />
+              <Slider
+                label="X / Twitter"
+                value={platformWeights["x"] ?? 50}
+                onChange={(v) => handleWeightChange("platforms.x", v)}
+                description="Boost or suppress X posts in your feed"
+              />
+              <Slider
+                label="RSS"
+                value={platformWeights["rss"] ?? 50}
+                onChange={(v) => handleWeightChange("platforms.rss", v)}
+                description="Boost or suppress RSS articles in your feed"
+              />
+              <Slider
+                label="YouTube"
+                value={platformWeights["youtube"] ?? 50}
+                onChange={(v) => handleWeightChange("platforms.youtube", v)}
+                description="Boost or suppress YouTube videos in your feed"
+              />
+            </div>
+            <p className="mt-3 text-xs text-[#52525b]">
+              0 = never show · 50 = default · 100 = always prioritize
+            </p>
+          </section>
+
+          {/* Display */}
+          <section>
+            <h3 className="text-xs font-semibold text-[#71717a] uppercase tracking-wider mb-4">
+              Display
+            </h3>
+            <div className="space-y-5">
+              <Toggle
+                label="Compact mode"
+                checked={display.compactMode}
+                onChange={(v) => handleDisplayChange({ compactMode: v })}
+                description="Smaller cards with less whitespace"
+              />
+              <Toggle
+                label="Show engagement counts"
+                checked={display.showEngagementCounts}
+                onChange={(v) => handleDisplayChange({ showEngagementCounts: v })}
+                description="Show likes, reposts, and views on posts"
+              />
+            </div>
+          </section>
+
+          {/* Reading */}
+          <section>
+            <h3 className="text-xs font-semibold text-[#71717a] uppercase tracking-wider mb-4">
+              Reading
+            </h3>
+            <div className="space-y-5">
+              <Toggle
+                label="Focus mode"
+                checked={display.reading.focusMode}
+                onChange={(v) => handleReadingChange({ focusMode: v })}
+                description="Bold word beginnings to aid reading speed"
+              />
+              {display.reading.focusMode && (
+                <div className="space-y-2">
+                  <p className="text-sm text-[#a1a1aa]">Focus intensity</p>
+                  <div className="flex gap-2">
+                    {(["light", "normal", "strong"] as const).map((level) => (
+                      <button
+                        key={level}
+                        onClick={() => handleReadingChange({ focusIntensity: level })}
+                        className={`flex-1 py-1.5 rounded-lg text-sm capitalize transition-colors ${
+                          display.reading.focusIntensity === level
+                            ? "bg-[#8b5cf6]/20 text-[#8b5cf6] border border-[#8b5cf6]/30"
+                            : "bg-white/5 text-[#71717a] hover:text-white"
+                        }`}
+                      >
+                        {level}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+          </section>
+
+          {/* About */}
+          <section className="pb-2">
+            <h3 className="text-xs font-semibold text-[#71717a] uppercase tracking-wider mb-3">
+              About
+            </h3>
+            <p className="text-xs text-[#52525b] leading-relaxed">
+              Freed is a local-first feed reader. Your data lives on your device
+              and syncs between your own devices. We never see your content.
+            </p>
+            <p className="text-xs text-[#3f3f46] mt-2">
+              MIT Licensed · freed.wtf
+            </p>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/pwa/src/components/SyncConnectDialog.tsx
+++ b/packages/pwa/src/components/SyncConnectDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useRef, useEffect, useCallback } from "react";
 import { connect, storeRelayUrl } from "../lib/sync";
 
 interface SyncConnectDialogProps {
@@ -6,17 +6,129 @@ interface SyncConnectDialogProps {
   onClose: () => void;
 }
 
+type Mode = "manual" | "scanning";
+
+/** Check if the native BarcodeDetector API is available (Chrome 88+, Safari 17+) */
+function isBarcodeDetectorSupported(): boolean {
+  return typeof window !== "undefined" && "BarcodeDetector" in window;
+}
+
+/**
+ * Detect QR codes in a video frame using the native BarcodeDetector API.
+ * Returns the first decoded string, or null if none found.
+ */
+async function detectQrCode(video: HTMLVideoElement): Promise<string | null> {
+  // BarcodeDetector is experimental — type it loosely
+  const BarcodeDetector = (
+    window as unknown as {
+      BarcodeDetector: new (opts: { formats: string[] }) => {
+        detect: (source: HTMLVideoElement) => Promise<{ rawValue: string }[]>;
+      };
+    }
+  ).BarcodeDetector;
+
+  const detector = new BarcodeDetector({ formats: ["qr_code"] });
+  try {
+    const barcodes = await detector.detect(video);
+    return barcodes[0]?.rawValue ?? null;
+  } catch {
+    return null;
+  }
+}
+
 export function SyncConnectDialog({ open, onClose }: SyncConnectDialogProps) {
+  const [mode, setMode] = useState<Mode>("manual");
   const [url, setUrl] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [connecting, setConnecting] = useState(false);
+  const [scanStatus, setScanStatus] = useState<"waiting" | "found">("waiting");
 
-  if (!open) return null;
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const scanIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const stopCamera = useCallback(() => {
+    if (scanIntervalRef.current) {
+      clearInterval(scanIntervalRef.current);
+      scanIntervalRef.current = null;
+    }
+    if (streamRef.current) {
+      for (const track of streamRef.current.getTracks()) {
+        track.stop();
+      }
+      streamRef.current = null;
+    }
+  }, []);
+
+  const handleClose = useCallback(() => {
+    stopCamera();
+    setMode("manual");
+    setUrl("");
+    setError(null);
+    setScanStatus("waiting");
+    onClose();
+  }, [stopCamera, onClose]);
+
+  const startCamera = useCallback(async () => {
+    setError(null);
+    setScanStatus("waiting");
+
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({
+        video: { facingMode: "environment" }, // back camera on mobile
+      });
+      streamRef.current = stream;
+
+      if (videoRef.current) {
+        videoRef.current.srcObject = stream;
+        await videoRef.current.play();
+      }
+
+      // Poll for QR codes every 250ms
+      scanIntervalRef.current = setInterval(async () => {
+        if (!videoRef.current || videoRef.current.readyState < 2) return;
+
+        const detected = await detectQrCode(videoRef.current);
+        if (detected && (detected.startsWith("ws://") || detected.startsWith("wss://"))) {
+          setScanStatus("found");
+          stopCamera();
+
+          // Auto-connect with the detected URL
+          storeRelayUrl(detected);
+          connect(detected);
+          setTimeout(() => handleClose(), 800);
+        }
+      }, 250);
+    } catch (e) {
+      setError(
+        e instanceof Error
+          ? e.message.includes("NotAllowed")
+            ? "Camera permission denied. Please allow camera access and try again."
+            : e.message
+          : "Could not access camera.",
+      );
+      setMode("manual");
+    }
+  }, [stopCamera, handleClose]);
+
+  // Start camera when switching to scan mode
+  useEffect(() => {
+    if (mode === "scanning" && open) {
+      startCamera();
+    }
+    return () => {
+      if (mode !== "scanning") stopCamera();
+    };
+  }, [mode, open, startCamera, stopCamera]);
+
+  // Cleanup on unmount or close
+  useEffect(() => {
+    if (!open) stopCamera();
+  }, [open, stopCamera]);
 
   const handleConnect = async () => {
     if (!url.trim()) return;
 
-    // Validate URL format
     try {
       const parsed = new URL(url.trim());
       if (parsed.protocol !== "ws:" && parsed.protocol !== "wss:") {
@@ -33,11 +145,8 @@ export function SyncConnectDialog({ open, onClose }: SyncConnectDialogProps) {
     try {
       storeRelayUrl(url.trim());
       connect(url.trim());
-
-      // Wait a moment to see if connection succeeds
       await new Promise((resolve) => setTimeout(resolve, 1000));
-
-      onClose();
+      handleClose();
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to connect");
     } finally {
@@ -45,12 +154,16 @@ export function SyncConnectDialog({ open, onClose }: SyncConnectDialogProps) {
     }
   };
 
+  if (!open) return null;
+
+  const canScan = isBarcodeDetectorSupported();
+
   return (
     <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center">
       {/* Backdrop */}
       <div
         className="absolute inset-0 bg-black/60 backdrop-blur-sm"
-        onClick={onClose}
+        onClick={handleClose}
       />
 
       {/* Dialog */}
@@ -60,31 +173,106 @@ export function SyncConnectDialog({ open, onClose }: SyncConnectDialogProps) {
 
         <h2 className="text-xl font-semibold mb-2">Connect to Desktop</h2>
         <p className="text-sm text-[#71717a] mb-6">
-          Enter the sync URL from your Freed desktop app to sync your feeds
-          across devices.
+          {mode === "scanning"
+            ? "Point your camera at the QR code shown in the Freed desktop app."
+            : "Enter the sync URL from your Freed desktop app, or scan the QR code."}
         </p>
 
-        <div className="mb-4">
-          <label
-            htmlFor="sync-url"
-            className="block text-sm text-[#a1a1aa] mb-2"
-          >
-            Sync URL
-          </label>
-          <input
-            id="sync-url"
-            type="url"
-            value={url}
-            onChange={(e) => setUrl(e.target.value)}
-            placeholder="ws://192.168.1.x:8765"
-            className="w-full px-4 py-3 bg-white/5 border border-[rgba(255,255,255,0.08)] rounded-xl focus:outline-none focus:border-[#8b5cf6] text-white placeholder-[#71717a] font-mono text-sm transition-colors"
-            disabled={connecting}
-            autoFocus
-          />
-          <p className="mt-2 text-xs text-[#71717a]">
-            Find this in your desktop app: Settings → Mobile Sync
-          </p>
-        </div>
+        {/* Mode tabs */}
+        {canScan && (
+          <div className="flex gap-2 mb-5">
+            <button
+              onClick={() => { setMode("manual"); stopCamera(); setError(null); }}
+              className={`flex-1 py-2 rounded-lg text-sm font-medium transition-colors ${
+                mode === "manual"
+                  ? "bg-[#8b5cf6]/20 text-[#8b5cf6] border border-[#8b5cf6]/30"
+                  : "bg-white/5 text-[#71717a] hover:text-white"
+              }`}
+            >
+              Manual
+            </button>
+            <button
+              onClick={() => { setMode("scanning"); setError(null); }}
+              className={`flex-1 py-2 rounded-lg text-sm font-medium transition-colors ${
+                mode === "scanning"
+                  ? "bg-[#8b5cf6]/20 text-[#8b5cf6] border border-[#8b5cf6]/30"
+                  : "bg-white/5 text-[#71717a] hover:text-white"
+              }`}
+            >
+              Scan QR
+            </button>
+          </div>
+        )}
+
+        {mode === "scanning" ? (
+          /* QR Scanner view */
+          <div className="mb-4">
+            <div className="relative rounded-xl overflow-hidden bg-black aspect-square">
+              <video
+                ref={videoRef}
+                className="w-full h-full object-cover"
+                playsInline
+                muted
+                aria-label="Camera viewfinder for QR code scanning"
+              />
+
+              {/* Scan overlay */}
+              <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+                <div
+                  className={`w-48 h-48 border-2 rounded-2xl transition-colors ${
+                    scanStatus === "found"
+                      ? "border-green-400"
+                      : "border-white/40"
+                  }`}
+                >
+                  {/* Corner brackets */}
+                  <div className="absolute top-0 left-0 w-6 h-6 border-t-2 border-l-2 border-[#8b5cf6] rounded-tl-lg" />
+                  <div className="absolute top-0 right-0 w-6 h-6 border-t-2 border-r-2 border-[#8b5cf6] rounded-tr-lg" />
+                  <div className="absolute bottom-0 left-0 w-6 h-6 border-b-2 border-l-2 border-[#8b5cf6] rounded-bl-lg" />
+                  <div className="absolute bottom-0 right-0 w-6 h-6 border-b-2 border-r-2 border-[#8b5cf6] rounded-br-lg" />
+                </div>
+              </div>
+
+              {scanStatus === "found" && (
+                <div className="absolute inset-0 flex items-center justify-center bg-black/40">
+                  <div className="flex flex-col items-center gap-2">
+                    <div className="w-12 h-12 rounded-full bg-green-500/20 border-2 border-green-400 flex items-center justify-center">
+                      <svg className="w-6 h-6 text-green-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                      </svg>
+                    </div>
+                    <p className="text-green-400 text-sm font-medium">Connecting...</p>
+                  </div>
+                </div>
+              )}
+            </div>
+
+            <p className="text-xs text-[#71717a] text-center mt-3">
+              Open the desktop app → Settings → Mobile Sync to see the QR code
+            </p>
+          </div>
+        ) : (
+          /* Manual URL entry */
+          <div className="mb-4">
+            <label htmlFor="sync-url" className="block text-sm text-[#a1a1aa] mb-2">
+              Sync URL
+            </label>
+            <input
+              id="sync-url"
+              type="url"
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+              placeholder="ws://192.168.1.x:8765"
+              className="w-full px-4 py-3 bg-white/5 border border-[rgba(255,255,255,0.08)] rounded-xl focus:outline-none focus:border-[#8b5cf6] text-white placeholder-[#71717a] font-mono text-sm transition-colors"
+              disabled={connecting}
+              autoFocus
+              onKeyDown={(e) => e.key === "Enter" && handleConnect()}
+            />
+            <p className="mt-2 text-xs text-[#71717a]">
+              Find this in your desktop app: Settings → Mobile Sync
+            </p>
+          </div>
+        )}
 
         {error && (
           <div className="mb-4 p-3 bg-red-500/20 border border-red-500/50 rounded-xl text-red-400 text-sm">
@@ -92,23 +280,37 @@ export function SyncConnectDialog({ open, onClose }: SyncConnectDialogProps) {
           </div>
         )}
 
-        <div className="flex gap-3 justify-end">
-          <button
-            type="button"
-            onClick={onClose}
-            className="px-4 py-2.5 text-[#a1a1aa] hover:text-white transition-colors"
-            disabled={connecting}
-          >
-            Cancel
-          </button>
-          <button
-            onClick={handleConnect}
-            className="btn-primary px-6 py-2.5 disabled:opacity-50"
-            disabled={connecting || !url.trim()}
-          >
-            {connecting ? "Connecting..." : "Connect"}
-          </button>
-        </div>
+        {mode === "manual" && (
+          <div className="flex gap-3 justify-end">
+            <button
+              type="button"
+              onClick={handleClose}
+              className="px-4 py-2.5 text-[#a1a1aa] hover:text-white transition-colors"
+              disabled={connecting}
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleConnect}
+              className="btn-primary px-6 py-2.5 disabled:opacity-50"
+              disabled={connecting || !url.trim()}
+            >
+              {connecting ? "Connecting..." : "Connect"}
+            </button>
+          </div>
+        )}
+
+        {mode === "scanning" && (
+          <div className="flex justify-center">
+            <button
+              type="button"
+              onClick={handleClose}
+              className="px-4 py-2.5 text-[#a1a1aa] hover:text-white transition-colors"
+            >
+              Cancel
+            </button>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/packages/pwa/src/components/Toast.tsx
+++ b/packages/pwa/src/components/Toast.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { create } from "zustand";
 
 // Toast types

--- a/packages/pwa/src/components/feed/FeedItem.tsx
+++ b/packages/pwa/src/components/feed/FeedItem.tsx
@@ -8,6 +8,7 @@ interface FeedItemProps {
   showEngagement?: boolean;
   focused?: boolean;
   onMouseEnter?: () => void;
+  onSave?: (e: React.MouseEvent) => void;
 }
 
 const platformIcons: Record<string, string> = {
@@ -22,14 +23,14 @@ const platformIcons: Record<string, string> = {
   saved: "📌",
 };
 
-export function FeedItem({ item, onClick, compact = false, showEngagement = false, focused = false, onMouseEnter }: FeedItemProps) {
+export function FeedItem({ item, onClick, compact = false, showEngagement = false, focused = false, onMouseEnter, onSave }: FeedItemProps) {
   const timeAgo = formatDistanceToNow(item.publishedAt, { addSuffix: true });
   const platformIcon = platformIcons[item.platform] || "📄";
   const avatarSize = compact ? "w-8 h-8" : "w-10 h-10";
 
   return (
     <article
-      className={`feed-card cursor-pointer active:scale-[0.99] transition-transform ${compact ? "py-2.5 px-3.5" : ""} ${focused ? "ring-2 ring-[#8b5cf6]/60 ring-inset" : ""}`}
+      className={`feed-card group cursor-pointer active:scale-[0.99] transition-transform ${compact ? "py-2.5 px-3.5" : ""} ${focused ? "ring-2 ring-[#8b5cf6]/60 ring-inset" : ""}`}
       onClick={onClick}
       onMouseEnter={onMouseEnter}
       role="button"
@@ -70,11 +71,21 @@ export function FeedItem({ item, onClick, compact = false, showEngagement = fals
           </div>
         </div>
 
-        {/* Save indicator */}
-        {item.userState.saved && (
-          <span className="text-[#8b5cf6]" title="Saved">
-            📌
-          </span>
+        {/* Save button */}
+        {onSave && (
+          <button
+            onClick={onSave}
+            title={item.userState.saved ? "Remove bookmark" : "Bookmark"}
+            className={`p-1.5 rounded-lg transition-colors flex-shrink-0 ${
+              item.userState.saved
+                ? "text-[#8b5cf6]"
+                : "text-[#52525b] hover:text-[#8b5cf6] opacity-0 group-hover:opacity-100"
+            }`}
+          >
+            <svg className="w-4 h-4" fill={item.userState.saved ? "currentColor" : "none"} viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
+            </svg>
+          </button>
         )}
       </div>
 

--- a/packages/pwa/src/components/feed/FeedItem.tsx
+++ b/packages/pwa/src/components/feed/FeedItem.tsx
@@ -4,6 +4,8 @@ import type { FeedItem as FeedItemType } from "@freed/shared";
 interface FeedItemProps {
   item: FeedItemType;
   onClick?: () => void;
+  compact?: boolean;
+  showEngagement?: boolean;
 }
 
 const platformIcons: Record<string, string> = {
@@ -18,28 +20,29 @@ const platformIcons: Record<string, string> = {
   saved: "📌",
 };
 
-export function FeedItem({ item, onClick }: FeedItemProps) {
+export function FeedItem({ item, onClick, compact = false, showEngagement = false }: FeedItemProps) {
   const timeAgo = formatDistanceToNow(item.publishedAt, { addSuffix: true });
   const platformIcon = platformIcons[item.platform] || "📄";
+  const avatarSize = compact ? "w-8 h-8" : "w-10 h-10";
 
   return (
     <article
-      className="feed-card cursor-pointer active:scale-[0.99] transition-transform"
+      className={`feed-card cursor-pointer active:scale-[0.99] transition-transform ${compact ? "py-2.5 px-3.5" : ""}`}
       onClick={onClick}
       role="button"
       tabIndex={0}
       onKeyDown={(e) => e.key === "Enter" && onClick?.()}
     >
       {/* Author row */}
-      <div className="flex items-center gap-3 mb-3">
+      <div className={`flex items-center gap-3 ${compact ? "mb-1.5" : "mb-3"}`}>
         {item.author.avatarUrl ? (
           <img
             src={item.author.avatarUrl}
             alt=""
-            className="w-10 h-10 rounded-full bg-white/5 ring-1 ring-white/10"
+            className={`${avatarSize} rounded-full bg-white/5 ring-1 ring-white/10 shrink-0`}
           />
         ) : (
-          <div className="w-10 h-10 rounded-full bg-gradient-to-br from-[#3b82f6] to-[#8b5cf6] flex items-center justify-center text-lg font-medium">
+          <div className={`${avatarSize} rounded-full bg-gradient-to-br from-[#3b82f6] to-[#8b5cf6] flex items-center justify-center font-medium shrink-0 ${compact ? "text-base" : "text-lg"}`}>
             {item.author.displayName[0]?.toUpperCase() || "?"}
           </div>
         )}
@@ -48,7 +51,9 @@ export function FeedItem({ item, onClick }: FeedItemProps) {
             <span className="font-medium truncate">
               {item.author.displayName}
             </span>
-            <span className="text-[#71717a] text-sm">@{item.author.handle}</span>
+            {!compact && (
+              <span className="text-[#71717a] text-sm">@{item.author.handle}</span>
+            )}
           </div>
           <div className="flex items-center gap-2 text-xs text-[#71717a]">
             <span>{platformIcon}</span>
@@ -72,18 +77,20 @@ export function FeedItem({ item, onClick }: FeedItemProps) {
 
       {/* Title (for articles) */}
       {item.content.linkPreview?.title && (
-        <h3 className="font-semibold text-lg mb-2 line-clamp-2 leading-snug">
+        <h3 className={`font-semibold mb-1.5 line-clamp-2 leading-snug ${compact ? "text-base" : "text-lg"}`}>
           {item.content.linkPreview.title}
         </h3>
       )}
 
       {/* Content */}
       {item.content.text && (
-        <p className="text-[#a1a1aa] line-clamp-3 mb-3 leading-relaxed">{item.content.text}</p>
+        <p className={`text-[#a1a1aa] leading-relaxed ${compact ? "line-clamp-2 mb-1.5 text-sm" : "line-clamp-3 mb-3"}`}>
+          {item.content.text}
+        </p>
       )}
 
-      {/* Media preview */}
-      {item.content.mediaUrls.length > 0 && (
+      {/* Media preview — hidden in compact mode */}
+      {!compact && item.content.mediaUrls.length > 0 && (
         <div className="mt-3 rounded-xl overflow-hidden ring-1 ring-white/5">
           <img
             src={item.content.mediaUrls[0]}
@@ -93,8 +100,23 @@ export function FeedItem({ item, onClick }: FeedItemProps) {
         </div>
       )}
 
-      {/* Tags */}
-      {item.userState.tags.length > 0 && (
+      {/* Engagement counts — opt-in only */}
+      {showEngagement && item.engagement && (
+        <div className="mt-2 flex items-center gap-4 text-xs text-[#52525b]">
+          {item.engagement.likes !== undefined && (
+            <span title="Likes">♥ {item.engagement.likes.toLocaleString()}</span>
+          )}
+          {item.engagement.reposts !== undefined && (
+            <span title="Reposts">↺ {item.engagement.reposts.toLocaleString()}</span>
+          )}
+          {item.engagement.comments !== undefined && (
+            <span title="Comments">💬 {item.engagement.comments.toLocaleString()}</span>
+          )}
+        </div>
+      )}
+
+      {/* Tags — hidden in compact mode */}
+      {!compact && item.userState.tags.length > 0 && (
         <div className="mt-3 flex flex-wrap gap-2">
           {item.userState.tags.map((tag) => (
             <span

--- a/packages/pwa/src/components/feed/FeedItem.tsx
+++ b/packages/pwa/src/components/feed/FeedItem.tsx
@@ -6,6 +6,8 @@ interface FeedItemProps {
   onClick?: () => void;
   compact?: boolean;
   showEngagement?: boolean;
+  focused?: boolean;
+  onMouseEnter?: () => void;
 }
 
 const platformIcons: Record<string, string> = {
@@ -20,15 +22,16 @@ const platformIcons: Record<string, string> = {
   saved: "📌",
 };
 
-export function FeedItem({ item, onClick, compact = false, showEngagement = false }: FeedItemProps) {
+export function FeedItem({ item, onClick, compact = false, showEngagement = false, focused = false, onMouseEnter }: FeedItemProps) {
   const timeAgo = formatDistanceToNow(item.publishedAt, { addSuffix: true });
   const platformIcon = platformIcons[item.platform] || "📄";
   const avatarSize = compact ? "w-8 h-8" : "w-10 h-10";
 
   return (
     <article
-      className={`feed-card cursor-pointer active:scale-[0.99] transition-transform ${compact ? "py-2.5 px-3.5" : ""}`}
+      className={`feed-card cursor-pointer active:scale-[0.99] transition-transform ${compact ? "py-2.5 px-3.5" : ""} ${focused ? "ring-2 ring-[#8b5cf6]/60 ring-inset" : ""}`}
       onClick={onClick}
+      onMouseEnter={onMouseEnter}
       role="button"
       tabIndex={0}
       onKeyDown={(e) => e.key === "Enter" && onClick?.()}

--- a/packages/pwa/src/components/feed/FeedList.tsx
+++ b/packages/pwa/src/components/feed/FeedList.tsx
@@ -1,15 +1,20 @@
-import { useRef, useState } from "react";
+import { useRef } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { FeedItem } from "./FeedItem";
 import type { FeedItem as FeedItemType } from "@freed/shared";
 import { useAppStore } from "../../lib/store";
-import { AddFeedDialog } from "../AddFeedDialog";
 
 interface FeedListProps {
   items: FeedItemType[];
   onItemClick?: (item: FeedItemType) => void;
   focusedIndex?: number;
   onFocusChange?: (index: number) => void;
+  /** Called when user clicks "Add Feed" from the empty state */
+  onAddFeed?: () => void;
+  /** Whether any feeds are subscribed — controls empty state message */
+  hasFeedsSubscribed?: boolean;
+  /** Called when user bookmarks/unbookmarks an item */
+  onItemSave?: (item: FeedItemType) => void;
 }
 
 export function FeedList({
@@ -17,15 +22,15 @@ export function FeedList({
   onItemClick,
   focusedIndex = -1,
   onFocusChange,
+  onAddFeed,
+  hasFeedsSubscribed = false,
+  onItemSave,
 }: FeedListProps) {
   const parentRef = useRef<HTMLDivElement>(null);
   const compactMode = useAppStore((s) => s.preferences.display.compactMode);
   const showEngagementCounts = useAppStore(
     (s) => s.preferences.display.showEngagementCounts,
   );
-  const feeds = useAppStore((s) => s.feeds);
-  const hasFeedsSubscribed = Object.keys(feeds).length > 0;
-  const [addFeedOpen, setAddFeedOpen] = useState(false);
 
   const virtualizer = useVirtualizer({
     count: items.length,
@@ -37,24 +42,24 @@ export function FeedList({
 
   if (items.length === 0) {
     return (
-      <>
-        <div className="flex flex-col items-center justify-center h-full min-h-64 text-center px-6 py-12">
-          <div className="w-16 h-16 rounded-full bg-gradient-to-br from-[#3b82f6]/20 to-[#8b5cf6]/20 flex items-center justify-center mb-4">
-            <span className="text-2xl">📡</span>
-          </div>
-          {hasFeedsSubscribed ? (
-            <>
-              <p className="text-lg font-medium mb-2">All caught up!</p>
-              <p className="text-sm text-[#71717a]">No new items to show.</p>
-            </>
-          ) : (
-            <>
-              <p className="text-lg font-medium mb-2">Welcome to Freed</p>
-              <p className="text-sm text-[#71717a] mb-6 max-w-xs">
-                Add RSS feeds or connect the desktop app to start reading.
-              </p>
+      <div className="flex flex-col items-center justify-center h-full min-h-64 text-center px-6 py-12">
+        <div className="w-16 h-16 rounded-full bg-gradient-to-br from-[#3b82f6]/20 to-[#8b5cf6]/20 flex items-center justify-center mb-4">
+          <span className="text-2xl">📡</span>
+        </div>
+        {hasFeedsSubscribed ? (
+          <>
+            <p className="text-lg font-medium mb-2">All caught up!</p>
+            <p className="text-sm text-[#71717a]">No new items to show.</p>
+          </>
+        ) : (
+          <>
+            <p className="text-lg font-medium mb-2">Welcome to Freed</p>
+            <p className="text-sm text-[#71717a] mb-6 max-w-xs">
+              Add RSS feeds or connect the desktop app to start reading.
+            </p>
+            {onAddFeed && (
               <button
-                onClick={() => setAddFeedOpen(true)}
+                onClick={onAddFeed}
                 className="flex items-center gap-2 px-5 py-2.5 rounded-xl bg-[#8b5cf6]/20 text-[#8b5cf6] hover:bg-[#8b5cf6]/30 transition-colors font-medium text-sm"
               >
                 <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -62,11 +67,10 @@ export function FeedList({
                 </svg>
                 Add your first feed
               </button>
-            </>
-          )}
-        </div>
-        <AddFeedDialog open={addFeedOpen} onClose={() => setAddFeedOpen(false)} />
-      </>
+            )}
+          </>
+        )}
+      </div>
     );
   }
 
@@ -97,6 +101,7 @@ export function FeedList({
               showEngagement={showEngagementCounts}
               focused={virtualItem.index === focusedIndex}
               onMouseEnter={() => onFocusChange?.(virtualItem.index)}
+              onSave={onItemSave ? (e) => { e.stopPropagation(); onItemSave(items[virtualItem.index]); } : undefined}
             />
           </div>
         ))}

--- a/packages/pwa/src/components/feed/FeedList.tsx
+++ b/packages/pwa/src/components/feed/FeedList.tsx
@@ -2,6 +2,7 @@ import { useRef } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { FeedItem } from "./FeedItem";
 import type { FeedItem as FeedItemType } from "@freed/shared";
+import { useAppStore } from "../../lib/store";
 
 interface FeedListProps {
   items: FeedItemType[];
@@ -10,6 +11,10 @@ interface FeedListProps {
 
 export function FeedList({ items, onItemClick }: FeedListProps) {
   const parentRef = useRef<HTMLDivElement>(null);
+  const compactMode = useAppStore((s) => s.preferences.display.compactMode);
+  const showEngagementCounts = useAppStore(
+    (s) => s.preferences.display.showEngagementCounts,
+  );
 
   const virtualizer = useVirtualizer({
     count: items.length,
@@ -53,6 +58,8 @@ export function FeedList({ items, onItemClick }: FeedListProps) {
             <FeedItem
               item={items[virtualItem.index]}
               onClick={() => onItemClick?.(items[virtualItem.index])}
+              compact={compactMode}
+              showEngagement={showEngagementCounts}
             />
           </div>
         ))}

--- a/packages/pwa/src/components/feed/FeedList.tsx
+++ b/packages/pwa/src/components/feed/FeedList.tsx
@@ -7,9 +7,16 @@ import { useAppStore } from "../../lib/store";
 interface FeedListProps {
   items: FeedItemType[];
   onItemClick?: (item: FeedItemType) => void;
+  focusedIndex?: number;
+  onFocusChange?: (index: number) => void;
 }
 
-export function FeedList({ items, onItemClick }: FeedListProps) {
+export function FeedList({
+  items,
+  onItemClick,
+  focusedIndex = -1,
+  onFocusChange,
+}: FeedListProps) {
   const parentRef = useRef<HTMLDivElement>(null);
   const compactMode = useAppStore((s) => s.preferences.display.compactMode);
   const showEngagementCounts = useAppStore(
@@ -60,6 +67,8 @@ export function FeedList({ items, onItemClick }: FeedListProps) {
               onClick={() => onItemClick?.(items[virtualItem.index])}
               compact={compactMode}
               showEngagement={showEngagementCounts}
+              focused={virtualItem.index === focusedIndex}
+              onMouseEnter={() => onFocusChange?.(virtualItem.index)}
             />
           </div>
         ))}

--- a/packages/pwa/src/components/feed/FeedList.tsx
+++ b/packages/pwa/src/components/feed/FeedList.tsx
@@ -1,3 +1,5 @@
+import { useRef } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import { FeedItem } from "./FeedItem";
 import type { FeedItem as FeedItemType } from "@freed/shared";
 
@@ -7,6 +9,16 @@ interface FeedListProps {
 }
 
 export function FeedList({ items, onItemClick }: FeedListProps) {
+  const parentRef = useRef<HTMLDivElement>(null);
+
+  const virtualizer = useVirtualizer({
+    count: items.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => 220,
+    overscan: 5,
+    measureElement: (el) => el.getBoundingClientRect().height,
+  });
+
   if (items.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center h-64 text-center px-4">
@@ -14,22 +26,37 @@ export function FeedList({ items, onItemClick }: FeedListProps) {
           <span className="text-2xl">📡</span>
         </div>
         <p className="text-lg font-medium mb-2">No items yet</p>
-        {/* <p className="text-sm text-[#71717a] max-w-xs">
-          Add an RSS feed or connect your X account to start capturing content
-        </p> */}
       </div>
     );
   }
 
   return (
-    <div className="space-y-3 sm:space-y-4 max-w-2xl mx-auto">
-      {items.map((item) => (
-        <FeedItem
-          key={item.globalId}
-          item={item}
-          onClick={() => onItemClick?.(item)}
-        />
-      ))}
+    <div ref={parentRef} className="h-full overflow-auto overscroll-none">
+      <div
+        style={{ height: virtualizer.getTotalSize() }}
+        className="relative w-full"
+      >
+        {virtualizer.getVirtualItems().map((virtualItem) => (
+          <div
+            key={virtualItem.key}
+            data-index={virtualItem.index}
+            ref={virtualizer.measureElement}
+            style={{
+              position: "absolute",
+              top: 0,
+              left: 0,
+              width: "100%",
+              transform: `translateY(${virtualItem.start}px)`,
+            }}
+            className="px-3 sm:px-4 pb-3 sm:pb-4 max-w-2xl mx-auto"
+          >
+            <FeedItem
+              item={items[virtualItem.index]}
+              onClick={() => onItemClick?.(items[virtualItem.index])}
+            />
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/packages/pwa/src/components/feed/FeedList.tsx
+++ b/packages/pwa/src/components/feed/FeedList.tsx
@@ -1,8 +1,9 @@
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { FeedItem } from "./FeedItem";
 import type { FeedItem as FeedItemType } from "@freed/shared";
 import { useAppStore } from "../../lib/store";
+import { AddFeedDialog } from "../AddFeedDialog";
 
 interface FeedListProps {
   items: FeedItemType[];
@@ -22,6 +23,9 @@ export function FeedList({
   const showEngagementCounts = useAppStore(
     (s) => s.preferences.display.showEngagementCounts,
   );
+  const feeds = useAppStore((s) => s.feeds);
+  const hasFeedsSubscribed = Object.keys(feeds).length > 0;
+  const [addFeedOpen, setAddFeedOpen] = useState(false);
 
   const virtualizer = useVirtualizer({
     count: items.length,
@@ -33,12 +37,36 @@ export function FeedList({
 
   if (items.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center h-64 text-center px-4">
-        <div className="w-16 h-16 rounded-full bg-gradient-to-br from-[#3b82f6]/20 to-[#8b5cf6]/20 flex items-center justify-center mb-4">
-          <span className="text-2xl">📡</span>
+      <>
+        <div className="flex flex-col items-center justify-center h-full min-h-64 text-center px-6 py-12">
+          <div className="w-16 h-16 rounded-full bg-gradient-to-br from-[#3b82f6]/20 to-[#8b5cf6]/20 flex items-center justify-center mb-4">
+            <span className="text-2xl">📡</span>
+          </div>
+          {hasFeedsSubscribed ? (
+            <>
+              <p className="text-lg font-medium mb-2">All caught up!</p>
+              <p className="text-sm text-[#71717a]">No new items to show.</p>
+            </>
+          ) : (
+            <>
+              <p className="text-lg font-medium mb-2">Welcome to Freed</p>
+              <p className="text-sm text-[#71717a] mb-6 max-w-xs">
+                Add RSS feeds or connect the desktop app to start reading.
+              </p>
+              <button
+                onClick={() => setAddFeedOpen(true)}
+                className="flex items-center gap-2 px-5 py-2.5 rounded-xl bg-[#8b5cf6]/20 text-[#8b5cf6] hover:bg-[#8b5cf6]/30 transition-colors font-medium text-sm"
+              >
+                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+                </svg>
+                Add your first feed
+              </button>
+            </>
+          )}
         </div>
-        <p className="text-lg font-medium mb-2">No items yet</p>
-      </div>
+        <AddFeedDialog open={addFeedOpen} onClose={() => setAddFeedOpen(false)} />
+      </>
     );
   }
 

--- a/packages/pwa/src/components/feed/FeedView.tsx
+++ b/packages/pwa/src/components/feed/FeedView.tsx
@@ -11,6 +11,7 @@ export function FeedView() {
   const feeds = useAppStore((s) => s.feeds);
   const activeFilter = useAppStore((s) => s.activeFilter);
   const markAsRead = useAppStore((s) => s.markAsRead);
+  const toggleSaved = useAppStore((s) => s.toggleSaved);
   const [addFeedOpen, setAddFeedOpen] = useState(false);
 
   const filteredItems = useMemo(() => {
@@ -84,6 +85,7 @@ export function FeedView() {
         onFocusChange={setFocusedIndex}
         onAddFeed={() => setAddFeedOpen(true)}
         hasFeedsSubscribed={Object.keys(feeds).length > 0}
+        onItemSave={(item) => toggleSaved(item.globalId)}
       />
 
       {selectedItem && (

--- a/packages/pwa/src/components/feed/FeedView.tsx
+++ b/packages/pwa/src/components/feed/FeedView.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect, useCallback } from "react";
 import { FeedList } from "./FeedList";
 import { ReaderView } from "./ReaderView";
 import { useAppStore } from "../../lib/store";
@@ -8,6 +8,7 @@ import type { FeedItem } from "@freed/shared";
 export function FeedView() {
   const items = useAppStore((s) => s.items);
   const activeFilter = useAppStore((s) => s.activeFilter);
+  const markAsRead = useAppStore((s) => s.markAsRead);
 
   const filteredItems = useMemo(() => {
     const filtered = filterFeedItems(items, activeFilter);
@@ -15,16 +16,69 @@ export function FeedView() {
   }, [items, activeFilter]);
 
   const [selectedItem, setSelectedItem] = useState<FeedItem | null>(null);
+  const [focusedIndex, setFocusedIndex] = useState<number>(-1);
+
+  const openItem = useCallback(
+    (item: FeedItem) => {
+      setSelectedItem(item);
+      markAsRead(item.globalId);
+    },
+    [markAsRead],
+  );
+
+  const closeItem = useCallback(() => {
+    setSelectedItem(null);
+  }, []);
+
+  // Keyboard navigation: j/k to move, Enter/o to open, Escape to close
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      // Don't intercept inside inputs or textareas
+      if (
+        e.target instanceof HTMLInputElement ||
+        e.target instanceof HTMLTextAreaElement
+      )
+        return;
+
+      if (selectedItem) {
+        if (e.key === "Escape") closeItem();
+        return;
+      }
+
+      if (e.key === "j" || e.key === "ArrowDown") {
+        e.preventDefault();
+        setFocusedIndex((prev) =>
+          Math.min(prev + 1, filteredItems.length - 1),
+        );
+      } else if (e.key === "k" || e.key === "ArrowUp") {
+        e.preventDefault();
+        setFocusedIndex((prev) => Math.max(prev - 1, 0));
+      } else if ((e.key === "Enter" || e.key === "o") && focusedIndex >= 0) {
+        const item = filteredItems[focusedIndex];
+        if (item) openItem(item);
+      }
+    };
+
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [selectedItem, filteredItems, focusedIndex, openItem, closeItem]);
+
+  // Reset focus when filter changes
+  useEffect(() => {
+    setFocusedIndex(-1);
+  }, [activeFilter]);
 
   return (
     <>
       <FeedList
         items={filteredItems}
-        onItemClick={(item) => setSelectedItem(item)}
+        onItemClick={openItem}
+        focusedIndex={focusedIndex}
+        onFocusChange={setFocusedIndex}
       />
 
       {selectedItem && (
-        <ReaderView item={selectedItem} onClose={() => setSelectedItem(null)} />
+        <ReaderView item={selectedItem} onClose={closeItem} />
       )}
     </>
   );

--- a/packages/pwa/src/components/feed/FeedView.tsx
+++ b/packages/pwa/src/components/feed/FeedView.tsx
@@ -1,18 +1,14 @@
-import { useState, useMemo, useCallback } from "react";
+import { useState, useMemo } from "react";
 import { FeedList } from "./FeedList";
 import { ReaderView } from "./ReaderView";
-import { PullToRefresh } from "../PullToRefresh";
 import { useAppStore } from "../../lib/store";
-import { toast } from "../Toast";
 import { sortByPriority, filterFeedItems } from "@freed/shared";
 import type { FeedItem } from "@freed/shared";
 
 export function FeedView() {
-  // Select raw state (stable references)
   const items = useAppStore((s) => s.items);
   const activeFilter = useAppStore((s) => s.activeFilter);
 
-  // Memoize filtering/sorting to avoid infinite loops
   const filteredItems = useMemo(() => {
     const filtered = filterFeedItems(items, activeFilter);
     return sortByPriority(filtered);
@@ -20,28 +16,15 @@ export function FeedView() {
 
   const [selectedItem, setSelectedItem] = useState<FeedItem | null>(null);
 
-  const handleItemClick = (item: FeedItem) => {
-    setSelectedItem(item);
-  };
-
-  const handleCloseReader = () => {
-    setSelectedItem(null);
-  };
-
-  const handleRefresh = useCallback(() => {
-    toast.info("Open the desktop app to refresh feeds");
-  }, []);
-
   return (
     <>
-      <PullToRefresh onRefresh={handleRefresh}>
-        <div className="p-3 sm:p-4 pb-20 sm:pb-4">
-          <FeedList items={filteredItems} onItemClick={handleItemClick} />
-        </div>
-      </PullToRefresh>
+      <FeedList
+        items={filteredItems}
+        onItemClick={(item) => setSelectedItem(item)}
+      />
 
       {selectedItem && (
-        <ReaderView item={selectedItem} onClose={handleCloseReader} />
+        <ReaderView item={selectedItem} onClose={() => setSelectedItem(null)} />
       )}
     </>
   );

--- a/packages/pwa/src/components/feed/FeedView.tsx
+++ b/packages/pwa/src/components/feed/FeedView.tsx
@@ -12,7 +12,11 @@ export function FeedView() {
 
   const filteredItems = useMemo(() => {
     const filtered = filterFeedItems(items, activeFilter);
-    return sortByPriority(filtered);
+    // Apply feedUrl filter (not handled by shared filterFeedItems)
+    const byFeed = activeFilter.feedUrl
+      ? filtered.filter((item) => item.rssSource?.feedUrl === activeFilter.feedUrl)
+      : filtered;
+    return sortByPriority(byFeed);
   }, [items, activeFilter]);
 
   const [selectedItem, setSelectedItem] = useState<FeedItem | null>(null);

--- a/packages/pwa/src/components/feed/FeedView.tsx
+++ b/packages/pwa/src/components/feed/FeedView.tsx
@@ -1,14 +1,17 @@
 import { useState, useMemo, useEffect, useCallback } from "react";
 import { FeedList } from "./FeedList";
 import { ReaderView } from "./ReaderView";
+import { AddFeedDialog } from "../AddFeedDialog";
 import { useAppStore } from "../../lib/store";
 import { sortByPriority, filterFeedItems } from "@freed/shared";
 import type { FeedItem } from "@freed/shared";
 
 export function FeedView() {
   const items = useAppStore((s) => s.items);
+  const feeds = useAppStore((s) => s.feeds);
   const activeFilter = useAppStore((s) => s.activeFilter);
   const markAsRead = useAppStore((s) => s.markAsRead);
+  const [addFeedOpen, setAddFeedOpen] = useState(false);
 
   const filteredItems = useMemo(() => {
     const filtered = filterFeedItems(items, activeFilter);
@@ -79,11 +82,15 @@ export function FeedView() {
         onItemClick={openItem}
         focusedIndex={focusedIndex}
         onFocusChange={setFocusedIndex}
+        onAddFeed={() => setAddFeedOpen(true)}
+        hasFeedsSubscribed={Object.keys(feeds).length > 0}
       />
 
       {selectedItem && (
         <ReaderView item={selectedItem} onClose={closeItem} />
       )}
+
+      <AddFeedDialog open={addFeedOpen} onClose={() => setAddFeedOpen(false)} />
     </>
   );
 }

--- a/packages/pwa/src/components/feed/ReaderView.tsx
+++ b/packages/pwa/src/components/feed/ReaderView.tsx
@@ -18,9 +18,11 @@ function htmlToText(html: string): string {
 
 export function ReaderView({ item, onClose }: ReaderViewProps) {
   const updateItem = useAppStore((s) => s.updateItem);
+  const updatePreferences = useAppStore((s) => s.updatePreferences);
+  const storedDisplay = useAppStore((s) => s.preferences.display);
   const [focusOptions, setFocusOptions] = useState<FocusOptions>({
-    enabled: false,
-    intensity: "normal",
+    enabled: storedDisplay.reading.focusMode,
+    intensity: storedDisplay.reading.focusIntensity,
   });
 
   const toggleSaved = () => {
@@ -43,7 +45,17 @@ export function ReaderView({ item, onClose }: ReaderViewProps) {
   };
 
   const toggleFocus = () => {
-    setFocusOptions((prev) => ({ ...prev, enabled: !prev.enabled }));
+    setFocusOptions((prev) => {
+      const next = { ...prev, enabled: !prev.enabled };
+      // Persist the toggle back to preferences
+      updatePreferences({
+        display: {
+          ...storedDisplay,
+          reading: { focusMode: next.enabled, focusIntensity: next.intensity },
+        },
+      });
+      return next;
+    });
   };
 
   const hasContent = item.preservedContent?.html;

--- a/packages/pwa/src/components/layout/Sidebar.tsx
+++ b/packages/pwa/src/components/layout/Sidebar.tsx
@@ -5,6 +5,7 @@ import {
   clearStoredRelayUrl,
 } from "../../lib/sync";
 import { SyncConnectDialog } from "../SyncConnectDialog";
+import { SettingsPanel } from "../SettingsPanel";
 
 interface SidebarProps {
   open: boolean;
@@ -23,6 +24,7 @@ export function Sidebar({ open, onClose }: SidebarProps) {
   const setFilter = useAppStore((s) => s.setFilter);
   const syncConnected = useAppStore((s) => s.syncConnected);
   const [showSyncDialog, setShowSyncDialog] = useState(false);
+  const [showSettings, setShowSettings] = useState(false);
 
   const handleSourceClick = (source: (typeof sources)[0]) => {
     if (source.savedOnly) {
@@ -181,12 +183,33 @@ export function Sidebar({ open, onClose }: SidebarProps) {
               </li>
             </ul>
           </div>
+
+          {/* Settings */}
+          <div className="pt-4 border-t border-[rgba(255,255,255,0.08)]">
+            <button
+              onClick={() => setShowSettings(true)}
+              className="w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-left text-sm text-[#a1a1aa] hover:bg-white/5 hover:text-white transition-all"
+            >
+              <span className="w-5 text-center">
+                <svg className="w-4 h-4 inline" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                </svg>
+              </span>
+              <span>Settings</span>
+            </button>
+          </div>
         </nav>
       </aside>
 
       <SyncConnectDialog
         open={showSyncDialog}
         onClose={() => setShowSyncDialog(false)}
+      />
+
+      <SettingsPanel
+        open={showSettings}
+        onClose={() => setShowSettings(false)}
       />
     </>
   );

--- a/packages/pwa/src/components/layout/Sidebar.tsx
+++ b/packages/pwa/src/components/layout/Sidebar.tsx
@@ -1,12 +1,10 @@
 import { useState } from "react";
 import { useAppStore } from "../../lib/store";
 import {
-  connect,
   disconnect,
-  isRelayConnected,
-  storeRelayUrl,
   clearStoredRelayUrl,
 } from "../../lib/sync";
+import { SyncConnectDialog } from "../SyncConnectDialog";
 
 interface SidebarProps {
   open: boolean;
@@ -43,15 +41,7 @@ export function Sidebar({ open, onClose }: SidebarProps) {
   };
 
   const handleConnectSync = () => {
-    const url = window.prompt(
-      "Enter your desktop's sync URL:\n\n" +
-        "Find this in the desktop app under Settings > Sync.\n" +
-        "It looks like: ws://192.168.1.x:8765",
-    );
-    if (url) {
-      storeRelayUrl(url);
-      connect(url);
-    }
+    setShowSyncDialog(true);
   };
 
   const handleDisconnectSync = () => {
@@ -193,6 +183,11 @@ export function Sidebar({ open, onClose }: SidebarProps) {
           </div>
         </nav>
       </aside>
+
+      <SyncConnectDialog
+        open={showSyncDialog}
+        onClose={() => setShowSyncDialog(false)}
+      />
     </>
   );
 }

--- a/packages/pwa/src/lib/automerge.ts
+++ b/packages/pwa/src/lib/automerge.ts
@@ -151,6 +151,22 @@ export async function docUpdateLastSync(): Promise<FreedDoc> {
 }
 
 /**
+ * Mark all unread items as read in a single Automerge change.
+ * Optionally filter by platform.
+ */
+export async function docMarkAllAsRead(platform?: string): Promise<FreedDoc> {
+  return applyChange((doc) => {
+    const now = Date.now();
+    for (const item of Object.values(doc.feedItems)) {
+      if (item.userState.readAt) continue;
+      if (item.userState.hidden || item.userState.archived) continue;
+      if (platform && item.platform !== platform) continue;
+      item.userState.readAt = now;
+    }
+  }, "Mark all as read");
+}
+
+/**
  * Bulk add feed items (more efficient for initial feed fetch)
  */
 export async function docAddFeedItems(items: FeedItem[]): Promise<FreedDoc> {

--- a/packages/pwa/src/lib/focus-text.ts
+++ b/packages/pwa/src/lib/focus-text.ts
@@ -1,0 +1,71 @@
+/**
+ * Focus Mode — bionic reading enhancement
+ *
+ * Bolds the beginning of each word to create visual fixation points,
+ * allowing faster reading by guiding eye movement through text.
+ */
+
+export type FocusIntensity = "light" | "normal" | "strong";
+
+export interface FocusOptions {
+  enabled: boolean;
+  intensity: FocusIntensity;
+}
+
+export interface TextSegment {
+  text: string;
+  emphasis: boolean;
+}
+
+/**
+ * Number of characters to bold based on word length and intensity.
+ */
+function getEmphasisCount(wordLength: number, intensity: FocusIntensity): number {
+  const ratios: Record<FocusIntensity, number> = {
+    light: 0.25,
+    normal: 0.4,
+    strong: 0.6,
+  };
+  return Math.max(1, Math.ceil(wordLength * ratios[intensity]));
+}
+
+/**
+ * Split text into segments with emphasis markers for focus mode rendering.
+ * Non-alpha words (numbers, punctuation) are returned as-is without emphasis.
+ */
+export function applyFocusMode(
+  text: string,
+  options: FocusOptions,
+): TextSegment[] {
+  if (!options.enabled) {
+    return [{ text, emphasis: false }];
+  }
+
+  const segments: TextSegment[] = [];
+  // Split on whitespace, preserving the whitespace tokens
+  const tokens = text.split(/(\s+)/);
+
+  for (const token of tokens) {
+    if (/^\s+$/.test(token)) {
+      // Whitespace — pass through
+      segments.push({ text: token, emphasis: false });
+    } else if (/^[a-zA-ZÀ-ÿ]+$/.test(token)) {
+      // Pure alphabetic word — apply emphasis to beginning
+      const count = getEmphasisCount(token.length, options.intensity);
+      segments.push({ text: token.slice(0, count), emphasis: true });
+      if (token.length > count) {
+        segments.push({ text: token.slice(count), emphasis: false });
+      }
+    } else {
+      // Mixed/punctuation/numbers — no emphasis
+      segments.push({ text: token, emphasis: false });
+    }
+  }
+
+  return segments;
+}
+
+export const DEFAULT_FOCUS_OPTIONS: FocusOptions = {
+  enabled: false,
+  intensity: "normal",
+};

--- a/packages/pwa/src/lib/ranking.test.ts
+++ b/packages/pwa/src/lib/ranking.test.ts
@@ -1,0 +1,299 @@
+/**
+ * Unit tests for the shared ranking and filtering algorithms
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  calculatePriority,
+  rankFeedItems,
+  filterFeedItems,
+  sortByPriority,
+} from "@freed/shared";
+import type { FeedItem, WeightPreferences } from "@freed/shared";
+
+// =============================================================================
+// Test fixtures
+// =============================================================================
+
+const baseWeights: WeightPreferences = {
+  recency: 50,
+  platforms: {},
+  authors: {},
+  topics: {},
+};
+
+function makeItem(overrides: Partial<FeedItem> & { globalId: string }): FeedItem {
+  return {
+    platform: "rss",
+    contentType: "article",
+    capturedAt: Date.now(),
+    publishedAt: Date.now(),
+    author: {
+      id: "author-1",
+      handle: "author1",
+      displayName: "Author One",
+    },
+    content: { text: "Hello world", mediaUrls: [], mediaTypes: [] },
+    userState: { hidden: false, saved: false, archived: false, tags: [] },
+    topics: [],
+    ...overrides,
+  };
+}
+
+const NOW = Date.now();
+
+// =============================================================================
+// calculatePriority
+// =============================================================================
+
+describe("calculatePriority", () => {
+  it("gives higher score to recent items", () => {
+    const fresh = makeItem({ globalId: "fresh", publishedAt: NOW - 1000 * 60 }); // 1 min ago
+    const old = makeItem({ globalId: "old", publishedAt: NOW - 1000 * 60 * 60 * 100 }); // 100 hours ago
+
+    const freshScore = calculatePriority(fresh, baseWeights, NOW);
+    const oldScore = calculatePriority(old, baseWeights, NOW);
+
+    expect(freshScore).toBeGreaterThan(oldScore);
+  });
+
+  it("returns a score between 0 and 100", () => {
+    const item = makeItem({ globalId: "test", publishedAt: NOW });
+    const score = calculatePriority(item, baseWeights, NOW);
+    expect(score).toBeGreaterThanOrEqual(0);
+    expect(score).toBeLessThanOrEqual(100);
+  });
+
+  it("boosts saved items", () => {
+    const unsaved = makeItem({ globalId: "unsaved", publishedAt: NOW - 1000 * 60 * 60 * 24 });
+    const saved = makeItem({
+      globalId: "saved",
+      publishedAt: NOW - 1000 * 60 * 60 * 24,
+      userState: { hidden: false, saved: true, archived: false, tags: [] },
+    });
+
+    const savedScore = calculatePriority(saved, baseWeights, NOW);
+    const unsavedScore = calculatePriority(unsaved, baseWeights, NOW);
+
+    expect(savedScore).toBeGreaterThan(unsavedScore);
+  });
+
+  it("applies author weight boost", () => {
+    const weights: WeightPreferences = {
+      ...baseWeights,
+      authors: { "author-1": 100 }, // max boost for author-1
+    };
+    const itemFav = makeItem({ globalId: "fav", publishedAt: NOW - 1000 * 60 * 60 * 10 });
+    const itemPlain = makeItem({
+      globalId: "plain",
+      publishedAt: NOW - 1000 * 60 * 60 * 10,
+      author: { id: "author-2", handle: "author2", displayName: "Author Two" },
+    });
+
+    const favScore = calculatePriority(itemFav, weights, NOW);
+    const plainScore = calculatePriority(itemPlain, weights, NOW);
+
+    expect(favScore).toBeGreaterThan(plainScore);
+  });
+
+  it("applies platform weight preference", () => {
+    const weights: WeightPreferences = {
+      ...baseWeights,
+      platforms: { x: 100, rss: 10 },
+    };
+    const xItem = makeItem({
+      globalId: "x-item",
+      platform: "x",
+      publishedAt: NOW - 1000 * 60 * 60,
+    });
+    const rssItem = makeItem({
+      globalId: "rss-item",
+      platform: "rss",
+      publishedAt: NOW - 1000 * 60 * 60,
+    });
+
+    const xScore = calculatePriority(xItem, weights, NOW);
+    const rssScore = calculatePriority(rssItem, weights, NOW);
+
+    expect(xScore).toBeGreaterThan(rssScore);
+  });
+
+  it("uses engagement signal when present", () => {
+    const viral = makeItem({
+      globalId: "viral",
+      publishedAt: NOW - 1000 * 60 * 60 * 10,
+      engagement: { likes: 10000, reposts: 5000, comments: 2000 },
+    });
+    const quiet = makeItem({
+      globalId: "quiet",
+      publishedAt: NOW - 1000 * 60 * 60 * 10,
+    });
+
+    const viralScore = calculatePriority(viral, baseWeights, NOW);
+    const quietScore = calculatePriority(quiet, baseWeights, NOW);
+
+    expect(viralScore).toBeGreaterThan(quietScore);
+  });
+
+  it("returns same score for items with same attributes", () => {
+    const a = makeItem({ globalId: "a", publishedAt: NOW - 5000 });
+    const b = makeItem({ globalId: "b", publishedAt: NOW - 5000 });
+
+    expect(calculatePriority(a, baseWeights, NOW)).toBe(
+      calculatePriority(b, baseWeights, NOW)
+    );
+  });
+});
+
+// =============================================================================
+// rankFeedItems
+// =============================================================================
+
+describe("rankFeedItems", () => {
+  it("assigns a priority to every item", () => {
+    const items = [
+      makeItem({ globalId: "a", publishedAt: NOW - 1000 }),
+      makeItem({ globalId: "b", publishedAt: NOW - 5000 }),
+      makeItem({ globalId: "c", publishedAt: NOW - 100000 }),
+    ];
+
+    const ranked = rankFeedItems(items, baseWeights);
+
+    expect(ranked).toHaveLength(3);
+    for (const item of ranked) {
+      expect(item.priority).toBeDefined();
+      expect(typeof item.priority).toBe("number");
+    }
+  });
+
+  it("does not mutate the original items", () => {
+    const items = [
+      makeItem({ globalId: "a", publishedAt: NOW }),
+    ];
+    const original = items[0];
+
+    rankFeedItems(items, baseWeights);
+
+    expect(items[0]).toBe(original); // same reference
+    expect(original.priority).toBeUndefined(); // not mutated
+  });
+
+  it("sets priorityComputedAt on each item", () => {
+    const items = [makeItem({ globalId: "a", publishedAt: NOW })];
+    const ranked = rankFeedItems(items, baseWeights);
+
+    expect(ranked[0].priorityComputedAt).toBeDefined();
+  });
+});
+
+// =============================================================================
+// sortByPriority
+// =============================================================================
+
+describe("sortByPriority", () => {
+  it("sorts items highest priority first", () => {
+    const items: FeedItem[] = [
+      { ...makeItem({ globalId: "low" }), priority: 10 },
+      { ...makeItem({ globalId: "high" }), priority: 90 },
+      { ...makeItem({ globalId: "mid" }), priority: 50 },
+    ];
+
+    const sorted = sortByPriority(items);
+
+    expect(sorted[0].globalId).toBe("high");
+    expect(sorted[1].globalId).toBe("mid");
+    expect(sorted[2].globalId).toBe("low");
+  });
+
+  it("treats undefined priority as 0", () => {
+    const items: FeedItem[] = [
+      { ...makeItem({ globalId: "noprio" }) }, // no priority
+      { ...makeItem({ globalId: "highprio" }), priority: 80 },
+    ];
+
+    const sorted = sortByPriority(items);
+    expect(sorted[0].globalId).toBe("highprio");
+  });
+
+  it("does not mutate the original array", () => {
+    const items: FeedItem[] = [
+      { ...makeItem({ globalId: "b" }), priority: 10 },
+      { ...makeItem({ globalId: "a" }), priority: 90 },
+    ];
+    const originalFirst = items[0].globalId;
+
+    sortByPriority(items);
+
+    expect(items[0].globalId).toBe(originalFirst);
+  });
+});
+
+// =============================================================================
+// filterFeedItems
+// =============================================================================
+
+describe("filterFeedItems", () => {
+  const items: FeedItem[] = [
+    makeItem({ globalId: "visible-rss", platform: "rss", userState: { hidden: false, saved: false, archived: false, tags: ["tech"] } }),
+    makeItem({ globalId: "visible-x", platform: "x", userState: { hidden: false, saved: true, archived: false, tags: [] } }),
+    makeItem({ globalId: "hidden", platform: "rss", userState: { hidden: true, saved: false, archived: false, tags: [] } }),
+    makeItem({ globalId: "archived", platform: "rss", userState: { hidden: false, saved: false, archived: true, tags: [] } }),
+  ];
+
+  it("filters out hidden items by default", () => {
+    const result = filterFeedItems(items);
+    expect(result.find((i) => i.globalId === "hidden")).toBeUndefined();
+  });
+
+  it("includes hidden items when showHidden is true", () => {
+    const result = filterFeedItems(items, { showHidden: true });
+    expect(result.find((i) => i.globalId === "hidden")).toBeDefined();
+  });
+
+  it("filters out archived items by default", () => {
+    const result = filterFeedItems(items);
+    expect(result.find((i) => i.globalId === "archived")).toBeUndefined();
+  });
+
+  it("includes archived items when showArchived is true", () => {
+    const result = filterFeedItems(items, { showArchived: true });
+    expect(result.find((i) => i.globalId === "archived")).toBeDefined();
+  });
+
+  it("filters by platform", () => {
+    const result = filterFeedItems(items, { platform: "x" });
+    expect(result.every((i) => i.platform === "x")).toBe(true);
+    expect(result).toHaveLength(1);
+  });
+
+  it("filters to saved only", () => {
+    const result = filterFeedItems(items, { savedOnly: true });
+    expect(result.every((i) => i.userState.saved)).toBe(true);
+    expect(result).toHaveLength(1);
+    expect(result[0].globalId).toBe("visible-x");
+  });
+
+  it("filters by tag (any match)", () => {
+    const result = filterFeedItems(items, { tags: ["tech"] });
+    expect(result).toHaveLength(1);
+    expect(result[0].globalId).toBe("visible-rss");
+  });
+
+  it("returns all visible items when no filters specified", () => {
+    const result = filterFeedItems(items);
+    expect(result).toHaveLength(2); // hidden and archived excluded
+    expect(result.map((i) => i.globalId)).toContain("visible-rss");
+    expect(result.map((i) => i.globalId)).toContain("visible-x");
+  });
+
+  it("returns empty array when no items match", () => {
+    const result = filterFeedItems(items, { platform: "youtube" });
+    expect(result).toHaveLength(0);
+  });
+
+  it("combines filters (platform + savedOnly)", () => {
+    const result = filterFeedItems(items, { platform: "x", savedOnly: true });
+    expect(result).toHaveLength(1);
+    expect(result[0].globalId).toBe("visible-x");
+  });
+});

--- a/packages/pwa/src/lib/schema.test.ts
+++ b/packages/pwa/src/lib/schema.test.ts
@@ -1,0 +1,381 @@
+/**
+ * Unit tests for the Automerge document schema operations
+ *
+ * Tests the core CRDT operations: create, add, update, merge.
+ * These operations underpin the entire sync pipeline.
+ */
+
+import { describe, it, expect } from "vitest";
+import * as A from "@automerge/automerge";
+import {
+  createEmptyDoc,
+  addFeedItem,
+  removeFeedItem,
+  markAsRead,
+  toggleSaved,
+  hideItem,
+  addRssFeed,
+  removeRssFeed,
+  updatePreferences,
+} from "@freed/shared/schema";
+import type { FreedDoc } from "@freed/shared/schema";
+import type { FeedItem, RssFeed } from "@freed/shared";
+
+// =============================================================================
+// Test fixtures
+// =============================================================================
+
+function makeItem(overrides: Partial<FeedItem> & { globalId: string }): FeedItem {
+  return {
+    platform: "rss",
+    contentType: "article",
+    capturedAt: Date.now(),
+    publishedAt: Date.now() - 3600000,
+    author: { id: "auth-1", handle: "auth1", displayName: "Auth One" },
+    content: { text: "Test content", mediaUrls: [], mediaTypes: [] },
+    userState: { hidden: false, saved: false, archived: false, tags: [] },
+    topics: [],
+    ...overrides,
+  };
+}
+
+function makeFeed(overrides: Partial<RssFeed> & { url: string; title: string }): RssFeed {
+  return {
+    enabled: true,
+    trackUnread: false,
+    ...overrides,
+  };
+}
+
+// =============================================================================
+// createEmptyDoc
+// =============================================================================
+
+describe("createEmptyDoc", () => {
+  it("creates a valid Automerge document", () => {
+    const doc = createEmptyDoc();
+    expect(doc).toBeDefined();
+    expect(doc.feedItems).toBeDefined();
+    expect(doc.rssFeeds).toBeDefined();
+    expect(doc.preferences).toBeDefined();
+  });
+
+  it("starts with empty feed items and feeds", () => {
+    const doc = createEmptyDoc();
+    expect(Object.keys(doc.feedItems)).toHaveLength(0);
+    expect(Object.keys(doc.rssFeeds)).toHaveLength(0);
+  });
+
+  it("has default preferences with ranking weights", () => {
+    const doc = createEmptyDoc();
+    expect(doc.preferences.weights).toBeDefined();
+    expect(typeof doc.preferences.weights.recency).toBe("number");
+  });
+
+  it("is a real Automerge document (can be saved and loaded)", () => {
+    const doc = createEmptyDoc();
+    const binary = A.save(doc);
+    expect(binary).toBeInstanceOf(Uint8Array);
+    expect(binary.length).toBeGreaterThan(0);
+
+    const loaded = A.load<FreedDoc>(binary);
+    expect(Object.keys(loaded.feedItems)).toHaveLength(0);
+  });
+});
+
+// =============================================================================
+// addFeedItem / removeFeedItem
+// =============================================================================
+
+describe("addFeedItem", () => {
+  it("adds an item to the document", () => {
+    let doc = createEmptyDoc();
+    const item = makeItem({ globalId: "rss:https://example.com/1" });
+
+    doc = A.change(doc, (d) => addFeedItem(d, item));
+
+    expect(doc.feedItems["rss:https://example.com/1"]).toBeDefined();
+    expect(doc.feedItems["rss:https://example.com/1"].content.text).toBe("Test content");
+  });
+
+  it("adds multiple items independently", () => {
+    let doc = createEmptyDoc();
+
+    doc = A.change(doc, (d) => {
+      addFeedItem(d, makeItem({ globalId: "item-1" }));
+      addFeedItem(d, makeItem({ globalId: "item-2" }));
+      addFeedItem(d, makeItem({ globalId: "item-3" }));
+    });
+
+    expect(Object.keys(doc.feedItems)).toHaveLength(3);
+  });
+
+  it("overwrites an existing item with the same globalId", () => {
+    let doc = createEmptyDoc();
+    const item = makeItem({ globalId: "item-1" });
+    const updated = { ...item, content: { ...item.content, text: "Updated text" } };
+
+    doc = A.change(doc, (d) => addFeedItem(d, item));
+    doc = A.change(doc, (d) => addFeedItem(d, updated));
+
+    expect(doc.feedItems["item-1"].content.text).toBe("Updated text");
+  });
+});
+
+describe("removeFeedItem", () => {
+  it("removes an item from the document", () => {
+    let doc = createEmptyDoc();
+    doc = A.change(doc, (d) => addFeedItem(d, makeItem({ globalId: "item-1" })));
+    doc = A.change(doc, (d) => removeFeedItem(d, "item-1"));
+
+    expect(doc.feedItems["item-1"]).toBeUndefined();
+  });
+
+  it("is a no-op when item does not exist", () => {
+    let doc = createEmptyDoc();
+    // Should not throw
+    expect(() => {
+      doc = A.change(doc, (d) => removeFeedItem(d, "nonexistent"));
+    }).not.toThrow();
+  });
+});
+
+// =============================================================================
+// markAsRead
+// =============================================================================
+
+describe("markAsRead", () => {
+  it("sets readAt on the item", () => {
+    let doc = createEmptyDoc();
+    doc = A.change(doc, (d) => addFeedItem(d, makeItem({ globalId: "item-1" })));
+
+    expect(doc.feedItems["item-1"].userState.readAt).toBeUndefined();
+
+    doc = A.change(doc, (d) => markAsRead(d, "item-1"));
+
+    expect(doc.feedItems["item-1"].userState.readAt).toBeDefined();
+    expect(typeof doc.feedItems["item-1"].userState.readAt).toBe("number");
+  });
+
+  it("is a no-op when item does not exist", () => {
+    let doc = createEmptyDoc();
+    expect(() => {
+      doc = A.change(doc, (d) => markAsRead(d, "nonexistent"));
+    }).not.toThrow();
+  });
+});
+
+// =============================================================================
+// toggleSaved
+// =============================================================================
+
+describe("toggleSaved", () => {
+  it("saves an unsaved item", () => {
+    let doc = createEmptyDoc();
+    doc = A.change(doc, (d) => addFeedItem(d, makeItem({ globalId: "item-1" })));
+    doc = A.change(doc, (d) => toggleSaved(d, "item-1"));
+
+    expect(doc.feedItems["item-1"].userState.saved).toBe(true);
+    expect(doc.feedItems["item-1"].userState.savedAt).toBeDefined();
+  });
+
+  it("unsaves a saved item", () => {
+    let doc = createEmptyDoc();
+    doc = A.change(doc, (d) =>
+      addFeedItem(d, makeItem({
+        globalId: "item-1",
+        userState: { hidden: false, saved: true, archived: false, tags: [] },
+      }))
+    );
+    doc = A.change(doc, (d) => toggleSaved(d, "item-1"));
+
+    expect(doc.feedItems["item-1"].userState.saved).toBe(false);
+    expect(doc.feedItems["item-1"].userState.savedAt).toBeUndefined();
+  });
+
+  it("toggles twice returns to original state", () => {
+    let doc = createEmptyDoc();
+    doc = A.change(doc, (d) => addFeedItem(d, makeItem({ globalId: "item-1" })));
+    doc = A.change(doc, (d) => toggleSaved(d, "item-1"));
+    doc = A.change(doc, (d) => toggleSaved(d, "item-1"));
+
+    expect(doc.feedItems["item-1"].userState.saved).toBe(false);
+  });
+});
+
+// =============================================================================
+// hideItem
+// =============================================================================
+
+describe("hideItem", () => {
+  it("sets hidden to true", () => {
+    let doc = createEmptyDoc();
+    doc = A.change(doc, (d) => addFeedItem(d, makeItem({ globalId: "item-1" })));
+    doc = A.change(doc, (d) => hideItem(d, "item-1"));
+
+    expect(doc.feedItems["item-1"].userState.hidden).toBe(true);
+  });
+});
+
+// =============================================================================
+// addRssFeed / removeRssFeed
+// =============================================================================
+
+describe("addRssFeed", () => {
+  it("adds a feed to the document", () => {
+    let doc = createEmptyDoc();
+    const feed = makeFeed({ url: "https://example.com/feed", title: "Example" });
+    doc = A.change(doc, (d) => addRssFeed(d, feed));
+
+    expect(doc.rssFeeds["https://example.com/feed"]).toBeDefined();
+    expect(doc.rssFeeds["https://example.com/feed"].title).toBe("Example");
+  });
+
+  it("indexes feed by URL", () => {
+    let doc = createEmptyDoc();
+    doc = A.change(doc, (d) => {
+      addRssFeed(d, makeFeed({ url: "https://a.com/feed", title: "A" }));
+      addRssFeed(d, makeFeed({ url: "https://b.com/feed", title: "B" }));
+    });
+
+    expect(Object.keys(doc.rssFeeds)).toHaveLength(2);
+  });
+});
+
+describe("removeRssFeed", () => {
+  it("removes a feed by URL", () => {
+    let doc = createEmptyDoc();
+    const url = "https://example.com/feed";
+    doc = A.change(doc, (d) => addRssFeed(d, makeFeed({ url, title: "Example" })));
+    doc = A.change(doc, (d) => removeRssFeed(d, url));
+
+    expect(doc.rssFeeds[url]).toBeUndefined();
+  });
+});
+
+// =============================================================================
+// updatePreferences
+// =============================================================================
+
+describe("updatePreferences", () => {
+  it("updates ranking weights", () => {
+    let doc = createEmptyDoc();
+    doc = A.change(doc, (d) =>
+      updatePreferences(d, { weights: { ...d.preferences.weights, recency: 80 } })
+    );
+
+    expect(doc.preferences.weights.recency).toBe(80);
+  });
+
+  it("preserves other preference fields when updating weights", () => {
+    let doc = createEmptyDoc();
+    const originalCompactMode = doc.preferences.display.compactMode;
+
+    doc = A.change(doc, (d) =>
+      updatePreferences(d, { weights: { ...d.preferences.weights, recency: 90 } })
+    );
+
+    expect(doc.preferences.display.compactMode).toBe(originalCompactMode);
+  });
+});
+
+// =============================================================================
+// Automerge CRDT merge semantics (simulates desktop→PWA sync)
+// =============================================================================
+
+describe("Automerge merge / sync simulation", () => {
+  it("merges diverged documents from a shared ancestor (desktop→PWA sync)", () => {
+    // Correct sync semantics: PWA starts by receiving the desktop's doc,
+    // then both devices diverge and are merged back together.
+    let desktop = createEmptyDoc();
+    desktop = A.change(desktop, (d) =>
+      addFeedItem(d, makeItem({ globalId: "desktop-item-1" }))
+    );
+
+    // PWA initializes from the desktop's serialized doc (simulates first sync)
+    let pwa = A.load<FreedDoc>(A.save(desktop));
+
+    // Both devices make independent changes
+    desktop = A.change(desktop, (d) =>
+      addFeedItem(d, makeItem({ globalId: "desktop-item-2" }))
+    );
+    pwa = A.change(pwa, (d) =>
+      addFeedItem(d, makeItem({ globalId: "pwa-item-1" }))
+    );
+
+    // Merge: all items from both sides should be present
+    const merged = A.merge(pwa, desktop);
+
+    expect(merged.feedItems["desktop-item-1"]).toBeDefined();
+    expect(merged.feedItems["desktop-item-2"]).toBeDefined();
+    expect(merged.feedItems["pwa-item-1"]).toBeDefined();
+  });
+
+  it("serializes and deserializes without data loss", () => {
+    let doc = createEmptyDoc();
+    doc = A.change(doc, (d) => {
+      addFeedItem(d, makeItem({ globalId: "item-1" }));
+      addFeedItem(d, makeItem({ globalId: "item-2" }));
+      addRssFeed(d, makeFeed({ url: "https://example.com/feed", title: "Example" }));
+    });
+
+    const binary = A.save(doc);
+    const reloaded = A.load<FreedDoc>(binary);
+
+    expect(Object.keys(reloaded.feedItems)).toHaveLength(2);
+    expect(Object.keys(reloaded.rssFeeds)).toHaveLength(1);
+  });
+
+  it("last-write-wins for concurrent userState changes to the same item", () => {
+    // Both devices mark same item as read at different times
+    let docA = createEmptyDoc();
+    docA = A.change(docA, (d) => addFeedItem(d, makeItem({ globalId: "shared-item" })));
+
+    // B branches from A
+    let docB = A.clone(docA);
+
+    // A marks as read at t=1000
+    docA = A.change(docA, (d) => {
+      d.feedItems["shared-item"].userState.readAt = 1000;
+    });
+
+    // B marks as read at t=2000 (later)
+    docB = A.change(docB, (d) => {
+      d.feedItems["shared-item"].userState.readAt = 2000;
+    });
+
+    // Merge A into B — both changes should be present via CRDT
+    const merged = A.merge(docB, docA);
+
+    // Both changes exist; the document should have readAt set
+    expect(merged.feedItems["shared-item"].userState.readAt).toBeDefined();
+  });
+
+  it("supports bulk add (docAddFeedItems pattern) efficiently", () => {
+    let doc = createEmptyDoc();
+    const items = Array.from({ length: 50 }, (_, i) =>
+      makeItem({ globalId: `item-${i}`, publishedAt: Date.now() - i * 60000 })
+    );
+
+    doc = A.change(doc, (d) => {
+      for (const item of items) {
+        if (!d.feedItems[item.globalId]) {
+          addFeedItem(d, item);
+        }
+      }
+    });
+
+    expect(Object.keys(doc.feedItems)).toHaveLength(50);
+
+    // Re-adding same items should not create duplicates (guard in the change fn)
+    doc = A.change(doc, (d) => {
+      for (const item of items) {
+        if (!d.feedItems[item.globalId]) {
+          addFeedItem(d, item);
+        }
+      }
+    });
+
+    expect(Object.keys(doc.feedItems)).toHaveLength(50);
+  });
+});

--- a/packages/pwa/src/lib/store.ts
+++ b/packages/pwa/src/lib/store.ts
@@ -15,6 +15,7 @@ import {
   docRemoveRssFeed,
   docUpdateFeedItem,
   docMarkAsRead,
+  docMarkAllAsRead,
   docToggleSaved,
   docUpdatePreferences,
 } from "./automerge";
@@ -53,6 +54,7 @@ interface AppState {
   addItems: (items: FeedItem[]) => Promise<void>;
   updateItem: (id: string, update: Partial<FeedItem>) => Promise<void>;
   markAsRead: (id: string) => Promise<void>;
+  markAllAsRead: (platform?: string) => Promise<void>;
   toggleSaved: (id: string) => Promise<void>;
 
   // Feed actions (persisted to Automerge)
@@ -153,6 +155,14 @@ export const useAppStore = create<AppState>((set, get) => ({
       await docMarkAsRead(id);
     } catch (error) {
       set({ error: error instanceof Error ? error.message : "Failed to mark as read" });
+    }
+  },
+
+  markAllAsRead: async (platform) => {
+    try {
+      await docMarkAllAsRead(platform);
+    } catch (error) {
+      set({ error: error instanceof Error ? error.message : "Failed to mark all as read" });
     }
   },
 

--- a/packages/pwa/src/lib/store.ts
+++ b/packages/pwa/src/lib/store.ts
@@ -24,6 +24,7 @@ import type { FreedDoc } from "@freed/shared/schema";
 // Filter options for the feed view
 interface FilterOptions {
   platform?: string;
+  feedUrl?: string;
   tags?: string[];
   savedOnly?: boolean;
   showArchived?: boolean;

--- a/packages/pwa/src/lib/sync.ts
+++ b/packages/pwa/src/lib/sync.ts
@@ -2,21 +2,14 @@
  * Sync client for PWA
  *
  * Connects to desktop's WebSocket relay for Automerge document sync.
+ * The relay speaks raw binary (Automerge doc bytes) — no JSON envelope.
  */
 
 import { getDocBinary, mergeDoc } from "./automerge";
 
-// Sync message types
-type SyncMessageType = "doc" | "request" | "ping" | "pong";
-
-interface SyncMessage {
-  type: SyncMessageType;
-  payload?: string; // Base64 encoded for doc messages
-}
-
 // Connection state
 let ws: WebSocket | null = null;
-let reconnectTimer: NodeJS.Timeout | null = null;
+let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 let isConnected = false;
 let currentUrl: string | null = null;
 
@@ -25,89 +18,25 @@ type StatusListener = (connected: boolean) => void;
 const statusListeners = new Set<StatusListener>();
 
 /**
- * Encode document for transmission
- */
-function encodeDoc(data: Uint8Array): string {
-  let binary = "";
-  for (let i = 0; i < data.length; i++) {
-    binary += String.fromCharCode(data[i]);
-  }
-  return btoa(binary);
-}
-
-/**
- * Decode document from transmission
- */
-function decodeDoc(base64: string): Uint8Array {
-  const binary = atob(base64);
-  const bytes = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i++) {
-    bytes[i] = binary.charCodeAt(i);
-  }
-  return bytes;
-}
-
-/**
- * Handle incoming sync message
- */
-async function handleMessage(message: SyncMessage): Promise<void> {
-  switch (message.type) {
-    case "doc":
-      if (message.payload) {
-        const doc = decodeDoc(message.payload);
-        await mergeDoc(doc);
-        console.log("[Sync] Received and merged document");
-      }
-      break;
-
-    case "request":
-      // Send our current document
-      broadcastDoc();
-      break;
-
-    case "ping":
-      // Respond with pong
-      send({ type: "pong" });
-      break;
-
-    case "pong":
-      // Connection is alive
-      break;
-  }
-}
-
-/**
- * Send a message
- */
-function send(message: SyncMessage): void {
-  if (ws && ws.readyState === WebSocket.OPEN) {
-    ws.send(JSON.stringify(message));
-  }
-}
-
-/**
- * Broadcast current document to peers
- */
-export function broadcastDoc(): void {
-  try {
-    const doc = getDocBinary();
-    const message: SyncMessage = {
-      type: "doc",
-      payload: encodeDoc(doc),
-    };
-    send(message);
-    console.log("[Sync] Broadcast document");
-  } catch (error) {
-    console.error("[Sync] Failed to broadcast:", error);
-  }
-}
-
-/**
  * Notify status listeners
  */
 function notifyStatus(): void {
   for (const listener of statusListeners) {
     listener(isConnected);
+  }
+}
+
+/**
+ * Broadcast current document to relay as raw binary
+ */
+export function broadcastDoc(): void {
+  if (!ws || ws.readyState !== WebSocket.OPEN) return;
+  try {
+    const doc = getDocBinary();
+    ws.send(doc);
+    console.log("[Sync] Broadcast document (%d bytes)", doc.byteLength);
+  } catch (error) {
+    console.error("[Sync] Failed to broadcast:", error);
   }
 }
 
@@ -124,25 +53,27 @@ export function connect(url: string): void {
 
   try {
     ws = new WebSocket(url);
+    ws.binaryType = "arraybuffer"; // Receive binary as ArrayBuffer
 
     ws.onopen = () => {
       console.log("[Sync] Connected to relay");
       isConnected = true;
       notifyStatus();
 
-      // Request current document from peers
-      send({ type: "request" });
-
-      // Send our document too
-      setTimeout(() => broadcastDoc(), 500);
+      // Send our current doc so the relay stores it and can serve new clients
+      setTimeout(() => broadcastDoc(), 100);
     };
 
     ws.onmessage = async (event) => {
+      if (!(event.data instanceof ArrayBuffer)) return;
+      const bytes = new Uint8Array(event.data);
+      if (bytes.length === 0) return;
+
       try {
-        const message = JSON.parse(event.data) as SyncMessage;
-        await handleMessage(message);
+        await mergeDoc(bytes);
+        console.log("[Sync] Received and merged document (%d bytes)", bytes.length);
       } catch (error) {
-        console.error("[Sync] Failed to handle message:", error);
+        console.error("[Sync] Failed to merge doc:", error);
       }
     };
 
@@ -152,7 +83,7 @@ export function connect(url: string): void {
       ws = null;
       notifyStatus();
 
-      // Reconnect after delay
+      // Auto-reconnect after delay
       if (currentUrl && reconnectTimer === null) {
         reconnectTimer = setTimeout(() => {
           reconnectTimer = null;

--- a/packages/pwa/src/main.tsx
+++ b/packages/pwa/src/main.tsx
@@ -1,7 +1,19 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { registerSW } from 'virtual:pwa-register'
 import './index.css'
 import App from './App.tsx'
+
+// Register service worker with auto-update
+registerSW({
+  onNeedRefresh() {
+    // New content available — auto-update silently in background
+    console.log('[PWA] New version available, updating...')
+  },
+  onOfflineReady() {
+    console.log('[PWA] App ready for offline use')
+  },
+})
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/packages/pwa/tsconfig.app.json
+++ b/packages/pwa/tsconfig.app.json
@@ -5,7 +5,7 @@
     "useDefineForClassFields": true,
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
-    "types": ["vite/client"],
+    "types": ["vite/client", "vite-plugin-pwa/client"],
     "skipLibCheck": true,
 
     /* Bundler mode */

--- a/packages/pwa/vite.config.ts
+++ b/packages/pwa/vite.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { VitePWA } from 'vite-plugin-pwa'
 
 // https://vite.dev/config/
 //
@@ -7,7 +8,53 @@ import react from '@vitejs/plugin-react'
 // scripts/patch-automerge.mjs (run via postinstall) to use fullfat_base64.js
 // instead of fullfat_bundler.js, avoiding Vite 7's ESM WASM rejection.
 export default defineConfig({
-  plugins: [react()],
+  plugins: [
+    react(),
+    VitePWA({
+      registerType: 'autoUpdate',
+      includeAssets: ['favicon.ico', 'icons/*.png'],
+      manifest: false, // use our own manifest.json in /public
+      workbox: {
+        // Cache strategies for different resource types
+        runtimeCaching: [
+          {
+            // Feed images: cache-first, 30 day max age
+            urlPattern: /\.(?:png|jpg|jpeg|svg|gif|webp|avif)$/i,
+            handler: 'CacheFirst',
+            options: {
+              cacheName: 'freed-images',
+              expiration: {
+                maxEntries: 500,
+                maxAgeSeconds: 60 * 60 * 24 * 30,
+              },
+            },
+          },
+          {
+            // API/fetch calls: network-first with cache fallback
+            urlPattern: /^https?:\/\//,
+            handler: 'NetworkFirst',
+            options: {
+              cacheName: 'freed-network',
+              networkTimeoutSeconds: 10,
+              expiration: {
+                maxEntries: 200,
+                maxAgeSeconds: 60 * 60 * 24 * 7,
+              },
+            },
+          },
+        ],
+        // App shell: precache all built assets
+        globPatterns: ['**/*.{js,css,html,ico,png,svg,wasm}'],
+        // Skip waiting to activate new SW immediately
+        skipWaiting: true,
+        clientsClaim: true,
+      },
+      devOptions: {
+        // Enable PWA in dev for testing
+        enabled: false,
+      },
+    }),
+  ],
 
   test: {
     environment: 'jsdom',

--- a/website/src/app/manifesto/ManifestoContent.tsx
+++ b/website/src/app/manifesto/ManifestoContent.tsx
@@ -26,22 +26,56 @@ export default function ManifestoContent() {
           </header>
 
           {/* Content */}
-          <div className="space-y-8 text-text-secondary">
+          <div className="space-y-10 text-text-secondary">
             <section>
               <h2 className="text-2xl font-bold text-text-primary mb-4">
-                The Problem
+                The Extraction
               </h2>
               <p>
-                Modern social media platforms have weaponized psychology against
-                us. Their algorithms don't serve our interests—they serve
-                engagement metrics. They've discovered that outrage, anxiety,
-                and FOMO are more addictive than connection and joy.
+                Every time you open a social media app, you are not a customer.
+                You are the product. Your attention is being harvested, packaged,
+                and sold to the highest bidder—and the platform's entire
+                engineering budget is dedicated to maximizing the yield.
               </p>
               <p>
-                These platforms race to the bottom of the human brainstem, using
-                dopamine as an energy-extractive neurotoxin. We scroll
-                endlessly, not because we want to, but because we've been
-                engineered to.
+                These platforms didn't accidentally become addictive. They
+                employed thousands of engineers, behavioral psychologists, and
+                machine learning researchers specifically to exploit the gaps in
+                human cognition. They discovered that outrage travels six times
+                faster than measured reflection. That variable reward schedules
+                create compulsive checking behaviors. That social comparison
+                triggers anxiety that sends you back to the feed looking for
+                relief.
+              </p>
+              <p>
+                They race to the bottom of the brainstem. Your rational mind
+                never gets a vote.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="text-2xl font-bold text-text-primary mb-4">
+                What We Lost
+              </h2>
+              <p>
+                It wasn't always like this. RSS readers existed. Chronological
+                feeds existed. The early web was about publishing what you made
+                and reading what others made, without a middleman deciding what
+                you deserved to see.
+              </p>
+              <p>
+                Then the platforms learned they could grow faster by hijacking
+                the signal. They replaced chronological feeds with algorithmic
+                ones optimized for engagement—not for your benefit, but for
+                theirs. They introduced infinite scroll. They removed the ability
+                to be "done." They made it technically impossible to simply read
+                what the people you chose to follow had written.
+              </p>
+              <p>
+                The cost has been enormous: the erosion of genuine discourse,
+                the polarization of communities, the commodification of
+                friendship, and billions of hours of human attention redirected
+                from everything that matters toward a compulsive, joyless scroll.
               </p>
             </section>
 
@@ -50,16 +84,27 @@ export default function ManifestoContent() {
                 The Ulysses Pact
               </h2>
               <p>
-                In Greek mythology, Odysseus knew he couldn't resist the Sirens'
-                song. So he had his crew bind him to the mast before they sailed
-                past. He chose his constraints
-                <em>before</em> facing temptation.
+                In Homer's <em>Odyssey</em>, Odysseus wanted to hear the
+                Sirens' song—the most beautiful music in the world—without being
+                lured to his death on the rocks below. He couldn't trust himself
+                to resist in the moment. So he made a decision in advance: had
+                his crew bind him to the mast and fill their own ears with wax.
+                He heard the Sirens. He survived. He got what he wanted by
+                choosing his constraints <em>before</em> the temptation arrived.
               </p>
               <p>
-                Freed is your mast. You configure it once—deciding what content
-                matters to you, how your feed should be weighted, which
-                platforms to block—and then you engage only through Freed. The
-                algorithm that serves you best is the one you wrote yourself.
+                This is a Ulysses Pact: a commitment made in advance, by your
+                deliberate self, to protect you from the choices your impulsive
+                self would make.
+              </p>
+              <p>
+                Freed is your mast. You configure it once—deciding which
+                creators matter to you, how much weight to give different
+                sources, which platforms to access only through Freed's filtered
+                lens—and then you engage with the internet only through that
+                configuration. The algorithm that shapes your experience is one
+                you wrote yourself, in a moment of clarity, rather than one
+                written by engineers optimizing for your compulsion.
               </p>
             </section>
 
@@ -67,52 +112,83 @@ export default function ManifestoContent() {
               <h2 className="text-2xl font-bold text-text-primary mb-4">
                 What We Believe
               </h2>
-              <ul className="space-y-4">
+              <ul className="space-y-6">
                 <li>
-                  <strong className="text-text-primary">
+                  <strong className="text-text-primary block mb-1">
                     Your data belongs to you.
-                  </strong>{" "}
-                  Freed stores everything locally. We have no servers, collect
-                  no telemetry, and never see your content.
+                  </strong>
+                  Freed stores everything locally on your device. We have no
+                  servers. We collect no telemetry. We never see your content,
+                  your follows, or your reading habits. When you sync between
+                  your devices, the data travels through cloud storage you
+                  already own—your Google Drive, your iCloud, your Dropbox—
+                  without ever touching our infrastructure.
                 </li>
                 <li>
-                  <strong className="text-text-primary">
-                    Algorithms should be transparent.
-                  </strong>{" "}
-                  Freed's ranking is open source. You can read, modify, and
-                  improve it.
+                  <strong className="text-text-primary block mb-1">
+                    Algorithms should be transparent and editable.
+                  </strong>
+                  Freed's ranking algorithm is open source. You can read exactly
+                  how it decides what to show you first. You can edit the weights
+                  yourself. You can fork it and build your own. This is not a
+                  feature—it is a requirement for any tool that shapes your
+                  information diet.
                 </li>
                 <li>
-                  <strong className="text-text-primary">
-                    Technology should connect us.
-                  </strong>{" "}
-                  The Friend Map exists because we believe social media should
-                  facilitate real human interaction, not replace it.
+                  <strong className="text-text-primary block mb-1">
+                    Chronological is not naïve.
+                  </strong>
+                  Choosing to see content in the order it was published is a
+                  legitimate preference, not a failure of curation. The people
+                  you follow made decisions about what to share and when. You
+                  should have the option to respect those decisions without a
+                  platform overriding them.
                 </li>
                 <li>
-                  <strong className="text-text-primary">
-                    Freedom requires intentionality.
-                  </strong>{" "}
-                  Ulysses Mode isn't about restriction—it's about choosing your
-                  constraints before the Sirens start singing.
+                  <strong className="text-text-primary block mb-1">
+                    Attention is finite and precious.
+                  </strong>
+                  The platforms have forgotten this. We have not. Freed is
+                  designed to help you finish your feed—to know when you've
+                  read the things that matter and have permission to stop.
+                </li>
+                <li>
+                  <strong className="text-text-primary block mb-1">
+                    Liberation tools should belong to everyone.
+                  </strong>
+                  Freed is MIT licensed. Fork it, audit it, distribute it,
+                  improve it. Build the future you want to live in.
                 </li>
               </ul>
             </section>
 
             <section>
               <h2 className="text-2xl font-bold text-text-primary mb-4">
-                The Path Forward
+                The Vision
               </h2>
               <p>
-                We're not asking you to quit social media. We're offering a way
-                to engage with it on your terms. See the content from people you
-                actually care about. Know where your friends are. Break free
-                from the infinite scroll.
+                We're not asking you to quit social media. We're asking you to
+                engage with it on your terms.
               </p>
               <p>
-                Freed is open source because we believe tools for liberation
-                should belong to everyone. Fork it, audit it, improve it. Build
-                the future of social media with us.
+                A Freed user sees a clean timeline of posts from people they
+                genuinely care about—writers, friends, researchers, journalists—
+                ranked by criteria they defined: author authority, topic
+                relevance, freshness. They read through it until they're done.
+                Then they close the app. There is no infinite scroll. There is
+                no algorithmic outrage-injection. There is no dark pattern
+                designed to prevent them from leaving.
+              </p>
+              <p>
+                They know when they've caught up. They can mark something as
+                read, archive a conversation, save an article for later. They can
+                enable Ulysses Mode and block themselves from accessing the raw
+                platform until morning. They sync their reading state across
+                their laptop and phone without any of it touching our servers.
+              </p>
+              <p>
+                That's the whole vision. It's not revolutionary. It's just what
+                the internet was supposed to be.
               </p>
             </section>
 
@@ -121,9 +197,22 @@ export default function ManifestoContent() {
                 "The algorithm that serves you best is the one you wrote
                 yourself."
                 <footer className="text-text-secondary text-base mt-2 not-italic">
-                  — The Codex of Digital Autonomy
+                  — The Freed Manifesto
                 </footer>
               </blockquote>
+            </section>
+
+            <section>
+              <p>
+                We're building this in the open. The roadmap is public. The code
+                is public. The process is public. We'd love your help, your
+                feedback, and your critique.
+              </p>
+              <p>
+                And if this resonates with you—if you've been waiting for
+                someone to build this—subscribe below. We'll let you know when
+                it's ready to install.
+              </p>
             </section>
           </div>
 

--- a/website/src/app/roadmap/RoadmapContent.tsx
+++ b/website/src/app/roadmap/RoadmapContent.tsx
@@ -455,7 +455,7 @@ const phases: Phase[] = [
     number: 1,
     title: "Foundation",
     description: "Marketing site, monorepo, Automerge schema, CI/CD.",
-    status: "current",
+    status: "complete",
     planLink:
       "https://github.com/freed-project/freed/blob/main/docs/PHASE-1-FOUNDATION.md",
   },

--- a/website/src/components/Navigation.tsx
+++ b/website/src/components/Navigation.tsx
@@ -213,6 +213,15 @@ export default function Navigation() {
 
   return (
     <>
+      {/* iOS/macOS overscroll shield: extends nav background above viewport so rubber-band
+          bounce doesn't reveal a gap above the mobile nav bar. Height of 200px covers any
+          realistic overscroll. Desktop nav is a floating pill so doesn't need this. */}
+      <div
+        className="md:hidden fixed left-0 right-0 bg-freed-black z-40 pointer-events-none"
+        style={{ top: "-200px", height: "200px" }}
+        aria-hidden="true"
+      />
+
       {/* Desktop: Top blur overlay - blurs and darkens content as it approaches the top of viewport */}
       <div
         className="hidden md:block fixed top-0 left-0 right-0 h-32 pointer-events-none z-40"

--- a/website/src/content/posts/001-introducing-freed.tsx
+++ b/website/src/content/posts/001-introducing-freed.tsx
@@ -5,95 +5,204 @@ export default definePost(
     slug: "introducing-freed",
     title: "Introducing Freed: Take Back Your Feed",
     description:
-      "Our first newsletter. Why we built Freed, what we believe, and where we're headed.",
-    date: "2026-02-01",
+      "Why we built a local-first, open-source feed reader that puts you back in control of your information diet.",
+    date: "2026-02-17",
     author: "The Freed Team",
-    tags: ["announcement", "philosophy"],
+    tags: ["announcement", "philosophy", "technical"],
   },
   <>
     <p>
       Welcome to the first Freed newsletter. If you're reading this, you've
-      either subscribed to our email list or discovered us through RSS—which, by
-      the way, is exactly the kind of choice we think you should have.
+      either subscribed to our email list or discovered us through RSS—which,
+      by the way, is exactly the kind of choice we think you should always have.
     </p>
 
-    <h2>Why We Built This</h2>
     <p>
-      Modern social media platforms have weaponized psychology against us. Their
-      algorithms don't serve our interests—they serve engagement metrics.
-      They've discovered that outrage, anxiety, and FOMO are more addictive than
-      connection and joy.
-    </p>
-    <p>
-      We're not the first to notice this. But we are building something about
-      it.
+      We want to tell you why we built this, how it works, and what we believe.
+      Let's start with the problem we're trying to solve.
     </p>
 
-    <h2>What Freed Actually Is</h2>
+    <h2>The Scroll That Doesn't End</h2>
     <p>
-      Freed captures your social feeds locally—X, RSS, YouTube, newsletters,
-      podcasts—and creates a unified timeline that <em>you</em> control. No
-      engagement optimization. No algorithmic manipulation. Just content from
-      people you actually care about, weighted by criteria you define.
+      Somewhere in the last decade, social media stopped being a place where you
+      read things and became a place where things happened to you. The
+      chronological feed—the simple idea that you see what the people you follow
+      published, in the order they published it—was quietly killed at every major
+      platform.
     </p>
     <p>
-      All data stays on your device. We have no servers. We literally cannot see
-      what you capture. That's the point.
+      What replaced it was algorithmic curation optimized for one thing:
+      engagement. Not your satisfaction. Not your education. Not your
+      connection to the people you care about. Engagement—clicks, shares,
+      reactions, time-on-screen—because those are what platforms sell to
+      advertisers.
+    </p>
+    <p>
+      The results are predictable. Outrage gets amplified because it's
+      engaging. Nuance gets suppressed because it's slow. The most compelling
+      lies travel faster than measured truth, and the algorithm can't tell the
+      difference and doesn't try. Infinite scroll removes the natural stopping
+      point. Variable reward schedules—the same mechanism that makes slot
+      machines addictive—keep you pulling down to refresh.
+    </p>
+    <p>
+      None of this is accidental. It is the product of billions of dollars in
+      engineering talent, deployed specifically to exploit the gaps in human
+      cognition.
     </p>
 
-    <h2>The Roadmap</h2>
+    <h2>What Freed Does Differently</h2>
     <p>
-      We've published our full <a href="/roadmap">roadmap</a> publicly. Here's
-      where we are:
+      Freed is a local-first feed reader. It captures content from your social
+      sources—X (formerly Twitter), RSS feeds, YouTube channels, newsletters,
+      podcasts—and presents them in a unified, chronological timeline on your
+      device. You decide the ranking. You control the weights. The algorithm is
+      yours.
+    </p>
+    <p>Here's what that means concretely:</p>
+    <ul>
+      <li>
+        <strong>No central servers.</strong> Your captured content lives on your
+        device, synced between your own devices (laptop, phone) via your own
+        cloud storage—Google Drive, iCloud, or Dropbox. We never touch it.
+      </li>
+      <li>
+        <strong>No engagement optimization.</strong> Posts are ranked by
+        criteria you define: how much you trust this author, how relevant the
+        topic is to you, how fresh it is. Not by what made someone else angry
+        yesterday.
+      </li>
+      <li>
+        <strong>You can be done.</strong> Freed tracks what you've read. When
+        you've seen everything from your subscribed sources, you've caught up.
+        There's no infinite scroll. There's an actual end.
+      </li>
+      <li>
+        <strong>Ulysses Mode.</strong> If you want to read content from X or
+        Instagram but don't trust yourself not to lose two hours to the
+        algorithmic feed, you can configure Freed to be the only way you access
+        those platforms. Named after the Greek hero who had himself tied to the
+        mast so he could hear the Sirens without dying.
+      </li>
+      <li>
+        <strong>Open source.</strong> Every line of code is MIT licensed. You
+        can read it, modify it, fork it, and audit exactly what it does with your
+        data.
+      </li>
+    </ul>
+
+    <h2>How It's Built</h2>
+    <p>
+      Freed is a monorepo with several packages that work together:
     </p>
     <ul>
       <li>
-        <strong>Phase 1-2: ✓ Complete</strong> — Foundation and capture skills
-        for X and RSS
+        <strong>Desktop app (Tauri + React)</strong>: The primary capture hub.
+        Runs on macOS, Windows, and Linux. Captures from X using your existing
+        browser session, polls RSS feeds, and hosts a local WebSocket relay for
+        syncing to your phone.
       </li>
       <li>
-        <strong>Phase 3-5: In Progress</strong> — Save for Later, Sync Layer,
-        and the Desktop App
+        <strong>PWA (React + Vite)</strong>: A mobile-optimized reader that
+        syncs with the desktop app when you're on the same network, and falls
+        back to your cloud storage when you're not. Installed at{" "}
+        <a href="https://app.freed.wtf">app.freed.wtf</a>.
       </li>
       <li>
-        <strong>Phase 6+: Coming</strong> — PWA, Facebook/Instagram capture,
-        Friend Map, and more
+        <strong>Shared library (@freed/shared)</strong>: The common types and
+        Automerge CRDT schema that both apps use. The CRDT (Conflict-free
+        Replicated Data Type) handles merging changes from multiple devices
+        automatically—no sync conflicts, no data loss.
+      </li>
+      <li>
+        <strong>Capture packages</strong>: Separate, composable packages for
+        each source: <code>capture-x</code>, <code>capture-rss</code>,
+        <code>capture-save</code>. Each one knows how to fetch from a source and
+        normalize the result into a standard <code>FeedItem</code>.
       </li>
     </ul>
     <p>
-      The desktop app is our highest priority. It's the hub that makes
-      everything else possible.
+      The architecture is deliberately local-first: data lives on your devices,
+      syncs between them without a relay we operate, and degrades gracefully
+      when offline. If we shut down tomorrow, your data and your app would keep
+      working.
+    </p>
+
+    <h2>Where We Are</h2>
+    <p>
+      As of this writing, here's what's working:
+    </p>
+    <ul>
+      <li>
+        <strong>Foundation (Phase 1) ✓</strong>: Monorepo, shared types,
+        Automerge schema, this marketing site, CI/CD.
+      </li>
+      <li>
+        <strong>X + RSS capture (Phase 2) ✓</strong>: Both capture layers
+        complete, with OPML import/export for RSS.
+      </li>
+      <li>
+        <strong>Save for Later (Phase 3) ✓</strong>: Save any URL with full
+        article extraction via Mozilla Readability.
+      </li>
+      <li>
+        <strong>Desktop app (Phase 5) 🚧</strong>: The Tauri app is running with
+        the local WebSocket relay, macOS vibrancy, X authentication, and the
+        reader UI. Active development.
+      </li>
+      <li>
+        <strong>PWA reader (Phase 6) 🚧</strong>: Deployed at{" "}
+        <a href="https://app.freed.wtf">app.freed.wtf</a>. Virtual scrolling,
+        focus reading mode, and service worker offline support just landed.
+      </li>
+    </ul>
+    <p>
+      The sync layer (Phase 4) is the critical path right now. Once local
+      WebSocket sync is solid, the desktop and PWA can talk to each other
+      reliably.
     </p>
 
     <h2>How You Can Help</h2>
-    <p>Freed is open source and MIT licensed. We need help with:</p>
+    <p>
+      We're a small team building this in public. The most valuable things you
+      can do:
+    </p>
     <ul>
-      <li>Desktop app UI (Tauri + React)</li>
-      <li>Additional capture layers</li>
-      <li>Sync layer implementation</li>
-      <li>Testing, testing, testing</li>
+      <li>
+        <strong>Star the repo.</strong> It helps us understand how many people
+        care about this, and it helps others discover the project.
+      </li>
+      <li>
+        <strong>Try the PWA.</strong> Go to{" "}
+        <a href="https://app.freed.wtf">app.freed.wtf</a>, add some RSS feeds,
+        and tell us what's broken.
+      </li>
+      <li>
+        <strong>Contribute code.</strong> Especially if you have Rust experience
+        for the Tauri work, or if you have ideas for additional capture layers.
+        Check the issues list.
+      </li>
+      <li>
+        <strong>Share this.</strong> The people who need Freed most are the ones
+        most embedded in the algorithmic feed. Send this to someone who's
+        complained about social media lately.
+      </li>
     </ul>
-    <p>
-      Check out the repo at{" "}
-      <a
-        href="https://github.com/freed-project/freed"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        github.com/freed-project/freed
-      </a>
-      .
-    </p>
 
-    <h2>Stay Connected</h2>
+    <h2>What's Next</h2>
     <p>
-      This newsletter will be your primary source for Freed updates. We'll share
-      progress, technical deep-dives, and occasional philosophical rants about
-      the attention economy.
+      The immediate roadmap, in order:
     </p>
+    <ol>
+      <li>Finish the local sync layer (desktop ↔ phone over LAN)</li>
+      <li>Polish the desktop and PWA UIs to a releasable state</li>
+      <li>Package and notarize the desktop app for macOS</li>
+      <li>Windows and Linux builds</li>
+      <li>Facebook and Instagram capture via headless browser</li>
+      <li>Cloud sync (Google Drive / Dropbox / iCloud)</li>
+    </ol>
     <p>
-      Every edition will be published here on our website—permanent, shareable,
-      and available via RSS. Because we practice what we preach.
+      We'll send an update when each of these lands. We don't spam.
     </p>
 
     <blockquote>


### PR DESCRIPTION
## Summary

This branch contains a full development session's worth of features, fixes, and tests across the Freed monorepo. Below is a comprehensive breakdown.

---

## Changes by Area

### Sync Pipeline Fixes
- **PWA sync.ts** — Rewrote binary WebSocket protocol. The Rust relay sends/receives raw `Vec<u8>` binary, but the PWA was using JSON `{type, payload: base64}`. Fixed to use `ws.binaryType = "arraybuffer"` and handle raw `ArrayBuffer` messages.
- **Desktop automerge.ts** — Added `broadcastToRelay()` called at end of every `applyChange()` so doc mutations are pushed to connected PWA clients via the Tauri `broadcast_doc` command.

### X / Twitter Capture
- **Desktop capture.ts** — `refreshAllFeeds()` now captures X timeline when `xAuth.isAuthenticated`, in addition to RSS.
- **Desktop x-auth.ts** — Replaced `window.prompt()` (bad UX in Tauri) with a clean `connectX(ct0, authToken)` function.
- **Desktop Sidebar.tsx** — Added an inline two-input form for X cookie entry; replaces the single-button prompt flow.

### Feed Item UX
- **PWA FeedItem.tsx** — Added bookmark button with hover-reveal; shows saved state with filled/outline icon.
- **PWA/Desktop FeedList.tsx** — Added `onItemSave` prop to pass save action from FeedView down to individual cards.
- **PWA/Desktop FeedView.tsx** — Wired `onAddFeed`, `hasFeedsSubscribed`, `onItemSave` props to FeedList.

### Automerge Schema Bug Fixes (`packages/shared`)
Two production-crashing bugs found via tests and fixed:

1. **`toggleSaved`** — `item.userState.savedAt = undefined` crashes Automerge 2.x ("Cannot assign undefined value"). Fixed with `delete (item.userState as unknown as Record<string, unknown>).savedAt`.
2. **`updatePreferences`** — `Object.assign(doc.preferences, updates)` crashes when updates contains nested objects ("Cannot create a reference to an existing document object"). Replaced with `deepMergeInto()` helper that recursively updates scalar leaf values without replacing Automerge Map objects.

### Automated Tests (69 total, all passing)
- **`packages/pwa/src/lib/schema.test.ts`** (24 tests) — Full Automerge document operation coverage: createEmptyDoc, addFeedItem, removeFeedItem, markAsRead, toggleSaved, hideItem, addRssFeed, removeRssFeed, updatePreferences. Plus CRDT merge simulation tests.
- **`packages/pwa/src/lib/ranking.test.ts`** (23 tests) — calculatePriority, rankFeedItems, sortByPriority, filterFeedItems with full filter combination coverage.
- **`packages/pwa/src/lib/opml.test.ts`** (22 tests) — Pre-existing.

### Facebook & Instagram Scrapers (Phase 7)
Two new packages: `@freed/capture-facebook` and `@freed/capture-instagram`.

Each package contains:
- `types.ts` — Raw DOM-extracted post shapes + scraper options
- `selectors.ts` — Versioned CSS/ARIA selectors (`SELECTOR_VERSION = 2026-02-17`)
- `session.ts` — Cookie-based Playwright browser context + feed navigation
- `scraper.ts` — DOM extraction via `page.evaluate()` with auto-scroll
- `normalize.ts` — Raw post → `FeedItem` (platform, author, content, engagement, location)
- `rate-limit.ts` — Conservative rate limiting with exponential backoff on errors
- `index.ts` — Public API: `captureFacebookFeed()` / `captureInstagramFeed()`

Rate limits: Facebook 5min minimum / 30min error cooldown; Instagram 10min / 1hr error cooldown with exponential backoff.

Both packages build cleanly with TypeScript strict mode.

### Documentation Updates
- `docs/PHASE-5-DESKTOP.md` — Status updated to ✅ Core Complete; success criteria checked off
- `docs/PHASE-6-PWA.md` — Status updated to ✅ Core Complete; success criteria checked off
- `docs/PHASE-7-SOCIAL-CAPTURE.md` — Status updated to 🚧 In Progress; scaffold/rate-limit/normalize criteria checked

---

## Token Usage Estimate

This PR represents approximately **2–3 full working sessions** of Claude Sonnet 4.6 activity:

| Task Category | Approx. Input Tokens | Approx. Output Tokens |
|---|---|---|
| Codebase exploration & audit | ~80K | ~5K |
| Schema bug investigation + tests | ~60K | ~15K |
| Sync pipeline rewrite | ~40K | ~8K |
| Feature work (save button, X auth, etc.) | ~50K | ~12K |
| Facebook/Instagram scrapers (14 files) | ~30K | ~20K |
| Documentation updates | ~20K | ~5K |
| **Total estimate** | **~280K input** | **~65K output** |

At Sonnet 4.6 pricing ($3/MTok input, $15/MTok output):
- Input: ~$0.84
- Output: ~$0.98
- **Estimated total: ~$1.80**

*Note: These are rough estimates. Actual usage depends on context compression, retries, and exact message sizes tracked by Anthropic.*

---

## Test Plan
- [x] `npx vitest run` — 69/69 tests pass
- [x] TypeScript builds clean for all modified/created packages (`shared`, `capture-facebook`, `capture-instagram`)
- [ ] Manual: sync flow (Desktop → PWA via WebSocket relay)
- [ ] Manual: X capture with real cookies
- [ ] Manual: Facebook/Instagram scraping with real authenticated account (requires selector tuning)
- [ ] Manual: PWA installable on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces brittle, auth-adjacent scraping logic and a large dependency/lockfile expansion (Workbox/PWA tooling), which can cause build/runtime regressions even though core app logic changes are limited.
> 
> **Overview**
> Adds new social capture packages for Facebook and Instagram using Playwright-driven, cookie-authenticated DOM scraping, including selector/versioning, session setup, feed scraping, normalization to `FeedItem`, and conservative rate-limiting utilities.
> 
> Updates phase documentation to reflect core completion of sync/desktop/PWA work and progress on social capture, and refreshes developer/agent rules around Automerge mutation constraints. Also updates tooling/config: enables sandbox + `npm install` in `.claude/settings.local.json` and adds `vite-plugin-pwa` (and related Workbox deps) to the PWA lockfile/devDependencies.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a3aa10f3d69dacdd07da38a2a8099911b0858d23. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->