### PR TITLE
feat: finish Google Contacts settings and sync

### DIFF
--- a/docs/PHASE-8-FRIENDS.md
+++ b/docs/PHASE-8-FRIENDS.md
@@ -230,7 +230,7 @@ Map popovers now use a wider card layout and deliberately omit the old MapLibre 
 | 8.16 | Install `maplibre-gl` and wire Map nav entry | Low | Done |
 | 8.17 | Implement macOS `CNContactStore` Tauri command (objc2-contacts) | High | Not Started |
 | 8.18 | Wire Friends to live sidebar navigation | Low | Done |
-| 8.19 | Google Contacts import, matching, and Friend creation flow | Medium | Done |
+| 8.19 | Google Contacts source, sync lifecycle, matching, and Friend creation flow | Medium | Done |
 | 8.20 | Wire Map to live sidebar navigation | Low | Done |
 | 8.21 | Add future-aware map filtering for location-bearing items | Medium | Not Started |
 | 8.22 | Add map timeline scrubber for past and future playback | Medium | Not Started |
@@ -254,6 +254,8 @@ Map popovers now use a wider card layout and deliberately omit the old MapLibre 
 - [x] Friends shown in Sidebar as a live navigation destination
 - [x] Google Contacts import suggests matches and can create Friends
 - [x] Desktop snapshot restore preserves cached Google contacts and pending match suggestions
+- [x] Google Contacts appears as a first-class source in Settings and Friends
+- [x] Google Contacts auto-links high-confidence matches and can create Friends from high-confidence unlinked authors
 - [x] Location extraction from geo-tags and text patterns
 - [x] Nominatim geocoding with rate limiter
 - [x] Geocoding cache with TTL

--- a/packages/desktop/src/App.tsx
+++ b/packages/desktop/src/App.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useCallback, useRef, useState, Profiler, type Profi
 import { AppShell } from "@freed/ui/components/layout";
 import { FeedView } from "@freed/ui/components/feed";
 import { LegalGate } from "@freed/ui/components/legal/LegalGate";
+import { GoogleContactsSection } from "@freed/ui/components/settings/GoogleContactsSection";
 import { ToastContainer } from "@freed/ui/components/Toast";
 import { PlatformProvider, type PlatformConfig, type UpdateDownloadProgress } from "@freed/ui/context";
 import { useDebugStore } from "@freed/ui/lib/debug-store";
@@ -284,6 +285,12 @@ function App() {
     await startCloudSync(provider, token);
   }, []);
 
+  const connectGoogleContacts = useCallback(async () => {
+    const token = await initiateDesktopOAuth("gdrive");
+    storeCloudToken("gdrive", token);
+    await startCloudSync("gdrive", token);
+  }, []);
+
   // Fake-authenticate all social providers for local testing. Writes stub
   // credentials to localStorage (matching the real auth persistence format)
   // and updates Zustand state so the sidebar dots light up without a real login.
@@ -342,6 +349,7 @@ function App() {
       FacebookSettingsContent: FacebookSettingsSection,
       InstagramSettingsContent: InstagramSettingsSection,
       LinkedInSettingsContent: LinkedInSettingsSection,
+      GoogleContactsSettingsContent: GoogleContactsSection,
       checkForUpdates: IS_LOCAL_PREVIEW ? undefined : checkForUpdates,
       applyUpdate: IS_LOCAL_PREVIEW ? undefined : applyUpdate,
       factoryReset: handleFactoryReset,
@@ -429,6 +437,7 @@ function App() {
       pickContact: pickContactViaTauri,
       googleContacts: {
         getToken: () => localStorage.getItem("freed_cloud_token_gdrive"),
+        connect: connectGoogleContacts,
       },
       updateDownloadProgress: ((): UpdateDownloadProgress | null => {
         if (updateState.phase === "downloading") return { phase: "downloading", percent: updateState.percent };
@@ -436,7 +445,7 @@ function App() {
         return null;
       })(),
     }),
-     [checkForUpdates, applyUpdate, handleFactoryReset, reconnectCloudProvider, retryCloudProvider, seedSocialConnections, updateState],
+     [checkForUpdates, applyUpdate, connectGoogleContacts, handleFactoryReset, reconnectCloudProvider, retryCloudProvider, seedSocialConnections, updateState],
   );
 
   if (!legalResolved) {

--- a/packages/desktop/src/lib/google-contacts.test.ts
+++ b/packages/desktop/src/lib/google-contacts.test.ts
@@ -1,0 +1,217 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  fetchGoogleContacts,
+  mergeContactChanges,
+} from "@freed/shared/google-contacts";
+import {
+  buildFriendSourcesFromAuthorIds,
+  createDeviceContactFromGoogleContact,
+  mergeFriendSources,
+  shouldAutoProcessMatch,
+} from "@freed/shared/google-contacts-automation";
+import type { ContactMatch, FeedItem, Friend } from "@freed/shared";
+
+describe("google contacts helpers", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("fetchGoogleContacts paginates and separates deleted contacts", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({
+        connections: [
+          {
+            resourceName: "people/1",
+            names: [{ displayName: "Jane Doe", givenName: "Jane", familyName: "Doe" }],
+            emailAddresses: [{ value: "jane@example.com" }],
+          },
+        ],
+        nextPageToken: "page-2",
+      })),
+    ).mockResolvedValueOnce(
+      new Response(JSON.stringify({
+        connections: [
+          {
+            resourceName: "people/2",
+            metadata: { deleted: true },
+          },
+        ],
+        nextSyncToken: "sync-2",
+      })),
+    );
+
+    const result = await fetchGoogleContacts("token-123");
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(result.nextSyncToken).toBe("sync-2");
+    expect(result.deleted).toEqual(["people/2"]);
+    expect(result.contacts[0].name.displayName).toBe("Jane Doe");
+  });
+
+  it("fetchGoogleContacts retries with a full sync when the token expires", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response("gone", { status: 410 }))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({
+          connections: [{ resourceName: "people/3", names: [{ displayName: "Retry Person" }] }],
+          nextSyncToken: "fresh-sync",
+        })),
+      );
+
+    const result = await fetchGoogleContacts("token-123", "expired-sync-token");
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(result.contacts).toHaveLength(1);
+    expect(result.nextSyncToken).toBe("fresh-sync");
+  });
+
+  it("mergeContactChanges replaces updated contacts and removes deleted ones", () => {
+    const merged = mergeContactChanges(
+      [
+        {
+          resourceName: "people/1",
+          name: { displayName: "Old Name" },
+          emails: [],
+          phones: [],
+          photos: [],
+          organizations: [],
+        },
+        {
+          resourceName: "people/2",
+          name: { displayName: "Delete Me" },
+          emails: [],
+          phones: [],
+          photos: [],
+          organizations: [],
+        },
+      ],
+      [
+        {
+          resourceName: "people/1",
+          name: { displayName: "New Name" },
+          emails: [],
+          phones: [],
+          photos: [],
+          organizations: [],
+        },
+      ],
+      ["people/2"],
+    );
+
+    expect(merged).toEqual([
+      expect.objectContaining({
+        resourceName: "people/1",
+        name: expect.objectContaining({ displayName: "New Name" }),
+      }),
+    ]);
+  });
+
+  it("dedupes sources when merging auto-linked friend identities", () => {
+    const existing = [{ platform: "rss", authorId: "author-1", displayName: "Jane" }] as Friend["sources"];
+    const additions = [
+      { platform: "rss", authorId: "author-1", displayName: "Jane" },
+      { platform: "x", authorId: "author-2", displayName: "Jane D" },
+    ] as Friend["sources"];
+
+    expect(mergeFriendSources(existing, additions)).toEqual([
+      { platform: "rss", authorId: "author-1", displayName: "Jane" },
+      { platform: "x", authorId: "author-2", displayName: "Jane D" },
+    ]);
+  });
+
+  it("builds friend sources from unique author ids and preserves platform metadata", () => {
+    const items: FeedItem[] = [
+      {
+        globalId: "x:1",
+        platform: "x",
+        contentType: "post",
+        capturedAt: Date.now(),
+        publishedAt: Date.now(),
+        author: { id: "author-1", handle: "jane", displayName: "Jane Doe", avatarUrl: "https://example.com/avatar.jpg" },
+        content: { text: "hello", mediaUrls: [], mediaTypes: [] },
+        userState: { hidden: false, saved: false, archived: false, tags: [] },
+        topics: [],
+      },
+      {
+        globalId: "x:2",
+        platform: "x",
+        contentType: "post",
+        capturedAt: Date.now(),
+        publishedAt: Date.now(),
+        author: { id: "author-1", handle: "jane", displayName: "Jane Doe", avatarUrl: "https://example.com/avatar.jpg" },
+        content: { text: "hello again", mediaUrls: [], mediaTypes: [] },
+        userState: { hidden: false, saved: false, archived: false, tags: [] },
+        topics: [],
+      },
+    ];
+
+    expect(buildFriendSourcesFromAuthorIds(items, ["author-1", "author-1"])).toEqual([
+      {
+        platform: "x",
+        authorId: "author-1",
+        handle: "jane",
+        displayName: "Jane Doe",
+        avatarUrl: "https://example.com/avatar.jpg",
+      },
+    ]);
+  });
+
+  it("marks only high-confidence friend or author matches for automatic processing", () => {
+    const baseMatch = {
+      contact: {
+        resourceName: "people/9",
+        name: { displayName: "Jane Doe" },
+        emails: [],
+        phones: [],
+        photos: [],
+        organizations: [],
+      },
+    };
+
+    const friendMatch: ContactMatch = {
+      ...baseMatch,
+      friend: { id: "friend-1" } as Friend,
+      authorIds: [],
+      confidence: "high",
+    };
+    const createMatch: ContactMatch = {
+      ...baseMatch,
+      friend: null,
+      authorIds: ["author-1"],
+      confidence: "high",
+    };
+    const manualMatch: ContactMatch = {
+      ...baseMatch,
+      friend: null,
+      authorIds: ["author-1"],
+      confidence: "medium",
+    };
+
+    expect(shouldAutoProcessMatch(friendMatch)).toBe(true);
+    expect(shouldAutoProcessMatch(createMatch)).toBe(true);
+    expect(shouldAutoProcessMatch(manualMatch)).toBe(false);
+  });
+
+  it("creates a Google device contact using resourceName as nativeId", () => {
+    expect(
+      createDeviceContactFromGoogleContact(
+        {
+          resourceName: "people/10",
+          name: { displayName: "Jane Doe" },
+          emails: [{ value: "jane@example.com" }],
+          phones: [{ value: "+1 555 0100" }],
+          photos: [],
+          organizations: [],
+        },
+        123,
+      ),
+    ).toEqual({
+      importedFrom: "google",
+      name: "Jane Doe",
+      email: "jane@example.com",
+      phone: "+1 555 0100",
+      nativeId: "people/10",
+      importedAt: 123,
+    });
+  });
+});

