### PR TITLE
fix: specify scraper restore URL type

### DIFF
--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -66,7 +66,7 @@ async fn restore_scraper_feed(
     platform: &str,
 ) -> Result<(), String> {
     window
-        .navigate(feed_url.parse().map_err(|e| e.to_string())?)
+        .navigate(feed_url.parse::<url::Url>().map_err(|e| e.to_string())?)
         .map_err(|e| e.to_string())?;
     info!("[{}] restoring feed after story viewer", platform);
     tokio::time::sleep(Duration::from_millis(gaussian_ms(6500.0, 900.0))).await;


### PR DESCRIPTION
(AI Generated)

## Summary
- fix the Tauri release build by making the scraper feed restore URL parse type explicit
- keep the background scraper window stability change building on macOS, Linux, and Windows

## Verification
- `cargo fmt --manifest-path packages/desktop/src-tauri/Cargo.toml --all`
- `cargo check --manifest-path packages/desktop/src-tauri/Cargo.toml` *(progresses past the previous `src/lib.rs:69` type inference failure, then stops on the known local `boring-sys2` toolchain issue: `'memory' file not found`)*
- GitHub Actions release logs for run `23868610365` failed on all platforms with the same `error[E0282]` at `src/lib.rs:69`, which this patch addresses
