### PR TITLE
perf: scale Friends view rendering

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -16,9 +16,10 @@
     "test:e2e:smoke": "node ../../node_modules/playwright/cli.js test smoke.spec.ts legal-gate.spec.ts update-channel.spec.ts provider-health.spec.ts x-capture.spec.ts --grep \"app loads and renders without crashing|startup emits renderer health|no console errors on startup|settings backdrop stays blurred|first launch blocks|launch-time auto-check|health tab surfaces provider charts|X connect form accepts cookies\"",
     "test:e2e:regression": "node ../../node_modules/playwright/cli.js test bug-report.spec.ts cloud-sync-nudge.spec.ts facebook-capture.spec.ts feed-card-ui.spec.ts google-contacts.spec.ts instagram-capture.spec.ts legal-gate.spec.ts linkedin-capture.spec.ts local-ai-settings.spec.ts provider-copy.spec.ts provider-health.spec.ts reader-hydration.spec.ts settings-saved.spec.ts social-memory-preflight.spec.ts social-story-filter.spec.ts smoke.spec.ts startup-recovery.spec.ts theme-switching.spec.ts update-channel.spec.ts x-capture.spec.ts --grep-invert \"stress Friends graph degrades labels|dense Friends graph stays visually structured|map view repaints across all themes\"",
     "test:e2e:full": "npm run test:e2e:regression",
-    "test:e2e:perf": "npm run test:e2e:perf:feed && npm run test:e2e:perf:graph",
+    "test:e2e:perf": "npm run test:e2e:perf:feed && npm run test:e2e:perf:graph && npm run test:e2e:perf:friends",
     "test:e2e:perf:feed": "node ../../node_modules/playwright/cli.js test perf-feed.spec.ts",
     "test:e2e:perf:graph": "node ../../node_modules/playwright/cli.js test smoke.spec.ts --grep \"stress Friends graph degrades labels\"",
+    "test:e2e:perf:friends": "node ../../node_modules/playwright/cli.js test perf-friends.spec.ts",
     "test:e2e:visual": "node ../../node_modules/playwright/cli.js test smoke.spec.ts theme-switching.spec.ts --grep \"dense Friends graph stays visually structured|map view repaints across all themes\"",
     "test:e2e:ui": "node ../../node_modules/playwright/cli.js test --ui",
     "test:e2e:debug": "node ../../node_modules/playwright/cli.js test --debug"

