### PR TITLE
fix: avoid roadmap ref mutation during render

### DIFF
--- a/website/src/app/roadmap/RoadmapContent.tsx
+++ b/website/src/app/roadmap/RoadmapContent.tsx
@@ -290,7 +290,10 @@ function useDataFlow(layout: (typeof LAYOUT)["desktop"]) {
   const nextId = useRef(0);
   const frameRef = useRef<number>(0);
   const layoutRef = useRef(layout);
-  layoutRef.current = layout;
+
+  useEffect(() => {
+    layoutRef.current = layout;
+  }, [layout]);
 
   const pulseCapture = useCallback((index: number) => {
     setCapturePulseKeys((prev) => {


### PR DESCRIPTION
(AI Generated).

## Summary
- move the roadmap layout ref update out of render and into an effect
- unblock the `www` branch build so the changelog refresh deploy can complete

## Testing
- `corepack npm run build --workspace=website`
