### PR TITLE
fix: update rss source test fixture

### DIFF
--- a/packages/desktop/src/lib/content-signals.test.ts
+++ b/packages/desktop/src/lib/content-signals.test.ts
@@ -107,7 +107,7 @@ describe("content signals", () => {
         rssSource: {
           feedUrl: "https://www.reuters.com/rss",
           feedTitle: "Reuters",
-          itemGuid: "news-1",
+          siteUrl: "https://www.reuters.com",
         },
         content: {
           text: "Reuters reports that regulators announced a new policy after officials reviewed new data.",


### PR DESCRIPTION
(AI Generated).

## Summary
- Replace the stale RSS source test fixture field with the current `siteUrl` field.
- Keep production validation aligned with the shared `RssSourceInfo` contract.

## Validation
- corepack npm run build --workspace=packages/desktop
- corepack npm run test:unit --workspace=packages/desktop -- content-signals.test.ts