### PR TITLE
fix: show one dev latest badge in changelog

### DIFF
--- a/website/src/app/changelog/ChangelogContent.tsx
+++ b/website/src/app/changelog/ChangelogContent.tsx
@@ -156,11 +156,13 @@ function PaginationNav({
 function ReleaseCard({
   release,
   index,
-  isLatest,
+  isLatestProduction,
+  isLatestDev,
 }: {
   release: ParsedRelease;
   index: number;
-  isLatest: boolean;
+  isLatestProduction: boolean;
+  isLatestDev: boolean;
 }) {
   const ref = useRef<HTMLDivElement>(null);
   const inView = useInView(ref, { once: true, margin: "-80px" });
@@ -200,9 +202,9 @@ function ReleaseCard({
 
         {/* Node */}
         <div className="release-timeline-node relative z-10 mt-1 transition-transform duration-300">
-          {isLatest ? (
+          {isLatestProduction || isLatestDev ? (
             <>
-              {/* Pulsing rings for latest release */}
+              {/* Pulsing rings for latest release in each channel */}
               <motion.div
                 className="absolute inset-0 rounded-full"
                 style={{
@@ -287,7 +289,7 @@ function ReleaseCard({
               >
                 v{release.version}
               </a>
-              {isLatest && (
+              {isLatestProduction && (
                 <span
                   className="px-2.5 py-0.5 rounded-full text-xs font-semibold border"
                   style={{
@@ -301,7 +303,7 @@ function ReleaseCard({
                   Latest
                 </span>
               )}
-              {release.channel === "dev" && (
+              {isLatestDev && (
                 <span
                   className="px-2.5 py-0.5 rounded-full border text-xs font-semibold text-text-secondary"
                   style={{
@@ -311,7 +313,7 @@ function ReleaseCard({
                       "color-mix(in srgb, var(--theme-text-muted) 24%, transparent)",
                   }}
                 >
-                  Dev
+                  Dev Latest
                 </span>
               )}
               <time className="ml-auto text-sm text-text-muted transition-colors duration-300">
@@ -451,12 +453,16 @@ export default function ChangelogContent({
   mode,
   totalPages,
   pageRange,
+  latestProductionTagName,
+  latestDevTagName,
 }: {
   releases: ParsedRelease[];
   currentPage: number;
   mode: ChangelogMode;
   totalPages: number;
   pageRange: { start: number; end: number; total: number };
+  latestProductionTagName: string | null;
+  latestDevTagName: string | null;
 }) {
   const pathname = usePathname();
   const shouldAnimateHeader = useMemo(
@@ -523,7 +529,8 @@ export default function ChangelogContent({
                   key={release.tagName}
                   release={release}
                   index={index}
-                  isLatest={currentPage === 1 && index === 0}
+                  isLatestProduction={release.tagName === latestProductionTagName}
+                  isLatestDev={release.tagName === latestDevTagName}
                 />
               ))}
             </div>

--- a/website/src/app/changelog/[page]/page.tsx
+++ b/website/src/app/changelog/[page]/page.tsx
@@ -5,6 +5,7 @@ import {
   getChangelogPageRange,
   getChangelogPageSlice,
   getChangelogPaginationStaticParams,
+  getLatestChangelogTagName,
   getChangelogTotalPages,
   parseChangelogPage,
 } from "../pagination";
@@ -34,6 +35,8 @@ export default async function ChangelogPaginationPage({ params }: Props) {
       mode={mode}
       totalPages={getChangelogTotalPages(mode)}
       pageRange={getChangelogPageRange(currentPage, mode)}
+      latestProductionTagName={getLatestChangelogTagName("production")}
+      latestDevTagName={getLatestChangelogTagName("dev")}
     />
   );
 }

--- a/website/src/app/changelog/all/[page]/page.tsx
+++ b/website/src/app/changelog/all/[page]/page.tsx
@@ -5,6 +5,7 @@ import {
   getChangelogPageRange,
   getChangelogPageSliceForMode,
   getChangelogPaginationStaticParams,
+  getLatestChangelogTagName,
   getChangelogTotalPages,
   parseChangelogPage,
 } from "../../pagination";
@@ -35,6 +36,8 @@ export default async function AllChangelogPaginationPage({ params }: Props) {
       mode={mode}
       totalPages={getChangelogTotalPages(mode)}
       pageRange={getChangelogPageRange(currentPage, mode)}
+      latestProductionTagName={getLatestChangelogTagName("production")}
+      latestDevTagName={getLatestChangelogTagName("dev")}
     />
   );
 }

--- a/website/src/app/changelog/all/page.tsx
+++ b/website/src/app/changelog/all/page.tsx
@@ -4,6 +4,7 @@ import {
   buildChangelogMetadata,
   getChangelogPageRange,
   getChangelogPageSliceForMode,
+  getLatestChangelogTagName,
   getChangelogTotalPages,
 } from "../pagination";
 
@@ -21,6 +22,8 @@ export default function AllChangelogPage() {
       mode={mode}
       totalPages={getChangelogTotalPages(mode)}
       pageRange={getChangelogPageRange(currentPage, mode)}
+      latestProductionTagName={getLatestChangelogTagName("production")}
+      latestDevTagName={getLatestChangelogTagName("dev")}
     />
   );
 }

--- a/website/src/app/changelog/page.tsx
+++ b/website/src/app/changelog/page.tsx
@@ -4,6 +4,7 @@ import {
   buildChangelogMetadata,
   getChangelogPageRange,
   getChangelogPageSlice,
+  getLatestChangelogTagName,
   getChangelogTotalPages,
 } from "./pagination";
 
@@ -20,6 +21,8 @@ export default function ChangelogPage() {
       mode={mode}
       totalPages={getChangelogTotalPages(mode)}
       pageRange={getChangelogPageRange(currentPage, mode)}
+      latestProductionTagName={getLatestChangelogTagName("production")}
+      latestDevTagName={getLatestChangelogTagName("dev")}
     />
   );
 }

--- a/website/src/app/changelog/pagination.ts
+++ b/website/src/app/changelog/pagination.ts
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import changelogReleases from "@/content/changelog.generated.json";
-import type { ParsedRelease } from "@/content/changelog";
+import type { ParsedRelease, ReleaseChannel } from "@/content/changelog";
 
 export const CHANGELOG_PAGE_SIZE = 5;
 export type ChangelogMode = "production" | "all";
@@ -14,6 +14,12 @@ function releasesForMode(mode: ChangelogMode): ParsedRelease[] {
   }
 
   return allReleases.filter((release) => release.channel !== "dev");
+}
+
+export function getLatestChangelogTagName(
+  channel: ReleaseChannel,
+): string | null {
+  return allReleases.find((release) => release.channel === channel)?.tagName ?? null;
 }
 
 export function getChangelogTotalPages(


### PR DESCRIPTION
(AI Generated).

## Summary
- remove the per-card Dev chip from changelog dev releases
- show a single Dev Latest chip on the newest dev release
- keep Latest tied to the newest production release by looking up the latest tag per channel

## Why
Every dev card was getting the same badge, which made the changelog noisy and blurred the distinction between any dev release and the current dev release.

## Validation
- `../node_modules/.bin/next build` in `website/`
