### PR TITLE
feat(ui): replace emoji sidebar icons with white SVG icons

### DIFF
--- a/packages/ui/src/components/feed/FeedItem.tsx
+++ b/packages/ui/src/components/feed/FeedItem.tsx
@@ -1,6 +1,7 @@
-import { memo } from "react";
+import { memo, type ReactNode } from "react";
 import { formatDistanceToNow } from "date-fns";
 import type { FeedItem as FeedItemType } from "@freed/shared";
+import { RssIcon, FacebookIcon, InstagramIcon, YoutubeIcon, RedditIcon, GithubIcon, MastodonIcon, BookmarkIcon } from "../icons.js";
 
 interface FeedItemProps {
   item: FeedItemType;
@@ -11,16 +12,18 @@ interface FeedItemProps {
   onSave?: (e: React.MouseEvent) => void;
 }
 
-const platformIcons: Record<string, string> = {
-  x: "𝕏",
-  rss: "📡",
-  youtube: "▶️",
-  reddit: "🔴",
-  mastodon: "🐘",
-  github: "🐙",
-  facebook: "📘",
-  instagram: "📸",
-  saved: "📌",
+const cls = "w-3.5 h-3.5";
+
+const platformIcons: Record<string, ReactNode> = {
+  x: <span className="text-xs font-bold leading-none">𝕏</span>,
+  rss: <RssIcon className={cls} />,
+  youtube: <YoutubeIcon className={cls} />,
+  reddit: <RedditIcon className={cls} />,
+  mastodon: <MastodonIcon className={cls} />,
+  github: <GithubIcon className={cls} />,
+  facebook: <FacebookIcon className={cls} />,
+  instagram: <InstagramIcon className={cls} />,
+  saved: <BookmarkIcon className={cls} />,
 };
 
 export const FeedItem = memo(function FeedItem({
@@ -32,7 +35,7 @@ export const FeedItem = memo(function FeedItem({
   onSave,
 }: FeedItemProps) {
   const timeAgo = formatDistanceToNow(item.publishedAt, { addSuffix: true });
-  const platformIcon = platformIcons[item.platform] || "📄";
+  const platformIcon = platformIcons[item.platform] ?? <span className="text-xs">📄</span>;
 
   return (
     <article

--- a/packages/ui/src/components/icons.tsx
+++ b/packages/ui/src/components/icons.tsx
@@ -1,0 +1,119 @@
+/** Shared SVG icon components used across the UI. All render at the caller's text color (currentColor). */
+
+interface IconProps {
+  className?: string;
+}
+
+// ─── Layout / navigation ────────────────────────────────────────────────────
+
+/** Three horizontal lines – "All sources" list icon. */
+export function AllIcon({ className = "w-4 h-4" }: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" className={className} aria-hidden="true">
+      <line x1="3" y1="6" x2="21" y2="6" />
+      <line x1="3" y1="12" x2="21" y2="12" />
+      <line x1="3" y1="18" x2="21" y2="18" />
+    </svg>
+  );
+}
+
+/** Bookmark shape – saved items. */
+export function BookmarkIcon({ className = "w-4 h-4" }: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className} aria-hidden="true">
+      <path d="M19 21l-7-5-7 5V5a2 2 0 012-2h10a2 2 0 012 2z" />
+    </svg>
+  );
+}
+
+/** Archive box – archived items. */
+export function ArchiveIcon({ className = "w-4 h-4" }: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className} aria-hidden="true">
+      <polyline points="21 8 21 21 3 21 3 8" />
+      <rect x="1" y="3" width="22" height="5" />
+      <line x1="10" y1="12" x2="14" y2="12" />
+    </svg>
+  );
+}
+
+/** Location pin – map view. */
+export function MapPinIcon({ className = "w-4 h-4" }: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className} aria-hidden="true">
+      <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0118 0z" />
+      <circle cx="12" cy="10" r="3" />
+    </svg>
+  );
+}
+
+// ─── Platform logos ──────────────────────────────────────────────────────────
+
+/**
+ * Classic RSS signal icon: dot + two quarter-circle arcs.
+ * Heroicons v2 solid path (24 × 24).
+ */
+export function RssIcon({ className = "w-4 h-4" }: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" className={className} aria-hidden="true">
+      <path d="M3.75 4.5a.75.75 0 01.75-.75h.75c8.284 0 15 6.716 15 15v.75a.75.75 0 01-.75.75h-.75a.75.75 0 01-.75-.75v-.75C18 11.979 12.021 6 4.5 6h-.75a.75.75 0 01-.75-.75V4.5zM3 12.75a.75.75 0 01.75-.75h.75a8.25 8.25 0 018.25 8.25v.75a.75.75 0 01-.75.75H11.25a.75.75 0 01-.75-.75v-.75a6 6 0 00-6-6h-.75A.75.75 0 013 14.25v-1.5zM6 20.25a2.25 2.25 0 114.5 0 2.25 2.25 0 01-4.5 0z" />
+    </svg>
+  );
+}
+
+/** Facebook "f" shape (Feather / Lucide style). */
+export function FacebookIcon({ className = "w-4 h-4" }: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" className={className} aria-hidden="true">
+      <path d="M18 2h-3a5 5 0 00-5 5v3H7v4h3v8h4v-8h3l1-4h-4V7a1 1 0 011-1h3z" />
+    </svg>
+  );
+}
+
+/** Instagram rounded-rect camera with lens dot. */
+export function InstagramIcon({ className = "w-4 h-4" }: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className} aria-hidden="true">
+      <rect x="2" y="2" width="20" height="20" rx="5" ry="5" />
+      <circle cx="12" cy="12" r="4" />
+      {/* viewfinder dot */}
+      <circle cx="17.5" cy="6.5" r="1" fill="currentColor" stroke="none" />
+    </svg>
+  );
+}
+
+/** YouTube play-button shield. */
+export function YoutubeIcon({ className = "w-4 h-4" }: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" className={className} aria-hidden="true">
+      <path d="M22.54 6.42a2.78 2.78 0 00-1.95-1.96C18.88 4 12 4 12 4s-6.88 0-8.59.46A2.78 2.78 0 001.46 6.42 29 29 0 001 12a29 29 0 00.46 5.58 2.78 2.78 0 001.95 1.95C5.12 20 12 20 12 20s6.88 0 8.59-.47a2.78 2.78 0 001.95-1.95A29 29 0 0023 12a29 29 0 00-.46-5.58zM9.75 15.02V8.98L15.5 12l-5.75 3.02z" />
+    </svg>
+  );
+}
+
+/** GitHub Octocat outline (simplified). */
+export function GithubIcon({ className = "w-4 h-4" }: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" className={className} aria-hidden="true">
+      <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" />
+    </svg>
+  );
+}
+
+/** Mastodon elephant tusk (simplified "M" shape). */
+export function MastodonIcon({ className = "w-4 h-4" }: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" className={className} aria-hidden="true">
+      <path d="M21.327 8.566c0-4.339-2.843-5.61-2.843-5.61-1.433-.658-3.894-.935-6.451-.956h-.063c-2.557.021-5.016.298-6.45.956 0 0-2.843 1.272-2.843 5.61 0 .993-.019 2.181.012 3.441.103 4.243.778 8.425 4.701 9.463 1.809.479 3.362.579 4.612.51 2.268-.126 3.542-.809 3.542-.809l-.075-1.646s-1.621.511-3.441.449c-1.804-.062-3.707-.194-3.999-2.409a4.523 4.523 0 01-.04-.621s1.77.433 4.014.536c1.372.063 2.658-.08 3.965-.236 2.506-.299 4.688-1.843 4.962-3.254.434-2.223.398-5.424.398-5.424zm-3.353 5.59h-2.081V9.057c0-1.075-.452-1.62-1.357-1.62-1 0-1.501.647-1.501 1.927v2.791h-2.069V9.364c0-1.28-.501-1.927-1.502-1.927-.905 0-1.357.545-1.357 1.62v5.099H6.026V8.903c0-1.074.273-1.927.823-2.558.567-.632 1.307-.955 2.228-.955 1.065 0 1.872.409 2.405 1.228l.518.869.519-.869c.533-.819 1.34-1.228 2.405-1.228.92 0 1.662.323 2.228.955.549.631.822 1.484.822 2.558v5.253z" />
+    </svg>
+  );
+}
+
+/** Reddit alien head (Simple Icons path). */
+export function RedditIcon({ className = "w-4 h-4" }: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" className={className} aria-hidden="true">
+      <path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.01 4.744c.688 0 1.25.561 1.25 1.249a1.25 1.25 0 0 1-2.498.056l-2.597-.547-.8 3.747c1.824.07 3.48.632 4.674 1.488.308-.309.73-.491 1.207-.491.968 0 1.754.786 1.754 1.754 0 .716-.435 1.333-1.01 1.614a3.111 3.111 0 0 1 .042.52c0 2.694-3.13 4.87-7.004 4.87-3.874 0-7.004-2.176-7.004-4.87 0-.183.015-.366.043-.534A1.748 1.748 0 0 1 4.028 12c0-.968.786-1.754 1.754-1.754.463 0 .898.196 1.207.49 1.207-.883 2.878-1.43 4.744-1.487l.885-4.182a.342.342 0 0 1 .14-.197.35.35 0 0 1 .238-.042l2.906.617a1.214 1.214 0 0 1 1.108-.701zM9.25 12C8.561 12 8 12.562 8 13.25c0 .687.561 1.248 1.25 1.248.687 0 1.248-.561 1.248-1.249 0-.688-.561-1.249-1.249-1.249zm5.5 0c-.687 0-1.248.561-1.248 1.25 0 .687.561 1.248 1.249 1.248.688 0 1.249-.561 1.249-1.249 0-.687-.562-1.249-1.25-1.249zm-5.466 3.99a.327.327 0 0 0-.231.094.33.33 0 0 0 0 .463c.842.842 2.484.913 2.961.913.477 0 2.105-.056 2.961-.913a.361.361 0 0 0 .029-.463.33.33 0 0 0-.464 0c-.547.533-1.684.73-2.512.73-.828 0-1.979-.196-2.512-.73a.326.326 0 0 0-.232-.095z" />
+    </svg>
+  );
+}

