### PR TITLE
fix: silence background social scrapers

### DIFF
--- a/docs/PHASE-12-ADDITIONAL-PLATFORMS.md
+++ b/docs/PHASE-12-ADDITIONAL-PLATFORMS.md
@@ -262,6 +262,7 @@ packages/capture-youtube/
 - [x] LinkedIn feed posts captured to FeedItem
 - [x] LinkedIn is visible in desktop Sources navigation and source status UI
 - [x] LinkedIn shares the Desktop scraper window modes: shown, cloaked, hidden
+- [x] LinkedIn background scrape and auth-check WebViews force provider media silent
 - [x] LinkedIn desktop flows have regression coverage in Playwright
 - [ ] Mozi activity captured to FeedItem with plans, trips, attendance, or overlap-adjacent events
 - [ ] Mozi is visible in desktop Sources navigation and source status UI

--- a/docs/PHASE-7-SOCIAL-CAPTURE.md
+++ b/docs/PHASE-7-SOCIAL-CAPTURE.md
@@ -1,6 +1,6 @@
 # Phase 7: Facebook + Instagram Capture
 
-> **Status:** 🚧 In Progress — Facebook and Instagram integrated into Desktop via Tauri WebView scraping, with feed pollution filtering and Facebook group controls
+> **Status:** 🚧 In Progress — Facebook and Instagram integrated into Desktop via Tauri WebView scraping, with feed pollution filtering, silent background media guarding, and Facebook group controls
 > **Dependencies:** Phase 5 (Desktop App)
 
 ---
