### PR TITLE
feat: tighten introducing-freed post, cut technical architecture section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,15 +1,15 @@
 # Contributing to Freed
 
-First off, thank you for considering contributing to Freed. It's people like you who will help make mental sovereignty a reality for millions.
+The platforms that hijacked your feed spent billions of dollars on it. This is the counter-move. It's built in public, by whoever shows up. If that's you, here's how to get started.
 
 ## Philosophy
 
-Freed exists to restore human autonomy in the attention economy. Every contribution should further this mission. We value:
+Every contribution should make Freed more useful, more transparent, or more trustworthy. The guiding principles:
 
-- **Privacy above all** — Never introduce telemetry or data collection
-- **Transparency** — Code should be readable and well-documented
-- **User empowerment** — Features should give users more control, not less
-- **Simplicity** — Prefer simple solutions over clever ones
+- **Privacy, always.** Never introduce telemetry or data collection.
+- **Transparency.** Code should be readable. Complexity should be justified.
+- **User control.** Features should give users more power, not less.
+- **Simplicity.** Prefer the obvious solution over the clever one.
 
 ## Ways to Contribute
 
@@ -165,4 +165,4 @@ Before adding a new platform:
 
 ---
 
-_Thank you for helping build a freer internet._
+_The platforms become players in your game. Thanks for helping build the board._

