### PR TITLE
perf: cache feed action scopes

### DIFF
--- a/packages/pwa/src/lib/feed-action-scope.test.ts
+++ b/packages/pwa/src/lib/feed-action-scope.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import type { FeedItem } from "@freed/shared";
+import { getFeedActionScope, getFeedArchiveCounts } from "../../../ui/src/lib/feed-action-scope";
+
+function makeItem(globalId: string, userState: Partial<FeedItem["userState"]> = {}): FeedItem {
+  return {
+    globalId,
+    platform: "rss",
+    sourceUrl: `https://example.com/${globalId}`,
+    author: {
+      id: "source",
+      displayName: "Source",
+      handle: "source",
+    },
+    content: {
+      text: globalId,
+      mediaUrls: [],
+      mediaTypes: [],
+    },
+    userState: {
+      hidden: false,
+      saved: false,
+      archived: false,
+      liked: false,
+      tags: [],
+      highlights: [],
+      ...userState,
+    },
+    topics: [],
+    contentType: "post",
+    capturedAt: 1,
+    publishedAt: 1,
+  } as FeedItem;
+}
+
+describe("feed action scope", () => {
+  it("collects unread and archivable IDs in one cached pass", () => {
+    const items = [
+      makeItem("unread"),
+      makeItem("read", { readAt: 1 }),
+      makeItem("saved-read", { readAt: 1, saved: true }),
+      makeItem("hidden", { hidden: true }),
+      makeItem("archived", { archived: true }),
+    ];
+
+    const scope = getFeedActionScope(items);
+
+    expect(scope.unreadItemIds).toEqual(["unread"]);
+    expect(scope.archivableItemIds).toEqual(["read"]);
+    expect(scope.unreadCount).toBe(1);
+    expect(scope.archivableCount).toBe(1);
+    expect(getFeedActionScope(items)).toBe(scope);
+  });
+
+  it("counts saved archived items separately from plain archived items", () => {
+    const items = [
+      makeItem("active"),
+      makeItem("archived", { archived: true }),
+      makeItem("saved-archived", { archived: true, saved: true }),
+    ];
+
+    const counts = getFeedArchiveCounts(items);
+
+    expect(counts).toEqual({ archivedCount: 1, savedArchivedCount: 1 });
+    expect(getFeedArchiveCounts(items)).toBe(counts);
+  });
+});

--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -52,6 +52,7 @@ import {
   useFeedCardDensity,
   type FeedCardDensity,
 } from "../../lib/feed-card-density.js";