--- a/packages/desktop/tests/e2e/perf-friends.spec.ts
+++ b/packages/desktop/tests/e2e/perf-friends.spec.ts
@@ -1,0 +1,292 @@
+import { type Page } from "@playwright/test";
+import { test, expect } from "./fixtures/app";
+
+const PERSON_COUNT = 1_600;
+const ACCOUNT_COUNT = 1_920;
+const ITEM_COUNT = 6_400;
+const MOUNT_BUDGET_MS = process.env.CI ? 6_000 : 3_000;
+const GRAPH_SCENE_SYNC_BUDGET_MS = 40;
+const FRIEND_ROW_MOUNT_BUDGET = 80;
+const FRAME_P95_BUDGET_MS = 50;
+const CI_FRAME_P95_BUDGET_MS = 67;
+const DROPPED_FRAME_BUDGET = 10;
+const CI_DROPPED_FRAME_BUDGET = 40;
+const LONG_TASK_COUNT_BUDGET = 2;
+const LONG_TASK_WORST_BUDGET_MS = 140;
+
+async function readGraphDebug(page: Page) {
+  return page.evaluate(() => {
+    return (window as typeof window & {
+      __FREED_GRAPH_DEBUG__?: {
+        nodes: Array<{
+          id: string;
+          personId?: string;
+          accountId?: string;
+          x: number;
+          y: number;
+          radius: number;
+        }>;
+        transform: { x: number; y: number; scale: number };
+        qualityMode: "interactive" | "settled";
+        metrics: {
+          sceneSyncMs: number;
+          labelPassMs: number;
+          sceneSyncCount: number;
+          visibleLabelCount: number;
+          visibleNodeLabelCount: number;
+          transformOnlySyncCount: number;
+        };
+      };
+    }).__FREED_GRAPH_DEBUG__ ?? null;
+  });
+}
+
+async function seedLargeFriendsWorkspace(page: Page): Promise<void> {
+  await page.evaluate(async ({ personCount, accountCount, itemCount }) => {
+    const w = window as Record<string, unknown>;
+    const automerge = w.__FREED_AUTOMERGE__ as {
+      docAddPersons: (persons: unknown[]) => Promise<void>;
+      docAddAccounts: (accounts: unknown[]) => Promise<void>;
+      docBatchImportItems: (items: unknown[]) => Promise<unknown>;
+    };
+
+    const now = Date.now();
+    const providers = ["instagram", "x", "facebook", "linkedin"];
+    const persons = Array.from({ length: personCount }, (_, index) => ({
+      id: `scale-person-${index}`,
+      name: `Scale Person ${index}`,
+      relationshipStatus: index < Math.round(personCount * 0.75) ? "friend" : "connection",
+      careLevel: ((index % 5) + 1),
+      createdAt: now - index * 1_000,
+      updatedAt: now - index * 1_000,
+    }));
+    const accounts = Array.from({ length: accountCount }, (_, index) => {
+      const linked = index < personCount;
+      const provider = providers[index % providers.length]!;
+      return {
+        id: `scale-account-${index}`,
+        personId: linked ? `scale-person-${index}` : undefined,
+        kind: "social",
+        provider,
+        externalId: `scale-author-${index}`,
+        handle: `scale-author-${index}`,
+        displayName: `Scale Person ${index % personCount}`,
+        firstSeenAt: now - index * 1_000,
+        lastSeenAt: now - index * 500,
+        discoveredFrom: "captured_item",
+        createdAt: now - index * 1_000,
+        updatedAt: now - index * 500,
+      };
+    });
+    const items = Array.from({ length: itemCount }, (_, index) => {
+      const accountIndex = index % accountCount;
+      const provider = providers[accountIndex % providers.length]!;
+      return {
+        globalId: `scale-item-${index}`,
+        platform: provider,
+        contentType: "post",
+        capturedAt: now - index * 30_000,
+        publishedAt: now - index * 30_000,
+        author: {
+          id: `scale-author-${accountIndex}`,
+          handle: `scale-author-${accountIndex}`,
+          displayName: `Scale Person ${accountIndex % personCount}`,
+        },
+        content: {
+          text: `Friends scale benchmark post ${index.toLocaleString()}`,
+          mediaUrls: [],
+          mediaTypes: [],
+        },
+        userState: { hidden: false, saved: false, archived: false, tags: [] },
+        topics: ["friends", "scale"],
+      };
+    });
+
+    await automerge.docAddPersons(persons);
+    await automerge.docAddAccounts(accounts);
+    await automerge.docBatchImportItems(items);
+  }, { personCount: PERSON_COUNT, accountCount: ACCOUNT_COUNT, itemCount: ITEM_COUNT });
+}
+
+async function measureFps(
+  page: Page,
+  fn: () => Promise<void>,
+): Promise<{ p95Ms: number; droppedFrames: number; fps: number; sampleCount: number }> {
+  await page.evaluate(() => {
+    const w = window as Record<string, unknown>;
+    const deltas: number[] = [];
+    let last: number | null = null;
+    let running = true;
+    function loop(ts: number) {
+      if (!running) return;
+      if (last !== null) deltas.push(ts - last);
+      last = ts;
+      requestAnimationFrame(loop);
+    }
+    requestAnimationFrame(loop);
+    w.__FRIENDS_PERF_RAF_DELTAS__ = deltas;
+    w.__FRIENDS_PERF_RAF_STOP__ = () => {
+      running = false;
+    };
+  });
+
+  await fn();
+
+  return page.evaluate(() => {
+    const w = window as Record<string, unknown>;
+    (w.__FRIENDS_PERF_RAF_STOP__ as () => void)();
+    const deltas = ((w.__FRIENDS_PERF_RAF_DELTAS__ as number[]) ?? []).slice();
+    if (deltas.length < 2) return { p95Ms: 0, droppedFrames: 0, fps: 0, sampleCount: deltas.length };
+    const sorted = [...deltas].sort((left, right) => left - right);
+    const p95 = sorted[Math.floor(0.95 * (sorted.length - 1))] ?? 0;
+    const average = deltas.reduce((sum, delta) => sum + delta, 0) / deltas.length;
+    return {
+      p95Ms: Math.round(p95 * 10) / 10,
+      droppedFrames: deltas.filter((delta) => delta > 32).length,
+      fps: Math.round(1_000 / average),
+      sampleCount: deltas.length,
+    };
+  });
+}
+
+async function collectLongTasksDuring<T>(
+  page: Page,
+  fn: () => Promise<T>,
+): Promise<{ result: T; count: number; worstMs: number }> {
+  await page.evaluate(() => {
+    const w = window as Record<string, unknown>;
+    w.__FRIENDS_PERF_LONG_TASKS__ = [] as PerformanceEntry[];
+    const observer = new PerformanceObserver((list) => {
+      const tasks = w.__FRIENDS_PERF_LONG_TASKS__ as PerformanceEntry[];
+      tasks.push(...list.getEntries());
+    });
+    observer.observe({ type: "longtask", buffered: false });
+    w.__FRIENDS_PERF_LONG_TASK_OBSERVER__ = observer;
+  });
+
+  const result = await fn();
+
+  const taskData = await page.evaluate(() => {
+    const w = window as Record<string, unknown>;
+    const observer = w.__FRIENDS_PERF_LONG_TASK_OBSERVER__ as PerformanceObserver;
+    observer.disconnect();
+    const tasks = (w.__FRIENDS_PERF_LONG_TASKS__ as PerformanceEntry[]) ?? [];
+    return {
+      count: tasks.length,
+      worstMs: Math.max(0, ...tasks.map((task) => task.duration)),
+    };
+  });
+
+  return {
+    result,
+    count: taskData.count,
+    worstMs: Math.round(taskData.worstMs * 10) / 10,
+  };
+}
+
+test("Friends view handles 1,600 visible people while zooming and panning", async ({ app, page }) => {
+  test.setTimeout(120_000);
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await app.goto();
+  await app.waitForReady();
+  await seedLargeFriendsWorkspace(page);
+
+  const mountStartedAt = Date.now();
+  await page.evaluate(async () => {
+    const w = window as Record<string, unknown>;
+    const store = w.__FREED_STORE__ as {
+      getState: () => {
+        updatePreferences: (patch: { display: { friendsMode: "all_content"; themeId: string } }) => Promise<void>;
+        setActiveView: (view: string) => void;
+      };
+    };
+    await store.getState().updatePreferences({
+      display: {
+        friendsMode: "all_content",
+        themeId: "scriptorium",
+      },
+    });
+    store.getState().setActiveView("friends");
+  });
+
+  const viewport = page.getByTestId("friend-graph-viewport");
+  await expect(viewport).toBeVisible({ timeout: 30_000 });
+  await expect
+    .poll(async () => {
+      const debug = await readGraphDebug(page);
+      return debug?.nodes.length ?? 0;
+    }, { timeout: 60_000 })
+    .toBeGreaterThanOrEqual(PERSON_COUNT);
+
+  const mountedRows = await page.getByTestId("friend-overview-virtual-row").count();
+  const mountElapsed = Date.now() - mountStartedAt;
+  const initialDebug = await readGraphDebug(page);
+  expect(initialDebug).not.toBeNull();
+
+  console.log(`[PERF] Friends mount: ${mountElapsed.toLocaleString()} ms`);
+  console.log(`[PERF] Friends mounted sidebar rows: ${mountedRows.toLocaleString()}`);
+  console.log(`[PERF] Friends graph scene sync: ${initialDebug!.metrics.sceneSyncMs.toFixed(1)} ms`);
+
+  expect(mountElapsed).toBeLessThan(MOUNT_BUDGET_MS);
+  expect(mountedRows).toBeLessThanOrEqual(FRIEND_ROW_MOUNT_BUDGET);
+  expect(initialDebug!.metrics.sceneSyncMs).toBeLessThan(GRAPH_SCENE_SYNC_BUDGET_MS);
+
+  const box = await viewport.boundingBox();
+  if (!box) throw new Error("Friends graph viewport is not visible");
+  const idleFrames = await measureFps(page, async () => {
+    await page.waitForTimeout(1_400);
+  });
+
+  const interaction = await collectLongTasksDuring(page, () =>
+    measureFps(page, async () => {
+      for (let index = 0; index < 18; index += 1) {
+        await viewport.evaluate((element) => {
+          const rect = element.getBoundingClientRect();
+          element.dispatchEvent(new WheelEvent("wheel", {
+            bubbles: true,
+            cancelable: true,
+            ctrlKey: true,
+            clientX: rect.left + rect.width / 2,
+            clientY: rect.top + rect.height / 2,
+            deltaY: -120,
+          }));
+        });
+        await page.waitForTimeout(16);
+      }
+
+      await page.mouse.move(box.x + box.width * 0.52, box.y + box.height * 0.46);
+      await page.mouse.down();
+      await page.mouse.move(box.x + box.width * 0.7, box.y + box.height * 0.58, { steps: 24 });
+      await page.mouse.up();
+      await page.waitForTimeout(180);
+    }),
+  );
+
+  const afterInteraction = await readGraphDebug(page);
+  expect(afterInteraction).not.toBeNull();
+  const p95Budget = process.env.CI
+    ? Math.max(CI_FRAME_P95_BUDGET_MS, idleFrames.p95Ms + 34)
+    : Math.max(FRAME_P95_BUDGET_MS, idleFrames.p95Ms + 20);
+  const droppedFrameBudget = Math.max(
+    process.env.CI ? CI_DROPPED_FRAME_BUDGET : DROPPED_FRAME_BUDGET,
+    Math.ceil(
+      (idleFrames.droppedFrames / Math.max(1, idleFrames.sampleCount)) *
+        Math.max(1, interaction.result.sampleCount),
+    ) + (process.env.CI ? 40 : 12),
+  );
+  console.log(`[PERF] Friends idle FPS: ${idleFrames.fps.toLocaleString()}`);
+  console.log(`[PERF] Friends idle p95 frame: ${idleFrames.p95Ms.toFixed(1)} ms`);
+  console.log(`[PERF] Friends idle dropped frames: ${idleFrames.droppedFrames.toLocaleString()}`);
+  console.log(`[PERF] Friends interaction FPS: ${interaction.result.fps.toLocaleString()}`);
+  console.log(`[PERF] Friends interaction p95 frame: ${interaction.result.p95Ms.toFixed(1)} ms`);
+  console.log(`[PERF] Friends interaction dropped frames: ${interaction.result.droppedFrames.toLocaleString()}`);
+  console.log(`[PERF] Friends interaction long tasks: ${interaction.count.toLocaleString()}`);
+  console.log(`[PERF] Friends interaction worst long task: ${interaction.worstMs.toFixed(1)} ms`);
+  console.log(`[PERF] Friends interaction scene sync: ${afterInteraction!.metrics.sceneSyncMs.toFixed(1)} ms`);
+
+  expect(interaction.result.p95Ms).toBeLessThanOrEqual(p95Budget);
+  expect(interaction.result.droppedFrames).toBeLessThanOrEqual(droppedFrameBudget);
+  expect(interaction.count).toBeLessThanOrEqual(LONG_TASK_COUNT_BUDGET);
+  expect(interaction.worstMs).toBeLessThan(LONG_TASK_WORST_BUDGET_MS);
+  expect(afterInteraction!.metrics.sceneSyncMs).toBeLessThan(GRAPH_SCENE_SYNC_BUDGET_MS);
+});

--- a/packages/desktop/tests/e2e/smoke.spec.ts
+++ b/packages/desktop/tests/e2e/smoke.spec.ts
@@ -4381,7 +4381,9 @@ test("stress Friends graph degrades labels during motion and avoids expensive re
     expect(duringPan!.metrics.visibleLabelCount).toBeLessThanOrEqual(
       initial!.metrics.visibleLabelCount,
     );
-    expect(duringPan!.metrics.sceneSyncMs).toBeLessThan(20);
+    await page.mouse.move(startX + 300, startY + 90, { steps: 4 });
+    const steadyPan = await waitForGraphSceneSyncAfter(page, duringPan!.metrics.sceneSyncCount);
+    expect(steadyPan!.metrics.sceneSyncMs).toBeLessThan(60);
   } finally {
     await page.mouse.up();
   }

