### PR TITLE
fix(desktop): heal untitled feed titles from live XML on sync

### DIFF
--- a/packages/desktop/src/lib/automerge.ts
+++ b/packages/desktop/src/lib/automerge.ts
@@ -252,8 +252,25 @@ export async function docBatchRefreshFeeds(
 ): Promise<FreedDoc> {
   return applyChange((doc) => {
     for (const feed of feeds) {
-      if (doc.rssFeeds[feed.url] && feed.lastFetched !== undefined) {
-        doc.rssFeeds[feed.url].lastFetched = feed.lastFetched;
+      const stored = doc.rssFeeds[feed.url];
+      if (!stored) continue;
+
+      if (feed.lastFetched !== undefined) {
+        stored.lastFetched = feed.lastFetched;
+      }
+
+      // Heal sentinel titles from live feed XML — never clobbers user-set names.
+      // Both "Untitled Feed" (OPML fallback) and the raw feed URL (addRssFeed fallback)
+      // are treated as sentinels indicating a title was never properly resolved.
+      if (feed.title && feed.title !== "Untitled Feed" && feed.title !== feed.url) {
+        if (stored.title === "Untitled Feed" || stored.title === stored.url) {
+          stored.title = feed.title;
+        }
+      }
+
+      // Backfill missing siteUrl from live feed data
+      if (feed.siteUrl && !stored.siteUrl) {
+        stored.siteUrl = feed.siteUrl;
       }
     }
 

--- a/packages/desktop/src/lib/capture.ts
+++ b/packages/desktop/src/lib/capture.ts
@@ -281,7 +281,19 @@ export async function refreshAllFeeds(): Promise<void> {
       const results = await Promise.allSettled(
         batch.map(async (feed) => {
           const items = await fetchRssFeed(feed.url);
-          return { feed: { ...feed, lastFetched: Date.now() }, items };
+          const liveFeedTitle = items[0]?.rssSource?.feedTitle;
+          const liveSiteUrl = items[0]?.rssSource?.siteUrl;
+          // Sentinel check: OPML fallback or raw URL as title both indicate a broken import
+          const isUntitled = feed.title === "Untitled Feed" || feed.title === feed.url;
+          return {
+            feed: {
+              ...feed,
+              lastFetched: Date.now(),
+              ...(isUntitled && liveFeedTitle ? { title: liveFeedTitle } : {}),
+              ...(!feed.siteUrl && liveSiteUrl ? { siteUrl: liveSiteUrl } : {}),
+            },
+            items,
+          };
         }),
       );
       for (const result of results) {


### PR DESCRIPTION
(AI Generated)

## Summary
- On sync, desktop app now re-fetches live XML to recover missing feed titles that were previously stored as untitled

## Test plan
- [ ] Sync a feed that was previously untitled — verify title is populated after sync