### PR TITLE
fix: improve Scriptorium body font legibility

### DIFF
--- a/packages/shared/src/themes.ts
+++ b/packages/shared/src/themes.ts
@@ -213,7 +213,7 @@ export const THEME_DEFINITIONS: readonly ThemeDefinition[] = [
       "A low-blue-light editorial theme for long reading sessions. Vellum, walnut, and quietly dignified typography.",
     previewGradient: "linear-gradient(135deg, #f4ead7, #d8c4a1 55%, #86684a)",
     previewDisplayFont: '"Baskerville", "Hoefler Text", "Iowan Old Style", "Palatino Linotype", Georgia, serif',
-    previewBodyFont: '"Baskerville", "Iowan Old Style", "Palatino Linotype", "Book Antiqua", Georgia, serif',
+    previewBodyFont: '"Manrope", "Avenir Next", "Segoe UI", "Helvetica Neue", Arial, sans-serif',
     surface: "light",
     effects: "restrained",
     background: {

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -392,8 +392,7 @@ html[data-theme="ember"] {
 
 html[data-theme="scriptorium"] {
   --font-body:
-    "Baskerville", "Iowan Old Style", "Palatino Linotype", "Book Antiqua",
-    Georgia, serif;
+    "Manrope", "Avenir Next", "Segoe UI", "Helvetica Neue", Arial, sans-serif;
   --font-logo: "Baskerville", "Hoefler Text", "Iowan Old Style", Georgia, serif;
   --font-display:
     "Baskerville", "Hoefler Text", "Iowan Old Style", "Palatino Linotype",


### PR DESCRIPTION
(AI Generated).

## Summary
- switch Scriptorium body text to a more legible sans serif stack while keeping the existing display and logo fonts
- update the theme preview metadata so the picker matches the live UI

## Why
The Scriptorium body font was using a serif stack that looked elegant in headings but was hard to read in dense UI copy, form labels, and settings content.

## Impact
Body copy in Scriptorium should be easier to scan without changing the theme's title, sidebar, or logo styling.

## Validation
- `git diff --check`
- attempted `packages/desktop` Playwright theme verification, but this worktree was missing usable root `node_modules` because the worktree setup script installed dependencies into a different worktree
