### PR TITLE
fix: never assign undefined into Automerge documents

### DIFF
--- a/packages/capture-facebook/src/normalize.ts
+++ b/packages/capture-facebook/src/normalize.ts
@@ -39,7 +39,7 @@ function buildAuthor(post: RawFbPost): Author {
     id: `fb:${extractAuthorId(post.authorProfileUrl)}`,
     handle: extractAuthorId(post.authorProfileUrl),
     displayName: post.authorName ?? "Unknown",
-    avatarUrl: post.authorAvatarUrl ?? undefined,
+    ...(post.authorAvatarUrl ? { avatarUrl: post.authorAvatarUrl } : {}),
   };
 }
 
@@ -54,7 +54,7 @@ function buildContent(post: RawFbPost): Content {
   });
 
   return {
-    text: post.text ?? undefined,
+    ...(post.text ? { text: post.text } : {}),
     mediaUrls: post.mediaUrls,
     mediaTypes: post.hasVideo
       ? ["video", ...mediaTypes.slice(1)]
@@ -98,9 +98,9 @@ function buildEngagement(post: RawFbPost): Engagement | undefined {
     return undefined;
   }
   return {
-    likes: post.likeCount ?? undefined,
-    comments: post.commentCount ?? undefined,
-    reposts: post.shareCount ?? undefined,
+    ...(post.likeCount != null ? { likes: post.likeCount } : {}),
+    ...(post.commentCount != null ? { comments: post.commentCount } : {}),
+    ...(post.shareCount != null ? { reposts: post.shareCount } : {}),
   };
 }
 