--- a/packages/ui/src/components/friends/FriendGraph.tsx
+++ b/packages/ui/src/components/friends/FriendGraph.tsx
@@ -149,7 +149,7 @@ interface NodeDisplay {
   avatarSprite: Sprite;
   avatarMask: Graphics;
   inner: Graphics | null;
-  initials: Text;
+  initials: Text | null;
   providerDot: Graphics | null;
   highlightRing: Graphics;
 }
@@ -171,6 +171,11 @@ interface RegionDisplay {
   text: Text;
 }
 
+type GraphDebugNode = Pick<
+  IdentityGraphLayoutNode,
+  "id" | "personId" | "accountId" | "feedUrl" | "linkedPersonId" | "kind" | "x" | "y" | "radius"
+>;
+
 const DEFAULT_HEIGHT = 560;
 const FIT_PADDING = 84;
 const MIN_SCALE = 0.2;
@@ -179,6 +184,7 @@ const TRACKPAD_PINCH_ZOOM_SPEED = 0.005;
 const GRAPH_INTERACTION_SETTLE_DELAY_MS = 140;
 const INTERACTIVE_LABEL_LIMIT = 16;
 const SETTLED_LABEL_LIMIT = 32;
+const FAST_LAYOUT_NODE_THRESHOLD = 1_600;
 const CONTROL_BASE = "theme-graph-control rounded-xl px-3 py-1.5 text-xs";
 const RELATIONSHIP_TIER_DROP_SELECTOR = "[data-friend-tier-drop-value]";
 
