### PR TITLE
fix: stabilize website theme preview selector

### DIFF
--- a/docs/PHASE-1-FOUNDATION.md
+++ b/docs/PHASE-1-FOUNDATION.md
@@ -139,7 +139,7 @@ Next.js 15 (App Router) site deployed to Vercel at freed.wtf.
 - Marketing site no longer inherits the shared app scrollbar chrome, while Freed Desktop and Freed Web keep the themed scrollbar treatment inside app shells and dialogs
 - Theme-aware form controls across the marketing site and shared UI package
 - Shared theme-aware tooltip primitive across the marketing site and shared UI package
-- Homepage footer theme picker uses the same preview swatches as Freed Desktop, with hover tooltips for each theme
+- Homepage footer theme picker uses the same preview swatches as Freed Desktop, with hover tooltips for each theme plus live hover and focus previews that blur between themes and snap back unless the user clicks
 - Five authored themes: Neon, Midas, Vesper, Ember, and Scriptorium
 - Synced theme preference with `Neon` as the default for fresh installs
 - Mobile-responsive design

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -149,6 +149,10 @@ html[data-theme="neon"] {
     0 0 30px rgb(var(--theme-accent-secondary-rgb) / 0.3),
     0 0 60px rgb(var(--theme-accent-primary-rgb) / 0.16),
     0 0 100px rgb(var(--theme-accent-tertiary-rgb) / 0.08);
+  --theme-transition-blur: 0px;
+  --theme-transition-brightness: 1;
+  --theme-transition-saturate: 1;
+  --theme-transition-duration: 170ms;
 
   --sidebar-width: 240px;
   --card-radius: 8px;
@@ -674,6 +678,22 @@ body {
   letter-spacing: var(--theme-body-letter-spacing);
   line-height: var(--theme-body-line-height);
   font-weight: var(--theme-body-font-weight);
+  filter:
+    blur(var(--theme-transition-blur))
+    brightness(var(--theme-transition-brightness))
+    saturate(var(--theme-transition-saturate));
+  transition: filter var(--theme-transition-duration) cubic-bezier(0.22, 1, 0.36, 1);
+  will-change: filter;
+}
+
+html[data-theme-transition] body {
+  overflow: clip;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  body {
+    transition: none;
+  }
 }
 
 .font-logo {

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -150,9 +150,9 @@ html[data-theme="neon"] {
     0 0 60px rgb(var(--theme-accent-primary-rgb) / 0.16),
     0 0 100px rgb(var(--theme-accent-tertiary-rgb) / 0.08);
   --theme-transition-blur: 0px;
-  --theme-transition-brightness: 1;
+  --theme-transition-opacity: 1;
   --theme-transition-saturate: 1;
-  --theme-transition-duration: 170ms;
+  --theme-transition-duration: 210ms;
 
   --sidebar-width: 240px;
   --card-radius: 8px;
@@ -678,20 +678,11 @@ body {
   letter-spacing: var(--theme-body-letter-spacing);
   line-height: var(--theme-body-line-height);
   font-weight: var(--theme-body-font-weight);
-  filter:
-    blur(var(--theme-transition-blur))
-    brightness(var(--theme-transition-brightness))
-    saturate(var(--theme-transition-saturate));
-  transition: filter var(--theme-transition-duration) cubic-bezier(0.22, 1, 0.36, 1);
-  will-change: filter;
-}
-
-html[data-theme-transition] body {
-  overflow: clip;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  body {
+  .theme-shell,
+  .app-theme-shell {
     transition: none;
   }
 }
@@ -792,6 +783,14 @@ html[data-theme="scriptorium"] .theme-page-heading-accent {
   background-repeat: no-repeat;
   background-size: cover;
   color: var(--theme-text-primary);
+  filter:
+    blur(var(--theme-transition-blur))
+    saturate(var(--theme-transition-saturate));
+  opacity: var(--theme-transition-opacity);
+  transition:
+    filter var(--theme-transition-duration) cubic-bezier(0.22, 1, 0.36, 1),
+    opacity var(--theme-transition-duration) cubic-bezier(0.22, 1, 0.36, 1);
+  will-change: filter, opacity;
 }
 
 .bg-gradient-orbs {

--- a/packages/ui/src/lib/theme.ts
+++ b/packages/ui/src/lib/theme.ts
@@ -1,3 +1,4 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   DEFAULT_THEME_ID,
   THEME_DEFINITIONS,
@@ -17,6 +18,97 @@ export {
 };
 
 export const THEME_STORAGE_KEY = "freed-theme";
+const THEME_TRANSITION_BLUR_OUT_MS = 90;
+const THEME_TRANSITION_BLUR_IN_MS = 170;
+const THEME_TRANSITION_CLEANUP_BUFFER_MS = 40;
+const THEME_TRANSITION_BLUR_AMOUNT = "16px";
+
+type ThemeTransitionPhase = "blur-out" | "blur-in";
+
+interface ThemeTransitionState {
+  cleanupTimer: number | null;
+  switchTimer: number | null;
+  token: number;
+}
+
+interface ThemePreviewControllerOptions {
+  committedThemeId: ThemeId;
+  onCommitTheme: (themeId: ThemeId) => void;
+}
+
+interface ThemePreviewController {
+  activeThemeId: ThemeId;
+  committedThemeId: ThemeId;
+  previewThemeId: ThemeId | null;
+  commitTheme: (themeId: ThemeId) => void;
+  previewTheme: (themeId: ThemeId) => void;
+  revertPreview: () => void;
+}
+
+const themeTransitionState: ThemeTransitionState = {
+  cleanupTimer: null,
+  switchTimer: null,
+  token: 0,
+};
+
+function getDocumentRoot(): HTMLElement | null {
+  if (typeof document === "undefined") {
+    return null;
+  }
+  return document.documentElement;
+}
+
+function clearThemeTransitionTimers(): void {
+  if (typeof window === "undefined") {
+    themeTransitionState.cleanupTimer = null;
+    themeTransitionState.switchTimer = null;
+    return;
+  }
+
+  if (themeTransitionState.switchTimer !== null) {
+    window.clearTimeout(themeTransitionState.switchTimer);
+    themeTransitionState.switchTimer = null;
+  }
+
+  if (themeTransitionState.cleanupTimer !== null) {
+    window.clearTimeout(themeTransitionState.cleanupTimer);
+    themeTransitionState.cleanupTimer = null;
+  }
+}
+
+function setThemeTransitionPhase(phase: ThemeTransitionPhase, durationMs: number): void {
+  const root = getDocumentRoot();
+  if (!root) {
+    return;
+  }
+
+  root.dataset.themeTransition = phase;
+  root.style.setProperty("--theme-transition-duration", `${durationMs}ms`);
+  root.style.setProperty("--theme-transition-blur", THEME_TRANSITION_BLUR_AMOUNT);
+  root.style.setProperty("--theme-transition-brightness", "0.97");
+  root.style.setProperty("--theme-transition-saturate", "0.92");
+}
+
+function clearThemeTransitionStyles(): void {
+  const root = getDocumentRoot();
+  if (!root) {
+    return;
+  }
+
+  root.removeAttribute("data-theme-transition");
+  root.style.removeProperty("--theme-transition-duration");
+  root.style.removeProperty("--theme-transition-blur");
+  root.style.removeProperty("--theme-transition-brightness");
+  root.style.removeProperty("--theme-transition-saturate");
+}
+
+function prefersReducedMotion(): boolean {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+    return false;
+  }
+
+  return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}
 
 export function getStoredThemeId(): ThemeId {
   if (typeof window === "undefined") return DEFAULT_THEME_ID;
@@ -47,6 +139,55 @@ export function applyThemeToDocument(themeId: ThemeId): void {
   }
 }
 
+function transitionThemeOnDocument(themeId: ThemeId): void {
+  const root = getDocumentRoot();
+  if (!root) {
+    return;
+  }
+
+  const currentThemeId = resolveThemeId(root.dataset.theme || DEFAULT_THEME_ID);
+  if (currentThemeId === themeId) {
+    clearThemeTransitionTimers();
+    clearThemeTransitionStyles();
+    return;
+  }
+
+  if (prefersReducedMotion()) {
+    clearThemeTransitionTimers();
+    clearThemeTransitionStyles();
+    applyThemeToDocument(themeId);
+    return;
+  }
+
+  clearThemeTransitionTimers();
+  themeTransitionState.token += 1;
+  const transitionToken = themeTransitionState.token;
+
+  setThemeTransitionPhase("blur-out", THEME_TRANSITION_BLUR_OUT_MS);
+  themeTransitionState.switchTimer = window.setTimeout(() => {
+    if (themeTransitionState.token !== transitionToken) {
+      return;
+    }
+
+    applyThemeToDocument(themeId);
+    setThemeTransitionPhase("blur-in", THEME_TRANSITION_BLUR_IN_MS);
+    root.style.setProperty("--theme-transition-blur", "0px");
+    root.style.setProperty("--theme-transition-brightness", "1");
+    root.style.setProperty("--theme-transition-saturate", "1");
+
+    themeTransitionState.cleanupTimer = window.setTimeout(() => {
+      if (themeTransitionState.token !== transitionToken) {
+        return;
+      }
+
+      clearThemeTransitionStyles();
+      themeTransitionState.cleanupTimer = null;
+    }, THEME_TRANSITION_BLUR_IN_MS + THEME_TRANSITION_CLEANUP_BUFFER_MS);
+
+    themeTransitionState.switchTimer = null;
+  }, THEME_TRANSITION_BLUR_OUT_MS);
+}
+
 export function persistTheme(themeId: ThemeId): void {
   if (typeof window === "undefined") return;
   window.localStorage.setItem(THEME_STORAGE_KEY, themeId);
@@ -56,4 +197,57 @@ export function bootstrapDocumentTheme(): ThemeId {
   const themeId = getStoredThemeId();
   applyThemeToDocument(themeId);
   return themeId;
+}
+
+export function useThemePreviewController({
+  committedThemeId,
+  onCommitTheme,
+}: ThemePreviewControllerOptions): ThemePreviewController {
+  const [previewThemeId, setPreviewThemeId] = useState<ThemeId | null>(null);
+
+  useEffect(() => {
+    if (previewThemeId === committedThemeId) {
+      setPreviewThemeId(null);
+    }
+  }, [committedThemeId, previewThemeId]);
+
+  const activeThemeId = previewThemeId ?? committedThemeId;
+
+  const previewTheme = useCallback((themeId: ThemeId) => {
+    if (themeId === activeThemeId) {
+      return;
+    }
+
+    setPreviewThemeId(themeId === committedThemeId ? null : themeId);
+    transitionThemeOnDocument(themeId);
+  }, [activeThemeId, committedThemeId]);
+
+  const revertPreview = useCallback(() => {
+    setPreviewThemeId((currentPreviewThemeId) => {
+      if (currentPreviewThemeId === null) {
+        return currentPreviewThemeId;
+      }
+
+      transitionThemeOnDocument(committedThemeId);
+      return null;
+    });
+  }, [committedThemeId]);
+
+  const commitTheme = useCallback((themeId: ThemeId) => {
+    if (themeId !== activeThemeId) {
+      transitionThemeOnDocument(themeId);
+    }
+
+    setPreviewThemeId(null);
+    onCommitTheme(themeId);
+  }, [activeThemeId, onCommitTheme]);
+
+  return useMemo(() => ({
+    activeThemeId,
+    committedThemeId,
+    previewThemeId,
+    commitTheme,
+    previewTheme,
+    revertPreview,
+  }), [activeThemeId, commitTheme, committedThemeId, previewTheme, previewThemeId, revertPreview]);
 }

--- a/packages/ui/src/lib/theme.ts
+++ b/packages/ui/src/lib/theme.ts
@@ -19,9 +19,9 @@ export {
 
 export const THEME_STORAGE_KEY = "freed-theme";
 const THEME_TRANSITION_BLUR_OUT_MS = 90;
-const THEME_TRANSITION_BLUR_IN_MS = 170;
+const THEME_TRANSITION_BLUR_IN_MS = 210;
 const THEME_TRANSITION_CLEANUP_BUFFER_MS = 40;
-const THEME_TRANSITION_BLUR_AMOUNT = "16px";
+const THEME_TRANSITION_BLUR_AMOUNT = "7px";
 
 type ThemeTransitionPhase = "blur-out" | "blur-in";
 
@@ -85,8 +85,8 @@ function setThemeTransitionPhase(phase: ThemeTransitionPhase, durationMs: number
   root.dataset.themeTransition = phase;
   root.style.setProperty("--theme-transition-duration", `${durationMs}ms`);
   root.style.setProperty("--theme-transition-blur", THEME_TRANSITION_BLUR_AMOUNT);
-  root.style.setProperty("--theme-transition-brightness", "0.97");
-  root.style.setProperty("--theme-transition-saturate", "0.92");
+  root.style.setProperty("--theme-transition-opacity", "0.965");
+  root.style.setProperty("--theme-transition-saturate", "0.985");
 }
 
 function clearThemeTransitionStyles(): void {
@@ -98,7 +98,7 @@ function clearThemeTransitionStyles(): void {
   root.removeAttribute("data-theme-transition");
   root.style.removeProperty("--theme-transition-duration");
   root.style.removeProperty("--theme-transition-blur");
-  root.style.removeProperty("--theme-transition-brightness");
+  root.style.removeProperty("--theme-transition-opacity");
   root.style.removeProperty("--theme-transition-saturate");
 }
 
@@ -172,7 +172,7 @@ function transitionThemeOnDocument(themeId: ThemeId): void {
     applyThemeToDocument(themeId);
     setThemeTransitionPhase("blur-in", THEME_TRANSITION_BLUR_IN_MS);
     root.style.setProperty("--theme-transition-blur", "0px");
-    root.style.setProperty("--theme-transition-brightness", "1");
+    root.style.setProperty("--theme-transition-opacity", "1");
     root.style.setProperty("--theme-transition-saturate", "1");
 
     themeTransitionState.cleanupTimer = window.setTimeout(() => {

--- a/website/src/components/HeroAnimation.tsx
+++ b/website/src/components/HeroAnimation.tsx
@@ -339,7 +339,7 @@ export default function HeroAnimation({
 }: {
   compact?: boolean;
 }) {
-  const { themeId } = useTheme();
+  const { activeThemeId } = useTheme();
   const logos = useMemo(() => buildLogos(), []);
   const centerBoxSize = compact ? COMPACT_CENTER_BOX_SIZE : DESKTOP_CENTER_BOX_SIZE;
   const centerBoxBounds = useMemo(
@@ -366,7 +366,7 @@ export default function HeroAnimation({
   return (
     <div className="relative w-full aspect-square">
       <svg
-        key={themeId}
+        key={activeThemeId}
         viewBox={`${viewBoxMin} ${viewBoxMin} ${viewBoxSize} ${viewBoxSize}`}
         className="w-full h-full"
       >

--- a/website/src/components/ThemeSelector.tsx
+++ b/website/src/components/ThemeSelector.tsx
@@ -1,5 +1,10 @@
 "use client";
 
+import {
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import { ThemePreviewButton } from "@freed/ui/components/ThemePreviewButton";
 import { Tooltip } from "@freed/ui/components/Tooltip";
 import { THEME_DEFINITIONS, useTheme } from "@/context/ThemeContext";
@@ -8,43 +13,100 @@ interface ThemeSelectorProps {
   compact?: boolean;
 }
 
+interface LockedRect {
+  height: number;
+  left: number;
+  top: number;
+  width: number;
+}
+
 export default function ThemeSelector({ compact = false }: ThemeSelectorProps) {
-  const { activeThemeId, setThemeId, previewTheme, revertPreview } = useTheme();
+  const { activeThemeId, themeId, setThemeId, previewTheme, revertPreview } = useTheme();
   const gapClassName = compact ? "gap-2" : "gap-3";
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
+  const [pointerPreviewThemeId, setPointerPreviewThemeId] = useState<string | null>(null);
+  const [lockedRect, setLockedRect] = useState<LockedRect | null>(null);
+  const shouldLockPosition = compact && pointerPreviewThemeId !== null && activeThemeId !== themeId;
+
+  useLayoutEffect(() => {
+    if (!shouldLockPosition) {
+      setLockedRect(null);
+      return;
+    }
+
+    const wrapper = wrapperRef.current;
+    if (!wrapper) {
+      return;
+    }
+
+    const rect = wrapper.getBoundingClientRect();
+    setLockedRect({
+      height: rect.height,
+      left: rect.left,
+      top: rect.top,
+      width: rect.width,
+    });
+  }, [shouldLockPosition]);
+
+  function clearPointerPreview() {
+    setPointerPreviewThemeId(null);
+    revertPreview();
+  }
 
   return (
-    <div className="flex flex-col">
-      <h4 className="mb-4 text-text-primary font-semibold">Theme</h4>
+    <div
+      ref={wrapperRef}
+      className="relative"
+      style={lockedRect ? { height: `${lockedRect.height}px` } : undefined}
+    >
       <div
-        className={`flex flex-wrap items-center ${gapClassName}`}
-        onMouseLeave={revertPreview}
-        onBlurCapture={(event) => {
-          const nextFocused = event.relatedTarget;
-          if (nextFocused && event.currentTarget.contains(nextFocused)) {
-            return;
-          }
-
-          revertPreview();
-        }}
+        className="flex flex-col"
+        style={lockedRect ? {
+          left: `${lockedRect.left}px`,
+          position: "fixed",
+          top: `${lockedRect.top}px`,
+          width: `${lockedRect.width}px`,
+          zIndex: 40,
+        } : undefined}
       >
-        {THEME_DEFINITIONS.map((theme) => (
-          <Tooltip
-            key={theme.id}
-            side="top"
-            label={theme.name}
-            description={theme.description}
-            className="h-[2.2rem] items-center sm:h-[2.4rem]"
-          >
-            <ThemePreviewButton
-              theme={theme}
-              active={activeThemeId === theme.id}
-              variant="compact"
-              onMouseEnter={() => previewTheme(theme.id)}
-              onFocus={() => previewTheme(theme.id)}
-              onClick={() => setThemeId(theme.id)}
-            />
-          </Tooltip>
-        ))}
+        <h4 className="mb-4 text-text-primary font-semibold">Theme</h4>
+        <div
+          className={`flex flex-wrap items-center ${gapClassName}`}
+          onMouseLeave={clearPointerPreview}
+          onBlurCapture={(event) => {
+            const nextFocused = event.relatedTarget;
+            if (nextFocused && event.currentTarget.contains(nextFocused)) {
+              return;
+            }
+
+            clearPointerPreview();
+          }}
+        >
+          {THEME_DEFINITIONS.map((theme) => (
+            <Tooltip
+              key={theme.id}
+              side="top"
+              label={theme.name}
+              description={theme.description}
+              className="h-[2.2rem] items-center sm:h-[2.4rem]"
+            >
+              <ThemePreviewButton
+                theme={theme}
+                active={themeId === theme.id}
+                variant="compact"
+                onMouseEnter={() => {
+                  setPointerPreviewThemeId(theme.id);
+                  previewTheme(theme.id);
+                }}
+                onFocus={() => previewTheme(theme.id)}
+                onClick={() => {
+                  setPointerPreviewThemeId(null);
+                  setThemeId(theme.id);
+                }}
+              />
+            </Tooltip>
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/website/src/components/ThemeSelector.tsx
+++ b/website/src/components/ThemeSelector.tsx
@@ -9,13 +9,24 @@ interface ThemeSelectorProps {
 }
 
 export default function ThemeSelector({ compact = false }: ThemeSelectorProps) {
-  const { themeId, setThemeId } = useTheme();
+  const { activeThemeId, setThemeId, previewTheme, revertPreview } = useTheme();
   const gapClassName = compact ? "gap-2" : "gap-3";
 
   return (
     <div className="flex flex-col">
       <h4 className="mb-4 text-text-primary font-semibold">Theme</h4>
-      <div className={`flex flex-wrap items-center ${gapClassName}`}>
+      <div
+        className={`flex flex-wrap items-center ${gapClassName}`}
+        onMouseLeave={revertPreview}
+        onBlurCapture={(event) => {
+          const nextFocused = event.relatedTarget;
+          if (nextFocused && event.currentTarget.contains(nextFocused)) {
+            return;
+          }
+
+          revertPreview();
+        }}
+      >
         {THEME_DEFINITIONS.map((theme) => (
           <Tooltip
             key={theme.id}
@@ -26,8 +37,10 @@ export default function ThemeSelector({ compact = false }: ThemeSelectorProps) {
           >
             <ThemePreviewButton
               theme={theme}
-              active={themeId === theme.id}
+              active={activeThemeId === theme.id}
               variant="compact"
+              onMouseEnter={() => previewTheme(theme.id)}
+              onFocus={() => previewTheme(theme.id)}
               onClick={() => setThemeId(theme.id)}
             />
           </Tooltip>

--- a/website/src/context/ThemeContext.tsx
+++ b/website/src/context/ThemeContext.tsx
@@ -11,46 +11,55 @@ import {
 import {
   DEFAULT_THEME_ID,
   THEME_DEFINITIONS,
-  getThemeCssVariables,
-  getThemeDefinition,
-  resolveThemeId,
   type ThemeId,
 } from "@freed/shared/themes";
-
-const THEME_STORAGE_KEY = "freed-theme";
+import {
+  applyThemeToDocument,
+  getStoredThemeId,
+  useThemePreviewController,
+} from "@freed/ui/lib/theme";
 
 interface ThemeContextValue {
   themeId: ThemeId;
+  activeThemeId: ThemeId;
   setThemeId: (themeId: ThemeId) => void;
+  previewTheme: (themeId: ThemeId) => void;
+  revertPreview: () => void;
 }
 
 const ThemeContext = createContext<ThemeContextValue | null>(null);
 
 export function ThemeProvider({ children }: { children: ReactNode }) {
   const [themeId, setThemeId] = useState<ThemeId>(DEFAULT_THEME_ID);
+  const {
+    activeThemeId,
+    commitTheme,
+    previewTheme,
+    revertPreview,
+  } = useThemePreviewController({
+    committedThemeId: themeId,
+    onCommitTheme: setThemeId,
+  });
 
   useEffect(() => {
-    const nextTheme = resolveThemeId(window.localStorage.getItem(THEME_STORAGE_KEY));
+    const nextTheme = getStoredThemeId();
     setThemeId(nextTheme);
   }, []);
 
   useEffect(() => {
-    const root = document.documentElement;
-    root.dataset.theme = themeId;
-    root.style.colorScheme = getThemeDefinition(themeId).surface;
-    const cssVariables = getThemeCssVariables(themeId);
-    for (const [name, value] of Object.entries(cssVariables)) {
-      root.style.setProperty(name, value);
-    }
-    window.localStorage.setItem(THEME_STORAGE_KEY, themeId);
+    applyThemeToDocument(themeId);
+    window.localStorage.setItem("freed-theme", themeId);
   }, [themeId]);
 
   const value = useMemo(
     () => ({
+      activeThemeId,
       themeId,
-      setThemeId,
+      setThemeId: commitTheme,
+      previewTheme,
+      revertPreview,
     }),
-    [themeId],
+    [activeThemeId, commitTheme, previewTheme, revertPreview, themeId],
   );
 
   return (


### PR DESCRIPTION
(AI Generated).

## What changed
- brought the shared theme preview controller and blur transition helper into the `www` branch workspace packages
- updated the footer theme selector to preview themes on hover and focus, then revert on exit unless clicked
- switched the marketing theme context and hero animation to respect the live active theme during preview
- updated the foundation phase doc

## Why
The marketing selector only committed a theme on click, so it did not match the richer live-preview behavior now used in the app.

## Validation
- `PATH="/Users/aubreyfalconer/dev/freed-theme-hover-preview-www/node_modules/.bin:$PATH" npm run build` in `website`

## Notes
- This is the `www` half of the coordinated theme preview work.
