### PR TITLE
fix: polish mobile website layout and tooltips

### DIFF
--- a/docs/PHASE-1-FOUNDATION.md
+++ b/docs/PHASE-1-FOUNDATION.md
@@ -131,6 +131,7 @@ Next.js 15 (App Router) site deployed to Vercel at freed.wtf.
 - RSS/Atom feed generation at build time
 - Public legal pages for Terms of Use, Privacy, and Desktop EULA
 - Versioned website clickwrap in the download modal for Terms of Use and Privacy before opening the PWA or downloading Freed Desktop
+- Get Freed modal now scrolls internally on small screens and defaults real mobile devices to a `Freed Web` launch target while still offering every desktop download explicitly
 - Shared cross-surface theme system for the marketing site, Freed Desktop, and the PWA
 - Theme-aware form controls across the marketing site and shared UI package
 - Shared theme-aware tooltip primitive across the marketing site and shared UI package
@@ -138,6 +139,7 @@ Next.js 15 (App Router) site deployed to Vercel at freed.wtf.
 - Five authored themes: Neon, Midas, Vesper, Ember, and Scriptorium
 - Synced theme preference with `Neon` as the default for fresh installs
 - Mobile-responsive design
+- Mobile landing layout uses wider gutters, denser feature and step cards, and a compact hero animation footprint for tighter one-hand browsing
 - Glassmorphic dark theme
 - Full accessibility support (skip links, ARIA labels, focus states)
 - `prefers-reduced-motion` support

--- a/packages/ui/src/components/Tooltip.tsx
+++ b/packages/ui/src/components/Tooltip.tsx
@@ -3,9 +3,11 @@
 import {
   useEffect,
   useId,
+  useLayoutEffect,
   useRef,
   useState,
   type ReactNode,
+  type CSSProperties,
 } from "react";
 import { createPortal } from "react-dom";
 
