### PR TITLE
fix: use opaque surface background on update toast

### DIFF
--- a/packages/desktop/src/App.tsx
+++ b/packages/desktop/src/App.tsx
@@ -316,7 +316,7 @@ function App() {
       {/* Post-restart confirmation — shown for 5s after a successful update relaunch */}
       {justUpdated && (
         <div className="fixed bottom-4 left-1/2 -translate-x-1/2 z-50 animate-slide-up pointer-events-none">
-          <div className="glass-card px-4 py-3 shadow-lg border border-[rgba(34,197,94,0.3)] flex items-center gap-2">
+          <div className="rounded-2xl bg-[var(--freed-surface)] px-4 py-3 shadow-lg border border-[rgba(34,197,94,0.3)] flex items-center gap-2">
             <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden>
               <path d="M3 8l3.5 3.5L13 5" stroke="#22c55e" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
             </svg>

--- a/packages/desktop/src/components/UpdateNotification.tsx
+++ b/packages/desktop/src/components/UpdateNotification.tsx
@@ -70,7 +70,7 @@ export function UpdateNotification({
 
   return (
     <div className="fixed bottom-4 right-4 z-50 max-w-sm animate-slide-up">
-      <div className="glass-card p-4 shadow-lg border border-[rgba(139,92,246,0.3)]">
+      <div className="rounded-2xl bg-[var(--freed-surface)] p-4 shadow-lg border border-[rgba(139,92,246,0.3)]">
         <div className="flex items-start gap-3">
           <div className="shrink-0 mt-0.5">
             <UpdateIcon phase={state.phase} />

--- a/packages/ui/src/components/Toast.tsx
+++ b/packages/ui/src/components/Toast.tsx
@@ -50,10 +50,12 @@ function ToastItem({ toast, onClose }: { toast: Toast; onClose: () => void }) {
     setTimeout(onClose, 200);
   };
 
+  // bg-[#1a1a1f] is the opaque base; the colored class stacks on top so the
+  // tint reads against the surface rather than bleeding through to content below.
   const bgColor = {
-    success: "bg-green-500/20 border-green-500/30",
-    error: "bg-red-500/20 border-red-500/30",
-    info: "bg-[#8b5cf6]/20 border-[#8b5cf6]/30",
+    success: "bg-[#1a1a1f] ring-1 ring-green-500/30 border-green-500/30",
+    error: "bg-[#1a1a1f] ring-1 ring-red-500/30 border-red-500/30",
+    info: "bg-[#1a1a1f] ring-1 ring-[#8b5cf6]/30 border-[#8b5cf6]/30",
   }[toast.type];
 
   const textColor = {


### PR DESCRIPTION
(AI Generated)

## Summary

- `UpdateNotification` was using `glass-card` whose `--bg-card` is `rgba(255,255,255,0.03)` -- basically invisible when floated over colored content
- Replace with `bg-[var(--freed-surface)]` (`#141414`, fully opaque) so the toast reads clearly regardless of what's behind it
- Border-radius preserved via `rounded-2xl` (matches `--card-radius: 16px`)

## Root cause

`glass-card` was designed for feed cards sitting on a near-black background, where 3% white barely registers as a surface tint. As a fixed-position overlay it becomes transparent against any non-black content underneath.