### PR TITLE
feat: UI polish bundle - tooltips, hover states, scroll reset, save fix, sidebar counts

### DIFF
--- a/packages/ui/src/components/Tooltip.tsx
+++ b/packages/ui/src/components/Tooltip.tsx
@@ -1,0 +1,72 @@
+import type { ReactNode } from "react";
+
+interface TooltipProps {
+  /** The element the tooltip is attached to */
+  children: ReactNode;
+  /** Tooltip text */
+  label: string;
+  /** Optional keyboard shortcut hint shown after the label */
+  shortcut?: string;
+  /** Placement relative to the trigger. Default: "bottom" */
+  side?: "top" | "bottom";
+  /** Extra classes on the outer wrapper */
+  className?: string;
+}
+
+/**
+ * Lightweight animated tooltip using pure CSS (group-hover).
+ *
+ * Wrap any interactive element. The tooltip fades/scales in after a short
+ * delay and positions itself above or below the trigger via absolute
+ * positioning. No JS timers, no portals, no layout thrash.
+ */
+export function Tooltip({
+  children,
+  label,
+  shortcut,
+  side = "bottom",
+  className = "",
+}: TooltipProps) {
+  const isTop = side === "top";
+
+  return (
+    <div className={`relative group/tip ${className}`}>
+      {children}
+      <div
+        role="tooltip"
+        className={`
+          pointer-events-none absolute left-1/2 -translate-x-1/2 z-[100]
+          px-2.5 py-1 rounded-lg
+          bg-[#1c1c1c] border border-white/[0.08]
+          shadow-xl shadow-black/50
+          text-[11px] font-medium text-[#d4d4d8] whitespace-nowrap
+          opacity-0 scale-95
+          group-hover/tip:opacity-100 group-hover/tip:scale-100
+          transition-all duration-150 delay-75
+          origin-center
+          ${isTop ? "bottom-full mb-2" : "top-full mt-2"}
+        `}
+      >
+        {/* Caret arrow */}
+        <span
+          className={`
+            absolute left-1/2 -translate-x-1/2 w-2 h-2
+            bg-[#1c1c1c] border-white/[0.08] rotate-45
+            ${isTop
+              ? "top-full -mt-1 border-r border-b"
+              : "bottom-full -mb-1 border-l border-t"
+            }
+          `}
+        />
+        <span className="relative">
+          {label}
+          {shortcut && (
+            <kbd className="ml-1.5 px-1 py-0.5 rounded bg-white/[0.06] text-[10px] text-[#71717a] font-mono">
+              {shortcut}
+            </kbd>
+          )}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/feed/FeedList.tsx
+++ b/packages/ui/src/components/feed/FeedList.tsx
@@ -97,6 +97,21 @@ export function FeedList({
   const isMobile = useIsMobile();
   const { FeedEmptyState } = usePlatform();
   const isLoading = useAppStore((s) => s.isLoading);
+  const activeFilter = useAppStore((s) => s.activeFilter);
+
+  // Reset scroll position when the user switches sources/filters in the sidebar.
+  const filterKeyRef = useRef<string>("");
+  useEffect(() => {
+    const key = JSON.stringify(activeFilter);
+    if (filterKeyRef.current && filterKeyRef.current !== key) {
+      if (isMobile) {
+        window.scrollTo({ top: 0 });
+      } else {
+        parentRef.current?.scrollTo({ top: 0 });
+      }
+    }
+    filterKeyRef.current = key;
+  }, [activeFilter, isMobile]);
   const showEngagementCounts = useAppStore(
     (s) => s.preferences.display.showEngagementCounts,
   );

--- a/packages/ui/src/components/feed/FeedView.tsx
+++ b/packages/ui/src/components/feed/FeedView.tsx
@@ -198,19 +198,26 @@ export function FeedView() {
 
   const dualColumnMode = useAppStore((s) => s.preferences.display.reading.dualColumnMode);
 
-  const [selectedItem, setSelectedItem] = useState<FeedItem | null>(null);
+  // Store only the ID so the rendered item stays in sync with the store.
+  // Holding the full FeedItem in state would freeze userState (saved, archived,
+  // tags) at the moment the user clicked, making toolbar toggles appear broken.
+  const [selectedItemId, setSelectedItemId] = useState<string | null>(null);
+  const selectedItem = useMemo(
+    () => (selectedItemId ? filteredItems.find((i) => i.globalId === selectedItemId) ?? null : null),
+    [filteredItems, selectedItemId],
+  );
   const [focusedIndex, setFocusedIndex] = useState<number>(-1);
 
   const openItem = useCallback(
     (item: FeedItem) => {
-      setSelectedItem(item);
+      setSelectedItemId(item.globalId);
       markAsRead(item.globalId);
     },
     [markAsRead],
   );
 
   const closeItem = useCallback(() => {
-    setSelectedItem(null);
+    setSelectedItemId(null);
   }, []);
 
   // Keyboard navigation: j/k to move, Enter/o to open, Escape to close.

--- a/packages/ui/src/components/feed/ReaderView.tsx
+++ b/packages/ui/src/components/feed/ReaderView.tsx
@@ -3,6 +3,7 @@ import { formatDistanceToNow } from "date-fns";
 import type { FeedItem as FeedItemType } from "@freed/shared";
 import { useAppStore, usePlatform, MACOS_TRAFFIC_LIGHT_INSET } from "../../context/PlatformContext.js";
 import { applyFocusMode, type FocusOptions } from "@freed/shared";
+import { Tooltip } from "../Tooltip.js";
 
 interface ReaderViewProps {
   item: FeedItemType;
@@ -38,7 +39,7 @@ const PROSE_CLASSES = `
 
 export function ReaderView({ item, onClose, dualColumn = false }: ReaderViewProps) {
   const { headerDragRegion, getLocalContent } = usePlatform();
-  const updateItem = useAppStore((s) => s.updateItem);
+  const toggleSaved = useAppStore((s) => s.toggleSaved);
   const toggleArchived = useAppStore((s) => s.toggleArchived);
   const updatePreferences = useAppStore((s) => s.updatePreferences);
   const storedDisplay = useAppStore((s) => s.preferences.display);
@@ -164,18 +165,9 @@ export function ReaderView({ item, onClose, dualColumn = false }: ReaderViewProp
     };
   }, [item.globalId, articleUrl, getLocalContent]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const toggleSaved = useCallback(() => {
-    const nowSaved = !item.userState.saved;
-    updateItem(item.globalId, {
-      userState: {
-        ...item.userState,
-        saved: nowSaved,
-        // Omit savedAt when un-saving rather than setting undefined —
-        // Automerge's proxy throws on undefined assignments.
-        ...(nowSaved ? { savedAt: Date.now() } : {}),
-      },
-    });
-  }, [updateItem, item.globalId, item.userState]);
+  const handleToggleSaved = useCallback(() => {
+    toggleSaved(item.globalId);
+  }, [toggleSaved, item.globalId]);
 
   const handleToggleArchived = useCallback(() => {
     toggleArchived(item.globalId);
@@ -267,104 +259,107 @@ export function ReaderView({ item, onClose, dualColumn = false }: ReaderViewProp
 
           {/* Offline / cached badge */}
           {contentSource === "cache" && (
-            <span
-              className="px-2 py-0.5 text-[10px] font-medium rounded-full bg-emerald-500/15 text-emerald-400 border border-emerald-500/20"
-              title="Served from your device cache"
-            >
-              Offline
-            </span>
+            <Tooltip label="Served from your device cache">
+              <span className="px-2 py-0.5 text-[10px] font-medium rounded-full bg-emerald-500/15 text-emerald-400 border border-emerald-500/20">
+                Offline
+              </span>
+            </Tooltip>
           )}
           {contentSource === "text" && (
-            <span
-              className="px-2 py-0.5 text-[10px] font-medium rounded-full bg-amber-500/15 text-amber-400 border border-amber-500/20"
-              title="Showing text summary -- full content will load when online"
-            >
-              Summary
-            </span>
+            <Tooltip label="Full content will load when online">
+              <span className="px-2 py-0.5 text-[10px] font-medium rounded-full bg-amber-500/15 text-amber-400 border border-amber-500/20">
+                Summary
+              </span>
+            </Tooltip>
           )}
 
           {/* Background caching spinner */}
           {isCaching && (
-            <div
-              className="w-4 h-4 border border-[#52525b] border-t-[#8b5cf6] rounded-full animate-spin"
-              title="Loading full article..."
-            />
+            <Tooltip label="Loading full article">
+              <div className="w-4 h-4 border border-[#52525b] border-t-[#8b5cf6] rounded-full animate-spin" />
+            </Tooltip>
           )}
 
           {/* Focus mode toggle */}
-          <button
-            onClick={toggleFocus}
-            title={focusOptions.enabled ? "Disable focus mode" : "Enable focus mode"}
-            className={`p-2 rounded-lg transition-colors text-sm font-bold ${
-              focusOptions.enabled
-                ? "bg-[#8b5cf6]/20 text-[#8b5cf6]"
-                : "hover:bg-white/10 text-[#71717a]"
-            }`}
-            style={headerDragRegion ? noDrag : undefined}
-            aria-pressed={focusOptions.enabled}
-            aria-label="Toggle focus reading mode"
-          >
-            <span aria-hidden="true">
-              <span className="font-black">F</span>
-              <span className="font-light text-xs">ocus</span>
-            </span>
-          </button>
-
-          <button
-            onClick={toggleSaved}
-            className={`p-2 rounded-lg transition-colors ${
-              item.userState.saved
-                ? "bg-[#8b5cf6]/20 text-[#8b5cf6]"
-                : "hover:bg-white/10 text-[#a1a1aa]"
-            }`}
-            style={headerDragRegion ? noDrag : undefined}
-            aria-label={item.userState.saved ? "Unsave" : "Save"}
-          >
-            <svg
-              className="w-5 h-5"
-              fill={item.userState.saved ? "currentColor" : "none"}
-              viewBox="0 0 24 24"
-              stroke="currentColor"
+          <Tooltip label={focusOptions.enabled ? "Disable focus mode" : "Enable focus mode"}>
+            <button
+              onClick={toggleFocus}
+              className={`p-2 rounded-lg transition-colors text-sm font-bold ${
+                focusOptions.enabled
+                  ? "bg-[#8b5cf6]/20 text-[#8b5cf6] hover:bg-[#8b5cf6]/30"
+                  : "hover:bg-white/10 text-[#71717a]"
+              }`}
+              style={headerDragRegion ? noDrag : undefined}
+              aria-pressed={focusOptions.enabled}
+              aria-label="Toggle focus reading mode"
             >
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
-            </svg>
-          </button>
+              <span aria-hidden="true">
+                <span className="font-black">F</span>
+                <span className="font-light text-xs">ocus</span>
+              </span>
+            </button>
+          </Tooltip>
 
-          <button
-            onClick={handleToggleArchived}
-            className={`p-2 rounded-lg transition-colors ${
-              item.userState.archived
-                ? "bg-green-500/20 text-green-400"
-                : "hover:bg-white/10 text-[#a1a1aa]"
-            }`}
-            style={headerDragRegion ? noDrag : undefined}
-            aria-label={item.userState.archived ? "Unarchive" : "Archive"}
-          >
-            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-            </svg>
-          </button>
+          <Tooltip label={item.userState.saved ? "Remove bookmark" : "Bookmark"}>
+            <button
+              onClick={handleToggleSaved}
+              className={`p-2 rounded-lg transition-colors ${
+                item.userState.saved
+                  ? "bg-[#8b5cf6]/20 text-[#8b5cf6] hover:bg-[#8b5cf6]/30"
+                  : "hover:bg-white/10 text-[#a1a1aa]"
+              }`}
+              style={headerDragRegion ? noDrag : undefined}
+              aria-label={item.userState.saved ? "Unsave" : "Save"}
+            >
+              <svg
+                className="w-5 h-5"
+                fill={item.userState.saved ? "currentColor" : "none"}
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
+              </svg>
+            </button>
+          </Tooltip>
+
+          <Tooltip label={item.userState.archived ? "Unarchive" : "Archive"}>
+            <button
+              onClick={handleToggleArchived}
+              className={`p-2 rounded-lg transition-colors ${
+                item.userState.archived
+                  ? "bg-green-500/20 text-green-400 hover:bg-green-500/30"
+                  : "hover:bg-white/10 text-[#a1a1aa]"
+              }`}
+              style={headerDragRegion ? noDrag : undefined}
+              aria-label={item.userState.archived ? "Unarchive" : "Archive"}
+            >
+              <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+              </svg>
+            </button>
+          </Tooltip>
 
           {/* Dual-column mode toggle (desktop only) */}
-          <button
-            onClick={toggleDualColumn}
-            title={dualColumn ? "Single column" : "Dual column"}
-            className={`hidden md:flex p-2 rounded-lg transition-colors ${
-              dualColumn
-                ? "bg-[#8b5cf6]/20 text-[#8b5cf6]"
-                : "hover:bg-white/10 text-[#71717a]"
-            }`}
-            style={headerDragRegion ? noDrag : undefined}
-            aria-pressed={dualColumn}
-            aria-label="Toggle dual column layout"
-          >
-            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
-              <path stroke="none" d="M0 0h24v24H0z" fill="none" />
-              <path d="M4 6a2 2 0 0 1 2 -2h12a2 2 0 0 1 2 2v12a2 2 0 0 1 -2 2h-12a2 2 0 0 1 -2 -2l0 -12" />
-              <path d="M9 4v16" />
-              <path d={dualColumn ? "M15 10l-2 2l2 2" : "M14 10l2 2l-2 2"} />
-            </svg>
-          </button>
+          <Tooltip label={dualColumn ? "Single column" : "Dual column"}>
+            <button
+              onClick={toggleDualColumn}
+              className={`hidden md:flex p-2 rounded-lg transition-colors ${
+                dualColumn
+                  ? "bg-[#8b5cf6]/20 text-[#8b5cf6] hover:bg-[#8b5cf6]/30"
+                  : "hover:bg-white/10 text-[#71717a]"
+              }`}
+              style={headerDragRegion ? noDrag : undefined}
+              aria-pressed={dualColumn}
+              aria-label="Toggle dual column layout"
+            >
+              <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+                <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+                <path d="M4 6a2 2 0 0 1 2 -2h12a2 2 0 0 1 2 2v12a2 2 0 0 1 -2 2h-12a2 2 0 0 1 -2 -2l0 -12" />
+                <path d="M9 4v16" />
+                <path d={dualColumn ? "M15 10l-2 2l2 2" : "M14 10l2 2l-2 2"} />
+              </svg>
+            </button>
+          </Tooltip>
         </div>
       </header>
 

--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useMemo } from "react";
 import { AddFeedDialog } from "../AddFeedDialog.js";
 import { SavedContentDialog } from "../SavedContentDialog.js";
+import { Tooltip } from "../Tooltip.js";
 import {
   useAppStore,
   usePlatform,
@@ -244,26 +245,28 @@ export function Header({ onMenuClick }: HeaderProps) {
           {...(headerDragRegion ? { "data-tauri-drag-region": true } : {})}
         >
           {/* Mobile menu button */}
-          <button
-            onClick={onMenuClick}
-            className="md:hidden p-1.5 rounded-lg hover:bg-white/10 transition-colors flex-shrink-0"
-            aria-label="Open menu"
-            style={headerDragRegion ? noDrag : undefined}
-          >
-            <svg
-              className="w-5 h-5"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
+          <Tooltip label="Menu" className="md:hidden">
+            <button
+              onClick={onMenuClick}
+              className="p-1.5 rounded-lg hover:bg-white/10 transition-colors flex-shrink-0"
+              aria-label="Open menu"
+              style={headerDragRegion ? noDrag : undefined}
             >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M4 6h16M4 12h16M4 18h16"
-              />
-            </svg>
-          </button>
+              <svg
+                className="w-5 h-5"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M4 6h16M4 12h16M4 18h16"
+                />
+              </svg>
+            </button>
+          </Tooltip>
 
           {/* FREED logo */}
           <div
@@ -407,64 +410,10 @@ export function Header({ onMenuClick }: HeaderProps) {
             {HeaderSyncIndicator && <HeaderSyncIndicator />}
 
             {unreadCount > 0 && (
-              <button
-                onClick={() => markAllAsRead(activeFilter.platform)}
-                title={`Mark all ${unreadCount.toLocaleString()} items as read`}
-                className="hidden sm:flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm text-[#71717a] hover:bg-white/5 hover:text-white transition-colors"
-              >
-                <svg
-                  className="w-4 h-4"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
-                  />
-                </svg>
-                <span>{unreadCount.toLocaleString()} unread</span>
-              </button>
-            )}
-
-            {archivableCount > 0 && (
-              <button
-                onClick={() =>
-                  archiveAllReadUnsaved(
-                    activeFilter.platform,
-                    activeFilter.feedUrl,
-                  )
-                }
-                title={`Archive all ${archivableCount.toLocaleString()} read items`}
-                className="hidden sm:flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm text-[#71717a] hover:bg-white/5 hover:text-white transition-colors"
-              >
-                <svg
-                  className="w-4 h-4"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M5 13l4 4L19 7"
-                  />
-                </svg>
-                <span>{archivableCount.toLocaleString()} read</span>
-              </button>
-            )}
-
-            {/* + New dropdown */}
-            {showNewButton && (
-              <div ref={dropdownRef} className="relative">
+              <Tooltip label={`Mark all ${unreadCount.toLocaleString()} items as read`} className="hidden sm:flex">
                 <button
-                  onClick={() => setDropdownOpen((v) => !v)}
-                  className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-[#8b5cf6]/20 text-[#8b5cf6] hover:bg-[#8b5cf6]/30 transition-colors"
-                  aria-haspopup="true"
-                  aria-expanded={dropdownOpen}
+                  onClick={() => markAllAsRead(activeFilter.platform)}
+                  className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm text-[#71717a] hover:bg-white/5 hover:text-white transition-colors"
                 >
                   <svg
                     className="w-4 h-4"
@@ -476,14 +425,27 @@ export function Header({ onMenuClick }: HeaderProps) {
                       strokeLinecap="round"
                       strokeLinejoin="round"
                       strokeWidth={2}
-                      d="M12 4v16m8-8H4"
+                      d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
                     />
                   </svg>
-                  <span className="text-sm font-medium hidden sm:inline">
-                    New
-                  </span>
+                  <span>{unreadCount.toLocaleString()} unread</span>
+                </button>
+              </Tooltip>
+            )}
+
+            {archivableCount > 0 && (
+              <Tooltip label={`Archive all ${archivableCount.toLocaleString()} read items`} className="hidden sm:flex">
+                <button
+                  onClick={() =>
+                    archiveAllReadUnsaved(
+                      activeFilter.platform,
+                      activeFilter.feedUrl,
+                    )
+                  }
+                  className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm text-[#71717a] hover:bg-white/5 hover:text-white transition-colors"
+                >
                   <svg
-                    className={`w-3 h-3 transition-transform hidden sm:block ${dropdownOpen ? "rotate-180" : ""}`}
+                    className="w-4 h-4"
                     fill="none"
                     viewBox="0 0 24 24"
                     stroke="currentColor"
@@ -492,10 +454,55 @@ export function Header({ onMenuClick }: HeaderProps) {
                       strokeLinecap="round"
                       strokeLinejoin="round"
                       strokeWidth={2}
-                      d="M19 9l-7 7-7-7"
+                      d="M5 13l4 4L19 7"
                     />
                   </svg>
+                  <span>{archivableCount.toLocaleString()} read</span>
                 </button>
+              </Tooltip>
+            )}
+
+            {/* + New dropdown */}
+            {showNewButton && (
+              <div ref={dropdownRef} className="relative">
+                <Tooltip label="Add new content">
+                  <button
+                    onClick={() => setDropdownOpen((v) => !v)}
+                    className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-[#8b5cf6]/20 text-[#8b5cf6] hover:bg-[#8b5cf6]/30 transition-colors"
+                    aria-haspopup="true"
+                    aria-expanded={dropdownOpen}
+                  >
+                    <svg
+                      className="w-4 h-4"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M12 4v16m8-8H4"
+                      />
+                    </svg>
+                    <span className="text-sm font-medium hidden sm:inline">
+                      New
+                    </span>
+                    <svg
+                      className={`w-3 h-3 transition-transform hidden sm:block ${dropdownOpen ? "rotate-180" : ""}`}
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M19 9l-7 7-7-7"
+                      />
+                    </svg>
+                  </button>
+                </Tooltip>
 
                 {dropdownOpen && (
                   <div className="absolute right-0 top-full mt-1.5 w-44 bg-[#161616] border border-[rgba(255,255,255,0.1)] rounded-xl shadow-2xl shadow-black/70 overflow-hidden z-50 py-1">

--- a/packages/ui/src/components/layout/Sidebar.tsx
+++ b/packages/ui/src/components/layout/Sidebar.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, useEffect, useRef, useMemo, type ReactNode } from "react";
+
 import type { RssFeed } from "@freed/shared";
 import { useAppStore, usePlatform } from "../../context/PlatformContext.js";
 import { SettingsDialog } from "../SettingsDialog.js";
@@ -230,6 +231,9 @@ export function Sidebar({ open, onClose }: SidebarProps) {
   const updatePreferences = useAppStore((s) => s.updatePreferences);
   const items = useAppStore((s) => s.items);
 
+  const savedCount = useMemo(() => items.filter((i) => i.userState.saved).length, [items]);
+  const archivedCount = useMemo(() => items.filter((i) => i.userState.archived).length, [items]);
+
   const { open: showSettings, openDefault: openSettings, close: closeSettings } = useSettingsStore();
   const [dragWidth, setDragWidth] = useState<number | null>(null);
 
@@ -452,7 +456,10 @@ export function Sidebar({ open, onClose }: SidebarProps) {
                   `}
                 >
                   <span className="w-5 flex items-center justify-center"><BookmarkIcon /></span>
-                  <span>Saved</span>
+                  <span className="flex-1">Saved</span>
+                  {savedCount > 0 && (
+                    <span className="text-[10px] tabular-nums text-[#52525b]">{fmt(savedCount)}</span>
+                  )}
                 </button>
               </li>
               <li>
@@ -469,7 +476,10 @@ export function Sidebar({ open, onClose }: SidebarProps) {
                   `}
                 >
                   <span className="w-5 flex items-center justify-center"><ArchiveIcon /></span>
-                  <span>Archived</span>
+                  <span className="flex-1">Archived</span>
+                  {archivedCount > 0 && (
+                    <span className="text-[10px] tabular-nums text-[#52525b]">{fmt(archivedCount)}</span>
+                  )}
                 </button>
               </li>
             </ul>


### PR DESCRIPTION
(AI Generated)

## Summary

- **Scroll to top on source change**: FeedList now resets scroll position when `activeFilter` changes, so switching sources in the sidebar always starts at the top.
- **Reader toolbar hover states**: Active-state toggle buttons (Focus, Save, Archive, Dual-column) now have visible hover feedback (`hover:bg-*/30`) instead of appearing inert.
- **Animated tooltips**: New shared `Tooltip` component using CSS-only transitions (scale + opacity, 75ms delay). Replaces all native `title` attributes on toolbar buttons in both Header and ReaderView.
- **Fix broken bookmark/archive in ReaderView**: The save button was calling `updateItem()` with a replaced `userState` object, which silently corrupts under Automerge's proxy. Switched to the store's `toggleSaved()` which mutates fields in place. Also fixed stale `selectedItem` in FeedView by storing only the ID and deriving the live item from `filteredItems` via `useMemo`.
- **Saved/Archived counts in sidebar**: Library section now shows item counts next to Saved and Archived, matching the pattern used by Sources and Feeds.

## Test plan

- [ ] Click between different sources in the sidebar; content list should scroll to top each time
- [ ] Hover active toggle buttons in the reader toolbar; background should brighten
- [ ] Hover any toolbar button; animated tooltip should appear after a brief delay
- [ ] Open an article, click the bookmark icon; it should toggle immediately and persist
- [ ] Open an article, click the archive icon; reader should close and item should move to archived
- [ ] Check sidebar Library section shows counts for Saved and Archived items