### PR TITLE
fix: polish mobile footer theme selector

### DIFF
--- a/website/src/components/Footer.tsx
+++ b/website/src/components/Footer.tsx
@@ -12,7 +12,10 @@ export default function Footer() {
         <div className="grid grid-cols-1 gap-8 md:grid-cols-3">
           {/* Brand */}
           <div>
-            <Link href="/" className="inline-flex items-baseline gap-0.5 mb-4">
+            <Link
+              href="/"
+              className="mb-4 hidden items-baseline gap-0.5 sm:inline-flex"
+            >
               <span className="relative text-xl font-bold text-text-primary font-logo">
                 FREED
                 <span
@@ -26,7 +29,7 @@ export default function Footer() {
                 .WTF
               </span>
             </Link>
-            <div className="mt-6 max-w-[18rem]">
+            <div className="max-w-[18rem] sm:mt-6">
               <ThemeSelector compact />
             </div>
           </div>

--- a/website/src/components/ThemeSelector.tsx
+++ b/website/src/components/ThemeSelector.tsx
@@ -13,10 +13,8 @@ export default function ThemeSelector({ compact = false }: ThemeSelectorProps) {
   const gapClassName = compact ? "gap-2" : "gap-3";
 
   return (
-    <div className="flex flex-col gap-2">
-      <span className="text-xs font-semibold uppercase tracking-[0.18em] text-text-muted">
-        Theme
-      </span>
+    <div className="flex flex-col">
+      <h4 className="mb-4 text-text-primary font-semibold">Theme</h4>
       <div className={`flex flex-wrap items-center ${gapClassName}`}>
         {THEME_DEFINITIONS.map((theme) => (
           <Tooltip


### PR DESCRIPTION
(AI Generated).

## Summary
- hide the `FREED.WTF` footer logo on mobile while keeping it visible on larger breakpoints
- give the footer theme selector the same heading style as the Product and Resources sections
- preserve footer spacing so the theme swatches stay aligned after the mobile logo is removed

## Why
The mobile footer still spent space on the footer wordmark, and the theme picker label did not match the other footer section headings. This made the mobile footer feel heavier and a little inconsistent.

## Validation
- `PATH="/Users/aubreyfalconer/dev/freed-mobile-footer-theme-heading/node_modules/.bin:$PATH" next build`
- verified the footer in a browser at mobile width and desktop width against the local preview
