### PR TITLE
feat: add bulk unsubscribe and factory reset features

### DIFF
--- a/packages/desktop/src/App.tsx
+++ b/packages/desktop/src/App.tsx
@@ -9,7 +9,18 @@ import { useAppStore } from "./lib/store";
 import { addRssFeed, importOPMLFeeds, exportFeedsAsOPML } from "./lib/capture";
 import { startRssPoller, stopRssPoller } from "./lib/rss-poller";
 import { relaunch } from "@tauri-apps/plugin-process";
-import { startSync, stopSync, startAllCloudSyncs } from "./lib/sync";
+import {
+  startSync,
+  stopSync,
+  startAllCloudSyncs,
+  stopAllCloudSyncs,
+  getActiveProviders,
+  getCloudToken,
+  clearCloudProvider,
+  deleteCloudFile,
+} from "./lib/sync";
+import { clearLocalDoc } from "./lib/automerge";
+import { clearStoredCookies } from "./lib/x-auth";
 import { XFeedEmptyState } from "./components/XFeedEmptyState";
 import { XAuthSection } from "./components/XAuthSection";
 import { XSourceIndicator } from "./components/XSourceIndicator";
@@ -61,6 +72,22 @@ function App() {
     await relaunch();
   }, []);
 
+  const handleFactoryReset = useCallback(async (deleteFromCloud: boolean) => {
+    const providers = getActiveProviders();
+    if (deleteFromCloud) {
+      for (const provider of providers) {
+        const token = getCloudToken(provider);
+        if (token) await deleteCloudFile(provider, token);
+      }
+    } else {
+      stopAllCloudSyncs();
+    }
+    clearStoredCookies();
+    for (const provider of providers) clearCloudProvider(provider);
+    await clearLocalDoc();
+    location.reload();
+  }, []);
+
   const platform: PlatformConfig = useMemo(
     () => ({
       store: useAppStore,
@@ -75,8 +102,16 @@ function App() {
       FeedEmptyState: XFeedEmptyState,
       checkForUpdates,
       applyUpdate,
+      factoryReset: handleFactoryReset,
+      activeCloudProviderLabel: () => {
+        const providers = getActiveProviders();
+        if (providers.length === 0) return null;
+        return providers
+          .map((p) => (p === "gdrive" ? "Google Drive" : "Dropbox"))
+          .join(" & ");
+      },
     }),
-    [checkForUpdates, applyUpdate],
+    [checkForUpdates, applyUpdate, handleFactoryReset],
   );
 
   if (!isInitialized && isLoading) {

--- a/packages/desktop/src/lib/automerge.ts
+++ b/packages/desktop/src/lib/automerge.ts
@@ -13,6 +13,7 @@ import {
   addFeedItem,
   addRssFeed,
   removeRssFeed,
+  removeAllFeeds,
   updateRssFeed,
   updateFeedItem,
   removeFeedItem,
@@ -205,6 +206,27 @@ export async function docUpdatePreferences(
 
 export async function docUpdateLastSync(): Promise<FreedDoc> {
   return applyChange((doc) => updateLastSync(doc), "Update last sync");
+}
+
+/**
+ * Remove all feed subscriptions in a single CRDT change.
+ * When includeItems is true, all articles are also deleted.
+ * This change propagates to all synced devices.
+ */
+export async function docRemoveAllFeeds(includeItems: boolean): Promise<FreedDoc> {
+  return applyChange(
+    (doc) => removeAllFeeds(doc, includeItems),
+    includeItems ? "Remove all feeds and articles" : "Remove all feeds",
+  );
+}
+
+/**
+ * Wipe the IndexedDB document store for this device.
+ * Local-only — does NOT propagate to other devices.
+ * After calling this, reload the page to start fresh.
+ */
+export async function clearLocalDoc(): Promise<void> {
+  await storage.clear();
 }
 
 /**

--- a/packages/desktop/src/lib/store.ts
+++ b/packages/desktop/src/lib/store.ts
@@ -13,6 +13,7 @@ import {
   docAddFeedItems,
   docAddRssFeed,
   docRemoveRssFeed,
+  docRemoveAllFeeds,
   docUpdateRssFeed,
   docUpdateFeedItem,
   docMarkAsRead,
@@ -77,6 +78,7 @@ interface AppState {
   addFeed: (feed: RssFeed) => Promise<void>;
   removeFeed: (url: string) => Promise<void>;
   renameFeed: (url: string, title: string) => Promise<void>;
+  removeAllFeeds: (includeItems: boolean) => Promise<void>;
 
   // Preference actions (persisted to Automerge)
   updatePreferences: (update: Partial<UserPreferences>) => Promise<void>;
@@ -226,6 +228,10 @@ export const useAppStore = create<AppState>((set, get) => ({
 
   removeFeed: async (url) => {
     await docRemoveRssFeed(url);
+  },
+
+  removeAllFeeds: async (includeItems) => {
+    await docRemoveAllFeeds(includeItems);
   },
 
   renameFeed: async (url, title) => {

--- a/packages/desktop/src/lib/sync.ts
+++ b/packages/desktop/src/lib/sync.ts
@@ -14,9 +14,11 @@ import {
   gdriveUploadSafe,
   gdriveStartPollLoop,
   gdriveDownloadLatest,
+  gdriveDeleteFile,
   dropboxUploadSafe,
   dropboxStartLongpollLoop,
   dropboxDownloadLatest,
+  dropboxDeleteFile,
   type CloudProvider,
 } from "@freed/sync/cloud";
 
@@ -477,6 +479,20 @@ export function stopCloudSync(provider: CloudProvider): void {
 export function stopAllCloudSyncs(): void {
   for (const provider of cloudAborts.keys()) {
     stopCloudSync(provider);
+  }
+}
+
+/**
+ * Delete the cloud sync file for the given provider.
+ * Stops the sync loop first to prevent a race with any in-flight upload.
+ * Used during factory reset when the user opts to also wipe cloud storage.
+ */
+export async function deleteCloudFile(provider: CloudProvider, token: string): Promise<void> {
+  stopCloudSync(provider);
+  if (provider === "gdrive") {
+    await gdriveDeleteFile(token);
+  } else {
+    await dropboxDeleteFile(token);
   }
 }
 

--- a/packages/pwa/src/App.tsx
+++ b/packages/pwa/src/App.tsx
@@ -11,10 +11,15 @@ import {
   disconnect,
   onStatusChange,
   getStoredRelayUrl,
+  clearStoredRelayUrl,
   startCloudSync,
+  stopCloudSync,
   getCloudProvider,
   getCloudToken,
+  clearCloudSync,
+  deleteCloudFile,
 } from "./lib/sync";
+import { clearLocalDoc } from "./lib/automerge";
 import { checkForPwaUpdate, applyPwaUpdate, onUpdateAvailable } from "./lib/pwa-updater";
 import { SyncIndicator } from "./components/layout/SyncIndicator";
 import { PwaFeedEmptyState } from "./components/PwaFeedEmptyState";
@@ -69,6 +74,20 @@ function App() {
 
   const checkForUpdates = useCallback(() => checkForPwaUpdate(), []);
 
+  const handleFactoryReset = useCallback(async (deleteFromCloud: boolean) => {
+    const provider = getCloudProvider();
+    const token = provider ? getCloudToken(provider) : null;
+    if (deleteFromCloud && provider && token) {
+      await deleteCloudFile(provider, token);
+    } else {
+      stopCloudSync();
+    }
+    clearStoredRelayUrl();
+    if (provider) clearCloudSync(provider);
+    await clearLocalDoc();
+    location.reload();
+  }, []);
+
   const platform: PlatformConfig = useMemo(
     () => ({
       store: useAppStore,
@@ -81,8 +100,15 @@ function App() {
       FeedEmptyState: PwaFeedEmptyState,
       checkForUpdates,
       applyUpdate: applyPwaUpdate,
+      factoryReset: handleFactoryReset,
+      activeCloudProviderLabel: () => {
+        const p = getCloudProvider();
+        if (p === "gdrive") return "Google Drive";
+        if (p === "dropbox") return "Dropbox";
+        return null;
+      },
     }),
-    [checkForUpdates],
+    [checkForUpdates, handleFactoryReset],
   );
 
   if (!isInitialized && isLoading) {

--- a/packages/pwa/src/lib/automerge.ts
+++ b/packages/pwa/src/lib/automerge.ts
@@ -12,6 +12,7 @@ import {
   addFeedItem,
   addRssFeed,
   removeRssFeed,
+  removeAllFeeds,
   updateRssFeed,
   updateFeedItem,
   removeFeedItem,
@@ -189,6 +190,27 @@ export async function docUpdatePreferences(
 
 export async function docUpdateLastSync(): Promise<FreedDoc> {
   return applyChange((doc) => updateLastSync(doc), "Update last sync");
+}
+
+/**
+ * Remove all feed subscriptions in a single CRDT change.
+ * When includeItems is true, all articles are also deleted.
+ * This change propagates to all synced devices.
+ */
+export async function docRemoveAllFeeds(includeItems: boolean): Promise<FreedDoc> {
+  return applyChange(
+    (doc) => removeAllFeeds(doc, includeItems),
+    includeItems ? "Remove all feeds and articles" : "Remove all feeds",
+  );
+}
+
+/**
+ * Wipe the IndexedDB document store for this device.
+ * Local-only — does NOT propagate to other devices.
+ * After calling this, reload the page to start fresh.
+ */
+export async function clearLocalDoc(): Promise<void> {
+  await storage.clear();
 }
 
 /**

--- a/packages/pwa/src/lib/store.ts
+++ b/packages/pwa/src/lib/store.ts
@@ -13,6 +13,7 @@ import {
   docAddFeedItems,
   docAddRssFeed,
   docRemoveRssFeed,
+  docRemoveAllFeeds,
   docUpdateRssFeed,
   docUpdateFeedItem,
   docMarkAsRead,
@@ -152,6 +153,10 @@ export const useAppStore = create<AppState>((set, get) => ({
 
   removeFeed: async (url) => {
     await docRemoveRssFeed(url);
+  },
+
+  removeAllFeeds: async (includeItems) => {
+    await docRemoveAllFeeds(includeItems);
   },
 
   renameFeed: async (url, title) => {

--- a/packages/pwa/src/lib/sync.ts
+++ b/packages/pwa/src/lib/sync.ts
@@ -18,9 +18,11 @@ import {
   gdriveUploadSafe,
   gdriveStartPollLoop,
   gdriveDownloadLatest,
+  gdriveDeleteFile,
   dropboxUploadSafe,
   dropboxStartLongpollLoop,
   dropboxDownloadLatest,
+  dropboxDeleteFile,
   type CloudProvider,
 } from "@freed/sync/cloud";
 
@@ -272,6 +274,20 @@ export async function startCloudSync(provider: CloudProvider, token: string): Pr
   }
 
   console.log("[CloudSync] Started (%s)", provider);
+}
+
+/**
+ * Delete the cloud sync file for the given provider.
+ * Stops the sync loop first to prevent a race with any in-flight upload.
+ * Used during factory reset when the user opts to also wipe cloud storage.
+ */
+export async function deleteCloudFile(provider: CloudProvider, token: string): Promise<void> {
+  stopCloudSync();
+  if (provider === "gdrive") {
+    await gdriveDeleteFile(token);
+  } else {
+    await dropboxDeleteFile(token);
+  }
 }
 
 /** Stop the active cloud sync loop and cancel any pending upload. */

--- a/packages/shared/src/schema.ts
+++ b/packages/shared/src/schema.ts
@@ -213,6 +213,26 @@ export function toggleFeedEnabled(doc: FreedDoc, url: string): void {
   }
 }
 
+/**
+ * Remove all RSS feed subscriptions in a single CRDT change.
+ *
+ * This propagates to all synced devices. When `includeItems` is true,
+ * all feedItems are also deleted — equivalent to a full data wipe.
+ *
+ * @param doc - The Automerge document (mutable within A.change)
+ * @param includeItems - Whether to also delete all feed items
+ */
+export function removeAllFeeds(doc: FreedDoc, includeItems: boolean): void {
+  for (const url of Object.keys(doc.rssFeeds)) {
+    delete doc.rssFeeds[url];
+  }
+  if (includeItems) {
+    for (const id of Object.keys(doc.feedItems)) {
+      delete doc.feedItems[id];
+    }
+  }
+}
+
 // =============================================================================
 // Preferences Operations
 // =============================================================================

--- a/packages/shared/src/store-types.ts
+++ b/packages/shared/src/store-types.ts
@@ -66,6 +66,8 @@ export interface BaseAppState {
   addFeed: (feed: RssFeed) => Promise<void>;
   removeFeed: (url: string) => Promise<void>;
   renameFeed: (url: string, title: string) => Promise<void>;
+  /** Remove all feed subscriptions. Pass `includeItems: true` to also wipe all articles. */
+  removeAllFeeds: (includeItems: boolean) => Promise<void>;
 
   // Preference actions
   updatePreferences: (update: Partial<UserPreferences>) => Promise<void>;

--- a/packages/sync/src/cloud/dropbox.ts
+++ b/packages/sync/src/cloud/dropbox.ts
@@ -103,6 +103,25 @@ export async function dropboxDownloadLatest(
 }
 
 /**
+ * Permanently delete the `freed.automerge` file from Dropbox.
+ * Used during factory reset when the user opts to also wipe cloud storage.
+ * A 409 response (path not found) is treated as success.
+ */
+export async function dropboxDeleteFile(token: string): Promise<void> {
+  const res = await fetch("https://api.dropboxapi.com/2/files/delete_v2", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ path: DBX_PATH }),
+  });
+  if (!res.ok && res.status !== 409) {
+    throw new Error(`Dropbox delete failed: ${res.status}`);
+  }
+}
+
+/**
  * Dropbox longpoll loop — near-instant change notification.
  * Blocks at the notify endpoint until the folder changes or timeout expires,
  * then fetches the diff and calls `onRemoteChange` when our file was updated.

--- a/packages/sync/src/cloud/gdrive.ts
+++ b/packages/sync/src/cloud/gdrive.ts
@@ -121,6 +121,30 @@ export async function gdriveDownloadLatest(
 }
 
 /**
+ * Permanently delete the `freed.automerge` file from Google Drive appDataFolder.
+ * Used during factory reset when the user opts to also wipe cloud storage.
+ * Silently succeeds if the file does not exist (404).
+ */
+export async function gdriveDeleteFile(token: string): Promise<void> {
+  const listRes = await fetch(
+    `${GDRIVE_FILES}?spaces=appDataFolder&q=name%3D'${FILE_NAME}'&fields=files(id)`,
+    { headers: { Authorization: `Bearer ${token}` } },
+  );
+  if (!listRes.ok) throw new Error(`GDrive list failed: ${listRes.status}`);
+
+  const { files } = await listRes.json();
+  if (files.length === 0) return; // Nothing to delete.
+
+  const deleteRes = await fetch(`${GDRIVE_FILES}/${files[0].id}`, {
+    method: "DELETE",
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!deleteRes.ok && deleteRes.status !== 404) {
+    throw new Error(`GDrive delete failed: ${deleteRes.status}`);
+  }
+}
+
+/**
  * Poll the GDrive Changes API every 5 s.
  * Uses a server-side page-token cursor so only genuine changes trigger a
  * download. Runs until `signal` is aborted.

--- a/packages/sync/src/cloud/index.ts
+++ b/packages/sync/src/cloud/index.ts
@@ -11,10 +11,11 @@
  */
 
 export type { CloudProvider } from "./types.js";
-export { gdriveUploadSafe, gdriveDownloadLatest, gdriveStartPollLoop } from "./gdrive.js";
+export { gdriveUploadSafe, gdriveDownloadLatest, gdriveStartPollLoop, gdriveDeleteFile } from "./gdrive.js";
 export {
   dropboxUploadSafe,
   dropboxDownloadLatest,
   dropboxStartLongpollLoop,
+  dropboxDeleteFile,
 } from "./dropbox.js";
 export { mergeBinaries, delay } from "./merge.js";

--- a/packages/ui/src/components/AddFeedDialog.tsx
+++ b/packages/ui/src/components/AddFeedDialog.tsx
@@ -150,8 +150,12 @@ function AddUrlTab({ onClose }: { onClose: () => void }) {
 function ManageTab() {
   const feeds = useAppStore((s) => s.feeds);
   const removeFeed = useAppStore((s) => s.removeFeed);
+  const removeAllFeeds = useAppStore((s) => s.removeAllFeeds);
   const feedList = Object.values(feeds);
   const [removing, setRemoving] = useState<string | null>(null);
+  const [showRemoveAll, setShowRemoveAll] = useState(false);
+  const [includeItems, setIncludeItems] = useState(false);
+  const [removingAll, setRemovingAll] = useState(false);
 
   const handleRemove = async (url: string) => {
     setRemoving(url);
@@ -159,6 +163,17 @@ function ManageTab() {
       await removeFeed(url);
     } finally {
       setRemoving(null);
+    }
+  };
+
+  const handleRemoveAll = async () => {
+    setRemovingAll(true);
+    try {
+      await removeAllFeeds(includeItems);
+    } finally {
+      setRemovingAll(false);
+      setShowRemoveAll(false);
+      setIncludeItems(false);
     }
   };
 
@@ -172,42 +187,114 @@ function ManageTab() {
   }
 
   return (
-    <div className="space-y-2">
-      {feedList.map((feed) => (
-        <div
-          key={feed.url}
-          className="flex items-center gap-3 px-3 py-2.5 rounded-xl bg-white/[0.03] border border-[rgba(255,255,255,0.05)]"
-        >
-          {feed.imageUrl ? (
-            <img src={feed.imageUrl} alt="" className="w-8 h-8 rounded-md flex-shrink-0 object-cover" />
-          ) : (
-            <div className="w-8 h-8 rounded-md bg-[#8b5cf6]/10 flex items-center justify-center flex-shrink-0">
-              <span className="text-sm">📡</span>
-            </div>
-          )}
-          <div className="flex-1 min-w-0">
-            <p className="text-sm text-white truncate">{feed.title}</p>
-            <p className="text-xs text-[#52525b] truncate">{feed.url}</p>
-          </div>
-          <button
-            onClick={() => handleRemove(feed.url)}
-            disabled={removing === feed.url}
-            className="flex-shrink-0 p-1.5 rounded-lg hover:bg-red-500/20 text-[#71717a] hover:text-red-400 transition-colors disabled:opacity-50"
-            aria-label={`Remove ${feed.title}`}
+    <>
+      <div className="space-y-2">
+        {feedList.map((feed) => (
+          <div
+            key={feed.url}
+            className="flex items-center gap-3 px-3 py-2.5 rounded-xl bg-white/[0.03] border border-[rgba(255,255,255,0.05)]"
           >
-            {removing === feed.url ? (
-              <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-              </svg>
+            {feed.imageUrl ? (
+              <img src={feed.imageUrl} alt="" className="w-8 h-8 rounded-md flex-shrink-0 object-cover" />
             ) : (
-              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-              </svg>
+              <div className="w-8 h-8 rounded-md bg-[#8b5cf6]/10 flex items-center justify-center flex-shrink-0">
+                <span className="text-sm">📡</span>
+              </div>
             )}
-          </button>
+            <div className="flex-1 min-w-0">
+              <p className="text-sm text-white truncate">{feed.title}</p>
+              <p className="text-xs text-[#52525b] truncate">{feed.url}</p>
+            </div>
+            <button
+              onClick={() => handleRemove(feed.url)}
+              disabled={removing === feed.url}
+              className="flex-shrink-0 p-1.5 rounded-lg hover:bg-red-500/20 text-[#71717a] hover:text-red-400 transition-colors disabled:opacity-50"
+              aria-label={`Remove ${feed.title}`}
+            >
+              {removing === feed.url ? (
+                <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                </svg>
+              ) : (
+                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                </svg>
+              )}
+            </button>
+          </div>
+        ))}
+      </div>
+
+      {/* Remove all section */}
+      <div className="mt-4 pt-4 border-t border-[rgba(255,255,255,0.06)]">
+        <button
+          onClick={() => setShowRemoveAll(true)}
+          className="text-xs text-red-400/70 hover:text-red-400 transition-colors"
+        >
+          Remove all {feedList.length.toLocaleString()} feeds&hellip;
+        </button>
+      </div>
+
+      {/* Remove-all confirmation overlay */}
+      {showRemoveAll && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm">
+          <div className="w-full max-w-sm bg-[#18181b] border border-[rgba(255,255,255,0.1)] rounded-2xl p-6 shadow-2xl">
+            <div className="flex items-center gap-3 mb-4">
+              <div className="w-10 h-10 rounded-full bg-red-500/15 flex items-center justify-center flex-shrink-0">
+                <svg className="w-5 h-5 text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                </svg>
+              </div>
+              <div>
+                <p className="text-sm font-semibold text-white">Remove all feeds?</p>
+                <p className="text-xs text-[#71717a] mt-0.5">
+                  This will unsubscribe from all {feedList.length.toLocaleString()} feeds on every synced device.
+                </p>
+              </div>
+            </div>
+
+            <label className="flex items-start gap-3 mb-5 cursor-pointer group">
+              <input
+                type="checkbox"
+                checked={includeItems}
+                onChange={(e) => setIncludeItems(e.target.checked)}
+                className="mt-0.5 w-4 h-4 rounded border-[rgba(255,255,255,0.2)] bg-white/5 text-red-500 focus:ring-red-500 focus:ring-offset-0"
+              />
+              <div>
+                <p className="text-sm text-[#a1a1aa] group-hover:text-white transition-colors">
+                  Also delete all articles and reading history
+                </p>
+                <p className="text-xs text-[#52525b] mt-0.5">Cannot be undone</p>
+              </div>
+            </label>
+
+            <div className="flex gap-3">
+              <button
+                onClick={() => { setShowRemoveAll(false); setIncludeItems(false); }}
+                disabled={removingAll}
+                className="flex-1 py-2.5 rounded-xl bg-white/5 hover:bg-white/10 text-[#a1a1aa] hover:text-white transition-colors text-sm disabled:opacity-50"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleRemoveAll}
+                disabled={removingAll}
+                className="flex-1 py-2.5 rounded-xl bg-red-500/20 hover:bg-red-500/30 text-red-400 hover:text-red-300 transition-colors text-sm font-medium disabled:opacity-50"
+              >
+                {removingAll ? (
+                  <span className="flex items-center justify-center gap-2">
+                    <span className="w-3 h-3 border-2 border-red-400 border-t-transparent rounded-full animate-spin" />
+                    Removing&hellip;
+                  </span>
+                ) : (
+                  "Remove All"
+                )}
+              </button>
+            </div>
+          </div>
         </div>
-      ))}
-    </div>
+      )}
+    </>
   );
 }
 

--- a/packages/ui/src/components/SettingsPanel.tsx
+++ b/packages/ui/src/components/SettingsPanel.tsx
@@ -53,7 +53,14 @@ type UpdateCheckState =
   | { status: "error" };
 
 export function SettingsPanel({ open, onClose }: SettingsPanelProps) {
-  const { SettingsExtraSections, checkForUpdates, applyUpdate, headerDragRegion } = usePlatform();
+  const {
+    SettingsExtraSections,
+    checkForUpdates,
+    applyUpdate,
+    headerDragRegion,
+    factoryReset,
+    activeCloudProviderLabel,
+  } = usePlatform();
   const preferences = useAppStore((s) => s.preferences);
   const toggleDebug = useDebugStore((s) => s.toggle);
   const updatePreferences = useAppStore((s) => s.updatePreferences);
@@ -61,6 +68,9 @@ export function SettingsPanel({ open, onClose }: SettingsPanelProps) {
   const [display, setDisplay] = useState(() => preferences.display);
   const [updateState, setUpdateState] = useState<UpdateCheckState>({ status: "idle" });
   const fadeTimer = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const [showResetConfirm, setShowResetConfirm] = useState(false);
+  const [deleteFromCloud, setDeleteFromCloud] = useState(false);
+  const [resetting, setResetting] = useState(false);
 
   const handleCheckForUpdates = useCallback(async () => {
     if (!checkForUpdates) return;
@@ -106,6 +116,17 @@ export function SettingsPanel({ open, onClose }: SettingsPanelProps) {
     },
     [updatePreferences],
   );
+
+  const handleReset = useCallback(async () => {
+    if (!factoryReset) return;
+    setResetting(true);
+    try {
+      await factoryReset(deleteFromCloud);
+    } catch {
+      setResetting(false);
+      setShowResetConfirm(false);
+    }
+  }, [factoryReset, deleteFromCloud]);
 
   return (
     <BottomSheet open={open} onClose={onClose} title="Settings">
@@ -230,6 +251,29 @@ export function SettingsPanel({ open, onClose }: SettingsPanelProps) {
           </button>
         </section>
 
+        {/* Danger Zone */}
+        {factoryReset && (
+          <section>
+            <h3 className="text-xs font-semibold text-red-400/60 uppercase tracking-wider mb-4">
+              Danger Zone
+            </h3>
+            <button
+              onClick={() => setShowResetConfirm(true)}
+              className="w-full flex items-center justify-between px-3 py-2.5 rounded-xl bg-red-500/5 hover:bg-red-500/10 border border-red-500/10 hover:border-red-500/20 transition-colors text-left"
+            >
+              <div>
+                <p className="text-sm text-red-400">Reset this device</p>
+                <p className="text-xs text-red-400/50 mt-0.5">
+                  Wipes all local data and restarts fresh
+                </p>
+              </div>
+              <svg className="w-4 h-4 text-red-400/40 shrink-0 ml-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+              </svg>
+            </button>
+          </section>
+        )}
+
         {/* Footer */}
         <div className="pb-2 text-center">
           <a
@@ -242,6 +286,71 @@ export function SettingsPanel({ open, onClose }: SettingsPanelProps) {
           </a>
         </div>
       </div>
+
+      {/* Factory reset confirmation overlay */}
+      {showResetConfirm && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm">
+          <div className="w-full max-w-sm bg-[#18181b] border border-[rgba(255,255,255,0.1)] rounded-2xl p-6 shadow-2xl">
+            <div className="flex items-center gap-3 mb-4">
+              <div className="w-10 h-10 rounded-full bg-red-500/15 flex items-center justify-center flex-shrink-0">
+                <svg className="w-5 h-5 text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                </svg>
+              </div>
+              <div>
+                <p className="text-sm font-semibold text-white">Reset this device?</p>
+                <p className="text-xs text-[#71717a] mt-0.5">
+                  Clears all local data on this device only.
+                  {!deleteFromCloud && " Cloud sync will re-download your data on next launch."}
+                </p>
+              </div>
+            </div>
+
+            {activeCloudProviderLabel?.() && (
+              <label className="flex items-start gap-3 mb-5 cursor-pointer group">
+                <input
+                  type="checkbox"
+                  checked={deleteFromCloud}
+                  onChange={(e) => setDeleteFromCloud(e.target.checked)}
+                  className="mt-0.5 w-4 h-4 rounded border-[rgba(255,255,255,0.2)] bg-white/5 text-red-500 focus:ring-red-500 focus:ring-offset-0"
+                />
+                <div>
+                  <p className="text-sm text-[#a1a1aa] group-hover:text-white transition-colors">
+                    Also delete from {activeCloudProviderLabel()}
+                  </p>
+                  <p className="text-xs text-[#52525b] mt-0.5">
+                    Permanently removes your cloud backup
+                  </p>
+                </div>
+              </label>
+            )}
+
+            <div className="flex gap-3">
+              <button
+                onClick={() => { setShowResetConfirm(false); setDeleteFromCloud(false); }}
+                disabled={resetting}
+                className="flex-1 py-2.5 rounded-xl bg-white/5 hover:bg-white/10 text-[#a1a1aa] hover:text-white transition-colors text-sm disabled:opacity-50"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleReset}
+                disabled={resetting}
+                className="flex-1 py-2.5 rounded-xl bg-red-500/20 hover:bg-red-500/30 text-red-400 hover:text-red-300 transition-colors text-sm font-medium disabled:opacity-50"
+              >
+                {resetting ? (
+                  <span className="flex items-center justify-center gap-2">
+                    <span className="w-3 h-3 border-2 border-red-400 border-t-transparent rounded-full animate-spin" />
+                    Resetting&hellip;
+                  </span>
+                ) : (
+                  "Reset Device"
+                )}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </BottomSheet>
   );
 }

--- a/packages/ui/src/context/PlatformContext.tsx
+++ b/packages/ui/src/context/PlatformContext.tsx
@@ -84,6 +84,21 @@ export interface PlatformConfig {
 
   /** Apply a detected update (PWA: reload, Desktop: handled by UpdateNotification). */
   applyUpdate?: () => void;
+
+  /**
+   * Perform a factory reset on this device.
+   * Wipes IndexedDB + localStorage. When `deleteFromCloud` is true, also
+   * deletes the sync file from the active cloud provider before clearing.
+   * Always ends with `location.reload()`.
+   */
+  factoryReset?: (deleteFromCloud: boolean) => Promise<void>;
+
+  /**
+   * Return a human-readable label for the currently active cloud provider
+   * (e.g. "Google Drive", "Dropbox"), or null when no cloud sync is connected.
+   * Called lazily in the Danger Zone UI so it reflects live state.
+   */
+  activeCloudProviderLabel?: () => string | null;
 }
 
 const PlatformCtx = createContext<PlatformConfig | null>(null);


### PR DESCRIPTION
(AI Generated)

## Summary

- **Bulk Unsubscribe** (Feeds > Manage tab): "Remove all N feeds…" button with a confirmation dialog. Optional checkbox lets the user also delete all articles and reading history. Implemented as a single `A.change()` so the deletion CRDT-syncs to all devices instantly.
- **Factory Reset** (Settings > Danger Zone): "Reset this device" wipes IndexedDB + localStorage on this device only. Optional checkbox offers to also permanently delete the cloud sync file (Google Drive or Dropbox). Adds `gdriveDeleteFile()` and `dropboxDeleteFile()` to the cloud adapters. Reset logic is injected via new `factoryReset` and `activeCloudProviderLabel` fields on `PlatformConfig`.

## Test plan

- [ ] Open Feeds > Manage with subscriptions — confirm "Remove all N feeds…" link appears at the bottom
- [ ] Click it — confirm confirmation dialog appears with feed count and cloud-sync warning
- [ ] Test without "also delete articles" checkbox — feeds removed, articles remain
- [ ] Test with checkbox checked — both feeds and articles removed
- [ ] Open Settings > Danger Zone — confirm "Reset this device" button appears
- [ ] With no cloud sync connected — confirm cloud delete checkbox is hidden
- [ ] With GDrive/Dropbox connected — confirm checkbox shows provider name
- [ ] Test factory reset without cloud checkbox — IndexedDB cleared, app reloads fresh
- [ ] Test factory reset with cloud checkbox — cloud file deleted, local cleared, app reloads