### PR TITLE
fix(ci): build capture-rss and capture-x before desktop release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,6 +93,8 @@ jobs:
         run: |
           npm run build -w @freed/shared
           npm run build -w @freed/sync
+          npm run build -w @freed/capture-rss
+          npm run build -w @freed/capture-x
 
       # macOS code signing (only runs if secrets are configured)
       - name: Import Apple signing certificate

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freed/desktop",
   "private": true,
-  "version": "26.3.104",
+  "version": "26.3.200",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freed-desktop"
-version = "26.3.104"
+version = "26.3.200"
 description = "Freed Desktop - Escape algorithmic manipulation"
 authors = ["Freed"]
 edition = "2021"

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Freed",
-  "version": "26.3.104",
+  "version": "26.3.200",
   "identifier": "wtf.freed.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freed/pwa",
   "private": true,
-  "version": "26.3.104",
+  "version": "26.3.200",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
(AI Generated)

The refactor PR (#13) delegated RSS parsing to `@freed/capture-rss` and X capture to `@freed/capture-x` in the desktop's `capture.ts`. The release workflow only pre-built `@freed/shared` and `@freed/sync`, causing `tsc -b` to fail with `TS2307` on all platforms for `v26.3.200`.

Adds the two capture packages to the workspace deps build step before Tauri compiles the desktop app.