### PR TITLE
chore: sync ui package exports before production release

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -20,7 +20,6 @@
     "./components/settings/GoogleContactsSection": "./src/components/settings/GoogleContactsSection.tsx",
     "./components/BugReportBoundary": "./src/components/BugReportBoundary.tsx",
     "./components/FatalErrorScreen": "./src/components/FatalErrorScreen.tsx",
-    "./components/LocalPreviewBadge": "./src/components/LocalPreviewBadge.tsx",
     "./components/legal/LegalGate": "./src/components/legal/LegalGate.tsx",
     "./components/legal/ProviderRiskDialog": "./src/components/legal/ProviderRiskDialog.tsx",
     "./components/DebugPanel": "./src/components/DebugPanel.tsx",


### PR DESCRIPTION
(AI Generated).

## Summary
- Remove the duplicate LocalPreviewBadge export from packages/ui/package.json so main matches dev on product-owned paths before the production release.

## Testing
- Not run, this is a package export list sync for the production release guard.