### PR TITLE
perf: prune orphaned snapshots

### DIFF
--- a/packages/desktop/src/lib/snapshots.test.ts
+++ b/packages/desktop/src/lib/snapshots.test.ts
@@ -37,7 +37,7 @@ vi.mock("./automerge", () => ({
   },
 }));
 
-import { readDir, remove } from "@tauri-apps/plugin-fs";
+import { exists, readDir, remove, writeFile } from "@tauri-apps/plugin-fs";
 import {
   clearSnapshots,
   createSnapshot,
@@ -146,6 +146,20 @@ describe("snapshots", () => {
 
     const snapshots = await listSnapshots();
     expect(snapshots).toHaveLength(24);
+  });
+
+  it("prunes orphaned snapshot files not tracked by the index", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-01T00:00:00Z"));
+    await writeFile("/mock/app-data/snapshots/orphan.automerge", new Uint8Array([9]));
+    await writeFile("/mock/app-data/snapshots/orphan.contacts.json", "{}");
+    await writeFile("/mock/app-data/snapshots/notes.txt", "keep me");
+
+    await createSnapshot("manual");
+
+    expect(await exists("/mock/app-data/snapshots/orphan.automerge")).toBe(false);
+    expect(await exists("/mock/app-data/snapshots/orphan.contacts.json")).toBe(false);
+    expect(await exists("/mock/app-data/snapshots/notes.txt")).toBe(true);
   });
 
   it("creates an initial auto snapshot when the manager starts", async () => {

--- a/packages/desktop/src/lib/snapshots.ts
+++ b/packages/desktop/src/lib/snapshots.ts
@@ -138,6 +138,16 @@ function snapshotContactsPath(root: string, id: string): string {
   return joinPath(root, `${id}.contacts.json`);
 }
 
+function snapshotIdFromFileName(name: string): string | null {
+  if (name.endsWith(".automerge")) {
+    return name.slice(0, -".automerge".length);
+  }
+  if (name.endsWith(".contacts.json")) {
+    return name.slice(0, -".contacts.json".length);
+  }
+  return null;
+}
+
 function normalizeSnapshotList(snapshots: SnapshotSummary[]): SnapshotSummary[] {
   return snapshots
     .slice()
@@ -184,16 +194,27 @@ async function pruneSnapshots(
 ): Promise<SnapshotSummary[]> {
   const keep = normalizeSnapshotList(snapshots);
   const keepIds = new Set(keep.map((snapshot) => snapshot.id));
+  const removals: Promise<unknown>[] = [];
 
   for (const snapshot of snapshots) {
     if (keepIds.has(snapshot.id)) continue;
 
-    await Promise.allSettled([
+    removals.push(
       remove(snapshotBinaryPath(root, snapshot.id)),
       remove(snapshotContactsPath(root, snapshot.id)),
-    ]);
+    );
   }
 
+  const files = await readDir(root).catch(() => []);
+  for (const entry of files) {
+    const name = entry.name;
+    if (!name) continue;
+    const id = snapshotIdFromFileName(name);
+    if (!id || keepIds.has(id)) continue;
+    removals.push(remove(joinPath(root, name)));
+  }
+
+  await Promise.allSettled(removals);
   return keep;
 }
 


### PR DESCRIPTION
(AI Generated).

## Summary
- Prune stale snapshot binaries and contact metadata that are no longer tracked by the local snapshot index, while preserving unrelated files.

## Testing
- npm run validate:feature