### PR TITLE
fix: default app themes to Scriptorium

### DIFF
--- a/packages/desktop/tests/e2e/theme-switching.spec.ts
+++ b/packages/desktop/tests/e2e/theme-switching.spec.ts
@@ -25,13 +25,13 @@ test("switching themes in settings applies the selected theme immediately", asyn
   await expect(page.getByText("Appearance").first()).toBeVisible({ timeout: 5_000 });
 
   const initialThemeId = await page.evaluate(() => document.documentElement.dataset.theme);
-  expect(initialThemeId).toBe("neon");
+  expect(initialThemeId).toBe("scriptorium");
 
-  await page.getByRole("button", { name: /^Scriptorium\./ }).click();
+  await page.getByRole("button", { name: /^Neon\./ }).click();
 
   await expect.poll(async () => {
     return page.evaluate(() => document.documentElement.dataset.theme);
-  }).toBe("scriptorium");
+  }).toBe("neon");
 
   await expect.poll(async () => {
     return page.evaluate(() => {
@@ -41,7 +41,7 @@ test("switching themes in settings applies the selected theme immediately", asyn
         | undefined;
       return store?.getState().preferences.display.themeId;
     });
-  }).toBe("scriptorium");
+  }).toBe("neon");
 });
 
 test("theme switching repaints the app even before preferences finish saving", async ({ app, page }) => {
@@ -66,11 +66,11 @@ test("theme switching repaints the app even before preferences finish saving", a
     });
   });
 
