### PR TITLE
fix: harden desktop background runtime recovery

### DIFF
--- a/docs/PHASE-5-DESKTOP.md
+++ b/docs/PHASE-5-DESKTOP.md
@@ -1,6 +1,6 @@
 # Phase 5: Desktop & Mobile App (Tauri)
 
-> **Status:** 🚧 In Progress (direct desktop distribution live, macOS signing and notarization live in releases, legal consent gate shipped, tri-state sidebar chrome shipped, local snapshot restore shipped, public-safe bug reporting shipped, runtime memory telemetry shipped, native startup recovery shipped, bundled recovery updater flow shipped, permanent local social media vault shipped, desktop hot-path side-effect scheduling shipped, event-aware outbox drains shipped, incremental item-patch state updates shipped)
+> **Status:** 🚧 In Progress (direct desktop distribution live, macOS signing and notarization live in releases, legal consent gate shipped, tri-state sidebar chrome shipped, local snapshot restore shipped, public-safe bug reporting shipped, runtime memory telemetry shipped, native startup recovery shipped, bundled recovery updater flow shipped, permanent local social media vault shipped, desktop hot-path side-effect scheduling shipped, event-aware outbox drains shipped, incremental item-patch state updates shipped, background runtime coordination shipped)
 > **Dependencies:** Phase 4 (Sync Layer)  
 > **Priority:** 🎯 HIGHEST — Universal liberation tool
 
@@ -36,6 +36,7 @@ Large app store distribution is not part of the current strategy. The mobile rea
 - **Live toolbar reopen cue** — During desktop drag preview, once the primary sidebar crosses into the closed state, the toolbar control now swaps immediately from collapse to expand so the reopen affordance stays truthful before mouseup
 - **Animated preview rail toggle:** The desktop reader keeps the compact preview rail mounted through show and hide transitions, while `Animations: None` still snaps instantly
 - **Hot-path side-effect scheduling:** Desktop routes native JSON persistence, encrypted secret store calls, cloud uploads, and outbox drains through typed queues so clicks, scroll callbacks, and document subscriptions do not directly run slow native I/O or large scans
+- **Background runtime coordination:** Desktop gates high-risk background work behind healthy renderer startup, shared memory pressure cooldowns, and a native social-scrape lease so WebKit pressure cannot keep blanking the main window
 
 ---
 
