### PR TITLE
perf: reduce desktop memory pressure

### DIFF
--- a/docs/PHASE-5-DESKTOP.md
+++ b/docs/PHASE-5-DESKTOP.md
@@ -296,6 +296,7 @@ export async function captureDomFeed(
 - [x] Settings > Saved now shows an overview dashboard with saved-volume charts and source mix, instead of listing every saved item inline
 - [x] Desktop debug tooling now samples runtime memory, relay document size, relay client count, and content-fetcher queue depth so long-run RAM growth can be correlated without attaching Instruments first
 - [x] Desktop diagnostics now also sample renderer JS heap and DOM node counts so overnight RAM growth can be split between native process pressure and WebView pressure
+- [x] Desktop diagnostics now include best-effort WebKit renderer RSS, Automerge binary size, IndexedDB size, WebKit cache size, and critical memory guardrails that pause background fetch and social capture before WebKit eats the machine
 - [x] Native relay broadcasts now reuse shared document buffers and stop writing a full snapshot on every live document push, reducing clone pressure during heavy sync churn
 - [x] Desktop worker state no longer ships the full `allItemIds` list or full Automerge binary back to the main thread on every mutation, and the content fetcher now bounds its failed-item cooldown cache instead of keeping an immortal set of every fetch miss
 - [x] Background fetch now tracks in-flight items so unrelated document updates cannot enqueue duplicate fetch work while a URL is already being processed
@@ -334,7 +335,11 @@ export async function captureDomFeed(
 > hot for an hour or more. The worker now fetches full item-id lists and
 > full Automerge binaries only on demand for import dedupe, relay, cloud
 > backup, and snapshots, rather than shipping those payloads back to the
-> main thread on every state update. The background content fetcher now
+> main thread on every state update. Desktop memory telemetry now also samples
+> the best-effort WebKit renderer process, Automerge binary size, IndexedDB
+> storage, and WebKit cache size. Critical memory pressure pauses background
+> content fetching and social capture, then offers a restart action instead of
+> letting WebKit keep conducting the RAM orchestra with a shovel. The background content fetcher now
 > bounds and ages out its failed-item cooldown cache, and it keeps an
 > in-flight set so unrelated state updates cannot queue the same fetch work
 > over and over while a URL is already being processed. It also stopped

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -162,6 +162,7 @@ fn stored_or_default_user_agent(agent: &std::sync::Mutex<String>) -> String {
 
 fn recycle_webview_window(app: &tauri::AppHandle, label: &str, reason: &str) {
     if let Some(window) = app.get_webview_window(label) {
+        scrub_webview_before_destroy(&window);
         match window.destroy() {
             Ok(()) => info!("[window] recycled {} ({})", label, reason),
             Err(error) => error!(
@@ -206,6 +207,31 @@ fn schedule_webview_recycle(
         tokio::time::sleep(delay).await;
         recycle_webview_window(&app, label, reason);
     });
+}
+
+fn scrub_webview_before_destroy(window: &tauri::WebviewWindow) {
+    let _ = window.eval(
+        r#"
+        (function() {
+            try {
+                for (var i = 1; i < 100000; i += 1) {
+                    clearTimeout(i);
+                    clearInterval(i);
+                }
+                document.querySelectorAll('video,audio').forEach(function(node) {
+                    try {
+                        node.pause();
+                        node.removeAttribute('src');
+                        node.load();
+                    } catch (_) {}
+                });
+                if (document.body) document.body.textContent = '';
+                if (window.stop) window.stop();
+            } catch (_) {}
+        })();
+    "#,
+    );
+    let _ = window.navigate("about:blank".parse().unwrap());
 }
 
 fn build_cloaked_scraper_window(
@@ -688,6 +714,12 @@ type RelayState = Arc<SyncRelayState>;
 struct RuntimeMemoryStats {
     process_resident_bytes: u64,
     process_virtual_bytes: u64,
+    webkit_resident_bytes: Option<u64>,
+    webkit_virtual_bytes: Option<u64>,
+    webkit_process_id: Option<u32>,
+    webkit_telemetry_available: bool,
+    indexed_db_bytes: Option<u64>,
+    webkit_cache_bytes: Option<u64>,
     relay_doc_bytes: u64,
     relay_client_count: u64,
 }
@@ -1033,8 +1065,54 @@ async fn get_sync_client_count(state: tauri::State<'_, RelayState>) -> Result<us
     Ok(*state.client_count.read().await)
 }
 
+fn dir_size_bytes(path: &Path) -> Option<u64> {
+    let metadata = std::fs::metadata(path).ok()?;
+    if metadata.is_file() {
+        return Some(metadata.len());
+    }
+    if !metadata.is_dir() {
+        return Some(0);
+    }
+
+    let mut total = 0u64;
+    let entries = std::fs::read_dir(path).ok()?;
+    for entry in entries.flatten() {
+        if let Some(size) = dir_size_bytes(&entry.path()) {
+            total = total.saturating_add(size);
+        }
+    }
+    Some(total)
+}
+
+fn best_effort_webkit_memory_stats(system: &System) -> (Option<u32>, Option<u64>, Option<u64>) {
+    #[cfg(target_os = "macos")]
+    {
+        let mut best: Option<(u32, u64, u64)> = None;
+        for (pid, process) in system.processes() {
+            let name = process.name().to_string_lossy();
+            if !name.contains("WebKit.WebContent") {
+                continue;
+            }
+            let resident = process.memory();
+            let virtual_bytes = process.virtual_memory();
+            if best
+                .map(|(_, best_resident, _)| resident > best_resident)
+                .unwrap_or(true)
+            {
+                best = Some((pid.as_u32(), resident, virtual_bytes));
+            }
+        }
+        if let Some((pid, resident, virtual_bytes)) = best {
+            return (Some(pid), Some(resident), Some(virtual_bytes));
+        }
+    }
+
+    (None, None, None)
+}
+
 #[tauri::command]
 async fn get_runtime_memory_stats(
+    app: tauri::AppHandle,
     state: tauri::State<'_, RelayState>,
 ) -> Result<RuntimeMemoryStats, String> {
     let pid = Pid::from_u32(std::process::id());
@@ -1049,6 +1127,24 @@ async fn get_runtime_memory_stats(
         .process(pid)
         .map(|process| (process.memory(), process.virtual_memory()))
         .unwrap_or((0, 0));
+    system.refresh_processes_specifics(
+        ProcessesToUpdate::All,
+        true,
+        ProcessRefreshKind::nothing().with_memory(),
+    );
+    let (webkit_process_id, webkit_resident_bytes, webkit_virtual_bytes) =
+        best_effort_webkit_memory_stats(&system);
+
+    let indexed_db_bytes = app
+        .path()
+        .app_data_dir()
+        .ok()
+        .and_then(|path| dir_size_bytes(&path.join("IndexedDB")));
+    let webkit_cache_bytes = app
+        .path()
+        .app_cache_dir()
+        .ok()
+        .and_then(|path| dir_size_bytes(&path.join("WebKit")));
 
     let relay_doc_bytes = state
         .current_doc
@@ -1062,6 +1158,12 @@ async fn get_runtime_memory_stats(
     Ok(RuntimeMemoryStats {
         process_resident_bytes,
         process_virtual_bytes,
+        webkit_resident_bytes,
+        webkit_virtual_bytes,
+        webkit_process_id,
+        webkit_telemetry_available: webkit_resident_bytes.is_some(),
+        indexed_db_bytes,
+        webkit_cache_bytes,
         relay_doc_bytes,
         relay_client_count,
     })

--- a/packages/desktop/src/App.tsx
+++ b/packages/desktop/src/App.tsx
@@ -11,7 +11,7 @@ import { FatalErrorScreen } from "@freed/ui/components/FatalErrorScreen";
 import { LocalPreviewBadge } from "@freed/ui/components/LocalPreviewBadge";
 import { LegalGate } from "@freed/ui/components/legal/LegalGate";
 import { GoogleContactsSection } from "@freed/ui/components/settings/GoogleContactsSection";
-import { ToastContainer } from "@freed/ui/components/Toast";
+import { ToastContainer, toast } from "@freed/ui/components/Toast";
 import {
   PlatformProvider,
   type AvailableUpdateInfo,
@@ -40,7 +40,7 @@ import {
   storeCloudToken,
   type CloudProvider,
 } from "./lib/sync";
-import { clearLocalDoc, getItemPreservedText } from "./lib/automerge";
+import { clearLocalDoc, getCachedDocStats, getItemPreservedText } from "./lib/automerge";
 import { isTauri } from "@tauri-apps/api/core";
 import { emit, listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
@@ -164,7 +164,18 @@ function App() {
     }
     // Start background content fetcher -- processes article HTML fetch queue.
     startContentFetcher();
-    startMemoryMonitor();
+    startMemoryMonitor({
+      getAutomergeStats: getCachedDocStats,
+      onCriticalPressure: () => {
+        stopContentFetcher();
+        toast.error("Freed paused background fetch because memory is critically high", {
+          actionLabel: "Restart",
+          onAction: () => {
+            void relaunch();
+          },
+        });
+      },
+    });
     return () => {
       stopRssPoller();
       stopSync();

--- a/packages/desktop/src/__mocks__/@tauri-apps/api/core.ts
+++ b/packages/desktop/src/__mocks__/@tauri-apps/api/core.ts
@@ -64,6 +64,12 @@ const handlers: Record<string, Handler> = {
   get_runtime_memory_stats: () => ({
     processResidentBytes: 64 * 1024 * 1024,
     processVirtualBytes: 256 * 1024 * 1024,
+    webkitResidentBytes: 96 * 1024 * 1024,
+    webkitVirtualBytes: 512 * 1024 * 1024,
+    webkitProcessId: 12345,
+    webkitTelemetryAvailable: true,
+    indexedDbBytes: 8 * 1024 * 1024,
+    webkitCacheBytes: 16 * 1024 * 1024,
     relayDocBytes: 0,
     relayClientCount: 0,
   }),

--- a/packages/desktop/src/lib/automerge-types.ts
+++ b/packages/desktop/src/lib/automerge-types.ts
@@ -36,6 +36,15 @@ export interface DocState {
   docItemCount: number;
 }
 
+export interface FeedItemPatch {
+  item: FeedItem;
+}
+
+export interface DocStats {
+  binaryBytes: number;
+  itemCount: number;
+}
+
 // ---------------------------------------------------------------------------
 // Main thread → worker
 // ---------------------------------------------------------------------------
@@ -98,6 +107,8 @@ export type WorkerResponse =
   | { reqId: number; type: "ACK"; error?: string }
   /** Broadcast on every doc mutation - main thread uses this to update UI */
   | { type: "STATE_UPDATE"; state: DocState }
+  /** Small mutation update that avoids cloning and hydrating the full document. */
+  | { type: "ITEM_PATCH"; patches: FeedItemPatch[] }
   /** Debug panel event forwarding */
   | { type: "DEBUG_EVENT"; kind: string; detail?: string; bytes?: number }
   /** Doc size snapshot for the debug panel */

--- a/packages/desktop/src/lib/automerge-worker-memory.test.ts
+++ b/packages/desktop/src/lib/automerge-worker-memory.test.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const workerSource = readFileSync(
+  join(process.cwd(), "src/lib/automerge.worker.ts"),
+  "utf8",
+);
+
+function caseBody(caseName: string): string {
+  const pattern = new RegExp(`case "${caseName}":[\\s\\S]*?break;`);
+  return workerSource.match(pattern)?.[0] ?? "";
+}
+
+describe("automerge worker memory routing", () => {
+  const patchOnlyMutations = [
+    "MARK_AS_READ",
+    "MARK_ITEMS_AS_READ",
+    "TOGGLE_ARCHIVED",
+    "TOGGLE_LIKED",
+    "CONFIRM_LIKED_SYNCED",
+    "CONFIRM_SEEN_SYNCED",
+  ];
+
+  it.each(patchOnlyMutations)("%s emits item patches without full hydration", (caseName) => {
+    const body = caseBody(caseName);
+
+    expect(body).toContain("applyItemPatchChange");
+    expect(body).not.toContain("applyRequestChange");
+    expect(body).not.toContain("saveAndBroadcast");
+  });
+
+  it("patch persistence does not hydrate or send a full state update", () => {
+    const body = workerSource.match(
+      /async function persistAndBroadcastWithoutHydration[\s\S]*?\n}/,
+    )?.[0] ?? "";
+
+    expect(body).toContain("persistDoc");
+    expect(body).toContain("storage.save");
+    expect(body).not.toContain("hydrateFromDoc");
+    expect(body).not.toContain("STATE_UPDATE");
+  });
+});

--- a/packages/desktop/src/lib/automerge.ts
+++ b/packages/desktop/src/lib/automerge.ts
@@ -22,7 +22,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { hashSavedUrl } from "@freed/capture-save/normalize";
 import { addDebugEvent, setDocSnapshot, registerDocAccessors } from "@freed/ui/lib/debug-store";
 import type { Account, FeedItem, Person, ReachOutLog, RssFeed, UserPreferences } from "@freed/shared";
-import type { DocState, WorkerRequest, WorkerResponse } from "./automerge-types";
+import type { DocState, DocStats, FeedItemPatch, WorkerRequest, WorkerResponse } from "./automerge-types";
 import { log } from "./logger.js";
 export type { DocState } from "./automerge-types";
 
@@ -86,7 +86,6 @@ const pendingPreservedText = new Map<
     timer: ReturnType<typeof setTimeout>;
   }
 >();
-
 async function request(msg: WorkerRequest): Promise<void> {
   await workerReady;
   return new Promise((resolve, reject) => {
@@ -108,10 +107,9 @@ async function request(msg: WorkerRequest): Promise<void> {
   });
 }
 
-let lastBinary: Uint8Array | null = null;
-
 // Latest hydrated state - updated on every STATE_UPDATE, exposed as getDocState()
 let lastDocState: DocState | null = null;
+let lastDocStats: DocStats | null = null;
 
 // ---------------------------------------------------------------------------
 // Subscriber model
@@ -123,6 +121,84 @@ const subscribers = new Set<Subscriber>();
 export function subscribe(callback: Subscriber): () => void {
   subscribers.add(callback);
   return () => subscribers.delete(callback);
+}
+
+function recomputeCounts(state: DocState): DocState {
+  const feedUnreadCounts: Record<string, number> = {};
+  const feedTotalCounts: Record<string, number> = {};
+  const unreadCountByPlatform: Record<string, number> = {};
+  const itemCountByPlatform: Record<string, number> = {};
+  const archivableCountByPlatform: Record<string, number> = {};
+  const archivableFeedCounts: Record<string, number> = {};
+  let totalUnreadCount = 0;
+  let totalItemCount = 0;
+  let totalArchivableCount = 0;
+
+  for (const item of state.items) {
+    if (item.userState.hidden || item.userState.archived) continue;
+    totalItemCount += 1;
+    itemCountByPlatform[item.platform] = (itemCountByPlatform[item.platform] ?? 0) + 1;
+    if (item.rssSource) {
+      const url = item.rssSource.feedUrl;
+      feedTotalCounts[url] = (feedTotalCounts[url] ?? 0) + 1;
+    }
+    if (!item.userState.readAt) {
+      totalUnreadCount += 1;
+      unreadCountByPlatform[item.platform] = (unreadCountByPlatform[item.platform] ?? 0) + 1;
+      if (item.rssSource) {
+        const url = item.rssSource.feedUrl;
+        feedUnreadCounts[url] = (feedUnreadCounts[url] ?? 0) + 1;
+      }
+    } else if (!item.userState.saved) {
+      totalArchivableCount += 1;
+      archivableCountByPlatform[item.platform] = (archivableCountByPlatform[item.platform] ?? 0) + 1;
+      if (item.rssSource) {
+        const url = item.rssSource.feedUrl;
+        archivableFeedCounts[url] = (archivableFeedCounts[url] ?? 0) + 1;
+      }
+    }
+  }
+
+  return {
+    ...state,
+    feedUnreadCounts,
+    feedTotalCounts,
+    totalUnreadCount,
+    unreadCountByPlatform,
+    totalItemCount,
+    itemCountByPlatform,
+    totalArchivableCount,
+    archivableCountByPlatform,
+    archivableFeedCounts,
+  };
+}
+
+function applyItemPatches(state: DocState, patches: FeedItemPatch[]): DocState {
+  if (patches.length === 0) return state;
+  const patchById = new Map(patches.map((patch) => [patch.item.globalId, patch.item]));
+  let changed = false;
+  const nextItems = state.items.map((item) => {
+    const patch = patchById.get(item.globalId);
+    if (!patch) return item;
+    changed = true;
+    patchById.delete(item.globalId);
+    return patch;
+  });
+
+  for (const item of patchById.values()) {
+    if (!item.userState.hidden) {
+      changed = true;
+      nextItems.push(item);
+    }
+  }
+
+  if (!changed) return state;
+  return recomputeCounts({ ...state, items: nextItems });
+}
+
+function publishState(state: DocState): void {
+  lastDocState = state;
+  for (const sub of subscribers) sub(state);
 }
 
 // ---------------------------------------------------------------------------
@@ -148,9 +224,13 @@ worker.onmessage = (event: MessageEvent<WorkerResponse>) => {
   if (msg.type === "READY") return;
 
   if (msg.type === "STATE_UPDATE") {
-    lastBinary = null;
-    lastDocState = msg.state;
-    for (const sub of subscribers) sub(msg.state);
+    publishState(msg.state);
+    return;
+  }
+
+  if (msg.type === "ITEM_PATCH") {
+    if (!lastDocState) return;
+    publishState(applyItemPatches(lastDocState, msg.patches));
     return;
   }
 
@@ -176,6 +256,7 @@ worker.onmessage = (event: MessageEvent<WorkerResponse>) => {
   }
 
   if (msg.type === "DEBUG_SNAPSHOT") {
+    lastDocStats = { binaryBytes: msg.binarySize, itemCount: msg.itemCount };
     setDocSnapshot({
       deviceId: msg.deviceId,
       itemCount: msg.itemCount,
@@ -200,7 +281,6 @@ worker.onmessage = (event: MessageEvent<WorkerResponse>) => {
     if (!pendingBinary) return;
     clearTimeout(pendingBinary.timer);
     pendingDocBinary.delete(msg.reqId);
-    lastBinary = msg.binary;
     pendingBinary.resolve(msg.binary);
     return;
   }
@@ -263,7 +343,6 @@ function sendInit(): Promise<DocState> {
     const stateHandler = (event: MessageEvent<WorkerResponse>) => {
       const msg = event.data;
       if (msg.type === "STATE_UPDATE" && !initialState) {
-        lastBinary = null;
         lastDocState = msg.state;
         initialState = msg.state;
         tryResolve();
@@ -271,7 +350,7 @@ function sendInit(): Promise<DocState> {
         registerDocAccessors(
           () => null,
           () => "(doc lives in worker - not directly accessible)",
-          () => lastBinary ?? new Uint8Array(0),
+          () => new Uint8Array(0),
         );
         worker.removeEventListener("message", stateHandler);
         if (msg.error) {
@@ -304,7 +383,6 @@ export function getDocState(): DocState | null {
 }
 
 export async function getDocBinary(): Promise<Uint8Array> {
-  if (lastBinary) return lastBinary;
   await workerReady;
   return new Promise((resolve, reject) => {
     const reqId = nextReqId++;
@@ -321,6 +399,10 @@ export async function getDocBinary(): Promise<Uint8Array> {
     pendingDocBinary.set(reqId, { resolve, reject, timer });
     worker.postMessage({ reqId, type: "GET_DOC_BINARY" } satisfies WorkerRequest);
   });
+}
+
+export function getCachedDocStats(): DocStats | null {
+  return lastDocStats;
 }
 
 export async function getAllItemIds(): Promise<string[]> {

--- a/packages/desktop/src/lib/automerge.worker.ts
+++ b/packages/desktop/src/lib/automerge.worker.ts
@@ -201,6 +201,18 @@ function feedItemUpdatesAffectSearchCorpus(updates: Partial<FeedItem>): boolean 
   );
 }
 
+function cloneFeedItemForPatch(item: FeedItem): FeedItem {
+  const cloned = JSON.parse(JSON.stringify(item)) as FeedItem;
+  const preservedText = cloned.preservedContent?.text;
+  if (cloned.preservedContent && preservedText && preservedText.length > DESKTOP_UI_PRESERVED_TEXT_LIMIT) {
+    cloned.preservedContent = {
+      ...cloned.preservedContent,
+      text: preservedText.slice(0, DESKTOP_UI_PRESERVED_TEXT_LIMIT),
+    };
+  }
+  return cloned;
+}
+
 /**
  * Convert the Automerge proxy document to a plain-JS DocState for postMessage.
  * Identical to the PWA worker — runs entirely off the main thread.
@@ -386,6 +398,44 @@ async function saveAndBroadcast(trace?: RequestTrace): Promise<void> {
   }
 }
 
+async function persistAndBroadcastWithoutHydration(trace?: RequestTrace): Promise<void> {
+  const doc = currentDoc;
+  if (!doc) return;
+
+  const startedAt = performance.now();
+  const persisted = persistDoc(doc, persistenceState);
+  const binary = persisted.binary;
+  persistenceState = persisted.persistence;
+  currentBinary = binary;
+  const afterSerializeAt = performance.now();
+  await storage.save(binary);
+  const afterPersistAt = performance.now();
+
+  send({
+    type: "DEBUG_SNAPSHOT",
+    deviceId: (doc.meta?.deviceId as string | undefined) ?? "unknown",
+    itemCount: Object.keys(doc.feedItems ?? {}).length,
+    feedCount: Object.keys(doc.rssFeeds ?? {}).length,
+    binarySize: binary.byteLength,
+  });
+
+  if (relayClientCount > 0) {
+    send({ type: "BROADCAST_REQUEST", data: Array.from(binary) });
+  }
+
+  const totalMs = performance.now() - startedAt;
+  if (trace && totalMs >= SLOW_SAVE_AND_BROADCAST_MS) {
+    emitWorkerTrace(
+      `[automerge-worker] patch-save op=${trace.opType} reqId=${trace.reqId}` +
+        ` serialize_ms=${formatMs(afterSerializeAt - startedAt)}` +
+        ` persist_ms=${formatMs(afterPersistAt - afterSerializeAt)}` +
+        ` total_ms=${formatMs(totalMs)}` +
+        ` persist_mode=${persisted.usedIncremental ? "incremental" : "snapshot"}` +
+        ` bytes=${binary.byteLength.toLocaleString()}`,
+    );
+  }
+}
+
 async function applyChange(
   changeFn: (doc: FreedDoc) => void,
   message: string,
@@ -397,6 +447,28 @@ async function applyChange(
   if (searchCorpusChanged) bumpSearchCorpusVersion();
   send({ type: "DEBUG_EVENT", kind: "change", detail: message });
   await saveAndBroadcast(trace);
+}
+
+async function applyItemPatchChange(
+  changeFn: (doc: FreedDoc) => string[],
+  message: string,
+  trace?: RequestTrace,
+): Promise<void> {
+  if (!currentDoc) throw new Error("Document not initialized");
+  let changedIds: string[] = [];
+  currentDoc = A.change(currentDoc, message, (doc) => {
+    changedIds = changeFn(doc);
+  });
+  send({ type: "DEBUG_EVENT", kind: "change", detail: message });
+  await persistAndBroadcastWithoutHydration(trace);
+
+  const patches = changedIds
+    .map((globalId) => currentDoc?.feedItems[globalId] as FeedItem | undefined)
+    .filter((item): item is FeedItem => Boolean(item))
+    .map((item) => ({ item: cloneFeedItemForPatch(item) }));
+  if (patches.length > 0) {
+    send({ type: "ITEM_PATCH", patches });
+  }
 }
 
 async function handleRequest(
@@ -507,14 +579,21 @@ async function handleRequest(
       }
 
       case "MARK_AS_READ":
-        await applyRequestChange((doc) => markAsRead(doc, req.globalId), "Mark as read");
+        await applyItemPatchChange((doc) => {
+          markAsRead(doc, req.globalId);
+          return [req.globalId];
+        }, "Mark as read", trace);
         ack(req.reqId);
         break;
 
       case "MARK_ITEMS_AS_READ":
-        await applyRequestChange(
-          (doc) => markItemsAsRead(doc, req.globalIds),
+        await applyItemPatchChange(
+          (doc) => {
+            markItemsAsRead(doc, req.globalIds);
+            return req.globalIds;
+          },
           `Mark ${req.globalIds.length.toLocaleString()} items as read`,
+          trace,
         );
         ack(req.reqId);
         break;
@@ -538,27 +617,41 @@ async function handleRequest(
         break;
 
       case "TOGGLE_ARCHIVED":
-        await applyRequestChange((doc) => toggleArchived(doc, req.globalId), "Toggle archived");
+        await applyItemPatchChange((doc) => {
+          toggleArchived(doc, req.globalId);
+          return [req.globalId];
+        }, "Toggle archived", trace);
         ack(req.reqId);
         break;
 
       case "TOGGLE_LIKED":
-        await applyRequestChange((doc) => toggleLiked(doc, req.globalId), "Toggle liked");
+        await applyItemPatchChange((doc) => {
+          toggleLiked(doc, req.globalId);
+          return [req.globalId];
+        }, "Toggle liked", trace);
         ack(req.reqId);
         break;
 
       case "CONFIRM_LIKED_SYNCED":
-        await applyRequestChange(
-          (doc) => confirmLikedSynced(doc, req.globalId, req.syncedAt),
+        await applyItemPatchChange(
+          (doc) => {
+            confirmLikedSynced(doc, req.globalId, req.syncedAt);
+            return [req.globalId];
+          },
           "Confirm liked synced",
+          trace,
         );
         ack(req.reqId);
         break;
 
       case "CONFIRM_SEEN_SYNCED":
-        await applyRequestChange(
-          (doc) => confirmSeenSynced(doc, req.globalId, req.syncedAt),
+        await applyItemPatchChange(
+          (doc) => {
+            confirmSeenSynced(doc, req.globalId, req.syncedAt);
+            return [req.globalId];
+          },
           "Confirm seen synced",
+          trace,
         );
         ack(req.reqId);
         break;

--- a/packages/desktop/src/lib/fb-capture.ts
+++ b/packages/desktop/src/lib/fb-capture.ts
@@ -25,6 +25,7 @@ import { getFbScraperWindowMode } from "./scraper-prefs";
 import { storeFbAuthState } from "./fb-auth";
 import { attachScraperMediaDiagListener } from "./scraper-media-diag";
 import { getProviderPause, recordProviderHealthEvent } from "./provider-health";
+import { isMemoryPressureCritical } from "./memory-monitor";
 
 // =============================================================================
 // Rate Limiting
@@ -107,6 +108,12 @@ export async function fetchFbFeed(): Promise<FbSyncResult> {
     errorStage: null,
     errorMessage: null,
   };
+
+  if (isMemoryPressureCritical()) {
+    diag.errorStage = "memory_pressure";
+    diag.errorMessage = "Facebook sync paused because Freed Desktop memory is critically high.";
+    return { items: [], diag };
+  }
 
   return new Promise<FbSyncResult>((resolve) => {
     let unlisten: UnlistenFn | null = null;

--- a/packages/desktop/src/lib/instagram-capture.ts
+++ b/packages/desktop/src/lib/instagram-capture.ts
@@ -24,6 +24,7 @@ import { getIgScraperWindowMode } from "./scraper-prefs";
 import { storeIgAuthState } from "./instagram-auth";
 import { attachScraperMediaDiagListener } from "./scraper-media-diag";
 import { getProviderPause, recordProviderHealthEvent } from "./provider-health";
+import { isMemoryPressureCritical } from "./memory-monitor";
 
 // =============================================================================
 // Rate Limiting
@@ -84,6 +85,12 @@ export async function fetchIgFeed(): Promise<IgSyncResult> {
     errorStage: null,
     errorMessage: null,
   };
+
+  if (isMemoryPressureCritical()) {
+    diag.errorStage = "memory_pressure";
+    diag.errorMessage = "Instagram sync paused because Freed Desktop memory is critically high.";
+    return { items: [], diag };
+  }
 
   // Accumulate raw posts across all scroll-pass events.
   // The Rust scraper emits one 'ig-feed-data' event per scroll pass (~11 total).

--- a/packages/desktop/src/lib/li-capture.ts
+++ b/packages/desktop/src/lib/li-capture.ts
@@ -20,6 +20,7 @@ import { getLiScraperWindowMode } from "./scraper-prefs";
 import { attachScraperMediaDiagListener } from "./scraper-media-diag";
 import { storeLiAuthState } from "./li-auth";
 import { getProviderPause, recordProviderHealthEvent } from "./provider-health";
+import { isMemoryPressureCritical } from "./memory-monitor";
 
 // =============================================================================
 // Rate Limiting
@@ -96,6 +97,12 @@ export async function fetchLiFeed(): Promise<LiSyncResult> {
 
   if (!isTauri()) {
     return emptyResult;
+  }
+
+  if (isMemoryPressureCritical()) {
+    diag.errorStage = "memory_pressure";
+    diag.errorMessage = "LinkedIn sync paused because Freed Desktop memory is critically high.";
+    return { items: [], diag };
   }
 
   return new Promise<LiSyncResult>((resolve) => {

--- a/packages/desktop/src/lib/memory-monitor.test.ts
+++ b/packages/desktop/src/lib/memory-monitor.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { formatBytesForMemoryLog, getMemoryPressureLevel } from "./memory-monitor";
+
+describe("memory monitor", () => {
+  it("formats byte values for log output", () => {
+    expect(formatBytesForMemoryLog(512)).toBe("512 B");
+    expect(formatBytesForMemoryLog(1536)).toBe("1.5 KB");
+    expect(formatBytesForMemoryLog(2 * 1024 * 1024)).toBe("2.0 MB");
+    expect(formatBytesForMemoryLog(3 * 1024 * 1024 * 1024)).toBe("3.00 GB");
+  });
+
+  it("classifies high and critical resident memory", () => {
+    expect(getMemoryPressureLevel(512 * 1024 * 1024)).toBe("normal");
+    expect(getMemoryPressureLevel(1_500 * 1024 * 1024)).toBe("high");
+    expect(getMemoryPressureLevel(3_000 * 1024 * 1024)).toBe("critical");
+  });
+});

--- a/packages/desktop/src/lib/memory-monitor.ts
+++ b/packages/desktop/src/lib/memory-monitor.ts
@@ -6,11 +6,18 @@ import { log } from "./logger";
 const MEMORY_SAMPLE_INTERVAL_MS = 15_000;
 const MEMORY_LOG_INTERVAL = 4;
 const HIGH_RESIDENT_BYTES = 1_500 * 1024 * 1024;
+const CRITICAL_RESIDENT_BYTES = 3_000 * 1024 * 1024;
 const HIGH_RELAY_DOC_BYTES = 64 * 1024 * 1024;
 
 interface NativeRuntimeMemoryStats {
   processResidentBytes: number;
   processVirtualBytes: number;
+  webkitResidentBytes?: number;
+  webkitVirtualBytes?: number;
+  webkitProcessId?: number;
+  webkitTelemetryAvailable?: boolean;
+  indexedDbBytes?: number;
+  webkitCacheBytes?: number;
   relayDocBytes: number;
   relayClientCount: number;
 }
@@ -32,37 +39,81 @@ function getDomNodeCount(): number | undefined {
   return document.getElementsByTagName("*").length;
 }
 
+function canSampleNativeMemoryStats(): boolean {
+  return isTauri() || import.meta.env.VITE_TEST_TAURI === "1";
+}
+
 let intervalHandle: ReturnType<typeof setInterval> | null = null;
+let startupFollowupHandles: Array<ReturnType<typeof setTimeout>> = [];
 let sampleCount = 0;
 let peakResidentBytes = 0;
+let peakWebkitResidentBytes = 0;
 let peakRelayDocBytes = 0;
+let lastCriticalToastAt = 0;
+let currentPressureLevel: MemoryPressureLevel = "normal";
 
-function formatBytes(bytes: number): string {
+type MemoryPressureLevel = "normal" | "high" | "critical";
+
+interface MemoryMonitorOptions {
+  getAutomergeStats?: () => { binaryBytes?: number; itemCount?: number } | null;
+  onCriticalPressure?: (snapshot: RuntimeMemorySnapshot) => void;
+}
+
+export function formatBytesForMemoryLog(bytes: number): string {
   if (bytes < 1024) return `${bytes.toLocaleString()} B`;
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
   if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
   return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
 }
 
-async function sampleRuntimeMemory(reason: "startup" | "interval"): Promise<void> {
+export function getMemoryPressureLevel(bytes: number): MemoryPressureLevel {
+  if (bytes >= CRITICAL_RESIDENT_BYTES) return "critical";
+  if (bytes >= HIGH_RESIDENT_BYTES) return "high";
+  return "normal";
+}
+
+async function sampleRuntimeMemory(
+  reason: "startup" | "interval",
+  options: MemoryMonitorOptions,
+): Promise<void> {
   const fetcher = getContentFetcherStatus();
   const renderer = getRendererMemoryStats();
   const domNodeCount = getDomNodeCount();
-  const native = isTauri()
+  const automerge = options.getAutomergeStats?.() ?? null;
+  const native = canSampleNativeMemoryStats()
     ? await invoke<NativeRuntimeMemoryStats>("get_runtime_memory_stats")
     : {
         processResidentBytes: 0,
         processVirtualBytes: 0,
+        webkitResidentBytes: undefined,
+        webkitVirtualBytes: undefined,
+        webkitProcessId: undefined,
+        webkitTelemetryAvailable: false,
+        indexedDbBytes: undefined,
+        webkitCacheBytes: undefined,
         relayDocBytes: 0,
         relayClientCount: 0,
       };
+  const pressureBytes = native.webkitResidentBytes ?? native.processResidentBytes;
+  const pressureLevel = getMemoryPressureLevel(pressureBytes);
+  currentPressureLevel = pressureLevel;
 
   peakResidentBytes = Math.max(peakResidentBytes, native.processResidentBytes);
+  peakWebkitResidentBytes = Math.max(peakWebkitResidentBytes, native.webkitResidentBytes ?? 0);
   peakRelayDocBytes = Math.max(peakRelayDocBytes, native.relayDocBytes);
 
   const snapshot: RuntimeMemorySnapshot = {
     processResidentBytes: native.processResidentBytes,
     processVirtualBytes: native.processVirtualBytes,
+    webkitResidentBytes: native.webkitResidentBytes,
+    webkitVirtualBytes: native.webkitVirtualBytes,
+    webkitProcessId: native.webkitProcessId,
+    webkitTelemetryAvailable: native.webkitTelemetryAvailable,
+    automergeBinaryBytes: automerge?.binaryBytes,
+    automergeItemCount: automerge?.itemCount,
+    indexedDbBytes: native.indexedDbBytes,
+    webkitCacheBytes: native.webkitCacheBytes,
+    pressureLevel,
     relayDocBytes: native.relayDocBytes,
     relayClientCount: native.relayClientCount,
     contentQueuePending: fetcher.pending,
@@ -80,53 +131,92 @@ async function sampleRuntimeMemory(reason: "startup" | "interval"): Promise<void
   const shouldLog =
     reason === "startup" ||
     sampleCount % MEMORY_LOG_INTERVAL === 0 ||
-    (isTauri() && native.processResidentBytes >= HIGH_RESIDENT_BYTES) ||
+    pressureLevel !== "normal" ||
     native.relayDocBytes >= HIGH_RELAY_DOC_BYTES;
 
   if (!shouldLog) return;
 
   const level =
-    (isTauri() && native.processResidentBytes >= HIGH_RESIDENT_BYTES) ||
+    pressureLevel !== "normal" ||
     native.relayDocBytes >= HIGH_RELAY_DOC_BYTES
       ? "warn"
       : "info";
 
   log[level](
-    `[memory] rss=${formatBytes(native.processResidentBytes)} ` +
-      `peak_rss=${formatBytes(peakResidentBytes)} ` +
-      `virtual=${formatBytes(native.processVirtualBytes)} ` +
-      `relay_doc=${formatBytes(native.relayDocBytes)} ` +
-      `peak_relay_doc=${formatBytes(peakRelayDocBytes)} ` +
+    `[memory] pressure=${pressureLevel} ` +
+      `native_rss=${formatBytesForMemoryLog(native.processResidentBytes)} ` +
+      `peak_native_rss=${formatBytesForMemoryLog(peakResidentBytes)} ` +
+      `native_virtual=${formatBytesForMemoryLog(native.processVirtualBytes)} ` +
+      (native.webkitTelemetryAvailable
+        ? `webkit_pid=${(native.webkitProcessId ?? 0).toLocaleString()} ` +
+          `webkit_rss=${formatBytesForMemoryLog(native.webkitResidentBytes ?? 0)} ` +
+          `peak_webkit_rss=${formatBytesForMemoryLog(peakWebkitResidentBytes)} ` +
+          `webkit_virtual=${formatBytesForMemoryLog(native.webkitVirtualBytes ?? 0)} `
+        : "webkit_rss=unavailable ") +
+      (automerge?.binaryBytes !== undefined
+        ? `automerge_binary=${formatBytesForMemoryLog(automerge.binaryBytes)} `
+        : "") +
+      (automerge?.itemCount !== undefined
+        ? `automerge_items=${automerge.itemCount.toLocaleString()} `
+        : "") +
+      (native.indexedDbBytes !== undefined
+        ? `indexeddb=${formatBytesForMemoryLog(native.indexedDbBytes)} `
+        : "") +
+      (native.webkitCacheBytes !== undefined
+        ? `webkit_cache=${formatBytesForMemoryLog(native.webkitCacheBytes)} `
+        : "") +
+      `relay_doc=${formatBytesForMemoryLog(native.relayDocBytes)} ` +
+      `peak_relay_doc=${formatBytesForMemoryLog(peakRelayDocBytes)} ` +
       `relay_clients=${native.relayClientCount.toLocaleString()} ` +
       `fetch_pending=${fetcher.pending.toLocaleString()} ` +
       `fetch_completed=${fetcher.completed.toLocaleString()} ` +
       `fetch_failed=${fetcher.failedCount.toLocaleString()}` +
       (renderer
-        ? ` renderer_heap=${formatBytes(renderer.usedJSHeapSize)} ` +
-          `renderer_total=${formatBytes(renderer.totalJSHeapSize)}`
+        ? ` renderer_heap=${formatBytesForMemoryLog(renderer.usedJSHeapSize)} ` +
+          `renderer_total=${formatBytesForMemoryLog(renderer.totalJSHeapSize)}`
         : "") +
       (domNodeCount !== undefined ? ` dom_nodes=${domNodeCount.toLocaleString()}` : ""),
   );
+
+  if (pressureLevel === "critical" && Date.now() - lastCriticalToastAt > 60_000) {
+    lastCriticalToastAt = Date.now();
+    options.onCriticalPressure?.(snapshot);
+  }
 }
 
-export function startMemoryMonitor(): void {
+export function startMemoryMonitor(options: MemoryMonitorOptions = {}): void {
   if (intervalHandle) return;
 
-  void sampleRuntimeMemory("startup").catch((error) => {
+  void sampleRuntimeMemory("startup", options).catch((error) => {
     const msg = error instanceof Error ? error.message : String(error);
     log.warn(`[memory] startup sample failed: ${msg}`);
   });
 
+  startupFollowupHandles = [2_000, 8_000, 16_000].map((delayMs) =>
+    setTimeout(() => {
+      void sampleRuntimeMemory("interval", options).catch((error) => {
+        const msg = error instanceof Error ? error.message : String(error);
+        log.warn(`[memory] followup sample failed: ${msg}`);
+      });
+    }, delayMs),
+  );
+
   intervalHandle = setInterval(() => {
-    void sampleRuntimeMemory("interval").catch((error) => {
+    void sampleRuntimeMemory("interval", options).catch((error) => {
       const msg = error instanceof Error ? error.message : String(error);
       log.warn(`[memory] interval sample failed: ${msg}`);
     });
   }, MEMORY_SAMPLE_INTERVAL_MS);
 }
 
+export function isMemoryPressureCritical(): boolean {
+  return currentPressureLevel === "critical";
+}
+
 export function stopMemoryMonitor(): void {
   if (!intervalHandle) return;
   clearInterval(intervalHandle);
   intervalHandle = null;
+  for (const handle of startupFollowupHandles) clearTimeout(handle);
+  startupFollowupHandles = [];
 }

--- a/packages/desktop/tests/e2e/fixtures/tauri-init.ts
+++ b/packages/desktop/tests/e2e/fixtures/tauri-init.ts
@@ -34,6 +34,12 @@ export function tauriInitScript(): string {
       get_runtime_memory_stats: () => ({
         processResidentBytes: 64 * 1024 * 1024,
         processVirtualBytes: 256 * 1024 * 1024,
+        webkitResidentBytes: 96 * 1024 * 1024,
+        webkitVirtualBytes: 512 * 1024 * 1024,
+        webkitProcessId: 12345,
+        webkitTelemetryAvailable: true,
+        indexedDbBytes: 8 * 1024 * 1024,
+        webkitCacheBytes: 16 * 1024 * 1024,
         relayDocBytes: 0,
         relayClientCount: 0,
       }),

--- a/packages/desktop/tests/e2e/perf-feed.spec.ts
+++ b/packages/desktop/tests/e2e/perf-feed.spec.ts
@@ -712,6 +712,74 @@ test.describe("Memory profiling (CDP heap snapshots)", () => {
     expect(growthMb).toBeLessThan(10);
   });
 
+  test("runtime telemetry stays below the desktop memory budget after common mutations", async ({ app, page }) => {
+    test.setTimeout(60_000);
+
+    await app.goto();
+    await app.waitForReady();
+    await injectPreservedRssItems(page, ITEM_COUNT_XLARGE);
+
+    await page.evaluate(async () => {
+      const w = window as Record<string, unknown>;
+      const store = w.__FREED_STORE__ as {
+        getState: () => {
+          markAsRead: (id: string) => Promise<void>;
+          toggleArchived: (id: string) => Promise<void>;
+          toggleLiked: (id: string) => Promise<void>;
+          items: Array<{ globalId: string }>;
+        };
+      };
+      const { markAsRead, toggleArchived, toggleLiked, items } = store.getState();
+      for (const item of items.slice(0, 25)) await markAsRead(item.globalId);
+      for (const item of items.slice(25, 35)) await toggleArchived(item.globalId);
+      for (const item of items.slice(35, 45)) await toggleLiked(item.globalId);
+    });
+
+    await page.waitForFunction(() => {
+      const freed = (window as Window & { __freed?: { debug?: () => { runtimeMemory?: { automergeItemCount?: number } } } }).__freed;
+      const debug = freed?.debug?.();
+      return Boolean(debug?.runtimeMemory?.automergeItemCount);
+    });
+
+    const telemetry = await page.evaluate(() => {
+      const freed = (window as Window & {
+        __freed?: {
+          debug?: () => {
+            runtimeMemory?: {
+              pressureLevel?: string;
+              webkitResidentBytes?: number;
+              automergeBinaryBytes?: number;
+              automergeItemCount?: number;
+              indexedDbBytes?: number;
+              webkitCacheBytes?: number;
+            };
+          };
+        };
+      }).__freed;
+      const memory = freed?.debug?.().runtimeMemory;
+      return {
+        pressureLevel: memory?.pressureLevel,
+        webkitResidentBytes: memory?.webkitResidentBytes ?? 0,
+        automergeBinaryBytes: memory?.automergeBinaryBytes ?? 0,
+        automergeItemCount: memory?.automergeItemCount ?? 0,
+        indexedDbBytes: memory?.indexedDbBytes ?? 0,
+        webkitCacheBytes: memory?.webkitCacheBytes ?? 0,
+      };
+    });
+
+    console.log(`[PERF] Runtime memory pressure: ${telemetry.pressureLevel}`);
+    console.log(`[PERF] Runtime WebKit RSS: ${(telemetry.webkitResidentBytes / (1024 * 1024)).toFixed(1)} MB`);
+    console.log(`[PERF] Runtime Automerge binary: ${(telemetry.automergeBinaryBytes / (1024 * 1024)).toFixed(1)} MB`);
+    console.log(`[PERF] Runtime Automerge item count: ${telemetry.automergeItemCount.toLocaleString()}`);
+    console.log(`[PERF] Runtime IndexedDB bytes: ${telemetry.indexedDbBytes.toLocaleString()}`);
+    console.log(`[PERF] Runtime WebKit cache bytes: ${telemetry.webkitCacheBytes.toLocaleString()}`);
+
+    expect(telemetry.pressureLevel).not.toBe("critical");
+    expect(telemetry.webkitResidentBytes).toBeLessThan(3_000 * 1024 * 1024);
+    expect(telemetry.automergeBinaryBytes).toBeGreaterThan(0);
+    expect(telemetry.automergeItemCount).toBeGreaterThanOrEqual(ITEM_COUNT_XLARGE);
+  });
+
   test("search index releases heap after clearing a heavy query", async ({ app, page }) => {
     await app.goto();
     await app.waitForReady();

--- a/packages/ui/src/lib/debug-store.ts
+++ b/packages/ui/src/lib/debug-store.ts
@@ -52,6 +52,15 @@ export interface DocSnapshot {
 export interface RuntimeMemorySnapshot {
   processResidentBytes: number;
   processVirtualBytes: number;
+  webkitResidentBytes?: number;
+  webkitVirtualBytes?: number;
+  webkitProcessId?: number;
+  webkitTelemetryAvailable?: boolean;
+  automergeBinaryBytes?: number;
+  automergeItemCount?: number;
+  indexedDbBytes?: number;
+  webkitCacheBytes?: number;
+  pressureLevel?: "normal" | "high" | "critical";
   relayDocBytes: number;
   relayClientCount: number;
   contentQueuePending: number;


### PR DESCRIPTION
(AI Generated).

## Summary

Reduces Freed Desktop memory pressure by adding real WebKit renderer telemetry, critical memory guardrails, and bounded Automerge worker updates for the common read, archive, like, and seen mutation paths.

## Changes

- Adds best-effort WebKit renderer RSS and virtual memory sampling from the native shell.
- Adds Automerge binary size, item count, IndexedDB size, WebKit cache size, and pressure level to debug telemetry.
- Pauses background content fetching and social capture when memory pressure reaches the critical threshold.
- Avoids full worker hydration broadcasts for read, archive, like, and seen sync mutations by sending item patches.
- Stops retaining full Automerge binaries on the main thread.
- Scrubs scraper WebViews before destroy so media, timers, and loaded pages do not linger.
- Adds focused unit coverage and a desktop E2E memory telemetry budget regression.
- Updates Phase 5 desktop docs.

## Validation

- `npm run test:unit` in `packages/desktop`: passed, 136 tests.
- `npm run test:unit -- src/lib/memory-monitor.test.ts src/lib/automerge-worker-memory.test.ts`: passed after rebase, 9 tests.
- `PATH=/Users/aubreyfalconer/dev/freed-desktop-memory/node_modules/.bin:$PATH npm run test:e2e -- tests/e2e/perf-feed.spec.ts -g "runtime telemetry stays below"`: passed.
- `cargo check` in `packages/desktop/src-tauri`: passed, with existing unused snapshot helper warnings.
- `git diff --check`: passed.

## Known Existing Validation Issues

- Full `npm run validate:feature` is currently blocked in desktop E2E by unrelated failures. The first failures are a bug report button label mismatch, a dynamic import 403, then localhost connection refusals after the test server collapses.
- Desktop `tsc -b` is blocked by the existing `src/google-contacts-section.test.tsx:46` `PlatformConfig` cast error.
