### PR TITLE
fix: polish unified toolbar and restore map timeline

### DIFF
--- a/docs/PHASE-8-FRIENDS.md
+++ b/docs/PHASE-8-FRIENDS.md
@@ -1,6 +1,6 @@
 # Phase 8: Friends + Social Graph
 
-> **Status:** In Progress, the canonical identity model now uses `Person` plus attached `Account` records, Google Contacts imports create friend persons by default, the Friends workspace now defaults to `All content` with confirmed friend hubs plus linked satellites and peripheral account nodes, and the map plus Friends surfaces share header-level identity controls while the map can switch between current, future, and past location windows and scrub through historical posts plus future plan ranges
+> **Status:** In Progress, the canonical identity model now uses `Person` plus attached `Account` records, Google Contacts imports create friend persons by default, the Friends workspace now defaults to `All content` with confirmed friend hubs plus linked satellites and peripheral account nodes, and the map plus Friends surfaces now share the same unified top toolbar, including header-level identity controls plus current, future, and past map windows with a quieter in-map timeline scrubber docked at the lower left for historical and future playback
 > **Dependencies:** Phase 7 (Facebook + Instagram capture provide most social content)
 
 ---
@@ -218,6 +218,7 @@ Friends and Map now consume the same shared theme tokens, button treatments, she
 The shared map now includes a persisted `Friends` / `All content` toggle. It restores the user's last mode from preferences and defaults to `All content` when the library has geolocatable followed accounts but no friend-linked pins yet.
 That same `Friends` / `All content` lens now lives in the shared toolbar for feed surfaces too, so the operator can collapse Freed down to real-world people without leaving the main reading views.
 The shared map now also persists a `Current` / `Future` / `Past` time filter. Future-dated `timeRange` windows stay out of the default current map until they start, upcoming travel or event windows can be previewed directly, and expired windows fall into a separate past view without hijacking the current last-seen map.
+Map history playback now stays inside the map surface as a lower-left scrubber panel, while the toolbar keeps only the high-level mode switches instead of growing a second floating control row.
 Friends and Map now use the shared top toolbar for their identity and time controls, and feed-only bulk actions no longer appear in those workspaces.
 Past and future views now expose a timeline scrubber, so the operator can replay historical location posts or step through upcoming travel windows instead of staring at one collapsed "latest" pin and pretending that counts as time.
 

