### PR TITLE
feat: add content signal filters

### DIFF
--- a/docs/PHASE-10-POLISH.md
+++ b/docs/PHASE-10-POLISH.md
@@ -397,6 +397,7 @@ Reward security researchers for responsible disclosure.
 | 10.13 | Sentiment analysis       | Medium     | ✓ Complete (AISummary.sentiment field)
 | 10.14 | Smart notifications      | High       |
 | 10.15 | AI settings UI           | Medium     | ✓ Complete (AISection.tsx in packages/ui)
+| 10.25 | Local content signals    | Medium     | ✓ Complete (rule-based contentSignals metadata, automatic ingestion inference, resumable desktop backfill, saved toolbar filter presets, and news classification)
 
 ### Extensibility
 
@@ -440,6 +441,7 @@ Reward security researchers for responsible disclosure.
 
 - [ ] Topic extraction works (at least one method)
 - [ ] Summarization available for long content
+- [x] Local content signals classify existing and newly ingested items without cloud AI, with saved feed filter presets and news classification in the toolbar
 - [ ] Smart notifications reduce noise
 
 ### Community

--- a/packages/desktop/src/lib/automerge-types.ts
+++ b/packages/desktop/src/lib/automerge-types.ts
@@ -9,7 +9,16 @@
  *                    IMPORT_PROGRESS (chunk progress for large imports)
  */
 
-import type { Account, FeedItem, Friend, Person, ReachOutLog, RssFeed, UserPreferences } from "@freed/shared";
+import type {
+  Account,
+  ContentSignalBackfillSummary,
+  FeedItem,
+  Friend,
+  Person,
+  ReachOutLog,
+  RssFeed,
+  UserPreferences,
+} from "@freed/shared";
 
 // ---------------------------------------------------------------------------
 // Hydrated state - identical to PWA's DocState (imported for type safety)
@@ -93,6 +102,7 @@ export type WorkerRequest =
   | { reqId: number; type: "BATCH_IMPORT_ITEMS"; items: FeedItem[] }
   | { reqId: number; type: "HEAL_UNTITLED_FEEDS" }
   | { reqId: number; type: "DEDUPLICATE_ITEMS" }
+  | { reqId: number; type: "BACKFILL_CONTENT_SIGNALS"; batchSize?: number }
   | { reqId: number; type: "GET_ALL_ITEM_IDS" }
   | { reqId: number; type: "GET_DOC_BINARY" }
   | { reqId: number; type: "GET_ITEM_PRESERVED_TEXT"; globalId: string }
@@ -129,5 +139,7 @@ export type WorkerResponse =
   | { reqId: number; type: "DOC_BINARY"; binary: Uint8Array }
   /** On-demand preserved article text for the active reader item. */
   | { reqId: number; type: "ITEM_PRESERVED_TEXT"; globalId: string; text: string | null }
+  /** One-batch content signal backfill summary. */
+  | { reqId: number; type: "CONTENT_SIGNAL_BACKFILL_RESULT"; summary: ContentSignalBackfillSummary }
   /** Progress reporting for BATCH_IMPORT_ITEMS. */
   | { type: "IMPORT_PROGRESS"; chunkIndex: number; totalChunks: number };

--- a/packages/desktop/src/lib/automerge.ts
+++ b/packages/desktop/src/lib/automerge.ts
@@ -21,7 +21,15 @@
 import { invoke } from "@tauri-apps/api/core";
 import { hashSavedUrl } from "@freed/capture-save/normalize";
 import { addDebugEvent, setDocSnapshot, registerDocAccessors } from "@freed/ui/lib/debug-store";
-import type { Account, FeedItem, Person, ReachOutLog, RssFeed, UserPreferences } from "@freed/shared";
+import type {
+  Account,
+  ContentSignalBackfillSummary,
+  FeedItem,
+  Person,
+  ReachOutLog,
+  RssFeed,
+  UserPreferences,
+} from "@freed/shared";
 import type { DocState, DocStats, FeedItemPatch, WorkerRequest, WorkerResponse } from "./automerge-types";
 import { log } from "./logger.js";
 export type { DocState } from "./automerge-types";
@@ -82,6 +90,14 @@ const pendingPreservedText = new Map<
   number,
   {
     resolve: (text: string | null) => void;
+    reject: (err: Error) => void;
+    timer: ReturnType<typeof setTimeout>;
+  }
+>();
+const pendingContentSignalBackfill = new Map<
+  number,
+  {
+    resolve: (summary: ContentSignalBackfillSummary) => void;
     reject: (err: Error) => void;
     timer: ReturnType<typeof setTimeout>;
   }
@@ -294,7 +310,24 @@ worker.onmessage = (event: MessageEvent<WorkerResponse>) => {
     return;
   }
 
+  if (msg.type === "CONTENT_SIGNAL_BACKFILL_RESULT") {
+    const pendingBackfill = pendingContentSignalBackfill.get(msg.reqId);
+    if (!pendingBackfill) return;
+    clearTimeout(pendingBackfill.timer);
+    pendingContentSignalBackfill.delete(msg.reqId);
+    pendingBackfill.resolve(msg.summary);
+    return;
+  }
+
   // ACK
+  const pendingBackfill = pendingContentSignalBackfill.get(msg.reqId);
+  if (pendingBackfill && msg.error) {
+    clearTimeout(pendingBackfill.timer);
+    pendingContentSignalBackfill.delete(msg.reqId);
+    pendingBackfill.reject(new Error(msg.error));
+    return;
+  }
+
   const p = pending.get(msg.reqId);
   if (!p) return;
   clearTimeout(p.timer);
