### PR TITLE
fix: switch reqwest and tauri-plugin-updater to rustls-tls

### DIFF
--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -15,14 +15,15 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 tauri = { version = "2", features = ["macos-private-api", "tray-icon", "image-png"] }
 tauri-plugin-shell = "2"
-tauri-plugin-updater = "2"
+tauri-plugin-updater = { version = "2", features = ["rustls-tls"] }
 tauri-plugin-process = "2"
 tauri-plugin-store = "2"
 tauri-plugin-fs = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 window-vibrancy = "0.6"
-reqwest = { version = "0.12", features = ["json"] }
+# default-features = false drops native-tls (OpenSSL) which conflicts with rquest's BoringSSL on Linux.
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 rquest = { version = "5", features = ["json"] }
 rquest-util = "2"
 tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
(AI Generated)

## Summary

- `rquest` (used for X API requests) links BoringSSL statically as its TLS implementation
- `reqwest` (used for RSS `fetch_url`) defaults to `native-tls` on Linux, which resolves to system OpenSSL
- At link time on Linux, both SSL stacks end up in the binary and the linker fails with undefined symbols: `SSL_CTX_ctrl`, `SSL_write_ex`, `SSL_read_ex`, `SSL_get1_peer_certificate` -- these are OpenSSL 1.1.1+ APIs that BoringSSL does not implement
- `tauri-plugin-updater` uses reqwest internally and was also pulling in `native-tls`
- Fix: `default-features = false` on `reqwest` + explicit `rustls-tls` on both deps eliminates OpenSSL from the link entirely, leaving BoringSSL as the sole SSL implementation

## Test plan

- [ ] CI passes (build + lint)
- [ ] After merge and re-tag, Linux x64 release build completes successfully
- [ ] macOS and Windows builds unaffected (rustls-tls works on all platforms)