### PR TITLE
fix: keep marketing theme preview hover stable

### DIFF
--- a/website/src/components/ThemeSelector.tsx
+++ b/website/src/components/ThemeSelector.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import {
-  useLayoutEffect,
+  useEffect,
   useRef,
   useState,
 } from "react";
+import { createPortal } from "react-dom";
+import type { ThemeId } from "@freed/shared/themes";
 import { ThemePreviewButton } from "@freed/ui/components/ThemePreviewButton";
 import { Tooltip } from "@freed/ui/components/Tooltip";
 import { THEME_DEFINITIONS, useTheme } from "@/context/ThemeContext";
@@ -13,101 +15,131 @@ interface ThemeSelectorProps {
   compact?: boolean;
 }
 
-interface LockedRect {
-  height: number;
+interface FloatingRect {
   left: number;
   top: number;
   width: number;
 }
 
 export default function ThemeSelector({ compact = false }: ThemeSelectorProps) {
-  const { activeThemeId, themeId, setThemeId, previewTheme, revertPreview } = useTheme();
+  const { themeId, setThemeId, previewTheme, revertPreview } = useTheme();
   const gapClassName = compact ? "gap-2" : "gap-3";
   const wrapperRef = useRef<HTMLDivElement | null>(null);
-  const [pointerPreviewThemeId, setPointerPreviewThemeId] = useState<string | null>(null);
-  const [lockedRect, setLockedRect] = useState<LockedRect | null>(null);
-  const shouldLockPosition = compact && pointerPreviewThemeId !== null && activeThemeId !== themeId;
+  const [floatingRect, setFloatingRect] = useState<FloatingRect | null>(null);
+  const isFloating = compact && floatingRect !== null;
 
-  useLayoutEffect(() => {
-    if (!shouldLockPosition) {
-      setLockedRect(null);
+  useEffect(() => {
+    if (!isFloating) {
       return;
     }
 
-    const wrapper = wrapperRef.current;
-    if (!wrapper) {
-      return;
+    function clearFloatingPreview() {
+      setFloatingRect(null);
+      revertPreview();
     }
 
-    const rect = wrapper.getBoundingClientRect();
-    setLockedRect({
-      height: rect.height,
-      left: rect.left,
-      top: rect.top,
-      width: rect.width,
-    });
-  }, [shouldLockPosition]);
+    window.addEventListener("resize", clearFloatingPreview);
+    window.addEventListener("scroll", clearFloatingPreview, true);
+    return () => {
+      window.removeEventListener("resize", clearFloatingPreview);
+      window.removeEventListener("scroll", clearFloatingPreview, true);
+    };
+  }, [isFloating, revertPreview]);
 
-  function clearPointerPreview() {
-    setPointerPreviewThemeId(null);
+  function activatePreview(themeId: ThemeId) {
+    if (compact && floatingRect === null) {
+      const rect = wrapperRef.current?.getBoundingClientRect();
+      if (rect) {
+        setFloatingRect({
+          left: rect.left,
+          top: rect.top,
+          width: rect.width,
+        });
+      }
+    }
+
+    previewTheme(themeId);
+  }
+
+  function clearPreview() {
+    setFloatingRect(null);
     revertPreview();
   }
 
-  return (
-    <div
-      ref={wrapperRef}
-      className="relative"
-      style={lockedRect ? { height: `${lockedRect.height}px` } : undefined}
-    >
-      <div
-        className="flex flex-col"
-        style={lockedRect ? {
-          left: `${lockedRect.left}px`,
-          position: "fixed",
-          top: `${lockedRect.top}px`,
-          width: `${lockedRect.width}px`,
-          zIndex: 40,
-        } : undefined}
-      >
+  function commitTheme(themeId: ThemeId) {
+    setFloatingRect(null);
+    setThemeId(themeId);
+  }
+
+  function renderSelectorContent() {
+    return (
+      <>
         <h4 className="mb-4 text-text-primary font-semibold">Theme</h4>
         <div
           className={`flex flex-wrap items-center ${gapClassName}`}
-          onMouseLeave={clearPointerPreview}
+          onMouseLeave={clearPreview}
           onBlurCapture={(event) => {
             const nextFocused = event.relatedTarget;
             if (nextFocused && event.currentTarget.contains(nextFocused)) {
               return;
             }
 
-            clearPointerPreview();
+            clearPreview();
           }}
         >
           {THEME_DEFINITIONS.map((theme) => (
-            <Tooltip
+            <div
               key={theme.id}
-              side="top"
-              label={theme.name}
-              description={theme.description}
-              className="h-[2.2rem] items-center sm:h-[2.4rem]"
+              className="flex items-center"
+              onMouseEnter={() => activatePreview(theme.id)}
             >
-              <ThemePreviewButton
-                theme={theme}
-                active={themeId === theme.id}
-                variant="compact"
-                onMouseEnter={() => {
-                  setPointerPreviewThemeId(theme.id);
-                  previewTheme(theme.id);
-                }}
-                onFocus={() => previewTheme(theme.id)}
-                onClick={() => {
-                  setPointerPreviewThemeId(null);
-                  setThemeId(theme.id);
-                }}
-              />
-            </Tooltip>
+              <Tooltip
+                side="top"
+                label={theme.name}
+                description={theme.description}
+                className="h-[2.2rem] items-center sm:h-[2.4rem]"
+              >
+                <ThemePreviewButton
+                  theme={theme}
+                  active={themeId === theme.id}
+                  variant="compact"
+                  onFocus={() => previewTheme(theme.id)}
+                  onClick={() => commitTheme(theme.id)}
+                />
+              </Tooltip>
+            </div>
           ))}
         </div>
+      </>
+    );
+  }
+
+  return (
+    <div ref={wrapperRef} className="relative">
+      <div
+        aria-hidden={isFloating || undefined}
+        className="flex flex-col"
+        style={isFloating ? { visibility: "hidden" } : undefined}
+      >
+        {renderSelectorContent()}
       </div>
+      {isFloating && typeof document !== "undefined"
+        ? createPortal(
+          <div
+            className="fixed z-[80]"
+            style={{
+              left: `${floatingRect!.left}px`,
+              top: `${floatingRect!.top}px`,
+              width: `${floatingRect!.width}px`,
+            }}
+          >
+            <div className="flex flex-col">
+              {renderSelectorContent()}
+            </div>
+          </div>,
+          document.body,
+        )
+        : null}
     </div>
   );
 }


### PR DESCRIPTION
(AI Generated). 

## Summary
- replace the in-place floating selector mutation with a portal-based fixed overlay during hover preview
- keep an invisible in-flow placeholder so header reflow does not collapse the footer layout
- preserve click, focus, and preview behavior while preventing the hovered theme control from being dragged away by large header font shifts

## Verification
- `git diff --check`

## Notes
- I was not able to run a trustworthy local website build in this fresh worktree because the local workspace install path is currently failing in unrelated dependency and tooling resolution.
