### PR TITLE
docs: document mozi source planning

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -114,7 +114,7 @@ Freed is a privacy-first, local-first system for capturing social media content 
 ```typescript
 interface FeedItem {
   globalId: string; // "platform:itemId" e.g., "x:1234567890"
-  platform: "x" | "facebook" | "instagram";
+  platform: "x" | "facebook" | "instagram" | "mozi";
   contentType: "post" | "story";
   capturedAt: number; // Unix timestamp
   publishedAt: number;
@@ -151,6 +151,16 @@ interface FeedItem {
     placeId?: string;
     source: "geo_tag" | "check_in" | "sticker" | "text_extraction";
     confidence: number; // 0-1
+  };
+
+  // Planned schema evolution for future-aware sources such as Mozi.
+  // Historical feeds can omit this. Planning-oriented items can attach
+  // a time window so the map and Friend views can reason about upcoming travel,
+  // event attendance, and in-town overlaps without inventing source-specific types.
+  timeRange?: {
+    startsAt: number;
+    endsAt?: number;
+    kind: "event" | "travel" | "overlap";
   };
 
   userState: {
@@ -218,6 +228,16 @@ interface FriendLocation {
 }
 ```
 
+### Planned time-aware location model
+
+The current location model is historical-first, but future planning sources require one more layer: location plus time. The intended direction is a generic optional `timeRange` on `FeedItem`, not a Mozi-only schema branch. That keeps the data model reusable for any future source that exposes travel windows, event attendance, or planned presence in a place.
+
+Important distinction:
+
+- Canonical captured items are stored in the Automerge document
+- Overlap views are derived at read time by comparing Friend-linked items with intersecting place and time windows
+- Derived overlaps should not be persisted as if they were source-authored records
+
 ---
 
 ## Platform Capture Strategies
