### PR TITLE
fix: remove updater progress bar lag

### DIFF
--- a/packages/desktop/src/components/UpdateNotification.test.tsx
+++ b/packages/desktop/src/components/UpdateNotification.test.tsx
@@ -34,4 +34,22 @@ Map view, refined consent gates, and signed macOS installs
     expect(html).not.toContain("<ul");
     expect(html).not.toContain("Shared map and friends workspace");
   });
+
+  it("renders the shared progress bar without width animation during downloads", () => {
+    const html = renderToStaticMarkup(
+      <UpdateNotification
+        state={{ phase: "downloading", percent: 100 }}
+        onInstall={() => {}}
+        onRelaunch={() => {}}
+        onDismiss={() => {}}
+      />,
+    );
+
+    expect(html).toContain("Downloading... 100%");
+    expect(html).toContain('role="progressbar"');
+    expect(html).toContain('aria-valuenow="100"');
+    expect(html).toContain('style="width:100%"');
+    expect(html).not.toContain("transition-[width]");
+    expect(html).not.toContain("duration-300");
+  });
 });

--- a/packages/desktop/src/components/UpdateNotification.tsx
+++ b/packages/desktop/src/components/UpdateNotification.tsx
@@ -1,4 +1,5 @@
 import type { Update } from "@tauri-apps/plugin-updater";
+import { UpdateProgressBar } from "@freed/ui/components/UpdateProgressBar";
 import { extractUpdatePreviewLine } from "../lib/update-release-preview";
 
 export type UpdateState =
@@ -60,12 +61,11 @@ export function UpdateNotification({
         </div>
 
         {state.phase === "downloading" && (
-          <div className="mt-3 h-1.5 rounded-full bg-[rgba(255,255,255,0.08)] overflow-hidden">
-            <div
-              className="h-full rounded-full bg-gradient-to-r from-[var(--glow-blue)] to-[var(--glow-purple)] transition-[width] duration-300"
-              style={{ width: `${state.percent}%` }}
-            />
-          </div>
+          <UpdateProgressBar
+            percent={state.percent}
+            trackClassName="mt-3 h-1.5 overflow-hidden rounded-full bg-[rgba(255,255,255,0.08)]"
+            fillClassName="h-full rounded-full bg-gradient-to-r from-[var(--glow-blue)] to-[var(--glow-purple)]"
+          />
         )}
       </div>
     </div>

--- a/packages/desktop/src/components/UpdateProgressBar.test.tsx
+++ b/packages/desktop/src/components/UpdateProgressBar.test.tsx
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { UpdateProgressBar } from "@freed/ui/components/UpdateProgressBar";
+
+describe("UpdateProgressBar", () => {
+  it("renders a full-width fill at 100 percent without animation classes", () => {
+    const html = renderToStaticMarkup(<UpdateProgressBar percent={100} />);
+
+    expect(html).toContain('role="progressbar"');
+    expect(html).toContain('aria-valuenow="100"');
+    expect(html).toContain('style="width:100%"');
+    expect(html).toContain("theme-bg-surface");
+    expect(html).toContain("theme-accent-primary");
+    expect(html).not.toContain("transition-[width]");
+    expect(html).not.toContain("duration-300");
+  });
+
+  it("clamps invalid percent values into the progress range", () => {
+    const html = renderToStaticMarkup(<UpdateProgressBar percent={140} />);
+
+    expect(html).toContain('aria-valuenow="100"');
+    expect(html).toContain('style="width:100%"');
+  });
+});

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -15,6 +15,7 @@
     "./components/SettingsToggle": "./src/components/SettingsToggle.tsx",
     "./components/AddFeedDialog": "./src/components/AddFeedDialog.tsx",
     "./components/SettingsDialog": "./src/components/SettingsDialog.tsx",
+    "./components/UpdateProgressBar": "./src/components/UpdateProgressBar.tsx",
     "./components/settings/GoogleContactsSection": "./src/components/settings/GoogleContactsSection.tsx",
     "./components/BugReportBoundary": "./src/components/BugReportBoundary.tsx",
     "./components/FatalErrorScreen": "./src/components/FatalErrorScreen.tsx",

--- a/packages/ui/src/components/SettingsDialog.tsx
+++ b/packages/ui/src/components/SettingsDialog.tsx
@@ -22,6 +22,7 @@ import {
 } from "../lib/provider-status.js";
 import { ProviderStatusIndicator } from "./ProviderStatusIndicator.js";
 import { toast } from "./Toast.js";
+import { UpdateProgressBar } from "./UpdateProgressBar.js";
 import {
   BASE_SECTION_METAS,
   UPDATES_SECTION_META,
@@ -865,12 +866,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
                   <p className="text-xs text-text-secondary">
                     Downloading... {Math.round(updateDownloadProgress.percent)}%
                   </p>
-                  <div className="h-1.5 overflow-hidden rounded-full bg-[color:color-mix(in_srgb,var(--theme-bg-surface)_86%,transparent)]">
-                    <div
-                      className="h-full rounded-full bg-[linear-gradient(90deg,var(--theme-accent-primary),var(--theme-accent-secondary),var(--theme-accent-tertiary))] transition-[width] duration-300"
-                      style={{ width: `${updateDownloadProgress.percent}%` }}
-                    />
-                  </div>
+                  <UpdateProgressBar percent={updateDownloadProgress.percent} />
                 </div>
               )}
               {updateDownloadProgress?.phase === "error" && (

--- a/packages/ui/src/components/UpdateProgressBar.tsx
+++ b/packages/ui/src/components/UpdateProgressBar.tsx
@@ -1,0 +1,30 @@
+interface UpdateProgressBarProps {
+  percent: number;
+  trackClassName?: string;
+  fillClassName?: string;
+}
+
+function clampPercent(percent: number): number {
+  if (!Number.isFinite(percent)) return 0;
+  return Math.max(0, Math.min(100, percent));
+}
+
+export function UpdateProgressBar({
+  percent,
+  trackClassName = "h-1.5 overflow-hidden rounded-full bg-[color:color-mix(in_srgb,var(--theme-bg-surface)_86%,transparent)]",
+  fillClassName = "h-full rounded-full bg-[linear-gradient(90deg,var(--theme-accent-primary),var(--theme-accent-secondary),var(--theme-accent-tertiary))]",
+}: UpdateProgressBarProps) {
+  const clampedPercent = clampPercent(percent);
+
+  return (
+    <div
+      role="progressbar"
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-valuenow={Math.round(clampedPercent)}
+      className={trackClassName}
+    >
+      <div className={fillClassName} style={{ width: `${clampedPercent}%` }} />
+    </div>
+  );
+}


### PR DESCRIPTION
(AI Generated). 

## Summary
- extract the desktop updater fill into a shared `UpdateProgressBar` component
- remove the width transition so the bar visually matches the numeric percentage at the end of a fast download
- cover the shared progress bar and desktop update toast with regression tests

## Root cause
- the updater text reached 100 percent before the animated width transition finished
- the download finished immediately after, so the UI swapped away while the fill still looked partially complete

## Validation
- `npm run test:unit --workspace=packages/desktop -- src/components/UpdateNotification.test.tsx src/components/UpdateProgressBar.test.tsx`
- `npx tsc -p packages/desktop/tsconfig.json --noEmit`
