### PR TITLE
fix: add value and cursorType fields to FollowingEntry.content type

### DIFF
--- a/packages/capture-x/src/types.ts
+++ b/packages/capture-x/src/types.ts
@@ -296,12 +296,15 @@ export interface FollowingEntry {
   entryId: string;
   sortIndex: string;
   content: {
-    entryType: "TimelineTimelineItem";
+    entryType: "TimelineTimelineItem" | "TimelineTimelineCursor";
     itemContent?: {
       user_results: {
         result: XUserResult;
       };
     };
+    /** Pagination token — present on cursor entries only */
+    value?: string;
+    cursorType?: "Top" | "Bottom";
   };
 }
 


### PR DESCRIPTION
(AI Generated)

## Summary

- `FollowingEntry.content` in `types.ts` was missing `value?: string` and `cursorType?: "Top" | "Bottom"`. Cursor entries in the Following timeline carry these fields at runtime, and `client.ts` reads `entry.content.value` to extract the pagination cursor. TypeScript rejected these accesses, causing the Release Desktop App workflow to fail on all platforms at the "Build workspace dependencies" step.

## Root cause

The inline object type for `FollowingEntry.content` only modeled user-result entries (`entryType: "TimelineTimelineItem"`). Cursor entries (`entryType: "TimelineTimelineCursor"`) have a different shape that wasn't captured. The fix widens `entryType` to include the cursor variant and adds the two optional cursor fields.

## Test plan

- [ ] `npx tsc -p packages/capture-x/tsconfig.json --noEmit` exits 0
- [ ] Release Desktop App workflow succeeds on all platforms