### PR TITLE
fix: remove redundant data wrapper from TimelineResponse type

### DIFF
--- a/packages/capture-x/src/types.ts
+++ b/packages/capture-x/src/types.ts
@@ -45,13 +45,11 @@ export interface XApiError {
 // =============================================================================
 
 export interface TimelineResponse {
-  data: {
-    home: {
-      home_timeline_urt: {
-        instructions: TimelineInstruction[];
-        responseObjects?: {
-          feedbackActions?: unknown[];
-        };
+  home: {
+    home_timeline_urt: {
+      instructions: TimelineInstruction[];
+      responseObjects?: {
+        feedbackActions?: unknown[];
       };
     };
   };


### PR DESCRIPTION
(AI Generated)

## Summary
- `TimelineResponse` had a redundant `data` wrapper that conflicted with `XApiResponse<T>` which already provides the `data` envelope. The `request()` method unwraps `data.data`, so the type parameter should match the inner structure directly.
- This caused `tsc` to reject `response.home.home_timeline_urt` at line 201 of `client.ts`, breaking all 4 platform release builds for v26.3.700.

## Test plan
- [x] `npx tsc --noEmit` passes for `@freed/capture-x`
- [ ] CI build passes on all platforms