### PR TITLE
chore: sync v26.4.2305 release notes into www

### DIFF
--- a/release-notes/daily/production/26.4.23.json
+++ b/release-notes/daily/production/26.4.23.json
@@ -10,5 +10,5 @@
   ],
   "pinnedHighlights": [],
   "editorialNotes": [],
-  "updatedAt": "2026-04-23T10:45:33.163Z"
+  "updatedAt": "2026-04-24T03:52:31.441Z"
 }

--- a/release-notes/releases/v26.4.2305.json
+++ b/release-notes/releases/v26.4.2305.json
@@ -1,0 +1,74 @@
+{
+  "tag": "v26.4.2305",
+  "version": "26.4.2305",
+  "channel": "production",
+  "dayKey": "26.4.23",
+  "approved": true,
+  "editorialNotes": [
+    "Reviewed for production release. Kept same-day carried-forward bullets so release validation can confirm this is the latest complete production note for the day."
+  ],
+  "generatedAt": "2026-04-24T03:52:31.440Z",
+  "model": "heuristic",
+  "source": {
+    "channel": "production",
+    "previousPublishedTag": "v26.4.2303",
+    "previousPublishedDayTag": "v26.4.2100",
+    "compareRef": "HEAD",
+    "isLatestOfDay": true,
+    "sameDayTagsIncluded": [
+      "v26.4.2300",
+      "v26.4.2301",
+      "v26.4.2303",
+      "v26.4.2305"
+    ],
+    "relatedBuildTags": [
+      "v26.4.2300",
+      "v26.4.2301",
+      "v26.4.2303",
+      "v26.4.2305"
+    ],
+    "prNumbers": [
+      279,
+      285,
+      290,
+      294,
+      306
+    ],
+    "commitSubjects": [
+      "chore: promote dev into main for production release (#306)",
+      "release: approve v26.4.2303",
+      "release: v26.4.2303",
+      "fix: repair google contacts platform test cast",
+      "release: approve v26.4.2302",
+      "release: v26.4.2302",
+      "chore: promote latest dev into main",
+      "fix: repair release validation for v26.4.2301 (#294)",
+      "release: approve v26.4.2301",
+      "release: v26.4.2301",
+      "chore: sync ui package exports before production release",
+      "chore: promote dev into main for production release",
+      "chore: promote dev into main after validation fixes (#290)",
+      "release: approve v26.4.2300",
+      "release: v26.4.2300",
+      "chore: promote dev into main for production release (#285)",
+      "chore: stop release workflow deploying website (#279)"
+    ]
+  },
+  "release": {
+    "deck": "Pixi WebGL Friends graph with linked people, channels, and feeds, desktop details rail controls and a mobile Details mode for the Friends workspace, and sync UI package exports before production release",
+    "features": [
+      "Pixi WebGL Friends graph with linked people, channels, and feeds",
+      "Desktop details rail controls and a mobile Details mode for the Friends workspace"
+    ],
+    "fixes": [
+      "Smoother pan and pinch behavior with cleaner four-edge vignette feathering in the Friends graph",
+      "Browser preview no longer crashes on native-only snapshot, LinkedIn, and capture paths",
+      "Crash report exports now label and gate public-safe versus private bundles correctly"
+    ],
+    "followUps": [
+      "Promote dev into main for production release and stop release workflow deploying website",
+      "This build ships the new Friends graph workspace and hardens desktop preview, diagnostics, and graph performance"
+    ]
+  },
+  "releaseBody": "(AI Generated).\n\n## Freed v26.4.2305\n\nPixi WebGL Friends graph with linked people, channels, and feeds, desktop details rail controls and a mobile Details mode for the Friends workspace, and sync UI package exports before production release\n\n### Features\n\n- Pixi WebGL Friends graph with linked people, channels, and feeds\n- Desktop details rail controls and a mobile Details mode for the Friends workspace\n\n### Fixes\n\n- Smoother pan and pinch behavior with cleaner four-edge vignette feathering in the Friends graph\n- Browser preview no longer crashes on native-only snapshot, LinkedIn, and capture paths\n- Crash report exports now label and gate public-safe versus private bundles correctly\n\n### Follow-ups\n\n- Promote dev into main for production release and stop release workflow deploying website\n- This build ships the new Friends graph workspace and hardens desktop preview, diagnostics, and graph performance\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+}

--- a/release-notes/releases/v26.4.2305.md
+++ b/release-notes/releases/v26.4.2305.md
@@ -1,0 +1,29 @@
+(AI Generated).
+
+## Freed v26.4.2305
+
+Pixi WebGL Friends graph with linked people, channels, and feeds, desktop details rail controls and a mobile Details mode for the Friends workspace, and sync UI package exports before production release
+
+### Features
+
+- Pixi WebGL Friends graph with linked people, channels, and feeds
+- Desktop details rail controls and a mobile Details mode for the Friends workspace
+
+### Fixes
+
+- Smoother pan and pinch behavior with cleaner four-edge vignette feathering in the Friends graph
+- Browser preview no longer crashes on native-only snapshot, LinkedIn, and capture paths
+- Crash report exports now label and gate public-safe versus private bundles correctly
+
+### Follow-ups
+
+- Promote dev into main for production release and stop release workflow deploying website
+- This build ships the new Friends graph workspace and hardens desktop preview, diagnostics, and graph performance
+
+### Downloads
+
+**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  
+**Windows:** `.exe` (NSIS installer)  
+**Linux:** `.AppImage`  
+
+> macOS downloads are signed and notarized for normal Gatekeeper installation.

--- a/website/src/content/changelog.generated.json
+++ b/website/src/content/changelog.generated.json
@@ -1,25 +1,70 @@
 [
   {
-    "version": "26.4.2300",
-    "tagName": "v26.4.2300",
+    "version": "26.4.2305",
+    "tagName": "v26.4.2305",
     "channel": "production",
-    "date": "2026-04-23T11:26:24Z",
-    "deck": "Promote dev into main for production release and stop release workflow deploying website",
-    "features": [],
-    "fixes": [],
-    "followUps": [],
-    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.2300",
+    "date": "2026-04-24T04:22:57Z",
+    "deck": "Pixi WebGL Friends graph with linked people, channels, and feeds, desktop details rail controls and a mobile Details mode for the Friends workspace, and sync UI package exports before production release",
+    "features": [
+      {
+        "text": "Pixi WebGL Friends graph with linked people, channels, and feeds"
+      },
+      {
+        "text": "Desktop details rail controls and a mobile Details mode for the Friends workspace"
+      }
+    ],
+    "fixes": [
+      {
+        "text": "Smoother pan and pinch behavior with cleaner four-edge vignette feathering in the Friends graph"
+      },
+      {
+        "text": "Browser preview no longer crashes on native-only snapshot, LinkedIn, and capture paths"
+      },
+      {
+        "text": "Crash report exports now label and gate public-safe versus private bundles correctly"
+      }
+    ],
+    "followUps": [
+      {
+        "text": "Promote dev into main for production release and stop release workflow deploying website"
+      },
+      {
+        "text": "This build ships the new Friends graph workspace and hardens desktop preview, diagnostics, and graph performance"
+      }
+    ],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.2305",
     "prNumbers": [
       279,
-      285
+      285,
+      290,
+      294,
+      306
     ],
     "builds": [
-      "26.4.2300"
+      "26.4.2300",
+      "26.4.2301",
+      "26.4.2303",
+      "26.4.2305"
     ],
     "buildLinks": [
       {
         "version": "26.4.2300",
         "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.2300",
+        "channel": "production"
+      },
+      {
+        "version": "26.4.2301",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.2301",
+        "channel": "production"
+      },
+      {
+        "version": "26.4.2303",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.2303",
+        "channel": "production"
+      },
+      {
+        "version": "26.4.2305",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.2305",
         "channel": "production"
       }
     ]


### PR DESCRIPTION
(AI Generated).

## Summary
- Add approved v26.4.2305 production release notes to www.
- Regenerate the static changelog snapshot so the website can see the latest release.

## Validation
- npm run generate-changelog
- PATH=/Users/aubreyfalconer/dev/freed-www-v26-4-2305-changelog/node_modules/.bin:$PATH npm run build