### PR TITLE
fix: normalize updater release asset urls

### DIFF
--- a/scripts/generate-tauri-latest-from-release.mjs
+++ b/scripts/generate-tauri-latest-from-release.mjs
@@ -104,11 +104,33 @@ function findSignatureForAsset(assetName, signatureDir) {
   return readFileSync(signaturePath, "utf8").trim();
 }
 
-function assetUrl(asset) {
+function assetUrl(release, asset) {
   const url = asset.browser_download_url ?? asset.browserDownloadUrl ?? asset.url;
   if (!url) {
     throw new Error(`Release asset ${asset.name} is missing a download URL.`);
   }
+
+  try {
+    const parsed = new URL(url);
+    const parts = parsed.pathname.split("/");
+    const downloadIndex = parts.findIndex(
+      (part, index) => part === "download" && parts[index - 1] === "releases",
+    );
+
+    if (
+      parsed.hostname === "github.com" &&
+      downloadIndex !== -1 &&
+      parts[downloadIndex + 1] &&
+      release.tag_name
+    ) {
+      parts[downloadIndex + 1] = release.tag_name;
+      parsed.pathname = parts.join("/");
+      return parsed.toString();
+    }
+  } catch {
+    return url;
+  }
+
   return url;
 }
 
@@ -144,7 +166,7 @@ export function generateLatestManifest({
 
     platforms[rule.platform] = {
       signature: findSignatureForAsset(asset.name, signatureDir),
-      url: assetUrl(asset),
+      url: assetUrl(release, asset),
     };
     withAliases(platforms, rule.platform, rule.aliases);
   }

--- a/scripts/generate-tauri-latest-from-release.test.mjs
+++ b/scripts/generate-tauri-latest-from-release.test.mjs
@@ -73,3 +73,26 @@ test("throws when an updater artifact has no signature", () => {
     /Missing updater signature/,
   );
 });
+
+test("normalizes draft asset URLs to the published release tag", () => {
+  const manifest = generateLatestManifest({
+    release: {
+      tag_name: "v26.4.2305",
+      assets: [
+        {
+          name: "Freed_aarch64.app.tar.gz",
+          browser_download_url:
+            "https://github.com/freed-project/freed/releases/download/untagged-1cf3faa3e92222d94ef1/Freed_aarch64.app.tar.gz",
+        },
+      ],
+    },
+    signatureDir: signatureDir({
+      "Freed_aarch64.app.tar.gz.sig": "mac-signature\n",
+    }),
+  });
+
+  assert.equal(
+    manifest.platforms["darwin-aarch64"].url,
+    "https://github.com/freed-project/freed/releases/download/v26.4.2305/Freed_aarch64.app.tar.gz",
+  );
+});


### PR DESCRIPTION
(AI Generated).

## Summary
- Normalize GitHub release asset download URLs to the published tag when generating latest.json.
- Cover the draft release URL regression that produced dead untagged updater URLs.

## Validation
- node scripts/generate-tauri-latest-from-release.test.mjs
- npm run validate:feature