### PR TITLE
fix: apply desktop theme changes immediately

### DIFF
--- a/packages/desktop/tests/e2e/theme-switching.spec.ts
+++ b/packages/desktop/tests/e2e/theme-switching.spec.ts
@@ -1,0 +1,84 @@
+import { test, expect, resolveViteFsModulePath } from "./fixtures/app";
+
+const SETTINGS_STORE_PATH = resolveViteFsModulePath(
+  "../../../ui/src/lib/settings-store.ts",
+  import.meta.url,
+);
+
+test("switching themes in settings applies the selected theme immediately", async ({ app, page }) => {
+  await app.goto();
+  await app.waitForReady();
+
+  await page.evaluate(async (settingsStorePath) => {
+    const mod = await import(settingsStorePath);
+    mod.useSettingsStore.getState().openTo("appearance");
+  }, SETTINGS_STORE_PATH);
+
+  await expect(page.getByText("Appearance").first()).toBeVisible({ timeout: 5_000 });
+
+  const initialThemeId = await page.evaluate(() => document.documentElement.dataset.theme);
+  expect(initialThemeId).toBe("neon");
+
+  await page
+    .locator("button")
+    .filter({ has: page.getByText("Scriptorium", { exact: true }) })
+    .first()
+    .click();
+
+  await expect.poll(async () => {
+    return page.evaluate(() => document.documentElement.dataset.theme);
+  }).toBe("scriptorium");
+
+  await expect.poll(async () => {
+    return page.evaluate(() => {
+      const w = window as Record<string, unknown>;
+      const store = w.__FREED_STORE__ as
+        | { getState: () => { preferences: { display: { themeId: string } } } }
+        | undefined;
+      return store?.getState().preferences.display.themeId;
+    });
+  }).toBe("scriptorium");
+});
+
+test("theme switching repaints the app even before preferences finish saving", async ({ app, page }) => {
+  await app.goto();
+  await app.waitForReady();
+
+  await page.evaluate(async (settingsStorePath) => {
+    const mod = await import(settingsStorePath);
+    mod.useSettingsStore.getState().openTo("appearance");
+  }, SETTINGS_STORE_PATH);
+
+  await expect(page.getByText("Appearance").first()).toBeVisible({ timeout: 5_000 });
+
+  await page.evaluate(() => {
+    const w = window as Record<string, unknown>;
+    const store = w.__FREED_STORE__ as {
+      getState: () => { updatePreferences: (update: unknown) => Promise<void> };
+      setState: (partial: unknown) => void;
+    };
+    store.setState({
+      updatePreferences: async () => await new Promise<void>(() => {}),
+    });
+  });
+
+  await page
+    .locator("button")
+    .filter({ has: page.getByText("Scriptorium", { exact: true }) })
+    .first()
+    .click();
+
+  await expect.poll(async () => {
+    return page.evaluate(() => document.documentElement.dataset.theme);
+  }).toBe("scriptorium");
+
+  await expect.poll(async () => {
+    return page.evaluate(() => {
+      const w = window as Record<string, unknown>;
+      const store = w.__FREED_STORE__ as
+        | { getState: () => { preferences: { display: { themeId: string } } } }
+        | undefined;
+      return store?.getState().preferences.display.themeId;
+    });
+  }).toBe("neon");
+});

--- a/packages/ui/src/components/SettingsDialog.tsx
+++ b/packages/ui/src/components/SettingsDialog.tsx
@@ -16,6 +16,7 @@ import { useAppStore, usePlatform } from "../context/PlatformContext.js";
 import { useDebugStore } from "../lib/debug-store.js";
 import { useSettingsStore } from "../lib/settings-store.js";
 import { refreshSampleLibraryData } from "../lib/sample-library-seed.js";
+import { applyThemeToDocument, persistTheme } from "../lib/theme.js";
 import {
   getProviderStatusLabel,
   getProviderStatusTone,
@@ -316,7 +317,18 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
     (update: Partial<typeof display>) => {
       setDisplay((prev) => {
         const next = { ...prev, ...update };
-        updatePreferences({ display: next });
+        if (update.themeId && update.themeId !== prev.themeId) {
+          applyThemeToDocument(update.themeId);
+          persistTheme(update.themeId);
+        }
+        void updatePreferences({ display: next }).catch(() => {
+          if (update.themeId && update.themeId !== prev.themeId) {
+            applyThemeToDocument(prev.themeId);
+            persistTheme(prev.themeId);
+            setDisplay(prev);
+          }
+          toast.error("Could not save settings");
+        });
         return next;
       });
     },


### PR DESCRIPTION
(AI Generated).

## Summary
- apply the selected theme immediately from the Settings appearance picker
- persist the theme selection right away and roll back with an error toast if saving fails
- add desktop E2E coverage for both the normal switch path and a stalled preferences-save path

## Root cause
The Settings dialog updated its local selection state before the persisted preference roundtrip completed. If that save stalled or failed, the active theme card could change while the live desktop shell stayed on the previous theme.

## Validation
- `node ../../node_modules/playwright/cli.js test theme-switching.spec.ts`
- `node ./node_modules/typescript/bin/tsc -b --pretty false`
