### PR TITLE
fix: reduce social scraper frame drops

### DIFF
--- a/packages/desktop/src-tauri/src/fb-extract.js
+++ b/packages/desktop/src-tauri/src/fb-extract.js
@@ -18,6 +18,12 @@
         }
       : function () {};
 
+  function textValue(node, maxChars) {
+    var value = node && node.textContent ? node.textContent : "";
+    if (maxChars && value.length > maxChars) value = value.slice(0, maxChars);
+    return value.trim();
+  }
+
   function parseEngagement(text) {
     if (!text) return null;
     var cleaned = text.replace(/[^0-9.KMkm]/g, "").trim();
@@ -111,14 +117,14 @@
       // - Contain some text or images
       // - NOT be the entire feed container itself
       if (h >= 150 && h <= 2000 && node !== container) {
-        var innerText = (node.innerText || "").trim();
+        var nodeText = textValue(node, 4000);
         var hasScontent =
           node.querySelector('img[src*="scontent"], img[src*="fbcdn"]') !==
           null;
         var hasVideo = node.querySelector("video") !== null;
 
         // Post-like: has substantial text or media
-        if (innerText.length > 40 || hasScontent || hasVideo) {
+        if (nodeText.length > 40 || hasScontent || hasVideo) {
           // Check if this is a profile/author link area (h3/h4 with name + text below)
           var hasAuthorArea =
             node.querySelector("h3 a, h4 a") !== null ||
@@ -128,7 +134,7 @@
           // or if it has media + some text
           if (hasAuthorArea || hasScontent || hasVideo) {
             var id =
-              node.offsetTop + ":" + h + ":" + innerText.length;
+              node.offsetTop + ":" + h + ":" + nodeText.length;
             if (!seen.has(id)) {
               seen.add(id);
               posts.push(node);
@@ -252,13 +258,13 @@
     var textEl = el.querySelector(
       '[data-ad-comet-preview="message"], [data-ad-preview="message"]'
     );
-    if (textEl) return (textEl.innerText || "").trim();
+    if (textEl) return textValue(textEl, 4000);
 
     // Find the largest dir="auto" block that looks like post content
     var dirAutos = el.querySelectorAll('[dir="auto"]');
     var best = "";
     for (var t = 0; t < dirAutos.length; t++) {
-      var candidate = (dirAutos[t].innerText || "").trim();
+      var candidate = textValue(dirAutos[t], 4000);
       if (candidate.length > best.length && candidate.length > 15) {
         // Skip if it's just a heading (same text as an h3/h4)
         var heading = el.querySelector("h3, h4");
@@ -346,7 +352,7 @@
     if (el.querySelector('[data-testid="sponsored_label"]')) return true;
     if (el.querySelector('[aria-label="Sponsored"]')) return true;
 
-    var fullText = (el.innerText || "").trim();
+    var fullText = textValue(el, 2000);
     if (/suggested for you|people you may know|recommended for you|recommended/i.test(fullText)) {
       return true;
     }

--- a/packages/desktop/src-tauri/src/ig-extract.js
+++ b/packages/desktop/src-tauri/src/ig-extract.js
@@ -17,6 +17,12 @@
         }
       : function () {};
 
+  function textValue(node, maxChars) {
+    var value = node && node.textContent ? node.textContent : "";
+    if (maxChars && value.length > maxChars) value = value.slice(0, maxChars);
+    return value.trim();
+  }
+
   function parseEngagement(text) {
     if (!text) return null;
     var cleaned = text.replace(/[^0-9.,KMkm]/g, "").replace(",", "");
@@ -159,7 +165,7 @@
       var spans = captionEl.querySelectorAll("span");
       var texts = [];
       for (var i = 0; i < spans.length; i++) {
-        var t = (spans[i].innerText || "").trim();
+        var t = textValue(spans[i], 2000);
         if (t.length > 0) texts.push(t);
       }
       if (texts.length > 0) return texts.join(" ");
@@ -168,7 +174,7 @@
     // Fallback: h1 with spans (common in single-post views)
     var h1 = article.querySelector("h1");
     if (h1) {
-      var h1text = (h1.innerText || "").trim();
+      var h1text = textValue(h1, 4000);
       if (h1text.length > 10) return h1text;
     }
 
@@ -176,7 +182,7 @@
     var dirAutos = article.querySelectorAll('[dir="auto"]');
     var best = "";
     for (var d = 0; d < dirAutos.length; d++) {
-      var candidate = (dirAutos[d].innerText || "").trim();
+      var candidate = textValue(dirAutos[d], 4000);
       if (candidate.length > best.length && candidate.length > 15) {
         // Skip if it looks like the author name
         var header = article.querySelector("header");
@@ -240,7 +246,7 @@
     // Like count: button or span with "like" text patterns
     var sections = article.querySelectorAll("section");
     for (var s = 0; s < sections.length; s++) {
-      var text = (sections[s].innerText || "").toLowerCase();
+      var text = textValue(sections[s], 2000).toLowerCase();
       // "1,234 likes" or "Liked by X and 1,234 others"
       var likeMatch = text.match(/([\d,]+)\s*like/);
       if (likeMatch) {
@@ -291,7 +297,7 @@
 
   function isSuggestedOrSponsored(article) {
     // "Suggested for you" / "Suggested Posts" label anywhere in article
-    var fullText = (article.innerText || "");
+    var fullText = textValue(article, 2000);
     if (/suggested|reels you might like/i.test(fullText)) {
       return true;
     }

--- a/packages/desktop/src-tauri/src/li-extract.js
+++ b/packages/desktop/src-tauri/src/li-extract.js
@@ -218,7 +218,7 @@
       ".feed-shared-update-v2__description",
       ".update-components-text",
     ]);
-    var text = textNode ? textNode.innerText.trim() : null;
+    var text = textNode ? textNode.textContent.trim() : null;
 
     // ── Timestamp ────────────────────────────────────────────────────────────
     var timestampIso = null;

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -14,9 +14,9 @@ use std::process::Command;
 use std::sync::{Arc, Mutex as StdMutex, RwLock as StdRwLock};
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use sysinfo::{Disks, Pid, ProcessRefreshKind, ProcessesToUpdate, System};
-use tauri::menu::{Menu, MenuItem};
 #[cfg(target_os = "macos")]
 use tauri::menu::Submenu;
+use tauri::menu::{Menu, MenuItem};
 use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
 use tauri::{Emitter, Listener, Manager};
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
@@ -64,6 +64,7 @@ const MIN_CRITICAL_MEMORY_BYTES: u64 = 7 * BYTES_PER_GIB / 2;
 const MAX_CRITICAL_MEMORY_BYTES: u64 = 8 * BYTES_PER_GIB;
 const WEBKIT_CACHE_TRIM_AT_BYTES: u64 = 768 * 1024 * 1024;
 const WEBKIT_CACHE_TRIM_TARGET_BYTES: u64 = 512 * 1024 * 1024;
+const OPTIONAL_STORY_MEMORY_BUDGET_PERCENT: u64 = 85;
 const STARTUP_RECOVERY_STATE_FILE: &str = "startup-recovery.json";
 const RUNTIME_HEALTH_FILE: &str = "runtime-health.jsonl";
 const RUNTIME_DIAGNOSTICS_FILE: &str = "runtime-diagnostics.jsonl";
@@ -2449,6 +2450,88 @@ fn scrape_memory_may_proceed(stats: &RuntimeMemoryStats) -> bool {
     stats.app_resident_bytes < stats.memory_high_bytes
 }
 
+fn optional_story_scrape_may_proceed(stats: &RuntimeMemoryStats) -> bool {
+    stats.app_resident_bytes
+        < stats
+            .memory_high_bytes
+            .saturating_mul(OPTIONAL_STORY_MEMORY_BUDGET_PERCENT)
+            / 100
+}
+
+fn social_scrape_may_continue(
+    app: &tauri::AppHandle,
+    provider: &str,
+    operation: &str,
+    pass_index: usize,
+    total_passes: usize,
+) -> bool {
+    let stats = collect_runtime_memory_stats(app, 0, 0);
+    let may_continue = scrape_memory_may_proceed(&stats);
+    if !may_continue {
+        warn!(
+            "[memory] ending scrape early provider={} operation={} pass={}/{} app_rss={} webkit_rss={} high_bytes={} critical_bytes={}",
+            provider,
+            operation,
+            pass_index,
+            total_passes,
+            stats.app_resident_bytes,
+            stats.webkit_total_resident_bytes,
+            stats.memory_high_bytes,
+            stats.memory_critical_bytes
+        );
+        append_runtime_health(
+            app,
+            serde_json::json!({
+                "event": "social_scrape_stopped_for_memory",
+                "provider": provider,
+                "operation": operation,
+                "passIndex": pass_index,
+                "totalPasses": total_passes,
+                "appResidentBytes": stats.app_resident_bytes,
+                "webkitResidentBytes": stats.webkit_total_resident_bytes,
+                "webkitLargestProcessId": stats.webkit_largest_process_id,
+                "webkitLargestResidentBytes": stats.webkit_largest_resident_bytes,
+                "memoryHighBytes": stats.memory_high_bytes,
+                "memoryCriticalBytes": stats.memory_critical_bytes
+            }),
+        );
+    }
+    may_continue
+}
+
+fn optional_story_scrape_may_continue(
+    app: &tauri::AppHandle,
+    provider: &str,
+    operation: &str,
+) -> bool {
+    let stats = collect_runtime_memory_stats(app, 0, 0);
+    let may_continue = optional_story_scrape_may_proceed(&stats);
+    if !may_continue {
+        info!(
+            "[memory] skipping optional story scrape provider={} operation={} app_rss={} webkit_rss={} story_budget={} high_bytes={}",
+            provider,
+            operation,
+            stats.app_resident_bytes,
+            stats.webkit_total_resident_bytes,
+            stats.memory_high_bytes.saturating_mul(OPTIONAL_STORY_MEMORY_BUDGET_PERCENT) / 100,
+            stats.memory_high_bytes
+        );
+        append_runtime_health(
+            app,
+            serde_json::json!({
+                "event": "optional_story_scrape_skipped_for_memory",
+                "provider": provider,
+                "operation": operation,
+                "appResidentBytes": stats.app_resident_bytes,
+                "webkitResidentBytes": stats.webkit_total_resident_bytes,
+                "storyBudgetBytes": stats.memory_high_bytes.saturating_mul(OPTIONAL_STORY_MEMORY_BUDGET_PERCENT) / 100,
+                "memoryHighBytes": stats.memory_high_bytes
+            }),
+        );
+    }
+    may_continue
+}
+
 fn recycle_social_scraper_windows_except(
     app: &tauri::AppHandle,
     preserve_label: Option<&str>,
@@ -3509,7 +3592,7 @@ async fn fb_scrape_feed(
 
     // Randomized ordering: ~50% stories-first, ~50% feed-first.
     // ~15% chance to skip story scraping entirely (real users don't always check stories).
-    let skip_stories = {
+    let skip_stories = !optional_story_scrape_may_continue(&app, "Facebook", "feed scrape") || {
         use rand::Rng;
         rand::thread_rng().gen_bool(0.15)
     };
@@ -3519,7 +3602,7 @@ async fn fb_scrape_feed(
     };
     let story_frame_cap = {
         use rand::Rng;
-        rand::thread_rng().gen_range(4usize..=8)
+        rand::thread_rng().gen_range(2usize..=4)
     };
 
     if stories_first {
@@ -3537,7 +3620,7 @@ async fn fb_scrape_feed(
     // We must scroll incrementally, extracting at each position.
     let num_passes = {
         use rand::Rng;
-        rand::thread_rng().gen_range(8usize..=18)
+        rand::thread_rng().gen_range(6usize..=10)
     };
     // If doing feed-first, split the passes: 2-4 passes before stories, rest after.
     let early_passes = if !stories_first && !skip_stories {
@@ -3555,6 +3638,9 @@ async fn fb_scrape_feed(
 
         tokio::time::sleep(Duration::from_millis(300)).await;
         cleanup_background_scraper_media(&wv);
+        if !social_scrape_may_continue(&app, "Facebook", "feed scrape", i + 1, num_passes) {
+            break;
+        }
 
         let scroll_amount = {
             use rand::Rng;
@@ -4074,7 +4160,7 @@ async fn ig_scrape_feed(
 
     // Randomized ordering: ~50% stories-first, ~50% feed-first.
     // ~15% chance to skip story scraping entirely.
-    let skip_stories = {
+    let skip_stories = !optional_story_scrape_may_continue(&app, "Instagram", "feed scrape") || {
         use rand::Rng;
         rand::thread_rng().gen_bool(0.15)
     };
@@ -4084,7 +4170,7 @@ async fn ig_scrape_feed(
     };
     let story_frame_cap = {
         use rand::Rng;
-        rand::thread_rng().gen_range(4usize..=8)
+        rand::thread_rng().gen_range(2usize..=4)
     };
 
     if stories_first {
@@ -4101,7 +4187,7 @@ async fn ig_scrape_feed(
     // incrementally, extracting at each position.
     let num_passes = {
         use rand::Rng;
-        rand::thread_rng().gen_range(7usize..=14)
+        rand::thread_rng().gen_range(5usize..=9)
     };
     // Feed-first: scrape stories after the first 2-4 passes
     let early_passes = if !stories_first && !skip_stories {
@@ -4119,6 +4205,9 @@ async fn ig_scrape_feed(
 
         tokio::time::sleep(Duration::from_millis(300)).await;
         cleanup_background_scraper_media(&wv);
+        if !social_scrape_may_continue(&app, "Instagram", "feed scrape", i + 1, num_passes) {
+            break;
+        }
 
         let scroll_amount = {
             use rand::Rng;
@@ -4715,7 +4804,7 @@ async fn li_scrape_feed(
     // position. Fewer passes than FB (LinkedIn loads fewer posts per scroll).
     let num_passes = {
         use rand::Rng;
-        rand::thread_rng().gen_range(6usize..=12)
+        rand::thread_rng().gen_range(4usize..=8)
     };
 
     // Inject the extract script as a const so we can append done=true on last pass.
@@ -4748,6 +4837,9 @@ async fn li_scrape_feed(
         inject_script(&wv, is_last)?;
         tokio::time::sleep(Duration::from_millis(300)).await;
         cleanup_background_scraper_media(&wv);
+        if !social_scrape_may_continue(&app, "LinkedIn", "feed scrape", i + 1, num_passes) {
+            break;
+        }
 
         let scroll_amount = {
             use rand::Rng;
@@ -4823,6 +4915,18 @@ async fn li_scrape_feed(
         );
     }
 
+    let _ = wv.eval(
+        r#"
+        (function() {
+            if (window.__TAURI__ && window.__TAURI__.event && window.__TAURI__.event.emit) {
+                window.__TAURI__.event.emit("li-feed-data", {
+                    posts: [], done: true, extractedAt: Date.now(),
+                    url: window.location.href, candidateCount: 0, scrollY: window.scrollY
+                });
+            }
+        })();
+    "#,
+    );
     tokio::time::sleep(Duration::from_millis(500)).await;
     println!(
         "[LI] scrape complete, {} extraction passes emitted",
@@ -6290,6 +6394,46 @@ mod tests {
         assert!(scrape_memory_may_proceed(&stats));
         assert!(!scrape_memory_may_proceed(&RuntimeMemoryStats {
             app_resident_bytes: MIN_CRITICAL_MEMORY_BYTES * 70 / 100,
+            ..stats
+        }));
+    }
+
+    #[test]
+    fn optional_story_scrape_uses_stricter_memory_budget() {
+        let stats = RuntimeMemoryStats {
+            total_physical_memory_bytes: 16 * BYTES_PER_GIB,
+            process_resident_bytes: 128,
+            process_virtual_bytes: 256,
+            app_resident_bytes: (MIN_CRITICAL_MEMORY_BYTES * 70 / 100)
+                * OPTIONAL_STORY_MEMORY_BUDGET_PERCENT
+                / 100
+                - 1,
+            webkit_resident_bytes: None,
+            webkit_virtual_bytes: None,
+            webkit_process_id: None,
+            webkit_total_resident_bytes: 0,
+            webkit_process_count: 0,
+            webkit_largest_resident_bytes: None,
+            webkit_largest_process_id: None,
+            webkit_largest_cpu_usage: None,
+            webkit_largest_age_seconds: None,
+            webkit_largest_role: None,
+            webkit_processes: Vec::new(),
+            webkit_telemetry_available: false,
+            indexed_db_bytes: None,
+            webkit_cache_bytes: None,
+            memory_high_bytes: MIN_CRITICAL_MEMORY_BYTES * 70 / 100,
+            memory_critical_bytes: MIN_CRITICAL_MEMORY_BYTES,
+            relay_doc_bytes: 0,
+            relay_client_count: 0,
+        };
+
+        assert!(optional_story_scrape_may_proceed(&stats));
+        assert!(!optional_story_scrape_may_proceed(&RuntimeMemoryStats {
+            app_resident_bytes: stats
+                .memory_high_bytes
+                .saturating_mul(OPTIONAL_STORY_MEMORY_BUDGET_PERCENT)
+                / 100,
             ..stats
         }));
     }

--- a/packages/desktop/src/lib/fb-capture.ts
+++ b/packages/desktop/src/lib/fb-capture.ts
@@ -120,80 +120,83 @@ export async function fetchFbFeed(): Promise<FbSyncResult> {
     return { items: [], diag };
   }
 
-  return new Promise<FbSyncResult>((resolve) => {
-    let unlisten: UnlistenFn | null = null;
+  const allRawPosts: RawFbPost[] = [];
+  const seenIds = new Set<string>();
+  let unlisten: UnlistenFn | null = null;
+  let unlistenDiag: UnlistenFn | null = null;
 
-    // Timeout if the WebView takes too long (30s for page load + extraction)
-    const timeout = setTimeout(() => {
-      unlisten?.();
-      diag.errorStage = "timeout";
-      diag.errorMessage = "Scrape timed out after 30 seconds";
-      resolve({ items: [], diag });
-    }, 30_000);
+  try {
+    attachScraperMediaDiagListener("FB", "facebook");
 
     // Listen for diagnostics (fires before extraction)
-    listen("fb-diag", (diagEvent) => {
+    unlistenDiag = await listen("fb-diag", (diagEvent) => {
       const diag = diagEvent.payload as Record<string, unknown>;
       addDebugEvent("change", `[FB] DOM diag: feedUnits=${diag.feedUnits}, fallback=${diag.feedUnitsFallback}, feed=${diag.feedContainer}, h4s=${diag.h4Count}, bodyLen=${diag.bodyLen}, url=${diag.url}, tauriEmit=${diag.hasTauriEmit}`);
       console.log("[FB] DOM diagnostics:", diag);
-    }).then((fn) => {
-      // Auto-cleanup after 35 seconds
-      setTimeout(() => fn(), 35_000);
     });
-    attachScraperMediaDiagListener("FB", "facebook");
 
-    // Listen for the extraction result
-    listen<{ posts: RawFbPost[]; error?: string; extractedAt: number; url: string; strategy?: string; candidateCount?: number }>(
+    // Listen for every extraction pass. The native scraper emits multiple
+    // batches while it scrolls through the virtualized feed.
+    unlisten = await listen<{ posts: RawFbPost[]; error?: string; extractedAt: number; url: string; strategy?: string; candidateCount?: number }>(
       "fb-feed-data",
       (event) => {
-        clearTimeout(timeout);
-        unlisten?.();
-
         const { posts, error, strategy, candidateCount } = event.payload;
 
         addDebugEvent("change", `[FB] extraction: strategy=${strategy ?? "?"}, candidates=${candidateCount ?? "?"}, posts=${posts.length}`);
 
         if (error) {
+          addDebugEvent("error", `[FB] extraction error: ${error}`);
           diag.errorStage = "extract";
           diag.errorMessage = error;
-          resolve({ items: [], diag });
           return;
         }
 
-        diag.postsExtracted = posts.length;
-
-        if (posts.length === 0) {
-          resolve({ items: [], diag });
-          return;
-        }
-
-        try {
-          const normalized = fbPostsToFeedItems(posts);
-          diag.itemsNormalized = normalized.length;
-
-          const items = deduplicateFeedItems(normalized);
-          diag.itemsDeduplicated = items.length;
-
-          resolve({ items, diag });
-        } catch (err) {
-          diag.errorStage = "normalize";
-          diag.errorMessage = err instanceof Error ? err.message : String(err);
-          resolve({ items: [], diag });
+        for (const post of posts) {
+          const key = post.id ?? post.url ?? `${post.authorName}:${(post.text ?? "").slice(0, 80)}`;
+          if (key && !seenIds.has(key)) {
+            seenIds.add(key);
+            allRawPosts.push(post);
+          }
         }
       },
-    ).then((fn) => {
-      unlisten = fn;
-    });
+    );
 
-    // Trigger the Rust command
-    invoke("fb_scrape_feed", { windowMode: getFbScraperWindowMode() }).catch((err) => {
-      clearTimeout(timeout);
-      unlisten?.();
+    await invoke("fb_scrape_feed", { windowMode: getFbScraperWindowMode() });
+    await new Promise<void>((resolve) => setTimeout(resolve, 500));
+  } catch (err) {
+    if (!diag.errorStage) {
       diag.errorStage = "invoke";
       diag.errorMessage = err instanceof Error ? err.message : String(err);
-      resolve({ items: [], diag });
-    });
-  });
+    }
+    return { items: [], diag };
+  } finally {
+    unlisten?.();
+    unlistenDiag?.();
+  }
+
+  if (diag.errorStage) {
+    return { items: [], diag };
+  }
+
+  diag.postsExtracted = allRawPosts.length;
+
+  if (allRawPosts.length === 0) {
+    return { items: [], diag };
+  }
+
+  try {
+    const normalized = fbPostsToFeedItems(allRawPosts);
+    diag.itemsNormalized = normalized.length;
+
+    const items = deduplicateFeedItems(normalized);
+    diag.itemsDeduplicated = items.length;
+
+    return { items, diag };
+  } catch (err) {
+    diag.errorStage = "normalize";
+    diag.errorMessage = err instanceof Error ? err.message : String(err);
+    return { items: [], diag };
+  }
 }
 
 export async function captureFbGroups(): Promise<FbGroupInfo[]> {

--- a/packages/desktop/src/lib/li-capture.ts
+++ b/packages/desktop/src/lib/li-capture.ts
@@ -109,53 +109,15 @@ export async function fetchLiFeed(): Promise<LiSyncResult> {
     return { items: [], diag };
   }
 
-  return new Promise<LiSyncResult>((resolve) => {
-    let unlisten: UnlistenFn | null = null;
-    const allRawPosts: RawLiPost[] = [];
-    const seenUrns = new Set<string>();
+  let unlisten: UnlistenFn | null = null;
+  const allRawPosts: RawLiPost[] = [];
+  const seenUrns = new Set<string>();
+
+  try {
     attachScraperMediaDiagListener("LI", "linkedin");
 
-    // Timeout if the WebView takes too long
-    const timeout = setTimeout(() => {
-      unlisten?.();
-      if (allRawPosts.length > 0) {
-        // We have partial results — return them rather than nothing
-        finalize(allRawPosts);
-      } else {
-        diag.errorStage = "timeout";
-        diag.errorMessage = "Scrape timed out after 60 seconds";
-        resolve({ items: [], diag });
-      }
-    }, 60_000);
-
-    function finalize(posts: RawLiPost[]) {
-      clearTimeout(timeout);
-      unlisten?.();
-
-      diag.postsExtracted = posts.length;
-
-      if (posts.length === 0) {
-        resolve({ items: [], diag });
-        return;
-      }
-
-      try {
-        const normalized = liPostsToFeedItems(posts);
-        diag.itemsNormalized = normalized.length;
-
-        const items = deduplicateFeedItems(normalized);
-        diag.itemsDeduplicated = items.length;
-
-        resolve({ items, diag });
-      } catch (err) {
-        diag.errorStage = "normalize";
-        diag.errorMessage = err instanceof Error ? err.message : String(err);
-        resolve({ items: [], diag });
-      }
-    }
-
-    // Listen for extraction events (multiple per scrape — one per scroll pass)
-    listen<{
+    // Listen for extraction events from each scroll pass.
+    unlisten = await listen<{
       posts: RawLiPost[];
       error?: string;
       extractedAt: number;
@@ -174,11 +136,8 @@ export async function fetchLiFeed(): Promise<LiSyncResult> {
         );
 
         if (error) {
-          clearTimeout(timeout);
-          unlisten?.();
           diag.errorStage = "extract";
           diag.errorMessage = error;
-          resolve({ items: [], diag });
           return;
         }
 
@@ -191,25 +150,45 @@ export async function fetchLiFeed(): Promise<LiSyncResult> {
           }
         }
 
-        if (done) {
-          finalize(allRawPosts);
-        }
-      },
-    ).then((fn) => {
-      unlisten = fn;
-    });
-
-    // Trigger the Rust command
-    invoke("li_scrape_feed", { windowMode: getLiScraperWindowMode() }).catch(
-      (err) => {
-        clearTimeout(timeout);
-        unlisten?.();
-        diag.errorStage = "invoke";
-        diag.errorMessage = err instanceof Error ? err.message : String(err);
-        resolve({ items: [], diag });
+        if (done) return;
       },
     );
-  });
+
+    await invoke("li_scrape_feed", { windowMode: getLiScraperWindowMode() });
+    await new Promise<void>((resolve) => setTimeout(resolve, 500));
+  } catch (err) {
+    if (!diag.errorStage) {
+      diag.errorStage = "invoke";
+      diag.errorMessage = err instanceof Error ? err.message : String(err);
+    }
+    return { items: [], diag };
+  } finally {
+    unlisten?.();
+  }
+
+  if (diag.errorStage) {
+    return { items: [], diag };
+  }
+
+  diag.postsExtracted = allRawPosts.length;
+
+  if (allRawPosts.length === 0) {
+    return { items: [], diag };
+  }
+
+  try {
+    const normalized = liPostsToFeedItems(allRawPosts);
+    diag.itemsNormalized = normalized.length;
+
+    const items = deduplicateFeedItems(normalized);
+    diag.itemsDeduplicated = items.length;
+
+    return { items, diag };
+  } catch (err) {
+    diag.errorStage = "normalize";
+    diag.errorMessage = err instanceof Error ? err.message : String(err);
+    return { items: [], diag };
+  }
 }
 
 // =============================================================================

--- a/packages/desktop/src/lib/social-capture-memory-pressure.test.ts
+++ b/packages/desktop/src/lib/social-capture-memory-pressure.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   invoke: vi.fn(),
+  listen: vi.fn(),
   prepareSocialScrapeMemory: vi.fn(),
 }));
 
@@ -11,7 +12,23 @@ vi.mock("@tauri-apps/api/core", () => ({
 }));
 
 vi.mock("@tauri-apps/api/event", () => ({
-  listen: vi.fn(),
+  listen: mocks.listen,
+}));
+
+vi.mock("@freed/capture-facebook/browser", () => ({
+  fbPostsToFeedItems: vi.fn((posts: Array<{ id?: string }>) =>
+    posts.map((post, index) => ({
+      globalId: post.id ?? `post-${index}`,
+      platform: "facebook",
+      content: { text: "post", mediaUrls: [], mediaTypes: [] },
+      author: { displayName: "Facebook" },
+      createdAt: Date.now(),
+      savedAt: Date.now(),
+      tags: [],
+      topics: [],
+    })),
+  ),
+  deduplicateFeedItems: vi.fn((items: unknown[]) => items),
 }));
 
 vi.mock("@freed/ui/lib/debug-store", () => ({
@@ -52,6 +69,7 @@ vi.mock("./media-vault", () => ({
 beforeEach(() => {
   vi.resetModules();
   mocks.invoke.mockReset();
+  mocks.listen.mockReset();
   mocks.prepareSocialScrapeMemory.mockReset();
   mocks.prepareSocialScrapeMemory.mockResolvedValue({
     before: {},
@@ -59,6 +77,53 @@ beforeEach(() => {
     recycledScraperWindows: true,
     cacheTrimmed: true,
     mayProceed: false,
+  });
+});
+
+describe("social capture completion", () => {
+  it("keeps Facebook listeners active until the native scraper finishes", async () => {
+    const listeners = new Map<string, (event: { payload: unknown }) => void>();
+    mocks.prepareSocialScrapeMemory.mockResolvedValue({
+      before: {},
+      after: { appResidentBytes: 512 * 1024 * 1024 },
+      recycledScraperWindows: false,
+      cacheTrimmed: false,
+      mayProceed: true,
+    });
+    mocks.listen.mockImplementation(async (eventName: string, callback: (event: { payload: unknown }) => void) => {
+      listeners.set(eventName, callback);
+      return vi.fn();
+    });
+    mocks.invoke.mockImplementation(async (command: string) => {
+      if (command !== "fb_scrape_feed") return null;
+
+      listeners.get("fb-feed-data")?.({
+        payload: {
+          posts: [{ id: "post-one", authorName: "One", text: "First" }],
+          extractedAt: Date.now(),
+          url: "https://www.facebook.com/",
+          strategy: "test",
+          candidateCount: 1,
+        },
+      });
+      listeners.get("fb-feed-data")?.({
+        payload: {
+          posts: [{ id: "post-two", authorName: "Two", text: "Second" }],
+          extractedAt: Date.now(),
+          url: "https://www.facebook.com/",
+          strategy: "test",
+          candidateCount: 1,
+        },
+      });
+      return null;
+    });
+
+    const { fetchFbFeed } = await import("./fb-capture");
+    const result = await fetchFbFeed();
+
+    expect(result.diag.errorStage).toBeNull();
+    expect(result.diag.postsExtracted).toBe(2);
+    expect(result.items).toHaveLength(2);
   });
 });
 

--- a/packages/desktop/src/lib/social-extract-performance.test.ts
+++ b/packages/desktop/src/lib/social-extract-performance.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("social feed extraction performance guards", () => {
+  it("does not force layout by reading innerText in feed extractors", () => {
+    const scripts = ["fb-extract.js", "ig-extract.js", "li-extract.js"];
+
+    for (const script of scripts) {
+      const source = readFileSync(join(process.cwd(), "src-tauri/src", script), "utf8");
+      expect(source).not.toContain("innerText");
+    }
+  });
+});


### PR DESCRIPTION
(AI Generated).

## Summary
- Reduces social scraper memory and renderer pressure by keeping listeners active until native scrapes finish, cutting expensive feed extraction work, skipping optional story passes under pressure, and ending long scrapes when RSS crosses the high-water mark.

## Testing
- npm run validate:feature