@@ -682,6 +715,27 @@ export async function docHealUntitledFeedTitles(): Promise<void> {
 export async function docDeduplicateFeedItems(): Promise<void> {
   const reqId = nextReqId++;
   return request({ reqId, type: "DEDUPLICATE_ITEMS" });
+}
+
+export async function docBackfillContentSignals(
+  batchSize: number = 200,
+): Promise<ContentSignalBackfillSummary> {
+  await workerReady;
+  return new Promise((resolve, reject) => {
+    const reqId = nextReqId++;
+    const timer = setTimeout(() => {
+      if (!pendingContentSignalBackfill.has(reqId)) return;
+      pendingContentSignalBackfill.delete(reqId);
+      reject(
+        new Error(
+          `[automerge-worker] request TIMEOUT op=BACKFILL_CONTENT_SIGNALS reqId=${reqId} timeout_ms=${WORKER_REQUEST_TIMEOUT_MS.toLocaleString()}`,
+        ),
+      );
+    }, WORKER_REQUEST_TIMEOUT_MS);
+
+    pendingContentSignalBackfill.set(reqId, { resolve, reject, timer });
+    worker.postMessage({ reqId, type: "BACKFILL_CONTENT_SIGNALS", batchSize } satisfies WorkerRequest);
+  });
 }
 
 /**

--- a/packages/desktop/src/lib/automerge.worker.ts
+++ b/packages/desktop/src/lib/automerge.worker.ts
@@ -21,6 +21,8 @@ import {
   createEmptyDoc,
   addAccount,
   addAccounts,
+  backfillContentSignals,
+  countContentSignalBackfillItems,
   addFeedItem,
   deduplicateDocFeedItems,
   hasLegacyIdentityGraphData,
@@ -31,6 +33,7 @@ import {
   removeAllFeeds,
   updateRssFeed,
   updateFeedItem,
+  summarizeDocContentSignals,
   removeFeedItem,
   markAsRead,
   markItemsAsRead,
@@ -183,6 +186,7 @@ function migrateLoadedIdentityGraph(message: string): void {
 function feedItemUpdatesAffectSearchCorpus(updates: Partial<FeedItem>): boolean {
   if (
     "author" in updates ||
+    "contentSignals" in updates ||
     "content" in updates ||
     "contentType" in updates ||
     "preservedContent" in updates ||
@@ -909,6 +913,28 @@ async function handleRequest(
         }, "Deduplicate feed items by article link URL and linked social cross-posts", true);
         ack(req.reqId);
         break;
+
+      case "BACKFILL_CONTENT_SIGNALS": {
+        if (!currentDoc) throw new Error("Document not initialized");
+        let summary = summarizeDocContentSignals(currentDoc);
+        const pendingCount = countContentSignalBackfillItems(currentDoc);
+        if (pendingCount > 0) {
+          currentDoc = A.change(currentDoc, "Backfill content signals", (doc) => {
+            summary = backfillContentSignals(doc, req.batchSize);
+          });
+          bumpSearchCorpusVersion();
+          send({
+            type: "DEBUG_EVENT",
+            kind: "change",
+            detail:
+              `[content-signals] backfilled ${summary.updated.toLocaleString()} items, ` +
+              `${summary.remaining.toLocaleString()} remaining`,
+          });
+          await saveAndBroadcast(trace);
+        }
+        send({ reqId: req.reqId, type: "CONTENT_SIGNAL_BACKFILL_RESULT", summary });
+        break;
+      }
 
       case "GET_ALL_ITEM_IDS":
         if (!currentDoc) throw new Error("Document not initialized");

--- a/packages/desktop/src/lib/content-signals.test.ts
+++ b/packages/desktop/src/lib/content-signals.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from "vitest";
+import type { FeedItem } from "@freed/shared";
+import {
+  applyFeedSignalModeToFilter,
+  applyFeedSignalModesToFilter,
+  filterFeedItems,
+  getFeedSignalModeForFilter,
+  inferContentSignals,
+} from "@freed/shared";
+import {
+  addFeedItem,
+  backfillContentSignals,
+  createEmptyDoc,
+  type FreedDoc,
+} from "@freed/shared/schema";
+
+function plainDoc(): FreedDoc {
+  return JSON.parse(JSON.stringify(createEmptyDoc())) as FreedDoc;
+}
+
+function makeItem(overrides: Partial<FeedItem> = {}): FeedItem {
+  const now = Date.parse("2026-04-25T12:00:00Z");
+  return {
+    globalId: "x:item-1",
+    platform: "x",
+    contentType: "post",
+    capturedAt: now,
+    publishedAt: now,
+    author: {
+      id: "author-1",
+      handle: "author",
+      displayName: "Author",
+    },
+    content: {
+      text: "",
+      mediaUrls: [],
+      mediaTypes: [],
+    },
+    topics: [],
+    userState: {
+      hidden: false,
+      saved: false,
+      archived: false,
+      tags: [],
+    },
+    ...overrides,
+  };
+}
+
+describe("content signals", () => {
+  it("infers multiple signals for promoted events", () => {
+    const signals = inferContentSignals(
+      makeItem({
+        content: {
+          text: "Join us Friday at 7pm for a launch party. RSVP now, early bird tickets are almost gone.",
+          mediaUrls: [],
+          mediaTypes: [],
+        },
+        location: {
+          name: "Austin",
+          source: "text_extraction",
+        },
+      }),
+      Date.parse("2026-04-25T12:00:00Z"),
+    );
+
+    expect(signals.tags).toContain("event");
+    expect(signals.tags).toContain("promotion");
+    expect(signals.scores.event).toBeGreaterThanOrEqual(0.5);
+    expect(signals.scores.promotion).toBeGreaterThanOrEqual(0.5);
+  });
+
+  it("keeps media as evidence instead of a signal", () => {
+    const signals = inferContentSignals(
+      makeItem({
+        content: {
+          text: "Today at the overlook.",
+          mediaUrls: ["https://example.com/photo.jpg"],
+          mediaTypes: ["image"],
+        },
+      }),
+    );
+
+    expect(signals.tags).toContain("moment");
+    expect(Object.keys(signals.scores)).not.toContain("media");
+  });
+
+  it("leaves weak items untagged", () => {
+    const signals = inferContentSignals(
+      makeItem({
+        content: {
+          text: "ok",
+          mediaUrls: [],
+          mediaTypes: [],
+        },
+      }),
+    );
+
+    expect(signals.tags).toEqual([]);
+  });
+
+  it("classifies reported news articles", () => {
+    const signals = inferContentSignals(
+      makeItem({
+        platform: "rss",
+        contentType: "article",
+        rssSource: {
+          feedUrl: "https://www.reuters.com/rss",
+          feedTitle: "Reuters",
+          itemGuid: "news-1",
+        },
+        content: {
+          text: "Reuters reports that regulators announced a new policy after officials reviewed new data.",
+          mediaUrls: [],
+          mediaTypes: [],
+          linkPreview: {
+            url: "https://www.reuters.com/world/example",
+            title: "Regulators announce new policy",
+          },
+        },
+      }),
+    );
+
+    expect(signals.tags).toContain("news");
+    expect(signals.scores.news).toBeGreaterThanOrEqual(0.5);
+  });
+
+  it("classifies new feed items during schema insertion", () => {
+    const doc = plainDoc();
+    addFeedItem(doc, makeItem({
+      content: {
+        text: "Anyone know a good book on local-first sync?",
+        mediaUrls: [],
+        mediaTypes: [],
+      },
+    }));
+
+    expect(doc.feedItems["x:item-1"]?.contentSignals?.tags).toEqual(
+      expect.arrayContaining(["request", "recommendation"]),
+    );
+  });
+
+  it("backfills stale feed items in bounded batches", () => {
+    const doc = plainDoc();
+    doc.feedItems["x:item-1"] = makeItem({
+      globalId: "x:item-1",
+      content: {
+        text: "Announcing a new release, now available in public beta.",
+        mediaUrls: [],
+        mediaTypes: [],
+      },
+    });
+    doc.feedItems["x:item-2"] = makeItem({
+      globalId: "x:item-2",
+      content: {
+        text: "This long read explains why local-first software changes collaboration.",
+        mediaUrls: [],
+        mediaTypes: [],
+      },
+      contentType: "article",
+      preservedContent: {
+        text: "This long read explains why local-first software changes collaboration.",
+        wordCount: 900,
+        readingTime: 5,
+        preservedAt: Date.now(),
+      },
+    });
+
+    const first = backfillContentSignals(doc, 1);
+    expect(first.updated).toBe(1);
+    expect(first.remaining).toBe(1);
+
+    const second = backfillContentSignals(doc, 1);
+    expect(second.updated).toBe(1);
+    expect(second.remaining).toBe(0);
+    expect(second.counts.announcement).toBeGreaterThanOrEqual(1);
+    expect(second.counts.essay).toBeGreaterThanOrEqual(1);
+  });
+
+  it("applies saved signal filter presets to feed filters", () => {
+    const inspiring = applyFeedSignalModeToFilter({ platform: "x" }, "inspiring");
+    expect(inspiring).toEqual({
+      platform: "x",
+      signals: ["essay", "recommendation", "moment"],
+    });
+    expect(getFeedSignalModeForFilter(inspiring)).toBe("inspiring");
+
+    expect(applyFeedSignalModeToFilter(inspiring, "all")).toEqual({
+      platform: "x",
+    });
+
+    expect(applyFeedSignalModesToFilter({ platform: "x" }, ["inspiring", "events"])).toEqual({
+      platform: "x",
+      signals: ["essay", "recommendation", "moment", "event", "promotion"],
+    });
+
+    expect(applyFeedSignalModesToFilter({ platform: "rss" }, ["news"])).toEqual({
+      platform: "rss",
+      signals: ["news"],
+    });
+  });
+
+  it("applies post and story filters in the unified feed", () => {
+    const post = makeItem({
+      globalId: "x:post",
+      contentType: "post",
+    });
+    const story = makeItem({
+      globalId: "ig:story",
+      platform: "instagram",
+      contentType: "story",
+    });
+
+    expect(filterFeedItems([post, story], { socialContentFilter: "posts" })).toEqual([post]);
+    expect(filterFeedItems([post, story], { socialContentFilter: "stories" })).toEqual([story]);
+  });
+});

--- a/packages/desktop/src/lib/store-preferences.test.ts
+++ b/packages/desktop/src/lib/store-preferences.test.ts
@@ -32,6 +32,7 @@ vi.mock("./automerge", () => ({
   docDeleteAllArchived: vi.fn(),
   docPruneArchivedItems: vi.fn(),
   docUpdatePreferences: mockDocUpdatePreferences,
+  docBackfillContentSignals: vi.fn(() => Promise.resolve({ updated: 0, remaining: 0 })),
   docDeduplicateFeedItems: vi.fn(),
   docHealUntitledFeedTitles: vi.fn(),
   docAddFriend: vi.fn(),

--- a/packages/desktop/src/lib/store-read-state.test.ts
+++ b/packages/desktop/src/lib/store-read-state.test.ts
@@ -30,6 +30,7 @@ vi.mock("./automerge", () => ({
   docDeleteAllArchived: vi.fn(),
   docPruneArchivedItems: vi.fn(),
   docUpdatePreferences: vi.fn(),
+  docBackfillContentSignals: vi.fn(() => Promise.resolve({ updated: 0, remaining: 0 })),
   docDeduplicateFeedItems: vi.fn(),
   docHealUntitledFeedTitles: vi.fn(),
   docAddFriend: vi.fn(),

--- a/packages/desktop/src/lib/store.ts
+++ b/packages/desktop/src/lib/store.ts
@@ -11,11 +11,13 @@
 import { create } from "zustand";
 import type { Account, FeedItem, FilterOptions, Friend, Person, ReachOutLog, UserPreferences, RssFeed, RemoveFeedOptions } from "@freed/shared";
 import {
+  applyFeedSignalModesToFilter,
   accountsFromLegacyFriend,
   buildConnectionPersonDraftFromAccounts,
   createDefaultPreferences,
   isPrunableConnectionPerson,
   personFromLegacyFriend,
+  resolveFeedSignalModesFromDisplay,
 } from "@freed/shared";
 import {
   initDoc,
@@ -37,6 +39,7 @@ import {
   docDeleteAllArchived,
   docPruneArchivedItems,
   docUpdatePreferences,
+  docBackfillContentSignals,
   docDeduplicateFeedItems,
   docHealUntitledFeedTitles,
   docAddAccount,
@@ -282,6 +285,13 @@ async function runStartupMigrations(archivePruneDays: number): Promise<void> {
       await docPruneArchivedItems(archivePruneDays * 24 * 60 * 60 * 1000);
     }
   } catch { /* non-fatal */ }
+  try {
+    for (;;) {
+      const summary = await docBackfillContentSignals(200);
+      if (summary.updated === 0 || summary.remaining === 0) break;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+  } catch { /* non-fatal */ }
 }
 
 const READ_MARK_BATCH_DELAY_MS = 50;
