### PR TITLE
fix: finish build feature with draft PR publish flow

### DIFF
--- a/.agents/skills/freed-build-feature/SKILL.md
+++ b/.agents/skills/freed-build-feature/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: freed-build-feature
-description: Scaffold product work in a dev-based worktree, implement it, verify it, and launch a preview only when the work actually needs one. Use for Desktop, PWA, shared packages, sync, capture packages, release tooling, app behavior, and product docs targeting dev. Do not use for public marketing changes targeting www.
+description: Scaffold product work in a dev-based worktree, implement it, verify it with focused checks, and finish by committing, pushing, and opening a draft PR. Use for Desktop, PWA, shared packages, sync, capture packages, release tooling, app behavior, and product docs targeting dev. Do not use for public marketing changes targeting www.
 disable-model-invocation: true
 ---
 
 # Build Feature
 
-Create a product worktree branch from the latest remote `dev`, implement the feature or fix, verify it, and launch the relevant preview only when the work reaches final verification or the user explicitly asks for one.
+Create a product worktree branch from the latest remote `dev`, implement the feature or fix, verify it with the lightest checks that actually cover the touched surface, and finish by committing the work, pushing the branch, and opening a draft PR to `dev`.
 
 ## Workflow
 
@@ -19,12 +19,18 @@ Create a product worktree branch from the latest remote `dev`, implement the fea
 5. Create a new worktree branch from `origin/dev` using `./scripts/worktree-add.sh ../freed-<slug> -b <branch> origin/dev --install auto --target <desktop|pwa|shared>`.
 6. Bootstrap dependencies only when the work actually needs them with `./scripts/worktree-bootstrap.sh <worktree> --target <desktop|pwa|shared>`.
 7. Implement the requested change.
-8. Verify with focused tests, then broader checks when shared behavior changed.
-9. Launch a preview only when final verification needs one or the user explicitly asks:
+8. Verify with focused checks first.
+   - Prefer changed-surface tests, lint, typecheck, or desktop E2E coverage that directly exercises the feature.
+   - Do not default every feature thread to full-repo validation when the touched surface is narrow.
+9. Escalate to broader checks only when the change crosses package boundaries or affects shared behavior.
+   - Shared schema, release tooling, shared UI primitives, and cross-app flows should earn broader validation before publish.
+   - Reserve the heaviest validation and release-shape smoke tests for `dev` integration and release prep, not every branch.
+10. Launch a preview only when final verification needs one or the user explicitly asks:
    - For PWA work, use `./scripts/worktree-preview.sh pwa`.
    - For desktop work, default to `./scripts/worktree-preview.sh desktop`.
    - Use `./scripts/worktree-preview.sh desktop --native` only when Tauri-native behavior itself matters.
-10. Open a PR targeting `dev` when the work is ready.
+11. Finish the branch with `./scripts/worktree-publish.sh --title "<conventional-commit title>" --summary "<user-facing change>" --test "<focused check>"`.
+12. Confirm the branch is pushed to `origin` and the new PR targeting `dev` is in draft state.
 
 ## Scope
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,15 @@ The helper now:
 - installs dependencies with the npm binary that matches the active Node runtime
 - avoids the broken "last worktree wins" assumption that can install into the wrong checkout
 
+When the branch is ready to publish, use:
+
+```bash
+./scripts/worktree-publish.sh --title "fix: describe the change" --summary "What changed for the user" --test "Focused check you ran"
+```
+
+That stages the worktree, creates the commit when needed, pushes the branch to
+`origin`, and opens a draft PR.
+
 ### Marketing Website (freed.wtf)
 
 ```bash

--- a/docs/PHASE-1-FOUNDATION.md
+++ b/docs/PHASE-1-FOUNDATION.md
@@ -243,7 +243,9 @@ The preview and production deploy helpers now resolve `npm` and `npx` from the
 active Node toolchain first, so they do not accidentally pick up an older
 system npm from the shell `PATH`.
 
-Local product worktrees now also default to deferred bootstrap. `./scripts/worktree-add.sh` can record `--install none|auto|full` and `--target desktop|pwa|website|shared`, `./scripts/worktree-bootstrap.sh` handles the on-demand install, `./scripts/worktree-preview.sh` launches tracked previews with one desktop slot and one web slot per repo, and `./scripts/worktree-cleanup.sh` stops tracked previews before removing merged worktrees.
+Local product worktrees now also default to deferred bootstrap. `./scripts/worktree-add.sh` can record `--install none|auto|full` and `--target desktop|pwa|website|shared`, `./scripts/worktree-bootstrap.sh` handles the on-demand install, `./scripts/worktree-preview.sh` launches tracked previews with one desktop slot and one web slot per repo, `./scripts/worktree-publish.sh` stages the finished branch, commits it, pushes it, and opens a draft PR to `dev`, and `./scripts/worktree-cleanup.sh` stops tracked previews before removing merged worktrees.
+
+Feature worktrees also now default to layered validation. Narrow feature branches should run focused checks that cover the touched surface, while broader integration passes stay attached to shared-surface changes, `dev` integration, and release prep.
 
 ---
 
@@ -274,7 +276,7 @@ Local product worktrees now also default to deferred bootstrap. `./scripts/workt
 | 1.9  | Generate RSS feed at build time              | ✓      |
 | 1.10 | Add public legal docs and versioned website clickwrap | ✓ |
 | 1.11 | Add unified shared theme system across website, Freed Desktop, and PWA | ✓ |
