### PR TITLE
fix: backfill PWA content signals

### DIFF
--- a/docs/PHASE-10-POLISH.md
+++ b/docs/PHASE-10-POLISH.md
@@ -409,7 +409,7 @@ Reward security researchers for responsible disclosure.
 | 10.13 | Sentiment analysis       | Medium     | ✓ Complete (AISummary.sentiment field)
 | 10.14 | Smart notifications      | High       |
 | 10.15 | AI settings UI           | Medium     | ✓ Complete (unified provider selector for Integrated AI, Ollama, OpenAI, Anthropic, and Gemini with provider-scoped sharing tags, optimistic selection, and default workflows when AI is enabled)
-| 10.25 | Local content signals    | Medium     | ✓ Complete (rule-based contentSignals metadata, automatic ingestion inference, resumable desktop semantic backfill, inclusive saved toolbar filter presets, expanded signal taxonomy, and compact event candidate extraction)
+| 10.25 | Local content signals    | Medium     | ✓ Complete (rule-based contentSignals metadata, automatic ingestion inference, resumable desktop and PWA semantic backfill, inclusive saved toolbar filter presets, expanded signal taxonomy, and compact event candidate extraction)
 | 10.26 | Optional local AI packs  | High       | ✓ Complete (disabled-by-default Light, Balanced, and Pro Integrated AI packs, hardware-based recommendations, pinned download manifests, semantic scan health, source links, resumable desktop downloads, raw-file checksum verification, and removal controls)
 
 ### Extensibility
@@ -455,7 +455,7 @@ Reward security researchers for responsible disclosure.
 - [ ] Topic extraction works (at least one method)
 - [ ] Summarization available for long content
 - [x] AI settings start with a single provider choice that determines whether content stays local, goes to Ollama, or goes to a selected API provider, without selection flicker while preferences persist
-- [x] Local content signals classify existing and newly ingested items without cloud AI, with inclusive saved feed filter presets, expanded semantic signals, and compact event metadata for high-confidence upcoming items
+- [x] Local content signals classify existing and newly ingested items without cloud AI on Desktop and PWA, with inclusive saved feed filter presets, expanded semantic signals, and compact event metadata for high-confidence upcoming items
 - [x] Optional local AI stays out of the installer, remains off by default, recommends Light, Balanced, or Pro from local hardware, stores pack selection plus model files in device-local state, and refreshes semantic scan health while settings is open
 - [ ] Smart notifications reduce noise
 

--- a/packages/pwa/src/lib/automerge-types.ts
+++ b/packages/pwa/src/lib/automerge-types.ts
@@ -8,7 +8,16 @@
  * postMessage boundary without serialization loss.
  */
 
-import type { Account, FeedItem, Friend, Person, ReachOutLog, RssFeed, UserPreferences } from "@freed/shared";
+import type {
+  Account,
+  ContentSignalBackfillSummary,
+  FeedItem,
+  Friend,
+  Person,
+  ReachOutLog,
+  RssFeed,
+  UserPreferences,
+} from "@freed/shared";
 
 // ---------------------------------------------------------------------------
 // Hydrated state posted to the main thread after every doc mutation.
@@ -73,6 +82,7 @@ export type WorkerRequest =
   | { reqId: number; type: "UPDATE_ACCOUNT"; accountId: string; updates: Partial<Account> }
   | { reqId: number; type: "REMOVE_ACCOUNT"; accountId: string }
   | { reqId: number; type: "ADD_STUB_ITEM"; url: string; tags: string[] }
+  | { reqId: number; type: "BACKFILL_CONTENT_SIGNALS"; batchSize?: number }
   | { reqId: number; type: "MERGE_DOC"; binary: Uint8Array }
   | { reqId: number; type: "CLEAR_LOCAL" };
 
@@ -89,5 +99,7 @@ export type WorkerResponse =
   | { type: "DEBUG_EVENT"; kind: string; detail?: string; bytes?: number }
   /** Doc size snapshot for the debug panel */
   | { type: "DEBUG_SNAPSHOT"; deviceId: string; itemCount: number; feedCount: number; binarySize: number }
+  /** One-batch content signal backfill summary. */
+  | { reqId: number; type: "CONTENT_SIGNAL_BACKFILL_RESULT"; summary: ContentSignalBackfillSummary }
   /** Sent once when the worker module finishes loading and is ready for messages */
   | { type: "READY" };

--- a/packages/pwa/src/lib/automerge.ts
+++ b/packages/pwa/src/lib/automerge.ts
@@ -11,7 +11,15 @@
  */
 
 import { addDebugEvent, setDocSnapshot, registerDocAccessors } from "@freed/ui/lib/debug-store";
