### PR TITLE
fix: mark items read when scrolled past

### DIFF
--- a/docs/PHASE-6-PWA.md
+++ b/docs/PHASE-6-PWA.md
@@ -30,7 +30,7 @@ Mobile companion to Freed Desktop for on-the-go reading. Timeline-focused, minim
 
 **Key Features:**
 
-1. **Per-source unread tracking** — Enable for newsletters and priority sources
+1. **Per-source unread tracking** — Enable for newsletters and priority sources, mark items read when they scroll past, and finish the list when you leave after reaching bottom
 2. **Reading enhancements** — Focus mode, font options, theming
 3. **Custom ranking** — User-controlled weights, not engagement
 4. **Source filtering** — View by platform, author, or topic

--- a/packages/desktop/src/lib/automerge-types.ts
+++ b/packages/desktop/src/lib/automerge-types.ts
@@ -46,6 +46,7 @@ export type WorkerRequest =
   | { reqId: number; type: "CLEAR_LOCAL" }
   // Mutations shared with PWA
   | { reqId: number; type: "MARK_AS_READ"; globalId: string }
+  | { reqId: number; type: "MARK_ITEMS_AS_READ"; globalIds: string[] }
   | { reqId: number; type: "MARK_ALL_AS_READ"; platform?: string }
   | { reqId: number; type: "TOGGLE_SAVED"; globalId: string }
   | { reqId: number; type: "TOGGLE_ARCHIVED"; globalId: string }

--- a/packages/desktop/src/lib/automerge.ts
+++ b/packages/desktop/src/lib/automerge.ts
@@ -290,6 +290,12 @@ export async function docMarkAsRead(globalId: string): Promise<void> {
   return request({ reqId, type: "MARK_AS_READ", globalId });
 }
 
