### PR TITLE
feat(pwa): subscribe to RSS feeds from the PWA with deferred metadata

### DIFF
--- a/packages/pwa/src/App.tsx
+++ b/packages/pwa/src/App.tsx
@@ -5,7 +5,7 @@ import { ToastContainer } from "@freed/ui/components/Toast";
 import { OAuthCallback } from "./components/OAuthCallback";
 import { PlatformProvider, type PlatformConfig } from "@freed/ui/context";
 import { useAppStore } from "./lib/store";
-import { exportFeedsAsOPML } from "./lib/capture";
+import { exportFeedsAsOPML, subscribeToFeed } from "./lib/capture";
 import {
   connect,
   disconnect,
@@ -72,6 +72,7 @@ function App() {
   const platform: PlatformConfig = useMemo(
     () => ({
       store: useAppStore,
+      addRssFeed: subscribeToFeed,
       exportFeedsAsOPML,
       SidebarConnectionSection: null,
       SourceIndicator: null,

--- a/packages/pwa/src/components/PwaFeedEmptyState.tsx
+++ b/packages/pwa/src/components/PwaFeedEmptyState.tsx
@@ -4,7 +4,68 @@ import { SyncConnectDialog } from "./SyncConnectDialog";
 
 export function PwaFeedEmptyState() {
   const syncConnected = useAppStore((s) => s.syncConnected);
+  const activeFilter = useAppStore((s) => s.activeFilter);
+  const feeds = useAppStore((s) => s.feeds);
   const [showConnect, setShowConnect] = useState(false);
+
+  // Per-feed view: a specific feed is selected but has no items yet.
+  // `lastFetched` is absent on stub entries added from the PWA — a reliable
+  // signal that the desktop hasn't polled this feed yet.
+  const activeFeed = activeFilter.feedUrl ? feeds[activeFilter.feedUrl] : null;
+  const isPendingSync = activeFeed != null && !activeFeed.lastFetched;
+
+  if (isPendingSync) {
+    // Display hostname when the title is still the raw URL sentinel
+    const displayName =
+      activeFeed.title === activeFeed.url
+        ? new URL(activeFeed.url).hostname
+        : activeFeed.title;
+
+    return (
+      <>
+        <div className="w-16 h-16 rounded-full bg-gradient-to-br from-[#3b82f6]/20 to-[#8b5cf6]/20 flex items-center justify-center mb-4">
+          <span className="text-2xl">📡</span>
+        </div>
+        <p className="text-lg font-medium mb-2">Subscribed!</p>
+        <p className="text-sm text-[#71717a] max-w-xs leading-relaxed">
+          Items from{" "}
+          <span className="text-white font-medium">{displayName}</span> will
+          appear here after your desktop app syncs and fetches the feed.
+        </p>
+        {!syncConnected && (
+          <>
+            <p className="text-xs text-[#52525b] mt-3 max-w-xs">
+              Open your desktop app and make sure it's connected to start
+              receiving content.
+            </p>
+            <button
+              onClick={() => setShowConnect(true)}
+              className="mt-4 flex items-center gap-2 px-5 py-2.5 rounded-xl bg-[#8b5cf6]/20 text-[#8b5cf6] hover:bg-[#8b5cf6]/30 transition-colors font-medium text-sm"
+            >
+              <svg
+                className="w-4 h-4"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"
+                />
+              </svg>
+              Connect desktop
+            </button>
+          </>
+        )}
+        <SyncConnectDialog
+          open={showConnect}
+          onClose={() => setShowConnect(false)}
+        />
+      </>
+    );
+  }
 
   return (
     <>
@@ -21,13 +82,26 @@ export function PwaFeedEmptyState() {
           onClick={() => setShowConnect(true)}
           className="mt-4 flex items-center gap-2 px-5 py-2.5 rounded-xl bg-[#8b5cf6]/20 text-[#8b5cf6] hover:bg-[#8b5cf6]/30 transition-colors font-medium text-sm"
         >
-          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
+          <svg
+            className="w-4 h-4"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"
+            />
           </svg>
           Connect
         </button>
       )}
-      <SyncConnectDialog open={showConnect} onClose={() => setShowConnect(false)} />
+      <SyncConnectDialog
+        open={showConnect}
+        onClose={() => setShowConnect(false)}
+      />
     </>
   );
 }

--- a/packages/pwa/src/lib/capture.ts
+++ b/packages/pwa/src/lib/capture.ts
@@ -3,13 +3,58 @@
  *
  * The PWA is a reader — it displays items synced from the desktop app
  * via Automerge. Feed subscription and fetching are desktop-only
- * capabilities (the PWA has no CORS proxy). The PWA can export existing
- * subscriptions to OPML for portability.
+ * capabilities (the PWA has no CORS proxy).
+ *
+ * The PWA CAN subscribe to feeds by writing a stub entry to the CRDT doc.
+ * The desktop poller detects the stub (title === url sentinel) on next sync
+ * and heals it with real metadata and content.
  */
 
+import type { RssFeed } from "@freed/shared";
+import { generateOPML, downloadFile } from "@freed/shared";
 import { useAppStore } from "./store";
 import { toast } from "@freed/ui/components/Toast";
-import { generateOPML, downloadFile } from "@freed/shared";
+
+/**
+ * Subscribe to an RSS feed from the PWA.
+ *
+ * The PWA cannot fetch RSS content directly (CORS). Instead, this writes a
+ * stub subscription to the Automerge doc using the URL as a sentinel title.
+ * The desktop poller recognises the sentinel on next sync, fetches real
+ * metadata and content, and heals the title in-place.
+ */
+export async function subscribeToFeed(url: string): Promise<void> {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error("Invalid URL");
+  }
+
+  if (!["http:", "https:"].includes(parsed.protocol)) {
+    throw new Error("Only http and https URLs are supported");
+  }
+
+  const store = useAppStore.getState();
+
+  if (store.feeds[url]) {
+    throw new Error("Already subscribed to this feed");
+  }
+
+  const stub: RssFeed = {
+    url,
+    // Use the raw URL as the title — this is the sentinel the desktop poller
+    // checks for when deciding whether to overwrite the stored title with the
+    // real feed title on first fetch.
+    title: url,
+    enabled: true,
+    trackUnread: false,
+  };
+
+  await store.addFeed(stub);
+
+  toast.success("Feed added — items will appear after your next desktop sync");
+}
 
 /**
  * Export all current feed subscriptions as an OPML file download.


### PR DESCRIPTION
(AI Generated)

## Summary

- Enables RSS feed subscription from the PWA — user enters a URL, a stub entry is written to the Automerge CRDT doc, and the desktop poller heals it (title, icon, content) on next sync
- Unlocks the "Add URL" tab in `AddFeedDialog` for PWA users by wiring `subscribeToFeed` into `PlatformConfig.addRssFeed`; the tab was previously hidden because the field was absent
- Adds a "Subscribed!" per-feed empty state in `PwaFeedEmptyState` that appears when viewing a feed with no `lastFetched` yet, with a nudge to connect the desktop app if not paired

## How it works

The PWA writes a stub `RssFeed` where `title === url`. The desktop's `docBatchRefreshFeeds` already treats this as a sentinel (per the `feed.title === feed.url` check at line 265 of `desktop/src/lib/automerge.ts`) and overwrites the title with the real feed title on first fetch. No new infrastructure required — this is pure CRDT ergonomics.

## Test plan

- [ ] Open PWA at `app.freed.wtf`, open RSS Feeds dialog — "Add URL" tab is now visible
- [ ] Add a feed URL (e.g. `https://hnrss.org/frontpage`) — toast appears: "Feed added — items will appear after your next desktop sync"
- [ ] Feed appears in sidebar with raw URL as name; clicking it shows the "Subscribed!" empty state
- [ ] With desktop connected, trigger a sync — feed title and items appear; empty state resolves
- [ ] Adding a duplicate URL shows "Already subscribed to this feed" error in the dialog
- [ ] Invalid URL (e.g. `not-a-url`) shows "Invalid URL" error