### PR TITLE
fix: polish contextual toolbar titles

### DIFF
--- a/packages/desktop/tests/e2e/smoke.spec.ts
+++ b/packages/desktop/tests/e2e/smoke.spec.ts
@@ -560,11 +560,13 @@ test("desktop toolbar wordmark and passive title block avoid text-selection affo
 
     const wordmarkStyle = window.getComputedStyle(wordmark);
     const titleBlockStyle = window.getComputedStyle(titleBlock);
+    const titleTextStyle = window.getComputedStyle(titleBlock.querySelector("p") as HTMLElement);
     return {
       wordmarkCursor: wordmarkStyle.cursor,
       wordmarkUserSelect: wordmarkStyle.userSelect,
       titleBlockCursor: titleBlockStyle.cursor,
       titleBlockUserSelect: titleBlockStyle.userSelect,
+      titleTextAlign: titleTextStyle.textAlign,
     };
   });
 
@@ -573,6 +575,7 @@ test("desktop toolbar wordmark and passive title block avoid text-selection affo
   expect(styleState?.wordmarkUserSelect).toBe("none");
   expect(styleState?.titleBlockCursor).toBe("default");
   expect(styleState?.titleBlockUserSelect).toBe("none");
+  expect(styleState?.titleTextAlign).toBe("center");
 });
 
 test("desktop toolbar title stays clear of the wordmark and sidebar toggle at narrow sidebar widths", async ({ app, page }) => {
@@ -2934,6 +2937,7 @@ test("dual-column reader toolbar toggles stay aligned with the sidebar and rail"
     const dualColumnToggle = document.querySelector(
       '[aria-label="Hide Previews"], [aria-label="Show Previews"]',
     ) as HTMLElement | null;
+    const dualColumnToggleIcon = dualColumnToggle?.querySelector("svg") as SVGElement | null;
     const archiveButton = document.querySelector('[aria-label="Archive"], [aria-label="Unarchive"]') as HTMLElement | null;
     const openButton = document.querySelector('[aria-label="Open"]') as HTMLElement | null;
     const backButton = document.querySelector('[aria-label="Back to list"]') as HTMLElement | null;
@@ -2963,6 +2967,7 @@ test("dual-column reader toolbar toggles stay aligned with the sidebar and rail"
     const sidebarToggleIconRect = sidebarToggleIcon?.getBoundingClientRect() ?? null;
     const bookmarkButtonRect = bookmarkButton.getBoundingClientRect();
     const dualColumnToggleRect = dualColumnToggle.getBoundingClientRect();
+    const dualColumnToggleIconRect = dualColumnToggleIcon?.getBoundingClientRect() ?? null;
     const archiveButtonRect = archiveButton.getBoundingClientRect();
     const openButtonRect = openButton?.getBoundingClientRect() ?? null;
     const backButtonRect = backButton.getBoundingClientRect();
@@ -3014,6 +3019,7 @@ test("dual-column reader toolbar toggles stay aligned with the sidebar and rail"
       dualColumnToggleCenterY: dualColumnToggleRect.top + dualColumnToggleRect.height / 2,
       dualColumnToggleLeft: dualColumnToggleRect.left,
       dualColumnToggleRight: dualColumnToggleRect.right,
+      dualColumnToggleIconRight: dualColumnToggleIconRect?.right ?? dualColumnToggleRect.right,
       dualColumnToggleWidth: dualColumnToggleRect.width,
       dualColumnToggleHeight: dualColumnToggleRect.height,
       archiveButtonTop: archiveButtonRect.top,
@@ -3023,7 +3029,7 @@ test("dual-column reader toolbar toggles stay aligned with the sidebar and rail"
       archiveButtonHeight: archiveButtonRect.height,
       bookmarkButtonCenterY: bookmarkButtonRect.top + bookmarkButtonRect.height / 2,
       backButtonLeft: backButtonRect.left,
-      previewBackGap: backButtonRect.left - dualColumnToggleRect.right,
+      previewBackGap: backButtonRect.left - (dualColumnToggleIconRect?.right ?? dualColumnToggleRect.right),
       focusButtonLeft: firstReaderActionRect.left,
       focusButtonRight: firstReaderActionRect.right,
       readerTitleRightGap: firstReaderActionRect.left - backButtonRect.right,
@@ -3047,8 +3053,7 @@ test("dual-column reader toolbar toggles stay aligned with the sidebar and rail"
   expect(alignment.archiveButtonRight).toBeLessThanOrEqual(alignment.toolbarRight - 8);
   expect(Math.abs(alignment.rightActionMargin - LAYOUT_CONTROL_GAP_PX)).toBeLessThanOrEqual(1);
   expect(Math.abs(alignment.readerTitleRightGap - LAYOUT_CONTROL_GAP_PX)).toBeLessThanOrEqual(1);
-  expect(alignment.previewBackGap).toBeGreaterThanOrEqual(4);
-  expect(alignment.previewBackGap).toBeLessThanOrEqual(8);
+  expect(Math.abs(alignment.previewBackGap - LAYOUT_CONTROL_GAP_PX)).toBeLessThanOrEqual(1);
   for (const gap of alignment.actionGaps) {
     expect(Math.abs(gap - LAYOUT_CONTROL_GAP_PX)).toBeLessThanOrEqual(1);
   }
@@ -3233,17 +3238,23 @@ test("forced compact reader toolbar keeps sidebar and overflow controls aligned"
     const wordmark = toolbar?.querySelector('[data-testid="workspace-toolbar-wordmark"]') as HTMLElement | null;
     const layoutControlCluster = document.querySelector('[data-testid="desktop-layout-control-cluster"]') as HTMLElement | null;
     const sidebarToggle = toolbar?.querySelector('[data-testid="desktop-sidebar-toggle"]') as HTMLElement | null;
+    const backButton = toolbar?.querySelector('[data-testid="workspace-toolbar-reader-back"]') as HTMLElement | null;
+    const readerTitleBlock = toolbar?.querySelector('[data-testid="workspace-toolbar-reader-title-block"]') as HTMLElement | null;
+    const readerBackIcon = toolbar?.querySelector('[data-testid="workspace-toolbar-reader-back-icon"]') as SVGElement | null;
     const bookmarkButton = toolbar?.querySelector('[aria-label="Save"], [aria-label="Unsave"]') as HTMLElement | null;
     const archiveButton = toolbar?.querySelector('[aria-label="Archive"], [aria-label="Unarchive"]') as HTMLElement | null;
     const overflowButton = toolbar?.querySelector('[data-testid="toolbar-overflow-button"]') as HTMLElement | null;
 
-    if (!wordmark || !layoutControlCluster || !sidebarToggle || !overflowButton) {
+    if (!wordmark || !layoutControlCluster || !sidebarToggle || !backButton || !readerTitleBlock || !readerBackIcon || !overflowButton) {
       throw new Error("Narrow reader toolbar buttons were not found");
     }
 
     const wordmarkRect = wordmark.getBoundingClientRect();
     const toolbarRect = toolbar!.getBoundingClientRect();
     const sidebarToggleRect = sidebarToggle.getBoundingClientRect();
+    const backButtonRect = backButton.getBoundingClientRect();
+    const readerTitleBlockRect = readerTitleBlock.getBoundingClientRect();
+    const readerBackIconRect = readerBackIcon.getBoundingClientRect();
     const bookmarkRect = bookmarkButton?.getBoundingClientRect() ?? null;
     const archiveRect = archiveButton?.getBoundingClientRect() ?? null;
     const overflowRect = overflowButton.getBoundingClientRect();
@@ -3252,6 +3263,18 @@ test("forced compact reader toolbar keeps sidebar and overflow controls aligned"
       wordmarkRight: wordmarkRect.right,
       sidebarToggleLeft: sidebarToggleRect.left,
       sidebarToggleRight: sidebarToggleRect.right,
+      sidebarBackGap: backButtonRect.left - sidebarToggleRect.right,
+      readerTitleText: readerTitleBlock.textContent?.replace(/\s+/g, " ").trim() ?? "",
+      readerTitleTextAlign: window.getComputedStyle(readerTitleBlock).textAlign,
+      readerTitleCenterGap: Math.abs(
+        readerTitleBlockRect.left + readerTitleBlockRect.width / 2 -
+        (backButtonRect.left + backButtonRect.width / 2),
+      ),
+      readerIconCenterGap: Math.abs(
+        readerBackIconRect.top + readerBackIconRect.height / 2 -
+        (readerTitleBlockRect.top + readerTitleBlockRect.height / 2),
+      ),
+      readerIconTextGap: readerTitleBlockRect.right > readerBackIconRect.right,
       viewportWidth: window.innerWidth,
       toolbarRight: toolbarRect.right,
       bookmarkInlineVisible: bookmarkRect
@@ -3270,6 +3293,13 @@ test("forced compact reader toolbar keeps sidebar and overflow controls aligned"
 
   expect(layout.sidebarToggleInLeftCluster).toBe(true);
   expect(Math.abs(layout.sidebarToggleLeft - layout.wordmarkRight - LAYOUT_CONTROL_GAP_PX)).toBeLessThanOrEqual(1);
+  expect(layout.sidebarBackGap).toBeGreaterThanOrEqual(0);
+  expect(layout.sidebarBackGap).toBeLessThanOrEqual(LAYOUT_CONTROL_GAP_PX);
+  expect(layout.readerTitleText).toMatch(/^All Sources\s*•\s*\d+ items$/);
+  expect(layout.readerTitleTextAlign).toBe("center");
+  expect(layout.readerTitleCenterGap).toBeLessThanOrEqual(1);
+  expect(layout.readerIconCenterGap).toBeLessThanOrEqual(1);
+  expect(layout.readerIconTextGap).toBe(true);
   expect(layout.sidebarToggleRight).toBeLessThanOrEqual(layout.toolbarRight - 8);
   expect(layout.bookmarkInlineVisible).toBe(false);
   expect(layout.overflowRight).toBeLessThanOrEqual(layout.viewportWidth + 48);
@@ -3290,9 +3320,51 @@ test("narrow reader toolbar moves hidden actions into the overflow menu", async 
   await app.waitForReady();
   await app.injectRssItems(4);
 
+  await page.evaluate(() => {
+    const store = (window as Record<string, unknown>).__FREED_STORE__ as
+      | {
+          getState: () => {
+            updatePreferences: (update: unknown) => Promise<void>;
+          };
+        }
+      | undefined;
+
+    void store?.getState().updatePreferences({
+      display: {
+        reading: {
+          dualColumnMode: true,
+        },
+      },
+    });
+  });
+
   await page.getByText("Article 0:", { exact: false }).click();
+  await expect.poll(async () => {
+    return page.evaluate(() => document.documentElement.classList.contains("feed-layout-transition"));
+  }).toBe(false);
+  await expect(page.getByRole("button", { name: "Hide Previews" })).toBeVisible({ timeout: 5_000 });
   const overflowButton = page.getByTestId("toolbar-overflow-button");
   await expect(overflowButton).toBeVisible({ timeout: 5_000 });
+  const spacing = await page.evaluate(() => {
+    const previewButton = document.querySelector('[aria-label="Hide Previews"]') as HTMLElement | null;
+    const previewIcon = previewButton?.querySelector("svg") as SVGElement | null;
+    const backButton = document.querySelector('[data-testid="workspace-toolbar-reader-back"]') as HTMLElement | null;
+    const overflowButton = document.querySelector('[data-testid="toolbar-overflow-button"]') as HTMLElement | null;
+    if (!previewIcon || !backButton || !overflowButton) {
+      throw new Error("Narrow reader toolbar spacing elements were not found");
+    }
+
+    const previewIconRect = previewIcon.getBoundingClientRect();
+    const backButtonRect = backButton.getBoundingClientRect();
+    const overflowButtonRect = overflowButton.getBoundingClientRect();
+
+    return {
+      leftGap: backButtonRect.left - previewIconRect.right,
+      rightGap: overflowButtonRect.left - backButtonRect.right,
+    };
+  });
+  expect(Math.abs(spacing.leftGap - spacing.rightGap)).toBeLessThanOrEqual(1);
+
   await overflowButton.click();
   const overflowMenu = page.getByTestId("toolbar-overflow-menu");
   await expect(overflowMenu.getByRole("menuitem", { name: "Enable focus mode" })).toBeVisible();
@@ -3325,7 +3397,177 @@ test("narrow feed toolbar moves bulk actions into the overflow menu", async ({ a
   await expect(overflowMenu.getByRole("menuitem", { name: /Archive .* read items/ })).toBeVisible();
 });
 
-test("mobile feed toolbar places overflow actions before the filter button", async ({ app, page }) => {
+test("feed toolbar bulk action counts follow the active filter", async ({ app, page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await app.goto();
+  await app.waitForReady();
+
+  await page.evaluate(async () => {
+    const store = (window as Record<string, unknown>).__FREED_STORE__ as
+      | {
+          getState: () => {
+            updatePreferences: (update: unknown) => Promise<void>;
+          };
+        }
+      | undefined;
+    await store?.getState().updatePreferences({
+      display: {
+        reading: {
+          markReadOnScroll: false,
+        },
+      },
+    });
+  });
+
+  const activeFeedUrl = "https://bench.example/active-filter-feed.xml";
+  const otherFeedUrl = "https://bench.example/other-filter-feed.xml";
+  await app.injectRssItems(2, activeFeedUrl);
+  await app.injectRssItems(6, otherFeedUrl);
+
+  await page.evaluate(async ({ activeFeedUrl, otherFeedUrl }) => {
+    const store = (window as Record<string, unknown>).__FREED_STORE__ as
+      | {
+          getState: () => {
+            setFilter: (filter: { feedUrl: string }) => void;
+            markItemsAsRead: (ids: string[]) => Promise<void>;
+          };
+        }
+      | undefined;
+    const state = store?.getState();
+    await state?.markItemsAsRead([
+      `rss:${activeFeedUrl}:bench-item-0`,
+      `rss:${otherFeedUrl}:bench-item-0`,
+      `rss:${otherFeedUrl}:bench-item-1`,
+      `rss:${otherFeedUrl}:bench-item-2`,
+      `rss:${otherFeedUrl}:bench-item-3`,
+    ]);
+    state?.setFilter({ feedUrl: activeFeedUrl });
+  }, { activeFeedUrl, otherFeedUrl });
+
+  await expect(page.getByTestId("workspace-toolbar-title-block")).toContainText("2 items");
+  await expect(page.getByTestId("workspace-toolbar").locator("button").filter({ hasText: / unread$/ })).toHaveCount(0);
+  await expect(page.getByTestId("workspace-toolbar").locator("button").filter({ hasText: / read$/ })).toHaveCount(0);
+
+  const overflowButton = page.getByTestId("toolbar-overflow-button");
+  await expect(overflowButton).toBeVisible({ timeout: 5_000 });
+  await overflowButton.click();
+
+  const overflowMenu = page.getByTestId("toolbar-overflow-menu");
+  await expect(overflowMenu.getByRole("menuitem", { name: "Mark 1 unread as read" })).toBeVisible();
+  await expect(overflowMenu.getByRole("menuitem", { name: "Archive 1 read items" })).toBeVisible();
+});
+
+test("feed toolbar title describes active content filters", async ({ app, page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await app.goto();
+  await app.waitForReady();
+
+  await page.evaluate(async () => {
+    const now = Date.now();
+    const w = window as Record<string, unknown>;
+    const automerge = w.__FREED_AUTOMERGE__ as {
+      docBatchImportItems: (items: unknown[]) => Promise<unknown>;
+    };
+    const store = w.__FREED_STORE__ as
+      | {
+          getState: () => {
+            setFilter: (filter: unknown) => void;
+            updatePreferences: (update: unknown) => Promise<void>;
+          };
+        }
+      | undefined;
+
+    await automerge.docBatchImportItems([
+      {
+        globalId: "context-title-facebook-story",
+        platform: "facebook",
+        contentType: "story",
+        capturedAt: now - 10_000,
+        publishedAt: now - 10_000,
+        author: { id: "fb:context-title", handle: "context.title", displayName: "Context Title" },
+        content: { text: "Facebook story title fixture", mediaUrls: [], mediaTypes: [] },
+        userState: { hidden: false, saved: false, archived: false, tags: [] },
+        topics: [],
+        contentSignals: { version: 3, method: "manual", inferredAt: now, scores: { life_update: 1 }, tags: ["life_update"] },
+      },
+      {
+        globalId: "context-title-conversation",
+        platform: "facebook",
+        contentType: "post",
+        capturedAt: now - 20_000,
+        publishedAt: now - 20_000,
+        author: { id: "fb:context-title", handle: "context.title", displayName: "Context Title" },
+        content: { text: "Conversation post title fixture", mediaUrls: [], mediaTypes: [] },
+        userState: { hidden: false, saved: false, archived: false, tags: [] },
+        topics: [],
+        contentSignals: { version: 3, method: "manual", inferredAt: now, scores: { request: 1 }, tags: ["request"] },
+      },
+      {
+        globalId: "context-title-news",
+        platform: "linkedin",
+        contentType: "post",
+        capturedAt: now - 30_000,
+        publishedAt: now - 30_000,
+        author: { id: "li:context-title", handle: "context.title", displayName: "Context Title" },
+        content: { text: "News post title fixture", mediaUrls: [], mediaTypes: [] },
+        userState: { hidden: false, saved: false, archived: false, tags: [] },
+        topics: [],
+        contentSignals: { version: 3, method: "manual", inferredAt: now, scores: { news: 1 }, tags: ["news"] },
+      },
+    ]);
+
+    await store?.getState().updatePreferences({
+      display: {
+        feedSignalModes: ["conversation", "news"],
+      },
+    });
+    store?.getState().setFilter({ signals: ["request", "discussion", "news", "alert", "product_update"] });
+  });
+
+  await expect(page.getByTestId("workspace-toolbar-title-block")).toContainText("Conversations and News");
+  await expect(page.getByTestId("workspace-toolbar-title-block")).toContainText("2 items");
+
+  await page.evaluate(async () => {
+    const store = (window as Record<string, unknown>).__FREED_STORE__ as
+      | {
+          getState: () => {
+            setFilter: (filter: unknown) => void;
+            updatePreferences: (update: unknown) => Promise<void>;
+          };
+        }
+      | undefined;
+    await store?.getState().updatePreferences({
+      display: {
+        feedSignalModes: ["conversation", "news", "personal"],
+      },
+    });
+    store?.getState().setFilter({
+      signals: ["request", "discussion", "news", "alert", "product_update", "life_update", "moment"],
+    });
+  });
+  await expect(page.getByTestId("workspace-toolbar-title-block")).toContainText("Filtered");
+
+  await page.evaluate(async () => {
+    const store = (window as Record<string, unknown>).__FREED_STORE__ as
+      | {
+          getState: () => {
+            setFilter: (filter: unknown) => void;
+            updatePreferences: (update: unknown) => Promise<void>;
+          };
+        }
+      | undefined;
+    await store?.getState().updatePreferences({
+      display: {
+        feedSignalModes: [],
+      },
+    });
+    store?.getState().setFilter({ platform: "facebook", socialContentFilter: "stories" });
+  });
+  await expect(page.getByTestId("workspace-toolbar-title-block")).toContainText("Facebook Stories");
+  await expect(page.getByTestId("workspace-toolbar-title-block")).toContainText("1 item");
+});
+
+test("mobile feed toolbar keeps more actions as the rightmost control", async ({ app, page }) => {
   await page.setViewportSize({ width: 390, height: 844 });
   await app.goto();
   await app.waitForReady();
@@ -3346,12 +3588,12 @@ test("mobile feed toolbar places overflow actions before the filter button", asy
     }
 
     return {
-      gap: filterRect.left - overflowRect.right,
-      overflowRight: overflowRect.right,
-      filterLeft: filterRect.left,
+      gap: overflowRect.left - filterRect.right,
+      filterRight: filterRect.right,
+      overflowLeft: overflowRect.left,
     };
   });
-  expect(geometry.overflowRight).toBeLessThanOrEqual(geometry.filterLeft);
+  expect(geometry.filterRight).toBeLessThanOrEqual(geometry.overflowLeft);
   expect(geometry.gap).toBeGreaterThanOrEqual(0);
 
   await overflowButton.click();

--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -88,6 +88,7 @@ const TOOLBAR_ICON_BUTTON_CLASS =
 const TOOLBAR_READER_LAYOUT_TOGGLE_BUTTON_CLASS =
   "theme-toolbar-reader-layout-button rounded-lg";
 const READER_LAYOUT_CONTROL_BUTTON_SIZE_PX = 32;
+const READER_LAYOUT_CONTROL_ICON_SIZE_PX = 20;
 const READER_LAYOUT_CONTROL_BUTTON_GAP_PX = 0;
 const LAYOUT_CONTROL_SAFE_GAP_PX = 8;
 const CLOSED_SIDEBAR_TOGGLE_LEFT_PX = 12;
@@ -192,6 +193,55 @@ function ToolbarOverflowIcon({ className = "h-5 w-5" }: { className?: string }) 
   );
 }
 
+function joinTitleParts(parts: readonly string[]): string {
+  if (parts.length <= 1) return parts[0] ?? "";
+  if (parts.length === 2) return `${parts[0]} and ${parts[1]}`;
+  return `${parts.slice(0, -1).join(", ")}, and ${parts[parts.length - 1]}`;
+}
+
+function signalTitlePart(modes: readonly FeedSignalMode[]): string | null {
+  if (modes.length === 0) return null;
+  if (modes.length > 2) return "Filtered";
+  const labels = modes.map((mode) =>
+    mode === "conversation"
+      ? "Conversations"
+      : FEED_SIGNAL_FILTER_PRESETS.find((preset) => preset.mode === mode)?.label ?? "Filtered"
+  );
+  return joinTitleParts(labels);
+}
+
+function contentKindTitlePart(filter: { platform?: string; feedUrl?: string; socialContentFilter?: SocialContentFilter }): string | null {
+  if (filter.feedUrl || filter.platform === "rss") return "Articles";
+  if (filter.socialContentFilter === "stories") return "Stories";
+  if (filter.socialContentFilter === "posts") return "Posts";
+  return null;
+}
+
+function contextualFeedTitle({
+  filter,
+  scopeLabel,
+  activeSignalModes,
+  allSignalsSelected,
+}: {
+  filter: { platform?: string; feedUrl?: string; socialContentFilter?: SocialContentFilter; savedOnly?: boolean; archivedOnly?: boolean };
+  scopeLabel: string;
+  activeSignalModes: readonly FeedSignalMode[];
+  allSignalsSelected: boolean;
+}): string {
+  if (filter.savedOnly || filter.archivedOnly) return scopeLabel;
+
+  const signalPart = allSignalsSelected ? null : signalTitlePart(activeSignalModes);
+  const kindPart = contentKindTitlePart(filter);
+  const providerPart =
+    filter.platform && filter.platform !== "rss"
+      ? scopeLabel
+      : null;
+  const hasContentFilter = !!signalPart || filter.socialContentFilter === "posts" || filter.socialContentFilter === "stories";
+
+  if (!providerPart && !hasContentFilter) return scopeLabel;
+  return [...(providerPart ? [providerPart] : []), ...(signalPart ? [signalPart] : []), ...(kindPart ? [kindPart] : [])].join(" ");
+}
+
 export function Header({
   mobileSidebarOpen,
   onMobileMenuToggle,
@@ -240,14 +290,8 @@ export function Header({
   const searchQuery = useAppStore((s) => s.searchQuery);
   const searchCorpusVersion = useAppStore((s) => s.searchCorpusVersion);
   const selectedItemId = useAppStore((s) => s.selectedItemId);
-  const totalUnreadCount = useAppStore((s) => s.totalUnreadCount);
-  const unreadCountByPlatform = useAppStore((s) => s.unreadCountByPlatform);
-  const totalArchivableCount = useAppStore((s) => s.totalArchivableCount);
-  const archivableCountByPlatform = useAppStore((s) => s.archivableCountByPlatform);
-  const archivableFeedCounts = useAppStore((s) => s.archivableFeedCounts);
   const pendingMatchCount = useAppStore((s) => s.pendingMatchCount);
-  const markAllAsRead = useAppStore((s) => s.markAllAsRead);
-  const archiveAllReadUnsaved = useAppStore((s) => s.archiveAllReadUnsaved);
+  const markItemsAsRead = useAppStore((s) => s.markItemsAsRead);
   const unarchiveSavedItems = useAppStore((s) => s.unarchiveSavedItems);
   const deleteAllArchived = useAppStore((s) => s.deleteAllArchived);
   const toggleSaved = useAppStore((s) => s.toggleSaved);
@@ -343,21 +387,25 @@ export function Header({
   const showInlineReaderBookmark =
     !!selectedItem && !isBelowReaderBookmarkToolbar;
 
-  const unreadCount =
-    activeFilter.savedOnly || activeFilter.archivedOnly
-      ? 0
-      : activeFilter.platform
-        ? (unreadCountByPlatform[activeFilter.platform] ?? 0)
-        : totalUnreadCount;
-
-  const archivableCount =
-    activeFilter.savedOnly || activeFilter.archivedOnly
-      ? 0
-      : activeFilter.feedUrl
-        ? (archivableFeedCounts[activeFilter.feedUrl] ?? 0)
-        : activeFilter.platform
-          ? (archivableCountByPlatform[activeFilter.platform] ?? 0)
-          : totalArchivableCount;
+  const filteredUnreadItemIds = useMemo(
+    () => filteredItems
+      .filter((item) => !item.userState.readAt && !item.userState.hidden && !item.userState.archived)
+      .map((item) => item.globalId),
+    [filteredItems],
+  );
+  const filteredArchivableItemIds = useMemo(
+    () => filteredItems
+      .filter((item) =>
+        !!item.userState.readAt &&
+        !item.userState.hidden &&
+        !item.userState.archived &&
+        !item.userState.saved
+      )
+      .map((item) => item.globalId),
+    [filteredItems],
+  );
+  const unreadCount = filteredUnreadItemIds.length;
+  const archivableCount = filteredArchivableItemIds.length;
 
   const handleSocialContentFilterChange = useCallback(
     (value: SocialContentFilter) => {
@@ -378,22 +426,7 @@ export function Header({
     return scopeLabel;
   }, [activeView, scopeLabel]);
 
-  const currentTitle = useMemo(() => {
-    if (selectedItem) {
-      return selectedItem.content.linkPreview?.title
-        ?? selectedItem.content.text?.slice(0, 90)
-        ?? selectedItem.author.displayName;
-    }
-    return currentListTitle;
-  }, [currentListTitle, selectedItem]);
-
-  const currentSubtitle = useMemo(() => {
-    if (selectedItem) {
-      const source = selectedItem.platform
-        ? selectedItem.platform.toLocaleUpperCase()
-        : scopeLabel;
-      return `${selectedItem.author.displayName} • ${source}`;
-    }
+  const currentListSubtitle = useMemo(() => {
     if (activeView === "friends") {
       if (pendingMatchCount > 0) {
         if (effectiveFriendsMode === "all_content") {
@@ -429,8 +462,17 @@ export function Header({
     resultCount,
     socialAccountCount,
     scopeLabel,
-    selectedItem,
   ]);
+
+  const currentSubtitle = useMemo(() => {
+    if (selectedItem) {
+      const source = selectedItem.platform
+        ? selectedItem.platform.toLocaleUpperCase()
+        : scopeLabel;
+      return `${selectedItem.author.displayName} • ${source}`;
+    }
+    return currentListSubtitle;
+  }, [currentListSubtitle, scopeLabel, selectedItem]);
 
   const [signalFilterMenuOpen, setSignalFilterMenuOpen] = useState(false);
   const signalFilterMenuRef = useRef<HTMLDivElement>(null);
@@ -481,6 +523,30 @@ export function Header({
     : activeFeedSignalModes.length === 1
       ? FEED_SIGNAL_FILTER_PRESETS.find((preset) => preset.mode === activeFeedSignalModes[0])?.label ?? "Custom"
       : `${activeFeedSignalModes.length.toLocaleString()} filters`;
+  const contextualListTitle = useMemo(() => {
+    if (activeView !== "feed") return currentListTitle;
+    return contextualFeedTitle({
+      filter: activeFilter,
+      scopeLabel,
+      activeSignalModes: activeFeedSignalModes,
+      allSignalsSelected: allFeedSignalsSelected,
+    });
+  }, [
+    activeFeedSignalModes,
+    activeFilter,
+    activeView,
+    allFeedSignalsSelected,
+    currentListTitle,
+    scopeLabel,
+  ]);
+  const currentTitle = useMemo(() => {
+    if (selectedItem) {
+      return selectedItem.content.linkPreview?.title
+        ?? selectedItem.content.text?.slice(0, 90)
+        ?? selectedItem.author.displayName;
+    }
+    return contextualListTitle;
+  }, [contextualListTitle, selectedItem]);
   const feedSignalCountBaseFilter = useMemo(() => {
     const nextFilter = { ...activeFilter };
     delete nextFilter.signals;
@@ -665,6 +731,14 @@ export function Header({
     void unarchiveSavedItems();
   }, [unarchiveSavedItems]);
 
+  const handleMarkFilteredUnreadAsRead = useCallback(() => {
+    void markItemsAsRead(filteredUnreadItemIds);
+  }, [filteredUnreadItemIds, markItemsAsRead]);
+
+  const handleArchiveFilteredRead = useCallback(() => {
+    void Promise.all(filteredArchivableItemIds.map((id) => toggleArchived(id)));
+  }, [filteredArchivableItemIds, toggleArchived]);
+
   const toolbarOverflowActions = useMemo<ToolbarOverflowAction[]>(() => {
     const actions: ToolbarOverflowAction[] = [];
 
@@ -747,49 +821,48 @@ export function Header({
         });
       }
 
-      if (showFeedBulkActions && unreadCount > 0) {
-        actions.push({
-          id: "mark-read",
-          label: `Mark ${unreadCount.toLocaleString()} unread as read`,
-          onClick: () => markAllAsRead(activeFilter.platform),
-          icon: (
-            <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
-            </svg>
-          ),
-        });
-      }
+    }
 
-      if (showFeedBulkActions && archivableCount > 0) {
-        actions.push({
-          id: "archive-read",
-          label: `Archive ${archivableCount.toLocaleString()} read items`,
-          onClick: () => archiveAllReadUnsaved(activeFilter.platform, activeFilter.feedUrl),
-          icon: (
-            <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-            </svg>
-          ),
-        });
-      }
+    if (!selectedItem && showFeedBulkActions && unreadCount > 0) {
+      actions.push({
+        id: "mark-read",
+        label: `Mark ${unreadCount.toLocaleString()} unread as read`,
+        onClick: handleMarkFilteredUnreadAsRead,
+        icon: (
+          <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+        ),
+      });
+    }
+
+    if (!selectedItem && showFeedBulkActions && archivableCount > 0) {
+      actions.push({
+        id: "archive-read",
+        label: `Archive ${archivableCount.toLocaleString()} read items`,
+        onClick: handleArchiveFilteredRead,
+        icon: (
+          <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+          </svg>
+        ),
+      });
     }
 
     return actions;
   }, [
-    activeFilter.feedUrl,
-    activeFilter.platform,
-    archiveAllReadUnsaved,
     archivableCount,
     deleteConfirmArmed,
     display.reading.focusMode,
+    handleArchiveFilteredRead,
     handleDeleteArchivedClick,
+    handleMarkFilteredUnreadAsRead,
     handleOpenReaderUrl,
     handleToggleFocusMode,
     handleToggleReaderSaved,
     handleToggleReaderArchived,
     handleUnarchiveSavedClick,
     isBelowLargeToolbar,
-    markAllAsRead,
     savedArchivedCount,
     selectedItem,
     showInlineReaderBookmark,
@@ -810,6 +883,7 @@ export function Header({
     previewToggleLeftPx: DEFAULT_LAYOUT_CONTROL_SAFE_LEFT_PX + READER_LAYOUT_CONTROL_BUTTON_SIZE_PX,
     reservedWidthPx: DEFAULT_LAYOUT_CONTROL_RESERVED_WIDTH_PX,
   });
+  const [previewToggleMounted, setPreviewToggleMounted] = useState(false);
   const activeSearchQuery = searchQuery.trim();
   const showToolbarSearch = !selectedItem && activeSearchQuery.length > 0;
   const showFriendsSidebarToggle = activeView === "friends" && !isMobile;
@@ -869,6 +943,7 @@ export function Header({
   const dropdownRef = useRef<HTMLDivElement>(null);
   const toolbarSearchInputRef = useRef<HTMLInputElement | null>(null);
   const layoutControlHostRef = useRef<HTMLDivElement | null>(null);
+  const previewToggleButtonRef = useRef<HTMLButtonElement | null>(null);
   const wordmarkRef = useRef<HTMLSpanElement | null>(null);
   const sidebarHandleCenterlineStyleRef = useRef<string | null>(null);
   const toolbarDragGestureRef = useRef<{
@@ -953,6 +1028,11 @@ export function Header({
     event.preventDefault();
     event.stopPropagation();
   }, [clearSuppressedToolbarClick]);
+
+  const handlePreviewToggleButtonRef = useCallback((node: HTMLButtonElement | null) => {
+    previewToggleButtonRef.current = node;
+    setPreviewToggleMounted(Boolean(node));
+  }, []);
 
   const getToolbarControlProps = useCallback((style?: CSSProperties) => ({
     ...(canManuallyDragToolbarControls
@@ -1097,8 +1177,13 @@ export function Header({
       const handleCenterPx = resizeHandleRect
         ? resizeHandleRect.left + resizeHandleRect.width / 2 - hostRect.left
         : fallbackHandleCenterPx;
+      const previewToggleButton = previewToggleButtonRef.current;
+      const previewToggleVisible =
+        !!previewToggleButton && previewToggleButton.getClientRects().length > 0;
+      const readerLayoutControlButtonCount = previewToggleVisible ? 2 : 1;
       const readerLayoutControlPairWidthPx =
-        READER_LAYOUT_CONTROL_BUTTON_SIZE_PX * 2 + READER_LAYOUT_CONTROL_BUTTON_GAP_PX;
+        READER_LAYOUT_CONTROL_BUTTON_SIZE_PX * readerLayoutControlButtonCount +
+        READER_LAYOUT_CONTROL_BUTTON_GAP_PX * (readerLayoutControlButtonCount - 1);
       const idealSidebarToggleLeftPx = visibleDesktopSidebarMode === "closed"
         ? CLOSED_SIDEBAR_TOGGLE_LEFT_PX
         : handleCenterPx - readerLayoutControlPairWidthPx / 2;
@@ -1106,8 +1191,13 @@ export function Header({
       const previewToggleLeftPx = Math.ceil(
         sidebarToggleLeftPx + READER_LAYOUT_CONTROL_BUTTON_SIZE_PX + READER_LAYOUT_CONTROL_BUTTON_GAP_PX,
       );
-      const toolbarBoundaryWidthPx = previewToggleLeftPx + READER_LAYOUT_CONTROL_BUTTON_SIZE_PX;
-      const toolbarSlotPaddingRightPx = showDesktopReaderLayoutToggle
+      const readerLayoutControlVisualInsetPx =
+        (READER_LAYOUT_CONTROL_BUTTON_SIZE_PX - READER_LAYOUT_CONTROL_ICON_SIZE_PX) / 2;
+      const toolbarBoundaryWidthPx =
+        sidebarToggleLeftPx +
+        readerLayoutControlPairWidthPx -
+        (selectedItem ? readerLayoutControlVisualInsetPx : 0);
+      const toolbarSlotPaddingRightPx = selectedItem
         ? 0
         : TOOLBAR_SIDEBAR_SLOT_PADDING_RIGHT_PX;
       const reservedWidthPx = Math.ceil(
@@ -1177,7 +1267,10 @@ export function Header({
     };
   }, [
     isMobileDevice,
+    previewToggleMounted,
+    selectedItem,
     showDesktopReaderLayoutToggle,
+    showReaderLayoutToggle,
     visibleDesktopSidebarMode,
   ]);
 
@@ -1310,6 +1403,7 @@ export function Header({
                     >
                       <Tooltip label={display.reading.dualColumnMode ? "Hide Previews" : "Show Previews"}>
                         <button
+                          ref={handlePreviewToggleButtonRef}
                           onClick={handleToggleDualColumn}
                           {...getToolbarControlProps()}
                           className={TOOLBAR_READER_LAYOUT_TOGGLE_BUTTON_CLASS}
@@ -1340,25 +1434,28 @@ export function Header({
                 onClick={handleCloseReader}
                 {...getToolbarControlProps()}
                 data-testid="workspace-toolbar-reader-back"
-                className="group flex w-full min-w-0 items-center gap-1 rounded-lg px-1 py-1 text-left transition-colors hover:bg-[var(--theme-bg-muted)]"
+                className="group flex w-full min-w-0 items-center justify-center rounded-lg px-1 py-1 text-center transition-colors hover:bg-[var(--theme-bg-muted)]"
                 aria-label="Back to list"
               >
-                <span className="pointer-events-none flex shrink-0 items-center rounded-lg p-1.5">
-                  <svg
-                    className="h-4 w-4 shrink-0 text-[var(--theme-text-muted)] transition-colors group-hover:text-[var(--theme-text-secondary)]"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                  >
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
-                  </svg>
-                </span>
                 <div
                   data-testid="workspace-toolbar-reader-title-block"
-                  className="pointer-events-none min-w-0 flex-1 cursor-default select-none"
+                  className="pointer-events-none flex min-w-0 max-w-full cursor-default select-none items-center justify-center gap-2 text-center"
                 >
+                  <span className="flex h-8 w-5 shrink-0 items-center justify-center rounded-lg">
+                    <svg
+                      data-testid="workspace-toolbar-reader-back-icon"
+                      className="h-4 w-4 shrink-0 text-[var(--theme-text-muted)] transition-colors group-hover:text-[var(--theme-text-secondary)]"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                    >
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+                    </svg>
+                  </span>
                   <p className="truncate text-sm font-medium text-[var(--theme-text-secondary)]">
-                    {currentListTitle}
+                    {contextualListTitle}
+                    <span className="mx-1.5 font-normal text-[var(--theme-text-muted)]">•</span>
+                    <span className="font-normal text-[var(--theme-text-muted)]">{currentListSubtitle}</span>
                   </p>
                 </div>
               </button>
@@ -1378,9 +1475,9 @@ export function Header({
             ) : (
               <div
                 data-testid="workspace-toolbar-title-block"
-                className="min-w-0 cursor-default select-none px-1"
+                className="flex min-w-0 cursor-default select-none justify-center px-1 text-center"
               >
-                <p className="truncate text-sm font-semibold text-[var(--theme-text-secondary)]">
+                <p className="truncate text-center text-sm font-semibold text-[var(--theme-text-secondary)]">
                   {currentTitle}
                   <span className="mx-1.5 font-normal text-[var(--theme-text-muted)]">•</span>
                   <span className="font-normal text-[var(--theme-text-muted)]">{currentSubtitle}</span>
@@ -1613,40 +1710,6 @@ export function Header({
                   ) : null}
                 </ToolbarAnimatedSlot>
 
-                <ToolbarAnimatedSlot visible={showFeedBulkActions && unreadCount > 0 && !isBelowLargeToolbar} width={TOOLBAR_SLOT_WIDTH_CONTENT} className="hidden lg:flex">
-                  {showFeedBulkActions && unreadCount > 0 && !isBelowLargeToolbar ? (
-                    <Tooltip label={`Mark all ${unreadCount.toLocaleString()} items as read`} className="hidden lg:flex">
-                      <button
-                        onClick={() => markAllAsRead(activeFilter.platform)}
-                        {...getToolbarControlProps()}
-                        className="theme-toolbar-button-ghost flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm"
-                      >
-                        <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
-                        </svg>
-                        <span>{unreadCount.toLocaleString()} unread</span>
-                      </button>
-                    </Tooltip>
-                  ) : null}
-                </ToolbarAnimatedSlot>
-
-                <ToolbarAnimatedSlot visible={showFeedBulkActions && archivableCount > 0 && !isBelowLargeToolbar} width={TOOLBAR_SLOT_WIDTH_CONTENT} className="hidden lg:flex">
-                  {showFeedBulkActions && archivableCount > 0 && !isBelowLargeToolbar ? (
-                    <Tooltip label={`Archive all ${archivableCount.toLocaleString()} read (unsaved) items`} className="hidden lg:flex">
-                      <button
-                        onClick={() => archiveAllReadUnsaved(activeFilter.platform, activeFilter.feedUrl)}
-                        {...getToolbarControlProps()}
-                        className="theme-toolbar-button-ghost flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm"
-                      >
-                        <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                        </svg>
-                        <span>{archivableCount.toLocaleString()} read</span>
-                      </button>
-                    </Tooltip>
-                  ) : null}
-                </ToolbarAnimatedSlot>
-
                 <ToolbarAnimatedSlot visible={showInlineSocialContentControls} width={TOOLBAR_SLOT_WIDTH_CONTENT}>
                   {showInlineSocialContentControls ? (
                     <ToolbarToggleGroup
@@ -1714,25 +1777,6 @@ export function Header({
                 >
                   {showToolbarOverflowMenuButton || showCollapsedToolbarFilterMenu ? (
                     <div className="flex items-center gap-2">
-                      {showToolbarOverflowMenuButton ? (
-                        <Tooltip label="More actions">
-                          <button
-                            ref={toolbarOverflowButtonRef}
-                            type="button"
-                            onClick={toggleToolbarOverflowMenu}
-                            {...getToolbarControlProps()}
-                            data-testid="toolbar-overflow-button"
-                            className={`${TOOLBAR_ICON_BUTTON_CLASS} ${
-                              isMobileDevice ? "theme-toolbar-button-ghost" : "theme-toolbar-button-neutral"
-                            }`}
-                            aria-haspopup="menu"
-                            aria-expanded={toolbarOverflowMenuOpen}
-                            aria-label="More actions"
-                          >
-                            <ToolbarOverflowIcon />
-                          </button>
-                        </Tooltip>
-                      ) : null}
                       {showCollapsedToolbarFilterMenu ? (
                         <Tooltip label="Filter view">
                           <button
@@ -1749,6 +1793,25 @@ export function Header({
                             aria-label="Filter view"
                           >
                             <FilterIcon className="h-5 w-5" />
+                          </button>
+                        </Tooltip>
+                      ) : null}
+                      {showToolbarOverflowMenuButton ? (
+                        <Tooltip label="More actions">
+                          <button
+                            ref={toolbarOverflowButtonRef}
+                            type="button"
+                            onClick={toggleToolbarOverflowMenu}
+                            {...getToolbarControlProps()}
+                            data-testid="toolbar-overflow-button"
+                            className={`${TOOLBAR_ICON_BUTTON_CLASS} ${
+                              isMobileDevice ? "theme-toolbar-button-ghost" : "theme-toolbar-button-neutral"
+                            }`}
+                            aria-haspopup="menu"
+                            aria-expanded={toolbarOverflowMenuOpen}
+                            aria-label="More actions"
+                          >
+                            <ToolbarOverflowIcon />
                           </button>
                         </Tooltip>
                       ) : null}


### PR DESCRIPTION
(AI Generated).

## Summary
- Center the toolbar state title and keep reader controls balanced around it.
- Keep feed bulk actions inside More Actions and scope action counts to active filters.
- Make feed titles reflect provider, content type, and signal filters without adding Posts when All is selected.

## Testing
- npm run validate:feature
- npm run test:e2e -- smoke.spec.ts -g "wordmark and passive title|dual-column reader toolbar|forced compact reader toolbar|narrow reader toolbar|narrow feed toolbar|bulk action counts|content filters|more actions as the rightmost"
- npm run test:e2e -- smoke.spec.ts -g "content filters"