### PR TITLE
feat: add time-aware map filtering

### DIFF
--- a/docs/PHASE-8-FRIENDS.md
+++ b/docs/PHASE-8-FRIENDS.md
@@ -1,6 +1,6 @@
 # Phase 8: Friends + Social Graph
 
-> **Status:** In Progress, the canonical identity model now uses `Person` plus attached `Account` records, Google Contacts imports create friend persons by default, and the map plus Friends surfaces resolve identity through linked accounts instead of embedded friend sources
+> **Status:** In Progress, the canonical identity model now uses `Person` plus attached `Account` records, Google Contacts imports create friend persons by default, and the map plus Friends surfaces resolve identity through linked accounts instead of embedded friend sources while the map can already switch between current, future, and past location windows
 > **Dependencies:** Phase 7 (Facebook + Instagram capture provide most social content)
 
 ---
@@ -214,6 +214,7 @@ Friend avatars now inherit a theme-authored tint across the Friends graph and ma
 Map popovers now use a wider card layout and deliberately omit the old MapLibre tail, so place names and actions fit cleanly without the popup looking like a speech bubble from a cheaper app.
 Friends and Map now consume the same shared theme tokens, button treatments, shell backgrounds, surface recipes, and theme-native map palettes as the rest of Freed, so themes like Neon, Midas, Vesper, Ember, and Scriptorium land consistently across the graph, sidebars, popovers, mini-map cards, editor, contact-sync flows, and map basemap itself.
 The shared map now includes a persisted `Friends` / `All content` toggle. It restores the user's last mode from preferences and defaults to `All content` when the library has geolocatable followed accounts but no friend-linked pins yet.
+The shared map now also persists a `Current` / `Future` / `Past` time filter. Future-dated `timeRange` windows stay out of the default current map until they start, upcoming travel or event windows can be previewed directly, and expired windows fall into a separate past view without hijacking the current last-seen map.
 
 ---
 
@@ -241,7 +242,7 @@ The shared map now includes a persisted `Friends` / `All content` toggle. It res
 | 8.18 | Wire Friends to live sidebar navigation | Low | Done |
 | 8.19 | Google Contacts source, sync lifecycle, matching, and Friend creation flow | Medium | Done |
 | 8.20 | Wire Map to live sidebar navigation | Low | Done |
-| 8.21 | Add future-aware map filtering for location-bearing items | Medium | Not Started |
+| 8.21 | Add future-aware map filtering for location-bearing items | Medium | Done |
 | 8.22 | Add map timeline scrubber for past and future playback | Medium | Not Started |
 | 8.23 | Replace embedded Friend identity with canonical `Person` + `Account` schema and Automerge migration | High | Done |
 | 8.24 | Backfill followed-account catalog from captured authors and stories | Medium | Done |
@@ -287,7 +288,7 @@ The shared map now includes a persisted `Friends` / `All content` toggle. It res
 - [x] Generic Instagram story labels are recovered from preserved location URLs or excluded from the map
 - [ ] macOS native contact picker (CNContactStore)
 - [x] Map promoted to live sidebar navigation
-- [ ] Future-aware map filtering supports past, current, and future location windows
+- [x] Future-aware map filtering supports past, current, and future location windows
 - [ ] Timeline scrubbing works across historical posts and future planning items
 - [ ] Overlaps render as derived read-time views, not persisted source records
 - [ ] Mozi-backed friend/location events appear in Friend identity and map flows

--- a/packages/desktop/src/lib/store-preferences.test.ts
+++ b/packages/desktop/src/lib/store-preferences.test.ts
@@ -95,4 +95,16 @@ describe("store.updatePreferences", () => {
       display: { mapMode: "all_content" },
     });
   });
+
+  it("passes map time preference updates through to persistence", async () => {
+    await expect(
+      useAppStore.getState().updatePreferences({
+        display: { mapTimeMode: "future" },
+      } as never),
+    ).resolves.toBeUndefined();
+
+    expect(mockDocUpdatePreferences).toHaveBeenCalledWith({
+      display: { mapTimeMode: "future" },
+    });
+  });
 });

--- a/packages/desktop/tests/e2e/smoke.spec.ts
+++ b/packages/desktop/tests/e2e/smoke.spec.ts
@@ -1527,6 +1527,105 @@ test("recoverable story locations appear in All content mode and the mode persis
   });
 });
 
