### PR TITLE
feat: add social story filters

### DIFF
--- a/docs/PHASE-7-SOCIAL-CAPTURE.md
+++ b/docs/PHASE-7-SOCIAL-CAPTURE.md
@@ -1,6 +1,6 @@
 # Phase 7: Facebook + Instagram Capture
 
-> **Status:** 🚧 In Progress — Facebook and Instagram integrated into Desktop via Tauri WebView scraping, with feed pollution filtering, silent background media guarding, provider health summaries, smart backoff, Facebook group controls, preserved Instagram story location metadata for map recovery, linked-account cross-post dedup across IG and FB, and captured authors now feeding the Phase 8 account catalog for identity review
+> **Status:** 🚧 In Progress: Facebook and Instagram integrated into Desktop via Tauri WebView scraping, with feed pollution filtering, silent background media guarding, provider health summaries, smart backoff, Facebook group controls, source-level post and story filtering, preserved Instagram story location metadata for map recovery, linked-account cross-post dedup across IG and FB, same-platform social story duplicate repair, and captured authors now feeding the Phase 8 account catalog for identity review
 > **Dependencies:** Phase 5 (Desktop App)
 
 ---
@@ -98,7 +98,7 @@ Self-contained JavaScript injected into the WebView's execution context. No exte
 - **Facebook** (`fb-extract.js`): Locates "Feed posts" h3, walks subtrees for post-sized blocks
 - **Instagram** (`ig-extract.js`): Queries `<article>` elements, extracts author/caption/media from semantic header/footer structure
 - **Facebook stories** (`fb-stories-extract.js`): Injected into the FB story viewer overlay. Extracts author, media, timestamp, location/check-in. Emits via `fb-feed-data` with `postType: "story"`.
