### PR TITLE
fix: restore marketing email subscriptions

### DIFF
--- a/docs/PHASE-1-FOUNDATION.md
+++ b/docs/PHASE-1-FOUNDATION.md
@@ -162,7 +162,7 @@ Next.js 15 (App Router) site deployed to Vercel at freed.wtf.
   - [ ] Add one-click endpoint smoke test before release
   - [x] Set `BREVO_API_KEY` and `BREVO_LIST_ID` in Vercel
   - [x] Add Turnstile verification, a honeypot field, and basic abuse throttling to `/api/subscribe`
-  - [ ] Set `NEXT_PUBLIC_TURNSTILE_SITE_KEY` and `TURNSTILE_SECRET_KEY` in `freed-www`
+  - [x] Set `NEXT_PUBLIC_TURNSTILE_SITE_KEY` and `TURNSTILE_SECRET_KEY` in `freed-www`
   - [ ] Configure freed.wtf domain in Vercel
 - [ ] Send our first email newsletter
 - [ ] Fix navigation bar vertical clipping on overscroll (iOS/macOS bounce)

--- a/website/next.config.ts
+++ b/website/next.config.ts
@@ -4,6 +4,10 @@ const nextConfig: NextConfig = {
   // Disable x-powered-by header
   poweredByHeader: false,
   transpilePackages: ["@freed/shared", "@freed/ui"],
+  env: {
+    NEXT_PUBLIC_TURNSTILE_SITE_KEY:
+      process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY,
+  },
 
   // Configure redirects if needed
   async redirects() {


### PR DESCRIPTION
(AI Generated).

## Summary
- expose the public Turnstile site key through Next config so the client bundle can render the widget
- mark the freed-www Turnstile env setup complete in the Phase 1 checklist

## Verification
- NEXT_PUBLIC_TURNSTILE_SITE_KEY=... ../node_modules/.bin/next build
- confirmed the local build contains the public site key
- confirmed the local build does not contain the Turnstile secret
- confirmed the live API reaches Turnstile verification with an invalid token instead of failing missing configuration