### PR TITLE
perf: reduce search memory retention

### DIFF
--- a/docs/PHASE-5-DESKTOP.md
+++ b/docs/PHASE-5-DESKTOP.md
@@ -279,6 +279,8 @@ export async function captureDomFeed(
 - [x] Removing RSS feeds now also drops their retained provider-health diagnostics instead of keeping dead feed histories in memory and storage forever
 - [x] Desktop live UI state now caps preserved article text previews and fetches full preserved text on demand for the active reader item, instead of cloning entire article bodies through every feed-state update
 - [x] Desktop persistence now appends Automerge incremental saves to the last snapshot and only compacts back to a fresh snapshot once incremental growth justifies it, instead of full-document reserialization on every mutation
+- [x] Search now drops its MiniSearch index as soon as the query clears, rebuilds only when the worker says the searchable corpus changed, and indexes a smaller preserved-text window so one exploratory search cannot pin a second full-text copy of the library in renderer memory
+- [x] Desktop perf memory checks now use CDP heap-usage sampling instead of the broken zero-value metric path, and they include a heavy preserved-text search scenario so renderer retention regressions show up in CI
 - [ ] Windows installer is code-signed (requires EV certificate)
 - [x] Update server runs on a Freed-owned domain instead of pointing the updater directly at GitHub Releases
 - [x] Desktop settings can switch this install between production and dev release channels
@@ -312,6 +314,14 @@ export async function captureDomFeed(
 > updates also now cap preserved article text previews and fetch the full
 > preserved text only for the reader item that is actually open, instead of
 > cloning full article bodies through the live UI state on every mutation.
+> Search now tears down its MiniSearch index as soon as the query clears,
+> rebuilds it only when the worker reports a real corpus change, and indexes
+> a smaller preserved-text window so a one-off search cannot keep a second
+> library-sized text copy resident in renderer memory for the rest of the
+> session. The desktop perf harness also switched from Chromium's broken
+> zero-value heap metric path to `Runtime.getHeapUsage()` and added a heavy
+> preserved-text search scenario, so memory regressions stop passing CI by
+> emitting a very confident `0.0 MB`.
 > Desktop persistence also now appends Automerge incremental saves to the
 > last stored snapshot and compacts back to a fresh snapshot only when the
 > incremental tail has grown large enough to justify it.

--- a/packages/desktop/src/lib/automerge-types.ts
+++ b/packages/desktop/src/lib/automerge-types.ts
@@ -17,6 +17,7 @@ import type { FeedItem, Friend, ReachOutLog, RssFeed, UserPreferences } from "@f
 
 export interface DocState {
   items: FeedItem[];
+  searchCorpusVersion: number;
   feeds: Record<string, RssFeed>;
   friends: Record<string, Friend>;
   preferences: UserPreferences;

--- a/packages/desktop/src/lib/automerge.worker.ts
+++ b/packages/desktop/src/lib/automerge.worker.ts
@@ -64,6 +64,7 @@ let persistenceState: AutomergePersistenceState = createPersistenceState(null);
 let relayClientCount = 0;
 let queuedRequestCount = 0;
 let requestChain: Promise<void> = Promise.resolve();
+let searchCorpusVersion = 0;
 
 const SLOW_QUEUE_WAIT_MS = 1_000;
 const SLOW_REQUEST_PROCESS_MS = 5_000;
@@ -99,6 +100,31 @@ function emitWorkerTrace(
   kind: Extract<WorkerResponse, { type: "DEBUG_EVENT" }>["kind"] = "change",
 ): void {
   send({ type: "DEBUG_EVENT", kind, detail });
+}
+
+function bumpSearchCorpusVersion(): void {
+  searchCorpusVersion += 1;
+}
+
+function feedItemUpdatesAffectSearchCorpus(updates: Partial<FeedItem>): boolean {
+  if (
+    "author" in updates ||
+    "content" in updates ||
+    "contentType" in updates ||
+    "preservedContent" in updates ||
+    "publishedAt" in updates ||
+    "rssSource" in updates ||
+    "topics" in updates
+  ) {
+    return true;
+  }
+
+  if (!updates.userState) return false;
+  return (
+    "hidden" in updates.userState ||
+    "tags" in updates.userState ||
+    "highlights" in updates.userState
+  );
 }
 
 /**
@@ -209,6 +235,7 @@ function hydrateFromDoc(doc: FreedDoc): DocState {
 
   return {
     items: rankedItems,
+    searchCorpusVersion,
     feeds,
     friends,
     preferences,
@@ -285,9 +312,11 @@ async function applyChange(
   changeFn: (doc: FreedDoc) => void,
   message: string,
   trace?: RequestTrace,
+  searchCorpusChanged = false,
 ): Promise<void> {
   if (!currentDoc) throw new Error("Document not initialized");
   currentDoc = A.change(currentDoc, message, changeFn);
+  if (searchCorpusChanged) bumpSearchCorpusVersion();
   send({ type: "DEBUG_EVENT", kind: "change", detail: message });
   await saveAndBroadcast(trace);
 }
@@ -316,7 +345,8 @@ async function handleRequest(
   const applyRequestChange = (
     changeFn: (doc: FreedDoc) => void,
     message: string,
-  ) => applyChange(changeFn, message, trace);
+    searchCorpusChanged = false,
+  ) => applyChange(changeFn, message, trace, searchCorpusChanged);
 
   try {
     switch (req.type) {
@@ -340,6 +370,7 @@ async function handleRequest(
           persistenceState = createPersistenceState(binary);
           await storage.save(binary);
         }
+        searchCorpusVersion = 1;
         const deviceId = (currentDoc.meta?.deviceId as string | undefined) ?? "unknown";
         send({ type: "DEBUG_EVENT", kind: "init", detail: `device ...${deviceId.slice(-8)}` });
         await saveAndBroadcast(trace);
@@ -352,6 +383,7 @@ async function handleRequest(
         currentDoc = null;
         currentBinary = null;
         persistenceState = createPersistenceState(null);
+        searchCorpusVersion = 0;
         ack(req.reqId);
         break;
 
@@ -359,6 +391,7 @@ async function handleRequest(
         currentDoc = A.load<FreedDoc>(req.binary);
         currentBinary = req.binary;
         persistenceState = createPersistenceState(req.binary);
+        bumpSearchCorpusVersion();
         await storage.save(req.binary);
         await saveAndBroadcast(trace);
         ack(req.reqId);
@@ -386,6 +419,7 @@ async function handleRequest(
           detail: delta !== 0 ? `${delta > 0 ? "+" : ""}${delta} items` : "no new items",
           bytes: req.binary.byteLength,
         });
+        bumpSearchCorpusVersion();
         await saveAndBroadcast(trace);
         ack(req.reqId);
         break;
@@ -451,7 +485,7 @@ async function handleRequest(
       case "ADD_FEED_ITEM":
         await applyRequestChange((doc) => {
           if (!doc.feedItems[req.item.globalId]) addFeedItem(doc, req.item);
-        }, "Add feed item");
+        }, "Add feed item", true);
         ack(req.reqId);
         break;
 
@@ -460,12 +494,12 @@ async function handleRequest(
           for (const item of req.items) {
             if (!doc.feedItems[item.globalId]) addFeedItem(doc, item);
           }
-        }, `Add ${req.items.length} feed items`);
+        }, `Add ${req.items.length} feed items`, true);
         ack(req.reqId);
         break;
 
       case "REMOVE_FEED_ITEM":
-        await applyRequestChange((doc) => removeFeedItem(doc, req.globalId), "Remove feed item");
+        await applyRequestChange((doc) => removeFeedItem(doc, req.globalId), "Remove feed item", true);
         ack(req.reqId);
         break;
 
@@ -473,6 +507,7 @@ async function handleRequest(
         await applyRequestChange(
           (doc) => updateFeedItem(doc, req.globalId, req.updates),
           "Update feed item",
+          feedItemUpdatesAffectSearchCorpus(req.updates),
         );
         ack(req.reqId);
         break;
@@ -494,6 +529,7 @@ async function handleRequest(
         await applyRequestChange(
           (doc) => pruneArchivedItems(doc, req.maxAgeMs),
           "Prune archived items",
+          true,
         );
         ack(req.reqId);
         break;
@@ -502,12 +538,13 @@ async function handleRequest(
         await applyRequestChange(
           (doc) => deleteAllArchivedItems(doc),
           "Delete all archived items",
+          true,
         );
         ack(req.reqId);
         break;
 
       case "ADD_RSS_FEED":
-        await applyRequestChange((doc) => addRssFeed(doc, req.feed), "Add RSS feed");
+        await applyRequestChange((doc) => addRssFeed(doc, req.feed), "Add RSS feed", true);
         ack(req.reqId);
         break;
 
@@ -515,6 +552,7 @@ async function handleRequest(
         await applyRequestChange(
           (doc) => removeRssFeed(doc, req.url, req.includeItems),
           req.includeItems ? "Remove RSS feed and articles" : "Remove RSS feed",
+          true,
         );
         ack(req.reqId);
         break;
@@ -523,6 +561,7 @@ async function handleRequest(
         await applyRequestChange(
           (doc) => updateRssFeed(doc, req.url, req.updates as Parameters<typeof updateRssFeed>[2]),
           "Update RSS feed",
+          true,
         );
         ack(req.reqId);
         break;
@@ -531,6 +570,7 @@ async function handleRequest(
         await applyRequestChange(
           (doc) => removeAllFeeds(doc, req.includeItems),
           req.includeItems ? "Remove all feeds and articles" : "Remove all feeds",
+          true,
         );
         ack(req.reqId);
         break;
@@ -609,7 +649,7 @@ async function handleRequest(
             addFeedItem(doc, item);
             if (linkUrl) existingLinkUrls.add(linkUrl);
           }
-        }, `Refresh ${req.feeds.length} feeds, ${req.items.length} items`);
+        }, `Refresh ${req.feeds.length} feeds, ${req.items.length} items`, true);
         ack(req.reqId);
         break;
 
@@ -624,7 +664,7 @@ async function handleRequest(
             for (const item of chunk) {
               if (!doc.feedItems[item.globalId]) addFeedItem(doc, item);
             }
-          }, `Batch import chunk ${chunkIndex + 1}/${totalChunks}`);
+          }, `Batch import chunk ${chunkIndex + 1}/${totalChunks}`, true);
           send({ type: "IMPORT_PROGRESS", chunkIndex: chunkIndex + 1, totalChunks });
         }
         ack(req.reqId);
@@ -640,7 +680,7 @@ async function handleRequest(
             try { healed = new URL(feed.url).hostname.replace(/^(?:www|feeds?)\./, ""); } catch { /* */ }
             if (healed) feed.title = healed;
           }
-        }, "Heal untitled feed titles from URL hostname");
+        }, "Heal untitled feed titles from URL hostname", true);
         ack(req.reqId);
         break;
 
