### PR TITLE
fix: finalize explicit www release flow on main

### DIFF
--- a/.agents/skills/freed-build-feature/SKILL.md
+++ b/.agents/skills/freed-build-feature/SKILL.md
@@ -1,18 +1,27 @@
 ---
 name: freed-build-feature
-description: Scaffold a feature branch in a worktree, plan the implementation, build it, and launch a live preview. Use when starting work on a new feature.
+description: Scaffold product work in a dev-based worktree, implement it, verify it, and launch the relevant app preview. Use for Desktop, PWA, shared packages, sync, capture packages, release tooling, app behavior, and product docs targeting dev. Do not use for public marketing changes targeting www.
 disable-model-invocation: true
 ---
 
 # Build Feature
 
-Create a new worktree branch from dev, plan the feature, implement it, and launch a live preview.
+Create a product worktree branch from `dev`, implement the feature or fix, verify it, and launch the relevant preview.
 
 ## Workflow
 
-1. Create a new worktree branch from `dev` using `./scripts/worktree-add.sh`.
-2. Activate planning mode and prepare an implementation plan for the feature described by the user.
-3. Implement the feature according to the plan.
-4. Launch a live preview so the user can test it:
-   - For web/PWA features: start a PWA dev server. If the standard preview port is in use (likely another agent in another worktree), find an available port instead of killing the existing one.
-   - For desktop-specific features: launch a Tauri dev preview instead.
+1. Confirm the work is product work targeting `dev`.
+2. Reject or reroute public marketing work targeting `www`; use `freed-build-www` instead.
+3. Create a new worktree branch from `dev` using `./scripts/worktree-add.sh`.
+4. Implement the requested change.
+5. Verify with focused tests, then broader checks when shared behavior changed.
+6. Launch the relevant preview:
+   - For PWA work, deploy or run the PWA preview.
+   - For desktop work, use the desktop E2E test harness or Tauri preview as appropriate.
+7. Open a PR targeting `dev` when the work is ready.
+
+## Scope
+
+Default allowed paths include `packages/`, product docs under `docs/`, release tooling, shared app config, and product CI.
+
+Do not use this skill for `website/` only marketing work, homepage copy, public roadmap presentation, or changelog presentation. Those changes target `www`.

--- a/.agents/skills/freed-build-www/SKILL.md
+++ b/.agents/skills/freed-build-www/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: freed-build-www
+description: Build marketing-site work in a www-based worktree, verify website changes, deploy a website preview, and prepare a PR targeting www. Use for homepage, public changelog presentation, public roadmap presentation, marketing copy, legal or marketing pages, and website-only changes intended for freed.wtf.
+disable-model-invocation: true
+---
+
+# Build WWW
+
+Create a marketing worktree branch from `www`, implement the website change, verify it, and deploy a website preview.
+
+## Workflow
+
+1. Confirm the request is public marketing work targeting `www`.
+2. Reject or reroute product work targeting `dev`; use `freed-build-feature` instead.
+3. Create a new worktree branch from `www` using `./scripts/worktree-add.sh`.
+4. Keep changes scoped to marketing paths unless the user explicitly changes the destination.
+5. Run website checks, at minimum `npm run build --workspace=website`.
+6. Deploy a website preview with `./scripts/vercel-deploy-preview.sh website`.
+7. Open a PR targeting `www` when the work is ready.
+
+## Scope
+
+Default allowed paths:
+
+- `website/**`
+- marketing docs such as `docs/MARKETING.md`
+- legal docs rendered by the marketing site
+- `.agents/skills/freed-build-www/SKILL.md` when updating this skill
+
+Require rerouting or explicit confirmation before touching:
+
+- `packages/**`
+- `scripts/release*`
+- `.github/workflows/release.yml`
+- `release-notes/**`
+- `packages/desktop/**`
+- `packages/pwa/**`
+- root package files, unless the website build tooling requires it

--- a/.agents/skills/freed-ship-build/SKILL.md
+++ b/.agents/skills/freed-ship-build/SKILL.md
@@ -22,3 +22,4 @@ Ship a new versioned build from the correct release branch using GitHub Actions.
    - Squash-merge the PR to `dev` for dev-release fixes, or to `main` for production-release fixes.
    - Initiate a follow-up build from the matching release branch.
 6. Repeat until all platform builds are successful.
+7. After a dev or production release ships successfully, use `freed-ship-www` in changelog refresh mode so the static public changelog can include the newly published release without merging `dev` into `www`.

--- a/.agents/skills/freed-ship-build/SKILL.md
+++ b/.agents/skills/freed-ship-build/SKILL.md
@@ -13,13 +13,20 @@ Ship a new versioned build from the correct release branch using GitHub Actions.
 1. Ask whether this should be a `dev` release or a `production` release before doing anything else.
 2. Ensure you are on the correct branch with a clean working tree:
    - `dev` releases ship from the `dev` branch
-   - `production` releases ship from the `main` branch
-3. Run `./scripts/release.sh --channel=<dev|production>` to compute the next CalVer version and prepare the release tag.
-4. Monitor the GitHub Actions build to ensure it succeeds for all platforms.
-5. If the build fails:
+   - `production` desktop releases ship from the `main` branch
+   - `production` website deploys ship from the `www` branch
+3. Before any production website deploy, ensure the website and changelog changes have already been merged to `www`.
+   - Never assume a production website deploy can safely build from `main`
+   - If a production release updates website changelog content, merge those reviewed website changes to `www` before the deploy runs
+4. Run `./scripts/release.sh --channel=<dev|production>` to compute the next CalVer version and prepare the release tag.
+5. Monitor the GitHub Actions build to ensure it succeeds for all platforms and that any production website deploy is pulled from `www`.
+6. If the build fails:
    - Create a new branch and open a PR with the fix.
    - Iterate until CI passes on the PR.
-   - Squash-merge the PR to `dev` for dev-release fixes, or to `main` for production-release fixes.
+   - Squash-merge the PR to `dev` for dev-release fixes.
+   - Squash-merge production desktop release fixes to `main`.
+   - Squash-merge production website fixes to `www`.
    - Initiate a follow-up build from the matching release branch.
-6. Repeat until all platform builds are successful.
-7. After a dev or production release ships successfully, use `freed-ship-www` in changelog refresh mode so the static public changelog can include the newly published release without merging `dev` into `www`.
+7. Repeat until all platform builds are successful.
+8. For production releases, ensure the reviewed website and changelog state is already merged to `www` before the workflow deploys `freed.wtf` from that branch.
+9. After a dev release ships successfully, use `freed-ship-www` in changelog refresh mode so the static public changelog can include the newly published release without merging `dev` into `www`.

--- a/.agents/skills/freed-ship-www/SKILL.md
+++ b/.agents/skills/freed-ship-www/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: freed-ship-www
+description: Publish freed.wtf from www, refresh the static changelog after releases, ship merged PRs targeting www, or sync approved main changes into www. Use for production marketing deploys and changelog refreshes. Never fast-forward www to dev.
+disable-model-invocation: true
+---
+
+# Ship WWW
+
+Publish the public marketing site from `www` or refresh its static changelog.
+
+## Modes
+
+### Ship Current WWW
+
+1. Check out or update `www`.
+2. Verify the working tree is clean.
+3. Run `./scripts/vercel-deploy-production.sh website`.
+4. Inspect the production deployment and report the URL.
+
+### Ship Merged WWW PR
+
+1. Verify the PR targeting `www` is merged.
+2. Update local `www` from origin.
+3. Run `./scripts/vercel-deploy-production.sh website`.
+4. Inspect the production deployment and report the URL.
+
+### Refresh Changelog
+
+1. Use this after a dev or production desktop release is published.
+2. Update local `www` from origin.
+3. Rebuild and deploy the website from current `www`.
+4. Never merge or fast-forward `www` to `dev`.
+
+### Sync From Main
+
+1. Fetch `main` and `www`.
+2. If `www` can fast-forward to `main`, fast-forward it.
+3. If `www` has marketing-only commits, merge `main` into `www`.
+4. Reject the sync if divergence includes non-marketing files.
+5. Build and deploy the website from `www`.
+
+## Safety Rules
+
+- Always preserve `--scope aubreyfs-projects` on Vercel CLI calls by using the repo deploy helpers.
+- Never run raw `vercel` from the repo root.
+- Never fast-forward `www` to `dev`.
+- Reject production deploys when the changed path set includes product files unless the user explicitly changes the plan.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: [dev, main]
 
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-desktop.yml
+++ b/.github/workflows/e2e-desktop.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [dev, main]
   pull_request:
-    branches: [dev, main]
+    branches: [dev]
     paths:
       - "packages/desktop/**"
       - "packages/ui/**"
@@ -16,6 +16,12 @@ permissions:
   contents: read
   pull-requests: write
 
+concurrency:
+  group: e2e-desktop-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 jobs:
   e2e:
     name: Smoke tests (Chromium, Linux)

