### PR TITLE
fix: align feed card regression with reader only media

### DIFF
--- a/packages/desktop/tests/e2e/feed-card-ui.spec.ts
+++ b/packages/desktop/tests/e2e/feed-card-ui.spec.ts
@@ -240,22 +240,15 @@ test("feed card overhaul actions and reader open flow work", async ({ app }) => 
   await expect(facebookCard).toHaveClass(/grayscale/);
   await expect(facebookCard.locator('button[aria-label="Archive"]').first()).toBeVisible();
   const facebookImage = facebookCard.locator(`img[src="${FACEBOOK_MEDIA_URL}"]`).first();
-  await expect(facebookImage).toBeVisible();
-  await expect(facebookImage).toHaveAttribute("src", /\/freed\.svg\?feed-card$/);
+  await expect(facebookImage).toHaveCount(0);
 
   const storyTile = app.page.locator('[data-feed-item-id="test-instagram-story-thumbnail"]');
   const storyImage = storyTile.locator("img").first();
-  await expect(storyImage).toBeVisible();
-  await expect(storyImage).toHaveAttribute("src", /\/freed\.svg\?story-tile$/);
+  await expect(storyImage).toHaveCount(0);
 
   const brokenCard = app.page.locator('[data-feed-item-id="test-broken-thumbnail-fallback"]');
   const brokenImage = brokenCard.locator("img").first();
-  await expect(brokenImage).toBeVisible();
-  await expect(brokenImage).toHaveAttribute("src", /\/freed\.svg\?fallback$/);
-  await brokenImage.evaluate((image) => {
-    image.dispatchEvent(new Event("error"));
-  });
-  await expect(brokenCard.locator("img")).toHaveCount(0);
+  await expect(brokenImage).toHaveCount(0);
   await expect(brokenCard).toContainText(BROKEN_TITLE);
 
   await facebookCard.hover();
@@ -281,8 +274,7 @@ test("feed card overhaul actions and reader open flow work", async ({ app }) => 
   await expect(app.page.getByLabel("Archive").first()).toBeVisible();
   const compactRailCard = app.page.locator('[data-testid="compact-feed-panel-scroll-container"] [data-feed-item-id="test-facebook-card-ui-overhaul"]');
   const compactRailImage = compactRailCard.locator(`img[src="${FACEBOOK_MEDIA_URL}"]`).first();
-  await expect(compactRailImage).toBeVisible();
-  await expect(compactRailImage).toHaveAttribute("src", /\/freed\.svg\?feed-card$/);
+  await expect(compactRailImage).toHaveCount(0);
 
   const openReaderButton = app.page.getByRole("button", { name: "Open", exact: true }).first();
   await expect(openReaderButton).toBeVisible();


### PR DESCRIPTION
(AI Generated).

## Summary

- Updates the feed-card regression test to match Freed Desktop's reader-only media policy.
- Verifies feed and compact rail cards no longer expect eager remote media images.

## Validation

- `npm run test:e2e -- feed-card-ui.spec.ts --grep "feed card overhaul actions"`
- `npm run validate:feature`

## Release Follow-up

- v26.5.606-dev failed release validation because this regression still expected inline feed media. This patch fixes that blocker so the replacement dev build can run through validation.