### PR TITLE
perf: instant app launch with deferred migrations and skeleton loading

### DIFF
--- a/packages/desktop/src/App.tsx
+++ b/packages/desktop/src/App.tsx
@@ -40,7 +40,6 @@ const JUST_UPDATED_KEY = "freed-updated-to";
 function App() {
   const initialize = useAppStore((state) => state.initialize);
   const isInitialized = useAppStore((state) => state.isInitialized);
-  const isLoading = useAppStore((state) => state.isLoading);
   const error = useAppStore((state) => state.error);
 
   useEffect(() => {
@@ -216,17 +215,6 @@ function App() {
     }),
     [checkForUpdates, applyUpdate, handleFactoryReset],
   );
-
-  if (!isInitialized && isLoading) {
-    return (
-      <div className="h-screen flex items-center justify-center bg-transparent">
-        <div className="text-center">
-          <div className="w-8 h-8 border-2 border-glow-purple border-t-transparent rounded-full animate-spin mx-auto mb-4" />
-          <p className="text-text-secondary">Loading your feed...</p>
-        </div>
-      </div>
-    );
-  }
 
   if (error && !isInitialized) {
     return (

--- a/packages/desktop/src/lib/store.ts
+++ b/packages/desktop/src/lib/store.ts
@@ -194,6 +194,33 @@ function hydrateFromDoc(doc: FreedDoc): Partial<AppState> {
   };
 }
 
+/**
+ * Run idempotent startup migrations in the background after the app renders.
+ * subscribe() is already wired up at call time, so any doc mutations propagate
+ * to the UI automatically. Errors are swallowed — all three ops are non-fatal.
+ */
+async function runStartupMigrations(archivePruneDays: number): Promise<void> {
+  try {
+    // Heal "Untitled Feed" sentinels from URL hostname — zero network required.
+    await docHealUntitledFeedTitles();
+  } catch {
+    // non-fatal
+  }
+  try {
+    // Remove phantom duplicates caused by key-scheme changes (guid vs link priority).
+    await docDeduplicateFeedItems();
+  } catch {
+    // non-fatal
+  }
+  try {
+    if (archivePruneDays > 0) {
+      await docPruneArchivedItems(archivePruneDays * 24 * 60 * 60 * 1000);
+    }
+  } catch {
+    // non-fatal
+  }
+}
+
 export const useAppStore = create<AppState>((set, get) => ({
   // Initial state
   items: [],
@@ -226,21 +253,8 @@ export const useAppStore = create<AppState>((set, get) => ({
       set({ isLoading: true });
       const doc = await initDoc();
 
-      // Heal "Untitled Feed" sentinels from URL hostname — zero network,
-      // runs before any cloud merge so users never see the sentinel on startup.
-      await docHealUntitledFeedTitles();
-
-      // Run dedup migration — no-op when clean, removes phantom duplicates
-      // caused by key-scheme changes (guid vs link priority).
-      await docDeduplicateFeedItems();
-
-      // Prune archived items older than the configured threshold
-      const pruneDays = doc.preferences.display.archivePruneDays ?? 30;
-      if (pruneDays > 0) {
-        await docPruneArchivedItems(pruneDays * 24 * 60 * 60 * 1000);
-      }
-
-      // Subscribe to future changes (for sync).
+      // Subscribe to future changes (for sync) before we flip isInitialized so
+      // background migrations that fire immediately after are propagated to the UI.
       // Reuse count map references when values haven't changed so Sidebar
       // selectors don't trigger re-renders on unrelated mutations.
       subscribe((updatedDoc) => {
@@ -263,13 +277,17 @@ export const useAppStore = create<AppState>((set, get) => ({
         ? { isAuthenticated: true, cookies: xCookies }
         : { isAuthenticated: false };
 
-      // Hydrate initial state
+      // Hydrate and show the app immediately — no need to wait for migrations.
       set({
         ...hydrateFromDoc(doc),
         xAuth,
         isInitialized: true,
         isLoading: false,
       });
+
+      // Run cleanup migrations in the background. All three are idempotent; failures
+      // are non-fatal. subscribe() above propagates any changes to the UI automatically.
+      void runStartupMigrations(doc.preferences.display.archivePruneDays ?? 30);
     } catch (error) {
       set({
         error: error instanceof Error ? error.message : "Failed to initialize",

--- a/packages/pwa/src/App.tsx
+++ b/packages/pwa/src/App.tsx
@@ -34,7 +34,6 @@ function App() {
   }
   const initialize = useAppStore((state) => state.initialize);
   const isInitialized = useAppStore((state) => state.isInitialized);
-  const isLoading = useAppStore((state) => state.isLoading);
   const error = useAppStore((state) => state.error);
   const setSyncConnected = useAppStore((state) => state.setSyncConnected);
   const [showUpdateBanner, setShowUpdateBanner] = useState(false);
@@ -131,17 +130,6 @@ function App() {
     }),
     [checkForUpdates, handleFactoryReset],
   );
-
-  if (!isInitialized && isLoading) {
-    return (
-      <div className="h-screen flex items-center justify-center bg-freed-black">
-        <div className="text-center">
-          <div className="w-8 h-8 border-2 border-glow-purple border-t-transparent rounded-full animate-spin mx-auto mb-4" />
-          <p className="text-text-secondary">Loading your feed...</p>
-        </div>
-      </div>
-    );
-  }
 
   if (error && !isInitialized) {
     return (

--- a/packages/pwa/src/lib/store.ts
+++ b/packages/pwa/src/lib/store.ts
@@ -149,13 +149,8 @@ export const useAppStore = create<AppState>((set, get) => ({
       set({ isLoading: true });
       const doc = await initDoc();
 
-      // Prune archived items older than the configured threshold
-      const pruneDays = doc.preferences.display.archivePruneDays ?? 30;
-      if (pruneDays > 0) {
-        await docPruneArchivedItems(pruneDays * 24 * 60 * 60 * 1000);
-      }
-
-      // Subscribe to future changes (for sync).
+      // Subscribe to future changes (for sync) before we flip isInitialized so
+      // background migrations that fire immediately after are propagated to the UI.
       // Reuse count map references when values haven't changed so Sidebar
       // selectors don't trigger re-renders on unrelated mutations.
       subscribe((updatedDoc) => {
@@ -172,12 +167,21 @@ export const useAppStore = create<AppState>((set, get) => ({
         set(next);
       });
 
-      // Hydrate initial state
+      // Hydrate and show the app immediately — no need to wait for migrations.
       set({
         ...hydrateFromDoc(doc),
         isInitialized: true,
         isLoading: false,
       });
+
+      // Prune archived items in the background. Idempotent; failure is non-fatal.
+      // subscribe() above propagates the resulting doc change to the UI automatically.
+      const pruneDays = doc.preferences.display.archivePruneDays ?? 30;
+      if (pruneDays > 0) {
+        void docPruneArchivedItems(pruneDays * 24 * 60 * 60 * 1000).catch(() => {
+          // non-fatal
+        });
+      }
     } catch (error) {
       set({
         error: error instanceof Error ? error.message : "Failed to initialize",

--- a/packages/ui/src/components/feed/FeedItemSkeleton.tsx
+++ b/packages/ui/src/components/feed/FeedItemSkeleton.tsx
@@ -1,0 +1,35 @@
+/**
+ * Shimmer placeholder that matches the FeedItem card layout.
+ * Rendered while the Automerge doc is loading from IndexedDB so the
+ * app chrome is visible immediately instead of showing a black spinner.
+ */
+export function FeedItemSkeleton() {
+  return (
+    <div className="feed-card animate-pulse" aria-hidden>
+      {/* Author row */}
+      <div className="flex items-center gap-3 mb-3">
+        {/* Avatar */}
+        <div className="w-10 h-10 rounded-full bg-white/10 shrink-0" />
+        <div className="flex-1 min-w-0 space-y-1.5">
+          {/* Display name + handle */}
+          <div className="flex items-center gap-2">
+            <div className="h-3.5 w-24 rounded bg-white/10" />
+            <div className="h-3 w-16 rounded bg-white/[0.06]" />
+          </div>
+          {/* Platform + timestamp */}
+          <div className="flex items-center gap-2">
+            <div className="h-3 w-3 rounded bg-white/[0.06]" />
+            <div className="h-3 w-16 rounded bg-white/[0.06]" />
+          </div>
+        </div>
+      </div>
+
+      {/* Body lines */}
+      <div className="space-y-2">
+        <div className="h-3.5 w-full rounded bg-white/10" />
+        <div className="h-3.5 w-[85%] rounded bg-white/10" />
+        <div className="h-3.5 w-[70%] rounded bg-white/[0.06]" />
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/feed/FeedList.tsx
+++ b/packages/ui/src/components/feed/FeedList.tsx
@@ -1,8 +1,11 @@
 import { useRef, memo, useCallback, useEffect, useState } from "react";
 import { useVirtualizer, useWindowVirtualizer } from "@tanstack/react-virtual";
 import { FeedItem } from "./FeedItem.js";
+import { FeedItemSkeleton } from "./FeedItemSkeleton.js";
 import type { FeedItem as FeedItemType } from "@freed/shared";
 import { useAppStore, usePlatform } from "../../context/PlatformContext.js";
+
+const SKELETON_COUNT = 8;
 
 /** Returns true when the viewport is narrower than Tailwind's `md` breakpoint (768px). */
 function useIsMobile(): boolean {
@@ -106,6 +109,7 @@ export function FeedList({
 
   const isMobile = useIsMobile();
   const { FeedEmptyState } = usePlatform();
+  const isLoading = useAppStore((s) => s.isLoading);
   const showEngagementCounts = useAppStore(
     (s) => s.preferences.display.showEngagementCounts,
   );
@@ -165,6 +169,21 @@ export function FeedList({
     }
     scrollReadHighWater.current = minVisible - 1;
   });
+
+  // Show shimmer placeholders while the doc is loading from IndexedDB.
+  // Once isLoading flips false, items will populate and we drop into the
+  // normal virtualizer path (or the empty state if the library is genuinely empty).
+  if (isLoading && items.length === 0) {
+    return (
+      <div className="flex-1 min-h-0 overflow-auto overscroll-none minimal-scroll">
+        <div className="px-4 pt-4 space-y-4 max-w-2xl mx-auto">
+          {Array.from({ length: SKELETON_COUNT }, (_, i) => (
+            <FeedItemSkeleton key={i} />
+          ))}
+        </div>
+      </div>
+    );
+  }
 
   if (items.length === 0) {
     // Search returned no results — custom empty state.

--- a/packages/ui/src/components/feed/index.ts
+++ b/packages/ui/src/components/feed/index.ts
@@ -1,4 +1,5 @@
 export { FeedList } from "./FeedList.js";
 export { FeedItem } from "./FeedItem.js";
+export { FeedItemSkeleton } from "./FeedItemSkeleton.js";
 export { FeedView } from "./FeedView.js";
 export { ReaderView } from "./ReaderView.js";


### PR DESCRIPTION
(AI Generated)

## Summary

- Removes the full-screen black spinner on startup. The app shell and skeleton feed cards appear immediately on first paint.
- Both stores now flip `isInitialized: true` right after `initDoc()`, then fire the three startup migrations (`docHealUntitledFeedTitles`, `docDeduplicateFeedItems`, `docPruneArchivedItems`) as fire-and-forget background work. `subscribe()` is wired before the flip so doc mutations propagate to the UI automatically.
- Adds a new `FeedItemSkeleton` shimmer component rendered by `FeedList` when `isLoading && items.length === 0`, hiding the unavoidable IDB read + WASM deserialize time behind real app chrome instead of a black screen.

## Test plan

- [ ] Launch Freed Desktop with a large library -- app shell and skeleton cards should appear immediately, then snap to real content
- [ ] Launch with an empty/fresh library -- skeletons appear then transition to the "Welcome to Freed" empty state
- [ ] Verify feed titles, dedup, and prune still run correctly after first render (check that "Untitled Feed" heals and archived items prune on next launch)
- [ ] Verify the error screen still appears correctly when `initDoc()` throws