### PR TITLE
fix: make browser session copy more accurate

### DIFF
--- a/packages/desktop/src/components/FacebookSettingsSection.tsx
+++ b/packages/desktop/src/components/FacebookSettingsSection.tsx
@@ -365,8 +365,10 @@ export function FacebookSettingsSection() {
         </details>
 
         <p className="text-xs text-[#52525b] leading-relaxed">
-          Freed reads your Facebook feed through a native browser session.
-          Your traffic looks identical to normal browsing.
+          Freed reads your Facebook feed through a native browser session to
+          deliver a seamless experience. Reading can potentially be interrupted
+          if Facebook changes their systems in an attempt to keep you in their
+          garden.
         </p>
       </div>
       {dialog}
@@ -381,8 +383,9 @@ export function FacebookSettingsSection() {
     <div className="space-y-4">
       <p className="text-sm text-[#71717a] leading-relaxed">
         Pull your Facebook feed into Freed. Log in through a native browser
-        window. Freed reads your feed the same way you would, so your account
-        stays safe.
+        window to give Freed an authenticated browser session. Reading can
+        potentially be interrupted if Facebook changes their systems in an
+        attempt to keep you in their garden.
       </p>
       <div className="flex gap-2">
         <button

--- a/packages/desktop/src/components/InstagramSettingsSection.tsx
+++ b/packages/desktop/src/components/InstagramSettingsSection.tsx
@@ -254,8 +254,10 @@ export function InstagramSettingsSection() {
         </details>
 
         <p className="text-xs text-[#52525b] leading-relaxed">
-          Freed reads your Instagram feed through a native browser session.
-          Your traffic looks identical to normal browsing.
+          Freed reads your Instagram feed through a native browser session to
+          deliver a seamless experience. Reading can potentially be interrupted
+          if Instagram changes their systems in an attempt to keep you in their
+          garden.
         </p>
       </div>
       {dialog}
@@ -270,8 +272,9 @@ export function InstagramSettingsSection() {
     <div className="space-y-4">
       <p className="text-sm text-[#71717a] leading-relaxed">
         Pull your Instagram feed into Freed. Log in through a native browser
-        window. Freed reads your feed the same way you would, so your account
-        stays safe.
+        window to give Freed an authenticated browser session. Reading can
+        potentially be interrupted if Instagram changes their systems in an
+        attempt to keep you in their garden.
       </p>
       <div className="flex gap-2">
         <button

--- a/packages/desktop/src/components/LinkedInSettingsSection.tsx
+++ b/packages/desktop/src/components/LinkedInSettingsSection.tsx
@@ -254,8 +254,10 @@ export function LinkedInSettingsSection() {
         </details>
 
         <p className="text-xs text-[#52525b] leading-relaxed">
-          Freed reads your LinkedIn feed through a native browser session.
-          Your traffic looks identical to normal browsing.
+          Freed reads your LinkedIn feed through a native browser session to
+          deliver a seamless experience. Reading can potentially be interrupted
+          if LinkedIn changes their systems in an attempt to keep you in their
+          garden.
         </p>
       </div>
       {dialog}
@@ -270,8 +272,9 @@ export function LinkedInSettingsSection() {
     <div className="space-y-4">
       <p className="text-sm text-[#71717a] leading-relaxed">
         Pull your LinkedIn feed into Freed. Log in through a native browser
-        window. Freed reads your feed the same way you would, so your account
-        stays safe.
+        window to give Freed an authenticated browser session. Reading can
+        potentially be interrupted if LinkedIn changes their systems in an
+        attempt to keep you in their garden.
       </p>
       <div className="flex gap-2">
         <button

--- a/website/src/app/privacy/PrivacyContent.tsx
+++ b/website/src/app/privacy/PrivacyContent.tsx
@@ -120,9 +120,9 @@ export default function PrivacyContent() {
                   <strong className="text-text-primary block mb-1">
                     Your credentials never leave your device.
                   </strong>
-                  Freed accesses social platforms through your own authenticated
-                  browser sessions. Credentials are stored in your local
-                  keychain or browser storage and never transmitted to us.
+                  Freed accesses social platforms through authenticated browser
+                  sessions on your device. Session data stays local to your
+                  device and is never transmitted to us.
                 </li>
               </ul>
             </section>


### PR DESCRIPTION
(AI Generated).

## Summary
- replace overconfident social session claims in desktop source settings
- explain that reading can be interrupted if providers change their systems
- tighten privacy copy to say session data stays on the device and is not sent to us