### PR TITLE
perf: gate startup social scraper pressure

### DIFF
--- a/packages/desktop/src/App.tsx
+++ b/packages/desktop/src/App.tsx
@@ -194,29 +194,6 @@ function App() {
 
   useEffect(() => {
     if (!legalAccepted || !isInitialized) return;
-    void initProviderHealth();
-    startRssPoller();
-    // Wire the LAN relay change subscription + client-count polling.
-    startSync();
-    // Resume cloud sync loops for any previously authenticated providers.
-    startAllCloudSyncs();
-    if (isTauri()) {
-      void startSnapshotManager();
-    }
-    // Start background content fetcher -- processes article HTML fetch queue.
-    startContentFetcher();
-    startSemanticClassifier({
-      isEnabled: () => {
-        const prefs = useDesktopStore.getState().preferences.ai;
-        return prefs.provider === "integrated" && prefs.extractTopics;
-      },
-      subscribeToPreferenceChanges: (callback) =>
-        useDesktopStore.subscribe((state, previous) => {
-          if (state.preferences.ai !== previous.preferences.ai) {
-            callback();
-          }
-        }),
-    });
     startMemoryMonitor({
       getAutomergeStats: getCachedDocStats,
       onCriticalPressure: () => {
@@ -232,6 +209,29 @@ function App() {
       onSample: (snapshot) => {
         noteMemoryPressure(snapshot);
       },
+    });
+    void initProviderHealth();
+    startRssPoller();
+    // Wire the LAN relay change subscription and client-count polling.
+    startSync();
+    // Resume cloud sync loops for any previously authenticated providers.
+    startAllCloudSyncs();
+    if (isTauri()) {
+      void startSnapshotManager();
+    }
+    // Start background content fetcher, which processes the article HTML queue.
+    startContentFetcher();
+    startSemanticClassifier({
+      isEnabled: () => {
+        const prefs = useDesktopStore.getState().preferences.ai;
+        return prefs.provider === "integrated" && prefs.extractTopics;
+      },
+      subscribeToPreferenceChanges: (callback) =>
+        useDesktopStore.subscribe((state, previous) => {
+          if (state.preferences.ai !== previous.preferences.ai) {
+            callback();
+          }
+        }),
     });
     return () => {
       stopRssPoller();

--- a/packages/desktop/src/lib/automerge-worker-memory.test.ts
+++ b/packages/desktop/src/lib/automerge-worker-memory.test.ts
@@ -57,8 +57,11 @@ describe("automerge worker memory routing", () => {
 
     expect(workerSource).toContain("DESKTOP_UI_CONTENT_TEXT_LIMIT = 600");
     expect(workerSource).toContain("DESKTOP_UI_PRESERVED_TEXT_LIMIT = 240");
+    expect(workerSource).toContain("DESKTOP_UI_LINK_DESCRIPTION_LIMIT = 180");
     expect(body).toContain("contentText.slice(0, DESKTOP_UI_CONTENT_TEXT_LIMIT)");
     expect(body).toContain("preservedText.slice(0, DESKTOP_UI_PRESERVED_TEXT_LIMIT)");
+    expect(workerSource).toContain("linkDescription.slice(0, DESKTOP_UI_LINK_DESCRIPTION_LIMIT)");
+    expect(workerSource).toContain("scores: {}");
     expect(workerSource).toContain(".map(trimFeedItemForDesktopUi)");
     expect(patchBody).toContain("trimFeedItemForDesktopUi(cloned)");
   });

--- a/packages/desktop/src/lib/automerge.worker.ts
+++ b/packages/desktop/src/lib/automerge.worker.ts
@@ -93,6 +93,7 @@ const SLOW_REQUEST_PROCESS_MS = 5_000;
 const SLOW_SAVE_AND_BROADCAST_MS = 2_000;
 const DESKTOP_UI_PRESERVED_TEXT_LIMIT = 240;
 const DESKTOP_UI_CONTENT_TEXT_LIMIT = 600;
+const DESKTOP_UI_LINK_DESCRIPTION_LIMIT = 180;
 const FRESH_DOC_REBUILD_MIN_CHANGED_BINARY_BYTES = 4 * 1024 * 1024;
 const FRESH_DOC_REBUILD_MIN_HISTORY_BINARY_BYTES = 16 * 1024 * 1024;
 const FRESH_DOC_REBUILD_MIN_SAVINGS_RATIO = 0.1;
@@ -301,6 +302,31 @@ function trimFeedItemForDesktopUi(item: FeedItem): FeedItem {
       content: {
         ...next.content,
         text: contentText.slice(0, DESKTOP_UI_CONTENT_TEXT_LIMIT),
+      },
+    };
+  }
+
+  const linkPreview = next.content.linkPreview;
+  const linkDescription = linkPreview?.description;
+  if (linkDescription && linkDescription.length > DESKTOP_UI_LINK_DESCRIPTION_LIMIT) {
+    next = {
+      ...next,
+      content: {
+        ...next.content,
+        linkPreview: {
+          ...linkPreview,
+          description: linkDescription.slice(0, DESKTOP_UI_LINK_DESCRIPTION_LIMIT),
+        },
+      },
+    };
+  }
+
+  if (next.contentSignals && Object.keys(next.contentSignals.scores ?? {}).length > 0) {
+    next = {
+      ...next,
+      contentSignals: {
+        ...next.contentSignals,
+        scores: {},
       },
     };
   }

--- a/packages/desktop/src/lib/fb-capture.ts
+++ b/packages/desktop/src/lib/fb-capture.ts
@@ -201,6 +201,15 @@ export async function fetchFbFeed(): Promise<FbSyncResult> {
 
 export async function captureFbGroups(): Promise<FbGroupInfo[]> {
   const store = useAppStore.getState();
+  const memoryPrep = await prepareSocialScrapeMemory("facebook", "groups scrape");
+  if (!memoryPrep.mayProceed) {
+    addDebugEvent(
+      "change",
+      `[FB] group refresh deferred for memory pressure: ${formatBytesForMemoryLog(memoryPrep.after.appResidentBytes)} after cleanup`,
+    );
+    return [];
+  }
+
   const groups = await invoke<FbGroupInfo[]>("fb_scrape_groups", {
     windowMode: getFbScraperWindowMode(),
   });

--- a/packages/desktop/src/lib/social-capture-memory-pressure.test.ts
+++ b/packages/desktop/src/lib/social-capture-memory-pressure.test.ts
@@ -137,6 +137,15 @@ describe("social capture memory pressure gate", () => {
     expect(mocks.invoke).not.toHaveBeenCalledWith("fb_scrape_feed", expect.anything());
   });
 
+  it("defers Facebook groups before invoking the native scraper", async () => {
+    const { captureFbGroups } = await import("./fb-capture");
+    const result = await captureFbGroups();
+
+    expect(result).toEqual([]);
+    expect(mocks.prepareSocialScrapeMemory).toHaveBeenCalledWith("facebook", "groups scrape");
+    expect(mocks.invoke).not.toHaveBeenCalledWith("fb_scrape_groups", expect.anything());
+  });
+
   it("returns Instagram memory diagnostics before invoking the native scraper", async () => {
     const { fetchIgFeed } = await import("./instagram-capture");
     const result = await fetchIgFeed();


### PR DESCRIPTION
(AI Generated).

Summary:
- Start Desktop memory monitoring before startup background pollers so pressure samples feed the background gate before native scrapers run.
- Add the same social scrape memory preflight to Facebook group refreshes that feed scrapes already use.
- Slim the Desktop renderer item projection by capping link-preview descriptions and removing signal score maps that the UI does not read.

Tests:
- npm run test:unit -- social-capture-memory-pressure.test.ts
- npm run test:unit -- memory-monitor-social-preflight.test.ts background-runtime-coordinator.test.ts
- npm run test:unit -- automerge-worker-memory.test.ts social-capture-memory-pressure.test.ts memory-monitor-social-preflight.test.ts background-runtime-coordinator.test.ts
- npm run build in packages/desktop
- npm run validate:feature
