### PR TITLE
fix: resolve all TypeScript errors breaking the release CI build

### DIFF
--- a/packages/capture-save/package.json
+++ b/packages/capture-save/package.json
@@ -3,25 +3,13 @@
   "version": "0.1.0",
   "description": "Save any URL to your Freed library",
   "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
   "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
-    },
-    "./browser": {
-      "types": "./dist/browser.d.ts",
-      "import": "./dist/browser.js"
-    },
-    "./import-markdown": {
-      "types": "./dist/import-markdown.d.ts",
-      "import": "./dist/import-markdown.js"
-    },
-    "./export-markdown": {
-      "types": "./dist/export-markdown.d.ts",
-      "import": "./dist/export-markdown.js"
-    }
+    ".": "./src/index.ts",
+    "./browser": "./src/browser.ts",
+    "./import-markdown": "./src/import-markdown.ts",
+    "./export-markdown": "./src/export-markdown.ts"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/desktop/src/lib/contacts.ts
+++ b/packages/desktop/src/lib/contacts.ts
@@ -22,7 +22,8 @@ interface ContactPickerResult {
  */
 export async function pickContactViaTauri(): Promise<ContactPickerResult | null> {
   try {
-    const result = await window.__TAURI__?.core.invoke<{
+    if (!window.__TAURI__) return null;
+    const result = await window.__TAURI__.core.invoke<{
       name: string;
       phone: string | null;
       email: string | null;

--- a/packages/desktop/src/lib/import-export.test.ts
+++ b/packages/desktop/src/lib/import-export.test.ts
@@ -100,10 +100,6 @@ function makeFileList(files: File[]): FileList {
   return files as unknown as FileList;
 }
 
-function collectPhases(calls: ImportProgress[]): ImportPhase[] {
-  return [...new Set(calls.map((p) => p.phase))];
-}
-
 // ── folderTagsFromRelativePath tests ──────────────────────────────────────────
 
 describe("folderTagsFromRelativePath", () => {

--- a/packages/desktop/src/lib/import-export.ts
+++ b/packages/desktop/src/lib/import-export.ts
@@ -159,7 +159,7 @@ export async function importMarkdownFiles(
 export async function exportLibrary(items: FeedItem[]): Promise<void> {
   const blob = await exportLibraryAsMarkdown(
     items,
-    (id) => contentCache.get(id),
+    (id: string) => contentCache.get(id),
   );
 
   const url = URL.createObjectURL(blob);

--- a/packages/desktop/src/lib/store.ts
+++ b/packages/desktop/src/lib/store.ts
@@ -55,6 +55,12 @@ interface AppState {
   totalItemCount: number;
   /** Total visible item count bucketed by platform. */
   itemCountByPlatform: Record<string, number>;
+  /** Total read-but-not-saved items eligible for archiving. */
+  totalArchivableCount: number;
+  /** Archivable item count bucketed by platform. */
+  archivableCountByPlatform: Record<string, number>;
+  /** Archivable item count per feed URL. */
+  archivableFeedCounts: Record<string, number>;
 
   // X auth state
   xAuth: XAuthState;
@@ -77,6 +83,8 @@ interface AppState {
   markAllAsRead: (platform?: string) => Promise<void>;
   toggleSaved: (id: string) => Promise<void>;
   removeItem: (id: string) => Promise<void>;
+  toggleArchived: (id: string) => Promise<void>;
+  archiveAllReadUnsaved: (platform?: string, feedUrl?: string) => Promise<void>;
 
   // Feed actions (persisted to Automerge)
   addFeed: (feed: RssFeed) => Promise<void>;

--- a/packages/ui/src/components/feed/ReaderView.tsx
+++ b/packages/ui/src/components/feed/ReaderView.tsx
@@ -177,7 +177,6 @@ export function ReaderView({ item, onClose }: ReaderViewProps) {
     });
   }, [updatePreferences, storedDisplay]);
 
-  const hasContent = !!(html || item.preservedContent?.html);
   const timeAgo = useMemo(
     () => formatDistanceToNow(item.publishedAt, { addSuffix: true }),
     [item.publishedAt],


### PR DESCRIPTION
(AI Generated)

## Summary

- **`capture-save/package.json`**: Switched exports from gitignored `dist/*.js` files to `src/*.ts` source directly. The `dist/` is in `.gitignore`, so CI never had these files. This follows the same pattern `@freed/ui` already uses and eliminates the need for a `capture-save` pre-build step.
- **`contacts.ts`**: Added a `window.__TAURI__` existence guard before calling `invoke<T>()`. Optional chaining (`?.`) causes TypeScript to strip generic type parameters from the call, producing TS2558. Checking first and calling directly fixes it.
- **`store.ts`**: Added `totalArchivableCount`, `archivableCountByPlatform`, `archivableFeedCounts`, `toggleArchived`, and `archiveAllReadUnsaved` to the `AppState` interface to match their implementations already in the store body.
- **`import-export.ts`**: Annotated the `(id: string)` callback parameter on `exportLibraryAsMarkdown` to satisfy strict mode.
- **`import-export.test.ts`**: Removed the unused `collectPhases` helper function (TS6133).
- **`ReaderView.tsx`**: Removed unused `hasContent` variable (TS6133).

## Test plan

- [ ] Re-trigger the release tag build to confirm all 4 platform jobs (macOS arm64, macOS x64, Windows, Linux) pass `tsc -b && vite build`