### PR TITLE
fix: harden helper session workflow

### DIFF
--- a/.agents/skills/freed-build-feature/SKILL.md
+++ b/.agents/skills/freed-build-feature/SKILL.md
@@ -17,6 +17,7 @@ Create a product worktree branch from the latest remote `dev`, implement the fea
    - Confirm whether local `dev` or `main` are behind their remote counterparts.
    - If `origin/main` contains commits that are not in `origin/dev`, call that out before continuing so the user can decide whether `dev` needs to be refreshed first.
 5. Create a new worktree branch from `origin/dev` using `./scripts/worktree-add.sh ../freed-<slug> -b <branch> origin/dev --install full --target <desktop|pwa|shared>`.
+   - When you are spinning up multiple speculative threads at once, prefer `--install auto` until the worktree actually needs verification or a preview.
 6. If the worktree was created with deferred bootstrap on purpose, recover with `./scripts/worktree-bootstrap.sh <worktree> --target <desktop|pwa|shared>`.
 7. Implement the requested change.
 8. Verify with focused tests, then broader checks when shared behavior changed.
@@ -26,8 +27,11 @@ Create a product worktree branch from the latest remote `dev`, implement the fea
    - Use `./scripts/worktree-preview.sh desktop --native` only when the change depends on real Tauri behavior such as native windowing, tray behavior, updater wiring, filesystem or process plugins, native OAuth windows, or Rust-side integrations.
    - When native Desktop preview is running, report the preview label so parallel native windows can be matched to the worktree and thread that launched them.
 10. Never run `npm run <script> --workspace=...` from the repo root in this monorepo. Run commands from the workspace directory itself, and when a hoisted binary is needed, prefix `PATH` with `<worktree>/node_modules/.bin`.
-11. Finish the branch with `./scripts/worktree-publish.sh --title "<conventional-commit title>" --summary "<user-facing change>" --test "<focused check>"`.
-12. Confirm the branch is pushed to `origin` and the PR targeting `dev` stays in draft state. Include the local preview URL or native preview label in the closeout.
+11. Browser tooling is opt-in only. Do not launch Chrome DevTools MCP, Playwright MCP, or Computer Use unless the task explicitly needs browser automation or browser debugging.
+12. When browser tooling was needed, clean the session before closeout with `./scripts/dev-session-clean.sh`.
+13. Finish the branch with `./scripts/worktree-publish.sh --title "<conventional-commit title>" --summary "<user-facing change>" --test "<focused check>"`.
+   - If the branch intentionally adds new files, stage them yourself first or re-run with `--include-untracked`.
+14. Confirm the branch is pushed to `origin` and the PR targeting `dev` stays in draft state. Include the local preview URL or native preview label in the closeout.
 
 ## Scope
 

--- a/.agents/skills/freed-build-www/SKILL.md
+++ b/.agents/skills/freed-build-www/SKILL.md
@@ -13,12 +13,16 @@ Create a marketing worktree branch from `www`, implement the website change, ver
 1. Confirm the request is public marketing work targeting `www`.
 2. Reject or reroute product work targeting `dev`; use `freed-build-feature` instead.
 3. Create a new worktree branch from `www` using `./scripts/worktree-add.sh ../freed-<slug> -b <branch> origin/www --install full --target website`.
+   - When you are spinning up multiple speculative threads at once, prefer `--install auto` until the worktree actually needs verification or a preview.
 4. If the worktree was created with deferred bootstrap on purpose, recover with `./scripts/worktree-bootstrap.sh <worktree> --target website`.
 5. Keep changes scoped to marketing paths unless the user explicitly changes the destination.
 6. Run website checks from the workspace directory, at minimum `cd website && PATH=../node_modules/.bin:$PATH npm run build`.
-7. Before opening the draft PR, launch the local website preview with `./scripts/worktree-preview.sh website`.
-8. Deploy `./scripts/vercel-deploy-preview.sh website` only when a shareable remote preview is needed.
-9. Open a draft PR targeting `www`, and include the local preview URL in the closeout.
+7. Browser tooling is opt-in only. Do not launch Chrome DevTools MCP, Playwright MCP, or Computer Use unless the task explicitly needs browser automation or browser debugging.
+8. Before opening the draft PR, launch the local website preview with `./scripts/worktree-preview.sh website`.
+9. Deploy `./scripts/vercel-deploy-preview.sh website` only when a shareable remote preview is needed.
+10. If browser tooling was needed, clean the session before closeout with `./scripts/dev-session-clean.sh`.
+11. Open a draft PR targeting `www`, and include the local preview URL in the closeout.
+   - If the branch intentionally adds new files, stage them yourself first or re-run `./scripts/worktree-publish.sh` with `--include-untracked`.
 
 Never run `npm run <script> --workspace=...` from the repo root in this monorepo. Run website commands from `website/`, and prefix `PATH` with the worktree root `node_modules/.bin` when a hoisted binary like `next` or `tsx` is required.
 

