### PR TITLE
fix: open all How You Can Help links in new tab

### DIFF
--- a/website/src/content/posts/001-introducing-freed.tsx
+++ b/website/src/content/posts/001-introducing-freed.tsx
@@ -81,21 +81,21 @@ export default definePost(
     <ul>
       <li>
         <strong>
-          <a href="https://github.com/freed-project/freed">Star the repo</a>
+          <a href="https://github.com/freed-project/freed" target="_blank" rel="noopener noreferrer">Star the repo</a>
           <span className="mx-2">⭐</span>
         </strong>{" "}
         It signals that this matters and helps others find it.
       </li>
       <li>
         <strong>
-          <a href="https://app.freed.wtf">Try the PWA</a>
+          <a href="https://app.freed.wtf" target="_blank" rel="noopener noreferrer">Try the PWA</a>
           <span className="mx-2">📱</span>
         </strong>{" "}
         Add some RSS feeds and tell me what's broken.
       </li>
       <li>
         <strong>
-          <a href="https://github.com/freed-project/freed/blob/main/CONTRIBUTING.md">
+          <a href="https://github.com/freed-project/freed/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener noreferrer">
             Contribute
           </a>
           <span className="mx-2">🛠️</span>


### PR DESCRIPTION
(AI Generated)

## Summary

- Added \`target="_blank" rel="noopener noreferrer"\` to Star the repo, Try the PWA, and Contribute links in the introducing-freed post.

## Test plan

- [ ] All three links open in a new tab