### PR TITLE
fix: harden build fanout and swarm worktree setup

### DIFF
--- a/.agents/skills/freed-build-feature/SKILL.md
+++ b/.agents/skills/freed-build-feature/SKILL.md
@@ -17,7 +17,7 @@ Create a product worktree branch from the latest remote `dev`, implement the fea
    - Confirm whether local `dev` or `main` are behind their remote counterparts.
    - If `origin/main` contains commits that are not in `origin/dev`, call that out before continuing so the user can decide whether `dev` needs to be refreshed first.
 5. Create a new worktree branch from `origin/dev` using `./scripts/worktree-add.sh ../freed-<slug> -b <branch> origin/dev --install full --target <desktop|pwa|shared>`.
-   - When you are spinning up multiple speculative threads at once, prefer `--install auto` until the worktree actually needs verification or a preview.
+   - When you are spinning up multiple speculative threads at once, prefer `./scripts/worktree-add.sh ../freed-<slug> -b <branch> origin/dev --swarm --target <desktop|pwa|shared>` so bootstrap stays deferred until that thread actually needs verification or a preview.
 6. If the worktree was created with deferred bootstrap on purpose, recover with `./scripts/worktree-bootstrap.sh <worktree> --target <desktop|pwa|shared>`.
 7. Implement the requested change.
 8. Verify with focused tests, then broader checks when shared behavior changed.

--- a/.agents/skills/freed-build-www/SKILL.md
+++ b/.agents/skills/freed-build-www/SKILL.md
@@ -13,7 +13,7 @@ Create a marketing worktree branch from `www`, implement the website change, ver
 1. Confirm the request is public marketing work targeting `www`.
 2. Reject or reroute product work targeting `dev`; use `freed-build-feature` instead.
 3. Create a new worktree branch from `www` using `./scripts/worktree-add.sh ../freed-<slug> -b <branch> origin/www --install full --target website`.
-   - When you are spinning up multiple speculative threads at once, prefer `--install auto` until the worktree actually needs verification or a preview.
+   - When you are spinning up multiple speculative threads at once, prefer `./scripts/worktree-add.sh ../freed-<slug> -b <branch> origin/www --swarm --target website` so bootstrap stays deferred until that thread actually needs verification or a preview.
 4. If the worktree was created with deferred bootstrap on purpose, recover with `./scripts/worktree-bootstrap.sh <worktree> --target website`.
 5. Keep changes scoped to marketing paths unless the user explicitly changes the destination.
 6. Run website checks from the workspace directory, at minimum `cd website && PATH=../node_modules/.bin:$PATH npm run build`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ Run `./scripts/release.sh` with no args to auto-compute the next version.
 
 `worktree-add.sh` is a drop-in replacement for `git worktree add`. It defaults to a full isolated install so the new worktree is ready immediately, and it still supports `--install auto` or `--install none` when you intentionally want to defer bootstrap. Never use bare `git worktree add` directly.
 Pass an explicit remote base like `origin/dev` or `origin/www` so feature work does not inherit a stale local branch by accident.
-For multi-thread or speculative worktree swarms, prefer `--install auto` until the thread actually needs verification or a preview.
+For multi-thread or speculative worktree swarms, prefer `--swarm`. That maps to deferred bootstrap until the thread actually needs verification or a preview.
 Prefer the lightest useful local preview before opening a draft PR:
 - product work usually uses `./scripts/worktree-preview.sh pwa`
 - website work uses `./scripts/worktree-preview.sh website`

