### PR TITLE
fix: restore native desktop toolbar dragging

### DIFF
--- a/packages/desktop/tests/e2e/smoke.spec.ts
+++ b/packages/desktop/tests/e2e/smoke.spec.ts
@@ -118,6 +118,36 @@ async function dragElementBy(page: Page, locator: Locator, deltaX: number, delta
   await page.mouse.up();
 }
 
+async function readPointDragState(page: Page, x: number, y: number) {
+  return page.evaluate(
+    ({ x, y }) => {
+      const target = document.elementFromPoint(x, y) as HTMLElement | null;
+      if (!target) return null;
+      const style = window.getComputedStyle(target);
+      return {
+        tagName: target.tagName.toLowerCase(),
+        testId: target.getAttribute("data-testid"),
+        text: target.textContent?.trim() ?? "",
+        hasDirectDragAttr: target.hasAttribute("data-tauri-drag-region"),
+        dragAttrValue: target.getAttribute("data-tauri-drag-region"),
+        inlineWebkitAppRegion: target.style.webkitAppRegion,
+        computedCursor: style.cursor,
+        computedUserSelect: style.userSelect,
+      };
+    },
+    { x, y },
+  );
+}
+
+async function readElementFromPointDragState(page: Page, locator: Locator) {
+  const box = await locator.boundingBox();
+  if (!box) {
+    throw new Error("Drag target is not visible");
+  }
+
+  return readPointDragState(page, box.x + box.width / 2, box.y + box.height / 2);
+}
+
 async function readDesktopSidebarGeometry(page: Page) {
   return page.evaluate(() => {
     const sidebarShell = document.querySelector('[data-testid="app-sidebar-shell"]') as HTMLElement | null;
@@ -826,7 +856,7 @@ test("compact sidebar search opens as a floating palette and closes cleanly", as
   await expect(trigger).toHaveAttribute("aria-pressed", "false");
 });
 
-test("dragging from the desktop sidebar toggle starts a window drag without collapsing the sidebar", async ({ app, page }) => {
+test("desktop toolbar controls remain clickable no-drag targets", async ({ app, page }) => {
   await page.setViewportSize({ width: 1440, height: 900 });
   await app.goto();
   await app.waitForReady();
@@ -836,91 +866,85 @@ test("dragging from the desktop sidebar toggle starts a window drag without coll
     return sidebarShell?.getBoundingClientRect().width ?? 0;
   });
 
-  await dragElementBy(page, page.getByTestId("desktop-sidebar-toggle"), 24);
-  await page.waitForTimeout(100);
+  const sidebarToggle = page.getByTestId("desktop-sidebar-toggle");
+  const targetState = await readElementFromPointDragState(page, sidebarToggle);
+  const sidebarToggleRegion = await sidebarToggle.evaluate((button) => button.style.webkitAppRegion);
+  expect(targetState).not.toBeNull();
+  expect(targetState?.hasDirectDragAttr).toBe(false);
+  expect(sidebarToggleRegion).toBe("no-drag");
 
-  const postDragState = await page.evaluate(() => {
-    const sidebarShell = document.querySelector('[data-testid="app-sidebar-shell"]') as HTMLElement | null;
-    const win = window as Record<string, unknown>;
+  await sidebarToggle.click();
+
+  expect(initialWidth).toBeGreaterThan(200);
+  await expect.poll(async () => {
+    return page.evaluate(() => {
+      const sidebarShell = document.querySelector('[data-testid="app-sidebar-shell"]') as HTMLElement | null;
+      return sidebarShell?.getBoundingClientRect().width ?? 0;
+    });
+  }).toBeLessThan(initialWidth);
+});
+
+test("desktop passive toolbar targets expose direct native drag attributes", async ({ app, page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await app.goto();
+  await app.waitForReady();
+
+  const wordmarkState = await readElementFromPointDragState(page, page.getByTestId("workspace-toolbar-wordmark"));
+  const titleState = await readElementFromPointDragState(page, page.getByTestId("workspace-toolbar-title-block").locator("p"));
+  const logoGapPoint = await page.evaluate(() => {
+    const wordmark = document.querySelector('[data-testid="workspace-toolbar-wordmark"]') as HTMLElement | null;
+    const sidebarToggle = document.querySelector('[data-testid="desktop-sidebar-toggle"]') as HTMLElement | null;
+    if (!wordmark || !sidebarToggle) return null;
+
+    const wordmarkRect = wordmark.getBoundingClientRect();
+    const toggleRect = sidebarToggle.getBoundingClientRect();
     return {
-      sidebarWidth: sidebarShell?.getBoundingClientRect().width ?? 0,
-      dragCalls: ((win.__TAURI_MOCK_WINDOW_DRAG_CALLS__ as Array<unknown> | undefined) ?? []).length,
+      x: wordmarkRect.right + Math.max(2, Math.min(24, (toggleRect.left - wordmarkRect.right) / 2)),
+      y: wordmarkRect.top + wordmarkRect.height / 2,
     };
   });
+  expect(logoGapPoint).not.toBeNull();
+  const logoGapState = await readPointDragState(page, logoGapPoint!.x, logoGapPoint!.y);
 
-  expect(postDragState.dragCalls).toBe(1);
-  expect(postDragState.sidebarWidth).toBeGreaterThan(initialWidth - 4);
+  expect(wordmarkState).not.toBeNull();
+  expect(wordmarkState?.hasDirectDragAttr).toBe(true);
+  expect(wordmarkState?.inlineWebkitAppRegion).toBe("drag");
+  expect(wordmarkState?.computedCursor).toBe("default");
+  expect(wordmarkState?.computedUserSelect).toBe("none");
+  expect(titleState).not.toBeNull();
+  expect(titleState?.hasDirectDragAttr).toBe(true);
+  expect(titleState?.inlineWebkitAppRegion).toBe("drag");
+  expect(titleState?.computedCursor).toBe("default");
+  expect(titleState?.computedUserSelect).toBe("none");
+  expect(logoGapState).not.toBeNull();
+  expect(logoGapState?.testId).toBe("workspace-toolbar-logo-drag-region");
+  expect(logoGapState?.hasDirectDragAttr).toBe(true);
+  expect(logoGapState?.inlineWebkitAppRegion).toBe("drag");
 });
 
-test("dragging from a reader toolbar button starts a window drag without firing the button action", async ({ app, page }) => {
+test("reader toolbar keeps back button clickable while title text is a drag target", async ({ app, page }) => {
   await page.setViewportSize({ width: 1440, height: 900 });
   await app.goto();
   await app.waitForReady();
   await app.injectRssItems(8);
 
   await page.locator("[data-feed-item-id]").first().click();
-  const railButton = page.getByRole("button", { name: "Hide Previews" }).first();
-  await expect(railButton).toBeVisible();
-
-  await railButton.evaluate((button) => {
-    const rect = button.getBoundingClientRect();
-    const startX = rect.left + rect.width / 2;
-    const startY = rect.top + rect.height / 2;
-    const pointerId = 41;
-
-    button.dispatchEvent(new PointerEvent("pointerdown", {
-      bubbles: true,
-      composed: true,
-      pointerId,
-      pointerType: "mouse",
-      isPrimary: true,
-      button: 0,
-      clientX: startX,
-      clientY: startY,
-    }));
-    window.dispatchEvent(new PointerEvent("pointermove", {
-      bubbles: true,
-      composed: true,
-      pointerId,
-      pointerType: "mouse",
-      isPrimary: true,
-      button: 0,
-      clientX: startX + 24,
-      clientY: startY,
-    }));
-    window.dispatchEvent(new PointerEvent("pointerup", {
-      bubbles: true,
-      composed: true,
-      pointerId,
-      pointerType: "mouse",
-      isPrimary: true,
-      button: 0,
-      clientX: startX + 24,
-      clientY: startY,
-    }));
-  });
-  await page.waitForTimeout(100);
-
-  const dragCalls = await page.evaluate(() => {
-    const win = window as Record<string, unknown>;
-    return ((win.__TAURI_MOCK_WINDOW_DRAG_CALLS__ as Array<unknown> | undefined) ?? []).length;
-  });
-
-  expect(dragCalls).toBe(1);
-  await expect(railButton).toBeVisible();
-});
-
-test("clicking the reader toolbar title region returns to the feed list", async ({ app, page }) => {
-  await page.setViewportSize({ width: 1440, height: 900 });
-  await app.goto();
-  await app.waitForReady();
-  await app.injectRssItems(8);
-
-  await page.locator("[data-feed-item-id]").first().click();
+  await expect.poll(async () => {
+    return page.evaluate(() => document.documentElement.classList.contains("feed-layout-transition"));
+  }).toBe(false);
   const readerTitleBlock = page.getByTestId("workspace-toolbar-reader-title-block");
   await expect(readerTitleBlock).toBeVisible();
 
-  await readerTitleBlock.click();
+  const readerTitleState = await readElementFromPointDragState(page, readerTitleBlock.locator("p"));
+  const backButton = page.getByTestId("workspace-toolbar-reader-back");
+  const backButtonRegion = await backButton.evaluate((button) => button.style.webkitAppRegion);
+
+  expect(readerTitleState).not.toBeNull();
+  expect(readerTitleState?.hasDirectDragAttr).toBe(true);
+  expect(readerTitleState?.inlineWebkitAppRegion).toBe("drag");
+  expect(backButtonRegion).toBe("no-drag");
+
+  await backButton.click();
 
   await page.waitForFunction(() => {
     const store = (window as Record<string, unknown>).__FREED_STORE__ as
@@ -931,27 +955,34 @@ test("clicking the reader toolbar title region returns to the feed list", async 
   await expect(page.locator("[data-feed-item-id]")).toHaveCount(8);
 });
 
-test("desktop passive toolbar title area remains a native drag region", async ({ app, page }) => {
-  await page.setViewportSize({ width: 1440, height: 900 });
+test("fullscreen reader toolbar passive targets expose direct native drag attributes", async ({ app, page }) => {
+  await page.addInitScript(() => {
+    Object.defineProperty(navigator, "userAgentData", {
+      configurable: true,
+      get: () => ({ mobile: true }),
+    });
+  });
+  await page.setViewportSize({ width: 430, height: 844 });
   await app.goto();
   await app.waitForReady();
+  await app.injectRssItems(4);
 
-  const dragRegionState = await page.evaluate(() => {
-    const titleBlock = document.querySelector('[data-testid="workspace-toolbar-title-block"]') as HTMLElement | null;
-    const dragRegion = titleBlock?.parentElement as HTMLElement | null;
-    if (!titleBlock || !dragRegion) {
-      return null;
-    }
+  await page.getByText("Article 0:", { exact: false }).click();
+  const title = page.getByTestId("reader-view-toolbar-title");
+  await expect(title).toBeVisible({ timeout: 5_000 });
 
-    return {
-      hasDragRegionAttr: dragRegion.hasAttribute("data-tauri-drag-region"),
-      webkitAppRegion: dragRegion.style.webkitAppRegion,
-    };
-  });
+  const titleState = await readElementFromPointDragState(page, title);
+  const spacerState = await readElementFromPointDragState(page, page.getByTestId("reader-view-toolbar-spacer"));
+  const backButton = page.getByRole("button", { name: "Back", exact: true });
+  const backButtonRegion = await backButton.evaluate((button) => button.style.webkitAppRegion);
 
-  expect(dragRegionState).not.toBeNull();
-  expect(dragRegionState?.hasDragRegionAttr).toBe(true);
-  expect(dragRegionState?.webkitAppRegion).toBe("drag");
+  expect(titleState).not.toBeNull();
+  expect(titleState?.hasDirectDragAttr).toBe(true);
+  expect(titleState?.inlineWebkitAppRegion).toBe("drag");
+  expect(spacerState).not.toBeNull();
+  expect(spacerState?.hasDirectDragAttr).toBe(true);
+  expect(spacerState?.inlineWebkitAppRegion).toBe("drag");
+  expect(backButtonRegion).toBe("no-drag");
 });
 
 test("desktop primary feed marks scrolled-past rows as read", async ({ app, page }) => {

--- a/packages/ui/src/components/feed/ReaderView.tsx
+++ b/packages/ui/src/components/feed/ReaderView.tsx
@@ -14,6 +14,10 @@ import {
   getReaderOfflineCacheMode,
   shouldPinOpenedReaderItem,
 } from "../../lib/reader-cache-settings.js";
+import {
+  getPassiveDragRegionProps,
+  noDragRegionStyle as noDrag,
+} from "../../lib/native-drag-region.js";
 import { Tooltip } from "../Tooltip.js";
 import { ExternalLinkIcon, TrashIcon } from "../icons.js";
 
@@ -199,7 +203,6 @@ const HEADING_CLASSES: Record<number, string> = {
   6: "mt-4 mb-2 text-sm font-medium text-[var(--theme-text-primary)]",
 };
 
-const noDrag = { WebkitAppRegion: "no-drag" } as React.CSSProperties;
 const STORY_REPLY_MESSAGE = "Story replies are private on this platform. Open the story to reply there.";
 
 export function ReaderView({ item, onClose, dualColumn = false, inline = false, onOpenUrl }: ReaderViewProps) {
@@ -507,16 +510,14 @@ export function ReaderView({ item, onClose, dualColumn = false, inline = false, 
       {!inline && (
         <header
           className="theme-topbar sticky top-0 z-10 border-b"
-          {...(headerDragRegion
-            ? {
-                "data-tauri-drag-region": true,
-                style: { WebkitAppRegion: "drag" } as React.CSSProperties,
-              }
-            : {})}
+          {...getPassiveDragRegionProps(headerDragRegion)}
         >
           <div
             className="h-14 w-full px-3 flex items-center gap-2"
-            style={headerDragRegion ? { paddingLeft: MACOS_TRAFFIC_LIGHT_INSET } : undefined}
+            {...getPassiveDragRegionProps(
+              headerDragRegion,
+              headerDragRegion ? { paddingLeft: MACOS_TRAFFIC_LIGHT_INSET } : undefined,
+            )}
           >
             <button
               onClick={onClose}
@@ -532,12 +533,20 @@ export function ReaderView({ item, onClose, dualColumn = false, inline = false, 
               >
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
               </svg>
-              <span className="truncate text-sm text-[var(--theme-text-muted)] transition-colors group-hover:text-[var(--theme-text-secondary)]">
+              <span
+                data-testid="reader-view-toolbar-title"
+                className="cursor-default select-none truncate text-sm text-[var(--theme-text-muted)] transition-colors group-hover:text-[var(--theme-text-secondary)]"
+                {...getPassiveDragRegionProps(headerDragRegion)}
+              >
                 {item.author.displayName}
               </span>
             </button>
 
-            <div className="flex-1" />
+            <div
+              data-testid="reader-view-toolbar-spacer"
+              className="flex-1"
+              {...getPassiveDragRegionProps(headerDragRegion)}
+            />
 
             {contentSource === "cache" && (
               <Tooltip label="Served from your device cache">

--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -8,8 +8,6 @@ import {
   type CSSProperties,
   type ButtonHTMLAttributes,
   type ChangeEvent,
-  type MouseEvent as ReactMouseEvent,
-  type PointerEvent as ReactPointerEvent,
   type ReactNode,
 } from "react";
 import {
@@ -55,6 +53,11 @@ import {
   type FeedCardDensity,
 } from "../../lib/feed-card-density.js";
 import {
+  dragRegionStyle as dragStyle,
+  getPassiveDragRegionProps,
+  noDragRegionStyle as noDrag,
+} from "../../lib/native-drag-region.js";
+import {
   COMPACT_PRIMARY_SIDEBAR_WIDTH_PX,
   PRIMARY_SIDEBAR_GAP_WIDTH_PX,
   TOOLBAR_SIDEBAR_SLOT_PADDING_RIGHT_PX,
@@ -83,10 +86,7 @@ interface ToolbarOverflowAction {
   danger?: boolean;
 }
 
-const noDrag = { WebkitAppRegion: "no-drag" } as CSSProperties;
-const dragStyle = { WebkitAppRegion: "drag" } as CSSProperties;
 const toolbarControlStyle = { ...noDrag, userSelect: "none" } as CSSProperties;
-const TOOLBAR_DRAG_THRESHOLD_PX = 6;
 const TOP_TOOLBAR_HEIGHT_PX =
   COMPACT_PRIMARY_SIDEBAR_WIDTH_PX + PRIMARY_SIDEBAR_GAP_WIDTH_PX / 2;
 const TOOLBAR_ICON_BUTTON_CLASS =
@@ -321,7 +321,6 @@ export function Header({
   const {
     HeaderSyncIndicator,
     headerDragRegion,
-    startWindowDrag,
     addRssFeed,
     saveUrl,
     importMarkdown,
@@ -1002,7 +1001,6 @@ export function Header({
     handleFriendsToolbarModeChange,
     handleIdentityModeChange,
   ]);
-  const canManuallyDragToolbarControls = !!(headerDragRegion && startWindowDrag);
   const macosTrafficLightInsetStyle = headerDragRegion
     ? ({ paddingLeft: `${MACOS_TRAFFIC_LIGHT_INSET}px` } as CSSProperties)
     : undefined;
@@ -1031,14 +1029,17 @@ export function Header({
   const layoutControlClusterStyle = {
     left: 0,
     width: px(layoutControlMetrics.reservedWidthPx),
+    pointerEvents: "none",
     ...(headerDragRegion ? noDrag : {}),
   } as CSSProperties;
   const sidebarTogglePositionStyle = {
     left: px(layoutControlMetrics.sidebarToggleLeftPx),
+    pointerEvents: "auto",
     ...(headerDragRegion ? noDrag : {}),
   } as CSSProperties;
   const previewTogglePositionStyle = {
     left: px(layoutControlMetrics.previewToggleLeftPx),
+    pointerEvents: "auto",
     ...(headerDragRegion ? noDrag : {}),
   } as CSSProperties;
   const toolbarContainerStyle = {
@@ -1056,88 +1057,6 @@ export function Header({
   const previewToggleButtonRef = useRef<HTMLButtonElement | null>(null);
   const wordmarkRef = useRef<HTMLSpanElement | null>(null);
   const sidebarHandleCenterlineStyleRef = useRef<string | null>(null);
-  const toolbarDragGestureRef = useRef<{
-    pointerId: number;
-    startX: number;
-    startY: number;
-    target: HTMLElement;
-  } | null>(null);
-  const suppressedToolbarClickRef = useRef<EventTarget | null>(null);
-  const suppressedToolbarClickTimeoutRef = useRef<number | null>(null);
-
-  const clearSuppressedToolbarClick = useCallback(() => {
-    suppressedToolbarClickRef.current = null;
-    if (suppressedToolbarClickTimeoutRef.current !== null) {
-      window.clearTimeout(suppressedToolbarClickTimeoutRef.current);
-      suppressedToolbarClickTimeoutRef.current = null;
-    }
-  }, []);
-
-  const scheduleSuppressedToolbarClickClear = useCallback(() => {
-    if (suppressedToolbarClickTimeoutRef.current !== null) {
-      window.clearTimeout(suppressedToolbarClickTimeoutRef.current);
-    }
-    suppressedToolbarClickTimeoutRef.current = window.setTimeout(() => {
-      suppressedToolbarClickRef.current = null;
-      suppressedToolbarClickTimeoutRef.current = null;
-    }, 250);
-  }, []);
-
-  const finishToolbarDragGesture = useCallback((pointerId?: number) => {
-    const gesture = toolbarDragGestureRef.current;
-    if (!gesture) return;
-    if (pointerId !== undefined && gesture.pointerId !== pointerId) return;
-    toolbarDragGestureRef.current = null;
-  }, []);
-
-  const handleToolbarControlPointerDown = useCallback((event: ReactPointerEvent<HTMLElement>) => {
-    if (!canManuallyDragToolbarControls) return;
-    if (event.button !== 0 || !event.isPrimary || event.pointerType === "touch") return;
-
-    clearSuppressedToolbarClick();
-    toolbarDragGestureRef.current = {
-      pointerId: event.pointerId,
-      startX: event.clientX,
-      startY: event.clientY,
-      target: event.currentTarget,
-    };
-  }, [canManuallyDragToolbarControls, clearSuppressedToolbarClick]);
-
-  const handleWindowToolbarPointerMove = useCallback((event: PointerEvent) => {
-    const gesture = toolbarDragGestureRef.current;
-    if (!gesture || !startWindowDrag) return;
-    if (gesture.pointerId !== event.pointerId) return;
-
-    const travelDistance = Math.hypot(
-      event.clientX - gesture.startX,
-      event.clientY - gesture.startY,
-    );
-
-    if (travelDistance <= TOOLBAR_DRAG_THRESHOLD_PX) return;
-
-    suppressedToolbarClickRef.current = gesture.target;
-    scheduleSuppressedToolbarClickClear();
-    finishToolbarDragGesture(gesture.pointerId);
-    void startWindowDrag().catch(() => {
-      clearSuppressedToolbarClick();
-    });
-  }, [
-    clearSuppressedToolbarClick,
-    finishToolbarDragGesture,
-    scheduleSuppressedToolbarClickClear,
-    startWindowDrag,
-  ]);
-
-  const handleWindowToolbarPointerEnd = useCallback((event: PointerEvent) => {
-    finishToolbarDragGesture(event.pointerId);
-  }, [finishToolbarDragGesture]);
-
-  const handleToolbarControlClickCapture = useCallback((event: ReactMouseEvent<HTMLElement>) => {
-    if (suppressedToolbarClickRef.current !== event.currentTarget) return;
-    clearSuppressedToolbarClick();
-    event.preventDefault();
-    event.stopPropagation();
-  }, [clearSuppressedToolbarClick]);
 
   const handlePreviewToggleButtonRef = useCallback((node: HTMLButtonElement | null) => {
     previewToggleButtonRef.current = node;
@@ -1145,19 +1064,10 @@ export function Header({
   }, []);
 
   const getToolbarControlProps = useCallback((style?: CSSProperties) => ({
-    ...(canManuallyDragToolbarControls
-      ? {
-          onPointerDown: handleToolbarControlPointerDown,
-          onClickCapture: handleToolbarControlClickCapture,
-        }
-      : {}),
     style: headerDragRegion
       ? ({ ...style, ...toolbarControlStyle } as CSSProperties)
       : style,
   }), [
-    canManuallyDragToolbarControls,
-    handleToolbarControlClickCapture,
-    handleToolbarControlPointerDown,
     headerDragRegion,
   ]);
 
@@ -1397,31 +1307,11 @@ export function Header({
   }, [activeFilter.archivedOnly]);
 
   useEffect(() => () => {
-    finishToolbarDragGesture();
-    clearSuppressedToolbarClick();
     if (deleteConfirmTimerRef.current) {
       window.clearTimeout(deleteConfirmTimerRef.current);
       deleteConfirmTimerRef.current = null;
     }
-  }, [clearSuppressedToolbarClick, finishToolbarDragGesture]);
-
-  useEffect(() => {
-    if (!canManuallyDragToolbarControls) return;
-
-    window.addEventListener("pointermove", handleWindowToolbarPointerMove);
-    window.addEventListener("pointerup", handleWindowToolbarPointerEnd);
-    window.addEventListener("pointercancel", handleWindowToolbarPointerEnd);
-
-    return () => {
-      window.removeEventListener("pointermove", handleWindowToolbarPointerMove);
-      window.removeEventListener("pointerup", handleWindowToolbarPointerEnd);
-      window.removeEventListener("pointercancel", handleWindowToolbarPointerEnd);
-    };
-  }, [
-    canManuallyDragToolbarControls,
-    handleWindowToolbarPointerEnd,
-    handleWindowToolbarPointerMove,
-  ]);
+  }, []);
 
   const toolbarOverflowMenuTop = toolbarOverflowMenuPosition?.top ?? 60;
   const signalFilterMenuTop = signalFilterMenuPosition?.top ?? 60;
@@ -1470,24 +1360,29 @@ export function Header({
               style={leftToolbarStyle}
             >
               {isMobileDevice ? (
-              <Tooltip label="Menu">
-                <button
-                  onClick={onMobileMenuToggle}
-                  {...getToolbarControlProps()}
-                  className={`${TOOLBAR_ICON_BUTTON_CLASS} theme-toolbar-button-ghost`}
-                  aria-label={mobileSidebarOpen ? "Close menu" : "Open menu"}
-                  aria-pressed={mobileSidebarOpen}
-                >
-                  <AnimatedMenuIcon open={mobileSidebarOpen} className="h-5 w-5" />
-                </button>
-              </Tooltip>
+                <Tooltip label="Menu">
+                  <button
+                    onClick={onMobileMenuToggle}
+                    {...getToolbarControlProps()}
+                    className={`${TOOLBAR_ICON_BUTTON_CLASS} theme-toolbar-button-ghost`}
+                    aria-label={mobileSidebarOpen ? "Close menu" : "Open menu"}
+                    aria-pressed={mobileSidebarOpen}
+                  >
+                    <AnimatedMenuIcon open={mobileSidebarOpen} className="h-5 w-5" />
+                  </button>
+                </Tooltip>
               ) : null}
 
-              <div className="flex h-full items-center pl-3 sm:pl-4" style={toolbarLogoRowStyle}>
+              <div
+                data-testid="workspace-toolbar-logo-drag-region"
+                className="flex h-full min-w-0 flex-1 items-center pl-3 sm:pl-4"
+                {...getPassiveDragRegionProps(headerDragRegion, toolbarLogoRowStyle)}
+              >
                 <span
                   ref={wordmarkRef}
                   data-testid="workspace-toolbar-wordmark"
                   className="cursor-default select-none text-lg font-bold gradient-text font-logo"
+                  {...getPassiveDragRegionProps(headerDragRegion)}
                 >
                   FREED
                 </span>
@@ -1565,7 +1460,8 @@ export function Header({
               >
                 <div
                   data-testid="workspace-toolbar-reader-title-block"
-                  className="pointer-events-none flex min-w-0 max-w-full cursor-default select-none items-center justify-center gap-2 text-center"
+                  className="flex min-w-0 max-w-full cursor-default select-none items-center justify-center gap-2 text-center"
+                  {...getPassiveDragRegionProps(headerDragRegion)}
                 >
                   <span className="flex h-8 w-5 shrink-0 items-center justify-center rounded-lg">
                     <svg
@@ -1578,10 +1474,23 @@ export function Header({
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
                     </svg>
                   </span>
-                  <p className="truncate text-sm font-medium text-[var(--theme-text-secondary)]">
+                  <p
+                    className="truncate text-sm font-medium text-[var(--theme-text-secondary)]"
+                    {...getPassiveDragRegionProps(headerDragRegion)}
+                  >
                     {contextualListTitle}
-                    <span className="mx-1.5 font-normal text-[var(--theme-text-muted)]">•</span>
-                    <span className="font-normal text-[var(--theme-text-muted)]">{currentListSubtitle}</span>
+                    <span
+                      className="mx-1.5 font-normal text-[var(--theme-text-muted)]"
+                      {...getPassiveDragRegionProps(headerDragRegion)}
+                    >
+                      •
+                    </span>
+                    <span
+                      className="font-normal text-[var(--theme-text-muted)]"
+                      {...getPassiveDragRegionProps(headerDragRegion)}
+                    >
+                      {currentListSubtitle}
+                    </span>
                   </p>
                 </div>
               </button>
@@ -1589,11 +1498,25 @@ export function Header({
               <div
                 data-testid="workspace-toolbar-title-block"
                 className="flex min-w-0 cursor-default select-none justify-center px-1 text-center"
+                {...getPassiveDragRegionProps(headerDragRegion)}
               >
-                <p className="truncate text-center text-sm font-semibold text-[var(--theme-text-secondary)]">
+                <p
+                  className="truncate text-center text-sm font-semibold text-[var(--theme-text-secondary)]"
+                  {...getPassiveDragRegionProps(headerDragRegion)}
+                >
                   {currentTitle}
-                  <span className="mx-1.5 font-normal text-[var(--theme-text-muted)]">•</span>
-                  <span className="font-normal text-[var(--theme-text-muted)]">{currentSubtitle}</span>
+                  <span
+                    className="mx-1.5 font-normal text-[var(--theme-text-muted)]"
+                    {...getPassiveDragRegionProps(headerDragRegion)}
+                  >
+                    •
+                  </span>
+                  <span
+                    className="font-normal text-[var(--theme-text-muted)]"
+                    {...getPassiveDragRegionProps(headerDragRegion)}
+                  >
+                    {currentSubtitle}
+                  </span>
                 </p>
               </div>
             )}

--- a/packages/ui/src/lib/native-drag-region.ts
+++ b/packages/ui/src/lib/native-drag-region.ts
@@ -1,0 +1,28 @@
+import type { CSSProperties } from "react";
+
+export const noDragRegionStyle = { WebkitAppRegion: "no-drag" } as CSSProperties;
+export const dragRegionStyle = { WebkitAppRegion: "drag" } as CSSProperties;
+
+export type PassiveDragRegionProps = {
+  "data-tauri-drag-region"?: true;
+  style?: CSSProperties;
+};
+
+export function getPassiveDragRegionProps(
+  enabled: boolean | undefined,
+  style?: CSSProperties,
+): PassiveDragRegionProps {
+  if (!enabled) {
+    return style ? { style } : {};
+  }
+
+  return {
+    "data-tauri-drag-region": true,
+    style: {
+      ...dragRegionStyle,
+      cursor: "default",
+      userSelect: "none",
+      ...style,
+    },
+  };
+}


### PR DESCRIPTION
(AI Generated).

## Summary
- Places Tauri drag attributes on the actual passive titlebar hit targets in the desktop header and reader toolbar.
- Keeps toolbar controls no-drag and removes the mock-only pointer-drag fallback.
- Restores the left toolbar shell to no-drag and makes only the FREED logo row fill the logo-to-button gap as a direct passive drag target.
- Updates E2E coverage to inspect document.elementFromPoint at drag coordinates, including the wordmark gap.

## Testing
- Focused desktop E2E toolbar grep, 17 passed.
- Native Tauri preview drag from the FREED wordmark moved the macOS window from 300,200 to 480,240.
- Native Tauri preview drag from the gap just right of the FREED wordmark moved the macOS window from 300,200 to 480,240.
- npm run validate:feature
