### PR TITLE
perf: prune snapshots on startup

### DIFF
--- a/packages/desktop/src/lib/snapshots.test.ts
+++ b/packages/desktop/src/lib/snapshots.test.ts
@@ -162,6 +162,18 @@ describe("snapshots", () => {
     expect(await exists("/mock/app-data/snapshots/notes.txt")).toBe(true);
   });
 
+  it("prunes orphaned snapshot files when snapshots are listed", async () => {
+    await writeFile("/mock/app-data/snapshots/orphan.automerge", new Uint8Array([9]));
+    await writeFile("/mock/app-data/snapshots/orphan.contacts.json", "{}");
+    await writeFile("/mock/app-data/snapshots/notes.txt", "keep me");
+
+    await listSnapshots();
+
+    expect(await exists("/mock/app-data/snapshots/orphan.automerge")).toBe(false);
+    expect(await exists("/mock/app-data/snapshots/orphan.contacts.json")).toBe(false);
+    expect(await exists("/mock/app-data/snapshots/notes.txt")).toBe(true);
+  });
+
   it("creates an initial auto snapshot when the manager starts", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-04-01T15:00:00Z"));

--- a/packages/desktop/src/lib/snapshots.ts
+++ b/packages/desktop/src/lib/snapshots.ts
@@ -227,15 +227,16 @@ export async function listSnapshots(): Promise<SnapshotSummary[]> {
 
   const root = await ensureSnapshotDir();
   const indexed = await readSnapshotIndex();
+  const pruned = await pruneSnapshots(root, indexed);
   const filtered: SnapshotSummary[] = [];
 
-  for (const snapshot of indexed) {
+  for (const snapshot of pruned) {
     if (await exists(snapshotBinaryPath(root, snapshot.id))) {
       filtered.push(snapshot);
     }
   }
 
-  if (filtered.length !== indexed.length) {
+  if (filtered.length !== indexed.length || filtered.length !== pruned.length) {
     await writeSnapshotIndex(filtered);
   }
 


### PR DESCRIPTION
(AI Generated).

## Summary
- Prune stale snapshot binaries and contact metadata when local snapshots are listed, so orphan cleanup runs on startup instead of waiting for the next snapshot write.

## Testing
- npm run validate:feature