### PR TITLE
fix: correct website page titles

### DIFF
--- a/website/src/app/changelog/pagination.ts
+++ b/website/src/app/changelog/pagination.ts
@@ -96,13 +96,15 @@ export function buildChangelogMetadata(
   mode: ChangelogMode = "production",
 ): Metadata {
   const pageSuffix = page > 1 ? `, page ${page.toLocaleString()}` : "";
-  const title = `Log | Freed`;
+  const title = "Changelog | Freed";
   const modeSuffix = mode === "all" ? " including dev builds" : "";
   const description = `Every release, every fix, every new feature${modeSuffix}${pageSuffix}. The full build history of Freed Desktop.`;
   const path = getChangelogPageHref(page, mode);
 
   return {
-    title,
+    title: {
+      absolute: title,
+    },
     description,
     alternates: {
       canonical: path,

--- a/website/src/app/updates/page.tsx
+++ b/website/src/app/updates/page.tsx
@@ -2,7 +2,9 @@ import type { Metadata } from "next";
 import UpdatesContent from "./UpdatesContent";
 
 export const metadata: Metadata = {
-  title: "Updates | Freed",
+  title: {
+    absolute: "Updates | Freed",
+  },
   description:
     "Progress reports, technical deep-dives, and the occasional philosophical rant about the attention economy.",
 };


### PR DESCRIPTION
(AI Generated).

## Summary

- Fix the changelog browser title so it renders as `Changelog | Freed` instead of appending the site suffix twice.

- Fix the updates browser title so it renders as `Updates | Freed` instead of appending the site suffix twice.
## Validation

- `PATH=../node_modules/.bin:$PATH npm run build`
- `curl -s http://localhost:3004/updates | rg -o "<title>[^<]+</title>"`
- `curl -s http://localhost:3004/changelog/all | rg -o "<title>[^<]+</title>"`