@@ -270,6 +290,17 @@ interface FriendLocation {
 - Author info in post header
 - Works on both feed and individual posts
 
+### Mozi
+
+**Difficulty:** High (authenticated planning app, future-oriented data)
+
+**Planned approach:**
+
+- Desktop WebView-authenticated capture against `app.mozi.app`
+- Prefer structured payloads or embedded page data over brittle DOM scraping
+- Fall back to DOM extraction for visible trip, event, and overlap details the payload does not provide
+- Normalize planning activity into standard `FeedItem` records with optional location and time window metadata
+
 ---
 
 ## Stories Capture
@@ -301,6 +332,7 @@ Stories are ephemeral (24h lifespan) and appear in carousels.
 1. **Explicit Geo-Tags** (1.0) — Platform-provided structured data
 2. **Location Stickers** (0.9) — Visual elements on stories
 3. **Text Extraction** (0.5-0.8) — Regex patterns
+4. **Planning Windows** (planned) — Source-provided place plus start/end windows from future-aware apps
 
 ### Text Extraction Patterns
 
@@ -343,6 +375,17 @@ async function geocode(placeName: string): Promise<Coordinates | null> {
   return null;
 }
 ```
+
+### Planned map playback and overlap derivation
+
+Map rendering is evolving from "show where someone posted from" to "show where someone was, is, or plans to be." The model is:
+
+- `location` provides the place signal
+- `timeRange` provides the relevant time window when a source has one
+- the map filters markers against a selected timeline position or window
+- overlap badges and Friend-level overlap summaries are computed from captured items at read time
+
+This keeps the storage layer simple while still supporting future-aware social planning.
 
 ---
 

--- a/docs/PHASE-12-ADDITIONAL-PLATFORMS.md
+++ b/docs/PHASE-12-ADDITIONAL-PLATFORMS.md
@@ -37,6 +37,50 @@ packages/capture-linkedin/
 
 ---
 
+### `@freed/capture-mozi`
+
+Private social planning network focused on trips, being-in-town windows, event attendance, and overlap signals.
+
+```
+packages/capture-mozi/
+├── src/
+│   ├── index.ts
+│   ├── extractor.ts      # Structured payload capture from authenticated WebView
+│   ├── selectors.ts      # DOM fallback selectors for visible cards and details
+│   ├── normalize.ts      # Mozi activity -> FeedItem
+│   └── types.ts
+├── package.json
+└── tsconfig.json
+```
+
+**Approach:**
+
+- Desktop-only authenticated source via Tauri WebView against `app.mozi.app`
+- Prefer structured network payloads or embedded page data when available
+- Fall back to DOM extraction only for fields the payload does not expose
+- Normalize plans, trips, event attendance, and other visible planning activity into unified `FeedItem` records
+
+**Why it matters:**
+
+- Mozi is not a generic content feed or an RSS source
+- The value is future-aware social planning data, not passive scrolling
+- Captured items should eventually power Friend identity, time-aware map playback, and derived overlap views
+
+**Desktop integration target:**
+
+- Sources settings section with login, auth check, disconnect, and sync actions
+- Sidebar source presence and source status indicator
+- Sync status panel parity with LinkedIn
+- Feed filtering parity with other desktop-authenticated sources
+
+**Challenges:**
+
+- Authenticated phone-based flow may require more brittle session handling than cookie-only providers
+- The most useful items are future-dated, which means downstream consumers need time-window semantics
+- Some overlap value is derived from multiple captured items and should not be persisted as canonical source content
+
+---
+
 ### `@freed/capture-tiktok`
 
 Short-form video feed.
@@ -192,19 +236,24 @@ packages/capture-youtube/
 | 12.3  | LinkedIn session management                | High       | ✓ Done |
 | 12.4  | LinkedIn desktop source integration        | Medium     | ✓ Done |
 | 12.5  | LinkedIn regression test coverage          | Medium     | ✓ Done |
-| 12.6  | `@freed/capture-tiktok` package scaffold   | Low        |        |
-| 12.7  | TikTok capture strategy research           | High       |
-| 12.8  | `@freed/capture-threads` package scaffold  | Low        |
-| 12.9  | Threads capture (similar to Instagram)     | Medium     |
-| 12.10 | `@freed/capture-bluesky` package scaffold  | Low        |
-| 12.11 | Bluesky AT Protocol client                 | Medium     |
-| 12.12 | Bluesky authentication flow                | Medium     |
-| 12.13 | `@freed/capture-reddit` package scaffold   | Low        |
-| 12.14 | Reddit OAuth setup                         | Medium     |
-| 12.15 | Reddit home feed capture                   | Medium     |
-| 12.16 | `@freed/capture-youtube` package scaffold  | Low        |
-| 12.17 | YouTube Data API integration               | Medium     |
-| 12.18 | YouTube subscriptions feed                 | Medium     |
+| 12.6  | `@freed/capture-mozi` package scaffold     | Low        |        |
+| 12.7  | Mozi auth and session flow research        | High       |        |
+| 12.8  | Mozi extraction strategy: payload first    | High       |        |
+| 12.9  | Mozi desktop source integration            | Medium     |        |
+| 12.10 | Mozi regression test coverage              | Medium     |        |
+| 12.11 | `@freed/capture-tiktok` package scaffold   | Low        |        |
+| 12.12 | TikTok capture strategy research           | High       |        |
+| 12.13 | `@freed/capture-threads` package scaffold  | Low        |        |
+| 12.14 | Threads capture (similar to Instagram)     | Medium     |        |
+| 12.15 | `@freed/capture-bluesky` package scaffold  | Low        |        |
+| 12.16 | Bluesky AT Protocol client                 | Medium     |        |
+| 12.17 | Bluesky authentication flow                | Medium     |        |
+| 12.18 | `@freed/capture-reddit` package scaffold   | Low        |        |
+| 12.19 | Reddit OAuth setup                         | Medium     |        |
+| 12.20 | Reddit home feed capture                   | Medium     |        |
+| 12.21 | `@freed/capture-youtube` package scaffold  | Low        |        |
+| 12.22 | YouTube Data API integration               | Medium     |        |
+| 12.23 | YouTube subscriptions feed                 | Medium     |        |
 
 ---
 
@@ -213,6 +262,9 @@ packages/capture-youtube/
 - [x] LinkedIn feed posts captured to FeedItem
 - [x] LinkedIn is visible in desktop Sources navigation and source status UI
 - [x] LinkedIn desktop flows have regression coverage in Playwright
+- [ ] Mozi activity captured to FeedItem with plans, trips, attendance, or overlap-adjacent events
+- [ ] Mozi is visible in desktop Sources navigation and source status UI
+- [ ] Mozi desktop flows have regression coverage in Playwright
 - [ ] TikTok feed captured (video metadata at minimum)
 - [ ] Threads posts captured to FeedItem
 - [ ] Bluesky timeline captured via AT Protocol
@@ -220,19 +272,21 @@ packages/capture-youtube/
 - [ ] YouTube subscriptions captured (beyond RSS)
 - [ ] Each platform handles its own rate limiting
 - [ ] Selector/API maintenance strategy per platform
+- [ ] Planning-oriented sources can surface future-dated activity without being forced through RSS assumptions
 
 ---
 
 ## Platform Comparison
 
-| Platform | Method      | Auth Required | API Quality | Difficulty |
-| -------- | ----------- | ------------- | ----------- | ---------- |
-| LinkedIn | DOM scrape  | Cookies       | N/A         | Very High  |
-| TikTok   | TBD         | TBD           | Limited     | Very High  |
-| Threads  | DOM scrape  | Cookies       | N/A         | High       |
-| Bluesky  | AT Protocol | App password  | Excellent   | Low        |
-| Reddit   | OAuth API   | OAuth         | Good        | Medium     |
-| YouTube  | Data API    | OAuth         | Good        | Medium     |
+| Platform | Method                | Auth Required | API Quality           | Difficulty | Primary Value |
+| -------- | --------------------- | ------------- | --------------------- | ---------- | ------------- |
+| LinkedIn | DOM scrape            | Cookies       | N/A                   | Very High  | Professional posts |
+| Mozi     | WebView payload + DOM | Phone session | Unknown / likely none | High       | Social planning, trips, overlaps |
+| TikTok   | TBD                   | TBD           | Limited               | Very High  | Short-form video feed |
+| Threads  | DOM scrape            | Cookies       | N/A                   | High       | Social posts |
+| Bluesky  | AT Protocol           | App password  | Excellent             | Low        | Timeline capture |
+| Reddit   | OAuth API             | OAuth         | Good                  | Medium     | Home feed beyond RSS |
+| YouTube  | Data API              | OAuth         | Good                  | Medium     | Subscriptions beyond RSS |
 
 ---
 
@@ -243,3 +297,5 @@ packages/capture-youtube/
 - Consider community contributions for selector maintenance
 - Bluesky is the most promising due to open protocol
 - API-based platforms (Bluesky, Reddit, YouTube) are more stable than DOM scraping
+- Mozi should be treated as a planning source, not squeezed into the RSS mental model
+- Mozi overlap views should be derived from captured items at read time, not stored as source-authored canonical records

--- a/docs/PHASE-8-FRIENDS.md
+++ b/docs/PHASE-8-FRIENDS.md
@@ -13,6 +13,8 @@ Clicking a friend zooms in to show a chronological timeline of everything they'v
 
 The geo map from the original Phase 8 design is retained as sub-phase 8D, now powered by Friend identities so pins cluster by person rather than by platform.
 
+This phase also becomes the home for future-aware social planning. Historical post locations still matter, but the map and friend timeline now need to handle future-dated place windows from sources like Mozi, plus derived overlap views when multiple friends are in the same place at the same time.
+
 ---
 
 ## Architecture
@@ -38,9 +40,10 @@ The geo map from the original Phase 8 design is retained as sub-phase 8D, now po
            │
            ▼
 ┌──────────────────────────────────────────────────────────────────┐
-│                     8D: Location / Map View                       │
-│  FeedItems → location extraction → Nominatim geocoding           │
-│  → cache (IndexedDB) → MapLibre markers (clustered by Friend)    │
+│                 8D: Location / Time-Aware Map View               │
+│  FeedItems + time windows → location extraction → Nominatim      │
+│  geocoding → cache → MapLibre markers → timeline scrubber        │
+│  → derived overlap views                                         │
 └──────────────────────────────────────────────────────────────────┘
 ```
 
@@ -153,12 +156,31 @@ Default nudge intervals by care level:
 ## 8D: Location / Map View
 
 ```
-FeedItems → extractLocationFromItem() → geocode() (Nominatim) → cache → MapLibre markers
+FeedItems → extractLocationFromItem() + optional time window → geocode() (Nominatim) → cache → MapLibre markers → timeline scrubber → derived overlap views
 ```
 
-Sources for location: Instagram geo-tags, Facebook check-ins, X geo-tags (rare), text patterns ("📍 Paris"), **and IG/FB story location stickers** (Phase 7.11).
+Sources for location: Instagram geo-tags, Facebook check-ins, X geo-tags (rare), text patterns ("📍 Paris"), **and IG/FB story location stickers** (Phase 7.11). Planned future sources such as Mozi add another class of signal: place windows that may sit in the future instead of the past.
 
 > **Note:** Stories cross-posted from Instagram to Facebook (or vice versa) currently create two separate FeedItems with different `globalId` prefixes (`ig:` vs `fb:`), which can produce duplicate map pins for the same location event. Phase 7.15 (cross-platform dedup) will address this by matching items with the same Friend identity + similar text + timestamps within a few minutes.
+
+### Planned time model
+
+- Historical posts still render as point-in-time events
+- Future-aware sources can attach a start and optional end time to a location-bearing item
+- The map defaults to `Now` but should be able to scrub backward and forward in time
+- Marker visibility is filtered by the selected time or time window, not just by "latest post wins"
+
+### Planned overlap model
+
+- Overlaps are derived at read time when multiple Friend-linked items share a place cluster and intersecting time windows
+- Overlaps are not persisted as canonical source content
+- Map popups and Friend detail surfaces can render overlaps as computed views on top of captured items
+
+### Planned source expansion
+
+- Mozi is the first explicit planning-oriented source for this phase
+- Mozi-backed friend/location events should participate in identity matching the same way Instagram, Facebook, and X items do
+- The map and timeline should not special-case Mozi in the long run. They should consume generic location-plus-time signals from any source
 
 ### Files
 
@@ -196,6 +218,10 @@ Sources for location: Instagram geo-tags, Facebook check-ins, X geo-tags (rare),
 | 8.18 | Wire Friends to live sidebar navigation | Low | Done |
 | 8.19 | Google Contacts import, matching, and Friend creation flow | Medium | Done |
 | 8.20 | Wire Map to live sidebar navigation | Low | Not Started |
+| 8.21 | Add future-aware map filtering for location-bearing items | Medium | Not Started |
+| 8.22 | Add map timeline scrubber for past and future playback | Medium | Not Started |
+| 8.23 | Render derived overlap states in map and Friend detail surfaces | Medium | Not Started |
+| 8.24 | Support Mozi-backed friend/location events in identity and map flows | Medium | Not Started |
 
 ---
 
@@ -219,6 +245,10 @@ Sources for location: Instagram geo-tags, Facebook check-ins, X geo-tags (rare),
 - [ ] `maplibre-gl` installed and map view live
 - [ ] macOS native contact picker (CNContactStore)
 - [ ] Map promoted to live sidebar navigation
+- [ ] Future-aware map filtering supports past, current, and future location windows
+- [ ] Timeline scrubbing works across historical posts and future planning items
+- [ ] Overlaps render as derived read-time views, not persisted source records
+- [ ] Mozi-backed friend/location events appear in Friend identity and map flows
 
 ---
 

--- a/website/src/app/roadmap/RoadmapContent.tsx
+++ b/website/src/app/roadmap/RoadmapContent.tsx
@@ -519,7 +519,7 @@ const phases: Phase[] = [
     number: 8,
     title: "Friends + Social Graph",
     description:
-      "A friend CRM with a force-directed social graph. Unify profiles across platforms into one identity per person, track relationship health, and get nudged when you've drifted from people you care about.",
+      "A friend CRM with a force-directed social graph. Unify profiles across platforms into one identity per person, track relationship health, and grow the map into a time-aware view of where friends were, are, and plan to be.",
     status: "current",
     planLink:
       "https://github.com/freed-project/freed/blob/main/docs/PHASE-8-FRIENDS.md",
@@ -554,7 +554,8 @@ const phases: Phase[] = [
   {
     number: 12,
     title: "Additional Platforms",
-    description: "LinkedIn complete. TikTok, Threads, Bluesky, Reddit, YouTube next.",
+    description:
+      "LinkedIn is in. Next up: Mozi for social planning, then TikTok, Threads, Bluesky, Reddit, and YouTube.",
     status: "current",
     planLink:
       "https://github.com/freed-project/freed/blob/main/docs/PHASE-12-ADDITIONAL-PLATFORMS.md",


### PR DESCRIPTION
(AI Generated).

## Summary
- add Mozi as a planned desktop-authenticated source in Phase 12 docs
- expand Phase 8 docs to cover future-aware map playback and derived overlap views
- document the planned generic time-aware model in architecture docs and align roadmap copy

## Testing
- not run, docs-only changes