+test("map time filters switch between current and future location windows", async ({ app, page }) => {
+  await app.goto();
+  await app.waitForReady();
+  await app.seedFriendLocation();
+  await dismissCloudSyncNudgeIfPresent(page);
+
+  await page.evaluate(async () => {
+    const w = window as Record<string, unknown>;
+    const automerge = w.__FREED_AUTOMERGE__ as {
+      docAddFeedItems: (items: unknown[]) => Promise<void>;
+    };
+    const store = w.__FREED_STORE__ as {
+      getState: () => {
+        items: Array<{ globalId: string }>;
+      };
+    };
+
+    const now = Date.now();
+    await automerge.docAddFeedItems([
+      {
+        globalId: "ig:ada:lisbon-plan",
+        platform: "instagram",
+        contentType: "post",
+        capturedAt: now,
+        publishedAt: now,
+        author: {
+          id: "ada-ig",
+          handle: "ada",
+          displayName: "Ada Lovelace",
+        },
+        content: {
+          text: "Landing in Lisbon later this week.",
+          mediaUrls: [],
+          mediaTypes: [],
+        },
+        location: {
+          name: "Lisbon",
+          coordinates: { lat: 38.7223, lng: -9.1393 },
+          source: "geo_tag",
+        },
+        timeRange: {
+          startsAt: now + 2 * 24 * 60 * 60_000,
+          endsAt: now + 5 * 24 * 60 * 60_000,
+          kind: "travel",
+        },
+        userState: {
+          hidden: false,
+          saved: false,
+          archived: false,
+          tags: [],
+        },
+        topics: [],
+      },
+    ]);
+
+    await new Promise<void>((resolve, reject) => {
+      const startedAt = Date.now();
+      const interval = window.setInterval(() => {
+        const hasFutureItem = store
+          .getState()
+          .items.some((item) => item.globalId === "ig:ada:lisbon-plan");
+        if (hasFutureItem) {
+          clearInterval(interval);
+          resolve();
+          return;
+        }
+        if (Date.now() - startedAt > 5_000) {
+          clearInterval(interval);
+          reject(new Error("seed timeout"));
+        }
+      }, 50);
+    });
+  });
+
+  await page.getByRole("button", { name: /^Map/ }).click();
+  await expect(page.getByRole("button", { name: "Current", exact: true })).toHaveClass(
+    /theme-chip-active/,
+    { timeout: 10_000 },
+  );
+
+  await openVisibleMapMarker(page, "Ada Lovelace");
+  await expect(page.getByText("Paris", { exact: true })).toBeVisible({ timeout: 10_000 });
+  await expect(page.getByText("Lisbon", { exact: true })).toHaveCount(0);
+
+  const futureButton = page.getByRole("button", { name: "Future", exact: true });
+  await futureButton.click();
+  await expect(futureButton).toHaveClass(/theme-chip-active/, { timeout: 10_000 });
+  await expect(page.getByText("Lisbon", { exact: true })).toBeVisible({ timeout: 10_000 });
+
+  await page.reload();
+  await app.waitForReady();
+  await dismissCloudSyncNudgeIfPresent(page);
+  await page.getByRole("button", { name: /^Map/ }).click();
+  await expect(page.getByRole("button", { name: "Future", exact: true })).toHaveClass(
+    /theme-chip-active/,
+    { timeout: 10_000 },
+  );
+});
+
 test("Friends view uses the floating detail drawer shell", async ({ app, page }) => {
   await page.setViewportSize({ width: 1440, height: 900 });
   await app.goto();

--- a/packages/pwa/src/lib/map-locations.test.ts
+++ b/packages/pwa/src/lib/map-locations.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   extractLocationFromItem,
+  filterResolvedLocationsByTime,
   getDefaultMapMode,
   getLatestAuthorLocationMarkers,
   getLatestFriendLocationMarkers,
@@ -286,6 +287,164 @@ describe("location grouping", () => {
     expect(getDefaultMapMode(0, 4)).toBe("all_content");
     expect(getDefaultMapMode(2, 4)).toBe("friends");
     expect(getDefaultMapMode(0, 0)).toBe("friends");
+  });
+
+  it("keeps future time windows out of the current map until they start", () => {
+    const now = 1_710_000_000_000;
+    const friend = makeFriend({ id: "friend-1" });
+    const markers = getLatestFriendLocationMarkers(
+      [
+        {
+          item: makeItem({
+            globalId: "ig:1",
+            publishedAt: now - 60_000,
+          }),
+          friend,
+          lat: 48.8566,
+          lng: 2.3522,
+          label: "Paris",
+        },
+        {
+          item: makeItem({
+            globalId: "ig:2",
+            publishedAt: now - 30_000,
+            timeRange: {
+              startsAt: now + 2 * 60 * 60_000,
+              endsAt: now + 5 * 60 * 60_000,
+              kind: "travel",
+            },
+          }),
+          friend,
+          lat: 38.7223,
+          lng: -9.1393,
+          label: "Lisbon",
+        },
+      ],
+      { now, timeMode: "current" },
+    );
+
+    expect(markers).toHaveLength(1);
+    expect(markers[0]?.label).toBe("Paris");
+    expect(markers[0]?.item.globalId).toBe("ig:1");
+  });
+
+  it("shows only upcoming time windows in future mode", () => {
+    const now = 1_710_000_000_000;
+    const friend = makeFriend({ id: "friend-1" });
+    const markers = getLatestFriendLocationMarkers(
+      [
+        {
+          item: makeItem({
+            globalId: "ig:1",
+            publishedAt: now - 60_000,
+          }),
+          friend,
+          lat: 48.8566,
+          lng: 2.3522,
+          label: "Paris",
+        },
+        {
+          item: makeItem({
+            globalId: "ig:2",
+            publishedAt: now - 30_000,
+            timeRange: {
+              startsAt: now + 2 * 60 * 60_000,
+              endsAt: now + 5 * 60 * 60_000,
+              kind: "travel",
+            },
+          }),
+          friend,
+          lat: 38.7223,
+          lng: -9.1393,
+          label: "Lisbon",
+        },
+      ],
+      { now, timeMode: "future" },
+    );
+
+    expect(markers).toHaveLength(1);
+    expect(markers[0]?.label).toBe("Lisbon");
+    expect(markers[0]?.seenAt).toBe(now + 2 * 60 * 60_000);
+  });
+
+  it("routes expired time windows into the past filter", () => {
+    const now = 1_710_000_000_000;
+    const friend = makeFriend({ id: "friend-1" });
+    const resolved: ResolvedLocationItem[] = [
+      {
+        item: makeItem({
+          globalId: "ig:1",
+          publishedAt: now - 8 * 60 * 60_000,
+          timeRange: {
+            startsAt: now - 8 * 60 * 60_000,
+            endsAt: now - 4 * 60 * 60_000,
+            kind: "event",
+          },
+        }),
+        friend,
+        lat: 35.6762,
+        lng: 139.6503,
+        label: "Tokyo",
+      },
+      {
+        item: makeItem({
+          globalId: "ig:2",
+          publishedAt: now - 60_000,
+          timeRange: {
+            startsAt: now + 2 * 60 * 60_000,
+            endsAt: now + 5 * 60 * 60_000,
+            kind: "travel",
+          },
+        }),
+        friend,
+        lat: 38.7223,
+        lng: -9.1393,
+        label: "Lisbon",
+      },
+    ];
+
+    expect(filterResolvedLocationsByTime(resolved, { now, timeMode: "past" })).toHaveLength(1);
+    expect(getLatestFriendLocationMarkers(resolved, { now, timeMode: "past" })[0]?.label).toBe(
+      "Tokyo",
+    );
+  });
+
+  it("uses the current map view for the friend last-seen card", () => {
+    const now = 1_710_000_000_000;
+    const friend = makeFriend({ id: "friend-1" });
+    const lastSeen = getLastSeenLocationForFriend(
+      [
+        {
+          item: makeItem({
+            globalId: "ig:1",
+            publishedAt: now - 60_000,
+          }),
+          friend,
+          lat: 48.8566,
+          lng: 2.3522,
+          label: "Paris",
+        },
+        {
+          item: makeItem({
+            globalId: "ig:2",
+            publishedAt: now - 30_000,
+            timeRange: {
+              startsAt: now + 2 * 60 * 60_000,
+              endsAt: now + 5 * 60 * 60_000,
+              kind: "travel",
+            },
+          }),
+          friend,
+          lat: 38.7223,
+          lng: -9.1393,
+          label: "Lisbon",
+        },
+      ],
+      friend.id,
+      { now, timeMode: "current" },
+    );
+
+    expect(lastSeen?.label).toBe("Paris");
   });
 });
 

