### PR TITLE
fix: harden worktree helper flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,24 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
+  tooling-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tooling smoke tests
+        run: npm run test:scripts
+
   build:
     runs-on: ubuntu-latest
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,8 @@ Prefer the lightest useful local preview before opening a draft PR:
 - never run `npm run <script> --workspace=...` from the repo root in this monorepo, run from the workspace directory instead
 - the root fanout scripts now fail fast if you try that dangerous pattern, treat that error as a routing mistake and re-run from the workspace
 - if a workspace command needs a hoisted binary, prefix `PATH` with the worktree root `node_modules/.bin`
+- expect the worktree helpers to print the resolved `node` and `npm` pair before they do real work, and treat a surprising path there as a machine issue to fix before debugging the repo
+- rerunning `./scripts/worktree-publish.sh` should update the existing draft PR body and title, and push a ready PR back to draft when the local branch changes underneath it
 
 **Branch naming:** `feat/`, `fix/`, `chore/`, `docs/`, `refactor/`, `perf/` prefix followed by a short kebab-case description.
 

--- a/README.md
+++ b/README.md
@@ -156,9 +156,11 @@ The helper now:
 
 - detects the new worktree path by diffing the worktree list before and after creation
 - defaults to a full install with the npm binary that matches the active Node runtime
+- prints the resolved `node` and `npm` pair before bootstrap, preview, or publish work so stale global toolchains are obvious
 - avoids the broken "last worktree wins" assumption that can install into the wrong checkout
 - stays on the branch you asked for instead of inheriting some crusty local base by accident
 - works cleanly with tracked local previews, including readable labels for native preview windows
+- reruns of `worktree-publish.sh` update the existing PR title and body, and flip a ready PR back to draft instead of pretending nothing happened
 - avoids root-level workspace npm dispatch in the preview and deploy helpers, because this monorepo can recurse badly when `npm run <script> --workspace=...` is launched from the repo root
 
 If you want a cheap speculative worktree instead, opt in explicitly:
@@ -193,6 +195,7 @@ PATH=../node_modules/.bin:$PATH npm run build
 
 Do not use root-level `npm run <script> --workspace=...` in this repo.
 The root `build`, `dev`, `test`, and `typecheck` scripts now fail fast if you try it, so the error is your cue to `cd` into the workspace and run the command there.
+For the helper smoke lane itself, run `npm run test:scripts`.
 
 ### Marketing Website (freed.wtf)
 

--- a/docs/PHASE-1-FOUNDATION.md
+++ b/docs/PHASE-1-FOUNDATION.md
@@ -240,9 +240,11 @@ under the release workflow.
 
 The preview and production deploy helpers now resolve `npm` and `npx` from the
 active Node toolchain first, so they do not accidentally pick up an older
-system npm from the shell `PATH`.
+system npm from the shell `PATH`. The root workspace fanout runner now does the
+same thing, which cuts out another stale-global-`npm` failure mode when local
+or CI commands fan out across workspaces.
 
-Local product worktrees now default to a ready-to-run full bootstrap so the next command does not trip over missing `node_modules`. `./scripts/worktree-add.sh` still supports `--install none|auto|full` and `--target desktop|pwa|website|shared` when you intentionally want to defer bootstrap, `./scripts/worktree-bootstrap.sh` handles the on-demand install, `./scripts/worktree-preview.sh` launches tracked previews with one desktop slot and one web slot per repo, defaults product work to the lightest useful preview surface, `./scripts/worktree-publish.sh` stages, commits, pushes, and opens a draft PR with the required `(AI Generated).` body prefix, preview labels are stamped with the worktree plus thread tail so concurrent native windows stay identifiable, and `./scripts/worktree-cleanup.sh` stops tracked previews before removing merged worktrees.
+Local product worktrees now default to a ready-to-run full bootstrap so the next command does not trip over missing `node_modules`. `./scripts/worktree-add.sh` still supports `--install none|auto|full` and `--target desktop|pwa|website|shared` when you intentionally want to defer bootstrap, the worktree helpers now print the resolved `node` and `npm` pair before they bootstrap, preview, or publish, `./scripts/worktree-bootstrap.sh` handles the on-demand install, `./scripts/worktree-preview.sh` launches tracked previews with one desktop slot and one web slot per repo, automatically skips an occupied website port even when the listener is only on IPv6, and now surfaces the local preview label inside the marketing site too, `./scripts/worktree-publish.sh` stages, commits, pushes, opens a draft PR with the required `(AI Generated).` body prefix, and updates that PR in place on reruns, preview labels are stamped with the worktree plus thread tail so concurrent native windows stay identifiable, `npm run test:scripts` covers the helper smoke lane in CI, and `./scripts/worktree-cleanup.sh` stops tracked previews before removing merged worktrees.
 
 ---
 