--- a/.github/workflows/pwa-preview.yml
+++ b/.github/workflows/pwa-preview.yml
@@ -1,0 +1,48 @@
+name: PWA Preview
+
+on:
+  pull_request:
+    branches: [dev]
+    paths:
+      - "packages/pwa/**"
+      - "packages/shared/**"
+      - "packages/sync/**"
+      - "packages/ui/**"
+      - "package.json"
+      - "package-lock.json"
+      - "tsconfig.base.json"
+      - "scripts/vercel-deploy-preview.sh"
+      - "scripts/lib/**"
+      - ".github/workflows/pwa-preview.yml"
+
+concurrency:
+  group: pwa-preview-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  preview:
+    name: Build and deploy PWA preview
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Deploy PWA preview
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          if [ -z "$VERCEL_TOKEN" ]; then
+            echo "VERCEL_TOKEN not configured, skipping PWA preview deploy."
+            exit 0
+          fi
+          ./scripts/vercel-deploy-preview.sh pwa "$VERCEL_TOKEN"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -317,6 +317,71 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release edit "${{ github.ref_name }}" --draft=false --repo "${{ github.repository }}"
 
+  # Redeploy the marketing site after the GitHub release is public so the
+  # checked-in changelog snapshot is rebuilt against the published release.
+  # Requires VERCEL_TOKEN to be set in repo secrets. If the secret is absent
+  # the step exits cleanly without failing the workflow.
+  publish-website:
+    name: Deploy Website
+    needs: [publish, notes]
+    if: needs.notes.outputs.release_channel == 'production'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: www
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+          cache: "npm"
+
+      - name: Verify website production branch contains this release
+        shell: bash
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          RELEASE_JSON="release-notes/releases/${TAG}.json"
+
+          if [[ ! -f "$RELEASE_JSON" ]]; then
+            echo "Website production deploys must ship from the www branch." >&2
+            echo "Missing ${RELEASE_JSON} on www for ${TAG}." >&2
+            echo "Merge the reviewed website and changelog updates into www before this production website deploy can run." >&2
+            exit 1
+          fi
+
+      - name: Wait for published GitHub release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          for attempt in {1..30}; do
+            draft_state=$(gh api "repos/${{ github.repository }}/releases/tags/${{ github.ref_name }}" --jq '.draft')
+            if [ "$draft_state" = "false" ]; then
+              echo "Release ${{ github.ref_name }} is published."
+              exit 0
+            fi
+
+            echo "Release ${{ github.ref_name }} is still draft, retrying in 10s (${attempt}/30)"
+            sleep 10
+          done
+
+          echo "Release ${{ github.ref_name }} never became published."
+          exit 1
+
+      - name: Deploy website to Vercel
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          if [ -z "$VERCEL_TOKEN" ]; then
+            echo "VERCEL_TOKEN not configured, skipping website deploy"
+            echo "Add a VERCEL_TOKEN secret to enable automatic website changelog refresh."
+            exit 0
+          fi
+          ./scripts/vercel-deploy-production.sh website "$VERCEL_TOKEN"
   # Deploy the PWA to Vercel after the GitHub release is published so the
   # version shown in the app always matches the shipped desktop release.
   # Requires VERCEL_TOKEN to be set in repo secrets. If the secret is absent

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -317,56 +317,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release edit "${{ github.ref_name }}" --draft=false --repo "${{ github.repository }}"
 
-  # Redeploy the marketing site after the GitHub release is public so the
-  # checked-in changelog snapshot is rebuilt against the published release.
-  # Requires VERCEL_TOKEN to be set in repo secrets. If the secret is absent
-  # the step exits cleanly without failing the workflow.
-  publish-website:
-    name: Deploy Website
-    needs: [publish, notes]
-    if: needs.notes.outputs.release_channel == 'production'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "lts/*"
-          cache: "npm"
-
-      - name: Wait for published GitHub release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          for attempt in {1..30}; do
-            draft_state=$(gh api "repos/${{ github.repository }}/releases/tags/${{ github.ref_name }}" --jq '.draft')
-            if [ "$draft_state" = "false" ]; then
-              echo "Release ${{ github.ref_name }} is published."
-              exit 0
-            fi
-
-            echo "Release ${{ github.ref_name }} is still draft, retrying in 10s (${attempt}/30)"
-            sleep 10
-          done
-
-          echo "Release ${{ github.ref_name }} never became published."
-          exit 1
-
-      - name: Deploy website to Vercel
-        env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-        run: |
-          if [ -z "$VERCEL_TOKEN" ]; then
-            echo "VERCEL_TOKEN not configured, skipping website deploy"
-            echo "Add a VERCEL_TOKEN secret to enable automatic website changelog refresh."
-            exit 0
-          fi
-          ./scripts/vercel-deploy-production.sh website "$VERCEL_TOKEN"
-
   # Deploy the PWA to Vercel after the GitHub release is published so the
   # version shown in the app always matches the shipped desktop release.
   # Requires VERCEL_TOKEN to be set in repo secrets. If the secret is absent

--- a/.github/workflows/website-preview.yml
+++ b/.github/workflows/website-preview.yml
@@ -1,0 +1,47 @@
+name: Website Preview
+
+on:
+  pull_request:
+    branches: [www]
+    paths:
+      - "website/**"
+      - "packages/shared/**"
+      - "packages/ui/**"
+      - "package.json"
+      - "package-lock.json"
+      - "tsconfig.base.json"
+      - "scripts/vercel-deploy-preview.sh"
+      - "scripts/lib/**"
+      - ".github/workflows/website-preview.yml"
+
+concurrency:
+  group: website-preview-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  preview:
+    name: Build and deploy website preview
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Deploy website preview
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          if [ -z "$VERCEL_TOKEN" ]; then
+            echo "VERCEL_TOKEN not configured, skipping website preview deploy."
+            exit 0
+          fi
+          ./scripts/vercel-deploy-preview.sh website "$VERCEL_TOKEN"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,22 @@ Or run the cleanup helper to sweep all merged worktrees at once:
 
 Branches are deleted after merge. The squash commit message is derived from the PR title — write PR titles as if they are commit messages.
 
+### Worktree Routing
+
+Before creating a worktree, classify the requested work by destination branch.
+
+- Product work targets `dev`: Desktop, PWA, shared packages, sync, capture packages, release tooling, app behavior, and product docs.
+- Public marketing work targets `www`: `website/`, marketing copy, public roadmap presentation, changelog presentation, and marketing docs.
+- Production release prep targets `main`.
+- Dev release prep targets `dev`.
+- Use `freed-build-feature` for product work targeting `dev`.
+- Use `freed-build-www` for marketing-site changes targeting `www`.
+- Use `freed-ship-build` for desktop release shipping.
+- Use `freed-ship-www` for publishing `www`, refreshing changelog, or syncing `main` into `www`.
+- Ask before creating a worktree if destination branch or path scope is unclear.
+- Never base public marketing work from `dev`.
+- Never fast-forward `www` to `dev`.
+
 **Never use `git log main..branch` to check whether a branch has been merged.** Squash merge creates a new commit hash on `main`, so the original branch commits are never reachable from `main`'s history. The branch always looks "ahead" even when its content is fully shipped. Use these instead:
 
 ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,6 +110,13 @@ Before creating a worktree, classify the requested work by destination branch.
 - Never base public marketing work from `dev`.
 - Never fast-forward `www` to `dev`.
 
+**Production website branch:** `freed.wtf` ships from `www`, not `main`.
+
+- Merge production website changes to `www` before deploying the marketing site
+- Production desktop releases still tag from `main`
+- If a production release updates checked-in changelog or website content, merge that reviewed website state to `www` before the production website deploy runs
+- Never assume a website deploy from `main` is correct just because the desktop release tagged from `main`
+
 **Never use `git log main..branch` to check whether a branch has been merged.** Squash merge creates a new commit hash on `main`, so the original branch commits are never reachable from `main`'s history. The branch always looks "ahead" even when its content is fully shipped. Use these instead:
 
 ```bash

--- a/docs/PHASE-1-FOUNDATION.md
+++ b/docs/PHASE-1-FOUNDATION.md
@@ -235,8 +235,9 @@ Manual preview deploys for this monorepo now go through `./scripts/vercel-deploy
 
 The website and PWA preview workflows use the helpers directly so PRs only
 build the surface they target. Native Vercel preview deploys should stay
-disabled where GitHub Actions owns preview deployment, otherwise a single PR
-can spend minutes in both systems for the same preview.
+disabled where GitHub Actions owns preview deployment. The website Vercel
+project only allows Git-triggered deploys from `www`, and the PWA project
+disables Git-triggered deploys entirely.
 
 The preview and production deploy helpers now resolve `npm` and `npx` from the
 active Node toolchain first, so they do not accidentally pick up an older

--- a/docs/PHASE-1-FOUNDATION.md
+++ b/docs/PHASE-1-FOUNDATION.md
@@ -214,7 +214,8 @@ GitHub Actions workflows for continuous integration and deployment.
 
 **Deploy (Vercel):**
 
-Two Vercel projects now follow a dev-first branch flow with preview deploys on PRs:
+Two Vercel projects now use branch-specific release lanes with GitHub Actions
+owning preview deploys:
 
 | Project      | Root Directory   | Domain                                          |
 | ------------ | ---------------- | ------------------------------------------------ |
@@ -223,13 +224,23 @@ Two Vercel projects now follow a dev-first branch flow with preview deploys on P
 
 Branch routing:
 
