### PR TITLE
feat: add optional local AI model downloads

### DIFF
--- a/docs/PHASE-10-POLISH.md
+++ b/docs/PHASE-10-POLISH.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-Final polish, accessibility, UX refinements, AI-powered features, and community infrastructure.
+Final polish, accessibility, UX refinements, optional local AI model packs, and community infrastructure.
 
 ---
 
@@ -398,6 +398,7 @@ Reward security researchers for responsible disclosure.
 | 10.14 | Smart notifications      | High       |
 | 10.15 | AI settings UI           | Medium     | ✓ Complete (AISection.tsx in packages/ui)
 | 10.25 | Local content signals    | Medium     | ✓ Complete (rule-based contentSignals metadata, automatic ingestion inference, resumable desktop backfill, saved toolbar filter presets, and news classification)
+| 10.26 | Optional local AI packs  | High       | ✓ Complete (disabled-by-default model cards, pinned download manifest, resumable desktop downloads, checksum verification, and removal controls)
 
 ### Extensibility
 
@@ -442,6 +443,7 @@ Reward security researchers for responsible disclosure.
 - [ ] Topic extraction works (at least one method)
 - [ ] Summarization available for long content
 - [x] Local content signals classify existing and newly ingested items without cloud AI, with saved feed filter presets and news classification in the toolbar
