### PR TITLE
fix: dedupe Instagram story captures

### DIFF
--- a/docs/PHASE-7-SOCIAL-CAPTURE.md
+++ b/docs/PHASE-7-SOCIAL-CAPTURE.md
@@ -1,6 +1,6 @@
 # Phase 7: Facebook + Instagram Capture
 
-> **Status:** 🚧 In Progress: Facebook and Instagram integrated into Desktop via Tauri WebView scraping, with feed pollution filtering, long-text expansion before extraction, silent background media guarding, provider health summaries, smart backoff, Facebook group controls, source-level post and story filtering, preserved Instagram story location metadata for map recovery, linked-account cross-post dedup across IG and FB, same-platform social story duplicate repair, X, Facebook, and Instagram reply hydration for the reader, captured authors now feeding the Phase 8 account catalog for identity review, and a local permanent media vault for a user's own Meta media
+> **Status:** 🚧 In Progress: Facebook and Instagram integrated into Desktop via Tauri WebView scraping, with feed pollution filtering, stricter Instagram story viewer validation, long-text expansion before extraction, silent background media guarding, provider health summaries, smart backoff, Facebook group controls, source-level post and story filtering, preserved Instagram story location metadata for map recovery, linked-account cross-post dedup across IG and FB, Instagram media-key duplicate repair, same-platform social story duplicate repair, X, Facebook, and Instagram reply hydration for the reader, captured authors now feeding the Phase 8 account catalog for identity review, and a local permanent media vault for a user's own Meta media
 > **Dependencies:** Phase 5 (Desktop App)
 
 ---
@@ -101,7 +101,7 @@ Self-contained JavaScript injected into the WebView's execution context. No exte
 - **Facebook comments** (`fb-comments-extract.js`): Opens the post URL in the authenticated WebView, expands visible comment controls, and emits inline reader replies with media.
 - **Instagram comments** (`ig-comments-extract.js`): Opens post and reel URLs in the authenticated WebView, expands visible comment controls, and emits inline reader replies with media.
 - **Facebook stories** (`fb-stories-extract.js`): Injected into the FB story viewer overlay. Extracts author, media, timestamp, location/check-in. Emits via `fb-feed-data` with `postType: "story"`.