--- a/.gitignore
+++ b/.gitignore
@@ -39,4 +39,6 @@ npm-debug.log*
 
 # Playwright MCP debug artifacts
 .playwright-mcp/
+.playwright-cli/
+.metadata_never_index
 .vercel

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,13 +60,18 @@ Run `./scripts/release.sh` with no args to auto-compute the next version.
 
 `worktree-add.sh` is a drop-in replacement for `git worktree add`. It defaults to a full isolated install so the new worktree is ready immediately, and it still supports `--install auto` or `--install none` when you intentionally want to defer bootstrap. Never use bare `git worktree add` directly.
 Pass an explicit remote base like `origin/dev` or `origin/www` so feature work does not inherit a stale local branch by accident.
+For multi-thread or speculative worktree swarms, prefer `--install auto` until the thread actually needs verification or a preview.
 Prefer the lightest useful local preview before opening a draft PR:
 - product work usually uses `./scripts/worktree-preview.sh pwa`
 - website work uses `./scripts/worktree-preview.sh website`
 - use `./scripts/worktree-preview.sh desktop --native` only when real Tauri behavior matters, and report the preview label when you do
 - never run `npm run <script> --workspace=...` from the repo root in this monorepo, run from the workspace directory instead
-- the root fanout scripts now fail fast if you try that dangerous pattern, treat that error as a routing mistake and re-run from the workspace
+- root `npm run dev` now fails fast on purpose, use `./scripts/worktree-preview.sh <target>` or run `npm run dev` from the workspace directory you actually want
+- the root fanout scripts now fail fast if you try the dangerous workspace-dispatch pattern, treat that error as a routing mistake and re-run from the workspace
 - if a workspace command needs a hoisted binary, prefix `PATH` with the worktree root `node_modules/.bin`
+- browser tooling is opt-in only, do not launch Chrome DevTools MCP, Playwright MCP, or Computer Use unless the task explicitly needs browser automation or browser debugging
+- after browser tooling work, run `./scripts/dev-session-clean.sh`
+- `./scripts/worktree-publish.sh` now refuses stray untracked files unless you stage them yourself first or pass `--include-untracked`
 
 **Branch naming:** `feat/`, `fix/`, `chore/`, `docs/`, `refactor/`, `perf/` prefix followed by a short kebab-case description.
 

--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ If you want a cheap speculative worktree instead, opt in explicitly:
 ./scripts/worktree-add.sh ../freed-my-branch -b feat/my-branch origin/dev --install auto --target shared
 ```
 
+That is the better default when you are spinning up several speculative threads at once and only one or two of them will reach verification.
+
 When you are ready to preview the work locally, prefer the lightest useful surface:
 
 ```bash
@@ -184,6 +186,8 @@ When the work is ready to publish from the feature worktree:
   --test "Focused validation you ran"
 ```
 
+If the branch intentionally adds new files, stage them yourself first or pass `--include-untracked`. The helper refuses stray untracked files by default so local junk like temporary browser artifacts does not get vacuumed into a commit.
+
 When you run workspace commands by hand, do the same thing as the helpers:
 
 ```bash
