### PR TITLE
feat: add browser-style navigation history

### DIFF
--- a/docs/PHASE-5-DESKTOP.md
+++ b/docs/PHASE-5-DESKTOP.md
@@ -22,6 +22,7 @@ Large app store distribution is not part of the current strategy. The mobile rea
 - **Provider risk interstitials** — X, Facebook, Instagram, and LinkedIn require separate local consent before login or sync actions
 - **Manual disconnect clears active pauses:** Disconnecting a social provider clears its current pause and resets future backoff escalation, but keeps historical diagnostics intact
 - **Paused providers reuse the primary action:** Settings surfaces swap `Sync Now` to `Resume Now` when a provider is paused, instead of rendering a second resume button
+- **Internal navigation history** — Desktop keeps a browser-style serialized navigation stack so `Cmd+[` and `Cmd+]` move through views and open reader state
 
 ---
 
@@ -191,9 +192,10 @@ export async function captureDomFeed(
 | 5.26 | Independent update server domain   | Medium     |
 | 5.27 | First-run legal gate and local-only acceptance storage | Medium |
 | 5.28 | Provider-specific risk interstitials for social capture | Medium |
-| 5.29 | Reviewed AI-assisted release notes and cumulative daily changelog cards | Medium |
-| 5.30 | Provider health dashboard, charts, and unsubscribe flow | Medium |
-| 5.31 | Rotating local database snapshots + restore UI | Medium |
+| 5.29 | Internal serialized navigation history with `Cmd+[` / `Cmd+]` | Low |
+| 5.30 | Reviewed AI-assisted release notes and cumulative daily changelog cards | Medium |
+| 5.31 | Provider health dashboard, charts, and unsubscribe flow | Medium |
+| 5.32 | Rotating local database snapshots + restore UI | Medium |
 
 ---
 
@@ -219,6 +221,7 @@ export async function captureDomFeed(
 - [x] Legal acceptance stays outside synced Automerge state
 - [x] Freed Desktop keeps rotating local database snapshots with a restore flow in Settings
 - [x] Desktop E2E test infrastructure bootstrapped (Playwright + VITE_TEST_TAURI=1 mock layer)
+- [x] Desktop navigation history supports browser-style back and forward shortcuts for views and reader state
 - [x] Performance benchmarks: MiniSearch lazy-build fix reduces markAsRead from ~300ms to ~30ms (10x)
 - [x] macOS DMG is notarized in CI releases
 - [x] Checked-in release notes are reviewed before a release tag can publish

--- a/docs/PHASE-6-PWA.md
+++ b/docs/PHASE-6-PWA.md
@@ -16,6 +16,7 @@ Mobile companion to Freed Desktop for on-the-go reading. Timeline-focused, minim
 - **Light saves** — Can save URLs with metadata extraction (og tags); full article extraction requires Desktop
 - **Offline-first** — Service worker caches feed data and images for offline reading
 - **Versioned first-run consent** — PWA startup is blocked until the current legal bundle is accepted locally in the browser
+- **URL-driven navigation** — Active view, feed scope, and open reader state serialize into the URL so browser back and forward behave naturally
 
 ---
 
@@ -208,6 +209,7 @@ export function filterByAuthor(
 | 6.12 | Offline support + image caching        | High       |
 | 6.13 | Add to homescreen prompt               | Low        |
 | 6.14 | First-run legal gate with local-only acceptance storage | Low |
+| 6.15 | URL navigation state with browser back/forward support | Low |
 
 ---
 
@@ -234,6 +236,7 @@ Build chain: `@freed/shared` → `@freed/sync` → `vite build` (configured in `
 - [x] RSS source accordion pages subscriptions in the sidebar and top search moves matching feeds into the first page
 - [x] RSS subscription management functional (add/remove/OPML import-export)
 - [x] First launch is blocked behind a local-only legal clickwrap gate
+- [x] Active view, feed filters, and reader selection round-trip through the URL for browser back/forward navigation
 - [ ] PWA installable on mobile (add to homescreen) — manifest exists, needs testing
 - [ ] Offline access works (service worker + image cache) — SW registered, image cache pending
 

--- a/packages/desktop/src/App.tsx
+++ b/packages/desktop/src/App.tsx
@@ -62,6 +62,7 @@ import { clearProviderPause, forgetRssFeedHealth, initProviderHealth } from "./l
 import { getDesktopSourceStatus } from "./lib/source-status";
 import { clearContactSyncState } from "./lib/contact-sync-storage";
 import { clearSnapshots, startSnapshotManager, stopSnapshotManager } from "./lib/snapshots";
+import { useDesktopNavigationHistory } from "./lib/navigation-history";
 
 const UPDATE_CHECK_INTERVAL_MS = 30 * 60 * 1000; // 30 minutes
 const JUST_UPDATED_KEY = "freed-updated-to";
@@ -92,6 +93,8 @@ function App() {
   const error = useAppStore((state) => state.error);
   const [legalResolved, setLegalResolved] = useState(false);
   const [legalAccepted, setLegalAccepted] = useState(false);
+
+  useDesktopNavigationHistory(legalAccepted);
 
   useEffect(() => {
     void hasAcceptedDesktopBundle()

--- a/packages/desktop/src/components/CloudSyncNudge.tsx
+++ b/packages/desktop/src/components/CloudSyncNudge.tsx
@@ -29,7 +29,7 @@ export function CloudSyncNudge() {
   if (dismissed || hasAnyCloudProvider()) return null;
 
   return (
-    <div className="fixed bottom-4 left-1/2 -translate-x-1/2 z-40 flex items-center gap-3 px-4 py-3 rounded-xl bg-[#1c1c1e] border border-[rgba(255,255,255,0.1)] shadow-2xl text-sm max-w-sm w-[calc(100%-2rem)]">
+    <div className="fixed bottom-4 left-4 right-4 z-40 flex items-center gap-3 px-4 py-3 rounded-xl bg-[#1c1c1e] border border-[rgba(255,255,255,0.1)] shadow-2xl text-sm max-w-sm sm:left-auto sm:right-4 sm:w-full">
       {/* Cloud icon */}
       <svg
         className="w-4 h-4 text-[#8b5cf6] flex-shrink-0"

--- a/packages/desktop/src/lib/navigation-history.ts
+++ b/packages/desktop/src/lib/navigation-history.ts
@@ -1,0 +1,134 @@
+import { useEffect, useRef } from "react";
+import {
+  canonicalizeNavigationState,
+  navigationStatesEqual,
+  parseNavigationState,
+  serializeNavigationState,
+  type NavigationState,
+} from "@freed/shared";
+import { useAppStore } from "./store";
+
+function snapshotNavigationState(): NavigationState {
+  const state = useAppStore.getState();
+  return {
+    activeView: state.activeView,
+    activeFilter: state.activeFilter,
+    selectedItemId: state.selectedItemId,
+  };
+}
+
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  const tagName = target.tagName;
+  return (
+    target.isContentEditable
+    || tagName === "INPUT"
+    || tagName === "TEXTAREA"
+    || tagName === "SELECT"
+  );
+}
+
+export function useDesktopNavigationHistory(enabled: boolean): void {
+  const activeView = useAppStore((state) => state.activeView);
+  const activeFilter = useAppStore((state) => state.activeFilter);
+  const selectedItemId = useAppStore((state) => state.selectedItemId);
+  const isInitialized = useAppStore((state) => state.isInitialized);
+  const items = useAppStore((state) => state.items);
+
+  const historyStackRef = useRef<string[]>([]);
+  const historyIndexRef = useRef(-1);
+  const skipRecordRef = useRef(false);
+  const recordTimerRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (!event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) return;
+      if (isEditableTarget(event.target)) return;
+
+      if (event.code === "BracketLeft" || event.key === "[") {
+        if (historyIndexRef.current <= 0) return;
+        event.preventDefault();
+        skipRecordRef.current = true;
+        historyIndexRef.current -= 1;
+        const nextState = parseNavigationState(historyStackRef.current[historyIndexRef.current]);
+        useAppStore.setState({
+          activeView: nextState.activeView,
+          activeFilter: nextState.activeFilter,
+          selectedItemId: nextState.selectedItemId,
+          selectedFriendId: null,
+        });
+      } else if (event.code === "BracketRight" || event.key === "]") {
+        if (historyIndexRef.current >= historyStackRef.current.length - 1) return;
+        event.preventDefault();
+        skipRecordRef.current = true;
+        historyIndexRef.current += 1;
+        const nextState = parseNavigationState(historyStackRef.current[historyIndexRef.current]);
+        useAppStore.setState({
+          activeView: nextState.activeView,
+          activeFilter: nextState.activeFilter,
+          selectedItemId: nextState.selectedItemId,
+          selectedFriendId: null,
+        });
+      }
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [enabled]);
+
+  useEffect(() => {
+    if (!enabled || !isInitialized || !selectedItemId) return;
+    if (items.some((item) => item.globalId === selectedItemId)) return;
+
+    useAppStore.setState({ selectedItemId: null });
+  }, [enabled, isInitialized, items, selectedItemId]);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    if (recordTimerRef.current !== null) {
+      window.clearTimeout(recordTimerRef.current);
+    }
+
+    recordTimerRef.current = window.setTimeout(() => {
+      recordTimerRef.current = null;
+
+      if (skipRecordRef.current) {
+        skipRecordRef.current = false;
+        return;
+      }
+
+      const rawState = snapshotNavigationState();
+      const knownItemIds = isInitialized ? new Set(items.map((item) => item.globalId)) : null;
+      const canonicalState = canonicalizeNavigationState(rawState, { knownItemIds });
+      const serialized = serializeNavigationState(canonicalState);
+
+      if (!navigationStatesEqual(rawState, canonicalState)) {
+        useAppStore.setState({
+          activeView: canonicalState.activeView,
+          activeFilter: canonicalState.activeFilter,
+          selectedItemId: canonicalState.selectedItemId,
+        });
+      }
+
+      const currentSerialized = historyStackRef.current[historyIndexRef.current];
+      if (currentSerialized === serialized) return;
+
+      if (historyIndexRef.current < historyStackRef.current.length - 1) {
+        historyStackRef.current = historyStackRef.current.slice(0, historyIndexRef.current + 1);
+      }
+
+      historyStackRef.current.push(serialized);
+      historyIndexRef.current = historyStackRef.current.length - 1;
+    }, 0);
+
+    return () => {
+      if (recordTimerRef.current !== null) {
+        window.clearTimeout(recordTimerRef.current);
+        recordTimerRef.current = null;
+      }
+    };
+  }, [activeFilter, activeView, enabled, isInitialized, items, selectedItemId]);
+}

--- a/packages/desktop/src/lib/navigation-history.ts
+++ b/packages/desktop/src/lib/navigation-history.ts
@@ -95,15 +95,19 @@ export function useDesktopNavigationHistory(enabled: boolean): void {
     recordTimerRef.current = window.setTimeout(() => {
       recordTimerRef.current = null;
 
-      if (skipRecordRef.current) {
-        skipRecordRef.current = false;
-        return;
-      }
-
       const rawState = snapshotNavigationState();
       const knownItemIds = isInitialized ? new Set(items.map((item) => item.globalId)) : null;
       const canonicalState = canonicalizeNavigationState(rawState, { knownItemIds });
       const serialized = serializeNavigationState(canonicalState);
+      const currentSerialized = historyStackRef.current[historyIndexRef.current];
+
+      if (skipRecordRef.current) {
+        skipRecordRef.current = false;
+        if (historyIndexRef.current >= 0 && currentSerialized !== serialized) {
+          historyStackRef.current[historyIndexRef.current] = serialized;
+        }
+        return;
+      }
 
       if (!navigationStatesEqual(rawState, canonicalState)) {
         useAppStore.setState({
@@ -113,7 +117,6 @@ export function useDesktopNavigationHistory(enabled: boolean): void {
         });
       }
 
-      const currentSerialized = historyStackRef.current[historyIndexRef.current];
       if (currentSerialized === serialized) return;
 
       if (historyIndexRef.current < historyStackRef.current.length - 1) {

--- a/packages/desktop/tests/e2e/smoke.spec.ts
+++ b/packages/desktop/tests/e2e/smoke.spec.ts
@@ -331,7 +331,7 @@ test("Map view supports popup navigation into Friends and Feed", async ({ app })
 
   const { page } = app;
 
-  await page.getByRole("button", { name: /^Map\b/ }).click();
+  await page.getByRole("button", { name: /^Map/ }).click();
   await page.waitForFunction(() => {
     const w = window as Record<string, unknown>;
     const store = w.__FREED_STORE__ as
@@ -352,7 +352,7 @@ test("Map view supports popup navigation into Friends and Feed", async ({ app })
   }, { timeout: 5_000 });
   await expect(page.locator("main").getByText("Ada Lovelace").first()).toBeVisible({ timeout: 5_000 });
 
-  await page.getByRole("button", { name: /^Map\b/ }).click();
+  await page.getByRole("button", { name: /^Map/ }).click();
   await page.locator(".freed-map-marker").first().click();
   await page.getByRole("button", { name: "Open Post" }).click();
   await page.waitForFunction(() => {
@@ -402,7 +402,9 @@ test("Friend detail last seen card opens the full Map view", async ({ app }) => 
     const state = store?.getState();
     return state?.activeView === "map" && state.selectedFriendId === "friend-ada";
   }, { timeout: 5_000 });
-  await expect(page.locator('.freed-map-marker[aria-label="Ada Lovelace"]')).toBeVisible({ timeout: 5_000 });
+  await expect(page.getByRole("button", { name: /Ada Lovelace/ })).toBeVisible({
+    timeout: 5_000,
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/desktop/tests/e2e/smoke.spec.ts
+++ b/packages/desktop/tests/e2e/smoke.spec.ts
@@ -190,6 +190,73 @@ test("Friends view can return to the feed from sidebar navigation", async ({ app
   await expect(page.getByText("Article 0:", { exact: false })).toBeVisible({ timeout: 5_000 });
 });
 
+test("desktop navigation history supports Cmd+[ and Cmd+] across views", async ({ app }) => {
+  await app.goto();
+  await app.waitForReady();
+  await app.injectRssItems(1);
+
+  const { page } = app;
+
+  await page.getByRole("button", { name: "Friends" }).click();
+  await page.waitForFunction(() => {
+    const store = (window as Record<string, unknown>).__FREED_STORE__ as
+      | { getState: () => { activeView: string } }
+      | undefined;
+    return store?.getState().activeView === "friends";
+  }, { timeout: 5_000 });
+
+  await page.keyboard.press("Meta+[");
+  await page.waitForFunction(() => {
+    const store = (window as Record<string, unknown>).__FREED_STORE__ as
+      | { getState: () => { activeView: string } }
+      | undefined;
+    return store?.getState().activeView === "feed";
+  }, { timeout: 5_000 });
+
+  await page.keyboard.press("Meta+]");
+  await page.waitForFunction(() => {
+    const store = (window as Record<string, unknown>).__FREED_STORE__ as
+      | { getState: () => { activeView: string } }
+      | undefined;
+    return store?.getState().activeView === "friends";
+  }, { timeout: 5_000 });
+});
+
+test("desktop reader history supports Cmd+[ and Cmd+] for open items", async ({ app }) => {
+  await app.goto();
+  await app.waitForReady();
+  await app.injectRssItems(1);
+
+  const { page } = app;
+  await page.getByText("Article 0:", { exact: false }).click();
+
+  await page.waitForFunction(() => {
+    const store = (window as Record<string, unknown>).__FREED_STORE__ as
+      | { getState: () => { selectedItemId: string | null } }
+      | undefined;
+    return store?.getState().selectedItemId !== null;
+  }, { timeout: 5_000 });
+  await expect(page.getByLabel("Back")).toBeVisible({ timeout: 5_000 });
+
+  await page.keyboard.press("Meta+[");
+  await page.waitForFunction(() => {
+    const store = (window as Record<string, unknown>).__FREED_STORE__ as
+      | { getState: () => { selectedItemId: string | null } }
+      | undefined;
+    return store?.getState().selectedItemId === null;
+  }, { timeout: 5_000 });
+  await expect(page.getByLabel("Back")).toHaveCount(0);
+
+  await page.keyboard.press("Meta+]");
+  await page.waitForFunction(() => {
+    const store = (window as Record<string, unknown>).__FREED_STORE__ as
+      | { getState: () => { selectedItemId: string | null } }
+      | undefined;
+    return store?.getState().selectedItemId !== null;
+  }, { timeout: 5_000 });
+  await expect(page.getByLabel("Back")).toBeVisible({ timeout: 5_000 });
+});
+
 test("Friends workspace keeps a visible sidebar and supports back navigation", async ({ app }) => {
   await app.goto();
   await app.waitForReady();

--- a/packages/desktop/tests/e2e/smoke.spec.ts
+++ b/packages/desktop/tests/e2e/smoke.spec.ts
@@ -24,6 +24,15 @@ async function dismissCloudSyncNudgeIfPresent(page: Page) {
     await dismissButton.click();
   }
 }
+
+async function clickMapPopupAction(page: Page, actionName: "Open Friend" | "Open Post") {
+  const actionButton = page.getByRole("button", { name: actionName });
+  await expect(actionButton).toBeVisible({ timeout: 5_000 });
+  await actionButton.evaluate((button) => {
+    (button as HTMLButtonElement).click();
+  });
+}
+
 const SETTINGS_STORE_PATH = resolveViteFsModulePath(
   "../../../ui/src/lib/settings-store.ts",
   import.meta.url,
@@ -341,7 +350,7 @@ test("Map view supports popup navigation into Friends and Feed", async ({ app })
   }, { timeout: 5_000 });
 
   await page.locator(".freed-map-marker").first().click();
-  await page.getByRole("button", { name: "Open Friend" }).click();
+  await clickMapPopupAction(page, "Open Friend");
   await page.waitForFunction(() => {
     const w = window as Record<string, unknown>;
     const store = w.__FREED_STORE__ as
@@ -354,7 +363,7 @@ test("Map view supports popup navigation into Friends and Feed", async ({ app })
 
   await page.getByRole("button", { name: /^Map/ }).click();
   await page.locator(".freed-map-marker").first().click();
-  await page.getByRole("button", { name: "Open Post" }).click();
+  await clickMapPopupAction(page, "Open Post");
   await page.waitForFunction(() => {
     const w = window as Record<string, unknown>;
     const store = w.__FREED_STORE__ as

--- a/packages/pwa/src/App.tsx
+++ b/packages/pwa/src/App.tsx
@@ -31,6 +31,7 @@ import { PwaXSettings } from "./components/PwaXSettings";
 import { PwaLegalSettingsSection } from "./components/PwaLegalSettingsSection";
 import { initiateGDriveOAuth } from "./components/SyncConnectDialog";
 import { acceptPwaBundle, hasAcceptedPwaBundle } from "./lib/legal-consent";
+import { useBrowserNavigationHistory } from "./lib/navigation-history";
 
 function App() {
   // Intercept OAuth callback before rendering the main app.
@@ -44,6 +45,8 @@ function App() {
   const [showUpdateBanner, setShowUpdateBanner] = useState(false);
   const [legalResolved, setLegalResolved] = useState(false);
   const [legalAccepted, setLegalAccepted] = useState(false);
+
+  useBrowserNavigationHistory(legalAccepted);
 
   useEffect(() => {
     setLegalAccepted(hasAcceptedPwaBundle());

--- a/packages/pwa/src/lib/navigation-history.ts
+++ b/packages/pwa/src/lib/navigation-history.ts
@@ -1,0 +1,108 @@
+import { useEffect, useLayoutEffect, useRef } from "react";
+import {
+  canonicalizeNavigationState,
+  navigationStatesEqual,
+  parseNavigationState,
+  serializeNavigationState,
+  type NavigationState,
+} from "@freed/shared";
+import { useAppStore } from "./store";
+
+function currentPathWithSearch(): string {
+  return `${window.location.pathname}${window.location.search}`;
+}
+
+function snapshotNavigationState(): NavigationState {
+  const state = useAppStore.getState();
+  return {
+    activeView: state.activeView,
+    activeFilter: state.activeFilter,
+    selectedItemId: state.selectedItemId,
+  };
+}
+
+export function useBrowserNavigationHistory(enabled: boolean): void {
+  const activeView = useAppStore((state) => state.activeView);
+  const activeFilter = useAppStore((state) => state.activeFilter);
+  const selectedItemId = useAppStore((state) => state.selectedItemId);
+  const isInitialized = useAppStore((state) => state.isInitialized);
+  const items = useAppStore((state) => state.items);
+
+  const bootstrappedRef = useRef(false);
+  const skipWriteRef = useRef(false);
+  const writeTimerRef = useRef<number | null>(null);
+
+  useLayoutEffect(() => {
+    if (!enabled || bootstrappedRef.current) return;
+
+    const parsed = parseNavigationState(window.location);
+    useAppStore.setState({
+      activeView: parsed.activeView,
+      activeFilter: parsed.activeFilter,
+      selectedItemId: parsed.selectedItemId,
+      selectedFriendId: null,
+    });
+    window.history.replaceState(window.history.state, "", serializeNavigationState(parsed));
+    bootstrappedRef.current = true;
+  }, [enabled]);
+
+  useEffect(() => {
+    if (!enabled || !bootstrappedRef.current) return;
+
+    const onPopState = () => {
+      const parsed = parseNavigationState(window.location);
+      skipWriteRef.current = true;
+      useAppStore.setState({
+        activeView: parsed.activeView,
+        activeFilter: parsed.activeFilter,
+        selectedItemId: parsed.selectedItemId,
+        selectedFriendId: null,
+      });
+    };
+
+    window.addEventListener("popstate", onPopState);
+    return () => window.removeEventListener("popstate", onPopState);
+  }, [enabled]);
+
+  useEffect(() => {
+    if (!enabled || !bootstrappedRef.current || !isInitialized || !selectedItemId) return;
+    if (items.some((item) => item.globalId === selectedItemId)) return;
+
+    useAppStore.setState({ selectedItemId: null });
+  }, [enabled, isInitialized, items, selectedItemId]);
+
+  useEffect(() => {
+    if (!enabled || !bootstrappedRef.current) return;
+
+    if (writeTimerRef.current !== null) {
+      window.clearTimeout(writeTimerRef.current);
+    }
+
+    writeTimerRef.current = window.setTimeout(() => {
+      writeTimerRef.current = null;
+
+      if (skipWriteRef.current) {
+        skipWriteRef.current = false;
+        return;
+      }
+
+      const knownItemIds = isInitialized ? new Set(items.map((item) => item.globalId)) : null;
+      const rawState = snapshotNavigationState();
+      const canonicalState = canonicalizeNavigationState(rawState, { knownItemIds });
+      const nextUrl = serializeNavigationState(canonicalState);
+      const currentUrl = currentPathWithSearch();
+
+      if (nextUrl === currentUrl) return;
+
+      const shouldReplace = !navigationStatesEqual(rawState, canonicalState);
+      window.history[shouldReplace ? "replaceState" : "pushState"](window.history.state, "", nextUrl);
+    }, 0);
+
+    return () => {
+      if (writeTimerRef.current !== null) {
+        window.clearTimeout(writeTimerRef.current);
+        writeTimerRef.current = null;
+      }
+    };
+  }, [activeFilter, activeView, enabled, isInitialized, items, selectedItemId]);
+}

--- a/packages/pwa/src/lib/navigation-history.ts
+++ b/packages/pwa/src/lib/navigation-history.ts
@@ -81,16 +81,19 @@ export function useBrowserNavigationHistory(enabled: boolean): void {
     writeTimerRef.current = window.setTimeout(() => {
       writeTimerRef.current = null;
 
-      if (skipWriteRef.current) {
-        skipWriteRef.current = false;
-        return;
-      }
-
       const knownItemIds = isInitialized ? new Set(items.map((item) => item.globalId)) : null;
       const rawState = snapshotNavigationState();
       const canonicalState = canonicalizeNavigationState(rawState, { knownItemIds });
       const nextUrl = serializeNavigationState(canonicalState);
       const currentUrl = currentPathWithSearch();
+
+      if (skipWriteRef.current) {
+        skipWriteRef.current = false;
+        if (nextUrl !== currentUrl) {
+          window.history.replaceState(window.history.state, "", nextUrl);
+        }
+        return;
+      }
 
       if (nextUrl === currentUrl) return;
 

--- a/packages/pwa/tests/app.spec.ts
+++ b/packages/pwa/tests/app.spec.ts
@@ -92,7 +92,9 @@ async function seedSidebarFeeds(
         }
       }, 50);
     });
-=======
+  });
+}
+
 async function waitForPwaReady(
   page: import("@playwright/test").Page,
 ): Promise<void> {
@@ -905,6 +907,30 @@ test.describe("FREED PWA", () => {
       });
     });
 
+    test("stale item cleanup replaces the current history entry", async ({ page }) => {
+      await page.goto("/friends");
+      await acceptLegalGate(page);
+      await waitForPwaReady(page);
+      await expect.poll(() => new URL(page.url()).pathname).toBe("/friends");
+
+      await page.evaluate(() => {
+        window.history.pushState(window.history.state, "", "/?item=missing-item");
+        window.dispatchEvent(new PopStateEvent("popstate"));
+      });
+      await expect.poll(() => new URL(page.url()).search).toBe("");
+
+      await page.goBack();
+      await page.waitForFunction(() => {
+        const store = (window as Record<string, unknown>).__FREED_STORE__ as {
+          getState: () => { activeView: string; selectedItemId: string | null };
+        };
+        const state = store.getState();
+        return state.activeView === "friends" && state.selectedItemId === null;
+      });
+      await expect.poll(() => new URL(page.url()).pathname).toBe("/friends");
+      await expect.poll(() => new URL(page.url()).search).toBe("");
+    });
+
     test("feed filter URLs restore the correct scope on direct load", async ({ page }) => {
       await page.goto("/");
       await acceptLegalGate(page);
@@ -938,7 +964,6 @@ test.describe("FREED PWA", () => {
           tags: ["research"],
         });
     });
-  });
   });
 
   test("map navigation is live from the sidebar", async ({ page }) => {

--- a/packages/pwa/tests/app.spec.ts
+++ b/packages/pwa/tests/app.spec.ts
@@ -92,6 +92,15 @@ async function seedSidebarFeeds(
         }
       }, 50);
     });
+=======
+async function waitForPwaReady(
+  page: import("@playwright/test").Page,
+): Promise<void> {
+  await page.waitForFunction(() => {
+    const store = (window as Record<string, unknown>).__FREED_STORE__ as {
+      getState: () => { isInitialized: boolean };
+    };
+    return store.getState().isInitialized === true;
   });
 }
 
@@ -496,6 +505,162 @@ async function getLibraryCounts(
   });
 }
 
+const NAV_FEED_URL = "https://example.com/navigation.xml";
+
+async function seedNavigationFeed(
+  page: import("@playwright/test").Page,
+): Promise<void> {
+  await page.evaluate(async (feedUrl: string) => {
+    const w = window as Record<string, unknown>;
+    const automerge = w.__FREED_AUTOMERGE__ as {
+      docAddRssFeed: (feed: unknown) => Promise<void>;
+      docAddFeedItems: (items: unknown[]) => Promise<void>;
+    };
+    const store = w.__FREED_STORE__ as {
+      getState: () => {
+        feeds: Record<string, unknown>;
+        items: Array<{ globalId: string }>;
+      };
+    };
+
+    const now = Date.now();
+    await automerge.docAddRssFeed({
+      url: feedUrl,
+      title: "Navigation Feed",
+      siteUrl: "https://example.com",
+      enabled: true,
+      trackUnread: true,
+      lastFetched: now,
+    });
+
+    await automerge.docAddFeedItems([
+      {
+        globalId: "rss:navigation:1",
+        platform: "rss",
+        contentType: "article",
+        capturedAt: now,
+        publishedAt: now - 60_000,
+        author: {
+          id: "nav-feed",
+          handle: "nav-feed",
+          displayName: "Navigation Feed",
+        },
+        content: {
+          text: "Navigation item one",
+          mediaUrls: [],
+          mediaTypes: [],
+          linkPreview: {
+            url: "https://example.com/navigation-1",
+            title: "Navigation Item One",
+            description: "First navigation test article",
+          },
+        },
+        rssSource: {
+          feedUrl,
+          feedTitle: "Navigation Feed",
+          siteUrl: "https://example.com",
+        },
+        userState: {
+          hidden: false,
+          saved: false,
+          archived: false,
+          tags: ["research", "alpha"],
+        },
+        topics: [],
+        sourceUrl: "https://example.com/navigation-1",
+      },
+      {
+        globalId: "rss:navigation:2",
+        platform: "rss",
+        contentType: "article",
+        capturedAt: now,
+        publishedAt: now - 120_000,
+        author: {
+          id: "nav-feed",
+          handle: "nav-feed",
+          displayName: "Navigation Feed",
+        },
+        content: {
+          text: "Navigation item two",
+          mediaUrls: [],
+          mediaTypes: [],
+          linkPreview: {
+            url: "https://example.com/navigation-2",
+            title: "Navigation Item Two",
+            description: "Second navigation test article",
+          },
+        },
+        rssSource: {
+          feedUrl,
+          feedTitle: "Navigation Feed",
+          siteUrl: "https://example.com",
+        },
+        userState: {
+          hidden: false,
+          saved: true,
+          savedAt: now - 30_000,
+          archived: false,
+          tags: ["research"],
+        },
+        topics: [],
+        sourceUrl: "https://example.com/navigation-2",
+      },
+      {
+        globalId: "rss:navigation:3",
+        platform: "rss",
+        contentType: "article",
+        capturedAt: now,
+        publishedAt: now - 180_000,
+        author: {
+          id: "nav-feed",
+          handle: "nav-feed",
+          displayName: "Navigation Feed",
+        },
+        content: {
+          text: "Archived navigation item",
+          mediaUrls: [],
+          mediaTypes: [],
+          linkPreview: {
+            url: "https://example.com/navigation-3",
+            title: "Archived Navigation Item",
+            description: "Archived navigation test article",
+          },
+        },
+        rssSource: {
+          feedUrl,
+          feedTitle: "Navigation Feed",
+          siteUrl: "https://example.com",
+        },
+        userState: {
+          hidden: false,
+          saved: false,
+          archived: true,
+          archivedAt: now - 10_000,
+          tags: ["archive"],
+        },
+        topics: [],
+        sourceUrl: "https://example.com/navigation-3",
+      },
+    ]);
+
+    await new Promise<void>((resolve, reject) => {
+      const startedAt = Date.now();
+      const interval = window.setInterval(() => {
+        const state = store.getState();
+        if (state.feeds[feedUrl] && state.items.some((item) => item.globalId === "rss:navigation:1")) {
+          clearInterval(interval);
+          resolve();
+          return;
+        }
+        if (Date.now() - startedAt > 5_000) {
+          clearInterval(interval);
+          reject(new Error("navigation seed timeout"));
+        }
+      }, 50);
+    });
+  }, NAV_FEED_URL);
+}
+
 test.describe("FREED PWA", () => {
   test("first load blocks the app shell until legal consent is accepted", async ({
     page,
@@ -631,6 +796,149 @@ test.describe("FREED PWA", () => {
     await expect(page.getByText("11 to 12 of 12")).toHaveCount(0);
     await expect(page.getByRole("button", { name: "Next feeds page" })).toHaveCount(0);
     await expect(page.getByRole("button", { name: "Alpha Dispatch" })).toHaveCount(0);
+  });
+
+  test.describe.serial("URL history", () => {
+    test("loads the Friends view directly from the URL", async ({ page }) => {
+      await page.goto("/friends");
+      await acceptLegalGate(page);
+      await waitForPwaReady(page);
+
+      await page.waitForFunction(() => {
+        const store = (window as Record<string, unknown>).__FREED_STORE__ as {
+          getState: () => { activeView: string };
+        };
+        return store.getState().activeView === "friends";
+      });
+      await expect(page.getByRole("button", { name: /import contacts/i })).toBeVisible();
+    });
+
+    test("browser history tracks top-level view navigation", async ({ page }) => {
+      await page.goto("/");
+      await acceptLegalGate(page);
+      await waitForPwaReady(page);
+
+      await page.locator("aside").getByRole("button", { name: "Friends" }).click({ force: true });
+      await expect.poll(() => new URL(page.url()).pathname).toBe("/friends");
+
+      await page.goBack();
+      await page.waitForFunction(() => {
+        const store = (window as Record<string, unknown>).__FREED_STORE__ as {
+          getState: () => { activeView: string };
+        };
+        return store.getState().activeView === "feed";
+      });
+      await expect.poll(() => new URL(page.url()).pathname).toBe("/");
+
+      await page.goForward();
+      await page.waitForFunction(() => {
+        const store = (window as Record<string, unknown>).__FREED_STORE__ as {
+          getState: () => { activeView: string };
+        };
+        return store.getState().activeView === "friends";
+      });
+      await expect.poll(() => new URL(page.url()).pathname).toBe("/friends");
+    });
+
+    test("feed filters update the URL and restore with browser history", async ({ page }) => {
+      await page.goto("/");
+      await acceptLegalGate(page);
+      await waitForPwaReady(page);
+      await seedNavigationFeed(page);
+
+      const sidebar = page.locator("aside");
+
+      await sidebar.getByRole("button", { name: /^RSS/ }).click();
+      await expect.poll(() => new URL(page.url()).search).toBe("?platform=rss");
+
+      await sidebar.getByRole("button", { name: "Saved" }).click();
+      await expect.poll(() => new URL(page.url()).search).toBe("?scope=saved");
+
+      await page.goBack();
+      await expect.poll(() => new URL(page.url()).search).toBe("?platform=rss");
+
+      await sidebar.getByRole("button", { name: "research" }).click();
+      await expect
+        .poll(() => new URL(page.url()).searchParams.getAll("tag"))
+        .toEqual(["research"]);
+
+      await sidebar.getByRole("button", { name: /^Feeds/ }).click();
+      await sidebar.getByRole("button", { name: /Navigation Feed/ }).click();
+      await expect
+        .poll(() => new URL(page.url()).searchParams.get("feed"))
+        .toBe(NAV_FEED_URL);
+
+      await sidebar.getByRole("button", { name: "Archived" }).click();
+      await expect.poll(() => new URL(page.url()).search).toBe("?scope=archived");
+    });
+
+    test("reader selection syncs to item history and restores with browser forward", async ({ page }) => {
+      await page.goto("/");
+      await acceptLegalGate(page);
+      await waitForPwaReady(page);
+      await seedNavigationFeed(page);
+
+      await page.locator(".feed-card").filter({ hasText: "Navigation Item One" }).first().click();
+      await expect(page.getByLabel("Back")).toBeVisible();
+      await expect.poll(() => new URL(page.url()).search).toBe("?item=rss%3Anavigation%3A1");
+
+      await page.goBack();
+      await expect(page.getByLabel("Back")).toHaveCount(0);
+      await expect.poll(() => new URL(page.url()).search).toBe("");
+
+      await page.goForward();
+      await expect(page.getByLabel("Back")).toBeVisible();
+      await expect.poll(() => new URL(page.url()).search).toBe("?item=rss%3Anavigation%3A1");
+    });
+
+    test("stale item URLs are cleaned up after initialization", async ({ page }) => {
+      await page.goto("/?item=missing-item");
+      await acceptLegalGate(page);
+      await waitForPwaReady(page);
+
+      await expect.poll(() => new URL(page.url()).search).toBe("");
+      await page.waitForFunction(() => {
+        const store = (window as Record<string, unknown>).__FREED_STORE__ as {
+          getState: () => { selectedItemId: string | null };
+        };
+        return store.getState().selectedItemId === null;
+      });
+    });
+
+    test("feed filter URLs restore the correct scope on direct load", async ({ page }) => {
+      await page.goto("/");
+      await acceptLegalGate(page);
+      await waitForPwaReady(page);
+      await seedNavigationFeed(page);
+
+      await page.goto(`/?feed=${encodeURIComponent(NAV_FEED_URL)}&tag=research`);
+      await waitForPwaReady(page);
+      await page.waitForFunction((feedUrl: string) => {
+        const store = (window as Record<string, unknown>).__FREED_STORE__ as {
+          getState: () => {
+            activeFilter: {
+              platform?: string;
+              feedUrl?: string;
+              tags?: string[];
+            };
+          };
+        };
+        const filter = store.getState().activeFilter;
+        return filter.platform === "rss"
+          && filter.feedUrl === feedUrl
+          && (filter.tags ?? []).includes("research");
+      }, NAV_FEED_URL);
+      await expect
+        .poll(() => ({
+          feed: new URL(page.url()).searchParams.get("feed"),
+          tags: new URL(page.url()).searchParams.getAll("tag"),
+        }))
+        .toEqual({
+          feed: NAV_FEED_URL,
+          tags: ["research"],
+        });
+    });
+  });
   });
 
   test("map navigation is live from the sidebar", async ({ page }) => {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -18,6 +18,7 @@ export * from "./focus-text";
 
 // Re-export store types (browser-safe, no deps)
 export * from "./store-types";
+export * from "./navigation-state";
 
 // Re-export friends identity resolution and CRM utilities (browser-safe, no deps)
 export * from "./friends";

--- a/packages/shared/src/navigation-state.ts
+++ b/packages/shared/src/navigation-state.ts
@@ -1,0 +1,178 @@
+import type { BaseAppState, FilterOptions } from "./store-types.js";
+
+export type NavigationView = BaseAppState["activeView"];
+
+export interface NavigationState {
+  activeView: NavigationView;
+  activeFilter: FilterOptions;
+  selectedItemId: string | null;
+}
+
+interface NavigationPathLike {
+  pathname: string;
+  search: string;
+}
+
+interface CanonicalizeOptions {
+  knownItemIds?: ReadonlySet<string> | null;
+}
+
+function normalizeText(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+function uniqueSortedTags(tags: readonly string[] | undefined): string[] {
+  if (!tags?.length) return [];
+  return Array.from(new Set(tags.map((tag) => tag.trim()).filter(Boolean))).sort((a, b) =>
+    a.localeCompare(b),
+  );
+}
+
+export function canonicalizeFilterOptions(filter: FilterOptions): FilterOptions {
+  if (filter.savedOnly) return { savedOnly: true };
+  if (filter.archivedOnly) return { archivedOnly: true };
+
+  const tags = uniqueSortedTags(filter.tags);
+  const feedUrl = normalizeText(filter.feedUrl);
+  const platform = feedUrl ? "rss" : normalizeText(filter.platform) ?? undefined;
+  const next: FilterOptions = {};
+
+  if (platform) next.platform = platform;
+  if (feedUrl) next.feedUrl = feedUrl;
+  if (tags.length > 0) next.tags = tags;
+
+  return next;
+}
+
+export function canonicalizeNavigationState(
+  state: NavigationState,
+  options: CanonicalizeOptions = {},
+): NavigationState {
+  const knownItemIds = options.knownItemIds ?? null;
+  const activeView: NavigationView =
+    state.activeView === "friends" || state.activeView === "map" ? state.activeView : "feed";
+
+  if (activeView !== "feed") {
+    return {
+      activeView,
+      activeFilter: {},
+      selectedItemId: null,
+    };
+  }
+
+  const activeFilter = canonicalizeFilterOptions(state.activeFilter);
+  const selectedItemId = normalizeText(state.selectedItemId);
+  const hasKnownItems = options.knownItemIds !== undefined;
+  const isKnownItem = !selectedItemId
+    || !hasKnownItems
+    || knownItemIds === null
+    || knownItemIds.has(selectedItemId);
+
+  return {
+    activeView,
+    activeFilter,
+    selectedItemId: isKnownItem ? selectedItemId : null,
+  };
+}
+
+export function parseNavigationState(input: string | NavigationPathLike): NavigationState {
+  const parsed =
+    typeof input === "string"
+      ? new URL(input, "https://freed.invalid")
+      : new URL(`${input.pathname}${input.search}`, "https://freed.invalid");
+
+  let activeView: NavigationView = "feed";
+  if (parsed.pathname === "/friends") activeView = "friends";
+  else if (parsed.pathname === "/map") activeView = "map";
+
+  if (activeView !== "feed") {
+    return {
+      activeView,
+      activeFilter: {},
+      selectedItemId: null,
+    };
+  }
+
+  const params = parsed.searchParams;
+  const scope = normalizeText(params.get("scope"));
+  const feedUrl = normalizeText(params.get("feed"));
+  const platform = normalizeText(params.get("platform"));
+  const tags = uniqueSortedTags(params.getAll("tag"));
+
+  let activeFilter: FilterOptions;
+  if (scope === "saved") {
+    activeFilter = { savedOnly: true };
+  } else if (scope === "archived") {
+    activeFilter = { archivedOnly: true };
+  } else if (feedUrl) {
+    activeFilter = { platform: "rss", feedUrl };
+    if (tags.length > 0) activeFilter.tags = tags;
+  } else {
+    activeFilter = {};
+    if (platform) activeFilter.platform = platform;
+    if (tags.length > 0) activeFilter.tags = tags;
+  }
+
+  return canonicalizeNavigationState({
+    activeView,
+    activeFilter,
+    selectedItemId: normalizeText(params.get("item")),
+  });
+}
+
+export function serializeNavigationState(state: NavigationState): string {
+  const canonical = canonicalizeNavigationState(state);
+  const pathname =
+    canonical.activeView === "friends"
+      ? "/friends"
+      : canonical.activeView === "map"
+        ? "/map"
+        : "/";
+
+  if (canonical.activeView !== "feed") return pathname;
+
+  const params = new URLSearchParams();
+  const { activeFilter, selectedItemId } = canonical;
+
+  if (activeFilter.savedOnly) {
+    params.set("scope", "saved");
+  } else if (activeFilter.archivedOnly) {
+    params.set("scope", "archived");
+  } else {
+    if (activeFilter.feedUrl) {
+      params.set("feed", activeFilter.feedUrl);
+    } else if (activeFilter.platform) {
+      params.set("platform", activeFilter.platform);
+    }
+
+    for (const tag of uniqueSortedTags(activeFilter.tags)) {
+      params.append("tag", tag);
+    }
+  }
+
+  if (selectedItemId) {
+    params.set("item", selectedItemId);
+  }
+
+  const search = params.toString();
+  return search ? `${pathname}?${search}` : pathname;
+}
+
+export function navigationStatesEqual(a: NavigationState, b: NavigationState): boolean {
+  const left = canonicalizeNavigationState(a);
+  const right = canonicalizeNavigationState(b);
+  const leftTags = uniqueSortedTags(left.activeFilter.tags);
+  const rightTags = uniqueSortedTags(right.activeFilter.tags);
+
+  return (
+    left.activeView === right.activeView
+    && left.selectedItemId === right.selectedItemId
+    && left.activeFilter.platform === right.activeFilter.platform
+    && left.activeFilter.feedUrl === right.activeFilter.feedUrl
+    && !!left.activeFilter.savedOnly === !!right.activeFilter.savedOnly
+    && !!left.activeFilter.archivedOnly === !!right.activeFilter.archivedOnly
+    && leftTags.length === rightTags.length
+    && leftTags.every((tag, index) => tag === rightTags[index])
+  );
+}

--- a/packages/ui/src/components/DebugPanel.tsx
+++ b/packages/ui/src/components/DebugPanel.tsx
@@ -64,6 +64,8 @@ const KIND_STYLES: Record<SyncEventKind, { badge: string; dot: string; label: st
   connect_timeout:    { badge: "bg-red-500/20 text-red-400 border-red-500/30",          dot: "bg-red-400",      label: "timeout" },
 };
 
+const EMPTY_PROVIDER_SYNC_COUNTS: Partial<Record<HealthProviderId, number>> = {};
+
 // ---------------------------------------------------------------------------
 // Sub-components
 // ---------------------------------------------------------------------------
@@ -549,7 +551,7 @@ function HealthTab() {
     (s) =>
       ((s as unknown as {
         providerSyncCounts?: Partial<Record<HealthProviderId, number>>;
-      }).providerSyncCounts ?? {}) as Partial<Record<HealthProviderId, number>>,
+      }).providerSyncCounts ?? EMPTY_PROVIDER_SYNC_COUNTS) as Partial<Record<HealthProviderId, number>>,
   );
   const {
     retryCloudProvider,

--- a/packages/ui/src/components/SettingsDialog.tsx
+++ b/packages/ui/src/components/SettingsDialog.tsx
@@ -75,6 +75,8 @@ type ProviderAuthSlices = {
   liAuth?: ProviderAuthState;
 };
 
+const EMPTY_PROVIDER_SYNC_COUNTS: Partial<Record<ProviderSectionId, number>> = {};
+
 function isProviderSection(sectionId: SectionId): sectionId is ProviderSectionId {
   return (
     sectionId === "x" ||
@@ -89,7 +91,7 @@ function ProviderStatusDot({ sectionId }: { sectionId: ProviderSectionId }) {
   const providerSyncCounts = useAppStore(
     (s) =>
       ((s as unknown as { providerSyncCounts?: Partial<Record<ProviderSectionId, number>> })
-        .providerSyncCounts ?? {}) as Partial<Record<ProviderSectionId, number>>,
+        .providerSyncCounts ?? EMPTY_PROVIDER_SYNC_COUNTS) as Partial<Record<ProviderSectionId, number>>,
   );
   const xAuth = useAppStore((s) => (s as unknown as ProviderAuthSlices).xAuth);
   const fbAuth = useAppStore((s) => (s as unknown as ProviderAuthSlices).fbAuth);

--- a/packages/ui/src/components/layout/Sidebar.tsx
+++ b/packages/ui/src/components/layout/Sidebar.tsx
@@ -372,6 +372,8 @@ function SourceContextMenu({
 const MIN_WIDTH = 180;
 const MAX_WIDTH = 480;
 const DEFAULT_WIDTH = 256;
+const EMPTY_PROVIDER_SYNC_COUNTS: Partial<Record<string, number>> = {};
+
 export function Sidebar({ open, onClose }: SidebarProps) {
   const { SourceIndicator, headerDragRegion, syncRssNow, syncSourceNow, getSourceStatus } = usePlatform();
   const activeFilter = useAppStore((s) => s.activeFilter);
@@ -393,7 +395,7 @@ export function Sidebar({ open, onClose }: SidebarProps) {
   const providerSyncCounts = useAppStore(
     (s) =>
       ((s as unknown as { providerSyncCounts?: Partial<Record<string, number>> })
-        .providerSyncCounts ?? {}) as Partial<Record<string, number>>,
+        .providerSyncCounts ?? EMPTY_PROVIDER_SYNC_COUNTS) as Partial<Record<string, number>>,
   );
   const sidebarWidth = useAppStore((s) => s.preferences.display.sidebarWidth) ?? DEFAULT_WIDTH;
   const updatePreferences = useAppStore((s) => s.updatePreferences);

--- a/website/src/app/roadmap/RoadmapContent.tsx
+++ b/website/src/app/roadmap/RoadmapContent.tsx
@@ -491,7 +491,7 @@ const phases: Phase[] = [
     number: 5,
     title: "Desktop & Mobile App",
     description:
-      "Freed Desktop ships for macOS (ARM + Intel), Windows, and Linux with signed auto-updates, first-run legal gating, provider risk interstitials, local snapshot rollback for disaster recovery, a provider health dashboard, failing-feed unsubscribe tools, and reviewed cumulative release headings.",
+      "Freed Desktop ships for macOS (ARM + Intel), Windows, and Linux with signed auto-updates, first-run legal gating, provider risk interstitials, browser-style back and forward shortcuts, local snapshot rollback for disaster recovery, a provider health dashboard, failing-feed unsubscribe tools, and reviewed cumulative release headings.",
     status: "current",
     priority: true,
     planLink:
@@ -501,7 +501,7 @@ const phases: Phase[] = [
     number: 6,
     title: "PWA Reader",
     description:
-      "Primary mobile surface with first-run legal gating. Read your feed anywhere, synced to Freed Desktop.",
+      "Primary mobile surface with first-run legal gating and URL-backed view state, so browser back and forward move through filters and open reading context naturally.",
     status: "complete",
     planLink:
       "https://github.com/freed-project/freed/blob/main/docs/PHASE-6-PWA.md",


### PR DESCRIPTION
(AI Generated).

## Summary
- add a shared serialized navigation-state model for feed view, filters, and open reader state
- sync PWA navigation state to browser history so back and forward work across views, filters, and reader selection
- add desktop internal navigation history with `Cmd+[` and `Cmd+]` for browser-style back and forward behavior
- add targeted PWA and desktop Playwright coverage and update the affected phase docs and roadmap copy

## Validation
- `./node_modules/.bin/tsc --noEmit -p packages/pwa/tsconfig.json`
- `./node_modules/.bin/tsc --noEmit -p packages/desktop/tsconfig.json`
- `npm run test --workspace=packages/pwa -- tests/app.spec.ts --grep "loads the Friends view directly from the URL|browser history tracks top-level view navigation|feed filters update the URL and restore with browser history|reader selection syncs to item history and restores with browser forward|stale item URLs are cleaned up after initialization|feed filter URLs restore the correct scope on direct load"`
- `npm run test:e2e --workspace=packages/desktop -- tests/e2e/smoke.spec.ts --grep "desktop navigation history supports Cmd\+\[ and Cmd\+\]|desktop reader history supports Cmd\+\[ and Cmd\+\]"`
