### PR TITLE
perf: defer worktree bootstrap and track local previews

### DIFF
--- a/.agents/skills/freed-build-feature/SKILL.md
+++ b/.agents/skills/freed-build-feature/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: freed-build-feature
-description: Scaffold product work in a dev-based worktree, implement it, verify it, and launch the relevant app preview. Use for Desktop, PWA, shared packages, sync, capture packages, release tooling, app behavior, and product docs targeting dev. Do not use for public marketing changes targeting www.
+description: Scaffold product work in a dev-based worktree, implement it, verify it, and launch a preview only when the work actually needs one. Use for Desktop, PWA, shared packages, sync, capture packages, release tooling, app behavior, and product docs targeting dev. Do not use for public marketing changes targeting www.
 disable-model-invocation: true
 ---
 
 # Build Feature
 
-Create a product worktree branch from the latest remote `dev`, implement the feature or fix, verify it, and launch the relevant preview.
+Create a product worktree branch from the latest remote `dev`, implement the feature or fix, verify it, and launch the relevant preview only when the work reaches final verification or the user explicitly asks for one.
 
 ## Workflow
 
@@ -16,13 +16,15 @@ Create a product worktree branch from the latest remote `dev`, implement the fea
 4. Check both `origin/dev` and `origin/main` before branching.
    - Confirm whether local `dev` or `main` are behind their remote counterparts.
    - If `origin/main` contains commits that are not in `origin/dev`, call that out before continuing so the user can decide whether `dev` needs to be refreshed first.
-5. Create a new worktree branch from `origin/dev` using `./scripts/worktree-add.sh ../freed-<slug> -b <branch> origin/dev`.
-6. Implement the requested change.
-7. Verify with focused tests, then broader checks when shared behavior changed.
-8. Launch the relevant preview:
-   - For PWA work, deploy or run the PWA preview.
-   - For desktop work, use the desktop E2E test harness or Tauri preview as appropriate.
-9. Open a PR targeting `dev` when the work is ready.
+5. Create a new worktree branch from `origin/dev` using `./scripts/worktree-add.sh ../freed-<slug> -b <branch> origin/dev --install auto --target <desktop|pwa|shared>`.
+6. Bootstrap dependencies only when the work actually needs them with `./scripts/worktree-bootstrap.sh <worktree> --target <desktop|pwa|shared>`.
+7. Implement the requested change.
+8. Verify with focused tests, then broader checks when shared behavior changed.
+9. Launch a preview only when final verification needs one or the user explicitly asks:
+   - For PWA work, use `./scripts/worktree-preview.sh pwa`.
+   - For desktop work, default to `./scripts/worktree-preview.sh desktop`.
+   - Use `./scripts/worktree-preview.sh desktop --native` only when Tauri-native behavior itself matters.
+10. Open a PR targeting `dev` when the work is ready.
 
 ## Scope
 

--- a/.agents/skills/freed-build-www/SKILL.md
+++ b/.agents/skills/freed-build-www/SKILL.md
@@ -12,11 +12,12 @@ Create a marketing worktree branch from `www`, implement the website change, ver
 
 1. Confirm the request is public marketing work targeting `www`.
 2. Reject or reroute product work targeting `dev`; use `freed-build-feature` instead.
-3. Create a new worktree branch from `www` using `./scripts/worktree-add.sh`.
-4. Keep changes scoped to marketing paths unless the user explicitly changes the destination.
-5. Run website checks, at minimum `npm run build --workspace=website`.
-6. Deploy a website preview with `./scripts/vercel-deploy-preview.sh website`.
-7. Open a PR targeting `www` when the work is ready.
+3. Create a new worktree branch from `www` using `./scripts/worktree-add.sh ../freed-<slug> -b <branch> origin/www --install auto --target website`.
+4. Bootstrap dependencies only when the work needs them with `./scripts/worktree-bootstrap.sh <worktree> --target website`.
+5. Keep changes scoped to marketing paths unless the user explicitly changes the destination.
+6. Run website checks, at minimum `npm run build --workspace=website`.
+7. Deploy a website preview with `./scripts/vercel-deploy-preview.sh website`.
+8. Open a PR targeting `www` when the work is ready.
 
 ## Scope
 

--- a/docs/PHASE-1-FOUNDATION.md
+++ b/docs/PHASE-1-FOUNDATION.md
@@ -243,6 +243,8 @@ The preview and production deploy helpers now resolve `npm` and `npx` from the
 active Node toolchain first, so they do not accidentally pick up an older
 system npm from the shell `PATH`.
 
+Local product worktrees now also default to deferred bootstrap. `./scripts/worktree-add.sh` can record `--install none|auto|full` and `--target desktop|pwa|website|shared`, `./scripts/worktree-bootstrap.sh` handles the on-demand install, `./scripts/worktree-preview.sh` launches tracked previews with one desktop slot and one web slot per repo, and `./scripts/worktree-cleanup.sh` stops tracked previews before removing merged worktrees.
+
 ---
 
 ## Key Decisions
@@ -272,6 +274,7 @@ system npm from the shell `PATH`.
 | 1.9  | Generate RSS feed at build time              | ✓      |
 | 1.10 | Add public legal docs and versioned website clickwrap | ✓ |
 | 1.11 | Add unified shared theme system across website, Freed Desktop, and PWA | ✓ |
+| 1.12 | Add deferred worktree bootstrap and tracked local preview tooling | ✓ |
 
 ---
 

