### PR TITLE
fix: serialize release asset uploads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,6 +120,9 @@ jobs:
       contents: write
 
     strategy:
+      # Tauri updates shared GitHub release assets like latest.json. Serializing
+      # the matrix avoids cross-target upload races on the same draft release.
+      max-parallel: 1
       fail-fast: false
       matrix:
         include:


### PR DESCRIPTION
(AI Generated).

## Summary
- serialize the release matrix so Tauri uploads shared release assets one target at a time
- avoid the macOS asset race on latest.json that broke the v26.4.2000-dev publish workflow

## Testing
- git diff --check