### PR TITLE
fix: resolve TypeScript compile errors blocking release build

### DIFF
--- a/packages/desktop/src/App.tsx
+++ b/packages/desktop/src/App.tsx
@@ -50,10 +50,10 @@ const JUST_UPDATED_KEY = "freed-updated-to";
 // Accumulate React render phases when running under Playwright (VITE_TEST_TAURI=1)
 interface ProfileEntry { id: string; phase: string; actualDuration: number; baseDuration: number }
 if (import.meta.env.VITE_TEST_TAURI === "1") {
-  (window as Record<string, unknown>).__FREED_REACT_PROFILE__ = [] as ProfileEntry[];
+  (window as unknown as Record<string, unknown>).__FREED_REACT_PROFILE__ = [] as ProfileEntry[];
 }
 const onRender: ProfilerOnRenderCallback = (id, phase, actual, base) => {
-  const w = window as Record<string, unknown>;
+  const w = window as unknown as Record<string, unknown>;
   const arr = w.__FREED_REACT_PROFILE__ as ProfileEntry[] | undefined;
   if (arr) arr.push({ id, phase, actualDuration: actual, baseDuration: base });
 };

--- a/packages/desktop/src/lib/outbox.ts
+++ b/packages/desktop/src/lib/outbox.ts
@@ -167,15 +167,15 @@ export function startOutboxProcessor(
 
     // If new items arrived during drain, schedule another pass so they
     // don't sit in the outbox until the next external doc change.
-    if (hasPendingItems(getDoc())) {
+    if (hasPendingItems(getItems())) {
       scheduleDrain();
     }
   }
 
   /** Quick check for any items that still need outbox processing. */
-  function hasPendingItems(doc: FreedDoc | null): boolean {
-    if (!doc) return false;
-    for (const item of Object.values(doc.feedItems)) {
+  function hasPendingItems(items: FeedItem[] | null): boolean {
+    if (!items) return false;
+    for (const item of items) {
       const us = item.userState;
       if (us.liked && us.likedAt && !us.likedSyncedAt) {
         const r = retryMap.get(item.globalId);

--- a/packages/desktop/tests/e2e/x-capture.spec.ts
+++ b/packages/desktop/tests/e2e/x-capture.spec.ts
@@ -153,12 +153,11 @@ test("X connect form accepts cookies and triggers sync", async ({
 
   // Click "Manual cookie setup" to reach the cookie input form
   const manualBtn = page.getByText("Manual cookie setup");
-  await expect(manualBtn).toBeVisible({ timeout: 3_000 });
+  await expect(manualBtn).toBeVisible({ timeout: 5_000 });
   await manualBtn.click();
-  await page.waitForTimeout(300);
 
-  // Fill cookies using getByPlaceholder which is more stable across re-renders
-  await expect(page.getByPlaceholder("ct0 value")).toBeVisible({ timeout: 3_000 });
+  // Fill cookies once the form is visible (allow for state transition)
+  await expect(page.getByPlaceholder("ct0 value")).toBeVisible({ timeout: 5_000 });
   await page.getByPlaceholder("ct0 value").fill("test_ct0_value");
   await page.getByPlaceholder("auth_token value").fill("test_auth_token_value");
 


### PR DESCRIPTION
(AI Generated)

## Summary

Two TypeScript compile errors blocking the v26.3.802 release build on all four platforms:

- **`App.tsx` TS2352**: Window casts via `window as Record<string, unknown>` fail strict TypeScript because `Window & typeof globalThis` doesn't have an index signature. Fixed with double cast: `window as unknown as Record<string, unknown>`.
- **`outbox.ts` TS2304/TS18046**: `hasPendingItems()` was referencing `getDoc()` and `FreedDoc` type - both removed from `outbox.ts` during the worker migration that changed the outbox to accept `FeedItem[] | null` instead of the raw doc. Updated to call `getItems()` and accept `FeedItem[]`.
- **X capture E2E**: Minor timeout increase for manual cookie form - the `ct0 value` input was timing out at 3s, bumped to 5s to match the rest of the test suite.

## Test plan

- [ ] All platform builds compile: `tsc -b && vite build` passes on macOS, Windows, Linux
- [ ] E2E: all 33 tests pass including `x-capture.spec.ts:120`