### PR TITLE
fix: stabilize release e2e checks

### DIFF
--- a/packages/desktop/tests/e2e/smoke.spec.ts
+++ b/packages/desktop/tests/e2e/smoke.spec.ts
@@ -1873,7 +1873,7 @@ test("Friends view can return to the feed from sidebar navigation", async ({ app
       | { getState: () => { activeView: string } }
       | undefined;
     return store?.getState().activeView === "friends";
-  }, { timeout: 5_000 });
+  }, { timeout: 15_000 });
 
   await page.getByRole("button", { name: /^Unified Feed$/ }).click();
   await page.waitForFunction(() => {
@@ -1882,7 +1882,7 @@ test("Friends view can return to the feed from sidebar navigation", async ({ app
       | { getState: () => { activeView: string } }
       | undefined;
     return store?.getState().activeView === "feed";
-  }, { timeout: 5_000 });
+  }, { timeout: 15_000 });
   await expect(page.getByText("Article 0:", { exact: false })).toBeVisible({ timeout: 5_000 });
 });
 
@@ -1980,17 +1980,23 @@ test("dual-column reader arrow navigation cycles tiles and keeps the next tile v
   await page.getByText("Article 0:", { exact: false }).click();
   await expect(page.getByLabel("Back")).toBeVisible({ timeout: 5_000 });
   await expect(page.getByTestId("compact-feed-panel-scroll-container")).toBeVisible({ timeout: 5_000 });
+  await expect.poll(async () => {
+    return page.evaluate(() => document.documentElement.classList.contains("feed-layout-transition"));
+  }).toBe(false);
 
   for (let i = 0; i < 6; i += 1) {
     await page.keyboard.press("ArrowDown");
+    await expect
+      .poll(async () => {
+        return page.evaluate(() => {
+          const container = document.querySelector('[data-testid="compact-feed-panel-scroll-container"]') as HTMLElement | null;
+          const selectedItem = container?.querySelector('[data-selected="true"]') as HTMLElement | null;
+          const selectedRow = selectedItem?.closest('[data-compact-panel-index]') as HTMLElement | null;
+          return Number(selectedRow?.dataset.compactPanelIndex ?? -1);
+        });
+      }, { timeout: 5_000 })
+      .toBe(i + 1);
   }
-
-  await page.waitForFunction(() => {
-    const store = (window as Record<string, unknown>).__FREED_STORE__ as
-      | { getState: () => { selectedItemId: string | null } }
-      | undefined;
-    return store?.getState().selectedItemId?.endsWith("bench-item-6") === true;
-  }, { timeout: 5_000 });
 
   await page.waitForFunction(() => {
     const container = document.querySelector('[data-testid="compact-feed-panel-scroll-container"]') as HTMLElement | null;
@@ -3510,19 +3516,15 @@ test("stress Friends graph degrades labels during motion and avoids expensive re
   await expect
     .poll(async () => {
       const debug = await readGraphDebug(page);
-      return {
-        nodes: debug?.nodes.length ?? 0,
-        qualityMode: debug?.qualityMode ?? "interactive",
-        visibleLabels: debug?.metrics.visibleLabelCount ?? 0,
-      };
-    }, { timeout: 30_000 })
-    .toMatchObject({
-      qualityMode: "settled",
-    });
+      if (!debug || debug.qualityMode !== "settled" || debug.metrics.visibleLabelCount <= 0) {
+        return 0;
+      }
+      return debug.nodes.length;
+    }, { timeout: 45_000 })
+    .toBeGreaterThan(1_000);
 
   const seededGraph = await readGraphDebug(page);
   expect(seededGraph).not.toBeNull();
-  expect(seededGraph!.nodes.length).toBeGreaterThan(1_000);
   expect(seededGraph!.metrics.visibleLabelCount).toBeGreaterThan(0);
 
   const initial = await waitForGraphPerfToSettle(page);

--- a/packages/ui/src/components/feed/FeedView.tsx
+++ b/packages/ui/src/components/feed/FeedView.tsx
@@ -263,6 +263,7 @@ export function FeedView() {
   }, [openUrl]);
 
   const [addFeedOpen, setAddFeedOpen] = useState(false);
+  const [readerOrderIds, setReaderOrderIds] = useState<string[] | null>(null);
 
   // useSearchResults handles both the search and the normal ranked+filtered path.
   // When searchQuery is empty it behaves identically to the previous useMemo.
@@ -292,6 +293,15 @@ export function FeedView() {
     () => (selectedItemId ? filteredItems.find((i) => i.globalId === selectedItemId) ?? null : null),
     [filteredItems, selectedItemId],
   );
+  const readerItems = useMemo(() => {
+    if (!readerOrderIds) return filteredItems;
+
+    const itemById = new Map(filteredItems.map((item) => [item.globalId, item]));
+    const stableItems = readerOrderIds
+      .map((id) => itemById.get(id))
+      .filter((item): item is FeedItem => Boolean(item));
+    return stableItems.length > 0 ? stableItems : filteredItems;
+  }, [filteredItems, readerOrderIds]);
   const [focusedIndex, setFocusedIndex] = useState<number>(-1);
   const [keyboardFocusDirection, setKeyboardFocusDirection] = useState<-1 | 0 | 1>(0);
   const [compactSelectionDirection, setCompactSelectionDirection] = useState<-1 | 0 | 1>(0);
@@ -304,13 +314,14 @@ export function FeedView() {
       };
 
       if (showDualColumn && !selectedItemId) {
+        setReaderOrderIds(filteredItems.map((candidate) => candidate.globalId));
         runFeedLayoutTransition(selectItem);
         return;
       }
 
       selectItem();
     },
