### PR TITLE
perf: recycle blocked scraper windows

### DIFF
--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -1288,7 +1288,7 @@ dependencies = [
 
 [[package]]
 name = "freed-desktop"
-version = "26.5.515"
+version = "26.5.602"
 dependencies = [
  "base64 0.22.1",
  "criterion",

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -2679,6 +2679,17 @@ fn recycle_social_scraper_windows_except(
     recycled
 }
 
+fn blocked_preflight_preserved_scraper_label<'a>(
+    preserve_label: Option<&'a str>,
+    critical: bool,
+) -> Option<&'a str> {
+    if critical {
+        None
+    } else {
+        preserve_label
+    }
+}
+
 async fn prepare_social_scrape_memory_internal(
     app: &tauri::AppHandle,
     provider: &str,
@@ -2796,10 +2807,16 @@ async fn ensure_social_scrape_memory(
         let reason = format!("{} {} critical memory preflight", provider, operation);
         recycle_social_scraper_windows(app, &reason);
     }
+    let mut recycled_preserved_scraper_window = false;
+    if let Some(label) = blocked_preflight_preserved_scraper_label(preserve_label, critical) {
+        let reason = format!("{} {} blocked memory preflight", provider, operation);
+        recycled_preserved_scraper_window = app.get_webview_window(label).is_some();
+        recycle_webview_window(app, label, &reason);
+    }
     let cooldown_ms = background_runtime.note_memory_pressure(provider, operation, critical);
     warn!(
-        "[memory] pausing background scraper work provider={} operation={} pressure={} cooldown_ms={}",
-        provider, operation, pressure_label, cooldown_ms
+        "[memory] pausing background scraper work provider={} operation={} pressure={} cooldown_ms={} recycled_preserved_scraper={}",
+        provider, operation, pressure_label, cooldown_ms, recycled_preserved_scraper_window
     );
     append_runtime_health(
         app,
@@ -2816,7 +2833,9 @@ async fn ensure_social_scrape_memory(
             "scrapeStartBudgetBytes": prep.scrape_start_budget_bytes,
             "memoryHighBytes": prep.after.memory_high_bytes,
             "memoryCriticalBytes": prep.after.memory_critical_bytes,
-            "recycledAllScraperWindows": critical
+            "recycledAllScraperWindows": critical,
+            "recycledPreservedScraperWindow": recycled_preserved_scraper_window,
+            "preservedScraperLabel": preserve_label
         }),
     );
     Err(format!(
@@ -6824,6 +6843,19 @@ mod tests {
             app_resident_bytes: budget,
             ..stats
         }));
+    }
+
+    #[test]
+    fn scrape_memory_recycles_preserved_window_under_high_pressure() {
+        assert_eq!(
+            blocked_preflight_preserved_scraper_label(Some("ig-scraper"), false),
+            Some("ig-scraper")
+        );
+        assert_eq!(
+            blocked_preflight_preserved_scraper_label(Some("ig-scraper"), true),
+            None
+        );
+        assert_eq!(blocked_preflight_preserved_scraper_label(None, false), None);
     }
 
     #[test]


### PR DESCRIPTION
(AI Generated).

## Summary
- Recycle a preserved scraper WebView when high memory blocks a social scrape before it starts.
- Record preserved scraper cleanup in runtime health so the next soak can distinguish blocked-start cleanup from critical full-window recycling.
- Correct the desktop Cargo.lock package version to the current dev release after native validation updated it.

## Testing
- PATH=/Users/aubreyfalconer/dev/freed-recycle-blocked-scraper/node_modules/.bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/usr/local/MacGPG2/bin:/Applications/VMware Fusion.app/Contents/Public:/usr/local/share/dotnet:~/.dotnet/tools:/usr/local/go/bin:/Library/Frameworks/Mono.framework/Versions/Current/Commands:/Users/aubreyfalconer/.nvm/versions/node/v24.14.1/bin:/Users/aubreyfalconer/.codex/tmp/arg0/codex-arg05cJIJd:/Users/aubreyfalconer/.local/bin:/opt/homebrew/opt/mysql-client/bin:/opt/homebrew/bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/Users/aubreyfalconer/.cargo/bin:/Users/aubreyfalconer/go/bin:/Users/aubreyfalconer/.cache/lm-studio/bin:/Users/aubreyfalconer/.safe-chain/bin:/Applications/Codex.app/Contents/Resources:/usr/local/bin npm run build from packages/desktop
- cargo test scrape_memory --lib from packages/desktop/src-tauri
- npm run validate:feature