@@ -102,6 +102,8 @@ Self-contained JavaScript injected into the WebView's execution context. No exte
 
 Story scraping is interleaved with feed scraping in each session. A coin flip (~50%) determines whether stories are scraped before or after the initial feed passes. ~15% of sessions skip story scraping entirely (real users don't always check stories). Up to 30 story frames are captured per session.
 
+Background scrape and auth-check sessions now force provider media elements silent through the injected WebKit mask layer. Audio elements are paused outright, video elements are forced muted, and newly inserted media is re-silenced as the DOM changes.
+
 ---
 
 ## Rate Limiting
@@ -158,6 +160,7 @@ const RATE_LIMITS = {
 - [x] Feed pollution filtering blocks promoted X entries and suggested FB/IG posts
 - [x] Facebook Settings includes per-group include/exclude controls for joined groups
 - [x] Desktop Sources settings expose per-source scraper window modes: shown, cloaked, hidden
+- [x] Background FB and IG scraper WebViews force provider media silent during scrape and auth-check flows
 - [x] Empty states for both platforms in the feed view
 - [x] Source indicators in sidebar for both platforms
 - [x] Sync indicator panel shows both platforms

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -37,12 +37,16 @@ fn sync_relay_port() -> u16 {
         .unwrap_or(DEFAULT_SYNC_RELAY_PORT)
 }
 
-const BACKGROUND_SCRAPER_WINDOW_NAME: &str = "__freed_background_scraper__";
 const DEFAULT_WEBKIT_SAFARI_UA: &str =
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.3 Safari/605.1.15";
 const ENABLE_BACKGROUND_SCRAPER_CLOAK_JS: &str = r#"
     (function() {
-        window.name = "__freed_background_scraper__";
+        var token = "__freed_background_scraper__";
+        var tokens = (window.name || "").split(/\s+/).filter(Boolean).filter(function(value) {
+            return value !== token;
+        });
+        tokens.push(token);
+        window.name = tokens.join(" ");
         if (typeof window.__FREED_SET_BACKGROUND_SCRAPER_CLOAK__ === "function") {
             window.__FREED_SET_BACKGROUND_SCRAPER_CLOAK__(true);
         }
@@ -50,7 +54,11 @@ const ENABLE_BACKGROUND_SCRAPER_CLOAK_JS: &str = r#"
 "#;
 const DISABLE_BACKGROUND_SCRAPER_CLOAK_JS: &str = r#"
     (function() {
-        window.name = "";
+        var token = "__freed_background_scraper__";
+        var tokens = (window.name || "").split(/\s+/).filter(Boolean).filter(function(value) {
+            return value !== token;
+        });
+        window.name = tokens.join(" ");
         if (typeof window.__FREED_SET_BACKGROUND_SCRAPER_CLOAK__ === "function") {
             window.__FREED_SET_BACKGROUND_SCRAPER_CLOAK__(false);
         }
@@ -58,9 +66,52 @@ const DISABLE_BACKGROUND_SCRAPER_CLOAK_JS: &str = r#"
 "#;
 const INITIALIZE_BACKGROUND_SCRAPER_CLOAK_JS: &str = r#"
     (function() {
-        window.name = "__freed_background_scraper__";
+        var token = "__freed_background_scraper__";
+        var tokens = (window.name || "").split(/\s+/).filter(Boolean).filter(function(value) {
+            return value !== token;
+        });
+        tokens.push(token);
+        window.name = tokens.join(" ");
         if (typeof window.__FREED_SET_BACKGROUND_SCRAPER_CLOAK__ === "function") {
             window.__FREED_SET_BACKGROUND_SCRAPER_CLOAK__(true);
+        }
+    })();
+"#;
+const ENABLE_BACKGROUND_SCRAPER_MEDIA_GUARD_JS: &str = r#"
+    (function() {
+        var token = "__freed_media_guard__";
+        var tokens = (window.name || "").split(/\s+/).filter(Boolean).filter(function(value) {
+            return value !== token;
+        });
+        tokens.push(token);
+        window.name = tokens.join(" ");
+        if (typeof window.__FREED_SET_BACKGROUND_SCRAPER_MEDIA_GUARD__ === "function") {
+            window.__FREED_SET_BACKGROUND_SCRAPER_MEDIA_GUARD__(true);
+        }
+    })();
+"#;
+const DISABLE_BACKGROUND_SCRAPER_MEDIA_GUARD_JS: &str = r#"
+    (function() {
+        var token = "__freed_media_guard__";
+        var tokens = (window.name || "").split(/\s+/).filter(Boolean).filter(function(value) {
+            return value !== token;
+        });
+        window.name = tokens.join(" ");
+        if (typeof window.__FREED_SET_BACKGROUND_SCRAPER_MEDIA_GUARD__ === "function") {
+            window.__FREED_SET_BACKGROUND_SCRAPER_MEDIA_GUARD__(false);
+        }
+    })();
+"#;
+const INITIALIZE_BACKGROUND_SCRAPER_MEDIA_GUARD_JS: &str = r#"
+    (function() {
+        var token = "__freed_media_guard__";
+        var tokens = (window.name || "").split(/\s+/).filter(Boolean).filter(function(value) {
+            return value !== token;
+        });
+        tokens.push(token);
+        window.name = tokens.join(" ");
+        if (typeof window.__FREED_SET_BACKGROUND_SCRAPER_MEDIA_GUARD__ === "function") {
+            window.__FREED_SET_BACKGROUND_SCRAPER_MEDIA_GUARD__(true);
         }
     })();
 "#;
@@ -151,6 +202,7 @@ fn build_cloaked_scraper_window(
     .user_agent(user_agent)
     .transparent(true)
     .initialization_script(include_str!("webkit-mask.js"))
+    .initialization_script(INITIALIZE_BACKGROUND_SCRAPER_MEDIA_GUARD_JS)
     .title(title)
     .inner_size(1280.0, 900.0)
     .focused(false)
@@ -178,10 +230,24 @@ fn set_background_scraper_window_cloak(
         .map_err(|e| e.to_string())
 }
 
+fn set_background_scraper_media_guard(
+    window: &tauri::WebviewWindow,
+    enabled: bool,
+) -> Result<(), String> {
+    window
+        .eval(if enabled {
+            ENABLE_BACKGROUND_SCRAPER_MEDIA_GUARD_JS
+        } else {
+            DISABLE_BACKGROUND_SCRAPER_MEDIA_GUARD_JS
+        })
+        .map_err(|e| e.to_string())
+}
+
 fn prepare_background_scraper_window(
     window: &tauri::WebviewWindow,
     window_mode: ScraperWindowMode,
 ) -> Result<(), String> {
+    set_background_scraper_media_guard(window, true)?;
     match window_mode {
         ScraperWindowMode::Shown => {
             let _ = window.set_ignore_cursor_events(false);
@@ -1003,6 +1069,8 @@ async fn fb_show_login(
     use tauri::WebviewWindowBuilder;
 
     if let Some(existing) = app.get_webview_window("fb-scraper") {
+        let _ = set_background_scraper_window_cloak(&existing, false);
+        let _ = set_background_scraper_media_guard(&existing, false);
         existing
             .navigate("https://www.facebook.com/login".parse().unwrap())
             .map_err(|e| e.to_string())?;
@@ -1097,12 +1165,15 @@ async fn fb_check_auth(
             tauri::WebviewUrl::External("https://www.facebook.com/".parse().unwrap()),
         )
         .user_agent(&scraper_user_agent)
+        .initialization_script(include_str!("webkit-mask.js"))
+        .initialization_script(INITIALIZE_BACKGROUND_SCRAPER_MEDIA_GUARD_JS)
         .title("Freed Facebook")
         .inner_size(460.0, 700.0)
         .visible(false)
         .build()
         .map_err(|e| e.to_string())?,
     };
+    set_background_scraper_media_guard(&wv, true)?;
 
     tokio::time::sleep(Duration::from_secs(6)).await;
 
@@ -1147,7 +1218,8 @@ async fn fb_check_auth(
 async fn scrape_fb_stories(wv: &tauri::WebviewWindow, max_frames: usize) {
     use rand::Rng;
 
-    println!("[FB] starting story scrape (max {} frames)", max_frames);
+    let _ = set_background_scraper_media_guard(wv, true);
+    info!("[FB] story scrape start, max_frames={}", max_frames);
 
     // Click the first story card at the top of the News Feed. Facebook renders
     // story cards as a horizontal carousel above the feed. The first non-"Your Story"
@@ -1258,7 +1330,8 @@ async fn scrape_fb_stories(wv: &tauri::WebviewWindow, max_frames: usize) {
 async fn scrape_ig_stories(wv: &tauri::WebviewWindow, max_frames: usize) {
     use rand::Rng;
 
-    println!("[IG] starting story scrape (max {} frames)", max_frames);
+    let _ = set_background_scraper_media_guard(wv, true);
+    info!("[IG] story scrape start, max_frames={}", max_frames);
 
     // Click the first friend's story avatar in the top tray.
     // Instagram story trays are anchors linking to /stories/<username>/
@@ -1392,6 +1465,7 @@ async fn fb_scrape_feed(
             .user_agent(&scraper_user_agent)
             .transparent(true)
             .initialization_script(include_str!("webkit-mask.js"))
+            .initialization_script(INITIALIZE_BACKGROUND_SCRAPER_MEDIA_GUARD_JS)
             .title("Freed Facebook")
             .inner_size(1280.0, 900.0)
             .on_navigation(move |url| {
@@ -1616,6 +1690,7 @@ async fn fb_scrape_groups(
             )
             .user_agent(&scraper_user_agent)
             .initialization_script(include_str!("webkit-mask.js"))
+            .initialization_script(INITIALIZE_BACKGROUND_SCRAPER_MEDIA_GUARD_JS)
             .title("Freed Facebook")
             .inner_size(1280.0, 900.0)
             .on_navigation(move |url| {
@@ -1724,6 +1799,8 @@ async fn ig_show_login(
     use tauri::WebviewWindowBuilder;
 
     if let Some(existing) = app.get_webview_window("ig-scraper") {
+        let _ = set_background_scraper_window_cloak(&existing, false);
+        let _ = set_background_scraper_media_guard(&existing, false);
         existing
             .navigate("https://www.instagram.com/accounts/login/".parse().unwrap())
             .map_err(|e| e.to_string())?;
@@ -1830,12 +1907,15 @@ async fn ig_check_auth(
             tauri::WebviewUrl::External("https://www.instagram.com/".parse().unwrap()),
         )
         .user_agent(&scraper_user_agent)
+        .initialization_script(include_str!("webkit-mask.js"))
+        .initialization_script(INITIALIZE_BACKGROUND_SCRAPER_MEDIA_GUARD_JS)
         .title("Freed Instagram")
         .inner_size(460.0, 700.0)
         .visible(false)
         .build()
         .map_err(|e| e.to_string())?,
     };
+    set_background_scraper_media_guard(&wv, true)?;
 
     tokio::time::sleep(Duration::from_secs(6)).await;
 
@@ -1905,6 +1985,7 @@ async fn ig_scrape_feed(
             .user_agent(&scraper_user_agent)
             .transparent(true)
             .initialization_script(include_str!("webkit-mask.js"))
+            .initialization_script(INITIALIZE_BACKGROUND_SCRAPER_MEDIA_GUARD_JS)
             .title("Freed Instagram")
             .inner_size(1280.0, 900.0)
             .on_navigation(move |url| {
@@ -2315,6 +2396,8 @@ async fn li_show_login(
     use tauri::WebviewWindowBuilder;
 
     if let Some(existing) = app.get_webview_window("li-scraper") {
+        let _ = set_background_scraper_window_cloak(&existing, false);
+        let _ = set_background_scraper_media_guard(&existing, false);
         existing
             .navigate("https://www.linkedin.com/login".parse().unwrap())
             .map_err(|e| e.to_string())?;
@@ -2398,6 +2481,7 @@ async fn li_check_auth(
     let _recycle_guard = WebviewRecycleGuard::new(app.clone(), "li-scraper", "auth check");
     let wv = match app.get_webview_window("li-scraper") {
         Some(w) => {
+            let _ = set_background_scraper_media_guard(&w, true);
             w.navigate("https://www.linkedin.com/feed/".parse().unwrap())
                 .map_err(|e| e.to_string())?;
             w
@@ -2408,12 +2492,15 @@ async fn li_check_auth(
             tauri::WebviewUrl::External("https://www.linkedin.com/feed/".parse().unwrap()),
         )
         .user_agent(&scraper_user_agent)
+        .initialization_script(include_str!("webkit-mask.js"))
+        .initialization_script(INITIALIZE_BACKGROUND_SCRAPER_MEDIA_GUARD_JS)
         .title("Freed LinkedIn")
         .inner_size(460.0, 700.0)
         .visible(false)
         .build()
         .map_err(|e| e.to_string())?,
     };
+    set_background_scraper_media_guard(&wv, true)?;
 
     tokio::time::sleep(Duration::from_secs(6)).await;
 
@@ -2483,6 +2570,7 @@ async fn li_scrape_feed(
             .user_agent(&scraper_user_agent)
             .transparent(true)
             .initialization_script(include_str!("webkit-mask.js"))
+            .initialization_script(INITIALIZE_BACKGROUND_SCRAPER_MEDIA_GUARD_JS)
             .title("Freed LinkedIn")
             .inner_size(1280.0, 900.0)
             .on_navigation(move |url| {

--- a/packages/desktop/src-tauri/src/webkit-mask.js
+++ b/packages/desktop/src-tauri/src/webkit-mask.js
@@ -17,8 +17,38 @@
 (function () {
   "use strict";
   var CLOAK_WINDOW_NAME = "__freed_background_scraper__";
+  var MEDIA_GUARD_WINDOW_NAME = "__freed_media_guard__";
   var CLOAK_STYLE_ID = "__freed_scraper_cloak__";
+  var MEDIA_GUARD_STATE_KEY = "__freedBackgroundScraperMediaGuardState__";
+  var MEDIA_GUARD_BOUND_KEY = "__freedMediaGuardBound__";
+  var MEDIA_GUARD_REPORTED_KEY = "__freedMediaGuardReported__";
+  var MAX_MEDIA_DIAG_EVENTS = 8;
   var cloakIntervalId = null;
+
+  function emit(name, data) {
+    if (
+      window.__TAURI__ &&
+      window.__TAURI__.event &&
+      typeof window.__TAURI__.event.emit === "function"
+    ) {
+      window.__TAURI__.event.emit(name, data);
+    }
+  }
+
+  function setWindowNameToken(token, enabled) {
+    var tokens = (window.name || "")
+      .split(/\s+/)
+      .filter(Boolean)
+      .filter(function (value) {
+        return value !== token;
+      });
+
+    if (enabled) {
+      tokens.push(token);
+    }
+
+    window.name = tokens.join(" ");
+  }
 
   function ensureCloakStyle() {
     var root = document.documentElement;
@@ -74,6 +104,135 @@
   }
 
   window.__FREED_SET_BACKGROUND_SCRAPER_CLOAK__ = setBackgroundScraperCloak;
+
+  function getMediaGuardState() {
+    if (!window[MEDIA_GUARD_STATE_KEY]) {
+      window[MEDIA_GUARD_STATE_KEY] = {
+        enabled: false,
+        observer: null,
+        diagCount: 0,
+      };
+    }
+    return window[MEDIA_GUARD_STATE_KEY];
+  }
+
+  function reportMediaSilenced(mediaEl, reason) {
+    var state = getMediaGuardState();
+    if (state.diagCount >= MAX_MEDIA_DIAG_EVENTS) return;
+    if (mediaEl[MEDIA_GUARD_REPORTED_KEY]) return;
+
+    mediaEl[MEDIA_GUARD_REPORTED_KEY] = true;
+    state.diagCount += 1;
+
+    emit("freed-scraper-media-diag", {
+      provider: (window.location.hostname || "unknown").replace(/^www\./, ""),
+      kind: mediaEl.tagName.toLowerCase(),
+      reason: reason,
+    });
+  }
+
+  function silenceMediaElement(mediaEl, reason) {
+    if (!(mediaEl instanceof HTMLMediaElement)) return;
+
+    try {
+      mediaEl.defaultMuted = true;
+    } catch (_e) {}
+    try {
+      mediaEl.muted = true;
+    } catch (_e) {}
+    try {
+      mediaEl.volume = 0;
+    } catch (_e) {}
+    try {
+      mediaEl.setAttribute("muted", "");
+    } catch (_e) {}
+
+    if (mediaEl instanceof HTMLAudioElement) {
+      try {
+        mediaEl.pause();
+      } catch (_e) {}
+    }
+
+    reportMediaSilenced(mediaEl, reason);
+  }
+
+  function bindMediaElement(mediaEl) {
+    if (!(mediaEl instanceof HTMLMediaElement)) return;
+    if (mediaEl[MEDIA_GUARD_BOUND_KEY]) {
+      silenceMediaElement(mediaEl, "re-scan");
+      return;
+    }
+
+    mediaEl[MEDIA_GUARD_BOUND_KEY] = true;
+
+    var enforce = function (event) {
+      silenceMediaElement(
+        mediaEl,
+        event && event.type ? event.type : "media-event"
+      );
+    };
+
+    mediaEl.addEventListener("play", enforce, true);
+    mediaEl.addEventListener("volumechange", enforce, true);
+    mediaEl.addEventListener("loadedmetadata", enforce, true);
+
+    silenceMediaElement(mediaEl, "initial-scan");
+  }
+
+  function scanNodeForMedia(node) {
+    if (!node || (node.nodeType !== 1 && node.nodeType !== 11)) return;
+
+    if (node instanceof HTMLMediaElement) {
+      bindMediaElement(node);
+    }
+
+    if (typeof node.querySelectorAll !== "function") return;
+
+    var mediaNodes = node.querySelectorAll("audio, video");
+    for (var i = 0; i < mediaNodes.length; i++) {
+      bindMediaElement(mediaNodes[i]);
+    }
+  }
+
+  function refreshMediaGuardObserver() {
+    var state = getMediaGuardState();
+
+    if (!state.enabled) {
+      if (state.observer) {
+        state.observer.disconnect();
+        state.observer = null;
+      }
+      return;
+    }
+
+    scanNodeForMedia(document.documentElement || document.body);
+
+    if (state.observer || !document.documentElement) return;
+
+    state.observer = new MutationObserver(function (mutations) {
+      for (var i = 0; i < mutations.length; i++) {
+        var mutation = mutations[i];
+        for (var j = 0; j < mutation.addedNodes.length; j++) {
+          scanNodeForMedia(mutation.addedNodes[j]);
+        }
+      }
+    });
+
+    state.observer.observe(document.documentElement, {
+      childList: true,
+      subtree: true,
+    });
+  }
+
+  function setBackgroundScraperMediaGuard(enabled) {
+    var state = getMediaGuardState();
+    state.enabled = !!enabled;
+    setWindowNameToken(MEDIA_GUARD_WINDOW_NAME, state.enabled);
+    refreshMediaGuardObserver();
+  }
+
+  window.__FREED_SET_BACKGROUND_SCRAPER_MEDIA_GUARD__ =
+    setBackgroundScraperMediaGuard;
 
   // ---------------------------------------------------------------------------
   // 1. window.webkit.messageHandlers masking
@@ -151,11 +310,25 @@
     }
   } catch (_e) {}
 
-  if (window.name === CLOAK_WINDOW_NAME) {
+  if ((window.name || "").indexOf(CLOAK_WINDOW_NAME) !== -1) {
     setBackgroundScraperCloak(true);
-    document.addEventListener("DOMContentLoaded", function () {
-      setBackgroundScraperCloak(true);
-    }, { once: true });
   }
+
+  if ((window.name || "").indexOf(MEDIA_GUARD_WINDOW_NAME) !== -1) {
+    setBackgroundScraperMediaGuard(true);
+  }
+
+  document.addEventListener(
+    "DOMContentLoaded",
+    function () {
+      if ((window.name || "").indexOf(CLOAK_WINDOW_NAME) !== -1) {
+        setBackgroundScraperCloak(true);
+      }
+      if ((window.name || "").indexOf(MEDIA_GUARD_WINDOW_NAME) !== -1) {
+        setBackgroundScraperMediaGuard(true);
+      }
+    },
+    { once: true }
+  );
 
 })();

--- a/packages/desktop/src/lib/fb-capture.ts
+++ b/packages/desktop/src/lib/fb-capture.ts
@@ -23,6 +23,7 @@ import { useAppStore } from "./store";
 import { addDebugEvent } from "@freed/ui/lib/debug-store";
 import { getFbScraperWindowMode } from "./scraper-prefs";
 import { storeFbAuthState } from "./fb-auth";
+import { attachScraperMediaDiagListener } from "./scraper-media-diag";
 
 // =============================================================================
 // Rate Limiting
@@ -126,6 +127,7 @@ export async function fetchFbFeed(): Promise<FbSyncResult> {
       // Auto-cleanup after 35 seconds
       setTimeout(() => fn(), 35_000);
     });
+    attachScraperMediaDiagListener("FB", "facebook");
 
     // Listen for the extraction result
     listen<{ posts: RawFbPost[]; error?: string; extractedAt: number; url: string; strategy?: string; candidateCount?: number }>(

--- a/packages/desktop/src/lib/ig-stories-extract.test.ts
+++ b/packages/desktop/src/lib/ig-stories-extract.test.ts
@@ -57,4 +57,45 @@ describe("ig-stories-extract.js", () => {
     expect(payloads[0].posts[0].shortcode).toBe("story_ABC123xyz");
     expect(payloads[1].posts[0].shortcode).toBe("story_ABC123xyz");
   });
+
+  it("still extracts video story media when the video is muted", () => {
+    window.history.replaceState({}, "", "/stories/alice/VID123/");
+
+    document.body.innerHTML = `
+      <div role="dialog">
+        <a href="https://www.instagram.com/alice/">alice</a>
+        <video src="https://cdn.example/story-video.mp4" poster="https://cdn.example/poster.jpg" muted></video>
+        <time datetime="2026-03-23T12:00:00.000Z"></time>
+      </div>
+    `;
+
+    const dialog = document.querySelector('[role="dialog"]') as HTMLElement;
+    setReadonlyNumber(dialog, "offsetHeight", 800);
+
+    const payloads: Array<{ posts: Array<{ shortcode: string; mediaUrls: string[]; isVideo: boolean }> }> = [];
+    (
+      window as unknown as {
+        __TAURI__: { event: { emit: (_name: string, payload: unknown) => void } };
+      }
+    ).__TAURI__ = {
+      event: {
+        emit: (_name, payload) => {
+          payloads.push(
+            payload as {
+              posts: Array<{ shortcode: string; mediaUrls: string[]; isVideo: boolean }>;
+            },
+          );
+        },
+      },
+    };
+
+    window.eval(script);
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0].posts[0].shortcode).toBe("story_VID123");
+    expect(payloads[0].posts[0].isVideo).toBe(true);
+    expect(payloads[0].posts[0].mediaUrls).toContain(
+      "https://cdn.example/story-video.mp4",
+    );
+  });
 });

--- a/packages/desktop/src/lib/instagram-capture.ts
+++ b/packages/desktop/src/lib/instagram-capture.ts
@@ -22,6 +22,7 @@ import { useAppStore } from "./store";
 import { addDebugEvent } from "@freed/ui/lib/debug-store";
 import { getIgScraperWindowMode } from "./scraper-prefs";
 import { storeIgAuthState } from "./instagram-auth";
+import { attachScraperMediaDiagListener } from "./scraper-media-diag";
 
 // =============================================================================
 // Rate Limiting
@@ -93,6 +94,7 @@ export async function fetchIgFeed(): Promise<IgSyncResult> {
   let unlisten: UnlistenFn | null = null;
 
   try {
+    attachScraperMediaDiagListener("IG", "instagram");
     unlisten = await listen<{
       posts: RawIgPost[];
       error?: string;

--- a/packages/desktop/src/lib/li-capture.ts
+++ b/packages/desktop/src/lib/li-capture.ts
@@ -17,6 +17,7 @@ import {
 import { useAppStore } from "./store";
 import { addDebugEvent } from "@freed/ui/lib/debug-store";
 import { getLiScraperWindowMode } from "./scraper-prefs";
+import { attachScraperMediaDiagListener } from "./scraper-media-diag";
 
 // =============================================================================
 // Rate Limiting
@@ -87,6 +88,7 @@ export async function fetchLiFeed(): Promise<LiSyncResult> {
     let unlisten: UnlistenFn | null = null;
     const allRawPosts: RawLiPost[] = [];
     const seenUrns = new Set<string>();
+    attachScraperMediaDiagListener("LI", "linkedin");
 
     // Timeout if the WebView takes too long
     const timeout = setTimeout(() => {

--- a/packages/desktop/src/lib/scraper-media-diag.ts
+++ b/packages/desktop/src/lib/scraper-media-diag.ts
@@ -1,0 +1,28 @@
+import { listen } from "@tauri-apps/api/event";
+import { addDebugEvent } from "@freed/ui/lib/debug-store";
+
+interface ScraperMediaDiagPayload {
+  provider?: string;
+  kind?: string;
+  reason?: string;
+}
+
+export function attachScraperMediaDiagListener(
+  platformLabel: string,
+  providerToken: string,
+  timeoutMs: number = 35_000,
+): void {
+  listen<ScraperMediaDiagPayload>("freed-scraper-media-diag", (event) => {
+    const provider = (event.payload.provider ?? "unknown").toLowerCase();
+    if (!provider.includes(providerToken)) return;
+
+    const kind = event.payload.kind ?? "media";
+    const reason = event.payload.reason ?? "unknown";
+    addDebugEvent(
+      "change",
+      `[${platformLabel}] silenced ${kind} (${reason}) on ${provider}`,
+    );
+  }).then((unlisten) => {
+    setTimeout(() => void unlisten(), timeoutMs);
+  });
+}

--- a/packages/desktop/src/lib/webkit-mask.test.ts
+++ b/packages/desktop/src/lib/webkit-mask.test.ts
@@ -1,0 +1,90 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const scriptPath = resolve(process.cwd(), "src-tauri/src/webkit-mask.js");
+const script = readFileSync(scriptPath, "utf8");
+
+function nextTick(): Promise<void> {
+  return new Promise((resolveTick) => setTimeout(resolveTick, 0));
+}
+
+describe("webkit-mask.js media guard", () => {
+  beforeEach(() => {
+    const existingDisable = (
+      window as unknown as Record<string, unknown>
+    ).__FREED_SET_BACKGROUND_SCRAPER_MEDIA_GUARD__;
+    if (typeof existingDisable === "function") {
+      (existingDisable as (enabled: boolean) => void)(false);
+    }
+    document.head.innerHTML = "";
+    document.body.innerHTML = "";
+    window.name = "__freed_media_guard__";
+    delete (window as unknown as Record<string, unknown>)
+      .__FREED_SET_BACKGROUND_SCRAPER_CLOAK__;
+    delete (window as unknown as Record<string, unknown>)
+      .__FREED_SET_BACKGROUND_SCRAPER_MEDIA_GUARD__;
+    delete (window as unknown as Record<string, unknown>)
+      .__freedBackgroundScraperMediaGuardState__;
+    delete (window as unknown as Record<string, unknown>).__TAURI__;
+  });
+
+  it("mutes existing video elements during the initial scan", () => {
+    document.body.innerHTML = `<video src="https://cdn.example/video.mp4"></video>`;
+
+    window.eval(script);
+
+    const video = document.querySelector("video") as HTMLVideoElement;
+    expect(video.muted).toBe(true);
+    expect(video.defaultMuted).toBe(true);
+    expect(video.volume).toBe(0);
+  });
+
+  it("mutes and pauses existing audio elements", () => {
+    const audio = document.createElement("audio");
+    const pause = vi.fn();
+    Object.defineProperty(audio, "pause", {
+      configurable: true,
+      value: pause,
+    });
+    document.body.append(audio);
+
+    window.eval(script);
+
+    expect(audio.muted).toBe(true);
+    expect(audio.defaultMuted).toBe(true);
+    expect(audio.volume).toBe(0);
+    expect(pause).toHaveBeenCalledTimes(1);
+  });
+
+  it("silences newly inserted media through the mutation observer", async () => {
+    window.eval(script);
+
+    const video = document.createElement("video");
+    video.src = "https://cdn.example/dynamic.mp4";
+    document.body.append(video);
+    await nextTick();
+
+    expect(video.muted).toBe(true);
+    expect(video.defaultMuted).toBe(true);
+    expect(video.volume).toBe(0);
+  });
+
+  it("does not duplicate media listeners when the script runs twice", () => {
+    const audio = document.createElement("audio");
+    const pause = vi.fn();
+    Object.defineProperty(audio, "pause", {
+      configurable: true,
+      value: pause,
+    });
+    document.body.append(audio);
+
+    window.eval(script);
+    pause.mockClear();
+
+    window.eval(script);
+    audio.dispatchEvent(new Event("play"));
+
+    expect(pause).toHaveBeenCalledTimes(1);
+  });
+});

--- a/website/src/app/roadmap/RoadmapContent.tsx
+++ b/website/src/app/roadmap/RoadmapContent.tsx
@@ -510,7 +510,7 @@ const phases: Phase[] = [
     number: 7,
     title: "Facebook + Instagram",
     description:
-      "Facebook and Instagram integrated via Tauri WebView scraping, with suggested-post filtering, hardened story capture, Facebook group controls, and per-source scraper window modes.",
+      "Facebook and Instagram integrated via Tauri WebView scraping, with suggested-post filtering, hardened story capture, silent background media guarding, Facebook group controls, and per-source scraper window modes.",
     status: "current",
     planLink:
       "https://github.com/freed-project/freed/blob/main/docs/PHASE-7-SOCIAL-CAPTURE.md",
@@ -555,7 +555,7 @@ const phases: Phase[] = [
     number: 12,
     title: "Additional Platforms",
     description:
-      "LinkedIn is in, including matching desktop scraper window controls. Next up: Mozi for social planning, then TikTok, Threads, Bluesky, Reddit, and YouTube.",
+      "LinkedIn is in, including matching desktop scraper window controls and silent background media guarding. Next up: Mozi for social planning, then TikTok, Threads, Bluesky, Reddit, and YouTube.",
     status: "current",
     planLink:
       "https://github.com/freed-project/freed/blob/main/docs/PHASE-12-ADDITIONAL-PLATFORMS.md",


### PR DESCRIPTION
(AI Generated).

## Summary
Silences background media in desktop social scraper WebViews so Facebook, Instagram, and LinkedIn ingestion cannot leak autoplay audio while Freed is syncing.

## What changed
- added a media guard to the injected WebKit mask that force-mutes `audio` and `video`, pauses `audio`, and re-applies on media events and DOM mutations
- enabled that guard across background scrape and auth-check windows in the desktop Tauri scraper lifecycle
- disabled the guard again when reusing a window for visible login flows
- added lightweight frontend debug logging for silenced provider media events
- added unit coverage for the media guard and a regression test confirming muted Instagram story video still extracts correctly
- updated the affected phase docs and roadmap copy

## Root cause
Freed's desktop social ingestion uses real provider WebViews in the background. Facebook and Instagram story viewers, and potentially other provider surfaces, can contain autoplaying media. Those windows were being hidden or cloaked, but not explicitly silenced.

## Validation
- added `packages/desktop/src/lib/webkit-mask.test.ts`
- extended `packages/desktop/src/lib/ig-stories-extract.test.ts`
- ran `git diff --check`
- could not run the desktop JS test suite in this shell because `node`, `npm`, `pnpm`, `yarn`, and `bun` were not available on PATH

## Impact
Background sync should stay silent while preserving story capture and the rest of the desktop social scraping flow.