@@ -400,6 +410,8 @@ export const useAppStore = create<AppState>((set, get) => ({
       subscribe((state: DocState) => {
         const prev = get();
         let next: Partial<AppState> = { ...state };
+        const previousFeedSignalModes = resolveFeedSignalModesFromDisplay(prev.preferences.display);
+        const nextFeedSignalModes = resolveFeedSignalModesFromDisplay(state.preferences.display);
 
         if (shallowEqualRecord(state.feedUnreadCounts, prev.feedUnreadCounts))
           next = { ...next, feedUnreadCounts: prev.feedUnreadCounts };
@@ -409,6 +421,12 @@ export const useAppStore = create<AppState>((set, get) => ({
           next = { ...next, unreadCountByPlatform: prev.unreadCountByPlatform };
         if (shallowEqualRecord(state.itemCountByPlatform, prev.itemCountByPlatform))
           next = { ...next, itemCountByPlatform: prev.itemCountByPlatform };
+        if (nextFeedSignalModes.join(",") !== previousFeedSignalModes.join(",")) {
+          next = {
+            ...next,
+            activeFilter: applyFeedSignalModesToFilter(prev.activeFilter, nextFeedSignalModes),
+          };
+        }
 
         set(next);
       });
@@ -425,6 +443,10 @@ export const useAppStore = create<AppState>((set, get) => ({
       // Hydrate immediately from the initial DocState returned by the worker.
       set({
         ...docState,
+        activeFilter: applyFeedSignalModesToFilter(
+          get().activeFilter,
+          resolveFeedSignalModesFromDisplay(docState.preferences.display),
+        ),
         xAuth,
         fbAuth,
         igAuth,

--- a/packages/pwa/src/lib/automerge.worker.ts
+++ b/packages/pwa/src/lib/automerge.worker.ts
@@ -145,6 +145,7 @@ function migrateLoadedIdentityGraph(message: string): void {
 function feedItemUpdatesAffectSearchCorpus(updates: Partial<FeedItem>): boolean {
   if (
     "author" in updates ||
+    "contentSignals" in updates ||
     "content" in updates ||
     "contentType" in updates ||
     "preservedContent" in updates ||

--- a/packages/pwa/src/lib/ranking.test.ts
+++ b/packages/pwa/src/lib/ranking.test.ts
@@ -328,7 +328,7 @@ describe("filterFeedItems", () => {
     ).toEqual(["fb-story"]);
   });
 
-  it("ignores the social content filter outside direct Facebook and Instagram sources", () => {
+  it("applies posts and stories filters across the unified feed", () => {
     const mixedItems: FeedItem[] = [
       makeItem({ globalId: "rss-article", platform: "rss", contentType: "article" }),
       makeItem({ globalId: "rss-story", platform: "rss", contentType: "story" }),
@@ -337,12 +337,15 @@ describe("filterFeedItems", () => {
 
     expect(
       filterFeedItems(mixedItems, { socialContentFilter: "posts" }).map((item) => item.globalId),
-    ).toEqual(["rss-article", "rss-story", "ig-story"]);
+    ).toEqual(["rss-article"]);
+    expect(
+      filterFeedItems(mixedItems, { socialContentFilter: "stories" }).map((item) => item.globalId),
+    ).toEqual(["rss-story", "ig-story"]);
     expect(
       filterFeedItems(mixedItems, {
         platform: "rss",
         socialContentFilter: "posts",
       }).map((item) => item.globalId),
-    ).toEqual(["rss-article", "rss-story"]);
+    ).toEqual(["rss-article"]);
   });
 });

--- a/packages/pwa/src/lib/store.ts
+++ b/packages/pwa/src/lib/store.ts
@@ -9,11 +9,13 @@
 
 import { create } from "zustand";
 import {
+  applyFeedSignalModesToFilter,
   accountsFromLegacyFriend,
   buildConnectionPersonDraftFromAccounts,
   createDefaultPreferences,
   isPrunableConnectionPerson,
   personFromLegacyFriend,
+  resolveFeedSignalModesFromDisplay,
 } from "@freed/shared";
 import type { Account, BaseAppState, Friend, Person, ReachOutLog, RemoveFeedOptions } from "@freed/shared";
 import { recordBugReportEvent, recordRuntimeError } from "@freed/ui/lib/bug-report";
@@ -133,6 +135,8 @@ export const useAppStore = create<AppState>((set, get) => ({
         const merged = {
           ...next,
         } as Partial<AppState>;
+        const previousFeedSignalModes = resolveFeedSignalModesFromDisplay(prev.preferences.display);
+        const nextFeedSignalModes = resolveFeedSignalModesFromDisplay(next.preferences.display);
         if (shallowEqualRecord(next.feedUnreadCounts, prev.feedUnreadCounts))
           merged.feedUnreadCounts = prev.feedUnreadCounts;
         if (shallowEqualRecord(next.feedTotalCounts, prev.feedTotalCounts))
@@ -141,10 +145,21 @@ export const useAppStore = create<AppState>((set, get) => ({
           merged.unreadCountByPlatform = prev.unreadCountByPlatform;
         if (shallowEqualRecord(next.itemCountByPlatform, prev.itemCountByPlatform))
           merged.itemCountByPlatform = prev.itemCountByPlatform;
+        if (nextFeedSignalModes.join(",") !== previousFeedSignalModes.join(",")) {
+          merged.activeFilter = applyFeedSignalModesToFilter(prev.activeFilter, nextFeedSignalModes);
+        }
         set(merged);
       });
 
-      set({ ...state, isInitialized: true, isLoading: false });
+      set({
+        ...state,
+        activeFilter: applyFeedSignalModesToFilter(
+          get().activeFilter,
+          resolveFeedSignalModesFromDisplay(state.preferences.display),
+        ),
+        isInitialized: true,
+        isLoading: false,
+      });
 
       // Prune archived items in the background. Idempotent; failure is non-fatal.
       // The subscriber above propagates the doc change to the UI automatically.

--- a/packages/shared/src/content-signals.ts
+++ b/packages/shared/src/content-signals.ts
@@ -1,0 +1,292 @@
+import type { ContentSignal, ContentSignals, FeedItem, MediaType } from "./types.js";
+
+export const CONTENT_SIGNAL_VERSION = 2;
+export const CONTENT_SIGNAL_THRESHOLD = 0.5;
+
+export const CONTENT_SIGNAL_KEYS: readonly ContentSignal[] = [
+  "event",
+  "essay",
+  "moment",
+  "life_update",
+  "announcement",
+  "recommendation",
+  "request",
+  "discussion",
+  "promotion",
+  "news",
+] as const;
+
+type ScoreMap = Record<ContentSignal, number>;
+
+interface SignalEvidence {
+  text: string;
+  title: string;
+  description: string;
+  combined: string;
+  topics: string[];
+  mediaTypes: MediaType[];
+  textLength: number;
+  wordCount: number;
+  hasLocation: boolean;
+  hasTimeRange: boolean;
+  hasLink: boolean;
+  isSocial: boolean;
+  isRss: boolean;
+  feedTitle: string;
+  sourceHost: string;
+}
+
+function emptyScores(): ScoreMap {
+  return {
+    event: 0,
+    essay: 0,
+    moment: 0,
+    life_update: 0,
+    announcement: 0,
+    recommendation: 0,
+    request: 0,
+    discussion: 0,
+    promotion: 0,
+    news: 0,
+  };
+}
+
+function clampScore(value: number): number {
+  return Math.max(0, Math.min(1, Number(value.toFixed(2))));
+}
+
+function add(scores: ScoreMap, signal: ContentSignal, amount: number): void {
+  scores[signal] = clampScore(scores[signal] + amount);
+}
+
+function matches(text: string, patterns: RegExp[]): number {
+  let count = 0;
+  for (const pattern of patterns) {
+    if (pattern.test(text)) count += 1;
+  }
+  return count;
+}
+
+function hasAny(text: string, patterns: RegExp[]): boolean {
+  return matches(text, patterns) > 0;
+}
+
+function wordCount(text: string): number {
+  if (!text.trim()) return 0;
+  return text.trim().split(/\s+/).length;
+}
+
+function sourceHost(item: FeedItem): string {
+  const url = item.content.linkPreview?.url ?? item.sourceUrl ?? item.rssSource?.siteUrl ?? "";
+  if (!url) return "";
+  try {
+    return new URL(url).hostname.toLowerCase();
+  } catch {
+    return "";
+  }
+}
+
+function buildEvidence(item: FeedItem): SignalEvidence {
+  const title = item.content.linkPreview?.title ?? "";
+  const description = item.content.linkPreview?.description ?? "";
+  const preserved = item.preservedContent?.text ?? "";
+  const text = [item.content.text ?? "", preserved].filter(Boolean).join("\n");
+  const combined = [title, description, text, item.rssSource?.feedTitle ?? "", item.topics.join(" ")]
+    .filter(Boolean)
+    .join("\n")
+    .toLowerCase();
+
+  return {
+    text: text.toLowerCase(),
+    title: title.toLowerCase(),
+    description: description.toLowerCase(),
+    combined,
+    topics: item.topics.map((topic) => topic.toLowerCase()),
+    mediaTypes: item.content.mediaTypes ?? [],
+    textLength: text.length,
+    wordCount: item.preservedContent?.wordCount ?? wordCount(text),
+    hasLocation: Boolean(item.location),
+    hasTimeRange: Boolean(item.timeRange),
+    hasLink: Boolean(item.content.linkPreview?.url || item.sourceUrl),
+    isSocial: item.platform !== "rss" && item.platform !== "github" && item.platform !== "youtube",
+    isRss: Boolean(item.rssSource) || item.platform === "rss",
+    feedTitle: item.rssSource?.feedTitle?.toLowerCase() ?? "",
+    sourceHost: sourceHost(item),
+  };
+}
+
+const DATE_OR_TIME_PATTERNS = [
+  /\b(?:today|tomorrow|tonight|this weekend|next week|next month)\b/i,
+  /\b(?:mon|tue|wed|thu|fri|sat|sun)(?:day)?\b/i,
+  /\b(?:jan|feb|mar|apr|may|jun|jul|aug|sep|sept|oct|nov|dec)[a-z]*\.?\s+\d{1,2}\b/i,
+  /\b\d{1,2}[\/.-]\d{1,2}(?:[\/.-]\d{2,4})?\b/i,
+  /\b\d{1,2}(?::\d{2})?\s?(?:am|pm)\b/i,
+];
+
+const EVENT_PATTERNS = [
+  /\b(?:rsvp|tickets?|register|registration|meetup|webinar|conference|workshop)\b/i,
+  /\b(?:doors open|show starts|join us|come to|see you at|live event)\b/i,
+  /\b(?:concert|festival|screening|demo day|office hours|book signing|launch party)\b/i,
+];
+
+const ESSAY_PATTERNS = [
+  /\b(?:essay|long read|deep dive|analysis|argument|thesis|manifesto)\b/i,
+  /\b(?:why|because|the problem|the point is|in short|in conclusion)\b/i,
+  /\b(?:i think|i believe|i argue|my view|my take)\b/i,
+];
+
+const LIFE_UPDATE_PATTERNS = [
+  /\b(?:i moved|we moved|new job|started at|joined|graduated|got married|engaged)\b/i,
+  /\b(?:birthday|anniversary|baby|born|pregnant|recovering|diagnosed|laid off|promotion)\b/i,
+  /\b(?:big news|personal news|life update|proud to share|happy to share)\b/i,
+];
+
+const ANNOUNCEMENT_PATTERNS = [
+  /\b(?:announcing|introducing|we launched|i launched|just launched|shipped|released)\b/i,
+  /\b(?:now available|now open|is live|goes live|launching|new release|version \d)\b/i,
+  /\b(?:we are excited|we're excited|coming soon|public beta|private beta)\b/i,
+];
+
+const RECOMMENDATION_PATTERNS = [
+  /\b(?:recommend|recommendation|favorite|worth reading|worth watching|check out)\b/i,
+  /\b(?:best|guide|tool|book|podcast|movie|restaurant|place|list of)\b/i,
+  /\b(?:you should|must read|must watch|great thread|useful resource)\b/i,
+];
+
+const REQUEST_PATTERNS = [
+  /\b(?:anyone know|looking for|need help|can someone|does anyone|help wanted)\b/i,
+  /\b(?:recommendations?|suggestions?|what should|how do i|how can i|poll)\b/i,
+  /\b(?:who knows|please share|send me|dm me if|reply with)\b/i,
+];
+
+const DISCUSSION_PATTERNS = [
+  /\b(?:thread|hot take|agree|disagree|thoughts|debate|conversation|comments)\b/i,
+  /\b(?:replying to|to be clear|counterpoint|my response|let's talk about)\b/i,
+  /\b(?:what do you think|curious what|change my mind)\b/i,
+];
+
+const PROMOTION_PATTERNS = [
+  /\b(?:buy|sale|discount|preorder|pre-order|order now|sponsor|sponsored)\b/i,
+  /\b(?:donate|support us|fundraiser|patreon|subscribe|follow me|share this)\b/i,
+  /\b(?:affiliate|coupon|free trial|limited time|early bird|back my)\b/i,
+];
+
+const NEWS_PATTERNS = [
+  /\b(?:breaking|reported|reports|report says|according to|announces|said on|sources say)\b/i,
+  /\b(?:lawsuit|election|court|government|market|war|policy|regulation|acquisition)\b/i,
+  /\b(?:investigation|study finds|researchers found|new data|officials|lawmakers|regulators)\b/i,
+  /\b(?:exclusive|developing story|live updates|press briefing|statement from)\b/i,
+];
+
+const NEWS_HOST_PATTERNS = [
+  /\b(?:nytimes|washingtonpost|theguardian|bbc|reuters|apnews|bloomberg|politico)\b/i,
+  /\b(?:cnn|nbcnews|cbsnews|abcnews|npr|axios|theverge|wired|wsj|ft\.com)\b/i,
+];
+
+function scoreSignals(item: FeedItem, evidence: SignalEvidence): ScoreMap {
+  const scores = emptyScores();
+  const combined = evidence.combined;
+
+  if (item.timeRange?.kind === "event") add(scores, "event", 0.45);
+  else if (evidence.hasTimeRange) add(scores, "event", 0.2);
+  if (hasAny(combined, EVENT_PATTERNS)) add(scores, "event", 0.3);
+  if (hasAny(combined, DATE_OR_TIME_PATTERNS)) add(scores, "event", 0.22);
+  if (evidence.hasLocation) add(scores, "event", 0.12);
+
+  if (item.contentType === "article") add(scores, "essay", 0.3);
+  if (evidence.wordCount >= 800) add(scores, "essay", 0.3);
+  else if (evidence.textLength >= 2_500) add(scores, "essay", 0.2);
+  if (hasAny(combined, ESSAY_PATTERNS)) add(scores, "essay", 0.22);
+  if (evidence.isRss && evidence.textLength >= 800) add(scores, "essay", 0.1);
+
+  if (item.contentType === "story") add(scores, "moment", 0.32);
+  if (evidence.mediaTypes.includes("image") && evidence.textLength <= 360) add(scores, "moment", 0.24);
+  if (evidence.hasLocation && evidence.textLength <= 500) add(scores, "moment", 0.18);
+  if (evidence.isSocial && /\b(?:today|this morning|this afternoon|this evening|here at|walking|visited)\b/i.test(combined)) {
+    add(scores, "moment", 0.18);
+  }
+  if (evidence.isSocial && evidence.textLength > 0 && evidence.textLength <= 180) add(scores, "moment", 0.1);
+
+  if (hasAny(combined, LIFE_UPDATE_PATTERNS)) add(scores, "life_update", 0.36);
+  if (/\b(?:i|we|my|our)\b/i.test(evidence.text) && hasAny(combined, LIFE_UPDATE_PATTERNS)) {
+    add(scores, "life_update", 0.12);
+  }
+  if (evidence.isSocial && scores.life_update > 0) add(scores, "life_update", 0.1);
+
+  if (hasAny(combined, ANNOUNCEMENT_PATTERNS)) add(scores, "announcement", 0.5);
+  if (/\b(?:launch|release|available|beta|new)\b/i.test(evidence.title)) add(scores, "announcement", 0.18);
+  if (evidence.sourceHost.includes("github.com") && /\b(?:release|version|changelog)\b/i.test(combined)) {
+    add(scores, "announcement", 0.2);
+  }
+
+  if (hasAny(combined, RECOMMENDATION_PATTERNS)) add(scores, "recommendation", 0.35);
+  if (evidence.hasLink && /\b(?:read|watch|listen|try|visit)\b/i.test(combined)) {
+    add(scores, "recommendation", 0.12);
+  }
+  if (evidence.topics.some((topic) => ["book", "books", "tools", "podcast", "restaurants"].includes(topic))) {
+    add(scores, "recommendation", 0.12);
+  }
+
+  if (hasAny(combined, REQUEST_PATTERNS)) add(scores, "request", 0.38);
+  if (combined.includes("?")) add(scores, "request", 0.16);
+  if (/\b(?:please|pls)\b/i.test(combined) && /\b(?:help|share|send|reply|recommend)\b/i.test(combined)) {
+    add(scores, "request", 0.14);
+  }
+  if (scores.request > 0 && scores.recommendation > 0) {
+    add(scores, "recommendation", 0.15);
+  }
+
+  if (hasAny(combined, DISCUSSION_PATTERNS)) add(scores, "discussion", 0.32);
+  if (evidence.isSocial && evidence.textLength >= 220 && combined.includes("?")) add(scores, "discussion", 0.12);
+  if (/\b(?:agree|disagree|take|thread)\b/i.test(combined)) add(scores, "discussion", 0.1);
+
+  if (hasAny(combined, PROMOTION_PATTERNS)) add(scores, "promotion", 0.38);
+  if (scores.event >= 0.4 && /\b(?:ticket|register|early bird|sale)\b/i.test(combined)) {
+    add(scores, "promotion", 0.18);
+  }
+  if (evidence.feedTitle.includes("product hunt") || evidence.sourceHost.includes("producthunt.com")) {
+    add(scores, "promotion", 0.24);
+    add(scores, "announcement", 0.12);
+  }
+
+  if (hasAny(combined, NEWS_PATTERNS)) add(scores, "news", 0.32);
+  if (item.contentType === "article" && hasAny(combined, NEWS_PATTERNS)) add(scores, "news", 0.18);
+  if (evidence.isRss && hasAny(`${evidence.feedTitle} ${evidence.sourceHost}`, NEWS_HOST_PATTERNS)) {
+    add(scores, "news", 0.28);
+  }
+  if (item.contentType === "article" && /\b(?:news|daily|times|post|journal)\b/i.test(evidence.feedTitle)) {
+    add(scores, "news", 0.18);
+  }
+
+  if (item.contentType === "podcast" || item.contentType === "video") {
+    if (scores.essay > 0) add(scores, "essay", 0.05);
+    if (scores.recommendation > 0) add(scores, "recommendation", 0.05);
+  }
+
+  return scores;
+}
+
+export function inferContentSignals(item: FeedItem, now: number = Date.now()): ContentSignals {
+  const evidence = buildEvidence(item);
+  const rawScores = scoreSignals(item, evidence);
+  const scores: Partial<Record<ContentSignal, number>> = {};
+
+  for (const signal of CONTENT_SIGNAL_KEYS) {
+    const score = clampScore(rawScores[signal]);
+    if (score > 0) scores[signal] = score;
+  }
+
+  const tags = CONTENT_SIGNAL_KEYS.filter((signal) => (scores[signal] ?? 0) >= CONTENT_SIGNAL_THRESHOLD);
+
+  return {
+    version: CONTENT_SIGNAL_VERSION,
+    method: "rules",
+    inferredAt: now,
+    scores,
+    tags,
+  };
+}
+
+export function hasCurrentContentSignals(item: FeedItem): boolean {
+  return item.contentSignals?.version === CONTENT_SIGNAL_VERSION;
+}

--- a/packages/shared/src/feed-signal-filters.ts
+++ b/packages/shared/src/feed-signal-filters.ts
@@ -1,0 +1,148 @@
+import type { FilterOptions } from "./store-types.js";
+import type { ContentSignal, DisplayPreferences, FeedSignalMode } from "./types.js";
+
+export interface FeedSignalFilterPreset {
+  mode: FeedSignalMode;
+  label: string;
+  description: string;
+  signals: readonly ContentSignal[];
+}
+
+export const FEED_SIGNAL_FILTER_PRESETS: readonly FeedSignalFilterPreset[] = [
+  {
+    mode: "all",
+    label: "Everything",
+    description: "Show every visible item.",
+    signals: [],
+  },
+  {
+    mode: "inspiring",
+    label: "Inspiring",
+    description: "Essays, recommendations, and memorable moments.",
+    signals: ["essay", "recommendation", "moment"],
+  },
+  {
+    mode: "events",
+    label: "Events",
+    description: "Promoted events and time-bound happenings.",
+    signals: ["event", "promotion"],
+  },
+  {
+    mode: "personal",
+    label: "Personal",
+    description: "Life updates and social moments.",
+    signals: ["life_update", "moment"],
+  },
+  {
+    mode: "conversation",
+    label: "Conversation",
+    description: "Requests, questions, and discussion threads.",
+    signals: ["request", "discussion"],
+  },
+  {
+    mode: "news",
+    label: "News",
+    description: "Reported stories, current events, and news analysis.",
+    signals: ["news"],
+  },
+] as const;
+
+const ALL_FEED_SIGNAL_MODES = new Set<FeedSignalMode>(
+  FEED_SIGNAL_FILTER_PRESETS.map((preset) => preset.mode),
+);
+const SELECTABLE_FEED_SIGNAL_MODES = new Set<FeedSignalMode>(
+  FEED_SIGNAL_FILTER_PRESETS
+    .filter((preset) => preset.mode !== "all")
+    .map((preset) => preset.mode),
+);
+
+function signalKey(signals: readonly ContentSignal[] | undefined): string {
+  return [...(signals ?? [])].sort().join(",");
+}
+
+export function normalizeFeedSignalMode(mode: FeedSignalMode | undefined): FeedSignalMode {
+  return mode && ALL_FEED_SIGNAL_MODES.has(mode) ? mode : "all";
+}
+
+export function normalizeFeedSignalModes(
+  modes: readonly FeedSignalMode[] | undefined,
+): FeedSignalMode[] {
+  if (!modes?.length) return [];
+  const unique = new Set<FeedSignalMode>();
+  for (const mode of modes) {
+    if (SELECTABLE_FEED_SIGNAL_MODES.has(mode)) {
+      unique.add(mode);
+    }
+  }
+  return [...unique];
+}
+
+export function getFeedSignalFilterPreset(
+  mode: FeedSignalMode | undefined,
+): FeedSignalFilterPreset {
+  const normalized = normalizeFeedSignalMode(mode);
+  return FEED_SIGNAL_FILTER_PRESETS.find((preset) => preset.mode === normalized)
+    ?? FEED_SIGNAL_FILTER_PRESETS[0]!;
+}
+
+export function getFeedSignalModeForFilter(filter: FilterOptions): FeedSignalMode | "custom" {
+  const signals = filter.signals ?? [];
+  if (signals.length === 0) return "all";
+
+  const activeKey = signalKey(signals);
+  const preset = FEED_SIGNAL_FILTER_PRESETS.find(
+    (candidate) => signalKey(candidate.signals) === activeKey,
+  );
+  return preset?.mode ?? "custom";
+}
+
+export function resolveFeedSignalModesFromDisplay(
+  display: Pick<DisplayPreferences, "feedSignalMode" | "feedSignalModes">,
+): FeedSignalMode[] {
+  const modes = normalizeFeedSignalModes(display.feedSignalModes);
+  if (modes.length > 0) return modes;
+  const legacyMode = normalizeFeedSignalMode(display.feedSignalMode);
+  return legacyMode === "all" ? [] : [legacyMode];
+}
+
+export function getSignalsForFeedSignalModes(
+  modes: readonly FeedSignalMode[] | undefined,
+): ContentSignal[] {
+  const selectedModes = normalizeFeedSignalModes(modes);
+  const signals = new Set<ContentSignal>();
+  for (const mode of selectedModes) {
+    const preset = getFeedSignalFilterPreset(mode);
+    for (const signal of preset.signals) {
+      signals.add(signal);
+    }
+  }
+  return [...signals];
+}
+
+export function applyFeedSignalModeToFilter(
+  filter: FilterOptions,
+  mode: FeedSignalMode | undefined,
+): FilterOptions {
+  const preset = getFeedSignalFilterPreset(mode);
+  const next: FilterOptions = { ...filter };
+  if (preset.signals.length === 0) {
+    delete next.signals;
+  } else {
+    next.signals = [...preset.signals];
+  }
+  return next;
+}
+
+export function applyFeedSignalModesToFilter(
+  filter: FilterOptions,
+  modes: readonly FeedSignalMode[] | undefined,
+): FilterOptions {
+  const next: FilterOptions = { ...filter };
+  const signals = getSignalsForFeedSignalModes(modes);
+  if (signals.length === 0) {
+    delete next.signals;
+  } else {
+    next.signals = signals;
+  }
+  return next;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -10,6 +10,10 @@ export * from "./types";
 // Re-export ranking algorithm (browser-safe, no Automerge)
 export * from "./ranking";
 
+// Re-export local content signal inference (browser-safe, no deps)
+export * from "./content-signals";
+export * from "./feed-signal-filters";
+
 // Re-export OPML utilities (browser-safe, no Automerge)
 export * from "./opml";
 

--- a/packages/shared/src/navigation-state.ts
+++ b/packages/shared/src/navigation-state.ts
@@ -1,4 +1,6 @@
 import type { BaseAppState, FilterOptions } from "./store-types.js";
+import { CONTENT_SIGNAL_KEYS } from "./content-signals";
+import type { ContentSignal } from "./types.js";
 
 export type NavigationView = BaseAppState["activeView"];
 
@@ -29,6 +31,13 @@ function uniqueSortedTags(tags: readonly string[] | undefined): string[] {
   );
 }
 
+function uniqueSortedSignals(signals: readonly string[] | undefined): ContentSignal[] {
+  if (!signals?.length) return [];
+  const allowed = new Set<string>(CONTENT_SIGNAL_KEYS);
+  return Array.from(new Set(signals.map((signal) => signal.trim()).filter((signal) => allowed.has(signal))))
+    .sort((a, b) => a.localeCompare(b)) as ContentSignal[];
+}
+
 function normalizeSocialContentFilter(
   value: FilterOptions["socialContentFilter"] | null | undefined,
 ): FilterOptions["socialContentFilter"] | undefined {
@@ -40,6 +49,7 @@ export function canonicalizeFilterOptions(filter: FilterOptions): FilterOptions 
   if (filter.archivedOnly) return { archivedOnly: true };
 
   const tags = uniqueSortedTags(filter.tags);
+  const signals = uniqueSortedSignals(filter.signals);
   const feedUrl = normalizeText(filter.feedUrl);
   const platform = feedUrl ? "rss" : normalizeText(filter.platform) ?? undefined;
   const socialContentFilter =
@@ -52,6 +62,7 @@ export function canonicalizeFilterOptions(filter: FilterOptions): FilterOptions 
   if (feedUrl) next.feedUrl = feedUrl;
   if (socialContentFilter) next.socialContentFilter = socialContentFilter;
   if (tags.length > 0) next.tags = tags;
+  if (signals.length > 0) next.signals = signals;
 
   return next;
 }
@@ -111,6 +122,7 @@ export function parseNavigationState(input: string | NavigationPathLike): Naviga
   const platform = normalizeText(params.get("platform"));
   const socialContentFilter = normalizeSocialContentFilter(params.get("content") as FilterOptions["socialContentFilter"] | null);
   const tags = uniqueSortedTags(params.getAll("tag"));
+  const signals = uniqueSortedSignals(params.getAll("signal"));
 
   let activeFilter: FilterOptions;
   if (scope === "saved") {
@@ -120,11 +132,13 @@ export function parseNavigationState(input: string | NavigationPathLike): Naviga
   } else if (feedUrl) {
     activeFilter = { platform: "rss", feedUrl };
     if (tags.length > 0) activeFilter.tags = tags;
+    if (signals.length > 0) activeFilter.signals = signals;
   } else {
     activeFilter = {};
     if (platform) activeFilter.platform = platform;
     if (socialContentFilter) activeFilter.socialContentFilter = socialContentFilter;
     if (tags.length > 0) activeFilter.tags = tags;
+    if (signals.length > 0) activeFilter.signals = signals;
   }
 
   return canonicalizeNavigationState({
@@ -166,6 +180,9 @@ export function serializeNavigationState(state: NavigationState): string {
     for (const tag of uniqueSortedTags(activeFilter.tags)) {
       params.append("tag", tag);
     }
+    for (const signal of uniqueSortedSignals(activeFilter.signals)) {
+      params.append("signal", signal);
+    }
   }
 
   if (selectedItemId) {
@@ -181,6 +198,8 @@ export function navigationStatesEqual(a: NavigationState, b: NavigationState): b
   const right = canonicalizeNavigationState(b);
   const leftTags = uniqueSortedTags(left.activeFilter.tags);
   const rightTags = uniqueSortedTags(right.activeFilter.tags);
+  const leftSignals = uniqueSortedSignals(left.activeFilter.signals);
+  const rightSignals = uniqueSortedSignals(right.activeFilter.signals);
 
   return (
     left.activeView === right.activeView
@@ -192,5 +211,7 @@ export function navigationStatesEqual(a: NavigationState, b: NavigationState): b
     && !!left.activeFilter.archivedOnly === !!right.activeFilter.archivedOnly
     && leftTags.length === rightTags.length
     && leftTags.every((tag, index) => tag === rightTags[index])
+    && leftSignals.length === rightSignals.length
+    && leftSignals.every((signal, index) => signal === rightSignals[index])
   );
 }

--- a/packages/shared/src/ranking.ts
+++ b/packages/shared/src/ranking.ts
@@ -5,7 +5,7 @@
  * Runs on Desktop/OpenClaw, results synced to edge devices.
  */
 
-import type { FeedItem, WeightPreferences } from "./types.js";
+import type { ContentSignal, FeedItem, WeightPreferences } from "./types.js";
 import type { SocialContentFilter } from "./store-types.js";
 
 /**
@@ -140,6 +140,7 @@ export function filterFeedItems(
     platform?: string;
     socialContentFilter?: SocialContentFilter;
     tags?: string[];
+    signals?: ContentSignal[];
     savedOnly?: boolean;
   } = {},
 ): FeedItem[] {
@@ -157,11 +158,7 @@ export function filterFeedItems(
     // Filter by platform
     if (options.platform && item.platform !== options.platform) return false;
 
-    if (
-      (options.platform === "facebook" || options.platform === "instagram") &&
-      options.socialContentFilter &&
-      options.socialContentFilter !== "all"
-    ) {
+    if (options.socialContentFilter && options.socialContentFilter !== "all") {
       if (options.socialContentFilter === "stories" && item.contentType !== "story") return false;
       if (options.socialContentFilter === "posts" && item.contentType === "story") return false;
     }
@@ -173,6 +170,12 @@ export function filterFeedItems(
     if (options.tags?.length) {
       const hasTag = options.tags.some((t) => item.userState.tags.includes(t));
       if (!hasTag) return false;
+    }
+
+    if (options.signals?.length) {
+      const itemSignals = item.contentSignals?.tags ?? [];
+      const hasSignal = options.signals.some((signal) => itemSignals.includes(signal));
+      if (!hasSignal) return false;
     }
 
     return true;

--- a/packages/shared/src/schema.ts
+++ b/packages/shared/src/schema.ts
@@ -17,9 +17,18 @@ import type {
   UserPreferences,
   DocumentMeta,
   FacebookCapturePreferences,
+  ContentSignal,
+  ContentSignalBackfillSummary,
+  ContentSignals,
 } from "./types.js";
 import { createDefaultPreferences, createDefaultMeta } from "./types.js";
 import { friendForAuthor, personForAuthor } from "./friends.js";
+import {
+  CONTENT_SIGNAL_KEYS,
+  CONTENT_SIGNAL_VERSION,
+  hasCurrentContentSignals,
+  inferContentSignals,
+} from "./content-signals.js";
 
 // =============================================================================
 // Document Schema
@@ -618,6 +627,55 @@ function mergeUserState(target: FeedItem["userState"], source: FeedItem["userSta
   mergeHighlights(target, source);
 }
 
+function applyContentSignalsToItem(
+  item: FeedItem,
+  signals: ContentSignals = inferContentSignals(item),
+): void {
+  const clean = stripUndefined(signals);
+  if (!item.contentSignals) {
+    item.contentSignals = clean;
+    return;
+  }
+
+  const target = item.contentSignals;
+  target.version = clean.version;
+  target.method = clean.method;
+  target.inferredAt = clean.inferredAt;
+
+  if (!target.scores) {
+    target.scores = {};
+  }
+  for (const key of Object.keys(target.scores) as ContentSignal[]) {
+    delete target.scores[key];
+  }
+  for (const signal of CONTENT_SIGNAL_KEYS) {
+    const score = clean.scores[signal];
+    if (score !== undefined) {
+      target.scores[signal] = score;
+    }
+  }
+
+  if (!target.tags) {
+    target.tags = [];
+  }
+  target.tags.splice(0, target.tags.length, ...clean.tags);
+}
+
+function feedItemUpdatesAffectContentSignals(updates: Partial<FeedItem>): boolean {
+  return (
+    "author" in updates ||
+    "content" in updates ||
+    "contentType" in updates ||
+    "location" in updates ||
+    "timeRange" in updates ||
+    "preservedContent" in updates ||
+    "publishedAt" in updates ||
+    "rssSource" in updates ||
+    "sourceUrl" in updates ||
+    "topics" in updates
+  );
+}
+
 function mergeEngagement(target: FeedItem, source: FeedItem): void {
   if (!source.engagement) return;
   if (!target.engagement) {
@@ -737,6 +795,7 @@ function mergeFeedItemInto(target: FeedItem, source: FeedItem): void {
     ),
   );
   mergeUserState(target.userState, source.userState);
+  applyContentSignalsToItem(target);
 }
 
 function dedupKeeperId(doc: FreedDoc, ids: string[]): string {
@@ -870,7 +929,11 @@ function normalizePerson(person: Person): Person {
  * @param item - The feed item to add
  */
 export function addFeedItem(doc: FreedDoc, item: FeedItem): void {
-  doc.feedItems[item.globalId] = stripUndefined(item);
+  const next = stripUndefined({ ...item }) as FeedItem;
+  if (!hasCurrentContentSignals(next)) {
+    applyContentSignalsToItem(next);
+  }
+  doc.feedItems[item.globalId] = stripUndefined(next);
 }
 
 /**
@@ -891,8 +954,107 @@ export function updateFeedItem(
 ): void {
   const existing = doc.feedItems[globalId];
   if (existing) {
-    Object.assign(existing, stripUndefined(updates));
+    const cleanUpdates = stripUndefined(updates);
+    const nextSignals = cleanUpdates.contentSignals;
+    delete cleanUpdates.contentSignals;
+    Object.assign(existing, cleanUpdates);
+    if (nextSignals) {
+      applyContentSignalsToItem(existing, nextSignals);
+    } else if (feedItemUpdatesAffectContentSignals(updates)) {
+      applyContentSignalsToItem(existing);
+    }
   }
+}
+
+function createEmptyContentSignalCounts(): Record<ContentSignal, number> {
+  return {
+    event: 0,
+    essay: 0,
+    moment: 0,
+    life_update: 0,
+    announcement: 0,
+    recommendation: 0,
+    request: 0,
+    discussion: 0,
+    promotion: 0,
+    news: 0,
+  };
+}
+
+function summarizeContentSignals(
+  doc: FreedDoc,
+  updated: number,
+  scanned: number,
+  remaining: number,
+): ContentSignalBackfillSummary {
+  const counts = createEmptyContentSignalCounts();
+  const samples: Partial<Record<ContentSignal, string[]>> = {};
+  let multiSignalCount = 0;
+  let untaggedCount = 0;
+  let total = 0;
+
+  for (const item of Object.values(doc.feedItems) as FeedItem[]) {
+    total += 1;
+    const tags = item.contentSignals?.tags ?? [];
+    if (tags.length === 0) {
+      untaggedCount += 1;
+      continue;
+    }
+    if (tags.length > 1) {
+      multiSignalCount += 1;
+    }
+    for (const tag of tags) {
+      counts[tag] += 1;
+      const signalSamples = samples[tag] ?? [];
+      if (signalSamples.length < 5) {
+        signalSamples.push(`...${item.globalId.slice(-8)}`);
+        samples[tag] = signalSamples;
+      }
+    }
+  }
+
+  return {
+    version: CONTENT_SIGNAL_VERSION,
+    total,
+    scanned,
+    updated,
+    remaining,
+    counts,
+    multiSignalCount,
+    untaggedCount,
+    samples,
+  };
+}
+
+export function summarizeDocContentSignals(doc: FreedDoc): ContentSignalBackfillSummary {
+  return summarizeContentSignals(doc, 0, 0, 0);
+}
+
+export function countContentSignalBackfillItems(doc: FreedDoc): number {
+  return (Object.values(doc.feedItems) as FeedItem[]).filter(
+    (item) => !hasCurrentContentSignals(item),
+  ).length;
+}
+
+export function backfillContentSignals(
+  doc: FreedDoc,
+  batchSize: number = 200,
+): ContentSignalBackfillSummary {
+  const staleItems = (Object.values(doc.feedItems) as FeedItem[]).filter(
+    (item) => !hasCurrentContentSignals(item),
+  );
+  const batch = staleItems.slice(0, Math.max(1, batchSize));
+
+  for (const item of batch) {
+    applyContentSignalsToItem(item);
+  }
+
+  return summarizeContentSignals(
+    doc,
+    batch.length,
+    batch.length,
+    Math.max(0, staleItems.length - batch.length),
+  );
 }
 
 /**

--- a/packages/shared/src/store-types.ts
+++ b/packages/shared/src/store-types.ts
@@ -5,7 +5,16 @@
  * implement, enabling shared UI components to work with either store.
  */
 
-import type { Account, FeedItem, Friend, Person, ReachOutLog, UserPreferences, RssFeed } from "./types.js";
+import type {
+  Account,
+  ContentSignal,
+  FeedItem,
+  Friend,
+  Person,
+  ReachOutLog,
+  UserPreferences,
+  RssFeed,
+} from "./types.js";
 
 export interface RemoveFeedOptions {
   includeItems?: boolean;
@@ -21,6 +30,7 @@ export interface FilterOptions {
   platform?: string;
   feedUrl?: string;
   tags?: string[];
+  signals?: ContentSignal[];
   savedOnly?: boolean;
   /** Direct Facebook and Instagram source views only. */
   socialContentFilter?: SocialContentFilter;

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -60,6 +60,22 @@ export type MapMode = "friends" | "all_content";
 export type MapTimeMode = "current" | "future" | "past";
 export type TimeRangeKind = "event" | "travel" | "overlap";
 
+/**
+ * Inferred intent signals used for feed filtering and ranking.
+ * These are not exclusive categories. A feed item can carry several signals.
+ */
+export type ContentSignal =
+  | "event"
+  | "essay"
+  | "moment"
+  | "life_update"
+  | "announcement"
+  | "recommendation"
+  | "request"
+  | "discussion"
+  | "promotion"
+  | "news";
+
 // =============================================================================
 // Feed Item
 // =============================================================================
@@ -177,6 +193,28 @@ export interface PreservedContent {
 
   /** When content was preserved */
   preservedAt: number;
+}
+
+export type ContentSignalMethod = "rules" | "ai" | "manual";
+
+export interface ContentSignals {
+  version: number;
+  method: ContentSignalMethod;
+  inferredAt: number;
+  scores: Partial<Record<ContentSignal, number>>;
+  tags: ContentSignal[];
+}
+
+export interface ContentSignalBackfillSummary {
+  version: number;
+  total: number;
+  scanned: number;
+  updated: number;
+  remaining: number;
+  counts: Record<ContentSignal, number>;
+  multiSignalCount: number;
+  untaggedCount: number;
+  samples: Partial<Record<ContentSignal, string[]>>;
 }
 
 /**
@@ -310,6 +348,9 @@ export interface FeedItem {
 
   /** Extracted/inferred topics */
   topics: string[];
+
+  /** Local or AI-inferred content intent signals */
+  contentSignals?: ContentSignals;
 
   /** Pre-computed priority score (0-100), calculated by Desktop/OpenClaw */
   priority?: number;
@@ -522,6 +563,7 @@ export interface ReadingEnhancements {
 }
 
 export type SidebarMode = "expanded" | "compact" | "closed";
+export type FeedSignalMode = "all" | "inspiring" | "events" | "personal" | "conversation" | "news";
 
 export interface DisplayPreferences {
   /** Items per page */
@@ -565,6 +607,12 @@ export interface DisplayPreferences {
 
   /** Saved map time filter. Unset means default to the current view. */
   mapTimeMode?: MapTimeMode;
+
+  /** Saved unified feed signal filter mode. Unset means show all items. */
+  feedSignalMode?: FeedSignalMode;
+
+  /** Saved unified feed signal filter modes. Empty means show all items. */
+  feedSignalModes?: FeedSignalMode[];
 
   /** Days to keep archived items before pruning (default: 30, 0 = never prune) */
   archivePruneDays: number;
@@ -765,6 +813,8 @@ export function createDefaultPreferences(): UserPreferences {
       friendsSidebarOpen: true,
       friendsMode: "all_content",
       mapTimeMode: "current",
+      feedSignalMode: "all",
+      feedSignalModes: [],
       archivePruneDays: 30,
     },
     xCapture: {

--- a/packages/ui/src/components/icons.tsx
+++ b/packages/ui/src/components/icons.tsx
@@ -62,6 +62,17 @@ export function ArchiveIcon({ className = "w-4 h-4", style }: IconProps) {
   );
 }
 
+/** Funnel shape for feed filtering. */
+export function FilterIcon({ className = "w-4 h-4", style }: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round" className={className} style={style} aria-hidden="true">
+      <path d="M4 5h16" />
+      <path d="M7 12h10" />
+      <path d="M10 19h4" />
+    </svg>
+  );
+}
+
 /** Location pin – map view. */
 export function MapPinIcon({ className = "w-4 h-4", style }: IconProps) {
   return (

--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -14,7 +14,12 @@ import {
 import {
   countAuthorsWithRecentLocationUpdates,
   countFriendsWithRecentLocationUpdates,
+  applyFeedSignalModesToFilter,
+  FEED_SIGNAL_FILTER_PRESETS,
+  filterFeedItems,
+  resolveFeedSignalModesFromDisplay,
   type DisplayPreferences,
+  type FeedSignalMode,
   type MapMode,
   type MapTimeMode,
   type SidebarMode,
@@ -25,6 +30,7 @@ import { SearchField } from "../SearchField.js";
 import { Tooltip } from "../Tooltip.js";
 import {
   ArchiveIcon,
+  FilterIcon,
   ReaderRailHideIcon,
   ReaderRailShowIcon,
   SidebarCollapseIcon,
@@ -269,13 +275,18 @@ export function Header({
   const showWorkspaceIdentityControls = activeView === "friends" || activeView === "map";
   const showMapTimeControls = activeView === "map";
   const showFeedBulkActions = activeView === "feed";
+  const showFeedSignalFilter = activeView === "feed" && !selectedItem;
   const showArchivedToolbar = activeView === "feed" && activeFilter.archivedOnly === true;
   const showArchivedDeleteAction = showArchivedToolbar && (display.archivePruneDays ?? 30) > 0;
   const showSocialContentControls =
     activeView === "feed" &&
     !selectedItem &&
     !activeFilter.feedUrl &&
-    (activeFilter.platform === "facebook" || activeFilter.platform === "instagram");
+    !activeFilter.savedOnly &&
+    !activeFilter.archivedOnly &&
+    (!activeFilter.platform ||
+      activeFilter.platform === "facebook" ||
+      activeFilter.platform === "instagram");
   const socialContentFilter: SocialContentFilter = activeFilter.socialContentFilter ?? "all";
 
   const unreadCount =
@@ -363,11 +374,112 @@ export function Header({
     selectedItem,
   ]);
 
+  const [signalFilterMenuOpen, setSignalFilterMenuOpen] = useState(false);
+  const signalFilterMenuRef = useRef<HTMLDivElement>(null);
+  const signalFilterButtonRef = useRef<HTMLButtonElement>(null);
+  const [signalFilterMenuPosition, setSignalFilterMenuPosition] = useState<{
+    top: number;
+    right: number;
+  } | null>(null);
+  const [signalFilterFeedback, setSignalFilterFeedback] = useState<{
+    mode: FeedSignalMode;
+    tick: number;
+  } | null>(null);
+
   const updateDisplayPreference = useCallback((patch: Partial<DisplayPreferences>) => {
     void updatePreferences({
       display: patch,
     } as Parameters<typeof updatePreferences>[0]);
   }, [updatePreferences]);
+
+  const activeFeedSignalModes = useMemo(
+    () => resolveFeedSignalModesFromDisplay(display),
+    [display],
+  );
+  const activeFeedSignalModeSet = useMemo(
+    () => new Set(activeFeedSignalModes),
+    [activeFeedSignalModes],
+  );
+  const selectableFeedSignalPresets = useMemo(
+    () => FEED_SIGNAL_FILTER_PRESETS.filter((preset) => preset.mode !== "all"),
+    [],
+  );
+  const selectableFeedSignalModes = useMemo(
+    () => selectableFeedSignalPresets.map((preset) => preset.mode),
+    [selectableFeedSignalPresets],
+  );
+  const everythingSignalPreset = FEED_SIGNAL_FILTER_PRESETS[0];
+  const allFeedSignalsSelected =
+    activeFeedSignalModes.length === 0 ||
+    activeFeedSignalModes.length === selectableFeedSignalModes.length;
+  const feedSignalFilterLabel = activeFeedSignalModes.length === 0
+    ? "Everything"
+    : activeFeedSignalModes.length === 1
+      ? FEED_SIGNAL_FILTER_PRESETS.find((preset) => preset.mode === activeFeedSignalModes[0])?.label ?? "Custom"
+      : `${activeFeedSignalModes.length.toLocaleString()} filters`;
+  const feedSignalCountBaseFilter = useMemo(() => {
+    const nextFilter = { ...activeFilter };
+    delete nextFilter.signals;
+    return nextFilter;
+  }, [activeFilter]);
+  const feedSignalCounts = useMemo(() => {
+    const counts: Record<FeedSignalMode, number> = {
+      all: filterFeedItems(items, feedSignalCountBaseFilter).length,
+      inspiring: 0,
+      events: 0,
+      personal: 0,
+      conversation: 0,
+      news: 0,
+    };
+    for (const preset of selectableFeedSignalPresets) {
+      counts[preset.mode] = filterFeedItems(items, {
+        ...feedSignalCountBaseFilter,
+        signals: [...preset.signals],
+      }).length;
+    }
+    return counts;
+  }, [feedSignalCountBaseFilter, items, selectableFeedSignalPresets]);
+
+  const handleFeedSignalModeChange = useCallback((mode: FeedSignalMode) => {
+    setSignalFilterFeedback({ mode, tick: Date.now() });
+    const nextModes = (() => {
+      if (mode === "all") return [];
+      const currentModes = allFeedSignalsSelected
+        ? selectableFeedSignalModes
+        : activeFeedSignalModes;
+      const next = currentModes.includes(mode)
+        ? currentModes.filter((candidate) => candidate !== mode)
+        : [...currentModes, mode];
+      return next.length === selectableFeedSignalModes.length ? [] : next;
+    })();
+    setFilter(applyFeedSignalModesToFilter(activeFilter, nextModes));
+    updateDisplayPreference({
+      feedSignalMode: nextModes.length === 1 ? nextModes[0] : "all",
+      feedSignalModes: nextModes,
+    });
+  }, [
+    activeFeedSignalModes,
+    activeFilter,
+    allFeedSignalsSelected,
+    selectableFeedSignalModes,
+    setFilter,
+    updateDisplayPreference,
+  ]);
+
+  const updateSignalFilterMenuPosition = useCallback(() => {
+    const button = signalFilterButtonRef.current;
+    if (!button) return;
+    const rect = button.getBoundingClientRect();
+    setSignalFilterMenuPosition({
+      top: Math.round(rect.bottom + 8),
+      right: Math.max(8, Math.round(window.innerWidth - rect.right)),
+    });
+  }, []);
+
+  const toggleSignalFilterMenu = useCallback(() => {
+    updateSignalFilterMenuPosition();
+    setSignalFilterMenuOpen((value) => !value);
+  }, [updateSignalFilterMenuPosition]);
 
   const handleIdentityModeChange = useCallback((key: "friendsMode" | "mapMode", mode: MapMode) => {
     updateDisplayPreference({ [key]: mode });
@@ -651,6 +763,33 @@ export function Header({
       document.removeEventListener("keydown", handleKey);
     };
   }, [dropdownOpen]);
+
+  useEffect(() => {
+    if (!signalFilterMenuOpen) return;
+    const handleClick = (e: MouseEvent) => {
+      if (
+        signalFilterMenuRef.current &&
+        !signalFilterMenuRef.current.contains(e.target as Node)
+        && signalFilterButtonRef.current &&
+        !signalFilterButtonRef.current.contains(e.target as Node)
+      ) {
+        setSignalFilterMenuOpen(false);
+      }
+    };
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setSignalFilterMenuOpen(false);
+    };
+    document.addEventListener("mousedown", handleClick);
+    document.addEventListener("keydown", handleKey);
+    window.addEventListener("resize", updateSignalFilterMenuPosition);
+    window.addEventListener("scroll", updateSignalFilterMenuPosition, true);
+    return () => {
+      document.removeEventListener("mousedown", handleClick);
+      document.removeEventListener("keydown", handleKey);
+      window.removeEventListener("resize", updateSignalFilterMenuPosition);
+      window.removeEventListener("scroll", updateSignalFilterMenuPosition, true);
+    };
+  }, [signalFilterMenuOpen, updateSignalFilterMenuPosition]);
 
   useEffect(() => {
     if (!showToolbarSearch) return;
@@ -1140,23 +1279,6 @@ export function Header({
                   ) : null}
                 </ToolbarAnimatedSlot>
 
-                <ToolbarAnimatedSlot visible={showSocialContentControls} width="11rem" className="hidden md:flex">
-                  {showSocialContentControls ? (
-                    <ToolbarToggleGroup
-                      dataTestId="social-content-toolbar-filter"
-                      options={[
-                        { value: "all", label: "All" },
-                        { value: "posts", label: "Posts" },
-                        { value: "stories", label: "Stories" },
-                      ]}
-                      value={socialContentFilter}
-                      onChange={handleSocialContentFilterChange}
-                      compact
-                      getButtonProps={getToolbarControlProps}
-                    />
-                  ) : null}
-                </ToolbarAnimatedSlot>
-
                 <ToolbarAnimatedSlot visible={showFeedBulkActions && unreadCount > 0} width="9.5rem" className="hidden lg:flex">
                   {showFeedBulkActions && unreadCount > 0 ? (
                     <Tooltip label={`Mark all ${unreadCount.toLocaleString()} items as read`} className="hidden lg:flex">
@@ -1191,6 +1313,46 @@ export function Header({
                   ) : null}
                 </ToolbarAnimatedSlot>
 
+                <ToolbarAnimatedSlot visible={showSocialContentControls} width="11rem" className="hidden md:flex">
+                  {showSocialContentControls ? (
+                    <ToolbarToggleGroup
+                      dataTestId="social-content-toolbar-filter"
+                      options={[
+                        { value: "all", label: "All" },
+                        { value: "posts", label: "Posts" },
+                        { value: "stories", label: "Stories" },
+                      ]}
+                      value={socialContentFilter}
+                      onChange={handleSocialContentFilterChange}
+                      compact
+                      getButtonProps={getToolbarControlProps}
+                    />
+                  ) : null}
+                </ToolbarAnimatedSlot>
+
+                <ToolbarAnimatedSlot visible={showFeedSignalFilter} width="10rem" className="hidden sm:flex">
+                  {showFeedSignalFilter ? (
+                    <div className="relative flex">
+                      <Tooltip label="Filter feed">
+                        <button
+                          ref={signalFilterButtonRef}
+                          type="button"
+                          onClick={toggleSignalFilterMenu}
+                          {...getToolbarControlProps()}
+                          data-testid="feed-signal-filter-button"
+                          className="theme-toolbar-button-neutral inline-flex h-9 items-center gap-2 rounded-lg px-3 text-sm font-semibold shadow-sm"
+                          aria-haspopup="menu"
+                          aria-expanded={signalFilterMenuOpen}
+                          aria-label="Filter feed"
+                        >
+                          <FilterIcon className="h-4 w-4" />
+                          <span className="hidden md:inline">{feedSignalFilterLabel}</span>
+                        </button>
+                      </Tooltip>
+                    </div>
+                  ) : null}
+                </ToolbarAnimatedSlot>
+
                 <ToolbarAnimatedSlot visible={showFriendsSidebarToggle} width="3rem" className="hidden md:flex">
                   {showFriendsSidebarToggle ? (
                     <Tooltip label={friendsSidebarOpen ? "Hide details" : "Show details"}>
@@ -1217,6 +1379,64 @@ export function Header({
           </div>
         </div>
       </header>
+
+      {signalFilterMenuOpen && showFeedSignalFilter ? (
+        <div
+          ref={signalFilterMenuRef}
+          data-testid="feed-signal-filter-menu"
+          role="menu"
+          className="theme-dialog-shell fixed z-[300] w-[20rem] overflow-hidden py-2 shadow-2xl shadow-black/35"
+          style={{
+            top: signalFilterMenuPosition?.top ?? 60,
+            right: signalFilterMenuPosition?.right ?? 8,
+            ...(headerDragRegion ? noDrag : {}),
+          }}
+        >
+          {[everythingSignalPreset, ...selectableFeedSignalPresets].map((preset) => {
+            const selected = preset.mode === "all"
+              ? allFeedSignalsSelected
+              : allFeedSignalsSelected || activeFeedSignalModeSet.has(preset.mode);
+            const feedbackKey = signalFilterFeedback?.mode === preset.mode
+              ? signalFilterFeedback.tick
+              : 0;
+            return (
+              <button
+                key={preset.mode}
+                type="button"
+                role="menuitemcheckbox"
+                aria-checked={selected}
+                onClick={() => handleFeedSignalModeChange(preset.mode)}
+                className={`flex w-full items-start gap-4 py-3.5 pl-7 pr-6 text-left transition-colors hover:bg-[var(--theme-bg-muted)] ${
+                  selected ? "text-[var(--theme-text-primary)]" : "text-[var(--theme-text-secondary)]"
+                }`}
+              >
+                <span
+                  key={`${preset.mode}-${selected ? "checked" : "empty"}-${feedbackKey}`}
+                  className={`feed-signal-checkbox mt-0.5 ${selected ? "feed-signal-checkbox-checked" : ""} ${
+                    feedbackKey ? "feed-signal-checkbox-feedback" : ""
+                  }`}
+                  aria-hidden="true"
+                >
+                  {selected ? (
+                    <svg className="feed-signal-check-icon h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                    </svg>
+                  ) : null}
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="block text-sm font-medium">{preset.label}</span>
+                  <span className="block text-xs leading-5 text-[var(--theme-text-muted)]">
+                    {preset.description}
+                  </span>
+                </span>
+                <span className="mt-0.5 shrink-0 text-xs tabular-nums text-[var(--theme-text-muted)]">
+                  {feedSignalCounts[preset.mode].toLocaleString()}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      ) : null}
 
       {showNewButton && (
         <div

--- a/packages/ui/src/hooks/useSearchResults.ts
+++ b/packages/ui/src/hooks/useSearchResults.ts
@@ -58,7 +58,7 @@ function toSearchDoc(item: FeedItem): SearchDoc {
     authorHandle: item.author.handle,
     feedTitle: item.rssSource?.feedTitle ?? "",
     preservedText: item.preservedContent?.text?.slice(0, SEARCH_PRESERVED_TEXT_LIMIT) ?? "",
-    topics: item.topics.join(" "),
+    topics: [...item.topics, ...(item.contentSignals?.tags ?? [])].join(" "),
     tags: (item.userState.tags ?? []).join(" "),
     highlights: (item.userState.highlights ?? [])
       .map((h) => `${h.text} ${h.note ?? ""}`)

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -2503,6 +2503,63 @@ input[type="radio"]:focus-visible {
   animation: pulse 1.5s ease-in-out infinite;
 }
 
+.feed-signal-checkbox {
+  display: flex;
+  width: 1.75rem;
+  height: 1.75rem;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--theme-border-subtle);
+  border-radius: 999px;
+  background: transparent;
+  color: transparent;
+  transition:
+    border-color 0.18s ease,
+    color 0.18s ease,
+    transform 0.18s ease;
+}
+
+.feed-signal-checkbox-checked {
+  border-color: var(--theme-text-secondary);
+  color: var(--theme-text-primary);
+}
+
+.feed-signal-checkbox-feedback {
+  animation: feed-signal-checkbox-pulse 0.32s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.feed-signal-check-icon {
+  animation: feed-signal-check-in 0.22s cubic-bezier(0.22, 1, 0.36, 1);
+  transform-origin: center;
+}
+
+@keyframes feed-signal-checkbox-pulse {
+  0% {
+    transform: scale(1);
+    box-shadow: 0 0 0 0 rgb(var(--theme-accent-secondary-rgb) / 0);
+  }
+  42% {
+    transform: scale(1.08);
+    box-shadow: 0 0 0 5px rgb(var(--theme-accent-secondary-rgb) / 0.18);
+  }
+  100% {
+    transform: scale(1);
+    box-shadow: 0 0 0 9px rgb(var(--theme-accent-secondary-rgb) / 0);
+  }
+}
+
+@keyframes feed-signal-check-in {
+  0% {
+    opacity: 0;
+    transform: scale(0.72);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
 @keyframes pulse {
   0%,
   100% {

--- a/website/src/app/roadmap/RoadmapContent.tsx
+++ b/website/src/app/roadmap/RoadmapContent.tsx
@@ -783,7 +783,7 @@ const phases: Phase[] = [
     number: 10,
     title: "Polish",
     description:
-      "Onboarding, statistics, AI features, plugin API, community infrastructure, and deeper crash recovery hardening.",
+      "Onboarding, statistics, local content signals with saved feed filter presets, AI features, plugin API, community infrastructure, and deeper crash recovery hardening.",
     status: "upcoming",
     planLink:
       "https://github.com/freed-project/freed/blob/dev/docs/PHASE-10-POLISH.md",


### PR DESCRIPTION
(AI Generated).

## Summary
- Add local content signal metadata, deterministic inference, and automatic inference on ingest.
- Add resumable Freed Desktop signal backfill with versioned stale detection.
- Add saved unified feed signal filters, multi-select counts, news classification, and unified posts and stories filtering.

## Testing
- npm run validate:feature