@@ -192,7 +196,14 @@ PATH=../node_modules/.bin:$PATH npm run build
 ```
 
 Do not use root-level `npm run <script> --workspace=...` in this repo.
-The root `build`, `dev`, `test`, and `typecheck` scripts now fail fast if you try it, so the error is your cue to `cd` into the workspace and run the command there.
+The root `build`, `test`, and `typecheck` scripts fail fast if you try that dangerous workspace-dispatch path, and root `npm run dev` now refuses to fan out at all. Treat those errors as your cue to `cd` into the workspace and run the command there, or use `./scripts/worktree-preview.sh <target>`.
+
+Browser tooling is opt-in only. Only turn on Chrome DevTools MCP, Playwright MCP, or Computer Use when the task explicitly needs browser automation or browser debugging. When that work is done, clean the session with:
+
+```bash
+./scripts/dev-session-clean.sh
+npm run session:clean
+```
 
 ### Marketing Website (freed.wtf)
 

--- a/docs/PHASE-1-FOUNDATION.md
+++ b/docs/PHASE-1-FOUNDATION.md
@@ -242,7 +242,7 @@ The preview and production deploy helpers now resolve `npm` and `npx` from the
 active Node toolchain first, so they do not accidentally pick up an older
 system npm from the shell `PATH`.
 
-Local product worktrees now default to a ready-to-run full bootstrap so the next command does not trip over missing `node_modules`. `./scripts/worktree-add.sh` still supports `--install none|auto|full` and `--target desktop|pwa|website|shared` when you intentionally want to defer bootstrap, `./scripts/worktree-bootstrap.sh` handles the on-demand install, `./scripts/worktree-preview.sh` launches tracked previews with one desktop slot and one web slot per repo, defaults product work to the lightest useful preview surface, `./scripts/worktree-publish.sh` stages, commits, pushes, and opens a draft PR with the required `(AI Generated).` body prefix, preview labels are stamped with the worktree plus thread tail so concurrent native windows stay identifiable, and `./scripts/worktree-cleanup.sh` stops tracked previews before removing merged worktrees.
+Local product worktrees now default to a ready-to-run full bootstrap so the next command does not trip over missing `node_modules`. `./scripts/worktree-add.sh` still supports `--install none|auto|full` and `--target desktop|pwa|website|shared` when you intentionally want to defer bootstrap, `./scripts/worktree-bootstrap.sh` handles the on-demand install, `./scripts/worktree-preview.sh` launches tracked previews with one desktop slot and one web slot per repo, defaults product work to the lightest useful preview surface, root `npm run dev` now fails fast instead of fanning out across every workspace, `./scripts/worktree-publish.sh` refuses stray untracked files unless you explicitly include them, `./scripts/dev-session-clean.sh` stops tracked previews and kills stale browser automation sidecars, preview labels are stamped with the worktree plus thread tail so concurrent native windows stay identifiable, and `./scripts/worktree-cleanup.sh` stops tracked previews before removing merged worktrees.
 
 ---
 
@@ -273,7 +273,7 @@ Local product worktrees now default to a ready-to-run full bootstrap so the next
 | 1.9  | Generate RSS feed at build time              | ✓      |
 | 1.10 | Add public legal docs and versioned website clickwrap | ✓ |
 | 1.11 | Add unified shared theme system across website, Freed Desktop, and PWA | ✓ |
-| 1.12 | Add ready-to-run worktree bootstrap controls plus labeled tracked local preview tooling | ✓ |
+| 1.12 | Add ready-to-run worktree bootstrap controls, safer root command routing, and labeled tracked local preview tooling | ✓ |
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "postinstall": "node scripts/patch-automerge.mjs",
     "build": "node scripts/run-workspace-fanout.mjs build",
     "dev": "node scripts/run-workspace-fanout.mjs dev",
+    "session:clean": "bash scripts/dev-session-clean.sh",
     "test": "node scripts/run-workspace-fanout.mjs test",
     "typecheck": "node scripts/run-workspace-fanout.mjs typecheck",
     "typecheck:graph": "tsc --build --dry"

--- a/scripts/dev-session-clean.sh
+++ b/scripts/dev-session-clean.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  ./scripts/dev-session-clean.sh [--dry-run] [--worktree <path>]
+
+Stops tracked local previews and kills stale browser automation helpers that are
+safe to identify by command line, including chrome-devtools-mcp, playwright-mcp,
+SkyComputerUseClient mcp, and Chrome processes running with automation profiles.
+EOF
+}
+
+DRY_RUN=false
+FILTER_WORKTREE=""
+CURRENT_UID="$(id -u)"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    --worktree)
+      [[ $# -ge 2 ]] || { echo "Error: --worktree requires a value." >&2; exit 1; }
+      FILTER_WORKTREE="$2"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Error: unexpected argument '$1'." >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+resolve_filter_args() {
+  if [[ -n "${FILTER_WORKTREE}" ]]; then
+    printf -- '--worktree\0%s\0' "${FILTER_WORKTREE}"
+  fi
+}
+
+stop_tracked_previews() {
+  local args=("${SCRIPT_DIR}/worktree-processes.sh" "stop")
+  if [[ -n "${FILTER_WORKTREE}" ]]; then
+    args+=("--worktree" "${FILTER_WORKTREE}")
+  fi
+
+  if ${DRY_RUN}; then
+    printf 'Would run:'
+    printf ' %q' "${args[@]}"
+    printf '\n'
+    return 0
+  fi
+
+  "${args[@]}"
+}
+
+matching_pids() {
+  local pattern="$1"
+
+  ps axww -o pid=,uid=,command= | awk -v uid="${CURRENT_UID}" -v pattern="${pattern}" '
+    $2 == uid && $0 ~ pattern { print $1 }
+  '
+}
+
+terminate_pid() {
+  local pid="$1"
+
+  if ${DRY_RUN}; then
+    echo "Would terminate pid ${pid}"
+    return 0
+  fi
+
+  kill "${pid}" 2>/dev/null || true
+}
+
+force_kill_pid() {
+  local pid="$1"
+
+  if ${DRY_RUN}; then
+    echo "Would force-kill pid ${pid}"
+    return 0
+  fi
+
+  kill -9 "${pid}" 2>/dev/null || true
+}
+
+stop_matching_group() {
+  local label="$1"
+  local pattern="$2"
+  local pid
+  local -a pids=()
+
+  while IFS= read -r pid; do
+    [[ -n "${pid}" ]] || continue
+    pids+=("${pid}")
+  done < <(matching_pids "${pattern}" | sort -u)
+
+  if [[ ${#pids[@]} -eq 0 ]]; then
+    echo "${label}: none found"
+    return 0
+  fi
+
+  echo "${label}: ${#pids[@]} process(es)"
+
+  for pid in "${pids[@]}"; do
+    terminate_pid "${pid}"
+  done
+
+  if ${DRY_RUN}; then
+    return 0
+  fi
+
+  sleep 1
+
+  for pid in "${pids[@]}"; do
+    if kill -0 "${pid}" 2>/dev/null; then
+      force_kill_pid "${pid}"
+    fi
+  done
+}
+
+echo "Stopping tracked previews..."
+stop_tracked_previews
+
+echo ""
+echo "Cleaning stale browser automation helpers..."
+stop_matching_group "chrome-devtools-mcp sidecars" 'npm exec chrome-devtools-mcp@latest|chrome-devtools-mcp[[:space:]]*$|chrome-devtools-mcp/build/src/telemetry/watchdog/main.js'
+stop_matching_group "playwright-mcp sidecars" 'playwright-mcp'
+stop_matching_group "computer-use sidecars" 'SkyComputerUseClient\.app/Contents/.*/SkyComputerUseClient mcp'
+stop_matching_group "automation Chrome roots" '/Applications/Google Chrome\.app/Contents/MacOS/Google Chrome .*(--remote-debugging-pipe|chrome-devtools-mcp/chrome-profile|playwright_chromiumdev_profile)'
+stop_matching_group "automation Chrome helpers" 'Google Chrome Helper.*(chrome-devtools-mcp/chrome-profile|playwright_chromiumdev_profile)'
+
+echo ""
+if ${DRY_RUN}; then
+  echo "Dry run complete."
+else
+  "${SCRIPT_DIR}/worktree-processes.sh" prune >/dev/null 2>&1 || true
+  echo "Cleanup complete."
+fi

--- a/scripts/run-workspace-fanout.mjs
+++ b/scripts/run-workspace-fanout.mjs
@@ -21,6 +21,14 @@ if (runningWorkspaceSelection) {
   process.exit(1);
 }
 
+if (scriptName === "dev") {
+  console.error('Refusing to run root "dev" from the monorepo root.');
+  console.error("That path can start too many long-lived processes at once.");
+  console.error("Use ./scripts/worktree-preview.sh <desktop|pwa|website> instead.");
+  console.error("Or cd into the workspace you actually want and run npm run dev there.");
+  process.exit(1);
+}
+
 const child = spawnSync(
   "npm",
   ["run", scriptName, "--workspaces", "--if-present", ...forwardedArgs],

--- a/scripts/worktree-publish.sh
+++ b/scripts/worktree-publish.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 usage() {
   cat <<'EOF'
 Usage:
-  ./scripts/worktree-publish.sh --title "<conventional-commit title>" [--summary "<bullet>"]... [--test "<bullet>"]... [--base <branch>] [--body-file <path>]
+  ./scripts/worktree-publish.sh --title "<conventional-commit title>" [--summary "<bullet>"]... [--test "<bullet>"]... [--base <branch>] [--body-file <path>] [--include-untracked]
 
 Stages local changes, commits them when needed, pushes the current branch to origin,
 and opens a draft pull request.
@@ -60,6 +60,10 @@ branch_has_unique_commits() {
   [[ "$(git rev-list --count "origin/${base_branch}..HEAD")" -gt 0 ]]
 }
 
+list_untracked_files() {
+  git ls-files --others --exclude-standard
+}
+
 build_body() {
   local title="$1"
   shift
@@ -109,6 +113,7 @@ build_body() {
 TITLE=""
 BASE_BRANCH="dev"
 BODY_FILE=""
+INCLUDE_UNTRACKED=false
 SUMMARY_ARGS=()
 TEST_ARGS=()
 
@@ -138,6 +143,10 @@ while [[ $# -gt 0 ]]; do
       [[ $# -ge 2 ]] || { echo "Error: --body-file requires a value." >&2; exit 1; }
       BODY_FILE="$2"
       shift 2
+      ;;
+    --include-untracked)
+      INCLUDE_UNTRACKED=true
+      shift
       ;;
     --help|-h)
       usage
@@ -172,9 +181,23 @@ BRANCH_NAME="$(current_branch)"
 ensure_publishable_branch "${BRANCH_NAME}"
 
 if has_worktree_changes; then
-  git add -A
+  UNTRACKED_FILES="$(list_untracked_files)"
+  if [[ -n "${UNTRACKED_FILES}" ]] && ! ${INCLUDE_UNTRACKED}; then
+    echo "Error: untracked files are present." >&2
+    echo "Stage intentional new files explicitly, ignore local junk, or re-run with --include-untracked." >&2
+    echo "" >&2
+    printf '%s\n' "${UNTRACKED_FILES}" >&2
+    exit 1
+  fi
+
+  if ${INCLUDE_UNTRACKED}; then
+    git add -A
+  else
+    git add -u
+  fi
+
   if git diff --cached --quiet; then
-    echo "Error: no staged changes found after git add -A." >&2
+    echo "Error: no staged changes found after staging tracked files." >&2
     exit 1
   fi
   git commit -m "${TITLE}"

--- a/website/src/app/roadmap/RoadmapContent.tsx
+++ b/website/src/app/roadmap/RoadmapContent.tsx
@@ -701,7 +701,7 @@ const phases: Phase[] = [
     number: 1,
     title: "Foundation",
     description:
-      "Marketing site, QR gallery, monorepo, Automerge schema, CI/CD, public legal docs with download clickwrap, a protected newsletter signup flow, and ready-to-run local worktree bootstrap with tracked preview tooling, light-by-default preview routing, draft-PR publish automation, labeled native windows, plus optional deferred installs when you actually want them.",
+      "Marketing site, QR gallery, monorepo, Automerge schema, CI/CD, public legal docs with download clickwrap, a protected newsletter signup flow, and ready-to-run local worktree bootstrap with tracked preview tooling, light-by-default preview routing, safer root command routing, draft-PR publish automation that rejects stray untracked files, labeled native windows, a local session cleanup helper for stale browser sidecars, plus optional deferred installs when you actually want them.",
     status: "complete",
     planLink:
       "https://github.com/freed-project/freed/blob/dev/docs/PHASE-1-FOUNDATION.md",


### PR DESCRIPTION
(AI Generated).

## Summary
- stop root npm run dev from fanning out across every workspace
- add a targeted cleanup helper for stale browser automation sidecars and tracked previews
- tighten publish and agent workflow guards around untracked artifacts, browser tooling, and speculative worktrees

## Testing
- bash -n scripts/dev-session-clean.sh scripts/worktree-publish.sh scripts/worktree-add.sh scripts/worktree-preview.sh scripts/worktree-processes.sh
- git diff --check
- npm run dev
- ./scripts/dev-session-clean.sh --dry-run
- npm run session:clean -- --dry-run
- ./scripts/worktree-publish.sh --title "fix: helper stability followup" --test "guard check"