--- a/packages/desktop/tests/e2e/google-contacts.spec.ts
+++ b/packages/desktop/tests/e2e/google-contacts.spec.ts
@@ -1,0 +1,200 @@
+import { test, expect } from "./fixtures/app";
+
+async function seedGoogleToken(page: import("@playwright/test").Page) {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("freed_cloud_token_gdrive", "google-test-token");
+  });
+}
+
+async function openGoogleContactsSection(
+  page: import("@playwright/test").Page,
+  t: typeof test,
+) {
+  const settingsBtn = page
+    .locator("button")
+    .filter({ hasText: /settings/i })
+    .first();
+  if (!(await settingsBtn.isVisible())) {
+    t.skip(true, "Settings button not visible");
+    return null;
+  }
+
+  await settingsBtn.click();
+  await expect(page.getByText("Settings").first()).toBeVisible({ timeout: 5_000 });
+
+  const settingsNav = page.getByRole("navigation").nth(1);
+  const navBtn = settingsNav.getByRole("button", { name: "Google Contacts" }).first();
+  await expect(navBtn).toBeVisible({ timeout: 3_000 });
+  await navBtn.click();
+
+  const section = page.getByTestId("google-contacts-settings");
+  await expect(section).toBeVisible({ timeout: 3_000 });
+  return section;
+}
+
+async function mockGoogleContacts(
+  page: import("@playwright/test").Page,
+  connections: unknown[],
+  status = 200,
+) {
+  await page.route("https://people.googleapis.com/v1/people/me/connections?*", async (route) => {
+    await route.fulfill({
+      status,
+      contentType: "application/json",
+      body: JSON.stringify(
+        status >= 400
+          ? { error: { message: `People API error ${status.toLocaleString()}` } }
+          : {
+              connections,
+              nextSyncToken: "sync-token-1",
+            },
+      ),
+    });
+  });
+}
+
+async function injectAuthor(page: import("@playwright/test").Page, displayName: string, handle = "author-handle") {
+  await page.evaluate(async ({ displayName, handle }) => {
+    const w = window as Record<string, unknown>;
+    const automerge = w.__FREED_AUTOMERGE__ as {
+      docBatchImportItems: (items: unknown[]) => Promise<void>;
+    };
+    const now = Date.now();
+    await automerge.docBatchImportItems([
+      {
+        globalId: `x:${displayName}`,
+        platform: "x",
+        contentType: "post",
+        capturedAt: now,
+        publishedAt: now,
+        author: { id: `author:${displayName}`, handle, displayName },
+        content: { text: `post from ${displayName}`, mediaUrls: [], mediaTypes: [] },
+        userState: { hidden: false, saved: false, archived: false, tags: [] },
+        topics: [],
+      },
+    ]);
+  }, { displayName, handle });
+}
+
+async function injectFriend(page: import("@playwright/test").Page, friendName: string) {
+  await page.evaluate(async (friendName) => {
+    const w = window as Record<string, unknown>;
+    const automerge = w.__FREED_AUTOMERGE__ as {
+      docAddFriend: (friend: unknown) => Promise<void>;
+    };
+    const now = Date.now();
+    await automerge.docAddFriend({
+      id: `friend:${friendName}`,
+      name: friendName,
+      sources: [],
+      careLevel: 3,
+      createdAt: now,
+      updatedAt: now,
+    });
+  }, friendName);
+}
+
+test("Google Contacts appears in Settings > Sources", async ({ app }) => {
+  await seedGoogleToken(app.page);
+  await app.goto();
+  await app.waitForReady();
+
+  const section = await openGoogleContactsSection(app.page, test);
+  if (!section) return;
+
+  await expect(section.getByText("Google Contacts", { exact: true })).toBeVisible();
+  await expect(section.getByRole("button", { name: "Sync Now" })).toBeVisible();
+  await expect(section.getByRole("button", { name: "Review Matches" })).toBeVisible();
+});
+
+test("high-confidence existing friend matches auto-link on sync", async ({ app }) => {
+  await seedGoogleToken(app.page);
+  await mockGoogleContacts(app.page, [
+    {
+      resourceName: "people/1",
+      names: [{ displayName: "Jane Doe", givenName: "Jane", familyName: "Doe" }],
+      emailAddresses: [{ value: "jane@example.com" }],
+    },
+  ]);
+  await app.goto();
+  await app.waitForReady();
+  await injectFriend(app.page, "Jane Doe");
+
+  const section = await openGoogleContactsSection(app.page, test);
+  if (!section) return;
+  await section.getByRole("button", { name: "Sync Now" }).click();
+
+  await app.page.waitForFunction(() => {
+    const store = (window as Record<string, unknown>).__FREED_STORE__ as {
+      getState: () => { friends: Record<string, { contact?: { importedFrom?: string } }> };
+    };
+    const friend = Object.values(store.getState().friends)[0];
+    return friend?.contact?.importedFrom === "google";
+  });
+
+  await expect(section.getByText("Auto-linked")).toBeVisible();
+});
+
+test("high-confidence unlinked author matches auto-create a friend on sync", async ({ app }) => {
+  await seedGoogleToken(app.page);
+  await mockGoogleContacts(app.page, [
+    {
+      resourceName: "people/2",
+      names: [{ displayName: "Robin Quinn", givenName: "Robin", familyName: "Quinn" }],
+    },
+  ]);
+  await app.goto();
+  await app.waitForReady();
+  await injectAuthor(app.page, "Robin Quinn", "robin-q");
+
+  const section = await openGoogleContactsSection(app.page, test);
+  if (!section) return;
+  await section.getByRole("button", { name: "Sync Now" }).click();
+
+  await app.page.waitForFunction(() => {
+    const store = (window as Record<string, unknown>).__FREED_STORE__ as {
+      getState: () => { friends: Record<string, { name: string; sources: Array<{ authorId: string }> }> };
+    };
+    return Object.values(store.getState().friends).some(
+      (friend) => friend.name === "Robin Quinn" && friend.sources.some((source) => source.authorId === "author:Robin Quinn"),
+    );
+  });
+});
+
+test("medium-confidence handle matches stay in manual review", async ({ app }) => {
+  await seedGoogleToken(app.page);
+  await mockGoogleContacts(app.page, [
+    {
+      resourceName: "people/3",
+      names: [{ displayName: "Sam Carter", givenName: "Sam", familyName: "Carter" }],
+    },
+  ]);
+  await app.goto();
+  await app.waitForReady();
+  await injectAuthor(app.page, "Completely Different", "sam.carter");
+
+  const section = await openGoogleContactsSection(app.page, test);
+  if (!section) return;
+  await section.getByRole("button", { name: "Sync Now" }).click();
+
+  await app.page.waitForFunction(() => {
+    const store = (window as Record<string, unknown>).__FREED_STORE__ as {
+      getState: () => { pendingMatchCount: number; friends: Record<string, unknown> };
+    };
+    const state = store.getState();
+    return state.pendingMatchCount === 1 && Object.keys(state.friends).length === 0;
+  });
+});
+
+test("People API failures surface reconnect state instead of failing silently", async ({ app }) => {
+  await seedGoogleToken(app.page);
+  await mockGoogleContacts(app.page, [], 401);
+  await app.goto();
+  await app.waitForReady();
+
+  const section = await openGoogleContactsSection(app.page, test);
+  if (!section) return;
+  await section.getByRole("button", { name: "Sync Now" }).click();
+
+  await expect(section.getByText("Reconnect required")).toBeVisible({ timeout: 5_000 });
+});

