### PR TITLE
fix(desktop): remove stale .data wrapper on TimelineResponse

### DIFF
--- a/packages/desktop/src/lib/x-capture.ts
+++ b/packages/desktop/src/lib/x-capture.ts
@@ -69,7 +69,7 @@ export async function fetchXTimeline(cookies: XCookies): Promise<ReturnType<type
 
   const tweets: XTweetResult[] = [];
   const instructions =
-    response.data?.home?.home_timeline_urt?.instructions || [];
+    response.home?.home_timeline_urt?.instructions || [];
 
   for (const instruction of instructions) {
     if (instruction.type === "TimelineAddEntries" && instruction.entries) {


### PR DESCRIPTION
(AI Generated)

After PR #13 refactored `@freed/capture-x`, `TimelineResponse` changed shape from `{ data: { home: ... } }` to `{ home: ... }`. The desktop's `x-capture.ts` still accessed `response.data?.home`, causing a `TS2339` type error that blocked all four release targets for `v26.3.200`.

One-line fix: `response.data?.home` → `response.home`.