### PR TITLE
perf: fix UI freeze when entering reading mode

### DIFF
--- a/packages/desktop/src/lib/store.ts
+++ b/packages/desktop/src/lib/store.ts
@@ -96,6 +96,21 @@ interface AppState {
 }
 
 /**
+ * Shallow-compare two string-keyed number maps.
+ * Used to preserve object identity on count maps so Zustand selectors that
+ * subscribe to these objects don't trigger re-renders when values are unchanged.
+ */
+function shallowEqualRecord(
+  a: Record<string, number>,
+  b: Record<string, number>,
+): boolean {
+  const aKeys = Object.keys(a);
+  return (
+    aKeys.length === Object.keys(b).length && aKeys.every((k) => a[k] === b[k])
+  );
+}
+
+/**
  * Hydrate store state from Automerge document
  */
 function hydrateFromDoc(doc: FreedDoc): Partial<AppState> {
@@ -179,9 +194,21 @@ export const useAppStore = create<AppState>((set, get) => ({
       // caused by key-scheme changes (guid vs link priority).
       await docDeduplicateFeedItems();
 
-      // Subscribe to future changes (for sync)
+      // Subscribe to future changes (for sync).
+      // Reuse count map references when values haven't changed so Sidebar
+      // selectors don't trigger re-renders on unrelated mutations.
       subscribe((updatedDoc) => {
-        set(hydrateFromDoc(updatedDoc));
+        const next = hydrateFromDoc(updatedDoc);
+        const prev = get();
+        if (shallowEqualRecord(next.feedUnreadCounts!, prev.feedUnreadCounts))
+          next.feedUnreadCounts = prev.feedUnreadCounts;
+        if (shallowEqualRecord(next.feedTotalCounts!, prev.feedTotalCounts))
+          next.feedTotalCounts = prev.feedTotalCounts;
+        if (shallowEqualRecord(next.unreadCountByPlatform!, prev.unreadCountByPlatform))
+          next.unreadCountByPlatform = prev.unreadCountByPlatform;
+        if (shallowEqualRecord(next.itemCountByPlatform!, prev.itemCountByPlatform))
+          next.itemCountByPlatform = prev.itemCountByPlatform;
+        set(next);
       });
 
       // Load X auth state from storage

--- a/packages/pwa/src/lib/store.ts
+++ b/packages/pwa/src/lib/store.ts
@@ -30,6 +30,21 @@ interface AppState extends BaseAppState {
 }
 
 /**
+ * Shallow-compare two string-keyed number maps.
+ * Used to preserve object identity on count maps so Zustand selectors that
+ * subscribe to these objects don't trigger re-renders when values are unchanged.
+ */
+function shallowEqualRecord(
+  a: Record<string, number>,
+  b: Record<string, number>,
+): boolean {
+  const aKeys = Object.keys(a);
+  return (
+    aKeys.length === Object.keys(b).length && aKeys.every((k) => a[k] === b[k])
+  );
+}
+
+/**
  * Hydrate store state from Automerge document
  */
 function hydrateFromDoc(doc: FreedDoc): Partial<AppState> {
@@ -106,9 +121,21 @@ export const useAppStore = create<AppState>((set, get) => ({
       set({ isLoading: true });
       const doc = await initDoc();
 
-      // Subscribe to future changes (for sync)
+      // Subscribe to future changes (for sync).
+      // Reuse count map references when values haven't changed so Sidebar
+      // selectors don't trigger re-renders on unrelated mutations.
       subscribe((updatedDoc) => {
-        set(hydrateFromDoc(updatedDoc));
+        const next = hydrateFromDoc(updatedDoc);
+        const prev = get();
+        if (shallowEqualRecord(next.feedUnreadCounts!, prev.feedUnreadCounts))
+          next.feedUnreadCounts = prev.feedUnreadCounts;
+        if (shallowEqualRecord(next.feedTotalCounts!, prev.feedTotalCounts))
+          next.feedTotalCounts = prev.feedTotalCounts;
+        if (shallowEqualRecord(next.unreadCountByPlatform!, prev.unreadCountByPlatform))
+          next.unreadCountByPlatform = prev.unreadCountByPlatform;
+        if (shallowEqualRecord(next.itemCountByPlatform!, prev.itemCountByPlatform))
+          next.itemCountByPlatform = prev.itemCountByPlatform;
+        set(next);
       });
 
       // Hydrate initial state

--- a/packages/shared/src/ranking.ts
+++ b/packages/shared/src/ranking.ts
@@ -107,7 +107,12 @@ export function sortByPriority(items: FeedItem[]): FeedItem[] {
 }
 
 /**
- * Compute priorities for all items and return updated items
+ * Compute priorities for all items and return updated items.
+ *
+ * Preserves object identity for items whose priority score has not changed.
+ * This is critical for React.memo and useMemo to bail out correctly — if every
+ * item gets a new object reference on every call (even for unrelated mutations
+ * like markAsRead on a different item), every mounted card re-renders.
  */
 export function rankFeedItems(
   items: FeedItem[],
@@ -115,11 +120,11 @@ export function rankFeedItems(
 ): FeedItem[] {
   const now = Date.now();
 
-  return items.map((item) => ({
-    ...item,
-    priority: calculatePriority(item, preferences, now),
-    priorityComputedAt: now,
-  }));
+  return items.map((item) => {
+    const newPriority = calculatePriority(item, preferences, now);
+    if (item.priority === newPriority) return item;
+    return { ...item, priority: newPriority, priorityComputedAt: now };
+  });
 }
 
 /**

--- a/packages/ui/src/components/feed/ReaderView.tsx
+++ b/packages/ui/src/components/feed/ReaderView.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useMemo, useCallback } from "react";
 import { formatDistanceToNow } from "date-fns";
 import type { FeedItem as FeedItemType } from "@freed/shared";
 import { useAppStore, usePlatform, MACOS_TRAFFIC_LIGHT_INSET } from "../../context/PlatformContext.js";
@@ -28,7 +28,7 @@ export function ReaderView({ item, onClose }: ReaderViewProps) {
     intensity: storedDisplay.reading.focusIntensity,
   });
 
-  const toggleSaved = () => {
+  const toggleSaved = useCallback(() => {
     updateItem(item.globalId, {
       userState: {
         ...item.userState,
@@ -36,18 +36,18 @@ export function ReaderView({ item, onClose }: ReaderViewProps) {
         savedAt: item.userState.saved ? undefined : Date.now(),
       },
     });
-  };
+  }, [updateItem, item.globalId, item.userState]);
 
-  const toggleArchived = () => {
+  const toggleArchived = useCallback(() => {
     updateItem(item.globalId, {
       userState: {
         ...item.userState,
         archived: !item.userState.archived,
       },
     });
-  };
+  }, [updateItem, item.globalId, item.userState]);
 
-  const toggleFocus = () => {
+  const toggleFocus = useCallback(() => {
     setFocusOptions((prev) => {
       const next = { ...prev, enabled: !prev.enabled };
       updatePreferences({
@@ -58,14 +58,20 @@ export function ReaderView({ item, onClose }: ReaderViewProps) {
       });
       return next;
     });
-  };
+  }, [updatePreferences, storedDisplay]);
 
-  const hasContent = item.preservedContent?.html;
-  const timeAgo = formatDistanceToNow(item.publishedAt, { addSuffix: true });
+  const hasContent = !!item.preservedContent?.html;
+  const timeAgo = useMemo(
+    () => formatDistanceToNow(item.publishedAt, { addSuffix: true }),
+    [item.publishedAt],
+  );
 
-  const plainText = hasContent
-    ? htmlToText(item.preservedContent!.html)
-    : item.content.text;
+  // Parsing the HTML into plain text for focus mode is expensive - memoize it
+  // so repeated re-renders while the reader is open don't recreate a DOM node.
+  const plainText = useMemo(() => {
+    if (!item.preservedContent?.html) return item.content.text;
+    return htmlToText(item.preservedContent.html);
+  }, [item.preservedContent?.html, item.content.text]);
 
   return (
     <div className="fixed inset-0 z-50 bg-[#0a0a0a] overflow-auto">


### PR DESCRIPTION
(AI Generated)

## Problem

Clicking a feed item caused the UI to freeze - toolbar buttons wouldn't even hover. The culprit was a cascade triggered by \`markAsRead\`:

\`\`\`
markAsRead → applyChange → hydrateFromDoc → rankFeedItems
  → new object for EVERY item → all React.memo invalidated
  → entire virtualised list re-renders behind the reader overlay
\`\`\`

\`rankFeedItems\` unconditionally spread every item into a new object on every call, regardless of whether anything changed. With 1,000+ items and \`React.memo\` fully defeated, the render wave was long enough to block interaction.

## Fixes

### 1. Preserve object identity in \`rankFeedItems\` (\`packages/shared/src/ranking.ts\`)

Compute the new priority first; only allocate a new object when the score actually changed. For a typical \`markAsRead\` call, one item gets a new reference. Every other \`FeedItemRow\`/\`FeedItem\` memo bails out immediately.

### 2. Memoize expensive work in \`ReaderView\` (\`packages/ui/src/components/feed/ReaderView.tsx\`)

\`ReaderView\` subscribes to \`s.preferences.display\`, so it re-renders on every doc change while reading. Previously it created a throwaway DOM node and set \`innerHTML\` on every render (\`htmlToText\`), and recomputed \`formatDistanceToNow\` unconditionally. Both are now guarded by \`useMemo\`. Toggle handlers wrapped in \`useCallback\`.

### 3. Stabilise count map references in both stores (\`packages/pwa/src/lib/store.ts\`, \`packages/desktop/src/lib/store.ts\`)

\`hydrateFromDoc\` always allocated fresh \`Record<string, number>\` objects for the four count maps. Zustand uses \`Object.is\`, so \`Sidebar\` re-rendered on every doc mutation even when no counts changed. The subscriber now shallow-compares each map and reuses the previous reference when values are identical.

## Test Plan

- [ ] Click a feed item - reader opens immediately, no lag
- [ ] Toolbar buttons (Save, Archive, Focus mode) hover and respond instantly
- [ ] Toggle focus mode - no perceptible freeze on large feeds
- [ ] Mark all as read - Sidebar count updates correctly
- [ ] PWA and Desktop builds both compile clean