### PR TITLE
fix: repair website Vercel deploy helpers

### DIFF
--- a/scripts/lib/node-tooling.sh
+++ b/scripts/lib/node-tooling.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+resolve_node_bin() {
+  if [[ -n "${NODE_BIN:-}" && -x "${NODE_BIN}" ]]; then
+    printf '%s\n' "${NODE_BIN}"
+    return 0
+  fi
+
+  if command -v node >/dev/null 2>&1; then
+    command -v node
+    return 0
+  fi
+
+  local candidate
+  for candidate in \
+    "${HOME}/.nvm/versions/node/v24.14.1/bin/node" \
+    "${HOME}/.nvm/versions/node/v22.12.0/bin/node"
+  do
+    if [[ -x "${candidate}" ]]; then
+      printf '%s\n' "${candidate}"
+      return 0
+    fi
+  done
+
+  echo "Error: could not find node. Set NODE_BIN or add node to PATH." >&2
+  return 1
+}
+
+resolve_npm_bin() {
+  local node_bin node_dir npm_bin
+  node_bin="$(resolve_node_bin)"
+  node_dir="$(cd "$(dirname "${node_bin}")" && pwd)"
+  npm_bin="${node_dir}/npm"
+
+  if [[ -x "${npm_bin}" ]]; then
+    printf '%s\n' "${npm_bin}"
+    return 0
+  fi
+
+  if command -v npm >/dev/null 2>&1; then
+    command -v npm
+    return 0
+  fi
+
+  echo "Error: could not find npm next to ${node_bin} or on PATH." >&2
+  return 1
+}
+
+resolve_npx_bin() {
+  local node_bin node_dir npx_bin
+  node_bin="$(resolve_node_bin)"
+  node_dir="$(cd "$(dirname "${node_bin}")" && pwd)"
+  npx_bin="${node_dir}/npx"
+
+  if [[ -x "${npx_bin}" ]]; then
+    printf '%s\n' "${npx_bin}"
+    return 0
+  fi
+
+  if command -v npx >/dev/null 2>&1; then
+    command -v npx
+    return 0
+  fi
+
+  echo "Error: could not find npx next to ${node_bin} or on PATH." >&2
+  return 1
+}
+
+use_resolved_node_path() {
+  local node_bin node_dir
+  node_bin="$(resolve_node_bin)"
+  node_dir="$(cd "$(dirname "${node_bin}")" && pwd)"
+  export PATH="${node_dir}:${PATH}"
+}

--- a/scripts/vercel-deploy-preview.sh
+++ b/scripts/vercel-deploy-preview.sh
@@ -1,12 +1,20 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ $# -ne 1 ]]; then
-  echo "Usage: $0 website|pwa" >&2
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./lib/node-tooling.sh
+source "${SCRIPT_DIR}/lib/node-tooling.sh"
+use_resolved_node_path
+NPM_BIN="$(resolve_npm_bin)"
+NPX_BIN="$(resolve_npx_bin)"
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  echo "Usage: $0 website|pwa [vercel-token]" >&2
   exit 1
 fi
 
 TARGET="$1"
+VERCEL_TOKEN="${2:-${VERCEL_TOKEN:-}}"
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TEMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/freed-vercel-preview.XXXXXX")"
 
@@ -74,26 +82,34 @@ done
 echo "Verifying preview bundle for $TARGET from $TEMP_DIR"
 (
   cd "$TEMP_DIR"
-  npm install
+  "$NPM_BIN" ci
   if [[ "$TARGET" == "website" ]]; then
-    npm run build --workspace=website
+    "$NPM_BIN" run build --workspace=website
   elif [[ "$STAGE_AT_ROOT" == "true" ]]; then
-    npm run build
+    "$NPM_BIN" run build
   else
-    npm run build -w @freed/pwa
+    "$NPM_BIN" run build -w @freed/pwa
   fi
 )
 
+VERCEL_FLAGS=(--scope aubreyfs-projects)
+if [[ -n "$VERCEL_TOKEN" ]]; then
+  VERCEL_FLAGS+=(--token "$VERCEL_TOKEN")
+fi
+
 echo "Pulling Vercel settings for $TARGET"
-npx vercel pull --yes --environment preview --cwd "$TEMP_DIR" --scope aubreyfs-projects
+"$NPX_BIN" vercel pull --yes --environment preview --cwd "$TEMP_DIR" "${VERCEL_FLAGS[@]}"
 
 if [[ "$TARGET" == "website" ]]; then
-  echo "Deploying $TARGET preview with Vercel"
-  npx vercel deploy --cwd "$TEMP_DIR" --scope aubreyfs-projects -y
-else
   echo "Building $TARGET preview with Vercel"
