### PR TITLE
fix: handle relay count worker requests

### DIFF
--- a/packages/desktop/src/lib/automerge.worker.ts
+++ b/packages/desktop/src/lib/automerge.worker.ts
@@ -623,6 +623,11 @@ async function handleRequest(
         ack(req.reqId);
         break;
 
+      case "UPDATE_RELAY_CLIENT_COUNT":
+        relayClientCount = req.count;
+        ack(req.reqId);
+        break;
+
       default: {
         const _exhaustive: never = req;
         void _exhaustive;


### PR DESCRIPTION
(AI Generated).

## Summary
- handle the relay client count request inside the worker switch so the request union stays exhaustive
- keep the existing fast path in the message handler intact while making queued handling safe too
- unblock release builds that were failing on the desktop TypeScript compile step

## Testing
- ./node_modules/.bin/tsc --noEmit -p packages/desktop/tsconfig.json
- node ../../node_modules/typescript/bin/tsc -b && node ../../node_modules/vite/bin/vite.js build