### PR TITLE
chore: switch website deploys to Vercel git

### DIFF
--- a/.github/workflows/website-preview.yml
+++ b/.github/workflows/website-preview.yml
@@ -1,0 +1,43 @@
+name: Website Build
+
+on:
+  pull_request:
+    branches: [www]
+    paths:
+      - "website/**"
+      - "packages/shared/**"
+      - "packages/ui/**"
+      - "release-notes/**"
+      - "package.json"
+      - "package-lock.json"
+      - "tsconfig.base.json"
+      - ".github/workflows/website-preview.yml"
+
+concurrency:
+  group: website-build-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build website
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build website
+        run: |
+          cd website
+          npm run build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,9 +13,11 @@
 - **Async-before-await is synchronous:** Code before the first `await` in an `async` function runs synchronously in the caller's microtask even if the caller doesn't await. Never put O(n) work (e.g. `Array.from(largeUint8Array)`, `A.save()`, serialization) before an `await` in a `subscribe()` callback or any other fire-and-forget async call on a hot path.
 - **Vercel deployments -- always use `--scope aubreyfs-projects`:** The only permitted Vercel team for this project is `aubreyfs-projects` (personal account). Never run `vercel deploy`, `vercel link`, or any Vercel CLI command without the `--scope aubreyfs-projects` flag. Never use the `deploy_to_vercel` MCP tool -- it accepts no arguments and silently deploys to whatever team the CLI defaults to. Never run `vercel` from the repo root.
   - This monorepo uses local workspace packages. Raw subdirectory deploys like `vercel deploy website/` and `vercel deploy packages/pwa/` can upload an incomplete tree and fail at `npm install`.
-  - Always use the preview helper instead:
-    - Website: `./scripts/vercel-deploy-preview.sh website`
-    - PWA: `./scripts/vercel-deploy-preview.sh pwa`
+  - Website preview and production deploys should come from Vercel Git integration on the `www` branch.
+  - Keep the website helper scripts only for explicit manual fallback work.
+  - The PWA still uses the helper scripts:
+    - Preview: `./scripts/vercel-deploy-preview.sh pwa`
+    - Production: `./scripts/vercel-deploy-production.sh pwa`
 
 ## Versioning
 

--- a/docs/PHASE-1-FOUNDATION.md
+++ b/docs/PHASE-1-FOUNDATION.md
@@ -225,10 +225,10 @@ Branch routing:
 
 - `dev` deploys to `dev.freed.wtf`
 - `dev` deploys to `dev-app.freed.wtf`
-- `main` deploys to `freed.wtf`
+- `www` deploys to `freed.wtf`
 - `main` deploys to `app.freed.wtf`
 
-Manual preview deploys for this monorepo now go through `./scripts/vercel-deploy-preview.sh website` and `./scripts/vercel-deploy-preview.sh pwa`. The helper stages a temporary monorepo slice with shared workspace packages before uploading to Vercel, which avoids the broken `npm install` failures caused by raw subdirectory deploys.
+Website preview and production deploys now come from Vercel Git integration on the `www` branch. The PWA still uses `./scripts/vercel-deploy-preview.sh pwa` and `./scripts/vercel-deploy-production.sh pwa` because raw subdirectory deploys can upload an incomplete monorepo slice and fail during install.
 
 ---
 

--- a/website/public/atom.xml
+++ b/website/public/atom.xml
@@ -2,7 +2,7 @@
 <feed xmlns="http://www.w3.org/2005/Atom">
     <id>https://freed.wtf</id>
     <title>Freed Blog</title>
-    <updated>2026-04-21T04:47:17.802Z</updated>
+    <updated>2026-04-21T21:54:10.309Z</updated>
     <generator>https://github.com/jpmonette/feed</generator>
     <author>
         <name>The Freed Team</name>

--- a/website/public/feed.xml
+++ b/website/public/feed.xml
@@ -4,7 +4,7 @@
         <title>Freed Blog</title>
         <link>https://freed.wtf</link>
         <description>Progress reports, technical deep-dives, and philosophical rants about the attention economy. From the team building Freed.</description>
-        <lastBuildDate>Tue, 21 Apr 2026 04:47:17 GMT</lastBuildDate>
+        <lastBuildDate>Tue, 21 Apr 2026 21:54:10 GMT</lastBuildDate>
         <docs>https://validator.w3.org/feed/docs/rss2.html</docs>
         <generator>https://github.com/jpmonette/feed</generator>
         <language>en</language>

--- a/website/src/content/changelog.generated.json
+++ b/website/src/content/changelog.generated.json
@@ -1,5 +1,63 @@
 [
   {
+    "version": "26.4.2100",
+    "tagName": "v26.4.2100",
+    "channel": "production",
+    "date": "2026-04-21T20:57:19Z",
+    "deck": "Map timeline playback, cleaner identity migration, and smoother install and update flows",
+    "features": [
+      {
+        "text": "Filter maps with a shared timeline scrubber"
+      },
+      {
+        "text": "Replay historical posts and future plans from one map timeline"
+      },
+      {
+        "text": "Manage friends and map identities through the new person and account graph"
+      }
+    ],
+    "fixes": [
+      {
+        "text": "Migrates older friend data into the new person and account graph during startup so existing identities keep loading cleanly after the update"
+      },
+      {
+        "text": "Dedupes Facebook and Instagram cross-posts"
+      },
+      {
+        "text": "Keeps the install prompt and update channel labeling clearer across the app"
+      },
+      {
+        "text": "Tightens reader, feed, header, sync, and release reliability"
+      }
+    ],
+    "followUps": [
+      {
+        "text": "Adds a tri-state source sidebar for faster filtering"
+      },
+      {
+        "text": "Brings the Friends lens into the feed toolbar"
+      },
+      {
+        "text": "Polishes settings jumps and hardens helper workflow stability"
+      }
+    ],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.2100",
+    "prNumbers": [
+      227,
+      274
+    ],
+    "builds": [
+      "26.4.2100"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.4.2100",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.2100",
+        "channel": "production"
+      }
+    ]
+  },
+  {
     "version": "26.4.2002-dev",
     "tagName": "v26.4.2002-dev",
     "channel": "dev",


### PR DESCRIPTION
(AI Generated).

## Summary
- switch website preview and production deploys to Vercel Git integration on `www`
- convert the website PR workflow into a build-only check
- regenerate the checked-in changelog and feeds so `v26.4.2100` is present

## Verification
- `PATH="/Users/aubreyfalconer/dev/freed-www-git-deploy/node_modules/.bin:$PATH" npm run build` from `website/`
- confirmed `website/src/content/changelog.generated.json` includes `26.4.2100`
