### PR TITLE
chore: refresh changelog for v26.5.309

### DIFF
--- a/release-notes/daily/production/26.5.3.json
+++ b/release-notes/daily/production/26.5.3.json
@@ -1,0 +1,22 @@
+{
+  "channel": "production",
+  "dayKey": "26.5.3",
+  "date": "2026-05-03",
+  "preferredDeck": "Relationship views, optional local intelligence, reliable capture, and calmer reading",
+  "editorialGuidance": [
+    "Keep the tone concise, professional, and specific.",
+    "Lead with user-facing outcomes, shipping milestones, trust wins, and installability improvements.",
+    "Demote internal cleanup unless it clearly changes the shipped product."
+  ],
+  "pinnedHighlights": [
+    "Friends graph tools now include ranked suggestions, relationship tiers, shared Friends or All content scoping, and search profile actions.",
+    "Optional local AI model packs can be installed from settings to enrich semantic analysis without bundling model weights.",
+    "Reading layouts now keep feeds, stories, sidebars, and cards steadier while media and view transitions load.",
+    "Startup recovery now waits for healthy renderer heartbeats, records diagnostics, and keeps background work from running into stalled windows.",
+    "Social capture is more reliable across Instagram, Facebook, LinkedIn, and X, with stronger story dedupe, comment hydration, OAuth, and memory-pressure handling."
+  ],
+  "editorialNotes": [
+    "Production rollup manually preserved the dev prerelease themes after automatic consolidation could not fit the full prerelease span."
+  ],
+  "updatedAt": "2026-05-04T04:39:00.000Z"
+}

