### PR TITLE
fix: polish marketing surfaces and stabilize desktop panels

### DIFF
--- a/packages/desktop/tests/e2e/provider-health.spec.ts
+++ b/packages/desktop/tests/e2e/provider-health.spec.ts
@@ -1394,8 +1394,9 @@ test("settings sources nav shows provider status dots", async ({ app, page }) =>
   const facebookSourceIndicatorLayout = await page.evaluate(() => {
     const row = document.querySelector('[data-testid="source-row-facebook"]')?.parentElement;
     const indicator = row?.querySelector('[data-testid="source-indicator-facebook"]');
+    const indicatorSlot = row?.querySelector('[data-testid="source-indicator-slot-facebook"]');
     const label = row?.querySelector('[data-testid="source-row-facebook"] span.min-w-0.flex-1.truncate');
-    if (!indicator || !label || !row) {
+    if (!indicator || !indicatorSlot || !label || !row) {
       return null;
     }
 
@@ -1405,6 +1406,7 @@ test("settings sources nav shows provider status dots", async ({ app, page }) =>
     return {
       indicatorLeft: indicatorRect.left,
       indicatorRight: indicatorRect.right,
+      indicatorOpacity: window.getComputedStyle(indicatorSlot).opacity,
       labelRight: labelRect.right,
       rowRight: rowRect.right,
     };
@@ -1413,6 +1415,7 @@ test("settings sources nav shows provider status dots", async ({ app, page }) =>
   expect(facebookSourceIndicatorLayout).not.toBeNull();
   expect(facebookSourceIndicatorLayout!.indicatorLeft).toBeGreaterThan(facebookSourceIndicatorLayout!.labelRight);
   expect(facebookSourceIndicatorLayout!.indicatorRight).toBeLessThan(facebookSourceIndicatorLayout!.rowRight);
+  expect(facebookSourceIndicatorLayout!.indicatorOpacity).toBe("1");
 
   const sidebarIndicatorSizes = await page.evaluate(() => {
     const settingsIndicator = document.querySelector('[data-testid="settings-provider-status-facebook"]');
@@ -1721,6 +1724,12 @@ test("feeds source indicator reflects aggregate feed health and active syncing",
         gdrive: 0,
         dropbox: 0,
       },
+      unreadCountByPlatform: {
+        rss: 24,
+      },
+      itemCountByPlatform: {
+        rss: 52,
+      },
     });
 
     const response = await fetch(debugStorePath);
@@ -1784,6 +1793,35 @@ test("feeds source indicator reflects aggregate feed health and active syncing",
   }, { debugStorePath });
 
   await expect(page.getByTestId("source-status-rss")).toHaveAttribute("title", "Syncing");
+  const rssRowLayout = await page.evaluate(() => {
+    const rowButton = document.querySelector('[data-testid="source-row-rss"]');
+    const row =
+      rowButton?.parentElement?.parentElement?.parentElement ?? null;
+    const label = rowButton?.querySelector("span.min-w-0.flex-1.truncate");
+    const status = document.querySelector('[data-testid="source-status-rss"]');
+    const counts = document.querySelector('[data-testid="source-counts-rss"]');
+    if (!row || !label || !status || !counts) {
+      return null;
+    }
+
+    const rowRect = row.getBoundingClientRect();
+    const labelRect = label.getBoundingClientRect();
+    const statusRect = status.getBoundingClientRect();
+    const countsRect = counts.getBoundingClientRect();
+    return {
+      rowRight: rowRect.right,
+      labelRight: labelRect.right,
+      statusLeft: statusRect.left,
+      statusRight: statusRect.right,
+      countsLeft: countsRect.left,
+      countsRight: countsRect.right,
+    };
+  });
+
+  expect(rssRowLayout).not.toBeNull();
+  expect(rssRowLayout!.statusLeft).toBeGreaterThan(rssRowLayout!.labelRight);
+  expect(rssRowLayout!.countsLeft).toBeGreaterThan(rssRowLayout!.statusRight);
+  expect(rssRowLayout!.countsRight).toBeLessThanOrEqual(rssRowLayout!.rowRight);
   await page.getByTestId("source-row-rss").hover();
   await expect(page.getByTestId("source-menu-trigger-rss")).toBeVisible();
 
@@ -1873,9 +1911,14 @@ test("source rows swap counts for an actions menu on hover", async ({ app, page 
   await expect(counts).toHaveClass(/opacity-100/);
   await expect(trigger).toHaveClass(/opacity-0/);
   await expect(trigger).toHaveClass(/pointer-events-none/);
-  await expect(indicator).toHaveClass(/transition-transform/);
   await expect(counts).toHaveClass(/transition-all/);
   await expect(trigger).toHaveClass(/transition-all/);
+  await expect(indicator).toBeVisible();
+
+  const indicatorOpacity = await indicator.evaluate((element) => {
+    return window.getComputedStyle(element).opacity;
+  });
+  expect(indicatorOpacity).toBe("1");
 
   await sourceRow.hover();
 

--- a/packages/desktop/tests/e2e/smoke.spec.ts
+++ b/packages/desktop/tests/e2e/smoke.spec.ts
@@ -771,6 +771,81 @@ test("dual-column reader arrow navigation cycles tiles and keeps the next tile v
   expect(metrics.nextRowBottom).toBeLessThanOrEqual(metrics.containerBottom);
 });
 
+test("dual-column reader toggles use shared view transitions when supported", async ({ app, page }) => {
+  await page.setViewportSize({ width: 1280, height: 600 });
+  await app.goto();
+  await app.waitForReady();
+  await app.injectRssItems(6);
+
+  await page.evaluate(() => {
+    const store = (window as Record<string, unknown>).__FREED_STORE__ as
+      | {
+          getState: () => {
+            updatePreferences: (update: unknown) => Promise<void>;
+          };
+        }
+      | undefined;
+
+    void store?.getState().updatePreferences({
+      display: {
+        reading: {
+          dualColumnMode: true,
+        },
+      },
+    });
+  });
+
+  await page.evaluate(() => {
+    const doc = document as Document & {
+      startViewTransition?: (update: () => void) => { finished: Promise<void> };
+    };
+    const state = { count: 0 };
+    (window as Record<string, unknown>).__FREED_VIEW_TRANSITIONS__ = state;
+
+    Object.defineProperty(doc, "startViewTransition", {
+      configurable: true,
+      writable: true,
+      value: (update: () => void) => {
+        state.count += 1;
+        update();
+        return { finished: Promise.resolve() };
+      },
+    });
+  });
+
+  const firstCard = page.locator('[data-feed-item-id$="bench-item-0"]').first();
+  await expect(firstCard).toBeVisible({ timeout: 5_000 });
+
+  const transitionName = await firstCard.evaluate((element) =>
+    window.getComputedStyle(element.parentElement as Element).viewTransitionName,
+  );
+  expect(transitionName).not.toBe("none");
+
+  await firstCard.click();
+  await expect(page.getByTestId("compact-feed-panel-scroll-container")).toBeVisible({ timeout: 5_000 });
+  await expect(page.getByLabel("Back")).toBeVisible({ timeout: 5_000 });
+
+  await expect.poll(async () => {
+    return page.evaluate(() => {
+      const state = (window as Record<string, unknown>).__FREED_VIEW_TRANSITIONS__ as
+        | { count: number }
+        | undefined;
+      return state?.count ?? 0;
+    });
+  }).toBe(1);
+
+  await page.getByLabel("Back").click();
+
+  await expect.poll(async () => {
+    return page.evaluate(() => {
+      const state = (window as Record<string, unknown>).__FREED_VIEW_TRANSITIONS__ as
+        | { count: number }
+        | undefined;
+      return state?.count ?? 0;
+    });
+  }).toBe(2);
+});
+
 test("Friends workspace keeps a visible sidebar and supports back navigation", async ({ app }) => {
   await app.goto();
   await app.waitForReady();

--- a/packages/desktop/tests/e2e/smoke.spec.ts
+++ b/packages/desktop/tests/e2e/smoke.spec.ts
@@ -555,6 +555,92 @@ test("desktop reader history supports Cmd+[ and Cmd+] for open items", async ({ 
   await expect(page.getByLabel("Back")).toBeVisible({ timeout: 5_000 });
 });
 
+test("dual-column reader arrow navigation cycles tiles and keeps the next tile visible", async ({ app, page }) => {
+  await page.setViewportSize({ width: 1280, height: 600 });
+  await app.goto();
+  await app.waitForReady();
+  await app.injectRssItems(12);
+
+  await page.evaluate(() => {
+    const store = (window as Record<string, unknown>).__FREED_STORE__ as
+      | {
+          getState: () => {
+            updatePreferences: (update: unknown) => Promise<void>;
+          };
+        }
+      | undefined;
+
+    void store?.getState().updatePreferences({
+      display: {
+        reading: {
+          dualColumnMode: true,
+        },
+      },
+    });
+  });
+
+  await page.getByText("Article 0:", { exact: false }).click();
+  await expect(page.getByLabel("Back")).toBeVisible({ timeout: 5_000 });
+  await expect(page.getByTestId("compact-feed-panel-scroll-container")).toBeVisible({ timeout: 5_000 });
+
+  for (let i = 0; i < 6; i += 1) {
+    await page.keyboard.press("ArrowDown");
+  }
+
+  await page.waitForFunction(() => {
+    const store = (window as Record<string, unknown>).__FREED_STORE__ as
+      | { getState: () => { selectedItemId: string | null } }
+      | undefined;
+    return store?.getState().selectedItemId?.endsWith("bench-item-6") === true;
+  }, { timeout: 5_000 });
+
+  await page.waitForFunction(() => {
+    const container = document.querySelector('[data-testid="compact-feed-panel-scroll-container"]') as HTMLElement | null;
+    const selectedItem = container?.querySelector('[data-selected="true"]') as HTMLElement | null;
+    const selectedRow = selectedItem?.closest('[data-compact-panel-index]') as HTMLElement | null;
+    if (!container || !selectedRow) return false;
+
+    const rowIndex = Number(selectedRow.dataset.compactPanelIndex);
+    const nextRow = container.querySelector(`[data-compact-panel-index="${rowIndex + 1}"]`) as HTMLElement | null;
+    if (!nextRow) return false;
+
+    const containerRect = container.getBoundingClientRect();
+    const nextRowRect = nextRow.getBoundingClientRect();
+
+    return nextRowRect.top >= containerRect.top && nextRowRect.bottom <= containerRect.bottom;
+  }, { timeout: 5_000 });
+
+  const metrics = await page.evaluate(() => {
+    const container = document.querySelector('[data-testid="compact-feed-panel-scroll-container"]') as HTMLElement | null;
+    const selectedItem = container?.querySelector('[data-selected="true"]') as HTMLElement | null;
+    const selectedRow = selectedItem?.closest('[data-compact-panel-index]') as HTMLElement | null;
+    if (!container || !selectedRow) {
+      throw new Error("Selected compact panel row was not found");
+    }
+
+    const rowIndex = Number(selectedRow.dataset.compactPanelIndex);
+    const nextRow = container.querySelector(`[data-compact-panel-index="${rowIndex + 1}"]`) as HTMLElement | null;
+    if (!nextRow) {
+      throw new Error("Next compact panel row was not found");
+    }
+
+    const containerRect = container.getBoundingClientRect();
+    const nextRowRect = nextRow.getBoundingClientRect();
+
+    return {
+      scrollTop: container.scrollTop,
+      nextRowTop: nextRowRect.top,
+      nextRowBottom: nextRowRect.bottom,
+      containerTop: containerRect.top,
+      containerBottom: containerRect.bottom,
+    };
+  });
+
+  expect(metrics.scrollTop).toBeGreaterThan(0);
+  expect(metrics.nextRowTop).toBeGreaterThanOrEqual(metrics.containerTop);
+  expect(metrics.nextRowBottom).toBeLessThanOrEqual(metrics.containerBottom);
+});
+
 test("Friends workspace keeps a visible sidebar and supports back navigation", async ({ app }) => {
   await app.goto();
   await app.waitForReady();

--- a/packages/desktop/tests/e2e/smoke.spec.ts
+++ b/packages/desktop/tests/e2e/smoke.spec.ts
@@ -390,7 +390,7 @@ test("settings dialog closes from the mobile header close button", async ({ app,
   }, SETTINGS_STORE_PATH);
   await expect(page.getByText("Settings").first()).toBeVisible({ timeout: 5_000 });
 
-  await page.getByRole("button", { name: "Reading" }).click();
+  await page.getByRole("button", { name: "Appearance" }).click();
   await expect(page.getByTestId("settings-close-button-mobile")).toBeVisible({ timeout: 5_000 });
 
   await page.getByTestId("settings-close-button-mobile").click();
@@ -412,21 +412,21 @@ test("settings nav highlight follows scroll position", async ({ app, page }) => 
   const appearanceButton = dialog.locator('button[data-active="true"]').filter({
     hasText: /^Appearance$/,
   });
-  const readingButton = dialog.locator('button[data-active="true"]').filter({
-    hasText: /^Reading$/,
+  const syncButton = dialog.locator('button[data-active="true"]').filter({
+    hasText: /^Sync$/,
   });
 
   await expect(appearanceButton).toHaveCount(1);
 
   await scrollContainer.evaluate((element) => {
-    const target = element.querySelector('[data-section="reading"]');
+    const target = element.querySelector('[data-section="sync"]');
     if (!(target instanceof HTMLElement)) {
-      throw new Error("Reading section not found");
+      throw new Error("Sync section not found");
     }
     element.scrollTo({ top: Math.max(0, target.offsetTop - 24) });
   });
 
-  await expect(readingButton).toHaveCount(1);
+  await expect(syncButton).toHaveCount(1);
 });
 
 test("provider risk dialog scrolls vertically on tiny mobile screens", async ({ app, page }) => {

--- a/packages/desktop/tests/e2e/smoke.spec.ts
+++ b/packages/desktop/tests/e2e/smoke.spec.ts
@@ -105,6 +105,63 @@ test("main content area renders", async ({ app }) => {
   await expect(app.page.locator("main")).toBeVisible();
 });
 
+test("keyboard focus scrolling keeps a full row visible past the focused item", async ({ app, page }) => {
+  await page.setViewportSize({ width: 1280, height: 600 });
+  await app.goto();
+  await app.waitForReady();
+  await app.injectRssItems(12);
+
+  for (let i = 0; i < 6; i += 1) {
+    await page.keyboard.press("ArrowDown");
+  }
+
+  await page.waitForFunction(() => {
+    const container = document.querySelector('[data-testid="feed-list-scroll-container"]') as HTMLElement | null;
+    const focusedItem = container?.querySelector('[data-focused="true"]') as HTMLElement | null;
+    const focusedRow = focusedItem?.closest('[data-feed-row-index]') as HTMLElement | null;
+    if (!container || !focusedRow) return false;
+
+    const rowIndex = Number(focusedRow.dataset.feedRowIndex);
+    const nextRow = container.querySelector(`[data-feed-row-index="${rowIndex + 1}"]`) as HTMLElement | null;
+    if (!nextRow) return false;
+
+    const containerRect = container.getBoundingClientRect();
+    const nextRowRect = nextRow.getBoundingClientRect();
+
+    return nextRowRect.top >= containerRect.top && nextRowRect.bottom <= containerRect.bottom;
+  });
+
+  const metrics = await page.evaluate(() => {
+    const container = document.querySelector('[data-testid="feed-list-scroll-container"]') as HTMLElement | null;
+    const focusedItem = container?.querySelector('[data-focused="true"]') as HTMLElement | null;
+    const focusedRow = focusedItem?.closest('[data-feed-row-index]') as HTMLElement | null;
+    if (!container || !focusedRow) {
+      throw new Error("Focused feed row was not found");
+    }
+
+    const rowIndex = Number(focusedRow.dataset.feedRowIndex);
+    const nextRow = container.querySelector(`[data-feed-row-index="${rowIndex + 1}"]`) as HTMLElement | null;
+    if (!nextRow) {
+      throw new Error("Next feed row was not found");
+    }
+
+    const containerRect = container.getBoundingClientRect();
+    const nextRowRect = nextRow.getBoundingClientRect();
+
+    return {
+      scrollTop: container.scrollTop,
+      nextRowTop: nextRowRect.top,
+      nextRowBottom: nextRowRect.bottom,
+      containerTop: containerRect.top,
+      containerBottom: containerRect.bottom,
+    };
+  });
+
+  expect(metrics.scrollTop).toBeGreaterThan(0);
+  expect(metrics.nextRowTop).toBeGreaterThanOrEqual(metrics.containerTop);
+  expect(metrics.nextRowBottom).toBeLessThanOrEqual(metrics.containerBottom);
+});
+
 test("sidebar resize holds the dragged width after mouseup", async ({ app, page }) => {
   await app.goto();
   await app.waitForReady();

--- a/packages/desktop/tests/e2e/smoke.spec.ts
+++ b/packages/desktop/tests/e2e/smoke.spec.ts
@@ -429,6 +429,136 @@ test("settings nav highlight follows scroll position", async ({ app, page }) => 
   await expect(syncButton).toHaveCount(1);
 });
 
+test("provider settings do not remount when health updates arrive", async ({ app, page }) => {
+  await app.goto();
+  await app.waitForReady();
+
+  await page.evaluate(async ({ settingsStorePath, debugStorePath }) => {
+    const makeDailyBuckets = () =>
+      Array.from({ length: 7 }, (_, index) => ({
+        dateKey: `2026-04-0${index + 1}`,
+        attempts: 0,
+        successes: 0,
+        failures: 0,
+        itemsSeen: 0,
+        itemsAdded: 0,
+        bytesMoved: 0,
+      }));
+    const makeHourlyBuckets = () =>
+      Array.from({ length: 24 }, (_, index) => ({
+        hourKey: `2026-04-12T${String(index).padStart(2, "0")}`,
+        attempts: 0,
+        successes: 0,
+        failures: 0,
+        itemsSeen: 0,
+        itemsAdded: 0,
+        bytesMoved: 0,
+      }));
+    const makeSnapshot = (
+      provider: "rss" | "x" | "facebook" | "instagram" | "linkedin" | "gdrive" | "dropbox",
+    ) => ({
+      provider,
+      status: provider === "x" ? "degraded" : "idle",
+      lastAttemptAt: provider === "x" ? Date.now() : undefined,
+      lastSuccessfulAt: provider === "x" ? Date.now() - 120_000 : undefined,
+      lastOutcome: provider === "x" ? "error" : undefined,
+      lastError: provider === "x" ? "Transient timeout" : undefined,
+      currentMessage: provider === "x" ? "Transient timeout" : undefined,
+      pause: null,
+      dailyBuckets: makeDailyBuckets(),
+      hourlyBuckets: makeHourlyBuckets(),
+      latestAttempts: [],
+      totalSeen7d: 0,
+      totalAdded7d: 0,
+      totalBytes7d: 0,
+    });
+
+    const settingsMod = await import(settingsStorePath);
+    const debugMod = await import(debugStorePath);
+
+    settingsMod.useSettingsStore.getState().openTo("x");
+    debugMod.useDebugStore.getState().setHealth({
+      providers: {
+        rss: makeSnapshot("rss"),
+        x: makeSnapshot("x"),
+        facebook: makeSnapshot("facebook"),
+        instagram: makeSnapshot("instagram"),
+        linkedin: makeSnapshot("linkedin"),
+        gdrive: makeSnapshot("gdrive"),
+        dropbox: makeSnapshot("dropbox"),
+      },
+      failingRssFeeds: [],
+      updatedAt: Date.now(),
+    });
+  }, { settingsStorePath: SETTINGS_STORE_PATH, debugStorePath: DEBUG_STORE_PATH });
+
+  await expect(page.getByText("X / Twitter").first()).toBeVisible({ timeout: 5_000 });
+  await page.getByRole("button", { name: "Manual cookie setup" }).click();
+
+  const ct0Input = page.getByPlaceholder("ct0 value");
+  await expect(ct0Input).toBeVisible();
+  await ct0Input.fill("sticky-cookie");
+
+  await page.evaluate(async (debugStorePath) => {
+    const makeDailyBuckets = () =>
+      Array.from({ length: 7 }, (_, index) => ({
+        dateKey: `2026-04-0${index + 1}`,
+        attempts: 0,
+        successes: 0,
+        failures: 0,
+        itemsSeen: 0,
+        itemsAdded: 0,
+        bytesMoved: 0,
+      }));
+    const makeHourlyBuckets = () =>
+      Array.from({ length: 24 }, (_, index) => ({
+        hourKey: `2026-04-12T${String(index).padStart(2, "0")}`,
+        attempts: 0,
+        successes: 0,
+        failures: 0,
+        itemsSeen: 0,
+        itemsAdded: 0,
+        bytesMoved: 0,
+      }));
+    const makeSnapshot = (
+      provider: "rss" | "x" | "facebook" | "instagram" | "linkedin" | "gdrive" | "dropbox",
+    ) => ({
+      provider,
+      status: provider === "x" ? "degraded" : "idle",
+      lastAttemptAt: provider === "x" ? Date.now() : undefined,
+      lastSuccessfulAt: provider === "x" ? Date.now() - 60_000 : undefined,
+      lastOutcome: provider === "x" ? "error" : undefined,
+      lastError: provider === "x" ? "Retrying after timeout" : undefined,
+      currentMessage: provider === "x" ? "Retrying after timeout" : undefined,
+      pause: null,
+      dailyBuckets: makeDailyBuckets(),
+      hourlyBuckets: makeHourlyBuckets(),
+      latestAttempts: [],
+      totalSeen7d: 0,
+      totalAdded7d: 0,
+      totalBytes7d: 0,
+    });
+
+    const debugMod = await import(debugStorePath);
+    debugMod.useDebugStore.getState().setHealth({
+      providers: {
+        rss: makeSnapshot("rss"),
+        x: makeSnapshot("x"),
+        facebook: makeSnapshot("facebook"),
+        instagram: makeSnapshot("instagram"),
+        linkedin: makeSnapshot("linkedin"),
+        gdrive: makeSnapshot("gdrive"),
+        dropbox: makeSnapshot("dropbox"),
+      },
+      failingRssFeeds: [],
+      updatedAt: Date.now(),
+    });
+  }, DEBUG_STORE_PATH);
+
+  await expect(ct0Input).toBeVisible();
+  await expect(ct0Input).toHaveValue("sticky-cookie");
+});
+
 test("provider risk dialog scrolls vertically on tiny mobile screens", async ({ app, page }) => {
   await page.setViewportSize({ width: 320, height: 360 });
   await app.goto();

--- a/packages/desktop/tests/e2e/smoke.spec.ts
+++ b/packages/desktop/tests/e2e/smoke.spec.ts
@@ -37,6 +37,10 @@ const SETTINGS_STORE_PATH = resolveViteFsModulePath(
   "../../../ui/src/lib/settings-store.ts",
   import.meta.url,
 );
+const DEBUG_STORE_PATH = resolveViteFsModulePath(
+  "../../../ui/src/lib/debug-store.ts",
+  import.meta.url,
+);
 
 // ---------------------------------------------------------------------------
 // App initialization
@@ -99,6 +103,202 @@ test("main content area renders", async ({ app }) => {
   await app.goto();
   await app.waitForReady();
   await expect(app.page.locator("main")).toBeVisible();
+});
+
+test("sidebar resize holds the dragged width after mouseup", async ({ app, page }) => {
+  await app.goto();
+  await app.waitForReady();
+
+  await page.evaluate(() => {
+    const w = window as Record<string, unknown>;
+    const store = w.__FREED_STORE__ as
+      | {
+          getState: () => {
+            updatePreferences: (patch: { display: { sidebarWidth: number } }) => Promise<void>;
+          };
+          setState: (partial: Record<string, unknown>) => void;
+        }
+      | undefined;
+
+    if (!store) return;
+
+    const originalUpdatePreferences = store.getState().updatePreferences;
+    store.setState({
+      updatePreferences: async (patch: { display: { sidebarWidth: number } }) => {
+        await new Promise((resolve) => window.setTimeout(resolve, 350));
+        await originalUpdatePreferences(patch);
+      },
+    });
+  });
+
+  const sidebar = page.getByTestId("app-sidebar");
+  const { initialWidth, widthAfterRelease } = await page.evaluate(async () => {
+    const sidebar = document.querySelector('[data-testid="app-sidebar"]') as HTMLElement | null;
+    const resizeHandle = document.querySelector('[data-testid="app-sidebar-resize-handle"]') as HTMLElement | null;
+    if (!sidebar || !resizeHandle) {
+      throw new Error("Sidebar resize elements were not found");
+    }
+
+    const initialWidth = sidebar.getBoundingClientRect().width;
+    const handleRect = resizeHandle.getBoundingClientRect();
+    const startX = handleRect.left + handleRect.width / 2;
+    const pointerY = handleRect.top + handleRect.height / 2;
+    const endX = startX + 72;
+
+    resizeHandle.dispatchEvent(
+      new MouseEvent("mousedown", {
+        bubbles: true,
+        clientX: startX,
+        clientY: pointerY,
+      }),
+    );
+    document.dispatchEvent(
+      new MouseEvent("mousemove", {
+        bubbles: true,
+        clientX: endX,
+        clientY: pointerY,
+      }),
+    );
+    document.dispatchEvent(
+      new MouseEvent("mouseup", {
+        bubbles: true,
+        clientX: endX,
+        clientY: pointerY,
+      }),
+    );
+
+    await new Promise((resolve) => window.setTimeout(resolve, 100));
+
+    return {
+      initialWidth,
+      widthAfterRelease: sidebar.getBoundingClientRect().width,
+    };
+  });
+
+  expect(widthAfterRelease).toBeGreaterThan(initialWidth + 40);
+
+  await page.waitForTimeout(450);
+  const settledWidth = await sidebar.evaluate((element) =>
+    element.getBoundingClientRect().width,
+  );
+
+  expect(Math.abs(settledWidth - widthAfterRelease)).toBeLessThanOrEqual(2);
+
+  await page.waitForFunction((expectedWidth) => {
+    const w = window as Record<string, unknown>;
+    const store = w.__FREED_STORE__ as
+      | {
+          getState: () => {
+            preferences: { display: { sidebarWidth?: number } };
+          };
+        }
+      | undefined;
+
+    const savedWidth = store?.getState().preferences.display.sidebarWidth ?? 0;
+    return Math.abs(savedWidth - expectedWidth) <= 2;
+  }, Math.round(settledWidth));
+});
+
+test("debug panel resize holds the dragged width after mouseup", async ({ app, page }) => {
+  await app.goto();
+  await app.waitForReady();
+
+  await page.evaluate(async (debugStorePath) => {
+    const mod = await import(debugStorePath);
+    mod.useDebugStore.getState().setVisible(true);
+  }, DEBUG_STORE_PATH);
+
+  const debugPanel = page.getByTestId("debug-panel-drawer");
+  await expect(debugPanel).toBeVisible();
+  await page.waitForTimeout(350);
+
+  await page.evaluate(() => {
+    const w = window as Record<string, unknown>;
+    const store = w.__FREED_STORE__ as
+      | {
+          getState: () => {
+            updatePreferences: (patch: { display: { debugPanelWidth: number } }) => Promise<void>;
+          };
+          setState: (partial: Record<string, unknown>) => void;
+        }
+      | undefined;
+
+    if (!store) return;
+
+    const originalUpdatePreferences = store.getState().updatePreferences;
+    store.setState({
+      updatePreferences: async (patch: { display: { debugPanelWidth: number } }) => {
+        await new Promise((resolve) => window.setTimeout(resolve, 350));
+        await originalUpdatePreferences(patch);
+      },
+    });
+  });
+
+  const initialWidth = await page.evaluate(() => {
+    const debugPanel = document.querySelector('[data-testid="debug-panel-drawer"]') as HTMLElement | null;
+    const resizeHandle = document.querySelector('[data-testid="debug-panel-resize-handle"]') as HTMLElement | null;
+    if (!debugPanel || !resizeHandle) {
+      throw new Error("Debug panel resize elements were not found");
+    }
+
+    const initialWidth = debugPanel.getBoundingClientRect().width;
+    const handleRect = resizeHandle.getBoundingClientRect();
+    const startX = handleRect.left + handleRect.width / 2;
+    const pointerY = handleRect.top + handleRect.height / 2;
+    const endX = startX - 72;
+
+    resizeHandle.dispatchEvent(
+      new MouseEvent("mousedown", {
+        bubbles: true,
+        clientX: startX,
+        clientY: pointerY,
+      }),
+    );
+    document.dispatchEvent(
+      new MouseEvent("mousemove", {
+        bubbles: true,
+        clientX: endX,
+        clientY: pointerY,
+      }),
+    );
+    document.dispatchEvent(
+      new MouseEvent("mouseup", {
+        bubbles: true,
+        clientX: endX,
+        clientY: pointerY,
+      }),
+    );
+
+    return initialWidth;
+  });
+
+  await page.waitForTimeout(450);
+  const widthAfterTransition = await debugPanel.evaluate((element) =>
+    element.getBoundingClientRect().width,
+  );
+
+  expect(widthAfterTransition).toBeGreaterThan(initialWidth + 40);
+
+  await page.waitForTimeout(450);
+  const settledWidth = await debugPanel.evaluate((element) =>
+    element.getBoundingClientRect().width,
+  );
+
+  expect(Math.abs(settledWidth - widthAfterTransition)).toBeLessThanOrEqual(2);
+
+  await page.waitForFunction((expectedWidth) => {
+    const w = window as Record<string, unknown>;
+    const store = w.__FREED_STORE__ as
+      | {
+          getState: () => {
+            preferences: { display: { debugPanelWidth?: number } };
+          };
+        }
+      | undefined;
+
+    const savedWidth = store?.getState().preferences.display.debugPanelWidth ?? 0;
+    return Math.abs(savedWidth - expectedWidth) <= 2;
+  }, Math.round(settledWidth));
 });
 
 test("settings dialog closes from the desktop sidebar close button", async ({ app }) => {

--- a/packages/desktop/tests/e2e/theme-switching.spec.ts
+++ b/packages/desktop/tests/e2e/theme-switching.spec.ts
@@ -19,11 +19,7 @@ test("switching themes in settings applies the selected theme immediately", asyn
   const initialThemeId = await page.evaluate(() => document.documentElement.dataset.theme);
   expect(initialThemeId).toBe("neon");
 
-  await page
-    .locator("button")
-    .filter({ has: page.getByText("Scriptorium", { exact: true }) })
-    .first()
-    .click();
+  await page.getByRole("button", { name: /^Scriptorium\./ }).click();
 
   await expect.poll(async () => {
     return page.evaluate(() => document.documentElement.dataset.theme);
@@ -62,11 +58,7 @@ test("theme switching repaints the app even before preferences finish saving", a
     });
   });
 
-  await page
-    .locator("button")
-    .filter({ has: page.getByText("Scriptorium", { exact: true }) })
-    .first()
-    .click();
+  await page.getByRole("button", { name: /^Scriptorium\./ }).click();
 
   await expect.poll(async () => {
     return page.evaluate(() => document.documentElement.dataset.theme);
@@ -89,10 +81,10 @@ test("settings switches render with a full track and knob", async ({ app, page }
 
   await page.evaluate(async (settingsStorePath) => {
     const mod = await import(settingsStorePath);
-    mod.useSettingsStore.getState().openTo("reading");
+    mod.useSettingsStore.getState().openTo("appearance");
   }, SETTINGS_STORE_PATH);
 
-  await expect(page.getByText("Reading").first()).toBeVisible({ timeout: 5_000 });
+  await expect(page.getByText("Appearance").first()).toBeVisible({ timeout: 5_000 });
 
   const metrics = await page.evaluate(() => {
     const button = document.querySelector('button[role="switch"][aria-label="Mark read on scroll"]') as HTMLButtonElement | null;

--- a/packages/desktop/tests/e2e/theme-switching.spec.ts
+++ b/packages/desktop/tests/e2e/theme-switching.spec.ts
@@ -82,3 +82,46 @@ test("theme switching repaints the app even before preferences finish saving", a
     });
   }).toBe("neon");
 });
+
+test("settings switches render with a full track and knob", async ({ app, page }) => {
+  await app.goto();
+  await app.waitForReady();
+
+  await page.evaluate(async (settingsStorePath) => {
+    const mod = await import(settingsStorePath);
+    mod.useSettingsStore.getState().openTo("reading");
+  }, SETTINGS_STORE_PATH);
+
+  await expect(page.getByText("Reading").first()).toBeVisible({ timeout: 5_000 });
+
+  const metrics = await page.evaluate(() => {
+    const button = document.querySelector('button[role="switch"][aria-label="Mark read on scroll"]') as HTMLButtonElement | null;
+    const track = button?.firstElementChild as HTMLElement | null;
+    const knob = track?.firstElementChild as HTMLElement | null;
+
+    if (!button || !track || !knob) {
+      throw new Error("Settings switch elements were not found");
+    }
+
+    const trackRect = track.getBoundingClientRect();
+    const knobRect = knob.getBoundingClientRect();
+
+    return {
+      trackWidth: trackRect.width,
+      trackHeight: trackRect.height,
+      knobWidth: knobRect.width,
+      knobHeight: knobRect.height,
+      knobWithinTrack:
+        knobRect.left >= trackRect.left - 0.5 &&
+        knobRect.right <= trackRect.right + 0.5 &&
+        knobRect.top >= trackRect.top - 0.5 &&
+        knobRect.bottom <= trackRect.bottom + 0.5,
+    };
+  });
+
+  expect(metrics.trackWidth).toBeGreaterThanOrEqual(34);
+  expect(metrics.trackHeight).toBeGreaterThanOrEqual(18);
+  expect(metrics.knobWidth).toBeGreaterThanOrEqual(14);
+  expect(metrics.knobHeight).toBeGreaterThanOrEqual(14);
+  expect(metrics.knobWithinTrack).toBe(true);
+});

--- a/packages/ui/src/components/SettingsDialog.tsx
+++ b/packages/ui/src/components/SettingsDialog.tsx
@@ -42,6 +42,7 @@ import { SettingsToggle } from "./SettingsToggle.js";
 import { ReportComposer } from "./report/ReportComposer.js";
 import { SearchField } from "./SearchField.js";
 import { ThemePreviewButton } from "./ThemePreviewButton.js";
+import { Tooltip } from "./Tooltip.js";
 import { GoogleContactsIcon } from "./icons.js";
 
 const SAMPLE_SEED_FEED_COUNT = 10;
@@ -166,14 +167,6 @@ const ICONS: Record<SectionId, ReactNode> = {
   ),
   appearance: (
     <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 3c4.97 0 9 4.03 9 9a9 9 0 01-9 9c-2.208 0-4-1.567-4-3.5 0-.971.42-1.84 1.09-2.473.476-.45.744-1.077.744-1.731 0-1.308-1.06-2.37-2.369-2.37-.653 0-1.28.269-1.73.745A3.49 3.49 0 013 12c0-4.97 4.03-9 9-9z" />
-      <circle cx="7.5" cy="10.5" r="1" fill="currentColor" stroke="none" />
-      <circle cx="12" cy="7.5" r="1" fill="currentColor" stroke="none" />
-      <circle cx="16.5" cy="10.5" r="1" fill="currentColor" stroke="none" />
-    </svg>
-  ),
-  reading: (
-    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
     </svg>
   ),
@@ -288,7 +281,6 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
     sectionById.legal,
     sectionById.support,
     sectionById.sync,
-    sectionById.reading,
     {
       kind: "group",
       label: "Sources",
@@ -662,35 +654,38 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
         return (
           <>
             <SectionHeading label="Appearance" />
-            <div className="grid gap-3 sm:grid-cols-2">
-              {THEME_DEFINITIONS.map((theme) => {
-                const isActive = display.themeId === theme.id;
-                return (
-                  <ThemePreviewButton
-                    key={theme.id}
-                    theme={theme}
-                    active={isActive}
-                    onClick={() => handleDisplayChange({ themeId: theme.id as ThemeId })}
-                  />
-                );
-              })}
-            </div>
-          </>
-        );
-
-      case "legal":
-        return (
-          <>
-            <SectionHeading label="Legal" />
-            {LegalSettingsContent ? <LegalSettingsContent /> : null}
-          </>
-        );
-
-      case "reading":
-        return (
-          <>
-            <SectionHeading label="Reading" />
             <div className="space-y-5">
+              <div className="theme-card-soft rounded-2xl p-4 sm:p-5">
+                <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+                  <div className="max-w-lg">
+                    <p className="text-sm font-semibold text-text-primary">Theme</p>
+                    <p className="mt-1 text-xs text-text-muted">
+                      Choose the look, atmosphere, and type treatment for Freed Desktop.
+                    </p>
+                  </div>
+                  <div className="flex flex-wrap items-center gap-2">
+                    {THEME_DEFINITIONS.map((theme) => {
+                      const isActive = display.themeId === theme.id;
+                      return (
+                        <Tooltip
+                          key={theme.id}
+                          side="top"
+                          label={theme.name}
+                          description={theme.description}
+                          className="h-[2.2rem] items-center"
+                        >
+                          <ThemePreviewButton
+                            theme={theme}
+                            active={isActive}
+                            variant="compact"
+                            onClick={() => handleDisplayChange({ themeId: theme.id as ThemeId })}
+                          />
+                        </Tooltip>
+                      );
+                    })}
+                  </div>
+                </div>
+              </div>
               <SettingsToggle
                 label="Mark read on scroll"
                 checked={display.reading.markReadOnScroll}
@@ -747,6 +742,14 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
                 </select>
               </div>
             </div>
+          </>
+        );
+
+      case "legal":
+        return (
+          <>
+            <SectionHeading label="Legal" />
+            {LegalSettingsContent ? <LegalSettingsContent /> : null}
           </>
         );
 

--- a/packages/ui/src/components/SettingsDialog.tsx
+++ b/packages/ui/src/components/SettingsDialog.tsx
@@ -42,6 +42,7 @@ import { SettingsToggle } from "./SettingsToggle.js";
 import { ReportComposer } from "./report/ReportComposer.js";
 import { SearchField } from "./SearchField.js";
 import { ThemePreviewButton } from "./ThemePreviewButton.js";
+import { GoogleContactsIcon } from "./icons.js";
 
 const SAMPLE_SEED_FEED_COUNT = 10;
 const SAMPLE_SEED_ITEM_COUNT = 155;
@@ -229,11 +230,7 @@ const ICONS: Record<SectionId, ReactNode> = {
     </svg>
   ),
   googleContacts: (
-    <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor">
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M15 11a4 4 0 10-6 3.465V17a1 1 0 001 1h4a1 1 0 001-1v-2.535A4 4 0 0015 11z" />
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 20h6" />
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M18 8h3M3 8h3M16.95 3.05l2.12-2.12M4.93 5.17L2.81 3.05" />
-    </svg>
+    <GoogleContactsIcon />
   ),
 };
 

--- a/packages/ui/src/components/SettingsDialog.tsx
+++ b/packages/ui/src/components/SettingsDialog.tsx
@@ -9,7 +9,7 @@
  * "pushes" to that section's content with a back button (iOS-style).
  */
 
-import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
+import { Fragment, useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 import { THEME_DEFINITIONS, type ThemeId } from "@freed/shared/themes";
 import { createPortal } from "react-dom";
 import { useAppStore, usePlatform } from "../context/PlatformContext.js";
@@ -632,15 +632,15 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
 
   // ── Section content renderer ──────────────────────────────────────────────
 
-  function SectionBlock({ id }: { id: SectionId }) {
+  function renderSectionBlock(id: SectionId) {
     const isVisible = visibleSections.some((s) => s.id === id);
     if (!isVisible) return null;
 
-    // SectionContent is called as a plain function (not as a JSX component)
-    // because it is defined inside SettingsDialog. If rendered as
-    // <SectionContent />, React would see a new component type on every
-    // SettingsDialog re-render and unmount/remount the entire subtree,
-    // destroying local state in nested components like XSettingsSection.
+    // SectionContent and this wrapper both stay plain function calls because
+    // they are defined inside SettingsDialog. Rendering either as JSX would
+    // create a fresh component type on each parent re-render and remount the
+    // active subtree, which is visible as periodic flicker in provider sections
+    // when sync health updates land.
     return (
       <section data-section={id} className="pb-8 min-h-full flex flex-col">
         {SectionContent({ id })}
@@ -1162,7 +1162,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
               </div>
             ) : (
               allSections.map((section) => (
-                <SectionBlock key={section.id} id={section.id} />
+                <Fragment key={section.id}>{renderSectionBlock(section.id)}</Fragment>
               ))
             )}
 

--- a/packages/ui/src/components/SettingsDialog.tsx
+++ b/packages/ui/src/components/SettingsDialog.tsx
@@ -1054,7 +1054,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
       {/* Panel */}
       <div
         className={`
-          theme-dialog-shell relative z-10 flex w-full flex-col
+          theme-dialog-shell theme-settings-shell relative z-10 flex w-full flex-col
           h-[92dvh] rounded-t-2xl
           sm:rounded-[28px]
           sm:flex-row sm:max-w-3xl sm:h-[80vh] sm:max-h-[700px]

--- a/packages/ui/src/components/SettingsToggle.tsx
+++ b/packages/ui/src/components/SettingsToggle.tsx
@@ -20,23 +20,24 @@ export function SettingsToggle({
       aria-checked={checked}
       aria-label={label}
       onClick={() => onChange(!checked)}
-      className="group flex w-full items-start gap-3 rounded-xl px-2 py-1.5 text-left transition-colors hover:bg-[rgb(var(--theme-control-accent-rgb)/0.08)]"
+      className="group flex w-full items-center gap-3 rounded-xl px-2 py-2 text-left transition-colors hover:bg-[rgb(var(--theme-control-accent-rgb)/0.08)]"
     >
       <div
-        className={`relative mt-0.5 h-4.5 w-8 shrink-0 rounded-full border transition-colors ${
+        aria-hidden="true"
+        className={`relative flex h-5 w-9 shrink-0 items-center rounded-full border px-[2px] transition-colors ${
           checked
             ? "border-[color:rgb(var(--theme-control-accent-rgb)/0.42)] bg-[color:rgb(var(--theme-control-accent-rgb)/0.68)]"
             : "border-[var(--theme-border-subtle)] bg-[var(--theme-bg-muted)]"
         }`}
       >
-        <div
-          className={`absolute top-0.5 left-0.5 h-3.5 w-3.5 rounded-full border border-[rgb(var(--theme-control-accent-rgb)/0.12)] bg-[var(--theme-button-primary-text)] shadow transition-transform ${
-            checked ? "translate-x-3.5" : "translate-x-0"
+        <span
+          className={`block h-4 w-4 rounded-full border border-[rgb(var(--theme-control-accent-rgb)/0.12)] bg-[var(--theme-button-primary-text)] shadow-[0_1px_3px_rgb(0_0_0_/_0.22)] transition-transform ${
+            checked ? "translate-x-4" : "translate-x-0"
           }`}
         />
       </div>
-      <div className="min-w-0">
-        <p className="text-sm text-[var(--theme-text-secondary)] group-hover:text-[var(--theme-text-primary)] transition-colors">{label}</p>
+      <div className="min-w-0 flex-1">
+        <p className="text-sm text-[var(--theme-text-secondary)] transition-colors group-hover:text-[var(--theme-text-primary)]">{label}</p>
         {description ? <p className="mt-0.5 text-xs text-[var(--theme-text-soft)]">{description}</p> : null}
       </div>
     </button>

--- a/packages/ui/src/components/Toast.tsx
+++ b/packages/ui/src/components/Toast.tsx
@@ -71,10 +71,10 @@ function ToastItem({ toast, onClose }: { toast: Toast; onClose: () => void }) {
 
   const bgColor = {
     success:
-      "bg-[color:color-mix(in_srgb,var(--theme-bg-surface)_94%,transparent)] ring-1 ring-[rgb(var(--theme-feedback-success-rgb)/0.3)] border-[rgb(var(--theme-feedback-success-rgb)/0.3)]",
+      "bg-[var(--theme-bg-elevated)] ring-1 ring-[rgb(var(--theme-feedback-success-rgb)/0.3)] border-[rgb(var(--theme-feedback-success-rgb)/0.3)]",
     error:
-      "bg-[color:color-mix(in_srgb,var(--theme-bg-surface)_94%,transparent)] ring-1 ring-[rgb(var(--theme-feedback-danger-rgb)/0.3)] border-[rgb(var(--theme-feedback-danger-rgb)/0.3)]",
-    info: "bg-[color:color-mix(in_srgb,var(--theme-bg-surface)_94%,transparent)] ring-1 ring-[color:color-mix(in_srgb,var(--theme-accent-secondary)_30%,transparent)] border-[color:color-mix(in_srgb,var(--theme-accent-secondary)_30%,transparent)]",
+      "bg-[var(--theme-bg-elevated)] ring-1 ring-[rgb(var(--theme-feedback-danger-rgb)/0.3)] border-[rgb(var(--theme-feedback-danger-rgb)/0.3)]",
+    info: "bg-[var(--theme-bg-elevated)] ring-1 ring-[color:color-mix(in_srgb,var(--theme-accent-secondary)_30%,transparent)] border-[color:color-mix(in_srgb,var(--theme-accent-secondary)_30%,transparent)]",
   }[toast.type];
 
   const textColor = {

--- a/packages/ui/src/components/feed/FeedItem.tsx
+++ b/packages/ui/src/components/feed/FeedItem.tsx
@@ -432,7 +432,7 @@ export const FeedItem = memo(function FeedItem({
             {onLike && (
               <div className="relative group/reactions">
                 {hasReactionPalette && (
-                  <div className="pointer-events-none absolute right-0 bottom-full mb-2 flex translate-y-1 rounded-xl border border-[var(--theme-border-subtle)] bg-[color:color-mix(in_oklab,var(--theme-bg-surface)_96%,transparent)] p-1 opacity-0 shadow-lg shadow-black/30 transition-all group-hover/reactions:pointer-events-auto group-hover/reactions:translate-y-0 group-hover/reactions:opacity-100 group-focus-within/reactions:pointer-events-auto group-focus-within/reactions:translate-y-0 group-focus-within/reactions:opacity-100">
+                  <div className="pointer-events-none absolute right-0 bottom-full mb-2 flex translate-y-1 rounded-xl border border-[var(--theme-border-subtle)] bg-[var(--theme-bg-elevated)] p-1 opacity-0 shadow-lg shadow-black/30 transition-all group-hover/reactions:pointer-events-auto group-hover/reactions:translate-y-0 group-hover/reactions:opacity-100 group-focus-within/reactions:pointer-events-auto group-focus-within/reactions:translate-y-0 group-focus-within/reactions:opacity-100">
                     {reactions.map((reaction) => (
                       <button
                         key={reaction.label}

--- a/packages/ui/src/components/feed/FeedItem.tsx
+++ b/packages/ui/src/components/feed/FeedItem.tsx
@@ -190,6 +190,8 @@ export const FeedItem = memo(function FeedItem({
 
     return (
       <div
+        data-feed-item-id={item.globalId}
+        data-focused={focused ? "true" : "false"}
         className={`relative overflow-hidden rounded-2xl cursor-pointer group select-none w-full transition-opacity ${
           isRead ? "grayscale opacity-60" : ""
         }`}
@@ -293,6 +295,8 @@ export const FeedItem = memo(function FeedItem({
     return (
       <div className="relative overflow-hidden rounded-xl">
         <article
+          data-feed-item-id={item.globalId}
+          data-focused={focused ? "true" : "false"}
           className={`feed-card group cursor-pointer aspect-square overflow-hidden p-3 flex flex-col transition-colors ${
             selected
               ? "border-l-2 border-l-[var(--theme-accent-secondary)] bg-[color:rgb(var(--theme-accent-secondary-rgb)/0.12)]"
@@ -382,6 +386,8 @@ export const FeedItem = memo(function FeedItem({
       )}
 
       <article
+        data-feed-item-id={item.globalId}
+        data-focused={focused ? "true" : "false"}
         className={`feed-card group cursor-pointer active:scale-[0.99] transition-transform ${focused ? "ring-2 ring-[color:rgb(var(--theme-accent-secondary-rgb)/0.6)] ring-inset" : ""} ${isRead ? "grayscale opacity-60" : ""}`}
         style={{
           transform: swipeX !== 0 ? `translateX(${swipeX}px)` : undefined,

--- a/packages/ui/src/components/feed/FeedItem.tsx
+++ b/packages/ui/src/components/feed/FeedItem.tsx
@@ -42,6 +42,10 @@ interface FeedItemProps {
   storyHeight?: number;
 }
 
+function feedCardTransitionName(globalId: string): string {
+  return `feed-card-${globalId.replace(/[^a-zA-Z0-9_-]/g, "-")}`;
+}
+
 const cls = "w-3.5 h-3.5";
 const SWIPE_THRESHOLD = 72;
 
@@ -132,6 +136,9 @@ export const FeedItem = memo(function FeedItem({
   storyHeight = 288,
 }: FeedItemProps) {
   const { feedMediaPreviews = "inline" } = usePlatform();
+  const sharedTransitionStyle = {
+    viewTransitionName: feedCardTransitionName(item.globalId),
+  } as React.CSSProperties;
   const timeAgo = formatDistanceToNow(item.publishedAt, { addSuffix: true });
   const platformIcon = platformIcons[item.platform] ?? <span className="text-xs">📄</span>;
   const isRead = Boolean(item.userState.readAt);
@@ -293,7 +300,7 @@ export const FeedItem = memo(function FeedItem({
 
   if (compact) {
     return (
-      <div className="relative overflow-hidden rounded-xl">
+      <div className="relative overflow-hidden rounded-xl" style={sharedTransitionStyle}>
         <article
           data-feed-item-id={item.globalId}
           data-focused={focused ? "true" : "false"}
@@ -367,7 +374,7 @@ export const FeedItem = memo(function FeedItem({
   const likeLabel = getLikeLabel(item, likeStatus);
 
   return (
-    <div className="relative overflow-hidden rounded-2xl">
+    <div className="relative overflow-hidden rounded-2xl" style={sharedTransitionStyle}>
       {enableSwipe && swipeX < 0 && (
         <div
           className="absolute inset-y-0 right-0 flex items-center justify-end pr-5 rounded-2xl transition-colors"

--- a/packages/ui/src/components/feed/FeedItem.tsx
+++ b/packages/ui/src/components/feed/FeedItem.tsx
@@ -297,6 +297,7 @@ export const FeedItem = memo(function FeedItem({
         <article
           data-feed-item-id={item.globalId}
           data-focused={focused ? "true" : "false"}
+          data-selected={selected ? "true" : "false"}
           className={`feed-card group cursor-pointer aspect-square overflow-hidden p-3 flex flex-col transition-colors ${
             selected
               ? "border-l-2 border-l-[var(--theme-accent-secondary)] bg-[color:rgb(var(--theme-accent-secondary-rgb)/0.12)]"

--- a/packages/ui/src/components/feed/FeedList.tsx
+++ b/packages/ui/src/components/feed/FeedList.tsx
@@ -1,4 +1,4 @@
-import { useRef, memo, useCallback, useEffect, useMemo, useState } from "react";
+import { useRef, memo, useCallback, useEffect, useLayoutEffect, useMemo, useState } from "react";
 import { useVirtualizer, useWindowVirtualizer } from "@tanstack/react-virtual";
 import { FeedItem } from "./FeedItem.js";
 import { FeedItemSkeleton } from "./FeedItemSkeleton.js";
@@ -96,6 +96,7 @@ interface FeedListProps {
   items: FeedItemType[];
   onItemClick?: (item: FeedItemType) => void;
   focusedIndex?: number;
+  focusMoveDirection?: -1 | 0 | 1;
   onFocusChange?: (index: number) => void;
   /** Called when user clicks "Add Feed" from the empty state */
   onAddFeed?: () => void;
@@ -222,6 +223,7 @@ export function FeedList({
   items,
   onItemClick,
   focusedIndex = -1,
+  focusMoveDirection = 0,
   onFocusChange,
   onAddFeed,
   hasFeedsSubscribed = false,
@@ -342,6 +344,55 @@ export function FeedList({
     // header so items are offset correctly as window.scrollY changes.
     scrollMargin: windowListRef.current?.offsetTop ?? 0,
   });
+
+  useLayoutEffect(() => {
+    if (isMobile || focusMoveDirection === 0 || focusedIndex < 0) return;
+
+    const container = parentRef.current;
+    if (!container) return;
+
+    const focusedRowIndex = itemIndexToRowIndex.get(focusedIndex);
+    if (focusedRowIndex === undefined) return;
+
+    const lookaheadRowIndex =
+      focusMoveDirection > 0
+        ? Math.min(focusedRowIndex + 1, rows.length - 1)
+        : Math.max(focusedRowIndex - 1, 0);
+    const scrollPadding = 16;
+    const lookaheadRow = container.querySelector(
+      `[data-feed-row-index="${lookaheadRowIndex}"]`,
+    ) as HTMLElement | null;
+
+    if (!lookaheadRow) {
+      elementVirtualizer.scrollToIndex(lookaheadRowIndex, {
+        align: focusMoveDirection > 0 ? "end" : "start",
+      });
+      return;
+    }
+
+    const containerRect = container.getBoundingClientRect();
+    const rowRect = lookaheadRow.getBoundingClientRect();
+
+    if (focusMoveDirection > 0) {
+      const overflow = rowRect.bottom - (containerRect.bottom - scrollPadding);
+      if (overflow > 0) {
+        container.scrollBy({ top: overflow, behavior: "auto" });
+      }
+      return;
+    }
+
+    const overflow = containerRect.top + scrollPadding - rowRect.top;
+    if (overflow > 0) {
+      container.scrollBy({ top: -overflow, behavior: "auto" });
+    }
+  }, [
+    elementVirtualizer,
+    focusMoveDirection,
+    focusedIndex,
+    isMobile,
+    itemIndexToRowIndex,
+    rows.length,
+  ]);
 
   const listKey = useMemo(
     () => JSON.stringify({ activeFilter, searchQuery: searchQuery.trim() }),
@@ -537,6 +588,7 @@ export function FeedList({
             return (
               <div
                 key={virtualItem.key}
+                data-feed-row-index={virtualItem.index}
                 data-index={virtualItem.index}
                 ref={windowVirtualizer.measureElement}
                 style={{
@@ -593,6 +645,7 @@ export function FeedList({
   return (
     <div
       ref={parentRef}
+      data-testid="feed-list-scroll-container"
       className="flex-1 min-h-0 overflow-auto overscroll-none minimal-scroll"
     >
       <div
@@ -605,6 +658,7 @@ export function FeedList({
           return (
             <div
               key={virtualItem.key}
+              data-feed-row-index={virtualItem.index}
               data-index={virtualItem.index}
               ref={elementVirtualizer.measureElement}
               style={{

--- a/packages/ui/src/components/feed/FeedView.tsx
+++ b/packages/ui/src/components/feed/FeedView.tsx
@@ -25,6 +25,7 @@ const CARD_V_GAP = 8;
 interface CompactFeedPanelProps {
   items: FeedItem[];
   selectedId: string;
+  selectionMoveDirection?: -1 | 0 | 1;
   onItemClick: (item: FeedItem) => void;
   width: number;
 }
@@ -32,6 +33,7 @@ interface CompactFeedPanelProps {
 const CompactFeedPanel = memo(function CompactFeedPanel({
   items,
   selectedId,
+  selectionMoveDirection = 0,
   onItemClick,
   width,
 }: CompactFeedPanelProps) {
@@ -111,18 +113,62 @@ const CompactFeedPanel = memo(function CompactFeedPanel({
     [items, selectedId],
   );
   const didInitialScroll = useRef(false);
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (selectedIndex < 0) return;
-    virtualizer.scrollToIndex(selectedIndex, {
-      align: "center",
-      behavior: didInitialScroll.current ? "smooth" : "auto",
-    });
+    const behavior = didInitialScroll.current ? "smooth" : "auto";
+
+    if (selectionMoveDirection === 0) {
+      virtualizer.scrollToIndex(selectedIndex, {
+        align: "center",
+        behavior,
+      });
+      didInitialScroll.current = true;
+      return;
+    }
+
+    const el = parentRef.current;
+    if (!el) return;
+
+    const lookaheadIndex =
+      selectionMoveDirection > 0
+        ? Math.min(selectedIndex + 1, items.length - 1)
+        : Math.max(selectedIndex - 1, 0);
+    const scrollPadding = CARD_V_GAP;
+    const lookaheadStart =
+      lookaheadIndex === 0
+        ? 0
+        : firstItemHeight + (lookaheadIndex - 1) * itemHeight;
+    const lookaheadSize = lookaheadIndex === 0 ? firstItemHeight : itemHeight;
+    const lookaheadEnd = lookaheadStart + lookaheadSize;
+    const visibleTop = el.scrollTop;
+    const visibleBottom = visibleTop + el.clientHeight;
+
+    if (selectionMoveDirection > 0) {
+      const nextTop = lookaheadEnd - (el.clientHeight - scrollPadding);
+      if (lookaheadEnd > visibleBottom - scrollPadding) {
+        el.scrollTo({ top: Math.max(0, nextTop), behavior });
+      }
+    } else {
+      const nextTop = lookaheadStart - scrollPadding;
+      if (lookaheadStart < visibleTop + scrollPadding) {
+        el.scrollTo({ top: Math.max(0, nextTop), behavior });
+      }
+    }
+
     didInitialScroll.current = true;
-  }, [selectedIndex, virtualizer]);
+  }, [
+    firstItemHeight,
+    itemHeight,
+    items.length,
+    selectedIndex,
+    selectionMoveDirection,
+    virtualizer,
+  ]);
 
   return (
     <div
       ref={parentRef}
+      data-testid="compact-feed-panel-scroll-container"
       className="shrink-0 min-h-0 overflow-y-auto minimal-scroll bg-[var(--theme-bg-root)]"
       style={{ width }}
     >
@@ -135,6 +181,7 @@ const CompactFeedPanel = memo(function CompactFeedPanel({
           return (
             <div
               key={vi.key}
+              data-compact-panel-index={vi.index}
               data-index={vi.index}
               style={{
                 position: "absolute",
@@ -256,6 +303,8 @@ export function FeedView() {
     : `${filteredItems.length.toLocaleString()} item${filteredItems.length === 1 ? "" : "s"}`;
 
   const dualColumnMode = useAppStore((s) => s.preferences.display.reading.dualColumnMode);
+  const isMobile = useIsMobile();
+  const showDualColumn = dualColumnMode && !!selectedItemId && !isMobile;
 
   // Store only the ID so the rendered item stays in sync with the store.
   // Holding the full FeedItem in state would freeze userState (saved, archived,
@@ -266,6 +315,7 @@ export function FeedView() {
   );
   const [focusedIndex, setFocusedIndex] = useState<number>(-1);
   const [keyboardFocusDirection, setKeyboardFocusDirection] = useState<-1 | 0 | 1>(0);
+  const [compactSelectionDirection, setCompactSelectionDirection] = useState<-1 | 0 | 1>(0);
 
   const openItem = useCallback(
     (item: FeedItem) => {
@@ -275,7 +325,13 @@ export function FeedView() {
     [markAsRead, setSelectedItem],
   );
 
+  const openItemDirect = useCallback((item: FeedItem) => {
+    setCompactSelectionDirection(0);
+    openItem(item);
+  }, [openItem]);
+
   const closeItem = useCallback(() => {
+    setCompactSelectionDirection(0);
     setSelectedItem(null);
   }, [setSelectedItem]);
 
@@ -290,6 +346,21 @@ export function FeedView() {
         return;
 
       if (selectedItem) {
+        if (showDualColumn && (e.key === "ArrowDown" || e.key === "ArrowUp")) {
+          e.preventDefault();
+          const currentIndex = filteredItems.findIndex((item) => item.globalId === selectedItem.globalId);
+          if (currentIndex < 0) return;
+
+          const direction = e.key === "ArrowDown" ? 1 : -1;
+          const nextIndex = Math.max(0, Math.min(currentIndex + direction, filteredItems.length - 1));
+          if (nextIndex === currentIndex) return;
+
+          setCompactSelectionDirection(direction);
+          setFocusedIndex(nextIndex);
+          openItem(filteredItems[nextIndex]);
+          return;
+        }
+
         if (e.key === "Escape") closeItem();
         return;
       }
@@ -304,16 +375,17 @@ export function FeedView() {
         setFocusedIndex((prev) => Math.max(prev - 1, 0));
       } else if ((e.key === "Enter" || e.key === "o") && focusedIndex >= 0) {
         const item = filteredItems[focusedIndex];
-        if (item) openItem(item);
+        if (item) openItemDirect(item);
       }
     };
 
     window.addEventListener("keydown", handleKey);
     return () => window.removeEventListener("keydown", handleKey);
-  }, [selectedItem, filteredItems, focusedIndex, openItem, closeItem]);
+  }, [selectedItem, showDualColumn, filteredItems, focusedIndex, openItem, openItemDirect, closeItem]);
 
   // Reset keyboard focus when the active filter or search query changes.
   useEffect(() => {
+    setCompactSelectionDirection(0);
     setKeyboardFocusDirection(0);
     setFocusedIndex(-1);
   }, [activeFilter, searchQuery]);
@@ -359,10 +431,7 @@ export function FeedView() {
 
   // ─── Layout decision ────────────────────────────────────────────────────────
 
-  const isMobile = useIsMobile();
-  const showDualColumn = dualColumnMode && !!selectedItem && !isMobile;
-
-  if (showDualColumn) {
+  if (showDualColumn && selectedItem) {
     return (
       <div className="h-full flex flex-col overflow-hidden">
         <ContentHeader title={scopeLabel} subtitle={feedSubtitle} />
@@ -388,7 +457,8 @@ export function FeedView() {
           <CompactFeedPanel
             items={filteredItems}
             selectedId={selectedItem.globalId}
-            onItemClick={openItem}
+            selectionMoveDirection={compactSelectionDirection}
+            onItemClick={openItemDirect}
             width={panelWidth}
           />
           {/* Draggable column separator -- zero visible width, padding provides the hit area */}
@@ -452,7 +522,7 @@ export function FeedView() {
 
       <FeedList
         items={filteredItems}
-        onItemClick={openItem}
+        onItemClick={openItemDirect}
         focusedIndex={focusedIndex}
         focusMoveDirection={keyboardFocusDirection}
         onFocusChange={handleFocusChange}

--- a/packages/ui/src/components/feed/FeedView.tsx
+++ b/packages/ui/src/components/feed/FeedView.tsx
@@ -22,6 +22,14 @@ const NARROW_THRESHOLD = 150;
 const CARD_H_PAD = 16;
 const CARD_V_GAP = 8;
 
+type ViewTransitionLike = {
+  finished: Promise<void>;
+};
+
+type ViewTransitionDocument = Document & {
+  startViewTransition?: (update: () => void) => ViewTransitionLike;
+};
+
 interface CompactFeedPanelProps {
   items: FeedItem[];
   selectedId: string;
@@ -306,6 +314,34 @@ export function FeedView() {
   const isMobile = useIsMobile();
   const showDualColumn = dualColumnMode && !!selectedItemId && !isMobile;
 
+  const runFeedLayoutTransition = useCallback((update: () => void) => {
+    if (typeof window === "undefined" || window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+      update();
+      return;
+    }
+
+    const doc = document as ViewTransitionDocument;
+    if (!doc.startViewTransition) {
+      update();
+      return;
+    }
+
+    document.documentElement.classList.add("feed-layout-transition");
+
+    try {
+      const transition = doc.startViewTransition(() => {
+        update();
+      });
+
+      void transition.finished.finally(() => {
+        document.documentElement.classList.remove("feed-layout-transition");
+      });
+    } catch {
+      document.documentElement.classList.remove("feed-layout-transition");
+      update();
+    }
+  }, []);
+
   // Store only the ID so the rendered item stays in sync with the store.
   // Holding the full FeedItem in state would freeze userState (saved, archived,
   // tags) at the moment the user clicked, making toolbar toggles appear broken.
@@ -319,10 +355,19 @@ export function FeedView() {
 
   const openItem = useCallback(
     (item: FeedItem) => {
-      setSelectedItem(item.globalId);
-      markAsRead(item.globalId);
+      const selectItem = () => {
+        setSelectedItem(item.globalId);
+        markAsRead(item.globalId);
+      };
+
+      if (dualColumnMode && !isMobile && !selectedItemId) {
+        runFeedLayoutTransition(selectItem);
+        return;
+      }
+
+      selectItem();
     },
-    [markAsRead, setSelectedItem],
+    [dualColumnMode, isMobile, markAsRead, runFeedLayoutTransition, selectedItemId, setSelectedItem],
   );
 
   const openItemDirect = useCallback((item: FeedItem) => {
@@ -332,8 +377,14 @@ export function FeedView() {
 
   const closeItem = useCallback(() => {
     setCompactSelectionDirection(0);
+    if (dualColumnMode && !isMobile && selectedItemId) {
+      runFeedLayoutTransition(() => {
+        setSelectedItem(null);
+      });
+      return;
+    }
     setSelectedItem(null);
-  }, [setSelectedItem]);
+  }, [dualColumnMode, isMobile, runFeedLayoutTransition, selectedItemId, setSelectedItem]);
 
   // Keyboard navigation: j/k to move, Enter/o to open, Escape to close.
   // The HTMLInputElement guard means j/k won't fire while the search bar is focused.

--- a/packages/ui/src/components/feed/FeedView.tsx
+++ b/packages/ui/src/components/feed/FeedView.tsx
@@ -265,6 +265,7 @@ export function FeedView() {
     [filteredItems, selectedItemId],
   );
   const [focusedIndex, setFocusedIndex] = useState<number>(-1);
+  const [keyboardFocusDirection, setKeyboardFocusDirection] = useState<-1 | 0 | 1>(0);
 
   const openItem = useCallback(
     (item: FeedItem) => {
@@ -295,9 +296,11 @@ export function FeedView() {
 
       if (e.key === "j" || e.key === "ArrowDown") {
         e.preventDefault();
+        setKeyboardFocusDirection(1);
         setFocusedIndex((prev) => Math.min(prev + 1, filteredItems.length - 1));
       } else if (e.key === "k" || e.key === "ArrowUp") {
         e.preventDefault();
+        setKeyboardFocusDirection(-1);
         setFocusedIndex((prev) => Math.max(prev - 1, 0));
       } else if ((e.key === "Enter" || e.key === "o") && focusedIndex >= 0) {
         const item = filteredItems[focusedIndex];
@@ -311,8 +314,14 @@ export function FeedView() {
 
   // Reset keyboard focus when the active filter or search query changes.
   useEffect(() => {
+    setKeyboardFocusDirection(0);
     setFocusedIndex(-1);
   }, [activeFilter, searchQuery]);
+
+  const handleFocusChange = useCallback((index: number) => {
+    setKeyboardFocusDirection(0);
+    setFocusedIndex(index);
+  }, []);
 
   // ─── Dual-column drag-resize ───────────────────────────────────────────────
 
@@ -445,7 +454,8 @@ export function FeedView() {
         items={filteredItems}
         onItemClick={openItem}
         focusedIndex={focusedIndex}
-        onFocusChange={setFocusedIndex}
+        focusMoveDirection={keyboardFocusDirection}
+        onFocusChange={handleFocusChange}
         onAddFeed={canAddFeeds ? () => setAddFeedOpen(true) : undefined}
         hasFeedsSubscribed={Object.keys(feeds).length > 0}
         onItemSave={handleItemSave}

--- a/packages/ui/src/components/icons.tsx
+++ b/packages/ui/src/components/icons.tsx
@@ -160,6 +160,20 @@ export function UsersIcon({ className = "w-4 h-4", style }: IconProps) {
   );
 }
 
+/** Contact card with profile and address rows for Google Contacts. */
+export function GoogleContactsIcon({ className = "w-4 h-4", style }: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" className={className} style={style} aria-hidden="true">
+      <rect x="4" y="3.5" width="16" height="17" rx="2.5" />
+      <path d="M8.75 9a2.25 2.25 0 104.5 0 2.25 2.25 0 00-4.5 0z" />
+      <path d="M7.75 14c.83-1.25 2.12-1.88 3.75-1.88S14.42 12.75 15.25 14" />
+      <path d="M16.5 8.25h1.75" />
+      <path d="M16.5 11.25h1.75" />
+      <path d="M8 17.25h10.25" />
+    </svg>
+  );
+}
+
 /** Reddit alien head (Simple Icons path). */
 export function RedditIcon({ className = "w-4 h-4", style }: IconProps) {
   return (

--- a/packages/ui/src/components/layout/AppShell.tsx
+++ b/packages/ui/src/components/layout/AppShell.tsx
@@ -41,12 +41,19 @@ export function AppShell({ children }: AppShellProps) {
   // interval and focus listener run regardless of which view is active.
   const contactSync = useContactSync();
   const [showContactReview, setShowContactReview] = useState(false);
-  const savedDebugWidth = useAppStore((s) => s.preferences.display.debugPanelWidth) ?? DEFAULT_DEBUG_WIDTH;
+  const persistedDebugWidth =
+    useAppStore((s) => s.preferences.display.debugPanelWidth) ?? DEFAULT_DEBUG_WIDTH;
   const updatePreferences = useAppStore((s) => s.updatePreferences);
   const [dragWidth, setDragWidth] = useState<number | null>(null);
+  const [committedDebugWidth, setCommittedDebugWidth] = useState(persistedDebugWidth);
   const dragging = useRef(false);
 
-  const debugWidth = dragWidth ?? savedDebugWidth;
+  useEffect(() => {
+    if (dragging.current || dragWidth !== null) return;
+    setCommittedDebugWidth(persistedDebugWidth);
+  }, [dragWidth, persistedDebugWidth]);
+
+  const debugWidth = dragWidth ?? committedDebugWidth;
 
   const handleDebugDragStart = useCallback(
     (e: React.MouseEvent) => {
@@ -54,6 +61,11 @@ export function AppShell({ children }: AppShellProps) {
       dragging.current = true;
       const startX = e.clientX;
       const startW = debugWidth;
+      const previousCursor = document.body.style.cursor;
+      const previousUserSelect = document.body.style.userSelect;
+
+      document.body.style.cursor = "col-resize";
+      document.body.style.userSelect = "none";
 
       const onMove = (ev: MouseEvent) => {
         if (!dragging.current) return;
@@ -65,7 +77,10 @@ export function AppShell({ children }: AppShellProps) {
         dragging.current = false;
         const final = Math.min(MAX_DEBUG_WIDTH, Math.max(MIN_DEBUG_WIDTH, startW - (ev.clientX - startX)));
         setDragWidth(null);
-        updatePreferences({ display: { debugPanelWidth: final } } as Parameters<typeof updatePreferences>[0]);
+        setCommittedDebugWidth(final);
+        void updatePreferences({ display: { debugPanelWidth: final } } as Parameters<typeof updatePreferences>[0]);
+        document.body.style.cursor = previousCursor;
+        document.body.style.userSelect = previousUserSelect;
         document.removeEventListener("mousemove", onMove);
         document.removeEventListener("mouseup", onUp);
       };
@@ -171,6 +186,7 @@ export function AppShell({ children }: AppShellProps) {
             The DebugPanel's own border-l is clipped by overflow-hidden when width is 0.
             Width is user-draggable; animated only when toggling open/closed. */}
         <div
+          data-testid="debug-panel-drawer"
           className="hidden sm:flex flex-none overflow-hidden relative"
           style={{
             width: debugVisible ? debugWidth : 0,
@@ -180,6 +196,7 @@ export function AppShell({ children }: AppShellProps) {
           {/* Left-edge resize handle - drag left to widen, drag right to narrow */}
           {debugVisible && (
             <div
+              data-testid="debug-panel-resize-handle"
               className="absolute left-0 top-0 z-10 h-full w-1 cursor-col-resize transition-colors hover:bg-[rgb(var(--theme-accent-secondary-rgb)/0.24)] active:bg-[rgb(var(--theme-accent-secondary-rgb)/0.4)]"
               onMouseDown={handleDebugDragStart}
             />

--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -261,7 +261,7 @@ export function Header({ onMenuClick }: HeaderProps) {
                 </Tooltip>
 
                 {dropdownOpen && (
-                  <div className="absolute right-0 top-full z-50 mt-1.5 w-44 overflow-hidden rounded-xl border border-[var(--theme-border-subtle)] bg-[color:color-mix(in_oklab,var(--theme-bg-surface)_95%,transparent)] py-1 shadow-2xl shadow-black/40">
+                  <div className="absolute right-0 top-full z-50 mt-1.5 w-44 overflow-hidden rounded-xl border border-[var(--theme-border-subtle)] bg-[var(--theme-bg-elevated)] py-1 shadow-2xl shadow-black/40">
                     {canAddRss && (
                       <button
                         onClick={() => {

--- a/packages/ui/src/components/layout/SearchJumpField.tsx
+++ b/packages/ui/src/components/layout/SearchJumpField.tsx
@@ -167,7 +167,7 @@ export function SearchJumpField() {
         <div
           role="listbox"
           aria-label="Quick actions"
-          className="absolute left-0 right-0 top-full z-50 mt-1.5 overflow-hidden rounded-xl border border-[var(--theme-border-subtle)] bg-[color:color-mix(in_oklab,var(--theme-bg-surface)_95%,transparent)] py-1 shadow-2xl shadow-black/50"
+          className="absolute left-0 right-0 top-full z-50 mt-1.5 overflow-hidden rounded-xl border border-[var(--theme-border-subtle)] bg-[var(--theme-bg-elevated)] py-1 shadow-2xl shadow-black/50"
         >
           {!inputValue && (
             <p className="px-3 pb-0.5 pt-1 text-[10px] font-semibold uppercase tracking-wider text-[var(--theme-text-soft)]">

--- a/packages/ui/src/components/layout/Sidebar.tsx
+++ b/packages/ui/src/components/layout/Sidebar.tsx
@@ -399,7 +399,8 @@ export function Sidebar({ open, onClose }: SidebarProps) {
       ((s as unknown as { providerSyncCounts?: Partial<Record<string, number>> })
         .providerSyncCounts ?? EMPTY_PROVIDER_SYNC_COUNTS) as Partial<Record<string, number>>,
   );
-  const sidebarWidth = useAppStore((s) => s.preferences.display.sidebarWidth) ?? DEFAULT_WIDTH;
+  const persistedSidebarWidth =
+    useAppStore((s) => s.preferences.display.sidebarWidth) ?? DEFAULT_WIDTH;
   const updatePreferences = useAppStore((s) => s.updatePreferences);
   const items = useAppStore((s) => s.items);
   const activeView = useAppStore((s) => s.activeView);
@@ -417,6 +418,7 @@ export function Sidebar({ open, onClose }: SidebarProps) {
 
   const { open: showSettings, openDefault: openSettings, close: closeSettings } = useSettingsStore();
   const [dragWidth, setDragWidth] = useState<number | null>(null);
+  const [committedWidth, setCommittedWidth] = useState(persistedSidebarWidth);
   const [rssFeedsOpen, setRssFeedsOpen] = useState(false);
   const [rssFeedPage, setRssFeedPage] = useState(0);
 
@@ -486,7 +488,12 @@ export function Sidebar({ open, onClose }: SidebarProps) {
     return childTagsOf(tag).some((t) => active.includes(t));
   };
 
-  const width = dragWidth ?? sidebarWidth;
+  useEffect(() => {
+    if (dragging.current || dragWidth !== null) return;
+    setCommittedWidth(persistedSidebarWidth);
+  }, [dragWidth, persistedSidebarWidth]);
+
+  const width = dragWidth ?? committedWidth;
 
   const handleDragStart = useCallback(
     (e: React.MouseEvent) => {
@@ -494,6 +501,11 @@ export function Sidebar({ open, onClose }: SidebarProps) {
       dragging.current = true;
       const startX = e.clientX;
       const startW = width;
+      const previousCursor = document.body.style.cursor;
+      const previousUserSelect = document.body.style.userSelect;
+
+      document.body.style.cursor = "col-resize";
+      document.body.style.userSelect = "none";
 
       const onMove = (ev: MouseEvent) => {
         if (!dragging.current) return;
@@ -504,7 +516,10 @@ export function Sidebar({ open, onClose }: SidebarProps) {
         dragging.current = false;
         const final = Math.min(MAX_WIDTH, Math.max(MIN_WIDTH, startW + ev.clientX - startX));
         setDragWidth(null);
-        updatePreferences({ display: { sidebarWidth: final } } as Parameters<typeof updatePreferences>[0]);
+        setCommittedWidth(final);
+        void updatePreferences({ display: { sidebarWidth: final } } as Parameters<typeof updatePreferences>[0]);
+        document.body.style.cursor = previousCursor;
+        document.body.style.userSelect = previousUserSelect;
         document.removeEventListener("mousemove", onMove);
         document.removeEventListener("mouseup", onUp);
       };
@@ -693,6 +708,7 @@ export function Sidebar({ open, onClose }: SidebarProps) {
 
       {/* Sidebar */}
       <aside
+        data-testid="app-sidebar"
         className={`
           fixed inset-y-0 left-0 md:relative z-50 md:z-auto
           h-full
@@ -752,11 +768,7 @@ export function Sidebar({ open, onClose }: SidebarProps) {
                     {SourceIndicator ? (
                       <span
                         data-testid={`source-indicator-slot-${sourceKey(source)}`}
-                        className={`flex h-4 w-4 shrink-0 items-center justify-center transition-transform duration-200 ease-in-out ${
-                          openMenuSourceKey === sourceKey(source)
-                            ? "translate-x-1"
-                            : "group-hover/source:translate-x-1"
-                        }`}
+                        className="flex h-4 w-4 shrink-0 items-center justify-center"
                       >
                         <SourceIndicator sourceId={source.id ?? "all"} />
                       </span>
@@ -908,12 +920,12 @@ export function Sidebar({ open, onClose }: SidebarProps) {
                           }`}
                         >
                           <div className="flex items-stretch gap-2">
-                          <div className="flex min-w-0 items-center gap-1.5 pl-3 py-1.5">
+                          <div className="flex min-w-0 flex-1 items-center gap-1.5 pl-3 py-1.5">
                             <button
                               onClick={() => handleSourceClick(source)}
                               data-testid={`source-row-${sourceKey(source)}`}
                               className={`
-                                flex min-w-0 items-center gap-3 text-left text-sm transition-all
+                                flex min-w-0 flex-1 items-center gap-3 text-left text-sm transition-all
                                 ${
                                   isTopSourceActive(source)
                                     ? "text-[color:var(--theme-text-primary)]"
@@ -922,18 +934,7 @@ export function Sidebar({ open, onClose }: SidebarProps) {
                               `}
                             >
                               <span className="w-5 flex items-center justify-center">{source.icon}</span>
-                              <span className="min-w-0 flex items-center gap-1.5">
-                                <span className="truncate">{source.label}</span>
-                                {sourceStatus ? (
-                                  <ProviderStatusIndicator
-                                    tone={sourceStatus.tone}
-                                    syncing={sourceStatus.syncing}
-                                    label={sourceStatus.label}
-                                    size="xxs"
-                                    testId={`source-status-${sourceKey(source)}`}
-                                  />
-                                ) : null}
-                              </span>
+                              <span className="min-w-0 flex-1 truncate">{source.label}</span>
                             </button>
                             <button
                               type="button"
@@ -953,6 +954,17 @@ export function Sidebar({ open, onClose }: SidebarProps) {
                             </button>
                           </div>
                           <div className="shrink-0 flex items-center pr-2">
+                            {sourceStatus ? (
+                              <span className="flex h-4 w-4 shrink-0 items-center justify-center">
+                                <ProviderStatusIndicator
+                                  tone={sourceStatus.tone}
+                                  syncing={sourceStatus.syncing}
+                                  label={sourceStatus.label}
+                                  size="xxs"
+                                  testId={`source-status-${sourceKey(source)}`}
+                                />
+                              </span>
+                            ) : null}
                             <div className="relative ml-1.5 h-6 w-[54px] shrink-0">
                               {sourceTotalCount(source) > 0 && (
                                 <span
@@ -1157,11 +1169,7 @@ export function Sidebar({ open, onClose }: SidebarProps) {
                       {SourceIndicator ? (
                         <span
                           data-testid={`source-indicator-slot-${sourceKey(source)}`}
-                          className={`flex h-4 w-4 shrink-0 items-center justify-center transition-transform duration-200 ease-in-out ${
-                            openMenuSourceKey === sourceKey(source)
-                              ? "translate-x-0 bg-[var(--theme-bg-muted)] text-[var(--theme-text-primary)] opacity-100"
-                              : "pointer-events-none translate-x-[-4px] text-[var(--theme-text-muted)] opacity-0 group-hover/source:pointer-events-auto group-hover/source:translate-x-0 group-hover/source:opacity-100"
-                          }`}
+                          className="flex h-4 w-4 shrink-0 items-center justify-center"
                         >
                           <SourceIndicator sourceId={source.id ?? "all"} />
                         </span>
@@ -1279,6 +1287,7 @@ export function Sidebar({ open, onClose }: SidebarProps) {
 
         {/* Resize handle — desktop only */}
         <div
+          data-testid="app-sidebar-resize-handle"
           className="hidden md:block absolute top-0 right-0 z-10 h-full w-1 cursor-col-resize transition-colors hover:bg-[rgb(var(--theme-accent-secondary-rgb)/0.3)] active:bg-[rgb(var(--theme-accent-secondary-rgb)/0.5)]"
           onMouseDown={handleDragStart}
         />

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -1291,6 +1291,19 @@ html[data-theme="scriptorium"] .feed-card {
   );
 }
 
+@media (prefers-reduced-motion: no-preference) {
+  html.feed-layout-transition::view-transition-group(*) {
+    animation-duration: 340ms;
+    animation-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
+  }
+
+  html.feed-layout-transition::view-transition-old(*),
+  html.feed-layout-transition::view-transition-new(*) {
+    animation-duration: 340ms;
+    animation-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
+  }
+}
+
 .theme-topbar {
   border-color: var(--theme-header-border);
   background: var(--theme-header-background);

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -15,7 +15,7 @@ html[data-theme="neon"] {
   --theme-bg-root: #0a0a0a;
   --theme-bg-deep: #0f0f15;
   --theme-bg-surface: #14141b;
-  --theme-bg-elevated: rgba(21, 21, 30, 0.9);
+  --theme-bg-elevated: #15151e;
   --theme-bg-card: rgba(255, 255, 255, 0.035);
   --theme-bg-card-hover: rgba(255, 255, 255, 0.06);
   --theme-bg-input: rgba(255, 255, 255, 0.05);
@@ -171,7 +171,7 @@ html[data-theme="midas"] {
   --theme-bg-root: #2b231d;
   --theme-bg-deep: #352b23;
   --theme-bg-surface: #3e3229;
-  --theme-bg-elevated: rgb(55 45 36 / 0.92);
+  --theme-bg-elevated: rgb(55 45 36);
   --theme-bg-card: rgb(243 233 218 / 0.04);
   --theme-bg-card-hover: rgb(243 233 218 / 0.07);
   --theme-bg-input: rgb(243 233 218 / 0.06);
@@ -287,7 +287,7 @@ html[data-theme="ember"] {
   --theme-bg-root: #180f0d;
   --theme-bg-deep: #221411;
   --theme-bg-surface: #2a1a16;
-  --theme-bg-elevated: rgb(39 24 20 / 0.93);
+  --theme-bg-elevated: rgb(39 24 20);
   --theme-bg-card: rgb(255 237 220 / 0.03);
   --theme-bg-card-hover: rgb(255 237 220 / 0.05);
   --theme-bg-input: rgb(255 237 220 / 0.05);
@@ -405,7 +405,7 @@ html[data-theme="scriptorium"] {
   --theme-bg-root: #f4ead7;
   --theme-bg-deep: #ece0ca;
   --theme-bg-surface: #f8efdf;
-  --theme-bg-elevated: rgb(250 242 228 / 0.96);
+  --theme-bg-elevated: rgb(250 242 228);
   --theme-bg-card: rgb(255 251 244 / 0.76);
   --theme-bg-card-hover: rgb(255 251 244 / 0.9);
   --theme-bg-input: rgb(255 249 239 / 0.88);
@@ -969,12 +969,7 @@ html[data-theme="scriptorium"] .phase-card-complete {
       var(--theme-border-strong) 48%,
       var(--theme-border-subtle)
     );
-  background: linear-gradient(
-    180deg,
-    color-mix(in oklab, var(--theme-bg-surface) 82%, white) 0%,
-    color-mix(in oklab, var(--theme-bg-surface) 96%, white) 22%,
-    color-mix(in oklab, var(--theme-bg-surface) 88%, black) 100%
-  );
+  background: color-mix(in oklab, var(--theme-bg-surface) 94%, black);
   color: var(--theme-text-primary);
   box-shadow:
     inset 0 1px 0 rgb(255 255 255 / 0.06),
@@ -986,11 +981,7 @@ html[data-theme="scriptorium"] .phase-card-complete {
 }
 
 html[data-theme="scriptorium"] .theme-tooltip-panel {
-  background: linear-gradient(
-    180deg,
-    color-mix(in oklab, var(--theme-bg-surface) 88%, white) 0%,
-    color-mix(in oklab, var(--theme-bg-surface) 96%, black) 100%
-  );
+  background: color-mix(in oklab, var(--theme-bg-surface) 96%, black);
   box-shadow:
     inset 0 1px 0 rgb(255 255 255 / 0.03),
     0 10px 26px rgb(84 58 35 / 0.08);
@@ -1488,7 +1479,7 @@ html[data-theme="scriptorium"] .theme-topbar {
     color-mix(in oklab, var(--theme-border-subtle) 70%, transparent);
   background:
     linear-gradient(180deg, rgb(255 255 255 / 0.045), transparent 18%),
-    color-mix(in oklab, var(--theme-bg-elevated) 86%, transparent);
+    var(--theme-bg-elevated);
   box-shadow:
     inset 0 1px 0 rgb(255 255 255 / 0.06),
     inset 0 0 0 0.5px rgb(255 255 255 / 0.028),
@@ -1628,6 +1619,40 @@ html[data-theme="scriptorium"] .btn-primary:hover {
 
 .btn-primary:active {
   transform: scale(0.985);
+}
+
+.nav-mobile-cta.btn-primary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: max-content;
+  margin-block: 0;
+  padding: 0.32rem 0.9rem;
+  line-height: 1;
+  border-radius: var(--button-radius);
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 0.08),
+    0 8px 18px rgb(0 0 0 / 0.22);
+  transition:
+    box-shadow 0.2s ease,
+    filter 0.2s ease,
+    opacity 0.2s ease;
+}
+
+.nav-mobile-cta.btn-primary:hover,
+.nav-mobile-cta.btn-primary:active {
+  transform: none;
+  border-radius: var(--button-radius);
+}
+
+.newsletter-modal .btn-primary:hover,
+.newsletter-modal .btn-primary:active {
+  transform: none;
+}
+
+.newsletter-modal-download-cta.btn-primary {
+  border-color: rgb(255 255 255 / 0.08);
+  box-shadow: var(--theme-button-primary-shadow);
 }
 
 .btn-secondary,

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -1523,6 +1523,24 @@ html[data-theme="scriptorium"] .theme-dialog-shell::before {
     );
 }
 
+.theme-settings-shell {
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 0.06),
+    inset 0 0 0 0.5px rgb(255 255 255 / 0.028),
+    0 22px 56px rgb(0 0 0 / 0.16),
+    0 44px 132px rgb(var(--theme-shell-rgb) / 0.42),
+    0 0 0 1px rgb(255 255 255 / 0.025);
+}
+
+html[data-theme="scriptorium"] .theme-settings-shell {
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 0.032),
+    inset 0 0 0 0.5px rgb(255 255 255 / 0.018),
+    0 18px 42px rgb(84 58 35 / 0.08),
+    0 34px 96px rgb(84 58 35 / 0.17),
+    0 0 0 1px rgb(255 255 255 / 0.04);
+}
+
 .theme-dialog-divider {
   border-color: color-mix(
     in oklab,

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -1648,9 +1648,7 @@ html[data-theme="scriptorium"] .btn-primary:hover {
   padding: 0.32rem 0.9rem;
   line-height: 1;
   border-radius: var(--button-radius);
-  box-shadow:
-    inset 0 1px 0 rgb(255 255 255 / 0.08),
-    0 8px 18px rgb(0 0 0 / 0.22);
+  box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.08);
   transition:
     box-shadow 0.2s ease,
     filter 0.2s ease,
@@ -1661,6 +1659,7 @@ html[data-theme="scriptorium"] .btn-primary:hover {
 .nav-mobile-cta.btn-primary:active {
   transform: none;
   border-radius: var(--button-radius);
+  box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.08);
 }
 
 .newsletter-modal .btn-primary:hover,

--- a/packages/ui/src/lib/settings-sections.ts
+++ b/packages/ui/src/lib/settings-sections.ts
@@ -9,7 +9,6 @@ export type SectionId =
   | "legal"
   | "appearance"
   | "support"
-  | "reading"
   | "feeds"
   | "saved"
   | "ai"
@@ -34,7 +33,13 @@ export const BASE_SECTION_METAS: readonly SectionMeta[] = [
   {
     id: "appearance",
     label: "Appearance",
-    keywords: ["theme", "appearance", "style", "midas", "neon", "ember", "scriptorium", "look"],
+    keywords: [
+      "theme", "appearance", "style", "midas", "neon", "ember", "scriptorium", "look",
+      "engagement", "counts", "likes", "reposts", "views",
+      "focus", "focus mode", "bionic", "bold", "reading speed",
+      "intensity", "light", "normal", "strong", "mark read", "scroll",
+      "archive", "delete archived", "prune", "reading",
+    ],
   },
   {
     id: "legal",
@@ -50,15 +55,6 @@ export const BASE_SECTION_METAS: readonly SectionMeta[] = [
     id: "sync",
     label: "Sync",
     keywords: ["cloud", "dropbox", "google drive", "gdrive", "backup", "provider", "connect"],
-  },
-  {
-    id: "reading",
-    label: "Reading",
-    keywords: [
-      "engagement", "counts", "likes", "reposts", "views",
-      "focus", "focus mode", "bionic", "bold", "reading speed",
-      "intensity", "light", "normal", "strong", "display",
-    ],
   },
   {
     id: "saved",

--- a/website/src/components/Features.tsx
+++ b/website/src/components/Features.tsx
@@ -232,9 +232,9 @@ export default function Features() {
               transition={{ duration: 0.5, delay: index * 0.1 }}
             >
               <div className="glass-card h-full p-5 sm:p-6">
-                <div className="mb-3 flex items-center gap-3 sm:mb-4 sm:flex-col sm:items-start">
+                <div className="mb-3 flex items-center gap-3 sm:mb-4">
                   <div className="shrink-0">{feature.icon}</div>
-                  <h3 className="text-lg font-semibold leading-tight text-text-primary sm:text-xl">
+                  <h3 className="text-lg font-semibold leading-tight text-text-primary sm:text-xl lg:text-[1.35rem]">
                     {feature.title}
                   </h3>
                 </div>

--- a/website/src/components/HowItWorks.tsx
+++ b/website/src/components/HowItWorks.tsx
@@ -59,7 +59,7 @@ export default function HowItWorks() {
         {/* Steps */}
         <div className="relative">
           <div
-            className="hidden lg:block absolute top-1/2 left-0 right-0 h-px -translate-y-1/2"
+            className="hidden xl:block absolute top-1/2 left-0 right-0 h-px -translate-y-1/2"
             style={{
               background:
                 "linear-gradient(to right, transparent, color-mix(in srgb, var(--theme-accent-secondary) 28%, transparent), transparent)",
@@ -96,7 +96,7 @@ export default function HowItWorks() {
                 {/* Connector dot */}
                 {index < steps.length - 1 && (
                   <div
-                    className="hidden lg:block absolute top-1/2 -right-5 h-2 w-2 rounded-full glow-sm -translate-y-1/2 z-20"
+                    className="hidden xl:block absolute top-1/2 -right-5 h-2 w-2 rounded-full glow-sm -translate-y-1/2 z-20"
                     style={{ background: "var(--theme-heading-accent)" }}
                   />
                 )}

--- a/website/src/components/Navigation.tsx
+++ b/website/src/components/Navigation.tsx
@@ -58,7 +58,9 @@ export default function Navigation() {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [scrolled, setScrolled] = useState(false);
   const [homePageScrolledPastFold, setHomePageScrolledPastFold] = useState(false);
+  const [mobileMenuTopOffset, setMobileMenuTopOffset] = useState(64);
   const navRefs = useRef<(HTMLAnchorElement | null)[]>([]);
+  const mobileTopBarRef = useRef<HTMLDivElement | null>(null);
   const [underlineStyle, setUnderlineStyle] = useState({ left: 0, width: 0 });
   const showMobileTopCta =
     !mobileMenuOpen && (pathname !== "/" || homePageScrolledPastFold);
@@ -109,6 +111,27 @@ export default function Navigation() {
       document.body.style.overflow = "";
     };
   }, [mobileMenuOpen]);
+
+  useLayoutEffect(() => {
+    const updateMobileTopOffset = () => {
+      if (!mobileTopBarRef.current) return;
+      const { height } = mobileTopBarRef.current.getBoundingClientRect();
+      setMobileMenuTopOffset(Math.max(0, Math.ceil(height)));
+    };
+
+    updateMobileTopOffset();
+    window.addEventListener("resize", updateMobileTopOffset);
+
+    const observer = new ResizeObserver(updateMobileTopOffset);
+    if (mobileTopBarRef.current) {
+      observer.observe(mobileTopBarRef.current);
+    }
+
+    return () => {
+      observer.disconnect();
+      window.removeEventListener("resize", updateMobileTopOffset);
+    };
+  }, []);
 
   const handleMouseEnter = () => {
     setCaptionIndex((prev) => (prev + 1) % WTF_CAPTIONS.length);
@@ -251,31 +274,43 @@ export default function Navigation() {
       >
         {/* Mobile: solid full-width bar */}
         <div
-          className={`lg:hidden bg-freed-black pl-8 pr-5 py-3 ${
+          ref={mobileTopBarRef}
+          className={`lg:hidden bg-freed-black pl-8 pr-4 py-3 ${
             mobileMenuOpen ? "" : "border-b border-freed-border"
           }`}
         >
           <div className="flex items-center justify-between">
             {logoElement}
-            <div className="flex items-center gap-4">
-              <motion.div
-                initial={false}
-                animate={{
-                  maxWidth: showMobileTopCta ? 144 : 0,
-                  opacity: showMobileTopCta ? 1 : 0,
-                  marginRight: showMobileTopCta ? 4 : 0,
-                }}
-                transition={{ duration: 0.24, ease: "easeInOut" }}
-                className="overflow-hidden"
-                style={{ pointerEvents: showMobileTopCta ? "auto" : "none" }}
-              >
-                <button
-                  onClick={openModal}
-                  className="btn-primary shrink-0 text-sm px-4 !py-1.5 whitespace-nowrap"
-                >
-                  Get Freed
-                </button>
-              </motion.div>
+            <div className="flex items-center gap-3">
+              <AnimatePresence initial={false}>
+                {showMobileTopCta && (
+                  <motion.div
+                    key="mobile-top-cta"
+                    initial={{ width: 0 }}
+                    animate={{ width: "auto" }}
+                    exit={{ width: 0 }}
+                    transition={{ duration: 0.2, ease: "easeInOut" }}
+                    className="overflow-hidden pr-4"
+                    style={{
+                      WebkitMaskImage:
+                        "linear-gradient(to right, black 0, black calc(100% - 18px), transparent 100%)",
+                      maskImage:
+                        "linear-gradient(to right, black 0, black calc(100% - 18px), transparent 100%)",
+                    }}
+                  >
+                    <motion.button
+                      onClick={openModal}
+                      initial={{ opacity: 0, x: 8 }}
+                      animate={{ opacity: 1, x: 0 }}
+                      exit={{ opacity: 0, x: 8 }}
+                      transition={{ duration: 0.2, ease: "easeInOut" }}
+                      className="btn-primary nav-mobile-cta my-0 shrink-0 whitespace-nowrap text-[0.765rem]"
+                    >
+                      Get Freed
+                    </motion.button>
+                  </motion.div>
+                )}
+              </AnimatePresence>
               {mobileHamburger}
             </div>
           </div>
@@ -306,7 +341,7 @@ export default function Navigation() {
               className="lg:hidden fixed left-0 right-0 bottom-0 bg-freed-black z-40"
               style={{
                 // Overlap navbar by 1px to eliminate sub-pixel rendering gaps
-                top: "calc(64px + env(safe-area-inset-top))",
+                top: `calc(${Math.max(0, mobileMenuTopOffset - 1)}px + env(safe-area-inset-top))`,
                 paddingBottom: "env(safe-area-inset-bottom)",
               }}
             >
@@ -321,7 +356,7 @@ export default function Navigation() {
                     <Link
                       href={item.path}
                       onClick={() => setMobileMenuOpen(false)}
-                      className={`text-lg font-medium transition-colors ${
+                      className={`text-[1.238rem] font-medium transition-colors ${
                         isActive(item.path, pathname)
                           ? "text-text-primary underline underline-offset-8 decoration-2"
                           : "text-text-secondary"
@@ -339,7 +374,7 @@ export default function Navigation() {
                   href="https://github.com/freed-project/freed"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="text-lg font-medium text-text-secondary"
+                  className="text-[1.238rem] font-medium text-text-secondary"
                 >
                   GitHub
                 </motion.a>
@@ -351,7 +386,7 @@ export default function Navigation() {
                     openModal();
                     setMobileMenuOpen(false);
                   }}
-                  className="btn-primary text-lg px-12 py-4 mt-4"
+                  className="btn-primary text-[1.0125rem] px-12 py-4 mt-4"
                 >
                   Get Freed
                 </motion.button>

--- a/website/src/components/NewsletterModal.tsx
+++ b/website/src/components/NewsletterModal.tsx
@@ -168,9 +168,11 @@ export default function NewsletterModal() {
     top: number;
     left: number;
     width: number;
+    openUpward: boolean;
   } | null>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const dropdownMenuRef = useRef<HTMLUListElement>(null);
+  const modalPanelRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     setSelectedTarget(detectDefaultInstallTarget());
@@ -181,6 +183,26 @@ export default function NewsletterModal() {
     setDetailsOpen(false);
     setTurnstileToken("");
     setTurnstileResetKey((current) => current + 1);
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const body = document.body;
+    const root = document.documentElement;
+    const previousBodyOverflow = body.style.overflow;
+    const previousRootOverflow = root.style.overflow;
+    const previousBodyTouchAction = body.style.touchAction;
+
+    body.style.overflow = "hidden";
+    root.style.overflow = "hidden";
+    body.style.touchAction = "none";
+
+    return () => {
+      body.style.overflow = previousBodyOverflow;
+      root.style.overflow = previousRootOverflow;
+      body.style.touchAction = previousBodyTouchAction;
+    };
   }, [isOpen]);
 
   useEffect(() => {
@@ -210,10 +232,34 @@ export default function NewsletterModal() {
     const updateDropdownPosition = () => {
       const rect = dropdownRef.current?.getBoundingClientRect();
       if (!rect) return;
+
+      const menuHeight =
+        dropdownMenuRef.current?.getBoundingClientRect().height || 0;
+      const viewportHeight = window.visualViewport?.height ?? window.innerHeight;
+      const viewportWidth = window.visualViewport?.width ?? window.innerWidth;
+      const fallbackMenuHeight = 240;
+      const effectiveMenuHeight = menuHeight || fallbackMenuHeight;
+      const availableTop = 8;
+      const availableBottom = viewportHeight - 8;
+      const downSpace = availableBottom - rect.bottom - 6;
+      const upSpace = rect.top - availableTop - 6;
+      const canOpenDown = downSpace >= effectiveMenuHeight;
+      const canOpenUp = upSpace >= effectiveMenuHeight;
+      const openUpward = !canOpenDown && canOpenUp;
+      const unclampedTop = openUpward
+        ? rect.top - effectiveMenuHeight - 6
+        : rect.bottom + 6;
+      const maxTop = availableBottom - effectiveMenuHeight;
+      const minTop = availableTop;
+      const top = Math.max(minTop, Math.min(unclampedTop, maxTop));
+      const maxLeft = Math.max(8, viewportWidth - rect.width - 8);
+      const left = Math.max(8, Math.min(rect.left, maxLeft));
+
       setDropdownMenuStyle({
-        top: rect.bottom + 6,
-        left: rect.left,
-        width: rect.width,
+        top,
+        left,
+        width: Math.min(rect.width, viewportWidth - 16),
+        openUpward,
       });
     };
 
@@ -323,7 +369,7 @@ export default function NewsletterModal() {
     [company, detailsOpen, email, name, phoneNumber, state, turnstileToken],
   );
 
-  const handleClose = () => {
+  const handleClose = useCallback(() => {
     if (state !== "loading") {
       setState("idle");
       setErrorMessage("");
@@ -337,7 +383,22 @@ export default function NewsletterModal() {
       setTurnstileResetKey((current) => current + 1);
     }
     closeModal();
-  };
+  }, [closeModal, state]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        handleClose();
+      }
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+    };
+  }, [handleClose, isOpen]);
 
   const currentDownload =
     selectedTarget === "web" ? null : DOWNLOADS[selectedTarget];
@@ -377,7 +438,26 @@ export default function NewsletterModal() {
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
-            onClick={handleClose}
+            onPointerDown={(event) => {
+              const target = event.target as Node | null;
+              const panel = modalPanelRef.current;
+
+              if (panel && target && panel.contains(target)) {
+                return;
+              }
+
+              handleClose();
+            }}
+            onTouchStart={(event) => {
+              const target = event.target as Node | null;
+              const panel = modalPanelRef.current;
+
+              if (panel && target && panel.contains(target)) {
+                return;
+              }
+
+              handleClose();
+            }}
             className="theme-elevated-overlay fixed inset-0 z-50 backdrop-blur-sm"
           />
 
@@ -389,13 +469,28 @@ export default function NewsletterModal() {
             animate={{ opacity: 1, scale: 1, y: 0 }}
             exit={{ opacity: 0, scale: 0.95, y: 20 }}
             transition={{ type: "spring", duration: 0.5 }}
-            className="fixed inset-0 z-50 flex items-start justify-center px-4 pt-4 sm:items-center sm:py-6"
+            className="fixed inset-0 z-50 flex items-center justify-center px-4 pt-4 sm:items-center sm:py-6"
             style={{
               paddingTop: "calc(env(safe-area-inset-top) + 1rem)",
               paddingBottom: "calc(env(safe-area-inset-bottom) + 1rem)",
             }}
+            onPointerDown={(event) => {
+              const target = event.target as Node | null;
+              const panel = modalPanelRef.current;
+              if (panel && target && panel.contains(target)) return;
+              handleClose();
+            }}
+            onTouchStart={(event) => {
+              const target = event.target as Node | null;
+              const panel = modalPanelRef.current;
+              if (panel && target && panel.contains(target)) return;
+              handleClose();
+            }}
           >
-            <div className="theme-panel relative w-full max-w-5xl overflow-hidden rounded-2xl">
+            <div
+              ref={modalPanelRef}
+              className="newsletter-modal theme-panel relative w-full max-w-5xl overflow-hidden rounded-2xl"
+            >
               <div
                 className="absolute top-0 left-1/4 h-32 w-32 rounded-full blur-3xl"
                 style={{
@@ -412,11 +507,15 @@ export default function NewsletterModal() {
               />
 
               <button
+                type="button"
+                aria-label="Close"
                 onClick={handleClose}
-                className="absolute top-5 right-5 text-text-muted hover:text-text-primary transition-colors"
+                onPointerDown={(event) => event.stopPropagation()}
+                onTouchStart={(event) => event.stopPropagation()}
+                className="absolute top-5 right-5 z-30 inline-flex h-11 w-11 cursor-pointer items-center justify-center rounded-full bg-[color-mix(in srgb,var(--theme-bg-card) 86%,transparent)] p-0 text-text-muted transition-colors hover:text-text-primary"
               >
                 <svg
-                  className="w-6 h-6"
+                  className="h-6 w-6"
                   fill="none"
                   viewBox="0 0 24 24"
                   stroke="currentColor"
@@ -431,7 +530,7 @@ export default function NewsletterModal() {
               </button>
 
               <div
-                className="relative z-10 overflow-y-auto px-6 py-6 sm:px-10 sm:py-10 md:px-12 md:py-12"
+                className="relative z-10 overflow-y-auto px-6 pt-6 pb-8 sm:px-10 sm:pt-10 sm:pb-12 md:px-12 md:pt-12 md:pb-14"
                 style={{
                   maxHeight:
                     "calc(100dvh - env(safe-area-inset-top) - env(safe-area-inset-bottom) - 2rem)",
@@ -525,7 +624,7 @@ export default function NewsletterModal() {
                                 <motion.button
                                   type="submit"
                                   disabled={state === "loading"}
-                                  className="btn-primary flex min-w-[8.5rem] shrink-0 items-center justify-center gap-2 px-5 py-2.5 text-sm whitespace-nowrap disabled:cursor-not-allowed disabled:opacity-70"
+                                  className="btn-primary flex min-w-[8.5rem] shrink-0 items-center justify-center gap-2 px-5 py-2.5 text-sm whitespace-nowrap hover:!scale-100 active:!scale-100 disabled:cursor-not-allowed disabled:opacity-70"
                                 >
                                   Continue
                                 </motion.button>
@@ -632,7 +731,7 @@ export default function NewsletterModal() {
                                   <motion.button
                                     type="submit"
                                     disabled={state === "loading"}
-                                    className="btn-primary flex min-w-[12rem] items-center justify-center gap-2 px-5 py-2.5 text-sm whitespace-nowrap disabled:cursor-not-allowed disabled:opacity-70"
+                                    className="btn-primary flex min-w-[12rem] items-center justify-center gap-2 px-5 py-2.5 text-sm whitespace-nowrap hover:!scale-100 active:!scale-100 disabled:cursor-not-allowed disabled:opacity-70"
                                   >
                                     {state === "loading" ? (
                                       <>
@@ -694,29 +793,19 @@ export default function NewsletterModal() {
 
                         <div className="relative" ref={dropdownRef}>
                           <div
-                            className="get-freed-launch-cta flex items-center rounded-xl border transition-all hover:border-[color:var(--theme-border-strong)]"
-                            style={{
-                              borderColor: "var(--theme-border-subtle)",
-                              background:
-                                "color-mix(in srgb, var(--theme-bg-surface) 62%, transparent)",
-                            }}
+                            className="newsletter-modal-download-cta btn-primary get-freed-launch-cta flex items-center rounded-xl !p-0 hover:!scale-100 active:!scale-100"
                           >
                             <button
                               type="button"
                               onClick={handlePrimaryAction}
                               data-testid="website-primary-action"
-                              className="get-freed-launch-cta__primary group flex min-w-0 flex-1 items-center gap-4 p-4"
+                              className="get-freed-launch-cta__primary group flex min-w-0 flex-1 items-center gap-4 p-4 text-left cursor-pointer"
                             >
                               <div
-                                className="get-freed-launch-cta__icon flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border"
-                                style={{
-                                  background:
-                                    "color-mix(in srgb, var(--theme-bg-surface) 88%, transparent)",
-                                  borderColor: "var(--theme-border-subtle)",
-                                }}
+                                className="get-freed-launch-cta__icon flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-white/15 bg-white/12"
                               >
                                 <svg
-                                  className="w-5 h-5 text-text-secondary"
+                                  className="w-5 h-5 text-white"
                                   fill="none"
                                   viewBox="0 0 24 24"
                                   stroke="currentColor"
@@ -734,12 +823,12 @@ export default function NewsletterModal() {
                                 </svg>
                               </div>
                               <div className="flex-1 min-w-0 text-left">
-                                <p className="get-freed-launch-cta__title text-sm font-semibold text-text-primary transition-colors group-hover:text-text-primary">
+                                <p className="get-freed-launch-cta__title text-sm font-semibold text-white transition-colors group-hover:text-white">
                                   {isWebTarget
                                     ? "Launch Freed Web"
                                     : `Download for ${selectedTargetLabel}`}
                                 </p>
-                                <p className="get-freed-launch-cta__subtitle text-xs text-text-muted">
+                                <p className="get-freed-launch-cta__subtitle text-xs text-white/80">
                                   {isWebTarget
                                     ? "Open the mobile reader instantly in your browser"
                                     : "Runs in background to subscribe and monitor"}
@@ -747,9 +836,10 @@ export default function NewsletterModal() {
                               </div>
                             </button>
                             <button
+                              type="button"
                               onClick={() => setDropdownOpen((o) => !o)}
                               aria-label="Choose a different platform"
-                              className="get-freed-launch-cta__toggle shrink-0 self-stretch border-l border-freed-border px-3 text-text-muted transition-colors hover:text-text-primary"
+                              className="get-freed-launch-cta__toggle shrink-0 self-stretch border-l border-white/15 px-4 text-white/90 transition-colors hover:bg-white/10 hover:text-white cursor-pointer"
                             >
                               <svg
                                 className={`w-4 h-4 transition-transform ${dropdownOpen ? "rotate-180" : ""}`}
@@ -784,7 +874,7 @@ export default function NewsletterModal() {
                               type="button"
                               onClick={handleOpenFreedWeb}
                               data-testid="website-open-web-app"
-                              className="inline-flex items-center gap-2 rounded-lg bg-transparent px-2 py-1.5 text-sm text-text-muted underline decoration-current underline-offset-4 transition-colors hover:bg-[rgb(var(--theme-control-accent-rgb)/0.08)] hover:text-text-primary"
+                              className="flex w-full cursor-pointer items-center justify-start gap-2 rounded-lg bg-transparent px-3 py-2.5 text-left text-sm text-text-muted underline decoration-current underline-offset-4 transition-colors hover:bg-[rgb(var(--theme-control-accent-rgb)/0.08)] hover:text-text-primary hover:no-underline"
                             >
                               <svg
                                 aria-hidden="true"
@@ -800,7 +890,7 @@ export default function NewsletterModal() {
                                   d="M9 6l6 6-6 6M14 6l6 6-6 6"
                                 />
                               </svg>
-                              <span>Already running Freed Desktop? Launch Freed Web.</span>
+                              <span>Already running Freed Desktop? Launch Freed Web here.</span>
                             </button>
                           )}
                         </div>
@@ -817,9 +907,15 @@ export default function NewsletterModal() {
               <AnimatePresence>
                 <motion.ul
                   ref={dropdownMenuRef}
-                  initial={{ opacity: 0, y: -4 }}
+                  initial={{
+                    opacity: 0,
+                    y: dropdownMenuStyle?.openUpward ? 4 : -4,
+                  }}
                   animate={{ opacity: 1, y: 0 }}
-                  exit={{ opacity: 0, y: -4 }}
+                  exit={{
+                    opacity: 0,
+                    y: dropdownMenuStyle?.openUpward ? 4 : -4,
+                  }}
                   transition={{ duration: 0.15 }}
                   className="fixed z-[70] overflow-hidden rounded-xl border shadow-lg"
                   style={{


### PR DESCRIPTION
(AI Generated).

## Summary

This PR rolls up the full UI polish and desktop interaction work from this thread into one draft branch.

## Included work

### Marketing site

- polished the mobile navbar Get Freed CTA sizing, spacing, copy, width, and transition behavior
- added fade and slide behavior to the mobile CTA and softened the right-edge clipping with a mask
- removed the stray lower-edge shadow from the mobile navbar CTA
- fixed the mobile menu gap above the expanded section
- aligned the CTA timing with the hamburger interaction timing
- fixed the Get Freed modal close behavior on mobile
- added close on outside click and Escape for the Get Freed modal
- locked page scroll behind the Get Freed modal
- kept the modal vertically centered on mobile when it fits in the viewport
- fixed the download dropdown so it opens upward when near the bottom edge
- made popup and menu surfaces fully opaque across themes
- updated the modal CTA hierarchy, hover behavior, padding, and inline success flow
- kept feature card icons and headings on one line across breakpoints and increased desktop heading presence slightly
- removed the How It Works connector dots once the layout wraps into multiple rows

### Desktop shell and sidebar

- fixed the left sidebar width snapping back after drag release
- fixed the right debug drawer width snapping back after drag release
- kept sidebar provider status indicators visible without hover
- aligned the feeds source row so it uses full width with counts and status on the right edge

### Desktop settings

- deepened the settings modal shadow while keeping theme preview visible
- restored proper desktop settings switch styling
- replaced the old appearance theme card grid with a single compact Theme row
- merged the reading controls into Appearance and removed the separate Reading section
- swapped the Appearance icon to the book icon from the old Reading section
- restored the Google Contacts settings icon
- fixed provider settings modal flicker caused by section remounts during health updates

### Desktop reading and keyboard navigation

- kept one full feed row visible past the focused item during keyboard navigation in list mode
- added Arrow Up and Arrow Down cycling inside dual-column reader mode when the left rail is visible
- kept one full compact tile visible past the selected tile in the dual-column rail
- animated feed cards into and out of the dual-column reader rail with shared view transitions when supported

## Validation

- `PATH="/Users/aubreyfalconer/dev/freed-thread-polish/node_modules/.bin:$PATH" npm --prefix website run lint`
- `npx tsc -p /Users/aubreyfalconer/dev/freed-thread-polish/packages/ui/tsconfig.json --noEmit`
- `PATH="$(pwd)/node_modules/.bin:$PATH" npm --prefix packages/desktop run test:e2e -- provider-health.spec.ts`
- `PATH="$(pwd)/node_modules/.bin:$PATH" npm --prefix packages/desktop run test:e2e -- smoke.spec.ts -g "resize holds the dragged width after mouseup"`
- `PATH="$(pwd)/node_modules/.bin:$PATH" npm --prefix packages/desktop run test:e2e -- smoke.spec.ts -g "keyboard focus scrolling keeps a full row visible past the focused item"`
- `PATH="$(pwd)/node_modules/.bin:$PATH" npm --prefix packages/desktop run test:e2e -- smoke.spec.ts -g "dual-column reader arrow navigation cycles tiles and keeps the next tile visible"`
- `PATH="$(pwd)/node_modules/.bin:$PATH" npm --prefix packages/desktop run test:e2e -- smoke.spec.ts -g "provider settings do not remount when health updates arrive|settings nav highlight follows scroll position"`
- `PATH="$(pwd)/node_modules/.bin:$PATH" npm --prefix packages/desktop run test:e2e -- smoke.spec.ts -g "dual-column reader arrow navigation cycles tiles and keeps the next tile visible|dual-column reader toggles use shared view transitions when supported"`
- `PATH="$(pwd)/node_modules/.bin:$PATH" npm --prefix packages/desktop run test:e2e -- theme-switching.spec.ts`

## Notes

This PR is still a draft because it collects a long sequence of thread-sized fixes and refinements on one branch, even though each implementation slice has its own commit.