+import { getFeedActionScope } from "../../lib/feed-action-scope.js";
 import {
   dragRegionStyle as dragStyle,
   getPassiveDragRegionProps,
@@ -470,25 +471,12 @@ export function Header({
     ? showInlineReaderBookmark ? "w-[11rem]" : "w-[8.5rem]"
     : showInlineReaderBookmark ? "w-[6.5rem]" : "w-14";
 
-  const filteredUnreadItemIds = useMemo(
-    () => filteredItems
-      .filter((item) => !item.userState.readAt && !item.userState.hidden && !item.userState.archived)
-      .map((item) => item.globalId),
-    [filteredItems],
-  );
-  const filteredArchivableItemIds = useMemo(
-    () => filteredItems
-      .filter((item) =>
-        !!item.userState.readAt &&
-        !item.userState.hidden &&
-        !item.userState.archived &&
-        !item.userState.saved
-      )
-      .map((item) => item.globalId),
-    [filteredItems],
-  );
-  const unreadCount = filteredUnreadItemIds.length;
-  const archivableCount = filteredArchivableItemIds.length;
+  const {
+    unreadItemIds: filteredUnreadItemIds,
+    archivableItemIds: filteredArchivableItemIds,
+    unreadCount,
+    archivableCount,
+  } = useMemo(() => getFeedActionScope(filteredItems), [filteredItems]);
 
   const handleSocialContentFilterChange = useCallback(
     (value: SocialContentFilter) => {

--- a/packages/ui/src/components/layout/SearchJumpField.tsx
+++ b/packages/ui/src/components/layout/SearchJumpField.tsx
@@ -24,6 +24,7 @@ import {
 import { useCommandSurfaceStore } from "../../lib/command-surface-store.js";
 import { useSettingsStore } from "../../lib/settings-store.js";
 import { buildSettingsSectionMetas } from "../../lib/settings-sections.js";
+import { getFeedActionScope, getFeedArchiveCounts } from "../../lib/feed-action-scope.js";
 import { buildTopLevelTagFilters, collectAllTags } from "../../lib/tag-navigation.js";
 import { applyFeedSearch, navigateToFeedView } from "../../lib/workspace-navigation.js";
 import { SearchField } from "../SearchField.js";
@@ -351,29 +352,12 @@ export function SearchJumpField({
     friends,
   );
 
-  const unreadScopeIds = useMemo(
-    () => commandScopeItems.filter((item) => !item.userState.readAt).map((item) => item.globalId),
-    [commandScopeItems],
-  );
-  const archivableScopeItems = useMemo(
-    () =>
-      commandScopeItems.filter(
-        (item) => !!item.userState.readAt && !item.userState.saved && !item.userState.archived,
-      ),
-    [commandScopeItems],
-  );
-  const archivableScopeIds = useMemo(
-    () => archivableScopeItems.map((item) => item.globalId),
-    [archivableScopeItems],
-  );
-  const savedArchivedCount = useMemo(
-    () => items.filter((item) => item.userState.saved && item.userState.archived).length,
-    [items],
-  );
-  const archivedCount = useMemo(
-    () => items.filter((item) => item.userState.archived && !item.userState.saved).length,
-    [items],
-  );
+  const {
+    unreadItemIds: unreadScopeIds,
+    archivableItemIds: archivableScopeIds,
+    archivableCount: archivableScopeCount,
+  } = useMemo(() => getFeedActionScope(commandScopeItems), [commandScopeItems]);
+  const { archivedCount, savedArchivedCount } = useMemo(() => getFeedArchiveCounts(items), [items]);
   const enabledFeeds = useMemo(
     () =>
       Object.values(feeds)
@@ -468,7 +452,7 @@ export function SearchJumpField({
         currentSourceId,
         selectedItem,
         unreadScopeCount: activeView === "feed" ? unreadScopeIds.length : 0,
-        archivableScopeCount: activeView === "feed" ? archivableScopeItems.length : 0,
+        archivableScopeCount: activeView === "feed" ? archivableScopeCount : 0,
         savedArchivedCount,
         archivedCount,
         openSettingsTo,
@@ -580,7 +564,7 @@ export function SearchJumpField({
       activeFilter,
       activeView,
       addRssFeed,
-      archivableScopeItems,
+      archivableScopeCount,
       archivedCount,
       checkForUpdates,
       currentSourceId,

--- a/packages/ui/src/lib/feed-action-scope.ts
+++ b/packages/ui/src/lib/feed-action-scope.ts
@@ -1,0 +1,64 @@
+import type { FeedItem } from "@freed/shared";
+
+export interface FeedActionScope {
+  unreadItemIds: string[];
+  archivableItemIds: string[];
+  unreadCount: number;
+  archivableCount: number;
+}
+
+export interface FeedArchiveCounts {
+  archivedCount: number;
+  savedArchivedCount: number;
+}
+
+const actionScopeCache = new WeakMap<readonly FeedItem[], FeedActionScope>();
+const archiveCountsCache = new WeakMap<readonly FeedItem[], FeedArchiveCounts>();
+
+export function getFeedActionScope(items: readonly FeedItem[]): FeedActionScope {
+  const cached = actionScopeCache.get(items);
+  if (cached) return cached;
+
+  const unreadItemIds: string[] = [];
+  const archivableItemIds: string[] = [];
+
+  for (const item of items) {
+    if (item.userState.hidden || item.userState.archived) continue;
+    if (!item.userState.readAt) {
+      unreadItemIds.push(item.globalId);
+      continue;
+    }
+    if (!item.userState.saved) {
+      archivableItemIds.push(item.globalId);
+    }
+  }
+
+  const scope = {
+    unreadItemIds,
+    archivableItemIds,
+    unreadCount: unreadItemIds.length,
+    archivableCount: archivableItemIds.length,
+  };
+  actionScopeCache.set(items, scope);
+  return scope;
+}
+
+export function getFeedArchiveCounts(items: readonly FeedItem[]): FeedArchiveCounts {
+  const cached = archiveCountsCache.get(items);
+  if (cached) return cached;
+
+  let archivedCount = 0;
+  let savedArchivedCount = 0;
+  for (const item of items) {
+    if (!item.userState.archived) continue;
+    if (item.userState.saved) {
+      savedArchivedCount += 1;
+    } else {
+      archivedCount += 1;
+    }
+  }
+
+  const counts = { archivedCount, savedArchivedCount };
+  archiveCountsCache.set(items, counts);
+  return counts;
+}


### PR DESCRIPTION
(AI Generated).

Summary:
- Cache feed action scope metadata for the header and command field.
- Reuse unread, archivable, and archive counts by filtered item array reference instead of scanning the same feed more than once per render.

Tests:
- PATH=/Users/aubreyfalconer/dev/freed-feed-render-cache/node_modules/.bin:$PATH npm run test:unit -- feed-action-scope.test.ts search-results.test.ts
- PATH=/Users/aubreyfalconer/dev/freed-feed-render-cache/node_modules/.bin:$PATH npm run typecheck
- npm run validate:feature