### PR TITLE
perf: drop reader text from renderer projection

### DIFF
--- a/packages/desktop/src/lib/automerge-worker-memory.test.ts
+++ b/packages/desktop/src/lib/automerge-worker-memory.test.ts
@@ -56,7 +56,7 @@ describe("automerge worker memory routing", () => {
     const patchBody = functionBody("cloneFeedItemForPatch");
 
     expect(workerSource).toContain("DESKTOP_UI_CONTENT_TEXT_LIMIT = 600");
-    expect(workerSource).toContain("DESKTOP_UI_PRESERVED_TEXT_LIMIT = 240");
+    expect(workerSource).toContain("DESKTOP_UI_PRESERVED_TEXT_LIMIT = 0");
     expect(workerSource).toContain("DESKTOP_UI_LINK_DESCRIPTION_LIMIT = 180");
     expect(body).toContain("contentText.slice(0, DESKTOP_UI_CONTENT_TEXT_LIMIT)");
     expect(body).toContain("preservedText.slice(0, DESKTOP_UI_PRESERVED_TEXT_LIMIT)");

--- a/packages/desktop/src/lib/automerge.worker.ts
+++ b/packages/desktop/src/lib/automerge.worker.ts
@@ -91,7 +91,7 @@ let searchCorpusVersion = 0;
 const SLOW_QUEUE_WAIT_MS = 1_000;
 const SLOW_REQUEST_PROCESS_MS = 5_000;
 const SLOW_SAVE_AND_BROADCAST_MS = 2_000;
-const DESKTOP_UI_PRESERVED_TEXT_LIMIT = 240;
+const DESKTOP_UI_PRESERVED_TEXT_LIMIT = 0;
 const DESKTOP_UI_CONTENT_TEXT_LIMIT = 600;
 const DESKTOP_UI_LINK_DESCRIPTION_LIMIT = 180;
 const FRESH_DOC_REBUILD_MIN_CHANGED_BINARY_BYTES = 4 * 1024 * 1024;
@@ -286,6 +286,8 @@ function trimFeedItemForDesktopUi(item: FeedItem): FeedItem {
   const preservedContent = item.preservedContent;
   const preservedText = preservedContent?.text;
   if (preservedContent && preservedText && preservedText.length > DESKTOP_UI_PRESERVED_TEXT_LIMIT) {
+    // The reader asks the worker for full preserved text on demand. Keeping
+    // it in every renderer item makes all non-reader surfaces pay for it.
     next = {
       ...next,
       preservedContent: {


### PR DESCRIPTION
(AI Generated).

Summary:
- Stop sending synced preserved reader text through every Desktop renderer item.
- Keep full preserved text available through the existing worker on-demand reader text request.
- Preserve the existing renderer text caps for feed content, link preview descriptions, and signal score maps.

Measured impact:
- Local 11,686 item snapshot projected item JSON drops from 18,200,218 bytes to 16,815,526 bytes, saving 1,384,692 raw bytes before WebKit object expansion.

Tests:
- npm run test:unit -- automerge-worker-memory.test.ts
- node ../../node_modules/playwright/cli.js test reader-hydration.spec.ts --grep "uncached online articles hydrate"
- PATH=/Users/aubreyfalconer/dev/freed-renderer-preserved-text/node_modules/.bin:$PATH npm run build in packages/desktop
- npm run validate:feature