### PR TITLE
fix: restore feed card max width

### DIFF
--- a/packages/ui/src/components/feed/FeedList.tsx
+++ b/packages/ui/src/components/feed/FeedList.tsx
@@ -22,9 +22,8 @@ const DESKTOP_FEED_CARD_HORIZONTAL_GUTTER = 0;
 const TILE_GAP = FEED_CARD_GAP;
 const MIN_TILE_W = 80; // minimum tile width before a column wraps
 const MAX_TILE_H = 288;
-// Story rows fill the primary content lane with the same outer gutter as cards.
-// The usable tile area tracks the scroll container instead of centering a
-// narrow column inside it.
+// Tailwind max-w-2xl = 42rem = 672px.
+const MAX_CONTENT_W = 672;
 
 /**
  * Height-to-width ratio for story tiles based on column count.
@@ -315,7 +314,7 @@ export function FeedList({
   // Max grid columns based on current container width (capped at 3).
   // Inner width = containerWidth minus the feed-card gutter on each side.
   const maxCols = useMemo(() => {
-    const inner = Math.max(containerWidth - feedCardHorizontalGutter * 2, 0);
+    const inner = Math.max(Math.min(containerWidth, MAX_CONTENT_W) - feedCardHorizontalGutter * 2, 0);
     return Math.max(1, Math.min(3, Math.floor((inner + TILE_GAP) / (MIN_TILE_W + TILE_GAP))));
   }, [containerWidth, feedCardHorizontalGutter]);
 
@@ -342,7 +341,7 @@ export function FeedList({
     (index: number) => {
       const row = rows[index];
       if (!row || row.type !== "stories") return 220;
-      const inner = Math.max(containerWidth - feedCardHorizontalGutter * 2, 0);
+      const inner = Math.max(Math.min(containerWidth, MAX_CONTENT_W) - feedCardHorizontalGutter * 2, 0);
       const nc = row.numCols;
       const tileWidth = nc > 1 ? (inner - (nc - 1) * TILE_GAP) / nc : inner;
       const tileHeight = Math.min(tileWidth * storyHeightRatio(nc), MAX_TILE_H);
@@ -537,7 +536,7 @@ export function FeedList({
     return (
       <div className="flex-1 min-h-0 overflow-auto overscroll-none minimal-scroll">
         <div
-          className="w-full"
+          className="max-w-2xl mx-auto"
           style={{
             paddingInline: `${feedCardHorizontalGutter}px`,
             paddingTop: `${FEED_CARD_GAP}px`,
@@ -649,7 +648,7 @@ export function FeedList({
                 }}
               >
                 <div
-                  className="w-full"
+                  className="max-w-2xl mx-auto"
                   style={{
                     paddingInline: `${FEED_CARD_GAP}px`,
                     paddingBottom: `${FEED_CARD_GAP}px`,
@@ -657,7 +656,7 @@ export function FeedList({
                   }}
                 >
                   {row.type === "stories" ? (() => {
-                    const inner = Math.max(containerWidth - feedCardHorizontalGutter * 2, 0);
+                    const inner = Math.max(Math.min(containerWidth, MAX_CONTENT_W) - feedCardHorizontalGutter * 2, 0);
                     const nc = row.numCols;
                     const tw = nc > 1 ? (inner - (nc - 1) * TILE_GAP) / nc : inner;
                     const th = Math.round(Math.min(tw * storyHeightRatio(nc), MAX_TILE_H));
@@ -726,7 +725,7 @@ export function FeedList({
               }}
             >
               <div
-                className="w-full"
+                className="max-w-2xl mx-auto"
                 style={{
                   paddingInline: `${feedCardHorizontalGutter}px`,
                   paddingBottom: `${FEED_CARD_GAP}px`,
@@ -734,7 +733,7 @@ export function FeedList({
                 }}
               >
                 {row.type === "stories" ? (() => {
-                  const inner = Math.max(containerWidth - feedCardHorizontalGutter * 2, 0);
+                  const inner = Math.max(Math.min(containerWidth, MAX_CONTENT_W) - feedCardHorizontalGutter * 2, 0);
                   const nc = row.numCols;
                   const tw = nc > 1 ? (inner - (nc - 1) * TILE_GAP) / nc : inner;
                   const th = Math.round(Math.min(tw * storyHeightRatio(nc), MAX_TILE_H));


### PR DESCRIPTION
(AI Generated).

## Summary
- Restore the 672px centered feed card lane without reintroducing desktop side padding.
- Keep story tile sizing and virtual row estimates capped to the same content lane.

## Testing
- npm run validate:feature
- PATH="/Users/aubreyfalconer/dev/freed-feed-card-max-width-preview/node_modules/.bin:$PATH" node ../../node_modules/playwright/cli.js test smoke.spec.ts -g "desktop primary feed scroller keeps the shared fade shell"
