### PR TITLE
fix: switch X API to GET, update feature flags, grant fs caps

### DIFF
--- a/packages/capture-x/src/browser.ts
+++ b/packages/capture-x/src/browser.ts
@@ -15,6 +15,8 @@
 
 export * from "./types.js";
 
+export type { EndpointDefinition } from "./endpoints.js";
+
 export {
   X_API_BASE,
   X_BEARER_TOKEN,

--- a/packages/capture-x/src/endpoints.ts
+++ b/packages/capture-x/src/endpoints.ts
@@ -23,43 +23,55 @@ export const X_BEARER_TOKEN =
 // =============================================================================
 
 /**
- * Common feature flags required by most endpoints
+ * Common feature flags shared across endpoints.
+ * Derived from the current X web client (TwitterInternalAPIDocument).
  */
 export const COMMON_FEATURES = {
-  rweb_tipjar_consumption_enabled: true,
-  responsive_web_graphql_exclude_directive_enabled: true,
+  rweb_video_screen_enabled: false,
+  profile_label_improvements_pcf_label_in_post_enabled: true,
+  responsive_web_profile_redirect_enabled: false,
+  rweb_tipjar_consumption_enabled: false,
   verified_phone_label_enabled: false,
   creator_subscriptions_tweet_preview_api_enabled: true,
   responsive_web_graphql_timeline_navigation_enabled: true,
   responsive_web_graphql_skip_user_profile_image_extensions_enabled: false,
+  premium_content_api_read_enabled: false,
   communities_web_enable_tweet_community_results_fetch: true,
   c9s_tweet_anatomy_moderator_badge_enabled: true,
+  responsive_web_grok_analyze_button_fetch_trends_enabled: false,
+  responsive_web_grok_analyze_post_followups_enabled: false,
+  responsive_web_jetfuel_frame: true,
+  responsive_web_grok_share_attachment_enabled: true,
+  responsive_web_grok_annotations_enabled: true,
   articles_preview_enabled: true,
-  tweetypie_unmention_optimization_enabled: true,
   responsive_web_edit_tweet_api_enabled: true,
   graphql_is_translatable_rweb_tweet_is_translatable_enabled: true,
   view_counts_everywhere_api_enabled: true,
   longform_notetweets_consumption_enabled: true,
   responsive_web_twitter_article_tweet_consumption_enabled: true,
   tweet_awards_web_tipping_enabled: false,
-  creator_subscriptions_quote_tweet_preview_enabled: false,
+  content_disclosure_indicator_enabled: true,
+  content_disclosure_ai_generated_indicator_enabled: true,
+  responsive_web_grok_show_grok_translated_post: false,
+  responsive_web_grok_analysis_button_from_backend: true,
+  post_ctas_fetch_enabled: false,
   freedom_of_speech_not_reach_fetch_enabled: true,
   standardized_nudges_misinfo: true,
   tweet_with_visibility_results_prefer_gql_limited_actions_policy_enabled: true,
-  rweb_video_timestamps_enabled: true,
   longform_notetweets_rich_text_read_enabled: true,
   longform_notetweets_inline_media_enabled: true,
+  responsive_web_grok_image_annotation_enabled: true,
+  responsive_web_grok_imagine_annotation_enabled: true,
+  responsive_web_grok_community_note_auto_translation_is_enabled: false,
   responsive_web_enhance_cards_enabled: false,
 };
 
 /**
- * Timeline-specific features
+ * Timeline-specific features (HomeTimeline / HomeLatestTimeline).
+ * Same set as COMMON_FEATURES for now — kept separate for future divergence.
  */
 export const TIMELINE_FEATURES = {
   ...COMMON_FEATURES,
-  responsive_web_home_pinned_timelines_enabled: true,
-  blue_business_profile_image_shape_enabled: true,
-  profile_foundations_has_custom_visual_feature_enabled: false,
 };
 
 // =============================================================================
@@ -149,7 +161,11 @@ export function buildRequestBody(
 }
 
 /**
- * Default variables for HomeLatestTimeline
+ * Default variables for HomeLatestTimeline.
+ *
+ * X's schema only validates the variable names it declares. Sending unknown
+ * variables (e.g. `requestContext`, `withCommunity`) causes a 422
+ * GRAPHQL_VALIDATION_FAILED. Keeping this to the documented minimum set.
  */
 export function getHomeLatestTimelineVariables(
   cursor?: string,
@@ -159,8 +175,6 @@ export function getHomeLatestTimelineVariables(
     count,
     includePromotedContent: true,
     latestControlAvailable: true,
-    requestContext: "launch",
-    withCommunity: true,
   };
 
   if (cursor) {

--- a/packages/desktop/src-tauri/capabilities/default.json
+++ b/packages/desktop/src-tauri/capabilities/default.json
@@ -7,6 +7,8 @@
     "core:default",
     "shell:allow-open",
     "updater:default",
-    "process:default"
+    "process:default",
+    "fs:allow-appdata-read-recursive",
+    "fs:allow-appdata-write-recursive"
   ]
 }

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -307,7 +307,11 @@ async fn fetch_url(url: String) -> Result<String, String> {
     response.text().await.map_err(|e| e.to_string())
 }
 
-/// Make an authenticated POST to the X (Twitter) API.
+/// Make an authenticated request to the X (Twitter) API.
+///
+/// Supports both GET (timeline queries) and POST (mutations). The X web client
+/// uses GET for read-only GraphQL queries — sending them as POST causes 422
+/// GRAPHQL_VALIDATION_FAILED.
 ///
 /// The client bypasses any system/environment proxy (`no_proxy`) and connects
 /// directly to x.com. This matters in dev where the shell may export an
@@ -318,6 +322,7 @@ async fn x_api_request(
     url: String,
     body: String,
     headers: std::collections::HashMap<String, String>,
+    method: Option<String>,
 ) -> Result<String, String> {
     let client = reqwest::Client::builder()
         .user_agent("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/132.0.0.0 Safari/537.36")
@@ -330,7 +335,13 @@ async fn x_api_request(
         .build()
         .map_err(|e| e.to_string())?;
 
-    let mut request = client.post(&url).body(body);
+    let req_builder = if method.as_deref() == Some("GET") {
+        client.get(&url)
+    } else {
+        client.post(&url).body(body)
+    };
+
+    let mut request = req_builder;
     for (key, value) in headers {
         request = request.header(&key, &value);
     }

--- a/packages/desktop/src/lib/x-capture.test.ts
+++ b/packages/desktop/src/lib/x-capture.test.ts
@@ -10,7 +10,7 @@
  * diagnostic panel after the first successful sync.
  */
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { fetchXTimeline } from "./x-capture";
 import type { XCookies } from "./x-auth";
 

--- a/packages/desktop/src/lib/x-capture.ts
+++ b/packages/desktop/src/lib/x-capture.ts
@@ -15,7 +15,6 @@ import {
   X_API_BASE,
   X_BEARER_TOKEN,
   HomeLatestTimeline,
-  buildRequestBody,
   tweetsToFeedItems,
   deduplicateFeedItems,
   getHomeLatestTimelineVariables,
@@ -33,15 +32,19 @@ import { addDebugEvent } from "@freed/ui/lib/debug-store";
  * A function that sends an HTTP request to the X API and returns the raw
  * response body as a string. In production this calls Tauri's x_api_request
  * command; in tests any function that returns fixture JSON can be substituted.
+ *
+ * `method` defaults to "GET" — X's read-only GraphQL endpoints expect GET
+ * with variables/features encoded as URL query params.
  */
 export type XRequester = (
   url: string,
   body: string,
   headers: Record<string, string>,
+  method?: string,
 ) => Promise<string>;
 
-const defaultRequester: XRequester = (url, body, headers) =>
-  invoke<string>("x_api_request", { url, body, headers });
+const defaultRequester: XRequester = (url, body, headers, method = "GET") =>
+  invoke<string>("x_api_request", { url, body, headers, method });
 
 // =============================================================================
 // Diagnostic Types
@@ -93,24 +96,29 @@ export interface XSyncResult {
 
 async function xRequest(
   cookies: XCookies,
-  endpoint: Parameters<typeof buildRequestBody>[0],
+  endpoint: { queryId: string; operationName: string; features: Record<string, boolean> },
   variables: Record<string, unknown>,
   requester: XRequester,
 ): Promise<string> {
-  const url = `${X_API_BASE}/${endpoint.queryId}/${endpoint.operationName}`;
-  const body = buildRequestBody(endpoint, variables);
+  // X read-only GraphQL endpoints use GET with variables/features as URL params.
+  // Sending them as POST causes 422 GRAPHQL_VALIDATION_FAILED.
+  const base = `${X_API_BASE}/${endpoint.queryId}/${endpoint.operationName}`;
+  const params = new URLSearchParams({
+    variables: JSON.stringify(variables),
+    features: JSON.stringify(endpoint.features),
+  });
+  const url = `${base}?${params.toString()}`;
 
   const headers: Record<string, string> = {
     authorization: `Bearer ${X_BEARER_TOKEN}`,
     "x-csrf-token": cookies.ct0,
     cookie: `ct0=${cookies.ct0}; auth_token=${cookies.authToken}`,
-    "content-type": "application/json",
     "x-twitter-active-user": "yes",
     "x-twitter-auth-type": "OAuth2Session",
     "x-twitter-client-language": "en",
   };
 
-  return requester(url, body, headers);
+  return requester(url, "", headers, "GET");
 }
 
 // =============================================================================


### PR DESCRIPTION
(AI Generated)

## Summary

- **X 422 GRAPHQL_VALIDATION_FAILED**: The `HomeLatestTimeline` endpoint expects `GET` with `variables`/`features` as URL query params, not `POST` with a JSON body. The `xRequest` function now builds a GET URL, and the Rust `x_api_request` command accepts an optional `method` parameter.
- **Invalid variables**: `requestContext: "launch"` and `withCommunity` are not in the X schema for this endpoint. Removing them was causing the validation failure.
- **Stale feature flags**: Refreshed `COMMON_FEATURES` and `TIMELINE_FEATURES` to match the current X web client schema (37 flags total), adding new Grok and content-disclosure flags and removing ones the API no longer declares.
- **`fs.write_text_file not allowed`**: The content cache writes article HTML to `{appDataDir}/content/` via the Tauri fs plugin, but the capability was never granted. Added `fs:allow-appdata-read-recursive` and `fs:allow-appdata-write-recursive` to `capabilities/default.json`.

## Test plan

- [ ] Build and run `npm run tauri:dev` -- confirm no Rust compile errors
- [ ] In Settings > Sources > X, click Sync Now -- expect items to appear or a different, more meaningful error
- [ ] Verify no `fs.write_text_file not allowed` errors in the Events panel after opening a feed item