### PR TITLE
fix: let startup recovery dialog scroll

### DIFF
--- a/packages/desktop/src/components/StartupRecoveryScreen.tsx
+++ b/packages/desktop/src/components/StartupRecoveryScreen.tsx
@@ -30,6 +30,7 @@ type RecoveryStatus =
   | { kind: "error"; message: string };
 
 const RETRY_COMMAND = "retry_startup_after_crash";
+const INTEGER_FORMATTER = new Intl.NumberFormat(undefined, { maximumFractionDigits: 0 });
 
 export function StartupRecoveryScreen() {
   const [releaseChannel, setReleaseChannel] = useState(() => bootstrapDesktopReleaseChannel());
@@ -177,7 +178,7 @@ export function StartupRecoveryScreen() {
   const statusIsError = !actionNotice && status.kind === "error";
 
   return (
-    <main className="min-h-screen bg-transparent px-7 py-7 text-[var(--theme-text-primary)]">
+    <main className="startup-recovery-scroll bg-transparent px-7 py-7 text-[var(--theme-text-primary)]">
       <div className="mx-auto flex min-h-[calc(100vh-56px)] w-full max-w-[560px] items-center">
         <section className="theme-dialog-shell w-full rounded-[24px] p-8 shadow-2xl shadow-black/50">
           <h1 className="text-4xl font-semibold leading-[1.05]">
@@ -220,7 +221,7 @@ export function StartupRecoveryScreen() {
                 className="rounded-[14px] border border-[rgba(124,92,255,0.28)] bg-[rgba(124,92,255,0.12)] px-5 py-3 text-base font-semibold text-[var(--theme-text-primary)] transition-colors hover:bg-[rgba(124,92,255,0.2)] disabled:cursor-wait disabled:opacity-70"
               >
                 {status.kind === "downloading"
-                  ? `Downloading ${Math.round(status.percent)}%`
+                  ? `Downloading ${INTEGER_FORMATTER.format(Math.round(status.percent))}%`
                   : "Install update and restart"}
               </button>
             ) : null}
@@ -269,7 +270,7 @@ function getStatusLine(
         ? "An update is available. Install it in place, or use the browser download fallback."
         : "An update is available.";
     case "downloading":
-      return `Downloading update... ${Math.round(status.percent)}%`;
+      return `Downloading update... ${INTEGER_FORMATTER.format(Math.round(status.percent))}%`;
     case "error":
       return status.message;
   }

--- a/packages/desktop/src/index.css
+++ b/packages/desktop/src/index.css
@@ -36,6 +36,11 @@ body {
   background: color-mix(in oklab, var(--theme-bg-root) 78%, transparent);
 }
 
+.startup-recovery-scroll {
+  height: 100vh;
+  overflow-y: auto;
+}
+
 .cloud-sync-nudge-countdown {
   animation: cloud-sync-nudge-countdown 15s linear forwards;
   opacity: 0.65;

--- a/packages/desktop/tests/e2e/startup-recovery.spec.ts
+++ b/packages/desktop/tests/e2e/startup-recovery.spec.ts
@@ -52,3 +52,35 @@ test("startup recovery installs pending updates in place and surfaces install er
   await expect(page.getByText("Synthetic install failure")).toBeVisible();
   await expect(page.getByRole("button", { name: "Install update and restart" })).toBeVisible();
 });
+
+test("startup recovery scrolls vertically when content exceeds the window", async ({
+  app,
+  page,
+}) => {
+  await page.setViewportSize({ width: 760, height: 420 });
+  await page.addInitScript(() => {
+    (window as Record<string, unknown>).__TAURI_MOCK_UPDATE__ = {
+      version: "26.5.302-dev",
+      body: "Harden startup recovery and refine feed layout",
+      downloadAndInstall: async () => undefined,
+    };
+  });
+
+  await app.page.goto("/startup-recovery.html?releaseChannel=dev");
+  await expect(page.getByText("Freed did not finish loading last time.")).toBeVisible();
+
+  const scrollMetrics = await page.locator("main").evaluate((element) => {
+    element.scrollTop = element.scrollHeight;
+    const style = window.getComputedStyle(element);
+    return {
+      overflowY: style.overflowY,
+      clientHeight: element.clientHeight,
+      scrollHeight: element.scrollHeight,
+      scrollTop: element.scrollTop,
+    };
+  });
+
+  expect(scrollMetrics.overflowY).toBe("auto");
+  expect(scrollMetrics.scrollHeight).toBeGreaterThan(scrollMetrics.clientHeight);
+  expect(scrollMetrics.scrollTop).toBeGreaterThan(0);
+});


### PR DESCRIPTION
(AI Generated).

## Summary
- Make the startup recovery screen own vertical scrolling when its content exceeds the recovery window height.
- Keep update progress labels locale formatted while touching the recovery screen.

## Testing
- `PATH=/Users/aubreyfalconer/dev/freed-recovery-dialog-scroll/node_modules/.bin:$PATH npm run test:e2e -- startup-recovery.spec.ts`
- `npm run validate:feature`
