### PR TITLE
fix: refine mobile website hero and nav behavior

### DIFF
--- a/website/src/components/HeroAnimation.tsx
+++ b/website/src/components/HeroAnimation.tsx
@@ -25,7 +25,9 @@ const HERO_ACCENTS = [
 const CENTER = 200;
 const RING_RADIUS = 175;
 const LOGO_RADIUS = 220;
-const BOX = { left: 155, right: 245, top: 155, bottom: 245 };
+const PARTICLE_RADIUS = 4;
+const DESKTOP_CENTER_BOX_SIZE = 90;
+const COMPACT_CENTER_BOX_SIZE = 112.5;
 
 const PLATFORMS = [
   {
@@ -87,11 +89,37 @@ interface Particle {
   state: "waiting" | "active" | "dead";
 }
 
+interface BoxBounds {
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+}
+
 const PARTICLE_SPEED = slowHeroSpeed(0.66);
 const PARTICLES_PER_LOGO = 12;
 const CYCLE_DURATION = slowHeroInterval(12000); // ms
 const MAX_AGE = Math.round(slowHeroMotion(600)); // frames
 const RED_BOUNCE_SPEED_LIMIT = slowHeroSpeed(0.6);
+
+function buildCenterBoxBounds(size: number): BoxBounds {
+  const inset = CENTER - size / 2;
+  return {
+    left: inset,
+    right: inset + size,
+    top: inset,
+    bottom: inset + size,
+  };
+}
+
+function expandBox(bounds: BoxBounds, padding: number): BoxBounds {
+  return {
+    left: bounds.left - padding,
+    right: bounds.right + padding,
+    top: bounds.top - padding,
+    bottom: bounds.bottom + padding,
+  };
+}
 
 function createParticle(logo: ReturnType<typeof buildLogos>[number], isRed: boolean): Particle {
   // Aim directly at center with small random spread (±5 degrees)
@@ -134,7 +162,10 @@ function initParticles(logos: ReturnType<typeof buildLogos>): Particle[] {
   );
 }
 
-function useParticleSystem(logos: ReturnType<typeof buildLogos>) {
+function useParticleSystem(
+  logos: ReturnType<typeof buildLogos>,
+  centerBoxBounds: BoxBounds,
+) {
   const [particles, setParticles] = useState<Particle[]>(() => initParticles(logos));
   const startTimeRef = useRef(performance.now());
   const frameRef = useRef<number>(0);
@@ -142,6 +173,7 @@ function useParticleSystem(logos: ReturnType<typeof buildLogos>) {
   const tick = useCallback(() => {
     const now = performance.now();
     const elapsed = now - startTimeRef.current;
+    const redBounceBox = expandBox(centerBoxBounds, PARTICLE_RADIUS);
 
     setParticles((prev) =>
       prev.map((p) => {
@@ -183,23 +215,31 @@ function useParticleSystem(logos: ReturnType<typeof buildLogos>) {
         const newX = x + vx;
         const newY = y + vy;
         const inBox =
-          newX >= BOX.left &&
-          newX <= BOX.right &&
-          newY >= BOX.top &&
-          newY <= BOX.bottom;
+          newX >= centerBoxBounds.left &&
+          newX <= centerBoxBounds.right &&
+          newY >= centerBoxBounds.top &&
+          newY <= centerBoxBounds.bottom;
 
         if (p.isRed) {
           // Red: moves toward center at constant speed, bounces off box edge
           // Check if about to enter the box (bounce off edge)
           const wasOutside =
-            x < BOX.left || x > BOX.right || y < BOX.top || y > BOX.bottom;
+            x < redBounceBox.left ||
+            x > redBounceBox.right ||
+            y < redBounceBox.top ||
+            y > redBounceBox.bottom;
+          const entersBounceShield =
+            newX >= redBounceBox.left &&
+            newX <= redBounceBox.right &&
+            newY >= redBounceBox.top &&
+            newY <= redBounceBox.bottom;
 
-          if (wasOutside && inBox && opacity === 1) {
+          if (wasOutside && entersBounceShield && opacity === 1) {
             // Bouncing! Determine which edge based on entry direction
-            const fromLeft = x < BOX.left;
-            const fromRight = x > BOX.right;
-            const fromTop = y < BOX.top;
-            const fromBottom = y > BOX.bottom;
+            const fromLeft = x < redBounceBox.left;
+            const fromRight = x > redBounceBox.right;
+            const fromTop = y < redBounceBox.top;
+            const fromBottom = y > redBounceBox.bottom;
 
             // Preserve linear motion by keeping the particle on its natural
             // next-frame position and only changing the outgoing velocity.
@@ -275,7 +315,7 @@ function useParticleSystem(logos: ReturnType<typeof buildLogos>) {
     );
 
     frameRef.current = requestAnimationFrame(tick);
-  }, []);
+  }, [centerBoxBounds]);
 
   useEffect(() => {
     frameRef.current = requestAnimationFrame(tick);
@@ -285,7 +325,7 @@ function useParticleSystem(logos: ReturnType<typeof buildLogos>) {
   useEffect(() => {
     setParticles(initParticles(logos));
     startTimeRef.current = performance.now();
-  }, [logos]);
+  }, [logos, centerBoxBounds]);
 
   return particles.filter((p) => p.state === "active" && p.opacity > 0);
 }
@@ -301,7 +341,12 @@ export default function HeroAnimation({
 }) {
   const { themeId } = useTheme();
   const logos = useMemo(() => buildLogos(), []);
-  const particles = useParticleSystem(logos);
+  const centerBoxSize = compact ? COMPACT_CENTER_BOX_SIZE : DESKTOP_CENTER_BOX_SIZE;
+  const centerBoxBounds = useMemo(
+    () => buildCenterBoxBounds(centerBoxSize),
+    [centerBoxSize],
+  );
+  const particles = useParticleSystem(logos, centerBoxBounds);
   const viewBoxInset = compact ? 78 : 50;
   const viewBoxMin = -viewBoxInset;
   const viewBoxSize = 400 + viewBoxInset * 2;
@@ -311,8 +356,7 @@ export default function HeroAnimation({
   const centerGlowExpandedRadius = compact ? 78 : 62;
   const centerGlowOpacity = compact ? 0.11 : 0.08;
   const centerGlowExpandedOpacity = compact ? 0.18 : 0.15;
-  const centerBoxSize = compact ? 112.5 : 90;
-  const centerBoxInset = CENTER - centerBoxSize / 2;
+  const centerBoxInset = centerBoxBounds.left;
   const centerBoxRadius = compact ? 20 : 16;
   const centerStrokeWidth = compact ? 3.75 : 3;
   const centerFontSize = compact ? 60 : 48;
@@ -414,7 +458,7 @@ export default function HeroAnimation({
             key={i}
             cx={p.x}
             cy={p.y}
-            r={4}
+            r={PARTICLE_RADIUS}
             fill={p.color}
             opacity={p.opacity}
             transform={`scale(${p.scale})`}

--- a/website/src/components/Navigation.tsx
+++ b/website/src/components/Navigation.tsx
@@ -57,18 +57,25 @@ export default function Navigation() {
   const [captionIndex, setCaptionIndex] = useState(0);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [scrolled, setScrolled] = useState(false);
+  const [homePageScrolledPastFold, setHomePageScrolledPastFold] = useState(false);
   const navRefs = useRef<(HTMLAnchorElement | null)[]>([]);
   const [underlineStyle, setUnderlineStyle] = useState({ left: 0, width: 0 });
-  const showMobileTopCta = pathname !== "/" || scrolled;
+  const showMobileTopCta =
+    !mobileMenuOpen && (pathname !== "/" || homePageScrolledPastFold);
 
   useEffect(() => {
     const handleScroll = () => {
       setScrolled(window.scrollY > 20);
+      setHomePageScrolledPastFold(window.scrollY > window.innerHeight);
     };
     handleScroll(); // Check initial position
     window.addEventListener("scroll", handleScroll, { passive: true });
-    return () => window.removeEventListener("scroll", handleScroll);
-  }, []);
+    window.addEventListener("resize", handleScroll);
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+      window.removeEventListener("resize", handleScroll);
+    };
+  }, [pathname]);
 
   // Update underline position when pathname changes
   useLayoutEffect(() => {
@@ -244,20 +251,19 @@ export default function Navigation() {
       >
         {/* Mobile: solid full-width bar */}
         <div
-          className={`lg:hidden bg-freed-black pl-8 pr-5 py-4 ${
+          className={`lg:hidden bg-freed-black pl-8 pr-5 py-3 ${
             mobileMenuOpen ? "" : "border-b border-freed-border"
           }`}
         >
           <div className="flex items-center justify-between">
             {logoElement}
             <div className="flex items-center gap-4">
-              {mobileHamburger}
               <motion.div
                 initial={false}
                 animate={{
                   maxWidth: showMobileTopCta ? 144 : 0,
                   opacity: showMobileTopCta ? 1 : 0,
-                  marginLeft: showMobileTopCta ? 4 : 0,
+                  marginRight: showMobileTopCta ? 4 : 0,
                 }}
                 transition={{ duration: 0.24, ease: "easeInOut" }}
                 className="overflow-hidden"
@@ -265,11 +271,12 @@ export default function Navigation() {
               >
                 <button
                   onClick={openModal}
-                  className="btn-primary shrink-0 text-sm px-4 !py-2 whitespace-nowrap"
+                  className="btn-primary shrink-0 text-sm px-4 !py-1.5 whitespace-nowrap"
                 >
                   Get Freed
                 </button>
               </motion.div>
+              {mobileHamburger}
             </div>
           </div>
         </div>
@@ -314,7 +321,7 @@ export default function Navigation() {
                     <Link
                       href={item.path}
                       onClick={() => setMobileMenuOpen(false)}
-                      className={`text-2xl font-medium transition-colors ${
+                      className={`text-lg font-medium transition-colors ${
                         isActive(item.path, pathname)
                           ? "text-text-primary underline underline-offset-8 decoration-2"
                           : "text-text-secondary"
@@ -332,7 +339,7 @@ export default function Navigation() {
                   href="https://github.com/freed-project/freed"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="text-2xl font-medium text-text-secondary"
+                  className="text-lg font-medium text-text-secondary"
                 >
                   GitHub
                 </motion.a>


### PR DESCRIPTION
(AI Generated).

## Summary

- align the home hero red-dot bounce shield with the larger compact center box on mobile
- hide the mobile top `Get Freed` button on the home page until the user has scrolled past one viewport
- place the mobile top `Get Freed` button to the left of the hamburger, hide it while the menu is open, reduce its vertical padding, and shrink mobile menu link text by 25%

## Why

The hero animation used hard-coded collision bounds that did not match the larger compact F box, so red particles could clip into the visible box on mobile. The mobile toolbar CTA also appeared too early on the home page and needed cleaner behavior while the menu was open.

## Impact

Mobile visitors get cleaner hero animation collisions and a less crowded top bar. The menu overlay is also easier to scan with smaller link text.

## Validation

- targeted `eslint` pass succeeded earlier for `website/src/components/HeroAnimation.tsx`
- full website lint and typecheck were not runnable in this worktree because the local install is missing website ESLint support packages and the repo currently lacks `framer-motion` resolution in the website TypeScript graph