--- a/packages/ui/src/components/layout/Sidebar.tsx
+++ b/packages/ui/src/components/layout/Sidebar.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback, useEffect, useRef, type ReactNode } from "react"
 import type { RssFeed } from "@freed/shared";
 import { useAppStore, usePlatform } from "../../context/PlatformContext.js";
 import { SettingsPanel } from "../SettingsPanel.js";
+import { AllIcon, RssIcon, FacebookIcon, InstagramIcon, MapPinIcon, BookmarkIcon, ArchiveIcon } from "../icons.js";
 
 /** Compact number: 1234 → "1.2k", 1_200_000 → "1.2m". Trims trailing ".0". */
 function fmt(n: number): string {
@@ -199,16 +200,16 @@ const MIN_WIDTH = 180;
 const MAX_WIDTH = 480;
 const DEFAULT_WIDTH = 256;
 
-const topSources = [
-  { id: undefined, label: "All", icon: "🌊" },
-  { id: "x", label: "X", icon: "𝕏" },
-  { id: "rss", label: "RSS", icon: "📡" },
+const topSources: { id: string | undefined; label: string; icon: ReactNode }[] = [
+  { id: undefined, label: "All", icon: <AllIcon /> },
+  { id: "x", label: "X", icon: <span className="text-sm font-bold leading-none">𝕏</span> },
+  { id: "rss", label: "RSS", icon: <RssIcon /> },
 ];
 
-const comingSoonSources = [
-  { id: "facebook", label: "Facebook", icon: "📘" },
-  { id: "instagram", label: "Instagram", icon: "📷" },
-  { id: "map", label: "Map", icon: "🗺️" },
+const comingSoonSources: { id: string; label: string; icon: ReactNode }[] = [
+  { id: "facebook", label: "Facebook", icon: <FacebookIcon /> },
+  { id: "instagram", label: "Instagram", icon: <InstagramIcon /> },
+  { id: "map", label: "Map", icon: <MapPinIcon /> },
 ];
 
 export function Sidebar({ open, onClose }: SidebarProps) {
@@ -369,7 +370,7 @@ export function Sidebar({ open, onClose }: SidebarProps) {
                       }
                     `}
                   >
-                    <span className="w-5 text-center">{source.icon}</span>
+                    <span className="w-5 flex items-center justify-center">{source.icon}</span>
                     <span className="flex-1">{source.label}</span>
                     {sourceTotalCount(source) > 0 && (
                       <span className="shrink-0 flex items-center gap-0.5 text-[10px] tabular-nums">
@@ -389,7 +390,7 @@ export function Sidebar({ open, onClose }: SidebarProps) {
               {comingSoonSources.map((source) => (
                 <li key={source.id}>
                   <div className="w-full flex items-center gap-3 px-3 py-2 rounded-lg text-sm text-[#52525b] cursor-default">
-                    <span className="w-5 text-center opacity-50">{source.icon}</span>
+                    <span className="w-5 flex items-center justify-center opacity-50">{source.icon}</span>
                     <span className="flex-1">{source.label}</span>
                     <span className="text-[10px] uppercase tracking-wider bg-white/5 px-1.5 py-0.5 rounded">soon</span>
                   </div>
@@ -414,7 +415,7 @@ export function Sidebar({ open, onClose }: SidebarProps) {
                     }
                   `}
                 >
-                  <span className="w-5 text-center">📌</span>
+                  <span className="w-5 flex items-center justify-center"><BookmarkIcon /></span>
                   <span>Saved</span>
                 </button>
               </li>
@@ -431,7 +432,7 @@ export function Sidebar({ open, onClose }: SidebarProps) {
                     }
                   `}
                 >
-                  <span className="w-5 text-center">📦</span>
+                  <span className="w-5 flex items-center justify-center"><ArchiveIcon /></span>
                   <span>Archived</span>
                 </button>
               </li>
@@ -469,9 +470,7 @@ export function Sidebar({ open, onClose }: SidebarProps) {
                             className="w-4 h-4 rounded-sm shrink-0 object-cover"
                           />
                         ) : (
-                          <span className="w-4 h-4 shrink-0 flex items-center justify-center text-[10px] text-[#52525b]">
-                            📡
-                          </span>
+                          <RssIcon className="w-4 h-4 shrink-0 text-[#52525b]" />
                         )}
                         <span className="flex-1 truncate text-xs">{feed.title}</span>
                       </button>


### PR DESCRIPTION
(AI Generated)

## Summary

- Adds a new `packages/ui/src/components/icons.tsx` module with inline SVG icon components for all sidebar nav items
- Replaces emoji characters in `Sidebar.tsx` with the new SVG icons -- consistent sizing, proper theming support, no font-dependent rendering
- Updates `FeedItem.tsx` to use the same SVG icon set for platform indicators

## Test plan

- [ ] Open the sidebar -- icons are sharp, correctly sized, and white/themed (no emoji fallback rendering on Linux or Windows)
- [ ] Resize the window -- icons scale correctly