### PR TITLE
feat: add dual-column reading mode

### DIFF
--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -421,6 +421,9 @@ export interface ReadingEnhancements {
    * When false, items are only marked read when explicitly opened.
    */
   markReadOnScroll: boolean;
+
+  /** Two-column reader layout: compact card thumbnail on left, article on right */
+  dualColumnMode: boolean;
 }
 
 /**
@@ -587,6 +590,7 @@ export function createDefaultPreferences(): UserPreferences {
         focusMode: false,
         focusIntensity: "normal",
         markReadOnScroll: true,
+        dualColumnMode: false,
       },
       archivePruneDays: 30,
     },

--- a/packages/ui/src/components/feed/FeedView.tsx
+++ b/packages/ui/src/components/feed/FeedView.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo, useEffect, useCallback } from "react";
 import { FeedList } from "./FeedList.js";
 import { ReaderView } from "./ReaderView.js";
+import { ReaderThumbnail } from "./ReaderThumbnail.js";
 import { AddFeedDialog } from "../AddFeedDialog.js";
 import { useAppStore, usePlatform } from "../../context/PlatformContext.js";
 import { useSearchResults } from "../../hooks/useSearchResults.js";
@@ -56,6 +57,8 @@ export function FeedView() {
 
   const scopeLabel = useMemo(() => getFilterLabel(activeFilter, feeds), [activeFilter, feeds]);
 
+  const dualColumnMode = useAppStore((s) => s.preferences.display.reading.dualColumnMode);
+
   const [selectedItem, setSelectedItem] = useState<FeedItem | null>(null);
   const [focusedIndex, setFocusedIndex] = useState<number>(-1);
 
@@ -106,6 +109,19 @@ export function FeedView() {
   useEffect(() => {
     setFocusedIndex(-1);
   }, [activeFilter, searchQuery]);
+
+  const showDualColumn = dualColumnMode && !!selectedItem;
+
+  // Dual-column: thumbnail + reader side by side, feed list hidden
+  if (showDualColumn) {
+    return (
+      <div className="h-full flex">
+        <ReaderThumbnail item={selectedItem} />
+        <ReaderView item={selectedItem} onClose={closeItem} dualColumn />
+        <AddFeedDialog open={addFeedOpen} onClose={() => setAddFeedOpen(false)} />
+      </div>
+    );
+  }
 
   return (
     <div className="h-full flex flex-col">

--- a/packages/ui/src/components/feed/ReaderThumbnail.tsx
+++ b/packages/ui/src/components/feed/ReaderThumbnail.tsx
@@ -1,0 +1,110 @@
+import { useMemo, type ReactNode } from "react";
+import { formatDistanceToNow } from "date-fns";
+import type { FeedItem } from "@freed/shared";
+import { RssIcon, FacebookIcon, InstagramIcon, YoutubeIcon, RedditIcon, GithubIcon, MastodonIcon } from "../icons.js";
+
+const cls = "w-3.5 h-3.5";
+
+const platformIcons: Record<string, ReactNode> = {
+  x: <span className="text-xs font-bold leading-none">𝕏</span>,
+  rss: <RssIcon className={cls} />,
+  youtube: <YoutubeIcon className={cls} />,
+  reddit: <RedditIcon className={cls} />,
+  mastodon: <MastodonIcon className={cls} />,
+  github: <GithubIcon className={cls} />,
+  facebook: <FacebookIcon className={cls} />,
+  instagram: <InstagramIcon className={cls} />,
+};
+
+interface ReaderThumbnailProps {
+  item: FeedItem;
+}
+
+/**
+ * Compact, read-only summary of the currently open feed item.
+ * Rendered as the left panel in dual-column reading mode.
+ */
+export function ReaderThumbnail({ item }: ReaderThumbnailProps) {
+  const timeAgo = useMemo(
+    () => formatDistanceToNow(item.publishedAt, { addSuffix: true }),
+    [item.publishedAt],
+  );
+
+  const platformIcon = platformIcons[item.platform] ?? <span className="text-xs">📄</span>;
+  const title = item.content.linkPreview?.title;
+  const heroImage = item.content.mediaUrls[0];
+
+  return (
+    <div className="w-80 shrink-0 border-r border-[rgba(255,255,255,0.08)] bg-[#0a0a0a] overflow-y-auto minimal-scroll flex flex-col">
+      <div className="p-4 flex flex-col gap-3">
+        {/* Author */}
+        <div className="flex items-center gap-3">
+          {item.author.avatarUrl ? (
+            <img
+              src={item.author.avatarUrl}
+              alt=""
+              className="w-10 h-10 rounded-full bg-white/5 ring-1 ring-white/10 shrink-0"
+            />
+          ) : (
+            <div className="w-10 h-10 rounded-full bg-gradient-to-br from-[#3b82f6] to-[#8b5cf6] flex items-center justify-center font-medium shrink-0 text-lg">
+              {item.author.displayName[0]?.toUpperCase() || "?"}
+            </div>
+          )}
+          <div className="min-w-0">
+            <p className="font-medium text-sm truncate">{item.author.displayName}</p>
+            <p className="text-xs text-[#71717a] truncate">@{item.author.handle}</p>
+          </div>
+        </div>
+
+        {/* Platform + time */}
+        <div className="flex items-center gap-2 text-xs text-[#71717a]">
+          <span>{platformIcon}</span>
+          <span>{timeAgo}</span>
+          {item.preservedContent?.readingTime && (
+            <>
+              <span>&middot;</span>
+              <span>{item.preservedContent.readingTime} min</span>
+            </>
+          )}
+        </div>
+
+        {/* Title */}
+        {title && (
+          <h3 className="font-semibold text-sm leading-snug line-clamp-3">{title}</h3>
+        )}
+
+        {/* Preview text */}
+        {item.content.text && (
+          <p className="text-xs text-[#a1a1aa] leading-relaxed line-clamp-4">
+            {item.content.text}
+          </p>
+        )}
+
+        {/* Hero image */}
+        {heroImage && (
+          <div className="rounded-lg overflow-hidden ring-1 ring-white/5">
+            <img
+              src={heroImage}
+              alt=""
+              className="w-full h-36 object-cover bg-white/5"
+            />
+          </div>
+        )}
+
+        {/* Tags */}
+        {item.userState.tags.length > 0 && (
+          <div className="flex flex-wrap gap-1.5">
+            {item.userState.tags.map((tag) => (
+              <span
+                key={tag}
+                className="px-2 py-0.5 text-[10px] rounded-full bg-[#8b5cf6]/20 text-[#8b5cf6]"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/feed/ReaderView.tsx
+++ b/packages/ui/src/components/feed/ReaderView.tsx
@@ -7,6 +7,8 @@ import { applyFocusMode, type FocusOptions } from "@freed/shared";
 interface ReaderViewProps {
   item: FeedItemType;
   onClose: () => void;
+  /** When true, renders inline as a flex child instead of a fixed overlay */
+  dualColumn?: boolean;
 }
 
 /** Content source labels for the offline badge */
@@ -34,7 +36,7 @@ const PROSE_CLASSES = `
   prose-li:text-[#a1a1aa]
 `.trim();
 
-export function ReaderView({ item, onClose }: ReaderViewProps) {
+export function ReaderView({ item, onClose, dualColumn = false }: ReaderViewProps) {
   const { headerDragRegion, getLocalContent } = usePlatform();
   const updateItem = useAppStore((s) => s.updateItem);
   const toggleArchived = useAppStore((s) => s.toggleArchived);
@@ -202,6 +204,16 @@ export function ReaderView({ item, onClose }: ReaderViewProps) {
     });
   }, [updatePreferences, storedDisplay]);
 
+  const toggleDualColumn = useCallback(() => {
+    const next = !storedDisplay.reading.dualColumnMode;
+    updatePreferences({
+      display: {
+        ...storedDisplay,
+        reading: { ...storedDisplay.reading, dualColumnMode: next },
+      },
+    });
+  }, [updatePreferences, storedDisplay]);
+
   const timeAgo = useMemo(
     () => formatDistanceToNow(item.publishedAt, { addSuffix: true }),
     [item.publishedAt],
@@ -215,7 +227,7 @@ export function ReaderView({ item, onClose }: ReaderViewProps) {
   );
 
   return (
-    <div className="fixed inset-0 z-50 bg-[#0a0a0a] overflow-auto">
+    <div className={dualColumn ? "flex-1 min-w-0 bg-[#0a0a0a] overflow-auto" : "fixed inset-0 z-50 bg-[#0a0a0a] overflow-auto"}>
       {/* Header */}
       <header
         className="sticky top-0 z-10 bg-[#0a0a0a]/90 backdrop-blur-xl border-b border-[rgba(255,255,255,0.08)]"
@@ -328,6 +340,31 @@ export function ReaderView({ item, onClose }: ReaderViewProps) {
           >
             <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+            </svg>
+          </button>
+
+          {/* Dual-column mode toggle (desktop only) */}
+          <button
+            onClick={toggleDualColumn}
+            title={dualColumn ? "Single column" : "Dual column"}
+            className={`hidden md:flex p-2 rounded-lg transition-colors ${
+              dualColumn
+                ? "bg-[#8b5cf6]/20 text-[#8b5cf6]"
+                : "hover:bg-white/10 text-[#71717a]"
+            }`}
+            style={headerDragRegion ? noDrag : undefined}
+            aria-pressed={dualColumn}
+            aria-label="Toggle dual column layout"
+          >
+            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+              {dualColumn ? (
+                <>
+                  <rect x="3" y="3" width="7.5" height="18" rx="1.5" />
+                  <rect x="13.5" y="3" width="7.5" height="18" rx="1.5" />
+                </>
+              ) : (
+                <rect x="3" y="3" width="18" height="18" rx="2" />
+              )}
             </svg>
           </button>
         </div>


### PR DESCRIPTION
(AI Generated)

## Summary

- Adds a two-column reader layout: clicking a card in dual-column mode shows a compact thumbnail on the left (author, title, preview, hero image) and the full article on the right, instead of a full-screen overlay.
- Toggle button in the reader toolbar (rightmost position, desktop only) switches between single and dual column. The preference persists across sessions via Automerge.
- New `ReaderThumbnail` component renders the compact left panel. `ReaderView` accepts a `dualColumn` prop to render inline instead of as a fixed overlay. `FeedView` orchestrates the split layout.

## Test plan

- [ ] Open a feed item in single-column mode (default), verify it still renders as a full-screen overlay
- [ ] Click the dual-column toggle (two-rectangles icon, rightmost button in reader toolbar) and verify the layout splits into thumbnail left / article right
- [ ] Toggle back to single-column and verify the overlay returns
- [ ] Close the reader (back button or Escape) in both modes, verify it returns to the feed list
- [ ] Refresh the page after toggling dual-column on, reopen a card, and verify the preference persisted
- [ ] Verify the toggle button is hidden on mobile-width viewports (<768px)
- [ ] Verify focus mode, save, and archive still work correctly in dual-column layout