--- a/README.md
+++ b/README.md
@@ -169,7 +169,13 @@ If you want a cheap speculative worktree instead, opt in explicitly:
 ./scripts/worktree-add.sh ../freed-my-branch -b feat/my-branch origin/dev --install auto --target shared
 ```
 
-That is the better default when you are spinning up several speculative threads at once and only one or two of them will reach verification.
+If you are spinning up several speculative threads at once, use the swarm alias instead:
+
+```bash
+./scripts/worktree-add.sh ../freed-my-branch -b feat/my-branch origin/dev --swarm --target shared
+```
+
+That is the better default when only one or two of those threads will reach verification.
 
 When you are ready to preview the work locally, prefer the lightest useful surface:
 

--- a/docs/PHASE-1-FOUNDATION.md
+++ b/docs/PHASE-1-FOUNDATION.md
@@ -244,7 +244,7 @@ system npm from the shell `PATH`. The root workspace fanout runner now does the
 same thing, which cuts out another stale-global-`npm` failure mode when local
 or CI commands fan out across workspaces.
 
-Local product worktrees now default to a ready-to-run full bootstrap so the next command does not trip over missing `node_modules`. `./scripts/worktree-add.sh` still supports `--install none|auto|full` and `--target desktop|pwa|website|shared` when you intentionally want to defer bootstrap, the worktree helpers now print the resolved `node` and `npm` pair before they bootstrap, preview, or publish, `./scripts/worktree-bootstrap.sh` handles the on-demand install, `./scripts/worktree-preview.sh` launches tracked previews with one desktop slot and one web slot per repo, defaults product work to the lightest useful preview surface, automatically skips an occupied website port even when the listener is only on IPv6, and now surfaces the local preview label inside the marketing site too, root `npm run dev` now fails fast instead of fanning out across every workspace, `./scripts/worktree-publish.sh` refuses stray untracked files unless you explicitly include them, still opens a draft PR with the required `(AI Generated).` body prefix, and now updates that PR in place on reruns, `./scripts/dev-session-clean.sh` stops tracked previews and kills stale browser automation sidecars, preview labels are stamped with the worktree plus thread tail so concurrent native windows stay identifiable, `npm run test:scripts` covers the helper smoke lane in CI, and `./scripts/worktree-cleanup.sh` stops tracked previews before removing merged worktrees.
+Local product worktrees now default to a ready-to-run full bootstrap so the next command does not trip over missing `node_modules`. `./scripts/worktree-add.sh` still supports `--install none|auto|full`, a `--swarm` shortcut for deferred speculative worktrees, and `--target desktop|pwa|website|shared` when you intentionally want to steer bootstrap and preview behavior, the worktree helpers now print the resolved `node` and `npm` pair before they bootstrap, preview, or publish, `./scripts/worktree-bootstrap.sh` handles the on-demand install, `./scripts/worktree-preview.sh` launches tracked previews with one desktop slot and one web slot per repo, defaults product work to the lightest useful preview surface, automatically skips an occupied website port even when the listener is only on IPv6, and now surfaces the local preview label inside the marketing site too, root `npm run dev` now fails fast instead of fanning out across every workspace, `./scripts/worktree-publish.sh` refuses stray untracked files unless you explicitly include them, still opens a draft PR with the required `(AI Generated).` body prefix, and now updates that PR in place on reruns, `./scripts/dev-session-clean.sh` stops tracked previews and kills stale browser automation sidecars, preview labels are stamped with the worktree plus thread tail so concurrent native windows stay identifiable, `npm run test:scripts` covers the helper smoke lane in CI, and `./scripts/worktree-cleanup.sh` stops tracked previews before removing merged worktrees.
 
 ---
 
@@ -275,7 +275,11 @@ Local product worktrees now default to a ready-to-run full bootstrap so the next
 | 1.9  | Generate RSS feed at build time              | ✓      |
 | 1.10 | Add public legal docs and versioned website clickwrap | ✓ |
 | 1.11 | Add unified shared theme system across website, Freed Desktop, and PWA | ✓ |
+<<<<<<< HEAD
 | 1.12 | Add ready-to-run worktree bootstrap controls, safer root command routing, rerunnable draft-PR publishing, helper smoke coverage, and labeled tracked local preview tooling | ✓ |
+=======
+| 1.12 | Add ready-to-run worktree bootstrap controls, a swarm shortcut for deferred worktrees, safer root command routing, and labeled tracked local preview tooling | ✓ |
+>>>>>>> e967bb1 (fix: harden build fanout and swarm worktree setup)
 
 ---
 

--- a/packages/ui/src/components/SettingsDialog.tsx
+++ b/packages/ui/src/components/SettingsDialog.tsx
@@ -758,9 +758,6 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
     container.scrollTo({ top: targetTop, behavior });
   }, []);
 
-  // ── Mobile nav state ──────────────────────────────────────────────────────
-  const [mobileView, setMobileView] = useState<"nav" | "section">("nav");
-
   useEffect(() => {
     const root = scrollRef.current;
     if (!root || searchLower || (isMobile && mobileView === "nav")) return;

--- a/scripts/run-workspace-fanout.mjs
+++ b/scripts/run-workspace-fanout.mjs
@@ -1,13 +1,18 @@
 #!/usr/bin/env node
 
-import fs from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
+
+const repoRoot = process.cwd();
+const rootPackageJsonPath = path.join(repoRoot, "package.json");
+const rootPackage = JSON.parse(readFileSync(rootPackageJsonPath, "utf8"));
 
 const scriptName = process.argv[2];
 const forwardedArgs = process.argv.slice(3);
 const workspace = process.env.npm_config_workspace;
-const runningWorkspaceSelection = workspace && process.env.npm_config_workspaces !== "true";
+const runningWorkspaceSelection =
+  workspace && process.env.npm_config_workspaces !== "true";
 
 if (!scriptName) {
   console.error("Missing script name for workspace fanout.");
@@ -23,40 +28,74 @@ if (runningWorkspaceSelection) {
   process.exit(1);
 }
 
-function resolveNpmCommand() {
-  const siblingNpm = path.join(path.dirname(process.execPath), process.platform === "win32" ? "npm.cmd" : "npm");
-
-  if (fs.existsSync(siblingNpm)) {
-    return siblingNpm;
-  }
-
-  return "npm";
-}
-
 if (scriptName === "dev") {
   console.error('Refusing to run root "dev" from the monorepo root.');
   console.error("That path can start too many long-lived processes at once.");
   console.error("Use ./scripts/worktree-preview.sh <desktop|pwa|website> instead.");
-  console.error("Or cd into the workspace you actually want and run npm run dev there.");
+  console.error(
+    "Or cd into the workspace you actually want and run npm run dev there."
+  );
   process.exit(1);
 }
 
-const child = spawnSync(
-  resolveNpmCommand(),
-  ["run", scriptName, "--workspaces", "--if-present", ...forwardedArgs],
-  {
+function expandWorkspacePattern(pattern) {
+  const normalizedPattern = pattern.replace(/\/+$/, "");
+  const wildcardSuffix = "/*";
+
+  if (normalizedPattern.endsWith(wildcardSuffix)) {
+    const baseDir = path.resolve(
+      repoRoot,
+      normalizedPattern.slice(0, -wildcardSuffix.length)
+    );
+
+    if (!existsSync(baseDir)) {
+      return [];
+    }
+
+    return readdirSync(baseDir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => path.join(baseDir, entry.name))
+      .filter((candidate) => existsSync(path.join(candidate, "package.json")));
+  }
+
+  const candidate = path.resolve(repoRoot, normalizedPattern);
+  if (existsSync(path.join(candidate, "package.json"))) {
+    return [candidate];
+  }
+
+  return [];
+}
+
+function getWorkspaceDirs() {
+  const workspacePatterns = rootPackage.workspaces ?? [];
+  const dirs = workspacePatterns.flatMap(expandWorkspacePattern);
+  return [...new Set(dirs)].sort((left, right) => left.localeCompare(right));
+}
+
+function workspaceHasScript(workspaceDir, name) {
+  const packageJsonPath = path.join(workspaceDir, "package.json");
+  const pkg = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+  return Object.prototype.hasOwnProperty.call(pkg.scripts ?? {}, name);
+}
+
+for (const workspaceDir of getWorkspaceDirs()) {
+  if (!workspaceHasScript(workspaceDir, scriptName)) {
+    continue;
+  }
+
+  const child = spawnSync("npm", ["run", scriptName, ...forwardedArgs], {
+    cwd: workspaceDir,
     stdio: "inherit",
     shell: process.platform === "win32",
-    env: {
-      ...process.env,
-      npm_config_workspace: "",
-    },
+    env: process.env,
+  });
+
+  if (child.error) {
+    console.error(child.error.message);
+    process.exit(1);
   }
-);
 
-if (child.error) {
-  console.error(child.error.message);
-  process.exit(1);
+  if ((child.status ?? 1) !== 0) {
+    process.exit(child.status ?? 1);
+  }
 }
-
-process.exit(child.status ?? 1);

--- a/scripts/worktree-add.sh
+++ b/scripts/worktree-add.sh
@@ -7,6 +7,7 @@
 # Usage:
 #   ./scripts/worktree-add.sh ../freed-<slug> -b feat/my-feature origin/dev
 #   ./scripts/worktree-add.sh ../freed-<slug> -b feat/my-feature origin/dev --install full --target desktop
+#   ./scripts/worktree-add.sh ../freed-<slug> -b feat/my-feature origin/dev --swarm --target shared
 #
 # Why not symlink node_modules from the primary worktree?
 #   npm writes *through* symlinks. Running `npm install foo` in a symlinked
@@ -31,11 +32,12 @@ source "${SCRIPT_DIR}/lib/worktree-runtime.sh"
 usage() {
   cat <<'EOF'
 Usage:
-  ./scripts/worktree-add.sh <path> [-b <branch>] [<commit-ish>] [--install none|auto|full] [--target desktop|pwa|website|shared]
+  ./scripts/worktree-add.sh <path> [-b <branch>] [<commit-ish>] [--install none|auto|full] [--target desktop|pwa|website|shared] [--swarm]
 
 Options:
   --install  Dependency bootstrap mode. Default: full
   --target   Hint for later bootstrap or preview commands
+  --swarm    Alias for --install auto, tuned for speculative multi-thread worktrees
 EOF
 }
 
@@ -65,10 +67,16 @@ validate_target_hint() {
 
 INSTALL_MODE="full"
 TARGET_HINT=""
+SWARM_MODE=false
 PASSTHROUGH_ARGS=()
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    --swarm)
+      SWARM_MODE=true
+      INSTALL_MODE="auto"
+      shift
+      ;;
     --install)
       [[ $# -ge 2 ]] || { echo "Error: --install requires a value." >&2; exit 1; }
       INSTALL_MODE="$2"
@@ -142,6 +150,9 @@ case "${INSTALL_MODE}" in
     ;;
   auto)
     echo "Created ${NEW_WT} with deferred bootstrap."
+    if ${SWARM_MODE}; then
+      echo "Swarm mode is on, so bootstrap is deferred until this thread actually needs it."
+    fi
     if [[ -n "${TARGET_HINT}" ]]; then
       echo "When this worktree needs dependencies, run:"
       echo "  ./scripts/worktree-bootstrap.sh \"${NEW_WT}\" --target ${TARGET_HINT}"

--- a/website/src/app/roadmap/RoadmapContent.tsx
+++ b/website/src/app/roadmap/RoadmapContent.tsx
@@ -701,7 +701,7 @@ const phases: Phase[] = [
     number: 1,
     title: "Foundation",
     description:
-      "Marketing site, QR gallery, monorepo, Automerge schema, CI/CD, public legal docs with download clickwrap, a protected newsletter signup flow, and ready-to-run local worktree bootstrap with tracked preview tooling, light-by-default preview routing, safer root command routing, rerunnable draft-PR publish automation that rejects stray untracked files, visible local preview labels, labeled native windows, helper smoke coverage, a local session cleanup helper for stale browser sidecars, plus optional deferred installs when you actually want them.",
+      "Marketing site, QR gallery, monorepo, Automerge schema, CI/CD, public legal docs with download clickwrap, a protected newsletter signup flow, and ready-to-run local worktree bootstrap with tracked preview tooling, a swarm shortcut for deferred speculative worktrees, light-by-default preview routing, safer root command routing, rerunnable draft-PR publish automation that rejects stray untracked files, visible local preview labels, labeled native windows, helper smoke coverage, a local session cleanup helper for stale browser sidecars, plus optional deferred installs when you actually want them.",
     status: "complete",
     planLink:
       "https://github.com/freed-project/freed/blob/dev/docs/PHASE-1-FOUNDATION.md",


### PR DESCRIPTION
(AI Generated).

## Summary
- fix the SettingsDialog mobileView ordering bug that was breaking desktop and PWA builds
- replace the root workspace fanout helper with an explicit root-excluding workspace runner so local npm cannot recurse into the root build script
- add a --swarm shortcut for deferred speculative worktrees and document it across the workflow guides

## Testing
- npm run build
- bash -n scripts/worktree-add.sh
- node --check scripts/run-workspace-fanout.mjs
- git diff --check
- ./scripts/worktree-add.sh /Users/aubreyfalconer/dev/freed-swarm-check -b chore/swarm-check-instability HEAD --swarm --target shared