-  npx vercel build --cwd "$TEMP_DIR" --local-config "$TEMP_DIR/vercel.json" --scope aubreyfs-projects
+  "$NPX_BIN" vercel build --cwd "$TEMP_DIR" "${VERCEL_FLAGS[@]}"
 
   echo "Deploying $TARGET preview with Vercel"
-  npx vercel deploy --prebuilt --cwd "$TEMP_DIR" --local-config "$TEMP_DIR/vercel.json" --scope aubreyfs-projects -y
+  "$NPX_BIN" vercel deploy --prebuilt --cwd "$TEMP_DIR" "${VERCEL_FLAGS[@]}" -y
+else
+  echo "Building $TARGET preview with Vercel"
+  "$NPX_BIN" vercel build --cwd "$TEMP_DIR" --local-config "$TEMP_DIR/vercel.json" "${VERCEL_FLAGS[@]}"
+
+  echo "Deploying $TARGET preview with Vercel"
+  "$NPX_BIN" vercel deploy --prebuilt --cwd "$TEMP_DIR" --local-config "$TEMP_DIR/vercel.json" "${VERCEL_FLAGS[@]}" -y
 fi

--- a/scripts/vercel-deploy-production.sh
+++ b/scripts/vercel-deploy-production.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./lib/node-tooling.sh
+source "${SCRIPT_DIR}/lib/node-tooling.sh"
+use_resolved_node_path
+NPM_BIN="$(resolve_npm_bin)"
+NPX_BIN="$(resolve_npx_bin)"
+
 if [[ $# -lt 1 || $# -gt 2 ]]; then
   echo "Usage: $0 website|pwa [vercel-token]" >&2
   exit 1
@@ -87,11 +94,11 @@ fi
 echo "Verifying production bundle for $TARGET from $TEMP_DIR"
 (
   cd "$TEMP_DIR"
-  npm install
+  "$NPM_BIN" ci
   if [[ "$TARGET" == "website" ]]; then
-    npm run build --workspace=website
+    "$NPM_BIN" run build --workspace=website
   else
-    npm run build -w @freed/pwa
+    "$NPM_BIN" run build -w @freed/pwa
   fi
 )
 
@@ -101,15 +108,18 @@ if [[ -n "$VERCEL_TOKEN" ]]; then
 fi
 
 echo "Pulling Vercel settings for $TARGET"
-npx vercel pull --yes --environment production --cwd "$TEMP_DIR" "${VERCEL_FLAGS[@]}"
+"$NPX_BIN" vercel pull --yes --environment production --cwd "$TEMP_DIR" "${VERCEL_FLAGS[@]}"
 
 if [[ "$TARGET" == "website" ]]; then
-  echo "Deploying $TARGET production build to Vercel"
-  npx vercel deploy --cwd "$TEMP_DIR" "${VERCEL_FLAGS[@]}" -y --prod
-else
   echo "Building $TARGET production bundle with Vercel"
-  npx vercel build --cwd "$TEMP_DIR" --local-config "$TEMP_DIR/vercel.json" "${VERCEL_FLAGS[@]}" --prod
+  "$NPX_BIN" vercel build --cwd "$TEMP_DIR" "${VERCEL_FLAGS[@]}" --prod
 
   echo "Deploying $TARGET production build to Vercel"
-  npx vercel deploy --prebuilt --cwd "$TEMP_DIR" --local-config "$TEMP_DIR/vercel.json" "${VERCEL_FLAGS[@]}" -y --prod
+  "$NPX_BIN" vercel deploy --prebuilt --cwd "$TEMP_DIR" "${VERCEL_FLAGS[@]}" -y --prod
+else
+  echo "Building $TARGET production bundle with Vercel"
+  "$NPX_BIN" vercel build --cwd "$TEMP_DIR" --local-config "$TEMP_DIR/vercel.json" "${VERCEL_FLAGS[@]}" --prod
+
+  echo "Deploying $TARGET production build to Vercel"
+  "$NPX_BIN" vercel deploy --prebuilt --cwd "$TEMP_DIR" --local-config "$TEMP_DIR/vercel.json" "${VERCEL_FLAGS[@]}" -y --prod
 fi


### PR DESCRIPTION
(AI Generated).

## Summary
- sync the website Vercel deploy helpers with the newer Node-aware implementation already used on `dev`
- add the shared node tooling helper so preview and production deploys resolve the intended Node, npm, and npx binaries
- fix website deploy verification so changelog refreshes and production deploys stop recursing through the root workspace build

## Verification
- `bash -n scripts/vercel-deploy-production.sh`
- `bash -n scripts/vercel-deploy-preview.sh`
- `./scripts/vercel-deploy-production.sh website`
- `curl -Ls https://www.freed.wtf/changelog/all | tr ',' '\\n' | rg 'v26\\.4\\.1700-dev'`
