### PR TITLE
feat(debug): comprehensive sync debug mode + QR connection diagnostics

### DIFF
--- a/.cursor/worktrees.json
+++ b/.cursor/worktrees.json
@@ -1,0 +1,5 @@
+{
+  "setup-worktree": [
+    "npm install"
+  ]
+}

--- a/docs/PHASE-5-DESKTOP.md
+++ b/docs/PHASE-5-DESKTOP.md
@@ -13,7 +13,7 @@ The universal liberation tool. Anyone can install this and escape algorithmic ma
 **Key architectural decisions:**
 
 - **TypeScript capture via subprocess** — Existing `capture-x`, `capture-rss` packages run via Node/Bun subprocess, not rewritten in Rust
-- **Shared React codebase** — `packages/pwa/` is embedded in WebView AND deployed standalone to freed.wtf/app
+- **Shared React codebase** — `packages/pwa/` is embedded in WebView AND deployed standalone to app.freed.wtf
 - **X authentication via WebView** — User logs into X inside the app; cookies captured from WebView session
 - **Ranking runs here** — Desktop computes `priority` scores, syncs to PWA via Automerge
 - **Tauri 2.0 for mobile** — Same codebase targets iOS and Android via Tauri's mobile support

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -158,6 +158,31 @@ fn get_local_ip() -> Result<String, String> {
         .map_err(|e| e.to_string())
 }
 
+/// Get all non-loopback IPv4 addresses with their interface names.
+/// Useful for diagnosing cases where the primary IP is a VPN tunnel
+/// rather than the Wi-Fi interface the phone is connected to.
+#[tauri::command]
+fn get_all_local_ips() -> Vec<serde_json::Value> {
+    let port = 8765u16;
+    match local_ip_address::list_afinet_netifas() {
+        Ok(ifaces) => ifaces
+            .into_iter()
+            .filter(|(_, ip)| {
+                // IPv4 only, skip loopback
+                matches!(ip, std::net::IpAddr::V4(v4) if !v4.is_loopback())
+            })
+            .map(|(name, ip)| {
+                serde_json::json!({
+                    "interface": name,
+                    "ip": ip.to_string(),
+                    "url": format!("ws://{}:{}", ip, port),
+                })
+            })
+            .collect(),
+        Err(_) => vec![],
+    }
+}
+
 /// Returns the full WebSocket pairing URL including the auth token.
 ///
 /// Format: `ws://<lan-ip>:<port>?t=<base64url-token>`
@@ -478,6 +503,7 @@ pub fn run() {
             fetch_url,
             x_api_request,
             get_local_ip,
+            get_all_local_ips,
             get_sync_url,
             get_sync_client_count,
             broadcast_doc,

--- a/packages/desktop/src/components/MobileSyncTab.tsx
+++ b/packages/desktop/src/components/MobileSyncTab.tsx
@@ -8,15 +8,20 @@
  * For situations where QR scanning is impractical, the IP address and
  * 43-character pairing token are shown as separate copyable fields so
  * the user can transcribe them manually.
+ *
+ * If a VPN or multiple network interfaces are detected, an interface
+ * picker lets the user regenerate the QR with the correct IP.
  */
 
 import { useState, useEffect, useCallback } from "react";
 import QRCode from "react-qr-code";
 import {
   getSyncUrl,
+  getAllLocalIPs,
   resetPairingToken,
   onStatusChange,
   type SyncStatus,
+  type NetworkInterface,
 } from "../lib/sync";
 
 /** Parse the LAN IP from a ws://ip:port?t=token URL. */
@@ -37,10 +42,24 @@ function parseToken(url: string): string {
   }
 }
 
