### PR TITLE
fix: use previous published release as changelog commit boundary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,10 +34,18 @@ jobs:
           TAG="${GITHUB_REF#refs/tags/}"
           VERSION="${TAG#v}"
 
-          # Find the previous tag to bound the commit range
-          PREV_TAG=$(git tag --sort=version:refname | grep -v "^${TAG}$" | tail -1)
+          # Find the previous *published* GitHub Release tag (not just any git tag).
+          # Using the previous git tag would silently drop all commits from failed
+          # build attempts that left unpublished tags between two good releases.
+          PREV_TAG=""
+          ALL_PUBLISHED=$(gh release list --limit 200 --json tagName,isDraft,isPrerelease \
+            --jq '.[] | select(.isDraft==false and .isPrerelease==false) | .tagName' | sort -V)
+          while IFS= read -r candidate; do
+            [[ "$candidate" == "$TAG" ]] && break
+            PREV_TAG="$candidate"
+          done <<< "$ALL_PUBLISHED"
 
-          # Collect commits between prev tag and this tag
+          # Collect commits between prev published release and this tag
           if [[ -n "$PREV_TAG" ]]; then
             COMMITS=$(git log "${PREV_TAG}..${TAG}" --format="%s" 2>/dev/null || true)
           else

--- a/scripts/backfill-changelog.sh
+++ b/scripts/backfill-changelog.sh
@@ -123,16 +123,20 @@ published = set(gh_run(["release", "list", "--limit", "200", "--json", "tagName"
 
 print(f"Found {len(all_tags)} tags, {len(published)} with GitHub Releases.\n")
 
-prev_tag = ""
+# We track the last *published* tag, not the last tag. This is the key: when a
+# build fails and leaves an unpublished tag, the next successful release should
+# span all the way back to the last good published release so that features
+# developed during the failed build attempts are not silently dropped.
+prev_published_tag = ""
 processed = 0
 for tag in all_tags:
     if tag not in published:
         print(f"⚠  {tag} — no GitHub Release, skipping")
-        prev_tag = tag
+        # Do NOT advance prev_published_tag here — that's the whole fix.
         continue
 
-    print(f"Processing {tag} (prev: {prev_tag or 'none'})...", end=" ", flush=True)
-    body = build_body(tag, prev_tag)
+    print(f"Processing {tag} (prev: {prev_published_tag or 'none'})...", end=" ", flush=True)
+    body = build_body(tag, prev_published_tag)
 
     if DRY_RUN:
         print("DRY RUN")
@@ -152,7 +156,7 @@ for tag in all_tags:
             print(f"✗  {proc.stderr.strip()}")
         time.sleep(0.5)   # be kind to the API
 
-    prev_tag = tag
+    prev_published_tag = tag
     processed += 1
 
 print(f"\nDone. {processed} releases {'previewed' if DRY_RUN else 'updated'}.")


### PR DESCRIPTION
(AI Generated)

## Summary

- Fixes changelog entries silently dropping features developed during failed build attempts
- Root cause: both the backfill script and release workflow used the previous git tag as the lower `git log` boundary. Failed builds leave unpublished tags that advance the boundary without ever appearing in the changelog, creating invisible gaps.
- Fix: track the last *published* release as the lower boundary. Unpublished tags are now skipped entirely without advancing the cursor.

## Impact

The most visible example is v26.3.702, which previously showed only two minor fixes (the 701→702 window). It now correctly shows the X/Facebook scrapers, dual-column reading mode, native X login, and Playwright test infrastructure -- all the big features developed during the v26.3.700 and v26.3.701 failed build window.

All 19 existing GitHub Releases have been re-backfilled with the corrected commit ranges.

## Files changed

- `scripts/backfill-changelog.sh` -- track `prev_published_tag` separately; don't advance it for unpublished tags
- `.github/workflows/release.yml` -- query GitHub Releases API to find the previous published tag instead of using `git tag | tail -1`