### PR TITLE
feat: sidebar purple dots, dev auto-seed, and social sample data

### DIFF
--- a/packages/desktop/src/App.tsx
+++ b/packages/desktop/src/App.tsx
@@ -20,9 +20,9 @@ import {
   deleteCloudFile,
 } from "./lib/sync";
 import { clearLocalDoc } from "./lib/automerge";
-import { clearStoredCookies } from "./lib/x-auth";
-import { disconnectIg } from "./lib/instagram-auth";
-import { disconnectFb } from "./lib/fb-auth";
+import { clearStoredCookies, storeCookies } from "./lib/x-auth";
+import { disconnectIg, storeIgAuthState } from "./lib/instagram-auth";
+import { disconnectFb, storeFbAuthState } from "./lib/fb-auth";
 import { contentCache } from "./lib/content-cache";
 import { saveUrlInDesktop } from "./lib/save-url";
 import { importMarkdownFiles, exportLibrary } from "./lib/import-export";
@@ -38,6 +38,7 @@ import { XSourceIndicator } from "./components/XSourceIndicator";
 import { DesktopSyncIndicator } from "./components/DesktopSyncIndicator";
 import { MobileSyncTab } from "./components/MobileSyncTab";
 import { check, type Update } from "@tauri-apps/plugin-updater";
+import { generateSampleFeeds, generateSampleItems } from "@freed/shared";
 
 const UPDATE_CHECK_INTERVAL_MS = 30 * 60 * 1000; // 30 minutes
 const JUST_UPDATED_KEY = "freed-updated-to";
@@ -177,6 +178,40 @@ function App() {
     location.reload();
   }, []);
 
