### PR TITLE
docs: refresh changelog for v26.5.403

### DIFF
--- a/release-notes/daily/production/26.5.4.json
+++ b/release-notes/daily/production/26.5.4.json
@@ -2,18 +2,18 @@
   "channel": "production",
   "dayKey": "26.5.4",
   "date": "2026-05-04",
-  "preferredDeck": "Fix stale renderer recovery restarts",
+  "preferredDeck": "Freed Desktop reliability fixes",
   "editorialGuidance": [
     "Keep the tone concise, professional, and specific.",
     "Lead with user-facing outcomes, shipping milestones, trust wins, and installability improvements.",
     "Demote internal cleanup unless it clearly changes the shipped product."
   ],
   "pinnedHighlights": [
-    "Stale renderer recovery no longer blocks the macOS main thread while the old main window unregisters.",
-    "Startup recovery actions remain reachable in shorter windows."
+    "Native macOS window dragging works from passive titlebar regions without stealing toolbar button clicks.",
+    "Freed Desktop is calmer during renderer memory pressure and stale renderer recovery."
   ],
   "editorialNotes": [
-    "Production follow-up for the renderer recovery restart fix."
+    "Production release for native toolbar dragging, renderer recovery stability, RSS startup retry, archive batching, and Linux release compile fixes."
   ],
-  "updatedAt": "2026-05-04T10:34:44.159Z"
+  "updatedAt": "2026-05-05T01:42:09.263Z"
 }

--- a/release-notes/releases/v26.5.403.json
+++ b/release-notes/releases/v26.5.403.json
@@ -1,0 +1,60 @@
+{
+  "tag": "v26.5.403",
+  "version": "26.5.403",
+  "channel": "production",
+  "dayKey": "26.5.4",
+  "approved": true,
+  "editorialNotes": [],
+  "generatedAt": "2026-05-05T01:38:28.202Z",
+  "model": "heuristic",
+  "source": {
+    "channel": "production",
+    "previousPublishedTag": "v26.5.400",
+    "previousPublishedDayTag": "v26.5.309",
+    "compareRef": "HEAD",
+    "isLatestOfDay": true,
+    "sameDayTagsIncluded": [
+      "v26.5.400",
+      "v26.5.403"
+    ],
+    "relatedBuildTags": [
+      "v26.5.400",
+      "v26.5.402-dev",
+      "v26.5.403"
+    ],
+    "prNumbers": [
+      408,
+      418,
+      419,
+      420,
+      421,
+      424,
+      425,
+      427,
+      428
+    ],
+    "commitSubjects": [
+      "chore: promote dev into main for production release (#428)",
+      "release: approve v26.5.400 notes",
+      "release: v26.5.400",
+      "chore: promote dev into main for production release (#421)"
+    ]
+  },
+  "release": {
+    "deck": "Freed Desktop reliability fixes",
+    "features": [],
+    "fixes": [
+      "Native macOS window dragging now works from the FREED wordmark, nearby titlebar gap, passive toolbar title areas, and fullscreen reader titlebar.",
+      "Toolbar controls stay clickable because buttons remain explicit no-drag targets while passive titlebar surfaces handle native dragging.",
+      "Fix stale renderer recovery restarts.",
+      "Recover stale renderers without blocking the macOS main thread while the old main window unregisters.",
+      "Let the startup recovery screen scroll in shorter windows so recovery actions stay reachable.",
+      "Pause heavy background work before high renderer memory can force repeated recovery.",
+      "Retry deferred startup RSS polls instead of waiting for the next normal polling interval.",
+      "Batch visible archive actions more aggressively.",
+      "Restore Linux release compilation for renderer memory diagnostics."
+    ],
+    "followUps": []
+  },
+  "releaseBody": "(AI Generated).\n\n## Freed v26.5.403\n\nFreed Desktop reliability fixes\n\n### Fixes\n\n- Native macOS window dragging now works from the FREED wordmark, nearby titlebar gap, passive toolbar title areas, and fullscreen reader titlebar.\n- Toolbar controls stay clickable because buttons remain explicit no-drag targets while passive titlebar surfaces handle native dragging.\n- Fix stale renderer recovery restarts.\n- Recover stale renderers without blocking the macOS main thread while the old main window unregisters.\n- Let the startup recovery screen scroll in shorter windows so recovery actions stay reachable.\n- Pause heavy background work before high renderer memory can force repeated recovery.\n- Retry deferred startup RSS polls instead of waiting for the next normal polling interval.\n- Batch visible archive actions more aggressively.\n- Restore Linux release compilation for renderer memory diagnostics.\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)\n**Windows:** `.exe` (NSIS installer)\n**Linux:** `.AppImage`\n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+}

--- a/release-notes/releases/v26.5.403.md
+++ b/release-notes/releases/v26.5.403.md
@@ -1,0 +1,25 @@
+(AI Generated).
+
+## Freed v26.5.403
+
+Freed Desktop reliability fixes
+
+### Fixes
+
+- Native macOS window dragging now works from the FREED wordmark, nearby titlebar gap, passive toolbar title areas, and fullscreen reader titlebar.
+- Toolbar controls stay clickable because buttons remain explicit no-drag targets while passive titlebar surfaces handle native dragging.
+- Fix stale renderer recovery restarts.
+- Recover stale renderers without blocking the macOS main thread while the old main window unregisters.
+- Let the startup recovery screen scroll in shorter windows so recovery actions stay reachable.
+- Pause heavy background work before high renderer memory can force repeated recovery.
+- Retry deferred startup RSS polls instead of waiting for the next normal polling interval.
+- Batch visible archive actions more aggressively.
+- Restore Linux release compilation for renderer memory diagnostics.
+
+### Downloads
+
+**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)
+**Windows:** `.exe` (NSIS installer)
+**Linux:** `.AppImage`
+
+> macOS downloads are signed and notarized for normal Gatekeeper installation.

