### PR TITLE
chore: establish squash-merge policy across AGENTS.md and CONTRIBUTING.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,41 @@ Run `./scripts/release.sh` with no args to auto-compute the next version.
 | `desktop/` | Tauri shell. May import from `@freed/pwa`. |
 | `capture-*/` | Isolated. Never import between capture packages. |
 
+## Git Workflow
+
+**Never work directly on `main`.** Always create a git worktree for feature work:
+
+```bash
+git worktree add ../freed-<slug> -b <branch>
+# work in ../freed-<slug>/
+# remove when done: git worktree remove ../freed-<slug>
+```
+
+**Branch naming:** `feat/`, `fix/`, `chore/`, `docs/`, `refactor/`, `perf/` prefix followed by a short kebab-case description.
+
+**Commit messages** follow Conventional Commits:
+
+| Prefix | When to use |
+|---|---|
+| `feat:` | New user-facing feature |
+| `fix:` | Bug fix |
+| `chore:` | Tooling, deps, config — no production code change |
+| `docs:` | Documentation only |
+| `refactor:` | Code restructure with no behavior change |
+| `perf:` | Performance improvement |
+| `style:` | Formatting, whitespace, CSS-only |
+
+**Merge policy:** Squash merge only. One PR = one commit on `main`.
+
+```bash
+# From the primary worktree (not the feature worktree):
+gh pr merge <n> --squash --delete-branch
+```
+
+Branches are deleted after merge. The squash commit message is derived from the PR title — write PR titles as if they are commit messages.
+
+---
+
 ## Automerge
 
 **Schema** (`packages/shared/src/schema.ts`): backward-compatible only. Add optional fields; never delete (mark `@deprecated`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,13 +88,15 @@ freed/
 ### Pull Requests
 
 1. Fork the repo
-2. Create a feature branch (`git checkout -b feature/amazing-feature`)
+2. Create a feature branch (`git checkout -b feat/amazing-feature`)
 3. Make your changes
 4. Write/update tests if applicable
 5. Ensure linting passes
-6. Commit with clear messages
+6. Commit with clear messages following [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `perf:`, `style:`)
 7. Push to your fork
 8. Open a PR against `main`
+
+**Merge policy:** All PRs are merged via **squash merge**. Your entire branch becomes a single commit on `main` — write your PR title and description accordingly, as the squash commit message is derived from them. Branches are deleted automatically after merge. Merge commits and rebase merges are disabled at the repository level.
 
 ### Commit Messages
 


### PR DESCRIPTION
(AI Generated)

## Summary

- Adds a `## Git Workflow` section to `AGENTS.md` codifying the worktree pattern, branch naming convention, Conventional Commits table, and squash-merge instructions for agents
- Updates `CONTRIBUTING.md` to document the squash-only merge policy for human contributors, including a note that merge commits and rebase merges are disabled at the repository level
- GitHub repo settings already applied in a previous step: `allow_merge_commit=false`, `allow_rebase_merge=false`, `allow_squash_merge=true`, `delete_branch_on_merge=true`

## Test plan

- [ ] Verify GitHub repo only shows "Squash and merge" button on PRs
- [ ] Verify branches auto-delete after merge