### PR TITLE
fix: grant startup recovery window desktop permissions

### DIFF
--- a/packages/desktop/src-tauri/capabilities/default.json
+++ b/packages/desktop/src-tauri/capabilities/default.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2/capability",
   "identifier": "default",
   "description": "Default capabilities for the Freed desktop app",
-  "windows": ["main", "x-login"],
+  "windows": ["main", "startup-recovery", "x-login"],
   "permissions": [
     "core:default",
     "core:window:allow-start-dragging",

--- a/packages/desktop/src/tauri-capabilities.test.ts
+++ b/packages/desktop/src/tauri-capabilities.test.ts
@@ -27,4 +27,13 @@ describe("desktop Tauri capabilities", () => {
     expect(capability.permissions).toContain("fs:allow-appdata-write-recursive");
     expect(capability.permissions).toContain("fs:allow-appdata-meta-recursive");
   });
+
+  it("grants recovery windows the permissions needed to update or open fallback downloads", () => {
+    const capability = readDefaultDesktopCapability();
+
+    expect(capability.windows).toContain("startup-recovery");
+    expect(capability.permissions).toContain("shell:allow-open");
+    expect(capability.permissions).toContain("updater:default");
+    expect(capability.permissions).toContain("process:default");
+  });
 });


### PR DESCRIPTION
(AI Generated).

## Summary
- Grant the startup recovery window the Tauri permissions it needs to check and install updates, relaunch, and open fallback download links.
- Add a capability regression test so the recovery window cannot lose updater, process, or shell access silently again.

## Testing
- `npm run test:unit -- tauri-capabilities.test.ts` from `packages/desktop`
- `npm run test:e2e -- startup-recovery.spec.ts` from `packages/desktop`
- `npm run validate:feature`
