### PR TITLE
fix(capture-x): add sideEffects:false for Rollup tree-shaking

### DIFF
--- a/packages/capture-x/package.json
+++ b/packages/capture-x/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "sideEffects": false,
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",


### PR DESCRIPTION
(AI Generated)

Without `"sideEffects": false`, Rollup includes `auth.js` (which imports `os`, `fs`, `path`, and `better-sqlite3`) whenever **any** export from `@freed/capture-x` is bundled — even if the auth functions are unreachable from the import chain.

This caused the desktop Vite build to hard-fail with:
```
"homedir" is not exported by "__vite-browser-external", imported by "../capture-x/dist/auth.js"
```

Setting `sideEffects: false` lets Rollup tree-shake `auth.js` and `client.js` out of the browser bundle, keeping only the pure constants (`endpoints.js`) and normalizers (`normalize.js`) that the desktop renderer actually uses.