### PR TITLE
fix: add cloud sync nudge countdown

### DIFF
--- a/docs/PHASE-4-SYNC.md
+++ b/docs/PHASE-4-SYNC.md
@@ -3,7 +3,7 @@
 > **Status:** 🚧 In Progress
 > **Dependencies:** Phase 1-2 (Capture layers ✓)
 >
-> Local relay, GDrive/Dropbox cloud sync, desktop local snapshot rotation, "Sync Now" button, "Last synced" indicator, server-proxied Google token exchange, durable Google OAuth refresh, appDataFolder Drive polling, and cloud sync health diagnostics are all working. iCloud sync is the remaining open item.
+> Local relay, GDrive/Dropbox cloud sync, desktop local snapshot rotation, "Sync Now" button, "Last synced" indicator, server-proxied Google token exchange, durable Google OAuth refresh, appDataFolder Drive polling, cloud sync health diagnostics, and the no-cloud-sync launch banner are all working. iCloud sync is the remaining open item.
 
 ---
 
@@ -293,6 +293,7 @@ Each provider stores a single Automerge binary file. CRDT handles merge conflict
 - [x] Google Drive uses server-proxied Google token exchange when a web OAuth client is configured, watches appDataFolder changes, and refreshes stored OAuth credentials before Drive or Contacts calls
 - [x] At least one cloud provider works: GDrive and Dropbox both confirmed working on app.freed.wtf
 - [x] Desktop surfaces cloud sync health with retry/reconnect actions, recent failures, and debug charts
+- [x] Desktop no-cloud-sync launch banner self-dismisses after 15 seconds with a gentle countdown ring
 - [x] Desktop writes rotating local snapshots and can restore an older Automerge copy from Settings
 - [ ] iCloud sync integration
 

--- a/packages/desktop/src/components/CloudSyncNudge.tsx
+++ b/packages/desktop/src/components/CloudSyncNudge.tsx
@@ -1,5 +1,5 @@
 /**
- * CloudSyncNudge — session-persistent toast that appears whenever no cloud
+ * CloudSyncNudge, session-persistent toast that appears whenever no cloud
  * provider is connected.
  *
  * Shown on every app launch until the user connects at least one provider.
@@ -8,8 +8,10 @@
  * Settings dialog pre-scrolled to the Sync section.
  */
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import { getCloudToken } from "../lib/sync";
+
+const AUTO_DISMISS_MS = 15_000;
 
 /** Returns true when at least one cloud provider has a stored token. */
 export function hasAnyCloudProvider(): boolean {
@@ -26,24 +28,38 @@ export function CloudSyncNudge() {
     );
   }, []);
 
