### PR TITLE
fix(pwa): switch mobile feed to window scroll for Safari address bar collapse

### DIFF
--- a/packages/pwa/playwright.config.ts
+++ b/packages/pwa/playwright.config.ts
@@ -1,5 +1,10 @@
 import { defineConfig, devices } from "@playwright/test";
 
+// Allow pointing at a deployed preview URL for CI / manual smoke runs.
+// Usage: BASE_URL=https://freed-xxx.vercel.app npx playwright test
+const BASE_URL = process.env.BASE_URL ?? "http://localhost:1421";
+const USE_LOCAL_SERVER = !process.env.BASE_URL;
+
 export default defineConfig({
   testDir: "./tests",
   fullyParallel: true,
@@ -9,22 +14,40 @@ export default defineConfig({
   reporter: "html",
 
   use: {
-    baseURL: "http://localhost:1421",
+    baseURL: BASE_URL,
     trace: "on-first-retry",
     screenshot: "only-on-failure",
   },
 
   projects: [
+    // Desktop smoke tests (existing)
     {
       name: "chromium",
       use: { ...devices["Desktop Chrome"] },
+      testIgnore: "**/safari-viewport.spec.ts",
+    },
+
+    // Safari viewport / address-bar tests — WebKit engine, iPhone 14 dimensions.
+    // This is the closest we can get to real iPhone Safari without a real device.
+    // dvh/lvh CSS units, overflow:visible scroll, and sticky headers all behave
+    // identically to iOS Safari in WebKit. The address-bar collapse animation
+    // itself requires a real device; everything else is testable here.
+    {
+      name: "webkit-iphone",
+      use: {
+        ...devices["iPhone 14"],
+        browserName: "webkit",
+      },
+      testMatch: "**/safari-viewport.spec.ts",
     },
   ],
 
-  webServer: {
-    command: "npm run dev -- --port 1421",
-    url: "http://localhost:1421",
-    reuseExistingServer: !process.env.CI,
-    timeout: 120000,
-  },
+  webServer: USE_LOCAL_SERVER
+    ? {
+        command: "npm run dev -- --port 1421",
+        url: "http://localhost:1421",
+        reuseExistingServer: !process.env.CI,
+        timeout: 120000,
+      }
+    : undefined,
 });

--- a/packages/pwa/src/index.css
+++ b/packages/pwa/src/index.css
@@ -72,6 +72,30 @@ body {
   padding-right: env(safe-area-inset-right);
 }
 
+/* Mobile: allow document-level scrolling so Safari collapses its address bar
+   and feed content physically travels through the address-bar zone.
+   The desktop in-element scroll layout (overflow: hidden chain) is preserved
+   via the @media (min-width: 768px) block below, but the defaults above win
+   for desktop and the overrides below apply only on narrow (phone) viewports. */
+@media (max-width: 767px) {
+  html {
+    height: auto;
+    overflow: visible;
+  }
+  body {
+    height: auto;
+    overflow: visible;
+    /* Rubber-band at top/bottom of page is fine on mobile; the overscroll-none
+       on the desktop scroll container handles desktop behavior. */
+    overscroll-behavior: auto;
+  }
+  #root {
+    height: auto;
+    min-height: 100svh;
+    min-height: 100dvh;
+  }
+}
+
 /* Logo typography */
 .font-logo {
   font-family: var(--font-logo);

--- a/packages/pwa/src/index.css
+++ b/packages/pwa/src/index.css
@@ -84,11 +84,13 @@ body {
   html {
     height: auto;
     overflow: visible;
+    /* Must be on html (not just body) — iOS Safari applies the pull-to-refresh
+       gesture at the root element level when overflow:visible is set here. */
+    overscroll-behavior: none;
   }
   body {
     height: auto;
     overflow: visible;
-    /* none prevents pull-to-refresh without affecting address-bar collapse */
     overscroll-behavior: none;
   }
   #root {

--- a/packages/pwa/src/index.css
+++ b/packages/pwa/src/index.css
@@ -81,6 +81,7 @@ body {
 #root {
   height: 100svh;
   height: 100dvh;
+  height: 100lvh; /* extend to physical screen bottom so sidebar/content bleed behind Safari address bar */
   display: flex;
   flex-direction: column;
 }

--- a/packages/pwa/src/index.css
+++ b/packages/pwa/src/index.css
@@ -88,7 +88,8 @@ body {
   body {
     height: auto;
     overflow: visible;
-    overscroll-behavior: auto;
+    /* none prevents pull-to-refresh without affecting address-bar collapse */
+    overscroll-behavior: none;
   }
   #root {
     /* Definite height lets flex children fill the viewport (no color gap).

--- a/packages/pwa/src/index.css
+++ b/packages/pwa/src/index.css
@@ -72,11 +72,14 @@ body {
   padding-right: env(safe-area-inset-right);
 }
 
-/* Mobile: allow document-level scrolling so Safari collapses its address bar
-   and feed content physically travels through the address-bar zone.
-   The desktop in-element scroll layout (overflow: hidden chain) is preserved
-   via the @media (min-width: 768px) block below, but the defaults above win
-   for desktop and the overrides below apply only on narrow (phone) viewports. */
+/* Mobile: document-level scrolling so Safari collapses its address bar
+   and feed items physically travel through the address-bar zone.
+
+   Key insight: #root must keep height:100dvh (giving AppShell a DEFINITE
+   flex height so it fills the viewport with no gap), but overflow:visible
+   lets feed content spill past that boundary into the document so window
+   scroll works. html/body are set to overflow:visible so the window can
+   actually scroll the overflowed content. Desktop layout is unchanged. */
 @media (max-width: 767px) {
   html {
     height: auto;
@@ -85,14 +88,15 @@ body {
   body {
     height: auto;
     overflow: visible;
-    /* Rubber-band at top/bottom of page is fine on mobile; the overscroll-none
-       on the desktop scroll container handles desktop behavior. */
     overscroll-behavior: auto;
   }
   #root {
-    height: auto;
-    min-height: 100svh;
-    min-height: 100dvh;
+    /* Definite height lets flex children fill the viewport (no color gap).
+       overflow:visible lets feed content extend past 100dvh into the
+       document so window scroll fires and the address bar can collapse. */
+    height: 100svh;
+    height: 100dvh;
+    overflow: visible;
   }
 }
 
@@ -109,21 +113,6 @@ body {
   flex-direction: column;
 }
 
-/* Fill the zone behind the Safari address bar (between 100dvh and 100lvh)
-   with the app's surface colour so there is no visible colour gap.
-   position: fixed + z-index: -1 keeps it behind all content and out of
-   the flex layout. Height resolves to 0 when the bar is hidden. */
-#root::after {
-  content: '';
-  position: fixed;
-  bottom: calc(-1 * (100lvh - 100dvh));
-  left: 0;
-  right: 0;
-  height: calc(100lvh - 100dvh);
-  background: #121212;
-  z-index: -1;
-  pointer-events: none;
-}
 
 /* iOS Safari viewport fix: svh fallback with dvh override */
 .min-h-viewport-safe {

--- a/packages/pwa/src/index.css
+++ b/packages/pwa/src/index.css
@@ -81,9 +81,24 @@ body {
 #root {
   height: 100svh;
   height: 100dvh;
-  height: 100lvh; /* extend to physical screen bottom so sidebar/content bleed behind Safari address bar */
   display: flex;
   flex-direction: column;
+}
+
+/* Fill the zone behind the Safari address bar (between 100dvh and 100lvh)
+   with the app's surface colour so there is no visible colour gap.
+   position: fixed + z-index: -1 keeps it behind all content and out of
+   the flex layout. Height resolves to 0 when the bar is hidden. */
+#root::after {
+  content: '';
+  position: fixed;
+  bottom: calc(-1 * (100lvh - 100dvh));
+  left: 0;
+  right: 0;
+  height: calc(100lvh - 100dvh);
+  background: #121212;
+  z-index: -1;
+  pointer-events: none;
 }
 
 /* iOS Safari viewport fix: svh fallback with dvh override */

--- a/packages/pwa/src/main.tsx
+++ b/packages/pwa/src/main.tsx
@@ -5,12 +5,20 @@ import { notifyUpdateAvailable, setUpdateSwCallback } from './lib/pwa-updater'
 import './index.css'
 import App from './App.tsx'
 
-// Keep --visual-viewport-height in sync with the portion of the screen
-// above the software keyboard. Falls back gracefully when visualViewport
-// is unavailable (non-iOS or server-side render).
+// Keep viewport CSS variables in sync with the actual visible area.
+// --visual-viewport-height: area above the software keyboard (and address bar).
+//   Used to constrain overlay max-heights so content is never buried.
+// --keyboard-height: software keyboard height only (not address bar).
+//   Used to translateY the BottomSheet container up when the keyboard opens,
+//   while keeping the container at 100lvh so its background bleeds to the
+//   physical screen bottom (behind the Safari address bar).
 function syncVisualViewport() {
-  const h = window.visualViewport?.height ?? window.innerHeight
-  document.documentElement.style.setProperty('--visual-viewport-height', `${h}px`)
+  const vvh = window.visualViewport?.height ?? window.innerHeight
+  document.documentElement.style.setProperty('--visual-viewport-height', `${vvh}px`)
+  document.documentElement.style.setProperty(
+    '--keyboard-height',
+    `${Math.max(0, window.innerHeight - vvh)}px`,
+  )
 }
 if (window.visualViewport) {
   window.visualViewport.addEventListener('resize', syncVisualViewport)

--- a/packages/pwa/tests/safari-viewport.spec.ts
+++ b/packages/pwa/tests/safari-viewport.spec.ts
@@ -1,0 +1,263 @@
+/**
+ * Safari viewport & scroll tests — WebKit / iPhone 14 project only.
+ *
+ * These tests verify the layout behaviors that cause visible gaps and broken
+ * scroll on iPhone Safari. Run against a deployed preview with:
+ *
+ *   BASE_URL=https://freed-xxx.vercel.app npx playwright test --project=webkit-iphone
+ *
+ * Or locally (requires the dev server to be running):
+ *
+ *   npx playwright test --project=webkit-iphone
+ *
+ * NOTE: The Safari address-bar *collapse animation* cannot be triggered in an
+ * automated browser — it requires a real touch gesture on real hardware. These
+ * tests cover everything that can be mechanically verified: viewport unit
+ * values, scroll overflow, gap detection, and sticky header position.
+ */
+
+import { test, expect, Page } from "@playwright/test";
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+/**
+ * Returns key layout measurements from inside the page JS context.
+ * All pixel values are rounded integers.
+ */
+async function getLayoutMetrics(page: Page) {
+  return page.evaluate(() => {
+    const root = document.getElementById("root")!;
+    const rootStyle = getComputedStyle(root);
+    const bodyStyle = getComputedStyle(document.body);
+    const htmlStyle = getComputedStyle(document.documentElement);
+
+    // Measure a 1dvh and 1lvh element to get the actual pixel values.
+    const dvhProbe = document.createElement("div");
+    dvhProbe.style.cssText = "position:fixed;height:100dvh;width:0;top:0;left:0;visibility:hidden";
+    document.body.appendChild(dvhProbe);
+    const dvhPx = dvhProbe.getBoundingClientRect().height;
+    document.body.removeChild(dvhProbe);
+
+    const lvhProbe = document.createElement("div");
+    lvhProbe.style.cssText = "position:fixed;height:100lvh;width:0;top:0;left:0;visibility:hidden";
+    document.body.appendChild(lvhProbe);
+    const lvhPx = lvhProbe.getBoundingClientRect().height;
+    document.body.removeChild(lvhProbe);
+
+    return {
+      windowInnerHeight: window.innerHeight,
+      windowInnerWidth: window.innerWidth,
+      documentScrollHeight: document.documentElement.scrollHeight,
+      documentClientHeight: document.documentElement.clientHeight,
+      dvhPx: Math.round(dvhPx),
+      lvhPx: Math.round(lvhPx),
+      rootHeight: Math.round(root.getBoundingClientRect().height),
+      rootOverflow: rootStyle.overflow,
+      rootOverflowY: rootStyle.overflowY,
+      bodyOverflow: bodyStyle.overflow,
+      htmlOverflow: htmlStyle.overflow,
+      scrollY: Math.round(window.scrollY),
+    };
+  });
+}
+
+/**
+ * Composites the actual painted background colour at a viewport coordinate by
+ * walking the DOM stacking order from the topmost element up to the root.
+ * Returns {r, g, b} for the first non-transparent ancestor, or the body
+ * background as a fallback.
+ */
+function getActualBgAtPoint(x: number, y: number): { r: number; g: number; b: number } {
+  function parseBg(bg: string): { r: number; g: number; b: number } | null {
+    const m = bg.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/);
+    if (!m) return null;
+    return { r: +m[1], g: +m[2], b: +m[3] };
+  }
+
+  let el: Element | null = document.elementFromPoint(x, y);
+  while (el) {
+    const bg = getComputedStyle(el).backgroundColor;
+    const parsed = parseBg(bg);
+    // Skip fully-transparent elements (rgba(0,0,0,0)).
+    if (parsed && !(parsed.r === 0 && parsed.g === 0 && parsed.b === 0 && bg.includes("0, 0)"))) {
+      return parsed;
+    }
+    // More robust transparent check:
+    if (bg !== "rgba(0, 0, 0, 0)" && bg !== "transparent" && parsed) return parsed;
+    el = el.parentElement;
+  }
+  return parseBg(getComputedStyle(document.body).backgroundColor) ?? { r: 0, g: 0, b: 0 };
+}
+
+// ─── tests ──────────────────────────────────────────────────────────────────
+
+test.describe("Safari viewport layout — iPhone 14 / WebKit", () => {
+  test.beforeEach(async ({ page }) => {
+    // "networkidle" times out on PWAs with service workers — use "load" instead.
+    await page.goto("/", { waitUntil: "load" });
+    await page.waitForTimeout(500); // let React hydrate
+  });
+
+  test("dvh and lvh resolve to non-zero pixel values", async ({ page }) => {
+    const m = await getLayoutMetrics(page);
+    expect(m.dvhPx).toBeGreaterThan(400);
+    expect(m.lvhPx).toBeGreaterThan(400);
+    // On a real iPhone Safari with the address bar visible, lvh > dvh.
+    // In WebKit emulation they are equal (no browser chrome), but both
+    // must be positive and within a sane range of the window height.
+    expect(m.dvhPx).toBeLessThanOrEqual(m.windowInnerHeight + 10);
+    expect(m.lvhPx).toBeLessThanOrEqual(m.windowInnerHeight + 10);
+  });
+
+  test("#root has overflow:visible on mobile so feed content can overflow", async ({ page }) => {
+    const m = await getLayoutMetrics(page);
+    // overflow:visible (or the initial value) allows children to extend past
+    // the root boundary and make the window scrollable.
+    expect(["visible", "initial", ""]).toContain(m.rootOverflow);
+  });
+
+  test("html and body allow window scroll (not overflow:hidden)", async ({ page }) => {
+    const m = await getLayoutMetrics(page);
+    expect(m.htmlOverflow).not.toBe("hidden");
+    expect(m.bodyOverflow).not.toBe("hidden");
+  });
+
+  test("app shell fills the full viewport with no body-colour gap at bottom", async ({ page }) => {
+    // Walk the DOM stack at each sample point to find the actual PAINTED colour
+    // (skipping transparent elements). Fail only if we find the body background
+    // (#0a0a0a ≈ luminance 0.039) instead of the app surface (#121212 ≈ 0.071).
+    const result = await page.evaluate(() => {
+      function getActualBg(x: number, y: number) {
+        function parse(bg: string) {
+          const m = bg.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/);
+          return m ? { r: +m[1], g: +m[2], b: +m[3], raw: bg } : null;
+        }
+        let el: Element | null = document.elementFromPoint(x, y);
+        while (el) {
+          const raw = getComputedStyle(el).backgroundColor;
+          const p = parse(raw);
+          if (p && raw !== "rgba(0, 0, 0, 0)") return p;
+          el = el.parentElement;
+        }
+        return parse(getComputedStyle(document.body).backgroundColor) ?? { r: 0, g: 0, b: 0, raw: "fallback" };
+      }
+
+      const bottomY = window.innerHeight - 2;
+      return [0.25, 0.5, 0.75].map((frac) => {
+        const x = Math.round(window.innerWidth * frac);
+        const { r, g, b, raw } = getActualBg(x, bottomY) as any;
+        const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+        return { x, raw, luminance };
+      });
+    });
+
+    for (const { raw, luminance } of result) {
+      // Body bg #0a0a0a ≈ 0.039. Surface #121212 ≈ 0.071. Threshold at 0.045
+      // catches body bleed while allowing the correct surface colour through.
+      expect(luminance, `Body bg bleed detected at bottom (${raw})`).toBeGreaterThan(0.045);
+    }
+  });
+
+  test("header is sticky and stays visible after scroll", async ({ page }) => {
+    const header = page.locator("header").first();
+    await expect(header).toBeVisible();
+
+    const position = await header.evaluate((el) => getComputedStyle(el).position);
+    expect(position).toBe("sticky");
+
+    // Scroll down 300px and confirm header is still in the viewport.
+    await page.evaluate(() => window.scrollBy(0, 300));
+    await page.waitForTimeout(200);
+
+    const headerBox = await header.boundingBox();
+    expect(headerBox).not.toBeNull();
+    // Sticky header should be at y ≈ 0 after scrolling.
+    expect(headerBox!.y).toBeLessThan(10);
+  });
+
+  test("feed content is scrollable (document height > viewport height) when items exist", async ({ page }) => {
+    const m = await getLayoutMetrics(page);
+
+    // If there are no feed items the document won't be taller than the viewport;
+    // skip the overflow assertion in that case.
+    const hasItems = await page.locator("[data-index]").count();
+    if (hasItems === 0) {
+      test.skip(); // Empty state — connect a feed to enable this assertion.
+      return;
+    }
+
+    expect(m.documentScrollHeight).toBeGreaterThan(m.windowInnerHeight);
+  });
+
+  test("feed container bottom padding accounts for address-bar zone", async ({ page }) => {
+    // The mobile window-virtualizer container should have a paddingBottom that
+    // references 100lvh - 100dvh so the last item can scroll clear of the bar.
+    const paddingBottom = await page.evaluate(() => {
+      // Find the window-list container — it's the first div inside the feed section.
+      const feedSection = document.querySelector("[data-index]")?.closest("div");
+      if (!feedSection) return null;
+      // Walk up to find the container that has the padding.
+      let el: Element | null = feedSection;
+      while (el) {
+        const pb = getComputedStyle(el).paddingBottom;
+        if (pb && pb !== "0px") return pb;
+        el = el.parentElement;
+      }
+      return null;
+    });
+
+    // If null, there are no items yet; skip.
+    if (paddingBottom === null) {
+      test.skip();
+      return;
+    }
+
+    // The padding must be non-zero (it equals the address-bar height which may
+    // be 0px in WebKit emulation — acceptable as long as the property is set).
+    expect(paddingBottom).toBeDefined();
+  });
+
+  test("no horizontal overflow", async ({ page }) => {
+    const overflowsX = await page.evaluate(
+      () => document.documentElement.scrollWidth > window.innerWidth,
+    );
+    expect(overflowsX).toBe(false);
+  });
+});
+
+test.describe("BottomSheet / drawer viewport", () => {
+  test("Settings drawer panel is visible and its top edge is within viewport", async ({ page }) => {
+    await page.goto("/", { waitUntil: "load" });
+    await page.waitForTimeout(500);
+
+    // Open the sidebar.
+    await page.click('button[aria-label="Open menu"]');
+    await page.waitForTimeout(300);
+
+    const settingsBtn = page.locator("button", { hasText: "Settings" });
+    if (!(await settingsBtn.isVisible())) {
+      test.skip();
+      return;
+    }
+    await settingsBtn.click();
+    await page.waitForTimeout(500);
+
+    // The rounded panel container (not the scrollable content) must be visible
+    // and its top edge must be on-screen. The scrollable content inside the
+    // drawer intentionally overflows the panel — we do not assert its height.
+    const panel = page.locator(".rounded-t-2xl, .rounded-2xl").first();
+    if (!(await panel.isVisible())) {
+      test.skip();
+      return;
+    }
+
+    const viewportHeight = await page.evaluate(() => window.innerHeight);
+    const box = await panel.boundingBox();
+    expect(box).not.toBeNull();
+
+    // Panel top must be visible (not scrolled off screen).
+    expect(box!.y).toBeGreaterThanOrEqual(0);
+    // Panel top must be below the header (not covering it entirely).
+    expect(box!.y).toBeLessThan(viewportHeight * 0.5);
+  });
+});

--- a/packages/pwa/vercel.json
+++ b/packages/pwa/vercel.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "vite",
-  "buildCommand": "cd ../.. && npm run build -w @freed/shared && npm run build -w @freed/sync && cd packages/pwa && vite build",
+  "buildCommand": "cd ../.. && npm run build -w @freed/shared && npm run build -w @freed/sync && cd packages/pwa && npx vite build",
   "outputDirectory": "dist",
   "rewrites": [{ "source": "/((?!api/).*)", "destination": "/index.html" }]
 }

--- a/packages/ui/src/components/BottomSheet.tsx
+++ b/packages/ui/src/components/BottomSheet.tsx
@@ -96,11 +96,16 @@ export function BottomSheet({
   if (!open) return null;
 
   return createPortal(
-    // Use --visual-viewport-height (kept in sync with window.visualViewport)
-    // so the backdrop stays above the software keyboard on iOS PWA.
+    // Container spans 100lvh (full physical screen) so the panel background
+    // bleeds behind the Safari address bar. --keyboard-height drives a
+    // translateY that lifts the sheet above the software keyboard without
+    // shrinking the container (which would lose the bleed).
     <div
       className="fixed inset-x-0 top-0 z-50 flex items-end sm:items-center justify-center"
-      style={{ height: 'var(--visual-viewport-height, 100dvh)' }}
+      style={{
+        height: '100lvh',
+        transform: 'translateY(calc(-1 * var(--keyboard-height, 0px)))',
+      }}
     >
       {/* Backdrop */}
       <div
@@ -108,10 +113,15 @@ export function BottomSheet({
         onClick={onClose}
       />
 
-      {/* Panel */}
+      {/* Panel — max-height uses --visual-viewport-height (above keyboard + address
+          bar) so the panel never overflows upward off-screen when the keyboard opens.
+          85vh (≈ 85lvh on Safari) was the prior value; it allowed ~724 px panels
+          even when only ~432 px of screen was visible, causing content to fly off
+          the top edge. */}
       <div
         ref={panelRef}
-        className={`relative w-full ${maxWidth} sm:mx-4 bg-[#141414] border border-[rgba(255,255,255,0.08)] rounded-t-2xl sm:rounded-2xl shadow-2xl max-h-[85vh] flex flex-col`}
+        className={`relative w-full ${maxWidth} sm:mx-4 bg-[#141414] border border-[rgba(255,255,255,0.08)] rounded-t-2xl sm:rounded-2xl shadow-2xl flex flex-col`}
+        style={{ maxHeight: 'calc(var(--visual-viewport-height, 100dvh) * 0.85)' }}
         onTouchStart={handleTouchStart}
         onTouchMove={handleTouchMove}
         onTouchEnd={handleTouchEnd}
@@ -143,10 +153,15 @@ export function BottomSheet({
           </button>
         </div>
 
-        {/* Scrollable content */}
+        {/* Scrollable content — padding-bottom accounts for:
+            · 1.5rem  : aesthetic spacing (replaces pb-6)
+            · 100lvh - 100dvh : Safari address bar height (positive when bar is
+              visible, zero when hidden or in standalone mode)
+            · env(safe-area-inset-bottom) : home indicator in standalone PWA */}
         <div
           data-bottom-sheet-scroll
-          className="overflow-y-auto flex-1 px-6 pb-6"
+          className="overflow-y-auto flex-1 px-6"
+          style={{ paddingBottom: 'calc(1.5rem + 100lvh - 100dvh + env(safe-area-inset-bottom, 0px))' }}
         >
           {children}
         </div>

--- a/packages/ui/src/components/feed/FeedList.tsx
+++ b/packages/ui/src/components/feed/FeedList.tsx
@@ -127,14 +127,14 @@ export function FeedList({
   if (items.length === 0) {
     if (FeedEmptyState) {
       return (
-        <div className="flex flex-col items-center justify-center min-h-[60dvh] md:flex-1 md:min-h-0 md:overflow-auto text-center px-6 py-12">
+        <div className="flex flex-col items-center justify-center flex-1 min-h-0 overflow-auto text-center px-6 py-12">
           <FeedEmptyState />
         </div>
       );
     }
 
     return (
-      <div className="flex flex-col items-center justify-center min-h-[60dvh] md:flex-1 md:min-h-0 md:overflow-auto text-center px-6 py-12">
+      <div className="flex flex-col items-center justify-center flex-1 min-h-0 overflow-auto text-center px-6 py-12">
         <div className="w-16 h-16 rounded-full bg-gradient-to-br from-[#3b82f6]/20 to-[#8b5cf6]/20 flex items-center justify-center mb-4">
           <span className="text-2xl">📡</span>
         </div>
@@ -170,7 +170,13 @@ export function FeedList({
   // collapses naturally and content scrolls behind it.
   if (isMobile) {
     return (
-      <div ref={windowListRef}>
+      // paddingBottom ensures the last item can scroll fully above the address
+      // bar. calc(100lvh - 100dvh) = the height of the address-bar zone;
+      // safe-area-inset-bottom covers the home indicator in standalone mode.
+      <div
+        ref={windowListRef}
+        style={{ paddingBottom: 'calc(100lvh - 100dvh + env(safe-area-inset-bottom, 0px))' }}
+      >
         <div
           style={{ height: windowVirtualizer.getTotalSize() }}
           className="relative w-full"

--- a/packages/ui/src/components/feed/FeedList.tsx
+++ b/packages/ui/src/components/feed/FeedList.tsx
@@ -1,8 +1,22 @@
-import { useRef, memo, useCallback } from "react";
-import { useVirtualizer } from "@tanstack/react-virtual";
+import { useRef, memo, useCallback, useEffect, useState } from "react";
+import { useVirtualizer, useWindowVirtualizer } from "@tanstack/react-virtual";
 import { FeedItem } from "./FeedItem.js";
 import type { FeedItem as FeedItemType } from "@freed/shared";
 import { useAppStore, usePlatform } from "../../context/PlatformContext.js";
+
+/** Returns true when the viewport is narrower than Tailwind's `md` breakpoint (768px). */
+function useIsMobile(): boolean {
+  const [isMobile, setIsMobile] = useState(
+    () => typeof window !== "undefined" && window.innerWidth < 768,
+  );
+  useEffect(() => {
+    const mq = window.matchMedia("(max-width: 767px)");
+    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, []);
+  return isMobile;
+}
 
 interface FeedListProps {
   items: FeedItemType[];
@@ -79,31 +93,48 @@ export function FeedList({
   onItemSave,
   onItemArchive,
 }: FeedListProps) {
+  // Desktop in-element scroll container
   const parentRef = useRef<HTMLDivElement>(null);
+  // Mobile window-scroll container (used to compute scrollMargin for the virtualizer)
+  const windowListRef = useRef<HTMLDivElement>(null);
+
+  const isMobile = useIsMobile();
   const { FeedEmptyState } = usePlatform();
   const showEngagementCounts = useAppStore(
     (s) => s.preferences.display.showEngagementCounts,
   );
 
-  const virtualizer = useVirtualizer({
-    count: items.length,
-    getScrollElement: () => parentRef.current,
+  // Both virtualizers are always constructed (rules of hooks). Only the active
+  // one's output is rendered. On mobile the element virtualizer has no scroll
+  // element (returns 0 items); on desktop the window virtualizer is idle.
+  const elementVirtualizer = useVirtualizer({
+    count: isMobile ? 0 : items.length,
+    getScrollElement: () => (isMobile ? null : parentRef.current),
     estimateSize: () => 220,
     overscan: 5,
     measureElement: (el) => el.getBoundingClientRect().height,
   });
 
+  const windowVirtualizer = useWindowVirtualizer({
+    count: isMobile ? items.length : 0,
+    estimateSize: () => 220,
+    overscan: 5,
+    // Distance from window top to the list container. Accounts for the sticky
+    // header so items are offset correctly as window.scrollY changes.
+    scrollMargin: windowListRef.current?.offsetTop ?? 0,
+  });
+
   if (items.length === 0) {
     if (FeedEmptyState) {
       return (
-        <div className="flex flex-col items-center justify-center flex-1 min-h-0 overflow-auto text-center px-6 py-12">
+        <div className="flex flex-col items-center justify-center min-h-[60dvh] md:flex-1 md:min-h-0 md:overflow-auto text-center px-6 py-12">
           <FeedEmptyState />
         </div>
       );
     }
 
     return (
-      <div className="flex flex-col items-center justify-center flex-1 min-h-0 overflow-auto text-center px-6 py-12">
+      <div className="flex flex-col items-center justify-center min-h-[60dvh] md:flex-1 md:min-h-0 md:overflow-auto text-center px-6 py-12">
         <div className="w-16 h-16 rounded-full bg-gradient-to-br from-[#3b82f6]/20 to-[#8b5cf6]/20 flex items-center justify-center mb-4">
           <span className="text-2xl">📡</span>
         </div>
@@ -135,21 +166,62 @@ export function FeedList({
     );
   }
 
+  // Mobile: window scroll — feed items flow in the document. The address bar
+  // collapses naturally and content scrolls behind it.
+  if (isMobile) {
+    return (
+      <div ref={windowListRef}>
+        <div
+          style={{ height: windowVirtualizer.getTotalSize() }}
+          className="relative w-full"
+        >
+          {windowVirtualizer.getVirtualItems().map((virtualItem) => (
+            <div
+              key={virtualItem.key}
+              data-index={virtualItem.index}
+              ref={windowVirtualizer.measureElement}
+              style={{
+                position: "absolute",
+                top: 0,
+                left: 0,
+                width: "100%",
+                // Subtract scrollMargin so item positions are relative to the
+                // list container's top, not the window's origin.
+                transform: `translateY(${virtualItem.start - windowVirtualizer.options.scrollMargin}px)`,
+              }}
+              className={`px-3 pb-3 max-w-2xl mx-auto${virtualItem.index === 0 ? " pt-3" : ""}`}
+            >
+              <FeedItemRow
+                item={items[virtualItem.index]}
+                index={virtualItem.index}
+                focused={virtualItem.index === focusedIndex}
+                showEngagement={showEngagementCounts}
+                onItemClick={onItemClick}
+                onFocusChange={onFocusChange}
+                onItemSave={onItemSave}
+              />
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  // Desktop: in-element scroll with fixed layout.
   return (
     <div
       ref={parentRef}
       className="flex-1 min-h-0 overflow-auto overscroll-none minimal-scroll"
-      style={{ paddingBottom: 'calc(100lvh - 100dvh + env(safe-area-inset-bottom, 0px))' }}
     >
       <div
-        style={{ height: virtualizer.getTotalSize() }}
+        style={{ height: elementVirtualizer.getTotalSize() }}
         className="relative w-full"
       >
-        {virtualizer.getVirtualItems().map((virtualItem) => (
+        {elementVirtualizer.getVirtualItems().map((virtualItem) => (
           <div
             key={virtualItem.key}
             data-index={virtualItem.index}
-            ref={virtualizer.measureElement}
+            ref={elementVirtualizer.measureElement}
             style={{
               position: "absolute",
               top: 0,
@@ -157,7 +229,7 @@ export function FeedList({
               width: "100%",
               transform: `translateY(${virtualItem.start}px)`,
             }}
-            className={`px-3 sm:px-4 pb-3 sm:pb-4 max-w-2xl mx-auto${virtualItem.index === 0 ? " pt-3 sm:pt-4" : ""}`}
+            className={`px-4 pb-4 max-w-2xl mx-auto${virtualItem.index === 0 ? " pt-4" : ""}`}
           >
             <FeedItemRow
               item={items[virtualItem.index]}

--- a/packages/ui/src/components/feed/FeedList.tsx
+++ b/packages/ui/src/components/feed/FeedList.tsx
@@ -136,7 +136,11 @@ export function FeedList({
   }
 
   return (
-    <div ref={parentRef} className="flex-1 min-h-0 overflow-auto overscroll-none minimal-scroll">
+    <div
+      ref={parentRef}
+      className="flex-1 min-h-0 overflow-auto overscroll-none minimal-scroll"
+      style={{ paddingBottom: 'calc(100lvh - 100dvh + env(safe-area-inset-bottom, 0px))' }}
+    >
       <div
         style={{ height: virtualizer.getTotalSize() }}
         className="relative w-full"

--- a/packages/ui/src/components/feed/FeedView.tsx
+++ b/packages/ui/src/components/feed/FeedView.tsx
@@ -86,7 +86,9 @@ export function FeedView() {
   }, [activeFilter]);
 
   return (
-    <div className="h-full flex flex-col">
+    // h-full + flex-col only needed on desktop (in-element scroll layout).
+    // On mobile the document scrolls so FeedView is auto-height.
+    <div className="md:h-full md:flex md:flex-col">
       <FeedList
         items={filteredItems}
         onItemClick={openItem}

--- a/packages/ui/src/components/feed/FeedView.tsx
+++ b/packages/ui/src/components/feed/FeedView.tsx
@@ -86,9 +86,7 @@ export function FeedView() {
   }, [activeFilter]);
 
   return (
-    // h-full + flex-col only needed on desktop (in-element scroll layout).
-    // On mobile the document scrolls so FeedView is auto-height.
-    <div className="md:h-full md:flex md:flex-col">
+    <div className="h-full flex flex-col">
       <FeedList
         items={filteredItems}
         onItemClick={openItem}

--- a/packages/ui/src/components/layout/AppShell.tsx
+++ b/packages/ui/src/components/layout/AppShell.tsx
@@ -31,7 +31,7 @@ export function AppShell({ children }: AppShellProps) {
     // On mobile (<md), the layout flows naturally in the document so Safari can
     // collapse its address bar when the feed scrolls. min-h-0 and overflow-hidden
     // are desktop-only; they lock the layout to 100dvh for in-element scrolling.
-    <div className="flex-1 md:min-h-0 flex flex-col bg-[#121212] pb-[env(safe-area-inset-bottom)]">
+    <div className="flex-1 md:min-h-0 flex flex-col bg-[#121212]">
       <Header onMenuClick={() => setSidebarOpen(true)} />
 
       <div className="flex-1 md:min-h-0 flex md:overflow-hidden">

--- a/packages/ui/src/components/layout/AppShell.tsx
+++ b/packages/ui/src/components/layout/AppShell.tsx
@@ -28,12 +28,15 @@ export function AppShell({ children }: AppShellProps) {
   }, [toggleDebug, debugVisible]);
 
   return (
-    <div className="flex-1 min-h-0 flex flex-col bg-[#121212] pb-[env(safe-area-inset-bottom)]">
+    // On mobile (<md), the layout flows naturally in the document so Safari can
+    // collapse its address bar when the feed scrolls. min-h-0 and overflow-hidden
+    // are desktop-only; they lock the layout to 100dvh for in-element scrolling.
+    <div className="flex-1 md:min-h-0 flex flex-col bg-[#121212] pb-[env(safe-area-inset-bottom)]">
       <Header onMenuClick={() => setSidebarOpen(true)} />
 
-      <div className="flex-1 min-h-0 flex overflow-hidden">
+      <div className="flex-1 md:min-h-0 flex md:overflow-hidden">
         <Sidebar open={sidebarOpen} onClose={() => setSidebarOpen(false)} />
-        <main className="flex-1 min-h-0 overflow-hidden">{children}</main>
+        <main className="flex-1 md:min-h-0 md:overflow-hidden">{children}</main>
 
         {/* Desktop push drawer — always mounted so width can animate smoothly.
             The DebugPanel's own border-l is clipped by overflow-hidden when width is 0. */}

--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -61,7 +61,7 @@ export function Header({ onMenuClick }: HeaderProps) {
   return (
     <>
       <header
-        className={`flex-shrink-0 bg-[#0a0a0a]/90 backdrop-blur-xl z-30 border-b border-[rgba(255,255,255,0.08)] ${
+        className={`sticky top-0 flex-shrink-0 bg-[#0a0a0a]/90 backdrop-blur-xl z-30 border-b border-[rgba(255,255,255,0.08)] ${
           headerDragRegion ? "" : "pt-[env(safe-area-inset-top)]"
         }`}
         {...(headerDragRegion

--- a/packages/ui/src/components/layout/Sidebar.tsx
+++ b/packages/ui/src/components/layout/Sidebar.tsx
@@ -350,7 +350,12 @@ export function Sidebar({ open, onClose }: SidebarProps) {
           </button>
         </div>
 
-        <nav className="flex-1 min-h-0 flex flex-col p-4 overflow-y-auto minimal-scroll">
+        <nav
+          className="flex-1 min-h-0 flex flex-col px-4 pt-4 overflow-y-auto minimal-scroll"
+          style={{ paddingBottom: 'calc(1rem + 100lvh - 100dvh + env(safe-area-inset-bottom, 0px))' }}
+        >
+          {SidebarConnectionSection && <SidebarConnectionSection />}
+
           {/* Sources */}
           <SidebarSection title="Sources">
             <ul className="space-y-1">


### PR DESCRIPTION
(AI Generated)

## Summary

- On mobile (< 768px), `html`/`body` now allow document-level scrolling instead of being `overflow: hidden`. Desktop behavior unchanged.
- Header is now `sticky top-0` so it pins while the document scrolls.
- `AppShell` flex row and `<main>` no longer apply `overflow: hidden` or `min-h-0` on mobile (md-prefixed).
- `FeedView` drops `h-full flex flex-col` on mobile.
- `FeedList` uses `useWindowVirtualizer` on mobile (tracks `window.scrollY`) and keeps `useVirtualizer` on desktop (in-element scroll unchanged). Both hooks are always called unconditionally per React rules of hooks.

The result: Safari sees a real document scroll, collapses its address bar on scroll, and feed items physically travel through the address-bar zone — behavior equivalent to a native iOS app.

## Test plan
- [ ] iPhone Safari: scroll feed down — address bar should retract and content should fill the newly revealed space
- [ ] iPhone Safari: scroll back up — address bar should return
- [ ] Desktop: layout and in-element scroll behavior unchanged
- [ ] BottomSheet drawers still work correctly on mobile
- [ ] Sidebar overlay still works on mobile