### PR TITLE
refactor: remove SidebarConnectionSection from PlatformContext

### DIFF
--- a/packages/desktop/src/App.tsx
+++ b/packages/desktop/src/App.tsx
@@ -22,7 +22,6 @@ import {
 import { clearLocalDoc } from "./lib/automerge";
 import { clearStoredCookies } from "./lib/x-auth";
 import { XFeedEmptyState } from "./components/XFeedEmptyState";
-import { XAuthSection } from "./components/XAuthSection";
 import { XSourceIndicator } from "./components/XSourceIndicator";
 import { DesktopSyncIndicator } from "./components/DesktopSyncIndicator";
 import { MobileSyncTab } from "./components/MobileSyncTab";
@@ -95,7 +94,6 @@ function App() {
       importOPMLFeeds,
       exportFeedsAsOPML,
       headerDragRegion: true,
-      SidebarConnectionSection: XAuthSection,
       SourceIndicator: XSourceIndicator,
       HeaderSyncIndicator: DesktopSyncIndicator,
       SettingsExtraSections: MobileSyncTab,

--- a/packages/pwa/src/App.tsx
+++ b/packages/pwa/src/App.tsx
@@ -93,7 +93,6 @@ function App() {
       store: useAppStore,
       addRssFeed: subscribeToFeed,
       exportFeedsAsOPML,
-      SidebarConnectionSection: null,
       SourceIndicator: null,
       HeaderSyncIndicator: SyncIndicator,
       SettingsExtraSections: null,

--- a/packages/ui/src/components/layout/Sidebar.tsx
+++ b/packages/ui/src/components/layout/Sidebar.tsx
@@ -212,7 +212,7 @@ const comingSoonSources = [
 ];
 
 export function Sidebar({ open, onClose }: SidebarProps) {
-  const { SidebarConnectionSection, SourceIndicator, headerDragRegion } = usePlatform();
+  const { SourceIndicator, headerDragRegion } = usePlatform();
   const activeFilter = useAppStore((s) => s.activeFilter);
   const setFilter = useAppStore((s) => s.setFilter);
   const feeds = useAppStore((s) => s.feeds);
@@ -350,8 +350,6 @@ export function Sidebar({ open, onClose }: SidebarProps) {
         </div>
 
         <nav className="flex-1 min-h-0 flex flex-col p-4 overflow-y-auto minimal-scroll">
-          {SidebarConnectionSection && <SidebarConnectionSection />}
-
           {/* Sources */}
           <SidebarSection title="Sources">
             <ul className="space-y-1">

--- a/packages/ui/src/context/PlatformContext.tsx
+++ b/packages/ui/src/context/PlatformContext.tsx
@@ -64,9 +64,6 @@ export interface PlatformConfig {
 
   // -- Layout slot components (null = not rendered) --
 
-  /** Rendered at top of Sidebar nav (e.g. Desktop Sync card, X Auth card) */
-  SidebarConnectionSection: ComponentType | null;
-
   /** Rendered inline per source button for status indicators (e.g. X auth dot) */
   SourceIndicator: ComponentType<{ sourceId: string }> | null;
 


### PR DESCRIPTION
(AI Generated)

## Summary

- Removes the dead `sidebarConnectionSection` slot from `PlatformContext` and all callsites
- `Sidebar.tsx` no longer renders an injected connection section -- that surface was unused after the cloud-sync UI was moved to the settings panel

## Test plan

- [ ] Open the sidebar in desktop and PWA -- no visual regression, no missing elements
- [ ] `npm run typecheck` passes