### PR TITLE
feat: mark items as read when scrolled past in the feed list

### DIFF
--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -415,6 +415,12 @@ export interface ReadingEnhancements {
 
   /** Focus mode intensity */
   focusIntensity: ReadingIntensity;
+
+  /**
+   * Mark items as read when they scroll past in the feed list.
+   * When false, items are only marked read when explicitly opened.
+   */
+  markReadOnScroll: boolean;
 }
 
 /**
@@ -580,6 +586,7 @@ export function createDefaultPreferences(): UserPreferences {
       reading: {
         focusMode: false,
         focusIntensity: "normal",
+        markReadOnScroll: true,
       },
       archivePruneDays: 30,
     },

--- a/packages/ui/src/components/SettingsDialog.tsx
+++ b/packages/ui/src/components/SettingsDialog.tsx
@@ -452,6 +452,12 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
             <SectionHeading label="Reading" />
             <div className="space-y-5">
               <Toggle
+                label="Mark read on scroll"
+                checked={display.reading.markReadOnScroll}
+                onChange={(v) => handleReadingChange({ markReadOnScroll: v })}
+                description="Mark items as read when you scroll past them in the feed"
+              />
+              <Toggle
                 label="Show engagement counts"
                 checked={display.showEngagementCounts}
                 onChange={(v) => handleDisplayChange({ showEngagementCounts: v })}

--- a/packages/ui/src/components/feed/FeedList.tsx
+++ b/packages/ui/src/components/feed/FeedList.tsx
@@ -109,6 +109,19 @@ export function FeedList({
   const showEngagementCounts = useAppStore(
     (s) => s.preferences.display.showEngagementCounts,
   );
+  const markAsRead = useAppStore((s) => s.markAsRead);
+  const markReadOnScroll = useAppStore(
+    (s) => s.preferences.display.reading.markReadOnScroll,
+  );
+
+  // Tracks the highest item index already marked read via scroll. Reset when
+  // the items array changes (filter/search switch) so stale offsets don't carry over.
+  const scrollReadHighWater = useRef(-1);
+  const prevItemsRef = useRef(items);
+  if (prevItemsRef.current !== items) {
+    prevItemsRef.current = items;
+    scrollReadHighWater.current = -1;
+  }
 
   // Both virtualizers are always constructed (rules of hooks). Only the active
   // one's output is rendered. On mobile the element virtualizer has no scroll
@@ -128,6 +141,29 @@ export function FeedList({
     // Distance from window top to the list container. Accounts for the sticky
     // header so items are offset correctly as window.scrollY changes.
     scrollMargin: windowListRef.current?.offsetTop ?? 0,
+  });
+
+  // Mark items as read when they scroll past the top of the viewport.
+  // We compare the current minimum visible index against the high-water mark
+  // and mark every item in the gap. Fires on every render triggered by the
+  // virtualizer (i.e. on every scroll tick), which is exactly what we want.
+  useEffect(() => {
+    if (!markReadOnScroll) return;
+    const virtualItems = isMobile
+      ? windowVirtualizer.getVirtualItems()
+      : elementVirtualizer.getVirtualItems();
+    if (virtualItems.length === 0) return;
+
+    const minVisible = virtualItems[0].index;
+    if (minVisible <= scrollReadHighWater.current + 1) return;
+
+    for (let i = scrollReadHighWater.current + 1; i < minVisible; i++) {
+      const item = items[i];
+      if (item && !item.userState.readAt) {
+        markAsRead(item.globalId);
+      }
+    }
+    scrollReadHighWater.current = minVisible - 1;
   });
 
   if (items.length === 0) {


### PR DESCRIPTION
(AI Generated)

## Summary

- Adds a **Mark read on scroll** toggle to the reader settings section (default: on)
- When enabled, items are marked as read as they scroll off the top of the feed -- no clicking required, just like Twitter/Instagram
- When disabled, items are only marked read when explicitly opened (previous behavior)
- Opening an item always marks it read regardless of the setting

## Implementation

The scroll tracking lives in `FeedList.tsx`. `@tanstack/react-virtual` already knows which items are visible via `getVirtualItems()`. On each render (which the virtualizer triggers on every scroll tick), we compare the current minimum visible index against a high-water mark ref. Any items in the gap between the old mark and the new minimum have scrolled off the top -- we mark those unread ones as read and advance the mark.

The high-water ref resets when the `items` array reference changes (filter switch, search change) so stale scroll offsets from a previous feed context don't bleed into the new one.

Works for both desktop (element scroll virtualizer) and mobile (window scroll virtualizer).

## Test plan

- [ ] Open the feed, scroll down -- unread items should disappear from unread count as they leave the viewport
- [ ] Turn the setting off in Settings > Reading -- scrolling should no longer mark items read
- [ ] Switch filters (e.g. All Sources -> a specific feed) -- scroll progress resets correctly
- [ ] Open an item -- still marked read even with the setting off