-- `dev` deploys to `dev.freed.wtf`
-- `dev` deploys to `dev-app.freed.wtf`
-- `main` deploys to `freed.wtf`
-- `main` deploys to `app.freed.wtf`
+- `www` is the public marketing branch for `freed.wtf`
+- PRs targeting `www` build and deploy website previews only
+- `dev` is the product integration branch
+- PRs targeting `dev` build PWA previews and run product checks
+- `main` remains the production app release branch
+- `main` no longer redeploys `freed.wtf` as a side effect
 
 Manual preview deploys for this monorepo now go through `./scripts/vercel-deploy-preview.sh website` and `./scripts/vercel-deploy-preview.sh pwa`. The helper stages a temporary monorepo slice with shared workspace packages before uploading to Vercel, which avoids the broken `npm install` failures caused by raw subdirectory deploys.
 
+The website and PWA preview workflows use the helpers directly so PRs only
+build the surface they target. Native Vercel preview deploys should stay
+disabled where GitHub Actions owns preview deployment, otherwise a single PR
+can spend minutes in both systems for the same preview.
+
+The preview and production deploy helpers now resolve `npm` and `npx` from the
+active Node toolchain first, so they do not accidentally pick up an older
+system npm from the shell `PATH`.
 ---
 
 ## Key Decisions

--- a/docs/PHASE-5-DESKTOP.md
+++ b/docs/PHASE-5-DESKTOP.md
@@ -336,10 +336,12 @@ export async function captureDomFeed(
 > and Freed Desktop can switch locally between production releases from `main`
 > and dev prereleases from `dev` without syncing that preference through the
 > shared document.
-> After the GitHub release is published, the workflow now
-> redeploys `freed.wtf` so the changelog snapshot rebuilds against the newly
-> published release instead of the earlier draft state. See
-> `RELEASE-SECRETS.md` for the full setup checklist.
+> Release shipping no longer redeploys `freed.wtf` directly. The public
+> marketing site is controlled by the `www` branch and the `freed-ship-www`
+> workflow. After a dev or production release ships, `freed-ship-build`
+> should refresh the static marketing changelog from current `www` without
+> ever moving `www` to `dev`. See `RELEASE-SECRETS.md` for the full setup
+> checklist.
 
 ### Mobile
 

--- a/docs/PHASE-5-DESKTOP.md
+++ b/docs/PHASE-5-DESKTOP.md
@@ -336,12 +336,15 @@ export async function captureDomFeed(
 > and Freed Desktop can switch locally between production releases from `main`
 > and dev prereleases from `dev` without syncing that preference through the
 > shared document.
-> Release shipping no longer redeploys `freed.wtf` directly. The public
-> marketing site is controlled by the `www` branch and the `freed-ship-www`
-> workflow. After a dev or production release ships, `freed-ship-build`
-> should refresh the static marketing changelog from current `www` without
-> ever moving `www` to `dev`. See `RELEASE-SECRETS.md` for the full setup
-> checklist.
+> The public marketing site is controlled by the `www` branch. After the
+> GitHub release is published, the workflow now
+> redeploys `freed.wtf` from the `www` branch so the changelog snapshot
+> rebuilds against the newly published release instead of the earlier draft
+> state. Production desktop tags still come from `main`, but production
+> website deploys must first merge the reviewed website and changelog state to
+> `www`. Dev releases should still refresh the static marketing changelog from
+> current `www` without ever moving `www` to `dev`. See `RELEASE-SECRETS.md`
+> for the full setup checklist.
 
 ### Mobile
 

--- a/docs/RELEASE-SECRETS.md
+++ b/docs/RELEASE-SECRETS.md
@@ -59,14 +59,26 @@ Options:
 2. Click "New repository secret"
 3. Add each secret listed above
 
-## Automatic website + PWA deploys
+## Explicit marketing site deploys and automatic PWA deploys
 
-`VERCEL_TOKEN` is required if you want the release workflow to deploy
-`freed.wtf` and `app.freed.wtf` automatically after a production desktop
-release is published.
+`freed.wtf` is controlled by the long-lived `www` branch. Product releases from
+`dev` or `main` do not deploy the marketing site directly. Use
+`freed-ship-www` to publish current `www`, refresh the static changelog, or
+sync approved `main` changes into `www`.
 
-Without it, the release still completes and publishes on GitHub, but the
-workflow will skip the website and PWA deploy steps.
+`VERCEL_TOKEN` is required for GitHub Actions preview deploys and the automated
+PWA production deploy after a production desktop release.
+
+Without it, desktop releases still complete and publish on GitHub, but the PWA
+deploy step and GitHub Actions owned preview deploys are skipped.
+
+Marketing preview routing:
+
+- PRs targeting `www` build and deploy website previews
+- PRs targeting `dev` build and deploy PWA previews
+- Desktop Playwright E2E runs for product PRs targeting `dev`
+- Native Vercel preview deploys should stay disabled where GitHub Actions owns
+  preview deployment
 
 ## Drafting release notes
 
@@ -136,15 +148,15 @@ creates a **draft** GitHub Release using the approved checked-in release body.
 After all platform builds succeed, the workflow publishes that release
 automatically.
 
-If `VERCEL_TOKEN` is configured, production releases then:
-
-- redeploys `website/` so `freed.wtf/changelog` rebuilds its checked-in
-  snapshot against the published GitHub release
-- deploys `packages/pwa/` so the PWA version stays aligned with the shipped
-  desktop release
+If `VERCEL_TOKEN` is configured, production releases deploy `packages/pwa/` so
+the PWA version stays aligned with the shipped desktop release. The marketing
+site changelog is refreshed separately through `freed-ship-www`, which rebuilds
+the static website snapshot from current `www`.
 
 Dev releases are published as GitHub prereleases with a `-dev` suffix and do
-not trigger the production Vercel deploy steps.
+not trigger production PWA deploys. They should still be followed by
+`freed-ship-www` in changelog refresh mode so `freed.wtf/changelog/all` can
+include the dev release in the next static marketing build.
 
 The in-app updater will pick the new GitHub release up automatically.
 
@@ -161,3 +173,19 @@ To regenerate historical artifacts and rewrite older GitHub release bodies:
 ```bash
 node scripts/backfill-release-notes.mjs --rewrite-github
 ```
+
+## Cloudflare release index follow-up
+
+The Cloudflare R2 updater migration should also publish release metadata for
+the website changelog. When that lands, the website changelog generator should
+read Cloudflare release metadata at build time instead of GitHub Releases.
+
+Expected public objects:
+
+- `https://updates.freed.wtf/releases/index.json`
+- `https://updates.freed.wtf/releases/vX.Y.Z.json`
+- `https://updates.freed.wtf/releases/vX.Y.Z-dev.json`
+
+The index must include production releases and dev prereleases. The changelog
+must stay a checked-in static build snapshot so public website visitors never
+wait on release metadata fetches.

--- a/docs/RELEASE-SECRETS.md
+++ b/docs/RELEASE-SECRETS.md
@@ -77,8 +77,9 @@ Marketing preview routing:
 - PRs targeting `www` build and deploy website previews
 - PRs targeting `dev` build and deploy PWA previews
 - Desktop Playwright E2E runs for product PRs targeting `dev`
-- Native Vercel preview deploys should stay disabled where GitHub Actions owns
-  preview deployment
+- `website/vercel.json` only allows Git-triggered Vercel deploys from `www`
+- `packages/pwa/vercel.json` disables Git-triggered Vercel deploys entirely
+- GitHub Actions owns website and PWA previews through the deploy helpers
 
 ## Drafting release notes
 

--- a/docs/RELEASE-SECRETS.md
+++ b/docs/RELEASE-SECRETS.md
@@ -149,10 +149,18 @@ creates a **draft** GitHub Release using the approved checked-in release body.
 After all platform builds succeed, the workflow publishes that release
 automatically.
 
-If `VERCEL_TOKEN` is configured, production releases deploy `packages/pwa/` so
-the PWA version stays aligned with the shipped desktop release. The marketing
-site changelog is refreshed separately through `freed-ship-www`, which rebuilds
-the static website snapshot from current `www`.
+If `VERCEL_TOKEN` is configured, production releases then:
+
+- redeploys `website/` from the `www` branch so `freed.wtf/changelog`
+  rebuilds its checked-in snapshot against the published GitHub release
+- deploys `packages/pwa/` so the PWA version stays aligned with the shipped
+  desktop release
+
+Production desktop tags still come from `main`, but the marketing site does
+not. Before the website deploy runs, merge the reviewed website and changelog
+state to `www`. The release workflow now checks out `www` for the production
+website deploy and fails if that branch does not contain the tagged release
+artifact.
 
 Dev releases are published as GitHub prereleases with a `-dev` suffix and do
 not trigger production PWA deploys. They should still be followed by

--- a/packages/pwa/vercel.json
+++ b/packages/pwa/vercel.json
@@ -2,6 +2,9 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "vite",
   "buildCommand": "cd ../.. && npm run build -w @freed/pwa",
+  "git": {
+    "deploymentEnabled": false
+  },
   "outputDirectory": "dist",
   "rewrites": [{ "source": "/((?!api/).*)", "destination": "/index.html" }]
 }

--- a/scripts/vercel-deploy-preview.sh
+++ b/scripts/vercel-deploy-preview.sh
@@ -1,12 +1,20 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ $# -ne 1 ]]; then
-  echo "Usage: $0 website|pwa" >&2
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./lib/node-tooling.sh
+source "${SCRIPT_DIR}/lib/node-tooling.sh"
+use_resolved_node_path
+NPM_BIN="$(resolve_npm_bin)"
+NPX_BIN="$(resolve_npx_bin)"
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  echo "Usage: $0 website|pwa [vercel-token]" >&2
   exit 1
 fi
 
 TARGET="$1"
+VERCEL_TOKEN="${2:-${VERCEL_TOKEN:-}}"
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TEMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/freed-vercel-preview.XXXXXX")"
 
@@ -84,16 +92,24 @@ echo "Verifying preview bundle for $TARGET from $TEMP_DIR"
   fi
 )
 
