### PR TITLE
fix: hide FB/IG scraper windows instead of moving them off-screen

### DIFF
--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -1288,7 +1288,7 @@ dependencies = [
 
 [[package]]
 name = "freed-desktop"
-version = "26.3.1002"
+version = "26.3.1101"
 dependencies = [
  "base64 0.22.1",
  "criterion",

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -892,12 +892,12 @@ async fn fb_check_auth(app: tauri::AppHandle) -> Result<bool, String> {
 /// the extraction script which reads the DOM and emits 'fb-feed-data'.
 ///
 /// `show_window` controls visibility during scraping:
-/// - `false` (default): window is positioned off-screen at (-20000, -20000) so
-///   WebKit renders at full speed without the window appearing on the user's desktop.
-/// - `true` (debug): window is centered and focused, matching the original behavior.
+/// - `false` (default): window is hidden via `hide()`. The RAF keepalive loop
+///   in webkit-mask.js keeps WKWebView JS timers running at full speed.
+/// - `true` (debug): window is centered and focused, visible on the user's desktop.
 #[tauri::command]
 async fn fb_scrape_feed(app: tauri::AppHandle, capture: tauri::State<'_, CaptureState>, show_window: bool) -> Result<(), String> {
-    use tauri::{LogicalPosition, WebviewWindowBuilder};
+    use tauri::WebviewWindowBuilder;
 
     let fb_feed_url = "https://www.facebook.com/";
 
@@ -908,10 +908,14 @@ async fn fb_scrape_feed(app: tauri::AppHandle, capture: tauri::State<'_, Capture
             if show_window {
                 let _ = w.center();
                 let _ = w.set_focus();
+                let _ = w.show();
             } else {
-                let _ = w.set_position(LogicalPosition::new(-20000.0_f64, -20000.0_f64));
+                // Truly hide the window so it doesn't appear on-screen, in
+                // Mission Control, or on secondary displays. The RAF keepalive
+                // loop in webkit-mask.js prevents WKWebView from throttling JS
+                // timers while the window is hidden.
+                let _ = w.hide();
             }
-            let _ = w.show();
             w
         }
         None => {
@@ -927,7 +931,6 @@ async fn fb_scrape_feed(app: tauri::AppHandle, capture: tauri::State<'_, Capture
             .initialization_script(include_str!("webkit-mask.js"))
             .title("Freed Facebook")
             .inner_size(1280.0, 900.0)
-            .visible(true)
             .on_navigation(move |url| {
                 let host = url.host_str().unwrap_or("");
                 let path = url.path();
@@ -942,9 +945,9 @@ async fn fb_scrape_feed(app: tauri::AppHandle, capture: tauri::State<'_, Capture
             });
 
             if show_window {
-                builder = builder.center();
+                builder = builder.center().visible(true);
             } else {
-                builder = builder.position(-20000.0, -20000.0);
+                builder = builder.visible(false);
             }
 
             builder.build().map_err(|e| e.to_string())?
@@ -977,8 +980,12 @@ async fn fb_scrape_feed(app: tauri::AppHandle, capture: tauri::State<'_, Capture
         rand::thread_rng().gen_range(8usize..=18)
     };
     for i in 0..num_passes {
-        // Keep window visible — WebKit throttles hidden windows, even off-screen ones.
-        let _ = wv.show();
+        // Only show the window if the user has opted into the debug view.
+        // When show_window=false the window stays hidden; the RAF keepalive
+        // loop in webkit-mask.js prevents WKWebView from throttling timers.
+        if show_window {
+            let _ = wv.show();
+        }
 
         wv.eval(FB_EXTRACT_SCRIPT)
             .map_err(|e| format!("Failed to inject extraction script: {}", e))?;
@@ -1198,27 +1205,31 @@ async fn ig_check_auth(app: tauri::AppHandle) -> Result<bool, String> {
 /// the extraction script which reads the DOM and emits 'ig-feed-data'.
 ///
 /// `show_window` controls visibility during scraping:
-/// - `false` (default): window is positioned off-screen at (-20000, -20000) so
-///   WebKit renders at full speed without the window appearing on the user's desktop.
-/// - `true` (debug): window is centered and on-screen, matching the original behavior.
+/// - `false` (default): window is hidden via `hide()`. The RAF keepalive loop
+///   in webkit-mask.js keeps WKWebView JS timers running at full speed.
+/// - `true` (debug): window is centered and on-screen, visible on the user's desktop.
 #[tauri::command]
 async fn ig_scrape_feed(app: tauri::AppHandle, capture: tauri::State<'_, CaptureState>, show_window: bool) -> Result<(), String> {
-    use tauri::{LogicalPosition, WebviewWindowBuilder};
+    use tauri::WebviewWindowBuilder;
 
     let ig_feed_url = "https://www.instagram.com/?variant=following";
 
     let wv = match app.get_webview_window("ig-scraper") {
         Some(w) => {
-            // Window exists (user already logged in). Re-position then show.
+            // Window exists (user already logged in).
             // DO NOT re-navigate — that would fire the ig_show_login on_navigation
-            // callback which hides the window, causing WebKit to throttle rendering.
+            // callback which hides the window.
             if show_window {
                 let _ = w.center();
                 let _ = w.set_focus();
+                let _ = w.show();
             } else {
-                let _ = w.set_position(LogicalPosition::new(-20000.0_f64, -20000.0_f64));
+                // Truly hide the window so it doesn't appear on-screen, in
+                // Mission Control, or on secondary displays. The RAF keepalive
+                // loop in webkit-mask.js prevents WKWebView from throttling JS
+                // timers while the window is hidden.
+                let _ = w.hide();
             }
-            let _ = w.show();
             info!("[IG] reusing existing ig-scraper window (show_window={})", show_window);
             w
         }
@@ -1237,7 +1248,6 @@ async fn ig_scrape_feed(app: tauri::AppHandle, capture: tauri::State<'_, Capture
             .initialization_script(include_str!("webkit-mask.js"))
             .title("Freed Instagram")
             .inner_size(1280.0, 900.0)
-            .visible(true)
             .on_navigation(move |url| {
                 let path = url.path();
                 let host = url.host_str().unwrap_or("");
@@ -1253,9 +1263,9 @@ async fn ig_scrape_feed(app: tauri::AppHandle, capture: tauri::State<'_, Capture
             });
 
             if show_window {
-                builder = builder.center();
+                builder = builder.center().visible(true);
             } else {
-                builder = builder.position(-20000.0, -20000.0);
+                builder = builder.visible(false);
             }
 
             builder.build().map_err(|e| e.to_string())?
@@ -1266,11 +1276,7 @@ async fn ig_scrape_feed(app: tauri::AppHandle, capture: tauri::State<'_, Capture
 
     tokio::time::sleep(Duration::from_millis(gaussian_ms(9000.0, 1200.0))).await;
 
-    // Ensure window is still visible so WebKit doesn't throttle JS execution.
-    // Do NOT set_focus here — we don't want to yank focus from the user's
-    // foreground app on every scrape pass.
-    let _ = wv.show();
-    info!("[IG] window visible, proceeding with extraction");
+    info!("[IG] waiting for feed to render, proceeding with extraction");
 
     // Belt-and-suspenders: click the Following tab if present
     let _ = wv.eval(r#"document.querySelector('a[href="/?variant=following"]')?.click();"#);
@@ -1283,8 +1289,12 @@ async fn ig_scrape_feed(app: tauri::AppHandle, capture: tauri::State<'_, Capture
         rand::thread_rng().gen_range(7usize..=14)
     };
     for i in 0..num_passes {
-        // Keep window visible — WebKit throttles hidden windows
-        let _ = wv.show();
+        // Only show the window if the user has opted into the debug view.
+        // When show_window=false the window stays hidden; the RAF keepalive
+        // loop in webkit-mask.js prevents WKWebView from throttling timers.
+        if show_window {
+            let _ = wv.show();
+        }
 
         wv.eval(IG_EXTRACT_SCRIPT)
             .map_err(|e| format!("Failed to inject extraction script: {}", e))?;

--- a/packages/desktop/src-tauri/src/webkit-mask.js
+++ b/packages/desktop/src-tauri/src/webkit-mask.js
@@ -92,4 +92,17 @@
       });
     }
   } catch (_e) {}
+
+  // ---------------------------------------------------------------------------
+  // 4. requestAnimationFrame keepalive — prevent WKWebView timer throttling
+  // ---------------------------------------------------------------------------
+  // When the scraper window is hidden via NSWindow orderOut (i.e. show_window=false),
+  // WKWebView throttles JS timers and pauses rAF callbacks at the native level.
+  // This loop keeps the rAF queue alive so setTimeout/setInterval/fetch continue
+  // firing at full rate even when the window is not visible on any display.
+  // Combined with the visibilityState override above, the page has no way to
+  // detect that it is running in a hidden window.
+  (function keepAlive() {
+    requestAnimationFrame(keepAlive);
+  })();
 })();

--- a/packages/desktop/src/components/DesktopSyncIndicator.tsx
+++ b/packages/desktop/src/components/DesktopSyncIndicator.tsx
@@ -25,10 +25,14 @@ interface ProviderRowProps {
   icon: React.ReactNode;
   connected: boolean;
   detail: string;
+  /** Optional secondary line, e.g. last sync time or error notice */
+  subDetail?: string;
+  /** When true, subDetail is rendered in amber to signal an error */
+  subDetailError?: boolean;
   syncing: boolean;
 }
 
-function ProviderRow({ name, icon, connected, detail, syncing }: ProviderRowProps) {
+function ProviderRow({ name, icon, connected, detail, subDetail, subDetailError, syncing }: ProviderRowProps) {
   return (
     <div className="flex items-center gap-3 px-4 py-2.5">
       <span className="w-5 h-5 flex items-center justify-center text-[#71717a] flex-shrink-0">
@@ -37,6 +41,11 @@ function ProviderRow({ name, icon, connected, detail, syncing }: ProviderRowProp
       <div className="flex-1 min-w-0">
         <span className="text-xs text-[#a1a1aa] font-medium">{name}</span>
         <p className="text-[10px] text-[#52525b] truncate">{detail}</p>
+        {subDetail && (
+          <p className={`text-[10px] truncate ${subDetailError ? "text-amber-600" : "text-[#3f3f46]"}`}>
+            {subDetail}
+          </p>
+        )}
       </div>
       <span
         className={`w-2 h-2 rounded-full flex-shrink-0 ${
@@ -224,6 +233,16 @@ export function DesktopSyncIndicator() {
                   ? `Connected, ${fbItemCount.toLocaleString()} items`
                   : "Not connected"
               }
+              subDetail={
+                fbAuth.isAuthenticated
+                  ? fbAuth.lastCaptureError
+                    ? "Last sync failed"
+                    : fbAuth.lastCapturedAt
+                      ? `Synced ${formatRelativeTime(fbAuth.lastCapturedAt)}`
+                      : undefined
+                  : undefined
+              }
+              subDetailError={!!fbAuth.lastCaptureError}
               syncing={isSyncing && fbAuth.isAuthenticated}
             />
             <ProviderRow
@@ -235,6 +254,16 @@ export function DesktopSyncIndicator() {
                   ? `Connected, ${igItemCount.toLocaleString()} items`
                   : "Not connected"
               }
+              subDetail={
+                igAuth.isAuthenticated
+                  ? igAuth.lastCaptureError
+                    ? "Last sync failed"
+                    : igAuth.lastCapturedAt
+                      ? `Synced ${formatRelativeTime(igAuth.lastCapturedAt)}`
+                      : undefined
+                  : undefined
+              }
+              subDetailError={!!igAuth.lastCaptureError}
               syncing={isSyncing && igAuth.isAuthenticated}
             />
           </div>

--- a/packages/desktop/src/lib/fb-auth.ts
+++ b/packages/desktop/src/lib/fb-auth.ts
@@ -14,6 +14,10 @@ export interface FbAuthState {
   isAuthenticated: boolean;
   /** Timestamp of last successful auth check */
   lastCheckedAt?: number;
+  /** Epoch ms of the last completed (successful) scrape */
+  lastCapturedAt?: number;
+  /** Error message from the last failed scrape; undefined when last scrape succeeded */
+  lastCaptureError?: string;
 }
 
 const FB_AUTH_KEY = "fb_auth_state";
@@ -91,7 +95,12 @@ export function initFbAuth(): FbAuthState {
   if (!stored) return { isAuthenticated: false };
   try {
     const parsed = JSON.parse(stored) as FbAuthState;
-    return { isAuthenticated: !!parsed.isAuthenticated, lastCheckedAt: parsed.lastCheckedAt };
+    return {
+      isAuthenticated: !!parsed.isAuthenticated,
+      lastCheckedAt: parsed.lastCheckedAt,
+      lastCapturedAt: parsed.lastCapturedAt,
+      lastCaptureError: parsed.lastCaptureError,
+    };
   } catch {
     return { isAuthenticated: false };
   }

--- a/packages/desktop/src/lib/fb-capture.ts
+++ b/packages/desktop/src/lib/fb-capture.ts
@@ -21,6 +21,7 @@ import {
 import { useAppStore } from "./store";
 import { addDebugEvent } from "@freed/ui/lib/debug-store";
 import { getFbScraperDebugWindow } from "./scraper-prefs";
+import { storeFbAuthState } from "./fb-auth";
 
 // =============================================================================
 // Rate Limiting
@@ -200,6 +201,10 @@ export async function captureFbFeed(): Promise<FbSyncResult> {
       const detail = `[FB] sync failed at stage="${result.diag.errorStage}": ${result.diag.errorMessage ?? "(no message)"}`;
       store.setError(result.diag.errorMessage ?? result.diag.errorStage);
       addDebugEvent("error", detail);
+      // Persist error so the sync dropdown can show "Last sync failed"
+      const errState = { ...useAppStore.getState().fbAuth, lastCaptureError: result.diag.errorMessage ?? result.diag.errorStage ?? "Sync failed" };
+      store.setFbAuth(errState);
+      storeFbAuthState(errState);
       return result;
     }
 
@@ -217,6 +222,11 @@ export async function captureFbFeed(): Promise<FbSyncResult> {
     } else {
       addDebugEvent("change", "[FB] sync complete: feed returned 0 posts");
     }
+
+    // Persist success timestamp so the sync dropdown shows "Synced X ago"
+    const successState = { ...useAppStore.getState().fbAuth, lastCapturedAt: Date.now(), lastCaptureError: undefined };
+    store.setFbAuth(successState);
+    storeFbAuthState(successState);
 
     return result;
   } catch (error) {

--- a/packages/desktop/src/lib/instagram-auth.ts
+++ b/packages/desktop/src/lib/instagram-auth.ts
@@ -13,6 +13,10 @@ import { selectPlatformUA, clearPlatformUA } from "./user-agent";
 export interface IgAuthState {
   isAuthenticated: boolean;
   lastCheckedAt?: number;
+  /** Epoch ms of the last completed (successful) scrape */
+  lastCapturedAt?: number;
+  /** Error message from the last failed scrape; undefined when last scrape succeeded */
+  lastCaptureError?: string;
 }
 
 const IG_AUTH_KEY = "ig_auth_state";
@@ -89,7 +93,12 @@ export function initIgAuth(): IgAuthState {
   if (!stored) return { isAuthenticated: false };
   try {
     const parsed = JSON.parse(stored) as IgAuthState;
-    return { isAuthenticated: !!parsed.isAuthenticated, lastCheckedAt: parsed.lastCheckedAt };
+    return {
+      isAuthenticated: !!parsed.isAuthenticated,
+      lastCheckedAt: parsed.lastCheckedAt,
+      lastCapturedAt: parsed.lastCapturedAt,
+      lastCaptureError: parsed.lastCaptureError,
+    };
   } catch {
     return { isAuthenticated: false };
   }

--- a/packages/desktop/src/lib/instagram-capture.ts
+++ b/packages/desktop/src/lib/instagram-capture.ts
@@ -21,6 +21,7 @@ import {
 import { useAppStore } from "./store";
 import { addDebugEvent } from "@freed/ui/lib/debug-store";
 import { getIgScraperDebugWindow } from "./scraper-prefs";
+import { storeIgAuthState } from "./instagram-auth";
 
 // =============================================================================
 // Rate Limiting
@@ -197,6 +198,10 @@ export async function captureIgFeed(): Promise<IgSyncResult> {
       const detail = `[IG] sync failed at stage="${result.diag.errorStage}": ${result.diag.errorMessage ?? "(no message)"}`;
       store.setError(result.diag.errorMessage ?? result.diag.errorStage);
       addDebugEvent("error", detail);
+      // Persist error so the sync dropdown can show "Last sync failed"
+      const errState = { ...useAppStore.getState().igAuth, lastCaptureError: result.diag.errorMessage ?? result.diag.errorStage ?? "Sync failed" };
+      store.setIgAuth(errState);
+      storeIgAuthState(errState);
       return result;
     }
 
@@ -214,6 +219,11 @@ export async function captureIgFeed(): Promise<IgSyncResult> {
     } else {
       addDebugEvent("change", "[IG] sync complete: feed returned 0 posts");
     }
+
+    // Persist success timestamp so the sync dropdown shows "Synced X ago"
+    const successState = { ...useAppStore.getState().igAuth, lastCapturedAt: Date.now(), lastCaptureError: undefined };
+    store.setIgAuth(successState);
+    storeIgAuthState(successState);
 
     return result;
   } catch (error) {


### PR DESCRIPTION
(AI Generated)

## Summary

- **Root cause:** Scraper windows placed at `(-20000, -20000)` are still real macOS windows. Mission Control can reset their position, secondary monitors can make them visible, and unconditional `wv.show()` calls inside every scroll pass repeatedly surfaced them. The "show scraper window" toggle had no effect on this.
- **Fix:** Add an `requestAnimationFrame` keepalive loop to `webkit-mask.js` (prevents WKWebView from throttling JS timers when the window is hidden), then replace the off-screen position hack with actual `hide()`/`visible(false)` calls. All in-loop `wv.show()` calls are now gated on `show_window`.
- **Bonus:** Persist `lastCapturedAt` and `lastCaptureError` per-scrape and surface them in the sync status dropdown as "Synced 2h ago" / "Last sync failed" beneath the item count for Facebook and Instagram.

## Changes

| File | Change |
|---|---|
| `webkit-mask.js` | Add section 4: `requestAnimationFrame` keepalive loop |
| `lib.rs` (FB + IG) | Replace `set_position(-20000)` + `show()` with `hide()`/`visible(false)` |
| `lib.rs` (FB + IG) | Gate all in-loop `wv.show()` calls on `show_window` |
| `fb-auth.ts` / `instagram-auth.ts` | Add `lastCapturedAt` and `lastCaptureError` fields |
| `fb-capture.ts` / `instagram-capture.ts` | Write stats to store + localStorage after each capture |
| `DesktopSyncIndicator.tsx` | Show last-sync time or error badge on FB/IG rows |

## Test plan

- [ ] Sync Facebook with "show scraper window" off - no window appears anywhere on macOS (not in Mission Control, not on secondary displays)
- [ ] Sync completes successfully and item count updates
- [ ] After sync, the FB/IG rows in the sync dropdown show "Synced X ago"
- [ ] Force a sync error (disconnect Wi-Fi mid-sync) - dropdown shows "Last sync failed" in amber
- [ ] Enable "show scraper window" - window appears centered and focused as before