### PR TITLE
fix: simplify subscription success flow

### DIFF
--- a/docs/PHASE-1-FOUNDATION.md
+++ b/docs/PHASE-1-FOUNDATION.md
@@ -131,7 +131,7 @@ Next.js 15 (App Router) site deployed to Vercel at freed.wtf.
 - RSS/Atom feed generation at build time
 - Public legal pages for Terms of Use, Privacy, and Desktop EULA
 - Get Freed modal now scrolls internally on small screens, removes the extra mobile subtitle under the main title, keeps the mobile signup and launch headings on matching vertical spacing, simplifies the mobile section copy, gives the mobile launch CTA a primary-tinted treatment, closes reliably from the `X` button even on direct `/get` visits, and defaults real mobile devices to a `Freed Web` launch target while still offering every desktop download explicitly
-- Mobile homepage hero now shows a direct email entry form that prefills the protected Get Freed signup flow, while desktop keeps the modal-first newsletter and download CTA
+- Mobile homepage hero now shows a direct email entry form that prefills the protected Get Freed signup flow, then swaps to a success message after subscription, while the modal now presents subscription and download as one progressive flow
 - Mobile nav header now keeps a top-level `Get Freed` CTA beside the hamburger once the user scrolls away from the top of the homepage or lands on any non-home page, animating it in smoothly while the full mobile menu still exposes the same primary action inside the drawer
 - Marketing homepage now stays in its single-column mobile layout through tablet widths, including the mobile nav, compact hero treatment, and stacked content grids, before switching to desktop layouts at `lg`
 - Marketing-site manifesto buttons now use the shared theme secondary button treatment consistently, including both `Read the Manifesto` and `Why We Built This`