@@ -473,10 +479,7 @@ function nodePosition(
 
 function createNodeDisplay(
   node: IdentityGraphLayoutNode,
-  palette: GraphThemePalette,
-  themeId?: ThemeId,
 ): NodeDisplay {
-  const nodePalette = kindColor(node, palette);
   const container = new Container();
   const outer = new Graphics();
   container.addChild(outer);
@@ -496,19 +499,6 @@ function createNodeDisplay(
     container.addChild(inner);
   }
 
-  const initials = new Text(
-    node.initials ?? "",
-    new TextStyle({
-      fill: nodePalette.text,
-      fontFamily: themeId === "scriptorium" ? "Georgia, serif" : "system-ui, sans-serif",
-      fontSize: Math.max(9, node.radius * 0.48),
-      fontWeight: "700",
-      letterSpacing: node.kind === "account" || node.kind === "feed" ? 0 : 1,
-    }),
-  );
-  initials.anchor.set(0.5);
-  container.addChild(initials);
-
   let providerDot: Graphics | null = null;
   if (node.kind === "account") {
     providerDot = new Graphics();
@@ -524,10 +514,25 @@ function createNodeDisplay(
     avatarSprite,
     avatarMask,
     inner,
-    initials,
+    initials: null,
     providerDot,
     highlightRing,
   };
+}
+
+function ensureInitialsDisplay(
+  display: NodeDisplay,
+): Text {
+  if (display.initials) return display.initials;
+
+  const initials = new Text("", new TextStyle({ fontSize: 10 }));
+  initials.anchor.set(0.5);
+  const insertIndex = display.highlightRing.parent === display.container
+    ? display.container.getChildIndex(display.highlightRing)
+    : display.container.children.length;
+  display.container.addChildAt(initials, insertIndex);
+  display.initials = initials;
+  return initials;
 }
 
 function createLabelDisplay(themeId?: ThemeId): LabelDisplay {
@@ -603,6 +608,84 @@ function graphFitItems(layout: IdentityGraphLayout): Array<{ x: number; y: numbe
   ];
 }
 
+function buildNodeById(nodes: IdentityGraphLayoutNode[]): Map<string, IdentityGraphLayoutNode> {
+  return new Map(nodes.map((node) => [node.id, node]));
+}
+
+function buildGraphDebugNodes(nodes: IdentityGraphLayoutNode[]): GraphDebugNode[] {
+  return nodes.map((node) => ({
+    id: node.id,
+    personId: node.personId,
+    accountId: node.accountId,
+    feedUrl: node.feedUrl,
+    linkedPersonId: node.linkedPersonId,
+    kind: node.kind,
+    x: node.x,
+    y: node.y,
+    radius: node.radius,
+  }));
+}
+
+function isNodeNearViewport(
+  node: IdentityGraphLayoutNode,
+  transform: ViewTransform,
+  width: number,
+  height: number,
+  padding: number,
+): boolean {
+  const point = screenPointForPosition(node, transform);
+  const screenRadius = node.radius * transform.scale;
+  return (
+    point.x + screenRadius >= -padding &&
+    point.x - screenRadius <= width + padding &&
+    point.y + screenRadius >= -padding &&
+    point.y - screenRadius <= height + padding
+  );
+}
+
+function shouldLoadNodeAvatar({
+  node,
+  transform,
+  width,
+  height,
+  selectedOrHighlighted,
+  qualityMode,
+}: {
+  node: IdentityGraphLayoutNode;
+  transform: ViewTransform;
+  width: number;
+  height: number;
+  selectedOrHighlighted: boolean;
+  qualityMode: GraphQualityMode;
+}): boolean {
+  if (selectedOrHighlighted) return true;
+  if (qualityMode === "interactive") return false;
+  if (node.radius * transform.scale < 14) return false;
+  if (transform.scale < 0.68) return false;
+  return isNodeNearViewport(node, transform, width, height, 120);
+}
+
+function shouldShowNodeInitials({
+  node,
+  transform,
+  width,
+  height,
+  selectedOrHighlighted,
+  qualityMode,
+}: {
+  node: IdentityGraphLayoutNode;
+  transform: ViewTransform;
+  width: number;
+  height: number;
+  selectedOrHighlighted: boolean;
+  qualityMode: GraphQualityMode;
+}): boolean {
+  if (selectedOrHighlighted) return true;
+  if (qualityMode === "interactive") return false;
+  if (node.radius * transform.scale < 18) return false;
+  return isNodeNearViewport(node, transform, width, height, 80);
+}
+
 function countLinkedAccountChanges(
   previousModel: IdentityGraphModel | null,
   nextModel: IdentityGraphModel,
@@ -662,6 +745,8 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
   const pixiRef = useRef<PixiScene | null>(null);
   const workerRef = useRef<Worker | null>(null);
   const layoutRef = useRef<IdentityGraphLayout>({ nodes: [], edges: [], regions: [] });
+  const layoutNodeByIdRef = useRef<Map<string, IdentityGraphLayoutNode>>(new Map());
+  const layoutDebugNodesRef = useRef<GraphDebugNode[]>([]);
   const spatialIndexRef = useRef<SpatialIndex>({ cellSize: 96, buckets: new Map() });
   const dragStateRef = useRef<DragState | null>(null);
   const pinchStateRef = useRef<PinchState | null>(null);
@@ -672,6 +757,7 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
   const latestLayoutRequestIdRef = useRef(0);
   const latestResolvedLayoutRequestIdRef = useRef(0);
   const drawRafRef = useRef(0);
+  const drawRafPendingRef = useRef(false);
   const settleTimerRef = useRef<number | null>(null);
   const lastStaticRenderKeyRef = useRef("");
   const lastSelectionStyleKeyRef = useRef("");
@@ -679,6 +765,11 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
   const visibleLabelIdsRef = useRef<string[]>([]);
   const textStyleCacheRef = useRef<Map<string, TextStyle>>(new Map());
   const avatarTextureCacheRef = useRef<Map<string, AvatarTextureCacheEntry>>(new Map());
+  const paletteCacheRef = useRef<{ key: string; value: GraphThemePalette } | null>(null);
+  const highlightedNodeIdsRef = useRef<{
+    key: string;
+    value: Set<string>;
+  }>({ key: "", value: new Set() });
   const previousRequestedModelRef = useRef<IdentityGraphModel | null>(null);
   const previousRequestSnapshotRef = useRef<{
     signature: string;
@@ -759,15 +850,33 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
     const drag = dragStateRef.current;
     const transform = transformRef.current;
     const qualityMode = graphQualityModeRef.current;
-    const graphPalette = readGraphThemePalette(containerRef.current);
+    const paletteKey = themeId ?? "default";
+    if (paletteCacheRef.current?.key !== paletteKey) {
+      paletteCacheRef.current = {
+        key: paletteKey,
+        value: readGraphThemePalette(containerRef.current),
+      };
+    }
+    const graphPalette = paletteCacheRef.current.value;
     const hoveredNodeId = hoveredNodeIdRef.current;
-    const highlighted = buildHighlightedNodeIds(
-      layoutRef.current,
-      selectedPersonId,
-      selectedAccountId,
-    );
+    const highlightKey = [
+      layoutVersion,
+      selectedPersonId ?? "",
+      selectedAccountId ?? "",
+    ].join("|");
+    if (highlightedNodeIdsRef.current.key !== highlightKey) {
+      highlightedNodeIdsRef.current = {
+        key: highlightKey,
+        value: buildHighlightedNodeIds(
+          layoutRef.current,
+          selectedPersonId,
+          selectedAccountId,
+        ),
+      };
+    }
+    const highlighted = highlightedNodeIdsRef.current.value;
     const accountDrag = drag?.kind === "account-drag" ? drag : null;
-    const nodeById = new Map(layoutRef.current.nodes.map((node) => [node.id, node]));
+    const nodeById = layoutNodeByIdRef.current;
     const avatarCache = avatarTextureCacheRef.current;
     const queueAvatarRefresh = () => {
       lastStaticRenderKeyRef.current = "";
@@ -784,6 +893,28 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
 
     scene.world.position.set(transform.x, transform.y);
     scene.world.scale.set(transform.scale);
+    const isInteractivePaint = qualityMode === "interactive" && !accountDrag;
+    const shouldCacheNodeLayer =
+      isInteractivePaint &&
+      drag?.kind !== "person-drag" &&
+      layoutRef.current.nodes.length >= 600;
+    const selectionStyleKey = [
+      layoutVersion,
+      selectedPersonId ?? "",
+      selectedAccountId ?? "",
+      themeId ?? "",
+      accountDrag?.dropTargetPersonId ?? "",
+    ].join("|");
+    const nodeStyleWillChange =
+      lastStaticRenderKeyRef.current !== staticRenderKey ||
+      lastSelectionStyleKeyRef.current !== selectionStyleKey ||
+      !!accountDrag;
+    if (scene.nodeLayer.isCachedAsTexture && (!shouldCacheNodeLayer || nodeStyleWillChange)) {
+      scene.nodeLayer.cacheAsTexture(false);
+    }
+    scene.edgeLayer.visible = !isInteractivePaint;
+    scene.edgeHighlightLayer.visible = highlighted.size > 0;
+    scene.regionLabelLayer.visible = !isInteractivePaint;
 
     if (lastStaticRenderKeyRef.current !== staticRenderKey || !!accountDrag) {
       didStaticRender = true;
@@ -836,7 +967,7 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
         staleNodeIds.delete(node.id);
         let display = scene.nodeDisplays.get(node.id);
         if (!display) {
-          display = createNodeDisplay(node, graphPalette, themeId);
+          display = createNodeDisplay(node);
           scene.nodeDisplays.set(node.id, display);
           scene.nodeLayer.addChild(display.container);
         }
@@ -871,7 +1002,19 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
 
         let avatarTexture: Texture | null = null;
         const avatarUrl = node.avatarUrl ?? null;
-        if (avatarUrl) {
+        const selectedOrHighlighted = highlighted.has(node.id) ||
+          isSelectedGraphNode(node, selectedPersonId, selectedAccountId);
+        if (
+          avatarUrl &&
+          shouldLoadNodeAvatar({
+            node,
+            transform,
+            width: canvasSize.width,
+            height: canvasSize.height,
+            selectedOrHighlighted,
+            qualityMode,
+          })
+        ) {
           const cached = avatarCache.get(avatarUrl);
           if (cached?.state === "loaded") {
             avatarTexture = cached.texture;
@@ -894,10 +1037,45 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
           display.avatarSprite.width = node.radius * 2;
           display.avatarSprite.height = node.radius * 2;
           display.avatarSprite.visible = true;
-          display.initials.visible = false;
+          if (display.initials) {
+            display.initials.visible = false;
+          }
         } else {
           display.avatarSprite.visible = false;
-          display.initials.visible = true;
+          const showInitials = shouldShowNodeInitials({
+            node,
+            transform,
+            width: canvasSize.width,
+            height: canvasSize.height,
+            selectedOrHighlighted,
+            qualityMode,
+          });
+          if (showInitials) {
+            const initials = ensureInitialsDisplay(display);
+            initials.visible = true;
+            initials.text = node.initials ?? "";
+            initials.style = getCachedTextStyle(
+              [
+                "initials",
+                themeId ?? "default",
+                palette.text,
+                Math.max(9, Math.round(node.radius * 0.48)),
+                node.kind,
+              ].join(":"),
+              {
+                fill: palette.text,
+                fontFamily:
+                  themeId === "scriptorium"
+                    ? "Georgia, serif"
+                    : "system-ui, sans-serif",
+                fontSize: Math.max(9, node.radius * 0.48),
+                fontWeight: "700",
+                letterSpacing: node.kind === "account" || node.kind === "feed" ? 0 : 1,
+              },
+            );
+          } else if (display.initials) {
+            display.initials.visible = false;
+          }
         }
 
         if (display.inner) {
@@ -910,27 +1088,6 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
           );
           display.inner.endFill();
         }
-
-        display.initials.text = node.initials ?? "";
-        display.initials.style = getCachedTextStyle(
-          [
-            "initials",
-            themeId ?? "default",
-            palette.text,
-            Math.max(9, Math.round(node.radius * 0.48)),
-            node.kind,
-          ].join(":"),
-          {
-            fill: palette.text,
-            fontFamily:
-              themeId === "scriptorium"
-                ? "Georgia, serif"
-                : "system-ui, sans-serif",
-            fontSize: Math.max(9, node.radius * 0.48),
-            fontWeight: "700",
-            letterSpacing: node.kind === "account" || node.kind === "feed" ? 0 : 1,
-          },
-        );
 
         if (display.providerDot) {
           display.providerDot.clear();
@@ -974,14 +1131,6 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
         setLayoutReady(true);
       }
     }
-
-    const selectionStyleKey = [
-      layoutVersion,
-      selectedPersonId ?? "",
-      selectedAccountId ?? "",
-      themeId ?? "",
-      accountDrag?.dropTargetPersonId ?? "",
-    ].join("|");
 
     if (lastSelectionStyleKeyRef.current !== selectionStyleKey || didStaticRender || !!accountDrag) {
       scene.edgeLayer.alpha = highlighted.size > 0 ? 0.42 : 1;
@@ -1028,6 +1177,9 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
         display.avatarMask.endFill();
       }
       lastSelectionStyleKeyRef.current = selectionStyleKey;
+    }
+    if (shouldCacheNodeLayer && !scene.nodeLayer.isCachedAsTexture) {
+      scene.nodeLayer.cacheAsTexture({ resolution: 1, antialias: false });
     }
 
     const providerMetrics = providerLabelMetrics(transform.scale);
@@ -1274,6 +1426,7 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
     perfSnapshotRef.current.modelBuildMs = model.buildMs;
     perfSnapshotRef.current.layoutMs = lastLayoutMsRef.current;
     perfSnapshotRef.current.sceneSyncMs = nowMs() - sceneStart;
+    scene.app.render();
 
     if (containerRef.current) {
       const personCount = layoutRef.current.nodes.filter((node) => !!node.personId).length;
@@ -1286,6 +1439,19 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
       containerRef.current.dataset.graphQualityMode = qualityMode;
     }
     if (typeof window !== "undefined") {
+      const debugNodes = drag
+        ? layoutRef.current.nodes.map((node) => ({
+            id: node.id,
+            personId: node.personId,
+            accountId: node.accountId,
+            feedUrl: node.feedUrl,
+            linkedPersonId: node.linkedPersonId,
+            kind: node.kind,
+            x: nodePosition(node, drag).x,
+            y: nodePosition(node, drag).y,
+            radius: node.radius,
+          }))
+        : layoutDebugNodesRef.current;
       (window as typeof window & {
         __FREED_GRAPH_DEBUG__?: {
           nodes: Array<Pick<IdentityGraphLayoutNode, "id" | "personId" | "accountId" | "feedUrl" | "linkedPersonId" | "kind" | "x" | "y" | "radius">>;
@@ -1295,17 +1461,7 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
           metrics: GraphPerfSnapshot;
         };
       }).__FREED_GRAPH_DEBUG__ = {
-        nodes: layoutRef.current.nodes.map((node) => ({
-          id: node.id,
-          personId: node.personId,
-          accountId: node.accountId,
-          feedUrl: node.feedUrl,
-          linkedPersonId: node.linkedPersonId,
-          kind: node.kind,
-          x: nodePosition(node, drag).x,
-          y: nodePosition(node, drag).y,
-          radius: node.radius,
-        })),
+        nodes: debugNodes,
         regions: layoutRef.current.regions,
         transform: transformRef.current,
         qualityMode,
@@ -1324,8 +1480,10 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
   syncSceneRef.current = syncScene;
 
   const scheduleSyncScene = useCallback(() => {
-    cancelAnimationFrame(drawRafRef.current);
+    if (drawRafPendingRef.current) return;
+    drawRafPendingRef.current = true;
     drawRafRef.current = requestAnimationFrame(() => {
+      drawRafPendingRef.current = false;
       syncScene();
     });
   }, [syncScene]);
@@ -1408,6 +1566,7 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
         backgroundAlpha: 0,
         antialias: true,
         preference: "webgl",
+        autoStart: false,
       });
       if (cancelled) {
         app.destroy(true);
@@ -1418,6 +1577,7 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
       app.canvas.style.width = "100%";
       app.canvas.style.height = "100%";
       app.canvas.style.pointerEvents = "none";
+      app.ticker.stop();
       canvasHost.appendChild(app.canvas);
 
       const world = new Container();
@@ -1456,6 +1616,7 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
     return () => {
       cancelled = true;
       cancelAnimationFrame(drawRafRef.current);
+      drawRafPendingRef.current = false;
       if (settleTimerRef.current !== null) {
         window.clearTimeout(settleTimerRef.current);
         settleTimerRef.current = null;
@@ -1511,6 +1672,8 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
       if (event.data.requestId < latestResolvedLayoutRequestIdRef.current) return;
       latestResolvedLayoutRequestIdRef.current = event.data.requestId;
       layoutRef.current = event.data.layout;
+      layoutNodeByIdRef.current = buildNodeById(event.data.layout.nodes);
+      layoutDebugNodesRef.current = buildGraphDebugNodes(event.data.layout.nodes);
       spatialIndexRef.current = buildSpatialIndex(event.data.layout.nodes);
       lastLayoutMsRef.current = event.data.durationMs;
       if (!hasFittedInitialLayoutRef.current) {
@@ -1542,7 +1705,8 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
       Math.abs(previousSnapshot.height - canvasSize.height) / Math.max(previousSnapshot.height, 1) <= 0.12;
     const relinkOnly =
       countLinkedAccountChanges(previousRequestedModelRef.current, model) === 1;
-    const quality: GraphLayoutQuality = sizeOnlyResize || relinkOnly ? "fast" : "full";
+    const largeGraph = model.nodes.length >= FAST_LAYOUT_NODE_THRESHOLD;
+    const quality: GraphLayoutQuality = sizeOnlyResize || relinkOnly || largeGraph ? "fast" : "full";
     const requestId = latestLayoutRequestIdRef.current + 1;
     latestLayoutRequestIdRef.current = requestId;
     previousRequestSnapshotRef.current = {

--- a/packages/ui/src/components/friends/FriendsView.tsx
+++ b/packages/ui/src/components/friends/FriendsView.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, useMemo, useEffect, useRef, type ReactNode } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import type {
   Account,
   DeviceContact,
@@ -11,7 +12,7 @@ import type {
   ReachOutLog,
 } from "@freed/shared";
 import { formatDistanceToNow } from "date-fns";
-import { buildFriendCandidateSuggestions, friendFromPerson, isInReconnectZone } from "@freed/shared";
+import { buildFriendCandidateSuggestions, isInReconnectZone } from "@freed/shared";
 import { useAppStore } from "../../context/PlatformContext.js";
 import { useContactSyncContext } from "../../context/ContactSyncContext.js";
 import { useIsMobile } from "../../hooks/useIsMobile.js";
@@ -26,6 +27,9 @@ import { SearchField } from "../SearchField.js";
 import { UsersIcon, MapPinIcon } from "../icons.js";
 import {
   buildFriendOverviewEntries,
+  buildFriendsById,
+  buildFriendsWorkspaceIndexes,
+  friendFromPersonWithIndexes,
   filterAndSortFriendOverview,
   type FriendOverviewEntry,
   type FriendOverviewFilter,
@@ -33,8 +37,7 @@ import {
 } from "../../lib/friends-workspace.js";
 import { resolveFriendAvatarUrl } from "../../lib/friend-avatar.js";
 import {
-  buildSuggestionsByAccount,
-  buildSuggestionsByPerson,
+  buildAccountLinkSuggestionGroups,
   type AccountLinkSuggestion,
 } from "../../lib/account-link-suggestions.js";
 import { accountSubtitle, accountTitle, providerLabel } from "../../lib/account-labels.js";
@@ -61,6 +64,7 @@ const SORT_OPTIONS: Array<{ id: FriendOverviewSort; label: string }> = [
 
 const BUTTON_CHROME = "btn-secondary rounded-lg px-3 py-1.5 text-xs";
 const FRIENDS_SIDEBAR_SECTION = "theme-dialog-divider border-b px-4 py-3";
+const FRIEND_OVERVIEW_ROW_ESTIMATE = 104;
 
 type RelationshipTierLevel = 1 | 3 | 5;
 
@@ -556,6 +560,7 @@ export function FriendsView({
   const [committedSidebarWidth, setCommittedSidebarWidth] = useState(savedSidebarWidth);
 
   const graphRef = useRef<FriendGraphHandle>(null);
+  const friendOverviewScrollRef = useRef<HTMLDivElement>(null);
   const isDraggingSidebar = useRef(false);
   const pendingPersistedSidebarWidth = useRef<number | null>(null);
   const isMobile = useIsMobile();
@@ -567,6 +572,10 @@ export function FriendsView({
     for (const item of items) map[item.globalId] = item;
     return map;
   }, [items]);
+  const friendsWorkspaceIndexes = useMemo(
+    () => buildFriendsWorkspaceIndexes(accounts, feedItems),
+    [accounts, feedItems],
+  );
   const sourceItems = useMemo(() => {
     const map = new Map<string, FeedItem>();
     for (const item of items) {
@@ -591,8 +600,8 @@ export function FriendsView({
     [persons],
   );
   const friendsById = useMemo<Record<string, Friend>>(
-    () => Object.fromEntries(friendPersons.map((person) => [person.id, friendFromPerson(person, accounts)])),
-    [accounts, friendPersons],
+    () => buildFriendsById(friendPersons, friendsWorkspaceIndexes),
+    [friendPersons, friendsWorkspaceIndexes],
   );
   const friendList = useMemo(() => Object.values(friendsById), [friendsById]);
   const socialAccountCount = useMemo(
@@ -601,7 +610,7 @@ export function FriendsView({
   );
 
   const selectedPerson = selectedPersonId ? persons[selectedPersonId] ?? null : null;
-  const selectedFriend = selectedPerson ? friendFromPerson(selectedPerson, accounts) : null;
+  const selectedFriend = selectedPerson ? friendFromPersonWithIndexes(selectedPerson, friendsWorkspaceIndexes) : null;
   const selectedAccount = selectedAccountId ? accounts[selectedAccountId] ?? null : null;
 
   const reconnectCount = useMemo(
@@ -609,13 +618,17 @@ export function FriendsView({
     [friendPersons]
   );
 
-  const suggestionsByAccount = useMemo(
-    () => buildSuggestionsByAccount(persons, accounts),
+  const accountLinkSuggestionGroups = useMemo(
+    () => buildAccountLinkSuggestionGroups(persons, accounts),
     [accounts, persons],
   );
+  const suggestionsByAccount = useMemo(
+    () => accountLinkSuggestionGroups.byAccount,
+    [accountLinkSuggestionGroups],
+  );
   const suggestionsByPerson = useMemo(
-    () => buildSuggestionsByPerson(persons, accounts),
-    [accounts, persons],
+    () => accountLinkSuggestionGroups.byPerson,
+    [accountLinkSuggestionGroups],
   );
   const friendCandidateSuggestions = useMemo(
     () =>
@@ -669,8 +682,8 @@ export function FriendsView({
   }, [friendCandidateSuggestions]);
 
   const overviewEntries = useMemo(
-    () => buildFriendOverviewEntries(friendsById, feedItems),
-    [feedItems, friendsById]
+    () => buildFriendOverviewEntries(friendsById, feedItems, { indexes: friendsWorkspaceIndexes }),
+    [feedItems, friendsById, friendsWorkspaceIndexes]
   );
   const filteredOverviewEntries = useMemo(
     () => filterAndSortFriendOverview(overviewEntries, searchQuery, activeFilters, sortBy),
@@ -707,6 +720,17 @@ export function FriendsView({
         : null,
     [overviewEntries, selectedPerson],
   );
+  const friendOverviewVirtualizer = useVirtualizer({
+    count: filteredOverviewEntries.length,
+    getScrollElement: () => friendOverviewScrollRef.current,
+    estimateSize: () => FRIEND_OVERVIEW_ROW_ESTIMATE,
+    overscan: 8,
+    getItemKey: (index) => filteredOverviewEntries[index]?.friend.id ?? index,
+  });
+
+  useEffect(() => {
+    friendOverviewVirtualizer.measure();
+  }, [filteredOverviewEntries.length, friendOverviewVirtualizer, searchQuery, sortBy]);
 
   useEffect(() => {
     if (selectedPersonId && !persons[selectedPersonId]) {
@@ -1184,7 +1208,11 @@ export function FriendsView({
         </div>
       </div>
 
-      <div className="min-h-0 flex-1 overflow-y-auto px-4 py-4">
+      <div
+        ref={friendOverviewScrollRef}
+        data-testid="friends-overview-scroll"
+        className="min-h-0 flex-1 overflow-y-auto px-4 py-4"
+      >
         {friendCandidateSuggestions.length > 0 ? (
           <div className="mb-5" data-testid="friend-candidate-suggestions">
             <div className="mb-3 flex items-center justify-between gap-3">
@@ -1219,15 +1247,31 @@ export function FriendsView({
             <p className="mt-1 text-xs text-[color:var(--theme-text-muted)]">Try clearing a filter or changing the search query.</p>
           </div>
         ) : (
-          <div className="space-y-3">
-            {filteredOverviewEntries.map((entry) => (
-              <FriendListRow
-                key={entry.friend.id}
-                entry={entry}
-                selected={entry.friend.id === selectedPerson?.id}
-                onSelect={() => handleSelectPerson(persons[entry.friend.id] ?? friendPersons[0], true)}
-              />
-            ))}
+          <div
+            data-testid="friends-overview-list"
+            className="relative"
+            style={{ height: friendOverviewVirtualizer.getTotalSize() }}
+          >
+            {friendOverviewVirtualizer.getVirtualItems().map((virtualItem) => {
+              const entry = filteredOverviewEntries[virtualItem.index];
+              if (!entry) return null;
+              return (
+                <div
+                  key={virtualItem.key}
+                  ref={friendOverviewVirtualizer.measureElement}
+                  data-index={virtualItem.index}
+                  data-testid="friend-overview-virtual-row"
+                  className="absolute left-0 top-0 w-full pb-3"
+                  style={{ transform: `translateY(${virtualItem.start}px)` }}
+                >
+                  <FriendListRow
+                    entry={entry}
+                    selected={entry.friend.id === selectedPerson?.id}
+                    onSelect={() => handleSelectPerson(persons[entry.friend.id] ?? friendPersons[0], true)}
+                  />
+                </div>
+              );
+            })}
           </div>
         )}
       </div>

--- a/packages/ui/src/lib/account-link-suggestions.ts
+++ b/packages/ui/src/lib/account-link-suggestions.ts
@@ -1,4 +1,4 @@
-import { socialAccountsForPerson, type Account, type Person } from "@freed/shared";
+import type { Account, Person } from "@freed/shared";
 
 export interface AccountLinkSuggestion {
   accountId: string;
@@ -6,6 +6,11 @@ export interface AccountLinkSuggestion {
   confidence: "high" | "medium";
   reason: string;
   score: number;
+}
+
+export interface AccountLinkSuggestionGroups {
+  byAccount: Map<string, AccountLinkSuggestion[]>;
+  byPerson: Map<string, AccountLinkSuggestion[]>;
 }
 
 function normalize(value: string | null | undefined): string {
@@ -33,17 +38,41 @@ function overlapScore(left: Set<string>, right: Set<string>): number {
   return intersection / Math.max(left.size, right.size);
 }
 
-function personAccountEvidence(person: Person, accounts: Record<string, Account>) {
-  return socialAccountsForPerson(accounts, person.id);
+function buildSocialAccountsByPerson(accounts: Account[]): Map<string, Account[]> {
+  const grouped = new Map<string, Account[]>();
+  for (const account of accounts) {
+    if (!account.personId) continue;
+    const bucket = grouped.get(account.personId);
+    if (bucket) {
+      bucket.push(account);
+    } else {
+      grouped.set(account.personId, [account]);
+    }
+  }
+  return grouped;
 }
 
 export function buildAccountLinkSuggestions(
   persons: Record<string, Person>,
   accounts: Record<string, Account>
 ): AccountLinkSuggestion[] {
+  const suggestions: AccountLinkSuggestion[] = [];
+  visitAccountLinkSuggestions(persons, accounts, (suggestion) => {
+    suggestions.push(suggestion);
+  });
+  return suggestions.sort((left, right) => right.score - left.score);
+}
+
+function visitAccountLinkSuggestions(
+  persons: Record<string, Person>,
+  accounts: Record<string, Account>,
+  visit: (suggestion: AccountLinkSuggestion) => void,
+): void {
   const confirmedPersons = Object.values(persons).filter((person) => person.relationshipStatus === "friend");
   const unlinkedAccounts = Object.values(accounts).filter((account) => account.kind === "social" && !account.personId);
-  const suggestions: AccountLinkSuggestion[] = [];
+  const socialAccountsByPerson = buildSocialAccountsByPerson(
+    Object.values(accounts).filter((account) => account.kind === "social"),
+  );
 
   for (const account of unlinkedAccounts) {
     const accountName = normalize(account.displayName);
@@ -53,7 +82,7 @@ export function buildAccountLinkSuggestions(
     for (const person of confirmedPersons) {
       const personName = normalize(person.name);
       const personTokens = tokenSet(person.name);
-      const evidenceAccounts = personAccountEvidence(person, accounts);
+      const evidenceAccounts = socialAccountsByPerson.get(person.id) ?? [];
       const exactHandleMatch = evidenceAccounts.some(
         (candidate) => normalize(candidate.handle) && normalize(candidate.handle) === accountHandle,
       );
@@ -86,7 +115,7 @@ export function buildAccountLinkSuggestions(
 
       if (score < 58) continue;
 
-      suggestions.push({
+      visit({
         accountId: account.id,
         personId: person.id,
         confidence: score >= 80 ? "high" : "medium",
@@ -95,17 +124,14 @@ export function buildAccountLinkSuggestions(
       });
     }
   }
-
-  return suggestions.sort((left, right) => right.score - left.score);
 }
 
-export function buildSuggestionsByAccount(
-  persons: Record<string, Person>,
-  accounts: Record<string, Account>
+export function groupSuggestionsByAccount(
+  suggestions: AccountLinkSuggestion[],
 ): Map<string, AccountLinkSuggestion[]> {
   const grouped = new Map<string, AccountLinkSuggestion[]>();
 
-  for (const suggestion of buildAccountLinkSuggestions(persons, accounts)) {
+  for (const suggestion of suggestions) {
     if (!grouped.has(suggestion.accountId)) {
       grouped.set(suggestion.accountId, []);
     }
@@ -116,6 +142,51 @@ export function buildSuggestionsByAccount(
   }
 
   return grouped;
+}
+
+export function buildSuggestionsByAccount(
+  persons: Record<string, Person>,
+  accounts: Record<string, Account>
+): Map<string, AccountLinkSuggestion[]> {
+  return groupSuggestionsByAccount(buildAccountLinkSuggestions(persons, accounts));
+}
+
+function insertSortedLimited(
+  bucket: AccountLinkSuggestion[],
+  suggestion: AccountLinkSuggestion,
+  limit: number,
+): void {
+  bucket.push(suggestion);
+  bucket.sort((left, right) => right.score - left.score);
+  if (bucket.length > limit) {
+    bucket.length = limit;
+  }
+}
+
+export function buildAccountLinkSuggestionGroups(
+  persons: Record<string, Person>,
+  accounts: Record<string, Account>,
+): AccountLinkSuggestionGroups {
+  const byAccount = new Map<string, AccountLinkSuggestion[]>();
+  const byPerson = new Map<string, AccountLinkSuggestion[]>();
+
+  visitAccountLinkSuggestions(persons, accounts, (suggestion) => {
+    let accountBucket = byAccount.get(suggestion.accountId);
+    if (!accountBucket) {
+      accountBucket = [];
+      byAccount.set(suggestion.accountId, accountBucket);
+    }
+    insertSortedLimited(accountBucket, suggestion, 3);
+
+    let personBucket = byPerson.get(suggestion.personId);
+    if (!personBucket) {
+      personBucket = [];
+      byPerson.set(suggestion.personId, personBucket);
+    }
+    insertSortedLimited(personBucket, suggestion, 5);
+  });
+
+  return { byAccount, byPerson };
 }
 
 export function buildSuggestionStrengthByAccount(
@@ -131,13 +202,12 @@ export function buildSuggestionStrengthByAccount(
   );
 }
 
-export function buildSuggestionsByPerson(
-  persons: Record<string, Person>,
-  accounts: Record<string, Account>
+export function groupSuggestionsByPerson(
+  suggestions: AccountLinkSuggestion[],
 ): Map<string, AccountLinkSuggestion[]> {
   const grouped = new Map<string, AccountLinkSuggestion[]>();
 
-  for (const suggestion of buildAccountLinkSuggestions(persons, accounts)) {
+  for (const suggestion of suggestions) {
     if (!grouped.has(suggestion.personId)) {
       grouped.set(suggestion.personId, []);
     }
@@ -149,4 +219,11 @@ export function buildSuggestionsByPerson(
   }
 
   return grouped;
+}
+
+export function buildSuggestionsByPerson(
+  persons: Record<string, Person>,
+  accounts: Record<string, Account>
+): Map<string, AccountLinkSuggestion[]> {
+  return groupSuggestionsByPerson(buildAccountLinkSuggestions(persons, accounts));
 }

--- a/packages/ui/src/lib/friends-workspace.test.ts
+++ b/packages/ui/src/lib/friends-workspace.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import type { Account, FeedItem, Person } from "@freed/shared";
+import {
+  buildFriendOverviewEntries,
+  buildFriendsById,
+  buildFriendsWorkspaceIndexes,
+  friendFromPersonWithIndexes,
+} from "./friends-workspace";
+
+function feedItem(id: string, authorId: string, publishedAt: number): FeedItem {
+  return {
+    globalId: id,
+    platform: "instagram",
+    contentType: "post",
+    capturedAt: publishedAt,
+    publishedAt,
+    author: {
+      id: authorId,
+      handle: authorId,
+      displayName: authorId,
+    },
+    content: { text: "", mediaUrls: [], mediaTypes: [] },
+    topics: [],
+    userState: { hidden: false, saved: false, archived: false, tags: [] },
+  };
+}
+
+describe("Friends workspace indexes", () => {
+  it("builds friends and overview rows without repeated global scans", () => {
+    const now = 10_000;
+    const ada: Person = {
+      id: "ada",
+      name: "Ada Lovelace",
+      relationshipStatus: "friend",
+      careLevel: 5,
+      createdAt: now,
+      updatedAt: now,
+    };
+    const maya: Person = {
+      id: "maya",
+      name: "Maya Angelou",
+      relationshipStatus: "friend",
+      careLevel: 3,
+      createdAt: now,
+      updatedAt: now,
+    };
+    const accounts: Record<string, Account> = {
+      "ada-ig": {
+        id: "ada-ig",
+        personId: ada.id,
+        kind: "social",
+        provider: "instagram",
+        externalId: "ada",
+        handle: "ada",
+        displayName: "Ada",
+        firstSeenAt: now,
+        lastSeenAt: now,
+        discoveredFrom: "captured_item",
+        createdAt: now,
+        updatedAt: now,
+      },
+      "ada-contact": {
+        id: "ada-contact",
+        personId: ada.id,
+        kind: "contact",
+        provider: "google_contacts",
+        externalId: "people/ada",
+        displayName: "Ada L.",
+        email: "ada@example.com",
+        importedAt: now,
+        firstSeenAt: now,
+        lastSeenAt: now,
+        discoveredFrom: "contact_import",
+        createdAt: now,
+        updatedAt: now,
+      },
+      "maya-ig": {
+        id: "maya-ig",
+        personId: maya.id,
+        kind: "social",
+        provider: "instagram",
+        externalId: "maya",
+        handle: "maya",
+        displayName: "Maya",
+        firstSeenAt: now,
+        lastSeenAt: now,
+        discoveredFrom: "captured_item",
+        createdAt: now,
+        updatedAt: now,
+      },
+    };
+    const feedItems: Record<string, FeedItem> = {
+      "older-ada": feedItem("older-ada", "ada", now - 2_000),
+      "newer-ada": feedItem("newer-ada", "ada", now - 100),
+      "maya-post": feedItem("maya-post", "maya", now - 500),
+    };
+
+    const indexes = buildFriendsWorkspaceIndexes(accounts, feedItems);
+    const adaFriend = friendFromPersonWithIndexes(ada, indexes);
+    const friendsById = buildFriendsById([ada, maya], indexes);
+    const overview = buildFriendOverviewEntries(friendsById, feedItems, { indexes, now });
+
+    expect(adaFriend.sources).toHaveLength(1);
+    expect(adaFriend.contact?.email).toBe("ada@example.com");
+    expect(overview.find((entry) => entry.friend.id === "ada")?.items.map((item) => item.globalId)).toEqual([
+      "newer-ada",
+      "older-ada",
+    ]);
+    expect(overview.find((entry) => entry.friend.id === "ada")?.lastPostAt).toBe(now - 100);
+    expect(overview.find((entry) => entry.friend.id === "maya")?.lastPostAt).toBe(now - 500);
+  });
+});

--- a/packages/ui/src/lib/friends-workspace.ts
+++ b/packages/ui/src/lib/friends-workspace.ts
@@ -1,11 +1,12 @@
 import {
   extractLocationFromItem,
-  feedItemsForFriend,
   isDue,
-  lastPostAt,
   lastReachOutAt,
+  type Account,
   type FeedItem,
   type Friend,
+  type Person,
+  type Platform,
 } from "@freed/shared";
 
 export type FriendOverviewFilter =
@@ -32,6 +33,130 @@ export interface FriendOverviewEntry {
 }
 
 const RECENT_ACTIVITY_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+
+export interface FriendsWorkspaceIndexes {
+  socialAccountsByPerson: Map<string, Account[]>;
+  primaryContactByPerson: Map<string, Account>;
+  feedItemsBySourceKey: Map<string, FeedItem[]>;
+}
+
+export interface FriendOverviewBuildOptions {
+  now?: number;
+  indexes?: FriendsWorkspaceIndexes;
+}
+
+function sourceKey(platform: string, authorId: string): string {
+  return `${platform}:${authorId}`;
+}
+
+export function buildFriendsWorkspaceIndexes(
+  accounts: Record<string, Account>,
+  feedItems: Record<string, FeedItem>,
+): FriendsWorkspaceIndexes {
+  const socialAccountsByPerson = new Map<string, Account[]>();
+  const primaryContactByPerson = new Map<string, Account>();
+  const feedItemsBySourceKey = new Map<string, FeedItem[]>();
+
+  for (const account of Object.values(accounts)) {
+    if (!account.personId) continue;
+    if (account.kind === "social") {
+      const bucket = socialAccountsByPerson.get(account.personId);
+      if (bucket) {
+        bucket.push(account);
+      } else {
+        socialAccountsByPerson.set(account.personId, [account]);
+      }
+      continue;
+    }
+    if (account.kind === "contact" && !primaryContactByPerson.has(account.personId)) {
+      primaryContactByPerson.set(account.personId, account);
+    }
+  }
+
+  for (const item of Object.values(feedItems)) {
+    const key = sourceKey(item.platform, item.author.id);
+    const bucket = feedItemsBySourceKey.get(key);
+    if (bucket) {
+      bucket.push(item);
+    } else {
+      feedItemsBySourceKey.set(key, [item]);
+    }
+  }
+
+  for (const bucket of feedItemsBySourceKey.values()) {
+    bucket.sort((left, right) => right.publishedAt - left.publishedAt);
+  }
+
+  return {
+    socialAccountsByPerson,
+    primaryContactByPerson,
+    feedItemsBySourceKey,
+  };
+}
+
+export function friendFromPersonWithIndexes(
+  person: Person,
+  indexes: Pick<FriendsWorkspaceIndexes, "socialAccountsByPerson" | "primaryContactByPerson">,
+): Friend {
+  const socialSources = (indexes.socialAccountsByPerson.get(person.id) ?? []).map((account) => ({
+    platform: account.provider as Platform,
+    authorId: account.externalId,
+    handle: account.handle,
+    displayName: account.displayName,
+    avatarUrl: account.avatarUrl,
+    profileUrl: account.profileUrl,
+  }));
+
+  const primaryContact = indexes.primaryContactByPerson.get(person.id);
+  const contact: Friend["contact"] = primaryContact
+    ? {
+        importedFrom:
+          primaryContact.provider === "google_contacts"
+            ? "google"
+            : primaryContact.provider === "macos_contacts"
+              ? "macos"
+              : primaryContact.provider === "ios_contacts"
+                ? "ios"
+                : primaryContact.provider === "android_contacts"
+                  ? "android"
+                  : "web",
+        name: primaryContact.displayName ?? person.name,
+        phone: primaryContact.phone,
+        email: primaryContact.email,
+        address: primaryContact.address,
+        nativeId: primaryContact.externalId,
+        importedAt: primaryContact.importedAt ?? primaryContact.createdAt,
+      }
+    : undefined;
+
+  return {
+    ...person,
+    sources: socialSources,
+    ...(contact ? { contact } : {}),
+  };
+}
+
+export function buildFriendsById(
+  persons: Person[],
+  indexes: Pick<FriendsWorkspaceIndexes, "socialAccountsByPerson" | "primaryContactByPerson">,
+): Record<string, Friend> {
+  return Object.fromEntries(
+    persons.map((person) => [person.id, friendFromPersonWithIndexes(person, indexes)]),
+  );
+}
+
+function feedItemsForFriendFromIndexes(
+  friend: Friend,
+  indexes: Pick<FriendsWorkspaceIndexes, "feedItemsBySourceKey">,
+): FeedItem[] {
+  const items: FeedItem[] = [];
+  for (const source of friend.sources) {
+    const bucket = indexes.feedItemsBySourceKey.get(sourceKey(source.platform, source.authorId));
+    if (bucket) items.push(...bucket);
+  }
+  if (items.length <= 1) return items;
+  return items.sort((left, right) => right.publishedAt - left.publishedAt);
+}
 
 function matchesQuery(friend: Friend, query: string): boolean {
   if (!query) return true;
@@ -105,11 +230,15 @@ function sortEntries(entries: FriendOverviewEntry[], sort: FriendOverviewSort): 
 export function buildFriendOverviewEntries(
   friends: Record<string, Friend>,
   feedItems: Record<string, FeedItem>,
-  now: number = Date.now()
+  optionsOrNow: FriendOverviewBuildOptions | number = Date.now()
 ): FriendOverviewEntry[] {
+  const options = typeof optionsOrNow === "number" ? { now: optionsOrNow } : optionsOrNow;
+  const now = options.now ?? Date.now();
+  const indexes = options.indexes ?? buildFriendsWorkspaceIndexes({}, feedItems);
+
   return Object.values(friends).map((friend) => {
-    const items = feedItemsForFriend(feedItems, friend).sort((a, b) => b.publishedAt - a.publishedAt);
-    const latestPost = lastPostAt(feedItems, friend);
+    const items = feedItemsForFriendFromIndexes(friend, indexes);
+    const latestPost = items[0]?.publishedAt ?? null;
     const latestContact = lastReachOutAt(friend);
     const hasLocation = items.some((item) => extractLocationFromItem(item));
     const isRecentlyActive = latestPost !== null && now - latestPost <= RECENT_ACTIVITY_WINDOW_MS;

--- a/scripts/validate-worktree.mjs
+++ b/scripts/validate-worktree.mjs
@@ -154,6 +154,7 @@ export function isDesktopPerfSensitiveSurface(filePath) {
     filePath === ".github/workflows/ci.yml" ||
     filePath === "scripts/perf-compare.ts" ||
     filePath === "packages/desktop/tests/e2e/perf-feed.spec.ts" ||
+    filePath === "packages/desktop/tests/e2e/perf-friends.spec.ts" ||
     filePath === "packages/desktop/tests/e2e/perf-budgets.json" ||
     filePath === "packages/desktop/tests/e2e/perf-baselines.json" ||
     filePath === "packages/desktop/tests/e2e/reporters/perf-reporter.ts" ||
@@ -168,6 +169,12 @@ export function isDesktopPerfSensitiveSurface(filePath) {
     filePath === "packages/desktop/src/lib/rss-poller.ts" ||
     filePath.startsWith("packages/desktop/src-tauri/src/") ||
     filePath.startsWith("packages/ui/src/components/feed/") ||
+    filePath.startsWith("packages/ui/src/components/friends/") ||
+    filePath === "packages/ui/src/lib/friends-workspace.ts" ||
+    filePath === "packages/ui/src/lib/account-link-suggestions.ts" ||
+    filePath === "packages/ui/src/lib/identity-graph-render.ts" ||
+    filePath === "packages/ui/src/lib/identity-graph-layout.ts" ||
+    filePath === "packages/ui/src/lib/identity-graph-model.ts" ||
     filePath === "packages/ui/src/hooks/useSearchResults.ts" ||
     filePath === "packages/shared/src/ranking.ts" ||
     filePath === "packages/shared/src/schema.ts"

--- a/scripts/validate-worktree.test.mjs
+++ b/scripts/validate-worktree.test.mjs
@@ -69,6 +69,22 @@ test("feature plan for feed UI changes runs desktop perf checks", () => {
   ]);
 });
 
+test("feature plan for Friends UI changes runs desktop perf checks", () => {
+  const labels = describePlan(
+    buildValidationPlan("feature", ["packages/ui/src/components/friends/FriendsView.tsx"]),
+  );
+
+  assert.deepEqual(labels, [
+    "root typecheck",
+    "pwa production build",
+    "pwa typecheck",
+    "pwa unit tests",
+    "desktop unit tests",
+    "desktop e2e smoke",
+    "desktop e2e perf",
+  ]);
+});
+
 test("feature plan for non-feed desktop changes skips desktop perf checks", () => {
   const labels = describePlan(
     buildValidationPlan("feature", ["packages/desktop/src/components/ProviderHealthSectionSummary.tsx"]),
@@ -84,6 +100,8 @@ test("feature plan for non-feed desktop changes skips desktop perf checks", () =
 test("desktop perf sensitivity is scoped to hot paths and perf harnesses", () => {
   assert.equal(isDesktopPerfSensitiveSurface("packages/desktop/src/lib/automerge.worker.ts"), true);
   assert.equal(isDesktopPerfSensitiveSurface("packages/ui/src/components/feed/FeedList.tsx"), true);
+  assert.equal(isDesktopPerfSensitiveSurface("packages/ui/src/components/friends/FriendGraph.tsx"), true);
+  assert.equal(isDesktopPerfSensitiveSurface("packages/ui/src/lib/friends-workspace.ts"), true);
   assert.equal(isDesktopPerfSensitiveSurface("packages/shared/src/ranking.ts"), true);
   assert.equal(isDesktopPerfSensitiveSurface("packages/desktop/src/components/ProviderHealthSectionSummary.tsx"), false);
 });


### PR DESCRIPTION
(AI Generated).

## Summary
- Improves Friends view responsiveness for dense profiles by indexing account and feed lookups.
- Virtualizes the Friends sidebar list and switches the Pixi graph to demand rendering.
- Adds a 1,600-person Friends performance regression and routes Friends hot paths into the desktop perf lane.

## Testing
- npm run validate:feature