### PR TITLE
feat: add friends lens to feed toolbar

### DIFF
--- a/docs/PHASE-8-FRIENDS.md
+++ b/docs/PHASE-8-FRIENDS.md
@@ -214,6 +214,7 @@ Friend avatars now inherit a theme-authored tint across the Friends graph and ma
 Map popovers now use a wider card layout and deliberately omit the old MapLibre tail, so place names and actions fit cleanly without the popup looking like a speech bubble from a cheaper app.
 Friends and Map now consume the same shared theme tokens, button treatments, shell backgrounds, surface recipes, and theme-native map palettes as the rest of Freed, so themes like Neon, Midas, Vesper, Ember, and Scriptorium land consistently across the graph, sidebars, popovers, mini-map cards, editor, contact-sync flows, and map basemap itself.
 The shared map now includes a persisted `Friends` / `All content` toggle. It restores the user's last mode from preferences and defaults to `All content` when the library has geolocatable followed accounts but no friend-linked pins yet.
+That same `Friends` / `All content` lens now lives in the shared toolbar for feed surfaces too, so the operator can collapse Freed down to real-world people without leaving the main reading views.
 The shared map now also persists a `Current` / `Future` / `Past` time filter. Future-dated `timeRange` windows stay out of the default current map until they start, upcoming travel or event windows can be previewed directly, and expired windows fall into a separate past view without hijacking the current last-seen map.
 Past and future views now expose a timeline scrubber, so the operator can replay historical location posts or step through upcoming travel windows instead of staring at one collapsed "latest" pin and pretending that counts as time.
 
@@ -253,6 +254,7 @@ Past and future views now expose a timeline scrubber, so the operator can replay
 | 8.24 | Support Mozi-backed friend/location events in identity and map flows | Medium | Not Started |
 | 8.25 | Include Google contact sync state in desktop disaster-recovery snapshots | Low | Done |
 | 8.26 | Add persisted `Friends` / `All content` map modes with latest-author pins | Medium | Done |
+| 8.27 | Extend the shared `Friends` / `All content` toolbar lens to feed views | Medium | Done |
 
 ---
 
@@ -284,6 +286,7 @@ Past and future views now expose a timeline scrubber, so the operator can replay
 - [x] Sample data refresh rebuilds a 25-friend social graph with linked profiles and recent map activity
 - [x] Sidebar shows live counts for Friends and recent friend location updates on Map
 - [x] Map supports persisted `Friends` and `All content` modes
+- [x] Feed views share the same persisted `Friends` and `All content` toolbar lens
 - [x] Map defaults to `All content` when there are valid author pins but no friend-linked pins
 - [x] `All content` mode shows the latest valid location per followed account
 - [x] Generic Instagram story labels are recovered from preserved location URLs or excluded from the map

