### PR TITLE
fix: finish linkedin desktop integration

### DIFF
--- a/docs/PHASE-12-ADDITIONAL-PLATFORMS.md
+++ b/docs/PHASE-12-ADDITIONAL-PLATFORMS.md
@@ -15,7 +15,7 @@ Expand capture to more platforms. Each platform gets its own capture layer packa
 
 ### `@freed/capture-linkedin`
 
-Professional network posts and articles.
+Professional network posts and articles, now fully surfaced in the desktop app.
 
 ```
 packages/capture-linkedin/
@@ -190,25 +190,29 @@ packages/capture-youtube/
 | 12.1  | `@freed/capture-linkedin` package scaffold | Low        | ✓ Done |
 | 12.2  | LinkedIn DOM selectors                     | High       | ✓ Done |
 | 12.3  | LinkedIn session management                | High       | ✓ Done |
-| 12.4  | `@freed/capture-tiktok` package scaffold   | Low        |        |
-| 12.5  | TikTok capture strategy research           | High       |
-| 12.6  | `@freed/capture-threads` package scaffold  | Low        |
-| 12.7  | Threads capture (similar to Instagram)     | Medium     |
-| 12.8  | `@freed/capture-bluesky` package scaffold  | Low        |
-| 12.9  | Bluesky AT Protocol client                 | Medium     |
-| 12.10 | Bluesky authentication flow                | Medium     |
-| 12.11 | `@freed/capture-reddit` package scaffold   | Low        |
-| 12.12 | Reddit OAuth setup                         | Medium     |
-| 12.13 | Reddit home feed capture                   | Medium     |
-| 12.14 | `@freed/capture-youtube` package scaffold  | Low        |
-| 12.15 | YouTube Data API integration               | Medium     |
-| 12.16 | YouTube subscriptions feed                 | Medium     |
+| 12.4  | LinkedIn desktop source integration        | Medium     | ✓ Done |
+| 12.5  | LinkedIn regression test coverage          | Medium     | ✓ Done |
+| 12.6  | `@freed/capture-tiktok` package scaffold   | Low        |        |
+| 12.7  | TikTok capture strategy research           | High       |
+| 12.8  | `@freed/capture-threads` package scaffold  | Low        |
+| 12.9  | Threads capture (similar to Instagram)     | Medium     |
+| 12.10 | `@freed/capture-bluesky` package scaffold  | Low        |
+| 12.11 | Bluesky AT Protocol client                 | Medium     |
+| 12.12 | Bluesky authentication flow                | Medium     |
+| 12.13 | `@freed/capture-reddit` package scaffold   | Low        |
+| 12.14 | Reddit OAuth setup                         | Medium     |
+| 12.15 | Reddit home feed capture                   | Medium     |
+| 12.16 | `@freed/capture-youtube` package scaffold  | Low        |
+| 12.17 | YouTube Data API integration               | Medium     |
+| 12.18 | YouTube subscriptions feed                 | Medium     |
 
 ---
 
 ## Success Criteria
 
 - [x] LinkedIn feed posts captured to FeedItem
+- [x] LinkedIn is visible in desktop Sources navigation and source status UI
+- [x] LinkedIn desktop flows have regression coverage in Playwright
 - [ ] TikTok feed captured (video metadata at minimum)
 - [ ] Threads posts captured to FeedItem
 - [ ] Bluesky timeline captured via AT Protocol

--- a/packages/desktop/src/__mocks__/@tauri-apps/api/core.ts
+++ b/packages/desktop/src/__mocks__/@tauri-apps/api/core.ts
@@ -81,6 +81,11 @@ const handlers: Record<string, Handler> = {
   ig_check_auth: () => true,
   ig_scrape_feed: () => null,
   ig_disconnect: () => null,
+  li_show_login: () => null,
+  li_hide_login: () => null,
+  li_check_auth: () => true,
+  li_scrape_feed: () => null,
+  li_disconnect: () => null,
 };
 
 // Expose handler map so tests and tauri-init.ts can override defaults.

--- a/packages/desktop/src/components/DesktopSyncIndicator.tsx
+++ b/packages/desktop/src/components/DesktopSyncIndicator.tsx
@@ -1,7 +1,8 @@
 /**
  * DesktopSyncIndicator -- desktop-only header widget
  *
- * Shows a high-level overview of each sync provider (RSS, X, Facebook)
+ * Shows a high-level overview of each sync provider (RSS, X, Facebook,
+ * Instagram, LinkedIn)
  * rather than listing individual feeds.
  */
 
@@ -85,6 +86,12 @@ const IgIcon = () => (
   </svg>
 );
 
+const LiIcon = () => (
+  <svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
+    <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+  </svg>
+);
+
 export function DesktopSyncIndicator() {
   const [panelOpen, setPanelOpen] = useState(false);
   const panelRef = useRef<HTMLDivElement>(null);
@@ -94,6 +101,7 @@ export function DesktopSyncIndicator() {
   const xAuth = useAppStore((s) => s.xAuth);
   const fbAuth = useAppStore((s) => s.fbAuth);
   const igAuth = useAppStore((s) => s.igAuth);
+  const liAuth = useAppStore((s) => s.liAuth);
   const items = useAppStore((s) => s.items);
 
   const feedList = useMemo(() => Object.values(feeds), [feeds]);
@@ -122,6 +130,10 @@ export function DesktopSyncIndicator() {
     () => items.filter((i) => i.platform === "instagram").length,
     [items],
   );
+  const liItemCount = useMemo(
+    () => items.filter((i) => i.platform === "linkedin").length,
+    [items],
+  );
 
   // Close panel on outside click
   useEffect(() => {
@@ -142,7 +154,7 @@ export function DesktopSyncIndicator() {
 
   const statusLabel = isSyncing
     ? "Syncing..."
-    : feedCount > 0 || xAuth.isAuthenticated || fbAuth.isAuthenticated || igAuth.isAuthenticated
+    : feedCount > 0 || xAuth.isAuthenticated || fbAuth.isAuthenticated || igAuth.isAuthenticated || liAuth.isAuthenticated
       ? "Synced"
       : "Ready";
 
@@ -150,7 +162,12 @@ export function DesktopSyncIndicator() {
     ? "bg-[#8b5cf6]/20 text-[#8b5cf6]"
     : "bg-white/5 text-[#71717a]";
 
-  const hasAnySources = feedCount > 0 || xAuth.isAuthenticated || fbAuth.isAuthenticated || igAuth.isAuthenticated;
+  const hasAnySources =
+    feedCount > 0 ||
+    xAuth.isAuthenticated ||
+    fbAuth.isAuthenticated ||
+    igAuth.isAuthenticated ||
+    liAuth.isAuthenticated;
 
   return (
     <div
@@ -265,6 +282,17 @@ export function DesktopSyncIndicator() {
               }
               subDetailError={!!igAuth.lastCaptureError}
               syncing={isSyncing && igAuth.isAuthenticated}
+            />
+            <ProviderRow
+              name="LinkedIn"
+              icon={<LiIcon />}
+              connected={liAuth.isAuthenticated}
+              detail={
+                liAuth.isAuthenticated
+                  ? `Connected, ${liItemCount.toLocaleString()} items`
+                  : "Not connected"
+              }
+              syncing={isSyncing && liAuth.isAuthenticated}
             />
           </div>
 

--- a/packages/desktop/src/components/XSourceIndicator.tsx
+++ b/packages/desktop/src/components/XSourceIndicator.tsx
@@ -1,6 +1,6 @@
 /**
  * SourceIndicator -- subtle purple dot for authenticated social sources in the sidebar.
- * Shows a connected indicator for X, Facebook, and Instagram when authenticated.
+ * Shows a connected indicator for X, Facebook, Instagram, and LinkedIn when authenticated.
  */
 
 import { useAppStore } from "../lib/store";
@@ -9,15 +9,21 @@ export function XSourceIndicator({ sourceId }: { sourceId: string }) {
   const xAuth = useAppStore((s) => s.xAuth.isAuthenticated);
   const fbAuth = useAppStore((s) => s.fbAuth.isAuthenticated);
   const igAuth = useAppStore((s) => s.igAuth.isAuthenticated);
+  const liAuth = useAppStore((s) => s.liAuth.isAuthenticated);
 
   const isConnected =
     (sourceId === "x" && xAuth) ||
     (sourceId === "facebook" && fbAuth) ||
-    (sourceId === "instagram" && igAuth);
+    (sourceId === "instagram" && igAuth) ||
+    (sourceId === "linkedin" && liAuth);
 
   if (!isConnected) return null;
 
   return (
-    <span className="ml-1.5 w-1.5 h-1.5 rounded-full bg-[#8b5cf6]/50 flex-shrink-0" />
+    <span
+      className="ml-1.5 w-1.5 h-1.5 rounded-full bg-[#8b5cf6]/50 flex-shrink-0"
+      data-testid={`source-indicator-${sourceId}`}
+      aria-label={`${sourceId} connected`}
+    />
   );
 }

--- a/packages/desktop/src/lib/import-export.test.ts
+++ b/packages/desktop/src/lib/import-export.test.ts
@@ -144,6 +144,7 @@ describe("folderTagsFromRelativePath", () => {
 describe("importMarkdownFiles", () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    mockAllItemIds.reset();
     Object.keys(docStore).forEach((k) => delete docStore[k]);
 
     // Restore implementations cleared by resetAllMocks()
@@ -157,6 +158,8 @@ describe("importMarkdownFiles", () => {
           }
           onChunk?.(Math.floor(i / CHUNK) + 1, total);
         }
+        const allItemIds = mockAllItemIds.get();
+        allItemIds.splice(0, allItemIds.length, ...Object.keys(docStore));
       },
     );
     mockCacheSet.mockResolvedValue(undefined);

--- a/packages/desktop/src/lib/save-url.test.ts
+++ b/packages/desktop/src/lib/save-url.test.ts
@@ -47,6 +47,7 @@ function makeMetadata(overrides: Record<string, unknown> = {}) {
 
 function makeContent(overrides: Record<string, unknown> = {}) {
   return {
+    html: "<article><p>Hello world.</p></article>",
     text: "Hello world. This is the full article body.",
     author: "Jane Doe",
     wordCount: 8,
@@ -76,7 +77,10 @@ describe("saveUrlInDesktop", () => {
   it("writes HTML to the content cache under the item's globalId", async () => {
     const { saveUrlInDesktop } = await import("./save-url.js");
     const item = await saveUrlInDesktop(SAMPLE_URL);
-    expect(mockCacheSet).toHaveBeenCalledWith(item.globalId, SAMPLE_HTML);
+    expect(mockCacheSet).toHaveBeenCalledWith(
+      item.globalId,
+      "<article><p>Hello world.</p></article>",
+    );
   });
 
   it("persists the item to Automerge with saved=true and platform=saved", async () => {

--- a/packages/desktop/tests/e2e/fixtures/tauri-init.ts
+++ b/packages/desktop/tests/e2e/fixtures/tauri-init.ts
@@ -51,6 +51,11 @@ export function tauriInitScript(): string {
       ig_check_auth: () => true,
       ig_scrape_feed: () => null,
       ig_disconnect: () => null,
+      li_show_login: () => null,
+      li_hide_login: () => null,
+      li_check_auth: () => true,
+      li_scrape_feed: () => null,
+      li_disconnect: () => null,
     };
     window.__TAURI_MOCK_INVOCATIONS__ = [];
     window.__TAURI_MOCK_OPENED_URLS__ = [];

--- a/packages/desktop/tests/e2e/linkedin-capture.spec.ts
+++ b/packages/desktop/tests/e2e/linkedin-capture.spec.ts
@@ -1,0 +1,176 @@
+import { test, expect } from "./fixtures/app";
+
+async function openLinkedInSection(
+  page: import("@playwright/test").Page,
+  t: typeof test,
+) {
+  const settingsBtn = page
+    .locator("button")
+    .filter({ hasText: /settings/i })
+    .first();
+  if (!(await settingsBtn.isVisible())) {
+    t.skip(true, "Settings button not visible");
+    return null;
+  }
+  await settingsBtn.click();
+  await expect(page.getByText("Settings").first()).toBeVisible({
+    timeout: 5_000,
+  });
+
+  const liNavBtn = page.getByRole("button", { name: "LinkedIn" }).nth(1);
+  await expect(liNavBtn).toBeVisible({ timeout: 3_000 });
+  await liNavBtn.click();
+  await page.waitForTimeout(500);
+
+  const liHeading = page.getByRole("heading", { name: "LinkedIn", level: 3 });
+  await expect(liHeading).toBeVisible({ timeout: 3_000 });
+  return liHeading.locator("..");
+}
+
+async function setLiAuthState(
+  page: import("@playwright/test").Page,
+  isAuthenticated: boolean,
+) {
+  await page.evaluate((authed) => {
+    const w = window as Record<string, unknown>;
+    const store = w.__FREED_STORE__ as {
+      setState: (partial: Record<string, unknown>) => void;
+    };
+    store.setState({
+      liAuth: { isAuthenticated: authed, lastCheckedAt: Date.now() },
+    });
+  }, isAuthenticated);
+}
+
+async function injectLinkedInItems(
+  page: import("@playwright/test").Page,
+  count: number,
+) {
+  await page.evaluate(async (itemCount) => {
+    const w = window as Record<string, unknown>;
+    const automerge = w.__FREED_AUTOMERGE__ as {
+      docBatchImportItems: (items: unknown[]) => Promise<unknown>;
+    };
+
+    const now = Date.now();
+    const items = Array.from({ length: itemCount }, (_, i) => ({
+      globalId: `linkedin:urn:li:activity:${9_000 + i}`,
+      platform: "linkedin",
+      contentType: "post",
+      capturedAt: now - i * 60_000,
+      publishedAt: now - i * 60_000,
+      author: {
+        id: `linkedin-author-${i}`,
+        handle: `author-${i}`,
+        displayName: `LinkedIn Author ${i.toLocaleString()}`,
+      },
+      content: {
+        text: `LinkedIn item ${i.toLocaleString()} for sidebar filtering`,
+        mediaUrls: [],
+        mediaTypes: [],
+        linkPreview: {
+          url: `https://www.linkedin.com/feed/update/urn:li:activity:${9_000 + i}/`,
+          title: `LinkedIn post ${i.toLocaleString()}`,
+          description: "LinkedIn E2E fixture",
+        },
+      },
+      userState: { hidden: false, saved: false, archived: false, tags: [] },
+      topics: [],
+    }));
+
+    await automerge.docBatchImportItems(items);
+  }, count);
+
+  await page.waitForFunction(
+    (expectedCount: number) => {
+      const w = window as Record<string, unknown>;
+      const store = w.__FREED_STORE__ as
+        | { getState: () => { itemCountByPlatform: Record<string, number> } }
+        | undefined;
+      return (store?.getState().itemCountByPlatform.linkedin ?? 0) >= expectedCount;
+    },
+    count,
+    { timeout: 30_000 },
+  );
+}
+
+test("LinkedIn settings shows login button when not authenticated", async ({
+  app,
+}) => {
+  await app.goto();
+  await app.waitForReady();
+
+  const liSection = await openLinkedInSection(app.page, test);
+  if (!liSection) return;
+
+  await expect(liSection.getByText("Log in with LinkedIn")).toBeVisible({
+    timeout: 3_000,
+  });
+  await expect(liSection.getByText("Check Connection")).toBeVisible({
+    timeout: 3_000,
+  });
+});
+
+test("LinkedIn appears in sidebar as an active source", async ({ app }) => {
+  await app.goto();
+  await app.waitForReady();
+
+  const sidebar = app.page.locator("nav").first();
+  const liButton = sidebar.getByRole("button", { name: "LinkedIn" });
+  await expect(liButton).toBeVisible({ timeout: 3_000 });
+});
+
+test("LinkedIn source indicator shows connected when authenticated", async ({
+  app,
+}) => {
+  await app.goto();
+  await app.waitForReady();
+
+  await setLiAuthState(app.page, true);
+
+  await expect(
+    app.page.getByTestId("source-indicator-linkedin"),
+  ).toBeVisible({ timeout: 3_000 });
+});
+
+test("LinkedIn source button filters the feed to LinkedIn items", async ({
+  app,
+}) => {
+  await app.goto();
+  await app.waitForReady();
+  await app.injectRssItems(1);
+  await injectLinkedInItems(app.page, 1);
+
+  const sidebar = app.page.locator("nav").first();
+  await sidebar.getByRole("button", { name: "LinkedIn" }).click();
+  await app.page.waitForFunction(() => {
+    const w = window as Record<string, unknown>;
+    const store = w.__FREED_STORE__ as
+      | { getState: () => { activeFilter: { platform?: string } } }
+      | undefined;
+    return store?.getState().activeFilter.platform === "linkedin";
+  }, { timeout: 5_000 });
+
+  await expect(
+    app.page.getByText("LinkedIn item 0 for sidebar filtering"),
+  ).toBeVisible({ timeout: 5_000 });
+  await expect(app.page.getByText("Article 0:", { exact: false })).toBeHidden();
+});
+
+test("LinkedIn appears in the sync status panel when authenticated", async ({
+  app,
+}) => {
+  await app.goto();
+  await app.waitForReady();
+  await setLiAuthState(app.page, true);
+  await injectLinkedInItems(app.page, 1);
+
+  await app.page.getByRole("button", { name: "Sync status" }).click();
+  const syncPanel = app.page.locator("div.absolute.right-0.top-full").last();
+  await expect(syncPanel.getByText("LinkedIn", { exact: true })).toBeVisible({
+    timeout: 3_000,
+  });
+  await expect(syncPanel.getByText("Connected, 1 items")).toBeVisible({
+    timeout: 3_000,
+  });
+});

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -20,7 +20,7 @@ export type Platform =
   | "github" // GitHub (via Atom)
   | "facebook" // Facebook (DOM capture)
   | "instagram" // Instagram (DOM capture)
