### PR TITLE
fix: stabilize desktop AI downloads and renderer recovery

### DIFF
--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -1288,7 +1288,7 @@ dependencies = [
 
 [[package]]
 name = "freed-desktop"
-version = "26.4.3005"
+version = "26.5.101"
 dependencies = [
  "base64 0.22.1",
  "criterion",

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -13,7 +13,7 @@ use std::path::{Path, PathBuf};
 #[cfg(target_os = "macos")]
 use std::process::Command;
 use std::sync::{Arc, RwLock as StdRwLock};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use sysinfo::{Disks, Pid, ProcessRefreshKind, ProcessesToUpdate, System};
 use tauri::menu::{Menu, MenuItem, Submenu};
 use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
@@ -72,6 +72,7 @@ const RENDERER_VISIBLE_RECOVERY_AFTER: Duration = Duration::from_secs(75);
 const RENDERER_HIDDEN_RECOVERY_AFTER: Duration = Duration::from_secs(600);
 const MAIN_WINDOW_RELEASE_POLL_INTERVAL: Duration = Duration::from_millis(50);
 const MAIN_WINDOW_RELEASE_POLL_ATTEMPTS: usize = 20;
+const LOCAL_AI_DOWNLOAD_PROGRESS_INTERVAL: Duration = Duration::from_millis(250);
 const ENABLE_BACKGROUND_SCRAPER_CLOAK_JS: &str = r#"
     (function() {
         var token = "__freed_background_scraper__";
@@ -436,6 +437,27 @@ struct StartupRecoveryState {
     pending_boot_started_at_ms: Option<u64>,
     last_failed_boot_at_ms: Option<u64>,
     last_successful_boot_at_ms: Option<u64>,
+}
+
+#[derive(Default)]
+struct LocalAIModelDownloadState(StdRwLock<HashSet<String>>);
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct LocalAIModelFileDownloadRequest {
+    download_id: String,
+    url: String,
+    target_path: String,
+    partial_path: String,
+    expected_size_bytes: u64,
+    progress_event: String,
+}
+
+#[derive(Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct LocalAIModelFileDownloadProgress {
+    download_id: String,
+    downloaded_bytes: u64,
 }
 
 fn now_unix_ms() -> u64 {
@@ -1349,6 +1371,252 @@ async fn sha256_file(app: tauri::AppHandle, path: String) -> Result<String, Stri
     Ok(format!("{:x}", hasher.finalize()))
 }
 
+fn validate_local_ai_download_url(raw: &str) -> Result<(), String> {
+    let url = url::Url::parse(raw).map_err(|error| format!("invalid model file URL: {error}"))?;
+    if url.scheme() != "https" || url.host_str() != Some("huggingface.co") {
+        return Err("local AI model downloads must use https://huggingface.co".to_string());
+    }
+    Ok(())
+}
+
+fn validate_local_ai_model_path(root: &Path, path: &Path, field: &str) -> Result<(), String> {
+    if !path.is_absolute() {
+        return Err(format!("{field} must be an absolute path"));
+    }
+    if !path.starts_with(root) {
+        return Err(format!(
+            "{field} must stay inside the local AI model directory"
+        ));
+    }
+    let parent = path
+        .parent()
+        .ok_or_else(|| format!("{field} is missing a parent directory"))?;
+    std::fs::create_dir_all(parent).map_err(|error| error.to_string())?;
+    let canonical_root = root.canonicalize().map_err(|error| error.to_string())?;
+    let canonical_parent = parent.canonicalize().map_err(|error| error.to_string())?;
+    if !canonical_parent.starts_with(&canonical_root) {
+        return Err(format!(
+            "{field} must stay inside the local AI model directory"
+        ));
+    }
+    Ok(())
+}
+
+fn local_ai_model_download_cancelled(
+    state: &tauri::State<'_, LocalAIModelDownloadState>,
+    download_id: &str,
+) -> bool {
+    state
+        .0
+        .read()
+        .map(|cancelled| cancelled.contains(download_id))
+        .unwrap_or(false)
+}
+
+fn emit_local_ai_download_progress(
+    app: &tauri::AppHandle,
+    event: &str,
+    download_id: &str,
+    downloaded_bytes: u64,
+) {
+    let _ = app.emit(
+        event,
+        LocalAIModelFileDownloadProgress {
+            download_id: download_id.to_string(),
+            downloaded_bytes,
+        },
+    );
+}
+
+#[tauri::command]
+async fn cancel_local_ai_model_download(
+    state: tauri::State<'_, LocalAIModelDownloadState>,
+    download_id: String,
+) -> Result<(), String> {
+    state
+        .0
+        .write()
+        .map_err(|_| "local AI download state is unavailable".to_string())?
+        .insert(download_id);
+    Ok(())
+}
+
+#[tauri::command]
+async fn download_local_ai_model_file(
+    app: tauri::AppHandle,
+    state: tauri::State<'_, LocalAIModelDownloadState>,
+    request: LocalAIModelFileDownloadRequest,
+) -> Result<u64, String> {
+    validate_local_ai_download_url(&request.url)?;
+
+    let model_root = app
+        .path()
+        .app_data_dir()
+        .map_err(|error| error.to_string())?
+        .join("local-ai-models");
+    std::fs::create_dir_all(&model_root).map_err(|error| error.to_string())?;
+
+    let target = PathBuf::from(&request.target_path);
+    let partial = PathBuf::from(&request.partial_path);
+    validate_local_ai_model_path(&model_root, &target, "targetPath")?;
+    validate_local_ai_model_path(&model_root, &partial, "partialPath")?;
+    if request.partial_path != format!("{}.partial", request.target_path) {
+        return Err("partialPath must match targetPath plus .partial".to_string());
+    }
+
+    {
+        let mut cancelled = state
+            .0
+            .write()
+            .map_err(|_| "local AI download state is unavailable".to_string())?;
+        cancelled.remove(&request.download_id);
+    }
+
+    if let Ok(metadata) = tokio::fs::metadata(&target).await {
+        if metadata.len() == request.expected_size_bytes {
+            emit_local_ai_download_progress(
+                &app,
+                &request.progress_event,
+                &request.download_id,
+                request.expected_size_bytes,
+            );
+            return Ok(request.expected_size_bytes);
+        }
+        tokio::fs::remove_file(&target)
+            .await
+            .map_err(|error| error.to_string())?;
+    }
+
+    let mut existing_partial_bytes = match tokio::fs::metadata(&partial).await {
+        Ok(metadata) => metadata.len(),
+        Err(_) => 0,
+    };
+    if existing_partial_bytes > request.expected_size_bytes {
+        tokio::fs::remove_file(&partial)
+            .await
+            .map_err(|error| error.to_string())?;
+        existing_partial_bytes = 0;
+    }
+
+    let client = reqwest::Client::new();
+    let mut response = {
+        let mut builder = client.get(&request.url);
+        if existing_partial_bytes > 0 {
+            builder = builder.header(
+                reqwest::header::RANGE,
+                format!("bytes={existing_partial_bytes}-"),
+            );
+        }
+        builder.send().await.map_err(|error| error.to_string())?
+    };
+
+    if response.status() == reqwest::StatusCode::RANGE_NOT_SATISFIABLE && existing_partial_bytes > 0
+    {
+        tokio::fs::remove_file(&partial)
+            .await
+            .map_err(|error| error.to_string())?;
+        existing_partial_bytes = 0;
+        response = client
+            .get(&request.url)
+            .send()
+            .await
+            .map_err(|error| error.to_string())?;
+    }
+
+    let can_append =
+        existing_partial_bytes > 0 && response.status() == reqwest::StatusCode::PARTIAL_CONTENT;
+    if existing_partial_bytes > 0 && !can_append {
+        tokio::fs::remove_file(&partial)
+            .await
+            .map_err(|error| error.to_string())?;
+        existing_partial_bytes = 0;
+    }
+
+    if !(response.status().is_success()
+        || response.status() == reqwest::StatusCode::PARTIAL_CONTENT)
+    {
+        return Err(format!(
+            "Download failed for local AI model file: {}",
+            response.status()
+        ));
+    }
+
+    let mut file = tokio::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .append(can_append)
+        .truncate(!can_append)
+        .open(&partial)
+        .await
+        .map_err(|error| error.to_string())?;
+
+    let mut downloaded_bytes = existing_partial_bytes;
+    let mut last_progress_at = Instant::now()
+        .checked_sub(LOCAL_AI_DOWNLOAD_PROGRESS_INTERVAL)
+        .unwrap_or_else(Instant::now);
+    emit_local_ai_download_progress(
+        &app,
+        &request.progress_event,
+        &request.download_id,
+        downloaded_bytes,
+    );
+
+    while let Some(chunk) = response.chunk().await.map_err(|error| error.to_string())? {
+        if local_ai_model_download_cancelled(&state, &request.download_id) {
+            return Err("download cancelled".to_string());
+        }
+        file.write_all(&chunk)
+            .await
+            .map_err(|error| error.to_string())?;
+        downloaded_bytes = downloaded_bytes.saturating_add(chunk.len() as u64);
+        if last_progress_at.elapsed() >= LOCAL_AI_DOWNLOAD_PROGRESS_INTERVAL {
+            emit_local_ai_download_progress(
+                &app,
+                &request.progress_event,
+                &request.download_id,
+                downloaded_bytes,
+            );
+            last_progress_at = Instant::now();
+        }
+    }
+
+    file.flush().await.map_err(|error| error.to_string())?;
+    drop(file);
+
+    if local_ai_model_download_cancelled(&state, &request.download_id) {
+        return Err("download cancelled".to_string());
+    }
+
+    let actual_size = tokio::fs::metadata(&partial)
+        .await
+        .map_err(|error| error.to_string())?
+        .len();
+    if actual_size != request.expected_size_bytes {
+        return Err(format!(
+            "Expected {} bytes for local AI model file, got {}",
+            request.expected_size_bytes, actual_size
+        ));
+    }
+
+    if tokio::fs::metadata(&target).await.is_ok() {
+        tokio::fs::remove_file(&target)
+            .await
+            .map_err(|error| error.to_string())?;
+    }
+    tokio::fs::rename(&partial, &target)
+        .await
+        .map_err(|error| error.to_string())?;
+
+    emit_local_ai_download_progress(
+        &app,
+        &request.progress_event,
+        &request.download_id,
+        request.expected_size_bytes,
+    );
+
+    Ok(request.expected_size_bytes)
+}
+
 #[tauri::command]
 async fn get_sync_client_count(state: tauri::State<'_, RelayState>) -> Result<usize, String> {
     Ok(*state.client_count.read().await)
@@ -1384,13 +1652,33 @@ fn path_is_under_any_root(path: &Path, roots: &[PathBuf]) -> bool {
     roots.iter().any(|root| path.starts_with(root))
 }
 
+fn push_unique_path(paths: &mut Vec<PathBuf>, path: PathBuf) {
+    if !paths.iter().any(|existing| existing == &path) {
+        paths.push(path);
+    }
+}
+
 fn app_storage_roots(app: &tauri::AppHandle) -> Vec<PathBuf> {
     let mut roots = Vec::new();
     if let Ok(path) = app.path().app_cache_dir() {
-        roots.push(path);
+        push_unique_path(&mut roots, path);
     }
     if let Ok(path) = app.path().app_data_dir() {
-        roots.push(path);
+        push_unique_path(&mut roots, path);
+    }
+    if let Ok(home) = app.path().home_dir() {
+        for app_dir in ["wtf.freed.desktop", "freed-desktop"] {
+            push_unique_path(
+                &mut roots,
+                home.join("Library").join("Caches").join(app_dir),
+            );
+            push_unique_path(
+                &mut roots,
+                home.join("Library")
+                    .join("Application Support")
+                    .join(app_dir),
+            );
+        }
     }
     roots
 }
@@ -1583,7 +1871,7 @@ fn trim_webkit_network_cache(app: &tauri::AppHandle) -> bool {
 }
 
 fn scrape_memory_may_proceed(stats: &RuntimeMemoryStats) -> bool {
-    stats.app_resident_bytes < stats.memory_critical_bytes
+    stats.app_resident_bytes < stats.memory_high_bytes
 }
 
 fn recycle_social_scraper_windows_except(
@@ -1624,6 +1912,20 @@ async fn prepare_social_scrape_memory_internal(
 
     let after = collect_runtime_memory_stats(app, relay_doc_bytes, relay_client_count);
     let may_proceed = scrape_memory_may_proceed(&after);
+    info!(
+        "[memory] scrape preflight provider={} operation={} before_app_rss={} before_webkit_rss={} after_app_rss={} after_webkit_rss={} high_bytes={} critical_bytes={} recycled_scrapers={} cache_trimmed={} may_proceed={}",
+        provider,
+        operation,
+        before.app_resident_bytes,
+        before.webkit_total_resident_bytes,
+        after.app_resident_bytes,
+        after.webkit_total_resident_bytes,
+        after.memory_high_bytes,
+        after.memory_critical_bytes,
+        recycled_scraper_windows,
+        cache_trimmed,
+        may_proceed
+    );
 
     ScrapeMemoryPreparation {
         before,
@@ -4265,6 +4567,34 @@ fn start_main_window(app: &tauri::AppHandle) -> Result<tauri::WebviewWindow, tau
 }
 
 fn recover_main_window(app: &tauri::AppHandle, reason: &str) -> Result<(), String> {
+    let app_for_recovery = app.clone();
+    let reason_for_recovery = reason.to_string();
+    let (tx, rx) = std::sync::mpsc::channel();
+
+    app.run_on_main_thread(move || {
+        let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            recover_main_window_on_main_thread(&app_for_recovery, &reason_for_recovery)
+        }))
+        .unwrap_or_else(|_| Err("renderer recovery panicked on main thread".to_string()));
+        let _ = tx.send(outcome);
+    })
+    .map_err(|error| format!("failed to schedule renderer recovery on main thread: {error}"))?;
+
+    match rx.recv_timeout(Duration::from_secs(15)) {
+        Ok(outcome) => outcome,
+        Err(error) => {
+            let message = format!("timed out waiting for main-thread renderer recovery: {error}");
+            error!(
+                "[main-window] {}; requesting app restart reason={}",
+                message, reason
+            );
+            app.request_restart();
+            Err(message)
+        }
+    }
+}
+
+fn recover_main_window_on_main_thread(app: &tauri::AppHandle, reason: &str) -> Result<(), String> {
     let _keepalive = open_main_window_recovery_keepalive(app, reason)?;
     let outcome = recover_main_window_with_keepalive(app, reason);
 
@@ -4443,6 +4773,7 @@ pub fn run() {
         .plugin(tauri_plugin_store::Builder::new().build())
         .plugin(tauri_plugin_fs::init())
         .manage(relay_state)
+        .manage(LocalAIModelDownloadState::default())
         .manage(CaptureState::new());
 
     #[cfg(target_os = "macos")]
@@ -4883,6 +5214,8 @@ pub fn run() {
             get_all_local_ips,
             get_sync_url,
             sha256_file,
+            download_local_ai_model_file,
+            cancel_local_ai_model_download,
             get_sync_client_count,
             get_runtime_memory_stats,
             get_ai_hardware_profile,
@@ -4980,12 +5313,34 @@ mod tests {
     }
 
     #[test]
-    fn scrape_memory_blocks_only_when_after_cleanup_is_still_critical() {
+    fn local_ai_download_urls_are_restricted_to_hugging_face() {
+        assert!(validate_local_ai_download_url(
+            "https://huggingface.co/onnx-community/model/resolve/rev/file.onnx"
+        )
+        .is_ok());
+        assert!(validate_local_ai_download_url("http://huggingface.co/model").is_err());
+        assert!(validate_local_ai_download_url("https://example.com/model").is_err());
+    }
+
+    #[test]
+    fn local_ai_model_paths_must_stay_under_model_root() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("local-ai-models");
+        std::fs::create_dir_all(&root).unwrap();
+        let allowed = root.join("integrated-balanced/rev/model.bin");
+        let denied = temp.path().join("other/model.bin");
+
+        assert!(validate_local_ai_model_path(&root, &allowed, "targetPath").is_ok());
+        assert!(validate_local_ai_model_path(&root, &denied, "targetPath").is_err());
+    }
+
+    #[test]
+    fn scrape_memory_blocks_when_after_cleanup_is_still_high() {
         let stats = RuntimeMemoryStats {
             total_physical_memory_bytes: 16 * BYTES_PER_GIB,
             process_resident_bytes: 128,
             process_virtual_bytes: 256,
-            app_resident_bytes: MIN_CRITICAL_MEMORY_BYTES - 1,
+            app_resident_bytes: (MIN_CRITICAL_MEMORY_BYTES * 70 / 100) - 1,
             webkit_resident_bytes: None,
             webkit_virtual_bytes: None,
             webkit_process_id: None,
@@ -5004,7 +5359,7 @@ mod tests {
 
         assert!(scrape_memory_may_proceed(&stats));
         assert!(!scrape_memory_may_proceed(&RuntimeMemoryStats {
-            app_resident_bytes: MIN_CRITICAL_MEMORY_BYTES,
+            app_resident_bytes: MIN_CRITICAL_MEMORY_BYTES * 70 / 100,
             ..stats
         }));
     }

--- a/packages/desktop/src/App.tsx
+++ b/packages/desktop/src/App.tsx
@@ -199,7 +199,18 @@ function App() {
     }
     // Start background content fetcher -- processes article HTML fetch queue.
     startContentFetcher();
-    startSemanticClassifier();
+    startSemanticClassifier({
+      isEnabled: () => {
+        const prefs = useDesktopStore.getState().preferences.ai;
+        return prefs.provider === "integrated" && prefs.extractTopics;
+      },
+      subscribeToPreferenceChanges: (callback) =>
+        useDesktopStore.subscribe((state, previous) => {
+          if (state.preferences.ai !== previous.preferences.ai) {
+            callback();
+          }
+        }),
+    });
     startMemoryMonitor({
       getAutomergeStats: getCachedDocStats,
       onCriticalPressure: () => {

--- a/packages/desktop/src/__mocks__/@tauri-apps/api/core.ts
+++ b/packages/desktop/src/__mocks__/@tauri-apps/api/core.ts
@@ -82,6 +82,11 @@ const handlers: Record<string, Handler> = {
   get_all_local_ips: () => [],
   get_sync_url: () => "ws://127.0.0.1:8765",
   sha256_file: () => "",
+  download_local_ai_model_file: (args: Record<string, unknown>) => {
+    const request = args.request as { expectedSizeBytes?: number } | undefined;
+    return request?.expectedSizeBytes ?? 0;
+  },
+  cancel_local_ai_model_download: () => null,
   get_sync_client_count: () => 0,
   get_runtime_memory_stats: () => ({
     totalPhysicalMemoryBytes: 16 * 1024 * 1024 * 1024,

--- a/packages/desktop/src/lib/local-ai-models.test.ts
+++ b/packages/desktop/src/lib/local-ai-models.test.ts
@@ -208,6 +208,47 @@ describe("local AI model manager", () => {
     expect(models[0].state.storageBytes).toBe(10);
   });
 
+  it("uses the native model downloader when available", async () => {
+    const { deps, files, requests } = createDeps();
+    const nativeDownloads: Array<{
+      url: string;
+      targetPath: string;
+      partialPath: string;
+      expectedSizeBytes: number;
+    }> = [];
+    deps.downloadModelFile = async (input, onProgress) => {
+      nativeDownloads.push({
+        url: input.url,
+        targetPath: input.targetPath,
+        partialPath: input.partialPath,
+        expectedSizeBytes: input.expectedSizeBytes,
+      });
+      files.set(input.targetPath, TEXT.encode("hello"));
+      onProgress(input.expectedSizeBytes);
+      return input.expectedSizeBytes;
+    };
+    const service = createLocalAIModelService(deps, TEST_MANIFEST);
+
+    const models = await service.downloadModel("integrated-balanced");
+
+    expect(models[0].state.status).toBe("available");
+    expect(requests).toEqual([]);
+    expect(nativeDownloads).toEqual([
+      {
+        url: "https://huggingface.co/test/model/resolve/abc123/model.bin",
+        targetPath: modelPath("model.bin"),
+        partialPath: `${modelPath("model.bin")}.partial`,
+        expectedSizeBytes: 5,
+      },
+      {
+        url: "https://huggingface.co/test/model/resolve/abc123/metadata.json",
+        targetPath: modelPath("metadata.json"),
+        partialPath: `${modelPath("metadata.json")}.partial`,
+        expectedSizeBytes: 5,
+      },
+    ]);
+  });
+
   it("treats Hugging Face etags as metadata, not raw file checksums", async () => {
     const { deps } = createDeps();
     const service = createLocalAIModelService(deps, TEST_MANIFEST);

--- a/packages/desktop/src/lib/local-ai-models.ts
+++ b/packages/desktop/src/lib/local-ai-models.ts
@@ -1,4 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
 import { appDataDir } from "@tauri-apps/api/path";
 import {
   exists,
@@ -36,6 +37,20 @@ const MIN_PROGRESS_INTERVAL_MS = 250;
 const LEGACY_LOCAL_AI_MODEL_ID: LocalAIModelId = "integrated-local-ai";
 type LocalAIModelStateSubscriber = () => void;
 const localAIModelStateSubscribers = new Set<LocalAIModelStateSubscriber>();
+
+type NativeDownloadProgressPayload = {
+  downloadId: string;
+  downloadedBytes: number;
+};
+
+type ModelFileDownloadInput = {
+  downloadId: string;
+  url: string;
+  targetPath: string;
+  partialPath: string;
+  expectedSizeBytes: number;
+  signal: AbortSignal;
+};
 
 export function subscribeToLocalAIModelState(callback: LocalAIModelStateSubscriber): () => void {
   localAIModelStateSubscribers.add(callback);
@@ -168,6 +183,11 @@ export interface LocalAIModelServiceDeps {
   size: (path: string) => Promise<number>;
   writeTextFile: (path: string, text: string) => Promise<void>;
   fetch: typeof fetch;
+  downloadModelFile?: (
+    input: ModelFileDownloadInput,
+    onProgress: (downloadedBytes: number) => void,
+  ) => Promise<number>;
+  cancelModelFileDownload?: (downloadId: string) => Promise<void>;
   now: () => number;
   sha256File: (path: string) => Promise<string>;
   webGPUAvailable: () => boolean;
@@ -186,6 +206,35 @@ const defaultDeps: LocalAIModelServiceDeps = {
   size: fsSize,
   writeTextFile,
   fetch: (...args) => fetch(...args),
+  downloadModelFile: async (input, onProgress) => {
+    const progressEvent = `local-ai-model-download-${input.downloadId}`;
+    const unlisten = await listen<NativeDownloadProgressPayload>(progressEvent, (event) => {
+      if (event.payload.downloadId !== input.downloadId) return;
+      onProgress(event.payload.downloadedBytes);
+    });
+    const abort = () => {
+      void invoke("cancel_local_ai_model_download", { downloadId: input.downloadId });
+    };
+
+    input.signal.addEventListener("abort", abort, { once: true });
+    try {
+      return await invoke<number>("download_local_ai_model_file", {
+        request: {
+          downloadId: input.downloadId,
+          url: input.url,
+          targetPath: input.targetPath,
+          partialPath: input.partialPath,
+          expectedSizeBytes: input.expectedSizeBytes,
+          progressEvent,
+        },
+      });
+    } finally {
+      input.signal.removeEventListener("abort", abort);
+      unlisten();
+    }
+  },
+  cancelModelFileDownload: (downloadId) =>
+    invoke("cancel_local_ai_model_download", { downloadId }),
   now: () => Date.now(),
   sha256File: (path) => invoke<string>("sha256_file", { path }),
   webGPUAvailable: () =>
@@ -487,12 +536,16 @@ export function createLocalAIModelService(
   async function downloadFile(input: {
     model: LocalAIModelManifestEntry;
     file: LocalAIModelManifestEntry["files"][number];
+    downloadId: string;
     signal: AbortSignal;
     completedBeforeFile: number;
     totalBytes: number;
     onProgress?: (progress: LocalAIModelDownloadProgress) => void;
   }): Promise<number> {
-    const { model, file, signal, completedBeforeFile, totalBytes, onProgress } = input;
+    const { model, file, downloadId, signal, completedBeforeFile, totalBytes, onProgress } = input;
+    if (signal.aborted) {
+      throw new DOMException("Aborted", "AbortError");
+    }
     const target = await filePath(model, file.path);
     const partial = `${target}.partial`;
     const parent = dirname(target);
@@ -527,6 +580,37 @@ export function createLocalAIModelService(
     const fileRevision = file.revision ?? model.revision;
     const sourcePath = file.sourcePath ?? file.path;
     const url = `https://huggingface.co/${fileRepo}/resolve/${fileRevision}/${sourcePath}`;
+
+    if (deps.downloadModelFile) {
+      let lastProgressAt = 0;
+      const emitProgress = (writtenForFile: number, force = false) => {
+        const now = deps.now();
+        if (!force && now - lastProgressAt < MIN_PROGRESS_INTERVAL_MS) return;
+        lastProgressAt = now;
+        onProgress?.({
+          id: model.id,
+          currentFile: file.path,
+          downloadedBytes: completedBeforeFile + writtenForFile,
+          totalBytes,
+        });
+      };
+
+      const downloaded = await deps.downloadModelFile(
+        {
+          downloadId,
+          url,
+          targetPath: target,
+          partialPath: partial,
+          expectedSizeBytes: file.sizeBytes,
+          signal,
+        },
+        (writtenForFile) => emitProgress(writtenForFile),
+      );
+      emitProgress(downloaded, true);
+      await verifyFile(target, file);
+      return file.sizeBytes;
+    }
+
     let response = await deps.fetch(url, { headers, signal });
     if (response.status === 416 && existingPartialBytes > 0) {
       await deps.remove(partial);
@@ -620,6 +704,7 @@ export function createLocalAIModelService(
         const downloaded = await downloadFile({
           model,
           file,
+          downloadId: id,
           signal: controller.signal,
           completedBeforeFile: completedBytes,
           totalBytes,
@@ -674,6 +759,7 @@ export function createLocalAIModelService(
 
   async function pauseDownload(id: LocalAIModelId): Promise<LocalAIModelViewState[]> {
     activeDownloads.get(id)?.abort();
+    await deps.cancelModelFileDownload?.(id);
     await updateModelState(id, (current) => ({
       ...current,
       status: current.status === "downloading" ? "paused" : current.status,

--- a/packages/desktop/src/lib/semantic-classifier.test.ts
+++ b/packages/desktop/src/lib/semantic-classifier.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+async function loadSemanticClassifierModule({
+  enabled,
+  summary = { updated: 1, remaining: 0, total: 28_349 },
+}: {
+  enabled: { current: boolean };
+  summary?: { updated: number; remaining: number; total: number };
+}) {
+  vi.resetModules();
+
+  const callbacks: {
+    doc: ((state: { docItemCount: number }) => void) | null;
+    model: (() => void) | null;
+    preferences: (() => void) | null;
+  } = {
+    doc: null,
+    model: null,
+    preferences: null,
+  };
+  const mockDocBackfillContentSignals = vi.fn(async () => summary);
+  const mockUpdateHealth = vi.fn(async () => undefined);
+  const mockListModels = vi.fn(async () => [
+    {
+      selected: true,
+      manifest: {
+        id: "integrated-pro",
+        supportsSemanticSearch: true,
+      },
+      state: {
+        status: "available",
+      },
+    },
+  ]);
+
+  vi.doMock("./automerge.js", () => ({
+    docBackfillContentSignals: mockDocBackfillContentSignals,
+    subscribe: vi.fn((callback: (state: { docItemCount: number }) => void) => {
+      callbacks.doc = callback;
+      return () => {
+        callbacks.doc = null;
+      };
+    }),
+  }));
+  vi.doMock("./local-ai-models.js", () => ({
+    localAIModels: {
+      listModels: mockListModels,
+      updateHealth: mockUpdateHealth,
+    },
+    subscribeToLocalAIModelState: vi.fn((callback: () => void) => {
+      callbacks.model = callback;
+      return () => {
+        callbacks.model = null;
+      };
+    }),
+  }));
+  vi.doMock("@freed/ui/lib/debug-store", () => ({
+    addDebugEvent: vi.fn(),
+  }));
+  vi.doMock("./logger.js", () => ({
+    log: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+  }));
+
+  const mod = await import("./semantic-classifier.js");
+  mod.start({
+    isEnabled: () => enabled.current,
+    subscribeToPreferenceChanges: (callback) => {
+      callbacks.preferences = callback;
+      return () => {
+        callbacks.preferences = null;
+      };
+    },
+  });
+
+  return {
+    callbacks,
+    mockDocBackfillContentSignals,
+    mockUpdateHealth,
+    mod,
+  };
+}
+
+describe("semantic classifier", () => {
+  afterEach(async () => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it("does not backfill or record health while workflow preferences are disabled", async () => {
+    vi.useFakeTimers();
+    const enabled = { current: false };
+    const { callbacks, mockDocBackfillContentSignals, mockUpdateHealth, mod } =
+      await loadSemanticClassifierModule({ enabled });
+
+    callbacks.doc?.({ docItemCount: 1 });
+    callbacks.model?.();
+    callbacks.preferences?.();
+    await vi.advanceTimersByTimeAsync(15_000);
+
+    expect(mockDocBackfillContentSignals).not.toHaveBeenCalled();
+    expect(mockUpdateHealth).not.toHaveBeenCalled();
+    mod.stop();
+  });
+
+  it("starts classification and records health when Topics and ranking becomes enabled", async () => {
+    vi.useFakeTimers();
+    const enabled = { current: false };
+    const { callbacks, mockDocBackfillContentSignals, mockUpdateHealth, mod } =
+      await loadSemanticClassifierModule({ enabled });
+
+    enabled.current = true;
+    callbacks.preferences?.();
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(mockDocBackfillContentSignals).toHaveBeenCalledWith(100);
+    expect(mockUpdateHealth).toHaveBeenCalledWith("integrated-pro", {
+      lastIndexedItemCount: 28_349,
+      lastRunAt: expect.any(Number),
+      failureCount: 0,
+    });
+    mod.stop();
+  });
+});

--- a/packages/desktop/src/lib/semantic-classifier.ts
+++ b/packages/desktop/src/lib/semantic-classifier.ts
@@ -8,6 +8,11 @@ const PROCESS_INTERVAL_MS = 5_000;
 const RETRY_COOLDOWN_MS = 60_000;
 const HEARTBEAT_INTERVAL_MS = 5 * 60 * 1000;
 
+type SemanticClassifierOptions = {
+  isEnabled?: () => boolean;
+  subscribeToPreferenceChanges?: (callback: () => void) => () => void;
+};
+
 let running = false;
 let scheduled = false;
 let processing = false;
@@ -20,14 +25,22 @@ let intervalHandle: ReturnType<typeof setInterval> | null = null;
 let heartbeatHandle: ReturnType<typeof setInterval> | null = null;
 let unsubscribeDoc: (() => void) | null = null;
 let unsubscribeLocalAIModelState: (() => void) | null = null;
+let unsubscribePreferenceChanges: (() => void) | null = null;
 let pending = 0;
+let isEnabled: () => boolean = () => false;
 
 function scheduleBackfill(): void {
+  if (!isEnabled()) {
+    scheduled = false;
+    pending = 0;
+    return;
+  }
   scheduled = true;
   pending = Math.max(pending, 1);
 }
 
 async function recordSemanticHealth(summary: Awaited<ReturnType<typeof docBackfillContentSignals>>): Promise<void> {
+  if (!isEnabled()) return;
   try {
     const models = await localAIModels.listModels();
     const semanticModel =
@@ -47,6 +60,11 @@ async function recordSemanticHealth(summary: Awaited<ReturnType<typeof docBackfi
 
 async function processNextBatch(): Promise<void> {
   if (!running || processing || !scheduled) return;
+  if (!isEnabled()) {
+    scheduled = false;
+    pending = 0;
+    return;
+  }
   const now = Date.now();
   if (lastFailureAt && now - lastFailureAt < RETRY_COOLDOWN_MS) return;
 
@@ -75,11 +93,12 @@ async function processNextBatch(): Promise<void> {
   }
 }
 
-export function start(): void {
+export function start(options: SemanticClassifierOptions = {}): void {
   if (running) return;
+  isEnabled = options.isEnabled ?? (() => false);
   running = true;
-  scheduled = true;
-  pending = 1;
+  scheduled = isEnabled();
+  pending = scheduled ? 1 : 0;
   lastScannedDocItemCount = null;
 
   unsubscribeDoc = subscribe((state) => {
@@ -90,6 +109,9 @@ export function start(): void {
   unsubscribeLocalAIModelState = subscribeToLocalAIModelState(() => {
     scheduleBackfill();
   });
+  unsubscribePreferenceChanges = options.subscribeToPreferenceChanges?.(() => {
+    scheduleBackfill();
+  }) ?? null;
 
   log.info("[semantic-classifier] started");
 
@@ -133,6 +155,11 @@ export function stop(): void {
     unsubscribeLocalAIModelState();
     unsubscribeLocalAIModelState = null;
   }
+  if (unsubscribePreferenceChanges) {
+    unsubscribePreferenceChanges();
+    unsubscribePreferenceChanges = null;
+  }
+  isEnabled = () => false;
 
   log.info("[semantic-classifier] stopped");
 }

--- a/packages/desktop/tests/e2e/fixtures/tauri-init.ts
+++ b/packages/desktop/tests/e2e/fixtures/tauri-init.ts
@@ -33,6 +33,8 @@ export function tauriInitScript(): string {
       get_all_local_ips: () => [],
       get_sync_url: () => 'ws://127.0.0.1:8765',
       sha256_file: () => '',
+      download_local_ai_model_file: (args) => args && args.request ? args.request.expectedSizeBytes || 0 : 0,
+      cancel_local_ai_model_download: () => null,
       get_sync_client_count: () => 0,
       get_runtime_memory_stats: () => ({
         totalPhysicalMemoryBytes: 16 * 1024 * 1024 * 1024,

--- a/packages/desktop/tests/e2e/local-ai-settings.spec.ts
+++ b/packages/desktop/tests/e2e/local-ai-settings.spec.ts
@@ -35,15 +35,15 @@ test("integrated AI settings offer a recommended local pack ladder", async ({ ap
   await expect(localAISettings).toBeVisible({ timeout: 5_000 });
   await expect(localAISettings.getByText("Integrated AI Download")).toBeVisible();
   await expect(localAISettings.getByText(/Choose one local pack/)).toBeVisible();
-  await expect(localAISettings.getByText(/Semantic scans run on startup/)).toBeVisible();
+  await expect(localAISettings.getByText(/Local classification runs only when Topics and ranking is enabled/)).toBeVisible();
   await expect(localAISettings.getByTestId("local-ai-pack-light")).toBeVisible();
   await expect(localAISettings.getByTestId("local-ai-pack-balanced")).toBeVisible();
   await expect(localAISettings.getByTestId("local-ai-pack-pro")).toBeVisible();
   await expect(localAISettings.getByText("Recommended: Balanced")).toBeVisible();
   await expect(localAISettings.getByTestId("local-ai-pack-balanced").getByText("Selected")).toBeVisible();
   await expect(localAISettings.getByTestId("local-ai-pack-balanced").getByText("Recommended", { exact: true })).toBeVisible();
-  await expect(localAISettings.getByTestId("local-ai-pack-balanced").getByText(/Classified:/)).toBeVisible();
-  await expect(localAISettings.getByTestId("local-ai-pack-balanced").getByText(/Last scan:/)).toBeVisible();
+  await expect(localAISettings.getByTestId("local-ai-pack-balanced").getByText("Classified: Off")).toBeVisible();
+  await expect(localAISettings.getByTestId("local-ai-pack-balanced").getByText("Last scan: Not enabled")).toBeVisible();
   await expect(localAISettings.getByText("Not installed")).toHaveCount(3);
   await expect(localAISettings.getByRole("button", { name: "Download" })).toHaveCount(3);
 
@@ -64,8 +64,8 @@ test("integrated AI settings offer a recommended local pack ladder", async ({ ap
 
   await providerSelector.getByRole("button", { name: /Ollama/ }).click();
   await expect(providerSelector.getByRole("button", { name: /Ollama/ })).toHaveAttribute("aria-pressed", "true");
-  await expect(settingsDialog.getByRole("switch", { name: "Summaries and extraction" })).toHaveAttribute("aria-checked", "true");
-  await expect(settingsDialog.getByRole("switch", { name: "Topics and ranking" })).toHaveAttribute("aria-checked", "true");
+  await expect(settingsDialog.getByRole("switch", { name: "Summaries and extraction" })).toHaveAttribute("aria-checked", "false");
+  await expect(settingsDialog.getByRole("switch", { name: "Topics and ranking" })).toHaveAttribute("aria-checked", "false");
 
   await providerSelector.getByRole("button", { name: /Off/ }).click();
   await expect(settingsDialog.getByRole("switch", { name: "Summaries and extraction" })).toHaveCount(0);

--- a/packages/ui/src/components/settings/AISection.tsx
+++ b/packages/ui/src/components/settings/AISection.tsx
@@ -265,6 +265,7 @@ function LocalModelCard({
   onPause,
   onRemove,
   onOpenSource,
+  classificationEnabled,
 }: {
   model: LocalAIModelViewState;
   recommended: boolean;
@@ -274,6 +275,7 @@ function LocalModelCard({
   onPause: (id: LocalAIModelId) => void;
   onRemove: (id: LocalAIModelId) => void;
   onOpenSource: (url: string) => void;
+  classificationEnabled: boolean;
 }) {
   const progressTotal = model.state.totalBytes || model.manifest.estimatedDownloadBytes;
   const progress = progressTotal > 0
@@ -323,8 +325,18 @@ function LocalModelCard({
       <div className="mt-3 grid gap-2 text-xs text-[var(--theme-text-muted)] sm:grid-cols-2">
         <p>Download: <span className="text-[var(--theme-text-secondary)]">{formatBytes(model.manifest.estimatedDownloadBytes)}</span></p>
         <p>Storage: <span className="text-[var(--theme-text-secondary)]">{formatBytes(model.state.storageBytes || model.manifest.estimatedStorageBytes)}</span></p>
-        <p>Classified: <span className="text-[var(--theme-text-secondary)]">{NUMBER_FORMAT.format(model.state.health?.lastIndexedItemCount ?? 0)} items</span></p>
-        <p>Last scan: <span className="text-[var(--theme-text-secondary)]">{formatLocalTime(model.state.health?.lastRunAt)}</span></p>
+        <p>
+          Classified: <span className="text-[var(--theme-text-secondary)]">
+            {classificationEnabled
+              ? `${NUMBER_FORMAT.format(model.state.health?.lastIndexedItemCount ?? 0)} items`
+              : "Off"}
+          </span>
+        </p>
+        <p>
+          Last scan: <span className="text-[var(--theme-text-secondary)]">
+            {classificationEnabled ? formatLocalTime(model.state.health?.lastRunAt) : "Not enabled"}
+          </span>
+        </p>
       </div>
 
       <p className="mt-2 text-xs leading-5 text-[var(--theme-text-soft)]">{model.manifest.hardwareNote}</p>
@@ -555,6 +567,12 @@ export function AISection() {
     [localModels, recommendedModelId],
   );
   const selectedLocalModelReady = selectedLocalModel?.state.status === "available";
+  const integratedClassificationEnabled = Boolean(
+    displayedAI.provider === "integrated" &&
+    displayedAI.extractTopics &&
+    selectedLocalModelReady &&
+    selectedLocalModel?.manifest.supportsSemanticSearch,
+  );
   const integratedSummariesEnabled =
     displayedAI.provider !== "integrated" ||
     Boolean(selectedLocalModelReady && selectedLocalModel?.manifest.supportsSummaries);
@@ -619,8 +637,8 @@ export function AISection() {
     update({
       provider,
       model: DEFAULT_MODELS[provider],
-      autoSummarize: disabling ? false : enablingFromOff ? true : displayedAI.autoSummarize,
-      extractTopics: disabling ? false : enablingFromOff ? true : displayedAI.extractTopics,
+      autoSummarize: disabling || enablingFromOff ? false : displayedAI.autoSummarize,
+      extractTopics: disabling || enablingFromOff ? false : displayedAI.extractTopics,
     });
   };
 
@@ -714,7 +732,7 @@ export function AISection() {
             </h3>
             <p className="mt-1 text-xs leading-5 text-[var(--theme-text-muted)]">
               Freed Desktop does not ship model weights. Choose one local pack for this device.
-              Semantic scans run on startup, after new content arrives, and when local pack state changes.
+              Local classification runs only when Topics and ranking is enabled.
             </p>
           </div>
           {!localAIModels ? (
@@ -744,6 +762,10 @@ export function AISection() {
                   onPause={handlePauseLocalModel}
                   onRemove={handleRemoveLocalModel}
                   onOpenSource={handleOpenSource}
+                  classificationEnabled={
+                    integratedClassificationEnabled &&
+                    selectedLocalModel?.manifest.id === model.manifest.id
+                  }
                 />
               ))}
             </div>


### PR DESCRIPTION
(AI Generated).

## Summary
- Stream Integrated AI model files through native disk IO instead of WebKit fetch.
- Rebuild stale macOS renderers on the main thread so recovery does not disappear after the old renderer is destroyed.
- Attribute dev and installed WebKit memory correctly, log scrape preflight memory state, and block scraper launches at the high memory threshold.
- Keep local AI workflows off by default, gate semantic classification behind Topics and ranking, and show classification health as off when the workflow is disabled.

## Testing
- npm run validate:feature
- npm run test:unit -- semantic-classifier.test.ts local-ai-models.test.ts
- cargo test --lib
- PATH=<worktree>/node_modules/.bin:$PATH npm run test:e2e -- local-ai-settings.spec.ts
- Native Tauri preview soak with sample data for more than 30 minutes, WebKit RSS remained stable after scraper memory gating
