### PR TITLE
fix: align sidebar section headers to same height as items

### DIFF
--- a/packages/ui/src/components/layout/Sidebar.tsx
+++ b/packages/ui/src/components/layout/Sidebar.tsx
@@ -32,7 +32,7 @@ function SidebarSection({
     <div className="shrink-0 mb-2">
       <button
         onClick={() => setOpen((v) => !v)}
-        className="w-full flex items-center px-3 py-1.5 rounded-lg group hover:bg-white/5 transition-colors"
+        className="w-full flex items-center px-3 py-1.5 rounded-lg border border-transparent group hover:bg-white/5 transition-colors"
       >
         <span className="text-xs font-semibold text-[#71717a] uppercase tracking-wider flex-1 text-left leading-5">
           {title}


### PR DESCRIPTION
(AI Generated)

## Summary

- Sidebar section header buttons (SOURCES, LIBRARY, FEEDS) were rendering at 32px while source/feed items were 34px
- The discrepancy came from items always having a `border` class (1px top + 1px bottom = 2px extra) for their active/inactive state styling, while headers had no border
- Added `border border-transparent` to header buttons so all rows sit in the same box model at 34px

## Test plan

- [ ] Visually confirm SOURCES / LIBRARY / FEEDS headers align with the rows beneath them in the sidebar