### PR TITLE
fix: restore neon background and polish mobile website

### DIFF
--- a/docs/PHASE-1-FOUNDATION.md
+++ b/docs/PHASE-1-FOUNDATION.md
@@ -130,9 +130,13 @@ Next.js 15 (App Router) site deployed to Vercel at freed.wtf.
 - Auto-generated sitemap.xml
 - RSS/Atom feed generation at build time
 - Public legal pages for Terms of Use, Privacy, and Desktop EULA
-- Versioned website clickwrap in the download modal for Terms of Use and Privacy before opening the PWA or downloading Freed Desktop
-- Get Freed modal now scrolls internally on small screens and defaults real mobile devices to a `Freed Web` launch target while still offering every desktop download explicitly
+- Get Freed modal now scrolls internally on small screens, removes the extra mobile subtitle under the main title, keeps the mobile signup and launch headings on matching vertical spacing, simplifies the mobile section copy, gives the mobile launch CTA a primary-tinted treatment, closes reliably from the `X` button even on direct `/get` visits, and defaults real mobile devices to a `Freed Web` launch target while still offering every desktop download explicitly
+- Mobile nav header now keeps a top-level `Get Freed` CTA beside the hamburger once the user scrolls away from the top of the homepage or lands on any non-home page, animating it in smoothly while the full mobile menu still exposes the same primary action inside the drawer
+- Marketing homepage now stays in its single-column mobile layout through tablet widths, including the mobile nav, compact hero treatment, and stacked content grids, before switching to desktop layouts at `lg`
+- Marketing-site manifesto buttons now use the shared theme secondary button treatment consistently, including both `Read the Manifesto` and `Why We Built This`
 - Shared cross-surface theme system for the marketing site, Freed Desktop, and the PWA
+- Neon now uses the original randomized marketing-site background logic as the canonical shared theme background across the marketing site, Freed Desktop, and Freed Web, while the other themes keep their current shared rendering
+- Marketing site no longer inherits the shared app scrollbar chrome, while Freed Desktop and Freed Web keep the themed scrollbar treatment inside app shells and dialogs
 - Theme-aware form controls across the marketing site and shared UI package
 - Shared theme-aware tooltip primitive across the marketing site and shared UI package
 - Homepage footer theme picker uses the same preview swatches as Freed Desktop, with hover tooltips for each theme