+VERCEL_FLAGS=(--scope aubreyfs-projects)
+if [[ -n "$VERCEL_TOKEN" ]]; then
+  VERCEL_FLAGS+=(--token "$VERCEL_TOKEN")
+fi
+
 echo "Pulling Vercel settings for $TARGET"
-npx vercel pull --yes --environment preview --cwd "$TEMP_DIR" --scope aubreyfs-projects
+"$NPX_BIN" vercel pull --yes --environment preview --cwd "$TEMP_DIR" "${VERCEL_FLAGS[@]}"
 
 if [[ "$TARGET" == "website" ]]; then
-  echo "Deploying $TARGET preview with Vercel"
-  npx vercel deploy --cwd "$TEMP_DIR" --scope aubreyfs-projects -y
-else
   echo "Building $TARGET preview with Vercel"
-  npx vercel build --cwd "$TEMP_DIR" --local-config "$TEMP_DIR/vercel.json" --scope aubreyfs-projects
+  "$NPX_BIN" vercel build --cwd "$TEMP_DIR" "${VERCEL_FLAGS[@]}"
 
   echo "Deploying $TARGET preview with Vercel"
-  npx vercel deploy --prebuilt --cwd "$TEMP_DIR" --local-config "$TEMP_DIR/vercel.json" --scope aubreyfs-projects -y
+  "$NPX_BIN" vercel deploy --prebuilt --cwd "$TEMP_DIR" "${VERCEL_FLAGS[@]}" -y
+else
+  echo "Building $TARGET preview with Vercel"
+  "$NPX_BIN" vercel build --cwd "$TEMP_DIR" --local-config "$TEMP_DIR/vercel.json" "${VERCEL_FLAGS[@]}"
+
+  echo "Deploying $TARGET preview with Vercel"
+  "$NPX_BIN" vercel deploy --prebuilt --cwd "$TEMP_DIR" --local-config "$TEMP_DIR/vercel.json" "${VERCEL_FLAGS[@]}" -y
 fi

--- a/scripts/vercel-deploy-production.sh
+++ b/scripts/vercel-deploy-production.sh
@@ -104,8 +104,11 @@ echo "Pulling Vercel settings for $TARGET"
 npx vercel pull --yes --environment production --cwd "$TEMP_DIR" "${VERCEL_FLAGS[@]}"
 
 if [[ "$TARGET" == "website" ]]; then
+  echo "Building $TARGET production bundle with Vercel"
+  "$NPX_BIN" vercel build --cwd "$TEMP_DIR" "${VERCEL_FLAGS[@]}" --prod
+
   echo "Deploying $TARGET production build to Vercel"
-  npx vercel deploy --cwd "$TEMP_DIR" "${VERCEL_FLAGS[@]}" -y --prod
+  "$NPX_BIN" vercel deploy --prebuilt --cwd "$TEMP_DIR" "${VERCEL_FLAGS[@]}" -y --prod
 else
   echo "Building $TARGET production bundle with Vercel"
   npx vercel build --cwd "$TEMP_DIR" --local-config "$TEMP_DIR/vercel.json" "${VERCEL_FLAGS[@]}" --prod

--- a/website/package.json
+++ b/website/package.json
@@ -10,6 +10,8 @@
     "dev": "next dev --turbopack",
     "build": "npm run generate-changelog && next build && npm run generate-feed",
     "generate-changelog": "npx tsx scripts/generate-changelog.ts",
+    "test": "npm run test:changelog",
+    "test:changelog": "npx tsx src/content/changelog.test.ts",
     "start": "next start",
     "generate-feed": "npx tsx scripts/generate-feed.ts",
     "lint": "eslint ."

--- a/website/public/atom.xml
+++ b/website/public/atom.xml
@@ -2,7 +2,7 @@
 <feed xmlns="http://www.w3.org/2005/Atom">
     <id>https://freed.wtf</id>
     <title>Freed Blog</title>
-    <updated>2026-04-14T15:30:17.393Z</updated>
+    <updated>2026-04-18T04:24:37.816Z</updated>
     <generator>https://github.com/jpmonette/feed</generator>
     <author>
         <name>The Freed Team</name>

--- a/website/public/feed.xml
+++ b/website/public/feed.xml
@@ -4,7 +4,7 @@
         <title>Freed Blog</title>
         <link>https://freed.wtf</link>
         <description>Progress reports, technical deep-dives, and philosophical rants about the attention economy. From the team building Freed.</description>
-        <lastBuildDate>Tue, 14 Apr 2026 15:30:17 GMT</lastBuildDate>
+        <lastBuildDate>Sat, 18 Apr 2026 04:24:37 GMT</lastBuildDate>
         <docs>https://validator.w3.org/feed/docs/rss2.html</docs>
         <generator>https://github.com/jpmonette/feed</generator>
         <language>en</language>

--- a/website/scripts/generate-changelog.ts
+++ b/website/scripts/generate-changelog.ts
@@ -4,6 +4,8 @@ import {
   groupReleasesByDay,
   normalizeGitHubReleases,
   type ParsedRelease,
+  type ReleaseBuild,
+  type ReleaseChannel,
   type ReleaseItem,
 } from "../src/content/changelog";
 
