### PR TITLE
feat: add map timeline scrubber

### DIFF
--- a/docs/PHASE-8-FRIENDS.md
+++ b/docs/PHASE-8-FRIENDS.md
@@ -1,6 +1,6 @@
 # Phase 8: Friends + Social Graph
 
-> **Status:** In Progress, the canonical identity model now uses `Person` plus attached `Account` records, Google Contacts imports create friend persons by default, and the map plus Friends surfaces resolve identity through linked accounts instead of embedded friend sources while the map can already switch between current, future, and past location windows
+> **Status:** In Progress, the canonical identity model now uses `Person` plus attached `Account` records, Google Contacts imports create friend persons by default, and the map plus Friends surfaces resolve identity through linked accounts instead of embedded friend sources while the map can switch between current, future, and past location windows and scrub through historical posts plus future plan ranges
 > **Dependencies:** Phase 7 (Facebook + Instagram capture provide most social content)
 
 ---
@@ -215,6 +215,7 @@ Map popovers now use a wider card layout and deliberately omit the old MapLibre 
 Friends and Map now consume the same shared theme tokens, button treatments, shell backgrounds, surface recipes, and theme-native map palettes as the rest of Freed, so themes like Neon, Midas, Vesper, Ember, and Scriptorium land consistently across the graph, sidebars, popovers, mini-map cards, editor, contact-sync flows, and map basemap itself.
 The shared map now includes a persisted `Friends` / `All content` toggle. It restores the user's last mode from preferences and defaults to `All content` when the library has geolocatable followed accounts but no friend-linked pins yet.
 The shared map now also persists a `Current` / `Future` / `Past` time filter. Future-dated `timeRange` windows stay out of the default current map until they start, upcoming travel or event windows can be previewed directly, and expired windows fall into a separate past view without hijacking the current last-seen map.
+Past and future views now expose a timeline scrubber, so the operator can replay historical location posts or step through upcoming travel windows instead of staring at one collapsed "latest" pin and pretending that counts as time.
 
 ---
 
@@ -243,7 +244,7 @@ The shared map now also persists a `Current` / `Future` / `Past` time filter. Fu
 | 8.19 | Google Contacts source, sync lifecycle, matching, and Friend creation flow | Medium | Done |
 | 8.20 | Wire Map to live sidebar navigation | Low | Done |
 | 8.21 | Add future-aware map filtering for location-bearing items | Medium | Done |
-| 8.22 | Add map timeline scrubber for past and future playback | Medium | Not Started |
+| 8.22 | Add map timeline scrubber for past and future playback | Medium | Done |
 | 8.23 | Replace embedded Friend identity with canonical `Person` + `Account` schema and Automerge migration | High | Done |
 | 8.24 | Backfill followed-account catalog from captured authors and stories | Medium | Done |
 | 8.25 | Google Contacts imports create friend persons with linked contact accounts | Medium | Done |
@@ -289,7 +290,7 @@ The shared map now also persists a `Current` / `Future` / `Past` time filter. Fu
 - [ ] macOS native contact picker (CNContactStore)
 - [x] Map promoted to live sidebar navigation
 - [x] Future-aware map filtering supports past, current, and future location windows
-- [ ] Timeline scrubbing works across historical posts and future planning items
+- [x] Timeline scrubbing works across historical posts and future planning items
 - [ ] Overlaps render as derived read-time views, not persisted source records
 - [ ] Mozi-backed friend/location events appear in Friend identity and map flows
 