-- **Instagram stories** (`ig-stories-extract.js`): Injected into the IG story viewer overlay. Extracts author handle (from URL + DOM), media URL, timestamp, and location sticker metadata. The normalized `FeedItem.location` now preserves the sticker source plus Instagram `locationUrl`, so later map resolution can recover real place names from generic labels such as `Locations`.
+- **Instagram stories** (`ig-stories-extract.js`): Injected into the IG story viewer overlay. Extracts author handle (from URL + DOM), typed media URLs, timestamp, and location sticker metadata. Timestamp-like fallback story IDs are replaced with stable content hashes. The normalized `FeedItem.location` now preserves the sticker source plus Instagram `locationUrl`, so later map resolution can recover real place names from generic labels such as `Locations`.
 
 Story scraping is interleaved with feed scraping in each session. A coin flip (~50%) determines whether stories are scraped before or after the initial feed passes. ~15% of sessions skip story scraping entirely (real users don't always check stories). Up to 30 story frames are captured per session.
 
@@ -174,9 +174,10 @@ const RATE_LIMITS = {
 - [x] Empty states for both platforms in the feed view
 - [x] Source indicators in sidebar for both platforms
 - [x] Sync indicator panel shows both platforms
+- [x] Direct Facebook and Instagram source views expose All, Posts, and Stories filters in the top toolbar
 - [ ] Facebook feed posts validated against real account (selector tuning)
 - [ ] Instagram feed posts validated against real account (selector tuning)
-- [~] Stories captured, with IG + FB story scraping integrated and Instagram story location URLs preserved for map recovery. Stable IG story IDs and selector tuning still need work.
+- [~] Stories captured, with IG + FB story scraping integrated, Instagram story location URLs preserved for map recovery, playable story video rendering in the feed, stable fallback IG story IDs, and same-platform story duplicate repair. Selector tuning still needs work.
 - [x] Cross-platform dedup (task 7.15): linked Facebook and Instagram stories or posts with similar text now collapse into one item when they land within a few minutes of each other, while preserving saved state, tags, and richer map metadata
 - [x] Like button with outbox pattern: intent recorded immediately, synced to platform async
 - [x] Two-state like UI: "noted" (amber) vs "memorialized" (red confirmed on platform)

--- a/packages/capture-instagram/src/normalize.ts
+++ b/packages/capture-instagram/src/normalize.ts
@@ -24,9 +24,13 @@ function buildAuthor(post: RawIgPost): Author {
 // =============================================================================
 
 function buildContent(post: RawIgPost): Content {
-  const mediaTypes = post.mediaUrls.map((): "image" | "video" => "image");
+  const mediaTypes = post.mediaTypes?.length === post.mediaUrls.length
+    ? post.mediaTypes
+    : post.mediaUrls.map((): "image" | "video" => "image");
   const allMediaTypes: ("image" | "video" | "link")[] =
-    post.isVideo ? ["video", ...mediaTypes.slice(1)] : mediaTypes;
+    post.isVideo && mediaTypes.length > 0 && !post.mediaTypes
+      ? ["video", ...mediaTypes.slice(1)]
+      : mediaTypes;
 
   return {
     ...(post.caption ? { text: post.caption } : {}),

--- a/packages/capture-instagram/src/types.ts
+++ b/packages/capture-instagram/src/types.ts
@@ -71,6 +71,9 @@ export interface RawIgPost {
   /** Image/video URLs */
   mediaUrls: string[];
 
+  /** Media type for each URL when the extractor can distinguish it. */
+  mediaTypes?: Array<"image" | "video">;
+
   /** Whether this is a video/Reel */
   isVideo: boolean;
 

--- a/packages/desktop/src-tauri/src/ig-stories-extract.js
+++ b/packages/desktop/src-tauri/src/ig-stories-extract.js
@@ -35,11 +35,15 @@
 
   // ── Extract story ID from current URL ────────────────────────────────────
 
+  function isLikelyEphemeralStoryId(storyId) {
+    return /^\d{13}$/.test(storyId || "");
+  }
+
   function extractStoryId() {
     var href = window.location.href;
     // /stories/username/<storyId>/
     var m = href.match(/\/stories\/([^/]+)\/([^/?]+)/);
-    if (m) return { username: m[1], storyId: m[2] };
+    if (m) return { username: m[1], storyId: isLikelyEphemeralStoryId(m[2]) ? null : m[2] };
     return { username: null, storyId: null };
   }
 
@@ -144,18 +148,29 @@
 
   function extractMedia(container) {
     var urls = [];
+    var types = [];
     var isVideo = false;
 
     // Video story
     var video = container.querySelector("video");
     if (video) {
       isVideo = true;
-      if (video.src) urls.push(video.src);
-      if (video.poster) urls.push(video.poster);
+      var videoUrl = video.currentSrc || video.src;
+      if (videoUrl && /^https?:\/\//i.test(videoUrl)) {
+        urls.push(videoUrl);
+        types.push("video");
+      }
+      if (video.poster) {
+        urls.push(video.poster);
+        types.push("image");
+      }
       // <source> tags
       var sources = video.querySelectorAll("source");
       for (var s = 0; s < sources.length; s++) {
-        if (sources[s].src) urls.push(sources[s].src);
+        if (sources[s].src && /^https?:\/\//i.test(sources[s].src)) {
+          urls.push(sources[s].src);
+          types.push("video");
+        }
       }
     }
 
@@ -178,10 +193,11 @@
       }
       if (bestImg && bestImg.src) {
         urls.push(bestImg.src);
+        types.push("image");
       }
     }
 
-    return { urls: urls, isVideo: isVideo };
+    return { urls: urls, types: types, isVideo: isVideo };
   }
 
   // ── Extract timestamp ─────────────────────────────────────────────────────
@@ -250,9 +266,15 @@
     var location = extractLocation(container);
 
     // Build a stable ID: story-<storyId> or a hash of author+timestamp
+    var stableSeed = [
+      media.urls[0] || "",
+      location.url || "",
+      location.name || "",
+      timestampIso || "",
+    ].join("||");
     var storyId = urlInfo.storyId
       ? "story_" + urlInfo.storyId
-      : "story_" + contentHash(author.handle || "unknown", media.urls[0] || window.location.href);
+      : "story_" + contentHash(author.handle || "unknown", stableSeed || window.location.pathname);
 
     var post = {
       shortcode: storyId,
@@ -264,6 +286,7 @@
       caption: null,
       timestampIso: timestampIso,
       mediaUrls: media.urls,
+      mediaTypes: media.types,
       isVideo: media.isVideo,
       isCarousel: false,
       likeCount: null,

--- a/packages/desktop/src/lib/ig-stories-extract.test.ts
+++ b/packages/desktop/src/lib/ig-stories-extract.test.ts
@@ -24,7 +24,7 @@ describe("ig-stories-extract.js", () => {
       <div role="dialog">
         <a href="https://www.instagram.com/alice/">alice</a>
         <img src="https://cdn.example/avatar.jpg" alt="avatar" />
-        <img src="https://cdn.example/story-frame.jpg" alt="story" />
+        <img src="https://scontent.example/story-frame.jpg" alt="story" />
         <time datetime="2026-03-23T12:00:00.000Z"></time>
       </div>
     `;
@@ -72,7 +72,14 @@ describe("ig-stories-extract.js", () => {
     const dialog = document.querySelector('[role="dialog"]') as HTMLElement;
     setReadonlyNumber(dialog, "offsetHeight", 800);
 
-    const payloads: Array<{ posts: Array<{ shortcode: string; mediaUrls: string[]; isVideo: boolean }> }> = [];
+    const payloads: Array<{
+      posts: Array<{
+        shortcode: string;
+        mediaUrls: string[];
+        mediaTypes: string[];
+        isVideo: boolean;
+      }>;
+    }> = [];
     (
       window as unknown as {
         __TAURI__: { event: { emit: (_name: string, payload: unknown) => void } };
@@ -82,7 +89,12 @@ describe("ig-stories-extract.js", () => {
         emit: (_name, payload) => {
           payloads.push(
             payload as {
-              posts: Array<{ shortcode: string; mediaUrls: string[]; isVideo: boolean }>;
+              posts: Array<{
+                shortcode: string;
+                mediaUrls: string[];
+                mediaTypes: string[];
+                isVideo: boolean;
+              }>;
             },
           );
         },
@@ -97,5 +109,49 @@ describe("ig-stories-extract.js", () => {
     expect(payloads[0].posts[0].mediaUrls).toContain(
       "https://cdn.example/story-video.mp4",
     );
+    expect(payloads[0].posts[0].mediaTypes).toEqual(["video", "image"]);
+  });
+
+  it("uses a content hash when Instagram exposes a timestamp-like story ID", () => {
+    window.history.replaceState({}, "", "/stories/alice/1774389196662/");
+
+    document.body.innerHTML = `
+      <div role="dialog">
+        <a href="https://www.instagram.com/alice/">alice</a>
+        <img src="https://cdn.example/avatar.jpg" alt="avatar" />
+        <img src="https://scontent.example/story-frame.jpg" alt="story" />
+        <time datetime="2026-03-23T12:00:00.000Z"></time>
+      </div>
+    `;
+
+    const dialog = document.querySelector('[role="dialog"]') as HTMLElement;
+    const images = Array.from(document.querySelectorAll("img")) as HTMLImageElement[];
+    setReadonlyNumber(dialog, "offsetHeight", 800);
+    setReadonlyNumber(images[0], "width", 40);
+    setReadonlyNumber(images[0], "height", 40);
+    setReadonlyNumber(images[1], "width", 1080);
+    setReadonlyNumber(images[1], "height", 1920);
+
+    const payloads: Array<{ posts: Array<{ shortcode: string; mediaTypes: string[] }> }> = [];
+    (
+      window as unknown as {
+        __TAURI__: { event: { emit: (_name: string, payload: unknown) => void } };
+      }
+    ).__TAURI__ = {
+      event: {
+        emit: (_name, payload) => {
+          payloads.push(payload as { posts: Array<{ shortcode: string; mediaTypes: string[] }> });
+        },
+      },
+    };
+
+    window.eval(script);
+    window.history.replaceState({}, "", "/stories/alice/1774389204187/");
+    window.eval(script);
+
+    expect(payloads).toHaveLength(2);
+    expect(payloads[0].posts[0].shortcode).toMatch(/^story_[a-z0-9]+$/);
+    expect(payloads[1].posts[0].shortcode).toBe(payloads[0].posts[0].shortcode);
+    expect(payloads[0].posts[0].mediaTypes).toEqual(["image"]);
   });
 });

--- a/packages/desktop/src/lib/instagram-normalize.test.ts
+++ b/packages/desktop/src/lib/instagram-normalize.test.ts
@@ -57,4 +57,32 @@ describe("igPostToFeedItem", () => {
       source: "geo_tag",
     });
   });
+
+  it("uses extractor media types when they are provided", () => {
+    const item = igPostToFeedItem({
+      shortcode: "story_video",
+      url: "https://www.instagram.com/stories/ada/story_video/",
+      authorHandle: "ada",
+      authorDisplayName: "Ada",
+      authorAvatarUrl: null,
+      authorProfileUrl: "https://www.instagram.com/ada/",
+      caption: null,
+      timestampIso: "2026-04-16T22:00:00.000Z",
+      mediaUrls: [
+        "https://cdn.example/story-video.mp4",
+        "https://cdn.example/story-poster.jpg",
+      ],
+      mediaTypes: ["video", "image"],
+      isVideo: true,
+      isCarousel: false,
+      likeCount: null,
+      commentCount: null,
+      hashtags: [],
+      location: null,
+      locationUrl: null,
+      postType: "story",
+    });
+
+    expect(item?.content.mediaTypes).toEqual(["video", "image"]);
+  });
 });

--- a/packages/desktop/tests/e2e/social-story-filter.spec.ts
+++ b/packages/desktop/tests/e2e/social-story-filter.spec.ts
@@ -1,0 +1,112 @@
+import { test, expect } from "./fixtures/app";
+
+async function injectInstagramItems(page: import("@playwright/test").Page): Promise<void> {
+  await page.evaluate(async () => {
+    const now = Date.now();
+    const w = window as Record<string, unknown>;
+    const automerge = w.__FREED_AUTOMERGE__ as {
+      docBatchImportItems: (items: unknown[]) => Promise<unknown>;
+    };
+
+    await automerge.docBatchImportItems([
+      {
+        globalId: "test-instagram-filter-post",
+        platform: "instagram",
+        contentType: "post",
+        capturedAt: now - 30_000,
+        publishedAt: now - 60_000,
+        author: {
+          id: "ig:social-filter",
+          handle: "social.filter",
+          displayName: "Social Filter",
+        },
+        content: {
+          text: "Instagram filter post item",
+          mediaUrls: [],
+          mediaTypes: [],
+        },
+        userState: { hidden: false, saved: false, archived: false, tags: [] },
+        topics: [],
+        sourceUrl: "https://www.instagram.com/p/social-filter-post/",
+      },
+      {
+        globalId: "test-instagram-filter-video",
+        platform: "instagram",
+        contentType: "video",
+        capturedAt: now - 20_000,
+        publishedAt: now - 50_000,
+        author: {
+          id: "ig:social-filter",
+          handle: "social.filter",
+          displayName: "Social Filter",
+        },
+        content: {
+          text: "Instagram filter reel item",
+          mediaUrls: [],
+          mediaTypes: [],
+        },
+        userState: { hidden: false, saved: false, archived: false, tags: [] },
+        topics: [],
+        sourceUrl: "https://www.instagram.com/reel/social-filter-video/",
+      },
+      {
+        globalId: "test-instagram-filter-story",
+        platform: "instagram",
+        contentType: "story",
+        capturedAt: now - 10_000,
+        publishedAt: now - 40_000,
+        author: {
+          id: "ig:social-filter",
+          handle: "social.filter",
+          displayName: "Social Filter",
+        },
+        content: {
+          text: "Instagram filter story item",
+          mediaUrls: ["https://cdn.example.com/social-filter-story.jpg"],
+          mediaTypes: ["image"],
+        },
+        userState: { hidden: false, saved: false, archived: false, tags: [] },
+        topics: [],
+        sourceUrl: "https://www.instagram.com/stories/social.filter/story/",
+      },
+    ]);
+  });
+
+  await page.waitForFunction(() => {
+    const w = window as Record<string, unknown>;
+    const store = w.__FREED_STORE__ as
+      | { getState: () => { items: Array<{ globalId: string }> } }
+      | undefined;
+    const ids = new Set(store?.getState().items.map((item) => item.globalId) ?? []);
+    return ids.has("test-instagram-filter-post") && ids.has("test-instagram-filter-story");
+  });
+}
+
+test("Instagram source toolbar filters posts, stories, and all items", async ({ app, page }) => {
+  await app.goto();
+  await app.waitForReady();
+  await injectInstagramItems(page);
+
+  await page.getByTestId("source-row-instagram").first().click();
+  const filter = page.getByTestId("social-content-toolbar-filter");
+  await expect(filter).toBeVisible();
+
+  await expect(page.getByText("Instagram filter post item")).toBeVisible();
+  await expect(page.getByText("Instagram filter reel item")).toBeVisible();
+  await expect(page.getByText("Instagram filter story item")).toBeVisible();
+
+  await filter.getByRole("button", { name: "Stories" }).click();
+  await expect(page.getByText("Instagram filter story item")).toBeVisible();
+  await expect(page.getByText("Instagram filter post item")).toBeHidden();
+  await expect(page.getByText("Instagram filter reel item")).toBeHidden();
+
+  await filter.getByRole("button", { name: "Posts" }).click();
+  await expect(page.getByText("Instagram filter post item")).toBeVisible();
+  await expect(page.getByText("Instagram filter reel item")).toBeVisible();
+  await expect(page.getByText("Instagram filter story item")).toBeHidden();
+
+  await filter.getByRole("button", { name: "All" }).click();
+  await expect(page.getByText("Instagram filter post item")).toBeVisible();
+  await expect(page.getByText("Instagram filter reel item")).toBeVisible();
+  await expect(page.getByText("Instagram filter story item")).toBeVisible();
+});

--- a/packages/pwa/src/lib/ranking.test.ts
+++ b/packages/pwa/src/lib/ranking.test.ts
@@ -297,4 +297,52 @@ describe("filterFeedItems", () => {
     expect(result).toHaveLength(1);
     expect(result[0].globalId).toBe("visible-x");
   });
+
+  it("filters Facebook and Instagram source views by posts and stories", () => {
+    const socialItems: FeedItem[] = [
+      makeItem({ globalId: "ig-post", platform: "instagram", contentType: "post" }),
+      makeItem({ globalId: "ig-video", platform: "instagram", contentType: "video" }),
+      makeItem({ globalId: "ig-story", platform: "instagram", contentType: "story" }),
+      makeItem({ globalId: "fb-post", platform: "facebook", contentType: "post" }),
+      makeItem({ globalId: "fb-story", platform: "facebook", contentType: "story" }),
+      makeItem({ globalId: "rss-story", platform: "rss", contentType: "story" }),
+    ];
+
+    expect(
+      filterFeedItems(socialItems, {
+        platform: "instagram",
+        socialContentFilter: "posts",
+      }).map((item) => item.globalId),
+    ).toEqual(["ig-post", "ig-video"]);
+    expect(
+      filterFeedItems(socialItems, {
+        platform: "instagram",
+        socialContentFilter: "stories",
+      }).map((item) => item.globalId),
+    ).toEqual(["ig-story"]);
+    expect(
+      filterFeedItems(socialItems, {
+        platform: "facebook",
+        socialContentFilter: "stories",
+      }).map((item) => item.globalId),
+    ).toEqual(["fb-story"]);
+  });
+
+  it("ignores the social content filter outside direct Facebook and Instagram sources", () => {
+    const mixedItems: FeedItem[] = [
+      makeItem({ globalId: "rss-article", platform: "rss", contentType: "article" }),
+      makeItem({ globalId: "rss-story", platform: "rss", contentType: "story" }),
+      makeItem({ globalId: "ig-story", platform: "instagram", contentType: "story" }),
+    ];
+
+    expect(
+      filterFeedItems(mixedItems, { socialContentFilter: "posts" }).map((item) => item.globalId),
+    ).toEqual(["rss-article", "rss-story", "ig-story"]);
+    expect(
+      filterFeedItems(mixedItems, {
+        platform: "rss",
+        socialContentFilter: "posts",
+      }).map((item) => item.globalId),
+    ).toEqual(["rss-article", "rss-story"]);
+  });
 });

--- a/packages/pwa/src/lib/schema.test.ts
+++ b/packages/pwa/src/lib/schema.test.ts
@@ -347,6 +347,65 @@ describe("deduplicateDocFeedItems", () => {
 
     expect(Object.keys(doc.feedItems)).toHaveLength(2);
   });
+
+  it("deduplicates same-platform stories with unstable captured story IDs", () => {
+    let doc = createEmptyDoc();
+
+    doc = A.change(doc, (d) => {
+      addFeedItem(d, makeItem({
+        globalId: "ig:story_ada_1774389196662",
+        platform: "instagram",
+        contentType: "story",
+        publishedAt: 1_774_389_007_000,
+        author: { id: "ig:ada", handle: "ada", displayName: "Ada" },
+        content: {
+          text: "",
+          mediaUrls: ["https://cdn.example/story-video.mp4"],
+          mediaTypes: ["video"],
+        },
+        location: {
+          name: "Big Bear, California",
+          source: "sticker",
+          url: "https://www.instagram.com/explore/locations/123/big-bear-california/",
+        },
+        userState: {
+          hidden: false,
+          saved: true,
+          savedAt: 1_774_389_200_000,
+          archived: false,
+          tags: ["trip"],
+        },
+      }));
+
+      addFeedItem(d, makeItem({
+        globalId: "ig:story_ada_1774389204187",
+        platform: "instagram",
+        contentType: "story",
+        publishedAt: 1_774_389_007_000,
+        author: { id: "ig:ada", handle: "ada", displayName: "Ada" },
+        content: {
+          text: "",
+          mediaUrls: ["https://cdn.example/story-video.mp4"],
+          mediaTypes: ["video"],
+        },
+        location: {
+          name: "Big Bear, California",
+          source: "sticker",
+          url: "https://www.instagram.com/explore/locations/123/big-bear-california/",
+        },
+      }));
+
+      deduplicateDocFeedItems(d);
+    });
+
+    expect(Object.keys(doc.feedItems)).toHaveLength(1);
+    const [survivor] = Object.values(doc.feedItems);
+    expect(survivor.platform).toBe("instagram");
+    expect(survivor.contentType).toBe("story");
+    expect(survivor.userState.saved).toBe(true);
+    expect(survivor.userState.tags).toContain("trip");
+    expect(survivor.content.mediaUrls).toContain("https://cdn.example/story-video.mp4");
+  });
 });
 
 // =============================================================================

--- a/packages/shared/src/navigation-state.ts
+++ b/packages/shared/src/navigation-state.ts
@@ -29,6 +29,12 @@ function uniqueSortedTags(tags: readonly string[] | undefined): string[] {
   );
 }
 
+function normalizeSocialContentFilter(
+  value: FilterOptions["socialContentFilter"] | null | undefined,
+): FilterOptions["socialContentFilter"] | undefined {
+  return value === "posts" || value === "stories" ? value : undefined;
+}
+
 export function canonicalizeFilterOptions(filter: FilterOptions): FilterOptions {
   if (filter.savedOnly) return { savedOnly: true };
   if (filter.archivedOnly) return { archivedOnly: true };
@@ -36,10 +42,15 @@ export function canonicalizeFilterOptions(filter: FilterOptions): FilterOptions 
   const tags = uniqueSortedTags(filter.tags);
   const feedUrl = normalizeText(filter.feedUrl);
   const platform = feedUrl ? "rss" : normalizeText(filter.platform) ?? undefined;
+  const socialContentFilter =
+    platform === "facebook" || platform === "instagram"
+      ? normalizeSocialContentFilter(filter.socialContentFilter)
+      : undefined;
   const next: FilterOptions = {};
 
   if (platform) next.platform = platform;
   if (feedUrl) next.feedUrl = feedUrl;
+  if (socialContentFilter) next.socialContentFilter = socialContentFilter;
   if (tags.length > 0) next.tags = tags;
 
   return next;
@@ -98,6 +109,7 @@ export function parseNavigationState(input: string | NavigationPathLike): Naviga
   const scope = normalizeText(params.get("scope"));
   const feedUrl = normalizeText(params.get("feed"));
   const platform = normalizeText(params.get("platform"));
+  const socialContentFilter = normalizeSocialContentFilter(params.get("content") as FilterOptions["socialContentFilter"] | null);
   const tags = uniqueSortedTags(params.getAll("tag"));
 
   let activeFilter: FilterOptions;
@@ -111,6 +123,7 @@ export function parseNavigationState(input: string | NavigationPathLike): Naviga
   } else {
     activeFilter = {};
     if (platform) activeFilter.platform = platform;
+    if (socialContentFilter) activeFilter.socialContentFilter = socialContentFilter;
     if (tags.length > 0) activeFilter.tags = tags;
   }
 
@@ -146,6 +159,10 @@ export function serializeNavigationState(state: NavigationState): string {
       params.set("platform", activeFilter.platform);
     }
 
+    if (activeFilter.socialContentFilter && activeFilter.socialContentFilter !== "all") {
+      params.set("content", activeFilter.socialContentFilter);
+    }
+
     for (const tag of uniqueSortedTags(activeFilter.tags)) {
       params.append("tag", tag);
     }
@@ -170,6 +187,7 @@ export function navigationStatesEqual(a: NavigationState, b: NavigationState): b
     && left.selectedItemId === right.selectedItemId
     && left.activeFilter.platform === right.activeFilter.platform
     && left.activeFilter.feedUrl === right.activeFilter.feedUrl
+    && (left.activeFilter.socialContentFilter ?? "all") === (right.activeFilter.socialContentFilter ?? "all")
     && !!left.activeFilter.savedOnly === !!right.activeFilter.savedOnly
     && !!left.activeFilter.archivedOnly === !!right.activeFilter.archivedOnly
     && leftTags.length === rightTags.length

--- a/packages/shared/src/ranking.ts
+++ b/packages/shared/src/ranking.ts
@@ -6,6 +6,7 @@
  */
 
 import type { FeedItem, WeightPreferences } from "./types.js";
+import type { SocialContentFilter } from "./store-types.js";
 
 /**
  * Default weights for ranking factors
@@ -137,6 +138,7 @@ export function filterFeedItems(
     /** Show only archived items (the Archived view). Mutually exclusive with normal feed. */
     archivedOnly?: boolean;
     platform?: string;
+    socialContentFilter?: SocialContentFilter;
     tags?: string[];
     savedOnly?: boolean;
   } = {},
@@ -154,6 +156,15 @@ export function filterFeedItems(
 
     // Filter by platform
     if (options.platform && item.platform !== options.platform) return false;
+
+    if (
+      (options.platform === "facebook" || options.platform === "instagram") &&
+      options.socialContentFilter &&
+      options.socialContentFilter !== "all"
+    ) {
+      if (options.socialContentFilter === "stories" && item.contentType !== "story") return false;
+      if (options.socialContentFilter === "posts" && item.contentType === "story") return false;
+    }
 
     // Filter by saved status
     if (options.savedOnly && !item.userState.saved) return false;

--- a/packages/shared/src/schema.ts
+++ b/packages/shared/src/schema.ts
@@ -377,6 +377,7 @@ const CROSS_POST_PLATFORMS = new Set<FeedItem["platform"]>([
   "facebook",
   "instagram",
 ]);
+const SAME_PLATFORM_STORY_DEDUP_WINDOW_MS = 10 * 60 * 1000;
 
 type LegacyFriendRoot = FreedDoc & {
   friends?: Record<string, Friend>;
@@ -433,6 +434,43 @@ function normalizedDedupText(item: FeedItem): string | null {
     .trim();
   if (normalized.length < CROSS_POST_MIN_TEXT_LENGTH) return null;
   return normalized.slice(0, CROSS_POST_TEXT_PREFIX_LENGTH).trim();
+}
+
+function normalizedStoryDedupText(item: FeedItem): string {
+  return (item.content.text ?? "")
+    .toLowerCase()
+    .replace(/https?:\/\/\S+/g, " ")
+    .replace(/www\.\S+/g, " ")
+    .replace(/[^\p{L}\p{N}]+/gu, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, CROSS_POST_TEXT_PREFIX_LENGTH);
+}
+
+function normalizedStoryMediaKey(item: FeedItem): string {
+  return item.content.mediaUrls[0] ?? item.sourceUrl ?? "";
+}
+
+function samePlatformStoryDedupKey(item: FeedItem): string | null {
+  if (!CROSS_POST_PLATFORMS.has(item.platform)) return null;
+  if (item.contentType !== "story") return null;
+
+  const mediaKey = normalizedStoryMediaKey(item);
+  const textKey = normalizedStoryDedupText(item);
+  if (!mediaKey && !textKey) return null;
+
+  const authorKey = item.author.id || item.author.handle || item.author.displayName;
+  const publishedBucket = Math.floor(item.publishedAt / SAME_PLATFORM_STORY_DEDUP_WINDOW_MS);
+  const locationKey = item.location?.url ?? item.location?.name ?? "";
+
+  return [
+    item.platform,
+    authorKey,
+    publishedBucket.toString(),
+    mediaKey,
+    locationKey,
+    textKey,
+  ].join("::");
 }
 
 function dedupIdentityKey(doc: FreedDoc, item: FeedItem): string | null {
@@ -726,6 +764,19 @@ export function deduplicateDocFeedItems(doc: FreedDoc): number {
   }
 
   for (const ids of exactUrlGroups.values()) {
+    addDedupGroup(unions, ids);
+  }
+
+  const samePlatformStoryGroups = new Map<string, string[]>();
+  for (const item of Object.values(doc.feedItems) as FeedItem[]) {
+    const groupKey = samePlatformStoryDedupKey(item);
+    if (!groupKey) continue;
+    const group = samePlatformStoryGroups.get(groupKey);
+    if (group) group.push(item.globalId);
+    else samePlatformStoryGroups.set(groupKey, [item.globalId]);
+  }
+
+  for (const ids of samePlatformStoryGroups.values()) {
     addDedupGroup(unions, ids);
   }
 

--- a/packages/shared/src/store-types.ts
+++ b/packages/shared/src/store-types.ts
@@ -11,6 +11,8 @@ export interface RemoveFeedOptions {
   includeItems?: boolean;
 }
 
+export type SocialContentFilter = "all" | "posts" | "stories";
+
 /**
  * Filter options for the feed view.
  * Duplicated in both PWA and Desktop stores — canonicalized here.
@@ -20,6 +22,8 @@ export interface FilterOptions {
   feedUrl?: string;
   tags?: string[];
   savedOnly?: boolean;
+  /** Direct Facebook and Instagram source views only. */
+  socialContentFilter?: SocialContentFilter;
   /** Navigate to the Archived view - shows only archived items. */
   archivedOnly?: boolean;
 }

--- a/packages/ui/src/components/feed/FeedItem.test.tsx
+++ b/packages/ui/src/components/feed/FeedItem.test.tsx
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
 import type { FeedItem as FeedItemType } from "@freed/shared";
+import { PlatformProvider, type PlatformConfig } from "../../context/PlatformContext.js";
 import { FeedItem } from "./FeedItem";
 
 const NOW = 1_712_147_200_000;
@@ -57,25 +60,45 @@ function makeItem(overrides: FeedItemOverrides = {}): FeedItemType {
   };
 }
 
+const platformConfig = {
+  feedMediaPreviews: "inline",
+  store: () => undefined,
+  SourceIndicator: null,
+  HeaderSyncIndicator: null,
+  SettingsExtraSections: null,
+  LegalSettingsContent: null,
+  FeedEmptyState: null,
+  XSettingsContent: null,
+  FacebookSettingsContent: null,
+  InstagramSettingsContent: null,
+  LinkedInSettingsContent: null,
+  GoogleContactsSettingsContent: null,
+} as unknown as PlatformConfig;
+
+function renderFeedItemToStaticMarkup(item: FeedItemType): string {
+  return renderToStaticMarkup(
+    <PlatformProvider value={platformConfig}>
+      <FeedItem item={item} />
+    </PlatformProvider>,
+  );
+}
+
 describe("FeedItem read styling", () => {
   it("applies read styling to story tiles", () => {
-    const html = renderToStaticMarkup(
-      <FeedItem item={makeItem({ userState: { readAt: NOW } })} />,
-    );
+    const html = renderFeedItemToStaticMarkup(makeItem({ userState: { readAt: NOW } }));
 
     expect(html).toContain("grayscale opacity-60");
   });
 
   it("leaves unread story tiles unstyled", () => {
-    const html = renderToStaticMarkup(<FeedItem item={makeItem()} />);
+    const html = renderFeedItemToStaticMarkup(makeItem());
 
     expect(html).not.toContain("grayscale opacity-60");
   });
 
   it("keeps regular feed cards styled as read", () => {
-    const html = renderToStaticMarkup(
-      <FeedItem
-        item={makeItem({
+    const html = renderFeedItemToStaticMarkup(
+      makeItem({
           globalId: "item-2",
           platform: "facebook",
           contentType: "post",
@@ -85,10 +108,68 @@ describe("FeedItem read styling", () => {
             mediaTypes: [],
           },
           userState: { readAt: NOW },
-        })}
-      />,
+        }),
     );
 
     expect(html).toContain("grayscale opacity-60");
+  });
+});
+
+describe("FeedItem story media", () => {
+  it("renders image stories as images", () => {
+    const html = renderFeedItemToStaticMarkup(makeItem());
+
+    expect(html).toContain("<img");
+    expect(html).toContain("https://example.com/story.jpg");
+    expect(html).not.toContain("<video");
+  });
+
+  it("renders video stories as playable videos", () => {
+    const html = renderFeedItemToStaticMarkup(
+      makeItem({
+          content: {
+            mediaUrls: ["https://example.com/story.mp4"],
+            mediaTypes: ["video"],
+          },
+        }),
+    );
+
+    expect(html).toContain("<video");
+    expect(html).toContain("controls=");
+    expect(html).toContain("playsInline=");
+    expect(html).toContain("https://example.com/story.mp4");
+  });
+
+  it("falls back to the gradient when story media fails", async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root: Root = createRoot(container);
+
+    try {
+      await act(async () => {
+        root.render(
+          <PlatformProvider value={platformConfig}>
+            <FeedItem item={makeItem()} />
+          </PlatformProvider>,
+        );
+      });
+
+      const image = container.querySelector("img[src='https://example.com/story.jpg']");
+      expect(image).toBeInstanceOf(HTMLImageElement);
+
+      await act(async () => {
+        image?.dispatchEvent(new Event("error", { bubbles: true }));
+      });
+
+      expect(container.querySelector("img[src='https://example.com/story.jpg']")).toBeNull();
+      expect(container.querySelector(".bg-gradient-to-br")).not.toBeNull();
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+      (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = false;
+    }
   });
 });

--- a/packages/ui/src/components/feed/FeedItem.tsx
+++ b/packages/ui/src/components/feed/FeedItem.tsx
@@ -1,4 +1,4 @@
-import { memo, useRef, useState, type KeyboardEvent, type MouseEvent, type ReactNode } from "react";
+import { memo, useEffect, useRef, useState, type KeyboardEvent, type MouseEvent, type ReactNode } from "react";
 import { formatDistanceToNow } from "date-fns";
 import { PLATFORM_LABELS, type FeedItem as FeedItemType } from "@freed/shared";
 import { usePlatform } from "../../context/PlatformContext.js";
@@ -153,10 +153,15 @@ export const FeedItem = memo(function FeedItem({
   const commentCount = formatEngagementCount(item.engagement?.comments);
 
   const [swipeX, setSwipeX] = useState(0);
+  const [storyMediaFailed, setStoryMediaFailed] = useState(false);
   const showInlineMedia = feedMediaPreviews === "inline";
   const touchStartX = useRef(0);
   const touchStartY = useRef(0);
   const swipeLocked = useRef<"horizontal" | "vertical" | null>(null);
+
+  useEffect(() => {
+    setStoryMediaFailed(false);
+  }, [item.content.mediaUrls[0], item.globalId]);
 
   const handleTouchStart = (e: React.TouchEvent) => {
     touchStartX.current = e.touches[0].clientX;
@@ -204,6 +209,8 @@ export const FeedItem = memo(function FeedItem({
 
   if (item.contentType === "story") {
     const bg = item.content.mediaUrls[0];
+    const firstMediaType = item.content.mediaTypes[0];
+    const showStoryMedia = showInlineMedia && bg && !storyMediaFailed;
     const isIg = item.platform === "instagram";
     const gradientFallback = isIg
       ? "from-[var(--theme-media-rss)] via-[var(--theme-media-instagram)] to-[var(--theme-accent-secondary)]"
@@ -221,12 +228,24 @@ export const FeedItem = memo(function FeedItem({
         tabIndex={0}
         onKeyDown={handleActivateKeyDown}
       >
-        {showInlineMedia && bg ? (
+        {showStoryMedia && firstMediaType === "video" ? (
+          <video
+            src={bg}
+            muted
+            playsInline
+            controls
+            preload="metadata"
+            onClick={(event) => event.stopPropagation()}
+            onError={() => setStoryMediaFailed(true)}
+            className="absolute inset-0 w-full h-full object-cover"
+          />
+        ) : showStoryMedia ? (
           <img
             src={bg}
             alt=""
             loading="lazy"
             decoding="async"
+            onError={() => setStoryMediaFailed(true)}
             className="absolute inset-0 w-full h-full object-cover transition-transform duration-300 group-hover:scale-[1.03]"
           />
         ) : (

--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -18,6 +18,7 @@ import {
   type MapMode,
   type MapTimeMode,
   type SidebarMode,
+  type SocialContentFilter,
   resolveMapMode,
 } from "@freed/shared";
 import { SearchField } from "../SearchField.js";
@@ -222,6 +223,7 @@ export function Header({
   const toggleArchived = useAppStore((s) => s.toggleArchived);
   const updatePreferences = useAppStore((s) => s.updatePreferences);
   const setSelectedItem = useAppStore((s) => s.setSelectedItem);
+  const setFilter = useAppStore((s) => s.setFilter);
   const setSearchQuery = useAppStore((s) => s.setSearchQuery);
   const display = useAppStore((s) => s.preferences.display);
 
@@ -269,6 +271,12 @@ export function Header({
   const showFeedBulkActions = activeView === "feed";
   const showArchivedToolbar = activeView === "feed" && activeFilter.archivedOnly === true;
   const showArchivedDeleteAction = showArchivedToolbar && (display.archivePruneDays ?? 30) > 0;
+  const showSocialContentControls =
+    activeView === "feed" &&
+    !selectedItem &&
+    !activeFilter.feedUrl &&
+    (activeFilter.platform === "facebook" || activeFilter.platform === "instagram");
+  const socialContentFilter: SocialContentFilter = activeFilter.socialContentFilter ?? "all";
 
   const unreadCount =
     activeFilter.savedOnly || activeFilter.archivedOnly
@@ -285,6 +293,19 @@ export function Header({
         : activeFilter.platform
           ? (archivableCountByPlatform[activeFilter.platform] ?? 0)
           : totalArchivableCount;
+
+  const handleSocialContentFilterChange = useCallback(
+    (value: SocialContentFilter) => {
+      const nextFilter = { ...activeFilter };
+      if (value === "all") {
+        delete nextFilter.socialContentFilter;
+      } else {
+        nextFilter.socialContentFilter = value;
+      }
+      setFilter(nextFilter);
+    },
+    [activeFilter, setFilter],
+  );
 
   const currentTitle = useMemo(() => {
     if (selectedItem) {
@@ -1116,6 +1137,23 @@ export function Header({
                     >
                       {deleteConfirmArmed ? "Confirm delete?" : "Delete archived"}
                     </button>
+                  ) : null}
+                </ToolbarAnimatedSlot>
+
+                <ToolbarAnimatedSlot visible={showSocialContentControls} width="11rem" className="hidden md:flex">
+                  {showSocialContentControls ? (
+                    <ToolbarToggleGroup
+                      dataTestId="social-content-toolbar-filter"
+                      options={[
+                        { value: "all", label: "All" },
+                        { value: "posts", label: "Posts" },
+                        { value: "stories", label: "Stories" },
+                      ]}
+                      value={socialContentFilter}
+                      onChange={handleSocialContentFilterChange}
+                      compact
+                      getButtonProps={getToolbarControlProps}
+                    />
                   ) : null}
                 </ToolbarAnimatedSlot>
 

--- a/website/src/app/roadmap/RoadmapContent.tsx
+++ b/website/src/app/roadmap/RoadmapContent.tsx
@@ -756,7 +756,7 @@ const phases: Phase[] = [
     number: 7,
     title: "Facebook + Instagram",
     description:
-      "Facebook and Instagram integrated via Tauri WebView scraping, with suggested-post filtering, hardened story capture, silent background media guarding, serialized background scraper sessions, Facebook group controls, provider health summaries, and smart backoff when sync looks rate-limited.",
+      "Facebook and Instagram integrated via Tauri WebView scraping, with suggested-post filtering, source-level post and story filters, hardened playable story capture, same-platform story duplicate repair, silent background media guarding, serialized background scraper sessions, Facebook group controls, provider health summaries, and smart backoff when sync looks rate-limited.",
     status: "current",
     planLink:
       "https://github.com/freed-project/freed/blob/dev/docs/PHASE-7-SOCIAL-CAPTURE.md",


### PR DESCRIPTION
(AI Generated).

## Summary
- Adds All, Posts, and Stories filtering for direct Facebook and Instagram source views.
- Renders playable story videos, keeps image stories, and falls back to the existing gradient on missing or failed media.
- Repairs same-platform social story duplicates and stabilizes Instagram fallback story IDs.

## Testing
- npm run validate:feature
- npm run test:e2e -- social-story-filter.spec.ts