### PR TITLE
fix(desktop): inline parseCookieString, switch x-auth to /browser imports

### DIFF
--- a/packages/capture-x/package.json
+++ b/packages/capture-x/package.json
@@ -9,6 +9,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./browser": {
+      "types": "./dist/browser.d.ts",
+      "import": "./dist/browser.js"
     }
   },
   "scripts": {

--- a/packages/capture-x/src/browser.ts
+++ b/packages/capture-x/src/browser.ts
@@ -1,0 +1,44 @@
+/**
+ * Browser-safe entry point for @freed/capture-x
+ *
+ * Re-exports only the pure, Node-free modules:
+ *   - types (TypeScript-only, stripped at runtime)
+ *   - endpoints (constants and query builders)
+ *   - normalize (pure tweet → FeedItem converters)
+ *
+ * Explicitly omits auth.js and client.js, which depend on Node built-ins
+ * (os, fs, path, better-sqlite3) and cannot be bundled into a browser renderer.
+ *
+ * Use this entry point from any browser/Tauri renderer context:
+ *   import { X_API_BASE, tweetsToFeedItems } from "@freed/capture-x/browser";
+ */
+
+export * from "./types.js";
+
+export {
+  X_API_BASE,
+  X_BEARER_TOKEN,
+  COMMON_FEATURES,
+  TIMELINE_FEATURES,
+  HomeLatestTimeline,
+  HomeTimeline,
+  Following,
+  UserTweets,
+  TweetDetail,
+  buildGraphQLUrl,
+  buildRequestBody,
+  getHomeLatestTimelineVariables,
+  getFollowingVariables,
+  getUserTweetsVariables,
+} from "./endpoints.js";
+
+export {
+  extractMediaUrls,
+  extractMediaTypes,
+  extractLinkPreview,
+  expandUrls,
+  cleanTweetText,
+  tweetToFeedItem,
+  tweetsToFeedItems,
+  deduplicateFeedItems,
+} from "./normalize.js";

--- a/packages/desktop/src/lib/x-auth.ts
+++ b/packages/desktop/src/lib/x-auth.ts
@@ -12,9 +12,32 @@
  * confirmed lazily on the first real API request via x-capture.ts.
  */
 
-export type { XCookies } from "@freed/capture-x";
-export { parseCookieString } from "@freed/capture-x";
-import type { XCookies } from "@freed/capture-x";
+export type { XCookies } from "@freed/capture-x/browser";
+import type { XCookies } from "@freed/capture-x/browser";
+
+/**
+ * Parse a raw cookie string (e.g. from document.cookie or a browser export)
+ * into a typed XCookies object.
+ *
+ * Inlined from @freed/capture-x/auth — that module uses Node built-ins
+ * (os, fs) and cannot be bundled into the Tauri renderer.
+ */
+export function parseCookieString(cookieString: string): XCookies | null {
+  const cookies: Record<string, string> = {};
+
+  for (const cookie of cookieString.split(";")) {
+    const [name, ...valueParts] = cookie.trim().split("=");
+    if (name && valueParts.length > 0) {
+      cookies[name.trim()] = valueParts.join("=").trim();
+    }
+  }
+
+  if (cookies.ct0 && cookies.auth_token) {
+    return { ct0: cookies.ct0, authToken: cookies.auth_token };
+  }
+
+  return null;
+}
 
 export interface XAuthState {
   isAuthenticated: boolean;

--- a/packages/desktop/src/lib/x-capture.ts
+++ b/packages/desktop/src/lib/x-capture.ts
@@ -18,8 +18,8 @@ import {
   tweetsToFeedItems,
   deduplicateFeedItems,
   getHomeLatestTimelineVariables,
-} from "@freed/capture-x";
-import type { XTweetResult, TimelineResponse } from "@freed/capture-x";
+} from "@freed/capture-x/browser";
+import type { XTweetResult, TimelineResponse } from "@freed/capture-x/browser";
 import type { XCookies } from "./x-auth";
 import { useAppStore } from "./store";
 


### PR DESCRIPTION
(AI Generated)

Follow-up to #25: `x-auth.ts` still imported `parseCookieString` and `XCookies` from the default `@freed/capture-x` entry, pulling `auth.js` (Node: `os`, `fs`, `path`) into the Vite renderer bundle.

**Changes:**
- `parseCookieString` inlined directly — it's a pure 10-line string splitter, no Node deps
- `XCookies` re-export and type import switched to `@freed/capture-x/browser`

Now **zero** imports from the default `@freed/capture-x` entry exist in the desktop renderer.