### PR TITLE
fix: warm PWA article images for offline reading

### DIFF
--- a/docs/PHASE-6-PWA.md
+++ b/docs/PHASE-6-PWA.md
@@ -1,6 +1,6 @@
 # Phase 6: PWA Reader
 
-> **Status:** ✅ Core Complete (first-run legal gate shipped, public-safe bug reporting shipped, homescreen install flow shipped, offline access verification pending)
+> **Status:** ✅ Complete (first-run legal gate shipped, public-safe bug reporting shipped, homescreen install flow shipped, offline article and image caching shipped)
 > **Dependencies:** Phase 4 (Sync Layer), Phase 5 (Desktop App)
 
 ---
@@ -253,7 +253,7 @@ Build chain: `@freed/shared` → `@freed/sync` → `vite build` (configured in `
 - [x] The shared floating mobile sidebar now behaves like a real toggle, so the same hamburger button opens and closes it cleanly
 - [x] Private diagnostics stay opt-in and are clearly separated from public GitHub sharing
 - [x] PWA installable on mobile (add to homescreen) — manifest ids and scope set, browser install notice shipped, iOS Safari homescreen guidance shipped, Playwright coverage added
-- [ ] Offline access works (service worker + image cache) — SW registered, image cache pending
+- [x] Offline access works (service worker + image cache) — article HTML and cacheable reader images are warmed locally for offline reading
 
 ---
 
@@ -285,4 +285,4 @@ Build chain: `@freed/shared` → `@freed/sync` → `vite build` (configured in `
 
 ## Deliverable
 
-Mobile-friendly PWA at [app.freed.wtf](https://app.freed.wtf), plus the dev channel at `dev-app.freed.wtf`, with offline support.
+Mobile-friendly PWA at [app.freed.wtf](https://app.freed.wtf), plus the dev channel at `dev-app.freed.wtf`, with offline article and image support.

--- a/packages/pwa/src/lib/article-cache.test.ts
+++ b/packages/pwa/src/lib/article-cache.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  cacheArticleHtml,
+  collectCacheableArticleImageUrls,
+  warmArticleImageCache,
+} from "@freed/ui/lib/article-cache";
+
+describe("article cache helpers", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("collects cacheable article image URLs from img and picture markup", () => {
+    const html = `
+      <article>
+        <img src="/hero.jpg" data-src="https://cdn.example.com/lazy.jpg" />
+        <img srcset="/small.jpg 1x, /large.jpg 2x" />
+        <picture>
+          <source srcset="https://img.example.com/one.webp 1x, https://img.example.com/two.webp 2x" />
+          <img src="data:image/png;base64,abc" />
+        </picture>
+      </article>
+    `;
+
+    expect(collectCacheableArticleImageUrls(html, "https://example.com/posts/1")).toEqual([
+      "https://example.com/hero.jpg",
+      "https://cdn.example.com/lazy.jpg",
+      "https://example.com/small.jpg",
+      "https://example.com/large.jpg",
+      "https://img.example.com/one.webp",
+      "https://img.example.com/two.webp",
+    ]);
+  });
+
+  it("stores article HTML under both the source URL and content cache key", async () => {
+    const put = vi.fn(async () => undefined);
+    const open = vi.fn(async () => ({ put }));
+
+    vi.stubGlobal("caches", { open });
+
+    await cacheArticleHtml("https://example.com/article", "saved:abc123", "<article>Hello</article>");
+
+    expect(open).toHaveBeenCalledWith("freed-articles-v1");
+    expect(put).toHaveBeenNthCalledWith(
+      1,
+      "https://example.com/article",
+      expect.any(Response),
+    );
+    expect(put).toHaveBeenNthCalledWith(
+      2,
+      "/content/saved:abc123",
+      expect.any(Response),
+    );
+  });
+
+  it("warms only uncached article images", async () => {
+    const put = vi.fn(async () => undefined);
+    const match = vi.fn(async (url: string) => (
+      url === "https://example.com/already-cached.jpg"
+        ? new Response("cached")
+        : undefined
+    ));
+    const open = vi.fn(async () => ({ match, put }));
+    const fetchMock = vi.fn(async () => new Response("image-bytes"));
+
+    vi.stubGlobal("caches", { open });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await warmArticleImageCache(
+      `
+        <article>
+          <img src="/already-cached.jpg" />
+          <img src="/needs-cache.jpg" />
+        </article>
+      `,
+      "https://example.com/post",
+    );
+
+    expect(open).toHaveBeenCalledWith("freed-images");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(match).toHaveBeenCalledWith("https://example.com/already-cached.jpg");
+    expect(match).toHaveBeenCalledWith("https://example.com/needs-cache.jpg");
+    expect(put).toHaveBeenCalledWith(
+      "https://example.com/needs-cache.jpg",
+      expect.any(Response),
+    );
+  });
+});

--- a/packages/pwa/src/lib/save-url.test.ts
+++ b/packages/pwa/src/lib/save-url.test.ts
@@ -6,6 +6,8 @@ const mockToastInfo = vi.fn();
 const mockBuildSavedFeedItem = vi.fn();
 const mockExtractMetadataBrowser = vi.fn();
 const mockExtractContentBrowser = vi.fn();
+const mockCacheArticleHtml = vi.fn(async () => undefined);
+const mockWarmArticleImageCache = vi.fn(async () => undefined);
 
 vi.mock("./automerge", () => ({
   docAddFeedItem: mockDocAddFeedItem,
@@ -27,16 +29,14 @@ vi.mock("@freed/capture-save/normalize", () => ({
   buildSavedFeedItem: mockBuildSavedFeedItem,
 }));
 
-describe("saveUrlInPwa", () => {
-  const cachePut = vi.fn(async () => undefined);
-  const cacheOpen = vi.fn(async () => ({ put: cachePut }));
+vi.mock("@freed/ui/lib/article-cache", () => ({
+  cacheArticleHtml: mockCacheArticleHtml,
+  warmArticleImageCache: mockWarmArticleImageCache,
+}));
 
+describe("saveUrlInPwa", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    Object.defineProperty(globalThis, "caches", {
-      value: { open: cacheOpen },
-      configurable: true,
-    });
 
     mockExtractMetadataBrowser.mockReturnValue({
       url: "https://example.com/article",
@@ -105,17 +105,14 @@ describe("saveUrlInPwa", () => {
       }),
     );
     expect(mockDocAddStubItem).not.toHaveBeenCalled();
-    expect(cacheOpen).toHaveBeenCalledWith("freed-articles-v1");
-    expect(cachePut).toHaveBeenCalledTimes(2);
-    expect(cachePut).toHaveBeenNthCalledWith(
-      1,
+    expect(mockCacheArticleHtml).toHaveBeenCalledWith(
       "https://example.com/article",
-      expect.any(Response),
+      "saved:abc123",
+      "<article><p>Readable body</p></article>",
     );
-    expect(cachePut).toHaveBeenNthCalledWith(
-      2,
-      "/content/saved:abc123",
-      expect.any(Response),
+    expect(mockWarmArticleImageCache).toHaveBeenCalledWith(
+      "<article><p>Readable body</p></article>",
+      "https://example.com/article",
     );
   });
 

--- a/packages/pwa/src/lib/save-url.ts
+++ b/packages/pwa/src/lib/save-url.ts
@@ -3,6 +3,7 @@ import {
   extractMetadataBrowser,
 } from "@freed/capture-save/browser";
 import { buildSavedFeedItem } from "@freed/capture-save/normalize";
+import { cacheArticleHtml, warmArticleImageCache } from "@freed/ui/lib/article-cache";
 import { toast } from "@freed/ui/components/Toast";
 import { docAddFeedItem, docAddStubItem } from "./automerge";
 
@@ -10,18 +11,6 @@ const FETCH_ENDPOINT = "/api/fetch-url";
 
 export interface SaveUrlOptions {
   tags?: string[];
-}
-
-async function cacheArticleHtml(url: string, globalId: string, html: string): Promise<void> {
-  if (!("caches" in window)) return;
-
-  const cache = await caches.open("freed-articles-v1");
-  await cache.put(url, new Response(html, {
-    headers: { "Content-Type": "text/html; charset=utf-8" },
-  }));
-  await cache.put(`/content/${globalId}`, new Response(html, {
-    headers: { "Content-Type": "text/html; charset=utf-8" },
-  }));
 }
 
 async function fetchArticleHtml(url: string): Promise<string> {
@@ -65,6 +54,7 @@ export async function saveUrlInPwa(
     });
 
     await cacheArticleHtml(stableUrl, item.globalId, content.html);
+    void warmArticleImageCache(content.html, stableUrl);
     await docAddFeedItem(item);
     return;
   } catch {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -32,6 +32,7 @@
     "./lib/debug-store": "./src/lib/debug-store.ts",
     "./lib/bug-report": "./src/lib/bug-report.ts",
     "./lib/build-info": "./src/lib/build-info.ts",
+    "./lib/article-cache": "./src/lib/article-cache.ts",
     "./lib/map-navigation": "./src/lib/map-navigation.ts",
     "./lib/provider-status": "./src/lib/provider-status.ts",
     "./lib/release-channel": "./src/lib/release-channel.ts",

--- a/packages/ui/src/components/feed/ReaderView.tsx
+++ b/packages/ui/src/components/feed/ReaderView.tsx
@@ -3,6 +3,7 @@ import { formatDistanceToNow } from "date-fns";
 import type { FeedItem as FeedItemType } from "@freed/shared";
 import { useAppStore, usePlatform, MACOS_TRAFFIC_LIGHT_INSET } from "../../context/PlatformContext.js";
 import { applyFocusMode, type FocusOptions } from "@freed/shared";
+import { cacheArticleHtml, warmArticleImageCache } from "../../lib/article-cache.js";
 import { Tooltip } from "../Tooltip.js";
 import { ExternalLinkIcon, TrashIcon } from "../icons.js";
 
@@ -757,18 +758,11 @@ async function liveFetch(
     const html = await resp.text();
     if (cancelled) return;
 
-    if ("caches" in window) {
-      try {
-        const cache = await caches.open("freed-articles-v1");
-        await cache.put(url, new Response(html, {
-          headers: { "Content-Type": "text/html; charset=utf-8" },
-        }));
-        await cache.put(`/content/${globalId}`, new Response(html, {
-          headers: { "Content-Type": "text/html; charset=utf-8" },
-        }));
-      } catch {
-        // Cache write failure is non-fatal
-      }
+    try {
+      await cacheArticleHtml(url, globalId, html);
+      void warmArticleImageCache(html, url);
+    } catch {
+      // Cache write failure is non-fatal
     }
 
     onDone(html);

--- a/packages/ui/src/lib/article-cache.ts
+++ b/packages/ui/src/lib/article-cache.ts
@@ -1,0 +1,101 @@
+const ARTICLE_CONTENT_CACHE_NAME = "freed-articles-v1";
+const ARTICLE_IMAGE_CACHE_NAME = "freed-images";
+const CACHEABLE_PROTOCOLS = new Set(["http:", "https:"]);
+const IMAGE_ATTRIBUTE_NAMES = [
+  "src",
+  "data-src",
+  "data-lazy-src",
+  "data-original",
+  "data-actualsrc",
+];
+const IMAGE_SRCSET_ATTRIBUTE_NAMES = [
+  "srcset",
+  "data-srcset",
+  "data-lazy-srcset",
+];
+
+function resolveCacheableUrl(raw: string | null, baseUrl: string): string | null {
+  const trimmed = raw?.trim();
+  if (!trimmed) return null;
+
+  try {
+    const resolved = new URL(trimmed, baseUrl);
+    return CACHEABLE_PROTOCOLS.has(resolved.protocol) ? resolved.toString() : null;
+  } catch {
+    return null;
+  }
+}
+
+function extractSrcsetUrls(raw: string | null, baseUrl: string): string[] {
+  const srcset = raw?.trim();
+  if (!srcset) return [];
+
+  return srcset
+    .split(",")
+    .map((candidate) => resolveCacheableUrl(candidate.trim().split(/\s+/, 1)[0] ?? null, baseUrl))
+    .filter((url): url is string => !!url);
+}
+
+export function collectCacheableArticleImageUrls(html: string, baseUrl: string): string[] {
+  if (!html.trim() || typeof DOMParser === "undefined") return [];
+
+  const doc = new DOMParser().parseFromString(html, "text/html");
+  const urls = new Set<string>();
+
+  for (const image of doc.querySelectorAll("img")) {
+    for (const attributeName of IMAGE_ATTRIBUTE_NAMES) {
+      const resolved = resolveCacheableUrl(image.getAttribute(attributeName), baseUrl);
+      if (resolved) urls.add(resolved);
+    }
+    for (const attributeName of IMAGE_SRCSET_ATTRIBUTE_NAMES) {
+      for (const resolved of extractSrcsetUrls(image.getAttribute(attributeName), baseUrl)) {
+        urls.add(resolved);
+      }
+    }
+  }
+
+  for (const source of doc.querySelectorAll("picture source")) {
+    for (const attributeName of IMAGE_SRCSET_ATTRIBUTE_NAMES) {
+      for (const resolved of extractSrcsetUrls(source.getAttribute(attributeName), baseUrl)) {
+        urls.add(resolved);
+      }
+    }
+  }
+
+  return [...urls];
+}
+
+export async function cacheArticleHtml(articleUrl: string, globalId: string, html: string): Promise<void> {
+  if (!("caches" in window)) return;
+
+  const cache = await caches.open(ARTICLE_CONTENT_CACHE_NAME);
+  const response = new Response(html, {
+    headers: { "Content-Type": "text/html; charset=utf-8" },
+  });
+
+  await cache.put(articleUrl, response.clone());
+  await cache.put(`/content/${globalId}`, response);
+}
+
+export async function warmArticleImageCache(html: string, baseUrl: string): Promise<void> {
+  if (!("caches" in window)) return;
+
+  await Promise.resolve();
+
+  const imageUrls = collectCacheableArticleImageUrls(html, baseUrl);
+  if (imageUrls.length === 0) return;
+
+  const cache = await caches.open(ARTICLE_IMAGE_CACHE_NAME);
+
+  await Promise.allSettled(
+    imageUrls.map(async (imageUrl) => {
+      const existing = await cache.match(imageUrl);
+      if (existing) return;
+
+      const response = await fetch(new Request(imageUrl, { mode: "no-cors" }));
+      if (!response.ok && response.type !== "opaque") return;
+      await cache.put(imageUrl, response);
+    }),
+  );
+}
+

--- a/website/src/app/roadmap/RoadmapContent.tsx
+++ b/website/src/app/roadmap/RoadmapContent.tsx
@@ -747,7 +747,7 @@ const phases: Phase[] = [
     number: 6,
     title: "PWA Reader",
     description:
-      "Primary mobile surface with first-run legal gating, URL-backed view state, homescreen install prompts for browser and iOS Safari flows, public-safe bug reporting, and switchable production or dev update channels across `app.freed.wtf` and the `dev` branch lane at `dev-app.freed.wtf`.",
+      "Primary mobile surface with first-run legal gating, URL-backed view state, warmed offline article plus image caching, homescreen install prompts for browser and iOS Safari flows, public-safe bug reporting, and switchable production or dev update channels across `app.freed.wtf` and the `dev` branch lane at `dev-app.freed.wtf`.",
     status: "complete",
     planLink:
       "https://github.com/freed-project/freed/blob/dev/docs/PHASE-6-PWA.md",


### PR DESCRIPTION
(AI Generated).

## What changed
- added a shared browser cache helper for article HTML and cacheable article image URLs
- warmed reader images during both the PWA save flow and the shared reader live-fetch path
- added focused PWA cache helper coverage and updated save-url tests
- updated Phase 6 roadmap docs to mark offline article and image caching complete

## Why
Offline reading already cached article HTML, but image assets were only available if the browser had fetched them opportunistically before going offline. This left saved and reader content looking broken once the network disappeared.

## Impact
PWA saved articles and live-fetched reader content now warm cacheable image assets while online, so offline reading is much more complete instead of degrading into missing media.

## Validation
- `npm run validate:feature`
- `npm run test:unit -- src/lib/article-cache.test.ts src/lib/save-url.test.ts`
- `npm run typecheck` in `packages/pwa`
