### PR TITLE
feat: add global command palette

### DIFF
--- a/docs/PHASE-10-POLISH.md
+++ b/docs/PHASE-10-POLISH.md
@@ -108,17 +108,17 @@ export async function exportToCsv(items: FeedItem[]): Promise<string> {
 
 ### Command Bar / Action Launcher
 
-The global search bar is the foundation of a keyboard-driven command launcher. It already searches feed content and surfaces settings sections as quick-jump actions (arrow keys to navigate, Enter to select). The long-term goal is for every action in the app to be reachable from this bar without touching the mouse.
+Freed now has a real global command palette, opened with `Cmd/Ctrl+K`, mounted from `AppShell`, and rendered as a centered desktop modal or a mobile `BottomSheet`. The old sidebar search field is feed search only again.
 
-Planned action categories beyond the current settings navigation:
+The command palette now covers:
 
-- **Feeds** — subscribe to a new RSS feed, unsubscribe, open a specific source
-- **Navigation** — jump to Saved, Archived, a specific tag, or a feed
-- **Content** — save current item, mark all read, archive all read
-- **Preferences** — toggle Focus Mode, engagement counts, and other settings directly
-- **Custom actions** — user-defined shortcuts via the plugin API (see Plugin/Extension API below)
+- **Navigation**: Unified Feed, Saved, Archived, Friends, Map, every top source, every RSS feed, top-level tag scopes, and every visible settings section
+- **Create flows**: Add RSS Feed, Save URL, import Freed Markdown, export Freed Markdown
+- **Current item actions**: Open original URL, close reader, save or unsave, archive or unarchive, like or unlike when supported
+- **Current scope actions**: Mark current scope read, archive current scope read items, unarchive saved items, sync RSS, sync the current provider, and check for updates when supported
+- **Danger actions**: Delete all archived items plus local or cloud-backed factory reset, guarded by typed confirmation
 
-The `CommandAction` interface in `packages/ui/src/components/layout/Header.tsx` and the `buildSettingsActions()` helper are the current extension point. New action categories are added by returning additional `CommandAction[]` arrays and merging them into `allCommandActions`.
+The shared extension points now live in `packages/ui/src/lib/command-palette.ts`, `packages/ui/src/lib/command-palette-registry.ts`, and `packages/ui/src/lib/command-surface-store.ts`.
 
 ### Keyboard Shortcuts
 
@@ -385,7 +385,7 @@ Reward security researchers for responsible disclosure.
 | 10.7  | Reduced motion support             | Low        |
 | 10.8  | Color contrast audit               | Low        |
 | 10.9  | Native Liquid Glass buttons        | High       |
-| 10.24 | Command bar — full action launcher | High       |
+| 10.24 | Command bar — full action launcher | High       | ✓ Complete (Global `Cmd/Ctrl+K` palette with navigation, creation, current-item, sync, and danger actions)
 
 ### AI Features
 
@@ -434,7 +434,7 @@ Reward security researchers for responsible disclosure.
 - [ ] Keyboard navigation complete
 - [ ] Screen reader accessible
 - [ ] Reduced motion respected
-- [ ] Command bar can trigger every major app action without a mouse
+- [x] Command bar can trigger every major app action without a mouse
 
 ### AI
 

--- a/packages/pwa/src/lib/command-palette.test.ts
+++ b/packages/pwa/src/lib/command-palette.test.ts
@@ -1,0 +1,640 @@
+import { createElement, useEffect } from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { create } from "zustand";
+import type { BaseAppState, FeedItem, FilterOptions } from "@freed/shared";
+import type { PlatformConfig } from "../../../ui/src/context/PlatformContext.tsx";
+import { PlatformProvider } from "../../../ui/src/context/PlatformContext.tsx";
+import { AppShell } from "../../../ui/src/components/layout/AppShell.tsx";
+import { CommandPalette } from "../../../ui/src/components/layout/CommandPalette.tsx";
+import {
+  dedupeCommandPaletteActions,
+  filterCommandPaletteActions,
+  rankCommandPaletteAction,
+  type CommandPaletteAction,
+} from "../../../ui/src/lib/command-palette.ts";
+import { buildCommandPaletteActions } from "../../../ui/src/lib/command-palette-registry.ts";
+import { useCommandSurfaceStore } from "../../../ui/src/lib/command-surface-store.ts";
+import { useSettingsStore } from "../../../ui/src/lib/settings-store.ts";
+
+const noop = () => {};
+const noopAsync = async () => {};
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+function resetSurfaceStores() {
+  useCommandSurfaceStore.setState({
+    paletteOpen: false,
+    addFeedOpen: false,
+    savedContentOpen: false,
+    libraryDialogOpen: false,
+    libraryDialogTab: "import",
+  });
+  useSettingsStore.setState({
+    open: false,
+    targetSection: null,
+  });
+}
+
+function setViewportWidth(width: number) {
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    writable: true,
+    value: width,
+  });
+}
+
+function createItem(overrides: Partial<FeedItem> = {}): FeedItem {
+  return {
+    globalId: overrides.globalId ?? "item-1",
+    platform: overrides.platform ?? "rss",
+    sourceUrl: overrides.sourceUrl ?? "https://example.com/article",
+    author: overrides.author ?? {
+      id: "author-1",
+      displayName: "Author",
+      handle: "@author",
+    },
+    content: overrides.content ?? {
+      text: "Alpha article",
+      linkPreview: {
+        title: "Alpha article",
+        description: "Alpha description",
+        url: "https://example.com/article",
+      },
+    },
+    userState: overrides.userState ?? {
+      hidden: false,
+      saved: false,
+      archived: false,
+      readAt: undefined,
+      liked: false,
+      tags: [],
+      highlights: [],
+    },
+    topics: overrides.topics ?? [],
+    rssSource: overrides.rssSource ?? {
+      feedUrl: "https://alpha.example/feed.xml",
+      feedTitle: "Alpha Feed",
+    },
+    contentType: overrides.contentType ?? "article",
+    publishedAt: overrides.publishedAt ?? Date.now(),
+    ...overrides,
+  } as FeedItem;
+}
+
+function createTestStore(overrides: Partial<BaseAppState> = {}) {
+  return create<BaseAppState>((set) => ({
+    items: overrides.items ?? [],
+    searchCorpusVersion: overrides.searchCorpusVersion ?? 0,
+    feeds: overrides.feeds ?? {},
+    persons: overrides.persons ?? {},
+    accounts: overrides.accounts ?? {},
+    friends: overrides.friends ?? {},
+    preferences: overrides.preferences ?? ({
+      display: {
+        themeId: "midas",
+        reading: {
+          dualColumnMode: false,
+          focusMode: false,
+        },
+        archivePruneDays: 30,
+        sidebarMode: "expanded",
+        friendsMode: "all_content",
+        mapMode: "friends",
+        mapTimeMode: "current",
+      },
+    } as BaseAppState["preferences"]),
+    feedUnreadCounts: overrides.feedUnreadCounts ?? {},
+    feedTotalCounts: overrides.feedTotalCounts ?? {},
+    totalUnreadCount: overrides.totalUnreadCount ?? 0,
+    unreadCountByPlatform: overrides.unreadCountByPlatform ?? {},
+    totalItemCount: overrides.totalItemCount ?? (overrides.items?.length ?? 0),
+    itemCountByPlatform: overrides.itemCountByPlatform ?? {},
+    totalArchivableCount: overrides.totalArchivableCount ?? 0,
+    archivableCountByPlatform: overrides.archivableCountByPlatform ?? {},
+    archivableFeedCounts: overrides.archivableFeedCounts ?? {},
+    isLoading: false,
+    isSyncing: false,
+    isInitialized: true,
+    error: null,
+    activeFilter: overrides.activeFilter ?? {},
+    selectedItemId: overrides.selectedItemId ?? null,
+    selectedPersonId: null,
+    selectedAccountId: null,
+    selectedFriendId: null,
+    initialize: overrides.initialize ?? noopAsync,
+    addItems: overrides.addItems ?? noopAsync,
+    updateItem: overrides.updateItem ?? noopAsync,
+    markAsRead: overrides.markAsRead ?? noopAsync,
+    markItemsAsRead:
+      overrides.markItemsAsRead
+      ?? (async (ids: string[]) => {
+        set((state) => ({
+          items: state.items.map((item) =>
+            ids.includes(item.globalId)
+              ? {
+                  ...item,
+                  userState: {
+                    ...item.userState,
+                    readAt: item.userState.readAt ?? Date.now(),
+                  },
+                }
+              : item,
+          ),
+        }));
+      }),
+    markAllAsRead: overrides.markAllAsRead ?? noopAsync,
+    toggleSaved:
+      overrides.toggleSaved
+      ?? (async (id: string) => {
+        set((state) => ({
+          items: state.items.map((item) =>
+            item.globalId === id
+              ? { ...item, userState: { ...item.userState, saved: !item.userState.saved } }
+              : item,
+          ),
+        }));
+      }),
+    toggleArchived:
+      overrides.toggleArchived
+      ?? (async (id: string) => {
+        set((state) => ({
+          items: state.items.map((item) =>
+            item.globalId === id
+              ? { ...item, userState: { ...item.userState, archived: !item.userState.archived } }
+              : item,
+          ),
+        }));
+      }),
+    archiveAllReadUnsaved: overrides.archiveAllReadUnsaved ?? noopAsync,
+    unarchiveSavedItems:
+      overrides.unarchiveSavedItems
+      ?? (async () => {
+        set((state) => ({
+          items: state.items.map((item) =>
+            item.userState.saved
+              ? { ...item, userState: { ...item.userState, archived: false } }
+              : item,
+          ),
+        }));
+      }),
+    deleteAllArchived:
+      overrides.deleteAllArchived
+      ?? (async () => {
+        set((state) => ({
+          items: state.items.filter((item) => !item.userState.archived || item.userState.saved),
+        }));
+      }),
+    removeItem: overrides.removeItem ?? noopAsync,
+    toggleLiked:
+      overrides.toggleLiked
+      ?? (async (id: string) => {
+        set((state) => ({
+          items: state.items.map((item) =>
+            item.globalId === id
+              ? { ...item, userState: { ...item.userState, liked: !item.userState.liked } }
+              : item,
+          ),
+        }));
+      }),
+    addFeed: overrides.addFeed ?? noopAsync,
+    removeFeed: overrides.removeFeed ?? noopAsync,
+    renameFeed: overrides.renameFeed ?? noopAsync,
+    removeAllFeeds: overrides.removeAllFeeds ?? noopAsync,
+    addPerson: overrides.addPerson ?? noopAsync,
+    addPersons: overrides.addPersons ?? noopAsync,
+    updatePerson: overrides.updatePerson ?? noopAsync,
+    removePerson: overrides.removePerson ?? noopAsync,
+    addFriend: overrides.addFriend ?? noopAsync,
+    addFriends: overrides.addFriends ?? noopAsync,
+    updateFriend: overrides.updateFriend ?? noopAsync,
+    removeFriend: overrides.removeFriend ?? noopAsync,
+    logReachOut: overrides.logReachOut ?? noopAsync,
+    addAccount: overrides.addAccount ?? noopAsync,
+    addAccounts: overrides.addAccounts ?? noopAsync,
+    updateAccount: overrides.updateAccount ?? noopAsync,
+    removeAccount: overrides.removeAccount ?? noopAsync,
+    updatePreferences: overrides.updatePreferences ?? noopAsync,
+    setFilter: overrides.setFilter ?? ((filter: FilterOptions) => set({ activeFilter: filter })),
+    setSelectedItem: overrides.setSelectedItem ?? ((id: string | null) => set({ selectedItemId: id })),
+    setSelectedPerson: overrides.setSelectedPerson ?? noop,
+    setSelectedAccount: overrides.setSelectedAccount ?? noop,
+    setSelectedFriend: overrides.setSelectedFriend ?? noop,
+    setLoading: overrides.setLoading ?? noop,
+    setSyncing: overrides.setSyncing ?? noop,
+    setError: overrides.setError ?? noop,
+    searchQuery: overrides.searchQuery ?? "",
+    setSearchQuery: overrides.setSearchQuery ?? ((query: string) => set({ searchQuery: query })),
+    activeView: overrides.activeView ?? "feed",
+    setActiveView: overrides.setActiveView ?? ((view: "feed" | "friends" | "map") => set({ activeView: view })),
+    pendingMatchCount: 0,
+    setPendingMatchCount: noop,
+  }));
+}
+
+function createPlatform(store: PlatformConfig["store"], overrides: Partial<PlatformConfig> = {}): PlatformConfig {
+  return {
+    store,
+    SourceIndicator: null,
+    HeaderSyncIndicator: null,
+    SettingsExtraSections: null,
+    LegalSettingsContent: null,
+    FeedEmptyState: null,
+    XSettingsContent: null,
+    FacebookSettingsContent: null,
+    InstagramSettingsContent: null,
+    LinkedInSettingsContent: null,
+    GoogleContactsSettingsContent: null,
+    ...overrides,
+  };
+}
+
+function ShortcutProbe({ onShortcut }: { onShortcut: () => void }) {
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      if (event.key === "j") {
+        onShortcut();
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [onShortcut]);
+
+  return null;
+}
+
+function click(element: Element) {
+  act(() => {
+    (element as HTMLElement).dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+}
+
+function changeInput(element: HTMLInputElement, value: string) {
+  act(() => {
+    const setter = Object.getOwnPropertyDescriptor(
+      HTMLInputElement.prototype,
+      "value",
+    )?.set;
+    setter?.call(element, value);
+    element.dispatchEvent(new Event("input", { bubbles: true }));
+    element.dispatchEvent(new Event("change", { bubbles: true }));
+  });
+}
+
+function keydown(target: EventTarget, key: string, options: KeyboardEventInit = {}) {
+  act(() => {
+    target.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true, ...options }));
+  });
+}
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+function renderNode(node: ReturnType<typeof createElement>) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(node);
+  });
+
+  return {
+    root,
+    container,
+    cleanup() {
+      act(() => {
+        root.unmount();
+      });
+      container.remove();
+    },
+  };
+}
+
+describe("command palette", () => {
+  const cleanups: Array<() => void> = [];
+
+  beforeEach(() => {
+    resetSurfaceStores();
+    document.body.innerHTML = "";
+    setViewportWidth(1280);
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      writable: true,
+      value: (query: string) => ({
+        matches: query.includes("max-width") ? window.innerWidth <= 767 : false,
+        media: query,
+        onchange: null,
+        addListener: noop,
+        removeListener: noop,
+        addEventListener: noop,
+        removeEventListener: noop,
+        dispatchEvent: () => false,
+      }),
+    });
+  });
+
+  afterEach(() => {
+    while (cleanups.length > 0) {
+      cleanups.pop()?.();
+    }
+    vi.restoreAllMocks();
+    resetSurfaceStores();
+    document.body.innerHTML = "";
+  });
+
+  it("ranks and dedupes actions, keeping feed search fallback last", () => {
+    const actions: CommandPaletteAction[] = [
+      { id: "alpha", title: "Alpha", section: "Go to", keywords: ["first"], run: noop },
+      { id: "alpha", title: "Alpha duplicate", section: "Go to", keywords: ["dup"], run: noop },
+      { id: "beta", title: "Beta", section: "Go to", keywords: ["alpha"], run: noop },
+      {
+        id: "search-feed",
+        title: 'Search feed for "alpha"',
+        section: "Search",
+        keywords: ["alpha"],
+        run: noop,
+        fallback: true,
+      },
+    ];
+
+    expect(dedupeCommandPaletteActions(actions).map((action) => action.id)).toEqual([
+      "alpha",
+      "beta",
+      "search-feed",
+    ]);
+    expect(rankCommandPaletteAction(actions[0], "alpha")).toBeGreaterThan(
+      rankCommandPaletteAction(actions[1], "alpha"),
+    );
+    expect(filterCommandPaletteActions(actions, "alpha").map((action) => action.id)).toEqual([
+      "alpha",
+      "beta",
+      "search-feed",
+    ]);
+  });
+
+  it("builds contextual actions only when the relevant inputs exist", () => {
+    const deleteArchived = vi.fn(async () => {});
+    const openImport = vi.fn();
+
+    const actions = buildCommandPaletteActions({
+      query: "privacy",
+      activeView: "friends",
+      activeFilter: {},
+      settingsSections: [{ id: "appearance", label: "Appearance", keywords: ["theme"] }],
+      topSources: [{ id: "rss", label: "Feeds" }],
+      feeds: [{ url: "https://alpha.example/feed.xml", title: "Alpha Feed" }],
+      tagFilters: [{ label: "Research", tags: ["Research", "Research/AI"] }],
+      currentSourceId: null,
+      selectedItem: null,
+      unreadScopeCount: 0,
+      archivableScopeCount: 0,
+      savedArchivedCount: 0,
+      archivedCount: 2,
+      openSettingsTo: noop,
+      navigateToFeed: noop,
+      navigateToFriends: noop,
+      navigateToMap: noop,
+      applyFeedSearch: noop,
+      openAddFeedDialog: null,
+      openSavedContentDialog: null,
+      openImportLibraryDialog: openImport,
+      openExportLibraryDialog: null,
+      deleteAllArchived: deleteArchived,
+      activeCloudProviderLabel: () => "Dropbox",
+    });
+
+    expect(actions.some((action) => action.id === "create-import-markdown")).toBe(true);
+    expect(actions.some((action) => action.id === "create-add-rss")).toBe(false);
+    expect(actions.some((action) => action.id === "item-open-original")).toBe(false);
+    expect(actions.find((action) => action.id === "danger-delete-archived")?.confirm?.token).toBe("DELETE");
+    expect(actions.at(-1)?.id).toBe("search-feed");
+  });
+
+  it("opens from AppShell with Cmd/Ctrl+K, closes on Escape, and blocks underlying shortcuts while open", async () => {
+    const shortcutSpy = vi.fn();
+    const store = createTestStore();
+    const platform = createPlatform(store);
+    const render = renderNode(
+      createElement(
+        PlatformProvider,
+        {
+          value: platform,
+          children: createElement(
+            AppShell,
+            null,
+            createElement(ShortcutProbe, { onShortcut: shortcutSpy }),
+          ),
+        },
+      ),
+    );
+    cleanups.push(render.cleanup);
+
+    keydown(window, "k", { metaKey: true });
+    await flush();
+
+    const paletteInput = document.querySelector<HTMLInputElement>('input[aria-label="Command palette"]');
+    expect(paletteInput).not.toBeNull();
+    expect(document.querySelector("[data-testid='command-palette-modal']")).not.toBeNull();
+
+    keydown(paletteInput!, "j");
+    expect(shortcutSpy).not.toHaveBeenCalled();
+
+    keydown(paletteInput!, "Escape");
+    await flush();
+    expect(document.querySelector("[data-testid='command-palette-modal']")).toBeNull();
+  });
+
+  it("renders as a bottom sheet on mobile", async () => {
+    setViewportWidth(390);
+    act(() => {
+      useCommandSurfaceStore.setState({ paletteOpen: true });
+    });
+
+    const store = createTestStore();
+    const platform = createPlatform(store);
+    const render = renderNode(
+      createElement(
+        PlatformProvider,
+        { value: platform, children: createElement(CommandPalette) },
+      ),
+    );
+    cleanups.push(render.cleanup);
+    await flush();
+
+    expect(document.querySelector("[data-testid='command-palette-modal']")).toBeNull();
+    expect(document.body.textContent).toContain("Command Palette");
+  });
+
+  it("does not mutate feed search until the explicit fallback action is selected", async () => {
+    act(() => {
+      useCommandSurfaceStore.setState({ paletteOpen: true });
+    });
+
+    const store = createTestStore({
+      activeView: "friends",
+      activeFilter: { platform: "rss", feedUrl: "https://alpha.example/feed.xml" },
+      feeds: {
+        "https://alpha.example/feed.xml": {
+          url: "https://alpha.example/feed.xml",
+          title: "Alpha Feed",
+          enabled: true,
+        } as BaseAppState["feeds"][string],
+      },
+    });
+    const platform = createPlatform(store);
+    const render = renderNode(
+      createElement(
+        PlatformProvider,
+        { value: platform, children: createElement(CommandPalette) },
+      ),
+    );
+    cleanups.push(render.cleanup);
+    await flush();
+
+    const input = document.querySelector<HTMLInputElement>('input[aria-label="Command palette"]');
+    expect(input).not.toBeNull();
+    changeInput(input!, "privacy");
+    await flush();
+
+    expect(store.getState().searchQuery).toBe("");
+
+    const searchAction = Array.from(document.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes('Search feed for "privacy"'),
+    );
+    expect(searchAction).not.toBeUndefined();
+    click(searchAction!);
+    await flush();
+
+    expect(store.getState().activeView).toBe("feed");
+    expect(store.getState().searchQuery).toBe("privacy");
+    expect(store.getState().activeFilter).toEqual({
+      platform: "rss",
+      feedUrl: "https://alpha.example/feed.xml",
+    });
+  });
+
+  it("shows destructive confirmation and refuses to run before the token matches", async () => {
+    act(() => {
+      useCommandSurfaceStore.setState({ paletteOpen: true });
+    });
+
+    const archivedItem = createItem({
+      globalId: "archived-1",
+      userState: {
+        hidden: false,
+        saved: false,
+        archived: true,
+        readAt: Date.now(),
+        liked: false,
+        tags: [],
+        highlights: [],
+      },
+    });
+    const deleteArchived = vi.fn(async () => {});
+    const store = createTestStore({
+      items: [archivedItem],
+      deleteAllArchived: deleteArchived,
+    });
+    const platform = createPlatform(store);
+    const render = renderNode(
+      createElement(
+        PlatformProvider,
+        { value: platform, children: createElement(CommandPalette) },
+      ),
+    );
+    cleanups.push(render.cleanup);
+    await flush();
+
+    const deleteAction = Array.from(document.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("Delete all archived items"),
+    );
+    expect(deleteAction).not.toBeUndefined();
+    click(deleteAction!);
+    await flush();
+
+    expect(deleteArchived).not.toHaveBeenCalled();
+    const confirmInput = document.querySelector<HTMLInputElement>("#command-palette-confirm");
+    expect(confirmInput).not.toBeNull();
+
+    changeInput(confirmInput!, "nope");
+    keydown(confirmInput!, "Enter");
+    await flush();
+    expect(deleteArchived).not.toHaveBeenCalled();
+
+    changeInput(confirmInput!, "DELETE");
+    const confirmButton = Array.from(document.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("Delete archived items"),
+    );
+    expect(confirmButton).not.toBeUndefined();
+    click(confirmButton!);
+    await flush();
+
+    expect(deleteArchived).toHaveBeenCalledTimes(1);
+  });
+
+  it("navigates to a feed destination and then applies explicit search without losing the feed scope", async () => {
+    act(() => {
+      useCommandSurfaceStore.setState({ paletteOpen: true });
+    });
+
+    const store = createTestStore({
+      activeView: "friends",
+      feeds: {
+        "https://alpha.example/feed.xml": {
+          url: "https://alpha.example/feed.xml",
+          title: "Alpha Feed",
+          enabled: true,
+        } as BaseAppState["feeds"][string],
+      },
+    });
+    const platform = createPlatform(store);
+    const render = renderNode(
+      createElement(
+        PlatformProvider,
+        { value: platform, children: createElement(CommandPalette) },
+      ),
+    );
+    cleanups.push(render.cleanup);
+    await flush();
+
+    const feedAction = Array.from(document.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("Alpha Feed"),
+    );
+    expect(feedAction).not.toBeUndefined();
+    click(feedAction!);
+    await flush();
+
+    expect(store.getState().activeView).toBe("feed");
+    expect(store.getState().activeFilter).toEqual({
+      platform: "rss",
+      feedUrl: "https://alpha.example/feed.xml",
+    });
+
+    act(() => {
+      useCommandSurfaceStore.setState({ paletteOpen: true });
+    });
+    await flush();
+
+    const input = document.querySelector<HTMLInputElement>('input[aria-label="Command palette"]');
+    expect(input).not.toBeNull();
+    changeInput(input!, "alpha");
+    await flush();
+
+    const searchAction = Array.from(document.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes('Search current feed for "alpha"'),
+    );
+    expect(searchAction).not.toBeUndefined();
+    click(searchAction!);
+    await flush();
+
+    expect(store.getState().activeFilter).toEqual({
+      platform: "rss",
+      feedUrl: "https://alpha.example/feed.xml",
+    });
+    expect(store.getState().searchQuery).toBe("alpha");
+  });
+});

