### PR TITLE
fix: unblock local AI pause test build

### DIFF
--- a/packages/desktop/src/lib/local-ai-models.test.ts
+++ b/packages/desktop/src/lib/local-ai-models.test.ts
@@ -389,7 +389,9 @@ describe("local AI model manager", () => {
     const sizeStarted = new Promise<void>((resolve) => {
       markSizeStarted = resolve;
     });
-    let releaseSize: (() => void) | null = null;
+    let releaseSize: () => void = () => {
+      throw new Error("releaseSize resolver was not initialized");
+    };
     const allowSizeToFinish = new Promise<void>((resolve) => {
       releaseSize = resolve;
     });
@@ -416,7 +418,7 @@ describe("local AI model manager", () => {
     const pending = service.downloadModel("integrated-balanced");
     await sizeStarted;
     await service.pauseDownload("integrated-balanced");
-    releaseSize?.();
+    releaseSize();
     const paused = await pending;
 
     expect(paused[0].state.status).toBe("paused");


### PR DESCRIPTION
(AI Generated).

## Summary
- fix the local AI pause test resolver typing so CI root build can compile tests
- keep the paused-download regression assertion unchanged

## Validation
- PATH=/Users/aubreyfalconer/dev/freed-dev-release-classifier-fix/node_modules/.bin:$PATH npm run build (packages/desktop)
- PATH=/Users/aubreyfalconer/dev/freed-dev-release-classifier-fix/node_modules/.bin:$PATH npm run test:unit -- src/lib/local-ai-models.test.ts (packages/desktop)
- npm run validate:feature