### PR TITLE
feat(sync): secure desktop ↔ mobile pairing with 256-bit token

### DIFF
--- a/docs/PHASE-4-SYNC.md
+++ b/docs/PHASE-4-SYNC.md
@@ -229,9 +229,18 @@ export function createSyncManager(repo: Repo): SyncManager {
 
 ## Device Pairing
 
-1. **QR code** — Desktop displays QR with local IP, phone scans
-2. **Manual entry** — User enters IP in PWA settings
-3. **mDNS discovery** — PWA auto-discovers `desktop.local`
+1. **QR code** — Desktop displays QR with local IP + pairing token, phone scans
+2. **Manual entry** — User copies full URL (including `?t=<token>`) from desktop settings
+3. **mDNS discovery** — PWA auto-discovers `desktop.local` (not yet implemented)
+
+### Pairing Security
+
+The relay requires a 256-bit token in the WebSocket upgrade URI (`?t=<base64url>`).
+
+- Token is generated on first launch, persisted to the app data directory, and re-used across restarts so paired devices auto-reconnect.
+- QR code is rendered locally via `react-qr-code` — the user's LAN IP and token are never sent to a third party.
+- "Reset Pairing Token" button (desktop Settings → Mobile Sync) rotates the token and persists the new value; connected devices remain unaffected until they disconnect and attempt to reconnect.
+- New devices must scan the current QR code to obtain a valid token.
 
 ---
 
@@ -293,6 +302,19 @@ Each provider stores a single Automerge binary file. CRDT handles merge conflict
   }
 }
 ```
+
+---
+
+## Implemented: Pairing Token Authentication
+
+**Status: ✅ Complete** (branch `feat/secure-pairing-token`)
+
+The relay validates a `?t=<base64url>` token on every WebSocket upgrade request using `accept_hdr_async`. Invalid or missing tokens receive HTTP 401 before any document data is exchanged.
+
+Key files:
+- `packages/desktop/src-tauri/src/lib.rs` — token generation, persistence, relay auth gate
+- `packages/desktop/src/components/MobileSyncTab.tsx` — local QR render, Reset Pairing button
+- `packages/pwa/src/components/SyncConnectDialog.tsx` — token presence validation before connect
 
 ---
 

--- a/docs/PHASE-5-DESKTOP.md
+++ b/docs/PHASE-5-DESKTOP.md
@@ -247,7 +247,7 @@ packages/desktop/
 - [x] Desktop app launches with native vibrancy on macOS
 - [x] Captures from X, RSS in background (refreshAllFeeds covers both)
 - [x] Local WebSocket relay enables instant phone sync (binary protocol)
-- [x] QR code pairing works
+- [x] QR code pairing works (token-authenticated; local SVG render, no third-party QR API)
 - [x] System tray shows sync status
 - [x] App runs in background after window close
 - [x] Auto-updater checks GitHub Releases and installs updates in-app

--- a/package-lock.json
+++ b/package-lock.json
@@ -9753,7 +9753,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -10301,7 +10300,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -10670,7 +10668,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -11304,7 +11301,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -11342,6 +11338,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/qr.js": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/qr.js/-/qr.js-0.0.0.tgz",
+      "integrity": "sha512-c4iYnWb+k2E+vYpRimHqSu575b1/wKl4XFeJGpFmrJQz5I88v9aY2czh7s0w36srfCM1sXgC/xpoJz5dJfq+OQ==",
+      "license": "MIT"
     },
     "node_modules/querystringify": {
       "version": "2.2.0",
@@ -11429,8 +11431,20 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-qr-code": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/react-qr-code/-/react-qr-code-2.0.18.tgz",
+      "integrity": "sha512-v1Jqz7urLMhkO6jkgJuBYhnqvXagzceg3qJUWayuCK/c6LTIonpWbwxR1f1APGd4xrW/QcQEovNrAojbUz65Tg==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.8.1",
+        "qr.js": "0.0.0"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -14435,7 +14449,7 @@
     },
     "packages/desktop": {
       "name": "@freed/desktop",
-      "version": "26.3.100",
+      "version": "26.3.104",
       "dependencies": {
         "@freed/pwa": "*",
         "@freed/shared": "*",
@@ -14447,6 +14461,7 @@
         "date-fns": "^4.1.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
+        "react-qr-code": "^2.0.18",
         "react-router-dom": "^7.1.1",
         "zustand": "^5.0.3"
       },
@@ -14466,7 +14481,7 @@
     },
     "packages/pwa": {
       "name": "@freed/pwa",
-      "version": "26.3.100",
+      "version": "26.3.104",
       "dependencies": {
         "@automerge/automerge": "^2.2.8",
         "@freed/shared": "*",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -22,6 +22,7 @@
     "date-fns": "^4.1.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
+    "react-qr-code": "^2.0.18",
     "react-router-dom": "^7.1.1",
     "zustand": "^5.0.3"
   },

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -907,8 +907,10 @@ dependencies = [
 name = "freed-desktop"
 version = "26.3.104"
 dependencies = [
+ "base64 0.22.1",
  "futures-util",
  "local-ip-address",
+ "rand 0.8.5",
  "reqwest",
  "serde",
  "serde_json",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -25,6 +25,8 @@ tokio = { version = "1", features = ["full"] }
 tokio-tungstenite = "0.26"
 futures-util = "0.3"
 local-ip-address = "0.6"
+rand = "0.8"
+base64 = "0.22"
 
 [features]
 default = ["custom-protocol"]

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -2,45 +2,100 @@
 //!
 //! Native desktop app that bundles capture, sync relay, and reader UI.
 
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use futures_util::{SinkExt, StreamExt};
+use rand::RngCore;
 use std::net::SocketAddr;
-use std::sync::Arc;
-use tauri::{Manager, Emitter};
+use std::sync::{Arc, RwLock as StdRwLock};
+use tauri::{Emitter, Manager};
 use tauri::menu::{Menu, MenuItem};
 use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::{broadcast, RwLock};
-use tokio_tungstenite::{accept_async, tungstenite::Message};
+use tokio_tungstenite::{
+    accept_hdr_async,
+    tungstenite::{
+        handshake::server::{ErrorResponse, Request as WsRequest, Response as WsResponse},
+        Message,
+    },
+};
 
 #[cfg(target_os = "macos")]
 use window_vibrancy::{apply_vibrancy, NSVisualEffectMaterial};
 
-// Sync relay state
+// ---------------------------------------------------------------------------
+// Token management
+// ---------------------------------------------------------------------------
+
+/// Generates a cryptographically random 256-bit pairing token encoded as
+/// base64url without padding (43 ASCII characters).
+fn generate_token() -> String {
+    let mut bytes = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut bytes);
+    URL_SAFE_NO_PAD.encode(bytes)
+}
+
+/// Loads the pairing token from `data_dir/pairing-token`, or creates and
+/// persists a fresh one if the file is missing or malformed.
+fn load_or_create_token(data_dir: &std::path::Path) -> String {
+    let path = data_dir.join("pairing-token");
+    if let Ok(raw) = std::fs::read_to_string(&path) {
+        let token = raw.trim().to_string();
+        // 32 bytes base64url-no-pad → exactly 43 chars, all URL-safe
+        let looks_valid = token.len() == 43
+            && token
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_');
+        if looks_valid {
+            return token;
+        }
+    }
+    let token = generate_token();
+    let _ = std::fs::write(&path, &token);
+    token
+}
+
+// ---------------------------------------------------------------------------
+// Relay state
+// ---------------------------------------------------------------------------
+
 struct SyncRelayState {
     port: u16,
-    // Channel for broadcasting document updates to all connected clients
+    /// Broadcast channel — sends doc bytes to all connected clients.
     broadcast_tx: broadcast::Sender<Vec<u8>>,
-    // Latest document state (for new clients)
+    /// Latest doc binary, served to new joiners immediately on connect.
     current_doc: RwLock<Option<Vec<u8>>>,
-    // Connected client count
+    /// Live connection count (displayed in tray / sync indicator).
     client_count: RwLock<usize>,
+    /// Pairing token — must appear as `?t=<token>` in the WS upgrade URI.
+    ///
+    /// Uses `std::sync::RwLock` (not Tokio's) because it is never held
+    /// across an `.await` point; it is read/written synchronously and the
+    /// guard is dropped before any async work begins.
+    pairing_token: StdRwLock<String>,
 }
 
 type RelayState = Arc<SyncRelayState>;
 
-/// Tauri command to get app version
+// ---------------------------------------------------------------------------
+// Tauri commands — meta
+// ---------------------------------------------------------------------------
+
 #[tauri::command]
 fn get_version() -> String {
     env!("CARGO_PKG_VERSION").to_string()
 }
 
-/// Tauri command to get platform info
 #[tauri::command]
 fn get_platform() -> String {
     std::env::consts::OS.to_string()
 }
 
-/// Fetch any URL and return its body as text (bypasses CORS)
+// ---------------------------------------------------------------------------
+// Tauri commands — network / proxy
+// ---------------------------------------------------------------------------
+
+/// Fetch any URL and return its body as text (bypasses browser CORS).
 #[tauri::command]
 async fn fetch_url(url: String) -> Result<String, String> {
     let client = reqwest::Client::builder()
@@ -61,7 +116,7 @@ async fn fetch_url(url: String) -> Result<String, String> {
     response.text().await.map_err(|e| e.to_string())
 }
 
-/// Make authenticated request to X API
+/// Make an authenticated POST to the X (Twitter) API.
 #[tauri::command]
 async fn x_api_request(
     url: String,
@@ -74,7 +129,6 @@ async fn x_api_request(
         .map_err(|e| e.to_string())?;
 
     let mut request = client.post(&url).body(body);
-
     for (key, value) in headers {
         request = request.header(&key, &value);
     }
@@ -93,7 +147,10 @@ async fn x_api_request(
     response.text().await.map_err(|e| e.to_string())
 }
 
-/// Get the local IP address for sync
+// ---------------------------------------------------------------------------
+// Tauri commands — sync
+// ---------------------------------------------------------------------------
+
 #[tauri::command]
 fn get_local_ip() -> Result<String, String> {
     local_ip_address::local_ip()
@@ -101,35 +158,64 @@ fn get_local_ip() -> Result<String, String> {
         .map_err(|e| e.to_string())
 }
 
-/// Get the sync relay URL
+/// Returns the full WebSocket pairing URL including the auth token.
+///
+/// Format: `ws://<lan-ip>:<port>?t=<base64url-token>`
+///
+/// This URL is encoded into the QR code shown in the Mobile Sync tab.
+/// Only devices that scan the QR code (i.e. know the token) can connect.
 #[tauri::command]
 fn get_sync_url(state: tauri::State<'_, RelayState>) -> String {
     let port = state.port;
-    match local_ip_address::local_ip() {
-        Ok(ip) => format!("ws://{}:{}", ip, port),
-        Err(_) => format!("ws://localhost:{}", port),
-    }
+    // StdRwLock guard is held briefly and dropped before any await — safe.
+    let token = state.pairing_token.read().unwrap().clone();
+    let ip = local_ip_address::local_ip()
+        .map(|ip| ip.to_string())
+        .unwrap_or_else(|_| "localhost".to_string());
+    format!("ws://{}:{}?t={}", ip, port, token)
 }
 