--- a/packages/pwa/src/vitest.setup.ts
+++ b/packages/pwa/src/vitest.setup.ts
@@ -13,3 +13,41 @@ if (!("Worker" in globalThis)) {
     configurable: true,
   });
 }
+
+if (!("matchMedia" in window)) {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: (query: string) => {
+      const maxWidthMatch = /\(max-width:\s*(\d+)px\)/.exec(query);
+      const minWidthMatch = /\(min-width:\s*(\d+)px\)/.exec(query);
+      const matches =
+        (maxWidthMatch ? window.innerWidth <= Number(maxWidthMatch[1]) : true) &&
+        (minWidthMatch ? window.innerWidth >= Number(minWidthMatch[1]) : true);
+
+      return {
+        matches,
+        media: query,
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => false,
+      };
+    },
+  });
+}
+
+if (!("ResizeObserver" in globalThis)) {
+  class MockResizeObserver {
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {}
+  }
+
+  Object.defineProperty(globalThis, "ResizeObserver", {
+    value: MockResizeObserver,
+    writable: true,
+    configurable: true,
+  });
+}

--- a/packages/ui/src/components/LibraryDialog.tsx
+++ b/packages/ui/src/components/LibraryDialog.tsx
@@ -8,13 +8,14 @@
  * be rendered by both desktop and (future) platforms.
  */
 
