### PR TITLE
fix: refine sharing qr layout

### DIFF
--- a/website/public/qr/classic-neon.svg
+++ b/website/public/qr/classic-neon.svg
@@ -1,17 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" width="666" height="666" viewBox="0 0 666 666" fill="none">
   <rect width="666" height="666" rx="48" fill="#ffffff" />
-  <rect
-    x="36"
-    y="36"
-    width="594"
-    height="594"
-    rx="36"
-    fill="none"
-    stroke="rgba(59,130,246,0.14)"
-    stroke-width="2"
-  />
-  
     <g>
       <rect x="72" y="72" width="126" height="126" rx="12" fill="#050814"/>
       <rect x="90" y="90" width="90" height="90" rx="9" fill="#ffffff"/>

--- a/website/src/app/qr/QrGallery.tsx
+++ b/website/src/app/qr/QrGallery.tsx
@@ -9,51 +9,71 @@ const qrAsset = {
 
 export default function QrGallery() {
   return (
-    <section className="relative min-h-screen overflow-hidden">
-      <div className="absolute inset-0 pointer-events-none">
-        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(6,182,212,0.20),transparent_34%),radial-gradient(circle_at_bottom_right,rgba(59,130,246,0.18),transparent_30%),linear-gradient(180deg,rgba(10,10,10,0.84),rgba(10,10,10,0.98))]" />
-        <div className="absolute inset-0 opacity-40 [background-image:linear-gradient(rgba(255,255,255,0.04)_1px,transparent_1px),linear-gradient(90deg,rgba(255,255,255,0.04)_1px,transparent_1px)] [background-size:72px_72px]" />
-      </div>
+    <section className="relative min-h-[100dvh] overflow-y-auto overflow-x-hidden bg-[var(--theme-bg-root)]">
+      <div className="theme-shell absolute inset-0 pointer-events-none" />
 
-      <div className="relative z-10 mx-auto flex min-h-screen max-w-7xl flex-col bg-black/25 px-4 py-6 shadow-[0_25px_120px_rgba(0,0,0,0.45)] backdrop-blur-sm sm:px-6 sm:py-8 lg:px-10 lg:py-10">
+      <div
+        className="relative z-10 mx-auto flex min-h-[100dvh] max-w-7xl flex-col px-4 sm:px-6 lg:px-8"
+      >
         <div className="absolute inset-0 pointer-events-none">
-          <div className="absolute inset-x-[14%] top-[14%] h-[40%] rounded-full blur-3xl bg-[radial-gradient(circle_at_center,rgba(6,182,212,0.22),rgba(59,130,246,0.14)_38%,transparent_70%)]" />
+          <div className="absolute inset-x-[14%] top-[14%] h-[40%] rounded-full blur-3xl" style={{ background: "radial-gradient(circle at center, rgb(var(--theme-accent-tertiary-rgb) / 0.18), rgb(var(--theme-accent-primary-rgb) / 0.12) 38%, transparent 70%)" }} />
         </div>
 
-        <div className="relative flex flex-1 flex-col items-center justify-between">
+        <div
+          className="relative grid min-h-[100dvh] w-full items-center"
+          style={{ gridTemplateRows: "minmax(clamp(0.75rem,2.6dvh,2rem),1fr) auto minmax(clamp(0.75rem,2.6dvh,2rem),1fr) auto minmax(clamp(0.75rem,2.6dvh,2rem),1fr) auto minmax(clamp(0.75rem,2.6dvh,2rem),1fr)" }}
+        >
+          <div aria-hidden="true" />
+
           <header className="w-full text-center">
-            <h1 className="mx-auto max-w-4xl text-5xl font-bold tracking-[-0.06em] text-white sm:text-6xl lg:text-7xl">
-              Scan to take back your feed
+            <h1 className="theme-display-large mx-auto max-w-5xl text-[clamp(2.15rem,6vw,5.1rem)] font-black leading-[0.88] tracking-[-0.065em]">
+              <span className="gradient-text inline-block">Scan to take back your feed</span>
             </h1>
           </header>
 
-          <div className="relative mt-10 flex w-full flex-1 items-center justify-center py-6 sm:py-10">
-            <div className="relative mx-auto w-full max-w-[46rem] rounded-[2.2rem] border border-cyan-300/14 bg-white/[0.07] p-4 shadow-[0_40px_130px_rgba(6,182,212,0.16)] sm:p-6 lg:p-7">
-              <div className="absolute inset-0 rounded-[2.2rem] bg-[linear-gradient(180deg,rgba(255,255,255,0.08),rgba(255,255,255,0.02))]" />
-              <div className="relative rounded-[1.7rem] bg-white p-5 shadow-[0_20px_80px_rgba(15,23,42,0.22)] sm:p-8">
+          <div aria-hidden="true" />
+
+          <div className="relative flex w-full items-center justify-center">
+            <div className="relative mx-auto aspect-square w-[clamp(10rem,min(84vw,50dvh,31rem),31rem)] min-w-0 rounded-[2rem] bg-white p-[clamp(0.1rem,0.3dvh,0.18rem)] shadow-[0_24px_56px_rgba(0,0,0,0.1)] sm:w-[clamp(10rem,min(78vw,48dvh,32rem),32rem)]">
+              <div className="relative size-full rounded-[1.75rem] bg-white">
                 <Image
                   src={qrAsset.asset}
                   alt="QR code linking to Freed home page"
                   width={666}
                   height={666}
                   unoptimized
-                  className="aspect-square h-auto w-full rounded-[1.1rem]"
+                  className="size-full rounded-[1.65rem]"
                 />
               </div>
             </div>
           </div>
 
-          <footer className="w-full pt-10 pb-6 text-center sm:pt-12 sm:pb-8">
+          <div aria-hidden="true" />
+
+          <footer className="w-full text-center">
             <Link
               href="/"
-              className="text-xl font-semibold tracking-[0.12em] text-white transition-opacity hover:opacity-80 sm:text-2xl"
+              className="inline-flex items-baseline gap-0.5 transition-opacity hover:opacity-80"
             >
-              Freed.wtf
+              <span className="relative text-[clamp(1.15rem,2vw,1.5rem)] font-bold text-text-primary font-logo">
+                FREED
+                <span
+                  className="absolute bottom-0 left-0 right-0 h-0.5 rounded-full"
+                  style={{
+                    background: "var(--theme-logo-spectrum)",
+                  }}
+                />
+              </span>
+              <span className="text-[clamp(0.8rem,1.2vw,1rem)] font-bold gradient-text font-logo">
+                .WTF
+              </span>
             </Link>
-            <p className="mx-auto mt-4 max-w-2xl text-base leading-7 text-text-secondary sm:text-lg">
+            <p className="mx-auto mt-[clamp(0.35rem,1.2dvh,0.7rem)] max-w-2xl text-[clamp(0.9rem,1.35vw,1rem)] leading-[1.45] text-text-secondary">
               Built for humans, not algorithms.
             </p>
           </footer>
+
+          <div aria-hidden="true" />
         </div>
       </div>
     </section>


### PR DESCRIPTION
(AI Generated).

## Summary
- refine the `/qr` page layout so the header, QR card, and footer use predictable vertical spacing
- remove the extra inner page background and let the primary theme background carry the view
- tighten the QR card inset and remove the inner blue ring from the QR asset

## Why
The QR page layout was fragile across themes and viewport sizes. Content was either pinned to the edges, clumped around the QR card, or wrapped in an unnecessary inner background layer that fought the active theme.

## Impact
- normal desktop and mobile layouts fit cleanly without vertical scrolling
- extremely short browser windows can scroll instead of crushing the layout
- the QR card reads more cleanly across themes, including lighter ones

## Validation
- browser automation screenshots at desktop, iPhone 13 portrait, and iPhone 13 landscape
- viewport metric checks confirming no scroll on desktop and standard mobile layouts
- tiny viewport check confirming vertical scroll appears once the window becomes unusually short

## Known build blocker
- `npm run build` in `website/` is currently blocked by a pre-existing baseline issue on `main`: `website/src/components/Footer.tsx` imports `@/components/ThemeSelector`, but that file is missing in this checkout
