### PR TITLE
fix: recover desktop startup when consent store fails

### DIFF
--- a/packages/desktop/src-tauri/capabilities/default.json
+++ b/packages/desktop/src-tauri/capabilities/default.json
@@ -6,6 +6,7 @@
   "permissions": [
     "core:default",
     "shell:allow-open",
+    "store:default",
     "updater:default",
     "process:default",
     "fs:allow-appdata-read-recursive",

--- a/packages/desktop/src/App.tsx
+++ b/packages/desktop/src/App.tsx
@@ -80,10 +80,21 @@ function App() {
   const [legalAccepted, setLegalAccepted] = useState(false);
 
   useEffect(() => {
-    void hasAcceptedDesktopBundle().then((accepted) => {
-      setLegalAccepted(accepted);
-      setLegalResolved(true);
-    });
+    void hasAcceptedDesktopBundle()
+      .then((accepted) => {
+        setLegalAccepted(accepted);
+      })
+      .catch((error) => {
+        log.error(
+          `[legal] failed to resolve desktop bundle consent: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+        setLegalAccepted(false);
+      })
+      .finally(() => {
+        setLegalResolved(true);
+      });
   }, []);
 
   useEffect(() => {
@@ -342,7 +353,13 @@ function App() {
   );
 
   if (!legalResolved) {
-    return <div className="h-screen bg-transparent" />;
+    return (
+      <div className="h-screen flex items-center justify-center bg-transparent">
+        <div className="rounded-2xl border border-white/10 bg-[rgba(10,10,10,0.72)] px-5 py-4 text-sm text-white/80 shadow-2xl shadow-black/60 backdrop-blur-xl">
+          Opening Freed Desktop...
+        </div>
+      </div>
+    );
   }
 
   if (!legalAccepted) {

--- a/packages/desktop/src/__mocks__/@tauri-apps/plugin-store/index.ts
+++ b/packages/desktop/src/__mocks__/@tauri-apps/plugin-store/index.ts
@@ -33,6 +33,14 @@ function persistStoreData(path: string, mem: Map<string, unknown>): void {
   }
 }
 
+function shouldThrow(): boolean {
+  try {
+    return window.localStorage.getItem("__TAURI_MOCK_STORE_THROW__") === "1";
+  } catch {
+    return false;
+  }
+}
+
 export class Store {
   private readonly path: string;
   private mem: Map<string, unknown>;
@@ -72,5 +80,8 @@ export async function load(
   path: string,
   _options?: { defaults?: Record<string, unknown>; autoSave?: boolean },
 ): Promise<Store> {
+  if (shouldThrow()) {
+    throw new Error("mock plugin-store failure");
+  }
   return new Store(path);
 }

--- a/packages/desktop/src/lib/legal-consent.ts
+++ b/packages/desktop/src/lib/legal-consent.ts
@@ -12,6 +12,7 @@ import { Store, load } from "@tauri-apps/plugin-store";
 
 const DESKTOP_BUNDLE_KEY = "legal.bundle.desktop";
 const PROVIDER_PREFIX = "legal.provider";
+const FALLBACK_STORAGE_PREFIX = "freed.legal.";
 
 let legalStore: Store | null = null;
 
@@ -22,9 +23,39 @@ async function getStore(): Promise<Store> {
   return legalStore;
 }
 
+function fallbackStorageKey(key: string): string {
+  return `${FALLBACK_STORAGE_PREFIX}${key}`;
+}
+
+function readFallbackRecord(key: string): LegalAcceptanceRecord | null {
+  try {
+    const raw = window.localStorage.getItem(fallbackStorageKey(key));
+    if (!raw) return null;
+    return coerceLegalAcceptanceRecord(JSON.parse(raw));
+  } catch {
+    return null;
+  }
+}
+
+function writeFallbackRecord(key: string, record: LegalAcceptanceRecord): void {
+  try {
+    window.localStorage.setItem(
+      fallbackStorageKey(key),
+      JSON.stringify(record),
+    );
+  } catch {
+    // Ignore localStorage failures, the caller already has the in-memory record.
+  }
+}
+
 async function readRecord(key: string): Promise<LegalAcceptanceRecord | null> {
-  const store = await getStore();
-  return coerceLegalAcceptanceRecord(await store.get<unknown>(key));
+  try {
+    const store = await getStore();
+    return coerceLegalAcceptanceRecord(await store.get<unknown>(key));
+  } catch (error) {
+    console.error("[legal] failed to read consent store, falling back", error);
+    return readFallbackRecord(key);
+  }
 }
 
 async function writeRecord(
@@ -32,9 +63,14 @@ async function writeRecord(
   version: string,
   surface: Parameters<typeof createAcceptanceRecord>[1],
 ): Promise<LegalAcceptanceRecord> {
-  const store = await getStore();
   const record = createAcceptanceRecord(version, surface);
-  await store.set(key, record);
+  try {
+    const store = await getStore();
+    await store.set(key, record);
+  } catch (error) {
+    console.error("[legal] failed to write consent store, falling back", error);
+    writeFallbackRecord(key, record);
+  }
   return record;
 }
 

--- a/packages/desktop/tests/e2e/legal-gate.spec.ts
+++ b/packages/desktop/tests/e2e/legal-gate.spec.ts
@@ -51,6 +51,21 @@ test("accepted legal consent persists across reloads on the same device", async 
   await app.waitForReady();
 });
 
+test("store failures fall back to the legal gate instead of a blank window", async ({
+  app,
+}) => {
+  await app.page.addInitScript(() => {
+    window.localStorage.setItem("__TAURI_MOCK_STORE_THROW__", "1");
+  });
+
+  await app.goto();
+
+  await expect(app.page.getByTestId("legal-gate-accept")).toBeVisible({
+    timeout: 5_000,
+  });
+  await expect(app.page.locator("main")).toBeHidden();
+});
+
 test("X risky connection flows require provider consent", async ({ app }) => {
   await app.goto();
   await app.waitForReady();


### PR DESCRIPTION
(AI Generated)

## Summary
- add the missing Tauri store capability to the main desktop window
- fall back to localStorage if the consent store cannot be read or written
- show the legal gate instead of an empty transparent shell when consent bootstrap fails
- add a regression test for the startup black-window failure mode

## Verification
- /Users/aubreyfalconer/.nvm/versions/node/v22.12.0/bin/npm run test:e2e -- tests/e2e/legal-gate.spec.ts
- /Users/aubreyfalconer/.nvm/versions/node/v22.12.0/bin/npm run build
