### PR TITLE
fix: publish desktop updates to Cloudflare R2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: Release Desktop App
 
+env:
+  UPDATES_BASE_URL: https://updates.freed.wtf
+
 on:
   push:
     tags:
@@ -306,6 +309,90 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release edit "${{ github.ref_name }}" --draft=false --repo "${{ github.repository }}"
+
+      - name: Mirror updater artifacts to Cloudflare R2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_BUCKET_NAME: ${{ secrets.R2_BUCKET_NAME }}
+        shell: bash
+        run: |
+          if [ -z "$R2_ACCOUNT_ID" ] || [ -z "$R2_ACCESS_KEY_ID" ] || [ -z "$R2_SECRET_ACCESS_KEY" ] || [ -z "$R2_BUCKET_NAME" ]; then
+            echo "R2 secrets not configured, skipping public artifact mirror."
+            echo "Add R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, and R2_BUCKET_NAME to enable updates.freed.wtf publishing."
+            exit 0
+          fi
+
+          TAG="${{ github.ref_name }}"
+          PRIVATE_REPO="${{ github.repository }}"
+          TMP_DIR="$(mktemp -d)"
+          ASSET_DIR="$TMP_DIR/assets"
+          ENDPOINT_URL="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
+
+          mkdir -p "$ASSET_DIR"
+
+          gh release download "$TAG" --repo "$PRIVATE_REPO" --dir "$ASSET_DIR"
+
+          node - "$ASSET_DIR/latest.json" "$UPDATES_BASE_URL" <<'NODE'
+          const fs = require("fs");
+
+          const manifestPath = process.argv[2];
+          const baseUrl = process.argv[3].replace(/\/$/, "");
+
+          const rewriteUrls = (value) => {
+            if (typeof value === "string" && /^https?:\/\//.test(value)) {
+              const marker = "/download/";
+              const idx = value.indexOf(marker);
+              if (idx !== -1) {
+                return `${baseUrl}/${value.slice(idx + marker.length)}`;
+              }
+              const filename = value.split("/").pop();
+              if (filename) {
+                return `${baseUrl}/${filename}`;
+              }
+            }
+            if (Array.isArray(value)) {
+              return value.map(rewriteUrls);
+            }
+            if (value && typeof value === "object") {
+              return Object.fromEntries(
+                Object.entries(value).map(([key, child]) => [key, rewriteUrls(child)]),
+              );
+            }
+            return value;
+          };
+
+          const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+          const rewritten = rewriteUrls(manifest);
+          fs.writeFileSync(manifestPath, `${JSON.stringify(rewritten, null, 2)}\n`);
+          NODE
+
+          export AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID"
+          export AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY"
+          export AWS_DEFAULT_REGION="auto"
+
+          aws s3 sync "$ASSET_DIR/" "s3://${R2_BUCKET_NAME}/" \
+            --endpoint-url "$ENDPOINT_URL" \
+            --delete
+
+          aws s3 cp "$ASSET_DIR/latest.json" "s3://${R2_BUCKET_NAME}/latest.json" \
+            --endpoint-url "$ENDPOINT_URL" \
+            --cache-control "public, max-age=60, must-revalidate" \
+            --content-type "application/json"
+
+          for stable_file in \
+            "Freed-macOS-arm64.dmg" \
+            "Freed-macOS-x64.dmg" \
+            "Freed-Windows-x64-setup.exe" \
+            "Freed-Linux-x64.AppImage"; do
+            if [ -f "$ASSET_DIR/$stable_file" ]; then
+              aws s3 cp "$ASSET_DIR/$stable_file" "s3://${R2_BUCKET_NAME}/$stable_file" \
+                --endpoint-url "$ENDPOINT_URL" \
+                --cache-control "public, max-age=300"
+            fi
+          done
 
   # Deploy the PWA to Vercel after the GitHub release is published so the
   # version shown in the app always matches the shipped desktop release.

--- a/docs/PHASE-5-DESKTOP.md
+++ b/docs/PHASE-5-DESKTOP.md
@@ -251,13 +251,13 @@ packages/desktop/
 - [x] QR code pairing works (token-authenticated; local SVG render, no third-party QR API)
 - [x] System tray shows sync status
 - [x] App runs in background after window close
-- [x] Auto-updater checks GitHub Releases and installs updates in-app
+- [x] Auto-updater checks a public release manifest and installs updates in-app
 - [x] CI/CD release pipeline builds for macOS (ARM + Intel), Windows, Linux on tag push
 - [x] App icons generated for all platforms
 - [x] macOS DMG builds (notarization deferred)
 - [x] Windows NSIS + MSI installers build
 - [x] Linux AppImage, .deb, .rpm all build
-- [x] All updater artifacts signed and uploaded to GitHub Releases
+- [x] All updater artifacts signed and mirrored to a public artifact host
 - [x] Desktop E2E test infrastructure bootstrapped (Playwright + VITE_TEST_TAURI=1 mock layer)
 - [x] Performance benchmarks: MiniSearch lazy-build fix reduces markAsRead from ~300ms to ~30ms (10x)
 - [ ] macOS DMG is notarized (requires APPLE_CERTIFICATE secret)
@@ -274,17 +274,12 @@ packages/desktop/
 > obtained or enough installs build reputation. See `RELEASE-SECRETS.md`
 > for the full setup checklist.
 
