### PR TITLE
fix: stabilize release validation e2e

### DIFF
--- a/packages/desktop/tests/e2e/smoke.spec.ts
+++ b/packages/desktop/tests/e2e/smoke.spec.ts
@@ -4054,6 +4054,7 @@ test("Friends graph renders confirmed friends, provisional people, and channels 
 });
 
 test("dragging a channel onto a person re-links it and the graph state survives reload", async ({ app, page }) => {
+  test.setTimeout(45_000);
   await page.setViewportSize({ width: 1440, height: 900 });
   await app.goto();
   await app.waitForReady();
@@ -4133,6 +4134,7 @@ test("dragging a channel onto a person re-links it and the graph state survives 
   await expect.poll(async () => {
     return viewport.evaluate((element) => Number((element as HTMLElement).dataset.graphNodeCount ?? "0"));
   }).toBeGreaterThanOrEqual(3);
+  await waitForGraphPerfToSettle(page);
 
   const accountPoint = await graphNodeScreenPoint(page, { accountId: "social:instagram:nora-ig" });
   const personPoint = await graphNodeScreenPoint(page, { personId: "friend-ada" });
@@ -4141,7 +4143,13 @@ test("dragging a channel onto a person re-links it and the graph state survives 
 
   await page.mouse.move(accountPoint!.x, accountPoint!.y);
   await page.mouse.down();
-  await page.mouse.move(personPoint!.x, personPoint!.y, { steps: 12 });
+  await page.mouse.move((accountPoint!.x + personPoint!.x) / 2, (accountPoint!.y + personPoint!.y) / 2, {
+    steps: 8,
+  });
+  await page.mouse.move(personPoint!.x, personPoint!.y, { steps: 16 });
+  await page.waitForTimeout(100);
+  await page.mouse.move(personPoint!.x + 1, personPoint!.y + 1);
+  await page.mouse.move(personPoint!.x, personPoint!.y);
   await page.mouse.up();
 
   await page.waitForFunction(() => {

--- a/packages/desktop/tests/e2e/update-channel.spec.ts
+++ b/packages/desktop/tests/e2e/update-channel.spec.ts
@@ -137,10 +137,11 @@ test("selected release channel survives when browser storage is missing after re
   const reopenedSettingsDialog = page.locator(".fixed.inset-0.z-50").last();
   await reopenedSettingsDialog.getByRole("button", { name: /^Updates$/ }).click();
 
+  const installedDevVersionPattern = /Installed version:\s*v\d+\.\d+\.\d+-dev/;
   await expect(page.getByTestId("settings-release-channel-select")).toHaveValue("dev");
-  await expect(reopenedSettingsDialog.getByText(/Installed version:\s*v26\.4\.2500-dev/)).toBeVisible();
+  await expect(reopenedSettingsDialog.getByText(installedDevVersionPattern)).toBeVisible();
 
   await page.getByTestId("settings-release-channel-select").selectOption("production");
   await expect(page.getByTestId("settings-release-channel-select")).toHaveValue("production");
-  await expect(reopenedSettingsDialog.getByText(/Installed version:\s*v26\.4\.2500-dev/)).toBeVisible();
+  await expect(reopenedSettingsDialog.getByText(installedDevVersionPattern)).toBeVisible();
 });


### PR DESCRIPTION
(AI Generated).

## Summary
- make the release-channel e2e assertion accept the current dev build version instead of a stale hard-coded CalVer
- wait for the Friends graph scene to settle before dragging, then use a more deliberate pointer path to avoid a flaky drop target miss

## Tests
- BASE_URL=http://localhost:1423 corepack npm run test:e2e --workspace=packages/desktop -- smoke.spec.ts --grep "dragging a channel onto a person"
- BASE_URL=http://localhost:1423 corepack npm run test:e2e --workspace=packages/desktop -- update-channel.spec.ts --grep "selected release channel survives"