### PR TITLE
fix: polish marketing theme surfaces

### DIFF
--- a/packages/shared/src/themes.ts
+++ b/packages/shared/src/themes.ts
@@ -267,9 +267,30 @@ const SCRIPTORIUM_MAP: ThemeMapPalette = {
   gridOpacity: 0.028,
 };
 
-export const DEFAULT_THEME_ID: ThemeId = "neon";
+export const DEFAULT_THEME_ID: ThemeId = "ember";
 
 export const THEME_DEFINITIONS: readonly ThemeDefinition[] = [
+  {
+    id: "ember",
+    name: "Ember",
+    tagline: "Iron, soot, and a hand that means it.",
+    description:
+      "Volcanic charcoal with ember-orange heat. Heavier, sharper, and forged for impact.",
+    previewGradient: "linear-gradient(135deg, #7a2f1f, #c15a2e 55%, #5b1711)",
+    previewDisplayFont: '"Avenir Next Condensed", "Impact", "Arial Black", sans-serif',
+    previewBodyFont: '"Optima", "Avenir Next", "Segoe UI", "Helvetica Neue", sans-serif',
+    surface: "dark",
+    effects: "dramatic",
+    background: {
+      shellBackground: EMBER_SHELL_BACKGROUND,
+      overlayBackground: DEFAULT_OVERLAY_BACKGROUND,
+      baseOpacity: 0.078,
+      textures: [{ image: MIDAS_NOISE_TEXTURE, size: "320px 320px", repeat: "repeat" }],
+      heroOrbs: DEFAULT_HERO_ORBS,
+      rowOrbs: DEFAULT_ROW_ORBS,
+    },
+    map: EMBER_MAP,
+  },
   {
     id: "neon",
     name: "Neon",
@@ -292,27 +313,6 @@ export const THEME_DEFINITIONS: readonly ThemeDefinition[] = [
       overlayEnabled: false,
     },
     map: NEON_MAP,
-  },
-  {
-    id: "ember",
-    name: "Ember",
-    tagline: "Iron, soot, and a hand that means it.",
-    description:
-      "Volcanic charcoal with ember-orange heat. Heavier, sharper, and forged for impact.",
-    previewGradient: "linear-gradient(135deg, #7a2f1f, #c15a2e 55%, #5b1711)",
-    previewDisplayFont: '"Avenir Next Condensed", "Impact", "Arial Black", sans-serif',
-    previewBodyFont: '"Optima", "Avenir Next", "Segoe UI", "Helvetica Neue", sans-serif',
-    surface: "dark",
-    effects: "dramatic",
-    background: {
-      shellBackground: EMBER_SHELL_BACKGROUND,
-      overlayBackground: DEFAULT_OVERLAY_BACKGROUND,
-      baseOpacity: 0.078,
-      textures: [{ image: MIDAS_NOISE_TEXTURE, size: "320px 320px", repeat: "repeat" }],
-      heroOrbs: DEFAULT_HERO_ORBS,
-      rowOrbs: DEFAULT_ROW_ORBS,
-    },
-    map: EMBER_MAP,
   },
   {
     id: "midas",

--- a/website/src/app/layout.tsx
+++ b/website/src/app/layout.tsx
@@ -104,12 +104,12 @@ export default function RootLayout({
         <Script id="freed-theme-bootstrap" strategy="beforeInteractive">{`
           (function() {
             try {
-              var theme = localStorage.getItem("freed-theme") || "neon";
+              var theme = localStorage.getItem("freed-theme") || "ember";
               var root = document.documentElement;
               var themeVars = ${JSON.stringify(THEME_BOOTSTRAP_VARS)};
               root.dataset.theme = theme;
               root.style.colorScheme = theme === "scriptorium" ? "light" : "dark";
-              var vars = themeVars[theme] || themeVars.neon;
+              var vars = themeVars[theme] || themeVars.ember;
               Object.keys(vars).forEach(function(name) {
                 root.style.setProperty(name, vars[name]);
               });

--- a/website/src/app/roadmap/RoadmapContent.tsx
+++ b/website/src/app/roadmap/RoadmapContent.tsx
@@ -860,9 +860,9 @@ function PhaseCard({ phase, index }: { phase: Phase; index: number }) {
         </div>
       )}
 
-      <div className="flex items-start justify-between gap-4">
-        <div className="flex-1">
-          <div className="flex items-center gap-3 mb-2">
+      <div className="block sm:flex sm:items-start sm:justify-between sm:gap-4">
+        <div className="w-full sm:flex-1">
+          <div className="flex items-center gap-3 mb-2 pr-28 sm:pr-0">
             <span className="text-2xl font-bold text-text-muted">
               {String(phase.number).padStart(2, "0")}
             </span>
@@ -873,7 +873,7 @@ function PhaseCard({ phase, index }: { phase: Phase; index: number }) {
           <p className="text-text-secondary">{phase.description}</p>
         </div>
 
-        <div className="flex flex-col items-end gap-2">
+        <div className="absolute top-6 right-6 flex flex-col items-end gap-2 sm:static sm:shrink-0">
           <span
             className={`px-3 py-1 rounded-full text-xs font-medium ${style.badge}`}
           >

--- a/website/src/components/Hero.tsx
+++ b/website/src/components/Hero.tsx
@@ -3,7 +3,13 @@
 import { motion, AnimatePresence } from "framer-motion";
 import Link from "next/link";
 import { useState, useEffect, type FormEvent } from "react";
-import { FaXTwitter, FaInstagram, FaFacebook, FaRss } from "react-icons/fa6";
+import {
+  FaArrowRight,
+  FaXTwitter,
+  FaInstagram,
+  FaFacebook,
+  FaRss,
+} from "react-icons/fa6";
 import HeroAnimation from "./HeroAnimation";
 import { useNewsletter } from "@/context/NewsletterContext";
 import { slowHeroMotion, slowHeroDelay, slowHeroInterval } from "@/lib/motion";
@@ -206,12 +212,13 @@ export default function Hero() {
                 />
                 <button
                   type="submit"
-                  className="shrink-0 rounded-r-xl px-4 text-sm font-semibold text-[var(--theme-button-primary-text)]"
+                  className="inline-flex shrink-0 items-center justify-center gap-1.5 rounded-r-xl px-4 text-sm font-semibold text-[var(--theme-button-primary-text)]"
                   style={{
-                    background: "var(--theme-button-primary-bg)",
+                    background: "var(--theme-button-primary-background)",
                   }}
                 >
-                  Join Us
+                  <span>Join Us</span>
+                  <FaArrowRight aria-hidden="true" className="h-3.5 w-3.5" />
                 </button>
               </div>
               {mobileEmailError && (


### PR DESCRIPTION
(AI Generated).

## Summary
- Restore the mobile hero Join Us button background in Scriptorium and add a right-arrow icon.
- Let mobile roadmap phase descriptions use the full card width while pinning the status and plan link at the top right.
- Put the marketing theme selector in Ember, Neon, Midas, Scriptorium order and default first paint to Ember.

## Testing
- `cd website && PATH=../node_modules/.bin:$PATH npm run build`
- Local website preview: http://localhost:3004