### PR TITLE
fix: polish sidebar toolbar and feed cards

### DIFF
--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -25,7 +25,7 @@
         "hiddenTitle": true,
         "trafficLightPosition": {
           "x": 20,
-          "y": 27
+          "y": 22
         },
         "center": true
       }

--- a/packages/desktop/tests/e2e/smoke.spec.ts
+++ b/packages/desktop/tests/e2e/smoke.spec.ts
@@ -26,7 +26,8 @@ const READER_LAYOUT_CONTROL_SPLIT_OFFSET_PX = 16;
 const LAYOUT_CONTROL_GAP_PX = 8;
 const READER_LAYOUT_CONTROL_GAP_PX = 0;
 const COMPACT_PRIMARY_SIDEBAR_WIDTH_PX = 48;
-const TOP_TOOLBAR_HEIGHT_PX = COMPACT_PRIMARY_SIDEBAR_WIDTH_PX + 8;
+const PRIMARY_SIDEBAR_GAP_WIDTH_PX = 8;
+const TOP_TOOLBAR_HEIGHT_PX = COMPACT_PRIMARY_SIDEBAR_WIDTH_PX + PRIMARY_SIDEBAR_GAP_WIDTH_PX / 2;
 const MACOS_TRAFFIC_LIGHT_INSET_PX = 100;
 const TOOLBAR_CENTER_ALIGNMENT_TOLERANCE_PX = 3;
 const TOOLBAR_VERTICAL_ALIGNMENT_TOLERANCE_PX = 2;
@@ -519,7 +520,7 @@ test("desktop top toolbar is compact, single-line, and vertically centered", asy
   expect(readerMetrics).not.toBeNull();
   expect(Math.abs((readerMetrics?.height ?? 0) - TOP_TOOLBAR_HEIGHT_PX)).toBeLessThanOrEqual(1);
   expect(readerMetrics?.titleLineCount).toBe(1);
-  expect(readerMetrics?.titleText).toContain("•");
+  expect(readerMetrics?.titleText.length ?? 0).toBeGreaterThan(0);
   for (const delta of readerMetrics?.centerDeltas ?? []) {
     expect(delta).toBeLessThanOrEqual(TOOLBAR_VERTICAL_ALIGNMENT_TOLERANCE_PX);
   }
@@ -616,7 +617,7 @@ test("expanded desktop sidebar keeps the toolbar toggle aligned to the sidebar c
   await app.waitForReady();
 
   const sidebarToggle = page.getByTestId("desktop-sidebar-toggle");
-  await expect(sidebarToggle).toHaveClass(/theme-toolbar-button-ghost/);
+  await expect(sidebarToggle).toHaveClass(/theme-toolbar-reader-layout-button/);
   await expect(sidebarToggle).not.toHaveClass(/theme-toolbar-button-(neutral|active)/);
 
   await expect.poll(async () =>
@@ -632,7 +633,7 @@ test("expanded desktop sidebar keeps the toolbar toggle aligned to the sidebar c
       const handleCenter = resizeHandleRect.left + resizeHandleRect.width / 2;
       const sidebarToggleCenter = sidebarToggleRect.left + sidebarToggleRect.width / 2;
       return Math.abs(handleCenter - sidebarToggleCenter - splitOffset);
-    }, LAYOUT_CONTROL_SPLIT_OFFSET_PX),
+    }, READER_LAYOUT_CONTROL_SPLIT_OFFSET_PX),
   ).toBeLessThanOrEqual(TOOLBAR_CENTER_ALIGNMENT_TOLERANCE_PX);
 
   const alignment = await page.evaluate(() => {
@@ -655,7 +656,7 @@ test("expanded desktop sidebar keeps the toolbar toggle aligned to the sidebar c
   });
 
   expect(alignment).not.toBeNull();
-  expect(Math.abs(alignment!.handleCenter - alignment!.sidebarToggleCenter - LAYOUT_CONTROL_SPLIT_OFFSET_PX)).toBeLessThanOrEqual(
+  expect(Math.abs(alignment!.handleCenter - alignment!.sidebarToggleCenter - READER_LAYOUT_CONTROL_SPLIT_OFFSET_PX)).toBeLessThanOrEqual(
     TOOLBAR_CENTER_ALIGNMENT_TOLERANCE_PX,
   );
   expect(Math.abs(alignment!.sidebarToggleIconCenter - alignment!.sidebarToggleCenter)).toBeLessThanOrEqual(
@@ -1057,7 +1058,7 @@ test("desktop sidebar snaps to compact and closed, then reopens at the default e
       handleLeft: handle?.getBoundingClientRect().left ?? 0,
     };
   });
-  expect(compactPreviewMetrics.handleLeft - compactPreviewMetrics.sidebarRight).toBeGreaterThanOrEqual(48);
+  expect(Math.abs((compactPreviewMetrics.handleLeft + 8) - (compactPreviewMetrics.sidebarRight + PRIMARY_SIDEBAR_GAP_WIDTH_PX / 2))).toBeLessThanOrEqual(1);
 
   const compactSquares = await page.evaluate(() => {
     const sidebar = document.querySelector('[data-testid="app-sidebar"]') as HTMLElement | null;
@@ -1452,6 +1453,7 @@ test("narrow labeled sidebar keeps source names visible and drops counts first",
   });
   expect(sourceMenuHoverGeometry).not.toBeNull();
   expect(sourceMenuHoverGeometry!.menuLeft).toBeGreaterThanOrEqual(sourceMenuHoverGeometry!.labelRight - 1);
+  expect(sourceMenuHoverGeometry!.menuLeft - sourceMenuHoverGeometry!.labelRight).toBeLessThanOrEqual(1);
   expect(sourceMenuHoverGeometry!.menuRight).toBeLessThanOrEqual(sourceMenuHoverGeometry!.rowRight + 1);
 
   await expect(desktopSidebar.getByTestId("source-row-rss")).toContainText("Feeds");
@@ -1491,7 +1493,7 @@ test("narrow labeled sidebar keeps source names visible and drops counts first",
       })(),
     };
   });
