### PR TITLE
fix: promote linked accounts without duplicate drafts

### DIFF
--- a/packages/desktop/tests/e2e/smoke.spec.ts
+++ b/packages/desktop/tests/e2e/smoke.spec.ts
@@ -5088,6 +5088,86 @@ test("AI ranked friend suggestions surface and promote connection people", async
   });
 });
 
+test("account detail promote upgrades a linked connection instead of opening a duplicate draft", async ({ app, page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await app.goto();
+  await app.waitForReady();
+
+  await page.evaluate(async () => {
+    const w = window as Record<string, unknown>;
+    const automerge = w.__FREED_AUTOMERGE__ as {
+      docAddPersons: (persons: unknown[]) => Promise<void>;
+      docAddAccount: (account: unknown) => Promise<void>;
+    };
+    const store = w.__FREED_STORE__ as {
+      getState: () => {
+        updatePreferences: (patch: { display: { friendsMode: "all_content" } }) => Promise<void>;
+        setActiveView: (view: string) => void;
+        setSelectedAccount: (accountId: string | null) => void;
+      };
+    };
+
+    const now = Date.now();
+    await automerge.docAddPersons([
+      {
+        id: "connection-linked-account",
+        name: "Linked Maya",
+        relationshipStatus: "connection",
+        careLevel: 2,
+        createdAt: now,
+        updatedAt: now,
+      },
+    ]);
+    await automerge.docAddAccount({
+      id: "social:instagram:linked-maya",
+      personId: "connection-linked-account",
+      kind: "social",
+      provider: "instagram",
+      externalId: "linked-maya",
+      handle: "linkedmaya",
+      displayName: "Linked Maya",
+      firstSeenAt: now,
+      lastSeenAt: now,
+      discoveredFrom: "captured_item",
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    await store.getState().updatePreferences({ display: { friendsMode: "all_content" } });
+    store.getState().setActiveView("friends");
+    store.getState().setSelectedAccount("social:instagram:linked-maya");
+  });
+
+  const promoteButton = page.getByRole("button", { name: "Promote to friend", exact: true });
+  await expect(promoteButton).toBeVisible({ timeout: 10_000 });
+  await promoteButton.click();
+
+  await expect.poll(async () =>
+    page.evaluate(() => {
+      const store = (window as Record<string, unknown>).__FREED_STORE__ as {
+        getState: () => {
+          selectedPersonId: string | null;
+          selectedAccountId: string | null;
+          persons: Record<string, { relationshipStatus: string; careLevel: number }>;
+        };
+      };
+      const state = store.getState();
+      return {
+        selectedPersonId: state.selectedPersonId,
+        selectedAccountId: state.selectedAccountId,
+        person: state.persons["connection-linked-account"],
+      };
+    }),
+  ).toMatchObject({
+    selectedPersonId: "connection-linked-account",
+    selectedAccountId: null,
+    person: {
+      relationshipStatus: "friend",
+      careLevel: 3,
+    },
+  });
+});
+
 test("AI ranked friend suggestion dismiss hides the candidate without deleting the account", async ({ app, page }) => {
   await page.setViewportSize({ width: 1440, height: 900 });
   await app.goto();

--- a/packages/ui/src/components/friends/FriendsView.tsx
+++ b/packages/ui/src/components/friends/FriendsView.tsx
@@ -801,10 +801,20 @@ export function FriendsView({
     [updateAccount],
   );
 
-  const handlePromoteSelectedAccount = useCallback(() => {
+  const handlePromoteSelectedAccount = useCallback(async () => {
     if (!selectedAccount) return;
+    const linkedPerson = selectedAccount.personId ? persons[selectedAccount.personId] ?? null : null;
+    if (linkedPerson && linkedPerson.relationshipStatus !== "friend") {
+      await updatePerson(linkedPerson.id, {
+        relationshipStatus: "friend",
+        careLevel: 3,
+        updatedAt: Date.now(),
+      });
+      setSelectedPerson(linkedPerson.id);
+      return;
+    }
     setEditorState({ kind: "new", draft: friendDraftFromAccount(selectedAccount) });
-  }, [selectedAccount]);
+  }, [persons, selectedAccount, setSelectedPerson, updatePerson]);
 
   const handlePromoteSelectedPerson = useCallback(async () => {
     if (!selectedPerson || selectedPerson.relationshipStatus === "friend") return;


### PR DESCRIPTION
(AI Generated).

## Summary
- Promote a linked connection in place when account detail uses the friend CTA
- Keep the new draft flow only for truly unlinked accounts

## Testing
- Focused desktop Playwright smoke test added for the linked-account promotion path
- Local execution blocked because ../../node_modules/playwright/cli.js is missing in this worktree