### PR TITLE
fix: show map pins for all content

### DIFF
--- a/docs/PHASE-7-SOCIAL-CAPTURE.md
+++ b/docs/PHASE-7-SOCIAL-CAPTURE.md
@@ -1,6 +1,6 @@
 # Phase 7: Facebook + Instagram Capture
 
-> **Status:** 🚧 In Progress — Facebook and Instagram integrated into Desktop via Tauri WebView scraping, with feed pollution filtering, silent background media guarding, provider health summaries, smart backoff, and Facebook group controls
+> **Status:** 🚧 In Progress — Facebook and Instagram integrated into Desktop via Tauri WebView scraping, with feed pollution filtering, silent background media guarding, provider health summaries, smart backoff, Facebook group controls, and preserved Instagram story location metadata for map recovery
 > **Dependencies:** Phase 5 (Desktop App)
 
 ---
@@ -98,7 +98,7 @@ Self-contained JavaScript injected into the WebView's execution context. No exte
 - **Facebook** (`fb-extract.js`): Locates "Feed posts" h3, walks subtrees for post-sized blocks
 - **Instagram** (`ig-extract.js`): Queries `<article>` elements, extracts author/caption/media from semantic header/footer structure
 - **Facebook stories** (`fb-stories-extract.js`): Injected into the FB story viewer overlay. Extracts author, media, timestamp, location/check-in. Emits via `fb-feed-data` with `postType: "story"`.
