### PR TITLE
fix: reorder sidebar sources and unclipped qr heading

### DIFF
--- a/packages/ui/src/components/layout/Sidebar.tsx
+++ b/packages/ui/src/components/layout/Sidebar.tsx
@@ -586,6 +586,25 @@ export function Sidebar({ open, onClose }: SidebarProps) {
   const allSource = TOP_SOURCE_ITEMS[0];
   const providerSourceItems = TOP_SOURCE_ITEMS.slice(1);
 
+  const sourceOrderClass = (source: SourceNavigationItem) => {
+    switch (source.id) {
+      case undefined:
+        return "order-1";
+      case "x":
+        return "order-6";
+      case "facebook":
+        return "order-7";
+      case "instagram":
+        return "order-8";
+      case "linkedin":
+        return "order-9";
+      case "rss":
+        return "order-10";
+      default:
+        return "";
+    }
+  };
+
   const settingsSectionForSource = (source: SourceNavigationItem) => {
     if (source.id === undefined) return null;
     if (source.id === "rss") return "feeds";
@@ -703,11 +722,11 @@ export function Sidebar({ open, onClose }: SidebarProps) {
         >
           <SearchJumpField />
 
-          <ul className="space-y-1">
+          <ul className="flex flex-col gap-1">
             {[allSource].map((source) => (
                 <li
                   key={source.id ?? "all"}
-                  className={`group/source flex items-stretch gap-2 rounded-lg border transition-all ${
+                  className={`order-1 group/source flex items-stretch gap-2 rounded-lg border transition-all ${
                     isTopSourceActive(source)
                       ? "border-[var(--theme-border-strong)] bg-[rgb(var(--theme-accent-secondary-rgb)/0.18)] text-[var(--theme-text-primary)]"
                       : "border-transparent text-[var(--theme-text-secondary)] hover:bg-[var(--theme-bg-muted)] hover:text-[var(--theme-text-primary)]"
@@ -763,7 +782,7 @@ export function Sidebar({ open, onClose }: SidebarProps) {
                   </div>
                 </li>
               ))}
-            <li>
+            <li className="order-4">
               <button
                 onClick={() => showFeed({ savedOnly: true })}
                 className={`
@@ -783,7 +802,7 @@ export function Sidebar({ open, onClose }: SidebarProps) {
                 )}
               </button>
             </li>
-            <li>
+            <li className="order-5">
               <button
                 onClick={() => showFeed({ archivedOnly: true })}
                 className={`
@@ -803,7 +822,7 @@ export function Sidebar({ open, onClose }: SidebarProps) {
                 )}
               </button>
             </li>
-            <li>
+            <li className="order-2">
               <button
                 onClick={() => {
                   setActiveView("friends");
@@ -840,7 +859,7 @@ export function Sidebar({ open, onClose }: SidebarProps) {
                 )}
               </button>
             </li>
-            <li>
+            <li className="order-3">
               <button
                 onClick={() => {
                   setActiveView("map");
@@ -879,15 +898,16 @@ export function Sidebar({ open, onClose }: SidebarProps) {
 
                 if (isRssSource) {
                   return (
-                    <li key={sourceKey(source)}>
-                      <div
-                        className={`group/source rounded-lg border transition-all ${
+                    <li key={sourceKey(source)} className={sourceOrderClass(source)}>
+                      <div className="space-y-1">
+                        <div
+                          className={`group/source rounded-lg border transition-all ${
                           isTopSourceActive(source)
                             ? "border-[color:var(--theme-border-strong)] bg-[rgb(var(--theme-accent-secondary-rgb)/0.18)] text-[color:var(--theme-text-primary)]"
                             : "border-transparent text-[color:var(--theme-text-secondary)] hover:bg-[color:var(--theme-bg-muted)] hover:text-[color:var(--theme-text-primary)]"
-                        }`}
-                      >
-                        <div className="flex items-stretch gap-2">
+                          }`}
+                        >
+                          <div className="flex items-stretch gap-2">
                           <div className="flex min-w-0 items-center gap-1.5 pl-3 py-1.5">
                             <button
                               onClick={() => handleSourceClick(source)}
@@ -985,10 +1005,11 @@ export function Sidebar({ open, onClose }: SidebarProps) {
                               ) : null}
                             </div>
                           </div>
+                          </div>
                         </div>
 
                         {rssFeedsOpen && (
-                          <div className="mt-1 ml-8 border-l border-[color:var(--theme-border-subtle)] pl-2">
+                          <div className="ml-8 border-l border-[color:var(--theme-border-subtle)] pl-2">
                             {visibleFeedList.length > 0 ? (
                               <>
                                 <ul className="space-y-0.5">
@@ -1110,7 +1131,7 @@ export function Sidebar({ open, onClose }: SidebarProps) {
                 return (
                   <li
                     key={source.id ?? "all"}
-                    className={`group/source flex items-stretch gap-2 rounded-lg border transition-all ${
+                    className={`${sourceOrderClass(source)} group/source flex items-stretch gap-2 rounded-lg border transition-all ${
                       isTopSourceActive(source)
                         ? "border-[color:var(--theme-border-strong)] bg-[rgb(var(--theme-accent-secondary-rgb)/0.18)] text-[color:var(--theme-text-primary)]"
                         : "border-transparent text-[color:var(--theme-text-secondary)] hover:bg-[color:var(--theme-bg-muted)] hover:text-[color:var(--theme-text-primary)]"

--- a/packages/ui/src/lib/source-navigation.tsx
+++ b/packages/ui/src/lib/source-navigation.tsx
@@ -15,7 +15,7 @@ export interface SourceNavigationItem {
 }
 
 export const TOP_SOURCE_ITEMS: readonly SourceNavigationItem[] = [
-  { id: undefined, label: "All", icon: <AllIcon /> },
+  { id: undefined, label: "Unified Feed", icon: <AllIcon /> },
   { id: "rss", label: "Feeds", icon: <RssIcon /> },
   { id: "x", label: "X", icon: <span className="text-sm font-bold leading-none">X</span> },
   { id: "facebook", label: "Facebook", icon: <FacebookIcon /> },

--- a/website/src/app/qr/QrGallery.tsx
+++ b/website/src/app/qr/QrGallery.tsx
@@ -26,8 +26,8 @@ export default function QrGallery() {
           <div aria-hidden="true" />
 
           <header className="w-full text-center">
-            <h1 className="theme-display-large mx-auto max-w-5xl text-[clamp(2.15rem,6vw,5.1rem)] font-black leading-[0.88] tracking-[-0.065em]">
-              <span className="gradient-text inline-block">Scan to take back your feed</span>
+            <h1 className="theme-display-large mx-auto max-w-5xl overflow-visible text-[clamp(2.15rem,6vw,5.1rem)] font-black leading-[0.88] tracking-[-0.065em]">
+              <span className="gradient-text inline-block pb-[0.08em]">Scan to take back your feed</span>
             </h1>
           </header>
 


### PR DESCRIPTION
(AI Generated).

## What changed

- renamed the primary sidebar `All` entry to `Unified Feed`
- reordered the primary sidebar to show Unified Feed, Friends, Map, Saved, Archived, X, Facebook, Instagram, LinkedIn, then Feeds
- kept the expanded Feeds child list visually separate so the parent row alone owns the hover and active treatment
- added a small descender-safe buffer to the QR heading so the tight hero line height no longer clips letters like `y`

## Why

- the sidebar order needed to match the requested reading order
- the Feeds accordion was styling the parent and children as one highlighted block when expanded
- the QR page heading was using a very tight line box and clipping descenders in Chrome

## Validation

- reviewed the scoped diff in a clean branch based on `main`
- attempted a focused TypeScript check, but the ad hoc compiler invocation from the clean worktree could not resolve the workspace package graph and Next types through that external-file path setup