@@ -109,7 +111,7 @@ function buildLinksFromArtifact(
   artifact: LocalReleaseArtifact,
   release: GitHubRelease,
   releaseMap: Map<string, GitHubRelease>,
-) {
+): ReleaseBuild[] {
   const relatedBuildTags = artifact.source?.relatedBuildTags ?? [];
   const buildLinks = relatedBuildTags
     .map((tag) => releaseMap.get(tag))
@@ -117,6 +119,7 @@ function buildLinksFromArtifact(
     .map((candidate) => ({
       version: candidate.tag_name.replace(/^v/, ""),
       htmlUrl: candidate.html_url,
+      channel: (candidate.tag_name.endsWith("-dev") ? "dev" : "production") as ReleaseChannel,
     }));
 
   if (buildLinks.length > 0) {
@@ -127,6 +130,7 @@ function buildLinksFromArtifact(
     {
       version: artifact.version || release.tag_name.replace(/^v/, ""),
       htmlUrl: release.html_url,
+      channel: (release.tag_name.endsWith("-dev") ? "dev" : "production") as ReleaseChannel,
     },
   ];
 }
@@ -137,6 +141,10 @@ function releaseFromLocalArtifact(
   releaseMap: Map<string, GitHubRelease>,
 ): ParsedRelease {
   const releaseShape = artifact.release ?? {};
+  const version = artifact.version || release.tag_name.replace(/^v/, "");
+  const channel: ReleaseChannel = release.tag_name.endsWith("-dev")
+    ? "dev"
+    : "production";
   const features = toReleaseItems(releaseShape.features ?? releaseShape.whatsNew);
   const fixes = toReleaseItems(releaseShape.fixes);
   const followUps = toReleaseItems([
@@ -146,8 +154,9 @@ function releaseFromLocalArtifact(
   const buildLinks = buildLinksFromArtifact(artifact, release, releaseMap);
 
   return {
-    version: artifact.version || release.tag_name.replace(/^v/, ""),
+    version,
     tagName: release.tag_name,
+    channel,
     date: release.published_at,
     deck: releaseShape.deck?.trim() || releaseShape.summary?.trim() || "",
     features,

--- a/website/src/app/changelog/ChangelogContent.tsx
+++ b/website/src/app/changelog/ChangelogContent.tsx
@@ -7,6 +7,8 @@ import type { CSSProperties, MouseEvent } from "react";
 import { useEffect, useMemo, useRef } from "react";
 import type { ParsedRelease } from "@/content/changelog";
 import { MarketingPageShell } from "@/components/MarketingPageShell";
+import type { ChangelogMode } from "./pagination";
+import { getChangelogPageHref } from "./pagination";
 
 const CHANGELOG_SMOOTH_SCROLL_KEY = "freed-changelog-smooth-scroll";
 
@@ -17,10 +19,6 @@ function formatDate(iso: string): string {
     month: "long",
     day: "numeric",
   });
-}
-
-function getPageHref(page: number): string {
-  return page <= 1 ? "/changelog" : `/changelog/${page.toString()}`;
 }
 
 function shouldAnimateChangelogHeader(pathname: string): boolean {
@@ -52,20 +50,20 @@ function shouldHandleSmoothPaginationClick(event: MouseEvent<HTMLAnchorElement>)
 
 function PaginationNav({
   currentPage,
+  mode,
   totalPages,
   className = "",
   smoothScrollOnNavigate = false,
 }: {
   currentPage: number;
+  mode: ChangelogMode;
   totalPages: number;
   className?: string;
   smoothScrollOnNavigate?: boolean;
 }) {
   const router = useRouter();
-
-  if (totalPages <= 1) {
-    return null;
-  }
+  const toggleHref = mode === "all" ? "/changelog" : "/changelog/all";
+  const toggleLabel = mode === "all" ? "Hide dev releases" : "Show dev releases";
 
   return (
     <nav
@@ -73,6 +71,30 @@ function PaginationNav({
       className={`text-sm text-text-muted ${className}`.trim()}
     >
       <div className="flex flex-wrap items-center justify-center gap-x-0.5 gap-y-2">
+        <Link
+          href={toggleHref}
+          scroll={!smoothScrollOnNavigate}
+          className="rounded-md px-1.5 py-1 text-text-secondary transition-colors hover:text-text-primary"
+          onClick={(event) => {
+            if (!smoothScrollOnNavigate) {
+              return;
+            }
+
+            if (!shouldHandleSmoothPaginationClick(event)) {
+              return;
+            }
+
+            event.preventDefault();
+
+            try {
+              sessionStorage.setItem(CHANGELOG_SMOOTH_SCROLL_KEY, toggleHref);
+            } catch {}
+
+            router.push(toggleHref, { scroll: false });
+          }}
+        >
+          {toggleLabel}
+        </Link>
         {Array.from({ length: totalPages }, (_, index) => {
           const page = index + 1;
           const isCurrent = page === currentPage;
@@ -93,7 +115,7 @@ function PaginationNav({
                 </span>
               ) : (
                 <Link
-                  href={getPageHref(page)}
+                  href={getChangelogPageHref(page, mode)}
                   scroll={!smoothScrollOnNavigate}
                   className="rounded-md px-1.5 py-1 transition-colors hover:text-text-primary"
                   onClick={(event) => {
@@ -110,11 +132,13 @@ function PaginationNav({
                     try {
                       sessionStorage.setItem(
                         CHANGELOG_SMOOTH_SCROLL_KEY,
-                        getPageHref(page)
+                        getChangelogPageHref(page, mode)
                       );
                     } catch {}
 
-                    router.push(getPageHref(page), { scroll: false });
+                    router.push(getChangelogPageHref(page, mode), {
+                      scroll: false,
+                    });
                   }}
                 >
                   {label}
@@ -278,6 +302,19 @@ function ReleaseCard({
                   Latest
                 </span>
               )}
+              {release.channel === "dev" && (
+                <span
+                  className="px-2.5 py-0.5 rounded-full border text-xs font-semibold text-text-secondary"
+                  style={{
+                    background:
+                      "color-mix(in srgb, var(--theme-text-muted) 12%, transparent)",
+                    borderColor:
+                      "color-mix(in srgb, var(--theme-text-muted) 24%, transparent)",
+                  }}
+                >
+                  Dev
+                </span>
+              )}
               <time className="ml-auto text-sm text-text-muted transition-colors duration-300">
                 {formatDate(release.date)}
               </time>
@@ -324,9 +361,14 @@ function ReleaseCard({
                     href={build.htmlUrl}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="pointer-events-auto text-xs text-text-muted transition-colors hover:text-text-primary"
+                    className="pointer-events-auto inline-flex items-center gap-1 text-xs text-text-muted transition-colors hover:text-text-primary"
                   >
-                    v{build.version}
+                    <span>v{build.version}</span>
+                    {build.channel === "dev" && (
+                      <span className="rounded-full border border-freed-border px-1 text-[10px] uppercase">
+                        Dev
+                      </span>
+                    )}
                   </a>
                 ))}
               </div>
@@ -407,11 +449,13 @@ function Section({
 export default function ChangelogContent({
   releases,
   currentPage,
+  mode,
   totalPages,
   pageRange,
 }: {
   releases: ParsedRelease[];
   currentPage: number;
+  mode: ChangelogMode;
   totalPages: number;
   pageRange: { start: number; end: number; total: number };
 }) {
@@ -464,6 +508,7 @@ export default function ChangelogContent({
 
         <PaginationNav
           currentPage={currentPage}
+          mode={mode}
           totalPages={totalPages}
           className="mb-6"
           smoothScrollOnNavigate
@@ -487,6 +532,7 @@ export default function ChangelogContent({
 
         <PaginationNav
           currentPage={currentPage}
+          mode={mode}
           totalPages={totalPages}
           className="mt-8"
           smoothScrollOnNavigate

--- a/website/src/app/changelog/all/[page]/page.tsx
+++ b/website/src/app/changelog/all/[page]/page.tsx
@@ -1,35 +1,36 @@
 import type { Metadata } from "next";
-import ChangelogContent from "../ChangelogContent";
+import ChangelogContent from "../../ChangelogContent";
 import {
   buildChangelogMetadata,
   getChangelogPageRange,
-  getChangelogPageSlice,
+  getChangelogPageSliceForMode,
   getChangelogPaginationStaticParams,
   getChangelogTotalPages,
   parseChangelogPage,
-} from "../pagination";
+} from "../../pagination";
 
 interface Props {
   params: Promise<{ page: string }>;
 }
 
+const mode = "all";
+
 export function generateStaticParams(): Array<{ page: string }> {
-  return getChangelogPaginationStaticParams("production");
+  return getChangelogPaginationStaticParams(mode);
 }
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { page } = await params;
-  return buildChangelogMetadata(parseChangelogPage(page, "production"));
+  return buildChangelogMetadata(parseChangelogPage(page, mode), mode);
 }
 
-export default async function ChangelogPaginationPage({ params }: Props) {
+export default async function AllChangelogPaginationPage({ params }: Props) {
   const { page } = await params;
-  const mode = "production";
   const currentPage = parseChangelogPage(page, mode);
 
   return (
     <ChangelogContent
-      releases={getChangelogPageSlice(currentPage)}
+      releases={getChangelogPageSliceForMode(currentPage, mode)}
       currentPage={currentPage}
       mode={mode}
       totalPages={getChangelogTotalPages(mode)}

--- a/website/src/app/changelog/all/page.tsx
+++ b/website/src/app/changelog/all/page.tsx
@@ -1,21 +1,22 @@
 import type { Metadata } from "next";
-import ChangelogContent from "./ChangelogContent";
+import ChangelogContent from "../ChangelogContent";
 import {
   buildChangelogMetadata,
   getChangelogPageRange,
-  getChangelogPageSlice,
+  getChangelogPageSliceForMode,
   getChangelogTotalPages,
-} from "./pagination";
+} from "../pagination";
 
-export const metadata: Metadata = buildChangelogMetadata(1);
+const mode = "all";
 
-export default function ChangelogPage() {
+export const metadata: Metadata = buildChangelogMetadata(1, mode);
+
+export default function AllChangelogPage() {
   const currentPage = 1;
-  const mode = "production";
 
   return (
     <ChangelogContent
-      releases={getChangelogPageSlice(currentPage)}
+      releases={getChangelogPageSliceForMode(currentPage, mode)}
       currentPage={currentPage}
       mode={mode}
       totalPages={getChangelogTotalPages(mode)}

--- a/website/src/app/changelog/pagination.ts
+++ b/website/src/app/changelog/pagination.ts
@@ -4,22 +4,40 @@ import changelogReleases from "@/content/changelog.generated.json";
 import type { ParsedRelease } from "@/content/changelog";
 
 export const CHANGELOG_PAGE_SIZE = 5;
+export type ChangelogMode = "production" | "all";
 
 const allReleases = changelogReleases as ParsedRelease[];
 
-export function getAllChangelogReleases(): ParsedRelease[] {
-  return allReleases;
+function releasesForMode(mode: ChangelogMode): ParsedRelease[] {
+  if (mode === "all") {
+    return allReleases;
+  }
+
+  return allReleases.filter((release) => release.channel !== "dev");
 }
 
-export function getChangelogTotalPages(): number {
-  return Math.max(1, Math.ceil(allReleases.length / CHANGELOG_PAGE_SIZE));
+export function getChangelogTotalPages(
+  mode: ChangelogMode = "production",
+): number {
+  return Math.max(
+    1,
+    Math.ceil(releasesForMode(mode).length / CHANGELOG_PAGE_SIZE),
+  );
 }
 
-export function getChangelogPageHref(page: number): string {
-  return page <= 1 ? "/changelog" : `/changelog/${page.toString()}`;
+export function getChangelogPageHref(
+  page: number,
+  mode: ChangelogMode = "production",
+): string {
+  const basePath = mode === "all" ? "/changelog/all" : "/changelog";
+  const pathPage = page.toLocaleString("en-US", { useGrouping: false });
+  return page <= 1 ? basePath : `${basePath}/${pathPage}`;
 }
 
-export function parseChangelogPage(value: string | number | undefined): number {
+export function parseChangelogPage(
+  value: string | number | undefined,
+  mode: ChangelogMode = "production",
+): number {
   const parsed =
     typeof value === "number" ? value : Number.parseInt(value ?? "1", 10);
 
@@ -27,7 +45,7 @@ export function parseChangelogPage(value: string | number | undefined): number {
     notFound();
   }
 
-  const totalPages = getChangelogTotalPages();
+  const totalPages = getChangelogTotalPages(mode);
 
   if (parsed > totalPages) {
     notFound();
@@ -37,16 +55,26 @@ export function parseChangelogPage(value: string | number | undefined): number {
 }
 
 export function getChangelogPageSlice(page: number): ParsedRelease[] {
-  const start = (page - 1) * CHANGELOG_PAGE_SIZE;
-  return allReleases.slice(start, start + CHANGELOG_PAGE_SIZE);
+  return getChangelogPageSliceForMode(page, "production");
 }
 
-export function getChangelogPageRange(page: number): {
+export function getChangelogPageSliceForMode(
+  page: number,
+  mode: ChangelogMode = "production",
+): ParsedRelease[] {
+  const start = (page - 1) * CHANGELOG_PAGE_SIZE;
+  return releasesForMode(mode).slice(start, start + CHANGELOG_PAGE_SIZE);
+}
+
+export function getChangelogPageRange(
+  page: number,
+  mode: ChangelogMode = "production",
+): {
   start: number;
   end: number;
   total: number;
 } {
-  const total = allReleases.length;
+  const total = releasesForMode(mode).length;
   if (total === 0) {
     return { start: 0, end: 0, total };
   }
@@ -57,11 +85,15 @@ export function getChangelogPageRange(page: number): {
   return { start, end, total };
 }
 
-export function buildChangelogMetadata(page: number): Metadata {
+export function buildChangelogMetadata(
+  page: number,
+  mode: ChangelogMode = "production",
+): Metadata {
   const pageSuffix = page > 1 ? `, page ${page.toLocaleString()}` : "";
   const title = `Log | Freed`;
-  const description = `Every release, every fix, every new feature${pageSuffix}. The full build history of Freed Desktop.`;
-  const path = getChangelogPageHref(page);
+  const modeSuffix = mode === "all" ? " including dev builds" : "";
+  const description = `Every release, every fix, every new feature${modeSuffix}${pageSuffix}. The full build history of Freed Desktop.`;
+  const path = getChangelogPageHref(page, mode);
 
   return {
     title,
@@ -77,10 +109,12 @@ export function buildChangelogMetadata(page: number): Metadata {
   };
 }
 
-export function getChangelogPaginationStaticParams(): Array<{ page: string }> {
-  const totalPages = getChangelogTotalPages();
+export function getChangelogPaginationStaticParams(
+  mode: ChangelogMode = "production",
+): Array<{ page: string }> {
+  const totalPages = getChangelogTotalPages(mode);
 
   return Array.from({ length: Math.max(0, totalPages - 1) }, (_, index) => ({
-    page: (index + 2).toString(),
+    page: (index + 2).toLocaleString("en-US", { useGrouping: false }),
   }));
 }

--- a/website/src/app/sitemap.ts
+++ b/website/src/app/sitemap.ts
@@ -1,6 +1,10 @@
 import type { MetadataRoute } from "next";
 import { posts } from "@/content";
-import { getChangelogTotalPages } from "./changelog/pagination";
+import {
+  getChangelogPageHref,
+  getChangelogTotalPages,
+  type ChangelogMode,
+} from "./changelog/pagination";
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const baseUrl = "https://freed.wtf";
@@ -53,15 +57,33 @@ export default function sitemap(): MetadataRoute.Sitemap {
     priority: 0.7,
   }));
 
-  const changelogPages: MetadataRoute.Sitemap = Array.from(
-    { length: Math.max(0, getChangelogTotalPages() - 1) },
-    (_, index) => ({
-      url: `${baseUrl}/changelog/${(index + 2).toString()}`,
+  const changelogPagesForMode = (
+    mode: ChangelogMode,
+  ): MetadataRoute.Sitemap =>
+    Array.from(
+      { length: Math.max(0, getChangelogTotalPages(mode) - 1) },
+      (_, index) => ({
+        url: `${baseUrl}${getChangelogPageHref(index + 2, mode)}`,
+        lastModified: new Date(),
+        changeFrequency: "weekly" as const,
+        priority: 0.7,
+      }),
+    );
+
+  const allChangelogPage: MetadataRoute.Sitemap = [
+    {
+      url: `${baseUrl}/changelog/all`,
       lastModified: new Date(),
       changeFrequency: "weekly" as const,
       priority: 0.7,
-    }),
-  );
+    },
+  ];
 
-  return [...staticPages, ...blogPosts, ...changelogPages];
+  return [
+    ...staticPages,
+    ...blogPosts,
+    ...changelogPagesForMode("production"),
+    ...allChangelogPage,
+    ...changelogPagesForMode("all"),
+  ];
 }

--- a/website/src/content/changelog.generated.json
+++ b/website/src/content/changelog.generated.json
@@ -2,6 +2,7 @@
   {
     "version": "26.4.1602",
     "tagName": "v26.4.1602",
+    "channel": "production",
     "date": "2026-04-17T02:06:16Z",
     "deck": "Freed Desktop keeps update dialogs visible, restores read state correctly, and trims sync memory growth on large saves",
     "features": [],
@@ -37,21 +38,160 @@
     "buildLinks": [
       {
         "version": "26.4.1600",
-        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1600"
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1600",
+        "channel": "production"
       },
       {
         "version": "26.4.1601-dev",
-        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1601-dev"
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1601-dev",
+        "channel": "dev"
       },
       {
         "version": "26.4.1602",
-        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1602"
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1602",
+        "channel": "production"
+      }
+    ]
+  },
+  {
+    "version": "26.4.1601-dev",
+    "tagName": "v26.4.1601-dev",
+    "channel": "dev",
+    "date": "2026-04-17T00:12:58Z",
+    "deck": "Map tiles are back, and desktop sync carries less preserved article text",
+    "features": [],
+    "fixes": [
+      {
+        "text": "Map view background tiles render again across the refreshed style palette"
+      },
+      {
+        "text": "Desktop sync now trims preserved article text before it reaches Automerge, which reduces sync memory growth on large saves"
+      }
+    ],
+    "followUps": [],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1601-dev",
+    "prNumbers": [],
+    "builds": [
+      "26.4.1601-dev"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.4.1601-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1601-dev",
+        "channel": "dev"
+      }
+    ]
+  },
+  {
+    "version": "26.4.1501-dev",
+    "tagName": "v26.4.1501-dev",
+    "channel": "dev",
+    "date": "2026-04-15T20:29:20Z",
+    "deck": "Explicit website release flow and stability fixes for recovery and UI checks",
+    "features": [
+      {
+        "text": "Explicit website release flow"
+      }
+    ],
+    "fixes": [
+      {
+        "text": "Crash reports now keep cleaner diagnostic state"
+      },
+      {
+        "text": "Map popup smoke tests and reader rail alignment checks are steadier"
+      },
+      {
+        "text": "Crash reporting and WebKit recovery are now more stable"
+      }
+    ],
+    "followUps": [],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1501-dev",
+    "prNumbers": [],
+    "builds": [
+      "26.4.1500-dev",
+      "26.4.1501-dev"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.4.1500-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1500-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.4.1501-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1501-dev",
+        "channel": "dev"
+      }
+    ]
+  },
+  {
+    "version": "26.4.1403-dev",
+    "tagName": "v26.4.1403-dev",
+    "channel": "dev",
+    "date": "2026-04-15T06:04:17Z",
+    "deck": "Theme-native map palettes, contacts settings and sync, and rotating desktop snapshots",
+    "features": [
+      {
+        "text": "Theme-native map palettes"
+      },
+      {
+        "text": "Finish Google Contacts settings and sync"
+      },
+      {
+        "text": "Rotating desktop snapshots"
+      }
+    ],
+    "fixes": [
+      {
+        "text": "Reader, feed, and header polish"
+      },
+      {
+        "text": "Release build and type-safety cleanup"
+      },
+      {
+        "text": "Copy and documentation cleanup"
+      },
+      {
+        "text": "Capture and scraper reliability fixes"
+      }
+    ],
+    "followUps": [
+      {
+        "text": "Reader, sidebar, and settings UX work"
+      },
+      {
+        "text": "Release workflow and build-system work"
+      },
+      {
+        "text": "Capture, login, and scraping platform work"
+      },
+      {
+        "text": "Sync, cloud, and pairing infrastructure"
+      },
+      {
+        "text": "Testing, diagnostics, and developer tooling"
+      },
+      {
+        "text": "Content and documentation work"
+      }
+    ],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1403-dev",
+    "prNumbers": [],
+    "builds": [
+      "26.4.1403-dev"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.4.1403-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1403-dev",
+        "channel": "dev"
       }
     ]
   },
   {
     "version": "26.4.1400",
     "tagName": "v26.4.1400",
+    "channel": "production",
     "date": "2026-04-14T23:13:01Z",
     "deck": "Theme-native map palettes, dev release channels and branch flow, and label macOS Activity Monitor web process as Freed",
     "features": [
@@ -78,13 +218,15 @@
     "buildLinks": [
       {
         "version": "26.4.1400",
-        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1400"
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1400",
+        "channel": "production"
       }
     ]
   },
   {
     "version": "26.4.1300",
     "tagName": "v26.4.1300",
+    "channel": "production",
     "date": "2026-04-14T05:17:28Z",
     "deck": "Desktop shell chrome is unified across the app, with theme-native maps, clearer recovery handoffs, and steadier reading surfaces.",
     "features": [
@@ -121,13 +263,15 @@
     "buildLinks": [
       {
         "version": "26.4.1300",
-        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1300"
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1300",
+        "channel": "production"
       }
     ]
   },
   {
     "version": "26.4.1203",
     "tagName": "v26.4.1203",
+    "channel": "production",
     "date": "2026-04-13T02:44:48Z",
     "deck": "Unify themes across website and app, refreshed theme system and typography polish, and privacy policy callout border removed",
     "features": [
@@ -191,21 +335,25 @@
     "buildLinks": [
       {
         "version": "26.4.1200",
-        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1200"
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1200",
+        "channel": "production"
       },
       {
         "version": "26.4.1201",
-        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1201"
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1201",
+        "channel": "production"
       },
       {
         "version": "26.4.1203",
-        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1203"
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1203",
+        "channel": "production"
       }
     ]
   },
   {
     "version": "26.4.1100",
     "tagName": "v26.4.1100",
+    "channel": "production",
     "date": "2026-04-12T06:06:18Z",
     "deck": "Contacts settings and sync, rotating desktop snapshots, and unify theming across website and app",
     "features": [
@@ -287,13 +435,15 @@
     "buildLinks": [
       {
         "version": "26.4.1100",
-        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1100"
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1100",
+        "channel": "production"
       }
     ]
   },
   {
     "version": "26.4.900",
     "tagName": "v26.4.900",
+    "channel": "production",
     "date": "2026-04-10T04:38:56Z",
     "deck": "Provider health diagnostics and quieter background scrapers",
     "features": [
@@ -326,13 +476,15 @@
     "buildLinks": [
       {
         "version": "26.4.900",
-        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.900"
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.900",
+        "channel": "production"
       }
     ]
   },
   {
     "version": "26.4.301",
     "tagName": "v26.4.301",
+    "channel": "production",
     "date": "2026-04-03T21:30:37Z",
     "deck": "Website changelog catches same-day releases",
     "features": [],
@@ -368,17 +520,20 @@
     "buildLinks": [
       {
         "version": "26.4.300",
-        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.300"
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.300",
+        "channel": "production"
       },
       {
         "version": "26.4.301",
-        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.301"
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.301",
+        "channel": "production"
       }
     ]
   },
   {
     "version": "26.4.109",
     "tagName": "v26.4.109",
+    "channel": "production",
     "date": "2026-04-02T02:49:52Z",
     "deck": "Map view, refined consent gates, and signed macOS installs",
     "features": [
@@ -455,41 +610,50 @@
     "buildLinks": [
       {
         "version": "26.4.100",
-        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.100"
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.100",
+        "channel": "production"
       },
       {
         "version": "26.4.101",
-        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.101"
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.101",
+        "channel": "production"
       },
       {
         "version": "26.4.102",
-        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.102"
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.102",
+        "channel": "production"
       },
       {
         "version": "26.4.103",
-        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.103"
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.103",
+        "channel": "production"
       },
       {
         "version": "26.4.105",
-        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.105"
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.105",
+        "channel": "production"
       },
       {
         "version": "26.4.107",
-        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.107"
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.107",
+        "channel": "production"
       },
       {
         "version": "26.4.108",
-        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.108"
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.108",
+        "channel": "production"
       },
       {
         "version": "26.4.109",
-        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.109"
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.109",
+        "channel": "production"
       }
     ]
   },
   {
     "version": "26.3.3100",
     "tagName": "v26.3.3100",
+    "channel": "production",
     "date": "2026-04-01T05:12:01Z",
     "deck": "QR landing page and refined consent gates",
     "features": [
@@ -513,13 +677,15 @@
     "buildLinks": [
       {
         "version": "26.3.3100",
-        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.3100"
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.3100",
+        "channel": "production"
       }
     ]
   },
   {
     "version": "26.3.2402",
     "tagName": "v26.3.2402",
+    "channel": "production",
     "date": "2026-03-25T04:11:35Z",
     "deck": "Friends view and contacts sync, LinkedIn capture, and feed card and reader actions",
     "features": [
@@ -559,17 +725,20 @@
     "buildLinks": [
       {
         "version": "26.3.2400",
-        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.2400"
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.2400",
+        "channel": "production"
       },
       {
         "version": "26.3.2402",
-        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.2402"
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.2402",
+        "channel": "production"
       }
     ]
   },
   {
     "version": "26.3.1300",
     "tagName": "v26.3.1300",
+    "channel": "production",
     "date": "2026-03-13T14:44:55Z",
     "deck": "Instagram and Facebook story scraping interleaved with feed scrolling",
     "features": [
@@ -589,13 +758,15 @@
     "buildLinks": [
       {
         "version": "26.3.1300",
-        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.1300"
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.1300",
+        "channel": "production"
       }
     ]
   },
   {
     "version": "26.3.1200",
     "tagName": "v26.3.1200",
+    "channel": "production",
     "date": "2026-03-13T03:50:50Z",
     "deck": "Daily changelog grouping and fB/IG scraper windows instead of moving them off-screen now stays out of the way",
     "features": [
@@ -616,13 +787,15 @@
     "buildLinks": [
       {
         "version": "26.3.1200",
-        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.1200"
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.1200",
+        "channel": "production"
       }
     ]
   },
   {
     "version": "26.3.1101",
     "tagName": "v26.3.1101",
+    "channel": "production",
     "date": "2026-03-11T20:13:18Z",
     "deck": "File logging and freeze guards",
     "features": [
@@ -648,17 +821,20 @@
     "buildLinks": [
       {
         "version": "26.3.1100",
-        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.1100"
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.1100",
+        "channel": "production"
       },
       {
         "version": "26.3.1101",
-        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.1101"
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.1101",
+        "channel": "production"
       }
     ]
   },
   {
     "version": "26.3.1002",
     "tagName": "v26.3.1002",
+    "channel": "production",
     "date": "2026-03-11T06:10:34Z",
     "deck": "Dual column reader view, capture hardening, and platform-specific install cautions",
     "features": [
@@ -842,21 +1018,25 @@
     "buildLinks": [
       {
         "version": "26.3.1000",
-        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.1000"
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.1000",
+        "channel": "production"
       },
       {
         "version": "26.3.1001",
-        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.1001"
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.1001",
+        "channel": "production"
       },
       {
         "version": "26.3.1002",
-        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.1002"
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.1002",
+        "channel": "production"
       }
     ]
   },
   {
     "version": "26.3.904",
     "tagName": "v26.3.904",
+    "channel": "production",
     "date": "2026-03-10T01:01:55Z",
     "deck": "Changelog page, remove frosted glass, fix update banner, unused user-agent import from fb-capture.ts, and capture-x build step from release CI",
     "features": [
@@ -898,17 +1078,20 @@
     "buildLinks": [
       {
         "version": "26.3.903",
-        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.903"
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.903",
+        "channel": "production"
       },
       {
         "version": "26.3.904",
-        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.904"
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.904",
+        "channel": "production"
       }
     ]
   },
   {
     "version": "26.3.804",
     "tagName": "v26.3.804",
+    "channel": "production",
     "date": "2026-03-09T03:27:30Z",
     "deck": "Sidebar purple dots, dev auto-seed, and social sample data and social engagement via outbox pattern (like, seen-sync, comment links)",
     "features": [
@@ -929,13 +1112,15 @@
     "buildLinks": [
       {
         "version": "26.3.804",
-        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.804"
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.804",
+        "channel": "production"
       }
     ]
   },
   {
     "version": "26.3.703",
     "tagName": "v26.3.703",
+    "channel": "production",
     "date": "2026-03-08T05:30:11Z",
     "deck": "Playwright e2e smoke test infrastructure for desktop, dual-column split view, and uI polish bundle - tooltips, hover states, scroll reset, save fix, sidebar counts",
     "features": [
@@ -988,17 +1173,20 @@
     "buildLinks": [
       {
         "version": "26.3.702",
-        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.702"
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.702",
+        "channel": "production"
       },
       {
         "version": "26.3.703",
-        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.703"
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.703",
+        "channel": "production"
       }
     ]
   },
   {
     "version": "26.3.601",
     "tagName": "v26.3.601",
+    "channel": "production",
     "date": "2026-03-06T22:40:26Z",
     "deck": "Fix focus mode showing raw HTML brackets from RSS feed descriptions and double-cast window through unknown to satisfy strict TS in mock files",
     "features": [],
@@ -1012,13 +1200,15 @@
     "buildLinks": [
       {
         "version": "26.3.601",
-        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.601"
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.601",
+        "channel": "production"
       }
     ]
   },
   {
     "version": "26.3.504",
     "tagName": "v26.3.504",
+    "channel": "production",
     "date": "2026-03-05T18:19:48Z",
     "deck": "Complete X/Twitter integration end-to-end, build out the archive system end-to-end, and universal full-text search across all sources",
     "features": [
@@ -1161,21 +1351,25 @@
     "buildLinks": [
       {
         "version": "26.3.502",
-        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.502"
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.502",
+        "channel": "production"
       },
       {
         "version": "26.3.503",
-        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.503"
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.503",
+        "channel": "production"
       },
       {
         "version": "26.3.504",
-        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.504"
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.504",
+        "channel": "production"
       }
     ]
   },
   {
     "version": "26.3.303",
     "tagName": "v26.3.303",
+    "channel": "production",
     "date": "2026-03-04T00:57:10Z",
     "deck": "Privacy policy page, heal untitled feed titles from live XML on sync, and syncConnectDialog UX",
     "features": [
@@ -1229,21 +1423,25 @@
     "buildLinks": [
       {
         "version": "26.3.300",
-        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.300"
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.300",
+        "channel": "production"
       },
       {
         "version": "26.3.302",
-        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.302"
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.302",
+        "channel": "production"
       },
       {
         "version": "26.3.303",
-        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.303"
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.303",
+        "channel": "production"
       }
     ]
   },
   {
     "version": "26.3.200",
     "tagName": "v26.3.200",
+    "channel": "production",
     "date": "2026-03-03T15:54:05Z",
     "deck": "Sync section explains user-owned cloud storage + passphrase encryption and mDNS discovery, cloud file sync + desktop cloud sync",
     "features": [
@@ -1264,13 +1462,15 @@
     "buildLinks": [
       {
         "version": "26.3.200",
-        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.200"
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.200",
+        "channel": "production"
       }
     ]
   },
   {
     "version": "26.3.104",
     "tagName": "v26.3.104",
+    "channel": "production",
     "date": "2026-03-02T05:30:02Z",
     "deck": "Per-feed context menu with sync status, rename, and unsubscribe, system, CalVer DDBUILD, UI polish, and fix tab strip alignment in AddFeedDialog",
     "features": [
@@ -1375,29 +1575,35 @@
     "buildLinks": [
       {
         "version": "26.3.100",
-        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.100"
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.100",
+        "channel": "production"
       },
       {
         "version": "26.3.101",
-        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.101"
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.101",
+        "channel": "production"
       },
       {
         "version": "26.3.102",
-        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.102"
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.102",
+        "channel": "production"
       },
       {
         "version": "26.3.103",
-        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.103"
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.103",
+        "channel": "production"
       },
       {
         "version": "26.3.104",
-        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.104"
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.104",
+        "channel": "production"
       }
     ]
   },
   {
     "version": "0.2.0",
     "tagName": "v0.2.0",
+    "channel": "production",
     "date": "2026-03-02T01:16:53Z",
     "deck": "@freed/capture-facebook and @freed/capture-instagram packages, sync, cloud, and pairing infrastructure, and content and documentation work",
     "features": [
@@ -1447,7 +1653,8 @@
     "buildLinks": [
       {
         "version": "0.2.0",
-        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v0.2.0"
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v0.2.0",
+        "channel": "production"
       }
     ]
   }

--- a/website/src/content/changelog.test.ts
+++ b/website/src/content/changelog.test.ts
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  groupReleasesByDay,
+  normalizeGitHubReleases,
+  versionDayKey,
+  type ParsedRelease,
+} from "./changelog";
+
+const release = (
+  tagName: string,
+  prerelease: boolean,
+  publishedAt: string,
+): {
+  tag_name: string;
+  body: string;
+  published_at: string;
+  html_url: string;
+  draft: boolean;
+  prerelease: boolean;
+} => ({
+  tag_name: tagName,
+  body: "## Freed\n\nRelease deck.\n\n### Features\n- Visible release item\n",
+  published_at: publishedAt,
+  html_url: `https://example.com/${tagName}`,
+  draft: false,
+  prerelease,
+});
+
+test("normalizes production and dev releases with channel metadata", () => {
+  const releases = normalizeGitHubReleases([
+    release("v26.4.1500-dev", true, "2026-04-15T19:00:00Z"),
+    release("v26.4.1400", false, "2026-04-14T19:00:00Z"),
+  ]);
+
+  assert.deepEqual(
+    releases.map((item) => [item.version, item.channel]),
+    [
+      ["26.4.1500-dev", "dev"],
+      ["26.4.1400", "production"],
+    ],
+  );
+  assert.equal(releases[0].buildLinks[0].channel, "dev");
+});
+
+test("excludes drafts and mismatched prerelease metadata", () => {
+  const draft = release("v26.4.1500", false, "2026-04-15T19:00:00Z");
+  draft.draft = true;
+
+  const releases = normalizeGitHubReleases([
+    draft,
+    release("v26.4.1501-dev", false, "2026-04-15T20:00:00Z"),
+    release("v26.4.1502", true, "2026-04-15T21:00:00Z"),
+    release("v26.4.1503", false, "2026-04-15T22:00:00Z"),
+  ]);
+
+  assert.deepEqual(
+    releases.map((item) => item.tagName),
+    ["v26.4.1503"],
+  );
+});
+
+test("uses the base version when deriving dev release day keys", () => {
+  assert.equal(versionDayKey("26.4.1500-dev"), "26.4.15");
+});
+
+test("groups same-day production and dev releases separately", () => {
+  const releases = normalizeGitHubReleases([
+    release("v26.4.1501-dev", true, "2026-04-15T21:00:00Z"),
+    release("v26.4.1500", false, "2026-04-15T20:00:00Z"),
+    release("v26.4.1502", false, "2026-04-15T22:00:00Z"),
+  ]);
+  const grouped = groupReleasesByDay(releases);
+
+  assert.deepEqual(
+    grouped.map((item: ParsedRelease) => [item.version, item.channel]),
+    [
+      ["26.4.1502", "production"],
+      ["26.4.1501-dev", "dev"],
+    ],
+  );
+  assert.deepEqual(grouped[0].builds, ["26.4.1500", "26.4.1502"]);
+});

--- a/website/src/content/changelog.ts
+++ b/website/src/content/changelog.ts
@@ -3,14 +3,18 @@ export interface ReleaseItem {
   prNumber?: number;
 }
 
+export type ReleaseChannel = "production" | "dev";
+
 export interface ReleaseBuild {
   version: string;
   htmlUrl: string;
+  channel: ReleaseChannel;
 }
 
 export interface ParsedRelease {
   version: string;
   tagName: string;
+  channel: ReleaseChannel;
   date: string;
   deck?: string;
   features: ReleaseItem[];
@@ -29,6 +33,28 @@ interface GitHubRelease {
   html_url: string;
   draft: boolean;
   prerelease: boolean;
+}
+
+function stripReleaseChannelSuffix(version: string): string {
+  return version.replace(/-dev$/, "");
+}
+
+function releaseChannelForTag(tagName: string): ReleaseChannel | null {
+  return tagName.endsWith("-dev") ? "dev" : "production";
+}
+
+function shouldIncludeRelease(release: GitHubRelease): boolean {
+  if (release.draft) {
+    return false;
+  }
+
+  const channel = releaseChannelForTag(release.tag_name);
+
+  if (channel === "dev") {
+    return release.prerelease;
+  }
+
+  return !release.prerelease;
 }
 
 function normalizeReleaseText(text: string): string {
@@ -230,15 +256,23 @@ export function normalizeGitHubReleases(
   releases: GitHubRelease[],
 ): ParsedRelease[] {
   return releases
-    .filter((release) => !release.draft && !release.prerelease)
+    .filter(shouldIncludeRelease)
+    .sort((left, right) => {
+      const leftDate = Date.parse(left.published_at);
+      const rightDate = Date.parse(right.published_at);
+      return rightDate - leftDate;
+    })
     .map((release) => {
       const { deck, features, fixes, followUps, prNumbers } = parseReleaseBody(
         release.body ?? "",
       );
+      const channel = releaseChannelForTag(release.tag_name) ?? "production";
+      const version = release.tag_name.replace(/^v/, "");
 
       return {
-        version: release.tag_name.replace(/^v/, ""),
+        version,
         tagName: release.tag_name,
+        channel,
         date: release.published_at,
         deck,
         features,
@@ -246,11 +280,12 @@ export function normalizeGitHubReleases(
         followUps,
         htmlUrl: release.html_url,
         prNumbers,
-        builds: [release.tag_name.replace(/^v/, "")],
+        builds: [version],
         buildLinks: [
           {
-            version: release.tag_name.replace(/^v/, ""),
+            version,
             htmlUrl: release.html_url,
+            channel,
           },
         ],
       };
@@ -293,7 +328,7 @@ function dedupeBuildLinks(buildLinks: ReleaseBuild[]): ReleaseBuild[] {
 }
 
 export function versionDayKey(version: string): string {
-  const parts = version.split(".");
+  const parts = stripReleaseChannelSuffix(version).split(".");
   if (parts.length !== 3) {
     return version;
   }
@@ -307,7 +342,7 @@ export function groupReleasesByDay(releases: ParsedRelease[]): ParsedRelease[] {
   const byDay = new Map<string, ParsedRelease[]>();
 
   for (const release of releases) {
-    const day = versionDayKey(release.version);
+    const day = `${versionDayKey(release.version)}:${release.channel}`;
     const group = byDay.get(day) ?? [];
     group.push(release);
     byDay.set(day, group);
@@ -324,6 +359,7 @@ export function groupReleasesByDay(releases: ParsedRelease[]): ParsedRelease[] {
               {
                 version: release.version,
                 htmlUrl: release.htmlUrl,
+                channel: release.channel,
               },
             ],
       ),

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,5 +1,11 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "nextjs",
+  "git": {
+    "deploymentEnabled": {
+      "dev": false,
+      "main": false
+    }
+  },
   "outputDirectory": ".next"
 }

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -3,8 +3,8 @@
   "framework": "nextjs",
   "git": {
     "deploymentEnabled": {
-      "dev": false,
-      "main": false
+      "*": false,
+      "www": true
     }
   },
   "outputDirectory": ".next"


### PR DESCRIPTION
(AI Generated).

## Summary
- backport the explicit `www` release flow and targeted preview routing from `dev` to `main`
- keep production website deploys sourced from `www` and enforce that release artifacts exist there before production website deploys run
- keep the static changelog behavior, dev-release toggle UI, and Vercel routing config aligned on `main`

## Validation
- `npm run test:changelog --workspace=website`
- `npm run build --workspace=website`
- `git diff --check`