--- a/packages/desktop/src/lib/map-playback.test.ts
+++ b/packages/desktop/src/lib/map-playback.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from "vitest";
+import {
+  getLatestFriendLocationMarkers,
+  getLocationTimelineMoments,
+  type FeedItem,
+  type Person,
+  type ResolvedLocationItem,
+} from "@freed/shared";
+
+const NOW = Date.UTC(2026, 3, 18, 19, 0, 0);
+
+const ADA: Person = {
+  id: "friend-ada",
+  name: "Ada Lovelace",
+  relationshipStatus: "friend",
+  careLevel: 5,
+  createdAt: NOW - 30 * 24 * 60 * 60_000,
+  updatedAt: NOW,
+};
+
+function createItem(
+  id: string,
+  publishedAt: number,
+  locationName: string,
+  coordinates: { lat: number; lng: number },
+  timeRange?: FeedItem["timeRange"],
+): FeedItem {
+  return {
+    globalId: id,
+    platform: "instagram",
+    contentType: "post",
+    capturedAt: publishedAt,
+    publishedAt,
+    author: {
+      id: "ada-ig",
+      handle: "ada",
+      displayName: "Ada Lovelace",
+    },
+    content: {
+      text: `Checking in from ${locationName}`,
+      mediaUrls: [],
+      mediaTypes: [],
+    },
+    location: {
+      name: locationName,
+      coordinates,
+      source: "geo_tag",
+    },
+    timeRange,
+    userState: {
+      hidden: false,
+      saved: false,
+      archived: false,
+      tags: [],
+    },
+    topics: [],
+  };
+}
+
+function resolved(
+  item: FeedItem,
+  coordinates: { lat: number; lng: number },
+): ResolvedLocationItem {
+  return {
+    item,
+    friend: ADA,
+    lat: coordinates.lat,
+    lng: coordinates.lng,
+    label: item.location?.name,
+  };
+}
+
+describe("map playback selectors", () => {
+  it("builds scrubber moments from historical posts and future planning windows", () => {
+    const berlin = createItem(
+      "ig:ada:berlin",
+      NOW - 9 * 24 * 60 * 60_000,
+      "Berlin",
+      { lat: 52.52, lng: 13.405 },
+    );
+    const parisTrip = createItem(
+      "ig:ada:paris-trip",
+      NOW - 4 * 24 * 60 * 60_000,
+      "Paris",
+      { lat: 48.8566, lng: 2.3522 },
+      {
+        startsAt: NOW - 4 * 24 * 60 * 60_000,
+        endsAt: NOW - 2 * 24 * 60 * 60_000,
+        kind: "travel",
+      },
+    );
+    const lisbonTrip = createItem(
+      "ig:ada:lisbon-trip",
+      NOW + 2 * 24 * 60 * 60_000,
+      "Lisbon",
+      { lat: 38.7223, lng: -9.1393 },
+      {
+        startsAt: NOW + 2 * 24 * 60 * 60_000,
+        endsAt: NOW + 5 * 24 * 60 * 60_000,
+        kind: "travel",
+      },
+    );
+
+    const resolvedItems = [
+      resolved(berlin, { lat: 52.52, lng: 13.405 }),
+      resolved(parisTrip, { lat: 48.8566, lng: 2.3522 }),
+      resolved(lisbonTrip, { lat: 38.7223, lng: -9.1393 }),
+    ];
+
+    expect(
+      getLocationTimelineMoments(resolvedItems, {
+        timeMode: "past",
+        now: NOW,
+      }),
+    ).toEqual([
+      NOW - 9 * 24 * 60 * 60_000,
+      NOW - 4 * 24 * 60 * 60_000,
+      NOW - 2 * 24 * 60 * 60_000,
+    ]);
+
+    expect(
+      getLocationTimelineMoments(resolvedItems, {
+        timeMode: "future",
+        now: NOW,
+      }),
+    ).toEqual([
+      NOW + 2 * 24 * 60 * 60_000,
+      NOW + 5 * 24 * 60 * 60_000,
+    ]);
+  });
+
+  it("plays back historical posts and future plans at the selected scrubber point", () => {
+    const rome = createItem(
+      "ig:ada:rome",
+      NOW - 10 * 24 * 60 * 60_000,
+      "Rome",
+      { lat: 41.9028, lng: 12.4964 },
+    );
+    const berlin = createItem(
+      "ig:ada:berlin",
+      NOW - 3 * 24 * 60 * 60_000,
+      "Berlin",
+      { lat: 52.52, lng: 13.405 },
+    );
+    const lisbon = createItem(
+      "ig:ada:lisbon-plan",
+      NOW + 2 * 24 * 60 * 60_000,
+      "Lisbon",
+      { lat: 38.7223, lng: -9.1393 },
+      {
+        startsAt: NOW + 2 * 24 * 60 * 60_000,
+        endsAt: NOW + 4 * 24 * 60 * 60_000,
+        kind: "travel",
+      },
+    );
+    const tokyo = createItem(
+      "ig:ada:tokyo-plan",
+      NOW + 6 * 24 * 60 * 60_000,
+      "Tokyo",
+      { lat: 35.6764, lng: 139.65 },
+      {
+        startsAt: NOW + 6 * 24 * 60 * 60_000,
+        endsAt: NOW + 7 * 24 * 60 * 60_000,
+        kind: "travel",
+      },
+    );
+
+    const resolvedItems = [
+      resolved(rome, { lat: 41.9028, lng: 12.4964 }),
+      resolved(berlin, { lat: 52.52, lng: 13.405 }),
+      resolved(lisbon, { lat: 38.7223, lng: -9.1393 }),
+      resolved(tokyo, { lat: 35.6764, lng: 139.65 }),
+    ];
+
+    const latePastMarkers = getLatestFriendLocationMarkers(resolvedItems, {
+      timeMode: "past",
+      now: NOW,
+      playbackAt: NOW - 2 * 24 * 60 * 60_000,
+    });
+    expect(latePastMarkers).toHaveLength(1);
+    expect(latePastMarkers[0]?.label).toBe("Berlin");
+
+    const earlyPastMarkers = getLatestFriendLocationMarkers(resolvedItems, {
+      timeMode: "past",
+      now: NOW,
+      playbackAt: NOW - 8 * 24 * 60 * 60_000,
+    });
+    expect(earlyPastMarkers).toHaveLength(1);
+    expect(earlyPastMarkers[0]?.label).toBe("Rome");
+
+    const lisbonMarkers = getLatestFriendLocationMarkers(resolvedItems, {
+      timeMode: "future",
+      now: NOW,
+      playbackAt: NOW + 3 * 24 * 60 * 60_000,
+    });
+    expect(lisbonMarkers).toHaveLength(1);
+    expect(lisbonMarkers[0]?.label).toBe("Lisbon");
+
+    const tokyoMarkers = getLatestFriendLocationMarkers(resolvedItems, {
+      timeMode: "future",
+      now: NOW,
+      playbackAt: NOW + 6 * 24 * 60 * 60_000 + 12 * 60 * 60_000,
+    });
+    expect(tokyoMarkers).toHaveLength(1);
+    expect(tokyoMarkers[0]?.label).toBe("Tokyo");
+  });
+});

