### PR TITLE
perf: preserve count maps for neutral patches

### DIFF
--- a/packages/desktop/src/lib/automerge-state-patches.test.ts
+++ b/packages/desktop/src/lib/automerge-state-patches.test.ts
@@ -114,4 +114,25 @@ describe("Automerge item patch state updates", () => {
     expect(result.state.totalItemCount).toBe(1);
     expect(result.state.totalUnreadCount).toBe(0);
   });
+
+  it("preserves count map identity for count-neutral item patches", () => {
+    const unread = makeItem("rss:unread");
+    const read = makeItem("rss:read", { readAt: 10 });
+    const state = makeState([unread, read]);
+    const index = createItemIndex(state.items);
+
+    const likedUnread = makeItem("rss:unread", { liked: true, likedAt: 40 });
+    const result = applyItemPatchesToState(state, [{ item: likedUnread }], index);
+
+    expect(result.state.items).toEqual([likedUnread, read]);
+    expect(result.state.feedUnreadCounts).toBe(state.feedUnreadCounts);
+    expect(result.state.feedTotalCounts).toBe(state.feedTotalCounts);
+    expect(result.state.unreadCountByPlatform).toBe(state.unreadCountByPlatform);
+    expect(result.state.itemCountByPlatform).toBe(state.itemCountByPlatform);
+    expect(result.state.archivableCountByPlatform).toBe(state.archivableCountByPlatform);
+    expect(result.state.archivableFeedCounts).toBe(state.archivableFeedCounts);
+    expect(result.state.totalUnreadCount).toBe(state.totalUnreadCount);
+    expect(result.state.totalItemCount).toBe(state.totalItemCount);
+    expect(result.state.totalArchivableCount).toBe(state.totalArchivableCount);
+  });
 });

--- a/packages/desktop/src/lib/automerge-state-patches.ts
+++ b/packages/desktop/src/lib/automerge-state-patches.ts
@@ -71,6 +71,21 @@ function applyItemContribution(counts: CountState, item: FeedItem, delta: 1 | -1
   }
 }
 
+function countContributionKey(item: FeedItem): string {
+  const userState = item.userState;
+  if (userState.hidden || userState.archived) return "excluded";
+  return [
+    item.platform,
+    item.rssSource?.feedUrl ?? "",
+    userState.readAt ? "read" : "unread",
+    userState.saved ? "saved" : "unsaved",
+  ].join("|");
+}
+
+function countContributionChanged(previous: FeedItem, next: FeedItem): boolean {
+  return countContributionKey(previous) !== countContributionKey(next);
+}
+
 function applyCountState(state: DocState, counts: CountState): DocState {
   return {
     ...state,
@@ -115,7 +130,11 @@ export function applyItemPatchesToState(
     const previous = items[existingIndex];
     if (!previous) continue;
 
-    applyItemContribution(ensureCounts(), previous, -1);
+    const countChanged = countContributionChanged(previous, item);
+    if (countChanged) {
+      applyItemContribution(ensureCounts(), previous, -1);
+    }
+
     if (item.userState.hidden) {
       items.splice(existingIndex, 1);
       itemIndex.delete(item.globalId);
@@ -124,13 +143,15 @@ export function applyItemPatchesToState(
     }
 
     items[existingIndex] = item;
-    applyItemContribution(ensureCounts(), item, 1);
+    if (countChanged) {
+      applyItemContribution(ensureCounts(), item, 1);
+    }
   }
 
-  if (!nextItems || !counts) return { state, itemIndex };
+  if (!nextItems) return { state, itemIndex };
   const nextIndex = indexNeedsRebuild ? createItemIndex(nextItems) : itemIndex;
   return {
-    state: applyCountState({ ...state, items: nextItems }, counts),
+    state: counts ? applyCountState({ ...state, items: nextItems }, counts) : { ...state, items: nextItems },
     itemIndex: nextIndex,
   };
 }


### PR DESCRIPTION
(AI Generated).

## Summary
- Count-neutral desktop item patches now replace the changed item without cloning aggregate count maps, keeping Zustand count selectors quiet for like and sync-confirmation updates.

## Testing
- npm run validate:feature