### PR TITLE
fix: remove unused user-agent import from fb-capture.ts

### DIFF
--- a/packages/desktop/src/lib/fb-capture.ts
+++ b/packages/desktop/src/lib/fb-capture.ts
@@ -20,7 +20,6 @@ import {
 } from "@freed/capture-facebook/browser";
 import { useAppStore } from "./store";
 import { addDebugEvent } from "@freed/ui/lib/debug-store";
-import { getPlatformUA, selectPlatformUA, clearPlatformUA } from "./user-agent";
 
 // =============================================================================
 // Rate Limiting


### PR DESCRIPTION
(AI Generated)

## Summary

- UA selection for Facebook happens in `fb-auth.ts` at connect time (`showFbLogin` calls `selectPlatformUA`)
- `fb-capture.ts` only calls `invoke("fb_scrape_feed")` -- the Rust side reads the UA from `CaptureState` directly, so the TypeScript layer doesn't need the helpers
- The stray import of `getPlatformUA`, `selectPlatformUA`, `clearPlatformUA` from `./user-agent` was caught by TypeScript's `noUnusedLocals` flag, killing the build on all 4 CI platforms with `TS6192`

## Test plan

- [ ] CI passes
- [ ] After merge and re-tag, release builds succeed on all platforms