### PR TITLE
chore: refresh changelog for v26.5.400

### DIFF
--- a/release-notes/daily/production/26.5.4.json
+++ b/release-notes/daily/production/26.5.4.json
@@ -1,0 +1,19 @@
+{
+  "channel": "production",
+  "dayKey": "26.5.4",
+  "date": "2026-05-04",
+  "preferredDeck": "Fix stale renderer recovery restarts",
+  "editorialGuidance": [
+    "Keep the tone concise, professional, and specific.",
+    "Lead with user-facing outcomes, shipping milestones, trust wins, and installability improvements.",
+    "Demote internal cleanup unless it clearly changes the shipped product."
+  ],
+  "pinnedHighlights": [
+    "Stale renderer recovery no longer blocks the macOS main thread while the old main window unregisters.",
+    "Startup recovery actions remain reachable in shorter windows."
+  ],
+  "editorialNotes": [
+    "Production follow-up for the renderer recovery restart fix."
+  ],
+  "updatedAt": "2026-05-04T10:34:44.159Z"
+}

--- a/release-notes/releases/v26.5.400.json
+++ b/release-notes/releases/v26.5.400.json
@@ -1,0 +1,41 @@
+{
+  "tag": "v26.5.400",
+  "version": "26.5.400",
+  "channel": "production",
+  "dayKey": "26.5.4",
+  "approved": true,
+  "editorialNotes": [
+    "Approved for production after renderer recovery fix merged to dev and main."
+  ],
+  "generatedAt": "2026-05-04T10:34:04.475Z",
+  "model": "heuristic",
+  "source": {
+    "channel": "production",
+    "previousPublishedTag": "v26.5.309",
+    "previousPublishedDayTag": "v26.5.309",
+    "compareRef": "HEAD",
+    "isLatestOfDay": true,
+    "sameDayTagsIncluded": [
+      "v26.5.400"
+    ],
+    "relatedBuildTags": [
+      "v26.5.400"
+    ],
+    "prNumbers": [
+      421
+    ],
+    "commitSubjects": [
+      "chore: promote dev into main for production release (#421)"
+    ]
+  },
+  "release": {
+    "deck": "Fix stale renderer recovery restarts",
+    "features": [],
+    "fixes": [
+      "Recover stale renderers without blocking the macOS main thread while the old main window unregisters.",
+      "Let the startup recovery screen scroll in shorter windows so recovery actions stay reachable."
+    ],
+    "followUps": []
+  },
+  "releaseBody": "(AI Generated).\n\n## Freed v26.5.400\n\nThis release fixes a stale renderer recovery path that could force Freed Desktop into repeated restarts after the renderer stopped sending heartbeats.\n\n### Fixes\n\n- Recover stale renderers without blocking the macOS main thread while the old main window unregisters.\n- Let the startup recovery screen scroll in shorter windows so recovery actions stay reachable.\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+}

--- a/release-notes/releases/v26.5.400.md
+++ b/release-notes/releases/v26.5.400.md
@@ -1,0 +1,18 @@
+(AI Generated).
+
+## Freed v26.5.400
+
+This release fixes a stale renderer recovery path that could force Freed Desktop into repeated restarts after the renderer stopped sending heartbeats.
+
+### Fixes
+
+- Recover stale renderers without blocking the macOS main thread while the old main window unregisters.
+- Let the startup recovery screen scroll in shorter windows so recovery actions stay reachable.
+
+### Downloads
+
+**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  
+**Windows:** `.exe` (NSIS installer)  
+**Linux:** `.AppImage`  
+
+> macOS downloads are signed and notarized for normal Gatekeeper installation.

--- a/website/public/atom.xml
+++ b/website/public/atom.xml
@@ -2,7 +2,7 @@
 <feed xmlns="http://www.w3.org/2005/Atom">
     <id>https://freed.wtf</id>
     <title>Freed Blog</title>
-    <updated>2026-05-04T05:11:36.368Z</updated>
+    <updated>2026-05-04T11:11:41.884Z</updated>
     <generator>https://github.com/jpmonette/feed</generator>
     <author>
         <name>The Freed Team</name>

--- a/website/public/feed.xml
+++ b/website/public/feed.xml
@@ -4,7 +4,7 @@
         <title>Freed Blog</title>
         <link>https://freed.wtf</link>
         <description>Progress reports, technical deep-dives, and philosophical rants about the attention economy. From the team building Freed.</description>
-        <lastBuildDate>Mon, 04 May 2026 05:11:36 GMT</lastBuildDate>
+        <lastBuildDate>Mon, 04 May 2026 11:11:41 GMT</lastBuildDate>
         <docs>https://validator.w3.org/feed/docs/rss2.html</docs>
         <generator>https://github.com/jpmonette/feed</generator>
         <language>en</language>

--- a/website/src/content/changelog.generated.json
+++ b/website/src/content/changelog.generated.json
@@ -1,5 +1,36 @@
 [
   {
+    "version": "26.5.400",
+    "tagName": "v26.5.400",
+    "channel": "production",
+    "date": "2026-05-04T11:05:47Z",
+    "deck": "Fix stale renderer recovery restarts",
+    "features": [],
+    "fixes": [
+      {
+        "text": "Recover stale renderers without blocking the macOS main thread while the old main window unregisters."
+      },
+      {
+        "text": "Let the startup recovery screen scroll in shorter windows so recovery actions stay reachable."
+      }
+    ],
+    "followUps": [],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.5.400",
+    "prNumbers": [
+      421
+    ],
+    "builds": [
+      "26.5.400"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.5.400",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.5.400",
+        "channel": "production"
+      }
+    ]
+  },
+  {
     "version": "26.5.309",
     "tagName": "v26.5.309",
     "channel": "production",


### PR DESCRIPTION
(AI Generated).

## Summary
- Add the v26.5.400 release notes to www.
- Regenerate the static changelog and public feed snapshots.

## Testing
- PATH="/Users/aubreyfalconer/dev/freed-www-release-26-5-400/node_modules/.bin:$PATH" npm run build (website)
- PATH="/Users/aubreyfalconer/dev/freed-www-release-26-5-400/node_modules/.bin:$PATH" npx tsx src/content/changelog.test.ts (website)
