### PR TITLE
fix: eliminate init flash and reduce desktop startup serialization overhead

### DIFF
--- a/packages/desktop/src/lib/automerge.ts
+++ b/packages/desktop/src/lib/automerge.ts
@@ -70,7 +70,9 @@ export async function initDoc(): Promise<FreedDoc> {
 
   const deviceId = (currentDoc.meta?.deviceId as string | undefined) ?? "unknown";
   addDebugEvent("init", `device ...${deviceId.slice(-8)}`);
-  snapshotDoc();
+  // Defer the debug snapshot so it doesn't block the init render path.
+  // A.save() is synchronous WASM work — run it after the UI is visible.
+  setTimeout(() => snapshotDoc(), 0);
 
   registerDocAccessors(
     () => currentDoc,
@@ -127,7 +129,6 @@ async function applyChange(
   currentDoc = A.change(currentDoc, message || "update", changeFn);
   await saveDoc();
   addDebugEvent("change", message);
-  snapshotDoc();
 
   // Notify subscribers
   for (const subscriber of subscribers) {

--- a/packages/desktop/src/lib/store.ts
+++ b/packages/desktop/src/lib/store.ts
@@ -210,7 +210,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   archivableCountByPlatform: {},
   archivableFeedCounts: {},
   xAuth: { isAuthenticated: false },
-  isLoading: false,
+  isLoading: true,
   isSyncing: false,
   isInitialized: false,
   error: null,

--- a/packages/pwa/src/lib/automerge.ts
+++ b/packages/pwa/src/lib/automerge.ts
@@ -69,7 +69,9 @@ export async function initDoc(): Promise<FreedDoc> {
 
   const deviceId = (currentDoc.meta?.deviceId as string | undefined) ?? "unknown";
   addDebugEvent("init", `device ...${deviceId.slice(-8)}`);
-  snapshotDoc();
+  // Defer the debug snapshot so it doesn't block the init render path.
+  // A.save() is synchronous WASM work — run it after the UI is visible.
+  setTimeout(() => snapshotDoc(), 0);
 
   // Register window escape hatch so the console can inspect the live doc.
   registerDocAccessors(
@@ -114,7 +116,6 @@ async function applyChange(
   currentDoc = A.change(currentDoc, message || "update", changeFn);
   await saveDoc();
   addDebugEvent("change", message);
-  snapshotDoc();
 
   // Notify subscribers
   for (const subscriber of subscribers) {

--- a/packages/pwa/src/lib/store.ts
+++ b/packages/pwa/src/lib/store.ts
@@ -133,7 +133,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   archivableCountByPlatform: {},
   archivableFeedCounts: {},
   syncConnected: false,
-  isLoading: false,
+  isLoading: true,
   isSyncing: false,
   isInitialized: false,
   error: null,


### PR DESCRIPTION
(AI Generated)

## Summary

- **Init flash (both platforms):** `isLoading` now starts as `true` in both stores. The spinner condition `!isInitialized && isLoading` is `true` from the very first React render, so the sidebar and empty layout never paint before init completes. Previously `isLoading` started `false`, meaning the spinner was invisible for the first frame — causing the sidebar slide-out on mobile and the blank-then-dark-spinner flash on desktop.

- **Desktop startup perf:** Removed `snapshotDoc()` from `applyChange()` in both automerge modules and deferred the `snapshotDoc()` call in `initDoc()` behind `setTimeout(0)`. `snapshotDoc()` runs `A.save()` (synchronous WASM serialization of the entire document) purely for debug metrics. The desktop was calling it 4 extra times during init (once in `initDoc`, once after each of the 3 healing mutations), for a total of 7 `A.save()` passes before showing any UI. Now it defers to the first idle event-loop tick after the app is visible.

## Test plan

- [ ] Open PWA on mobile: no sidebar flash during load
- [ ] Open desktop app: spinner appears immediately, no blank-layout frame
- [ ] Desktop app loads noticeably faster with a large feed library
- [ ] Debug panel still shows doc snapshot after init completes