-> **Planned — Independent Update Server (Task 5.26):**
-> The auto-updater currently points at GitHub Releases. If the repo is
-> taken down, transferred, or GitHub has a prolonged outage, every
-> installed copy of Freed loses the ability to update. To ensure project
-> continuity, we need a Freed-owned domain (e.g. `updates.freed.wtf`)
-> serving the Tauri update manifest and release artifacts. The CI/CD
-> pipeline would upload binaries to this endpoint in addition to (or
-> instead of) GitHub Releases, and `tauri.conf.json` would point the
-> updater at the Freed-controlled URL. A static file host behind
-> Cloudflare or a simple S3 bucket is sufficient; no custom server logic
-> required.
+> **Current — R2-Backed Update Host:**
+> The release workflow now rewrites `latest.json` and uploads signed
+> updater artifacts to a public Cloudflare R2 bucket behind
+> `updates.freed.wtf`. This keeps the source repo private while anonymous
+> clients still fetch updates. DNS, bucket policy, and secrets must exist
+> in production for Task 5.26 to be fully live.
 
 ### Mobile
 

--- a/docs/RELEASE-SECRETS.md
+++ b/docs/RELEASE-SECRETS.md
@@ -13,6 +13,34 @@ certain secrets to be configured in the GitHub repository settings.
 The corresponding **public key** is already embedded in
 `packages/desktop/src-tauri/tauri.conf.json` under `plugins.updater.pubkey`.
 
+## Required (for private source repo + Cloudflare R2 updates)
+
+Freed Desktop now expects signed updater artifacts to be mirrored into a public
+Cloudflare R2 bucket behind `updates.freed.wtf` so in-app update checks keep
+working after the source repo goes private.
+
+| Secret | Description |
+|--------|-------------|
+| `R2_ACCOUNT_ID` | Cloudflare account ID for the R2 API endpoint. |
+| `R2_ACCESS_KEY_ID` | R2 access key with write access to the updates bucket. |
+| `R2_SECRET_ACCESS_KEY` | Secret key paired with `R2_ACCESS_KEY_ID`. |
+| `R2_BUCKET_NAME` | Bucket name that serves the public updater files. |
+
+### Cloudflare R2 setup
+
+1. Create an R2 bucket for updater artifacts
+2. Expose it through a public custom domain at `updates.freed.wtf`
+3. Add the four R2 secrets above to the private source repo's GitHub Actions secrets
+4. Keep `packages/desktop/src-tauri/tauri.conf.json` pointed at:
+
+```text
+https://updates.freed.wtf/latest.json
+```
+
+The release workflow downloads the signed GitHub Release assets from the private
+repo, rewrites `latest.json` to point at `updates.freed.wtf`, then uploads the
+full artifact set to R2.
+
 ## macOS Code Signing + Notarization (deferred)
 
 Without these, macOS builds will run but produce unsigned DMGs. Users must
@@ -60,6 +88,7 @@ git push origin main --follow-tags
 ```
 
 This bumps versions, tags the commit, and pushes. The `v*` tag triggers the
-release workflow which builds all platforms and creates a **draft** GitHub
-Release. Review the draft, then click "Publish" to make it live. The in-app
-updater will pick it up automatically.
+release workflow which builds all platforms, creates a **draft** release in the
+private source repo, and mirrors updater artifacts to Cloudflare R2. Review the
+draft, then click "Publish" if needed. The in-app updater will read
+`latest.json` from `updates.freed.wtf` automatically.

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -57,7 +57,7 @@
     "updater": {
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEZCNjc0QTYyMDg3MzMyRUUKUldUdU1uTUlZa3BuKzAzK3orZzBQUkdnZ0l5NnB5YUZjTWd5L2tiYmxOY2tRRkxJRHZNVThEaG8K",
       "endpoints": [
-        "https://github.com/freed-project/freed/releases/latest/download/latest.json"
+        "https://updates.freed.wtf/latest.json"
       ],
       "windows": {
         "installMode": "passive"

--- a/website/src/app/roadmap/RoadmapContent.tsx
+++ b/website/src/app/roadmap/RoadmapContent.tsx
@@ -490,7 +490,7 @@ const phases: Phase[] = [
     number: 5,
     title: "Desktop & Mobile App",
     description:
-      "Native apps shipping for macOS (ARM + Intel), Windows, and Linux with signed auto-updates. Code signing deferred.",
+      "Native apps shipping for macOS (ARM + Intel), Windows, and Linux with signed auto-updates and a public artifact channel. Code signing deferred.",
     status: "current",
     priority: true,
     planLink:

--- a/website/src/components/NewsletterModal.tsx
+++ b/website/src/components/NewsletterModal.tsx
@@ -17,7 +17,7 @@ import { useNewsletter } from "@/context/NewsletterContext";
 type SubmitState = "idle" | "loading" | "success" | "error";
 
 const RELEASE_BASE =
-  "https://github.com/freed-project/freed/releases/latest/download";
+  "https://updates.freed.wtf";
 
 type DownloadKey = "mac-arm" | "mac-intel" | "windows" | "linux";
 


### PR DESCRIPTION
(AI Generated).

## Summary
- switch Freed Desktop update checks and website download links to `https://updates.freed.wtf`
- mirror signed release artifacts from the private GitHub release into Cloudflare R2 during the publish job
- document the required R2 secrets and sync the desktop roadmap notes

## Testing
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release.yml ok"'`
- `jq empty packages/desktop/src-tauri/tauri.conf.json`

## Follow-up
- create the R2 bucket and attach the `updates.freed.wtf` custom domain
- add `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, and `R2_BUCKET_NAME` to GitHub Actions secrets
- publish Cloudflare release metadata for the website changelog, including production releases and dev prereleases
- switch the website changelog generator from GitHub Releases to the Cloudflare release index when that migration lands
- keep the changelog as a build-time static snapshot so public visitors do not wait on release metadata fetches
- expected release metadata paths: `https://updates.freed.wtf/releases/index.json`, `https://updates.freed.wtf/releases/vX.Y.Z.json`, and `https://updates.freed.wtf/releases/vX.Y.Z-dev.json`
- keep GitHub as a temporary fallback only during the migration