### PR TITLE
fix: mark feed items read while scrolling

### DIFF
--- a/packages/desktop/tests/e2e/smoke.spec.ts
+++ b/packages/desktop/tests/e2e/smoke.spec.ts
@@ -1724,6 +1724,109 @@ test("desktop primary feed scroller keeps the shared fade shell", async ({ app, 
   expect((fadeState?.webkitMaskImage || fadeState?.maskImage || "none")).not.toBe("none");
 });
 
+test("desktop primary feed marks scrolled-past rows as read", async ({ app, page }) => {
+  await page.setViewportSize({ width: 1280, height: 600 });
+  await app.goto();
+  await app.waitForReady();
+  await app.injectRssItems(30);
+
+  const firstItemId = "rss:https://bench.example/feed.xml:bench-item-0";
+  const initialUnreadCount = await page.evaluate(() => {
+    const store = (window as Record<string, unknown>).__FREED_STORE__ as
+      | {
+          getState: () => {
+            preferences: {
+              display: {
+                reading: {
+                  markReadOnScroll: boolean;
+                  showReadInGrayscale: boolean;
+                };
+              };
+            };
+            totalUnreadCount: number;
+          };
+        }
+      | undefined;
+    const state = store?.getState();
+    if (!state?.preferences.display.reading.markReadOnScroll) {
+      throw new Error("Mark read on scroll is not enabled");
+    }
+    if (!state.preferences.display.reading.showReadInGrayscale) {
+      throw new Error("Read grayscale is not enabled");
+    }
+    return state.totalUnreadCount;
+  });
+
+  await page.evaluate(() => {
+    const container = document.querySelector('[data-testid="feed-list-scroll-container"]') as HTMLElement | null;
+    if (!container) {
+      throw new Error("Feed scroll container was not found");
+    }
+    container.scrollTop = 1_400;
+    container.dispatchEvent(new Event("scroll"));
+  });
+
+  await expect
+    .poll(async () => page.evaluate((itemId) => {
+      const store = (window as Record<string, unknown>).__FREED_STORE__ as
+        | {
+            getState: () => {
+              items: Array<{ globalId: string; userState: { readAt?: number } }>;
+            };
+          }
+        | undefined;
+      return Boolean(store?.getState().items.find((item) => item.globalId === itemId)?.userState.readAt);
+    }, firstItemId), { timeout: 10_000 })
+    .toBe(true);
+
+  await expect
+    .poll(async () => page.evaluate(() => {
+      const store = (window as Record<string, unknown>).__FREED_STORE__ as
+        | { getState: () => { totalUnreadCount: number } }
+        | undefined;
+      return store?.getState().totalUnreadCount ?? Number.POSITIVE_INFINITY;
+    }), { timeout: 10_000 })
+    .toBeLessThan(initialUnreadCount);
+
+  await page.evaluate(() => {
+    const container = document.querySelector('[data-testid="feed-list-scroll-container"]') as HTMLElement | null;
+    if (!container) {
+      throw new Error("Feed scroll container was not found");
+    }
+    container.scrollTop = container.scrollHeight;
+    container.dispatchEvent(new Event("scroll"));
+  });
+
+  await expect
+    .poll(async () => page.evaluate(() => {
+      const store = (window as Record<string, unknown>).__FREED_STORE__ as
+        | { getState: () => { totalUnreadCount: number } }
+        | undefined;
+      return store?.getState().totalUnreadCount ?? Number.POSITIVE_INFINITY;
+    }), { timeout: 10_000 })
+    .toBe(0);
+
+  await page.evaluate(() => {
+    const container = document.querySelector('[data-testid="feed-list-scroll-container"]') as HTMLElement | null;
+    if (!container) {
+      throw new Error("Feed scroll container was not found");
+    }
+    container.scrollTop = 0;
+    container.dispatchEvent(new Event("scroll"));
+  });
+
+  await expect
+    .poll(async () => page.evaluate(() => {
+      const container = document.querySelector('[data-testid="feed-list-scroll-container"]') as HTMLElement | null;
+      return container?.scrollTop ?? Number.NaN;
+    }), { timeout: 10_000 })
+    .toBe(0);
+
+  const topCard = page.locator("[data-feed-item-id]").first();
+  await expect(topCard).toBeVisible({ timeout: 10_000 });
+  await expect(topCard).toHaveClass(/grayscale/);
+});
+
 test("keyboard focus scrolling keeps a full row visible past the focused item", async ({ app, page }) => {
   await page.setViewportSize({ width: 1280, height: 600 });
   await app.goto();

--- a/packages/ui/src/components/feed/FeedList.tsx
+++ b/packages/ui/src/components/feed/FeedList.tsx
@@ -9,6 +9,7 @@ import {
   getRemainingUnreadIds,
   hasReachedListBottom,
   type ReadTrackRow,
+  type VirtualRowRange,
 } from "./read-on-scroll.js";
 import type { FeedItem as FeedItemType } from "@freed/shared";
 import { useAppStore, usePlatform } from "../../context/PlatformContext.js";
@@ -117,6 +118,14 @@ interface FeedListProps {
   /** The active search query text — used in the empty state message */
   searchQuery?: string;
 }
+
+type ReadScrollVirtualizer = {
+  getVirtualItems: () => VirtualRowRange[];
+  getTotalSize: () => number;
+  options: {
+    scrollMargin?: number;
+  };
+};
 
 /**
  * Memoized per-row adapter. Keeps handler references stable so FeedItem's
@@ -339,12 +348,101 @@ export function FeedList({
     [rows, containerWidth],
   );
 
+  const listKey = useMemo(
+    () => JSON.stringify({ activeFilter, searchQuery: searchQuery.trim() }),
+    [activeFilter, searchQuery],
+  );
+  const maxPassedRowIndexRef = useRef(-1);
+  const listSessionRef = useRef({
+    key: listKey,
+    items,
+    reachedBottom: false,
+  });
+
+  const flushReadIds = useCallback((ids: string[]) => {
+    if (ids.length === 0) return;
+    void markItemsAsRead(ids);
+  }, [markItemsAsRead]);
+
+  const collectUnreadIdsFromRows = useCallback((startIndex: number, endIndex: number) => {
+    return collectUnreadIdsFromReadRows(
+      rows as Array<ReadTrackRow<FeedItemType>>,
+      startIndex,
+      endIndex,
+    );
+  }, [rows]);
+
+  const finalizeListSession = useCallback((session: { items: FeedItemType[]; reachedBottom: boolean }) => {
+    if (!markReadOnScroll || !session.reachedBottom) return;
+    flushReadIds(getRemainingUnreadIds(session.items));
+  }, [flushReadIds, markReadOnScroll]);
+
+  const markRemainingUnreadInSession = useCallback(() => {
+    const session = listSessionRef.current;
+    if (session.reachedBottom) return;
+    session.reachedBottom = true;
+    flushReadIds(getRemainingUnreadIds(session.items));
+  }, [flushReadIds]);
+
+  const processReadOnScroll = useCallback((
+    virtualizer: ReadScrollVirtualizer,
+    scrollSource: "element" | "window",
+  ) => {
+    if (!markReadOnScroll) return;
+
+    const vItems = virtualizer.getVirtualItems();
+    if (vItems.length === 0) return;
+
+    const rawScrollTop = scrollSource === "window"
+      ? window.scrollY
+      : (parentRef.current?.scrollTop ?? 0);
+    const vpHeight = scrollSource === "window"
+      ? window.innerHeight
+      : (parentRef.current?.clientHeight ?? 0);
+    const scrollMargin = scrollSource === "window"
+      ? (virtualizer.options.scrollMargin ?? 0)
+      : 0;
+    const { scrollTop, viewportBottom: vpBottom } = getListViewportMetrics(
+      rawScrollTop,
+      vpHeight,
+      scrollMargin,
+    );
+
+    const newlyPassedEnd = getNewlyPassedRowEnd(
+      vItems,
+      scrollTop,
+      rows.length,
+      maxPassedRowIndexRef.current,
+    );
+    if (newlyPassedEnd !== null) {
+      const unreadIds = collectUnreadIdsFromRows(
+        maxPassedRowIndexRef.current + 1,
+        newlyPassedEnd,
+      );
+      maxPassedRowIndexRef.current = newlyPassedEnd;
+      flushReadIds(unreadIds);
+    }
+
+    if (hasReachedListBottom(rows.length, vpBottom, virtualizer.getTotalSize())) {
+      markRemainingUnreadInSession();
+    }
+  }, [
+    collectUnreadIdsFromRows,
+    flushReadIds,
+    markReadOnScroll,
+    markRemainingUnreadInSession,
+    rows.length,
+  ]);
+
   const elementVirtualizer = useVirtualizer({
     count: isMobile ? 0 : rows.length,
     getScrollElement: () => (isMobile ? null : parentRef.current),
     estimateSize: estimateRowSize,
     overscan: 5,
     measureElement: (el) => el.getBoundingClientRect().height,
+    onChange: (instance) => {
+      if (!isMobile) processReadOnScroll(instance, "element");
+    },
   });
 
   const windowVirtualizer = useWindowVirtualizer({
@@ -354,6 +452,9 @@ export function FeedList({
     // Distance from window top to the list container. Accounts for the sticky
     // header so items are offset correctly as window.scrollY changes.
     scrollMargin: windowListRef.current?.offsetTop ?? 0,
+    onChange: (instance) => {
+      if (isMobile) processReadOnScroll(instance, "window");
+    },
   });
 
   useLayoutEffect(() => {
@@ -405,35 +506,6 @@ export function FeedList({
     rows.length,
   ]);
 
-  const listKey = useMemo(
-    () => JSON.stringify({ activeFilter, searchQuery: searchQuery.trim() }),
-    [activeFilter, searchQuery],
-  );
-  const maxPassedRowIndexRef = useRef(-1);
-  const listSessionRef = useRef({
-    key: listKey,
-    items,
-    reachedBottom: false,
-  });
-
-  const flushReadIds = useCallback((ids: string[]) => {
-    if (ids.length === 0) return;
-    void markItemsAsRead(ids);
-  }, [markItemsAsRead]);
-
-  const collectUnreadIdsFromRows = useCallback((startIndex: number, endIndex: number) => {
-    return collectUnreadIdsFromReadRows(
-      rows as Array<ReadTrackRow<FeedItemType>>,
-      startIndex,
-      endIndex,
-    );
-  }, [rows]);
-
-  const finalizeListSession = useCallback((session: { items: FeedItemType[]; reachedBottom: boolean }) => {
-    if (!markReadOnScroll || !session.reachedBottom) return;
-    flushReadIds(getRemainingUnreadIds(session.items));
-  }, [flushReadIds, markReadOnScroll]);
-
   useEffect(() => {
     const session = listSessionRef.current;
     if (session.key !== listKey) {
@@ -454,61 +526,6 @@ export function FeedList({
       finalizeListSession(listSessionRef.current);
     };
   }, [finalizeListSession]);
-
-  // Mark rows as read once the viewport has fully scrolled past them.
-  useEffect(() => {
-    if (!markReadOnScroll) return;
-
-    const vItems = isMobile
-      ? windowVirtualizer.getVirtualItems()
-      : elementVirtualizer.getVirtualItems();
-    if (vItems.length === 0) return;
-
-    const rawScrollTop = isMobile
-      ? window.scrollY
-      : (parentRef.current?.scrollTop ?? 0);
-    const vpHeight = isMobile
-      ? window.innerHeight
-      : (parentRef.current?.clientHeight ?? 0);
-    const scrollMargin = isMobile
-      ? (windowVirtualizer.options.scrollMargin ?? 0)
-      : 0;
-    const { scrollTop, viewportBottom: vpBottom } = getListViewportMetrics(
-      rawScrollTop,
-      vpHeight,
-      scrollMargin,
-    );
-    const totalSize = isMobile
-      ? windowVirtualizer.getTotalSize()
-      : elementVirtualizer.getTotalSize();
-
-    const newlyPassedEnd = getNewlyPassedRowEnd(
-      vItems,
-      scrollTop,
-      rows.length,
-      maxPassedRowIndexRef.current,
-    );
-    if (newlyPassedEnd !== null) {
-      const unreadIds = collectUnreadIdsFromRows(
-        maxPassedRowIndexRef.current + 1,
-        newlyPassedEnd,
-      );
-      maxPassedRowIndexRef.current = newlyPassedEnd;
-      flushReadIds(unreadIds);
-    }
-
-    if (hasReachedListBottom(rows.length, vpBottom, totalSize)) {
-      listSessionRef.current.reachedBottom = true;
-    }
-  }, [
-    collectUnreadIdsFromRows,
-    elementVirtualizer,
-    flushReadIds,
-    isMobile,
-    markReadOnScroll,
-    rows,
-    windowVirtualizer,
-  ]);
 
   // Show shimmer placeholders while the doc is loading from IndexedDB.
   // Once isLoading flips false, items will populate and we drop into the

--- a/packages/ui/src/components/feed/read-on-scroll.test.ts
+++ b/packages/ui/src/components/feed/read-on-scroll.test.ts
@@ -43,6 +43,29 @@ describe("read-on-scroll helpers", () => {
     expect(getNewlyPassedRowEnd([], 9999, 5, 2)).toBe(4);
   });
 
+  it("does not rewind the passed-row boundary when scrolling back up", () => {
+    const rows: Array<ReadTrackRow<TestItem>> = [
+      { type: "item", item: item("a") },
+      { type: "item", item: item("b") },
+      { type: "item", item: item("c") },
+      { type: "item", item: item("d") },
+      { type: "item", item: item("e") },
+    ];
+    const farDownRows = [
+      { index: 4, end: 1_100 },
+    ];
+    const backUpRows = [
+      { index: 1, end: 440 },
+      { index: 2, end: 660 },
+    ];
+
+    const passedEnd = getNewlyPassedRowEnd(farDownRows, 900, rows.length, -1);
+
+    expect(passedEnd).toBe(3);
+    expect(collectUnreadIdsFromRows(rows, 0, passedEnd ?? -1)).toEqual(["a", "b", "c", "d"]);
+    expect(getNewlyPassedRowEnd(backUpRows, 250, rows.length, passedEnd ?? -1)).toBeNull();
+  });
+
   it("returns the remaining unread ids when finishing a list", () => {
     expect(
       getRemainingUnreadIds([


### PR DESCRIPTION
(AI Generated).

## Summary
- Drive feed read tracking from virtualizer scroll changes instead of passive render effects.
- Mark the remaining feed session read immediately when the list bottom is reached.

## Testing
- node ../../node_modules/vitest/vitest.mjs run src/components/feed/read-on-scroll.test.ts
- PATH=<worktree>/node_modules/.bin:$PATH npm run test:e2e -- smoke.spec.ts --grep "desktop primary feed marks scrolled-past rows as read"
- npm run validate:feature