-- **Instagram stories** (`ig-stories-extract.js`): Injected into the IG story viewer overlay. Extracts author handle (from URL + DOM), media URL, timestamp, location sticker. Emits via `ig-feed-data` with `postType: "story"`.
+- **Instagram stories** (`ig-stories-extract.js`): Injected into the IG story viewer overlay. Extracts author handle (from URL + DOM), media URL, timestamp, and location sticker metadata. The normalized `FeedItem.location` now preserves the sticker source plus Instagram `locationUrl`, so later map resolution can recover real place names from generic labels such as `Locations`.
 
 Story scraping is interleaved with feed scraping in each session. A coin flip (~50%) determines whether stories are scraped before or after the initial feed passes. ~15% of sessions skip story scraping entirely (real users don't always check stories). Up to 30 story frames are captured per session.
 
@@ -138,7 +138,7 @@ const RATE_LIMITS = {
 | 7.8  | Rate limiting to avoid bans                 | ✓ Complete  |
 | 7.9  | Selector versioning strategy                | ✓ Complete  |
 | 7.10 | Location extraction (for Phase 8)           | ✓ Complete  |
-| 7.11 | Stories capture (IG + FB)                   | 🚧 In Progress |
+| 7.11 | Stories capture (IG + FB, with map-ready location metadata) | 🚧 In Progress |
 | 7.12 | Social engagement write-back (like, seen)   | ✓ Complete  |
 | 7.13 | Outbox processor for cross-device sync      | ✓ Complete  |
 | 7.14 | Comment links (open on platform)            | ✓ Complete  |
@@ -175,7 +175,7 @@ const RATE_LIMITS = {
 - [x] Sync indicator panel shows both platforms
 - [ ] Facebook feed posts validated against real account (selector tuning)
 - [ ] Instagram feed posts validated against real account (selector tuning)
-- [~] Stories captured — IG + FB story scraping integrated, with stable IG story IDs and selector tuning still needed
+- [~] Stories captured, with IG + FB story scraping integrated and Instagram story location URLs preserved for map recovery. Stable IG story IDs and selector tuning still need work.
 - [ ] Cross-platform dedup (task 7.15): IG/FB cross-posted stories/posts create duplicate FeedItems because globalId is platform-prefixed (ig: vs fb:). The existing docDeduplicateFeedItems only deduplicates by linkPreview.url. A content-similarity pass is needed: match items by same Friend identity + similar text (first 120 chars) + timestamps within a few minutes.
 - [x] Like button with outbox pattern: intent recorded immediately, synced to platform async
 - [x] Two-state like UI: "noted" (amber) vs "memorialized" (red confirmed on platform)

--- a/docs/PHASE-8-FRIENDS.md
+++ b/docs/PHASE-8-FRIENDS.md
@@ -11,7 +11,7 @@ A friend CRM built on a force-directed social graph. Unify a person's blog RSS f
 
 Clicking a friend zooms in to show a chronological timeline of everything they've posted across all their linked social channels.
 
-The geo map from the original Phase 8 design is retained as sub-phase 8D, now powered by Friend identities so pins cluster by person rather than by platform and render in Freed's dark purple visual language.
+The geo map from the original Phase 8 design is retained as sub-phase 8D. It now supports both Friend-linked pins and an `All content` fallback that shows the latest valid location per followed account when no Friend graph exists yet.
 
 This phase also becomes the home for future-aware social planning. Historical post locations still matter, but the map and friend timeline now need to handle future-dated place windows from sources like Mozi, plus derived overlap views when multiple friends are in the same place at the same time.
 
@@ -42,7 +42,8 @@ This phase also becomes the home for future-aware social planning. Historical po
 ┌──────────────────────────────────────────────────────────────────┐
 │                 8D: Location / Time-Aware Map View               │
 │  FeedItems + time windows → location extraction → Nominatim      │
-│  geocoding → cache → MapLibre markers (latest pin per Friend)    │
+│  geocoding → cache → MapLibre markers (latest pin per Friend or   │
+│  latest valid pin per followed account in All content mode)       │
 │  → timeline scrubber → derived overlap views                     │
 └──────────────────────────────────────────────────────────────────┘
 ```
@@ -156,10 +157,10 @@ Default nudge intervals by care level:
 ## 8D: Location / Map View
 
 ```
-FeedItems → extractLocationFromItem() + optional time window → geocode() (Nominatim) → cache → MapLibre markers → timeline scrubber → derived overlap views
+FeedItems → extractLocationFromItem() + optional time window → geocode() (Nominatim) → cache → MapLibre markers → Friends mode or All content mode → timeline scrubber → derived overlap views
 ```
 
-Sources for location: Instagram geo-tags, Facebook check-ins, X geo-tags (rare), text patterns ("📍 Paris"), **and IG/FB story location stickers** (Phase 7.11). Planned future sources such as Mozi add another class of signal: place windows that may sit in the future instead of the past.
+Sources for location: Instagram geo-tags, Facebook check-ins, X geo-tags (rare), text patterns ("📍 Paris"), **and IG/FB story location stickers** (Phase 7.11). Low-confidence story labels are recovered from preserved Instagram location URLs when possible, or dropped when they cannot be trusted. Planned future sources such as Mozi add another class of signal: place windows that may sit in the future instead of the past.
 
 > **Note:** Stories cross-posted from Instagram to Facebook (or vice versa) currently create two separate FeedItems with different `globalId` prefixes (`ig:` vs `fb:`), which can produce duplicate map pins for the same location event. Phase 7.15 (cross-platform dedup) will address this by matching items with the same Friend identity + similar text + timestamps within a few minutes.
 
@@ -207,6 +208,7 @@ Friend captions in the graph now use pill backgrounds and label-aware spacing, s
 Friend avatars now inherit a theme-authored tint across the Friends graph and map markers, so each theme stays coherent without a stray custom accent fighting the palette.
 Map popovers now use a wider card layout and deliberately omit the old MapLibre tail, so place names and actions fit cleanly without the popup looking like a speech bubble from a cheaper app.
 Friends and Map now consume the same shared theme tokens, button treatments, shell backgrounds, surface recipes, and theme-native map palettes as the rest of Freed, so themes like Neon, Midas, Vesper, Ember, and Scriptorium land consistently across the graph, sidebars, popovers, mini-map cards, editor, contact-sync flows, and map basemap itself.
+The shared map now includes a persisted `Friends` / `All content` toggle. It restores the user's last mode from preferences and defaults to `All content` when the library has geolocatable followed accounts but no friend-linked pins yet.
 
 ---
 
@@ -239,6 +241,7 @@ Friends and Map now consume the same shared theme tokens, button treatments, she
 | 8.23 | Render derived overlap states in map and Friend detail surfaces | Medium | Not Started |
 | 8.24 | Support Mozi-backed friend/location events in identity and map flows | Medium | Not Started |
 | 8.25 | Include Google contact sync state in desktop disaster-recovery snapshots | Low | Done |
+| 8.26 | Add persisted `Friends` / `All content` map modes with latest-author pins | Medium | Done |
 
 ---
 
@@ -268,6 +271,10 @@ Friends and Map now consume the same shared theme tokens, button treatments, she
 - [x] Friends and Map inherit the shared multi-theme design system instead of hardcoded one-off gradients
 - [x] Sample data refresh rebuilds a 25-friend social graph with linked profiles and recent map activity
 - [x] Sidebar shows live counts for Friends and recent friend location updates on Map
+- [x] Map supports persisted `Friends` and `All content` modes
+- [x] Map defaults to `All content` when there are valid author pins but no friend-linked pins
+- [x] `All content` mode shows the latest valid location per followed account
+- [x] Generic Instagram story labels are recovered from preserved location URLs or excluded from the map
 - [ ] macOS native contact picker (CNContactStore)
 - [x] Map promoted to live sidebar navigation
 - [ ] Future-aware map filtering supports past, current, and future location windows

--- a/packages/capture-instagram/src/normalize.ts
+++ b/packages/capture-instagram/src/normalize.ts
@@ -55,7 +55,8 @@ function buildLocation(post: RawIgPost): Location | undefined {
   if (!post.location) return undefined;
   return {
     name: post.location,
-    source: "geo_tag",
+    ...(post.locationUrl ? { url: post.locationUrl } : {}),
+    source: post.postType === "story" ? "sticker" : "geo_tag",
   };
 }
 

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -1288,7 +1288,7 @@ dependencies = [
 
 [[package]]
 name = "freed-desktop"
-version = "26.4.1403"
+version = "26.4.1601"
 dependencies = [
  "base64 0.22.1",
  "criterion",

--- a/packages/desktop/src/lib/instagram-normalize.test.ts
+++ b/packages/desktop/src/lib/instagram-normalize.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { igPostToFeedItem } from "@freed/capture-instagram/browser";
+
+describe("igPostToFeedItem", () => {
+  it("preserves story location metadata and marks it as a sticker", () => {
+    const item = igPostToFeedItem({
+      shortcode: "story_123",
+      url: "https://www.instagram.com/stories/ada/123/",
+      authorHandle: "ada",
+      authorDisplayName: "Ada",
+      authorAvatarUrl: null,
+      authorProfileUrl: "https://www.instagram.com/ada/",
+      caption: null,
+      timestampIso: "2026-04-16T22:00:00.000Z",
+      mediaUrls: ["https://cdn.example/story.jpg"],
+      isVideo: false,
+      isCarousel: false,
+      likeCount: null,
+      commentCount: null,
+      hashtags: [],
+      location: "Locations",
+      locationUrl: "https://www.instagram.com/explore/locations/123456789/big-bear-california/",
+      postType: "story",
+    });
+
+    expect(item?.location).toEqual({
+      name: "Locations",
+      url: "https://www.instagram.com/explore/locations/123456789/big-bear-california/",
+      source: "sticker",
+    });
+  });
+
+  it("keeps standard Instagram posts as geo tags", () => {
+    const item = igPostToFeedItem({
+      shortcode: "abc123",
+      url: "https://www.instagram.com/p/abc123/",
+      authorHandle: "ada",
+      authorDisplayName: "Ada",
+      authorAvatarUrl: null,
+      authorProfileUrl: "https://www.instagram.com/ada/",
+      caption: "Hello from Paris",
+      timestampIso: "2026-04-16T22:00:00.000Z",
+      mediaUrls: ["https://cdn.example/post.jpg"],
+      isVideo: false,
+      isCarousel: false,
+      likeCount: 10,
+      commentCount: 1,
+      hashtags: ["paris"],
+      location: "Paris, France",
+      locationUrl: "https://www.instagram.com/explore/locations/6889842/paris-france/",
+      postType: "photo",
+    });
+
+    expect(item?.location).toEqual({
+      name: "Paris, France",
+      url: "https://www.instagram.com/explore/locations/6889842/paris-france/",
+      source: "geo_tag",
+    });
+  });
+});

--- a/packages/desktop/src/lib/store-preferences.test.ts
+++ b/packages/desktop/src/lib/store-preferences.test.ts
@@ -83,4 +83,16 @@ describe("store.updatePreferences", () => {
       error.message,
     );
   });
+
+  it("passes map mode preference updates through to persistence", async () => {
+    await expect(
+      useAppStore.getState().updatePreferences({
+        display: { mapMode: "all_content" },
+      } as never),
+    ).resolves.toBeUndefined();
+
+    expect(mockDocUpdatePreferences).toHaveBeenCalledWith({
+      display: { mapMode: "all_content" },
+    });
+  });
 });

--- a/packages/desktop/tests/e2e/fixtures/app.ts
+++ b/packages/desktop/tests/e2e/fixtures/app.ts
@@ -278,6 +278,130 @@ export class AppFixture {
       });
     });
   }
+
+  async seedAllContentLocationsWithoutFriends(): Promise<void> {
+    await this.page.evaluate(async () => {
+      const w = window as Record<string, unknown>;
+      const automerge = w.__FREED_AUTOMERGE__ as {
+        docAddFeedItems: (items: unknown[]) => Promise<void>;
+      };
+      const store = w.__FREED_STORE__ as {
+        getState: () => {
+          friends: Record<string, unknown>;
+          items: Array<{ globalId: string }>;
+        };
+      };
+
+      const now = Date.now();
+      await automerge.docAddFeedItems([
+        {
+          globalId: "ig:nora:paris",
+          platform: "instagram",
+          contentType: "post",
+          capturedAt: now - 120_000,
+          publishedAt: now - 120_000,
+          author: {
+            id: "nora-ig",
+            handle: "nora",
+            displayName: "Nora Quinn",
+          },
+          content: {
+            text: "Earlier stop in Paris",
+            mediaUrls: [],
+            mediaTypes: [],
+          },
+          location: {
+            name: "Paris",
+            coordinates: { lat: 48.8566, lng: 2.3522 },
+            source: "geo_tag",
+          },
+          userState: {
+            hidden: false,
+            saved: false,
+            archived: false,
+            tags: [],
+          },
+          topics: [],
+        },
+        {
+          globalId: "ig:nora:story",
+          platform: "instagram",
+          contentType: "story",
+          capturedAt: now - 60_000,
+          publishedAt: now - 60_000,
+          author: {
+            id: "nora-ig",
+            handle: "nora",
+            displayName: "Nora Quinn",
+          },
+          content: {
+            text: "Recoverable story location",
+            mediaUrls: [],
+            mediaTypes: [],
+          },
+          location: {
+            name: "Locations",
+            coordinates: { lat: 34.2439, lng: -116.9114 },
+            url: "https://www.instagram.com/explore/locations/123456789/big-bear-california/",
+            source: "sticker",
+          },
+          userState: {
+            hidden: false,
+            saved: false,
+            archived: false,
+            tags: [],
+          },
+          topics: [],
+        },
+        {
+          globalId: "ig:ghost:story",
+          platform: "instagram",
+          contentType: "story",
+          capturedAt: now - 30_000,
+          publishedAt: now - 30_000,
+          author: {
+            id: "ghost-ig",
+            handle: "ghost",
+            displayName: "Ghost Noise",
+          },
+          content: {
+            text: "Should not show on the map",
+            mediaUrls: [],
+            mediaTypes: [],
+          },
+          location: {
+            name: "Check registration",
+            source: "sticker",
+          },
+          userState: {
+            hidden: false,
+            saved: false,
+            archived: false,
+            tags: [],
+          },
+          topics: [],
+        },
+      ]);
+
+      await new Promise<void>((resolve, reject) => {
+        const startedAt = Date.now();
+        const interval = window.setInterval(() => {
+          const state = store.getState();
+          const hasNora = state.items.some((item) => item.globalId === "ig:nora:story");
+          const hasGhost = state.items.some((item) => item.globalId === "ig:ghost:story");
+          if (hasNora && hasGhost) {
+            clearInterval(interval);
+            resolve();
+            return;
+          }
+          if (Date.now() - startedAt > 5_000) {
+            clearInterval(interval);
+            reject(new Error("seed timeout"));
+          }
+        }, 50);
+      });
+    });
+  }
 }
 
 export async function acceptLegalGate(page: Page, timeout = 5_000): Promise<boolean> {

--- a/packages/desktop/tests/e2e/smoke.spec.ts
+++ b/packages/desktop/tests/e2e/smoke.spec.ts
@@ -1198,6 +1198,49 @@ test("Friend detail last seen card opens the full Map view", async ({ app }) => 
   });
 });
 
+test("map defaults to All content when only unlinked author locations exist", async ({ app, page }) => {
+  await app.goto();
+  await app.waitForReady();
+  await app.seedAllContentLocationsWithoutFriends();
+  await dismissCloudSyncNudgeIfPresent(page);
+
+  await page.getByRole("button", { name: /^Map/ }).click();
+  const allContentButton = page.getByRole("button", { name: "All content", exact: true });
+  await expect(allContentButton).toHaveClass(/theme-chip-active/, { timeout: 10_000 });
+  await expect(page.locator('.freed-map-marker[aria-label="Nora Quinn"]')).toBeVisible({
+    timeout: 10_000,
+  });
+  await expect(page.locator('.freed-map-marker[aria-label="Ghost Noise"]')).toHaveCount(0);
+});
+
+test("recoverable story locations appear in All content mode and the mode persists", async ({ app, page }) => {
+  await app.goto();
+  await app.waitForReady();
+  await app.seedFriendLocation();
+  await app.seedAllContentLocationsWithoutFriends();
+  await dismissCloudSyncNudgeIfPresent(page);
+
+  await page.getByRole("button", { name: /^Map/ }).click();
+  const allContentButton = page.getByRole("button", { name: "All content", exact: true });
+  await allContentButton.click();
+  await expect(allContentButton).toHaveClass(/theme-chip-active/, { timeout: 10_000 });
+
+  await openVisibleMapMarker(page, "Nora Quinn");
+  await expect(page.getByText("Big Bear California")).toBeVisible({ timeout: 10_000 });
+
+  await page.reload();
+  await app.waitForReady();
+  await dismissCloudSyncNudgeIfPresent(page);
+  await page.getByRole("button", { name: /^Map/ }).click();
+  await expect(page.getByRole("button", { name: "All content", exact: true })).toHaveClass(
+    /theme-chip-active/,
+    { timeout: 10_000 },
+  );
+  await expect(page.locator('.freed-map-marker[aria-label="Nora Quinn"]')).toBeVisible({
+    timeout: 10_000,
+  });
+});
+
 test("Friends view uses the floating detail drawer shell", async ({ app, page }) => {
   await page.setViewportSize({ width: 1440, height: 900 });
   await app.goto();

--- a/packages/pwa/src/lib/map-locations.test.ts
+++ b/packages/pwa/src/lib/map-locations.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  extractLocationFromItem,
+  getDefaultMapMode,
+  getLatestAuthorLocationMarkers,
   getLatestFriendLocationMarkers,
   getLastSeenLocationForFriend,
   groupResolvedLocations,
@@ -203,6 +206,85 @@ describe("location grouping", () => {
     ]);
     expect(markers[0]?.label).toBe("London");
     expect(markers[0]?.item.globalId).toBe("ig:2");
+  });
+
+  it("shows only the newest location per author in all-content mode", () => {
+    const ada = makeFriend({ id: "friend-ada" });
+
+    const markers = getLatestAuthorLocationMarkers([
+      {
+        item: makeItem({ globalId: "ig:1", publishedAt: 10 }),
+        friend: ada,
+        lat: 37.7749,
+        lng: -122.4194,
+        label: "San Francisco",
+      },
+      {
+        item: makeItem({ globalId: "ig:2", publishedAt: 40 }),
+        friend: ada,
+        lat: 51.5072,
+        lng: -0.1276,
+        label: "London",
+      },
+      {
+        item: makeItem({
+          globalId: "ig:3",
+          publishedAt: 30,
+          author: { id: "maya-ig", handle: "maya", displayName: "Maya" },
+        }),
+        friend: null,
+        lat: 48.8566,
+        lng: 2.3522,
+        label: "Paris",
+      },
+    ]);
+
+    expect(markers).toHaveLength(2);
+    expect(markers.map((marker) => marker.authorKey)).toEqual([
+      "author:instagram:ada-ig",
+      "author:instagram:maya-ig",
+    ]);
+    expect(markers[0]?.label).toBe("London");
+    expect(markers[0]?.item.globalId).toBe("ig:2");
+  });
+
+  it("recovers story place names from Instagram location URLs when the label is junk", () => {
+    const signal = extractLocationFromItem(
+      makeItem({
+        globalId: "ig:story-1",
+        publishedAt: 10,
+        contentType: "story",
+        location: {
+          name: "Locations",
+          url: "https://www.instagram.com/explore/locations/123456789/big-bear-california/",
+          source: "sticker",
+        },
+      }),
+    );
+
+    expect(signal).toEqual({ name: "Big Bear California" });
+  });
+
+  it("rejects unrecoverable generic story labels", () => {
+    const signal = extractLocationFromItem(
+      makeItem({
+        globalId: "ig:story-2",
+        publishedAt: 10,
+        contentType: "story",
+        location: {
+          name: "Check registration",
+          source: "sticker",
+        },
+      }),
+    );
+
+    expect(signal).toBeNull();
+  });
+
+  it("defaults to all content when there are no friend markers", () => {
+    expect(getDefaultMapMode(0, 4)).toBe("all_content");
+    expect(getDefaultMapMode(2, 4)).toBe("friends");
+    expect(getDefaultMapMode(0, 0)).toBe("friends");
   });
 });
 

--- a/packages/shared/src/location.ts
+++ b/packages/shared/src/location.ts
@@ -5,7 +5,7 @@
  */
 
 import { friendForAuthor } from "./friends";
-import type { FeedItem, Friend } from "./types.js";
+import type { FeedItem, Friend, MapMode } from "./types.js";
 
 // =============================================================================
 // Types
@@ -44,6 +44,15 @@ export interface LocationMarkerSummary {
   seenAt: number;
 }
 
+interface NamedLocationSignal {
+  name: string;
+}
+
+export interface LocationCandidate {
+  coordinates?: { lat: number; lng: number };
+  name?: string;
+}
+
 // =============================================================================
 // Text pattern extraction
 // =============================================================================
@@ -68,6 +77,86 @@ export function extractLocationFromText(text: string): string | null {
   return null;
 }
 
+const LOW_CONFIDENCE_LOCATION_LABELS = new Set([
+  "locations",
+  "check registration",
+]);
+
+function titleCaseLocationSlug(value: string): string {
+  return value
+    .split(" ")
+    .filter(Boolean)
+    .map((part) => {
+      if (part.length <= 2) return part.toUpperCase();
+      return part.charAt(0).toUpperCase() + part.slice(1);
+    })
+    .join(" ");
+}
+
+export function isLowConfidenceLocationLabel(label: string | null | undefined): boolean {
+  const normalized = label?.trim().toLowerCase();
+  if (!normalized) return true;
+  return LOW_CONFIDENCE_LOCATION_LABELS.has(normalized);
+}
+
+export function recoverLocationNameFromUrl(url: string | null | undefined): string | null {
+  if (!url) return null;
+
+  try {
+    const parsed = new URL(url, "https://www.instagram.com");
+    const segments = parsed.pathname.split("/").filter(Boolean);
+    const locationIndex = segments.findIndex((segment) => segment === "locations");
+    const slug = locationIndex >= 0 ? segments[locationIndex + 2] ?? null : segments.at(-1) ?? null;
+    if (!slug) return null;
+
+    const decoded = decodeURIComponent(slug)
+      .replace(/[_-]+/g, " ")
+      .replace(/\s+/g, " ")
+      .trim();
+
+    if (!decoded || /^\d+$/.test(decoded)) return null;
+    if (isLowConfidenceLocationLabel(decoded)) return null;
+
+    return titleCaseLocationSlug(decoded);
+  } catch {
+    return null;
+  }
+}
+
+export function sanitizeLocationName(
+  name: string | null | undefined,
+  url: string | null | undefined,
+): string | null {
+  const trimmed = name?.trim() ?? "";
+  if (!trimmed || isLowConfidenceLocationLabel(trimmed)) {
+    return recoverLocationNameFromUrl(url);
+  }
+  return trimmed;
+}
+
+export function getLocationCandidate(item: FeedItem): LocationCandidate | null {
+  if (item.location?.coordinates) {
+    const sanitizedName = sanitizeLocationName(item.location.name, item.location.url);
+    return {
+      coordinates: item.location.coordinates,
+      ...(sanitizedName ? { name: sanitizedName } : {}),
+    };
+  }
+
+  const sanitizedName = sanitizeLocationName(item.location?.name, item.location?.url);
+  if (sanitizedName) {
+    return { name: sanitizedName };
+  }
+
+  const text = item.content.text;
+  if (text) {
+    const extracted = extractLocationFromText(text);
+    if (extracted) return { name: extracted };
+  }
+
+  return null;
+}
+
 // =============================================================================
 // FeedItem location extraction
 // =============================================================================
@@ -84,34 +173,33 @@ export function extractLocationFromText(text: string): string | null {
  */
 export function extractLocationFromItem(
   item: FeedItem
-): { coordinates: { lat: number; lng: number }; name?: string } | { name: string } | null {
-  // 1. Explicit coordinates from geo-tag or check-in
-  if (item.location?.coordinates) {
+): { coordinates: { lat: number; lng: number }; name?: string } | NamedLocationSignal | null {
+  const candidate = getLocationCandidate(item);
+  if (!candidate) return null;
+  if (candidate.coordinates) {
     return {
-      coordinates: item.location.coordinates,
-      name: item.location.name,
+      coordinates: candidate.coordinates,
+      ...(candidate.name ? { name: candidate.name } : {}),
     };
   }
-
-  // 2. Named location without coordinates — needs geocoding
-  if (item.location?.name) {
-    return { name: item.location.name };
+  if (candidate.name) {
+    return { name: candidate.name };
   }
-
-  // 3. Text extraction
-  const text = item.content.text;
-  if (text) {
-    const extracted = extractLocationFromText(text);
-    if (extracted) return { name: extracted };
-  }
-
   return null;
+}
+
+function authorIdentityKey(item: FeedItem): string {
+  return `author:${item.platform}:${item.author.id}`;
+}
+
+function friendIdentityKey(friend: Friend): string {
+  return `friend:${friend.id}`;
 }
 
 function markerIdentityKey(resolved: ResolvedLocationItem): string {
   return resolved.friend
-    ? `friend:${resolved.friend.id}`
-    : `author:${resolved.item.platform}:${resolved.item.author.id}`;
+    ? friendIdentityKey(resolved.friend)
+    : authorIdentityKey(resolved.item);
 }
 
 function coordinateKey(lat: number, lng: number): string {
@@ -197,6 +285,43 @@ export function getLatestFriendLocationMarkers(
     .sort((a, b) => b.seenAt - a.seenAt);
 }
 
+export function getLatestAuthorLocationMarkers(
+  resolvedItems: ResolvedLocationItem[]
+): LocationMarkerSummary[] {
+  const latestByAuthor = new Map<string, ResolvedLocationItem>();
+
+  for (const resolved of resolvedItems) {
+    const authorKey = authorIdentityKey(resolved.item);
+    const existing = latestByAuthor.get(authorKey);
+    if (!existing || resolved.item.publishedAt > existing.item.publishedAt) {
+      latestByAuthor.set(authorKey, resolved);
+    }
+  }
+
+  return Array.from(latestByAuthor.entries())
+    .map(([authorKey, resolved]) => {
+      const pointKey = coordinateKey(resolved.lat, resolved.lng);
+      const groupCount = resolvedItems.filter(
+        (candidate) =>
+          authorIdentityKey(candidate.item) === authorKey &&
+          coordinateKey(candidate.lat, candidate.lng) === pointKey
+      ).length;
+
+      return {
+        key: authorKey,
+        authorKey,
+        friend: resolved.friend,
+        item: resolved.item,
+        lat: resolved.lat,
+        lng: resolved.lng,
+        label: resolved.label,
+        groupCount,
+        seenAt: resolved.item.publishedAt,
+      };
+    })
+    .sort((a, b) => b.seenAt - a.seenAt);
+}
+
 export function getLastSeenLocationForFriend(
   resolvedItems: ResolvedLocationItem[],
   friendId: string
@@ -228,4 +353,30 @@ export function countFriendsWithRecentLocationUpdates(
   }
 
   return friendIds.size;
+}
+
+export function countAuthorsWithRecentLocationUpdates(
+  items: FeedItem[],
+  windowMs: number = 7 * 24 * 60 * 60 * 1000,
+  now: number = Date.now()
+): number {
+  const cutoff = now - windowMs;
+  const authorIds = new Set<string>();
+
+  for (const item of items) {
+    if (item.publishedAt < cutoff) continue;
+    if (!extractLocationFromItem(item)) continue;
+    authorIds.add(authorIdentityKey(item));
+  }
+
+  return authorIds.size;
+}
+
+export function getDefaultMapMode(
+  friendMarkerCount: number,
+  allContentMarkerCount: number
+): MapMode {
+  if (friendMarkerCount > 0) return "friends";
+  if (allContentMarkerCount > 0) return "all_content";
+  return "friends";
 }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -56,6 +56,8 @@ export type LocationSource =
   | "sticker"
   | "text_extraction";
 
+export type MapMode = "friends" | "all_content";
+
 // =============================================================================
 // Feed Item
 // =============================================================================
@@ -105,6 +107,7 @@ export interface Engagement {
 export interface Location {
   name: string;
   coordinates?: { lat: number; lng: number };
+  url?: string;
   source: LocationSource;
 }
 
@@ -528,6 +531,9 @@ export interface DisplayPreferences {
 
   /** Debug panel width in pixels (default: 320, min: 280, max: 600) */
   debugPanelWidth?: number;
+
+  /** Saved map display mode. Unset means compute a default from available data. */
+  mapMode?: MapMode;
 
   /** Days to keep archived items before pruning (default: 30, 0 = never prune) */
   archivePruneDays: number;

--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -1,5 +1,9 @@
 import { useState, useEffect, useRef, useMemo, useCallback, type CSSProperties, type ReactNode } from "react";
-import { countFriendsWithRecentLocationUpdates } from "@freed/shared";
+import {
+  countAuthorsWithRecentLocationUpdates,
+  countFriendsWithRecentLocationUpdates,
+  getDefaultMapMode,
+} from "@freed/shared";
 import { AddFeedDialog } from "../AddFeedDialog.js";
 import { SavedContentDialog } from "../SavedContentDialog.js";
 import { Tooltip } from "../Tooltip.js";
@@ -110,6 +114,12 @@ export function Header({ onMenuClick, sidebarExpanded, onSidebarToggle }: Header
     () => countFriendsWithRecentLocationUpdates(items, friends),
     [friends, items],
   );
+  const mappedAllContentCount = useMemo(
+    () => countAuthorsWithRecentLocationUpdates(items),
+    [items],
+  );
+  const effectiveMapMode = display.mapMode
+    ?? getDefaultMapMode(mappedFriendCount, mappedAllContentCount);
 
   const unreadCount =
     activeFilter.savedOnly || activeFilter.archivedOnly
@@ -152,6 +162,9 @@ export function Header({ onMenuClick, sidebarExpanded, onSidebarToggle }: Header
       return `${friendCount.toLocaleString()} friends`;
     }
     if (activeView === "map") {
+      if (effectiveMapMode === "all_content") {
+        return `${mappedAllContentCount.toLocaleString()} accounts on the map`;
+      }
       return `${mappedFriendCount.toLocaleString()} friends on the map`;
     }
     if (isSearching) {
@@ -162,7 +175,9 @@ export function Header({ onMenuClick, sidebarExpanded, onSidebarToggle }: Header
     activeView,
     filteredItems.length,
     friendCount,
+    effectiveMapMode,
     isSearching,
+    mappedAllContentCount,
     mappedFriendCount,
     pendingMatchCount,
     resultCount,

--- a/packages/ui/src/components/layout/Sidebar.tsx
+++ b/packages/ui/src/components/layout/Sidebar.tsx
@@ -1,6 +1,12 @@
 import { useState, useCallback, useEffect, useRef, useMemo, type ReactNode } from "react";
 
-import { countFriendsWithRecentLocationUpdates, type FilterOptions, type RssFeed } from "@freed/shared";
+import {
+  countAuthorsWithRecentLocationUpdates,
+  countFriendsWithRecentLocationUpdates,
+  getDefaultMapMode,
+  type FilterOptions,
+  type RssFeed,
+} from "@freed/shared";
 import { useAppStore, usePlatform, type SidebarSourceStatusSummary } from "../../context/PlatformContext.js";
 import { ProviderStatusIndicator } from "../ProviderStatusIndicator.js";
 import { SettingsDialog } from "../SettingsDialog.js";
@@ -407,6 +413,7 @@ export function Sidebar({ open, onClose, desktopExpanded = true }: SidebarProps)
   const activeView = useAppStore((s) => s.activeView);
   const setActiveView = useAppStore((s) => s.setActiveView);
   const pendingMatchCount = useAppStore((s) => s.pendingMatchCount);
+  const display = useAppStore((s) => s.preferences.display);
   const health = useDebugStore((s) => s.health);
 
   const savedCount = useMemo(() => items.filter((i) => i.userState.saved).length, [items]);
@@ -416,6 +423,15 @@ export function Sidebar({ open, onClose, desktopExpanded = true }: SidebarProps)
     () => countFriendsWithRecentLocationUpdates(items, friends),
     [friends, items]
   );
+  const mapAllContentCount = useMemo(
+    () => countAuthorsWithRecentLocationUpdates(items),
+    [items],
+  );
+  const effectiveMapMode = display.mapMode
+    ?? getDefaultMapMode(mapFriendCount, mapAllContentCount);
+  const mapCount = effectiveMapMode === "all_content"
+    ? mapAllContentCount
+    : mapFriendCount;
 
   const { open: showSettings, openDefault: openSettings, close: closeSettings } = useSettingsStore();
   const [dragWidth, setDragWidth] = useState<number | null>(null);
@@ -856,13 +872,13 @@ export function Sidebar({ open, onClose, desktopExpanded = true }: SidebarProps)
               >
                 <span className="w-5 flex items-center justify-center"><MapPinIcon /></span>
                 <span className="flex-1">Map</span>
-                {mapFriendCount > 0 && (
+                {mapCount > 0 && (
                   <span
                     className={`shrink-0 text-[10px] tabular-nums ${
                       activeView === "map" ? "text-[var(--theme-accent-secondary)]" : "text-[var(--theme-text-soft)]"
                     }`}
                   >
-                    {fmt(mapFriendCount)}
+                    {fmt(mapCount)}
                   </span>
                 )}
               </button>

--- a/packages/ui/src/components/map/MapView.tsx
+++ b/packages/ui/src/components/map/MapView.tsx
@@ -1,4 +1,5 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { type MapMode } from "@freed/shared";
 import { useAppStore } from "../../context/PlatformContext.js";
 import { useResolvedLocations } from "../../hooks/useResolvedLocations.js";
 import { openFriendFromMap, openPostFromMap } from "../../lib/map-navigation.js";
@@ -13,16 +14,61 @@ export function MapView() {
   const setActiveView = useAppStore((state) => state.setActiveView);
   const setFilter = useAppStore((state) => state.setFilter);
   const setSearchQuery = useAppStore((state) => state.setSearchQuery);
-  const themeId = useAppStore((state) => state.preferences.display.themeId);
+  const display = useAppStore((state) => state.preferences.display);
+  const updatePreferences = useAppStore((state) => state.updatePreferences);
+  const themeId = display.themeId;
 
-  const { markers } = useResolvedLocations(items, friends);
+  const { friendMarkers, allContentMarkers, defaultMode } = useResolvedLocations(items, friends);
+  const savedMode = display.mapMode;
+  const [pendingMode, setPendingMode] = useState<MapMode | null>(null);
+  const effectiveMode = pendingMode ?? savedMode ?? defaultMode;
+  const markers = effectiveMode === "friends" ? friendMarkers : allContentMarkers;
+
+  useEffect(() => {
+    if (pendingMode && savedMode === pendingMode) {
+      setPendingMode(null);
+    }
+  }, [pendingMode, savedMode]);
 
   const focusedMarker = useMemo(
     () => markers.find((marker) => marker.friend?.id === selectedFriendId) ?? null,
     [markers, selectedFriendId]
   );
+
+  const handleModeChange = (mode: MapMode) => {
+    setPendingMode(mode);
+    void updatePreferences({
+      display: {
+        mapMode: mode,
+      },
+    } as Parameters<typeof updatePreferences>[0]).catch(() => {
+      setPendingMode(null);
+    });
+  };
+
   return (
-    <div className="app-theme-shell h-full overflow-hidden">
+    <div className="app-theme-shell relative h-full overflow-hidden">
+      <div className="pointer-events-none absolute inset-x-0 top-0 z-20 flex justify-center px-4 pt-4">
+        <div className="pointer-events-auto inline-flex items-center gap-1 rounded-full border border-[color:var(--theme-border-subtle)] bg-[color:color-mix(in_oklab,var(--theme-bg-elevated)_88%,transparent)] p-1 shadow-[var(--theme-glow-sm)] backdrop-blur-md">
+          {([
+            ["friends", "Friends"],
+            ["all_content", "All content"],
+          ] as const).map(([mode, label]) => (
+            <button
+              key={mode}
+              type="button"
+              onClick={() => handleModeChange(mode)}
+              className={`rounded-full px-3 py-1.5 text-xs font-medium transition-colors ${
+                effectiveMode === mode
+                  ? "theme-chip-active"
+                  : "theme-chip"
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
       <MapSurface
         markers={markers}
         focusedMarkerKey={focusedMarker?.key ?? null}
@@ -43,7 +89,16 @@ export function MapView() {
             setSearchQuery,
           });
         }}
-        emptyBody="Friends with location data from Instagram and Facebook will appear here."
+        emptyTitle={
+          effectiveMode === "friends"
+            ? "No friend pins yet."
+            : "No location pins yet."
+        }
+        emptyBody={
+          effectiveMode === "friends"
+            ? "Switch to All content to see the latest locations from followed accounts."
+            : "Followed accounts with valid location data will appear here."
+        }
       />
     </div>
   );

