### PR TITLE
fix: scope social provider error copy

### DIFF
--- a/packages/desktop/src/components/FacebookFeedEmptyState.tsx
+++ b/packages/desktop/src/components/FacebookFeedEmptyState.tsx
@@ -13,6 +13,7 @@ import { captureFbFeed } from "../lib/fb-capture";
 import { useSettingsStore } from "@freed/ui/lib/settings-store";
 import { resetProviderPauseState } from "../lib/provider-health";
 import { SampleDataTestingSection } from "@freed/ui/components/SampleDataTestingSection";
+import { socialProviderCopy } from "../lib/social-provider-copy";
 
 const FbIcon = () => (
   <svg className="h-7 w-7 text-[var(--theme-media-facebook)]" viewBox="0 0 24 24" fill="currentColor">
@@ -25,19 +26,22 @@ export function FacebookFeedEmptyState() {
   const setFbAuth = useAppStore((s) => s.setFbAuth);
   const isLoading = useAppStore((s) => s.isLoading);
   const activeFilter = useAppStore((s) => s.activeFilter);
-  const storeError = useAppStore((s) => s.error);
   const setError = useAppStore((s) => s.setError);
   const openSettings = useSettingsStore((s) => s.openTo);
 
   const [syncing, setSyncing] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const copy = socialProviderCopy("facebook");
 
   const handleSync = async () => {
     setError(null);
+    setActionError(null);
     setSyncing(true);
     try {
       await captureFbFeed();
     } catch (err) {
       console.error("Facebook sync failed:", err);
+      setActionError(err instanceof Error ? err.message : "Facebook sync failed");
     } finally {
       setSyncing(false);
     }
@@ -52,9 +56,10 @@ export function FacebookFeedEmptyState() {
     await resetProviderPauseState("facebook");
     setFbAuth({ isAuthenticated: false });
     setError(null);
+    setActionError(null);
   };
 
-  const syncError = storeError && fbAuth.isAuthenticated ? storeError : null;
+  const syncError = fbAuth.isAuthenticated ? fbAuth.lastCaptureError ?? actionError : null;
 
   if (activeFilter.platform !== "facebook") return null;
 
@@ -65,7 +70,7 @@ export function FacebookFeedEmptyState() {
           <FbIcon />
         </div>
         <p className="text-lg font-medium mb-2">All caught up!</p>
-        <p className="mb-6 text-sm text-[var(--theme-text-muted)]">Your Facebook feed is up to date.</p>
+        <p className="mb-6 text-sm text-[var(--theme-text-muted)]">{copy.connectedEmptyState}</p>
         <div className="flex gap-3">
           <button
             onClick={handleSync}
@@ -112,7 +117,7 @@ export function FacebookFeedEmptyState() {
       </div>
       <p className="text-lg font-medium mb-2">Connect Facebook</p>
       <p className="mb-6 max-w-xs text-center text-sm text-[var(--theme-text-muted)]">
-        Pull your news feed into Freed. Set it up in Sources settings.
+        {copy.disconnectedEmptyState}
       </p>
       <button
         onClick={() => openSettings("facebook")}

--- a/packages/desktop/src/components/FacebookSettingsSection.tsx
+++ b/packages/desktop/src/components/FacebookSettingsSection.tsx
@@ -42,6 +42,7 @@ import { SyncProviderSectionSurface } from "./SyncProviderSectionSurface";
 import { withProviderSyncing } from "../lib/store";
 import { clearProviderPause, resetProviderPauseState } from "../lib/provider-health";
 import { MediaVaultSettingsCard } from "./MediaVaultSettingsCard";
+import { socialProviderCopy } from "../lib/social-provider-copy";
 
 // =============================================================================
 // Diagnostic Panel
@@ -195,8 +196,6 @@ export function FacebookSettingsSection({
   const fbCapture = useAppStore((s) => s.preferences.fbCapture);
   const updatePreferences = useAppStore((s) => s.updatePreferences);
   const isLoading = useAppStore((s) => s.isLoading);
-  const storeError = useAppStore((s) => s.error);
-  const setError = useAppStore((s) => s.setError);
   const items = useAppStore((s) => s.items);
   const syncing = useAppStore((s) => (s.providerSyncCounts.facebook ?? 0) > 0);
   const healthSnapshot = useDebugStore((s) => s.health?.providers.facebook ?? null);
@@ -205,6 +204,8 @@ export function FacebookSettingsSection({
   const [refreshingGroups, setRefreshingGroups] = useState(false);
   const [lastDiag, setLastDiag] = useState<FbSyncDiag | null>(null);
   const [windowMode, setWindowMode] = useState(() => getFbScraperWindowMode());
+  const [actionError, setActionError] = useState<string | null>(null);
+  const copy = socialProviderCopy("facebook");
   const { confirm, dialog } = useProviderRiskGate("facebook");
 
   const knownGroups = fbCapture?.knownGroups ?? {};
@@ -230,19 +231,19 @@ export function FacebookSettingsSection({
 
   const handleLogin = useCallback(async () => {
     await confirm(async () => {
-      setError(null);
+      setActionError(null);
       try {
         await showFbLogin();
       } catch (err) {
-        setError(err instanceof Error ? err.message : "Failed to open login window");
+        setActionError(err instanceof Error ? err.message : "Failed to open login window");
       }
     });
-  }, [confirm, setError]);
+  }, [confirm]);
 
   const handleCheckAuth = useCallback(async () => {
     await confirm(async () => {
       setChecking(true);
-      setError(null);
+      setActionError(null);
       try {
         const loggedIn = await checkFbAuth();
         const newState = { isAuthenticated: loggedIn, lastCheckedAt: Date.now() };
@@ -250,15 +251,15 @@ export function FacebookSettingsSection({
         storeFbAuthState(newState);
 
         if (!loggedIn) {
-          setError("Not logged in. Please log in through the Facebook window first.");
+          setActionError("Not logged in. Please log in through the Facebook window first.");
         }
       } catch (err) {
-        setError(err instanceof Error ? err.message : "Auth check failed");
+        setActionError(err instanceof Error ? err.message : "Auth check failed");
       } finally {
         setChecking(false);
       }
     });
-  }, [confirm, setFbAuth, setError]);
+  }, [confirm, setFbAuth]);
 
   const runSync = useCallback(async () => {
     setLastDiag(null);
@@ -309,15 +310,15 @@ export function FacebookSettingsSection({
 
   const handleRefreshGroups = useCallback(async () => {
     setRefreshingGroups(true);
-    setError(null);
+    setActionError(null);
     try {
       await captureFbGroups();
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to refresh Facebook groups");
+      setActionError(err instanceof Error ? err.message : "Failed to refresh Facebook groups");
     } finally {
       setRefreshingGroups(false);
     }
-  }, [setError]);
+  }, []);
 
   const handleDisconnect = useCallback(async () => {
     try {
@@ -328,11 +329,11 @@ export function FacebookSettingsSection({
     await resetProviderPauseState("facebook");
     setFbAuth({ isAuthenticated: false });
     setLastDiag(null);
-    setError(null);
-  }, [setFbAuth, setError]);
+    setActionError(null);
+  }, [setFbAuth]);
 
-  const syncError = storeError && fbAuth.isAuthenticated ? storeError : null;
-  const authError = fbAuth.lastCaptureError ?? syncError;
+  const syncError = fbAuth.isAuthenticated ? fbAuth.lastCaptureError ?? null : null;
+  const authError = fbAuth.lastCaptureError ?? actionError;
   const needsReconnect = needsProviderReconnect(authError);
   const statusTone = getProviderStatusTone({
     isConnected: fbAuth.isAuthenticated,
@@ -354,7 +355,7 @@ export function FacebookSettingsSection({
       if (lastDiag.itemsAdded === 0 && lastDiag.postsExtracted === 0) {
         return (
           <p className="text-xs text-[#52525b]">
-            Feed returned no posts. Facebook may need a moment to load.
+            {copy.feedReturnedEmpty}
           </p>
         );
       }
@@ -420,14 +421,18 @@ export function FacebookSettingsSection({
 
           {needsReconnect && (
             <p className="text-xs text-red-400 leading-relaxed">
-              {formatProviderReconnectMessage("Facebook", authError)}
+              {formatProviderReconnectMessage(copy.label, authError)}
             </p>
+          )}
+
+          {actionError && !needsReconnect && (
+            <p className="text-xs text-red-400 leading-relaxed">{actionError}</p>
           )}
 
           {syncError && !needsReconnect && (
             <p className="text-xs text-red-400 leading-relaxed">
               {syncError.includes("timeout")
-                ? "Scrape timed out. Facebook may be slow to load. Try again."
+                ? copy.timeout
                 : syncError}
             </p>
           )}
@@ -520,8 +525,7 @@ export function FacebookSettingsSection({
           </details>
 
           <p className="text-xs text-[#52525b] leading-relaxed">
-            Freed reads your Facebook feed through a native browser session.
-            Your traffic looks identical to normal browsing.
+            {copy.connectedInfo}
           </p>
         </div>
       </SyncProviderSectionSurface>
@@ -539,7 +543,7 @@ export function FacebookSettingsSection({
         <p className="text-sm text-[#71717a] leading-relaxed">
           {needsReconnect
             ? "Your Facebook session is no longer valid. Sign in again to restore sync."
-            : "Pull your Facebook feed into Freed. Log in through a native browser window. Freed reads your feed the same way you would, so your account stays safe."}
+            : copy.disconnectedSettings}
         </p>
         <div className="flex gap-2">
           <button
@@ -558,8 +562,11 @@ export function FacebookSettingsSection({
         </div>
         {needsReconnect && authError && (
           <p className="text-xs text-amber-400 leading-relaxed">
-            {formatProviderReconnectMessage("Facebook", authError)}
+            {formatProviderReconnectMessage(copy.label, authError)}
           </p>
+        )}
+        {actionError && !needsReconnect && (
+          <p className="text-xs text-red-400 leading-relaxed">{actionError}</p>
         )}
         <ProviderHealthSectionSummary provider="facebook" />
       </div>

--- a/packages/desktop/src/components/InstagramFeedEmptyState.tsx
+++ b/packages/desktop/src/components/InstagramFeedEmptyState.tsx
@@ -13,6 +13,7 @@ import { captureIgFeed } from "../lib/instagram-capture";
 import { useSettingsStore } from "@freed/ui/lib/settings-store";
 import { resetProviderPauseState } from "../lib/provider-health";
 import { SampleDataTestingSection } from "@freed/ui/components/SampleDataTestingSection";
+import { socialProviderCopy } from "../lib/social-provider-copy";
 
 const IgIcon = () => (
   <svg className="h-7 w-7 text-[var(--theme-media-instagram)]" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
@@ -27,19 +28,22 @@ export function InstagramFeedEmptyState() {
   const setIgAuth = useAppStore((s) => s.setIgAuth);
   const isLoading = useAppStore((s) => s.isLoading);
   const activeFilter = useAppStore((s) => s.activeFilter);
-  const storeError = useAppStore((s) => s.error);
   const setError = useAppStore((s) => s.setError);
   const openSettings = useSettingsStore((s) => s.openTo);
 
   const [syncing, setSyncing] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const copy = socialProviderCopy("instagram");
 
   const handleSync = async () => {
     setError(null);
+    setActionError(null);
     setSyncing(true);
     try {
       await captureIgFeed();
     } catch (err) {
       console.error("Instagram sync failed:", err);
+      setActionError(err instanceof Error ? err.message : "Instagram sync failed");
     } finally {
       setSyncing(false);
     }
@@ -54,9 +58,10 @@ export function InstagramFeedEmptyState() {
     await resetProviderPauseState("instagram");
     setIgAuth({ isAuthenticated: false });
     setError(null);
+    setActionError(null);
   };
 
-  const syncError = storeError && igAuth.isAuthenticated ? storeError : null;
+  const syncError = igAuth.isAuthenticated ? igAuth.lastCaptureError ?? actionError : null;
 
   if (activeFilter.platform !== "instagram") return null;
 
@@ -67,7 +72,7 @@ export function InstagramFeedEmptyState() {
           <IgIcon />
         </div>
         <p className="text-lg font-medium mb-2">All caught up!</p>
-        <p className="mb-6 text-sm text-[var(--theme-text-muted)]">Your Instagram feed is up to date.</p>
+        <p className="mb-6 text-sm text-[var(--theme-text-muted)]">{copy.connectedEmptyState}</p>
         <div className="flex gap-3">
           <button
             onClick={handleSync}
@@ -114,7 +119,7 @@ export function InstagramFeedEmptyState() {
       </div>
       <p className="text-lg font-medium mb-2">Connect Instagram</p>
       <p className="mb-6 max-w-xs text-center text-sm text-[var(--theme-text-muted)]">
-        Pull your feed into Freed. Set it up in Sources settings.
+        {copy.disconnectedEmptyState}
       </p>
       <button
         onClick={() => openSettings("instagram")}

--- a/packages/desktop/src/components/InstagramSettingsSection.tsx
+++ b/packages/desktop/src/components/InstagramSettingsSection.tsx
@@ -41,6 +41,7 @@ import { SyncProviderSectionSurface } from "./SyncProviderSectionSurface";
 import { withProviderSyncing } from "../lib/store";
 import { clearProviderPause, resetProviderPauseState } from "../lib/provider-health";
 import { MediaVaultSettingsCard } from "./MediaVaultSettingsCard";
+import { socialProviderCopy } from "../lib/social-provider-copy";
 
 // =============================================================================
 // Diagnostic Panel
@@ -112,8 +113,6 @@ export function InstagramSettingsSection({
   const igAuth = useAppStore((s) => s.igAuth);
   const setIgAuth = useAppStore((s) => s.setIgAuth);
   const isLoading = useAppStore((s) => s.isLoading);
-  const storeError = useAppStore((s) => s.error);
-  const setError = useAppStore((s) => s.setError);
   const items = useAppStore((s) => s.items);
   const syncing = useAppStore((s) => (s.providerSyncCounts.instagram ?? 0) > 0);
   const healthSnapshot = useDebugStore((s) => s.health?.providers.instagram ?? null);
@@ -121,6 +120,8 @@ export function InstagramSettingsSection({
   const [checking, setChecking] = useState(false);
   const [lastDiag, setLastDiag] = useState<IgSyncDiag | null>(null);
   const [windowMode, setWindowMode] = useState(() => getIgScraperWindowMode());
+  const [actionError, setActionError] = useState<string | null>(null);
+  const copy = socialProviderCopy("instagram");
   const { confirm, dialog } = useProviderRiskGate("instagram");
 
   // Auto-detect login success from the WebView's on_navigation callback
@@ -139,19 +140,19 @@ export function InstagramSettingsSection({
 
   const handleLogin = useCallback(async () => {
     await confirm(async () => {
-      setError(null);
+      setActionError(null);
       try {
         await showIgLogin();
       } catch (err) {
-        setError(err instanceof Error ? err.message : "Failed to open login window");
+        setActionError(err instanceof Error ? err.message : "Failed to open login window");
       }
     });
-  }, [confirm, setError]);
+  }, [confirm]);
 
   const handleCheckAuth = useCallback(async () => {
     await confirm(async () => {
       setChecking(true);
-      setError(null);
+      setActionError(null);
       try {
         const loggedIn = await checkIgAuth();
         const newState = { isAuthenticated: loggedIn, lastCheckedAt: Date.now() };
@@ -159,15 +160,15 @@ export function InstagramSettingsSection({
         storeIgAuthState(newState);
 
         if (!loggedIn) {
-          setError("Not logged in. Please log in through the Instagram window first.");
+          setActionError("Not logged in. Please log in through the Instagram window first.");
         }
       } catch (err) {
-        setError(err instanceof Error ? err.message : "Auth check failed");
+        setActionError(err instanceof Error ? err.message : "Auth check failed");
       } finally {
         setChecking(false);
       }
     });
-  }, [confirm, setIgAuth, setError]);
+  }, [confirm, setIgAuth]);
 
   const runSync = useCallback(async () => {
     setLastDiag(null);
@@ -188,11 +189,11 @@ export function InstagramSettingsSection({
     await resetProviderPauseState("instagram");
     setIgAuth({ isAuthenticated: false });
     setLastDiag(null);
-    setError(null);
-  }, [setIgAuth, setError]);
+    setActionError(null);
+  }, [setIgAuth]);
 
-  const syncError = storeError && igAuth.isAuthenticated ? storeError : null;
-  const authError = igAuth.lastCaptureError ?? syncError;
+  const syncError = igAuth.isAuthenticated ? igAuth.lastCaptureError ?? null : null;
+  const authError = igAuth.lastCaptureError ?? actionError;
   const needsReconnect = needsProviderReconnect(authError);
   const statusTone = getProviderStatusTone({
     isConnected: igAuth.isAuthenticated,
@@ -214,7 +215,7 @@ export function InstagramSettingsSection({
       if (lastDiag.itemsAdded === 0 && lastDiag.postsExtracted === 0) {
         return (
           <p className="text-xs text-[#52525b]">
-            Feed returned no posts. Instagram may need a moment to load.
+            {copy.feedReturnedEmpty}
           </p>
         );
       }
@@ -280,14 +281,18 @@ export function InstagramSettingsSection({
 
           {needsReconnect && (
             <p className="text-xs text-red-400 leading-relaxed">
-              {formatProviderReconnectMessage("Instagram", authError)}
+              {formatProviderReconnectMessage(copy.label, authError)}
             </p>
+          )}
+
+          {actionError && !needsReconnect && (
+            <p className="text-xs text-red-400 leading-relaxed">{actionError}</p>
           )}
 
           {syncError && !needsReconnect && (
             <p className="text-xs text-red-400 leading-relaxed">
               {syncError.includes("timeout")
-                ? "Scrape timed out. Instagram may be slow to load. Try again."
+                ? copy.timeout
                 : syncError}
             </p>
           )}
@@ -323,8 +328,7 @@ export function InstagramSettingsSection({
           </details>
 
           <p className="text-xs text-[#52525b] leading-relaxed">
-            Freed reads your Instagram feed through a native browser session.
-            Your traffic looks identical to normal browsing.
+            {copy.connectedInfo}
           </p>
         </div>
       </SyncProviderSectionSurface>
@@ -342,7 +346,7 @@ export function InstagramSettingsSection({
         <p className="text-sm text-[#71717a] leading-relaxed">
           {needsReconnect
             ? "Your Instagram session is no longer valid. Sign in again to restore sync."
-            : "Pull your Instagram feed into Freed. Log in through a native browser window. Freed reads your feed the same way you would, so your account stays safe."}
+            : copy.disconnectedSettings}
         </p>
         <div className="flex gap-2">
           <button
@@ -361,8 +365,11 @@ export function InstagramSettingsSection({
         </div>
         {needsReconnect && authError && (
           <p className="text-xs text-amber-400 leading-relaxed">
-            {formatProviderReconnectMessage("Instagram", authError)}
+            {formatProviderReconnectMessage(copy.label, authError)}
           </p>
+        )}
+        {actionError && !needsReconnect && (
+          <p className="text-xs text-red-400 leading-relaxed">{actionError}</p>
         )}
         <ProviderHealthSectionSummary provider="instagram" />
       </div>

--- a/packages/desktop/src/components/LinkedInSettingsSection.tsx
+++ b/packages/desktop/src/components/LinkedInSettingsSection.tsx
@@ -40,6 +40,7 @@ import { ProviderSyncActionButton } from "./ProviderSyncActionButton";
 import { SyncProviderSectionSurface } from "./SyncProviderSectionSurface";
 import { withProviderSyncing } from "../lib/store";
 import { clearProviderPause, resetProviderPauseState } from "../lib/provider-health";
+import { socialProviderCopy } from "../lib/social-provider-copy";
 
 // =============================================================================
 // Diagnostic Panel
@@ -111,14 +112,14 @@ export function LinkedInSettingsSection({
   const liAuth = useAppStore((s) => s.liAuth);
   const setLiAuth = useAppStore((s) => s.setLiAuth);
   const isLoading = useAppStore((s) => s.isLoading);
-  const storeError = useAppStore((s) => s.error);
-  const setError = useAppStore((s) => s.setError);
   const syncing = useAppStore((s) => (s.providerSyncCounts.linkedin ?? 0) > 0);
   const healthSnapshot = useDebugStore((s) => s.health?.providers.linkedin ?? null);
 
   const [checking, setChecking] = useState(false);
   const [lastDiag, setLastDiag] = useState<LiSyncDiag | null>(null);
   const [windowMode, setWindowMode] = useState(() => getLiScraperWindowMode());
+  const [actionError, setActionError] = useState<string | null>(null);
+  const copy = socialProviderCopy("linkedin");
   const { confirm, dialog } = useProviderRiskGate("linkedin");
 
   const runSync = useCallback(async () => {
@@ -150,19 +151,19 @@ export function LinkedInSettingsSection({
 
   const handleLogin = useCallback(async () => {
     await confirm(async () => {
-      setError(null);
+      setActionError(null);
       try {
         await showLiLogin();
       } catch (err) {
-        setError(err instanceof Error ? err.message : "Failed to open login window");
+        setActionError(err instanceof Error ? err.message : "Failed to open login window");
       }
     });
-  }, [confirm, setError]);
+  }, [confirm]);
 
   const handleCheckAuth = useCallback(async () => {
     await confirm(async () => {
       setChecking(true);
-      setError(null);
+      setActionError(null);
       try {
         const loggedIn = await checkLiAuth();
         const newState = { isAuthenticated: loggedIn, lastCheckedAt: Date.now() };
@@ -170,15 +171,15 @@ export function LinkedInSettingsSection({
         storeLiAuthState(newState);
 
         if (!loggedIn) {
-          setError("Not logged in. Please log in through the LinkedIn window first.");
+          setActionError("Not logged in. Please log in through the LinkedIn window first.");
         }
       } catch (err) {
-        setError(err instanceof Error ? err.message : "Auth check failed");
+        setActionError(err instanceof Error ? err.message : "Auth check failed");
       } finally {
         setChecking(false);
       }
     });
-  }, [confirm, setLiAuth, setError]);
+  }, [confirm, setLiAuth]);
 
   const handleDisconnect = useCallback(async () => {
     try {
@@ -189,11 +190,11 @@ export function LinkedInSettingsSection({
     await resetProviderPauseState("linkedin");
     setLiAuth({ isAuthenticated: false });
     setLastDiag(null);
-    setError(null);
-  }, [setLiAuth, setError]);
+    setActionError(null);
+  }, [setLiAuth]);
 
-  const syncError = storeError && liAuth.isAuthenticated ? storeError : null;
-  const authError = liAuth.lastCaptureError ?? syncError;
+  const syncError = liAuth.isAuthenticated ? liAuth.lastCaptureError ?? null : null;
+  const authError = liAuth.lastCaptureError ?? actionError;
   const needsReconnect = needsProviderReconnect(authError);
   const statusTone = getProviderStatusTone({
     isConnected: liAuth.isAuthenticated,
@@ -215,7 +216,7 @@ export function LinkedInSettingsSection({
       if (lastDiag.itemsAdded === 0 && lastDiag.postsExtracted === 0) {
         return (
           <p className="text-xs text-[#52525b]">
-            Feed returned no posts. LinkedIn may need a moment to load.
+            {copy.feedReturnedEmpty}
           </p>
         );
       }
@@ -281,14 +282,18 @@ export function LinkedInSettingsSection({
 
           {needsReconnect && (
             <p className="text-xs text-red-400 leading-relaxed">
-              {formatProviderReconnectMessage("LinkedIn", authError)}
+              {formatProviderReconnectMessage(copy.label, authError)}
             </p>
+          )}
+
+          {actionError && !needsReconnect && (
+            <p className="text-xs text-red-400 leading-relaxed">{actionError}</p>
           )}
 
           {syncError && !needsReconnect && (
             <p className="text-xs text-red-400 leading-relaxed">
               {syncError.includes("timeout")
-                ? "Scrape timed out. LinkedIn may be slow to load. Try again."
+                ? copy.timeout
                 : syncError}
             </p>
           )}
@@ -317,8 +322,7 @@ export function LinkedInSettingsSection({
           </details>
 
           <p className="text-xs text-[#52525b] leading-relaxed">
-            Freed reads your LinkedIn feed through a native browser session.
-            Your traffic looks identical to normal browsing.
+            {copy.connectedInfo}
           </p>
         </div>
       </SyncProviderSectionSurface>
@@ -336,7 +340,7 @@ export function LinkedInSettingsSection({
         <p className="text-sm text-[#71717a] leading-relaxed">
           {needsReconnect
             ? "Your LinkedIn session is no longer valid. Sign in again to restore sync."
-            : "Pull your LinkedIn feed into Freed. Log in through a native browser window. Freed reads your feed the same way you would, so your account stays safe."}
+            : copy.disconnectedSettings}
         </p>
         <div className="flex gap-2">
           <button
@@ -355,8 +359,11 @@ export function LinkedInSettingsSection({
         </div>
         {needsReconnect && authError && (
           <p className="text-xs text-amber-400 leading-relaxed">
-            {formatProviderReconnectMessage("LinkedIn", authError)}
+            {formatProviderReconnectMessage(copy.label, authError)}
           </p>
+        )}
+        {actionError && !needsReconnect && (
+          <p className="text-xs text-red-400 leading-relaxed">{actionError}</p>
         )}
         <ProviderHealthSectionSummary provider="linkedin" />
       </div>

--- a/packages/desktop/src/components/XFeedEmptyState.tsx
+++ b/packages/desktop/src/components/XFeedEmptyState.tsx
@@ -16,6 +16,7 @@ import { captureXTimeline } from "../lib/x-capture";
 import { useSettingsStore } from "@freed/ui/lib/settings-store";
 import { resetProviderPauseState } from "../lib/provider-health";
 import { SampleDataTestingSection } from "@freed/ui/components/SampleDataTestingSection";
+import { socialProviderCopy } from "../lib/social-provider-copy";
 
 const XIcon = () => (
   <svg className="h-7 w-7 text-[var(--theme-media-x)]" viewBox="0 0 24 24" fill="currentColor">
@@ -28,21 +29,24 @@ export function XFeedEmptyState() {
   const setXAuth = useAppStore((s) => s.setXAuth);
   const isLoading = useAppStore((s) => s.isLoading);
   const activeFilter = useAppStore((s) => s.activeFilter);
-  const storeError = useAppStore((s) => s.error);
   const setError = useAppStore((s) => s.setError);
   const openSettings = useSettingsStore((s) => s.openTo);
 
   const [syncing, setSyncing] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const copy = socialProviderCopy("x");
 
   const handleSync = async () => {
     const cookies = loadStoredCookies();
     if (!cookies) return;
     setError(null);
+    setActionError(null);
     setSyncing(true);
     try {
       await captureXTimeline(cookies);
     } catch (err) {
       console.error("X sync failed:", err);
+      setActionError(err instanceof Error ? err.message : "X sync failed");
     } finally {
       setSyncing(false);
     }
@@ -53,9 +57,10 @@ export function XFeedEmptyState() {
     await resetProviderPauseState("x");
     setXAuth({ isAuthenticated: false });
     setError(null);
+    setActionError(null);
   };
 
-  const syncError = storeError && xAuth.isAuthenticated ? storeError : null;
+  const syncError = xAuth.isAuthenticated ? xAuth.lastCaptureError ?? actionError : null;
 
   // Non-X filter → generic empty state
   if (activeFilter.platform !== "x") {
@@ -79,7 +84,7 @@ export function XFeedEmptyState() {
           <XIcon />
         </div>
         <p className="text-lg font-medium mb-2">All caught up!</p>
-        <p className="mb-6 text-sm text-[var(--theme-text-muted)]">Your X timeline is up to date.</p>
+        <p className="mb-6 text-sm text-[var(--theme-text-muted)]">{copy.connectedEmptyState}</p>
         <div className="flex gap-3">
           <button
             onClick={handleSync}
@@ -127,7 +132,7 @@ export function XFeedEmptyState() {
         </div>
       <p className="text-lg font-medium mb-2">Connect X / Twitter</p>
       <p className="mb-6 max-w-xs text-center text-sm text-[var(--theme-text-muted)]">
-        Pull your home timeline into Freed. Set it up in Sources settings.
+        {copy.disconnectedEmptyState}
       </p>
       <button
         onClick={() => openSettings("x")}

--- a/packages/desktop/src/components/XSettingsSection.tsx
+++ b/packages/desktop/src/components/XSettingsSection.tsx
@@ -29,6 +29,7 @@ import { ProviderSyncActionButton } from "./ProviderSyncActionButton";
 import { SyncProviderSectionSurface } from "./SyncProviderSectionSurface";
 import { withProviderSyncing } from "../lib/store";
 import { clearProviderPause, resetProviderPauseState } from "../lib/provider-health";
+import { socialProviderCopy } from "../lib/social-provider-copy";
 
 // =============================================================================
 // Types
@@ -187,12 +188,13 @@ export function XSettingsSection({
   const xAuth = useAppStore((s) => s.xAuth);
   const setXAuth = useAppStore((s) => s.setXAuth);
   const isLoading = useAppStore((s) => s.isLoading);
-  const storeError = useAppStore((s) => s.error);
   const setError = useAppStore((s) => s.setError);
   const syncing = useAppStore((s) => (s.providerSyncCounts.x ?? 0) > 0);
   const healthSnapshot = useDebugStore((s) => s.health?.providers.x ?? null);
 
   const [lastDiag, setLastDiag] = useState<XSyncDiag | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const copy = socialProviderCopy("x");
 
   // Manual cookie entry (fallback)
   const [showManual, setShowManual] = useState(false);
@@ -214,6 +216,7 @@ export function XSettingsSection({
   const finishLogin = useCallback(
     async (ct0Val: string, authTokenVal: string) => {
       setError(null);
+      setActionError(null);
       const cookies = connectX(ct0Val, authTokenVal);
       if (!cookies) return;
       setXAuth({ isAuthenticated: true, cookies });
@@ -228,10 +231,12 @@ export function XSettingsSection({
   const handleSignIn = async () => {
     await confirm(async () => {
       try {
+        setActionError(null);
         await invoke("open_x_login_window");
         poller.start();
       } catch (err) {
         console.error("Failed to open X login window:", err);
+        setActionError(err instanceof Error ? err.message : "Failed to open X login window");
       }
     });
   };
@@ -246,6 +251,7 @@ export function XSettingsSection({
     await confirm(async () => {
       setFormError("");
       setError(null);
+      setActionError(null);
       const cookies = connectX(ct0, authToken);
       if (!cookies) {
         setFormError("Both ct0 and auth_token are required.");
@@ -264,6 +270,7 @@ export function XSettingsSection({
       const cookies = xAuth.cookies ?? loadStoredCookies();
       if (!cookies) return;
       setError(null);
+      setActionError(null);
       if (healthSnapshot?.pause && healthSnapshot.pause.pausedUntil > Date.now()) {
         await clearProviderPause("x");
       }
@@ -277,11 +284,12 @@ export function XSettingsSection({
     setXAuth({ isAuthenticated: false });
     setLastDiag(null);
     setError(null);
+    setActionError(null);
     setShowManual(false);
   };
 
-  const syncError = storeError && xAuth.isAuthenticated ? storeError : null;
-  const authError = xAuth.lastCaptureError ?? syncError;
+  const syncError = xAuth.isAuthenticated ? xAuth.lastCaptureError ?? null : null;
+  const authError = xAuth.lastCaptureError ?? actionError;
   const needsReconnect = needsProviderReconnect(authError);
   const statusTone = getProviderStatusTone({
     isConnected: xAuth.isAuthenticated,
@@ -300,7 +308,7 @@ export function XSettingsSection({
       if (!lastDiag) return null;
       if (lastDiag.errorStage) return null;
       if (lastDiag.itemsAdded === 0 && lastDiag.tweetsExtracted === 0) {
-        return <p className="text-xs text-[#52525b]">Timeline returned no posts.</p>;
+        return <p className="text-xs text-[#52525b]">{copy.feedReturnedEmpty}</p>;
       }
       if (lastDiag.itemsAdded === 0) {
         return <p className="text-xs text-[#52525b]">Already up to date.</p>;
@@ -353,8 +361,12 @@ export function XSettingsSection({
 
           {needsReconnect && (
             <p className="text-xs text-red-400 leading-relaxed">
-              {formatProviderReconnectMessage("X", authError)}
+              {formatProviderReconnectMessage(copy.label, authError)}
             </p>
+          )}
+
+          {actionError && !needsReconnect && (
+            <p className="text-xs text-red-400 leading-relaxed">{actionError}</p>
           )}
 
           {syncError && !needsReconnect && (
@@ -372,8 +384,7 @@ export function XSettingsSection({
           {lastDiag && <DiagPanel diag={lastDiag} />}
 
           <p className="text-xs text-[#52525b] leading-relaxed">
-            Freed syncs your home timeline every 30 minutes while the app is open.
-            Cookies expire periodically, reconnect when sync stops working.
+            {copy.connectedInfo}
           </p>
         </div>
       </SyncProviderSectionSurface>
@@ -478,7 +489,7 @@ export function XSettingsSection({
         <p className="text-sm text-[#71717a] leading-relaxed">
           {needsReconnect
             ? "Your X session is no longer valid. Sign in again to restore sync."
-            : "Pull your home timeline into Freed. Sign in with your X account to start syncing."}
+            : copy.disconnectedSettings}
         </p>
         <button
           onClick={handleSignIn}
@@ -488,8 +499,11 @@ export function XSettingsSection({
         </button>
         {needsReconnect && authError && (
           <p className="text-xs text-amber-400 leading-relaxed">
-            {formatProviderReconnectMessage("X", authError)}
+            {formatProviderReconnectMessage(copy.label, authError)}
           </p>
+        )}
+        {actionError && !needsReconnect && (
+          <p className="text-xs text-red-400 leading-relaxed">{actionError}</p>
         )}
         <button
           onClick={() => setShowManual(true)}

--- a/packages/desktop/src/lib/fb-capture.ts
+++ b/packages/desktop/src/lib/fb-capture.ts
@@ -27,6 +27,7 @@ import { attachScraperMediaDiagListener } from "./scraper-media-diag";
 import { getProviderPause, recordProviderHealthEvent } from "./provider-health";
 import { isMemoryPressureCritical } from "./memory-monitor";
 import { archiveRecentProviderMedia, upsertMediaVaultRosterFromItems } from "./media-vault";
+import { socialProviderCopy } from "./social-provider-copy";
 
 // =============================================================================
 // Rate Limiting
@@ -112,7 +113,7 @@ export async function fetchFbFeed(): Promise<FbSyncResult> {
 
   if (isMemoryPressureCritical()) {
     diag.errorStage = "memory_pressure";
-    diag.errorMessage = "Facebook sync paused because Freed Desktop memory is critically high.";
+    diag.errorMessage = socialProviderCopy("facebook").memoryPressure;
     return { items: [], diag };
   }
 

--- a/packages/desktop/src/lib/instagram-capture.ts
+++ b/packages/desktop/src/lib/instagram-capture.ts
@@ -26,6 +26,7 @@ import { attachScraperMediaDiagListener } from "./scraper-media-diag";
 import { getProviderPause, recordProviderHealthEvent } from "./provider-health";
 import { isMemoryPressureCritical } from "./memory-monitor";
 import { archiveRecentProviderMedia, upsertMediaVaultRosterFromItems } from "./media-vault";
+import { socialProviderCopy } from "./social-provider-copy";
 
 // =============================================================================
 // Rate Limiting
@@ -89,7 +90,7 @@ export async function fetchIgFeed(): Promise<IgSyncResult> {
 
   if (isMemoryPressureCritical()) {
     diag.errorStage = "memory_pressure";
-    diag.errorMessage = "Instagram sync paused because Freed Desktop memory is critically high.";
+    diag.errorMessage = socialProviderCopy("instagram").memoryPressure;
     return { items: [], diag };
   }
 

--- a/packages/desktop/src/lib/li-capture.ts
+++ b/packages/desktop/src/lib/li-capture.ts
@@ -21,6 +21,7 @@ import { attachScraperMediaDiagListener } from "./scraper-media-diag";
 import { storeLiAuthState } from "./li-auth";
 import { getProviderPause, recordProviderHealthEvent } from "./provider-health";
 import { isMemoryPressureCritical } from "./memory-monitor";
+import { socialProviderCopy } from "./social-provider-copy";
 
 // =============================================================================
 // Rate Limiting
@@ -101,7 +102,7 @@ export async function fetchLiFeed(): Promise<LiSyncResult> {
 
   if (isMemoryPressureCritical()) {
     diag.errorStage = "memory_pressure";
-    diag.errorMessage = "LinkedIn sync paused because Freed Desktop memory is critically high.";
+    diag.errorMessage = socialProviderCopy("linkedin").memoryPressure;
     return { items: [], diag };
   }
 

--- a/packages/desktop/src/lib/social-provider-copy.test.ts
+++ b/packages/desktop/src/lib/social-provider-copy.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { SOCIAL_PROVIDER_COPY, type SocialProviderId } from "./social-provider-copy";
+
+const allCopyText = (provider: SocialProviderId) => Object.values(SOCIAL_PROVIDER_COPY[provider]).join(" ");
+
+describe("social provider copy", () => {
+  it("keeps provider labels, domains, and feed terms scoped to the right provider", () => {
+    const forbidden: Record<SocialProviderId, string[]> = {
+      x: ["Facebook", "Instagram", "LinkedIn", "facebook.com", "instagram.com", "linkedin.com"],
+      facebook: ["Instagram", "LinkedIn", "x.com", "twitter.com", "home timeline", "Manual cookie"],
+      instagram: ["Facebook", "LinkedIn", "x.com", "twitter.com", "home timeline", "Manual cookie", "groups"],
+      linkedin: ["Facebook", "Instagram", "x.com", "twitter.com", "home timeline", "Manual cookie", "groups"],
+    };
+
+    for (const provider of Object.keys(SOCIAL_PROVIDER_COPY) as SocialProviderId[]) {
+      const text = allCopyText(provider);
+      for (const phrase of forbidden[provider]) {
+        expect(text, `${provider} copy must not contain ${phrase}`).not.toContain(phrase);
+      }
+    }
+  });
+
+  it("uses memory pressure copy that describes a skipped start, not a paused provider", () => {
+    for (const provider of Object.keys(SOCIAL_PROVIDER_COPY) as SocialProviderId[]) {
+      expect(SOCIAL_PROVIDER_COPY[provider].memoryPressure).toContain("sync did not start");
+      expect(SOCIAL_PROVIDER_COPY[provider].memoryPressure).not.toContain("sync paused");
+    }
+  });
+});

--- a/packages/desktop/src/lib/social-provider-copy.ts
+++ b/packages/desktop/src/lib/social-provider-copy.ts
@@ -1,0 +1,87 @@
+export type SocialProviderId = "x" | "facebook" | "instagram" | "linkedin";
+
+export interface SocialProviderCopy {
+  label: string;
+  settingsTitle: string;
+  connectedEmptyState: string;
+  disconnectedSettings: string;
+  disconnectedEmptyState: string;
+  feedReturnedEmpty: string;
+  timeout: string;
+  connectedInfo: string;
+  memoryPressure: string;
+}
+
+export const SOCIAL_PROVIDER_COPY = {
+  x: {
+    label: "X",
+    settingsTitle: "X",
+    connectedEmptyState: "Your X timeline is up to date.",
+    disconnectedSettings:
+      "Pull your home timeline into Freed. Sign in with your X account to start syncing.",
+    disconnectedEmptyState:
+      "Pull your home timeline into Freed. Set it up in Sources settings.",
+    feedReturnedEmpty: "Timeline returned no posts.",
+    timeout:
+      "Scrape timed out. X may be slow to load. Try again.",
+    connectedInfo:
+      "Freed syncs your home timeline every 30 minutes while the app is open. Cookies expire periodically, reconnect when sync stops working.",
+    memoryPressure:
+      "X sync did not start because Freed Desktop memory is critically high.",
+  },
+  facebook: {
+    label: "Facebook",
+    settingsTitle: "Facebook",
+    connectedEmptyState: "Your Facebook feed is up to date.",
+    disconnectedSettings:
+      "Pull your Facebook feed into Freed. Log in through a native browser window. Freed reads your feed the same way you would.",
+    disconnectedEmptyState:
+      "Pull your Facebook feed into Freed. Set it up in Sources settings.",
+    feedReturnedEmpty:
+      "Feed returned no posts. Facebook may need a moment to load.",
+    timeout:
+      "Scrape timed out. Facebook may be slow to load. Try again.",
+    connectedInfo:
+      "Freed reads your Facebook feed through a native browser session. Your traffic looks identical to normal browsing.",
+    memoryPressure:
+      "Facebook sync did not start because Freed Desktop memory is critically high.",
+  },
+  instagram: {
+    label: "Instagram",
+    settingsTitle: "Instagram",
+    connectedEmptyState: "Your Instagram feed is up to date.",
+    disconnectedSettings:
+      "Pull your Instagram feed into Freed. Log in through a native browser window. Freed reads your feed the same way you would.",
+    disconnectedEmptyState:
+      "Pull your Instagram feed into Freed. Set it up in Sources settings.",
+    feedReturnedEmpty:
+      "Feed returned no posts. Instagram may need a moment to load.",
+    timeout:
+      "Scrape timed out. Instagram may be slow to load. Try again.",
+    connectedInfo:
+      "Freed reads your Instagram feed through a native browser session. Your traffic looks identical to normal browsing.",
+    memoryPressure:
+      "Instagram sync did not start because Freed Desktop memory is critically high.",
+  },
+  linkedin: {
+    label: "LinkedIn",
+    settingsTitle: "LinkedIn",
+    connectedEmptyState: "Your LinkedIn feed is up to date.",
+    disconnectedSettings:
+      "Pull your LinkedIn feed into Freed. Log in through a native browser window. Freed reads your feed the same way you would.",
+    disconnectedEmptyState:
+      "Pull your LinkedIn feed into Freed. Set it up in Sources settings.",
+    feedReturnedEmpty:
+      "Feed returned no posts. LinkedIn may need a moment to load.",
+    timeout:
+      "Scrape timed out. LinkedIn may be slow to load. Try again.",
+    connectedInfo:
+      "Freed reads your LinkedIn feed through a native browser session. Your traffic looks identical to normal browsing.",
+    memoryPressure:
+      "LinkedIn sync did not start because Freed Desktop memory is critically high.",
+  },
+} satisfies Record<SocialProviderId, SocialProviderCopy>;
+
+export function socialProviderCopy(provider: SocialProviderId): SocialProviderCopy {
+  return SOCIAL_PROVIDER_COPY[provider];
+}

--- a/packages/desktop/tests/e2e/provider-copy.spec.ts
+++ b/packages/desktop/tests/e2e/provider-copy.spec.ts
@@ -1,0 +1,113 @@
+import { test, expect } from "./fixtures/app";
+
+const LINKEDIN_ERROR = "LinkedIn sync did not start because Freed Desktop memory is critically high.";
+
+async function seedAcceptedDesktopConsent(page: import("@playwright/test").Page) {
+  await page.addInitScript(() => {
+    window.localStorage.setItem(
+      "__TAURI_MOCK_STORE__:legal.json",
+      JSON.stringify({
+        "legal.bundle.desktop": {
+          version: "2026-03-31.1",
+          acceptedAt: 1775146800000,
+          surface: "desktop-first-run",
+        },
+      }),
+    );
+  });
+}
+
+async function authenticateSocialProviders(page: import("@playwright/test").Page) {
+  await page.evaluate((linkedinError) => {
+    const store = (window as Record<string, unknown>).__FREED_STORE__ as {
+      getState: () => {
+        setError: (error: string | null) => void;
+        setXAuth: (auth: unknown) => void;
+        setFbAuth: (auth: unknown) => void;
+        setIgAuth: (auth: unknown) => void;
+        setLiAuth: (auth: unknown) => void;
+      };
+    };
+    const state = store.getState();
+    state.setXAuth({
+      isAuthenticated: true,
+      cookies: { ct0: "csrf-token", authToken: "auth-token" },
+    });
+    state.setFbAuth({ isAuthenticated: true });
+    state.setIgAuth({ isAuthenticated: true });
+    state.setLiAuth({ isAuthenticated: true, lastCaptureError: linkedinError });
+    state.setError(linkedinError);
+  }, LINKEDIN_ERROR);
+}
+
+async function openSettingsSection(
+  page: import("@playwright/test").Page,
+  sectionName: "X" | "Facebook" | "Instagram" | "LinkedIn",
+) {
+  const navName = sectionName === "X" ? "X / Twitter" : sectionName;
+  const testId = {
+    X: "provider-sync-action-x",
+    Facebook: "provider-sync-action-facebook",
+    Instagram: "provider-sync-action-instagram",
+    LinkedIn: "provider-sync-action-linkedin",
+  }[sectionName];
+  if (!(await page.getByTestId("settings-scroll-container").isVisible().catch(() => false))) {
+    const settingsBtn = page.locator("button").filter({ hasText: /settings/i }).first();
+    await expect(settingsBtn).toBeVisible({ timeout: 5_000 });
+    await settingsBtn.click();
+  }
+  await expect(page.getByText("Settings").first()).toBeVisible({ timeout: 5_000 });
+  const navButton = page.locator("button").filter({
+    has: page.getByText(navName, { exact: true }),
+  }).last();
+  await expect(navButton).toBeVisible({ timeout: 3_000 });
+  await navButton.click();
+  await expect(page.getByTestId(testId)).toBeVisible({ timeout: 3_000 });
+}
+
+function settingsSection(page: import("@playwright/test").Page, provider: "x" | "facebook" | "instagram" | "linkedin") {
+  return page.locator(`[data-section="${provider}"]`);
+}
+
+test("provider settings only show errors for their own provider", async ({ app, page }) => {
+  await seedAcceptedDesktopConsent(page);
+  await app.goto();
+  await app.waitForReady();
+  await authenticateSocialProviders(page);
+
+  for (const provider of ["X", "Facebook", "Instagram"] as const) {
+    await openSettingsSection(page, provider);
+    const sectionId = provider === "X" ? "x" : provider.toLowerCase();
+    await expect(
+      settingsSection(page, sectionId as "x" | "facebook" | "instagram").getByText(LINKEDIN_ERROR),
+    ).toHaveCount(0);
+  }
+
+  await openSettingsSection(page, "LinkedIn");
+  await expect(settingsSection(page, "linkedin").getByText(LINKEDIN_ERROR)).toHaveCount(1);
+});
+
+test("social provider empty states do not inherit a different provider error", async ({ app, page }) => {
+  await seedAcceptedDesktopConsent(page);
+  await app.goto();
+  await app.waitForReady();
+  await authenticateSocialProviders(page);
+
+  await page.evaluate(() => {
+    const store = (window as Record<string, unknown>).__FREED_STORE__ as {
+      getState: () => { setFilter: (filter: { platform: string }) => void };
+    };
+    store.getState().setFilter({ platform: "facebook" });
+  });
+  await expect(page.getByText("Your Facebook feed is up to date.")).toBeVisible();
+  await expect(page.getByText(LINKEDIN_ERROR)).toHaveCount(0);
+
+  await page.evaluate(() => {
+    const store = (window as Record<string, unknown>).__FREED_STORE__ as {
+      getState: () => { setFilter: (filter: { platform: string }) => void };
+    };
+    store.getState().setFilter({ platform: "instagram" });
+  });
+  await expect(page.getByText("Your Instagram feed is up to date.")).toBeVisible();
+  await expect(page.getByText(LINKEDIN_ERROR)).toHaveCount(0);
+});


### PR DESCRIPTION
(AI Generated).

## Summary
- Provider settings and empty states now read provider scoped errors instead of app wide sync errors.
- Added shared social provider copy and audit coverage for wrong provider labels, domains, and feed terms.
- Changed memory pressure copy to say sync did not start, not paused.

## Testing
- npm run test:unit -- social-provider-copy.test.ts
- PATH=/Users/aubreyfalconer/dev/freed-provider-copy-audit/node_modules/.bin:$PATH npm run test:e2e -- provider-copy.spec.ts
- npm run validate:feature
