### PR TITLE
fix: repair validation workflow jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,9 +36,6 @@ jobs:
       - name: Run tooling smoke tests
         run: npm run test:scripts
 
-  feature:
-    if: github.event_name == 'pull_request'
-
   main-pr-guard:
     if: github.event_name == 'pull_request' && github.base_ref == 'main'
     runs-on: ubuntu-latest


### PR DESCRIPTION
(AI Generated).

Remove the stray empty `feature` job stub from `.github/workflows/ci.yml` so the validation workflow defines a single real `feature` job again.

Validation:
- `npm run test:scripts`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "workflow yaml ok"'