### PR TITLE
fix: carry dev prereleases into production changelog

### DIFF
--- a/docs/PHASE-5-DESKTOP.md
+++ b/docs/PHASE-5-DESKTOP.md
@@ -321,7 +321,10 @@ export async function captureDomFeed(
 > the reviewed release artifact passes validation and is approved. The latest
 > release of each day is cumulative, so website changelog cards describe
 > everything newly shipped since the previous day instead of unioning same-day
-> bullets after the fact. Release artifacts now render a distinct opener plus
+> bullets after the fact. Production releases now also carry forward
+> intermediary dev prereleases since the prior production release, so the
+> public card does not drop features that first shipped on `dev`. Release
+> artifacts now render a distinct opener plus
 > separate `Features`, `Fixes`, and `Follow-ups` sections so the card headline
 > can reinforce the theme without collapsing the details into one bucket. The
 > desktop updater now shows only that reviewed opener line when an update is

--- a/docs/RELEASE-SECRETS.md
+++ b/docs/RELEASE-SECRETS.md
@@ -112,7 +112,10 @@ raw items, related fixes and follow-ups are consolidated into grouped lines.
 
 For the latest release of a day, the generated copy is cumulative. It should
 describe everything newly shipped since the previous day, not just the delta
-from the previous same-day build.
+from the previous same-day build. Production releases also pull forward
+relevant intermediary dev prereleases that landed after the previous
+production release, so the public changelog card does not forget what just
+shipped.
 
 Freed Desktop update prompts use only the reviewed deck line. They do not
 render release bullets inside the install toast.
@@ -151,6 +154,7 @@ The in-app updater will pick the new GitHub release up automatically.
 - there are no more than 3 features
 - there are no more than 15 fixes or 15 follow-ups after consolidation
 - the latest release of a day still carries forward earlier same-day highlights
+- the latest production release also carries forward intermediary dev prereleases since the prior production release
 
 To regenerate historical artifacts and rewrite older GitHub release bodies:
 

--- a/release-notes/README.md
+++ b/release-notes/README.md
@@ -74,7 +74,8 @@ The publish step validates that:
 - the deck does not duplicate a feature or follow-up
 - there are at most 3 features
 - there are at most 15 fixes and 15 follow-ups after consolidation
-- same-day latest releases still include earlier same-day highlights
+- latest production releases still include earlier same-day production highlights
+- latest production releases can also carry forward intermediary dev prereleases since the prior production release
 
 Freed Desktop update prompts use the deck line only. They do not render bullet lists.
 

--- a/release-notes/releases/v26.4.1602.json
+++ b/release-notes/releases/v26.4.1602.json
@@ -5,25 +5,34 @@
   "dayKey": "26.4.16",
   "approved": true,
   "editorialNotes": [],
-  "generatedAt": "2026-04-17T01:51:43.006Z",
+  "generatedAt": "2026-04-17T04:23:10.452Z",
   "model": "heuristic",
   "source": {
     "channel": "production",
     "previousPublishedTag": "v26.4.1600",
     "previousPublishedDayTag": "v26.4.1400",
-    "compareRef": "HEAD",
+    "compareRef": "v26.4.1602",
     "isLatestOfDay": true,
     "sameDayTagsIncluded": [
       "v26.4.1600",
+      "v26.4.1602"
+    ],
+    "relatedBuildTags": [
+      "v26.4.1600",
+      "v26.4.1601-dev",
       "v26.4.1602"
     ],
     "prNumbers": [
       213,
       215,
       216,
-      222
+      222,
+      223,
+      224
     ],
     "commitSubjects": [
+      "release: approve v26.4.1602",
+      "release: v26.4.1602",
       "release: approve v26.4.1600",
       "release: v26.4.1600",
       "fix: clarify desktop update channel state (#222)",
@@ -34,12 +43,15 @@
     ]
   },
   "release": {
-    "deck": "Freed Desktop keeps update dialogs visible, restores read state correctly, and makes release channel status clearer, the Updates settings view now labels the installed version clearly and rechecks when you switch release channels, and update dialogs now stay above the floating new button",
+    "deck": "Freed Desktop keeps update dialogs visible, restores read state correctly, and trims sync memory growth on large saves",
     "features": [],
     "fixes": [
-      "Read state and related UI updates are restored correctly after merge recovery paths"
+      "Update dialogs stay above the floating new button, and the Updates settings view labels the installed version clearly when you switch release channels.",
+      "Read state and related UI updates restore correctly after merge recovery paths.",
+      "Map view background tiles render again across the refreshed style palette.",
+      "Desktop sync trims preserved article text before it reaches Automerge, which reduces sync memory growth on large saves."
     ],
     "followUps": []
   },
-  "releaseBody": "(AI Generated).\n\n## Freed v26.4.1602\n\nFreed Desktop keeps update dialogs visible, restores read state correctly, and makes release channel status clearer, the Updates settings view now labels the installed version clearly and rechecks when you switch release channels, and update dialogs now stay above the floating new button\n\n### Fixes\n\n- Read state and related UI updates are restored correctly after merge recovery paths\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+  "releaseBody": "(AI Generated).\n\n## Freed v26.4.1602\n\nFreed Desktop keeps update dialogs visible, restores read state correctly, and trims sync memory growth on large saves\n\n### Fixes\n\n- Update dialogs stay above the floating new button, and the Updates settings view labels the installed version clearly when you switch release channels\n- Read state and related UI updates restore correctly after merge recovery paths\n- Map view background tiles render again across the refreshed style palette\n- Desktop sync trims preserved article text before it reaches Automerge, which reduces sync memory growth on large saves\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
 }

