### PR TITLE
fix: redeploy website after release publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -283,6 +283,55 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release edit "${{ github.ref_name }}" --draft=false --repo "${{ github.repository }}"
 
+  # Redeploy the marketing site after the GitHub release is public so the
+  # checked-in changelog snapshot is rebuilt against the published release.
+  # Requires VERCEL_TOKEN to be set in repo secrets. If the secret is absent
+  # the step exits cleanly without failing the workflow.
+  publish-website:
+    name: Deploy Website
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+          cache: "npm"
+
+      - name: Wait for published GitHub release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          for attempt in {1..30}; do
+            draft_state=$(gh api "repos/${{ github.repository }}/releases/tags/${{ github.ref_name }}" --jq '.draft')
+            if [ "$draft_state" = "false" ]; then
+              echo "Release ${{ github.ref_name }} is published."
+              exit 0
+            fi
+
+            echo "Release ${{ github.ref_name }} is still draft, retrying in 10s (${attempt}/30)"
+            sleep 10
+          done
+
+          echo "Release ${{ github.ref_name }} never became published."
+          exit 1
+
+      - name: Deploy website to Vercel
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          if [ -z "$VERCEL_TOKEN" ]; then
+            echo "VERCEL_TOKEN not configured, skipping website deploy"
+            echo "Add a VERCEL_TOKEN secret to enable automatic website changelog refresh."
+            exit 0
+          fi
+          npx vercel deploy website/ --scope aubreyfs-projects -y --prod --token "$VERCEL_TOKEN"
+
   # Deploy the PWA to Vercel after the GitHub release is published so the
   # version shown in the app always matches the shipped desktop release.
   # Requires VERCEL_TOKEN to be set in repo secrets. If the secret is absent
@@ -309,7 +358,7 @@ jobs:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: |
           if [ -z "$VERCEL_TOKEN" ]; then
-            echo "VERCEL_TOKEN not configured — skipping PWA deploy"
+            echo "VERCEL_TOKEN not configured, skipping PWA deploy"
             echo "Add a VERCEL_TOKEN secret to enable automated PWA deployment."
             exit 0
           fi

--- a/docs/PHASE-5-DESKTOP.md
+++ b/docs/PHASE-5-DESKTOP.md
@@ -235,7 +235,10 @@ export async function captureDomFeed(
 > separate `Features`, `Fixes`, and `Follow-ups` sections so the card headline
 > can reinforce the theme without collapsing the details into one bucket. The
 > desktop updater now shows only that reviewed opener line when an update is
-> available. See `RELEASE-SECRETS.md` for the full setup checklist.
+> available. After the GitHub release is published, the workflow now
+> redeploys `freed.wtf` so the changelog snapshot rebuilds against the newly
+> published release instead of the earlier draft state. See
+> `RELEASE-SECRETS.md` for the full setup checklist.
 
 > **Planned — Independent Update Server (Task 5.26):**
 > The auto-updater currently points at GitHub Releases. If the repo is

--- a/docs/RELEASE-SECRETS.md
+++ b/docs/RELEASE-SECRETS.md
@@ -59,6 +59,15 @@ Options:
 2. Click "New repository secret"
 3. Add each secret listed above
 
+## Automatic website + PWA deploys
+
+`VERCEL_TOKEN` is required if you want the release workflow to deploy
+`freed.wtf` and `app.freed.wtf` automatically after a desktop release is
+published.
+
+Without it, the release still completes and publishes on GitHub, but the
+workflow will skip the website and PWA deploy steps.
+
 ## Drafting release notes
 
 `./scripts/release.sh` now prepares a release in two stages:
@@ -120,8 +129,17 @@ git push origin main --follow-tags
 
 The `v*` tag triggers the release workflow which builds all platforms and
 creates a **draft** GitHub Release using the approved checked-in release body.
-Review the draft, then click "Publish" to make it live. The in-app updater
-will pick it up automatically.
+After all platform builds succeed, the workflow publishes that release
+automatically.
+
+If `VERCEL_TOKEN` is configured, the workflow then:
+
+- redeploys `website/` so `freed.wtf/changelog` rebuilds its checked-in
+  snapshot against the published GitHub release
+- deploys `packages/pwa/` so the PWA version stays aligned with the shipped
+  desktop release
+
+The in-app updater will pick the new GitHub release up automatically.
 
 `./scripts/release-publish.sh` and the release workflow both validate that:
 


### PR DESCRIPTION
(AI Generated).

## Summary
- redeploy `website/` after the GitHub release is published so the changelog snapshot includes the newly shipped build
- keep the existing snapshot-based changelog flow and current PWA deploy behavior
- document the post-publish website deploy and `VERCEL_TOKEN` requirement in the release docs

## Testing
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "workflow yaml ok"'