### PR TITLE
fix(pwa): fix update detection and move HTTPS warning before QR/manual forms

### DIFF
--- a/packages/pwa/src/components/SyncConnectDialog.tsx
+++ b/packages/pwa/src/components/SyncConnectDialog.tsx
@@ -365,33 +365,20 @@ export function SyncConnectDialog({ open, onClose, initialMode = "cloud" }: Sync
     { id: "manual", label: "Manual" },
   ];
 
-  // Derive the constructed URL for display and HTTPS warning
+  // Derive the constructed URL for display purposes
   const constructedUrl = ip.trim()
     ? `ws://${ip.trim()}:8765${token.trim() ? `?t=${token.trim()}` : ""}`
     : "";
+
+  // Show the warning as soon as the user picks a local mode on an HTTPS page —
+  // don't make them waste time typing an IP or scanning before they discover it.
   const mixedContentRisk =
     typeof window !== "undefined" &&
     window.location.protocol === "https:" &&
-    (constructedUrl.startsWith("ws://") ||
-      (mode === "scanning" && lastQrContent?.startsWith("ws://")));
+    (mode === "scanning" || mode === "manual");
 
   return (
     <BottomSheet open={open} onClose={handleClose} title="Connect to Desktop">
-      {/* HTTPS mixed-content warning — the #1 reason sync fails on iPhone */}
-      {mixedContentRisk && (
-        <div className="mb-4 p-3 bg-orange-500/15 border border-orange-500/40 rounded-xl">
-          <p className="text-xs font-semibold text-orange-400 mb-1">
-            HTTPS → ws:// Connection Blocked
-          </p>
-          <p className="text-xs text-orange-300/80">
-            Safari and Chrome block plain{" "}
-            <code className="font-mono">ws://</code> connections from HTTPS
-            pages. This is why sync likely fails on iPhone even when the desktop
-            is running. Use the desktop app directly, or open the app over HTTP.
-          </p>
-        </div>
-      )}
-
       <p className="text-sm text-[#71717a] mb-5">
         {mode === "scanning"
           ? "Point your camera at the QR code shown in your desktop app."
@@ -401,7 +388,7 @@ export function SyncConnectDialog({ open, onClose, initialMode = "cloud" }: Sync
       </p>
 
       {/* Mode tabs */}
-      <div className="flex gap-2 mb-5">
+      <div className="flex gap-2 mb-4">
         {tabs.map(({ id, label }) => (
           <button
             key={id}
@@ -420,6 +407,22 @@ export function SyncConnectDialog({ open, onClose, initialMode = "cloud" }: Sync
           </button>
         ))}
       </div>
+
+      {/* HTTPS mixed-content warning — shown immediately when a local mode is
+          selected on an HTTPS page, before the user wastes time trying to connect */}
+      {mixedContentRisk && (
+        <div className="mb-4 p-3 bg-orange-500/15 border border-orange-500/40 rounded-xl">
+          <p className="text-xs font-semibold text-orange-400 mb-1">
+            Local sync blocked on HTTPS
+          </p>
+          <p className="text-xs text-orange-300/80">
+            Safari and Chrome block plain{" "}
+            <code className="font-mono">ws://</code> connections from HTTPS
+            pages. Local QR and Manual modes will not connect on iPhone. Use
+            Cloud Sync instead, or open the app over HTTP.
+          </p>
+        </div>
+      )}
 
       {mode === "scanning" ? (
         <div className="mb-4">

--- a/packages/pwa/src/lib/pwa-updater.ts
+++ b/packages/pwa/src/lib/pwa-updater.ts
@@ -1,16 +1,24 @@
 /**
  * PWA update detection & application.
  *
- * vite-plugin-pwa's `autoUpdate` activates new service workers silently,
- * but the running tab still serves stale JS until reload. This module
- * exposes check/apply functions for Settings and an auto-detected update
- * callback for showing a toast.
+ * vite-plugin-pwa's `prompt` mode parks new service workers in the `waiting`
+ * state and fires `onNeedRefresh` so the user can choose when to reload.
+ * This module bridges that signal to React components via pub/sub, and
+ * provides an imperative `checkForPwaUpdate()` for the Settings button.
  */
 
 type UpdateListener = (available: boolean) => void;
 
 let updateAvailable = false;
 const listeners = new Set<UpdateListener>();
+
+// Injected by main.tsx after registerSW(); used to send SKIP_WAITING + reload.
+let updateSWFn: ((reload: boolean) => void) | null = null;
+
+/** Called from main.tsx to store the updateSW handle returned by registerSW(). */
+export function setUpdateSwCallback(fn: (reload: boolean) => void) {
+  updateSWFn = fn;
+}
 
 /** Called from main.tsx when the SW detects new content. */
 export function notifyUpdateAvailable() {
@@ -28,6 +36,10 @@ export function onUpdateAvailable(fn: UpdateListener): () => void {
 /**
  * Force the service worker to check for a new version.
  * Returns a truthy string if an update was detected, null if up-to-date.
+ *
+ * Uses event-based detection rather than a fixed sleep: we listen for
+ * `updatefound` on the registration and then watch the installing SW's
+ * `statechange` until it reaches `installed` (i.e. parked in `waiting`).
  */
 export async function checkForPwaUpdate(): Promise<string | null> {
   if (updateAvailable) return "new version";
@@ -35,20 +47,54 @@ export async function checkForPwaUpdate(): Promise<string | null> {
   const reg = await navigator.serviceWorker?.getRegistration();
   if (!reg) return null;
 
-  await reg.update();
-
-  // Give the SW a moment to move through installing → waiting/active
-  await new Promise((r) => setTimeout(r, 1500));
-
-  if (reg.waiting || reg.installing) {
+  // A SW is already waiting (e.g. user opens Settings after auto-detection)
+  if (reg.waiting) {
     notifyUpdateAvailable();
     return "new version";
   }
 
-  return null;
+  return new Promise<string | null>((resolve) => {
+    // Give the network request up to 10 seconds before giving up
+    const timer = setTimeout(() => resolve(null), 10_000);
+
+    reg.addEventListener(
+      "updatefound",
+      () => {
+        const sw = reg.installing;
+        if (!sw) {
+          clearTimeout(timer);
+          resolve(null);
+          return;
+        }
+        sw.addEventListener("statechange", () => {
+          // `installed` means the SW finished installing and is now waiting
+          if (sw.state === "installed" && reg.waiting) {
+            clearTimeout(timer);
+            notifyUpdateAvailable();
+            resolve("new version");
+          }
+        });
+      },
+      { once: true },
+    );
+
+    reg.update().catch(() => {
+      clearTimeout(timer);
+      resolve(null);
+    });
+  });
 }
 
-/** Reload the page to pick up the new service worker's assets. */
+/**
+ * Activate the waiting service worker and reload the page.
+ *
+ * Prefers the `updateSW` handle from vite-plugin-pwa (which sends
+ * SKIP_WAITING then reloads) over a bare `window.location.reload()`.
+ */
 export function applyPwaUpdate() {
-  window.location.reload();
+  if (updateSWFn) {
+    updateSWFn(true);
+  } else {
+    window.location.reload();
+  }
 }

--- a/packages/pwa/src/main.tsx
+++ b/packages/pwa/src/main.tsx
@@ -1,7 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { registerSW } from 'virtual:pwa-register'
-import { notifyUpdateAvailable } from './lib/pwa-updater'
+import { notifyUpdateAvailable, setUpdateSwCallback } from './lib/pwa-updater'
 import './index.css'
 import App from './App.tsx'
 
@@ -18,7 +18,7 @@ if (window.visualViewport) {
 }
 syncVisualViewport()
 
-registerSW({
+const updateSW = registerSW({
   onNeedRefresh() {
     notifyUpdateAvailable()
   },
@@ -26,6 +26,7 @@ registerSW({
     console.log('[PWA] App ready for offline use')
   },
 })
+setUpdateSwCallback(updateSW)
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/packages/pwa/vite.config.ts
+++ b/packages/pwa/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
     topLevelAwait(),
     react(),
     VitePWA({
-      registerType: 'autoUpdate',
+      registerType: 'prompt',
       includeAssets: ['favicon.ico', 'icons/*.png'],
       manifest: false,
       workbox: {
@@ -67,7 +67,6 @@ export default defineConfig({
           },
         ],
         globPatterns: ['**/*.{js,css,html,ico,png,svg}'],
-        skipWaiting: true,
         clientsClaim: true,
       },
       devOptions: {


### PR DESCRIPTION
(AI Generated)

## Summary

- **PWA updates were silently broken**: `skipWaiting: true` in the Workbox config caused new service workers to skip the waiting phase entirely, so `onNeedRefresh` never fired and the "Check for Updates" button in Settings always returned "You are up to date" even when a new version was deployed. Switches `registerType` to `prompt`, removes `skipWaiting: true`, and rewires `checkForPwaUpdate()` to use event-based detection (`updatefound` + `statechange`) instead of a 1500ms sleep racing against a state transition it could never win.
- **`applyPwaUpdate()` now properly hands off to the new SW**: previously called `window.location.reload()` directly (which reloads with the old SW still active); now calls vite-plugin-pwa's `updateSW(true)` handle, which sends `SKIP_WAITING` first.
- **HTTPS warning in Connect to Desktop shows before the user wastes effort**: moved below the mode tabs so it appears the instant the user selects Local QR or Manual, not only after they've typed a full IP address or successfully scanned a QR code. Condition simplified from checking constructed/scanned URL content to just `protocol === https && localMode`.

## Test plan

- [ ] On a deployed HTTPS PWA build, open Settings and tap "Check for Updates" — should now correctly detect and report a newer version if one exists
- [ ] The bottom-right "New version available / Reload" banner should appear automatically when a new SW is ready
- [ ] "Reload" button should activate the new SW and reload (not just reload with the old SW)
- [ ] In Connect to Desktop, tap "Local QR" or "Manual" on an HTTPS page — orange warning banner should appear immediately below the tabs before any input
- [ ] Tapping "Cloud Sync" tab should hide the warning banner
- [ ] On an HTTP page the warning should never appear