### PR TITLE
fix: require arrow click to expand feeds

### DIFF
--- a/packages/pwa/tests/app.spec.ts
+++ b/packages/pwa/tests/app.spec.ts
@@ -1019,6 +1019,25 @@ test.describe("FREED PWA", () => {
     await expect(page.getByRole("button", { name: "Alpha Dispatch" })).toHaveCount(0);
   });
 
+  test("rss source row selects feeds without opening the accordion", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await acceptLegalGate(page);
+    await seedSidebarFeeds(page);
+
+    const sidebar = page.locator("aside");
+    await sidebar.getByTestId("source-row-rss").click();
+
+    await expect.poll(() => new URL(page.url()).search).toBe("?platform=rss");
+    await expect(sidebar.getByRole("button", { name: "Alpha Dispatch" })).toHaveCount(0);
+    const expandFeedsButton = sidebar.locator('button[aria-label="Expand feeds"]');
+    await expect(expandFeedsButton).toBeVisible();
+
+    await expandFeedsButton.click();
+    await expect(sidebar.getByRole("button", { name: "Alpha Dispatch" })).toBeVisible();
+  });
+
   test("feed pagination clears an off-page feed selection back to top-level feeds", async ({
     page,
   }) => {

--- a/packages/ui/src/components/layout/Sidebar.tsx
+++ b/packages/ui/src/components/layout/Sidebar.tsx
@@ -924,12 +924,6 @@ export function Sidebar({
   );
 
   useEffect(() => {
-    if (activeFilter.platform === "rss" || activeFilter.feedUrl) {
-      setRssFeedsOpen(true);
-    }
-  }, [activeFilter.feedUrl, activeFilter.platform]);
-
-  useEffect(() => {
     const maxPage = Math.max(0, totalFeedPages - 1);
     if (rssFeedPage > maxPage) {
       setRssFeedPage(maxPage);


### PR DESCRIPTION
(AI Generated).

## Summary
- Keep the Feeds source row from opening the RSS accordion when it is selected.

## Testing
- PATH=/Users/aubreyfalconer/dev/freed-feed-accordion-arrow/node_modules/.bin:$PATH npm run test -- app.spec.ts -g "rss source row selects feeds without opening the accordion"
- npm run validate:feature