### PR TITLE
fix: repair google contacts platform test cast

### DIFF
--- a/packages/desktop/src/google-contacts-section.test.tsx
+++ b/packages/desktop/src/google-contacts-section.test.tsx
@@ -48,7 +48,7 @@ describe("GoogleContactsSection", () => {
         getToken: () => null,
         connect,
       },
-    } as PlatformConfig;
+    } as unknown as PlatformConfig;
 
     const contactSyncValue: ContactSyncContextValue = {
       syncState,


### PR DESCRIPTION
(AI Generated).

Fixes the release validation TypeScript error in the Google Contacts settings test by casting the partial platform test double through unknown before PlatformConfig.

Validation:
- npm run test:unit -- src/google-contacts-section.test.tsx from packages/desktop
- npm run build from packages/desktop