-  await page.getByRole("button", { name: /^Scriptorium\./ }).click();
+  await page.getByRole("button", { name: /^Neon\./ }).click();
 
   await expect.poll(async () => {
     return page.evaluate(() => document.documentElement.dataset.theme);
-  }).toBe("scriptorium");
+  }).toBe("neon");
 
   await expect.poll(async () => {
     return page.evaluate(() => {
@@ -80,7 +80,7 @@ test("theme switching repaints the app even before preferences finish saving", a
         | undefined;
       return store?.getState().preferences.display.themeId;
     });
-  }).toBe("neon");
+  }).toBe("scriptorium");
 });
 
 test("hovering a theme previews it and leaving restores the committed theme", async ({ app, page }) => {
@@ -94,23 +94,23 @@ test("hovering a theme previews it and leaving restores the committed theme", as
 
   await expect(page.getByText("Appearance").first()).toBeVisible({ timeout: 5_000 });
 
-  const scriptoriumButton = page.getByRole("button", { name: /^Scriptorium\./ });
+  const emberButton = page.getByRole("button", { name: /^Ember\./ });
 
-  await scriptoriumButton.hover();
+  await emberButton.hover();
 
   await expect.poll(async () => {
     return page.evaluate(() => document.documentElement.dataset.theme);
-  }).toBe("scriptorium");
-  await expect(page.getByRole("button", { name: /^Neon\./ })).toHaveAttribute("aria-pressed", "true");
-  await expect(scriptoriumButton).toHaveAttribute("aria-pressed", "false");
+  }).toBe("ember");
+  await expect(page.getByRole("button", { name: /^Scriptorium\./ })).toHaveAttribute("aria-pressed", "true");
+  await expect(emberButton).toHaveAttribute("aria-pressed", "false");
 
   await page.getByText("Mark read on scroll").hover();
 
   await expect.poll(async () => {
     return page.evaluate(() => document.documentElement.dataset.theme);
-  }).toBe("neon");
-  await expect(page.getByRole("button", { name: /^Neon\./ })).toHaveAttribute("aria-pressed", "true");
-  await expect(scriptoriumButton).toHaveAttribute("aria-pressed", "false");
+  }).toBe("scriptorium");
+  await expect(page.getByRole("button", { name: /^Scriptorium\./ })).toHaveAttribute("aria-pressed", "true");
+  await expect(emberButton).toHaveAttribute("aria-pressed", "false");
 });
 
 test("keyboard focus previews a theme and blur restores the committed theme", async ({ app, page }) => {
@@ -124,24 +124,24 @@ test("keyboard focus previews a theme and blur restores the committed theme", as
 
   await expect(page.getByText("Appearance").first()).toBeVisible({ timeout: 5_000 });
 
-  const emberButton = page.getByRole("button", { name: /^Ember\./ });
+  const neonButton = page.getByRole("button", { name: /^Neon\./ });
   const readingToggle = page.getByRole("switch", { name: "Mark read on scroll" });
 
-  await emberButton.focus();
+  await neonButton.focus();
 
   await expect.poll(async () => {
     return page.evaluate(() => document.documentElement.dataset.theme);
-  }).toBe("ember");
-  await expect(page.getByRole("button", { name: /^Neon\./ })).toHaveAttribute("aria-pressed", "true");
-  await expect(emberButton).toHaveAttribute("aria-pressed", "false");
+  }).toBe("neon");
+  await expect(page.getByRole("button", { name: /^Scriptorium\./ })).toHaveAttribute("aria-pressed", "true");
+  await expect(neonButton).toHaveAttribute("aria-pressed", "false");
 
   await readingToggle.focus();
 
   await expect.poll(async () => {
     return page.evaluate(() => document.documentElement.dataset.theme);
-  }).toBe("neon");
-  await expect(page.getByRole("button", { name: /^Neon\./ })).toHaveAttribute("aria-pressed", "true");
-  await expect(emberButton).toHaveAttribute("aria-pressed", "false");
+  }).toBe("scriptorium");
+  await expect(page.getByRole("button", { name: /^Scriptorium\./ })).toHaveAttribute("aria-pressed", "true");
+  await expect(neonButton).toHaveAttribute("aria-pressed", "false");
 });
 
 test("settings switches render with a full track and knob", async ({ app, page }) => {
@@ -226,7 +226,7 @@ test("rapid theme browsing only persists the final selected theme", async ({ app
   });
 
   await page.evaluate(() => {
-    const labels = [/^Ember\./, /^Midas\./, /^Scriptorium\./];
+    const labels = [/^Neon\./, /^Midas\./, /^Ember\./];
     const buttons = Array.from(document.querySelectorAll("button"));
     for (const label of labels) {
       const button = buttons.find((candidate) => label.test(candidate.getAttribute("aria-label") ?? ""));
@@ -239,7 +239,7 @@ test("rapid theme browsing only persists the final selected theme", async ({ app
 
   await expect.poll(async () => {
     return page.evaluate(() => document.documentElement.dataset.theme);
-  }).toBe("scriptorium");
+  }).toBe("ember");
 
   await page.waitForTimeout(700);
 
@@ -250,7 +250,7 @@ test("rapid theme browsing only persists the final selected theme", async ({ app
         ?.map((patch) => patch.display?.themeId)
         .filter((themeId): themeId is string => typeof themeId === "string");
     });
-  }).toEqual(["scriptorium"]);
+  }).toEqual(["ember"]);
 
   await expect.poll(async () => {
     return page.evaluate(() => {
@@ -260,11 +260,11 @@ test("rapid theme browsing only persists the final selected theme", async ({ app
         | undefined;
       return store?.getState().preferences.display.themeId;
     });
-  }).toBe("scriptorium");
+  }).toBe("ember");
 
   await expect.poll(async () => {
     return page.evaluate(() => document.documentElement.dataset.theme);
-  }).toBe("scriptorium");
+  }).toBe("ember");
 });
 test("map view repaints across all themes without using the old canvas filter", async ({ app, page }) => {
   const stableMapSurfaceWidth = process.platform === "linux" ? 996 : 992;
@@ -293,7 +293,7 @@ test("map view repaints across all themes without using the old canvas filter", 
   }, stableMapSurfaceWidth);
   await page.waitForTimeout(100);
 
-  const themeIds = ["neon", "ember", "midas", "scriptorium"] as const;
+  const themeIds = ["ember", "neon", "midas", "scriptorium"] as const;
 
   for (const themeId of themeIds) {
     await page.evaluate(async (nextThemeId) => {

--- a/packages/shared/src/themes.ts
+++ b/packages/shared/src/themes.ts
@@ -267,9 +267,30 @@ const SCRIPTORIUM_MAP: ThemeMapPalette = {
   gridOpacity: 0.028,
 };
 
-export const DEFAULT_THEME_ID: ThemeId = "neon";
+export const DEFAULT_THEME_ID: ThemeId = "scriptorium";
 
 export const THEME_DEFINITIONS: readonly ThemeDefinition[] = [
+  {
+    id: "ember",
+    name: "Ember",
+    tagline: "Iron, soot, and a hand that means it.",
+    description:
+      "Volcanic charcoal with ember-orange heat. Heavier, sharper, and forged for impact.",
+    previewGradient: "linear-gradient(135deg, #7a2f1f, #c15a2e 55%, #5b1711)",
+    previewDisplayFont: '"Avenir Next Condensed", "Impact", "Arial Black", sans-serif',
+    previewBodyFont: '"Optima", "Avenir Next", "Segoe UI", "Helvetica Neue", sans-serif',
+    surface: "dark",
+    effects: "dramatic",
+    background: {
+      shellBackground: EMBER_SHELL_BACKGROUND,
+      overlayBackground: DEFAULT_OVERLAY_BACKGROUND,
+      baseOpacity: 0.078,
+      textures: [{ image: MIDAS_NOISE_TEXTURE, size: "320px 320px", repeat: "repeat" }],
+      heroOrbs: DEFAULT_HERO_ORBS,
+      rowOrbs: DEFAULT_ROW_ORBS,
+    },
+    map: EMBER_MAP,
+  },
   {
     id: "neon",
     name: "Neon",
@@ -292,27 +313,6 @@ export const THEME_DEFINITIONS: readonly ThemeDefinition[] = [
       overlayEnabled: false,
     },
     map: NEON_MAP,
-  },
-  {
-    id: "ember",
-    name: "Ember",
-    tagline: "Iron, soot, and a hand that means it.",
-    description:
-      "Volcanic charcoal with ember-orange heat. Heavier, sharper, and forged for impact.",
-    previewGradient: "linear-gradient(135deg, #7a2f1f, #c15a2e 55%, #5b1711)",
-    previewDisplayFont: '"Avenir Next Condensed", "Impact", "Arial Black", sans-serif',
-    previewBodyFont: '"Optima", "Avenir Next", "Segoe UI", "Helvetica Neue", sans-serif',
-    surface: "dark",
-    effects: "dramatic",
-    background: {
-      shellBackground: EMBER_SHELL_BACKGROUND,
-      overlayBackground: DEFAULT_OVERLAY_BACKGROUND,
-      baseOpacity: 0.078,
-      textures: [{ image: MIDAS_NOISE_TEXTURE, size: "320px 320px", repeat: "repeat" }],
-      heroOrbs: DEFAULT_HERO_ORBS,
-      rowOrbs: DEFAULT_ROW_ORBS,
-    },
-    map: EMBER_MAP,
   },
   {
     id: "midas",

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -809,7 +809,7 @@ export function createDefaultPreferences(): UserPreferences {
     display: {
       itemsPerPage: 20,
       compactMode: false,
-      themeId: "neon",
+      themeId: "scriptorium",
       showEngagementCounts: false, // Hidden by default
       reading: {
         focusMode: false,

--- a/packages/ui/src/components/layout/BackgroundAtmosphere.tsx
+++ b/packages/ui/src/components/layout/BackgroundAtmosphere.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import {
+  DEFAULT_THEME_ID,
   getThemeDefinition,
   resolveThemeId,
   type ThemeId,
@@ -204,7 +205,7 @@ function resolveTextureOpacity(
 export function BackgroundAtmosphere() {
   const [orbs, setOrbs] = useState<Orb[] | null>(null);
   const [viewportWidth, setViewportWidth] = useState(DESKTOP_BASELINE_WIDTH);
-  const [themeId, setThemeId] = useState<ThemeId>("neon");
+  const [themeId, setThemeId] = useState<ThemeId>(DEFAULT_THEME_ID);
   const themeRecipe = useMemo(
     () => getThemeDefinition(themeId).background,
     [themeId],
@@ -218,14 +219,14 @@ export function BackgroundAtmosphere() {
 
   useEffect(() => {
     const initialThemeId = resolveThemeId(
-      document.documentElement.dataset.theme || "neon",
+      document.documentElement.dataset.theme || DEFAULT_THEME_ID,
     );
     setViewportWidth(window.innerWidth);
     setThemeId(initialThemeId);
 
     const observer = new MutationObserver(() => {
       const nextThemeId = resolveThemeId(
-        document.documentElement.dataset.theme || "neon",
+        document.documentElement.dataset.theme || DEFAULT_THEME_ID,
       );
       setThemeId(nextThemeId);
     });

--- a/packages/ui/src/lib/map-style.test.ts
+++ b/packages/ui/src/lib/map-style.test.ts
@@ -52,7 +52,7 @@ describe("buildThemedMapStyle", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     const { buildThemedMapStyle } = await loadBuilder();
-    const themeIds: ThemeId[] = ["neon", "ember", "midas", "scriptorium"];
+    const themeIds: ThemeId[] = ["ember", "neon", "midas", "scriptorium"];
 
     for (const themeId of themeIds) {
       const style = await buildThemedMapStyle(themeId);


### PR DESCRIPTION
(AI Generated).

## Summary
- Make Scriptorium the default app theme.
- Keep app theme selectors in Ember, Neon, Midas, Scriptorium order.
- Update app theme fallbacks and tests for the corrected default.

## Testing
- `cd packages/desktop && PATH=../../node_modules/.bin:$PATH npm run test:e2e -- theme-switching.spec.ts`
- `npm run validate:feature`
- Local PWA preview: http://localhost:1421