### PR TITLE
fix(desktop): import invoke/isTauri from @tauri-apps/api/core instead of window.__TAURI__

### DIFF
--- a/packages/desktop/src/lib/contacts.ts
+++ b/packages/desktop/src/lib/contacts.ts
@@ -7,12 +7,22 @@
  * causing FriendEditor to fall back to manual entry.
  */
 
+import { invoke, isTauri } from "@tauri-apps/api/core";
+
 interface ContactPickerResult {
   name: string;
   phone?: string;
   email?: string;
   address?: string;
   nativeId?: string;
+}
+
+interface PickContactResponse {
+  name: string;
+  phone: string | null;
+  email: string | null;
+  address: string | null;
+  native_id: string | null;
 }
 
 /**
@@ -22,14 +32,8 @@ interface ContactPickerResult {
  */
 export async function pickContactViaTauri(): Promise<ContactPickerResult | null> {
   try {
-    if (!window.__TAURI__) return null;
-    const result = await window.__TAURI__.core.invoke<{
-      name: string;
-      phone: string | null;
-      email: string | null;
-      address: string | null;
-      native_id: string | null;
-    } | null>("pick_contact");
+    if (!isTauri()) return null;
+    const result = await invoke<PickContactResponse | null>("pick_contact");
 
     if (!result) return null;
 


### PR DESCRIPTION
(AI Generated)

## Summary

- `window.__TAURI__.core.invoke` is not typed with generics in the Tauri v2 type declarations, causing `TS2558: Expected 0 type arguments, but got 1` and five `TS2339: Property does not exist on type '{}'` errors
- Switched to importing `invoke` and `isTauri` directly from `@tauri-apps/api/core`, which has the properly-generic `invoke<T>()` signature
- Extracted the raw Tauri response shape into a named `PickContactResponse` interface for clarity

This was blocking the Release Desktop App workflow on all three platforms (macOS arm64, macOS x64, Windows, Linux).

## Test plan

- [ ] CI release build passes on all platforms

Made with [Cursor](https://cursor.com)