### PR TITLE
perf: make desktop feed media reader only

### DIFF
--- a/packages/desktop/src/App.tsx
+++ b/packages/desktop/src/App.tsx
@@ -669,7 +669,7 @@ function App() {
   const platform: PlatformConfig = useMemo(
     () => ({
       store: useAppStore,
-      feedMediaPreviews: "inline",
+      feedMediaPreviews: "reader-only",
       addRssFeed,
       importOPMLFeeds,
       exportFeedsAsOPML,

--- a/packages/desktop/src/desktop-feed-media-policy.test.ts
+++ b/packages/desktop/src/desktop-feed-media-policy.test.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("desktop feed media policy", () => {
+  it("keeps remote feed media previews reader-only", () => {
+    const source = readFileSync(resolve(process.cwd(), "src/App.tsx"), "utf8");
+
+    expect(source).toContain('feedMediaPreviews: "reader-only"');
+    expect(source).not.toContain('feedMediaPreviews: "inline"');
+  });
+});

--- a/packages/ui/src/components/feed/FeedItem.test.tsx
+++ b/packages/ui/src/components/feed/FeedItem.test.tsx
@@ -79,6 +79,11 @@ const platformConfig = {
   GoogleContactsSettingsContent: null,
 } as unknown as PlatformConfig;
 
+const readerOnlyPlatformConfig = {
+  ...platformConfig,
+  feedMediaPreviews: "reader-only",
+} as unknown as PlatformConfig;
+
 function setMemoryPressure(pressureLevel: RuntimeMemorySnapshot["pressureLevel"]): void {
   useDebugStore.setState({
     runtimeMemory: {
@@ -205,6 +210,32 @@ describe("FeedItem story media", () => {
     expect(html).toContain("<img");
     expect(html).toContain("https://example.com/story.jpg");
     expect(html).not.toContain("<video");
+  });
+
+  it("suppresses feed media when the platform uses reader-only previews", async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root: Root = createRoot(container);
+
+    try {
+      await act(async () => {
+        root.render(
+          <PlatformProvider value={readerOnlyPlatformConfig}>
+            <FeedItem item={makeItem()} />
+          </PlatformProvider>,
+        );
+      });
+
+      expect(container.querySelector("img[src='https://example.com/story.jpg']")).toBeNull();
+      expect(container.querySelector(".bg-gradient-to-br")).not.toBeNull();
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+      (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = false;
+    }
   });
 
   it("suppresses story images under renderer memory pressure", async () => {


### PR DESCRIPTION
(AI Generated).

## Summary

- Sets Freed Desktop feed cards to reader-only media previews so the feed no longer eagerly mounts remote story and post media in the main renderer.
- Keeps reader hydration intact for opening full content.
- Adds coverage for reader-only feed media behavior and a Desktop policy check so this does not quietly flip back.

## Validation

- `PATH=/Users/aubreyfalconer/dev/freed-desktop-reader-only-media/node_modules/.bin:$PATH node node_modules/vitest/vitest.mjs run packages/ui/src/components/feed/FeedItem.test.tsx`
- `PATH=/Users/aubreyfalconer/dev/freed-desktop-reader-only-media/node_modules/.bin:$PATH npm run test:unit -- desktop-feed-media-policy.test.ts`
- `npm run validate:feature`

## Performance Notes

- Final feature validation Friends perf: mount 1,527 ms, idle p95 17.5 ms, interaction p95 25.4 ms, dropped frames 2, long tasks 0.
- Existing installed v26.5.605-dev soak is healthy but still shows WebContent RSS as the live bottleneck, so this branch is intended to reduce renderer resource loading in the next installed build.