### PR TITLE
fix: tune provider sidebar spacing

### DIFF
--- a/packages/desktop/tests/e2e/provider-health.spec.ts
+++ b/packages/desktop/tests/e2e/provider-health.spec.ts
@@ -2105,6 +2105,96 @@ test("source rows swap counts for an actions menu on hover", async ({ app, page 
   await expect(page.getByText("X / Twitter").first()).toBeVisible();
 });
 
+test("full detail provider rows expand highlights without moving counts", async ({ app, page }) => {
+  await seedAcceptedDesktopConsent(page);
+
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await app.goto();
+  await app.waitForReady();
+
+  await page.evaluate(() => {
+    const w = window as Record<string, unknown>;
+    const store = w.__FREED_STORE__ as {
+      getState: () => {
+        preferences: {
+          display: {
+            sidebarMode?: string;
+            sidebarWidth?: number;
+          };
+        };
+      };
+      setState: (partial: Record<string, unknown>) => void;
+    };
+    const current = store.getState();
+
+    store.setState({
+      preferences: {
+        ...current.preferences,
+        display: {
+          ...current.preferences.display,
+          sidebarMode: "expanded",
+          sidebarWidth: 256,
+        },
+      },
+      xAuth: {
+        isAuthenticated: true,
+        cookies: { ct0: "ct0", authToken: "token" },
+      },
+      unreadCountByPlatform: {
+        x: 45,
+      },
+      itemCountByPlatform: {
+        x: 350,
+      },
+    });
+  });
+
+  const sidebar = getDesktopSidebar(page);
+  await expect(sidebar.getByTestId("source-counts-x")).toContainText("45/350");
+
+  const layout = await page.evaluate(() => {
+    const sidebarElement = document.querySelector('[data-testid="app-sidebar"]');
+    const sourceRow = sidebarElement?.querySelector('[data-testid="source-row-x"]') as HTMLElement | null;
+    const savedRow = Array.from(sidebarElement?.querySelectorAll("button") ?? []).find((button) =>
+      button.textContent?.trim().startsWith("Saved")
+    ) as HTMLElement | undefined;
+    const rowShell = sourceRow?.parentElement as HTMLElement | null;
+    const sourceIcon = sourceRow?.querySelector("span.relative") as HTMLElement | null;
+    const savedIcon = savedRow?.querySelector("span.relative") as HTMLElement | null;
+    const count = sidebarElement?.querySelector('[data-testid="source-counts-x"]') as HTMLElement | null;
+    const actionSlot = rowShell?.querySelector(".relative.self-stretch.shrink-0") as HTMLElement | null;
+    const trigger = sidebarElement?.querySelector('[data-testid="source-menu-trigger-x"]') as HTMLElement | null;
+
+    if (!sourceRow || !savedRow || !rowShell || !sourceIcon || !savedIcon || !count || !actionSlot || !trigger) {
+      return null;
+    }
+
+    const rowRect = rowShell.getBoundingClientRect();
+    const sourceRowRect = sourceRow.getBoundingClientRect();
+    const sourceIconRect = sourceIcon.getBoundingClientRect();
+    const savedIconRect = savedIcon.getBoundingClientRect();
+    const countRect = count.getBoundingClientRect();
+    const actionSlotRect = actionSlot.getBoundingClientRect();
+    const triggerRect = trigger.getBoundingClientRect();
+
+    return {
+      highlightLeftPad: sourceRowRect.left - rowRect.left,
+      highlightRightPad: rowRect.right - countRect.right,
+      countSlotRightDelta: Math.abs(actionSlotRect.right - countRect.right),
+      socialIconShiftLeft: savedIconRect.left - sourceIconRect.left,
+      triggerWidth: triggerRect.width,
+      triggerHeight: triggerRect.height,
+    };
+  });
+
+  expect(layout).not.toBeNull();
+  expect(layout!.highlightLeftPad).toBeGreaterThanOrEqual(5);
+  expect(layout!.highlightRightPad).toBeGreaterThanOrEqual(7);
+  expect(layout!.countSlotRightDelta).toBeLessThanOrEqual(1);
+  expect(layout!.socialIconShiftLeft).toBeGreaterThanOrEqual(1);
+  expect(Math.abs(layout!.triggerWidth - layout!.triggerHeight)).toBeLessThanOrEqual(1);
+});
+
 test("narrow labeled provider rows keep labels readable and source menus available", async ({ app, page }) => {
   await seedAcceptedDesktopConsent(page);
 
@@ -2156,7 +2246,9 @@ test("narrow labeled provider rows keep labels readable and source menus availab
     return ids.map((id) => {
       const row = sidebar.querySelector(`[data-testid="source-row-${id}"]`) as HTMLElement | null;
       const label = row?.querySelector("span.min-w-0") as HTMLElement | null;
-      const actionSlot = row?.parentElement?.querySelector(".relative.h-6.shrink-0") as HTMLElement | null;
+      const actionSlot = row?.parentElement?.querySelector(
+        ".relative.self-stretch.shrink-0, .relative.h-6.shrink-0",
+      ) as HTMLElement | null;
       if (!row || !label || !actionSlot) {
         return {
           id,
@@ -2190,6 +2282,15 @@ test("narrow labeled provider rows keep labels readable and source menus availab
 
   await xRow.hover();
   await expect(xTrigger).toHaveClass(/opacity-100/);
+
+  const narrowTriggerLayout = await xTrigger.evaluate((element) => {
+    const rect = element.getBoundingClientRect();
+    return {
+      width: rect.width,
+      height: rect.height,
+    };
+  });
+  expect(narrowTriggerLayout.height - narrowTriggerLayout.width).toBeGreaterThanOrEqual(2);
 
   await xTrigger.click();
   await expect(page.getByTestId("source-context-menu-x")).toBeVisible();

--- a/packages/ui/src/components/layout/Sidebar.tsx
+++ b/packages/ui/src/components/layout/Sidebar.tsx
@@ -906,6 +906,17 @@ export function Sidebar({
     source.id === "facebook" ||
     source.id === "instagram" ||
     source.id === "linkedin";
+  const isSocialSource = (source: SourceNavigationItem) =>
+    source.id === "x" ||
+    source.id === "facebook" ||
+    source.id === "instagram" ||
+    source.id === "linkedin";
+  const providerRowShellClass = rowCountsVisible ? "-mx-1.5 px-1.5" : "";
+  const providerRowLeadingPaddingClass = (source: SourceNavigationItem) =>
+    rowCountsVisible && isSocialSource(source) ? "pl-1" : rowLeadingPaddingClass;
+  const sourceMenuTriggerBaseClass = rowCountsVisible
+    ? "absolute right-0 top-1/2 flex h-6 w-6 -translate-y-1/2 items-center justify-center rounded-md transition-all duration-200 ease-in-out hover:text-[color:var(--theme-text-primary)] hover:bg-[color:var(--theme-bg-muted)]"
+    : "absolute top-[-1px] bottom-[-1px] right-0 flex items-center justify-center rounded-md px-1 transition-all duration-200 ease-in-out hover:text-[color:var(--theme-text-primary)] hover:bg-[color:var(--theme-bg-muted)]";
   const sourceActionSlotClass = (source: SourceNavigationItem) => {
     if (rowCountsVisible) return "ml-1.5 w-[54px]";
     if (!sourceMenusVisible || !canShowSourceMenu(source)) return "ml-0 w-0";
@@ -1352,10 +1363,10 @@ export function Sidebar({
                     <li key={sourceKey(source)} className={sourceOrderClass(source)}>
                       <div className="space-y-1">
                         <div
-                          className={`group/source rounded-lg border transition-all ${
-                          isTopSourceActive(source)
-                            ? "border-[color:var(--theme-border-strong)] bg-[rgb(var(--theme-accent-secondary-rgb)/0.18)] text-[color:var(--theme-text-primary)]"
-                            : "border-transparent text-[color:var(--theme-text-secondary)] hover:bg-[color:var(--theme-bg-muted)] hover:text-[color:var(--theme-text-primary)]"
+                          className={`group/source rounded-lg border transition-all ${providerRowShellClass} ${
+                            isTopSourceActive(source)
+                              ? "border-[color:var(--theme-border-strong)] bg-[rgb(var(--theme-accent-secondary-rgb)/0.18)] text-[color:var(--theme-text-primary)]"
+                              : "border-transparent text-[color:var(--theme-text-secondary)] hover:bg-[color:var(--theme-bg-muted)] hover:text-[color:var(--theme-text-primary)]"
                           }`}
                         >
                           <div className="flex items-stretch gap-2">
@@ -1371,7 +1382,7 @@ export function Sidebar({
                             role="button"
                             tabIndex={0}
                             className={`
-                              flex min-w-0 flex-1 cursor-pointer items-center gap-1.5 ${rowLeadingPaddingClass} ${rowVerticalPaddingClass} outline-none
+                              flex min-w-0 flex-1 cursor-pointer items-center gap-1.5 ${providerRowLeadingPaddingClass(source)} ${rowVerticalPaddingClass} outline-none
                               ${
                                 isTopSourceActive(source)
                                   ? "text-[color:var(--theme-text-primary)]"
@@ -1465,7 +1476,7 @@ export function Sidebar({
                                       setSourceMenuAnchorElement(e.currentTarget);
                                     }
                                   }}
-                                  className={`absolute top-[-1px] bottom-[-1px] right-0 flex items-center justify-center rounded-md px-1 transition-all duration-200 ease-in-out hover:text-[color:var(--theme-text-primary)] hover:bg-[color:var(--theme-bg-muted)] ${
+                                  className={`${sourceMenuTriggerBaseClass} ${
                                     openMenuSourceKey === sourceKey(source)
                                       ? "translate-x-0 bg-[color:var(--theme-bg-muted)] text-[color:var(--theme-text-primary)] opacity-100"
                                       : "pointer-events-none translate-x-[-4px] text-[color:var(--theme-text-muted)] opacity-0 group-hover/source:pointer-events-auto group-hover/source:translate-x-0 group-hover/source:opacity-100"
@@ -1609,7 +1620,7 @@ export function Sidebar({
                 return (
                   <li
                     key={source.id ?? "all"}
-                    className={`${sourceOrderClass(source)} group/source flex items-stretch gap-0 rounded-lg border transition-all ${
+                    className={`${sourceOrderClass(source)} group/source flex items-stretch gap-0 rounded-lg border transition-all ${providerRowShellClass} ${
                       isTopSourceActive(source)
                         ? "border-[color:var(--theme-border-strong)] bg-[rgb(var(--theme-accent-secondary-rgb)/0.18)] text-[color:var(--theme-text-primary)]"
                         : "border-transparent text-[color:var(--theme-text-secondary)] hover:bg-[color:var(--theme-bg-muted)] hover:text-[color:var(--theme-text-primary)]"
@@ -1619,7 +1630,7 @@ export function Sidebar({
                       onClick={() => handleSourceClick(source)}
                       data-testid={`source-row-${sourceKey(source)}`}
                       className={`
-                        flex-1 cursor-pointer flex items-center ${rowGapClass} ${rowLeadingPaddingClass} ${rowVerticalPaddingClass} min-w-0
+                        flex-1 cursor-pointer flex items-center ${rowGapClass} ${providerRowLeadingPaddingClass(source)} ${rowVerticalPaddingClass} min-w-0
                         text-left ${rowTextClass} transition-all
                         ${
                           isTopSourceActive(source)
@@ -1678,7 +1689,7 @@ export function Sidebar({
                                 setSourceMenuAnchorElement(e.currentTarget);
                               }
                             }}
-                            className={`absolute top-[-1px] bottom-[-1px] right-0 flex items-center justify-center rounded-md px-1 transition-all duration-200 ease-in-out hover:text-[color:var(--theme-text-primary)] hover:bg-[color:var(--theme-bg-muted)] ${
+                            className={`${sourceMenuTriggerBaseClass} ${
                               openMenuSourceKey === sourceKey(source)
                                 ? "translate-x-0 bg-[color:var(--theme-bg-muted)] text-[color:var(--theme-text-primary)] opacity-100"
                                 : "pointer-events-none translate-x-[-4px] text-[color:var(--theme-text-muted)] opacity-0 group-hover/source:pointer-events-auto group-hover/source:translate-x-0 group-hover/source:opacity-100"


### PR DESCRIPTION
(AI Generated).

## Summary
- Expand provider row highlights in the detailed sidebar without moving the count lane.
- Shift social provider icons left and make full-detail source action triggers square.

## Testing
- cd packages/desktop && npm run test:e2e -- provider-health.spec.ts --grep "source rows swap counts|full detail provider rows|narrow labeled provider rows"
- npm run validate:feature