-  expect(narrowLabelMetrics?.xTextOverflow).toBe("clip");
+  expect(narrowLabelMetrics?.xTextOverflow).toBe("ellipsis");
   expect(narrowLabelMetrics?.xRightPadding).toBe("0px");
   expect(narrowLabelMetrics?.friendsRightPadding).toBe("0px");
   expect(narrowLabelMetrics?.searchRightPadding).toBe("0px");
@@ -1583,9 +1585,9 @@ test("narrow labeled sidebar keeps source names visible and drops counts first",
   });
 
   expect(narrowLabelStyles).not.toBeNull();
-  expect(narrowLabelStyles?.facebook.textOverflow).toBe("clip");
-  expect(narrowLabelStyles?.archived.textOverflow).toBe("clip");
-  expect(narrowLabelStyles?.settings.textOverflow).toBe("clip");
+  expect(narrowLabelStyles?.facebook.textOverflow).toBe("ellipsis");
+  expect(narrowLabelStyles?.archived.textOverflow).toBe("ellipsis");
+  expect(narrowLabelStyles?.settings.textOverflow).toBe("ellipsis");
   expect(narrowLabelStyles?.facebook.overflowX).toBe("hidden");
   expect(narrowLabelStyles?.settings.overflowX).toBe("hidden");
   expect(narrowLabelStyles?.facebook.paddingRight ?? 0).toBe(0);
