### PR TITLE
fix: polish mobile settings navigation

### DIFF
--- a/docs/PHASE-5-DESKTOP.md
+++ b/docs/PHASE-5-DESKTOP.md
@@ -265,6 +265,7 @@ export async function captureDomFeed(
 - [x] Reader toolbar controls now lock to the live sidebar and thumbnail-rail widths, so the sidebar toggle, dual-column toggle, and back-to-list control stay aligned with the floating cards below them
 - [x] Settings now use a shared polished dropdown treatment, and Appearance keeps the theme selector as one compact row instead of a descriptive mini card with live hover and focus previews across every theme
 - [x] Settings use a stronger modal shadow plus a blur-only frosted backdrop, the backdrop temporarily clears while previewing themes so desktop and touch users can see the active page treatment underneath, and hover previews now blur between the previous and next theme before snapping back unless the user clicks
+- [x] The shared Settings shell now keeps the desktop close control aligned with the left sidebar header, while the mobile sheet runs flush to the top edge with a tighter toolbar and reliable section-to-section navigation
 - [x] Appearance now exposes `Show read in grayscale`, and mark-read-on-scroll correctly normalizes mobile list offsets before deciding which rows have scrolled past
 - [x] Desktop resize grips now live in the gaps between floating panels and use neutral hover feedback instead of a loud accent stripe
 - [x] Friends and Map sit directly under `All` in the primary Sources sidebar so navigation order matches the product's main reading flow

--- a/docs/PHASE-6-PWA.md
+++ b/docs/PHASE-6-PWA.md
@@ -248,6 +248,7 @@ Build chain: `@freed/shared` → `@freed/sync` → `vite build` (configured in `
 - [x] Settings and crash recovery surfaces can export public-safe bug report bundles
 - [x] PWA Settings surfaces X / Twitter, Facebook, Instagram, and LinkedIn with Freed Desktop sync and download handoff states
 - [x] Theme changes in Settings temporarily clear the frosted backdrop on touch devices so the active page treatment stays visible while previewing themes
+- [x] Mobile Settings now open as a full-height sheet with a persistent close button, larger back target, and reliable section jumps instead of snapping back to the last scrolled provider section
 - [x] Appearance exposes `Show read in grayscale`, and mark-read-on-scroll now subtracts the feed list offset before marking mobile rows as passed
 - [x] The shared floating mobile sidebar now behaves like a real toggle, so the same hamburger button opens and closes it cleanly
 - [x] Private diagnostics stay opt-in and are clearly separated from public GitHub sharing

--- a/packages/ui/src/components/SettingsDialog.tsx
+++ b/packages/ui/src/components/SettingsDialog.tsx
@@ -55,6 +55,7 @@ import { SearchField } from "./SearchField.js";
 import { ThemePreviewButton } from "./ThemePreviewButton.js";
 import { Tooltip } from "./Tooltip.js";
 import { GoogleContactsIcon } from "./icons.js";
+import { useIsMobile } from "../hooks/useIsMobile.js";
 
 const SAMPLE_SEED_FEED_COUNT = 10;
 const SAMPLE_SEED_ITEM_COUNT = 155;
@@ -251,6 +252,7 @@ type UpdateCheckState =
 // ── Main component ────────────────────────────────────────────────────────────
 
 export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
+  const isMobile = useIsMobile();
   const {
     SettingsExtraSections,
     LegalSettingsContent,
@@ -369,15 +371,18 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
   useEffect(() => {
     if (typeof window === "undefined") return;
 
-    const media = window.matchMedia("(pointer: coarse)");
+    const coarsePointerMedia = window.matchMedia("(pointer: coarse)");
+    const hoverCapableMedia = window.matchMedia("(any-hover: hover)");
     const updatePointerMode = () => {
-      setHasCoarsePointer(media.matches || navigator.maxTouchPoints > 0);
+      setHasCoarsePointer(coarsePointerMedia.matches && !hoverCapableMedia.matches);
     };
 
     updatePointerMode();
-    media.addEventListener?.("change", updatePointerMode);
+    coarsePointerMedia.addEventListener?.("change", updatePointerMode);
+    hoverCapableMedia.addEventListener?.("change", updatePointerMode);
     return () => {
-      media.removeEventListener?.("change", updatePointerMode);
+      coarsePointerMedia.removeEventListener?.("change", updatePointerMode);
+      hoverCapableMedia.removeEventListener?.("change", updatePointerMode);
     };
   }, []);
 
@@ -716,9 +721,43 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
     }
   }, [searchLower, visibleSections]);
 
+  const scrollSectionIntoView = useCallback((id: SectionId, behavior: ScrollBehavior = "smooth") => {
+    const container = scrollRef.current;
+    if (!container) {
+      return;
+    }
+
+    const el = container.querySelector<HTMLElement>(`[data-section="${id}"]`);
+    if (!el) {
+      return;
+    }
+
+    const targetTop = Math.max(0, el.offsetTop - 16);
+
+    isScrollingProgrammatically.current = true;
+    clearTimeout(scrollEndTimerRef.current);
+
+    if (behavior === "auto") {
+      container.scrollTop = targetTop;
+      requestAnimationFrame(() => {
+        isScrollingProgrammatically.current = false;
+      });
+      return;
+    }
+
+    const clearScrolling = () => {
+      isScrollingProgrammatically.current = false;
+    };
+
+    container.addEventListener("scrollend", clearScrolling, { once: true });
+    scrollEndTimerRef.current = setTimeout(clearScrolling, 800);
+
+    container.scrollTo({ top: targetTop, behavior });
+  }, []);
+
   useEffect(() => {
     const root = scrollRef.current;
-    if (!root || searchLower) return;
+    if (!root || searchLower || (isMobile && mobileView === "nav")) return;
 
     const updateActiveSectionFromScroll = () => {
       if (isScrollingProgrammatically.current) return;
@@ -752,34 +791,23 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
       root.removeEventListener("scroll", updateActiveSectionFromScroll);
       window.removeEventListener("resize", updateActiveSectionFromScroll);
     };
-  }, [open, searchLower]);
+  }, [isMobile, mobileView, open, searchLower]);
 
   const scrollToSection = useCallback((id: SectionId) => {
     setActiveSection(id);
-    if (scrollRef.current) {
-      const el = scrollRef.current.querySelector<HTMLElement>(`[data-section="${id}"]`);
-      if (el) {
-        const container = scrollRef.current;
-        const elTop = el.getBoundingClientRect().top - container.getBoundingClientRect().top;
-
-        // Lock out the observer so intermediate sections don't flicker
-        isScrollingProgrammatically.current = true;
-        clearTimeout(scrollEndTimerRef.current);
-
-        const clearScrolling = () => {
-          isScrollingProgrammatically.current = false;
-        };
-        // scrollend fires when the animation settles (Chrome/FF/Safari 17.4+)
-        container.addEventListener("scrollend", clearScrolling, { once: true });
-        // Timeout fallback for older Safari
-        scrollEndTimerRef.current = setTimeout(clearScrolling, 800);
-
-        container.scrollBy({ top: elTop - 16, behavior: "smooth" });
-      }
+    if (isMobile && mobileView === "nav") {
+      setMobileView("section");
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          scrollSectionIntoView(id, "auto");
+        });
+      });
+      return;
     }
-    // On mobile, switch to section view
+
+    scrollSectionIntoView(id, "smooth");
     setMobileView("section");
-  }, []);
+  }, [isMobile, mobileView, scrollSectionIntoView]);
 
   // ── Mobile nav state ──────────────────────────────────────────────────────
   const [mobileView, setMobileView] = useState<"nav" | "section">("nav");
@@ -796,18 +824,16 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
   const { targetSection, clearTarget } = useSettingsStore();
   useEffect(() => {
     if (!open || !targetSection) return;
-    // Wait one frame for the DOM to be fully painted before scrolling
     const rafId = requestAnimationFrame(() => {
-      const el = scrollRef.current?.querySelector<HTMLElement>(`[data-section="${targetSection}"]`);
-      if (el && scrollRef.current) {
-        scrollRef.current.scrollTop = el.offsetTop - 16;
-        setActiveSection(targetSection as SectionId);
-        setMobileView("section");
-      }
+      setActiveSection(targetSection as SectionId);
+      setMobileView("section");
+      requestAnimationFrame(() => {
+        scrollSectionIntoView(targetSection as SectionId, "auto");
+      });
       clearTarget();
     });
     return () => cancelAnimationFrame(rafId);
-  }, [open, targetSection, clearTarget]);
+  }, [clearTarget, open, scrollSectionIntoView, targetSection]);
 
   // Body scroll lock
   useEffect(() => {
@@ -834,9 +860,9 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
         onClick={onClose}
         aria-label="Close settings"
         data-testid={testId}
-        className={`inline-flex h-9 w-9 items-center justify-center rounded-lg text-[var(--theme-text-muted)] transition-colors hover:bg-[var(--theme-bg-muted)] hover:text-[var(--theme-text-primary)] ${className}`}
+        className={`inline-flex h-10 w-10 items-center justify-center rounded-[28px] text-[var(--theme-text-muted)] transition-colors hover:bg-[var(--theme-bg-muted)] hover:text-[var(--theme-text-primary)] ${className}`}
       >
-        <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
         </svg>
       </button>
@@ -1310,14 +1336,13 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
       <div
         className={`theme-settings-overlay absolute inset-0 ${themeBackdropSuppressed ? "theme-settings-overlay-preview-off" : ""}`}
         onClick={onClose}
-        style={{ top: "calc(env(safe-area-inset-top, 0px) + 58px)" }}
       />
 
       {/* Panel */}
       <div
         className={`
           theme-dialog-shell theme-settings-shell relative z-10 flex w-full flex-col
-          h-[92dvh] rounded-t-2xl
+          h-[100dvh] rounded-none
           sm:rounded-[28px]
           sm:flex-row sm:max-w-3xl sm:h-[80vh] sm:max-h-[700px]
         `}
@@ -1331,16 +1356,27 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
           `}
         >
           {/* Header */}
-          <div className="flex items-center justify-between gap-3 pl-5 pr-2 pt-4 pb-2 shrink-0">
-            <h2 className="text-base font-semibold text-text-primary">Settings</h2>
+          <div className="relative hidden shrink-0 items-center justify-center px-2 pt-4 pb-2 sm:flex">
             <CloseButton
               testId="settings-close-button-sidebar"
-              className="sm:mr-0"
+              className="absolute left-2"
+            />
+            <h2 className="text-base font-semibold text-center text-text-primary">Settings</h2>
+          </div>
+
+          <div
+            className="flex shrink-0 items-center justify-between px-4 pb-1.5 pt-2 sm:hidden"
+            style={{ paddingTop: "calc(env(safe-area-inset-top, 0px) + 0.5rem)" }}
+          >
+            <h2 className="text-sm font-semibold text-text-primary">Settings</h2>
+            <CloseButton
+              testId="settings-close-button-sidebar-mobile"
+              className="-mr-1"
             />
           </div>
 
           {/* Search */}
-          <div className="px-3 pb-2 pt-2 shrink-0">
+          <div className="px-3 pb-2 pt-1 shrink-0 sm:pt-2">
             <SearchField
               value={search}
               onChange={(e) => setSearch(e.target.value)}
@@ -1389,22 +1425,25 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
           `}
         >
           {/* Mobile back button + section title */}
-          <div className="theme-dialog-divider sm:hidden flex shrink-0 items-center gap-2 border-b px-4 pb-3 pt-5">
+          <div
+            className="theme-dialog-divider sm:hidden flex shrink-0 items-center justify-between gap-3 border-b px-4 pb-2 pt-2"
+            style={{ paddingTop: "calc(env(safe-area-inset-top, 0px) + 0.5rem)" }}
+          >
             <button
               onClick={() => setMobileView("nav")}
-              className="-ml-1 rounded-lg p-1.5 text-text-secondary transition-colors hover:bg-[color:color-mix(in_srgb,var(--theme-bg-surface)_72%,transparent)] hover:text-text-primary"
+              className="-ml-1 flex min-w-0 items-center gap-1.5 rounded-lg px-1.5 py-1.5 text-text-secondary transition-colors hover:bg-[color:color-mix(in_srgb,var(--theme-bg-surface)_72%,transparent)] hover:text-text-primary"
               aria-label="Back to settings"
             >
-              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <svg className="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
               </svg>
+              <span className="truncate text-sm font-medium text-text-primary">
+                {allSections.find((s) => s.id === activeSection)?.label}
+              </span>
             </button>
-            <span className="text-sm font-medium text-text-primary">
-              {allSections.find((s) => s.id === activeSection)?.label}
-            </span>
             <CloseButton
               testId="settings-close-button-mobile"
-              className="ml-auto -mr-1"
+              className="-mr-1 shrink-0"
             />
           </div>
 


### PR DESCRIPTION
(AI Generated). 

## Summary
- tighten the shared settings header chrome on desktop and mobile
- make the mobile settings sheet run flush to the top edge with a persistent close button and larger back target
- fix mobile section navigation so section taps switch views first, then scroll the visible pane without snapping back to the last provider position
- refine theme preview pointer detection so hover-capable browsers still get live theme preview in Settings

## Verification
- `./node_modules/.bin/tsc -p packages/pwa/tsconfig.json --noEmit`
- local PWA preview on `http://localhost:5173`
