### PR TITLE
fix: stabilize website theme selector interactions

### DIFF
--- a/website/public/atom.xml
+++ b/website/public/atom.xml
@@ -2,7 +2,7 @@
 <feed xmlns="http://www.w3.org/2005/Atom">
     <id>https://freed.wtf</id>
     <title>Freed Blog</title>
-    <updated>2026-04-21T04:25:21.815Z</updated>
+    <updated>2026-04-21T04:47:17.802Z</updated>
     <generator>https://github.com/jpmonette/feed</generator>
     <author>
         <name>The Freed Team</name>

--- a/website/public/feed.xml
+++ b/website/public/feed.xml
@@ -4,7 +4,7 @@
         <title>Freed Blog</title>
         <link>https://freed.wtf</link>
         <description>Progress reports, technical deep-dives, and philosophical rants about the attention economy. From the team building Freed.</description>
-        <lastBuildDate>Tue, 21 Apr 2026 04:25:21 GMT</lastBuildDate>
+        <lastBuildDate>Tue, 21 Apr 2026 04:47:17 GMT</lastBuildDate>
         <docs>https://validator.w3.org/feed/docs/rss2.html</docs>
         <generator>https://github.com/jpmonette/feed</generator>
         <language>en</language>

--- a/website/src/components/ThemeSelector.tsx
+++ b/website/src/components/ThemeSelector.tsx
@@ -27,9 +27,11 @@ export default function ThemeSelector({ compact = false }: ThemeSelectorProps) {
   const { themeId, setThemeId, previewTheme, revertPreview } = useTheme();
   const gapClassName = compact ? "gap-2" : "gap-3";
   const wrapperRef = useRef<HTMLDivElement | null>(null);
-  const floatingLayerRef = useRef<HTMLDivElement | null>(null);
+  const inlineRowRef = useRef<HTMLDivElement | null>(null);
+  const floatingRowRef = useRef<HTMLDivElement | null>(null);
   const ignoreNextInlineMouseLeaveRef = useRef(false);
   const [floatingRect, setFloatingRect] = useState<FloatingRect | null>(null);
+  const [stableHeight, setStableHeight] = useState<number | null>(null);
   const isFloating = compact && floatingRect !== null;
 
   useEffect(() => {
@@ -49,6 +51,40 @@ export default function ThemeSelector({ compact = false }: ThemeSelectorProps) {
       window.removeEventListener("scroll", clearFloatingPreview, true);
     };
   }, [isFloating, revertPreview]);
+
+  useEffect(() => {
+    if (!wrapperRef.current || typeof ResizeObserver === "undefined") {
+      return;
+    }
+
+    const recordHeight = () => {
+      if (!wrapperRef.current) {
+        return;
+      }
+
+      const nextHeight = Math.ceil(wrapperRef.current.getBoundingClientRect().height);
+      setStableHeight((currentHeight) => {
+        if (currentHeight !== null && currentHeight >= nextHeight) {
+          return currentHeight;
+        }
+
+        return nextHeight;
+      });
+    };
+
+    recordHeight();
+
+    const observer = new ResizeObserver(() => {
+      recordHeight();
+    });
+    observer.observe(wrapperRef.current);
+    window.addEventListener("resize", recordHeight);
+
+    return () => {
+      observer.disconnect();
+      window.removeEventListener("resize", recordHeight);
+    };
+  }, []);
 
   function activatePreview(themeId: ThemeId) {
     if (compact && floatingRect === null) {
@@ -92,7 +128,11 @@ export default function ThemeSelector({ compact = false }: ThemeSelectorProps) {
       return true;
     }
 
-    return floatingLayerRef.current?.contains(nextTarget) ?? false;
+    return (
+      inlineRowRef.current?.contains(nextTarget)
+      || floatingRowRef.current?.contains(nextTarget)
+      || false
+    );
   }
 
   function handleMouseLeave(
@@ -119,11 +159,29 @@ export default function ThemeSelector({ compact = false }: ThemeSelectorProps) {
     clearPreview();
   }
 
+  function handleButtonMouseLeave(
+    layer: "inline" | "floating",
+    event: ReactMouseEvent<HTMLButtonElement>,
+  ) {
+    if (layer === "inline" && ignoreNextInlineMouseLeaveRef.current) {
+      ignoreNextInlineMouseLeaveRef.current = false;
+      return;
+    }
+
+    const nextTarget = event.relatedTarget;
+    if (nextTarget instanceof Element && nextTarget.closest(".theme-preview-button")) {
+      return;
+    }
+
+    clearPreview();
+  }
+
   function renderSelectorContent(layer: "inline" | "floating") {
     return (
       <>
         <h4 className="mb-4 text-text-primary font-semibold">Theme</h4>
         <div
+          ref={layer === "inline" ? inlineRowRef : floatingRowRef}
           className={`flex flex-wrap items-center ${gapClassName}`}
           onMouseLeave={(event) => handleMouseLeave(layer, event)}
           onBlurCapture={handleBlurCapture}
@@ -140,6 +198,7 @@ export default function ThemeSelector({ compact = false }: ThemeSelectorProps) {
                   active={themeId === theme.id}
                   variant="compact"
                   onMouseEnter={() => activatePreview(theme.id)}
+                  onMouseLeave={(event) => handleButtonMouseLeave(layer, event)}
                   onFocus={() => previewTheme(theme.id)}
                   onClick={() => commitTheme(theme.id)}
                 />
@@ -152,7 +211,11 @@ export default function ThemeSelector({ compact = false }: ThemeSelectorProps) {
   }
 
   return (
-    <div ref={wrapperRef} className="relative">
+    <div
+      ref={wrapperRef}
+      className="relative"
+      style={stableHeight ? { minHeight: `${stableHeight}px` } : undefined}
+    >
       <div
         aria-hidden={isFloating || undefined}
         className="flex flex-col"
@@ -163,7 +226,6 @@ export default function ThemeSelector({ compact = false }: ThemeSelectorProps) {
       {isFloating && typeof document !== "undefined"
         ? createPortal(
           <div
-            ref={floatingLayerRef}
             className="fixed z-[80]"
             style={{
               left: `${floatingRect!.left}px`,

--- a/website/src/content/changelog.generated.json
+++ b/website/src/content/changelog.generated.json
@@ -1,5 +1,188 @@
 [
   {
+    "version": "26.4.2002-dev",
+    "tagName": "v26.4.2002-dev",
+    "channel": "dev",
+    "date": "2026-04-21T04:39:59Z",
+    "deck": "This dev build improves install flow and tightens startup, capture, and release stability.",
+    "features": [
+      {
+        "text": "PWA install prompt flow"
+      }
+    ],
+    "fixes": [
+      {
+        "text": "Stop the desktop dev launch crash and clean up the recovery dialog"
+      },
+      {
+        "text": "Dedupe Facebook and Instagram cross-posts"
+      },
+      {
+        "text": "Reset preview banners to bottom center on load"
+      },
+      {
+        "text": "Harden build fanout and swarm worktree setup"
+      },
+      {
+        "text": "Keep installed version stable across release channels"
+      },
+      {
+        "text": "Polish mobile settings navigation"
+      },
+      {
+        "text": "Refine live theme preview interactions"
+      }
+    ],
+    "followUps": [
+      {
+        "text": "Refine settings section jump alignment, harden worktree helper flow, and harden helper session workflow"
+      }
+    ],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.2002-dev",
+    "prNumbers": [],
+    "builds": [
+      "26.4.2001-dev",
+      "26.4.2002-dev"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.4.2001-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.2001-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.4.2002-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.2002-dev",
+        "channel": "dev"
+      }
+    ]
+  },
+  {
+    "version": "26.4.1901-dev",
+    "tagName": "v26.4.1901-dev",
+    "channel": "dev",
+    "date": "2026-04-20T03:41:16Z",
+    "deck": "Expand friends and map identity workflows, tri-state source sidebar, and Friends lens to feed toolbar",
+    "features": [
+      {
+        "text": "Expand friends and map identity workflows"
+      },
+      {
+        "text": "Tri-state source sidebar"
+      },
+      {
+        "text": "Friends lens to feed toolbar"
+      }
+    ],
+    "fixes": [
+      {
+        "text": "Redeploy dev pwa on dev merges"
+      },
+      {
+        "text": "Dismiss sticky tooltips after pointer activation"
+      },
+      {
+        "text": "Show -dev suffix for dev build versions"
+      },
+      {
+        "text": "Desktop toolbar dragging and back target restored"
+      },
+      {
+        "text": "Fall back to newer production updates on dev"
+      },
+      {
+        "text": "Add native startup recovery window"
+      },
+      {
+        "text": "Lets dev installs take a newer production update when no newer dev build exists, without switching release channels"
+      },
+      {
+        "text": "Shows the -dev suffix consistently in desktop update surfaces and settings"
+      }
+    ],
+    "followUps": [
+      {
+        "text": "Map timeline scrubber"
+      }
+    ],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1901-dev",
+    "prNumbers": [],
+    "builds": [
+      "26.4.1900-dev",
+      "26.4.1901-dev"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.4.1900-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1900-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.4.1901-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1901-dev",
+        "channel": "dev"
+      }
+    ]
+  },
+  {
+    "version": "26.4.1802-dev",
+    "tagName": "v26.4.1802-dev",
+    "channel": "dev",
+    "date": "2026-04-18T20:09:06Z",
+    "deck": "Time-aware map filtering and migrate legacy identity graph on startup",
+    "features": [
+      {
+        "text": "Time-aware map filtering"
+      }
+    ],
+    "fixes": [
+      {
+        "text": "Migrates older friend data into the person and account graph during startup so existing identities keep loading cleanly after the update."
+      }
+    ],
+    "followUps": [],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1802-dev",
+    "prNumbers": [],
+    "builds": [
+      "26.4.1800-dev",
+      "26.4.1802-dev"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.4.1800-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1800-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.4.1802-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1802-dev",
+        "channel": "dev"
+      }
+    ]
+  },
+  {
+    "version": "26.4.1700-dev",
+    "tagName": "v26.4.1700-dev",
+    "channel": "dev",
+    "date": "2026-04-18T04:42:45Z",
+    "deck": "Refactor friends into a person account identity graph",
+    "features": [],
+    "fixes": [],
+    "followUps": [],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1700-dev",
+    "prNumbers": [],
+    "builds": [
+      "26.4.1700-dev"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.4.1700-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1700-dev",
+        "channel": "dev"
+      }
+    ]
+  },
+  {
     "version": "26.4.1602",
     "tagName": "v26.4.1602",
     "channel": "production",


### PR DESCRIPTION
(AI Generated). 

## Summary
- stop theme previews from staying active after the cursor leaves the actual theme chips
- keep the compact theme selector wrapper at a stable height so clicking between themes does not bounce the page
- retain the earlier floating-preview and navbar fixes while tightening the row-to-row hover handoff

## Verification
- npm --prefix website run build
- verified on http://127.0.0.1:3000 that the selector wrapper stayed at 83px through hover and commit
- verified the upward one-pixel hover probe released the preview instead of keeping the hovered theme active indefinitely
