### PR TITLE
fix: keep friends map scoped to confirmed friends

### DIFF
--- a/packages/desktop/tests/e2e/smoke.spec.ts
+++ b/packages/desktop/tests/e2e/smoke.spec.ts
@@ -4001,6 +4001,26 @@ test("map defaults to All content when only unlinked author locations exist", as
   await expect(page.locator('.freed-map-marker[aria-label="Ghost Noise"]')).toHaveCount(0);
 });
 
+test("explicit Friends map mode hides unlinked author locations", async ({ app, page }) => {
+  await app.goto();
+  await app.waitForReady();
+  await app.seedAllContentLocationsWithoutFriends();
+  await dismissCloudSyncNudgeIfPresent(page);
+
+  await page.getByRole("button", { name: /^Map/ }).click();
+  await expect(page.locator('.freed-map-marker[aria-label="Nora Quinn"]')).toBeVisible({
+    timeout: 10_000,
+  });
+
+  const friendsButton = page
+    .getByTestId("map-toolbar-scope")
+    .getByRole("button", { name: "Friends", exact: true });
+  await friendsButton.click();
+  await expect(friendsButton).toHaveAttribute("aria-pressed", "true", { timeout: 10_000 });
+  await expect(page.locator('.freed-map-marker[aria-label="Nora Quinn"]')).toHaveCount(0);
+  await expect(page.getByText("0 friends on the map")).toBeVisible({ timeout: 10_000 });
+});
+
 test("friends and map move identity controls into the header and hide feed bulk actions", async ({ app, page }) => {
   await page.setViewportSize({ width: 1440, height: 900 });
   await app.goto();

--- a/packages/pwa/src/lib/map-locations.test.ts
+++ b/packages/pwa/src/lib/map-locations.test.ts
@@ -1,12 +1,14 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   extractLocationFromItem,
+  countFriendsWithRecentLocationUpdates,
   filterResolvedLocationsByTime,
   getDefaultMapMode,
   getLatestAuthorLocationMarkers,
   getLatestFriendLocationMarkers,
   getLastSeenLocationForFriend,
   groupResolvedLocations,
+  resolveMapMode,
   type FeedItem,
   type Friend,
   type LocationMarkerSummary,
@@ -287,6 +289,62 @@ describe("location grouping", () => {
     expect(getDefaultMapMode(0, 4)).toBe("all_content");
     expect(getDefaultMapMode(2, 4)).toBe("friends");
     expect(getDefaultMapMode(0, 0)).toBe("friends");
+  });
+
+  it("honors an explicit Friends map mode even when only all-content markers exist", () => {
+    expect(resolveMapMode("friends", 0, 4)).toBe("friends");
+    expect(resolveMapMode("all_content", 2, 0)).toBe("all_content");
+    expect(resolveMapMode(undefined, 0, 4)).toBe("all_content");
+  });
+
+  it("counts only confirmed friends as mapped friends", () => {
+    const friend = makeFriend({ id: "friend-ada" });
+    const connection = makeFriend({
+      id: "person-joe",
+      name: "Joe Jarvis",
+      relationshipStatus: "connection",
+      sources: [
+        {
+          platform: "instagram",
+          authorId: "joe-ig",
+          handle: "joe",
+        },
+      ],
+    });
+    const now = Date.now();
+
+    const count = countFriendsWithRecentLocationUpdates(
+      [
+        makeItem({
+          globalId: "ig:ada:paris",
+          publishedAt: now - 60_000,
+          location: {
+            name: "Paris",
+            coordinates: { lat: 48.8566, lng: 2.3522 },
+            source: "geo_tag",
+          },
+        }),
+        makeItem({
+          globalId: "ig:joe:puerto-rico",
+          publishedAt: now - 30_000,
+          author: { id: "joe-ig", handle: "joe", displayName: "Joe Jarvis" },
+          location: {
+            name: "Puerto Rico",
+            coordinates: { lat: 18.2208, lng: -66.5901 },
+            source: "geo_tag",
+          },
+        }),
+      ],
+      {
+        [friend.id]: friend,
+        [connection.id]: connection,
+      },
+      undefined,
+      7 * 24 * 60 * 60 * 1000,
+      now,
+    );
+
+    expect(count).toBe(1);
   });
 
   it("keeps future time windows out of the current map until they start", () => {

--- a/packages/shared/src/location.ts
+++ b/packages/shared/src/location.ts
@@ -498,7 +498,7 @@ export function countFriendsWithRecentLocationUpdates(
           item.platform,
           item.author.id,
         );
-    if (friend && (!accounts || friend.relationshipStatus === "friend")) {
+    if (friend?.relationshipStatus === "friend") {
       friendIds.add(friend.id);
     }
   }
@@ -539,12 +539,6 @@ export function resolveMapMode(
 ): MapMode {
   if (!preferredMode) {
     return getDefaultMapMode(friendMarkerCount, allContentMarkerCount);
-  }
-  if (preferredMode === "friends" && friendMarkerCount === 0 && allContentMarkerCount > 0) {
-    return "all_content";
-  }
-  if (preferredMode === "all_content" && allContentMarkerCount === 0 && friendMarkerCount > 0) {
-    return "friends";
   }
   return preferredMode;
 }

--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -317,10 +317,13 @@ export function Header({
   );
 
   const scopeLabel = useMemo(() => getFilterLabel(activeFilter, feeds, accounts), [accounts, activeFilter, feeds]);
-  const friendCount = useMemo(() => Object.keys(friends).length, [friends]);
+  const friendCount = useMemo(
+    () => Object.values(persons).filter((person) => person.relationshipStatus === "friend").length,
+    [persons],
+  );
   const mappedFriendCount = useMemo(
-    () => countFriendsWithRecentLocationUpdates(items, friends),
-    [friends, items],
+    () => countFriendsWithRecentLocationUpdates(items, persons, accounts),
+    [accounts, items, persons],
   );
   const mappedAllContentCount = useMemo(
     () => countAuthorsWithRecentLocationUpdates(items),


### PR DESCRIPTION
(AI Generated).

## Summary
- Friends map mode now stays scoped to confirmed friends, and map header counts use confirmed friend relationships instead of legacy person projections.

## Testing
- npm run validate:feature