### PR TITLE
fix: remove static card hover states

### DIFF
--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -475,7 +475,7 @@ html[data-theme="midas"] .theme-display-large {
     0 22px 56px rgb(0 0 0 / 0.18);
 }
 
-.glass-card:hover {
+.glass-card-interactive:hover {
   background:
     linear-gradient(
       180deg,

--- a/website/src/index.css
+++ b/website/src/index.css
@@ -66,11 +66,6 @@ body {
   }
 }
 
-.glass-card-interactive:hover {
-  background: color-mix(in oklab, var(--theme-bg-surface) 94%, transparent);
-  border-color: var(--theme-border-strong);
-}
-
 .gradient-border {
   position: relative;
   background: var(--theme-bg-surface);


### PR DESCRIPTION
(AI Generated).

## What changed
- moved the shared glass card hover styling behind the opt-in `glass-card-interactive` selector
- removed the website-specific `glass-card-interactive` hover override so there is one source of truth

## Why
Static marketing cards like the How It Works steps were showing hover affordances even though they are not clickable. This made the UI imply interactivity where none existed.

## Impact
- non-clickable glass cards stay visually stable on hover
- clickable cards that already use `glass-card-interactive` keep their hover affordance

## Validation
- verified the CSS diff in a clean branch
- attempted `npm run lint --workspace=website`, but this checkout does not define a `lint` script for that workspace
