### PR TITLE
fix: preserve paused local AI download progress

### DIFF
--- a/packages/desktop/src/lib/local-ai-models.test.ts
+++ b/packages/desktop/src/lib/local-ai-models.test.ts
@@ -187,13 +187,30 @@ describe("local AI model manager", () => {
     let wroteFirstChunk!: () => void;
     const firstChunk = new Promise<void>((resolve) => { wroteFirstChunk = resolve; });
     const { deps } = createDeps();
+    const originalOpen = deps.open;
+    deps.open = async (path, openOptions) => {
+      const handle = await originalOpen(path, openOptions);
+      let resolved = false;
+      return {
+        async write(data) {
+          const written = await handle.write(data);
+          if (!resolved) {
+            resolved = true;
+            wroteFirstChunk();
+          }
+          return written;
+        },
+        async close() {
+          await handle.close();
+        },
+      };
+    };
     deps.fetch = async (_url, init) => {
       const signal = init?.signal as AbortSignal;
       return new Response(
         new ReadableStream<Uint8Array>({
           start(controller) {
             controller.enqueue(TEXT.encode("he"));
-            wroteFirstChunk();
             signal.addEventListener("abort", () => controller.error(new DOMException("Aborted", "AbortError")));
           },
         }),

--- a/packages/desktop/src/lib/local-ai-models.test.ts
+++ b/packages/desktop/src/lib/local-ai-models.test.ts
@@ -203,10 +203,11 @@ describe("local AI model manager", () => {
 
     const pending = service.downloadModel("semantic-embeddinggemma");
     await firstChunk;
-    const paused = await service.pauseDownload("semantic-embeddinggemma");
-    await pending;
+    await service.pauseDownload("semantic-embeddinggemma");
+    const paused = await pending;
 
     expect(paused[0].state.status).toBe("paused");
+    expect(paused[0].state.downloadedBytes).toBe(2);
   });
 
   it("removes downloaded model files and resets state", async () => {

--- a/packages/desktop/src/lib/local-ai-models.ts
+++ b/packages/desktop/src/lib/local-ai-models.ts
@@ -281,6 +281,26 @@ export function createLocalAIModelService(
     }));
   }
 
+  async function measuredDownloadedBytes(model: LocalAIModelManifestEntry): Promise<number> {
+    let downloadedBytes = 0;
+
+    for (const file of model.files) {
+      const target = await filePath(model, file.path);
+      const partial = `${target}.partial`;
+
+      if (await deps.exists(target)) {
+        downloadedBytes += Math.min(await deps.size(target), file.sizeBytes);
+        continue;
+      }
+
+      if (await deps.exists(partial)) {
+        downloadedBytes += Math.min(await deps.size(partial), file.sizeBytes);
+      }
+    }
+
+    return downloadedBytes;
+  }
+
   async function verifyFile(path: string, file: LocalAIModelManifestEntry["files"][number]): Promise<void> {
     const actualSize = await deps.size(path);
     if (actualSize !== file.sizeBytes) {
@@ -444,7 +464,6 @@ export function createLocalAIModelService(
     }));
 
     let completedBytes = 0;
-    let latestProgressBytes = 0;
     try {
       for (const file of model.files) {
         const downloaded = await downloadFile({
@@ -453,13 +472,9 @@ export function createLocalAIModelService(
           signal: controller.signal,
           completedBeforeFile: completedBytes,
           totalBytes,
-          onProgress: (progress) => {
-            latestProgressBytes = progress.downloadedBytes;
-            onProgress?.(progress);
-          },
+          onProgress,
         });
         completedBytes += downloaded;
-        latestProgressBytes = completedBytes;
         await updateModelState(id, (current) => ({
           ...current,
           downloadedBytes: completedBytes,
@@ -483,7 +498,7 @@ export function createLocalAIModelService(
     } catch (error) {
       const aborted = controller.signal.aborted;
       const downloadedBytes = aborted
-        ? Math.max(completedBytes, latestProgressBytes)
+        ? await measuredDownloadedBytes(model)
         : completedBytes;
       await updateModelState(id, (current) => ({
         ...current,

--- a/packages/desktop/src/lib/local-ai-models.ts
+++ b/packages/desktop/src/lib/local-ai-models.ts
@@ -444,6 +444,7 @@ export function createLocalAIModelService(
     }));
 
     let completedBytes = 0;
+    let latestProgressBytes = 0;
     try {
       for (const file of model.files) {
         const downloaded = await downloadFile({
@@ -452,9 +453,13 @@ export function createLocalAIModelService(
           signal: controller.signal,
           completedBeforeFile: completedBytes,
           totalBytes,
-          onProgress,
+          onProgress: (progress) => {
+            latestProgressBytes = progress.downloadedBytes;
+            onProgress?.(progress);
+          },
         });
         completedBytes += downloaded;
+        latestProgressBytes = completedBytes;
         await updateModelState(id, (current) => ({
           ...current,
           downloadedBytes: completedBytes,
@@ -477,10 +482,13 @@ export function createLocalAIModelService(
       }));
     } catch (error) {
       const aborted = controller.signal.aborted;
+      const downloadedBytes = aborted
+        ? Math.max(completedBytes, latestProgressBytes)
+        : completedBytes;
       await updateModelState(id, (current) => ({
         ...current,
         status: aborted ? "paused" : "error",
-        downloadedBytes: completedBytes,
+        downloadedBytes,
         totalBytes,
         updatedAt: deps.now(),
         lastError: aborted


### PR DESCRIPTION
(AI Generated).

## Summary
- Preserve the latest streamed byte count when a local AI download is paused mid-file, so the saved settings state does not jump backward.
- Add regression coverage for the paused-download path in the desktop local AI model service test.

## Testing
- git diff --check
- Local Vitest and Playwright runs were blocked in this worktree because the expected hoisted test runner installs are missing.