--- a/packages/desktop/tests/e2e/smoke.spec.ts
+++ b/packages/desktop/tests/e2e/smoke.spec.ts
@@ -1777,7 +1777,7 @@ test("map defaults to All content when only unlinked author locations exist", as
 
   await page.getByRole("button", { name: /^Map/ }).click();
   const allContentButton = page.getByRole("button", { name: "All content", exact: true });
-  await expect(allContentButton).toHaveClass(/theme-chip-active/, { timeout: 10_000 });
+  await expect(allContentButton).toHaveAttribute("aria-pressed", "true", { timeout: 10_000 });
   await expect(page.locator('.freed-map-marker[aria-label="Nora Quinn"]')).toBeVisible({
     timeout: 10_000,
   });
@@ -1877,7 +1877,7 @@ test("recoverable story locations appear in All content mode and the mode persis
   await page.getByRole("button", { name: /^Map/ }).click();
   const allContentButton = page.getByRole("button", { name: "All content", exact: true });
   await allContentButton.click();
-  await expect(allContentButton).toHaveClass(/theme-chip-active/, { timeout: 10_000 });
+  await expect(allContentButton).toHaveAttribute("aria-pressed", "true", { timeout: 10_000 });
 
   await openVisibleMapMarker(page, "Nora Quinn");
   await expect(page.getByText("Big Bear California")).toBeVisible({ timeout: 10_000 });
@@ -1886,8 +1886,9 @@ test("recoverable story locations appear in All content mode and the mode persis
   await app.waitForReady();
   await dismissCloudSyncNudgeIfPresent(page);
   await page.getByRole("button", { name: /^Map/ }).click();
-  await expect(page.getByRole("button", { name: "All content", exact: true })).toHaveClass(
-    /theme-chip-active/,
+  await expect(page.getByRole("button", { name: "All content", exact: true })).toHaveAttribute(
+    "aria-pressed",
+    "true",
     { timeout: 10_000 },
   );
   await expect(page.locator('.freed-map-marker[aria-label="Nora Quinn"]')).toBeVisible({
@@ -1970,8 +1971,9 @@ test("map time filters switch between current and future location windows", asyn
   });
 
   await page.getByRole("button", { name: /^Map/ }).click();
-  await expect(page.getByRole("button", { name: "Current", exact: true })).toHaveClass(
-    /theme-chip-active/,
+  await expect(page.getByRole("button", { name: "Current", exact: true })).toHaveAttribute(
+    "aria-pressed",
+    "true",
     { timeout: 10_000 },
   );
 
@@ -1981,15 +1983,16 @@ test("map time filters switch between current and future location windows", asyn
 
   const futureButton = page.getByRole("button", { name: "Future", exact: true });
   await futureButton.click();
-  await expect(futureButton).toHaveClass(/theme-chip-active/, { timeout: 10_000 });
+  await expect(futureButton).toHaveAttribute("aria-pressed", "true", { timeout: 10_000 });
   await expect(page.getByText("Lisbon", { exact: true })).toBeVisible({ timeout: 10_000 });
 
   await page.reload();
   await app.waitForReady();
   await dismissCloudSyncNudgeIfPresent(page);
   await page.getByRole("button", { name: /^Map/ }).click();
-  await expect(page.getByRole("button", { name: "Future", exact: true })).toHaveClass(
-    /theme-chip-active/,
+  await expect(page.getByRole("button", { name: "Future", exact: true })).toHaveAttribute(
+    "aria-pressed",
+    "true",
     { timeout: 10_000 },
   );
 });

--- a/packages/ui/src/components/SettingsDialog.tsx
+++ b/packages/ui/src/components/SettingsDialog.tsx
@@ -755,6 +755,9 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
     container.scrollTo({ top: targetTop, behavior });
   }, []);
 
+  // ── Mobile nav state ──────────────────────────────────────────────────────
+  const [mobileView, setMobileView] = useState<"nav" | "section">("nav");
+
   useEffect(() => {
     const root = scrollRef.current;
     if (!root || searchLower || (isMobile && mobileView === "nav")) return;
@@ -808,9 +811,6 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
     scrollSectionIntoView(id, "smooth");
     setMobileView("section");
   }, [isMobile, mobileView, scrollSectionIntoView]);
-
-  // ── Mobile nav state ──────────────────────────────────────────────────────
-  const [mobileView, setMobileView] = useState<"nav" | "section">("nav");
 
   // Reset state on close
   useEffect(() => {

--- a/packages/ui/src/components/feed/FeedView.tsx
+++ b/packages/ui/src/components/feed/FeedView.tsx
@@ -8,7 +8,6 @@ import { useAppStore, usePlatform } from "../../context/PlatformContext.js";
 import { useSearchResults } from "../../hooks/useSearchResults.js";
 import { useIsMobile } from "../../hooks/useIsMobile.js";
 import type { FeedItem } from "@freed/shared";
-import { getFilterLabel, getRetentionLabel } from "../../lib/feed-view-labels.js";
 import { runFeedLayoutTransition } from "../../lib/view-transitions.js";
 
 // ─── Compact sidebar panel for dual-column mode ────────────────────────────
@@ -237,9 +236,6 @@ export function FeedView() {
   const toggleSaved = useAppStore((s) => s.toggleSaved);
   const toggleArchived = useAppStore((s) => s.toggleArchived);
   const toggleLiked = useAppStore((s) => s.toggleLiked);
-  const unarchiveSavedItems = useAppStore((s) => s.unarchiveSavedItems);
-  const deleteAllArchived = useAppStore((s) => s.deleteAllArchived);
-  const archivePruneDays = useAppStore((s) => s.preferences.display.archivePruneDays);
   const friendsMode = useAppStore((s) => s.preferences.display.friendsMode ?? "all_content");
 
   const handleItemSave = useCallback(
@@ -265,43 +261,11 @@ export function FeedView() {
     }
   }, [openUrl]);
 
-  // Archive toolbar confirm-to-delete state.
-  // First click arms the button; second click executes. Auto-resets after 3s.
-  const [deleteConfirmArmed, setDeleteConfirmArmed] = useState(false);
-  const deleteConfirmTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const savedArchivedCount = useMemo(
-    () => items.filter((item) => item.userState.saved && item.userState.archived).length,
-    [items],
-  );
-
-  const handleDeleteArchivedClick = useCallback(() => {
-    if (!deleteConfirmArmed) {
-      setDeleteConfirmArmed(true);
-      deleteConfirmTimerRef.current = setTimeout(() => setDeleteConfirmArmed(false), 3000);
-      return;
-    }
-    if (deleteConfirmTimerRef.current) clearTimeout(deleteConfirmTimerRef.current);
-    setDeleteConfirmArmed(false);
-    void deleteAllArchived();
-  }, [deleteConfirmArmed, deleteAllArchived]);
-
-  const handleUnarchiveSavedClick = useCallback(() => {
-    void unarchiveSavedItems();
-  }, [unarchiveSavedItems]);
-
-  // Reset confirm state whenever the archived view is left.
-  useEffect(() => {
-    if (!activeFilter.archivedOnly) {
-      if (deleteConfirmTimerRef.current) clearTimeout(deleteConfirmTimerRef.current);
-      setDeleteConfirmArmed(false);
-    }
-  }, [activeFilter.archivedOnly]);
-
   const [addFeedOpen, setAddFeedOpen] = useState(false);
 
   // useSearchResults handles both the search and the normal ranked+filtered path.
   // When searchQuery is empty it behaves identically to the previous useMemo.
-  const { filteredItems, isSearching, resultCount } = useSearchResults(
+  const { filteredItems, isSearching } = useSearchResults(
     items,
     searchQuery,
     activeFilter,
@@ -312,7 +276,6 @@ export function FeedView() {
     friends,
   );
 
-  const scopeLabel = useMemo(() => getFilterLabel(activeFilter, feeds), [activeFilter, feeds]);
   const dualColumnMode = useAppStore((s) => s.preferences.display.reading.dualColumnMode);
   const isMobile = useIsMobile();
   const showInlineReader = !!selectedItemId && !isMobile;
@@ -469,34 +432,6 @@ export function FeedView() {
   if (showInlineReader && selectedItem) {
     return (
       <div className="h-full flex flex-col overflow-hidden">
-        {/* Archive retention toolbar — only shown in the archived view */}
-        {activeFilter.archivedOnly && (
-          <div className="flex-shrink-0 px-4 py-2 border-b border-[var(--theme-header-border)] flex items-center justify-between gap-4">
-            <p className="text-xs text-[var(--theme-text-soft)]">{getRetentionLabel(archivePruneDays ?? 30)}</p>
-            <div className="flex items-center gap-2">
-              {savedArchivedCount > 0 && (
-                <button
-                  onClick={handleUnarchiveSavedClick}
-                  className="text-xs px-3 py-1 rounded-lg transition-colors border whitespace-nowrap bg-[var(--theme-bg-muted)] text-[var(--theme-text-muted)] border-transparent hover:bg-[var(--theme-bg-card-hover)] hover:text-[var(--theme-text-primary)]"
-                >
-                  Unarchive Saved Content
-                </button>
-              )}
-              {(archivePruneDays ?? 30) > 0 && (
-                <button
-                  onClick={handleDeleteArchivedClick}
-                  className={`text-xs px-3 py-1 rounded-lg transition-colors border whitespace-nowrap ${
-                    deleteConfirmArmed
-                      ? "bg-red-500/20 text-red-400 border-red-500/30 hover:bg-red-500/30"
-                      : "bg-[var(--theme-bg-muted)] text-[var(--theme-text-muted)] border-transparent hover:bg-[var(--theme-bg-card-hover)] hover:text-[var(--theme-text-primary)]"
-                  }`}
-                >
-                  {deleteConfirmArmed ? "Confirm delete?" : "Delete archived content now"}
-                </button>
-              )}
-            </div>
-          </div>
-        )}
         <div className="flex-1 flex overflow-hidden">
           {showDualColumn ? (
             <>
@@ -537,54 +472,6 @@ export function FeedView() {
 
   return (
     <div className="h-full flex flex-col">
-      {/* Archive retention toolbar — only shown in the archived view */}
-      {activeFilter.archivedOnly && (
-        <div className="flex-shrink-0 px-4 py-2 border-b border-[var(--theme-header-border)] flex items-center justify-between gap-4">
-          <p className="text-xs text-[var(--theme-text-soft)]">{getRetentionLabel(archivePruneDays ?? 30)}</p>
-          <div className="flex items-center gap-2">
-            {savedArchivedCount > 0 && (
-              <button
-                onClick={handleUnarchiveSavedClick}
-                className="text-xs px-3 py-1 rounded-lg transition-colors border whitespace-nowrap bg-[var(--theme-bg-muted)] text-[var(--theme-text-muted)] border-transparent hover:bg-[var(--theme-bg-card-hover)] hover:text-[var(--theme-text-primary)]"
-              >
-                Unarchive Saved Content
-              </button>
-            )}
-            {(archivePruneDays ?? 30) > 0 && (
-              <button
-                onClick={handleDeleteArchivedClick}
-                className={`text-xs px-3 py-1 rounded-lg transition-colors border whitespace-nowrap ${
-                  deleteConfirmArmed
-                    ? "bg-red-500/20 text-red-400 border-red-500/30 hover:bg-red-500/30"
-                    : "bg-[var(--theme-bg-muted)] text-[var(--theme-text-muted)] border-transparent hover:bg-[var(--theme-bg-card-hover)] hover:text-[var(--theme-text-primary)]"
-                }`}
-              >
-                {deleteConfirmArmed ? "Confirm delete?" : "Delete archived content now"}
-              </button>
-            )}
-          </div>
-        </div>
-      )}
-
-      {/* Search results banner — only shown when actively searching */}
-      {isSearching && (
-        <div className="flex-shrink-0 px-4 py-2 border-b border-[var(--theme-header-border)] flex items-center justify-between">
-          <p className="text-xs text-[var(--theme-text-muted)]">
-            {resultCount > 0 ? (
-              <>
-                <span className="font-medium text-[var(--theme-text-secondary)]">{resultCount.toLocaleString()}</span>
-                {" "}result{resultCount !== 1 ? "s" : ""} in{" "}
-                <span className="font-medium text-[var(--theme-text-secondary)]">{scopeLabel}</span>
-              </>
-            ) : (
-              <>
-                No results in <span className="font-medium text-[var(--theme-text-secondary)]">{scopeLabel}</span>
-              </>
-            )}
-          </p>
-        </div>
-      )}
-
       <FeedList
         items={filteredItems}
         onItemClick={openItemDirect}

--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -5,6 +5,7 @@ import {
   useMemo,
   useCallback,
   type CSSProperties,
+  type ButtonHTMLAttributes,
   type MouseEvent as ReactMouseEvent,
   type PointerEvent as ReactPointerEvent,
   type ReactNode,
@@ -36,7 +37,7 @@ import {
   useAppStore,
   usePlatform,
 } from "../../context/PlatformContext.js";
-import { getFilterLabel } from "../../lib/feed-view-labels.js";
+import { getFilterLabel, getRetentionLabel } from "../../lib/feed-view-labels.js";
 import {
   PRIMARY_SIDEBAR_GAP_WIDTH_PX,
   TOOLBAR_SIDEBAR_SLOT_PADDING_RIGHT_PX,
@@ -91,6 +92,48 @@ function ToolbarAnimatedSlot({
   );
 }
 
+function ToolbarToggleGroup<T extends string>({
+  options,
+  value,
+  onChange,
+  compact = false,
+  dataTestId,
+  getButtonProps,
+}: {
+  options: Array<{ value: T; label: string }>;
+  value: T;
+  onChange: (value: T) => void;
+  compact?: boolean;
+  dataTestId?: string;
+  getButtonProps?: () => ButtonHTMLAttributes<HTMLButtonElement>;
+}) {
+  return (
+    <div
+      data-testid={dataTestId}
+      className={`theme-toolbar-segmented inline-flex items-center ${compact ? "theme-toolbar-segmented-compact" : ""}`}
+      role="tablist"
+    >
+      {options.map((option) => {
+        const selected = option.value === value;
+        return (
+          <button
+            key={option.value}
+            type="button"
+            onClick={() => onChange(option.value)}
+            aria-pressed={selected}
+            className={`theme-toolbar-segment whitespace-nowrap ${
+              selected ? "theme-toolbar-segment-active" : "theme-toolbar-segment-inactive"
+            }`}
+            {...getButtonProps?.()}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
 export function Header({
   mobileSidebarOpen,
   onMobileMenuToggle,
@@ -131,6 +174,8 @@ export function Header({
   const pendingMatchCount = useAppStore((s) => s.pendingMatchCount);
   const markAllAsRead = useAppStore((s) => s.markAllAsRead);
   const archiveAllReadUnsaved = useAppStore((s) => s.archiveAllReadUnsaved);
+  const unarchiveSavedItems = useAppStore((s) => s.unarchiveSavedItems);
+  const deleteAllArchived = useAppStore((s) => s.deleteAllArchived);
   const toggleSaved = useAppStore((s) => s.toggleSaved);
   const toggleArchived = useAppStore((s) => s.toggleArchived);
   const updatePreferences = useAppStore((s) => s.updatePreferences);
@@ -166,12 +211,18 @@ export function Header({
     () => Object.values(accounts).filter((account) => account.kind === "social").length,
     [accounts],
   );
+  const savedArchivedCount = useMemo(
+    () => items.filter((item) => item.userState.saved && item.userState.archived).length,
+    [items],
+  );
   const effectiveMapMode = display.mapMode
     ?? getDefaultMapMode(mappedFriendCount, mappedAllContentCount);
   const effectiveFriendsMode = display.friendsMode ?? "all_content";
   const showWorkspaceIdentityControls = activeView === "friends" || activeView === "map";
   const showMapTimeControls = activeView === "map";
   const showFeedBulkActions = activeView === "feed";
+  const showArchivedToolbar = activeView === "feed" && activeFilter.archivedOnly;
+  const showArchivedDeleteAction = showArchivedToolbar && (display.archivePruneDays ?? 30) > 0;
 
   const unreadCount =
     activeFilter.savedOnly || activeFilter.archivedOnly
@@ -307,6 +358,9 @@ export function Header({
     });
   }, [display, updatePreferences]);
 
+  const [deleteConfirmArmed, setDeleteConfirmArmed] = useState(false);
+  const deleteConfirmTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   const handleOpenReaderUrl = useCallback(() => {
     if (!selectedItem?.sourceUrl) return;
     if (openUrl) {
@@ -315,6 +369,30 @@ export function Header({
     }
     window.open(selectedItem.sourceUrl, "_blank", "noopener,noreferrer");
   }, [openUrl, selectedItem]);
+
+  const handleDeleteArchivedClick = useCallback(() => {
+    if (!deleteConfirmArmed) {
+      setDeleteConfirmArmed(true);
+      if (deleteConfirmTimerRef.current) {
+        window.clearTimeout(deleteConfirmTimerRef.current);
+      }
+      deleteConfirmTimerRef.current = window.setTimeout(() => {
+        setDeleteConfirmArmed(false);
+        deleteConfirmTimerRef.current = null;
+      }, 3000);
+      return;
+    }
+    if (deleteConfirmTimerRef.current) {
+      window.clearTimeout(deleteConfirmTimerRef.current);
+      deleteConfirmTimerRef.current = null;
+    }
+    setDeleteConfirmArmed(false);
+    void deleteAllArchived();
+  }, [deleteAllArchived, deleteConfirmArmed]);
+
+  const handleUnarchiveSavedClick = useCallback(() => {
+    void unarchiveSavedItems();
+  }, [unarchiveSavedItems]);
 
   const showReaderLayoutToggle =
     !isMobile &&
@@ -482,9 +560,24 @@ export function Header({
     }
   }, [addFeedOpen, savedContentOpen]);
 
+  useEffect(() => {
+    if (activeFilter.archivedOnly) {
+      return;
+    }
+    if (deleteConfirmTimerRef.current) {
+      window.clearTimeout(deleteConfirmTimerRef.current);
+      deleteConfirmTimerRef.current = null;
+    }
+    setDeleteConfirmArmed(false);
+  }, [activeFilter.archivedOnly]);
+
   useEffect(() => () => {
     finishToolbarDragGesture();
     clearSuppressedToolbarClick();
+    if (deleteConfirmTimerRef.current) {
+      window.clearTimeout(deleteConfirmTimerRef.current);
+      deleteConfirmTimerRef.current = null;
+    }
   }, [clearSuppressedToolbarClick, finishToolbarDragGesture]);
 
   useEffect(() => {
@@ -533,7 +626,9 @@ export function Header({
                 <button
                   onClick={onMobileMenuToggle}
                   {...getToolbarControlProps()}
-                  className={`rounded-lg p-1.5 transition-colors hover:bg-[var(--theme-bg-muted)] ${mobileSidebarOpen ? "bg-[var(--theme-bg-muted)]" : ""}`}
+                  className={`rounded-lg p-1.5 ${
+                    mobileSidebarOpen ? "theme-toolbar-button-active" : "theme-toolbar-button-neutral"
+                  }`}
                   aria-label={mobileSidebarOpen ? "Close menu" : "Open menu"}
                   aria-pressed={mobileSidebarOpen}
                 >
@@ -555,7 +650,7 @@ export function Header({
                   onClick={onDesktopSidebarToggle}
                   {...getToolbarControlProps()}
                   data-testid="desktop-sidebar-toggle"
-                  className="theme-subtle-button rounded-lg p-1.5 transition-colors hover:bg-[var(--theme-bg-muted)]"
+                  className="theme-toolbar-button-neutral rounded-lg p-1.5"
                   aria-label={desktopSidebarMode === "closed" ? "Expand sidebar" : "Collapse sidebar"}
                 >
                   {desktopSidebarMode === "closed" ? (
@@ -578,7 +673,11 @@ export function Header({
                   <button
                     onClick={handleToggleDualColumn}
                     {...getToolbarControlProps()}
-                    className="theme-subtle-button rounded-lg p-2 transition-colors hover:bg-[var(--theme-bg-muted)]"
+                    className={`rounded-lg p-2 ${
+                      display.reading.dualColumnMode
+                        ? "theme-toolbar-button-active"
+                        : "theme-toolbar-button-neutral"
+                    }`}
                     aria-pressed={display.reading.dualColumnMode}
                     aria-label={display.reading.dualColumnMode ? "Hide thumbnail rail" : "Show thumbnail rail"}
                   >
@@ -644,10 +743,10 @@ export function Header({
                     <button
                       onClick={handleToggleFocusMode}
                       {...getToolbarControlProps()}
-                      className={`rounded-lg px-2.5 py-2 text-sm font-bold transition-colors lg:inline-flex ${
+                      className={`rounded-lg px-2.5 py-2 text-sm font-bold lg:inline-flex ${
                         display.reading.focusMode
-                          ? "theme-accent-button"
-                          : "theme-subtle-button hover:bg-[var(--theme-bg-muted)]"
+                          ? "theme-toolbar-button-active"
+                          : "theme-toolbar-button-neutral"
                       }`}
                       aria-pressed={display.reading.focusMode}
                       aria-label="Toggle focus reading mode"
@@ -665,10 +764,10 @@ export function Header({
                     <button
                       onClick={handleToggleReaderSaved}
                       {...getToolbarControlProps()}
-                      className={`rounded-lg p-2 transition-colors ${
+                      className={`rounded-lg p-2 ${
                         selectedItem.userState.saved
-                          ? "theme-accent-button"
-                          : "theme-subtle-button hover:bg-[var(--theme-bg-muted)]"
+                          ? "theme-toolbar-button-active"
+                          : "theme-toolbar-button-neutral"
                       }`}
                       aria-label={selectedItem.userState.saved ? "Unsave" : "Save"}
                     >
@@ -689,10 +788,10 @@ export function Header({
                     <button
                       onClick={handleToggleReaderArchived}
                       {...getToolbarControlProps()}
-                      className={`rounded-lg p-2 transition-colors ${
+                      className={`rounded-lg p-2 ${
                         selectedItem.userState.archived
                           ? "theme-status-pill-success hover:bg-[rgb(var(--theme-feedback-success-rgb)/0.18)]"
-                          : "theme-subtle-button hover:bg-[var(--theme-bg-muted)]"
+                          : "theme-toolbar-button-neutral"
                       }`}
                       aria-label={selectedItem.userState.archived ? "Unarchive" : "Archive"}
                     >
@@ -706,7 +805,7 @@ export function Header({
                     <button
                       onClick={handleOpenReaderUrl}
                       {...getToolbarControlProps()}
-                      className="theme-subtle-button inline-flex items-center gap-1.5 rounded-lg px-2.5 py-2 text-sm"
+                      className="theme-toolbar-button-neutral inline-flex items-center gap-1.5 rounded-lg px-2.5 py-2 text-sm"
                       aria-label="Open"
                     >
                       <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -727,60 +826,77 @@ export function Header({
                   ) : null}
                 </ToolbarAnimatedSlot>
 
-                <ToolbarAnimatedSlot
-                  visible={showWorkspaceIdentityControls}
-                  width={showMapTimeControls ? "min(22rem, 54vw)" : "min(10rem, 34vw)"}
-                  className="flex min-w-0"
-                >
+                <ToolbarAnimatedSlot visible={showWorkspaceIdentityControls} width="12rem">
                   {showWorkspaceIdentityControls ? (
-                    <div className="flex min-w-0 items-center gap-2 overflow-x-auto py-1">
-                      <div className="inline-flex shrink-0 items-center gap-1 rounded-full border border-[color:var(--theme-border-subtle)] bg-[color:color-mix(in_oklab,var(--theme-bg-surface)_86%,transparent)] p-1">
-                        {([
-                          ["friends", "Friends"],
-                          ["all_content", "All content"],
-                        ] as const).map(([mode, label]) => {
-                          const isActive = activeView === "map"
-                            ? effectiveMapMode === mode
-                            : effectiveFriendsMode === mode;
+                    <ToolbarToggleGroup
+                      dataTestId={activeView === "map" ? "map-toolbar-scope" : "friends-toolbar-lens"}
+                      options={[
+                        { value: "friends", label: "Friends" },
+                        { value: "all_content", label: "All content" },
+                      ]}
+                      value={activeView === "map" ? effectiveMapMode : effectiveFriendsMode}
+                      onChange={(mode) =>
+                        handleIdentityModeChange(activeView === "friends" ? "friendsMode" : "mapMode", mode)
+                      }
+                      getButtonProps={getToolbarControlProps}
+                    />
+                  ) : null}
+                </ToolbarAnimatedSlot>
 
-                          return (
-                            <button
-                              key={`${activeView}-${mode}`}
-                              type="button"
-                              onClick={() => handleIdentityModeChange(activeView === "friends" ? "friendsMode" : "mapMode", mode)}
-                              {...getToolbarControlProps()}
-                              className={`rounded-full px-3 py-1.5 text-xs font-medium transition-colors ${
-                                isActive ? "theme-chip-active" : "theme-chip"
-                              }`}
-                            >
-                              {label}
-                            </button>
-                          );
-                        })}
-                      </div>
+                <ToolbarAnimatedSlot visible={showMapTimeControls} width="14rem">
+                  {showMapTimeControls ? (
+                    <ToolbarToggleGroup
+                      dataTestId="map-toolbar-timeframe"
+                      options={[
+                        { value: "current", label: "Current" },
+                        { value: "future", label: "Future" },
+                        { value: "past", label: "Past" },
+                      ]}
+                      value={display.mapTimeMode ?? "current"}
+                      onChange={handleMapTimeModeChange}
+                      compact
+                      getButtonProps={getToolbarControlProps}
+                    />
+                  ) : null}
+                </ToolbarAnimatedSlot>
 
-                      {showMapTimeControls ? (
-                        <div className="inline-flex shrink-0 items-center gap-1 rounded-full border border-[color:var(--theme-border-subtle)] bg-[color:color-mix(in_oklab,var(--theme-bg-surface)_86%,transparent)] p-1">
-                          {([
-                            ["current", "Current"],
-                            ["future", "Future"],
-                            ["past", "Past"],
-                          ] as const).map(([mode, label]) => (
-                            <button
-                              key={`map-time-${mode}`}
-                              type="button"
-                              onClick={() => handleMapTimeModeChange(mode)}
-                              {...getToolbarControlProps()}
-                              className={`rounded-full px-3 py-1.5 text-xs font-medium transition-colors ${
-                                (display.mapTimeMode ?? "current") === mode ? "theme-chip-active" : "theme-chip"
-                              }`}
-                            >
-                              {label}
-                            </button>
-                          ))}
-                        </div>
-                      ) : null}
-                    </div>
+                <ToolbarAnimatedSlot visible={showArchivedToolbar} width="11rem" className="hidden xl:flex">
+                  {showArchivedToolbar ? (
+                    <span className="text-xs text-[var(--theme-text-muted)]">
+                      {getRetentionLabel(display.archivePruneDays ?? 30)}
+                    </span>
+                  ) : null}
+                </ToolbarAnimatedSlot>
+
+                <ToolbarAnimatedSlot
+                  visible={showArchivedToolbar && savedArchivedCount > 0}
+                  width="11rem"
+                  className="hidden lg:flex"
+                >
+                  {showArchivedToolbar && savedArchivedCount > 0 ? (
+                    <button
+                      onClick={handleUnarchiveSavedClick}
+                      {...getToolbarControlProps()}
+                      className="theme-toolbar-button-ghost rounded-lg px-3 py-1.5 text-sm"
+                    >
+                      Unarchive saved
+                    </button>
+                  ) : null}
+                </ToolbarAnimatedSlot>
+
+                <ToolbarAnimatedSlot visible={showArchivedDeleteAction} width="11rem" className="hidden lg:flex">
+                  {showArchivedDeleteAction ? (
+                    <button
+                      onClick={handleDeleteArchivedClick}
+                      {...getToolbarControlProps()}
+                      className={`rounded-lg px-3 py-1.5 text-sm transition-colors ${
+                        deleteConfirmArmed
+                          ? "bg-red-500/20 text-red-400 hover:bg-red-500/30"
+                          : "theme-toolbar-button-ghost"
+                      }`}
+                    >
+                      {deleteConfirmArmed ? "Confirm delete?" : "Delete archived"}
+                    </button>
                   ) : null}
                 </ToolbarAnimatedSlot>
 
@@ -790,7 +906,7 @@ export function Header({
                       <button
                         onClick={() => markAllAsRead(activeFilter.platform)}
                         {...getToolbarControlProps()}
-                        className="flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm text-[var(--theme-text-muted)] transition-colors hover:bg-[var(--theme-bg-muted)] hover:text-[var(--theme-text-primary)]"
+                        className="theme-toolbar-button-ghost flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm"
                       >
                         <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
@@ -807,7 +923,7 @@ export function Header({
                       <button
                         onClick={() => archiveAllReadUnsaved(activeFilter.platform, activeFilter.feedUrl)}
                         {...getToolbarControlProps()}
-                        className="flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm text-[var(--theme-text-muted)] transition-colors hover:bg-[var(--theme-bg-muted)] hover:text-[var(--theme-text-primary)]"
+                        className="theme-toolbar-button-ghost flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm"
                       >
                         <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />

--- a/packages/ui/src/components/map/MapView.tsx
+++ b/packages/ui/src/components/map/MapView.tsx
@@ -152,14 +152,14 @@ export function MapView() {
   return (
     <div className="app-theme-shell relative h-full overflow-hidden">
       {savedTimeMode !== "current" && timelineMoments.length > 0 && effectiveTimelineIndex !== null ? (
-        <div className="pointer-events-none absolute inset-x-0 top-0 z-20 flex justify-center px-4 pt-4">
+        <div className="pointer-events-none absolute bottom-4 left-4 z-20 flex justify-start">
           <div
-            className="pointer-events-auto w-full max-w-[min(40rem,calc(100vw-2rem))] rounded-[24px] border border-[color:var(--theme-border-subtle)] bg-[color:color-mix(in_oklab,var(--theme-bg-elevated)_88%,transparent)] px-4 py-3 shadow-[var(--theme-glow-sm)] backdrop-blur-md"
+            className="pointer-events-auto theme-floating-panel w-[min(25rem,calc(100vw-2rem))] px-4 py-3"
             data-testid="map-timeline-scrubber"
           >
-            <div className="flex items-center justify-between gap-3 text-[11px] font-medium uppercase tracking-[0.22em] text-[color:var(--theme-text-muted)]">
-              <span>{savedTimeMode === "past" ? "History scrub" : "Future playback"}</span>
-              <span className="text-right normal-case tracking-normal text-[color:var(--theme-text-primary)]">
+            <div className="flex items-center justify-between gap-3 text-[10px] font-medium text-[color:var(--theme-text-muted)]">
+              <span>{savedTimeMode === "past" ? "History" : "Future"}</span>
+              <span className="text-right text-[color:var(--theme-text-secondary)]">
                 {formatTimelineMoment(timelineMoments[effectiveTimelineIndex])}
               </span>
             </div>
@@ -170,10 +170,10 @@ export function MapView() {
               step={1}
               value={effectiveTimelineIndex}
               aria-label="Map timeline scrubber"
-              className="mt-3 h-2 w-full accent-[var(--theme-accent-primary)]"
+              className="mt-3 h-2 w-full accent-[var(--theme-accent-secondary)]"
               onChange={(event) => handleTimelineScrub(Number.parseInt(event.currentTarget.value, 10))}
             />
-            <div className="mt-2 flex items-center justify-between text-[11px] text-[color:var(--theme-text-muted)]">
+            <div className="mt-2 flex items-center justify-between text-[10px] text-[color:var(--theme-text-soft)]">
               <span>{formatTimelineEdge(timelineMoments[0])}</span>
               <span>{formatTimelineEdge(timelineMoments[timelineMoments.length - 1])}</span>
             </div>

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -1481,6 +1481,7 @@ html[data-theme="scriptorium"] .theme-floating-panel {
 }
 
 .theme-subtle-button {
+  cursor: pointer;
   color: var(--theme-text-muted);
   transition:
     color 0.18s ease,
@@ -1494,6 +1495,7 @@ html[data-theme="scriptorium"] .theme-floating-panel {
 }
 
 .theme-accent-button {
+  cursor: pointer;
   background: rgb(var(--theme-accent-secondary-rgb) / 0.16);
   color: var(--theme-accent-secondary);
   border: 1px solid rgb(var(--theme-accent-secondary-rgb) / 0.24);
@@ -1501,6 +1503,58 @@ html[data-theme="scriptorium"] .theme-floating-panel {
 
 .theme-accent-button:hover {
   background: rgb(var(--theme-accent-secondary-rgb) / 0.24);
+}
+
+.theme-toolbar-button-neutral {
+  cursor: pointer;
+  border: 1px solid var(--theme-border-subtle);
+  background: var(--theme-button-secondary-background);
+  color: var(--theme-text-secondary);
+  transition:
+    color 0.18s ease,
+    background-color 0.18s ease,
+    border-color 0.18s ease;
+}
+
+.theme-toolbar-button-neutral:hover {
+  color: var(--theme-text-primary);
+  background: var(--theme-bg-muted);
+  border-color: var(--theme-border-subtle);
+}
+
+.theme-toolbar-button-ghost {
+  cursor: pointer;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--theme-text-secondary);
+  transition:
+    color 0.18s ease,
+    background-color 0.18s ease,
+    border-color 0.18s ease;
+}
+
+.theme-toolbar-button-ghost:hover {
+  color: var(--theme-text-primary);
+  background: var(--theme-bg-muted);
+  border-color: var(--theme-border-subtle);
+}
+
+.theme-toolbar-button-active {
+  cursor: pointer;
+  border: 1px solid rgb(var(--theme-accent-secondary-rgb) / 0.72);
+  background: rgb(var(--theme-accent-secondary-rgb) / 0.16);
+  color: var(--theme-text-primary);
+  box-shadow: inset 0 0 0 1px rgb(var(--theme-accent-secondary-rgb) / 0.18);
+  transition:
+    color 0.18s ease,
+    background-color 0.18s ease,
+    border-color 0.18s ease,
+    box-shadow 0.18s ease;
+}
+
+.theme-toolbar-button-active:hover {
+  background: rgb(var(--theme-accent-secondary-rgb) / 0.2);
+  border-color: rgb(var(--theme-accent-secondary-rgb) / 0.82);
 }
 
 .theme-fab-button {
@@ -1535,7 +1589,7 @@ html[data-theme="scriptorium"] .theme-floating-panel {
 }
 
 .theme-toolbar-cluster > .theme-toolbar-slot + .theme-toolbar-slot {
-  margin-inline-start: 0.5rem;
+  margin-inline-start: 0.75rem;
 }
 
 .theme-reader-rail-slot {
@@ -1544,18 +1598,22 @@ html[data-theme="scriptorium"] .theme-floating-panel {
 
 .theme-toolbar-slot {
   display: flex;
-  flex: 0 0 var(--toolbar-slot-width, auto);
   align-items: center;
   min-width: 0;
-  width: var(--toolbar-slot-width, auto);
   max-width: var(--toolbar-slot-width, 16rem);
   overflow: hidden;
   opacity: 1;
   transform: translateX(0);
   transition:
+    max-width 0.24s cubic-bezier(0.22, 1, 0.36, 1),
     opacity 0.18s ease,
     transform 0.24s cubic-bezier(0.22, 1, 0.36, 1),
     margin-inline-start 0.24s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.theme-toolbar-slot-visible {
+  overflow: visible;
+  max-width: fit-content;
 }
 
 .theme-toolbar-slot-hidden {
@@ -1563,6 +1621,8 @@ html[data-theme="scriptorium"] .theme-floating-panel {
   opacity: 0;
   transform: translateX(10px);
   pointer-events: none;
+  overflow: hidden;
+  margin-inline-start: 0 !important;
 }
 
 .theme-toolbar-slot-hidden > * {
@@ -2060,6 +2120,93 @@ html[data-theme="scriptorium"] .btn-primary:hover {
   );
   color: var(--theme-text-primary);
   box-shadow: var(--theme-glow-sm);
+}
+
+.theme-toolbar-segmented {
+  display: inline-flex;
+  align-items: center;
+  height: 2.25rem;
+  overflow: hidden;
+  border: 1px solid var(--theme-border-subtle);
+  border-radius: var(--button-radius);
+  background: var(--theme-button-secondary-background);
+}
+
+.theme-toolbar-segmented-compact {
+  height: 2.25rem;
+}
+
+.theme-toolbar-segment {
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  height: 100%;
+  padding: 0 0.95rem;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  font-size: 0.9375rem;
+  font-weight: 500;
+  line-height: 1;
+  transition:
+    background-color 0.18s ease,
+    color 0.18s ease,
+    box-shadow 0.18s ease;
+}
+
+.theme-toolbar-segment:first-child {
+  border-top-left-radius: calc(var(--button-radius) - 1px);
+  border-bottom-left-radius: calc(var(--button-radius) - 1px);
+}
+
+.theme-toolbar-segment:last-child {
+  border-top-right-radius: calc(var(--button-radius) - 1px);
+  border-bottom-right-radius: calc(var(--button-radius) - 1px);
+}
+
+.theme-toolbar-segment-inactive {
+  color: var(--theme-text-secondary);
+}
+
+.theme-toolbar-segment-inactive:hover {
+  background: var(--theme-bg-muted);
+  color: var(--theme-text-primary);
+}
+
+.theme-toolbar-segment-active {
+  background: rgb(var(--theme-accent-secondary-rgb) / 0.16);
+  color: var(--theme-text-primary);
+  box-shadow: inset 0 0 0 1px rgb(var(--theme-accent-secondary-rgb) / 0.72);
+  z-index: 1;
+}
+
+.theme-toolbar-segment + .theme-toolbar-segment {
+  position: relative;
+}
+
+.theme-toolbar-segment + .theme-toolbar-segment::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0.35rem;
+  bottom: 0.35rem;
+  width: 1px;
+  background: var(--theme-border-subtle);
+  pointer-events: none;
+}
+
+.theme-toolbar-segmented-compact .theme-toolbar-segment {
+  padding-inline: 0.9rem;
+  font-size: 0.9rem;
+}
+
+[data-testid="app-sidebar"] button,
+[data-testid="app-sidebar-mobile"] button,
+[data-testid="app-sidebar"] [role="button"],
+[data-testid="app-sidebar-mobile"] [role="button"] {
+  cursor: pointer;
 }
 
 .theme-section {

--- a/website/src/app/roadmap/RoadmapContent.tsx
+++ b/website/src/app/roadmap/RoadmapContent.tsx
@@ -765,7 +765,7 @@ const phases: Phase[] = [
     number: 8,
     title: "Friends + Social Graph",
     description:
-      "A people CRM with a canonical Person plus Account identity graph, a stable pan-and-zoom Friends workspace that defaults to All content with confirmed friend hubs, linked channel satellites, and peripheral captured accounts, drag-and-drop plus sidebar linking and promotion flows, Google Contacts imports that create friend people by default, suggestion-only same-person review across platforms, and a map that resolves identity through linked accounts with shared header controls plus current, future, and past filters with a timeline scrubber for replaying history and upcoming plans.",
+      "A people CRM with a canonical Person plus Account identity graph, a stable pan-and-zoom Friends workspace that defaults to All content with confirmed friend hubs, linked channel satellites, and peripheral captured accounts, drag-and-drop plus sidebar linking and promotion flows, Google Contacts imports that create friend people by default, suggestion-only same-person review across platforms, and a map that resolves identity through linked accounts with unified header controls plus current, future, and past filters while a quieter lower-left timeline scrubber replays history and upcoming plans.",
     status: "current",
     planLink:
       "https://github.com/freed-project/freed/blob/dev/docs/PHASE-8-FRIENDS.md",


### PR DESCRIPTION
(AI Generated).

## Summary
- restore time-aware map filtering and the in-map timeline scrubber
- polish unified toolbar spacing, button states, hover affordances, and pointer behavior
- sync Phase 8 docs and the website roadmap copy with the restored map timeline behavior

## Validation
- `node ../../node_modules/playwright/cli.js test tests/e2e/smoke.spec.ts --grep "view-specific controls|selected timeframe has no markers|restores the in-map timeline scrubber|archived and search states"`
- `node ../../node_modules/playwright/cli.js test tests/app.spec.ts --grep "map popovers show update time and keep only one open"`
