### PR TITLE
fix: label macOS Activity Monitor web process as Freed

### DIFF
--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -1288,7 +1288,7 @@ dependencies = [
 
 [[package]]
 name = "freed-desktop"
-version = "26.4.108"
+version = "26.4.1300"
 dependencies = [
  "base64 0.22.1",
  "criterion",
@@ -1297,6 +1297,9 @@ dependencies = [
  "local-ip-address",
  "log",
  "mdns-sd",
+ "objc2",
+ "objc2-foundation",
+ "objc2-web-kit",
  "rand 0.8.5",
  "reqwest",
  "rquest",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -38,6 +38,11 @@ rand = "0.8"
 base64 = "0.22"
 url = "2"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2 = "0.6"
+objc2-foundation = { version = "0.3", default-features = false, features = ["std", "NSString", "NSKeyValueCoding", "NSObject", "NSThread"] }
+objc2-web-kit = { version = "0.3", features = ["WKWebViewConfiguration"] }
+
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
 tempfile = "3"

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -25,6 +25,12 @@ use tokio_tungstenite::{
 };
 
 #[cfg(target_os = "macos")]
+use objc2::rc::Retained;
+#[cfg(target_os = "macos")]
+use objc2_foundation::{ns_string, MainThreadMarker, NSObjectNSKeyValueCoding, NSString};
+#[cfg(target_os = "macos")]
+use objc2_web_kit::WKWebViewConfiguration;
+#[cfg(target_os = "macos")]
 use window_vibrancy::{apply_vibrancy, NSVisualEffectMaterial};
 
 const DEFAULT_SYNC_RELAY_PORT: u16 = 8765;
@@ -3051,6 +3057,47 @@ async fn start_sync_relay(state: RelayState, app: tauri::AppHandle) {
 // App entry point
 // ---------------------------------------------------------------------------
 
+#[cfg(target_os = "macos")]
+fn main_window_webview_configuration() -> Retained<WKWebViewConfiguration> {
+    let mtm = MainThreadMarker::new()
+        .expect("WKWebView configuration must be created on the main thread");
+    let config = unsafe { WKWebViewConfiguration::new(mtm) };
+    let display_name = NSString::from_str("Freed");
+
+    // Label the WebKit content process as "Freed" in Activity Monitor instead
+    // of leaving the default custom protocol URL visible.
+    unsafe {
+        config.setValue_forKey(
+            Some(display_name.as_ref()),
+            ns_string!("processDisplayName"),
+        );
+    }
+
+    config
+}
+
+fn create_main_window(app: &tauri::App) -> Result<tauri::WebviewWindow, tauri::Error> {
+    if let Some(window) = app.get_webview_window("main") {
+        return Ok(window);
+    }
+
+    let window_config = app
+        .config()
+        .app
+        .windows
+        .iter()
+        .find(|config| config.label == "main")
+        .expect("missing main window config")
+        .clone();
+
+    let builder = tauri::WebviewWindowBuilder::from_config(app, &window_config)?;
+
+    #[cfg(target_os = "macos")]
+    let builder = builder.with_webview_configuration(main_window_webview_configuration());
+
+    builder.build()
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     // When built with --features perf, initialise a JSON tracing subscriber so
@@ -3107,7 +3154,7 @@ pub fn run() {
         .manage(relay_state)
         .manage(CaptureState::new())
         .setup(move |app| {
-            let window = app.get_webview_window("main").unwrap();
+            let window = create_main_window(app)?;
 
             #[cfg(target_os = "macos")]
             apply_vibrancy(

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -13,6 +13,7 @@
     "withGlobalTauri": true,
     "windows": [
       {
+        "create": false,
         "title": "Freed",
         "width": 1200,
         "height": 800,


### PR DESCRIPTION
(AI Generated).

## What changed

- moved the main desktop window to manual creation on startup so macOS can attach a custom `WKWebViewConfiguration` before the web content process launches
- set WebKit's private `processDisplayName` to `Freed` for the main desktop webview
- kept the existing window config intact by reusing the `main` window definition from `tauri.conf.json`

## Why

macOS Activity Monitor was showing the WebKit content process as `tauri://localhost` instead of `Freed`. The existing Tauri config already set the bundle and window title correctly, but that does not control the WebKit child process label. The private `processDisplayName` hook has to be applied before the webview is created.

## Impact

- macOS Activity Monitor should show the Freed web content process as `Freed`
- no behavior change is intended for Windows or Linux
- desktop startup still uses the same `main` window config and existing vibrancy setup

## Validation

- `~/.nvm/versions/node/v24.14.1/bin/npm run build` in `packages/desktop`
- `cargo check --manifest-path packages/desktop/src-tauri/Cargo.toml`