-import type { Account, FeedItem, Person, ReachOutLog, RssFeed, UserPreferences } from "@freed/shared";
+import type {
+  Account,
+  ContentSignalBackfillSummary,
+  FeedItem,
+  Person,
+  ReachOutLog,
+  RssFeed,
+  UserPreferences,
+} from "@freed/shared";
 import type { DocState, WorkerRequest, WorkerResponse } from "./automerge-types";
 export type { DocState } from "./automerge-types";
 
@@ -47,6 +55,13 @@ const workerReady = new Promise<void>((resolve, reject) => {
 
 let nextReqId = 1;
 const pending = new Map<number, { resolve: () => void; reject: (err: Error) => void }>();
+const pendingContentSignalBackfill = new Map<
+  number,
+  {
+    resolve: (summary: ContentSignalBackfillSummary) => void;
+    reject: (err: Error) => void;
+  }
+>();
 
 async function request(msg: WorkerRequest): Promise<void> {
   await workerReady;
@@ -103,7 +118,22 @@ worker.onmessage = (event: MessageEvent<WorkerResponse>) => {
     return;
   }
 
+  if (msg.type === "CONTENT_SIGNAL_BACKFILL_RESULT") {
+    const pendingBackfill = pendingContentSignalBackfill.get(msg.reqId);
+    if (!pendingBackfill) return;
+    pendingContentSignalBackfill.delete(msg.reqId);
+    pendingBackfill.resolve(msg.summary);
+    return;
+  }
+
   // ACK — resolve or reject the pending promise
+  const pendingBackfill = pendingContentSignalBackfill.get(msg.reqId);
+  if (pendingBackfill && msg.error) {
+    pendingContentSignalBackfill.delete(msg.reqId);
+    pendingBackfill.reject(new Error(msg.error));
+    return;
+  }
+
   const p = pending.get(msg.reqId);
   if (!p) return;
   pending.delete(msg.reqId);
@@ -216,6 +246,17 @@ export async function docRemoveFeedItem(globalId: string): Promise<void> {
 export async function docUpdateFeedItem(globalId: string, updates: Partial<FeedItem>): Promise<void> {
   const reqId = nextReqId++;
   return request({ reqId, type: "UPDATE_FEED_ITEM", globalId, updates });
+}
+
+export async function docBackfillContentSignals(
+  batchSize: number = 200,
+): Promise<ContentSignalBackfillSummary> {
+  await workerReady;
+  return new Promise((resolve, reject) => {
+    const reqId = nextReqId++;
+    pendingContentSignalBackfill.set(reqId, { resolve, reject });
+    worker.postMessage({ reqId, type: "BACKFILL_CONTENT_SIGNALS", batchSize } satisfies WorkerRequest);
+  });
 }
 
 export async function docMarkAsRead(globalId: string): Promise<void> {

--- a/packages/pwa/src/lib/automerge.worker.ts
+++ b/packages/pwa/src/lib/automerge.worker.ts
@@ -18,11 +18,14 @@ import {
   createEmptyDoc,
   addAccount,
   addAccounts,
+  backfillContentSignals,
+  countContentSignalBackfillItems,
   addFeedItem,
   hasLegacyIdentityGraphData,
   migrateLegacyIdentityGraph,
   addPerson,
   addRssFeed,
+  summarizeDocContentSignals,
   removeRssFeed,
   removeAllFeeds,
   updateRssFeed,
@@ -564,6 +567,28 @@ self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
           if (!doc.feedItems[stub.globalId]) addFeedItem(doc, stub);
         }, `Add stub item for ${req.url}`, true);
         ack(req.reqId);
+        break;
+      }
+
+      case "BACKFILL_CONTENT_SIGNALS": {
+        if (!currentDoc) throw new Error("Document not initialized");
+        let summary = summarizeDocContentSignals(currentDoc);
+        const pendingCount = countContentSignalBackfillItems(currentDoc);
+        if (pendingCount > 0) {
+          currentDoc = A.change(currentDoc, "Backfill content signals", (doc) => {
+            summary = backfillContentSignals(doc, req.batchSize);
+          });
+          bumpSearchCorpusVersion();
+          send({
+            type: "DEBUG_EVENT",
+            kind: "change",
+            detail:
+              `[content-signals] backfilled ${summary.updated.toLocaleString()} items, ` +
+              `${summary.remaining.toLocaleString()} remaining`,
+          });
+          await saveAndBroadcast();
+        }
+        send({ reqId: req.reqId, type: "CONTENT_SIGNAL_BACKFILL_RESULT", summary });
         break;
       }
 

--- a/packages/pwa/src/lib/store-startup.test.ts
+++ b/packages/pwa/src/lib/store-startup.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createDefaultPreferences, type ContentSignalBackfillSummary } from "@freed/shared";
+import type { DocState } from "./automerge-types";
+
+const automerge = vi.hoisted(() => {
+  const resolved = () => vi.fn(() => Promise.resolve());
+  return {
+    initDoc: vi.fn(),
+    subscribe: vi.fn(),
+    docAddFeedItems: resolved(),
+    docAddRssFeed: resolved(),
+    docRemoveRssFeed: resolved(),
+    docRemoveAllFeeds: resolved(),
+    docUpdateRssFeed: resolved(),
+    docUpdateFeedItem: resolved(),
+    docBackfillContentSignals: vi.fn(),
+    docMarkAsRead: resolved(),
+    docMarkItemsAsRead: resolved(),
+    docMarkAllAsRead: resolved(),
+    docToggleSaved: resolved(),
+    docRemoveFeedItem: resolved(),
+    docToggleArchived: resolved(),
+    docToggleLiked: resolved(),
+    docArchiveAllReadUnsaved: resolved(),
+    docUnarchiveSavedItems: resolved(),
+    docDeleteAllArchived: resolved(),
+    docPruneArchivedItems: resolved(),
+    docUpdatePreferences: resolved(),
+    docAddAccount: resolved(),
+    docAddAccounts: resolved(),
+    docAddPerson: resolved(),
+    docAddPersons: resolved(),
+    docUpdateAccount: resolved(),
+    docUpdatePerson: resolved(),
+    docUpsertConnectionPersons: resolved(),
+    docRemoveAccount: resolved(),
+    docRemovePerson: resolved(),
+    docLogReachOut: resolved(),
+  };
+});
+
+vi.mock("./automerge", () => automerge);
+
+vi.mock("./reader-cache", () => ({
+  pinReaderItemInPwa: vi.fn(),
+}));
+
+vi.mock("@freed/ui/lib/bug-report", () => ({
+  recordBugReportEvent: vi.fn(),
+  recordRuntimeError: vi.fn(),
+}));
+
+import { useAppStore } from "./store";
+
+function makeDocState(): DocState {
+  return {
+    items: [],
+    searchCorpusVersion: 0,
+    feeds: {},
+    persons: {},
+    accounts: {},
+    friends: {},
+    preferences: createDefaultPreferences(),
+    feedUnreadCounts: {},
+    feedTotalCounts: {},
+    totalUnreadCount: 0,
+    unreadCountByPlatform: {},
+    totalItemCount: 0,
+    itemCountByPlatform: {},
+    totalArchivableCount: 0,
+    archivableCountByPlatform: {},
+    archivableFeedCounts: {},
+  };
+}
+
+function makeBackfillSummary(
+  updated: number,
+  remaining: number,
+): ContentSignalBackfillSummary {
+  return {
+    version: 3,
+    total: updated + remaining,
+    scanned: updated,
+    updated,
+    remaining,
+    counts: {} as ContentSignalBackfillSummary["counts"],
+    multiSignalCount: 0,
+    untaggedCount: 0,
+    samples: {},
+  };
+}
+
+describe("PWA store startup maintenance", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useAppStore.setState(useAppStore.getInitialState(), true);
+    automerge.initDoc.mockResolvedValue(makeDocState());
+    automerge.docBackfillContentSignals.mockResolvedValue(makeBackfillSummary(0, 0));
+  });
+
+  it("backfills content signals after initialization until no stale items remain", async () => {
+    automerge.docBackfillContentSignals
+      .mockResolvedValueOnce(makeBackfillSummary(200, 5))
+      .mockResolvedValueOnce(makeBackfillSummary(5, 0));
+
+    await useAppStore.getState().initialize();
+
+    await vi.waitFor(() => {
+      expect(automerge.docPruneArchivedItems).toHaveBeenCalledWith(30 * 24 * 60 * 60 * 1000);
+      expect(automerge.docBackfillContentSignals).toHaveBeenCalledTimes(1);
+    });
+    await vi.waitFor(() => {
+      expect(automerge.docBackfillContentSignals).toHaveBeenCalledTimes(2);
+    });
+    expect(automerge.docBackfillContentSignals).toHaveBeenNthCalledWith(1, 200);
+    expect(automerge.docBackfillContentSignals).toHaveBeenNthCalledWith(2, 200);
+  });
+});