--- a/packages/shared/src/location.ts
+++ b/packages/shared/src/location.ts
@@ -5,7 +5,7 @@
  */
 
 import { friendForAuthor, personForAuthor } from "./friends";
-import type { Account, FeedItem, Friend, MapMode, Person } from "./types.js";
+import type { Account, FeedItem, Friend, MapMode, MapTimeMode, Person, TimeRange } from "./types.js";
 
 // =============================================================================
 // Types
@@ -42,6 +42,11 @@ export interface LocationMarkerSummary {
   label?: string;
   groupCount: number;
   seenAt: number;
+}
+
+export interface LocationMarkerOptions {
+  timeMode?: MapTimeMode;
+  now?: number;
 }
 
 interface NamedLocationSignal {
@@ -206,6 +211,54 @@ function coordinateKey(lat: number, lng: number): string {
   return `${lat.toFixed(4)}:${lng.toFixed(4)}`;
 }
 
+function locationSortTimestamp(
+  item: FeedItem,
+  timeMode: MapTimeMode,
+): number {
+  const timeRange = item.timeRange;
+  if (!timeRange) return item.publishedAt;
+  if (timeMode === "past") {
+    return timeRange.endsAt ?? timeRange.startsAt;
+  }
+  return timeRange.startsAt;
+}
+
+function normalizeTimeRange(timeRange: TimeRange): { startsAt: number; endsAt: number } {
+  return {
+    startsAt: timeRange.startsAt,
+    endsAt: timeRange.endsAt ?? timeRange.startsAt,
+  };
+}
+
+export function isLocationItemVisibleInTimeMode(
+  item: FeedItem,
+  timeMode: MapTimeMode = "current",
+  now: number = Date.now(),
+): boolean {
+  const timeRange = item.timeRange;
+  if (!timeRange) {
+    return timeMode !== "future" && item.publishedAt <= now;
+  }
+
+  const normalized = normalizeTimeRange(timeRange);
+  if (timeMode === "future") {
+    return normalized.startsAt > now;
+  }
+  if (timeMode === "past") {
+    return normalized.endsAt < now;
+  }
+  return normalized.startsAt <= now && normalized.endsAt >= now;
+}
+
+export function filterResolvedLocationsByTime(
+  resolvedItems: ResolvedLocationItem[],
+  options: LocationMarkerOptions = {},
+): ResolvedLocationItem[] {
+  const timeMode = options.timeMode ?? "current";
+  const now = options.now ?? Date.now();
+  return resolvedItems.filter((resolved) => isLocationItemVisibleInTimeMode(resolved.item, timeMode, now));
+}
+
 export function groupResolvedLocations(
   resolvedItems: ResolvedLocationItem[]
 ): LocationMarkerSummary[] {
@@ -248,15 +301,21 @@ export function groupResolvedLocations(
 }
 
 export function getLatestFriendLocationMarkers(
-  resolvedItems: ResolvedLocationItem[]
+  resolvedItems: ResolvedLocationItem[],
+  options: LocationMarkerOptions = {},
 ): LocationMarkerSummary[] {
+  const timeMode = options.timeMode ?? "current";
+  const filteredItems = filterResolvedLocationsByTime(resolvedItems, options);
   const latestByFriend = new Map<string, ResolvedLocationItem>();
 
-  for (const resolved of resolvedItems) {
+  for (const resolved of filteredItems) {
     if (!resolved.friend) continue;
 
     const existing = latestByFriend.get(resolved.friend.id);
-    if (!existing || resolved.item.publishedAt > existing.item.publishedAt) {
+    if (
+      !existing ||
+      locationSortTimestamp(resolved.item, timeMode) > locationSortTimestamp(existing.item, timeMode)
+    ) {
       latestByFriend.set(resolved.friend.id, resolved);
     }
   }
@@ -264,7 +323,7 @@ export function getLatestFriendLocationMarkers(
   return Array.from(latestByFriend.values())
     .map((resolved) => {
       const pointKey = coordinateKey(resolved.lat, resolved.lng);
-      const groupCount = resolvedItems.filter(
+      const groupCount = filteredItems.filter(
         (candidate) =>
           candidate.friend?.id === resolved.friend?.id &&
           coordinateKey(candidate.lat, candidate.lng) === pointKey
@@ -279,21 +338,27 @@ export function getLatestFriendLocationMarkers(
         lng: resolved.lng,
         label: resolved.label,
         groupCount,
-        seenAt: resolved.item.publishedAt,
+        seenAt: locationSortTimestamp(resolved.item, timeMode),
       };
     })
     .sort((a, b) => b.seenAt - a.seenAt);
 }
 
 export function getLatestAuthorLocationMarkers(
-  resolvedItems: ResolvedLocationItem[]
+  resolvedItems: ResolvedLocationItem[],
+  options: LocationMarkerOptions = {},
 ): LocationMarkerSummary[] {
+  const timeMode = options.timeMode ?? "current";
+  const filteredItems = filterResolvedLocationsByTime(resolvedItems, options);
   const latestByAuthor = new Map<string, ResolvedLocationItem>();
 
-  for (const resolved of resolvedItems) {
+  for (const resolved of filteredItems) {
     const authorKey = authorIdentityKey(resolved.item);
     const existing = latestByAuthor.get(authorKey);
-    if (!existing || resolved.item.publishedAt > existing.item.publishedAt) {
+    if (
+      !existing ||
+      locationSortTimestamp(resolved.item, timeMode) > locationSortTimestamp(existing.item, timeMode)
+    ) {
       latestByAuthor.set(authorKey, resolved);
     }
   }
@@ -301,7 +366,7 @@ export function getLatestAuthorLocationMarkers(
   return Array.from(latestByAuthor.entries())
     .map(([authorKey, resolved]) => {
       const pointKey = coordinateKey(resolved.lat, resolved.lng);
-      const groupCount = resolvedItems.filter(
+      const groupCount = filteredItems.filter(
         (candidate) =>
           authorIdentityKey(candidate.item) === authorKey &&
           coordinateKey(candidate.lat, candidate.lng) === pointKey
@@ -316,7 +381,7 @@ export function getLatestAuthorLocationMarkers(
         lng: resolved.lng,
         label: resolved.label,
         groupCount,
-        seenAt: resolved.item.publishedAt,
+        seenAt: locationSortTimestamp(resolved.item, timeMode),
       };
     })
     .sort((a, b) => b.seenAt - a.seenAt);
@@ -324,11 +389,13 @@ export function getLatestAuthorLocationMarkers(
 
 export function getLastSeenLocationForFriend(
   resolvedItems: ResolvedLocationItem[],
-  friendId: string
+  friendId: string,
+  options: LocationMarkerOptions = {},
 ): LocationMarkerSummary | null {
   return (
     getLatestFriendLocationMarkers(
-      resolvedItems.filter((resolved) => resolved.friend?.id === friendId)
+      resolvedItems.filter((resolved) => resolved.friend?.id === friendId),
+      options,
     )[0] ?? null
   );
 }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -57,6 +57,8 @@ export type LocationSource =
   | "text_extraction";
 
 export type MapMode = "friends" | "all_content";
+export type MapTimeMode = "current" | "future" | "past";
+export type TimeRangeKind = "event" | "travel" | "overlap";
 
 // =============================================================================
 // Feed Item
@@ -109,6 +111,18 @@ export interface Location {
   coordinates?: { lat: number; lng: number };
   url?: string;
   source: LocationSource;
+}
+
+/**
+ * Optional time window for location-bearing planning items.
+ * Historical capture can omit this and continue behaving like a "current"
+ * last-seen signal, while planning-oriented sources can attach future or
+ * bounded windows.
+ */
+export interface TimeRange {
+  startsAt: number;
+  endsAt?: number;
+  kind: TimeRangeKind;
 }
 
 /**
@@ -278,6 +292,9 @@ export interface FeedItem {
 
   /** Location information (optional) */
   location?: Location;
+
+  /** Optional time window for planning-aware location playback. */
+  timeRange?: TimeRange;
 
   /** RSS-specific source info (optional) */
   rssSource?: RssSourceInfo;
@@ -535,6 +552,9 @@ export interface DisplayPreferences {
   /** Saved map display mode. Unset means compute a default from available data. */
   mapMode?: MapMode;
 
+  /** Saved map time filter. Unset means default to the current view. */
+  mapTimeMode?: MapTimeMode;
+
   /** Days to keep archived items before pruning (default: 30, 0 = never prune) */
   archivePruneDays: number;
 }
@@ -731,6 +751,7 @@ export function createDefaultPreferences(): UserPreferences {
         showReadInGrayscale: true,
         dualColumnMode: true,
       },
+      mapTimeMode: "current",
       archivePruneDays: 30,
     },
     xCapture: {

--- a/packages/ui/src/components/map/MapView.tsx
+++ b/packages/ui/src/components/map/MapView.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useMemo, useState } from "react";
-import { type MapMode } from "@freed/shared";
+import { type MapMode, type MapTimeMode } from "@freed/shared";
 import { useAppStore } from "../../context/PlatformContext.js";
 import { useResolvedLocations } from "../../hooks/useResolvedLocations.js";
 import { openFriendFromMap, openPostFromMap } from "../../lib/map-navigation.js";
 import { MapSurface } from "./MapSurface.js";
+
+const MAP_TIME_REFRESH_MS = 60_000;
 
 export function MapView() {
   const items = useAppStore((state) => state.items);
@@ -18,22 +20,40 @@ export function MapView() {
   const display = useAppStore((state) => state.preferences.display);
   const updatePreferences = useAppStore((state) => state.updatePreferences);
   const themeId = display.themeId;
+  const savedTimeMode = display.mapTimeMode ?? "current";
+  const [referenceNow, setReferenceNow] = useState(() => Date.now());
+  const [pendingTimeMode, setPendingTimeMode] = useState<MapTimeMode | null>(null);
 
-  const { friendMarkers, allContentMarkers, defaultMode } = useResolvedLocations(
-    items,
-    persons,
-    accounts,
-  );
+  const effectiveTimeMode = pendingTimeMode ?? savedTimeMode;
+  const { friendMarkers, allContentMarkers, defaultMode } = useResolvedLocations(items, persons, accounts, {
+    timeMode: effectiveTimeMode,
+    now: referenceNow,
+  });
   const savedMode = display.mapMode;
   const [pendingMode, setPendingMode] = useState<MapMode | null>(null);
   const effectiveMode = pendingMode ?? savedMode ?? defaultMode;
   const markers = effectiveMode === "friends" ? friendMarkers : allContentMarkers;
 
   useEffect(() => {
+    const interval = window.setInterval(() => {
+      setReferenceNow(Date.now());
+    }, MAP_TIME_REFRESH_MS);
+    return () => {
+      window.clearInterval(interval);
+    };
+  }, []);
+
+  useEffect(() => {
     if (pendingMode && savedMode === pendingMode) {
       setPendingMode(null);
     }
   }, [pendingMode, savedMode]);
+
+  useEffect(() => {
+    if (pendingTimeMode && savedTimeMode === pendingTimeMode) {
+      setPendingTimeMode(null);
+    }
+  }, [pendingTimeMode, savedTimeMode]);
 
   const focusedMarker = useMemo(
     () => markers.find((marker) => marker.friend?.id === selectedFriendId) ?? null,
@@ -51,27 +71,85 @@ export function MapView() {
     });
   };
 
+  const handleTimeModeChange = (timeMode: MapTimeMode) => {
+    setPendingTimeMode(timeMode);
+    void updatePreferences({
+      display: {
+        mapTimeMode: timeMode,
+      },
+    } as Parameters<typeof updatePreferences>[0]).catch(() => {
+      setPendingTimeMode(null);
+    });
+  };
+
+  const emptyState = (() => {
+    if (effectiveTimeMode === "future") {
+      return {
+        title: "No future location windows yet.",
+        body: "Future-dated travel or event plans will appear here once captured.",
+      };
+    }
+    if (effectiveTimeMode === "past") {
+      return {
+        title: effectiveMode === "friends" ? "No friend location history yet." : "No past location pins yet.",
+        body:
+          effectiveMode === "friends"
+            ? "Switch to Current or All content to see active last-seen pins."
+            : "Captured historical check-ins and posts will appear here.",
+      };
+    }
+    return {
+      title: effectiveMode === "friends" ? "No friend pins yet." : "No location pins yet.",
+      body:
+        effectiveMode === "friends"
+          ? "Switch to All content to see the latest locations from followed accounts."
+          : "Followed accounts with valid location data will appear here.",
+    };
+  })();
+
   return (
     <div className="app-theme-shell relative h-full overflow-hidden">
       <div className="pointer-events-none absolute inset-x-0 top-0 z-20 flex justify-center px-4 pt-4">
-        <div className="pointer-events-auto inline-flex items-center gap-1 rounded-full border border-[color:var(--theme-border-subtle)] bg-[color:color-mix(in_oklab,var(--theme-bg-elevated)_88%,transparent)] p-1 shadow-[var(--theme-glow-sm)] backdrop-blur-md">
-          {([
-            ["friends", "Friends"],
-            ["all_content", "All content"],
-          ] as const).map(([mode, label]) => (
-            <button
-              key={mode}
-              type="button"
-              onClick={() => handleModeChange(mode)}
-              className={`rounded-full px-3 py-1.5 text-xs font-medium transition-colors ${
-                effectiveMode === mode
-                  ? "theme-chip-active"
-                  : "theme-chip"
-              }`}
-            >
-              {label}
-            </button>
-          ))}
+        <div className="pointer-events-auto flex flex-wrap items-center justify-center gap-2 rounded-[28px] border border-[color:var(--theme-border-subtle)] bg-[color:color-mix(in_oklab,var(--theme-bg-elevated)_88%,transparent)] p-2 shadow-[var(--theme-glow-sm)] backdrop-blur-md">
+          <div className="inline-flex items-center gap-1 rounded-full border border-[color:var(--theme-border-subtle)] bg-[color:color-mix(in_oklab,var(--theme-bg-surface)_82%,transparent)] p-1">
+            {([
+              ["friends", "Friends"],
+              ["all_content", "All content"],
+            ] as const).map(([mode, label]) => (
+              <button
+                key={mode}
+                type="button"
+                onClick={() => handleModeChange(mode)}
+                className={`rounded-full px-3 py-1.5 text-xs font-medium transition-colors ${
+                  effectiveMode === mode
+                    ? "theme-chip-active"
+                    : "theme-chip"
+                }`}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+          <div className="inline-flex items-center gap-1 rounded-full border border-[color:var(--theme-border-subtle)] bg-[color:color-mix(in_oklab,var(--theme-bg-surface)_82%,transparent)] p-1">
+            {([
+              ["current", "Current"],
+              ["future", "Future"],
+              ["past", "Past"],
+            ] as const).map(([timeMode, label]) => (
+              <button
+                key={timeMode}
+                type="button"
+                onClick={() => handleTimeModeChange(timeMode)}
+                className={`rounded-full px-3 py-1.5 text-xs font-medium transition-colors ${
+                  effectiveTimeMode === timeMode
+                    ? "theme-chip-active"
+                    : "theme-chip"
+                }`}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
         </div>
       </div>
       <MapSurface
@@ -94,16 +172,8 @@ export function MapView() {
             setSearchQuery,
           });
         }}
-        emptyTitle={
-          effectiveMode === "friends"
-            ? "No friend pins yet."
-            : "No location pins yet."
-        }
-        emptyBody={
-          effectiveMode === "friends"
-            ? "Switch to All content to see the latest locations from followed accounts."
-            : "Followed accounts with valid location data will appear here."
-        }
+        emptyTitle={emptyState.title}
+        emptyBody={emptyState.body}
       />
     </div>
   );

--- a/packages/ui/src/hooks/useResolvedLocations.ts
+++ b/packages/ui/src/hooks/useResolvedLocations.ts
@@ -11,6 +11,7 @@ import {
   type Person,
   type LocationMarkerSummary,
   type MapMode,
+  type MapTimeMode,
   type ResolvedLocationItem,
 } from "@freed/shared";
 import { geocode } from "../lib/geocoding.js";
@@ -24,21 +25,30 @@ interface ResolvedLocationsState {
   defaultMode: MapMode;
 }
 
-const EMPTY_STATE: ResolvedLocationsState = {
-  friendMarkers: [],
-  allContentMarkers: [],
+interface ResolvedLocationsCacheState {
+  resolvedItems: ResolvedLocationItem[];
+  lastResolvedAt: number | null;
+  resolvingCount: number;
+}
+
+const EMPTY_STATE: ResolvedLocationsCacheState = {
   resolvedItems: [],
   lastResolvedAt: null,
   resolvingCount: 0,
-  defaultMode: "friends",
 };
 
 export function useResolvedLocations(
   feedItems: FeedItem[],
   persons: Record<string, Person>,
-  accounts: Record<string, Account>
+  accounts: Record<string, Account>,
+  options: {
+    timeMode?: MapTimeMode;
+    now?: number;
+  } = {},
 ): ResolvedLocationsState {
-  const [state, setState] = useState<ResolvedLocationsState>(EMPTY_STATE);
+  const [state, setState] = useState<ResolvedLocationsCacheState>(EMPTY_STATE);
+  const timeMode = options.timeMode ?? "current";
+  const now = options.now;
 
   useEffect(() => {
     let cancelled = false;
@@ -88,16 +98,10 @@ export function useResolvedLocations(
       );
       if (cancelled) return;
 
-      const friendMarkers = getLatestFriendLocationMarkers(resolvedItems);
-      const allContentMarkers = getLatestAuthorLocationMarkers(resolvedItems);
-
       setState({
-        friendMarkers,
-        allContentMarkers,
         resolvedItems,
         resolvingCount: 0,
         lastResolvedAt: Date.now(),
-        defaultMode: getDefaultMapMode(friendMarkers.length, allContentMarkers.length),
       });
     }
 
@@ -108,7 +112,25 @@ export function useResolvedLocations(
     };
   }, [accounts, feedItems, persons]);
 
-  return state;
+  const friendMarkers = useMemo(
+    () => getLatestFriendLocationMarkers(state.resolvedItems, { timeMode, now }),
+    [now, state.resolvedItems, timeMode],
+  );
+  const allContentMarkers = useMemo(
+    () => getLatestAuthorLocationMarkers(state.resolvedItems, { timeMode, now }),
+    [now, state.resolvedItems, timeMode],
+  );
+  const defaultMode = useMemo(
+    () => getDefaultMapMode(friendMarkers.length, allContentMarkers.length),
+    [allContentMarkers.length, friendMarkers.length],
+  );
+
+  return {
+    ...state,
+    friendMarkers,
+    allContentMarkers,
+    defaultMode,
+  };
 }
 
 export function useFriendLastSeenLocation(
@@ -122,7 +144,7 @@ export function useFriendLastSeenLocation(
   const friendMap = useMemo(() => ({ [friend.id]: friend }), [friend]);
   const { resolvedItems, resolvingCount } = useResolvedLocations(feedItems, friendMap, accounts);
   return {
-    lastSeen: getLastSeenLocationForFriend(resolvedItems, friend.id),
+    lastSeen: getLastSeenLocationForFriend(resolvedItems, friend.id, { timeMode: "current" }),
     resolvingCount,
   };
 }

--- a/website/src/app/roadmap/RoadmapContent.tsx
+++ b/website/src/app/roadmap/RoadmapContent.tsx
@@ -765,7 +765,7 @@ const phases: Phase[] = [
     number: 8,
     title: "Friends + Social Graph",
     description:
-      "A people CRM with a canonical Person plus Account identity graph, a stable pan-and-zoom Friends workspace, Google Contacts imports that create friend people by default, suggestion-only same-person review across platforms, and a map that resolves identity through linked accounts while still showing followed accounts at the edge before confirmation.",
+      "A people CRM with a canonical Person plus Account identity graph, a stable pan-and-zoom Friends workspace, Google Contacts imports that create friend people by default, suggestion-only same-person review across platforms, and a map that resolves identity through linked accounts with current, future, and past location filters while still showing followed accounts at the edge before confirmation.",
     status: "current",
     planLink:
       "https://github.com/freed-project/freed/blob/dev/docs/PHASE-8-FRIENDS.md",


### PR DESCRIPTION
(AI Generated).

## Summary
- add optional `FeedItem.timeRange` support for planning-aware location windows
- add persisted `Current`, `Future`, and `Past` map filters on top of the existing `Friends` and `All content` modes
- update shared map filtering, regression coverage, and roadmap documentation for Phase 8.21

## Why
The map stack still treated every location as a simple historical last-seen pin keyed only by `publishedAt`. That blocked future-aware planning work, timeline playback groundwork, and clean integration of sources that carry explicit location windows.

## Impact
- future-dated plans stay out of the default current map until they begin
- expired windows fall into a separate past view instead of overriding the current map
- map time filter state now persists across reloads
- Phase 8 docs and the public roadmap now reflect that future-aware map filtering is complete

## Root Cause
The architecture docs already described a generic `timeRange` model, but the real shared `FeedItem` type and map selection logic never implemented it. The map could only choose the newest pin by `publishedAt`, which made current and future planning data impossible to separate cleanly.

## Validation
- `npm run test:unit --workspace=packages/pwa -- src/lib/map-locations.test.ts`
- `npm run test:unit --workspace=packages/desktop -- src/lib/store-preferences.test.ts`
- `npm run test:e2e --workspace=packages/desktop -- smoke.spec.ts --grep "map time filters switch between current and future location windows"`
- `node node_modules/typescript/bin/tsc -b packages/shared packages/ui packages/desktop packages/pwa --pretty false`