-import { useState, useRef } from "react";
+import { useEffect, useState, useRef } from "react";
 import type { ImportSummary, ProgressFn } from "./LibraryDialog.types.js";
 
 export type { ImportSummary, ProgressFn };
 
 interface LibraryDialogProps {
   onClose: () => void;
+  initialTab?: Tab;
   /**
    * Platform-provided import handler.
    * When undefined the Import tab shows a "not available" message.
@@ -31,15 +32,22 @@ type Tab = "import" | "export";
 
 export function LibraryDialog({
   onClose,
+  initialTab = "import",
   importMarkdown,
   exportMarkdown,
 }: LibraryDialogProps) {
-  const [tab, setTab] = useState<Tab>("import");
+  const [tab, setTab] = useState<Tab>(initialTab);
   const [importing, setImporting] = useState(false);
   const [exporting, setExporting] = useState(false);
   const [summary, setSummary] = useState<ImportSummary | null>(null);
   const [progress, setProgress] = useState<{ current: number; total: number } | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    setTab(initialTab);
+    setSummary(null);
+    setProgress(null);
+  }, [initialTab]);
 
   const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = e.target.files;

--- a/packages/ui/src/components/SearchField.tsx
+++ b/packages/ui/src/components/SearchField.tsx
@@ -20,16 +20,19 @@ function joinClasses(...classes: Array<string | false | null | undefined>) {
   return classes.filter(Boolean).join(" ");
 }
 
-export const SearchField = forwardRef<HTMLInputElement, SearchFieldProps>(function SearchField({
-  containerClassName,
-  inputClassName,
-  clearButtonAriaLabel = "Clear search",
-  density = "default",
-  onClear,
-  type,
-  value,
-  ...inputProps
-}, ref) {
+export const SearchField = forwardRef<HTMLInputElement, SearchFieldProps>(function SearchField(
+  {
+    containerClassName,
+    inputClassName,
+    clearButtonAriaLabel = "Clear search",
+    density = "default",
+    onClear,
+    type,
+    value,
+    ...inputProps
+  },
+  ref,
+) {
   const hasValue =
     typeof value === "string" ? value.length > 0 : typeof value === "number";
 
@@ -51,8 +54,8 @@ export const SearchField = forwardRef<HTMLInputElement, SearchFieldProps>(functi
       </svg>
 
       <input
-        ref={ref}
         {...inputProps}
+        ref={ref}
         type={type ?? "text"}
         value={value}
         className={joinClasses(

--- a/packages/ui/src/components/SettingsDialog.tsx
+++ b/packages/ui/src/components/SettingsDialog.tsx
@@ -36,15 +36,7 @@ import { ProviderStatusIndicator } from "./ProviderStatusIndicator.js";
 import { toast } from "./Toast.js";
 import { UpdateProgressBar } from "./UpdateProgressBar.js";
 import {
-  BASE_SECTION_METAS,
-  UPDATES_SECTION_META,
-  DANGER_SECTION_META,
-  GOOGLE_CONTACTS_SECTION_META,
-  AI_SECTION_META,
-  X_SECTION_META,
-  FB_SECTION_META,
-  IG_SECTION_META,
-  LI_SECTION_META,
+  buildSettingsSectionMetas,
   type SectionId,
   type SectionMeta,
 } from "../lib/settings-sections.js";
@@ -281,29 +273,20 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
   const pendingThemeIdRef = useRef<ThemeId | null>(null);
   const pendingThemeSaveSeqRef = useRef(0);
   const committedThemeIdRef = useRef(preferences.display.themeId);
-  const baseSectionById = Object.fromEntries(BASE_SECTION_METAS.map((section) => [section.id, section])) as Record<
-    Exclude<SectionId, "ai" | "updates" | "danger" | "googleContacts" | "x" | "facebook" | "instagram" | "linkedin">,
-    SectionMeta
-  >;
-
   // Flat section list — drives scrollspy and right-pane rendering.
   // Keywords live in settings-sections.ts so Header's command palette can share them.
-  const allSections: Section[] = [
-    { ...baseSectionById.appearance, icon: ICONS.appearance },
-    { ...baseSectionById.sync, icon: ICONS.sync },
-    ...(GoogleContactsSettingsContent ? [{ ...GOOGLE_CONTACTS_SECTION_META, icon: ICONS.googleContacts }] : []),
-    { ...baseSectionById.saved, icon: ICONS.saved },
-    ...(XSettingsContent ? [{ ...X_SECTION_META, icon: ICONS.x }] : []),
-    ...(FacebookSettingsContent ? [{ ...FB_SECTION_META, icon: ICONS.facebook }] : []),
-    ...(InstagramSettingsContent ? [{ ...IG_SECTION_META, icon: ICONS.instagram }] : []),
-    ...(LinkedInSettingsContent ? [{ ...LI_SECTION_META, icon: ICONS.linkedin }] : []),
-    { ...baseSectionById.feeds, icon: ICONS.feeds },
-    { ...AI_SECTION_META, icon: ICONS.ai },
-    ...(checkForUpdates ? [{ ...UPDATES_SECTION_META, icon: ICONS.updates }] : []),
-    { ...baseSectionById.legal, icon: ICONS.legal },
-    { ...baseSectionById.support, icon: ICONS.support },
-    ...(factoryReset ? [{ ...DANGER_SECTION_META, icon: ICONS.danger }] : []),
-  ];
+  const allSections: Section[] = buildSettingsSectionMetas({
+    hasGoogleContacts: !!GoogleContactsSettingsContent,
+    hasX: !!XSettingsContent,
+    hasFacebook: !!FacebookSettingsContent,
+    hasInstagram: !!InstagramSettingsContent,
+    hasLinkedIn: !!LinkedInSettingsContent,
+    hasUpdateChecks: !!checkForUpdates,
+    hasFactoryReset: !!factoryReset,
+  }).map((section) => ({
+    ...section,
+    icon: ICONS[section.id],
+  }));
 
   // Hierarchical nav structure — drives left sidebar rendering only.
   // Re-use the Section objects already defined in allSections so keywords stay in sync.

--- a/packages/ui/src/components/layout/AppShell.tsx
+++ b/packages/ui/src/components/layout/AppShell.tsx
@@ -1,15 +1,21 @@
 import { useEffect, useState, useRef, useCallback, type CSSProperties, type ReactNode } from "react";
 import { Sidebar } from "./Sidebar.js";
 import { Header } from "./Header.js";
+import { CommandPalette } from "./CommandPalette.js";
 import { DebugPanel } from "../DebugPanel.js";
+import { AddFeedDialog } from "../AddFeedDialog.js";
+import { SavedContentDialog } from "../SavedContentDialog.js";
+import { LibraryDialog } from "../LibraryDialog.js";
 import { useDebugStore } from "../../lib/debug-store.js";
 import { useAppStore } from "../../context/PlatformContext.js";
+import { useCommandSurfaceStore } from "../../lib/command-surface-store.js";
 import { FriendsView } from "../friends/FriendsView.js";
 import { ContactSyncModal } from "../friends/ContactSyncModal.js";
 import { useContactSync } from "../../hooks/useContactSync.js";
 import { ContactSyncContext } from "../../context/ContactSyncContext.js";
 import { useIsMobile } from "../../hooks/useIsMobile.js";
 import { useIsMobileDevice } from "../../hooks/useIsMobileDevice.js";
+import { useSettingsStore } from "../../lib/settings-store.js";
 import {
   buildDiscoveredAccountsFromItems,
   type GoogleContact,
@@ -25,7 +31,6 @@ import { MapView } from "../map/MapView.js";
 import { BackgroundAtmosphere } from "./BackgroundAtmosphere.js";
 import {
   AUXILIARY_DRAWER_GAP_WIDTH_PX,
-  DEFAULT_PRIMARY_SIDEBAR_WIDTH_PX,
   PRIMARY_SIDEBAR_GAP_WIDTH_PX,
   px,
 } from "./layoutConstants.js";
@@ -52,6 +57,17 @@ export function AppShell({ children }: AppShellProps) {
   const isInitialized = useAppStore((s) => s.isInitialized);
   const themeId = useAppStore((s) => s.preferences.display.themeId);
   const showAtmosphere = activeView !== "friends" && activeView !== "map";
+  const settingsOpen = useSettingsStore((s) => s.open);
+  const paletteOpen = useCommandSurfaceStore((s) => s.paletteOpen);
+  const openPalette = useCommandSurfaceStore((s) => s.openPalette);
+  const closePalette = useCommandSurfaceStore((s) => s.closePalette);
+  const addFeedOpen = useCommandSurfaceStore((s) => s.addFeedOpen);
+  const closeAddFeedDialog = useCommandSurfaceStore((s) => s.closeAddFeedDialog);
+  const savedContentOpen = useCommandSurfaceStore((s) => s.savedContentOpen);
+  const closeSavedContentDialog = useCommandSurfaceStore((s) => s.closeSavedContentDialog);
+  const libraryDialogOpen = useCommandSurfaceStore((s) => s.libraryDialogOpen);
+  const libraryDialogTab = useCommandSurfaceStore((s) => s.libraryDialogTab);
+  const closeLibraryDialog = useCommandSurfaceStore((s) => s.closeLibraryDialog);
 
   // Mount the contact sync hook here (not in FriendsView) so the 15-minute
   // interval and focus listener run regardless of which view is active.
@@ -69,7 +85,16 @@ export function AppShell({ children }: AppShellProps) {
   const dragging = useRef(false);
   const pendingPersistedDebugWidth = useRef<number | null>(null);
   const pendingPersistedDesktopSidebarMode = useRef<SidebarMode | null>(null);
+  const lastNonClosedDesktopSidebarModeRef = useRef<SidebarMode>(
+    persistedDesktopSidebarMode === "closed" ? "expanded" : persistedDesktopSidebarMode,
+  );
   const discoveredAccountScanRef = useRef({ itemCount: 0, accountCount: 0 });
+  const blockingModalOpen =
+    settingsOpen ||
+    addFeedOpen ||
+    savedContentOpen ||
+    libraryDialogOpen ||
+    showContactReview;
 
   useEffect(() => {
     if (dragging.current || dragWidth !== null) return;
@@ -89,12 +114,18 @@ export function AppShell({ children }: AppShellProps) {
     }
     setDesktopSidebarMode(persistedDesktopSidebarMode);
     setDesktopSidebarDisplayMode(persistedDesktopSidebarMode);
+    if (persistedDesktopSidebarMode !== "closed") {
+      lastNonClosedDesktopSidebarModeRef.current = persistedDesktopSidebarMode;
+    }
   }, [persistedDesktopSidebarMode]);
 
   const debugWidth = dragWidth ?? committedDebugWidth;
 
   const persistDesktopSidebarMode = useCallback((nextMode: SidebarMode) => {
     setDesktopSidebarMode(nextMode);
+    if (nextMode !== "closed") {
+      lastNonClosedDesktopSidebarModeRef.current = nextMode;
+    }
     pendingPersistedDesktopSidebarMode.current = nextMode;
     void updatePreferences({ display: { sidebarMode: nextMode } } as Parameters<typeof updatePreferences>[0]).catch(() => {
       if (pendingPersistedDesktopSidebarMode.current === nextMode) {
@@ -104,24 +135,11 @@ export function AppShell({ children }: AppShellProps) {
   }, [updatePreferences]);
 
   const handleDesktopSidebarToggle = useCallback(() => {
-    if (desktopSidebarMode === "closed") {
-      pendingPersistedDesktopSidebarMode.current = "expanded";
-      setDesktopSidebarMode("expanded");
-      void updatePreferences({
-        display: {
-          sidebarMode: "expanded",
-          sidebarWidth: DEFAULT_PRIMARY_SIDEBAR_WIDTH_PX,
-        },
-      } as Parameters<typeof updatePreferences>[0]).catch(() => {
-        if (pendingPersistedDesktopSidebarMode.current === "expanded") {
-          pendingPersistedDesktopSidebarMode.current = null;
-        }
-      });
-      return;
-    }
-
-    persistDesktopSidebarMode("closed");
-  }, [desktopSidebarMode, persistDesktopSidebarMode, updatePreferences]);
+    const nextMode = desktopSidebarMode === "closed"
+      ? lastNonClosedDesktopSidebarModeRef.current
+      : "closed";
+    persistDesktopSidebarMode(nextMode);
+  }, [desktopSidebarMode, persistDesktopSidebarMode]);
 
   const handleDebugDragStart = useCallback(
     (e: React.MouseEvent) => {
@@ -181,7 +199,15 @@ export function AppShell({ children }: AppShellProps) {
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
-      if (e.key === "D" && e.shiftKey && (e.metaKey || e.ctrlKey)) {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+        e.preventDefault();
+        if (blockingModalOpen) return;
+        if (paletteOpen) {
+          closePalette();
+          return;
+        }
+        openPalette();
+      } else if (e.key === "D" && e.shiftKey && (e.metaKey || e.ctrlKey)) {
         e.preventDefault();
         toggleDebug();
       } else if (e.key === "Escape" && debugVisible) {
@@ -190,7 +216,7 @@ export function AppShell({ children }: AppShellProps) {
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, [toggleDebug, debugVisible]);
+  }, [blockingModalOpen, closePalette, debugVisible, openPalette, paletteOpen, toggleDebug]);
 
   useEffect(() => {
     if (!isMobileDevice && mobileSidebarOpen) {
@@ -281,6 +307,10 @@ export function AppShell({ children }: AppShellProps) {
           desktopSidebarMode={desktopSidebarMode}
           desktopSidebarDisplayMode={desktopSidebarDisplayMode}
           onDesktopSidebarToggle={handleDesktopSidebarToggle}
+          onOpenCommandPalette={() => {
+            if (blockingModalOpen) return;
+            openPalette();
+          }}
         />
 
         <div
@@ -334,6 +364,16 @@ export function AppShell({ children }: AppShellProps) {
             <DebugPanel variant="overlay" />
           </div>
         )}
+
+        <CommandPalette />
+        <AddFeedDialog open={addFeedOpen} onClose={closeAddFeedDialog} />
+        <SavedContentDialog open={savedContentOpen} onClose={closeSavedContentDialog} />
+        {libraryDialogOpen ? (
+          <LibraryDialog
+            onClose={closeLibraryDialog}
+            initialTab={libraryDialogTab}
+          />
+        ) : null}
 
         {showContactReview && (
           <ContactSyncModal

--- a/packages/ui/src/components/layout/CommandPalette.tsx
+++ b/packages/ui/src/components/layout/CommandPalette.tsx
@@ -1,0 +1,615 @@
+import { createPortal } from "react-dom";
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+} from "react";
+import type { FilterOptions, Platform } from "@freed/shared";
+import { TOP_SOURCE_ITEMS } from "../../lib/source-navigation.tsx";
+import { useAppStore, usePlatform } from "../../context/PlatformContext.js";
+import { useSettingsStore } from "../../lib/settings-store.js";
+import { useCommandSurfaceStore } from "../../lib/command-surface-store.js";
+import { SearchField } from "../SearchField.js";
+import { BottomSheet } from "../BottomSheet.js";
+import { useIsMobile } from "../../hooks/useIsMobile.js";
+import { useSearchResults } from "../../hooks/useSearchResults.js";
+import { buildSettingsSectionMetas } from "../../lib/settings-sections.js";
+import { buildTopLevelTagFilters, collectAllTags } from "../../lib/tag-navigation.js";
+import { applyFeedSearch, navigateToFeedView } from "../../lib/workspace-navigation.js";
+import { buildCommandPaletteActions } from "../../lib/command-palette-registry.js";
+import {
+  filterCommandPaletteActions,
+  type CommandPaletteAction,
+} from "../../lib/command-palette.js";
+
+function groupActionsBySection(actions: readonly CommandPaletteAction[]) {
+  const sections: Array<{ section: string; actions: CommandPaletteAction[] }> = [];
+  for (const action of actions) {
+    const group = sections.find((candidate) => candidate.section === action.section);
+    if (group) {
+      group.actions.push(action);
+      continue;
+    }
+    sections.push({ section: action.section, actions: [action] });
+  }
+  return sections;
+}
+
+export function CommandPalette() {
+  const isMobile = useIsMobile();
+  const paletteOpen = useCommandSurfaceStore((s) => s.paletteOpen);
+  const closePalette = useCommandSurfaceStore((s) => s.closePalette);
+  const openAddFeedDialog = useCommandSurfaceStore((s) => s.openAddFeedDialog);
+  const openSavedContentDialog = useCommandSurfaceStore((s) => s.openSavedContentDialog);
+  const openLibraryDialog = useCommandSurfaceStore((s) => s.openLibraryDialog);
+  const openSettingsTo = useSettingsStore((s) => s.openTo);
+  const settingsOpen = useSettingsStore((s) => s.open);
+  const platform = usePlatform();
+  const {
+    addRssFeed,
+    saveUrl,
+    importMarkdown,
+    exportMarkdown,
+    syncRssNow,
+    syncSourceNow,
+    checkForUpdates,
+    factoryReset,
+    activeCloudProviderLabel,
+    openUrl,
+    XSettingsContent,
+    FacebookSettingsContent,
+    InstagramSettingsContent,
+    LinkedInSettingsContent,
+    GoogleContactsSettingsContent,
+  } = platform;
+
+  const items = useAppStore((s) => s.items);
+  const feeds = useAppStore((s) => s.feeds);
+  const persons = useAppStore((s) => s.persons);
+  const accounts = useAppStore((s) => s.accounts);
+  const friends = useAppStore((s) => s.friends);
+  const activeView = useAppStore((s) => s.activeView);
+  const activeFilter = useAppStore((s) => s.activeFilter);
+  const setFilter = useAppStore((s) => s.setFilter);
+  const setActiveView = useAppStore((s) => s.setActiveView);
+  const selectedItemId = useAppStore((s) => s.selectedItemId);
+  const setSelectedItem = useAppStore((s) => s.setSelectedItem);
+  const setSelectedPerson = useAppStore((s) => s.setSelectedPerson);
+  const toggleSaved = useAppStore((s) => s.toggleSaved);
+  const toggleArchived = useAppStore((s) => s.toggleArchived);
+  const toggleLiked = useAppStore((s) => s.toggleLiked);
+  const markItemsAsRead = useAppStore((s) => s.markItemsAsRead);
+  const unarchiveSavedItems = useAppStore((s) => s.unarchiveSavedItems);
+  const deleteAllArchived = useAppStore((s) => s.deleteAllArchived);
+  const searchQuery = useAppStore((s) => s.searchQuery);
+  const setSearchQuery = useAppStore((s) => s.setSearchQuery);
+  const searchCorpusVersion = useAppStore((s) => s.searchCorpusVersion);
+  const display = useAppStore((s) => s.preferences.display);
+
+  const selectedItem = useMemo(
+    () => (selectedItemId ? items.find((item) => item.globalId === selectedItemId) ?? null : null),
+    [items, selectedItemId],
+  );
+
+  const { filteredItems } = useSearchResults(
+    items,
+    searchQuery,
+    activeFilter,
+    searchCorpusVersion,
+    display.friendsMode ?? "all_content",
+    persons,
+    accounts,
+    friends,
+  );
+
+  const unreadScopeIds = useMemo(
+    () => filteredItems.filter((item) => !item.userState.readAt).map((item) => item.globalId),
+    [filteredItems],
+  );
+  const archivableScopeItems = useMemo(
+    () =>
+      filteredItems.filter(
+        (item) => !!item.userState.readAt && !item.userState.saved && !item.userState.archived,
+      ),
+    [filteredItems],
+  );
+  const savedArchivedCount = useMemo(
+    () => items.filter((item) => item.userState.saved && item.userState.archived).length,
+    [items],
+  );
+  const archivedCount = useMemo(
+    () => items.filter((item) => item.userState.archived && !item.userState.saved).length,
+    [items],
+  );
+
+  const enabledFeeds = useMemo(
+    () =>
+      Object.values(feeds)
+        .filter((feed) => feed.enabled)
+        .sort((left, right) => left.title.localeCompare(right.title)),
+    [feeds],
+  );
+  const allTags = useMemo(() => collectAllTags(items), [items]);
+  const tagFilters = useMemo(() => buildTopLevelTagFilters(allTags), [allTags]);
+  const settingsSections = useMemo(
+    () =>
+      buildSettingsSectionMetas({
+        hasGoogleContacts: !!GoogleContactsSettingsContent,
+        hasX: !!XSettingsContent,
+        hasFacebook: !!FacebookSettingsContent,
+        hasInstagram: !!InstagramSettingsContent,
+        hasLinkedIn: !!LinkedInSettingsContent,
+        hasUpdateChecks: !!checkForUpdates,
+        hasFactoryReset: !!factoryReset,
+      }),
+    [
+      FacebookSettingsContent,
+      GoogleContactsSettingsContent,
+      InstagramSettingsContent,
+      LinkedInSettingsContent,
+      XSettingsContent,
+      checkForUpdates,
+      factoryReset,
+    ],
+  );
+
+  const currentSourceId = useMemo<Platform | null>(() => {
+    if (activeView !== "feed") return null;
+    if (activeFilter.platform) return activeFilter.platform as Platform;
+    if (activeFilter.feedUrl) return "rss";
+    return null;
+  }, [activeFilter.feedUrl, activeFilter.platform, activeView]);
+
+  const [query, setQuery] = useState("");
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const [confirmAction, setConfirmAction] = useState<CommandPaletteAction | null>(null);
+  const [confirmValue, setConfirmValue] = useState("");
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const confirmInputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    if (!paletteOpen) {
+      setQuery("");
+      setActiveIndex(-1);
+      setConfirmAction(null);
+      setConfirmValue("");
+      return;
+    }
+
+    const focusTarget = window.setTimeout(() => {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }, 0);
+    return () => window.clearTimeout(focusTarget);
+  }, [paletteOpen]);
+
+  useEffect(() => {
+    if (!confirmAction) return;
+    const focusTarget = window.setTimeout(() => {
+      confirmInputRef.current?.focus();
+      confirmInputRef.current?.select();
+    }, 0);
+    return () => window.clearTimeout(focusTarget);
+  }, [confirmAction]);
+
+  useEffect(() => {
+    if (!paletteOpen || isMobile) return undefined;
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [isMobile, paletteOpen]);
+
+  useEffect(() => {
+    if (paletteOpen && settingsOpen) {
+      closePalette();
+    }
+  }, [closePalette, paletteOpen, settingsOpen]);
+
+  const actions = useMemo(
+    () =>
+      buildCommandPaletteActions({
+        query,
+        activeView,
+        activeFilter,
+        settingsSections,
+        topSources: TOP_SOURCE_ITEMS.map((source) => ({
+          id: (source.id ?? undefined) as Platform | undefined,
+          label: source.label,
+        })),
+        feeds: enabledFeeds.map((feed) => ({
+          url: feed.url,
+          title: feed.title,
+        })),
+        tagFilters,
+        currentSourceId,
+        selectedItem,
+        unreadScopeCount: activeView === "feed" ? unreadScopeIds.length : 0,
+        archivableScopeCount: activeView === "feed" ? archivableScopeItems.length : 0,
+        savedArchivedCount,
+        archivedCount,
+        openSettingsTo,
+        navigateToFeed: (filter: FilterOptions) =>
+          navigateToFeedView(
+            {
+              setActiveView,
+              setSelectedPerson,
+              setSelectedItem,
+              setFilter,
+            },
+            filter,
+          ),
+        navigateToFriends: () => {
+          setSelectedItem(null);
+          setSelectedPerson(null);
+          setActiveView("friends");
+        },
+        navigateToMap: () => {
+          setSelectedItem(null);
+          setSelectedPerson(null);
+          setActiveView("map");
+        },
+        applyFeedSearch: (nextQuery: string) =>
+          applyFeedSearch(
+            {
+              setActiveView,
+              setSelectedPerson,
+              setSelectedItem,
+              setSearchQuery,
+            },
+            nextQuery,
+          ),
+        openAddFeedDialog: addRssFeed ? () => openAddFeedDialog() : null,
+        openSavedContentDialog: saveUrl ? () => openSavedContentDialog() : null,
+        openImportLibraryDialog: importMarkdown
+          ? () => openLibraryDialog("import")
+          : null,
+        openExportLibraryDialog: exportMarkdown
+          ? () => openLibraryDialog("export")
+          : null,
+        openCurrentItemUrl:
+          selectedItem?.sourceUrl
+            ? () => {
+                if (openUrl) {
+                  openUrl(selectedItem.sourceUrl!);
+                  return;
+                }
+                window.open(selectedItem.sourceUrl!, "_blank", "noopener,noreferrer");
+              }
+            : null,
+        closeReader:
+          selectedItem
+            ? () => setSelectedItem(null)
+            : null,
+        toggleCurrentItemSaved:
+          selectedItem
+            ? () => toggleSaved(selectedItem.globalId)
+            : null,
+        toggleCurrentItemArchived:
+          selectedItem
+            ? async () => {
+                const wasArchived = selectedItem.userState.archived;
+                await toggleArchived(selectedItem.globalId);
+                if (!wasArchived) {
+                  setSelectedItem(null);
+                }
+              }
+            : null,
+        toggleCurrentItemLiked:
+          selectedItem && toggleLiked
+            ? () => toggleLiked(selectedItem.globalId)
+            : null,
+        markScopeRead:
+          activeView === "feed" && unreadScopeIds.length > 0
+            ? () => markItemsAsRead(unreadScopeIds)
+            : null,
+        archiveScopeRead:
+          activeView === "feed" && archivableScopeItems.length > 0
+            ? async () => {
+                for (const item of archivableScopeItems) {
+                  await toggleArchived(item.globalId);
+                }
+              }
+            : null,
+        unarchiveSavedItems,
+        syncRssNow,
+        syncCurrentSource: syncSourceNow,
+        checkForUpdates,
+        deleteAllArchived,
+        factoryReset,
+        activeCloudProviderLabel,
+      }),
+    [
+      activeCloudProviderLabel,
+      activeFilter,
+      activeView,
+      addRssFeed,
+      archivableScopeItems,
+      archivedCount,
+      checkForUpdates,
+      currentSourceId,
+      deleteAllArchived,
+      enabledFeeds,
+      factoryReset,
+      markItemsAsRead,
+      openAddFeedDialog,
+      openSavedContentDialog,
+      openSettingsTo,
+      openUrl,
+      importMarkdown,
+      exportMarkdown,
+      saveUrl,
+      savedArchivedCount,
+      selectedItem,
+      setActiveView,
+      setFilter,
+      setSearchQuery,
+      setSelectedItem,
+      setSelectedPerson,
+      settingsSections,
+      syncRssNow,
+      syncSourceNow,
+      tagFilters,
+      toggleArchived,
+      toggleLiked,
+      toggleSaved,
+      unreadScopeIds,
+      unarchiveSavedItems,
+      query,
+    ],
+  );
+
+  const filteredActions = useMemo(
+    () => filterCommandPaletteActions(actions, query),
+    [actions, query],
+  );
+  const actionSections = useMemo(
+    () => groupActionsBySection(filteredActions),
+    [filteredActions],
+  );
+
+  useEffect(() => {
+    if (confirmAction) return;
+    setActiveIndex(filteredActions.length > 0 ? 0 : -1);
+  }, [confirmAction, filteredActions]);
+
+  if (!paletteOpen) {
+    return null;
+  }
+
+  const selectedAction = activeIndex >= 0 ? filteredActions[activeIndex] ?? null : null;
+
+  function handleClose() {
+    closePalette();
+  }
+
+  async function runAction(action: CommandPaletteAction) {
+    if (action.confirm) {
+      setConfirmAction(action);
+      setConfirmValue("");
+      return;
+    }
+
+    closePalette();
+    await action.run();
+  }
+
+  async function handleConfirmSubmit() {
+    if (!confirmAction?.confirm) return;
+    if (confirmValue !== confirmAction.confirm.token) return;
+    closePalette();
+    await confirmAction.run();
+  }
+
+  async function handleActionSelection(action: CommandPaletteAction) {
+    try {
+      await runAction(action);
+    } catch {
+      // Toast state is handled by the action runner.
+    }
+  }
+
+  function handleActionKeyDown(event: ReactKeyboardEvent<HTMLInputElement>) {
+    event.stopPropagation();
+
+    if (confirmAction?.confirm) {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        setConfirmAction(null);
+        setConfirmValue("");
+        return;
+      }
+      if (event.key === "Enter") {
+        event.preventDefault();
+        void handleConfirmSubmit();
+      }
+      return;
+    }
+
+    if (event.key === "Escape") {
+      event.preventDefault();
+      handleClose();
+      return;
+    }
+
+    if (filteredActions.length === 0) return;
+
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setActiveIndex((index) => {
+        const nextIndex = index < 0 ? 0 : index + 1;
+        return nextIndex % filteredActions.length;
+      });
+      return;
+    }
+
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setActiveIndex((index) => {
+        if (index <= 0) return filteredActions.length - 1;
+        return index - 1;
+      });
+      return;
+    }
+
+    if (event.key === "Enter" && selectedAction) {
+      event.preventDefault();
+      void handleActionSelection(selectedAction);
+    }
+  }
+
+  const panel = (
+    <div className="flex flex-col">
+      {confirmAction?.confirm ? (
+        <div className="space-y-4 p-1">
+          <div className="space-y-1">
+            <p className="text-base font-semibold text-[var(--theme-text-primary)]">
+              {confirmAction.confirm.title}
+            </p>
+            <p className="text-sm text-[var(--theme-text-muted)]">
+              {confirmAction.confirm.description}
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <label
+              htmlFor="command-palette-confirm"
+              className="block text-xs font-semibold uppercase tracking-[0.16em] text-[var(--theme-text-soft)]"
+            >
+              Type {confirmAction.confirm.token}
+            </label>
+            <input
+              ref={confirmInputRef}
+              id="command-palette-confirm"
+              value={confirmValue}
+              onChange={(event) => setConfirmValue(event.target.value)}
+              onKeyDown={handleActionKeyDown}
+              className="theme-input w-full rounded-xl px-3 py-2.5 text-sm outline-none"
+            />
+          </div>
+
+          <div className="flex items-center justify-end gap-2">
+            <button
+              type="button"
+              onClick={() => {
+                setConfirmAction(null);
+                setConfirmValue("");
+              }}
+              className="theme-toolbar-button-ghost rounded-lg px-3 py-2 text-sm"
+            >
+              Back
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                void handleConfirmSubmit();
+              }}
+              disabled={confirmValue !== confirmAction.confirm.token}
+              className="btn-primary rounded-lg px-3 py-2 text-sm disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {confirmAction.confirm.confirmLabel}
+            </button>
+          </div>
+        </div>
+      ) : (
+        <>
+          <SearchField
+            ref={inputRef}
+            autoFocus
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            onKeyDown={handleActionKeyDown}
+            onClear={() => setQuery("")}
+            placeholder="Type a command or search term"
+            aria-label="Command palette"
+            containerClassName="mb-3"
+          />
+
+          {actionSections.length > 0 ? (
+            <div
+              role="listbox"
+              aria-label="Command palette actions"
+              data-testid="command-palette-results"
+              className="max-h-[min(60vh,28rem)] overflow-y-auto"
+            >
+              {actionSections.map((section) => (
+                <div key={section.section} className="pb-3">
+                  <p className="px-2 pb-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-[var(--theme-text-soft)]">
+                    {section.section}
+                  </p>
+                  <div className="space-y-1">
+                    {section.actions.map((action) => {
+                      const index = filteredActions.findIndex((candidate) => candidate.id === action.id);
+                      const isActive = index === activeIndex;
+                      return (
+                        <button
+                          key={action.id}
+                          type="button"
+                          role="option"
+                          aria-selected={isActive}
+                          data-testid={`command-palette-action-${action.id}`}
+                          onMouseDown={(event) => event.preventDefault()}
+                          onMouseEnter={() => setActiveIndex(index)}
+                          onClick={() => {
+                            void handleActionSelection(action);
+                          }}
+                          className={`flex w-full items-center justify-between gap-3 rounded-xl px-3 py-2 text-left text-sm transition-colors ${
+                            isActive
+                              ? "bg-[var(--theme-bg-muted)] text-[var(--theme-text-primary)]"
+                              : "text-[var(--theme-text-secondary)] hover:bg-[var(--theme-bg-muted)] hover:text-[var(--theme-text-primary)]"
+                          }`}
+                        >
+                          <span className="min-w-0 flex-1 truncate">{action.title}</span>
+                          {action.confirm ? (
+                            <span className="shrink-0 rounded-md border border-[var(--theme-border-subtle)] px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-[0.14em] text-[var(--theme-text-soft)]">
+                              Confirm
+                            </span>
+                          ) : null}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="rounded-xl border border-[var(--theme-border-subtle)] px-4 py-5 text-center text-sm text-[var(--theme-text-muted)]">
+              No matching commands.
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+
+  if (isMobile) {
+    return (
+      <BottomSheet open={paletteOpen} onClose={handleClose} title="Command Palette" maxWidth="sm:max-w-2xl">
+        {panel}
+      </BottomSheet>
+    );
+  }
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[150] flex items-start justify-center overflow-y-auto p-4 pt-[max(3rem,10dvh)]"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) {
+          handleClose();
+        }
+      }}
+    >
+      <div className="theme-elevated-overlay absolute inset-0" />
+      <section
+        className="theme-dialog-shell relative z-10 flex w-full max-w-2xl flex-col rounded-[28px] border border-[var(--theme-border-subtle)] bg-[var(--theme-bg-elevated)] p-4 shadow-[var(--theme-glow-lg)]"
+        data-testid="command-palette-modal"
+      >
+        {panel}
+      </section>
+    </div>,
+    document.body,
+  );
+}

--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -19,8 +19,6 @@ import {
   type MapTimeMode,
   type SidebarMode,
 } from "@freed/shared";
-import { AddFeedDialog } from "../AddFeedDialog.js";
-import { SavedContentDialog } from "../SavedContentDialog.js";
 import { SearchField } from "../SearchField.js";
 import { Tooltip } from "../Tooltip.js";
 import {
@@ -33,6 +31,7 @@ import {
 import { useSearchResults } from "../../hooks/useSearchResults.js";
 import { useIsMobile } from "../../hooks/useIsMobile.js";
 import { useIsMobileDevice } from "../../hooks/useIsMobileDevice.js";
+import { useCommandSurfaceStore } from "../../lib/command-surface-store.js";
 import { runFeedLayoutTransition } from "../../lib/view-transitions.js";
 import {
   MACOS_TRAFFIC_LIGHT_INSET,
@@ -53,6 +52,7 @@ interface HeaderProps {
   desktopSidebarMode: SidebarMode;
   desktopSidebarDisplayMode?: SidebarMode;
   onDesktopSidebarToggle: () => void;
+  onOpenCommandPalette: () => void;
 }
 
 const noDrag = { WebkitAppRegion: "no-drag" } as CSSProperties;
@@ -147,6 +147,7 @@ export function Header({
   desktopSidebarMode,
   desktopSidebarDisplayMode,
   onDesktopSidebarToggle,
+  onOpenCommandPalette,
 }: HeaderProps) {
   const {
     HeaderSyncIndicator,
@@ -165,6 +166,10 @@ export function Header({
   const canAddRss = !!addRssFeed;
   const canSaveContent = !!(saveUrl || importMarkdown || exportMarkdown);
   const showNewButton = canAddRss || canSaveContent;
+  const addFeedOpen = useCommandSurfaceStore((s) => s.addFeedOpen);
+  const savedContentOpen = useCommandSurfaceStore((s) => s.savedContentOpen);
+  const openAddFeedDialog = useCommandSurfaceStore((s) => s.openAddFeedDialog);
+  const openSavedContentDialog = useCommandSurfaceStore((s) => s.openSavedContentDialog);
 
   const items = useAppStore((s) => s.items);
   const feeds = useAppStore((s) => s.feeds);
@@ -411,6 +416,10 @@ export function Header({
   const activeSearchQuery = searchQuery.trim();
   const showToolbarSearch = !selectedItem && activeSearchQuery.length > 0;
   const canManuallyDragToolbarControls = !!(headerDragRegion && startWindowDrag);
+  const commandShortcutHint =
+    typeof navigator !== "undefined" && /(Mac|iPhone|iPad)/i.test(navigator.platform)
+      ? "Cmd K"
+      : "Ctrl K";
   const macosTrafficLightInsetStyle = headerDragRegion
     ? ({ paddingLeft: `${MACOS_TRAFFIC_LIGHT_INSET}px` } as CSSProperties)
     : undefined;
@@ -456,8 +465,6 @@ export function Header({
   } as CSSProperties;
 
   const [dropdownOpen, setDropdownOpen] = useState(false);
-  const [addFeedOpen, setAddFeedOpen] = useState(false);
-  const [savedContentOpen, setSavedContentOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const leftToolbarSlotRef = useRef<HTMLDivElement | null>(null);
   const wordmarkRef = useRef<HTMLSpanElement | null>(null);
@@ -834,6 +841,30 @@ export function Header({
           >
             {selectedItem ? (
               <>
+                <Tooltip label={`Command palette (${commandShortcutHint})`}>
+                  <button
+                    type="button"
+                    onClick={onOpenCommandPalette}
+                    {...getToolbarControlProps()}
+                    data-testid="command-palette-trigger"
+                    className="theme-toolbar-button-neutral inline-flex items-center gap-2 rounded-lg px-2.5 py-2 text-sm"
+                    aria-label="Open command palette"
+                  >
+                    <svg className="h-4 w-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+                      />
+                    </svg>
+                    <span className="hidden md:inline">Commands</span>
+                    <span className="hidden lg:inline text-xs text-[var(--theme-text-soft)]">
+                      {commandShortcutHint}
+                    </span>
+                  </button>
+                </Tooltip>
+
                 <ToolbarAnimatedSlot visible={!isMobile} width="5.25rem" className="hidden lg:flex">
                   <Tooltip label={display.reading.focusMode ? "Disable focus mode" : "Enable focus mode"}>
                     <button
@@ -914,6 +945,30 @@ export function Header({
               </>
             ) : (
               <>
+                <Tooltip label={`Command palette (${commandShortcutHint})`}>
+                  <button
+                    type="button"
+                    onClick={onOpenCommandPalette}
+                    {...getToolbarControlProps()}
+                    data-testid="command-palette-trigger"
+                    className="theme-toolbar-button-neutral inline-flex items-center gap-2 rounded-lg px-2.5 py-2 text-sm"
+                    aria-label="Open command palette"
+                  >
+                    <svg className="h-4 w-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+                      />
+                    </svg>
+                    <span className="hidden md:inline">Commands</span>
+                    <span className="hidden lg:inline text-xs text-[var(--theme-text-soft)]">
+                      {commandShortcutHint}
+                    </span>
+                  </button>
+                </Tooltip>
+
                 <ToolbarAnimatedSlot visible={!!HeaderSyncIndicator} width="4.5rem" className="hidden md:flex">
                   {HeaderSyncIndicator ? (
                     <div className="hidden md:flex">
@@ -1048,7 +1103,7 @@ export function Header({
                 <button
                   onClick={() => {
                     setDropdownOpen(false);
-                    setAddFeedOpen(true);
+                    openAddFeedDialog();
                   }}
                   className="flex w-full items-center gap-2.5 px-4 py-3 text-left text-sm text-[var(--theme-text-secondary)] transition-colors hover:bg-[var(--theme-bg-muted)] hover:text-[var(--theme-text-primary)]"
                 >
@@ -1062,7 +1117,7 @@ export function Header({
                 <button
                   onClick={() => {
                     setDropdownOpen(false);
-                    setSavedContentOpen(true);
+                    openSavedContentDialog();
                   }}
                   className="flex w-full items-center gap-2.5 px-4 py-3 text-left text-sm text-[var(--theme-text-secondary)] transition-colors hover:bg-[var(--theme-bg-muted)] hover:text-[var(--theme-text-primary)]"
                 >
@@ -1090,12 +1145,6 @@ export function Header({
           </Tooltip>
         </div>
       )}
-
-      <AddFeedDialog open={addFeedOpen} onClose={() => setAddFeedOpen(false)} />
-      <SavedContentDialog
-        open={savedContentOpen}
-        onClose={() => setSavedContentOpen(false)}
-      />
     </>
   );
 }

--- a/packages/ui/src/components/layout/SearchJumpField.tsx
+++ b/packages/ui/src/components/layout/SearchJumpField.tsx
@@ -1,106 +1,9 @@
 import { createPortal } from "react-dom";
-import { useState, useEffect, useRef, useMemo, type CSSProperties } from "react";
+import { useState, useEffect, useRef, type CSSProperties, type KeyboardEvent as ReactKeyboardEvent } from "react";
 
-import { useAppStore, usePlatform } from "../../context/PlatformContext.js";
-import { useSettingsStore } from "../../lib/settings-store.js";
-import {
-  BASE_SECTION_METAS,
-  UPDATES_SECTION_META,
-  DANGER_SECTION_META,
-  GOOGLE_CONTACTS_SECTION_META,
-  AI_SECTION_META,
-  X_SECTION_META,
-  FB_SECTION_META,
-  IG_SECTION_META,
-  LI_SECTION_META,
-  type SectionMeta,
-} from "../../lib/settings-sections.js";
+import { useAppStore } from "../../context/PlatformContext.js";
 import { SearchField } from "../SearchField.js";
 import { Tooltip } from "../Tooltip.js";
-
-interface CommandAction {
-  id: string;
-  label: string;
-  hint: string;
-  keywords: string[];
-  onSelect: () => void;
-}
-
-function buildSettingsActions(
-  sections: readonly SectionMeta[],
-  openTo: (id: string) => void,
-): CommandAction[] {
-  return sections.map((s) => ({
-    id: `settings-${s.id}`,
-    label: s.label,
-    hint: "Settings",
-    keywords: s.keywords,
-    onSelect: () => openTo(s.id),
-  }));
-}
-
-function CommandActionList({
-  actions,
-  activeIndex,
-  inputValue,
-  onSelect,
-}: {
-  actions: CommandAction[];
-  activeIndex: number;
-  inputValue: string;
-  onSelect: (action: CommandAction) => void;
-}) {
-  if (actions.length === 0) return null;
-
-  return (
-    <>
-      {!inputValue && (
-        <p className="px-3 pb-0.5 pt-1 text-[10px] font-semibold uppercase tracking-wider text-[var(--theme-text-soft)]">
-          Quick actions
-        </p>
-      )}
-      {actions.map((action, i) => (
-        <button
-          key={action.id}
-          role="option"
-          aria-selected={i === activeIndex}
-          onMouseDown={(e) => e.preventDefault()}
-          onClick={() => onSelect(action)}
-          className={`w-full flex items-center gap-2.5 px-3 py-2 text-sm text-left transition-colors ${
-            i === activeIndex
-              ? "bg-[var(--theme-bg-muted)] text-[var(--theme-text-primary)]"
-              : "text-[var(--theme-text-secondary)] hover:bg-[var(--theme-bg-muted)] hover:text-[var(--theme-text-primary)]"
-          }`}
-        >
-          <svg
-            className="h-3.5 w-3.5 shrink-0 text-[var(--theme-text-soft)]"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            aria-hidden="true"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={1.5}
-              d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"
-            />
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={1.5}
-              d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
-            />
-          </svg>
-          <span className="flex-1 truncate">{action.label}</span>
-          <span className="shrink-0 text-xs text-[var(--theme-text-soft)]">
-            {action.hint}
-          </span>
-        </button>
-      ))}
-    </>
-  );
-}
 
 export function SearchJumpField({
   compactSidebar = false,
@@ -111,22 +14,11 @@ export function SearchJumpField({
   narrowSidebar?: boolean;
   variant?: "inline" | "trigger";
 }) {
-  const {
-    checkForUpdates,
-    factoryReset,
-    XSettingsContent,
-    FacebookSettingsContent,
-    InstagramSettingsContent,
-    LinkedInSettingsContent,
-    GoogleContactsSettingsContent,
-  } = usePlatform();
-  const openSettingsTo = useSettingsStore((s) => s.openTo);
   const searchQuery = useAppStore((s) => s.searchQuery);
   const setSearchQuery = useAppStore((s) => s.setSearchQuery);
-  const [inputValue, setInputValue] = useState("");
+  const [inputValue, setInputValue] = useState(searchQuery);
   const [isFocused, setIsFocused] = useState(false);
   const [isTriggerOpen, setIsTriggerOpen] = useState(false);
-  const [activeIndex, setActiveIndex] = useState(-1);
   const [mounted, setMounted] = useState(false);
   const [palettePosition, setPalettePosition] = useState<CSSProperties>({
     left: 12,
@@ -137,6 +29,9 @@ export function SearchJumpField({
   const triggerButtonRef = useRef<HTMLButtonElement | null>(null);
   const triggerPaletteRef = useRef<HTMLDivElement | null>(null);
   const hasActiveSearch = searchQuery.trim().length > 0;
+  const inlinePlaceholder = narrowSidebar ? "Search" : "Search feed";
+  const usesFloatingTrigger = variant === "trigger";
+  const showFloatingField = usesFloatingTrigger && isTriggerOpen;
 
   useEffect(() => {
     setMounted(true);
@@ -159,61 +54,6 @@ export function SearchJumpField({
     });
   }, [searchQuery]);
 
-  const allCommandActions = useMemo((): CommandAction[] => {
-    const sectionById = Object.fromEntries(BASE_SECTION_METAS.map((section) => [section.id, section])) as Record<
-      "appearance" | "legal" | "support" | "feeds" | "saved" | "sync",
-      SectionMeta
-    >;
-    const sections: SectionMeta[] = [
-      sectionById.appearance,
-      sectionById.sync,
-      ...(GoogleContactsSettingsContent ? [GOOGLE_CONTACTS_SECTION_META] : []),
-      sectionById.saved,
-      ...(XSettingsContent ? [X_SECTION_META] : []),
-      ...(FacebookSettingsContent ? [FB_SECTION_META] : []),
-      ...(InstagramSettingsContent ? [IG_SECTION_META] : []),
-      ...(LinkedInSettingsContent ? [LI_SECTION_META] : []),
-      sectionById.feeds,
-      AI_SECTION_META,
-      ...(checkForUpdates ? [UPDATES_SECTION_META] : []),
-      sectionById.legal,
-      sectionById.support,
-      ...(factoryReset ? [DANGER_SECTION_META] : []),
-    ];
-    return buildSettingsActions(sections, openSettingsTo);
-  }, [
-    FacebookSettingsContent,
-    GoogleContactsSettingsContent,
-    InstagramSettingsContent,
-    LinkedInSettingsContent,
-    XSettingsContent,
-    checkForUpdates,
-    factoryReset,
-    openSettingsTo,
-  ]);
-
-  const filteredActions = useMemo(() => {
-    const q = inputValue.toLowerCase().trim();
-    if (!q) return allCommandActions;
-    return allCommandActions
-      .filter(
-        (a) =>
-          a.label.toLowerCase().includes(q) ||
-          a.keywords.some((k) => k.includes(q)),
-      )
-      .slice(0, 6);
-  }, [allCommandActions, inputValue]);
-  const inlinePlaceholder = narrowSidebar ? "Search" : "Search or jump to...";
-
-  useEffect(() => {
-    setActiveIndex(-1);
-  }, [inputValue]);
-
-  const usesFloatingTrigger = variant === "trigger";
-  const showPalette = usesFloatingTrigger
-    ? isTriggerOpen
-    : isFocused && filteredActions.length > 0;
-
   useEffect(() => {
     if (!usesFloatingTrigger) {
       setIsTriggerOpen(false);
@@ -221,7 +61,7 @@ export function SearchJumpField({
   }, [usesFloatingTrigger]);
 
   useEffect(() => {
-    if (!usesFloatingTrigger || !showPalette) {
+    if (!usesFloatingTrigger || !showFloatingField) {
       return undefined;
     }
 
@@ -229,17 +69,17 @@ export function SearchJumpField({
       if (!triggerButtonRef.current || !triggerPaletteRef.current) return;
 
       const anchorRect = triggerButtonRef.current.getBoundingClientRect();
-      const paletteRect = triggerPaletteRef.current.getBoundingClientRect();
+      const fieldRect = triggerPaletteRef.current.getBoundingClientRect();
       const viewportPadding = 12;
       const gap = 10;
       const maxLeft = Math.max(
         viewportPadding,
-        window.innerWidth - viewportPadding - paletteRect.width,
+        window.innerWidth - viewportPadding - fieldRect.width,
       );
       const left = Math.min(anchorRect.right + gap, maxLeft);
       const maxTop = Math.max(
         viewportPadding,
-        window.innerHeight - viewportPadding - paletteRect.height,
+        window.innerHeight - viewportPadding - fieldRect.height,
       );
       const top = Math.min(
         Math.max(viewportPadding, anchorRect.top),
@@ -261,13 +101,11 @@ export function SearchJumpField({
         return;
       }
       setIsTriggerOpen(false);
-      setActiveIndex(-1);
     };
 
     const handleEscape = (event: KeyboardEvent) => {
       if (event.key !== "Escape") return;
       setIsTriggerOpen(false);
-      setActiveIndex(-1);
     };
 
     updatePosition();
@@ -282,73 +120,58 @@ export function SearchJumpField({
       document.removeEventListener("mousedown", handlePointerDown);
       document.removeEventListener("keydown", handleEscape);
     };
-  }, [showPalette, usesFloatingTrigger]);
+  }, [showFloatingField, usesFloatingTrigger]);
 
   function clearSearch() {
     setInputValue("");
     setSearchQuery("");
   }
 
-  function handleActionSelect(action: CommandAction) {
-    setIsFocused(false);
-    setIsTriggerOpen(false);
-    setActiveIndex(-1);
-    action.onSelect();
-  }
+  function handleInputKeyDown(event: ReactKeyboardEvent<HTMLInputElement>) {
+    if (event.key !== "Escape") return;
 
-  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
-    if (e.key === "Escape") {
-      if (showPalette) {
-        setIsFocused(false);
-        setIsTriggerOpen(false);
-        setActiveIndex(-1);
-      } else {
-        clearSearch();
-        e.currentTarget.blur();
-      }
+    if (usesFloatingTrigger && showFloatingField) {
+      setIsTriggerOpen(false);
       return;
     }
 
-    if (filteredActions.length === 0) return;
-    if (!showPalette && !usesFloatingTrigger) return;
-
-    if (e.key === "ArrowDown") {
-      e.preventDefault();
-      setActiveIndex((i) => (i + 1) % filteredActions.length);
-    } else if (e.key === "ArrowUp") {
-      e.preventDefault();
-      setActiveIndex((i) => (i <= 0 ? filteredActions.length - 1 : i - 1));
-    } else if (e.key === "Enter" && activeIndex >= 0) {
-      e.preventDefault();
-      const action = filteredActions[activeIndex];
-      if (action) handleActionSelect(action);
+    if (inputValue) {
+      clearSearch();
+      return;
     }
+
+    event.currentTarget.blur();
   }
 
   if (usesFloatingTrigger) {
-    const compactTriggerActive = showPalette || hasActiveSearch;
+    const triggerActive = showFloatingField || hasActiveSearch;
 
     return (
-      <div className="relative z-20 w-full">
-        <Tooltip label="Search or run a command" side="right" className="flex w-full">
+      <div className={compactSidebar ? "relative z-20 w-full" : "relative z-20 mb-3 flex justify-center"}>
+        <Tooltip
+          label="Search feed"
+          side={compactSidebar ? "right" : undefined}
+          className={compactSidebar ? "flex w-full" : undefined}
+        >
           <button
             ref={triggerButtonRef}
             type="button"
             data-testid="compact-sidebar-search-trigger"
-            onClick={() => {
-              setIsTriggerOpen((value) => !value);
-              setActiveIndex(-1);
-            }}
-            className={`relative flex aspect-square w-full items-center justify-center overflow-hidden rounded-[var(--card-radius)] border transition-colors ${
-              compactTriggerActive
-                ? "border-[var(--theme-border-strong)] bg-[rgb(var(--theme-accent-secondary-rgb)/0.18)] text-[var(--theme-text-primary)]"
-                : "border-transparent bg-transparent text-[var(--theme-text-secondary)] hover:bg-[var(--theme-bg-muted)] hover:text-[var(--theme-text-primary)]"
-            }`}
-            aria-label="Search or run a command"
-            aria-expanded={showPalette}
-            aria-pressed={compactTriggerActive}
+            onClick={() => setIsTriggerOpen((value) => !value)}
+            className={compactSidebar
+              ? `relative flex aspect-square w-full items-center justify-center overflow-hidden rounded-[var(--card-radius)] border transition-colors ${
+                  triggerActive
+                    ? "border-[var(--theme-border-strong)] bg-[rgb(var(--theme-accent-secondary-rgb)/0.18)] text-[var(--theme-text-primary)]"
+                    : "border-transparent bg-transparent text-[var(--theme-text-secondary)] hover:bg-[var(--theme-bg-muted)] hover:text-[var(--theme-text-primary)]"
+                }`
+              : `relative flex h-10 w-10 items-center justify-center rounded-xl border border-[var(--theme-border-subtle)] bg-transparent text-[var(--theme-text-secondary)] transition-colors hover:border-[var(--theme-border-quiet)] hover:bg-[var(--theme-bg-muted)] hover:text-[var(--theme-text-primary)] ${
+                  showFloatingField ? "border-[var(--theme-border-strong)] bg-[var(--theme-bg-muted)] text-[var(--theme-text-primary)]" : ""
+                }`}
+            aria-label="Search feed"
+            aria-expanded={showFloatingField}
+            aria-pressed={triggerActive}
             aria-haspopup="dialog"
-            >
+          >
             <svg
               className="h-[18px] w-[18px]"
               fill="none"
@@ -366,7 +189,7 @@ export function SearchJumpField({
           </button>
         </Tooltip>
 
-        {mounted && showPalette
+        {mounted && showFloatingField
           ? createPortal(
               <div
                 ref={triggerPaletteRef}
@@ -377,26 +200,12 @@ export function SearchJumpField({
                 <SearchField
                   autoFocus
                   value={inputValue}
-                  onChange={(e) => setInputValue(e.target.value)}
-                  onKeyDown={handleKeyDown}
+                  onChange={(event) => setInputValue(event.target.value)}
+                  onKeyDown={handleInputKeyDown}
                   onClear={clearSearch}
-                  placeholder="Search or jump to..."
-                  aria-label="Search or run a command"
+                  placeholder="Search feed"
+                  aria-label="Search feed"
                 />
-                {filteredActions.length > 0 ? (
-                  <div
-                    role="listbox"
-                    aria-label="Quick actions"
-                    className="mt-1.5 overflow-hidden rounded-xl py-1"
-                  >
-                    <CommandActionList
-                      actions={filteredActions}
-                      activeIndex={activeIndex}
-                      inputValue={inputValue}
-                      onSelect={handleActionSelect}
-                    />
-                  </div>
-                ) : null}
               </div>,
               document.body,
             )
@@ -409,17 +218,15 @@ export function SearchJumpField({
     <div className="relative z-20 mb-4">
       <SearchField
         value={inputValue}
-        onChange={(e) => setInputValue(e.target.value)}
+        onChange={(event) => setInputValue(event.target.value)}
         onFocus={() => setIsFocused(true)}
         onBlur={() => {
           setTimeout(() => setIsFocused(false), 150);
         }}
-        onKeyDown={handleKeyDown}
+        onKeyDown={handleInputKeyDown}
         onClear={clearSearch}
         placeholder={inlinePlaceholder}
-        aria-label="Search or run a command"
-        aria-expanded={showPalette}
-        aria-haspopup="listbox"
+        aria-label="Search feed"
         inputClassName={
           compactSidebar
             ? "pl-7 pr-6"
@@ -427,22 +234,8 @@ export function SearchJumpField({
               ? "pl-7 pr-4"
               : "pl-8 pr-5"
         }
+        data-expanded={isFocused ? "true" : "false"}
       />
-
-      {showPalette && (
-        <div
-          role="listbox"
-          aria-label="Quick actions"
-          className="absolute left-0 right-0 top-full z-50 mt-1.5 overflow-hidden rounded-xl border border-[var(--theme-border-subtle)] bg-[var(--theme-bg-elevated)] py-1 shadow-2xl shadow-black/50"
-        >
-          <CommandActionList
-            actions={filteredActions}
-            activeIndex={activeIndex}
-            inputValue={inputValue}
-            onSelect={handleActionSelect}
-          />
-        </div>
-      )}
     </div>
   );
 }

--- a/packages/ui/src/components/layout/Sidebar.tsx
+++ b/packages/ui/src/components/layout/Sidebar.tsx
@@ -20,6 +20,8 @@ import { getTopSourceItems, type SourceNavigationItem } from "../../lib/source-n
 import { useIsMobile } from "../../hooks/useIsMobile.js";
 import { useIsMobileDevice } from "../../hooks/useIsMobileDevice.js";
 import { SearchJumpField } from "./SearchJumpField.js";
+import { buildTopLevelTagFilters, childTagsOf, collectAllTags } from "../../lib/tag-navigation.js";
+import { navigateToFeedView } from "../../lib/workspace-navigation.js";
 import {
   CLOSED_PRIMARY_SIDEBAR_SNAP_THRESHOLD_PX,
   COMPACT_PRIMARY_SIDEBAR_SNAP_THRESHOLD_PX,
@@ -504,34 +506,15 @@ export function Sidebar({
   // ─── Tag tree ────────────────────────────────────────────────────────────────
 
   /** All unique tags collected from the library, sorted alphabetically */
-  const allTags = useMemo(() => {
-    const tagSet = new Set<string>();
-    for (const item of items) {
-      for (const tag of item.userState.tags ?? []) {
-        tagSet.add(tag);
-      }
-    }
-    return Array.from(tagSet).sort();
-  }, [items]);
-
-  /**
-   * Top-level tag segments (before the first "/").
-   * E.g. ["Technology/AI", "Technology/React", "Science"] → ["Science", "Technology"]
-   */
-  const topLevelTags = useMemo(() => {
-    const tops = new Set<string>();
-    for (const tag of allTags) {
-      tops.add(tag.split("/")[0]);
-    }
-    return Array.from(tops).sort();
-  }, [allTags]);
-
-  /** All descendant tag paths under a given top-level segment */
-  const childTagsOf = (top: string) =>
-    allTags.filter((t) => t === top || t.startsWith(`${top}/`));
+  const allTags = useMemo(() => collectAllTags(items), [items]);
+  const topLevelTagFilters = useMemo(() => buildTopLevelTagFilters(allTags), [allTags]);
+  const topLevelTags = useMemo(
+    () => topLevelTagFilters.map((tagFilter) => tagFilter.label),
+    [topLevelTagFilters],
+  );
 
   const handleTagClick = (tag: string) => {
-    const children = childTagsOf(tag);
+    const children = childTagsOf(allTags, tag);
     showFeed({ tags: children });
   };
 
@@ -541,7 +524,7 @@ export function Sidebar({
     if (!isFeedView) return false;
     const active = activeFilter.tags;
     if (!active || active.length === 0) return false;
-    return childTagsOf(tag).some((t) => active.includes(t));
+    return childTagsOf(allTags, tag).some((t) => active.includes(t));
   };
 
   useEffect(() => {
@@ -728,10 +711,15 @@ export function Sidebar({
   );
 
   const showFeed = useCallback((filter: FilterOptions) => {
-    setActiveView("feed");
-    setSelectedFriend(null);
-    setSelectedItem(null);
-    setFilter(filter);
+    navigateToFeedView(
+      {
+        setActiveView,
+        setSelectedPerson: setSelectedFriend,
+        setSelectedItem,
+        setFilter,
+      },
+      filter,
+    );
     onMobileClose();
   }, [onMobileClose, setActiveView, setFilter, setSelectedFriend, setSelectedItem]);
 
@@ -1591,9 +1579,7 @@ export function Sidebar({
             <SidebarSection title="Tags" defaultOpen={true} count={allTags.length}>
               <ul className="space-y-0.5">
                 {topLevelTags.map((top) => {
-                  const children = allTags.filter(
-                    (t) => t.startsWith(`${top}/`) && t !== top,
-                  );
+                  const children = childTagsOf(allTags, top).filter((tag) => tag !== top);
                   const hasChildren = children.length > 0;
                   const active = isTagActive(top);
                   return (

--- a/packages/ui/src/lib/command-palette-registry.ts
+++ b/packages/ui/src/lib/command-palette-registry.ts
@@ -1,0 +1,443 @@
+import type { FilterOptions, FeedItem, Platform } from "@freed/shared";
+import { PLATFORM_LABELS } from "@freed/shared";
+import { toast } from "../components/Toast.js";
+import type { AvailableUpdateInfo } from "../context/PlatformContext.js";
+import type { CommandPaletteAction } from "./command-palette.js";
+import type { SectionMeta } from "./settings-sections.js";
+
+interface TagFilter {
+  label: string;
+  tags: string[];
+}
+
+interface FeedDestination {
+  url: string;
+  title: string;
+}
+
+interface SourceDestination {
+  id: Platform | undefined;
+  label: string;
+}
+
+interface BuildCommandPaletteActionsOptions {
+  query: string;
+  activeView: "feed" | "friends" | "map";
+  activeFilter: FilterOptions;
+  settingsSections: readonly SectionMeta[];
+  topSources: readonly SourceDestination[];
+  feeds: readonly FeedDestination[];
+  tagFilters: readonly TagFilter[];
+  currentSourceId: Platform | null;
+  selectedItem: FeedItem | null;
+  unreadScopeCount: number;
+  archivableScopeCount: number;
+  savedArchivedCount: number;
+  archivedCount: number;
+  openSettingsTo: (id: string) => void;
+  navigateToFeed: (filter: FilterOptions) => void;
+  navigateToFriends: () => void;
+  navigateToMap: () => void;
+  applyFeedSearch: (query: string) => void;
+  openAddFeedDialog?: (() => void) | null;
+  openSavedContentDialog?: (() => void) | null;
+  openImportLibraryDialog?: (() => void) | null;
+  openExportLibraryDialog?: (() => void) | null;
+  openCurrentItemUrl?: (() => void) | null;
+  closeReader?: (() => void) | null;
+  toggleCurrentItemSaved?: (() => void | Promise<void>) | null;
+  toggleCurrentItemArchived?: (() => void | Promise<void>) | null;
+  toggleCurrentItemLiked?: (() => void | Promise<void>) | null;
+  markScopeRead?: (() => void | Promise<void>) | null;
+  archiveScopeRead?: (() => void | Promise<void>) | null;
+  unarchiveSavedItems?: (() => void | Promise<void>) | null;
+  syncRssNow?: (() => Promise<void>) | null;
+  syncCurrentSource?: ((sourceId: string) => Promise<void>) | null;
+  checkForUpdates?: (() => Promise<AvailableUpdateInfo | null>) | null;
+  deleteAllArchived?: (() => void | Promise<void>) | null;
+  factoryReset?: ((deleteFromCloud: boolean) => Promise<void>) | null;
+  activeCloudProviderLabel?: (() => string | null) | null;
+}
+
+async function runWithToast(
+  runner: () => void | Promise<void>,
+  successMessage?: string,
+  errorMessage = "Action failed",
+) {
+  try {
+    await runner();
+    if (successMessage) toast.success(successMessage);
+  } catch (error) {
+    toast.error(error instanceof Error ? error.message : errorMessage);
+    throw error;
+  }
+}
+
+function currentSourceLabel(sourceId: Platform | null): string | null {
+  return sourceId ? PLATFORM_LABELS[sourceId] ?? sourceId.toLocaleUpperCase() : null;
+}
+
+export function buildCommandPaletteActions({
+  query,
+  activeView,
+  activeFilter: _activeFilter,
+  settingsSections,
+  topSources,
+  feeds,
+  tagFilters,
+  currentSourceId,
+  selectedItem,
+  unreadScopeCount,
+  archivableScopeCount,
+  savedArchivedCount,
+  archivedCount,
+  openSettingsTo,
+  navigateToFeed,
+  navigateToFriends,
+  navigateToMap,
+  applyFeedSearch,
+  openAddFeedDialog,
+  openSavedContentDialog,
+  openImportLibraryDialog,
+  openExportLibraryDialog,
+  openCurrentItemUrl,
+  closeReader,
+  toggleCurrentItemSaved,
+  toggleCurrentItemArchived,
+  toggleCurrentItemLiked,
+  markScopeRead,
+  archiveScopeRead,
+  unarchiveSavedItems,
+  syncRssNow,
+  syncCurrentSource,
+  checkForUpdates,
+  deleteAllArchived,
+  factoryReset,
+  activeCloudProviderLabel,
+}: BuildCommandPaletteActionsOptions): CommandPaletteAction[] {
+  const actions: CommandPaletteAction[] = [
+    {
+      id: "go-unified-feed",
+      title: "Unified Feed",
+      section: "Go to",
+      keywords: ["all", "feed", "timeline", "home"],
+      run: () => navigateToFeed({}),
+    },
+    {
+      id: "go-saved",
+      title: "Saved",
+      section: "Go to",
+      keywords: ["bookmarks", "reading list", "saved items"],
+      run: () => navigateToFeed({ savedOnly: true }),
+    },
+    {
+      id: "go-archived",
+      title: "Archived",
+      section: "Go to",
+      keywords: ["archive", "archived items", "history"],
+      run: () => navigateToFeed({ archivedOnly: true }),
+    },
+    {
+      id: "go-friends",
+      title: "Friends",
+      section: "Go to",
+      keywords: ["people", "social graph", "contacts"],
+      run: navigateToFriends,
+    },
+    {
+      id: "go-map",
+      title: "Map",
+      section: "Go to",
+      keywords: ["locations", "places", "travel"],
+      run: navigateToMap,
+    },
+    ...(openAddFeedDialog
+      ? [{
+      id: "create-add-rss",
+      title: "Add RSS Feed",
+      section: "Create",
+      keywords: ["rss", "feed", "subscribe", "source"],
+      run: openAddFeedDialog,
+    }]
+      : []),
+    ...(openSavedContentDialog
+      ? [{
+      id: "create-save-url",
+      title: "Save URL",
+      section: "Create",
+      keywords: ["save", "bookmark", "article", "url"],
+      run: openSavedContentDialog,
+    }]
+      : []),
+    ...(openImportLibraryDialog
+      ? [{
+      id: "create-import-markdown",
+      title: "Import Freed Markdown",
+      section: "Create",
+      keywords: ["import", "markdown", "archive", "library"],
+      run: openImportLibraryDialog,
+    }]
+      : []),
+    ...(openExportLibraryDialog
+      ? [{
+      id: "create-export-markdown",
+      title: "Export Freed Markdown",
+      section: "Create",
+      keywords: ["export", "markdown", "backup", "library"],
+      run: openExportLibraryDialog,
+    }]
+      : []),
+  ];
+
+  for (const source of topSources) {
+    actions.push({
+      id: `go-source-${source.id ?? "all"}`,
+      title: source.label,
+      section: "Go to",
+      keywords: [source.label.toLocaleLowerCase(), "source", "platform"],
+      entity: true,
+      run: () => navigateToFeed(source.id ? { platform: source.id } : {}),
+    });
+  }
+
+  for (const feed of feeds) {
+    actions.push({
+      id: `go-feed-${feed.url}`,
+      title: feed.title,
+      section: "Go to",
+      keywords: [feed.url.toLocaleLowerCase(), "feed", "rss", feed.title.toLocaleLowerCase()],
+      entity: true,
+      run: () => navigateToFeed({ platform: "rss", feedUrl: feed.url }),
+    });
+  }
+
+  for (const tagFilter of tagFilters) {
+    actions.push({
+      id: `go-tag-${tagFilter.label}`,
+      title: tagFilter.label,
+      section: "Go to",
+      keywords: ["tag", tagFilter.label.toLocaleLowerCase()],
+      entity: true,
+      run: () => navigateToFeed({ tags: tagFilter.tags }),
+    });
+  }
+
+  for (const section of settingsSections) {
+    actions.push({
+      id: `go-settings-${section.id}`,
+      title: section.label,
+      section: "Go to",
+      keywords: section.keywords,
+      entity: true,
+      run: () => openSettingsTo(section.id),
+    });
+  }
+
+  if (selectedItem) {
+    if (openCurrentItemUrl && selectedItem.sourceUrl) {
+      actions.push({
+        id: "item-open-original",
+        title: "Open original URL",
+        section: "Current item",
+        keywords: ["open", "source", "browser", "original"],
+        run: openCurrentItemUrl,
+      });
+    }
+    if (closeReader) {
+      actions.push({
+        id: "item-close-reader",
+        title: "Close reader",
+        section: "Current item",
+        keywords: ["close", "reader", "back"],
+        run: closeReader,
+      });
+    }
+    if (toggleCurrentItemSaved) {
+      actions.push({
+        id: "item-toggle-saved",
+        title: selectedItem.userState.saved ? "Unsave current item" : "Save current item",
+        section: "Current item",
+        keywords: ["save", "unsave", "bookmark"],
+        run: () => toggleCurrentItemSaved(),
+      });
+    }
+    if (toggleCurrentItemArchived) {
+      actions.push({
+        id: "item-toggle-archived",
+        title: selectedItem.userState.archived ? "Unarchive current item" : "Archive current item",
+        section: "Current item",
+        keywords: ["archive", "unarchive", "hide"],
+        run: () => toggleCurrentItemArchived(),
+      });
+    }
+    if (toggleCurrentItemLiked) {
+      actions.push({
+        id: "item-toggle-liked",
+        title: selectedItem.userState.liked ? "Unlike current item" : "Like current item",
+        section: "Current item",
+        keywords: ["like", "unlike", "favorite", "heart"],
+        run: () => toggleCurrentItemLiked(),
+      });
+    }
+  }
+
+  if (markScopeRead && unreadScopeCount > 0) {
+    actions.push({
+      id: "scope-mark-read",
+      title: "Mark current scope read",
+      section: "Current scope",
+      keywords: ["mark read", "unread", "scope"],
+      run: () =>
+        runWithToast(
+          () => markScopeRead(),
+          `${unreadScopeCount.toLocaleString()} item${unreadScopeCount === 1 ? "" : "s"} marked read`,
+        ),
+    });
+  }
+
+  if (archiveScopeRead && archivableScopeCount > 0) {
+    actions.push({
+      id: "scope-archive-read",
+      title: "Archive current scope read items",
+      section: "Current scope",
+      keywords: ["archive", "read", "scope"],
+      run: () =>
+        runWithToast(
+          () => archiveScopeRead(),
+          `${archivableScopeCount.toLocaleString()} item${archivableScopeCount === 1 ? "" : "s"} archived`,
+        ),
+    });
+  }
+
+  if (unarchiveSavedItems && savedArchivedCount > 0) {
+    actions.push({
+      id: "scope-unarchive-saved",
+      title: "Unarchive saved items",
+      section: "Current scope",
+      keywords: ["unarchive", "saved", "repair"],
+      run: () =>
+        runWithToast(
+          () => unarchiveSavedItems(),
+          "Saved items restored to the library",
+        ),
+    });
+  }
+
+  if (syncRssNow) {
+    actions.push({
+      id: "scope-sync-rss",
+      title: "Sync RSS now",
+      section: "Current scope",
+      keywords: ["sync", "rss", "refresh"],
+      run: () => runWithToast(() => syncRssNow(), "RSS sync started"),
+    });
+  }
+
+  const sourceLabel = currentSourceLabel(currentSourceId);
+  if (syncCurrentSource && currentSourceId && sourceLabel) {
+    actions.push({
+      id: `scope-sync-source-${currentSourceId}`,
+      title: `Sync ${sourceLabel}`,
+      section: "Current scope",
+      keywords: ["sync", "refresh", currentSourceId, sourceLabel.toLocaleLowerCase()],
+      run: () =>
+        runWithToast(
+          () => syncCurrentSource(currentSourceId),
+          `${sourceLabel} sync started`,
+        ),
+    });
+  }
+
+  if (checkForUpdates) {
+    actions.push({
+      id: "scope-check-updates",
+      title: "Check for updates",
+      section: "Current scope",
+      keywords: ["update", "version", "release"],
+      run: async () => {
+        try {
+          const update = await checkForUpdates();
+          if (update) {
+            openSettingsTo("updates");
+            toast.info(`Update ${update.version} is available`);
+            return;
+          }
+          toast.success("Freed is up to date");
+        } catch (error) {
+          toast.error(error instanceof Error ? error.message : "Failed to check for updates");
+          throw error;
+        }
+      },
+    });
+  }
+
+  if (deleteAllArchived) {
+    actions.push({
+      id: "danger-delete-archived",
+      title: "Delete all archived items",
+      section: "Danger",
+      keywords: ["delete", "archived", "danger"],
+      availability: () => archivedCount > 0,
+      confirm: {
+        title: "Delete all archived items?",
+        description: "Type DELETE to permanently remove archived, unsaved items from this library.",
+        token: "DELETE",
+        confirmLabel: "Delete archived items",
+      },
+      run: () =>
+        runWithToast(
+          () => deleteAllArchived(),
+          "Archived items deleted",
+        ),
+    });
+  }
+
+  if (factoryReset) {
+    actions.push({
+      id: "danger-reset-device",
+      title: "Factory reset this device",
+      section: "Danger",
+      keywords: ["reset", "wipe", "device", "danger"],
+      confirm: {
+        title: "Reset this device?",
+        description: "Type RESET to wipe local data on this device and reload Freed.",
+        token: "RESET",
+        confirmLabel: "Reset device",
+      },
+      run: () => factoryReset(false),
+    });
+
+    const cloudProviderLabel = activeCloudProviderLabel?.();
+    if (cloudProviderLabel) {
+      actions.push({
+        id: "danger-reset-cloud",
+        title: `Factory reset this device and ${cloudProviderLabel}`,
+        section: "Danger",
+        keywords: ["reset", "wipe", "cloud", cloudProviderLabel.toLocaleLowerCase(), "danger"],
+        confirm: {
+          title: `Reset this device and ${cloudProviderLabel}?`,
+          description: `Type RESET to wipe this device and permanently remove the ${cloudProviderLabel} backup.`,
+          token: "RESET",
+          confirmLabel: "Reset device and cloud backup",
+        },
+        run: () => factoryReset(true),
+      });
+    }
+  }
+
+  if (query.trim()) {
+    actions.push({
+      id: "search-feed",
+      title:
+        activeView === "feed"
+          ? `Search current feed for "${query.trim()}"`
+          : `Search feed for "${query.trim()}"`,
+      section: "Search",
+      keywords: [query.trim().toLocaleLowerCase(), "search", "feed"],
+      fallback: true,
+      run: () => applyFeedSearch(query.trim()),
+    });
+  }
+
+  return actions;
+}

--- a/packages/ui/src/lib/command-palette.ts
+++ b/packages/ui/src/lib/command-palette.ts
@@ -1,0 +1,95 @@
+export interface CommandPaletteConfirm {
+  title: string;
+  description: string;
+  token: string;
+  confirmLabel: string;
+}
+
+export interface CommandPaletteAction {
+  id: string;
+  title: string;
+  section: string;
+  keywords: string[];
+  run: () => void | Promise<void>;
+  availability?: () => boolean;
+  confirm?: CommandPaletteConfirm;
+  entity?: boolean;
+  fallback?: boolean;
+}
+
+function normalizeQuery(value: string): string {
+  return value.trim().toLocaleLowerCase();
+}
+
+function includesMatch(candidates: readonly string[], query: string): boolean {
+  return candidates.some((candidate) => candidate.toLocaleLowerCase().includes(query));
+}
+
+export function isCommandPaletteActionAvailable(
+  action: CommandPaletteAction,
+): boolean {
+  return action.availability ? action.availability() : true;
+}
+
+export function dedupeCommandPaletteActions(
+  actions: readonly CommandPaletteAction[],
+): CommandPaletteAction[] {
+  const seen = new Set<string>();
+  const deduped: CommandPaletteAction[] = [];
+  for (const action of actions) {
+    if (seen.has(action.id)) continue;
+    seen.add(action.id);
+    deduped.push(action);
+  }
+  return deduped;
+}
+
+export function rankCommandPaletteAction(
+  action: CommandPaletteAction,
+  rawQuery: string,
+): number {
+  const query = normalizeQuery(rawQuery);
+  if (!query) return action.fallback ? Number.NEGATIVE_INFINITY : 0;
+  if (action.fallback) return -1;
+
+  const title = action.title.toLocaleLowerCase();
+  if (title === query) return action.entity ? 150 : 400;
+  if (title.startsWith(query)) return action.entity ? 125 : 300;
+
+  if (action.entity) {
+    return includesMatch([action.title, ...action.keywords], query) ? 100 : 0;
+  }
+
+  return includesMatch([action.title, ...action.keywords], query) ? 200 : 0;
+}
+
+export function filterCommandPaletteActions(
+  actions: readonly CommandPaletteAction[],
+  rawQuery: string,
+): CommandPaletteAction[] {
+  const available = dedupeCommandPaletteActions(actions).filter(
+    isCommandPaletteActionAvailable,
+  );
+  const query = normalizeQuery(rawQuery);
+
+  if (!query) {
+    return available.filter((action) => !action.fallback);
+  }
+
+  const ranked = available
+    .map((action, index) => ({
+      action,
+      index,
+      score: rankCommandPaletteAction(action, query),
+    }))
+    .filter(({ score }) => score > 0 || score === -1)
+    .sort((left, right) => {
+      if (left.score !== right.score) return right.score - left.score;
+      return left.index - right.index;
+    });
+
+  const fallback = ranked.filter(({ action }) => action.fallback);
+  const regular = ranked.filter(({ action }) => !action.fallback);
+
+  return [...regular, ...fallback].map(({ action }) => action);
+}

--- a/packages/ui/src/lib/command-surface-store.ts
+++ b/packages/ui/src/lib/command-surface-store.ts
@@ -1,0 +1,36 @@
+import { create } from "zustand";
+
+export type LibraryDialogTab = "import" | "export";
+
+interface CommandSurfaceStore {
+  paletteOpen: boolean;
+  addFeedOpen: boolean;
+  savedContentOpen: boolean;
+  libraryDialogOpen: boolean;
+  libraryDialogTab: LibraryDialogTab;
+  openPalette: () => void;
+  closePalette: () => void;
+  openAddFeedDialog: () => void;
+  closeAddFeedDialog: () => void;
+  openSavedContentDialog: () => void;
+  closeSavedContentDialog: () => void;
+  openLibraryDialog: (tab?: LibraryDialogTab) => void;
+  closeLibraryDialog: () => void;
+}
+
+export const useCommandSurfaceStore = create<CommandSurfaceStore>((set) => ({
+  paletteOpen: false,
+  addFeedOpen: false,
+  savedContentOpen: false,
+  libraryDialogOpen: false,
+  libraryDialogTab: "import",
+  openPalette: () => set({ paletteOpen: true }),
+  closePalette: () => set({ paletteOpen: false }),
+  openAddFeedDialog: () => set({ addFeedOpen: true }),
+  closeAddFeedDialog: () => set({ addFeedOpen: false }),
+  openSavedContentDialog: () => set({ savedContentOpen: true }),
+  closeSavedContentDialog: () => set({ savedContentOpen: false }),
+  openLibraryDialog: (tab = "import") =>
+    set({ libraryDialogOpen: true, libraryDialogTab: tab }),
+  closeLibraryDialog: () => set({ libraryDialogOpen: false }),
+}));

--- a/packages/ui/src/lib/settings-sections.ts
+++ b/packages/ui/src/lib/settings-sections.ts
@@ -28,6 +28,16 @@ export interface SectionMeta {
   keywords: string[];
 }
 
+export interface SettingsSectionAvailability {
+  hasGoogleContacts: boolean;
+  hasX: boolean;
+  hasFacebook: boolean;
+  hasInstagram: boolean;
+  hasLinkedIn: boolean;
+  hasUpdateChecks: boolean;
+  hasFactoryReset: boolean;
+}
+
 /** Sections always present, regardless of platform capabilities. */
 export const BASE_SECTION_METAS: readonly SectionMeta[] = [
   {
@@ -127,3 +137,31 @@ export const DANGER_SECTION_META: SectionMeta = {
     "sample", "populate", "seed", "test data", "regression",
   ],
 };
+
+export function buildSettingsSectionMetas(
+  availability: SettingsSectionAvailability,
+): SectionMeta[] {
+  const baseSectionById = Object.fromEntries(
+    BASE_SECTION_METAS.map((section) => [section.id, section]),
+  ) as Record<
+    Exclude<SectionId, "ai" | "updates" | "danger" | "googleContacts" | "x" | "facebook" | "instagram" | "linkedin">,
+    SectionMeta
+  >;
+
+  return [
+    baseSectionById.appearance,
+    baseSectionById.sync,
+    ...(availability.hasGoogleContacts ? [GOOGLE_CONTACTS_SECTION_META] : []),
+    baseSectionById.saved,
+    ...(availability.hasX ? [X_SECTION_META] : []),
+    ...(availability.hasFacebook ? [FB_SECTION_META] : []),
+    ...(availability.hasInstagram ? [IG_SECTION_META] : []),
+    ...(availability.hasLinkedIn ? [LI_SECTION_META] : []),
+    baseSectionById.feeds,
+    AI_SECTION_META,
+    ...(availability.hasUpdateChecks ? [UPDATES_SECTION_META] : []),
+    baseSectionById.legal,
+    baseSectionById.support,
+    ...(availability.hasFactoryReset ? [DANGER_SECTION_META] : []),
+  ];
+}

--- a/packages/ui/src/lib/tag-navigation.ts
+++ b/packages/ui/src/lib/tag-navigation.ts
@@ -1,0 +1,31 @@
+import type { FeedItem } from "@freed/shared";
+
+export interface TopLevelTagFilter {
+  label: string;
+  tags: string[];
+}
+
+export function collectAllTags(items: readonly FeedItem[]): string[] {
+  const tagSet = new Set<string>();
+  for (const item of items) {
+    for (const tag of item.userState.tags ?? []) {
+      tagSet.add(tag);
+    }
+  }
+  return Array.from(tagSet).sort();
+}
+
+export function childTagsOf(allTags: readonly string[], topLevelTag: string): string[] {
+  return allTags.filter((tag) => tag === topLevelTag || tag.startsWith(`${topLevelTag}/`));
+}
+
+export function buildTopLevelTagFilters(allTags: readonly string[]): TopLevelTagFilter[] {
+  const topLevelTags = Array.from(
+    new Set(allTags.map((tag) => tag.split("/")[0])),
+  ).sort();
+
+  return topLevelTags.map((label) => ({
+    label,
+    tags: childTagsOf(allTags, label),
+  }));
+}

--- a/packages/ui/src/lib/workspace-navigation.ts
+++ b/packages/ui/src/lib/workspace-navigation.ts
@@ -1,0 +1,32 @@
+import type { FilterOptions } from "@freed/shared";
+
+interface FeedNavigationActions {
+  setActiveView: (view: "feed") => void;
+  setSelectedItem: (id: string | null) => void;
+  setSelectedPerson: (id: string | null) => void;
+  setFilter: (filter: FilterOptions) => void;
+}
+
+interface FeedSearchActions {
+  setActiveView: (view: "feed") => void;
+  setSelectedItem: (id: string | null) => void;
+  setSelectedPerson: (id: string | null) => void;
+  setSearchQuery: (query: string) => void;
+}
+
+export function navigateToFeedView(
+  actions: FeedNavigationActions,
+  filter: FilterOptions,
+) {
+  actions.setActiveView("feed");
+  actions.setSelectedPerson(null);
+  actions.setSelectedItem(null);
+  actions.setFilter(filter);
+}
+
+export function applyFeedSearch(actions: FeedSearchActions, query: string) {
+  actions.setActiveView("feed");
+  actions.setSelectedPerson(null);
+  actions.setSelectedItem(null);
+  actions.setSearchQuery(query);
+}

--- a/website/src/app/roadmap/RoadmapContent.tsx
+++ b/website/src/app/roadmap/RoadmapContent.tsx
@@ -783,7 +783,7 @@ const phases: Phase[] = [
     number: 10,
     title: "Polish",
     description:
-      "Onboarding, statistics, AI features, plugin API, community infrastructure, and deeper recovery hardening beyond the bundled startup recovery updater flow already shipped.",
+      "Onboarding, statistics, AI features, plugin API, community infrastructure, the global command palette now shipped across desktop and mobile layouts, and deeper recovery hardening beyond the bundled startup recovery updater flow already shipped.",
     status: "upcoming",
     planLink:
       "https://github.com/freed-project/freed/blob/dev/docs/PHASE-10-POLISH.md",


### PR DESCRIPTION
(AI Generated). 
## Summary
- Adds a real global command palette opened with Cmd/Ctrl+K from AppShell.
- Restores the sidebar search field to feed search only.
- Shares overlay state for the palette, add-feed, save-content, and library flows.
- Adds command registry coverage for navigation, create flows, current-item actions, scope actions, and typed-confirm danger actions.
- Updates Phase 10 polish docs and roadmap copy to reflect the shipped command palette.

## Validation
- npm run validate:feature