### PR TITLE
fix: dismiss sticky tooltips after pointer activation

### DIFF
--- a/packages/desktop/tests/e2e/smoke.spec.ts
+++ b/packages/desktop/tests/e2e/smoke.spec.ts
@@ -436,6 +436,41 @@ test("desktop sidebar and debug drawer use floating shell cards", async ({ app, 
   expect(debugShellState).toBe(true);
 });
 
+test("desktop toolbar tooltips dismiss after clicking a moving control", async ({ app, page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await app.goto();
+  await app.waitForReady();
+
+  const sidebarToggle = page.getByTestId("desktop-sidebar-toggle");
+  await sidebarToggle.hover();
+  await expect(page.getByRole("tooltip")).toHaveText("Collapse sidebar");
+
+  await sidebarToggle.click();
+
+  await expect.poll(async () => {
+    return page.locator('[role="tooltip"]').count();
+  }).toBe(0);
+
+  await expect(sidebarToggle).toHaveAttribute("aria-label", "Expand sidebar");
+});
+
+test("desktop toolbar tooltips still open on keyboard focus", async ({ app, page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await app.goto();
+  await app.waitForReady();
+
+  const sidebarToggle = page.getByTestId("desktop-sidebar-toggle");
+  for (let attempt = 0; attempt < 4; attempt += 1) {
+    await page.keyboard.press("Tab");
+    if (await sidebarToggle.evaluate((element) => element === document.activeElement)) {
+      break;
+    }
+  }
+
+  await expect(sidebarToggle).toBeFocused();
+  await expect(page.getByRole("tooltip")).toHaveText("Collapse sidebar");
+});
+
 test("main content area renders", async ({ app }) => {
   await app.goto();
   await app.waitForReady();

--- a/packages/ui/src/components/Tooltip.tsx
+++ b/packages/ui/src/components/Tooltip.tsx
@@ -8,6 +8,7 @@ import {
   useState,
   type ReactNode,
   type CSSProperties,
+  type FocusEvent,
 } from "react";
 import { createPortal } from "react-dom";
 
@@ -57,6 +58,8 @@ export function Tooltip({
   });
   const triggerRef = useRef<HTMLSpanElement | null>(null);
   const tooltipRef = useRef<HTMLDivElement | null>(null);
+  const pointerDownRef = useRef(false);
+  const suppressHoverRef = useRef(false);
   const tooltipId = useId();
 
   useEffect(() => {
@@ -175,6 +178,47 @@ export function Tooltip({
     setOpen(true);
   };
 
+  const closeTooltip = () => {
+    setOpen(false);
+  };
+
+  const handlePointerEnter = () => {
+    if (suppressHoverRef.current) {
+      return;
+    }
+
+    openTooltip();
+  };
+
+  const handlePointerLeave = () => {
+    suppressHoverRef.current = false;
+    closeTooltip();
+  };
+
+  const handlePointerDown = () => {
+    pointerDownRef.current = true;
+    suppressHoverRef.current = true;
+    closeTooltip();
+  };
+
+  const handleFocus = (event: FocusEvent<HTMLSpanElement>) => {
+    if (!(event.target instanceof HTMLElement) || !event.target.matches(":focus-visible")) {
+      return;
+    }
+
+    if (pointerDownRef.current) {
+      return;
+    }
+
+    openTooltip();
+  };
+
+  const handleBlur = () => {
+    pointerDownRef.current = false;
+    suppressHoverRef.current = false;
+    closeTooltip();
+  };
+
   const tooltipStyle = {
     left: `${position.left}px`,
     top: `${position.top}px`,
@@ -188,10 +232,11 @@ export function Tooltip({
         ref={triggerRef}
         aria-describedby={open ? tooltipId : undefined}
         className={["relative inline-flex", className].filter(Boolean).join(" ")}
-        onMouseEnter={openTooltip}
-        onMouseLeave={() => setOpen(false)}
-        onFocus={openTooltip}
-        onBlur={() => setOpen(false)}
+        onPointerEnter={handlePointerEnter}
+        onPointerLeave={handlePointerLeave}
+        onPointerDown={handlePointerDown}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
       >
         {children}
       </span>


### PR DESCRIPTION
(AI Generated).

## What changed
- Updated the shared tooltip wrapper to close on pointer activation and suppress hover reopen until the pointer leaves.
- Kept keyboard-triggered tooltip behavior working by only opening on focus-visible focus.
- Added desktop E2E coverage for click dismissal and keyboard focus behavior.

## Why
Toolbar tooltips could stay open after clicking controls that changed state or layout, which left the tooltip stranded on screen and made the UI feel broken.

## Validation
- node ../../node_modules/playwright/cli.js test --grep "desktop sidebar and debug drawer use floating shell cards|desktop toolbar tooltips dismiss after clicking a moving control|desktop toolbar tooltips still open on keyboard focus"
