### PR TITLE
chore: remove em dashes and AI writing tells from all marketing copy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,11 +8,12 @@
 - **IDs:** Display tail — `...${id.slice(-8)}`.
 - **Number formatting:** All user-facing numbers must use `Number.toLocaleString()` (or `Intl.NumberFormat`) — never raw `.toString()` or string interpolation. This ensures locale-appropriate grouping separators (e.g. commas in `en-US`) for counts, totals, and stats.
 - **Before creating any new component or hook:** `SemanticSearch` or `Grep` the package for existing code that does the same thing. Duplication is never acceptable — if two surfaces need the same UI or logic, extract a shared primitive and have both import it.
-- **Before shipping any feature:** Verify that every exported function/class you added or touched is actually *called* from an appropriate entry point. Exported-but-never-called code is a bug. Grep for each new export name to confirm it appears in a consumer.
+- **Before shipping any feature:** Verify that every exported function/class you added or touched is actually _called_ from an appropriate entry point. Exported-but-never-called code is a bug. Grep for each new export name to confirm it appears in a consumer.
 
 ## Versioning
 
 CalVer `YY.M.DDBUILD` — patch segment encodes the day and build number:
+
 - `patch = (day_of_month × 100) + build_number`
 - March 1, first build → `26.3.100`; fifth build → `26.3.104`
 - March 15, first build → `26.3.1500`
@@ -21,22 +22,22 @@ Run `./scripts/release.sh` with no args to auto-compute the next version.
 
 ## Package Boundaries
 
-| Package | Rule |
-|---|---|
-| `shared/` | Pure functions + types. Zero runtime deps. No React. |
-| `ui/` | Platform-agnostic React UI layer. May import `@freed/shared`. No platform stores, no Tauri APIs, no service-worker logic, no `@freed/sync` imports. Ships raw `.tsx` source — no build step. |
-| `sync/` | Storage-agnostic. Works in browser (IndexedDB) and Node (filesystem). |
-| `pwa/` | PWA app shell only. Imports `@freed/ui` and `@freed/shared`. Never import Tauri APIs. |
-| `desktop/` | Tauri shell. Imports `@freed/ui` and `@freed/shared`. Never import from `@freed/pwa`. |
-| `capture-*/` | Isolated. Never import between capture packages. |
+| Package      | Rule                                                                                                                                                                                         |
+| ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `shared/`    | Pure functions + types. Zero runtime deps. No React.                                                                                                                                         |
+| `ui/`        | Platform-agnostic React UI layer. May import `@freed/shared`. No platform stores, no Tauri APIs, no service-worker logic, no `@freed/sync` imports. Ships raw `.tsx` source — no build step. |
+| `sync/`      | Storage-agnostic. Works in browser (IndexedDB) and Node (filesystem).                                                                                                                        |
+| `pwa/`       | PWA app shell only. Imports `@freed/ui` and `@freed/shared`. Never import Tauri APIs.                                                                                                        |
+| `desktop/`   | Tauri shell. Imports `@freed/ui` and `@freed/shared`. Never import from `@freed/pwa`.                                                                                                        |
+| `capture-*/` | Isolated. Never import between capture packages.                                                                                                                                             |
 
 ## URLs
 
-| Property | URL |
-|---|---|
-| Marketing site | `https://freed.wtf` |
+| Property            | URL                     |
+| ------------------- | ----------------------- |
+| Marketing site      | `https://freed.wtf`     |
 | PWA (mobile reader) | `https://app.freed.wtf` |
-| Download page | `https://freed.wtf/get` |
+| Download page       | `https://freed.wtf/get` |
 
 **Never write `freed.wtf/app`** — the PWA lives at the subdomain `app.freed.wtf`.
 
@@ -54,15 +55,15 @@ git worktree add ../freed-<slug> -b <branch>
 
 **Commit messages** follow Conventional Commits:
 
-| Prefix | When to use |
-|---|---|
-| `feat:` | New user-facing feature |
-| `fix:` | Bug fix |
-| `chore:` | Tooling, deps, config — no production code change |
-| `docs:` | Documentation only |
-| `refactor:` | Code restructure with no behavior change |
-| `perf:` | Performance improvement |
-| `style:` | Formatting, whitespace, CSS-only |
+| Prefix      | When to use                                       |
+| ----------- | ------------------------------------------------- |
+| `feat:`     | New user-facing feature                           |
+| `fix:`      | Bug fix                                           |
+| `chore:`    | Tooling, deps, config — no production code change |
+| `docs:`     | Documentation only                                |
+| `refactor:` | Code restructure with no behavior change          |
+| `perf:`     | Performance improvement                           |
+| `style:`    | Formatting, whitespace, CSS-only                  |
 
 **Merge policy:** Squash merge only. One PR = one commit on `main`.
 
@@ -77,26 +78,29 @@ Branches are deleted after merge. The squash commit message is derived from the 
 
 ## Writing Style (All User-Facing Copy)
 
-These rules apply to every string rendered in the browser: marketing pages, manifesto, privacy policy, roadmap, blog posts, modal text, feature descriptions, and any future content.
+Copy must read like a person wrote it. When in doubt, read it aloud. If it sounds like a press release, rewrite it.
 