--- a/website/src/components/Hero.tsx
+++ b/website/src/components/Hero.tsx
@@ -12,7 +12,7 @@ const ROTATING_WORDS = ["Feed", "Life", "Mind"];
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 export default function Hero() {
-  const { openModal } = useNewsletter();
+  const { isSubscribed, openModal } = useNewsletter();
   const [wordIndex, setWordIndex] = useState(0);
   const [compactHeroAnimation, setCompactHeroAnimation] = useState(false);
   const [mobileEmail, setMobileEmail] = useState("");
@@ -137,57 +137,98 @@ export default function Hero() {
             people.
           </p>
 
-          <form
-            onSubmit={handleMobileSignup}
-            className="mx-auto flex w-full max-w-md flex-col gap-2 lg:hidden"
-          >
-            <label htmlFor="mobile-newsletter-email" className="sr-only">
-              Email
-            </label>
-            <div className="flex w-full items-stretch rounded-xl border border-[color-mix(in_srgb,var(--theme-border-strong)_82%,transparent)] bg-[color-mix(in_srgb,var(--theme-bg-elevated)_96%,transparent)] shadow-[0_0_0_1px_rgb(255_255_255_/_0.04),inset_0_1px_0_rgb(255_255_255_/_0.05)]">
-              <input
-                id="mobile-newsletter-email"
-                type="email"
-                value={mobileEmail}
-                onChange={(event) => {
-                  setMobileEmail(event.target.value);
-                  if (mobileEmailError) setMobileEmailError("");
-                }}
-                placeholder="your@email.com"
-                className="min-w-0 flex-1 bg-transparent px-4 py-3 text-sm text-text-primary placeholder:text-text-muted focus:outline-none"
-                autoComplete="email"
-                inputMode="email"
-                aria-invalid={!!mobileEmailError}
-                aria-describedby={
-                  mobileEmailError ? "mobile-newsletter-error" : undefined
-                }
-                maxLength={254}
-                required
-              />
-              <button
-                type="submit"
-                className="shrink-0 rounded-r-xl px-4 text-sm font-semibold text-[var(--theme-button-primary-text)]"
-                style={{
-                  background: "var(--theme-button-primary-bg)",
-                }}
-              >
-                Join Us
-              </button>
+          {isSubscribed ? (
+            <div
+              role="status"
+              aria-live="polite"
+              className="mx-auto flex w-full max-w-md gap-3 rounded-xl border p-4 text-left lg:hidden"
+              style={{
+                background:
+                  "color-mix(in srgb, rgb(var(--theme-feedback-success-rgb)) 10%, var(--theme-bg-elevated))",
+                borderColor:
+                  "color-mix(in srgb, rgb(var(--theme-feedback-success-rgb)) 38%, var(--theme-border-strong))",
+                boxShadow:
+                  "0 0 0 1px rgb(255 255 255 / 0.04), inset 0 1px 0 rgb(255 255 255 / 0.05)",
+              }}
+            >
+              <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-[rgb(var(--theme-feedback-success-rgb))] text-white">
+                <svg
+                  aria-hidden="true"
+                  className="h-5 w-5"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={2.5}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M4.5 12.75l6 6 9-13.5"
+                  />
+                </svg>
+              </div>
+              <div className="space-y-1">
+                <p className="text-sm font-semibold text-text-primary">
+                  You are now subscribed.
+                </p>
+                <p className="text-xs leading-relaxed text-text-secondary">
+                  We will email you a download link when Freed launches.
+                </p>
+              </div>
             </div>
-            {mobileEmailError && (
-              <p
-                id="mobile-newsletter-error"
-                role="status"
-                className="text-left text-xs text-[rgb(var(--theme-feedback-danger-rgb))]"
-              >
-                {mobileEmailError}
+          ) : (
+            <form
+              onSubmit={handleMobileSignup}
+              className="mx-auto flex w-full max-w-md flex-col gap-2 lg:hidden"
+            >
+              <label htmlFor="mobile-newsletter-email" className="sr-only">
+                Email
+              </label>
+              <div className="flex w-full items-stretch rounded-xl border border-[color-mix(in_srgb,var(--theme-border-strong)_82%,transparent)] bg-[color-mix(in_srgb,var(--theme-bg-elevated)_96%,transparent)] shadow-[0_0_0_1px_rgb(255_255_255_/_0.04),inset_0_1px_0_rgb(255_255_255_/_0.05)]">
+                <input
+                  id="mobile-newsletter-email"
+                  type="email"
+                  value={mobileEmail}
+                  onChange={(event) => {
+                    setMobileEmail(event.target.value);
+                    if (mobileEmailError) setMobileEmailError("");
+                  }}
+                  placeholder="your@email.com"
+                  className="min-w-0 flex-1 bg-transparent px-4 py-3 text-sm text-text-primary placeholder:text-text-muted focus:outline-none"
+                  autoComplete="email"
+                  inputMode="email"
+                  aria-invalid={!!mobileEmailError}
+                  aria-describedby={
+                    mobileEmailError ? "mobile-newsletter-error" : undefined
+                  }
+                  maxLength={254}
+                  required
+                />
+                <button
+                  type="submit"
+                  className="shrink-0 rounded-r-xl px-4 text-sm font-semibold text-[var(--theme-button-primary-text)]"
+                  style={{
+                    background: "var(--theme-button-primary-bg)",
+                  }}
+                >
+                  Join Us
+                </button>
+              </div>
+              {mobileEmailError && (
+                <p
+                  id="mobile-newsletter-error"
+                  role="status"
+                  className="text-left text-xs text-[rgb(var(--theme-feedback-danger-rgb))]"
+                >
+                  {mobileEmailError}
+                </p>
+              )}
+              <p className="text-xs leading-relaxed text-text-muted">
+                Freed is in early beta. You'll receive a download link when we
+                launch 🚀
               </p>
-            )}
-            <p className="text-xs leading-relaxed text-text-muted">
-              We're in early beta. You'll receive a free download link when we
-              launch 🚀
-            </p>
-          </form>
+            </form>
+          )}
 
           <div className="hidden flex-col flex-wrap justify-center gap-3 lg:flex lg:flex-row lg:justify-start lg:gap-4">
             <motion.button

--- a/website/src/components/NewsletterModal.tsx
+++ b/website/src/components/NewsletterModal.tsx
@@ -180,6 +180,7 @@ export default function NewsletterModal() {
   const {
     isOpen,
     closeModal,
+    markSubscribed,
     prefillEmail,
     prefillDetailsOpen,
   } = useNewsletter();
@@ -392,6 +393,7 @@ export default function NewsletterModal() {
           setDetailsOpen(false);
           setNameManuallyEdited(false);
           setState("idle");
+          markSubscribed();
           setSuccessMessage(
             "You are subscribed. We will email you about new builds and major progress."
           );
@@ -410,7 +412,16 @@ export default function NewsletterModal() {
         setTurnstileResetKey((current) => current + 1);
       }
     },
-    [company, detailsOpen, email, name, phoneNumber, state, turnstileToken],
+    [
+      company,
+      detailsOpen,
+      email,
+      markSubscribed,
+      name,
+      phoneNumber,
+      state,
+      turnstileToken,
+    ],
   );
 
   const handleClose = useCallback(() => {
@@ -456,6 +467,7 @@ export default function NewsletterModal() {
   const normalizedEmailInput = email.trim().toLowerCase();
   const isEmailInputValid = isValidEmailAddress(normalizedEmailInput);
   const isPhoneInputValid = isValidPhoneNumber(phoneNumber);
+  const isSubscribed = Boolean(successMessage);
 
   const handleOpenFreedWeb = useCallback(() => {
     window.open(freedWebUrl, "_blank", "noopener,noreferrer");
@@ -539,7 +551,7 @@ export default function NewsletterModal() {
           >
             <div
               ref={modalPanelRef}
-              className="newsletter-modal theme-panel relative w-full max-w-5xl overflow-hidden rounded-2xl"
+              className="newsletter-modal theme-panel relative w-full max-w-3xl overflow-hidden rounded-2xl"
             >
               <div
                 className="absolute top-0 left-1/4 h-32 w-32 rounded-full blur-3xl"
@@ -599,8 +611,8 @@ export default function NewsletterModal() {
                     </p>
                   </div>
 
-                  <div className="grid gap-0 lg:grid-cols-2 lg:items-start">
-                    <div className="pb-2 sm:py-4 lg:pr-8">
+                  <div className="mx-auto max-w-xl space-y-8">
+                    <section className="space-y-6">
                       <div className="mb-6 max-w-md">
                         <h4 className="flex items-center gap-4 text-2xl font-bold text-text-primary sm:text-3xl">
                           <CircledStepNumber>1</CircledStepNumber>
@@ -608,7 +620,50 @@ export default function NewsletterModal() {
                         </h4>
                       </div>
 
-                      <div className="relative">
+                      {isSubscribed && (
+                        <div
+                          role="status"
+                          aria-live="polite"
+                          className="rounded-xl border p-5"
+                          style={{
+                            background:
+                              "color-mix(in srgb, rgb(var(--theme-feedback-success-rgb)) 10%, var(--theme-bg-elevated))",
+                            borderColor:
+                              "color-mix(in srgb, rgb(var(--theme-feedback-success-rgb)) 38%, var(--theme-border-strong))",
+                            boxShadow:
+                              "0 0 0 1px rgb(255 255 255 / 0.04), inset 0 1px 0 rgb(255 255 255 / 0.05)",
+                          }}
+                        >
+                          <div className="flex gap-4">
+                            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-[rgb(var(--theme-feedback-success-rgb))] text-white">
+                              <svg
+                                aria-hidden="true"
+                                className="h-5 w-5"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                                stroke="currentColor"
+                                strokeWidth={2.5}
+                              >
+                                <path
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                  d="M4.5 12.75l6 6 9-13.5"
+                                />
+                              </svg>
+                            </div>
+                            <div className="space-y-1">
+                              <p className="text-base font-semibold text-text-primary">
+                                You are now subscribed.
+                              </p>
+                              <p className="text-sm leading-relaxed text-text-secondary">
+                                We will email you about new builds and major progress.
+                              </p>
+                            </div>
+                          </div>
+                        </div>
+                      )}
+                      {!isSubscribed && (
+                        <div className="relative">
                         <form onSubmit={handleSubmit} className="space-y-3">
                           <div
                             aria-hidden="true"
@@ -801,15 +856,6 @@ export default function NewsletterModal() {
                             )}
                           </AnimatePresence>
 
-                          {successMessage && (
-                            <p
-                              role="status"
-                              aria-live="polite"
-                              className="text-xs leading-relaxed text-[rgb(var(--theme-feedback-success-rgb))]"
-                            >
-                              {successMessage}
-                            </p>
-                          )}
                           {state === "error" && (
                             <p
                               id="newsletter-error"
@@ -825,9 +871,11 @@ export default function NewsletterModal() {
                           </p>
                         </form>
                       </div>
-                    </div>
+                      )}
+                    </section>
 
-                    <div className="space-y-5 pt-10 pb-2 sm:py-4 lg:pt-4 lg:pl-8 lg:border-l lg:border-freed-border">
+                    {isSubscribed && (
+                      <section className="space-y-5 border-t border-freed-border pt-6 pb-2">
                       <div className="max-w-lg space-y-2">
                         <h4 className="flex items-center gap-4 text-2xl font-bold text-text-primary sm:text-3xl">
                           <CircledStepNumber>2</CircledStepNumber>
@@ -981,8 +1029,9 @@ export default function NewsletterModal() {
                             </button>
                           )}
                         </div>
-                      </div>
-                    </div>
+                      </section>
+                    )}
+                  </div>
                 </>
               </div>
             </div>

--- a/website/src/context/NewsletterContext.tsx
+++ b/website/src/context/NewsletterContext.tsx
@@ -15,11 +15,13 @@ const MODAL_PATH = "/get";
 
 interface NewsletterContextType {
   isOpen: boolean;
+  isSubscribed: boolean;
   openModal: (options?: {
     email?: string;
     detailsOpen?: boolean;
   }) => void;
   closeModal: () => void;
+  markSubscribed: () => void;
   prefillEmail: string;
   prefillDetailsOpen: boolean;
 }
@@ -30,6 +32,7 @@ const NewsletterContext = createContext<NewsletterContextType | undefined>(
 
 export function NewsletterProvider({ children }: { children: ReactNode }) {
   const [isOpen, setIsOpen] = useState(false);
+  const [isSubscribed, setIsSubscribed] = useState(false);
   const [prefillEmail, setPrefillEmail] = useState("");
   const [prefillDetailsOpen, setPrefillDetailsOpen] = useState(false);
   const pathname = usePathname();
@@ -82,6 +85,10 @@ export function NewsletterProvider({ children }: { children: ReactNode }) {
     }
   }, [router]);
 
+  const markSubscribed = useCallback(() => {
+    setIsSubscribed(true);
+  }, []);
+
   // Handle browser back/forward
   useEffect(() => {
     const onPopState = () => {
@@ -96,8 +103,10 @@ export function NewsletterProvider({ children }: { children: ReactNode }) {
     <NewsletterContext.Provider
       value={{
         isOpen,
+        isSubscribed,
         openModal,
         closeModal,
+        markSubscribed,
         prefillEmail,
         prefillDetailsOpen,
       }}


### PR DESCRIPTION
(AI Generated).

## Summary
- Turn the Get Freed modal into a progressive subscription then download flow.
- Replace the post-subscription form with a bordered success state.
- Swap the mobile homepage signup form to a success message after subscribing.

## Test Plan
- git diff --check
- Local dev server compiled / and /get
- Vercel production build from www