### PR TITLE
fix: build dev releases for all primary platforms

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,6 +132,8 @@ jobs:
             exit 1
           fi
 
+          PRIMARY_RELEASE_MATRIX='{"include":[{"platform":"macos-latest","args":"--target aarch64-apple-darwin","rust_target":"aarch64-apple-darwin"},{"platform":"macos-latest","args":"--target x86_64-apple-darwin","rust_target":"x86_64-apple-darwin"},{"platform":"windows-latest","args":"--target x86_64-pc-windows-msvc","rust_target":"x86_64-pc-windows-msvc"},{"platform":"ubuntu-22.04","args":"","rust_target":"x86_64-unknown-linux-gnu"}]}'
+
           # Write to GITHUB_OUTPUT using heredoc to handle multiline
           {
             echo "release_body<<RELEASE_BODY_EOF"
@@ -143,11 +145,7 @@ jobs:
             else
               echo "is_prerelease=false"
             fi
-            if [[ "$CHANNEL" == "dev" ]]; then
-              echo 'release_matrix={"include":[{"platform":"macos-latest","args":"--target aarch64-apple-darwin","rust_target":"aarch64-apple-darwin"}]}'
-            else
-              echo 'release_matrix={"include":[{"platform":"macos-latest","args":"--target aarch64-apple-darwin","rust_target":"aarch64-apple-darwin"},{"platform":"macos-latest","args":"--target x86_64-apple-darwin","rust_target":"x86_64-apple-darwin"},{"platform":"windows-latest","args":"--target x86_64-pc-windows-msvc","rust_target":"x86_64-pc-windows-msvc"},{"platform":"ubuntu-22.04","args":"","rust_target":"x86_64-unknown-linux-gnu"}]}'
-            fi
+            echo "release_matrix=${PRIMARY_RELEASE_MATRIX}"
           } >> "$GITHUB_OUTPUT"
 
   validation:

--- a/scripts/release-workflow-matrix.test.mjs
+++ b/scripts/release-workflow-matrix.test.mjs
@@ -1,0 +1,54 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "..");
+const releaseWorkflowPath = path.join(repoRoot, ".github", "workflows", "release.yml");
+
+function loadPrimaryReleaseMatrix() {
+  const workflow = readFileSync(releaseWorkflowPath, "utf8");
+  const match = workflow.match(/PRIMARY_RELEASE_MATRIX='([^']+)'/);
+  assert.ok(match, "release workflow should define a shared primary release matrix");
+  return JSON.parse(match[1]);
+}
+
+test("dev and production releases use the same primary platform matrix", () => {
+  const workflow = readFileSync(releaseWorkflowPath, "utf8");
+  const matrix = loadPrimaryReleaseMatrix();
+
+  assert.equal(
+    (workflow.match(/release_matrix=/g) ?? []).length,
+    1,
+    "workflow should define the matrix once and write it once",
+  );
+  assert.doesNotMatch(
+    workflow,
+    /release_matrix=\{"include":\[\{"platform":"macos-latest","args":"--target aarch64-apple-darwin","rust_target":"aarch64-apple-darwin"\}\]\}/,
+  );
+  assert.deepEqual(matrix.include, [
+    {
+      platform: "macos-latest",
+      args: "--target aarch64-apple-darwin",
+      rust_target: "aarch64-apple-darwin",
+    },
+    {
+      platform: "macos-latest",
+      args: "--target x86_64-apple-darwin",
+      rust_target: "x86_64-apple-darwin",
+    },
+    {
+      platform: "windows-latest",
+      args: "--target x86_64-pc-windows-msvc",
+      rust_target: "x86_64-pc-windows-msvc",
+    },
+    {
+      platform: "ubuntu-22.04",
+      args: "",
+      rust_target: "x86_64-unknown-linux-gnu",
+    },
+  ]);
+});


### PR DESCRIPTION
(AI Generated).

## Summary
- Use one shared primary release matrix for dev and production tagged releases.
- Cover macOS Apple Silicon, macOS Intel, Windows x64, and Linux x64 in dev release builds.
- Add a script test that rejects the old single platform dev matrix.

## Testing
- node --test scripts/release-workflow-matrix.test.mjs
- npm run test:scripts
- npm run validate:feature