-- **No em dashes (—) or en dashes (–).** Rewrite the sentence. Use a comma, semicolon, colon, or parentheses instead. Em dashes are a reliable signal that copy was auto-generated.
-- **No double-hyphen constructions (`--`).** Use a comma or rewrite.
-- **No curly/smart quotes in source code.** Use straight quotes (`"`, `'`) in TSX string literals. The browser handles typographic rendering.
-- **No overused AI constructions:** avoid "not just X but Y", "delve into", "it's worth noting", "in today's world", "leverage" (as a verb), and list items that all start with adverbs ("Furthermore,", "Moreover,", "Additionally,").
-- **Parentheses for asides**, colons for introductions, commas or semicolons for clauses. Plain punctuation reads like a person wrote it.
-- **Short sentences beat compound-complex ones.** If you need an em dash to hold a sentence together, the sentence is too long.
-- **Blockquote attributions** use "From ..." prose, not a leading dash.
+- **No em dashes (—) or en dashes (–).** Standard hyphens and normal punctuation only. Em dashes are a near-universal AI tell.
+- **No AI filler phrases:** "not just X but Y", "delve into", "it's worth noting", "leverage" (verb), "in today's world", "Furthermore,", "Moreover,", "Additionally,", "at the end of the day", "game-changer", "seamlessly".
+- **No throat-clearing.** Cut the first sentence of any paragraph that just announces what the paragraph is about.
+- **Short sentences.** If a sentence needs an em dash to hold together, split it in two.
+- **Concrete over abstract.** "Stores posts on your hard drive" beats "enables local-first data persistence".
+- **Contractions are fine.** "We don't" reads warmer than "We do not". Use them.
 
 ## Automerge
 
 **Schema** (`packages/shared/src/schema.ts`): backward-compatible only. Add optional fields; never delete (mark `@deprecated`).
 
 **Mutations** must use `A.change()` — direct mutation silently fails to sync:
+
 ```ts
-A.change(doc, d => { d.items.push(item) }) // ✅
-doc.items.push(item)                        // ❌ silent failure
+A.change(doc, (d) => {
+  d.items.push(item);
+}); // ✅
+doc.items.push(item); // ❌ silent failure
 ```
 
 **Proxy constraints inside `A.change()`:**
+
 - Never assign `undefined` — use `delete` instead
 - Never replace an existing nested object — assign fields individually or use a `deepMergeInto` helper

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,18 @@ Branches are deleted after merge. The squash commit message is derived from the 
 
 ---
 
+## Writing Style (All User-Facing Copy)
+
+These rules apply to every string rendered in the browser: marketing pages, manifesto, privacy policy, roadmap, blog posts, modal text, feature descriptions, and any future content.
+
+- **No em dashes (—) or en dashes (–).** Rewrite the sentence. Use a comma, semicolon, colon, or parentheses instead. Em dashes are a reliable signal that copy was auto-generated.
+- **No double-hyphen constructions (`--`).** Use a comma or rewrite.
+- **No curly/smart quotes in source code.** Use straight quotes (`"`, `'`) in TSX string literals. The browser handles typographic rendering.
+- **No overused AI constructions:** avoid "not just X but Y", "delve into", "it's worth noting", "in today's world", "leverage" (as a verb), and list items that all start with adverbs ("Furthermore,", "Moreover,", "Additionally,").
+- **Parentheses for asides**, colons for introductions, commas or semicolons for clauses. Plain punctuation reads like a person wrote it.
+- **Short sentences beat compound-complex ones.** If you need an em dash to hold a sentence together, the sentence is too long.
+- **Blockquote attributions** use "From ..." prose, not a leading dash.
+
 ## Automerge
 
 **Schema** (`packages/shared/src/schema.ts`): backward-compatible only. Add optional fields; never delete (mark `@deprecated`).