--- a/release-notes/releases/v26.4.1602.md
+++ b/release-notes/releases/v26.4.1602.md
@@ -2,11 +2,14 @@
 
 ## Freed v26.4.1602
 
-Freed Desktop keeps update dialogs visible, restores read state correctly, and makes release channel status clearer, the Updates settings view now labels the installed version clearly and rechecks when you switch release channels, and update dialogs now stay above the floating new button
+Freed Desktop keeps update dialogs visible, restores read state correctly, and trims sync memory growth on large saves
 
 ### Fixes
 
-- Read state and related UI updates are restored correctly after merge recovery paths
+- Update dialogs stay above the floating new button, and the Updates settings view labels the installed version clearly when you switch release channels
+- Read state and related UI updates restore correctly after merge recovery paths
+- Map view background tiles render again across the refreshed style palette
+- Desktop sync trims preserved article text before it reaches Automerge, which reduces sync memory growth on large saves
 
 ### Downloads
 

--- a/scripts/prepare-release-notes.mjs
+++ b/scripts/prepare-release-notes.mjs
@@ -8,6 +8,7 @@ import {
   areNearDuplicates,
   buildReleaseDeck,
   compareTags,
+  dedupeSimilarStrings,
   dayDateFromVersion,
   MAX_FEATURES,
   normalizeReleaseText,
@@ -321,6 +322,7 @@ function defaultReleaseArtifact(tag, version, dayKey, channel) {
       compareRef: "HEAD",
       isLatestOfDay: true,
       sameDayTagsIncluded: [],
+      relatedBuildTags: [],
       prNumbers: [],
       commitSubjects: [],
     },
@@ -458,6 +460,7 @@ function releaseArtifactsMatch(existingArtifact, nextRelease, nextSource) {
     compareRef: existingArtifact.source?.compareRef ?? "HEAD",
     isLatestOfDay: Boolean(existingArtifact.source?.isLatestOfDay),
     sameDayTagsIncluded: existingArtifact.source?.sameDayTagsIncluded ?? [],
+    relatedBuildTags: existingArtifact.source?.relatedBuildTags ?? [],
     prNumbers: existingArtifact.source?.prNumbers ?? [],
     commitSubjects: existingArtifact.source?.commitSubjects ?? [],
   };
@@ -483,6 +486,10 @@ async function listPublishedReleases(channel) {
     .filter((release) => {
       if (release.draft) {
         return false;
+      }
+
+      if (channel === "all") {
+        return true;
       }
 
       if (channel === "dev") {
@@ -567,8 +574,150 @@ function collectPriorSameDayReleases(tag, dayKey, publishedReleases) {
   );
 }
 
+function dedupeNumericList(values) {
+  return [...new Set(values)].sort((a, b) => a - b);
+}
+
+function dedupeReleaseTags(tags) {
+  return [...new Set(tags)].sort(compareTags);
+}
+
+function dedupePublishedReleases(releases) {
+  const releaseMap = new Map();
+
+  for (const release of releases) {
+    releaseMap.set(release.tag_name, release);
+  }
+
+  return Array.from(releaseMap.values()).sort(compareReleases);
+}
+
+function extractPublishedReleaseDeck(body) {
+  const lines = normalizeBodyText(body).split("\n");
+  const deckLines = [];
+  let sawHeading = false;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    if (trimmed.startsWith("(AI Generated")) {
+      continue;
+    }
+
+    if (!sawHeading && /^##\s+/.test(trimmed)) {
+      sawHeading = true;
+      continue;
+    }
+
+    if (!sawHeading) {
+      continue;
+    }
+
+    if (/^###\s+/.test(trimmed)) {
+      break;
+    }
+
+    if (!trimmed) {
+      if (deckLines.length > 0) {
+        break;
+      }
+      continue;
+    }
+
+    deckLines.push(cleanDetailLine(trimmed));
+  }
+
+  return summarizeFallbackText(deckLines.join(" "));
+}
+
+function parsePublishedReleaseBody(body) {
+  const normalizedBody = normalizeBodyText(body);
+  const features = [];
+  const fixes = [];
+  const followUps = [];
+  const sectionRegex = /###\s+(.+?)\n([\s\S]*?)(?=\n###|\n##|$)/g;
+  let match;
+
+  while ((match = sectionRegex.exec(normalizedBody)) !== null) {
+    const heading = match[1].trim().toLowerCase();
+    const items = dedupeSimilarStrings(
+      match[2]
+        .split("\n")
+        .map((line) => line.trim())
+        .filter((line) => line.startsWith("- "))
+        .map((line) =>
+          summarizeFallbackText(
+            cleanDetailLine(
+              line
+                .replace(/^- /, "")
+                .replace(/\[#(\d+)\]\([^)]+\)/g, "#$1")
+                .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1"),
+            ),
+          ),
+        ),
+    );
+
+    if (heading.includes("feature") || heading.includes("new") || heading.includes("feat")) {
+      features.push(...items);
+      continue;
+    }
+
+    if (heading.includes("fix")) {
+      fixes.push(...items);
+      continue;
+    }
+
+    if (heading.includes("follow") || heading.includes("perf")) {
+      followUps.push(...items);
+    }
+  }
+
+  return sanitizeReleaseShape({
+    deck: extractPublishedReleaseDeck(normalizedBody),
+    features,
+    fixes,
+    followUps,
+  });
+}
+
+function loadPublishedReleaseSummary(release) {
+  const artifact = readJsonIfExists(releasePaths(release.tag_name).json);
+
+  if (artifact?.release) {
+    return {
+      release: releaseFromArtifact(artifact),
+      prNumbers: dedupeNumericList(artifact.source?.prNumbers ?? []),
+    };
+  }
+
+  return {
+    release: parsePublishedReleaseBody(release.body || ""),
+    prNumbers: [],
+  };
+}
+
+function collectIntermediaryDevReleases(tag, previousPublishedTag, publishedReleases) {
+  return publishedReleases.filter((release) => {
+    if (!release.prerelease || !release.tag_name.endsWith(DEV_SUFFIX)) {
+      return false;
+    }
+
+    if (compareTags(release.tag_name, tag) >= 0) {
+      return false;
+    }
+
+    if (!previousPublishedTag) {
+      return true;
+    }
+
+    return compareTags(release.tag_name, previousPublishedTag) > 0;
+  });
+}
+
 async function collectReleaseContext(tag, version, channel) {
   const publishedReleases = await listPublishedReleases(channel);
+  const allPublishedReleases =
+    channel === "production" ? await listPublishedReleases("all") : publishedReleases;
   const dayKey = versionDayKey(version);
   const sameDayPublished = publishedReleases.filter(
     (release) => versionDayKey(release.tag_name.replace(/^v/, "")) === dayKey,
@@ -579,6 +728,18 @@ async function collectReleaseContext(tag, version, channel) {
   const previousPublishedDay = previousPublishedDayRelease(version, publishedReleases);
   const isLatestOfDay =
     sameDayPublished.find((release) => compareTags(release.tag_name, tag) > 0) === undefined;
+  const priorSameDayReleases = collectPriorSameDayReleases(tag, dayKey, publishedReleases);
+  const intermediaryDevReleases =
+    channel === "production"
+      ? collectIntermediaryDevReleases(
+          tag,
+          previousPublished?.tag_name ?? null,
+          allPublishedReleases,
+        )
+      : [];
+  const priorCumulativeReleases = isLatestOfDay
+    ? dedupePublishedReleases([...priorSameDayReleases, ...intermediaryDevReleases])
+    : [];
   const compareRef = hasGitRef(tag) ? tag : "HEAD";
   const rangeStart = isLatestOfDay ? previousPublishedDay?.tag_name : previousPublished?.tag_name;
   const range = rangeStart ? `${rangeStart}..${compareRef}` : compareRef;
@@ -650,7 +811,12 @@ async function collectReleaseContext(tag, version, channel) {
     previousPublishedTag: previousPublished?.tag_name ?? null,
     previousPublishedDayTag: previousPublishedDay?.tag_name ?? null,
     sameDayPublishedTags: sameDayPublished.map((release) => release.tag_name),
-    priorSameDayReleases: collectPriorSameDayReleases(tag, dayKey, publishedReleases),
+    priorSameDayReleases,
+    intermediaryDevReleases,
+    priorCumulativeReleases,
+    relatedBuildTags: isLatestOfDay
+      ? dedupeReleaseTags([...priorCumulativeReleases.map((release) => release.tag_name), tag])
+      : [tag],
     publishedReleases,
     commitSubjects: subjects,
     prNumbers: [...prNumbers].sort((a, b) => a - b),
@@ -781,6 +947,7 @@ async function generateWithOpenAI(promptInput) {
     "The deck must be a distinct opener and must not duplicate any bullet.",
     `Features must contain at most ${MAX_FEATURES.toLocaleString()} items.`,
     "When isLatestOfDay is true, the release must cumulatively describe everything new since the previous day.",
+    "When channel is production, carry forward relevant dev prereleases shipped after the previous production release.",
     "Prefer installability, trust wins, and meaningful shipped behavior over internal implementation detail.",
     "Do not mention pull requests, commit hashes, internal tickets, or implementation trivia unless it materially changes the shipped product.",
   ].join(" ");
@@ -816,15 +983,6 @@ async function generateWithOpenAI(promptInput) {
   return validateStructuredNotes(parseJsonContent(raw));
 }
 
-function loadPriorSameDayArtifact(release) {
-  const artifact = readJsonIfExists(releasePaths(release.tag_name).json);
-  if (artifact?.release) {
-    return releaseFromArtifact(artifact);
-  }
-
-  return null;
-}
-
 async function main() {
   const { input, force } = parseArguments(process.argv.slice(2));
 
@@ -852,12 +1010,17 @@ async function main() {
   const draftSeedRelease = releaseHasContent(heuristicRelease)
     ? heuristicRelease
     : existingSeedRelease;
-  const earlierSameDayArtifacts = context.priorSameDayReleases
-    .map((release) => loadPriorSameDayArtifact(release))
-    .filter(Boolean);
+  const carriedForwardSummaries = context.priorCumulativeReleases
+    .map((release) => loadPublishedReleaseSummary(release))
+    .filter((summary) => releaseHasContent(summary.release));
+  const carriedForwardReleases = carriedForwardSummaries.map((summary) => summary.release);
+  const cumulativePrNumbers = dedupeNumericList([
+    ...context.prNumbers,
+    ...carriedForwardSummaries.flatMap((summary) => summary.prNumbers),
+  ]);
   const cumulativeDraftRelease = context.isLatestOfDay
     ? withComputedDeck(
-        mergePriorSameDayReleases(draftSeedRelease, earlierSameDayArtifacts),
+        mergePriorSameDayReleases(draftSeedRelease, carriedForwardReleases),
         context,
         existingDaily,
       )
@@ -875,6 +1038,7 @@ async function main() {
       sameDayTagsIncluded: context.isLatestOfDay
         ? [...context.sameDayPublishedTags.filter((sameDayTag) => compareTags(sameDayTag, tag) < 0), tag]
         : [tag],
+      relatedBuildTags: context.relatedBuildTags,
       commitSubjects: context.commitSubjects,
       sourceItems: context.entries.map((entry) => ({
         kind: entry.kind,
@@ -883,7 +1047,8 @@ async function main() {
         fallback: entry.fallback,
         details: entry.details.slice(0, 5),
       })),
-      priorSameDayReleases: earlierSameDayArtifacts,
+      priorSameDayReleases: carriedForwardReleases,
+      intermediaryBuildTags: context.intermediaryDevReleases.map((release) => release.tag_name),
       editorialGuidance: existingDaily.editorialGuidance,
       pinnedHighlights: existingDaily.pinnedHighlights,
       editorialNotes: existingDaily.editorialNotes,
@@ -901,13 +1066,13 @@ async function main() {
   const draftedRelease = sanitizeReleaseShape(structured?.release ?? cumulativeDraftRelease);
   const finalRelease = withComputedDeck(
     context.isLatestOfDay
-      ? mergePriorSameDayReleases(draftedRelease, earlierSameDayArtifacts)
+      ? mergePriorSameDayReleases(draftedRelease, carriedForwardReleases)
       : draftedRelease,
     context,
     existingDaily,
   );
   const validation = validateReleaseShape(finalRelease, {
-    earlierReleases: context.isLatestOfDay ? earlierSameDayArtifacts : [],
+    earlierReleases: context.isLatestOfDay ? carriedForwardReleases : [],
   });
 
   if (validation.errors.length > 0) {
@@ -927,7 +1092,8 @@ async function main() {
     sameDayTagsIncluded: context.isLatestOfDay
       ? [...context.sameDayPublishedTags.filter((sameDayTag) => compareTags(sameDayTag, tag) < 0), tag]
       : [tag],
-    prNumbers: context.prNumbers,
+    relatedBuildTags: context.relatedBuildTags,
+    prNumbers: cumulativePrNumbers,
     commitSubjects: context.commitSubjects,
   };
   const shouldKeepApproval = releaseArtifactsMatch(

--- a/website/scripts/generate-changelog.ts
+++ b/website/scripts/generate-changelog.ts
@@ -35,6 +35,7 @@ interface LocalReleaseArtifact {
   dayKey: string;
   source?: {
     prNumbers?: number[];
+    relatedBuildTags?: string[];
   };
   release?: {
     deck?: string;
@@ -104,9 +105,36 @@ function readLocalReleaseArtifacts(): Map<string, LocalReleaseArtifact> {
   return artifacts;
 }
 
+function buildLinksFromArtifact(
+  artifact: LocalReleaseArtifact,
+  release: GitHubRelease,
+  releaseMap: Map<string, GitHubRelease>,
+) {
+  const relatedBuildTags = artifact.source?.relatedBuildTags ?? [];
+  const buildLinks = relatedBuildTags
+    .map((tag) => releaseMap.get(tag))
+    .filter((candidate): candidate is GitHubRelease => Boolean(candidate))
+    .map((candidate) => ({
+      version: candidate.tag_name.replace(/^v/, ""),
+      htmlUrl: candidate.html_url,
+    }));
+
+  if (buildLinks.length > 0) {
+    return buildLinks;
+  }
+
+  return [
+    {
+      version: artifact.version || release.tag_name.replace(/^v/, ""),
+      htmlUrl: release.html_url,
+    },
+  ];
+}
+
 function releaseFromLocalArtifact(
   artifact: LocalReleaseArtifact,
   release: GitHubRelease,
+  releaseMap: Map<string, GitHubRelease>,
 ): ParsedRelease {
   const releaseShape = artifact.release ?? {};
   const features = toReleaseItems(releaseShape.features ?? releaseShape.whatsNew);
@@ -115,6 +143,7 @@ function releaseFromLocalArtifact(
     ...(releaseShape.followUps ?? []),
     ...(releaseShape.performance ?? []),
   ]);
+  const buildLinks = buildLinksFromArtifact(artifact, release, releaseMap);
 
   return {
     version: artifact.version || release.tag_name.replace(/^v/, ""),
@@ -126,13 +155,8 @@ function releaseFromLocalArtifact(
     followUps,
     htmlUrl: release.html_url,
     prNumbers: [...new Set(artifact.source?.prNumbers ?? [])].sort((a, b) => a - b),
-    builds: [release.tag_name.replace(/^v/, "")],
-    buildLinks: [
-      {
-        version: artifact.version || release.tag_name.replace(/^v/, ""),
-        htmlUrl: release.html_url,
-      },
-    ],
+    builds: buildLinks.map((build) => build.version),
+    buildLinks,
   };
 }
 
@@ -149,7 +173,7 @@ async function fetchChangelog(): Promise<ParsedRelease[]> {
     const localArtifact = release ? localReleaseArtifacts.get(release.tag_name) : null;
 
     if (release && localArtifact?.release) {
-      return releaseFromLocalArtifact(localArtifact, release);
+      return releaseFromLocalArtifact(localArtifact, release, releaseMap);
     }
 
     return publishedRelease;

--- a/website/src/content/changelog.generated.json
+++ b/website/src/content/changelog.generated.json
@@ -1,5 +1,88 @@
 [
   {
+    "version": "26.4.1602",
+    "tagName": "v26.4.1602",
+    "date": "2026-04-17T02:06:16Z",
+    "deck": "Freed Desktop keeps update dialogs visible, restores read state correctly, and trims sync memory growth on large saves",
+    "features": [],
+    "fixes": [
+      {
+        "text": "Update dialogs stay above the floating new button, and the Updates settings view labels the installed version clearly when you switch release channels."
+      },
+      {
+        "text": "Read state and related UI updates restore correctly after merge recovery paths."
+      },
+      {
+        "text": "Map view background tiles render again across the refreshed style palette."
+      },
+      {
+        "text": "Desktop sync trims preserved article text before it reaches Automerge, which reduces sync memory growth on large saves."
+      }
+    ],
+    "followUps": [],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1602",
+    "prNumbers": [
+      213,
+      215,
+      216,
+      222,
+      223,
+      224
+    ],
+    "builds": [
+      "26.4.1600",
+      "26.4.1601-dev",
+      "26.4.1602"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.4.1600",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1600"
+      },
+      {
+        "version": "26.4.1601-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1601-dev"
+      },
+      {
+        "version": "26.4.1602",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1602"
+      }
+    ]
+  },
+  {
+    "version": "26.4.1400",
+    "tagName": "v26.4.1400",
+    "date": "2026-04-14T23:13:01Z",
+    "deck": "Theme-native map palettes, dev release channels and branch flow, and label macOS Activity Monitor web process as Freed",
+    "features": [
+      {
+        "text": "Theme-native map palettes"
+      },
+      {
+        "text": "Dev release channels and branch flow"
+      }
+    ],
+    "fixes": [],
+    "followUps": [],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1400",
+    "prNumbers": [
+      208,
+      209,
+      210,
+      211,
+      212
+    ],
+    "builds": [
+      "26.4.1400"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.4.1400",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1400"
+      }
+    ]
+  },
+  {
     "version": "26.4.1300",
     "tagName": "v26.4.1300",
     "date": "2026-04-14T05:17:28Z",

--- a/website/src/content/changelog.ts
+++ b/website/src/content/changelog.ts
@@ -39,6 +39,25 @@ function normalizeReleaseText(text: string): string {
     .trim();
 }
 
+function parseComparableVersion(version: string): {
+  yy: number;
+  month: number;
+  patch: number;
+  channel: "dev" | "production";
+} {
+  const normalized = version.replace(/^v/, "");
+  const channel = normalized.endsWith("-dev") ? "dev" : "production";
+  const baseVersion = channel === "dev" ? normalized.slice(0, -"-dev".length) : normalized;
+  const [yy = "0", month = "0", patch = "0"] = baseVersion.split(".");
+
+  return {
+    yy: Number(yy),
+    month: Number(month),
+    patch: Number(patch),
+    channel,
+  };
+}
+
 function isLowSignalReleaseText(text: string): boolean {
   const normalized = normalizeReleaseText(text).toLowerCase();
 
@@ -239,20 +258,38 @@ export function normalizeGitHubReleases(
 }
 
 function compareVersionsAscending(left: string, right: string): number {
-  const leftParts = left.split(".").map((part) => Number(part));
-  const rightParts = right.split(".").map((part) => Number(part));
-  const length = Math.max(leftParts.length, rightParts.length);
+  const leftVersion = parseComparableVersion(left);
+  const rightVersion = parseComparableVersion(right);
 
-  for (let index = 0; index < length; index += 1) {
-    const leftPart = leftParts[index] ?? 0;
-    const rightPart = rightParts[index] ?? 0;
+  if (leftVersion.yy !== rightVersion.yy) {
+    return leftVersion.yy - rightVersion.yy;
+  }
 
-    if (leftPart !== rightPart) {
-      return leftPart - rightPart;
+  if (leftVersion.month !== rightVersion.month) {
+    return leftVersion.month - rightVersion.month;
+  }
+
+  if (leftVersion.patch !== rightVersion.patch) {
+    return leftVersion.patch - rightVersion.patch;
+  }
+
+  if (leftVersion.channel === rightVersion.channel) {
+    return 0;
+  }
+
+  return leftVersion.channel === "dev" ? -1 : 1;
+}
+
+function dedupeBuildLinks(buildLinks: ReleaseBuild[]): ReleaseBuild[] {
+  const deduped = new Map<string, ReleaseBuild>();
+
+  for (const buildLink of buildLinks) {
+    if (!deduped.has(buildLink.version)) {
+      deduped.set(buildLink.version, buildLink);
     }
   }
 
-  return 0;
+  return Array.from(deduped.values());
 }
 
 export function versionDayKey(version: string): string {
@@ -279,11 +316,18 @@ export function groupReleasesByDay(releases: ParsedRelease[]): ParsedRelease[] {
   return Array.from(byDay.values()).map((group) => {
     const [head, ...rest] = group;
     const allReleases = [head, ...rest];
-    const buildLinks = allReleases
-      .map((release) => ({
-        version: release.version,
-        htmlUrl: release.htmlUrl,
-      }))
+    const buildLinks = dedupeBuildLinks(
+      allReleases.flatMap((release) =>
+        release.buildLinks.length > 0
+          ? release.buildLinks
+          : [
+              {
+                version: release.version,
+                htmlUrl: release.htmlUrl,
+              },
+            ],
+      ),
+    )
       .sort((left, right) => compareVersionsAscending(left.version, right.version));
 
     return {


### PR DESCRIPTION
(AI Generated).

## Summary
- carry intermediary dev prereleases into cumulative production release-note generation
- preserve related dev and production build links in grouped website changelog cards
- refresh the latest production changelog artifact and generated website snapshot to reflect the full shipped scope

## Why
Production changelog cards were only looking at production releases and same-day production siblings. That dropped functionality that first shipped in intermediary `dev` releases before the next production cut, which made the public changelog understate what actually shipped.

## Impact
The latest production changelog card now includes the full feature and fix set since the previous production release, even when some of that work first shipped as dev prereleases. The card footer also lists those relevant dev builds alongside same-day production builds.

## Validation
- `npm run generate-changelog` in `website/`
- `npx npm@10.9.2 run lint` in `website/`
- local browser verification on `/changelog` confirmed the updated deck text and the `26.4.1601-dev` build link render on the page