+  useEffect(() => {
+    const timer = window.setTimeout(() => setDismissed(true), AUTO_DISMISS_MS);
+    return () => window.clearTimeout(timer);
+  }, []);
+
   if (dismissed || hasAnyCloudProvider()) return null;
 
   return (
     <div className="fixed bottom-4 left-1/2 z-40 flex w-[calc(100%-2rem)] max-w-sm -translate-x-1/2 items-center gap-3 rounded-xl border border-[var(--theme-border-subtle)] bg-[color-mix(in_oklab,var(--theme-bg-surface)_92%,transparent)] px-4 py-3 text-sm shadow-[var(--theme-header-shadow)] backdrop-blur-sm">
-      {/* Cloud icon */}
-      <svg
-        className="h-4 w-4 flex-shrink-0 text-[var(--theme-accent-secondary)]"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
-      >
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth={1.5}
-          d="M3 15a4 4 0 004 4h9a5 5 0 10-.1-9.999 5.002 5.002 0 10-9.78 2.096A4.001 4.001 0 003 15z"
-        />
-      </svg>
+      <span className="relative flex h-8 w-8 flex-shrink-0 items-center justify-center text-[var(--theme-accent-secondary)]">
+        <svg className="h-8 w-8" fill="none" viewBox="0 0 36 36" aria-hidden="true">
+          <path
+            className="cloud-sync-nudge-countdown"
+            d="M18 2.75a15.25 15.25 0 1 1 0 30.5a15.25 15.25 0 1 1 0-30.5"
+            pathLength={1}
+          />
+        </svg>
+        <svg
+          className="absolute h-4 w-4"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={1.5}
+            d="M3 15a4 4 0 004 4h9a5 5 0 10-.1-9.999 5.002 5.002 0 10-9.78 2.096A4.001 4.001 0 003 15z"
+          />
+        </svg>
+      </span>
 
       <p className="flex-1 leading-snug text-[var(--theme-text-secondary)]">
         No cloud sync, your feed won't reach mobile.

--- a/packages/desktop/src/index.css
+++ b/packages/desktop/src/index.css
@@ -1,6 +1,6 @@
 @import url("https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&display=swap");
 
-/* Shared design system — design tokens + all component classes.
+/* Shared design system, design tokens plus all component classes.
    Must precede @tailwind directives; @import after any non-import rule
    is invalid CSS and silently ignored by browsers. */
 @import "../../ui/src/index.css";
@@ -34,4 +34,30 @@ body {
   height: 100%;
   overflow: hidden;
   background: color-mix(in oklab, var(--theme-bg-root) 78%, transparent);
+}
+
+.cloud-sync-nudge-countdown {
+  animation: cloud-sync-nudge-countdown 15s linear forwards;
+  opacity: 0.65;
+  stroke: currentColor;
+  stroke-dasharray: 1;
+  stroke-dashoffset: 0;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 2.25;
+  vector-effect: non-scaling-stroke;
+}
+
+@keyframes cloud-sync-nudge-countdown {
+  to {
+    stroke-dashoffset: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cloud-sync-nudge-countdown {
+    animation: none;
+    opacity: 0.45;
+    stroke-dashoffset: 0.25;
+  }
 }

--- a/packages/desktop/tests/e2e/cloud-sync-nudge.spec.ts
+++ b/packages/desktop/tests/e2e/cloud-sync-nudge.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from "./fixtures/app";
+
+test("cloud sync nudge shows a countdown and closes after fifteen seconds", async ({ app }) => {
+  await app.page.clock.install({ time: new Date("2026-04-30T12:00:00Z") });
+
+  await app.goto();
+  await app.waitForReady();
+
+  const nudge = app.page.getByText("No cloud sync, your feed won't reach mobile.");
+  await expect(nudge).toBeVisible();
+
+  const countdown = app.page.locator(".cloud-sync-nudge-countdown");
+  await expect(countdown).toHaveCount(1);
+
+  await app.page.clock.fastForward(14_000);
+  await expect(nudge).toBeVisible();
+
+  await app.page.clock.fastForward(1_000);
+  await expect(nudge).toBeHidden();
+});

--- a/website/src/app/roadmap/RoadmapContent.tsx
+++ b/website/src/app/roadmap/RoadmapContent.tsx
@@ -728,7 +728,7 @@ const phases: Phase[] = [
     number: 4,
     title: "Sync Layer",
     description:
-      "Local relay and GDrive/Dropbox sync are working, with server-proxied Google token exchange, appDataFolder Drive polling, durable Google OAuth refresh, cloud health diagnostics, retry and reconnect actions, debug charts, and desktop snapshot restore. iCloud remains the open item.",
+      "Local relay and GDrive/Dropbox sync are working, with server-proxied Google token exchange, appDataFolder Drive polling, durable Google OAuth refresh, cloud health diagnostics, retry and reconnect actions, debug charts, the timed no-cloud-sync launch banner, and desktop snapshot restore. iCloud remains the open item.",
     status: "current",
     planLink:
       "https://github.com/freed-project/freed/blob/dev/docs/PHASE-4-SYNC.md",


### PR DESCRIPTION
(AI Generated).

## Summary
- Enlarges the desktop no-cloud-sync countdown mark so it frames the cloud icon instead of overlapping it.
- Auto-dismisses the banner after 15 seconds while keeping manual dismiss and setup actions intact.
- Updates Phase 4 sync docs and roadmap copy for the timed banner behavior.

## Testing
- Focused desktop E2E: PATH=<worktree>/node_modules/.bin:$PATH npm run test:e2e with cloud-sync-nudge.spec.ts
- Feature validation: npm run validate:feature