--- a/packages/pwa/src/App.tsx
+++ b/packages/pwa/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState, useCallback } from "react";
 import { AppShell } from "@freed/ui/components/layout";
 import { FeedView } from "@freed/ui/components/feed";
+import { GoogleContactsSection } from "@freed/ui/components/settings/GoogleContactsSection";
 import { ToastContainer } from "@freed/ui/components/Toast";
 import { LegalGate } from "@freed/ui/components/legal/LegalGate";
 import { OAuthCallback } from "./components/OAuthCallback";
@@ -28,6 +29,7 @@ import { PwaFeedEmptyState } from "./components/PwaFeedEmptyState";
 import { PwaSyncSettings } from "./components/PwaSyncSettings";
 import { PwaXSettings } from "./components/PwaXSettings";
 import { PwaLegalSettingsSection } from "./components/PwaLegalSettingsSection";
+import { initiateGDriveOAuth } from "./components/SyncConnectDialog";
 import { acceptPwaBundle, hasAcceptedPwaBundle } from "./lib/legal-consent";
 
 function App() {
@@ -123,6 +125,7 @@ function App() {
       FacebookSettingsContent: null,
       InstagramSettingsContent: null,
       LinkedInSettingsContent: null,
+      GoogleContactsSettingsContent: GoogleContactsSection,
       checkForUpdates,
       applyUpdate: applyPwaUpdate,
       factoryReset: handleFactoryReset,
@@ -152,6 +155,7 @@ function App() {
       pickContact: pickContactViaWebApi,
       googleContacts: {
         getToken: () => localStorage.getItem("freed_cloud_token_gdrive"),
+        connect: initiateGDriveOAuth,
       },
       openUrl: (url: string) => { window.open(url, "_blank", "noopener,noreferrer"); },
     }),

--- a/packages/pwa/src/components/SyncConnectDialog.tsx
+++ b/packages/pwa/src/components/SyncConnectDialog.tsx
@@ -39,7 +39,7 @@ const GDRIVE_CLIENT_ID = import.meta.env.VITE_GDRIVE_CLIENT_ID ?? "";
 const DROPBOX_CLIENT_ID = import.meta.env.VITE_DROPBOX_CLIENT_ID ?? "";
 const OAUTH_REDIRECT_URI = `${window.location.origin}/oauth-callback`;
 
-async function initiateGDriveOAuth(): Promise<void> {
+export async function initiateGDriveOAuth(): Promise<void> {
   const verifier = generateCodeVerifier();
   const challenge = await generateCodeChallenge(verifier);
   sessionStorage.setItem("freed_pkce_verifier", verifier);

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -11,6 +11,7 @@
     "./legal-storage": "./src/legal-storage.ts",
     "./opml": "./src/opml.ts",
     "./google-contacts": "./src/google-contacts.ts",
+    "./google-contacts-automation": "./src/google-contacts-automation.ts",
     "./contact-matching": "./src/contact-matching.ts"
   },
   "scripts": {

--- a/packages/shared/src/contact-sync-state.ts
+++ b/packages/shared/src/contact-sync-state.ts
@@ -4,11 +4,17 @@ export const CONTACT_SYNC_STORAGE_KEY = "freed_contact_sync";
 
 export function createEmptyContactSyncState(): ContactSyncState {
   return {
+    authStatus: "reconnect_required",
+    syncStatus: "idle",
     syncToken: null,
     lastSyncedAt: null,
+    lastErrorCode: undefined,
+    lastErrorMessage: undefined,
     cachedContacts: [],
     pendingMatches: [],
     dismissedMatches: [],
+    autoLinkedCount: 0,
+    autoCreatedCount: 0,
   };
 }
 
@@ -20,11 +26,17 @@ export function parseContactSyncState(raw: string | null | undefined): ContactSy
   try {
     const parsed = JSON.parse(raw) as Partial<ContactSyncState>;
     return {
+      authStatus: parsed.authStatus ?? "reconnect_required",
+      syncStatus: parsed.syncStatus ?? "idle",
       syncToken: parsed.syncToken ?? null,
       lastSyncedAt: parsed.lastSyncedAt ?? null,
+      lastErrorCode: parsed.lastErrorCode,
+      lastErrorMessage: parsed.lastErrorMessage,
       cachedContacts: parsed.cachedContacts ?? [],
       pendingMatches: parsed.pendingMatches ?? [],
       dismissedMatches: parsed.dismissedMatches ?? [],
+      autoLinkedCount: parsed.autoLinkedCount ?? 0,
+      autoCreatedCount: parsed.autoCreatedCount ?? 0,
     };
   } catch {
     return createEmptyContactSyncState();

--- a/packages/shared/src/google-contacts-automation.ts
+++ b/packages/shared/src/google-contacts-automation.ts
@@ -1,0 +1,70 @@
+import type { ContactMatch, DeviceContact, FeedItem, FriendSource, GoogleContact } from "./types.js";
+
+function sourceKey(source: FriendSource): string {
+  return `${source.platform}:${source.authorId}`;
+}
+
+export function createDeviceContactFromGoogleContact(
+  contact: GoogleContact,
+  importedAt: number,
+): DeviceContact {
+  const deviceContact: DeviceContact = {
+    importedFrom: "google",
+    name: contact.name.displayName ?? contact.name.givenName ?? "",
+    nativeId: contact.resourceName,
+    importedAt,
+  };
+  const phone = contact.phones[0]?.value;
+  const email = contact.emails[0]?.value;
+  if (phone) deviceContact.phone = phone;
+  if (email) deviceContact.email = email;
+  return deviceContact;
+}
+
+export function buildFriendSourcesFromAuthorIds(
+  items: FeedItem[],
+  authorIds: string[],
+): FriendSource[] {
+  const seen = new Set<string>();
+  const sources: FriendSource[] = [];
+
+  for (const authorId of authorIds) {
+    const item = items.find((entry) => entry.author.id === authorId);
+    if (!item) continue;
+
+    const source: FriendSource = {
+      platform: item.platform,
+      authorId: item.author.id,
+    };
+    if (item.author.handle) source.handle = item.author.handle;
+    if (item.author.displayName) source.displayName = item.author.displayName;
+    if (item.author.avatarUrl) source.avatarUrl = item.author.avatarUrl;
+    const key = sourceKey(source);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    sources.push(source);
+  }
+
+  return sources;
+}
+
+export function mergeFriendSources(
+  existing: FriendSource[],
+  additions: FriendSource[],
+): FriendSource[] {
+  const merged = [...existing];
+  const seen = new Set(existing.map(sourceKey));
+
+  for (const source of additions) {
+    const key = sourceKey(source);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    merged.push(source);
+  }
+
+  return merged;
+}
+
+export function shouldAutoProcessMatch(match: ContactMatch): boolean {
+  return match.confidence === "high" && (Boolean(match.friend) || match.authorIds.length > 0);
+}

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -724,11 +724,17 @@ export interface ContactMatch {
  * Persisted state for the Google Contacts sync cycle.
  */
 export interface ContactSyncState {
+  authStatus: "connected" | "reconnect_required";
+  syncStatus: "idle" | "syncing" | "error";
   syncToken: string | null;
   lastSyncedAt: number | null;
+  lastErrorCode?: "missing_token" | "auth" | "network" | "unknown";
+  lastErrorMessage?: string;
   cachedContacts: GoogleContact[];
   pendingMatches: ContactMatch[];
   dismissedMatches: Array<{ contactResourceName: string; friendIdOrAuthorId: string }>;
+  autoLinkedCount: number;
+  autoCreatedCount: number;
 }
 
 /**

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -13,6 +13,7 @@
     "./components/SettingsToggle": "./src/components/SettingsToggle.tsx",
     "./components/AddFeedDialog": "./src/components/AddFeedDialog.tsx",
     "./components/SettingsDialog": "./src/components/SettingsDialog.tsx",
+    "./components/settings/GoogleContactsSection": "./src/components/settings/GoogleContactsSection.tsx",
     "./components/legal/LegalGate": "./src/components/legal/LegalGate.tsx",
     "./components/legal/ProviderRiskDialog": "./src/components/legal/ProviderRiskDialog.tsx",
     "./components/DebugPanel": "./src/components/DebugPanel.tsx",

--- a/packages/ui/src/components/SettingsDialog.tsx
+++ b/packages/ui/src/components/SettingsDialog.tsx
@@ -27,6 +27,7 @@ import {
   BASE_SECTION_METAS,
   UPDATES_SECTION_META,
   DANGER_SECTION_META,
+  GOOGLE_CONTACTS_SECTION_META,
   X_SECTION_META,
   FB_SECTION_META,
   IG_SECTION_META,
@@ -209,6 +210,13 @@ const ICONS: Record<SectionId, ReactNode> = {
       <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
     </svg>
   ),
+  googleContacts: (
+    <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M15 11a4 4 0 10-6 3.465V17a1 1 0 001 1h4a1 1 0 001-1v-2.535A4 4 0 0015 11z" />
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 20h6" />
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M18 8h3M3 8h3M16.95 3.05l2.12-2.12M4.93 5.17L2.81 3.05" />
+    </svg>
+  ),
 };
 
 // ── Update check state ────────────────────────────────────────────────────────
@@ -230,6 +238,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
     FacebookSettingsContent,
     InstagramSettingsContent,
     LinkedInSettingsContent,
+    GoogleContactsSettingsContent,
     checkForUpdates,
     applyUpdate,
     headerDragRegion,
@@ -251,6 +260,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
     ...(FacebookSettingsContent ? [{ ...FB_SECTION_META, icon: ICONS.facebook }] : []),
     ...(InstagramSettingsContent ? [{ ...IG_SECTION_META, icon: ICONS.instagram }] : []),
     ...(LinkedInSettingsContent ? [{ ...LI_SECTION_META, icon: ICONS.linkedin }] : []),
+    ...(GoogleContactsSettingsContent ? [{ ...GOOGLE_CONTACTS_SECTION_META, icon: ICONS.googleContacts }] : []),
     ...(checkForUpdates ? [{ ...UPDATES_SECTION_META, icon: ICONS.updates }] : []),
     ...(factoryReset ? [{ ...DANGER_SECTION_META, icon: ICONS.danger }] : []),
   ];
@@ -273,6 +283,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
         ...(FacebookSettingsContent ? [sectionById.facebook] : []),
         ...(InstagramSettingsContent ? [sectionById.instagram] : []),
         ...(LinkedInSettingsContent ? [sectionById.linkedin] : []),
+        ...(GoogleContactsSettingsContent ? [sectionById.googleContacts] : []),
       ],
     },
     // sectionById.ai, // AI coming soon -- do not delete
@@ -764,6 +775,14 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
           <>
             <SectionHeading label="LinkedIn" />
             <LinkedInSettingsContent surface="settings" />
+          </>
+        ) : null;
+
+      case "googleContacts":
+        return GoogleContactsSettingsContent ? (
+          <>
+            <SectionHeading label="Google Contacts" />
+            <GoogleContactsSettingsContent />
           </>
         ) : null;
 

--- a/packages/ui/src/components/friends/FriendsView.tsx
+++ b/packages/ui/src/components/friends/FriendsView.tsx
@@ -1,13 +1,5 @@
 import { useState, useCallback, useMemo, useEffect, useRef } from "react";
-import type {
-  ContactMatch,
-  DeviceContact,
-  FeedItem,
-  Friend,
-  FriendSource,
-  GoogleContact,
-  ReachOutLog,
-} from "@freed/shared";
+import type { FeedItem, Friend, ReachOutLog } from "@freed/shared";
 import { formatDistanceToNow } from "date-fns";
 import { DEFAULT_FRIEND_AVATAR_TINT, isInReconnectZone } from "@freed/shared";
 import { useAppStore } from "../../context/PlatformContext.js";
@@ -18,7 +10,6 @@ import { FriendAvatar } from "./FriendAvatar.js";
 import { FriendGraph } from "./FriendGraph.js";
 import { FriendDetailPanel } from "./FriendDetailPanel.js";
 import { FriendEditor } from "./FriendEditor.js";
-import { ContactSyncModal } from "./ContactSyncModal.js";
 import { UsersIcon, MapPinIcon } from "../icons.js";
 import { ContentHeader } from "../layout/ContentHeader.js";
 import {
@@ -153,7 +144,6 @@ export function FriendsView() {
 
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [editorTarget, setEditorTarget] = useState<Friend | null | "new">(null);
-  const [showSyncModal, setShowSyncModal] = useState(false);
   const [openingSyncModal, setOpeningSyncModal] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const [activeFilters, setActiveFilters] = useState<Set<FriendOverviewFilter>>(new Set());
@@ -164,7 +154,7 @@ export function FriendsView() {
   const isDraggingSidebar = useRef(false);
   const isMobile = useIsMobile();
 
-  const { syncState, dismissMatch, syncNow } = useContactSyncContext();
+  const { openReview } = useContactSyncContext();
 
   const feedItems = useMemo(() => {
     const map: Record<string, FeedItem> = {};
@@ -253,89 +243,14 @@ export function FriendsView() {
     [handleClearSelection, removeFriend, selectedId]
   );
 
-  const handleLink = useCallback(
-    async (match: ContactMatch) => {
-      const { contact, friend, authorIds } = match;
-
-      const deviceContact: DeviceContact = {
-        importedFrom: "google",
-        name: contact.name.displayName ?? contact.name.givenName ?? "",
-        phone: contact.phones[0]?.value,
-        email: contact.emails[0]?.value,
-        nativeId: contact.resourceName,
-        importedAt: Date.now(),
-      };
-
-      const newSources: FriendSource[] = authorIds.flatMap((authorId) => {
-        const item = items.find((candidate) => candidate.author.id === authorId);
-        if (!item) return [];
-        return [{
-          platform: item.platform,
-          authorId: item.author.id,
-          handle: item.author.handle,
-          displayName: item.author.displayName,
-          avatarUrl: item.author.avatarUrl,
-        }];
-      });
-
-      if (friend) {
-        await updateFriend(friend.id, {
-          contact: deviceContact,
-          sources: [...(friend.sources ?? []), ...newSources],
-        });
-      } else if (newSources.length > 0) {
-        const now = Date.now();
-        await addFriend({
-          id: crypto.randomUUID(),
-          name: contact.name.displayName ?? contact.name.givenName ?? "",
-          sources: newSources,
-          contact: deviceContact,
-          careLevel: 3,
-          createdAt: now,
-          updatedAt: now,
-        });
-      }
-
-      const dismissIds = [...(friend ? [friend.id] : []), ...authorIds];
-      for (const dismissId of dismissIds) {
-        dismissMatch(contact.resourceName, dismissId);
-      }
-    },
-    [addFriend, dismissMatch, items, updateFriend]
-  );
-
-  const handleCreateFriend = useCallback(
-    async (contact: GoogleContact) => {
-      const now = Date.now();
-      await addFriend({
-        id: crypto.randomUUID(),
-        name: contact.name.displayName ?? contact.name.givenName ?? "",
-        sources: [],
-        contact: {
-          importedFrom: "google",
-          name: contact.name.displayName ?? contact.name.givenName ?? "",
-          phone: contact.phones[0]?.value,
-          email: contact.emails[0]?.value,
-          nativeId: contact.resourceName,
-          importedAt: now,
-        },
-        careLevel: 3,
-        createdAt: now,
-        updatedAt: now,
-      });
-    },
-    [addFriend]
-  );
-
   const handleOpenSyncModal = useCallback(async () => {
     setOpeningSyncModal(true);
     try {
-      await syncNow();
-      setShowSyncModal(true);
+      await openReview();
     } finally {
       setOpeningSyncModal(false);
     }
-  }, [syncNow]);
+  }, [openReview]);
 
   const toggleFilter = useCallback((filter: FriendOverviewFilter) => {
     setActiveFilters((current) => {
@@ -615,16 +530,6 @@ export function FriendsView() {
           onSave={handleSave}
           onDelete={editorTarget !== "new" ? handleDelete : undefined}
           onCancel={() => setEditorTarget(null)}
-        />
-      )}
-
-      {showSyncModal && (
-        <ContactSyncModal
-          onClose={() => setShowSyncModal(false)}
-          syncState={syncState}
-          onLink={handleLink}
-          onSkip={dismissMatch}
-          onCreateFriend={handleCreateFriend}
         />
       )}
     </div>

--- a/packages/ui/src/components/layout/AppShell.tsx
+++ b/packages/ui/src/components/layout/AppShell.tsx
@@ -5,8 +5,15 @@ import { DebugPanel } from "../DebugPanel.js";
 import { useDebugStore } from "../../lib/debug-store.js";
 import { useAppStore } from "../../context/PlatformContext.js";
 import { FriendsView } from "../friends/FriendsView.js";
+import { ContactSyncModal } from "../friends/ContactSyncModal.js";
 import { useContactSync } from "../../hooks/useContactSync.js";
 import { ContactSyncContext } from "../../context/ContactSyncContext.js";
+import type { ContactMatch, GoogleContact } from "@freed/shared";
+import {
+  buildFriendSourcesFromAuthorIds,
+  createDeviceContactFromGoogleContact,
+  mergeFriendSources,
+} from "@freed/shared/google-contacts-automation";
 import { MapView } from "../map/MapView.js";
 
 const DEFAULT_DEBUG_WIDTH = 320;
@@ -22,10 +29,14 @@ export function AppShell({ children }: AppShellProps) {
   const debugVisible = useDebugStore((s) => s.visible);
   const toggleDebug = useDebugStore((s) => s.toggle);
   const activeView = useAppStore((s) => s.activeView);
+  const items = useAppStore((s) => s.items);
+  const addFriend = useAppStore((s) => s.addFriend);
+  const updateFriend = useAppStore((s) => s.updateFriend);
 
   // Mount the contact sync hook here (not in FriendsView) so the 15-minute
   // interval and focus listener run regardless of which view is active.
   const contactSync = useContactSync();
+  const [showContactReview, setShowContactReview] = useState(false);
   const savedDebugWidth = useAppStore((s) => s.preferences.display.debugPanelWidth) ?? DEFAULT_DEBUG_WIDTH;
   const updatePreferences = useAppStore((s) => s.updatePreferences);
   const [dragWidth, setDragWidth] = useState<number | null>(null);
@@ -74,8 +85,61 @@ export function AppShell({ children }: AppShellProps) {
     return () => window.removeEventListener("keydown", handler);
   }, [toggleDebug, debugVisible]);
 
+  const handleLinkContact = useCallback(async (match: ContactMatch) => {
+    const now = Date.now();
+    const contact = createDeviceContactFromGoogleContact(match.contact, now);
+    const newSources = buildFriendSourcesFromAuthorIds(items, match.authorIds);
+
+    if (match.friend) {
+      await updateFriend(match.friend.id, {
+        contact,
+        sources: mergeFriendSources(match.friend.sources ?? [], newSources),
+        updatedAt: now,
+      });
+    } else if (newSources.length > 0) {
+      await addFriend({
+        id: crypto.randomUUID(),
+        name: contact.name,
+        sources: newSources,
+        contact,
+        careLevel: 3,
+        createdAt: now,
+        updatedAt: now,
+      });
+    }
+
+    for (const id of [
+      ...(match.friend ? [match.friend.id] : []),
+      ...match.authorIds,
+    ]) {
+      contactSync.dismissMatch(match.contact.resourceName, id);
+    }
+  }, [addFriend, contactSync, items, updateFriend]);
+
+  const handleCreateFriend = useCallback(async (contact: GoogleContact) => {
+    const now = Date.now();
+    await addFriend({
+      id: crypto.randomUUID(),
+      name: contact.name.displayName ?? contact.name.givenName ?? "",
+      sources: [],
+      contact: createDeviceContactFromGoogleContact(contact, now),
+      careLevel: 3,
+      createdAt: now,
+      updatedAt: now,
+    });
+  }, [addFriend]);
+
+  const openReview = useCallback(async () => {
+    const result = await contactSync.syncNow();
+    const shouldOpen =
+      result.authStatus === "connected" ||
+      result.pendingMatches.length > 0 ||
+      result.cachedContacts.length > 0;
+    setShowContactReview(shouldOpen);
+  }, [contactSync]);
+
   return (
-    <ContactSyncContext.Provider value={contactSync}>
+    <ContactSyncContext.Provider value={{ ...contactSync, openReview }}>
     {/* On mobile (<md), the layout flows naturally in the document so Safari can
         collapse its address bar when the feed scrolls. min-h-0 and overflow-hidden
         are desktop-only; they lock the layout to 100dvh for in-element scrolling. */}
@@ -118,6 +182,16 @@ export function AppShell({ children }: AppShellProps) {
         <div className="sm:hidden">
           <DebugPanel variant="overlay" />
         </div>
+      )}
+
+      {showContactReview && (
+        <ContactSyncModal
+          onClose={() => setShowContactReview(false)}
+          syncState={contactSync.syncState}
+          onLink={handleLinkContact}
+          onSkip={contactSync.dismissMatch}
+          onCreateFriend={handleCreateFriend}
+        />
       )}
     </div>
     </ContactSyncContext.Provider>

--- a/packages/ui/src/components/settings/GoogleContactsSection.tsx
+++ b/packages/ui/src/components/settings/GoogleContactsSection.tsx
@@ -1,0 +1,144 @@
+import { useState } from "react";
+import { usePlatform } from "../../context/PlatformContext.js";
+import { useContactSyncContext } from "../../context/ContactSyncContext.js";
+
+function formatSyncTime(timestamp: number | null): string {
+  if (!timestamp) return "Never";
+  return new Date(timestamp).toLocaleString();
+}
+
+function StatusPill({
+  label,
+  tone,
+}: {
+  label: string;
+  tone: "neutral" | "success" | "warning" | "error" | "syncing";
+}) {
+  const toneClass =
+    tone === "success"
+      ? "bg-green-500/15 text-green-300"
+      : tone === "warning"
+        ? "bg-amber-500/15 text-amber-300"
+        : tone === "error"
+          ? "bg-red-500/15 text-red-300"
+          : tone === "syncing"
+            ? "bg-[#8b5cf6]/20 text-[#c4b5fd]"
+            : "bg-white/5 text-[#a1a1aa]";
+
+  return (
+    <span className={`inline-flex items-center rounded-full px-2 py-1 text-[11px] font-medium ${toneClass}`}>
+      {label}
+    </span>
+  );
+}
+
+export function GoogleContactsSection() {
+  const { googleContacts } = usePlatform();
+  const { syncState, syncNow, openReview } = useContactSyncContext();
+  const [connecting, setConnecting] = useState(false);
+
+  const isConnected = syncState.authStatus === "connected";
+  const needsReconnect = syncState.authStatus === "reconnect_required";
+  const isSyncing = syncState.syncStatus === "syncing";
+
+  const handleConnect = async () => {
+    if (!googleContacts) return;
+    setConnecting(true);
+    try {
+      await googleContacts.connect();
+      await syncNow();
+    } finally {
+      setConnecting(false);
+    }
+  };
+
+  const handleSync = async () => {
+    await syncNow();
+  };
+
+  const cachedCount = syncState.cachedContacts.length.toLocaleString();
+  const pendingCount = syncState.pendingMatches.length.toLocaleString();
+  const autoLinkedCount = syncState.autoLinkedCount.toLocaleString();
+  const autoCreatedCount = syncState.autoCreatedCount.toLocaleString();
+
+  return (
+    <div className="space-y-4" data-testid="google-contacts-settings">
+      <div className="rounded-xl bg-white/[0.03] border border-[rgba(255,255,255,0.06)] p-4 space-y-4">
+        <div className="flex items-start justify-between gap-4">
+          <div className="space-y-1">
+            <div className="flex items-center gap-2">
+              <p className="text-sm font-semibold text-white">Google Contacts</p>
+              {isSyncing ? (
+                <StatusPill label="Syncing" tone="syncing" />
+              ) : needsReconnect ? (
+                <StatusPill label="Reconnect required" tone="warning" />
+              ) : isConnected ? (
+                <StatusPill label="Connected" tone="success" />
+              ) : (
+                <StatusPill label="Not connected" tone="neutral" />
+              )}
+            </div>
+            <p className="text-xs text-[#71717a]">
+              Sync contact matches into Friends, auto-link obvious matches, and review the ambiguous ones.
+            </p>
+          </div>
+          {syncState.lastErrorMessage && (
+            <StatusPill label="Needs attention" tone="error" />
+          )}
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <div className="rounded-xl bg-white/[0.03] border border-[rgba(255,255,255,0.05)] px-3 py-2.5">
+            <p className="text-[11px] uppercase tracking-wider text-[#52525b]">Cached contacts</p>
+            <p className="mt-1 text-base font-semibold text-white">{cachedCount}</p>
+          </div>
+          <div className="rounded-xl bg-white/[0.03] border border-[rgba(255,255,255,0.05)] px-3 py-2.5">
+            <p className="text-[11px] uppercase tracking-wider text-[#52525b]">Needs review</p>
+            <p className="mt-1 text-base font-semibold text-white">{pendingCount}</p>
+          </div>
+          <div className="rounded-xl bg-white/[0.03] border border-[rgba(255,255,255,0.05)] px-3 py-2.5">
+            <p className="text-[11px] uppercase tracking-wider text-[#52525b]">Auto-linked</p>
+            <p className="mt-1 text-base font-semibold text-white">{autoLinkedCount}</p>
+          </div>
+          <div className="rounded-xl bg-white/[0.03] border border-[rgba(255,255,255,0.05)] px-3 py-2.5">
+            <p className="text-[11px] uppercase tracking-wider text-[#52525b]">Auto-created</p>
+            <p className="mt-1 text-base font-semibold text-white">{autoCreatedCount}</p>
+          </div>
+        </div>
+
+        <div className="space-y-1 text-xs text-[#71717a]">
+          <p>Last successful sync: <span className="text-[#a1a1aa]">{formatSyncTime(syncState.lastSyncedAt)}</span></p>
+          {syncState.lastErrorMessage && (
+            <p className="text-red-300">
+              {syncState.lastErrorMessage}
+            </p>
+          )}
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          <button
+            onClick={handleConnect}
+            disabled={!googleContacts || connecting || isSyncing}
+            className="text-sm px-3 py-1.5 rounded-lg bg-[#8b5cf6] hover:bg-[#7c3aed] text-white transition-colors disabled:opacity-50"
+          >
+            {connecting ? "Connecting..." : needsReconnect || !isConnected ? "Reconnect Google" : "Reconnect"}
+          </button>
+          <button
+            onClick={handleSync}
+            disabled={!googleContacts || connecting || isSyncing}
+            className="text-sm px-3 py-1.5 rounded-lg bg-white/5 hover:bg-white/10 text-[#a1a1aa] hover:text-white transition-colors disabled:opacity-50"
+          >
+            {isSyncing ? "Syncing..." : "Sync Now"}
+          </button>
+          <button
+            onClick={() => void openReview()}
+            disabled={!googleContacts || connecting}
+            className="text-sm px-3 py-1.5 rounded-lg bg-white/5 hover:bg-white/10 text-[#a1a1aa] hover:text-white transition-colors disabled:opacity-50"
+          >
+            Review Matches
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/context/ContactSyncContext.tsx
+++ b/packages/ui/src/context/ContactSyncContext.tsx
@@ -14,6 +14,7 @@ export interface ContactSyncContextValue {
   getSyncState: () => ContactSyncState;
   syncNow: () => Promise<ContactSyncState>;
   dismissMatch: (contactResourceName: string, friendIdOrAuthorId: string) => void;
+  openReview: () => Promise<void>;
 }
 
 export const ContactSyncContext = createContext<ContactSyncContextValue | null>(null);

--- a/packages/ui/src/context/PlatformContext.tsx
+++ b/packages/ui/src/context/PlatformContext.tsx
@@ -15,6 +15,7 @@ import {
 } from "react";
 import type {
   BaseAppState,
+  ContactSyncState,
   ImportProgress,
 } from "@freed/shared";
 import type { OPMLFeedEntry } from "@freed/shared";
@@ -134,6 +135,12 @@ export interface PlatformConfig {
    */
   LinkedInSettingsContent: ComponentType<SyncProviderSectionProps> | null;
 
+  /**
+   * Content rendered in the Settings > Sources > Google Contacts section.
+   * When null, the Google Contacts section is omitted from settings entirely.
+   */
+  GoogleContactsSettingsContent: ComponentType | null;
+
   /** Manual update check. Returns version string if available, null if up-to-date. */
   checkForUpdates?: () => Promise<string | null>;
 
@@ -240,6 +247,8 @@ export interface PlatformConfig {
   googleContacts?: {
     /** Return the current Google OAuth access token, or null when not authenticated. */
     getToken: () => string | null;
+    /** Start or refresh the Google OAuth flow so contacts scope is granted. */
+    connect: () => Promise<void>;
   };
 
   /**
@@ -259,6 +268,12 @@ export interface PlatformConfig {
     address?: string;
     nativeId?: string;
   } | null>;
+}
+
+export interface ContactSyncActions {
+  syncNow: () => Promise<ContactSyncState>;
+  dismissMatch: (contactResourceName: string, friendIdOrAuthorId: string) => void;
+  openReview: () => Promise<void>;
 }
 
 const PlatformCtx = createContext<PlatformConfig | null>(null);

--- a/packages/ui/src/context/index.ts
+++ b/packages/ui/src/context/index.ts
@@ -3,6 +3,7 @@ export {
   usePlatform,
   useAppStore,
   MACOS_TRAFFIC_LIGHT_INSET,
+  type ContactSyncActions,
   type PlatformConfig,
   type SidebarSourceStatusSummary,
   type SyncProviderSectionProps,

--- a/packages/ui/src/hooks/useContactSync.ts
+++ b/packages/ui/src/hooks/useContactSync.ts
@@ -1,12 +1,23 @@
 import { useEffect, useRef, useCallback, useState } from "react";
-import { fetchGoogleContacts, mergeContactChanges } from "@freed/shared/google-contacts";
-import { matchContacts } from "@freed/shared/contact-matching";
 import {
   CONTACT_SYNC_STORAGE_KEY,
   createEmptyContactSyncState,
   parseContactSyncState,
+  type ContactMatch,
   type ContactSyncState,
 } from "@freed/shared";
+import {
+  fetchGoogleContacts,
+  mergeContactChanges,
+  type GoogleContactsResult,
+} from "@freed/shared/google-contacts";
+import {
+  buildFriendSourcesFromAuthorIds,
+  createDeviceContactFromGoogleContact,
+  mergeFriendSources,
+  shouldAutoProcessMatch,
+} from "@freed/shared/google-contacts-automation";
+import { matchContacts } from "@freed/shared/contact-matching";
 import { usePlatform } from "../context/PlatformContext.js";
 
 const SYNC_INTERVAL_MS = 15 * 60 * 1000; // 15 minutes
@@ -22,24 +33,50 @@ function loadSyncState(): ContactSyncState {
 function saveSyncState(state: ContactSyncState): void {
   try {
     localStorage.setItem(CONTACT_SYNC_STORAGE_KEY, JSON.stringify(state));
-  } catch { /* ignore storage errors */ }
+  } catch {
+    // Ignore storage errors.
+  }
+}
+
+function getPotentialIds(match: ContactMatch): string[] {
+  return [
+    ...(match.friend ? [match.friend.id] : []),
+    ...match.authorIds,
+  ];
+}
+
+function withError(
+  current: ContactSyncState,
+  code: ContactSyncState["lastErrorCode"],
+  message: string,
+): ContactSyncState {
+  return {
+    ...current,
+    authStatus: code === "missing_token" || code === "auth"
+      ? "reconnect_required"
+      : current.authStatus,
+    syncStatus: "error",
+    lastErrorCode: code,
+    lastErrorMessage: message,
+    autoLinkedCount: 0,
+    autoCreatedCount: 0,
+  };
 }
 
 export function useContactSync() {
   const { store, googleContacts } = usePlatform();
 
   // Read live values for use in the sync callback. We store them in refs so
-  // that runSync's useCallback deps stay stable. If we captured friends/items
-  // directly in the dep array, every feed or friend update would recreate
-  // runSync and reset the 15-minute setInterval.
+  // that runSync's deps stay stable and the interval does not reset on every
+  // feed or friend update.
   const friends = store((s) => s.friends);
   const items = store((s) => s.items);
+  const addFriend = store((s) => s.addFriend);
+  const updateFriend = store((s) => s.updateFriend);
   const setPendingMatchCount = store((s) => s.setPendingMatchCount);
 
   const friendsRef = useRef(friends);
   const itemsRef = useRef(items);
-  // Assign synchronously so the refs are always current by the time any async
-  // code reads them, even without an extra useEffect round-trip.
   friendsRef.current = friends;
   itemsRef.current = items;
 
@@ -57,95 +94,173 @@ export function useContactSync() {
     saveSyncState(nextState);
   }, []);
 
+  const autoProcessMatches = useCallback(async (matches: ContactMatch[]) => {
+    let autoLinkedCount = 0;
+    let autoCreatedCount = 0;
+
+    for (const match of matches) {
+      const now = Date.now();
+      const contact = createDeviceContactFromGoogleContact(match.contact, now);
+      const newSources = buildFriendSourcesFromAuthorIds(itemsRef.current, match.authorIds);
+
+      if (match.friend) {
+        await updateFriend(match.friend.id, {
+          contact,
+          sources: mergeFriendSources(match.friend.sources ?? [], newSources),
+          updatedAt: now,
+        });
+        autoLinkedCount += 1;
+        continue;
+      }
+
+      if (newSources.length === 0) continue;
+
+      await addFriend({
+        id: crypto.randomUUID(),
+        name: contact.name,
+        sources: newSources,
+        contact,
+        careLevel: 3,
+        createdAt: now,
+        updatedAt: now,
+      });
+      autoCreatedCount += 1;
+    }
+
+    return { autoLinkedCount, autoCreatedCount };
+  }, [addFriend, updateFriend]);
+
   const runSync = useCallback(async () => {
-    const token = googleContacts?.getToken();
-    if (!token) return syncStateRef.current;
+    const current = syncStateRef.current;
+    const token = googleContacts?.getToken() ?? null;
+
+    if (!token) {
+      const nextState = withError(
+        current,
+        "missing_token",
+        "Reconnect Google to sync contacts.",
+      );
+      commitSyncState(nextState);
+      return nextState;
+    }
+
+    const startingState: ContactSyncState = {
+      ...current,
+      authStatus: "connected",
+      syncStatus: "syncing",
+      lastErrorCode: undefined,
+      lastErrorMessage: undefined,
+      autoLinkedCount: 0,
+      autoCreatedCount: 0,
+    };
+    commitSyncState(startingState);
 
     try {
-      const current = syncStateRef.current;
-      const result = await fetchGoogleContacts(token, current.syncToken);
+      const result: GoogleContactsResult = await fetchGoogleContacts(token, current.syncToken);
       const merged = mergeContactChanges(
         current.cachedContacts,
         result.contacts,
-        result.deleted
+        result.deleted,
       );
 
-      // Read from refs so we always get the latest store values without
-      // taking them as useCallback deps (which would reset the interval).
       const allMatches = matchContacts(merged, friendsRef.current, itemsRef.current);
+      const autoMatches = allMatches.filter(shouldAutoProcessMatch);
+      const { autoLinkedCount, autoCreatedCount } = await autoProcessMatches(autoMatches);
 
       const dismissedSet = new Set(
         current.dismissedMatches.map(
-          (d) => `${d.contactResourceName}:${d.friendIdOrAuthorId}`
-        )
+          (entry) => `${entry.contactResourceName}:${entry.friendIdOrAuthorId}`,
+        ),
       );
 
-      const pending = allMatches.filter((m) => {
-        if (!m.friend && m.authorIds.length === 0) return false;
-        const potentialIds = [
-          ...(m.friend ? [m.friend.id] : []),
-          ...m.authorIds,
-        ];
+      const pendingMatches = allMatches.filter((match) => {
+        if (shouldAutoProcessMatch(match)) return false;
+        const potentialIds = getPotentialIds(match);
+        if (potentialIds.length === 0) return false;
         return potentialIds.some(
-          (id) => !dismissedSet.has(`${m.contact.resourceName}:${id}`)
+          (id) => !dismissedSet.has(`${match.contact.resourceName}:${id}`),
         );
       });
 
       const nextState: ContactSyncState = {
+        authStatus: "connected",
+        syncStatus: "idle",
         syncToken: result.nextSyncToken,
         lastSyncedAt: Date.now(),
         cachedContacts: merged,
-        pendingMatches: pending,
+        pendingMatches,
         dismissedMatches: current.dismissedMatches,
+        autoLinkedCount,
+        autoCreatedCount,
       };
 
       commitSyncState(nextState);
       return nextState;
     } catch (err) {
-      console.warn("[useContactSync] sync failed:", err);
-      return syncStateRef.current;
+      const message = err instanceof Error ? err.message : "Google Contacts sync failed.";
+      const status = typeof err === "object" && err !== null && "status" in err
+        ? (err as { status?: number }).status
+        : undefined;
+      const code = status === 401 || status === 403 ? "auth" : "network";
+      const nextState = withError(current, code, message);
+      commitSyncState(nextState);
+      return nextState;
     }
-  // Only stable references in deps. googleContacts and setPendingMatchCount
-  // are both stable across renders, so this callback never re-creates.
-  }, [commitSyncState, googleContacts]);
+  }, [autoProcessMatches, commitSyncState, googleContacts]);
 
-  // 15-minute interval. Stable because runSync is stable.
   useEffect(() => {
-    const id = setInterval(runSync, SYNC_INTERVAL_MS);
+    if (!googleContacts) return undefined;
+    const id = setInterval(() => {
+      if (googleContacts.getToken()) {
+        void runSync();
+      }
+    }, SYNC_INTERVAL_MS);
     return () => clearInterval(id);
-  }, [runSync]);
+  }, [googleContacts, runSync]);
 
-  // Re-sync immediately when the user returns to the app.
   useEffect(() => {
-    window.addEventListener("focus", runSync);
-    return () => window.removeEventListener("focus", runSync);
-  }, [runSync]);
+    if (!googleContacts) return undefined;
+    const onFocus = () => {
+      if (googleContacts.getToken()) {
+        void runSync();
+      } else {
+        const current = syncStateRef.current;
+        if (current.authStatus !== "reconnect_required" || current.syncStatus !== "error") {
+          commitSyncState(
+            withError(current, "missing_token", "Reconnect Google to sync contacts."),
+          );
+        }
+      }
+    };
+    window.addEventListener("focus", onFocus);
+    return () => window.removeEventListener("focus", onFocus);
+  }, [commitSyncState, googleContacts, runSync]);
 
   const dismissMatch = useCallback(
     (contactResourceName: string, friendIdOrAuthorId: string) => {
       const current = syncStateRef.current;
-      const dismissed = [
+      const dismissedMatches = [
         ...current.dismissedMatches,
         { contactResourceName, friendIdOrAuthorId },
       ];
       const dismissedSet = new Set(
-        dismissed.map(d => `${d.contactResourceName}:${d.friendIdOrAuthorId}`)
+        dismissedMatches.map(
+          (entry) => `${entry.contactResourceName}:${entry.friendIdOrAuthorId}`,
+        ),
       );
-      const remainingPending = current.pendingMatches.filter((m) => {
-        const potentials = [
-          ...(m.friend ? [m.friend.id] : []),
-          ...m.authorIds,
-        ];
-        return potentials.some(id => !dismissedSet.has(`${m.contact.resourceName}:${id}`));
+      const pendingMatches = current.pendingMatches.filter((match) => {
+        const potentialIds = getPotentialIds(match);
+        return potentialIds.some(
+          (id) => !dismissedSet.has(`${match.contact.resourceName}:${id}`),
+        );
       });
-      const next: ContactSyncState = {
+      commitSyncState({
         ...current,
-        dismissedMatches: dismissed,
-        pendingMatches: remainingPending,
-      };
-      commitSyncState(next);
+        dismissedMatches,
+        pendingMatches,
+      });
     },
-    [commitSyncState]
+    [commitSyncState],
   );
 
   return {

--- a/packages/ui/src/lib/settings-sections.ts
+++ b/packages/ui/src/lib/settings-sections.ts
@@ -14,6 +14,7 @@ export type SectionId =
   | "sync"
   | "updates"
   | "danger"
+  | "googleContacts"
   | "x"
   | "facebook"
   | "instagram"
@@ -92,6 +93,13 @@ export const LI_SECTION_META: SectionMeta = {
   id: "linkedin",
   label: "LinkedIn",
   keywords: ["linkedin", "li", "professional", "feed", "connect", "network", "jobs", "posts"],
+};
+
+/** Shown only when the platform provides a Google Contacts settings component. */
+export const GOOGLE_CONTACTS_SECTION_META: SectionMeta = {
+  id: "googleContacts",
+  label: "Google Contacts",
+  keywords: ["google contacts", "contacts", "people api", "friends", "address book", "connect", "sync"],
 };
 
 /** Shown only when the platform supports factory reset (desktop). */

--- a/website/src/app/roadmap/RoadmapContent.tsx
+++ b/website/src/app/roadmap/RoadmapContent.tsx
@@ -519,7 +519,7 @@ const phases: Phase[] = [
     number: 8,
     title: "Friends + Social Graph",
     description:
-      "A friend CRM with a stable pan-and-zoom graph workspace, a permanent resizable reconnect sidebar, shared purple avatar styling across Friends and Map, and a dark map that shows each friend's latest known location with time-aware popovers. Unify profiles across platforms into one identity per person, track relationship health, restore Google contact matches from desktop snapshots, and keep growing the map into a richer view of where friends were, are, and plan to be.",
+      "A friend CRM with a stable pan-and-zoom graph workspace, a permanent resizable reconnect sidebar, Google Contacts sync and review, shared purple avatar styling across Friends and Map, and a dark map that shows each friend's latest known location with time-aware popovers. Unify profiles across platforms into one identity per person, track relationship health, restore Google contact matches from desktop snapshots, and keep growing the map into a richer view of where friends were, are, and plan to be.",
     status: "current",
     planLink:
       "https://github.com/freed-project/freed/blob/main/docs/PHASE-8-FRIENDS.md",


### PR DESCRIPTION
(AI Generated).

## Summary
- add Google Contacts as a first-class Settings source on desktop and PWA
- unify the Friends import and Settings flows behind shared contact sync state and review actions
- auto-link high-confidence matches, auto-create Friends from high-confidence unlinked authors, and keep ambiguous matches in manual review
- surface reconnect and sync errors instead of failing silently
- update Phase 8 docs and roadmap copy to match the shipped behavior

## Verification
- ./node_modules/.bin/tsc -p packages/shared/tsconfig.json --noEmit
- ./node_modules/.bin/tsc -p packages/ui/tsconfig.json --noEmit
- ./node_modules/.bin/tsc -p packages/desktop/tsconfig.json --noEmit
- npm run typecheck --workspace=@freed/pwa
- npm run test:unit --workspace=@freed/desktop
- npm run test:e2e --workspace=@freed/desktop -- tests/e2e/google-contacts.spec.ts

## Notes
- full workspace typecheck still hits pre-existing unrelated failures in @freed/capture-save