--- a/website/src/app/manifesto/ManifestoContent.tsx
+++ b/website/src/app/manifesto/ManifestoContent.tsx
@@ -34,8 +34,8 @@ export default function ManifestoContent() {
               <p>
                 Every time you open a social media app, you are not a customer.
                 You are the product. Your attention is being harvested, packaged,
-                and sold to the highest bidder—and the platform's entire
-                engineering budget is dedicated to maximizing the yield.
+                and sold to the highest bidder, with the platform's entire
+                engineering budget dedicated to maximizing the yield.
               </p>
               <p>
                 These platforms didn't accidentally become addictive. They
@@ -66,7 +66,7 @@ export default function ManifestoContent() {
               <p>
                 Then the platforms learned they could grow faster by hijacking
                 the signal. They replaced chronological feeds with algorithmic
-                ones optimized for engagement—not for your benefit, but for
+                ones optimized for engagement, not for your benefit but for
                 theirs. They introduced infinite scroll. They removed the ability
                 to be "done." They made it technically impossible to simply read
                 what the people you chose to follow had written.
@@ -85,7 +85,7 @@ export default function ManifestoContent() {
               </h2>
               <p>
                 In Homer's <em>Odyssey</em>, Odysseus wanted to hear the
-                Sirens' song—the most beautiful music in the world—without being
+                Sirens' song (the most beautiful music in the world) without being
                 lured to his death on the rocks below. He couldn't trust himself
                 to resist in the moment. So he made a decision in advance: had
                 his crew bind him to the mast and fill their own ears with wax.
@@ -98,10 +98,10 @@ export default function ManifestoContent() {
                 self would make.
               </p>
               <p>
-                Freed is your mast. You configure it once—deciding which
+                Freed is your mast. You configure it once, deciding which
                 creators matter to you, how much weight to give different
                 sources, which platforms to access only through Freed's filtered
-                lens—and then you engage with the internet only through that
+                lens, and then you engage with the internet only through that
                 configuration. The algorithm that shapes your experience is one
                 you wrote yourself, in a moment of clarity, rather than one
                 written by engineers optimizing for your compulsion.
@@ -121,8 +121,8 @@ export default function ManifestoContent() {
                   servers. We collect no telemetry. We never see your content,
                   your follows, or your reading habits. When you sync between
                   your devices, the data travels through cloud storage you
-                  already own—your Google Drive, your iCloud, your Dropbox—
-                  without ever touching our infrastructure.
+                  already own: your Google Drive, your iCloud, your Dropbox.
+                  None of it ever touches our infrastructure.
                 </li>
                 <li>
                   <strong className="text-text-primary block mb-1">
@@ -131,7 +131,7 @@ export default function ManifestoContent() {
                   Freed's ranking algorithm is open source. You can read exactly
                   how it decides what to show you first. You can edit the weights
                   yourself. You can fork it and build your own. This is not a
-                  feature—it is a requirement for any tool that shapes your
+                  feature; it is a requirement for any tool that shapes your
                   information diet.
                 </li>
                 <li>
@@ -149,8 +149,8 @@ export default function ManifestoContent() {
                     Attention is finite and precious.
                   </strong>
                   The platforms have forgotten this. We have not. Freed is
-                  designed to help you finish your feed—to know when you've
-                  read the things that matter and have permission to stop.
+                  designed to help you finish your feed. You know when you've
+                  read what matters and you have permission to stop.
                 </li>
                 <li>
                   <strong className="text-text-primary block mb-1">
@@ -172,8 +172,8 @@ export default function ManifestoContent() {
               </p>
               <p>
                 A Freed user sees a clean timeline of posts from people they
-                genuinely care about—writers, friends, researchers, journalists—
-                ranked by criteria they defined: author authority, topic
+                genuinely care about: writers, friends, researchers, journalists.
+                Posts are ranked by criteria they defined: author authority, topic
                 relevance, freshness. They read through it until they're done.
                 Then they close the app. There is no infinite scroll. There is
                 no algorithmic outrage-injection. There is no dark pattern
@@ -197,7 +197,7 @@ export default function ManifestoContent() {
                 "The algorithm that serves you best is the one you wrote
                 yourself."
                 <footer className="text-text-secondary text-base mt-2 not-italic">
-                  — The Freed Manifesto
+                  From the Freed Manifesto
                 </footer>
               </blockquote>
             </section>
@@ -209,8 +209,8 @@ export default function ManifestoContent() {
                 feedback, and your critique.
               </p>
               <p>
-                And if this resonates with you—if you've been waiting for
-                someone to build this—subscribe below. We'll let you know when
+                And if this resonates with you, if you've been waiting for
+                someone to build this, subscribe below. We'll let you know when
                 it's ready to install.
               </p>
             </section>

--- a/website/src/app/manifesto/ManifestoContent.tsx
+++ b/website/src/app/manifesto/ManifestoContent.tsx
@@ -28,191 +28,116 @@ export default function ManifestoContent() {
           {/* Content */}
           <div className="space-y-10 text-text-secondary">
             <section>
-              <h2 className="text-2xl font-bold text-text-primary mb-4">
-                The Extraction
-              </h2>
-              <p>
-                Every time you open a social media app, you are not a customer.
-                You are the product. Your attention is being harvested, packaged,
-                and sold to the highest bidder, with the platform's entire
-                engineering budget dedicated to maximizing the yield.
-              </p>
-              <p>
-                These platforms didn't accidentally become addictive. They
-                employed thousands of engineers, behavioral psychologists, and
-                machine learning researchers specifically to exploit the gaps in
-                human cognition. They discovered that outrage travels six times
-                faster than measured reflection. That variable reward schedules
-                create compulsive checking behaviors. That social comparison
-                triggers anxiety that sends you back to the feed looking for
-                relief.
-              </p>
-              <p>
-                They race to the bottom of the brainstem. Your rational mind
-                never gets a vote.
-              </p>
+              <h2 className="text-2xl font-bold text-text-primary mb-4">The Problem</h2>
+              <p>Every time you open your feed, a machine decides what you see. Not to serve you. To keep you in the system. The design is deliberate. Outrage travels faster than nuance. Anxiety keeps you scrolling. The machine is working perfectly. It's just not working for you.</p>
             </section>
 
             <section>
-              <h2 className="text-2xl font-bold text-text-primary mb-4">
-                What We Lost
-              </h2>
-              <p>
-                It wasn't always like this. RSS readers existed. Chronological
-                feeds existed. The early web was about publishing what you made
-                and reading what others made, without a middleman deciding what
-                you deserved to see.
-              </p>
-              <p>
-                Then the platforms learned they could grow faster by hijacking
-                the signal. They replaced chronological feeds with algorithmic
-                ones optimized for engagement, not for your benefit but for
-                theirs. They introduced infinite scroll. They removed the ability
-                to be "done." They made it technically impossible to simply read
-                what the people you chose to follow had written.
-              </p>
-              <p>
-                The cost has been enormous: the erosion of genuine discourse,
-                the polarization of communities, the commodification of
-                friendship, and billions of hours of human attention redirected
-                from everything that matters toward a compulsive, joyless scroll.
-              </p>
+              <h2 className="text-2xl font-bold text-text-primary mb-4">The Pact</h2>
+              <p>Odysseus wanted to hear the Sirens without dying. He couldn't trust himself in the moment, so he had his crew lash him to the mast before the ship got close. He heard the song. He survived. He got what he wanted by choosing his constraints <em>before</em> the temptation arrived. Configure Freed once, in a moment of clarity: which creators matter, how much weight each source gets, which platforms you'll only access through a filtered lens. Your algorithm. Not one engineered to exploit you.</p>
             </section>
 
             <section>
-              <h2 className="text-2xl font-bold text-text-primary mb-4">
-                The Ulysses Pact
-              </h2>
-              <p>
-                In Homer's <em>Odyssey</em>, Odysseus wanted to hear the
-                Sirens' song (the most beautiful music in the world) without being
-                lured to his death on the rocks below. He couldn't trust himself
-                to resist in the moment. So he made a decision in advance: had
-                his crew bind him to the mast and fill their own ears with wax.
-                He heard the Sirens. He survived. He got what he wanted by
-                choosing his constraints <em>before</em> the temptation arrived.
-              </p>
-              <p>
-                This is a Ulysses Pact: a commitment made in advance, by your
-                deliberate self, to protect you from the choices your impulsive
-                self would make.
-              </p>
-              <p>
-                Freed is your mast. You configure it once, deciding which
-                creators matter to you, how much weight to give different
-                sources, which platforms to access only through Freed's filtered
-                lens, and then you engage with the internet only through that
-                configuration. The algorithm that shapes your experience is one
-                you wrote yourself, in a moment of clarity, rather than one
-                written by engineers optimizing for your compulsion.
-              </p>
+              <h2 className="text-2xl font-bold text-text-primary mb-4">What You Can Reclaim</h2>
+              <p>You followed people. They shared ideas, learnings, things they loved. You checked in, then got on with your day. That model still works. Let's bring it back.</p>
             </section>
 
             <section>
-              <h2 className="text-2xl font-bold text-text-primary mb-4">
-                What We Believe
-              </h2>
-              <ul className="space-y-6">
+              <h2 className="text-2xl font-bold text-text-primary mb-4">What We Believe</h2>
+              <ul className="space-y-5">
                 <li>
-                  <strong className="text-text-primary block mb-1">
-                    Your data belongs to you.
-                  </strong>
-                  Freed stores everything locally on your device. We have no
-                  servers. We collect no telemetry. We never see your content,
-                  your follows, or your reading habits. When you sync between
-                  your devices, the data travels through cloud storage you
-                  already own: your Google Drive, your iCloud, your Dropbox.
-                  None of it ever touches our infrastructure.
+                  <strong className="text-text-primary block mb-1">Your data belongs to you.</strong>
+                  Everything lives on your device. No servers. No telemetry. We never see your content, your follows, or your habits.
                 </li>
                 <li>
-                  <strong className="text-text-primary block mb-1">
-                    Algorithms should be transparent and editable.
-                  </strong>
-                  Freed's ranking algorithm is open source. You can read exactly
-                  how it decides what to show you first. You can edit the weights
-                  yourself. You can fork it and build your own. This is not a
-                  feature; it is a requirement for any tool that shapes your
-                  information diet.
+                  <strong className="text-text-primary block mb-1">You deserve to see the algorithm.</strong>
+                  Freed's ranking is open source. You can read exactly why a post appears first. You can change the weights. You can fork the whole thing.
                 </li>
                 <li>
-                  <strong className="text-text-primary block mb-1">
-                    Chronological is not naïve.
-                  </strong>
-                  Choosing to see content in the order it was published is a
-                  legitimate preference, not a failure of curation. The people
-                  you follow made decisions about what to share and when. You
-                  should have the option to respect those decisions without a
-                  platform overriding them.
+                  <strong className="text-text-primary block mb-1">Chronological is not naïve.</strong>
+                  Reading things in the order they were written is a choice, not a failure of curation.
                 </li>
                 <li>
-                  <strong className="text-text-primary block mb-1">
-                    Attention is finite and precious.
-                  </strong>
-                  The platforms have forgotten this. We have not. Freed is
-                  designed to help you finish your feed. You know when you've
-                  read what matters and you have permission to stop.
+                  <strong className="text-text-primary block mb-1">You have the right to be done.</strong>
+                  Freed lets you finish your feed. When you're done, you're done. No machine will try to stop you.
                 </li>
                 <li>
-                  <strong className="text-text-primary block mb-1">
-                    Liberation tools should belong to everyone.
-                  </strong>
-                  Freed is MIT licensed. Fork it, audit it, distribute it,
-                  improve it. Build the future you want to live in.
+                  <strong className="text-text-primary block mb-1">This belongs to everyone.</strong>
+                  MIT licensed. Fork it. Audit it. Build on it.
                 </li>
               </ul>
             </section>
 
             <section>
-              <h2 className="text-2xl font-bold text-text-primary mb-4">
-                The Vision
-              </h2>
-              <p>
-                We're not asking you to quit social media. We're asking you to
-                engage with it on your terms.
-              </p>
-              <p>
-                A Freed user sees a clean timeline of posts from people they
-                genuinely care about: writers, friends, researchers, journalists.
-                Posts are ranked by criteria they defined: author authority, topic
-                relevance, freshness. They read through it until they're done.
-                Then they close the app. There is no infinite scroll. There is
-                no algorithmic outrage-injection. There is no dark pattern
-                designed to prevent them from leaving.
-              </p>
-              <p>
-                They know when they've caught up. They can mark something as
-                read, archive a conversation, save an article for later. They can
-                enable Ulysses Mode and block themselves from accessing the raw
-                platform until morning. They sync their reading state across
-                their laptop and phone without any of it touching our servers.
-              </p>
-              <p>
-                That's the whole vision. It's not revolutionary. It's just what
-                the internet was supposed to be.
-              </p>
+              <p>We're building a world where you stay in the driver's seat. Your feed, your algorithm, your rules. The code is public. The roadmap is public. Resonate? Subscribe below.</p>
             </section>
 
-            <section className="pt-8 border-t border-freed-border">
-              <blockquote className="text-xl italic text-text-primary border-l-4 border-glow-purple pl-6">
-                "The algorithm that serves you best is the one you wrote
-                yourself."
-                <footer className="text-text-secondary text-base mt-2 not-italic">
-                  From the Freed Manifesto
-                </footer>
-              </blockquote>
+            <section className="not-prose text-center py-14">
+              <motion.button
+                whileHover={{ scale: 1.05 }}
+                whileTap={{ scale: 0.95 }}
+                onClick={openModal}
+                className="btn-primary text-base px-8 py-3"
+              >
+                Free My Feed
+              </motion.button>
             </section>
 
             <section>
-              <p>
-                We're building this in the open. The roadmap is public. The code
-                is public. The process is public. We'd love your help, your
-                feedback, and your critique.
-              </p>
-              <p>
-                And if this resonates with you, if you've been waiting for
-                someone to build this, subscribe below. We'll let you know when
-                it's ready to install.
-              </p>
+              <h2 className="text-2xl font-bold text-text-primary mb-6">Go Deeper</h2>
+              <div className="space-y-3 not-prose">
+                {[
+                  {
+                    href: "https://www.youtube.com/watch?v=Ma4VZ7rxGOw",
+                    title: "The Slow Poison of Endless Fantasy",
+                    source: "After Skool",
+                    description: "On escapism, variable reward loops, and what the attention economy is slowly doing to your capacity for sustained thought.",
+                  },
+                  {
+                    href: "https://www.youtube.com/watch?v=v1eW62X5fiE",
+                    title: "What if we had fixed social media? An alternative history",
+                    source: "Center for Humane Technology",
+                    description: "What if we'd optimized for people instead of engagement? This is that internet.",
+                  },
+                  {
+                    href: "https://www.youtube.com/watch?v=0v5RiMdSqwk&t=2109s",
+                    title: "War on Sensemaking V",
+                    source: "Daniel Schmachtenberger, Rebel Wisdom",
+                    description: "How algorithmic feeds degrade our collective ability to reason about reality. The linked timestamp drops you into the key section.",
+                  },
+                  {
+                    href: "https://www.youtube.com/watch?v=C74amJRp730",
+                    title: "How a handful of tech companies control billions of minds",
+                    source: "Tristan Harris, TED",
+                    description: "The 17-minute version of everything in this manifesto's first two sections, by the person who spent years inside Google trying to fix it.",
+                  },
+                  {
+                    href: "https://www.eff.org/cyberspace-independence",
+                    title: "A Declaration of the Independence of Cyberspace",
+                    source: "John Perry Barlow, 1996",
+                    description: "The original. Written the day the U.S. government first tried to regulate the internet. This manifesto was written in its spirit.",
+                  },
+                ].map((item) => (
+                  <a
+                    key={item.href}
+                    href={item.href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="group flex flex-col gap-1 p-4 rounded-xl border border-freed-border hover:border-glow-purple/50 bg-freed-surface/30 hover:bg-freed-surface/60 transition-all duration-200"
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <span className="text-sm font-semibold text-text-primary group-hover:text-white transition-colors leading-snug">
+                        {item.title}
+                      </span>
+                      <svg className="w-3.5 h-3.5 text-text-muted group-hover:text-text-secondary transition-colors shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                      </svg>
+                    </div>
+                    <span className="text-xs text-text-muted">{item.source}</span>
+                    <p className="text-xs text-text-secondary mt-1 leading-relaxed">{item.description}</p>
+                  </a>
+                ))}
+              </div>
             </section>
           </div>
 
@@ -221,7 +146,7 @@ export default function ManifestoContent() {
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ delay: 0.4 }}
-            className="mt-16 text-center"
+            className="pt-24 pb-8 text-center"
           >
             <motion.button
               whileHover={{ scale: 1.05 }}
@@ -229,7 +154,7 @@ export default function ManifestoContent() {
               onClick={openModal}
               className="btn-primary text-base px-8 py-3"
             >
-              Get Freed
+              Join the Movement
             </motion.button>
           </motion.div>
         </motion.article>

--- a/website/src/app/privacy/PrivacyContent.tsx
+++ b/website/src/app/privacy/PrivacyContent.tsx
@@ -50,7 +50,7 @@ export default function PrivacyContent() {
               </h2>
               <p>
                 This marketing site is a static Next.js application hosted on
-                Vercel.                 Like any web host, Vercel's infrastructure logs standard
+                Vercel. Like any web host, Vercel's infrastructure logs standard
                 HTTP request metadata (your IP address, browser user-agent,
                 timestamp, and the URL requested) as part of their CDN
                 operation. This data is governed by{" "}
@@ -116,7 +116,7 @@ export default function PrivacyContent() {
                     Your credentials never leave your device.
                   </strong>
                   Freed accesses social platforms through your own authenticated
-                  browser sessions.                   Credentials are stored in your local
+                  browser sessions. Credentials are stored in your local
                   keychain or browser storage and never transmitted to us.
                 </li>
               </ul>
@@ -173,7 +173,7 @@ export default function PrivacyContent() {
                 Freed captures content from third-party platforms (X, YouTube,
                 RSS feeds, etc.) on your behalf, using your own authenticated
                 session. By doing so, you remain subject to those platforms'
-                terms of service and privacy policies.                 Freed does not aggregate
+                terms of service and privacy policies. Freed does not aggregate
                 or transmit that content anywhere. It stays local. The
                 act of accessing it is governed by each platform's relationship
                 with you, not with us.
@@ -187,7 +187,7 @@ export default function PrivacyContent() {
               </h2>
               <p>
                 Freed is not directed at children under 13. We do not knowingly
-                collect any personal information from children.                 Given our
+                collect any personal information from children. Given our
                 local-first architecture, we are not positioned to collect
                 anyone's personal information, but we state this explicitly for
                 compliance clarity.
@@ -236,8 +236,8 @@ export default function PrivacyContent() {
                   className="text-text-primary underline hover:no-underline transition-colors"
                 >
                   GitHub
-                </a>
-                .                 We'd rather have a public conversation about our privacy
+                </a                >
+                . We'd rather have a public conversation about our privacy
                 posture than a private one; transparency is kind of the whole
                 point.
               </p>
@@ -248,7 +248,7 @@ export default function PrivacyContent() {
               <blockquote className="text-xl italic text-text-primary border-l-4 border-glow-purple pl-6">
                 "Your data belongs to you."
                 <footer className="text-text-secondary text-base mt-2 not-italic">
-                  From the Freed Manifesto
+                  - The Freed Manifesto
                 </footer>
               </blockquote>
             </section>

--- a/website/src/app/privacy/PrivacyContent.tsx
+++ b/website/src/app/privacy/PrivacyContent.tsx
@@ -50,9 +50,9 @@ export default function PrivacyContent() {
               </h2>
               <p>
                 This marketing site is a static Next.js application hosted on
-                Vercel. Like any web host, Vercel's infrastructure logs standard
-                HTTP request metadata — your IP address, browser user-agent,
-                timestamp, and the URL requested — as part of their CDN
+                Vercel.                 Like any web host, Vercel's infrastructure logs standard
+                HTTP request metadata (your IP address, browser user-agent,
+                timestamp, and the URL requested) as part of their CDN
                 operation. This data is governed by{" "}
                 <a
                   href="https://vercel.com/legal/privacy-policy"
@@ -90,7 +90,7 @@ export default function PrivacyContent() {
                     Your feed data stays on your device.
                   </strong>
                   Posts captured from X, RSS, YouTube, or any other source are
-                  written to local storage — IndexedDB in the browser, the
+                  written to local storage: IndexedDB in the browser, the
                   filesystem in the desktop app. None of this ever touches our
                   infrastructure, because we have no infrastructure to touch.
                 </li>
@@ -116,8 +116,8 @@ export default function PrivacyContent() {
                     Your credentials never leave your device.
                   </strong>
                   Freed accesses social platforms through your own authenticated
-                  browser sessions. Credentials are stored in your local
-                  keychain or browser storage — never transmitted to us.
+                  browser sessions.                   Credentials are stored in your local
+                  keychain or browser storage and never transmitted to us.
                 </li>
               </ul>
             </section>
@@ -125,11 +125,11 @@ export default function PrivacyContent() {
             {/* 3. Sync */}
             <section>
               <h2 className="text-2xl font-bold text-text-primary mb-4">
-                Data Sync — Your Cloud, Your Keys
+                Data Sync: Your Cloud, Your Keys
               </h2>
               <p>
                 If you enable cross-device sync, your Freed data is backed up
-                to cloud storage <em>you already own</em> — Google Drive,
+                to cloud storage <em>you already own</em>: Google Drive,
                 iCloud, or Dropbox. The data is encrypted with a passphrase
                 only you know before it ever leaves your device. We cannot read
                 it. We cannot be compelled to hand it over, because we do not
@@ -173,8 +173,8 @@ export default function PrivacyContent() {
                 Freed captures content from third-party platforms (X, YouTube,
                 RSS feeds, etc.) on your behalf, using your own authenticated
                 session. By doing so, you remain subject to those platforms'
-                terms of service and privacy policies. Freed does not aggregate
-                or transmit that content anywhere — it stays local — but the
+                terms of service and privacy policies.                 Freed does not aggregate
+                or transmit that content anywhere. It stays local. The
                 act of accessing it is governed by each platform's relationship
                 with you, not with us.
               </p>
@@ -187,9 +187,9 @@ export default function PrivacyContent() {
               </h2>
               <p>
                 Freed is not directed at children under 13. We do not knowingly
-                collect any personal information from children. Given our
+                collect any personal information from children.                 Given our
                 local-first architecture, we are not positioned to collect
-                anyone's personal information — but we state this explicitly for
+                anyone's personal information, but we state this explicitly for
                 compliance clarity.
               </p>
             </section>
@@ -200,8 +200,8 @@ export default function PrivacyContent() {
                 Changes to This Policy
               </h2>
               <p>
-                If we ever change anything material here — which would require
-                us to build infrastructure we currently don't have — we'll
+                If we ever change anything material here (which would require
+                us to build infrastructure we currently don't have), we'll
                 update the effective date at the top and post a note in the{" "}
                 <Link
                   href="/updates"
@@ -237,8 +237,8 @@ export default function PrivacyContent() {
                 >
                   GitHub
                 </a>
-                . We'd rather have a public conversation about our privacy
-                posture than a private one — transparency is kind of the whole
+                .                 We'd rather have a public conversation about our privacy
+                posture than a private one; transparency is kind of the whole
                 point.
               </p>
             </section>
@@ -248,7 +248,7 @@ export default function PrivacyContent() {
               <blockquote className="text-xl italic text-text-primary border-l-4 border-glow-purple pl-6">
                 "Your data belongs to you."
                 <footer className="text-text-secondary text-base mt-2 not-italic">
-                  — The Freed Manifesto
+                  From the Freed Manifesto
                 </footer>
               </blockquote>
             </section>

--- a/website/src/app/roadmap/RoadmapContent.tsx
+++ b/website/src/app/roadmap/RoadmapContent.tsx
@@ -434,7 +434,7 @@ function ArchitectureDiagram() {
           fontStyle="italic"
           className="hidden sm:inline"
         >
-          Desktop is the hub — runs capture, hosts sync, powers everything
+          Desktop is the hub: runs capture, hosts sync, powers everything
         </text>
       </svg>
     </div>
@@ -689,7 +689,7 @@ export default function RoadmapContent() {
           {/*  We build in daylight.*/}
           {/*</p>*/}
           <p className="text-text-muted text-sm sm:text-base">
-            Every commit, every decision, every pivot — visible.
+            Every commit, every decision, every pivot. All visible.
           </p>
         </motion.header>
 

--- a/website/src/components/Features.tsx
+++ b/website/src/components/Features.tsx
@@ -176,7 +176,7 @@ const features = [
     icon: <UnifiedFeedIcon />,
     title: "Unified Feed",
     description:
-      "One feed to rule them all. X, Facebook, Instagram—combined and weighted by what matters to you.",
+      "One feed to rule them all. X, Facebook, Instagram, combined and weighted by what matters to you.",
   },
   {
     icon: <FriendMapIcon />,
@@ -194,7 +194,7 @@ const features = [
     icon: <SyncIcon />,
     title: "Cross-Device Sync",
     description:
-      "CRDT-powered sync across all your devices. No cloud required—peer-to-peer when you want it.",
+      "CRDT-powered sync across all your devices. No cloud required. Peer-to-peer when you want it.",
   },
   {
     icon: <OpenSourceIcon />,

--- a/website/src/components/Navigation.tsx
+++ b/website/src/components/Navigation.tsx
@@ -66,6 +66,10 @@ export default function Navigation() {
   // Update underline position when pathname changes
   useLayoutEffect(() => {
     const activeIndex = NAV_ITEMS.findIndex((item) => item.path === pathname);
+    if (activeIndex === -1) {
+      setUnderlineStyle({ left: 0, width: 0 });
+      return;
+    }
     const activeRef = navRefs.current[activeIndex];
     if (activeRef) {
       const parent = activeRef.parentElement;

--- a/website/src/components/NewsletterModal.tsx
+++ b/website/src/components/NewsletterModal.tsx
@@ -228,7 +228,7 @@ export default function NewsletterModal() {
                     {/* Early-build disclaimer */}
                     <div className="mb-6 px-4 py-3 rounded-xl border border-amber-500/30 bg-amber-500/5">
                       <p className="text-center text-xs sm:text-sm font-bold text-amber-400/90">
-                        ⚠️ Very early build — nothing works yet!
+                        ⚠️ Very early build. Nothing works yet!
                       </p>
                       <p className="text-center text-xs text-amber-400/60 mt-1">
                         Active development in progress. Expect a functional
@@ -263,7 +263,7 @@ export default function NewsletterModal() {
                           Open Web App
                         </p>
                         <p className="text-xs text-text-muted">
-                          Read your feeds anywhere — great on mobile
+                          Read your feeds anywhere, great on mobile
                         </p>
                       </div>
                       <svg

--- a/website/src/content/posts/001-introducing-freed.tsx
+++ b/website/src/content/posts/001-introducing-freed.tsx
@@ -13,8 +13,8 @@ export default definePost(
   <>
     <p>
       Welcome to the first Freed newsletter. If you're reading this, you've
-      either subscribed to our email list or discovered us through RSS—which,
-      by the way, is exactly the kind of choice we think you should always have.
+      either subscribed to our email list or discovered us through RSS, which
+      is exactly the kind of choice we think you should always have.
     </p>
 
     <p>
@@ -25,16 +25,16 @@ export default definePost(
     <h2>The Scroll That Doesn't End</h2>
     <p>
       Somewhere in the last decade, social media stopped being a place where you
-      read things and became a place where things happened to you. The
-      chronological feed—the simple idea that you see what the people you follow
-      published, in the order they published it—was quietly killed at every major
+      read things and became a place where things happened to you.       The
+      chronological feed (the simple idea that you see what the people you follow
+      published, in the order they published it) was quietly killed at every major
       platform.
     </p>
     <p>
       What replaced it was algorithmic curation optimized for one thing:
       engagement. Not your satisfaction. Not your education. Not your
-      connection to the people you care about. Engagement—clicks, shares,
-      reactions, time-on-screen—because those are what platforms sell to
+      connection to the people you care about. Engagement: clicks, shares,
+      reactions, time-on-screen. That is what platforms sell to
       advertisers.
     </p>
     <p>
@@ -42,8 +42,8 @@ export default definePost(
       engaging. Nuance gets suppressed because it's slow. The most compelling
       lies travel faster than measured truth, and the algorithm can't tell the
       difference and doesn't try. Infinite scroll removes the natural stopping
-      point. Variable reward schedules—the same mechanism that makes slot
-      machines addictive—keep you pulling down to refresh.
+      point. Variable reward schedules (the same mechanism that makes slot
+      machines addictive) keep you pulling down to refresh.
     </p>
     <p>
       None of this is accidental. It is the product of billions of dollars in
@@ -54,8 +54,8 @@ export default definePost(
     <h2>What Freed Does Differently</h2>
     <p>
       Freed is a local-first feed reader. It captures content from your social
-      sources—X (formerly Twitter), RSS feeds, YouTube channels, newsletters,
-      podcasts—and presents them in a unified, chronological timeline on your
+      sources: X (formerly Twitter), RSS feeds, YouTube channels, newsletters,
+      and podcasts. It presents them in a unified, chronological timeline on your
       device. You decide the ranking. You control the weights. The algorithm is
       yours.
     </p>
@@ -64,7 +64,7 @@ export default definePost(
       <li>
         <strong>No central servers.</strong> Your captured content lives on your
         device, synced between your own devices (laptop, phone) via your own
-        cloud storage—Google Drive, iCloud, or Dropbox. We never touch it.
+        cloud storage: Google Drive, iCloud, or Dropbox. We never touch it.
       </li>
       <li>
         <strong>No engagement optimization.</strong> Posts are ranked by
@@ -112,7 +112,7 @@ export default definePost(
         <strong>Shared library (@freed/shared)</strong>: The common types and
         Automerge CRDT schema that both apps use. The CRDT (Conflict-free
         Replicated Data Type) handles merging changes from multiple devices
-        automatically—no sync conflicts, no data loss.
+        automatically, with no sync conflicts and no data loss.
       </li>
       <li>
         <strong>Capture packages</strong>: Separate, composable packages for

--- a/website/src/content/posts/001-introducing-freed.tsx
+++ b/website/src/content/posts/001-introducing-freed.tsx
@@ -19,13 +19,12 @@ export default definePost(
 
     <p>
       We want to tell you why we built this, how it works, and what we believe.
-      Let's start with the problem we're trying to solve.
     </p>
 
     <h2>The Scroll That Doesn't End</h2>
     <p>
       Somewhere in the last decade, social media stopped being a place where you
-      read things and became a place where things happened to you.       The
+      read things and became a place where things happened to you. The
       chronological feed (the simple idea that you see what the people you follow
       published, in the order they published it) was quietly killed at every major
       platform.
@@ -93,7 +92,7 @@ export default definePost(
 
     <h2>How It's Built</h2>
     <p>
-      Freed is a monorepo with several packages that work together:
+      Freed is a monorepo with four main packages:
     </p>
     <ul>
       <li>

--- a/website/src/content/posts/001-introducing-freed.tsx
+++ b/website/src/content/posts/001-introducing-freed.tsx
@@ -168,8 +168,11 @@ export default definePost(
     </p>
     <ul>
       <li>
-        <strong>Star the repo.</strong> It helps us understand how many people
-        care about this, and it helps others discover the project.
+        <strong>
+          <a href="https://github.com/freed-project/freed">Star the repo.</a>
+        </strong>{" "}
+        It helps us understand how many people care about this, and it helps
+        others discover the project.
       </li>
       <li>
         <strong>Try the PWA.</strong> Go to{" "}


### PR DESCRIPTION
(AI Generated)

## Summary

- Rewrote manifesto for punch and empowerment: tighter prose, "we" framing throughout, sections consolidated to single paragraphs, removed self-referential blockquote
- Added "Go Deeper" clickable resource cards (five external links) and two CTAs ("Free My Feed" / "Join the Movement") with breathing room
- Eliminated all em dashes across every piece of user-facing copy (manifesto, privacy policy, blog post, features, roadmap, newsletter modal)
- Removed AI filler phrases and throat-clearing from the blog post intro
- Added `Writing Style` section to `AGENTS.md` to prevent recurrence
- Fixed nav underline persisting on non-nav pages (e.g. /privacy)
- Linked "Star the repo" in the first newsletter post to the GitHub repo

## Test plan

- [ ] Verify manifesto sections read as single paragraphs with no mid-paragraph line breaks
- [ ] Confirm "Go Deeper" cards are clickable and open in new tabs
- [ ] Check both CTAs appear with correct captions and spacing
- [ ] Navigate to /privacy and confirm no nav item shows as active
- [ ] Confirm no em dashes remain in any rendered page
- [ ] Verify "Star the repo" link in the first post resolves to github.com/freed-project/freed