+export async function docMarkItemsAsRead(globalIds: string[]): Promise<void> {
+  if (globalIds.length === 0) return;
+  const reqId = nextReqId++;
+  return request({ reqId, type: "MARK_ITEMS_AS_READ", globalIds });
+}
+
 export async function docMarkAllAsRead(platform?: string): Promise<void> {
   const reqId = nextReqId++;
   return request({ reqId, type: "MARK_ALL_AS_READ", platform });

--- a/packages/desktop/src/lib/automerge.worker.ts
+++ b/packages/desktop/src/lib/automerge.worker.ts
@@ -27,6 +27,7 @@ import {
   updateFeedItem,
   removeFeedItem,
   markAsRead,
+  markItemsAsRead,
   toggleSaved,
   toggleArchived,
   archiveAllReadUnsaved,
@@ -279,6 +280,14 @@ self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
       // ─── Item mutations ───────────────────────────────────────────────────
       case "MARK_AS_READ":
         await applyChange((doc) => markAsRead(doc, req.globalId), "Mark as read");
+        ack(req.reqId);
+        break;
+
+      case "MARK_ITEMS_AS_READ":
+        await applyChange(
+          (doc) => markItemsAsRead(doc, req.globalIds),
+          `Mark ${req.globalIds.length.toLocaleString()} items as read`,
+        );
         ack(req.reqId);
         break;
 

--- a/packages/desktop/src/lib/store.ts
+++ b/packages/desktop/src/lib/store.ts
@@ -22,6 +22,7 @@ import {
   docUpdateRssFeed,
   docUpdateFeedItem,
   docMarkAsRead,
+  docMarkItemsAsRead,
   docMarkAllAsRead,
   docToggleSaved,
   docRemoveFeedItem,
@@ -93,6 +94,7 @@ interface AppState {
   addItems: (items: FeedItem[]) => Promise<void>;
   updateItem: (id: string, update: Partial<FeedItem>) => Promise<void>;
   markAsRead: (id: string) => Promise<void>;
+  markItemsAsRead: (ids: string[]) => Promise<void>;
   markAllAsRead: (platform?: string) => Promise<void>;
   toggleSaved: (id: string) => Promise<void>;
   removeItem: (id: string) => Promise<void>;
@@ -293,6 +295,10 @@ export const useAppStore = create<AppState>((set, get) => ({
 
   markAsRead: async (id) => {
     await docMarkAsRead(id);
+  },
+
+  markItemsAsRead: async (ids) => {
+    await docMarkItemsAsRead(ids);
   },
 
   markAllAsRead: async (platform) => {

--- a/packages/pwa/src/lib/automerge-types.ts
+++ b/packages/pwa/src/lib/automerge-types.ts
@@ -38,6 +38,7 @@ export interface DocState {
 export type WorkerRequest =
   | { reqId: number; type: "INIT" }
   | { reqId: number; type: "MARK_AS_READ"; globalId: string }
+  | { reqId: number; type: "MARK_ITEMS_AS_READ"; globalIds: string[] }
   | { reqId: number; type: "MARK_ALL_AS_READ"; platform?: string }
   | { reqId: number; type: "TOGGLE_SAVED"; globalId: string }
   | { reqId: number; type: "TOGGLE_ARCHIVED"; globalId: string }

--- a/packages/pwa/src/lib/automerge.ts
+++ b/packages/pwa/src/lib/automerge.ts
@@ -223,6 +223,12 @@ export async function docMarkAsRead(globalId: string): Promise<void> {
   return request({ reqId, type: "MARK_AS_READ", globalId });
 }
 
+export async function docMarkItemsAsRead(globalIds: string[]): Promise<void> {
+  if (globalIds.length === 0) return;
+  const reqId = nextReqId++;
+  return request({ reqId, type: "MARK_ITEMS_AS_READ", globalIds });
+}
+
 export async function docMarkAllAsRead(platform?: string): Promise<void> {
   const reqId = nextReqId++;
   return request({ reqId, type: "MARK_ALL_AS_READ", platform });

--- a/packages/pwa/src/lib/automerge.worker.ts
+++ b/packages/pwa/src/lib/automerge.worker.ts
@@ -23,6 +23,7 @@ import {
   updateFeedItem,
   removeFeedItem,
   markAsRead,
+  markItemsAsRead,
   toggleSaved,
   toggleArchived,
   archiveAllReadUnsaved,
@@ -203,6 +204,14 @@ self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
 
       case "MARK_AS_READ":
         await applyChange((doc) => markAsRead(doc, req.globalId), "Mark as read");
+        ack(req.reqId);
+        break;
+
+      case "MARK_ITEMS_AS_READ":
+        await applyChange(
+          (doc) => markItemsAsRead(doc, req.globalIds),
+          `Mark ${req.globalIds.length.toLocaleString()} items as read`,
+        );
         ack(req.reqId);
         break;
 

--- a/packages/pwa/src/lib/store.ts
+++ b/packages/pwa/src/lib/store.ts
@@ -20,6 +20,7 @@ import {
   docUpdateRssFeed,
   docUpdateFeedItem,
   docMarkAsRead,
+  docMarkItemsAsRead,
   docMarkAllAsRead,
   docToggleSaved,
   docRemoveFeedItem,
@@ -138,6 +139,10 @@ export const useAppStore = create<AppState>((set, get) => ({
 
   markAsRead: async (id) => {
     await docMarkAsRead(id);
+  },
+
+  markItemsAsRead: async (ids) => {
+    await docMarkItemsAsRead(ids);
   },
 
   markAllAsRead: async (platform) => {

--- a/packages/shared/src/schema.ts
+++ b/packages/shared/src/schema.ts
@@ -166,6 +166,21 @@ export function markAsRead(doc: FreedDoc, globalId: string): void {
 }
 
 /**
+ * Mark multiple feed items as read in a single Automerge change.
+ *
+ * @param doc - The Automerge document (mutable within A.change)
+ * @param globalIds - The item IDs to mark as read
+ */
+export function markItemsAsRead(doc: FreedDoc, globalIds: readonly string[]): void {
+  const now = Date.now();
+  for (const globalId of globalIds) {
+    const item = doc.feedItems[globalId];
+    if (!item || item.userState.readAt) continue;
+    item.userState.readAt = now;
+  }
+}
+
+/**
  * Toggle archived status for a feed item, maintaining the archivedAt timestamp.
  *
  * @param doc - The Automerge document (mutable within A.change)

--- a/packages/shared/src/store-types.ts
+++ b/packages/shared/src/store-types.ts
@@ -68,6 +68,7 @@ export interface BaseAppState {
   addItems: (items: FeedItem[]) => Promise<void>;
   updateItem: (id: string, update: Partial<FeedItem>) => Promise<void>;
   markAsRead: (id: string) => Promise<void>;
+  markItemsAsRead: (ids: string[]) => Promise<void>;
   markAllAsRead: (platform?: string) => Promise<void>;
   toggleSaved: (id: string) => Promise<void>;
   toggleArchived: (id: string) => Promise<void>;

--- a/packages/ui/src/components/feed/FeedItem.test.tsx
+++ b/packages/ui/src/components/feed/FeedItem.test.tsx
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { FeedItem as FeedItemType } from "@freed/shared";
+import { FeedItem } from "./FeedItem";
+
+const NOW = 1_712_147_200_000;
+
+type FeedItemOverrides = Omit<Partial<FeedItemType>, "author" | "content" | "userState"> & {
+  author?: Partial<FeedItemType["author"]>;
+  content?: Partial<FeedItemType["content"]>;
+  userState?: Partial<FeedItemType["userState"]>;
+};
+
+function makeItem(overrides: FeedItemOverrides = {}): FeedItemType {
+  const base: FeedItemType = {
+    globalId: "item-1",
+    platform: "instagram",
+    contentType: "story",
+    capturedAt: NOW,
+    publishedAt: NOW - 60_000,
+    author: {
+      id: "author-1",
+      handle: "story.tester",
+      displayName: "Story Tester",
+    },
+    content: {
+      text: "Story text",
+      mediaUrls: ["https://example.com/story.jpg"],
+      mediaTypes: ["image"],
+    },
+    userState: {
+      hidden: false,
+      saved: false,
+      archived: false,
+      tags: [],
+    },
+    topics: [],
+  };
+
+  const { author, content, userState, ...rest } = overrides;
+
+  return {
+    ...base,
+    ...rest,
+    author: {
+      ...base.author,
+      ...author,
+    },
+    content: {
+      ...base.content,
+      ...content,
+    },
+    userState: {
+      ...base.userState,
+      ...userState,
+    },
+  };
+}
+
+describe("FeedItem read styling", () => {
+  it("applies read styling to story tiles", () => {
+    const html = renderToStaticMarkup(
+      <FeedItem item={makeItem({ userState: { readAt: NOW } })} />,
+    );
+
+    expect(html).toContain("grayscale opacity-60");
+  });
+
+  it("leaves unread story tiles unstyled", () => {
+    const html = renderToStaticMarkup(<FeedItem item={makeItem()} />);
+
+    expect(html).not.toContain("grayscale opacity-60");
+  });
+
+  it("keeps regular feed cards styled as read", () => {
+    const html = renderToStaticMarkup(
+      <FeedItem
+        item={makeItem({
+          globalId: "item-2",
+          platform: "facebook",
+          contentType: "post",
+          content: {
+            text: "Post text",
+            mediaUrls: [],
+            mediaTypes: [],
+          },
+          userState: { readAt: NOW },
+        })}
+      />,
+    );
+
+    expect(html).toContain("grayscale opacity-60");
+  });
+});

--- a/packages/ui/src/components/feed/FeedItem.tsx
+++ b/packages/ui/src/components/feed/FeedItem.tsx
@@ -187,7 +187,9 @@ export const FeedItem = memo(function FeedItem({
 
     return (
       <div
-        className="relative overflow-hidden rounded-2xl cursor-pointer group select-none w-full"
+        className={`relative overflow-hidden rounded-2xl cursor-pointer group select-none w-full transition-opacity ${
+          isRead ? "grayscale opacity-60" : ""
+        }`}
         style={{ height: storyHeight }}
         onClick={onClick}
         onMouseEnter={onMouseEnter}

--- a/packages/ui/src/components/feed/FeedList.tsx
+++ b/packages/ui/src/components/feed/FeedList.tsx
@@ -2,6 +2,13 @@ import { useRef, memo, useCallback, useEffect, useMemo, useState } from "react";
 import { useVirtualizer, useWindowVirtualizer } from "@tanstack/react-virtual";
 import { FeedItem } from "./FeedItem.js";
 import { FeedItemSkeleton } from "./FeedItemSkeleton.js";
+import {
+  collectUnreadIdsFromRows as collectUnreadIdsFromReadRows,
+  getNewlyPassedRowEnd,
+  getRemainingUnreadIds,
+  hasReachedListBottom,
+  type ReadTrackRow,
+} from "./read-on-scroll.js";
 import type { FeedItem as FeedItemType } from "@freed/shared";
 import { useAppStore, usePlatform } from "../../context/PlatformContext.js";
 import { useIsMobile } from "../../hooks/useIsMobile.js";
@@ -251,33 +258,9 @@ export function FeedList({
   const showEngagementCounts = useAppStore(
     (s) => s.preferences.display.showEngagementCounts,
   );
-  const markAsRead = useAppStore((s) => s.markAsRead);
+  const markItemsAsRead = useAppStore((s) => s.markItemsAsRead);
   const markReadOnScroll = useAppStore(
     (s) => s.preferences.display.reading.markReadOnScroll,
-  );
-
-  // Per-item timers for the "mark read after 1 s in viewport" behaviour.
-  // Each entry maps a globalId to its pending setTimeout handle.
-  const READ_DELAY_MS = 1000;
-  const readTimersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(
-    new Map(),
-  );
-
-  // Clear all pending timers when the items array identity changes (filter or
-  // search switch) so timers from a previous view don't fire into a new one.
-  const prevItemsRef = useRef(items);
-  if (prevItemsRef.current !== items) {
-    prevItemsRef.current = items;
-    for (const t of readTimersRef.current.values()) clearTimeout(t);
-    readTimersRef.current.clear();
-  }
-
-  // Cleanup on unmount.
-  useEffect(
-    () => () => {
-      for (const t of readTimersRef.current.values()) clearTimeout(t);
-    },
-    [],
   );
 
   // Track scroll container width so story group rows are sized correctly.
@@ -360,11 +343,57 @@ export function FeedList({
     scrollMargin: windowListRef.current?.offsetTop ?? 0,
   });
 
-  // Mark items as read after they have been continuously visible for
-  // READ_DELAY_MS. On each virtualizer scroll tick we compute the true pixel
-  // viewport, start a timer for every unread item inside it, and cancel timers
-  // for items that have left. The setTimeout fires markAsRead independently of
-  // the render cycle, so it works even after the user stops scrolling.
+  const listKey = useMemo(
+    () => JSON.stringify({ activeFilter, searchQuery: searchQuery.trim() }),
+    [activeFilter, searchQuery],
+  );
+  const maxPassedRowIndexRef = useRef(-1);
+  const listSessionRef = useRef({
+    key: listKey,
+    items,
+    reachedBottom: false,
+  });
+
+  const flushReadIds = useCallback((ids: string[]) => {
+    if (ids.length === 0) return;
+    void markItemsAsRead(ids);
+  }, [markItemsAsRead]);
+
+  const collectUnreadIdsFromRows = useCallback((startIndex: number, endIndex: number) => {
+    return collectUnreadIdsFromReadRows(
+      rows as Array<ReadTrackRow<FeedItemType>>,
+      startIndex,
+      endIndex,
+    );
+  }, [rows]);
+
+  const finalizeListSession = useCallback((session: { items: FeedItemType[]; reachedBottom: boolean }) => {
+    if (!markReadOnScroll || !session.reachedBottom) return;
+    flushReadIds(getRemainingUnreadIds(session.items));
+  }, [flushReadIds, markReadOnScroll]);
+
+  useEffect(() => {
+    const session = listSessionRef.current;
+    if (session.key !== listKey) {
+      finalizeListSession(session);
+      listSessionRef.current = {
+        key: listKey,
+        items,
+        reachedBottom: false,
+      };
+      maxPassedRowIndexRef.current = -1;
+      return;
+    }
+    session.items = items;
+  }, [finalizeListSession, items, listKey]);
+
+  useEffect(() => {
+    return () => {
+      finalizeListSession(listSessionRef.current);
+    };
+  }, [finalizeListSession]);
+
+  // Mark rows as read once the viewport has fully scrolled past them.
   useEffect(() => {
     if (!markReadOnScroll) return;
 
@@ -380,38 +409,37 @@ export function FeedList({
       ? window.innerHeight
       : (parentRef.current?.clientHeight ?? 0);
     const vpBottom = scrollTop + vpHeight;
+    const totalSize = isMobile
+      ? windowVirtualizer.getTotalSize()
+      : elementVirtualizer.getTotalSize();
 
-    const visibleNow = new Set<string>();
-    for (const vi of vItems) {
-      if (vi.start < vpBottom && vi.end > scrollTop) {
-        const row = rows[vi.index];
-        if (!row) continue;
-        const rowItems = row.type === "item" ? [row.item] : row.items;
-        for (const item of rowItems) {
-          if (item.userState.readAt) continue;
-          visibleNow.add(item.globalId);
-          if (!readTimersRef.current.has(item.globalId)) {
-            const id = item.globalId;
-            readTimersRef.current.set(
-              id,
-              setTimeout(() => {
-                markAsRead(id);
-                readTimersRef.current.delete(id);
-              }, READ_DELAY_MS),
-            );
-          }
-        }
-      }
+    const newlyPassedEnd = getNewlyPassedRowEnd(
+      vItems,
+      scrollTop,
+      rows.length,
+      maxPassedRowIndexRef.current,
+    );
+    if (newlyPassedEnd !== null) {
+      const unreadIds = collectUnreadIdsFromRows(
+        maxPassedRowIndexRef.current + 1,
+        newlyPassedEnd,
+      );
+      maxPassedRowIndexRef.current = newlyPassedEnd;
+      flushReadIds(unreadIds);
     }
 
-    // Cancel timers for items that left the viewport before the delay elapsed.
-    for (const [id, timer] of readTimersRef.current) {
-      if (!visibleNow.has(id)) {
-        clearTimeout(timer);
-        readTimersRef.current.delete(id);
-      }
+    if (hasReachedListBottom(rows.length, vpBottom, totalSize)) {
+      listSessionRef.current.reachedBottom = true;
     }
-  });
+  }, [
+    collectUnreadIdsFromRows,
+    elementVirtualizer,
+    flushReadIds,
+    isMobile,
+    markReadOnScroll,
+    rows,
+    windowVirtualizer,
+  ]);
 
   // Show shimmer placeholders while the doc is loading from IndexedDB.
   // Once isLoading flips false, items will populate and we drop into the

--- a/packages/ui/src/components/feed/read-on-scroll.test.ts
+++ b/packages/ui/src/components/feed/read-on-scroll.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import {
+  collectUnreadIdsFromRows,
+  getNewlyPassedRowEnd,
+  getRemainingUnreadIds,
+  hasReachedListBottom,
+  type ReadTrackRow,
+} from "./read-on-scroll";
+
+type TestItem = {
+  globalId: string;
+  userState: {
+    readAt?: number;
+  };
+};
+
+function item(globalId: string, readAt?: number): TestItem {
+  return { globalId, userState: { readAt } };
+}
+
+describe("read-on-scroll helpers", () => {
+  it("collects unread ids only from the newly passed rows", () => {
+    const rows: Array<ReadTrackRow<TestItem>> = [
+      { type: "item", item: item("a") },
+      { type: "stories", items: [item("b"), item("c", 1)] },
+      { type: "item", item: item("d") },
+    ];
+
+    expect(collectUnreadIdsFromRows(rows, 0, 1)).toEqual(["a", "b"]);
+    expect(collectUnreadIdsFromRows(rows, 2, 1)).toEqual([]);
+  });
+
+  it("advances the passed-row boundary when the first visible row moves down", () => {
+    const virtualRows = [
+      { index: 2, end: 660 },
+      { index: 3, end: 880 },
+      { index: 4, end: 1100 },
+    ];
+
+    expect(getNewlyPassedRowEnd(virtualRows, 600, 10, -1)).toBe(1);
+    expect(getNewlyPassedRowEnd(virtualRows, 600, 10, 1)).toBeNull();
+    expect(getNewlyPassedRowEnd([], 9999, 5, 2)).toBe(4);
+  });
+
+  it("returns the remaining unread ids when finishing a list", () => {
+    expect(
+      getRemainingUnreadIds([
+        item("a"),
+        item("b", 1),
+        item("c"),
+      ]),
+    ).toEqual(["a", "c"]);
+  });
+
+  it("treats the list as complete only when the viewport reaches the bottom", () => {
+    expect(hasReachedListBottom(3, 999, 1000)).toBe(true);
+    expect(hasReachedListBottom(3, 900, 1000)).toBe(false);
+    expect(hasReachedListBottom(0, 1000, 1000)).toBe(false);
+  });
+});

--- a/packages/ui/src/components/feed/read-on-scroll.ts
+++ b/packages/ui/src/components/feed/read-on-scroll.ts
@@ -1,0 +1,53 @@
+export type ReadTrackRow<TItem> =
+  | { type: "item"; item: TItem }
+  | { type: "stories"; items: TItem[] };
+
+export interface VirtualRowRange {
+  index: number;
+  end: number;
+}
+
+export function collectUnreadIdsFromRows<TItem extends { globalId: string; userState: { readAt?: number } }>(
+  rows: Array<ReadTrackRow<TItem>>,
+  startIndex: number,
+  endIndex: number,
+): string[] {
+  if (endIndex < startIndex) return [];
+  const unreadIds: string[] = [];
+  for (let rowIndex = startIndex; rowIndex <= endIndex; rowIndex++) {
+    const row = rows[rowIndex];
+    if (!row) continue;
+    const rowItems = row.type === "item" ? [row.item] : row.items;
+    for (const item of rowItems) {
+      if (!item.userState.readAt) unreadIds.push(item.globalId);
+    }
+  }
+  return unreadIds;
+}
+
+export function getNewlyPassedRowEnd(
+  virtualRows: VirtualRowRange[],
+  scrollTop: number,
+  rowCount: number,
+  previousMaxPassedRowIndex: number,
+): number | null {
+  const firstVisible = virtualRows.find((row) => row.end > scrollTop);
+  const newlyPassedEnd = (firstVisible?.index ?? rowCount) - 1;
+  return newlyPassedEnd > previousMaxPassedRowIndex ? newlyPassedEnd : null;
+}
+
+export function getRemainingUnreadIds<TItem extends { globalId: string; userState: { readAt?: number } }>(
+  items: TItem[],
+): string[] {
+  return items
+    .filter((item) => !item.userState.readAt)
+    .map((item) => item.globalId);
+}
+
+export function hasReachedListBottom(
+  rowCount: number,
+  viewportBottom: number,
+  totalSize: number,
+): boolean {
+  return rowCount > 0 && viewportBottom >= totalSize - 1;
+}


### PR DESCRIPTION
(AI Generated)

## What changed

- switched feed read tracking from time-on-screen to scroll-past behavior
- mark the rest of a list as read when the user has reached the bottom and then leaves that list
- added batched mark-as-read plumbing through the shared store and Automerge workers
- extracted the scroll-read decision logic into a small helper with unit coverage
- updated the Phase 6 PWA doc note to match the shipped behavior

## Why

The previous behavior marked items read after they had been visible for a fixed delay, which did not match the intended product behavior. This change makes read state follow actual scrolling progress and treats reaching the end of a list as a caught-up signal once the user leaves that scope.

## Impact

Users now keep items unread until they actually scroll past them. When they finish a list and navigate away, the remaining unread items in that list are cleared in one batch instead of requiring each item to spend time on screen.

## Validation

- `./node_modules/.bin/tsc -p packages/shared/tsconfig.json --noEmit`
- `./node_modules/.bin/tsc -p packages/ui/tsconfig.json --noEmit`
- `./node_modules/.bin/tsc -p packages/pwa/tsconfig.json --noEmit`
- `./node_modules/.bin/tsc -p packages/desktop/tsconfig.json --noEmit`
- `node ./node_modules/vitest/vitest.mjs run packages/ui/src/components/feed/read-on-scroll.test.ts`

## Notes

I tried a desktop Playwright regression for this behavior, but the scroll harness was flaky, so I kept the deterministic helper-level coverage instead of checking in a haunted UI test.