--- a/docs/PHASE-5-DESKTOP.md
+++ b/docs/PHASE-5-DESKTOP.md
@@ -224,6 +224,7 @@ export async function captureDomFeed(
 - [x] Legal acceptance stays outside synced Automerge state
 - [x] Freed Desktop keeps rotating local database snapshots with a restore flow in Settings
 - [x] Desktop E2E test infrastructure bootstrapped (Playwright + VITE_TEST_TAURI=1 mock layer)
+- [x] Local desktop preview now defaults to the mocked browser harness, while tracked preview slots keep concurrent local threads to one desktop preview at a time unless native Tauri behavior is explicitly requested
 - [x] Desktop navigation history supports browser-style back and forward shortcuts for views and reader state
 - [x] Settings and crash recovery surfaces can export public-safe bug report bundles
 - [x] Private diagnostic bundles are opt-in, redacted, and steered toward email instead of public GitHub attachment
@@ -315,6 +316,10 @@ export async function captureDomFeed(
 > Desktop persistence also now appends Automerge incremental saves to the
 > last stored snapshot and compacts back to a fresh snapshot only when the
 > incremental tail has grown large enough to justify it.
+> Local developer workflow now also defaults desktop preview to the
+> `VITE_TEST_TAURI=1` browser harness, with tracked preview slots so
+> multiple concurrent worktrees do not each spin up their own native Tauri
+> stack by default.
 > Release notes now use a
 > checked-in review gate: `./scripts/release.sh` prepares draft notes and
 > daily editorial memory, then `./scripts/release-publish.sh` tags only after

--- a/packages/desktop/README.md
+++ b/packages/desktop/README.md
@@ -11,11 +11,14 @@ Native macOS/Windows/Linux desktop application built with Tauri.
 ## Development
 
 ```bash
-# Install dependencies
-npm install
+# Install dependencies in the current worktree
+../../scripts/worktree-bootstrap.sh ../.. --target desktop
 
-# Run in development mode (hot reload)
-npm run tauri:dev
+# Start the default mocked desktop preview
+../../scripts/worktree-preview.sh desktop
+
+# Start native Tauri only when native behavior matters
+../../scripts/worktree-preview.sh desktop --native
 
 # Build for production
 npm run tauri:build

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -1288,7 +1288,7 @@ dependencies = [
 
 [[package]]
 name = "freed-desktop"
-version = "26.4.1403"
+version = "26.4.1601"
 dependencies = [
  "base64 0.22.1",
  "criterion",

--- a/packages/desktop/tests/e2e/fixtures/app.ts
+++ b/packages/desktop/tests/e2e/fixtures/app.ts
@@ -336,6 +336,10 @@ export const test = base.extend<Fixtures>({
   app: async ({ page }, use) => {
     // Inject the IPC shim before page JS fires so mock globals are ready.
     await page.addInitScript(tauriInitScript());
+    await page.addInitScript(() => {
+      (window as Window & { __FREED_E2E_FORCE_MAP_FALLBACK__?: boolean })
+        .__FREED_E2E_FORCE_MAP_FALLBACK__ = true;
+    });
     await use(new AppFixture(page));
   },
 

--- a/packages/ui/src/components/map/MapSurface.tsx
+++ b/packages/ui/src/components/map/MapSurface.tsx
@@ -70,6 +70,17 @@ const popupDateFormatter = new Intl.DateTimeFormat(undefined, {
 const MAP_POPUP_MAX_WIDTH = 560;
 const MAP_POPUP_VIEWPORT_MARGIN = 40;
 
+function shouldForceMapFallback() {
+  if (typeof window === "undefined") return false;
+  return (
+    (
+      window as Window & {
+        __FREED_E2E_FORCE_MAP_FALLBACK__?: boolean;
+      }
+    ).__FREED_E2E_FORCE_MAP_FALLBACK__ === true
+  );
+}
+
 function popupRelativeTime(seenAt: number): string {
   return formatDistanceToNow(seenAt, { addSuffix: true });
 }
@@ -496,6 +507,19 @@ export function MapSurface({
     let cancelled = false;
     setMapReady(false);
     setLoadFailed(false);
+
+    if (shouldForceMapFallback()) {
+      setLoadFailed(true);
+      return () => {
+        cancelled = true;
+        closeActivePopup();
+        for (const marker of markersRef.current) marker.remove();
+        markersRef.current = [];
+        mapRef.current?.remove();
+        mapRef.current = null;
+      };
+    }
+
     ensureMapLibreCss();
 
     void Promise.all([

--- a/scripts/lib/worktree-runtime.sh
+++ b/scripts/lib/worktree-runtime.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+git_common_dir() {
+  git rev-parse --git-common-dir
+}
+
+runtime_root() {
+  printf '%s\n' "$(git_common_dir)/freed-runtime"
+}
+
+worktree_state_dir() {
+  printf '%s\n' "$(runtime_root)/worktrees"
+}
+
+process_state_dir() {
+  printf '%s\n' "$(runtime_root)/processes"
+}
+
+lock_state_dir() {
+  printf '%s\n' "$(runtime_root)/locks"
+}
+
+log_state_dir() {
+  printf '%s\n' "$(runtime_root)/logs"
+}
+
+ensure_runtime_dirs() {
+  mkdir -p \
+    "$(worktree_state_dir)" \
+    "$(process_state_dir)" \
+    "$(lock_state_dir)" \
+    "$(log_state_dir)"
+}
+
+resolve_worktree_path() {
+  local path="$1"
+
+  (
+    cd "${path}"
+    pwd
+  )
+}
+
+hash_string() {
+  printf '%s' "$1" | shasum -a 256 | awk '{print $1}'
+}
+
+worktree_id_for_path() {
+  local path="$1"
+  local abs_path
+
+  abs_path="$(resolve_worktree_path "${path}")"
+  hash_string "${abs_path}"
+}
+
+worktree_manifest_path() {
+  local path="$1"
+
+  printf '%s/%s.env\n' "$(worktree_state_dir)" "$(worktree_id_for_path "${path}")"
+}
+
+process_manifest_path() {
+  local pid="$1"
+
+  printf '%s/%s.env\n' "$(process_state_dir)" "${pid}"
+}
+
+lock_manifest_path() {
+  local kind="$1"
+
+  printf '%s/%s.env\n' "$(lock_state_dir)" "${kind}"
+}
+
+current_timestamp() {
+  date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+is_pid_running() {
+  local pid="$1"
+
+  [[ -n "${pid}" ]] && kill -0 "${pid}" 2>/dev/null
+}
+
+write_shell_var() {
+  local name="$1"
+  local value="$2"
+
+  printf '%s=%q\n' "${name}" "${value}"
+}
+
+record_worktree_metadata() {
+  local path="$1"
+  local install_mode="$2"
+  local target_hint="$3"
+  local abs_path worktree_id manifest
+
+  ensure_runtime_dirs
+
+  abs_path="$(resolve_worktree_path "${path}")"
+  worktree_id="$(worktree_id_for_path "${abs_path}")"
+  manifest="$(worktree_manifest_path "${abs_path}")"
+
+  {
+    write_shell_var "WORKTREE_ID" "${worktree_id}"
+    write_shell_var "WORKTREE_PATH" "${abs_path}"
+    write_shell_var "INSTALL_MODE" "${install_mode}"
+    write_shell_var "TARGET_HINT" "${target_hint}"
+    write_shell_var "CREATED_AT" "$(current_timestamp)"
+  } > "${manifest}"
+}
+
+load_worktree_metadata() {
+  local path="$1"
+  local manifest
+
+  manifest="$(worktree_manifest_path "${path}")"
+  [[ -f "${manifest}" ]] || return 1
+  # shellcheck disable=SC1090
+  source "${manifest}"
+}
+
+write_process_metadata() {
+  local pid="$1"
+  local kind="$2"
+  local target="$3"
+  local path="$4"
+  local port="$5"
+  local command="$6"
+  local log_path="$7"
+  local abs_path worktree_id manifest
+
+  ensure_runtime_dirs
+
+  abs_path="$(resolve_worktree_path "${path}")"
+  worktree_id="$(worktree_id_for_path "${abs_path}")"
+  manifest="$(process_manifest_path "${pid}")"
+
+  {
+    write_shell_var "PID" "${pid}"
+    write_shell_var "PROCESS_KIND" "${kind}"
+    write_shell_var "TARGET" "${target}"
+    write_shell_var "WORKTREE_ID" "${worktree_id}"
+    write_shell_var "WORKTREE_PATH" "${abs_path}"
+    write_shell_var "PORT" "${port}"
+    write_shell_var "COMMAND" "${command}"
+    write_shell_var "LOG_PATH" "${log_path}"
+    write_shell_var "STARTED_AT" "$(current_timestamp)"
+  } > "${manifest}"
+}
+
+write_lock_metadata() {
+  local kind="$1"
+  local pid="$2"
+  local path="$3"
+  local target="$4"
+  local port="$5"
+  local abs_path worktree_id manifest
+
+  ensure_runtime_dirs
+
+  abs_path="$(resolve_worktree_path "${path}")"
+  worktree_id="$(worktree_id_for_path "${abs_path}")"
+  manifest="$(lock_manifest_path "${kind}")"
+
+  {
+    write_shell_var "LOCK_KIND" "${kind}"
+    write_shell_var "LOCK_PID" "${pid}"
+    write_shell_var "LOCK_WORKTREE_ID" "${worktree_id}"
+    write_shell_var "LOCK_WORKTREE_PATH" "${abs_path}"
+    write_shell_var "LOCK_TARGET" "${target}"
+    write_shell_var "LOCK_PORT" "${port}"
+    write_shell_var "LOCK_CREATED_AT" "$(current_timestamp)"
+  } > "${manifest}"
+}
+
+release_lock() {
+  local kind="$1"
+  local expected_pid="${2:-}"
+  local manifest
+
+  manifest="$(lock_manifest_path "${kind}")"
+  [[ -f "${manifest}" ]] || return 0
+
+  unset LOCK_PID
+  # shellcheck disable=SC1090
+  source "${manifest}"
+
+  if [[ -n "${expected_pid}" && "${LOCK_PID:-}" != "${expected_pid}" ]]; then
+    return 0
+  fi
+
+  rm -f "${manifest}"
+}
+
+prune_runtime_state() {
+  local manifest
+
+  ensure_runtime_dirs
+
+  shopt -s nullglob
+  for manifest in "$(worktree_state_dir)"/*.env; do
+    unset WORKTREE_PATH
+    # shellcheck disable=SC1090
+    source "${manifest}"
+    if [[ ! -d "${WORKTREE_PATH:-}" ]]; then
+      rm -f "${manifest}"
+    fi
+  done
+
+  for manifest in "$(process_state_dir)"/*.env; do
+    unset PID
+    # shellcheck disable=SC1090
+    source "${manifest}"
+    if ! is_pid_running "${PID:-}"; then
+      rm -f "${manifest}"
+    fi
+  done
+
+  for manifest in "$(lock_state_dir)"/*.env; do
+    unset LOCK_PID
+    # shellcheck disable=SC1090
+    source "${manifest}"
+    if ! is_pid_running "${LOCK_PID:-}"; then
+      rm -f "${manifest}"
+    fi
+  done
+  shopt -u nullglob
+}

--- a/scripts/worktree-add.sh
+++ b/scripts/worktree-add.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 # worktree-add.sh
 #
-# Wrapper around `git worktree add` that immediately runs `npm ci` so the
-# new worktree has its own isolated node_modules and is ready to use.
+# Wrapper around `git worktree add` that can bootstrap dependencies now or
+# later, while recording worktree intent for other local helpers.
 #
-# Usage (identical args to git worktree add):
-#   ./scripts/worktree-add.sh ../freed-<slug> -b feat/my-feature
+# Usage:
+#   ./scripts/worktree-add.sh ../freed-<slug> -b feat/my-feature origin/dev
+#   ./scripts/worktree-add.sh ../freed-<slug> -b feat/my-feature origin/dev --install full --target desktop
 #
 # Why not symlink node_modules from the primary worktree?
 #   npm writes *through* symlinks. Running `npm install foo` in a symlinked
@@ -13,19 +14,94 @@
 #   silently corrupts every other worktree sharing that link. Isolated
 #   installs are the only safe option.
 #
-# Why is this fast?
-#   `npm ci --prefer-offline` skips dependency resolution (reads the lockfile
-#   directly) and pulls all packages from the local npm cache (~/.npm).
-#   With a warm cache this takes ~74s vs ~170s for a cold `npm install`.
+# Why defer installs by default?
+#   Most concurrent feature threads do not need a full dependency tree until
+#   they reach focused verification. Deferring bootstrap keeps idle worktrees
+#   cheap and saves RAM for the threads that are actually running builds.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=./lib/node-tooling.sh
 source "${SCRIPT_DIR}/lib/node-tooling.sh"
+# shellcheck source=./lib/worktree-runtime.sh
+source "${SCRIPT_DIR}/lib/worktree-runtime.sh"
 
-if [[ $# -eq 0 ]]; then
-  echo "Usage: ./scripts/worktree-add.sh <path> [-b <branch>] [<commit-ish>]"
+usage() {
+  cat <<'EOF'
+Usage:
+  ./scripts/worktree-add.sh <path> [-b <branch>] [<commit-ish>] [--install none|auto|full] [--target desktop|pwa|website|shared]
+
+Options:
+  --install  Dependency bootstrap mode. Default: auto
+  --target   Hint for later bootstrap or preview commands
+EOF
+}
+
+validate_install_mode() {
+  case "$1" in
+    none|auto|full) ;;
+    *)
+      echo "Error: unsupported install mode '$1'. Use none, auto, or full." >&2
+      exit 1
+      ;;
+  esac
+}
+
+validate_target_hint() {
+  if [[ -z "$1" ]]; then
+    return 0
+  fi
+
+  case "$1" in
+    desktop|pwa|website|shared) ;;
+    *)
+      echo "Error: unsupported target '$1'. Use desktop, pwa, website, or shared." >&2
+      exit 1
+      ;;
+  esac
+}
+
+INSTALL_MODE="auto"
+TARGET_HINT=""
+PASSTHROUGH_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --install)
+      [[ $# -ge 2 ]] || { echo "Error: --install requires a value." >&2; exit 1; }
+      INSTALL_MODE="$2"
+      shift 2
+      ;;
+    --install=*)
+      INSTALL_MODE="${1#*=}"
+      shift
+      ;;
+    --target)
+      [[ $# -ge 2 ]] || { echo "Error: --target requires a value." >&2; exit 1; }
+      TARGET_HINT="$2"
+      shift 2
+      ;;
+    --target=*)
+      TARGET_HINT="${1#*=}"
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      PASSTHROUGH_ARGS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+validate_install_mode "${INSTALL_MODE}"
+validate_target_hint "${TARGET_HINT}"
+
+if [[ ${#PASSTHROUGH_ARGS[@]} -eq 0 ]]; then
+  usage
   exit 1
 fi
 
@@ -34,7 +110,7 @@ while IFS= read -r line; do
   EXISTING_WORKTREES+=("$line")
 done < <(git worktree list --porcelain | awk '/^worktree / { print $2 }')
 
-git worktree add "$@"
+git worktree add "${PASSTHROUGH_ARGS[@]}"
 
 CURRENT_WORKTREES=()
 while IFS= read -r line; do
@@ -54,10 +130,31 @@ if [[ -z "${NEW_WT}" ]]; then
   exit 1
 fi
 
-NPM_BIN="$(resolve_npm_bin)"
+record_worktree_metadata "${NEW_WT}" "${INSTALL_MODE}" "${TARGET_HINT}"
 
 echo ""
-echo "Installing node_modules in $NEW_WT with $("${NPM_BIN}" -v) ..."
-"${NPM_BIN}" ci --prefer-offline --prefix "$NEW_WT"
+case "${INSTALL_MODE}" in
+  none)
+    echo "Created ${NEW_WT} with dependency bootstrap disabled."
+    ;;
+  auto)
+    echo "Created ${NEW_WT} with deferred bootstrap."
+    if [[ -n "${TARGET_HINT}" ]]; then
+      echo "When this worktree needs dependencies, run:"
+      echo "  ./scripts/worktree-bootstrap.sh \"${NEW_WT}\" --target ${TARGET_HINT}"
+    else
+      echo "When this worktree needs dependencies, run:"
+      echo "  ./scripts/worktree-bootstrap.sh \"${NEW_WT}\""
+    fi
+    ;;
+  full)
+    if [[ -n "${TARGET_HINT}" ]]; then
+      "${SCRIPT_DIR}/worktree-bootstrap.sh" "${NEW_WT}" --target "${TARGET_HINT}"
+    else
+      "${SCRIPT_DIR}/worktree-bootstrap.sh" "${NEW_WT}"
+    fi
+    ;;
+esac
+
 echo ""
 echo "Done. Worktree is ready."

--- a/scripts/worktree-bootstrap.sh
+++ b/scripts/worktree-bootstrap.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./lib/node-tooling.sh
+source "${SCRIPT_DIR}/lib/node-tooling.sh"
+# shellcheck source=./lib/worktree-runtime.sh
+source "${SCRIPT_DIR}/lib/worktree-runtime.sh"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  ./scripts/worktree-bootstrap.sh <worktree> [--target desktop|pwa|website|shared]
+
+Installs dependencies on demand for a specific worktree.
+EOF
+}
+
+validate_target_hint() {
+  case "$1" in
+    desktop|pwa|website|shared) ;;
+    *)
+      echo "Error: unsupported target '$1'. Use desktop, pwa, website, or shared." >&2
+      exit 1
+      ;;
+  esac
+}
+
+WORKTREE_PATH=""
+TARGET_HINT=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --target)
+      [[ $# -ge 2 ]] || { echo "Error: --target requires a value." >&2; exit 1; }
+      TARGET_HINT="$2"
+      shift 2
+      ;;
+    --target=*)
+      TARGET_HINT="${1#*=}"
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      if [[ -n "${WORKTREE_PATH}" ]]; then
+        echo "Error: unexpected argument '$1'." >&2
+        usage
+        exit 1
+      fi
+      WORKTREE_PATH="$1"
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "${WORKTREE_PATH}" ]]; then
+  usage
+  exit 1
+fi
+
+WORKTREE_PATH="$(resolve_worktree_path "${WORKTREE_PATH}")"
+
+if [[ -z "${TARGET_HINT}" ]]; then
+  load_worktree_metadata "${WORKTREE_PATH}" 2>/dev/null || true
+fi
+
+if [[ -z "${TARGET_HINT}" ]]; then
+  TARGET_HINT="shared"
+fi
+
+validate_target_hint "${TARGET_HINT}"
+
+if [[ -d "${WORKTREE_PATH}/node_modules" ]]; then
+  echo "Dependencies already present in ${WORKTREE_PATH}."
+  exit 0
+fi
+
+NPM_BIN="$(resolve_npm_bin)"
+NPM_VERSION="$("${NPM_BIN}" -v)"
+
+echo "Bootstrapping ${WORKTREE_PATH}"
+echo "Target: ${TARGET_HINT}"
+echo "npm: ${NPM_VERSION}"
+
+if [[ "${TARGET_HINT}" == "shared" ]]; then
+  echo "Shared-only bootstrap still uses the root workspace install with the current npm lockfile layout."
+fi
+
+"${NPM_BIN}" ci --prefer-offline --prefix "${WORKTREE_PATH}"
+record_worktree_metadata "${WORKTREE_PATH}" "full" "${TARGET_HINT}"
+
+echo "Bootstrap complete."

--- a/scripts/worktree-cleanup.sh
+++ b/scripts/worktree-cleanup.sh
@@ -2,7 +2,8 @@
 # worktree-cleanup.sh
 #
 # Removes worktrees and local branches for PRs that have already been merged
-# on GitHub. Run this from the primary worktree (the repo root).
+# on GitHub. It also stops tracked preview processes before removing a
+# worktree. Run this from the primary worktree.
 #
 # Usage:
 #   ./scripts/worktree-cleanup.sh          # interactive: confirms each removal
@@ -87,6 +88,7 @@ for i in "${!PATHS[@]}"; do
   echo "  -> Merged via PR #$pr_number"
 
   if confirm "Remove worktree '$path' and delete branch '$branch'?"; then
+    ./scripts/worktree-processes.sh stop --worktree "$path" >/dev/null 2>&1 || true
     git worktree remove --force "$path"
     # -D because squash merges leave branch commits unreachable from the
     # target branch.
@@ -119,6 +121,8 @@ while IFS= read -r line; do
     fi
   fi
 done < <(git branch -vv | grep '\[.*: gone\]' | awk '{print $1}')
+
+./scripts/worktree-processes.sh prune >/dev/null 2>&1 || true
 
 echo ""
 echo "Done. Removed: $removed  Skipped: $skipped"

--- a/scripts/worktree-preview.sh
+++ b/scripts/worktree-preview.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./lib/node-tooling.sh
+source "${SCRIPT_DIR}/lib/node-tooling.sh"
+# shellcheck source=./lib/worktree-runtime.sh
+source "${SCRIPT_DIR}/lib/worktree-runtime.sh"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  ./scripts/worktree-preview.sh <desktop|pwa|website> [--worktree <path>] [--port <port>] [--native]
+
+Desktop defaults to the mocked browser preview. Use --native only when Tauri
+behavior itself is the thing being tested.
+EOF
+}
+
+find_free_port() {
+  local start_port="$1"
+
+  python3 - "${start_port}" <<'PY'
+import socket
+import sys
+
+start = int(sys.argv[1])
+
+for port in range(start, start + 200):
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        try:
+            sock.bind(("127.0.0.1", port))
+        except OSError:
+            continue
+    print(port)
+    break
+else:
+    raise SystemExit("No free port found in the requested range.")
+PY
+}
+
+existing_process_for_target() {
+  local worktree_path="$1"
+  local preview_target="$2"
+  local manifest
+
+  prune_runtime_state
+
+  shopt -s nullglob
+  for manifest in "$(process_state_dir)"/*.env; do
+    unset PID PROCESS_KIND TARGET WORKTREE_PATH PORT COMMAND LOG_PATH STARTED_AT
+    # shellcheck disable=SC1090
+    source "${manifest}"
+    if [[ "${WORKTREE_PATH:-}" == "${worktree_path}" && "${TARGET:-}" == "${preview_target}" ]]; then
+      printf '%s\n' "${manifest}"
+      shopt -u nullglob
+      return 0
+    fi
+  done
+  shopt -u nullglob
+  return 1
+}
+
+TARGET=""
+WORKTREE_PATH=""
+PORT=""
+USE_NATIVE=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    desktop|pwa|website)
+      if [[ -n "${TARGET}" ]]; then
+        echo "Error: preview target already set to '${TARGET}'." >&2
+        exit 1
+      fi
+      TARGET="$1"
+      shift
+      ;;
+    --worktree)
+      [[ $# -ge 2 ]] || { echo "Error: --worktree requires a value." >&2; exit 1; }
+      WORKTREE_PATH="$2"
+      shift 2
+      ;;
+    --port)
+      [[ $# -ge 2 ]] || { echo "Error: --port requires a value." >&2; exit 1; }
+      PORT="$2"
+      shift 2
+      ;;
+    --native)
+      USE_NATIVE=true
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Error: unexpected argument '$1'." >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "${TARGET}" ]]; then
+  usage
+  exit 1
+fi
+
+if [[ -z "${WORKTREE_PATH}" ]]; then
+  WORKTREE_PATH="$(git rev-parse --show-toplevel)"
+fi
+
+WORKTREE_PATH="$(resolve_worktree_path "${WORKTREE_PATH}")"
+PROCESS_SCRIPT="${SCRIPT_DIR}/worktree-processes.sh"
+
+if existing_manifest="$(existing_process_for_target "${WORKTREE_PATH}" "${TARGET}")"; then
+  unset PID PROCESS_KIND TARGET WORKTREE_PATH PORT COMMAND LOG_PATH STARTED_AT
+  # shellcheck disable=SC1090
+  source "${existing_manifest}"
+  echo "Preview already running for ${TARGET} in ${WORKTREE_PATH}: pid ${PID}, port ${PORT:-"-"}"
+  if [[ -n "${LOG_PATH:-}" ]]; then
+    echo "Log: ${LOG_PATH}"
+  fi
+  exit 0
+fi
+
+"${SCRIPT_DIR}/worktree-bootstrap.sh" "${WORKTREE_PATH}" --target "${TARGET}"
+
+NPM_BIN="$(resolve_npm_bin)"
+use_resolved_node_path
+
+SLOT_KIND="web"
+DEFAULT_PORT=""
+COMMAND_DISPLAY=""
+LOG_PATH=""
+URL=""
+ENV_VARS=()
+RUN_ARGS=()
+
+case "${TARGET}" in
+  desktop)
+    SLOT_KIND="desktop"
+    if ${USE_NATIVE}; then
+      DEFAULT_PORT="1420"
+      PORT="${PORT:-${DEFAULT_PORT}}"
+      if [[ "${PORT}" != "1420" ]]; then
+        echo "Error: native desktop preview is fixed to port 1420 by tauri.conf.json." >&2
+        exit 1
+      fi
+      RUN_ARGS=("${NPM_BIN}" "run" "tauri:dev" "--workspace=packages/desktop")
+      COMMAND_DISPLAY="npm run tauri:dev --workspace=packages/desktop"
+      URL="http://localhost:1420"
+    else
+      DEFAULT_PORT="1422"
+      PORT="${PORT:-$(find_free_port "${DEFAULT_PORT}")}"
+      ENV_VARS=("VITE_TEST_TAURI=1")
+      RUN_ARGS=("${NPM_BIN}" "run" "dev" "--workspace=packages/desktop" "--" "--port" "${PORT}")
+      COMMAND_DISPLAY="VITE_TEST_TAURI=1 npm run dev --workspace=packages/desktop -- --port ${PORT}"
+      URL="http://localhost:${PORT}"
+    fi
+    ;;
+  pwa)
+    SLOT_KIND="web"
+    DEFAULT_PORT="1421"
+    PORT="${PORT:-$(find_free_port "${DEFAULT_PORT}")}"
+    RUN_ARGS=("${NPM_BIN}" "run" "dev" "--workspace=packages/pwa" "--" "--port" "${PORT}")
+    COMMAND_DISPLAY="npm run dev --workspace=packages/pwa -- --port ${PORT}"
+    URL="http://localhost:${PORT}"
+    ;;
+  website)
+    SLOT_KIND="web"
+    DEFAULT_PORT="3000"
+    PORT="${PORT:-$(find_free_port "${DEFAULT_PORT}")}"
+    RUN_ARGS=("${NPM_BIN}" "run" "dev" "--workspace=website" "--" "--port" "${PORT}")
+    COMMAND_DISPLAY="npm run dev --workspace=website -- --port ${PORT}"
+    URL="http://localhost:${PORT}"
+    ;;
+esac
+
+"${PROCESS_SCRIPT}" claim --kind "${SLOT_KIND}" --worktree "${WORKTREE_PATH}" --pid "$$"
+trap '"${PROCESS_SCRIPT}" release --kind "${SLOT_KIND}" --pid "$$" >/dev/null 2>&1 || true' EXIT
+
+ensure_runtime_dirs
+LOG_PATH="$(log_state_dir)/${TARGET}-$(date -u +%Y%m%dT%H%M%SZ)-$(worktree_id_for_path "${WORKTREE_PATH}").log"
+
+spawn_preview() {
+  local env_blob=""
+  local entry
+
+  if [[ ${#ENV_VARS[@]} -gt 0 ]]; then
+    for entry in "${ENV_VARS[@]}"; do
+      env_blob+="${entry}"$'\n'
+    done
+  fi
+
+  FREED_PREVIEW_ENV="${env_blob}" python3 - "${WORKTREE_PATH}" "${LOG_PATH}" "${RUN_ARGS[@]}" <<'PY'
+import os
+import subprocess
+import sys
+
+cwd = sys.argv[1]
+log_path = sys.argv[2]
+args = sys.argv[3:]
+
+env = os.environ.copy()
+for item in os.environ.get("FREED_PREVIEW_ENV", "").splitlines():
+    if not item:
+        continue
+    key, value = item.split("=", 1)
+    env[key] = value
+
+with open(log_path, "ab", buffering=0) as log_file:
+    process = subprocess.Popen(
+        args,
+        cwd=cwd,
+        env=env,
+        stdin=subprocess.DEVNULL,
+        stdout=log_file,
+        stderr=subprocess.STDOUT,
+        start_new_session=True,
+    )
+
+print(process.pid)
+PY
+}
+
+PID_VALUE="$(spawn_preview)"
+
+"${PROCESS_SCRIPT}" track \
+  --pid "${PID_VALUE}" \
+  --kind "${SLOT_KIND}" \
+  --target "${TARGET}" \
+  --worktree "${WORKTREE_PATH}" \
+  --port "${PORT}" \
+  --log "${LOG_PATH}" \
+  --command "${COMMAND_DISPLAY}"
+
+sleep 2
+if ! is_pid_running "${PID_VALUE}"; then
+  "${PROCESS_SCRIPT}" stop --worktree "${WORKTREE_PATH}" --target "${TARGET}" >/dev/null 2>&1 || true
+  echo "Error: preview exited immediately. Check ${LOG_PATH}." >&2
+  exit 1
+fi
+
+trap - EXIT
+
+echo "Started ${TARGET} preview."
+echo "Worktree: ${WORKTREE_PATH}"
+echo "PID: ${PID_VALUE}"
+echo "Log: ${LOG_PATH}"
+if [[ -n "${URL}" ]]; then
+  echo "URL: ${URL}"
+fi

--- a/scripts/worktree-processes.sh
+++ b/scripts/worktree-processes.sh
@@ -1,0 +1,355 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./lib/worktree-runtime.sh
+source "${SCRIPT_DIR}/lib/worktree-runtime.sh"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  ./scripts/worktree-processes.sh list [--worktree <path>] [--kind desktop|web] [--target <name>]
+  ./scripts/worktree-processes.sh stop [--worktree <path>] [--kind desktop|web] [--target <name>]
+  ./scripts/worktree-processes.sh prune
+
+Internal:
+  ./scripts/worktree-processes.sh claim --kind <desktop|web> --worktree <path> --pid <pid>
+  ./scripts/worktree-processes.sh track --pid <pid> --kind <desktop|web> --target <name> --worktree <path> [--port <port>] [--log <path>] --command <command>
+  ./scripts/worktree-processes.sh release --kind <desktop|web> [--pid <pid>]
+EOF
+}
+
+validate_kind() {
+  case "$1" in
+    desktop|web) ;;
+    *)
+      echo "Error: unsupported process kind '$1'. Use desktop or web." >&2
+      exit 1
+      ;;
+  esac
+}
+
+matches_filters() {
+  local expected_path="$1"
+  local expected_kind="$2"
+  local expected_target="$3"
+
+  if [[ -n "${expected_path}" && "${WORKTREE_PATH:-}" != "${expected_path}" ]]; then
+    return 1
+  fi
+
+  if [[ -n "${expected_kind}" && "${PROCESS_KIND:-}" != "${expected_kind}" ]]; then
+    return 1
+  fi
+
+  if [[ -n "${expected_target}" && "${TARGET:-}" != "${expected_target}" ]]; then
+    return 1
+  fi
+
+  return 0
+}
+
+stop_pid() {
+  local pid="$1"
+  local attempts=0
+
+  if ! is_pid_running "${pid}"; then
+    return 0
+  fi
+
+  kill "${pid}" 2>/dev/null || true
+  while is_pid_running "${pid}" && [[ ${attempts} -lt 10 ]]; do
+    sleep 0.2
+    attempts=$((attempts + 1))
+  done
+
+  if is_pid_running "${pid}"; then
+    kill -9 "${pid}" 2>/dev/null || true
+  fi
+}
+
+list_processes() {
+  local filter_path="$1"
+  local filter_kind="$2"
+  local filter_target="$3"
+  local manifest found=0
+
+  prune_runtime_state
+
+  printf '%-8s %-10s %-7s %-6s %s\n' "kind" "target" "pid" "port" "worktree"
+
+  shopt -s nullglob
+  for manifest in "$(process_state_dir)"/*.env; do
+    unset PID PROCESS_KIND TARGET WORKTREE_PATH PORT COMMAND LOG_PATH STARTED_AT
+    # shellcheck disable=SC1090
+    source "${manifest}"
+
+    if ! matches_filters "${filter_path}" "${filter_kind}" "${filter_target}"; then
+      continue
+    fi
+
+    printf '%-8s %-10s %-7s %-6s %s\n' \
+      "${PROCESS_KIND:-}" \
+      "${TARGET:-}" \
+      "${PID:-}" \
+      "${PORT:-"-"}" \
+      "${WORKTREE_PATH:-}"
+    found=1
+  done
+  shopt -u nullglob
+
+  if [[ ${found} -eq 0 ]]; then
+    echo "No tracked preview processes."
+  fi
+}
+
+stop_processes() {
+  local filter_path="$1"
+  local filter_kind="$2"
+  local filter_target="$3"
+  local manifest count=0
+
+  prune_runtime_state
+
+  shopt -s nullglob
+  for manifest in "$(process_state_dir)"/*.env; do
+    unset PID PROCESS_KIND TARGET WORKTREE_PATH PORT COMMAND LOG_PATH STARTED_AT
+    # shellcheck disable=SC1090
+    source "${manifest}"
+
+    if ! matches_filters "${filter_path}" "${filter_kind}" "${filter_target}"; then
+      continue
+    fi
+
+    stop_pid "${PID}"
+    rm -f "${manifest}"
+    release_lock "${PROCESS_KIND}" "${PID}"
+    count=$((count + 1))
+  done
+  shopt -u nullglob
+
+  echo "Stopped ${count} tracked process(es)."
+}
+
+claim_slot() {
+  local kind="$1"
+  local worktree_path="$2"
+  local claim_pid="$3"
+  local manifest
+  local mutex_dir
+  local waited=0
+
+  validate_kind "${kind}"
+  prune_runtime_state
+  manifest="$(lock_manifest_path "${kind}")"
+  mutex_dir="${manifest}.mutex"
+
+  while ! mkdir "${mutex_dir}" 2>/dev/null; do
+    sleep 0.1
+    waited=$((waited + 1))
+    if [[ ${waited} -ge 100 ]]; then
+      echo "Error: timed out waiting for the ${kind} preview lock." >&2
+      exit 1
+    fi
+  done
+  trap 'rmdir "'"${mutex_dir}"'" >/dev/null 2>&1 || true' RETURN
+
+  if [[ -f "${manifest}" ]]; then
+    unset LOCK_PID LOCK_WORKTREE_PATH LOCK_TARGET LOCK_PORT
+    # shellcheck disable=SC1090
+    source "${manifest}"
+    if is_pid_running "${LOCK_PID:-}"; then
+      echo "Error: ${kind} preview slot is already in use by ${LOCK_WORKTREE_PATH:-unknown} (pid ${LOCK_PID:-unknown}, target ${LOCK_TARGET:-unknown}, port ${LOCK_PORT:-unknown})." >&2
+      exit 1
+    fi
+    rm -f "${manifest}"
+  fi
+
+  write_lock_metadata "${kind}" "${claim_pid}" "${worktree_path}" "starting" ""
+  trap - RETURN
+  rmdir "${mutex_dir}" >/dev/null 2>&1 || true
+}
+
+track_process() {
+  local pid="$1"
+  local kind="$2"
+  local target="$3"
+  local worktree_path="$4"
+  local port="$5"
+  local log_path="$6"
+  local command="$7"
+
+  validate_kind "${kind}"
+  write_process_metadata "${pid}" "${kind}" "${target}" "${worktree_path}" "${port}" "${command}" "${log_path}"
+  write_lock_metadata "${kind}" "${pid}" "${worktree_path}" "${target}" "${port}"
+}
+
+SUBCOMMAND="${1:-}"
+if [[ -z "${SUBCOMMAND}" ]]; then
+  usage
+  exit 1
+fi
+shift || true
+
+case "${SUBCOMMAND}" in
+  list|stop)
+    FILTER_WORKTREE=""
+    FILTER_KIND=""
+    FILTER_TARGET=""
+
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --worktree)
+          [[ $# -ge 2 ]] || { echo "Error: --worktree requires a value." >&2; exit 1; }
+          FILTER_WORKTREE="$(resolve_worktree_path "$2")"
+          shift 2
+          ;;
+        --kind)
+          [[ $# -ge 2 ]] || { echo "Error: --kind requires a value." >&2; exit 1; }
+          FILTER_KIND="$2"
+          validate_kind "${FILTER_KIND}"
+          shift 2
+          ;;
+        --target)
+          [[ $# -ge 2 ]] || { echo "Error: --target requires a value." >&2; exit 1; }
+          FILTER_TARGET="$2"
+          shift 2
+          ;;
+        *)
+          echo "Error: unexpected argument '$1'." >&2
+          usage
+          exit 1
+          ;;
+      esac
+    done
+
+    if [[ "${SUBCOMMAND}" == "list" ]]; then
+      list_processes "${FILTER_WORKTREE}" "${FILTER_KIND}" "${FILTER_TARGET}"
+    else
+      stop_processes "${FILTER_WORKTREE}" "${FILTER_KIND}" "${FILTER_TARGET}"
+    fi
+    ;;
+  prune)
+    prune_runtime_state
+    echo "Pruned stale process state."
+    ;;
+  claim)
+    KIND=""
+    WORKTREE_PATH=""
+    CLAIM_PID=""
+
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --kind)
+          KIND="$2"
+          shift 2
+          ;;
+        --worktree)
+          WORKTREE_PATH="$2"
+          shift 2
+          ;;
+        --pid)
+          CLAIM_PID="$2"
+          shift 2
+          ;;
+        *)
+          echo "Error: unexpected argument '$1'." >&2
+          exit 1
+          ;;
+      esac
+    done
+
+    [[ -n "${KIND}" && -n "${WORKTREE_PATH}" && -n "${CLAIM_PID}" ]] || {
+      echo "Error: claim requires --kind, --worktree, and --pid." >&2
+      exit 1
+    }
+
+    claim_slot "${KIND}" "${WORKTREE_PATH}" "${CLAIM_PID}"
+    ;;
+  track)
+    PID_VALUE=""
+    KIND=""
+    TARGET_VALUE=""
+    WORKTREE_PATH=""
+    PORT_VALUE=""
+    LOG_PATH_VALUE=""
+    COMMAND_VALUE=""
+
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --pid)
+          PID_VALUE="$2"
+          shift 2
+          ;;
+        --kind)
+          KIND="$2"
+          shift 2
+          ;;
+        --target)
+          TARGET_VALUE="$2"
+          shift 2
+          ;;
+        --worktree)
+          WORKTREE_PATH="$2"
+          shift 2
+          ;;
+        --port)
+          PORT_VALUE="$2"
+          shift 2
+          ;;
+        --log)
+          LOG_PATH_VALUE="$2"
+          shift 2
+          ;;
+        --command)
+          COMMAND_VALUE="$2"
+          shift 2
+          ;;
+        *)
+          echo "Error: unexpected argument '$1'." >&2
+          exit 1
+          ;;
+      esac
+    done
+
+    [[ -n "${PID_VALUE}" && -n "${KIND}" && -n "${TARGET_VALUE}" && -n "${WORKTREE_PATH}" && -n "${COMMAND_VALUE}" ]] || {
+      echo "Error: track requires --pid, --kind, --target, --worktree, and --command." >&2
+      exit 1
+    }
+
+    track_process "${PID_VALUE}" "${KIND}" "${TARGET_VALUE}" "${WORKTREE_PATH}" "${PORT_VALUE}" "${LOG_PATH_VALUE}" "${COMMAND_VALUE}"
+    ;;
+  release)
+    KIND=""
+    EXPECTED_PID=""
+
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --kind)
+          KIND="$2"
+          shift 2
+          ;;
+        --pid)
+          EXPECTED_PID="$2"
+          shift 2
+          ;;
+        *)
+          echo "Error: unexpected argument '$1'." >&2
+          exit 1
+          ;;
+      esac
+    done
+
+    [[ -n "${KIND}" ]] || {
+      echo "Error: release requires --kind." >&2
+      exit 1
+    }
+
+    release_lock "${KIND}" "${EXPECTED_PID}"
+    ;;
+  *)
+    usage
+    exit 1
+    ;;
+esac

--- a/website/src/app/roadmap/RoadmapContent.tsx
+++ b/website/src/app/roadmap/RoadmapContent.tsx
@@ -700,7 +700,7 @@ const phases: Phase[] = [
     number: 1,
     title: "Foundation",
     description:
-      "Marketing site, QR gallery, monorepo, Automerge schema, CI/CD, public legal docs with download clickwrap, and a protected newsletter signup flow.",
+      "Marketing site, QR gallery, monorepo, Automerge schema, CI/CD, public legal docs with download clickwrap, a protected newsletter signup flow, and deferred local worktree bootstrap with tracked preview tooling.",
     status: "complete",
     planLink:
       "https://github.com/freed-project/freed/blob/dev/docs/PHASE-1-FOUNDATION.md",


### PR DESCRIPTION
(AI Generated). 

## What changed
- deferred worktree setup so new worktrees default to `--install auto` with target hints instead of always running a full `npm ci`
- added `scripts/worktree-bootstrap.sh` for explicit bootstrap, `scripts/worktree-preview.sh` for tracked preview startup, and `scripts/worktree-processes.sh` plus `scripts/lib/worktree-runtime.sh` for shared runtime metadata, slot locks, and process cleanup
- updated worktree cleanup to stop tracked previews before removing a worktree
- updated the feature and web build skills, desktop README, phase docs, and roadmap copy to match the new workflow

## Why
- multiple concurrent feature threads were paying for duplicate installs and long lived preview processes by default
- this shifts the local workflow toward demand driven bootstrap and explicit preview ownership so concurrent worktrees put less pressure on memory and background process count

## Validation
- `bash -n scripts/worktree-add.sh scripts/worktree-bootstrap.sh scripts/worktree-processes.sh scripts/worktree-preview.sh scripts/worktree-cleanup.sh scripts/lib/worktree-runtime.sh`
- `git diff --check`
- created a temp worktree with `--install auto --target shared` and confirmed no `node_modules` was created until bootstrap was requested
- verified mocked desktop preview end to end, including `HTTP/1.1 200 OK` on port `1432`, tracked process listing, and tracked shutdown
- verified PWA preview served successfully on port `1431`
- verified website preview served successfully on port `3001` and that the single web preview slot blocks a second concurrent web preview
- verified native desktop preview served successfully on port `1420` and could be stopped through tracked process cleanup
