### PR TITLE
fix: reduce desktop sync memory growth

### DIFF
--- a/.agents/skills/freed-build-feature/SKILL.md
+++ b/.agents/skills/freed-build-feature/SKILL.md
@@ -6,19 +6,23 @@ disable-model-invocation: true
 
 # Build Feature
 
-Create a product worktree branch from `dev`, implement the feature or fix, verify it, and launch the relevant preview.
+Create a product worktree branch from the latest remote `dev`, implement the feature or fix, verify it, and launch the relevant preview.
 
 ## Workflow
 
 1. Confirm the work is product work targeting `dev`.
 2. Reject or reroute public marketing work targeting `www`; use `freed-build-www` instead.
-3. Create a new worktree branch from `dev` using `./scripts/worktree-add.sh`.
-4. Implement the requested change.
-5. Verify with focused tests, then broader checks when shared behavior changed.
-6. Launch the relevant preview:
+3. Fetch the latest remote refs first with `git fetch --all --prune`.
+4. Check both `origin/dev` and `origin/main` before branching.
+   - Confirm whether local `dev` or `main` are behind their remote counterparts.
+   - If `origin/main` contains commits that are not in `origin/dev`, call that out before continuing so the user can decide whether `dev` needs to be refreshed first.
+5. Create a new worktree branch from `origin/dev` using `./scripts/worktree-add.sh ../freed-<slug> -b <branch> origin/dev`.
+6. Implement the requested change.
+7. Verify with focused tests, then broader checks when shared behavior changed.
+8. Launch the relevant preview:
    - For PWA work, deploy or run the PWA preview.
    - For desktop work, use the desktop E2E test harness or Tauri preview as appropriate.
-7. Open a PR targeting `dev` when the work is ready.
+9. Open a PR targeting `dev` when the work is ready.
 
 ## Scope
 

--- a/packages/desktop/src/lib/content-fetcher.test.ts
+++ b/packages/desktop/src/lib/content-fetcher.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { FeedItem } from "@freed/shared";
+import { MAX_SYNCED_PRESERVED_TEXT_CHARS } from "./preserved-text.js";
+
+const SAMPLE_URL = "https://example.com/articles/memory-landfill";
+const SAMPLE_HTML = "<html><body><article><p>Expanded article HTML.</p></article></body></html>";
+const SAMPLE_ARTICLE_HTML = "<article><p>Expanded article HTML.</p></article>";
+const LONG_TEXT =
+  `${"Paragraph with   noisy spacing and plenty of detail. ".repeat(160)}Tail text that should be trimmed away.`;
+
+function makeStubItem(): FeedItem {
+  return {
+    globalId: "rss:1",
+    platform: "rss",
+    contentType: "article",
+    capturedAt: 1,
+    publishedAt: 1,
+    author: {
+      id: "author-1",
+      handle: "author",
+      displayName: "Author",
+    },
+    content: {
+      text: "Short description",
+      mediaUrls: [],
+      mediaTypes: [],
+      linkPreview: {
+        url: SAMPLE_URL,
+        title: "Article title",
+        description: "Short description",
+      },
+    },
+    rssSource: {
+      feedUrl: "https://example.com/feed.xml",
+      feedTitle: "Example Feed",
+      siteUrl: "https://example.com",
+    },
+    userState: {
+      hidden: false,
+      saved: false,
+      archived: false,
+      tags: [],
+    },
+    topics: [],
+  };
+}
+
+async function loadContentFetcherModule() {
+  vi.resetModules();
+
+  const mockInvoke = vi.fn(async () => SAMPLE_HTML);
+  const mockExtractContent = vi.fn(() => ({
+    html: SAMPLE_ARTICLE_HTML,
+    text: LONG_TEXT,
+    author: "Content Author",
+    wordCount: 900,
+    readingTime: 4,
+  }));
+  const mockExtractMetadata = vi.fn(() => ({
+    author: "Metadata Author",
+    publishedAt: 1_700_000_000_000,
+  }));
+  const mockCacheSet = vi.fn(async () => undefined);
+  const mockDocUpdateFeedItem = vi.fn(async () => undefined);
+  const mockSubscribe = vi.fn<(cb: (state: { items: FeedItem[]; docItemCount: number }) => void) => () => void>();
+  const subscriberRef: {
+    current: ((state: { items: FeedItem[]; docItemCount: number }) => void) | null;
+  } = { current: null };
+  mockSubscribe.mockImplementation((cb) => {
+    subscriberRef.current = cb;
+    return () => {
+      subscriberRef.current = null;
+    };
+  });
+
+  vi.doMock("@tauri-apps/api/core", () => ({ invoke: mockInvoke }));
+  vi.doMock("@freed/capture-save/browser", () => ({
+    extractContentBrowser: mockExtractContent,
+    extractMetadataBrowser: mockExtractMetadata,
+  }));
+  vi.doMock("./content-cache.js", () => ({
+    contentCache: { set: mockCacheSet },
+  }));
+  vi.doMock("./automerge.js", () => ({
+    docUpdateFeedItem: mockDocUpdateFeedItem,
+    subscribe: mockSubscribe,
+  }));
+  vi.doMock("./store.js", () => ({
+    useAppStore: {
+      getState: () => ({
+        preferences: {
+          ai: {
+            autoSummarize: false,
+            provider: "none",
+          },
+        },
+      }),
+    },
+  }));
+  vi.doMock("./ai-summarizer.js", () => ({
+    summarize: vi.fn(async () => null),
+  }));
+  vi.doMock("./secure-storage.js", () => ({
+    secureStorage: {
+      getApiKey: vi.fn(async () => null),
+    },
+  }));
+  vi.doMock("@freed/ui/lib/debug-store", () => ({
+    addDebugEvent: vi.fn(),
+  }));
+  vi.doMock("./logger.js", () => ({
+    log: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+  }));
+
+  const mod = await import("./content-fetcher.js");
+  return {
+    mod,
+    subscriberRef,
+    mockCacheSet,
+    mockDocUpdateFeedItem,
+  };
+}
+
+afterEach(() => {
+  vi.clearAllTimers();
+  vi.useRealTimers();
+  vi.clearAllMocks();
+  vi.resetModules();
+});
+
+describe("content fetcher", () => {
+  it("keeps full HTML in the local cache but syncs only a compact excerpt", async () => {
+    vi.useFakeTimers();
+    const { mod, subscriberRef, mockCacheSet, mockDocUpdateFeedItem } = await loadContentFetcherModule();
+
+    mod.start();
+    subscriberRef.current?.({ items: [makeStubItem()], docItemCount: 1 });
+    await vi.advanceTimersByTimeAsync(2_000);
+    mod.stop();
+
+    expect(mockCacheSet).toHaveBeenCalledWith("rss:1", SAMPLE_ARTICLE_HTML);
+    expect(mockDocUpdateFeedItem).toHaveBeenCalledOnce();
+
+    const update = mockDocUpdateFeedItem.mock.calls.at(0)?.at(1) as unknown as
+      | { preservedContent: { text: string; author?: string } }
+      | undefined;
+    expect(update).toBeDefined();
+    const preservedContent = update!.preservedContent;
+    expect(preservedContent.text.length).toBeLessThanOrEqual(MAX_SYNCED_PRESERVED_TEXT_CHARS);
+    expect(preservedContent.text).not.toContain("  ");
+    expect(preservedContent.text).not.toContain("Tail text that should be trimmed away.");
+    expect(preservedContent.author).toBe("Content Author");
+  });
+});

