### PR TITLE
fix(desktop): startup feed-name healing, toolbar height, window drag

### DIFF
--- a/packages/desktop/src/lib/automerge.ts
+++ b/packages/desktop/src/lib/automerge.ts
@@ -288,6 +288,7 @@ export async function docBatchRefreshFeeds(
       // leaving the sentinel in place.
       if (feed.title && feed.title !== "Untitled Feed" && feed.title !== feed.url) {
         if (stored.title === "Untitled Feed" || stored.title === stored.url) {
+          console.log(`[Heal] CRDT write: "${stored.title}" → "${feed.title}" (${feed.url})`);
           stored.title = feed.title;
         }
       }
@@ -314,6 +315,37 @@ export async function docBatchRefreshFeeds(
       if (linkUrl) existingLinkUrls.add(linkUrl);
     }
   }, `Refresh ${feeds.length} feeds, ${items.length} items`);
+}
+
+/**
+ * Startup migration: heal "Untitled Feed" and raw-URL-as-title sentinels using
+ * the feed URL hostname as a fallback — zero network required.
+ *
+ * This runs synchronously during app initialization so the user never sees
+ * "Untitled Feed" in the sidebar. The RSS poller's network-based heal can
+ * later upgrade these hostname titles to the real XML <title> values.
+ *
+ * Safe to call on every startup — it is a no-op for feeds that already have
+ * a proper title.
+ */
+export async function docHealUntitledFeedTitles(): Promise<FreedDoc> {
+  return applyChange((doc) => {
+    for (const feed of Object.values(doc.rssFeeds)) {
+      const isUntitled = feed.title === "Untitled Feed" || feed.title === feed.url;
+      if (!isUntitled) continue;
+
+      let healed: string | undefined;
+      try {
+        healed = new URL(feed.url).hostname.replace(/^(?:www|feeds?)\./, "");
+      } catch {
+        // Malformed URL — leave as-is; network heal will try again later
+      }
+
+      if (healed) {
+        feed.title = healed;
+      }
+    }
+  }, "Heal untitled feed titles from URL hostname");
 }
 
 /**

--- a/packages/desktop/src/lib/capture.ts
+++ b/packages/desktop/src/lib/capture.ts
@@ -126,6 +126,9 @@ export async function refreshAllFeeds(): Promise<void> {
             } catch {
               healedTitle = liveTitle;
             }
+            console.log(
+              `[Heal] ${feed.url} | stored="${feed.title}" liveTitle="${liveTitle}" healedTitle="${healedTitle}"`,
+            );
           }
 
           return {

--- a/packages/desktop/src/lib/store.ts
+++ b/packages/desktop/src/lib/store.ts
@@ -21,6 +21,7 @@ import {
   docToggleSaved,
   docUpdatePreferences,
   docDeduplicateFeedItems,
+  docHealUntitledFeedTitles,
 } from "./automerge";
 import type { FreedDoc } from "@freed/shared/schema";
 import { loadStoredCookies, type XAuthState } from "./x-auth";
@@ -169,6 +170,10 @@ export const useAppStore = create<AppState>((set, get) => ({
     try {
       set({ isLoading: true });
       const doc = await initDoc();
+
+      // Heal "Untitled Feed" sentinels from URL hostname — zero network,
+      // runs before any cloud merge so users never see the sentinel on startup.
+      await docHealUntitledFeedTitles();
 
       // Run dedup migration — no-op when clean, removes phantom duplicates
       // caused by key-scheme changes (guid vs link priority).

--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -39,8 +39,12 @@ export function Header({ onMenuClick }: HeaderProps) {
           : {})}
       >
         <div
-          className="h-14 flex items-center pl-4 pr-2"
-          style={headerDragRegion ? { paddingLeft: MACOS_TRAFFIC_LIGHT_INSET } : undefined}
+          className="h-[55px] flex items-center pl-4 pr-2"
+          style={
+            headerDragRegion
+              ? ({ paddingLeft: MACOS_TRAFFIC_LIGHT_INSET, WebkitAppRegion: "drag" } as React.CSSProperties)
+              : undefined
+          }
           {...(headerDragRegion ? { "data-tauri-drag-region": true } : {})}
         >
           {/* Mobile menu button */}


### PR DESCRIPTION
(AI Generated)

## Summary

- **Untitled feed healing**: New `docHealUntitledFeedTitles` startup migration heals "Untitled Feed" and url-as-title sentinels using URL hostname at app init — zero network, runs before cloud sync, so users never see "Untitled Feed" after opening the app. The existing network-based heal in `refreshAllFeeds` continues to run and upgrades hostname titles to real XML `<title>` values. Added `console.log` to both heal paths for diagnosability.
- **Toolbar height**: `h-14` (56px) → `h-[55px]`, making the interior below the border 54px.
- **macOS window drag**: Tauri v2 injects `[data-tauri-drag-region] * { -webkit-app-region: no-drag }` which silently reset the inner header div's drag state. Added `WebkitAppRegion: "drag"` to the inner div's inline style (matching the spacer pattern) so the explicit inline rule wins over the injected stylesheet.

## Test plan

- [ ] Open app with feeds that have "Untitled Feed" titles — they should show hostname-based names (e.g. `substack.com`) immediately on launch, no refresh needed
- [ ] After a sync cycle, feeds with real XML titles should show those proper names
- [ ] Toolbar height looks visually correct at 54px interior
- [ ] Click and drag anywhere in the toolbar empty space on macOS — window moves