### PR TITLE
fix: prevent health persistence from freezing dev preview

### DIFF
--- a/packages/desktop/src/lib/provider-health.test.ts
+++ b/packages/desktop/src/lib/provider-health.test.ts
@@ -23,24 +23,38 @@ function createMockAppState() {
   return state;
 }
 
-async function loadProviderHealthModule() {
+async function loadProviderHealthModule(options: { native?: boolean } = {}) {
   vi.resetModules();
   localStorage.clear();
 
-  const persisted = { value: undefined as unknown };
+  const nativeFiles = new Map<string, string>();
+  const nativeWrites: Array<{ path: string; contents: string }> = [];
   const toastInfo = vi.fn();
   const openTo = vi.fn();
   const storeState = createMockAppState();
-  const storeSet = vi.fn(async (_key: string, value: unknown) => {
-    persisted.value = value;
-  });
 
-  vi.doMock("@tauri-apps/plugin-store", () => ({
-    Store: class Store {},
-    load: vi.fn(async () => ({
-      get: vi.fn(async () => persisted.value),
-      set: storeSet,
-    })),
+  vi.doMock("@tauri-apps/api/core", () => ({
+    isTauri: () => options.native === true,
+  }));
+  vi.doMock("@tauri-apps/api/path", () => ({
+    appDataDir: vi.fn(async () => "/mock/app-data"),
+  }));
+  vi.doMock("@tauri-apps/plugin-fs", () => ({
+    readTextFile: vi.fn(async (path: string) => {
+      const value = nativeFiles.get(path);
+      if (value === undefined) throw new Error(`ENOENT: ${path}`);
+      return value;
+    }),
+    writeTextFile: vi.fn(async (path: string, contents: string) => {
+      nativeWrites.push({ path, contents });
+      nativeFiles.set(path, contents);
+    }),
+    rename: vi.fn(async (oldPath: string, newPath: string) => {
+      const value = nativeFiles.get(oldPath);
+      if (value === undefined) throw new Error(`ENOENT: ${oldPath}`);
+      nativeFiles.set(newPath, value);
+      nativeFiles.delete(oldPath);
+    }),
   }));
   vi.doMock("@freed/ui/components/Toast", () => ({
     toast: {
@@ -75,7 +89,8 @@ async function loadProviderHealthModule() {
   const mod = await import("./provider-health");
   return {
     mod,
-    persisted,
+    nativeFiles,
+    nativeWrites,
     toastInfo,
     openTo,
     storeState,
@@ -120,6 +135,88 @@ describe("provider health", () => {
       provider?.hourlyBuckets.find((bucket) => bucket.hourKey === "2026-04-02T19")
         ?.itemsSeen,
     ).toBe(12);
+  });
+
+  it("persists native health state through the filesystem instead of Tauri store", async () => {
+    vi.useFakeTimers();
+    const now = new Date("2026-04-02T19:15:00.000Z");
+    vi.setSystemTime(now);
+
+    const { mod, nativeFiles, nativeWrites } = await loadProviderHealthModule({ native: true });
+
+    await mod.recordProviderHealthEvent({
+      provider: "rss",
+      scope: "rss_feed",
+      feedUrl: "https://example.com/rss.xml",
+      feedTitle: "Example Feed",
+      outcome: "success",
+      finishedAt: now.getTime(),
+      itemsSeen: 42,
+      itemsAdded: 5,
+    });
+
+    const stored = JSON.parse(
+      nativeFiles.get("/mock/app-data/sync-health.json") ?? "{}",
+    ) as {
+      "provider-health"?: {
+        providers?: {
+          rss?: { latestAttempts?: Array<{ itemsSeen?: number }> };
+        };
+        rssFeeds?: Record<string, unknown>;
+      };
+    };
+
+    expect(nativeWrites.some((write) => write.path.endsWith("sync-health.json.tmp"))).toBe(true);
+    expect(stored["provider-health"]?.rssFeeds?.["https://example.com/rss.xml"]).toBeTruthy();
+    expect(stored["provider-health"]?.providers?.rss?.latestAttempts?.[0]?.itemsSeen).toBe(42);
+  });
+
+  it("reads existing native health files written in the store-compatible shape", async () => {
+    vi.useFakeTimers();
+    const now = new Date("2026-04-02T19:15:00.000Z");
+    vi.setSystemTime(now);
+
+    const { mod, nativeFiles, debugStore } = await loadProviderHealthModule({ native: true });
+    nativeFiles.set(
+      "/mock/app-data/sync-health.json",
+      JSON.stringify({
+        "provider-health": {
+          version: 1,
+          providers: {
+            x: {
+              provider: "x",
+              dailyBuckets: [],
+              hourlyBuckets: [],
+              latestAttempts: [
+                {
+                  id: "existing",
+                  provider: "x",
+                  scope: "provider",
+                  outcome: "error",
+                  reason: "Rate limit exceeded",
+                  startedAt: now.getTime() - 1_000,
+                  finishedAt: now.getTime(),
+                  durationMs: 1_000,
+                  itemsSeen: 0,
+                  itemsAdded: 0,
+                  bytesMoved: 0,
+                  signalType: "explicit",
+                },
+              ],
+              pause: null,
+            },
+          },
+          rssFeeds: {},
+          updatedAt: now.getTime(),
+        },
+      }),
+    );
+
+    await mod.initProviderHealth();
+
+    const provider = debugStore.useDebugStore.getState().health?.providers.x;
+    expect(provider?.lastOutcome).toBe("error");
+    expect(provider?.lastError).toBe("Rate limit exceeded");
   });
 
   it("does not auto-pause on cooldown outcomes", async () => {

--- a/packages/desktop/src/lib/provider-health.ts
+++ b/packages/desktop/src/lib/provider-health.ts
@@ -1,5 +1,6 @@
 import { isTauri } from "@tauri-apps/api/core";
-import { Store, load } from "@tauri-apps/plugin-store";
+import { appDataDir } from "@tauri-apps/api/path";
+import { readTextFile, rename, writeTextFile } from "@tauri-apps/plugin-fs";
 import { toast } from "@freed/ui/components/Toast";
 import {
   setProviderHealth,
@@ -107,9 +108,10 @@ interface PersistedHealthState {
   updatedAt: number;
 }
 
-let healthStore: Store | null = null;
 let currentState: PersistedHealthState | null = null;
 let initPromise: Promise<void> | null = null;
+let healthStorePathPromise: Promise<string> | null = null;
+let nativePersistQueue: Promise<void> = Promise.resolve();
 
 function defaultDailyBuckets(now = Date.now()): HealthDailyBucket[] {
   return Array.from({ length: DEFAULT_DAILY_BUCKETS }, (_unused, index) => {
@@ -210,14 +212,19 @@ function fallbackWrite(state: PersistedHealthState): void {
   }
 }
 
-async function getStore(): Promise<Store> {
-  if (!isTauri()) {
-    throw new Error("Native health store is unavailable outside Freed Desktop");
+function isMissingHealthFile(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.includes("ENOENT") || message.includes("No such file");
+}
+
+async function getHealthStorePath(): Promise<string> {
+  if (!healthStorePathPromise) {
+    healthStorePathPromise = appDataDir().then((dir) => {
+      const base = dir.endsWith("/") ? dir.slice(0, -1) : dir;
+      return `${base}/${HEALTH_STORE_FILE}`;
+    });
   }
-  if (!healthStore) {
-    healthStore = await load(HEALTH_STORE_FILE, { defaults: {}, autoSave: true });
-  }
-  return healthStore;
+  return healthStorePathPromise;
 }
 
 function coerceBuckets<T extends HealthDailyBucket | HealthHourlyBucket>(
@@ -893,17 +900,7 @@ async function persistState(state: PersistedHealthState): Promise<void> {
     fallbackWrite(state);
     return;
   }
-  try {
-    const store = await getStore();
-    await store.set(HEALTH_STORE_KEY, state);
-  } catch (error) {
-    log.error(
-      `[provider-health] failed to persist health store, falling back: ${
-        error instanceof Error ? error.message : String(error)
-      }`,
-    );
-    fallbackWrite(state);
-  }
+  await persistNativeState(state);
 }
 
 async function readState(): Promise<PersistedHealthState> {
@@ -911,16 +908,55 @@ async function readState(): Promise<PersistedHealthState> {
     return fallbackRead() ?? createEmptyState();
   }
   try {
-    const store = await getStore();
-    const value = await store.get<unknown>(HEALTH_STORE_KEY);
-    return coercePersistedHealthState(value);
+    const path = await getHealthStorePath();
+    const raw = await readTextFile(path);
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    return coercePersistedHealthState(parsed[HEALTH_STORE_KEY] ?? parsed);
   } catch (error) {
+    if (isMissingHealthFile(error)) {
+      return createEmptyState();
+    }
     log.error(
       `[provider-health] failed to read health store, falling back: ${
         error instanceof Error ? error.message : String(error)
       }`,
     );
     return fallbackRead() ?? createEmptyState();
+  }
+}
+
+async function persistNativeState(state: PersistedHealthState): Promise<void> {
+  const queuedAt = Date.now();
+  const write = nativePersistQueue
+    .catch(() => {
+      // Keep the queue alive after a failed write.
+    })
+    .then(async () => {
+      const queueWaitMs = Date.now() - queuedAt;
+      const startedAt = Date.now();
+      await Promise.resolve();
+      const payload = JSON.stringify({ [HEALTH_STORE_KEY]: state });
+      const path = await getHealthStorePath();
+      const tempPath = `${path}.tmp`;
+      await writeTextFile(tempPath, payload);
+      await rename(tempPath, path);
+      const durationMs = Date.now() - startedAt;
+      if (durationMs >= 750 || queueWaitMs >= 750 || payload.length >= 1_000_000) {
+        log.info(
+          `[provider-health] persisted native health store bytes=${payload.length.toLocaleString()} duration_ms=${durationMs.toLocaleString()} queue_wait_ms=${queueWaitMs.toLocaleString()} rss_feeds=${Object.keys(state.rssFeeds).length.toLocaleString()}`,
+        );
+      }
+    });
+  nativePersistQueue = write;
+  try {
+    await write;
+  } catch (error) {
+    log.error(
+      `[provider-health] failed to persist health file, falling back: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    fallbackWrite(state);
   }
 }
 


### PR DESCRIPTION
(AI Generated).

## Summary
- Move provider health persistence off the Tauri store mutex path and add serialized native file writes with slow-write telemetry.

## Testing
- npm run validate:feature