+/** Heuristic: does this interface look like a VPN tunnel? */
+function looksLikeVpn(iface: NetworkInterface): boolean {
+  const name = iface.interface.toLowerCase();
+  return (
+    name.startsWith("utun") ||
+    name.startsWith("tun") ||
+    name.startsWith("tap") ||
+    name.startsWith("wg") || // WireGuard
+    name.startsWith("ppp")
+  );
+}
+
 export function MobileSyncTab() {
   const [syncUrl, setSyncUrl] = useState<string>("");
   const [clientCount, setClientCount] = useState(0);
   const [resetting, setResetting] = useState(false);
+  const [allIPs, setAllIPs] = useState<NetworkInterface[]>([]);
+  const [showIPPicker, setShowIPPicker] = useState(false);
 
   // Independent copy-flash state for each copyable field
   const [copiedIp, setCopiedIp] = useState(false);
@@ -49,6 +68,7 @@ export function MobileSyncTab() {
 
   useEffect(() => {
     getSyncUrl().then(setSyncUrl);
+    getAllLocalIPs().then(setAllIPs);
 
     const unsubscribe = onStatusChange((status: SyncStatus) => {
       setClientCount(status.clientCount);
@@ -56,6 +76,9 @@ export function MobileSyncTab() {
 
     return unsubscribe;
   }, []);
+
+  const hasVpn = allIPs.some(looksLikeVpn);
+  const multipleIPs = allIPs.length > 1;
 
   const makeCopyHandler = (text: string, setFlash: (v: boolean) => void) =>
     async () => {
@@ -79,6 +102,20 @@ export function MobileSyncTab() {
       setResetting(false);
     }
   }, []);
+
+  /** Switch to a different interface IP while preserving the port and token. */
+  const handleSelectInterface = (iface: NetworkInterface) => {
+    if (!syncUrl) return;
+    try {
+      const current = new URL(syncUrl);
+      current.hostname = iface.ip;
+      setSyncUrl(current.toString());
+    } catch {
+      // Fallback: use the raw url from the interface (no token)
+      setSyncUrl(iface.url);
+    }
+    setShowIPPicker(false);
+  };
 
   const ip = parseIp(syncUrl);
   const token = parseToken(syncUrl);
@@ -105,12 +142,54 @@ export function MobileSyncTab() {
           </div>
         )}
         <p className="text-xs text-[#71717a] mt-3 text-center">
-          Open <span className="text-[#8b5cf6]">freed.wtf/app</span> on your
+          Open <span className="text-[#8b5cf6]">app.freed.wtf</span> on your
           phone,
           <br />
           then scan this QR code
         </p>
       </div>
+
+      {/* VPN / multi-interface warning with IP picker */}
+      {(hasVpn || multipleIPs) && (
+        <div className="mb-4 p-3 bg-orange-500/10 border border-orange-500/30 rounded-xl">
+          <p className="text-xs font-semibold text-orange-400 mb-1">
+            {hasVpn ? "VPN detected" : "Multiple network interfaces"}
+          </p>
+          <p className="text-xs text-orange-300/80 mb-2">
+            {hasVpn
+              ? "A VPN may encode the wrong IP in the QR code. If your phone can't connect, pick the correct interface below."
+              : "Multiple network adapters found. If the QR code doesn't work, try a different IP."}
+          </p>
+          <button
+            onClick={() => setShowIPPicker((v) => !v)}
+            className="text-xs text-orange-400 hover:text-orange-300 transition-colors"
+          >
+            {showIPPicker ? "Hide interfaces ↑" : "Show all interfaces ↓"}
+          </button>
+
+          {showIPPicker && (
+            <div className="mt-2 space-y-1.5">
+              {allIPs.map((iface) => (
+                <button
+                  key={iface.url}
+                  onClick={() => handleSelectInterface(iface)}
+                  className={`w-full flex items-center justify-between px-3 py-2 rounded-lg text-xs transition-colors border ${
+                    ip === iface.ip
+                      ? "bg-[#8b5cf6]/20 border-[#8b5cf6]/30 text-[#8b5cf6]"
+                      : "bg-white/5 border-transparent text-[#a1a1aa] hover:bg-white/10"
+                  }`}
+                >
+                  <span className="font-mono">{iface.ip}</span>
+                  <span className="text-[#52525b] ml-2">
+                    {iface.interface}
+                    {looksLikeVpn(iface) && " (VPN)"}
+                  </span>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
 
       {/* Manual entry fields — IP and token shown separately for transcription */}
       <div className="mb-4 p-3 bg-white/5 rounded-xl border border-[rgba(255,255,255,0.08)]">

--- a/packages/desktop/src/lib/automerge.ts
+++ b/packages/desktop/src/lib/automerge.ts
@@ -22,6 +22,7 @@ import {
   updateLastSync,
 } from "@freed/shared/schema";
 import type { FeedItem, RssFeed, UserPreferences } from "@freed/shared";
+import { addDebugEvent, setDocSnapshot, registerDocAccessors } from "@freed/ui/lib/debug-store";
 
 // Singleton storage instance
 const storage = new IndexedDBStorage();
@@ -32,6 +33,19 @@ let currentDoc: FreedDoc | null = null;
 // Subscribers for document changes
 type Subscriber = (doc: FreedDoc) => void;
 const subscribers = new Set<Subscriber>();
+
+/** Snapshot current doc stats into the debug store */
+function snapshotDoc(): void {
+  if (!currentDoc) return;
+  const binary = A.save(currentDoc);
+  setDocSnapshot({
+    deviceId: (currentDoc.meta?.deviceId as string | undefined) ?? "unknown",
+    itemCount: Object.keys(currentDoc.feedItems ?? {}).length,
+    feedCount: Object.keys(currentDoc.rssFeeds ?? {}).length,
+    binarySize: binary.byteLength,
+    savedAt: Date.now(),
+  });
+}
 
 /**
  * Initialize or load the Automerge document
@@ -45,6 +59,16 @@ export async function initDoc(): Promise<FreedDoc> {
     currentDoc = createEmptyDoc();
     await saveDoc();
   }
+
+  const deviceId = (currentDoc.meta?.deviceId as string | undefined) ?? "unknown";
+  addDebugEvent("init", `device ...${deviceId.slice(-8)}`);
+  snapshotDoc();
+
+  registerDocAccessors(
+    () => currentDoc,
+    () => JSON.stringify(A.toJS(currentDoc!), null, 2),
+    () => A.save(currentDoc!),
+  );
 
   return currentDoc;
 }
@@ -94,6 +118,8 @@ async function applyChange(
 
   currentDoc = A.change(currentDoc, message || "update", changeFn);
   await saveDoc();
+  addDebugEvent("change", message);
+  snapshotDoc();
 
   // Notify subscribers
   for (const subscriber of subscribers) {
@@ -319,9 +345,20 @@ export async function mergeDoc(incoming: Uint8Array): Promise<FreedDoc> {
     throw new Error("Document not initialized");
   }
 
-  const incomingDoc = A.load<FreedDoc>(incoming);
-  currentDoc = A.merge(currentDoc, incomingDoc);
-  await saveDoc();
+  try {
+    const beforeCount = Object.keys(currentDoc.feedItems ?? {}).length;
+    const incomingDoc = A.load<FreedDoc>(incoming);
+    currentDoc = A.merge(currentDoc, incomingDoc);
+    await saveDoc();
+
+    const afterCount = Object.keys(currentDoc.feedItems ?? {}).length;
+    const delta = afterCount - beforeCount;
+    addDebugEvent("merge_ok", delta !== 0 ? `${delta > 0 ? "+" : ""}${delta} items` : "no new items", incoming.byteLength);
+    snapshotDoc();
+  } catch (err) {
+    addDebugEvent("merge_err", err instanceof Error ? err.message : String(err));
+    throw err;
+  }
 
   // Notify subscribers
   for (const subscriber of subscribers) {

--- a/packages/desktop/src/lib/sync.ts
+++ b/packages/desktop/src/lib/sync.ts
@@ -36,6 +36,24 @@ export async function getLocalIP(): Promise<string> {
   }
 }
 
+export interface NetworkInterface {
+  interface: string;
+  ip: string;
+  url: string;
+}
+
+/**
+ * Get all non-loopback IPv4 network interfaces with sync URLs.
+ * Use this to let the user pick the right IP when a VPN is active.
+ */
+export async function getAllLocalIPs(): Promise<NetworkInterface[]> {
+  try {
+    return await invoke<NetworkInterface[]>("get_all_local_ips");
+  } catch {
+    return [];
+  }
+}
+
 /**
  * Get the sync relay URL for PWA to connect to.
  * The returned URL includes the pairing token as `?t=<token>`.

--- a/packages/pwa/src/components/SyncConnectDialog.tsx
+++ b/packages/pwa/src/components/SyncConnectDialog.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect, useCallback } from "react";
 import jsQR from "jsqr";
 import { connect, storeRelayUrl, onStatusChange } from "../lib/sync";
 import { BottomSheet } from "@freed/ui/components/BottomSheet";
+import { addDebugEvent } from "@freed/ui/lib/debug-store";
 
 const CONNECT_TIMEOUT_MS = 5000;
 
@@ -25,7 +26,11 @@ function waitForConnection(): Promise<void> {
   return new Promise((resolve, reject) => {
     const timer = setTimeout(() => {
       unsubscribe();
-      reject(new Error("Connection timed out. Check that the desktop app is running and on the same network."));
+      reject(
+        new Error(
+          "Connection timed out. Check that the desktop app is running and on the same network.",
+        ),
+      );
     }, CONNECT_TIMEOUT_MS);
 
     const unsubscribe = onStatusChange((connected) => {
@@ -44,6 +49,11 @@ interface SyncConnectDialogProps {
 }
 
 type Mode = "manual" | "scanning";
+
+/** True when the page protocol makes ws:// connections likely to be blocked */
+function isMixedContentRisk(wsUrl: string): boolean {
+  return window.location.protocol === "https:" && wsUrl.startsWith("ws://");
+}
 
 /**
  * Decode a QR code from a video frame via an offscreen canvas + jsQR.
@@ -78,6 +88,9 @@ export function SyncConnectDialog({ open, onClose }: SyncConnectDialogProps) {
   const [error, setError] = useState<string | null>(null);
   const [connecting, setConnecting] = useState(false);
   const [scanStatus, setScanStatus] = useState<"waiting" | "found">("waiting");
+  const [scanFrameCount, setScanFrameCount] = useState(0);
+  const [videoResolution, setVideoResolution] = useState<string | null>(null);
+  const [lastQrContent, setLastQrContent] = useState<string | null>(null);
 
   const videoRef = useRef<HTMLVideoElement>(null);
   const streamRef = useRef<MediaStream | null>(null);
@@ -103,12 +116,18 @@ export function SyncConnectDialog({ open, onClose }: SyncConnectDialogProps) {
     setToken("");
     setError(null);
     setScanStatus("waiting");
+    setScanFrameCount(0);
+    setVideoResolution(null);
+    setLastQrContent(null);
     onClose();
   }, [stopCamera, onClose]);
 
   const startCamera = useCallback(async () => {
     setError(null);
     setScanStatus("waiting");
+    setScanFrameCount(0);
+    setVideoResolution(null);
+    setLastQrContent(null);
 
     try {
       const stream = await navigator.mediaDevices.getUserMedia({
@@ -121,44 +140,73 @@ export function SyncConnectDialog({ open, onClose }: SyncConnectDialogProps) {
         await videoRef.current.play();
       }
 
+      // Capture resolution once video metadata is available
+      const vid = videoRef.current;
+      if (vid) {
+        const onMeta = () => {
+          setVideoResolution(`${vid.videoWidth}×${vid.videoHeight}`);
+        };
+        vid.addEventListener("loadedmetadata", onMeta, { once: true });
+      }
+
+      addDebugEvent("camera_started", stream.getVideoTracks()[0]?.label ?? "unknown track");
+
       scanIntervalRef.current = setInterval(() => {
         if (!videoRef.current || videoRef.current.readyState < 2) return;
 
+        setScanFrameCount((n) => n + 1);
+
+        // Capture resolution on first good frame if not yet set
+        if (videoRef.current.videoWidth && videoRef.current.videoHeight) {
+          setVideoResolution(
+            `${videoRef.current.videoWidth}×${videoRef.current.videoHeight}`,
+          );
+        }
+
         const detected = detectQrCode(videoRef.current);
-        if (detected && (detected.startsWith("ws://") || detected.startsWith("wss://"))) {
-          // Reject QR codes from older desktop versions that lack a pairing token.
-          if (!hasTokenParam(detected)) {
-            stopCamera();
-            setError(
-              "This QR code has no pairing token. Please update your desktop app and rescan.",
-            );
-            setMode("manual");
-            return;
-          }
 
-          stopCamera();
-          storeRelayUrl(detected);
-          connect(detected);
+        if (detected) {
+          setLastQrContent(detected);
 
-          waitForConnection()
-            .then(() => {
-              setScanStatus("found");
-              setTimeout(() => handleClose(), 800);
-            })
-            .catch((err) => {
-              setError(err instanceof Error ? err.message : "Connection failed");
+          if (detected.startsWith("ws://") || detected.startsWith("wss://")) {
+            // Reject QR codes from older desktop versions that lack a pairing token.
+            if (!hasTokenParam(detected)) {
+              stopCamera();
+              setError(
+                "This QR code has no pairing token. Please update your desktop app and rescan.",
+              );
               setMode("manual");
-            });
+              return;
+            }
+
+            addDebugEvent("qr_decoded", detected);
+            stopCamera();
+            storeRelayUrl(detected);
+            connect(detected);
+
+            waitForConnection()
+              .then(() => {
+                setScanStatus("found");
+                setTimeout(() => handleClose(), 800);
+              })
+              .catch((err) => {
+                addDebugEvent("connect_timeout", detected);
+                setError(err instanceof Error ? err.message : "Connection failed");
+                setMode("manual");
+              });
+          }
+          // Non-ws QR codes: content shown in the diagnostic line below viewfinder
         }
       }, 250);
     } catch (e) {
-      setError(
+      const msg =
         e instanceof Error
           ? e.message.includes("NotAllowed")
             ? "Camera permission denied. Please allow camera access and try again."
             : e.message
-          : "Could not access camera.",
-      );
+          : "Could not access camera.";
+      addDebugEvent("camera_denied", msg);
+      setError(msg);
       setMode("manual");
     }
   }, [stopCamera, handleClose]);
@@ -201,6 +249,12 @@ export function SyncConnectDialog({ open, onClose }: SyncConnectDialogProps) {
 
     setError(null);
     setConnecting(true);
+    addDebugEvent("connect_attempt", relayUrl);
+
+    // Warn about mixed content — the connection will likely be blocked by the browser.
+    if (isMixedContentRisk(relayUrl)) {
+      addDebugEvent("mixed_content_warn", relayUrl);
+    }
 
     try {
       storeRelayUrl(relayUrl);
@@ -208,14 +262,40 @@ export function SyncConnectDialog({ open, onClose }: SyncConnectDialogProps) {
       await waitForConnection();
       handleClose();
     } catch (e) {
+      addDebugEvent("connect_timeout", relayUrl);
       setError(e instanceof Error ? e.message : "Failed to connect");
     } finally {
       setConnecting(false);
     }
   };
 
+  // Derive the constructed URL for display and HTTPS warning
+  const constructedUrl = ip.trim()
+    ? `ws://${ip.trim()}:8765${token.trim() ? `?t=${token.trim()}` : ""}`
+    : "";
+  const mixedContentRisk =
+    typeof window !== "undefined" &&
+    window.location.protocol === "https:" &&
+    (constructedUrl.startsWith("ws://") ||
+      (mode === "scanning" && lastQrContent?.startsWith("ws://")));
+
   return (
     <BottomSheet open={open} onClose={handleClose} title="Connect to Desktop">
+      {/* HTTPS mixed-content warning — the #1 reason sync fails on iPhone */}
+      {mixedContentRisk && (
+        <div className="mb-4 p-3 bg-orange-500/15 border border-orange-500/40 rounded-xl">
+          <p className="text-xs font-semibold text-orange-400 mb-1">
+            HTTPS → ws:// Connection Blocked
+          </p>
+          <p className="text-xs text-orange-300/80">
+            Safari and Chrome block plain{" "}
+            <code className="font-mono">ws://</code> connections from HTTPS
+            pages. This is why sync likely fails on iPhone even when the desktop
+            is running. Use the desktop app directly, or open the app over HTTP.
+          </p>
+        </div>
+      )}
+
       <p className="text-sm text-[#71717a] mb-5">
         {mode === "scanning"
           ? "Point your camera at the QR code shown in the Freed desktop app."
@@ -225,7 +305,11 @@ export function SyncConnectDialog({ open, onClose }: SyncConnectDialogProps) {
       {/* Mode tabs */}
       <div className="flex gap-2 mb-5">
         <button
-          onClick={() => { setMode("manual"); stopCamera(); setError(null); }}
+          onClick={() => {
+            setMode("manual");
+            stopCamera();
+            setError(null);
+          }}
           className={`flex-1 py-2 rounded-lg text-sm font-medium transition-colors ${
             mode === "manual"
               ? "bg-[#8b5cf6]/20 text-[#8b5cf6] border border-[#8b5cf6]/30"
@@ -265,9 +349,7 @@ export function SyncConnectDialog({ open, onClose }: SyncConnectDialogProps) {
             <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
               <div
                 className={`w-48 h-48 border-2 rounded-2xl transition-colors ${
-                  scanStatus === "found"
-                    ? "border-green-400"
-                    : "border-white/40"
+                  scanStatus === "found" ? "border-green-400" : "border-white/40"
                 }`}
               >
                 <div className="absolute top-0 left-0 w-6 h-6 border-t-2 border-l-2 border-[#8b5cf6] rounded-tl-lg" />
@@ -281,18 +363,51 @@ export function SyncConnectDialog({ open, onClose }: SyncConnectDialogProps) {
               <div className="absolute inset-0 flex items-center justify-center bg-black/40">
                 <div className="flex flex-col items-center gap-2">
                   <div className="w-12 h-12 rounded-full bg-green-500/20 border-2 border-green-400 flex items-center justify-center">
-                    <svg className="w-6 h-6 text-green-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                    <svg
+                      className="w-6 h-6 text-green-400"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M5 13l4 4L19 7"
+                      />
                     </svg>
                   </div>
-                  <p className="text-green-400 text-sm font-medium">Connecting...</p>
+                  <p className="text-green-400 text-sm font-medium">
+                    Connecting...
+                  </p>
                 </div>
               </div>
             )}
           </div>
 
-          <p className="text-xs text-[#71717a] text-center mt-3">
-            Open the desktop app &rarr; Settings &rarr; Mobile Sync to see the QR code
+          {/* Live scan diagnostics */}
+          <div className="mt-3 flex items-center justify-between text-[10px] text-[#52525b] font-mono">
+            <span>
+              {videoResolution
+                ? `Camera ${videoResolution}`
+                : "Camera initialising..."}
+              {scanFrameCount > 0 && ` · Frame ${scanFrameCount}`}
+            </span>
+            {lastQrContent &&
+              !lastQrContent.startsWith("ws://") &&
+              !lastQrContent.startsWith("wss://") && (
+                <span
+                  className="text-orange-400 truncate max-w-[140px]"
+                  title={lastQrContent}
+                >
+                  QR: {lastQrContent.slice(0, 20)}
+                  {lastQrContent.length > 20 ? "…" : ""}
+                </span>
+              )}
+          </div>
+          <p className="text-xs text-[#71717a] text-center mt-2">
+            Open the desktop app &rarr; Settings &rarr; Mobile Sync to see the
+            QR code
           </p>
         </div>
       ) : (
@@ -300,10 +415,7 @@ export function SyncConnectDialog({ open, onClose }: SyncConnectDialogProps) {
         <div className="mb-4 space-y-4">
           {/* IP address */}
           <div>
-            <label
-              htmlFor="sync-ip"
-              className="block text-sm text-[#a1a1aa] mb-2"
-            >
+            <label htmlFor="sync-ip" className="block text-sm text-[#a1a1aa] mb-2">
               Desktop IP address
             </label>
             <input
@@ -322,10 +434,7 @@ export function SyncConnectDialog({ open, onClose }: SyncConnectDialogProps) {
 
           {/* Pairing token */}
           <div>
-            <label
-              htmlFor="sync-token"
-              className="block text-sm text-[#a1a1aa] mb-2"
-            >
+            <label htmlFor="sync-token" className="block text-sm text-[#a1a1aa] mb-2">
               Pairing token{" "}
               <span className="text-[#52525b] text-xs">(43 characters)</span>
             </label>
@@ -365,14 +474,21 @@ export function SyncConnectDialog({ open, onClose }: SyncConnectDialogProps) {
       )}
 
       {mode === "manual" && (
-        <div className="flex justify-end">
-          <button
-            onClick={handleConnect}
-            className="btn-primary px-6 py-2.5 disabled:opacity-50"
-            disabled={connecting || !ip.trim() || token.length === 0}
-          >
-            {connecting ? "Connecting..." : "Connect"}
-          </button>
+        <div className="flex flex-col gap-2">
+          {connecting && constructedUrl && (
+            <p className="text-xs text-[#52525b] font-mono text-center truncate">
+              Attempting: {constructedUrl}
+            </p>
+          )}
+          <div className="flex justify-end">
+            <button
+              onClick={handleConnect}
+              className="btn-primary px-6 py-2.5 disabled:opacity-50"
+              disabled={connecting || !ip.trim() || token.length === 0}
+            >
+              {connecting ? "Connecting..." : "Connect"}
+            </button>
+          </div>
         </div>
       )}
 

--- a/packages/pwa/src/components/layout/SyncIndicator.tsx
+++ b/packages/pwa/src/components/layout/SyncIndicator.tsx
@@ -9,6 +9,10 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useAppStore } from "../../lib/store";
 import { disconnect, clearStoredRelayUrl } from "../../lib/sync";
 import { SyncConnectDialog } from "../SyncConnectDialog";
+import { useDebugStore } from "@freed/ui/lib/debug-store";
+
+const DEBUG_TAP_COUNT = 5;
+const DEBUG_TAP_WINDOW_MS = 2000;
 
 function formatRelativeTime(timestamp: number): string {
   const seconds = Math.floor((Date.now() - timestamp) / 1000);
@@ -28,6 +32,11 @@ export function SyncIndicator() {
   const syncConnected = useAppStore((s) => s.syncConnected);
   const feeds = useAppStore((s) => s.feeds);
   const panelRef = useRef<HTMLDivElement>(null);
+  const toggleDebug = useDebugStore((s) => s.toggle);
+
+  // 5-tap secret trigger for debug panel (resets after 2s idle)
+  const tapCountRef = useRef(0);
+  const tapTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const feedList = Object.values(feeds);
   const feedCount = feedList.length;
@@ -77,7 +86,22 @@ export function SyncIndicator() {
   return (
     <div className="relative" ref={panelRef}>
       <button
-        onClick={() => setPanelOpen((prev) => !prev)}
+        onClick={() => {
+          // Count tap for secret debug trigger; normal dropdown toggle on every tap
+          tapCountRef.current += 1;
+          if (tapTimerRef.current) clearTimeout(tapTimerRef.current);
+
+          if (tapCountRef.current >= DEBUG_TAP_COUNT) {
+            tapCountRef.current = 0;
+            setPanelOpen(false);
+            toggleDebug();
+          } else {
+            tapTimerRef.current = setTimeout(() => {
+              tapCountRef.current = 0;
+            }, DEBUG_TAP_WINDOW_MS);
+            setPanelOpen((prev) => !prev);
+          }
+        }}
         className={`flex items-center gap-1.5 sm:gap-2 px-2 sm:px-3 py-1.5 rounded-lg text-xs sm:text-sm transition-colors hover:bg-white/5 ${statusColor}`}
       >
         <span className={`w-1.5 h-1.5 rounded-full shrink-0 ${dotColor} ${isSyncing ? "animate-pulse" : ""}`} />

--- a/packages/pwa/src/lib/automerge.ts
+++ b/packages/pwa/src/lib/automerge.ts
@@ -21,6 +21,7 @@ import {
   updateLastSync,
 } from "@freed/shared/schema";
 import type { FeedItem, RssFeed, UserPreferences } from "@freed/shared";
+import { addDebugEvent, setDocSnapshot, registerDocAccessors } from "@freed/ui/lib/debug-store";
 
 // Singleton storage instance
 const storage = new IndexedDBStorage();
@@ -31,6 +32,19 @@ let currentDoc: FreedDoc | null = null;
 // Subscribers for document changes
 type Subscriber = (doc: FreedDoc) => void;
 const subscribers = new Set<Subscriber>();
+
+/** Snapshot current doc stats into the debug store */
+function snapshotDoc(): void {
+  if (!currentDoc) return;
+  const binary = A.save(currentDoc);
+  setDocSnapshot({
+    deviceId: (currentDoc.meta?.deviceId as string | undefined) ?? "unknown",
+    itemCount: Object.keys(currentDoc.feedItems ?? {}).length,
+    feedCount: Object.keys(currentDoc.rssFeeds ?? {}).length,
+    binarySize: binary.byteLength,
+    savedAt: Date.now(),
+  });
+}
 
 /**
  * Initialize or load the Automerge document
@@ -44,6 +58,17 @@ export async function initDoc(): Promise<FreedDoc> {
     currentDoc = createEmptyDoc();
     await saveDoc();
   }
+
+  const deviceId = (currentDoc.meta?.deviceId as string | undefined) ?? "unknown";
+  addDebugEvent("init", `device ...${deviceId.slice(-8)}`);
+  snapshotDoc();
+
+  // Register window escape hatch so the console can inspect the live doc.
+  registerDocAccessors(
+    () => currentDoc,
+    () => JSON.stringify(A.toJS(currentDoc!), null, 2),
+    () => A.save(currentDoc!),
+  );
 
   return currentDoc;
 }
@@ -80,6 +105,8 @@ async function applyChange(
 
   currentDoc = A.change(currentDoc, message || "update", changeFn);
   await saveDoc();
+  addDebugEvent("change", message);
+  snapshotDoc();
 
   // Notify subscribers
   for (const subscriber of subscribers) {
@@ -212,9 +239,20 @@ export async function mergeDoc(incoming: Uint8Array): Promise<FreedDoc> {
     throw new Error("Document not initialized");
   }
 
-  const incomingDoc = A.load<FreedDoc>(incoming);
-  currentDoc = A.merge(currentDoc, incomingDoc);
-  await saveDoc();
+  try {
+    const beforeCount = Object.keys(currentDoc.feedItems ?? {}).length;
+    const incomingDoc = A.load<FreedDoc>(incoming);
+    currentDoc = A.merge(currentDoc, incomingDoc);
+    await saveDoc();
+
+    const afterCount = Object.keys(currentDoc.feedItems ?? {}).length;
+    const delta = afterCount - beforeCount;
+    addDebugEvent("merge_ok", delta !== 0 ? `${delta > 0 ? "+" : ""}${delta} items` : "no new items", incoming.byteLength);
+    snapshotDoc();
+  } catch (err) {
+    addDebugEvent("merge_err", err instanceof Error ? err.message : String(err));
+    throw err;
+  }
 
   // Notify subscribers
   for (const subscriber of subscribers) {

--- a/packages/pwa/src/lib/sync.ts
+++ b/packages/pwa/src/lib/sync.ts
@@ -6,12 +6,14 @@
  */
 
 import { getDocBinary, mergeDoc } from "./automerge";
+import { addDebugEvent } from "@freed/ui/lib/debug-store";
 
 // Connection state
 let ws: WebSocket | null = null;
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 let isConnected = false;
 let currentUrl: string | null = null;
+let reconnectCount = 0;
 
 // Status listeners
 type StatusListener = (connected: boolean) => void;
@@ -35,8 +37,10 @@ export function broadcastDoc(): void {
     const doc = getDocBinary();
     ws.send(doc);
     console.log("[Sync] Broadcast document (%d bytes)", doc.byteLength);
+    addDebugEvent("sent", undefined, doc.byteLength);
   } catch (error) {
     console.error("[Sync] Failed to broadcast:", error);
+    addDebugEvent("error", error instanceof Error ? error.message : String(error));
   }
 }
 
@@ -50,6 +54,7 @@ export function connect(url: string): void {
 
   currentUrl = url;
   console.log(`[Sync] Connecting to ${url}...`);
+  addDebugEvent("connect_attempt", url);
 
   try {
     ws = new WebSocket(url);
@@ -58,7 +63,9 @@ export function connect(url: string): void {
     ws.onopen = () => {
       console.log("[Sync] Connected to relay");
       isConnected = true;
+      reconnectCount = 0;
       notifyStatus();
+      addDebugEvent("connected", url);
 
       // Send our current doc so the relay stores it and can serve new clients
       setTimeout(() => broadcastDoc(), 100);
@@ -68,6 +75,8 @@ export function connect(url: string): void {
       if (!(event.data instanceof ArrayBuffer)) return;
       const bytes = new Uint8Array(event.data);
       if (bytes.length === 0) return;
+
+      addDebugEvent("received", undefined, bytes.length);
 
       try {
         await mergeDoc(bytes);
@@ -82,9 +91,12 @@ export function connect(url: string): void {
       isConnected = false;
       ws = null;
       notifyStatus();
+      addDebugEvent("disconnected", currentUrl ?? undefined);
 
       // Auto-reconnect after delay
       if (currentUrl && reconnectTimer === null) {
+        reconnectCount += 1;
+        addDebugEvent("reconnecting", `attempt ${reconnectCount} in 5s`);
         reconnectTimer = setTimeout(() => {
           reconnectTimer = null;
           if (currentUrl && !isConnected) {
@@ -96,9 +108,11 @@ export function connect(url: string): void {
 
     ws.onerror = (error) => {
       console.error("[Sync] WebSocket error:", error);
+      addDebugEvent("error", "WebSocket error — check browser console for details");
     };
   } catch (error) {
     console.error("[Sync] Failed to connect:", error);
+    addDebugEvent("error", error instanceof Error ? error.message : String(error));
   }
 }
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -11,6 +11,8 @@
     "./components/Toast": "./src/components/Toast.tsx",
     "./components/AddFeedDialog": "./src/components/AddFeedDialog.tsx",
     "./components/SettingsPanel": "./src/components/SettingsPanel.tsx",
+    "./components/DebugPanel": "./src/components/DebugPanel.tsx",
+    "./lib/debug-store": "./src/lib/debug-store.ts",
     "./context": "./src/context/index.ts"
   },
   "peerDependencies": {

--- a/packages/ui/src/components/DebugPanel.tsx
+++ b/packages/ui/src/components/DebugPanel.tsx
@@ -1,0 +1,381 @@
+/**
+ * DebugPanel — in-app sync diagnostics overlay
+ *
+ * Three tabs: Connection, Events, Document.
+ * Opened via Cmd/Ctrl+Shift+D, 5-tap on the sync indicator, or Settings → Developer.
+ */
+
+import { useEffect, useRef, useState } from "react";
+import { useDebugStore, type SyncEvent, type SyncEventKind } from "../lib/debug-store";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatTs(ts: number): string {
+  const d = new Date(ts);
+  return d.toLocaleTimeString([], { hour12: false, hour: "2-digit", minute: "2-digit", second: "2-digit" });
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+}
+
+function formatRelative(ts: number): string {
+  const s = Math.floor((Date.now() - ts) / 1000);
+  if (s < 5) return "just now";
+  if (s < 60) return `${s}s ago`;
+  if (s < 3600) return `${Math.floor(s / 60)}m ago`;
+  return `${Math.floor(s / 3600)}h ago`;
+}
+
+// Colour coding by event kind
+const KIND_STYLES: Record<SyncEventKind, { badge: string; dot: string; label: string }> = {
+  connected:          { badge: "bg-green-500/20 text-green-400 border-green-500/30",    dot: "bg-green-400",    label: "connected" },
+  disconnected:       { badge: "bg-red-500/20 text-red-400 border-red-500/30",          dot: "bg-red-400",      label: "disconnected" },
+  reconnecting:       { badge: "bg-yellow-500/20 text-yellow-400 border-yellow-500/30", dot: "bg-yellow-400",   label: "reconnecting" },
+  sent:               { badge: "bg-blue-500/20 text-blue-400 border-blue-500/30",        dot: "bg-blue-400",     label: "sent" },
+  received:           { badge: "bg-cyan-500/20 text-cyan-400 border-cyan-500/30",        dot: "bg-cyan-400",     label: "received" },
+  merge_ok:           { badge: "bg-green-500/20 text-green-400 border-green-500/30",    dot: "bg-green-400",    label: "merge ok" },
+  merge_err:          { badge: "bg-red-500/20 text-red-400 border-red-500/30",          dot: "bg-red-400",      label: "merge err" },
+  init:               { badge: "bg-purple-500/20 text-purple-400 border-purple-500/30", dot: "bg-purple-400",   label: "init" },
+  change:             { badge: "bg-[#52525b]/40 text-[#a1a1aa] border-[#52525b]/30",    dot: "bg-[#71717a]",    label: "change" },
+  error:              { badge: "bg-red-500/20 text-red-400 border-red-500/30",          dot: "bg-red-400",      label: "error" },
+  mixed_content_warn: { badge: "bg-orange-500/20 text-orange-400 border-orange-500/30", dot: "bg-orange-400",   label: "mixed content" },
+  camera_started:     { badge: "bg-[#52525b]/40 text-[#a1a1aa] border-[#52525b]/30",   dot: "bg-[#71717a]",    label: "camera" },
+  camera_denied:      { badge: "bg-red-500/20 text-red-400 border-red-500/30",          dot: "bg-red-400",      label: "cam denied" },
+  qr_decoded:         { badge: "bg-purple-500/20 text-purple-400 border-purple-500/30", dot: "bg-purple-400",   label: "qr decoded" },
+  connect_attempt:    { badge: "bg-blue-500/20 text-blue-400 border-blue-500/30",        dot: "bg-blue-400",     label: "connecting" },
+  connect_timeout:    { badge: "bg-red-500/20 text-red-400 border-red-500/30",          dot: "bg-red-400",      label: "timeout" },
+};
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function EventRow({ event }: { event: SyncEvent }) {
+  const style = KIND_STYLES[event.kind];
+  return (
+    <div className="flex items-start gap-2.5 py-2 border-b border-white/5 last:border-0">
+      <span className="text-[10px] text-[#52525b] tabular-nums shrink-0 mt-0.5 font-mono">
+        {formatTs(event.ts)}
+      </span>
+      <span className={`shrink-0 mt-0.5 text-[10px] px-1.5 py-0.5 rounded border font-mono ${style.badge}`}>
+        {style.label}
+      </span>
+      <div className="flex-1 min-w-0">
+        {event.detail && (
+          <p className="text-xs text-[#a1a1aa] truncate font-mono">{event.detail}</p>
+        )}
+        {event.bytes !== undefined && (
+          <p className="text-[10px] text-[#52525b] font-mono">{formatBytes(event.bytes)}</p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ConnectionTab() {
+  const events = useDebugStore((s) => s.events);
+  const docSnapshot = useDebugStore((s) => s.docSnapshot);
+  const [, setTick] = useState(0);
+
+  // Re-render every second so relative timestamps stay fresh
+  useEffect(() => {
+    const id = setInterval(() => setTick((t) => t + 1), 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  const lastConnected = events.find((e) => e.kind === "connected");
+  const lastDisconnected = events.find((e) => e.kind === "disconnected");
+  const lastSent = events.find((e) => e.kind === "sent");
+  const lastReceived = events.find((e) => e.kind === "received");
+  const reconnects = events.filter((e) => e.kind === "reconnecting").length;
+  const connectAttempt = events.find((e) => e.kind === "connect_attempt");
+  const isConnected = lastConnected && (!lastDisconnected || lastConnected.ts > lastDisconnected.ts);
+
+  const proto = typeof window !== "undefined" ? window.location.protocol : "";
+  const relayUrl = connectAttempt?.detail ?? "—";
+  const isWsPlain = relayUrl.startsWith("ws://");
+  const mixedContentRisk = proto === "https:" && isWsPlain;
+
+  return (
+    <div className="space-y-4">
+      {/* Mixed content warning */}
+      {mixedContentRisk && (
+        <div className="p-3 bg-orange-500/15 border border-orange-500/40 rounded-xl">
+          <p className="text-xs font-semibold text-orange-400 mb-1">HTTPS → ws:// Mixed Content</p>
+          <p className="text-xs text-orange-300/80">
+            This page is served over HTTPS. Safari and Chrome block plain <code className="font-mono">ws://</code> connections from HTTPS pages — this is almost certainly why sync fails on iPhone. The desktop relay works, but the browser kills the socket silently.
+          </p>
+        </div>
+      )}
+
+      {/* Status */}
+      <div className="grid grid-cols-2 gap-2">
+        <div className="bg-white/5 rounded-xl p-3">
+          <p className="text-[10px] text-[#52525b] uppercase tracking-wider mb-1">Status</p>
+          <div className="flex items-center gap-2">
+            <span className={`w-2 h-2 rounded-full shrink-0 ${isConnected ? "bg-green-400" : "bg-[#52525b]"}`} />
+            <span className={`text-sm font-medium ${isConnected ? "text-green-400" : "text-[#71717a]"}`}>
+              {isConnected ? "Connected" : "Offline"}
+            </span>
+          </div>
+        </div>
+
+        <div className="bg-white/5 rounded-xl p-3">
+          <p className="text-[10px] text-[#52525b] uppercase tracking-wider mb-1">Reconnects</p>
+          <p className="text-sm font-medium text-[#a1a1aa] font-mono">{reconnects}</p>
+        </div>
+
+        <div className="bg-white/5 rounded-xl p-3">
+          <p className="text-[10px] text-[#52525b] uppercase tracking-wider mb-1">Page Protocol</p>
+          <p className={`text-sm font-medium font-mono ${proto === "https:" ? "text-orange-400" : "text-green-400"}`}>
+            {proto || "—"}
+          </p>
+        </div>
+
+        <div className="bg-white/5 rounded-xl p-3">
+          <p className="text-[10px] text-[#52525b] uppercase tracking-wider mb-1">Doc Size</p>
+          <p className="text-sm font-medium text-[#a1a1aa] font-mono">
+            {docSnapshot ? formatBytes(docSnapshot.binarySize) : "—"}
+          </p>
+        </div>
+      </div>
+
+      {/* Relay URL */}
+      <div className="bg-white/5 rounded-xl p-3">
+        <p className="text-[10px] text-[#52525b] uppercase tracking-wider mb-1">Relay URL</p>
+        <p className="text-xs text-[#a1a1aa] font-mono break-all">{relayUrl}</p>
+      </div>
+
+      {/* Transfer stats */}
+      <div className="grid grid-cols-2 gap-2">
+        <div className="bg-white/5 rounded-xl p-3">
+          <p className="text-[10px] text-[#52525b] uppercase tracking-wider mb-1">Last Sent</p>
+          <p className="text-xs text-blue-400 font-mono">{lastSent ? formatBytes(lastSent.bytes ?? 0) : "—"}</p>
+          {lastSent && <p className="text-[10px] text-[#52525b] font-mono mt-0.5">{formatRelative(lastSent.ts)}</p>}
+        </div>
+        <div className="bg-white/5 rounded-xl p-3">
+          <p className="text-[10px] text-[#52525b] uppercase tracking-wider mb-1">Last Received</p>
+          <p className="text-xs text-cyan-400 font-mono">{lastReceived ? formatBytes(lastReceived.bytes ?? 0) : "—"}</p>
+          {lastReceived && <p className="text-[10px] text-[#52525b] font-mono mt-0.5">{formatRelative(lastReceived.ts)}</p>}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function EventsTab() {
+  const events = useDebugStore((s) => s.events);
+  const clearEvents = useDebugStore((s) => s.clearEvents);
+
+  const copyAll = async () => {
+    const text = events
+      .map((e) => `[${formatTs(e.ts)}] ${e.kind}${e.detail ? ` — ${e.detail}` : ""}${e.bytes !== undefined ? ` (${formatBytes(e.bytes)})` : ""}`)
+      .join("\n");
+    await navigator.clipboard.writeText(text);
+  };
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex items-center justify-between mb-3 shrink-0">
+        <p className="text-xs text-[#52525b]">{events.length} events (last 200)</p>
+        <div className="flex gap-2">
+          <button
+            onClick={copyAll}
+            className="text-xs px-2.5 py-1 rounded-lg bg-white/5 hover:bg-white/10 text-[#71717a] hover:text-white transition-colors"
+          >
+            Copy All
+          </button>
+          <button
+            onClick={clearEvents}
+            className="text-xs px-2.5 py-1 rounded-lg bg-white/5 hover:bg-red-500/20 text-[#71717a] hover:text-red-400 transition-colors"
+          >
+            Clear
+          </button>
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-y-auto min-h-0">
+        {events.length === 0 ? (
+          <p className="text-xs text-[#52525b] text-center py-8">No events yet. Try connecting.</p>
+        ) : (
+          events.map((e) => <EventRow key={e.id} event={e} />)
+        )}
+      </div>
+    </div>
+  );
+}
+
+function DocumentTab() {
+  const docSnapshot = useDebugStore((s) => s.docSnapshot);
+  const [copied, setCopied] = useState(false);
+
+  const copyJson = async () => {
+    const json = window.__freed?.getDocJson?.();
+    if (!json) return;
+    await navigator.clipboard.writeText(json);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const downloadBinary = () => {
+    const binary = window.__freed?.getDocBinary?.();
+    if (!binary) return;
+    // Ensure we have a plain ArrayBuffer to satisfy Blob's type constraint
+    const blob = new Blob([binary.buffer instanceof ArrayBuffer ? binary.buffer : new Uint8Array(binary).buffer], { type: "application/octet-stream" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `freed-doc-${Date.now()}.automerge`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  if (!docSnapshot) {
+    return (
+      <p className="text-xs text-[#52525b] text-center py-8">
+        Document not yet initialized.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Summary grid */}
+      <div className="grid grid-cols-2 gap-2">
+        <div className="bg-white/5 rounded-xl p-3">
+          <p className="text-[10px] text-[#52525b] uppercase tracking-wider mb-1">Device ID</p>
+          <p className="text-xs text-[#a1a1aa] font-mono">...{docSnapshot.deviceId.slice(-8)}</p>
+        </div>
+        <div className="bg-white/5 rounded-xl p-3">
+          <p className="text-[10px] text-[#52525b] uppercase tracking-wider mb-1">Doc Size</p>
+          <p className="text-xs text-[#a1a1aa] font-mono">{formatBytes(docSnapshot.binarySize)}</p>
+        </div>
+        <div className="bg-white/5 rounded-xl p-3">
+          <p className="text-[10px] text-[#52525b] uppercase tracking-wider mb-1">Feed Items</p>
+          <p className="text-sm font-semibold text-white font-mono">{docSnapshot.itemCount.toLocaleString()}</p>
+        </div>
+        <div className="bg-white/5 rounded-xl p-3">
+          <p className="text-[10px] text-[#52525b] uppercase tracking-wider mb-1">RSS Feeds</p>
+          <p className="text-sm font-semibold text-white font-mono">{docSnapshot.feedCount}</p>
+        </div>
+      </div>
+
+      <div className="bg-white/5 rounded-xl p-3">
+        <p className="text-[10px] text-[#52525b] uppercase tracking-wider mb-1">Snapshot Taken</p>
+        <p className="text-xs text-[#a1a1aa] font-mono">{new Date(docSnapshot.savedAt).toLocaleTimeString()}</p>
+      </div>
+
+      {/* Actions */}
+      <div className="space-y-2">
+        <button
+          onClick={copyJson}
+          className="w-full py-2.5 rounded-xl bg-[#8b5cf6]/20 text-[#8b5cf6] hover:bg-[#8b5cf6]/30 text-sm font-medium transition-colors border border-[#8b5cf6]/20"
+        >
+          {copied ? "Copied!" : "Copy Doc as JSON"}
+        </button>
+        <button
+          onClick={downloadBinary}
+          className="w-full py-2.5 rounded-xl bg-white/5 text-[#a1a1aa] hover:bg-white/10 hover:text-white text-sm font-medium transition-colors"
+        >
+          Download .automerge Binary
+        </button>
+      </div>
+
+      <p className="text-[10px] text-[#52525b] text-center">
+        Or run <code className="font-mono">window.__freed.getDocJson()</code> in DevTools
+      </p>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main panel
+// ---------------------------------------------------------------------------
+
+type Tab = "connection" | "events" | "document";
+
+export function DebugPanel() {
+  const toggle = useDebugStore((s) => s.toggle);
+  const [tab, setTab] = useState<Tab>("connection");
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  // Escape key closes
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") toggle();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [toggle]);
+
+  const tabs: { id: Tab; label: string }[] = [
+    { id: "connection", label: "Connection" },
+    { id: "events", label: "Events" },
+    { id: "document", label: "Document" },
+  ];
+
+  return (
+    <div className="fixed inset-0 z-[200] flex items-end sm:items-center justify-center bg-black/60 backdrop-blur-sm">
+      <div
+        ref={panelRef}
+        className="w-full sm:max-w-lg bg-[#111111] border border-[rgba(255,255,255,0.1)] rounded-t-2xl sm:rounded-2xl shadow-2xl flex flex-col"
+        style={{ maxHeight: "85vh" }}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-4 border-b border-white/8 shrink-0">
+          <div className="flex items-center gap-2.5">
+            <span className="text-xs font-mono px-2 py-0.5 rounded bg-[#8b5cf6]/20 text-[#8b5cf6] border border-[#8b5cf6]/30">
+              DEBUG
+            </span>
+            <h2 className="text-sm font-semibold text-white">Sync Diagnostics</h2>
+          </div>
+          <button
+            onClick={toggle}
+            className="p-1.5 rounded-lg hover:bg-white/10 text-[#71717a] hover:text-white transition-colors"
+            aria-label="Close debug panel"
+          >
+            <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+              <path d="M1 1l12 12M13 1L1 13" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Tabs */}
+        <div className="flex border-b border-white/8 shrink-0">
+          {tabs.map((t) => (
+            <button
+              key={t.id}
+              onClick={() => setTab(t.id)}
+              className={`flex-1 py-2.5 text-xs font-medium transition-colors ${
+                tab === t.id
+                  ? "text-[#8b5cf6] border-b-2 border-[#8b5cf6]"
+                  : "text-[#71717a] hover:text-white"
+              }`}
+            >
+              {t.label}
+            </button>
+          ))}
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 overflow-y-auto min-h-0 p-5">
+          {tab === "connection" && <ConnectionTab />}
+          {tab === "events" && <EventsTab />}
+          {tab === "document" && <DocumentTab />}
+        </div>
+
+        {/* Footer hint */}
+        <div className="px-5 py-3 border-t border-white/8 shrink-0">
+          <p className="text-[10px] text-[#52525b] text-center font-mono">
+            Esc to close · Cmd+Shift+D to toggle · window.__freed in DevTools
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/SettingsPanel.tsx
+++ b/packages/ui/src/components/SettingsPanel.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useRef } from "react";
 import { useAppStore, usePlatform } from "../context/PlatformContext.js";
 import { BottomSheet } from "./BottomSheet.js";
+import { useDebugStore } from "../lib/debug-store.js";
 
 interface SettingsPanelProps {
   open: boolean;
@@ -54,6 +55,7 @@ type UpdateCheckState =
 export function SettingsPanel({ open, onClose }: SettingsPanelProps) {
   const { SettingsExtraSections, checkForUpdates, applyUpdate, headerDragRegion } = usePlatform();
   const preferences = useAppStore((s) => s.preferences);
+  const toggleDebug = useDebugStore((s) => s.toggle);
   const updatePreferences = useAppStore((s) => s.updatePreferences);
 
   const [display, setDisplay] = useState(() => preferences.display);
@@ -209,6 +211,23 @@ export function SettingsPanel({ open, onClose }: SettingsPanelProps) {
               </div>
             )}
           </div>
+        </section>
+
+        {/* Developer */}
+        <section>
+          <h3 className="text-xs font-semibold text-[#71717a] uppercase tracking-wider mb-4">
+            Developer
+          </h3>
+          <button
+            onClick={() => { onClose(); setTimeout(toggleDebug, 150); }}
+            className="w-full flex items-center justify-between px-3 py-2.5 rounded-xl bg-white/5 hover:bg-white/10 transition-colors text-left"
+          >
+            <div>
+              <p className="text-sm text-[#a1a1aa]">Open Debug Panel</p>
+              <p className="text-xs text-[#52525b] mt-0.5">Sync diagnostics, event log, document inspector</p>
+            </div>
+            <span className="text-[10px] font-mono text-[#52525b] shrink-0 ml-3">⌘⇧D</span>
+          </button>
         </section>
 
         {/* Footer */}

--- a/packages/ui/src/components/layout/AppShell.tsx
+++ b/packages/ui/src/components/layout/AppShell.tsx
@@ -1,6 +1,8 @@
-import { useState, type ReactNode } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import { Sidebar } from "./Sidebar.js";
 import { Header } from "./Header.js";
+import { DebugPanel } from "../DebugPanel.js";
+import { useDebugStore } from "../../lib/debug-store.js";
 
 interface AppShellProps {
   children: ReactNode;
@@ -8,6 +10,20 @@ interface AppShellProps {
 
 export function AppShell({ children }: AppShellProps) {
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  const debugVisible = useDebugStore((s) => s.visible);
+  const toggleDebug = useDebugStore((s) => s.toggle);
+
+  // Cmd/Ctrl+Shift+D keyboard shortcut
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "D" && e.shiftKey && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        toggleDebug();
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [toggleDebug]);
 
   return (
     <div className="flex-1 min-h-0 flex flex-col bg-[#121212] pb-[env(safe-area-inset-bottom)]">
@@ -17,6 +33,8 @@ export function AppShell({ children }: AppShellProps) {
         <Sidebar open={sidebarOpen} onClose={() => setSidebarOpen(false)} />
         <main className="flex-1 min-h-0 overflow-hidden">{children}</main>
       </div>
+
+      {debugVisible && <DebugPanel />}
     </div>
   );
 }

--- a/packages/ui/src/lib/debug-store.ts
+++ b/packages/ui/src/lib/debug-store.ts
@@ -1,0 +1,144 @@
+/**
+ * Debug store for Freed sync diagnostics
+ *
+ * Zustand store that tracks sync events, document state snapshots, and
+ * panel visibility. Consumed by DebugPanel; written to by automerge.ts
+ * and sync.ts in both the PWA and desktop packages.
+ *
+ * Also exposes window.__freed as a console escape hatch for inspecting
+ * live document state without opening the panel.
+ */
+
+import { create } from "zustand";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type SyncEventKind =
+  | "init"
+  | "change"
+  | "merge_ok"
+  | "merge_err"
+  | "connected"
+  | "disconnected"
+  | "reconnecting"
+  | "sent"
+  | "received"
+  | "error"
+  | "mixed_content_warn"
+  | "camera_started"
+  | "camera_denied"
+  | "qr_decoded"
+  | "connect_attempt"
+  | "connect_timeout";
+
+export interface SyncEvent {
+  id: string;
+  ts: number;
+  kind: SyncEventKind;
+  detail?: string;
+  bytes?: number;
+}
+
+export interface DocSnapshot {
+  deviceId: string;
+  itemCount: number;
+  feedCount: number;
+  binarySize: number;
+  savedAt: number;
+}
+
+interface DebugState {
+  visible: boolean;
+  events: SyncEvent[];
+  docSnapshot: DocSnapshot | null;
+
+  toggle: () => void;
+  addEvent: (kind: SyncEventKind, detail?: string, bytes?: number) => void;
+  clearEvents: () => void;
+  setDocSnapshot: (snap: DocSnapshot) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Store
+// ---------------------------------------------------------------------------
+
+const MAX_EVENTS = 200;
+
+export const useDebugStore = create<DebugState>()((set) => ({
+  visible: false,
+  events: [],
+  docSnapshot: null,
+
+  toggle: () => set((s) => ({ visible: !s.visible })),
+
+  addEvent: (kind, detail, bytes) =>
+    set((s) => {
+      const event: SyncEvent = {
+        id: `${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+        ts: Date.now(),
+        kind,
+        detail,
+        bytes,
+      };
+      return { events: [event, ...s.events].slice(0, MAX_EVENTS) };
+    }),
+
+  clearEvents: () => set({ events: [] }),
+
+  setDocSnapshot: (docSnapshot) => set({ docSnapshot }),
+}));
+
+// ---------------------------------------------------------------------------
+// Convenience functions (usable outside React render context)
+// ---------------------------------------------------------------------------
+
+export function addDebugEvent(
+  kind: SyncEventKind,
+  detail?: string,
+  bytes?: number,
+): void {
+  useDebugStore.getState().addEvent(kind, detail, bytes);
+}
+
+export function setDocSnapshot(snap: DocSnapshot): void {
+  useDebugStore.getState().setDocSnapshot(snap);
+}
+
+// ---------------------------------------------------------------------------
+// window.__freed escape hatch
+//
+// Call registerDocAccessors(getDoc, getDocBinary) from automerge.ts after
+// initDoc() so the console can reach live document state without the panel.
+// ---------------------------------------------------------------------------
+
+declare global {
+  interface Window {
+    __freed: {
+      getDoc?: () => unknown;
+      getDocJson?: () => string;
+      getDocBinary?: () => Uint8Array;
+      debug?: () => DebugState;
+    };
+  }
+}
+
+export function registerDocAccessors(
+  getDoc: () => unknown,
+  getDocJson: () => string,
+  getDocBinary: () => Uint8Array,
+): void {
+  window.__freed = {
+    ...window.__freed,
+    getDoc,
+    getDocJson,
+    getDocBinary,
+    debug: () => useDebugStore.getState(),
+  };
+}
+
+// Initialise the base object immediately so it's always safe to spread into.
+if (typeof window !== "undefined") {
+  window.__freed = window.__freed ?? {};
+}


### PR DESCRIPTION
(AI Generated)

## Summary

- **In-app debug overlay** accessible via `Cmd/Ctrl+Shift+D`, 5-tap on the sync status pill, or Settings → Developer. Three tabs: Connection (status, relay URL, HTTPS risk, byte counts), Events (rolling 200-entry log), Document (device ID, item counts, copy JSON, download binary). Also exposes `window.__freed` in DevTools console.
- **Root cause identified via live test**: the WebSocket relay and Automerge sync work perfectly. The real failure mode is HTTPS mixed-content blocking — Safari silently kills `ws://` connections from `https://` pages. The connect dialog now surfaces this as a prominent warning instead of a misleading 5-second timeout error.
- **QR diagnostics**: live camera resolution + frame counter in scan mode, raw QR decode display for non-ws codes, multi-interface IP picker on desktop with VPN detection (addresses the case where a VPN tunnel encodes the wrong IP in the QR code).

## What changed

| File | Change |
|---|---|
| `packages/pwa/src/lib/debug-store.ts` | New — Zustand store, 16 event kinds, `window.__freed` escape hatch |
| `packages/pwa/src/components/DebugPanel.tsx` | New — tabbed overlay component |
| `packages/pwa/src/lib/sync.ts` | Instrumented with debug events |
| `packages/pwa/src/lib/automerge.ts` | Instrumented + window.__freed registered |
| `packages/desktop/src/lib/automerge.ts` | Same instrumentation via `@freed/pwa/lib/debug-store` |
| `packages/pwa/src/components/layout/AppShell.tsx` | Keyboard shortcut + panel render |
| `packages/pwa/src/components/layout/SyncIndicator.tsx` | 5-tap secret trigger |
| `packages/pwa/src/components/SettingsPanel.tsx` | Developer section |
| `packages/pwa/src/components/SyncConnectDialog.tsx` | HTTPS warning, scan diagnostics, event emission |
| `packages/desktop/src/components/MobileSyncTab.tsx` | IP picker, VPN warning, URL fix |
| `packages/desktop/src/lib/sync.ts` | `getAllLocalIPs()` wrapper |
| `packages/desktop/src-tauri/src/lib.rs` | `get_all_local_ips()` Tauri command |
| `packages/pwa/package.json` | Export `./lib/debug-store` |
| `AGENTS.md` | Canonical URL table — `app.freed.wtf` locked in |
| `docs/PHASE-5-DESKTOP.md` | Fixed `freed.wtf/app` → `app.freed.wtf` |

## Test plan

- [ ] Open PWA dev server (`npm run dev` in `packages/pwa`), press `Cmd+Shift+D` — debug panel opens
- [ ] Click the sync status pill 5 times rapidly — debug panel opens
- [ ] Settings → Developer → Open Debug Panel — panel opens, settings closes first
- [ ] Connect to desktop relay via manual URL — Connection tab shows relay URL, events log shows `connect_attempt → connected → received` with byte count
- [ ] Try connecting from `https://` with a `ws://` URL — orange HTTPS warning banner appears in connect dialog
- [ ] Switch to Scan QR mode — frame counter increments, resolution shown below viewfinder
- [ ] Document tab: Copy JSON copies valid JSON, Download downloads `.automerge` file
- [ ] Open browser DevTools, run `window.__freed.getDocJson()` — returns formatted JSON
- [ ] Desktop: Settings → Mobile Sync with VPN active — orange warning + IP picker visible