### PR TITLE
fix: batch identity repair worker writes

### DIFF
--- a/packages/desktop/src/lib/automerge-types.ts
+++ b/packages/desktop/src/lib/automerge-types.ts
@@ -80,6 +80,7 @@ export type WorkerRequest =
   | { reqId: number; type: "ADD_PERSON"; person: Person }
   | { reqId: number; type: "ADD_PERSONS"; persons: Person[] }
   | { reqId: number; type: "UPDATE_PERSON"; personId: string; updates: Partial<Person> }
+  | { reqId: number; type: "UPSERT_CONNECTION_PERSONS"; candidates: Array<{ person: Person; accountIds: string[] }> }
   | { reqId: number; type: "REMOVE_PERSON"; personId: string }
   | { reqId: number; type: "LOG_REACH_OUT"; personId: string; entry: ReachOutLog }
   | { reqId: number; type: "ADD_ACCOUNT"; account: Account }

--- a/packages/desktop/src/lib/automerge-worker-memory.test.ts
+++ b/packages/desktop/src/lib/automerge-worker-memory.test.ts
@@ -40,4 +40,13 @@ describe("automerge worker memory routing", () => {
     expect(body).not.toContain("hydrateFromDoc");
     expect(body).not.toContain("STATE_UPDATE");
   });
+
+  it("batches provisional connection repair into one document mutation", () => {
+    const body = caseBody("UPSERT_CONNECTION_PERSONS");
+
+    expect(body).toContain("applyRequestChange");
+    expect(body).toContain("updatePerson");
+    expect(body).toContain("updateAccount");
+    expect(body).toContain("ack(req.reqId)");
+  });
 });

--- a/packages/desktop/src/lib/automerge.ts
+++ b/packages/desktop/src/lib/automerge.ts
@@ -603,6 +603,14 @@ export async function docUpdatePerson(
   return request({ reqId, type: "UPDATE_PERSON", personId, updates });
 }
 