+  // Fake-authenticate all social providers for local testing. Writes stub
+  // credentials to localStorage (matching the real auth persistence format)
+  // and updates Zustand state so the sidebar dots light up without a real login.
+  const seedSocialConnections = useCallback(() => {
+    const { setXAuth, setFbAuth, setIgAuth } = useAppStore.getState();
+    const now = Date.now();
+
+    const xCookies = { ct0: "sample-ct0-token", authToken: "sample-auth-token" };
+    storeCookies(xCookies);
+    setXAuth({ isAuthenticated: true, cookies: xCookies, username: "sample_user" });
+
+    const fbState = { isAuthenticated: true, lastCheckedAt: now };
+    storeFbAuthState(fbState);
+    setFbAuth(fbState);
+
+    const igState = { isAuthenticated: true, lastCheckedAt: now };
+    storeIgAuthState(igState);
+    setIgAuth(igState);
+  }, []);
+
+  // In dev mode, auto-seed sample data on first page load of each browser
+  // session. sessionStorage guard prevents re-seeding on hot-reload while
+  // still running fresh on every full browser open (e.g. new worktree test).
+  useEffect(() => {
+    if (!isInitialized || !import.meta.env.DEV) return;
+    if (sessionStorage.getItem("freed_dev_seeded")) return;
+    sessionStorage.setItem("freed_dev_seeded", "1");
+
+    const { addFeed, addItems } = useAppStore.getState();
+    generateSampleFeeds().forEach((f) => addFeed(f));
+    addItems(generateSampleItems());
+    seedSocialConnections();
+  }, [isInitialized, seedSocialConnections]);
+
   const platform: PlatformConfig = useMemo(
     () => ({
       store: useAppStore,
@@ -194,6 +229,7 @@ function App() {
       checkForUpdates,
       applyUpdate,
       factoryReset: handleFactoryReset,
+      seedSocialConnections,
       activeCloudProviderLabel: () => {
         const providers = getActiveProviders();
         if (providers.length === 0) return null;
@@ -221,7 +257,7 @@ function App() {
       openUrl: (url: string) => { void shellOpen(url); },
       pickContact: pickContactViaTauri,
     }),
-    [checkForUpdates, applyUpdate, handleFactoryReset],
+    [checkForUpdates, applyUpdate, handleFactoryReset, seedSocialConnections],
   );
 
   if (error && !isInitialized) {

--- a/packages/shared/src/sample-data.ts
+++ b/packages/shared/src/sample-data.ts
@@ -154,6 +154,59 @@ const SAVED_DOMAINS = [
   "atlasobscura.com", "makersguide.io", "indoorgardens.net",
 ];
 
+// ── Social post pools ────────────────────────────────────────────────────────
+
+const X_POSTS: string[] = [
+  "Hot take: the best documentation is the kind that fits in a tweet. Prove me wrong.",
+  "Spent the morning reading CRDT papers. My brain is now a conflict-free replicated data type.",
+  "The best debugging tool is still a good night's sleep. Change my mind.",
+  "Local-first software isn't just a pattern. It's a philosophy about who owns your data.",
+  "Reminder that `git blame` is a feature, not a slur.",
+  "Every abstraction is a lie we agree to believe for long enough to ship.",
+  "The real LLM alignment problem is getting it to stop explaining what a hash map is.",
+  "Compilers are just very confident editors with zero social skills.",
+  "New blog post: why I rewrote my side project in six languages and learned nothing.",
+  "Unpopular opinion: the README is the product. Everything else is implementation detail.",
+];
+
+const X_AUTHORS = [
+  { id: "sample-x-1", handle: "@devposts", displayName: "Dev Posts" },
+  { id: "sample-x-2", handle: "@nullpointer", displayName: "Null Pointer" },
+  { id: "sample-x-3", handle: "@bytewatcher", displayName: "Byte Watcher" },
+];
+
+const FACEBOOK_POSTS: string[] = [
+  "Just shipped a feature I've been sitting on for three weeks. Feels good. Grabbed a coffee to celebrate.",
+  "Does anyone else get unreasonably excited when a PR comes back with zero comments?",
+  "Reminder: your coworkers are not trying to frustrate you. They just have different context than you do.",
+  "Took a long walk today. Came back with the solution to a bug I've been fighting for two days.",
+  "Hot desk tip: find the chair with the best lumbar support and defend it with your life.",
+  "Running retrospectives is basically group therapy for people who refuse to go to therapy.",
+  "Anyone else have a folder called 'temp' that's been around since 2019?",
+  "Finished the book. Would recommend. No spoilers but: the architecture holds.",
+  "Our standup ran exactly 12 minutes today. A personal record.",
+  "The sprint ended. No one died. Ship it.",
+];
+
+const FACEBOOK_AUTHORS = [
+  { id: "sample-fb-1", handle: "Engineering Thoughts", displayName: "Engineering Thoughts" },
+  { id: "sample-fb-2", handle: "The Dev Desk", displayName: "The Dev Desk" },
+  { id: "sample-fb-3", handle: "Ship It Culture", displayName: "Ship It Culture" },
+];
+
+const INSTAGRAM_POSTS: string[] = [
+  "Morning light, cold brew, and a diff that's finally green ☀️",
+  "The office at 7am hits different. Nobody here yet. Just me and the compiler.",
+  "Mechanical keyboard + good headphones = flow state in 3 minutes flat.",
+  "Whiteboard session went long but the diagram finally makes sense.",
+  "Setup tour coming soon. Spoiler: it's mostly cables.",
+  "Found a two-line fix for a week-old bug. Framing this diff.",
+  "First deploy of the week. Clean. Fast. Going back to bed.",
+  "Documenting is an act of kindness for your future self.",
+  "Pair programming session: we argued for 40 minutes and then agreed I was right.",
+  "New desk plant. It will outlive this codebase.",
+];
+
 // ── Deterministic pseudo-random ─────────────────────────────────────────────
 
 /** Simple seeded PRNG (mulberry32) for reproducible distributions. */
@@ -189,9 +242,11 @@ export function generateSampleFeeds(): RssFeed[] {
 }
 
 /**
- * Generate 100 sample feed items: 80 RSS articles (8 per feed) +
- * 20 saved bookmarks. Items are spread across the last 14 days with
- * varied user states (read, saved, archived) to exercise all UI views.
+ * Generate 130 sample feed items: 80 RSS articles (8 per feed) +
+ * 20 saved bookmarks + 10 X posts + 10 Facebook posts + 10 Instagram posts.
+ * Items are spread across the last 14 days with varied user states (read,
+ * saved, archived) to exercise all UI views. All IDs are deterministic so
+ * repeated calls are idempotent against the Automerge duplicate guard.
  */
 export function generateSampleItems(): FeedItem[] {
   const rand = mulberry32(42);
@@ -288,6 +343,115 @@ export function generateSampleItems(): FeedItem[] {
         tags: [],
       },
       topics: pickTopics(rand, 80 + si),
+    });
+  }
+
+  // 10 X posts
+  for (let xi = 0; xi < 10; xi++) {
+    const age = (xi / 10) * 7 * DAY + rand() * DAY;
+    const publishedAt = Math.round(now - age);
+    const r = rand();
+    const author = X_AUTHORS[xi % X_AUTHORS.length];
+
+    items.push({
+      globalId: `sample-x:${xi}`,
+      platform: "x",
+      contentType: "post",
+      capturedAt: publishedAt + 5_000,
+      publishedAt,
+      author,
+      content: {
+        text: X_POSTS[xi % X_POSTS.length],
+        mediaUrls: [],
+        mediaTypes: [],
+      },
+      engagement: {
+        likes: Math.round(rand() * 2000),
+        reposts: Math.round(rand() * 400),
+        comments: Math.round(rand() * 150),
+      },
+      userState: {
+        hidden: false,
+        saved: r > 0.85,
+        savedAt: r > 0.85 ? publishedAt + 10_000 : undefined,
+        archived: r < 0.1,
+        archivedAt: r < 0.1 ? publishedAt + 60_000 : undefined,
+        readAt: r < 0.5 ? publishedAt + 8_000 : undefined,
+        tags: [],
+      },
+      topics: pickTopics(rand, 100 + xi),
+    });
+  }
+
+  // 10 Facebook posts
+  for (let fi = 0; fi < 10; fi++) {
+    const age = (fi / 10) * 7 * DAY + rand() * DAY;
+    const publishedAt = Math.round(now - age);
+    const r = rand();
+    const author = FACEBOOK_AUTHORS[fi % FACEBOOK_AUTHORS.length];
+
+    items.push({
+      globalId: `sample-facebook:${fi}`,
+      platform: "facebook",
+      contentType: "post",
+      capturedAt: publishedAt + 5_000,
+      publishedAt,
+      author,
+      content: {
+        text: FACEBOOK_POSTS[fi % FACEBOOK_POSTS.length],
+        mediaUrls: [],
+        mediaTypes: [],
+      },
+      engagement: {
+        likes: Math.round(rand() * 800),
+        comments: Math.round(rand() * 60),
+      },
+      userState: {
+        hidden: false,
+        saved: r > 0.85,
+        savedAt: r > 0.85 ? publishedAt + 10_000 : undefined,
+        archived: r < 0.1,
+        archivedAt: r < 0.1 ? publishedAt + 60_000 : undefined,
+        readAt: r < 0.5 ? publishedAt + 8_000 : undefined,
+        tags: [],
+      },
+      topics: pickTopics(rand, 110 + fi),
+    });
+  }
+
+  // 10 Instagram posts
+  const IG_AUTHOR = { id: "sample-ig-1", handle: "@freed.desk", displayName: "Freed Desk" };
+  for (let ii = 0; ii < 10; ii++) {
+    const age = (ii / 10) * 7 * DAY + rand() * DAY;
+    const publishedAt = Math.round(now - age);
+    const r = rand();
+
+    items.push({
+      globalId: `sample-instagram:${ii}`,
+      platform: "instagram",
+      contentType: "post",
+      capturedAt: publishedAt + 5_000,
+      publishedAt,
+      author: IG_AUTHOR,
+      content: {
+        text: INSTAGRAM_POSTS[ii % INSTAGRAM_POSTS.length],
+        mediaUrls: [],
+        mediaTypes: [],
+      },
+      engagement: {
+        likes: Math.round(rand() * 1500),
+        comments: Math.round(rand() * 80),
+      },
+      userState: {
+        hidden: false,
+        saved: r > 0.85,
+        savedAt: r > 0.85 ? publishedAt + 10_000 : undefined,
+        archived: r < 0.1,
+        archivedAt: r < 0.1 ? publishedAt + 60_000 : undefined,
+        readAt: r < 0.5 ? publishedAt + 8_000 : undefined,
+        tags: [],
+      },
+      topics: pickTopics(rand, 120 + ii),
     });
   }
 

--- a/packages/ui/src/components/SettingsDialog.tsx
+++ b/packages/ui/src/components/SettingsDialog.tsx
@@ -177,6 +177,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
     headerDragRegion,
     factoryReset,
     activeCloudProviderLabel,
+    seedSocialConnections,
   } = usePlatform();
   const preferences = useAppStore((s) => s.preferences);
   const updatePreferences = useAppStore((s) => s.updatePreferences);
@@ -297,11 +298,12 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
         await addFeed(feed);
       }
       await addItems(items);
