### PR TITLE
fix: retry deferred startup rss poll

### DIFF
--- a/packages/desktop/src/lib/rss-poller.test.ts
+++ b/packages/desktop/src/lib/rss-poller.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const refreshAllFeeds = vi.fn();
+const addDebugEvent = vi.fn();
+const runBackgroundJob = vi.fn();
+const isBackgroundRuntimeDeferredError = vi.fn(
+  (error: unknown) =>
+    typeof error === "object" &&
+    error !== null &&
+    "reason" in error,
+);
+
+vi.mock("./capture", () => ({
+  refreshAllFeeds,
+}));
+
+vi.mock("@freed/ui/lib/debug-store", () => ({
+  addDebugEvent,
+}));
+
+vi.mock("./background-runtime-coordinator", () => ({
+  runBackgroundJob,
+  isBackgroundRuntimeDeferredError,
+}));
+
+async function loadPoller() {
+  vi.resetModules();
+  return import("./rss-poller");
+}
+
+describe("rss poller", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    refreshAllFeeds.mockReset();
+    addDebugEvent.mockReset();
+    runBackgroundJob.mockReset();
+    isBackgroundRuntimeDeferredError.mockClear();
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("retries a deferred startup poll before the normal interval", async () => {
+    const deferredError = { reason: "waiting_for_renderer_heartbeat:1" };
+    runBackgroundJob
+      .mockRejectedValueOnce(deferredError)
+      .mockResolvedValueOnce(undefined);
+
+    const poller = await loadPoller();
+    poller.startRssPoller(30 * 60 * 1000);
+
+    await vi.runAllTicks();
+    expect(runBackgroundJob).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(14_999);
+    expect(runBackgroundJob).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(runBackgroundJob).toHaveBeenCalledTimes(2);
+    expect(addDebugEvent).toHaveBeenCalledWith(
+      "change",
+      "[RSS] poll deferred: waiting_for_renderer_heartbeat:1",
+    );
+
+    poller.stopRssPoller();
+  });
+
+  it("clears a deferred retry when the poller stops", async () => {
+    runBackgroundJob.mockRejectedValueOnce({ reason: "cooldown:120000" });
+
+    const poller = await loadPoller();
+    poller.startRssPoller(30 * 60 * 1000);
+    await vi.runAllTicks();
+
+    poller.stopRssPoller();
+    await vi.advanceTimersByTimeAsync(15_000);
+
+    expect(runBackgroundJob).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/desktop/src/lib/rss-poller.ts
+++ b/packages/desktop/src/lib/rss-poller.ts
@@ -14,9 +14,26 @@ import {
 
 /** Default poll interval: 30 minutes */
 const DEFAULT_INTERVAL_MS = 30 * 60 * 1000;
+const DEFERRED_RETRY_MS = 15_000;
 
 let pollIntervalId: ReturnType<typeof setInterval> | null = null;
+let retryTimeoutId: ReturnType<typeof setTimeout> | null = null;
 let isPolling = false;
+
+function clearDeferredRetry(): void {
+  if (retryTimeoutId !== null) {
+    clearTimeout(retryTimeoutId);
+    retryTimeoutId = null;
+  }
+}
+
+function scheduleDeferredRetry(): void {
+  if (retryTimeoutId !== null) return;
+  retryTimeoutId = setTimeout(() => {
+    retryTimeoutId = null;
+    void triggerPoll();
+  }, DEFERRED_RETRY_MS);
+}
 
 /**
  * Start background RSS polling.
@@ -28,7 +45,7 @@ export function startRssPoller(intervalMs = DEFAULT_INTERVAL_MS): void {
   if (pollIntervalId !== null) return; // Already running
 
   // Do an immediate refresh on first start
-  triggerPoll();
+  void triggerPoll();
 
   pollIntervalId = setInterval(triggerPoll, intervalMs);
   console.log(
@@ -40,6 +57,7 @@ export function startRssPoller(intervalMs = DEFAULT_INTERVAL_MS): void {
  * Stop background RSS polling.
  */
 export function stopRssPoller(): void {
+  clearDeferredRetry();
   if (pollIntervalId !== null) {
     clearInterval(pollIntervalId);
     pollIntervalId = null;
@@ -61,9 +79,11 @@ async function triggerPoll(): Promise<void> {
       timeoutMs: 180_000,
       run: refreshAllFeeds,
     });
+    clearDeferredRetry();
   } catch (err) {
     if (isBackgroundRuntimeDeferredError(err)) {
       addDebugEvent("change", `[RSS] poll deferred: ${err.reason}`);
+      scheduleDeferredRetry();
       return;
     }
     const msg = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
(AI Generated).

## Summary
- retry deferred RSS startup polls instead of waiting for the next 30 minute interval
- add focused unit coverage for deferred retry scheduling and shutdown cleanup

## Testing
- Not run, this worktree has no node_modules and vitest is unavailable.