### PR TITLE
fix: refresh public changelog after dev releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -320,6 +320,73 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release edit "${{ github.ref_name }}" --draft=false --repo "${{ github.repository }}"
 
+  # Redeploy the public marketing site after any GitHub release is public so
+  # the checked-in changelog snapshot is rebuilt against the newly published
+  # release list. Production releases still require the reviewed website branch
+  # to contain the matching release notes file before deployment.
+  # Requires VERCEL_TOKEN to be set in repo secrets. If the secret is absent
+  # the step exits cleanly without failing the workflow.
+  publish-website:
+    name: Deploy Website
+    needs: [publish, notes]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: www
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+          cache: "npm"
+
+      - name: Verify website production branch contains this release
+        if: needs.notes.outputs.release_channel == 'production'
+        shell: bash
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          RELEASE_JSON="release-notes/releases/${TAG}.json"
+
+          if [[ ! -f "$RELEASE_JSON" ]]; then
+            echo "Website production deploys must ship from the www branch." >&2
+            echo "Missing ${RELEASE_JSON} on www for ${TAG}." >&2
+            echo "Merge the reviewed website and changelog updates into www before this production website deploy can run." >&2
+            exit 1
+          fi
+
+      - name: Wait for published GitHub release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          for attempt in {1..30}; do
+            draft_state=$(gh api "repos/${{ github.repository }}/releases/tags/${{ github.ref_name }}" --jq '.draft')
+            if [ "$draft_state" = "false" ]; then
+              echo "Release ${{ github.ref_name }} is published."
+              exit 0
+            fi
+
+            echo "Release ${{ github.ref_name }} is still draft, retrying in 10s (${attempt}/30)"
+            sleep 10
+          done
+
+          echo "Release ${{ github.ref_name }} never became published."
+          exit 1
+
+      - name: Deploy website to Vercel
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          if [ -z "$VERCEL_TOKEN" ]; then
+            echo "VERCEL_TOKEN not configured, skipping website deploy"
+            echo "Add a VERCEL_TOKEN secret to enable automatic website changelog refresh."
+            exit 0
+          fi
+          ./scripts/vercel-deploy-production.sh website "$VERCEL_TOKEN"
   # Deploy the PWA to Vercel after the GitHub release is published so the
   # version shown in the app always matches the shipped desktop release.
   # Requires VERCEL_TOKEN to be set in repo secrets. If the secret is absent

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,6 +110,19 @@ Before creating a worktree, classify the requested work by destination branch.
 - Never base public marketing work from `dev`.
 - Never fast-forward `www` to `dev`.
 
+### Branch Promotion
+
+Treat `dev`, `main`, and `www` as separate lanes with explicit promotion points.
+
+- `dev` is the default branch for ongoing product work.
+- `main` is the production release branch. Do not use it as a second development branch.
+- Promote `dev` into `main` when shipping a reviewed production release.
+- Merge `main` back into `dev` only when `main` has diverged with a production-only fix, release-only adjustment, or other reviewed change that `dev` does not already contain.
+- If a hotfix lands on `main`, merge or cherry-pick it back into `dev` immediately after the production release is stable. Do not let `main` drift sit around.
+- `www` is the public marketing branch. Sync approved `main` changes into `www` when the website or checked-in changelog needs them. Never sync `www` from `dev`.
+- Do not talk about routine `main` and `dev` sync. The normal flow is promotion from `dev` to `main`, with rare repair merges from `main` back to `dev`.
+- When release tooling or deployment helpers exist on more than one long-lived branch, update the matching copies in the same sweep or document why they intentionally differ.
+
 **Never use `git log main..branch` to check whether a branch has been merged.** Squash merge creates a new commit hash on `main`, so the original branch commits are never reachable from `main`'s history. The branch always looks "ahead" even when its content is fully shipped. Use these instead:
 
 ```bash

--- a/docs/PHASE-5-DESKTOP.md
+++ b/docs/PHASE-5-DESKTOP.md
@@ -355,10 +355,13 @@ export async function captureDomFeed(
 > and Freed Desktop can switch locally between production releases from `main`
 > and dev prereleases from `dev` without syncing that preference through the
 > shared document.
-> Release shipping no longer redeploys `freed.wtf` directly. The public
-> marketing site is controlled by the `www` branch and the `freed-ship-www`
-> workflow. After a dev or production release ships, `freed-ship-build`
-> should refresh the static marketing changelog from current `www` without
+> The public marketing site is controlled by the `www` branch. After any
+> GitHub release is published, the workflow now redeploys `freed.wtf` from the
+> current `www` branch so the changelog snapshot rebuilds against the newly
+> published release instead of waiting for a later production ship. Production
+> desktop tags still come from `main`, and production website deploys still
+> require the reviewed website and changelog state to be merged into `www`
+> first. Dev releases refresh the public changelog from current `www` without
 > ever moving `www` to `dev`. See `RELEASE-SECRETS.md` for the full setup
 > checklist.
 

--- a/docs/RELEASE-SECRETS.md
+++ b/docs/RELEASE-SECRETS.md
@@ -66,6 +66,15 @@ Options:
 `freed-ship-www` to publish current `www`, refresh the static changelog, or
 sync approved `main` changes into `www`.
 
+Branch promotion rules:
+
+- `dev` carries ongoing product work and dev releases.
+- `main` is only for reviewed production release promotion and rare production hotfixes.
+- Promote `dev` into `main` when shipping production. Do not treat `main` as a peer development branch.
+- If `main` gets a production-only fix or release adjustment that `dev` does not already have, merge or cherry-pick it back into `dev` immediately after the production release is stable.
+- `www` stays separate from product branches. Sync approved `main` changes into `www` when the public website or checked-in changelog needs them. Never sync `www` from `dev`.
+- If release tooling or website deploy helpers are duplicated across long-lived branches, update the matching copies in the same sweep or note the intentional divergence in the PR.
+
 `VERCEL_TOKEN` is required for GitHub Actions preview deploys and the automated
 PWA production deploy after a production desktop release.
 
@@ -162,14 +171,17 @@ After all platform builds succeed, the workflow publishes that release
 automatically.
 
 If `VERCEL_TOKEN` is configured, production releases deploy `packages/pwa/` so
-the PWA version stays aligned with the shipped desktop release. The marketing
-site changelog is refreshed separately through `freed-ship-www`, which rebuilds
-the static website snapshot from current `www`.
+the PWA version stays aligned with the shipped desktop release. After any
+GitHub release is published, the release workflow also redeploys the public
+website from current `www` so the static changelog snapshot is rebuilt against
+the latest release list. Production website deploys still require the reviewed
+website and changelog state to already be merged into `www`.
 
 Dev releases are published as GitHub prereleases with a `-dev` suffix and do
-not trigger production PWA deploys. They should still be followed by
-`freed-ship-www` in changelog refresh mode so `freed.wtf/changelog/all` can
-include the dev release in the next static marketing build.
+not trigger production PWA deploys. They do trigger the public changelog
+refresh from current `www`, so `freed.wtf/changelog/all` can pick up the dev
+release without waiting for a later production ship. Use `freed-ship-www` as
+the manual fallback if the website refresh needs to be rerun independently.
 
 For dev releases, only the Git tag and release metadata use the `-dev` suffix.
 The app package versions written to Desktop and PWA package files stay numeric,


### PR DESCRIPTION
(AI Generated).

## Summary
- redeploy the public website after any published GitHub release so the static changelog snapshot refreshes for dev releases too
- keep the release-notes gate production-only so website production deploys still require reviewed `www` state
- update Phase 5 docs to reflect the actual release and changelog behavior

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml")'`
- `git diff --check`
