### PR TITLE
fix: desktop build errors in x-capture and fb-capture

### DIFF
--- a/packages/desktop/src/lib/fb-capture.ts
+++ b/packages/desktop/src/lib/fb-capture.ts
@@ -27,7 +27,6 @@ import { addDebugEvent } from "@freed/ui/lib/debug-store";
 
 let lastScrapeAt = 0;
 const MIN_INTERVAL_MS = 20 * 60 * 1000; // 20 minutes minimum between scrapes
-const MAX_SCRAPES_PER_HOUR = 3;
 const recentScrapes: number[] = [];
 
 function isRateLimited(): boolean {

--- a/packages/desktop/src/lib/x-capture.ts
+++ b/packages/desktop/src/lib/x-capture.ts
@@ -200,10 +200,11 @@ export async function fetchXTimeline(
     return { items: [], diag };
   }
 
-  const response = parsed as TimelineResponse;
-  // Real API wraps in `data`; fall back to unwrapped for robustness.
-  const home =
-    response?.data?.home ?? (parsed as Record<string, unknown>)?.home as TimelineResponse["data"]["home"] | undefined;
+  // Raw X API wraps in { data: { home: ... } }; capture-x client unwraps
+  // the data layer but desktop hits the API directly via Tauri invoke.
+  const wrapped = parsed as { data?: TimelineResponse };
+  const unwrapped = parsed as TimelineResponse;
+  const home = wrapped?.data?.home ?? unwrapped?.home;
   const instructions = home?.home_timeline_urt?.instructions ?? [];
 
   if (instructions.length === 0) {


### PR DESCRIPTION
(AI Generated)

## Summary
- `x-capture.ts`: After #109 removed the `data` wrapper from `TimelineResponse`, the desktop code that accesses the raw API response (which still has `{ data: { home: ... } }`) broke. Now handles both wrapped and unwrapped shapes.
- `fb-capture.ts`: Removed unused `MAX_SCRAPES_PER_HOUR` constant that violated `noUnusedLocals`.

These two errors caused all 4 platform builds to fail for v26.3.701.

## Test plan
- [x] `npx tsc --noEmit` passes for both `@freed/capture-x` and desktop
- [ ] CI passes
- [ ] Release build succeeds after merge