### PR TITLE
fix: prefix unused state param in capture-instagram rate-limit

### DIFF
--- a/packages/capture-instagram/src/rate-limit.ts
+++ b/packages/capture-instagram/src/rate-limit.ts
@@ -35,7 +35,7 @@ export function checkRateLimit(
 }
 
 export function recordSuccess(
-  state: RateLimitState,
+  _state: RateLimitState,
   now: number = Date.now()
 ): RateLimitState {
   return { lastScrapeAt: now, consecutiveErrors: 0, cooldownUntil: 0 };


### PR DESCRIPTION
(AI Generated)

## Summary
- Prefixes the unused `state` parameter with `_` in `recordSuccess()` in `packages/capture-instagram/src/rate-limit.ts`
- Fixes TS6133 error that broke all four platform release builds for v26.3.703

## Test plan
- [x] `tsc -b packages/desktop/tsconfig.json` passes locally
- [ ] CI passes on this PR