### PR TITLE
chore: stop release workflow deploying website

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -317,13 +317,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release edit "${{ github.ref_name }}" --draft=false --repo "${{ github.repository }}"
 
-  # Redeploy the marketing site after the GitHub release is public so the
-  # checked-in changelog snapshot is rebuilt against the published release.
-  # Requires VERCEL_TOKEN to be set in repo secrets. If the secret is absent
-  # the step exits cleanly without failing the workflow.
-  publish-website:
-    name: Deploy Website
-    needs: [publish, notes]
+  # Production website deploys come from Vercel Git integration on the www
+  # branch. Keep this verification so production releases still fail fast when
+  # the reviewed changelog state has not reached www yet.
+  verify-website-release-branch:
+    name: Verify Website Release Branch
+    needs: notes
     if: needs.notes.outputs.release_channel == 'production'
     runs-on: ubuntu-latest
     permissions:
@@ -334,12 +333,6 @@ jobs:
         with:
           ref: www
           fetch-depth: 0
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "lts/*"
-          cache: "npm"
 
       - name: Verify website production branch contains this release
         shell: bash
@@ -353,35 +346,6 @@ jobs:
             echo "Merge the reviewed website and changelog updates into www before this production website deploy can run." >&2
             exit 1
           fi
-
-      - name: Wait for published GitHub release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          for attempt in {1..30}; do
-            draft_state=$(gh api "repos/${{ github.repository }}/releases/tags/${{ github.ref_name }}" --jq '.draft')
-            if [ "$draft_state" = "false" ]; then
-              echo "Release ${{ github.ref_name }} is published."
-              exit 0
-            fi
-
-            echo "Release ${{ github.ref_name }} is still draft, retrying in 10s (${attempt}/30)"
-            sleep 10
-          done
-
-          echo "Release ${{ github.ref_name }} never became published."
-          exit 1
-
-      - name: Deploy website to Vercel
-        env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-        run: |
-          if [ -z "$VERCEL_TOKEN" ]; then
-            echo "VERCEL_TOKEN not configured, skipping website deploy"
-            echo "Add a VERCEL_TOKEN secret to enable automatic website changelog refresh."
-            exit 0
-          fi
-          ./scripts/vercel-deploy-production.sh website "$VERCEL_TOKEN"
   # Deploy the PWA to Vercel after the GitHub release is published so the
   # version shown in the app always matches the shipped desktop release.
   # Requires VERCEL_TOKEN to be set in repo secrets. If the secret is absent

--- a/.github/workflows/website-preview.yml
+++ b/.github/workflows/website-preview.yml
@@ -1,4 +1,4 @@
-name: Website Preview
+name: Website Build
 
 on:
   pull_request:
@@ -7,24 +7,22 @@ on:
       - "website/**"
       - "packages/shared/**"
       - "packages/ui/**"
+      - "release-notes/**"
       - "package.json"
       - "package-lock.json"
       - "tsconfig.base.json"
-      - "scripts/vercel-deploy-preview.sh"
-      - "scripts/lib/**"
       - ".github/workflows/website-preview.yml"
 
 concurrency:
-  group: website-preview-${{ github.event.pull_request.number || github.ref }}
+  group: website-build-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
-  preview:
-    name: Build and deploy website preview
+  build:
+    name: Build website
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -36,12 +34,10 @@ jobs:
           node-version: "22"
           cache: "npm"
 
-      - name: Deploy website preview
-        env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build website
         run: |
-          if [ -z "$VERCEL_TOKEN" ]; then
-            echo "VERCEL_TOKEN not configured, skipping website preview deploy."
-            exit 0
-          fi
-          ./scripts/vercel-deploy-preview.sh website "$VERCEL_TOKEN"
+          cd website
+          npm run build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,9 +13,11 @@
 - **Async-before-await is synchronous:** Code before the first `await` in an `async` function runs synchronously in the caller's microtask even if the caller doesn't await. Never put O(n) work (e.g. `Array.from(largeUint8Array)`, `A.save()`, serialization) before an `await` in a `subscribe()` callback or any other fire-and-forget async call on a hot path.
 - **Vercel deployments -- always use `--scope aubreyfs-projects`:** The only permitted Vercel team for this project is `aubreyfs-projects` (personal account). Never run `vercel deploy`, `vercel link`, or any Vercel CLI command without the `--scope aubreyfs-projects` flag. Never use the `deploy_to_vercel` MCP tool -- it accepts no arguments and silently deploys to whatever team the CLI defaults to. Never run `vercel` from the repo root.
   - This monorepo uses local workspace packages. Raw subdirectory deploys like `vercel deploy website/` and `vercel deploy packages/pwa/` can upload an incomplete tree and fail at `npm install`.