--- a/packages/pwa/tests/app.spec.ts
+++ b/packages/pwa/tests/app.spec.ts
@@ -129,11 +129,13 @@ async function seedFriendLocation(
     const w = window as Record<string, unknown>;
     const automerge = w.__FREED_AUTOMERGE__ as {
       docAddFriend: (friend: unknown) => Promise<void>;
+      docAddAccount: (account: unknown) => Promise<void>;
       docAddFeedItems: (items: unknown[]) => Promise<void>;
     };
     const store = w.__FREED_STORE__ as {
       getState: () => {
         friends: Record<string, unknown>;
+        accounts: Record<string, unknown>;
         items: unknown[];
         setActiveView: (view: string) => void;
         setSelectedFriend: (id: string | null) => void;
@@ -144,15 +146,22 @@ async function seedFriendLocation(
     await automerge.docAddFriend({
       id: "friend-ada",
       name: "Ada Lovelace",
-      sources: [
-        {
-          platform: "instagram",
-          authorId: "ada-ig",
-          handle: "ada",
-          displayName: "Ada Lovelace",
-        },
-      ],
+      relationshipStatus: "friend",
       careLevel: 4,
+      createdAt: now,
+      updatedAt: now,
+    });
+    await automerge.docAddAccount({
+      id: "social:instagram:ada-ig",
+      personId: "friend-ada",
+      kind: "social",
+      provider: "instagram",
+      externalId: "ada-ig",
+      handle: "ada",
+      displayName: "Ada Lovelace",
+      firstSeenAt: now,
+      lastSeenAt: now,
+      discoveredFrom: "captured_item",
       createdAt: now,
       updatedAt: now,
     });
@@ -193,7 +202,11 @@ async function seedFriendLocation(
       const startedAt = Date.now();
       const interval = window.setInterval(() => {
         const state = store.getState();
-        if (state.friends["friend-ada"] && state.items.length > 0) {
+        if (
+          state.friends["friend-ada"]
+          && state.accounts["social:instagram:ada-ig"]
+          && state.items.length > 0
+        ) {
           clearInterval(interval);
           resolve();
           return;
@@ -208,6 +221,132 @@ async function seedFriendLocation(
     const state = store.getState();
     state.setActiveView("friends");
     state.setSelectedFriend("friend-ada");
+  });
+}
+
+async function seedFriendFeedLens(
+  page: import("@playwright/test").Page,
+): Promise<void> {
+  await waitForPwaDocumentReady(page);
+  await page.evaluate(async () => {
+    const w = window as Record<string, unknown>;
+    const automerge = w.__FREED_AUTOMERGE__ as {
+      docAddFriend: (friend: unknown) => Promise<void>;
+      docAddAccount: (account: unknown) => Promise<void>;
+      docAddFeedItems: (items: unknown[]) => Promise<void>;
+    };
+    const store = w.__FREED_STORE__ as {
+      getState: () => {
+        friends: Record<string, unknown>;
+        accounts: Record<string, unknown>;
+        items: Array<{ globalId: string }>;
+        setActiveView: (view: string) => void;
+        setSelectedFriend: (id: string | null) => void;
+        setSelectedItem: (id: string | null) => void;
+      };
+    };
+
+    const now = Date.now();
+    await automerge.docAddFriend({
+      id: "friend-grace",
+      name: "Grace Hopper",
+      relationshipStatus: "friend",
+      careLevel: 4,
+      createdAt: now,
+      updatedAt: now,
+    });
+    await automerge.docAddAccount({
+      id: "social:linkedin:grace-li",
+      personId: "friend-grace",
+      kind: "social",
+      provider: "linkedin",
+      externalId: "grace-li",
+      handle: "grace",
+      displayName: "Grace Hopper",
+      firstSeenAt: now,
+      lastSeenAt: now,
+      discoveredFrom: "captured_item",
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    await automerge.docAddFeedItems([
+      {
+        globalId: "li:grace:lens",
+        platform: "linkedin",
+        contentType: "post",
+        capturedAt: now,
+        publishedAt: now - 30_000,
+        author: {
+          id: "grace-li",
+          handle: "grace",
+          displayName: "Grace Hopper",
+        },
+        content: {
+          text: "Grace friend toggle scenario",
+          mediaUrls: [],
+          mediaTypes: [],
+        },
+        userState: {
+          hidden: false,
+          saved: false,
+          archived: false,
+          tags: [],
+        },
+        topics: [],
+      },
+      {
+        globalId: "x:outsider:lens",
+        platform: "x",
+        contentType: "post",
+        capturedAt: now,
+        publishedAt: now - 20_000,
+        author: {
+          id: "outsider-x",
+          handle: "outsider",
+          displayName: "Outsider Account",
+        },
+        content: {
+          text: "Outsider toggle scenario",
+          mediaUrls: [],
+          mediaTypes: [],
+        },
+        userState: {
+          hidden: false,
+          saved: false,
+          archived: false,
+          tags: [],
+        },
+        topics: [],
+      },
+    ]);
+
+    await new Promise<void>((resolve, reject) => {
+      const startedAt = Date.now();
+      const interval = window.setInterval(() => {
+        const state = store.getState();
+        const itemIds = new Set(state.items.map((item) => item.globalId));
+        if (
+          state.friends["friend-grace"]
+          && state.accounts["social:linkedin:grace-li"]
+          && itemIds.has("li:grace:lens")
+          && itemIds.has("x:outsider:lens")
+        ) {
+          clearInterval(interval);
+          resolve();
+          return;
+        }
+        if (Date.now() - startedAt > 5_000) {
+          clearInterval(interval);
+          reject(new Error("friend feed lens seed timeout"));
+        }
+      }, 50);
+    });
+
+    const state = store.getState();
+    state.setActiveView("feed");
+    state.setSelectedFriend(null);
+    state.setSelectedItem(null);
   });
 }
 
@@ -1065,6 +1204,26 @@ test.describe("FREED PWA", () => {
     expect(mainBox).not.toBeNull();
     expect(mapBox).not.toBeNull();
     expect(Math.round(mapBox!.y)).toBe(Math.round(mainBox!.y));
+  });
+
+  test("toolbar identity toggle narrows the feed to linked friends", async ({ page }) => {
+    await page.goto("/");
+    await acceptLegalGate(page);
+    await seedFriendFeedLens(page);
+
+    await expect(page.getByText("Grace friend toggle scenario")).toBeVisible();
+    await expect(page.getByText("Outsider toggle scenario")).toBeVisible();
+
+    const toolbar = page.getByTestId("workspace-toolbar");
+    await toolbar.getByRole("button", { name: "Friends", exact: true }).click();
+
+    await expect(page.getByText("Grace friend toggle scenario")).toBeVisible();
+    await expect(page.getByText("Outsider toggle scenario")).toHaveCount(0);
+
+    await toolbar.getByRole("button", { name: "All content", exact: true }).click();
+
+    await expect(page.getByText("Grace friend toggle scenario")).toBeVisible();
+    await expect(page.getByText("Outsider toggle scenario")).toBeVisible();
   });
 
   test("friend detail shows the last seen location card when location data exists", async ({

--- a/packages/shared/src/friends.ts
+++ b/packages/shared/src/friends.ts
@@ -121,6 +121,17 @@ export function personForAuthor(
   return persons[account.personId] ?? null;
 }
 
+export function isFriendAuthoredItem(
+  item: FeedItem,
+  persons: Record<string, Person>,
+  accounts: Record<string, Account>,
+  friends: Record<string, Friend>,
+): boolean {
+  const person = personForAuthor(persons, accounts, item.platform, item.author.id);
+  if (person) return person.relationshipStatus === "friend";
+  return friendForAuthor(friends, item.platform, item.author.id) !== null;
+}
+
 function legacySourceKeys(friend: Pick<Friend, "sources">): Set<string> {
   return new Set(friend.sources.map((source) => `${source.platform}:${source.authorId}`));
 }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -552,6 +552,9 @@ export interface DisplayPreferences {
   /** Saved map display mode. Unset means compute a default from available data. */
   mapMode?: MapMode;
 
+  /** Saved feed identity mode. Unset means show all captured content. */
+  friendsMode?: MapMode;
+
   /** Saved map time filter. Unset means default to the current view. */
   mapTimeMode?: MapTimeMode;
 
@@ -751,6 +754,7 @@ export function createDefaultPreferences(): UserPreferences {
         showReadInGrayscale: true,
         dualColumnMode: true,
       },
+      friendsMode: "all_content",
       mapTimeMode: "current",
       archivePruneDays: 30,
     },

--- a/packages/ui/src/components/feed/FeedView.tsx
+++ b/packages/ui/src/components/feed/FeedView.tsx
@@ -225,6 +225,9 @@ export function FeedView() {
   const canAddFeeds = !!addRssFeed;
   const items = useAppStore((s) => s.items);
   const feeds = useAppStore((s) => s.feeds);
+  const persons = useAppStore((s) => s.persons);
+  const accounts = useAppStore((s) => s.accounts);
+  const friends = useAppStore((s) => s.friends);
   const activeFilter = useAppStore((s) => s.activeFilter);
   const searchQuery = useAppStore((s) => s.searchQuery);
   const searchCorpusVersion = useAppStore((s) => s.searchCorpusVersion);
@@ -237,6 +240,7 @@ export function FeedView() {
   const unarchiveSavedItems = useAppStore((s) => s.unarchiveSavedItems);
   const deleteAllArchived = useAppStore((s) => s.deleteAllArchived);
   const archivePruneDays = useAppStore((s) => s.preferences.display.archivePruneDays);
+  const friendsMode = useAppStore((s) => s.preferences.display.friendsMode ?? "all_content");
 
   const handleItemSave = useCallback(
     (item: FeedItem) => toggleSaved(item.globalId),
@@ -302,6 +306,10 @@ export function FeedView() {
     searchQuery,
     activeFilter,
     searchCorpusVersion,
+    friendsMode,
+    persons,
+    accounts,
+    friends,
   );
 
   const scopeLabel = useMemo(() => getFilterLabel(activeFilter, feeds), [activeFilter, feeds]);

--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -100,6 +100,8 @@ export function Header({ onMenuClick, sidebarExpanded, onSidebarToggle }: Header
 
   const items = useAppStore((s) => s.items);
   const feeds = useAppStore((s) => s.feeds);
+  const persons = useAppStore((s) => s.persons);
+  const accounts = useAppStore((s) => s.accounts);
   const friends = useAppStore((s) => s.friends);
   const activeView = useAppStore((s) => s.activeView);
   const activeFilter = useAppStore((s) => s.activeFilter);
@@ -125,6 +127,10 @@ export function Header({ onMenuClick, sidebarExpanded, onSidebarToggle }: Header
     searchQuery,
     activeFilter,
     searchCorpusVersion,
+    display.friendsMode ?? "all_content",
+    persons,
+    accounts,
+    friends,
   );
   const selectedItem = useMemo(
     () => (selectedItemId ? items.find((item) => item.globalId === selectedItemId) ?? null : null),
@@ -143,6 +149,8 @@ export function Header({ onMenuClick, sidebarExpanded, onSidebarToggle }: Header
   );
   const effectiveMapMode = display.mapMode
     ?? getDefaultMapMode(mappedFriendCount, mappedAllContentCount);
+  const effectiveFriendsMode = display.friendsMode ?? "all_content";
+  const showIdentityModeControls = activeView === "feed" || activeView === "map";
 
   const unreadCount =
     activeFilter.savedOnly || activeFilter.archivedOnly
@@ -207,6 +215,14 @@ export function Header({ onMenuClick, sidebarExpanded, onSidebarToggle }: Header
     scopeLabel,
     selectedItem,
   ]);
+
+  const handleIdentityModeChange = useCallback((mode: "friends" | "all_content") => {
+    void updatePreferences({
+      display: {
+        ...(activeView === "map" ? { mapMode: mode } : { friendsMode: mode }),
+      },
+    } as Parameters<typeof updatePreferences>[0]);
+  }, [activeView, updatePreferences]);
 
   const handleCloseReader = useCallback(() => {
     if (display.reading.dualColumnMode && !isMobile && selectedItemId) {
@@ -668,6 +684,37 @@ export function Header({ onMenuClick, sidebarExpanded, onSidebarToggle }: Header
                   {HeaderSyncIndicator ? (
                     <div className="hidden md:flex">
                       <HeaderSyncIndicator />
+                    </div>
+                  ) : null}
+                </ToolbarAnimatedSlot>
+
+                <ToolbarAnimatedSlot visible={showIdentityModeControls} width="10.75rem" className="flex min-w-0">
+                  {showIdentityModeControls ? (
+                    <div className="flex min-w-0 items-center gap-2 overflow-x-auto py-1">
+                      <div className="inline-flex shrink-0 items-center gap-1 rounded-full border border-[color:var(--theme-border-subtle)] bg-[color:color-mix(in_oklab,var(--theme-bg-surface)_86%,transparent)] p-1">
+                        {([
+                          ["friends", "Friends"],
+                          ["all_content", "All content"],
+                        ] as const).map(([mode, label]) => {
+                          const isActive = activeView === "map"
+                            ? effectiveMapMode === mode
+                            : effectiveFriendsMode === mode;
+
+                          return (
+                            <button
+                              key={`${activeView}-${mode}`}
+                              type="button"
+                              onClick={() => handleIdentityModeChange(mode)}
+                              {...getToolbarControlProps()}
+                              className={`rounded-full px-3 py-1.5 text-xs font-medium transition-colors ${
+                                isActive ? "theme-chip-active" : "theme-chip"
+                              }`}
+                            >
+                              {label}
+                            </button>
+                          );
+                        })}
+                      </div>
                     </div>
                   ) : null}
                 </ToolbarAnimatedSlot>

--- a/packages/ui/src/components/map/MapView.tsx
+++ b/packages/ui/src/components/map/MapView.tsx
@@ -4,7 +4,6 @@ import {
   getLatestAuthorLocationMarkers,
   getLatestFriendLocationMarkers,
   getLocationTimelineMoments,
-  type MapMode,
   type MapTimeMode,
 } from "@freed/shared";
 import { useAppStore } from "../../context/PlatformContext.js";
@@ -103,8 +102,7 @@ export function MapView() {
     [allContentMarkers.length, friendMarkers.length],
   );
   const savedMode = display.mapMode;
-  const [pendingMode, setPendingMode] = useState<MapMode | null>(null);
-  const effectiveMode = pendingMode ?? savedMode ?? defaultMode;
+  const effectiveMode = savedMode ?? defaultMode;
   const markers = effectiveMode === "friends" ? friendMarkers : allContentMarkers;
 
   useEffect(() => {
@@ -117,12 +115,6 @@ export function MapView() {
   }, []);
 
   useEffect(() => {
-    if (pendingMode && savedMode === pendingMode) {
-      setPendingMode(null);
-    }
-  }, [pendingMode, savedMode]);
-
-  useEffect(() => {
     if (pendingTimeMode && savedTimeMode === pendingTimeMode) {
       setPendingTimeMode(null);
     }
@@ -132,17 +124,6 @@ export function MapView() {
     () => markers.find((marker) => marker.friend?.id === selectedFriendId) ?? null,
     [markers, selectedFriendId]
   );
-
-  const handleModeChange = (mode: MapMode) => {
-    setPendingMode(mode);
-    void updatePreferences({
-      display: {
-        mapMode: mode,
-      },
-    } as Parameters<typeof updatePreferences>[0]).catch(() => {
-      setPendingMode(null);
-    });
-  };
 
   const handleTimeModeChange = (timeMode: MapTimeMode) => {
     setPendingTimeMode(timeMode);
@@ -193,25 +174,6 @@ export function MapView() {
       <div className="pointer-events-none absolute inset-x-0 top-0 z-20 flex justify-center px-4 pt-4">
         <div className="pointer-events-auto flex w-full max-w-[min(56rem,calc(100vw-2rem))] flex-col gap-2 rounded-[28px] border border-[color:var(--theme-border-subtle)] bg-[color:color-mix(in_oklab,var(--theme-bg-elevated)_88%,transparent)] p-2 shadow-[var(--theme-glow-sm)] backdrop-blur-md">
           <div className="flex flex-wrap items-center justify-center gap-2">
-            <div className="inline-flex items-center gap-1 rounded-full border border-[color:var(--theme-border-subtle)] bg-[color:color-mix(in_oklab,var(--theme-bg-surface)_82%,transparent)] p-1">
-              {([
-                ["friends", "Friends"],
-                ["all_content", "All content"],
-              ] as const).map(([mode, label]) => (
-                <button
-                  key={mode}
-                  type="button"
-                  onClick={() => handleModeChange(mode)}
-                  className={`rounded-full px-3 py-1.5 text-xs font-medium transition-colors ${
-                    effectiveMode === mode
-                      ? "theme-chip-active"
-                      : "theme-chip"
-                  }`}
-                >
-                  {label}
-                </button>
-              ))}
-            </div>
             <div className="inline-flex items-center gap-1 rounded-full border border-[color:var(--theme-border-subtle)] bg-[color:color-mix(in_oklab,var(--theme-bg-surface)_82%,transparent)] p-1">
               {([
                 ["current", "Current"],

--- a/packages/ui/src/hooks/useSearchResults.ts
+++ b/packages/ui/src/hooks/useSearchResults.ts
@@ -28,8 +28,8 @@
 
 import { useMemo, useRef } from "react";
 import MiniSearch from "minisearch";
-import { filterFeedItems, sortByPriority } from "@freed/shared";
-import type { FeedItem, FilterOptions } from "@freed/shared";
+import { filterFeedItems, isFriendAuthoredItem, sortByPriority } from "@freed/shared";
+import type { Account, FeedItem, FilterOptions, Friend, Person } from "@freed/shared";
 
 const SEARCH_PRESERVED_TEXT_LIMIT = 1_200;
 
@@ -126,6 +126,10 @@ export function useSearchResults(
   searchQuery: string,
   activeFilter: FilterOptions,
   searchCorpusVersion: number,
+  identityMode: "friends" | "all_content",
+  persons: Record<string, Person>,
+  accounts: Record<string, Account>,
+  friends: Record<string, Friend>,
 ): SearchResults {
   const trimmedQuery = searchQuery.trim();
 
@@ -151,9 +155,14 @@ export function useSearchResults(
   }
 
   return useMemo(() => {
+    const filterIdentityMode = (candidateItems: FeedItem[]): FeedItem[] =>
+      identityMode === "friends"
+        ? candidateItems.filter((item) => isFriendAuthoredItem(item, persons, accounts, friends))
+        : candidateItems;
+
     if (!trimmedQuery) {
       // Normal feed: apply active filter then sort by priority. No MiniSearch work.
-      const filtered = filterFeedItems(items, activeFilter);
+      const filtered = filterFeedItems(filterIdentityMode(items), activeFilter);
       const byFeed = activeFilter.feedUrl
         ? filtered.filter((item) => item.rssSource?.feedUrl === activeFilter.feedUrl)
         : filtered;
@@ -176,7 +185,7 @@ export function useSearchResults(
       .map((r) => itemById.get(r.id as string))
       .filter((item): item is FeedItem => item !== undefined);
 
-    const filtered = filterFeedItems(matchingItems, activeFilter);
+    const filtered = filterFeedItems(filterIdentityMode(matchingItems), activeFilter);
     const byFeed = activeFilter.feedUrl
       ? filtered.filter((item) => item.rssSource?.feedUrl === activeFilter.feedUrl)
       : filtered;
@@ -188,5 +197,5 @@ export function useSearchResults(
     );
 
     return { filteredItems: sorted, isSearching: true, resultCount: sorted.length };
-  }, [items, trimmedQuery, activeFilter, searchCorpusVersion]);
+  }, [accounts, activeFilter, friends, identityMode, items, persons, searchCorpusVersion, trimmedQuery]);
 }

--- a/website/src/app/roadmap/RoadmapContent.tsx
+++ b/website/src/app/roadmap/RoadmapContent.tsx
@@ -765,7 +765,7 @@ const phases: Phase[] = [
     number: 8,
     title: "Friends + Social Graph",
     description:
-      "A people CRM with a canonical Person plus Account identity graph, a stable pan-and-zoom Friends workspace, Google Contacts imports that create friend people by default, suggestion-only same-person review across platforms, and a map that resolves identity through linked accounts with current, future, and past filters plus a timeline scrubber for replaying history and upcoming plans while still showing followed accounts at the edge before confirmation.",
+      "A people CRM with a canonical Person plus Account identity graph, a stable pan-and-zoom Friends workspace, Google Contacts imports that create friend people by default, suggestion-only same-person review across platforms, a shared Friends and All content toolbar lens across feed surfaces, and a map that resolves identity through linked accounts with current, future, and past filters plus a timeline scrubber for replaying history and upcoming plans while still showing followed accounts at the edge before confirmation.",
     status: "current",
     planLink:
       "https://github.com/freed-project/freed/blob/dev/docs/PHASE-8-FRIENDS.md",


### PR DESCRIPTION
(AI Generated). 

## What changed
- added a persisted `Friends / All content` lens to feed surfaces through the shared toolbar
- filtered feed and search results to linked friends when the personal lens is active
- moved the map identity toggle responsibility into the shared header to avoid duplicate controls
- added a PWA regression for the feed lens and updated the Phase 8 roadmap docs

## Why
Freed should stay useful for following interesting things online without losing its center of gravity around real-world relationships. This brings the personal lens into the main reading surfaces instead of keeping it isolated to map-centric flows.

## Impact
- feed views can now collapse to friend-linked posts without changing the active source scope
- the chosen feed lens persists between sessions
- map views keep the same mode, but the toggle now lives in the shared toolbar chrome

## Validation
- `/Users/aubreyfalconer/.nvm/versions/node/v24.14.1/bin/npm run test --workspace=packages/pwa -- --grep "toolbar identity toggle narrows the feed to linked friends"`
- `/Users/aubreyfalconer/.nvm/versions/node/v24.14.1/bin/npm run typecheck --workspace=packages/pwa`