-    [markAsRead, runFeedLayoutTransition, selectedItemId, setSelectedItem, showDualColumn],
+    [filteredItems, markAsRead, runFeedLayoutTransition, selectedItemId, setSelectedItem, showDualColumn],
   );
 
   const openItemDirect = useCallback((item: FeedItem) => {
@@ -320,6 +331,7 @@ export function FeedView() {
 
   const closeItem = useCallback(() => {
     setCompactSelectionDirection(0);
+    setReaderOrderIds(null);
     if (showDualColumn && selectedItemId) {
       runFeedLayoutTransition(() => {
         setSelectedItem(null);
@@ -342,16 +354,16 @@ export function FeedView() {
       if (selectedItem) {
         if (showDualColumn && (e.key === "ArrowDown" || e.key === "ArrowUp")) {
           e.preventDefault();
-          const currentIndex = filteredItems.findIndex((item) => item.globalId === selectedItem.globalId);
+          const currentIndex = readerItems.findIndex((item) => item.globalId === selectedItem.globalId);
           if (currentIndex < 0) return;
 
           const direction = e.key === "ArrowDown" ? 1 : -1;
-          const nextIndex = Math.max(0, Math.min(currentIndex + direction, filteredItems.length - 1));
+          const nextIndex = Math.max(0, Math.min(currentIndex + direction, readerItems.length - 1));
           if (nextIndex === currentIndex) return;
 
           setCompactSelectionDirection(direction);
           setFocusedIndex(nextIndex);
-          openItem(filteredItems[nextIndex]);
+          openItem(readerItems[nextIndex]);
           return;
         }
 
@@ -375,13 +387,14 @@ export function FeedView() {
 
     window.addEventListener("keydown", handleKey);
     return () => window.removeEventListener("keydown", handleKey);
-  }, [selectedItem, showDualColumn, filteredItems, focusedIndex, openItem, openItemDirect, closeItem]);
+  }, [selectedItem, showDualColumn, filteredItems, readerItems, focusedIndex, openItem, openItemDirect, closeItem]);
 
   // Reset keyboard focus when the active filter or search query changes.
   useEffect(() => {
     setCompactSelectionDirection(0);
     setKeyboardFocusDirection(0);
     setFocusedIndex(-1);
+    setReaderOrderIds(null);
   }, [activeFilter, searchQuery]);
 
   const handleFocusChange = useCallback((index: number) => {
@@ -440,7 +453,7 @@ export function FeedView() {
           {showDualColumn ? (
             <>
               <CompactFeedPanel
-                items={filteredItems}
+                items={readerItems}
                 selectedId={selectedItem.globalId}
                 selectionMoveDirection={compactSelectionDirection}
                 onItemClick={openItemDirect}

--- a/packages/ui/src/components/layout/Sidebar.tsx
+++ b/packages/ui/src/components/layout/Sidebar.tsx
@@ -615,7 +615,9 @@ export function Sidebar({
       ? "width 180ms ease, transform 180ms ease, opacity 160ms ease"
       : "width 220ms ease, transform 220ms ease, opacity 180ms ease";
   const desktopAsideTransform = renderMode === "closed"
-    ? `translateX(calc(-100% - ${px(effectiveGapWidthPx)}))`
+    ? closedPreviewActive
+      ? "translateX(calc(-100% - var(--feed-card-gap, 8px)))"
+      : `translateX(calc(-100% - ${px(effectiveGapWidthPx)}))`
     : "translateX(0)";
   const resizeHandleVisible = !forceCompactDesktopRail && (dragWidth !== null || renderMode !== "closed");
 


### PR DESCRIPTION
(AI Generated).

Stabilizes the release validation failures by keeping dual-column reader navigation on a stable rail order, fixing closed sidebar preview spacing, and making the Friends graph stress wait assert the settled graph state instead of sampling too early.

Validation:
- npm run validate:feature
- CI=1 PATH="/Users/aubreyfalconer/dev/freed-release-e2e-fixes/node_modules/.bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/usr/local/MacGPG2/bin:/Applications/VMware Fusion.app/Contents/Public:/usr/local/share/dotnet:~/.dotnet/tools:/usr/local/go/bin:/Library/Frameworks/Mono.framework/Versions/Current/Commands:/Users/aubreyfalconer/.nvm/versions/node/v24.14.1/bin:/Users/aubreyfalconer/.codex/tmp/arg0/codex-arg0EkSuWb:/Users/aubreyfalconer/.local/bin:/opt/homebrew/opt/mysql-client/bin:/opt/homebrew/bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/Users/aubreyfalconer/.cargo/bin:/Users/aubreyfalconer/go/bin:/Users/aubreyfalconer/.cache/lm-studio/bin:/Users/aubreyfalconer/.safe-chain/bin:/Applications/Codex.app/Contents/Resources:/usr/local/bin" npm run test:e2e -- --grep "desktop sidebar snaps to compact and closed|dual-column reader arrow navigation cycles tiles|stress Friends graph degrades labels"