### PR TITLE
fix(cloud-sync): fix OAuth redirect URI, Google Drive client secret, offline status, and diagnostics panel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14462,7 +14462,7 @@
     },
     "packages/desktop": {
       "name": "@freed/desktop",
-      "version": "26.3.300",
+      "version": "26.3.302",
       "dependencies": {
         "@freed/capture-rss": "*",
         "@freed/capture-x": "*",
@@ -14497,7 +14497,7 @@
     },
     "packages/pwa": {
       "name": "@freed/pwa",
-      "version": "26.3.300",
+      "version": "26.3.302",
       "dependencies": {
         "@automerge/automerge": "^2.2.8",
         "@freed/shared": "*",

--- a/packages/desktop/.env.local.example
+++ b/packages/desktop/.env.local.example
@@ -1,6 +1,24 @@
 # Desktop cloud sync credentials
 # Copy this file to .env.local and fill in your values.
-# The desktop client ID uses the "Desktop app" OAuth type — no client_secret needed.
 
-VITE_GDRIVE_DESKTOP_CLIENT_ID=304530272769-fkbpan1l071vdvum1j6kufvo8rbq6sm1.apps.googleusercontent.com
+# ── Dropbox ──────────────────────────────────────────────────────────────────
+# PKCE flow — no client secret needed.
+# In the Dropbox App Console (https://www.dropbox.com/developers/apps) you MUST
+# register exactly "http://localhost" as a redirect URI. The desktop app appends
+# the ephemeral port at runtime (http://localhost:PORT/callback); Dropbox matches
+# on the registered prefix so any port is accepted.
 VITE_DROPBOX_CLIENT_ID=yaqbppqya009gky
+
+# ── Google Drive ─────────────────────────────────────────────────────────────
+# Scopes required: https://www.googleapis.com/auth/drive.appdata
+#
+# Preferred: create a "Desktop app" OAuth client in Google Cloud Console — these
+# support PKCE without a client_secret, so only VITE_GDRIVE_DESKTOP_CLIENT_ID
+# is needed.
+#
+# Fallback: if you only have a "Web application" client (e.g. the same one used
+# by the PWA), also set VITE_GDRIVE_CLIENT_SECRET. Google requires a secret for
+# web-app clients even when PKCE is used, and returns 400 "client_secret is
+# missing" without it. Keep this value out of any public repository.
+VITE_GDRIVE_DESKTOP_CLIENT_ID=304530272769-fkbpan1l071vdvum1j6kufvo8rbq6sm1.apps.googleusercontent.com
+# VITE_GDRIVE_CLIENT_SECRET=your_client_secret_here

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "freed-desktop"
-version = "26.3.301"
+version = "26.3.302"
 dependencies = [
  "base64 0.22.1",
  "futures-util",

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -11,8 +11,10 @@ use std::sync::{Arc, RwLock as StdRwLock};
 use tauri::{Emitter, Manager};
 use tauri::menu::{Menu, MenuItem};
 use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::{broadcast, RwLock};
+use tokio::time::{timeout, Duration};
 use tokio_tungstenite::{
     accept_hdr_async,
     tungstenite::{
@@ -431,6 +433,55 @@ fn list_snapshots(app: tauri::AppHandle) -> Vec<String> {
 // Tauri commands — OAuth localhost server
 // ---------------------------------------------------------------------------
 
+/// Parse the OAuth callback request from the browser stream, emit the code to
+/// the frontend, and respond with a success page so the user knows to close
+/// the tab.
+async fn handle_oauth_stream(stream: TcpStream, app: tauri::AppHandle) {
+    let (reader_half, mut writer_half) = stream.into_split();
+    let mut buf_reader = BufReader::new(reader_half);
+    let mut request_line = String::new();
+    if buf_reader.read_line(&mut request_line).await.is_err() {
+        return;
+    }
+
+    // Parse `GET /callback?code=...&state=... HTTP/1.1`
+    let path = request_line
+        .split_whitespace()
+        .nth(1)
+        .unwrap_or("")
+        .to_string();
+
+    let query = path.splitn(2, '?').nth(1).unwrap_or("");
+    let mut code = String::new();
+    let mut state = String::new();
+
+    // OAuth code and state values are URL-safe by spec (base64url / UUID), so
+    // raw string splitting is sufficient — no percent-decoding needed.
+    for pair in query.split('&') {
+        if let Some(v) = pair.strip_prefix("code=") {
+            code = v.to_string();
+        } else if let Some(v) = pair.strip_prefix("state=") {
+            state = v.to_string();
+        }
+    }
+
+    let _ = app.emit("cloud-oauth-code", serde_json::json!({ "code": code, "state": state }));
+
+    let body = "<html><body style='font-family:sans-serif;text-align:center;padding:4rem'>\
+        <h2>Connected to Freed</h2>\
+        <p>You can close this tab and return to the app.</p>\
+        </body></html>";
+
+    let response = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        body.len(),
+        body,
+    );
+
+    let _ = writer_half.write_all(response.as_bytes()).await;
+    let _ = writer_half.flush().await;
+}
+
 /// Spin up a one-shot HTTP server on a random localhost port to capture the
 /// OAuth redirect from the system browser.
 ///
@@ -440,65 +491,62 @@ fn list_snapshots(app: tauri::AppHandle) -> Vec<String> {
 /// the server down. Times out after 5 minutes of waiting.
 #[tauri::command]
 async fn start_oauth_server(app: tauri::AppHandle) -> Result<u16, String> {
-    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-    use tokio::time::{timeout, Duration};
 
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+    // Bind to IPv4 loopback first to get a port, then also bind IPv6 loopback
+    // on the same port so that browsers which resolve localhost → ::1 (common
+    // on macOS) can still reach the callback server.
+    let listener = TcpListener::bind("127.0.0.1:0")
         .await
         .map_err(|e| e.to_string())?;
     let port = listener.local_addr().map_err(|e| e.to_string())?.port();
 
-    tokio::spawn(async move {
+    // Attempt IPv6 loopback on the same port — best-effort, not fatal if ::1 is
+    // unavailable (e.g. IPv6 disabled system-wide).
+    let listener6 = TcpListener::bind(format!("[::1]:{}", port)).await.ok();
+
+    // Race both listeners — whichever receives the browser callback first wins.
+    // The success response and the Tauri event are emitted from the winning task;
+    // the other task is dropped once the oneshot fires.
+    let (tx, rx) = tokio::sync::oneshot::channel::<TcpStream>();
+
+    async fn accept_one(
+        listener: TcpListener,
+        tx: tokio::sync::oneshot::Sender<TcpStream>,
+    ) {
         let accept = timeout(Duration::from_secs(300), listener.accept()).await;
-
-        let Ok(Ok((stream, _))) = accept else {
-            eprintln!("[OAuth] Server timed out or failed to accept connection");
-            return;
-        };
-
-        let (reader_half, mut writer_half) = stream.into_split();
-        let mut buf_reader = BufReader::new(reader_half);
-        let mut request_line = String::new();
-        if buf_reader.read_line(&mut request_line).await.is_err() {
-            return;
+        if let Ok(Ok((stream, _))) = accept {
+            let _ = tx.send(stream);
         }
+    }
 
-        // Parse `GET /callback?code=...&state=... HTTP/1.1`
-        let path = request_line
-            .split_whitespace()
-            .nth(1)
-            .unwrap_or("")
-            .to_string();
+    tokio::spawn(accept_one(listener, tx));
+    if let Some(l6) = listener6 {
+        // Spawn IPv6 acceptor with its own sender clone isn't possible for
+        // oneshot, so we use a second oneshot and pick whichever fires.
+        // Re-implement the race with a select instead.
+        let (tx6, rx6) = tokio::sync::oneshot::channel::<TcpStream>();
+        tokio::spawn(accept_one(l6, tx6));
 
-        let query = path.splitn(2, '?').nth(1).unwrap_or("");
-        let mut code = String::new();
-        let mut state = String::new();
-
-        for pair in query.split('&') {
-            if let Some(v) = pair.strip_prefix("code=") {
-                code = v.to_string();
-            } else if let Some(v) = pair.strip_prefix("state=") {
-                state = v.to_string();
-            }
-        }
-
-        // Emit OAuth code to the frontend, then send the browser a success page.
-        let _ = app.emit("cloud-oauth-code", serde_json::json!({ "code": code, "state": state }));
-
-        let body = "<html><body style='font-family:sans-serif;text-align:center;padding:4rem'>\
-            <h2>Connected to Freed</h2>\
-            <p>You can close this tab and return to the app.</p>\
-            </body></html>";
-
-        let response = format!(
-            "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
-            body.len(),
-            body,
-        );
-
-        let _ = writer_half.write_all(response.as_bytes()).await;
-        let _ = writer_half.flush().await;
-    });
+        tokio::spawn(async move {
+            let stream = tokio::select! {
+                Ok(s) = rx  => s,
+                Ok(s) = rx6 => s,
+                else => {
+                    eprintln!("[OAuth] Both listeners timed out or errored");
+                    return;
+                }
+            };
+            handle_oauth_stream(stream, app).await;
+        });
+    } else {
+        tokio::spawn(async move {
+            let Ok(stream) = rx.await else {
+                eprintln!("[OAuth] Server timed out or failed to accept connection");
+                return;
+            };
+            handle_oauth_stream(stream, app).await;
+        });
+    }
 
     Ok(port)
 }

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -24,7 +24,7 @@
         "hiddenTitle": true,
         "trafficLightPosition": {
           "x": 20,
-          "y": 28
+          "y": 27
         },
         "center": true
       }

--- a/packages/desktop/src/hooks/useCloudProviders.ts
+++ b/packages/desktop/src/hooks/useCloudProviders.ts
@@ -6,7 +6,7 @@
  * If you find yourself re-implementing this inline, import from here instead.
  */
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import {
   initiateDesktopOAuth,
   storeCloudToken,
@@ -19,6 +19,7 @@ import type {
   ProviderState,
   CloudProviderStatus,
 } from "@freed/ui/components/CloudProviderCard";
+import { setCloudProviders } from "@freed/ui/lib/debug-store";
 
 export type { ProviderState, CloudProviderStatus };
 
@@ -64,6 +65,20 @@ export function useCloudProviders() {
     },
     [setProvider],
   );
+
+  // Keep the debug panel's cloud sync section in sync with live provider state.
+  useEffect(() => {
+    setCloudProviders({
+      gdrive: {
+        status: providers.gdrive.status,
+        error: providers.gdrive.status === "error" ? providers.gdrive.error : undefined,
+      },
+      dropbox: {
+        status: providers.dropbox.status,
+        error: providers.dropbox.status === "error" ? providers.dropbox.error : undefined,
+      },
+    });
+  }, [providers]);
 
   const anyConnected =
     providers.gdrive.status === "connected" ||

--- a/packages/desktop/src/lib/sync.ts
+++ b/packages/desktop/src/lib/sync.ts
@@ -251,6 +251,10 @@ const cloudChangeUnsubscribes = new Map<CloudProvider, () => void>();
 
 // Desktop OAuth client IDs (not secret — embedded in the app bundle).
 const GDRIVE_CLIENT_ID = import.meta.env.VITE_GDRIVE_DESKTOP_CLIENT_ID ?? "";
+// Only needed when using a "Web application" OAuth client type for GDrive instead
+// of the correct "Desktop app" type. Desktop app clients support PKCE without a
+// client_secret; web app clients require it.
+const GDRIVE_CLIENT_SECRET = import.meta.env.VITE_GDRIVE_CLIENT_SECRET ?? "";
 const DROPBOX_CLIENT_ID = import.meta.env.VITE_DROPBOX_CLIENT_ID ?? "";
 
 /** Persist an OAuth access token for a cloud provider. */
@@ -311,7 +315,10 @@ export async function initiateDesktopOAuth(provider: CloudProvider): Promise<str
   // Start the localhost server first so the port is known before we build the
   // OAuth URL. The Rust command returns the port and then waits for the callback.
   const port = await invoke<number>("start_oauth_server");
-  const redirectUri = `http://127.0.0.1:${port}/callback`;
+  // Use localhost (not 127.0.0.1) — Dropbox and Google only accept the
+  // registered redirect URI prefix, and "http://localhost" is the standard
+  // registration for desktop/native PKCE apps on both platforms.
+  const redirectUri = `http://localhost:${port}/callback`;
   const state = crypto.randomUUID();
 
   let authUrl: string;
@@ -384,6 +391,12 @@ async function exchangeCode(
   let tokenUrl: string;
   if (provider === "gdrive") {
     params.set("client_id", GDRIVE_CLIENT_ID);
+    // Desktop app OAuth clients use PKCE without a secret. If the console client
+    // is a "Web application" type, VITE_GDRIVE_CLIENT_SECRET must be set or
+    // Google returns 400 "client_secret is missing".
+    if (GDRIVE_CLIENT_SECRET) {
+      params.set("client_secret", GDRIVE_CLIENT_SECRET);
+    }
     tokenUrl = "https://oauth2.googleapis.com/token";
   } else {
     params.set("client_id", DROPBOX_CLIENT_ID);

--- a/packages/pwa/src/components/SyncConnectDialog.tsx
+++ b/packages/pwa/src/components/SyncConnectDialog.tsx
@@ -5,7 +5,11 @@ import {
   storeRelayUrl,
   onStatusChange,
   startCloudSync,
+  stopCloudSync,
   storeCloudToken,
+  getCloudProvider,
+  getCloudToken,
+  clearCloudSync,
   type CloudProvider,
 } from "../lib/sync";
 import { BottomSheet } from "@freed/ui/components/BottomSheet";
@@ -163,7 +167,12 @@ export function SyncConnectDialog({ open, onClose, initialMode = "cloud" }: Sync
   const [scanFrameCount, setScanFrameCount] = useState(0);
   const [videoResolution, setVideoResolution] = useState<string | null>(null);
   const [lastQrContent, setLastQrContent] = useState<string | null>(null);
-  const [cloudConnecting, setCloudConnecting] = useState(false);
+  const [cloudConnecting, setCloudConnecting] = useState<CloudProvider | null>(null);
+  // Read the real connected provider from localStorage so the cards reflect
+  // actual state — especially important after returning from the OAuth redirect.
+  const [connectedProvider, setConnectedProvider] = useState<CloudProvider | null>(
+    () => getCloudProvider(),
+  );
 
   const videoRef = useRef<HTMLVideoElement>(null);
   const streamRef = useRef<MediaStream | null>(null);
@@ -192,6 +201,7 @@ export function SyncConnectDialog({ open, onClose, initialMode = "cloud" }: Sync
     setScanFrameCount(0);
     setVideoResolution(null);
     setLastQrContent(null);
+    setCloudConnecting(null);
     onClose();
   }, [stopCamera, onClose, initialMode]);
 
@@ -346,7 +356,7 @@ export function SyncConnectDialog({ open, onClose, initialMode = "cloud" }: Sync
   };
 
   const handleCloudConnect = async (provider: CloudProvider) => {
-    setCloudConnecting(true);
+    setCloudConnecting(provider);
     setError(null);
     try {
       if (provider === "gdrive") {
@@ -356,8 +366,14 @@ export function SyncConnectDialog({ open, onClose, initialMode = "cloud" }: Sync
       }
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to start OAuth flow");
-      setCloudConnecting(false);
+      setCloudConnecting(null);
     }
+  };
+
+  const handleCloudDisconnect = (provider: CloudProvider) => {
+    clearCloudSync(provider);
+    stopCloudSync();
+    setConnectedProvider(null);
   };
 
   const tabs: Array<{ id: Mode; label: string }> = [
@@ -552,14 +568,27 @@ export function SyncConnectDialog({ open, onClose, initialMode = "cloud" }: Sync
 
       {mode === "cloud" && (
         <div className="mb-4 flex flex-col gap-3">
-          {(["dropbox", "gdrive"] as const).map((provider) => (
-            <CloudProviderCard
-              key={provider}
-              provider={provider}
-              state={{ status: cloudConnecting ? "connecting" : "idle" }}
-              onConnect={handleCloudConnect}
-            />
-          ))}
+          {(["dropbox", "gdrive"] as const).map((provider) => {
+            // Derive per-provider state from actual localStorage data so the
+            // card reflects reality after returning from the OAuth redirect.
+            const isThisConnected = connectedProvider === provider;
+            const isThisConnecting = cloudConnecting === provider;
+            const state = isThisConnected
+              ? { status: "connected" as const }
+              : isThisConnecting
+                ? { status: "connecting" as const }
+                : { status: "idle" as const };
+
+            return (
+              <CloudProviderCard
+                key={provider}
+                provider={provider}
+                state={state}
+                onConnect={handleCloudConnect}
+                onDisconnect={handleCloudDisconnect}
+              />
+            );
+          })}
           <p className="text-xs text-[#71717a] text-center pt-1">
             Your reading list is stored in your own cloud account.
             <br />

--- a/packages/pwa/src/components/layout/SyncIndicator.tsx
+++ b/packages/pwa/src/components/layout/SyncIndicator.tsx
@@ -7,7 +7,13 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useAppStore } from "../../lib/store";
-import { disconnect, clearStoredRelayUrl } from "../../lib/sync";
+import {
+  disconnect,
+  clearStoredRelayUrl,
+  getCloudProvider,
+  clearCloudSync,
+  stopCloudSync,
+} from "../../lib/sync";
 import { SyncConnectDialog } from "../SyncConnectDialog";
 import { useDebugStore } from "@freed/ui/lib/debug-store";
 
@@ -60,8 +66,14 @@ export function SyncIndicator() {
   }, [panelOpen]);
 
   const handleDisconnect = () => {
+    // Disconnect both channels — whichever is active.
     clearStoredRelayUrl();
     disconnect();
+    const cloudProvider = getCloudProvider();
+    if (cloudProvider) {
+      clearCloudSync(cloudProvider);
+      stopCloudSync();
+    }
     setPanelOpen(false);
   };
 
@@ -119,7 +131,7 @@ export function SyncIndicator() {
           {/* Header */}
           <div className="px-4 py-3 border-b border-[rgba(255,255,255,0.06)]">
             <div className="flex items-center justify-between">
-              <span className="text-sm font-medium text-white">Desktop Sync</span>
+              <span className="text-sm font-medium text-white">Sync</span>
               <span
                 className={`text-xs px-2 py-0.5 rounded-full ${
                   isSyncing

--- a/packages/pwa/src/lib/sync.ts
+++ b/packages/pwa/src/lib/sync.ts
@@ -26,23 +26,29 @@ import {
   type CloudProvider,
 } from "@freed/sync/cloud";
 
-// Connection state
+// Connection state — WebSocket relay
 let ws: WebSocket | null = null;
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
-let isConnected = false;
+let isRelayConnectedState = false;
 let currentUrl: string | null = null;
 let reconnectCount = 0;
+
+// Cloud sync connection state — set by startCloudSync/stopCloudSync so the
+// toolbar reflects "Connected" as soon as either channel is active.
+let isCloudConnectedState = false;
 
 // Status listeners
 type StatusListener = (connected: boolean) => void;
 const statusListeners = new Set<StatusListener>();
 
 /**
- * Notify status listeners
+ * Notify status listeners with the combined connection state.
+ * Either the WebSocket relay or the cloud sync loop counts as "connected".
  */
 function notifyStatus(): void {
+  const connected = isRelayConnectedState || isCloudConnectedState;
   for (const listener of statusListeners) {
-    listener(isConnected);
+    listener(connected);
   }
 }
 
@@ -89,7 +95,7 @@ export function connect(url: string): void {
 
     ws.onopen = () => {
       console.log("[Sync] Connected to relay");
-      isConnected = true;
+      isRelayConnectedState = true;
       reconnectCount = 0;
       notifyStatus();
       addDebugEvent("connected", url);
@@ -115,7 +121,7 @@ export function connect(url: string): void {
 
     ws.onclose = () => {
       console.log("[Sync] Disconnected from relay");
-      isConnected = false;
+      isRelayConnectedState = false;
       ws = null;
       notifyStatus();
       addDebugEvent("disconnected", currentUrl ?? undefined);
@@ -126,7 +132,7 @@ export function connect(url: string): void {
         addDebugEvent("reconnecting", `attempt ${reconnectCount} in 5s`);
         reconnectTimer = setTimeout(() => {
           reconnectTimer = null;
-          if (currentUrl && !isConnected) {
+          if (currentUrl && !isRelayConnectedState) {
             connect(currentUrl);
           }
         }, 5000);
@@ -156,15 +162,15 @@ export function disconnect(): void {
     ws.close();
     ws = null;
   }
-  isConnected = false;
+  isRelayConnectedState = false;
   notifyStatus();
 }
 
 /**
- * Check if connected to relay
+ * Check if the WebSocket relay is connected
  */
 export function isRelayConnected(): boolean {
-  return isConnected;
+  return isRelayConnectedState;
 }
 
 /**
@@ -240,6 +246,11 @@ export async function startCloudSync(provider: CloudProvider, token: string): Pr
   cloudAbort = new AbortController();
   const { signal } = cloudAbort;
 
+  // Mark cloud as connected immediately so the toolbar updates before the
+  // initial download completes (download can take several seconds).
+  isCloudConnectedState = true;
+  notifyStatus();
+
   // Pull latest remote state immediately on connect. The AbortSignal is passed
   // through so stopCloudSync() cancels any in-flight fetch rather than orphaning it.
   try {
@@ -298,6 +309,8 @@ export function stopCloudSync(): void {
     clearTimeout(uploadTimer);
     uploadTimer = null;
   }
+  isCloudConnectedState = false;
+  notifyStatus();
 }
 
 /**

--- a/packages/ui/src/components/DebugPanel.tsx
+++ b/packages/ui/src/components/DebugPanel.tsx
@@ -9,8 +9,8 @@
  *   Desktop (sm+):  right-edge push drawer — AppShell renders this always (width-animates open/closed)
  */
 
-import { useEffect, useState } from "react";
-import { useDebugStore, type SyncEvent, type SyncEventKind } from "../lib/debug-store";
+import { useEffect, useState, type ReactNode } from "react";
+import { useDebugStore, type SyncEvent, type SyncEventKind, type CloudSyncStatus } from "../lib/debug-store";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -81,9 +81,67 @@ function EventRow({ event }: { event: SyncEvent }) {
   );
 }
 
+// ─── Cloud sync status helpers ────────────────────────────────────────────────
+
+const CLOUD_STATUS_STYLES: Record<
+  CloudSyncStatus,
+  { dot: string; label: string; labelColor: string }
+> = {
+  idle:       { dot: "bg-[#52525b]",  label: "Not connected", labelColor: "text-[#71717a]" },
+  connecting: { dot: "bg-yellow-400 animate-pulse", label: "Connecting…",    labelColor: "text-yellow-400" },
+  connected:  { dot: "bg-green-400",  label: "Connected",     labelColor: "text-green-400" },
+  error:      { dot: "bg-red-400",    label: "Error",         labelColor: "text-red-400" },
+};
+
+function CloudProviderRow({
+  name,
+  icon,
+  status,
+  error,
+}: {
+  name: string;
+  icon: ReactNode;
+  status: CloudSyncStatus;
+  error?: string;
+}) {
+  const s = CLOUD_STATUS_STYLES[status];
+  return (
+    <div className="bg-white/5 rounded-xl p-3">
+      <div className="flex items-center gap-2 mb-1">
+        <span className="shrink-0 opacity-70">{icon}</span>
+        <p className="text-[10px] text-[#52525b] uppercase tracking-wider">{name}</p>
+      </div>
+      <div className="flex items-center gap-1.5">
+        <span className={`w-1.5 h-1.5 rounded-full shrink-0 ${s.dot}`} />
+        <span className={`text-xs font-medium ${s.labelColor}`}>{s.label}</span>
+      </div>
+      {error && (
+        <p className="text-[10px] text-red-400 font-mono mt-1 break-all leading-snug">{error}</p>
+      )}
+    </div>
+  );
+}
+
+// Minimal inline SVG icons for Dropbox and Google Drive
+const DropboxIcon = () => (
+  <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" className="text-[#0061FF]">
+    <path d="M6 2L0 6l6 4 6-4zm12 0l-6 4 6 4 6-4zM0 14l6 4 6-4-6-4zm18-4l-6 4 6 4 6-4zM6 19.5L12 23l6-3.5-6-4z"/>
+  </svg>
+);
+
+const GDriveIcon = () => (
+  <svg width="12" height="12" viewBox="0 0 24 24" fill="none">
+    <path d="M4.5 20L9 12 0 12z" fill="#4285F4"/>
+    <path d="M19.5 20L15 12l9 0z" fill="#FBBC04"/>
+    <path d="M9 12L4.5 20h15L15 12z" fill="#34A853"/>
+    <path d="M12 2L9 12h6z" fill="#EA4335"/>
+  </svg>
+);
+
 function ConnectionTab() {
   const events = useDebugStore((s) => s.events);
   const docSnapshot = useDebugStore((s) => s.docSnapshot);
+  const cloudProviders = useDebugStore((s) => s.cloudProviders);
   const [, setTick] = useState(0);
 
   // Re-render every second so relative timestamps stay fresh
@@ -106,68 +164,103 @@ function ConnectionTab() {
   const mixedContentRisk = proto === "https:" && isWsPlain;
 
   return (
-    <div className="space-y-4">
-      {/* Mixed content warning */}
-      {mixedContentRisk && (
-        <div className="p-3 bg-orange-500/15 border border-orange-500/40 rounded-xl">
-          <p className="text-xs font-semibold text-orange-400 mb-1">HTTPS → ws:// Mixed Content</p>
-          <p className="text-xs text-orange-300/80">
-            This page is served over HTTPS. Safari and Chrome block plain <code className="font-mono">ws://</code> connections from HTTPS pages — this is almost certainly why sync fails on iPhone. The desktop relay works, but the browser kills the socket silently.
-          </p>
-        </div>
-      )}
+    <div className="space-y-5">
 
-      {/* Status */}
-      <div className="grid grid-cols-2 gap-2">
-        <div className="bg-white/5 rounded-xl p-3">
-          <p className="text-[10px] text-[#52525b] uppercase tracking-wider mb-1">Status</p>
-          <div className="flex items-center gap-2">
-            <span className={`w-2 h-2 rounded-full shrink-0 ${isConnected ? "bg-green-400" : "bg-[#52525b]"}`} />
-            <span className={`text-sm font-medium ${isConnected ? "text-green-400" : "text-[#71717a]"}`}>
-              {isConnected ? "Connected" : "Offline"}
-            </span>
+      {/* ── Cloud Sync ─────────────────────────────────────────────────────── */}
+      <div>
+        <p className="text-[10px] text-[#52525b] uppercase tracking-widest mb-2 px-0.5">
+          Cloud Sync
+        </p>
+        <div className="grid grid-cols-2 gap-2">
+          <CloudProviderRow
+            name="Dropbox"
+            icon={<DropboxIcon />}
+            status={cloudProviders?.dropbox.status ?? "idle"}
+            error={cloudProviders?.dropbox.error}
+          />
+          <CloudProviderRow
+            name="Google Drive"
+            icon={<GDriveIcon />}
+            status={cloudProviders?.gdrive.status ?? "idle"}
+            error={cloudProviders?.gdrive.error}
+          />
+        </div>
+      </div>
+
+      {/* ── Local Sync ─────────────────────────────────────────────────────── */}
+      <div>
+        <p className="text-[10px] text-[#52525b] uppercase tracking-widest mb-2 px-0.5">
+          Local Sync
+        </p>
+
+        <div className="space-y-2">
+          {/* Mixed content warning */}
+          {mixedContentRisk && (
+            <div className="p-3 bg-orange-500/15 border border-orange-500/40 rounded-xl">
+              <p className="text-xs font-semibold text-orange-400 mb-1">HTTPS → ws:// Mixed Content</p>
+              <p className="text-xs text-orange-300/80">
+                This page is served over HTTPS. Safari and Chrome block plain{" "}
+                <code className="font-mono">ws://</code> connections from HTTPS pages — this is
+                almost certainly why sync fails on iPhone. The desktop relay works, but the
+                browser kills the socket silently.
+              </p>
+            </div>
+          )}
+
+          {/* Status grid */}
+          <div className="grid grid-cols-2 gap-2">
+            <div className="bg-white/5 rounded-xl p-3">
+              <p className="text-[10px] text-[#52525b] uppercase tracking-wider mb-1">Status</p>
+              <div className="flex items-center gap-2">
+                <span className={`w-2 h-2 rounded-full shrink-0 ${isConnected ? "bg-green-400" : "bg-[#52525b]"}`} />
+                <span className={`text-sm font-medium ${isConnected ? "text-green-400" : "text-[#71717a]"}`}>
+                  {isConnected ? "Connected" : "Offline"}
+                </span>
+              </div>
+            </div>
+
+            <div className="bg-white/5 rounded-xl p-3">
+              <p className="text-[10px] text-[#52525b] uppercase tracking-wider mb-1">Reconnects</p>
+              <p className="text-sm font-medium text-[#a1a1aa] font-mono">{reconnects}</p>
+            </div>
+
+            <div className="bg-white/5 rounded-xl p-3">
+              <p className="text-[10px] text-[#52525b] uppercase tracking-wider mb-1">Page Protocol</p>
+              <p className={`text-sm font-medium font-mono ${proto === "https:" ? "text-orange-400" : "text-green-400"}`}>
+                {proto || "—"}
+              </p>
+            </div>
+
+            <div className="bg-white/5 rounded-xl p-3">
+              <p className="text-[10px] text-[#52525b] uppercase tracking-wider mb-1">Doc Size</p>
+              <p className="text-sm font-medium text-[#a1a1aa] font-mono">
+                {docSnapshot ? formatBytes(docSnapshot.binarySize) : "—"}
+              </p>
+            </div>
+          </div>
+
+          {/* Relay URL */}
+          <div className="bg-white/5 rounded-xl p-3">
+            <p className="text-[10px] text-[#52525b] uppercase tracking-wider mb-1">Relay URL</p>
+            <p className="text-xs text-[#a1a1aa] font-mono break-all">{relayUrl}</p>
+          </div>
+
+          {/* Transfer stats */}
+          <div className="grid grid-cols-2 gap-2">
+            <div className="bg-white/5 rounded-xl p-3">
+              <p className="text-[10px] text-[#52525b] uppercase tracking-wider mb-1">Last Sent</p>
+              <p className="text-xs text-blue-400 font-mono">{lastSent ? formatBytes(lastSent.bytes ?? 0) : "—"}</p>
+              {lastSent && <p className="text-[10px] text-[#52525b] font-mono mt-0.5">{formatRelative(lastSent.ts)}</p>}
+            </div>
+            <div className="bg-white/5 rounded-xl p-3">
+              <p className="text-[10px] text-[#52525b] uppercase tracking-wider mb-1">Last Received</p>
+              <p className="text-xs text-cyan-400 font-mono">{lastReceived ? formatBytes(lastReceived.bytes ?? 0) : "—"}</p>
+              {lastReceived && <p className="text-[10px] text-[#52525b] font-mono mt-0.5">{formatRelative(lastReceived.ts)}</p>}
+            </div>
           </div>
         </div>
-
-        <div className="bg-white/5 rounded-xl p-3">
-          <p className="text-[10px] text-[#52525b] uppercase tracking-wider mb-1">Reconnects</p>
-          <p className="text-sm font-medium text-[#a1a1aa] font-mono">{reconnects}</p>
-        </div>
-
-        <div className="bg-white/5 rounded-xl p-3">
-          <p className="text-[10px] text-[#52525b] uppercase tracking-wider mb-1">Page Protocol</p>
-          <p className={`text-sm font-medium font-mono ${proto === "https:" ? "text-orange-400" : "text-green-400"}`}>
-            {proto || "—"}
-          </p>
-        </div>
-
-        <div className="bg-white/5 rounded-xl p-3">
-          <p className="text-[10px] text-[#52525b] uppercase tracking-wider mb-1">Doc Size</p>
-          <p className="text-sm font-medium text-[#a1a1aa] font-mono">
-            {docSnapshot ? formatBytes(docSnapshot.binarySize) : "—"}
-          </p>
-        </div>
       </div>
 
-      {/* Relay URL */}
-      <div className="bg-white/5 rounded-xl p-3">
-        <p className="text-[10px] text-[#52525b] uppercase tracking-wider mb-1">Relay URL</p>
-        <p className="text-xs text-[#a1a1aa] font-mono break-all">{relayUrl}</p>
-      </div>
-
-      {/* Transfer stats */}
-      <div className="grid grid-cols-2 gap-2">
-        <div className="bg-white/5 rounded-xl p-3">
-          <p className="text-[10px] text-[#52525b] uppercase tracking-wider mb-1">Last Sent</p>
-          <p className="text-xs text-blue-400 font-mono">{lastSent ? formatBytes(lastSent.bytes ?? 0) : "—"}</p>
-          {lastSent && <p className="text-[10px] text-[#52525b] font-mono mt-0.5">{formatRelative(lastSent.ts)}</p>}
-        </div>
-        <div className="bg-white/5 rounded-xl p-3">
-          <p className="text-[10px] text-[#52525b] uppercase tracking-wider mb-1">Last Received</p>
-          <p className="text-xs text-cyan-400 font-mono">{lastReceived ? formatBytes(lastReceived.bytes ?? 0) : "—"}</p>
-          {lastReceived && <p className="text-[10px] text-[#52525b] font-mono mt-0.5">{formatRelative(lastReceived.ts)}</p>}
-        </div>
-      </div>
     </div>
   );
 }

--- a/packages/ui/src/lib/debug-store.ts
+++ b/packages/ui/src/lib/debug-store.ts
@@ -49,15 +49,32 @@ export interface DocSnapshot {
   savedAt: number;
 }
 
+// Cloud sync provider state surfaced in the diagnostics panel.
+// Kept intentionally minimal — the panel only needs status + optional error.
+export type CloudSyncStatus = "idle" | "connecting" | "connected" | "error";
+
+export interface CloudProviderDebugState {
+  status: CloudSyncStatus;
+  error?: string;
+  lastSyncAt?: number;
+}
+
+export interface CloudProvidersDebugState {
+  gdrive: CloudProviderDebugState;
+  dropbox: CloudProviderDebugState;
+}
+
 interface DebugState {
   visible: boolean;
   events: SyncEvent[];
   docSnapshot: DocSnapshot | null;
+  cloudProviders: CloudProvidersDebugState | null;
 
   toggle: () => void;
   addEvent: (kind: SyncEventKind, detail?: string, bytes?: number) => void;
   clearEvents: () => void;
   setDocSnapshot: (snap: DocSnapshot) => void;
+  setCloudProviders: (state: CloudProvidersDebugState) => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -70,6 +87,7 @@ export const useDebugStore = create<DebugState>()((set) => ({
   visible: false,
   events: [],
   docSnapshot: null,
+  cloudProviders: null,
 
   toggle: () => set((s) => ({ visible: !s.visible })),
 
@@ -88,6 +106,8 @@ export const useDebugStore = create<DebugState>()((set) => ({
   clearEvents: () => set({ events: [] }),
 
   setDocSnapshot: (docSnapshot) => set({ docSnapshot }),
+
+  setCloudProviders: (cloudProviders) => set({ cloudProviders }),
 }));
 
 // ---------------------------------------------------------------------------
@@ -104,6 +124,10 @@ export function addDebugEvent(
 
 export function setDocSnapshot(snap: DocSnapshot): void {
   useDebugStore.getState().setDocSnapshot(snap);
+}
+
+export function setCloudProviders(state: CloudProvidersDebugState): void {
+  useDebugStore.getState().setCloudProviders(state);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
(AI Generated)

## Summary

- **Dropbox OAuth**: fixes \`Invalid redirect_uri\` by changing the desktop OAuth redirect from \`http://127.0.0.1:PORT\` to \`http://localhost:PORT\` to match the standard Dropbox App Console registration. The Tauri OAuth callback server now races both IPv4 and IPv6 loopback listeners so macOS browsers that resolve \`localhost\` → \`::1\` still complete the flow.
- **Google Drive OAuth**: adds \`VITE_GDRIVE_CLIENT_SECRET\` env var support for the desktop token exchange, fixing the \`400 client_secret is missing\` error that occurs when using a "Web application" type OAuth client.
- **PWA offline status**: \`startCloudSync\` never called \`notifyStatus()\`, so the toolbar showed "Offline" even when cloud sync was running. Added \`isCloudConnectedState\`; \`notifyStatus\` now broadcasts \`relay || cloud\` so either channel marks the indicator as Connected.
- **SyncConnectDialog**: provider cards were always rendered \`idle\` regardless of actual state. Now reads the real connected provider from \`localStorage\` on mount and derives per-card state from it. \`onDisconnect\` is wired up so users can disconnect from the same dialog.
- **SyncIndicator**: disconnect now clears cloud credentials in addition to the relay URL. Renames "Desktop Sync" to "Sync".
- **Debug panel**: Connection tab now has Cloud Sync and Local Sync groups with live provider status.
- **Desktop**: traffic light buttons moved up 1 px (\`y: 28 → 27\`).

## Test plan

- [ ] Connect Dropbox from desktop — browser should show auth page, not "Invalid redirect_uri"
- [ ] Connect Google Drive from desktop — token exchange should succeed
- [ ] After connecting via PWA cloud sync, toolbar should immediately show "Connected"
- [ ] Open sync dialog after OAuth — connected provider card shows Connected with Disconnect button
- [ ] Debug panel Connection tab shows Cloud Sync and Local Sync sections