### PR TITLE
fix: preserve fb preference record replacement

### DIFF
--- a/packages/desktop/src/lib/store-preferences.test.ts
+++ b/packages/desktop/src/lib/store-preferences.test.ts
@@ -140,4 +140,61 @@ describe("store.updatePreferences", () => {
       display: { mapTimeMode: "future" },
     });
   });
+
+  it("replaces Facebook exclusion records during optimistic updates", async () => {
+    useAppStore.setState((state) => ({
+      preferences: {
+        ...state.preferences,
+        fbCapture: {
+          knownGroups: {
+            one: {
+              id: "one",
+              name: "One",
+              url: "https://facebook.com/groups/one",
+            },
+          },
+          excludedGroupIds: {
+            one: true,
+          },
+        },
+      },
+    }));
+
+    let resolvePersistence: (() => void) | undefined;
+    mockDocUpdatePreferences.mockImplementationOnce(
+      () => new Promise<void>((resolve) => {
+        resolvePersistence = resolve;
+      }),
+    );
+
+    const updatePromise = useAppStore.getState().updatePreferences({
+      fbCapture: {
+        knownGroups: {
+          one: {
+            id: "one",
+            name: "One",
+            url: "https://facebook.com/groups/one",
+          },
+        },
+        excludedGroupIds: {},
+      },
+    } as never);
+
+    expect(useAppStore.getState().preferences.fbCapture.excludedGroupIds).toEqual({});
+    expect(mockDocUpdatePreferences).toHaveBeenCalledWith({
+      fbCapture: {
+        knownGroups: {
+          one: {
+            id: "one",
+            name: "One",
+            url: "https://facebook.com/groups/one",
+          },
+        },
+        excludedGroupIds: {},
+      },
+    });
+
+    resolvePersistence?.();
+    await expect(updatePromise).resolves.toBeUndefined();
+  });
 });

--- a/packages/desktop/src/lib/store.ts
+++ b/packages/desktop/src/lib/store.ts
@@ -240,6 +240,18 @@ function mergePreferenceUpdate<T extends object>(
   return next;
 }
 
+function mergeFacebookCapturePreferenceUpdate(
+  current: UserPreferences["fbCapture"],
+  update: Partial<UserPreferences["fbCapture"]>,
+): UserPreferences["fbCapture"] {
+  return {
+    knownGroups: update.knownGroups ? { ...update.knownGroups } : { ...current.knownGroups },
+    excludedGroupIds: update.excludedGroupIds
+      ? { ...update.excludedGroupIds }
+      : { ...current.excludedGroupIds },
+  };
+}
+
 async function pruneConnectionPersonIfNeeded(
   getState: () => AppState,
   personId: string | null | undefined,
@@ -640,7 +652,15 @@ export const useAppStore = create<AppState>((set, get) => ({
 
   // Preference actions
   updatePreferences: async (update) => {
-    set({ preferences: mergePreferenceUpdate(get().preferences, update) });
+    const currentPreferences = get().preferences;
+    const nextPreferences = mergePreferenceUpdate(currentPreferences, update);
+    if (update.fbCapture !== undefined) {
+      nextPreferences.fbCapture = mergeFacebookCapturePreferenceUpdate(
+        currentPreferences.fbCapture,
+        update.fbCapture,
+      );
+    }
+    set({ preferences: nextPreferences });
 
     try {
       await docUpdatePreferences(update);


### PR DESCRIPTION
(AI Generated).

## Summary
- Fix the desktop optimistic preference merge so Facebook capture maps use record replacement semantics.
- Keep clearing excluded Facebook groups in local state aligned with the shared schema behavior.

## Testing
- vitest run packages/desktop/src/lib/store-preferences.test.ts