### PR TITLE
fix(pwa/api): rewrite Google OAuth proxy as Node.js Lambda

### DIFF
--- a/packages/pwa/api/oauth/google.ts
+++ b/packages/pwa/api/oauth/google.ts
@@ -10,7 +10,9 @@
  * protection against authorization code interception attacks.
  */
 
-export const runtime = "edge";
+// Do NOT set runtime = "edge": Cloudflare Workers (Edge Runtime) silently
+// hangs outbound fetch to oauth2.googleapis.com in Vercel's infrastructure.
+// Running as a Node.js Lambda has no such restriction.
 
 export default async function handler(req: Request): Promise<Response> {
   if (req.method !== "POST") {
@@ -48,6 +50,7 @@ export default async function handler(req: Request): Promise<Response> {
     method: "POST",
     headers: { "Content-Type": "application/x-www-form-urlencoded" },
     body: params,
+    signal: AbortSignal.timeout(8000),
   });
 
   const data = await upstream.json();

--- a/packages/pwa/api/oauth/google.ts
+++ b/packages/pwa/api/oauth/google.ts
@@ -2,39 +2,48 @@
  * Server-side proxy for Google Drive OAuth token exchange.
  *
  * Google's token endpoint requires a client_secret even for PKCE flows when
- * using a "Web application" OAuth client type. This edge function holds the
- * secret server-side and proxies the exchange, returning only the access_token
- * to the client.
+ * using a "Web application" OAuth client type. This serverless function holds
+ * the secret server-side and proxies the exchange, returning only the
+ * access_token to the client.
  *
  * The PKCE code_verifier is still forwarded to Google, preserving PKCE's
  * protection against authorization code interception attacks.
+ *
+ * NOTE: Do NOT add `export const runtime = "edge"`. Vercel's Edge Runtime
+ * (Cloudflare Workers) silently hangs on outbound connections to
+ * oauth2.googleapis.com. This runs as a Node.js Lambda which has unrestricted
+ * outbound network access.
+ *
+ * The Vercel Node.js Lambda runtime invokes the function with (req, res) and
+ * expects the handler to call res.json() / res.send() — not return a Response.
  */
 
-// Do NOT set runtime = "edge": Cloudflare Workers (Edge Runtime) silently
-// hangs outbound fetch to oauth2.googleapis.com in Vercel's infrastructure.
-// Running as a Node.js Lambda has no such restriction.
-
-export default async function handler(req: Request): Promise<Response> {
+// Vercel extends IncomingMessage / ServerResponse at runtime.
+// Using any avoids installing @vercel/node as a devDependency.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export default async function handler(req: any, res: any): Promise<void> {
   if (req.method !== "POST") {
-    return new Response("Method Not Allowed", { status: 405 });
+    res.status(405).json({ error: "Method Not Allowed" });
+    return;
   }
 
   const clientId = process.env.VITE_GDRIVE_CLIENT_ID;
   const clientSecret = process.env.GDRIVE_CLIENT_SECRET;
 
   if (!clientId || !clientSecret) {
-    return json({ error: "OAuth credentials not configured on server" }, 500);
+    res.status(500).json({ error: "OAuth credentials not configured on server" });
+    return;
   }
 
-  let code: string, verifier: string, redirectUri: string;
-  try {
-    const body = await req.json();
-    code = body.code;
-    verifier = body.verifier;
-    redirectUri = body.redirectUri;
-    if (!code || !verifier || !redirectUri) throw new Error("missing fields");
-  } catch {
-    return json({ error: "Invalid request body" }, 400);
+  const { code, verifier, redirectUri } = (req.body ?? {}) as {
+    code?: string;
+    verifier?: string;
+    redirectUri?: string;
+  };
+
+  if (!code || !verifier || !redirectUri) {
+    res.status(400).json({ error: "Invalid request body" });
+    return;
   }
 
   const params = new URLSearchParams({
@@ -46,28 +55,27 @@ export default async function handler(req: Request): Promise<Response> {
     grant_type: "authorization_code",
   });
 
-  const upstream = await fetch("https://oauth2.googleapis.com/token", {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: params,
-    signal: AbortSignal.timeout(8000),
-  });
+  try {
+    const upstream = await fetch("https://oauth2.googleapis.com/token", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: params,
+      signal: AbortSignal.timeout(8000),
+    });
 
-  const data = await upstream.json();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const data = (await upstream.json()) as any;
 
-  if (!upstream.ok) {
-    const msg = data.error_description ?? data.error ?? "token exchange failed";
-    return json({ error: msg }, upstream.status);
+    if (!upstream.ok) {
+      const msg: string = data.error_description ?? data.error ?? "token exchange failed";
+      res.status(upstream.status).json({ error: msg });
+      return;
+    }
+
+    // Return only the access_token — client_secret and refresh_token never leave the server.
+    res.status(200).json({ access_token: data.access_token });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    res.status(500).json({ error: `Token exchange failed: ${message}` });
   }
-
-  // Return only the access_token. The client_secret and refresh_token never
-  // leave the server. Refresh token handling is deferred to a future phase.
-  return json({ access_token: data.access_token });
-}
-
-function json(body: unknown, status = 200): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { "Content-Type": "application/json" },
-  });
 }


### PR DESCRIPTION
(AI Generated)

## Summary
- Rewrites the Google OAuth proxy API route as a Node.js Lambda (req/res style) to fix Cloudflare Edge blocking `oauth2.googleapis.com`
- Switches from Edge runtime to Node.js runtime to allow outbound OAuth token exchange

## Test plan
- [ ] Verify Google Drive OAuth flow completes successfully in the PWA
- [ ] Confirm no CORS or runtime errors in Vercel function logs