### PR TITLE
fix: prevent SectionContent from remounting on every SettingsDialog render

### DIFF
--- a/packages/ui/src/components/SettingsDialog.tsx
+++ b/packages/ui/src/components/SettingsDialog.tsx
@@ -496,9 +496,14 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
     const isVisible = visibleSections.some((s) => s.id === id);
     if (!isVisible) return null;
 
+    // SectionContent is called as a plain function (not as a JSX component)
+    // because it is defined inside SettingsDialog. If rendered as
+    // <SectionContent />, React would see a new component type on every
+    // SettingsDialog re-render and unmount/remount the entire subtree,
+    // destroying local state in nested components like XSettingsSection.
     return (
       <section data-section={id} className="pb-8 min-h-full flex flex-col">
-        <SectionContent id={id} />
+        {SectionContent({ id })}
       </section>
     );
   }


### PR DESCRIPTION
## Summary

- `SectionContent` was defined as a nested function component inside `SettingsDialog`. React creates a new function reference on every parent render, so `<SectionContent />` was seen as a different component type each time -- triggering a full unmount/remount of the entire subtree on any `SettingsDialog` re-render.
- This destroyed local state in `XSettingsSection` (the `showManual`, `ct0`, and `authToken` `useState` values), causing the manual cookie input to vanish mid-interaction. In the E2E suite this showed up as "element was detached from the DOM, retrying" looping for 30s until timeout.
- Fix: call `SectionContent` as a plain function `{SectionContent({ id })}` rather than as a JSX component, eliminating the intermediate component boundary.

## Test plan

- [ ] `npm run test:e2e --workspace=packages/desktop` passes (specifically `x-capture.spec.ts > X connect form accepts cookies and triggers sync`)
- [ ] Open Settings and manually navigate to X / Twitter, click "Manual cookie setup" -- form persists across any store updates