### PR TITLE
release: v26.3.200

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freed/desktop",
   "private": true,
-  "version": "26.3.104",
+  "version": "26.3.200",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freed-desktop"
-version = "26.3.104"
+version = "26.3.200"
 description = "Freed Desktop - Escape algorithmic manipulation"
 authors = ["Freed"]
 edition = "2021"

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Freed",
-  "version": "26.3.104",
+  "version": "26.3.200",
   "identifier": "wtf.freed.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freed/pwa",
   "private": true,
-  "version": "26.3.104",
+  "version": "26.3.200",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
(AI Generated)

## v26.3.200

CalVer bump to `26.3.200` (March 3, build 0).

### What's in this build

- GDrive + Dropbox OAuth confirmed working on `app.freed.wtf` — both flows complete end-to-end in ~4-5 seconds
- Vercel Google OAuth proxy rewritten as Node.js Lambda (Cloudflare Edge blocked `oauth2.googleapis.com`)
- Workbox service worker: `NetworkOnly` rule for `/api/*` before the catch-all
- Error handling improvements: `.catch()` on OAuth exchange, `AbortSignal.timeout(8000)` on upstream fetch
- Phase 4 cloud sync marked complete in docs