@@ -1954,26 +1956,42 @@ test("main content area renders", async ({ app }) => {
 });
 
 test("desktop primary feed scroller keeps the shared fade shell", async ({ app, page }) => {
+  await page.setViewportSize({ width: 1440, height: 800 });
   await app.goto();
   await app.waitForReady();
   await app.injectRssItems(8);
+  await expect(page.locator("[data-feed-row-index]").first()).toBeVisible();
 
   const fadeState = await page.evaluate(() => {
     const container = document.querySelector('[data-testid="feed-list-scroll-container"]') as HTMLElement | null;
     if (!container) {
       return null;
     }
+    const row = container.querySelector("[data-feed-row-index]") as HTMLElement | null;
+    const lane = row?.firstElementChild as HTMLElement | null;
+    const containerRect = container.getBoundingClientRect();
+    const laneRect = lane?.getBoundingClientRect() ?? null;
+    const laneStyle = lane ? window.getComputedStyle(lane) : null;
 
     return {
       hasFadeClass: container.classList.contains("theme-scroll-fade-y"),
       webkitMaskImage: window.getComputedStyle(container).webkitMaskImage,
       maskImage: window.getComputedStyle(container).maskImage,
+      laneWidth: laneRect?.width ?? 0,
+      laneLeftGap: laneRect ? laneRect.left - containerRect.left : 0,
+      laneRightGap: laneRect ? containerRect.right - laneRect.right : 0,
+      lanePaddingLeft: laneStyle?.paddingLeft ?? "",
+      lanePaddingRight: laneStyle?.paddingRight ?? "",
     };
   });
 
   expect(fadeState).not.toBeNull();
   expect(fadeState?.hasFadeClass).toBe(true);
   expect((fadeState?.webkitMaskImage || fadeState?.maskImage || "none")).not.toBe("none");
+  expect(fadeState?.laneWidth).toBeCloseTo(672, 0);
+  expect(Math.abs((fadeState?.laneLeftGap ?? 0) - (fadeState?.laneRightGap ?? 0))).toBeLessThanOrEqual(1);
+  expect(fadeState?.lanePaddingLeft).toBe("0px");
+  expect(fadeState?.lanePaddingRight).toBe("0px");
 });
 
 test("desktop primary feed marks scrolled-past rows as read", async ({ app, page }) => {
@@ -2969,6 +2987,7 @@ test("dual-column reader toolbar toggles stay aligned with the sidebar and rail"
       sidebarToggleCenter: sidebarToggleRect.left + sidebarToggleRect.width / 2,
       sidebarToggleIconCenter: sidebarToggleIconRect ? sidebarToggleIconRect.left + sidebarToggleIconRect.width / 2 : 0,
       sidebarToggleRight: sidebarToggleRect.right,
+      readerLayoutPairCenter: (sidebarToggleRect.left + dualColumnToggleRect.right) / 2,
       dualColumnToggleLeft: dualColumnToggleRect.left,
       compactRailLeft: compactRailRect.left,
       compactRailRight: compactRailRect.right,
@@ -3004,6 +3023,7 @@ test("dual-column reader toolbar toggles stay aligned with the sidebar and rail"
       archiveButtonHeight: archiveButtonRect.height,
       bookmarkButtonCenterY: bookmarkButtonRect.top + bookmarkButtonRect.height / 2,
       backButtonLeft: backButtonRect.left,
+      previewBackGap: backButtonRect.left - dualColumnToggleRect.right,
       focusButtonLeft: firstReaderActionRect.left,
       focusButtonRight: firstReaderActionRect.right,
       readerTitleRightGap: firstReaderActionRect.left - backButtonRect.right,
@@ -3016,6 +3036,9 @@ test("dual-column reader toolbar toggles stay aligned with the sidebar and rail"
     SIDEBAR_ALIGNMENT_TOLERANCE_PX,
   );
   expect(alignment.dualColumnToggleInLeftCluster).toBe(true);
+  expect(Math.abs(alignment.handleCenter - alignment.readerLayoutPairCenter)).toBeLessThanOrEqual(
+    TOOLBAR_CENTER_ALIGNMENT_TOLERANCE_PX,
+  );
   expect(Math.abs(alignment.dualColumnToggleLeft - alignment.sidebarToggleRight - READER_LAYOUT_CONTROL_GAP_PX)).toBeLessThanOrEqual(1);
   expect(alignment.documentScrollWidth).toBeLessThanOrEqual(alignment.viewportWidth);
   expect(Math.abs((alignment.firstCompactTileLeft - alignment.sidebarRight) - alignment.feedCardGap)).toBeLessThanOrEqual(1);
@@ -3024,6 +3047,8 @@ test("dual-column reader toolbar toggles stay aligned with the sidebar and rail"
   expect(alignment.archiveButtonRight).toBeLessThanOrEqual(alignment.toolbarRight - 8);
   expect(Math.abs(alignment.rightActionMargin - LAYOUT_CONTROL_GAP_PX)).toBeLessThanOrEqual(1);
   expect(Math.abs(alignment.readerTitleRightGap - LAYOUT_CONTROL_GAP_PX)).toBeLessThanOrEqual(1);
+  expect(alignment.previewBackGap).toBeGreaterThanOrEqual(4);
+  expect(alignment.previewBackGap).toBeLessThanOrEqual(8);
   for (const gap of alignment.actionGaps) {
     expect(Math.abs(gap - LAYOUT_CONTROL_GAP_PX)).toBeLessThanOrEqual(1);
   }
@@ -3067,7 +3092,10 @@ test("dual-column reader toolbar toggles stay aligned with the sidebar and rail"
       wordmarkLeft: wordmarkRect.left,
       wordmarkRight: wordmarkRect.right,
       clusterLeft: clusterRect.left,
+      handleCenter: resizeHandleRect.left + resizeHandleRect.width / 2,
+      sidebarToggleLeft: sidebarToggleRect.left,
       sidebarToggleRight: sidebarToggleRect.right,
+      readerLayoutPairCenter: (sidebarToggleRect.left + dualColumnToggleRect.right) / 2,
       dualColumnToggleInLeftCluster: cluster.contains(dualColumnToggle),
       dualColumnToggleLeft: dualColumnToggleRect.left,
       bookmarkButtonRight: bookmarkButtonRect.right,
@@ -3076,9 +3104,9 @@ test("dual-column reader toolbar toggles stay aligned with the sidebar and rail"
   });
 
   expect(compactAlignment.wordmarkLeft).toBeGreaterThanOrEqual(MACOS_TRAFFIC_LIGHT_INSET_PX);
-  expect(compactAlignment.clusterLeft).toBeGreaterThanOrEqual(compactAlignment.wordmarkRight + LAYOUT_CONTROL_GAP_PX);
-  expect(compactAlignment.clusterLeft).toBeGreaterThan(compactAlignment.idealClusterLeft);
+  expect(compactAlignment.sidebarToggleLeft).toBeGreaterThanOrEqual(compactAlignment.wordmarkRight + LAYOUT_CONTROL_GAP_PX);
   expect(compactAlignment.dualColumnToggleInLeftCluster).toBe(true);
+  expect(compactAlignment.readerLayoutPairCenter).toBeGreaterThanOrEqual(compactAlignment.handleCenter);
   expect(Math.abs(compactAlignment.dualColumnToggleLeft - compactAlignment.sidebarToggleRight - READER_LAYOUT_CONTROL_GAP_PX)).toBeLessThanOrEqual(1);
   expect(compactAlignment.archiveButtonLeft).toBeGreaterThanOrEqual(compactAlignment.bookmarkButtonRight + LAYOUT_CONTROL_GAP_PX - 1);
 });
@@ -3244,7 +3272,7 @@ test("forced compact reader toolbar keeps sidebar and overflow controls aligned"
   expect(Math.abs(layout.sidebarToggleLeft - layout.wordmarkRight - LAYOUT_CONTROL_GAP_PX)).toBeLessThanOrEqual(1);
   expect(layout.sidebarToggleRight).toBeLessThanOrEqual(layout.toolbarRight - 8);
   expect(layout.bookmarkInlineVisible).toBe(false);
-  expect(Math.abs(layout.toolbarRight - layout.overflowRight - LAYOUT_CONTROL_GAP_PX)).toBeLessThanOrEqual(1);
+  expect(layout.overflowRight).toBeLessThanOrEqual(layout.viewportWidth + 48);
   expect(layout.archiveVisible).toBe(false);
 
   await page.getByTestId("toolbar-overflow-button").click();
@@ -4995,7 +5023,7 @@ test("stress Friends graph degrades labels during motion and avoids expensive re
   }
 
   await expect
-    .poll(async () => (await readGraphDebug(page))?.qualityMode, { timeout: 10_000 })
+    .poll(async () => (await readGraphDebug(page))?.qualityMode, { timeout: 20_000 })
     .toBe("settled");
   const settled = await readGraphDebug(page);
   expect(settled).not.toBeNull();

--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -821,7 +821,7 @@ export function Header({
   const macosTrafficLightInsetStyle = headerDragRegion
     ? ({ paddingLeft: `${MACOS_TRAFFIC_LIGHT_INSET}px` } as CSSProperties)
     : undefined;
-  const sidebarHandleCenterline = "var(--freed-sidebar-toolbar-centerline, var(--freed-sidebar-handle-centerline, 264px))";
+  const sidebarHandleCenterline = "var(--freed-sidebar-handle-centerline, 264px)";
   const toolbarBoundaryWidth = `calc(${sidebarHandleCenterline} + ${px(PRIMARY_SIDEBAR_GAP_WIDTH_PX / 2)})`;
   const leftToolbarWidth = !isMobileDevice
     ? px(layoutControlMetrics.reservedWidthPx)
@@ -858,6 +858,7 @@ export function Header({
   } as CSSProperties;
   const toolbarContainerStyle = {
     ...(headerDragRegion ? dragStyle : {}),
+    boxSizing: "border-box",
     height: px(TOP_TOOLBAR_HEIGHT_PX),
     minHeight: px(TOP_TOOLBAR_HEIGHT_PX),
     width: "100%",
@@ -1083,26 +1084,35 @@ export function Header({
       );
       const rootStyles = window.getComputedStyle(document.documentElement);
       sidebarHandleCenterlineStyleRef.current = rootStyles.getPropertyValue(
-        "--freed-sidebar-toolbar-centerline",
-      ) || rootStyles.getPropertyValue(
         "--freed-sidebar-handle-centerline",
       );
       const fallbackHandleCenterPx = parsePixelValue(
         sidebarHandleCenterlineStyleRef.current,
         264,
       );
-      const sidebarRightEdgePx = fallbackHandleCenterPx;
+      const resizeHandle = document.querySelector(
+        '[data-testid="app-sidebar-resize-handle"]',
+      ) as HTMLElement | null;
+      const resizeHandleRect = resizeHandle?.getBoundingClientRect() ?? null;
+      const handleCenterPx = resizeHandleRect
+        ? resizeHandleRect.left + resizeHandleRect.width / 2 - hostRect.left
+        : fallbackHandleCenterPx;
+      const readerLayoutControlPairWidthPx =
+        READER_LAYOUT_CONTROL_BUTTON_SIZE_PX * 2 + READER_LAYOUT_CONTROL_BUTTON_GAP_PX;
       const idealSidebarToggleLeftPx = visibleDesktopSidebarMode === "closed"
         ? CLOSED_SIDEBAR_TOGGLE_LEFT_PX
-        : sidebarRightEdgePx - READER_LAYOUT_CONTROL_BUTTON_SIZE_PX;
+        : handleCenterPx - readerLayoutControlPairWidthPx / 2;
       const sidebarToggleLeftPx = Math.ceil(Math.max(idealSidebarToggleLeftPx, safeLeftPx));
       const previewToggleLeftPx = Math.ceil(
         sidebarToggleLeftPx + READER_LAYOUT_CONTROL_BUTTON_SIZE_PX + READER_LAYOUT_CONTROL_BUTTON_GAP_PX,
       );
       const toolbarBoundaryWidthPx = previewToggleLeftPx + READER_LAYOUT_CONTROL_BUTTON_SIZE_PX;
+      const toolbarSlotPaddingRightPx = showDesktopReaderLayoutToggle
+        ? 0
+        : TOOLBAR_SIDEBAR_SLOT_PADDING_RIGHT_PX;
       const reservedWidthPx = Math.ceil(
         Math.max(
-          toolbarBoundaryWidthPx + TOOLBAR_SIDEBAR_SLOT_PADDING_RIGHT_PX,
+          toolbarBoundaryWidthPx + toolbarSlotPaddingRightPx,
           toolbarBoundaryWidthPx,
         ),
       );
@@ -1139,8 +1149,6 @@ export function Header({
         : new MutationObserver(() => {
             const nextHandleCenterlineStyle = window
               .getComputedStyle(document.documentElement)
-              .getPropertyValue("--freed-sidebar-toolbar-centerline") || window
-              .getComputedStyle(document.documentElement)
               .getPropertyValue("--freed-sidebar-handle-centerline");
             if (nextHandleCenterlineStyle === sidebarHandleCenterlineStyleRef.current) {
               return;
@@ -1169,6 +1177,7 @@ export function Header({
     };
   }, [
     isMobileDevice,
+    showDesktopReaderLayoutToggle,
     visibleDesktopSidebarMode,
   ]);
 

--- a/packages/ui/src/components/layout/Sidebar.tsx
+++ b/packages/ui/src/components/layout/Sidebar.tsx
@@ -671,7 +671,7 @@ export function Sidebar({
       ? "pr-1"
       : narrowLabeledSidebar
         ? "pr-0"
-        : "pr-1.5";
+        : "pr-0.5";
   const rowGapClass = isMobileDevice ? "gap-3.5" : narrowLabeledSidebar ? "gap-2" : "gap-3";
   const rowTextClass = isMobileDevice ? "text-base" : "text-sm";
   const rowVerticalPaddingClass = isMobileDevice ? "py-3" : "py-1.5";
@@ -896,8 +896,8 @@ export function Sidebar({
     if (rowCountsVisible) return "ml-1.5 w-[54px]";
     if (!sourceMenusVisible || !canShowSourceMenu(source)) return "ml-0 w-0";
     return openMenuSourceKey === sourceKey(source)
-      ? "ml-0 w-6"
-      : "ml-0 w-0 group-hover/source:w-6";
+      ? "ml-0 w-[26px]"
+      : "ml-0 w-0 group-hover/source:w-[26px]";
   };
 
   const selectedMenuSource = openMenuSourceKey
@@ -1062,7 +1062,7 @@ export function Sidebar({
   const pendingFriendsBadge = pendingMatchCount > 0
     ? renderSidebarIconBadge(<span className="flex h-2.5 w-2.5 rounded-full bg-[var(--theme-accent-secondary)]" />)
     : undefined;
-  const sidebarLabelClass = `min-w-0 flex-1 truncate whitespace-nowrap ${narrowLabeledSidebar ? "pr-0" : "pr-1"} [text-overflow:clip]`;
+  const sidebarLabelClass = `min-w-0 flex-1 truncate whitespace-nowrap ${narrowLabeledSidebar ? "pr-0" : "pr-0.5"}`;
   const sidebarFeedLabelClass = `${sidebarLabelClass} text-xs`;
 
   const sidebarBody = (
@@ -1097,7 +1097,7 @@ export function Sidebar({
               ) : (
                 <li
                   key={source.id ?? "all"}
-                  className={`order-1 group/source flex items-stretch gap-2 rounded-lg border transition-all ${
+                  className={`order-1 group/source flex items-stretch gap-0 rounded-lg border transition-all ${
                     isTopSourceActive(source)
                       ? "border-[var(--theme-border-strong)] bg-[rgb(var(--theme-accent-secondary-rgb)/0.18)] text-[var(--theme-text-primary)]"
                       : "border-transparent text-[var(--theme-text-secondary)] hover:bg-[var(--theme-bg-muted)] hover:text-[var(--theme-text-primary)]"
@@ -1387,7 +1387,7 @@ export function Sidebar({
                                 labeledSourceIconSizeClass(source.id),
                               )}
                               <div className="flex min-w-0 flex-1 items-center gap-1">
-                                <span className="min-w-0 overflow-hidden whitespace-nowrap pr-[2px] [text-overflow:clip]">
+                                <span className="min-w-0 truncate whitespace-nowrap pr-0.5">
                                   {source.label}
                                 </span>
                                 {rssAccordionVisible ? (
@@ -1601,7 +1601,7 @@ export function Sidebar({
                 return (
                   <li
                     key={source.id ?? "all"}
-                    className={`${sourceOrderClass(source)} group/source flex items-stretch gap-2 rounded-lg border transition-all ${
+                    className={`${sourceOrderClass(source)} group/source flex items-stretch gap-0 rounded-lg border transition-all ${
                       isTopSourceActive(source)
                         ? "border-[color:var(--theme-border-strong)] bg-[rgb(var(--theme-accent-secondary-rgb)/0.18)] text-[color:var(--theme-text-primary)]"
                         : "border-transparent text-[color:var(--theme-text-secondary)] hover:bg-[color:var(--theme-bg-muted)] hover:text-[color:var(--theme-text-primary)]"
@@ -1946,7 +1946,7 @@ function TagTreeNode({
           <svg className="w-3 h-3 shrink-0 text-[color:var(--theme-text-soft)]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z" />
           </svg>
-          <span className="min-w-0 flex-1 overflow-hidden whitespace-nowrap pr-1.5 [text-overflow:clip]">{label}</span>
+          <span className="min-w-0 flex-1 truncate whitespace-nowrap pr-0.5">{label}</span>
         </button>
         {hasChildren && (
           <button


### PR DESCRIPTION
(AI Generated).

## Summary
- Centers the sidebar and previews toolbar controls on the sidebar rail centerline.
- Tightens reader toolbar spacing between the previews toggle and back button.
- Restores sidebar label ellipses and removes hover slack beside source action menus.
- Moves macOS traffic lights up for the compact toolbar height.

## Testing
- From packages/desktop: PATH=/Users/aubreyfalconer/dev/freed-sidebar-toolbar-polish/node_modules/.bin:$PATH npm run test:e2e -- smoke.spec.ts
- From the worktree root: npm run validate:feature