--- a/website/public/atom.xml
+++ b/website/public/atom.xml
@@ -2,7 +2,7 @@
 <feed xmlns="http://www.w3.org/2005/Atom">
     <id>https://freed.wtf</id>
     <title>Freed Blog</title>
-    <updated>2026-05-04T11:11:41.884Z</updated>
+    <updated>2026-05-05T02:18:22.758Z</updated>
     <generator>https://github.com/jpmonette/feed</generator>
     <author>
         <name>The Freed Team</name>

--- a/website/public/feed.xml
+++ b/website/public/feed.xml
@@ -4,7 +4,7 @@
         <title>Freed Blog</title>
         <link>https://freed.wtf</link>
         <description>Progress reports, technical deep-dives, and philosophical rants about the attention economy. From the team building Freed.</description>
-        <lastBuildDate>Mon, 04 May 2026 11:11:41 GMT</lastBuildDate>
+        <lastBuildDate>Tue, 05 May 2026 02:18:22 GMT</lastBuildDate>
         <docs>https://validator.w3.org/feed/docs/rss2.html</docs>
         <generator>https://github.com/jpmonette/feed</generator>
         <language>en</language>

--- a/website/src/content/changelog.generated.json
+++ b/website/src/content/changelog.generated.json
@@ -1,32 +1,118 @@
 [
   {
-    "version": "26.5.400",
-    "tagName": "v26.5.400",
+    "version": "26.5.403",
+    "tagName": "v26.5.403",
     "channel": "production",
-    "date": "2026-05-04T11:05:47Z",
-    "deck": "Fix stale renderer recovery restarts",
+    "date": "2026-05-05T02:12:56Z",
+    "deck": "Freed Desktop reliability fixes",
     "features": [],
     "fixes": [
+      {
+        "text": "Native macOS window dragging now works from the FREED wordmark, nearby titlebar gap, passive toolbar title areas, and fullscreen reader titlebar."
+      },
+      {
+        "text": "Toolbar controls stay clickable because buttons remain explicit no-drag targets while passive titlebar surfaces handle native dragging."
+      },
+      {
+        "text": "Fix stale renderer recovery restarts."
+      },
       {
         "text": "Recover stale renderers without blocking the macOS main thread while the old main window unregisters."
       },
       {
         "text": "Let the startup recovery screen scroll in shorter windows so recovery actions stay reachable."
+      },
+      {
+        "text": "Pause heavy background work before high renderer memory can force repeated recovery."
+      },
+      {
+        "text": "Retry deferred startup RSS polls instead of waiting for the next normal polling interval."
+      },
+      {
+        "text": "Batch visible archive actions more aggressively."
+      },
+      {
+        "text": "Restore Linux release compilation for renderer memory diagnostics."
       }
     ],
     "followUps": [],
-    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.5.400",
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.5.403",
     "prNumbers": [
-      421
+      408,
+      418,
+      419,
+      420,
+      421,
+      424,
+      425,
+      427,
+      428
     ],
     "builds": [
-      "26.5.400"
+      "26.5.400",
+      "26.5.403"
     ],
     "buildLinks": [
       {
         "version": "26.5.400",
         "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.5.400",
         "channel": "production"
+      },
+      {
+        "version": "26.5.403",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.5.403",
+        "channel": "production"
+      }
+    ]
+  },
+  {
+    "version": "26.5.402-dev",
+    "tagName": "v26.5.402-dev",
+    "channel": "dev",
+    "date": "2026-05-04T21:52:52Z",
+    "deck": "Freed Desktop is calmer during renderer memory spikes",
+    "features": [],
+    "fixes": [
+      {
+        "text": "Freed Desktop now pauses heavy background work before high renderer memory can force repeated recovery."
+      },
+      {
+        "text": "Renderer health events now include generation, route, visibility, memory footprint, recovery state, and active background work."
+      },
+      {
+        "text": "Social sync memory preflights now defer the shared scheduler instead of cycling through providers."
+      },
+      {
+        "text": "Startup recovery now waits for stable renderer heartbeats before high-memory background jobs resume."
+      },
+      {
+        "text": "Startup recovery and Settings copy now distinguish high memory from critical memory."
+      },
+      {
+        "text": "Non-macOS release builds now compile the renderer memory diagnostics cleanly."
+      }
+    ],
+    "followUps": [
+      {
+        "text": "Local diagnostics now write bounded runtime bundles for memory pressure, stale heartbeats, and pre-recovery samples."
+      },
+      {
+        "text": "Startup recovery UI can scroll when the dialog content is taller than the window."
+      },
+      {
+        "text": "Visible archive actions now batch state work more aggressively."
+      }
+    ],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.5.402-dev",
+    "prNumbers": [],
+    "builds": [
+      "26.5.402-dev"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.5.402-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.5.402-dev",
+        "channel": "dev"
       }
     ]
   },


### PR DESCRIPTION
(AI Generated).

## Summary
- add the v26.5.403 production release-note artifacts to www
- regenerate the public changelog snapshot and feeds

## Validation
- npm run build, from website
- npm run lint, from website
- node scripts/validate-release-notes.mjs release-notes/releases/v26.5.403.json release-notes/releases/v26.5.400.json
- git diff --check