--- a/package-lock.json
+++ b/package-lock.json
@@ -14462,7 +14462,7 @@
     },
     "packages/desktop": {
       "name": "@freed/desktop",
-      "version": "26.3.302",
+      "version": "26.3.303",
       "dependencies": {
         "@freed/capture-rss": "*",
         "@freed/capture-x": "*",
@@ -14497,7 +14497,7 @@
     },
     "packages/pwa": {
       "name": "@freed/pwa",
-      "version": "26.3.302",
+      "version": "26.3.303",
       "dependencies": {
         "@automerge/automerge": "^2.2.8",
         "@freed/shared": "*",

--- a/website/src/app/manifesto/ManifestoContent.tsx
+++ b/website/src/app/manifesto/ManifestoContent.tsx
@@ -92,7 +92,9 @@ export default function ManifestoContent() {
                     This belongs to everyone
                   </strong>
                   The code is public. The roadmap is public. Fork it. Audit it.
-                  Share it. Resonate? Join the movement.
+                  Share it.
+                  <br />
+                  Resonate? Join the movement.
                 </li>
               </ul>
             </section>
@@ -127,7 +129,7 @@ export default function ManifestoContent() {
                       "What if we had fixed social media? An alternative history",
                     source: "Center for Humane Technology",
                     description:
-                      "What if we'd optimized for people instead of engagement? That internet is possible.",
+                      "What if we'd optimized for human flourishing instead of engagement?",
                   },
                   {
                     href: "https://www.youtube.com/watch?v=0v5RiMdSqwk&t=2109s",

--- a/website/src/app/manifesto/ManifestoContent.tsx
+++ b/website/src/app/manifesto/ManifestoContent.tsx
@@ -144,7 +144,7 @@ export default function ManifestoContent() {
                       "How a handful of tech companies control billions of minds",
                     source: "Tristan Harris, TED",
                     description:
-                      "The 17-minute version of everything in this manifesto's first two sections, by the person who spent years inside Google trying to fix it.",
+                      "The attention economy, explained by the person who tried hardest to redeem it.",
                   },
                   {
                     href: "https://www.eff.org/cyberspace-independence",

--- a/website/src/app/manifesto/ManifestoContent.tsx
+++ b/website/src/app/manifesto/ManifestoContent.tsx
@@ -48,9 +48,7 @@ export default function ManifestoContent() {
                 Odysseus wanted to hear the Sirens without dying. He couldn't
                 trust himself in the moment, so he had his crew lash him to the
                 mast before the ship got close. He heard the song. He survived.
-                Do it once, in a moment of clarity: tell Freed which creators
-                matter, how much you trust each source. Your algorithm. Not one
-                engineered to exploit you.
+                Install Freed in a moment of clarity. Choose which creators matter. Set how much you trust each one. Then step away. Those choices run in your place. Your attention, yours again. Your algorithm. Not one engineered to exploit you.
               </p>
             </section>
 

--- a/website/src/app/manifesto/ManifestoContent.tsx
+++ b/website/src/app/manifesto/ManifestoContent.tsx
@@ -39,7 +39,7 @@ export default function ManifestoContent() {
 
             <section>
               <h2 className="text-2xl font-bold text-text-primary mb-4">What You Can Reclaim</h2>
-              <p>You followed people. They shared ideas, learnings, things they loved. You checked in, then got on with your day. That model still works. Let's bring it back.</p>
+              <p>It wasn't always this way. You followed people. They shared ideas, learnings, things they loved. You checked in, then got on with your day. That model still works. Let's bring it back.</p>
             </section>
 
             <section>

--- a/website/src/app/manifesto/ManifestoContent.tsx
+++ b/website/src/app/manifesto/ManifestoContent.tsx
@@ -34,7 +34,7 @@ export default function ManifestoContent() {
 
             <section>
               <h2 className="text-2xl font-bold text-text-primary mb-4">The Pact</h2>
-              <p>Odysseus wanted to hear the Sirens without dying. He couldn't trust himself in the moment, so he had his crew lash him to the mast before the ship got close. He heard the song. He survived. He got what he wanted by choosing his constraints <em>before</em> the temptation arrived. Configure Freed once, in a moment of clarity: which creators matter, how much weight each source gets, which platforms you'll only access through a filtered lens. Your algorithm. Not one engineered to exploit you.</p>
+              <p>Odysseus wanted to hear the Sirens without dying. He couldn't trust himself in the moment, so he had his crew lash him to the mast before the ship got close. He heard the song. He survived. He got what he wanted by choosing his constraints <em>before</em> the temptation arrived. Do it once, in a moment of clarity: tell Freed which creators matter, how much you trust each source, which platforms you'll only read through Freed. Your algorithm. Not one engineered to exploit you.</p>
             </section>
 
             <section>
@@ -47,7 +47,7 @@ export default function ManifestoContent() {
               <ul className="space-y-5">
                 <li>
                   <strong className="text-text-primary block mb-1">Your attention is not a resource to be harvested.</strong>
-                  Your time, your focus, and your data belong to you. Everything lives on your device. No servers. No telemetry. We never see your content, your follows, or your habits. And when you've read what you came to read, you're done.
+                  Your time and your data stay yours. Everything you read lives on your device. We never see any of it. And when you've read what you came to read, you're done.
                 </li>
                 <li>
                   <strong className="text-text-primary block mb-1">You deserve to see the algorithm.</strong>
@@ -89,7 +89,7 @@ export default function ManifestoContent() {
                     href: "https://www.youtube.com/watch?v=v1eW62X5fiE",
                     title: "What if we had fixed social media? An alternative history",
                     source: "Center for Humane Technology",
-                    description: "What if we'd optimized for people instead of engagement? This is that internet.",
+                    description: "What if we'd optimized for people instead of engagement? That internet is possible.",
                   },
                   {
                     href: "https://www.youtube.com/watch?v=0v5RiMdSqwk&t=2109s",

--- a/website/src/app/manifesto/ManifestoContent.tsx
+++ b/website/src/app/manifesto/ManifestoContent.tsx
@@ -28,40 +28,80 @@ export default function ManifestoContent() {
           {/* Content */}
           <div className="space-y-10 text-text-secondary">
             <section>
-              <h2 className="text-2xl font-bold text-text-primary mb-4">The Problem</h2>
-              <p>Every time you open your feed, a machine decides what you see. Not to serve you. To keep you in the system. The design is deliberate. Outrage travels faster than nuance. Anxiety keeps you scrolling. The machine is working perfectly. It's just not working for you.</p>
+              <h2 className="text-2xl font-bold text-text-primary mb-4">
+                The Problem
+              </h2>
+              <p>
+                Open your feed. Something else has already decided what's waiting.
+                Not to serve you. To keep you in the system. The design is
+                deliberate. Outrage travels faster than nuance. Anxiety keeps
+                you scrolling. The machine is working perfectly. It's just not
+                working for you.
+              </p>
             </section>
 
             <section>
-              <h2 className="text-2xl font-bold text-text-primary mb-4">The Pact</h2>
-              <p>Odysseus wanted to hear the Sirens without dying. He couldn't trust himself in the moment, so he had his crew lash him to the mast before the ship got close. He heard the song. He survived. Do it once, in a moment of clarity: tell Freed which creators matter, how much you trust each source. Your algorithm. Not one engineered to exploit you.</p>
+              <h2 className="text-2xl font-bold text-text-primary mb-4">
+                The Pact
+              </h2>
+              <p>
+                Odysseus wanted to hear the Sirens without dying. He couldn't
+                trust himself in the moment, so he had his crew lash him to the
+                mast before the ship got close. He heard the song. He survived.
+                Do it once, in a moment of clarity: tell Freed which creators
+                matter, how much you trust each source. Your algorithm. Not one
+                engineered to exploit you.
+              </p>
             </section>
 
             <section>
-              <h2 className="text-2xl font-bold text-text-primary mb-4">What You Can Reclaim</h2>
-              <p>It wasn't always this way. Before extractive social media, you followed people. They shared ideas, learnings, things they loved. You checked in, then got on with your day. That model still works. Let's bring it back.</p>
+              <h2 className="text-2xl font-bold text-text-primary mb-4">
+                What You Can Reclaim
+              </h2>
+              <p>
+                It wasn't always this way. Before extractive social media, you
+                followed people. They shared ideas, learnings, things they
+                loved. You checked in, then got on with your day. That model
+                still works. Let's bring it back.
+              </p>
             </section>
 
             <section>
-              <h2 className="text-2xl font-bold text-text-primary mb-4">What We Believe</h2>
+              <h2 className="text-2xl font-bold text-text-primary mb-4">
+                What We Believe
+              </h2>
               <ul className="space-y-5">
                 <li>
-                  <strong className="text-text-primary block mb-1">Your attention is not a resource to be harvested.</strong>
-                  Your time and your data stay yours. Everything you read lives on your device. We never see any of it. And when you've read what you came to read, you're done.
+                  <strong className="text-text-primary block mb-1">
+                    Your attention is not a resource to be harvested.
+                  </strong>
+                  Your time and your data stay yours. Everything you read lives
+                  on your device. We never see any of it. And when you've read
+                  what you came to read, you're done.
                 </li>
                 <li>
-                  <strong className="text-text-primary block mb-1">You deserve to see the algorithm.</strong>
-                  Freed's ranking is open source. You can read exactly why a post appears first. You can change the weights. You can fork the whole thing.
+                  <strong className="text-text-primary block mb-1">
+                    You deserve to see the algorithm.
+                  </strong>
+                  Freed's ranking is open source. You can read exactly why a
+                  post appears first. You can change the weights. You can fork
+                  the whole thing.
                 </li>
                 <li>
-                  <strong className="text-text-primary block mb-1">This belongs to everyone.</strong>
+                  <strong className="text-text-primary block mb-1">
+                    This belongs to everyone.
+                  </strong>
                   MIT licensed. Fork it. Audit it. Share it.
                 </li>
               </ul>
             </section>
 
             <section>
-              <p>We're building a world where you stay in the driver's seat. Your feed, your algorithm, your rules. The code is public. The roadmap is public. Resonate? Subscribe below.</p>
+              <p>
+                We're building a world where you stay in the driver's seat. Your
+                feed, your algorithm, your rules. The code is public. The
+                roadmap is public. Resonate? Subscribe below.
+              </p>
             </section>
 
             <section className="not-prose text-center py-14">
@@ -76,38 +116,47 @@ export default function ManifestoContent() {
             </section>
 
             <section>
-              <h2 className="text-2xl font-bold text-text-primary mb-6">Go Deeper</h2>
+              <h2 className="text-2xl font-bold text-text-primary mb-6">
+                Go Deeper
+              </h2>
               <div className="space-y-3 not-prose">
                 {[
                   {
                     href: "https://www.youtube.com/watch?v=Ma4VZ7rxGOw",
                     title: "The Slow Poison of Endless Fantasy",
                     source: "After Skool",
-                    description: "On escapism, variable reward loops, and what the attention economy is slowly doing to your capacity for sustained thought.",
+                    description:
+                      "On escapism, variable reward loops, and what the attention economy is slowly doing to your capacity for sustained thought.",
                   },
                   {
                     href: "https://www.youtube.com/watch?v=v1eW62X5fiE",
-                    title: "What if we had fixed social media? An alternative history",
+                    title:
+                      "What if we had fixed social media? An alternative history",
                     source: "Center for Humane Technology",
-                    description: "What if we'd optimized for people instead of engagement? That internet is possible.",
+                    description:
+                      "What if we'd optimized for people instead of engagement? That internet is possible.",
                   },
                   {
                     href: "https://www.youtube.com/watch?v=0v5RiMdSqwk&t=2109s",
                     title: "War on Sensemaking V",
                     source: "Daniel Schmachtenberger, Rebel Wisdom",
-                    description: "How algorithmic feeds degrade our collective ability to reason about reality. The linked timestamp drops you into the key section.",
+                    description:
+                      "How algorithmic feeds degrade our collective ability to reason about reality. The linked timestamp drops you into the key section.",
                   },
                   {
                     href: "https://www.youtube.com/watch?v=C74amJRp730",
-                    title: "How a handful of tech companies control billions of minds",
+                    title:
+                      "How a handful of tech companies control billions of minds",
                     source: "Tristan Harris, TED",
-                    description: "The 17-minute version of everything in this manifesto's first two sections, by the person who spent years inside Google trying to fix it.",
+                    description:
+                      "The 17-minute version of everything in this manifesto's first two sections, by the person who spent years inside Google trying to fix it.",
                   },
                   {
                     href: "https://www.eff.org/cyberspace-independence",
                     title: "A Declaration of the Independence of Cyberspace",
                     source: "John Perry Barlow, 1996",
-                    description: "The original. Written the day the U.S. government first tried to regulate the internet. Thirty years later, may we each do our part.",
+                    description:
+                      "The original. Written the day the U.S. government first tried to regulate the internet. Thirty years later, may we each do our part.",
                   },
                 ].map((item) => (
                   <a
@@ -121,12 +170,26 @@ export default function ManifestoContent() {
                       <span className="text-sm font-semibold text-text-primary group-hover:text-white transition-colors leading-snug">
                         {item.title}
                       </span>
-                      <svg className="w-3.5 h-3.5 text-text-muted group-hover:text-text-secondary transition-colors shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                      <svg
+                        className="w-3.5 h-3.5 text-text-muted group-hover:text-text-secondary transition-colors shrink-0 mt-0.5"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={2}
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+                        />
                       </svg>
                     </div>
-                    <span className="text-xs text-text-muted">{item.source}</span>
-                    <p className="text-xs text-text-secondary mt-1 leading-relaxed">{item.description}</p>
+                    <span className="text-xs text-text-muted">
+                      {item.source}
+                    </span>
+                    <p className="text-xs text-text-secondary mt-1 leading-relaxed">
+                      {item.description}
+                    </p>
                   </a>
                 ))}
               </div>

--- a/website/src/app/manifesto/ManifestoContent.tsx
+++ b/website/src/app/manifesto/ManifestoContent.tsx
@@ -47,9 +47,9 @@ export default function ManifestoContent() {
               <p>
                 Odysseus lashed himself to the mast before his ship reached the
                 Sirens. He heard the song. He survived. The secret: decide
-                before temptation arrives. Install Freed now. Choose your
-                sources. Set your priorities. Our algorithm serves you. Your
-                attention, yours again.
+                before temptation arrives. Install Freed. It browses your feeds
+                and stores what you care about in a vault on your device. The
+                platforms become players in your game.
               </p>
             </section>
 
@@ -72,7 +72,7 @@ export default function ManifestoContent() {
               <ul className="space-y-5">
                 <li>
                   <strong className="text-text-primary block mb-1">
-                    Your attention is sacred
+                    Your attention is priceless
                   </strong>
                   Your time and your data stay yours. Everything you read lives
                   on your device. We never see any of it. And when you've read
@@ -80,11 +80,11 @@ export default function ManifestoContent() {
                 </li>
                 <li>
                   <strong className="text-text-primary block mb-1">
-                    You deserve to see the algorithm.
+                    You should own the algorithm.
                   </strong>
-                  Freed's ranking is open source. You can read exactly why a
-                  post appears first. You can change the weights. You can fork
-                  the whole thing.
+                  Freed's ranking is open source. You can tune which sources
+                  matter most to you. You can read exactly why a post appears
+                  first. You are in control.
                 </li>
                 <li>
                   <strong className="text-text-primary block mb-1">

--- a/website/src/app/manifesto/ManifestoContent.tsx
+++ b/website/src/app/manifesto/ManifestoContent.tsx
@@ -46,20 +46,12 @@ export default function ManifestoContent() {
               <h2 className="text-2xl font-bold text-text-primary mb-4">What We Believe</h2>
               <ul className="space-y-5">
                 <li>
-                  <strong className="text-text-primary block mb-1">Your data belongs to you.</strong>
-                  Everything lives on your device. No servers. No telemetry. We never see your content, your follows, or your habits.
+                  <strong className="text-text-primary block mb-1">Your attention is not a resource to be harvested.</strong>
+                  Your time, your focus, and your data belong to you. Everything lives on your device. No servers. No telemetry. We never see your content, your follows, or your habits. And when you've read what you came to read, you're done. No machine will try to stop you.
                 </li>
                 <li>
                   <strong className="text-text-primary block mb-1">You deserve to see the algorithm.</strong>
                   Freed's ranking is open source. You can read exactly why a post appears first. You can change the weights. You can fork the whole thing.
-                </li>
-                <li>
-                  <strong className="text-text-primary block mb-1">Chronological is not naïve.</strong>
-                  Reading things in the order they were written is a choice, not a failure of curation.
-                </li>
-                <li>
-                  <strong className="text-text-primary block mb-1">You have the right to be done.</strong>
-                  Freed lets you finish your feed. When you're done, you're done. No machine will try to stop you.
                 </li>
                 <li>
                   <strong className="text-text-primary block mb-1">This belongs to everyone.</strong>

--- a/website/src/app/manifesto/ManifestoContent.tsx
+++ b/website/src/app/manifesto/ManifestoContent.tsx
@@ -47,7 +47,7 @@ export default function ManifestoContent() {
               <ul className="space-y-5">
                 <li>
                   <strong className="text-text-primary block mb-1">Your attention is not a resource to be harvested.</strong>
-                  Your time, your focus, and your data belong to you. Everything lives on your device. No servers. No telemetry. We never see your content, your follows, or your habits. And when you've read what you came to read, you're done. No machine will try to stop you.
+                  Your time, your focus, and your data belong to you. Everything lives on your device. No servers. No telemetry. We never see your content, your follows, or your habits. And when you've read what you came to read, you're done. The machine knows that, and it respects it.
                 </li>
                 <li>
                   <strong className="text-text-primary block mb-1">You deserve to see the algorithm.</strong>
@@ -55,7 +55,7 @@ export default function ManifestoContent() {
                 </li>
                 <li>
                   <strong className="text-text-primary block mb-1">This belongs to everyone.</strong>
-                  MIT licensed. Fork it. Audit it. Build on it.
+                  MIT licensed. Fork it. Audit it. Share it.
                 </li>
               </ul>
             </section>

--- a/website/src/app/manifesto/ManifestoContent.tsx
+++ b/website/src/app/manifesto/ManifestoContent.tsx
@@ -39,7 +39,7 @@ export default function ManifestoContent() {
 
             <section>
               <h2 className="text-2xl font-bold text-text-primary mb-4">What You Can Reclaim</h2>
-              <p>It wasn't always this way. You followed people. They shared ideas, learnings, things they loved. You checked in, then got on with your day. That model still works. Let's bring it back.</p>
+              <p>It wasn't always this way. Before extractive social media, you followed people. They shared ideas, learnings, things they loved. You checked in, then got on with your day. That model still works. Let's bring it back.</p>
             </section>
 
             <section>

--- a/website/src/app/manifesto/ManifestoContent.tsx
+++ b/website/src/app/manifesto/ManifestoContent.tsx
@@ -47,7 +47,7 @@ export default function ManifestoContent() {
               <ul className="space-y-5">
                 <li>
                   <strong className="text-text-primary block mb-1">Your attention is not a resource to be harvested.</strong>
-                  Your time, your focus, and your data belong to you. Everything lives on your device. No servers. No telemetry. We never see your content, your follows, or your habits. And when you've read what you came to read, you're done. The machine knows that, and it respects it.
+                  Your time, your focus, and your data belong to you. Everything lives on your device. No servers. No telemetry. We never see your content, your follows, or your habits. And when you've read what you came to read, you're done.
                 </li>
                 <li>
                   <strong className="text-text-primary block mb-1">You deserve to see the algorithm.</strong>

--- a/website/src/app/manifesto/ManifestoContent.tsx
+++ b/website/src/app/manifesto/ManifestoContent.tsx
@@ -46,13 +46,22 @@ export default function ManifestoContent() {
               </h2>
               <p>
                 Odysseus lashed himself to the mast before his ship reached the
-                Sirens. He heard the song. He survived. The secret: decide
-                before temptation arrives. Install Freed now.
-                <br />
-                <br />
-                We browse in the background. Posts land in a vault on your
-                device, synced to your phone. We build you a feed from
-                everything you love. The platforms become players in your game.
+                Sirens. He heard the songs. He survived. The secret: decide
+                before temptation arrives. Install Freed now. We'll protect you
+                from ever doom scrolling again.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="text-2xl font-bold text-text-primary mb-4">
+                The Solution
+              </h2>
+              <p>
+                Freed browses your feeds in the background and strips out the
+                noise. Posts land in a secure vault on your computer, and are
+                live-synced to your phone. Freed curates a unified feed of
+                everything you love, with you in control. The platforms become
+                players in your game.
               </p>
             </section>
 
@@ -65,11 +74,9 @@ export default function ManifestoContent() {
                   <strong className="text-text-primary block mb-1">
                     Your attention is priceless
                   </strong>
-                  It's also finite. Every algorithm on earth knows this. That's
-                  the business model. Freed takes the opposite position: your
-                  time, your focus, and your data stay yours. Everything you
-                  read lives on your device. We never see any of it. And when
-                  you've read what you came to read, you're done.
+                  It's also finite. With Freed, your time, your focus, and your
+                  data stay yours. Everything you read lives on your device. We
+                  never see any of it. Read what you came for. Get back to life.
                 </li>
                 <li>
                   <strong className="text-text-primary block mb-1">
@@ -83,17 +90,11 @@ export default function ManifestoContent() {
                   <strong className="text-text-primary block mb-1">
                     This belongs to everyone.
                   </strong>
-                  MIT licensed. Fork it. Audit it. Share it.
+                  MIT licensed. Fork it. Audit it. Share it. Your feed, your
+                  algorithm, your rules. The code is public. The roadmap is
+                  public. Resonate? Subscribe below.
                 </li>
               </ul>
-            </section>
-
-            <section>
-              <p>
-                We're building a world where you stay in the driver's seat. Your
-                feed, your algorithm, your rules. The code is public. The
-                roadmap is public. Resonate? Subscribe below.
-              </p>
             </section>
 
             <section className="not-prose text-center py-14">

--- a/website/src/app/manifesto/ManifestoContent.tsx
+++ b/website/src/app/manifesto/ManifestoContent.tsx
@@ -32,9 +32,9 @@ export default function ManifestoContent() {
                 The Problem
               </h2>
               <p>
-                Open your feed. Something else has already decided what's waiting.
-                Not to serve you. To keep you in the system. The design is
-                deliberate. Outrage travels faster than nuance. Anxiety keeps
+                Open your feed. Something else has already decided what's
+                waiting. Not to serve you. To keep you in the system. The design
+                is deliberate. Outrage travels faster than nuance. Anxiety keeps
                 you scrolling. The machine is working perfectly. It's just not
                 working for you.
               </p>
@@ -45,7 +45,11 @@ export default function ManifestoContent() {
                 The Pact
               </h2>
               <p>
-                Odysseus lashed himself to the mast before the ship reached the Sirens. He heard the song. He survived. The secret: decide before the temptation arrives, not during it. Install Freed in a clear moment. Choose your sources. Set your trust. Then step away. Your algorithm runs in your place. Not one engineered to exploit you. Your attention, yours again.
+                Odysseus lashed himself to the mast before his ship reached the
+                Sirens. He heard the song. He survived. The secret: decide
+                before temptation arrives. Install Freed now. Choose your
+                sources. Set your priorities. Our algorithm serves you. Your
+                attention, yours again.
               </p>
             </section>
 
@@ -68,7 +72,7 @@ export default function ManifestoContent() {
               <ul className="space-y-5">
                 <li>
                   <strong className="text-text-primary block mb-1">
-                    Your attention is not a resource to be harvested.
+                    Your attention is sacred
                   </strong>
                   Your time and your data stay yours. Everything you read lives
                   on your device. We never see any of it. And when you've read

--- a/website/src/app/manifesto/ManifestoContent.tsx
+++ b/website/src/app/manifesto/ManifestoContent.tsx
@@ -48,8 +48,8 @@ export default function ManifestoContent() {
                 Odysseus lashed himself to the mast before his ship reached the
                 Sirens. He heard the song. He survived. The secret: decide
                 before temptation arrives. Install Freed. It browses your feeds
-                and stores what you care about in a vault on your device. The
-                platforms become players in your game.
+                in the background, and stores what you care about in a vault on
+                your machine. The platforms become players in your game.
               </p>
             </section>
 
@@ -74,9 +74,11 @@ export default function ManifestoContent() {
                   <strong className="text-text-primary block mb-1">
                     Your attention is priceless
                   </strong>
-                  Your time and your data stay yours. Everything you read lives
-                  on your device. We never see any of it. And when you've read
-                  what you came to read, you're done.
+                  It's also finite. Every algorithm on earth knows this. That's
+                  the business model. Freed takes the opposite position: your
+                  time, your focus, and your data stay yours. Everything you
+                  read lives on your device. We never see any of it. And when
+                  you've read what you came to read, you're done.
                 </li>
                 <li>
                   <strong className="text-text-primary block mb-1">

--- a/website/src/app/manifesto/ManifestoContent.tsx
+++ b/website/src/app/manifesto/ManifestoContent.tsx
@@ -47,21 +47,12 @@ export default function ManifestoContent() {
               <p>
                 Odysseus lashed himself to the mast before his ship reached the
                 Sirens. He heard the song. He survived. The secret: decide
-                before temptation arrives. Install Freed. It browses your feeds
-                in the background, and stores what you care about in a vault on
-                your machine. The platforms become players in your game.
-              </p>
-            </section>
-
-            <section>
-              <h2 className="text-2xl font-bold text-text-primary mb-4">
-                What You Can Reclaim
-              </h2>
-              <p>
-                It wasn't always this way. Before extractive social media, you
-                followed people. They shared ideas, learnings, things they
-                loved. You checked in, then got on with your day. That model
-                still works. Let's bring it back.
+                before temptation arrives. Install Freed now.
+                <br />
+                <br />
+                We browse in the background. Posts land in a vault on your
+                device, synced to your phone. We build you a feed from
+                everything you love. The platforms become players in your game.
               </p>
             </section>
 

--- a/website/src/app/manifesto/ManifestoContent.tsx
+++ b/website/src/app/manifesto/ManifestoContent.tsx
@@ -47,8 +47,8 @@ export default function ManifestoContent() {
               <p>
                 Odysseus lashed himself to the mast before his ship reached the
                 Sirens. He heard the songs. He survived. The secret: decide
-                before temptation arrives. Install Freed now. We'll protect you
-                from ever doom scrolling again.
+                before temptation arrives. Install Freed now. Never doom-scroll
+                again.
               </p>
             </section>
 
@@ -60,8 +60,8 @@ export default function ManifestoContent() {
                 Freed browses your feeds in the background and strips out the
                 noise. Posts land in a secure vault on your computer, and are
                 live-synced to your phone. Freed curates a unified feed of
-                everything you love, with you in control. The platforms become
-                players in your game.
+                everything you love, with you in control. Your algorithm, your
+                rules. The platforms become players in your game.
               </p>
             </section>
 
@@ -76,23 +76,23 @@ export default function ManifestoContent() {
                   </strong>
                   It's also finite. With Freed, your time, your focus, and your
                   data stay yours. Everything you read lives on your device. We
-                  never see any of it. Read what you came for. Get back to life.
+                  never see any of it. Read what you came for. Get back to your
+                  life.
                 </li>
                 <li>
                   <strong className="text-text-primary block mb-1">
-                    You should own the algorithm.
+                    You should own the algorithm
                   </strong>
                   Freed's ranking is open source. You can tune which sources
                   matter most to you. You can read exactly why a post appears
-                  first. You are in control.
+                  first. You're in control.
                 </li>
                 <li>
                   <strong className="text-text-primary block mb-1">
-                    This belongs to everyone.
+                    This belongs to everyone
                   </strong>
-                  MIT licensed. Fork it. Audit it. Share it. Your feed, your
-                  algorithm, your rules. The code is public. The roadmap is
-                  public. Resonate? Subscribe below.
+                  The code is public. The roadmap is public. Fork it. Audit it.
+                  Share it. Resonate? Join the movement.
                 </li>
               </ul>
             </section>

--- a/website/src/app/manifesto/ManifestoContent.tsx
+++ b/website/src/app/manifesto/ManifestoContent.tsx
@@ -144,7 +144,7 @@ export default function ManifestoContent() {
                       "How a handful of tech companies control billions of minds",
                     source: "Tristan Harris, TED",
                     description:
-                      "The attention economy, explained by the person who tried hardest to redeem it.",
+                      "Seventeen minutes. The clearest explanation of how this happened, by someone who was inside Google when it did.",
                   },
                   {
                     href: "https://www.eff.org/cyberspace-independence",

--- a/website/src/app/manifesto/ManifestoContent.tsx
+++ b/website/src/app/manifesto/ManifestoContent.tsx
@@ -34,7 +34,7 @@ export default function ManifestoContent() {
 
             <section>
               <h2 className="text-2xl font-bold text-text-primary mb-4">The Pact</h2>
-              <p>Odysseus wanted to hear the Sirens without dying. He couldn't trust himself in the moment, so he had his crew lash him to the mast before the ship got close. He heard the song. He survived. He got what he wanted by choosing his constraints <em>before</em> the temptation arrived. Do it once, in a moment of clarity: tell Freed which creators matter, how much you trust each source, which platforms you'll only read through Freed. Your algorithm. Not one engineered to exploit you.</p>
+              <p>Odysseus wanted to hear the Sirens without dying. He couldn't trust himself in the moment, so he had his crew lash him to the mast before the ship got close. He heard the song. He survived. Do it once, in a moment of clarity: tell Freed which creators matter, how much you trust each source. Your algorithm. Not one engineered to exploit you.</p>
             </section>
 
             <section>

--- a/website/src/app/manifesto/ManifestoContent.tsx
+++ b/website/src/app/manifesto/ManifestoContent.tsx
@@ -45,10 +45,7 @@ export default function ManifestoContent() {
                 The Pact
               </h2>
               <p>
-                Odysseus wanted to hear the Sirens without dying. He couldn't
-                trust himself in the moment, so he had his crew lash him to the
-                mast before the ship got close. He heard the song. He survived.
-                Install Freed in a moment of clarity. Choose which creators matter. Set how much you trust each one. Then step away. Those choices run in your place. Your attention, yours again. Your algorithm. Not one engineered to exploit you.
+                Odysseus lashed himself to the mast before the ship reached the Sirens. He heard the song. He survived. The secret: decide before the temptation arrives, not during it. Install Freed in a clear moment. Choose your sources. Set your trust. Then step away. Your algorithm runs in your place. Not one engineered to exploit you. Your attention, yours again.
               </p>
             </section>
 

--- a/website/src/app/manifesto/ManifestoContent.tsx
+++ b/website/src/app/manifesto/ManifestoContent.tsx
@@ -115,7 +115,7 @@ export default function ManifestoContent() {
                     href: "https://www.eff.org/cyberspace-independence",
                     title: "A Declaration of the Independence of Cyberspace",
                     source: "John Perry Barlow, 1996",
-                    description: "The original. Written the day the U.S. government first tried to regulate the internet. This manifesto was written in its spirit.",
+                    description: "The original. Written the day the U.S. government first tried to regulate the internet. Thirty years later, may we each do our part.",
                   },
                 ].map((item) => (
                   <a

--- a/website/src/app/updates/[slug]/PostContent.tsx
+++ b/website/src/app/updates/[slug]/PostContent.tsx
@@ -108,8 +108,14 @@ export default function PostContent({ post }: PostContentProps) {
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             transition={{ delay: 0.4 }}
-            className="mt-24 text-right not-prose"
+            className="mt-24 not-prose flex items-center justify-between"
           >
+            <Link
+              href="/updates"
+              className="text-sm text-text-muted hover:text-glow-purple transition-colors"
+            >
+              ← Back to Updates
+            </Link>
             <p className="text-text-muted text-sm">
               <a
                 href={`https://twitter.com/intent/tweet?url=${encodeURIComponent(

--- a/website/src/app/updates/[slug]/PostContent.tsx
+++ b/website/src/app/updates/[slug]/PostContent.tsx
@@ -93,8 +93,41 @@ export default function PostContent({ post }: PostContentProps) {
             {post.content}
           </div>
 
+          {/* Share */}
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ delay: 0.4 }}
+            className="mt-24 text-center not-prose"
+          >
+            <p className="text-text-muted text-sm">
+              Share this post:{" "}
+              <a
+                href={`https://twitter.com/intent/tweet?url=${encodeURIComponent(
+                  `https://freed.wtf/updates/${post.slug}`
+                )}&text=${encodeURIComponent(post.title)}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-glow-purple hover:text-glow-blue transition-colors"
+              >
+                X
+              </a>
+              {" • "}
+              <button
+                onClick={() =>
+                  navigator.clipboard.writeText(
+                    `https://freed.wtf/updates/${post.slug}`
+                  )
+                }
+                className="text-glow-purple hover:text-glow-blue transition-colors"
+              >
+                Copy link
+              </button>
+            </p>
+          </motion.div>
+
           {/* Footer */}
-          <footer className="mt-16 pt-8 border-t border-freed-border not-prose">
+          <footer className="mt-8 pt-8 border-t border-freed-border not-prose">
             <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
               <div>
                 <p className="text-text-secondary text-sm mb-1">
@@ -130,39 +163,6 @@ export default function PostContent({ post }: PostContentProps) {
             </div>
           </footer>
         </motion.article>
-
-        {/* Share */}
-        <motion.div
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          transition={{ delay: 0.4 }}
-          className="mt-8 text-center"
-        >
-          <p className="text-text-muted text-sm">
-            Share this post:{" "}
-            <a
-              href={`https://twitter.com/intent/tweet?url=${encodeURIComponent(
-                `https://freed.wtf/updates/${post.slug}`
-              )}&text=${encodeURIComponent(post.title)}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-glow-purple hover:text-glow-blue transition-colors"
-            >
-              X
-            </a>
-            {" • "}
-            <button
-              onClick={() =>
-                navigator.clipboard.writeText(
-                  `https://freed.wtf/updates/${post.slug}`
-                )
-              }
-              className="text-glow-purple hover:text-glow-blue transition-colors"
-            >
-              Copy link
-            </button>
-          </p>
-        </motion.div>
       </div>
     </section>
   );

--- a/website/src/app/updates/[slug]/PostContent.tsx
+++ b/website/src/app/updates/[slug]/PostContent.tsx
@@ -112,9 +112,9 @@ export default function PostContent({ post }: PostContentProps) {
           >
             <Link
               href="/updates"
-              className="text-sm text-text-muted hover:text-glow-purple transition-colors"
+              className="text-sm text-glow-purple hover:text-glow-blue transition-colors"
             >
-              ← Back to Updates
+              ‹ Back to Updates
             </Link>
             <p className="text-text-muted text-sm">
               <a

--- a/website/src/app/updates/[slug]/PostContent.tsx
+++ b/website/src/app/updates/[slug]/PostContent.tsx
@@ -121,10 +121,10 @@ export default function PostContent({ post }: PostContentProps) {
               >
                 Share on X
               </a>
-              {" • "}
+              <span className="mx-3 text-text-muted">•</span>
               <button
                 onClick={handleCopy}
-                className="text-glow-purple hover:text-glow-blue transition-colors relative"
+                className="text-glow-purple hover:text-glow-blue transition-colors relative cursor-pointer"
               >
                 Copy link
                 <AnimatePresence>

--- a/website/src/app/updates/[slug]/PostContent.tsx
+++ b/website/src/app/updates/[slug]/PostContent.tsx
@@ -98,7 +98,7 @@ export default function PostContent({ post }: PostContentProps) {
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             transition={{ delay: 0.4 }}
-            className="mt-24 text-center not-prose"
+            className="mt-24 text-right not-prose"
           >
             <p className="text-text-muted text-sm">
               Share this post:{" "}
@@ -110,7 +110,7 @@ export default function PostContent({ post }: PostContentProps) {
                 rel="noopener noreferrer"
                 className="text-glow-purple hover:text-glow-blue transition-colors"
               >
-                X
+                Share on X
               </a>
               {" • "}
               <button

--- a/website/src/app/updates/[slug]/PostContent.tsx
+++ b/website/src/app/updates/[slug]/PostContent.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { motion } from "framer-motion";
+import { motion, AnimatePresence } from "framer-motion";
 import Link from "next/link";
+import { useState, useCallback } from "react";
 import { useNewsletter } from "@/context/NewsletterContext";
 import type { Post } from "@/content";
 
@@ -22,6 +23,13 @@ interface PostContentProps {
 
 export default function PostContent({ post }: PostContentProps) {
   const { openModal } = useNewsletter();
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(() => {
+    navigator.clipboard.writeText(`https://freed.wtf/updates/${post.slug}`);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }, [post.slug]);
 
   return (
     <section className="py-24 sm:py-32 px-4 sm:px-6 md:px-12 lg:px-8">
@@ -65,7 +73,9 @@ export default function PostContent({ post }: PostContentProps) {
                       {post.author}
                     </a>
                   ) : (
-                    <span className="text-sm text-text-muted">{post.author}</span>
+                    <span className="text-sm text-text-muted">
+                      {post.author}
+                    </span>
                   )}
                 </>
               )}
@@ -101,10 +111,9 @@ export default function PostContent({ post }: PostContentProps) {
             className="mt-24 text-right not-prose"
           >
             <p className="text-text-muted text-sm">
-              Share this post:{" "}
               <a
                 href={`https://twitter.com/intent/tweet?url=${encodeURIComponent(
-                  `https://freed.wtf/updates/${post.slug}`
+                  `https://freed.wtf/updates/${post.slug}`,
                 )}&text=${encodeURIComponent(post.title)}`}
                 target="_blank"
                 rel="noopener noreferrer"
@@ -114,14 +123,22 @@ export default function PostContent({ post }: PostContentProps) {
               </a>
               {" • "}
               <button
-                onClick={() =>
-                  navigator.clipboard.writeText(
-                    `https://freed.wtf/updates/${post.slug}`
-                  )
-                }
-                className="text-glow-purple hover:text-glow-blue transition-colors"
+                onClick={handleCopy}
+                className="text-glow-purple hover:text-glow-blue transition-colors relative"
               >
                 Copy link
+                <AnimatePresence>
+                  {copied && (
+                    <motion.span
+                      initial={{ opacity: 0, y: 4 }}
+                      animate={{ opacity: 1, y: 0 }}
+                      exit={{ opacity: 0, y: -4 }}
+                      className="absolute -top-7 left-1/2 -translate-x-1/2 bg-freed-surface border border-freed-border text-text-primary text-xs px-2 py-1 rounded whitespace-nowrap"
+                    >
+                      Copied!
+                    </motion.span>
+                  )}
+                </AnimatePresence>
               </button>
             </p>
           </motion.div>

--- a/website/src/app/updates/[slug]/PostContent.tsx
+++ b/website/src/app/updates/[slug]/PostContent.tsx
@@ -55,7 +55,18 @@ export default function PostContent({ post }: PostContentProps) {
               {post.author && (
                 <>
                   <span className="text-text-muted">•</span>
-                  <span className="text-sm text-text-muted">{post.author}</span>
+                  {post.authorUrl ? (
+                    <a
+                      href={post.authorUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-sm text-text-muted hover:text-glow-purple transition-colors"
+                    >
+                      {post.author}
+                    </a>
+                  ) : (
+                    <span className="text-sm text-text-muted">{post.author}</span>
+                  )}
                 </>
               )}
             </div>

--- a/website/src/app/updates/[slug]/PostContent.tsx
+++ b/website/src/app/updates/[slug]/PostContent.tsx
@@ -44,7 +44,7 @@ export default function PostContent({ post }: PostContentProps) {
             href="/updates"
             className="text-sm text-text-muted hover:text-glow-purple transition-colors"
           >
-            ← Back to Updates
+            ‹ Back to Updates
           </Link>
         </motion.div>
 

--- a/website/src/content/posts/001-introducing-freed.tsx
+++ b/website/src/content/posts/001-introducing-freed.tsx
@@ -5,7 +5,7 @@ export default definePost(
     slug: "introducing-freed",
     title: "Introducing Freed: Take Back Your Feed",
     description:
-      "Why we built a local-first, open-source feed reader that puts you back in control of your information diet.",
+      "A local-first, open-source reader that captures your feeds in the background and puts you back in charge of what you read.",
     date: "2026-02-17",
     author: "Aubrey Falconer",
     authorUrl: "https://AubreyFalconer.com",
@@ -13,52 +13,73 @@ export default definePost(
   },
   <>
     <p>
-      Welcome to the first Freed update. You're here because you subscribed or
-      found us through RSS. Both are good choices.
+      The chronological feed was quietly killed at every major platform. Not
+      because it failed you. Because it let you leave.
     </p>
-
-    <h2>The Problem</h2>
     <p>
-      Open your feed. Something else has already decided what's waiting. Not to
-      serve you. To keep you in the system. Platforms replaced chronological
-      reading with engagement algorithms optimized for clicks, shares, and
-      time-on-screen. That's what they sell. The machine is working perfectly.
-      It's just not working for you.
+      What replaced it was engineered to keep you scrolling. Outrage gets
+      amplified because it's engaging. Nuance gets buried because it's slow.
+      Infinite scroll removes the stopping point. Variable reward schedules,
+      the same mechanism that makes slot machines addictive, keep you pulling
+      down to refresh. None of this is accidental. Billions of dollars in
+      engineering talent were deployed specifically to exploit the gaps in human
+      cognition.
     </p>
+    <p>We built Freed because we were done with it.</p>
 
-    <h2>What Freed Does</h2>
+    <h2>What Freed Is</h2>
     <p>
-      Freed runs in the background, capturing posts from the sources you care
-      about: X, RSS feeds, YouTube channels, newsletters, and podcasts.
-      Everything lands in a local vault on your computer, live-synced to your
-      phone. No central servers. We never see your data.
+      Freed is a local-first feed reader. It captures content from the sources
+      you choose: X, RSS feeds, YouTube channels, newsletters, and podcasts.
+      Everything lands in a vault on your device, live-synced to your phone.
+      You get a unified, chronological feed of everything you care about, ranked
+      the way you decide. Your algorithm, your rules. The platforms become
+      players in your game.
     </p>
     <ul>
       <li>
-        <strong>Your algorithm, your rules.</strong> Posts are ranked by
-        criteria you set: author trust, topic relevance, freshness. You can
-        tune the weights and read exactly why any post appears first.
+        <strong>No central servers.</strong> Your content lives on your device,
+        synced between your own devices via Google Drive, iCloud, or Dropbox.
+        We never see it.
       </li>
       <li>
-        <strong>You can be done.</strong> When you've read everything from your
-        subscribed sources, you're caught up. There's an actual end.
+        <strong>No engagement optimization.</strong> Posts are ranked by
+        criteria you set: author trust, topic relevance, freshness. Not by what
+        made someone else angry yesterday.
       </li>
       <li>
-        <strong>Ulysses Mode.</strong> Lock yourself out of X or Instagram's
-        algorithmic feed and only access them through Freed. You get the
-        content without the compulsion.
+        <strong>You can be done.</strong> Freed tracks what you've read. When
+        you've seen everything from your subscribed sources, you're caught up.
+        There's an actual end.
       </li>
       <li>
-        <strong>Open source.</strong> MIT licensed. Fork it, audit it, build
-        on it.
+        <strong>Ulysses Mode.</strong> Configure Freed as the only way you
+        access X or Instagram. You get the content without the compulsion. Named
+        after the hero who lashed himself to the mast so he could hear the
+        Sirens without losing his mind.
+      </li>
+      <li>
+        <strong>Open source.</strong> MIT licensed. Read it, fork it, audit it.
       </li>
     </ul>
 
+    <h2>How It's Built</h2>
+    <p>
+      Freed runs as a desktop app (macOS, Windows, Linux) that captures content
+      in the background using your existing browser sessions. A companion PWA at{" "}
+      <a href="https://app.freed.wtf">app.freed.wtf</a> syncs with the desktop
+      when you're on the same network and falls back to your cloud storage when
+      you're not. The architecture is deliberately local-first: if we shut down
+      tomorrow, your data and your app keep working.
+    </p>
+
     <h2>Where We Are</h2>
     <p>
-      X and RSS capture are working. Save for Later works. The desktop app and
-      mobile reader are in active development. We're building in public and
-      shipping fast.
+      X and RSS capture are working. Save for Later works: save any URL and
+      Freed extracts the full article. The desktop app is running with capture,
+      reader UI, and local sync. The PWA is live at{" "}
+      <a href="https://app.freed.wtf">app.freed.wtf</a> with virtual scrolling,
+      focus reading mode, and offline support. Active development on both.
     </p>
 
     <h2>How You Can Help</h2>
@@ -85,11 +106,14 @@ export default definePost(
     </ul>
 
     <h2>What's Next</h2>
-    <p>
-      Desktop-to-phone sync. A downloadable desktop app for macOS, Windows, and
-      Linux. Facebook and Instagram capture. Cloud sync via Google Drive,
-      iCloud, or Dropbox. We'll update you when each one ships. We don't spam.
-    </p>
+    <ol>
+      <li>Desktop-to-phone sync over LAN</li>
+      <li>Notarized, downloadable desktop app for macOS</li>
+      <li>Windows and Linux builds</li>
+      <li>Cloud sync (Google Drive, Dropbox, iCloud)</li>
+      <li>Facebook and Instagram capture</li>
+    </ol>
+    <p>We'll send an update when each of these lands. We don't spam.</p>
 
     <p>
       Until next time,

--- a/website/src/content/posts/001-introducing-freed.tsx
+++ b/website/src/content/posts/001-introducing-freed.tsx
@@ -25,7 +25,7 @@ export default definePost(
       engineering talent were deployed specifically to exploit the gaps in human
       cognition.
     </p>
-    <p>I built Freed because I was done with it.</p>
+    <p>I built Freed because we can do better.</p>
 
     <h2>What Freed Is</h2>
     <p>

--- a/website/src/content/posts/001-introducing-freed.tsx
+++ b/website/src/content/posts/001-introducing-freed.tsx
@@ -12,204 +12,93 @@ export default definePost(
   },
   <>
     <p>
-      Welcome to the first Freed newsletter. If you're reading this, you've
-      either subscribed to our email list or discovered us through RSS, which
-      is exactly the kind of choice we think you should always have.
+      Welcome to the first Freed newsletter. You're here because you subscribed
+      or found us through RSS. Both are good choices.
     </p>
 
+    <h2>The Feed Isn't For You</h2>
     <p>
-      We want to tell you why we built this, how it works, and what we believe.
+      Somewhere in the last decade, reading the internet became something that
+      happened to you. Platforms killed chronological feeds and replaced them
+      with algorithms optimized for one thing: engagement. Not your
+      satisfaction. Not your learning. Engagement: clicks, shares,
+      time-on-screen. That's what they sell.
+    </p>
+    <p>
+      Outrage gets amplified because it's engaging. Nuance gets buried because
+      it's slow. Infinite scroll removes the stopping point. None of this is
+      accidental.
     </p>
 
-    <h2>The Scroll That Doesn't End</h2>
+    <h2>What Freed Does</h2>
     <p>
-      Somewhere in the last decade, social media stopped being a place where you
-      read things and became a place where things happened to you. The
-      chronological feed (the simple idea that you see what the people you follow
-      published, in the order they published it) was quietly killed at every major
-      platform.
-    </p>
-    <p>
-      What replaced it was algorithmic curation optimized for one thing:
-      engagement. Not your satisfaction. Not your education. Not your
-      connection to the people you care about. Engagement: clicks, shares,
-      reactions, time-on-screen. That is what platforms sell to
-      advertisers.
-    </p>
-    <p>
-      The results are predictable. Outrage gets amplified because it's
-      engaging. Nuance gets suppressed because it's slow. The most compelling
-      lies travel faster than measured truth, and the algorithm can't tell the
-      difference and doesn't try. Infinite scroll removes the natural stopping
-      point. Variable reward schedules (the same mechanism that makes slot
-      machines addictive) keep you pulling down to refresh.
-    </p>
-    <p>
-      None of this is accidental. It is the product of billions of dollars in
-      engineering talent, deployed specifically to exploit the gaps in human
-      cognition.
-    </p>
-
-    <h2>What Freed Does Differently</h2>
-    <p>
-      Freed is a local-first feed reader. It captures content from your social
-      sources: X (formerly Twitter), RSS feeds, YouTube channels, newsletters,
-      and podcasts. It presents them in a unified, chronological timeline on your
-      device. You decide the ranking. You control the weights. The algorithm is
-      yours.
-    </p>
-    <p>Here's what that means concretely:</p>
-    <ul>
-      <li>
-        <strong>No central servers.</strong> Your captured content lives on your
-        device, synced between your own devices (laptop, phone) via your own
-        cloud storage: Google Drive, iCloud, or Dropbox. We never touch it.
-      </li>
-      <li>
-        <strong>No engagement optimization.</strong> Posts are ranked by
-        criteria you define: how much you trust this author, how relevant the
-        topic is to you, how fresh it is. Not by what made someone else angry
-        yesterday.
-      </li>
-      <li>
-        <strong>You can be done.</strong> Freed tracks what you've read. When
-        you've seen everything from your subscribed sources, you've caught up.
-        There's no infinite scroll. There's an actual end.
-      </li>
-      <li>
-        <strong>Ulysses Mode.</strong> If you want to read content from X or
-        Instagram but don't trust yourself not to lose two hours to the
-        algorithmic feed, you can configure Freed to be the only way you access
-        those platforms. Named after the Greek hero who had himself tied to the
-        mast so he could hear the Sirens without dying.
-      </li>
-      <li>
-        <strong>Open source.</strong> Every line of code is MIT licensed. You
-        can read it, modify it, fork it, and audit exactly what it does with your
-        data.
-      </li>
-    </ul>
-
-    <h2>How It's Built</h2>
-    <p>
-      Freed is a monorepo with four main packages:
+      Freed captures content from the sources you choose (X, RSS feeds, YouTube
+      channels, newsletters, podcasts) and shows it to you chronologically, on
+      your device, ranked the way you decide. You control the weights. You write
+      the algorithm.
     </p>
     <ul>
       <li>
-        <strong>Desktop app (Tauri + React)</strong>: The primary capture hub.
-        Runs on macOS, Windows, and Linux. Captures from X using your existing
-        browser session, polls RSS feeds, and hosts a local WebSocket relay for
-        syncing to your phone.
+        <strong>No central servers.</strong> Your content lives on your device,
+        synced between your own devices via Google Drive, iCloud, or Dropbox. We
+        never see it.
       </li>
       <li>
-        <strong>PWA (React + Vite)</strong>: A mobile-optimized reader that
-        syncs with the desktop app when you're on the same network, and falls
-        back to your cloud storage when you're not. Installed at{" "}
-        <a href="https://app.freed.wtf">app.freed.wtf</a>.
+        <strong>No engagement optimization.</strong> Posts are ranked by criteria
+        you define: author trust, topic relevance, freshness. Not by what made
+        someone else angry yesterday.
       </li>
       <li>
-        <strong>Shared library (@freed/shared)</strong>: The common types and
-        Automerge CRDT schema that both apps use. The CRDT (Conflict-free
-        Replicated Data Type) handles merging changes from multiple devices
-        automatically, with no sync conflicts and no data loss.
+        <strong>You can be done.</strong> When you've seen everything from your
+        subscribed sources, you've caught up. There's an actual end.
       </li>
       <li>
-        <strong>Capture packages</strong>: Separate, composable packages for
-        each source: <code>capture-x</code>, <code>capture-rss</code>,
-        <code>capture-save</code>. Each one knows how to fetch from a source and
-        normalize the result into a standard <code>FeedItem</code>.
+        <strong>Ulysses Mode.</strong> Configure Freed as your only lens for X
+        or Instagram. You get the content without the algorithm. Named after the
+        hero who had himself lashed to the mast so he could hear the Sirens
+        without jumping overboard.
+      </li>
+      <li>
+        <strong>Open source.</strong> MIT licensed. Read it, fork it, audit it.
       </li>
     </ul>
-    <p>
-      The architecture is deliberately local-first: data lives on your devices,
-      syncs between them without a relay we operate, and degrades gracefully
-      when offline. If we shut down tomorrow, your data and your app would keep
-      working.
-    </p>
 
     <h2>Where We Are</h2>
     <p>
-      As of this writing, here's what's working:
-    </p>
-    <ul>
-      <li>
-        <strong>Foundation (Phase 1) ✓</strong>: Monorepo, shared types,
-        Automerge schema, this marketing site, CI/CD.
-      </li>
-      <li>
-        <strong>X + RSS capture (Phase 2) ✓</strong>: Both capture layers
-        complete, with OPML import/export for RSS.
-      </li>
-      <li>
-        <strong>Save for Later (Phase 3) ✓</strong>: Save any URL with full
-        article extraction via Mozilla Readability.
-      </li>
-      <li>
-        <strong>Desktop app (Phase 5) 🚧</strong>: The Tauri app is running with
-        the local WebSocket relay, macOS vibrancy, X authentication, and the
-        reader UI. Active development.
-      </li>
-      <li>
-        <strong>PWA reader (Phase 6) 🚧</strong>: Deployed at{" "}
-        <a href="https://app.freed.wtf">app.freed.wtf</a>. Virtual scrolling,
-        focus reading mode, and service worker offline support just landed.
-      </li>
-    </ul>
-    <p>
-      The sync layer (Phase 4) is the critical path right now. Once local
-      WebSocket sync is solid, the desktop and PWA can talk to each other
-      reliably.
+      Capturing from X and RSS works. Save for Later works. The desktop app and
+      mobile reader are in active development. We're building in public and
+      shipping fast.
     </p>
 
     <h2>How You Can Help</h2>
-    <p>
-      We're a small team building this in public. The most valuable things you
-      can do:
-    </p>
     <ul>
       <li>
         <strong>
           <a href="https://github.com/freed-project/freed">Star the repo.</a>
         </strong>{" "}
-        It helps us understand how many people care about this, and it helps
-        others discover the project.
+        It signals that this matters and helps others find us.
       </li>
       <li>
-        <strong>Try the PWA.</strong> Go to{" "}
-        <a href="https://app.freed.wtf">app.freed.wtf</a>, add some RSS feeds,
-        and tell us what's broken.
+        <strong>Try the PWA.</strong> Add some RSS feeds at{" "}
+        <a href="https://app.freed.wtf">app.freed.wtf</a> and tell us what's
+        broken.
       </li>
       <li>
-        <strong>Contribute code.</strong> Especially if you have Rust experience
-        for the Tauri work, or if you have ideas for additional capture layers.
-        Check the issues list.
+        <strong>Contribute.</strong> Especially if you know Rust or have ideas
+        for additional capture sources. Check the issues list.
       </li>
       <li>
-        <strong>Share this.</strong> The people who need Freed most are the ones
-        most embedded in the algorithmic feed. Send this to someone who's
-        complained about social media lately.
+        <strong>Share this.</strong> Send it to someone who's complained about
+        social media lately.
       </li>
     </ul>
 
     <h2>What's Next</h2>
     <p>
-      The immediate roadmap, in order:
-    </p>
-    <ol>
-      <li>Finish the local sync layer (desktop ↔ phone over LAN)</li>
-      <li>Polish the desktop and PWA UIs to a releasable state</li>
-      <li>Package and notarize the desktop app for macOS</li>
-      <li>Windows and Linux builds</li>
-      <li>Facebook and Instagram capture via headless browser</li>
-      <li>Cloud sync (Google Drive / Dropbox / iCloud)</li>
-    </ol>
-    <p>
+      Sync between desktop and phone. A polished, downloadable desktop app.
+      Windows and Linux builds. Cloud sync. Facebook and Instagram capture.
       We'll send an update when each of these lands. We don't spam.
     </p>
-
-    <blockquote>
-      "The algorithm that serves you best is the one you wrote yourself."
-    </blockquote>
 
     <p>
       Until next time,

--- a/website/src/content/posts/001-introducing-freed.tsx
+++ b/website/src/content/posts/001-introducing-freed.tsx
@@ -4,8 +4,7 @@ export default definePost(
   {
     slug: "introducing-freed",
     title: "Introducing Freed: Take Back Your Feed",
-    description:
-      "Your feeds, your way, on all your devices.",
+    description: "Your feeds, your way, on all your devices.",
     date: "2026-02-17",
     author: "Aubrey Falconer",
     authorUrl: "https://AubreyFalconer.com",
@@ -14,16 +13,15 @@ export default definePost(
   <>
     <p>
       The chronological feed was quietly killed by every major social platform.
-      Because it failed. Only to exploit you.
+      Did it fail? Only to exploit you.
     </p>
     <p>
-      What replaced it was psychological warfare to keep you scrolling. Outrage gets
-      amplified because it's engaging. Nuance gets buried because it's slow.
-      Infinite scroll removes the stopping point. Variable reward schedules,
-      the same mechanism that makes slot machines addictive, keep you pulling
-      down to refresh. None of this is accidental. Billions of dollars in
-      engineering talent were deployed specifically to exploit the gaps in human
-      cognition.
+      What replaced it? Psychological warfare to keep you addicted. Outrage gets
+      amplified because it's engaging. Infinite scroll removes the natural rest
+      point. Variable reward schedules, the same mechanism that makes slot
+      machines addictive, keep you pulling down to refresh. None of this is
+      accidental. Billions of dollars in engineering talent were deployed
+      specifically to exploit the gaps in human cognition.
     </p>
     <p>I built Freed because we can do better.</p>
 
@@ -31,17 +29,16 @@ export default definePost(
     <p>
       Freed is a local-first feed reader. It captures content from the sources
       you choose: social platforms, RSS feeds, YouTube channels, newsletters,
-      and podcasts.
-      Everything lands in a vault on your device, live-synced to your phone.
-      You get a unified, chronological feed of everything you care about, ranked
-      the way you decide. Your algorithm, your rules. The platforms become
-      players in your game.
+      and podcasts. Everything lands in a vault on your device, live-synced to
+      your phone. You get a unified, chronological feed of everything you care
+      about, ranked the way you decide. Your algorithm, your rules. The
+      platforms become players in your game.
     </p>
     <ul>
       <li>
         <strong>No central servers.</strong> Your content lives on your device,
-        synced between your own devices via Google Drive, iCloud, or Dropbox.
-        I never see it.
+        synced between your own devices via Google Drive, iCloud, or Dropbox. I
+        never see it.
       </li>
       <li>
         <strong>No engagement optimization.</strong> Posts are ranked by
@@ -55,8 +52,8 @@ export default definePost(
       </li>
       <li>
         <strong>Ulysses Mode.</strong> Configure Freed as the only way you
-        access social platforms. You get the content without the compulsion. Named
-        after the hero who lashed himself to the mast so he could hear the
+        access social platforms. You get the content without the compulsion.
+        Named after the hero who lashed himself to the mast so he could hear the
         Sirens without losing his mind.
       </li>
       <li>
@@ -76,11 +73,8 @@ export default definePost(
 
     <h2>Where Things Stand</h2>
     <p>
-      X and RSS capture are working. Save for Later works: save any URL and
-      Freed extracts the full article. The desktop app is running with capture,
-      reader UI, and local sync. The PWA is live at{" "}
-      <a href="https://app.freed.wtf">app.freed.wtf</a> with virtual scrolling,
-      focus reading mode, and offline support. Active development on both.
+      RSS capture is working. X capture and Save for Later are coming soon.
+      The desktop app and mobile reader are in active development.
     </p>
 
     <h2>How You Can Help</h2>
@@ -107,8 +101,8 @@ export default definePost(
         capture sources.
       </li>
       <li>
-        <strong>Share this. 🤍</strong> Send it to someone who's complained
-        about social media lately.
+        <strong>Share this 🤍</strong>&nbsp;&nbsp;Pass along to a friend who's
+        complained about social media lately. We can win, together!
       </li>
     </ul>
 
@@ -121,8 +115,8 @@ export default definePost(
       <li>Facebook and Instagram capture</li>
     </ol>
     <p>
-      I'll post an update as each of these ships.{" "}
-      <a href="/updates">Follow along.</a>
+      I'll post an update when each of these ships.{" "}
+      <a href="/roadmap">Follow along</a>!
     </p>
-  </>
+  </>,
 );

--- a/website/src/content/posts/001-introducing-freed.tsx
+++ b/website/src/content/posts/001-introducing-freed.tsx
@@ -97,8 +97,13 @@ export default definePost(
         Add some RSS feeds and tell me what's broken.
       </li>
       <li>
-        <strong>Contribute.</strong> Especially if you know Rust or have ideas
-        for additional capture sources. Check the issues list.
+        <strong>
+          <a href="https://github.com/freed-project/freed/blob/main/CONTRIBUTING.md">
+            Contribute.
+          </a>
+        </strong>{" "}
+        Especially if you know Rust/TypeScript or have ideas for additional
+        capture sources.
       </li>
       <li>
         <strong>Share this.</strong> Send it to someone who's complained about

--- a/website/src/content/posts/001-introducing-freed.tsx
+++ b/website/src/content/posts/001-introducing-freed.tsx
@@ -73,28 +73,29 @@ export default definePost(
 
     <h2>Where Things Stand</h2>
     <p>
-      RSS capture is working. X capture and Save for Later are coming soon.
-      The desktop app and mobile reader are in active development.
+      RSS capture is working. X and Save for Later are coming soon. The desktop
+      app and mobile reader are in active development.
     </p>
 
     <h2>How You Can Help</h2>
     <ul>
       <li>
         <strong>
-          <a href="https://github.com/freed-project/freed">Star the repo.</a>
+          ⭐ <a href="https://github.com/freed-project/freed">Star the repo</a>
         </strong>{" "}
         It signals that this matters and helps others find it.
       </li>
       <li>
         <strong>
-          <a href="https://app.freed.wtf">Try the PWA.</a>
+          📱 <a href="https://app.freed.wtf">Try the PWA</a>
         </strong>{" "}
         Add some RSS feeds and tell me what's broken.
       </li>
       <li>
         <strong>
+          🛠️{" "}
           <a href="https://github.com/freed-project/freed/blob/main/CONTRIBUTING.md">
-            Contribute.
+            Contribute
           </a>
         </strong>{" "}
         Especially if you know Rust/TypeScript or have ideas for additional

--- a/website/src/content/posts/001-introducing-freed.tsx
+++ b/website/src/content/posts/001-introducing-freed.tsx
@@ -13,8 +13,8 @@ export default definePost(
   },
   <>
     <p>
-      The chronological feed was quietly killed at every major platform. Not
-      because it failed you. Because it let you leave.
+      The chronological feed was quietly killed by every major social platform.
+      Because it failed to exploit you.
     </p>
     <p>
       What replaced it was engineered to keep you scrolling. Outrage gets

--- a/website/src/content/posts/001-introducing-freed.tsx
+++ b/website/src/content/posts/001-introducing-freed.tsx
@@ -5,7 +5,7 @@ export default definePost(
     slug: "introducing-freed",
     title: "Introducing Freed: Take Back Your Feed",
     description:
-      "Your feeds, your algorithms, your devices.",
+      "Your feeds, your way, on all your devices.",
     date: "2026-02-17",
     author: "Aubrey Falconer",
     authorUrl: "https://AubreyFalconer.com",

--- a/website/src/content/posts/001-introducing-freed.tsx
+++ b/website/src/content/posts/001-introducing-freed.tsx
@@ -7,7 +7,8 @@ export default definePost(
     description:
       "Why we built a local-first, open-source feed reader that puts you back in control of your information diet.",
     date: "2026-02-17",
-    author: "The Freed Team",
+    author: "Aubrey Falconer",
+    authorUrl: "https://AubreyFalconer.com",
     tags: ["announcement", "philosophy", "technical"],
   },
   <>
@@ -93,7 +94,7 @@ export default definePost(
     <p>
       Until next time,
       <br />
-      The Freed Team
+      <a href="https://AubreyFalconer.com">Aubrey Falconer</a>
     </p>
   </>
 );

--- a/website/src/content/posts/001-introducing-freed.tsx
+++ b/website/src/content/posts/001-introducing-freed.tsx
@@ -91,9 +91,10 @@ export default definePost(
         It signals that this matters and helps others find us.
       </li>
       <li>
-        <strong>Try the PWA.</strong> Add some RSS feeds at{" "}
-        <a href="https://app.freed.wtf">app.freed.wtf</a> and tell us what's
-        broken.
+        <strong>
+          <a href="https://app.freed.wtf">Try the PWA.</a>
+        </strong>{" "}
+        Add some RSS feeds and tell us what's broken.
       </li>
       <li>
         <strong>Contribute.</strong> Especially if you know Rust or have ideas

--- a/website/src/content/posts/001-introducing-freed.tsx
+++ b/website/src/content/posts/001-introducing-freed.tsx
@@ -14,10 +14,10 @@ export default definePost(
   <>
     <p>
       The chronological feed was quietly killed by every major social platform.
-      Because it failed to exploit you.
+      Because it failed. Only to exploit you.
     </p>
     <p>
-      What replaced it was engineered to keep you scrolling. Outrage gets
+      What replaced it was psychological warfare to keep you scrolling. Outrage gets
       amplified because it's engaging. Nuance gets buried because it's slow.
       Infinite scroll removes the stopping point. Variable reward schedules,
       the same mechanism that makes slot machines addictive, keep you pulling

--- a/website/src/content/posts/001-introducing-freed.tsx
+++ b/website/src/content/posts/001-introducing-freed.tsx
@@ -12,60 +12,50 @@ export default definePost(
   },
   <>
     <p>
-      Welcome to the first Freed newsletter. You're here because you subscribed
-      or found us through RSS. Both are good choices.
+      Welcome to the first Freed update. You're here because you subscribed or
+      found us through RSS. Both are good choices.
     </p>
 
-    <h2>The Feed Isn't For You</h2>
+    <h2>The Problem</h2>
     <p>
-      Somewhere in the last decade, reading the internet became something that
-      happened to you. Platforms killed chronological feeds and replaced them
-      with algorithms optimized for one thing: engagement. Not your
-      satisfaction. Not your learning. Engagement: clicks, shares,
-      time-on-screen. That's what they sell.
-    </p>
-    <p>
-      Outrage gets amplified because it's engaging. Nuance gets buried because
-      it's slow. Infinite scroll removes the stopping point. None of this is
-      accidental.
+      Open your feed. Something else has already decided what's waiting. Not to
+      serve you. To keep you in the system. Platforms replaced chronological
+      reading with engagement algorithms optimized for clicks, shares, and
+      time-on-screen. That's what they sell. The machine is working perfectly.
+      It's just not working for you.
     </p>
 
     <h2>What Freed Does</h2>
     <p>
-      Freed captures content from the sources you choose (X, RSS feeds, YouTube
-      channels, newsletters, podcasts) and shows it to you chronologically, on
-      your device, ranked the way you decide. You control the weights. You write
-      the algorithm.
+      Freed runs in the background, capturing posts from the sources you care
+      about: X, RSS feeds, YouTube channels, newsletters, and podcasts.
+      Everything lands in a local vault on your computer, live-synced to your
+      phone. No central servers. We never see your data.
     </p>
     <ul>
       <li>
-        <strong>No central servers.</strong> Your content lives on your device,
-        synced between your own devices via Google Drive, iCloud, or Dropbox. We
-        never see it.
+        <strong>Your algorithm, your rules.</strong> Posts are ranked by
+        criteria you set: author trust, topic relevance, freshness. You can
+        tune the weights and read exactly why any post appears first.
       </li>
       <li>
-        <strong>No engagement optimization.</strong> Posts are ranked by criteria
-        you define: author trust, topic relevance, freshness. Not by what made
-        someone else angry yesterday.
+        <strong>You can be done.</strong> When you've read everything from your
+        subscribed sources, you're caught up. There's an actual end.
       </li>
       <li>
-        <strong>You can be done.</strong> When you've seen everything from your
-        subscribed sources, you've caught up. There's an actual end.
+        <strong>Ulysses Mode.</strong> Lock yourself out of X or Instagram's
+        algorithmic feed and only access them through Freed. You get the
+        content without the compulsion.
       </li>
       <li>
-        <strong>Ulysses Mode.</strong> Configure Freed as your only lens for X
-        or Instagram. You get the content without the algorithm. Named after the
-        hero who had himself lashed to the mast so he could hear the Sirens
-        without jumping overboard.
-      </li>
-      <li>
-        <strong>Open source.</strong> MIT licensed. Read it, fork it, audit it.
+        <strong>Open source.</strong> MIT licensed. Fork it, audit it, build
+        on it.
       </li>
     </ul>
 
     <h2>Where We Are</h2>
     <p>
-      Capturing from X and RSS works. Save for Later works. The desktop app and
+      X and RSS capture are working. Save for Later works. The desktop app and
       mobile reader are in active development. We're building in public and
       shipping fast.
     </p>
@@ -95,9 +85,9 @@ export default definePost(
 
     <h2>What's Next</h2>
     <p>
-      Sync between desktop and phone. A polished, downloadable desktop app.
-      Windows and Linux builds. Cloud sync. Facebook and Instagram capture.
-      We'll send an update when each of these lands. We don't spam.
+      Desktop-to-phone sync. A downloadable desktop app for macOS, Windows, and
+      Linux. Facebook and Instagram capture. Cloud sync via Google Drive,
+      iCloud, or Dropbox. We'll update you when each one ships. We don't spam.
     </p>
 
     <p>

--- a/website/src/content/posts/001-introducing-freed.tsx
+++ b/website/src/content/posts/001-introducing-freed.tsx
@@ -107,8 +107,8 @@ export default definePost(
         capture sources.
       </li>
       <li>
-        <strong>Share this.</strong> Send it to someone who's complained about
-        social media lately.
+        <strong>Share this. 🤍</strong> Send it to someone who's complained
+        about social media lately.
       </li>
     </ul>
 

--- a/website/src/content/posts/001-introducing-freed.tsx
+++ b/website/src/content/posts/001-introducing-freed.tsx
@@ -81,29 +81,32 @@ export default definePost(
     <ul>
       <li>
         <strong>
-          ⭐ <a href="https://github.com/freed-project/freed">Star the repo</a>
+          <a href="https://github.com/freed-project/freed">Star the repo</a>
+          {" ⭐"}
         </strong>{" "}
         It signals that this matters and helps others find it.
       </li>
       <li>
         <strong>
-          📱 <a href="https://app.freed.wtf">Try the PWA</a>
+          <a href="https://app.freed.wtf">Try the PWA</a>
+          {" 📱"}
         </strong>{" "}
         Add some RSS feeds and tell me what's broken.
       </li>
       <li>
         <strong>
-          🛠️{" "}
           <a href="https://github.com/freed-project/freed/blob/main/CONTRIBUTING.md">
             Contribute
           </a>
+          {" 🛠️"}
         </strong>{" "}
         Especially if you know Rust/TypeScript or have ideas for additional
         capture sources.
       </li>
       <li>
-        <strong>Share this 🤍</strong>&nbsp;&nbsp;Pass along to a friend who's
-        complained about social media lately. We can win, together!
+        <strong>Share this 🤍</strong>{" "}
+        Pass along to a friend who's complained about social media lately. We
+        can win, together!
       </li>
     </ul>
 

--- a/website/src/content/posts/001-introducing-freed.tsx
+++ b/website/src/content/posts/001-introducing-freed.tsx
@@ -5,7 +5,7 @@ export default definePost(
     slug: "introducing-freed",
     title: "Introducing Freed: Take Back Your Feed",
     description:
-      "A local-first, open-source reader that captures your feeds in the background and puts you back in charge of what you read.",
+      "Your feeds, your algorithms, your devices.",
     date: "2026-02-17",
     author: "Aubrey Falconer",
     authorUrl: "https://AubreyFalconer.com",

--- a/website/src/content/posts/001-introducing-freed.tsx
+++ b/website/src/content/posts/001-introducing-freed.tsx
@@ -25,7 +25,7 @@ export default definePost(
       engineering talent were deployed specifically to exploit the gaps in human
       cognition.
     </p>
-    <p>We built Freed because we were done with it.</p>
+    <p>I built Freed because I was done with it.</p>
 
     <h2>What Freed Is</h2>
     <p>
@@ -40,7 +40,7 @@ export default definePost(
       <li>
         <strong>No central servers.</strong> Your content lives on your device,
         synced between your own devices via Google Drive, iCloud, or Dropbox.
-        We never see it.
+        I never see it.
       </li>
       <li>
         <strong>No engagement optimization.</strong> Posts are ranked by
@@ -69,11 +69,11 @@ export default definePost(
       in the background using your existing browser sessions. A companion PWA at{" "}
       <a href="https://app.freed.wtf">app.freed.wtf</a> syncs with the desktop
       when you're on the same network and falls back to your cloud storage when
-      you're not. The architecture is deliberately local-first: if we shut down
-      tomorrow, your data and your app keep working.
+      you're not. The architecture is deliberately local-first: if Freed shuts
+      down tomorrow, your data and your app keep working.
     </p>
 
-    <h2>Where We Are</h2>
+    <h2>Where Things Stand</h2>
     <p>
       X and RSS capture are working. Save for Later works: save any URL and
       Freed extracts the full article. The desktop app is running with capture,
@@ -88,13 +88,13 @@ export default definePost(
         <strong>
           <a href="https://github.com/freed-project/freed">Star the repo.</a>
         </strong>{" "}
-        It signals that this matters and helps others find us.
+        It signals that this matters and helps others find it.
       </li>
       <li>
         <strong>
           <a href="https://app.freed.wtf">Try the PWA.</a>
         </strong>{" "}
-        Add some RSS feeds and tell us what's broken.
+        Add some RSS feeds and tell me what's broken.
       </li>
       <li>
         <strong>Contribute.</strong> Especially if you know Rust or have ideas
@@ -114,7 +114,7 @@ export default definePost(
       <li>Cloud sync (Google Drive, Dropbox, iCloud)</li>
       <li>Facebook and Instagram capture</li>
     </ol>
-    <p>We'll send an update when each of these lands. We don't spam.</p>
+    <p>I'll send an update when each of these lands. I don't spam.</p>
 
     <p>
       Until next time,

--- a/website/src/content/posts/001-introducing-freed.tsx
+++ b/website/src/content/posts/001-introducing-freed.tsx
@@ -3,7 +3,7 @@ import { definePost } from "../types";
 export default definePost(
   {
     slug: "introducing-freed",
-    title: "Introducing Freed: Take Back Your Feed",
+    title: "Introducing Freed",
     description: "Your feeds, your way, on all your devices.",
     date: "2026-02-17",
     author: "Aubrey Falconer",
@@ -82,14 +82,14 @@ export default definePost(
       <li>
         <strong>
           <a href="https://github.com/freed-project/freed">Star the repo</a>
-          {" ⭐"}
+          <span className="mx-2">⭐</span>
         </strong>{" "}
         It signals that this matters and helps others find it.
       </li>
       <li>
         <strong>
           <a href="https://app.freed.wtf">Try the PWA</a>
-          {" 📱"}
+          <span className="mx-2">📱</span>
         </strong>{" "}
         Add some RSS feeds and tell me what's broken.
       </li>
@@ -98,15 +98,14 @@ export default definePost(
           <a href="https://github.com/freed-project/freed/blob/main/CONTRIBUTING.md">
             Contribute
           </a>
-          {" 🛠️"}
+          <span className="mx-2">🛠️</span>
         </strong>{" "}
         Especially if you know Rust/TypeScript or have ideas for additional
         capture sources.
       </li>
       <li>
-        <strong>Share this 🤍</strong>{" "}
-        Pass along to a friend who's complained about social media lately. We
-        can win, together!
+        <strong>Share <span className="mx-2">🤍</span></strong> Pass along to a
+        friend who's complained about social media lately. We can win, together!
       </li>
     </ul>
 

--- a/website/src/content/posts/001-introducing-freed.tsx
+++ b/website/src/content/posts/001-introducing-freed.tsx
@@ -30,7 +30,8 @@ export default definePost(
     <h2>What Freed Is</h2>
     <p>
       Freed is a local-first feed reader. It captures content from the sources
-      you choose: X, RSS feeds, YouTube channels, newsletters, and podcasts.
+      you choose: social platforms, RSS feeds, YouTube channels, newsletters,
+      and podcasts.
       Everything lands in a vault on your device, live-synced to your phone.
       You get a unified, chronological feed of everything you care about, ranked
       the way you decide. Your algorithm, your rules. The platforms become
@@ -54,7 +55,7 @@ export default definePost(
       </li>
       <li>
         <strong>Ulysses Mode.</strong> Configure Freed as the only way you
-        access X or Instagram. You get the content without the compulsion. Named
+        access social platforms. You get the content without the compulsion. Named
         after the hero who lashed himself to the mast so he could hear the
         Sirens without losing his mind.
       </li>

--- a/website/src/content/posts/001-introducing-freed.tsx
+++ b/website/src/content/posts/001-introducing-freed.tsx
@@ -121,8 +121,8 @@ export default definePost(
       <li>Facebook and Instagram capture</li>
     </ol>
     <p>
-      I'll post an update when each of these lands.{" "}
-      <a href="/updates">Follow along here.</a> I don't spam.
+      I'll post an update as each of these ships.{" "}
+      <a href="/updates">Follow along.</a>
     </p>
   </>
 );

--- a/website/src/content/posts/001-introducing-freed.tsx
+++ b/website/src/content/posts/001-introducing-freed.tsx
@@ -119,12 +119,9 @@ export default definePost(
       <li>Cloud sync (Google Drive, Dropbox, iCloud)</li>
       <li>Facebook and Instagram capture</li>
     </ol>
-    <p>I'll send an update when each of these lands. I don't spam.</p>
-
     <p>
-      Until next time,
-      <br />
-      <a href="https://AubreyFalconer.com">Aubrey Falconer</a>
+      I'll post an update when each of these lands.{" "}
+      <a href="/updates">Follow along here.</a> I don't spam.
     </p>
   </>
 );

--- a/website/src/content/types.ts
+++ b/website/src/content/types.ts
@@ -6,6 +6,7 @@ export interface PostMeta {
   description: string;
   date: string; // ISO 8601 format: YYYY-MM-DD
   author?: string;
+  authorUrl?: string;
   tags?: string[];
 }
 


### PR DESCRIPTION
(AI Generated)

## Summary

- Rewrote manifesto with four named sections (Problem, Pact, Solution, Believe), shorter sentences, empowering "Freed on your side" framing, and updated Go Deeper card descriptions
- Rewrote introducing-freed post in manifesto voice: punchy problem section, technical product details, first-person authorship attributed to Aubrey Falconer with link to personal site
- Added \`authorUrl\` to PostMeta type and rendered author byline as a link in PostContent
- Updated CONTRIBUTING.md opening and philosophy in manifesto tone
- Post page UX: share row above HR with Back to Updates on left, Share on X + Copy link on right, Copied! toast, pointer cursor, guillemet caret on both back links

## Test plan

- [ ] Manifesto renders all four sections with no em dashes or AI filler
- [ ] Go Deeper cards all link correctly and open in new tabs
- [ ] Introducing Freed post renders with Aubrey Falconer byline linked to AubreyFalconer.com
- [ ] Copy link shows Copied! toast and dismisses after 2 seconds
- [ ] Back to Updates link (top and bottom) uses ‹ caret and purple color
- [ ] Share on X prefills tweet with post title and URL