+- [x] Optional local AI model packs stay out of the installer, remain off by default, and install or remove from AI settings with device-local model state
 - [ ] Smart notifications reduce noise
 
 ### Community

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -1288,7 +1288,7 @@ dependencies = [
 
 [[package]]
 name = "freed-desktop"
-version = "26.4.2401"
+version = "26.4.2606"
 dependencies = [
  "base64 0.22.1",
  "criterion",
@@ -1306,6 +1306,7 @@ dependencies = [
  "rquest-util",
  "serde",
  "serde_json",
+ "sha2",
  "sysinfo",
  "tauri",
  "tauri-build",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -38,6 +38,7 @@ rand = "0.8"
 base64 = "0.22"
 url = "2"
 sysinfo = "0.37"
+sha2 = "0.10"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6"

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -6,6 +6,7 @@ use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use futures_util::{SinkExt, StreamExt};
 use log::{error, info, warn};
 use rand::RngCore;
+use sha2::{Digest, Sha256};
 use std::collections::HashSet;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
@@ -15,7 +16,7 @@ use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, System};
 use tauri::menu::{Menu, MenuItem, Submenu};
 use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
 use tauri::{Emitter, Listener, Manager};
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::{broadcast, RwLock};
 use tokio::time::{timeout, Duration};
@@ -1216,6 +1217,36 @@ async fn reset_pairing_token(
     *state.pairing_token.write().unwrap() = new_token.clone();
     info!("[Sync] Pairing token rotated");
     Ok(new_token)
+}
+
+#[tauri::command]
+async fn sha256_file(app: tauri::AppHandle, path: String) -> Result<String, String> {
+    let model_root = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| e.to_string())?
+        .join("local-ai-models");
+    let root = model_root.canonicalize().map_err(|e| e.to_string())?;
+    let target = PathBuf::from(path).canonicalize().map_err(|e| e.to_string())?;
+    if !target.starts_with(&root) {
+        return Err("Refusing to hash a file outside the local AI model directory".to_string());
+    }
+
+    let mut file = tokio::fs::File::open(&target)
+        .await
+        .map_err(|e| e.to_string())?;
+    let mut hasher = Sha256::new();
+    let mut buffer = vec![0u8; 1024 * 1024];
+
+    loop {
+        let read = file.read(&mut buffer).await.map_err(|e| e.to_string())?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+
+    Ok(format!("{:x}", hasher.finalize()))
 }
 
 #[tauri::command]
@@ -4324,6 +4355,7 @@ pub fn run() {
             get_local_ip,
             get_all_local_ips,
             get_sync_url,
+            sha256_file,
             get_sync_client_count,
             get_runtime_memory_stats,
             broadcast_doc,

--- a/packages/desktop/src/App.tsx
+++ b/packages/desktop/src/App.tsx
@@ -59,6 +59,7 @@ import { saveUrlInDesktop } from "./lib/save-url";
 import { hydrateReaderItem as hydrateReaderItemForDesktop } from "./lib/reader-hydration";
 import { importMarkdownFiles, exportLibrary } from "./lib/import-export";
 import { secureStorage } from "./lib/secure-storage";
+import { localAIModels } from "./lib/local-ai-models";
 import { pinReaderItem, start as startContentFetcher, stop as stopContentFetcher } from "./lib/content-fetcher";
 import { useAppStore as useDesktopStore, withProviderSyncing } from "./lib/store";
 import { pickContactViaTauri } from "./lib/contacts";
@@ -661,6 +662,7 @@ function App() {
         setApiKey: (provider: string, key: string) => Promise<void>;
         clearApiKey: (provider: string) => Promise<void>;
       },
+      localAIModels,
       openUrl: (url: string) => { void shellOpen(url); },
       pickContact: pickContactViaTauri,
       googleContacts: {

--- a/packages/desktop/src/__mocks__/@tauri-apps/api/core.ts
+++ b/packages/desktop/src/__mocks__/@tauri-apps/api/core.ts
@@ -76,6 +76,7 @@ const handlers: Record<string, Handler> = {
   get_local_ip: () => "127.0.0.1",
   get_all_local_ips: () => [],
   get_sync_url: () => "ws://127.0.0.1:8765",
+  sha256_file: () => "",
   get_sync_client_count: () => 0,
   get_runtime_memory_stats: () => ({
     processResidentBytes: 64 * 1024 * 1024,

--- a/packages/desktop/src/__mocks__/@tauri-apps/plugin-fs/index.ts
+++ b/packages/desktop/src/__mocks__/@tauri-apps/plugin-fs/index.ts
@@ -1,8 +1,9 @@
 /**
  * Mock for @tauri-apps/plugin-fs
  *
- * content-cache.ts uses exists(), readFile(), writeFile(), readTextFile(),
- * writeTextFile(), mkdir(), remove(), and readDir().
+ * content-cache.ts and local model tests use exists(), readFile(), writeFile(),
+ * readTextFile(), writeTextFile(), mkdir(), remove(), rename(), open(), size(),
+ * and readDir().
  * In test mode all FS operations are backed by an in-memory map.
  */
 
@@ -18,7 +19,8 @@ export function __readMemfs(path: string): Uint8Array | undefined {
 }
 
 export async function exists(path: string): Promise<boolean> {
-  return memfs.has(path);
+  const prefix = path.endsWith("/") ? path : `${path}/`;
+  return memfs.has(path) || Array.from(memfs.keys()).some((key) => key.startsWith(prefix));
 }
 
 export async function readFile(path: string): Promise<Uint8Array> {
@@ -52,8 +54,67 @@ export async function mkdir(
   _opts?: { recursive?: boolean },
 ): Promise<void> {}
 
-export async function remove(_path: string): Promise<void> {
-  memfs.delete(_path);
+export async function remove(path: string, opts?: { recursive?: boolean }): Promise<void> {
+  memfs.delete(path);
+  if (opts?.recursive) {
+    const prefix = path.endsWith("/") ? path : `${path}/`;
+    for (const key of Array.from(memfs.keys())) {
+      if (key.startsWith(prefix)) memfs.delete(key);
+    }
+  }
+}
+
+export async function rename(oldPath: string, newPath: string): Promise<void> {
+  const data = memfs.get(oldPath);
+  if (!data) throw new Error(`ENOENT: ${oldPath}`);
+  memfs.set(newPath, data);
+  memfs.delete(oldPath);
+}
+
+export async function size(path: string): Promise<number> {
+  const file = memfs.get(path);
+  if (file) return file.byteLength;
+
+  const prefix = path.endsWith("/") ? path : `${path}/`;
+  let total = 0;
+  for (const [key, value] of memfs.entries()) {
+    if (key.startsWith(prefix)) total += value.byteLength;
+  }
+  if (total > 0) return total;
+  throw new Error(`ENOENT: ${path}`);
+}
+
+export async function open(
+  path: string,
+  opts: { append?: boolean; truncate?: boolean; create?: boolean } = {},
+): Promise<{
+  write(data: Uint8Array): Promise<number>;
+  close(): Promise<void>;
+}> {
+  if (!opts.create && !memfs.has(path)) throw new Error(`ENOENT: ${path}`);
+  let chunks: Uint8Array[] = [];
+  if (opts.append && memfs.has(path)) {
+    chunks = [memfs.get(path)!];
+  }
+  if (opts.truncate) {
+    chunks = [];
+  }
+
+  return {
+    async write(data: Uint8Array): Promise<number> {
+      chunks.push(data);
+      const total = chunks.reduce((sum, chunk) => sum + chunk.byteLength, 0);
+      const next = new Uint8Array(total);
+      let offset = 0;
+      for (const chunk of chunks) {
+        next.set(chunk, offset);
+        offset += chunk.byteLength;
+      }
+      memfs.set(path, next);
+      return data.byteLength;
+    },
+    async close(): Promise<void> {},
+  };
 }
 
 export async function readDir(path: string): Promise<DirEntry[]> {

--- a/packages/desktop/src/lib/local-ai-models.test.ts
+++ b/packages/desktop/src/lib/local-ai-models.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it } from "vitest";
+import * as A from "@automerge/automerge";
+import type { LocalAIModelManifestEntry } from "@freed/shared";
+import { createDefaultPreferences } from "@freed/shared";
+import { createEmptyDoc } from "@freed/shared/schema";
+import {
+  createLocalAIModelService,
+  type LocalAIModelServiceDeps,
+} from "./local-ai-models";
+
+const TEXT = new TextEncoder();
+const HELLO_SHA1 = "aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d";
+
+const TEST_MANIFEST: readonly LocalAIModelManifestEntry[] = [
+  {
+    id: "semantic-embeddinggemma",
+    title: "Semantic search and ranking",
+    capability: "Embeddings",
+    description: "Test model",
+    repo: "test/model",
+    revision: "abc123",
+    sourceUrl: "https://example.com/model",
+    estimatedDownloadBytes: 5,
+    estimatedStorageBytes: 5,
+    hardwareNote: "Test hardware",
+    requiresWebGPU: false,
+    wasmFallback: true,
+    files: [{ path: "model.bin", sizeBytes: 5, sha1: HELLO_SHA1 }],
+  },
+];
+
+function createDeps(options: {
+  responses?: Uint8Array[];
+  webGPUAvailable?: boolean;
+  seedFiles?: Record<string, string>;
+  sha256?: string;
+} = {}) {
+  const files = new Map<string, Uint8Array>();
+  const requests: Array<{ url: string; range: string | null }> = [];
+
+  for (const [path, text] of Object.entries(options.seedFiles ?? {})) {
+    files.set(path, TEXT.encode(text));
+  }
+
+  const deps: LocalAIModelServiceDeps = {
+    appDataDir: async () => "/app",
+    exists: async (path) => {
+      const prefix = path.endsWith("/") ? path : `${path}/`;
+      return files.has(path) || Array.from(files.keys()).some((key) => key.startsWith(prefix));
+    },
+    mkdir: async () => {},
+    open: async (path, openOptions) => {
+      let chunks: Uint8Array[] = [];
+      if (openOptions.append && files.has(path)) chunks = [files.get(path)!];
+      if (openOptions.truncate) chunks = [];
+      return {
+        async write(data) {
+          chunks.push(data);
+          const total = chunks.reduce((sum, chunk) => sum + chunk.byteLength, 0);
+          const next = new Uint8Array(total);
+          let offset = 0;
+          for (const chunk of chunks) {
+            next.set(chunk, offset);
+            offset += chunk.byteLength;
+          }
+          files.set(path, next);
+          return data.byteLength;
+        },
+        async close() {},
+      };
+    },
+    readFile: async (path) => {
+      const file = files.get(path);
+      if (!file) throw new Error(`ENOENT: ${path}`);
+      return file;
+    },
+    readTextFile: async (path) => {
+      const file = files.get(path);
+      if (!file) throw new Error(`ENOENT: ${path}`);
+      return new TextDecoder().decode(file);
+    },
+    remove: async (path, removeOptions) => {
+      files.delete(path);
+      if (removeOptions?.recursive) {
+        const prefix = path.endsWith("/") ? path : `${path}/`;
+        for (const key of Array.from(files.keys())) {
+          if (key.startsWith(prefix)) files.delete(key);
+        }
+      }
+    },
+    rename: async (oldPath, newPath) => {
+      const file = files.get(oldPath);
+      if (!file) throw new Error(`ENOENT: ${oldPath}`);
+      files.set(newPath, file);
+      files.delete(oldPath);
+    },
+    size: async (path) => {
+      const file = files.get(path);
+      if (file) return file.byteLength;
+      const prefix = path.endsWith("/") ? path : `${path}/`;
+      return Array.from(files.entries()).reduce(
+        (sum, [key, value]) => sum + (key.startsWith(prefix) ? value.byteLength : 0),
+        0,
+      );
+    },
+    writeTextFile: async (path, text) => {
+      files.set(path, TEXT.encode(text));
+    },
+    fetch: async (url, init) => {
+      const range = init?.headers instanceof Headers ? init.headers.get("Range") : null;
+      requests.push({ url: String(url), range });
+      const next = options.responses?.shift() ?? TEXT.encode("hello");
+      const body = next.buffer.slice(next.byteOffset, next.byteOffset + next.byteLength) as ArrayBuffer;
+      return new Response(body, { status: range ? 206 : 200 });
+    },
+    now: () => 1_000,
+    sha256File: async () => options.sha256 ?? "",
+    webGPUAvailable: () => options.webGPUAvailable ?? true,
+  };
+
+  return { deps, files, requests };
+}
+
+function modelPath(path: string): string {
+  return `/app/local-ai-models/semantic-embeddinggemma/abc123/${path}`;
+}
+
+describe("local AI model manager", () => {
+  it("keeps AI disabled by default", async () => {
+    const { deps } = createDeps();
+    const service = createLocalAIModelService(deps, TEST_MANIFEST);
+    const models = await service.listModels();
+
+    expect(createDefaultPreferences().ai).toEqual({
+      provider: "none",
+      model: "",
+      autoSummarize: false,
+      extractTopics: false,
+    });
+    expect(models[0].state.status).toBe("not_downloaded");
+    expect(models[0].state.downloadedBytes).toBe(0);
+  });
+
+  it("downloads, verifies, and records an available model", async () => {
+    const { deps, files } = createDeps();
+    const service = createLocalAIModelService(deps, TEST_MANIFEST);
+
+    const models = await service.downloadModel("semantic-embeddinggemma");
+
+    expect(models[0].state.status).toBe("available");
+    expect(files.has(modelPath("model.bin"))).toBe(true);
+    expect(models[0].state.storageBytes).toBe(5);
+  });
+
+  it("records checksum failures without marking the model available", async () => {
+    const badManifest: readonly LocalAIModelManifestEntry[] = [
+      {
+        ...TEST_MANIFEST[0],
+        files: [{ path: "model.bin", sizeBytes: 5, sha1: "0000000000000000000000000000000000000000" }],
+      },
+    ];
+    const { deps } = createDeps();
+    const service = createLocalAIModelService(deps, badManifest);
+
+    const models = await service.downloadModel("semantic-embeddinggemma");
+
+    expect(models[0].state.status).toBe("error");
+    expect(models[0].state.lastError).toContain("Checksum failed");
+  });
+
+  it("resumes a partial download with a range request", async () => {
+    const { deps, requests } = createDeps({
+      responses: [TEXT.encode("llo")],
+      seedFiles: {
+        [modelPath("model.bin.partial")]: "he",
+      },
+    });
+    const service = createLocalAIModelService(deps, TEST_MANIFEST);
+
+    const models = await service.downloadModel("semantic-embeddinggemma");
+
+    expect(requests[0].range).toBe("bytes=2-");
+    expect(models[0].state.status).toBe("available");
+  });
+
+  it("pauses an active download", async () => {
+    let wroteFirstChunk!: () => void;
+    const firstChunk = new Promise<void>((resolve) => { wroteFirstChunk = resolve; });
+    const { deps } = createDeps();
+    deps.fetch = async (_url, init) => {
+      const signal = init?.signal as AbortSignal;
+      return new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(TEXT.encode("he"));
+            wroteFirstChunk();
+            signal.addEventListener("abort", () => controller.error(new DOMException("Aborted", "AbortError")));
+          },
+        }),
+      );
+    };
+    const service = createLocalAIModelService(deps, TEST_MANIFEST);
+
+    const pending = service.downloadModel("semantic-embeddinggemma");
+    await firstChunk;
+    const paused = await service.pauseDownload("semantic-embeddinggemma");
+    await pending;
+
+    expect(paused[0].state.status).toBe("paused");
+  });
+
+  it("removes downloaded model files and resets state", async () => {
+    const { deps, files } = createDeps();
+    const service = createLocalAIModelService(deps, TEST_MANIFEST);
+
+    await service.downloadModel("semantic-embeddinggemma");
+    const models = await service.removeModel("semantic-embeddinggemma");
+
+    expect(models[0].state.status).toBe("not_downloaded");
+    expect(files.has(modelPath("model.bin"))).toBe(false);
+  });
+
+  it("does not add vectors or local model state to Automerge", () => {
+    const doc = createEmptyDoc();
+    const plain = A.toJS(doc) as unknown as Record<string, unknown>;
+    const serialized = JSON.stringify(plain);
+
+    expect(serialized).not.toContain("embedding");
+    expect(serialized).not.toContain("vector");
+    expect(serialized).not.toContain("localAI");
+    expect((plain.preferences as Record<string, unknown>).ai).toEqual({
+      provider: "none",
+      model: "",
+      autoSummarize: false,
+      extractTopics: false,
+    });
+  });
+});

--- a/packages/desktop/src/lib/local-ai-models.ts
+++ b/packages/desktop/src/lib/local-ai-models.ts
@@ -1,0 +1,530 @@
+import { invoke } from "@tauri-apps/api/core";
+import { appDataDir } from "@tauri-apps/api/path";
+import {
+  exists,
+  mkdir,
+  open as openFile,
+  readFile,
+  readTextFile,
+  remove,
+  rename,
+  size as fsSize,
+  writeTextFile,
+} from "@tauri-apps/plugin-fs";
+import type {
+  LocalAIModelId,
+  LocalAIModelInstallState,
+  LocalAIModelManifestEntry,
+} from "@freed/shared";
+import type {
+  LocalAIModelDownloadProgress,
+  LocalAIModelViewState,
+} from "@freed/ui/context";
+
+const STATE_VERSION = 1;
+const MODEL_ROOT_DIR = "local-ai-models";
+const STATE_FILE = "state.json";
+
+export const LOCAL_AI_MODEL_MANIFEST: readonly LocalAIModelManifestEntry[] = [
+  {
+    id: "semantic-embeddinggemma",
+    title: "Semantic search and ranking",
+    capability: "Embeddings",
+    description: "Indexes saved items and feed text for local semantic matching.",
+    repo: "onnx-community/embeddinggemma-300m-ONNX",
+    revision: "5090578d9565bb06545b4552f76e6bc2c93e4a66",
+    sourceUrl: "https://huggingface.co/onnx-community/embeddinggemma-300m-ONNX",
+    estimatedDownloadBytes: 223_000_000,
+    estimatedStorageBytes: 223_000_000,
+    hardwareNote: "Works best with WebGPU. CPU fallback is allowed for smaller libraries.",
+    requiresWebGPU: false,
+    wasmFallback: true,
+    files: [
+      { path: "config.json", sizeBytes: 1_765, sha1: "edb6342fb0d447a42960920034c773ddd6ed6d55" },
+      { path: "onnx/model_q4.onnx", sizeBytes: 519_322, sha256: "ad1dfee81a70f7944b9b9d1cc6e48075b832881cf33fab2f2b248be78f3f0043" },
+      { path: "onnx/model_q4.onnx_data", sizeBytes: 196_725_760, sha256: "599962c3143b040de2dd05e5975be3e9091dd067cacc6a8f7186e3203bab9e02" },
+      { path: "special_tokens_map.json", sizeBytes: 662, sha1: "1a6193244714d3d78be48666cb02cdbfac62ad86" },
+      { path: "tokenizer.json", sizeBytes: 20_323_312, sha256: "4dda02faaf32bc91031dc8c88457ac272b00c1016cc679757d1c441b248b9c47" },
+      { path: "tokenizer.model", sizeBytes: 4_689_074, sha256: "1299c11d7cf632ef3b4e11937501358ada021bbdf7c47638d13c0ee982f2e79c" },
+      { path: "tokenizer_config.json", sizeBytes: 1_156_830, sha1: "73b499ae604d0bcbeb2889639a42f46462e9d372" },
+    ],
+  },
+  {
+    id: "summary-qwen3",
+    title: "Local summaries",
+    capability: "Compact generation",
+    description: "Downloads the compact local generation pack reserved for summary benchmarks.",
+    repo: "onnx-community/Qwen3-0.6B-ONNX",
+    revision: "da1453100cf3ff33ef56d17983fc7a8648706db6",
+    sourceUrl: "https://huggingface.co/onnx-community/Qwen3-0.6B-ONNX",
+    estimatedDownloadBytes: 555_000_000,
+    estimatedStorageBytes: 555_000_000,
+    hardwareNote: "Requires WebGPU for acceptable latency in Freed Desktop.",
+    requiresWebGPU: true,
+    wasmFallback: false,
+    files: [
+      { path: "onnxruntime/webgpu/webgpu-int4-kld-block-32/chat_template.jinja", sizeBytes: 4_168, sha1: "01be9b307daa2d425f7c168c9fb145a286e0afb4" },
+      { path: "onnxruntime/webgpu/webgpu-int4-kld-block-32/config.json", sizeBytes: 9_033, sha1: "d0a1f0936e40260ebc455b29c1f8e02364852e4e" },
+      { path: "onnxruntime/webgpu/webgpu-int4-kld-block-32/genai_config.json", sizeBytes: 1_752, sha1: "51c41d433774036fecd682183abe686f19f9441e" },
+      { path: "onnxruntime/webgpu/webgpu-int4-kld-block-32/model.onnx", sizeBytes: 543_321_042, sha256: "5e9fb386cb1a14009b02b43b0e0f0043e248ad5a6d3c3521c9a516062509909a" },
+      { path: "onnxruntime/webgpu/webgpu-int4-kld-block-32/tokenizer.json", sizeBytes: 11_422_648, sha256: "979d160e081df25a1bf7f4e2e8f4c441b5dfdc9a8e84aec9f32e80445e1b59b8" },
+      { path: "onnxruntime/webgpu/webgpu-int4-kld-block-32/tokenizer_config.json", sizeBytes: 663, sha1: "eeb7009b684350496c7020a205e8ee025d9ee159" },
+    ],
+  },
+  {
+    id: "assistant-gemma4",
+    title: "Advanced local assistant",
+    capability: "Gemma 4 E2B",
+    description: "Downloads the large Gemma 4 E2B text pack for explicit local assistant experiments.",
+    repo: "onnx-community/gemma-4-E2B-it-ONNX",
+    revision: "9f4bef82ea6e296bc69f8a2f5939f73af81b07a6",
+    sourceUrl: "https://huggingface.co/onnx-community/gemma-4-E2B-it-ONNX",
+    estimatedDownloadBytes: 3_140_000_000,
+    estimatedStorageBytes: 3_140_000_000,
+    hardwareNote: "Requires WebGPU and several gigabytes of free memory.",
+    requiresWebGPU: true,
+    wasmFallback: false,
+    files: [
+      { path: "chat_template.jinja", sizeBytes: 16_317, sha1: "07e50e69a8c445f2c31a089b828e85b2a93942bf" },
+      { path: "config.json", sizeBytes: 5_549, sha1: "a7f7623b5229c8498655847bd9cdeea34e5017f6" },
+      { path: "generation_config.json", sizeBytes: 238, sha1: "b2b0ab11eaf5317ad648bb48ce64b110532d661a" },
+      { path: "preprocessor_config.json", sizeBytes: 43, sha1: "6418e09c5fdb500f7ad9e86a7de9de7e60317f34" },
+      { path: "processor_config.json", sizeBytes: 1_689, sha1: "5465974d23e1eca2c46c2809b26c997946ce0d90" },
+      { path: "tokenizer.json", sizeBytes: 19_439_251, sha256: "47bd35616c7c782aaca6ccf48c75f3461d5877170984b8836b375107d0a9f566" },
+      { path: "tokenizer_config.json", sizeBytes: 18_807, sha1: "8dc6453271e40decb8ebdb68f4f9421d306dd6b3" },
+      { path: "onnx/embed_tokens_q4f16.onnx", sizeBytes: 5_621, sha256: "d7ca53f6a169471b5699b2f57ee4c7aa2c73732b0152f3909e64b71384444825" },
+      { path: "onnx/embed_tokens_q4f16.onnx_data", sizeBytes: 1_590_689_792, sha256: "024b199e6358ed42970f807686add5f9430d7e254ca7ce22fc9c83f015b9c517" },
+      { path: "onnx/decoder_model_merged_q4f16.onnx", sizeBytes: 673_231, sha256: "73c0f1fe04f9a3a048fb3319c0671b6cf0346bf33a3a8624c853bcffe01c24a4" },
+      { path: "onnx/decoder_model_merged_q4f16.onnx_data", sizeBytes: 1_519_700_992, sha256: "3b27245a7396cb7039a4e4118bd2a8aa35106bae381522edf7c4867b5f22bb10" },
+    ],
+  },
+];
+
+type PersistedState = {
+  version: number;
+  models: Partial<Record<LocalAIModelId, LocalAIModelInstallState>>;
+};
+
+type WritableFile = {
+  write(data: Uint8Array): Promise<number>;
+  close(): Promise<void>;
+};
+
+export interface LocalAIModelServiceDeps {
+  appDataDir: () => Promise<string>;
+  exists: (path: string) => Promise<boolean>;
+  mkdir: (path: string, options?: { recursive?: boolean }) => Promise<void>;
+  open: (path: string, options: { write?: boolean; append?: boolean; create?: boolean; truncate?: boolean }) => Promise<WritableFile>;
+  readFile: (path: string) => Promise<Uint8Array>;
+  readTextFile: (path: string) => Promise<string>;
+  remove: (path: string, options?: { recursive?: boolean }) => Promise<void>;
+  rename: (oldPath: string, newPath: string) => Promise<void>;
+  size: (path: string) => Promise<number>;
+  writeTextFile: (path: string, text: string) => Promise<void>;
+  fetch: typeof fetch;
+  now: () => number;
+  sha256File: (path: string) => Promise<string>;
+  webGPUAvailable: () => boolean;
+}
+
+const defaultDeps: LocalAIModelServiceDeps = {
+  appDataDir,
+  exists,
+  mkdir,
+  open: openFile,
+  readFile,
+  readTextFile,
+  remove,
+  rename,
+  size: fsSize,
+  writeTextFile,
+  fetch: (...args) => fetch(...args),
+  now: () => Date.now(),
+  sha256File: (path) => invoke<string>("sha256_file", { path }),
+  webGPUAvailable: () =>
+    typeof navigator !== "undefined" &&
+    typeof navigator === "object" &&
+    "gpu" in navigator,
+};
+
+function findManifestEntry(
+  manifest: readonly LocalAIModelManifestEntry[],
+  id: LocalAIModelId,
+): LocalAIModelManifestEntry {
+  const entry = manifest.find((model) => model.id === id);
+  if (!entry) throw new Error(`Unknown local AI model: ${id}`);
+  return entry;
+}
+
+function joinPath(...parts: string[]): string {
+  return parts
+    .map((part, index) => {
+      if (index === 0) return part.replace(/\/+$/g, "");
+      return part.replace(/^\/+|\/+$/g, "");
+    })
+    .filter(Boolean)
+    .join("/");
+}
+
+function dirname(path: string): string {
+  const index = path.lastIndexOf("/");
+  return index <= 0 ? "" : path.slice(0, index);
+}
+
+async function digest(algorithm: "SHA-1" | "SHA-256", bytes: Uint8Array): Promise<string> {
+  const input = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+  const hash = await crypto.subtle.digest(algorithm, input);
+  return Array.from(new Uint8Array(hash), (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+function defaultState(
+  manifest: LocalAIModelManifestEntry,
+  now: number,
+  webGPUAvailable: boolean,
+): LocalAIModelInstallState {
+  return {
+    id: manifest.id,
+    status: manifest.requiresWebGPU && !manifest.wasmFallback && !webGPUAvailable
+      ? "unsupported"
+      : "not_downloaded",
+    revision: manifest.revision,
+    downloadedBytes: 0,
+    totalBytes: manifest.estimatedDownloadBytes,
+    storageBytes: 0,
+    updatedAt: now,
+    health: {
+      lastIndexedItemCount: 0,
+      failureCount: 0,
+    },
+  };
+}
+
+function cleanState(
+  manifest: LocalAIModelManifestEntry,
+  state: LocalAIModelInstallState | undefined,
+  now: number,
+  webGPUAvailable: boolean,
+): LocalAIModelInstallState {
+  if (!state) return defaultState(manifest, now, webGPUAvailable);
+  if (state.status === "available") return state;
+  if (manifest.requiresWebGPU && !manifest.wasmFallback && !webGPUAvailable) {
+    return { ...state, status: "unsupported", updatedAt: now };
+  }
+  if (state.status === "unsupported") {
+    return { ...state, status: "not_downloaded", updatedAt: now };
+  }
+  return state;
+}
+
+export function createLocalAIModelService(
+  deps: LocalAIModelServiceDeps = defaultDeps,
+  manifest: readonly LocalAIModelManifestEntry[] = LOCAL_AI_MODEL_MANIFEST,
+) {
+  const activeDownloads = new Map<LocalAIModelId, AbortController>();
+  const byId = (id: LocalAIModelId) => findManifestEntry(manifest, id);
+
+  async function rootDir(): Promise<string> {
+    return joinPath(await deps.appDataDir(), MODEL_ROOT_DIR);
+  }
+
+  async function statePath(): Promise<string> {
+    return joinPath(await rootDir(), STATE_FILE);
+  }
+
+  async function modelDir(model: LocalAIModelManifestEntry): Promise<string> {
+    return joinPath(await rootDir(), model.id, model.revision);
+  }
+
+  async function filePath(model: LocalAIModelManifestEntry, path: string): Promise<string> {
+    return joinPath(await modelDir(model), path);
+  }
+
+  async function loadPersisted(): Promise<PersistedState> {
+    try {
+      const raw = await deps.readTextFile(await statePath());
+      const parsed = JSON.parse(raw) as PersistedState;
+      return {
+        version: STATE_VERSION,
+        models: parsed.models ?? {},
+      };
+    } catch {
+      return { version: STATE_VERSION, models: {} };
+    }
+  }
+
+  async function savePersisted(state: PersistedState): Promise<void> {
+    const root = await rootDir();
+    await deps.mkdir(root, { recursive: true });
+    await deps.writeTextFile(await statePath(), JSON.stringify({ ...state, version: STATE_VERSION }, null, 2));
+  }
+
+  async function updateModelState(
+    id: LocalAIModelId,
+    update: (current: LocalAIModelInstallState) => LocalAIModelInstallState,
+  ): Promise<LocalAIModelInstallState> {
+    const persisted = await loadPersisted();
+    const entry = byId(id);
+    const current = cleanState(entry, persisted.models[id], deps.now(), deps.webGPUAvailable());
+    const next = update(current);
+    persisted.models[id] = next;
+    await savePersisted(persisted);
+    return next;
+  }
+
+  async function listModels(): Promise<LocalAIModelViewState[]> {
+    const persisted = await loadPersisted();
+    const webGPUAvailable = deps.webGPUAvailable();
+    return manifest.map((entry) => ({
+      manifest: entry,
+      state: cleanState(entry, persisted.models[entry.id], deps.now(), webGPUAvailable),
+      webGPUAvailable,
+    }));
+  }
+
+  async function verifyFile(path: string, file: LocalAIModelManifestEntry["files"][number]): Promise<void> {
+    const actualSize = await deps.size(path);
+    if (actualSize !== file.sizeBytes) {
+      throw new Error(`Expected ${file.sizeBytes.toLocaleString()} bytes for ${file.path}, got ${actualSize.toLocaleString()}`);
+    }
+
+    if (file.sha256) {
+      const actual = await deps.sha256File(path);
+      if (actual !== file.sha256) {
+        throw new Error(`Checksum failed for ${file.path}`);
+      }
+      return;
+    }
+
+    if (file.sha1) {
+      const bytes = await deps.readFile(path);
+      const actual = await digest("SHA-1", bytes);
+      if (actual !== file.sha1) {
+        throw new Error(`Checksum failed for ${file.path}`);
+      }
+    }
+  }
+
+  async function writeResponseBody(
+    response: Response,
+    handle: WritableFile,
+    onChunk: (bytes: number) => void,
+  ): Promise<void> {
+    if (!response.body) {
+      const bytes = new Uint8Array(await response.arrayBuffer());
+      await handle.write(bytes);
+      onChunk(bytes.byteLength);
+      return;
+    }
+
+    const reader = response.body.getReader();
+    while (true) {
+      const next = await reader.read();
+      if (next.done) return;
+      if (!next.value) continue;
+      await handle.write(next.value);
+      onChunk(next.value.byteLength);
+    }
+  }
+
+  async function downloadFile(input: {
+    model: LocalAIModelManifestEntry;
+    file: LocalAIModelManifestEntry["files"][number];
+    signal: AbortSignal;
+    completedBeforeFile: number;
+    totalBytes: number;
+    onProgress?: (progress: LocalAIModelDownloadProgress) => void;
+  }): Promise<number> {
+    const { model, file, signal, completedBeforeFile, totalBytes, onProgress } = input;
+    const target = await filePath(model, file.path);
+    const partial = `${target}.partial`;
+    const parent = dirname(target);
+    if (parent) await deps.mkdir(parent, { recursive: true });
+
+    if (await deps.exists(target)) {
+      await verifyFile(target, file);
+      onProgress?.({
+        id: model.id,
+        currentFile: file.path,
+        downloadedBytes: completedBeforeFile + file.sizeBytes,
+        totalBytes,
+      });
+      return file.sizeBytes;
+    }
+
+    let existingPartialBytes = 0;
+    if (await deps.exists(partial)) {
+      existingPartialBytes = await deps.size(partial);
+      if (existingPartialBytes > file.sizeBytes) {
+        await deps.remove(partial);
+        existingPartialBytes = 0;
+      }
+    }
+
+    const headers = new Headers();
+    if (existingPartialBytes > 0) {
+      headers.set("Range", `bytes=${existingPartialBytes}-`);
+    }
+
+    const url = `https://huggingface.co/${model.repo}/resolve/${model.revision}/${file.path}`;
+    let response = await deps.fetch(url, { headers, signal });
+    if (response.status === 416 && existingPartialBytes > 0) {
+      await deps.remove(partial);
+      existingPartialBytes = 0;
+      response = await deps.fetch(url, { signal });
+    }
+    if (!response.ok && response.status !== 206) {
+      throw new Error(`Download failed for ${file.path}: ${response.status}`);
+    }
+
+    const canAppend = existingPartialBytes > 0 && response.status === 206;
+    if (existingPartialBytes > 0 && !canAppend) {
+      await deps.remove(partial);
+      existingPartialBytes = 0;
+    }
+
+    const handle = await deps.open(partial, {
+      write: true,
+      create: true,
+      append: canAppend,
+      truncate: !canAppend,
+    });
+
+    let writtenForFile = existingPartialBytes;
+    try {
+      await writeResponseBody(response, handle, (bytes) => {
+        writtenForFile += bytes;
+        onProgress?.({
+          id: model.id,
+          currentFile: file.path,
+          downloadedBytes: completedBeforeFile + writtenForFile,
+          totalBytes,
+        });
+      });
+    } finally {
+      await handle.close();
+    }
+
+    await verifyFile(partial, file);
+    if (await deps.exists(target)) {
+      await deps.remove(target);
+    }
+    await deps.rename(partial, target);
+    return file.sizeBytes;
+  }
+
+  async function downloadModel(
+    id: LocalAIModelId,
+    onProgress?: (progress: LocalAIModelDownloadProgress) => void,
+  ): Promise<LocalAIModelViewState[]> {
+    const model = byId(id);
+    const webGPUAvailable = deps.webGPUAvailable();
+    if (model.requiresWebGPU && !model.wasmFallback && !webGPUAvailable) {
+      await updateModelState(id, (current) => ({
+        ...current,
+        status: "unsupported",
+        updatedAt: deps.now(),
+        lastError: "WebGPU is required for this model pack.",
+      }));
+      return listModels();
+    }
+
+    activeDownloads.get(id)?.abort();
+    const controller = new AbortController();
+    activeDownloads.set(id, controller);
+
+    const totalBytes = model.files.reduce((sum, file) => sum + file.sizeBytes, 0);
+    await updateModelState(id, (current) => ({
+      ...current,
+      status: "downloading",
+      revision: model.revision,
+      downloadedBytes: 0,
+      totalBytes,
+      lastError: undefined,
+      updatedAt: deps.now(),
+    }));
+
+    let completedBytes = 0;
+    try {
+      for (const file of model.files) {
+        const downloaded = await downloadFile({
+          model,
+          file,
+          signal: controller.signal,
+          completedBeforeFile: completedBytes,
+          totalBytes,
+          onProgress,
+        });
+        completedBytes += downloaded;
+        await updateModelState(id, (current) => ({
+          ...current,
+          downloadedBytes: completedBytes,
+          totalBytes,
+          updatedAt: deps.now(),
+        }));
+      }
+
+      const dir = await modelDir(model);
+      const storageBytes = await deps.size(dir).catch(() => completedBytes);
+      await updateModelState(id, (current) => ({
+        ...current,
+        status: "available",
+        downloadedBytes: totalBytes,
+        totalBytes,
+        storageBytes,
+        installedAt: deps.now(),
+        updatedAt: deps.now(),
+        lastError: undefined,
+      }));
+    } catch (error) {
+      const aborted = controller.signal.aborted;
+      await updateModelState(id, (current) => ({
+        ...current,
+        status: aborted ? "paused" : "error",
+        downloadedBytes: completedBytes,
+        totalBytes,
+        updatedAt: deps.now(),
+        lastError: aborted
+          ? undefined
+          : error instanceof Error
+            ? error.message
+            : String(error),
+      }));
+    } finally {
+      if (activeDownloads.get(id) === controller) {
+        activeDownloads.delete(id);
+      }
+    }
+
+    return listModels();
+  }
+
+  async function pauseDownload(id: LocalAIModelId): Promise<LocalAIModelViewState[]> {
+    activeDownloads.get(id)?.abort();
+    await updateModelState(id, (current) => ({
+      ...current,
+      status: current.status === "downloading" ? "paused" : current.status,
+      updatedAt: deps.now(),
+    }));
+    return listModels();
+  }
+
+  async function removeModel(id: LocalAIModelId): Promise<LocalAIModelViewState[]> {
+    activeDownloads.get(id)?.abort();
+    const model = byId(id);
+    const dir = joinPath(await rootDir(), model.id);
+    if (await deps.exists(dir)) {
+      await deps.remove(dir, { recursive: true });
+    }
+    await updateModelState(id, () => defaultState(model, deps.now(), deps.webGPUAvailable()));
+    return listModels();
+  }
+
+  return {
+    listModels,
+    downloadModel,
+    pauseDownload,
+    removeModel,
+  };
+}
+
+export const localAIModels = createLocalAIModelService();

--- a/packages/desktop/src/tauri-stubs.d.ts
+++ b/packages/desktop/src/tauri-stubs.d.ts
@@ -106,7 +106,16 @@ declare module "@tauri-apps/plugin-fs" {
     path: string,
     contents: string,
   ): Promise<void>;
-  export function remove(path: string): Promise<void>;
+  export function remove(path: string, options?: { recursive?: boolean }): Promise<void>;
+  export function rename(oldPath: string, newPath: string): Promise<void>;
+  export function size(path: string): Promise<number>;
+  export function open(
+    path: string,
+    options?: { write?: boolean; append?: boolean; create?: boolean; truncate?: boolean },
+  ): Promise<{
+    write(contents: Uint8Array): Promise<number>;
+    close(): Promise<void>;
+  }>;
   export function exists(path: string): Promise<boolean>;
   export function mkdir(
     path: string,

--- a/packages/desktop/tests/e2e/fixtures/tauri-init.ts
+++ b/packages/desktop/tests/e2e/fixtures/tauri-init.ts
@@ -31,6 +31,7 @@ export function tauriInitScript(): string {
       get_local_ip: () => '127.0.0.1',
       get_all_local_ips: () => [],
       get_sync_url: () => 'ws://127.0.0.1:8765',
+      sha256_file: () => '',
       get_sync_client_count: () => 0,
       get_runtime_memory_stats: () => ({
         processResidentBytes: 64 * 1024 * 1024,

--- a/packages/desktop/tests/e2e/local-ai-settings.spec.ts
+++ b/packages/desktop/tests/e2e/local-ai-settings.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from "./fixtures/app";
+
+test("local AI settings are disabled until a model pack is downloaded", async ({ app, page }) => {
+  await app.goto();
+  await app.waitForReady();
+
+  const settingsButton = page.locator("button").filter({ hasText: /settings/i }).first();
+  await expect(settingsButton).toBeVisible({ timeout: 5_000 });
+  await settingsButton.click();
+  const settingsDialog = page.locator(".fixed.inset-0.z-50").last();
+  await expect(settingsDialog).toBeVisible({ timeout: 5_000 });
+  await settingsDialog.getByRole("button", { name: "AI", exact: true }).click();
+
+  const localAISettings = settingsDialog.getByTestId("local-ai-model-settings");
+  await expect(localAISettings).toBeVisible({ timeout: 5_000 });
+  await expect(localAISettings.getByText("Optional Local AI")).toBeVisible();
+  await expect(localAISettings.getByText("Semantic search and ranking")).toBeVisible();
+  await expect(localAISettings.getByText("Local summaries")).toBeVisible();
+  await expect(localAISettings.getByText("Advanced local assistant")).toBeVisible();
+  await expect(localAISettings.getByText("Not installed")).toHaveCount(3);
+  await expect(localAISettings.getByRole("button", { name: "Download" })).toHaveCount(3);
+});

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -237,6 +237,61 @@ export interface AIPreferences {
   extractTopics: boolean;
 }
 
+export type LocalAIModelId =
+  | "semantic-embeddinggemma"
+  | "summary-qwen3"
+  | "assistant-gemma4";
+
+export type LocalAIModelStatus =
+  | "not_downloaded"
+  | "downloading"
+  | "paused"
+  | "available"
+  | "error"
+  | "unsupported";
+
+export interface LocalAIModelFileManifest {
+  path: string;
+  sizeBytes: number;
+  sha256?: string;
+  sha1?: string;
+}
+
+export interface LocalAIModelManifestEntry {
+  id: LocalAIModelId;
+  title: string;
+  capability: string;
+  description: string;
+  repo: string;
+  revision: string;
+  sourceUrl: string;
+  estimatedDownloadBytes: number;
+  estimatedStorageBytes: number;
+  hardwareNote: string;
+  requiresWebGPU: boolean;
+  wasmFallback: boolean;
+  files: LocalAIModelFileManifest[];
+}
+
+export interface LocalAIModelHealth {
+  lastIndexedItemCount?: number;
+  lastRunAt?: number;
+  failureCount?: number;
+}
+
+export interface LocalAIModelInstallState {
+  id: LocalAIModelId;
+  status: LocalAIModelStatus;
+  revision: string;
+  downloadedBytes: number;
+  totalBytes: number;
+  storageBytes: number;
+  installedAt?: number;
+  updatedAt: number;
+  lastError?: string;
+  health?: LocalAIModelHealth;
+}
+
 /**
  * User interaction state
  */

--- a/packages/ui/src/components/settings/AISection.tsx
+++ b/packages/ui/src/components/settings/AISection.tsx
@@ -10,8 +10,12 @@
  */
 
 import { useState, useEffect, useCallback } from "react";
-import type { AIPreferences } from "@freed/shared";
+import type { AIPreferences, LocalAIModelId } from "@freed/shared";
 import { useAppStore, usePlatform } from "../../context/PlatformContext.js";
+import type {
+  LocalAIModelDownloadProgress,
+  LocalAIModelViewState,
+} from "../../context/PlatformContext.js";
 import { SettingsToggle } from "../SettingsToggle.js";
 
 const DEFAULT_MODELS: Record<string, string> = {
@@ -29,6 +33,198 @@ const PROVIDER_LABELS: Record<string, string> = {
   anthropic: "Anthropic",
   gemini: "Google Gemini",
 };
+
+const NUMBER_FORMAT = new Intl.NumberFormat();
+
+function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  let value = bytes;
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+  const maximumFractionDigits = value >= 10 || unitIndex === 0 ? 0 : 1;
+  return `${NUMBER_FORMAT.format(Number(value.toFixed(maximumFractionDigits)))} ${units[unitIndex]}`;
+}
+
+function formatLocalTime(timestamp?: number): string {
+  if (!timestamp) return "Never";
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(timestamp));
+}
+
+function applyDownloadProgress(
+  models: LocalAIModelViewState[],
+  progress: LocalAIModelDownloadProgress,
+): LocalAIModelViewState[] {
+  return models.map((model) => {
+    if (model.manifest.id !== progress.id) return model;
+    return {
+      ...model,
+      state: {
+        ...model.state,
+        status: "downloading",
+        downloadedBytes: progress.downloadedBytes,
+        totalBytes: progress.totalBytes,
+        updatedAt: Date.now(),
+      },
+    };
+  });
+}
+
+function statusLabel(model: LocalAIModelViewState): string {
+  const { status } = model.state;
+  if (status === "available" && model.state.revision !== model.manifest.revision) {
+    return "Update available";
+  }
+  switch (status) {
+    case "available":
+      return "Ready";
+    case "downloading":
+      return "Downloading";
+    case "paused":
+      return "Paused";
+    case "error":
+      return "Needs attention";
+    case "unsupported":
+      return "Unsupported";
+    case "not_downloaded":
+    default:
+      return "Not installed";
+  }
+}
+
+function statusTone(status: string): string {
+  switch (status) {
+    case "available":
+      return "bg-[rgb(var(--theme-feedback-success-rgb)/0.12)] text-[rgb(var(--theme-feedback-success-rgb))]";
+    case "downloading":
+      return "bg-[color:color-mix(in_srgb,var(--theme-accent-secondary)_16%,transparent)] text-[var(--theme-accent-secondary)]";
+    case "error":
+    case "unsupported":
+      return "bg-[rgb(var(--theme-feedback-danger-rgb)/0.12)] text-[rgb(var(--theme-feedback-danger-rgb))]";
+    case "paused":
+      return "bg-[rgb(var(--theme-feedback-warning-rgb)/0.16)] text-[rgb(var(--theme-feedback-warning-rgb))]";
+    default:
+      return "bg-[var(--theme-bg-muted)] text-[var(--theme-text-muted)]";
+  }
+}
+
+function LocalModelCard({
+  model,
+  busy,
+  onDownload,
+  onPause,
+  onRemove,
+  onOpenSource,
+}: {
+  model: LocalAIModelViewState;
+  busy: boolean;
+  onDownload: (id: LocalAIModelId) => void;
+  onPause: (id: LocalAIModelId) => void;
+  onRemove: (id: LocalAIModelId) => void;
+  onOpenSource: (url: string) => void;
+}) {
+  const progressTotal = model.state.totalBytes || model.manifest.estimatedDownloadBytes;
+  const progress = progressTotal > 0
+    ? Math.min(100, Math.round((model.state.downloadedBytes / progressTotal) * 100))
+    : 0;
+  const isDownloading = model.state.status === "downloading";
+  const isAvailable = model.state.status === "available";
+  const isUnsupported = model.state.status === "unsupported";
+  const needsUpdate = isAvailable && model.state.revision !== model.manifest.revision;
+  const actionDisabled = busy || isUnsupported;
+
+  return (
+    <div className="rounded-lg border border-[var(--theme-border-subtle)] bg-[color:color-mix(in_srgb,var(--theme-bg-surface)_82%,transparent)] p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <p className="text-sm font-semibold text-[var(--theme-text-primary)]">{model.manifest.title}</p>
+            <span className={`rounded-full px-2 py-0.5 text-[11px] font-medium ${statusTone(model.state.status)}`}>
+              {statusLabel(model)}
+            </span>
+          </div>
+          <p className="mt-1 text-xs text-[var(--theme-text-muted)]">{model.manifest.description}</p>
+        </div>
+        <p className="shrink-0 rounded-full bg-[var(--theme-bg-muted)] px-2 py-0.5 text-[11px] text-[var(--theme-text-muted)]">
+          {model.manifest.capability}
+        </p>
+      </div>
+
+      <div className="mt-3 grid gap-2 text-xs text-[var(--theme-text-muted)] sm:grid-cols-2">
+        <p>Download: <span className="text-[var(--theme-text-secondary)]">{formatBytes(model.manifest.estimatedDownloadBytes)}</span></p>
+        <p>Storage: <span className="text-[var(--theme-text-secondary)]">{formatBytes(model.state.storageBytes || model.manifest.estimatedStorageBytes)}</span></p>
+        <p>Indexed: <span className="text-[var(--theme-text-secondary)]">{NUMBER_FORMAT.format(model.state.health?.lastIndexedItemCount ?? 0)} items</span></p>
+        <p>Last run: <span className="text-[var(--theme-text-secondary)]">{formatLocalTime(model.state.health?.lastRunAt)}</span></p>
+      </div>
+
+      <p className="mt-2 text-xs text-[var(--theme-text-soft)]">{model.manifest.hardwareNote}</p>
+
+      {isDownloading && (
+        <div className="mt-3">
+          <div className="h-2 overflow-hidden rounded-full bg-[var(--theme-bg-muted)]">
+            <div
+              className="h-full rounded-full bg-[var(--theme-accent-secondary)] transition-[width]"
+              style={{ width: `${progress}%` }}
+            />
+          </div>
+          <p className="mt-1 text-[11px] text-[var(--theme-text-muted)]">
+            {formatBytes(model.state.downloadedBytes)} of {formatBytes(progressTotal)}
+          </p>
+        </div>
+      )}
+
+      {model.state.lastError && (
+        <p className="mt-3 rounded-lg bg-[rgb(var(--theme-feedback-danger-rgb)/0.08)] px-3 py-2 text-xs text-[rgb(var(--theme-feedback-danger-rgb))]">
+          {model.state.lastError}
+        </p>
+      )}
+
+      <div className="mt-4 flex flex-wrap items-center gap-2">
+        {isDownloading ? (
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() => onPause(model.manifest.id)}
+            className="theme-toolbar-button-ghost rounded-lg px-3 py-1.5 text-xs transition-colors disabled:opacity-40"
+          >
+            Pause
+          </button>
+        ) : isAvailable && !needsUpdate ? (
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() => onRemove(model.manifest.id)}
+            className="theme-feedback-button-danger rounded-lg px-3 py-1.5 text-xs transition-colors disabled:opacity-40"
+          >
+            Remove
+          </button>
+        ) : (
+          <button
+            type="button"
+            disabled={actionDisabled}
+            onClick={() => onDownload(model.manifest.id)}
+            className="theme-accent-button rounded-lg px-3 py-1.5 text-xs transition-colors disabled:opacity-40"
+          >
+            {needsUpdate ? "Update" : model.state.status === "paused" ? "Resume" : "Download"}
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={() => onOpenSource(model.manifest.sourceUrl)}
+          className="theme-toolbar-button-ghost rounded-lg px-3 py-1.5 text-xs transition-colors"
+        >
+          Source
+        </button>
+      </div>
+    </div>
+  );
+}
 
 /** Dot indicator showing Ollama reachability */
 function OllamaStatus({ url }: { url: string }) {
@@ -127,7 +323,7 @@ function ApiKeyInput({
 }
 
 export function AISection() {
-  const { secureStorage } = usePlatform();
+  const { secureStorage, localAIModels, openUrl } = usePlatform();
   const preferences = useAppStore((s) => s.preferences);
   const updatePreferences = useAppStore((s) => s.updatePreferences);
 
@@ -139,7 +335,24 @@ export function AISection() {
   };
 
   const [showOllamaUrl, setShowOllamaUrl] = useState(false);
+  const [localModels, setLocalModels] = useState<LocalAIModelViewState[]>([]);
+  const [localModelsLoading, setLocalModelsLoading] = useState(false);
+  const [busyModelId, setBusyModelId] = useState<LocalAIModelId | null>(null);
   const ollamaUrl = ai.ollamaUrl ?? "http://localhost:11434";
+
+  const refreshLocalModels = useCallback(async () => {
+    if (!localAIModels) return;
+    setLocalModelsLoading(true);
+    try {
+      setLocalModels(await localAIModels.listModels());
+    } finally {
+      setLocalModelsLoading(false);
+    }
+  }, [localAIModels]);
+
+  useEffect(() => {
+    void refreshLocalModels();
+  }, [refreshLocalModels]);
 
   const update = useCallback(
     (patch: Partial<AIPreferences>) => {
@@ -157,10 +370,73 @@ export function AISection() {
 
   const requiresKey = ai.provider === "openai" || ai.provider === "anthropic" || ai.provider === "gemini";
 
+  const handleDownloadLocalModel = useCallback((id: LocalAIModelId) => {
+    if (!localAIModels) return;
+    setBusyModelId(id);
+    void localAIModels
+      .downloadModel(id, (progress) => {
+        setLocalModels((current) => applyDownloadProgress(current, progress));
+      })
+      .then(setLocalModels)
+      .finally(() => setBusyModelId(null));
+  }, [localAIModels]);
+
+  const handlePauseLocalModel = useCallback((id: LocalAIModelId) => {
+    if (!localAIModels) return;
+    setBusyModelId(id);
+    void localAIModels.pauseDownload(id).then(setLocalModels).finally(() => setBusyModelId(null));
+  }, [localAIModels]);
+
+  const handleRemoveLocalModel = useCallback((id: LocalAIModelId) => {
+    if (!localAIModels) return;
+    setBusyModelId(id);
+    void localAIModels.removeModel(id).then(setLocalModels).finally(() => setBusyModelId(null));
+  }, [localAIModels]);
+
+  const handleOpenSource = useCallback((url: string) => {
+    if (openUrl) {
+      openUrl(url);
+      return;
+    }
+    window.open(url, "_blank", "noopener,noreferrer");
+  }, [openUrl]);
+
   return (
     <div className="space-y-4">
+      {localAIModels && (
+        <div className="space-y-3" data-testid="local-ai-model-settings">
+          <div>
+            <h3 className="text-xs font-semibold uppercase tracking-wider text-[var(--theme-text-muted)]">
+              Optional Local AI
+            </h3>
+            <p className="mt-1 text-xs text-[var(--theme-text-muted)]">
+              Model packs stay out of the installer and are downloaded only when you turn them on here.
+            </p>
+          </div>
+          {localModelsLoading && localModels.length === 0 ? (
+            <p className="rounded-lg border border-[var(--theme-border-subtle)] bg-[var(--theme-bg-muted)] px-3 py-2 text-xs text-[var(--theme-text-muted)]">
+              Checking local model state...
+            </p>
+          ) : (
+            <div className="space-y-3">
+              {localModels.map((model) => (
+                <LocalModelCard
+                  key={model.manifest.id}
+                  model={model}
+                  busy={busyModelId === model.manifest.id}
+                  onDownload={handleDownloadLocalModel}
+                  onPause={handlePauseLocalModel}
+                  onRemove={handleRemoveLocalModel}
+                  onOpenSource={handleOpenSource}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
       <h3 className="text-xs font-semibold uppercase tracking-wider text-[var(--theme-text-muted)]">
-        AI Summarization
+        Cloud And Ollama Summaries
       </h3>
 
       {/* Provider */}

--- a/packages/ui/src/context/PlatformContext.tsx
+++ b/packages/ui/src/context/PlatformContext.tsx
@@ -21,6 +21,9 @@ import type {
   FeedItem,
   GeneratedBugReportBundle,
   ImportProgress,
+  LocalAIModelId,
+  LocalAIModelInstallState,
+  LocalAIModelManifestEntry,
   ReportPrivacyTier,
 } from "@freed/shared";
 import type { OPMLFeedEntry, ReleaseChannel } from "@freed/shared";
@@ -108,6 +111,29 @@ export interface ReaderHydrationResult {
   replies?: ReaderThreadReply[];
   status?: "hydrated" | "partial" | "expired" | "auth_required" | "unsupported";
   message?: string;
+}
+
+export interface LocalAIModelDownloadProgress {
+  id: LocalAIModelId;
+  downloadedBytes: number;
+  totalBytes: number;
+  currentFile?: string;
+}
+
+export interface LocalAIModelViewState {
+  manifest: LocalAIModelManifestEntry;
+  state: LocalAIModelInstallState;
+  webGPUAvailable: boolean;
+}
+
+export interface LocalAIModelControls {
+  listModels: () => Promise<LocalAIModelViewState[]>;
+  downloadModel: (
+    id: LocalAIModelId,
+    onProgress?: (progress: LocalAIModelDownloadProgress) => void,
+  ) => Promise<LocalAIModelViewState[]>;
+  pauseDownload: (id: LocalAIModelId) => Promise<LocalAIModelViewState[]>;
+  removeModel: (id: LocalAIModelId) => Promise<LocalAIModelViewState[]>;
 }
 
 export interface PlatformConfig {
@@ -327,6 +353,9 @@ export interface PlatformConfig {
     setApiKey: (provider: string, key: string) => Promise<void>;
     clearApiKey: (provider: string) => Promise<void>;
   };
+
+  /** Device-local optional model downloads for offline AI. */
+  localAIModels?: LocalAIModelControls;
 
   /**
    * Google Contacts API integration.

--- a/packages/ui/src/context/index.ts
+++ b/packages/ui/src/context/index.ts
@@ -6,6 +6,8 @@ export {
   type ContactSyncActions,
   type BugReportingConfig,
   type AvailableUpdateInfo,
+  type LocalAIModelDownloadProgress,
+  type LocalAIModelViewState,
   type PlatformConfig,
   type ReaderHydrationResult,
   type ReaderThreadReply,

--- a/website/src/app/roadmap/RoadmapContent.tsx
+++ b/website/src/app/roadmap/RoadmapContent.tsx
@@ -783,7 +783,7 @@ const phases: Phase[] = [
     number: 10,
     title: "Polish",
     description:
-      "Onboarding, statistics, local content signals with saved feed filter presets, AI features, plugin API, community infrastructure, and deeper crash recovery hardening.",
+      "Onboarding, statistics, local content signals with saved feed filter presets, optional local AI model packs, plugin API, community infrastructure, and deeper crash recovery hardening.",
     status: "upcoming",
     planLink:
       "https://github.com/freed-project/freed/blob/dev/docs/PHASE-10-POLISH.md",


### PR DESCRIPTION
(AI Generated).

## Summary
- Adds disabled-by-default local model cards in AI settings for semantic search, compact summaries, and the large Gemma pack.
- Downloads are device-local, resumable, pinned to Hugging Face revisions, and verified before models become available.
- Updates Phase 10 docs and the public roadmap copy to include optional local AI packs.

## Testing
- npm run validate:feature
- PATH=/Users/aubreyfalconer/dev/freed-optional-local-ai/node_modules/.bin:$PATH npm run test:e2e -- local-ai-settings.spec.ts
- cargo check
