### PR TITLE
fix: align masked workspace edges

### DIFF
--- a/packages/desktop/tests/e2e/smoke.spec.ts
+++ b/packages/desktop/tests/e2e/smoke.spec.ts
@@ -20,6 +20,9 @@ import { tauriInitScript } from "./fixtures/tauri-init";
 
 const SIDEBAR_ALIGNMENT_TOLERANCE_PX = 4;
 const READER_RAIL_ALIGNMENT_TOLERANCE_PX = 8;
+const PRIMARY_SIDEBAR_GAP_WIDTH = "16px";
+const AUXILIARY_DRAWER_GAP_WIDTH = "12px";
+const SOFT_VIEWPORT_RADIUS = "20px";
 
 async function dismissCloudSyncNudgeIfPresent(page: Page) {
   const dismissButton = page.getByRole("button", { name: "Dismiss", exact: true });
@@ -643,6 +646,58 @@ test("desktop toolbar tooltips still open on keyboard focus", async ({ app, page
 
   await expect(sidebarToggle).toBeFocused();
   await expect(page.getByRole("tooltip")).toHaveText("Collapse sidebar");
+});
+
+test("desktop masked workspaces compensate for adjacent shell gaps", async ({ app, page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await app.goto();
+  await app.waitForReady();
+  await app.seedFriendLocation();
+  await dismissCloudSyncNudgeIfPresent(page);
+
+  await page.getByRole("button", { name: /^Map/ }).click();
+  await expect(page.getByTestId("map-surface")).toBeVisible({ timeout: 10_000 });
+
+  const initialMapMaskState = await page.evaluate(() => {
+    const mapSurface = document.querySelector('[data-testid="map-surface"]') as HTMLElement | null;
+    const content = mapSurface?.querySelector(".theme-soft-viewport-content") as HTMLElement | null;
+    const styles = mapSurface ? window.getComputedStyle(mapSurface) : null;
+    const contentStyles = content ? window.getComputedStyle(content) : null;
+
+    return {
+      leftBase: styles?.getPropertyValue("--theme-soft-viewport-base-comp-left").trim() ?? "",
+      rightBase: styles?.getPropertyValue("--theme-soft-viewport-base-comp-right").trim() ?? "",
+      radius: styles?.getPropertyValue("--theme-soft-viewport-radius").trim() ?? "",
+      clipPath: contentStyles?.clipPath ?? "",
+    };
+  });
+
+  expect(initialMapMaskState.leftBase).toBe(PRIMARY_SIDEBAR_GAP_WIDTH);
+  expect(initialMapMaskState.rightBase).toBe("0px");
+  expect(initialMapMaskState.radius).toBe(SOFT_VIEWPORT_RADIUS);
+  expect(initialMapMaskState.clipPath).toContain(SOFT_VIEWPORT_RADIUS);
+
+  await page.keyboard.press("Control+Shift+D");
+  await expect(page.getByTestId("debug-panel-drawer")).toBeVisible();
+
+  await expect.poll(async () => {
+    return page.evaluate(() => {
+      const mapSurface = document.querySelector('[data-testid="map-surface"]') as HTMLElement | null;
+      return mapSurface
+        ? window.getComputedStyle(mapSurface).getPropertyValue("--theme-soft-viewport-base-comp-right").trim()
+        : "";
+    });
+  }).toBe(AUXILIARY_DRAWER_GAP_WIDTH);
+
+  await page.getByTestId("desktop-sidebar-toggle").click();
+  await expect.poll(async () => {
+    return page.evaluate(() => {
+      const mapSurface = document.querySelector('[data-testid="map-surface"]') as HTMLElement | null;
+      return mapSurface
+        ? window.getComputedStyle(mapSurface).getPropertyValue("--theme-soft-viewport-base-comp-left").trim()
+        : "";
+    });
+  }).toBe("0px");
 });
 
 test("main content area renders", async ({ app }) => {
@@ -1644,10 +1699,10 @@ test("Map view popup exposes friend actions and supports post navigation", async
   await page.waitForFunction(() => {
     const w = window as Record<string, unknown>;
     const store = w.__FREED_STORE__ as
-      | { getState: () => { activeView: string; selectedFriendId: string | null } }
+      | { getState: () => { activeView: string; selectedPersonId: string | null } }
       | undefined;
     const state = store?.getState();
-    return state?.activeView === "friends" && state.selectedFriendId === "friend-ada";
+    return state?.activeView === "friends" && state.selectedPersonId === "friend-ada";
   }, { timeout: 10_000 });
   await expect(page.getByRole("button", { name: "Back to all friends" })).toBeVisible({
     timeout: 10_000,
@@ -1704,10 +1759,10 @@ test("Friend detail last seen card opens the full Map view", async ({ app }) => 
   await page.waitForFunction(() => {
     const w = window as Record<string, unknown>;
     const store = w.__FREED_STORE__ as
-      | { getState: () => { activeView: string; selectedFriendId: string | null } }
+      | { getState: () => { activeView: string; selectedPersonId: string | null } }
       | undefined;
     const state = store?.getState();
-    return state?.activeView === "map" && state.selectedFriendId === "friend-ada";
+    return state?.activeView === "map" && state.selectedPersonId === "friend-ada";
   }, { timeout: 10_000 });
   await expect(page.locator('.freed-map-marker[aria-label="Ada Lovelace"]')).toBeVisible({
     timeout: 10_000,
@@ -2147,18 +2202,23 @@ test("Friends view uses the floating detail drawer shell", async ({ app, page })
     const sidebar = document.querySelector('[data-testid="friends-sidebar"]') as HTMLElement | null;
     const shell = document.querySelector('[data-testid="friends-sidebar-shell"]') as HTMLElement | null;
     const handle = document.querySelector('[aria-label="Resize friends sidebar"]') as HTMLElement | null;
+    const viewport = document.querySelector('[data-testid="friend-graph-viewport"]') as HTMLElement | null;
 
     return {
       sidebarIsFloating: sidebar?.classList.contains("theme-floating-panel") ?? false,
       shellWidth: shell?.getBoundingClientRect().width ?? 0,
       sidebarWidth: sidebar?.getBoundingClientRect().width ?? 0,
       handleUsesGapGrip: handle?.classList.contains("theme-resize-gap-handle") ?? false,
+      extraRightComp: viewport
+        ? window.getComputedStyle(viewport).getPropertyValue("--theme-soft-viewport-extra-comp-right").trim()
+        : "",
     };
   });
 
   expect(shellState.sidebarIsFloating).toBe(true);
   expect(shellState.handleUsesGapGrip).toBe(true);
   expect(shellState.shellWidth).toBeGreaterThanOrEqual(shellState.sidebarWidth);
+  expect(shellState.extraRightComp).toBe(AUXILIARY_DRAWER_GAP_WIDTH);
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/ui/src/components/friends/FriendGraph.tsx
+++ b/packages/ui/src/components/friends/FriendGraph.tsx
@@ -683,7 +683,11 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
   }, [findHitNode, fitAll, focusNode]);
 
   return (
-    <div ref={containerRef} className="theme-soft-viewport relative h-full w-full">
+    <div
+      ref={containerRef}
+      data-testid="friend-graph-viewport"
+      className="theme-soft-viewport relative h-full w-full"
+    >
       <div className="theme-soft-viewport-content">
         <canvas
           ref={canvasRef}

--- a/packages/ui/src/components/friends/FriendsView.tsx
+++ b/packages/ui/src/components/friends/FriendsView.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo, useEffect, useRef } from "react";
+import { useState, useCallback, useMemo, useEffect, useRef, type CSSProperties } from "react";
 import type {
   Account,
   DeviceContact,
@@ -34,6 +34,10 @@ import {
   buildSuggestionsByPerson,
   type AccountLinkSuggestion,
 } from "../../lib/account-link-suggestions.js";
+import {
+  FRIENDS_SIDEBAR_GAP_WIDTH_PX,
+  px,
+} from "../layout/layoutConstants.js";
 
 const DEFAULT_SIDEBAR_WIDTH = 360;
 const MIN_SIDEBAR_WIDTH = 280;
@@ -377,6 +381,11 @@ export function FriendsView() {
   }, [dragWidth, savedSidebarWidth]);
 
   const sidebarWidth = dragWidth ?? committedSidebarWidth;
+  const graphViewportStyle = isMobile
+    ? undefined
+    : ({
+        "--theme-soft-viewport-extra-comp-right": px(FRIENDS_SIDEBAR_GAP_WIDTH_PX),
+      } as CSSProperties);
 
   const focusGraphNode = useCallback((id: string) => {
     graphRef.current?.focusNode(id);
@@ -903,7 +912,7 @@ export function FriendsView() {
   return (
     <div className="app-theme-shell flex h-full flex-col overflow-hidden">
       <div className={`flex min-h-0 flex-1 ${isMobile ? "flex-col" : "flex-row"}`}>
-        <div className="relative min-h-0 min-w-0 flex-1">
+        <div className="relative min-h-0 min-w-0 flex-1" style={graphViewportStyle}>
           {(effectiveMode === "friends" && friendList.length === 0) || (effectiveMode === "all_content" && socialAccountCount === 0 && friendList.length === 0) ? (
             renderGraphEmptyState()
           ) : (
@@ -954,7 +963,7 @@ export function FriendsView() {
             <aside
               data-testid="friends-sidebar"
               className="theme-floating-panel flex h-full min-h-0 w-full flex-col overflow-hidden"
-              style={{ width: `${sidebarWidth}px` }}
+              style={{ width: px(sidebarWidth) }}
             >
               {activeSidebar}
             </aside>

--- a/packages/ui/src/components/layout/AppShell.tsx
+++ b/packages/ui/src/components/layout/AppShell.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef, useCallback, type ReactNode } from "react";
+import { useEffect, useState, useRef, useCallback, type CSSProperties, type ReactNode } from "react";
 import { Sidebar } from "./Sidebar.js";
 import { Header } from "./Header.js";
 import { DebugPanel } from "../DebugPanel.js";
@@ -8,6 +8,7 @@ import { FriendsView } from "../friends/FriendsView.js";
 import { ContactSyncModal } from "../friends/ContactSyncModal.js";
 import { useContactSync } from "../../hooks/useContactSync.js";
 import { ContactSyncContext } from "../../context/ContactSyncContext.js";
+import { useIsMobile } from "../../hooks/useIsMobile.js";
 import {
   buildDiscoveredAccountsFromItems,
   type GoogleContact,
@@ -21,6 +22,11 @@ import {
 import { applyThemeToDocument, persistTheme } from "../../lib/theme.js";
 import { MapView } from "../map/MapView.js";
 import { BackgroundAtmosphere } from "./BackgroundAtmosphere.js";
+import {
+  AUXILIARY_DRAWER_GAP_WIDTH_PX,
+  PRIMARY_SIDEBAR_GAP_WIDTH_PX,
+  px,
+} from "./layoutConstants.js";
 
 const DEFAULT_DEBUG_WIDTH = 320;
 const MIN_DEBUG_WIDTH = 280;
@@ -32,6 +38,7 @@ interface AppShellProps {
 
 export function AppShell({ children }: AppShellProps) {
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
+  const isMobile = useIsMobile();
   const debugVisible = useDebugStore((s) => s.visible);
   const toggleDebug = useDebugStore((s) => s.toggle);
   const activeView = useAppStore((s) => s.activeView);
@@ -154,6 +161,15 @@ export function AppShell({ children }: AppShellProps) {
     persistTheme(themeId);
   }, [isInitialized, themeId]);
 
+  const workspaceMaskStyle = isMobile
+    ? undefined
+    : ({
+        "--theme-soft-viewport-base-comp-left":
+          desktopSidebarMode === "closed" ? "0px" : px(PRIMARY_SIDEBAR_GAP_WIDTH_PX),
+        "--theme-soft-viewport-base-comp-right":
+          debugVisible ? px(AUXILIARY_DRAWER_GAP_WIDTH_PX) : "0px",
+      } as CSSProperties);
+
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if (e.key === "D" && e.shiftKey && (e.metaKey || e.ctrlKey)) {
@@ -259,7 +275,10 @@ export function AppShell({ children }: AppShellProps) {
             desktopMode={desktopSidebarMode}
             onDesktopModeChange={persistDesktopSidebarMode}
           />
-          <main className="min-w-0 flex-1 md:min-h-0 md:overflow-hidden">
+          <main
+            className="min-w-0 flex-1 md:min-h-0 md:overflow-hidden"
+            style={workspaceMaskStyle}
+          >
             {activeView === "friends"
               ? <FriendsView />
               : activeView === "map"
@@ -271,7 +290,7 @@ export function AppShell({ children }: AppShellProps) {
             data-testid="debug-panel-drawer"
             className="relative hidden sm:flex flex-none overflow-hidden"
             style={{
-              width: debugVisible ? debugWidth + 12 : 0,
+              width: debugVisible ? debugWidth + AUXILIARY_DRAWER_GAP_WIDTH_PX : 0,
               opacity: debugVisible ? 1 : 0,
               transition: dragging.current ? "none" : "width 300ms ease-in-out, opacity 180ms ease-in-out",
             }}

--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -37,6 +37,11 @@ import {
   usePlatform,
 } from "../../context/PlatformContext.js";
 import { getFilterLabel } from "../../lib/feed-view-labels.js";
+import {
+  PRIMARY_SIDEBAR_GAP_WIDTH_PX,
+  TOOLBAR_SIDEBAR_SLOT_PADDING_RIGHT_PX,
+  px,
+} from "./layoutConstants.js";
 
 interface HeaderProps {
   mobileSidebarOpen: boolean;
@@ -323,7 +328,10 @@ export function Header({
     : undefined;
   const sidebarSlotStyle =
     !isMobile && desktopSidebarMode !== "closed"
-      ? ({ width: "calc(var(--freed-sidebar-card-width, 240px) + 16px)", paddingRight: "8px" } as CSSProperties)
+      ? ({
+          width: `calc(var(--freed-sidebar-card-width, 240px) + ${px(PRIMARY_SIDEBAR_GAP_WIDTH_PX)})`,
+          paddingRight: px(TOOLBAR_SIDEBAR_SLOT_PADDING_RIGHT_PX),
+        } as CSSProperties)
       : undefined;
   const leftToolbarStyle = sidebarSlotStyle
     ? {

--- a/packages/ui/src/components/layout/Sidebar.tsx
+++ b/packages/ui/src/components/layout/Sidebar.tsx
@@ -19,6 +19,10 @@ import { MapPinIcon, RssIcon, BookmarkIcon, ArchiveIcon, UsersIcon } from "../ic
 import { TOP_SOURCE_ITEMS, type SourceNavigationItem } from "../../lib/source-navigation.js";
 import { useIsMobile } from "../../hooks/useIsMobile.js";
 import { SearchJumpField } from "./SearchJumpField.js";
+import {
+  PRIMARY_SIDEBAR_GAP_WIDTH_PX,
+  px,
+} from "./layoutConstants.js";
 
 const compactNumberFormatter = new Intl.NumberFormat(undefined, {
   notation: "compact",
@@ -567,10 +571,10 @@ export function Sidebar({
     paddingBottom: `calc(${sidebarPaddingPx}px + 100lvh - 100dvh + env(safe-area-inset-bottom, 0px))`,
   };
   const desktopShellWidth = dragWidth !== null
-    ? desktopWidth + 16
+    ? desktopWidth + PRIMARY_SIDEBAR_GAP_WIDTH_PX
     : desktopMode === "closed"
       ? 0
-      : (desktopMode === "compact" ? COMPACT_WIDTH : committedWidth) + 16;
+      : (desktopMode === "compact" ? COMPACT_WIDTH : committedWidth) + PRIMARY_SIDEBAR_GAP_WIDTH_PX;
   const desktopShellOpacity = dragWidth !== null ? 1 : desktopMode === "closed" ? 0 : 1;
   const desktopShellTopPadding = dragWidth !== null || desktopMode !== "closed"
     ? "var(--feed-card-gap, 8px)"
@@ -1545,7 +1549,7 @@ export function Sidebar({
           <aside
             data-testid="app-sidebar"
             className="theme-floating-panel relative z-10 flex h-full min-h-0 shrink-0 flex-col overflow-hidden"
-            style={{ width: `${desktopAsideWidth}px` }}
+            style={{ width: px(desktopAsideWidth) }}
           >
             {sidebarBody}
           </aside>

--- a/packages/ui/src/components/layout/layoutConstants.ts
+++ b/packages/ui/src/components/layout/layoutConstants.ts
@@ -1,0 +1,11 @@
+export const SOFT_VIEWPORT_MASK_SIZE_PX = 20;
+export const SOFT_VIEWPORT_RADIUS_PX = 20;
+
+export const PRIMARY_SIDEBAR_GAP_WIDTH_PX = 16;
+export const AUXILIARY_DRAWER_GAP_WIDTH_PX = 12;
+export const FRIENDS_SIDEBAR_GAP_WIDTH_PX = 12;
+export const TOOLBAR_SIDEBAR_SLOT_PADDING_RIGHT_PX = 8;
+
+export function px(value: number): string {
+  return `${value}px`;
+}

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -818,10 +818,16 @@ html[data-theme="scriptorium"] .theme-panel-muted {
 }
 
 .theme-soft-viewport {
+  --theme-soft-viewport-mask-size: 20px;
+  --theme-soft-viewport-radius: 20px;
+  --theme-soft-viewport-comp-left: calc(var(--theme-soft-viewport-base-comp-left, 0px) + var(--theme-soft-viewport-extra-comp-left, 0px));
+  --theme-soft-viewport-comp-right: calc(var(--theme-soft-viewport-base-comp-right, 0px) + var(--theme-soft-viewport-extra-comp-right, 0px));
+  --theme-soft-viewport-comp-top: calc(var(--theme-soft-viewport-base-comp-top, 0px) + var(--theme-soft-viewport-extra-comp-top, 0px));
+  --theme-soft-viewport-comp-bottom: calc(var(--theme-soft-viewport-base-comp-bottom, 0px) + var(--theme-soft-viewport-extra-comp-bottom, 0px));
   position: relative;
   overflow: hidden;
   isolation: isolate;
-  border-radius: 20px;
+  border-radius: var(--theme-soft-viewport-radius);
 }
 
 .theme-soft-viewport-content {
@@ -829,6 +835,7 @@ html[data-theme="scriptorium"] .theme-panel-muted {
   inset: 0;
   overflow: hidden;
   border-radius: inherit;
+  clip-path: inset(0 round var(--theme-soft-viewport-radius));
 }
 
 .theme-scroll-fade-y {
@@ -844,17 +851,17 @@ html[data-theme="scriptorium"] .theme-panel-muted {
     -webkit-mask-image:
       linear-gradient(
         to right,
-        transparent 0,
-        #000 20px,
-        #000 calc(100% - 20px),
-        transparent 100%
+        transparent calc(0px - var(--theme-soft-viewport-comp-left)),
+        #000 calc(var(--theme-soft-viewport-mask-size) - var(--theme-soft-viewport-comp-left)),
+        #000 calc(100% - var(--theme-soft-viewport-mask-size) + var(--theme-soft-viewport-comp-right)),
+        transparent calc(100% + var(--theme-soft-viewport-comp-right))
       ),
       linear-gradient(
         to bottom,
-        transparent 0,
-        #000 20px,
-        #000 calc(100% - 20px),
-        transparent 100%
+        transparent calc(0px - var(--theme-soft-viewport-comp-top)),
+        #000 calc(var(--theme-soft-viewport-mask-size) - var(--theme-soft-viewport-comp-top)),
+        #000 calc(100% - var(--theme-soft-viewport-mask-size) + var(--theme-soft-viewport-comp-bottom)),
+        transparent calc(100% + var(--theme-soft-viewport-comp-bottom))
       );
     -webkit-mask-repeat: no-repeat, no-repeat;
     -webkit-mask-size: 100% 100%, 100% 100%;
@@ -862,17 +869,17 @@ html[data-theme="scriptorium"] .theme-panel-muted {
     mask-image:
       linear-gradient(
         to right,
-        transparent 0,
-        #000 20px,
-        #000 calc(100% - 20px),
-        transparent 100%
+        transparent calc(0px - var(--theme-soft-viewport-comp-left)),
+        #000 calc(var(--theme-soft-viewport-mask-size) - var(--theme-soft-viewport-comp-left)),
+        #000 calc(100% - var(--theme-soft-viewport-mask-size) + var(--theme-soft-viewport-comp-right)),
+        transparent calc(100% + var(--theme-soft-viewport-comp-right))
       ),
       linear-gradient(
         to bottom,
-        transparent 0,
-        #000 20px,
-        #000 calc(100% - 20px),
-        transparent 100%
+        transparent calc(0px - var(--theme-soft-viewport-comp-top)),
+        #000 calc(var(--theme-soft-viewport-mask-size) - var(--theme-soft-viewport-comp-top)),
+        #000 calc(100% - var(--theme-soft-viewport-mask-size) + var(--theme-soft-viewport-comp-bottom)),
+        transparent calc(100% + var(--theme-soft-viewport-comp-bottom))
       );
     mask-repeat: no-repeat, no-repeat;
     mask-size: 100% 100%, 100% 100%;

--- a/packages/ui/src/lib/map-navigation.ts
+++ b/packages/ui/src/lib/map-navigation.ts
@@ -25,7 +25,6 @@ export function openFriendFromMap(
 ): void {
   if (!marker.friend) return;
   actions.setSelectedPerson(marker.friend.id);
-  actions.setSelectedAccount(null);
   actions.setSelectedItem(null);
   actions.setActiveView("friends");
 }
@@ -53,7 +52,6 @@ export function openPostFromMap(
   actions.setFilter({});
   actions.setSearchQuery("");
   actions.setSelectedPerson(marker.friend?.id ?? null);
-  actions.setSelectedAccount(null);
   actions.setSelectedItem(marker.item.globalId);
   actions.setActiveView("feed");
 }


### PR DESCRIPTION
(AI Generated).

## Summary

Align the masked workspace edges with the surrounding shell gaps so the left and right fades match the top spacing, and give the masked content a smooth 20px inner radius.

## Root cause

The soft viewport mask used a fixed rectangular fade while the desktop shell added separate resize-gap widths beside the map and Friends workspaces. That made the left edge feel farther from the content than the top edge. Map navigation also cleared the selected person immediately after selecting it, which broke the Open Friend path from the map popup.

## Validation
- `node ../../node_modules/typescript/bin/tsc -b` in `packages/desktop`
- `node ../../node_modules/vite/bin/vite.js build` in `packages/desktop`
- `npm run test:e2e -- tests/e2e/smoke.spec.ts -g "desktop masked workspaces compensate for adjacent shell gaps|Friends view uses the floating detail drawer shell"` in `packages/desktop`
- `npm run test:e2e -- tests/e2e/smoke.spec.ts -g "Map view popup exposes friend actions and supports post navigation|Friend detail last seen card opens the full Map view"` in `packages/desktop`
- `npm run test:e2e -- tests/e2e/theme-switching.spec.ts -g "map view repaints across all themes without using the old canvas filter"` in `packages/desktop`

## Impact

Map, Friends, and future soft-viewport surfaces now share one compensation pattern for shell gaps, while the sidebar grab handles keep the existing hover and drag behavior.
