### PR TITLE
fix: keep installed version stable across release channels

### DIFF
--- a/packages/desktop/src/App.tsx
+++ b/packages/desktop/src/App.tsx
@@ -660,7 +660,7 @@ function App() {
                     <path d="M3 8l3.5 3.5L13 5" stroke="#22c55e" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
                   </svg>
                   <span className="text-sm text-text-primary">
-                    Updated to <span className="font-mono font-bold">v{formatReleaseVersion(justUpdated, releaseChannel)}</span>
+                    Updated to <span className="font-mono font-bold">v{formatReleaseVersion(justUpdated)}</span>
                   </span>
                 </div>
               </div>

--- a/packages/desktop/tests/e2e/update-channel.spec.ts
+++ b/packages/desktop/tests/e2e/update-channel.spec.ts
@@ -19,7 +19,12 @@ test("switching release channels clears stale update state and rechecks the new 
   await expect(page.getByRole("heading", { name: "Updates" }).last()).toBeVisible({
     timeout: 5_000,
   });
-  await expect(page.getByText("Installed version:")).toBeVisible();
+  const installedVersionLabel = page.getByText(/^Installed version:/).last();
+  await expect(installedVersionLabel).toBeVisible();
+  const initialInstalledVersion = (await installedVersionLabel.textContent())
+    ?.replace(/\s+/g, " ")
+    .trim();
+  expect(initialInstalledVersion).toBeTruthy();
 
   const releaseChannelSelect = page.getByTestId("settings-release-channel-select");
   await expect(releaseChannelSelect).toHaveValue("production");
@@ -38,6 +43,7 @@ test("switching release channels clears stale update state and rechecks the new 
 
   await releaseChannelSelect.selectOption("dev");
   await expect(releaseChannelSelect).toHaveValue("dev");
+  await expect(installedVersionLabel).toHaveText(initialInstalledVersion ?? "");
 
   await expect(page.getByText("You're up to date")).toHaveCount(0);
   await expect(

--- a/packages/ui/src/components/SettingsDialog.tsx
+++ b/packages/ui/src/components/SettingsDialog.tsx
@@ -530,7 +530,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
   const [updateState, setUpdateState] = useState<UpdateCheckState>({ status: "idle" });
   const fadeTimer = useRef<ReturnType<typeof setTimeout>>(undefined);
   const shouldRecheckAfterChannelChangeRef = useRef(false);
-  const displayVersion = formatReleaseVersion(__APP_VERSION__, releaseChannel ?? "production");
+  const displayVersion = formatReleaseVersion(__APP_VERSION__);
 
   const runUpdateCheck = useCallback(async () => {
     if (!checkForUpdates) return;


### PR DESCRIPTION
(AI Generated).

## Summary
- stop deriving the displayed installed version from the selected release channel
- keep the post-update success toast pinned to the actual installed version
- add a desktop regression test that flips channels and verifies the installed version label stays unchanged

## Testing
- npm run test:e2e -- tests/e2e/update-channel.spec.ts