### PR TITLE
feat: group changelog cards by CalVer day

### DIFF
--- a/website/src/app/changelog/page.tsx
+++ b/website/src/app/changelog/page.tsx
@@ -108,16 +108,18 @@ async function getReleases(): Promise<ParsedRelease[]> {
 
   const data = await res.json();
 
-  return (data as Array<{
-    id: number;
-    tag_name: string;
-    name: string;
-    body: string | null;
-    published_at: string;
-    html_url: string;
-    draft: boolean;
-    prerelease: boolean;
-  }>)
+  return (
+    data as Array<{
+      id: number;
+      tag_name: string;
+      name: string;
+      body: string | null;
+      published_at: string;
+      html_url: string;
+      draft: boolean;
+      prerelease: boolean;
+    }>
+  )
     .filter((r) => !r.draft && !r.prerelease)
     .map((r) => {
       const { features, fixes, performance, prNumbers } = parseReleaseBody(
@@ -136,8 +138,51 @@ async function getReleases(): Promise<ParsedRelease[]> {
     });
 }
 
+/**
+ * Derives the CalVer day key from a version string.
+ *
+ * Scheme: YY.M.DDBUILD where patch = (day × 100) + build_number
+ * e.g. "26.3.904" → day=9 → key "26.3.9"
+ *
+ * Using the version (not published_at) avoids UTC midnight edge cases where
+ * two same-day builds can have different UTC date strings.
+ */
+function versionDayKey(version: string): string {
+  const parts = version.split(".");
+  if (parts.length !== 3) return version;
+  const [yy, m, patch] = parts;
+  const day = Math.floor(Number(patch) / 100);
+  return `${yy}.${m}.${day}`;
+}
+
+function groupReleasesByDay(releases: ParsedRelease[]): ParsedRelease[] {
+  const byDay = new Map<string, ParsedRelease[]>();
+
+  for (const r of releases) {
+    const day = versionDayKey(r.version);
+    const group = byDay.get(day) ?? [];
+    group.push(r);
+    byDay.set(day, group);
+  }
+
+  // GitHub returns releases newest-first, so the first entry in each group
+  // is already the most recent build for that day.
+  return Array.from(byDay.values()).map((group) => {
+    const [head, ...rest] = group;
+    return {
+      ...head,
+      features: [...head.features, ...rest.flatMap((r) => r.features)],
+      fixes: [...head.fixes, ...rest.flatMap((r) => r.fixes)],
+      performance: [...head.performance, ...rest.flatMap((r) => r.performance)],
+      prNumbers: [
+        ...new Set([...head.prNumbers, ...rest.flatMap((r) => r.prNumbers)]),
+      ].sort((a, b) => a - b),
+    };
+  });
+}
+
 export default async function ChangelogPage() {
   const releases = await getReleases();
 
-  return <ChangelogContent releases={releases} />;
+  return <ChangelogContent releases={groupReleasesByDay(releases)} />;
 }


### PR DESCRIPTION
(AI Generated)

## Summary

- Adds `groupReleasesByDay()` to the changelog server component that collapses all releases sharing the same CalVer day into a single card
- The most recent build for the day is used as the card header; all features, fixes, and performance items from every build that day are merged into it
- Groups by version-derived day key (`floor(patch / 100)`) rather than `published_at` UTC date, which avoids midnight edge cases where two same-day builds can land on different UTC date strings

## Test plan

- [ ] Visit `/changelog` on the preview and confirm multiple builds from the same day render as one card
- [ ] Confirm PR number links across all merged builds appear deduplicated in the footer
- [ ] Confirm the "Latest" badge and pulsing node appear on the top card