### PR TITLE
fix: wait for Connect button to be enabled before clicking in X E2E test

### DIFF
--- a/packages/desktop/tests/e2e/x-capture.spec.ts
+++ b/packages/desktop/tests/e2e/x-capture.spec.ts
@@ -161,12 +161,16 @@ test("X connect form accepts cookies and triggers sync", async ({
   await page.getByPlaceholder("ct0 value").fill("test_ct0_value");
   await page.getByPlaceholder("auth_token value").fill("test_auth_token_value");
 
-  // Click Connect
-  await page
+  // Wait for the Connect button to become enabled (both fields filled, React
+  // settled) before clicking. The button re-renders when either input changes
+  // because its `disabled` prop is derived from both state values. Using
+  // `toBeEnabled()` here ensures the DOM is stable before Playwright acts.
+  const connectBtn = page
     .locator("button")
     .filter({ hasText: /^Connect$/ })
-    .first()
-    .click();
+    .first();
+  await expect(connectBtn).toBeEnabled({ timeout: 5_000 });
+  await connectBtn.click();
 
   // After connecting, the "Connected" indicator should appear
   await expect(page.getByText("Connected", { exact: true })).toBeVisible({ timeout: 10_000 });


### PR DESCRIPTION
(AI Generated)

## What

The X capture E2E test "X connect form accepts cookies and triggers sync" has been failing intermittently on CI because Playwright times out trying to click the Connect button.

## Why it fails

The button's `disabled` prop is derived from two local state values (`ct0` and `authToken`). After Playwright calls `fill()` on each input, React re-renders the component -- on CI machines the re-render cycle can detach and re-attach the button's DOM node fast enough to hit Playwright's "element is not stable" / "element was detached" check. Playwright was retrying for the full 30s default timeout and eventually giving up.

## Fix

Add an explicit `await expect(connectBtn).toBeEnabled()` assertion before `.click()`. Playwright's built-in polling will wait until the button is both attached and enabled (both fields filled, React settled), then proceed. This is the standard pattern for clicking a button whose enabled state is derived from controlled form inputs.

No production code changed.