### PR TITLE
fix: install newest eligible desktop update

### DIFF
--- a/packages/desktop/src/lib/desktop-updater.test.ts
+++ b/packages/desktop/src/lib/desktop-updater.test.ts
@@ -1,10 +1,31 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockCheck, mockInvoke } = vi.hoisted(() => ({
+  mockCheck: vi.fn(),
+  mockInvoke: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/plugin-updater", () => ({
+  check: mockCheck,
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: mockInvoke,
+}));
+
 import {
+  checkDesktopUpdate,
   getDesktopDownloadFallbackUrl,
   mapUpdaterTargetToDownloadTarget,
 } from "./desktop-updater";
 
 describe("desktop updater helpers", () => {
+  beforeEach(() => {
+    mockCheck.mockReset();
+    mockInvoke.mockReset();
+    mockInvoke.mockResolvedValue("darwin-aarch64");
+  });
+
   it("maps supported updater targets to website download targets", () => {
     expect(mapUpdaterTargetToDownloadTarget("darwin-aarch64")).toBe("mac-arm");
     expect(mapUpdaterTargetToDownloadTarget("darwin-x86_64")).toBe("mac-intel");
@@ -32,5 +53,44 @@ describe("desktop updater helpers", () => {
     expect(
       getDesktopDownloadFallbackUrl("dev", "linux-aarch64"),
     ).toBe("https://dev.freed.wtf/get");
+  });
+
+  it("chooses a newer production release while keeping dev selected", async () => {
+    mockCheck.mockImplementation(async ({ target }: { target?: string }) => {
+      if (target === "dev-darwin-aarch64") {
+        return { version: "26.4.2604", downloadAndInstall: async () => {} };
+      }
+      if (target === "production-darwin-aarch64") {
+        return { version: "26.4.2605", downloadAndInstall: async () => {} };
+      }
+      return null;
+    });
+
+    await expect(checkDesktopUpdate("dev")).resolves.toMatchObject({
+      channel: "production",
+      fallbackDownloadUrl: "https://dev.freed.wtf/api/downloads/mac-arm",
+      update: { version: "26.4.2605" },
+    });
+    expect(mockCheck).toHaveBeenNthCalledWith(1, { target: "dev-darwin-aarch64" });
+    expect(mockCheck).toHaveBeenNthCalledWith(2, {
+      target: "production-darwin-aarch64",
+    });
+  });
+
+  it("keeps a newer dev release ahead of production fallback", async () => {
+    mockCheck.mockImplementation(async ({ target }: { target?: string }) => {
+      if (target === "dev-darwin-aarch64") {
+        return { version: "26.4.2606-dev", downloadAndInstall: async () => {} };
+      }
+      if (target === "production-darwin-aarch64") {
+        return { version: "26.4.2605", downloadAndInstall: async () => {} };
+      }
+      return null;
+    });
+
+    await expect(checkDesktopUpdate("dev")).resolves.toMatchObject({
+      channel: "dev",
+      update: { version: "26.4.2606-dev" },
+    });
   });
 });

--- a/packages/desktop/src/lib/desktop-updater.ts
+++ b/packages/desktop/src/lib/desktop-updater.ts
@@ -1,5 +1,9 @@
 import { check, type Update } from "@tauri-apps/plugin-updater";
-import { getWebsiteHostForChannel, type ReleaseChannel } from "@freed/shared";
+import {
+  getWebsiteHostForChannel,
+  stripReleaseChannelSuffix,
+  type ReleaseChannel,
+} from "@freed/shared";
 import {
   buildDesktopUpdateTargets,
   getNativeUpdaterTarget,
@@ -23,6 +27,30 @@ export type PendingDesktopUpdate = {
 export type DesktopInstallProgress =
   | { phase: "downloading"; percent: number }
   | { phase: "ready" };
+
+function parseUpdateVersion(version: string): [number, number, number] {
+  const [yy = "0", month = "0", patch = "0"] = stripReleaseChannelSuffix(
+    version,
+  ).split(".");
+  return [Number(yy) || 0, Number(month) || 0, Number(patch) || 0];
+}
+
+function compareUpdateVersions(left: string, right: string): number {
+  const a = parseUpdateVersion(left);
+  const b = parseUpdateVersion(right);
+
+  for (let index = 0; index < a.length; index += 1) {
+    if (a[index] !== b[index]) {
+      return a[index] - b[index];
+    }
+  }
+
+  return 0;
+}
+
+function isNewerUpdate(left: Update, right: Update): boolean {
+  return compareUpdateVersions(left.version, right.version) > 0;
+}
 
 export function mapUpdaterTargetToDownloadTarget(
   updaterTarget: string,
@@ -69,19 +97,24 @@ export async function checkDesktopUpdate(
     nativeUpdaterTarget,
   );
 
+  let latestUpdate: PendingDesktopUpdate | null = null;
+
   for (const candidate of buildDesktopUpdateTargets(channel, nativeUpdaterTarget)) {
     const update = await check({ target: candidate.target });
     if (update) {
-      return {
+      const pendingUpdate = {
         channel: candidate.channel,
         update,
         fallbackDownloadUrl,
         nativeUpdaterTarget,
       };
+      if (!latestUpdate || isNewerUpdate(update, latestUpdate.update)) {
+        latestUpdate = pendingUpdate;
+      }
     }
   }
 
-  return null;
+  return latestUpdate;
 }
 
 export async function installPendingDesktopUpdate(


### PR DESCRIPTION
(AI Generated).

## Summary
- Desktop dev-channel update checks now compare available dev and production releases and install the newest eligible build without changing the saved dev channel.

## Testing
- npm run test:unit -- src/lib/desktop-updater.test.ts
- npm run test:e2e -- update-channel.spec.ts
- npm run validate:feature