### PR TITLE
perf: trim feed search frame work

### DIFF
--- a/packages/desktop/tests/e2e/perf-feed.spec.ts
+++ b/packages/desktop/tests/e2e/perf-feed.spec.ts
@@ -413,7 +413,7 @@ test.describe("Search input (async MiniSearch index preparation)", () => {
     console.log(`[PERF] Search long tasks: ${searchLongTasks.count}, worst: ${Math.round(searchLongTasks.worstMs)} ms`);
 
     // Typing should not wait on a synchronous full-corpus index build.
-    expect(searchLongTasks.worstMs).toBeLessThan(180);
+    expect(searchLongTasks.worstMs).toBeLessThan(120);
 
     // Verify search actually produces results (proves MiniSearch is working).
     await expect(page.locator(".feed-card")).not.toHaveCount(0, { timeout: 2_000 });

--- a/packages/ui/src/hooks/useSearchResults.ts
+++ b/packages/ui/src/hooks/useSearchResults.ts
@@ -189,6 +189,7 @@ interface SharedSearchIndexCache {
 
 let sharedSearchIndexCache: SharedSearchIndexCache | null = null;
 let releaseSearchIndexTimer: ReturnType<typeof setTimeout> | null = null;
+const searchItemByIdCache = new WeakMap<FeedItem[], Map<string, FeedItem>>();
 
 function searchIndexKey(
   items: FeedItem[],
@@ -244,6 +245,20 @@ function getPreparedSearchIndex(
 ): MiniSearch<SearchDoc> | null {
   const key = searchIndexKey(items, searchCorpusVersion, accounts);
   return sharedSearchIndexCache?.key === key ? sharedSearchIndexCache.index : null;
+}
+
+function getSearchItemById(
+  items: FeedItem[],
+  trimmedQuery: string,
+): Map<string, FeedItem> | null {
+  if (!trimmedQuery) return null;
+
+  let cached = searchItemByIdCache.get(items);
+  if (!cached) {
+    cached = new Map(items.map((item) => [item.globalId, item]));
+    searchItemByIdCache.set(items, cached);
+  }
+  return cached;
 }
 
 function searchOptionsForQuery(query: string) {
@@ -349,22 +364,18 @@ function computeSearchResults(args: {
     // Search then filter, preserving MiniSearch's relevance ordering.
     const hits = args.index.search(args.trimmedQuery, searchOptionsForQuery(args.trimmedQuery));
 
-    const scoreById = new Map(hits.map((r) => [r.id as string, r.score]));
-
-    const matchingItems = hits
-      .map((r) => args.itemById?.get(r.id as string))
-      .filter((item): item is FeedItem => item !== undefined);
+    const matchingItems: FeedItem[] = [];
+    for (const hit of hits) {
+      const item = args.itemById.get(hit.id as string);
+      if (item) matchingItems.push(item);
+    }
 
     const filtered = filterFeedItems(filterIdentityMode(matchingItems), args.activeFilter);
     const byFeed = args.activeFilter.feedUrl
       ? filtered.filter((item) => item.rssSource?.feedUrl === args.activeFilter.feedUrl)
       : filtered;
 
-    const sorted = [...byFeed].sort(
-      (a, b) => (scoreById.get(b.globalId) ?? 0) - (scoreById.get(a.globalId) ?? 0),
-    );
-
-    result = { filteredItems: sorted, isSearching: true, resultCount: sorted.length };
+    result = { filteredItems: byFeed, isSearching: true, resultCount: byFeed.length };
   }
 
   lastSearchResultCache = { ...args, result };
@@ -395,7 +406,7 @@ export function useSearchResults(
     getPreparedSearchIndex(items, searchCorpusVersion, accounts),
   );
   const itemById = useMemo(
-    () => (trimmedQuery ? new Map(items.map((item) => [item.globalId, item])) : null),
+    () => getSearchItemById(items, trimmedQuery),
     [items, trimmedQuery],
   );
 


### PR DESCRIPTION
(AI Generated).

## Summary
- Shares the feed search item lookup across mounted consumers and keeps MiniSearch relevance order instead of building a score map and sorting the full hit set again on every query.

## Testing
- node ../../node_modules/playwright/cli.js test perf-feed.spec.ts --grep "typing a 5-character query"
- npm run validate:feature