### PR TITLE
perf: move feed priority sorting off the render path

### DIFF
--- a/packages/desktop/src/lib/automerge.worker.ts
+++ b/packages/desktop/src/lib/automerge.worker.ts
@@ -55,7 +55,7 @@ import {
   confirmLikedSynced,
   confirmSeenSynced,
 } from "@freed/shared/schema";
-import { mergeDefaultPreferences, rankFeedItems } from "@freed/shared";
+import { mergeDefaultPreferences, rankFeedItems, sortByPriority } from "@freed/shared";
 import type { Account, FeedItem, Friend, LegacyDeviceContact, LegacyFriendSource, Person, RssFeed, UserPreferences } from "@freed/shared";
 import type { DocState, WorkerRequest, WorkerResponse } from "./automerge-types";
 import {
@@ -249,10 +249,12 @@ function hydrateFromDoc(doc: FreedDoc): DocState {
   const preferences = mergeDefaultPreferences(plain.preferences as Partial<UserPreferences> | undefined);
 
   const visibleItems = plainItems.filter((item) => !item.userState.hidden);
-  const rankedItems = rankFeedItems(
-    visibleItems.sort((a, b) => b.publishedAt - a.publishedAt),
-    preferences.weights,
-    { persons, accounts },
+  const rankedItems = sortByPriority(
+    rankFeedItems(
+      visibleItems.sort((a, b) => b.publishedAt - a.publishedAt),
+      preferences.weights,
+      { persons, accounts },
+    ),
   );
 
   const feedUnreadCounts: Record<string, number> = {};

--- a/packages/pwa/src/lib/automerge.worker.ts
+++ b/packages/pwa/src/lib/automerge.worker.ts
@@ -51,7 +51,7 @@ import {
   confirmLikedSynced,
   confirmSeenSynced,
 } from "@freed/shared/schema";
-import { mergeDefaultPreferences, rankFeedItems } from "@freed/shared";
+import { mergeDefaultPreferences, rankFeedItems, sortByPriority } from "@freed/shared";
 import type { Account, FeedItem, Friend, LegacyDeviceContact, LegacyFriendSource, Person, RssFeed, UserPreferences } from "@freed/shared";
 import type { DocState, WorkerRequest, WorkerResponse } from "./automerge-types";
 
@@ -183,10 +183,12 @@ function hydrateFromDoc(doc: FreedDoc): DocState {
   const preferences = mergeDefaultPreferences(plain.preferences as Partial<UserPreferences> | undefined);
 
   const visibleItems = plainItems.filter((item) => !item.userState.hidden);
-  const rankedItems = rankFeedItems(
-    visibleItems.sort((a, b) => b.publishedAt - a.publishedAt),
-    preferences.weights,
-    { persons, accounts },
+  const rankedItems = sortByPriority(
+    rankFeedItems(
+      visibleItems.sort((a, b) => b.publishedAt - a.publishedAt),
+      preferences.weights,
+      { persons, accounts },
+    ),
   );
 
   const feedUnreadCounts: Record<string, number> = {};

--- a/packages/pwa/src/lib/search-results.test.ts
+++ b/packages/pwa/src/lib/search-results.test.ts
@@ -100,4 +100,24 @@ describe("useSearchResults", () => {
 
     expect(host.textContent).toBe("item-1");
   });
+
+  it("preserves priority-ordered browsing items without resorting the feed", () => {
+    const host = renderProbe([
+      makeItem({ globalId: "high", priority: 90 }),
+      makeItem({ globalId: "mid", priority: 40 }),
+      makeItem({ globalId: "low", priority: 10 }),
+    ], {}, "");
+
+    expect(host.textContent).toBe("high,mid,low");
+  });
+
+  it("keeps the browsing fallback sorted when callers provide unsorted items", () => {
+    const host = renderProbe([
+      makeItem({ globalId: "low", priority: 10 }),
+      makeItem({ globalId: "high", priority: 90 }),
+      makeItem({ globalId: "mid", priority: 40 }),
+    ], {}, "");
+
+    expect(host.textContent).toBe("high,mid,low");
+  });
 });

--- a/packages/ui/src/hooks/useSearchResults.ts
+++ b/packages/ui/src/hooks/useSearchResults.ts
@@ -255,6 +255,19 @@ function searchOptionsForQuery(query: string) {
   };
 }
 
+function priorityValue(item: FeedItem): number {
+  return item.priority ?? 0;
+}
+
+function ensurePriorityOrder(items: FeedItem[]): FeedItem[] {
+  for (let index = 1; index < items.length; index += 1) {
+    if (priorityValue(items[index]) > priorityValue(items[index - 1])) {
+      return sortByPriority(items);
+    }
+  }
+  return items;
+}
+
 function buildEmptyIndex(): MiniSearch<SearchDoc> {
   const ms = new MiniSearch<SearchDoc>({
     idField: "id",
@@ -271,6 +284,91 @@ export interface SearchResults {
   isSearching: boolean;
   /** Number of items matching the query after applying the active filter. */
   resultCount: number;
+}
+
+interface SearchResultCache {
+  items: FeedItem[];
+  trimmedQuery: string;
+  activeFilter: FilterOptions;
+  identityMode: "friends" | "all_content";
+  persons: Record<string, Person>;
+  accounts: Record<string, Account>;
+  friends: Record<string, Friend>;
+  index: MiniSearch<SearchDoc> | null;
+  itemById: Map<string, FeedItem> | null;
+  result: SearchResults;
+}
+
+let lastSearchResultCache: SearchResultCache | null = null;
+
+function computeSearchResults(args: {
+  items: FeedItem[];
+  trimmedQuery: string;
+  activeFilter: FilterOptions;
+  identityMode: "friends" | "all_content";
+  persons: Record<string, Person>;
+  accounts: Record<string, Account>;
+  friends: Record<string, Friend>;
+  index: MiniSearch<SearchDoc> | null;
+  itemById: Map<string, FeedItem> | null;
+}): SearchResults {
+  const cached = lastSearchResultCache;
+  if (
+    cached &&
+    cached.items === args.items &&
+    cached.trimmedQuery === args.trimmedQuery &&
+    cached.activeFilter === args.activeFilter &&
+    cached.identityMode === args.identityMode &&
+    cached.persons === args.persons &&
+    cached.accounts === args.accounts &&
+    cached.friends === args.friends &&
+    cached.index === args.index &&
+    cached.itemById === args.itemById
+  ) {
+    return cached.result;
+  }
+
+  const filterIdentityMode = (candidateItems: FeedItem[]): FeedItem[] =>
+    args.identityMode === "friends"
+      ? candidateItems.filter((item) => isFriendAuthoredItem(item, args.persons, args.accounts, args.friends))
+      : candidateItems;
+
+  let result: SearchResults;
+  if (!args.trimmedQuery) {
+    // Normal feed: apply active filter and preserve the worker-provided priority order.
+    // Older callers that still provide unsorted items get a cheap orderedness check
+    // followed by the old fallback sort only when needed.
+    const filtered = filterFeedItems(filterIdentityMode(args.items), args.activeFilter);
+    const byFeed = args.activeFilter.feedUrl
+      ? filtered.filter((item) => item.rssSource?.feedUrl === args.activeFilter.feedUrl)
+      : filtered;
+    result = { filteredItems: ensurePriorityOrder(byFeed), isSearching: false, resultCount: 0 };
+  } else if (!args.index || !args.itemById) {
+    result = { filteredItems: [], isSearching: true, resultCount: 0 };
+  } else {
+    // Search then filter, preserving MiniSearch's relevance ordering.
+    const hits = args.index.search(args.trimmedQuery, searchOptionsForQuery(args.trimmedQuery));
+
+    const scoreById = new Map(hits.map((r) => [r.id as string, r.score]));
+
+    const matchingItems = hits
+      .map((r) => args.itemById?.get(r.id as string))
+      .filter((item): item is FeedItem => item !== undefined);
+
+    const filtered = filterFeedItems(filterIdentityMode(matchingItems), args.activeFilter);
+    const byFeed = args.activeFilter.feedUrl
+      ? filtered.filter((item) => item.rssSource?.feedUrl === args.activeFilter.feedUrl)
+      : filtered;
+
+    const sorted = [...byFeed].sort(
+      (a, b) => (scoreById.get(b.globalId) ?? 0) - (scoreById.get(a.globalId) ?? 0),
+    );
+
+    result = { filteredItems: sorted, isSearching: true, resultCount: sorted.length };
+  }
+
+  lastSearchResultCache = { ...args, result };
+  return result;
 }
 
 /**
@@ -296,7 +394,10 @@ export function useSearchResults(
   const [index, setIndex] = useState<MiniSearch<SearchDoc> | null>(() =>
     getPreparedSearchIndex(items, searchCorpusVersion, accounts),
   );
-  const itemById = useMemo(() => new Map(items.map((item) => [item.globalId, item])), [items]);
+  const itemById = useMemo(
+    () => (trimmedQuery ? new Map(items.map((item) => [item.globalId, item])) : null),
+    [items, trimmedQuery],
+  );
 
   useEffect(() => {
     let cancelled = false;
@@ -330,46 +431,19 @@ export function useSearchResults(
     };
   }, [accounts, items, searchCorpusVersion, trimmedQuery]);
 
-  return useMemo(() => {
-    const filterIdentityMode = (candidateItems: FeedItem[]): FeedItem[] =>
-      identityMode === "friends"
-        ? candidateItems.filter((item) => isFriendAuthoredItem(item, persons, accounts, friends))
-        : candidateItems;
-
-    if (!trimmedQuery) {
-      // Normal feed: apply active filter then sort by priority. No MiniSearch work.
-      const filtered = filterFeedItems(filterIdentityMode(items), activeFilter);
-      const byFeed = activeFilter.feedUrl
-        ? filtered.filter((item) => item.rssSource?.feedUrl === activeFilter.feedUrl)
-        : filtered;
-      return { filteredItems: sortByPriority(byFeed), isSearching: false, resultCount: 0 };
-    }
-
-    // Search then filter — preserving MiniSearch's relevance ordering.
-    if (!index) {
-      return { filteredItems: [], isSearching: true, resultCount: 0 };
-    }
-
-    const hits = index.search(trimmedQuery, searchOptionsForQuery(trimmedQuery));
-
-    const scoreById = new Map(hits.map((r) => [r.id as string, r.score]));
-
-    // Map results back to FeedItems, preserving MiniSearch order.
-    const matchingItems = hits
-      .map((r) => itemById.get(r.id as string))
-      .filter((item): item is FeedItem => item !== undefined);
-
-    const filtered = filterFeedItems(filterIdentityMode(matchingItems), activeFilter);
-    const byFeed = activeFilter.feedUrl
-      ? filtered.filter((item) => item.rssSource?.feedUrl === activeFilter.feedUrl)
-      : filtered;
-
-    // Sort by relevance score (MiniSearch already orders hits, but filterFeedItems
-    // may reorder, so we re-sort explicitly).
-    const sorted = [...byFeed].sort(
-      (a, b) => (scoreById.get(b.globalId) ?? 0) - (scoreById.get(a.globalId) ?? 0),
-    );
-
-    return { filteredItems: sorted, isSearching: true, resultCount: sorted.length };
-  }, [accounts, activeFilter, friends, identityMode, index, itemById, items, persons, trimmedQuery]);
+  return useMemo(
+    () =>
+      computeSearchResults({
+        items,
+        trimmedQuery,
+        activeFilter,
+        identityMode,
+        persons,
+        accounts,
+        friends,
+        index,
+        itemById,
+      }),
+    [accounts, activeFilter, friends, identityMode, index, itemById, items, persons, trimmedQuery],
+  );
 }


### PR DESCRIPTION
(AI Generated).

## Summary
- Ranks and sorts feed items in the Automerge workers so the normal feed render path can preserve priority order after filtering instead of sorting the visible feed every render.

## Testing
- npm run validate:feature