### PR TITLE
feat: build out the archive system end-to-end

### DIFF
--- a/packages/desktop/src/lib/automerge.ts
+++ b/packages/desktop/src/lib/automerge.ts
@@ -19,6 +19,9 @@ import {
   removeFeedItem,
   markAsRead,
   toggleSaved,
+  toggleArchived,
+  archiveAllReadUnsaved,
+  pruneArchivedItems,
   updatePreferences,
   updateLastSync,
 } from "@freed/shared/schema";
@@ -193,6 +196,27 @@ export async function docMarkAsRead(globalId: string): Promise<FreedDoc> {
 
 export async function docToggleSaved(globalId: string): Promise<FreedDoc> {
   return applyChange((doc) => toggleSaved(doc, globalId), "Toggle saved");
+}
+
+export async function docToggleArchived(globalId: string): Promise<FreedDoc> {
+  return applyChange((doc) => toggleArchived(doc, globalId), "Toggle archived");
+}
+
+export async function docArchiveAllReadUnsaved(
+  platform?: string,
+  feedUrl?: string,
+): Promise<FreedDoc> {
+  return applyChange(
+    (doc) => archiveAllReadUnsaved(doc, platform, feedUrl),
+    "Archive all read",
+  );
+}
+
+export async function docPruneArchivedItems(maxAgeMs?: number): Promise<FreedDoc> {
+  return applyChange(
+    (doc) => pruneArchivedItems(doc, maxAgeMs),
+    "Prune archived items",
+  );
 }
 
 export async function docUpdatePreferences(

--- a/packages/desktop/src/lib/store.ts
+++ b/packages/desktop/src/lib/store.ts
@@ -5,7 +5,7 @@
  */
 
 import { create } from "zustand";
-import type { FeedItem, UserPreferences, RssFeed } from "@freed/shared";
+import type { FeedItem, UserPreferences, RssFeed, FilterOptions } from "@freed/shared";
 import { createDefaultPreferences, rankFeedItems } from "@freed/shared";
 import {
   initDoc,
@@ -19,6 +19,9 @@ import {
   docMarkAsRead,
   docMarkAllAsRead,
   docToggleSaved,
+  docToggleArchived,
+  docArchiveAllReadUnsaved,
+  docPruneArchivedItems,
   docUpdatePreferences,
   docDeduplicateFeedItems,
   docHealUntitledFeedTitles,
@@ -26,14 +29,6 @@ import {
 import type { FreedDoc } from "@freed/shared/schema";
 import { loadStoredCookies, type XAuthState } from "./x-auth";
 
-// Filter options for the feed view
-interface FilterOptions {
-  platform?: string;
-  feedUrl?: string;
-  tags?: string[];
-  savedOnly?: boolean;
-  showArchived?: boolean;
-}
 
 // App state interface
 interface AppState {
@@ -93,6 +88,10 @@ interface AppState {
   setLoading: (loading: boolean) => void;
   setSyncing: (syncing: boolean) => void;
   setError: (error: string | null) => void;
+  /** Current full-text search query. Empty string means no search active. */
+  searchQuery: string;
+  /** Update the full-text search query. Empty string clears the search. */
+  setSearchQuery: (query: string) => void;
 }
 
 /**
@@ -126,8 +125,11 @@ function hydrateFromDoc(doc: FreedDoc): Partial<AppState> {
   const feedTotalCounts: Record<string, number> = {};
   const unreadCountByPlatform: Record<string, number> = {};
   const itemCountByPlatform: Record<string, number> = {};
+  const archivableCountByPlatform: Record<string, number> = {};
+  const archivableFeedCounts: Record<string, number> = {};
   let totalUnreadCount = 0;
   let totalItemCount = 0;
+  let totalArchivableCount = 0;
   for (const item of allItems) {
     if (item.userState.hidden || item.userState.archived) continue;
     totalItemCount++;
@@ -143,6 +145,13 @@ function hydrateFromDoc(doc: FreedDoc): Partial<AppState> {
         const url = item.rssSource.feedUrl;
         feedUnreadCounts[url] = (feedUnreadCounts[url] ?? 0) + 1;
       }
+    } else if (!item.userState.saved) {
+      totalArchivableCount++;
+      archivableCountByPlatform[item.platform] = (archivableCountByPlatform[item.platform] ?? 0) + 1;
+      if (item.rssSource) {
+        const url = item.rssSource.feedUrl;
+        archivableFeedCounts[url] = (archivableFeedCounts[url] ?? 0) + 1;
+      }
     }
   }
 
@@ -156,6 +165,9 @@ function hydrateFromDoc(doc: FreedDoc): Partial<AppState> {
     unreadCountByPlatform,
     totalItemCount,
     itemCountByPlatform,
+    totalArchivableCount,
+    archivableCountByPlatform,
+    archivableFeedCounts,
   };
 }
 
@@ -170,6 +182,9 @@ export const useAppStore = create<AppState>((set, get) => ({
   unreadCountByPlatform: {},
   totalItemCount: 0,
   itemCountByPlatform: {},
+  totalArchivableCount: 0,
+  archivableCountByPlatform: {},
+  archivableFeedCounts: {},
   xAuth: { isAuthenticated: false },
   isLoading: false,
   isSyncing: false,
@@ -177,6 +192,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   error: null,
   activeFilter: {},
   selectedItemId: null,
+  searchQuery: "",
 
   // Initialize from Automerge
   initialize: async () => {
@@ -193,6 +209,12 @@ export const useAppStore = create<AppState>((set, get) => ({
       // Run dedup migration — no-op when clean, removes phantom duplicates
       // caused by key-scheme changes (guid vs link priority).
       await docDeduplicateFeedItems();
+
+      // Prune archived items older than the configured threshold
+      const pruneDays = doc.preferences.display.archivePruneDays ?? 30;
+      if (pruneDays > 0) {
+        await docPruneArchivedItems(pruneDays * 24 * 60 * 60 * 1000);
+      }
 
       // Subscribe to future changes (for sync).
       // Reuse count map references when values haven't changed so Sidebar
@@ -253,6 +275,14 @@ export const useAppStore = create<AppState>((set, get) => ({
     await docToggleSaved(id);
   },
 
+  toggleArchived: async (id) => {
+    await docToggleArchived(id);
+  },
+
+  archiveAllReadUnsaved: async (platform, feedUrl) => {
+    await docArchiveAllReadUnsaved(platform, feedUrl);
+  },
+
   // Feed actions
   addFeed: async (feed) => {
     await docAddRssFeed(feed);
@@ -284,4 +314,5 @@ export const useAppStore = create<AppState>((set, get) => ({
   setLoading: (isLoading) => set({ isLoading }),
   setSyncing: (isSyncing) => set({ isSyncing }),
   setError: (error) => set({ error }),
+  setSearchQuery: (searchQuery) => set({ searchQuery }),
 }));

--- a/packages/pwa/src/lib/automerge.ts
+++ b/packages/pwa/src/lib/automerge.ts
@@ -18,6 +18,9 @@ import {
   removeFeedItem,
   markAsRead,
   toggleSaved,
+  toggleArchived,
+  archiveAllReadUnsaved,
+  pruneArchivedItems,
   updatePreferences,
   updateLastSync,
 } from "@freed/shared/schema";
@@ -177,6 +180,27 @@ export async function docMarkAsRead(globalId: string): Promise<FreedDoc> {
 
 export async function docToggleSaved(globalId: string): Promise<FreedDoc> {
   return applyChange((doc) => toggleSaved(doc, globalId), "Toggle saved");
+}
+
+export async function docToggleArchived(globalId: string): Promise<FreedDoc> {
+  return applyChange((doc) => toggleArchived(doc, globalId), "Toggle archived");
+}
+
+export async function docArchiveAllReadUnsaved(
+  platform?: string,
+  feedUrl?: string,
+): Promise<FreedDoc> {
+  return applyChange(
+    (doc) => archiveAllReadUnsaved(doc, platform, feedUrl),
+    "Archive all read",
+  );
+}
+
+export async function docPruneArchivedItems(maxAgeMs?: number): Promise<FreedDoc> {
+  return applyChange(
+    (doc) => pruneArchivedItems(doc, maxAgeMs),
+    "Prune archived items",
+  );
 }
 
 export async function docUpdatePreferences(

--- a/packages/pwa/src/lib/ranking.test.ts
+++ b/packages/pwa/src/lib/ranking.test.ts
@@ -255,8 +255,9 @@ describe("filterFeedItems", () => {
     expect(result.find((i) => i.globalId === "archived")).toBeUndefined();
   });
 
-  it("includes archived items when showArchived is true", () => {
-    const result = filterFeedItems(items, { showArchived: true });
+  it("shows only archived items when archivedOnly is true", () => {
+    const result = filterFeedItems(items, { archivedOnly: true });
+    expect(result.every((i) => i.userState.archived)).toBe(true);
     expect(result.find((i) => i.globalId === "archived")).toBeDefined();
   });
 

--- a/packages/pwa/src/lib/store.ts
+++ b/packages/pwa/src/lib/store.ts
@@ -19,6 +19,9 @@ import {
   docMarkAsRead,
   docMarkAllAsRead,
   docToggleSaved,
+  docToggleArchived,
+  docArchiveAllReadUnsaved,
+  docPruneArchivedItems,
   docUpdatePreferences,
 } from "./automerge";
 import type { FreedDoc } from "@freed/shared/schema";
@@ -61,8 +64,11 @@ function hydrateFromDoc(doc: FreedDoc): Partial<AppState> {
   const feedTotalCounts: Record<string, number> = {};
   const unreadCountByPlatform: Record<string, number> = {};
   const itemCountByPlatform: Record<string, number> = {};
+  const archivableCountByPlatform: Record<string, number> = {};
+  const archivableFeedCounts: Record<string, number> = {};
   let totalUnreadCount = 0;
   let totalItemCount = 0;
+  let totalArchivableCount = 0;
   for (const item of allItems) {
     if (item.userState.hidden || item.userState.archived) continue;
     totalItemCount++;
@@ -78,6 +84,14 @@ function hydrateFromDoc(doc: FreedDoc): Partial<AppState> {
         const url = item.rssSource.feedUrl;
         feedUnreadCounts[url] = (feedUnreadCounts[url] ?? 0) + 1;
       }
+    } else if (!item.userState.saved) {
+      // Read and not saved: eligible for batch archive
+      totalArchivableCount++;
+      archivableCountByPlatform[item.platform] = (archivableCountByPlatform[item.platform] ?? 0) + 1;
+      if (item.rssSource) {
+        const url = item.rssSource.feedUrl;
+        archivableFeedCounts[url] = (archivableFeedCounts[url] ?? 0) + 1;
+      }
     }
   }
 
@@ -91,6 +105,9 @@ function hydrateFromDoc(doc: FreedDoc): Partial<AppState> {
     unreadCountByPlatform,
     totalItemCount,
     itemCountByPlatform,
+    totalArchivableCount,
+    archivableCountByPlatform,
+    archivableFeedCounts,
   };
 }
 
@@ -105,6 +122,9 @@ export const useAppStore = create<AppState>((set, get) => ({
   unreadCountByPlatform: {},
   totalItemCount: 0,
   itemCountByPlatform: {},
+  totalArchivableCount: 0,
+  archivableCountByPlatform: {},
+  archivableFeedCounts: {},
   syncConnected: false,
   isLoading: false,
   isSyncing: false,
@@ -112,6 +132,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   error: null,
   activeFilter: {},
   selectedItemId: null,
+  searchQuery: "",
 
   // Initialize from Automerge
   initialize: async () => {
@@ -120,6 +141,12 @@ export const useAppStore = create<AppState>((set, get) => ({
     try {
       set({ isLoading: true });
       const doc = await initDoc();
+
+      // Prune archived items older than the configured threshold
+      const pruneDays = doc.preferences.display.archivePruneDays ?? 30;
+      if (pruneDays > 0) {
+        await docPruneArchivedItems(pruneDays * 24 * 60 * 60 * 1000);
+      }
 
       // Subscribe to future changes (for sync).
       // Reuse count map references when values haven't changed so Sidebar
@@ -173,6 +200,14 @@ export const useAppStore = create<AppState>((set, get) => ({
     await docToggleSaved(id);
   },
 
+  toggleArchived: async (id) => {
+    await docToggleArchived(id);
+  },
+
+  archiveAllReadUnsaved: async (platform, feedUrl) => {
+    await docArchiveAllReadUnsaved(platform, feedUrl);
+  },
+
   // Feed actions
   addFeed: async (feed) => {
     await docAddRssFeed(feed);
@@ -204,4 +239,5 @@ export const useAppStore = create<AppState>((set, get) => ({
   setLoading: (isLoading) => set({ isLoading }),
   setSyncing: (isSyncing) => set({ isSyncing }),
   setError: (error) => set({ error }),
+  setSearchQuery: (searchQuery) => set({ searchQuery }),
 }));

--- a/packages/shared/src/ranking.ts
+++ b/packages/shared/src/ranking.ts
@@ -134,7 +134,8 @@ export function filterFeedItems(
   items: FeedItem[],
   options: {
     showHidden?: boolean;
-    showArchived?: boolean;
+    /** Show only archived items (the Archived view). Mutually exclusive with normal feed. */
+    archivedOnly?: boolean;
     platform?: string;
     tags?: string[];
     savedOnly?: boolean;
@@ -144,8 +145,12 @@ export function filterFeedItems(
     // Filter hidden unless explicitly showing
     if (!options.showHidden && item.userState.hidden) return false;
 
-    // Filter archived unless explicitly showing
-    if (!options.showArchived && item.userState.archived) return false;
+    // Archived view shows only archived; normal feed excludes archived
+    if (options.archivedOnly) {
+      if (!item.userState.archived) return false;
+    } else {
+      if (item.userState.archived) return false;
+    }
 
     // Filter by platform
     if (options.platform && item.platform !== options.platform) return false;

--- a/packages/shared/src/schema.ts
+++ b/packages/shared/src/schema.ts
@@ -127,6 +127,80 @@ export function markAsRead(doc: FreedDoc, globalId: string): void {
 }
 
 /**
+ * Toggle archived status for a feed item, maintaining the archivedAt timestamp.
+ *
+ * @param doc - The Automerge document (mutable within A.change)
+ * @param globalId - The item's global ID
+ */
+export function toggleArchived(doc: FreedDoc, globalId: string): void {
+  const item = doc.feedItems[globalId];
+  if (!item) return;
+  if (item.userState.archived) {
+    item.userState.archived = false;
+    delete (item.userState as unknown as Record<string, unknown>).archivedAt;
+  } else {
+    item.userState.archived = true;
+    item.userState.archivedAt = Date.now();
+  }
+}
+
+/**
+ * Archive all read, non-saved items — optionally scoped to a platform or feed.
+ * Skips items already archived, hidden, or saved.
+ *
+ * @param doc - The Automerge document (mutable within A.change)
+ * @param platform - Optional platform filter (e.g. "rss", "x")
+ * @param feedUrl - Optional RSS feed URL filter
+ */
+export function archiveAllReadUnsaved(
+  doc: FreedDoc,
+  platform?: string,
+  feedUrl?: string,
+): number {
+  const now = Date.now();
+  let count = 0;
+  for (const item of Object.values(doc.feedItems)) {
+    if (item.userState.archived) continue;
+    if (item.userState.hidden) continue;
+    if (item.userState.saved) continue;
+    if (!item.userState.readAt) continue;
+    if (platform && item.platform !== platform) continue;
+    if (feedUrl && item.rssSource?.feedUrl !== feedUrl) continue;
+    item.userState.archived = true;
+    item.userState.archivedAt = now;
+    count++;
+  }
+  return count;
+}
+
+/**
+ * Delete archived items older than maxAgeMs. Saved items are never deleted.
+ * Items archived before archivedAt was introduced (no timestamp) are skipped.
+ *
+ * @param doc - The Automerge document (mutable within A.change)
+ * @param maxAgeMs - Max age in milliseconds (default: 30 days)
+ * @returns Number of items deleted
+ */
+export function pruneArchivedItems(
+  doc: FreedDoc,
+  maxAgeMs: number = 30 * 24 * 60 * 60 * 1000,
+): number {
+  if (maxAgeMs <= 0) return 0;
+  const cutoff = Date.now() - maxAgeMs;
+  let pruned = 0;
+  for (const [id, item] of Object.entries(doc.feedItems)) {
+    if (!item.userState.archived) continue;
+    if (item.userState.saved) continue;
+    const { archivedAt } = item.userState;
+    if (archivedAt !== undefined && archivedAt < cutoff) {
+      delete doc.feedItems[id];
+      pruned++;
+    }
+  }
+  return pruned;
+}
+
+/**
  * Toggle bookmark status for a feed item
  *
  * @param doc - The Automerge document (mutable within A.change)

--- a/packages/shared/src/store-types.ts
+++ b/packages/shared/src/store-types.ts
@@ -16,7 +16,8 @@ export interface FilterOptions {
   feedUrl?: string;
   tags?: string[];
   savedOnly?: boolean;
-  showArchived?: boolean;
+  /** Navigate to the Archived view - shows only archived items. */
+  archivedOnly?: boolean;
 }
 
 /**
@@ -43,6 +44,12 @@ export interface BaseAppState {
   totalItemCount: number;
   /** Total visible item count bucketed by platform. */
   itemCountByPlatform: Record<string, number>;
+  /** Count of archivable items (read, non-saved, non-archived) across all platforms. */
+  totalArchivableCount: number;
+  /** Archivable count bucketed by platform. */
+  archivableCountByPlatform: Record<string, number>;
+  /** Archivable count bucketed by RSS feed URL. */
+  archivableFeedCounts: Record<string, number>;
 
   // UI state
   isLoading: boolean;
@@ -61,6 +68,9 @@ export interface BaseAppState {
   markAsRead: (id: string) => Promise<void>;
   markAllAsRead: (platform?: string) => Promise<void>;
   toggleSaved: (id: string) => Promise<void>;
+  toggleArchived: (id: string) => Promise<void>;
+  /** Archive all read, non-saved items in the current view. */
+  archiveAllReadUnsaved: (platform?: string, feedUrl?: string) => Promise<void>;
 
   // Feed actions
   addFeed: (feed: RssFeed) => Promise<void>;
@@ -78,6 +88,10 @@ export interface BaseAppState {
   setLoading: (loading: boolean) => void;
   setSyncing: (syncing: boolean) => void;
   setError: (error: string | null) => void;
+  /** Current full-text search query. Empty string means no search active. */
+  searchQuery: string;
+  /** Update the full-text search query. Empty string clears the search. */
+  setSearchQuery: (query: string) => void;
 }
 
 /**

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -149,6 +149,9 @@ export interface UserState {
   /** Archived (removed from active queue, kept in library) */
   archived: boolean;
 
+  /** When item was archived (Unix ms) — used for 30-day pruning */
+  archivedAt?: number;
+
   /** User-assigned tags */
   tags: string[];
 
@@ -403,6 +406,9 @@ export interface DisplayPreferences {
 
   /** Sidebar width in pixels (default: 256, min: 180, max: 480) */
   sidebarWidth?: number;
+
+  /** Days to keep archived items before pruning (default: 30, 0 = never prune) */
+  archivePruneDays: number;
 }
 
 /**
@@ -469,6 +475,7 @@ export function createDefaultPreferences(): UserPreferences {
         focusMode: false,
         focusIntensity: "normal",
       },
+      archivePruneDays: 30,
     },
     xCapture: {
       mode: "mirror", // Default: capture from everyone you follow

--- a/packages/ui/src/components/feed/FeedItem.tsx
+++ b/packages/ui/src/components/feed/FeedItem.tsx
@@ -1,4 +1,4 @@
-import { memo, type ReactNode } from "react";
+import { memo, useRef, useState, type ReactNode } from "react";
 import { formatDistanceToNow } from "date-fns";
 import type { FeedItem as FeedItemType } from "@freed/shared";
 import { RssIcon, FacebookIcon, InstagramIcon, YoutubeIcon, RedditIcon, GithubIcon, MastodonIcon, BookmarkIcon } from "../icons.js";
@@ -10,6 +10,7 @@ interface FeedItemProps {
   focused?: boolean;
   onMouseEnter?: () => void;
   onSave?: (e: React.MouseEvent) => void;
+  onArchive?: (e: React.MouseEvent) => void;
 }
 
 const cls = "w-3.5 h-3.5";
@@ -26,6 +27,8 @@ const platformIcons: Record<string, ReactNode> = {
   saved: <BookmarkIcon className={cls} />,
 };
 
+const SWIPE_THRESHOLD = 72;
+
 export const FeedItem = memo(function FeedItem({
   item,
   onClick,
@@ -33,118 +36,206 @@ export const FeedItem = memo(function FeedItem({
   focused = false,
   onMouseEnter,
   onSave,
+  onArchive,
 }: FeedItemProps) {
   const timeAgo = formatDistanceToNow(item.publishedAt, { addSuffix: true });
   const platformIcon = platformIcons[item.platform] ?? <span className="text-xs">📄</span>;
 
+  // Swipe-to-archive state (mobile only)
+  const [swipeX, setSwipeX] = useState(0);
+  const touchStartX = useRef(0);
+  const touchStartY = useRef(0);
+  const swipeLocked = useRef<"horizontal" | "vertical" | null>(null);
+
+  const handleTouchStart = (e: React.TouchEvent) => {
+    touchStartX.current = e.touches[0].clientX;
+    touchStartY.current = e.touches[0].clientY;
+    swipeLocked.current = null;
+  };
+
+  const handleTouchMove = (e: React.TouchEvent) => {
+    const dx = e.touches[0].clientX - touchStartX.current;
+    const dy = e.touches[0].clientY - touchStartY.current;
+
+    if (!swipeLocked.current) {
+      // Determine swipe axis on first meaningful move
+      if (Math.abs(dx) < 4 && Math.abs(dy) < 4) return;
+      swipeLocked.current = Math.abs(dx) > Math.abs(dy) ? "horizontal" : "vertical";
+    }
+
+    if (swipeLocked.current === "vertical") return;
+
+    // Only track leftward swipe
+    if (dx < 0 && onArchive) {
+      e.preventDefault();
+      setSwipeX(Math.max(dx, -SWIPE_THRESHOLD * 1.4));
+    }
+  };
+
+  const handleTouchEnd = (e: React.TouchEvent) => {
+    if (swipeLocked.current === "horizontal" && swipeX < -SWIPE_THRESHOLD && onArchive) {
+      onArchive(e as unknown as React.MouseEvent);
+    }
+    setSwipeX(0);
+    swipeLocked.current = null;
+  };
+
+  const swipeProgress = Math.min(Math.abs(swipeX) / SWIPE_THRESHOLD, 1);
+  const pastThreshold = swipeX < -SWIPE_THRESHOLD;
+
   return (
-    <article
-      className={`feed-card group cursor-pointer active:scale-[0.99] transition-transform ${focused ? "ring-2 ring-[#8b5cf6]/60 ring-inset" : ""}`}
-      onClick={onClick}
-      onMouseEnter={onMouseEnter}
-      role="button"
-      tabIndex={0}
-      onKeyDown={(e) => e.key === "Enter" && onClick?.()}
-    >
-      {/* Author row */}
-      <div className="flex items-center gap-3 mb-3">
-        {item.author.avatarUrl ? (
-          <img
-            src={item.author.avatarUrl}
-            alt=""
-            loading="lazy"
-            decoding="async"
-            className="w-10 h-10 rounded-full bg-white/5 ring-1 ring-white/10 shrink-0"
-          />
-        ) : (
-          <div className="w-10 h-10 rounded-full bg-gradient-to-br from-[#3b82f6] to-[#8b5cf6] flex items-center justify-center font-medium shrink-0 text-lg">
-            {item.author.displayName[0]?.toUpperCase() || "?"}
+    <div className="relative overflow-hidden rounded-2xl">
+      {/* Archive action revealed by swipe */}
+      {onArchive && (
+        <div
+          className="absolute inset-y-0 right-0 flex items-center justify-end pr-5 rounded-2xl transition-colors"
+          style={{
+            width: `${Math.abs(swipeX) + 16}px`,
+            backgroundColor: pastThreshold ? "rgb(34 197 94 / 0.25)" : "rgb(34 197 94 / 0.12)",
+          }}
+          aria-hidden
+        >
+          <svg
+            className="w-5 h-5 text-green-400 transition-transform"
+            style={{ transform: `scale(${0.7 + swipeProgress * 0.3})`, opacity: swipeProgress }}
+            fill="none" viewBox="0 0 24 24" stroke="currentColor"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+          </svg>
+        </div>
+      )}
+
+      <article
+        className={`feed-card group cursor-pointer active:scale-[0.99] transition-transform ${focused ? "ring-2 ring-[#8b5cf6]/60 ring-inset" : ""}`}
+        style={{
+          transform: swipeX !== 0 ? `translateX(${swipeX}px)` : undefined,
+          transition: swipeX === 0 ? "transform 0.25s ease" : undefined,
+          willChange: swipeX !== 0 ? "transform" : undefined,
+        }}
+        onClick={onClick}
+        onMouseEnter={onMouseEnter}
+        onTouchStart={onArchive ? handleTouchStart : undefined}
+        onTouchMove={onArchive ? handleTouchMove : undefined}
+        onTouchEnd={onArchive ? handleTouchEnd : undefined}
+        role="button"
+        tabIndex={0}
+        onKeyDown={(e) => e.key === "Enter" && onClick?.()}
+      >
+        {/* Author row */}
+        <div className="flex items-center gap-3 mb-3">
+          {item.author.avatarUrl ? (
+            <img
+              src={item.author.avatarUrl}
+              alt=""
+              loading="lazy"
+              decoding="async"
+              className="w-10 h-10 rounded-full bg-white/5 ring-1 ring-white/10 shrink-0"
+            />
+          ) : (
+            <div className="w-10 h-10 rounded-full bg-gradient-to-br from-[#3b82f6] to-[#8b5cf6] flex items-center justify-center font-medium shrink-0 text-lg">
+              {item.author.displayName[0]?.toUpperCase() || "?"}
+            </div>
+          )}
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2 flex-wrap">
+              <span className="font-medium truncate">{item.author.displayName}</span>
+              <span className="text-[#71717a] text-sm">@{item.author.handle}</span>
+            </div>
+            <div className="flex items-center gap-2 text-xs text-[#71717a]">
+              <span>{platformIcon}</span>
+              <span>{timeAgo}</span>
+              {item.preservedContent?.readingTime && (
+                <>
+                  <span>•</span>
+                  <span>{item.preservedContent.readingTime} min</span>
+                </>
+              )}
+            </div>
           </div>
-        )}
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-2 flex-wrap">
-            <span className="font-medium truncate">{item.author.displayName}</span>
-            <span className="text-[#71717a] text-sm">@{item.author.handle}</span>
-          </div>
-          <div className="flex items-center gap-2 text-xs text-[#71717a]">
-            <span>{platformIcon}</span>
-            <span>{timeAgo}</span>
-            {item.preservedContent?.readingTime && (
-              <>
-                <span>•</span>
-                <span>{item.preservedContent.readingTime} min</span>
-              </>
+
+          {/* Action buttons — shown on hover (desktop) */}
+          <div className="flex items-center gap-0.5 shrink-0">
+            {onSave && (
+              <button
+                onClick={onSave}
+                title={item.userState.saved ? "Remove bookmark" : "Bookmark"}
+                className={`p-1.5 rounded-lg transition-colors ${
+                  item.userState.saved
+                    ? "text-[#8b5cf6]"
+                    : "text-[#52525b] hover:text-[#8b5cf6] opacity-0 group-hover:opacity-100"
+                }`}
+              >
+                <svg className="w-4 h-4" fill={item.userState.saved ? "currentColor" : "none"} viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
+                </svg>
+              </button>
+            )}
+
+            {onArchive && (
+              <button
+                onClick={onArchive}
+                title="Archive"
+                className="p-1.5 rounded-lg transition-colors text-[#52525b] hover:text-green-400 opacity-0 group-hover:opacity-100"
+              >
+                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                </svg>
+              </button>
             )}
           </div>
         </div>
 
-        {onSave && (
-          <button
-            onClick={onSave}
-            title={item.userState.saved ? "Remove bookmark" : "Bookmark"}
-            className={`p-1.5 rounded-lg transition-colors flex-shrink-0 ${
-              item.userState.saved
-                ? "text-[#8b5cf6]"
-                : "text-[#52525b] hover:text-[#8b5cf6] opacity-0 group-hover:opacity-100"
-            }`}
-          >
-            <svg className="w-4 h-4" fill={item.userState.saved ? "currentColor" : "none"} viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
-            </svg>
-          </button>
+        {item.content.linkPreview?.title && (
+          <h3 className="font-semibold mb-1.5 line-clamp-2 leading-snug text-lg">
+            {item.content.linkPreview.title}
+          </h3>
         )}
-      </div>
 
-      {item.content.linkPreview?.title && (
-        <h3 className="font-semibold mb-1.5 line-clamp-2 leading-snug text-lg">
-          {item.content.linkPreview.title}
-        </h3>
-      )}
+        {item.content.text && (
+          <p className="text-[#a1a1aa] leading-relaxed line-clamp-3 mb-3">
+            {item.content.text}
+          </p>
+        )}
 
-      {item.content.text && (
-        <p className="text-[#a1a1aa] leading-relaxed line-clamp-3 mb-3">
-          {item.content.text}
-        </p>
-      )}
+        {item.content.mediaUrls.length > 0 && (
+          <div className="mt-3 rounded-xl overflow-hidden ring-1 ring-white/5">
+            <img
+              src={item.content.mediaUrls[0]}
+              alt=""
+              loading="lazy"
+              decoding="async"
+              className="w-full h-48 sm:h-56 object-cover bg-white/5"
+            />
+          </div>
+        )}
 
-      {item.content.mediaUrls.length > 0 && (
-        <div className="mt-3 rounded-xl overflow-hidden ring-1 ring-white/5">
-          <img
-            src={item.content.mediaUrls[0]}
-            alt=""
-            loading="lazy"
-            decoding="async"
-            className="w-full h-48 sm:h-56 object-cover bg-white/5"
-          />
-        </div>
-      )}
+        {showEngagement && item.engagement && (
+          <div className="mt-2 flex items-center gap-4 text-xs text-[#52525b]">
+            {item.engagement.likes !== undefined && (
+              <span title="Likes">♥ {item.engagement.likes.toLocaleString()}</span>
+            )}
+            {item.engagement.reposts !== undefined && (
+              <span title="Reposts">↺ {item.engagement.reposts.toLocaleString()}</span>
+            )}
+            {item.engagement.comments !== undefined && (
+              <span title="Comments">💬 {item.engagement.comments.toLocaleString()}</span>
+            )}
+          </div>
+        )}
 
-      {showEngagement && item.engagement && (
-        <div className="mt-2 flex items-center gap-4 text-xs text-[#52525b]">
-          {item.engagement.likes !== undefined && (
-            <span title="Likes">♥ {item.engagement.likes.toLocaleString()}</span>
-          )}
-          {item.engagement.reposts !== undefined && (
-            <span title="Reposts">↺ {item.engagement.reposts.toLocaleString()}</span>
-          )}
-          {item.engagement.comments !== undefined && (
-            <span title="Comments">💬 {item.engagement.comments.toLocaleString()}</span>
-          )}
-        </div>
-      )}
-
-      {item.userState.tags.length > 0 && (
-        <div className="mt-3 flex flex-wrap gap-2">
-          {item.userState.tags.map((tag) => (
-            <span
-              key={tag}
-              className="px-2.5 py-1 text-xs rounded-full bg-[#8b5cf6]/20 text-[#8b5cf6]"
-            >
-              {tag}
-            </span>
-          ))}
-        </div>
-      )}
-    </article>
+        {item.userState.tags.length > 0 && (
+          <div className="mt-3 flex flex-wrap gap-2">
+            {item.userState.tags.map((tag) => (
+              <span
+                key={tag}
+                className="px-2.5 py-1 text-xs rounded-full bg-[#8b5cf6]/20 text-[#8b5cf6]"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        )}
+      </article>
+    </div>
   );
 });

--- a/packages/ui/src/components/feed/FeedList.tsx
+++ b/packages/ui/src/components/feed/FeedList.tsx
@@ -15,6 +15,8 @@ interface FeedListProps {
   hasFeedsSubscribed?: boolean;
   /** Called when user bookmarks/unbookmarks an item */
   onItemSave?: (item: FeedItemType) => void;
+  /** Called when user archives an item from the feed card */
+  onItemArchive?: (item: FeedItemType) => void;
 }
 
 /**
@@ -30,6 +32,7 @@ interface FeedItemRowProps {
   onItemClick?: (item: FeedItemType) => void;
   onFocusChange?: (index: number) => void;
   onItemSave?: (item: FeedItemType) => void;
+  onItemArchive?: (item: FeedItemType) => void;
 }
 
 const FeedItemRow = memo(function FeedItemRow({
@@ -40,12 +43,17 @@ const FeedItemRow = memo(function FeedItemRow({
   onItemClick,
   onFocusChange,
   onItemSave,
+  onItemArchive,
 }: FeedItemRowProps) {
   const handleClick = useCallback(() => onItemClick?.(item), [item, onItemClick]);
   const handleMouseEnter = useCallback(() => onFocusChange?.(index), [index, onFocusChange]);
   const handleSave = useCallback(
     (e: React.MouseEvent) => { e.stopPropagation(); onItemSave?.(item); },
     [item, onItemSave],
+  );
+  const handleArchive = useCallback(
+    (e: React.MouseEvent) => { e.stopPropagation(); onItemArchive?.(item); },
+    [item, onItemArchive],
   );
 
   return (
@@ -56,6 +64,7 @@ const FeedItemRow = memo(function FeedItemRow({
       showEngagement={showEngagement}
       onMouseEnter={handleMouseEnter}
       onSave={onItemSave ? handleSave : undefined}
+      onArchive={onItemArchive ? handleArchive : undefined}
     />
   );
 });
@@ -68,6 +77,7 @@ export function FeedList({
   onAddFeed,
   hasFeedsSubscribed = false,
   onItemSave,
+  onItemArchive,
 }: FeedListProps) {
   const parentRef = useRef<HTMLDivElement>(null);
   const { FeedEmptyState } = usePlatform();
@@ -153,6 +163,7 @@ export function FeedList({
               onItemClick={onItemClick}
               onFocusChange={onFocusChange}
               onItemSave={onItemSave}
+              onItemArchive={onItemArchive}
             />
           </div>
         ))}

--- a/packages/ui/src/components/feed/FeedView.tsx
+++ b/packages/ui/src/components/feed/FeedView.tsx
@@ -14,9 +14,15 @@ export function FeedView() {
   const activeFilter = useAppStore((s) => s.activeFilter);
   const markAsRead = useAppStore((s) => s.markAsRead);
   const toggleSaved = useAppStore((s) => s.toggleSaved);
+  const toggleArchived = useAppStore((s) => s.toggleArchived);
   const handleItemSave = useCallback(
     (item: FeedItem) => toggleSaved(item.globalId),
     [toggleSaved],
+  );
+  // Only offer archive action on non-archived views; archived view shows the item already
+  const handleItemArchive = useCallback(
+    (item: FeedItem) => toggleArchived(item.globalId),
+    [toggleArchived],
   );
   const [addFeedOpen, setAddFeedOpen] = useState(false);
 
@@ -89,6 +95,7 @@ export function FeedView() {
         onAddFeed={canAddFeeds ? () => setAddFeedOpen(true) : undefined}
         hasFeedsSubscribed={Object.keys(feeds).length > 0}
         onItemSave={handleItemSave}
+        onItemArchive={activeFilter.archivedOnly ? undefined : handleItemArchive}
       />
 
       {selectedItem && (

--- a/packages/ui/src/components/feed/ReaderView.tsx
+++ b/packages/ui/src/components/feed/ReaderView.tsx
@@ -21,6 +21,7 @@ const noDrag = { WebkitAppRegion: "no-drag" } as React.CSSProperties;
 export function ReaderView({ item, onClose }: ReaderViewProps) {
   const { headerDragRegion } = usePlatform();
   const updateItem = useAppStore((s) => s.updateItem);
+  const toggleArchived = useAppStore((s) => s.toggleArchived);
   const updatePreferences = useAppStore((s) => s.updatePreferences);
   const storedDisplay = useAppStore((s) => s.preferences.display);
   const [focusOptions, setFocusOptions] = useState<FocusOptions>({
@@ -38,14 +39,11 @@ export function ReaderView({ item, onClose }: ReaderViewProps) {
     });
   }, [updateItem, item.globalId, item.userState]);
 
-  const toggleArchived = useCallback(() => {
-    updateItem(item.globalId, {
-      userState: {
-        ...item.userState,
-        archived: !item.userState.archived,
-      },
-    });
-  }, [updateItem, item.globalId, item.userState]);
+  const handleToggleArchived = useCallback(() => {
+    toggleArchived(item.globalId);
+    // Close the reader when archiving — item leaves the active feed
+    if (!item.userState.archived) onClose();
+  }, [toggleArchived, item.globalId, item.userState.archived, onClose]);
 
   const toggleFocus = useCallback(() => {
     setFocusOptions((prev) => {
@@ -150,7 +148,7 @@ export function ReaderView({ item, onClose }: ReaderViewProps) {
           </button>
 
           <button
-            onClick={toggleArchived}
+            onClick={handleToggleArchived}
             className={`p-2 rounded-lg transition-colors ${
               item.userState.archived
                 ? "bg-green-500/20 text-green-400"

--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 import { AddFeedDialog } from "../AddFeedDialog.js";
 import { useAppStore, usePlatform, MACOS_TRAFFIC_LIGHT_INSET } from "../../context/PlatformContext.js";
 
@@ -7,23 +7,56 @@ interface HeaderProps {
 }
 
 const noDrag = { WebkitAppRegion: "no-drag" } as React.CSSProperties;
+const dragStyle = { WebkitAppRegion: "drag" } as React.CSSProperties;
 
 export function Header({ onMenuClick }: HeaderProps) {
   const { HeaderSyncIndicator, headerDragRegion, addRssFeed } = usePlatform();
   const canAddFeeds = !!addRssFeed;
   const [addFeedOpen, setAddFeedOpen] = useState(false);
   const markAllAsRead = useAppStore((s) => s.markAllAsRead);
+  const archiveAllReadUnsaved = useAppStore((s) => s.archiveAllReadUnsaved);
   const activeFilter = useAppStore((s) => s.activeFilter);
   const totalUnreadCount = useAppStore((s) => s.totalUnreadCount);
   const unreadCountByPlatform = useAppStore((s) => s.unreadCountByPlatform);
+  const totalArchivableCount = useAppStore((s) => s.totalArchivableCount);
+  const archivableCountByPlatform = useAppStore((s) => s.archivableCountByPlatform);
+  const archivableFeedCounts = useAppStore((s) => s.archivableFeedCounts);
+  const setSearchQuery = useAppStore((s) => s.setSearchQuery);
+
+  // inputValue drives the visible input; searchQuery in the store is debounced
+  // so MiniSearch isn't invoked on every keystroke.
+  const [inputValue, setInputValue] = useState("");
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    debounceRef.current = setTimeout(() => {
+      setSearchQuery(inputValue);
+    }, 150);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [inputValue, setSearchQuery]);
+
+  function clearSearch() {
+    setInputValue("");
+    setSearchQuery("");
+  }
 
   // Derive display count from pre-computed store values — no items iteration.
-  // savedOnly views don't show a "mark all read" count (no useful total there).
-  const unreadCount = activeFilter.savedOnly
+  // savedOnly and archivedOnly views don't show these actions.
+  const unreadCount = (activeFilter.savedOnly || activeFilter.archivedOnly)
     ? 0
     : activeFilter.platform
       ? (unreadCountByPlatform[activeFilter.platform] ?? 0)
       : totalUnreadCount;
+
+  const archivableCount = (activeFilter.savedOnly || activeFilter.archivedOnly)
+    ? 0
+    : activeFilter.feedUrl
+      ? (archivableFeedCounts[activeFilter.feedUrl] ?? 0)
+      : activeFilter.platform
+        ? (archivableCountByPlatform[activeFilter.platform] ?? 0)
+        : totalArchivableCount;
 
   return (
     <>
@@ -39,7 +72,7 @@ export function Header({ onMenuClick }: HeaderProps) {
           : {})}
       >
         <div
-          className="h-[55px] flex items-center pl-4 pr-2"
+          className="h-[55px] flex items-center pl-4 pr-2 gap-2"
           style={
             headerDragRegion
               ? ({ paddingLeft: MACOS_TRAFFIC_LIGHT_INSET, WebkitAppRegion: "drag" } as React.CSSProperties)
@@ -50,7 +83,7 @@ export function Header({ onMenuClick }: HeaderProps) {
           {/* Mobile menu button */}
           <button
             onClick={onMenuClick}
-            className="md:hidden p-2 -ml-2 rounded-lg hover:bg-white/10 transition-colors"
+            className="md:hidden p-2 -ml-2 rounded-lg hover:bg-white/10 transition-colors flex-shrink-0"
             aria-label="Open menu"
             style={headerDragRegion ? noDrag : undefined}
           >
@@ -61,23 +94,65 @@ export function Header({ onMenuClick }: HeaderProps) {
 
           {/* FREED logo */}
           <div
-            className="flex items-center gap-1 ml-1 md:ml-0"
+            className="flex items-center gap-1 ml-1 md:ml-0 flex-shrink-0"
             style={headerDragRegion ? noDrag : undefined}
           >
             <span className="text-lg font-bold gradient-text font-logo">FREED</span>
           </div>
 
-          {/* Spacer — explicitly draggable so the empty middle area registers drag events */}
+          {/* Search bar — takes the center space; outer div stays draggable on desktop */}
           <div
-            className="flex-1 self-stretch"
-            {...(headerDragRegion
-              ? { "data-tauri-drag-region": true, style: { WebkitAppRegion: "drag" } as React.CSSProperties }
-              : {})}
-          />
+            className="flex-1 flex items-center justify-center min-w-0"
+            {...(headerDragRegion ? { "data-tauri-drag-region": true, style: dragStyle } : {})}
+          >
+            <div
+              className="relative w-full max-w-sm"
+              style={headerDragRegion ? noDrag : undefined}
+            >
+              {/* Search icon */}
+              <svg
+                className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-[#71717a]"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                aria-hidden="true"
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+              </svg>
+
+              <input
+                type="search"
+                value={inputValue}
+                onChange={(e) => setInputValue(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Escape") {
+                    clearSearch();
+                    e.currentTarget.blur();
+                  }
+                }}
+                placeholder="Search..."
+                aria-label="Search all sources"
+                className="w-full bg-white/5 border border-white/10 rounded-lg pl-8 pr-7 py-1.5 text-sm text-white/80 placeholder-[#52525b] focus:outline-none focus:border-white/20 focus:bg-white/[0.08] transition-colors"
+              />
+
+              {/* Clear button — only visible when there's input */}
+              {inputValue && (
+                <button
+                  onClick={clearSearch}
+                  aria-label="Clear search"
+                  className="absolute right-2 top-1/2 -translate-y-1/2 p-0.5 rounded hover:bg-white/10 transition-colors"
+                >
+                  <svg className="w-3 h-3 text-[#71717a]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                </button>
+              )}
+            </div>
+          </div>
 
           {/* Actions */}
           <div
-            className="flex items-center gap-1 sm:gap-2"
+            className="flex items-center gap-1 sm:gap-2 flex-shrink-0"
             style={headerDragRegion ? noDrag : undefined}
           >
             {HeaderSyncIndicator && <HeaderSyncIndicator />}
@@ -85,13 +160,26 @@ export function Header({ onMenuClick }: HeaderProps) {
             {unreadCount > 0 && (
               <button
                 onClick={() => markAllAsRead(activeFilter.platform)}
-                title={`Mark all ${unreadCount} items as read`}
+                title={`Mark all ${unreadCount.toLocaleString()} items as read`}
                 className="hidden sm:flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm text-[#71717a] hover:bg-white/5 hover:text-white transition-colors"
               >
                 <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
                 </svg>
                 <span>{unreadCount.toLocaleString()} unread</span>
+              </button>
+            )}
+
+            {archivableCount > 0 && (
+              <button
+                onClick={() => archiveAllReadUnsaved(activeFilter.platform, activeFilter.feedUrl)}
+                title={`Archive all ${archivableCount.toLocaleString()} read items`}
+                className="hidden sm:flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm text-[#71717a] hover:bg-white/5 hover:text-white transition-colors"
+              >
+                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                </svg>
+                <span>{archivableCount.toLocaleString()} read</span>
               </button>
             )}
 

--- a/packages/ui/src/components/layout/Sidebar.tsx
+++ b/packages/ui/src/components/layout/Sidebar.tsx
@@ -300,7 +300,7 @@ export function Sidebar({ open, onClose }: SidebarProps) {
 
   const isTopSourceActive = (source: (typeof topSources)[0]) => {
     if (activeFilter.feedUrl) return false;
-    if (activeFilter.showArchived) return false;
+    if (activeFilter.archivedOnly) return false;
     if (activeFilter.savedOnly) return false;
     return activeFilter.platform === source.id;
   };
@@ -419,12 +419,12 @@ export function Sidebar({ open, onClose }: SidebarProps) {
               </li>
               <li>
                 <button
-                  onClick={() => { setFilter({ showArchived: true }); onClose(); }}
+                  onClick={() => { setFilter({ archivedOnly: true }); onClose(); }}
                   className={`
                     w-full flex items-center gap-3 px-3 py-2 rounded-lg
                     text-left text-sm transition-all border
                     ${
-                      activeFilter.showArchived
+                      activeFilter.archivedOnly
                         ? "bg-[#8b5cf6]/20 text-white border-[#8b5cf6]/30"
                         : "border-transparent text-[#a1a1aa] hover:bg-white/5 hover:text-white"
                     }


### PR DESCRIPTION
(AI Generated)

## Summary

- **Fix broken Archived view**: `showArchived` was renamed to `archivedOnly` with correct filter semantics. The old flag only stopped excluding archived items — it never required them — so clicking "Archived" in the sidebar was silently showing the entire library. Now `archivedOnly: true` filters to only archived items; all other views exclude them.
- **Archive from anywhere**: Archive button appears on hover on feed cards (desktop) and via swipe-left gesture on mobile. The reader now closes automatically when you archive since the item leaves the active feed.
- **Batch archive**: Header shows an "N read" button beside "N unread" whenever the current view has read, non-saved items to clean up. Scoped to the active platform or feed filter.
- **Auto-pruning**: Archived items older than 30 days (configurable via `DisplayPreferences.archivePruneDays`) are deleted on startup. Saved items are never pruned. Items archived before this change have no `archivedAt` timestamp and are skipped until they are re-archived.

## Test plan

- [ ] Navigate to Archived in sidebar — confirm only archived items appear (not all items)
- [ ] Open a feed item, tap/click the checkmark in the reader — confirm it archives and closes
- [ ] Hover a feed card on desktop — confirm archive (checkmark) and bookmark buttons appear
- [ ] Swipe a feed card left on mobile — confirm green background reveals and item archives past threshold; springs back if released early
- [ ] Open a view with read, non-saved items — confirm "N read" button appears in header; click it and confirm items move to Archived
- [ ] Verify "N read" button does not appear in Saved or Archived views
- [ ] Verify archived items no longer appear in source views (All, X, RSS, per-feed)