### PR TITLE
fix(header): locale-aware unread count formatting + agent number formatting rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@
 - **Roadmap sync:** When `docs/PHASE-*.md` changes, update `website/src/pages/Roadmap.tsx` to match (`✓ Complete` → `"complete"`, `🚧 In Progress` → `"current"`, else `"upcoming"`).
 - **Time estimates:** Machine time only ("one conversation", "~10 min"). Never quote human hours/days.
 - **IDs:** Display tail — `...${id.slice(-8)}`.
+- **Number formatting:** All user-facing numbers must use `Number.toLocaleString()` (or `Intl.NumberFormat`) — never raw `.toString()` or string interpolation. This ensures locale-appropriate grouping separators (e.g. commas in `en-US`) for counts, totals, and stats.
 
 ## Versioning
 

--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -81,7 +81,7 @@ export function Header({ onMenuClick }: HeaderProps) {
                 <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
                 </svg>
-                <span>{unreadCount} unread</span>
+                <span>{unreadCount.toLocaleString()} unread</span>
               </button>
             )}
 


### PR DESCRIPTION
## Summary

- Format unread count in the Header toolbar button with `toLocaleString()` so US users see `2,401` instead of `2401`
- Add AGENTS.md rule mandating `Number.toLocaleString()` / `Intl.NumberFormat` for all user-facing numbers — no raw integer strings to humans

## Test plan

- [ ] Open the desktop app with >999 unread items — confirm the toolbar button reads e.g. `2,401 unread`
- [ ] Verify no regressions in sidebar count display (those use compact `fmt()` notation intentionally)