-  | "linkedin" // LinkedIn (DOM capture, future)
+  | "linkedin" // LinkedIn (DOM capture)
   | "saved"; // Manually saved URLs (bookmarks)
 
 /** User-facing display names for each platform. */

--- a/packages/ui/src/components/feed/FeedItem.tsx
+++ b/packages/ui/src/components/feed/FeedItem.tsx
@@ -5,6 +5,7 @@ import {
   RssIcon,
   FacebookIcon,
   InstagramIcon,
+  LinkedInIcon,
   YoutubeIcon,
   RedditIcon,
   GithubIcon,
@@ -52,6 +53,7 @@ const platformIcons: Record<string, ReactNode> = {
   github: <GithubIcon className={cls} />,
   facebook: <FacebookIcon className={cls} />,
   instagram: <InstagramIcon className={cls} />,
+  linkedin: <LinkedInIcon className={cls} />,
   saved: <BookmarkIcon className={cls} />,
 };
 

--- a/packages/ui/src/components/icons.tsx
+++ b/packages/ui/src/components/icons.tsx
@@ -103,6 +103,15 @@ export function InstagramIcon({ className = "w-4 h-4", style }: IconProps) {
   );
 }
 
+/** LinkedIn boxed "in" mark. */
+export function LinkedInIcon({ className = "w-4 h-4", style }: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" className={className} style={style} aria-hidden="true">
+      <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+    </svg>
+  );
+}
+
 /** YouTube play-button shield. */
 export function YoutubeIcon({ className = "w-4 h-4", style }: IconProps) {
   return (

--- a/packages/ui/src/components/layout/Sidebar.tsx
+++ b/packages/ui/src/components/layout/Sidebar.tsx
@@ -4,7 +4,12 @@ import type { FilterOptions, RssFeed } from "@freed/shared";
 import { useAppStore, usePlatform } from "../../context/PlatformContext.js";
 import { SettingsDialog } from "../SettingsDialog.js";
 import { useSettingsStore } from "../../lib/settings-store.js";
-import { AllIcon, RssIcon, FacebookIcon, InstagramIcon, MapPinIcon, BookmarkIcon, ArchiveIcon, UsersIcon } from "../icons.js";
+import { RssIcon, BookmarkIcon, ArchiveIcon, UsersIcon } from "../icons.js";
+import {
+  COMING_SOON_SOURCE_ITEMS,
+  TOP_SOURCE_ITEMS,
+  type SourceNavigationItem,
+} from "../../lib/source-navigation.js";
 /** Compact number: 1234 → "1.2k", 1_200_000 → "1.2m". Trims trailing ".0". */
 function fmt(n: number): string {
   if (n >= 1_000_000) return `${+(n / 1_000_000).toFixed(1)}m`;
@@ -201,18 +206,6 @@ const MIN_WIDTH = 180;
 const MAX_WIDTH = 480;
 const DEFAULT_WIDTH = 256;
 
-const topSources: { id: string | undefined; label: string; icon: ReactNode }[] = [
-  { id: undefined, label: "All", icon: <AllIcon /> },
-  { id: "rss", label: "RSS", icon: <RssIcon /> },
-  { id: "x", label: "X", icon: <span className="text-sm font-bold leading-none">𝕏</span> },
-  { id: "facebook", label: "Facebook", icon: <FacebookIcon /> },
-  { id: "instagram", label: "Instagram", icon: <InstagramIcon /> },
-];
-
-const comingSoonSources: { id: string; label: string; icon: ReactNode }[] = [
-  { id: "map", label: "Map", icon: <MapPinIcon /> },
-];
-
 export function Sidebar({ open, onClose }: SidebarProps) {
   const { SourceIndicator, headerDragRegion } = usePlatform();
   const activeFilter = useAppStore((s) => s.activeFilter);
@@ -334,7 +327,7 @@ export function Sidebar({ open, onClose }: SidebarProps) {
     onClose();
   }, [onClose, setActiveView, setFilter]);
 
-  const handleSourceClick = (source: (typeof topSources)[0]) => {
+  const handleSourceClick = (source: SourceNavigationItem) => {
     showFeed({ platform: source.id });
   };
 
@@ -342,19 +335,19 @@ export function Sidebar({ open, onClose }: SidebarProps) {
     showFeed({ platform: "rss", feedUrl });
   };
 
-  const isTopSourceActive = (source: (typeof topSources)[0]) => {
+  const isTopSourceActive = (source: SourceNavigationItem) => {
     if (activeFilter.feedUrl) return false;
     if (activeFilter.archivedOnly) return false;
     if (activeFilter.savedOnly) return false;
     return activeFilter.platform === source.id;
   };
 
-  const sourceUnreadCount = (source: (typeof topSources)[0]) =>
+  const sourceUnreadCount = (source: SourceNavigationItem) =>
     source.id === undefined
       ? totalUnreadCount
       : (unreadCountByPlatform[source.id] ?? 0);
 
-  const sourceTotalCount = (source: (typeof topSources)[0]) =>
+  const sourceTotalCount = (source: SourceNavigationItem) =>
     source.id === undefined
       ? totalItemCount
       : (itemCountByPlatform[source.id] ?? 0);
@@ -401,7 +394,7 @@ export function Sidebar({ open, onClose }: SidebarProps) {
           {/* Sources */}
           <SidebarSection title="Sources">
             <ul className="space-y-1">
-              {topSources.map((source) => (
+              {TOP_SOURCE_ITEMS.map((source) => (
                 <li key={source.id ?? "all"}>
                   <button
                     onClick={() => handleSourceClick(source)}
@@ -457,7 +450,7 @@ export function Sidebar({ open, onClose }: SidebarProps) {
                   )}
                 </button>
               </li>
-              {comingSoonSources.map((source) => (
+              {COMING_SOON_SOURCE_ITEMS.map((source) => (
                 <li key={source.id}>
                   <div className="w-full flex items-center gap-3 px-3 py-1.5 rounded-lg text-sm text-[#52525b] cursor-default">
                     <span className="w-5 flex items-center justify-center opacity-50">{source.icon}</span>

--- a/packages/ui/src/lib/source-navigation.tsx
+++ b/packages/ui/src/lib/source-navigation.tsx
@@ -1,0 +1,28 @@
+import type { ReactNode } from "react";
+import {
+  AllIcon,
+  FacebookIcon,
+  InstagramIcon,
+  LinkedInIcon,
+  MapPinIcon,
+  RssIcon,
+} from "../components/icons.js";
+
+export interface SourceNavigationItem {
+  id: string | undefined;
+  label: string;
+  icon: ReactNode;
+}
+
+export const TOP_SOURCE_ITEMS: readonly SourceNavigationItem[] = [
+  { id: undefined, label: "All", icon: <AllIcon /> },
+  { id: "rss", label: "RSS", icon: <RssIcon /> },
+  { id: "x", label: "X", icon: <span className="text-sm font-bold leading-none">X</span> },
+  { id: "facebook", label: "Facebook", icon: <FacebookIcon /> },
+  { id: "instagram", label: "Instagram", icon: <InstagramIcon /> },
+  { id: "linkedin", label: "LinkedIn", icon: <LinkedInIcon /> },
+] as const;
+
+export const COMING_SOON_SOURCE_ITEMS: readonly SourceNavigationItem[] = [
+  { id: "map", label: "Map", icon: <MapPinIcon /> },
+] as const;

--- a/website/src/app/roadmap/RoadmapContent.tsx
+++ b/website/src/app/roadmap/RoadmapContent.tsx
@@ -554,7 +554,7 @@ const phases: Phase[] = [
   {
     number: 12,
     title: "Additional Platforms",
-    description: "LinkedIn, TikTok, Threads, Bluesky, Reddit, YouTube.",
+    description: "LinkedIn complete. TikTok, Threads, Bluesky, Reddit, YouTube next.",
     status: "current",
     planLink:
       "https://github.com/freed-project/freed/blob/main/docs/PHASE-12-ADDITIONAL-PLATFORMS.md",


### PR DESCRIPTION
(AI Generated)

## Summary

- add LinkedIn to the desktop Sources sidebar as a first-class source
- add LinkedIn connection and item-count parity to the desktop sync status UI
- add LinkedIn feed card icon support and source navigation metadata to keep the sidebar list in one place
- add LinkedIn Playwright coverage for sidebar visibility, connected state, filtering, and sync panel presence
- fix the unrelated desktop unit test regressions in `save-url` and markdown import coverage
- update Phase 12 docs and the website roadmap copy to reflect LinkedIn as complete in desktop surfaces

## Local verification

- `npm run build --workspace=packages/desktop` ✅
- `npm run test:unit --workspace=packages/desktop` ✅
- `npm run test:e2e --workspace=packages/desktop -- linkedin-capture.spec.ts legal-gate.spec.ts instagram-capture.spec.ts smoke.spec.ts` ✅
