### PR TITLE
fix: harden feed read scroll tracking

### DIFF
--- a/packages/desktop/src/lib/automerge.worker.ts
+++ b/packages/desktop/src/lib/automerge.worker.ts
@@ -54,7 +54,7 @@ import {
   confirmLikedSynced,
   confirmSeenSynced,
 } from "@freed/shared/schema";
-import { createDefaultPreferences, rankFeedItems } from "@freed/shared";
+import { mergeDefaultPreferences, rankFeedItems } from "@freed/shared";
 import type { Account, FeedItem, Friend, LegacyDeviceContact, LegacyFriendSource, Person, RssFeed, UserPreferences } from "@freed/shared";
 import type { DocState, WorkerRequest, WorkerResponse } from "./automerge-types";
 import {
@@ -245,46 +245,7 @@ function hydrateFromDoc(doc: FreedDoc): DocState {
   const persons = (plain.persons ?? {}) as Record<string, Person>;
   const accounts = (plain.accounts ?? {}) as Record<string, Account>;
   const friends = projectLegacyFriends(persons, accounts);
-  const preferences = {
-    ...createDefaultPreferences(),
-    ...(plain.preferences as Partial<UserPreferences>),
-    xCapture: {
-      ...createDefaultPreferences().xCapture,
-      ...(plain.preferences?.xCapture as Partial<UserPreferences["xCapture"]> | undefined),
-    },
-    fbCapture: {
-      ...createDefaultPreferences().fbCapture,
-      ...(plain.preferences?.fbCapture as Partial<UserPreferences["fbCapture"]> | undefined),
-    },
-    ai: {
-      ...createDefaultPreferences().ai,
-      ...(plain.preferences?.ai as Partial<UserPreferences["ai"]> | undefined),
-    },
-    display: {
-      ...createDefaultPreferences().display,
-      ...(plain.preferences?.display as Partial<UserPreferences["display"]> | undefined),
-      reading: {
-        ...createDefaultPreferences().display.reading,
-        ...(plain.preferences?.display?.reading as Partial<UserPreferences["display"]["reading"]> | undefined),
-      },
-    },
-    sync: {
-      ...createDefaultPreferences().sync,
-      ...(plain.preferences?.sync as Partial<UserPreferences["sync"]> | undefined),
-    },
-    ulysses: {
-      ...createDefaultPreferences().ulysses,
-      ...(plain.preferences?.ulysses as Partial<UserPreferences["ulysses"]> | undefined),
-      allowedPaths: {
-        ...createDefaultPreferences().ulysses.allowedPaths,
-        ...(plain.preferences?.ulysses?.allowedPaths as Record<string, string[]> | undefined),
-      },
-    },
-    weights: {
-      ...createDefaultPreferences().weights,
-      ...(plain.preferences?.weights as Partial<UserPreferences["weights"]> | undefined),
-    },
-  } satisfies UserPreferences;
+  const preferences = mergeDefaultPreferences(plain.preferences as Partial<UserPreferences> | undefined);
 
   const visibleItems = plainItems.filter((item) => !item.userState.hidden);
   const rankedItems = rankFeedItems(

--- a/packages/desktop/src/lib/bug-report.ts
+++ b/packages/desktop/src/lib/bug-report.ts
@@ -7,6 +7,7 @@ import type {
   GeneratedBugReportBundle,
   ReportPrivacyTier,
 } from "@freed/shared";
+import { getReleaseChannelFromVersion } from "@freed/shared";
 import { useDebugStore } from "@freed/ui/lib/debug-store";
 import {
   buildBugReportManifest,
@@ -26,6 +27,11 @@ const APP_NAME = "Freed Desktop";
 
 interface DesktopRuntimeInfo {
   version: string;
+  releaseChannel: string;
+  buildKind: string;
+  commitSha: string | null;
+  commitRef: string | null;
+  deployedAt: string | null;
   platform: string;
   userAgent: string;
   appMode: "test" | "development" | "production";
@@ -58,6 +64,11 @@ async function getPlatformName(): Promise<string> {
 function getRuntimeInfo(platform: string): DesktopRuntimeInfo {
   return {
     version: __APP_VERSION__,
+    releaseChannel: getReleaseChannelFromVersion(__APP_VERSION__),
+    buildKind: __BUILD_KIND__,
+    commitSha: __BUILD_COMMIT_SHA__,
+    commitRef: __BUILD_COMMIT_REF__,
+    deployedAt: __BUILD_DEPLOYED_AT__,
     platform,
     userAgent: navigator.userAgent,
     appMode:

--- a/packages/desktop/src/lib/store-read-state.test.ts
+++ b/packages/desktop/src/lib/store-read-state.test.ts
@@ -115,6 +115,32 @@ describe("store read-state batching", () => {
       error.message,
     );
   });
+
+  it("records queued and flushed diagnostics for multi-item read updates", async () => {
+    const useAppStore = await loadStore();
+    useAppStore.setState({ totalUnreadCount: 3 });
+
+    const markItemsPromise = useAppStore.getState().markItemsAsRead([
+      "rss:test:article-12345678",
+      "rss:test:article-87654321",
+    ]);
+
+    await vi.advanceTimersByTimeAsync(READ_MARK_BATCH_DELAY_MS_FOR_TESTS);
+    await markItemsPromise;
+
+    expect(mockRecordBugReportEvent).toHaveBeenCalledWith(
+      "desktop:readState",
+      "info",
+      "Queued 2 read marks",
+      expect.stringContaining("...12345678"),
+    );
+    expect(mockRecordBugReportEvent).toHaveBeenCalledWith(
+      "desktop:readState",
+      "info",
+      "Flushed 2 read marks",
+      expect.stringContaining("...87654321"),
+    );
+  });
 });
 
 const READ_MARK_BATCH_DELAY_MS_FOR_TESTS = 50;

--- a/packages/desktop/src/lib/store.ts
+++ b/packages/desktop/src/lib/store.ts
@@ -320,6 +320,19 @@ function recordReadStateFailure(error: unknown, batchSize: number): void {
   );
 }
 
+function readStateIdTails(ids: readonly string[]): string[] {
+  return ids.slice(0, 5).map((id) => `...${id.slice(-8)}`);
+}
+
+function recordReadStateInfo(message: string, detail: Record<string, unknown>): void {
+  recordBugReportEvent(
+    "desktop:readState",
+    "info",
+    message,
+    JSON.stringify(detail),
+  );
+}
+
 async function flushPendingReadMarks(): Promise<void> {
   if (readMarkBatchInFlight) return;
   readMarkBatchInFlight = true;
@@ -499,7 +512,36 @@ export const useAppStore = create<AppState>((set, get) => ({
   },
 
   markItemsAsRead: async (ids) => {
-    await queueReadMarks(ids);
+    const nextIds = ids.filter(Boolean);
+    if (nextIds.length === 0) return;
+
+    const startedAt = performance.now();
+    const beforeUnreadCount = get().totalUnreadCount;
+    recordReadStateInfo(
+      `Queued ${nextIds.length.toLocaleString()} read mark${nextIds.length === 1 ? "" : "s"}`,
+      {
+        queuedCount: nextIds.length,
+        beforeUnreadCount,
+        itemIdTails: readStateIdTails(nextIds),
+      },
+    );
+
+    try {
+      await queueReadMarks(nextIds);
+      recordReadStateInfo(
+        `Flushed ${nextIds.length.toLocaleString()} read mark${nextIds.length === 1 ? "" : "s"}`,
+        {
+          batchCount: nextIds.length,
+          beforeUnreadCount,
+          afterUnreadCount: get().totalUnreadCount,
+          durationMs: Math.round(performance.now() - startedAt),
+          itemIdTails: readStateIdTails(nextIds),
+        },
+      );
+    } catch (error) {
+      recordReadStateFailure(error, nextIds.length);
+      throw error;
+    }
   },
 
   markAllAsRead: async (platform) => {

--- a/packages/desktop/tests/e2e/smoke.spec.ts
+++ b/packages/desktop/tests/e2e/smoke.spec.ts
@@ -2030,14 +2030,16 @@ test("desktop primary feed marks scrolled-past rows as read", async ({ app, page
     return state.totalUnreadCount;
   });
 
-  await page.evaluate(() => {
-    const container = document.querySelector('[data-testid="feed-list-scroll-container"]') as HTMLElement | null;
-    if (!container) {
-      throw new Error("Feed scroll container was not found");
-    }
-    container.scrollTop = 1_400;
-    container.dispatchEvent(new Event("scroll"));
-  });
+  const feedContainer = page.getByTestId("feed-list-scroll-container");
+  await expect(feedContainer).toBeVisible();
+  const feedBox = await feedContainer.boundingBox();
+  if (!feedBox) {
+    throw new Error("Feed scroll container was not visible");
+  }
+  await page.mouse.move(feedBox.x + feedBox.width / 2, feedBox.y + feedBox.height / 2);
+  for (let index = 0; index < 8; index += 1) {
+    await page.mouse.wheel(0, 400);
+  }
 
   await expect
     .poll(async () => page.evaluate((itemId) => {
@@ -2098,6 +2100,85 @@ test("desktop primary feed marks scrolled-past rows as read", async ({ app, page
   const topCard = page.locator("[data-feed-item-id]").first();
   await expect(topCard).toBeVisible({ timeout: 10_000 });
   await expect(topCard).toHaveClass(/grayscale/);
+});
+
+test("desktop compact feed panel marks scrolled-past rows as read", async ({ app, page }) => {
+  await page.setViewportSize({ width: 1280, height: 600 });
+  await app.goto();
+  await app.waitForReady();
+  await app.injectRssItems(30);
+
+  await page.evaluate(() => {
+    const store = (window as Record<string, unknown>).__FREED_STORE__ as
+      | {
+          getState: () => {
+            updatePreferences: (update: unknown) => Promise<void>;
+          };
+        }
+      | undefined;
+    return store?.getState().updatePreferences({
+      display: {
+        reading: {
+          dualColumnMode: true,
+          markReadOnScroll: true,
+          showReadInGrayscale: true,
+        },
+      },
+    });
+  });
+
+  await page.locator("[data-feed-item-id]").first().click();
+  const compactPanel = page.getByTestId("compact-feed-panel-scroll-container");
+  await expect(compactPanel).toBeVisible({ timeout: 5_000 });
+
+  const secondItemId = "rss:https://bench.example/feed.xml:bench-item-1";
+  const initialUnreadCount = await page.evaluate(() => {
+    const store = (window as Record<string, unknown>).__FREED_STORE__ as
+      | { getState: () => { totalUnreadCount: number } }
+      | undefined;
+    return store?.getState().totalUnreadCount ?? Number.POSITIVE_INFINITY;
+  });
+
+  const compactBox = await compactPanel.boundingBox();
+  if (!compactBox) {
+    throw new Error("Compact feed panel was not visible");
+  }
+  await page.mouse.move(compactBox.x + compactBox.width / 2, compactBox.y + compactBox.height / 2);
+  for (let index = 0; index < 8; index += 1) {
+    await page.mouse.wheel(0, 260);
+  }
+
+  await expect
+    .poll(async () => page.evaluate((itemId) => {
+      const store = (window as Record<string, unknown>).__FREED_STORE__ as
+        | {
+            getState: () => {
+              items: Array<{ globalId: string; userState: { readAt?: number } }>;
+            };
+          }
+        | undefined;
+      return Boolean(store?.getState().items.find((item) => item.globalId === itemId)?.userState.readAt);
+    }, secondItemId), { timeout: 10_000 })
+    .toBe(true);
+
+  await expect
+    .poll(async () => page.evaluate(() => {
+      const store = (window as Record<string, unknown>).__FREED_STORE__ as
+        | { getState: () => { totalUnreadCount: number } }
+        | undefined;
+      return store?.getState().totalUnreadCount ?? Number.POSITIVE_INFINITY;
+    }), { timeout: 10_000 })
+    .toBeLessThan(initialUnreadCount);
+
+  await compactPanel.evaluate((element) => {
+    const container = element as HTMLElement;
+    container.scrollTop = 0;
+    container.dispatchEvent(new Event("scroll"));
+  });
+
+  const secondCompactCard = compactPanel.locator(`[data-feed-item-id="${secondItemId}"]`).first();
+  await expect(secondCompactCard).toBeVisible({ timeout: 10_000 });
+  await expect(secondCompactCard).toHaveClass(/grayscale/);
 });
 
 test("keyboard focus scrolling keeps a full row visible past the focused item", async ({ app, page }) => {

--- a/packages/pwa/src/lib/automerge.worker.ts
+++ b/packages/pwa/src/lib/automerge.worker.ts
@@ -47,7 +47,7 @@ import {
   confirmLikedSynced,
   confirmSeenSynced,
 } from "@freed/shared/schema";
-import { createDefaultPreferences, rankFeedItems } from "@freed/shared";
+import { mergeDefaultPreferences, rankFeedItems } from "@freed/shared";
 import type { Account, FeedItem, Friend, LegacyDeviceContact, LegacyFriendSource, Person, RssFeed, UserPreferences } from "@freed/shared";
 import type { DocState, WorkerRequest, WorkerResponse } from "./automerge-types";
 
@@ -176,46 +176,7 @@ function hydrateFromDoc(doc: FreedDoc): DocState {
   const persons = (plain.persons ?? {}) as Record<string, Person>;
   const accounts = (plain.accounts ?? {}) as Record<string, Account>;
   const friends = projectLegacyFriends(persons, accounts);
-  const preferences = {
-    ...createDefaultPreferences(),
-    ...(plain.preferences as Partial<UserPreferences>),
-    xCapture: {
-      ...createDefaultPreferences().xCapture,
-      ...(plain.preferences?.xCapture as Partial<UserPreferences["xCapture"]> | undefined),
-    },
-    fbCapture: {
-      ...createDefaultPreferences().fbCapture,
-      ...(plain.preferences?.fbCapture as Partial<UserPreferences["fbCapture"]> | undefined),
-    },
-    ai: {
-      ...createDefaultPreferences().ai,
-      ...(plain.preferences?.ai as Partial<UserPreferences["ai"]> | undefined),
-    },
-    display: {
-      ...createDefaultPreferences().display,
-      ...(plain.preferences?.display as Partial<UserPreferences["display"]> | undefined),
-      reading: {
-        ...createDefaultPreferences().display.reading,
-        ...(plain.preferences?.display?.reading as Partial<UserPreferences["display"]["reading"]> | undefined),
-      },
-    },
-    sync: {
-      ...createDefaultPreferences().sync,
-      ...(plain.preferences?.sync as Partial<UserPreferences["sync"]> | undefined),
-    },
-    ulysses: {
-      ...createDefaultPreferences().ulysses,
-      ...(plain.preferences?.ulysses as Partial<UserPreferences["ulysses"]> | undefined),
-      allowedPaths: {
-        ...createDefaultPreferences().ulysses.allowedPaths,
-        ...(plain.preferences?.ulysses?.allowedPaths as Record<string, string[]> | undefined),
-      },
-    },
-    weights: {
-      ...createDefaultPreferences().weights,
-      ...(plain.preferences?.weights as Partial<UserPreferences["weights"]> | undefined),
-    },
-  } satisfies UserPreferences;
+  const preferences = mergeDefaultPreferences(plain.preferences as Partial<UserPreferences> | undefined);
 
   const visibleItems = plainItems.filter((item) => !item.userState.hidden);
   const rankedItems = rankFeedItems(

--- a/packages/pwa/src/lib/bug-report.ts
+++ b/packages/pwa/src/lib/bug-report.ts
@@ -5,6 +5,7 @@ import type {
   GeneratedBugReportBundle,
   ReportPrivacyTier,
 } from "@freed/shared";
+import { getReleaseChannelFromVersion } from "@freed/shared";
 import { useDebugStore } from "@freed/ui/lib/debug-store";
 import {
   buildBugReportManifest,
@@ -32,6 +33,11 @@ function collectEvents(events: BugReportEvent[], tier: ReportPrivacyTier): BugRe
 function getPwaRuntimeInfo() {
   return {
     version: __APP_VERSION__,
+    releaseChannel: getReleaseChannelFromVersion(__APP_VERSION__),
+    buildKind: __BUILD_KIND__,
+    commitSha: __BUILD_COMMIT_SHA__,
+    commitRef: __BUILD_COMMIT_REF__,
+    deployedAt: __BUILD_DEPLOYED_AT__,
     userAgent: navigator.userAgent,
     platform: navigator.platform || "web",
     serviceWorker: "serviceWorker" in navigator,

--- a/packages/pwa/src/lib/preferences.test.ts
+++ b/packages/pwa/src/lib/preferences.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { mergeDefaultPreferences, type UserPreferences } from "@freed/shared";
+
+describe("mergeDefaultPreferences", () => {
+  it("fills reading defaults for legacy preference documents", () => {
+    const preferences = mergeDefaultPreferences({
+      display: {
+        themeId: "neon",
+      },
+    } as Partial<UserPreferences>);
+
+    expect(preferences.display.themeId).toBe("neon");
+    expect(preferences.display.reading.markReadOnScroll).toBe(true);
+    expect(preferences.display.reading.showReadInGrayscale).toBe(true);
+    expect(preferences.display.reading.dualColumnMode).toBe(true);
+  });
+
+  it("preserves explicit reading preferences", () => {
+    const preferences = mergeDefaultPreferences({
+      display: {
+        reading: {
+          markReadOnScroll: false,
+          showReadInGrayscale: false,
+        },
+      },
+    } as Partial<UserPreferences>);
+
+    expect(preferences.display.reading.markReadOnScroll).toBe(false);
+    expect(preferences.display.reading.showReadInGrayscale).toBe(false);
+    expect(preferences.display.reading.focusMode).toBe(false);
+  });
+});

--- a/packages/pwa/src/lib/store.ts
+++ b/packages/pwa/src/lib/store.ts
@@ -54,6 +54,19 @@ import {
 import type { DocState } from "./automerge";
 import { pinReaderItemInPwa } from "./reader-cache";
 
+function readStateIdTails(ids: readonly string[]): string[] {
+  return ids.slice(0, 5).map((id) => `...${id.slice(-8)}`);
+}
+
+function recordReadStateInfo(message: string, detail: Record<string, unknown>): void {
+  recordBugReportEvent(
+    "pwa:readState",
+    "info",
+    message,
+    JSON.stringify(detail),
+  );
+}
+
 /** PWA-specific store state — extends the shared base with sync connection status. */
 interface AppState extends BaseAppState {
   syncConnected: boolean;
@@ -194,7 +207,42 @@ export const useAppStore = create<AppState>((set, get) => ({
   },
 
   markItemsAsRead: async (ids) => {
-    await docMarkItemsAsRead(ids);
+    const nextIds = ids.filter(Boolean);
+    if (nextIds.length === 0) return;
+
+    const startedAt = performance.now();
+    const beforeUnreadCount = get().totalUnreadCount;
+    recordReadStateInfo(
+      `Queued ${nextIds.length.toLocaleString()} read mark${nextIds.length === 1 ? "" : "s"}`,
+      {
+        queuedCount: nextIds.length,
+        beforeUnreadCount,
+        itemIdTails: readStateIdTails(nextIds),
+      },
+    );
+
+    try {
+      await docMarkItemsAsRead(nextIds);
+      recordReadStateInfo(
+        `Flushed ${nextIds.length.toLocaleString()} read mark${nextIds.length === 1 ? "" : "s"}`,
+        {
+          batchCount: nextIds.length,
+          beforeUnreadCount,
+          afterUnreadCount: get().totalUnreadCount,
+          durationMs: Math.round(performance.now() - startedAt),
+          itemIdTails: readStateIdTails(nextIds),
+        },
+      );
+    } catch (error) {
+      recordRuntimeError({ source: "pwa:readState", error, fatal: false });
+      recordBugReportEvent(
+        "pwa:readState",
+        "error",
+        `Read state update failed for ${nextIds.length.toLocaleString()} item${nextIds.length === 1 ? "" : "s"}`,
+        error instanceof Error ? error.message : String(error),
+      );
+      throw error;
+    }
   },
 
   markAllAsRead: async (platform) => {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -957,6 +957,96 @@ export function createDefaultPreferences(): UserPreferences {
   };
 }
 
+/**
+ * Merge persisted preferences with current defaults.
+ */
+export function mergeDefaultPreferences(
+  preferences?: Partial<UserPreferences> | null,
+): UserPreferences {
+  const defaults = createDefaultPreferences();
+  if (!preferences) {
+    return defaults;
+  }
+
+  const display = preferences.display as Partial<DisplayPreferences> | undefined;
+  const reading = display?.reading as Partial<ReadingEnhancements> | undefined;
+  const weights = preferences.weights as Partial<WeightPreferences> | undefined;
+  const ulysses = preferences.ulysses as Partial<UlyssesPreferences> | undefined;
+  const sync = preferences.sync as Partial<SyncPreferences> | undefined;
+  const xCapture = preferences.xCapture as Partial<XCapturePreferences> | undefined;
+  const fbCapture = preferences.fbCapture as Partial<FacebookCapturePreferences> | undefined;
+  const ai = preferences.ai as Partial<AIPreferences> | undefined;
+
+  return {
+    ...defaults,
+    ...preferences,
+    weights: {
+      ...defaults.weights,
+      ...weights,
+      platforms: {
+        ...defaults.weights.platforms,
+        ...(weights?.platforms ?? {}),
+      },
+      topics: {
+        ...defaults.weights.topics,
+        ...(weights?.topics ?? {}),
+      },
+      authors: {
+        ...defaults.weights.authors,
+        ...(weights?.authors ?? {}),
+      },
+    },
+    ulysses: {
+      ...defaults.ulysses,
+      ...ulysses,
+      allowedPaths: {
+        ...defaults.ulysses.allowedPaths,
+        ...(ulysses?.allowedPaths ?? {}),
+      },
+    },
+    sync: {
+      ...defaults.sync,
+      ...sync,
+    },
+    display: {
+      ...defaults.display,
+      ...display,
+      reading: {
+        ...defaults.display.reading,
+        ...reading,
+      },
+    },
+    xCapture: {
+      ...defaults.xCapture,
+      ...xCapture,
+      whitelist: {
+        ...defaults.xCapture.whitelist,
+        ...(xCapture?.whitelist ?? {}),
+      },
+      blacklist: {
+        ...defaults.xCapture.blacklist,
+        ...(xCapture?.blacklist ?? {}),
+      },
+    },
+    fbCapture: {
+      ...defaults.fbCapture,
+      ...fbCapture,
+      knownGroups: {
+        ...defaults.fbCapture.knownGroups,
+        ...(fbCapture?.knownGroups ?? {}),
+      },
+      excludedGroupIds: {
+        ...defaults.fbCapture.excludedGroupIds,
+        ...(fbCapture?.excludedGroupIds ?? {}),
+      },
+    },
+    ai: {
+      ...defaults.ai,
+      ...ai,
+    },
+  };
+}
+
 // =============================================================================
 // Google Contacts
 // =============================================================================

--- a/packages/ui/src/components/feed/FeedList.tsx
+++ b/packages/ui/src/components/feed/FeedList.tsx
@@ -2,15 +2,7 @@ import { useRef, memo, useCallback, useEffect, useLayoutEffect, useMemo, useStat
 import { useVirtualizer, useWindowVirtualizer } from "@tanstack/react-virtual";
 import { FeedItem } from "./FeedItem.js";
 import { FeedItemSkeleton } from "./FeedItemSkeleton.js";
-import {
-  collectUnreadIdsFromRows as collectUnreadIdsFromReadRows,
-  getListViewportMetrics,
-  getNewlyPassedRowEnd,
-  getRemainingUnreadIds,
-  hasReachedListBottom,
-  type ReadTrackRow,
-  type VirtualRowRange,
-} from "./read-on-scroll.js";
+import { useReadOnScrollTracker } from "./useReadOnScrollTracker.js";
 import type { FeedItem as FeedItemType } from "@freed/shared";
 import { useAppStore, usePlatform } from "../../context/PlatformContext.js";
 import { useIsMobile } from "../../hooks/useIsMobile.js";
@@ -117,14 +109,6 @@ interface FeedListProps {
   /** The active search query text — used in the empty state message */
   searchQuery?: string;
 }
-
-type ReadScrollVirtualizer = {
-  getVirtualItems: () => VirtualRowRange[];
-  getTotalSize: () => number;
-  options: {
-    scrollMargin?: number;
-  };
-};
 
 /**
  * Memoized per-row adapter. Keeps handler references stable so FeedItem's
@@ -354,87 +338,28 @@ export function FeedList({
     () => JSON.stringify({ activeFilter, searchQuery: searchQuery.trim() }),
     [activeFilter, searchQuery],
   );
-  const maxPassedRowIndexRef = useRef(-1);
-  const listSessionRef = useRef({
-    key: listKey,
-    items,
-    reachedBottom: false,
-  });
-
-  const flushReadIds = useCallback((ids: string[]) => {
-    if (ids.length === 0) return;
-    void markItemsAsRead(ids);
-  }, [markItemsAsRead]);
-
-  const collectUnreadIdsFromRows = useCallback((startIndex: number, endIndex: number) => {
-    return collectUnreadIdsFromReadRows(
-      rows as Array<ReadTrackRow<FeedItemType>>,
-      startIndex,
-      endIndex,
-    );
-  }, [rows]);
-
-  const finalizeListSession = useCallback((session: { items: FeedItemType[]; reachedBottom: boolean }) => {
-    if (!markReadOnScroll || !session.reachedBottom) return;
-    flushReadIds(getRemainingUnreadIds(session.items));
-  }, [flushReadIds, markReadOnScroll]);
-
-  const markRemainingUnreadInSession = useCallback(() => {
-    const session = listSessionRef.current;
-    if (session.reachedBottom) return;
-    session.reachedBottom = true;
-    flushReadIds(getRemainingUnreadIds(session.items));
-  }, [flushReadIds]);
-
-  const processReadOnScroll = useCallback((
-    virtualizer: ReadScrollVirtualizer,
-    scrollSource: "element" | "window",
-  ) => {
-    if (!markReadOnScroll) return;
-
-    const vItems = virtualizer.getVirtualItems();
-    if (vItems.length === 0) return;
-
-    const rawScrollTop = scrollSource === "window"
+  const getReadScrollMetrics = useCallback((scrollSource: "element" | "window", virtualizer: {
+    options?: { scrollMargin?: number };
+  }) => ({
+    rawScrollTop: scrollSource === "window"
       ? window.scrollY
-      : (parentRef.current?.scrollTop ?? 0);
-    const vpHeight = scrollSource === "window"
+      : (parentRef.current?.scrollTop ?? 0),
+    viewportHeight: scrollSource === "window"
       ? window.innerHeight
-      : (parentRef.current?.clientHeight ?? 0);
-    const scrollMargin = scrollSource === "window"
-      ? (virtualizer.options.scrollMargin ?? 0)
-      : 0;
-    const { scrollTop, viewportBottom: vpBottom } = getListViewportMetrics(
-      rawScrollTop,
-      vpHeight,
-      scrollMargin,
-    );
-
-    const newlyPassedEnd = getNewlyPassedRowEnd(
-      vItems,
-      scrollTop,
-      rows.length,
-      maxPassedRowIndexRef.current,
-    );
-    if (newlyPassedEnd !== null) {
-      const unreadIds = collectUnreadIdsFromRows(
-        maxPassedRowIndexRef.current + 1,
-        newlyPassedEnd,
-      );
-      maxPassedRowIndexRef.current = newlyPassedEnd;
-      flushReadIds(unreadIds);
-    }
-
-    if (hasReachedListBottom(rows.length, vpBottom, virtualizer.getTotalSize())) {
-      markRemainingUnreadInSession();
-    }
-  }, [
-    collectUnreadIdsFromRows,
-    flushReadIds,
+      : (parentRef.current?.clientHeight ?? 0),
+    scrollMargin: scrollSource === "window"
+      ? (virtualizer.options?.scrollMargin ?? 0)
+      : 0,
+  }), []);
+  const processReadOnScroll = useReadOnScrollTracker({
+    surface: isMobile ? "mobile-feed" : "primary-feed",
+    listKey,
+    rows,
+    items,
     markReadOnScroll,
-    markRemainingUnreadInSession,
-    rows.length,
-  ]);
+    getScrollMetrics: getReadScrollMetrics,
+    markItemsAsRead,
+  });
 
   const elementVirtualizer = useVirtualizer({
     count: isMobile ? 0 : rows.length,
@@ -507,27 +432,6 @@ export function FeedList({
     itemIndexToRowIndex,
     rows.length,
   ]);
-
-  useEffect(() => {
-    const session = listSessionRef.current;
-    if (session.key !== listKey) {
-      finalizeListSession(session);
-      listSessionRef.current = {
-        key: listKey,
-        items,
-        reachedBottom: false,
-      };
-      maxPassedRowIndexRef.current = -1;
-      return;
-    }
-    session.items = items;
-  }, [finalizeListSession, items, listKey]);
-
-  useEffect(() => {
-    return () => {
-      finalizeListSession(listSessionRef.current);
-    };
-  }, [finalizeListSession]);
 
   // Show shimmer placeholders while the doc is loading from IndexedDB.
   // Once isLoading flips false, items will populate and we drop into the

--- a/packages/ui/src/components/feed/FeedView.tsx
+++ b/packages/ui/src/components/feed/FeedView.tsx
@@ -3,6 +3,7 @@ import { useVirtualizer } from "@tanstack/react-virtual";
 import { FeedList } from "./FeedList.js";
 import { ReaderView } from "./ReaderView.js";
 import { FeedItem as FeedItemCard } from "./FeedItem.js";
+import { useReadOnScrollTracker } from "./useReadOnScrollTracker.js";
 import { AddFeedDialog } from "../AddFeedDialog.js";
 import { useAppStore, usePlatform } from "../../context/PlatformContext.js";
 import { useSearchResults } from "../../hooks/useSearchResults.js";
@@ -32,6 +33,9 @@ interface CompactFeedPanelProps {
   selectedId: string;
   selectionMoveDirection?: -1 | 0 | 1;
   onItemClick: (item: FeedItem) => void;
+  markReadOnScroll: boolean;
+  showReadInGrayscale: boolean;
+  markItemsAsRead: (ids: string[]) => Promise<void>;
   width: number;
   leadingOffset?: string;
 }
@@ -41,6 +45,9 @@ const CompactFeedPanel = memo(function CompactFeedPanel({
   selectedId,
   selectionMoveDirection = 0,
   onItemClick,
+  markReadOnScroll,
+  showReadInGrayscale,
+  markItemsAsRead,
   width,
   leadingOffset,
 }: CompactFeedPanelProps) {
@@ -85,12 +92,37 @@ const CompactFeedPanel = memo(function CompactFeedPanel({
     },
     [items, itemHeight, storyItemHeight],
   );
+  const readRows = useMemo(
+    () => items.map((item) => ({ type: "item" as const, item })),
+    [items],
+  );
+  const readListKey = useMemo(
+    () => items.map((item) => item.globalId).join("|"),
+    [items],
+  );
+  const getReadScrollMetrics = useCallback(() => ({
+    rawScrollTop: parentRef.current?.scrollTop ?? 0,
+    viewportHeight: parentRef.current?.clientHeight ?? 0,
+    scrollMargin: 0,
+  }), []);
+  const processReadOnScroll = useReadOnScrollTracker({
+    surface: "compact-feed",
+    listKey: readListKey,
+    rows: readRows,
+    items,
+    markReadOnScroll,
+    getScrollMetrics: getReadScrollMetrics,
+    markItemsAsRead,
+  });
 
   const virtualizer = useVirtualizer({
     count: items.length,
     getScrollElement: () => parentRef.current,
     estimateSize: estimateItemSize,
     overscan: 3,
+    onChange: (instance) => {
+      processReadOnScroll(instance, "element");
+    },
   });
 
   // Restore scroll after DOM updates with new card sizes (runs before paint).
@@ -194,6 +226,7 @@ const CompactFeedPanel = memo(function CompactFeedPanel({
                   compact
                   narrow={width < NARROW_THRESHOLD}
                   selected={item.globalId === selectedId}
+                  showReadInGrayscale={showReadInGrayscale}
                   onClick={() => onItemClick(item)}
                   storyHeight={item.contentType === "story" ? storyTileH : undefined}
                 />
@@ -267,6 +300,9 @@ export function FeedView() {
   );
 
   const dualColumnMode = useAppStore((s) => s.preferences.display.reading.dualColumnMode);
+  const markReadOnScroll = useAppStore((s) => s.preferences.display.reading.markReadOnScroll);
+  const showReadInGrayscale = useAppStore((s) => s.preferences.display.reading.showReadInGrayscale);
+  const markItemsAsRead = useAppStore((s) => s.markItemsAsRead);
   const isMobileViewport = useIsMobile();
   const isMobileDevice = useIsMobileDevice();
   const autoCollapseReaderRail = !isMobileDevice && isMobileViewport;
@@ -461,6 +497,9 @@ export function FeedView() {
                 selectedId={selectedItem.globalId}
                 selectionMoveDirection={compactSelectionDirection}
                 onItemClick={openItemDirect}
+                markReadOnScroll={markReadOnScroll}
+                showReadInGrayscale={showReadInGrayscale}
+                markItemsAsRead={markItemsAsRead}
                 width={panelWidth}
                 leadingOffset={compactRailLeadingOffset}
               />

--- a/packages/ui/src/components/feed/useReadOnScrollTracker.ts
+++ b/packages/ui/src/components/feed/useReadOnScrollTracker.ts
@@ -1,0 +1,228 @@
+import { useCallback, useEffect, useRef } from "react";
+import { recordBugReportEvent } from "../../lib/bug-report.js";
+import {
+  collectUnreadIdsFromRows,
+  getListViewportMetrics,
+  getNewlyPassedRowEnd,
+  getRemainingUnreadIds,
+  hasReachedListBottom,
+  type ReadTrackRow,
+  type VirtualRowRange,
+} from "./read-on-scroll.js";
+
+type ReadScrollVirtualizer = {
+  getVirtualItems: () => VirtualRowRange[];
+  getTotalSize: () => number;
+  options?: {
+    scrollMargin?: number;
+  };
+};
+
+type ReadScrollMetrics = {
+  rawScrollTop: number;
+  viewportHeight: number;
+  scrollMargin?: number;
+};
+
+type ReadScrollSource = "element" | "window";
+type ReadScrollSurface = "primary-feed" | "mobile-feed" | "compact-feed";
+
+type ReadTrackItem = {
+  globalId: string;
+  userState: {
+    readAt?: number;
+  };
+};
+
+interface ReadListSession<TItem extends ReadTrackItem> {
+  key: string;
+  items: TItem[];
+  reachedBottom: boolean;
+}
+
+interface UseReadOnScrollTrackerOptions<TItem extends ReadTrackItem> {
+  surface: ReadScrollSurface;
+  listKey: string;
+  rows: Array<ReadTrackRow<TItem>>;
+  items: TItem[];
+  markReadOnScroll: boolean;
+  getScrollMetrics: (scrollSource: ReadScrollSource, virtualizer: ReadScrollVirtualizer) => ReadScrollMetrics;
+  markItemsAsRead: (ids: string[]) => Promise<void>;
+}
+
+function formatIdTail(id: string): string {
+  return `...${id.slice(-8)}`;
+}
+
+function recordReadScrollDiagnostic(
+  message: string,
+  detail: Record<string, unknown>,
+): void {
+  recordBugReportEvent(
+    "feed:read-scroll",
+    "info",
+    message,
+    JSON.stringify(detail),
+  );
+}
+
+export function useReadOnScrollTracker<TItem extends ReadTrackItem>({
+  surface,
+  listKey,
+  rows,
+  items,
+  markReadOnScroll,
+  getScrollMetrics,
+  markItemsAsRead,
+}: UseReadOnScrollTrackerOptions<TItem>) {
+  const maxPassedRowIndexRef = useRef(-1);
+  const listSessionRef = useRef<ReadListSession<TItem>>({
+    key: listKey,
+    items,
+    reachedBottom: false,
+  });
+
+  const flushReadIds = useCallback((ids: string[], reason: string) => {
+    if (ids.length === 0) return;
+
+    const startedAt = performance.now();
+    recordReadScrollDiagnostic(
+      `Queued ${ids.length.toLocaleString()} read mark${ids.length === 1 ? "" : "s"}`,
+      {
+        surface,
+        reason,
+        queuedCount: ids.length,
+        itemIdTails: ids.slice(0, 5).map(formatIdTail),
+      },
+    );
+
+    void markItemsAsRead(ids)
+      .then(() => {
+        recordReadScrollDiagnostic(
+          `Flushed ${ids.length.toLocaleString()} read mark${ids.length === 1 ? "" : "s"}`,
+          {
+            surface,
+            reason,
+            batchCount: ids.length,
+            durationMs: Math.round(performance.now() - startedAt),
+            itemIdTails: ids.slice(0, 5).map(formatIdTail),
+          },
+        );
+      })
+      .catch((error: unknown) => {
+        recordBugReportEvent(
+          "feed:read-scroll",
+          "error",
+          `Failed to flush ${ids.length.toLocaleString()} read mark${ids.length === 1 ? "" : "s"}`,
+          error instanceof Error ? error.message : String(error),
+        );
+      });
+  }, [markItemsAsRead, surface]);
+
+  const collectUnreadIdsFromVisibleRows = useCallback((startIndex: number, endIndex: number) => {
+    return collectUnreadIdsFromRows(rows, startIndex, endIndex);
+  }, [rows]);
+
+  const finalizeListSession = useCallback((session: ReadListSession<TItem>) => {
+    if (!markReadOnScroll || !session.reachedBottom) return;
+    flushReadIds(getRemainingUnreadIds(session.items), "session-finalize");
+  }, [flushReadIds, markReadOnScroll]);
+
+  const markRemainingUnreadInSession = useCallback(() => {
+    const session = listSessionRef.current;
+    if (session.reachedBottom) return;
+    session.reachedBottom = true;
+    flushReadIds(getRemainingUnreadIds(session.items), "list-bottom");
+  }, [flushReadIds]);
+
+  const processReadOnScroll = useCallback((
+    virtualizer: ReadScrollVirtualizer,
+    scrollSource: ReadScrollSource,
+  ) => {
+    if (!markReadOnScroll) return;
+
+    const vItems = virtualizer.getVirtualItems();
+    if (vItems.length === 0) return;
+
+    const rawMetrics = getScrollMetrics(scrollSource, virtualizer);
+    const { scrollTop, viewportBottom } = getListViewportMetrics(
+      rawMetrics.rawScrollTop,
+      rawMetrics.viewportHeight,
+      rawMetrics.scrollMargin ?? virtualizer.options?.scrollMargin ?? 0,
+    );
+
+    const previousPassedRowIndex = maxPassedRowIndexRef.current;
+    const newlyPassedEnd = getNewlyPassedRowEnd(
+      vItems,
+      scrollTop,
+      rows.length,
+      previousPassedRowIndex,
+    );
+
+    if (newlyPassedEnd !== null) {
+      const unreadIds = collectUnreadIdsFromVisibleRows(
+        previousPassedRowIndex + 1,
+        newlyPassedEnd,
+      );
+      maxPassedRowIndexRef.current = newlyPassedEnd;
+      recordReadScrollDiagnostic("Processed read-on-scroll boundary", {
+        surface,
+        scrollSource,
+        rowCount: rows.length,
+        scrollTop: Math.round(scrollTop),
+        viewportHeight: Math.round(rawMetrics.viewportHeight),
+        totalSize: Math.round(virtualizer.getTotalSize()),
+        firstVirtualRowIndex: vItems[0]?.index ?? null,
+        firstVirtualRowEnd: Math.round(vItems[0]?.end ?? 0),
+        previousPassedRowIndex,
+        newlyPassedRowIndex: newlyPassedEnd,
+        unreadCandidateCount: unreadIds.length,
+        markReadOnScroll,
+      });
+      flushReadIds(unreadIds, "passed-rows");
+    }
+
+    if (hasReachedListBottom(rows.length, viewportBottom, virtualizer.getTotalSize())) {
+      recordReadScrollDiagnostic("Reached read-on-scroll list bottom", {
+        surface,
+        scrollSource,
+        rowCount: rows.length,
+        viewportBottom: Math.round(viewportBottom),
+        totalSize: Math.round(virtualizer.getTotalSize()),
+        markReadOnScroll,
+      });
+      markRemainingUnreadInSession();
+    }
+  }, [
+    collectUnreadIdsFromVisibleRows,
+    flushReadIds,
+    getScrollMetrics,
+    markReadOnScroll,
+    markRemainingUnreadInSession,
+    rows.length,
+    surface,
+  ]);
+
+  useEffect(() => {
+    const session = listSessionRef.current;
+    if (session.key !== listKey) {
+      finalizeListSession(session);
+      listSessionRef.current = {
+        key: listKey,
+        items,
+        reachedBottom: false,
+      };
+      maxPassedRowIndexRef.current = -1;
+      return;
+    }
+    session.items = items;
+  }, [finalizeListSession, items, listKey]);
+
+  useEffect(() => {
+    return () => {
+      finalizeListSession(listSessionRef.current);
+    };
+  }, [finalizeListSession]);
+
+  return processReadOnScroll;
+}


### PR DESCRIPTION
(AI Generated).

## Summary
- Marks scrolled-past items read across the primary feed and compact reader rail, restores reading defaults for legacy documents, and records read-scroll diagnostics in bug reports.

## Testing
- npm run validate:feature