### PR TITLE
fix: deploy production website from www

### DIFF
--- a/.agents/skills/freed-ship-build/SKILL.md
+++ b/.agents/skills/freed-ship-build/SKILL.md
@@ -13,13 +13,19 @@ Ship a new versioned build from the correct release branch using GitHub Actions.
 1. Ask whether this should be a `dev` release or a `production` release before doing anything else.
 2. Ensure you are on the correct branch with a clean working tree:
    - `dev` releases ship from the `dev` branch
-   - `production` releases ship from the `main` branch
-3. Run `./scripts/release.sh --channel=<dev|production>` to compute the next CalVer version and prepare the release tag.
-4. Monitor the GitHub Actions build to ensure it succeeds for all platforms.
-5. If the build fails:
+   - `production` desktop releases ship from the `main` branch
+   - `production` website deploys ship from the `www` branch
+3. Before any production website deploy, ensure the website and changelog changes have already been merged to `www`.
+   - Never assume a production website deploy can safely build from `main`
+   - If a production release updates website changelog content, merge those reviewed website changes to `www` before the deploy runs
+4. Run `./scripts/release.sh --channel=<dev|production>` to compute the next CalVer version and prepare the release tag.
+5. Monitor the GitHub Actions build to ensure it succeeds for all platforms and that any production website deploy is pulled from `www`.
+6. If the build fails:
    - Create a new branch and open a PR with the fix.
    - Iterate until CI passes on the PR.
-   - Squash-merge the PR to `dev` for dev-release fixes, or to `main` for production-release fixes.
+   - Squash-merge the PR to `dev` for dev-release fixes.
+   - Squash-merge production desktop release fixes to `main`.
+   - Squash-merge production website fixes to `www`.
    - Initiate a follow-up build from the matching release branch.
-6. Repeat until all platform builds are successful.
-7. If the public marketing changelog should reflect the newly published release, follow up with an explicit `www` sync and website deploy instead of assuming the desktop release branch will update `freed.wtf` for you.
+7. Repeat until all platform builds are successful.
+8. If the public marketing changelog should reflect the newly published release, follow up with an explicit `www` sync and website deploy instead of assuming the desktop release branch will update `freed.wtf` for you.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -331,12 +331,28 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: www
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: "lts/*"
           cache: "npm"
+
+      - name: Verify website production branch contains this release
+        shell: bash
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          RELEASE_JSON="release-notes/releases/${TAG}.json"
+
+          if [[ ! -f "$RELEASE_JSON" ]]; then
+            echo "Website production deploys must ship from the www branch." >&2
+            echo "Missing ${RELEASE_JSON} on www for ${TAG}." >&2
+            echo "Merge the reviewed website and changelog updates into www before this production website deploy can run." >&2
+            exit 1
+          fi
 
       - name: Wait for published GitHub release
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,13 @@ Or run the cleanup helper to sweep all merged worktrees at once:
 
 Branches are deleted after merge. The squash commit message is derived from the PR title — write PR titles as if they are commit messages.
 
+**Production website branch:** `freed.wtf` ships from `www`, not `main`.
+
+- Merge production website changes to `www` before deploying the marketing site
+- Production desktop releases still tag from `main`
+- If a production release updates checked-in changelog or website content, merge that reviewed website state to `www` before the production website deploy runs
+- Never assume a website deploy from `main` is correct just because the desktop release tagged from `main`
+
 **Never use `git log main..branch` to check whether a branch has been merged.** Squash merge creates a new commit hash on `main`, so the original branch commits are never reachable from `main`'s history. The branch always looks "ahead" even when its content is fully shipped. Use these instead:
 
 ```bash

--- a/docs/PHASE-5-DESKTOP.md
+++ b/docs/PHASE-5-DESKTOP.md
@@ -334,9 +334,11 @@ export async function captureDomFeed(
 > and dev prereleases from `dev` without syncing that preference through the
 > shared document.
 > After the GitHub release is published, the workflow now
-> redeploys `freed.wtf` so the changelog snapshot rebuilds against the newly
-> published release instead of the earlier draft state. See
-> `RELEASE-SECRETS.md` for the full setup checklist.
+> redeploys `freed.wtf` from the `www` branch so the changelog snapshot
+> rebuilds against the newly published release instead of the earlier draft
+> state. Production desktop tags still come from `main`, but production
+> website deploys must first merge the reviewed website and changelog state to
+> `www`. See `RELEASE-SECRETS.md` for the full setup checklist.
 
 ### Mobile
 

--- a/docs/RELEASE-SECRETS.md
+++ b/docs/RELEASE-SECRETS.md
@@ -158,10 +158,18 @@ creates a **draft** GitHub Release using the approved checked-in release body.
 After all platform builds succeed, the workflow publishes that release
 automatically.
 
-If `VERCEL_TOKEN` is configured, production releases deploy `packages/pwa/` so
-the PWA version stays aligned with the shipped desktop release. The marketing
-site changelog is refreshed separately from `www`, which rebuilds the static
-website snapshot from the current `www` branch state.
+If `VERCEL_TOKEN` is configured, production releases then:
+
+- redeploys `website/` from the `www` branch so `freed.wtf/changelog`
+  rebuilds its checked-in snapshot against the published GitHub release
+- deploys `packages/pwa/` so the PWA version stays aligned with the shipped
+  desktop release
+
+Production desktop tags still come from `main`, but the marketing site does
+not. Before the website deploy runs, merge the reviewed website and changelog
+state to `www`. The release workflow now checks out `www` for the production
+website deploy and fails if that branch does not contain the tagged release
+artifact.
 
 Dev releases are published as GitHub prereleases with a `-dev` suffix and do
 not trigger production PWA deploys. They should still be followed by an


### PR DESCRIPTION
(AI Generated).

## Summary
- deploy the production website from `www` instead of the desktop release checkout
- fail the release workflow if `www` does not contain the tagged release artifact needed for the website changelog rebuild
- update repo instructions and the release skill so the production website branch contract is explicit

## Why
The marketing site and changelog behavior were being treated as if they shipped from `main`, but the intended production website branch is `www`. That mismatch makes it too easy to overwrite `www`-only website changes during a production release.

## Impact
Production desktop tags still come from `main`, but the production website deploy now checks out `www` and enforces that the reviewed website state is merged there first. The local instructions now match that rule so the release path is harder to get wrong.

## Validation
- `git diff --check`
- inspected the release workflow changes and confirmed the website deploy job now checks out `www`
- resolved the `www` branch cherry-pick cleanly so this PR only contains the website production-flow fix