--- a/release-notes/releases/v26.5.309.json
+++ b/release-notes/releases/v26.5.309.json
@@ -1,0 +1,87 @@
+{
+  "tag": "v26.5.309",
+  "version": "26.5.309",
+  "channel": "production",
+  "dayKey": "26.5.3",
+  "approved": true,
+  "editorialNotes": [
+    "Manually authored after prepare-release-notes could not consolidate the full dev prerelease run into the production rollup."
+  ],
+  "generatedAt": "2026-05-04T04:39:00.000Z",
+  "model": "manual",
+  "source": {
+    "channel": "production",
+    "previousPublishedTag": "v26.4.2603",
+    "previousPublishedDayTag": "v26.4.2603",
+    "compareRef": "HEAD",
+    "isLatestOfDay": true,
+    "sameDayTagsIncluded": [
+      "v26.5.309"
+    ],
+    "relatedBuildTags": [
+      "v26.4.2604-dev",
+      "v26.4.2605-dev",
+      "v26.4.2606-dev",
+      "v26.4.2700-dev",
+      "v26.4.2800-dev",
+      "v26.4.2900-dev",
+      "v26.4.2901-dev",
+      "v26.4.2902-dev",
+      "v26.4.2903-dev",
+      "v26.4.2904-dev",
+      "v26.4.3000-dev",
+      "v26.4.3001-dev",
+      "v26.4.3002-dev",
+      "v26.4.3003-dev",
+      "v26.4.3005-dev",
+      "v26.4.3006-dev",
+      "v26.5.100-dev",
+      "v26.5.101-dev",
+      "v26.5.102-dev",
+      "v26.5.103-dev",
+      "v26.5.200-dev",
+      "v26.5.201-dev",
+      "v26.5.300-dev",
+      "v26.5.301-dev",
+      "v26.5.302-dev",
+      "v26.5.303-dev",
+      "v26.5.304-dev",
+      "v26.5.305-dev",
+      "v26.5.306-dev",
+      "v26.5.308-dev",
+      "v26.5.309"
+    ],
+    "prNumbers": [
+      411,
+      412,
+      414,
+      416
+    ],
+    "commitSubjects": [
+      "chore: promote dev into main for production release",
+      "chore: promote dev into main for production retry"
+    ]
+  },
+  "release": {
+    "deck": "A larger Freed Desktop update focused on relationship views, optional local intelligence, reliable capture, and calmer reading.",
+    "features": [
+      "Friends graph tools now include ranked suggestions, relationship tiers, shared Friends or All content scoping, and search profile actions.",
+      "Optional local AI model packs can be installed from settings to enrich semantic analysis without bundling model weights.",
+      "Reading layouts now keep feeds, stories, sidebars, and cards steadier while media and view transitions load."
+    ],
+    "fixes": [
+      "Startup recovery now waits for healthy renderer heartbeats, records diagnostics, and keeps background work from running into stalled windows.",
+      "Social capture is more reliable across Instagram, Facebook, LinkedIn, and X, with stronger story dedupe, comment hydration, OAuth, and memory-pressure handling.",
+      "Sync and update flows are steadier across Google Drive, Dropbox, mobile pairing, updater channels, outbox persistence, and Automerge state patches.",
+      "Provider health, source action menus, graph selection, and graph label checks have stronger Freed Desktop validation coverage.",
+      "Cloud media vault setup, Google contacts sync, and local archive handling have clearer settings and safer storage paths.",
+      "Read-on-scroll, reader hydration, saved signals, search, map markers, and command state now preserve context more consistently."
+    ],
+    "followUps": [
+      "Release validation now covers the full primary platform matrix and slimmer Freed Desktop E2E gates.",
+      "Website changelog and roadmap presentation will be refreshed from the production tag after the release workflow publishes.",
+      "Reverse integration will merge this production release back into dev after updater verification."
+    ]
+  },
+  "releaseBody": "(AI Generated).\n\n## Freed v26.5.309\n\nA larger Freed Desktop update focused on relationship views, optional local intelligence, reliable capture, and calmer reading.\n\n### Features\n\n- Friends graph tools now include ranked suggestions, relationship tiers, shared Friends or All content scoping, and search profile actions.\n- Optional local AI model packs can be installed from settings to enrich semantic analysis without bundling model weights.\n- Reading layouts now keep feeds, stories, sidebars, and cards steadier while media and view transitions load.\n\n### Fixes\n\n- Startup recovery now waits for healthy renderer heartbeats, records diagnostics, and keeps background work from running into stalled windows.\n- Social capture is more reliable across Instagram, Facebook, LinkedIn, and X, with stronger story dedupe, comment hydration, OAuth, and memory-pressure handling.\n- Sync and update flows are steadier across Google Drive, Dropbox, mobile pairing, updater channels, outbox persistence, and Automerge state patches.\n- Provider health, source action menus, graph selection, and graph label checks have stronger Freed Desktop validation coverage.\n- Cloud media vault setup, Google contacts sync, and local archive handling have clearer settings and safer storage paths.\n- Read-on-scroll, reader hydration, saved signals, search, map markers, and command state now preserve context more consistently.\n\n### Follow-ups\n\n- Release validation now covers the full primary platform matrix and slimmer Freed Desktop E2E gates.\n- Website changelog and roadmap presentation will be refreshed from the production tag after the release workflow publishes.\n- Reverse integration will merge this production release back into dev after updater verification.\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+}

--- a/release-notes/releases/v26.5.309.md
+++ b/release-notes/releases/v26.5.309.md
@@ -1,0 +1,34 @@
+(AI Generated).
+
+## Freed v26.5.309
+
+A larger Freed Desktop update focused on relationship views, optional local intelligence, reliable capture, and calmer reading.
+
+### Features
+
+- Friends graph tools now include ranked suggestions, relationship tiers, shared Friends or All content scoping, and search profile actions.
+- Optional local AI model packs can be installed from settings to enrich semantic analysis without bundling model weights.
+- Reading layouts now keep feeds, stories, sidebars, and cards steadier while media and view transitions load.
+
+### Fixes
+
+- Startup recovery now waits for healthy renderer heartbeats, records diagnostics, and keeps background work from running into stalled windows.
+- Social capture is more reliable across Instagram, Facebook, LinkedIn, and X, with stronger story dedupe, comment hydration, OAuth, and memory-pressure handling.
+- Sync and update flows are steadier across Google Drive, Dropbox, mobile pairing, updater channels, outbox persistence, and Automerge state patches.
+- Provider health, source action menus, graph selection, and graph label checks have stronger Freed Desktop validation coverage.
+- Cloud media vault setup, Google contacts sync, and local archive handling have clearer settings and safer storage paths.
+- Read-on-scroll, reader hydration, saved signals, search, map markers, and command state now preserve context more consistently.
+
+### Follow-ups
+
+- Release validation now covers the full primary platform matrix and slimmer Freed Desktop E2E gates.
+- Website changelog and roadmap presentation will be refreshed from the production tag after the release workflow publishes.
+- Reverse integration will merge this production release back into dev after updater verification.
+
+### Downloads
+
+**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  
+**Windows:** `.exe` (NSIS installer)  
+**Linux:** `.AppImage`  
+
+> macOS downloads are signed and notarized for normal Gatekeeper installation.

--- a/website/public/atom.xml
+++ b/website/public/atom.xml
@@ -2,7 +2,7 @@
 <feed xmlns="http://www.w3.org/2005/Atom">
     <id>https://freed.wtf</id>
     <title>Freed Blog</title>
-    <updated>2026-04-30T17:32:18.982Z</updated>
+    <updated>2026-05-04T05:11:36.368Z</updated>
     <generator>https://github.com/jpmonette/feed</generator>
     <author>
         <name>The Freed Team</name>

--- a/website/public/feed.xml
+++ b/website/public/feed.xml
@@ -4,7 +4,7 @@
         <title>Freed Blog</title>
         <link>https://freed.wtf</link>
         <description>Progress reports, technical deep-dives, and philosophical rants about the attention economy. From the team building Freed.</description>
-        <lastBuildDate>Thu, 30 Apr 2026 17:32:18 GMT</lastBuildDate>
+        <lastBuildDate>Mon, 04 May 2026 05:11:36 GMT</lastBuildDate>
         <docs>https://validator.w3.org/feed/docs/rss2.html</docs>
         <generator>https://github.com/jpmonette/feed</generator>
         <language>en</language>

--- a/website/src/content/changelog.generated.json
+++ b/website/src/content/changelog.generated.json
@@ -1,10 +1,276 @@
 [
   {
-    "version": "26.4.3002-dev",
-    "tagName": "v26.4.3002-dev",
+    "version": "26.5.309",
+    "tagName": "v26.5.309",
+    "channel": "production",
+    "date": "2026-05-04T05:08:35Z",
+    "deck": "A larger Freed Desktop update focused on relationship views, optional local intelligence, reliable capture, and calmer reading.",
+    "features": [
+      {
+        "text": "Friends graph tools now include ranked suggestions, relationship tiers, shared Friends or All content scoping, and search profile actions."
+      },
+      {
+        "text": "Optional local AI model packs can be installed from settings to enrich semantic analysis without bundling model weights."
+      },
+      {
+        "text": "Reading layouts now keep feeds, stories, sidebars, and cards steadier while media and view transitions load."
+      }
+    ],
+    "fixes": [
+      {
+        "text": "Startup recovery now waits for healthy renderer heartbeats, records diagnostics, and keeps background work from running into stalled windows."
+      },
+      {
+        "text": "Social capture is more reliable across Instagram, Facebook, LinkedIn, and X, with stronger story dedupe, comment hydration, OAuth, and memory-pressure handling."
+      },
+      {
+        "text": "Sync and update flows are steadier across Google Drive, Dropbox, mobile pairing, updater channels, outbox persistence, and Automerge state patches."
+      },
+      {
+        "text": "Provider health, source action menus, graph selection, and graph label checks have stronger Freed Desktop validation coverage."
+      },
+      {
+        "text": "Cloud media vault setup, Google contacts sync, and local archive handling have clearer settings and safer storage paths."
+      },
+      {
+        "text": "Read-on-scroll, reader hydration, saved signals, search, map markers, and command state now preserve context more consistently."
+      }
+    ],
+    "followUps": [
+      {
+        "text": "Release validation now covers the full primary platform matrix and slimmer Freed Desktop E2E gates."
+      },
+      {
+        "text": "Website changelog and roadmap presentation will be refreshed from the production tag after the release workflow publishes."
+      },
+      {
+        "text": "Reverse integration will merge this production release back into dev after updater verification."
+      }
+    ],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.5.309",
+    "prNumbers": [
+      411,
+      412,
+      414,
+      416
+    ],
+    "builds": [
+      "26.5.309"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.5.309",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.5.309",
+        "channel": "production"
+      }
+    ]
+  },
+  {
+    "version": "26.5.308-dev",
+    "tagName": "v26.5.308-dev",
     "channel": "dev",
-    "date": "2026-04-30T20:48:39Z",
-    "deck": "Integrated AI pack ladder, adaptive social scrape memory handling, and global animation controls",
+    "date": "2026-05-04T04:44:25Z",
+    "deck": "Stabilize feed layout, search, and capture cleanup",
+    "features": [
+      {
+        "text": "Friends relationship tiers"
+      },
+      {
+        "text": "Refine sidebar rows and card density"
+      },
+      {
+        "text": "Search profile actions"
+      }
+    ],
+    "fixes": [
+      {
+        "text": "Deduped duplicate Instagram story captures"
+      },
+      {
+        "text": "Desktop feed scroll layout is now more stable"
+      },
+      {
+        "text": "Freed Desktop startup recovery now waits for healthy renderer heartbeats before running high-risk jobs"
+      },
+      {
+        "text": "Added runtime-health diagnostics for blank renderer reports, including active background work, memory pressure, and recovery attempts"
+      },
+      {
+        "text": "Promote linked accounts without duplicate drafts"
+      },
+      {
+        "text": "Tightened collapsed feed filter menu headings, copy, spacing, and classification selection animation"
+      },
+      {
+        "text": "Floating menus now stay inside the viewport and scroll internally"
+      }
+    ],
+    "followUps": [
+      {
+        "text": "Friends graph validation now checks structural graph signals instead of provider label text"
+      },
+      {
+        "text": "Friends graph validation now fits the graph before checking visual labels"
+      },
+      {
+        "text": "Friends graph validation now waits for provider labels before checking the visual state"
+      },
+      {
+        "text": "Friends graph and feed perf gates now allow normal CI timing variance"
+      },
+      {
+        "text": "Slim desktop e2e gates"
+      },
+      {
+        "text": "Added fixed-height desktop feed cards and story rows so media loading no longer changes scroll position"
+      },
+      {
+        "text": "Added compact, comfortable, and expansive feed card density controls with matching skeleton heights and bounded internal scrolling for floating menus"
+      }
+    ],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.5.308-dev",
+    "prNumbers": [],
+    "builds": [
+      "26.5.300-dev",
+      "26.5.301-dev",
+      "26.5.302-dev",
+      "26.5.308-dev"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.5.300-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.5.300-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.5.301-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.5.301-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.5.302-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.5.302-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.5.308-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.5.308-dev",
+        "channel": "dev"
+      }
+    ]
+  },
+  {
+    "version": "26.5.201-dev",
+    "tagName": "v26.5.201-dev",
+    "channel": "dev",
+    "date": "2026-05-02T22:17:34Z",
+    "deck": "AI ranked friend suggestions and a shared friends lens across core views.",
+    "features": [],
+    "fixes": [],
+    "followUps": [],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.5.201-dev",
+    "prNumbers": [],
+    "builds": [
+      "26.5.201-dev"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.5.201-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.5.201-dev",
+        "channel": "dev"
+      }
+    ]
+  },
+  {
+    "version": "26.5.103-dev",
+    "tagName": "v26.5.103-dev",
+    "channel": "dev",
+    "date": "2026-05-02T06:07:30Z",
+    "deck": "Keeps crash recovery, AI downloads, and common desktop actions responsive",
+    "features": [],
+    "fixes": [
+      {
+        "text": "Startup recovery can now check for updates, install them, relaunch, and open fallback browser downloads"
+      },
+      {
+        "text": "Desktop AI downloads and renderer recovery are now more stable"
+      },
+      {
+        "text": "Update outbox test fixture types"
+      },
+      {
+        "text": "Preserve side-effect queue serialization on timeout"
+      },
+      {
+        "text": "Kept desktop side-effect queues serialized even when a queued task times out, so one slow persistence or sync action cannot let later work overlap out of order"
+      },
+      {
+        "text": "Moved provider health, secure storage, cloud upload, snapshots, and outbox side effects through typed queues so UI gestures return quickly"
+      },
+      {
+        "text": "Prevented read, like, archive, and sync-confirmation item patches from making the outbox rescan the full feed"
+      },
+      {
+        "text": "Updated desktop item patches incrementally on the main thread, including count-map identity preservation for like and sync-confirmation patches"
+      },
+      {
+        "text": "Fixed stale outbox test fixtures so release validation covers the new patch-drain path"
+      },
+      {
+        "text": "Integrated AI pack downloads now stream through native disk IO, which keeps large local model downloads out of the WebKit renderer"
+      },
+      {
+        "text": "Renderer recovery now rebuilds stale macOS windows on the main thread after heartbeat failure"
+      },
+      {
+        "text": "Local AI classification now stays off until Topics and ranking is enabled, and settings show classification as off while disabled"
+      },
+      {
+        "text": "Desktop scrapers now log and respect WebKit memory pressure before launching new provider work"
+      }
+    ],
+    "followUps": [
+      {
+        "text": "Preserve count maps for neutral patches"
+      },
+      {
+        "text": "Item patch state incrementally"
+      },
+      {
+        "text": "Route desktop hot-path side effects"
+      }
+    ],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.5.103-dev",
+    "prNumbers": [],
+    "builds": [
+      "26.5.101-dev",
+      "26.5.102-dev",
+      "26.5.103-dev"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.5.101-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.5.101-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.5.102-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.5.102-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.5.103-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.5.103-dev",
+        "channel": "dev"
+      }
+    ]
+  },
+  {
+    "version": "26.4.3006-dev",
+    "tagName": "v26.4.3006-dev",
+    "channel": "dev",
+    "date": "2026-05-01T03:01:14Z",
+    "deck": "Integrated AI pack ladder, constrain settings list growth, and an Appearance animation control with None, Light, and Detailed options, so app motion can be reduced or disabled across controlled fades, slides, layout transitions, shimmers, and theme changes",
     "features": [
       {
         "text": "Integrated AI pack ladder"
@@ -18,25 +284,7 @@
     ],
     "fixes": [
       {
-        "text": "Social scrapes now measure Freed-owned WebKit memory, reclaim stale scraper windows and oversized network cache, and keep provider errors scoped to the right settings panel"
-      },
-      {
-        "text": "Show desktop feed thumbnails"
-      },
-      {
-        "text": "Scope social provider error copy"
-      },
-      {
-        "text": "Constrain settings list growth"
-      },
-      {
-        "text": "Scale desktop settings dialog with viewport"
-      },
-      {
-        "text": "Renderer recovery and model installs are now more stable"
-      },
-      {
-        "text": "Main window reopen after renderer recovery restored"
+        "text": "Run background social scraper windows fully hidden by default and restart cleanly if Tauri cannot rebuild a stalled main window, so Freed Desktop does not strand users on a black window."
       },
       {
         "text": "Rebuild the main window through a hidden keepalive window during renderer recovery, so watchdog recovery no longer quits the app before the replacement window opens"
@@ -46,25 +294,67 @@
       },
       {
         "text": "Keep Pause available while an AI model download is active"
+      },
+      {
+        "text": "Feed card max width and desktop feed thumbnails so dense feeds stay readable restored"
+      },
+      {
+        "text": "Scale the desktop Settings dialog with the viewport so tall settings lists remain usable on smaller displays"
+      },
+      {
+        "text": "Social scrapes now measure Freed-owned WebKit memory, reclaim stale scraper windows and oversized network cache, and keep provider errors scoped to the right settings panel"
+      },
+      {
+        "text": "Renderer recovery and model installs are now more stable"
+      },
+      {
+        "text": "Main window reopen after renderer recovery restored"
+      },
+      {
+        "text": "Expanded provider rows now draw wider highlights, shift social icons left, and keep unread and total counts pinned in place"
+      },
+      {
+        "text": "Primary search suggestions now rank useful scopes, actions, and recent destinations more clearly"
+      },
+      {
+        "text": "Channel avatar fallbacks are shared across feed cards, Friends, and map markers for more consistent identity cues"
+      },
+      {
+        "text": "Cloud sync nudges now show a countdown before a delayed reminder becomes active"
+      },
+      {
+        "text": "Background AI summarization now runs through one paced fetcher worker with randomized delay, capped backoff, and 60-second AI timeouts, so slow local models cannot stack overlapping work"
+      },
+      {
+        "text": "Scope social provider error copy by provider, so Instagram, Facebook, LinkedIn, and X setup states say what actually failed"
       }
     ],
     "followUps": [
       {
+        "text": "Renderer heartbeat telemetry now has a clearer recovery path for future black-window reports."
+      },
+      {
         "text": "Freed Desktop now keeps the app alive while rebuilding a stalled main window, and large AI model pack downloads put less pressure on the interface"
+      },
+      {
+        "text": "Motion preferences now have a synced default of Detailed, while None removes app-controlled animation for users who need a quiet interface"
       },
       {
         "text": "Facebook, Instagram, and LinkedIn scraping should keep moving for larger libraries unless Freed itself remains under unsafe memory pressure after cleanup"
       },
       {
-        "text": "Motion preferences now have a synced default of Detailed, while None removes app-controlled animation for users who need a quiet interface"
+        "text": "Source action menus and provider status surfaces now have tighter geometry coverage in the desktop E2E suite"
       }
     ],
-    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.3002-dev",
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.3006-dev",
     "prNumbers": [],
     "builds": [
       "26.4.3000-dev",
       "26.4.3001-dev",
-      "26.4.3002-dev"
+      "26.4.3002-dev",
+      "26.4.3003-dev",
+      "26.4.3005-dev",
+      "26.4.3006-dev"
     ],
     "buildLinks": [
       {
@@ -80,6 +370,21 @@
       {
         "version": "26.4.3002-dev",
         "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.3002-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.4.3003-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.3003-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.4.3005-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.3005-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.4.3006-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.3006-dev",
         "channel": "dev"
       }
     ]


### PR DESCRIPTION
(AI Generated).

Summary:
- Add reviewed release notes for v26.5.309 to the website branch.
- Regenerate the static changelog snapshot and feeds.

Validation:
- node scripts/validate-release-notes.mjs release-notes/releases/v26.5.309.json
- PATH=/Users/aubreyfalconer/dev/freed-www-release-26-5-309/node_modules/.bin:$PATH npm run build