@@ -135,8 +135,8 @@ export function fbPostToFeedItem(post: RawFbPost): FeedItem | null {
     publishedAt,
     author,
     content,
-    engagement,
-    location,
+    ...(engagement !== undefined ? { engagement } : {}),
+    ...(location !== undefined ? { location } : {}),
     topics,
     userState: {
       hidden: false,

--- a/packages/capture-instagram/src/normalize.ts
+++ b/packages/capture-instagram/src/normalize.ts
@@ -15,7 +15,7 @@ function buildAuthor(post: RawIgPost): Author {
     id: `ig:${handle}`,
     handle,
     displayName: post.authorDisplayName ?? handle,
-    avatarUrl: post.authorAvatarUrl ?? undefined,
+    ...(post.authorAvatarUrl ? { avatarUrl: post.authorAvatarUrl } : {}),
   };
 }
 
@@ -29,7 +29,7 @@ function buildContent(post: RawIgPost): Content {
     post.isVideo ? ["video", ...mediaTypes.slice(1)] : mediaTypes;
 
   return {
-    text: post.caption ?? undefined,
+    ...(post.caption ? { text: post.caption } : {}),
     mediaUrls: post.mediaUrls,
     mediaTypes: allMediaTypes,
   };
@@ -66,8 +66,8 @@ function buildLocation(post: RawIgPost): Location | undefined {
 function buildEngagement(post: RawIgPost): Engagement | undefined {
   if (post.likeCount == null && post.commentCount == null) return undefined;
   return {
-    likes: post.likeCount ?? undefined,
-    comments: post.commentCount ?? undefined,
+    ...(post.likeCount != null ? { likes: post.likeCount } : {}),
+    ...(post.commentCount != null ? { comments: post.commentCount } : {}),
   };
 }
 
@@ -105,8 +105,8 @@ export function igPostToFeedItem(post: RawIgPost): FeedItem | null {
     publishedAt,
     author,
     content,
-    engagement,
-    location,
+    ...(engagement !== undefined ? { engagement } : {}),
+    ...(location !== undefined ? { location } : {}),
     topics,
     userState: {
       hidden: false,

--- a/packages/capture-rss/src/normalize.ts
+++ b/packages/capture-rss/src/normalize.ts
@@ -243,6 +243,7 @@ export function rssItemToFeedItem(
   // Parse publication date
   const pubDate = item.pubDate ? new Date(item.pubDate) : new Date();
   const publishedAt = isNaN(pubDate.getTime()) ? Date.now() : pubDate.getTime();
+  const textContent = getTextContent(item);
 
   return {
     globalId,
@@ -254,19 +255,23 @@ export function rssItemToFeedItem(
       id: feed.feedUrl,
       handle: extractHandle(feed, item),
       displayName: feed.title,
-      avatarUrl: feed.image?.url,
+      ...(feed.image?.url ? { avatarUrl: feed.image.url } : {}),
     },
     content: {
-      text: getTextContent(item),
+      ...(textContent !== undefined ? { text: textContent } : {}),
       mediaUrls: extractMediaUrls(item),
       mediaTypes: extractMediaTypes(item),
-      linkPreview: item.link
+      ...(item.link
         ? {
-            url: item.link,
-            title: item.title,
-            description: item.contentSnippet?.slice(0, 200),
+            linkPreview: {
+              url: item.link,
+              ...(item.title ? { title: item.title } : {}),
+              ...(item.contentSnippet
+                ? { description: item.contentSnippet.slice(0, 200) }
+                : {}),
+            },
           }
-        : undefined,
+        : {}),
     },
     rssSource: {
       feedUrl: feed.feedUrl,

--- a/packages/capture-save/src/import-markdown.ts
+++ b/packages/capture-save/src/import-markdown.ts
@@ -193,26 +193,26 @@ export function parseMarkdownArchiveFile(
       id: sourceUrl ? new URL(sourceUrl).hostname : "unknown",
       handle: sourceUrl ? new URL(sourceUrl).hostname : "unknown",
       displayName: author ?? (sourceUrl ? new URL(sourceUrl).hostname : "Unknown"),
-      avatarUrl: undefined,
+      // avatarUrl intentionally omitted -- undefined is not valid in Automerge
     },
     content: {
       text: text.slice(0, 300),
       mediaUrls: [],
       mediaTypes: [],
-      linkPreview: sourceUrl
-        ? { url: sourceUrl, title }
-        : undefined,
+      ...(sourceUrl ? { linkPreview: { url: sourceUrl, title } } : {}),
     },
-    preservedContent: hasBody
+    ...(hasBody
       ? {
-          // html intentionally omitted -- goes to content cache only
-          text,
-          author,
-          wordCount,
-          readingTime,
-          preservedAt: now,
+          preservedContent: {
+            // html intentionally omitted -- goes to content cache only
+            text,
+            ...(author !== undefined ? { author } : {}),
+            wordCount,
+            readingTime,
+            preservedAt: now,
+          },
         }
-      : undefined,
+      : {}),
     userState: {
       hidden: false,
       saved: true,

--- a/packages/capture-x/src/normalize.ts
+++ b/packages/capture-x/src/normalize.ts
@@ -125,11 +125,7 @@ export function extractLinkPreview(
     );
 
     if (nonMediaUrls.length > 0) {
-      return {
-        url: nonMediaUrls[0].expanded_url,
-        title: undefined,
-        description: undefined,
-      };
+      return { url: nonMediaUrls[0].expanded_url };
     }
   }
 
@@ -215,11 +211,12 @@ export function tweetToFeedItem(tweet: XTweetResult): FeedItem {
   };
 
   // Build content
+  const linkPreview = extractLinkPreview(displayTweet);
   const content: Content = {
     text: cleanTweetText(displayTweet),
     mediaUrls: extractMediaUrls(displayTweet),
     mediaTypes: extractMediaTypes(displayTweet),
-    linkPreview: extractLinkPreview(displayTweet),
+    ...(linkPreview !== undefined ? { linkPreview } : {}),
   };
 
   // Build engagement (captured for user-controlled ranking)
@@ -227,9 +224,9 @@ export function tweetToFeedItem(tweet: XTweetResult): FeedItem {
     likes: displayTweet.legacy.favorite_count,
     reposts: displayTweet.legacy.retweet_count,
     comments: displayTweet.legacy.reply_count,
-    views: displayTweet.views?.count
-      ? parseInt(displayTweet.views.count)
-      : undefined,
+    ...(displayTweet.views?.count
+      ? { views: parseInt(displayTweet.views.count) }
+      : {}),
   };
 
   // Parse timestamp

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "freed-desktop"
-version = "26.3.402"
+version = "26.3.404"
 dependencies = [
  "base64 0.22.1",
  "futures-util",

--- a/packages/shared/src/schema.ts
+++ b/packages/shared/src/schema.ts
@@ -83,13 +83,40 @@ export function createDocFromData(data: Partial<FreedDoc>): FreedDoc {
 // =============================================================================
 
 /**
+ * Recursively remove any keys whose value is `undefined` from a plain object.
+ *
+ * Automerge's CRDT proxy throws on `undefined` assignments. This is a
+ * last-resort defensive sanitizer applied before writing to the document —
+ * normalizers should already produce clean objects, but this prevents a single
+ * bad optional field from crashing the whole capture.
+ */
+function stripUndefined<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map(stripUndefined) as unknown as T;
+  }
+  if (value !== null && typeof value === "object") {
+    const result: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      if (v !== undefined) {
+        result[k] = stripUndefined(v);
+      }
+    }
+    return result as T;
+  }
+  return value;
+}
+
+/**
  * Add a feed item to the document
+ *
+ * Strips any `undefined` values before writing — Automerge's proxy throws on
+ * them, and a single bad optional field would otherwise crash the whole capture.
  *
  * @param doc - The Automerge document (mutable within A.change)
  * @param item - The feed item to add
  */
 export function addFeedItem(doc: FreedDoc, item: FeedItem): void {
-  doc.feedItems[item.globalId] = item;
+  doc.feedItems[item.globalId] = stripUndefined(item);
 }
 
 /**

--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -277,7 +277,7 @@ export function Header({ onMenuClick }: HeaderProps) {
 
           {/* Search / command bar — fills all remaining center space */}
           <div
-            className="hidden sm:flex flex-1 items-center justify-center min-w-0 ml-3"
+            className="flex flex-1 items-center justify-center min-w-0 ml-3"
             {...(headerDragRegion
               ? { "data-tauri-drag-region": true, style: dragStyle }
               : {})}
@@ -316,7 +316,7 @@ export function Header({ onMenuClick }: HeaderProps) {
                 aria-label="Search or run a command"
                 aria-expanded={showPalette}
                 aria-haspopup="listbox"
-                className="w-full bg-transparent border border-white/[0.06] rounded-lg pl-8 pr-7 py-1.5 text-sm text-white/70 placeholder-[#3f3f46] focus:outline-none hover:border-white/[0.11] hover:bg-white/[0.02] focus:border-white/[0.16] focus:bg-white/[0.04] transition-colors"
+                className="w-full bg-transparent border border-white/[0.06] rounded-lg pl-8 pr-7 py-1.5 text-sm text-white/70 placeholder-transparent sm:placeholder-[#3f3f46] focus:outline-none hover:border-white/[0.11] hover:bg-white/[0.02] focus:border-white/[0.16] focus:bg-white/[0.04] transition-colors"
               />
 
               {/* Clear button — only visible when there's input */}

--- a/packages/ui/src/components/layout/Sidebar.tsx
+++ b/packages/ui/src/components/layout/Sidebar.tsx
@@ -32,9 +32,9 @@ function SidebarSection({
     <div className="shrink-0 mb-2">
       <button
         onClick={() => setOpen((v) => !v)}
-        className="w-full flex items-center px-3 py-1.5 group"
+        className="w-full flex items-center px-3 py-1.5 rounded-lg group hover:bg-white/5 transition-colors"
       >
-        <span className="text-xs font-semibold text-[#71717a] uppercase tracking-wider flex-1 text-left">
+        <span className="text-xs font-semibold text-[#71717a] uppercase tracking-wider flex-1 text-left leading-5">
           {title}
         </span>
         {!open && count !== undefined && count > 0 && (
@@ -397,7 +397,7 @@ export function Sidebar({ open, onClose }: SidebarProps) {
                   <button
                     onClick={() => handleSourceClick(source)}
                     className={`
-                      w-full flex items-center gap-3 px-3 py-2 rounded-lg
+                      w-full flex items-center gap-3 px-3 py-1.5 rounded-lg
                       text-left text-sm transition-all border
                       ${
                         isTopSourceActive(source)
@@ -425,7 +425,7 @@ export function Sidebar({ open, onClose }: SidebarProps) {
               ))}
               {comingSoonSources.map((source) => (
                 <li key={source.id}>
-                  <div className="w-full flex items-center gap-3 px-3 py-2 rounded-lg text-sm text-[#52525b] cursor-default">
+                  <div className="w-full flex items-center gap-3 px-3 py-1.5 rounded-lg text-sm text-[#52525b] cursor-default">
                     <span className="w-5 flex items-center justify-center opacity-50">{source.icon}</span>
                     <span className="flex-1">{source.label}</span>
                     <span className="text-[10px] uppercase tracking-wider bg-white/5 px-1.5 py-0.5 rounded">soon</span>
@@ -442,7 +442,7 @@ export function Sidebar({ open, onClose }: SidebarProps) {
                 <button
                   onClick={() => { setFilter({ savedOnly: true }); onClose(); }}
                   className={`
-                    w-full flex items-center gap-3 px-3 py-2 rounded-lg
+                    w-full flex items-center gap-3 px-3 py-1.5 rounded-lg
                     text-left text-sm transition-all border
                     ${
                       activeFilter.savedOnly
@@ -459,7 +459,7 @@ export function Sidebar({ open, onClose }: SidebarProps) {
                 <button
                   onClick={() => { setFilter({ archivedOnly: true }); onClose(); }}
                   className={`
-                    w-full flex items-center gap-3 px-3 py-2 rounded-lg
+                    w-full flex items-center gap-3 px-3 py-1.5 rounded-lg
                     text-left text-sm transition-all border
                     ${
                       activeFilter.archivedOnly
@@ -592,7 +592,7 @@ export function Sidebar({ open, onClose }: SidebarProps) {
           <div className="mt-auto shrink-0">
             <button
               onClick={openSettings}
-              className="w-full flex items-center gap-3 px-3 py-2 rounded-lg text-left text-sm text-[#a1a1aa] hover:bg-white/5 hover:text-white transition-all"
+              className="w-full flex items-center gap-3 px-3 py-1.5 rounded-lg text-left text-sm text-[#a1a1aa] hover:bg-white/5 hover:text-white transition-all"
             >
               <span className="w-5 text-center">
                 <svg className="w-4 h-4 inline" fill="none" viewBox="0 0 24 24" stroke="currentColor">


### PR DESCRIPTION
(AI Generated)

## Summary

- All capture normalizers (facebook, instagram, rss, save/import-markdown, x) were explicitly setting optional fields like `avatarUrl`, `linkPreview`, `text`, and `views` to `undefined`. Automerge's CRDT proxy throws on any `undefined` assignment since it's not a valid JSON value -- this was the root cause of the crash seen during bulk import.
- Replaced every `field: undefined` pattern with conditional spreads (`...(val ? { field: val } : {})`), so absent optional fields are simply omitted from the object rather than explicitly nulled out.
- Added a `stripUndefined` recursive sanitizer in `addFeedItem` (schema.ts) as a last-resort defensive layer -- normalizers should now produce clean objects, but this prevents any future stray `undefined` from crashing an entire capture run.
- Minor sidebar (`py-2` -> `py-1.5`) and header (search bar visible on mobile, placeholder hidden on small screens) polish.

## Test plan

- [ ] Re-run the bulk import that triggered the crash -- should complete without errors
- [ ] Verify individual captures (RSS feed, X/Twitter, saved articles) still produce correct items
- [ ] Confirm engagement stats (likes, comments, views) appear correctly when present and are absent when not in source data