### PR TITLE
docs: correct phase status for capture-x, save-for-later, and sync

### DIFF
--- a/docs/PHASE-2-CAPTURE-SKILLS.md
+++ b/docs/PHASE-2-CAPTURE-SKILLS.md
@@ -1,7 +1,9 @@
 # Phase 2: Capture Skills
 
-> **Status:** ✓ Complete  
+> **Status:** 🚧 In Progress  
 > **Dependencies:** Phase 1 (Foundation ✓)
+>
+> `capture-rss` is complete. `capture-x` core library is built but the OpenClaw skill wrapper is not yet fully integrated.
 
 ---
 
@@ -284,7 +286,7 @@ capture-rss recent [count]
 | 2.3  | Build GraphQL API client                             | ✓      |
 | 2.4  | Normalize tweets to FeedItem                         | ✓      |
 | 2.5  | Implement capture modes (mirror/whitelist/blacklist) | ✓      |
-| 2.6  | Create OpenClaw skill wrapper for X                  | ✓      |
+| 2.6  | Create OpenClaw skill wrapper for X                  | ☐      |
 | 2.7  | Create `@freed/capture-rss` package                  | ✓      |
 | 2.8  | Build RSS/Atom parser                                | ✓      |
 | 2.9  | Implement feed discovery                             | ✓      |

--- a/docs/PHASE-3-SAVE-FOR-LATER.md
+++ b/docs/PHASE-3-SAVE-FOR-LATER.md
@@ -1,7 +1,9 @@
 # Phase 3: Save for Later (`capture-save`)
 
-> **Status:** ✓ Complete  
-> **Dependencies:** Phase 1-2 (Capture layers ✓)
+> **Status:** Not Started  
+> **Dependencies:** Phase 1-2 (Capture layers)
+>
+> No implementation exists yet. The design below reflects the intended architecture.
 
 ---
 
@@ -201,14 +203,14 @@ Capture any URL to your Freed library with full article extraction.
 
 ## Tasks
 
-| Task | Description                                   | Complexity |
-| ---- | --------------------------------------------- | ---------- |
-| 3.1  | Create `@freed/capture-save` package scaffold | Low        |
-| 3.2  | Implement URL metadata extraction             | Medium     |
-| 3.3  | Implement Readability-style content parser    | Medium     |
-| 3.4  | Normalize to FeedItem with PreservedContent   | Low        |
-| 3.5  | Create OpenClaw skill wrapper                 | Low        |
-| 3.6  | CLI commands (add, list, search)              | Medium     |
+| Task | Description                                   | Status | Complexity |
+| ---- | --------------------------------------------- | ------ | ---------- |
+| 3.1  | Create `@freed/capture-save` package scaffold | ☐      | Low        |
+| 3.2  | Implement URL metadata extraction             | ☐      | Medium     |
+| 3.3  | Implement Readability-style content parser    | ☐      | Medium     |
+| 3.4  | Normalize to FeedItem with PreservedContent   | ☐      | Low        |
+| 3.5  | Create OpenClaw skill wrapper                 | ☐      | Low        |
+| 3.6  | CLI commands (add, list, search)              | ☐      | Medium     |
 
 ---
 

--- a/docs/PHASE-4-SYNC.md
+++ b/docs/PHASE-4-SYNC.md
@@ -3,7 +3,7 @@
 > **Status:** 🚧 In Progress
 > **Dependencies:** Phase 1-2 (Capture layers ✓)
 >
-> Local relay and GDrive/Dropbox cloud sync are working. iCloud sync and several secondary features are not yet complete.
+> Local relay, GDrive/Dropbox cloud sync, "Sync Now" button, and "Last synced" indicator are all working. iCloud sync is the remaining open item.
 
 ---
 
@@ -274,8 +274,8 @@ Each provider stores a single Automerge binary file. CRDT handles merge conflict
 | 4.8  | Dropbox sync integration              | ✓      | Low        |
 | 4.9  | iCloud sync integration               | ☐      | High       |
 | 4.10 | Sync status observable                | ✓      | Low        |
-| 4.11 | "Last synced" UI indicator            | ☐      | Low        |
-| 4.12 | Manual "Sync now" button              | ☐      | Low        |
+| 4.11 | "Last synced" UI indicator            | ✓      | Low        |
+| 4.12 | Manual "Sync now" button              | ✓      | Low        |
 
 ---
 
@@ -290,8 +290,6 @@ Each provider stores a single Automerge binary file. CRDT handles merge conflict
 - [x] PWA falls back to cloud sync when away from home (GDrive + Dropbox PKCE OAuth, Automerge merge-upload)
 - [x] At least one cloud provider works — GDrive and Dropbox both confirmed working on app.freed.wtf
 - [ ] iCloud sync integration
-- [ ] "Last synced" UI indicator
-- [ ] Manual "Sync now" button
 
 ---
 

--- a/docs/PHASE-4-SYNC.md
+++ b/docs/PHASE-4-SYNC.md
@@ -1,7 +1,9 @@
 # Phase 4: Sync Layer
 