--- a/packages/pwa/src/lib/store.ts
+++ b/packages/pwa/src/lib/store.ts
@@ -28,6 +28,7 @@ import {
   docRemoveAllFeeds,
   docUpdateRssFeed,
   docUpdateFeedItem,
+  docBackfillContentSignals,
   docMarkAsRead,
   docMarkItemsAsRead,
   docMarkAllAsRead,
@@ -98,6 +99,26 @@ async function pruneConnectionPersonIfNeeded(
     return;
   }
   await docRemovePerson(personId!);
+}
+
+async function runStartupMigrations(archivePruneDays: number): Promise<void> {
+  try {
+    if (archivePruneDays > 0) {
+      await docPruneArchivedItems(archivePruneDays * 24 * 60 * 60 * 1000);
+    }
+  } catch {
+    // non-fatal
+  }
+
+  try {
+    for (;;) {
+      const summary = await docBackfillContentSignals(200);
+      if (summary.updated === 0 || summary.remaining === 0) break;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+  } catch {
+    // non-fatal
+  }
 }
 
 export const useAppStore = create<AppState>((set, get) => ({
@@ -175,14 +196,10 @@ export const useAppStore = create<AppState>((set, get) => ({
         isLoading: false,
       });
 
-      // Prune archived items in the background. Idempotent; failure is non-fatal.
-      // The subscriber above propagates the doc change to the UI automatically.
+      // Run idempotent maintenance in the background. The subscriber above
+      // propagates doc changes to the UI automatically.
       const pruneDays = state.preferences.display.archivePruneDays ?? 30;
-      if (pruneDays > 0) {
-        void docPruneArchivedItems(pruneDays * 24 * 60 * 60 * 1000).catch(() => {
-          // non-fatal
-        });
-      }
+      void runStartupMigrations(pruneDays);
     } catch (error) {
       recordRuntimeError({ source: "pwa:initialize", error, fatal: false });
       recordBugReportEvent("pwa:initialize", "error", "Initialization failed");

--- a/website/src/app/roadmap/RoadmapContent.tsx
+++ b/website/src/app/roadmap/RoadmapContent.tsx
@@ -783,7 +783,7 @@ const phases: Phase[] = [
     number: 10,
     title: "Polish",
     description:
-      "Onboarding, statistics, global animation controls, expanded local content signals with inclusive saved feed filter presets and compact event extraction, unified AI provider settings, Light, Balanced, and Pro Integrated AI packs with semantic scan health, plugin API, community infrastructure, and deeper crash recovery hardening.",
+      "Onboarding, statistics, global animation controls, expanded local content signals with Desktop and PWA backfill, inclusive saved feed filter presets, and compact event extraction, unified AI provider settings, Light, Balanced, and Pro Integrated AI packs with semantic scan health, plugin API, community infrastructure, and deeper crash recovery hardening.",
     status: "upcoming",
     planLink:
       "https://github.com/freed-project/freed/blob/dev/docs/PHASE-10-POLISH.md",


### PR DESCRIPTION
(AI Generated).

## Summary
- Adds a PWA worker command for bounded content signal backfill, matching the Desktop path.
- Runs PWA startup maintenance through prune plus resumable content signal classification so stale synced libraries get classified without reopening Desktop.
- Documents Desktop and PWA backfill parity in the phase plan and roadmap.

## Testing
- PATH=/Users/aubreyfalconer/dev/freed-classify-everything/node_modules/.bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/usr/local/MacGPG2/bin:/Applications/VMware Fusion.app/Contents/Public:/usr/local/share/dotnet:~/.dotnet/tools:/usr/local/go/bin:/Library/Frameworks/Mono.framework/Versions/Current/Commands:/Users/aubreyfalconer/.nvm/versions/node/v24.14.1/bin:/Users/aubreyfalconer/.codex/tmp/arg0/codex-arg00y1K37:/Users/aubreyfalconer/.local/bin:/opt/homebrew/opt/mysql-client/bin:/opt/homebrew/bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/Users/aubreyfalconer/.cargo/bin:/Users/aubreyfalconer/go/bin:/Users/aubreyfalconer/.cache/lm-studio/bin:/Users/aubreyfalconer/.safe-chain/bin:/Applications/Codex.app/Contents/Resources:/usr/local/bin npm run test:unit -- store-startup.test.ts (packages/pwa)
- PATH=/Users/aubreyfalconer/dev/freed-classify-everything/node_modules/.bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/usr/local/MacGPG2/bin:/Applications/VMware Fusion.app/Contents/Public:/usr/local/share/dotnet:~/.dotnet/tools:/usr/local/go/bin:/Library/Frameworks/Mono.framework/Versions/Current/Commands:/Users/aubreyfalconer/.nvm/versions/node/v24.14.1/bin:/Users/aubreyfalconer/.codex/tmp/arg0/codex-arg00y1K37:/Users/aubreyfalconer/.local/bin:/opt/homebrew/opt/mysql-client/bin:/opt/homebrew/bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/Users/aubreyfalconer/.cargo/bin:/Users/aubreyfalconer/go/bin:/Users/aubreyfalconer/.cache/lm-studio/bin:/Users/aubreyfalconer/.safe-chain/bin:/Applications/Codex.app/Contents/Resources:/usr/local/bin npm run test:unit -- content-signals.test.ts (packages/desktop)
- npm run validate:feature