### PR TITLE
fix: stop Automerge undefined writes from crashing RSS and X sync

### DIFF
--- a/packages/capture-x/src/normalize.ts
+++ b/packages/capture-x/src/normalize.ts
@@ -203,11 +203,16 @@ export function tweetToFeedItem(tweet: XTweetResult): FeedItem {
     id: displayTweet.core.user_results.result.rest_id,
     handle: displayTweet.core.user_results.result.legacy.screen_name,
     displayName: displayTweet.core.user_results.result.legacy.name,
-    avatarUrl:
-      displayTweet.core.user_results.result.legacy.profile_image_url_https.replace(
-        "_normal",
-        "_bigger"
-      ), // Get larger avatar
+    // Optional-chain in case the API omits the avatar URL on some tweet types.
+    // addFeedItem's stripUndefined removes the key if this resolves to undefined.
+    ...(displayTweet.core.user_results.result.legacy.profile_image_url_https
+      ? {
+          avatarUrl: displayTweet.core.user_results.result.legacy.profile_image_url_https.replace(
+            "_normal",
+            "_bigger"
+          ),
+        }
+      : {}),
   };
 
   // Build content

--- a/packages/desktop/src/lib/capture.ts
+++ b/packages/desktop/src/lib/capture.ts
@@ -84,94 +84,140 @@ export async function addRssFeed(feedUrl: string): Promise<void> {
 const FETCH_CONCURRENCY = 5;
 
 /**
- * Refresh all subscribed RSS feeds.
+ * Refresh all subscribed RSS feeds and the X timeline.
  *
  * Key performance contract: ALL feed fetches run in parallel batches, and the
  * entire result (feed timestamps + new items) is committed as ONE Automerge
  * change. Previously this was N sequential changes → N full-doc IndexedDB
  * writes → N React re-renders → N rankFeedItems passes. Now it's 1.
+ *
+ * Error isolation contract: RSS and X are fully independent. A failure in
+ * either path is logged and surfaces a user notification, but never prevents
+ * the other path from running. Individual feed fetch failures are logged
+ * silently unless every single feed failed (in which case the user is told).
  */
 export async function refreshAllFeeds(): Promise<void> {
   const store = useAppStore.getState();
   const feeds = Object.values(store.feeds).filter((f) => f.enabled);
 
-  // Skip the entire function only when there is nothing to do at all:
-  // no RSS feeds AND no authenticated X account.
+  // Skip only when there is truly nothing to do.
   if (feeds.length === 0 && !store.xAuth.isAuthenticated) return;
 
   store.setSyncing(true);
   store.setError(null);
 
   try {
-    const allNewItems: FeedItem[] = [];
-    const fetchedFeeds: RssFeed[] = [];
+    // ── RSS feeds ─────────────────────────────────────────────────────────────
+    // Each feed fetch is already isolated by Promise.allSettled. The Automerge
+    // commit is wrapped in its own try/catch so a CRDT write error can't
+    // prevent the X capture below from running.
+    try {
+      const allNewItems: FeedItem[] = [];
+      const fetchedFeeds: RssFeed[] = [];
+      const feedErrors: string[] = [];
 
-    // Parallel fetch with concurrency cap
-    for (let i = 0; i < feeds.length; i += FETCH_CONCURRENCY) {
-      const batch = feeds.slice(i, i + FETCH_CONCURRENCY);
-      const results = await Promise.allSettled(
-        batch.map(async (feed) => {
-          const { items, liveTitle, liveSiteUrl } = await fetchRssFeed(feed.url);
+      // Parallel fetch with concurrency cap
+      for (let i = 0; i < feeds.length; i += FETCH_CONCURRENCY) {
+        const batch = feeds.slice(i, i + FETCH_CONCURRENCY);
+        const results = await Promise.allSettled(
+          batch.map(async (feed) => {
+            const { items, liveTitle, liveSiteUrl } = await fetchRssFeed(feed.url);
 
-          // Sentinel check: OPML fallback or raw URL as title both indicate a broken import.
-          const isUntitled = feed.title === "Untitled Feed" || feed.title === feed.url;
+            // Sentinel check: OPML fallback or raw URL as title both indicate a broken import.
+            const isUntitled = feed.title === "Untitled Feed" || feed.title === feed.url;
 
-          // Resolve the best available title:
-          //   1. Live XML title (if the parser found one)
-          //   2. Hostname of the feed URL (e.g. "news.ycombinator.com") as a
-          //      last resort so the feed doesn't stay labelled "Untitled Feed"
-          //      forever when the XML genuinely omits a <title> element.
-          let healedTitle: string | undefined;
-          if (isUntitled) {
-            try {
-              healedTitle = liveTitle ?? new URL(feed.url).hostname.replace(/^(?:www|feeds?)\./, "");
-            } catch {
-              healedTitle = liveTitle;
+            // Resolve the best available title:
+            //   1. Live XML title (if the parser found one)
+            //   2. Hostname of the feed URL (e.g. "news.ycombinator.com") as a
+            //      last resort so the feed doesn't stay labelled "Untitled Feed"
+            //      forever when the XML genuinely omits a <title> element.
+            let healedTitle: string | undefined;
+            if (isUntitled) {
+              try {
+                healedTitle = liveTitle ?? new URL(feed.url).hostname.replace(/^(?:www|feeds?)\./, "");
+              } catch {
+                healedTitle = liveTitle;
+              }
+              console.log(
+                `[Heal] ${feed.url} | stored="${feed.title}" liveTitle="${liveTitle}" healedTitle="${healedTitle}"`,
+              );
             }
-            console.log(
-              `[Heal] ${feed.url} | stored="${feed.title}" liveTitle="${liveTitle}" healedTitle="${healedTitle}"`,
-            );
-          }
 
-          return {
-            feed: {
-              ...feed,
-              lastFetched: Date.now(),
-              ...(healedTitle ? { title: healedTitle } : {}),
-              ...(!feed.siteUrl && liveSiteUrl ? { siteUrl: liveSiteUrl } : {}),
-            },
-            items,
-          };
-        }),
-      );
-      for (const result of results) {
-        if (result.status === "fulfilled") {
-          fetchedFeeds.push(result.value.feed);
-          allNewItems.push(...result.value.items);
-        } else {
-          console.error("[Refresh] Feed fetch failed:", result.reason);
+            return {
+              feed: {
+                ...feed,
+                lastFetched: Date.now(),
+                ...(healedTitle ? { title: healedTitle } : {}),
+                ...(!feed.siteUrl && liveSiteUrl ? { siteUrl: liveSiteUrl } : {}),
+              },
+              items,
+            };
+          }),
+        );
+
+        for (const result of results) {
+          if (result.status === "fulfilled") {
+            fetchedFeeds.push(result.value.feed);
+            allNewItems.push(...result.value.items);
+          } else {
+            const msg = result.reason instanceof Error
+              ? result.reason.message
+              : String(result.reason);
+            console.error("[Refresh] Feed fetch failed:", result.reason);
+            feedErrors.push(msg);
+          }
         }
       }
+
+      // Single Automerge change for ALL feed + item updates
+      if (fetchedFeeds.length > 0 || allNewItems.length > 0) {
+        await docBatchRefreshFeeds(fetchedFeeds, allNewItems);
+      }
+
+      // Surface per-feed failures to the user only when every feed failed.
+      // Partial failures are logged but kept silent — some fresh content is
+      // better than a scary error banner.
+      if (feedErrors.length > 0) {
+        if (feedErrors.length === feeds.length) {
+          store.setError(
+            feedErrors.length === 1
+              ? `Feed failed to load: ${feedErrors[0]}`
+              : `All ${feedErrors.length} feeds failed to load. Check your network connection.`,
+          );
+        } else {
+          console.warn(
+            `[Refresh] ${feedErrors.length}/${feeds.length} feeds failed (partial):`,
+            feedErrors,
+          );
+        }
+      }
+    } catch (rssError) {
+      // Automerge commit error or unexpected RSS failure — log and notify,
+      // but continue so the X capture below still runs.
+      const msg = rssError instanceof Error ? rssError.message : "RSS refresh failed";
+      console.error("[Refresh] RSS batch failed:", rssError);
+      store.setError(msg);
     }
 
-    // Single Automerge change for ALL feed + item updates
-    if (fetchedFeeds.length > 0 || allNewItems.length > 0) {
-      await docBatchRefreshFeeds(fetchedFeeds, allNewItems);
-    }
-
-    // X timeline — separate change since it has its own auth path
-    const { xAuth } = store;
+    // ── X timeline ────────────────────────────────────────────────────────────
+    // Always runs — completely independent of RSS outcome. captureXTimeline
+    // already calls store.setError on auth/network failures; we add a fallback
+    // here so any unexpected throw is still surfaced and logged.
+    const { xAuth } = useAppStore.getState();
     if (xAuth.isAuthenticated && xAuth.cookies) {
       try {
         await captureXTimeline(xAuth.cookies);
-      } catch (error) {
-        console.error("Failed to capture X timeline:", error);
+      } catch (xError) {
+        console.error("[Refresh] X timeline failed:", xError);
+        // captureXTimeline sets the store error before re-throwing; only set
+        // ours if something slipped through without doing so.
+        if (!useAppStore.getState().error) {
+          store.setError(
+            xError instanceof Error ? xError.message : "X timeline sync failed",
+          );
+        }
       }
     }
-  } catch (error) {
-    store.setError(
-      error instanceof Error ? error.message : "Failed to refresh feeds",
-    );
   } finally {
     store.setSyncing(false);
   }

--- a/packages/desktop/src/lib/content-fetcher.ts
+++ b/packages/desktop/src/lib/content-fetcher.ts
@@ -126,11 +126,14 @@ async function processNext(): Promise<void> {
       }
     }
 
-    // Write metadata + short text summary to Automerge (syncs to all devices)
+    // Write metadata + short text summary to Automerge (syncs to all devices).
+    // author is omitted rather than set to undefined — Automerge's proxy
+    // throws on undefined assignments and updateFeedItem uses Object.assign.
+    const resolvedAuthor = content.author ?? metadata.author;
     await docUpdateFeedItem(entry.globalId, {
       preservedContent: {
         text: summaryText.slice(0, 10_000),
-        author: content.author ?? metadata.author,
+        ...(resolvedAuthor !== undefined ? { author: resolvedAuthor } : {}),
         publishedAt: metadata.publishedAt,
         wordCount: content.wordCount,
         readingTime: content.readingTime,

--- a/packages/shared/src/schema.ts
+++ b/packages/shared/src/schema.ts
@@ -122,6 +122,10 @@ export function addFeedItem(doc: FreedDoc, item: FeedItem): void {
 /**
  * Update a feed item in the document
  *
+ * Strips `undefined` values before writing — callers may produce partial
+ * updates where optional fields are `undefined` (e.g. `savedAt` when
+ * un-saving, `author` when content extraction yields nothing).
+ *
  * @param doc - The Automerge document (mutable within A.change)
  * @param globalId - The item's global ID
  * @param updates - Partial updates to apply
@@ -133,7 +137,7 @@ export function updateFeedItem(
 ): void {
   const existing = doc.feedItems[globalId];
   if (existing) {
-    Object.assign(existing, updates);
+    Object.assign(existing, stripUndefined(updates));
   }
 }
 
@@ -273,15 +277,21 @@ export function hideItem(doc: FreedDoc, globalId: string): void {
 /**
  * Add an RSS feed subscription
  *
+ * Strips `undefined` values before writing — feed metadata derived from live
+ * XML (imageUrl, siteUrl, etc.) is optional and may be undefined for feeds
+ * that lack those elements.
+ *
  * @param doc - The Automerge document (mutable within A.change)
  * @param feed - The RSS feed to add
  */
 export function addRssFeed(doc: FreedDoc, feed: RssFeed): void {
-  doc.rssFeeds[feed.url] = feed;
+  doc.rssFeeds[feed.url] = stripUndefined(feed);
 }
 
 /**
  * Update an RSS feed
+ *
+ * Strips `undefined` values before writing for the same reasons as addRssFeed.
  *
  * @param doc - The Automerge document (mutable within A.change)
  * @param url - The feed URL
@@ -294,7 +304,7 @@ export function updateRssFeed(
 ): void {
   const existing = doc.rssFeeds[url];
   if (existing) {
-    Object.assign(existing, updates);
+    Object.assign(existing, stripUndefined(updates));
   }
 }
 

--- a/packages/ui/src/components/feed/ReaderView.tsx
+++ b/packages/ui/src/components/feed/ReaderView.tsx
@@ -149,11 +149,14 @@ export function ReaderView({ item, onClose }: ReaderViewProps) {
   }, [item.globalId, articleUrl, getLocalContent]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const toggleSaved = useCallback(() => {
+    const nowSaved = !item.userState.saved;
     updateItem(item.globalId, {
       userState: {
         ...item.userState,
-        saved: !item.userState.saved,
-        savedAt: item.userState.saved ? undefined : Date.now(),
+        saved: nowSaved,
+        // Omit savedAt when un-saving rather than setting undefined —
+        // Automerge's proxy throws on undefined assignments.
+        ...(nowSaved ? { savedAt: Date.now() } : {}),
       },
     });
   }, [updateItem, item.globalId, item.userState]);


### PR DESCRIPTION
(AI Generated)

## Summary

- `addRssFeed`, `updateRssFeed`, and `updateFeedItem` in `schema.ts` now call `stripUndefined` before writing to the Automerge proxy. Optional fields like `imageUrl`, `siteUrl`, `savedAt`, and `preservedContent.author` were reaching the proxy as `undefined`, throwing "Cannot assign undefined value" errors that crashed the entire sync pipeline.
- `refreshAllFeeds` in `capture.ts` is split into independent RSS and X try/catch blocks. An Automerge write failure on the RSS path no longer prevents the X timeline capture from running. The error was silently suppressing all X feed loading and surfacing as a cryptic red message in the X empty state.
- `profile_image_url_https` in the X normalizer now uses a conditional spread instead of a bare `.replace()` call, so a missing avatar URL results in a clean omission rather than a TypeError.
- `content-fetcher.ts` omits `preservedContent.author` when neither the article extractor nor the metadata parser resolved an author string.
- `ReaderView.tsx` uses a conditional spread for `savedAt` when un-saving so it's never written as `undefined`.

## Test plan

- [ ] Sync RSS feeds -- items load without red error text appearing in any source view
- [ ] X timeline loads (the Automerge crash no longer prevents `captureXTimeline` from being called)
- [ ] Saving and un-saving a post in the reader view does not throw a console error
- [ ] With a network issue on one feed, other feeds still load and no user-visible error appears unless ALL feeds fail