### PR TITLE
fix(desktop): extend drag region to inner header div and spacer

### DIFF
--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -41,6 +41,7 @@ export function Header({ onMenuClick }: HeaderProps) {
         <div
           className="h-14 flex items-center pl-4 pr-2"
           style={headerDragRegion ? { paddingLeft: MACOS_TRAFFIC_LIGHT_INSET } : undefined}
+          {...(headerDragRegion ? { "data-tauri-drag-region": true } : {})}
         >
           {/* Mobile menu button */}
           <button
@@ -62,8 +63,13 @@ export function Header({ onMenuClick }: HeaderProps) {
             <span className="text-lg font-bold gradient-text font-logo">FREED</span>
           </div>
 
-          {/* Spacer */}
-          <div className="flex-1" />
+          {/* Spacer — explicitly draggable so the empty middle area registers drag events */}
+          <div
+            className="flex-1 self-stretch"
+            {...(headerDragRegion
+              ? { "data-tauri-drag-region": true, style: { WebkitAppRegion: "drag" } as React.CSSProperties }
+              : {})}
+          />
 
           {/* Actions */}
           <div


### PR DESCRIPTION
(AI Generated)

## Summary

- `data-tauri-drag-region` must be present on every element Tauri should treat as a drag target — CSS attribute inheritance does not apply to HTML attributes
- Added the attribute to the inner `h-14` content div so the entire header height registers as a drag surface
- Gave the flex spacer an explicit `data-tauri-drag-region` + `WebkitAppRegion: drag` + `self-stretch` so the empty center area is a valid drag target at full height
- All interactive children (hamburger, logo, action buttons, sync indicator) remain opted out via `WebkitAppRegion: no-drag`

## Test plan

- [ ] Click and drag from the empty center area of the title bar — window should move
- [ ] Click the logo, menu button, and action buttons — they should still respond normally without triggering a drag