### PR TITLE
chore: sync v26.4.2300 release notes into www

### DIFF
--- a/release-notes/daily/production/26.4.23.json
+++ b/release-notes/daily/production/26.4.23.json
@@ -1,0 +1,14 @@
+{
+  "channel": "production",
+  "dayKey": "26.4.23",
+  "date": "2026-04-23",
+  "preferredDeck": null,
+  "editorialGuidance": [
+    "Keep the tone concise, professional, and specific.",
+    "Lead with user-facing outcomes, shipping milestones, trust wins, and installability improvements.",
+    "Demote internal cleanup unless it clearly changes the shipped product."
+  ],
+  "pinnedHighlights": [],
+  "editorialNotes": [],
+  "updatedAt": "2026-04-23T10:45:33.163Z"
+}

--- a/release-notes/releases/v26.4.2300.json
+++ b/release-notes/releases/v26.4.2300.json
@@ -1,0 +1,38 @@
+{
+  "tag": "v26.4.2300",
+  "version": "26.4.2300",
+  "channel": "production",
+  "dayKey": "26.4.23",
+  "approved": true,
+  "editorialNotes": [],
+  "generatedAt": "2026-04-23T10:45:33.163Z",
+  "model": "heuristic",
+  "source": {
+    "channel": "production",
+    "previousPublishedTag": "v26.4.2100",
+    "previousPublishedDayTag": "v26.4.2100",
+    "compareRef": "HEAD",
+    "isLatestOfDay": true,
+    "sameDayTagsIncluded": [
+      "v26.4.2300"
+    ],
+    "relatedBuildTags": [
+      "v26.4.2300"
+    ],
+    "prNumbers": [
+      279,
+      285
+    ],
+    "commitSubjects": [
+      "chore: promote dev into main for production release (#285)",
+      "chore: stop release workflow deploying website (#279)"
+    ]
+  },
+  "release": {
+    "deck": "Promote dev into main for production release and stop release workflow deploying website",
+    "features": [],
+    "fixes": [],
+    "followUps": []
+  },
+  "releaseBody": "(AI Generated).\n\n## Freed v26.4.2300\n\nPromote dev into main for production release and stop release workflow deploying website\n\n### Fixes\n\n- Bug fixes and improvements\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+}

--- a/release-notes/releases/v26.4.2300.md
+++ b/release-notes/releases/v26.4.2300.md
@@ -1,0 +1,17 @@
+(AI Generated).
+
+## Freed v26.4.2300
+
+Promote dev into main for production release and stop release workflow deploying website
+
+### Fixes
+
+- Bug fixes and improvements
+
+### Downloads
+
+**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  
+**Windows:** `.exe` (NSIS installer)  
+**Linux:** `.AppImage`  
+
+> macOS downloads are signed and notarized for normal Gatekeeper installation.

--- a/website/src/content/changelog.generated.json
+++ b/website/src/content/changelog.generated.json
@@ -1,5 +1,30 @@
 [
   {
+    "version": "26.4.2300",
+    "tagName": "v26.4.2300",
+    "channel": "production",
+    "date": "2026-04-23T11:26:24Z",
+    "deck": "Promote dev into main for production release and stop release workflow deploying website",
+    "features": [],
+    "fixes": [],
+    "followUps": [],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.2300",
+    "prNumbers": [
+      279,
+      285
+    ],
+    "builds": [
+      "26.4.2300"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.4.2300",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.2300",
+        "channel": "production"
+      }
+    ]
+  },
+  {
     "version": "26.4.2100",
     "tagName": "v26.4.2100",
     "channel": "production",


### PR DESCRIPTION
(AI Generated).

## Summary
- sync the `v26.4.2300` production release note files from `main` into `www`
- refresh the checked-in changelog snapshot for the website branch
- unblock the production website deploy, which requires the release note to exist on `www`

## Testing
- `npm run generate-changelog`
