### PR TITLE
fix(pwa): bypass service worker for API routes + surface OAuth errors

### DIFF
--- a/packages/pwa/src/components/OAuthCallback.tsx
+++ b/packages/pwa/src/components/OAuthCallback.tsx
@@ -112,29 +112,37 @@ export function OAuthCallback() {
 
     const exchange = provider === "gdrive" ? exchangeGDrive : exchangeDropbox;
 
-    exchange(code, verifier).then(async (result) => {
-      if (!result.ok) {
+    exchange(code, verifier)
+      .then(async (result) => {
+        if (!result.ok) {
+          setStatus("error");
+          setErrorMessage(result.error);
+          return;
+        }
+
+        storeCloudToken(provider, result.accessToken);
+
+        // Fire-and-forget — token exchange is the success condition.
+        // The initial download/merge happens in the background; if it fails
+        // the poll loop will retry. Don't block the callback page on it.
+        startCloudSync(provider, result.accessToken).catch((err) => {
+          console.error("[OAuthCallback] startCloudSync failed:", err);
+        });
+
+        setStatus("success");
+
+        // Give the user a moment to see the success state before navigating.
+        setTimeout(() => {
+          window.location.replace("/");
+        }, 1200);
+      })
+      .catch((err: unknown) => {
+        console.error("[OAuthCallback] token exchange threw:", err);
         setStatus("error");
-        setErrorMessage(result.error);
-        return;
-      }
-
-      storeCloudToken(provider, result.accessToken);
-
-      // Fire-and-forget — token exchange is the success condition.
-      // The initial download/merge happens in the background; if it fails
-      // the poll loop will retry. Don't block the callback page on it.
-      startCloudSync(provider, result.accessToken).catch((err) => {
-        console.error("[OAuthCallback] startCloudSync failed:", err);
+        setErrorMessage(
+          err instanceof Error ? err.message : "Unexpected error during token exchange.",
+        );
       });
-
-      setStatus("success");
-
-      // Give the user a moment to see the success state before navigating.
-      setTimeout(() => {
-        window.location.replace("/");
-      }, 1200);
-    });
   }, []);
 
   return (

--- a/packages/pwa/vite.config.ts
+++ b/packages/pwa/vite.config.ts
@@ -20,6 +20,13 @@ export default defineConfig({
       workbox: {
         runtimeCaching: [
           {
+            // API routes must bypass the service worker entirely — Workbox's
+            // NetworkFirst strategy doesn't handle POST requests correctly and
+            // will silently hang the fetch (no network request, no error).
+            urlPattern: ({ url }) => url.pathname.startsWith('/api/'),
+            handler: 'NetworkOnly',
+          },
+          {
             urlPattern: /\.(?:png|jpg|jpeg|svg|gif|webp|avif)$/i,
             handler: 'CacheFirst',
             options: {
@@ -45,7 +52,9 @@ export default defineConfig({
             },
           },
           {
-            urlPattern: /^https?:\/\//,
+            // Catch-all for external resources (CDN, external APIs).
+            // Same-origin fetches not matched above bypass the SW natively.
+            urlPattern: /^https?:\/\/(?!freed-pwa)/,
             handler: 'NetworkFirst',
             options: {
               cacheName: 'freed-network',


### PR DESCRIPTION
## Root cause

Workbox's `NetworkFirst` strategy was matching **all** `https://` URLs via the catch-all `runtimeCaching` rule. When `OAuthCallback.tsx` posted to `/api/oauth/google` (the GDrive token-exchange proxy), Workbox intercepted it, attempted to cache the response (impossible for POST requests), and the promise **silently hung forever** — no network request, no error, infinite spinner.

## Changes

- **`vite.config.ts`** — add `NetworkOnly` rule for `/api/*` paths, placed before the catch-all. Also restrict the catch-all regex to external origins only, since same-origin fetches not matched by explicit rules already bypass the SW natively.
- **`OAuthCallback.tsx`** — add `.catch()` to the exchange promise so any future unhandled rejections surface as visible error UI instead of an infinite spinner.

## Test plan
- [ ] GDrive: Connect Google Drive → allow consent → callback completes and shows ✓ → redirects to app  
- [ ] Dropbox: Connect Dropbox → allow consent → callback completes and shows ✓ → redirects to app
- [ ] Cloud sync token persisted in localStorage; background poll loop starts

> **Note:** The new preview URL (`freed-pwa-git-fix-pwa-sw-oauth-api-bypass-v2-aubreyfs-projects.vercel.app`) needs to be added to Google Cloud Console OAuth redirect URIs and to the Dropbox app's redirect URIs before end-to-end OAuth testing can be run on this preview. Alternatively, merge to `main` and add `app.freed.wtf/oauth-callback` to both consoles.