### PR TITLE
fix: stabilize renderer recovery and model installs

### DIFF
--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -1288,7 +1288,7 @@ dependencies = [
 
 [[package]]
 name = "freed-desktop"
-version = "26.4.2903"
+version = "26.4.2904"
 dependencies = [
  "base64 0.22.1",
  "criterion",

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -41,6 +41,7 @@ use window_vibrancy::{apply_vibrancy, NSVisualEffectMaterial};
 
 const DEFAULT_SYNC_RELAY_PORT: u16 = 8765;
 const MAIN_WINDOW_LABEL: &str = "main";
+const MAIN_WINDOW_RECOVERY_KEEPALIVE_LABEL: &str = "main-recovery-keepalive";
 const PRIMARY_MENU_ITEM_SHOW: &str = "show";
 const PRIMARY_MENU_ITEM_QUIT: &str = "quit";
 
@@ -1260,7 +1261,9 @@ async fn sha256_file(app: tauri::AppHandle, path: String) -> Result<String, Stri
         .map_err(|e| e.to_string())?
         .join("local-ai-models");
     let root = model_root.canonicalize().map_err(|e| e.to_string())?;
-    let target = PathBuf::from(path).canonicalize().map_err(|e| e.to_string())?;
+    let target = PathBuf::from(path)
+        .canonicalize()
+        .map_err(|e| e.to_string())?;
     if !target.starts_with(&root) {
         return Err("Refusing to hash a file outside the local AI model directory".to_string());
     }
@@ -3841,6 +3844,57 @@ fn create_main_window(app: &tauri::AppHandle) -> Result<tauri::WebviewWindow, ta
     Ok(window)
 }
 
+fn open_main_window_recovery_keepalive(
+    app: &tauri::AppHandle,
+    reason: &str,
+) -> Result<tauri::WebviewWindow, String> {
+    if let Some(window) = app.get_webview_window(MAIN_WINDOW_RECOVERY_KEEPALIVE_LABEL) {
+        info!(
+            "[main-window] reusing renderer recovery keepalive reason={}",
+            reason
+        );
+        return Ok(window);
+    }
+
+    let window = tauri::WebviewWindowBuilder::new(
+        app,
+        MAIN_WINDOW_RECOVERY_KEEPALIVE_LABEL,
+        tauri::WebviewUrl::App(RECOVERY_WINDOW_ROUTE.into()),
+    )
+    .title("Freed")
+    .inner_size(1.0, 1.0)
+    .resizable(false)
+    .decorations(false)
+    .focused(false)
+    .visible(false)
+    .skip_taskbar(true)
+    .build()
+    .map_err(|error| format!("recovery keepalive build failed: {}", error))?;
+
+    info!(
+        "[main-window] opened renderer recovery keepalive reason={}",
+        reason
+    );
+    Ok(window)
+}
+
+fn close_main_window_recovery_keepalive(app: &tauri::AppHandle, reason: &str) {
+    let Some(window) = app.get_webview_window(MAIN_WINDOW_RECOVERY_KEEPALIVE_LABEL) else {
+        return;
+    };
+
+    match window.destroy() {
+        Ok(()) => info!(
+            "[main-window] closed renderer recovery keepalive reason={}",
+            reason
+        ),
+        Err(error) => warn!(
+            "[main-window] failed to close renderer recovery keepalive reason={} error={}",
+            reason, error
+        ),
+    }
+}
+
 fn start_main_window(app: &tauri::AppHandle) -> Result<tauri::WebviewWindow, tauri::Error> {
     if let Some(window) = live_main_window(app) {
         show_webview_window(&window);
@@ -3863,6 +3917,27 @@ fn start_main_window(app: &tauri::AppHandle) -> Result<tauri::WebviewWindow, tau
 }
 
 fn recover_main_window(app: &tauri::AppHandle, reason: &str) -> Result<(), String> {
+    let _keepalive = open_main_window_recovery_keepalive(app, reason)?;
+    let outcome = recover_main_window_with_keepalive(app, reason);
+
+    if outcome.is_ok() {
+        close_main_window_recovery_keepalive(app, reason);
+    } else if let Err(error) = &outcome {
+        warn!(
+            "[main-window] renderer recovery failed after keepalive opened reason={} error={}",
+            reason, error
+        );
+
+        if let Ok(window) = open_or_focus_recovery_window(app) {
+            show_webview_window(&window);
+            close_main_window_recovery_keepalive(app, reason);
+        }
+    }
+
+    outcome
+}
+
+fn recover_main_window_with_keepalive(app: &tauri::AppHandle, reason: &str) -> Result<(), String> {
     let was_visible = app
         .get_webview_window(MAIN_WINDOW_LABEL)
         .and_then(|window| window.is_visible().ok())

--- a/packages/desktop/src/lib/local-ai-models.test.ts
+++ b/packages/desktop/src/lib/local-ai-models.test.ts
@@ -197,7 +197,49 @@ describe("local AI model manager", () => {
     expect(models[0].state.status).toBe("available");
   });
 
+  it("batches streamed chunks before writing model files", async () => {
+    const { deps } = createDeps();
+    const writeSizes: number[] = [];
+    const originalOpen = deps.open;
+    deps.open = async (path, openOptions) => {
+      const handle = await originalOpen(path, openOptions);
+      return {
+        async write(data) {
+          writeSizes.push(data.byteLength);
+          return handle.write(data);
+        },
+        async close() {
+          await handle.close();
+        },
+      };
+    };
+    deps.fetch = async () => new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(TEXT.encode("h"));
+          controller.enqueue(TEXT.encode("el"));
+          controller.enqueue(TEXT.encode("lo"));
+          controller.close();
+        },
+      }),
+    );
+    const service = createLocalAIModelService(deps, TEST_MANIFEST);
+
+    const models = await service.downloadModel("integrated-local-ai");
+
+    expect(models[0].state.status).toBe("available");
+    expect(writeSizes).toEqual([5, 5]);
+  });
+
   it("pauses an active download", async () => {
+    const largeChunkManifest: readonly LocalAIModelManifestEntry[] = [
+      {
+        ...TEST_MANIFEST[0],
+        estimatedDownloadBytes: 1_048_576,
+        estimatedStorageBytes: 1_048_576,
+        files: [{ path: "model.bin", sizeBytes: 1_048_576 }],
+      },
+    ];
     let wroteFirstChunk!: () => void;
     const firstChunk = new Promise<void>((resolve) => { wroteFirstChunk = resolve; });
     const { deps } = createDeps();
@@ -224,13 +266,13 @@ describe("local AI model manager", () => {
       return new Response(
         new ReadableStream<Uint8Array>({
           start(controller) {
-            controller.enqueue(TEXT.encode("he"));
+            controller.enqueue(new Uint8Array(1_048_576));
             signal.addEventListener("abort", () => controller.error(new DOMException("Aborted", "AbortError")));
           },
         }),
       );
     };
-    const service = createLocalAIModelService(deps, TEST_MANIFEST);
+    const service = createLocalAIModelService(deps, largeChunkManifest);
 
     const pending = service.downloadModel("integrated-local-ai");
     await firstChunk;
@@ -238,7 +280,7 @@ describe("local AI model manager", () => {
     const paused = await pending;
 
     expect(paused[0].state.status).toBe("paused");
-    expect(paused[0].state.downloadedBytes).toBe(2);
+    expect(paused[0].state.downloadedBytes).toBe(1_048_576);
   });
 
   it("removes downloaded model files and resets state", async () => {

--- a/packages/desktop/src/lib/local-ai-models.ts
+++ b/packages/desktop/src/lib/local-ai-models.ts
@@ -25,6 +25,8 @@ import type {
 const STATE_VERSION = 1;
 const MODEL_ROOT_DIR = "local-ai-models";
 const STATE_FILE = "state.json";
+const MIN_STREAM_WRITE_BYTES = 1024 * 1024;
+const MIN_PROGRESS_INTERVAL_MS = 250;
 
 export const LOCAL_AI_MODEL_MANIFEST: readonly LocalAIModelManifestEntry[] = [
   {
@@ -295,12 +297,42 @@ export function createLocalAIModelService(
     }
 
     const reader = response.body.getReader();
+    const pendingChunks: Uint8Array[] = [];
+    let pendingBytes = 0;
+
+    const flush = async () => {
+      if (pendingBytes === 0) return;
+
+      const bytes = pendingChunks.length === 1
+        ? pendingChunks[0]
+        : new Uint8Array(pendingBytes);
+
+      if (pendingChunks.length > 1) {
+        let offset = 0;
+        for (const chunk of pendingChunks) {
+          bytes.set(chunk, offset);
+          offset += chunk.byteLength;
+        }
+      }
+
+      pendingChunks.length = 0;
+      pendingBytes = 0;
+      await handle.write(bytes);
+      onChunk(bytes.byteLength);
+    };
+
     while (true) {
       const next = await reader.read();
-      if (next.done) return;
+      if (next.done) {
+        await flush();
+        return;
+      }
       if (!next.value) continue;
-      await handle.write(next.value);
-      onChunk(next.value.byteLength);
+      pendingChunks.push(next.value);
+      pendingBytes += next.value.byteLength;
+      if (pendingBytes >= MIN_STREAM_WRITE_BYTES) {
+        await flush();
+      }
     }
   }
 
@@ -370,16 +402,25 @@ export function createLocalAIModelService(
     });
 
     let writtenForFile = existingPartialBytes;
+    let lastProgressAt = 0;
+    const emitProgress = (force = false) => {
+      const now = deps.now();
+      if (!force && now - lastProgressAt < MIN_PROGRESS_INTERVAL_MS) return;
+      lastProgressAt = now;
+      onProgress?.({
+        id: model.id,
+        currentFile: file.path,
+        downloadedBytes: completedBeforeFile + writtenForFile,
+        totalBytes,
+      });
+    };
+
     try {
       await writeResponseBody(response, handle, (bytes) => {
         writtenForFile += bytes;
-        onProgress?.({
-          id: model.id,
-          currentFile: file.path,
-          downloadedBytes: completedBeforeFile + writtenForFile,
-          totalBytes,
-        });
+        emitProgress();
       });
+      emitProgress(true);
     } finally {
       await handle.close();
     }

--- a/packages/ui/src/components/settings/AISection.tsx
+++ b/packages/ui/src/components/settings/AISection.tsx
@@ -634,7 +634,7 @@ export function AISection() {
                 <LocalModelCard
                   key={model.manifest.id}
                   model={model}
-                  busy={busyModelId === model.manifest.id}
+                  busy={busyModelId === model.manifest.id && model.state.status !== "downloading"}
                   onDownload={handleDownloadLocalModel}
                   onPause={handlePauseLocalModel}
                   onRemove={handleRemoveLocalModel}


### PR DESCRIPTION
(AI Generated).

## Summary
- keep a hidden native window alive while rebuilding the main renderer after heartbeat stalls
- batch local AI model stream writes and throttle progress updates to reduce renderer and IPC pressure
- keep the model pack pause action usable during active downloads

## Tests
- PATH=/Users/aubreyfalconer/dev/freed-renderer-recovery-keepalive/node_modules/.bin:$PATH npm run test:unit -- local-ai-models
- npm run validate:feature
- PATH=/Users/aubreyfalconer/dev/freed-renderer-recovery-keepalive/node_modules/.bin:$PATH node ./scripts/tauri-cli.mjs build --bundles app