### PR TITLE
fix: unify search field styling

### DIFF
--- a/packages/ui/src/components/SearchField.tsx
+++ b/packages/ui/src/components/SearchField.tsx
@@ -1,0 +1,90 @@
+import type { InputHTMLAttributes } from "react";
+
+type SearchFieldDensity = "default" | "compact";
+
+interface SearchFieldProps
+  extends Omit<InputHTMLAttributes<HTMLInputElement>, "className" | "size"> {
+  containerClassName?: string;
+  inputClassName?: string;
+  clearButtonAriaLabel?: string;
+  density?: SearchFieldDensity;
+  onClear?: () => void;
+}
+
+const DENSITY_CLASSES: Record<SearchFieldDensity, string> = {
+  default: "rounded-lg py-2 pl-8 pr-7 text-sm",
+  compact: "rounded-lg py-1.5 pl-8 pr-7 text-sm",
+};
+
+function joinClasses(...classes: Array<string | false | null | undefined>) {
+  return classes.filter(Boolean).join(" ");
+}
+
+export function SearchField({
+  containerClassName,
+  inputClassName,
+  clearButtonAriaLabel = "Clear search",
+  density = "default",
+  onClear,
+  type,
+  value,
+  ...inputProps
+}: SearchFieldProps) {
+  const hasValue =
+    typeof value === "string" ? value.length > 0 : typeof value === "number";
+
+  return (
+    <div className={joinClasses("relative", containerClassName)}>
+      <svg
+        className="pointer-events-none absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-[var(--theme-text-soft)]"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        aria-hidden="true"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+        />
+      </svg>
+
+      <input
+        {...inputProps}
+        type={type ?? "text"}
+        value={value}
+        className={joinClasses(
+          "w-full border border-[var(--theme-border-subtle)] bg-transparent text-[var(--theme-text-primary)] placeholder:text-[var(--theme-text-soft)] transition-colors hover:border-[var(--theme-border-quiet)] hover:bg-[var(--theme-bg-muted)] focus:border-[var(--theme-border-strong)] focus:bg-[var(--theme-bg-muted)] focus:outline-none",
+          DENSITY_CLASSES[density],
+          hasValue ? "pr-8" : "",
+          inputClassName,
+        )}
+      />
+
+      {hasValue && onClear ? (
+        <button
+          type="button"
+          onClick={onClear}
+          aria-label={clearButtonAriaLabel}
+          className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-0.5 transition-colors hover:bg-[var(--theme-bg-muted)]"
+        >
+          <svg
+            className="h-3 w-3 text-[var(--theme-text-soft)]"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2.5}
+              d="M6 18L18 6M6 6l12 12"
+            />
+          </svg>
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/ui/src/components/SettingsDialog.tsx
+++ b/packages/ui/src/components/SettingsDialog.tsx
@@ -39,6 +39,7 @@ import { FeedsSection } from "./settings/FeedsSection.js";
 import { SavedSection } from "./settings/SavedSection.js";
 import { SettingsToggle } from "./SettingsToggle.js";
 import { ReportComposer } from "./report/ReportComposer.js";
+import { SearchField } from "./SearchField.js";
 import { ThemePreviewButton } from "./ThemePreviewButton.js";
 
 const SAMPLE_SEED_FEED_COUNT = 10;
@@ -1066,29 +1067,14 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
 
           {/* Search */}
           <div className="px-3 pb-2 pt-2 shrink-0">
-            <div className="relative">
-              <svg className="pointer-events-none absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-text-muted" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-              </svg>
-              <input
-                type="text"
-                value={search}
-                onChange={(e) => setSearch(e.target.value)}
-                placeholder="Search settings"
-                className={`theme-card-soft w-full rounded-lg py-1.5 pl-8 text-sm text-text-primary placeholder:text-text-muted focus:outline-none focus:border-[color:color-mix(in_srgb,var(--theme-accent-secondary)_40%,transparent)] transition-colors ${search ? "pr-7" : "pr-3"}`}
-              />
-              {search && (
-                <button
-                  onClick={() => setSearch("")}
-                  aria-label="Clear search"
-                  className="absolute right-2 top-1/2 flex h-4 w-4 -translate-y-1/2 items-center justify-center rounded-full bg-[color:color-mix(in_srgb,var(--theme-bg-surface)_82%,transparent)] text-text-muted transition-colors hover:bg-[color:color-mix(in_srgb,var(--theme-bg-surface)_94%,transparent)] hover:text-text-primary"
-                >
-                  <svg className="w-2.5 h-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M6 18L18 6M6 6l12 12" />
-                  </svg>
-                </button>
-              )}
-            </div>
+            <SearchField
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              onClear={() => setSearch("")}
+              placeholder="Search settings"
+              aria-label="Search settings"
+              density="compact"
+            />
           </div>
 
           <NavList />

--- a/packages/ui/src/components/friends/FriendEditor.tsx
+++ b/packages/ui/src/components/friends/FriendEditor.tsx
@@ -23,6 +23,7 @@ import {
   BookmarkIcon,
 } from "../icons.js";
 import type { ReactNode } from "react";
+import { SearchField } from "../SearchField.js";
 
 // ---------------------------------------------------------------------------
 // Platform icon map
@@ -489,12 +490,13 @@ export function FriendEditor({
             )}
 
             {/* Search + candidates */}
-            <input
-              type="text"
+            <SearchField
               value={sourceSearch}
               onChange={(e) => setSourceSearch(e.target.value)}
+              onClear={() => setSourceSearch("")}
               placeholder="Search profiles in your feed..."
-              className="theme-input mb-2 w-full rounded-lg px-3 py-2 text-sm"
+              aria-label="Search profiles in your feed"
+              containerClassName="mb-2"
             />
 
             {filteredCandidates.length === 0 && (

--- a/packages/ui/src/components/friends/FriendsView.tsx
+++ b/packages/ui/src/components/friends/FriendsView.tsx
@@ -10,6 +10,7 @@ import { FriendAvatar } from "./FriendAvatar.js";
 import { FriendGraph } from "./FriendGraph.js";
 import { FriendDetailPanel } from "./FriendDetailPanel.js";
 import { FriendEditor } from "./FriendEditor.js";
+import { SearchField } from "../SearchField.js";
 import { UsersIcon, MapPinIcon } from "../icons.js";
 import { ContentHeader } from "../layout/ContentHeader.js";
 import {
@@ -329,18 +330,14 @@ export function FriendsView() {
         </div>
 
         <div className="mt-3">
-          <div className="relative">
-            <svg className="pointer-events-none absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-[color:var(--theme-text-muted)]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-            </svg>
-            <input
-              type="text"
-              value={searchQuery}
-              onChange={(event) => setSearchQuery(event.target.value)}
-              placeholder="Search friends"
-              className="theme-input w-full rounded-xl py-2 pl-9 pr-3 text-sm"
-            />
-          </div>
+          <SearchField
+            value={searchQuery}
+            onChange={(event) => setSearchQuery(event.target.value)}
+            onClear={() => setSearchQuery("")}
+            placeholder="Search friends"
+            aria-label="Search friends"
+            inputClassName="rounded-xl"
+          />
         </div>
       </div>
 

--- a/packages/ui/src/components/layout/SearchJumpField.tsx
+++ b/packages/ui/src/components/layout/SearchJumpField.tsx
@@ -12,6 +12,7 @@ import {
   LI_SECTION_META,
   type SectionMeta,
 } from "../../lib/settings-sections.js";
+import { SearchField } from "../SearchField.js";
 
 interface CommandAction {
   id: string;
@@ -147,23 +148,7 @@ export function SearchJumpField() {
 
   return (
     <div className="relative z-20 mb-4">
-      <svg
-        className="pointer-events-none absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-[var(--theme-text-soft)]"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
-        aria-hidden="true"
-      >
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth={2}
-          d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
-        />
-      </svg>
-
-      <input
-        type="text"
+      <SearchField
         value={inputValue}
         onChange={(e) => setInputValue(e.target.value)}
         onFocus={() => setIsFocused(true)}
@@ -171,34 +156,12 @@ export function SearchJumpField() {
           setTimeout(() => setIsFocused(false), 150);
         }}
         onKeyDown={handleKeyDown}
+        onClear={clearSearch}
         placeholder="Search or jump to..."
         aria-label="Search or run a command"
         aria-expanded={showPalette}
         aria-haspopup="listbox"
-        className="w-full rounded-lg border border-[var(--theme-border-subtle)] bg-transparent py-2 pl-8 pr-7 text-sm text-[var(--theme-text-secondary)] placeholder:text-[var(--theme-text-soft)] transition-colors hover:border-[var(--theme-border-quiet)] hover:bg-[var(--theme-bg-muted)] focus:bg-[var(--theme-bg-muted)] focus:outline-none focus:border-[var(--theme-border-strong)]"
       />
-
-      {inputValue && (
-        <button
-          onClick={clearSearch}
-          aria-label="Clear search"
-          className="absolute right-2 top-1/2 rounded p-0.5 transition-colors hover:bg-[var(--theme-bg-muted)]"
-        >
-          <svg
-            className="h-3 w-3 text-[var(--theme-text-soft)]"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2.5}
-              d="M6 18L18 6M6 6l12 12"
-            />
-          </svg>
-        </button>
-      )}
 
       {showPalette && (
         <div


### PR DESCRIPTION
(AI Generated).

## What changed

- Added a shared search field component and moved the sidebar, settings, friends, and profile-source search inputs onto it.

## Why

- The settings search field had heavier visual effects than the cleaner primary sidebar search, so search surfaces had drifted out of sync.
## Validation
- `./node_modules/.bin/tsc -p packages/ui/tsconfig.json --noEmit`








