### PR TITLE
fix: align pwa map navigation tests

### DIFF
--- a/packages/pwa/src/lib/map-locations.test.ts
+++ b/packages/pwa/src/lib/map-locations.test.ts
@@ -462,16 +462,18 @@ describe("map navigation helpers", () => {
     ]);
 
     const setActiveView = vi.fn();
-    const setSelectedFriend = vi.fn();
+    const setSelectedPerson = vi.fn();
+    const setSelectedAccount = vi.fn();
     const setSelectedItem = vi.fn();
 
     openFriendFromMap(marker, {
       setActiveView,
-      setSelectedFriend,
+      setSelectedPerson,
+      setSelectedAccount,
       setSelectedItem,
     });
 
-    expect(setSelectedFriend).toHaveBeenCalledWith(friend.id);
+    expect(setSelectedPerson).toHaveBeenCalledWith(friend.id);
     expect(setSelectedItem).toHaveBeenCalledWith(null);
     expect(setActiveView).toHaveBeenCalledWith("friends");
   });
@@ -489,14 +491,16 @@ describe("map navigation helpers", () => {
     ]);
 
     const setActiveView = vi.fn();
-    const setSelectedFriend = vi.fn();
+    const setSelectedPerson = vi.fn();
+    const setSelectedAccount = vi.fn();
     const setSelectedItem = vi.fn();
     const setFilter = vi.fn();
     const setSearchQuery = vi.fn();
 
     openPostFromMap(marker, {
       setActiveView,
-      setSelectedFriend,
+      setSelectedPerson,
+      setSelectedAccount,
       setSelectedItem,
       setFilter,
       setSearchQuery,
@@ -504,7 +508,7 @@ describe("map navigation helpers", () => {
 
     expect(setFilter).toHaveBeenCalledWith({});
     expect(setSearchQuery).toHaveBeenCalledWith("");
-    expect(setSelectedFriend).toHaveBeenCalledWith(friend.id);
+    expect(setSelectedPerson).toHaveBeenCalledWith(friend.id);
     expect(setSelectedItem).toHaveBeenCalledWith("ig:1");
     expect(setActiveView).toHaveBeenCalledWith("feed");
   });


### PR DESCRIPTION
(AI Generated).

## Summary

- fix the `@freed/pwa` test typing mismatch that breaks Vercel `dev` branch builds
- update map navigation tests to use `setSelectedPerson` and include the current action shape

## Root Cause

The map navigation helpers now take `setSelectedPerson`, but `packages/pwa/src/lib/map-locations.test.ts` still passed `setSelectedFriend`. Vercel's Git driven `dev` preview deployment compiled the test file and failed before the new preview could be promoted.

## Validation

- `npm run build --workspace=packages/pwa`
- `npm run test:unit --workspace=packages/pwa -- map-locations.test.ts`