--- a/packages/desktop/src/lib/content-fetcher.ts
+++ b/packages/desktop/src/lib/content-fetcher.ts
@@ -28,6 +28,7 @@ import { summarize } from "./ai-summarizer.js";
 import { secureStorage } from "./secure-storage.js";
 import { addDebugEvent } from "@freed/ui/lib/debug-store";
 import { log } from "./logger.js";
+import { toSyncedPreservedText } from "./preserved-text.js";
 
 const FETCH_TIMEOUT_MS = 30_000;
 const HEARTBEAT_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
@@ -165,7 +166,9 @@ async function processNext(): Promise<void> {
     // Get current AI preferences from the store (worker keeps preferences in sync)
     const prefs = (useAppStore.getState().preferences as { ai?: AIPreferences })?.ai;
 
-    let summaryText = content.text;
+    // Keep the synced document small. Full article HTML already lives in the
+    // device-local cache, so Automerge only needs a compact fallback excerpt.
+    let summaryText = toSyncedPreservedText(content.text);
     let extraTopics: string[] = [];
 
     // Optionally run AI summarization (replaces raw text in Automerge with a concise summary)
@@ -175,7 +178,7 @@ async function processNext(): Promise<void> {
         : null;
       const aiResult = await summarize(content.text, prefs, apiKey);
       if (aiResult) {
-        summaryText = aiResult.summary;
+        summaryText = toSyncedPreservedText(aiResult.summary);
         extraTopics = aiResult.topics;
       }
     }
@@ -186,7 +189,7 @@ async function processNext(): Promise<void> {
     const resolvedAuthor = content.author ?? metadata.author;
     await docUpdateFeedItem(entry.globalId, {
       preservedContent: {
-        text: summaryText.slice(0, 10_000),
+        text: summaryText,
         ...(resolvedAuthor !== undefined ? { author: resolvedAuthor } : {}),
         publishedAt: metadata.publishedAt,
         wordCount: content.wordCount,

--- a/packages/desktop/src/lib/preserved-text.ts
+++ b/packages/desktop/src/lib/preserved-text.ts
@@ -1,0 +1,31 @@
+const MAX_SYNCED_PRESERVED_TEXT_CHARS = 1_500;
+const MIN_SENTENCE_BREAK_INDEX = Math.floor(MAX_SYNCED_PRESERVED_TEXT_CHARS * 0.6);
+const MIN_WORD_BREAK_INDEX = Math.floor(MAX_SYNCED_PRESERVED_TEXT_CHARS * 0.75);
+
+function normalizeWhitespace(text: string): string {
+  return text.replace(/\s+/g, " ").trim();
+}
+
+export function toSyncedPreservedText(text: string): string {
+  const normalized = normalizeWhitespace(text);
+  if (normalized.length <= MAX_SYNCED_PRESERVED_TEXT_CHARS) return normalized;
+
+  const candidate = normalized.slice(0, MAX_SYNCED_PRESERVED_TEXT_CHARS + 1);
+  const sentenceBreak = Math.max(
+    candidate.lastIndexOf(". "),
+    candidate.lastIndexOf("! "),
+    candidate.lastIndexOf("? "),
+  );
+  if (sentenceBreak >= MIN_SENTENCE_BREAK_INDEX) {
+    return candidate.slice(0, sentenceBreak + 1).trim();
+  }
+
+  const wordBreak = candidate.lastIndexOf(" ");
+  if (wordBreak >= MIN_WORD_BREAK_INDEX) {
+    return candidate.slice(0, wordBreak).trim();
+  }
+
+  return candidate.slice(0, MAX_SYNCED_PRESERVED_TEXT_CHARS).trim();
+}
+
+export { MAX_SYNCED_PRESERVED_TEXT_CHARS };

--- a/packages/desktop/src/lib/save-url.test.ts
+++ b/packages/desktop/src/lib/save-url.test.ts
@@ -7,6 +7,7 @@
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { FeedItem } from "@freed/shared";
+import { MAX_SYNCED_PRESERVED_TEXT_CHARS } from "./preserved-text.js";
 
 // ── Module mocks ──────────────────────────────────────────────────────────────
 
@@ -103,6 +104,21 @@ describe("saveUrlInDesktop", () => {
     const { saveUrlInDesktop } = await import("./save-url.js");
     const item = await saveUrlInDesktop(SAMPLE_URL);
     expect("html" in (item.preservedContent ?? {})).toBe(false);
+  });
+
+  it("stores only a compact synced excerpt in preservedContent.text", async () => {
+    mockExtractContent.mockReturnValue(
+      makeContent({
+        text: `${"Paragraph with   noisy spacing. ".repeat(120)}Tail text that should never survive the trim.`,
+      }),
+    );
+
+    const { saveUrlInDesktop } = await import("./save-url.js");
+    const item = await saveUrlInDesktop(SAMPLE_URL);
+
+    expect(item.preservedContent?.text.length).toBeLessThanOrEqual(MAX_SYNCED_PRESERVED_TEXT_CHARS);
+    expect(item.preservedContent?.text).not.toContain("  ");
+    expect(item.preservedContent?.text).not.toContain("Tail text that should never survive the trim.");
   });
 
   it("assigns user-supplied tags to the item", async () => {

--- a/packages/desktop/src/lib/save-url.ts
+++ b/packages/desktop/src/lib/save-url.ts
@@ -17,6 +17,7 @@ import {
 import type { FeedItem } from "@freed/shared";
 import { contentCache } from "./content-cache.js";
 import { docAddFeedItem } from "./automerge.js";
+import { toSyncedPreservedText } from "./preserved-text.js";
 
 export interface SaveUrlOptions {
   tags?: string[];
@@ -89,7 +90,7 @@ export async function saveUrlInDesktop(
     },
     preservedContent: {
       // html intentionally omitted -- it lives in contentCache only
-      text: content.text.slice(0, 10_000),
+      text: toSyncedPreservedText(content.text),
       author: content.author ?? metadata.author,
       publishedAt: metadata.publishedAt,
       wordCount: content.wordCount,


### PR DESCRIPTION
(AI Generated). 

## Summary
- keep large preserved article bodies out of Automerge by compacting synced fallback text
- apply the compacted text rule to both background content fetching and manual URL saves
- update the freed build skill to fetch remotes and branch from origin/dev explicitly

## Verification
- node ../../node_modules/vitest/vitest.mjs run src/lib/content-fetcher.test.ts src/lib/save-url.test.ts
- node ../../node_modules/typescript/bin/tsc -b
- bash -n scripts/worktree-add.sh
