### PR TITLE
feat: surface update download progress inside the Settings card

### DIFF
--- a/packages/desktop/src/App.tsx
+++ b/packages/desktop/src/App.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useCallback, useRef, useState, Profiler, type ProfilerOnRenderCallback } from "react";
 import { AppShell } from "@freed/ui/components/layout";
 import { FeedView } from "@freed/ui/components/feed";
-import { PlatformProvider, type PlatformConfig } from "@freed/ui/context";
+import { PlatformProvider, type PlatformConfig, type UpdateDownloadProgress } from "@freed/ui/context";
 import { UpdateNotification, type UpdateState } from "./components/UpdateNotification";
 import { CloudSyncNudge } from "./components/CloudSyncNudge";
 import { useAppStore } from "./lib/store";
@@ -299,8 +299,13 @@ function App() {
       },
       openUrl: (url: string) => { void shellOpen(url); },
       pickContact: pickContactViaTauri,
+      updateDownloadProgress: ((): UpdateDownloadProgress | null => {
+        if (updateState.phase === "downloading") return { phase: "downloading", percent: updateState.percent };
+        if (updateState.phase === "error") return { phase: "error", message: updateState.message };
+        return null;
+      })(),
     }),
-    [checkForUpdates, applyUpdate, handleFactoryReset, seedSocialConnections],
+    [checkForUpdates, applyUpdate, handleFactoryReset, seedSocialConnections, updateState],
   );
 
   if (error && !isInitialized) {

--- a/packages/ui/src/components/SettingsDialog.tsx
+++ b/packages/ui/src/components/SettingsDialog.tsx
@@ -178,6 +178,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
     factoryReset,
     activeCloudProviderLabel,
     seedSocialConnections,
+    updateDownloadProgress,
   } = usePlatform();
   const preferences = useAppStore((s) => s.preferences);
   const updatePreferences = useAppStore((s) => s.updatePreferences);
@@ -639,7 +640,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
                 <div ref={checkButtonRef} className="flex items-center gap-3">
                   <button
                     onClick={handleCheckForUpdates}
-                    disabled={updateState.status === "checking"}
+                    disabled={updateState.status === "checking" || updateDownloadProgress?.phase === "downloading"}
                     className="text-sm px-3 py-1.5 rounded-lg bg-white/5 hover:bg-white/10 text-[#a1a1aa] hover:text-white transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                   >
                     {updateState.status === "checking" ? (
@@ -658,7 +659,8 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
                       {applyUpdate && (
                         <button
                           onClick={applyUpdate}
-                          className="text-xs font-semibold px-2.5 py-1 rounded-md bg-[#8b5cf6] text-white hover:bg-[#7c3aed] transition-colors"
+                          disabled={updateDownloadProgress?.phase === "downloading"}
+                          className="text-xs font-semibold px-2.5 py-1 rounded-md bg-[#8b5cf6] text-white hover:bg-[#7c3aed] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                         >
                           {headerDragRegion ? "Install & Restart" : "Reload"}
                         </button>
@@ -669,6 +671,22 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
                     <span className="text-xs text-red-400">Check failed</span>
                   )}
                 </div>
+              )}
+              {updateDownloadProgress?.phase === "downloading" && (
+                <div className="space-y-1.5">
+                  <p className="text-xs text-[#a1a1aa]">
+                    Downloading... {Math.round(updateDownloadProgress.percent)}%
+                  </p>
+                  <div className="h-1.5 rounded-full bg-[rgba(255,255,255,0.08)] overflow-hidden">
+                    <div
+                      className="h-full rounded-full bg-gradient-to-r from-[var(--glow-blue)] to-[var(--glow-purple)] transition-[width] duration-300"
+                      style={{ width: `${updateDownloadProgress.percent}%` }}
+                    />
+                  </div>
+                </div>
+              )}
+              {updateDownloadProgress?.phase === "error" && (
+                <p className="text-xs text-red-400">{updateDownloadProgress.message}</p>
               )}
             </div>
           </>

--- a/packages/ui/src/context/PlatformContext.tsx
+++ b/packages/ui/src/context/PlatformContext.tsx
@@ -34,6 +34,15 @@ export const MACOS_TRAFFIC_LIGHT_INSET = 100;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AppStoreHook = <U>(selector: (state: any) => U) => U;
 
+/**
+ * Live state of an in-progress update download, surfaced in the Settings card.
+ * Only the phases that need UI treatment are included here -- idle/available
+ * are represented by `null` (no active download).
+ */
+export type UpdateDownloadProgress =
+  | { phase: "downloading"; percent: number }
+  | { phase: "error"; message: string };
+
 export interface PlatformConfig {
   /** Zustand store hook — both PWA and Desktop stores extend BaseAppState */
   store: AppStoreHook;
@@ -100,6 +109,12 @@ export interface PlatformConfig {
 
   /** Apply a detected update (PWA: reload, Desktop: handled by UpdateNotification). */
   applyUpdate?: () => void;
+
+  /**
+   * Live download progress when an update is being installed.
+   * Null when no download is active. Desktop only.
+   */
+  updateDownloadProgress?: UpdateDownloadProgress | null;
 
   /**
    * Fake-authenticate all social providers (X, Facebook, Instagram) for local

--- a/packages/ui/src/context/index.ts
+++ b/packages/ui/src/context/index.ts
@@ -4,4 +4,5 @@ export {
   useAppStore,
   MACOS_TRAFFIC_LIGHT_INSET,
   type PlatformConfig,
+  type UpdateDownloadProgress,
 } from "./PlatformContext.js";


### PR DESCRIPTION
(AI Generated)

## Summary

- Adds a `UpdateDownloadProgress` type to `PlatformConfig` and exports it from `@freed/ui/context`
- In `App.tsx`, derives the progress from the existing `updateState` and passes it through `PlatformContext` (reactive -- `updateState` is now a dep of the `platform` useMemo)
- In `SettingsDialog`, renders a progress bar + "Downloading X%" text inline in the Updates card when a download is active, and disables the Check / Install & Restart buttons while it's in flight -- matching the visual style of the bottom-right toast

## Test plan

- [ ] Click **Install & Restart** from Settings > Updates while an update is available; verify the progress bar and percentage appear inside the card
- [ ] Confirm the bottom-right toast also still shows during the download (both surfaces update simultaneously)
- [ ] Confirm **Check for updates** and **Install & Restart** buttons are disabled during download
- [ ] Confirm the progress bar disappears after relaunch (app restarts)