-> **Status:** ✅ Complete
-> **Dependencies:** Phase 1-2 (Capture layers ✓), Phase 3 (Save for Later ✓)
+> **Status:** 🚧 In Progress
+> **Dependencies:** Phase 1-2 (Capture layers ✓)
+>
+> Local relay and GDrive/Dropbox cloud sync are working. iCloud sync and several secondary features are not yet complete.
 
 ---
 
@@ -260,20 +262,20 @@ Each provider stores a single Automerge binary file. CRDT handles merge conflict
 
 ## Tasks
 
-| Task | Description                           | Complexity |
-| ---- | ------------------------------------- | ---------- |
-| 4.1  | Create `@freed/sync` package scaffold | Low        |
-| 4.2  | Implement IndexedDB storage adapter   | Medium     |
-| 4.3  | Implement Filesystem storage adapter  | Medium     |
-| 4.4  | WebSocket relay server                | Medium     |
-| 4.5  | PWA WebSocket client + auto-connect   | Medium     |
-| 4.6  | QR code pairing flow                  | Low        |
-| 4.7  | Google Drive sync integration         | Medium     |
-| 4.8  | Dropbox sync integration              | Low        |
-| 4.9  | iCloud sync integration               | High       |
-| 4.10 | Sync status observable                | Low        |
-| 4.11 | "Last synced" UI indicator            | Low        |
-| 4.12 | Manual "Sync now" button              | Low        |
+| Task | Description                           | Status | Complexity |
+| ---- | ------------------------------------- | ------ | ---------- |
+| 4.1  | Create `@freed/sync` package scaffold | ✓      | Low        |
+| 4.2  | Implement IndexedDB storage adapter   | ✓      | Medium     |
+| 4.3  | Implement Filesystem storage adapter  | ✓      | Medium     |
+| 4.4  | WebSocket relay server                | ✓      | Medium     |
+| 4.5  | PWA WebSocket client + auto-connect   | ✓      | Medium     |
+| 4.6  | QR code pairing flow                  | ✓      | Low        |
+| 4.7  | Google Drive sync integration         | ✓      | Medium     |
+| 4.8  | Dropbox sync integration              | ✓      | Low        |
+| 4.9  | iCloud sync integration               | ☐      | High       |
+| 4.10 | Sync status observable                | ✓      | Low        |
+| 4.11 | "Last synced" UI indicator            | ☐      | Low        |
+| 4.12 | Manual "Sync now" button              | ☐      | Low        |
 
 ---
 
@@ -287,6 +289,9 @@ Each provider stores a single Automerge binary file. CRDT handles merge conflict
 - [x] Sync connection status observable (`onStatusChange` listener in sync.ts)
 - [x] PWA falls back to cloud sync when away from home (GDrive + Dropbox PKCE OAuth, Automerge merge-upload)
 - [x] At least one cloud provider works — GDrive and Dropbox both confirmed working on app.freed.wtf
+- [ ] iCloud sync integration
+- [ ] "Last synced" UI indicator
+- [ ] Manual "Sync now" button
 
 ---
 

--- a/website/src/app/roadmap/RoadmapContent.tsx
+++ b/website/src/app/roadmap/RoadmapContent.tsx
@@ -463,8 +463,8 @@ const phases: Phase[] = [
     number: 2,
     title: "Capture Skills",
     description:
-      "capture-x and capture-rss packages with OpenClaw skill wrappers.",
-    status: "complete",
+      "RSS capture complete. X capture built; OpenClaw skill integration in progress.",
+    status: "current",
     planLink:
       "https://github.com/freed-project/freed/blob/main/docs/PHASE-2-CAPTURE-SKILLS.md",
   },
@@ -473,7 +473,7 @@ const phases: Phase[] = [
     title: "Save for Later",
     description:
       "URL capture with Readability extraction. Capture any article, thread, or page.",
-    status: "complete",
+    status: "upcoming",
     planLink:
       "https://github.com/freed-project/freed/blob/main/docs/PHASE-3-SAVE-FOR-LATER.md",
   },
@@ -481,8 +481,8 @@ const phases: Phase[] = [
     number: 4,
     title: "Sync Layer",
     description:
-      "Local WebSocket relay + cloud backup. Automerge CRDT for conflict-free sync.",
-    status: "complete",
+      "Local relay and GDrive/Dropbox sync working. iCloud and remaining UI polish in progress.",
+    status: "current",
     planLink:
       "https://github.com/freed-project/freed/blob/main/docs/PHASE-4-SYNC.md",
   },


### PR DESCRIPTION
(AI Generated)

## Summary

- **Phase 2 (Capture Skills):** `complete` → `in progress`. `capture-rss` is done. `capture-x` core library is built but the OpenClaw skill wrapper (task 2.6) is not yet complete.
- **Phase 3 (Save for Later):** `complete` → `not started`. Nothing is implemented yet; the doc now clearly states this and marks all tasks as pending.
- **Phase 4 (Sync Layer):** `complete` → `in progress`. Local relay, GDrive, and Dropbox are working. iCloud sync, "Last synced" UI, and "Sync now" button are outstanding; success criteria and task table updated accordingly.
- **Roadmap page:** Phase statuses and descriptions updated to match.