### PR TITLE
fix: center feed cards to match skeleton layout

### DIFF
--- a/packages/ui/src/components/feed/FeedList.tsx
+++ b/packages/ui/src/components/feed/FeedList.tsx
@@ -274,17 +274,18 @@ export function FeedList({
                 // list container's top, not the window's origin.
                 transform: `translateY(${virtualItem.start - windowVirtualizer.options.scrollMargin}px)`,
               }}
-              className={`px-3 pb-3 max-w-2xl mx-auto${virtualItem.index === 0 ? " pt-3" : ""}`}
             >
-              <FeedItemRow
-                item={items[virtualItem.index]}
-                index={virtualItem.index}
-                focused={virtualItem.index === focusedIndex}
-                showEngagement={showEngagementCounts}
-                onItemClick={onItemClick}
-                onFocusChange={onFocusChange}
-                onItemSave={onItemSave}
-              />
+              <div className={`px-3 pb-3 max-w-2xl mx-auto${virtualItem.index === 0 ? " pt-3" : ""}`}>
+                <FeedItemRow
+                  item={items[virtualItem.index]}
+                  index={virtualItem.index}
+                  focused={virtualItem.index === focusedIndex}
+                  showEngagement={showEngagementCounts}
+                  onItemClick={onItemClick}
+                  onFocusChange={onFocusChange}
+                  onItemSave={onItemSave}
+                />
+              </div>
             </div>
           ))}
         </div>
@@ -314,18 +315,19 @@ export function FeedList({
               width: "100%",
               transform: `translateY(${virtualItem.start}px)`,
             }}
-            className={`px-4 pb-4 max-w-2xl mx-auto${virtualItem.index === 0 ? " pt-4" : ""}`}
           >
-            <FeedItemRow
-              item={items[virtualItem.index]}
-              index={virtualItem.index}
-              focused={virtualItem.index === focusedIndex}
-              showEngagement={showEngagementCounts}
-              onItemClick={onItemClick}
-              onFocusChange={onFocusChange}
-              onItemSave={onItemSave}
-              onItemArchive={onItemArchive}
-            />
+            <div className={`px-4 pb-4 max-w-2xl mx-auto${virtualItem.index === 0 ? " pt-4" : ""}`}>
+              <FeedItemRow
+                item={items[virtualItem.index]}
+                index={virtualItem.index}
+                focused={virtualItem.index === focusedIndex}
+                showEngagement={showEngagementCounts}
+                onItemClick={onItemClick}
+                onFocusChange={onFocusChange}
+                onItemSave={onItemSave}
+                onItemArchive={onItemArchive}
+              />
+            </div>
           </div>
         ))}
       </div>


### PR DESCRIPTION
(AI Generated)

## Summary

- Feed cards were left-aligned on wide viewports because `mx-auto` has no effect on absolutely-positioned elements with `left: 0` pinned
- Wrap each virtualizer row's content in a normal-flow inner div so `max-w-2xl mx-auto` works correctly, matching the centered skeleton loading state
- Affects both the mobile (window scroll) and desktop (element scroll) virtualizer paths

## Test plan

- [ ] Open the feed on a wide desktop window -- cards should be centered
- [ ] Verify the skeleton loading state and loaded cards are aligned identically
- [ ] Check mobile layout is unchanged