-| 1.12 | Add deferred worktree bootstrap and tracked local preview tooling | ✓ |
+| 1.12 | Add deferred worktree bootstrap, tracked local preview tooling, draft PR publish helper, and layered feature validation guidance | ✓ |
 
 ---
 

--- a/scripts/worktree-publish.sh
+++ b/scripts/worktree-publish.sh
@@ -1,0 +1,246 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  ./scripts/worktree-publish.sh --title "<conventional-commit title>" [--summary "<bullet>"]... [--test "<bullet>"]... [--base <branch>] [--body-file <path>]
+
+Stages local changes, commits them when needed, pushes the current branch to origin,
+and opens a draft pull request.
+EOF
+}
+
+require_command() {
+  local command_name="$1"
+
+  if ! command -v "${command_name}" >/dev/null 2>&1; then
+    echo "Error: required command '${command_name}' is not available." >&2
+    exit 1
+  fi
+}
+
+ensure_conventional_title() {
+  local title="$1"
+
+  if [[ ! "${title}" =~ ^(feat|fix|chore|docs|refactor|perf|style):\ .+ ]]; then
+    echo "Error: title must use a Conventional Commit prefix such as 'feat:' or 'fix:'." >&2
+    exit 1
+  fi
+}
+
+current_branch() {
+  git branch --show-current
+}
+
+ensure_publishable_branch() {
+  local branch_name="$1"
+
+  if [[ -z "${branch_name}" ]]; then
+    echo "Error: cannot publish from a detached HEAD." >&2
+    exit 1
+  fi
+
+  case "${branch_name}" in
+    main|dev|www)
+      echo "Error: refusing to publish directly from protected branch '${branch_name}'." >&2
+      exit 1
+      ;;
+  esac
+}
+
+has_worktree_changes() {
+  [[ -n "$(git status --short)" ]]
+}
+
+branch_has_unique_commits() {
+  local base_branch="$1"
+
+  [[ "$(git rev-list --count "origin/${base_branch}..HEAD")" -gt 0 ]]
+}
+
+build_body() {
+  local title="$1"
+  shift
+
+  local summaries=()
+  local tests=()
+  local mode="summary"
+  local item
+
+  for item in "$@"; do
+    case "${item}" in
+      --summary)
+        mode="summary"
+        ;;
+      --test)
+        mode="test"
+        ;;
+      *)
+        if [[ "${mode}" == "summary" ]]; then
+          summaries+=("${item}")
+        else
+          tests+=("${item}")
+        fi
+        ;;
+    esac
+  done
+
+  if [[ ${#summaries[@]} -eq 0 ]]; then
+    summaries+=("${title#*: }")
+  fi
+
+  if [[ ${#tests[@]} -eq 0 ]]; then
+    tests+=("Not run, no focused validation was recorded.")
+  fi
+
+  printf '%s\n\n' '(AI Generated).'
+  printf '## Summary\n'
+  for item in "${summaries[@]}"; do
+    printf -- '- %s\n' "${item}"
+  done
+  printf '\n## Testing\n'
+  for item in "${tests[@]}"; do
+    printf -- '- %s\n' "${item}"
+  done
+}
+
+TITLE=""
+BASE_BRANCH="dev"
+BODY_FILE=""
+SUMMARY_ARGS=()
+TEST_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --title)
+      [[ $# -ge 2 ]] || { echo "Error: --title requires a value." >&2; exit 1; }
+      TITLE="$2"
+      shift 2
+      ;;
+    --base)
+      [[ $# -ge 2 ]] || { echo "Error: --base requires a value." >&2; exit 1; }
+      BASE_BRANCH="$2"
+      shift 2
+      ;;
+    --summary)
+      [[ $# -ge 2 ]] || { echo "Error: --summary requires a value." >&2; exit 1; }
+      SUMMARY_ARGS+=("$2")
+      shift 2
+      ;;
+    --test)
+      [[ $# -ge 2 ]] || { echo "Error: --test requires a value." >&2; exit 1; }
+      TEST_ARGS+=("$2")
+      shift 2
+      ;;
+    --body-file)
+      [[ $# -ge 2 ]] || { echo "Error: --body-file requires a value." >&2; exit 1; }
+      BODY_FILE="$2"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Error: unexpected argument '$1'." >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "${TITLE}" ]]; then
+  usage
+  exit 1
+fi
+
+require_command git
+require_command gh
+
+ensure_conventional_title "${TITLE}"
+
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  echo "Error: current directory is not inside a git repository." >&2
+  exit 1
+fi
+
+git fetch origin "${BASE_BRANCH}" >/dev/null 2>&1
+
+BRANCH_NAME="$(current_branch)"
+ensure_publishable_branch "${BRANCH_NAME}"
+
+if has_worktree_changes; then
+  git add -A
+  if git diff --cached --quiet; then
+    echo "Error: no staged changes found after git add -A." >&2
+    exit 1
+  fi
+  git commit -m "${TITLE}"
+elif ! branch_has_unique_commits "${BASE_BRANCH}"; then
+  echo "Error: no local changes and no commits ahead of origin/${BASE_BRANCH}." >&2
+  exit 1
+fi
+
+git push -u origin HEAD
+
+BODY_CONTENT=""
+if [[ -n "${BODY_FILE}" ]]; then
+  BODY_CONTENT="$(cat "${BODY_FILE}")"
+  if [[ "${BODY_CONTENT}" != "(AI Generated)."* ]]; then
+    BODY_CONTENT="$(printf '%s\n\n%s' '(AI Generated).' "${BODY_CONTENT}")"
+  fi
+else
+  BODY_ARGS=()
+  for item in "${SUMMARY_ARGS[@]}"; do
+    BODY_ARGS+=(--summary "${item}")
+  done
+  for item in "${TEST_ARGS[@]}"; do
+    BODY_ARGS+=(--test "${item}")
+  done
+  BODY_CONTENT="$(build_body "${TITLE}" "${BODY_ARGS[@]}")"
+fi
+
+EXISTING_PR_NUMBER="$(
+  gh pr list \
+    --head "${BRANCH_NAME}" \
+    --base "${BASE_BRANCH}" \
+    --state open \
+    --json number \
+    --jq '.[0].number // empty' \
+    --limit 1
+)"
+EXISTING_PR_URL="$(
+  gh pr list \
+    --head "${BRANCH_NAME}" \
+    --base "${BASE_BRANCH}" \
+    --state open \
+    --json url \
+    --jq '.[0].url // empty' \
+    --limit 1
+)"
+EXISTING_PR_IS_DRAFT="$(
+  gh pr list \
+    --head "${BRANCH_NAME}" \
+    --base "${BASE_BRANCH}" \
+    --state open \
+    --json isDraft \
+    --jq '.[0].isDraft // empty' \
+    --limit 1
+)"
+
+if [[ -n "${EXISTING_PR_NUMBER}" ]]; then
+  if [[ "${EXISTING_PR_IS_DRAFT}" != "true" ]]; then
+    gh pr ready "${EXISTING_PR_NUMBER}" --undo >/dev/null
+  fi
+  printf 'Draft PR already exists: %s\n' "${EXISTING_PR_URL}"
+  exit 0
+fi
+
+gh pr create \
+  --draft \
+  --base "${BASE_BRANCH}" \
+  --head "${BRANCH_NAME}" \
+  --title "${TITLE}" \
+  --body "${BODY_CONTENT}"

--- a/website/src/app/roadmap/RoadmapContent.tsx
+++ b/website/src/app/roadmap/RoadmapContent.tsx
@@ -701,7 +701,7 @@ const phases: Phase[] = [
     number: 1,
     title: "Foundation",
     description:
-      "Marketing site, QR gallery, monorepo, Automerge schema, CI/CD, public legal docs with download clickwrap, a protected newsletter signup flow, and deferred local worktree bootstrap with tracked preview tooling.",
+      "Marketing site, QR gallery, monorepo, Automerge schema, CI/CD, public legal docs with download clickwrap, a protected newsletter signup flow, deferred local worktree bootstrap with tracked preview tooling, and a draft PR publish helper for product worktrees.",
     status: "complete",
     planLink:
       "https://github.com/freed-project/freed/blob/dev/docs/PHASE-1-FOUNDATION.md",


### PR DESCRIPTION
(AI Generated).

## Summary
- Add a worktree publish helper that stages changes, commits them, pushes to origin, and opens a draft PR.
- Update the freed-build-feature skill, Phase 1 docs, roadmap copy, and README to use the new publish flow and layered validation guidance.

## Testing
- bash -n scripts/worktree-publish.sh
- ./scripts/worktree-publish.sh --help