### PR TITLE
fix: polish roadmap icons, hero motion, and changelog pagination

### DIFF
--- a/docs/PHASE-5-DESKTOP.md
+++ b/docs/PHASE-5-DESKTOP.md
@@ -280,7 +280,7 @@ export async function captureDomFeed(
 > separate `Features`, `Fixes`, and `Follow-ups` sections so the card headline
 > can reinforce the theme without collapsing the details into one bucket. The
 > desktop updater now shows only that reviewed opener line when an update is
-> available. The public changelog now paginates in URL-addressable sets of 10
+> available. The public changelog now paginates in URL-addressable sets of 5
 > releases so older builds can be linked directly without turning the page
 > into a mile-long papyrus scroll, and card hover states now key off the
 > existing timeline lane instead of inventing a second internal accent rail.

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -124,6 +124,19 @@ html[data-theme="neon"] {
     var(--theme-accent-tertiary) 70%,
     white 30%
   );
+  --theme-status-active-progress: rgb(113 113 122 / 0.9);
+  --theme-card-top-glint: rgb(255 255 255 / 0.022);
+  --theme-card-top-glint-hover: rgb(255 255 255 / 0.03);
+  --theme-card-top-accent: color-mix(
+    in srgb,
+    var(--theme-heading-accent) 4%,
+    transparent
+  );
+  --theme-card-top-accent-hover: color-mix(
+    in srgb,
+    var(--theme-heading-accent) 6%,
+    transparent
+  );
   --theme-header-background: rgb(10 10 10 / 0.7);
   --theme-header-border: rgb(255 255 255 / 0.08);
   --theme-header-shadow: 0 4px 30px rgb(0 0 0 / 0.5);
@@ -264,6 +277,23 @@ html[data-theme="midas"] {
   --theme-status-complete-border: rgb(176 138 72 / 0.28);
   --theme-status-complete-bg: rgb(176 138 72 / 0.08);
   --theme-status-complete-text: #d0b89c;
+  --theme-status-active-progress: color-mix(
+    in srgb,
+    var(--theme-accent-primary) 38%,
+    var(--theme-text-soft) 62%
+  );
+  --theme-card-top-glint: rgb(255 255 255 / 0.04);
+  --theme-card-top-glint-hover: rgb(255 255 255 / 0.05);
+  --theme-card-top-accent: color-mix(
+    in srgb,
+    var(--theme-heading-accent) 7%,
+    transparent
+  );
+  --theme-card-top-accent-hover: color-mix(
+    in srgb,
+    var(--theme-heading-accent) 10%,
+    transparent
+  );
   --theme-feedback-info-rgb: 176 138 72;
   --theme-feedback-success-rgb: 122 156 104;
   --theme-feedback-warning-rgb: 196 154 93;
@@ -373,6 +403,23 @@ html[data-theme="ember"] {
   --theme-status-complete-border: rgb(193 90 46 / 0.26);
   --theme-status-complete-bg: rgb(193 90 46 / 0.08);
   --theme-status-complete-text: #d9895a;
+  --theme-status-active-progress: color-mix(
+    in srgb,
+    var(--theme-accent-primary) 28%,
+    var(--theme-text-soft) 72%
+  );
+  --theme-card-top-glint: rgb(255 255 255 / 0.04);
+  --theme-card-top-glint-hover: rgb(255 255 255 / 0.05);
+  --theme-card-top-accent: color-mix(
+    in srgb,
+    var(--theme-heading-accent) 7%,
+    transparent
+  );
+  --theme-card-top-accent-hover: color-mix(
+    in srgb,
+    var(--theme-heading-accent) 10%,
+    transparent
+  );
   --theme-feedback-info-rgb: 193 90 46;
   --theme-feedback-success-rgb: 112 155 91;
   --theme-feedback-warning-rgb: 215 142 78;
@@ -495,6 +542,23 @@ html[data-theme="scriptorium"] {
   --theme-status-complete-border: rgb(132 100 68 / 0.22);
   --theme-status-complete-bg: rgb(132 100 68 / 0.06);
   --theme-status-complete-text: #86684a;
+  --theme-status-active-progress: color-mix(
+    in srgb,
+    var(--theme-accent-primary) 18%,
+    var(--theme-text-soft) 82%
+  );
+  --theme-card-top-glint: rgb(255 255 255 / 0.04);
+  --theme-card-top-glint-hover: rgb(255 255 255 / 0.05);
+  --theme-card-top-accent: color-mix(
+    in srgb,
+    var(--theme-heading-accent) 7%,
+    transparent
+  );
+  --theme-card-top-accent-hover: color-mix(
+    in srgb,
+    var(--theme-heading-accent) 10%,
+    transparent
+  );
   --theme-header-background: rgb(249 241 226 / 0.985);
   --theme-header-border: rgb(132 100 68 / 0.12);
   --theme-header-shadow: 0 4px 10px rgb(84 58 35 / 0.035);
@@ -836,7 +900,7 @@ html[data-theme="scriptorium"] .theme-panel-muted {
 .glass-card {
   position: relative;
   background:
-    linear-gradient(180deg, rgb(255 255 255 / 0.04), transparent 18%),
+    linear-gradient(180deg, var(--theme-card-top-glint), transparent 18%),
     color-mix(in oklab, var(--theme-bg-surface) 82%, transparent);
   backdrop-filter: blur(20px) saturate(145%);
   -webkit-backdrop-filter: blur(20px) saturate(145%);
@@ -860,7 +924,7 @@ html[data-theme="scriptorium"] .glass-card {
 
 .glass-card-interactive:hover {
   background:
-    linear-gradient(180deg, rgb(255 255 255 / 0.05), transparent 18%),
+    linear-gradient(180deg, var(--theme-card-top-glint-hover), transparent 18%),
     color-mix(in oklab, var(--theme-bg-surface) 88%, transparent);
   border-color: color-mix(
     in oklab,
@@ -893,7 +957,7 @@ html[data-theme="scriptorium"] .glass-card-interactive:hover {
   background:
     linear-gradient(
       180deg,
-      color-mix(in srgb, var(--theme-heading-accent) 10%, transparent) 0%,
+      var(--theme-card-top-accent-hover) 0%,
       transparent 5.5rem
     ),
     color-mix(in oklab, var(--theme-bg-card-hover) 54%, var(--theme-bg-surface));
@@ -920,14 +984,18 @@ html[data-theme="scriptorium"] .glass-card-interactive:hover {
   );
 }
 
-.release-entry:hover .release-timeline-line,
-.release-entry:focus-within .release-timeline-line {
-  background: linear-gradient(
-    to bottom,
-    color-mix(in srgb, var(--theme-heading-accent) 58%, transparent) 0%,
-    color-mix(in srgb, var(--theme-accent-tertiary) 26%, transparent) 100%
-  ) !important;
-  transform: translateX(3px);
+.release-timeline-line-base,
+.release-timeline-line-hover {
+  transition: opacity 300ms ease;
+}
+
+.release-timeline-line-hover {
+  opacity: 0;
+}
+
+.release-entry:hover .release-timeline-line-hover,
+.release-entry:focus-within .release-timeline-line-hover {
+  opacity: 1;
 }
 
 .release-entry:hover .release-timeline-node,
@@ -952,6 +1020,50 @@ html[data-theme="scriptorium"] .release-entry:focus-within .release-card-shell {
   box-shadow:
     0 14px 26px rgb(84 58 35 / 0.08),
     0 0 0 1px color-mix(in srgb, var(--theme-heading-accent) 10%, transparent);
+}
+
+html[data-theme="scriptorium"] .phase-card-upcoming {
+  background: color-mix(
+    in oklab,
+    var(--theme-bg-deep) 56%,
+    var(--theme-bg-root)
+  ) !important;
+  border-color: color-mix(
+    in srgb,
+    var(--theme-border-subtle) 72%,
+    transparent
+  ) !important;
+  opacity: 0.78;
+}
+
+html[data-theme="scriptorium"] .phase-card-current {
+  background: color-mix(
+    in oklab,
+    var(--theme-accent-secondary) 11%,
+    var(--theme-bg-surface)
+  ) !important;
+  border-color: color-mix(
+    in srgb,
+    var(--theme-accent-primary) 26%,
+    var(--theme-border-subtle)
+  ) !important;
+  box-shadow:
+    0 10px 24px rgb(84 58 35 / 0.06),
+    0 0 0 1px color-mix(in srgb, var(--theme-accent-secondary) 8%, transparent);
+}
+
+html[data-theme="scriptorium"] .phase-card-complete {
+  background: color-mix(
+    in oklab,
+    var(--theme-accent-secondary) 9%,
+    var(--theme-bg-surface)
+  ) !important;
+  border-color: color-mix(
+    in srgb,
+    var(--theme-accent-primary) 22%,
+    var(--theme-border-subtle)
+  ) !important;
+  box-shadow: 0 8px 18px rgb(84 58 35 / 0.045);
 }
 
 .theme-tooltip-panel {

--- a/website/src/app/changelog/ChangelogContent.tsx
+++ b/website/src/app/changelog/ChangelogContent.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import { motion, useInView } from "framer-motion";
 import type { CSSProperties } from "react";
-import { useRef } from "react";
+import { useMemo, useRef } from "react";
 import type { ParsedRelease } from "@/content/changelog";
 
 function formatDate(iso: string): string {
@@ -16,7 +17,76 @@ function formatDate(iso: string): string {
 }
 
 function getPageHref(page: number): string {
-  return page <= 1 ? "/changelog" : `/changelog/page/${page.toString()}`;
+  return page <= 1 ? "/changelog" : `/changelog/${page.toString()}`;
+}
+
+function shouldAnimateChangelogHeader(pathname: string): boolean {
+  if (typeof window === "undefined") {
+    return true;
+  }
+
+  try {
+    const previousPath = sessionStorage.getItem("freed-previous-path");
+    const currentPath = sessionStorage.getItem("freed-current-path");
+    const priorPath = currentPath === pathname ? previousPath : currentPath;
+
+    return priorPath ? !priorPath.startsWith("/changelog") : true;
+  } catch {
+    return true;
+  }
+}
+
+function PaginationNav({
+  currentPage,
+  totalPages,
+  className = "",
+}: {
+  currentPage: number;
+  totalPages: number;
+  className?: string;
+}) {
+  if (totalPages <= 1) {
+    return null;
+  }
+
+  return (
+    <nav
+      aria-label="Changelog pagination"
+      className={`text-sm text-text-muted ${className}`.trim()}
+    >
+      <div className="flex flex-wrap items-center justify-center gap-x-1 gap-y-2">
+        {Array.from({ length: totalPages }, (_, index) => {
+          const page = index + 1;
+          const isCurrent = page === currentPage;
+          const label = page === 1 ? "Latest" : page.toLocaleString();
+
+          return (
+            <span key={page} className="flex items-center">
+              {isCurrent ? (
+                <span
+                  aria-current="page"
+                  className="rounded-md px-2 py-1 text-text-primary underline underline-offset-4 decoration-1"
+                  style={{
+                    textDecorationColor:
+                      "color-mix(in srgb, var(--theme-heading-accent) 72%, transparent)",
+                  }}
+                >
+                  {label}
+                </span>
+              ) : (
+                <Link
+                  href={getPageHref(page)}
+                  className="rounded-md px-2 py-1 transition-colors hover:text-text-primary"
+                >
+                  {label}
+                </Link>
+              )}
+            </span>
+          );
+        })}
+      </div>
+    </nav>
+  );
 }
 
 // ── Individual release card ───────────────────────────────────────────────────
@@ -49,13 +119,22 @@ function ReleaseCard({
         style={{ width: 24, flexShrink: 0 }}
       >
         {/* Vertical line below node (hidden on last item) */}
-        <div
-          className="release-timeline-line absolute top-6 bottom-0 w-px last:hidden transition-all duration-300"
-          style={{
-            background:
-              "linear-gradient(to bottom, color-mix(in srgb, var(--theme-accent-secondary) 40%, transparent) 0%, color-mix(in srgb, var(--theme-accent-tertiary) 15%, transparent) 100%)",
-          }}
-        />
+        <div className="release-timeline-line absolute top-6 bottom-0 w-px last:hidden">
+          <div
+            className="release-timeline-line-base absolute inset-0"
+            style={{
+              background:
+                "linear-gradient(to bottom, color-mix(in srgb, var(--theme-accent-secondary) 40%, transparent) 0%, color-mix(in srgb, var(--theme-accent-tertiary) 15%, transparent) 100%)",
+            }}
+          />
+          <div
+            className="release-timeline-line-hover absolute inset-0"
+            style={{
+              background:
+                "linear-gradient(to bottom, color-mix(in srgb, var(--theme-heading-accent) 58%, transparent) 0%, color-mix(in srgb, var(--theme-accent-tertiary) 26%, transparent) 100%)",
+            }}
+          />
+        </div>
 
         {/* Node */}
         <div className="release-timeline-node relative z-10 mt-1 transition-transform duration-300">
@@ -306,18 +385,21 @@ export default function ChangelogContent({
   totalPages: number;
   pageRange: { start: number; end: number; total: number };
 }) {
-  const hasPreviousPage = currentPage > 1;
-  const hasNextPage = currentPage < totalPages;
+  const pathname = usePathname();
+  const shouldAnimateHeader = useMemo(
+    () => shouldAnimateChangelogHeader(pathname),
+    [pathname]
+  );
 
   return (
     <section className="py-24 sm:py-32 px-4 sm:px-6 md:px-12 lg:px-8">
       <div className="max-w-2xl mx-auto">
         {/* Header */}
         <motion.header
-          initial={{ opacity: 0, y: 20 }}
+          initial={shouldAnimateHeader ? { opacity: 0, y: 20 } : false}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.6 }}
-          className="text-center mb-16 sm:mb-20"
+          className="text-center mb-10 sm:mb-12"
         >
           <h1 className="theme-display-large text-3xl sm:text-5xl font-bold mb-4">
             <span className="theme-heading-accent">Changelog</span>
@@ -325,13 +407,6 @@ export default function ChangelogContent({
           <p className="text-text-secondary text-base sm:text-lg">
             Even death stars have an exhaust vent.
           </p>
-          {pageRange.total > 0 && (
-            <p className="mt-3 text-sm text-text-muted">
-              Showing versions {pageRange.start.toLocaleString()} to{" "}
-              {pageRange.end.toLocaleString()} of{" "}
-              {pageRange.total.toLocaleString()}
-            </p>
-          )}
         </motion.header>
 
         {/* Empty state */}
@@ -345,18 +420,15 @@ export default function ChangelogContent({
           </motion.div>
         )}
 
+        <PaginationNav
+          currentPage={currentPage}
+          totalPages={totalPages}
+          className="mb-6"
+        />
+
         {/* Timeline */}
         {releases.length > 0 && (
           <div className="relative">
-            {/* Faint background track for the full timeline line */}
-            <div
-              className="absolute left-[11px] top-2 bottom-0 w-px pointer-events-none"
-              style={{
-                background:
-                  "linear-gradient(to bottom, color-mix(in srgb, var(--theme-accent-secondary) 12%, transparent) 0%, color-mix(in srgb, var(--theme-accent-tertiary) 4%, transparent) 100%)",
-              }}
-            />
-
             <div>
               {releases.map((release, index) => (
                 <ReleaseCard
@@ -370,53 +442,11 @@ export default function ChangelogContent({
           </div>
         )}
 
-        {totalPages > 1 && (
-          <motion.nav
-            initial={{ opacity: 0, y: 12 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ delay: 0.35 }}
-            aria-label="Changelog pagination"
-            className="mt-12 flex flex-col gap-4 rounded-xl border border-freed-border bg-freed-surface/40 p-4 sm:flex-row sm:items-center sm:justify-between"
-          >
-            <div className="text-sm text-text-muted">
-              Page {currentPage.toLocaleString()} of{" "}
-              {totalPages.toLocaleString()}
-            </div>
-
-            <div className="flex items-center gap-3">
-              <Link
-                href={
-                  hasPreviousPage
-                    ? getPageHref(currentPage - 1)
-                    : getPageHref(currentPage)
-                }
-                aria-disabled={!hasPreviousPage}
-                className={`rounded-lg border px-3 py-2 text-sm transition-colors ${
-                  hasPreviousPage
-                    ? "border-freed-border text-text-secondary hover:border-[color:var(--theme-heading-accent)] hover:text-text-primary"
-                    : "pointer-events-none border-freed-border/60 text-text-muted opacity-50"
-                }`}
-              >
-                Newer
-              </Link>
-              <Link
-                href={
-                  hasNextPage
-                    ? getPageHref(currentPage + 1)
-                    : getPageHref(currentPage)
-                }
-                aria-disabled={!hasNextPage}
-                className={`rounded-lg border px-3 py-2 text-sm transition-colors ${
-                  hasNextPage
-                    ? "border-freed-border text-text-secondary hover:border-[color:var(--theme-heading-accent)] hover:text-text-primary"
-                    : "pointer-events-none border-freed-border/60 text-text-muted opacity-50"
-                }`}
-              >
-                Older
-              </Link>
-            </div>
-          </motion.nav>
-        )}
+        <PaginationNav
+          currentPage={currentPage}
+          totalPages={totalPages}
+          className="mt-8"
+        />
 
         {/* Footer CTA */}
         {releases.length > 0 && (
@@ -432,7 +462,7 @@ export default function ChangelogContent({
               rel="noopener noreferrer"
               className="text-sm text-text-muted transition-colors hover:text-text-primary"
             >
-              View all releases on GitHub →
+              View all {pageRange.total.toLocaleString()} releases on GitHub →
             </a>
           </motion.div>
         )}

--- a/website/src/app/changelog/ChangelogContent.tsx
+++ b/website/src/app/changelog/ChangelogContent.tsx
@@ -198,8 +198,6 @@ function ReleaseCard({
           style={{
             borderColor:
               "color-mix(in srgb, var(--theme-border-subtle) 92%, transparent)",
-            background:
-              "linear-gradient(180deg, color-mix(in srgb, var(--theme-heading-accent) 7%, transparent) 0%, transparent 5rem), color-mix(in srgb, var(--theme-bg-surface) 88%, transparent)",
             boxShadow: isLatest
               ? "0 16px 34px rgb(var(--theme-shell-rgb) / 0.22)"
               : "0 12px 26px rgb(var(--theme-shell-rgb) / 0.16)",

--- a/website/src/app/changelog/[page]/page.tsx
+++ b/website/src/app/changelog/[page]/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import ChangelogContent from "../../ChangelogContent";
+import ChangelogContent from "../ChangelogContent";
 import {
   buildChangelogMetadata,
   getChangelogPageRange,
@@ -7,7 +7,7 @@ import {
   getChangelogPaginationStaticParams,
   getChangelogTotalPages,
   parseChangelogPage,
-} from "../../pagination";
+} from "../pagination";
 
 interface Props {
   params: Promise<{ page: string }>;
@@ -17,16 +17,12 @@ export function generateStaticParams(): Array<{ page: string }> {
   return getChangelogPaginationStaticParams();
 }
 
-export async function generateMetadata({
-  params,
-}: Props): Promise<Metadata> {
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { page } = await params;
   return buildChangelogMetadata(parseChangelogPage(page));
 }
 
-export default async function ChangelogPaginationPage({
-  params,
-}: Props) {
+export default async function ChangelogPaginationPage({ params }: Props) {
   const { page } = await params;
   const currentPage = parseChangelogPage(page);
 

--- a/website/src/app/changelog/pagination.ts
+++ b/website/src/app/changelog/pagination.ts
@@ -3,7 +3,7 @@ import { notFound } from "next/navigation";
 import changelogReleases from "@/content/changelog.generated.json";
 import type { ParsedRelease } from "@/content/changelog";
 
-export const CHANGELOG_PAGE_SIZE = 10;
+export const CHANGELOG_PAGE_SIZE = 5;
 
 const allReleases = changelogReleases as ParsedRelease[];
 
@@ -16,7 +16,7 @@ export function getChangelogTotalPages(): number {
 }
 
 export function getChangelogPageHref(page: number): string {
-  return page <= 1 ? "/changelog" : `/changelog/page/${page.toString()}`;
+  return page <= 1 ? "/changelog" : `/changelog/${page.toString()}`;
 }
 
 export function parseChangelogPage(value: string | number | undefined): number {

--- a/website/src/app/roadmap/RoadmapContent.tsx
+++ b/website/src/app/roadmap/RoadmapContent.tsx
@@ -87,19 +87,181 @@ const CLIENT_ICONS = [
   {
     id: "mobile",
     label: "Mobile",
-    path: "M17 1.01L7 1c-1.1 0-2 .9-2 2v18c0 1.1.9 2 2 2h10c1.1 0 2-.9 2-2V3c0-1.1-.9-1.99-2-1.99zM17 19H7V5h10v14z",
+    kind: "phone" as const,
   },
   {
     id: "pwa",
     label: "PWA",
-    path: "M21 3H3c-1.1 0-2 .9-2 2v11c0 1.1.9 2 2 2h7l-1.5 3h7L14 18h7c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 13H3V5h18v11zm-8-9h-2v3H8l4 4 4-4h-3V7z",
+    kind: "browser" as const,
   },
   {
     id: "desktop-viewer",
     label: "Desktop Viewer",
-    path: "M21 2H3c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h7v2H8v2h8v-2h-2v-2h7c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm-7 13H3V4h18v11h-5l-2 2-2-2z",
+    kind: "viewer" as const,
   },
 ];
+
+function FreedDesktopIcon() {
+  return (
+    <g aria-hidden="true">
+      <rect
+        x="22"
+        y="23"
+        width="56"
+        height="38"
+        rx="8"
+        fill="none"
+        stroke="var(--theme-text-primary)"
+        strokeWidth="2"
+      />
+      <text
+        x="50"
+        y="52"
+        fill="var(--theme-text-primary)"
+        fontSize="27"
+        fontWeight="700"
+        textAnchor="middle"
+      >
+        F
+      </text>
+      <rect
+        x="44"
+        y="62"
+        width="12"
+        height="4"
+        rx="2"
+        fill="var(--theme-text-primary)"
+      />
+      <rect
+        x="38"
+        y="66.5"
+        width="24"
+        height="3"
+        rx="1.5"
+        fill="var(--theme-text-primary)"
+      />
+    </g>
+  );
+}
+
+function ClientIcon({
+  kind,
+}: {
+  kind: "phone" | "browser" | "viewer";
+}) {
+  const color = "var(--theme-text-secondary)";
+
+  if (kind === "phone") {
+    const phoneColor = "var(--theme-text-primary)";
+    return (
+      <g aria-hidden="true">
+        <rect
+          x="15.5"
+          y="5.5"
+          width="19"
+          height="29"
+          rx="4"
+          fill="none"
+          stroke={phoneColor}
+          strokeWidth="2"
+        />
+        <path
+          d="M22 10.5h6"
+          fill="none"
+          stroke={phoneColor}
+          strokeWidth="1.5"
+          strokeLinecap="round"
+        />
+        <rect
+          x="19"
+          y="13.5"
+          width="12"
+          height="13"
+          rx="2.2"
+          fill="none"
+          stroke={phoneColor}
+          strokeWidth="1.6"
+        />
+        <circle cx="25" cy="29.8" r="1.1" fill={phoneColor} />
+      </g>
+    );
+  }
+
+  if (kind === "browser") {
+    return (
+      <g aria-hidden="true">
+        <rect
+          x="7"
+          y="8"
+          width="36"
+          height="24"
+          rx="5"
+          fill="none"
+          stroke={color}
+          strokeWidth="2"
+        />
+        <path
+          d="M9.5 14h31"
+          fill="none"
+          stroke={color}
+          strokeWidth="1.8"
+          strokeLinecap="round"
+        />
+        <circle cx="13" cy="11.2" r="1.1" fill={color} />
+        <circle cx="17" cy="11.2" r="1.1" fill={color} />
+        <circle cx="21" cy="11.2" r="1.1" fill={color} />
+        <circle
+          cx="25"
+          cy="23"
+          r="6.5"
+          fill="none"
+          stroke={color}
+          strokeWidth="1.6"
+        />
+        <path
+          d="M18.5 23h13M25 16.7c2.4 2.8 2.4 12.5 0 12.5M25 16.7c-2.4 2.8-2.4 12.5 0 12.5"
+          fill="none"
+          stroke={color}
+          strokeWidth="1.4"
+          strokeLinecap="round"
+        />
+      </g>
+    );
+  }
+
+  return (
+    <g aria-hidden="true">
+      <rect
+        x="8"
+        y="8"
+        width="34"
+        height="22"
+        rx="4"
+        fill="none"
+        stroke={color}
+        strokeWidth="2"
+      />
+      <rect x="22" y="30" width="6" height="3" rx="1.5" fill={color} />
+      <rect x="18" y="33" width="14" height="2.5" rx="1.25" fill={color} />
+      <path
+        d="M25 12a6.8 6.8 0 1 1-3.7 12.6l-2.8 1.6.9-3.1A6.8 6.8 0 0 1 25 12z"
+        fill="none"
+        stroke={color}
+        strokeWidth="1.5"
+        strokeLinejoin="round"
+      />
+      <circle cx="23.2" cy="16.6" r="0.95" fill={color} />
+      <circle cx="28.2" cy="16.6" r="0.95" fill={color} />
+      <path
+        d="M22.8 19.5c1.4 1.3 4.8 1.3 6.2 0"
+        fill="none"
+        stroke={color}
+        strokeWidth="1.3"
+        strokeLinecap="round"
+      />
+    </g>
+  );
+}
 
 interface DataParticle {
   id: number;
@@ -118,10 +280,32 @@ interface DataParticle {
 
 function useDataFlow(layout: (typeof LAYOUT)["desktop"]) {
   const [particles, setParticles] = useState<DataParticle[]>([]);
+  const [capturePulseKeys, setCapturePulseKeys] = useState<number[]>(() =>
+    CAPTURE_ICONS.map(() => 0),
+  );
+  const [clientPulseKeys, setClientPulseKeys] = useState<number[]>(() =>
+    CLIENT_ICONS.map(() => 0),
+  );
   const nextId = useRef(0);
   const frameRef = useRef<number>(0);
   const layoutRef = useRef(layout);
   layoutRef.current = layout;
+
+  const pulseCapture = useCallback((index: number) => {
+    setCapturePulseKeys((prev) => {
+      const next = [...prev];
+      next[index] += 1;
+      return next;
+    });
+  }, []);
+
+  const pulseClient = useCallback((index: number) => {
+    setClientPulseKeys((prev) => {
+      const next = [...prev];
+      next[index] += 1;
+      return next;
+    });
+  }, []);
 
   const spawnParticle = useCallback(() => {
     const isCapture = Math.random() > 0.3;
@@ -136,6 +320,7 @@ function useDataFlow(layout: (typeof LAYOUT)["desktop"]) {
 
     if (isCapture) {
       const sourceIndex = Math.floor(Math.random() * 4);
+      pulseCapture(sourceIndex);
       const particle: DataParticle = {
         id: nextId.current++,
         x: 60,
@@ -169,21 +354,39 @@ function useDataFlow(layout: (typeof LAYOUT)["desktop"]) {
       };
       setParticles((prev) => [...prev, particle]);
     }
-  }, []);
+  }, [pulseCapture]);
 
   const tick = useCallback(() => {
+    const completedClientTargets: number[] = [];
+
     setParticles((prev) =>
       prev
-        .map((p) => ({
-          ...p,
-          progress: p.progress + p.speed,
-          x: p.x + (p.targetX - p.x) * p.speed * 3,
-          y: p.y + (p.targetY - p.y) * p.speed * 3,
-        }))
-        .filter((p) => p.progress < 1),
+        .map((p) => {
+          const progress = p.progress + p.speed;
+          return {
+            ...p,
+            progress,
+            x: p.x + (p.targetX - p.x) * p.speed * 3,
+            y: p.y + (p.targetY - p.y) * p.speed * 3,
+          };
+        })
+        .filter((p) => {
+          const isComplete = p.progress >= 1;
+          if (isComplete && p.path === "sync-to-client") {
+            completedClientTargets.push(p.targetIndex);
+          }
+          return !isComplete;
+        }),
     );
+
+    if (completedClientTargets.length > 0) {
+      completedClientTargets.forEach((targetIndex) => {
+        pulseClient(targetIndex);
+      });
+    }
+
     frameRef.current = requestAnimationFrame(tick);
-  }, []);
+  }, [pulseClient]);
 
   useEffect(() => {
     frameRef.current = requestAnimationFrame(tick);
@@ -194,13 +397,13 @@ function useDataFlow(layout: (typeof LAYOUT)["desktop"]) {
     };
   }, [tick, spawnParticle]);
 
-  return particles;
+  return { particles, capturePulseKeys, clientPulseKeys };
 }
 
 function ArchitectureDiagram() {
   const isMobile = useIsMobile();
   const layout = isMobile ? LAYOUT.mobile : LAYOUT.desktop;
-  const particles = useDataFlow(layout);
+  const { particles, capturePulseKeys, clientPulseKeys } = useDataFlow(layout);
 
   // Memoize path calculations
   const { capturePathTarget, clientPathConfig } = useMemo(
@@ -306,7 +509,7 @@ function ArchitectureDiagram() {
           </text>
           {CAPTURE_ICONS.map((icon, i) => (
             <g key={icon.id} transform={`translate(30, ${30 + i * 50})`}>
-              <motion.rect
+              <rect
                 x="0"
                 y="0"
                 width="32"
@@ -315,14 +518,24 @@ function ArchitectureDiagram() {
                 fill="color-mix(in srgb, var(--theme-bg-surface) 72%, transparent)"
                 stroke="color-mix(in srgb, var(--theme-accent-secondary) 36%, transparent)"
                 strokeWidth="1"
-                initial={{ opacity: 0.5 }}
-                animate={{ opacity: [0.5, 0.8, 0.5] }}
-                transition={{
-                  duration: slowHeroMotion(2),
-                  repeat: Infinity,
-                  delay: slowHeroDelay(i * 0.3),
-                }}
               />
+              {capturePulseKeys[i] > 0 && (
+                <motion.rect
+                  key={`capture-pulse-${icon.id}-${capturePulseKeys[i]}`}
+                  x="0"
+                  y="0"
+                  width="32"
+                  height="32"
+                  rx="8"
+                  fill="none"
+                  stroke="var(--theme-accent-secondary)"
+                  strokeWidth="1.5"
+                  filter="url(#archGlow)"
+                  initial={{ scale: 1, opacity: 0 }}
+                  animate={{ scale: [1, 1.06, 1], opacity: [0, 0.85, 0] }}
+                  transition={{ duration: slowHeroMotion(0.8), ease: "easeOut" }}
+                />
+              )}
               <g
                 transform={`translate(${icon.offsetX}, ${icon.offsetY}) scale(${icon.scale})`}
               >
@@ -336,7 +549,7 @@ function ArchitectureDiagram() {
         <g transform={`translate(${layout.syncHub.x}, ${layout.syncHub.y})`}>
           <text
             x="50"
-            y="-10"
+            y="-17"
             fill="var(--theme-text-muted)"
             fontSize="10"
             fontWeight="600"
@@ -381,35 +594,7 @@ function ArchitectureDiagram() {
             filter="url(#archGlow)"
           />
 
-          {/* Freed Desktop text */}
-          <text
-            x="50"
-            y="40"
-            fill="var(--theme-text-primary)"
-            fontSize="11"
-            fontWeight="700"
-            textAnchor="middle"
-          >
-            Freed
-          </text>
-          <text
-            x="50"
-            y="54"
-            fill="var(--theme-text-secondary)"
-            fontSize="9"
-            textAnchor="middle"
-          >
-            Desktop
-          </text>
-          <text
-            x="50"
-            y="70"
-            fill="var(--theme-accent-secondary)"
-            fontSize="8"
-            textAnchor="middle"
-          >
-            Capture + Sync
-          </text>
+          <FreedDesktopIcon />
         </g>
 
         {/* Clients */}
@@ -429,38 +614,34 @@ function ArchitectureDiagram() {
               key={icon.id}
               transform={`translate(${layout.clients.x}, ${40 + i * 65})`}
             >
-              <motion.rect
+              <rect
                 x="0"
                 y="0"
                 width="50"
                 height="40"
                 rx="8"
                 fill="color-mix(in srgb, var(--theme-bg-surface) 72%, transparent)"
-                stroke={
-                  i === 0
-                    ? "color-mix(in srgb, var(--theme-accent-secondary) 56%, transparent)"
-                    : "color-mix(in srgb, var(--theme-accent-secondary) 34%, transparent)"
-                }
-                strokeWidth={i === 0 ? "2" : "1"}
-                initial={{ opacity: 0.5 }}
-                animate={{ opacity: [0.5, 0.9, 0.5] }}
-                transition={{
-                  duration: slowHeroMotion(2.5),
-                  repeat: Infinity,
-                  delay: slowHeroDelay(i * 0.4),
-                }}
-                filter={i === 0 ? "url(#archGlow)" : undefined}
+                stroke="color-mix(in srgb, var(--theme-accent-secondary) 34%, transparent)"
+                strokeWidth="1"
               />
-              <g transform="translate(14.7, 9.7) scale(0.86)">
-                <path
-                  d={icon.path}
-                  fill={
-                    i === 0
-                      ? "var(--theme-accent-secondary)"
-                      : "var(--theme-text-secondary)"
-                  }
+              {clientPulseKeys[i] > 0 && (
+                <motion.rect
+                  key={`client-pulse-${icon.id}-${clientPulseKeys[i]}`}
+                  x="0"
+                  y="0"
+                  width="50"
+                  height="40"
+                  rx="8"
+                  fill="none"
+                  stroke="var(--theme-accent-secondary)"
+                  strokeWidth="1.5"
+                  filter="url(#archGlow)"
+                  initial={{ scale: 1, opacity: 0 }}
+                  animate={{ scale: [1, 1.05, 1], opacity: [0, 0.85, 0] }}
+                  transition={{ duration: slowHeroMotion(0.8), ease: "easeOut" }}
                 />
-              </g>
+              )}
+              <ClientIcon kind={icon.kind} />
               <text
                 x="25"
                 y="52"
@@ -637,8 +818,9 @@ const phases: Phase[] = [
 function PhaseCard({ phase, index }: { phase: Phase; index: number }) {
   const statusStyles = {
     complete: {
-      border: "border-[color:var(--theme-status-complete-border)]",
-      bg: "bg-[color:var(--theme-status-complete-bg)]",
+      border:
+        "phase-card-complete border-[color:var(--theme-status-complete-border)]",
+      bg: "phase-card-complete bg-[color:var(--theme-status-complete-bg)]",
       badge:
         "bg-[color:var(--theme-status-complete-bg)] text-[color:var(--theme-status-complete-text)]",
       badgeText: "✓ Complete",
@@ -646,16 +828,16 @@ function PhaseCard({ phase, index }: { phase: Phase; index: number }) {
     },
     current: {
       border:
-        "border-[color:color-mix(in_srgb,var(--theme-accent-secondary)_50%,transparent)]",
-      bg: "bg-[color:color-mix(in_srgb,var(--theme-accent-secondary)_8%,transparent)]",
+        "phase-card-current border-[color:color-mix(in_srgb,var(--theme-accent-secondary)_50%,transparent)]",
+      bg: "phase-card-current bg-[color:color-mix(in_srgb,var(--theme-accent-secondary)_8%,transparent)]",
       badge:
         "bg-[color:color-mix(in_srgb,var(--theme-accent-secondary)_18%,transparent)] text-[var(--theme-accent-secondary)]",
       badgeText: "● In Progress",
       glow: "glow-sm",
     },
     upcoming: {
-      border: "border-freed-border",
-      bg: "bg-freed-surface/50",
+      border: "phase-card-upcoming border-freed-border",
+      bg: "phase-card-upcoming bg-freed-surface/50",
       badge: "bg-freed-surface text-text-muted",
       badgeText: "Upcoming",
       glow: "",
@@ -798,7 +980,7 @@ export default function RoadmapContent() {
               initial={{ width: 0 }}
               animate={{ width: `${(activeCount / totalCount) * 100}%` }}
               transition={{ duration: 1, delay: 0.6 }}
-              className="h-full bg-zinc-600"
+              className="h-full bg-[color:var(--theme-status-active-progress)]"
             />
           </div>
         </motion.div>

--- a/website/src/app/sitemap.ts
+++ b/website/src/app/sitemap.ts
@@ -56,7 +56,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
   const changelogPages: MetadataRoute.Sitemap = Array.from(
     { length: Math.max(0, getChangelogTotalPages() - 1) },
     (_, index) => ({
-      url: `${baseUrl}/changelog/page/${(index + 2).toString()}`,
+      url: `${baseUrl}/changelog/${(index + 2).toString()}`,
       lastModified: new Date(),
       changeFrequency: "weekly" as const,
       priority: 0.7,

--- a/website/src/components/HeroAnimation.tsx
+++ b/website/src/components/HeroAnimation.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { motion } from "framer-motion";
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { useTheme } from "@/context/ThemeContext";
 import {
   slowHeroMotion,
@@ -50,21 +50,22 @@ const PLATFORMS = [
   },
 ];
 
-// Pre-compute logo positions and spin params
-const LOGOS = PLATFORMS.map((platform, i) => {
-  const angle = ((i * 360) / PLATFORMS.length - 90) * (Math.PI / 180);
-  return {
-    ...platform,
-    angle,
-    cx: CENTER + LOGO_RADIUS * Math.cos(angle),
-    cy: CENTER + LOGO_RADIUS * Math.sin(angle),
-    emitX: CENTER + RING_RADIUS * Math.cos(angle),
-    emitY: CENTER + RING_RADIUS * Math.sin(angle),
-    spinDuration: 25 + i * 5,
-    spinDirection: Math.random() > 0.5 ? 1 : -1,
-    flashDelay: Math.random() * 5,
-  };
-});
+function buildLogos() {
+  return PLATFORMS.map((platform, i) => {
+    const angle = ((i * 360) / PLATFORMS.length - 90) * (Math.PI / 180);
+    return {
+      ...platform,
+      angle,
+      cx: CENTER + LOGO_RADIUS * Math.cos(angle),
+      cy: CENTER + LOGO_RADIUS * Math.sin(angle),
+      emitX: CENTER + RING_RADIUS * Math.cos(angle),
+      emitY: CENTER + RING_RADIUS * Math.sin(angle),
+      spinDuration: 25 + i * 5,
+      spinDirection: Math.random() > 0.5 ? 1 : -1,
+      flashDelay: Math.random() * 5,
+    };
+  });
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Particle System (single animation loop for all particles)
@@ -92,7 +93,7 @@ const CYCLE_DURATION = slowHeroInterval(12000); // ms
 const MAX_AGE = Math.round(slowHeroMotion(600)); // frames
 const RED_BOUNCE_SPEED_LIMIT = slowHeroSpeed(0.6);
 
-function createParticle(logo: (typeof LOGOS)[0], isRed: boolean): Particle {
+function createParticle(logo: ReturnType<typeof buildLogos>[number], isRed: boolean): Particle {
   // Aim directly at center with small random spread (±5 degrees)
   const angleToCenter = Math.atan2(CENTER - logo.emitY, CENTER - logo.emitX);
   const spread = (Math.random() - 0.5) * 0.17; // ~±5 degrees
@@ -124,8 +125,8 @@ function clampRedBounceVelocity(value: number): number {
   );
 }
 
-function initParticles(): Particle[] {
-  return LOGOS.flatMap((logo) =>
+function initParticles(logos: ReturnType<typeof buildLogos>): Particle[] {
+  return logos.flatMap((logo) =>
     Array.from(
       { length: PARTICLES_PER_LOGO },
       (_, i) => createParticle(logo, i < 2) // First 2 particles per logo are red
@@ -133,8 +134,8 @@ function initParticles(): Particle[] {
   );
 }
 
-function useParticleSystem() {
-  const [particles, setParticles] = useState<Particle[]>(() => initParticles());
+function useParticleSystem(logos: ReturnType<typeof buildLogos>) {
+  const [particles, setParticles] = useState<Particle[]>(() => initParticles(logos));
   const startTimeRef = useRef(performance.now());
   const frameRef = useRef<number>(0);
 
@@ -200,20 +201,21 @@ function useParticleSystem() {
             const fromTop = y < BOX.top;
             const fromBottom = y > BOX.bottom;
 
+            // Preserve linear motion by keeping the particle on its natural
+            // next-frame position and only changing the outgoing velocity.
+            x = newX;
+            y = newY;
+
             if (fromLeft) {
-              x = BOX.left - 3;
               vx = -Math.abs(vx) * (0.6 + Math.random() * 0.15);
               vy += (Math.random() - 0.5) * 0.5;
             } else if (fromRight) {
-              x = BOX.right + 3;
               vx = Math.abs(vx) * (0.6 + Math.random() * 0.15);
               vy += (Math.random() - 0.5) * 0.5;
             } else if (fromTop) {
-              y = BOX.top - 3;
               vy = -Math.abs(vy) * (0.6 + Math.random() * 0.15);
               vx += (Math.random() - 0.5) * 0.5;
             } else if (fromBottom) {
-              y = BOX.bottom + 3;
               vy = Math.abs(vy) * (0.6 + Math.random() * 0.15);
               vx += (Math.random() - 0.5) * 0.5;
             }
@@ -280,6 +282,11 @@ function useParticleSystem() {
     return () => cancelAnimationFrame(frameRef.current);
   }, [tick]);
 
+  useEffect(() => {
+    setParticles(initParticles(logos));
+    startTimeRef.current = performance.now();
+  }, [logos]);
+
   return particles.filter((p) => p.state === "active" && p.opacity > 0);
 }
 
@@ -289,7 +296,8 @@ function useParticleSystem() {
 
 export default function HeroAnimation() {
   const { themeId } = useTheme();
-  const particles = useParticleSystem();
+  const logos = useMemo(() => buildLogos(), []);
+  const particles = useParticleSystem(logos);
 
   return (
     <div className="relative w-full aspect-square">
@@ -392,7 +400,7 @@ export default function HeroAnimation() {
         ))}
 
         {/* Platform logos */}
-        {LOGOS.map((logo) => (
+        {logos.map((logo) => (
           <g key={logo.id}>
             <motion.circle
               cx={logo.cx}

--- a/website/src/components/SiteShell.tsx
+++ b/website/src/components/SiteShell.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect } from "react";
 import { usePathname } from "next/navigation";
 import Navigation from "@/components/Navigation";
 import Footer from "@/components/Footer";
@@ -13,6 +14,18 @@ export default function SiteShell({
 }) {
   const pathname = usePathname();
   const isQrGallery = pathname === "/qr";
+
+  useEffect(() => {
+    try {
+      const currentPath = sessionStorage.getItem("freed-current-path");
+
+      if (currentPath && currentPath !== pathname) {
+        sessionStorage.setItem("freed-previous-path", currentPath);
+      }
+
+      sessionStorage.setItem("freed-current-path", pathname);
+    } catch {}
+  }, [pathname]);
 
   return (
     <>


### PR DESCRIPTION
(AI Generated).

## What changed

- repaired changelog pagination routes and navigation so paged changelog URLs live under `/changelog/[page]`
- tightened changelog presentation, roadmap architecture artwork, hero animation timing, and roadmap interaction polish
- updated website shell and theme styling to support the refreshed website experience
- synced the Phase 5 roadmap doc to mention paginated changelog history

## Why

The website had a mix of pagination issues and rough visual behavior across the changelog, roadmap diagram, and hero animation. This bundles those fixes into one website polish pass so the public surfaces feel consistent again.

## Impact

- changelog pages should route and paginate correctly
- roadmap architecture visuals are cleaner and more expressive
- homepage hero particles and provider motion behave more naturally
- theme and shell polish better match the rest of the site

## Validation

- local checks were not rerun at the end because iteration had been explicitly optimized for speed
- branch pushed successfully to GitHub for CI and review
