### PR TITLE
fix(capture-x): add browser-safe subpath export to isolate Node-only code

### DIFF
--- a/packages/capture-x/package.json
+++ b/packages/capture-x/package.json
@@ -9,6 +9,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./browser": {
+      "types": "./dist/browser.d.ts",
+      "import": "./dist/browser.js"
     }
   },
   "scripts": {

--- a/packages/capture-x/src/browser.ts
+++ b/packages/capture-x/src/browser.ts
@@ -1,0 +1,44 @@
+/**
+ * Browser-safe entry point for @freed/capture-x
+ *
+ * Re-exports only the pure, Node-free modules:
+ *   - types (TypeScript-only, stripped at runtime)
+ *   - endpoints (constants and query builders)
+ *   - normalize (pure tweet → FeedItem converters)
+ *
+ * Explicitly omits auth.js and client.js, which depend on Node built-ins
+ * (os, fs, path, better-sqlite3) and cannot be bundled into a browser renderer.
+ *
+ * Use this entry point from any browser/Tauri renderer context:
+ *   import { X_API_BASE, tweetsToFeedItems } from "@freed/capture-x/browser";
+ */
+
+export * from "./types.js";
+
+export {
+  X_API_BASE,
+  X_BEARER_TOKEN,
+  COMMON_FEATURES,
+  TIMELINE_FEATURES,
+  HomeLatestTimeline,
+  HomeTimeline,
+  Following,
+  UserTweets,
+  TweetDetail,
+  buildGraphQLUrl,
+  buildRequestBody,
+  getHomeLatestTimelineVariables,
+  getFollowingVariables,
+  getUserTweetsVariables,
+} from "./endpoints.js";
+
+export {
+  extractMediaUrls,
+  extractMediaTypes,
+  extractLinkPreview,
+  expandUrls,
+  cleanTweetText,
+  tweetToFeedItem,
+  tweetsToFeedItems,
+  deduplicateFeedItems,
+} from "./normalize.js";

--- a/packages/desktop/src/lib/x-capture.ts
+++ b/packages/desktop/src/lib/x-capture.ts
@@ -18,8 +18,8 @@ import {
   tweetsToFeedItems,
   deduplicateFeedItems,
   getHomeLatestTimelineVariables,
-} from "@freed/capture-x";
-import type { XTweetResult, TimelineResponse } from "@freed/capture-x";
+} from "@freed/capture-x/browser";
+import type { XTweetResult, TimelineResponse } from "@freed/capture-x/browser";
 import type { XCookies } from "./x-auth";
 import { useAppStore } from "./store";
 


### PR DESCRIPTION
(AI Generated)

## Problem

`@freed/capture-x/auth.js` imports `os`, `fs`, `path`, and `better-sqlite3`. Even though the desktop renderer never calls `extractCookies` etc., importing **any** export from `@freed/capture-x` pulls `auth.js` into Rollup's module graph. Vite's browser bundler can't resolve `os.homedir`, causing a hard build failure on all 4 release platforms:

```
"homedir" is not exported by "__vite-browser-external", imported by "../capture-x/dist/auth.js"
```

## Fix

| File | Change |
|------|--------|
| `packages/capture-x/src/browser.ts` | New Node-free entry: re-exports only `types`, `endpoints`, `normalize` |
| `packages/capture-x/package.json` | Adds `"./browser"` subpath export pointing to `dist/browser.{js,d.ts}` |
| `packages/desktop/src/lib/x-capture.ts` | Switches imports to `@freed/capture-x/browser` |

Node/CLI consumers continue using the default `"."` entry with full access to `auth.js` and `client.js`.