@@ -308,6 +309,9 @@ export async function captureDomFeed(
 - [x] Desktop debug tooling now samples runtime memory, relay document size, relay client count, and content-fetcher queue depth so long-run RAM growth can be correlated without attaching Instruments first
 - [x] Desktop diagnostics now also sample renderer JS heap and DOM node counts so overnight RAM growth can be split between native process pressure and WebView pressure
 - [x] Desktop diagnostics now include Freed-owned WebKit renderer RSS, Automerge binary size, IndexedDB size, WebKit cache size, and adaptive memory guardrails that reclaim scraper windows and network-cache blobs before pausing social capture
+- [x] Desktop now records rotating runtime-health diagnostics with renderer heartbeat state, memory preflight results, recovery attempts, and active background work so blank-renderer reports include the last bad minute of runtime context
+- [x] High-risk background work now waits for healthy renderer startup and memory pressure cooldowns before running content fetches, RSS polls, automatic snapshots, cloud uploads, outbox drains, or native social scrapes
+- [x] Native renderer recovery now marks failed recovery state, requests relaunch, and forces the old process to exit if the main WebView label stays stuck after a destroyed renderer
 - [x] Native relay broadcasts now reuse shared document buffers and stop writing a full snapshot on every live document push, reducing clone pressure during heavy sync churn
 - [x] Desktop worker state no longer ships the full `allItemIds` list or full Automerge binary back to the main thread on every mutation, and the content fetcher now bounds its failed-item cooldown cache instead of keeping an immortal set of every fetch miss
 - [x] Background fetch now tracks in-flight items, runs one active worker job at a time, and uses randomized pacing plus capped backoff so slow AI or network work cannot overlap the queue into renderer pressure
@@ -356,7 +360,11 @@ export async function captureDomFeed(
 > WebKit cache size, and adaptive high and critical memory limits. Social
 > capture now runs a native preflight that recycles stale scraper windows and
 > trims only Freed WebKit network-cache blobs before it decides a scrape must
-> pause. Critical memory pressure pauses background content fetching, then
+> pause. The background runtime now also gates content fetches, RSS polls,
+> automatic snapshots, cloud uploads, outbox drains, and social scrapes behind
+> healthy renderer startup and shared pressure cooldowns, while native recovery
+> writes runtime-health records and relaunches if the old renderer label stays
+> stuck after destroy. Critical memory pressure pauses background content fetching, then
 > offers a restart action instead of letting WebKit conduct the RAM orchestra
 > with a shovel. The background content fetcher now runs one active worker job
 > at a time, randomizes its next fetch delay, backs off after timeouts or AI

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -64,12 +64,17 @@ const MAX_CRITICAL_MEMORY_BYTES: u64 = 8 * BYTES_PER_GIB;
 const WEBKIT_CACHE_TRIM_AT_BYTES: u64 = 768 * 1024 * 1024;
 const WEBKIT_CACHE_TRIM_TARGET_BYTES: u64 = 512 * 1024 * 1024;
 const STARTUP_RECOVERY_STATE_FILE: &str = "startup-recovery.json";
+const RUNTIME_HEALTH_FILE: &str = "runtime-health.jsonl";
 const RECOVERY_WINDOW_LABEL: &str = "startup-recovery";
 const RECOVERY_WINDOW_ROUTE: &str = "startup-recovery.html";
 const RENDERER_HEARTBEAT_WATCHDOG_INTERVAL: Duration = Duration::from_secs(15);
 const RENDERER_STALE_LOG_AFTER: Duration = Duration::from_secs(45);
 const RENDERER_VISIBLE_RECOVERY_AFTER: Duration = Duration::from_secs(75);
 const RENDERER_HIDDEN_RECOVERY_AFTER: Duration = Duration::from_secs(600);
+const BACKGROUND_REQUIRED_HEALTHY_HEARTBEATS: u64 = 2;
+const BACKGROUND_RECOVERY_COOLDOWN: Duration = Duration::from_secs(120);
+const BACKGROUND_JOB_MAX_HELD: Duration = Duration::from_secs(120);
+const FORCE_EXIT_AFTER_RESTART_REQUEST: Duration = Duration::from_secs(8);
 const MAIN_WINDOW_RELEASE_POLL_INTERVAL: Duration = Duration::from_millis(50);
 const MAIN_WINDOW_RELEASE_POLL_ATTEMPTS: usize = 20;
 const LOCAL_AI_DOWNLOAD_PROGRESS_INTERVAL: Duration = Duration::from_millis(250);
@@ -541,6 +546,41 @@ fn save_startup_recovery_state(data_dir: &Path, state: &StartupRecoveryState) {
     }
 }
 
+fn runtime_health_path(data_dir: &Path) -> PathBuf {
+    data_dir.join(RUNTIME_HEALTH_FILE)
+}
+
+fn append_runtime_health(app: &tauri::AppHandle, mut payload: serde_json::Value) {
+    let Ok(data_dir) = app.path().app_data_dir() else {
+        return;
+    };
+    std::fs::create_dir_all(&data_dir).ok();
+
+    if let serde_json::Value::Object(fields) = &mut payload {
+        fields.insert("tsMs".to_string(), serde_json::json!(now_unix_ms()));
+    }
+
+    let Ok(line) = serde_json::to_string(&payload) else {
+        return;
+    };
+    let path = runtime_health_path(&data_dir);
+    match std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+    {
+        Ok(mut file) => {
+            use std::io::Write;
+            let _ = writeln!(file, "{}", line);
+        }
+        Err(error) => warn!(
+            "[runtime-health] failed to open {}: {}",
+            path.display(),
+            error
+        ),
+    }
+}
+
 fn reconcile_startup_recovery_state(data_dir: &Path) -> StartupRecoveryState {
     let mut state = load_startup_recovery_state(data_dir);
 
@@ -555,6 +595,14 @@ fn reconcile_startup_recovery_state(data_dir: &Path) -> StartupRecoveryState {
     }
 
     state
+}
+
+fn mark_startup_failed(data_dir: &Path) {
+    let mut state = load_startup_recovery_state(data_dir);
+    state.pending_boot_started_at_ms = None;
+    state.consecutive_failed_boots = state.consecutive_failed_boots.saturating_add(1);
+    state.last_failed_boot_at_ms = Some(now_unix_ms());
+    save_startup_recovery_state(data_dir, &state);
 }
 
 fn mark_startup_pending(data_dir: &Path) {
@@ -830,6 +878,132 @@ struct WebkitMemoryStats {
     largest_process_id: Option<u32>,
 }
 
+#[derive(Debug, Clone)]
+struct ActiveBackgroundJob {
+    operation: &'static str,
+    started_at: Instant,
+}
+
+#[derive(Debug)]
+struct BackgroundRuntimeState {
+    healthy_heartbeats: u64,
+    renderer_stale: bool,
+    cooldown_until: Option<Instant>,
+    active_job: Option<ActiveBackgroundJob>,
+    last_recovery_reason: Option<String>,
+}
+
+impl BackgroundRuntimeState {
+    fn new() -> Self {
+        Self {
+            healthy_heartbeats: 0,
+            renderer_stale: true,
+            cooldown_until: None,
+            active_job: None,
+            last_recovery_reason: None,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct BackgroundRuntimeCoordinator {
+    state: StdRwLock<BackgroundRuntimeState>,
+}
+
+impl BackgroundRuntimeCoordinator {
+    fn new() -> Self {
+        Self {
+            state: StdRwLock::new(BackgroundRuntimeState::new()),
+        }
+    }
+
+    fn note_renderer_heartbeat(&self) {
+        let mut state = self.state.write().unwrap();
+        state.healthy_heartbeats = state.healthy_heartbeats.saturating_add(1);
+        if state.healthy_heartbeats >= BACKGROUND_REQUIRED_HEALTHY_HEARTBEATS {
+            state.renderer_stale = false;
+        }
+    }
+
+    fn note_renderer_stale(&self, reason: &str) {
+        let mut state = self.state.write().unwrap();
+        state.renderer_stale = true;
+        state.cooldown_until = Some(Instant::now() + BACKGROUND_RECOVERY_COOLDOWN);
+        state.last_recovery_reason = Some(reason.to_string());
+    }
+
+    fn note_renderer_recovery_attempt(&self, reason: &str) {
+        let mut state = self.state.write().unwrap();
+        state.healthy_heartbeats = 0;
+        state.renderer_stale = true;
+        state.cooldown_until = Some(Instant::now() + BACKGROUND_RECOVERY_COOLDOWN);
+        state.last_recovery_reason = Some(reason.to_string());
+    }
+
+    fn begin_job(&self, operation: &'static str) -> Result<(), String> {
+        let now = Instant::now();
+        let mut state = self.state.write().unwrap();
+
+        if state.healthy_heartbeats < BACKGROUND_REQUIRED_HEALTHY_HEARTBEATS {
+            return Err(format!(
+                "background work is waiting for {} healthy renderer heartbeats",
+                BACKGROUND_REQUIRED_HEALTHY_HEARTBEATS
+            ));
+        }
+
+        if state.renderer_stale {
+            return Err("background work is paused while the renderer is stale".to_string());
+        }
+
+        if let Some(cooldown_until) = state.cooldown_until {
+            if cooldown_until > now {
+                let wait_ms = cooldown_until.duration_since(now).as_millis();
+                return Err(format!(
+                    "background work is cooling down for {} ms after renderer recovery",
+                    wait_ms
+                ));
+            }
+            state.cooldown_until = None;
+        }
+
+        if let Some(active) = &state.active_job {
+            return Err(format!(
+                "background job {} is already active",
+                active.operation
+            ));
+        }
+
+        state.active_job = Some(ActiveBackgroundJob {
+            operation,
+            started_at: now,
+        });
+        Ok(())
+    }
+
+    fn finish_job(&self, operation: &'static str) -> Option<u128> {
+        let mut state = self.state.write().unwrap();
+        let Some(active) = state.active_job.take() else {
+            return None;
+        };
+        if active.operation != operation {
+            warn!(
+                "[background-runtime] finishing op={} while active_op={}",
+                operation, active.operation
+            );
+        }
+        Some(active.started_at.elapsed().as_millis())
+    }
+
+    fn active_job_for_health(&self) -> (Option<&'static str>, Option<u128>) {
+        let state = self.state.read().unwrap();
+        state
+            .active_job
+            .as_ref()
+            .map(|job| (Some(job.operation), Some(job.started_at.elapsed().as_millis())))
+            .unwrap_or((None, None))
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Capture state — shared UA strings and HTTP client for social scrapers
 // ---------------------------------------------------------------------------
@@ -841,6 +1015,7 @@ struct CaptureState {
     ig_user_agent: std::sync::Mutex<String>,
     li_user_agent: std::sync::Mutex<String>,
     scraper_session: Arc<tokio::sync::Mutex<()>>,
+    background_runtime: Arc<BackgroundRuntimeCoordinator>,
     x_client: rquest::Client,
 }
 
@@ -859,6 +1034,7 @@ impl CaptureState {
             ig_user_agent: std::sync::Mutex::new(String::new()),
             li_user_agent: std::sync::Mutex::new(String::new()),
             scraper_session: Arc::new(tokio::sync::Mutex::new(())),
+            background_runtime: Arc::new(BackgroundRuntimeCoordinator::new()),
             x_client,
         }
     }
@@ -866,12 +1042,25 @@ impl CaptureState {
 
 struct ActiveScraperSession {
     _guard: tokio::sync::OwnedMutexGuard<()>,
+    background_runtime: Arc<BackgroundRuntimeCoordinator>,
     operation: &'static str,
     acquired_at: std::time::Instant,
 }
 
 impl Drop for ActiveScraperSession {
     fn drop(&mut self) {
+        let runtime_held_ms = self
+            .background_runtime
+            .finish_job(self.operation)
+            .unwrap_or_else(|| self.acquired_at.elapsed().as_millis());
+        if runtime_held_ms > BACKGROUND_JOB_MAX_HELD.as_millis() {
+            warn!(
+                "[background-runtime] scraper op={} exceeded max_held_ms={} held_ms={}",
+                self.operation,
+                BACKGROUND_JOB_MAX_HELD.as_millis(),
+                runtime_held_ms
+            );
+        }
         info!(
             "[scraper] released session op={} held_ms={}",
             self.operation,
@@ -1047,32 +1236,36 @@ fn truncate_for_log(value: &str, max_chars: usize) -> String {
 async fn acquire_background_scraper_session(
     capture: &CaptureState,
     operation: &'static str,
-) -> ActiveScraperSession {
+) -> Result<ActiveScraperSession, String> {
     let session = capture.scraper_session.clone();
 
     match session.clone().try_lock_owned() {
         Ok(guard) => {
+            capture.background_runtime.begin_job(operation)?;
             info!("[scraper] acquired session op={} wait_ms=0", operation);
-            ActiveScraperSession {
+            Ok(ActiveScraperSession {
                 _guard: guard,
+                background_runtime: capture.background_runtime.clone(),
                 operation,
                 acquired_at: std::time::Instant::now(),
-            }
+            })
         }
         Err(_) => {
             info!("[scraper] waiting for active session op={}", operation);
             let wait_started = std::time::Instant::now();
             let guard = session.lock_owned().await;
+            capture.background_runtime.begin_job(operation)?;
             info!(
                 "[scraper] acquired session op={} wait_ms={}",
                 operation,
                 wait_started.elapsed().as_millis()
             );
-            ActiveScraperSession {
+            Ok(ActiveScraperSession {
                 _guard: guard,
+                background_runtime: capture.background_runtime.clone(),
                 operation,
                 acquired_at: std::time::Instant::now(),
-            }
+            })
         }
     }
 }
@@ -1926,6 +2119,23 @@ async fn prepare_social_scrape_memory_internal(
         cache_trimmed,
         may_proceed
     );
+    append_runtime_health(
+        app,
+        serde_json::json!({
+            "event": "scrape_memory_preflight",
+            "provider": provider,
+            "operation": operation,
+            "beforeAppResidentBytes": before.app_resident_bytes,
+            "beforeWebkitResidentBytes": before.webkit_total_resident_bytes,
+            "afterAppResidentBytes": after.app_resident_bytes,
+            "afterWebkitResidentBytes": after.webkit_total_resident_bytes,
+            "memoryHighBytes": after.memory_high_bytes,
+            "memoryCriticalBytes": after.memory_critical_bytes,
+            "recycledScraperWindows": recycled_scraper_windows,
+            "cacheTrimmed": cache_trimmed,
+            "mayProceed": may_proceed
+        }),
+    );
 
     ScrapeMemoryPreparation {
         before,
@@ -1973,6 +2183,27 @@ async fn get_runtime_memory_stats(
         relay_doc_bytes,
         relay_client_count,
     ))
+}
+
+#[tauri::command]
+async fn get_recent_runtime_health(
+    app: tauri::AppHandle,
+    limit: Option<usize>,
+) -> Result<Vec<String>, String> {
+    let data_dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|error| error.to_string())?;
+    let path = runtime_health_path(&data_dir);
+    let raw = match std::fs::read_to_string(&path) {
+        Ok(raw) => raw,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) => return Err(error.to_string()),
+    };
+    let limit = limit.unwrap_or(120).clamp(1, 1_000);
+    let lines: Vec<String> = raw.lines().map(|line| line.to_string()).collect();
+    let start = lines.len().saturating_sub(limit);
+    Ok(lines[start..].to_vec())
 }
 
 #[tauri::command]
@@ -2485,7 +2716,7 @@ async fn fb_check_auth(
     use tauri::WebviewWindowBuilder;
 
     let scraper_user_agent = stored_or_default_user_agent(&capture.fb_user_agent);
-    let _scraper_session = acquire_background_scraper_session(&capture, "fb_check_auth").await;
+    let _scraper_session = acquire_background_scraper_session(&capture, "fb_check_auth").await?;
     ensure_social_scrape_memory(&app, "Facebook", "auth check", Some("fb-scraper")).await?;
     let _recycle_guard = WebviewRecycleGuard::new(app.clone(), "fb-scraper", "auth check");
     let wv = match app.get_webview_window("fb-scraper") {
@@ -2776,7 +3007,7 @@ async fn fb_scrape_feed(
 
     let fb_feed_url = "https://www.facebook.com/";
     let scraper_user_agent = stored_or_default_user_agent(&capture.fb_user_agent);
-    let _scraper_session = acquire_background_scraper_session(&capture, "fb_scrape_feed").await;
+    let _scraper_session = acquire_background_scraper_session(&capture, "fb_scrape_feed").await?;
     ensure_social_scrape_memory(&app, "Facebook", "feed scrape", None).await?;
     let _recycle_guard =
         WebviewRecycleGuard::new(app.clone(), "fb-scraper", "feed scrape complete");
@@ -3006,7 +3237,7 @@ async fn fb_scrape_groups(
 
     let fb_groups_url = "https://www.facebook.com/groups/?category=joined";
     let scraper_user_agent = stored_or_default_user_agent(&capture.fb_user_agent);
-    let _scraper_session = acquire_background_scraper_session(&capture, "fb_scrape_groups").await;
+    let _scraper_session = acquire_background_scraper_session(&capture, "fb_scrape_groups").await?;
     ensure_social_scrape_memory(&app, "Facebook", "groups scrape", None).await?;
     let _recycle_guard =
         WebviewRecycleGuard::new(app.clone(), "fb-scraper", "groups scrape complete");
@@ -3110,7 +3341,7 @@ async fn fb_scrape_comments(
     window_mode: ScraperWindowMode,
 ) -> Result<(), String> {
     let scraper_user_agent = stored_or_default_user_agent(&capture.fb_user_agent);
-    let _scraper_session = acquire_background_scraper_session(&capture, "fb_scrape_comments").await;
+    let _scraper_session = acquire_background_scraper_session(&capture, "fb_scrape_comments").await?;
     let _recycle_guard =
         WebviewRecycleGuard::new(app.clone(), "fb-scraper", "comments scrape complete");
     let wv = match app.get_webview_window("fb-scraper") {
@@ -3278,7 +3509,7 @@ async fn ig_check_auth(
     use tauri::WebviewWindowBuilder;
 
     let scraper_user_agent = stored_or_default_user_agent(&capture.ig_user_agent);
-    let _scraper_session = acquire_background_scraper_session(&capture, "ig_check_auth").await;
+    let _scraper_session = acquire_background_scraper_session(&capture, "ig_check_auth").await?;
     ensure_social_scrape_memory(&app, "Instagram", "auth check", Some("ig-scraper")).await?;
     let _recycle_guard = WebviewRecycleGuard::new(app.clone(), "ig-scraper", "auth check");
     let wv = match app.get_webview_window("ig-scraper") {
@@ -3340,7 +3571,7 @@ async fn ig_scrape_feed(
 
     let ig_feed_url = "https://www.instagram.com/?variant=following";
     let scraper_user_agent = stored_or_default_user_agent(&capture.ig_user_agent);
-    let _scraper_session = acquire_background_scraper_session(&capture, "ig_scrape_feed").await;
+    let _scraper_session = acquire_background_scraper_session(&capture, "ig_scrape_feed").await?;
     ensure_social_scrape_memory(&app, "Instagram", "feed scrape", None).await?;
     let _recycle_guard =
         WebviewRecycleGuard::new(app.clone(), "ig-scraper", "feed scrape complete");
@@ -3590,7 +3821,7 @@ async fn ig_scrape_comments(
     window_mode: ScraperWindowMode,
 ) -> Result<(), String> {
     let scraper_user_agent = stored_or_default_user_agent(&capture.ig_user_agent);
-    let _scraper_session = acquire_background_scraper_session(&capture, "ig_scrape_comments").await;
+    let _scraper_session = acquire_background_scraper_session(&capture, "ig_scrape_comments").await?;
     let _recycle_guard =
         WebviewRecycleGuard::new(app.clone(), "ig-scraper", "comments scrape complete");
     let wv = match app.get_webview_window("ig-scraper") {
@@ -3652,7 +3883,7 @@ async fn fb_visit_url(
     url: String,
 ) -> Result<(), String> {
     let scraper_user_agent = stored_or_default_user_agent(&capture.fb_user_agent);
-    let _scraper_session = acquire_background_scraper_session(&capture, "fb_visit_url").await;
+    let _scraper_session = acquire_background_scraper_session(&capture, "fb_visit_url").await?;
     ensure_social_scrape_memory(&app, "Facebook", "visit", None).await?;
     let _recycle_guard = WebviewRecycleGuard::new(app.clone(), "fb-scraper", "visit complete");
     let wv = match app.get_webview_window("fb-scraper") {
@@ -3684,7 +3915,7 @@ async fn ig_visit_url(
     url: String,
 ) -> Result<(), String> {
     let scraper_user_agent = stored_or_default_user_agent(&capture.ig_user_agent);
-    let _scraper_session = acquire_background_scraper_session(&capture, "ig_visit_url").await;
+    let _scraper_session = acquire_background_scraper_session(&capture, "ig_visit_url").await?;
     ensure_social_scrape_memory(&app, "Instagram", "visit", None).await?;
     let _recycle_guard = WebviewRecycleGuard::new(app.clone(), "ig-scraper", "visit complete");
     let wv = match app.get_webview_window("ig-scraper") {
@@ -3722,7 +3953,7 @@ async fn fb_like_post(
     url: String,
 ) -> Result<(), String> {
     let scraper_user_agent = stored_or_default_user_agent(&capture.fb_user_agent);
-    let _scraper_session = acquire_background_scraper_session(&capture, "fb_like_post").await;
+    let _scraper_session = acquire_background_scraper_session(&capture, "fb_like_post").await?;
     ensure_social_scrape_memory(&app, "Facebook", "like", None).await?;
     let _recycle_guard = WebviewRecycleGuard::new(app.clone(), "fb-scraper", "like complete");
     let wv = match app.get_webview_window("fb-scraper") {
@@ -3772,7 +4003,7 @@ async fn ig_like_post(
     url: String,
 ) -> Result<(), String> {
     let scraper_user_agent = stored_or_default_user_agent(&capture.ig_user_agent);
-    let _scraper_session = acquire_background_scraper_session(&capture, "ig_like_post").await;
+    let _scraper_session = acquire_background_scraper_session(&capture, "ig_like_post").await?;
     ensure_social_scrape_memory(&app, "Instagram", "like", None).await?;
     let _recycle_guard = WebviewRecycleGuard::new(app.clone(), "ig-scraper", "like complete");
     let wv = match app.get_webview_window("ig-scraper") {
@@ -3916,7 +4147,7 @@ async fn li_check_auth(
     use tauri::WebviewWindowBuilder;
 
     let scraper_user_agent = stored_or_default_user_agent(&capture.li_user_agent);
-    let _scraper_session = acquire_background_scraper_session(&capture, "li_check_auth").await;
+    let _scraper_session = acquire_background_scraper_session(&capture, "li_check_auth").await?;
     ensure_social_scrape_memory(&app, "LinkedIn", "auth check", Some("li-scraper")).await?;
     let _recycle_guard = WebviewRecycleGuard::new(app.clone(), "li-scraper", "auth check");
     let wv = match app.get_webview_window("li-scraper") {
@@ -3990,7 +4221,7 @@ async fn li_scrape_feed(
 
     let li_feed_url = "https://www.linkedin.com/feed/";
     let scraper_user_agent = stored_or_default_user_agent(&capture.li_user_agent);
-    let _scraper_session = acquire_background_scraper_session(&capture, "li_scrape_feed").await;
+    let _scraper_session = acquire_background_scraper_session(&capture, "li_scrape_feed").await?;
     ensure_social_scrape_memory(&app, "LinkedIn", "feed scrape", None).await?;
     let _recycle_guard =
         WebviewRecycleGuard::new(app.clone(), "li-scraper", "feed scrape complete");
@@ -4588,10 +4819,36 @@ fn recover_main_window(app: &tauri::AppHandle, reason: &str) -> Result<(), Strin
                 "[main-window] {}; requesting app restart reason={}",
                 message, reason
             );
-            app.request_restart();
+            request_restart_after_recovery_failure(app, reason, &message);
             Err(message)
         }
     }
+}
+
+fn request_restart_after_recovery_failure(app: &tauri::AppHandle, reason: &str, error: &str) {
+    if let Ok(data_dir) = app.path().app_data_dir() {
+        mark_startup_failed(&data_dir);
+    }
+    append_runtime_health(
+        app,
+        serde_json::json!({
+            "event": "renderer_recovery_restart_requested",
+            "reason": reason,
+            "error": error
+        }),
+    );
+    app.request_restart();
+
+    let app_for_exit = app.clone();
+    let reason_for_exit = reason.to_string();
+    tauri::async_runtime::spawn(async move {
+        tokio::time::sleep(FORCE_EXIT_AFTER_RESTART_REQUEST).await;
+        warn!(
+            "[main-window] forcing old process exit after restart request reason={}",
+            reason_for_exit
+        );
+        app_for_exit.exit(0);
+    });
 }
 
 fn recover_main_window_on_main_thread(app: &tauri::AppHandle, reason: &str) -> Result<(), String> {
@@ -4605,7 +4862,7 @@ fn recover_main_window_on_main_thread(app: &tauri::AppHandle, reason: &str) -> R
             "[main-window] renderer recovery failed; requesting app restart reason={} error={}",
             reason, error
         );
-        app.request_restart();
+        request_restart_after_recovery_failure(app, reason, error);
 
         if let Ok(window) = open_or_focus_recovery_window(app) {
             show_webview_window(&window);
@@ -4987,6 +5244,10 @@ pub fn run() {
             let renderer_health_for_listener = renderer_health.clone();
             let app_for_renderer = app.handle().clone();
             let app_for_renderer_listener = app_for_renderer.clone();
+            let background_runtime_for_listener = app
+                .state::<CaptureState>()
+                .background_runtime
+                .clone();
             app_for_renderer.listen("renderer-heartbeat", move |event| {
                 let payload = match serde_json::from_str::<RendererHeartbeatPayload>(event.payload()) {
                     Ok(payload) => payload,
@@ -5004,8 +5265,25 @@ pub fn run() {
                 let mut health = renderer_health_for_listener.write().unwrap();
                 let (first_heartbeat, gap_ms, recovered) =
                     health.note_heartbeat(&payload, now);
+                background_runtime_for_listener.note_renderer_heartbeat();
 
                 let href = truncate_for_log(&payload.href, 120);
+                let (active_job, active_job_age_ms) =
+                    background_runtime_for_listener.active_job_for_health();
+                append_runtime_health(
+                    &app_for_renderer_listener,
+                    serde_json::json!({
+                        "event": "renderer_heartbeat",
+                        "seq": payload.seq,
+                        "reason": payload.reason.clone(),
+                        "visibility": payload.visibility.clone(),
+                        "href": href.clone(),
+                        "gapMs": gap_ms,
+                        "recovered": recovered,
+                        "activeBackgroundJob": active_job,
+                        "activeBackgroundJobAgeMs": active_job_age_ms
+                    }),
+                );
                 if recovered {
                     warn!(
                         "[main-window] renderer heartbeat recovered seq={} gap_ms={} reason={} visibility={} href={} ts={}",
@@ -5041,6 +5319,10 @@ pub fn run() {
 
             let renderer_health_for_watchdog = renderer_health.clone();
             let app_for_renderer_watchdog = app.handle().clone();
+            let background_runtime_for_watchdog = app
+                .state::<CaptureState>()
+                .background_runtime
+                .clone();
             tauri::async_runtime::spawn(async move {
                 loop {
                     tokio::time::sleep(RENDERER_HEARTBEAT_WATCHDOG_INTERVAL).await;
@@ -5094,10 +5376,42 @@ pub fn run() {
                                 webkit_details
                             );
                             health.stale_logged = true;
+                            background_runtime_for_watchdog
+                                .note_renderer_stale("renderer heartbeat stale");
+                            let (active_job, active_job_age_ms) =
+                                background_runtime_for_watchdog.active_job_for_health();
+                            append_runtime_health(
+                                &app_for_renderer_watchdog,
+                                serde_json::json!({
+                                    "event": "renderer_heartbeat_stale",
+                                    "ageMs": age.as_millis(),
+                                    "thresholdMs": recovery_threshold.as_millis(),
+                                    "visible": is_main_visible,
+                                    "lastSeq": health.last_seq,
+                                    "lastReason": health.last_reason.clone(),
+                                    "lastVisibility": health.last_visibility.clone(),
+                                    "href": truncate_for_log(&health.last_href, 120),
+                                    "nativeResidentBytes": native_rss,
+                                    "activeBackgroundJob": active_job,
+                                    "activeBackgroundJobAgeMs": active_job_age_ms
+                                }),
+                            );
                         }
 
                         if should_recover {
                             let attempt = health.note_recovery_attempt(std::time::Instant::now());
+                            background_runtime_for_watchdog
+                                .note_renderer_recovery_attempt("renderer heartbeat stale");
+                            append_runtime_health(
+                                &app_for_renderer_watchdog,
+                                serde_json::json!({
+                                    "event": "renderer_recovery_attempt",
+                                    "attempt": attempt,
+                                    "ageMs": age.as_millis(),
+                                    "thresholdMs": recovery_threshold.as_millis(),
+                                    "visible": is_main_visible
+                                }),
+                            );
                             warn!(
                                 "[main-window] recovering stale renderer attempt={} age_ms={} threshold_ms={} visible={}",
                                 attempt,
@@ -5218,6 +5532,7 @@ pub fn run() {
             cancel_local_ai_model_download,
             get_sync_client_count,
             get_runtime_memory_stats,
+            get_recent_runtime_health,
             get_ai_hardware_profile,
             prepare_social_scrape_memory,
             broadcast_doc,
@@ -5285,6 +5600,50 @@ mod tests {
                 MAX_CRITICAL_MEMORY_BYTES
             )
         );
+    }
+
+    #[test]
+    fn background_runtime_requires_stable_renderer_before_jobs() {
+        let runtime = BackgroundRuntimeCoordinator::new();
+        assert!(runtime.begin_job("fb_scrape_feed").is_err());
+
+        runtime.note_renderer_heartbeat();
+        assert!(runtime.begin_job("fb_scrape_feed").is_err());
+
+        runtime.note_renderer_heartbeat();
+        assert!(runtime.begin_job("fb_scrape_feed").is_ok());
+        assert!(runtime.begin_job("ig_scrape_feed").is_err());
+        assert!(runtime.finish_job("fb_scrape_feed").is_some());
+    }
+
+    #[test]
+    fn background_runtime_blocks_during_recovery_cooldown() {
+        let runtime = BackgroundRuntimeCoordinator::new();
+        runtime.note_renderer_heartbeat();
+        runtime.note_renderer_heartbeat();
+        assert!(runtime.begin_job("fb_scrape_feed").is_ok());
+        let _ = runtime.finish_job("fb_scrape_feed");
+
+        runtime.note_renderer_stale("test stale renderer");
+        let err = runtime.begin_job("ig_scrape_feed").unwrap_err();
+        assert!(err.contains("renderer is stale") || err.contains("cooling down"));
+
+        runtime.note_renderer_heartbeat();
+        runtime.note_renderer_heartbeat();
+        let err = runtime.begin_job("ig_scrape_feed").unwrap_err();
+        assert!(err.contains("cooling down"));
+    }
+
+    #[test]
+    fn mark_startup_failed_forces_recovery_on_next_launch() {
+        let temp = tempfile::tempdir().unwrap();
+        mark_startup_success(temp.path());
+        mark_startup_failed(temp.path());
+        let state = load_startup_recovery_state(temp.path());
+
+        assert!(startup_requires_recovery(&state));
+        assert_eq!(state.consecutive_failed_boots, 1);
+        assert!(state.last_failed_boot_at_ms.is_some());
     }
 
     #[test]

--- a/packages/desktop/src/App.tsx
+++ b/packages/desktop/src/App.tsx
@@ -85,6 +85,7 @@ import { useDesktopNavigationHistory } from "./lib/navigation-history";
 import { desktopBugReporting } from "./lib/bug-report";
 import { clearFatalRuntimeError, useFatalRuntimeError } from "@freed/ui/lib/bug-report";
 import { startMemoryMonitor, stopMemoryMonitor } from "./lib/memory-monitor";
+import { noteMemoryPressure, noteRendererHeartbeat } from "./lib/background-runtime-coordinator";
 import {
   bootstrapDesktopReleaseChannel,
   loadDesktopReleaseChannelState,
@@ -223,6 +224,9 @@ function App() {
           },
         });
       },
+      onSample: (snapshot) => {
+        noteMemoryPressure(snapshot);
+      },
     });
     return () => {
       stopRssPoller();
@@ -255,19 +259,29 @@ function App() {
   }, [legalAccepted]);
 
   useEffect(() => {
-    if (!isTauri()) return;
+    const hasTauriMock = "__TAURI_INTERNALS__" in window;
+    const canEmitRendererHeartbeat =
+      import.meta.env.VITE_TEST_TAURI === "1" || isTauri() || hasTauriMock;
+    if (!canEmitRendererHeartbeat) return;
 
     let heartbeatSeq = 0;
 
     const sendRendererHeartbeat = (reason: string) => {
       heartbeatSeq += 1;
-      void emit("renderer-heartbeat", {
+      const payload = {
         seq: heartbeatSeq,
         ts: Date.now(),
         reason,
         visibility: document.visibilityState,
         href: window.location.href,
-      }).catch(() => {
+      };
+      noteRendererHeartbeat(payload);
+      if (import.meta.env.VITE_TEST_TAURI === "1") {
+        const testWindow = window as unknown as { __FREED_RENDERER_HEARTBEATS__?: number };
+        testWindow.__FREED_RENDERER_HEARTBEATS__ =
+          (testWindow.__FREED_RENDERER_HEARTBEATS__ ?? 0) + 1;
+      }
+      void emit("renderer-heartbeat", payload).catch(() => {
         // If the renderer is already failing, heartbeat delivery may fail too.
       });
     };

--- a/packages/desktop/src/lib/background-runtime-coordinator.test.ts
+++ b/packages/desktop/src/lib/background-runtime-coordinator.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@freed/ui/lib/debug-store", () => ({
+  addDebugEvent: vi.fn(),
+}));
+
+vi.mock("./logger", () => ({
+  log: {
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+async function loadCoordinator() {
+  vi.resetModules();
+  return import("./background-runtime-coordinator");
+}
+
+function heartbeat(seq: number) {
+  return {
+    seq,
+    ts: Date.now(),
+    reason: "interval",
+    visibility: "visible",
+    href: "tauri://localhost",
+  };
+}
+
+describe("background runtime coordinator", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("gates jobs until the renderer has sent two heartbeats", async () => {
+    const coordinator = await loadCoordinator();
+    coordinator.resetBackgroundRuntimeForTests({ requireRendererHealth: true });
+
+    expect(coordinator.canStartBackgroundJob("content-fetch")).toEqual({
+      ok: false,
+      reason: "waiting_for_renderer_heartbeat:0",
+    });
+
+    coordinator.noteRendererHeartbeat(heartbeat(1));
+    expect(coordinator.canStartBackgroundJob("content-fetch")).toEqual({
+      ok: false,
+      reason: "waiting_for_renderer_heartbeat:1",
+    });
+
+    coordinator.noteRendererHeartbeat(heartbeat(2));
+    expect(coordinator.canStartBackgroundJob("content-fetch")).toEqual({ ok: true });
+  });
+
+  it("prevents overlapping background jobs", async () => {
+    const coordinator = await loadCoordinator();
+    coordinator.resetBackgroundRuntimeForTests({ requireRendererHealth: true });
+    coordinator.noteRendererHeartbeat(heartbeat(1));
+    coordinator.noteRendererHeartbeat(heartbeat(2));
+
+    let releaseFirst: () => void = () => {};
+    const first = coordinator.runBackgroundJob({
+      kind: "content-fetch",
+      source: "test-fetch",
+      run: () => new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      }),
+    });
+
+    await Promise.resolve();
+    await expect(
+      coordinator.runBackgroundJob({
+        kind: "outbox",
+        source: "test-outbox",
+        run: () => undefined,
+      }),
+    ).rejects.toMatchObject({ reason: "active:content-fetch:test-fetch" });
+
+    releaseFirst();
+    await first;
+    await expect(
+      coordinator.runBackgroundJob({
+        kind: "outbox",
+        source: "test-outbox",
+        run: () => "ok",
+      }),
+    ).resolves.toBe("ok");
+  });
+
+  it("pauses jobs during memory pressure cooldown", async () => {
+    vi.useFakeTimers();
+    const coordinator = await loadCoordinator();
+    coordinator.resetBackgroundRuntimeForTests({ requireRendererHealth: true });
+    coordinator.noteRendererHeartbeat(heartbeat(1));
+    coordinator.noteRendererHeartbeat(heartbeat(2));
+
+    coordinator.noteMemoryPressure({
+      processResidentBytes: 10,
+      processVirtualBytes: 20,
+      appResidentBytes: 30,
+      pressureLevel: "high",
+      relayDocBytes: 0,
+      relayClientCount: 0,
+      contentQueuePending: 0,
+      contentCompleted: 0,
+      contentFailed: 0,
+      contentActive: false,
+      contentBackoffLevel: 0,
+      sampleTs: Date.now(),
+    });
+
+    await expect(
+      coordinator.runBackgroundJob({
+        kind: "content-fetch",
+        source: "test-fetch",
+        run: () => undefined,
+      }),
+    ).rejects.toMatchObject({ reason: expect.stringContaining("cooldown:") });
+
+    await vi.advanceTimersByTimeAsync(60_001);
+    await expect(
+      coordinator.runBackgroundJob({
+        kind: "snapshot",
+        source: "test-snapshot",
+        run: () => "ready",
+      }),
+    ).resolves.toBe("ready");
+  });
+});

--- a/packages/desktop/src/lib/background-runtime-coordinator.ts
+++ b/packages/desktop/src/lib/background-runtime-coordinator.ts
@@ -1,0 +1,180 @@
+import type { RuntimeMemorySnapshot } from "@freed/ui/lib/debug-store";
+import { addDebugEvent } from "@freed/ui/lib/debug-store";
+import { log } from "./logger";
+
+export type BackgroundJobKind =
+  | "cloud-sync"
+  | "content-fetch"
+  | "outbox"
+  | "rss-poll"
+  | "snapshot";
+
+export interface RendererHeartbeatNote {
+  seq: number;
+  reason: string;
+  visibility: string;
+  href: string;
+  ts: number;
+}
+
+export interface BackgroundRuntimeStatus {
+  healthyHeartbeats: number;
+  rendererReady: boolean;
+  cooldownUntil: number | null;
+  pressureLevel: "normal" | "high" | "critical";
+  activeJob: BackgroundJobKind | null;
+  activeSource: string | null;
+  activeAgeMs: number | null;
+}
+
+export interface BackgroundRuntimeTask<T> {
+  kind: BackgroundJobKind;
+  source: string;
+  timeoutMs?: number;
+  run: () => Promise<T> | T;
+}
+
+const REQUIRED_HEALTHY_HEARTBEATS = 2;
+const HIGH_PRESSURE_COOLDOWN_MS = 60_000;
+const CRITICAL_PRESSURE_COOLDOWN_MS = 120_000;
+const DEFAULT_TIMEOUT_MS = 120_000;
+
+let healthyHeartbeats = 0;
+let cooldownUntil = 0;
+let pressureLevel: "normal" | "high" | "critical" = "normal";
+let activeJob: {
+  kind: BackgroundJobKind;
+  source: string;
+  startedAt: number;
+} | null = null;
+let requireRendererHealth = import.meta.env.MODE !== "test";
+
+export class BackgroundRuntimeDeferredError extends Error {
+  readonly reason: string;
+
+  constructor(reason: string) {
+    super(reason);
+    this.name = "BackgroundRuntimeDeferredError";
+    this.reason = reason;
+  }
+}
+
+export function isBackgroundRuntimeDeferredError(
+  error: unknown,
+): error is BackgroundRuntimeDeferredError {
+  return error instanceof BackgroundRuntimeDeferredError;
+}
+
+function nowMs(): number {
+  return Date.now();
+}
+
+function markCooldown(durationMs: number, reason: string): void {
+  cooldownUntil = Math.max(cooldownUntil, nowMs() + durationMs);
+  const message = `[background-runtime] paused reason=${reason} cooldown_ms=${durationMs.toLocaleString()}`;
+  log.warn(message);
+  addDebugEvent("error", message);
+}
+
+export function noteRendererHeartbeat(_payload: RendererHeartbeatNote): void {
+  healthyHeartbeats += 1;
+}
+
+export function noteRendererRecovery(reason: string): void {
+  healthyHeartbeats = 0;
+  markCooldown(CRITICAL_PRESSURE_COOLDOWN_MS, `renderer_recovery:${reason}`);
+}
+
+export function noteMemoryPressure(snapshot: RuntimeMemorySnapshot): void {
+  pressureLevel = snapshot.pressureLevel ?? "normal";
+  if (pressureLevel === "critical") {
+    markCooldown(CRITICAL_PRESSURE_COOLDOWN_MS, "critical_memory_pressure");
+  } else if (pressureLevel === "high") {
+    markCooldown(HIGH_PRESSURE_COOLDOWN_MS, "high_memory_pressure");
+  }
+}
+
+export function getBackgroundRuntimeStatus(): BackgroundRuntimeStatus {
+  const activeAgeMs = activeJob ? nowMs() - activeJob.startedAt : null;
+  return {
+    healthyHeartbeats,
+    rendererReady: !requireRendererHealth || healthyHeartbeats >= REQUIRED_HEALTHY_HEARTBEATS,
+    cooldownUntil: cooldownUntil > nowMs() ? cooldownUntil : null,
+    pressureLevel,
+    activeJob: activeJob?.kind ?? null,
+    activeSource: activeJob?.source ?? null,
+    activeAgeMs,
+  };
+}
+
+export function canStartBackgroundJob(kind: BackgroundJobKind): { ok: true } | { ok: false; reason: string } {
+  if (requireRendererHealth && healthyHeartbeats < REQUIRED_HEALTHY_HEARTBEATS) {
+    return {
+      ok: false,
+      reason: `waiting_for_renderer_heartbeat:${healthyHeartbeats.toLocaleString()}`,
+    };
+  }
+
+  const cooldownRemainingMs = cooldownUntil - nowMs();
+  if (cooldownRemainingMs > 0) {
+    return {
+      ok: false,
+      reason: `cooldown:${Math.ceil(cooldownRemainingMs).toLocaleString()}`,
+    };
+  }
+
+  if (pressureLevel === "critical") {
+    return { ok: false, reason: "critical_memory_pressure" };
+  }
+
+  if (pressureLevel === "high" && kind !== "snapshot") {
+    return { ok: false, reason: "high_memory_pressure" };
+  }
+
+  if (activeJob) {
+    return { ok: false, reason: `active:${activeJob.kind}:${activeJob.source}` };
+  }
+
+  return { ok: true };
+}
+
+export async function runBackgroundJob<T>(task: BackgroundRuntimeTask<T>): Promise<T> {
+  const gate = canStartBackgroundJob(task.kind);
+  if (!gate.ok) {
+    throw new BackgroundRuntimeDeferredError(gate.reason);
+  }
+
+  activeJob = {
+    kind: task.kind,
+    source: task.source,
+    startedAt: nowMs(),
+  };
+
+  let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+  try {
+    const timeoutMs = task.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    return await Promise.race([
+      Promise.resolve().then(task.run),
+      new Promise<never>((_, reject) => {
+        timeoutHandle = setTimeout(() => {
+          reject(
+            new Error(
+              `[background-runtime] job timed out kind=${task.kind} source=${task.source} timeout_ms=${timeoutMs.toLocaleString()}`,
+            ),
+          );
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeoutHandle) clearTimeout(timeoutHandle);
+    activeJob = null;
+  }
+}
+
+export function resetBackgroundRuntimeForTests(options?: { requireRendererHealth?: boolean }): void {
+  healthyHeartbeats = 0;
+  cooldownUntil = 0;
+  pressureLevel = "normal";
+  activeJob = null;
+  requireRendererHealth = options?.requireRendererHealth ?? false;
+}

--- a/packages/desktop/src/lib/bug-report.ts
+++ b/packages/desktop/src/lib/bug-report.ts
@@ -45,6 +45,14 @@ async function getRecentLogs(limit: number): Promise<string[]> {
   }
 }
 
+async function getRecentRuntimeHealth(limit: number): Promise<string[]> {
+  try {
+    return await invoke<string[]>("get_recent_runtime_health", { limit });
+  } catch {
+    return [];
+  }
+}
+
 async function getSnapshotNames(): Promise<string[]> {
   try {
     return await invoke<string[]>("list_snapshots");
@@ -87,7 +95,8 @@ function collectPublicEvents(events: BugReportEvent[], tier: ReportPrivacyTier):
 }
 
 function sanitizeLogLines(lines: string[], tier: ReportPrivacyTier): string[] {
-  const filtered = lines.slice(-(tier === "private" ? 200 : 80));
+  const safeLines = Array.isArray(lines) ? lines : [];
+  const filtered = safeLines.slice(-(tier === "private" ? 200 : 80));
   return filtered.map((line) => redactSensitiveText(line));
 }
 
@@ -129,6 +138,9 @@ async function buildDesktopBundle(input: {
   const logLines = includedArtifacts.some((artifact) => artifact === "expanded-logs")
     ? sanitizeLogLines(await getRecentLogs(240), "private")
     : sanitizeLogLines(await getRecentLogs(100), "public-safe");
+  const runtimeHealthLines = includedArtifacts.includes("diagnostic-events")
+    ? sanitizeLogLines(await getRecentRuntimeHealth(120), input.privacyTier)
+    : [];
   const snapshotNames =
     input.privacyTier === "private" && includedArtifacts.includes("snapshot-metadata")
       ? (await getSnapshotNames()).map((name) => redactSensitiveText(name))
@@ -175,6 +187,7 @@ async function buildDesktopBundle(input: {
   if (includedArtifacts.includes("diagnostic-events")) {
     diagnostics.reportEvents = reportEvents;
     diagnostics.debugEvents = debugEvents;
+    diagnostics.runtimeHealthLineCount = runtimeHealthLines.length;
   }
   if (includedArtifacts.includes("crash-context")) {
     diagnostics.fatalError = fatalError;
@@ -199,6 +212,7 @@ async function buildDesktopBundle(input: {
   if (includedArtifacts.includes("diagnostic-events")) {
     addJson(zip, "diagnostics/report-events.json", reportEvents);
     addJson(zip, "diagnostics/debug-events.json", debugEvents);
+    zip.file("diagnostics/runtime-health.jsonl", runtimeHealthLines.join("\n"));
   }
   if (includedArtifacts.includes("state-summary")) {
     addJson(zip, "diagnostics/state-summary.json", stateSummary);

--- a/packages/desktop/src/lib/content-fetcher.ts
+++ b/packages/desktop/src/lib/content-fetcher.ts
@@ -29,6 +29,10 @@ import { secureStorage } from "./secure-storage.js";
 import { addDebugEvent } from "@freed/ui/lib/debug-store";
 import { log } from "./logger.js";
 import { toSyncedPreservedText } from "./preserved-text.js";
+import {
+  isBackgroundRuntimeDeferredError,
+  runBackgroundJob,
+} from "./background-runtime-coordinator.js";
 
 const FETCH_TIMEOUT_MS = 30_000;
 const AI_SUMMARY_TIMEOUT_MS = 60_000;
@@ -203,7 +207,7 @@ function maybeScanVisibleItems(items: FeedItem[], docItemCount: number): void {
   enqueue(items);
 }
 
-type ProcessOutcome = "success" | "backoff" | "idle";
+type ProcessOutcome = "success" | "backoff" | "deferred" | "idle";
 
 function randomDelayForBackoff(level: number): number {
   const multiplier = 2 ** Math.min(level, MAX_BACKOFF_LEVEL);
@@ -273,12 +277,22 @@ async function runWorkerOnce(): Promise<void> {
 
   let outcome: ProcessOutcome = "idle";
   try {
-    outcome = await processNext();
+    outcome = await runBackgroundJob({
+      kind: "content-fetch",
+      source: "content-fetcher",
+      timeoutMs: 180_000,
+      run: processNext,
+    });
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    log.error(`[content-fetcher] unexpected error in processNext: ${msg}`);
-    addDebugEvent("error", `[Fetcher] unexpected error in processNext: ${msg}`);
-    outcome = "backoff";
+    if (isBackgroundRuntimeDeferredError(err)) {
+      log.info(`[content-fetcher] deferred by background runtime reason=${err.reason}`);
+      outcome = "deferred";
+    } else {
+      const msg = err instanceof Error ? err.message : String(err);
+      log.error(`[content-fetcher] unexpected error in processNext: ${msg}`);
+      addDebugEvent("error", `[Fetcher] unexpected error in processNext: ${msg}`);
+      outcome = "backoff";
+    }
   } finally {
     activeStartedAt = null;
   }
@@ -292,7 +306,8 @@ async function runWorkerOnce(): Promise<void> {
   notifyStatus();
 
   if (running && queue.length > 0) {
-    scheduleWorker(randomDelayForBackoff(backoffLevel));
+    const delayBackoffLevel = outcome === "deferred" ? Math.max(1, backoffLevel) : backoffLevel;
+    scheduleWorker(randomDelayForBackoff(delayBackoffLevel));
   }
 }
 

--- a/packages/desktop/src/lib/memory-monitor.ts
+++ b/packages/desktop/src/lib/memory-monitor.ts
@@ -76,6 +76,7 @@ type MemoryPressureLevel = "normal" | "high" | "critical";
 interface MemoryMonitorOptions {
   getAutomergeStats?: () => { binaryBytes?: number; itemCount?: number } | null;
   onCriticalPressure?: (snapshot: RuntimeMemorySnapshot) => void;
+  onSample?: (snapshot: RuntimeMemorySnapshot) => void;
 }
 
 export function formatBytesForMemoryLog(bytes: number): string {
@@ -200,6 +201,7 @@ async function sampleRuntimeMemory(
     sampleTs: Date.now(),
   };
   setRuntimeMemory(snapshot);
+  options.onSample?.(snapshot);
 
   sampleCount += 1;
   const shouldLog =

--- a/packages/desktop/src/lib/outbox.ts
+++ b/packages/desktop/src/lib/outbox.ts
@@ -25,6 +25,10 @@ import type { PlatformActions } from "./platform-actions";
 import type { DocChangeEvent } from "./automerge-types";
 import { addDebugEvent } from "@freed/ui/lib/debug-store";
 import { scheduleSideEffect } from "./side-effect-scheduler";
+import {
+  isBackgroundRuntimeDeferredError,
+  runBackgroundJob,
+} from "./background-runtime-coordinator";
 
 // =============================================================================
 // Constants
@@ -254,7 +258,13 @@ export function startOutboxProcessor(
       kind: "drain",
       timeoutMs: 120_000,
       slowMs: 1_000,
-      run: drainNow,
+      run: () =>
+        runBackgroundJob({
+          kind: "outbox",
+          source: "outbox",
+          timeoutMs: 120_000,
+          run: drainNow,
+        }),
     });
   }
 
@@ -268,6 +278,12 @@ export function startOutboxProcessor(
     drainTimer = setTimeout(() => {
       drainTimer = null;
       drain().catch((err) => {
+        if (isBackgroundRuntimeDeferredError(err)) {
+          addDebugEvent("change", `[Outbox] drain deferred: ${err.reason}`);
+          isDraining = false;
+          scheduleDrain();
+          return;
+        }
         addDebugEvent("error", `[Outbox] drain threw: ${err instanceof Error ? err.message : String(err)}`);
         isDraining = false;
       });
@@ -279,6 +295,12 @@ export function startOutboxProcessor(
 
   // Run an immediate drain on startup (catch anything queued while offline)
   drain().catch((err) => {
+    if (isBackgroundRuntimeDeferredError(err)) {
+      addDebugEvent("change", `[Outbox] startup drain deferred: ${err.reason}`);
+      isDraining = false;
+      scheduleDrain();
+      return;
+    }
     addDebugEvent("error", `[Outbox] startup drain threw: ${err instanceof Error ? err.message : String(err)}`);
     isDraining = false;
   });

--- a/packages/desktop/src/lib/rss-poller.ts
+++ b/packages/desktop/src/lib/rss-poller.ts
@@ -7,6 +7,10 @@
 
 import { refreshAllFeeds } from "./capture";
 import { addDebugEvent } from "@freed/ui/lib/debug-store";
+import {
+  isBackgroundRuntimeDeferredError,
+  runBackgroundJob,
+} from "./background-runtime-coordinator";
 
 /** Default poll interval: 30 minutes */
 const DEFAULT_INTERVAL_MS = 30 * 60 * 1000;
@@ -51,8 +55,17 @@ async function triggerPoll(): Promise<void> {
   isPolling = true;
 
   try {
-    await refreshAllFeeds();
+    await runBackgroundJob({
+      kind: "rss-poll",
+      source: "rss-poller",
+      timeoutMs: 180_000,
+      run: refreshAllFeeds,
+    });
   } catch (err) {
+    if (isBackgroundRuntimeDeferredError(err)) {
+      addDebugEvent("change", `[RSS] poll deferred: ${err.reason}`);
+      return;
+    }
     const msg = err instanceof Error ? err.message : String(err);
     console.error("[RssPoller] Error during poll:", err);
     addDebugEvent("error", `[RSS] poller crashed: ${msg}`);

--- a/packages/desktop/src/lib/snapshots.ts
+++ b/packages/desktop/src/lib/snapshots.ts
@@ -13,6 +13,10 @@ import {
 import { getDocBinary, getDocState, replaceLocalDoc, subscribe } from "./automerge";
 import { log } from "./logger.js";
 import { readContactSyncState, readContactSyncStateJson, writeContactSyncStateJson } from "./contact-sync-storage.js";
+import {
+  isBackgroundRuntimeDeferredError,
+  runBackgroundJob,
+} from "./background-runtime-coordinator.js";
 
 export type SnapshotReason = "auto" | "manual";
 
@@ -294,7 +298,16 @@ function scheduleAutoSnapshot(): void {
       return;
     }
 
-    createSnapshot("auto").catch((error) => {
+    runBackgroundJob({
+      kind: "snapshot",
+      source: "auto-snapshot",
+      timeoutMs: 180_000,
+      run: () => createSnapshot("auto"),
+    }).catch((error) => {
+      if (isBackgroundRuntimeDeferredError(error)) {
+        log.info(`[snapshots] auto snapshot deferred: ${error.reason}`);
+        return;
+      }
       log.error(
         `[snapshots] auto snapshot failed: ${
           error instanceof Error ? error.message : String(error)

--- a/packages/desktop/src/lib/social-capture-memory-pressure.test.ts
+++ b/packages/desktop/src/lib/social-capture-memory-pressure.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  invoke: vi.fn(),
+  prepareSocialScrapeMemory: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: mocks.invoke,
+  isTauri: () => true,
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(),
+}));
+
+vi.mock("@freed/ui/lib/debug-store", () => ({
+  addDebugEvent: vi.fn(),
+}));
+
+vi.mock("./memory-monitor", () => ({
+  formatBytesForMemoryLog: (bytes: number) => `${bytes.toLocaleString()} B`,
+  prepareSocialScrapeMemory: mocks.prepareSocialScrapeMemory,
+}));
+
+vi.mock("./store", () => ({
+  useAppStore: {
+    getState: () => ({
+      addFeedItems: vi.fn(),
+      preferences: {},
+    }),
+  },
+}));
+
+vi.mock("./scraper-media-diag", () => ({
+  attachScraperMediaDiagListener: vi.fn(),
+}));
+
+vi.mock("./provider-health", () => ({
+  getProviderPause: vi.fn(() => null),
+  recordProviderHealthEvent: vi.fn(),
+}));
+
+vi.mock("./fb-auth", () => ({ storeFbAuthState: vi.fn() }));
+vi.mock("./instagram-auth", () => ({ storeIgAuthState: vi.fn() }));
+vi.mock("./li-auth", () => ({ storeLiAuthState: vi.fn() }));
+vi.mock("./media-vault", () => ({
+  archiveRecentProviderMedia: vi.fn(),
+  upsertMediaVaultRosterFromItems: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.resetModules();
+  mocks.invoke.mockReset();
+  mocks.prepareSocialScrapeMemory.mockReset();
+  mocks.prepareSocialScrapeMemory.mockResolvedValue({
+    before: {},
+    after: { appResidentBytes: 4_000_000_000 },
+    recycledScraperWindows: true,
+    cacheTrimmed: true,
+    mayProceed: false,
+  });
+});
+
+describe("social capture memory pressure gate", () => {
+  it("returns Facebook memory diagnostics before invoking the native scraper", async () => {
+    const { fetchFbFeed } = await import("./fb-capture");
+    const result = await fetchFbFeed();
+
+    expect(result.diag.errorStage).toBe("memory_pressure");
+    expect(mocks.prepareSocialScrapeMemory).toHaveBeenCalledWith("facebook", "feed scrape");
+    expect(mocks.invoke).not.toHaveBeenCalledWith("fb_scrape_feed", expect.anything());
+  });
+
+  it("returns Instagram memory diagnostics before invoking the native scraper", async () => {
+    const { fetchIgFeed } = await import("./instagram-capture");
+    const result = await fetchIgFeed();
+
+    expect(result.diag.errorStage).toBe("memory_pressure");
+    expect(mocks.prepareSocialScrapeMemory).toHaveBeenCalledWith("instagram", "feed scrape");
+    expect(mocks.invoke).not.toHaveBeenCalledWith("ig_scrape_feed", expect.anything());
+  });
+
+  it("returns LinkedIn memory diagnostics before invoking the native scraper", async () => {
+    const { fetchLiFeed } = await import("./li-capture");
+    const result = await fetchLiFeed();
+
+    expect(result.diag.errorStage).toBe("memory_pressure");
+    expect(mocks.prepareSocialScrapeMemory).toHaveBeenCalledWith("linkedin", "feed scrape");
+    expect(mocks.invoke).not.toHaveBeenCalledWith("li_scrape_feed", expect.anything());
+  });
+});

--- a/packages/desktop/src/lib/sync.ts
+++ b/packages/desktop/src/lib/sync.ts
@@ -25,6 +25,10 @@ import { addDebugEvent } from "@freed/ui/lib/debug-store";
 import { log } from "./logger.js";
 import { recordProviderHealthEvent } from "./provider-health";
 import { scheduleSideEffect } from "./side-effect-scheduler";
+import {
+  isBackgroundRuntimeDeferredError,
+  runBackgroundJob,
+} from "./background-runtime-coordinator";
 
 const FALLBACK_SYNC_PORT = import.meta.env.VITE_FREED_SYNC_PORT || "8765";
 const RELAY_POLL_TIMEOUT_MS = 5_000;
@@ -895,43 +899,56 @@ export function scheduleCloudUpload(provider: CloudProvider, token?: string): vo
       kind: "upload",
       timeoutMs: 180_000,
       slowMs: 2_000,
-      run: async () => {
-        const startedAt = Date.now();
-        let byteLength = 0;
-        try {
-          const binary = await getDocBinary();
-          byteLength = binary.byteLength;
-          const uploadToken = token ?? await getValidCloudToken(provider);
-          if (!uploadToken) throw new Error("Cloud token missing. Reconnect the provider.");
-          if (provider === "gdrive") {
-            await gdriveUploadSafe(uploadToken, binary);
-          } else {
-            await dropboxUploadSafe(uploadToken, binary);
+      run: () =>
+        runBackgroundJob({
+          kind: "cloud-sync",
+          source: `cloud:${provider}`,
+          timeoutMs: 180_000,
+          run: async () => {
+            const startedAt = Date.now();
+            let byteLength = 0;
+            try {
+              const binary = await getDocBinary();
+              byteLength = binary.byteLength;
+              const uploadToken = token ?? await getValidCloudToken(provider);
+              if (!uploadToken) throw new Error("Cloud token missing. Reconnect the provider.");
+              if (provider === "gdrive") {
+                await gdriveUploadSafe(uploadToken, binary);
+              } else {
+                await dropboxUploadSafe(uploadToken, binary);
+              }
+              console.log("[CloudSync/%s] Uploaded (%d bytes)", provider, binary.byteLength);
+              await recordProviderHealthEvent({
+                provider,
+                outcome: "success",
+                stage: "upload",
+                startedAt,
+                finishedAt: Date.now(),
+                bytesMoved: byteLength,
+              });
+            } catch (err) {
+              const msg = err instanceof Error ? err.message : String(err);
+              console.error(`[CloudSync/${provider}] Upload failed:`, err);
+              addDebugEvent("error", `[Cloud/${provider}] upload failed: ${msg}`);
+              await recordProviderHealthEvent({
+                provider,
+                outcome: "error",
+                stage: "upload",
+                reason: msg,
+                startedAt,
+                finishedAt: Date.now(),
+                bytesMoved: byteLength,
+              });
+            }
+          },
+        }).catch((error) => {
+          if (isBackgroundRuntimeDeferredError(error)) {
+            addDebugEvent("change", `[Cloud/${provider}] upload deferred: ${error.reason}`);
+            scheduleCloudUpload(provider, token);
+            return;
           }
-          console.log("[CloudSync/%s] Uploaded (%d bytes)", provider, binary.byteLength);
-          await recordProviderHealthEvent({
-            provider,
-            outcome: "success",
-            stage: "upload",
-            startedAt,
-            finishedAt: Date.now(),
-            bytesMoved: byteLength,
-          });
-        } catch (err) {
-          const msg = err instanceof Error ? err.message : String(err);
-          console.error(`[CloudSync/${provider}] Upload failed:`, err);
-          addDebugEvent("error", `[Cloud/${provider}] upload failed: ${msg}`);
-          await recordProviderHealthEvent({
-            provider,
-            outcome: "error",
-            stage: "upload",
-            reason: msg,
-            startedAt,
-            finishedAt: Date.now(),
-            bytesMoved: byteLength,
-          });
-        }
-      },
+          throw error;
+        }),
     });
   }, UPLOAD_DEBOUNCE_MS);
 

--- a/packages/desktop/tests/e2e/fixtures/tauri-init.ts
+++ b/packages/desktop/tests/e2e/fixtures/tauri-init.ts
@@ -97,6 +97,7 @@ export function tauriInitScript(): string {
       retry_startup_after_crash: () => null,
       reset_pairing_token: () => null,
       get_recent_logs: () => [],
+      get_recent_runtime_health: () => [],
       start_relay: () => null,
       stop_relay: () => null,
       list_snapshots: () => [],

--- a/packages/desktop/tests/e2e/smoke.spec.ts
+++ b/packages/desktop/tests/e2e/smoke.spec.ts
@@ -400,6 +400,20 @@ test("app loads and renders without crashing", async ({ app }) => {
   await expect(app.page.locator("main")).toBeVisible();
 });
 
+test("startup emits renderer health before background work can run", async ({ app, page }) => {
+  await app.goto();
+  await app.waitForReady();
+
+  await expect
+    .poll(async () =>
+      page.evaluate(() => {
+        return (window as unknown as { __FREED_RENDERER_HEARTBEATS__?: number })
+          .__FREED_RENDERER_HEARTBEATS__ ?? 0;
+      }),
+    )
+    .toBeGreaterThanOrEqual(1);
+});
+
 test("page title is set", async ({ page }) => {
   await page.addInitScript(tauriInitScript());
   await page.goto("/");


### PR DESCRIPTION
(AI Generated).

## Summary
- Adds renderer-health startup gating and shared memory pressure cooldowns for high-risk Freed Desktop background work.
- Adds native social-scrape leases, runtime-health diagnostics, and relaunch fallback when the main WebView label stays stuck.
- Includes runtime-health data in desktop bug report bundles and updates the Phase 5 desktop plan.

## Testing
- npm run validate:feature
- PATH=/Users/aubreyfalconer/dev/freed-runtime-coordinator/node_modules/.bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/usr/local/MacGPG2/bin:/Applications/VMware Fusion.app/Contents/Public:/usr/local/share/dotnet:~/.dotnet/tools:/usr/local/go/bin:/Library/Frameworks/Mono.framework/Versions/Current/Commands:/Users/aubreyfalconer/.nvm/versions/node/v24.14.1/bin:/Users/aubreyfalconer/.codex/tmp/arg0/codex-arg0LhytI1:/Users/aubreyfalconer/.local/bin:/opt/homebrew/opt/mysql-client/bin:/opt/homebrew/bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/Users/aubreyfalconer/.cargo/bin:/Users/aubreyfalconer/go/bin:/Users/aubreyfalconer/.cache/lm-studio/bin:/Users/aubreyfalconer/.safe-chain/bin:/Applications/Codex.app/Contents/Resources:/usr/local/bin npm run test:unit -- background-runtime-coordinator.test.ts social-capture-memory-pressure.test.ts
- cargo test --lib
- PATH=/Users/aubreyfalconer/dev/freed-runtime-coordinator/node_modules/.bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/usr/local/MacGPG2/bin:/Applications/VMware Fusion.app/Contents/Public:/usr/local/share/dotnet:~/.dotnet/tools:/usr/local/go/bin:/Library/Frameworks/Mono.framework/Versions/Current/Commands:/Users/aubreyfalconer/.nvm/versions/node/v24.14.1/bin:/Users/aubreyfalconer/.codex/tmp/arg0/codex-arg0LhytI1:/Users/aubreyfalconer/.local/bin:/opt/homebrew/opt/mysql-client/bin:/opt/homebrew/bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/Users/aubreyfalconer/.cargo/bin:/Users/aubreyfalconer/go/bin:/Users/aubreyfalconer/.cache/lm-studio/bin:/Users/aubreyfalconer/.safe-chain/bin:/Applications/Codex.app/Contents/Resources:/usr/local/bin npm run build
- PATH=/Users/aubreyfalconer/dev/freed-runtime-coordinator/node_modules/.bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/usr/local/MacGPG2/bin:/Applications/VMware Fusion.app/Contents/Public:/usr/local/share/dotnet:~/.dotnet/tools:/usr/local/go/bin:/Library/Frameworks/Mono.framework/Versions/Current/Commands:/Users/aubreyfalconer/.nvm/versions/node/v24.14.1/bin:/Users/aubreyfalconer/.codex/tmp/arg0/codex-arg0LhytI1:/Users/aubreyfalconer/.local/bin:/opt/homebrew/opt/mysql-client/bin:/opt/homebrew/bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/Users/aubreyfalconer/.cargo/bin:/Users/aubreyfalconer/go/bin:/Users/aubreyfalconer/.cache/lm-studio/bin:/Users/aubreyfalconer/.safe-chain/bin:/Applications/Codex.app/Contents/Resources:/usr/local/bin npm run test:e2e -- smoke.spec.ts startup-recovery.spec.ts --grep 'app loads and renders without crashing|startup emits renderer health|startup recovery checks immediately'