-/// Get connected client count
+/// Rotates the pairing token and persists the new value to disk.
+///
+/// In-flight connections are unaffected (they already authenticated).
+/// New connection attempts with the old token will be rejected — devices
+/// must rescan the QR code to reconnect.
+#[tauri::command]
+async fn reset_pairing_token(
+    app: tauri::AppHandle,
+    state: tauri::State<'_, RelayState>,
+) -> Result<String, String> {
+    let data_dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| e.to_string())?;
+    let new_token = generate_token();
+    std::fs::write(data_dir.join("pairing-token"), &new_token).map_err(|e| e.to_string())?;
+    *state.pairing_token.write().unwrap() = new_token.clone();
+    println!("[Sync] Pairing token rotated");
+    Ok(new_token)
+}
+
 #[tauri::command]
 async fn get_sync_client_count(state: tauri::State<'_, RelayState>) -> Result<usize, String> {
     Ok(*state.client_count.read().await)
 }
 
-/// Broadcast document to all connected clients
+/// Push a document update to all connected clients.
 #[tauri::command]
-async fn broadcast_doc(state: tauri::State<'_, RelayState>, doc_bytes: Vec<u8>) -> Result<(), String> {
-    // Store the latest document
+async fn broadcast_doc(
+    state: tauri::State<'_, RelayState>,
+    doc_bytes: Vec<u8>,
+) -> Result<(), String> {
     *state.current_doc.write().await = Some(doc_bytes.clone());
-
-    // Broadcast to all connected clients (ignore send errors - clients may disconnect)
     let _ = state.broadcast_tx.send(doc_bytes);
-
     Ok(())
 }
 
-/// Show the main window (called from tray)
+// ---------------------------------------------------------------------------
+// Tauri commands — window
+// ---------------------------------------------------------------------------
+
 #[tauri::command]
 fn show_window(app: tauri::AppHandle) {
     if let Some(window) = app.get_webview_window("main") {
@@ -138,14 +224,66 @@ fn show_window(app: tauri::AppHandle) {
     }
 }
 
-/// Handle a single WebSocket connection
-async fn handle_connection(stream: TcpStream, addr: SocketAddr, state: RelayState, app: tauri::AppHandle) {
+// ---------------------------------------------------------------------------
+// WebSocket relay
+// ---------------------------------------------------------------------------
+
+/// Authenticate and handle a single WebSocket connection.
+///
+/// The client must include `?t=<token>` in the upgrade URI.  Any connection
+/// that omits the token or presents an incorrect value is rejected with HTTP
+/// 401 before the WebSocket handshake completes — no data is exchanged.
+async fn handle_connection(
+    stream: TcpStream,
+    addr: SocketAddr,
+    state: RelayState,
+    app: tauri::AppHandle,
+) {
     println!("[Sync] New connection from: {}", addr);
 
-    let ws_stream = match accept_async(stream).await {
+    // Snapshot the token now — the StdRwLock guard is dropped here, so it is
+    // never held across an .await point.
+    let expected_token = state.pairing_token.read().unwrap().clone();
+
+    let ws_stream = match accept_hdr_async(
+        stream,
+        move |req: &WsRequest, resp: WsResponse| -> Result<WsResponse, ErrorResponse> {
+            let token_ok = req
+                .uri()
+                .query()
+                .and_then(|q| {
+                    // Parse ?t=<value> from the query string
+                    q.split('&').find_map(|pair| {
+                        let mut kv = pair.splitn(2, '=');
+                        (kv.next() == Some("t")).then(|| kv.next()).flatten()
+                    })
+                })
+                .map(|t| t == expected_token.as_str())
+                .unwrap_or(false);
+
+            if token_ok {
+                Ok(resp)
+            } else {
+                eprintln!("[Sync] Rejected unauthorized connection from {}", addr);
+                Err(
+                    tokio_tungstenite::tungstenite::http::Response::builder()
+                        .status(401)
+                        .body(Some(
+                            "Unauthorized: rescan the QR code to pair".to_owned(),
+                        ))
+                        .unwrap(),
+                )
+            }
+        },
+    )
+    .await
+    {
         Ok(ws) => ws,
         Err(e) => {
-            eprintln!("[Sync] WebSocket handshake failed: {}", e);
+            // 401 rejections are normal; log everything else
+            if !e.to_string().contains("HTTP error") {
+                eprintln!("[Sync] WebSocket handshake failed: {}", e);
+            }
             return;
         }
     };
@@ -161,23 +299,21 @@ async fn handle_connection(stream: TcpStream, addr: SocketAddr, state: RelayStat
         let _ = app.emit("sync-client-count", new_count);
     }
 
-    // Send current document state to new client
+    // Push current doc to the new client immediately
     if let Some(doc) = state.current_doc.read().await.clone() {
         if let Err(e) = ws_sender.send(Message::Binary(doc.into())).await {
             eprintln!("[Sync] Failed to send initial doc: {}", e);
         }
     }
 
-    // Subscribe to broadcast channel
     let mut broadcast_rx = state.broadcast_tx.subscribe();
 
     loop {
         tokio::select! {
-            // Receive from client
             msg = ws_receiver.next() => {
                 match msg {
                     Some(Ok(Message::Binary(data))) => {
-                        // Client sent a document update - store and broadcast
+                        // Client pushed a doc update — store and rebroadcast
                         let bytes = data.to_vec();
                         *state.current_doc.write().await = Some(bytes.clone());
                         let _ = state.broadcast_tx.send(bytes);
@@ -196,7 +332,6 @@ async fn handle_connection(stream: TcpStream, addr: SocketAddr, state: RelayStat
                     _ => {}
                 }
             }
-            // Receive broadcasts to send to this client
             broadcast = broadcast_rx.recv() => {
                 if let Ok(doc) = broadcast {
                     if let Err(e) = ws_sender.send(Message::Binary(doc.into())).await {
@@ -218,7 +353,6 @@ async fn handle_connection(stream: TcpStream, addr: SocketAddr, state: RelayStat
     }
 }
 
-/// Start the sync relay server
 async fn start_sync_relay(state: RelayState, app: tauri::AppHandle) {
     let addr = format!("0.0.0.0:{}", state.port);
 
@@ -239,17 +373,21 @@ async fn start_sync_relay(state: RelayState, app: tauri::AppHandle) {
     }
 }
 
+// ---------------------------------------------------------------------------
+// App entry point
+// ---------------------------------------------------------------------------
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    // Create broadcast channel for sync
     let (broadcast_tx, _) = broadcast::channel::<Vec<u8>>(16);
 
-    // Create sync relay state
     let relay_state = Arc::new(SyncRelayState {
         port: 8765,
         broadcast_tx,
         current_doc: RwLock::new(None),
         client_count: RwLock::new(0),
+        // Populated from disk in .setup() before the relay starts accepting connections.
+        pairing_token: StdRwLock::new(String::new()),
     });
 
     let relay_state_clone = relay_state.clone();
@@ -262,7 +400,6 @@ pub fn run() {
         .setup(move |app| {
             let window = app.get_webview_window("main").unwrap();
 
-            // Apply vibrancy on macOS
             #[cfg(target_os = "macos")]
             apply_vibrancy(
                 &window,
@@ -272,12 +409,21 @@ pub fn run() {
             )
             .expect("Failed to apply vibrancy");
 
-            // Build tray menu
+            // Load (or generate) the persistent pairing token before the relay
+            // starts accepting connections.
+            let data_dir = app
+                .path()
+                .app_data_dir()
+                .expect("Failed to resolve app data directory");
+            std::fs::create_dir_all(&data_dir).ok();
+            let token = load_or_create_token(&data_dir);
+            *relay_state_clone.pairing_token.write().unwrap() = token;
+
+            // Build system tray
             let show_item = MenuItem::with_id(app, "show", "Show Freed", true, None::<&str>)?;
             let quit_item = MenuItem::with_id(app, "quit", "Quit Freed", true, None::<&str>)?;
             let menu = Menu::with_items(app, &[&show_item, &quit_item])?;
 
-            // Build system tray icon
             let _tray = TrayIconBuilder::new()
                 .icon(app.default_window_icon().cloned().unwrap())
                 .menu(&menu)
@@ -295,7 +441,6 @@ pub fn run() {
                     _ => {}
                 })
                 .on_tray_icon_event(|tray, event| {
-                    // Single click on macOS shows the window
                     if let TrayIconEvent::Click {
                         button: MouseButton::Left,
                         button_state: MouseButtonState::Up,
@@ -311,7 +456,8 @@ pub fn run() {
                 })
                 .build(app)?;
 
-            // Start sync relay in background (use Tauri's async runtime, not bare tokio)
+            // Start the relay — token is already set, so new connections are
+            // immediately subject to authentication.
             let state = relay_state_clone.clone();
             let app_handle = app.handle().clone();
             tauri::async_runtime::spawn(async move {
@@ -321,7 +467,6 @@ pub fn run() {
             Ok(())
         })
         .on_window_event(|window, event| {
-            // Keep app running in background when window is closed
             if let tauri::WindowEvent::CloseRequested { api, .. } = event {
                 window.hide().unwrap();
                 api.prevent_close();
@@ -336,7 +481,8 @@ pub fn run() {
             get_sync_url,
             get_sync_client_count,
             broadcast_doc,
-            show_window
+            reset_pairing_token,
+            show_window,
         ])
         .run(tauri::generate_context!())
         .expect("error while running Freed");

--- a/packages/desktop/src/components/MobileSyncTab.tsx
+++ b/packages/desktop/src/components/MobileSyncTab.tsx
@@ -4,6 +4,10 @@
  * Displays a QR code containing the sync WebSocket URL + pairing token.
  * The QR is rendered locally (no external service) so the user's LAN IP
  * and token are never sent to a third party.
+ *
+ * For situations where QR scanning is impractical, the IP address and
+ * 43-character pairing token are shown as separate copyable fields so
+ * the user can transcribe them manually.
  */
 
 import { useState, useEffect, useCallback } from "react";
@@ -15,11 +19,33 @@ import {
   type SyncStatus,
 } from "../lib/sync";
 
+/** Parse the LAN IP from a ws://ip:port?t=token URL. */
+function parseIp(url: string): string {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return "";
+  }
+}
+
+/** Parse the 43-character pairing token from the ?t= query param. */
+function parseToken(url: string): string {
+  try {
+    return new URL(url).searchParams.get("t") ?? "";
+  } catch {
+    return "";
+  }
+}
+
 export function MobileSyncTab() {
   const [syncUrl, setSyncUrl] = useState<string>("");
   const [clientCount, setClientCount] = useState(0);
-  const [copied, setCopied] = useState(false);
   const [resetting, setResetting] = useState(false);
+
+  // Independent copy-flash state for each copyable field
+  const [copiedIp, setCopiedIp] = useState(false);
+  const [copiedToken, setCopiedToken] = useState(false);
+  const [copiedUrl, setCopiedUrl] = useState(false);
 
   useEffect(() => {
     getSyncUrl().then(setSyncUrl);
@@ -31,15 +57,16 @@ export function MobileSyncTab() {
     return unsubscribe;
   }, []);
 
-  const handleCopyUrl = async () => {
-    try {
-      await navigator.clipboard.writeText(syncUrl);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    } catch (err) {
-      console.error("Failed to copy:", err);
-    }
-  };
+  const makeCopyHandler = (text: string, setFlash: (v: boolean) => void) =>
+    async () => {
+      try {
+        await navigator.clipboard.writeText(text);
+        setFlash(true);
+        setTimeout(() => setFlash(false), 2000);
+      } catch (err) {
+        console.error("Failed to copy:", err);
+      }
+    };
 
   const handleResetPairing = useCallback(async () => {
     setResetting(true);
@@ -52,6 +79,9 @@ export function MobileSyncTab() {
       setResetting(false);
     }
   }, []);
+
+  const ip = parseIp(syncUrl);
+  const token = parseToken(syncUrl);
 
   return (
     <section id="mobile-sync-section">
@@ -82,24 +112,78 @@ export function MobileSyncTab() {
         </p>
       </div>
 
-      {/* Sync URL */}
-      <div className="mb-4">
-        <label className="block text-xs text-[#71717a] mb-2">
-          Or enter this URL manually:
-        </label>
-        <div className="flex gap-2">
-          <input
-            type="text"
-            value={syncUrl}
-            readOnly
-            className="flex-1 px-3 py-2 bg-white/5 border border-[rgba(255,255,255,0.08)] rounded-lg text-sm text-[#a1a1aa] font-mono"
-          />
-          <button
-            onClick={handleCopyUrl}
-            className="px-3 py-2 bg-[#8b5cf6]/20 text-[#8b5cf6] rounded-lg hover:bg-[#8b5cf6]/30 transition-colors text-sm font-medium"
-          >
-            {copied ? "Copied!" : "Copy"}
-          </button>
+      {/* Manual entry fields — IP and token shown separately for transcription */}
+      <div className="mb-4 p-3 bg-white/5 rounded-xl border border-[rgba(255,255,255,0.08)]">
+        <p className="text-xs font-medium text-[#71717a] uppercase tracking-wider mb-3">
+          Manual Entry
+        </p>
+
+        {/* IP address */}
+        <div className="mb-3">
+          <label className="block text-xs text-[#71717a] mb-1.5">
+            Desktop IP address
+          </label>
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={ip}
+              readOnly
+              aria-label="Desktop IP address"
+              className="flex-1 px-3 py-2 bg-white/5 border border-[rgba(255,255,255,0.08)] rounded-lg text-sm text-[#a1a1aa] font-mono tracking-wide"
+            />
+            <button
+              onClick={makeCopyHandler(ip, setCopiedIp)}
+              className="px-3 py-2 bg-[#8b5cf6]/20 text-[#8b5cf6] rounded-lg hover:bg-[#8b5cf6]/30 transition-colors text-sm font-medium min-w-[68px]"
+            >
+              {copiedIp ? "Copied!" : "Copy"}
+            </button>
+          </div>
+        </div>
+
+        {/* Pairing token */}
+        <div className="mb-3">
+          <label className="block text-xs text-[#71717a] mb-1.5">
+            Pairing token{" "}
+            <span className="text-[#52525b]">(43 characters)</span>
+          </label>
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={token}
+              readOnly
+              aria-label="Pairing token"
+              className="flex-1 px-3 py-2 bg-white/5 border border-[rgba(255,255,255,0.08)] rounded-lg text-sm text-[#a1a1aa] font-mono tracking-wide min-w-0"
+            />
+            <button
+              onClick={makeCopyHandler(token, setCopiedToken)}
+              className="px-3 py-2 bg-[#8b5cf6]/20 text-[#8b5cf6] rounded-lg hover:bg-[#8b5cf6]/30 transition-colors text-sm font-medium min-w-[68px]"
+            >
+              {copiedToken ? "Copied!" : "Copy"}
+            </button>
+          </div>
+        </div>
+
+        {/* Full URL — for power users or browser-based paste */}
+        <div>
+          <label className="block text-xs text-[#71717a] mb-1.5">
+            Full URL{" "}
+            <span className="text-[#52525b]">(IP + port + token combined)</span>
+          </label>
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={syncUrl}
+              readOnly
+              aria-label="Full sync URL"
+              className="flex-1 px-3 py-2 bg-white/5 border border-[rgba(255,255,255,0.08)] rounded-lg text-xs text-[#52525b] font-mono min-w-0"
+            />
+            <button
+              onClick={makeCopyHandler(syncUrl, setCopiedUrl)}
+              className="px-3 py-2 bg-[#8b5cf6]/20 text-[#8b5cf6] rounded-lg hover:bg-[#8b5cf6]/30 transition-colors text-sm font-medium min-w-[68px]"
+            >
+              {copiedUrl ? "Copied!" : "Copy"}
+            </button>
+          </div>
         </div>
       </div>
 
@@ -120,7 +204,8 @@ export function MobileSyncTab() {
       <div className="p-3 bg-white/5 rounded-xl border border-[rgba(255,255,255,0.08)]">
         <p className="text-xs text-[#71717a] mb-2">
           Rotate the pairing token if you suspect an unauthorized device has
-          connected. Paired phones will need to rescan the QR code.
+          connected. Paired phones will need to rescan the QR code or re-enter
+          the new token.
         </p>
         <button
           onClick={handleResetPairing}

--- a/packages/desktop/src/components/MobileSyncTab.tsx
+++ b/packages/desktop/src/components/MobileSyncTab.tsx
@@ -1,13 +1,16 @@
 /**
  * MobileSyncTab — desktop-only settings section
  *
- * Provides QR code and URL for PWA mobile sync connection.
- * Rendered as an extra section in the shared SettingsPanel.
+ * Displays a QR code containing the sync WebSocket URL + pairing token.
+ * The QR is rendered locally (no external service) so the user's LAN IP
+ * and token are never sent to a third party.
  */
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
+import QRCode from "react-qr-code";
 import {
   getSyncUrl,
+  resetPairingToken,
   onStatusChange,
   type SyncStatus,
 } from "../lib/sync";
@@ -16,6 +19,7 @@ export function MobileSyncTab() {
   const [syncUrl, setSyncUrl] = useState<string>("");
   const [clientCount, setClientCount] = useState(0);
   const [copied, setCopied] = useState(false);
+  const [resetting, setResetting] = useState(false);
 
   useEffect(() => {
     getSyncUrl().then(setSyncUrl);
@@ -37,9 +41,17 @@ export function MobileSyncTab() {
     }
   };
 
-  const qrCodeUrl = `https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${encodeURIComponent(
-    syncUrl,
-  )}&bgcolor=0a0a0a&color=fafafa`;
+  const handleResetPairing = useCallback(async () => {
+    setResetting(true);
+    try {
+      const newUrl = await resetPairingToken();
+      setSyncUrl(newUrl);
+    } catch (err) {
+      console.error("Failed to reset pairing token:", err);
+    } finally {
+      setResetting(false);
+    }
+  }, []);
 
   return (
     <section id="mobile-sync-section">
@@ -47,21 +59,24 @@ export function MobileSyncTab() {
         Mobile Sync
       </h3>
 
-      {/* QR Code */}
+      {/* QR Code — rendered locally, never sent to a third party */}
       <div className="flex flex-col items-center p-4 bg-white/5 rounded-xl border border-[rgba(255,255,255,0.08)] mb-4">
         <p className="text-xs text-[#71717a] mb-3">
           Scan with your phone to connect Freed PWA
         </p>
         {syncUrl && (
-          <img
-            src={qrCodeUrl}
-            alt="Sync QR Code"
-            className="w-40 h-40 rounded-lg"
-          />
+          <div className="p-3 bg-white rounded-lg">
+            <QRCode
+              value={syncUrl}
+              size={160}
+              bgColor="#ffffff"
+              fgColor="#0a0a0a"
+            />
+          </div>
         )}
         <p className="text-xs text-[#71717a] mt-3 text-center">
-          Open <span className="text-[#8b5cf6]">freed.wtf/app</span> on
-          your phone,
+          Open <span className="text-[#8b5cf6]">freed.wtf/app</span> on your
+          phone,
           <br />
           then scan this QR code
         </p>
@@ -89,7 +104,7 @@ export function MobileSyncTab() {
       </div>
 
       {/* Connected Devices */}
-      <div className="flex items-center justify-between p-3 bg-white/5 rounded-xl">
+      <div className="flex items-center justify-between p-3 bg-white/5 rounded-xl mb-4">
         <div className="flex items-center gap-2">
           <span
             className={`sync-dot ${
@@ -98,9 +113,22 @@ export function MobileSyncTab() {
           />
           <span className="text-sm">Connected devices</span>
         </div>
-        <span className="text-sm font-medium text-[#a1a1aa]">
-          {clientCount}
-        </span>
+        <span className="text-sm font-medium text-[#a1a1aa]">{clientCount}</span>
+      </div>
+
+      {/* Reset Pairing */}
+      <div className="p-3 bg-white/5 rounded-xl border border-[rgba(255,255,255,0.08)]">
+        <p className="text-xs text-[#71717a] mb-2">
+          Rotate the pairing token if you suspect an unauthorized device has
+          connected. Paired phones will need to rescan the QR code.
+        </p>
+        <button
+          onClick={handleResetPairing}
+          disabled={resetting}
+          className="w-full px-3 py-2 bg-red-500/10 text-red-400 border border-red-500/20 rounded-lg hover:bg-red-500/20 transition-colors text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {resetting ? "Rotating…" : "Reset Pairing Token"}
+        </button>
       </div>
     </section>
   );

--- a/packages/desktop/src/lib/sync.ts
+++ b/packages/desktop/src/lib/sync.ts
@@ -37,15 +37,32 @@ export async function getLocalIP(): Promise<string> {
 }
 
 /**
- * Get the sync relay URL for PWA to connect to
+ * Get the sync relay URL for PWA to connect to.
+ * The returned URL includes the pairing token as `?t=<token>`.
  */
 export async function getSyncUrl(): Promise<string> {
   try {
     return await invoke<string>("get_sync_url");
   } catch {
     const ip = await getLocalIP();
+    // Fallback lacks a token — any connection using this URL will be
+    // rejected by the relay, which is correct (pairing requires a QR scan).
     return `ws://${ip}:8765`;
   }
+}
+
+/**
+ * Rotate the pairing token.
+ *
+ * The new token is persisted to disk and takes effect immediately for new
+ * connections. Devices that are currently connected remain unaffected until
+ * they disconnect. Paired phones must rescan the QR code after a reset.
+ *
+ * Returns the new sync URL (including the rotated token).
+ */
+export async function resetPairingToken(): Promise<string> {
+  await invoke("reset_pairing_token");
+  return getSyncUrl();
 }
 
 /**

--- a/packages/pwa/src/components/SyncConnectDialog.tsx
+++ b/packages/pwa/src/components/SyncConnectDialog.tsx
@@ -6,6 +6,18 @@ import { BottomSheet } from "./BottomSheet";
 const CONNECT_TIMEOUT_MS = 5000;
 
 /**
+ * Returns true if the given WebSocket URL includes a `?t=` pairing token.
+ * URLs without a token will be rejected by the relay with HTTP 401.
+ */
+function hasTokenParam(url: string): boolean {
+  try {
+    return new URL(url).searchParams.has("t");
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Returns a promise that resolves when the sync WebSocket connects,
  * or rejects after a timeout.
  */
@@ -107,6 +119,16 @@ export function SyncConnectDialog({ open, onClose }: SyncConnectDialogProps) {
 
         const detected = detectQrCode(videoRef.current);
         if (detected && (detected.startsWith("ws://") || detected.startsWith("wss://"))) {
+          // Reject QR codes from older desktop versions that lack a pairing token.
+          if (!hasTokenParam(detected)) {
+            stopCamera();
+            setError(
+              "This QR code has no pairing token. Please update your desktop app and rescan.",
+            );
+            setMode("manual");
+            return;
+          }
+
           stopCamera();
           storeRelayUrl(detected);
           connect(detected);
@@ -156,6 +178,11 @@ export function SyncConnectDialog({ open, onClose }: SyncConnectDialogProps) {
       const parsed = new URL(url.trim());
       if (parsed.protocol !== "ws:" && parsed.protocol !== "wss:") {
         throw new Error("URL must start with ws:// or wss://");
+      }
+      if (!parsed.searchParams.has("t")) {
+        throw new Error(
+          "URL is missing the pairing token (?t=…). Copy the full URL from the desktop app.",
+        );
       }
     } catch (e) {
       setError(e instanceof Error ? e.message : "Invalid URL format");
@@ -269,7 +296,7 @@ export function SyncConnectDialog({ open, onClose }: SyncConnectDialogProps) {
             type="url"
             value={url}
             onChange={(e) => setUrl(e.target.value)}
-            placeholder="ws://192.168.1.x:8765"
+            placeholder="ws://192.168.1.x:8765?t=…"
             className="w-full px-4 py-3 bg-white/5 border border-[rgba(255,255,255,0.08)] rounded-xl focus:outline-none focus:border-[#8b5cf6] text-white placeholder-[#71717a] font-mono text-sm transition-colors"
             disabled={connecting}
             autoFocus

--- a/packages/pwa/src/components/SyncConnectDialog.tsx
+++ b/packages/pwa/src/components/SyncConnectDialog.tsx
@@ -66,9 +66,15 @@ function detectQrCode(video: HTMLVideoElement): string | null {
   return result?.data ?? null;
 }
 
+/** Validate a base64url token — exactly 43 chars, URL-safe alphabet only. */
+function isValidToken(t: string): boolean {
+  return t.length === 43 && /^[A-Za-z0-9_-]+$/.test(t);
+}
+
 export function SyncConnectDialog({ open, onClose }: SyncConnectDialogProps) {
   const [mode, setMode] = useState<Mode>("manual");
-  const [url, setUrl] = useState("");
+  const [ip, setIp] = useState("");
+  const [token, setToken] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [connecting, setConnecting] = useState(false);
   const [scanStatus, setScanStatus] = useState<"waiting" | "found">("waiting");
@@ -93,7 +99,8 @@ export function SyncConnectDialog({ open, onClose }: SyncConnectDialogProps) {
   const handleClose = useCallback(() => {
     stopCamera();
     setMode("manual");
-    setUrl("");
+    setIp("");
+    setToken("");
     setError(null);
     setScanStatus("waiting");
     onClose();
@@ -172,29 +179,32 @@ export function SyncConnectDialog({ open, onClose }: SyncConnectDialogProps) {
   }, [open, stopCamera]);
 
   const handleConnect = async () => {
-    if (!url.trim()) return;
+    const trimmedIp = ip.trim();
+    const trimmedToken = token.trim();
 
-    try {
-      const parsed = new URL(url.trim());
-      if (parsed.protocol !== "ws:" && parsed.protocol !== "wss:") {
-        throw new Error("URL must start with ws:// or wss://");
-      }
-      if (!parsed.searchParams.has("t")) {
-        throw new Error(
-          "URL is missing the pairing token (?t=…). Copy the full URL from the desktop app.",
-        );
-      }
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Invalid URL format");
+    if (!trimmedIp) {
+      setError("Enter the desktop IP address shown in the Freed desktop app.");
       return;
     }
+    if (!isValidToken(trimmedToken)) {
+      setError(
+        trimmedToken.length === 0
+          ? "Enter the 43-character pairing token shown in the Freed desktop app."
+          : `Token must be exactly 43 characters (${trimmedToken.length} entered).`,
+      );
+      return;
+    }
+
+    // Construct the full WebSocket URL — user never has to type the protocol,
+    // port, or query key themselves.
+    const relayUrl = `ws://${trimmedIp}:8765?t=${trimmedToken}`;
 
     setError(null);
     setConnecting(true);
 
     try {
-      storeRelayUrl(url.trim());
-      connect(url.trim());
+      storeRelayUrl(relayUrl);
+      connect(relayUrl);
       await waitForConnection();
       handleClose();
     } catch (e) {
@@ -209,7 +219,7 @@ export function SyncConnectDialog({ open, onClose }: SyncConnectDialogProps) {
       <p className="text-sm text-[#71717a] mb-5">
         {mode === "scanning"
           ? "Point your camera at the QR code shown in the Freed desktop app."
-          : "Enter the sync URL from your Freed desktop app, or scan the QR code."}
+          : "Enter your desktop's IP address and pairing token, or scan the QR code."}
       </p>
 
       {/* Mode tabs */}
@@ -286,24 +296,64 @@ export function SyncConnectDialog({ open, onClose }: SyncConnectDialogProps) {
           </p>
         </div>
       ) : (
-        /* Manual URL entry */
-        <div className="mb-4">
-          <label htmlFor="sync-url" className="block text-sm text-[#a1a1aa] mb-2">
-            Sync URL
-          </label>
-          <input
-            id="sync-url"
-            type="url"
-            value={url}
-            onChange={(e) => setUrl(e.target.value)}
-            placeholder="ws://192.168.1.x:8765?t=…"
-            className="w-full px-4 py-3 bg-white/5 border border-[rgba(255,255,255,0.08)] rounded-xl focus:outline-none focus:border-[#8b5cf6] text-white placeholder-[#71717a] font-mono text-sm transition-colors"
-            disabled={connecting}
-            autoFocus
-            onKeyDown={(e) => e.key === "Enter" && handleConnect()}
-          />
-          <p className="mt-2 text-xs text-[#71717a]">
-            Find this in your desktop app: Settings &rarr; Mobile Sync
+        /* Manual entry — structured IP + token fields */
+        <div className="mb-4 space-y-4">
+          {/* IP address */}
+          <div>
+            <label
+              htmlFor="sync-ip"
+              className="block text-sm text-[#a1a1aa] mb-2"
+            >
+              Desktop IP address
+            </label>
+            <input
+              id="sync-ip"
+              type="text"
+              inputMode="decimal"
+              value={ip}
+              onChange={(e) => setIp(e.target.value)}
+              placeholder="192.168.1.x"
+              className="w-full px-4 py-3 bg-white/5 border border-[rgba(255,255,255,0.08)] rounded-xl focus:outline-none focus:border-[#8b5cf6] text-white placeholder-[#71717a] font-mono text-sm transition-colors"
+              disabled={connecting}
+              autoFocus
+              onKeyDown={(e) => e.key === "Enter" && handleConnect()}
+            />
+          </div>
+
+          {/* Pairing token */}
+          <div>
+            <label
+              htmlFor="sync-token"
+              className="block text-sm text-[#a1a1aa] mb-2"
+            >
+              Pairing token{" "}
+              <span className="text-[#52525b] text-xs">(43 characters)</span>
+            </label>
+            <input
+              id="sync-token"
+              type="text"
+              value={token}
+              onChange={(e) => setToken(e.target.value.trim())}
+              placeholder="43-character token from desktop app"
+              maxLength={43}
+              className="w-full px-4 py-3 bg-white/5 border border-[rgba(255,255,255,0.08)] rounded-xl focus:outline-none focus:border-[#8b5cf6] text-white placeholder-[#71717a] font-mono text-xs tracking-wide transition-colors"
+              disabled={connecting}
+              onKeyDown={(e) => e.key === "Enter" && handleConnect()}
+            />
+            {token.length > 0 && (
+              <p
+                className={`mt-1 text-xs ${
+                  token.length === 43 ? "text-green-500" : "text-[#71717a]"
+                }`}
+              >
+                {token.length}/43 characters
+              </p>
+            )}
+          </div>
+
+          <p className="text-xs text-[#71717a]">
+            Find these in your desktop app: Settings &rarr; Mobile Sync &rarr;
+            Manual Entry
           </p>
         </div>
       )}
@@ -319,7 +369,7 @@ export function SyncConnectDialog({ open, onClose }: SyncConnectDialogProps) {
           <button
             onClick={handleConnect}
             className="btn-primary px-6 py-2.5 disabled:opacity-50"
-            disabled={connecting || !url.trim()}
+            disabled={connecting || !ip.trim() || token.length === 0}
           >
             {connecting ? "Connecting..." : "Connect"}
           </button>


### PR DESCRIPTION
(AI Generated)

## Summary

- Relay now rejects any WebSocket connection that doesn't present a valid `?t=<token>` in the upgrade URI — so only devices that physically scanned the QR code can ever receive Automerge data
- QR code rendered locally via `react-qr-code` (SVG, zero external calls) — previously used `api.qrserver.com` which meant the user's LAN IP and token left the device on every render
- \"Reset Pairing Token\" button rotates the 256-bit secret and persists it; existing connections are unaffected, new devices must rescan

## How it works

1. On first launch, Rust generates 32 random bytes → base64url → written to `<app-data-dir>/pairing-token`
2. `get_sync_url` now returns `ws://ip:8765?t=<token>` — this is what goes in the QR code
3. Every new TCP connection hits `accept_hdr_async`; the callback extracts `?t=`, compares against the stored token, and returns HTTP 401 if it doesn't match — the WebSocket handshake never completes for unauthorized callers
4. PWA `SyncConnectDialog` validates that scanned/typed URLs include `?t=` before attempting connection, surfacing a clear error for older desktop versions

## Test plan

- [ ] Fresh install: QR appears, mobile scans, connects successfully
- [ ] Another device on LAN without the token: cannot connect (relay returns 401)
- [ ] Reset pairing: new QR appears, old phone cannot reconnect until it rescans
- [ ] Old stored URL in PWA localStorage (no `?t=`): gracefully fails to connect; user prompted to rescan
- [ ] `cargo check` (with `dist/` present): compiles clean

Made with [Cursor](https://cursor.com)