### PR TITLE
fix: load PWA map assets through Vite

### DIFF
--- a/packages/pwa/tests/app.spec.ts
+++ b/packages/pwa/tests/app.spec.ts
@@ -1376,15 +1376,24 @@ test.describe("FREED PWA", () => {
   });
 
   test("map popovers show update time and keep only one open", async ({ page }) => {
+    const mapAssetResponses: Array<{ url: string; status: number }> = [];
+    page.on("response", (response) => {
+      const url = response.url();
+      if (url.includes("maplibre-gl")) {
+        mapAssetResponses.push({ url, status: response.status() });
+      }
+    });
+
     await page.goto("/");
     await acceptLegalGate(page);
     await seedMultipleFriendLocations(page);
 
     await page.getByRole("button", { name: "Map" }).click();
+    await expect(page.getByText("Map failed to load")).toHaveCount(0);
     await page.getByRole("button", { name: "Omar Hassan" }).click();
     await expect(page.getByText("Reykjavik, Capital Region, Iceland")).toBeVisible();
     await expect(page.getByText(/ago/).first()).toBeVisible();
-    await expect(page.getByRole("button", { name: "Open Friend" })).toHaveCount(1);
+    await expect(page.getByRole("button", { name: "Open Post" })).toHaveCount(1);
     const livePopup = page.locator(".maplibregl-popup-content");
     const fallbackPopup = page.getByTestId("map-fallback-popup");
     const useLivePopup = await livePopup.isVisible().catch(() => false);
@@ -1400,7 +1409,9 @@ test.describe("FREED PWA", () => {
     await page.getByRole("button", { name: "Samir Dutta" }).click();
     await expect(page.getByText("Paris")).toBeVisible();
     await expect(page.getByText("Reykjavik, Capital Region, Iceland")).toHaveCount(0);
-    await expect(page.getByRole("button", { name: "Open Friend" })).toHaveCount(1);
+    await expect(page.getByRole("button", { name: "Open Post" })).toHaveCount(1);
+    expect(mapAssetResponses.length).toBeGreaterThan(0);
+    expect(mapAssetResponses.some(({ status }) => status === 403)).toBeFalsy();
   });
 
   test("can add an RSS feed", async ({ page }) => {

--- a/packages/pwa/vite.config.ts
+++ b/packages/pwa/vite.config.ts
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react'
 import wasm from 'vite-plugin-wasm'
 import topLevelAwait from 'vite-plugin-top-level-await'
 import { VitePWA } from 'vite-plugin-pwa'
+import { realpathSync } from 'fs'
 import { fileURLToPath } from 'url'
 import pkg from './package.json' with { type: 'json' }
 import { getBuildMetadata } from '../../scripts/lib/build-metadata.mjs'
@@ -11,6 +12,20 @@ import { getBuildMetadata } from '../../scripts/lib/build-metadata.mjs'
 // worktrees don't need to build dist/ artifacts before running the dev server.
 const src = (name: string) =>
   fileURLToPath(new URL(`../${name}/src`, import.meta.url))
+
+const workspaceRoot = fileURLToPath(new URL('../..', import.meta.url))
+const workspaceNodeModules = fileURLToPath(new URL('../../node_modules', import.meta.url))
+const fsAllow = [
+  workspaceRoot,
+  workspaceNodeModules,
+  (() => {
+    try {
+      return realpathSync(workspaceNodeModules)
+    } catch {
+      return workspaceNodeModules
+    }
+  })(),
+]
 
 const buildMetadata = getBuildMetadata(pkg.version)
 
@@ -32,6 +47,11 @@ export default defineConfig({
   worker: {
     format: 'es',
     plugins: () => [wasm(), topLevelAwait()],
+  },
+  server: {
+    fs: {
+      allow: fsAllow,
+    },
   },
 
   plugins: [

--- a/packages/ui/src/components/map/MapSurface.tsx
+++ b/packages/ui/src/components/map/MapSurface.tsx
@@ -31,11 +31,7 @@ type MapInstance = {
   off: (event: string, handler: () => void) => void;
 };
 
-type MapLibreModule = {
-  Map: new (options: unknown) => MapInstance;
-  Marker: new (options: { element: HTMLElement }) => MarkerInstance;
-  Popup: new (options?: unknown) => PopupInstance;
-};
+type MapLibreModule = typeof import("maplibre-gl");
 
 interface MapSurfaceProps {
   markers: LocationMarkerSummary[];
@@ -50,19 +46,7 @@ interface MapSurfaceProps {
   emptyBody?: string;
 }
 
-const MAPLIBRE_MODULE_PATH =
-  new URL(
-    "../../../../../node_modules/maplibre-gl/dist/maplibre-gl.js",
-    import.meta.url
-  ).href;
-const MAPLIBRE_CSS_PATH =
-  new URL(
-    "../../../../../node_modules/maplibre-gl/dist/maplibre-gl.css",
-    import.meta.url
-  ).href;
-
 let mapLibreLoader: Promise<MapLibreModule> | null = null;
-let mapLibreCssLoaded = false;
 const popupDateFormatter = new Intl.DateTimeFormat(undefined, {
   month: "short",
   day: "numeric",
@@ -109,52 +93,21 @@ function popupMeta(marker: LocationMarkerSummary): string {
   return `${popupRelativeTime(marker.seenAt)} · ${popupAbsoluteTime(marker.seenAt)}`;
 }
 
-function ensureMapLibreCss() {
-  if (typeof document === "undefined" || mapLibreCssLoaded) return;
-  const existing = document.querySelector(`link[data-freed-maplibre="true"]`);
-  if (existing) {
-    mapLibreCssLoaded = true;
-    return;
-  }
-
-  const link = document.createElement("link");
-  link.rel = "stylesheet";
-  link.href = MAPLIBRE_CSS_PATH;
-  link.dataset.freedMaplibre = "true";
-  document.head.appendChild(link);
-  mapLibreCssLoaded = true;
-}
-
 function loadMapLibre(): Promise<MapLibreModule> {
   if (typeof window === "undefined") {
     return Promise.reject(new Error("window is unavailable"));
   }
 
-  const globalModule = (
-    window as Window & { maplibregl?: MapLibreModule }
-  ).maplibregl;
-  if (globalModule) {
-    return Promise.resolve(globalModule);
-  }
-
   if (mapLibreLoader) return mapLibreLoader;
 
-  mapLibreLoader = new Promise((resolve, reject) => {
-    const script = document.createElement("script");
-    script.src = MAPLIBRE_MODULE_PATH;
-    script.async = true;
-    script.onload = () => {
-      const loadedModule = (
-        window as Window & { maplibregl?: MapLibreModule }
-      ).maplibregl;
-      if (loadedModule) {
-        resolve(loadedModule);
-        return;
-      }
-      reject(new Error("maplibregl global was not initialized"));
-    };
-    script.onerror = () => reject(new Error("Failed to load maplibre-gl"));
-    document.head.appendChild(script);
+  // Let Vite own the asset URLs so parallel worktrees do not depend on raw
+  // @fs paths into whichever checkout currently holds node_modules.
+  mapLibreLoader = Promise.all([
+    import("maplibre-gl"),
+    import("maplibre-gl/dist/maplibre-gl.css"),
+  ]).then(([module]) => module).catch((error) => {
+    mapLibreLoader = null;
+    throw error;
   });
 
   return mapLibreLoader;
@@ -568,8 +521,6 @@ export function MapSurface({
         mapRef.current = null;
       };
     }
-
-    ensureMapLibreCss();
 
     void Promise.all([
       loadMapLibre(),

--- a/packages/ui/src/globals.d.ts
+++ b/packages/ui/src/globals.d.ts
@@ -5,4 +5,7 @@ declare global {
   const __BUILD_COMMIT_REF__: string | null;
   const __BUILD_DEPLOYED_AT__: string | null;
 }
+
+declare module "*.css";
+
 export {};


### PR DESCRIPTION
(AI Generated).

## Summary
- load MapLibre through Vite-managed lazy imports instead of manual node_modules asset injection
- allow the PWA dev server to serve the real node_modules path used by symlinked worktrees
- cover the regression in the PWA map popup test by asserting MapLibre assets no longer fail with 403

## Testing
- ./node_modules/.bin/playwright test packages/pwa/tests/app.spec.ts --grep "map popovers show update time and keep only one open" --config packages/pwa/playwright.config.ts