### PR TITLE
fix: raise update dialogs above floating new button

### DIFF
--- a/packages/desktop/src/components/UpdateNotification.tsx
+++ b/packages/desktop/src/components/UpdateNotification.tsx
@@ -27,7 +27,7 @@ export function UpdateNotification({
   if (state.phase === "idle") return null;
 
   return (
-    <div className="fixed bottom-4 right-4 z-50 max-w-sm animate-slide-up">
+    <div className="fixed bottom-4 right-4 z-[120] max-w-sm animate-slide-up">
       <div className="rounded-2xl bg-[var(--freed-surface)] p-4 shadow-lg border border-[rgba(139,92,246,0.3)]">
         <div className="flex items-start gap-3">
           <div className="shrink-0 mt-0.5">

--- a/packages/pwa/src/App.tsx
+++ b/packages/pwa/src/App.tsx
@@ -264,7 +264,7 @@ function App() {
         </AppShell>
         <ToastContainer />
         {showUpdateBanner && (
-          <div className="fixed bottom-4 right-4 z-50 max-w-sm animate-slide-up">
+          <div className="fixed bottom-4 right-4 z-[120] max-w-sm animate-slide-up">
             <div className="theme-panel flex items-center gap-3 rounded-xl p-4">
               <div className="flex-1 min-w-0">
                 <p className="text-sm font-medium text-[var(--theme-text-primary)]">New version available</p>


### PR DESCRIPTION
(AI Generated).

## Summary
- raise the desktop update notification above the floating New button
- raise the PWA update banner above the floating New button

## Validation
- `node ./node_modules/typescript/bin/tsc -p packages/desktop/tsconfig.json --noEmit`
- `PATH="$(pwd)/node_modules/.bin:$PATH" npm --prefix packages/pwa run build`
