### PR TITLE
feat: replace manual cookie entry with native X login window

### DIFF
--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "freed-desktop"
-version = "26.3.404"
+version = "26.3.601"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -945,6 +945,7 @@ dependencies = [
  "tauri-plugin-updater",
  "tokio",
  "tokio-tungstenite",
+ "url",
  "window-vibrancy",
 ]
 

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -31,6 +31,7 @@ mdns-sd = "0.11"
 hostname = "0.4"
 rand = "0.8"
 base64 = "0.22"
+url = "2"
 
 [features]
 default = ["custom-protocol"]

--- a/packages/desktop/src-tauri/capabilities/default.json
+++ b/packages/desktop/src-tauri/capabilities/default.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2/capability",
   "identifier": "default",
   "description": "Default capabilities for the Freed desktop app",
-  "windows": ["main"],
+  "windows": ["main", "x-login"],
   "permissions": [
     "core:default",
     "shell:allow-open",

--- a/packages/desktop/src-tauri/gen/schemas/capabilities.json
+++ b/packages/desktop/src-tauri/gen/schemas/capabilities.json
@@ -1,1 +1,1 @@
-{"default":{"identifier":"default","description":"Default capabilities for the Freed desktop app","local":true,"windows":["main"],"permissions":["core:default","shell:allow-open","updater:default","process:default"]}}
+{"default":{"identifier":"default","description":"Default capabilities for the Freed desktop app","local":true,"windows":["main","x-login"],"permissions":["core:default","shell:allow-open","updater:default","process:default","fs:allow-appdata-read-recursive","fs:allow-appdata-write-recursive"]}}

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -630,6 +630,84 @@ fn show_window(app: tauri::AppHandle) {
 }
 
 // ---------------------------------------------------------------------------
+// Tauri commands — X login window
+// ---------------------------------------------------------------------------
+
+#[derive(serde::Serialize)]
+#[serde(tag = "status")]
+enum XLoginCheckResult {
+    /// The login window is not open.
+    #[serde(rename = "closed")]
+    Closed,
+    /// The window is open but session cookies are not yet available.
+    #[serde(rename = "pending")]
+    Pending,
+    /// Both ct0 and auth_token are present.
+    #[serde(rename = "ready")]
+    Ready { ct0: String, auth_token: String },
+}
+
+/// Open a secondary WebView window pointing to X's login page.
+/// If the window already exists, focus it instead of creating a duplicate.
+#[tauri::command]
+async fn open_x_login_window(app: tauri::AppHandle) -> Result<(), String> {
+    if let Some(existing) = app.get_webview_window("x-login") {
+        let _ = existing.show();
+        let _ = existing.set_focus();
+        return Ok(());
+    }
+
+    tauri::WebviewWindowBuilder::new(
+        &app,
+        "x-login",
+        tauri::WebviewUrl::External("https://x.com/i/flow/login".parse().unwrap()),
+    )
+    .title("Sign in to X")
+    .inner_size(480.0, 720.0)
+    .center()
+    .build()
+    .map_err(|e| e.to_string())?;
+
+    Ok(())
+}
+
+/// Check whether the X login webview has session cookies available.
+/// Returns a tagged result so the frontend can distinguish "window gone"
+/// from "window open, still waiting for login."
+#[tauri::command]
+async fn check_x_login_cookies(app: tauri::AppHandle) -> Result<XLoginCheckResult, String> {
+    let Some(window) = app.get_webview_window("x-login") else {
+        return Ok(XLoginCheckResult::Closed);
+    };
+
+    let url: url::Url = "https://x.com".parse().unwrap();
+    let cookies = window.cookies_for_url(url).map_err(|e| e.to_string())?;
+
+    let ct0 = cookies
+        .iter()
+        .find(|c| c.name() == "ct0")
+        .map(|c| c.value().to_string());
+    let auth_token = cookies
+        .iter()
+        .find(|c| c.name() == "auth_token")
+        .map(|c| c.value().to_string());
+
+    match (ct0, auth_token) {
+        (Some(ct0), Some(auth_token)) => Ok(XLoginCheckResult::Ready { ct0, auth_token }),
+        _ => Ok(XLoginCheckResult::Pending),
+    }
+}
+
+/// Close and destroy the X login window.
+#[tauri::command]
+async fn close_x_login_window(app: tauri::AppHandle) -> Result<(), String> {
+    if let Some(window) = app.get_webview_window("x-login") {
+        window.destroy().map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
 // WebSocket relay
 // ---------------------------------------------------------------------------
 
@@ -879,8 +957,10 @@ pub fn run() {
         })
         .on_window_event(|window, event| {
             if let tauri::WindowEvent::CloseRequested { api, .. } = event {
-                window.hide().unwrap();
-                api.prevent_close();
+                if window.label() == "main" {
+                    window.hide().unwrap();
+                    api.prevent_close();
+                }
             }
         })
         .invoke_handler(tauri::generate_handler![
@@ -895,6 +975,9 @@ pub fn run() {
             broadcast_doc,
             reset_pairing_token,
             show_window,
+            open_x_login_window,
+            check_x_login_cookies,
+            close_x_login_window,
             get_mdns_active,
             list_snapshots,
             start_oauth_server,

--- a/packages/desktop/src/__mocks__/@tauri-apps/api/core.ts
+++ b/packages/desktop/src/__mocks__/@tauri-apps/api/core.ts
@@ -22,6 +22,9 @@ const handlers: Record<string, Handler> = {
   stop_relay: () => null,
   save_url_content: () => null,
   get_x_cookies: () => null,
+  open_x_login_window: () => null,
+  check_x_login_cookies: () => ({ status: "closed" }),
+  close_x_login_window: () => null,
   pick_contact: () => null,
 };
 

--- a/packages/desktop/src/components/XSettingsSection.tsx
+++ b/packages/desktop/src/components/XSettingsSection.tsx
@@ -1,16 +1,26 @@
 /**
  * XSettingsSection — Settings > Sources > X / Twitter
  *
- * Cookie-based X authentication, manual sync, disconnect, and a per-stage
- * diagnostic panel that surfaces exactly where the pipeline stalls when
- * "All caught up" appears without any data.
+ * Primary flow: open a native login window at x.com, extract session cookies
+ * automatically after the user signs in. Falls back to manual cookie entry
+ * for users who hit captchas or 2FA friction in the embedded WebView.
  */
 
-import { useState } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
+import { invoke } from "@tauri-apps/api/core";
 import { useAppStore } from "../lib/store";
 import { connectX, loadStoredCookies, disconnectX } from "../lib/x-auth";
 import { captureXTimeline } from "../lib/x-capture";
 import type { XSyncDiag } from "../lib/x-capture";
+
+// =============================================================================
+// Types
+// =============================================================================
+
+type XLoginCheckResult =
+  | { status: "closed" }
+  | { status: "pending" }
+  | { status: "ready"; ct0: string; auth_token: string };
 
 // =============================================================================
 // Diagnostic Panel
@@ -19,7 +29,6 @@ import type { XSyncDiag } from "../lib/x-capture";
 interface DiagRowProps {
   label: string;
   value: string;
-  /** Highlight amber when a stage produced 0 after a prior stage produced >0 */
   warn?: boolean;
 }
 
@@ -32,11 +41,7 @@ function DiagRow({ label, value, warn }: DiagRowProps) {
   );
 }
 
-interface DiagPanelProps {
-  diag: XSyncDiag;
-}
-
-function DiagPanel({ diag }: DiagPanelProps) {
+function DiagPanel({ diag }: { diag: XSyncDiag }) {
   const [copied, setCopied] = useState(false);
 
   const copyPreview = () => {
@@ -111,6 +116,51 @@ function DiagPanel({ diag }: DiagPanelProps) {
 }
 
 // =============================================================================
+// Cookie Polling Hook
+// =============================================================================
+
+const POLL_INTERVAL_MS = 2_000;
+
+function useXLoginPoller(onReady: (ct0: string, authToken: string) => void) {
+  const [polling, setPolling] = useState(false);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const onReadyRef = useRef(onReady);
+  onReadyRef.current = onReady;
+
+  const stop = useCallback(() => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+    setPolling(false);
+  }, []);
+
+  const start = useCallback(() => {
+    stop();
+    setPolling(true);
+
+    intervalRef.current = setInterval(async () => {
+      try {
+        const result = await invoke<XLoginCheckResult>("check_x_login_cookies");
+
+        if (result.status === "ready") {
+          stop();
+          onReadyRef.current(result.ct0, result.auth_token);
+        } else if (result.status === "closed") {
+          stop();
+        }
+      } catch {
+        stop();
+      }
+    }, POLL_INTERVAL_MS);
+  }, [stop]);
+
+  useEffect(() => stop, [stop]);
+
+  return { polling, start, stop };
+}
+
+// =============================================================================
 // Main Component
 // =============================================================================
 
@@ -122,11 +172,13 @@ export function XSettingsSection() {
   const setError = useAppStore((s) => s.setError);
 
   const [syncing, setSyncing] = useState(false);
-  const [showForm, setShowForm] = useState(false);
+  const [lastDiag, setLastDiag] = useState<XSyncDiag | null>(null);
+
+  // Manual cookie entry (fallback)
+  const [showManual, setShowManual] = useState(false);
   const [ct0, setCt0] = useState("");
   const [authToken, setAuthToken] = useState("");
   const [formError, setFormError] = useState("");
-  const [lastDiag, setLastDiag] = useState<XSyncDiag | null>(null);
 
   const runSync = async (cookies: Parameters<typeof captureXTimeline>[0]) => {
     setSyncing(true);
@@ -141,7 +193,36 @@ export function XSettingsSection() {
     }
   };
 
-  const handleConnect = async () => {
+  const finishLogin = useCallback(
+    async (ct0Val: string, authTokenVal: string) => {
+      setError(null);
+      const cookies = connectX(ct0Val, authTokenVal);
+      if (!cookies) return;
+      setXAuth({ isAuthenticated: true, cookies });
+      invoke("close_x_login_window").catch(() => {});
+      await runSync(cookies);
+    },
+    [setXAuth, setError],
+  );
+
+  const poller = useXLoginPoller(finishLogin);
+
+  const handleSignIn = async () => {
+    try {
+      await invoke("open_x_login_window");
+      poller.start();
+    } catch (err) {
+      console.error("Failed to open X login window:", err);
+    }
+  };
+
+  const handleCancelLogin = async () => {
+    poller.stop();
+    invoke("close_x_login_window").catch(() => {});
+  };
+
+  // Manual cookie entry handlers
+  const handleManualConnect = async () => {
     setFormError("");
     setError(null);
     const cookies = connectX(ct0, authToken);
@@ -150,7 +231,7 @@ export function XSettingsSection() {
       return;
     }
     setXAuth({ isAuthenticated: true, cookies });
-    setShowForm(false);
+    setShowManual(false);
     setCt0("");
     setAuthToken("");
     await runSync(cookies);
@@ -168,15 +249,16 @@ export function XSettingsSection() {
     setXAuth({ isAuthenticated: false });
     setLastDiag(null);
     setError(null);
-    setShowForm(false);
+    setShowManual(false);
   };
 
   const syncError = storeError && xAuth.isAuthenticated ? storeError : null;
 
+  // ----- Authenticated view -----
   if (xAuth.isAuthenticated) {
     const statusLine = (() => {
       if (!lastDiag) return null;
-      if (lastDiag.errorStage) return null; // error is shown separately
+      if (lastDiag.errorStage) return null;
       if (lastDiag.itemsAdded === 0 && lastDiag.tweetsExtracted === 0) {
         return <p className="text-xs text-[#52525b]">Timeline returned no posts.</p>;
       }
@@ -228,13 +310,38 @@ export function XSettingsSection() {
 
         <p className="text-xs text-[#52525b] leading-relaxed">
           Freed syncs your home timeline every 30 minutes while the app is open.
-          Cookies expire periodically — reconnect when sync stops working.
+          Cookies expire periodically, reconnect when sync stops working.
         </p>
       </div>
     );
   }
 
-  if (showForm) {
+  // ----- Login pending (window open, waiting for credentials) -----
+  if (poller.polling) {
+    return (
+      <div className="space-y-4">
+        <div className="flex items-center gap-3 px-3 py-2.5 rounded-xl bg-white/5">
+          <div className="w-2 h-2 rounded-full bg-amber-400 animate-pulse shrink-0" />
+          <span className="text-sm text-[#a1a1aa]">Waiting for sign-in...</span>
+        </div>
+
+        <p className="text-xs text-[#71717a] leading-relaxed">
+          Sign in to your X account in the window that just opened.
+          This page will update automatically once you're logged in.
+        </p>
+
+        <button
+          onClick={handleCancelLogin}
+          className="text-sm px-3 py-2 rounded-xl bg-white/5 text-[#71717a] hover:bg-white/10 transition-colors"
+        >
+          Cancel
+        </button>
+      </div>
+    );
+  }
+
+  // ----- Manual cookie entry (fallback) -----
+  if (showManual) {
     return (
       <div className="space-y-4">
         <div className="p-3 rounded-xl bg-white/5 text-xs text-[#a1a1aa] leading-relaxed space-y-2">
@@ -243,7 +350,7 @@ export function XSettingsSection() {
             <li>Log in to <span className="text-white font-medium">x.com</span> in Chrome</li>
             <li>Open DevTools with <kbd className="px-1 py-0.5 bg-white/10 rounded text-[10px]">⌥⌘I</kbd></li>
             <li>Click the <span className="text-white">Application</span> tab</li>
-            <li>Expand <span className="text-white">Cookies</span> → select <span className="font-mono text-[10px] text-[#c4b5fd]">https://x.com</span></li>
+            <li>Expand <span className="text-white">Cookies</span> and select <span className="font-mono text-[10px] text-[#c4b5fd]">https://x.com</span></li>
             <li>Copy the value for <span className="font-mono text-[#c4b5fd]">ct0</span></li>
             <li>Copy the value for <span className="font-mono text-[#c4b5fd]">auth_token</span></li>
           </ol>
@@ -261,7 +368,7 @@ export function XSettingsSection() {
           placeholder="auth_token value"
           value={authToken}
           onChange={(e) => setAuthToken(e.target.value)}
-          onKeyDown={(e) => { if (e.key === "Enter") handleConnect(); }}
+          onKeyDown={(e) => { if (e.key === "Enter") handleManualConnect(); }}
           className="w-full text-sm px-3 py-2 bg-white/5 border border-[rgba(255,255,255,0.1)] rounded-xl text-white placeholder-[#52525b] focus:outline-none focus:border-[#8b5cf6]/50"
         />
 
@@ -269,14 +376,14 @@ export function XSettingsSection() {
 
         <div className="flex gap-2">
           <button
-            onClick={handleConnect}
+            onClick={handleManualConnect}
             disabled={!ct0 || !authToken}
             className="flex-1 text-sm px-3 py-2 rounded-xl bg-[#8b5cf6]/15 text-[#8b5cf6] hover:bg-[#8b5cf6]/25 disabled:opacity-40 transition-colors"
           >
             Connect
           </button>
           <button
-            onClick={() => { setShowForm(false); setFormError(""); }}
+            onClick={() => { setShowManual(false); setFormError(""); }}
             className="text-sm px-3 py-2 rounded-xl bg-white/5 text-[#71717a] hover:bg-white/10 transition-colors"
           >
             Cancel
@@ -286,17 +393,24 @@ export function XSettingsSection() {
     );
   }
 
+  // ----- Default: not connected -----
   return (
     <div className="space-y-4">
       <p className="text-sm text-[#71717a] leading-relaxed">
-        Pull your home timeline into Freed. Freed uses your existing browser session
-        — no developer account or API key needed.
+        Pull your home timeline into Freed. Sign in with your X account
+        to start syncing.
       </p>
       <button
-        onClick={() => setShowForm(true)}
-        className="text-sm px-4 py-2 rounded-xl bg-[#8b5cf6]/15 text-[#8b5cf6] hover:bg-[#8b5cf6]/25 transition-colors"
+        onClick={handleSignIn}
+        className="w-full text-sm px-4 py-2.5 rounded-xl bg-[#8b5cf6]/15 text-[#8b5cf6] hover:bg-[#8b5cf6]/25 transition-colors"
       >
-        Connect X Account
+        Sign in to X
+      </button>
+      <button
+        onClick={() => setShowManual(true)}
+        className="text-xs text-[#52525b] hover:text-[#71717a] transition-colors"
+      >
+        Manual cookie setup
       </button>
     </div>
   );

--- a/packages/desktop/tests/e2e/fixtures/tauri-init.ts
+++ b/packages/desktop/tests/e2e/fixtures/tauri-init.ts
@@ -25,6 +25,9 @@ export function tauriInitScript(): string {
       stop_relay: () => null,
       save_url_content: () => null,
       get_x_cookies: () => null,
+      open_x_login_window: () => null,
+      check_x_login_cookies: () => ({ status: 'closed' }),
+      close_x_login_window: () => null,
       pick_contact: () => null,
     };
     window.__TAURI_MOCK_INVOCATIONS__ = [];


### PR DESCRIPTION
(AI Generated)

## Summary

- Replaces the manual cookie-pasting flow (DevTools > Application > Cookies) with a native WebView login window at x.com. Users sign in normally and cookies are extracted automatically via Tauri's `cookies_for_url()` API.
- Adds three new Rust IPC commands: `open_x_login_window`, `check_x_login_cookies`, `close_x_login_window`. Frontend polls for session cookies every 2 seconds after the login window opens.
- Keeps manual cookie entry accessible as a fallback ("Manual cookie setup" link) for users who hit captchas or 2FA friction in the embedded WebView.

## Test plan

- [x] `cargo check` passes
- [x] All 18 E2E tests pass
- [x] No linter errors on changed files
- [x] Tauri binary compiles and launches (mDNS + sync relay start successfully)
- [ ] Manual test: click "Sign in to X", complete login in popup, verify cookies are extracted and first sync fires
- [ ] Manual test: close login window before completing login, verify UI resets to idle
- [ ] Manual test: click "Manual cookie setup", paste cookies, verify existing flow still works