@@ -273,7 +275,7 @@ Local product worktrees now default to a ready-to-run full bootstrap so the next
 | 1.9  | Generate RSS feed at build time              | ✓      |
 | 1.10 | Add public legal docs and versioned website clickwrap | ✓ |
 | 1.11 | Add unified shared theme system across website, Freed Desktop, and PWA | ✓ |
-| 1.12 | Add ready-to-run worktree bootstrap controls plus labeled tracked local preview tooling | ✓ |
+| 1.12 | Add ready-to-run worktree bootstrap controls plus labeled tracked local preview tooling, rerunnable draft-PR publishing, and helper smoke coverage | ✓ |
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build": "node scripts/run-workspace-fanout.mjs build",
     "dev": "node scripts/run-workspace-fanout.mjs dev",
     "test": "node scripts/run-workspace-fanout.mjs test",
+    "test:scripts": "bash -n scripts/*.sh scripts/lib/*.sh && node --test scripts/*.test.mjs",
     "typecheck": "node scripts/run-workspace-fanout.mjs typecheck",
     "typecheck:graph": "tsc --build --dry"
   },

--- a/packages/ui/src/components/SettingsDialog.tsx
+++ b/packages/ui/src/components/SettingsDialog.tsx
@@ -754,6 +754,9 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
     };
   }, [open, searchLower]);
 
