### PR TITLE
feat: add universal full-text search across all sources

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10523,6 +10523,12 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/minisearch": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-7.2.0.tgz",
+      "integrity": "sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==",
+      "license": "MIT"
+    },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
@@ -14936,6 +14942,7 @@
         "@types/d3-force": "^3.0.10",
         "d3-force": "^3.0.0",
         "date-fns": "^4.1.0",
+        "minisearch": "^7.2.0",
         "zustand": "^5.0.3"
       },
       "devDependencies": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -27,6 +27,7 @@
     "@types/d3-force": "^3.0.10",
     "d3-force": "^3.0.0",
     "date-fns": "^4.1.0",
+    "minisearch": "^7.2.0",
     "zustand": "^5.0.3"
   },
   "devDependencies": {

--- a/packages/ui/src/components/feed/FeedList.tsx
+++ b/packages/ui/src/components/feed/FeedList.tsx
@@ -17,6 +17,10 @@ interface FeedListProps {
   onItemSave?: (item: FeedItemType) => void;
   /** Called when user archives an item from the feed card */
   onItemArchive?: (item: FeedItemType) => void;
+  /** True when a search query is active — changes the empty state message */
+  isSearching?: boolean;
+  /** The active search query text — used in the empty state message */
+  searchQuery?: string;
 }
 
 /**
@@ -78,6 +82,8 @@ export function FeedList({
   hasFeedsSubscribed = false,
   onItemSave,
   onItemArchive,
+  isSearching = false,
+  searchQuery = "",
 }: FeedListProps) {
   const parentRef = useRef<HTMLDivElement>(null);
   const { FeedEmptyState } = usePlatform();
@@ -94,6 +100,24 @@ export function FeedList({
   });
 
   if (items.length === 0) {
+    // Search returned no results — custom empty state.
+    if (isSearching) {
+      return (
+        <div className="flex flex-col items-center justify-center flex-1 min-h-0 overflow-auto text-center px-6 py-12">
+          <div className="w-16 h-16 rounded-full bg-gradient-to-br from-[#3b82f6]/20 to-[#8b5cf6]/20 flex items-center justify-center mb-4">
+            <svg className="w-7 h-7 text-[#3b82f6]/60" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+            </svg>
+          </div>
+          <p className="text-lg font-medium mb-2">No results</p>
+          <p className="text-sm text-[#71717a] max-w-xs">
+            Nothing matched{searchQuery ? <> &ldquo;<span className="text-white/60">{searchQuery}</span>&rdquo;</> : ""}.
+            Try a different term, or switch to <span className="text-white/60">All Sources</span> in the sidebar to search everywhere.
+          </p>
+        </div>
+      );
+    }
+
     if (FeedEmptyState) {
       return (
         <div className="flex flex-col items-center justify-center flex-1 min-h-0 overflow-auto text-center px-6 py-12">

--- a/packages/ui/src/components/feed/FeedView.tsx
+++ b/packages/ui/src/components/feed/FeedView.tsx
@@ -3,8 +3,29 @@ import { FeedList } from "./FeedList.js";
 import { ReaderView } from "./ReaderView.js";
 import { AddFeedDialog } from "../AddFeedDialog.js";
 import { useAppStore, usePlatform } from "../../context/PlatformContext.js";
-import { sortByPriority, filterFeedItems } from "@freed/shared";
-import type { FeedItem } from "@freed/shared";
+import { useSearchResults } from "../../hooks/useSearchResults.js";
+import type { FeedItem, RssFeed, FilterOptions } from "@freed/shared";
+
+const PLATFORM_LABELS: Record<string, string> = {
+  x: "X",
+  rss: "RSS",
+  youtube: "YouTube",
+  reddit: "Reddit",
+  mastodon: "Mastodon",
+  github: "GitHub",
+  facebook: "Facebook",
+  instagram: "Instagram",
+  saved: "Saved",
+};
+
+/** Human-readable label for the scope currently active in the sidebar. */
+function getFilterLabel(filter: FilterOptions, feeds: Record<string, RssFeed>): string {
+  if (filter.savedOnly) return "Saved";
+  if (filter.archivedOnly) return "Archived";
+  if (filter.feedUrl) return feeds[filter.feedUrl]?.title ?? "this feed";
+  if (filter.platform) return PLATFORM_LABELS[filter.platform] ?? filter.platform;
+  return "All Sources";
+}
 
 export function FeedView() {
   const { addRssFeed } = usePlatform();
@@ -12,9 +33,11 @@ export function FeedView() {
   const items = useAppStore((s) => s.items);
   const feeds = useAppStore((s) => s.feeds);
   const activeFilter = useAppStore((s) => s.activeFilter);
+  const searchQuery = useAppStore((s) => s.searchQuery);
   const markAsRead = useAppStore((s) => s.markAsRead);
   const toggleSaved = useAppStore((s) => s.toggleSaved);
   const toggleArchived = useAppStore((s) => s.toggleArchived);
+
   const handleItemSave = useCallback(
     (item: FeedItem) => toggleSaved(item.globalId),
     [toggleSaved],
@@ -24,16 +47,14 @@ export function FeedView() {
     (item: FeedItem) => toggleArchived(item.globalId),
     [toggleArchived],
   );
+
   const [addFeedOpen, setAddFeedOpen] = useState(false);
 
-  const filteredItems = useMemo(() => {
-    const filtered = filterFeedItems(items, activeFilter);
-    // Apply feedUrl filter (not handled by shared filterFeedItems)
-    const byFeed = activeFilter.feedUrl
-      ? filtered.filter((item) => item.rssSource?.feedUrl === activeFilter.feedUrl)
-      : filtered;
-    return sortByPriority(byFeed);
-  }, [items, activeFilter]);
+  // useSearchResults handles both the search and the normal ranked+filtered path.
+  // When searchQuery is empty it behaves identically to the previous useMemo.
+  const { filteredItems, isSearching, resultCount } = useSearchResults(items, searchQuery, activeFilter);
+
+  const scopeLabel = useMemo(() => getFilterLabel(activeFilter, feeds), [activeFilter, feeds]);
 
   const [selectedItem, setSelectedItem] = useState<FeedItem | null>(null);
   const [focusedIndex, setFocusedIndex] = useState<number>(-1);
@@ -50,7 +71,8 @@ export function FeedView() {
     setSelectedItem(null);
   }, []);
 
-  // Keyboard navigation: j/k to move, Enter/o to open, Escape to close
+  // Keyboard navigation: j/k to move, Enter/o to open, Escape to close.
+  // The HTMLInputElement guard means j/k won't fire while the search bar is focused.
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
       if (
@@ -80,13 +102,32 @@ export function FeedView() {
     return () => window.removeEventListener("keydown", handleKey);
   }, [selectedItem, filteredItems, focusedIndex, openItem, closeItem]);
 
-  // Reset focus when filter changes
+  // Reset keyboard focus when the active filter or search query changes.
   useEffect(() => {
     setFocusedIndex(-1);
-  }, [activeFilter]);
+  }, [activeFilter, searchQuery]);
 
   return (
     <div className="h-full flex flex-col">
+      {/* Search results banner — only shown when actively searching */}
+      {isSearching && (
+        <div className="flex-shrink-0 px-4 py-2 border-b border-white/5 flex items-center justify-between">
+          <p className="text-xs text-[#71717a]">
+            {resultCount > 0 ? (
+              <>
+                <span className="text-white/60 font-medium">{resultCount.toLocaleString()}</span>
+                {" "}result{resultCount !== 1 ? "s" : ""} in{" "}
+                <span className="text-white/60 font-medium">{scopeLabel}</span>
+              </>
+            ) : (
+              <>
+                No results in <span className="text-white/60 font-medium">{scopeLabel}</span>
+              </>
+            )}
+          </p>
+        </div>
+      )}
+
       <FeedList
         items={filteredItems}
         onItemClick={openItem}
@@ -96,6 +137,8 @@ export function FeedView() {
         hasFeedsSubscribed={Object.keys(feeds).length > 0}
         onItemSave={handleItemSave}
         onItemArchive={activeFilter.archivedOnly ? undefined : handleItemArchive}
+        isSearching={isSearching}
+        searchQuery={searchQuery}
       />
 
       {selectedItem && (

--- a/packages/ui/src/hooks/useSearchResults.ts
+++ b/packages/ui/src/hooks/useSearchResults.ts
@@ -1,0 +1,153 @@
+/**
+ * Full-text search over in-memory feed items using MiniSearch.
+ *
+ * The index is rebuilt only when the items array reference changes (i.e. on
+ * every Automerge document update). Searching is a pure read over the index,
+ * so it never triggers a rebuild.
+ *
+ * Preserved article text is truncated to 3 000 chars before indexing — full
+ * articles can be 20 k+ words and the marginal recall gain past that point is
+ * negligible while the indexing cost is not.
+ */
+
+import { useMemo } from "react";
+import MiniSearch from "minisearch";
+import { filterFeedItems, sortByPriority } from "@freed/shared";
+import type { FeedItem, FilterOptions } from "@freed/shared";
+
+const PRESERVED_TEXT_LIMIT = 3_000;
+
+/** Flat document shape fed to MiniSearch (one per FeedItem). */
+interface SearchDoc {
+  id: string;
+  text: string;
+  linkTitle: string;
+  linkDesc: string;
+  authorName: string;
+  authorHandle: string;
+  feedTitle: string;
+  preservedText: string;
+  topics: string;
+  tags: string;
+  highlights: string;
+}
+
+function toSearchDoc(item: FeedItem): SearchDoc {
+  return {
+    id: item.globalId,
+    text: item.content.text ?? "",
+    linkTitle: item.content.linkPreview?.title ?? "",
+    linkDesc: item.content.linkPreview?.description ?? "",
+    authorName: item.author.displayName,
+    authorHandle: item.author.handle,
+    feedTitle: item.rssSource?.feedTitle ?? "",
+    preservedText: item.preservedContent?.text?.slice(0, PRESERVED_TEXT_LIMIT) ?? "",
+    topics: item.topics.join(" "),
+    tags: (item.userState.tags ?? []).join(" "),
+    highlights: (item.userState.highlights ?? [])
+      .map((h) => `${h.text} ${h.note ?? ""}`)
+      .join(" "),
+  };
+}
+
+/** Fields indexed + per-field boosts applied at query time. */
+const SEARCH_FIELDS: Array<keyof Omit<SearchDoc, "id">> = [
+  "text",
+  "linkTitle",
+  "linkDesc",
+  "authorName",
+  "authorHandle",
+  "feedTitle",
+  "preservedText",
+  "topics",
+  "tags",
+  "highlights",
+];
+
+const FIELD_BOOST: Partial<Record<keyof Omit<SearchDoc, "id">, number>> = {
+  linkTitle: 4,
+  topics: 3,
+  tags: 3,
+  authorName: 3,
+  authorHandle: 3,
+  text: 2,
+  linkDesc: 2,
+  feedTitle: 2,
+  highlights: 2,
+  preservedText: 1,
+};
+
+export interface SearchResults {
+  /** Items to render — either the normal ranked+filtered list, or search results. */
+  filteredItems: FeedItem[];
+  /** True when there is a non-empty search query. */
+  isSearching: boolean;
+  /** Number of items matching the query after applying the active filter. */
+  resultCount: number;
+}
+
+/**
+ * Returns the set of items to display given the current search query and
+ * active filter.
+ *
+ * - Empty query: normal ranked feed filtered by activeFilter.
+ * - Non-empty query: MiniSearch results filtered by activeFilter, sorted by
+ *   relevance score descending.
+ */
+export function useSearchResults(
+  items: FeedItem[],
+  searchQuery: string,
+  activeFilter: FilterOptions,
+): SearchResults {
+  // Rebuild the index only when the items array changes.
+  const index = useMemo(() => {
+    const ms = new MiniSearch<SearchDoc>({
+      idField: "id",
+      fields: SEARCH_FIELDS as string[],
+      storeFields: ["id"],
+    });
+    ms.addAll(items.map(toSearchDoc));
+    return ms;
+  }, [items]);
+
+  return useMemo(() => {
+    const trimmedQuery = searchQuery.trim();
+
+    if (!trimmedQuery) {
+      // Normal feed: apply active filter then sort by priority.
+      const filtered = filterFeedItems(items, activeFilter);
+      const byFeed = activeFilter.feedUrl
+        ? filtered.filter((item) => item.rssSource?.feedUrl === activeFilter.feedUrl)
+        : filtered;
+      return { filteredItems: sortByPriority(byFeed), isSearching: false, resultCount: 0 };
+    }
+
+    // Search then filter — preserving MiniSearch's relevance ordering.
+    const hits = index.search(trimmedQuery, {
+      boost: FIELD_BOOST as Record<string, number>,
+      fuzzy: 0.2,
+      prefix: true,
+    });
+
+    const scoreById = new Map(hits.map((r) => [r.id as string, r.score]));
+    const itemById = new Map(items.map((item) => [item.globalId, item]));
+
+    // Map results back to FeedItems, preserving MiniSearch order.
+    const matchingItems = hits
+      .map((r) => itemById.get(r.id as string))
+      .filter((item): item is FeedItem => item !== undefined);
+
+    const filtered = filterFeedItems(matchingItems, activeFilter);
+    const byFeed = activeFilter.feedUrl
+      ? filtered.filter((item) => item.rssSource?.feedUrl === activeFilter.feedUrl)
+      : filtered;
+
+    // Sort by relevance score (MiniSearch already orders hits, but filterFeedItems
+    // may reorder, so we re-sort explicitly).
+    const sorted = [...byFeed].sort(
+      (a, b) => (scoreById.get(b.globalId) ?? 0) - (scoreById.get(a.globalId) ?? 0),
+    );
+
+    return { filteredItems: sorted, isSearching: true, resultCount: sorted.length };
+  }, [items, searchQuery, activeFilter, index]);
+}


### PR DESCRIPTION
(AI Generated)

## Summary

- Adds a persistent search bar to the header that queries every FeedItem field (body text, link headlines, author name/handle, feed title, preserved article text, topics, user tags, and highlights) via an in-memory MiniSearch inverted index
- Search is scoped to the active sidebar selection by default (searching X while on X, Saved while in Library, etc.); switching to All Sources searches everything
- Results show a count + scope label ("12 results in X"); empty results state hints to switch to All Sources

## Test plan

- [ ] Type into the search bar while on All Sources and confirm items filter in real time
- [ ] Switch to a specific platform (e.g. X) and search — confirm results are scoped to that platform
- [ ] Switch to Saved and search — confirm only saved items appear
- [ ] Select a specific RSS feed and search — confirm results are scoped to that feed
- [ ] Search for something with no results — confirm the "No results" empty state appears with the hint
- [ ] Press Escape to clear search and confirm feed returns to normal
- [ ] Verify j/k keyboard nav still works normally when the search bar is not focused