### PR TITLE
fix: polish narrow reader rail

### DIFF
--- a/packages/desktop/tests/e2e/reader-hydration.spec.ts
+++ b/packages/desktop/tests/e2e/reader-hydration.spec.ts
@@ -414,7 +414,80 @@ test("Instagram reader hydration renders post comments inside Freed", async ({ a
   await expect(app.page.locator(`img[src="${IG_REPLY_MEDIA}"]`)).toBeVisible();
 });
 
-test("Facebook and Instagram stories show that story replies stay private", async ({ app }) => {
+test("narrow desktop reader keeps rail gutters even and open action furthest right", async ({ app }) => {
+  await app.page.setViewportSize({ width: 700, height: 900 });
+  await app.goto();
+  await app.waitForReady();
+  await injectItems(app.page);
+
+  const feedCard = app.page.locator('[data-feed-item-id="rss:reader-hydration"]');
+  await expect(feedCard).toBeVisible();
+
+  await expect.poll(async () =>
+    app.page.evaluate(() => {
+      const main = document.querySelector("main") as HTMLElement | null;
+      const card = document.querySelector('[data-feed-item-id="rss:reader-hydration"]') as HTMLElement | null;
+      if (!main || !card) return null;
+
+      const feedCardGap = parseFloat(window.getComputedStyle(document.documentElement).getPropertyValue("--feed-card-gap"));
+      const mainRect = main.getBoundingClientRect();
+      const cardRect = card.getBoundingClientRect();
+      return {
+        left: Math.round(cardRect.left - mainRect.left),
+        right: Math.round(mainRect.right - cardRect.right),
+        expected: Math.round(feedCardGap),
+      };
+    }),
+  ).toMatchObject({ left: 8, right: 8, expected: 8 });
+
+  await app.page.evaluate(() => {
+    const store = (window as Record<string, unknown>).__FREED_STORE__ as {
+      getState: () => { setSelectedItem: (id: string) => void };
+    };
+    store.getState().setSelectedItem("fb:story-cached");
+  });
+
+  await expect(app.page.getByTestId("reader-article")).toBeVisible();
+  await expect(app.page.getByRole("button", { name: "Open", exact: true })).toBeVisible();
+
+  await expect.poll(async () =>
+    app.page.evaluate(() => {
+      const article = document.querySelector('[data-testid="reader-article"]') as HTMLElement | null;
+      const storyMedia = document.querySelector('img[src="https://scontent.example/story.jpg"]') as HTMLElement | null;
+      const toolbar = document.querySelector('[data-testid="workspace-toolbar"]') as HTMLElement | null;
+      const openButton = toolbar?.querySelector('[aria-label="Open"]') as HTMLElement | null;
+      const overflowButton = toolbar?.querySelector('[aria-label="More actions"]') as HTMLElement | null;
+      if (!article || !storyMedia || !toolbar || !openButton || !overflowButton) return null;
+
+      const feedCardGap = parseFloat(window.getComputedStyle(document.documentElement).getPropertyValue("--feed-card-gap"));
+      const articleRect = article.getBoundingClientRect();
+      const mediaRect = storyMedia.getBoundingClientRect();
+      const openRect = openButton.getBoundingClientRect();
+      const overflowRect = overflowButton.getBoundingClientRect();
+      return {
+        readerLeft: Math.round(mediaRect.left - articleRect.left),
+        readerRight: Math.round(articleRect.right - mediaRect.right),
+        expected: Math.round(feedCardGap),
+        openAfterOverflow: openRect.left >= overflowRect.right,
+        openRightmost: openRect.right >= overflowRect.right,
+        openHeight: Math.round(openRect.height),
+        overflowHeight: Math.round(overflowRect.height),
+        openTop: Math.round(openRect.top),
+        overflowTop: Math.round(overflowRect.top),
+      };
+    }),
+  ).toMatchObject({
+    readerLeft: 8,
+    readerRight: 8,
+    expected: 8,
+    openAfterOverflow: true,
+    openRightmost: true,
+    openHeight: 40,
+    overflowHeight: 40,
+  });
+});
+
+test("Facebook and Instagram stories show that story replies stay private", async ({ app, ipc }) => {
   await app.goto();
   await app.waitForReady();
   await injectItems(app.page);
@@ -427,6 +500,10 @@ test("Facebook and Instagram stories show that story replies stay private", asyn
   });
 
   await expect(app.page.getByText(STORY_REPLY_MESSAGE)).toBeVisible();
+  await app.page.getByRole("button", { name: "Open the story" }).click();
+  await expect.poll(async () => (await ipc.openedUrls()).at(-1)).toBe(
+    "https://www.facebook.com/stories/fb_story/123",
+  );
   await expect(app.page.getByText("Connect to the internet")).toHaveCount(0);
 
   await app.page.evaluate(() => {
@@ -437,5 +514,9 @@ test("Facebook and Instagram stories show that story replies stay private", asyn
   });
 
   await expect(app.page.getByText(STORY_REPLY_MESSAGE)).toBeVisible();
+  await app.page.getByRole("button", { name: "Open the story" }).click();
+  await expect.poll(async () => (await ipc.openedUrls()).at(-1)).toBe(
+    "https://www.instagram.com/stories/ig_story/123",
+  );
   await expect(app.page.getByText("Connect to the internet")).toHaveCount(0);
 });

--- a/packages/ui/src/components/feed/FeedList.tsx
+++ b/packages/ui/src/components/feed/FeedList.tsx
@@ -552,7 +552,7 @@ export function FeedList({
                 }}
               >
                 <div
-                  className="max-w-2xl mx-auto"
+                  className="mx-auto w-full max-w-2xl max-[959px]:max-w-none"
                   style={{
                     paddingInline: `${FEED_CARD_GAP}px`,
                     paddingBottom: `${FEED_CARD_GAP}px`,
@@ -629,7 +629,7 @@ export function FeedList({
               }}
             >
               <div
-                className="max-w-2xl mx-auto"
+                className="mx-auto w-full max-w-2xl max-[959px]:max-w-none"
                 style={{
                   paddingInline: `${feedCardHorizontalGutter}px`,
                   paddingBottom: `${FEED_CARD_GAP}px`,

--- a/packages/ui/src/components/feed/ReaderView.tsx
+++ b/packages/ui/src/components/feed/ReaderView.tsx
@@ -200,6 +200,7 @@ const HEADING_CLASSES: Record<number, string> = {
 };
 
 const noDrag = { WebkitAppRegion: "no-drag" } as React.CSSProperties;
+const STORY_REPLY_MESSAGE = "Story replies are private on this platform. Open the story to reply there.";
 
 export function ReaderView({ item, onClose, dualColumn = false, inline = false, onOpenUrl }: ReaderViewProps) {
   const {
@@ -248,6 +249,11 @@ export function ReaderView({ item, onClose, dualColumn = false, inline = false, 
   const displayMediaUrls = readerMediaUrls ?? item.content.mediaUrls;
   const displayMediaTypes = readerMediaTypes ?? item.content.mediaTypes;
   const isStory = item.contentType === "story";
+  const canOpenSource = Boolean(onOpenUrl && item.sourceUrl);
+  const handleOpenSource = useCallback(() => {
+    if (!onOpenUrl || !item.sourceUrl) return;
+    onOpenUrl(item.sourceUrl);
+  }, [item.sourceUrl, onOpenUrl]);
   const supportsThreadHydration =
     !isStory &&
     (item.platform === "x" || item.platform === "facebook" || item.platform === "instagram");
@@ -643,7 +649,10 @@ export function ReaderView({ item, onClose, dualColumn = false, inline = false, 
       )}
 
       {/* Article content */}
-      <article className="max-w-3xl mx-auto px-4 sm:px-6 py-6 sm:py-8">
+      <article
+        data-testid="reader-article"
+        className="mx-auto w-full max-w-3xl max-[959px]:max-w-none px-[var(--feed-card-gap,8px)] py-6 sm:py-8 min-[960px]:px-6"
+      >
         {/* Meta */}
         <div className="mb-6">
           <div className="mb-4 flex flex-wrap items-center gap-3 text-sm text-[var(--theme-text-muted)]">
@@ -698,7 +707,21 @@ export function ReaderView({ item, onClose, dualColumn = false, inline = false, 
                 : "border-[var(--theme-border-subtle)] bg-[var(--theme-bg-muted)] text-[var(--theme-text-secondary)]"
             }`}
           >
-            {hydrationMessage}
+            {hydrationMessage === STORY_REPLY_MESSAGE && canOpenSource ? (
+              <>
+                Story replies are private on this platform.{" "}
+                <button
+                  type="button"
+                  onClick={handleOpenSource}
+                  className="font-medium text-[var(--theme-accent-secondary)] underline decoration-[color:rgb(var(--theme-accent-secondary-rgb)/0.4)] underline-offset-2 transition-colors hover:text-[var(--theme-text-primary)]"
+                >
+                  Open the story
+                </button>{" "}
+                to reply there.
+              </>
+            ) : (
+              hydrationMessage
+            )}
           </div>
         )}
 

--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -386,6 +386,12 @@ export function Header({
     showFeedSignalFilter && !showCollapsedToolbarFilterMenu;
   const showInlineReaderBookmark =
     !!selectedItem && !isBelowReaderBookmarkToolbar;
+  const collapsedReaderTitlePaddingClass = selectedItem?.sourceUrl
+    ? showInlineReaderBookmark ? "pr-[11rem]" : "pr-[8.5rem]"
+    : showInlineReaderBookmark ? "pr-[6.5rem]" : "pr-14";
+  const collapsedReaderActionWidthClass = selectedItem?.sourceUrl
+    ? showInlineReaderBookmark ? "w-[11rem]" : "w-[8.5rem]"
+    : showInlineReaderBookmark ? "w-[6.5rem]" : "w-14";
 
   const filteredUnreadItemIds = useMemo(
     () => filteredItems
@@ -770,19 +776,6 @@ export function Header({
               aria-hidden="true"
             >
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
-            </svg>
-          ),
-        });
-      }
-
-      if (selectedItem.sourceUrl) {
-        actions.push({
-          id: "open",
-          label: "Open",
-          onClick: handleOpenReaderUrl,
-          icon: (
-            <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14 5h5m0 0v5m0-5L10 14M5 9v10h10" />
             </svg>
           ),
         });
@@ -1426,7 +1419,7 @@ export function Header({
           </div>
 
           <div
-            className={`min-w-0 basis-0 flex-1 overflow-hidden ${selectedItem && isBelowLargeToolbar ? "pr-14" : ""}`}
+            className={`min-w-0 basis-0 flex-1 overflow-hidden ${selectedItem && isBelowLargeToolbar ? collapsedReaderTitlePaddingClass : ""}`}
             {...(headerDragRegion ? { "data-tauri-drag-region": true, style: dragStyle } : {})}
           >
             {selectedItem ? (
@@ -1489,7 +1482,7 @@ export function Header({
           <div
             className={selectedItem
               ? isBelowLargeToolbar
-                ? `theme-toolbar-cluster theme-toolbar-cluster-tight absolute right-0 top-1/2 z-10 flex shrink-0 -translate-y-1/2 items-center justify-end pr-2 ${showInlineReaderBookmark ? "w-[6.5rem]" : "w-14"}`
+                ? `theme-toolbar-cluster theme-toolbar-cluster-tight absolute right-0 top-1/2 z-10 flex shrink-0 -translate-y-1/2 items-center justify-end pr-2 ${collapsedReaderActionWidthClass}`
                 : "theme-toolbar-cluster theme-toolbar-cluster-tight ml-auto flex min-w-max shrink-0 items-center pr-2"
               : "theme-toolbar-cluster theme-toolbar-cluster-tight flex min-w-max shrink-0 items-center pr-2 sm:pr-2.5"}
           >
@@ -1575,22 +1568,6 @@ export function Header({
                   ) : null}
                 </ToolbarAnimatedSlot>
 
-                {selectedItem.sourceUrl && !isBelowLargeToolbar ? (
-                  <ToolbarAnimatedSlot visible={true} width="4.5rem" className="hidden lg:flex">
-                    <button
-                      onClick={handleOpenReaderUrl}
-                      {...getToolbarControlProps()}
-                      className="theme-toolbar-button-neutral inline-flex items-center gap-1.5 rounded-lg px-2.5 py-2 text-sm"
-                      aria-label="Open"
-                    >
-                      <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14 5h5m0 0v5m0-5L10 14M5 9v10h10" />
-                      </svg>
-                      <span className="hidden lg:inline">Open</span>
-                    </button>
-                  </ToolbarAnimatedSlot>
-                ) : null}
-
                 <ToolbarAnimatedSlot visible={!isBelowLargeToolbar} width="2.5rem" className="hidden lg:flex">
                   {!isBelowLargeToolbar ? (
                   <Tooltip label={selectedItem.userState.archived ? "Unarchive" : "Archive"}>
@@ -1609,6 +1586,22 @@ export function Header({
                   </Tooltip>
                   ) : null}
                 </ToolbarAnimatedSlot>
+
+                {selectedItem.sourceUrl ? (
+                  <ToolbarAnimatedSlot visible={true} width="4.5rem" style={{ order: 99 }}>
+                    <button
+                      onClick={handleOpenReaderUrl}
+                      {...getToolbarControlProps({ width: "4.5rem" })}
+                      className="theme-toolbar-button-neutral inline-flex h-10 items-center justify-center gap-1.5 rounded-lg px-2.5 py-0 text-sm"
+                      aria-label="Open"
+                    >
+                      <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14 5h5m0 0v5m0-5L10 14M5 9v10h10" />
+                      </svg>
+                      <span>Open</span>
+                    </button>
+                  </ToolbarAnimatedSlot>
+                ) : null}
               </>
             ) : (
               <>


### PR DESCRIPTION
(AI Generated).

## Summary
- Match narrow feed and reader rail gutters to the feed card gap.
- Keep reader Open visible as the rightmost toolbar action and make story reply text open the source story.

## Testing
- PATH=<worktree>/node_modules/.bin:$PATH npm run test:e2e -- reader-hydration.spec.ts
- PATH=<worktree>/node_modules/.bin:$PATH npm run test:e2e -- smoke.spec.ts --grep "narrow desktop reader mode|dual-column reader toolbar toggles|narrow reader toolbar"
- PATH=<worktree>/node_modules/.bin:$PATH npm run validate:feature