### PR TITLE
docs: sync roadmap with phase doc statuses

### DIFF
--- a/docs/PHASE-1-FOUNDATION.md
+++ b/docs/PHASE-1-FOUNDATION.md
@@ -1,6 +1,6 @@
 # Phase 1: Foundation
 
-> **Status:** 🚧 Nearly Complete  
+> **Status:** ✅ Complete  
 > **Dependencies:** None
 
 ---

--- a/website/src/app/roadmap/RoadmapContent.tsx
+++ b/website/src/app/roadmap/RoadmapContent.tsx
@@ -501,7 +501,7 @@ const phases: Phase[] = [
     title: "PWA Reader",
     description:
       "Mobile companion app. Read your feed anywhere, synced to your desktop.",
-    status: "current",
+    status: "complete",
     planLink:
       "https://github.com/freed-project/freed/blob/main/docs/PHASE-6-PWA.md",
   },
@@ -543,8 +543,9 @@ const phases: Phase[] = [
   },
   {
     number: 11,
-    title: "OpenClaw Integration 🦞",
-    description: "Headless capture for power users. Run Freed without the GUI.",
+    title: "OpenClaw + Omi 🦞",
+    description:
+      "Headless capture for power users via OpenClaw CLI. Plus bidirectional Omi wearable integration: say \"Hey Freed\" to save a voice note, and your reading activity enriches Omi's memory.",
     status: "upcoming",
     planLink:
       "https://github.com/freed-project/freed/blob/main/docs/PHASE-11-OPENCLAW.md",


### PR DESCRIPTION
(AI Generated)

## Summary

- Phase 1 doc status updated to "✅ Complete" (all 9 tasks were already checked off, doc said "Nearly Complete")
- Phase 6 roadmap status bumped from "current" to "complete" (8/10 success criteria met; two remaining items are homescreen install testing and offline image cache, both noted as testing-pending in the doc, not blocked features)
- Phase 11 roadmap title updated from "OpenClaw Integration" to "OpenClaw + Omi" and description rewritten to cover both the headless CLI side and the bidirectional Omi wearable integration (Hey Freed voice saves + reading digest to Omi memory)

## Why it slipped

The Phase 11 doc was expanded to include a full Omi integration spec, but the corresponding roadmap entry was never updated. The other two were stale status lines that accumulated without a feature change to trigger the sync rule.