### PR TITLE
fix: tighten Vercel git deployment routing

### DIFF
--- a/docs/PHASE-1-FOUNDATION.md
+++ b/docs/PHASE-1-FOUNDATION.md
@@ -235,8 +235,9 @@ Manual preview deploys for this monorepo now go through `./scripts/vercel-deploy
 
 The website and PWA preview workflows use the helpers directly so PRs only
 build the surface they target. Native Vercel preview deploys should stay
-disabled where GitHub Actions owns preview deployment, otherwise a single PR
-can spend minutes in both systems for the same preview.
+disabled where GitHub Actions owns preview deployment. The website Vercel
+project only allows Git-triggered deploys from `www`, and the PWA project
+disables Git-triggered deploys entirely.
 
 The preview and production deploy helpers now resolve `npm` and `npx` from the
 active Node toolchain first, so they do not accidentally pick up an older

--- a/docs/RELEASE-SECRETS.md
+++ b/docs/RELEASE-SECRETS.md
@@ -77,8 +77,9 @@ Marketing preview routing:
 - PRs targeting `www` build and deploy website previews
 - PRs targeting `dev` build and deploy PWA previews
 - Desktop Playwright E2E runs for product PRs targeting `dev`
-- Native Vercel preview deploys should stay disabled where GitHub Actions owns
-  preview deployment
+- `website/vercel.json` only allows Git-triggered Vercel deploys from `www`
+- `packages/pwa/vercel.json` disables Git-triggered Vercel deploys entirely
+- GitHub Actions owns website and PWA previews through the deploy helpers
 
 ## Website GitHub release token
 

--- a/packages/pwa/vercel.json
+++ b/packages/pwa/vercel.json
@@ -2,6 +2,9 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "vite",
   "buildCommand": "cd ../.. && npm run build -w @freed/pwa",
+  "git": {
+    "deploymentEnabled": false
+  },
   "outputDirectory": "dist",
   "rewrites": [{ "source": "/((?!api/).*)", "destination": "/index.html" }]
 }

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -3,8 +3,8 @@
   "framework": "nextjs",
   "git": {
     "deploymentEnabled": {
-      "dev": false,
-      "main": false
+      "*": false,
+      "www": true
     }
   },
   "outputDirectory": ".next"


### PR DESCRIPTION
(AI Generated).

Tighten Vercel Git deployment routing after the explicit www release flow landed.

Changes:
- Allow website Git-triggered deployments only from www.
- Disable PWA Git-triggered deployments so GitHub Actions and release workflows own PWA preview and production deploys.
- Document the exact routing in release and foundation docs.

Verification:
- Parsed website and PWA vercel.json files with Node.
- Ran git diff --check.