-  - Always use the preview helper instead:
-    - Website: `./scripts/vercel-deploy-preview.sh website`
-    - PWA: `./scripts/vercel-deploy-preview.sh pwa`
+  - Website preview and production deploys should come from Vercel Git integration on the `www` branch.
+  - Keep the website helper scripts only for explicit manual fallback work.
+  - The PWA still uses the helper scripts:
+    - Preview: `./scripts/vercel-deploy-preview.sh pwa`
+    - Production: `./scripts/vercel-deploy-production.sh pwa`
 
 ## Versioning
 

--- a/docs/PHASE-1-FOUNDATION.md
+++ b/docs/PHASE-1-FOUNDATION.md
@@ -231,13 +231,7 @@ Branch routing:
 - `main` remains the production app release branch
 - `main` no longer redeploys `freed.wtf` as a side effect
 
-Manual preview deploys for this monorepo now go through `./scripts/vercel-deploy-preview.sh website` and `./scripts/vercel-deploy-preview.sh pwa`. The helper stages a temporary monorepo slice with shared workspace packages before uploading to Vercel, which avoids the broken `npm install` failures caused by raw subdirectory deploys.
-
-The website and PWA preview workflows use the helpers directly so PRs only
-build the surface they target. Native Vercel preview deploys should stay
-disabled where GitHub Actions owns preview deployment. The website Vercel
-project only allows Git-triggered deploys from `www`, and the PWA project
-disables Git-triggered deploys entirely.
+Website preview and production deploys now come from Vercel Git integration on the `www` branch. The website GitHub workflow only verifies that PRs targeting `www` still build cleanly. The PWA still uses `./scripts/vercel-deploy-preview.sh pwa` and `./scripts/vercel-deploy-production.sh pwa` because raw subdirectory deploys can upload an incomplete monorepo slice and fail during install.
 
 The preview and production deploy helpers now resolve `npm` and `npx` from the
 active Node toolchain first, so they do not accidentally pick up an older

--- a/packages/capture-save/tsconfig.json
+++ b/packages/capture-save/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
     "declaration": true,
     "outDir": "dist",
     "rootDir": "src",

--- a/website/public/atom.xml
+++ b/website/public/atom.xml
@@ -2,7 +2,7 @@
 <feed xmlns="http://www.w3.org/2005/Atom">
     <id>https://freed.wtf</id>
     <title>Freed Blog</title>
-    <updated>2026-04-18T04:24:37.816Z</updated>
+    <updated>2026-04-21T21:54:15.004Z</updated>
     <generator>https://github.com/jpmonette/feed</generator>
     <author>
         <name>The Freed Team</name>

--- a/website/public/feed.xml
+++ b/website/public/feed.xml
@@ -4,7 +4,7 @@
         <title>Freed Blog</title>
         <link>https://freed.wtf</link>
         <description>Progress reports, technical deep-dives, and philosophical rants about the attention economy. From the team building Freed.</description>
-        <lastBuildDate>Sat, 18 Apr 2026 04:24:37 GMT</lastBuildDate>
+        <lastBuildDate>Tue, 21 Apr 2026 21:54:15 GMT</lastBuildDate>
         <docs>https://validator.w3.org/feed/docs/rss2.html</docs>
         <generator>https://github.com/jpmonette/feed</generator>
         <language>en</language>