--- a/packages/ui/src/hooks/useResolvedLocations.ts
+++ b/packages/ui/src/hooks/useResolvedLocations.ts
@@ -2,27 +2,34 @@ import { useEffect, useMemo, useState } from "react";
 import {
   extractLocationFromItem,
   friendForAuthor,
+  getDefaultMapMode,
+  getLatestAuthorLocationMarkers,
   getLatestFriendLocationMarkers,
   getLastSeenLocationForFriend,
   type FeedItem,
   type Friend,
   type LocationMarkerSummary,
+  type MapMode,
   type ResolvedLocationItem,
 } from "@freed/shared";
 import { geocode } from "../lib/geocoding.js";
 
 interface ResolvedLocationsState {
-  markers: LocationMarkerSummary[];
+  friendMarkers: LocationMarkerSummary[];
+  allContentMarkers: LocationMarkerSummary[];
   resolvedItems: ResolvedLocationItem[];
   lastResolvedAt: number | null;
   resolvingCount: number;
+  defaultMode: MapMode;
 }
 
 const EMPTY_STATE: ResolvedLocationsState = {
-  markers: [],
+  friendMarkers: [],
+  allContentMarkers: [],
   resolvedItems: [],
   lastResolvedAt: null,
   resolvingCount: 0,
+  defaultMode: "friends",
 };
 
 export function useResolvedLocations(
@@ -79,11 +86,16 @@ export function useResolvedLocations(
       );
       if (cancelled) return;
 
+      const friendMarkers = getLatestFriendLocationMarkers(resolvedItems);
+      const allContentMarkers = getLatestAuthorLocationMarkers(resolvedItems);
+
       setState({
-        markers: getLatestFriendLocationMarkers(resolvedItems),
+        friendMarkers,
+        allContentMarkers,
         resolvedItems,
         resolvingCount: 0,
         lastResolvedAt: Date.now(),
+        defaultMode: getDefaultMapMode(friendMarkers.length, allContentMarkers.length),
       });
     }
 

