### PR TITLE
fix: reduce desktop feed webview media pressure

### DIFF
--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -1288,7 +1288,7 @@ dependencies = [
 
 [[package]]
 name = "freed-desktop"
-version = "26.4.105"
+version = "26.4.108"
 dependencies = [
  "base64 0.22.1",
  "criterion",

--- a/packages/desktop/src/App.tsx
+++ b/packages/desktop/src/App.tsx
@@ -298,6 +298,7 @@ function App() {
   const platform: PlatformConfig = useMemo(
     () => ({
       store: useAppStore,
+      feedMediaPreviews: "reader-only",
       addRssFeed,
       importOPMLFeeds,
       exportFeedsAsOPML,

--- a/packages/desktop/tests/e2e/feed-card-ui.spec.ts
+++ b/packages/desktop/tests/e2e/feed-card-ui.spec.ts
@@ -4,11 +4,12 @@ const FACEBOOK_TITLE = "Card UI Overhaul Facebook Item";
 const RSS_TITLE = "Card UI Overhaul RSS Item";
 const FACEBOOK_URL = "https://example.com/facebook/card-ui-overhaul";
 const RSS_URL = "https://example.com/rss/card-ui-overhaul";
+const FACEBOOK_MEDIA_URL = "https://images.example.com/facebook/card-ui-overhaul.jpg";
 const TRASH_PATH = 'path[d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"]';
 
 async function injectCardUiItems(page: import("@playwright/test").Page): Promise<void> {
   await page.evaluate(
-    async ({ facebookTitle, rssTitle, facebookUrl, rssUrl }) => {
+    async ({ facebookTitle, rssTitle, facebookUrl, rssUrl, facebookMediaUrl }) => {
       const now = Date.now();
       const w = window as Record<string, unknown>;
       const automerge = w.__FREED_AUTOMERGE__ as {
@@ -29,8 +30,8 @@ async function injectCardUiItems(page: import("@playwright/test").Page): Promise
           },
           content: {
             text: "Facebook item to exercise the moved action cluster and hover reaction palette.",
-            mediaUrls: [],
-            mediaTypes: [],
+            mediaUrls: [facebookMediaUrl],
+            mediaTypes: ["image"],
             linkPreview: {
               url: facebookUrl,
               title: facebookTitle,
@@ -97,6 +98,7 @@ async function injectCardUiItems(page: import("@playwright/test").Page): Promise
       rssTitle: RSS_TITLE,
       facebookUrl: FACEBOOK_URL,
       rssUrl: RSS_URL,
+      facebookMediaUrl: FACEBOOK_MEDIA_URL,
     },
   );
 }
@@ -140,6 +142,7 @@ test("feed card overhaul actions and reader open flow work", async ({ app }) => 
   await expect(facebookCard).toContainText("45");
   await expect(facebookCard).toHaveClass(/grayscale/);
   await expect(facebookCard.locator(TRASH_PATH).first()).toBeVisible();
+  await expect(facebookCard.locator(`img[src="${FACEBOOK_MEDIA_URL}"]`)).toHaveCount(0);
 
   await facebookCard.hover();
   const likeButton = facebookCard.locator('button[aria-label="Like"]').last();
@@ -160,8 +163,10 @@ test("feed card overhaul actions and reader open flow work", async ({ app }) => 
 
   await facebookCard.click();
   const reader = app.page.locator("header").filter({ hasText: "Card UI Overhaul" }).first();
+  const readerHeading = app.page.locator("article h1").filter({ hasText: FACEBOOK_TITLE }).first();
   await expect(reader).toBeVisible();
   await expect(reader.locator(TRASH_PATH).first()).toBeVisible();
+  await expect(readerHeading).toBeVisible();
 
   const openReaderButton = reader.locator('button[aria-label="Open"]').first();
   await expect(openReaderButton).toBeVisible();

--- a/packages/pwa/src/App.tsx
+++ b/packages/pwa/src/App.tsx
@@ -111,6 +111,7 @@ function App() {
   const platform: PlatformConfig = useMemo(
     () => ({
       store: useAppStore,
+      feedMediaPreviews: "inline",
       addRssFeed: subscribeToFeed,
       exportFeedsAsOPML,
       SourceIndicator: null,

--- a/packages/ui/src/components/SettingsDialog.tsx
+++ b/packages/ui/src/components/SettingsDialog.tsx
@@ -31,6 +31,7 @@ import {
 } from "../lib/settings-sections.js";
 import { FeedsSection } from "./settings/FeedsSection.js";
 import { SavedSection } from "./settings/SavedSection.js";
+import { SettingsToggle } from "./SettingsToggle.js";
 
 const SAMPLE_SEED_FEED_COUNT = 10;
 const SAMPLE_SEED_ITEM_COUNT = 155;
@@ -54,43 +55,6 @@ type NavStructureItem = Section | NavGroup;
 interface SettingsDialogProps {
   open: boolean;
   onClose: () => void;
-}
-
-// ── Toggle primitive ──────────────────────────────────────────────────────────
-
-function Toggle({
-  label,
-  checked,
-  onChange,
-  description,
-}: {
-  label: string;
-  checked: boolean;
-  onChange: (v: boolean) => void;
-  description?: string;
-}) {
-  return (
-    <div className="flex items-start justify-between gap-4">
-      <div>
-        <p className="text-sm text-[#a1a1aa]">{label}</p>
-        {description && <p className="text-xs text-[#52525b] mt-0.5">{description}</p>}
-      </div>
-      <button
-        role="switch"
-        aria-checked={checked}
-        onClick={() => onChange(!checked)}
-        className={`relative shrink-0 w-9 h-5 rounded-full transition-colors ${
-          checked ? "bg-[#8b5cf6]" : "bg-white/10"
-        }`}
-      >
-        <span
-          className={`absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full shadow transition-transform ${
-            checked ? "translate-x-4" : "translate-x-0"
-          }`}
-        />
-      </button>
-    </div>
-  );
 }
 
 // ── Section icons ─────────────────────────────────────────────────────────────
@@ -578,13 +542,13 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
           <>
             <SectionHeading label="Reading" />
             <div className="space-y-5">
-              <Toggle
+              <SettingsToggle
                 label="Mark read on scroll"
                 checked={display.reading.markReadOnScroll}
                 onChange={(v) => handleReadingChange({ markReadOnScroll: v })}
                 description="Mark items as read when you scroll past them in the feed"
               />
-              <Toggle
+              <SettingsToggle
                 label="Show engagement counts"
                 checked={display.showEngagementCounts}
                 onChange={(v) => handleDisplayChange({ showEngagementCounts: v })}
@@ -623,7 +587,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
                   </button>
                 </div>
               </div>
-              <Toggle
+              <SettingsToggle
                 label="Focus mode"
                 checked={display.reading.focusMode}
                 onChange={(v) => handleReadingChange({ focusMode: v })}

--- a/packages/ui/src/components/feed/FeedItem.tsx
+++ b/packages/ui/src/components/feed/FeedItem.tsx
@@ -1,6 +1,7 @@
 import { memo, useRef, useState, type ReactNode } from "react";
 import { formatDistanceToNow } from "date-fns";
 import { PLATFORM_LABELS, type FeedItem as FeedItemType } from "@freed/shared";
+import { usePlatform } from "../../context/PlatformContext.js";
 import {
   RssIcon,
   FacebookIcon,
@@ -130,6 +131,7 @@ export const FeedItem = memo(function FeedItem({
   onOpenCommentUrl,
   storyHeight = 288,
 }: FeedItemProps) {
+  const { feedMediaPreviews = "inline" } = usePlatform();
   const timeAgo = formatDistanceToNow(item.publishedAt, { addSuffix: true });
   const platformIcon = platformIcons[item.platform] ?? <span className="text-xs">📄</span>;
   const isRead = Boolean(item.userState.readAt);
@@ -139,6 +141,7 @@ export const FeedItem = memo(function FeedItem({
   const commentCount = formatEngagementCount(item.engagement?.comments);
 
   const [swipeX, setSwipeX] = useState(0);
+  const showInlineMedia = feedMediaPreviews === "inline";
   const touchStartX = useRef(0);
   const touchStartY = useRef(0);
   const swipeLocked = useRef<"horizontal" | "vertical" | null>(null);
@@ -195,7 +198,7 @@ export const FeedItem = memo(function FeedItem({
         tabIndex={0}
         onKeyDown={(e) => e.key === "Enter" && onClick?.()}
       >
-        {bg ? (
+        {showInlineMedia && bg ? (
           <img
             src={bg}
             alt=""
@@ -538,7 +541,7 @@ export const FeedItem = memo(function FeedItem({
           </p>
         )}
 
-        {item.content.mediaUrls.length > 0 && (
+        {showInlineMedia && item.content.mediaUrls.length > 0 && (
           <div className="mt-3 rounded-xl overflow-hidden ring-1 ring-white/5">
             <img
               src={item.content.mediaUrls[0]}

--- a/packages/ui/src/components/feed/ReaderView.tsx
+++ b/packages/ui/src/components/feed/ReaderView.tsx
@@ -557,6 +557,8 @@ export function ReaderView({ item, onClose, dualColumn = false, onOpenUrl }: Rea
           <img
             src={item.content.mediaUrls[0]}
             alt=""
+            loading="lazy"
+            decoding="async"
             className="w-full rounded-xl mb-8 bg-white/5 ring-1 ring-white/5"
           />
         )}

--- a/packages/ui/src/context/PlatformContext.tsx
+++ b/packages/ui/src/context/PlatformContext.tsx
@@ -48,6 +48,12 @@ export interface PlatformConfig {
   store: AppStoreHook;
 
   /**
+   * Controls whether feed cards eagerly render remote media previews.
+   * Desktop can force reader-only mode to reduce WebKit renderer pressure.
+   */
+  feedMediaPreviews?: "inline" | "reader-only";
+
+  /**
    * Register + fetch a feed by URL.
    * Only available on platforms that can fetch RSS (desktop).
    * When absent, feed-add UI is hidden.


### PR DESCRIPTION
(AI Generated).

## Summary
- stop Freed Desktop feed cards from eagerly rendering remote media previews
- keep inline media previews enabled in the PWA
- add a desktop regression test that proves social feed cards do not mount inline media
- extract the shared settings toggle primitive so the branch builds cleanly

## Testing
- PATH=/Users/aubreyfalconer/.nvm/versions/node/v22.12.0/bin:$PATH npm run test:e2e -- tests/e2e/feed-card-ui.spec.ts
- PATH=/Users/aubreyfalconer/.nvm/versions/node/v22.12.0/bin:$PATH npm run build
- cargo check