### PR TITLE
perf: skip no-op startup hydration

### DIFF
--- a/packages/desktop/src/lib/automerge-worker-memory.test.ts
+++ b/packages/desktop/src/lib/automerge-worker-memory.test.ts
@@ -46,6 +46,24 @@ describe("automerge worker memory routing", () => {
     expect(body).not.toContain("STATE_UPDATE");
   });
 
+  it("last sync persists without rehydrating the full document", () => {
+    const body = caseBody("UPDATE_LAST_SYNC");
+
+    expect(body).toContain("persistAndBroadcastWithoutHydration");
+    expect(body).not.toContain("applyRequestChange");
+    expect(body).not.toContain("saveAndBroadcast");
+  });
+
+  it.each(["HEAL_UNTITLED_FEEDS", "DEDUPLICATE_ITEMS", "PRUNE_ARCHIVED_ITEMS"])(
+    "%s skips full hydration when no records change",
+    (caseName) => {
+      const body = caseBody(caseName);
+
+      expect(body).toContain("applyCountedChange");
+      expect(body).not.toContain("applyRequestChange");
+    },
+  );
+
   it("batches provisional connection repair into one document mutation", () => {
     const body = caseBody("UPSERT_CONNECTION_PERSONS");
 

--- a/packages/desktop/src/lib/automerge.worker.ts
+++ b/packages/desktop/src/lib/automerge.worker.ts
@@ -261,6 +261,22 @@ function unarchiveSavedItemIds(doc: FreedDoc): string[] {
   return changedIds;
 }
 
+function healUntitledFeedTitles(doc: FreedDoc): number {
+  let changed = 0;
+  for (const feed of Object.values(doc.rssFeeds) as RssFeed[]) {
+    const isUntitled = feed.title === "Untitled Feed" || feed.title === feed.url;
+    if (!isUntitled) continue;
+    let healed: string | undefined;
+    try {
+      healed = new URL(feed.url).hostname.replace(/^(?:www|feeds?)\./, "");
+    } catch { /* non-fatal */ }
+    if (!healed || healed === feed.title) continue;
+    feed.title = healed;
+    changed++;
+  }
+  return changed;
+}
+
 /**
  * Convert the Automerge proxy document to a plain-JS DocState for postMessage.
  * Identical to the PWA worker — runs entirely off the main thread.
@@ -459,6 +475,36 @@ async function applyChange(
   if (searchCorpusChanged) bumpSearchCorpusVersion();
   send({ type: "DEBUG_EVENT", kind: "change", detail: message });
   await saveAndBroadcast(trace);
+}
+
+async function applyCountedChange(
+  changeFn: (doc: FreedDoc) => number,
+  message: string,
+  trace?: RequestTrace,
+  searchCorpusChanged = false,
+): Promise<number> {
+  if (!currentDoc) throw new Error("Document not initialized");
+  let changedCount = 0;
+  currentDoc = A.change(currentDoc, message, (doc) => {
+    changedCount = changeFn(doc);
+  });
+
+  if (changedCount === 0) {
+    emitWorkerTrace(
+      `[automerge-worker] skip op=${trace?.opType ?? "unknown"} reason=no_changes`,
+      "change",
+    );
+    return changedCount;
+  }
+
+  if (searchCorpusChanged) bumpSearchCorpusVersion();
+  send({
+    type: "DEBUG_EVENT",
+    kind: "change",
+    detail: `${message}: ${changedCount.toLocaleString()} changed`,
+  });
+  await saveAndBroadcast(trace);
+  return changedCount;
 }
 
 async function applyItemPatchChange(
@@ -733,9 +779,10 @@ async function handleRequest(
         break;
 
       case "PRUNE_ARCHIVED_ITEMS":
-        await applyRequestChange(
+        await applyCountedChange(
           (doc) => pruneArchivedItems(doc, req.maxAgeMs),
           "Prune archived items",
+          trace,
           true,
         );
         ack(req.reqId);
@@ -791,7 +838,12 @@ async function handleRequest(
         break;
 
       case "UPDATE_LAST_SYNC":
-        await applyRequestChange((doc) => updateLastSync(doc), "Update last sync");
+        if (!currentDoc) throw new Error("Document not initialized");
+        currentDoc = A.change(currentDoc, "Update last sync", (doc) => {
+          updateLastSync(doc);
+        });
+        send({ type: "DEBUG_EVENT", kind: "change", detail: "Update last sync" });
+        await persistAndBroadcastWithoutHydration(trace);
         ack(req.reqId);
         break;
 
@@ -921,22 +973,22 @@ async function handleRequest(
       }
 
       case "HEAL_UNTITLED_FEEDS":
-        await applyRequestChange((doc) => {
-          for (const feed of Object.values(doc.rssFeeds) as RssFeed[]) {
-            const isUntitled = feed.title === "Untitled Feed" || feed.title === feed.url;
-            if (!isUntitled) continue;
-            let healed: string | undefined;
-            try { healed = new URL(feed.url).hostname.replace(/^(?:www|feeds?)\./, ""); } catch { /* */ }
-            if (healed) feed.title = healed;
-          }
-        }, "Heal untitled feed titles from URL hostname", true);
+        await applyCountedChange(
+          healUntitledFeedTitles,
+          "Heal untitled feed titles from URL hostname",
+          trace,
+          true,
+        );
         ack(req.reqId);
         break;
 
       case "DEDUPLICATE_ITEMS":
-        await applyRequestChange((doc) => {
-          deduplicateDocFeedItems(doc);
-        }, "Deduplicate feed items by article link URL and linked social cross-posts", true);
+        await applyCountedChange(
+          deduplicateDocFeedItems,
+          "Deduplicate feed items by article link URL and linked social cross-posts",
+          trace,
+          true,
+        );
         ack(req.reqId);
         break;
 


### PR DESCRIPTION
(AI Generated).

## Summary
- Avoid full document hydration when startup maintenance finds no feed titles, duplicates, or archived items to change, and persist last-sync updates without broadcasting a full state snapshot.

## Testing
- npm run validate:feature