+export async function docUpsertConnectionPersons(
+  candidates: Array<{ person: Person; accountIds: string[] }>,
+): Promise<void> {
+  if (candidates.length === 0) return;
+  const reqId = nextReqId++;
+  return request({ reqId, type: "UPSERT_CONNECTION_PERSONS", candidates });
+}
+
 export async function docRemovePerson(personId: string): Promise<void> {
   const reqId = nextReqId++;
   return request({ reqId, type: "REMOVE_PERSON", personId });

--- a/packages/desktop/src/lib/automerge.worker.ts
+++ b/packages/desktop/src/lib/automerge.worker.ts
@@ -787,6 +787,28 @@ async function handleRequest(
         ack(req.reqId);
         break;
 
+      case "UPSERT_CONNECTION_PERSONS":
+        await applyRequestChange((doc) => {
+          const now = Date.now();
+          for (const candidate of req.candidates) {
+            if (doc.persons[candidate.person.id]) {
+              updatePerson(doc, candidate.person.id, candidate.person);
+            } else {
+              addPerson(doc, candidate.person);
+            }
+            for (const accountId of candidate.accountIds) {
+              const account = doc.accounts[accountId];
+              if (!account || account.personId === candidate.person.id) continue;
+              updateAccount(doc, accountId, {
+                personId: candidate.person.id,
+                updatedAt: now,
+              });
+            }
+          }
+        }, `Upsert ${req.candidates.length.toLocaleString()} connection people`);
+        ack(req.reqId);
+        break;
+
       case "REMOVE_PERSON":
         await applyRequestChange((doc) => removePerson(doc, req.personId), "Remove person");
         ack(req.reqId);

--- a/packages/desktop/src/lib/store-preferences.test.ts
+++ b/packages/desktop/src/lib/store-preferences.test.ts
@@ -37,6 +37,7 @@ vi.mock("./automerge", () => ({
   docAddFriends: vi.fn(),
   docUpdateFriend: vi.fn(),
   docRemoveFriend: vi.fn(),
+  docUpsertConnectionPersons: vi.fn(),
   docLogReachOut: vi.fn(),
   docToggleLiked: vi.fn(),
   docConfirmLikedSynced: vi.fn(),

--- a/packages/desktop/src/lib/store-read-state.test.ts
+++ b/packages/desktop/src/lib/store-read-state.test.ts
@@ -36,6 +36,7 @@ vi.mock("./automerge", () => ({
   docAddFriends: vi.fn(),
   docUpdateFriend: vi.fn(),
   docRemoveFriend: vi.fn(),
+  docUpsertConnectionPersons: vi.fn(),
   docLogReachOut: vi.fn(),
   docToggleLiked: vi.fn(),
   docConfirmLikedSynced: vi.fn(),

--- a/packages/desktop/src/lib/store.ts
+++ b/packages/desktop/src/lib/store.ts
@@ -45,6 +45,7 @@ import {
   docAddPersons,
   docUpdateAccount,
   docUpdatePerson,
+  docUpsertConnectionPersons,
   docRemoveAccount,
   docRemovePerson,
   docLogReachOut,
@@ -165,6 +166,9 @@ interface AppState {
   removeAccount: (id: string) => Promise<void>;
   linkAccountToPerson: (accountId: string, personId: string | null) => Promise<void>;
   createConnectionPersonFromAccounts: (accountIds: string[], person?: Person) => Promise<string>;
+  createConnectionPersonsFromCandidates: (
+    candidates: Array<{ person: Person; accountIds: string[] }>,
+  ) => Promise<number>;
 
   // Preference actions (persisted to Automerge)
   updatePreferences: (update: Partial<UserPreferences>) => Promise<void>;
@@ -542,6 +546,12 @@ export const useAppStore = create<AppState>((set, get) => ({
       await get().linkAccountToPerson(accountId, person.id);
     }
     return person.id;
+  },
+
+  createConnectionPersonsFromCandidates: async (candidates) => {
+    if (candidates.length === 0) return 0;
+    await docUpsertConnectionPersons(candidates);
+    return candidates.length;
   },
 
   // Deprecated friend aliases

--- a/packages/pwa/src/lib/automerge-types.ts
+++ b/packages/pwa/src/lib/automerge-types.ts
@@ -65,6 +65,7 @@ export type WorkerRequest =
   | { reqId: number; type: "ADD_PERSON"; person: Person }
   | { reqId: number; type: "ADD_PERSONS"; persons: Person[] }
   | { reqId: number; type: "UPDATE_PERSON"; personId: string; updates: Partial<Person> }
+  | { reqId: number; type: "UPSERT_CONNECTION_PERSONS"; candidates: Array<{ person: Person; accountIds: string[] }> }
   | { reqId: number; type: "REMOVE_PERSON"; personId: string }
   | { reqId: number; type: "LOG_REACH_OUT"; personId: string; entry: ReachOutLog }
   | { reqId: number; type: "ADD_ACCOUNT"; account: Account }

--- a/packages/pwa/src/lib/automerge.ts
+++ b/packages/pwa/src/lib/automerge.ts
@@ -327,6 +327,14 @@ export async function docUpdatePerson(personId: string, updates: Partial<Person>
   return request({ reqId, type: "UPDATE_PERSON", personId, updates });
 }
 
+export async function docUpsertConnectionPersons(
+  candidates: Array<{ person: Person; accountIds: string[] }>,
+): Promise<void> {
+  if (candidates.length === 0) return;
+  const reqId = nextReqId++;
+  return request({ reqId, type: "UPSERT_CONNECTION_PERSONS", candidates });
+}
+
 export async function docRemovePerson(personId: string): Promise<void> {
   const reqId = nextReqId++;
   return request({ reqId, type: "REMOVE_PERSON", personId });

--- a/packages/pwa/src/lib/automerge.worker.ts
+++ b/packages/pwa/src/lib/automerge.worker.ts
@@ -483,6 +483,28 @@ self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
         ack(req.reqId);
         break;
 
+      case "UPSERT_CONNECTION_PERSONS":
+        await applyChange((doc) => {
+          const now = Date.now();
+          for (const candidate of req.candidates) {
+            if (doc.persons[candidate.person.id]) {
+              updatePerson(doc, candidate.person.id, candidate.person);
+            } else {
+              addPerson(doc, candidate.person);
+            }
+            for (const accountId of candidate.accountIds) {
+              const account = doc.accounts[accountId];
+              if (!account || account.personId === candidate.person.id) continue;
+              updateAccount(doc, accountId, {
+                personId: candidate.person.id,
+                updatedAt: now,
+              });
+            }
+          }
+        }, `Upsert ${req.candidates.length.toLocaleString()} connection people`);
+        ack(req.reqId);
+        break;
+
       case "REMOVE_PERSON":
         await applyChange((doc) => removePerson(doc, req.personId), "Remove person");
         ack(req.reqId);

--- a/packages/pwa/src/lib/command-palette.test.ts
+++ b/packages/pwa/src/lib/command-palette.test.ts
@@ -219,6 +219,9 @@ function createTestStore(overrides: Partial<BaseAppState> = {}) {
     createConnectionPersonFromAccounts:
       overrides.createConnectionPersonFromAccounts
       ?? (async () => "connection-person-id"),
+    createConnectionPersonsFromCandidates:
+      overrides.createConnectionPersonsFromCandidates
+      ?? (async () => 0),
     updatePreferences: overrides.updatePreferences ?? noopAsync,
     setFilter: overrides.setFilter ?? ((filter: FilterOptions) => set({ activeFilter: filter })),
     setSelectedItem: overrides.setSelectedItem ?? ((id: string | null) => set({ selectedItemId: id })),

--- a/packages/pwa/src/lib/store.ts
+++ b/packages/pwa/src/lib/store.ts
@@ -44,6 +44,7 @@ import {
   docAddPersons,
   docUpdateAccount,
   docUpdatePerson,
+  docUpsertConnectionPersons,
   docRemoveAccount,
   docRemovePerson,
   docLogReachOut,
@@ -276,6 +277,12 @@ export const useAppStore = create<AppState>((set, get) => ({
       await get().linkAccountToPerson(accountId, person.id);
     }
     return person.id;
+  },
+
+  createConnectionPersonsFromCandidates: async (candidates) => {
+    if (candidates.length === 0) return 0;
+    await docUpsertConnectionPersons(candidates);
+    return candidates.length;
   },
 
   // Deprecated friend aliases

--- a/packages/shared/src/store-types.ts
+++ b/packages/shared/src/store-types.ts
@@ -128,6 +128,9 @@ export interface BaseAppState {
   removeAccount: (id: string) => Promise<void>;
   linkAccountToPerson: (accountId: string, personId: string | null) => Promise<void>;
   createConnectionPersonFromAccounts: (accountIds: string[], person?: Person) => Promise<string>;
+  createConnectionPersonsFromCandidates: (
+    candidates: Array<{ person: Person; accountIds: string[] }>,
+  ) => Promise<number>;
 
   // Preference actions
   updatePreferences: (update: Partial<UserPreferences>) => Promise<void>;

--- a/packages/ui/src/components/layout/AppShell.tsx
+++ b/packages/ui/src/components/layout/AppShell.tsx
@@ -5,7 +5,7 @@ import { DebugPanel } from "../DebugPanel.js";
 import { AddFeedDialog } from "../AddFeedDialog.js";
 import { SavedContentDialog } from "../SavedContentDialog.js";
 import { LibraryDialog } from "../LibraryDialog.js";
-import { useDebugStore } from "../../lib/debug-store.js";
+import { addDebugEvent, useDebugStore } from "../../lib/debug-store.js";
 import { useAppStore } from "../../context/PlatformContext.js";
 import { useCommandSurfaceStore } from "../../lib/command-surface-store.js";
 import { FriendsView } from "../friends/FriendsView.js";
@@ -60,7 +60,7 @@ export function AppShell({ children }: AppShellProps) {
   const persons = useAppStore((s) => s.persons);
   const addPerson = useAppStore((s) => s.addPerson);
   const addAccounts = useAppStore((s) => s.addAccounts);
-  const createConnectionPersonFromAccounts = useAppStore((s) => s.createConnectionPersonFromAccounts);
+  const createConnectionPersonsFromCandidates = useAppStore((s) => s.createConnectionPersonsFromCandidates);
   const isInitialized = useAppStore((s) => s.isInitialized);
   const themeId = useAppStore((s) => s.preferences.display.themeId);
   const showAtmosphere = activeView !== "friends" && activeView !== "map";
@@ -271,12 +271,11 @@ export function AppShell({ children }: AppShellProps) {
     provisionalPersonScanRef.current = { personCount, accountCount };
     const candidates = buildProvisionalPersonCandidates(persons, accounts);
     if (candidates.length === 0) return;
-    void (async () => {
-      for (const candidate of candidates) {
-        await createConnectionPersonFromAccounts(candidate.accountIds, candidate.person);
-      }
-    })();
-  }, [accounts, createConnectionPersonFromAccounts, isInitialized, persons]);
+    void createConnectionPersonsFromCandidates(candidates).catch((error) => {
+      const message = error instanceof Error ? error.message : String(error);
+      addDebugEvent("error", `[Identity] provisional person repair failed: ${message}`);
+    });
+  }, [accounts, createConnectionPersonsFromCandidates, isInitialized, persons]);
 
   const handleLinkSuggestion = useCallback(async (suggestion: IdentitySuggestion) => {
     const match = contactSync.getMatchForSuggestion(suggestion.id);


### PR DESCRIPTION
(AI Generated).

## Summary
- Batch provisional connection person repair into one Automerge worker mutation so startup repair does not enqueue dozens of person updates and turn worker backpressure into fatal unhandled rejections.

## Testing
- npm run validate:feature