-- **Instagram stories** (`ig-stories-extract.js`): Injected into the IG story viewer overlay. Extracts author handle (from URL + DOM), typed media URLs, timestamp, and location sticker metadata. Timestamp-like fallback story IDs are replaced with stable content hashes. The normalized `FeedItem.location` now preserves the sticker source plus Instagram `locationUrl`, so later map resolution can recover real place names from generic labels such as `Locations`.
+- **Instagram stories** (`ig-stories-extract.js`): Injected into the IG story viewer overlay. Extraction now requires a real story URL, dialog, or full-screen story container with controls before emitting, so feed cards cannot fall through as stories. Author detection prefers `/stories/<username>/` and rejects generic handles such as `reels`, `locations`, and `instagram`. Timestamp-like fallback story IDs are replaced with stable content hashes. The normalized `FeedItem.location` now preserves the sticker source plus Instagram `locationUrl`, so later map resolution can recover real place names from generic labels such as `Locations`.
 
 Story scraping is interleaved with feed scraping in each session. A coin flip (~50%) determines whether stories are scraped before or after the initial feed passes. ~15% of sessions skip story scraping entirely (real users don't always check stories). Up to 30 story frames are captured per session.
 
@@ -206,7 +206,7 @@ const RATE_LIMITS = {
 - [ ] Facebook feed posts validated against real account (selector tuning)
 - [ ] Instagram feed posts validated against real account (selector tuning)
 - [ ] Direct own-profile crawler validated against saved Facebook profile, Instagram grid, reels, albums, and media-page DOM fixtures
-- [~] Stories captured, with IG + FB story scraping integrated, Instagram story location URLs preserved for map recovery, playable story video rendering in the feed, stable fallback IG story IDs, and same-platform story duplicate repair. Selector tuning still needs work.
+- [~] Stories captured, with IG + FB story scraping integrated, stricter Instagram story viewer validation, Instagram story location URLs preserved for map recovery, playable story video rendering in the feed, stable fallback IG story IDs, Instagram media-key duplicate repair, and same-platform story duplicate repair. Selector tuning still needs work.
 - [x] Cross-platform dedup (task 7.15): linked Facebook and Instagram stories or posts with similar text now collapse into one item when they land within a few minutes of each other, while preserving saved state, tags, and richer map metadata
 - [x] Like button with outbox pattern: intent recorded immediately, synced to platform async
 - [x] Two-state like UI: "noted" (amber) vs "memorialized" (red confirmed on platform)

--- a/packages/desktop/src-tauri/src/ig-stories-extract.js
+++ b/packages/desktop/src-tauri/src/ig-stories-extract.js
@@ -33,75 +33,107 @@
     return Math.abs(hash).toString(36);
   }
 
-  // ── Extract story ID from current URL ────────────────────────────────────
-
   function isLikelyEphemeralStoryId(storyId) {
     return /^\d{13}$/.test(storyId || "");
   }
 
   function extractStoryId() {
     var href = window.location.href;
-    // /stories/username/<storyId>/
-    var m = href.match(/\/stories\/([^/]+)\/([^/?]+)/);
-    if (m) return { username: m[1], storyId: isLikelyEphemeralStoryId(m[2]) ? null : m[2] };
+    var m = href.match(/\/stories\/([^/?#]+)(?:\/([^/?#]+))?/);
+    if (m) {
+      return {
+        username: decodeURIComponent(m[1]),
+        storyId: m[2] && !isLikelyEphemeralStoryId(m[2]) ? decodeURIComponent(m[2]) : null,
+      };
+    }
     return { username: null, storyId: null };
   }
 
-  // ── Find the active story viewer overlay ─────────────────────────────────
-  // The story viewer is a full-screen overlay. Instagram uses several
-  // container strategies; we try the most reliable first.
+  function isStoryUrl(urlInfo) {
+    return !!(urlInfo && urlInfo.username);
+  }
 
-  function findStoryContainer() {
-    // Strategy 1: dialog or role="presentation" at the root level
+  function hasStoryControls(container) {
+    return !!(
+      container.querySelector('[aria-label*="Next"], [aria-label*="next"]') ||
+      container.querySelector('[aria-label*="Close"], [aria-label*="close"]') ||
+      container.querySelector('[role="progressbar"]') ||
+      container.querySelector('a[href*="/stories/"]')
+    );
+  }
+
+  function hasStoryMedia(container) {
+    return !!(
+      container.querySelector("video") ||
+      container.querySelector('img[src*="cdninstagram"], img[src*="scontent"], img[srcset]')
+    );
+  }
+
+  function findStoryContainer(urlInfo) {
+    var onStoryUrl = isStoryUrl(urlInfo);
     var dialog = document.querySelector('[role="dialog"]');
-    if (dialog && dialog.offsetHeight > 400) return dialog;
+    if (
+      dialog &&
+      dialog.offsetHeight > 400 &&
+      hasStoryMedia(dialog) &&
+      (onStoryUrl || hasStoryControls(dialog))
+    ) {
+      return dialog;
+    }
 
-    // Strategy 2: a div that fills the viewport and contains a video or
-    // a large full-bleed image (story media)
     var fullBleed = document.querySelector(
       'div[style*="position: fixed"], div[style*="position:fixed"]'
     );
-    if (fullBleed && fullBleed.offsetHeight > window.innerHeight * 0.8) {
+    if (
+      fullBleed &&
+      fullBleed.offsetHeight > window.innerHeight * 0.8 &&
+      hasStoryMedia(fullBleed) &&
+      (onStoryUrl || hasStoryControls(fullBleed))
+    ) {
       return fullBleed;
     }
 
-    // Strategy 3: the section containing the story controls bar
-    // (progress bars at the top, close button)
     var sections = document.querySelectorAll("section");
     for (var i = 0; i < sections.length; i++) {
       var s = sections[i];
-      // Story sections are tall and contain a video or large img
       if (
         s.offsetHeight > 400 &&
-        (s.querySelector("video") ||
-          s.querySelector('img[src*="cdninstagram"], img[src*="scontent"]'))
+        hasStoryMedia(s) &&
+        (onStoryUrl || hasStoryControls(s))
       ) {
         return s;
       }
     }
 
-    // Fallback: body (will extract whatever is visible)
-    return document.body;
+    return null;
   }
 
-  // ── Extract author ────────────────────────────────────────────────────────
-
   var IG_USERNAME_RE = /instagram\.com\/([A-Za-z0-9_.]+)\/?(?:\?|$|#)/;
-  var IG_SKIP_PATHS = /^(p|reel|stories|explore|accounts|direct|tv|ar|challenge|audio|location|tags)$/i;
+  var IG_SKIP_PATHS = /^(p|reel|reels|stories|explore|accounts|direct|tv|ar|challenge|audio|location|locations|tags|instagram)$/i;
 
-  function extractAuthor(container) {
+  function isGenericHandle(handle) {
+    return !handle || IG_SKIP_PATHS.test(handle);
+  }
+
+  function extractAuthor(container, urlInfo) {
     var handle = null;
     var displayName = null;
     var avatarUrl = null;
     var profileUrl = null;
 
-    // Look for header-area links near the top of the container
+    if (urlInfo.username && !isGenericHandle(urlInfo.username)) {
+      handle = urlInfo.username;
+      displayName = urlInfo.username;
+      profileUrl = "https://www.instagram.com/" + urlInfo.username + "/";
+    }
+
     var allLinks = container.querySelectorAll("a[href]");
     for (var i = 0; i < allLinks.length; i++) {
       var link = allLinks[i];
       var href = link.href || "";
       var m = href.match(IG_USERNAME_RE);
-      if (m && !IG_SKIP_PATHS.test(m[1])) {
+      if (m && !isGenericHandle(m[1])) {
+        if (handle && m[1] !== handle) continue;
         handle = m[1];
         profileUrl = href;
         var linkText = (link.textContent || "").trim();
@@ -112,7 +144,6 @@
       }
     }
 
-    // Avatar: small circular image at the very top (story author avatar)
     var imgs = container.querySelectorAll("img");
     for (var j = 0; j < Math.min(imgs.length, 10); j++) {
       var img = imgs[j];
@@ -122,15 +153,6 @@
       if (w > 20 && w < 90 && h > 20 && h < 90 && img.src) {
         avatarUrl = img.src;
         break;
-      }
-    }
-
-    // URL-based username extraction from /stories/<username>/
-    if (!handle) {
-      var urlInfo = extractStoryId();
-      if (urlInfo.username) {
-        handle = urlInfo.username;
-        displayName = urlInfo.username;
       }
     }
 
@@ -259,9 +281,33 @@
 
   try {
     var urlInfo = extractStoryId();
-    var container = findStoryContainer();
-    var author = extractAuthor(container);
+    var container = findStoryContainer(urlInfo);
+    if (!container) {
+      emit("ig-feed-data", {
+        posts: [],
+        extractedAt: Date.now(),
+        url: window.location.href,
+        candidateCount: 0,
+        scrollY: 0,
+        strategy: "story-viewer-skip",
+      });
+      return;
+    }
+
+    var author = extractAuthor(container, urlInfo);
     var media = extractMedia(container);
+    if (isGenericHandle(author.handle) || media.urls.length === 0) {
+      emit("ig-feed-data", {
+        posts: [],
+        extractedAt: Date.now(),
+        url: window.location.href,
+        candidateCount: 0,
+        scrollY: 0,
+        strategy: "story-viewer-skip",
+      });
+      return;
+    }
+
     var timestampIso = extractTimestamp(container);
     var location = extractLocation(container);
 

--- a/packages/desktop/src/lib/ig-stories-extract.test.ts
+++ b/packages/desktop/src/lib/ig-stories-extract.test.ts
@@ -13,6 +13,43 @@ function setReadonlyNumber(target: object, key: string, value: number) {
 }
 
 describe("ig-stories-extract.js", () => {
+  it("does not emit feed cards as stories when no story viewer exists", () => {
+    window.history.replaceState({}, "", "/?variant=following");
+
+    document.body.innerHTML = `
+      <main>
+        <article>
+          <a href="https://www.instagram.com/reels/">Reels</a>
+          <img src="https://scontent.example/feed-card.jpg" alt="feed post" />
+          <time datetime="2026-03-23T12:00:00.000Z"></time>
+        </article>
+      </main>
+    `;
+
+    const image = document.querySelector("img") as HTMLImageElement;
+    setReadonlyNumber(image, "width", 1080);
+    setReadonlyNumber(image, "height", 1350);
+
+    const payloads: Array<{ posts: unknown[]; strategy: string }> = [];
+    (
+      window as unknown as {
+        __TAURI__: { event: { emit: (_name: string, payload: unknown) => void } };
+      }
+    ).__TAURI__ = {
+      event: {
+        emit: (_name, payload) => {
+          payloads.push(payload as { posts: unknown[]; strategy: string });
+        },
+      },
+    };
+
+    window.eval(script);
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0].strategy).toBe("story-viewer-skip");
+    expect(payloads[0].posts).toHaveLength(0);
+  });
+
   it("keeps alphanumeric story IDs stable across repeated injections", () => {
     window.history.replaceState(
       {},
@@ -110,6 +147,47 @@ describe("ig-stories-extract.js", () => {
       "https://cdn.example/story-video.mp4",
     );
     expect(payloads[0].posts[0].mediaTypes).toEqual(["video", "image"]);
+  });
+
+  it("prefers the story URL username over generic profile links", () => {
+    window.history.replaceState({}, "", "/stories/o2_treehouse/FRAME123/");
+
+    document.body.innerHTML = `
+      <div role="dialog">
+        <a href="https://www.instagram.com/reels/">Reels</a>
+        <a href="https://www.instagram.com/o2_treehouse/">o2_treehouse</a>
+        <img src="https://cdn.example/avatar.jpg" alt="avatar" />
+        <img src="https://scontent.example/story-frame.jpg" alt="story" />
+        <time datetime="2026-03-23T12:00:00.000Z"></time>
+      </div>
+    `;
+
+    const dialog = document.querySelector('[role="dialog"]') as HTMLElement;
+    const images = Array.from(document.querySelectorAll("img")) as HTMLImageElement[];
+    setReadonlyNumber(dialog, "offsetHeight", 800);
+    setReadonlyNumber(images[0], "width", 40);
+    setReadonlyNumber(images[0], "height", 40);
+    setReadonlyNumber(images[1], "width", 1080);
+    setReadonlyNumber(images[1], "height", 1920);
+
+    const payloads: Array<{ posts: Array<{ authorHandle: string; shortcode: string }> }> = [];
+    (
+      window as unknown as {
+        __TAURI__: { event: { emit: (_name: string, payload: unknown) => void } };
+      }
+    ).__TAURI__ = {
+      event: {
+        emit: (_name, payload) => {
+          payloads.push(payload as { posts: Array<{ authorHandle: string; shortcode: string }> });
+        },
+      },
+    };
+
+    window.eval(script);
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0].posts[0].authorHandle).toBe("o2_treehouse");
+    expect(payloads[0].posts[0].shortcode).toBe("story_FRAME123");
   });
 
   it("uses a content hash when Instagram exposes a timestamp-like story ID", () => {

--- a/packages/desktop/src/lib/instagram-dedup.test.ts
+++ b/packages/desktop/src/lib/instagram-dedup.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import type { FeedItem } from "@freed/shared";
+import type { FreedDoc } from "@freed/shared/schema";
+import { createEmptyDoc, deduplicateDocFeedItems } from "@freed/shared/schema";
+
+function makeDoc(): FreedDoc {
+  return JSON.parse(JSON.stringify(createEmptyDoc())) as FreedDoc;
+}
+
+function makeItem(
+  globalId: string,
+  update: Partial<FeedItem> & Pick<FeedItem, "platform" | "contentType">,
+): FeedItem {
+  const now = Date.parse("2026-05-03T20:15:34.000Z");
+  return {
+    globalId,
+    platform: update.platform,
+    contentType: update.contentType,
+    capturedAt: now,
+    publishedAt: now,
+    author: {
+      id: update.author?.id ?? "ig:o2_treehouse",
+      handle: update.author?.handle ?? "o2_treehouse",
+      displayName: update.author?.displayName ?? "o2_treehouse",
+    },
+    content: {
+      text: update.content?.text,
+      mediaUrls: update.content?.mediaUrls ?? [],
+      mediaTypes: update.content?.mediaTypes ?? ["image"],
+    },
+    sourceUrl: update.sourceUrl,
+    location: update.location,
+    topics: update.topics ?? [],
+    userState: {
+      hidden: update.userState?.hidden ?? false,
+      saved: update.userState?.saved ?? false,
+      archived: update.userState?.archived ?? false,
+      tags: update.userState?.tags ?? [],
+      readAt: update.userState?.readAt,
+    },
+  };
+}
+
+describe("Instagram feed item dedupe", () => {
+  it("deduplicates stories with matching Instagram media keys across CDN hosts", () => {
+    const doc = makeDoc();
+    const mediaA =
+      "https://scontent-sjc6-1.cdninstagram.com/v/t51.82787-15/685786136_18590219392021644_927956206531323318_n.jpg?ig_cache_key=Mzg4OTEyMDU3MDY1NTI2OTgxNg%3D%3D.3-ccb7-5&_nc_gid=a";
+    const mediaB =
+      "https://scontent-sea1-1.cdninstagram.com/v/t51.82787-15/685786136_18590219392021644_927956206531323318_n.jpg?ig_cache_key=Mzg4OTEyMDU3MDY1NTI2OTgxNg%3D%3D.3-ccb7-5&_nc_gid=b";
+
+    doc.feedItems["ig:story_a"] = makeItem("ig:story_a", {
+      platform: "instagram",
+      contentType: "story",
+      content: { mediaUrls: [mediaA], mediaTypes: ["image"] },
+      location: { name: "Locations", url: "https://www.instagram.com/explore/locations/", source: "sticker" },
+    });
+    doc.feedItems["ig:story_b"] = makeItem("ig:story_b", {
+      platform: "instagram",
+      contentType: "story",
+      content: { mediaUrls: [mediaB], mediaTypes: ["image"] },
+      location: { name: "Locations", url: "https://www.instagram.com/explore/locations/", source: "sticker" },
+      userState: { hidden: false, saved: false, archived: false, tags: ["seen"] },
+    });
+
+    expect(deduplicateDocFeedItems(doc)).toBe(1);
+    const remaining = Object.values(doc.feedItems);
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].userState.tags).toContain("seen");
+  });
+
+  it("merges false feed-home stories into the matching Instagram post", () => {
+    const doc = makeDoc();
+    const media =
+      "https://scontent-sjc6-1.cdninstagram.com/v/t51.82787-15/686160351_18590219362021644_2956174995573013549_n.jpg?ig_cache_key=Mzg4OTEyMDU2NjkzOTE0MjI5Ng%3D%3D.3-ccb7-5&_nc_gid=a";
+
+    doc.feedItems["ig:DX47qX6ktQg"] = makeItem("ig:DX47qX6ktQg", {
+      platform: "instagram",
+      contentType: "video",
+      content: {
+        text: "POV: your backyard just became the favorite hangout.",
+        mediaUrls: [media],
+        mediaTypes: ["image"],
+      },
+      sourceUrl: "https://www.instagram.com/p/DX47qX6ktQg/",
+    });
+    doc.feedItems["ig:story_reels"] = makeItem("ig:story_reels", {
+      platform: "instagram",
+      contentType: "story",
+      author: { id: "ig:reels", handle: "reels", displayName: "Reels" },
+      content: { mediaUrls: [media.replace("scontent-sjc6-1", "scontent-sea1-1")], mediaTypes: ["image"] },
+      location: { name: "Locations", url: "https://www.instagram.com/explore/locations/", source: "sticker" },
+      sourceUrl: "https://www.instagram.com/?variant=following",
+      userState: { hidden: false, saved: true, archived: false, tags: ["saved-story"] },
+    });
+
+    expect(deduplicateDocFeedItems(doc)).toBe(1);
+    expect(doc.feedItems["ig:DX47qX6ktQg"]).toBeDefined();
+    expect(doc.feedItems["ig:story_reels"]).toBeUndefined();
+    expect(doc.feedItems["ig:DX47qX6ktQg"].contentType).toBe("video");
+    expect(doc.feedItems["ig:DX47qX6ktQg"].userState.saved).toBe(true);
+    expect(doc.feedItems["ig:DX47qX6ktQg"].userState.tags).toContain("saved-story");
+  });
+
+  it("keeps unrelated stories with different media keys separate", () => {
+    const doc = makeDoc();
+
+    doc.feedItems["ig:story_a"] = makeItem("ig:story_a", {
+      platform: "instagram",
+      contentType: "story",
+      content: {
+        mediaUrls: ["https://scontent.example/one.jpg?ig_cache_key=one"],
+        mediaTypes: ["image"],
+      },
+      location: { name: "Locations", source: "sticker" },
+    });
+    doc.feedItems["ig:story_b"] = makeItem("ig:story_b", {
+      platform: "instagram",
+      contentType: "story",
+      content: {
+        mediaUrls: ["https://scontent.example/two.jpg?ig_cache_key=two"],
+        mediaTypes: ["image"],
+      },
+      location: { name: "Locations", source: "sticker" },
+    });
+
+    expect(deduplicateDocFeedItems(doc)).toBe(0);
+    expect(Object.keys(doc.feedItems)).toHaveLength(2);
+  });
+});

--- a/packages/shared/src/schema.ts
+++ b/packages/shared/src/schema.ts
@@ -391,6 +391,7 @@ const CROSS_POST_PLATFORMS = new Set<FeedItem["platform"]>([
   "instagram",
 ]);
 const SAME_PLATFORM_STORY_DEDUP_WINDOW_MS = 10 * 60 * 1000;
+const INSTAGRAM_FALSE_STORY_MATCH_WINDOW_MS = 2 * 60 * 60 * 1000;
 
 type LegacyFriendRoot = FreedDoc & {
   friends?: Record<string, Friend>;
@@ -436,6 +437,10 @@ function dedupKeeperScore(item: FeedItem): number {
   return dedupUserStateScore(item) + dedupMetadataScore(item);
 }
 
+function dedupKeeperClass(item: FeedItem): number {
+  return isLikelyFalseInstagramFeedStory(item) ? 0 : 1;
+}
+
 function normalizedDedupText(item: FeedItem): string | null {
   const raw = item.content.text ?? item.content.linkPreview?.title ?? "";
   const normalized = raw
@@ -461,7 +466,39 @@ function normalizedStoryDedupText(item: FeedItem): string {
 }
 
 function normalizedStoryMediaKey(item: FeedItem): string {
-  return item.content.mediaUrls[0] ?? item.sourceUrl ?? "";
+  if (item.platform !== "instagram") {
+    return item.content.mediaUrls[0] ?? item.sourceUrl ?? "";
+  }
+
+  for (const url of item.content.mediaUrls ?? []) {
+    const key = instagramMediaAssetKey(url);
+    if (key) return key;
+  }
+
+  return item.sourceUrl ?? "";
+}
+
+function instagramMediaAssetKey(rawUrl: string | undefined): string | null {
+  if (!rawUrl) return null;
+
+  try {
+    const url = new URL(rawUrl);
+    const cacheKey = url.searchParams.get("ig_cache_key");
+    if (cacheKey) return `ig-cache:${cacheKey}`;
+
+    const videoServerKey = url.searchParams.get("vs");
+    if (videoServerKey) return `ig-video:${videoServerKey}`;
+
+    const filename = url.pathname.split("/").filter(Boolean).at(-1);
+    if (filename) return `ig-file:${filename}`;
+  } catch {
+    const cacheMatch = rawUrl.match(/[?&]ig_cache_key=([^&]+)/);
+    if (cacheMatch) return `ig-cache:${decodeURIComponent(cacheMatch[1])}`;
+    const filenameMatch = rawUrl.match(/\/([^/?#]+\.(?:jpe?g|png|webp|mp4))(?:[?#]|$)/i);
+    if (filenameMatch) return `ig-file:${filenameMatch[1]}`;
+  }
+
+  return null;
 }
 
 function samePlatformStoryDedupKey(item: FeedItem): string | null {
@@ -471,6 +508,11 @@ function samePlatformStoryDedupKey(item: FeedItem): string | null {
   const mediaKey = normalizedStoryMediaKey(item);
   const textKey = normalizedStoryDedupText(item);
   if (!mediaKey && !textKey) return null;
+
+  if (item.platform === "instagram" && mediaKey) {
+    const publishedBucket = Math.floor(item.publishedAt / SAME_PLATFORM_STORY_DEDUP_WINDOW_MS);
+    return [item.platform, publishedBucket.toString(), mediaKey].join("::");
+  }
 
   const authorKey = item.author.id || item.author.handle || item.author.displayName;
   const publishedBucket = Math.floor(item.publishedAt / SAME_PLATFORM_STORY_DEDUP_WINDOW_MS);
@@ -484,6 +526,71 @@ function samePlatformStoryDedupKey(item: FeedItem): string | null {
     locationKey,
     textKey,
   ].join("::");
+}
+
+function isInstagramFeedHomeUrl(sourceUrl: string | undefined): boolean {
+  if (!sourceUrl) return false;
+  try {
+    const parsed = new URL(sourceUrl);
+    return (
+      parsed.hostname.endsWith("instagram.com") &&
+      (parsed.pathname === "/" || parsed.pathname === "") &&
+      parsed.searchParams.get("variant") === "following"
+    );
+  } catch {
+    return sourceUrl === "https://www.instagram.com/?variant=following";
+  }
+}
+
+function isGenericInstagramStoryLocation(item: FeedItem): boolean {
+  if (!item.location) return true;
+  const locationName = item.location.name?.trim().toLowerCase() ?? "";
+  const locationUrl = item.location.url ?? "";
+  return (
+    locationName === "" ||
+    locationName === "location" ||
+    locationName === "locations" ||
+    locationUrl === "https://www.instagram.com/explore/locations/" ||
+    locationUrl === "https://www.instagram.com/explore/locations"
+  );
+}
+
+function isLikelyFalseInstagramFeedStory(item: FeedItem): boolean {
+  return (
+    item.platform === "instagram" &&
+    item.contentType === "story" &&
+    isInstagramFeedHomeUrl(item.sourceUrl) &&
+    (item.content.text ?? "").trim() === "" &&
+    isGenericInstagramStoryLocation(item) &&
+    normalizedStoryMediaKey(item) !== ""
+  );
+}
+
+function addFalseInstagramStoryGroups(
+  parent: Map<string, string>,
+  items: FeedItem[],
+): void {
+  const realItemsByMediaKey = new Map<string, FeedItem[]>();
+
+  for (const item of items) {
+    if (item.platform !== "instagram" || item.contentType === "story") continue;
+    const mediaKey = normalizedStoryMediaKey(item);
+    if (!mediaKey) continue;
+    const group = realItemsByMediaKey.get(mediaKey);
+    if (group) group.push(item);
+    else realItemsByMediaKey.set(mediaKey, [item]);
+  }
+
+  for (const item of items) {
+    if (!isLikelyFalseInstagramFeedStory(item)) continue;
+    const mediaKey = normalizedStoryMediaKey(item);
+    const matches = (realItemsByMediaKey.get(mediaKey) ?? []).filter(
+      (candidate) =>
+        Math.abs(candidate.publishedAt - item.publishedAt) <= INSTAGRAM_FALSE_STORY_MATCH_WINDOW_MS,
+    );
+    if (matches.length === 0) continue;
+    addDedupGroup(parent, [item.globalId, ...matches.map((candidate) => candidate.globalId)]);
+  }
 }
 
 function dedupIdentityKey(doc: FreedDoc, item: FeedItem): string | null {
@@ -871,6 +978,7 @@ function dedupKeeperId(doc: FreedDoc, ids: string[]): string {
     const left = doc.feedItems[leftId];
     const right = doc.feedItems[rightId];
     return (
+      dedupKeeperClass(right) - dedupKeeperClass(left) ||
       dedupKeeperScore(right) - dedupKeeperScore(left) ||
       right.publishedAt - left.publishedAt ||
       rightId.localeCompare(leftId)
@@ -880,6 +988,7 @@ function dedupKeeperId(doc: FreedDoc, ids: string[]): string {
 
 export function deduplicateDocFeedItems(doc: FreedDoc): number {
   const unions = new Map<string, string>();
+  const items = Object.values(doc.feedItems) as FeedItem[];
   const exactUrlGroups = new Map<string, string[]>();
 
   for (const [id, item] of Object.entries(doc.feedItems) as [string, FeedItem][]) {
@@ -907,8 +1016,10 @@ export function deduplicateDocFeedItems(doc: FreedDoc): number {
     addDedupGroup(unions, ids);
   }
 
+  addFalseInstagramStoryGroups(unions, items);
+
   const crossPostGroups = new Map<string, FeedItem[]>();
-  for (const item of Object.values(doc.feedItems) as FeedItem[]) {
+  for (const item of items) {
     if (!CROSS_POST_PLATFORMS.has(item.platform)) continue;
     const identityKey = dedupIdentityKey(doc, item);
     const textKey = normalizedDedupText(item);

--- a/website/src/app/roadmap/RoadmapContent.tsx
+++ b/website/src/app/roadmap/RoadmapContent.tsx
@@ -756,7 +756,7 @@ const phases: Phase[] = [
     number: 7,
     title: "Facebook + Instagram",
     description:
-      "Facebook and Instagram integrated via Tauri WebView scraping, with suggested-post filtering, long-text expansion, source-level post and story filters, hardened playable story capture, same-platform story duplicate repair, silent background media guarding, serialized background scraper sessions, filtered Facebook group controls, provider health summaries, Meta export import, a permanent local archive for the user's own media, X, Facebook, and Instagram reply hydration in the reader, private story reply states, and smart backoff when sync looks rate-limited.",
+      "Facebook and Instagram integrated via Tauri WebView scraping, with suggested-post filtering, long-text expansion, source-level post and story filters, stricter Instagram story viewer validation, hardened playable story capture, Instagram media-key duplicate repair, same-platform story duplicate repair, silent background media guarding, serialized background scraper sessions, filtered Facebook group controls, provider health summaries, Meta export import, a permanent local archive for the user's own media, X, Facebook, and Instagram reply hydration in the reader, private story reply states, and smart backoff when sync looks rate-limited.",
     status: "current",
     planLink:
       "https://github.com/freed-project/freed/blob/dev/docs/PHASE-7-SOCIAL-CAPTURE.md",


### PR DESCRIPTION
(AI Generated).

## Summary
- Require a real Instagram story viewer before story extraction emits items.
- Use stable Instagram media asset keys to collapse duplicate stories and repair false feed-home stories into matching posts or videos.
- Document the Phase 7 story capture hardening and keep the roadmap status current.

## Testing
- cd packages/desktop && npm run test:unit -- ig-stories-extract.test.ts instagram-dedup.test.ts
- npm run validate:feature