### PR TITLE
fix: preserve paused native local AI downloads

### DIFF
--- a/packages/desktop/src/lib/local-ai-models.test.ts
+++ b/packages/desktop/src/lib/local-ai-models.test.ts
@@ -376,6 +376,53 @@ describe("local AI model manager", () => {
     expect(paused[0].state.downloadedBytes).toBe(1_048_576);
   });
 
+  it("keeps a native download paused if pause lands during final bookkeeping", async () => {
+    const nativeManifest: readonly LocalAIModelManifestEntry[] = [
+      {
+        ...TEST_MANIFEST[0],
+        estimatedDownloadBytes: 5,
+        estimatedStorageBytes: 5,
+        files: [{ path: "model.bin", sizeBytes: 5, sha1: HELLO_SHA1 }],
+      },
+    ];
+    let markSizeStarted: (() => void) | null = null;
+    const sizeStarted = new Promise<void>((resolve) => {
+      markSizeStarted = resolve;
+    });
+    let releaseSize: (() => void) | null = null;
+    const allowSizeToFinish = new Promise<void>((resolve) => {
+      releaseSize = resolve;
+    });
+    const { deps, files } = createDeps();
+    deps.downloadModelFile = async (input) => {
+      files.set(input.targetPath, TEXT.encode("hello"));
+      return input.expectedSizeBytes;
+    };
+    deps.size = async (path) => {
+      if (path === "/app/local-ai-models/integrated-balanced/abc123") {
+        markSizeStarted?.();
+        await allowSizeToFinish;
+      }
+      const file = files.get(path);
+      if (file) return file.byteLength;
+      const prefix = path.endsWith("/") ? path : `${path}/`;
+      return Array.from(files.entries()).reduce(
+        (sum, [key, value]) => sum + (key.startsWith(prefix) ? value.byteLength : 0),
+        0,
+      );
+    };
+    const service = createLocalAIModelService(deps, nativeManifest);
+
+    const pending = service.downloadModel("integrated-balanced");
+    await sizeStarted;
+    await service.pauseDownload("integrated-balanced");
+    releaseSize?.();
+    const paused = await pending;
+
+    expect(paused[0].state.status).toBe("paused");
+    expect(paused[0].state.downloadedBytes).toBe(5);
+  });
+
   it("removes downloaded model files and resets state", async () => {
     const { deps, files } = createDeps();
     const service = createLocalAIModelService(deps, TEST_MANIFEST);

--- a/packages/desktop/src/lib/local-ai-models.ts
+++ b/packages/desktop/src/lib/local-ai-models.ts
@@ -719,8 +719,14 @@ export function createLocalAIModelService(
         }));
       }
 
+      if (controller.signal.aborted) {
+        throw new DOMException("Aborted", "AbortError");
+      }
       const dir = await modelDir(model);
       const storageBytes = await deps.size(dir).catch(() => completedBytes);
+      if (controller.signal.aborted) {
+        throw new DOMException("Aborted", "AbortError");
+      }
       await updateModelState(id, (current) => ({
         ...current,
         status: "available",


### PR DESCRIPTION
(AI Generated).

## Summary
- preserve the paused state when a native local AI download is cancelled during final bookkeeping
- add a regression test for pausing after the last file finishes but before the model is marked available

## Root cause
- `downloadModel()` still finalized the pack as `available` after the native downloader completed, even if `pauseDownload()` landed during the final `deps.size(...)` bookkeeping window

## Validation
- local desktop Vitest is blocked in this worktree because `../../node_modules/vitest/vitest.mjs` is missing and `packages/desktop/vite.config.ts` cannot resolve `vitest`
- rely on PR CI for executable validation in this lane
