### PR TITLE
fix(capture-rss): cast rdf.channel before spread in browser.ts

### DIFF
--- a/packages/capture-rss/src/browser.ts
+++ b/packages/capture-rss/src/browser.ts
@@ -193,7 +193,7 @@ export async function parseFeedXml(
   } else if (doc["rdf:RDF"]) {
     // RSS 1.0 / RDF — channel metadata lives at rdf:RDF.channel
     const rdf = doc["rdf:RDF"] as Rec;
-    result = parseRss({ channel: { ...rdf.channel, item: rdf.item } });
+    result = parseRss({ channel: { ...(rdf.channel as Rec), item: rdf.item } });
   } else {
     throw new Error("Unrecognized feed format");
   }


### PR DESCRIPTION
(AI Generated)

One-line TypeScript fix: `...rdf.channel` → `...(rdf.channel as Rec)`.

The spread in `parseFeedXml`'s RDF/RSS 1.0 branch failed with `TS2698: Spread types may only be created from object types` because `rdf.channel` is `unknown`. Casting to `Rec` (= `Record<string, unknown>`) is safe here — `rdf.channel` is the parsed channel node from `fast-xml-parser` and will always be an object.