### PR TITLE
perf: fix feed reader lockup and move PWA Automerge to a Web Worker

### DIFF
--- a/packages/desktop/src/lib/automerge.ts
+++ b/packages/desktop/src/lib/automerge.ts
@@ -42,15 +42,14 @@ let currentDoc: FreedDoc | null = null;
 type Subscriber = (doc: FreedDoc) => void;
 const subscribers = new Set<Subscriber>();
 
-/** Snapshot current doc stats into the debug store */
+/** Snapshot current doc stats into the debug store using the cached binary. */
 function snapshotDoc(): void {
-  if (!currentDoc) return;
-  const binary = A.save(currentDoc);
+  if (!currentDoc || !lastBinary) return;
   setDocSnapshot({
     deviceId: (currentDoc.meta?.deviceId as string | undefined) ?? "unknown",
     itemCount: Object.keys(currentDoc.feedItems ?? {}).length,
     feedCount: Object.keys(currentDoc.rssFeeds ?? {}).length,
-    binarySize: binary.byteLength,
+    binarySize: lastBinary.byteLength,
     savedAt: Date.now(),
   });
 }
@@ -63,6 +62,8 @@ export async function initDoc(): Promise<FreedDoc> {
 
   if (saved) {
     currentDoc = A.load<FreedDoc>(saved);
+    // Use the stored bytes directly — no need to re-serialize on startup.
+    lastBinary = saved;
   } else {
     currentDoc = createEmptyDoc();
     await saveDoc();
@@ -71,13 +72,12 @@ export async function initDoc(): Promise<FreedDoc> {
   const deviceId = (currentDoc.meta?.deviceId as string | undefined) ?? "unknown";
   addDebugEvent("init", `device ...${deviceId.slice(-8)}`);
   // Defer the debug snapshot so it doesn't block the init render path.
-  // A.save() is synchronous WASM work — run it after the UI is visible.
   setTimeout(() => snapshotDoc(), 0);
 
   registerDocAccessors(
     () => currentDoc,
     () => JSON.stringify(A.toJS(currentDoc!), null, 2),
-    () => A.save(currentDoc!),
+    () => lastBinary ?? new Uint8Array(0),
   );
 
   return currentDoc;
@@ -93,30 +93,65 @@ export function getDoc(): FreedDoc {
   return currentDoc;
 }
 
+// Pending save timer — debounces A.save() so rapid back-to-back mutations
+// (e.g. mark-as-read while scrolling) batch into a single WASM serialization.
+let saveTimer: ReturnType<typeof setTimeout> | null = null;
+
+// Latest serialized binary — refreshed in flushSave(), used for relay broadcast
+// and getDocBinary() so callers never need to call A.save() themselves.
+let lastBinary: Uint8Array | null = null;
+
 /**
- * Save the current document to IndexedDB
+ * Schedule a debounced persist + relay broadcast. A.save() is synchronous WASM
+ * work; running it on every mutation blocks the main thread before React can
+ * paint. Deferring by 400 ms lets the UI render first while still persisting
+ * and syncing promptly.
+ *
+ * Callers that need the doc saved immediately (init, mergeDoc) use flushSave().
  */
-async function saveDoc(): Promise<void> {
+function scheduleSave(): void {
+  if (saveTimer) clearTimeout(saveTimer);
+  saveTimer = setTimeout(() => {
+    saveTimer = null;
+    void flushSave().then(() => broadcastToRelay());
+  }, 400);
+}
+
+/** Serialize and persist the doc immediately (bypasses debounce). */
+async function flushSave(): Promise<void> {
   if (!currentDoc) return;
-  const binary = A.save(currentDoc);
-  await storage.save(binary);
+  if (saveTimer) {
+    clearTimeout(saveTimer);
+    saveTimer = null;
+  }
+  lastBinary = A.save(currentDoc);
+  await storage.save(lastBinary);
 }
 
 /**
- * Broadcast the current document to all connected PWA clients via Tauri relay
+ * Save the current document to IndexedDB (immediate, for init/merge paths).
+ */
+async function saveDoc(): Promise<void> {
+  await flushSave();
+}
+
+/**
+ * Push the latest binary to connected PWA clients via Tauri relay.
+ * Uses the cached binary from the last flushSave() — no extra A.save() call.
  */
 async function broadcastToRelay(): Promise<void> {
-  if (!currentDoc) return;
+  if (!lastBinary) return;
   try {
-    const bytes = A.save(currentDoc);
-    await invoke("broadcast_doc", { docBytes: Array.from(bytes) });
+    await invoke("broadcast_doc", { docBytes: Array.from(lastBinary) });
   } catch {
     // Relay may not be running yet or no clients connected — safe to ignore
   }
 }
 
 /**
- * Apply a change to the document and persist
+ * Apply a change to the document, notify subscribers immediately, and schedule
+ * a debounced persist. Subscribers (and React) fire right after A.change()
+ * so the UI paints before A.save() runs on the main thread.
  */
 async function applyChange(
   changeFn: (doc: FreedDoc) => void,
@@ -127,16 +162,16 @@ async function applyChange(
   }
 
   currentDoc = A.change(currentDoc, message || "update", changeFn);
-  await saveDoc();
-  addDebugEvent("change", message);
 
-  // Notify subscribers
+  // Notify subscribers and push to relay BEFORE persisting so React can paint.
+  addDebugEvent("change", message);
   for (const subscriber of subscribers) {
     subscriber(currentDoc);
   }
-
-  // Push updated doc to connected PWA clients
   broadcastToRelay();
+
+  // Defer the expensive WASM serialization until after the frame paints.
+  scheduleSave();
 
   return currentDoc;
 }
@@ -543,13 +578,14 @@ export async function docAddStubItem(
 }
 
 /**
- * Get binary representation for sync
+ * Return the latest serialized binary for sync/relay.
+ * Uses the cached value from the last flushSave() — no extra A.save() call.
  */
 export function getDocBinary(): Uint8Array {
-  if (!currentDoc) {
+  if (!lastBinary) {
     throw new Error("Document not initialized");
   }
-  return A.save(currentDoc);
+  return lastBinary;
 }
 
 /**

--- a/packages/pwa/src/lib/automerge-types.ts
+++ b/packages/pwa/src/lib/automerge-types.ts
@@ -1,0 +1,76 @@
+/**
+ * Shared message types for the Automerge Web Worker boundary.
+ *
+ * Main thread → worker: WorkerRequest (typed action objects)
+ * Worker → main thread: WorkerResponse (state updates, acks, debug events)
+ *
+ * Using typed action objects instead of function closures lets us cross the
+ * postMessage boundary without serialization loss.
+ */
+
+import type { FeedItem, Friend, ReachOutLog, RssFeed, UserPreferences } from "@freed/shared";
+
+// ---------------------------------------------------------------------------
+// Hydrated state posted to the main thread after every doc mutation.
+// Plain JS — safe for structured-clone transfer.
+// ---------------------------------------------------------------------------
+
+export interface DocState {
+  items: FeedItem[];
+  feeds: Record<string, RssFeed>;
+  friends: Record<string, Friend>;
+  preferences: UserPreferences;
+  feedUnreadCounts: Record<string, number>;
+  feedTotalCounts: Record<string, number>;
+  totalUnreadCount: number;
+  unreadCountByPlatform: Record<string, number>;
+  totalItemCount: number;
+  itemCountByPlatform: Record<string, number>;
+  totalArchivableCount: number;
+  archivableCountByPlatform: Record<string, number>;
+  archivableFeedCounts: Record<string, number>;
+}
+
+// ---------------------------------------------------------------------------
+// Main thread → worker
+// ---------------------------------------------------------------------------
+
+export type WorkerRequest =
+  | { reqId: number; type: "INIT" }
+  | { reqId: number; type: "MARK_AS_READ"; globalId: string }
+  | { reqId: number; type: "MARK_ALL_AS_READ"; platform?: string }
+  | { reqId: number; type: "TOGGLE_SAVED"; globalId: string }
+  | { reqId: number; type: "TOGGLE_ARCHIVED"; globalId: string }
+  | { reqId: number; type: "ADD_FEED_ITEM"; item: FeedItem }
+  | { reqId: number; type: "ADD_FEED_ITEMS"; items: FeedItem[] }
+  | { reqId: number; type: "REMOVE_FEED_ITEM"; globalId: string }
+  | { reqId: number; type: "UPDATE_FEED_ITEM"; globalId: string; updates: Partial<FeedItem> }
+  | { reqId: number; type: "ARCHIVE_ALL_READ_UNSAVED"; platform?: string; feedUrl?: string }
+  | { reqId: number; type: "PRUNE_ARCHIVED_ITEMS"; maxAgeMs?: number }
+  | { reqId: number; type: "ADD_RSS_FEED"; feed: RssFeed }
+  | { reqId: number; type: "REMOVE_RSS_FEED"; url: string }
+  | { reqId: number; type: "UPDATE_RSS_FEED"; url: string; updates: Partial<RssFeed> }
+  | { reqId: number; type: "REMOVE_ALL_FEEDS"; includeItems: boolean }
+  | { reqId: number; type: "UPDATE_PREFERENCES"; updates: Partial<UserPreferences> }
+  | { reqId: number; type: "UPDATE_LAST_SYNC" }
+  | { reqId: number; type: "ADD_FRIEND"; friend: Friend }
+  | { reqId: number; type: "UPDATE_FRIEND"; friendId: string; updates: Partial<Friend> }
+  | { reqId: number; type: "REMOVE_FRIEND"; friendId: string }
+  | { reqId: number; type: "LOG_REACH_OUT"; friendId: string; entry: ReachOutLog }
+  | { reqId: number; type: "ADD_STUB_ITEM"; url: string; tags: string[] }
+  | { reqId: number; type: "MERGE_DOC"; binary: Uint8Array }
+  | { reqId: number; type: "CLEAR_LOCAL" };
+
+// ---------------------------------------------------------------------------
+// Worker → main thread
+// ---------------------------------------------------------------------------
+
+export type WorkerResponse =
+  /** Simple acknowledgement for mutations that return void */
+  | { reqId: number; type: "ACK"; error?: string }
+  /** Broadcast on every doc mutation — main thread uses this to update UI */
+  | { type: "STATE_UPDATE"; state: DocState; binary: Uint8Array }
+  /** Debug panel event forwarding */
+  | { type: "DEBUG_EVENT"; kind: string; detail?: string; bytes?: number }
+  /** Doc size snapshot for the debug panel */
+  | { type: "DEBUG_SNAPSHOT"; deviceId: string; itemCount: number; feedCount: number; binarySize: number };

--- a/packages/pwa/src/lib/automerge.ts
+++ b/packages/pwa/src/lib/automerge.ts
@@ -1,395 +1,280 @@
 /**
- * Automerge document management for Freed PWA
+ * Automerge document client for Freed PWA (main thread)
  *
- * Handles loading, saving, and syncing the Automerge CRDT document.
+ * This module is a thin wrapper around the Automerge Web Worker. All WASM
+ * operations (A.change, A.save, A.load, A.merge) run in the worker thread,
+ * keeping the main thread free to paint and respond to user input.
+ *
+ * Public API is identical to the previous direct implementation so callers
+ * (store.ts, sync.ts, App.tsx) require no changes other than the subscriber
+ * type changing from (doc: FreedDoc) to (state: DocState).
  */
 
-import * as A from "@automerge/automerge";
-import { IndexedDBStorage } from "@freed/sync/storage/indexeddb";
-import type { FreedDoc } from "@freed/shared/schema";
-import {
-  createEmptyDoc,
-  addFeedItem,
-  addRssFeed,
-  removeRssFeed,
-  removeAllFeeds,
-  updateRssFeed,
-  updateFeedItem,
-  removeFeedItem,
-  markAsRead,
-  toggleSaved,
-  toggleArchived,
-  archiveAllReadUnsaved,
-  pruneArchivedItems,
-  updatePreferences,
-  updateLastSync,
-  addFriend,
-  updateFriend,
-  removeFriend,
-  logReachOut,
-} from "@freed/shared/schema";
-import type { FeedItem, Friend, ReachOutLog, RssFeed, UserPreferences } from "@freed/shared";
 import { addDebugEvent, setDocSnapshot, registerDocAccessors } from "@freed/ui/lib/debug-store";
+import type { FeedItem, Friend, ReachOutLog, RssFeed, UserPreferences } from "@freed/shared";
+import type { DocState, WorkerRequest, WorkerResponse } from "./automerge-types";
+export type { DocState } from "./automerge-types";
 
-// Singleton storage instance
-const storage = new IndexedDBStorage();
+// ---------------------------------------------------------------------------
+// Worker lifecycle
+// ---------------------------------------------------------------------------
 
-// Current document state
-let currentDoc: FreedDoc | null = null;
+const worker = new Worker(new URL("./automerge.worker.ts", import.meta.url), {
+  type: "module",
+});
 
-// Subscribers for document changes
-type Subscriber = (doc: FreedDoc) => void;
-const subscribers = new Set<Subscriber>();
+// ---------------------------------------------------------------------------
+// Request/response plumbing
+// ---------------------------------------------------------------------------
 
-/** Snapshot current doc stats into the debug store */
-function snapshotDoc(): void {
-  if (!currentDoc) return;
-  const binary = A.save(currentDoc);
-  setDocSnapshot({
-    deviceId: (currentDoc.meta?.deviceId as string | undefined) ?? "unknown",
-    itemCount: Object.keys(currentDoc.feedItems ?? {}).length,
-    feedCount: Object.keys(currentDoc.rssFeeds ?? {}).length,
-    binarySize: binary.byteLength,
-    savedAt: Date.now(),
+let nextReqId = 1;
+const pending = new Map<number, { resolve: () => void; reject: (err: Error) => void }>();
+
+function request(msg: WorkerRequest): Promise<void> {
+  return new Promise((resolve, reject) => {
+    pending.set(msg.reqId, { resolve, reject });
+    worker.postMessage(msg);
   });
 }
 
-/**
- * Initialize or load the Automerge document
- */
-export async function initDoc(): Promise<FreedDoc> {
-  const saved = await storage.load();
+// Latest binary from the worker — updated on every STATE_UPDATE.
+// Returned synchronously by getDocBinary() so sync.ts callers are unchanged.
+let lastBinary: Uint8Array | null = null;
 
-  if (saved) {
-    currentDoc = A.load<FreedDoc>(saved);
-  } else {
-    currentDoc = createEmptyDoc();
-    await saveDoc();
-  }
+// ---------------------------------------------------------------------------
+// Subscriber model
+// ---------------------------------------------------------------------------
 
-  const deviceId = (currentDoc.meta?.deviceId as string | undefined) ?? "unknown";
-  addDebugEvent("init", `device ...${deviceId.slice(-8)}`);
-  // Defer the debug snapshot so it doesn't block the init render path.
-  // A.save() is synchronous WASM work — run it after the UI is visible.
-  setTimeout(() => snapshotDoc(), 0);
+type Subscriber = (state: DocState) => void;
+const subscribers = new Set<Subscriber>();
 
-  // Register window escape hatch so the console can inspect the live doc.
-  registerDocAccessors(
-    () => currentDoc,
-    () => JSON.stringify(A.toJS(currentDoc!), null, 2),
-    () => A.save(currentDoc!),
-  );
-
-  return currentDoc;
-}
-
-/**
- * Get the current document (throws if not initialized)
- */
-export function getDoc(): FreedDoc {
-  if (!currentDoc) {
-    throw new Error("Document not initialized. Call initDoc() first.");
-  }
-  return currentDoc;
-}
-
-/**
- * Save the current document to IndexedDB
- */
-async function saveDoc(): Promise<void> {
-  if (!currentDoc) return;
-  const binary = A.save(currentDoc);
-  await storage.save(binary);
-}
-
-/**
- * Apply a change to the document and persist
- */
-async function applyChange(
-  changeFn: (doc: FreedDoc) => void,
-  message?: string
-): Promise<FreedDoc> {
-  if (!currentDoc) {
-    throw new Error("Document not initialized. Call initDoc() first.");
-  }
-
-  currentDoc = A.change(currentDoc, message || "update", changeFn);
-  await saveDoc();
-  addDebugEvent("change", message);
-
-  // Notify subscribers
-  for (const subscriber of subscribers) {
-    subscriber(currentDoc);
-  }
-
-  return currentDoc;
-}
-
-/**
- * Subscribe to document changes
- */
 export function subscribe(callback: Subscriber): () => void {
   subscribers.add(callback);
   return () => subscribers.delete(callback);
 }
 
-// =============================================================================
-// Document Operations (wrapped for persistence)
-// =============================================================================
+// ---------------------------------------------------------------------------
+// Inbound worker message handler
+// ---------------------------------------------------------------------------
 
-export async function docAddFeedItem(item: FeedItem): Promise<FreedDoc> {
-  // Guard: never overwrite an existing item — that would clobber the user's
-  // read/saved/tags state. Consistent with the bulk docAddFeedItems path.
-  return applyChange((doc) => {
-    if (!doc.feedItems[item.globalId]) {
-      addFeedItem(doc, item);
+worker.onmessage = (event: MessageEvent<WorkerResponse>) => {
+  const msg = event.data;
+
+  if (msg.type === "STATE_UPDATE") {
+    lastBinary = msg.binary;
+    for (const sub of subscribers) sub(msg.state);
+    return;
+  }
+
+  if (msg.type === "DEBUG_EVENT") {
+    addDebugEvent(msg.kind as Parameters<typeof addDebugEvent>[0], msg.detail, msg.bytes);
+    return;
+  }
+
+  if (msg.type === "DEBUG_SNAPSHOT") {
+    setDocSnapshot({
+      deviceId: msg.deviceId,
+      itemCount: msg.itemCount,
+      feedCount: msg.feedCount,
+      binarySize: msg.binarySize,
+      savedAt: Date.now(),
+    });
+    return;
+  }
+
+  // ACK — resolve or reject the pending promise
+  const p = pending.get(msg.reqId);
+  if (!p) return;
+  pending.delete(msg.reqId);
+  if (msg.error) {
+    p.reject(new Error(msg.error));
+  } else {
+    p.resolve();
+  }
+};
+
+worker.onerror = (err) => {
+  console.error("[AutomergeWorker] Unhandled error:", err);
+};
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Initialize the Automerge document. Must be called once before any mutations.
+ * Returns the initial hydrated state (equivalent to the old FreedDoc return,
+ * but already processed into plain JS — no WASM on the main thread).
+ */
+export async function initDoc(): Promise<DocState> {
+  return new Promise((resolve, reject) => {
+    const reqId = nextReqId++;
+
+    // One-time handler: resolve with the state from the first STATE_UPDATE
+    // that arrives while we wait for the INIT ACK.
+    let initialState: DocState | null = null;
+    let initAcked = false;
+
+    function tryResolve() {
+      if (initialState && initAcked) resolve(initialState);
     }
-  }, "Add feed item");
-}
 
-export async function docAddRssFeed(feed: RssFeed): Promise<FreedDoc> {
-  return applyChange((doc) => addRssFeed(doc, feed), "Add RSS feed");
-}
-
-export async function docRemoveRssFeed(url: string): Promise<FreedDoc> {
-  return applyChange((doc) => removeRssFeed(doc, url), "Remove RSS feed");
-}
-
-export async function docUpdateRssFeed(
-  url: string,
-  updates: Parameters<typeof updateRssFeed>[2]
-): Promise<FreedDoc> {
-  return applyChange((doc) => updateRssFeed(doc, url, updates), "Update RSS feed");
-}
-
-export async function docUpdateFeedItem(
-  globalId: string,
-  updates: Partial<FeedItem>
-): Promise<FreedDoc> {
-  return applyChange(
-    (doc) => updateFeedItem(doc, globalId, updates),
-    "Update feed item"
-  );
-}
-
-export async function docRemoveFeedItem(globalId: string): Promise<FreedDoc> {
-  return applyChange(
-    (doc) => removeFeedItem(doc, globalId),
-    "Remove feed item"
-  );
-}
-
-export async function docMarkAsRead(globalId: string): Promise<FreedDoc> {
-  return applyChange((doc) => markAsRead(doc, globalId), "Mark as read");
-}
-
-export async function docToggleSaved(globalId: string): Promise<FreedDoc> {
-  return applyChange((doc) => toggleSaved(doc, globalId), "Toggle saved");
-}
-
-export async function docToggleArchived(globalId: string): Promise<FreedDoc> {
-  return applyChange((doc) => toggleArchived(doc, globalId), "Toggle archived");
-}
-
-export async function docArchiveAllReadUnsaved(
-  platform?: string,
-  feedUrl?: string,
-): Promise<FreedDoc> {
-  return applyChange(
-    (doc) => archiveAllReadUnsaved(doc, platform, feedUrl),
-    "Archive all read",
-  );
-}
-
-export async function docPruneArchivedItems(maxAgeMs?: number): Promise<FreedDoc> {
-  return applyChange(
-    (doc) => pruneArchivedItems(doc, maxAgeMs),
-    "Prune archived items",
-  );
-}
-
-export async function docUpdatePreferences(
-  updates: Partial<UserPreferences>
-): Promise<FreedDoc> {
-  return applyChange(
-    (doc) => updatePreferences(doc, updates),
-    "Update preferences"
-  );
-}
-
-export async function docUpdateLastSync(): Promise<FreedDoc> {
-  return applyChange((doc) => updateLastSync(doc), "Update last sync");
-}
-
-// =============================================================================
-// Friend Operations
-// =============================================================================
-
-export async function docAddFriend(friend: Friend): Promise<FreedDoc> {
-  return applyChange((doc) => addFriend(doc, friend), "Add friend");
-}
-
-export async function docUpdateFriend(
-  id: string,
-  updates: Partial<Friend>
-): Promise<FreedDoc> {
-  return applyChange((doc) => updateFriend(doc, id, updates), "Update friend");
-}
-
-export async function docRemoveFriend(id: string): Promise<FreedDoc> {
-  return applyChange((doc) => removeFriend(doc, id), "Remove friend");
-}
-
-export async function docLogReachOut(
-  id: string,
-  entry: ReachOutLog
-): Promise<FreedDoc> {
-  return applyChange((doc) => logReachOut(doc, id, entry), "Log reach-out");
-}
-
-/**
- * Remove all feed subscriptions in a single CRDT change.
- * When includeItems is true, all articles are also deleted.
- * This change propagates to all synced devices.
- */
-export async function docRemoveAllFeeds(includeItems: boolean): Promise<FreedDoc> {
-  return applyChange(
-    (doc) => removeAllFeeds(doc, includeItems),
-    includeItems ? "Remove all feeds and articles" : "Remove all feeds",
-  );
-}
-
-/**
- * Wipe the IndexedDB document store for this device.
- * Local-only — does NOT propagate to other devices.
- * After calling this, reload the page to start fresh.
- */
-export async function clearLocalDoc(): Promise<void> {
-  await storage.clear();
-}
-
-/**
- * Mark all unread items as read in a single Automerge change.
- * Optionally filter by platform.
- */
-export async function docMarkAllAsRead(platform?: string): Promise<FreedDoc> {
-  return applyChange((doc) => {
-    const now = Date.now();
-    for (const item of Object.values(doc.feedItems)) {
-      if (item.userState.readAt) continue;
-      if (item.userState.hidden || item.userState.archived) continue;
-      if (platform && item.platform !== platform) continue;
-      item.userState.readAt = now;
-    }
-  }, "Mark all as read");
-}
-
-/**
- * Bulk add feed items (more efficient for initial feed fetch)
- */
-export async function docAddFeedItems(items: FeedItem[]): Promise<FreedDoc> {
-  return applyChange((doc) => {
-    for (const item of items) {
-      // Only add if not already present
-      if (!doc.feedItems[item.globalId]) {
-        addFeedItem(doc, item);
+    const stateHandler = (event: MessageEvent<WorkerResponse>) => {
+      const msg = event.data;
+      if (msg.type === "STATE_UPDATE" && !initialState) {
+        lastBinary = msg.binary;
+        initialState = msg.state;
+        tryResolve();
+      } else if (msg.type === "ACK" && msg.reqId === reqId) {
+        // Register the doc accessors so window.__freed works in the console.
+        registerDocAccessors(
+          () => null,
+          () => "(doc lives in worker — not directly accessible)",
+          () => lastBinary ?? new Uint8Array(0),
+        );
+        worker.removeEventListener("message", stateHandler);
+        if (msg.error) {
+          reject(new Error(msg.error));
+        } else {
+          initAcked = true;
+          tryResolve();
+        }
       }
-    }
-  }, `Add ${items.length} feed items`);
+    };
+
+    worker.addEventListener("message", stateHandler);
+    worker.postMessage({ reqId, type: "INIT" } satisfies WorkerRequest);
+  });
+}
+
+/** Binary snapshot of the current doc — used by sync.ts for relay/cloud upload. */
+export function getDocBinary(): Uint8Array {
+  if (!lastBinary) throw new Error("Document not initialized");
+  return lastBinary;
+}
+
+/** Merge incoming sync binary into the doc (relay / cloud download). */
+export async function mergeDoc(incoming: Uint8Array): Promise<void> {
+  const reqId = nextReqId++;
+  return request({ reqId, type: "MERGE_DOC", binary: incoming });
+}
+
+/** Permanently wipe the local IndexedDB store. Reload the page afterwards. */
+export async function clearLocalDoc(): Promise<void> {
+  const reqId = nextReqId++;
+  return request({ reqId, type: "CLEAR_LOCAL" });
+}
+
+// ---------------------------------------------------------------------------
+// Document mutations — one function per schema operation
+// ---------------------------------------------------------------------------
+
+export async function docAddFeedItem(item: FeedItem): Promise<void> {
+  const reqId = nextReqId++;
+  return request({ reqId, type: "ADD_FEED_ITEM", item });
+}
+
+export async function docAddFeedItems(items: FeedItem[]): Promise<void> {
+  const reqId = nextReqId++;
+  return request({ reqId, type: "ADD_FEED_ITEMS", items });
+}
+
+export async function docRemoveFeedItem(globalId: string): Promise<void> {
+  const reqId = nextReqId++;
+  return request({ reqId, type: "REMOVE_FEED_ITEM", globalId });
+}
+
+export async function docUpdateFeedItem(globalId: string, updates: Partial<FeedItem>): Promise<void> {
+  const reqId = nextReqId++;
+  return request({ reqId, type: "UPDATE_FEED_ITEM", globalId, updates });
+}
+
+export async function docMarkAsRead(globalId: string): Promise<void> {
+  const reqId = nextReqId++;
+  return request({ reqId, type: "MARK_AS_READ", globalId });
+}
+
+export async function docMarkAllAsRead(platform?: string): Promise<void> {
+  const reqId = nextReqId++;
+  return request({ reqId, type: "MARK_ALL_AS_READ", platform });
+}
+
+export async function docToggleSaved(globalId: string): Promise<void> {
+  const reqId = nextReqId++;
+  return request({ reqId, type: "TOGGLE_SAVED", globalId });
+}
+
+export async function docToggleArchived(globalId: string): Promise<void> {
+  const reqId = nextReqId++;
+  return request({ reqId, type: "TOGGLE_ARCHIVED", globalId });
+}
+
+export async function docArchiveAllReadUnsaved(platform?: string, feedUrl?: string): Promise<void> {
+  const reqId = nextReqId++;
+  return request({ reqId, type: "ARCHIVE_ALL_READ_UNSAVED", platform, feedUrl });
+}
+
+export async function docPruneArchivedItems(maxAgeMs?: number): Promise<void> {
+  const reqId = nextReqId++;
+  return request({ reqId, type: "PRUNE_ARCHIVED_ITEMS", maxAgeMs });
+}
+
+export async function docAddRssFeed(feed: RssFeed): Promise<void> {
+  const reqId = nextReqId++;
+  return request({ reqId, type: "ADD_RSS_FEED", feed });
+}
+
+export async function docRemoveRssFeed(url: string): Promise<void> {
+  const reqId = nextReqId++;
+  return request({ reqId, type: "REMOVE_RSS_FEED", url });
+}
+
+export async function docUpdateRssFeed(url: string, updates: Partial<RssFeed>): Promise<void> {
+  const reqId = nextReqId++;
+  return request({ reqId, type: "UPDATE_RSS_FEED", url, updates });
+}
+
+export async function docRemoveAllFeeds(includeItems: boolean): Promise<void> {
+  const reqId = nextReqId++;
+  return request({ reqId, type: "REMOVE_ALL_FEEDS", includeItems });
+}
+
+export async function docUpdatePreferences(updates: Partial<UserPreferences>): Promise<void> {
+  const reqId = nextReqId++;
+  return request({ reqId, type: "UPDATE_PREFERENCES", updates });
+}
+
+export async function docUpdateLastSync(): Promise<void> {
+  const reqId = nextReqId++;
+  return request({ reqId, type: "UPDATE_LAST_SYNC" });
+}
+
+export async function docAddFriend(friend: Friend): Promise<void> {
+  const reqId = nextReqId++;
+  return request({ reqId, type: "ADD_FRIEND", friend });
+}
+
+export async function docUpdateFriend(friendId: string, updates: Partial<Friend>): Promise<void> {
+  const reqId = nextReqId++;
+  return request({ reqId, type: "UPDATE_FRIEND", friendId, updates });
+}
+
+export async function docRemoveFriend(friendId: string): Promise<void> {
+  const reqId = nextReqId++;
+  return request({ reqId, type: "REMOVE_FRIEND", friendId });
+}
+
+export async function docLogReachOut(friendId: string, entry: ReachOutLog): Promise<void> {
+  const reqId = nextReqId++;
+  return request({ reqId, type: "LOG_REACH_OUT", friendId, entry });
 }
 
 /**
  * Add a minimal stub FeedItem for a URL that has not yet been fetched.
- *
- * Used by the PWA Save URL flow. The stub syncs to the desktop via relay,
- * where the content fetcher picks it up, fetches the HTML (bypassing CORS),
- * extracts the content, and syncs the result back to all devices.
- *
- * The stub has no preservedContent -- the desktop fills that in after fetch.
+ * The stub is created inside the worker; the return value is void because
+ * the PWA caller (App.tsx) does not use the returned stub object.
  */
-export async function docAddStubItem(
-  url: string,
-  tags: string[] = [],
-): Promise<FeedItem> {
-  let hash = 0;
-  for (let i = 0; i < url.length; i++) {
-    const ch = url.charCodeAt(i);
-    hash = (hash << 5) - hash + ch;
-    hash = hash & hash;
-  }
-  const globalId = `saved:${Math.abs(hash).toString(36)}`;
-  const now = Date.now();
-
-  let hostname = url;
-  try {
-    hostname = new URL(url).hostname;
-  } catch {
-    // malformed URL
-  }
-
-  const stub: FeedItem = {
-    globalId,
-    platform: "saved",
-    contentType: "article",
-    capturedAt: now,
-    publishedAt: now,
-    author: { id: hostname, handle: hostname, displayName: hostname },
-    content: {
-      text: url,
-      mediaUrls: [],
-      mediaTypes: [],
-      linkPreview: { url, title: url },
-    },
-    userState: { hidden: false, saved: true, savedAt: now, archived: false, tags },
-    topics: [],
-  };
-
-  await applyChange((doc) => {
-    if (!doc.feedItems[stub.globalId]) {
-      addFeedItem(doc, stub);
-    }
-  }, `Add stub item for ${url}`);
-
-  return stub;
-}
-
-/**
- * Get binary representation for sync
- */
-export function getDocBinary(): Uint8Array {
-  if (!currentDoc) {
-    throw new Error("Document not initialized");
-  }
-  return A.save(currentDoc);
-}
-
-/**
- * Merge with incoming sync data
- */
-export async function mergeDoc(incoming: Uint8Array): Promise<FreedDoc> {
-  if (!currentDoc) {
-    throw new Error("Document not initialized");
-  }
-
-  try {
-    const beforeCount = Object.keys(currentDoc.feedItems ?? {}).length;
-    const incomingDoc = A.load<FreedDoc>(incoming);
-    currentDoc = A.merge(currentDoc, incomingDoc);
-    await saveDoc();
-
-    const afterCount = Object.keys(currentDoc.feedItems ?? {}).length;
-    const delta = afterCount - beforeCount;
-    addDebugEvent("merge_ok", delta !== 0 ? `${delta > 0 ? "+" : ""}${delta} items` : "no new items", incoming.byteLength);
-    snapshotDoc();
-  } catch (err) {
-    addDebugEvent("merge_err", err instanceof Error ? err.message : String(err));
-    throw err;
-  }
-
-  // Notify subscribers
-  for (const subscriber of subscribers) {
-    subscriber(currentDoc);
-  }
-
-  return currentDoc;
+export async function docAddStubItem(url: string, tags: string[] = []): Promise<void> {
+  const reqId = nextReqId++;
+  return request({ reqId, type: "ADD_STUB_ITEM", url, tags });
 }

--- a/packages/pwa/src/lib/automerge.worker.ts
+++ b/packages/pwa/src/lib/automerge.worker.ts
@@ -1,0 +1,383 @@
+/**
+ * Automerge document worker for Freed PWA
+ *
+ * Runs in a dedicated Web Worker so ALL WASM operations (A.change, A.save,
+ * A.load, A.merge) happen off the main thread. The main thread never blocks
+ * on CRDT work — it only receives plain-JS state updates via postMessage.
+ *
+ * Communication protocol:
+ *   Main → Worker : WorkerRequest  (typed action objects, no closures)
+ *   Worker → Main : WorkerResponse (state updates + acks)
+ */
+
+import * as A from "@automerge/automerge";
+import { IndexedDBStorage } from "@freed/sync/storage/indexeddb";
+import type { FreedDoc } from "@freed/shared/schema";
+import {
+  createEmptyDoc,
+  addFeedItem,
+  addRssFeed,
+  removeRssFeed,
+  removeAllFeeds,
+  updateRssFeed,
+  updateFeedItem,
+  removeFeedItem,
+  markAsRead,
+  toggleSaved,
+  toggleArchived,
+  archiveAllReadUnsaved,
+  pruneArchivedItems,
+  updatePreferences,
+  updateLastSync,
+  addFriend,
+  updateFriend,
+  removeFriend,
+  logReachOut,
+} from "@freed/shared/schema";
+import { rankFeedItems, createDefaultPreferences } from "@freed/shared";
+import type { FeedItem, Friend, RssFeed, UserPreferences } from "@freed/shared";
+import type { DocState, WorkerRequest, WorkerResponse } from "./automerge-types";
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+const storage = new IndexedDBStorage();
+let currentDoc: FreedDoc | null = null;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function send(msg: WorkerResponse): void {
+  self.postMessage(msg);
+}
+
+function ack(reqId: number, error?: string): void {
+  send({ reqId, type: "ACK", error });
+}
+
+/**
+ * Convert the Automerge proxy document to a plain-JS DocState for postMessage.
+ * A.toJS() converts CRDT proxies to regular objects, safe for structured clone.
+ */
+function hydrateFromDoc(doc: FreedDoc): DocState {
+  // A.toJS converts Automerge proxies to plain JS — required for postMessage
+  const plainItems = Object.values(A.toJS(doc.feedItems) as Record<string, FeedItem>);
+  const feeds = A.toJS(doc.rssFeeds) as Record<string, RssFeed>;
+  const friends = A.toJS(doc.friends ?? {}) as Record<string, Friend>;
+  const preferences = A.toJS(doc.preferences) as UserPreferences;
+
+  const visibleItems = plainItems.filter((item) => !item.userState.hidden);
+  const rankedItems = rankFeedItems(
+    visibleItems.sort((a, b) => b.publishedAt - a.publishedAt),
+    preferences.weights,
+  );
+
+  const feedUnreadCounts: Record<string, number> = {};
+  const feedTotalCounts: Record<string, number> = {};
+  const unreadCountByPlatform: Record<string, number> = {};
+  const itemCountByPlatform: Record<string, number> = {};
+  const archivableCountByPlatform: Record<string, number> = {};
+  const archivableFeedCounts: Record<string, number> = {};
+  let totalUnreadCount = 0;
+  let totalItemCount = 0;
+  let totalArchivableCount = 0;
+
+  for (const item of plainItems) {
+    if (item.userState.hidden || item.userState.archived) continue;
+    totalItemCount++;
+    itemCountByPlatform[item.platform] = (itemCountByPlatform[item.platform] ?? 0) + 1;
+    if (item.rssSource) {
+      const url = item.rssSource.feedUrl;
+      feedTotalCounts[url] = (feedTotalCounts[url] ?? 0) + 1;
+    }
+    if (!item.userState.readAt) {
+      totalUnreadCount++;
+      unreadCountByPlatform[item.platform] = (unreadCountByPlatform[item.platform] ?? 0) + 1;
+      if (item.rssSource) {
+        const url = item.rssSource.feedUrl;
+        feedUnreadCounts[url] = (feedUnreadCounts[url] ?? 0) + 1;
+      }
+    } else if (!item.userState.saved) {
+      totalArchivableCount++;
+      archivableCountByPlatform[item.platform] = (archivableCountByPlatform[item.platform] ?? 0) + 1;
+      if (item.rssSource) {
+        const url = item.rssSource.feedUrl;
+        archivableFeedCounts[url] = (archivableFeedCounts[url] ?? 0) + 1;
+      }
+    }
+  }
+
+  return {
+    items: rankedItems,
+    feeds,
+    friends,
+    preferences,
+    feedUnreadCounts,
+    feedTotalCounts,
+    totalUnreadCount,
+    unreadCountByPlatform,
+    totalItemCount,
+    itemCountByPlatform,
+    totalArchivableCount,
+    archivableCountByPlatform,
+    archivableFeedCounts,
+  };
+}
+
+/**
+ * Persist the doc to IndexedDB and broadcast the hydrated state + binary to
+ * the main thread. Called after every mutation.
+ */
+async function saveAndBroadcast(): Promise<void> {
+  if (!currentDoc) return;
+  const binary = A.save(currentDoc);
+  await storage.save(binary);
+  const state = hydrateFromDoc(currentDoc);
+
+  const snapshot: Extract<WorkerResponse, { type: "DEBUG_SNAPSHOT" }> = {
+    type: "DEBUG_SNAPSHOT",
+    deviceId: (currentDoc.meta?.deviceId as string | undefined) ?? "unknown",
+    itemCount: Object.keys(currentDoc.feedItems ?? {}).length,
+    feedCount: Object.keys(currentDoc.rssFeeds ?? {}).length,
+    binarySize: binary.byteLength,
+  };
+  send(snapshot);
+
+  // binary is cloned by structured-clone on postMessage (not transferred) so
+  // the copy in storage.save() above is not affected.
+  const stateUpdate: WorkerResponse = { type: "STATE_UPDATE", state, binary };
+  send(stateUpdate);
+}
+
+/**
+ * Apply a change function to the doc, persist, and broadcast state.
+ * Returns the updated doc.
+ */
+async function applyChange(
+  changeFn: (doc: FreedDoc) => void,
+  message: string,
+): Promise<void> {
+  if (!currentDoc) throw new Error("Document not initialized");
+  currentDoc = A.change(currentDoc, message, changeFn);
+  send({ type: "DEBUG_EVENT", kind: "change", detail: message });
+  await saveAndBroadcast();
+}
+
+// ---------------------------------------------------------------------------
+// Message handler
+// ---------------------------------------------------------------------------
+
+self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
+  const req = event.data;
+
+  try {
+    switch (req.type) {
+      case "INIT": {
+        const saved = await storage.load();
+        if (saved) {
+          currentDoc = A.load<FreedDoc>(saved);
+        } else {
+          currentDoc = createEmptyDoc();
+          const binary = A.save(currentDoc);
+          await storage.save(binary);
+        }
+        const deviceId = (currentDoc.meta?.deviceId as string | undefined) ?? "unknown";
+        send({ type: "DEBUG_EVENT", kind: "init", detail: `device ...${deviceId.slice(-8)}` });
+        // Send initial state back via STATE_UPDATE so the main thread can hydrate
+        await saveAndBroadcast();
+        ack(req.reqId);
+        break;
+      }
+
+      case "MARK_AS_READ":
+        await applyChange((doc) => markAsRead(doc, req.globalId), "Mark as read");
+        ack(req.reqId);
+        break;
+
+      case "MARK_ALL_AS_READ":
+        await applyChange((doc) => {
+          const now = Date.now();
+          for (const item of Object.values(doc.feedItems)) {
+            if (item.userState.readAt) continue;
+            if (item.userState.hidden || item.userState.archived) continue;
+            if (req.platform && item.platform !== req.platform) continue;
+            item.userState.readAt = now;
+          }
+        }, "Mark all as read");
+        ack(req.reqId);
+        break;
+
+      case "TOGGLE_SAVED":
+        await applyChange((doc) => toggleSaved(doc, req.globalId), "Toggle saved");
+        ack(req.reqId);
+        break;
+
+      case "TOGGLE_ARCHIVED":
+        await applyChange((doc) => toggleArchived(doc, req.globalId), "Toggle archived");
+        ack(req.reqId);
+        break;
+
+      case "ADD_FEED_ITEM":
+        await applyChange((doc) => {
+          if (!doc.feedItems[req.item.globalId]) addFeedItem(doc, req.item);
+        }, "Add feed item");
+        ack(req.reqId);
+        break;
+
+      case "ADD_FEED_ITEMS":
+        await applyChange((doc) => {
+          for (const item of req.items) {
+            if (!doc.feedItems[item.globalId]) addFeedItem(doc, item);
+          }
+        }, `Add ${req.items.length} feed items`);
+        ack(req.reqId);
+        break;
+
+      case "REMOVE_FEED_ITEM":
+        await applyChange((doc) => removeFeedItem(doc, req.globalId), "Remove feed item");
+        ack(req.reqId);
+        break;
+
+      case "UPDATE_FEED_ITEM":
+        await applyChange((doc) => updateFeedItem(doc, req.globalId, req.updates), "Update feed item");
+        ack(req.reqId);
+        break;
+
+      case "ARCHIVE_ALL_READ_UNSAVED":
+        await applyChange(
+          (doc) => archiveAllReadUnsaved(doc, req.platform, req.feedUrl),
+          "Archive all read",
+        );
+        ack(req.reqId);
+        break;
+
+      case "PRUNE_ARCHIVED_ITEMS":
+        await applyChange((doc) => pruneArchivedItems(doc, req.maxAgeMs), "Prune archived items");
+        ack(req.reqId);
+        break;
+
+      case "ADD_RSS_FEED":
+        await applyChange((doc) => addRssFeed(doc, req.feed), "Add RSS feed");
+        ack(req.reqId);
+        break;
+
+      case "REMOVE_RSS_FEED":
+        await applyChange((doc) => removeRssFeed(doc, req.url), "Remove RSS feed");
+        ack(req.reqId);
+        break;
+
+      case "UPDATE_RSS_FEED":
+        await applyChange((doc) => updateRssFeed(doc, req.url, req.updates as Parameters<typeof updateRssFeed>[2]), "Update RSS feed");
+        ack(req.reqId);
+        break;
+
+      case "REMOVE_ALL_FEEDS":
+        await applyChange((doc) => removeAllFeeds(doc, req.includeItems), req.includeItems ? "Remove all feeds and articles" : "Remove all feeds");
+        ack(req.reqId);
+        break;
+
+      case "UPDATE_PREFERENCES":
+        await applyChange((doc) => updatePreferences(doc, req.updates), "Update preferences");
+        ack(req.reqId);
+        break;
+
+      case "UPDATE_LAST_SYNC":
+        await applyChange((doc) => updateLastSync(doc), "Update last sync");
+        ack(req.reqId);
+        break;
+
+      case "ADD_FRIEND":
+        await applyChange((doc) => addFriend(doc, req.friend), "Add friend");
+        ack(req.reqId);
+        break;
+
+      case "UPDATE_FRIEND":
+        await applyChange((doc) => updateFriend(doc, req.friendId, req.updates as Partial<Friend>), "Update friend");
+        ack(req.reqId);
+        break;
+
+      case "REMOVE_FRIEND":
+        await applyChange((doc) => removeFriend(doc, req.friendId), "Remove friend");
+        ack(req.reqId);
+        break;
+
+      case "LOG_REACH_OUT":
+        await applyChange((doc) => logReachOut(doc, req.friendId, req.entry), "Log reach-out");
+        ack(req.reqId);
+        break;
+
+      case "ADD_STUB_ITEM": {
+        // Build the stub inside the worker so the globalId is consistent
+        let hash = 0;
+        for (let i = 0; i < req.url.length; i++) {
+          const ch = req.url.charCodeAt(i);
+          hash = (hash << 5) - hash + ch;
+          hash = hash & hash;
+        }
+        const globalId = `saved:${Math.abs(hash).toString(36)}`;
+        const now = Date.now();
+        let hostname = req.url;
+        try { hostname = new URL(req.url).hostname; } catch { /* malformed */ }
+
+        const stub: FeedItem = {
+          globalId,
+          platform: "saved",
+          contentType: "article",
+          capturedAt: now,
+          publishedAt: now,
+          author: { id: hostname, handle: hostname, displayName: hostname },
+          content: {
+            text: req.url,
+            mediaUrls: [],
+            mediaTypes: [],
+            linkPreview: { url: req.url, title: req.url },
+          },
+          userState: { hidden: false, saved: true, savedAt: now, archived: false, tags: req.tags },
+          topics: [],
+        };
+
+        await applyChange((doc) => {
+          if (!doc.feedItems[stub.globalId]) addFeedItem(doc, stub);
+        }, `Add stub item for ${req.url}`);
+        ack(req.reqId);
+        break;
+      }
+
+      case "MERGE_DOC": {
+        if (!currentDoc) throw new Error("Document not initialized");
+        const beforeCount = Object.keys(currentDoc.feedItems ?? {}).length;
+        const incomingDoc = A.load<FreedDoc>(req.binary);
+        currentDoc = A.merge(currentDoc, incomingDoc);
+        const afterCount = Object.keys(currentDoc.feedItems ?? {}).length;
+        const delta = afterCount - beforeCount;
+        send({
+          type: "DEBUG_EVENT",
+          kind: "merge_ok",
+          detail: delta !== 0 ? `${delta > 0 ? "+" : ""}${delta} items` : "no new items",
+          bytes: req.binary.byteLength,
+        });
+        await saveAndBroadcast();
+        ack(req.reqId);
+        break;
+      }
+
+      case "CLEAR_LOCAL":
+        await storage.clear();
+        ack(req.reqId);
+        break;
+
+      default: {
+        const _exhaustive: never = req;
+        void _exhaustive;
+        ack((req as WorkerRequest).reqId, `Unknown request type: ${(req as { type: string }).type}`);
+      }
+    }
+  } catch (err) {
+    ack(req.reqId, err instanceof Error ? err.message : String(err));
+  }
+};
+
+// Required for TypeScript module isolation
+export {};

--- a/packages/pwa/src/lib/store.ts
+++ b/packages/pwa/src/lib/store.ts
@@ -2,10 +2,13 @@
  * Global app state management with Zustand
  *
  * PWA version - uses Automerge for persistence and syncs with desktop.
+ * Hydration (CRDT → plain JS) now runs in the Automerge Web Worker, so the
+ * subscriber callback receives already-processed DocState — no O(n) work
+ * or WASM calls on the main thread.
  */
 
 import { create } from "zustand";
-import { createDefaultPreferences, rankFeedItems } from "@freed/shared";
+import { createDefaultPreferences } from "@freed/shared";
 import type { BaseAppState, Friend, ReachOutLog } from "@freed/shared";
 import {
   initDoc,
@@ -29,7 +32,7 @@ import {
   docRemoveFriend,
   docLogReachOut,
 } from "./automerge";
-import type { FreedDoc } from "@freed/shared/schema";
+import type { DocState } from "./automerge";
 
 /** PWA-specific store state — extends the shared base with sync connection status. */
 interface AppState extends BaseAppState {
@@ -39,8 +42,8 @@ interface AppState extends BaseAppState {
 
 /**
  * Shallow-compare two string-keyed number maps.
- * Used to preserve object identity on count maps so Zustand selectors that
- * subscribe to these objects don't trigger re-renders when values are unchanged.
+ * Preserves object identity on count maps so Zustand selectors don't trigger
+ * re-renders when values haven't changed.
  */
 function shallowEqualRecord(
   a: Record<string, number>,
@@ -50,71 +53,6 @@ function shallowEqualRecord(
   return (
     aKeys.length === Object.keys(b).length && aKeys.every((k) => a[k] === b[k])
   );
-}
-
-/**
- * Hydrate store state from Automerge document
- */
-function hydrateFromDoc(doc: FreedDoc): Partial<AppState> {
-  const allItems = Object.values(doc.feedItems);
-
-  const visibleItems = allItems.filter((item) => !item.userState.hidden);
-  const rankedItems = rankFeedItems(
-    visibleItems.sort((a, b) => b.publishedAt - a.publishedAt),
-    doc.preferences.weights,
-  );
-
-  // Single pass: derive all count derivations.
-  const feedUnreadCounts: Record<string, number> = {};
-  const feedTotalCounts: Record<string, number> = {};
-  const unreadCountByPlatform: Record<string, number> = {};
-  const itemCountByPlatform: Record<string, number> = {};
-  const archivableCountByPlatform: Record<string, number> = {};
-  const archivableFeedCounts: Record<string, number> = {};
-  let totalUnreadCount = 0;
-  let totalItemCount = 0;
-  let totalArchivableCount = 0;
-  for (const item of allItems) {
-    if (item.userState.hidden || item.userState.archived) continue;
-    totalItemCount++;
-    itemCountByPlatform[item.platform] = (itemCountByPlatform[item.platform] ?? 0) + 1;
-    if (item.rssSource) {
-      const url = item.rssSource.feedUrl;
-      feedTotalCounts[url] = (feedTotalCounts[url] ?? 0) + 1;
-    }
-    if (!item.userState.readAt) {
-      totalUnreadCount++;
-      unreadCountByPlatform[item.platform] = (unreadCountByPlatform[item.platform] ?? 0) + 1;
-      if (item.rssSource) {
-        const url = item.rssSource.feedUrl;
-        feedUnreadCounts[url] = (feedUnreadCounts[url] ?? 0) + 1;
-      }
-    } else if (!item.userState.saved) {
-      // Read and not saved: eligible for batch archive
-      totalArchivableCount++;
-      archivableCountByPlatform[item.platform] = (archivableCountByPlatform[item.platform] ?? 0) + 1;
-      if (item.rssSource) {
-        const url = item.rssSource.feedUrl;
-        archivableFeedCounts[url] = (archivableFeedCounts[url] ?? 0) + 1;
-      }
-    }
-  }
-
-  return {
-    items: rankedItems,
-    feeds: doc.rssFeeds,
-    friends: doc.friends ?? {},
-    preferences: doc.preferences,
-    feedUnreadCounts,
-    feedTotalCounts,
-    totalUnreadCount,
-    unreadCountByPlatform,
-    totalItemCount,
-    itemCountByPlatform,
-    totalArchivableCount,
-    archivableCountByPlatform,
-    archivableFeedCounts,
-  };
 }
 
 export const useAppStore = create<AppState>((set, get) => ({
@@ -141,42 +79,37 @@ export const useAppStore = create<AppState>((set, get) => ({
   selectedItemId: null,
   searchQuery: "",
 
-  // Initialize from Automerge
+  // Initialize from Automerge worker
   initialize: async () => {
     if (get().isInitialized) return;
 
     try {
       set({ isLoading: true });
-      const doc = await initDoc();
+      const state = await initDoc();
 
-      // Subscribe to future changes (for sync) before we flip isInitialized so
-      // background migrations that fire immediately after are propagated to the UI.
-      // Reuse count map references when values haven't changed so Sidebar
-      // selectors don't trigger re-renders on unrelated mutations.
-      subscribe((updatedDoc) => {
-        const next = hydrateFromDoc(updatedDoc);
+      // Subscribe to future changes before flipping isInitialized so background
+      // mutations (prune, sync merges) propagate to the UI immediately.
+      // Reuse count map references when values are unchanged to avoid
+      // re-rendering sidebar selectors on unrelated mutations.
+      subscribe((next: DocState) => {
         const prev = get();
-        if (shallowEqualRecord(next.feedUnreadCounts!, prev.feedUnreadCounts))
-          next.feedUnreadCounts = prev.feedUnreadCounts;
-        if (shallowEqualRecord(next.feedTotalCounts!, prev.feedTotalCounts))
-          next.feedTotalCounts = prev.feedTotalCounts;
-        if (shallowEqualRecord(next.unreadCountByPlatform!, prev.unreadCountByPlatform))
-          next.unreadCountByPlatform = prev.unreadCountByPlatform;
-        if (shallowEqualRecord(next.itemCountByPlatform!, prev.itemCountByPlatform))
-          next.itemCountByPlatform = prev.itemCountByPlatform;
-        set(next);
+        const merged = { ...next } as Partial<AppState>;
+        if (shallowEqualRecord(next.feedUnreadCounts, prev.feedUnreadCounts))
+          merged.feedUnreadCounts = prev.feedUnreadCounts;
+        if (shallowEqualRecord(next.feedTotalCounts, prev.feedTotalCounts))
+          merged.feedTotalCounts = prev.feedTotalCounts;
+        if (shallowEqualRecord(next.unreadCountByPlatform, prev.unreadCountByPlatform))
+          merged.unreadCountByPlatform = prev.unreadCountByPlatform;
+        if (shallowEqualRecord(next.itemCountByPlatform, prev.itemCountByPlatform))
+          merged.itemCountByPlatform = prev.itemCountByPlatform;
+        set(merged);
       });
 
-      // Hydrate and show the app immediately — no need to wait for migrations.
-      set({
-        ...hydrateFromDoc(doc),
-        isInitialized: true,
-        isLoading: false,
-      });
+      set({ ...state, isInitialized: true, isLoading: false });
 
       // Prune archived items in the background. Idempotent; failure is non-fatal.
-      // subscribe() above propagates the resulting doc change to the UI automatically.
-      const pruneDays = doc.preferences.display.archivePruneDays ?? 30;
+      // The subscriber above propagates the doc change to the UI automatically.
+      const pruneDays = state.preferences.display.archivePruneDays ?? 30;
       if (pruneDays > 0) {
         void docPruneArchivedItems(pruneDays * 24 * 60 * 60 * 1000).catch(() => {
           // non-fatal

--- a/packages/ui/src/components/feed/ReaderView.tsx
+++ b/packages/ui/src/components/feed/ReaderView.tsx
@@ -121,14 +121,28 @@ export function ReaderView({ item, onClose }: ReaderViewProps) {
       // Layer 3: Live fetch (online only)
       if (articleUrl && navigator.onLine) {
         setIsCaching(true);
-        liveFetch(articleUrl, item.globalId, cancelled, (h) => {
-          if (!cancelled) {
-            setHtml(h);
-            setContentSource("live");
-            setIsCaching(false);
-          }
-          if (!cancelled) setIsLoading(false);
-        });
+        liveFetch(
+          articleUrl,
+          item.globalId,
+          cancelled,
+          (h) => {
+            if (!cancelled) {
+              setHtml(h);
+              setContentSource("live");
+              setIsCaching(false);
+              setIsLoading(false);
+            }
+          },
+          () => {
+            // Fetch failed (CORS, network error, non-2xx) -- show feed preview text
+            if (!cancelled) {
+              setHtml(null);
+              setContentSource(null);
+              setIsCaching(false);
+              setIsLoading(false);
+            }
+          },
+        );
       } else {
         // Offline and no cached content -- fall back to feed preview text
         if (!cancelled) {
@@ -419,17 +433,22 @@ function FocusText({ text, options }: { text: string; options: FocusOptions }) {
 
 /**
  * Live-fetch an article URL and cache it in the PWA Cache API.
- * Calls `onDone` with the extracted HTML on success.
+ * Calls `onDone` with the extracted HTML on success, `onError` on any failure
+ * (CORS block, non-2xx response, network error, or cancellation).
  */
 async function liveFetch(
   url: string,
   globalId: string,
   cancelled: boolean,
   onDone: (html: string) => void,
+  onError?: () => void,
 ): Promise<void> {
   try {
     const resp = await fetch(url);
-    if (!resp.ok || cancelled) return;
+    if (!resp.ok || cancelled) {
+      onError?.();
+      return;
+    }
     const html = await resp.text();
     if (cancelled) return;
 
@@ -451,6 +470,7 @@ async function liveFetch(
 
     onDone(html);
   } catch {
-    // Network error -- content unavailable offline, silent fail
+    // Network error, CORS block, or any other exception
+    onError?.();
   }
 }


### PR DESCRIPTION
(AI Generated)

## Summary

- **Infinite spinner bug:** `liveFetch` in `ReaderView.tsx` silently swallowed CORS errors and non-2xx responses without calling `onDone`, leaving `setIsLoading(false)` unreachable. Every third-party article URL CORS-blocks in the browser, so the spinner never stopped. Fixed by adding an `onError` callback called on all failure paths.
- **PWA main-thread lockup:** Moved the entire Automerge document into a Web Worker (`automerge.worker.ts`). All WASM (`A.change`, `A.save`, `A.load`, `A.merge`) and the O(n) `hydrateFromDoc` pass now run off the main thread. The main thread receives plain-JS `DocState` via `postMessage` and calls Zustand `set()` with zero computation. `automerge.ts` is a thin `postMessage` client; `store.ts` drops `hydrateFromDoc` entirely.
- **Desktop jank:** Debounced `A.save()` in `applyChange()` so React fires immediately after `A.change()` and WASM serialization runs 400ms later. Cached the last binary so `getDocBinary()` and `broadcastToRelay()` no longer call `A.save()` independently.

## Test plan

- [ ] Open a feed item — should show content immediately (or the feed preview text if offline/CORS-blocked) with no infinite spinner
- [ ] Open multiple feed items rapidly — no UI lockup between clicks
- [ ] Mark items as read — sidebar unread counts update instantly with no jank
- [ ] Sync (relay + cloud) still works after the PWA worker change — verify `getDocBinary()` returns current data
- [ ] Desktop: mark items as read — UI updates immediately, doc saves after ~400ms (check DevTools IndexedDB)