--- a/website/src/content/changelog.generated.json
+++ b/website/src/content/changelog.generated.json
@@ -1,5 +1,288 @@
 [
   {
+    "version": "26.4.2100",
+    "tagName": "v26.4.2100",
+    "channel": "production",
+    "date": "2026-04-21T20:57:19Z",
+    "deck": "Map timeline playback, cleaner identity migration, and smoother install and update flows",
+    "features": [
+      {
+        "text": "Filter maps with a shared timeline scrubber"
+      },
+      {
+        "text": "Replay historical posts and future plans from one map timeline"
+      },
+      {
+        "text": "Manage friends and map identities through the new person and account graph"
+      }
+    ],
+    "fixes": [
+      {
+        "text": "Migrates older friend data into the new person and account graph during startup so existing identities keep loading cleanly after the update"
+      },
+      {
+        "text": "Dedupes Facebook and Instagram cross-posts"
+      },
+      {
+        "text": "Keeps the install prompt and update channel labeling clearer across the app"
+      },
+      {
+        "text": "Tightens reader, feed, header, sync, and release reliability"
+      }
+    ],
+    "followUps": [
+      {
+        "text": "Adds a tri-state source sidebar for faster filtering"
+      },
+      {
+        "text": "Brings the Friends lens into the feed toolbar"
+      },
+      {
+        "text": "Polishes settings jumps and hardens helper workflow stability"
+      }
+    ],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.2100",
+    "prNumbers": [
+      227,
+      274
+    ],
+    "builds": [
+      "26.4.1700-dev",
+      "26.4.1800-dev",
+      "26.4.1802-dev",
+      "26.4.1900-dev",
+      "26.4.1901-dev",
+      "26.4.2001-dev",
+      "26.4.2002-dev",
+      "26.4.2100"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.4.1700-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1700-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.4.1800-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1800-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.4.1802-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1802-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.4.1900-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1900-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.4.1901-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1901-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.4.2001-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.2001-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.4.2002-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.2002-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.4.2100",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.2100",
+        "channel": "production"
+      }
+    ]
+  },
+  {
+    "version": "26.4.2002-dev",
+    "tagName": "v26.4.2002-dev",
+    "channel": "dev",
+    "date": "2026-04-21T04:39:59Z",
+    "deck": "This dev build improves install flow and tightens startup, capture, and release stability.",
+    "features": [
+      {
+        "text": "PWA install prompt flow"
+      }
+    ],
+    "fixes": [
+      {
+        "text": "Stop the desktop dev launch crash and clean up the recovery dialog"
+      },
+      {
+        "text": "Dedupe Facebook and Instagram cross-posts"
+      },
+      {
+        "text": "Reset preview banners to bottom center on load"
+      },
+      {
+        "text": "Harden build fanout and swarm worktree setup"
+      },
+      {
+        "text": "Keep installed version stable across release channels"
+      },
+      {
+        "text": "Polish mobile settings navigation"
+      },
+      {
+        "text": "Refine live theme preview interactions"
+      }
+    ],
+    "followUps": [
+      {
+        "text": "Refine settings section jump alignment, harden worktree helper flow, and harden helper session workflow"
+      }
+    ],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.2002-dev",
+    "prNumbers": [],
+    "builds": [
+      "26.4.2001-dev",
+      "26.4.2002-dev"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.4.2001-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.2001-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.4.2002-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.2002-dev",
+        "channel": "dev"
+      }
+    ]
+  },
+  {
+    "version": "26.4.1901-dev",
+    "tagName": "v26.4.1901-dev",
+    "channel": "dev",
+    "date": "2026-04-20T03:41:16Z",
+    "deck": "Expand friends and map identity workflows, tri-state source sidebar, and Friends lens to feed toolbar",
+    "features": [
+      {
+        "text": "Expand friends and map identity workflows"
+      },
+      {
+        "text": "Tri-state source sidebar"
+      },
+      {
+        "text": "Friends lens to feed toolbar"
+      }
+    ],
+    "fixes": [
+      {
+        "text": "Redeploy dev pwa on dev merges"
+      },
+      {
+        "text": "Dismiss sticky tooltips after pointer activation"
+      },
+      {
+        "text": "Show -dev suffix for dev build versions"
+      },
+      {
+        "text": "Desktop toolbar dragging and back target restored"
+      },
+      {
+        "text": "Fall back to newer production updates on dev"
+      },
+      {
+        "text": "Add native startup recovery window"
+      },
+      {
+        "text": "Lets dev installs take a newer production update when no newer dev build exists, without switching release channels"
+      },
+      {
+        "text": "Shows the -dev suffix consistently in desktop update surfaces and settings"
+      }
+    ],
+    "followUps": [
+      {
+        "text": "Map timeline scrubber"
+      }
+    ],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1901-dev",
+    "prNumbers": [],
+    "builds": [
+      "26.4.1900-dev",
+      "26.4.1901-dev"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.4.1900-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1900-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.4.1901-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1901-dev",
+        "channel": "dev"
+      }
+    ]
+  },
+  {
+    "version": "26.4.1802-dev",
+    "tagName": "v26.4.1802-dev",
+    "channel": "dev",
+    "date": "2026-04-18T20:09:06Z",
+    "deck": "Time-aware map filtering and migrate legacy identity graph on startup",
+    "features": [
+      {
+        "text": "Time-aware map filtering"
+      }
+    ],
+    "fixes": [
+      {
+        "text": "Migrates older friend data into the person and account graph during startup so existing identities keep loading cleanly after the update."
+      }
+    ],
+    "followUps": [],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1802-dev",
+    "prNumbers": [],
+    "builds": [
+      "26.4.1800-dev",
+      "26.4.1802-dev"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.4.1800-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1800-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.4.1802-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1802-dev",
+        "channel": "dev"
+      }
+    ]
+  },
+  {
+    "version": "26.4.1700-dev",
+    "tagName": "v26.4.1700-dev",
+    "channel": "dev",
+    "date": "2026-04-18T04:42:45Z",
+    "deck": "Refactor friends into a person account identity graph",
+    "features": [],
+    "fixes": [],
+    "followUps": [],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1700-dev",
+    "prNumbers": [],
+    "builds": [
+      "26.4.1700-dev"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.4.1700-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1700-dev",
+        "channel": "dev"
+      }
+    ]
+  },
+  {
     "version": "26.4.1602",
     "tagName": "v26.4.1602",
     "channel": "production",


### PR DESCRIPTION
(AI Generated).

## Summary
- remove the release workflow step that tried to deploy the website directly
- replace it with a verification step that ensures the reviewed release artifact exists on `www`
- convert the website PR workflow into a build-only check and regenerate the checked-in changelog and feeds

## Verification
- `PATH="/Users/aubreyfalconer/dev/freed-main-git-deploy/node_modules/.bin:$PATH" npm run build` from `website/`
- confirmed the release workflow now uses `verify-website-release-branch`
