### PR TITLE
fix: preserve saved and archived signal filters

### DIFF
--- a/packages/pwa/src/lib/navigation-state.test.ts
+++ b/packages/pwa/src/lib/navigation-state.test.ts
@@ -5,14 +5,16 @@ import {
   parseNavigationState,
   serializeNavigationState,
 } from "@freed/shared";
+import type { FilterOptions } from "@freed/shared";
+import type { NavigationState } from "../../../shared/src/navigation-state";
 
 describe("navigation state", () => {
   it("preserves signal filters on saved views", () => {
-    const state = {
+    const state: NavigationState = {
       activeView: "feed" as const,
       activeFilter: {
         savedOnly: true,
-        signals: ["news", "essay"] as const,
+        signals: ["news", "essay"],
       },
       selectedItemId: null,
     };
@@ -31,11 +33,11 @@ describe("navigation state", () => {
   });
 
   it("preserves signal filters on archived views", () => {
-    const state = {
+    const state: NavigationState = {
       activeView: "feed" as const,
       activeFilter: {
         archivedOnly: true,
-        signals: ["discussion"] as const,
+        signals: ["discussion"],
       },
       selectedItemId: null,
     };
@@ -54,9 +56,9 @@ describe("navigation state", () => {
   });
 
   it("treats saved signal filters as canonical instead of stripping them", () => {
-    const raw = {
+    const raw: FilterOptions = {
       savedOnly: true,
-      signals: ["news", "essay", "news"] as const,
+      signals: ["news", "essay", "news"],
     };
 
     expect(canonicalizeFilterOptions(raw)).toEqual({

--- a/packages/pwa/src/lib/navigation-state.test.ts
+++ b/packages/pwa/src/lib/navigation-state.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import {
+  canonicalizeFilterOptions,
+  navigationStatesEqual,
+  parseNavigationState,
+  serializeNavigationState,
+} from "@freed/shared";
+
+describe("navigation state", () => {
+  it("preserves signal filters on saved views", () => {
+    const state = {
+      activeView: "feed" as const,
+      activeFilter: {
+        savedOnly: true,
+        signals: ["news", "essay"] as const,
+      },
+      selectedItemId: null,
+    };
+
+    const serialized = serializeNavigationState(state);
+
+    expect(serialized).toBe("/?scope=saved&signal=essay&signal=news");
+    expect(parseNavigationState(serialized)).toEqual({
+      activeView: "feed",
+      activeFilter: {
+        savedOnly: true,
+        signals: ["essay", "news"],
+      },
+      selectedItemId: null,
+    });
+  });
+
+  it("preserves signal filters on archived views", () => {
+    const state = {
+      activeView: "feed" as const,
+      activeFilter: {
+        archivedOnly: true,
+        signals: ["discussion"] as const,
+      },
+      selectedItemId: null,
+    };
+
+    const serialized = serializeNavigationState(state);
+
+    expect(serialized).toBe("/?scope=archived&signal=discussion");
+    expect(parseNavigationState(serialized)).toEqual({
+      activeView: "feed",
+      activeFilter: {
+        archivedOnly: true,
+        signals: ["discussion"],
+      },
+      selectedItemId: null,
+    });
+  });
+
+  it("treats saved signal filters as canonical instead of stripping them", () => {
+    const raw = {
+      savedOnly: true,
+      signals: ["news", "essay", "news"] as const,
+    };
+
+    expect(canonicalizeFilterOptions(raw)).toEqual({
+      savedOnly: true,
+      signals: ["essay", "news"],
+    });
+    expect(
+      navigationStatesEqual(
+        {
+          activeView: "feed",
+          activeFilter: raw,
+          selectedItemId: null,
+        },
+        {
+          activeView: "feed",
+          activeFilter: {
+            savedOnly: true,
+            signals: ["essay", "news"],
+          },
+          selectedItemId: null,
+        },
+      ),
+    ).toBe(true);
+  });
+});

--- a/packages/shared/src/navigation-state.ts
+++ b/packages/shared/src/navigation-state.ts
@@ -45,11 +45,21 @@ function normalizeSocialContentFilter(
 }
 
 export function canonicalizeFilterOptions(filter: FilterOptions): FilterOptions {
-  if (filter.savedOnly) return { savedOnly: true };
-  if (filter.archivedOnly) return { archivedOnly: true };
-
   const tags = uniqueSortedTags(filter.tags);
   const signals = uniqueSortedSignals(filter.signals);
+  if (filter.savedOnly) {
+    const next: FilterOptions = { savedOnly: true };
+    if (tags.length > 0) next.tags = tags;
+    if (signals.length > 0) next.signals = signals;
+    return next;
+  }
+  if (filter.archivedOnly) {
+    const next: FilterOptions = { archivedOnly: true };
+    if (tags.length > 0) next.tags = tags;
+    if (signals.length > 0) next.signals = signals;
+    return next;
+  }
+
   const feedUrl = normalizeText(filter.feedUrl);
   const platform = feedUrl ? "rss" : normalizeText(filter.platform) ?? undefined;
   const socialContentFilter =
@@ -127,8 +137,12 @@ export function parseNavigationState(input: string | NavigationPathLike): Naviga
   let activeFilter: FilterOptions;
   if (scope === "saved") {
     activeFilter = { savedOnly: true };
+    if (tags.length > 0) activeFilter.tags = tags;
+    if (signals.length > 0) activeFilter.signals = signals;
   } else if (scope === "archived") {
     activeFilter = { archivedOnly: true };
+    if (tags.length > 0) activeFilter.tags = tags;
+    if (signals.length > 0) activeFilter.signals = signals;
   } else if (feedUrl) {
     activeFilter = { platform: "rss", feedUrl };
     if (tags.length > 0) activeFilter.tags = tags;
@@ -166,6 +180,15 @@ export function serializeNavigationState(state: NavigationState): string {
     params.set("scope", "saved");
   } else if (activeFilter.archivedOnly) {
     params.set("scope", "archived");
+  }
+
+  if (activeFilter.savedOnly || activeFilter.archivedOnly) {
+    for (const tag of uniqueSortedTags(activeFilter.tags)) {
+      params.append("tag", tag);
+    }
+    for (const signal of uniqueSortedSignals(activeFilter.signals)) {
+      params.append("signal", signal);
+    }
   } else {
     if (activeFilter.feedUrl) {
       params.set("feed", activeFilter.feedUrl);


### PR DESCRIPTION
(AI Generated).

## Summary
- Preserve signal and tag filters when feed scope is saved or archived.
- Round-trip saved and archived feed filters through shared navigation state.

## Testing
- npx --yes tsx inline assertions for serializeNavigationState, parseNavigationState, canonicalizeFilterOptions, and navigationStatesEqual