### PR TITLE
fix(desktop): heal untitled feed titles from live XML on sync

### DIFF
--- a/packages/desktop/src/lib/automerge.ts
+++ b/packages/desktop/src/lib/automerge.ts
@@ -252,8 +252,25 @@ export async function docBatchRefreshFeeds(
 ): Promise<FreedDoc> {
   return applyChange((doc) => {
     for (const feed of feeds) {
-      if (doc.rssFeeds[feed.url] && feed.lastFetched !== undefined) {
-        doc.rssFeeds[feed.url].lastFetched = feed.lastFetched;
+      const stored = doc.rssFeeds[feed.url];
+      if (!stored) continue;
+
+      if (feed.lastFetched !== undefined) {
+        stored.lastFetched = feed.lastFetched;
+      }
+
+      // Heal sentinel titles from live feed XML — never clobbers user-set names.
+      // Both "Untitled Feed" (OPML fallback) and the raw feed URL (addRssFeed fallback)
+      // are treated as sentinels indicating a title was never properly resolved.
+      if (feed.title && feed.title !== "Untitled Feed" && feed.title !== feed.url) {
+        if (stored.title === "Untitled Feed" || stored.title === stored.url) {
+          stored.title = feed.title;
+        }
+      }
+
+      // Backfill missing siteUrl from live feed data
+      if (feed.siteUrl && !stored.siteUrl) {
+        stored.siteUrl = feed.siteUrl;
       }
     }
 

--- a/packages/desktop/src/lib/capture.ts
+++ b/packages/desktop/src/lib/capture.ts
@@ -281,7 +281,19 @@ export async function refreshAllFeeds(): Promise<void> {
       const results = await Promise.allSettled(
         batch.map(async (feed) => {
           const items = await fetchRssFeed(feed.url);
-          return { feed: { ...feed, lastFetched: Date.now() }, items };
+          const liveFeedTitle = items[0]?.rssSource?.feedTitle;
+          const liveSiteUrl = items[0]?.rssSource?.siteUrl;
+          // Sentinel check: OPML fallback or raw URL as title both indicate a broken import
+          const isUntitled = feed.title === "Untitled Feed" || feed.title === feed.url;
+          return {
+            feed: {
+              ...feed,
+              lastFetched: Date.now(),
+              ...(isUntitled && liveFeedTitle ? { title: liveFeedTitle } : {}),
+              ...(!feed.siteUrl && liveSiteUrl ? { siteUrl: liveSiteUrl } : {}),
+            },
+            items,
+          };
         }),
       );
       for (const result of results) {


### PR DESCRIPTION
(AI Generated)

## Root Cause

Two accomplices conspired to produce "Untitled Feed" permanently:

1. **OPML parser trusts the file.** Both `packages/shared/src/opml.ts` and `packages/capture-rss/src/opml.ts` fall back to `"Untitled Feed"` when an `<outline>` element has no `text`/`title` attribute. If the source OPML was exported from a reader that omitted those attributes, every feed was branded before a single HTTP request was made.

2. **`docBatchRefreshFeeds` only updated `lastFetched`.** After import, `importOPMLFeeds` fires `refreshAllFeeds()`, which fetches the live XML and correctly parses `<channel><title>` into every `FeedItem`'s `rssSource.feedTitle` — then throws it away. The CRDT write only touched `lastFetched`. Every subsequent 30-minute poll repeated the same discard. Feeds stayed "Untitled Feed" for eternity.

## Changes

### `packages/desktop/src/lib/capture.ts` — `refreshAllFeeds`

Extract the live `feedTitle` and `siteUrl` from the first fetched `FeedItem`. If the stored title is a sentinel (`"Untitled Feed"` or the raw feed URL), replace it in the outgoing feed object before it reaches the CRDT write.

### `packages/desktop/src/lib/automerge.ts` — `docBatchRefreshFeeds`

Extend the per-feed update block to also persist a healed title and backfill a missing `siteUrl` when the currently stored value is still a sentinel. A double-guard (`feed.title !== sentinel` AND `stored.title === sentinel`) ensures user-customised names are never touched.

## Recovery

All existing "Untitled Feed" entries in users' CRDTs will self-heal on the next scheduled 30-minute poll, or immediately on "Sync Now". No migration script or one-time startup job required.

## Test Plan

- [ ] Import an OPML file with blank/missing `text` attributes on `<outline>` elements; verify feeds display real titles immediately after the post-import sync completes
- [ ] Verify that a feed manually renamed by the user retains its custom name after a sync cycle
- [ ] Confirm existing "Untitled Feed" entries resolve to real titles after hitting "Sync Now"
- [ ] Verify feeds with no items returned (empty feed) keep their stored title and don't regress to the URL sentinel