### PR TITLE
fix: remove capture-x build step from release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,7 +208,6 @@ jobs:
           npm run build -w @freed/shared
           npm run build -w @freed/sync
           npm run build -w @freed/capture-rss
-          npm run build -w @freed/capture-x
 
       # macOS code signing (only runs if secrets are configured)
       - name: Import Apple signing certificate


### PR DESCRIPTION
(AI Generated)

## Summary

- The anti-detection hardening PR (#119) stripped `packages/capture-x/package.json` down to just a `typecheck` script (no `build`) since the package now only exports raw `.ts` source directly and has no compiled dist output
- The `release.yml` workflow still had `npm run build -w @freed/capture-x` which caused all 4 release platform legs to fail identically with `Missing script: "build"`
- One-line fix: remove that step from the workflow

## Test plan

- [ ] CI passes on this PR
- [ ] After merge and re-tag, all 4 release platform builds succeed