--- a/website/src/app/roadmap/RoadmapContent.tsx
+++ b/website/src/app/roadmap/RoadmapContent.tsx
@@ -755,7 +755,7 @@ const phases: Phase[] = [
     number: 7,
     title: "Facebook + Instagram",
     description:
-      "Facebook and Instagram integrated via Tauri WebView scraping, with suggested-post filtering, hardened story capture, silent background media guarding, serialized background scraper sessions, Facebook group controls, provider health summaries, and smart backoff when sync looks rate-limited.",
+      "Facebook and Instagram integrated via Tauri WebView scraping, with suggested-post filtering, hardened story capture, preserved Instagram story location metadata for map recovery, silent background media guarding, serialized background scraper sessions, Facebook group controls, provider health summaries, and smart backoff when sync looks rate-limited.",
     status: "current",
     planLink:
       "https://github.com/freed-project/freed/blob/dev/docs/PHASE-7-SOCIAL-CAPTURE.md",
@@ -764,7 +764,7 @@ const phases: Phase[] = [
     number: 8,
     title: "Friends + Social Graph",
     description:
-      "A friend CRM with a stable pan-and-zoom graph workspace, a permanent resizable reconnect sidebar, Google Contacts sync and review, theme-authored avatar styling across Friends and Map, and a map with theme-native cartography that shows each friend's latest known location with time-aware popovers. Unify profiles across platforms into one identity per person, track relationship health, restore Google contact matches from desktop snapshots, and keep growing the map into a richer view of where friends were, are, and plan to be.",
+      "A friend CRM with a stable pan-and-zoom graph workspace, a permanent resizable reconnect sidebar, Google Contacts sync and review, theme-authored avatar styling across Friends and Map, and a map with theme-native cartography that can switch between each friend's latest known location and the latest valid pin from all followed content. Unify profiles across platforms into one identity per person, persist the user's preferred map mode, restore Google contact matches from desktop snapshots, and keep growing the map into a richer view of where people were, are, and plan to be.",
     status: "current",
     planLink:
       "https://github.com/freed-project/freed/blob/dev/docs/PHASE-8-FRIENDS.md",


### PR DESCRIPTION
(AI Generated).

## Summary
- add persisted `Friends` and `All content` map modes
- recover usable Instagram story locations from preserved location URLs
- add unit and desktop E2E regressions for all-content map pins and map-mode persistence

## Validation
- corepack npm run test:unit -- src/lib/instagram-normalize.test.ts src/lib/store-preferences.test.ts
- corepack npm run test:unit -- src/lib/map-locations.test.ts
- corepack npm run test:e2e -- smoke.spec.ts -g "map defaults to All content|recoverable story locations appear in All content mode and the mode persists"
- targeted TypeScript checks for shared, ui, capture-instagram, desktop, pwa, and website