### PR TITLE
fix: remember desktop release channel

### DIFF
--- a/packages/desktop/src/App.tsx
+++ b/packages/desktop/src/App.tsx
@@ -81,6 +81,8 @@ import { clearFatalRuntimeError, useFatalRuntimeError } from "@freed/ui/lib/bug-
 import { startMemoryMonitor, stopMemoryMonitor } from "./lib/memory-monitor";
 import {
   bootstrapDesktopReleaseChannel,
+  loadDesktopReleaseChannelState,
+  persistDesktopInstalledReleaseChannel,
   persistDesktopReleaseChannel,
 } from "./lib/release-channel";
 import {
@@ -124,9 +126,35 @@ function App() {
   const [releaseChannel, setReleaseChannelState] = useState<ReleaseChannel>(() =>
     bootstrapDesktopReleaseChannel(),
   );
+  const [installedReleaseChannel, setInstalledReleaseChannel] = useState<ReleaseChannel>(() =>
+    bootstrapDesktopReleaseChannel(),
+  );
+  const [releaseChannelResolved, setReleaseChannelResolved] = useState(IS_LOCAL_PREVIEW);
   const fatalError = useFatalRuntimeError();
 
   useDesktopNavigationHistory(legalAccepted);
+
+  useEffect(() => {
+    if (IS_LOCAL_PREVIEW) return;
+
+    let cancelled = false;
+    void loadDesktopReleaseChannelState()
+      .then(({ selectedChannel, installedChannel }) => {
+        if (!cancelled) {
+          setReleaseChannelState(selectedChannel);
+          setInstalledReleaseChannel(installedChannel);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setReleaseChannelResolved(true);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   useEffect(() => {
     void hasAcceptedDesktopBundle()
@@ -331,7 +359,7 @@ function App() {
 
   // Check once at launch, then continue polling in the background every 30 minutes.
   useEffect(() => {
-    if (!legalAccepted || IS_LOCAL_PREVIEW) return;
+    if (!legalAccepted || IS_LOCAL_PREVIEW || !releaseChannelResolved) return;
 
     async function poll() {
       try {
@@ -349,7 +377,7 @@ function App() {
     return () => {
       clearInterval(interval);
     };
-  }, [legalAccepted, runDesktopUpdateCheck]);
+  }, [legalAccepted, releaseChannelResolved, runDesktopUpdateCheck]);
 
   // Manual check triggered from Settings panel.
   const checkForUpdates = useCallback(async (): Promise<AvailableUpdateInfo | null> => {
@@ -361,7 +389,7 @@ function App() {
 
   // Recovery mode should trigger its own immediate update check.
   useEffect(() => {
-    if (!legalAccepted || IS_LOCAL_PREVIEW || !isCrashState) {
+    if (!legalAccepted || IS_LOCAL_PREVIEW || !releaseChannelResolved || !isCrashState) {
       crashRecoveryUpdateCheckStarted.current = false;
       return;
     }
@@ -370,7 +398,7 @@ function App() {
     void runDesktopUpdateCheck({ showCheckingState: false }).catch(() => {
       // Silent. Recovery still exposes the manual download path.
     });
-  }, [isCrashState, legalAccepted, runDesktopUpdateCheck]);
+  }, [isCrashState, legalAccepted, releaseChannelResolved, runDesktopUpdateCheck]);
 
   // Download + install with progress, then relaunch. Used by both the toast
   // and the "Install & Restart" button in Settings via PlatformContext.
@@ -393,6 +421,9 @@ function App() {
       });
 
       // Persist the installed version across the relaunch so we can greet the user.
+      await persistDesktopInstalledReleaseChannel(pending.channel);
+      setInstalledReleaseChannel(pending.channel);
+      await persistDesktopReleaseChannel(releaseChannel);
       localStorage.setItem(JUST_UPDATED_KEY, version);
       await relaunch();
     } catch (err) {
@@ -401,19 +432,19 @@ function App() {
         message: err instanceof Error ? err.message : "Update failed",
       });
     }
-  }, []);
+  }, [releaseChannel]);
 
   const handleRelaunch = useCallback(() => relaunch(), []);
   const handleDismissUpdate = useCallback(() => setUpdateState({ phase: "idle" }), []);
   const handleOpenLatestDownload = useCallback(() => {
     void shellOpen(fallbackDownloadUrl);
   }, [fallbackDownloadUrl]);
-  const setReleaseChannel = useCallback((channel: ReleaseChannel) => {
+  const setReleaseChannel = useCallback(async (channel: ReleaseChannel) => {
     if (channel === releaseChannel) {
       return;
     }
 
-    persistDesktopReleaseChannel(channel);
+    await persistDesktopReleaseChannel(channel);
     pendingUpdate.current = null;
     setUpdateState({ phase: "idle" });
     setReleaseChannelState(channel);
@@ -542,8 +573,9 @@ function App() {
       GoogleContactsSettingsContent: GoogleContactsSection,
       checkForUpdates: IS_LOCAL_PREVIEW ? undefined : checkForUpdates,
       applyUpdate: IS_LOCAL_PREVIEW ? undefined : applyUpdate,
-      releaseChannel: IS_LOCAL_PREVIEW ? undefined : releaseChannel,
-      setReleaseChannel: IS_LOCAL_PREVIEW ? undefined : setReleaseChannel,
+      releaseChannel: IS_LOCAL_PREVIEW || !releaseChannelResolved ? undefined : releaseChannel,
+      installedReleaseChannel: IS_LOCAL_PREVIEW || !releaseChannelResolved ? undefined : installedReleaseChannel,
+      setReleaseChannel: IS_LOCAL_PREVIEW || !releaseChannelResolved ? undefined : setReleaseChannel,
       factoryReset: handleFactoryReset,
       seedSocialConnections,
       activeCloudProviderLabel: () => {
@@ -639,7 +671,7 @@ function App() {
       })(),
       bugReporting: desktopBugReporting,
     }),
-     [checkForUpdates, applyUpdate, connectGoogleContacts, handleFactoryReset, reconnectCloudProvider, releaseChannel, retryCloudProvider, seedSocialConnections, setReleaseChannel, updateState],
+     [checkForUpdates, applyUpdate, connectGoogleContacts, handleFactoryReset, installedReleaseChannel, reconnectCloudProvider, releaseChannel, releaseChannelResolved, retryCloudProvider, seedSocialConnections, setReleaseChannel, updateState],
   );
 
   if (!legalResolved) {
@@ -718,7 +750,7 @@ function App() {
                     <path d="M3 8l3.5 3.5L13 5" stroke="#22c55e" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
                   </svg>
                   <span className="text-sm text-text-primary">
-                    Updated to <span className="font-mono font-bold">v{formatReleaseVersion(justUpdated)}</span>
+                    Updated to <span className="font-mono font-bold">v{formatReleaseVersion(justUpdated, installedReleaseChannel)}</span>
                   </span>
                 </div>
               </div>

--- a/packages/desktop/src/components/StartupRecoveryScreen.tsx
+++ b/packages/desktop/src/components/StartupRecoveryScreen.tsx
@@ -14,7 +14,12 @@ import {
   type PendingDesktopUpdate,
   resolveDesktopDownloadFallbackUrl,
 } from "../lib/desktop-updater";
-import { bootstrapDesktopReleaseChannel } from "../lib/release-channel";
+import {
+  bootstrapDesktopReleaseChannel,
+  loadDesktopReleaseChannelState,
+  persistDesktopInstalledReleaseChannel,
+  persistDesktopReleaseChannel,
+} from "../lib/release-channel";
 import { extractUpdatePreviewLine } from "../lib/update-release-preview";
 
 type RecoveryStatus =
@@ -27,7 +32,11 @@ type RecoveryStatus =
 const RETRY_COMMAND = "retry_startup_after_crash";
 
 export function StartupRecoveryScreen() {
-  const [releaseChannel] = useState(() => bootstrapDesktopReleaseChannel());
+  const [releaseChannel, setReleaseChannel] = useState(() => bootstrapDesktopReleaseChannel());
+  const [installedReleaseChannel, setInstalledReleaseChannel] = useState(() =>
+    bootstrapDesktopReleaseChannel(),
+  );
+  const [releaseChannelResolved, setReleaseChannelResolved] = useState(false);
   const [status, setStatus] = useState<RecoveryStatus>({ kind: "checking" });
   const [pendingUpdate, setPendingUpdate] = useState<PendingDesktopUpdate | null>(null);
   const [fallbackDownloadUrl, setFallbackDownloadUrl] = useState(
@@ -38,6 +47,28 @@ export function StartupRecoveryScreen() {
   const [downloadBusy, setDownloadBusy] = useState(false);
 
   useEffect(() => {
+    let cancelled = false;
+    void loadDesktopReleaseChannelState()
+      .then(({ selectedChannel, installedChannel }) => {
+        if (!cancelled) {
+          setReleaseChannel(selectedChannel);
+          setInstalledReleaseChannel(installedChannel);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setReleaseChannelResolved(true);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!releaseChannelResolved) return;
+
     async function loadRecoveryUpdate() {
       try {
         const resolvedFallbackUrl = await resolveDesktopDownloadFallbackUrl(releaseChannel);
@@ -63,7 +94,7 @@ export function StartupRecoveryScreen() {
     }
 
     void loadRecoveryUpdate();
-  }, [releaseChannel]);
+  }, [releaseChannel, releaseChannelResolved]);
 
   const handleRetry = useCallback(async () => {
     setRetryBusy(true);
@@ -98,6 +129,9 @@ export function StartupRecoveryScreen() {
 
         setStatus({ kind: "available" });
       });
+      await persistDesktopInstalledReleaseChannel(pendingUpdate.channel);
+      setInstalledReleaseChannel(pendingUpdate.channel);
+      await persistDesktopReleaseChannel(releaseChannel);
       localStorage.setItem(JUST_UPDATED_KEY, version);
       await relaunch();
     } catch (error) {
@@ -106,7 +140,7 @@ export function StartupRecoveryScreen() {
         message: error instanceof Error ? error.message : "Install failed.",
       });
     }
-  }, [pendingUpdate]);
+  }, [pendingUpdate, releaseChannel]);
 
   const handleDownload = useCallback(async () => {
     setDownloadBusy(true);
@@ -213,7 +247,7 @@ export function StartupRecoveryScreen() {
           </p>
 
           <p className="mt-5 text-xs text-[var(--theme-text-muted)]">
-            Version {formatReleaseVersion(__APP_VERSION__)}
+            Version {formatReleaseVersion(__APP_VERSION__, installedReleaseChannel)}
           </p>
         </section>
       </div>

--- a/packages/desktop/src/lib/release-channel.test.ts
+++ b/packages/desktop/src/lib/release-channel.test.ts
@@ -1,22 +1,46 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockInvoke } = vi.hoisted(() => ({
+const { mockInvoke, mockStoreData, mockStoreShouldThrow } = vi.hoisted(() => ({
   mockInvoke: vi.fn(),
+  mockStoreData: new Map<string, unknown>(),
+  mockStoreShouldThrow: { current: false },
 }));
 
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: mockInvoke,
 }));
 
+vi.mock("@tauri-apps/plugin-store", () => ({
+  load: vi.fn(async () => {
+    if (mockStoreShouldThrow.current) {
+      throw new Error("store unavailable");
+    }
+
+    return {
+      get: vi.fn(async (key: string) => mockStoreData.get(key) ?? null),
+      set: vi.fn(async (key: string, value: unknown) => {
+        mockStoreData.set(key, value);
+      }),
+    };
+  }),
+}));
+
 import {
   buildDesktopUpdateTargets,
+  loadDesktopReleaseChannel,
+  loadDesktopReleaseChannelState,
   getDesktopUpdateTargets,
   getNativeUpdaterTarget,
+  persistDesktopInstalledReleaseChannel,
+  persistDesktopReleaseChannel,
 } from "./release-channel";
 
 describe("desktop release channel helpers", () => {
   beforeEach(() => {
     mockInvoke.mockReset();
+    mockStoreData.clear();
+    mockStoreShouldThrow.current = false;
+    window.localStorage.clear();
   });
 
   it("reads the native updater target from Tauri", async () => {
@@ -50,5 +74,45 @@ describe("desktop release channel helpers", () => {
       { channel: "dev", target: "dev-windows-x86_64" },
       { channel: "production", target: "production-windows-x86_64" },
     ]);
+  });
+
+  it("loads the desktop channel from native store when browser storage is empty", async () => {
+    mockStoreData.set("channel", "dev");
+
+    await expect(loadDesktopReleaseChannel()).resolves.toBe("dev");
+    expect(window.localStorage.getItem("freed-release-channel")).toBe("dev");
+  });
+
+  it("seeds native store from browser storage when native store is empty", async () => {
+    window.localStorage.setItem("freed-release-channel", "dev");
+
+    await expect(loadDesktopReleaseChannel()).resolves.toBe("dev");
+    expect(mockStoreData.get("channel")).toBe("dev");
+  });
+
+  it("persists channel changes to native store and browser storage", async () => {
+    await persistDesktopReleaseChannel("dev");
+
+    expect(mockStoreData.get("channel")).toBe("dev");
+    expect(window.localStorage.getItem("freed-release-channel")).toBe("dev");
+  });
+
+  it("tracks installed channel separately from the selected update channel", async () => {
+    await persistDesktopReleaseChannel("production");
+    await persistDesktopInstalledReleaseChannel("dev");
+
+    await expect(loadDesktopReleaseChannelState()).resolves.toEqual({
+      selectedChannel: "production",
+      installedChannel: "dev",
+    });
+  });
+
+  it("keeps using browser storage if native store is unavailable", async () => {
+    mockStoreShouldThrow.current = true;
+    window.localStorage.setItem("freed-release-channel", "dev");
+
+    await expect(loadDesktopReleaseChannel()).resolves.toBe("dev");
+    await expect(persistDesktopReleaseChannel("production")).resolves.toBeUndefined();
+    expect(window.localStorage.getItem("freed-release-channel")).toBe("production");
   });
 });

--- a/packages/desktop/src/lib/release-channel.ts
+++ b/packages/desktop/src/lib/release-channel.ts
@@ -1,16 +1,102 @@
 import { invoke } from "@tauri-apps/api/core";
+import { load, type Store } from "@tauri-apps/plugin-store";
 import type { ReleaseChannel } from "@freed/shared";
 import {
-  bootstrapReleaseChannel,
   persistReleaseChannel,
+  RELEASE_CHANNEL_STORAGE_KEY,
 } from "@freed/ui/lib/release-channel";
 
-export function bootstrapDesktopReleaseChannel(): ReleaseChannel {
-  return bootstrapReleaseChannel();
+const DESKTOP_RELEASE_CHANNEL_STORE_FILE = "release-channel.json";
+const DESKTOP_RELEASE_CHANNEL_STORE_KEY = "channel";
+const DESKTOP_INSTALLED_RELEASE_CHANNEL_STORE_KEY = "installedChannel";
+
+let releaseChannelStore: Store | null = null;
+
+async function getReleaseChannelStore(): Promise<Store> {
+  if (!releaseChannelStore) {
+    releaseChannelStore = await load(DESKTOP_RELEASE_CHANNEL_STORE_FILE, {
+      defaults: {},
+      autoSave: true,
+    });
+  }
+
+  return releaseChannelStore;
 }
 
-export function persistDesktopReleaseChannel(channel: ReleaseChannel): void {
+function normalizeStoredDesktopReleaseChannel(value: unknown): ReleaseChannel | null {
+  return value === "dev" || value === "production" ? value : null;
+}
+
+export interface DesktopReleaseChannelState {
+  selectedChannel: ReleaseChannel;
+  installedChannel: ReleaseChannel;
+}
+
+export function bootstrapDesktopReleaseChannel(): ReleaseChannel {
+  if (typeof window === "undefined") {
+    return "production";
+  }
+
+  const channel =
+    normalizeStoredDesktopReleaseChannel(
+      window.localStorage.getItem(RELEASE_CHANNEL_STORAGE_KEY),
+    ) ?? "production";
   persistReleaseChannel(channel);
+  return channel;
+}
+
+export async function loadDesktopReleaseChannel(): Promise<ReleaseChannel> {
+  return (await loadDesktopReleaseChannelState()).selectedChannel;
+}
+
+export async function loadDesktopReleaseChannelState(): Promise<DesktopReleaseChannelState> {
+  const fallbackChannel = bootstrapDesktopReleaseChannel();
+
+  try {
+    const store = await getReleaseChannelStore();
+    const storedChannel = normalizeStoredDesktopReleaseChannel(
+      await store.get(DESKTOP_RELEASE_CHANNEL_STORE_KEY),
+    );
+    const selectedChannel = storedChannel ?? fallbackChannel;
+    const storedInstalledChannel = normalizeStoredDesktopReleaseChannel(
+      await store.get(DESKTOP_INSTALLED_RELEASE_CHANNEL_STORE_KEY),
+    );
+    const installedChannel = storedInstalledChannel ?? selectedChannel;
+    persistReleaseChannel(selectedChannel);
+
+    if (!storedChannel) {
+      await store.set(DESKTOP_RELEASE_CHANNEL_STORE_KEY, selectedChannel);
+    }
+    if (!storedInstalledChannel) {
+      await store.set(DESKTOP_INSTALLED_RELEASE_CHANNEL_STORE_KEY, installedChannel);
+    }
+
+    return { selectedChannel, installedChannel };
+  } catch {
+    return { selectedChannel: fallbackChannel, installedChannel: fallbackChannel };
+  }
+}
+
+export async function persistDesktopReleaseChannel(channel: ReleaseChannel): Promise<void> {
+  persistReleaseChannel(channel);
+
+  try {
+    const store = await getReleaseChannelStore();
+    await store.set(DESKTOP_RELEASE_CHANNEL_STORE_KEY, channel);
+  } catch {
+    // localStorage is still updated, so the current install keeps working.
+  }
+}
+
+export async function persistDesktopInstalledReleaseChannel(
+  channel: ReleaseChannel,
+): Promise<void> {
+  try {
+    const store = await getReleaseChannelStore();
+    await store.set(DESKTOP_INSTALLED_RELEASE_CHANNEL_STORE_KEY, channel);
+  } catch {
+    // The current process can still render the channel from React state.
+  }
 }
 
 export async function getNativeUpdaterTarget(): Promise<string> {

--- a/packages/desktop/tests/e2e/update-channel.spec.ts
+++ b/packages/desktop/tests/e2e/update-channel.spec.ts
@@ -93,3 +93,54 @@ test("switching release channels clears stale update state and rechecks the new 
     "https://dev.freed.wtf/api/downloads/mac-arm",
   );
 });
+
+test("selected release channel survives when browser storage is missing after relaunch", async ({
+  app,
+  page,
+}) => {
+  await app.goto();
+  await app.waitForReady();
+
+  const settingsButton = page.locator("button").filter({ hasText: /settings/i }).first();
+  await expect(settingsButton).toBeVisible({ timeout: 5_000 });
+  await settingsButton.click();
+
+  const settingsDialog = page.locator(".fixed.inset-0.z-50").last();
+  await settingsDialog.getByRole("button", { name: /^Updates$/ }).click();
+
+  const releaseChannelSelect = page.getByTestId("settings-release-channel-select");
+  await expect(releaseChannelSelect).toHaveValue("production");
+  await releaseChannelSelect.selectOption("dev");
+  await expect(releaseChannelSelect).toHaveValue("dev");
+
+  await page.evaluate(() => {
+    const mockStoreKey = "__TAURI_MOCK_STORE__:release-channel.json";
+    const existing = JSON.parse(window.localStorage.getItem(mockStoreKey) ?? "{}") as Record<
+      string,
+      unknown
+    >;
+    window.localStorage.setItem(
+      mockStoreKey,
+      JSON.stringify({
+        ...existing,
+        channel: "dev",
+        installedChannel: "dev",
+      }),
+    );
+    window.localStorage.removeItem("freed-release-channel");
+  });
+
+  await page.reload();
+  await app.waitForReady();
+
+  await page.locator("button").filter({ hasText: /settings/i }).first().click();
+  const reopenedSettingsDialog = page.locator(".fixed.inset-0.z-50").last();
+  await reopenedSettingsDialog.getByRole("button", { name: /^Updates$/ }).click();
+
+  await expect(page.getByTestId("settings-release-channel-select")).toHaveValue("dev");
+  await expect(reopenedSettingsDialog.getByText(/Installed version:\s*v26\.4\.2500-dev/)).toBeVisible();
+
+  await page.getByTestId("settings-release-channel-select").selectOption("production");
+  await expect(page.getByTestId("settings-release-channel-select")).toHaveValue("production");
+  await expect(reopenedSettingsDialog.getByText(/Installed version:\s*v26\.4\.2500-dev/)).toBeVisible();
+});

--- a/packages/ui/src/components/SettingsDialog.tsx
+++ b/packages/ui/src/components/SettingsDialog.tsx
@@ -262,6 +262,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
     activeCloudProviderLabel,
     seedSocialConnections,
     releaseChannel,
+    installedReleaseChannel,
     setReleaseChannel,
     updateDownloadProgress,
   } = usePlatform();
@@ -520,7 +521,10 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
   const [updateState, setUpdateState] = useState<UpdateCheckState>({ status: "idle" });
   const fadeTimer = useRef<ReturnType<typeof setTimeout>>(undefined);
   const shouldRecheckAfterChannelChangeRef = useRef(false);
-  const displayVersion = formatReleaseVersion(__APP_VERSION__);
+  const displayVersion = formatReleaseVersion(
+    __APP_VERSION__,
+    installedReleaseChannel ?? releaseChannel,
+  );
 
   const runUpdateCheck = useCallback(async () => {
     if (!checkForUpdates) return;

--- a/packages/ui/src/context/PlatformContext.tsx
+++ b/packages/ui/src/context/PlatformContext.tsx
@@ -177,6 +177,9 @@ export interface PlatformConfig {
   /** Current locally-selected update channel for this install or browser. */
   releaseChannel?: ReleaseChannel;
 
+  /** Release channel that produced the currently installed build. */
+  installedReleaseChannel?: ReleaseChannel;
+
   /** Persist a new update channel for this install or browser. */
   setReleaseChannel?: (channel: ReleaseChannel) => Promise<void> | void;
 


### PR DESCRIPTION
(AI Generated).

## Summary

- Persist the desktop update channel in Tauri store so it survives installer updates.
- Track the installed release channel separately from the selected future update channel.
- Show dev installs as `-dev` in Settings, the footer, restart toast, and startup recovery.

## Validation

- `corepack npm run test:unit --workspace=packages/desktop -- src/lib/release-channel.test.ts`
- `corepack npm run test:e2e --workspace=packages/desktop -- update-channel.spec.ts`
- `corepack npm run build --workspace=packages/desktop`
- `corepack npm run validate:feature`