@@ -670,7 +710,7 @@ async function handleRequest(
             scored.sort((a, b) => b.score - a.score || b.id.localeCompare(a.id));
             for (let i = 1; i < scored.length; i++) delete doc.feedItems[scored[i].id];
           }
-        }, "Deduplicate feed items by article link URL");
+        }, "Deduplicate feed items by article link URL", true);
         ack(req.reqId);
         break;
 

--- a/packages/desktop/src/lib/store.ts
+++ b/packages/desktop/src/lib/store.ts
@@ -79,6 +79,7 @@ const EMPTY_PROVIDER_SYNC_COUNTS: ProviderSyncCounts = {
 interface AppState {
   // Data (received pre-hydrated from Automerge worker as DocState)
   items: FeedItem[];
+  searchCorpusVersion: number;
   feeds: Record<string, RssFeed>;
   friends: Record<string, Friend>;
   preferences: UserPreferences;
@@ -210,6 +211,7 @@ async function runStartupMigrations(archivePruneDays: number): Promise<void> {
 export const useAppStore = create<AppState>((set, get) => ({
   // Initial state
   items: [],
+  searchCorpusVersion: 0,
   feeds: {},
   friends: {},
   preferences: createDefaultPreferences(),

--- a/packages/desktop/tests/e2e/perf-feed.spec.ts
+++ b/packages/desktop/tests/e2e/perf-feed.spec.ts
@@ -105,6 +105,98 @@ async function measureFps(
   return result;
 }
 
+async function injectPreservedRssItems(
+  page: Page,
+  count: number,
+  {
+    feedUrl = "https://bench.example/preserved.xml",
+    preservedTextLength = 4_000,
+  }: {
+    feedUrl?: string;
+    preservedTextLength?: number;
+  } = {},
+): Promise<void> {
+  await page.evaluate(
+    async ({ count, feedUrl, preservedTextLength }) => {
+      const w = window as Record<string, unknown>;
+      const automerge = w.__FREED_AUTOMERGE__ as {
+        docBatchImportItems: (items: unknown[]) => Promise<unknown>;
+      };
+
+      const now = Date.now();
+      const seed = "quartz vector lattice memory probe ";
+      const repeated = seed.repeat(Math.ceil(preservedTextLength / seed.length)).slice(0, preservedTextLength);
+
+      const items = Array.from({ length: count }, (_, i) => ({
+        globalId: `rss:${feedUrl}:preserved-${i}`,
+        platform: "rss",
+        contentType: "article",
+        capturedAt: now - i * 60_000,
+        publishedAt: now - i * 60_000,
+        author: {
+          id: "preserved-feed",
+          handle: "preserved-feed",
+          displayName: "Preserved Feed",
+        },
+        content: {
+          text: `Preserved article ${i.toLocaleString()} carrying a longer search corpus.`,
+          mediaUrls: [],
+          mediaTypes: [],
+          linkPreview: {
+            url: `https://bench.example/preserved-${i}`,
+            title: `Preserved Benchmark Article ${i.toLocaleString()}`,
+            description: `Long-form preserved payload ${i.toLocaleString()}`,
+          },
+        },
+        preservedContent: {
+          text: `${repeated} item-${i.toLocaleString()}`,
+          wordCount: 700,
+          readingTime: 4,
+          preservedAt: now - i * 60_000,
+        },
+        userState: { hidden: false, saved: false, archived: false, tags: [] },
+        topics: ["memory", "search"],
+        rssSource: {
+          feedUrl,
+          feedTitle: "Preserved Feed",
+        },
+      }));
+
+      await automerge.docBatchImportItems(items);
+    },
+    { count, feedUrl, preservedTextLength },
+  );
+
+  await page.waitForFunction(
+    (expectedCount: number) => {
+      const w = window as Record<string, unknown>;
+      const store = w.__FREED_STORE__ as
+        | { getState: () => { items: unknown[] } }
+        | undefined;
+      return (store?.getState().items.length ?? 0) >= expectedCount;
+    },
+    count,
+    { timeout: 30_000 },
+  );
+}
+
+async function collectHeapUsageBytes(
+  page: Page,
+): Promise<{ usedBytes: number; totalBytes: number }> {
+  const cdp = await page.context().newCDPSession(page);
+  await cdp.send("HeapProfiler.enable");
+  await cdp.send("HeapProfiler.collectGarbage");
+  const usage = await cdp.send("Runtime.getHeapUsage") as {
+    usedSize: number;
+    totalSize: number;
+  };
+  await cdp.send("HeapProfiler.disable");
+  return {
+    usedBytes: usage.usedSize,
+    totalBytes: usage.totalSize,
+  };
+}
+
 // ─── 1. Cold load ─────────────────────────────────────────────────────────────
 
 test.describe("Cold load with pre-populated corpus", () => {
@@ -578,26 +670,10 @@ test.describe("Memory profiling (CDP heap snapshots)", () => {
   test("JS heap growth after injecting 5k items", async ({ app, page }) => {
     await app.goto();
     await app.waitForReady();
-
-    const cdp = await page.context().newCDPSession(page);
-
-    // Baseline heap before injection
-    const baselineMetrics = await cdp.send("Performance.getMetrics") as {
-      metrics: Array<{ name: string; value: number }>;
-    };
-    const baselineHeap = baselineMetrics.metrics.find((m) => m.name === "JSHeapUsedSize")?.value ?? 0;
+    const baselineHeap = (await collectHeapUsageBytes(page)).usedBytes;
 
     await app.injectRssItems(ITEM_COUNT_XLARGE);
-
-    // Force GC before measuring to exclude short-lived allocations
-    await cdp.send("HeapProfiler.enable");
-    await cdp.send("HeapProfiler.collectGarbage");
-    await cdp.send("HeapProfiler.disable");
-
-    const afterMetrics = await cdp.send("Performance.getMetrics") as {
-      metrics: Array<{ name: string; value: number }>;
-    };
-    const afterHeap = afterMetrics.metrics.find((m) => m.name === "JSHeapUsedSize")?.value ?? 0;
+    const afterHeap = (await collectHeapUsageBytes(page)).usedBytes;
 
     const growthMb = (afterHeap - baselineHeap) / (1024 * 1024);
     console.log(`[PERF] Heap baseline: ${(baselineHeap / (1024 * 1024)).toFixed(1)} MB`);
@@ -612,16 +688,7 @@ test.describe("Memory profiling (CDP heap snapshots)", () => {
     await app.goto();
     await app.waitForReady();
     await app.injectRssItems(ITEM_COUNT_LARGE);
-
-    const cdp = await page.context().newCDPSession(page);
-    await cdp.send("HeapProfiler.enable");
-    await cdp.send("HeapProfiler.collectGarbage");
-    await cdp.send("HeapProfiler.disable");
-
-    const beforeMetrics = await cdp.send("Performance.getMetrics") as {
-      metrics: Array<{ name: string; value: number }>;
-    };
-    const beforeHeap = beforeMetrics.metrics.find((m) => m.name === "JSHeapUsedSize")?.value ?? 0;
+    const beforeHeap = (await collectHeapUsageBytes(page)).usedBytes;
 
     // Run 50 mutations
     await page.evaluate(async () => {
@@ -635,20 +702,55 @@ test.describe("Memory profiling (CDP heap snapshots)", () => {
       }
     });
 
-    await cdp.send("HeapProfiler.enable");
-    await cdp.send("HeapProfiler.collectGarbage");
-    await cdp.send("HeapProfiler.disable");
-
-    const afterMetrics = await cdp.send("Performance.getMetrics") as {
-      metrics: Array<{ name: string; value: number }>;
-    };
-    const afterHeap = afterMetrics.metrics.find((m) => m.name === "JSHeapUsedSize")?.value ?? 0;
+    const afterHeap = (await collectHeapUsageBytes(page)).usedBytes;
 
     const growthMb = (afterHeap - beforeHeap) / (1024 * 1024);
     console.log(`[PERF] Heap growth after 50 mutations: ${growthMb.toFixed(1)} MB`);
 
     // Mutations should not leak more than 10MB after GC - indicates retained closures
     expect(growthMb).toBeLessThan(10);
+  });
+
+  test("search index releases heap after clearing a heavy query", async ({ app, page }) => {
+    await app.goto();
+    await app.waitForReady();
+    await injectPreservedRssItems(page, 3_000);
+
+    const baseline = (await collectHeapUsageBytes(page)).usedBytes;
+
+    await page.evaluate(() => {
+      const w = window as Record<string, unknown>;
+      const store = w.__FREED_STORE__ as {
+        getState: () => { setSearchQuery: (query: string) => void };
+      };
+      store.getState().setSearchQuery("quartz");
+    });
+
+    await page.waitForFunction(() => {
+      const input = document.querySelector('input[type="search"], input[placeholder*="Search"]');
+      return input instanceof HTMLInputElement ? input.value === "quartz" : true;
+    });
+
+    const activeSearch = (await collectHeapUsageBytes(page)).usedBytes;
+
+    await page.evaluate(() => {
+      const w = window as Record<string, unknown>;
+      const store = w.__FREED_STORE__ as {
+        getState: () => { setSearchQuery: (query: string) => void };
+      };
+      store.getState().setSearchQuery("");
+    });
+
+    await page.waitForTimeout(100);
+    const clearedSearch = (await collectHeapUsageBytes(page)).usedBytes;
+
+    const searchGrowthMb = (activeSearch - baseline) / (1024 * 1024);
+    const releasedMb = (activeSearch - clearedSearch) / (1024 * 1024);
+    console.log(`[PERF] Search heap growth heavy corpus: ${searchGrowthMb.toFixed(1)} MB`);
+    console.log(`[PERF] Search heap released after clear: ${releasedMb.toFixed(1)} MB`);
+
+    expect(releasedMb).toBeGreaterThan(5);
+    expect(clearedSearch).toBeLessThan(activeSearch);
   });
 });
 

--- a/packages/pwa/src/lib/automerge-types.ts
+++ b/packages/pwa/src/lib/automerge-types.ts
@@ -17,6 +17,7 @@ import type { FeedItem, Friend, ReachOutLog, RssFeed, UserPreferences } from "@f
 
 export interface DocState {
   items: FeedItem[];
+  searchCorpusVersion: number;
   feeds: Record<string, RssFeed>;
   friends: Record<string, Friend>;
   preferences: UserPreferences;

--- a/packages/pwa/src/lib/automerge.worker.ts
+++ b/packages/pwa/src/lib/automerge.worker.ts
@@ -50,6 +50,7 @@ import type { DocState, WorkerRequest, WorkerResponse } from "./automerge-types"
 
 const storage = new IndexedDBStorage();
 let currentDoc: FreedDoc | null = null;
+let searchCorpusVersion = 0;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -61,6 +62,31 @@ function send(msg: WorkerResponse): void {
 
 function ack(reqId: number, error?: string): void {
   send({ reqId, type: "ACK", error });
+}
+
+function bumpSearchCorpusVersion(): void {
+  searchCorpusVersion += 1;
+}
+
+function feedItemUpdatesAffectSearchCorpus(updates: Partial<FeedItem>): boolean {
+  if (
+    "author" in updates ||
+    "content" in updates ||
+    "contentType" in updates ||
+    "preservedContent" in updates ||
+    "publishedAt" in updates ||
+    "rssSource" in updates ||
+    "topics" in updates
+  ) {
+    return true;
+  }
+
+  if (!updates.userState) return false;
+  return (
+    "hidden" in updates.userState ||
+    "tags" in updates.userState ||
+    "highlights" in updates.userState
+  );
 }
 
 /**
@@ -118,6 +144,7 @@ function hydrateFromDoc(doc: FreedDoc): DocState {
 
   return {
     items: rankedItems,
+    searchCorpusVersion,
     feeds,
     friends,
     preferences,
@@ -165,9 +192,11 @@ async function saveAndBroadcast(): Promise<void> {
 async function applyChange(
   changeFn: (doc: FreedDoc) => void,
   message: string,
+  searchCorpusChanged = false,
 ): Promise<void> {
   if (!currentDoc) throw new Error("Document not initialized");
   currentDoc = A.change(currentDoc, message, changeFn);
+  if (searchCorpusChanged) bumpSearchCorpusVersion();
   send({ type: "DEBUG_EVENT", kind: "change", detail: message });
   await saveAndBroadcast();
 }
@@ -196,6 +225,7 @@ self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
           const binary = A.save(currentDoc);
           await storage.save(binary);
         }
+        searchCorpusVersion = 1;
         const deviceId = (currentDoc.meta?.deviceId as string | undefined) ?? "unknown";
         send({ type: "DEBUG_EVENT", kind: "init", detail: `device ...${deviceId.slice(-8)}` });
         await saveAndBroadcast();
@@ -263,7 +293,7 @@ self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
       case "ADD_FEED_ITEM":
         await applyChange((doc) => {
           if (!doc.feedItems[req.item.globalId]) addFeedItem(doc, req.item);
-        }, "Add feed item");
+        }, "Add feed item", true);
         ack(req.reqId);
         break;
 
@@ -272,17 +302,21 @@ self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
           for (const item of req.items) {
             if (!doc.feedItems[item.globalId]) addFeedItem(doc, item);
           }
-        }, `Add ${req.items.length} feed items`);
+        }, `Add ${req.items.length} feed items`, true);
         ack(req.reqId);
         break;
 
       case "REMOVE_FEED_ITEM":
-        await applyChange((doc) => removeFeedItem(doc, req.globalId), "Remove feed item");
+        await applyChange((doc) => removeFeedItem(doc, req.globalId), "Remove feed item", true);
         ack(req.reqId);
         break;
 
       case "UPDATE_FEED_ITEM":
-        await applyChange((doc) => updateFeedItem(doc, req.globalId, req.updates), "Update feed item");
+        await applyChange(
+          (doc) => updateFeedItem(doc, req.globalId, req.updates),
+          "Update feed item",
+          feedItemUpdatesAffectSearchCorpus(req.updates),
+        );
         ack(req.reqId);
         break;
 
@@ -300,17 +334,17 @@ self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
         break;
 
       case "PRUNE_ARCHIVED_ITEMS":
-        await applyChange((doc) => pruneArchivedItems(doc, req.maxAgeMs), "Prune archived items");
+        await applyChange((doc) => pruneArchivedItems(doc, req.maxAgeMs), "Prune archived items", true);
         ack(req.reqId);
         break;
 
       case "DELETE_ALL_ARCHIVED":
-        await applyChange((doc) => deleteAllArchivedItems(doc), "Delete all archived items");
+        await applyChange((doc) => deleteAllArchivedItems(doc), "Delete all archived items", true);
         ack(req.reqId);
         break;
 
       case "ADD_RSS_FEED":
-        await applyChange((doc) => addRssFeed(doc, req.feed), "Add RSS feed");
+        await applyChange((doc) => addRssFeed(doc, req.feed), "Add RSS feed", true);
         ack(req.reqId);
         break;
 
@@ -318,17 +352,26 @@ self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
         await applyChange(
           (doc) => removeRssFeed(doc, req.url, req.includeItems),
           req.includeItems ? "Remove RSS feed and articles" : "Remove RSS feed",
+          true,
         );
         ack(req.reqId);
         break;
 
       case "UPDATE_RSS_FEED":
-        await applyChange((doc) => updateRssFeed(doc, req.url, req.updates as Parameters<typeof updateRssFeed>[2]), "Update RSS feed");
+        await applyChange(
+          (doc) => updateRssFeed(doc, req.url, req.updates as Parameters<typeof updateRssFeed>[2]),
+          "Update RSS feed",
+          true,
+        );
         ack(req.reqId);
         break;
 
       case "REMOVE_ALL_FEEDS":
-        await applyChange((doc) => removeAllFeeds(doc, req.includeItems), req.includeItems ? "Remove all feeds and articles" : "Remove all feeds");
+        await applyChange(
+          (doc) => removeAllFeeds(doc, req.includeItems),
+          req.includeItems ? "Remove all feeds and articles" : "Remove all feeds",
+          true,
+        );
         ack(req.reqId);
         break;
 
@@ -403,7 +446,7 @@ self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
 
         await applyChange((doc) => {
           if (!doc.feedItems[stub.globalId]) addFeedItem(doc, stub);
-        }, `Add stub item for ${req.url}`);
+        }, `Add stub item for ${req.url}`, true);
         ack(req.reqId);
         break;
       }
@@ -421,6 +464,7 @@ self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
           detail: delta !== 0 ? `${delta > 0 ? "+" : ""}${delta} items` : "no new items",
           bytes: req.binary.byteLength,
         });
+        bumpSearchCorpusVersion();
         await saveAndBroadcast();
         ack(req.reqId);
         break;
@@ -428,6 +472,8 @@ self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
 
       case "CLEAR_LOCAL":
         await storage.clear();
+        currentDoc = null;
+        searchCorpusVersion = 0;
         ack(req.reqId);
         break;
 

--- a/packages/pwa/src/lib/store.ts
+++ b/packages/pwa/src/lib/store.ts
@@ -64,6 +64,7 @@ function shallowEqualRecord(
 export const useAppStore = create<AppState>((set, get) => ({
   // Initial state
   items: [],
+  searchCorpusVersion: 0,
   feeds: {},
   friends: {},
   preferences: createDefaultPreferences(),

--- a/packages/shared/src/store-types.ts
+++ b/packages/shared/src/store-types.ts
@@ -33,6 +33,8 @@ export interface FilterOptions {
 export interface BaseAppState {
   // Data (derived from Automerge doc)
   items: FeedItem[];
+  /** Bumps only when search-relevant corpus content changes. */
+  searchCorpusVersion: number;
   feeds: Record<string, RssFeed>;
   /** Friends (unified identities) — keyed by Friend.id */
   friends: Record<string, Friend>;

--- a/packages/ui/src/components/feed/FeedView.tsx
+++ b/packages/ui/src/components/feed/FeedView.tsx
@@ -227,6 +227,7 @@ export function FeedView() {
   const feeds = useAppStore((s) => s.feeds);
   const activeFilter = useAppStore((s) => s.activeFilter);
   const searchQuery = useAppStore((s) => s.searchQuery);
+  const searchCorpusVersion = useAppStore((s) => s.searchCorpusVersion);
   const selectedItemId = useAppStore((s) => s.selectedItemId);
   const setSelectedItem = useAppStore((s) => s.setSelectedItem);
   const markAsRead = useAppStore((s) => s.markAsRead);
@@ -296,7 +297,12 @@ export function FeedView() {
 
   // useSearchResults handles both the search and the normal ranked+filtered path.
   // When searchQuery is empty it behaves identically to the previous useMemo.
-  const { filteredItems, isSearching, resultCount } = useSearchResults(items, searchQuery, activeFilter);
+  const { filteredItems, isSearching, resultCount } = useSearchResults(
+    items,
+    searchQuery,
+    activeFilter,
+    searchCorpusVersion,
+  );
 
   const scopeLabel = useMemo(() => getFilterLabel(activeFilter, feeds), [activeFilter, feeds]);
   const dualColumnMode = useAppStore((s) => s.preferences.display.reading.dualColumnMode);

--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -83,6 +83,7 @@ export function Header({ onMenuClick, sidebarExpanded, onSidebarToggle }: Header
   const activeView = useAppStore((s) => s.activeView);
   const activeFilter = useAppStore((s) => s.activeFilter);
   const searchQuery = useAppStore((s) => s.searchQuery);
+  const searchCorpusVersion = useAppStore((s) => s.searchCorpusVersion);
   const selectedItemId = useAppStore((s) => s.selectedItemId);
   const totalUnreadCount = useAppStore((s) => s.totalUnreadCount);
   const unreadCountByPlatform = useAppStore((s) => s.unreadCountByPlatform);
@@ -98,7 +99,12 @@ export function Header({ onMenuClick, sidebarExpanded, onSidebarToggle }: Header
   const setSelectedItem = useAppStore((s) => s.setSelectedItem);
   const display = useAppStore((s) => s.preferences.display);
 
-  const { filteredItems, isSearching, resultCount } = useSearchResults(items, searchQuery, activeFilter);
+  const { filteredItems, isSearching, resultCount } = useSearchResults(
+    items,
+    searchQuery,
+    activeFilter,
+    searchCorpusVersion,
+  );
   const selectedItem = useMemo(
     () => (selectedItemId ? items.find((item) => item.globalId === selectedItemId) ?? null : null),
     [items, selectedItemId],

--- a/packages/ui/src/hooks/useSearchResults.ts
+++ b/packages/ui/src/hooks/useSearchResults.ts
@@ -21,9 +21,9 @@
  * item IDs, titles, text, tags, and highlights. Plain state changes (readAt,
  * saved) don't appear in the content key, so they don't trigger a rebuild.
  *
- * Preserved article text is truncated to 3 000 chars before indexing — full
- * articles can be 20 k+ words and the marginal recall gain past that point is
- * negligible while the indexing cost is not.
+ * Preserved article text is truncated to 1 200 chars before indexing — full
+ * articles can be 20 k+ words and the marginal recall gain past the opening
+ * section is small while the memory cost of duplicating that text is not.
  */
 
 import { useMemo, useRef } from "react";
@@ -31,7 +31,7 @@ import MiniSearch from "minisearch";
 import { filterFeedItems, sortByPriority } from "@freed/shared";
 import type { FeedItem, FilterOptions } from "@freed/shared";
 
-const PRESERVED_TEXT_LIMIT = 3_000;
+const SEARCH_PRESERVED_TEXT_LIMIT = 1_200;
 
 /** Flat document shape fed to MiniSearch (one per FeedItem). */
 interface SearchDoc {
@@ -57,7 +57,7 @@ function toSearchDoc(item: FeedItem): SearchDoc {
     authorName: item.author.displayName,
     authorHandle: item.author.handle,
     feedTitle: item.rssSource?.feedTitle ?? "",
-    preservedText: item.preservedContent?.text?.slice(0, PRESERVED_TEXT_LIMIT) ?? "",
+    preservedText: item.preservedContent?.text?.slice(0, SEARCH_PRESERVED_TEXT_LIMIT) ?? "",
     topics: item.topics.join(" "),
     tags: (item.userState.tags ?? []).join(" "),
     highlights: (item.userState.highlights ?? [])
@@ -93,23 +93,6 @@ const FIELD_BOOST: Partial<Record<keyof Omit<SearchDoc, "id">, number>> = {
   preservedText: 1,
 };
 
-/**
- * Derive a stable string that changes only when searchable content changes --
- * not when userState.readAt / saved / archived flip. This prevents a full index
- * rebuild on every scroll-to-read or bookmark toggle while a query is active.
- */
-function contentFingerprint(items: FeedItem[]): string {
-  // Fast path: join IDs + searchable-content lengths. Not a cryptographic hash,
-  // but false-positive rebuilds (same content, same fingerprint) are safe.
-  return items
-    .map((item) => {
-      const tagsKey = (item.userState.tags ?? []).join(",");
-      const hlKey = (item.userState.highlights ?? []).length;
-      return `${item.globalId}:${item.content.text?.length ?? 0}:${item.preservedContent?.text?.length ?? 0}:${tagsKey}:${hlKey}`;
-    })
-    .join("|");
-}
-
 function buildIndex(items: FeedItem[]): MiniSearch<SearchDoc> {
   const ms = new MiniSearch<SearchDoc>({
     idField: "id",
@@ -142,22 +125,28 @@ export function useSearchResults(
   items: FeedItem[],
   searchQuery: string,
   activeFilter: FilterOptions,
+  searchCorpusVersion: number,
 ): SearchResults {
   const trimmedQuery = searchQuery.trim();
 
-  // Cache the index and the fingerprint it was built from across renders.
+  // Cache the index and the corpus version it was built from across renders.
   // Using refs instead of useMemo lets us control invalidation independently of
   // React's referential equality check on `items`.
   const indexRef = useRef<MiniSearch<SearchDoc> | null>(null);
-  const fingerprintRef = useRef<string>("");
+  const versionRef = useRef<number>(-1);
+
+  if (!trimmedQuery) {
+    indexRef.current = null;
+    versionRef.current = -1;
+  }
 
   // When a query is active, ensure the index is up to date with the current
-  // corpus. We only rebuild if the content fingerprint has changed.
+  // corpus. The worker bumps searchCorpusVersion only for search-relevant
+  // changes, so mark-as-read, save, and archive churn does not rebuild.
   if (trimmedQuery) {
-    const fp = contentFingerprint(items);
-    if (!indexRef.current || fp !== fingerprintRef.current) {
+    if (!indexRef.current || searchCorpusVersion !== versionRef.current) {
       indexRef.current = buildIndex(items);
-      fingerprintRef.current = fp;
+      versionRef.current = searchCorpusVersion;
     }
   }
 
@@ -199,5 +188,5 @@ export function useSearchResults(
     );
 
     return { filteredItems: sorted, isSearching: true, resultCount: sorted.length };
-  }, [items, trimmedQuery, activeFilter]);
+  }, [items, trimmedQuery, activeFilter, searchCorpusVersion]);
 }


### PR DESCRIPTION
(AI Generated).

## Summary
- reduce search memory retention by clearing the MiniSearch index when search is inactive
- rebuild the search index only when the worker reports a search-relevant corpus change
- replace the broken heap test path with working CDP heap usage checks and add a heavy preserved-text search experiment

## Verification
- corepack npm run test:e2e --workspace=packages/desktop -- tests/e2e/perf-feed.spec.ts -g "Memory profiling"
- corepack npm run build --workspace=packages/desktop
- corepack npm run build --workspace=packages/pwa
