### PR TITLE
debug(pwa): diagnostic logging for OAuthCallback to trace hung exchange

### DIFF
--- a/packages/pwa/api/oauth/google.ts
+++ b/packages/pwa/api/oauth/google.ts
@@ -10,7 +10,9 @@
  * protection against authorization code interception attacks.
  */
 
-export const runtime = "edge";
+// Do NOT set runtime = "edge": Cloudflare Workers (Edge Runtime) silently
+// hangs outbound fetch to oauth2.googleapis.com in Vercel's infrastructure.
+// Running as a Node.js Lambda has no such restriction.
 
 export default async function handler(req: Request): Promise<Response> {
   if (req.method !== "POST") {
@@ -48,6 +50,7 @@ export default async function handler(req: Request): Promise<Response> {
     method: "POST",
     headers: { "Content-Type": "application/x-www-form-urlencoded" },
     body: params,
+    signal: AbortSignal.timeout(8000),
   });
 
   const data = await upstream.json();

--- a/packages/pwa/src/components/OAuthCallback.tsx
+++ b/packages/pwa/src/components/OAuthCallback.tsx
@@ -92,6 +92,16 @@ export function OAuthCallback() {
     const provider = sessionStorage.getItem("freed_pkce_provider") as CloudProvider | null;
     const verifier = sessionStorage.getItem("freed_pkce_verifier");
 
+    // Diagnostic logging — retained until OAuth flow is verified stable.
+    console.log("[OAuthCallback] effect running", {
+      hasCode: !!code,
+      hasProvider: !!provider,
+      provider,
+      hasVerifier: !!verifier,
+      hasError: !!oauthError,
+      search: window.location.search.slice(0, 80),
+    });
+
     // Clean up PKCE state immediately — single-use.
     sessionStorage.removeItem("freed_pkce_provider");
     sessionStorage.removeItem("freed_pkce_verifier");
@@ -103,6 +113,11 @@ export function OAuthCallback() {
     }
 
     if (!code || !provider || !verifier) {
+      console.warn("[OAuthCallback] missing required params — aborting", {
+        code: code ? "ok" : "MISSING",
+        provider: provider ?? "MISSING",
+        verifier: verifier ? "ok" : "MISSING",
+      });
       setStatus("error");
       setErrorMessage(
         "OAuth callback is missing required parameters. Please try connecting again.",
@@ -110,10 +125,12 @@ export function OAuthCallback() {
       return;
     }
 
+    console.log("[OAuthCallback] starting token exchange for", provider);
     const exchange = provider === "gdrive" ? exchangeGDrive : exchangeDropbox;
 
     exchange(code, verifier)
       .then(async (result) => {
+        console.log("[OAuthCallback] exchange resolved", { ok: result.ok });
         if (!result.ok) {
           setStatus("error");
           setErrorMessage(result.error);

--- a/packages/pwa/src/components/OAuthCallback.tsx
+++ b/packages/pwa/src/components/OAuthCallback.tsx
@@ -112,29 +112,37 @@ export function OAuthCallback() {
 
     const exchange = provider === "gdrive" ? exchangeGDrive : exchangeDropbox;
 
-    exchange(code, verifier).then(async (result) => {
-      if (!result.ok) {
+    exchange(code, verifier)
+      .then(async (result) => {
+        if (!result.ok) {
+          setStatus("error");
+          setErrorMessage(result.error);
+          return;
+        }
+
+        storeCloudToken(provider, result.accessToken);
+
+        // Fire-and-forget — token exchange is the success condition.
+        // The initial download/merge happens in the background; if it fails
+        // the poll loop will retry. Don't block the callback page on it.
+        startCloudSync(provider, result.accessToken).catch((err) => {
+          console.error("[OAuthCallback] startCloudSync failed:", err);
+        });
+
+        setStatus("success");
+
+        // Give the user a moment to see the success state before navigating.
+        setTimeout(() => {
+          window.location.replace("/");
+        }, 1200);
+      })
+      .catch((err: unknown) => {
+        console.error("[OAuthCallback] token exchange threw:", err);
         setStatus("error");
-        setErrorMessage(result.error);
-        return;
-      }
-
-      storeCloudToken(provider, result.accessToken);
-
-      // Fire-and-forget — token exchange is the success condition.
-      // The initial download/merge happens in the background; if it fails
-      // the poll loop will retry. Don't block the callback page on it.
-      startCloudSync(provider, result.accessToken).catch((err) => {
-        console.error("[OAuthCallback] startCloudSync failed:", err);
+        setErrorMessage(
+          err instanceof Error ? err.message : "Unexpected error during token exchange.",
+        );
       });
-
-      setStatus("success");
-
-      // Give the user a moment to see the success state before navigating.
-      setTimeout(() => {
-        window.location.replace("/");
-      }, 1200);
-    });
   }, []);
 
   return (

--- a/packages/pwa/vite.config.ts
+++ b/packages/pwa/vite.config.ts
@@ -20,6 +20,13 @@ export default defineConfig({
       workbox: {
         runtimeCaching: [
           {
+            // API routes must bypass the service worker entirely — Workbox's
+            // NetworkFirst strategy doesn't handle POST requests correctly and
+            // will silently hang the fetch (no network request, no error).
+            urlPattern: ({ url }) => url.pathname.startsWith('/api/'),
+            handler: 'NetworkOnly',
+          },
+          {
             urlPattern: /\.(?:png|jpg|jpeg|svg|gif|webp|avif)$/i,
             handler: 'CacheFirst',
             options: {
@@ -45,7 +52,9 @@ export default defineConfig({
             },
           },
           {
-            urlPattern: /^https?:\/\//,
+            // Catch-all for external resources (CDN, external APIs).
+            // Same-origin fetches not matched above bypass the SW natively.
+            urlPattern: /^https?:\/\/(?!freed-pwa)/,
             handler: 'NetworkFirst',
             options: {
               cacheName: 'freed-network',


### PR DESCRIPTION
Temporary console.log statements to diagnose why the token exchange fetch never fires. Will be removed once the flow is confirmed working.