### PR TITLE
fix: unblock Turnstile fallback signups

### DIFF
--- a/website/src/app/api/subscribe/route.ts
+++ b/website/src/app/api/subscribe/route.ts
@@ -17,6 +17,7 @@ const TURNSTILE_VERIFY_ENDPOINT =
 const RATE_LIMIT_WINDOW_MS = 10 * 60 * 1000;
 const RATE_LIMIT_MAX_REQUESTS = 6;
 const EMAIL_COOLDOWN_MS = 60 * 1000;
+const TURNSTILE_UNAVAILABLE_TOKEN = "turnstile-unavailable";
 
 const requestBuckets = new Map<string, { count: number; resetAt: number }>();
 const recentEmailSubmissions = new Map<string, number>();
@@ -157,6 +158,8 @@ export async function POST(request: NextRequest) {
     const normalizedName = (body.name ?? "").trim();
     const normalizedPhoneNumber = normalizePhoneNumber(body.phoneNumber ?? "");
     const turnstileToken = (body.turnstileToken ?? "").trim();
+    const isTurnstileUnavailable =
+      turnstileToken === TURNSTILE_UNAVAILABLE_TOKEN;
     const honeypotValue = (body.company ?? "").trim();
 
     if (honeypotValue) {
@@ -204,20 +207,22 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const turnstileResult = await verifyTurnstileToken(turnstileToken, request);
+    if (!isTurnstileUnavailable) {
+      const turnstileResult = await verifyTurnstileToken(turnstileToken, request);
 
-    if (!turnstileResult.success) {
-      const errorCodes = turnstileResult["error-codes"] ?? [];
-      const isExpired = errorCodes.includes("timeout-or-duplicate");
+      if (!turnstileResult.success) {
+        const errorCodes = turnstileResult["error-codes"] ?? [];
+        const isExpired = errorCodes.includes("timeout-or-duplicate");
 
-      return NextResponse.json(
-        {
-          error: isExpired
-            ? "That human check expired. Please try again."
-            : "We could not verify the human check. Please try again.",
-        },
-        { status: 400 }
-      );
+        return NextResponse.json(
+          {
+            error: isExpired
+              ? "That human check expired. Please try again."
+              : "We could not verify the human check. Please try again.",
+          },
+          { status: 400 }
+        );
+      }
     }
 
     if (isEmailCoolingDown(normalizedEmail)) {

--- a/website/src/components/TurnstileWidget.tsx
+++ b/website/src/components/TurnstileWidget.tsx
@@ -3,6 +3,8 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import Script from "next/script";
 
+const TURNSTILE_UNAVAILABLE_TOKEN = "turnstile-unavailable";
+
 declare global {
   interface Window {
     turnstile?: {
@@ -65,7 +67,7 @@ export default function TurnstileWidget({
 
   const markFailed = useCallback(() => {
     clearVerificationTimer();
-    emitTokenChange("");
+    emitTokenChange(TURNSTILE_UNAVAILABLE_TOKEN);
     setVerificationState("failed");
   }, [clearVerificationTimer, emitTokenChange]);
 
@@ -162,7 +164,7 @@ export default function TurnstileWidget({
       <div ref={containerRef} className="min-h-[68px]" />
       {verificationState === "failed" ? (
         <div className="mt-2 flex flex-wrap items-center gap-2 text-xs leading-relaxed text-[rgb(var(--theme-feedback-danger-rgb))]">
-          <span>Human check is taking too long.</span>
+          <span>Human check is taking too long. Try again, or submit below.</span>
           <button
             type="button"
             onClick={rerenderWidget}


### PR DESCRIPTION
(AI Generated).

## Summary
- Let the modal surface a submit path when Turnstile never returns a token.
- Accept the explicit Turnstile unavailable fallback token server-side.
- Keep retry, email validation, honeypot handling, and rate limiting in place.

## Test Plan
- git diff --check
- Vercel production build from www