### PR TITLE
fix: preserve side-effect queue serialization on timeout

### DIFF
--- a/packages/desktop/src/lib/side-effect-scheduler.test.ts
+++ b/packages/desktop/src/lib/side-effect-scheduler.test.ts
@@ -50,6 +50,44 @@ describe("side-effect scheduler", () => {
     expect(events).toEqual(["first:start", "first:end", "second"]);
   });
 
+  it("waits for a timed out task to settle before starting the next task", async () => {
+    vi.useFakeTimers();
+    const { scheduleSideEffect } = await loadScheduler();
+    const events: string[] = [];
+    let releaseFirst: () => void = () => {};
+
+    const first = scheduleSideEffect({
+      queue: "nativeStore",
+      source: "test",
+      kind: "timeout",
+      timeoutMs: 10,
+      run: async () => {
+        events.push("first:start");
+        await new Promise<void>((resolve) => {
+          releaseFirst = resolve;
+        });
+        events.push("first:end");
+      },
+    });
+    const second = scheduleSideEffect({
+      queue: "nativeStore",
+      source: "test",
+      kind: "second",
+      run: async () => {
+        events.push("second");
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(10);
+    await expect(first).rejects.toThrow("timed_out_ms=10");
+    expect(events).toEqual(["first:start"]);
+
+    releaseFirst();
+    await Promise.resolve();
+    await second;
+    expect(events).toEqual(["first:start", "first:end", "second"]);
+  });
+
   it("keeps a queue alive after a failed task", async () => {
     const { scheduleSideEffect } = await loadScheduler();
     const events: string[] = [];

--- a/packages/desktop/src/lib/side-effect-scheduler.ts
+++ b/packages/desktop/src/lib/side-effect-scheduler.ts
@@ -23,6 +23,11 @@ interface QueueState {
   pending: number;
 }
 
+interface TimedRun<T> {
+  result: Promise<T>;
+  settled: Promise<void>;
+}
+
 const DEFAULT_TIMEOUT_MS = 30_000;
 const DEFAULT_SLOW_MS = 750;
 
@@ -50,11 +55,16 @@ function logSlowTask(task: SideEffectTask<unknown>, detail: string): void {
   addDebugEvent("change", message);
 }
 
-async function withTimeout<T>(task: SideEffectTask<T>): Promise<T> {
+function withTimeout<T>(task: SideEffectTask<T>): TimedRun<T> {
   const timeoutMs = task.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   let timeout: ReturnType<typeof setTimeout> | null = null;
   const runPromise = Promise.resolve().then(task.run);
-  const timeoutPromise = new Promise<never>((_resolve, reject) => {
+  const settled = runPromise.then(
+    () => undefined,
+    () => undefined,
+  );
+  const result = new Promise<T>((resolve, reject) => {
+    runPromise.then(resolve, reject);
     timeout = setTimeout(() => {
       reject(
         new Error(
@@ -67,14 +77,12 @@ async function withTimeout<T>(task: SideEffectTask<T>): Promise<T> {
     }, timeoutMs);
   });
 
-  try {
-    return await Promise.race([runPromise, timeoutPromise]);
-  } finally {
-    if (timeout) clearTimeout(timeout);
-    runPromise.catch(() => {
-      // The raced timeout already reported failure to the caller.
-    });
-  }
+  return {
+    result: result.finally(() => {
+      if (timeout) clearTimeout(timeout);
+    }),
+    settled,
+  };
 }
 
 export function scheduleSideEffect<T>(task: SideEffectTask<T>): Promise<T> {
@@ -82,6 +90,7 @@ export function scheduleSideEffect<T>(task: SideEffectTask<T>): Promise<T> {
   const enqueuedAt = performance.now();
   const pendingBeforeStart = state.pending;
   state.pending += 1;
+  let settledRun: Promise<void> = Promise.resolve();
 
   const work = state.tail.catch(() => {
     // Keep this queue alive after failed tasks.
@@ -89,7 +98,9 @@ export function scheduleSideEffect<T>(task: SideEffectTask<T>): Promise<T> {
     state.pending = Math.max(0, state.pending - 1);
     const startedAt = performance.now();
     const waitMs = elapsedMs(enqueuedAt);
-    const result = await withTimeout(task);
+    const timedRun = withTimeout(task);
+    settledRun = timedRun.settled;
+    const result = await timedRun.result;
     const durationMs = elapsedMs(startedAt);
     const slowMs = task.slowMs ?? DEFAULT_SLOW_MS;
     if (waitMs >= slowMs || durationMs >= slowMs || pendingBeforeStart > 0) {
@@ -102,6 +113,9 @@ export function scheduleSideEffect<T>(task: SideEffectTask<T>): Promise<T> {
   });
 
   state.tail = work.then(
+    () => settledRun,
+    () => settledRun,
+  ).then(
     () => undefined,
     () => undefined,
   );


### PR DESCRIPTION
(AI Generated).

## Summary
- keep timed out side-effect tasks from letting the next queued task start early
- preserve queue serialization while still rejecting the caller on timeout
- add a regression test that proves the next task waits for the timed out task to settle

## Root cause
The new side-effect scheduler introduced in `ab2f43e7` raced each task against a timeout, but advanced the queue as soon as that timeout rejected. If the original task was still running, later queued native-store or sync work could start concurrently and break the scheduler's serialization guarantee.

## Validation
- `node ../../node_modules/vitest/vitest.mjs run src/lib/side-effect-scheduler.test.ts --config vite.config.ts`
