### PR TITLE
fix: exclude draft releases from changelog commit boundary

### DIFF
--- a/scripts/backfill-changelog.sh
+++ b/scripts/backfill-changelog.sh
@@ -117,9 +117,14 @@ def build_body(tag, prev_tag):
 # All v* tags in version order
 all_tags = [t for t in git(["tag", "--sort=version:refname"]).splitlines() if t.startswith("v")]
 
-# Only tags that have a published GitHub Release
-published = set(gh_run(["release", "list", "--limit", "200", "--json", "tagName",
-                         "--jq", ".[].tagName"]).splitlines())
+# Only tags with a fully published (non-draft, non-prerelease) GitHub Release.
+# Draft releases are failed builds that never shipped to users -- they must not
+# be used as changelog boundaries or their features will be silently swallowed.
+published = set(gh_run([
+    "release", "list", "--limit", "200",
+    "--json", "tagName,isDraft,isPrerelease",
+    "--jq", '.[] | select(.isDraft==false and .isPrerelease==false) | .tagName',
+]).splitlines())
 
 print(f"Found {len(all_tags)} tags, {len(published)} with GitHub Releases.\n")
 


### PR DESCRIPTION
(AI Generated)

## Summary

- The backfill script fetched all GitHub releases (including drafts) when building the boundary set, causing draft releases from failed builds to be used as changelog boundaries
- Draft releases are failed builds with no downloadable artifacts -- users can't update to them, they never appear on the changelog page, and their commits should roll up into the next successful release
- Filter the boundary set to non-draft, non-prerelease only, matching the same filter the changelog page applies when rendering

## Impact

v26.3.903 (the latest release) was showing only a single fix because v26.3.902 (a failed draft build) was incorrectly used as its lower boundary. With this fix, v26.3.903 spans back to v26.3.804 and correctly shows the anti-detection hardening (#119) and changelog page launch (#118) that shipped to users in this release window.

All 18 published releases have been re-backfilled.