+  // ── Mobile nav state ──────────────────────────────────────────────────────
+  const [mobileView, setMobileView] = useState<"nav" | "section">("nav");
+
   const scrollToSection = useCallback((id: SectionId) => {
     setActiveSection(id);
     if (scrollRef.current) {
@@ -780,9 +783,6 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
     // On mobile, switch to section view
     setMobileView("section");
   }, []);
-
-  // ── Mobile nav state ──────────────────────────────────────────────────────
-  const [mobileView, setMobileView] = useState<"nav" | "section">("nav");
 
   // Reset state on close
   useEffect(() => {

--- a/scripts/lib/find-free-port.mjs
+++ b/scripts/lib/find-free-port.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+
+import net from "node:net";
+import { pathToFileURL } from "node:url";
+
+function parseStartPort(rawValue) {
+  const port = Number.parseInt(rawValue ?? "", 10);
+  if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+    throw new Error("Start port must be an integer between 1 and 65535.");
+  }
+
+  return port;
+}
+
+function probePort(host, port) {
+  return new Promise((resolve) => {
+    const socket = net.createConnection({ host, port });
+    let settled = false;
+
+    const finish = (isInUse) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      socket.destroy();
+      resolve(isInUse);
+    };
+
+    socket.once("connect", () => finish(true));
+    socket.once("error", () => finish(false));
+    socket.setTimeout(100, () => finish(false));
+  });
+}
+
+export async function isPortInUse(port) {
+  const probes = ["127.0.0.1"];
+
+  if (net.isIPv6("::1")) {
+    probes.push("::1");
+  }
+
+  for (const host of probes) {
+    if (await probePort(host, port)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+export async function findFreePort(startPort, range = 200) {
+  const parsedStartPort = parseStartPort(startPort);
+
+  for (let port = parsedStartPort; port < parsedStartPort + range; port += 1) {
+    if (!(await isPortInUse(port))) {
+      return port;
+    }
+  }
+
+  throw new Error("No free port found in the requested range.");
+}
+
+async function main() {
+  try {
+    const port = await findFreePort(process.argv[2]);
+    console.log(port);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await main();
+}

--- a/scripts/lib/node-tooling.sh
+++ b/scripts/lib/node-tooling.sh
@@ -74,3 +74,15 @@ use_resolved_node_path() {
   node_dir="$(cd "$(dirname "${node_bin}")" && pwd)"
   export PATH="${node_dir}:${PATH}"
 }
+
+print_node_tooling_preflight() {
+  local node_bin npm_bin node_version npm_version
+
+  node_bin="$(resolve_node_bin)"
+  npm_bin="$(resolve_npm_bin)"
+  node_version="$("${node_bin}" -v)"
+  npm_version="$("${npm_bin}" -v)"
+
+  printf 'node: %s (%s)\n' "${node_version}" "${node_bin}"
+  printf 'npm: %s (%s)\n' "${npm_version}" "${npm_bin}"
+}

--- a/scripts/run-workspace-fanout.mjs
+++ b/scripts/run-workspace-fanout.mjs
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+import fs from "node:fs";
+import path from "node:path";
 import { spawnSync } from "node:child_process";
 
 const scriptName = process.argv[2];
@@ -21,8 +23,18 @@ if (runningWorkspaceSelection) {
   process.exit(1);
 }
 
+function resolveNpmCommand() {
+  const siblingNpm = path.join(path.dirname(process.execPath), process.platform === "win32" ? "npm.cmd" : "npm");
+
+  if (fs.existsSync(siblingNpm)) {
+    return siblingNpm;
+  }
+
+  return "npm";
+}
+
 const child = spawnSync(
-  "npm",
+  resolveNpmCommand(),
   ["run", scriptName, "--workspaces", "--if-present", ...forwardedArgs],
   {
     stdio: "inherit",

--- a/scripts/run-workspace-fanout.test.mjs
+++ b/scripts/run-workspace-fanout.test.mjs
@@ -1,0 +1,41 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const scriptsDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptsDir, "..");
+
+test("run-workspace-fanout refuses root workspace dispatch", () => {
+  const result = spawnSync(
+    process.execPath,
+    ["scripts/run-workspace-fanout.mjs", "build"],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        npm_config_workspace: "packages/pwa",
+        npm_config_workspaces: "false",
+      },
+    },
+  );
+
+  assert.equal(result.status, 1);
+  assert.match(
+    result.stderr,
+    /Refusing to run root "build" with --workspace=packages\/pwa\./,
+  );
+  assert.match(result.stderr, /Run the script from the workspace directory instead\./);
+});
+
+test("run-workspace-fanout rejects a missing script name", () => {
+  const result = spawnSync(process.execPath, ["scripts/run-workspace-fanout.mjs"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Missing script name for workspace fanout\./);
+});

--- a/scripts/worktree-add.sh
+++ b/scripts/worktree-add.sh
@@ -106,6 +106,8 @@ if [[ ${#PASSTHROUGH_ARGS[@]} -eq 0 ]]; then
   exit 1
 fi
 
+print_node_tooling_preflight
+
 EXISTING_WORKTREES=()
 while IFS= read -r line; do
   EXISTING_WORKTREES+=("$line")

--- a/scripts/worktree-bootstrap.sh
+++ b/scripts/worktree-bootstrap.sh
@@ -75,6 +75,7 @@ fi
 validate_target_hint "${TARGET_HINT}"
 
 if [[ -d "${WORKTREE_PATH}/node_modules" ]]; then
+  print_node_tooling_preflight
   echo "Dependencies already present in ${WORKTREE_PATH}."
   exit 0
 fi
@@ -82,9 +83,9 @@ fi
 NPM_BIN="$(resolve_npm_bin)"
 NPM_VERSION="$("${NPM_BIN}" -v)"
 
+print_node_tooling_preflight
 echo "Bootstrapping ${WORKTREE_PATH}"
 echo "Target: ${TARGET_HINT}"
-echo "npm: ${NPM_VERSION}"
 
 if [[ "${TARGET_HINT}" == "shared" ]]; then
   echo "Shared-only bootstrap still uses the root workspace install with the current npm lockfile layout."

--- a/scripts/worktree-preview.sh
+++ b/scripts/worktree-preview.sh
@@ -18,41 +18,6 @@ behavior itself is the thing being tested.
 EOF
 }
 
-find_free_port() {
-  local start_port="$1"
-
-  python3 - "${start_port}" <<'PY'
-import socket
-import sys
-
-start = int(sys.argv[1])
-
-for port in range(start, start + 200):
-    is_in_use = False
-    probes = [(socket.AF_INET, ("127.0.0.1", port))]
-    if socket.has_ipv6:
-        probes.append((socket.AF_INET6, ("::1", port, 0, 0)))
-
-    for family, target in probes:
-        with socket.socket(family, socket.SOCK_STREAM) as sock:
-            sock.settimeout(0.1)
-            try:
-                if sock.connect_ex(target) == 0:
-                    is_in_use = True
-                    break
-            except OSError:
-                continue
-
-    if is_in_use:
-        continue
-
-    print(port)
-    break
-else:
-    raise SystemExit("No free port found in the requested range.")
-PY
-}
-
 existing_process_for_target() {
   local worktree_path="$1"
   local preview_target="$2"
@@ -134,6 +99,7 @@ fi
 WORKTREE_PATH="$(resolve_worktree_path "${WORKTREE_PATH}")"
 PROCESS_SCRIPT="${SCRIPT_DIR}/worktree-processes.sh"
 PREVIEW_LABEL="${PREVIEW_LABEL:-$(preview_label_for_worktree "${WORKTREE_PATH}")}"
+print_node_tooling_preflight
 
 if existing_manifest="$(existing_process_for_target "${WORKTREE_PATH}" "${TARGET}")"; then
   unset PID PROCESS_KIND TARGET WORKTREE_PATH PORT COMMAND LOG_PATH PREVIEW_LABEL STARTED_AT
@@ -185,7 +151,7 @@ case "${TARGET}" in
       URL="http://localhost:1420"
     else
       DEFAULT_PORT="1422"
-      PORT="${PORT:-$(find_free_port "${DEFAULT_PORT}")}"
+      PORT="${PORT:-$("$(resolve_node_bin)" "${SCRIPT_DIR}/lib/find-free-port.mjs" "${DEFAULT_PORT}")}"
       ENV_VARS=(
         "PATH=${ROOT_BIN_DIR}:${PATH}"
         "VITE_TEST_TAURI=1"
@@ -199,7 +165,7 @@ case "${TARGET}" in
   pwa)
     SLOT_KIND="web"
     DEFAULT_PORT="1421"
-    PORT="${PORT:-$(find_free_port "${DEFAULT_PORT}")}"
+    PORT="${PORT:-$("$(resolve_node_bin)" "${SCRIPT_DIR}/lib/find-free-port.mjs" "${DEFAULT_PORT}")}"
     RUN_CWD="$(workspace_path_for_target "${WORKTREE_PATH}" "pwa")"
     ENV_VARS=(
       "PATH=${ROOT_BIN_DIR}:${PATH}"
@@ -212,7 +178,7 @@ case "${TARGET}" in
   website)
     SLOT_KIND="web"
     DEFAULT_PORT="3000"
-    PORT="${PORT:-$(find_free_port "${DEFAULT_PORT}")}"
+    PORT="${PORT:-$("$(resolve_node_bin)" "${SCRIPT_DIR}/lib/find-free-port.mjs" "${DEFAULT_PORT}")}"
     RUN_CWD="$(workspace_path_for_target "${WORKTREE_PATH}" "website")"
     ENV_VARS=(
       "PATH=${ROOT_BIN_DIR}:${PATH}"

--- a/scripts/worktree-preview.test.mjs
+++ b/scripts/worktree-preview.test.mjs
@@ -1,0 +1,67 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import net from "node:net";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+import { findFreePort } from "./lib/find-free-port.mjs";
+
+const scriptsDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptsDir, "..");
+
+function listen(server, port, host) {
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(port, host, () => {
+      server.removeListener("error", reject);
+      resolve();
+    });
+  });
+}
+
+function close(server) {
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+test("findFreePort skips a port that is only occupied on IPv6", async (t) => {
+  const server = net.createServer();
+  t.after(async () => {
+    await close(server);
+  });
+
+  try {
+    await listen(server, 0, "::1");
+  } catch (error) {
+    if (error && typeof error === "object" && "code" in error && error.code === "EADDRNOTAVAIL") {
+      t.skip("IPv6 loopback is not available in this environment.");
+      return;
+    }
+    throw error;
+  }
+
+  const address = server.address();
+  assert.ok(address && typeof address === "object" && "port" in address);
+
+  const candidate = await findFreePort(address.port, 5);
+  assert.notEqual(candidate, address.port);
+});
+
+test("worktree-preview help prints usage", () => {
+  const result = spawnSync("bash", ["scripts/worktree-preview.sh", "--help"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /Usage:/);
+  assert.match(result.stdout, /desktop\|pwa\|website/);
+});

--- a/scripts/worktree-publish.sh
+++ b/scripts/worktree-publish.sh
@@ -2,6 +2,10 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./lib/node-tooling.sh
+source "${SCRIPT_DIR}/lib/node-tooling.sh"
+
 usage() {
   cat <<'EOF'
 Usage:
@@ -106,6 +110,28 @@ build_body() {
   done
 }
 
+pr_field() {
+  local json="$1"
+  local field="$2"
+
+  python3 - "${json}" "${field}" <<'PY'
+import json
+import sys
+
+payload = json.loads(sys.argv[1])
+field = sys.argv[2]
+
+if not payload:
+    raise SystemExit(0)
+
+value = payload[0].get(field, "")
+if isinstance(value, bool):
+    print("true" if value else "false")
+else:
+    print(value)
+PY
+}
+
 TITLE=""
 BASE_BRANCH="dev"
 BODY_FILE=""
@@ -158,6 +184,7 @@ fi
 
 require_command git
 require_command gh
+print_node_tooling_preflight
 
 ensure_conventional_title "${TITLE}"
 
@@ -193,48 +220,35 @@ if [[ -n "${BODY_FILE}" ]]; then
   fi
 else
   BODY_ARGS=()
-  for item in "${SUMMARY_ARGS[@]}"; do
+  for item in "${SUMMARY_ARGS[@]-}"; do
+    [[ -n "${item}" ]] || continue
     BODY_ARGS+=(--summary "${item}")
   done
-  for item in "${TEST_ARGS[@]}"; do
+  for item in "${TEST_ARGS[@]-}"; do
+    [[ -n "${item}" ]] || continue
     BODY_ARGS+=(--test "${item}")
   done
   BODY_CONTENT="$(build_body "${TITLE}" "${BODY_ARGS[@]}")"
 fi
 
-EXISTING_PR_NUMBER="$(
+EXISTING_PR_JSON="$(
   gh pr list \
     --head "${BRANCH_NAME}" \
     --base "${BASE_BRANCH}" \
     --state open \
-    --json number \
-    --jq '.[0].number // empty' \
+    --json number,url,isDraft \
     --limit 1
 )"
-EXISTING_PR_URL="$(
-  gh pr list \
-    --head "${BRANCH_NAME}" \
-    --base "${BASE_BRANCH}" \
-    --state open \
-    --json url \
-    --jq '.[0].url // empty' \
-    --limit 1
-)"
-EXISTING_PR_IS_DRAFT="$(
-  gh pr list \
-    --head "${BRANCH_NAME}" \
-    --base "${BASE_BRANCH}" \
-    --state open \
-    --json isDraft \
-    --jq '.[0].isDraft // empty' \
-    --limit 1
-)"
+EXISTING_PR_NUMBER="$(pr_field "${EXISTING_PR_JSON}" "number")"
+EXISTING_PR_URL="$(pr_field "${EXISTING_PR_JSON}" "url")"
+EXISTING_PR_IS_DRAFT="$(pr_field "${EXISTING_PR_JSON}" "isDraft")"
 
 if [[ -n "${EXISTING_PR_NUMBER}" ]]; then
   if [[ "${EXISTING_PR_IS_DRAFT}" != "true" ]]; then
     gh pr ready "${EXISTING_PR_NUMBER}" --undo >/dev/null
   fi
-  printf 'Draft PR already exists: %s\n' "${EXISTING_PR_URL}"
+  gh pr edit "${EXISTING_PR_NUMBER}" --title "${TITLE}" --body "${BODY_CONTENT}" >/dev/null
+  printf 'Updated draft PR: %s\n' "${EXISTING_PR_URL}"
   exit 0
 fi
 

--- a/scripts/worktree-publish.test.mjs
+++ b/scripts/worktree-publish.test.mjs
@@ -1,0 +1,245 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const scriptsDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptsDir, "..");
+const publishScript = path.join(repoRoot, "scripts/worktree-publish.sh");
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    encoding: "utf8",
+    ...options,
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  return result;
+}
+
+function assertSuccess(result) {
+  assert.equal(
+    result.status,
+    0,
+    `stdout:\n${result.stdout ?? ""}\n\nstderr:\n${result.stderr ?? ""}`,
+  );
+}
+
+async function createPublishFixture(t) {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "freed-worktree-publish-"));
+  t.after(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  const origin = path.join(root, "origin.git");
+  const seed = path.join(root, "seed");
+  const worktree = path.join(root, "worktree");
+  const binDir = path.join(root, "bin");
+  const ghStateFile = path.join(root, "gh-state.json");
+  const ghLogFile = path.join(root, "gh-log.jsonl");
+
+  await fs.mkdir(seed, { recursive: true });
+  await fs.mkdir(binDir, { recursive: true });
+  await fs.writeFile(ghStateFile, JSON.stringify({ prList: [] }, null, 2));
+  await fs.writeFile(ghLogFile, "");
+
+  assert.equal(run("git", ["init", "--bare", origin]).status, 0);
+  assert.equal(run("git", ["init"], { cwd: seed }).status, 0);
+  assert.equal(run("git", ["config", "user.name", "Freed Tests"], { cwd: seed }).status, 0);
+  assert.equal(run("git", ["config", "user.email", "tests@freed.invalid"], { cwd: seed }).status, 0);
+  await fs.writeFile(path.join(seed, "README.md"), "seed\n");
+  assert.equal(run("git", ["add", "README.md"], { cwd: seed }).status, 0);
+  assert.equal(run("git", ["commit", "-m", "chore: seed repo"], { cwd: seed }).status, 0);
+  assert.equal(run("git", ["branch", "-M", "dev"], { cwd: seed }).status, 0);
+  assert.equal(run("git", ["remote", "add", "origin", origin], { cwd: seed }).status, 0);
+  assert.equal(run("git", ["push", "-u", "origin", "dev"], { cwd: seed }).status, 0);
+
+  assert.equal(run("git", ["clone", "--branch", "dev", origin, worktree]).status, 0);
+  assert.equal(run("git", ["config", "user.name", "Freed Tests"], { cwd: worktree }).status, 0);
+  assert.equal(run("git", ["config", "user.email", "tests@freed.invalid"], { cwd: worktree }).status, 0);
+  assert.equal(run("git", ["checkout", "-b", "fix/worktree-publish-test"], { cwd: worktree }).status, 0);
+
+  const ghStub = `#!/usr/bin/env node
+const fs = require("node:fs");
+
+const args = process.argv.slice(2);
+const stateFile = process.env.GH_STATE_FILE;
+const logFile = process.env.GH_LOG_FILE;
+const state = JSON.parse(fs.readFileSync(stateFile, "utf8"));
+
+fs.appendFileSync(logFile, JSON.stringify({ args }) + "\\n");
+
+if (args[0] !== "pr") {
+  process.exit(1);
+}
+
+if (args[1] === "list") {
+  process.stdout.write(JSON.stringify(state.prList || []));
+  process.exit(0);
+}
+
+if (args[1] === "create") {
+  process.stdout.write(state.createUrl || "https://github.com/freed-project/freed/pull/999");
+  process.exit(0);
+}
+
+if (args[1] === "edit" || args[1] === "ready") {
+  process.exit(0);
+}
+
+process.exit(1);
+`;
+
+  await fs.writeFile(path.join(binDir, "gh"), ghStub, { mode: 0o755 });
+
+  return {
+    worktree,
+    ghStateFile,
+    ghLogFile,
+    env: {
+      ...process.env,
+      GH_STATE_FILE: ghStateFile,
+      GH_LOG_FILE: ghLogFile,
+      PATH: `${binDir}:${process.env.PATH}`,
+    },
+  };
+}
+
+async function readGhLog(logFile) {
+  const raw = await fs.readFile(logFile, "utf8");
+  return raw
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+test("worktree-publish converts an existing ready PR back to draft and updates it", async (t) => {
+  const fixture = await createPublishFixture(t);
+
+  await fs.writeFile(
+    fixture.ghStateFile,
+    JSON.stringify(
+      {
+        prList: [
+          {
+            number: 253,
+            url: "https://github.com/freed-project/freed/pull/253",
+            isDraft: false,
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+
+  await fs.writeFile(path.join(fixture.worktree, "README.md"), "updated\n");
+
+  const result = run(
+    "bash",
+    [
+      publishScript,
+      "--title",
+      "fix: refresh worktree publish flow",
+      "--summary",
+      "Refresh the worktree publish flow",
+      "--test",
+      "node --test scripts/*.test.mjs",
+    ],
+    {
+      cwd: fixture.worktree,
+      env: fixture.env,
+    },
+  );
+
+  assertSuccess(result);
+  assert.match(result.stdout, /Updated draft PR: https:\/\/github.com\/freed-project\/freed\/pull\/253/);
+
+  const headMessage = run("git", ["log", "-1", "--pretty=%s"], { cwd: fixture.worktree });
+  assert.equal(headMessage.stdout.trim(), "fix: refresh worktree publish flow");
+
+  const ghCalls = await readGhLog(fixture.ghLogFile);
+  assert.deepEqual(ghCalls[0].args.slice(0, 2), ["pr", "list"]);
+  assert.deepEqual(ghCalls[1].args, ["pr", "ready", "253", "--undo"]);
+  assert.equal(ghCalls[2].args[0], "pr");
+  assert.equal(ghCalls[2].args[1], "edit");
+  assert.match(ghCalls[2].args.join("\n"), /\(AI Generated\)\./);
+});
+
+test("worktree-publish updates an existing draft PR without toggling it", async (t) => {
+  const fixture = await createPublishFixture(t);
+
+  await fs.writeFile(
+    fixture.ghStateFile,
+    JSON.stringify(
+      {
+        prList: [
+          {
+            number: 251,
+            url: "https://github.com/freed-project/freed/pull/251",
+            isDraft: true,
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+
+  await fs.writeFile(path.join(fixture.worktree, "README.md"), "updated draft\n");
+
+  const result = run(
+    "bash",
+    [
+      publishScript,
+      "--title",
+      "fix: update draft publish helper",
+      "--summary",
+      "Update the draft publish helper",
+    ],
+    {
+      cwd: fixture.worktree,
+      env: fixture.env,
+    },
+  );
+
+  assertSuccess(result);
+  assert.match(result.stdout, /Updated draft PR: https:\/\/github.com\/freed-project\/freed\/pull\/251/);
+
+  const ghCalls = await readGhLog(fixture.ghLogFile);
+  assert.equal(ghCalls.some((call) => call.args[1] === "ready"), false);
+  assert.equal(ghCalls.at(-1).args[1], "edit");
+});
+
+test("worktree-publish creates a new draft PR when none exists", async (t) => {
+  const fixture = await createPublishFixture(t);
+  await fs.writeFile(path.join(fixture.worktree, "README.md"), "fresh create\n");
+
+  const result = run(
+    "bash",
+    [
+      publishScript,
+      "--title",
+      "fix: create a new draft publish helper",
+      "--summary",
+      "Create the new draft publish helper",
+    ],
+    {
+      cwd: fixture.worktree,
+      env: fixture.env,
+    },
+  );
+
+  assertSuccess(result);
+  assert.match(result.stdout, /https:\/\/github.com\/freed-project\/freed\/pull\/999/);
+
+  const ghCalls = await readGhLog(fixture.ghLogFile);
+  assert.equal(ghCalls.at(-1).args[1], "create");
+  assert.ok(ghCalls.at(-1).args.includes("--draft"));
+});

--- a/website/src/app/roadmap/RoadmapContent.tsx
+++ b/website/src/app/roadmap/RoadmapContent.tsx
@@ -701,7 +701,7 @@ const phases: Phase[] = [
     number: 1,
     title: "Foundation",
     description:
-      "Marketing site, QR gallery, monorepo, Automerge schema, CI/CD, public legal docs with download clickwrap, a protected newsletter signup flow, and ready-to-run local worktree bootstrap with tracked preview tooling, light-by-default preview routing, draft-PR publish automation, labeled native windows, plus optional deferred installs when you actually want them.",
+      "Marketing site, QR gallery, monorepo, Automerge schema, CI/CD, public legal docs with download clickwrap, a protected newsletter signup flow, and ready-to-run local worktree bootstrap with tracked preview tooling, light-by-default preview routing, rerunnable draft-PR publish automation, visible local preview labels, native window labels, helper smoke coverage, plus optional deferred installs when you actually want them.",
     status: "complete",
     planLink:
       "https://github.com/freed-project/freed/blob/dev/docs/PHASE-1-FOUNDATION.md",

--- a/website/src/components/SiteShell.tsx
+++ b/website/src/components/SiteShell.tsx
@@ -2,10 +2,13 @@
 
 import { useEffect } from "react";
 import { usePathname } from "next/navigation";
+import { LocalPreviewBadge } from "@freed/ui/components/LocalPreviewBadge";
 import Navigation from "@/components/Navigation";
 import Footer from "@/components/Footer";
 import NewsletterModal from "@/components/NewsletterModal";
 import BackgroundGradients from "@/components/BackgroundGradients";
+
+const LOCAL_PREVIEW_LABEL = process.env.NEXT_PUBLIC_FREED_PREVIEW_LABEL?.trim() || null;
 
 export default function SiteShell({
   children,
@@ -31,6 +34,7 @@ export default function SiteShell({
     <>
       <div className="theme-shell flex flex-col overflow-hidden relative">
         <BackgroundGradients />
+        <LocalPreviewBadge label={LOCAL_PREVIEW_LABEL} />
 
         {!isQrGallery && <Navigation />}
 


### PR DESCRIPTION
(AI Generated).

## Summary
- Add script smoke coverage for worktree preview, publish, and root fanout helpers.
- Make worktree helpers print the resolved node and npm pair, and make root fanout use the npm that matches the active Node runtime.
- Show the local preview label inside website previews and keep draft PRs in sync on publish reruns.

## Testing
- npm run test:scripts
- PATH=/Users/aubreyfalconer/dev/freed-worktree-flow-followups/node_modules/.bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/usr/local/MacGPG2/bin:/Applications/VMware Fusion.app/Contents/Public:/usr/local/share/dotnet:~/.dotnet/tools:/usr/local/go/bin:/Library/Frameworks/Mono.framework/Versions/Current/Commands:/Users/aubreyfalconer/.nvm/versions/node/v24.14.1/bin:/Users/aubreyfalconer/.codex/tmp/arg0/codex-arg0Vg6FJ1:/Users/aubreyfalconer/.local/bin:/opt/homebrew/opt/mysql-client/bin:/opt/homebrew/bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/Users/aubreyfalconer/.cargo/bin:/Users/aubreyfalconer/go/bin:/Users/aubreyfalconer/.cache/lm-studio/bin:/Users/aubreyfalconer/.safe-chain/bin:/Applications/Codex.app/Contents/Resources:/usr/local/bin npm run build (website)
- ./scripts/worktree-preview.sh website skipped occupied port 3000 and launched at http://localhost:3001 with a visible preview label
- ./scripts/worktree-preview.sh desktop --native launched the native desktop preview on http://localhost:1420 with label 'flow followups native smoke'