@@ -22,9 +24,18 @@ interface TooltipProps {
 interface TooltipPosition {
   left: number;
   top: number;
+  arrowLeft: number;
+  placement: "top" | "bottom";
+  ready: boolean;
 }
 
 const TOOLTIP_OFFSET = 12;
+const VIEWPORT_PADDING = 12;
+const TOOLTIP_ARROW_INSET = 18;
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
 
 export function Tooltip({
   children,
@@ -37,8 +48,15 @@ export function Tooltip({
 }: TooltipProps) {
   const [open, setOpen] = useState(false);
   const [mounted, setMounted] = useState(false);
-  const [position, setPosition] = useState<TooltipPosition>({ left: 0, top: 0 });
+  const [position, setPosition] = useState<TooltipPosition>({
+    left: 0,
+    top: 0,
+    arrowLeft: TOOLTIP_ARROW_INSET,
+    placement: side,
+    ready: false,
+  });
   const triggerRef = useRef<HTMLSpanElement | null>(null);
+  const tooltipRef = useRef<HTMLDivElement | null>(null);
   const tooltipId = useId();
 
   useEffect(() => {
@@ -46,34 +64,123 @@ export function Tooltip({
   }, []);
 
   const updatePosition = () => {
-    if (!triggerRef.current) {
+    if (!triggerRef.current || !tooltipRef.current) {
       return;
     }
 
-    const rect = triggerRef.current.getBoundingClientRect();
-    setPosition({
-      left: rect.left + rect.width / 2,
-      top: side === "top" ? rect.top - TOOLTIP_OFFSET : rect.bottom + TOOLTIP_OFFSET,
+    const triggerRect = triggerRef.current.getBoundingClientRect();
+    const tooltipRect = tooltipRef.current.getBoundingClientRect();
+    const viewportWidth = window.innerWidth;
+    const viewportHeight = window.innerHeight;
+    const roomAbove = triggerRect.top - VIEWPORT_PADDING;
+    const roomBelow = viewportHeight - triggerRect.bottom - VIEWPORT_PADDING;
+
+    let placement: "top" | "bottom" = side;
+    const fitsAbove = roomAbove >= tooltipRect.height + TOOLTIP_OFFSET;
+    const fitsBelow = roomBelow >= tooltipRect.height + TOOLTIP_OFFSET;
+
+    if (side === "top" && !fitsAbove && fitsBelow) {
+      placement = "bottom";
+    } else if (side === "bottom" && !fitsBelow && fitsAbove) {
+      placement = "top";
+    } else if (!fitsAbove && !fitsBelow) {
+      placement = roomBelow >= roomAbove ? "bottom" : "top";
+    }
+
+    const desiredLeft = triggerRect.left + triggerRect.width / 2 - tooltipRect.width / 2;
+    const maxLeft = Math.max(VIEWPORT_PADDING, viewportWidth - VIEWPORT_PADDING - tooltipRect.width);
+    const left = clamp(desiredLeft, VIEWPORT_PADDING, maxLeft);
+
+    const desiredTop =
+      placement === "top"
+        ? triggerRect.top - tooltipRect.height - TOOLTIP_OFFSET
+        : triggerRect.bottom + TOOLTIP_OFFSET;
+    const maxTop = Math.max(VIEWPORT_PADDING, viewportHeight - VIEWPORT_PADDING - tooltipRect.height);
+    const top = clamp(desiredTop, VIEWPORT_PADDING, maxTop);
+
+    const arrowLeft = clamp(
+      triggerRect.left + triggerRect.width / 2 - left,
+      TOOLTIP_ARROW_INSET,
+      Math.max(TOOLTIP_ARROW_INSET, tooltipRect.width - TOOLTIP_ARROW_INSET),
+    );
+
+    setPosition((current) => {
+      const next = {
+        left: Math.round(left),
+        top: Math.round(top),
+        arrowLeft: Math.round(arrowLeft),
+        placement,
+        ready: true,
+      };
+
+      if (
+        current.left === next.left &&
+        current.top === next.top &&
+        current.arrowLeft === next.arrowLeft &&
+        current.placement === next.placement &&
+        current.ready === next.ready
+      ) {
+        return current;
+      }
+
+      return next;
     });
   };
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!open) {
       return undefined;
     }
 
-    updatePosition();
+    let frameId = window.requestAnimationFrame(() => {
+      updatePosition();
+    });
+
     const closeTooltip = () => setOpen(false);
-    const refreshPosition = () => updatePosition();
+    const refreshPosition = () => {
+      window.cancelAnimationFrame(frameId);
+      frameId = window.requestAnimationFrame(() => {
+        updatePosition();
+      });
+    };
+
+    const resizeObserver =
+      typeof ResizeObserver === "undefined"
+        ? null
+        : new ResizeObserver(() => {
+            refreshPosition();
+          });
+
+    if (triggerRef.current) {
+      resizeObserver?.observe(triggerRef.current);
+    }
+    if (tooltipRef.current) {
+      resizeObserver?.observe(tooltipRef.current);
+    }
+
     window.addEventListener("scroll", refreshPosition, true);
     window.addEventListener("resize", refreshPosition);
     window.addEventListener("blur", closeTooltip);
     return () => {
+      window.cancelAnimationFrame(frameId);
+      resizeObserver?.disconnect();
       window.removeEventListener("scroll", refreshPosition, true);
       window.removeEventListener("resize", refreshPosition);
       window.removeEventListener("blur", closeTooltip);
     };
-  }, [open, side]);
+  }, [badge, description, label, open, shortcut, side]);
+
+  const openTooltip = () => {
+    setPosition((current) => ({ ...current, placement: side, ready: false }));
+    setOpen(true);
+  };
+
+  const tooltipStyle = {
+    left: `${position.left}px`,
+    top: `${position.top}px`,
+    visibility: position.ready ? "visible" : "hidden",
+    "--theme-tooltip-arrow-left": `${position.arrowLeft}px`,
+  } as CSSProperties;
 
   return (
     <>
@@ -81,15 +188,9 @@ export function Tooltip({
         ref={triggerRef}
         aria-describedby={open ? tooltipId : undefined}
         className={["relative inline-flex", className].filter(Boolean).join(" ")}
-        onMouseEnter={() => {
-          updatePosition();
-          setOpen(true);
-        }}
+        onMouseEnter={openTooltip}
         onMouseLeave={() => setOpen(false)}
-        onFocus={() => {
-          updatePosition();
-          setOpen(true);
-        }}
+        onFocus={openTooltip}
         onBlur={() => setOpen(false)}
       >
         {children}
@@ -97,17 +198,11 @@ export function Tooltip({
       {mounted && open
         ? createPortal(
             <div
+              ref={tooltipRef}
               id={tooltipId}
               role="tooltip"
               className="theme-tooltip-panel"
-              style={{
-                left: position.left,
-                top: position.top,
-                transform:
-                  side === "top"
-                    ? "translate(-50%, calc(-100% - 2px))"
-                    : "translate(-50%, 2px)",
-              }}
+              style={tooltipStyle}
             >
               {badge ? <span className="theme-tooltip-badge">{badge}</span> : null}
               <div className="theme-tooltip-body">
@@ -120,7 +215,7 @@ export function Tooltip({
                 ) : null}
               </div>
               <span
-                className={`theme-tooltip-arrow ${side === "top" ? "theme-tooltip-arrow-top" : "theme-tooltip-arrow-bottom"}`}
+                className={`theme-tooltip-arrow ${position.placement === "top" ? "theme-tooltip-arrow-top" : "theme-tooltip-arrow-bottom"}`}
               />
             </div>,
             document.body,

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -1080,9 +1080,12 @@ html[data-theme="scriptorium"] .phase-card-complete {
       var(--theme-border-strong) 48%,
       var(--theme-border-subtle)
     );
-  background:
-    linear-gradient(180deg, rgb(255 255 255 / 0.06), transparent 22%),
-    color-mix(in oklab, var(--theme-bg-elevated) 94%, transparent);
+  background: linear-gradient(
+    180deg,
+    color-mix(in oklab, var(--theme-bg-surface) 82%, white) 0%,
+    color-mix(in oklab, var(--theme-bg-surface) 96%, white) 22%,
+    color-mix(in oklab, var(--theme-bg-surface) 88%, black) 100%
+  );
   color: var(--theme-text-primary);
   box-shadow:
     inset 0 1px 0 rgb(255 255 255 / 0.06),
@@ -1094,7 +1097,11 @@ html[data-theme="scriptorium"] .phase-card-complete {
 }
 
 html[data-theme="scriptorium"] .theme-tooltip-panel {
-  background: color-mix(in oklab, var(--theme-bg-surface) 97%, transparent);
+  background: linear-gradient(
+    180deg,
+    color-mix(in oklab, var(--theme-bg-surface) 88%, white) 0%,
+    color-mix(in oklab, var(--theme-bg-surface) 96%, black) 100%
+  );
   box-shadow:
     inset 0 1px 0 rgb(255 255 255 / 0.03),
     0 10px 26px rgb(84 58 35 / 0.08);
@@ -1317,10 +1324,10 @@ html[data-theme="scriptorium"] .theme-tooltip-panel {
 
 .theme-tooltip-arrow {
   position: absolute;
-  left: 50%;
+  left: var(--theme-tooltip-arrow-left, 50%);
   width: 10px;
   height: 10px;
-  background: color-mix(in oklab, var(--theme-bg-elevated) 94%, transparent);
+  background: color-mix(in oklab, var(--theme-bg-surface) 92%, black);
   border: 1px solid
     color-mix(
       in oklab,
@@ -1331,7 +1338,7 @@ html[data-theme="scriptorium"] .theme-tooltip-panel {
 }
 
 html[data-theme="scriptorium"] .theme-tooltip-arrow {
-  background: color-mix(in oklab, var(--theme-bg-surface) 97%, transparent);
+  background: color-mix(in oklab, var(--theme-bg-surface) 96%, black);
 }
 
 .theme-tooltip-arrow-top {

--- a/website/src/components/CTA.tsx
+++ b/website/src/components/CTA.tsx
@@ -7,7 +7,7 @@ import { useNewsletter } from "@/context/NewsletterContext";
 export default function CTA() {
   const { openModal } = useNewsletter();
   return (
-    <section className="py-16 sm:py-24 px-4 sm:px-6 md:px-12 lg:px-8">
+    <section className="px-8 py-8 sm:px-6 sm:py-24 md:px-12 lg:px-8">
       <div className="max-w-4xl mx-auto">
         <motion.div
           initial={{ opacity: 0, scale: 0.95 }}
@@ -24,7 +24,7 @@ export default function CTA() {
             }}
           />
 
-          <div className="relative glass-card p-8 sm:p-12 md:p-16 text-center overflow-hidden">
+          <div className="relative overflow-hidden text-center glass-card p-6 sm:p-12 md:p-16">
             <div
               className="absolute top-0 left-1/4 h-32 w-32 rounded-full blur-3xl"
               style={{
@@ -45,7 +45,7 @@ export default function CTA() {
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
               transition={{ delay: 0.2 }}
-              className="theme-display-large text-3xl sm:text-4xl md:text-5xl font-bold mb-4 relative z-10"
+              className="theme-display-large relative z-10 mb-3 text-3xl font-bold sm:mb-4 sm:text-4xl md:text-5xl"
             >
               Ready for <span className="theme-heading-accent">Freed</span>om?
             </motion.h2>
@@ -55,7 +55,7 @@ export default function CTA() {
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
               transition={{ delay: 0.3 }}
-              className="text-text-secondary text-base sm:text-lg max-w-xl mx-auto mb-6 sm:mb-8 relative z-10"
+              className="relative z-10 mb-5 max-w-xl mx-auto text-base text-text-secondary sm:mb-8 sm:text-lg"
             >
               Their algorithms optimize for profit. Optimize yours for life.
             </motion.p>
@@ -65,7 +65,7 @@ export default function CTA() {
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
               transition={{ delay: 0.4 }}
-              className="flex flex-col sm:flex-row flex-wrap gap-3 sm:gap-4 justify-center relative z-10"
+              className="relative z-10 flex flex-col flex-wrap justify-center gap-3 sm:flex-row sm:gap-4"
             >
               <motion.button
                 whileHover={{ scale: 1.05 }}

--- a/website/src/components/Features.tsx
+++ b/website/src/components/Features.tsx
@@ -2,11 +2,15 @@
 
 import { motion } from "framer-motion";
 
+const ICON_FRAME_CLASS =
+  "flex h-9 w-9 items-center justify-center sm:h-12 sm:w-12";
+const ICON_GLYPH_CLASS = "h-7 w-7 sm:h-10 sm:w-10";
+
 // Shield icon with gradient fill - using Heroicons 2 ShieldCheck SVG path
 const PrivacyIcon = () => (
-  <div className="w-12 h-12 flex items-center justify-center">
+  <div className={ICON_FRAME_CLASS}>
     <div
-      className="w-10 h-10"
+      className={ICON_GLYPH_CLASS}
       style={{
         background:
           "linear-gradient(135deg, var(--theme-accent-primary), var(--theme-accent-secondary))",
@@ -23,9 +27,9 @@ const PrivacyIcon = () => (
 
 // Wave icon with gradient - styled like 🌊 emoji
 const UnifiedFeedIcon = () => (
-  <div className="w-12 h-12 flex items-center justify-center">
+  <div className={ICON_FRAME_CLASS}>
     <div
-      className="w-10 h-10"
+      className={ICON_GLYPH_CLASS}
       style={{
         background:
           "linear-gradient(145deg, var(--theme-accent-primary), var(--theme-accent-secondary) 55%, var(--theme-accent-tertiary))",
@@ -41,8 +45,8 @@ const UnifiedFeedIcon = () => (
 );
 
 const FriendMapIcon = () => (
-  <div className="w-12 h-12 flex items-center justify-center">
-    <svg viewBox="0 0 48 48" className="w-10 h-10">
+  <div className={ICON_FRAME_CLASS}>
+    <svg viewBox="0 0 48 48" className={ICON_GLYPH_CLASS}>
       <defs>
         <linearGradient id="mapGrad" x1="0%" y1="0%" x2="100%" y2="100%">
           <stop offset="0%" stopColor="var(--theme-accent-primary)" />
@@ -67,8 +71,8 @@ const FriendMapIcon = () => (
 
 // Siren face - elegant woman's profile with flowing hair (LoDi design)
 const UlyssesIcon = () => (
-  <div className="w-12 h-12">
-    <svg viewBox="950 450 600 700" className="w-12 h-12">
+  <div className={ICON_FRAME_CLASS}>
+    <svg viewBox="950 450 600 700" className="h-8 w-8 sm:h-12 sm:w-12">
       <defs>
         <linearGradient id="ulyssesGrad" x1="0%" y1="0%" x2="100%" y2="100%">
           <stop offset="0%" stopColor="var(--theme-accent-primary)" />
@@ -137,9 +141,9 @@ const UlyssesIcon = () => (
 
 // Sync icon - using Lucide RefreshCw pattern with gradient
 const SyncIcon = () => (
-  <div className="w-12 h-12 flex items-center justify-center">
+  <div className={ICON_FRAME_CLASS}>
     <div
-      className="w-10 h-10"
+      className={ICON_GLYPH_CLASS}
       style={{
         background:
           "linear-gradient(135deg, var(--theme-accent-primary), var(--theme-accent-secondary))",
@@ -155,8 +159,8 @@ const SyncIcon = () => (
 );
 
 const OpenSourceIcon = () => (
-  <div className="w-12 h-12 flex items-center justify-center">
-    <svg viewBox="4 6 40 40" className="w-10 h-10">
+  <div className={ICON_FRAME_CLASS}>
+    <svg viewBox="4 6 40 40" className={ICON_GLYPH_CLASS}>
       <defs>
         <linearGradient id="ossGrad" x1="0%" y1="0%" x2="100%" y2="100%">
           <stop offset="0%" stopColor="var(--theme-accent-secondary)" />
@@ -214,11 +218,11 @@ export default function Features() {
   return (
     <section
       id="features"
-      className="py-16 sm:py-24 px-4 sm:px-6 md:px-12 lg:px-8"
+      className="px-8 py-8 sm:px-6 sm:py-24 md:px-12 lg:px-8"
     >
       <div className="max-w-6xl mx-auto">
         {/* Feature Grid */}
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        <div className="grid grid-cols-1 gap-4 sm:gap-6 md:grid-cols-2 lg:grid-cols-3">
           {features.map((feature, index) => (
             <motion.div
               key={feature.title}
@@ -227,12 +231,16 @@ export default function Features() {
               viewport={{ once: true }}
               transition={{ duration: 0.5, delay: index * 0.1 }}
             >
-              <div className="glass-card p-6 h-full">
-                <div className="mb-4">{feature.icon}</div>
-                <h3 className="text-xl font-semibold text-text-primary mb-2">
-                  {feature.title}
-                </h3>
-                <p className="text-text-secondary">{feature.description}</p>
+              <div className="glass-card h-full p-5 sm:p-6">
+                <div className="mb-3 flex items-center gap-3 sm:mb-4 sm:flex-col sm:items-start">
+                  <div className="shrink-0">{feature.icon}</div>
+                  <h3 className="text-lg font-semibold leading-tight text-text-primary sm:text-xl">
+                    {feature.title}
+                  </h3>
+                </div>
+                <p className="text-sm text-text-secondary sm:text-base">
+                  {feature.description}
+                </p>
               </div>
             </motion.div>
           ))}

--- a/website/src/components/Footer.tsx
+++ b/website/src/components/Footer.tsx
@@ -5,7 +5,7 @@ export default function Footer() {
   return (
     <footer
       aria-label="Site footer"
-      className="relative z-10 border-t border-freed-border pt-8 sm:pt-12 px-8 sm:px-8 md:px-12 lg:px-8 bg-freed-black"
+      className="relative z-10 border-t border-freed-border bg-freed-black px-8 pt-8 sm:px-8 sm:pt-12 md:px-12 lg:px-8"
       style={{ paddingBottom: "calc(2rem + env(safe-area-inset-bottom))" }}
     >
       <div className="max-w-6xl mx-auto">
@@ -31,102 +31,84 @@ export default function Footer() {
             </div>
           </div>
 
-          {/* Links */}
-          <div>
-            <h4 className="text-text-primary font-semibold mb-4">Product</h4>
-            <ul className="space-y-2">
-              <li>
-                <Link
-                  href="/"
-                  className="text-text-secondary text-sm hover:text-text-primary transition-colors"
-                >
-                  Home
-                </Link>
-              </li>
-              <li>
-                <Link
-                  href="/manifesto"
-                  className="text-text-secondary text-sm hover:text-text-primary transition-colors"
-                >
-                  Manifesto
-                </Link>
-              </li>
-              <li>
-                <Link
-                  href="/roadmap"
-                  className="text-text-secondary text-sm hover:text-text-primary transition-colors"
-                >
-                  Roadmap
-                </Link>
-              </li>
-              <li>
-                <Link
-                  href="/updates"
-                  className="text-text-secondary text-sm hover:text-text-primary transition-colors"
-                >
-                  Updates
-                </Link>
-              </li>
-            </ul>
-          </div>
+          <div className="grid grid-cols-2 gap-8 md:contents">
+            {/* Links */}
+            <div>
+              <h4 className="text-text-primary font-semibold mb-4">Product</h4>
+              <ul className="space-y-2">
+                <li>
+                  <Link
+                    href="/"
+                    className="text-text-secondary text-sm hover:text-text-primary transition-colors"
+                  >
+                    Home
+                  </Link>
+                </li>
+                <li>
+                  <Link
+                    href="/manifesto"
+                    className="text-text-secondary text-sm hover:text-text-primary transition-colors"
+                  >
+                    Manifesto
+                  </Link>
+                </li>
+                <li>
+                  <Link
+                    href="/roadmap"
+                    className="text-text-secondary text-sm hover:text-text-primary transition-colors"
+                  >
+                    Roadmap
+                  </Link>
+                </li>
+                <li>
+                  <Link
+                    href="/updates"
+                    className="text-text-secondary text-sm hover:text-text-primary transition-colors"
+                  >
+                    Updates
+                  </Link>
+                </li>
+              </ul>
+            </div>
 
-          {/* Resources */}
-          <div>
-            <h4 className="text-text-primary font-semibold mb-4">Resources</h4>
-            <ul className="space-y-2">
-              {/* <li>
-                <a
-                  href="https://github.com/freed-project/freed"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-text-secondary text-sm hover:text-text-primary transition-colors"
-                >
-                  GitHub
-                </a>
-              </li>
-              <li>
-                <a
-                  href="/feed.xml"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-text-secondary text-sm hover:text-text-primary transition-colors"
-                >
-                  RSS Feed
-                </a>
-              </li> */}
-              <li>
-                <Link
-                  href="/terms"
-                  className="text-text-secondary text-sm hover:text-text-primary transition-colors"
-                >
-                  Terms of Use
-                </Link>
-              </li>
-              <li>
-                <Link
-                  href="/privacy"
-                  className="text-text-secondary text-sm hover:text-text-primary transition-colors"
-                >
-                  Privacy Policy
-                </Link>
-              </li>
-              <li>
-                <Link
-                  href="/eula"
-                  className="text-text-secondary text-sm hover:text-text-primary transition-colors"
-                >
-                  Desktop EULA
-                </Link>
-              </li>
-              <li>
-                <Link
-                  href="/qr"
-                  className="text-text-secondary text-sm hover:text-text-primary transition-colors"
-                >
-                  Sharing QR
-                </Link>
-              </li>
-            </ul>
+            {/* Resources */}
+            <div>
+              <h4 className="text-text-primary font-semibold mb-4">Resources</h4>
+              <ul className="space-y-2">
+                <li>
+                  <Link
+                    href="/terms"
+                    className="text-text-secondary text-sm hover:text-text-primary transition-colors"
+                  >
+                    Terms of Use
+                  </Link>
+                </li>
+                <li>
+                  <Link
+                    href="/privacy"
+                    className="text-text-secondary text-sm hover:text-text-primary transition-colors"
+                  >
+                    Privacy Policy
+                  </Link>
+                </li>
+                <li>
+                  <Link
+                    href="/eula"
+                    className="text-text-secondary text-sm hover:text-text-primary transition-colors"
+                  >
+                    Desktop EULA
+                  </Link>
+                </li>
+                <li>
+                  <Link
+                    href="/qr"
+                    className="text-text-secondary text-sm hover:text-text-primary transition-colors"
+                  >
+                    Sharing QR
+                  </Link>
+                </li>
+              </ul>
+            </div>
           </div>
         </div>
 

--- a/website/src/components/Hero.tsx
+++ b/website/src/components/Hero.tsx
@@ -13,6 +13,7 @@ const ROTATING_WORDS = ["Feed", "Life", "Mind"];
 export default function Hero() {
   const { openModal } = useNewsletter();
   const [wordIndex, setWordIndex] = useState(0);
+  const [compactHeroAnimation, setCompactHeroAnimation] = useState(false);
 
   useEffect(() => {
     const interval = setInterval(() => {
@@ -21,8 +22,16 @@ export default function Hero() {
     return () => clearInterval(interval);
   }, []);
 
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(max-width: 639px)");
+    const updateCompactHero = () => setCompactHeroAnimation(mediaQuery.matches);
+    updateCompactHero();
+    mediaQuery.addEventListener("change", updateCompactHero);
+    return () => mediaQuery.removeEventListener("change", updateCompactHero);
+  }, []);
+
   return (
-    <section className="relative min-h-viewport-safe flex items-start justify-center px-4 sm:px-6 pb-16 pt-24 md:pt-[clamp(7rem,_25vh,_50rem)]">
+    <section className="relative min-h-viewport-safe flex items-start justify-center px-8 sm:px-6 pb-8 pt-24 sm:pb-16 md:pt-[clamp(7rem,_25vh,_50rem)]">
       {/* Open Source badge - aligned with nav container right edge, hidden on mobile */}
       <div className="hidden lg:block absolute top-20 left-0 right-0 mt-4 px-4 sm:px-6">
         <div className="max-w-6xl mx-auto flex justify-end">
@@ -44,7 +53,7 @@ export default function Hero() {
         </div>
       </div>
 
-      <div className="max-w-6xl mx-auto grid grid-cols-1 lg:grid-cols-[1fr_1.5fr] gap-8 lg:gap-4 items-center">
+      <div className="max-w-6xl mx-auto grid grid-cols-1 items-center gap-4 sm:gap-8 lg:grid-cols-[1fr_1.5fr] lg:gap-4">
         {/* Animation - shows first on mobile */}
         <motion.div
           initial={{ opacity: 0, scale: 0.9 }}
@@ -53,10 +62,13 @@ export default function Hero() {
             duration: slowHeroMotion(0.8),
             delay: slowHeroDelay(0.2),
           }}
-          className="relative order-1 lg:order-2 w-full"
-          style={{ maxWidth: "425px", margin: "0 auto" }}
+          className="relative order-1 w-full lg:order-2"
+          style={{
+            maxWidth: compactHeroAnimation ? "212px" : "425px",
+            margin: "0 auto",
+          }}
         >
-          <HeroAnimation />
+          <HeroAnimation compact={compactHeroAnimation} />
         </motion.div>
 
         {/* Text Content */}
@@ -67,9 +79,9 @@ export default function Hero() {
             duration: slowHeroMotion(0.8),
             delay: slowHeroDelay(0.3),
           }}
-          className="order-2 lg:order-1 text-center lg:text-left lg:pl-10"
+          className="order-2 text-center lg:order-1 lg:pl-10 lg:text-left"
         >
-          <h1 className="theme-display-large text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold leading-[1.05] mb-10 sm:mb-12 lg:-ml-2">
+          <h1 className="theme-display-large mb-6 text-4xl font-bold leading-[1.05] sm:mb-12 sm:text-5xl md:text-6xl lg:-ml-2 lg:text-7xl">
             <span className="text-text-primary">Take Back</span>
             <br />
             <span className="text-text-primary">Your </span>
@@ -92,7 +104,7 @@ export default function Hero() {
             </span>
           </h1>
 
-          <p className="inline-flex items-center gap-3 text-xl sm:text-2xl text-text-primary font-medium mb-2 sm:mb-3">
+          <p className="mb-2 inline-flex items-center gap-3 text-xl font-medium text-text-primary sm:mb-3 sm:text-2xl">
             <FaFacebook className="shrink-0 text-[var(--theme-media-icon)]" />
             <FaInstagram className="shrink-0 text-[var(--theme-media-icon)]" />
             <FaXTwitter className="shrink-0 text-[var(--theme-media-icon)]" />
@@ -100,13 +112,13 @@ export default function Hero() {
             <span>in one local app.</span>
           </p>
 
-          <p className="text-base sm:text-lg text-text-secondary max-w-xl mx-auto lg:mx-0 mb-6 sm:mb-8">
+          <p className="mb-6 max-w-xl mx-auto text-base text-text-secondary sm:mb-8 sm:text-lg lg:mx-0">
             Mental sovereignty. Digital dignity. Your feed, your rules. Torch
             the ads, tune your algo, and connect IRL with a live map of your
             people.
           </p>
 
-          <div className="flex flex-col sm:flex-row flex-wrap gap-3 sm:gap-4 justify-center lg:justify-start">
+          <div className="flex flex-col flex-wrap justify-center gap-3 sm:flex-row sm:gap-4 lg:justify-start">
             <motion.button
               whileHover={{ scale: 1.05 }}
               whileTap={{ scale: 0.98 }}
@@ -120,7 +132,7 @@ export default function Hero() {
               <motion.button
                 whileHover={{ scale: 1.02 }}
                 whileTap={{ scale: 0.98 }}
-                className="btn-secondary text-base px-8 py-3 w-full"
+                className="btn-secondary hero-manifesto-button text-base px-8 py-3 w-full"
               >
                 Read the Manifesto
               </motion.button>
@@ -128,7 +140,7 @@ export default function Hero() {
           </div>
 
           {/* Stats */}
-          <div className="flex justify-center lg:justify-start gap-6 sm:gap-8 mt-8 sm:mt-12 pt-6 sm:pt-8 border-t border-freed-border">
+          <div className="mt-6 flex justify-center gap-6 border-t border-freed-border pt-5 sm:mt-12 sm:gap-8 sm:pt-8 lg:justify-start">
             <div className="text-center lg:text-left">
               <p
                 className="text-2xl sm:text-3xl font-bold"

--- a/website/src/components/HeroAnimation.tsx
+++ b/website/src/components/HeroAnimation.tsx
@@ -294,10 +294,16 @@ function useParticleSystem(logos: ReturnType<typeof buildLogos>) {
 // Component
 // ─────────────────────────────────────────────────────────────────────────────
 
-export default function HeroAnimation() {
+export default function HeroAnimation({
+  compact = false,
+}: {
+  compact?: boolean;
+}) {
   const { themeId } = useTheme();
   const logos = useMemo(() => buildLogos(), []);
   const particles = useParticleSystem(logos);
+  const platformRadius = compact ? 26 : 22;
+  const platformIconSize = compact ? 24 : 20;
 
   return (
     <div className="relative w-full aspect-square">
@@ -405,7 +411,7 @@ export default function HeroAnimation() {
             <motion.circle
               cx={logo.cx}
               cy={logo.cy}
-              r="22"
+              r={platformRadius}
               fill="var(--theme-platform-ring-fill)"
               stroke="var(--theme-platform-ring-stroke)"
               strokeWidth="2"
@@ -428,8 +434,10 @@ export default function HeroAnimation() {
               style={{ transformOrigin: `${logo.cx}px ${logo.cy}px` }}
             >
               <g
-                transform={`translate(${logo.cx - 10}, ${logo.cy - 10}) scale(${
-                  20 / 24
+                transform={`translate(${logo.cx - platformIconSize / 2}, ${
+                  logo.cy - platformIconSize / 2
+                }) scale(${
+                  platformIconSize / 24
                 })`}
               >
                 <path

--- a/website/src/components/HowItWorks.tsx
+++ b/website/src/components/HowItWorks.tsx
@@ -30,7 +30,7 @@ const steps = [
 
 export default function HowItWorks() {
   return (
-    <section className="py-16 sm:py-24 px-4 sm:px-6 md:px-12 lg:px-8 relative overflow-hidden">
+    <section className="relative overflow-hidden px-8 py-8 sm:px-6 sm:py-24 md:px-12 lg:px-8">
       <div
         className="absolute inset-0"
         style={{
@@ -46,12 +46,12 @@ export default function HowItWorks() {
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
           transition={{ duration: 0.6 }}
-          className="text-center mb-16"
+          className="mb-8 text-center sm:mb-16"
         >
-          <h2 className="theme-display-large text-4xl md:text-5xl font-bold mb-4">
+          <h2 className="theme-display-large mb-3 text-4xl font-bold md:text-5xl sm:mb-4">
             How It <span className="theme-heading-accent">Works</span>
           </h2>
-          <p className="text-text-secondary text-lg max-w-2xl mx-auto">
+          <p className="max-w-2xl mx-auto text-base text-text-secondary sm:text-lg">
             Four simple steps to digital sovereignty.
           </p>
         </motion.div>
@@ -66,7 +66,7 @@ export default function HowItWorks() {
             }}
           />
 
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
+          <div className="grid grid-cols-1 gap-4 sm:gap-8 md:grid-cols-2 lg:grid-cols-4">
             {steps.map((step, index) => (
               <motion.div
                 key={step.number}
@@ -76,21 +76,19 @@ export default function HowItWorks() {
                 transition={{ duration: 0.5, delay: index * 0.15 }}
                 className="relative"
               >
-                <div className="glass-card p-6 h-full">
-                  {/* Step number */}
-                  <div className="relative z-10 mb-4">
+                <div className="glass-card h-full p-5 sm:p-6">
+                  <div className="relative z-10 mb-3 flex items-center gap-3 sm:mb-4 sm:block">
                     <span
-                      className="text-5xl font-bold opacity-55"
+                      className="shrink-0 text-3xl font-bold leading-none opacity-55 sm:text-5xl"
                       style={{ color: "var(--theme-heading-accent)" }}
                     >
                       {step.number}
                     </span>
+                    <h3 className="text-lg font-semibold leading-tight text-text-primary sm:mt-4 sm:text-xl">
+                      {step.title}
+                    </h3>
                   </div>
-
-                  <h3 className="text-xl font-semibold text-text-primary mb-2">
-                    {step.title}
-                  </h3>
-                  <p className="text-text-secondary text-sm">
+                  <p className="text-sm text-text-secondary">
                     {step.description}
                   </p>
                 </div>

--- a/website/src/components/Navigation.tsx
+++ b/website/src/components/Navigation.tsx
@@ -243,7 +243,7 @@ export default function Navigation() {
       >
         {/* Mobile: solid full-width bar */}
         <div
-          className={`md:hidden bg-freed-black px-4 py-4 ${
+          className={`md:hidden bg-freed-black px-8 py-4 ${
             mobileMenuOpen ? "" : "border-b border-freed-border"
           }`}
         >

--- a/website/src/components/NewsletterModal.tsx
+++ b/website/src/components/NewsletterModal.tsx
@@ -16,8 +16,10 @@ type SubmitState = "idle" | "loading" | "error";
 
 const RELEASE_BASE =
   "https://github.com/freed-project/freed/releases/latest/download";
+const FREED_WEB_URL = "https://app.freed.wtf";
 
 type DownloadKey = "mac-arm" | "mac-intel" | "windows" | "linux";
+type InstallTarget = DownloadKey | "web";
 
 const DOWNLOADS: Record<DownloadKey, { label: string; file: string }> = {
   "mac-arm": {
@@ -124,6 +126,35 @@ function detectDownloadKey(): DownloadKey {
   return "mac-arm";
 }
 
+function isMobileDevice(): boolean {
+  if (typeof navigator === "undefined") return false;
+
+  const navWithUAData = navigator as Navigator & {
+    userAgentData?: { mobile?: boolean };
+  };
+
+  if (navWithUAData.userAgentData?.mobile === true) {
+    return true;
+  }
+
+  const ua = navigator.userAgent.toLowerCase();
+  if (
+    /\b(iphone|ipod|ipad|android|windows phone|mobile)\b/.test(ua)
+  ) {
+    return true;
+  }
+
+  return navigator.maxTouchPoints > 1 && ua.includes("macintosh");
+}
+
+function detectDefaultInstallTarget(): InstallTarget {
+  if (isMobileDevice()) {
+    return "web";
+  }
+
+  return detectDownloadKey();
+}
+
 export default function NewsletterModal() {
   const { isOpen, closeModal } = useNewsletter();
   const [email, setEmail] = useState("");
@@ -137,8 +168,7 @@ export default function NewsletterModal() {
   const [turnstileResetKey, setTurnstileResetKey] = useState(0);
   const [detailsOpen, setDetailsOpen] = useState(false);
   const [nameManuallyEdited, setNameManuallyEdited] = useState(false);
-  const [selectedPlatform, setSelectedPlatform] =
-    useState<DownloadKey>("mac-arm");
+  const [selectedTarget, setSelectedTarget] = useState<InstallTarget>("mac-arm");
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [dropdownMenuStyle, setDropdownMenuStyle] = useState<{
     top: number;
@@ -151,7 +181,7 @@ export default function NewsletterModal() {
   const dropdownMenuRef = useRef<HTMLUListElement>(null);
 
   useEffect(() => {
-    setSelectedPlatform(detectDownloadKey());
+    setSelectedTarget(detectDefaultInstallTarget());
     setAcceptedBundle(hasAcceptedWebsiteBundle());
   }, []);
 
@@ -320,8 +350,14 @@ export default function NewsletterModal() {
     closeModal();
   };
 
-  const currentDownload = DOWNLOADS[selectedPlatform];
-  const downloadUrl = `${RELEASE_BASE}/${currentDownload.file}`;
+  const currentDownload =
+    selectedTarget === "web" ? null : DOWNLOADS[selectedTarget];
+  const downloadUrl = currentDownload
+    ? `${RELEASE_BASE}/${currentDownload.file}`
+    : null;
+  const selectedTargetLabel =
+    selectedTarget === "web" ? "Freed Web" : currentDownload?.label ?? "";
+  const isWebTarget = selectedTarget === "web";
   const canProceed = acceptedBundle || legalChecked;
   const storedAcceptance = getWebsiteBundleAcceptance();
   const normalizedEmailInput = email.trim().toLowerCase();
@@ -337,14 +373,25 @@ export default function NewsletterModal() {
     return !!record;
   }, [acceptedBundle, legalChecked]);
 
-  const handleOpenWebApp = useCallback(() => {
-    window.open("https://app.freed.wtf", "_blank", "noopener,noreferrer");
-  }, []);
+  const handleOpenFreedWeb = useCallback(() => {
+    if (!ensureAccepted()) return;
+    window.open(FREED_WEB_URL, "_blank", "noopener,noreferrer");
+  }, [ensureAccepted]);
 
   const handleDownload = useCallback(() => {
     if (!ensureAccepted()) return;
+    if (!downloadUrl) return;
     window.open(downloadUrl, "_blank", "noopener,noreferrer");
   }, [downloadUrl, ensureAccepted]);
+
+  const handlePrimaryAction = useCallback(() => {
+    if (isWebTarget) {
+      handleOpenFreedWeb();
+      return;
+    }
+
+    handleDownload();
+  }, [handleDownload, handleOpenFreedWeb, isWebTarget]);
 
   return (
     <AnimatePresence>
@@ -366,9 +413,13 @@ export default function NewsletterModal() {
             animate={{ opacity: 1, scale: 1, y: 0 }}
             exit={{ opacity: 0, scale: 0.95, y: 20 }}
             transition={{ type: "spring", duration: 0.5 }}
-            className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-50 w-full max-w-5xl px-4"
+            className="fixed inset-0 z-50 flex items-start justify-center px-4 pt-4 sm:items-center sm:py-6"
+            style={{
+              paddingTop: "calc(env(safe-area-inset-top) + 1rem)",
+              paddingBottom: "calc(env(safe-area-inset-bottom) + 1rem)",
+            }}
           >
-            <div className="theme-panel relative overflow-visible rounded-2xl p-6 sm:p-10 md:p-12">
+            <div className="theme-panel relative w-full max-w-5xl overflow-hidden rounded-2xl">
               <div
                 className="absolute top-0 left-1/4 h-32 w-32 rounded-full blur-3xl"
                 style={{
@@ -403,12 +454,18 @@ export default function NewsletterModal() {
                 </svg>
               </button>
 
-              <div className="relative z-10">
+              <div
+                className="relative z-10 overflow-y-auto px-6 py-6 sm:px-10 sm:py-10 md:px-12 md:py-12"
+                style={{
+                  maxHeight:
+                    "calc(100dvh - env(safe-area-inset-top) - env(safe-area-inset-bottom) - 2rem)",
+                }}
+              >
                 <>
                   <div className="text-center mb-8">
                     <h3
                       id="get-freed-title"
-                      className="text-5xl font-bold text-text-primary mb-2"
+                      className="mb-2 text-4xl font-bold text-text-primary sm:text-5xl"
                     >
                       Get <span className="theme-heading-accent">Freed</span>
                     </h3>
@@ -651,9 +708,9 @@ export default function NewsletterModal() {
 
                     <div className="space-y-5 py-2 sm:py-4 lg:pl-8 lg:border-l lg:border-freed-border">
                         <div className="max-w-lg">
-                          <h4 className="flex items-center gap-3 text-3xl font-bold text-text-primary">
+                          <h4 className="flex items-center gap-3 text-2xl font-bold text-text-primary sm:text-3xl">
                             <CircledStepNumber number={2} />
-                            <span>Install Freed Desktop</span>
+                            <span>Launch or Install Freed</span>
                           </h4>
                         </div>
 
@@ -718,7 +775,7 @@ export default function NewsletterModal() {
                           >
                             <button
                               type="button"
-                              onClick={handleDownload}
+                              onClick={handlePrimaryAction}
                               disabled={!canProceed}
                               data-testid="website-legal-download"
                               className="group flex items-center gap-4 p-4 flex-1 min-w-0 disabled:opacity-50 disabled:cursor-not-allowed"
@@ -741,16 +798,24 @@ export default function NewsletterModal() {
                                   <path
                                     strokeLinecap="round"
                                     strokeLinejoin="round"
-                                    d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3"
+                                    d={
+                                      isWebTarget
+                                        ? "M13.5 6H19.5V12M10.5 18L19.5 9M4.5 7.5A1.5 1.5 0 016 6h6M4.5 10.5v7.5A1.5 1.5 0 006 19.5h7.5"
+                                        : "M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3"
+                                    }
                                   />
                                 </svg>
                               </div>
                               <div className="flex-1 min-w-0 text-left">
                                 <p className="text-sm font-semibold text-text-primary group-hover:text-text-primary transition-colors">
-                                  Download for {currentDownload.label}
+                                  {isWebTarget
+                                    ? "Launch Freed Web"
+                                    : `Download for ${selectedTargetLabel}`}
                                 </p>
                                 <p className="text-xs text-text-muted">
-                                  Runs in background to subscribe and monitor
+                                  {isWebTarget
+                                    ? "Open the mobile reader instantly in your browser"
+                                    : "Runs in background to subscribe and monitor"}
                                 </p>
                               </div>
                             </button>
@@ -778,37 +843,39 @@ export default function NewsletterModal() {
                         </div>
 
                         <div className="space-y-3">
-                          {(selectedPlatform === "windows" ||
-                            selectedPlatform === "linux") && (
+                          {(selectedTarget === "windows" ||
+                            selectedTarget === "linux") && (
                             <p className="text-xs leading-relaxed text-text-muted">
-                              {selectedPlatform === "windows"
+                              {selectedTarget === "windows"
                                 ? "Windows will probably warn before opening this unsigned installer. Click More info, then Run anyway."
                                 : "Before running on Linux, make the AppImage executable with chmod +x Freed-Linux-x64.AppImage."}
                             </p>
                           )}
 
-                          <button
-                            type="button"
-                            onClick={handleOpenWebApp}
-                            data-testid="website-legal-open-web-app"
-                            className="inline-flex items-center gap-2 rounded-lg bg-transparent px-2 py-1.5 text-sm text-text-muted underline decoration-current underline-offset-4 transition-colors hover:bg-[rgb(var(--theme-control-accent-rgb)/0.08)] hover:text-text-primary"
-                          >
-                            <svg
-                              aria-hidden="true"
-                              className="h-4 w-4"
-                              fill="none"
-                              viewBox="0 0 24 24"
-                              stroke="currentColor"
-                              strokeWidth={2}
+                          {!isWebTarget && (
+                            <button
+                              type="button"
+                              onClick={handleOpenFreedWeb}
+                              data-testid="website-legal-open-web-app"
+                              className="inline-flex items-center gap-2 rounded-lg bg-transparent px-2 py-1.5 text-sm text-text-muted underline decoration-current underline-offset-4 transition-colors hover:bg-[rgb(var(--theme-control-accent-rgb)/0.08)] hover:text-text-primary"
                             >
-                              <path
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                                d="M9 6l6 6-6 6M14 6l6 6-6 6"
-                              />
-                            </svg>
-                            <span>Already running Freed Desktop? Open the web app.</span>
-                          </button>
+                              <svg
+                                aria-hidden="true"
+                                className="h-4 w-4"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                                stroke="currentColor"
+                                strokeWidth={2}
+                              >
+                                <path
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                  d="M9 6l6 6-6 6M14 6l6 6-6 6"
+                                />
+                              </svg>
+                              <span>Already running Freed Desktop? Launch Freed Web.</span>
+                            </button>
+                          )}
                         </div>
                       </div>
                     </div>
@@ -836,25 +903,26 @@ export default function NewsletterModal() {
                     background: "var(--theme-bg-elevated)",
                   }}
                 >
-                  {(
-                    Object.entries(DOWNLOADS) as [
+                  {([
+                    ["web", { label: "Freed Web" }],
+                    ...(Object.entries(DOWNLOADS) as [
                       DownloadKey,
                       (typeof DOWNLOADS)[DownloadKey],
-                    ][]
-                  ).map(([key, dl]) => (
+                    ][]),
+                  ] as [InstallTarget, { label: string }][]).map(([key, dl]) => (
                     <li key={key}>
                       <button
                         onClick={() => {
-                          setSelectedPlatform(key);
+                          setSelectedTarget(key);
                           setDropdownOpen(false);
                         }}
                         className={`flex w-full items-center justify-between px-4 py-3 text-left text-sm transition-colors ${
-                          key === selectedPlatform
+                          key === selectedTarget
                             ? "text-text-primary"
                             : "text-text-secondary hover:text-text-primary"
                         }`}
                         style={
-                          key === selectedPlatform
+                          key === selectedTarget
                             ? {
                                 background:
                                   "color-mix(in srgb, var(--theme-heading-accent) 12%, transparent)",
@@ -863,7 +931,7 @@ export default function NewsletterModal() {
                         }
                       >
                         <span>{dl.label}</span>
-                        {key === selectedPlatform && (
+                        {key === selectedTarget && (
                           <svg
                             className="w-4 h-4 text-[color:var(--theme-heading-accent)]"
                             fill="none"

--- a/website/src/index.css
+++ b/website/src/index.css
@@ -74,6 +74,49 @@ html[data-theme="scriptorium"] .btn-primary:hover {
   transform: scale(1.05);
 }
 
+.hero-manifesto-button {
+  background: linear-gradient(
+    180deg,
+    color-mix(in oklab, var(--theme-bg-surface) 80%, white) 0%,
+    color-mix(in oklab, var(--theme-bg-surface) 94%, white) 24%,
+    color-mix(in oklab, var(--theme-bg-surface) 90%, black) 100%
+  );
+  border-color: color-mix(
+    in oklab,
+    var(--theme-border-subtle) 82%,
+    var(--theme-border-strong)
+  );
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 0.06),
+    inset 0 0 0 0.5px rgb(255 255 255 / 0.03),
+    0 14px 30px rgb(0 0 0 / 0.14);
+}
+
+.hero-manifesto-button:hover {
+  background: linear-gradient(
+    180deg,
+    color-mix(in oklab, var(--theme-bg-surface) 76%, white) 0%,
+    color-mix(in oklab, var(--theme-bg-surface) 92%, white) 24%,
+    color-mix(in oklab, var(--theme-bg-surface) 88%, black) 100%
+  );
+  border-color: color-mix(
+    in oklab,
+    var(--theme-border-strong) 62%,
+    var(--theme-border-subtle)
+  );
+}
+
+html[data-theme="scriptorium"] .hero-manifesto-button {
+  background: linear-gradient(
+    180deg,
+    color-mix(in oklab, var(--theme-bg-surface) 82%, white) 0%,
+    color-mix(in oklab, var(--theme-bg-surface) 94%, black) 100%
+  );
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 0.04),
+    0 10px 24px rgb(84 58 35 / 0.06);
+}
+
 .gradient-border {
   position: relative;
   background: var(--theme-bg-surface);


### PR DESCRIPTION
(AI Generated).

## What changed

- fixed shared tooltip positioning so panels clamp to the viewport, flip when space runs out, and keep their arrow anchored to the trigger
- made Neon, Ember, and Midas tooltip surfaces fully opaque
- tightened the mobile landing page layout with wider gutters, smaller hero art, denser feature and how-it-works cards, and a two-column mobile footer link layout
- gave the home page manifesto button a neutral liquid-glass background so the page texture no longer bleeds through
- updated the Get Freed modal to scroll internally on small screens and added a `Freed Web` launch target that defaults only on real mobile devices

## Why

The marketing site had a cluster of mobile polish issues and tooltip regressions. Tooltips could run off-screen, some dark-theme tooltip surfaces were too transparent, the home page burned too much vertical space on phones, and the Get Freed modal broke on mobile because it could exceed the viewport without scrolling.

## Impact

- mobile landing pages are denser and easier to browse one-handed
- the Get Freed flow is usable on phones and points mobile users at the web reader by default
- tooltip behavior is now predictable across the site and shared UI surfaces
- the manifesto CTA reads as a stable button surface instead of a transparent hole in the page

## Root cause

The shared tooltip primitive was using a fixed centered layout with no collision handling, and several website surfaces were leaning on transparent treatments that looked good in isolation but fell apart over the site background texture on small screens.

## Validation

- `npm run lint --workspace=website`
- `npx tsc --noEmit -p website/tsconfig.json`
- `npx tsc --noEmit -p packages/ui/tsconfig.json`
- browser verification against `http://localhost:3010` including mobile-device emulation for the `Freed Web` default and internal modal scrolling
