### PR TITLE
fix: restore map view background tiles

### DIFF
--- a/packages/ui/src/lib/map-style.test.ts
+++ b/packages/ui/src/lib/map-style.test.ts
@@ -15,7 +15,10 @@ const STYLE_FIXTURE = {
     { id: "highway_major_inner", type: "line", paint: { "line-color": "#fff" } },
     { id: "boundary_2", type: "line", paint: { "line-color": "#fff" } },
     { id: "waterway", type: "line", paint: { "line-color": "#fff" } },
+    { id: "waterway_line_label", type: "symbol", paint: { "text-color": "#fff", "text-halo-color": "#000" } },
     { id: "water_name_line_label", type: "symbol", paint: { "text-color": "#fff", "text-halo-color": "#000" } },
+    { id: "highway-name-major", type: "symbol", paint: { "text-color": "#fff", "text-halo-color": "#000" } },
+    { id: "road_shield_us", type: "symbol", paint: { "text-color": "#fff", "text-halo-color": "#000" } },
     { id: "label_city", type: "symbol", paint: { "text-color": "#fff", "text-halo-color": "#000" } },
     { id: "label_state", type: "symbol", paint: { "text-color": "#fff", "text-halo-color": "#000" } },
     { id: "airport", type: "symbol", paint: { "text-color": "#fff", "text-halo-color": "#000" } },
@@ -66,7 +69,10 @@ describe("buildThemedMapStyle", () => {
       expect(layerPaint(style, "highway_major_inner")["line-color"]).toBe(palette.roadsMajor);
       expect(layerPaint(style, "boundary_2")["line-color"]).toBe(palette.boundary);
       expect(layerPaint(style, "waterway")["line-color"]).toBe(palette.labelWater);
+      expect(layerPaint(style, "waterway_line_label")["text-color"]).toBe(palette.labelWater);
       expect(layerPaint(style, "water_name_line_label")["text-color"]).toBe(palette.labelWater);
+      expect(layerPaint(style, "highway-name-major")["text-color"]).toBe(palette.labelSoft);
+      expect(layerPaint(style, "road_shield_us")["line-color"]).toBeUndefined();
       expect(layerPaint(style, "label_city")["text-color"]).toBe(palette.labelStrong);
       expect(layerPaint(style, "label_state")["text-color"]).toBe(palette.labelSoft);
       expect(layerPaint(style, "airport")["text-color"]).toBe(palette.labelStrong);
@@ -74,5 +80,17 @@ describe("buildThemedMapStyle", () => {
     }
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not attach line paint to symbol layers that only share road-like ids", async () => {
+    const fetchMock = vi.fn(async () => responseWithStyle());
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { buildThemedMapStyle } = await loadBuilder();
+    const style = await buildThemedMapStyle("neon");
+
+    expect(layerPaint(style, "waterway_line_label")["line-color"]).toBeUndefined();
+    expect(layerPaint(style, "highway-name-major")["line-color"]).toBeUndefined();
+    expect(layerPaint(style, "road_shield_us")["line-color"]).toBeUndefined();
   });
 });

--- a/packages/ui/src/lib/map-style.ts
+++ b/packages/ui/src/lib/map-style.ts
@@ -61,60 +61,80 @@ function isMinorRoadLayer(id: string): boolean {
 function rethemeLayer(layer: MapStyleLayer, palette: ThemeMapPalette) {
   const id = layer.id.toLowerCase();
 
-  if (id === "background") {
+  if (layer.type === "background" && id === "background") {
     setPaint(layer, "background-color", palette.background);
     return;
   }
 
-  if (id === "water") {
+  if (layer.type === "symbol") {
+    if (id.startsWith("water_name") || id === "waterway_line_label") {
+      applyLabelPaint(layer, palette.labelWater, palette.labelHalo);
+      return;
+    }
+
+    if (
+      id.startsWith("label_country")
+      || id.startsWith("label_city")
+      || id === "airport"
+    ) {
+      applyLabelPaint(layer, palette.labelStrong, palette.labelHalo);
+      return;
+    }
+
+    if (id.startsWith("label_") || id.startsWith("highway-name")) {
+      applyLabelPaint(layer, palette.labelSoft, palette.labelHalo);
+    }
+    return;
+  }
+
+  if (layer.type === "fill" && id === "water") {
     setPaint(layer, "fill-color", palette.water);
     return;
   }
 
-  if (id === "park") {
+  if (layer.type === "fill" && id === "park") {
     setPaint(layer, "fill-color", palette.park);
     return;
   }
 
-  if (id.includes("wood")) {
+  if (layer.type === "fill" && id.includes("wood")) {
     setPaint(layer, "fill-color", palette.wood);
     return;
   }
 
-  if (id.includes("residential")) {
+  if (layer.type === "fill" && id.includes("residential")) {
     setPaint(layer, "fill-color", palette.residential);
     return;
   }
 
-  if (id.includes("ice_shelf") || id.includes("glacier")) {
+  if (layer.type === "fill" && (id.includes("ice_shelf") || id.includes("glacier"))) {
     setPaint(layer, "fill-color", palette.residential);
     return;
   }
 
-  if (id.startsWith("building")) {
+  if (layer.type === "fill" && id.startsWith("building")) {
     setPaint(layer, "fill-color", palette.building);
     setPaint(layer, "fill-outline-color", palette.building);
     return;
   }
 
-  if (id.startsWith("boundary_")) {
+  if (layer.type === "line" && id.startsWith("boundary_")) {
     setPaint(layer, "line-color", palette.boundary);
     return;
   }
 
-  if (id.startsWith("waterway")) {
+  if (layer.type === "line" && id.startsWith("waterway")) {
     setPaint(layer, "line-color", palette.labelWater);
-    return;
-  }
-
-  if (id.startsWith("water_name")) {
-    applyLabelPaint(layer, palette.labelWater, palette.labelHalo);
     return;
   }
 
   if (isMajorRoadLayer(id)) {
     if (layer.type === "fill") {
       setPaint(layer, "fill-color", palette.roadsMajor);
+      return;
+    }
+
+    if (layer.type !== "line") {
       return;
     }
 
@@ -128,25 +148,12 @@ function rethemeLayer(layer: MapStyleLayer, palette: ThemeMapPalette) {
       return;
     }
 
+    if (layer.type !== "line") {
+      return;
+    }
+
     setPaint(layer, "line-color", palette.roadsMinor);
     return;
-  }
-
-  if (
-    id.startsWith("label_country")
-    || id.startsWith("label_city")
-    || id === "airport"
-  ) {
-    applyLabelPaint(layer, palette.labelStrong, palette.labelHalo);
-    return;
-  }
-
-  if (
-    id.startsWith("label_")
-    || id.startsWith("highway-name")
-    || id === "waterway_line_label"
-  ) {
-    applyLabelPaint(layer, palette.labelSoft, palette.labelHalo);
   }
 }
 


### PR DESCRIPTION
(AI Generated).

## Summary
- tighten themed map style retheming so symbol layers do not receive invalid line paint
- keep waterway and road label symbol layers themed with text colors instead of line colors
- add regression coverage for waterway label and road shield style cases

## Root Cause
The themed map style pass matched layer ids too loosely and assigned `line-color` to symbol layers such as `waterway_line_label`, `highway-name-major`, and `road_shield_us`. That produced an invalid themed style and caused the MapView background to disappear in the desktop build.

## Impact
MapView backgrounds render again in Freed Desktop without changing marker or popup behavior.

## Validation
- `node ./node_modules/vitest/vitest.mjs run packages/ui/src/lib/map-style.test.ts`
- `npm run test:e2e -- theme-switching.spec.ts`
