### PR TITLE
feat: archive toolbar with delete action and retention settings

### DIFF
--- a/docs/PHASE-5-DESKTOP.md
+++ b/docs/PHASE-5-DESKTOP.md
@@ -183,6 +183,7 @@ export async function captureDomFeed(
 | 5.23 | CI/CD release pipeline (GH Actions)| Medium     |
 | 5.24 | macOS code signing + notarization  | High       |
 | 5.25 | Windows code signing               | Medium     |
+| 5.26 | Independent update server domain   | Medium     |
 
 ### Mobile (Tauri 2.0)
 
@@ -261,6 +262,7 @@ packages/desktop/
 - [x] Performance benchmarks: MiniSearch lazy-build fix reduces markAsRead from ~300ms to ~30ms (10x)
 - [ ] macOS DMG is notarized (requires APPLE_CERTIFICATE secret)
 - [ ] Windows installer is code-signed (requires EV certificate)
+- [ ] Update server runs on a Freed-owned domain (not GitHub Releases)
 
 > **Deferred — Code Signing:**
 > macOS notarization and Windows code signing require secrets to be
@@ -271,6 +273,18 @@ packages/desktop/
 > Windows SmartScreen warnings will appear until an EV certificate is
 > obtained or enough installs build reputation. See `RELEASE-SECRETS.md`
 > for the full setup checklist.
+
+> **Planned — Independent Update Server (Task 5.26):**
+> The auto-updater currently points at GitHub Releases. If the repo is
+> taken down, transferred, or GitHub has a prolonged outage, every
+> installed copy of Freed loses the ability to update. To ensure project
+> continuity, we need a Freed-owned domain (e.g. `updates.freed.wtf`)
+> serving the Tauri update manifest and release artifacts. The CI/CD
+> pipeline would upload binaries to this endpoint in addition to (or
+> instead of) GitHub Releases, and `tauri.conf.json` would point the
+> updater at the Freed-controlled URL. A static file host behind
+> Cloudflare or a simple S3 bucket is sufficient; no custom server logic
+> required.
 
 ### Mobile
 

--- a/packages/desktop/src/lib/automerge-types.ts
+++ b/packages/desktop/src/lib/automerge-types.ts
@@ -58,6 +58,7 @@ export type WorkerRequest =
   | { reqId: number; type: "UPDATE_FEED_ITEM"; globalId: string; updates: Partial<FeedItem> }
   | { reqId: number; type: "ARCHIVE_ALL_READ_UNSAVED"; platform?: string; feedUrl?: string }
   | { reqId: number; type: "PRUNE_ARCHIVED_ITEMS"; maxAgeMs?: number }
+  | { reqId: number; type: "DELETE_ALL_ARCHIVED" }
   | { reqId: number; type: "ADD_RSS_FEED"; feed: RssFeed }
   | { reqId: number; type: "REMOVE_RSS_FEED"; url: string }
   | { reqId: number; type: "UPDATE_RSS_FEED"; url: string; updates: Partial<RssFeed> }

--- a/packages/desktop/src/lib/automerge.ts
+++ b/packages/desktop/src/lib/automerge.ts
@@ -313,6 +313,11 @@ export async function docPruneArchivedItems(maxAgeMs?: number): Promise<void> {
   return request({ reqId, type: "PRUNE_ARCHIVED_ITEMS", maxAgeMs });
 }
 
+export async function docDeleteAllArchived(): Promise<void> {
+  const reqId = nextReqId++;
+  return request({ reqId, type: "DELETE_ALL_ARCHIVED" });
+}
+
 export async function docAddRssFeed(feed: RssFeed): Promise<void> {
   const reqId = nextReqId++;
   return request({ reqId, type: "ADD_RSS_FEED", feed });

--- a/packages/desktop/src/lib/automerge.worker.ts
+++ b/packages/desktop/src/lib/automerge.worker.ts
@@ -31,6 +31,7 @@ import {
   toggleArchived,
   archiveAllReadUnsaved,
   pruneArchivedItems,
+  deleteAllArchivedItems,
   updatePreferences,
   updateLastSync,
   addFriend,
@@ -327,6 +328,14 @@ self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
         await applyChange(
           (doc) => pruneArchivedItems(doc, req.maxAgeMs),
           "Prune archived items",
+        );
+        ack(req.reqId);
+        break;
+
+      case "DELETE_ALL_ARCHIVED":
+        await applyChange(
+          (doc) => deleteAllArchivedItems(doc),
+          "Delete all archived items",
         );
         ack(req.reqId);
         break;

--- a/packages/desktop/src/lib/store.ts
+++ b/packages/desktop/src/lib/store.ts
@@ -27,6 +27,7 @@ import {
   docRemoveFeedItem,
   docToggleArchived,
   docArchiveAllReadUnsaved,
+  docDeleteAllArchived,
   docPruneArchivedItems,
   docUpdatePreferences,
   docDeduplicateFeedItems,
@@ -297,6 +298,10 @@ export const useAppStore = create<AppState>((set, get) => ({
 
   archiveAllReadUnsaved: async (platform, feedUrl) => {
     await docArchiveAllReadUnsaved(platform, feedUrl);
+  },
+
+  deleteAllArchived: async () => {
+    await docDeleteAllArchived();
   },
 
   removeItem: async (id) => {

--- a/packages/pwa/src/lib/automerge-types.ts
+++ b/packages/pwa/src/lib/automerge-types.ts
@@ -50,6 +50,7 @@ export type WorkerRequest =
   | { reqId: number; type: "UPDATE_FEED_ITEM"; globalId: string; updates: Partial<FeedItem> }
   | { reqId: number; type: "ARCHIVE_ALL_READ_UNSAVED"; platform?: string; feedUrl?: string }
   | { reqId: number; type: "PRUNE_ARCHIVED_ITEMS"; maxAgeMs?: number }
+  | { reqId: number; type: "DELETE_ALL_ARCHIVED" }
   | { reqId: number; type: "ADD_RSS_FEED"; feed: RssFeed }
   | { reqId: number; type: "REMOVE_RSS_FEED"; url: string }
   | { reqId: number; type: "UPDATE_RSS_FEED"; url: string; updates: Partial<RssFeed> }

--- a/packages/pwa/src/lib/automerge.ts
+++ b/packages/pwa/src/lib/automerge.ts
@@ -263,6 +263,11 @@ export async function docPruneArchivedItems(maxAgeMs?: number): Promise<void> {
   return request({ reqId, type: "PRUNE_ARCHIVED_ITEMS", maxAgeMs });
 }
 
+export async function docDeleteAllArchived(): Promise<void> {
+  const reqId = nextReqId++;
+  return request({ reqId, type: "DELETE_ALL_ARCHIVED" });
+}
+
 export async function docAddRssFeed(feed: RssFeed): Promise<void> {
   const reqId = nextReqId++;
   return request({ reqId, type: "ADD_RSS_FEED", feed });

--- a/packages/pwa/src/lib/automerge.worker.ts
+++ b/packages/pwa/src/lib/automerge.worker.ts
@@ -27,6 +27,7 @@ import {
   toggleArchived,
   archiveAllReadUnsaved,
   pruneArchivedItems,
+  deleteAllArchivedItems,
   updatePreferences,
   updateLastSync,
   addFriend,
@@ -285,6 +286,11 @@ self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
 
       case "PRUNE_ARCHIVED_ITEMS":
         await applyChange((doc) => pruneArchivedItems(doc, req.maxAgeMs), "Prune archived items");
+        ack(req.reqId);
+        break;
+
+      case "DELETE_ALL_ARCHIVED":
+        await applyChange((doc) => deleteAllArchivedItems(doc), "Delete all archived items");
         ack(req.reqId);
         break;
 

--- a/packages/pwa/src/lib/store.ts
+++ b/packages/pwa/src/lib/store.ts
@@ -26,6 +26,7 @@ import {
   docToggleArchived,
   docToggleLiked,
   docArchiveAllReadUnsaved,
+  docDeleteAllArchived,
   docPruneArchivedItems,
   docUpdatePreferences,
   docAddFriend,
@@ -155,6 +156,10 @@ export const useAppStore = create<AppState>((set, get) => ({
 
   archiveAllReadUnsaved: async (platform, feedUrl) => {
     await docArchiveAllReadUnsaved(platform, feedUrl);
+  },
+
+  deleteAllArchived: async () => {
+    await docDeleteAllArchived();
   },
 
   removeItem: async (id) => {

--- a/packages/shared/src/schema.ts
+++ b/packages/shared/src/schema.ts
@@ -239,6 +239,24 @@ export function pruneArchivedItems(
 }
 
 /**
+ * Immediately delete all archived, non-saved items regardless of age.
+ * Use when the user explicitly requests "delete now" from the archive toolbar.
+ *
+ * @param doc - The Automerge document (mutable within A.change)
+ * @returns Number of items deleted
+ */
+export function deleteAllArchivedItems(doc: FreedDoc): number {
+  let deleted = 0;
+  for (const [id, item] of Object.entries(doc.feedItems)) {
+    if (!item.userState.archived) continue;
+    if (item.userState.saved) continue;
+    delete doc.feedItems[id];
+    deleted++;
+  }
+  return deleted;
+}
+
+/**
  * Toggle bookmark status for a feed item
  *
  * @param doc - The Automerge document (mutable within A.change)

--- a/packages/shared/src/store-types.ts
+++ b/packages/shared/src/store-types.ts
@@ -73,6 +73,8 @@ export interface BaseAppState {
   toggleArchived: (id: string) => Promise<void>;
   /** Archive all read, non-saved items in the current view. */
   archiveAllReadUnsaved: (platform?: string, feedUrl?: string) => Promise<void>;
+  /** Immediately delete ALL archived, non-saved items regardless of age. */
+  deleteAllArchived: () => Promise<void>;
   /** Permanently remove a single feed item from the library. */
   removeItem: (id: string) => Promise<void>;
   /**

--- a/packages/ui/src/components/SettingsDialog.tsx
+++ b/packages/ui/src/components/SettingsDialog.tsx
@@ -548,6 +548,23 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
                   </div>
                 </div>
               )}
+              <div className="flex items-center justify-between gap-4">
+                <div className="min-w-0">
+                  <p className="text-sm text-white">Delete archived content after</p>
+                  <p className="text-xs text-[#52525b] mt-0.5">Saved items are never deleted</p>
+                </div>
+                <select
+                  value={display.archivePruneDays ?? 30}
+                  onChange={(e) => handleDisplayChange({ archivePruneDays: Number(e.target.value) })}
+                  className="shrink-0 bg-[#18181b] border border-[rgba(255,255,255,0.1)] rounded-lg text-sm text-white px-3 py-1.5 focus:outline-none focus:border-[#8b5cf6]/50 cursor-pointer"
+                >
+                  <option value={3}>3 days</option>
+                  <option value={7}>7 days</option>
+                  <option value={30}>30 days</option>
+                  <option value={90}>90 days</option>
+                  <option value={0}>Never</option>
+                </select>
+              </div>
             </div>
           </>
         );

--- a/packages/ui/src/components/feed/FeedView.tsx
+++ b/packages/ui/src/components/feed/FeedView.tsx
@@ -146,6 +146,13 @@ const CompactFeedPanel = memo(function CompactFeedPanel({
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
+/** Human-readable retention message for the archive toolbar. */
+function getRetentionLabel(pruneDays: number): string {
+  if (pruneDays === 0) return "Archived content is kept forever";
+  if (pruneDays === 1) return "Archived content deleted after 1 day";
+  return `Archived content deleted after ${pruneDays} days`;
+}
+
 /** Human-readable label for the scope currently active in the sidebar. */
 function getFilterLabel(filter: FilterOptions, feeds: Record<string, RssFeed>): string {
   if (filter.savedOnly) return "Saved";
@@ -166,6 +173,8 @@ export function FeedView() {
   const toggleSaved = useAppStore((s) => s.toggleSaved);
   const toggleArchived = useAppStore((s) => s.toggleArchived);
   const toggleLiked = useAppStore((s) => s.toggleLiked);
+  const deleteAllArchived = useAppStore((s) => s.deleteAllArchived);
+  const archivePruneDays = useAppStore((s) => s.preferences.display.archivePruneDays);
 
   const handleItemSave = useCallback(
     (item: FeedItem) => toggleSaved(item.globalId),
@@ -189,6 +198,30 @@ export function FeedView() {
       window.open(url, "_blank", "noopener,noreferrer");
     }
   }, [openUrl]);
+
+  // Archive toolbar confirm-to-delete state.
+  // First click arms the button; second click executes. Auto-resets after 3s.
+  const [deleteConfirmArmed, setDeleteConfirmArmed] = useState(false);
+  const deleteConfirmTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleDeleteArchivedClick = useCallback(() => {
+    if (!deleteConfirmArmed) {
+      setDeleteConfirmArmed(true);
+      deleteConfirmTimerRef.current = setTimeout(() => setDeleteConfirmArmed(false), 3000);
+      return;
+    }
+    if (deleteConfirmTimerRef.current) clearTimeout(deleteConfirmTimerRef.current);
+    setDeleteConfirmArmed(false);
+    void deleteAllArchived();
+  }, [deleteConfirmArmed, deleteAllArchived]);
+
+  // Reset confirm state whenever the archived view is left.
+  useEffect(() => {
+    if (!activeFilter.archivedOnly) {
+      if (deleteConfirmTimerRef.current) clearTimeout(deleteConfirmTimerRef.current);
+      setDeleteConfirmArmed(false);
+    }
+  }, [activeFilter.archivedOnly]);
 
   const [addFeedOpen, setAddFeedOpen] = useState(false);
 
@@ -299,25 +332,45 @@ export function FeedView() {
 
   if (showDualColumn) {
     return (
-      <div className="h-full flex overflow-hidden">
-        <CompactFeedPanel
-          items={filteredItems}
-          selectedId={selectedItem.globalId}
-          onItemClick={openItem}
-          width={panelWidth}
-        />
-        {/* Draggable column separator -- zero visible width, padding provides the hit area */}
-        <div
-          className="w-0 px-0.5 shrink-0 cursor-col-resize hover:bg-[#8b5cf6]/20 active:bg-[#8b5cf6]/30 transition-colors -mx-0.5 z-10"
-          onPointerDown={handleDragStart}
-          onPointerMove={handleDragMove}
-          onPointerUp={handleDragEnd}
-          onPointerCancel={handleDragEnd}
-          role="separator"
-          aria-orientation="vertical"
-          aria-label="Resize sidebar"
-        />
-        <ReaderView item={selectedItem} onClose={closeItem} dualColumn />
+      <div className="h-full flex flex-col overflow-hidden">
+        {/* Archive retention toolbar — only shown in the archived view */}
+        {activeFilter.archivedOnly && (
+          <div className="flex-shrink-0 px-4 py-2 border-b border-white/5 flex items-center justify-between gap-4">
+            <p className="text-xs text-[#52525b]">{getRetentionLabel(archivePruneDays ?? 30)}</p>
+            {(archivePruneDays ?? 30) > 0 && (
+              <button
+                onClick={handleDeleteArchivedClick}
+                className={`text-xs px-3 py-1 rounded-lg transition-colors border whitespace-nowrap ${
+                  deleteConfirmArmed
+                    ? "bg-red-500/20 text-red-400 border-red-500/30 hover:bg-red-500/30"
+                    : "bg-white/5 text-[#71717a] border-transparent hover:bg-white/10 hover:text-white"
+                }`}
+              >
+                {deleteConfirmArmed ? "Confirm delete?" : "Delete archived content now"}
+              </button>
+            )}
+          </div>
+        )}
+        <div className="flex-1 flex overflow-hidden">
+          <CompactFeedPanel
+            items={filteredItems}
+            selectedId={selectedItem.globalId}
+            onItemClick={openItem}
+            width={panelWidth}
+          />
+          {/* Draggable column separator -- zero visible width, padding provides the hit area */}
+          <div
+            className="w-0 px-0.5 shrink-0 cursor-col-resize hover:bg-[#8b5cf6]/20 active:bg-[#8b5cf6]/30 transition-colors -mx-0.5 z-10"
+            onPointerDown={handleDragStart}
+            onPointerMove={handleDragMove}
+            onPointerUp={handleDragEnd}
+            onPointerCancel={handleDragEnd}
+            role="separator"
+            aria-orientation="vertical"
+            aria-label="Resize sidebar"
+          />
+          <ReaderView item={selectedItem} onClose={closeItem} dualColumn />
+        </div>
         <AddFeedDialog open={addFeedOpen} onClose={() => setAddFeedOpen(false)} />
       </div>
     );
@@ -325,6 +378,25 @@ export function FeedView() {
 
   return (
     <div className="h-full flex flex-col">
+      {/* Archive retention toolbar — only shown in the archived view */}
+      {activeFilter.archivedOnly && (
+        <div className="flex-shrink-0 px-4 py-2 border-b border-white/5 flex items-center justify-between gap-4">
+          <p className="text-xs text-[#52525b]">{getRetentionLabel(archivePruneDays ?? 30)}</p>
+          {(archivePruneDays ?? 30) > 0 && (
+            <button
+              onClick={handleDeleteArchivedClick}
+              className={`text-xs px-3 py-1 rounded-lg transition-colors border whitespace-nowrap ${
+                deleteConfirmArmed
+                  ? "bg-red-500/20 text-red-400 border-red-500/30 hover:bg-red-500/30"
+                  : "bg-white/5 text-[#71717a] border-transparent hover:bg-white/10 hover:text-white"
+              }`}
+            >
+              {deleteConfirmArmed ? "Confirm delete?" : "Delete archived content now"}
+            </button>
+          )}
+        </div>
+      )}
+
       {/* Search results banner — only shown when actively searching */}
       {isSearching && (
         <div className="flex-shrink-0 px-4 py-2 border-b border-white/5 flex items-center justify-between">


### PR DESCRIPTION
(AI Generated)

## Summary

- Adds a sticky info toolbar to the top of the Archived view showing the current retention period (e.g. "Archived content deleted after 30 days", or "Archived content kept forever" when set to Never)
- Adds a two-click "Delete archived content now" button -- first click arms it (turns red, "Confirm delete?"), second click executes, auto-resets after 3s if not confirmed
- Adds a "Delete archived content after" dropdown to Settings > Reading with options: 3 days, 7 days, 30 days (default), 90 days, Never. Saved items are never deleted regardless of the setting.
- Wires a new `deleteAllArchivedItems()` schema function through the full Automerge worker pipeline on both Desktop and PWA so the action syncs correctly across devices

## Test plan

- [ ] Navigate to Archived view -- toolbar is visible with correct retention text
- [ ] Change retention setting in Settings > Reading -- toolbar text updates to match
- [ ] Set retention to Never -- delete button disappears, toolbar says "kept forever"
- [ ] Click "Delete archived content now" once -- button turns red and says "Confirm delete?"
- [ ] Wait 3s without confirming -- button resets to normal state
- [ ] Click twice quickly -- all archived content is deleted and the list empties
- [ ] Toolbar renders correctly in dual-column layout (reader open alongside list)