### PR TITLE
fix: migrate legacy identity graph on startup

### DIFF
--- a/packages/desktop/src/lib/automerge.worker.ts
+++ b/packages/desktop/src/lib/automerge.worker.ts
@@ -22,6 +22,8 @@ import {
   addAccount,
   addAccounts,
   addFeedItem,
+  hasLegacyIdentityGraphData,
+  migrateLegacyIdentityGraph,
   addPerson,
   addRssFeed,
   removeRssFeed,
@@ -168,6 +170,13 @@ function emitWorkerTrace(
 
 function bumpSearchCorpusVersion(): void {
   searchCorpusVersion += 1;
+}
+
+function migrateLoadedIdentityGraph(message: string): void {
+  if (!currentDoc || !hasLegacyIdentityGraphData(currentDoc)) return;
+  currentDoc = A.change(currentDoc, message, (doc) => {
+    migrateLegacyIdentityGraph(doc);
+  });
 }
 
 function feedItemUpdatesAffectSearchCorpus(updates: Partial<FeedItem>): boolean {
@@ -423,6 +432,7 @@ async function handleRequest(
         if (saved) {
           try {
             currentDoc = A.load<FreedDoc>(saved);
+            migrateLoadedIdentityGraph("Migrate legacy identity graph");
             currentBinary = saved;
             persistenceState = createPersistenceState(saved);
           } catch {
@@ -457,6 +467,7 @@ async function handleRequest(
 
       case "REPLACE_DOC":
         currentDoc = A.load<FreedDoc>(req.binary);
+        migrateLoadedIdentityGraph("Migrate legacy identity graph");
         currentBinary = req.binary;
         persistenceState = createPersistenceState(req.binary);
         bumpSearchCorpusVersion();
@@ -479,6 +490,7 @@ async function handleRequest(
         const beforeCount = Object.keys(currentDoc.feedItems ?? {}).length;
         const incomingDoc = A.load<FreedDoc>(req.binary);
         currentDoc = A.merge(currentDoc, incomingDoc);
+        migrateLoadedIdentityGraph("Migrate legacy identity graph");
         const afterCount = Object.keys(currentDoc.feedItems ?? {}).length;
         const delta = afterCount - beforeCount;
         send({

--- a/packages/pwa/src/lib/automerge.worker.ts
+++ b/packages/pwa/src/lib/automerge.worker.ts
@@ -18,6 +18,8 @@ import {
   addAccount,
   addAccounts,
   addFeedItem,
+  hasLegacyIdentityGraphData,
+  migrateLegacyIdentityGraph,
   addPerson,
   addRssFeed,
   removeRssFeed,
@@ -130,6 +132,13 @@ function projectLegacyFriends(
 
 function bumpSearchCorpusVersion(): void {
   searchCorpusVersion += 1;
+}
+
+function migrateLoadedIdentityGraph(message: string): void {
+  if (!currentDoc || !hasLegacyIdentityGraphData(currentDoc)) return;
+  currentDoc = A.change(currentDoc, message, (doc) => {
+    migrateLegacyIdentityGraph(doc);
+  });
 }
 
 function feedItemUpdatesAffectSearchCorpus(updates: Partial<FeedItem>): boolean {
@@ -283,6 +292,7 @@ self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
         if (saved) {
           try {
             currentDoc = A.load<FreedDoc>(saved);
+            migrateLoadedIdentityGraph("Migrate legacy identity graph");
           } catch {
             await storage.clear();
             send({ type: "DEBUG_EVENT", kind: "init", detail: "corrupt doc cleared, creating fresh" });
@@ -544,6 +554,7 @@ self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
         const beforeCount = Object.keys(currentDoc.feedItems ?? {}).length;
         const incomingDoc = A.load<FreedDoc>(req.binary);
         currentDoc = A.merge(currentDoc, incomingDoc);
+        migrateLoadedIdentityGraph("Migrate legacy identity graph");
         const afterCount = Object.keys(currentDoc.feedItems ?? {}).length;
         const delta = afterCount - beforeCount;
         send({

--- a/packages/pwa/src/lib/schema.test.ts
+++ b/packages/pwa/src/lib/schema.test.ts
@@ -8,8 +8,12 @@
 import { describe, it, expect } from "vitest";
 import * as A from "@automerge/automerge";
 import {
+  addAccounts,
   createEmptyDoc,
+  createDocFromData,
   addFeedItem,
+  hasLegacyIdentityGraphData,
+  migrateLegacyIdentityGraph,
   removeFeedItem,
   markAsRead,
   toggleSaved,
@@ -20,7 +24,7 @@ import {
   updatePreferences,
 } from "@freed/shared/schema";
 import type { FreedDoc } from "@freed/shared/schema";
-import type { FeedItem, RssFeed } from "@freed/shared";
+import type { Account, FeedItem, RssFeed } from "@freed/shared";
 
 // =============================================================================
 // Test fixtures
@@ -277,6 +281,84 @@ describe("updatePreferences", () => {
     );
 
     expect(doc.preferences.display.compactMode).toBe(originalCompactMode);
+  });
+});
+
+describe("legacy identity graph migration", () => {
+  function makeLegacyFriend() {
+    const now = Date.now();
+    return {
+      id: "person-1",
+      name: "Ada Lovelace",
+      sources: [{
+        platform: "x" as const,
+        authorId: "ada-l",
+        handle: "ada",
+        displayName: "Ada",
+      }],
+      careLevel: 3 as const,
+      createdAt: now,
+      updatedAt: now,
+    };
+  }
+
+  it("migrates legacy friends into persons and accounts when creating docs from data", () => {
+    const base = A.toJS(createEmptyDoc()) as FreedDoc;
+    const legacyFriend = makeLegacyFriend();
+    const doc = createDocFromData({
+      feedItems: base.feedItems,
+      rssFeeds: base.rssFeeds,
+      preferences: base.preferences,
+      meta: base.meta,
+      friends: {
+        [legacyFriend.id]: legacyFriend,
+      },
+    } as unknown as Partial<FreedDoc>);
+
+    expect(doc.persons[legacyFriend.id]?.name).toBe(legacyFriend.name);
+    expect(doc.accounts[`${legacyFriend.id}:x:${legacyFriend.sources[0].authorId}`]).toBeDefined();
+  });
+
+  it("repairs loaded legacy docs before discovered account writes run", () => {
+    const base = A.toJS(createEmptyDoc()) as FreedDoc;
+    const legacyFriend = makeLegacyFriend();
+    let doc = A.from({
+      feedItems: base.feedItems,
+      rssFeeds: base.rssFeeds,
+      preferences: base.preferences,
+      meta: base.meta,
+      friends: {
+        [legacyFriend.id]: legacyFriend,
+      },
+    } as Record<string, unknown>) as unknown as FreedDoc;
+
+    expect(hasLegacyIdentityGraphData(doc)).toBe(true);
+
+    doc = A.change(doc, (draft) => {
+      migrateLegacyIdentityGraph(draft);
+    });
+
+    const discoveredAccount: Account = {
+      id: `${legacyFriend.id}:x:new-author`,
+      personId: legacyFriend.id,
+      kind: "social",
+      provider: "x",
+      externalId: "new-author",
+      handle: "newauthor",
+      displayName: "New Author",
+      firstSeenAt: legacyFriend.updatedAt,
+      lastSeenAt: legacyFriend.updatedAt,
+      discoveredFrom: "captured_item",
+      createdAt: legacyFriend.updatedAt,
+      updatedAt: legacyFriend.updatedAt,
+    };
+
+    doc = A.change(doc, (draft) => {
+      addAccounts(draft, [discoveredAccount]);
+    });
+
+    expect(doc.persons[legacyFriend.id]?.name).toBe(legacyFriend.name);
+    expect(doc.accounts[discoveredAccount.id]?.externalId).toBe("new-author");
   });
 });
 

--- a/packages/shared/src/schema.ts
+++ b/packages/shared/src/schema.ts
@@ -206,6 +206,140 @@ function migrateLegacyIdentityData(data: Partial<FreedDoc>): Partial<FreedDoc> {
   };
 }
 
+function ensureIdentityGraphRoots(doc: FreedDoc): void {
+  const root = doc as FreedDoc & {
+    persons?: Record<string, Person>;
+    accounts?: Record<string, Account>;
+  };
+
+  if (!root.persons) {
+    root.persons = {};
+  }
+  if (!root.accounts) {
+    root.accounts = {};
+  }
+}
+
+function addLegacyFriendToIdentityGraph(doc: FreedDoc, legacy: LegacyFriend): void {
+  ensureIdentityGraphRoots(doc);
+
+  if (!doc.persons[legacy.id]) {
+    doc.persons[legacy.id] = normalizePerson({
+      id: legacy.id,
+      name: legacy.name,
+      avatarUrl: legacy.avatarUrl,
+      bio: legacy.bio,
+      relationshipStatus: "friend",
+      careLevel: legacy.careLevel,
+      reachOutIntervalDays: legacy.reachOutIntervalDays,
+      reachOutLog: legacy.reachOutLog,
+      tags: legacy.tags,
+      notes: legacy.notes,
+      createdAt: legacy.createdAt,
+      updatedAt: legacy.updatedAt,
+    });
+  }
+
+  for (const source of legacy.sources ?? []) {
+    const accountId = accountIdForLegacySocial(legacy.id, source);
+    if (!doc.accounts[accountId]) {
+      doc.accounts[accountId] = stripUndefined({
+        id: accountId,
+        personId: legacy.id,
+        kind: "social",
+        provider: source.platform,
+        externalId: source.authorId,
+        handle: source.handle,
+        displayName: source.displayName,
+        avatarUrl: source.avatarUrl,
+        profileUrl: source.profileUrl,
+        firstSeenAt: legacy.createdAt,
+        lastSeenAt: legacy.updatedAt,
+        discoveredFrom: "captured_item",
+        createdAt: legacy.createdAt,
+        updatedAt: legacy.updatedAt,
+      });
+    }
+  }
+
+  if (!legacy.contact) return;
+
+  const accountId = accountIdForLegacyContact(legacy.id, legacy.contact);
+  if (!doc.accounts[accountId]) {
+    doc.accounts[accountId] = stripUndefined({
+      id: accountId,
+      personId: legacy.id,
+      kind: "contact",
+      provider: contactProviderForLegacyContact(legacy.contact),
+      externalId: legacy.contact.nativeId ?? legacy.contact.name,
+      displayName: legacy.contact.name,
+      email: legacy.contact.email,
+      phone: legacy.contact.phone,
+      address: legacy.contact.address,
+      importedAt: legacy.contact.importedAt,
+      firstSeenAt: legacy.contact.importedAt,
+      lastSeenAt: legacy.updatedAt,
+      discoveredFrom: "contact_import",
+      createdAt: legacy.createdAt,
+      updatedAt: legacy.updatedAt,
+    });
+  }
+}
+
+export function hasLegacyIdentityGraphData(doc: FreedDoc): boolean {
+  const root = doc as FreedDoc & {
+    friends?: Record<string, LegacyFriend>;
+    persons?: Record<string, Person>;
+    accounts?: Record<string, Account>;
+  };
+
+  return !root.persons || !root.accounts || !!root.friends;
+}
+
+export function migrateLegacyIdentityGraph(doc: FreedDoc): boolean {
+  const root = doc as FreedDoc & {
+    friends?: Record<string, LegacyFriend>;
+  };
+  let changed = false;
+
+  if (!(doc as FreedDoc & { persons?: Record<string, Person> }).persons) {
+    (doc as FreedDoc & { persons?: Record<string, Person> }).persons = {};
+    changed = true;
+  }
+  if (!(doc as FreedDoc & { accounts?: Record<string, Account> }).accounts) {
+    (doc as FreedDoc & { accounts?: Record<string, Account> }).accounts = {};
+    changed = true;
+  }
+
+  const legacyFriends = root.friends;
+  if (!legacyFriends) {
+    return changed;
+  }
+
+  for (const legacy of Object.values(legacyFriends)) {
+    const personExists = !!doc.persons[legacy.id];
+    const socialAccountIds = (legacy.sources ?? []).map((source) =>
+      accountIdForLegacySocial(legacy.id, source),
+    );
+    const missingSocialAccount = socialAccountIds.some((id) => !doc.accounts[id]);
+    const contactAccountId = legacy.contact
+      ? accountIdForLegacyContact(legacy.id, legacy.contact)
+      : null;
+    const missingContactAccount = contactAccountId
+      ? !doc.accounts[contactAccountId]
+      : false;
+
+    if (personExists && !missingSocialAccount && !missingContactAccount) {
+      continue;
+    }
+
+    addLegacyFriendToIdentityGraph(doc, legacy);
+    changed = true;
+  }
+
+  return changed;
+}
+
 // =============================================================================
 // Feed Item Operations
 // =============================================================================
@@ -638,6 +772,7 @@ export function removeAllFeeds(doc: FreedDoc, includeItems: boolean): void {
  * @param friend - The friend to add
  */
 export function addPerson(doc: FreedDoc, person: Person): void {
+  ensureIdentityGraphRoots(doc);
   doc.persons[person.id] = normalizePerson(person);
 }
 
@@ -656,6 +791,7 @@ export function updatePerson(
   id: string,
   updates: Partial<Person>
 ): void {
+  ensureIdentityGraphRoots(doc);
   const existing = doc.persons[id];
   if (!existing) return;
 
@@ -685,6 +821,7 @@ export function updatePerson(
  * @param id - Friend.id
  */
 export function removePerson(doc: FreedDoc, id: string): void {
+  ensureIdentityGraphRoots(doc);
   delete doc.persons[id];
   for (const [accountId, account] of Object.entries(doc.accounts)) {
     if (account.personId === id) {
@@ -705,6 +842,7 @@ export function logReachOut(
   id: string,
   entry: ReachOutLog
 ): void {
+  ensureIdentityGraphRoots(doc);
   const person = doc.persons[id];
   if (!person) return;
 
@@ -726,6 +864,7 @@ export function logReachOut(
 // =============================================================================
 
 export function addAccount(doc: FreedDoc, account: Account): void {
+  ensureIdentityGraphRoots(doc);
   doc.accounts[account.id] = stripUndefined(account);
 }
 
@@ -740,6 +879,7 @@ export function updateAccount(
   id: string,
   updates: Partial<Account>
 ): void {
+  ensureIdentityGraphRoots(doc);
   const existing = doc.accounts[id];
   if (!existing) return;
   Object.assign(existing, stripUndefined(updates));
@@ -747,6 +887,7 @@ export function updateAccount(
 }
 
 export function removeAccount(doc: FreedDoc, id: string): void {
+  ensureIdentityGraphRoots(doc);
   delete doc.accounts[id];
 }
 


### PR DESCRIPTION
(AI Generated).

## Summary
- migrate legacy `friends` docs into the new `persons/accounts` identity graph before worker load and merge paths continue
- defensively ensure identity graph roots exist before person or account mutations
- add a regression test for pre-graph documents receiving discovered account writes on startup

## Verification
- /Users/aubreyfalconer/.nvm/versions/node/v24.14.1/bin/npm run test:unit --workspace=packages/pwa -- src/lib/schema.test.ts
- /Users/aubreyfalconer/.nvm/versions/node/v24.14.1/bin/npm run build --workspace=packages/desktop
