### PR TITLE
perf: derive map counts off the render path

### DIFF
--- a/packages/desktop/src/lib/automerge-state-patches.test.ts
+++ b/packages/desktop/src/lib/automerge-state-patches.test.ts
@@ -57,6 +57,8 @@ function makeState(items: FeedItem[]): DocState {
     totalArchivableCount: 1,
     archivableCountByPlatform: { rss: 1 },
     archivableFeedCounts: { [FEED_URL]: 1 },
+    mapFriendLocationCount: 7,
+    mapAllContentLocationCount: 11,
     docItemCount: items.length,
   };
 }
@@ -80,6 +82,8 @@ describe("Automerge item patch state updates", () => {
     expect(result.state.totalArchivableCount).toBe(2);
     expect(result.state.archivableCountByPlatform).toEqual({ rss: 2 });
     expect(result.state.archivableFeedCounts).toEqual({ [FEED_URL]: 2 });
+    expect(result.state.mapFriendLocationCount).toBe(7);
+    expect(result.state.mapAllContentLocationCount).toBe(11);
   });
 
   it("removes archived items from aggregate counts while keeping them in the item list", () => {

--- a/packages/desktop/src/lib/automerge-types.ts
+++ b/packages/desktop/src/lib/automerge-types.ts
@@ -41,6 +41,8 @@ export interface DocState {
   totalArchivableCount: number;
   archivableCountByPlatform: Record<string, number>;
   archivableFeedCounts: Record<string, number>;
+  mapFriendLocationCount: number;
+  mapAllContentLocationCount: number;
   /** Total feed-item records in the CRDT, including hidden and archived items. */
   docItemCount: number;
 }

--- a/packages/desktop/src/lib/automerge.worker.ts
+++ b/packages/desktop/src/lib/automerge.worker.ts
@@ -53,7 +53,13 @@ import {
   confirmLikedSynced,
   confirmSeenSynced,
 } from "@freed/shared/schema";
-import { mergeDefaultPreferences, rankFeedItems, sortByPriority } from "@freed/shared";
+import {
+  countAuthorsWithRecentLocationUpdates,
+  countFriendsWithRecentLocationUpdates,
+  mergeDefaultPreferences,
+  rankFeedItems,
+  sortByPriority,
+} from "@freed/shared";
 import type { Account, FeedItem, Friend, LegacyDeviceContact, LegacyFriendSource, Person, RssFeed, UserPreferences } from "@freed/shared";
 import type { DocState, WorkerRequest, WorkerResponse } from "./automerge-types";
 import {
@@ -381,6 +387,8 @@ function hydrateFromDoc(doc: FreedDoc): DocState {
     totalArchivableCount,
     archivableCountByPlatform,
     archivableFeedCounts,
+    mapFriendLocationCount: countFriendsWithRecentLocationUpdates(rankedItems, persons, accounts),
+    mapAllContentLocationCount: countAuthorsWithRecentLocationUpdates(rankedItems),
     docItemCount: Object.keys(plain.feedItems as Record<string, FeedItem>).length,
   };
 }

--- a/packages/desktop/src/lib/store.ts
+++ b/packages/desktop/src/lib/store.ts
@@ -109,6 +109,8 @@ interface AppState {
   totalArchivableCount: number;
   archivableCountByPlatform: Record<string, number>;
   archivableFeedCounts: Record<string, number>;
+  mapFriendLocationCount: number;
+  mapAllContentLocationCount: number;
   /** Total feed-item records including hidden and archived items. */
   docItemCount: number;
 
@@ -391,6 +393,8 @@ export const useAppStore = create<AppState>((set, get) => ({
   totalArchivableCount: 0,
   archivableCountByPlatform: {},
   archivableFeedCounts: {},
+  mapFriendLocationCount: 0,
+  mapAllContentLocationCount: 0,
   docItemCount: 0,
   xAuth: { isAuthenticated: false },
   fbAuth: { isAuthenticated: false },

--- a/packages/pwa/src/lib/automerge-types.ts
+++ b/packages/pwa/src/lib/automerge-types.ts
@@ -41,6 +41,8 @@ export interface DocState {
   totalArchivableCount: number;
   archivableCountByPlatform: Record<string, number>;
   archivableFeedCounts: Record<string, number>;
+  mapFriendLocationCount: number;
+  mapAllContentLocationCount: number;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/pwa/src/lib/automerge.worker.ts
+++ b/packages/pwa/src/lib/automerge.worker.ts
@@ -51,7 +51,13 @@ import {
   confirmLikedSynced,
   confirmSeenSynced,
 } from "@freed/shared/schema";
-import { mergeDefaultPreferences, rankFeedItems, sortByPriority } from "@freed/shared";
+import {
+  countAuthorsWithRecentLocationUpdates,
+  countFriendsWithRecentLocationUpdates,
+  mergeDefaultPreferences,
+  rankFeedItems,
+  sortByPriority,
+} from "@freed/shared";
 import type { Account, FeedItem, Friend, LegacyDeviceContact, LegacyFriendSource, Person, RssFeed, UserPreferences } from "@freed/shared";
 import type { DocState, WorkerRequest, WorkerResponse } from "./automerge-types";
 
@@ -243,6 +249,8 @@ function hydrateFromDoc(doc: FreedDoc): DocState {
     totalArchivableCount,
     archivableCountByPlatform,
     archivableFeedCounts,
+    mapFriendLocationCount: countFriendsWithRecentLocationUpdates(rankedItems, persons, accounts),
+    mapAllContentLocationCount: countAuthorsWithRecentLocationUpdates(rankedItems),
   };
 }
 

--- a/packages/pwa/src/lib/command-palette.test.ts
+++ b/packages/pwa/src/lib/command-palette.test.ts
@@ -114,6 +114,8 @@ function createTestStore(overrides: Partial<BaseAppState> = {}) {
     totalArchivableCount: overrides.totalArchivableCount ?? 0,
     archivableCountByPlatform: overrides.archivableCountByPlatform ?? {},
     archivableFeedCounts: overrides.archivableFeedCounts ?? {},
+    mapFriendLocationCount: overrides.mapFriendLocationCount ?? 0,
+    mapAllContentLocationCount: overrides.mapAllContentLocationCount ?? 0,
     isLoading: false,
     isSyncing: false,
     isInitialized: true,

--- a/packages/pwa/src/lib/store-startup.test.ts
+++ b/packages/pwa/src/lib/store-startup.test.ts
@@ -70,6 +70,8 @@ function makeDocState(): DocState {
     totalArchivableCount: 0,
     archivableCountByPlatform: {},
     archivableFeedCounts: {},
+    mapFriendLocationCount: 0,
+    mapAllContentLocationCount: 0,
   };
 }
 

--- a/packages/pwa/src/lib/store.ts
+++ b/packages/pwa/src/lib/store.ts
@@ -140,6 +140,8 @@ export const useAppStore = create<AppState>((set, get) => ({
   totalArchivableCount: 0,
   archivableCountByPlatform: {},
   archivableFeedCounts: {},
+  mapFriendLocationCount: 0,
+  mapAllContentLocationCount: 0,
   syncConnected: false,
   isLoading: true,
   isSyncing: false,

--- a/packages/shared/src/store-types.ts
+++ b/packages/shared/src/store-types.ts
@@ -78,6 +78,10 @@ export interface BaseAppState {
   archivableCountByPlatform: Record<string, number>;
   /** Archivable count bucketed by RSS feed URL. */
   archivableFeedCounts: Record<string, number>;
+  /** Friends with recent mapped content. Derived off the render path. */
+  mapFriendLocationCount: number;
+  /** Authors with recent mapped content. Derived off the render path. */
+  mapAllContentLocationCount: number;
 
   // UI state
   isLoading: boolean;

--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -11,8 +11,6 @@ import {
   type ReactNode,
 } from "react";
 import {
-  countAuthorsWithRecentLocationUpdates,
-  countFriendsWithRecentLocationUpdates,
   applyFeedSignalModesToFilter,
   FEED_SIGNAL_FILTER_PRESETS,
   filterFeedItems,
@@ -386,14 +384,8 @@ export function Header({
 
   const scopeLabel = useMemo(() => getFilterLabel(activeFilter, feeds, accounts), [accounts, activeFilter, feeds]);
   const friendCount = useMemo(() => Object.keys(friends).length, [friends]);
-  const mappedFriendCount = useMemo(
-    () => countFriendsWithRecentLocationUpdates(items, friends),
-    [friends, items],
-  );
-  const mappedAllContentCount = useMemo(
-    () => countAuthorsWithRecentLocationUpdates(items),
-    [items],
-  );
+  const mappedFriendCount = useAppStore((s) => s.mapFriendLocationCount);
+  const mappedAllContentCount = useAppStore((s) => s.mapAllContentLocationCount);
   const socialAccountCount = useMemo(
     () => Object.values(accounts).filter((account) => account.kind === "social").length,
     [accounts],

--- a/packages/ui/src/components/layout/Sidebar.tsx
+++ b/packages/ui/src/components/layout/Sidebar.tsx
@@ -1,8 +1,6 @@
 import { useState, useCallback, useEffect, useRef, useMemo, cloneElement, isValidElement, type CSSProperties, type KeyboardEvent as ReactKeyboardEvent, type ReactNode } from "react";
 
 import {
-  countAuthorsWithRecentLocationUpdates,
-  countFriendsWithRecentLocationUpdates,
   resolveMapMode,
   type FilterOptions,
   type RssFeed,
@@ -587,7 +585,6 @@ export function Sidebar({
   const searchQuery = useAppStore((s) => s.searchQuery);
   const feeds = useAppStore((s) => s.feeds);
   const friends = useAppStore((s) => s.persons);
-  const accounts = useAppStore((s) => s.accounts);
   const feedUnreadCounts = useAppStore((s) => s.feedUnreadCounts);
   const feedTotalCounts = useAppStore((s) => s.feedTotalCounts);
   const renameFeed = useAppStore((s) => s.renameFeed);
@@ -617,14 +614,8 @@ export function Sidebar({
   const savedCount = useMemo(() => items.filter((i) => i.userState.saved).length, [items]);
   const archivedCount = useMemo(() => items.filter((i) => i.userState.archived).length, [items]);
   const friendCount = useMemo(() => Object.keys(friends).length, [friends]);
-  const mapFriendCount = useMemo(
-    () => countFriendsWithRecentLocationUpdates(items, friends, accounts),
-    [accounts, friends, items]
-  );
-  const mapAllContentCount = useMemo(
-    () => countAuthorsWithRecentLocationUpdates(items),
-    [items],
-  );
+  const mapFriendCount = useAppStore((s) => s.mapFriendLocationCount);
+  const mapAllContentCount = useAppStore((s) => s.mapAllContentLocationCount);
   const effectiveMapMode = resolveMapMode(
     display.mapMode,
     mapFriendCount,


### PR DESCRIPTION
(AI Generated).

## Summary
- Derives map friend and all-content location counts in the Automerge workers instead of Header and Sidebar render paths.
- Keeps those counts stable across hot item-patch updates such as mark-as-read.
- Removes per-render location text extraction from the measured mark-as-read profile.

## Testing
- npm run validate:feature

## Performance
- markAsRead × 20 storm p95 improved from about 66.7 ms to 48.4 ms locally.
- Dropped frames in the same storm improved from 19 to 9 locally.
- extractLocationFromText disappeared from the mark-as-read CPU profile top 30.