--- a/packages/shared/src/themes.ts
+++ b/packages/shared/src/themes.ts
@@ -7,6 +7,8 @@ export interface ThemeBackgroundTextureLayer {
   image: string;
   size: string;
   repeat: "repeat" | "no-repeat";
+  compactSize?: string;
+  compactOpacity?: number;
 }
 
 export interface ThemeBackgroundHeroOrb {
@@ -39,6 +41,8 @@ export interface ThemeBackgroundRecipe {
   textures: readonly ThemeBackgroundTextureLayer[];
   heroOrbs: readonly ThemeBackgroundHeroOrb[];
   rowOrbs: ThemeBackgroundRowOrb;
+  renderer?: "legacy" | "responsive";
+  overlayEnabled?: boolean;
 }
 
 export interface ThemeDefinition {
@@ -87,8 +91,6 @@ const DEFAULT_HERO_ORBS: readonly ThemeBackgroundHeroOrb[] = [
   },
 ] as const;
 
-const NEON_HERO_ORBS: readonly ThemeBackgroundHeroOrb[] = [] as const;
-
 const DEFAULT_ROW_ORBS: ThemeBackgroundRowOrb = {
   countPerRow: 2,
   channels: ["secondary", "primary", "tertiary"] as const,
@@ -121,24 +123,7 @@ const DEFAULT_OVERLAY_BACKGROUND = `radial-gradient(
     ),
     linear-gradient(180deg, transparent 0%, rgb(var(--theme-shell-rgb) / 0.05) 100%)`;
 
-const NEON_SHELL_BACKGROUND = `radial-gradient(circle at 12% 16%, rgb(59 130 246 / 0.18) 0, transparent 34%),
-    radial-gradient(circle at 84% 10%, rgb(139 92 246 / 0.22) 0, transparent 30%),
-    radial-gradient(circle at 76% 82%, rgb(6 182 212 / 0.14) 0, transparent 32%),
-    linear-gradient(180deg, #090a11 0%, #0a0a0f 34%, #090909 100%)`;
-
-const NEON_OVERLAY_BACKGROUND = `radial-gradient(
-      ellipse 900px 900px at -10% -15%,
-      rgb(var(--theme-accent-secondary-rgb) / 0.17) 0%,
-      rgb(var(--theme-accent-secondary-rgb) / 0.05) 35%,
-      transparent 65%
-    ),
-    radial-gradient(
-      ellipse 800px 800px at 110% 110%,
-      rgb(var(--theme-accent-primary-rgb) / 0.14) 0%,
-      rgb(var(--theme-accent-primary-rgb) / 0.04) 35%,
-      transparent 65%
-    ),
-    linear-gradient(180deg, transparent 0%, rgb(var(--theme-shell-rgb) / 0.08) 100%)`;
+const NEON_SHELL_BACKGROUND = `linear-gradient(180deg, #090a11 0%, #0a0a0f 34%, #090909 100%)`;
 
 const MIDAS_SHELL_BACKGROUND = `radial-gradient(circle at 14% 14%, rgb(176 138 72 / 0.12) 0, transparent 36%),
     radial-gradient(circle at 78% 8%, rgb(124 92 56 / 0.1) 0, transparent 32%),
@@ -171,11 +156,13 @@ export const THEME_DEFINITIONS: readonly ThemeDefinition[] = [
     effects: "dramatic",
     background: {
       shellBackground: NEON_SHELL_BACKGROUND,
-      overlayBackground: NEON_OVERLAY_BACKGROUND,
+      overlayBackground: "none",
       baseOpacity: 0.12,
       textures: [{ image: NOISE_TEXTURE, size: "256px 256px", repeat: "repeat" }],
-      heroOrbs: NEON_HERO_ORBS,
+      heroOrbs: DEFAULT_HERO_ORBS,
       rowOrbs: DEFAULT_ROW_ORBS,
+      renderer: "legacy",
+      overlayEnabled: false,
     },
   },
   {

--- a/packages/ui/src/components/layout/BackgroundAtmosphere.tsx
+++ b/packages/ui/src/components/layout/BackgroundAtmosphere.tsx
@@ -6,6 +6,7 @@ import {
   resolveThemeId,
   type ThemeId,
   type ThemeBackgroundRecipe,
+  type ThemeBackgroundTextureLayer,
 } from "@freed/shared/themes";
 
 const channels = {
@@ -20,6 +21,8 @@ const MAX_HEIGHT = 2500;
 const VERTICAL_SPACING = 600;
 const HERO_ZONE_HEIGHT = 800;
 const MOBILE_BREAKPOINT = 768;
+const DESKTOP_BASELINE_WIDTH = 1280;
+const MIN_WIDTH_SCALE = 0.58;
 
 interface Orb {
   channel: ChannelName;
@@ -29,13 +32,53 @@ interface Orb {
   intensity: number;
 }
 
+interface ViewportProfile {
+  compact: boolean;
+  orbSizeScale: number;
+  orbIntensityScale: number;
+}
+
+type RendererMode = NonNullable<ThemeBackgroundRecipe["renderer"]>;
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
 function randomInRange(min: number, range: number): number {
   return min + Math.random() * range;
 }
 
-function generateOrbs(recipe: ThemeBackgroundRecipe): Orb[] {
+function getViewportProfile(viewportWidth: number): ViewportProfile {
+  const widthScale = clamp(
+    viewportWidth / DESKTOP_BASELINE_WIDTH,
+    MIN_WIDTH_SCALE,
+    1,
+  );
+
+  return {
+    compact: viewportWidth < MOBILE_BREAKPOINT,
+    orbSizeScale: Math.sqrt(widthScale),
+    orbIntensityScale: clamp(0.72 + widthScale * 0.28, 0.82, 1),
+  };
+}
+
+function getCompactCountPerRow(countPerRow: number): number {
+  return Math.max(1, Math.ceil(countPerRow / 2));
+}
+
+function generateOrbs(
+  recipe: ThemeBackgroundRecipe,
+  compact: boolean,
+  rendererMode: RendererMode,
+): Orb[] {
   const orbs: Orb[] = [];
   const rowRecipe = recipe.rowOrbs;
+  const countPerRow =
+    rendererMode === "legacy"
+      ? rowRecipe.countPerRow
+      : compact
+    ? getCompactCountPerRow(rowRecipe.countPerRow)
+    : rowRecipe.countPerRow;
 
   recipe.heroOrbs.forEach((heroOrb) => {
     orbs.push({
@@ -51,7 +94,7 @@ function generateOrbs(recipe: ThemeBackgroundRecipe): Orb[] {
     Math.ceil((MAX_HEIGHT - HERO_ZONE_HEIGHT) / VERTICAL_SPACING) + 1;
   for (let row = 0; row < numRows; row++) {
     const baseY = HERO_ZONE_HEIGHT + row * VERTICAL_SPACING;
-    for (let i = 0; i < rowRecipe.countPerRow; i++) {
+    for (let i = 0; i < countPerRow; i++) {
       orbs.push({
         channel:
           rowRecipe.channels[
@@ -71,7 +114,28 @@ function generateOrbs(recipe: ThemeBackgroundRecipe): Orb[] {
   return orbs;
 }
 
-function buildBackground(
+function buildGradientBackground(
+  orbs: Orb[],
+  viewportProfile: ViewportProfile,
+  recipe: ThemeBackgroundRecipe,
+): string {
+  return orbs
+    .map((orb) => {
+      const { rgbVar, intensity } = channels[orb.channel];
+      const size = Math.round(orb.size * viewportProfile.orbSizeScale);
+      const opacityMultiplier = Number(
+        (
+          orb.intensity
+          * intensity
+          * viewportProfile.orbIntensityScale
+        ).toFixed(3),
+      );
+      return `radial-gradient(${size}px ${size}px at ${orb.x}% ${orb.y}px, rgb(var(${rgbVar}) / ${recipe.baseOpacity * opacityMultiplier}), transparent)`;
+    })
+    .join(", ");
+}
+
+function buildLegacyBackground(
   orbs: Orb[],
   intensityMultiplier: number,
   recipe: ThemeBackgroundRecipe,
@@ -89,7 +153,15 @@ function buildBackground(
   return [...textures, gradients].join(", ");
 }
 
-function buildRepeatValues(
+function buildGradientRepeatValues(count: number): string {
+  return Array(count).fill("no-repeat").join(", ");
+}
+
+function buildGradientSizeValues(count: number): string {
+  return Array(count).fill("auto").join(", ");
+}
+
+function buildLegacyRepeatValues(
   count: number,
   recipe: ThemeBackgroundRecipe,
 ): string {
@@ -99,28 +171,56 @@ function buildRepeatValues(
   ].join(", ");
 }
 
-function buildSizeValues(count: number, recipe: ThemeBackgroundRecipe): string {
+function buildLegacySizeValues(
+  count: number,
+  recipe: ThemeBackgroundRecipe,
+): string {
   return [
     ...recipe.textures.map((texture) => texture.size),
     ...Array(count).fill("auto"),
   ].join(", ");
 }
 
+function resolveTextureSize(
+  texture: ThemeBackgroundTextureLayer,
+  viewportProfile: ViewportProfile,
+): string {
+  return viewportProfile.compact
+    ? texture.compactSize ?? texture.size
+    : texture.size;
+}
+
+function resolveTextureOpacity(
+  texture: ThemeBackgroundTextureLayer,
+  viewportProfile: ViewportProfile,
+): number {
+  if (!viewportProfile.compact) {
+    return 1;
+  }
+
+  return texture.compactOpacity ?? 1;
+}
+
 export function BackgroundAtmosphere() {
   const [orbs, setOrbs] = useState<Orb[] | null>(null);
-  const [isMobile, setIsMobile] = useState(false);
+  const [viewportWidth, setViewportWidth] = useState(DESKTOP_BASELINE_WIDTH);
   const [themeId, setThemeId] = useState<ThemeId>("neon");
   const themeRecipe = useMemo(
     () => getThemeDefinition(themeId).background,
     [themeId],
   );
+  const viewportProfile = useMemo(
+    () => getViewportProfile(viewportWidth),
+    [viewportWidth],
+  );
+  const rendererMode: RendererMode = themeRecipe.renderer ?? "responsive";
+  const isLegacyRenderer = rendererMode === "legacy";
 
   useEffect(() => {
     const initialThemeId = resolveThemeId(
       document.documentElement.dataset.theme || "neon",
     );
-    setOrbs(generateOrbs(getThemeDefinition(initialThemeId).background));
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+    setViewportWidth(window.innerWidth);
     setThemeId(initialThemeId);
 
     const observer = new MutationObserver(() => {
@@ -128,7 +228,6 @@ export function BackgroundAtmosphere() {
         document.documentElement.dataset.theme || "neon",
       );
       setThemeId(nextThemeId);
-      setOrbs(generateOrbs(getThemeDefinition(nextThemeId).background));
     });
     observer.observe(document.documentElement, {
       attributes: true,
@@ -139,7 +238,7 @@ export function BackgroundAtmosphere() {
     const onResize = () => {
       cancelAnimationFrame(rafId);
       rafId = requestAnimationFrame(() => {
-        setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+        setViewportWidth(window.innerWidth);
       });
     };
     window.addEventListener("resize", onResize);
@@ -150,36 +249,88 @@ export function BackgroundAtmosphere() {
     };
   }, []);
 
-  const backgroundImage = useMemo(
-    () => (orbs ? buildBackground(orbs, isMobile ? 0.5 : 1, themeRecipe) : ""),
-    [orbs, isMobile, themeRecipe],
+  useEffect(() => {
+    setOrbs(generateOrbs(themeRecipe, viewportProfile.compact, rendererMode));
+  }, [themeRecipe, viewportProfile.compact, rendererMode]);
+
+  const gradientBackgroundImage = useMemo(
+    () =>
+      orbs
+        ? isLegacyRenderer
+          ? buildLegacyBackground(
+              orbs,
+              viewportProfile.compact ? 0.5 : 1,
+              themeRecipe,
+            )
+          : buildGradientBackground(orbs, viewportProfile, themeRecipe)
+        : "",
+    [isLegacyRenderer, orbs, viewportProfile, themeRecipe],
   );
-  const backgroundRepeat = useMemo(
-    () => (orbs ? buildRepeatValues(orbs.length, themeRecipe) : ""),
-    [orbs, themeRecipe],
+  const gradientBackgroundRepeat = useMemo(
+    () =>
+      orbs
+        ? isLegacyRenderer
+          ? buildLegacyRepeatValues(orbs.length, themeRecipe)
+          : buildGradientRepeatValues(orbs.length)
+        : "",
+    [isLegacyRenderer, orbs, themeRecipe],
   );
-  const backgroundSize = useMemo(
-    () => (orbs ? buildSizeValues(orbs.length, themeRecipe) : ""),
-    [orbs, themeRecipe],
+  const gradientBackgroundSize = useMemo(
+    () =>
+      orbs
+        ? isLegacyRenderer
+          ? buildLegacySizeValues(orbs.length, themeRecipe)
+          : buildGradientSizeValues(orbs.length)
+        : "",
+    [isLegacyRenderer, orbs, themeRecipe],
   );
 
   if (!orbs) return null;
 
   return (
     <div className="pointer-events-none absolute inset-0 overflow-hidden" aria-hidden="true">
-      <div
-        className="absolute inset-0"
-        style={{
-          backgroundImage,
-          backgroundRepeat,
-          backgroundSize,
-          willChange: "transform",
-          transform: "translateZ(0)",
-        }}
-      />
-      <div
-        className="bg-gradient-orbs absolute inset-0"
-      />
+      {isLegacyRenderer ? (
+        <div
+          className="absolute inset-0"
+          style={{
+            backgroundImage: gradientBackgroundImage,
+            backgroundRepeat: gradientBackgroundRepeat,
+            backgroundSize: gradientBackgroundSize,
+            willChange: "transform",
+            transform: "translateZ(0)",
+          }}
+        />
+      ) : (
+        <>
+          {themeRecipe.textures.map((texture, index) => (
+            <div
+              key={`${themeId}-${index}`}
+              className="absolute inset-0"
+              style={{
+                backgroundImage: texture.image,
+                backgroundRepeat: texture.repeat,
+                backgroundSize: resolveTextureSize(texture, viewportProfile),
+                opacity: resolveTextureOpacity(texture, viewportProfile),
+                willChange: "transform",
+                transform: "translateZ(0)",
+              }}
+            />
+          ))}
+          <div
+            className="absolute inset-0"
+            style={{
+              backgroundImage: gradientBackgroundImage,
+              backgroundRepeat: gradientBackgroundRepeat,
+              backgroundSize: gradientBackgroundSize,
+              willChange: "transform",
+              transform: "translateZ(0)",
+            }}
+          />
+        </>
+      )}
+      {themeRecipe.overlayEnabled !== false && (
+        <div className="bg-gradient-orbs absolute inset-0" />
+      )}
     </div>
   );
 }

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -39,41 +39,8 @@ html[data-theme="neon"] {
   --theme-accent-tertiary-rgb: 6 182 212;
 
   --theme-shell-rgb: 6 7 13;
-  --theme-shell-background:
-    radial-gradient(
-      circle at 12% 16%,
-      rgb(59 130 246 / 0.18) 0,
-      transparent 34%
-    ),
-    radial-gradient(
-      circle at 84% 10%,
-      rgb(139 92 246 / 0.22) 0,
-      transparent 30%
-    ),
-    radial-gradient(
-      circle at 76% 82%,
-      rgb(6 182 212 / 0.14) 0,
-      transparent 32%
-    ),
-    linear-gradient(180deg, #090a11 0%, #0a0a0f 34%, #090909 100%);
-  --theme-atmosphere-overlay-background:
-    radial-gradient(
-      ellipse 900px 900px at -10% -15%,
-      rgb(var(--theme-accent-secondary-rgb) / 0.17) 0%,
-      rgb(var(--theme-accent-secondary-rgb) / 0.05) 35%,
-      transparent 65%
-    ),
-    radial-gradient(
-      ellipse 800px 800px at 110% 110%,
-      rgb(var(--theme-accent-primary-rgb) / 0.14) 0%,
-      rgb(var(--theme-accent-primary-rgb) / 0.04) 35%,
-      transparent 65%
-    ),
-    linear-gradient(
-      180deg,
-      transparent 0%,
-      rgb(var(--theme-shell-rgb) / 0.08) 100%
-    );
+  --theme-shell-background: linear-gradient(180deg, #090a11 0%, #0a0a0f 34%, #090909 100%);
+  --theme-atmosphere-overlay-background: none;
 
   --theme-button-primary-background: linear-gradient(
     135deg,
@@ -1923,21 +1890,33 @@ input[type="radio"]:focus-visible {
   outline-offset: 2px;
 }
 
-::-webkit-scrollbar {
+.app-theme-shell::-webkit-scrollbar,
+.app-theme-shell ::-webkit-scrollbar,
+.theme-dialog-shell::-webkit-scrollbar,
+.theme-dialog-shell ::-webkit-scrollbar {
   width: 8px;
   height: 8px;
 }
 
-::-webkit-scrollbar-track {
+.app-theme-shell::-webkit-scrollbar-track,
+.app-theme-shell ::-webkit-scrollbar-track,
+.theme-dialog-shell::-webkit-scrollbar-track,
+.theme-dialog-shell ::-webkit-scrollbar-track {
   background: transparent;
 }
 
-::-webkit-scrollbar-thumb {
+.app-theme-shell::-webkit-scrollbar-thumb,
+.app-theme-shell ::-webkit-scrollbar-thumb,
+.theme-dialog-shell::-webkit-scrollbar-thumb,
+.theme-dialog-shell ::-webkit-scrollbar-thumb {
   background: rgb(var(--theme-accent-secondary-rgb) / 0.18);
   border-radius: 999px;
 }
 
-::-webkit-scrollbar-thumb:hover {
+.app-theme-shell::-webkit-scrollbar-thumb:hover,
+.app-theme-shell ::-webkit-scrollbar-thumb:hover,
+.theme-dialog-shell::-webkit-scrollbar-thumb:hover,
+.theme-dialog-shell ::-webkit-scrollbar-thumb:hover {
   background: rgb(var(--theme-accent-secondary-rgb) / 0.28);
 }
 

--- a/website/src/components/Features.tsx
+++ b/website/src/components/Features.tsx
@@ -218,11 +218,11 @@ export default function Features() {
   return (
     <section
       id="features"
-      className="px-8 py-8 sm:px-6 sm:py-24 md:px-12 lg:px-8"
+      className="px-8 py-8 sm:px-6 sm:py-24 lg:px-8 xl:px-12"
     >
       <div className="max-w-6xl mx-auto">
         {/* Feature Grid */}
-        <div className="grid grid-cols-1 gap-4 sm:gap-6 md:grid-cols-2 lg:grid-cols-3">
+        <div className="grid grid-cols-1 gap-4 sm:gap-6 lg:grid-cols-2 xl:grid-cols-3">
           {features.map((feature, index) => (
             <motion.div
               key={feature.title}

--- a/website/src/components/Footer.tsx
+++ b/website/src/components/Footer.tsx
@@ -5,11 +5,11 @@ export default function Footer() {
   return (
     <footer
       aria-label="Site footer"
-      className="relative z-10 border-t border-freed-border bg-freed-black px-8 pt-8 sm:px-8 sm:pt-12 md:px-12 lg:px-8"
+      className="relative z-10 border-t border-freed-border bg-freed-black px-8 pt-8 sm:px-8 sm:pt-12 lg:px-8 xl:px-12"
       style={{ paddingBottom: "calc(2rem + env(safe-area-inset-bottom))" }}
     >
       <div className="max-w-6xl mx-auto">
-        <div className="grid grid-cols-1 gap-8 md:grid-cols-3">
+        <div className="grid grid-cols-1 gap-8 lg:grid-cols-3">
           {/* Brand */}
           <div>
             <Link
@@ -34,7 +34,7 @@ export default function Footer() {
             </div>
           </div>
 
-          <div className="grid grid-cols-2 gap-8 md:contents">
+          <div className="grid grid-cols-2 gap-8 lg:contents">
             {/* Links */}
             <div>
               <h4 className="text-text-primary font-semibold mb-4">Product</h4>
@@ -116,7 +116,7 @@ export default function Footer() {
         </div>
 
         {/* Bottom */}
-        <div className="mt-12 pt-8 border-t border-freed-border flex flex-col md:flex-row items-center justify-between gap-4 text-center md:text-left">
+        <div className="mt-12 flex flex-col items-center justify-between gap-4 border-t border-freed-border pt-8 text-center lg:flex-row lg:text-left">
           <p className="text-text-muted text-sm">
             &copy; 2025-{new Date().getFullYear()} Freed contributors. Open source under MIT
             License.

--- a/website/src/components/Hero.tsx
+++ b/website/src/components/Hero.tsx
@@ -23,7 +23,7 @@ export default function Hero() {
   }, []);
 
   useEffect(() => {
-    const mediaQuery = window.matchMedia("(max-width: 639px)");
+    const mediaQuery = window.matchMedia("(max-width: 1023px)");
     const updateCompactHero = () => setCompactHeroAnimation(mediaQuery.matches);
     updateCompactHero();
     mediaQuery.addEventListener("change", updateCompactHero);
@@ -31,7 +31,7 @@ export default function Hero() {
   }, []);
 
   return (
-    <section className="relative min-h-viewport-safe flex items-start justify-center px-8 sm:px-6 pb-8 pt-24 sm:pb-16 md:pt-[clamp(7rem,_25vh,_50rem)]">
+    <section className="relative min-h-viewport-safe flex items-start justify-center px-8 sm:px-6 pb-8 pt-24 sm:pb-16 lg:pt-[clamp(7rem,_25vh,_50rem)]">
       {/* Open Source badge - aligned with nav container right edge, hidden on mobile */}
       <div className="hidden lg:block absolute top-20 left-0 right-0 mt-4 px-4 sm:px-6">
         <div className="max-w-6xl mx-auto flex justify-end">
@@ -64,7 +64,7 @@ export default function Hero() {
           }}
           className="relative order-1 w-full lg:order-2"
           style={{
-            maxWidth: compactHeroAnimation ? "212px" : "425px",
+            maxWidth: compactHeroAnimation ? "282px" : "425px",
             margin: "0 auto",
           }}
         >
@@ -81,7 +81,7 @@ export default function Hero() {
           }}
           className="order-2 text-center lg:order-1 lg:pl-10 lg:text-left"
         >
-          <h1 className="theme-display-large mb-6 text-4xl font-bold leading-[1.05] sm:mb-12 sm:text-5xl md:text-6xl lg:-ml-2 lg:text-7xl">
+          <h1 className="theme-display-large mb-6 text-4xl font-bold leading-[1.05] sm:mb-12 sm:text-5xl lg:-ml-2 lg:text-7xl">
             <span className="text-text-primary">Take Back</span>
             <br />
             <span className="text-text-primary">Your </span>
@@ -132,7 +132,7 @@ export default function Hero() {
               <motion.button
                 whileHover={{ scale: 1.02 }}
                 whileTap={{ scale: 0.98 }}
-                className="btn-secondary hero-manifesto-button text-base px-8 py-3 w-full"
+                className="btn-secondary text-base px-8 py-3 w-full"
               >
                 Read the Manifesto
               </motion.button>

--- a/website/src/components/HeroAnimation.tsx
+++ b/website/src/components/HeroAnimation.tsx
@@ -302,12 +302,30 @@ export default function HeroAnimation({
   const { themeId } = useTheme();
   const logos = useMemo(() => buildLogos(), []);
   const particles = useParticleSystem(logos);
-  const platformRadius = compact ? 26 : 22;
-  const platformIconSize = compact ? 24 : 20;
+  const viewBoxInset = compact ? 78 : 50;
+  const viewBoxMin = -viewBoxInset;
+  const viewBoxSize = 400 + viewBoxInset * 2;
+  const platformRadius = compact ? 39 : 22;
+  const platformIconSize = compact ? 36 : 20;
+  const centerGlowRadius = compact ? 69 : 55;
+  const centerGlowExpandedRadius = compact ? 78 : 62;
+  const centerGlowOpacity = compact ? 0.11 : 0.08;
+  const centerGlowExpandedOpacity = compact ? 0.18 : 0.15;
+  const centerBoxSize = compact ? 112.5 : 90;
+  const centerBoxInset = CENTER - centerBoxSize / 2;
+  const centerBoxRadius = compact ? 20 : 16;
+  const centerStrokeWidth = compact ? 3.75 : 3;
+  const centerFontSize = compact ? 60 : 48;
+  const centerTextY = compact ? 221 : 215;
+  const pulseStrokeWidth = compact ? 2.5 : 2;
 
   return (
     <div className="relative w-full aspect-square">
-      <svg key={themeId} viewBox="-50 -50 500 500" className="w-full h-full">
+      <svg
+        key={themeId}
+        viewBox={`${viewBoxMin} ${viewBoxMin} ${viewBoxSize} ${viewBoxSize}`}
+        className="w-full h-full"
+      >
         <defs>
           <linearGradient id="ringGradient" x1="0%" y1="0%" x2="100%" y2="100%">
             <stop offset="0%" stopColor="var(--theme-accent-primary)" stopOpacity="0.3" />
@@ -453,11 +471,18 @@ export default function HeroAnimation({
         <motion.circle
           cx={CENTER}
           cy={CENTER}
-          r="55"
+          r={centerGlowRadius}
           fill="url(#centerGradient)"
-          opacity="0.08"
+          opacity={centerGlowOpacity}
           filter="url(#glow)"
-          animate={{ r: [55, 62, 55], opacity: [0.08, 0.15, 0.08] }}
+          animate={{
+            r: [centerGlowRadius, centerGlowExpandedRadius, centerGlowRadius],
+            opacity: [
+              centerGlowOpacity,
+              centerGlowExpandedOpacity,
+              centerGlowOpacity,
+            ],
+          }}
           transition={{
             duration: slowHeroMotion(2),
             repeat: Infinity,
@@ -467,30 +492,30 @@ export default function HeroAnimation({
 
         {/* Center box */}
         <rect
-          x="155"
-          y="155"
-          width="90"
-          height="90"
-          rx="16"
+          x={centerBoxInset}
+          y={centerBoxInset}
+          width={centerBoxSize}
+          height={centerBoxSize}
+          rx={centerBoxRadius}
           fill="var(--theme-platform-surface-fill)"
         />
         <rect
-          x="155"
-          y="155"
-          width="90"
-          height="90"
-          rx="16"
+          x={centerBoxInset}
+          y={centerBoxInset}
+          width={centerBoxSize}
+          height={centerBoxSize}
+          rx={centerBoxRadius}
           fill="none"
           stroke="url(#centerGradient)"
-          strokeWidth="3"
+          strokeWidth={centerStrokeWidth}
           filter="url(#glow)"
         />
         <text
           x={CENTER}
-          y="215"
+          y={centerTextY}
           textAnchor="middle"
           fill="var(--theme-text-primary)"
-          fontSize="48"
+          fontSize={centerFontSize}
           fontWeight="bold"
           fontFamily="system-ui"
         >
@@ -501,14 +526,14 @@ export default function HeroAnimation({
         {[1, 2, 3].map((i) => (
           <motion.rect
             key={i}
-            x="155"
-            y="155"
-            width="90"
-            height="90"
-            rx="16"
+            x={centerBoxInset}
+            y={centerBoxInset}
+            width={centerBoxSize}
+            height={centerBoxSize}
+            rx={centerBoxRadius}
             fill="none"
             stroke="var(--theme-accent-secondary)"
-            strokeWidth="2"
+            strokeWidth={pulseStrokeWidth}
             animate={{ scale: [1, 1.8 + i * 0.3], opacity: [0.6, 0] }}
             transition={{
               duration: slowHeroMotion(2.5),

--- a/website/src/components/HowItWorks.tsx
+++ b/website/src/components/HowItWorks.tsx
@@ -30,7 +30,7 @@ const steps = [
 
 export default function HowItWorks() {
   return (
-    <section className="relative overflow-hidden px-8 py-8 sm:px-6 sm:py-24 md:px-12 lg:px-8">
+    <section className="relative overflow-hidden px-8 py-8 sm:px-6 sm:py-24 lg:px-8 xl:px-12">
       <div
         className="absolute inset-0"
         style={{
@@ -48,7 +48,7 @@ export default function HowItWorks() {
           transition={{ duration: 0.6 }}
           className="mb-8 text-center sm:mb-16"
         >
-          <h2 className="theme-display-large mb-3 text-4xl font-bold md:text-5xl sm:mb-4">
+          <h2 className="theme-display-large mb-3 text-4xl font-bold sm:mb-4 lg:text-5xl">
             How It <span className="theme-heading-accent">Works</span>
           </h2>
           <p className="max-w-2xl mx-auto text-base text-text-secondary sm:text-lg">
@@ -66,7 +66,7 @@ export default function HowItWorks() {
             }}
           />
 
-          <div className="grid grid-cols-1 gap-4 sm:gap-8 md:grid-cols-2 lg:grid-cols-4">
+          <div className="grid grid-cols-1 gap-4 sm:gap-8 lg:grid-cols-2 xl:grid-cols-4">
             {steps.map((step, index) => (
               <motion.div
                 key={step.number}

--- a/website/src/components/Navigation.tsx
+++ b/website/src/components/Navigation.tsx
@@ -59,6 +59,7 @@ export default function Navigation() {
   const [scrolled, setScrolled] = useState(false);
   const navRefs = useRef<(HTMLAnchorElement | null)[]>([]);
   const [underlineStyle, setUnderlineStyle] = useState({ left: 0, width: 0 });
+  const showMobileTopCta = pathname !== "/" || scrolled;
 
   useEffect(() => {
     const handleScroll = () => {
@@ -131,7 +132,7 @@ export default function Navigation() {
   );
 
   const desktopLinks = (
-    <div className="hidden md:flex items-center gap-8 relative">
+    <div className="hidden lg:flex items-center gap-8 relative">
       {NAV_ITEMS.map((item, index) => (
         <Link
           key={item.path}
@@ -176,7 +177,7 @@ export default function Navigation() {
   const mobileHamburger = (
     <button
       onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
-      className="md:hidden relative w-8 h-8 flex items-center justify-center"
+      className="lg:hidden relative w-8 h-8 flex items-center justify-center"
       aria-label="Toggle menu"
     >
       <motion.span
@@ -212,14 +213,14 @@ export default function Navigation() {
           bounce doesn't reveal a gap above the mobile nav bar. Height of 200px covers any
           realistic overscroll. Desktop nav is a floating pill so doesn't need this. */}
       <div
-        className="md:hidden fixed left-0 right-0 bg-freed-black z-40 pointer-events-none"
+        className="lg:hidden fixed left-0 right-0 bg-freed-black z-40 pointer-events-none"
         style={{ top: "-200px", height: "200px" }}
         aria-hidden="true"
       />
 
       {/* Desktop: Top blur overlay - blurs and darkens content as it approaches the top of viewport */}
       <div
-        className="hidden md:block fixed top-0 left-0 right-0 h-32 pointer-events-none z-40"
+        className="hidden lg:block fixed top-0 left-0 right-0 h-32 pointer-events-none z-40"
         style={{
           backdropFilter: "blur(20px)",
           WebkitBackdropFilter: "blur(20px)",
@@ -243,18 +244,38 @@ export default function Navigation() {
       >
         {/* Mobile: solid full-width bar */}
         <div
-          className={`md:hidden bg-freed-black px-8 py-4 ${
+          className={`lg:hidden bg-freed-black pl-8 pr-5 py-4 ${
             mobileMenuOpen ? "" : "border-b border-freed-border"
           }`}
         >
           <div className="flex items-center justify-between">
             {logoElement}
-            {mobileHamburger}
+            <div className="flex items-center gap-4">
+              {mobileHamburger}
+              <motion.div
+                initial={false}
+                animate={{
+                  maxWidth: showMobileTopCta ? 144 : 0,
+                  opacity: showMobileTopCta ? 1 : 0,
+                  marginLeft: showMobileTopCta ? 4 : 0,
+                }}
+                transition={{ duration: 0.24, ease: "easeInOut" }}
+                className="overflow-hidden"
+                style={{ pointerEvents: showMobileTopCta ? "auto" : "none" }}
+              >
+                <button
+                  onClick={openModal}
+                  className="btn-primary shrink-0 text-sm px-4 !py-2 whitespace-nowrap"
+                >
+                  Get Freed
+                </button>
+              </motion.div>
+            </div>
           </div>
         </div>
 
         {/* Desktop: floating pill navbar */}
-        <div className="hidden md:block px-4 py-4">
+        <div className="hidden lg:block px-4 py-4">
           <div
             className={`max-w-[calc(72rem+2rem)] mx-auto px-4 py-[13px] rounded-2xl border transition-all duration-300 ${
               scrolled ? "theme-topbar" : "bg-transparent border-transparent shadow-none"
@@ -275,7 +296,7 @@ export default function Navigation() {
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}
               transition={{ duration: 0.2 }}
-              className="md:hidden fixed left-0 right-0 bottom-0 bg-freed-black z-40"
+              className="lg:hidden fixed left-0 right-0 bottom-0 bg-freed-black z-40"
               style={{
                 // Overlap navbar by 1px to eliminate sub-pixel rendering gaps
                 top: "calc(64px + env(safe-area-inset-top))",

--- a/website/src/components/NewsletterModal.tsx
+++ b/website/src/components/NewsletterModal.tsx
@@ -3,14 +3,8 @@
 import { useRef, useState, useEffect, useCallback } from "react";
 import { createPortal } from "react-dom";
 import { motion, AnimatePresence } from "framer-motion";
-import { LEGAL_BUNDLE_VERSION, LEGAL_DOCS } from "@freed/shared/legal";
 import TurnstileWidget from "@/components/TurnstileWidget";
 import { useNewsletter } from "@/context/NewsletterContext";
-import {
-  acceptWebsiteBundle,
-  getWebsiteBundleAcceptance,
-  hasAcceptedWebsiteBundle,
-} from "@/lib/legal-consent";
 
 type SubmitState = "idle" | "loading" | "error";
 
@@ -175,20 +169,15 @@ export default function NewsletterModal() {
     left: number;
     width: number;
   } | null>(null);
-  const [acceptedBundle, setAcceptedBundle] = useState(false);
-  const [legalChecked, setLegalChecked] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const dropdownMenuRef = useRef<HTMLUListElement>(null);
 
   useEffect(() => {
     setSelectedTarget(detectDefaultInstallTarget());
-    setAcceptedBundle(hasAcceptedWebsiteBundle());
   }, []);
 
   useEffect(() => {
     if (!isOpen) return;
-    setAcceptedBundle(hasAcceptedWebsiteBundle());
-    setLegalChecked(false);
     setDetailsOpen(false);
     setTurnstileToken("");
     setTurnstileResetKey((current) => current + 1);
@@ -358,31 +347,18 @@ export default function NewsletterModal() {
   const selectedTargetLabel =
     selectedTarget === "web" ? "Freed Web" : currentDownload?.label ?? "";
   const isWebTarget = selectedTarget === "web";
-  const canProceed = acceptedBundle || legalChecked;
-  const storedAcceptance = getWebsiteBundleAcceptance();
   const normalizedEmailInput = email.trim().toLowerCase();
   const isEmailInputValid = isValidEmailAddress(normalizedEmailInput);
   const isPhoneInputValid = isValidPhoneNumber(phoneNumber);
 
-  const ensureAccepted = useCallback(() => {
-    if (acceptedBundle) return true;
-    if (!legalChecked) return false;
-    const record = acceptWebsiteBundle();
-    setAcceptedBundle(!!record);
-    setLegalChecked(false);
-    return !!record;
-  }, [acceptedBundle, legalChecked]);
-
   const handleOpenFreedWeb = useCallback(() => {
-    if (!ensureAccepted()) return;
     window.open(FREED_WEB_URL, "_blank", "noopener,noreferrer");
-  }, [ensureAccepted]);
+  }, []);
 
   const handleDownload = useCallback(() => {
-    if (!ensureAccepted()) return;
     if (!downloadUrl) return;
     window.open(downloadUrl, "_blank", "noopener,noreferrer");
-  }, [downloadUrl, ensureAccepted]);
+  }, [downloadUrl]);
 
   const handlePrimaryAction = useCallback(() => {
     if (isWebTarget) {
@@ -462,29 +438,25 @@ export default function NewsletterModal() {
                 }}
               >
                 <>
-                  <div className="text-center mb-8">
+                  <div className="text-center mb-10 sm:mb-8">
                     <h3
                       id="get-freed-title"
                       className="mb-2 text-4xl font-bold text-text-primary sm:text-5xl"
                     >
                       Get <span className="theme-heading-accent">Freed</span>
                     </h3>
-                    <p className="text-text-secondary text-base mt-2">
+                    <p className="mt-2 hidden text-base text-text-secondary sm:block">
                       Open-source. Free forever. Take back your feed.
                     </p>
                   </div>
 
                   <div className="grid gap-0 lg:grid-cols-2 lg:items-start">
-                    <div className="py-2 sm:py-4 lg:pr-8">
+                    <div className="pb-2 sm:py-4 lg:pr-8">
                       <div className="mb-6 max-w-md">
-                        <h4 className="flex items-center gap-3 text-3xl font-bold text-text-primary">
+                        <h4 className="flex items-center gap-3 text-2xl font-bold text-text-primary sm:text-3xl">
                           <CircledStepNumber number={1} />
                           <span>Email Updates</span>
                         </h4>
-                        <p className="mt-2 text-base leading-relaxed text-text-secondary">
-                          Track our development of new builds, major fixes, and
-                          progress on liberating legacy social media.
-                        </p>
                       </div>
 
                       <div className="relative">
@@ -706,67 +678,23 @@ export default function NewsletterModal() {
                       </div>
                     </div>
 
-                    <div className="space-y-5 py-2 sm:py-4 lg:pl-8 lg:border-l lg:border-freed-border">
-                        <div className="max-w-lg">
+                    <div className="space-y-5 pt-10 pb-2 sm:py-4 lg:pt-4 lg:pl-8 lg:border-l lg:border-freed-border">
+                        <div className="max-w-lg space-y-2">
                           <h4 className="flex items-center gap-3 text-2xl font-bold text-text-primary sm:text-3xl">
                             <CircledStepNumber number={2} />
-                            <span>Launch or Install Freed</span>
+                            <span>{isWebTarget ? "Launch Freed" : "Download Freed"}</span>
                           </h4>
-                        </div>
-
-                        <div className="p-0">
-                          {acceptedBundle ? (
-                            <p className="text-xs leading-relaxed text-text-muted">
-                              Legal terms already accepted for bundle {LEGAL_BUNDLE_VERSION}
-                              {storedAcceptance?.acceptedAt
-                                ? ` on ${new Date(storedAcceptance.acceptedAt).toLocaleString()}`
-                                : ""}
-                              .
+                          {!isWebTarget && (
+                            <p className="text-sm leading-relaxed text-text-secondary">
+                              Install Freed Desktop first, then launch Freed Web on your
+                              mobile device.
                             </p>
-                          ) : (
-                            <label className="flex items-start gap-3 rounded-xl px-2 py-2 text-xs sm:text-sm leading-relaxed text-text-secondary cursor-pointer transition-colors hover:bg-[rgb(var(--theme-control-accent-rgb)/0.08)]">
-                              <input
-                                type="checkbox"
-                                checked={legalChecked}
-                                onChange={(event) => setLegalChecked(event.target.checked)}
-                                className="mt-0.5 h-4 w-4 rounded border-freed-border bg-transparent text-[color:var(--theme-control-accent)] focus:ring-[color:var(--theme-focus-ring)]"
-                              />
-                              <span>
-                                I have read and agree to the{" "}
-                                <a
-                                  href={LEGAL_DOCS.terms.path}
-                                  target="_blank"
-                                  rel="noopener noreferrer"
-                                  className="underline underline-offset-2 hover:text-text-primary transition-colors"
-                                >
-                                  {LEGAL_DOCS.terms.label}
-                                </a>{" "}
-                                and{" "}
-                                <a
-                                  href={LEGAL_DOCS.privacy.path}
-                                  target="_blank"
-                                  rel="noopener noreferrer"
-                                  className="underline underline-offset-2 hover:text-text-primary transition-colors"
-                                >
-                                  {LEGAL_DOCS.privacy.label}
-                                </a>
-                                . I understand that Freed is experimental software
-                                under active development.
-                              </span>
-                            </label>
                           )}
                         </div>
 
-                        <div className="relative group/download" ref={dropdownRef}>
-                          {!canProceed && (
-                            <div className="pointer-events-none absolute bottom-full left-1/2 z-10 mb-2 -translate-x-1/2 opacity-0 transition-opacity duration-150 group-hover/download:opacity-100">
-                              <div className="rounded-lg border border-[color:var(--theme-border-subtle)] bg-[color:var(--theme-bg-elevated)] px-3 py-1.5 text-xs text-text-secondary shadow-lg">
-                                Accept the terms above
-                              </div>
-                            </div>
-                          )}
+                        <div className="relative" ref={dropdownRef}>
                           <div
-                            className="flex items-center rounded-xl border transition-all hover:border-[color:var(--theme-border-strong)]"
+                            className="get-freed-launch-cta flex items-center rounded-xl border transition-all hover:border-[color:var(--theme-border-strong)]"
                             style={{
                               borderColor: "var(--theme-border-subtle)",
                               background:
@@ -776,12 +704,11 @@ export default function NewsletterModal() {
                             <button
                               type="button"
                               onClick={handlePrimaryAction}
-                              disabled={!canProceed}
-                              data-testid="website-legal-download"
-                              className="group flex items-center gap-4 p-4 flex-1 min-w-0 disabled:opacity-50 disabled:cursor-not-allowed"
+                              data-testid="website-primary-action"
+                              className="get-freed-launch-cta__primary group flex min-w-0 flex-1 items-center gap-4 p-4"
                             >
                               <div
-                                className="shrink-0 flex h-10 w-10 items-center justify-center rounded-lg border"
+                                className="get-freed-launch-cta__icon flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border"
                                 style={{
                                   background:
                                     "color-mix(in srgb, var(--theme-bg-surface) 88%, transparent)",
@@ -807,12 +734,12 @@ export default function NewsletterModal() {
                                 </svg>
                               </div>
                               <div className="flex-1 min-w-0 text-left">
-                                <p className="text-sm font-semibold text-text-primary group-hover:text-text-primary transition-colors">
+                                <p className="get-freed-launch-cta__title text-sm font-semibold text-text-primary transition-colors group-hover:text-text-primary">
                                   {isWebTarget
                                     ? "Launch Freed Web"
                                     : `Download for ${selectedTargetLabel}`}
                                 </p>
-                                <p className="text-xs text-text-muted">
+                                <p className="get-freed-launch-cta__subtitle text-xs text-text-muted">
                                   {isWebTarget
                                     ? "Open the mobile reader instantly in your browser"
                                     : "Runs in background to subscribe and monitor"}
@@ -822,7 +749,7 @@ export default function NewsletterModal() {
                             <button
                               onClick={() => setDropdownOpen((o) => !o)}
                               aria-label="Choose a different platform"
-                              className="shrink-0 self-stretch border-l border-freed-border px-3 text-text-muted transition-colors hover:text-text-primary"
+                              className="get-freed-launch-cta__toggle shrink-0 self-stretch border-l border-freed-border px-3 text-text-muted transition-colors hover:text-text-primary"
                             >
                               <svg
                                 className={`w-4 h-4 transition-transform ${dropdownOpen ? "rotate-180" : ""}`}
@@ -856,7 +783,7 @@ export default function NewsletterModal() {
                             <button
                               type="button"
                               onClick={handleOpenFreedWeb}
-                              data-testid="website-legal-open-web-app"
+                              data-testid="website-open-web-app"
                               className="inline-flex items-center gap-2 rounded-lg bg-transparent px-2 py-1.5 text-sm text-text-muted underline decoration-current underline-offset-4 transition-colors hover:bg-[rgb(var(--theme-control-accent-rgb)/0.08)] hover:text-text-primary"
                             >
                               <svg

--- a/website/src/context/NewsletterContext.tsx
+++ b/website/src/context/NewsletterContext.tsx
@@ -6,6 +6,7 @@ import {
   useState,
   useEffect,
   useCallback,
+  useRef,
   type ReactNode,
 } from "react";
 import { usePathname, useRouter } from "next/navigation";
@@ -26,25 +27,44 @@ export function NewsletterProvider({ children }: { children: ReactNode }) {
   const [isOpen, setIsOpen] = useState(false);
   const pathname = usePathname();
   const router = useRouter();
+  const returnPathRef = useRef("/");
+  const suppressAutoOpenRef = useRef(false);
+
+  useEffect(() => {
+    if (!pathname || pathname === MODAL_PATH) return;
+    returnPathRef.current = pathname;
+    suppressAutoOpenRef.current = false;
+  }, [pathname]);
 
   // Auto-open when landing on /get
   useEffect(() => {
-    if (pathname === MODAL_PATH && !isOpen) {
+    if (
+      pathname === MODAL_PATH &&
+      !isOpen &&
+      !suppressAutoOpenRef.current
+    ) {
       setIsOpen(true);
     }
   }, [pathname, isOpen]);
 
   const openModal = useCallback(() => {
+    suppressAutoOpenRef.current = false;
     setIsOpen(true);
     if (pathname !== MODAL_PATH) {
+      returnPathRef.current = pathname || "/";
       window.history.pushState(null, "", MODAL_PATH);
     }
   }, [pathname]);
 
   const closeModal = useCallback(() => {
+    suppressAutoOpenRef.current = true;
     setIsOpen(false);
     if (window.location.pathname === MODAL_PATH) {
-      router.back();
+      const fallbackPath =
+        returnPathRef.current && returnPathRef.current !== MODAL_PATH
+          ? returnPathRef.current
+          : "/";
+      router.replace(fallbackPath);
     }
   }, [router]);
 

--- a/website/src/index.css
+++ b/website/src/index.css
@@ -74,49 +74,6 @@ html[data-theme="scriptorium"] .btn-primary:hover {
   transform: scale(1.05);
 }
 
-.hero-manifesto-button {
-  background: linear-gradient(
-    180deg,
-    color-mix(in oklab, var(--theme-bg-surface) 80%, white) 0%,
-    color-mix(in oklab, var(--theme-bg-surface) 94%, white) 24%,
-    color-mix(in oklab, var(--theme-bg-surface) 90%, black) 100%
-  );
-  border-color: color-mix(
-    in oklab,
-    var(--theme-border-subtle) 82%,
-    var(--theme-border-strong)
-  );
-  box-shadow:
-    inset 0 1px 0 rgb(255 255 255 / 0.06),
-    inset 0 0 0 0.5px rgb(255 255 255 / 0.03),
-    0 14px 30px rgb(0 0 0 / 0.14);
-}
-
-.hero-manifesto-button:hover {
-  background: linear-gradient(
-    180deg,
-    color-mix(in oklab, var(--theme-bg-surface) 76%, white) 0%,
-    color-mix(in oklab, var(--theme-bg-surface) 92%, white) 24%,
-    color-mix(in oklab, var(--theme-bg-surface) 88%, black) 100%
-  );
-  border-color: color-mix(
-    in oklab,
-    var(--theme-border-strong) 62%,
-    var(--theme-border-subtle)
-  );
-}
-
-html[data-theme="scriptorium"] .hero-manifesto-button {
-  background: linear-gradient(
-    180deg,
-    color-mix(in oklab, var(--theme-bg-surface) 82%, white) 0%,
-    color-mix(in oklab, var(--theme-bg-surface) 94%, black) 100%
-  );
-  box-shadow:
-    inset 0 1px 0 rgb(255 255 255 / 0.04),
-    0 10px 24px rgb(84 58 35 / 0.06);
-}
-
 .gradient-border {
   position: relative;
   background: var(--theme-bg-surface);
@@ -140,4 +97,51 @@ html[data-theme="scriptorium"] .hero-manifesto-button {
 
 .bg-gradient-orbs {
   background: var(--theme-atmosphere-overlay-background);
+}
+
+@media (max-width: 639px) {
+  .get-freed-launch-cta {
+    border-color: rgb(var(--theme-accent-primary-rgb) / 0.24) !important;
+    background: linear-gradient(
+      135deg,
+      rgb(var(--theme-accent-primary-rgb) / 0.18),
+      rgb(var(--theme-accent-secondary-rgb) / 0.14)
+    ) !important;
+    box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.05);
+  }
+
+  .get-freed-launch-cta:hover {
+    border-color: rgb(var(--theme-accent-primary-rgb) / 0.32) !important;
+  }
+
+  .get-freed-launch-cta__icon {
+    background: color-mix(
+      in srgb,
+      var(--theme-accent-primary) 18%,
+      var(--theme-bg-surface)
+    ) !important;
+    border-color: rgb(var(--theme-accent-primary-rgb) / 0.24) !important;
+  }
+
+  .get-freed-launch-cta__title,
+  .get-freed-launch-cta__subtitle,
+  .get-freed-launch-cta__toggle {
+    color: var(--theme-text-primary);
+  }
+
+  .get-freed-launch-cta__subtitle {
+    color: color-mix(
+      in srgb,
+      var(--theme-text-primary) 74%,
+      var(--theme-text-secondary)
+    );
+  }
+
+  .get-freed-launch-cta__toggle {
+    border-left-color: rgb(var(--theme-accent-primary-rgb) / 0.2);
+  }
+
+  .get-freed-launch-cta__toggle:hover {
+    background: rgb(var(--theme-accent-primary-rgb) / 0.08);
+  }
 }


### PR DESCRIPTION
(AI Generated). 

## Summary
- restore Neon to the original randomized marketing-site background logic and use that shared behavior across the marketing site, Freed Desktop, and Freed Web
- polish the marketing site mobile experience, including tablet breakpoints, nav CTA behavior, modal flow, and button consistency
- remove redundant marketing-site background stacking so Neon no longer renders hotter than the legacy site

## Root Cause
Neon had become much brighter because the shared theme-shell glows, the atmosphere renderer, and the extra overlay glow layer were all stacking together. The marketing site and app surfaces were no longer using the same effective background system.

## Validation
- `npx tsc -p packages/shared/tsconfig.json --noEmit`
- `npx tsc -p packages/ui/tsconfig.json --noEmit`
- `npm run lint` in `website/`
- `npm run build` in `website/`