--- a/packages/desktop/tests/e2e/smoke.spec.ts
+++ b/packages/desktop/tests/e2e/smoke.spec.ts
@@ -35,7 +35,7 @@ async function openVisibleMapMarker(
 ) {
   const visibleMarker = page.locator(`.freed-map-marker[aria-label="${label}"]:visible`).first();
   await expect(visibleMarker).toBeVisible({ timeout: 10_000 });
-  await visibleMarker.click();
+  await visibleMarker.click({ force: true });
 
   if (!popupActionName) {
     return;
@@ -1624,6 +1624,201 @@ test("map time filters switch between current and future location windows", asyn
     /theme-chip-active/,
     { timeout: 10_000 },
   );
+});
+
+test("map timeline scrubber replays historical posts and future plans", async ({ app, page }) => {
+  await app.goto();
+  await app.waitForReady();
+  await app.seedFriendLocation();
+  await dismissCloudSyncNudgeIfPresent(page);
+
+  await page.evaluate(async () => {
+    const w = window as Record<string, unknown>;
+    const automerge = w.__FREED_AUTOMERGE__ as {
+      docAddFeedItems: (items: unknown[]) => Promise<void>;
+    };
+    const store = w.__FREED_STORE__ as {
+      getState: () => {
+        items: Array<{ globalId: string }>;
+      };
+    };
+
+    const now = Date.now();
+    await automerge.docAddFeedItems([
+      {
+        globalId: "ig:ada:rome-history",
+        platform: "instagram",
+        contentType: "post",
+        capturedAt: now - 10 * 24 * 60 * 60_000,
+        publishedAt: now - 10 * 24 * 60 * 60_000,
+        author: {
+          id: "ada-ig",
+          handle: "ada",
+          displayName: "Ada Lovelace",
+        },
+        content: {
+          text: "Throwback to Rome.",
+          mediaUrls: [],
+          mediaTypes: [],
+        },
+        location: {
+          name: "Rome",
+          coordinates: { lat: 41.9028, lng: 12.4964 },
+          source: "geo_tag",
+        },
+        userState: {
+          hidden: false,
+          saved: false,
+          archived: false,
+          tags: [],
+        },
+        topics: [],
+      },
+      {
+        globalId: "ig:ada:berlin-history",
+        platform: "instagram",
+        contentType: "post",
+        capturedAt: now - 3 * 24 * 60 * 60_000,
+        publishedAt: now - 3 * 24 * 60 * 60_000,
+        author: {
+          id: "ada-ig",
+          handle: "ada",
+          displayName: "Ada Lovelace",
+        },
+        content: {
+          text: "Berlin was a good idea.",
+          mediaUrls: [],
+          mediaTypes: [],
+        },
+        location: {
+          name: "Berlin",
+          coordinates: { lat: 52.52, lng: 13.405 },
+          source: "geo_tag",
+        },
+        userState: {
+          hidden: false,
+          saved: false,
+          archived: false,
+          tags: [],
+        },
+        topics: [],
+      },
+      {
+        globalId: "ig:ada:lisbon-plan",
+        platform: "instagram",
+        contentType: "post",
+        capturedAt: now,
+        publishedAt: now,
+        author: {
+          id: "ada-ig",
+          handle: "ada",
+          displayName: "Ada Lovelace",
+        },
+        content: {
+          text: "Landing in Lisbon soon.",
+          mediaUrls: [],
+          mediaTypes: [],
+        },
+        location: {
+          name: "Lisbon",
+          coordinates: { lat: 38.7223, lng: -9.1393 },
+          source: "geo_tag",
+        },
+        timeRange: {
+          startsAt: now + 2 * 24 * 60 * 60_000,
+          endsAt: now + 4 * 24 * 60 * 60_000,
+          kind: "travel",
+        },
+        userState: {
+          hidden: false,
+          saved: false,
+          archived: false,
+          tags: [],
+        },
+        topics: [],
+      },
+      {
+        globalId: "ig:ada:tokyo-plan",
+        platform: "instagram",
+        contentType: "post",
+        capturedAt: now,
+        publishedAt: now,
+        author: {
+          id: "ada-ig",
+          handle: "ada",
+          displayName: "Ada Lovelace",
+        },
+        content: {
+          text: "Then straight to Tokyo.",
+          mediaUrls: [],
+          mediaTypes: [],
+        },
+        location: {
+          name: "Tokyo",
+          coordinates: { lat: 35.6764, lng: 139.65 },
+          source: "geo_tag",
+        },
+        timeRange: {
+          startsAt: now + 6 * 24 * 60 * 60_000,
+          endsAt: now + 7 * 24 * 60 * 60_000,
+          kind: "travel",
+        },
+        userState: {
+          hidden: false,
+          saved: false,
+          archived: false,
+          tags: [],
+        },
+        topics: [],
+      },
+    ]);
+
+    await new Promise<void>((resolve, reject) => {
+      const startedAt = Date.now();
+      const interval = window.setInterval(() => {
+        const itemIds = new Set(store.getState().items.map((item) => item.globalId));
+        if (
+          itemIds.has("ig:ada:rome-history")
+          && itemIds.has("ig:ada:berlin-history")
+          && itemIds.has("ig:ada:lisbon-plan")
+          && itemIds.has("ig:ada:tokyo-plan")
+        ) {
+          clearInterval(interval);
+          resolve();
+          return;
+        }
+        if (Date.now() - startedAt > 5_000) {
+          clearInterval(interval);
+          reject(new Error("seed timeout"));
+        }
+      }, 50);
+    });
+  });
+
+  await page.getByRole("button", { name: /^Map/ }).click();
+
+  const futureButton = page.getByRole("button", { name: "Future", exact: true });
+  await futureButton.click();
+  await expect(page.getByTestId("map-timeline-scrubber")).toBeVisible({ timeout: 10_000 });
+
+  await openVisibleMapMarker(page, "Ada Lovelace", "Open Post");
+  await expect(page.getByText("Lisbon", { exact: true })).toBeVisible({ timeout: 10_000 });
+
+  await page.getByLabel("Map timeline scrubber").fill("2");
+  await openVisibleMapMarker(page, "Ada Lovelace", "Open Post");
+  await expect(page.getByText("Tokyo", { exact: true })).toBeVisible({ timeout: 10_000 });
+
+  const pastButton = page.getByRole("button", { name: "Past", exact: true });
+  await pastButton.click();
+  await expect(page.getByTestId("map-timeline-scrubber")).toBeVisible({ timeout: 10_000 });
+
+  await page.getByLabel("Map timeline scrubber").fill("1");
+  await openVisibleMapMarker(page, "Ada Lovelace", "Open Post");
+  await expect(page.getByText("Berlin", { exact: true })).toBeVisible({ timeout: 10_000 });
+
+  await page.getByLabel("Map timeline scrubber").fill("0");
+  await openVisibleMapMarker(page, "Ada Lovelace", "Open Post");
+  await expect(page.getByText("Rome", { exact: true })).toBeVisible({ timeout: 10_000 });
 });
 
 test("Friends view uses the floating detail drawer shell", async ({ app, page }) => {

--- a/packages/shared/src/location.ts
+++ b/packages/shared/src/location.ts
@@ -47,6 +47,7 @@ export interface LocationMarkerSummary {
 export interface LocationMarkerOptions {
   timeMode?: MapTimeMode;
   now?: number;
+  playbackAt?: number | null;
 }
 
 interface NamedLocationSignal {
@@ -250,13 +251,82 @@ export function isLocationItemVisibleInTimeMode(
   return normalized.startsAt <= now && normalized.endsAt >= now;
 }
 
+function isLocationItemVisibleAtPlayback(
+  item: FeedItem,
+  timeMode: MapTimeMode,
+  playbackAt: number,
+  now: number,
+): boolean {
+  if (timeMode === "current") {
+    return isLocationItemVisibleInTimeMode(item, "current", playbackAt);
+  }
+
+  const timeRange = item.timeRange;
+  if (!timeRange) {
+    return timeMode === "past" && item.publishedAt <= playbackAt && item.publishedAt < now;
+  }
+
+  const normalized = normalizeTimeRange(timeRange);
+  if (timeMode === "future" && normalized.startsAt <= now) {
+    return false;
+  }
+
+  return normalized.startsAt <= playbackAt && normalized.endsAt >= playbackAt;
+}
+
 export function filterResolvedLocationsByTime(
   resolvedItems: ResolvedLocationItem[],
   options: LocationMarkerOptions = {},
 ): ResolvedLocationItem[] {
   const timeMode = options.timeMode ?? "current";
   const now = options.now ?? Date.now();
-  return resolvedItems.filter((resolved) => isLocationItemVisibleInTimeMode(resolved.item, timeMode, now));
+  const playbackAt = options.playbackAt ?? null;
+  return resolvedItems.filter((resolved) =>
+    playbackAt === null
+      ? isLocationItemVisibleInTimeMode(resolved.item, timeMode, now)
+      : isLocationItemVisibleAtPlayback(resolved.item, timeMode, playbackAt, now)
+  );
+}
+
+export function getLocationTimelineMoments(
+  resolvedItems: ResolvedLocationItem[],
+  options: LocationMarkerOptions = {},
+): number[] {
+  const timeMode = options.timeMode ?? "current";
+  const now = options.now ?? Date.now();
+  if (timeMode === "current") return [];
+
+  const moments = new Set<number>();
+
+  for (const resolved of resolvedItems) {
+    const timeRange = resolved.item.timeRange;
+    if (!timeRange) {
+      if (timeMode === "past" && resolved.item.publishedAt < now) {
+        moments.add(resolved.item.publishedAt);
+      }
+      continue;
+    }
+
+    const normalized = normalizeTimeRange(timeRange);
+    if (timeMode === "future") {
+      if (normalized.startsAt > now) {
+        moments.add(normalized.startsAt);
+      }
+      if (normalized.endsAt > now) {
+        moments.add(normalized.endsAt);
+      }
+      continue;
+    }
+
+    if (normalized.startsAt < now) {
+      moments.add(normalized.startsAt);
+    }
+    if (normalized.endsAt < now) {
+      moments.add(normalized.endsAt);
+    }
+  }
+
+  return Array.from(moments).sort((a, b) => a - b);
 }
 
 export function groupResolvedLocations(

--- a/packages/ui/src/components/map/MapView.tsx
+++ b/packages/ui/src/components/map/MapView.tsx
@@ -1,11 +1,38 @@
 import { useEffect, useMemo, useState } from "react";
-import { type MapMode, type MapTimeMode } from "@freed/shared";
+import {
+  getDefaultMapMode,
+  getLatestAuthorLocationMarkers,
+  getLatestFriendLocationMarkers,
+  getLocationTimelineMoments,
+  type MapMode,
+  type MapTimeMode,
+} from "@freed/shared";
 import { useAppStore } from "../../context/PlatformContext.js";
 import { useResolvedLocations } from "../../hooks/useResolvedLocations.js";
 import { openFriendFromMap, openPostFromMap } from "../../lib/map-navigation.js";
 import { MapSurface } from "./MapSurface.js";
 
 const MAP_TIME_REFRESH_MS = 60_000;
+const timelineMomentFormatter = new Intl.DateTimeFormat(undefined, {
+  dateStyle: "medium",
+  timeStyle: "short",
+});
+const timelineEdgeFormatter = new Intl.DateTimeFormat(undefined, {
+  month: "short",
+  day: "numeric",
+});
+const DEFAULT_TIMELINE_INDEX: Record<Exclude<MapTimeMode, "current">, number> = {
+  past: -1,
+  future: 0,
+};
+
+function formatTimelineMoment(value: number): string {
+  return timelineMomentFormatter.format(value);
+}
+
+function formatTimelineEdge(value: number): string {
+  return timelineEdgeFormatter.format(value);
+}
 
 export function MapView() {
   const items = useAppStore((state) => state.items);
@@ -23,12 +50,58 @@ export function MapView() {
   const savedTimeMode = display.mapTimeMode ?? "current";
   const [referenceNow, setReferenceNow] = useState(() => Date.now());
   const [pendingTimeMode, setPendingTimeMode] = useState<MapTimeMode | null>(null);
+  const [timelineIndexes, setTimelineIndexes] = useState<Record<Exclude<MapTimeMode, "current">, number | null>>({
+    past: null,
+    future: null,
+  });
 
   const effectiveTimeMode = pendingTimeMode ?? savedTimeMode;
-  const { friendMarkers, allContentMarkers, defaultMode } = useResolvedLocations(items, persons, accounts, {
-    timeMode: effectiveTimeMode,
-    now: referenceNow,
-  });
+  const { resolvedItems } = useResolvedLocations(items, persons, accounts);
+  const timelineMoments = useMemo(
+    () => getLocationTimelineMoments(resolvedItems, { timeMode: effectiveTimeMode, now: referenceNow }),
+    [effectiveTimeMode, referenceNow, resolvedItems],
+  );
+  const selectedTimelineIndex =
+    effectiveTimeMode === "current"
+      ? null
+      : timelineIndexes[effectiveTimeMode];
+  const fallbackTimelineIndex =
+    effectiveTimeMode === "current"
+      ? null
+      : DEFAULT_TIMELINE_INDEX[effectiveTimeMode] < 0
+        ? Math.max(0, timelineMoments.length - 1)
+        : DEFAULT_TIMELINE_INDEX[effectiveTimeMode];
+  const effectiveTimelineIndex =
+    effectiveTimeMode === "current" || timelineMoments.length === 0
+      ? null
+      : Math.min(
+          selectedTimelineIndex ?? fallbackTimelineIndex ?? 0,
+          timelineMoments.length - 1,
+        );
+  const playbackAt =
+    effectiveTimelineIndex === null ? null : timelineMoments[effectiveTimelineIndex] ?? null;
+  const friendMarkers = useMemo(
+    () =>
+      getLatestFriendLocationMarkers(resolvedItems, {
+        timeMode: effectiveTimeMode,
+        now: referenceNow,
+        playbackAt,
+      }),
+    [effectiveTimeMode, playbackAt, referenceNow, resolvedItems],
+  );
+  const allContentMarkers = useMemo(
+    () =>
+      getLatestAuthorLocationMarkers(resolvedItems, {
+        timeMode: effectiveTimeMode,
+        now: referenceNow,
+        playbackAt,
+      }),
+    [effectiveTimeMode, playbackAt, referenceNow, resolvedItems],
+  );
+  const defaultMode = useMemo(
+    () => getDefaultMapMode(friendMarkers.length, allContentMarkers.length),
+    [allContentMarkers.length, friendMarkers.length],
+  );
   const savedMode = display.mapMode;
   const [pendingMode, setPendingMode] = useState<MapMode | null>(null);
   const effectiveMode = pendingMode ?? savedMode ?? defaultMode;
@@ -82,6 +155,14 @@ export function MapView() {
     });
   };
 
+  const handleTimelineScrub = (nextIndex: number) => {
+    if (effectiveTimeMode === "current") return;
+    setTimelineIndexes((current) => ({
+      ...current,
+      [effectiveTimeMode]: nextIndex,
+    }));
+  };
+
   const emptyState = (() => {
     if (effectiveTimeMode === "future") {
       return {
@@ -110,46 +191,75 @@ export function MapView() {
   return (
     <div className="app-theme-shell relative h-full overflow-hidden">
       <div className="pointer-events-none absolute inset-x-0 top-0 z-20 flex justify-center px-4 pt-4">
-        <div className="pointer-events-auto flex flex-wrap items-center justify-center gap-2 rounded-[28px] border border-[color:var(--theme-border-subtle)] bg-[color:color-mix(in_oklab,var(--theme-bg-elevated)_88%,transparent)] p-2 shadow-[var(--theme-glow-sm)] backdrop-blur-md">
-          <div className="inline-flex items-center gap-1 rounded-full border border-[color:var(--theme-border-subtle)] bg-[color:color-mix(in_oklab,var(--theme-bg-surface)_82%,transparent)] p-1">
-            {([
-              ["friends", "Friends"],
-              ["all_content", "All content"],
-            ] as const).map(([mode, label]) => (
-              <button
-                key={mode}
-                type="button"
-                onClick={() => handleModeChange(mode)}
-                className={`rounded-full px-3 py-1.5 text-xs font-medium transition-colors ${
-                  effectiveMode === mode
-                    ? "theme-chip-active"
-                    : "theme-chip"
-                }`}
-              >
-                {label}
-              </button>
-            ))}
+        <div className="pointer-events-auto flex w-full max-w-[min(56rem,calc(100vw-2rem))] flex-col gap-2 rounded-[28px] border border-[color:var(--theme-border-subtle)] bg-[color:color-mix(in_oklab,var(--theme-bg-elevated)_88%,transparent)] p-2 shadow-[var(--theme-glow-sm)] backdrop-blur-md">
+          <div className="flex flex-wrap items-center justify-center gap-2">
+            <div className="inline-flex items-center gap-1 rounded-full border border-[color:var(--theme-border-subtle)] bg-[color:color-mix(in_oklab,var(--theme-bg-surface)_82%,transparent)] p-1">
+              {([
+                ["friends", "Friends"],
+                ["all_content", "All content"],
+              ] as const).map(([mode, label]) => (
+                <button
+                  key={mode}
+                  type="button"
+                  onClick={() => handleModeChange(mode)}
+                  className={`rounded-full px-3 py-1.5 text-xs font-medium transition-colors ${
+                    effectiveMode === mode
+                      ? "theme-chip-active"
+                      : "theme-chip"
+                  }`}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+            <div className="inline-flex items-center gap-1 rounded-full border border-[color:var(--theme-border-subtle)] bg-[color:color-mix(in_oklab,var(--theme-bg-surface)_82%,transparent)] p-1">
+              {([
+                ["current", "Current"],
+                ["future", "Future"],
+                ["past", "Past"],
+              ] as const).map(([timeMode, label]) => (
+                <button
+                  key={timeMode}
+                  type="button"
+                  onClick={() => handleTimeModeChange(timeMode)}
+                  className={`rounded-full px-3 py-1.5 text-xs font-medium transition-colors ${
+                    effectiveTimeMode === timeMode
+                      ? "theme-chip-active"
+                      : "theme-chip"
+                  }`}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
           </div>
-          <div className="inline-flex items-center gap-1 rounded-full border border-[color:var(--theme-border-subtle)] bg-[color:color-mix(in_oklab,var(--theme-bg-surface)_82%,transparent)] p-1">
-            {([
-              ["current", "Current"],
-              ["future", "Future"],
-              ["past", "Past"],
-            ] as const).map(([timeMode, label]) => (
-              <button
-                key={timeMode}
-                type="button"
-                onClick={() => handleTimeModeChange(timeMode)}
-                className={`rounded-full px-3 py-1.5 text-xs font-medium transition-colors ${
-                  effectiveTimeMode === timeMode
-                    ? "theme-chip-active"
-                    : "theme-chip"
-                }`}
-              >
-                {label}
-              </button>
-            ))}
-          </div>
+          {effectiveTimeMode !== "current" && timelineMoments.length > 0 && effectiveTimelineIndex !== null ? (
+            <div
+              className="rounded-[24px] border border-[color:var(--theme-border-subtle)] bg-[color:color-mix(in_oklab,var(--theme-bg-surface)_82%,transparent)] px-4 py-3"
+              data-testid="map-timeline-scrubber"
+            >
+              <div className="flex items-center justify-between gap-3 text-[11px] font-medium uppercase tracking-[0.22em] text-[color:var(--theme-text-muted)]">
+                <span>{effectiveTimeMode === "past" ? "History scrub" : "Future playback"}</span>
+                <span className="text-right normal-case tracking-normal text-[color:var(--theme-text-primary)]">
+                  {formatTimelineMoment(timelineMoments[effectiveTimelineIndex])}
+                </span>
+              </div>
+              <input
+                type="range"
+                min={0}
+                max={Math.max(0, timelineMoments.length - 1)}
+                step={1}
+                value={effectiveTimelineIndex}
+                aria-label="Map timeline scrubber"
+                className="mt-3 h-2 w-full accent-[var(--theme-accent-primary)]"
+                onChange={(event) => handleTimelineScrub(Number.parseInt(event.currentTarget.value, 10))}
+              />
+              <div className="mt-2 flex items-center justify-between text-[11px] text-[color:var(--theme-text-muted)]">
+                <span>{formatTimelineEdge(timelineMoments[0])}</span>
+                <span>{formatTimelineEdge(timelineMoments[timelineMoments.length - 1])}</span>
+              </div>
+            </div>
+          ) : null}
         </div>
       </div>
       <MapSurface

--- a/website/src/app/roadmap/RoadmapContent.tsx
+++ b/website/src/app/roadmap/RoadmapContent.tsx
@@ -765,7 +765,7 @@ const phases: Phase[] = [
     number: 8,
     title: "Friends + Social Graph",
     description:
-      "A people CRM with a canonical Person plus Account identity graph, a stable pan-and-zoom Friends workspace, Google Contacts imports that create friend people by default, suggestion-only same-person review across platforms, and a map that resolves identity through linked accounts with current, future, and past location filters while still showing followed accounts at the edge before confirmation.",
+      "A people CRM with a canonical Person plus Account identity graph, a stable pan-and-zoom Friends workspace, Google Contacts imports that create friend people by default, suggestion-only same-person review across platforms, and a map that resolves identity through linked accounts with current, future, and past filters plus a timeline scrubber for replaying history and upcoming plans while still showing followed accounts at the edge before confirmation.",
     status: "current",
     planLink:
       "https://github.com/freed-project/freed/blob/dev/docs/PHASE-8-FRIENDS.md",


### PR DESCRIPTION
(AI Generated).

## Summary
- add a shared map timeline scrubber for past and future playback
- make shared location marker selection respect an explicit playback timestamp
- add desktop regression coverage for historical and future map replay

## Why
Phase 8 already had time-aware map filtering but still collapsed each non-current view to one latest pin. This finishes the next roadmap slice by letting the map replay historical posts and upcoming plan windows at specific moments.

## Impact
- people can scrub through historical and future map states instead of toggling only between coarse buckets
- shared selectors now support future planning sources without hard-coding source-specific logic
- roadmap docs and website roadmap copy now match the shipped behavior

## Validation
- npm run typecheck --workspace=packages/shared
- npm exec tsc -- --noEmit -p packages/ui/tsconfig.json
- npm exec tsc -- --noEmit -p packages/desktop/tsconfig.json
- npm run test:unit --workspace=packages/desktop -- src/lib/map-playback.test.ts src/lib/store-preferences.test.ts
- npm run test:e2e --workspace=packages/desktop -- tests/e2e/smoke.spec.ts -g "map timeline scrubber replays historical posts and future plans"