+      seedSocialConnections?.();
       setSeedDone(true);
     } finally {
       setSeeding(false);
     }
-  }, [addFeed, addItems]);
+  }, [addFeed, addItems, seedSocialConnections]);
 
   // ── Search ────────────────────────────────────────────────────────────────
   const [search, setSearch] = useState("");
@@ -679,8 +681,8 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
                   </p>
                   <p className="text-xs text-amber-400/50 mt-0.5">
                     {seedDone
-                      ? "10 feeds and 100 items added"
-                      : "Adds 10 RSS feeds and 100 items for regression testing"}
+                      ? "10 feeds, 130 items, and social connections added"
+                      : "Adds 10 RSS feeds, 130 items, and X/Facebook/Instagram connections"}
                   </p>
                 </div>
                 {seedDone ? (

--- a/packages/ui/src/context/PlatformContext.tsx
+++ b/packages/ui/src/context/PlatformContext.tsx
@@ -102,6 +102,14 @@ export interface PlatformConfig {
   applyUpdate?: () => void;
 
   /**
+   * Fake-authenticate all social providers (X, Facebook, Instagram) for local
+   * testing. Writes stub credentials to localStorage and updates store auth
+   * state so the purple connection dots appear in the sidebar without needing
+   * a real login flow. Desktop only -- absent on PWA.
+   */
+  seedSocialConnections?: () => void;
+
+  /**
    * Perform a factory reset on this device.
    * Wipes IndexedDB + localStorage. When `deleteFromCloud` is true, also
    * deletes the sync file from the active cloud provider before clearing.


### PR DESCRIPTION
(AI Generated)

## Summary

- Connection indicator dots in the sidebar are now small, subtle purple dots (6px, `bg-[#8b5cf6]/50`) instead of large green ones, and sit just right of the label text rather than being pushed to the far right where they interfered with count alignment
- `generateSampleItems()` now returns 130 items: adds 10 X posts, 10 Facebook posts, and 10 Instagram posts with deterministic IDs so re-running is idempotent
- New `seedSocialConnections()` platform callback writes stub auth state to localStorage and flips all three Zustand auth slices to `isAuthenticated: true` -- purple sidebar dots appear without a real login flow
- Settings "Populate sample data" button now also calls `seedSocialConnections` and reflects the updated counts in its copy
- In dev mode (`import.meta.env.DEV`), the app auto-seeds all of the above on first page load per browser session (guarded by `sessionStorage` so hot-reload doesn't repeat it)
- `strictPort` in `vite.config.ts` is now `false` when `VITE_TEST_TAURI=1`, so multiple worktrees running mock dev servers no longer collide on port 1420

## Test plan

- [ ] Open `http://localhost:1421/` -- feeds, items, and social connections should be seeded automatically on first load; purple dots should appear next to X, Facebook, and Instagram in the sidebar
- [ ] Reload the page -- seed should NOT re-run (sessionStorage guard)
- [ ] Open Settings > Developer > "Populate sample data" -- button should describe "X/Facebook/Instagram connections"; clicking it should set the dots if cleared
- [ ] Verify count numbers in the sidebar are still right-aligned and unaffected by the dots