### PR TITLE
fix: speed up production validation stress tests

### DIFF
--- a/packages/desktop/tests/e2e/smoke.spec.ts
+++ b/packages/desktop/tests/e2e/smoke.spec.ts
@@ -330,17 +330,21 @@ async function seedStressIdentityGraph(page: Page) {
     };
 
     const now = Date.now();
-    const persons = Array.from({ length: 1_000 }, (_, index) => ({
+    const personCount = 360;
+    const accountCount = 1_440;
+    const feedCount = 80;
+    const friendCutoff = Math.round(personCount * 0.82);
+    const persons = Array.from({ length: personCount }, (_, index) => ({
       id: `stress-person-${index}`,
       name: `Stress Person ${index}`,
-      relationshipStatus: index < 820 ? "friend" : "connection",
-      careLevel: index < 820 ? 3 + (index % 3) : 2,
+      relationshipStatus: index < friendCutoff ? "friend" : "connection",
+      careLevel: index < friendCutoff ? 3 + (index % 3) : 2,
       createdAt: now,
       updatedAt: now,
     }));
-    const accounts = Array.from({ length: 5_000 }, (_, index) => ({
+    const accounts = Array.from({ length: accountCount }, (_, index) => ({
       id: `stress-account-${index}`,
-      personId: `stress-person-${index % 1_000}`,
+      personId: `stress-person-${index % personCount}`,
       kind: "social",
       provider: index % 5 === 0 ? "rss" : index % 5 === 1 ? "instagram" : index % 5 === 2 ? "linkedin" : index % 5 === 3 ? "facebook" : "x",
       externalId: `stress-external-${index}`,
@@ -352,7 +356,7 @@ async function seedStressIdentityGraph(page: Page) {
       createdAt: now,
       updatedAt: now,
     }));
-    const feeds = Array.from({ length: 180 }, (_, index) => ({
+    const feeds = Array.from({ length: feedCount }, (_, index) => ({
       url: `https://stress.example/feed-${index}.xml`,
       title: `Stress Feed ${index}`,
       enabled: true,

--- a/packages/desktop/tests/e2e/theme-switching.spec.ts
+++ b/packages/desktop/tests/e2e/theme-switching.spec.ts
@@ -225,9 +225,17 @@ test("rapid theme browsing only persists the final selected theme", async ({ app
     });
   });
 
-  await page.getByRole("button", { name: /^Ember\./ }).click();
-  await page.getByRole("button", { name: /^Midas\./ }).click();
-  await page.getByRole("button", { name: /^Scriptorium\./ }).click();
+  await page.evaluate(() => {
+    const labels = [/^Ember\./, /^Midas\./, /^Scriptorium\./];
+    const buttons = Array.from(document.querySelectorAll("button"));
+    for (const label of labels) {
+      const button = buttons.find((candidate) => label.test(candidate.getAttribute("aria-label") ?? ""));
+      if (!button) {
+        throw new Error(`Theme button not found for ${label.source}`);
+      }
+      button.click();
+    }
+  });
 
   await expect.poll(async () => {
     return page.evaluate(() => document.documentElement.dataset.theme);


### PR DESCRIPTION
(AI Generated).

## Summary
- Reduce the Friends graph stress fixture while keeping more than 1,000 graph nodes under test.
- Make the rapid theme browsing test trigger the rapid clicks in one browser task so debounce behavior is tested deterministically.

## Validation
- BASE_URL=http://localhost:1423 corepack npm run test:e2e --workspace=packages/desktop -- smoke.spec.ts --grep "stress Friends graph degrades labels"
- BASE_URL=http://localhost:1423 corepack npm run test:e2e --workspace=packages/desktop -- theme-switching.spec.ts --grep "rapid theme browsing"