### PR TITLE
fix: remove hardcoded local path from .cargo/config.toml

### DIFF
--- a/packages/desktop/src-tauri/.cargo/config.toml
+++ b/packages/desktop/src-tauri/.cargo/config.toml
@@ -1,7 +1,8 @@
 [build]
-# Share the compiled Rust artifact cache across all git worktrees.
-# Without this, each new worktree recompiles all 500+ crates from scratch
-# even though the compiled crates are identical. With a shared target-dir,
-# only the first ever build pays the full compile cost; all subsequent
-# worktrees reuse it and compile only the changed application code.
-target-dir = "/Users/aubreyfalconer/.cargo/freed-target"
+# To share the compiled Rust artifact cache across git worktrees (avoids
+# recompiling all 500+ crates per worktree), set CARGO_TARGET_DIR in your
+# shell profile instead of hardcoding it here:
+#
+#   export CARGO_TARGET_DIR="$HOME/.cargo/freed-target"
+#
+# Cargo respects that env var without anything needing to be committed.


### PR DESCRIPTION
(AI Generated)

## Summary

- `packages/desktop/src-tauri/.cargo/config.toml` had `target-dir = "/Users/aubreyfalconer/.cargo/freed-target"`. This is a local machine path that CI runners cannot access, causing "Permission denied (os error 13)" on macOS and Linux, and breaking artifact lookup on Windows. Every release build since the file was introduced has been failing.
- Replaced with a comment explaining how to get the same worktree cache-sharing benefit locally via the `CARGO_TARGET_DIR` environment variable (which Cargo respects without anything committed).

## Test plan

- [ ] Release Desktop App workflow completes on all 4 platforms (macOS arm64, macOS x86_64, Linux, Windows)