### PR TITLE
fix: route Google Drive through native sync requests

### DIFF
--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -1862,6 +1862,75 @@ async fn google_api_request(url: String, access_token: String) -> Result<String,
     Ok(body)
 }
 
+#[derive(serde::Serialize)]
+struct GoogleDriveResponse {
+    status: u16,
+    headers: Vec<(String, String)>,
+    body: Vec<u8>,
+}
+
+/// Make a Google Drive API request through the native networking stack.
+#[tauri::command]
+async fn google_drive_request(
+    url: String,
+    method: Option<String>,
+    headers: Option<Vec<(String, String)>>,
+    body: Option<Vec<u8>>,
+) -> Result<GoogleDriveResponse, String> {
+    let parsed = url::Url::parse(&url)
+        .map_err(|e| format!("Invalid Google Drive API URL: {}", e))?;
+    let allowed_path = parsed.path().starts_with("/drive/v3/")
+        || parsed.path().starts_with("/upload/drive/v3/");
+    if parsed.scheme() != "https" || parsed.host_str() != Some("www.googleapis.com") || !allowed_path {
+        return Err("Google Drive API URL is not allowed".to_string());
+    }
+
+    let method_name = method.unwrap_or_else(|| "GET".to_string()).to_uppercase();
+    let method = match method_name.as_str() {
+        "GET" => reqwest::Method::GET,
+        "POST" => reqwest::Method::POST,
+        "PATCH" => reqwest::Method::PATCH,
+        "DELETE" => reqwest::Method::DELETE,
+        _ => return Err(format!("Google Drive API method is not allowed: {}", method_name)),
+    };
+
+    let client = reqwest::Client::builder()
+        .user_agent("Freed/1.0 (https://freed.wtf)")
+        .build()
+        .map_err(|e| e.to_string())?;
+
+    let mut builder = client.request(method, parsed);
+    for (key, value) in headers.unwrap_or_default() {
+        builder = builder.header(&key, &value);
+    }
+    if let Some(body) = body {
+        builder = builder.body(body);
+    }
+
+    let response = builder
+        .send()
+        .await
+        .map_err(|e| format!("Google Drive request failed: {}", e))?;
+    let status = response.status().as_u16();
+    let headers = response
+        .headers()
+        .iter()
+        .filter_map(|(key, value)| {
+            value
+                .to_str()
+                .ok()
+                .map(|value| (key.as_str().to_string(), value.to_string()))
+        })
+        .collect();
+    let body = response.bytes().await.map_err(|e| e.to_string())?.to_vec();
+
+    Ok(GoogleDriveResponse {
+        status,
+        headers,
+        body,
+    })
+}
+
 /// Fetch any URL and return its body as bytes for permanent local media archive.
 #[tauri::command]
 async fn fetch_binary_url(url: String) -> Result<Vec<u8>, String> {
@@ -6564,6 +6633,7 @@ pub fn run() {
             retry_startup_after_crash,
             fetch_url,
             google_api_request,
+            google_drive_request,
             fetch_binary_url,
             x_api_request,
             get_local_ip,

--- a/packages/desktop/src/App.tsx
+++ b/packages/desktop/src/App.tsx
@@ -37,6 +37,7 @@ import {
   clearCloudProvider,
   deleteCloudFile,
   startCloudSync,
+  setGoogleDriveFetch,
   initiateDesktopOAuth,
   isOAuthCanceledError,
   storeCloudToken,
@@ -67,6 +68,7 @@ import { start as startSemanticClassifier, stop as stopSemanticClassifier } from
 import { useAppStore as useDesktopStore, withProviderSyncing } from "./lib/store";
 import { pickContactViaTauri } from "./lib/contacts";
 import { fetchGoogleContactsViaTauri } from "./lib/google-contacts";
+import { googleDriveFetchViaTauri } from "./lib/google-drive";
 import { FeedEmptyState } from "./components/FeedEmptyState";
 import { XSettingsSection } from "./components/XSettingsSection";
 import { FacebookSettingsSection } from "./components/FacebookSettingsSection";
@@ -113,6 +115,7 @@ const RENDERER_HEARTBEAT_INTERVAL_MS = 15 * 1000;
 // Register the desktop log transport so addDebugEvent calls from ui/ flow
 // through the native logger in both local preview and release builds.
 setLogTransport((level, msg) => log[level](msg));
+setGoogleDriveFetch(googleDriveFetchViaTauri);
 
 // ---------------------------------------------------------------------------
 // React Profiler — activated only under Playwright (VITE_TEST_TAURI=1)
@@ -585,18 +588,14 @@ function App() {
       storeCloudToken(provider, token);
       await startCloudSync(provider, token.accessToken);
     } catch (error) {
-      if (provider === "gdrive") {
-        recordGoogleContactsConnectError(error);
-      }
       throw error;
     }
-  }, [recordGoogleContactsConnectError]);
+  }, []);
 
   const connectGoogleContacts = useCallback(async (options?: { signal?: AbortSignal }) => {
+    let token: Awaited<ReturnType<typeof initiateDesktopOAuth>>;
     try {
-      const token = await initiateDesktopOAuth("gdrive", options);
-      storeCloudToken("gdrive", token);
-      await startCloudSync("gdrive", token.accessToken);
+      token = await initiateDesktopOAuth("gdrive", options);
     } catch (error) {
       if (isOAuthCanceledError(error)) {
         log.info("[contacts] Google reconnect canceled");
@@ -604,6 +603,14 @@ function App() {
       }
       recordGoogleContactsConnectError(error);
       throw error;
+    }
+
+    storeCloudToken("gdrive", token);
+    try {
+      await startCloudSync("gdrive", token.accessToken);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      log.warn(`[contacts] Google Drive sync failed after Contacts reconnect: ${message}`);
     }
   }, [recordGoogleContactsConnectError]);
 

--- a/packages/desktop/src/__mocks__/@tauri-apps/api/core.ts
+++ b/packages/desktop/src/__mocks__/@tauri-apps/api/core.ts
@@ -67,6 +67,28 @@ async function proxyFetchBinary(args: Record<string, unknown>): Promise<number[]
   return Array.from(new Uint8Array(await resp.arrayBuffer()));
 }
 
+async function proxyGoogleDriveRequest(args: Record<string, unknown>): Promise<{
+  status: number;
+  headers: Array<[string, string]>;
+  body: number[];
+}> {
+  const resp = await fetch("/api/proxy", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      url: args.url,
+      headers: args.headers ?? [],
+      method: args.method ?? "GET",
+      body: args.body ?? [],
+    }),
+  });
+  return {
+    status: resp.status,
+    headers: Array.from(resp.headers.entries()),
+    body: Array.from(new Uint8Array(await resp.arrayBuffer())),
+  };
+}
+
 /** Default handlers for every command the app calls on startup. */
 const handlers: Record<string, Handler> = {
   broadcast_doc: () => null,
@@ -76,6 +98,7 @@ const handlers: Record<string, Handler> = {
     method: "GET",
     headers: { Authorization: `Bearer ${String(args.accessToken ?? "")}` },
   }),
+  google_drive_request: (args: Record<string, unknown>) => proxyGoogleDriveRequest(args),
   fetch_binary_url: (args: Record<string, unknown>) => proxyFetchBinary({ url: args.url, method: "GET" }),
   x_api_request: (args: Record<string, unknown>) => proxyFetch(args),
   get_local_ip: () => "127.0.0.1",

--- a/packages/desktop/src/lib/gdrive-sync.test.ts
+++ b/packages/desktop/src/lib/gdrive-sync.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { gdriveStartPollLoop, gdriveUploadSafe } from "@freed/sync/cloud";
+import { gdriveDownloadLatest, gdriveStartPollLoop, gdriveUploadSafe } from "@freed/sync/cloud";
 
 function jsonResponse(body: unknown, init?: ResponseInit): Response {
   return new Response(JSON.stringify(body), {
@@ -72,6 +72,46 @@ describe("Google Drive cloud sync", () => {
 
     expect(uploadHeaders).toHaveLength(1);
     expect(uploadHeaders[0]).toMatchObject({ "If-Match": '"server-etag"' });
+  });
+
+  it("can route Drive downloads through a platform fetcher", async () => {
+    const globalFetch = vi.fn();
+    vi.stubGlobal("fetch", globalFetch);
+    const platformFetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/files?")) {
+        return jsonResponse({ files: [{ id: "file-1" }] });
+      }
+      if (url.includes("/files/file-1?fields=")) {
+        return jsonResponse({ size: "0" });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    await expect(gdriveDownloadLatest("token", undefined, platformFetch)).resolves.toBeNull();
+
+    expect(platformFetch).toHaveBeenCalled();
+    expect(globalFetch).not.toHaveBeenCalled();
+  });
+
+  it("preserves Google Drive error body details for sync diagnostics", async () => {
+    vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/files?")) {
+        return jsonResponse({
+          error: {
+            message: "Request had insufficient authentication scopes.",
+            errors: [{ reason: "insufficientPermissions" }],
+          },
+        }, { status: 403, statusText: "Forbidden" });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    }));
+
+    await expect(gdriveDownloadLatest("token")).rejects.toMatchObject({
+      message: "GDrive list failed: 403 Forbidden - Request had insufficient authentication scopes. (insufficientPermissions)",
+      status: 403,
+    });
   });
 
   it("omits If-Match instead of sending an invalid md5 checksum as an ETag", async () => {

--- a/packages/desktop/src/lib/google-contacts-platform.test.ts
+++ b/packages/desktop/src/lib/google-contacts-platform.test.ts
@@ -42,4 +42,15 @@ describe("desktop Google Contacts platform fetch", () => {
       status: 403,
     });
   });
+
+  it("replaces WebKit load failures with an actionable Contacts error", async () => {
+    invokeMock.mockRejectedValueOnce("Load failed");
+
+    const { fetchGoogleContactsViaTauri } = await import("./google-contacts");
+
+    await expect(fetchGoogleContactsViaTauri("access-token", null)).rejects.toMatchObject({
+      message: "Google Contacts request failed before Google returned a response. Check your network connection and try again.",
+      rawMessage: "Load failed",
+    });
+  });
 });

--- a/packages/desktop/src/lib/google-contacts.ts
+++ b/packages/desktop/src/lib/google-contacts.ts
@@ -6,11 +6,22 @@ import {
 } from "@freed/shared/google-contacts";
 
 const GOOGLE_CONTACTS_CONNECTIONS_URL = "https://people.googleapis.com/v1/people/me/connections";
+const NETWORK_FAILURE_MESSAGES = new Set([
+  "Load failed",
+  "Failed to fetch",
+  "NetworkError when attempting to fetch resource.",
+]);
 
 function coerceGoogleApiError(error: unknown): Error {
   const message = error instanceof Error ? error.message : String(error);
   const statusMatch = message.match(/Google API error\s+(\d{3})|HTTP\s+(\d{3})/);
   const status = statusMatch ? Number(statusMatch[1] ?? statusMatch[2]) : undefined;
+  if (!status && NETWORK_FAILURE_MESSAGES.has(message)) {
+    return Object.assign(
+      new Error("Google Contacts request failed before Google returned a response. Check your network connection and try again."),
+      { rawMessage: message },
+    );
+  }
   return Object.assign(new Error(message), status ? { status } : {});
 }
 

--- a/packages/desktop/src/lib/google-drive.test.ts
+++ b/packages/desktop/src/lib/google-drive.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const invokeMock = vi.fn();
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: invokeMock,
+}));
+
+describe("desktop Google Drive platform fetch", () => {
+  afterEach(() => {
+    invokeMock.mockReset();
+  });
+
+  it("routes Drive API requests through the Tauri command", async () => {
+    invokeMock.mockResolvedValueOnce({
+      status: 200,
+      headers: [["content-type", "application/json"]],
+      body: Array.from(new TextEncoder().encode('{"files":[{"id":"file-1"}]}')),
+    });
+
+    const { googleDriveFetchViaTauri } = await import("./google-drive");
+    const response = await googleDriveFetchViaTauri(
+      "https://www.googleapis.com/drive/v3/files?spaces=appDataFolder",
+      { headers: { Authorization: "Bearer token" } },
+    );
+
+    expect(invokeMock).toHaveBeenCalledWith("google_drive_request", {
+      url: "https://www.googleapis.com/drive/v3/files?spaces=appDataFolder",
+      method: "GET",
+      headers: [["Authorization", "Bearer token"]],
+      body: undefined,
+    });
+    await expect(response.json()).resolves.toEqual({ files: [{ id: "file-1" }] });
+  });
+
+  it("sends upload bytes through the Tauri command", async () => {
+    invokeMock.mockResolvedValueOnce({
+      status: 200,
+      headers: [],
+      body: [],
+    });
+
+    const { googleDriveFetchViaTauri } = await import("./google-drive");
+    const response = await googleDriveFetchViaTauri(
+      "https://www.googleapis.com/upload/drive/v3/files/file-1?uploadType=media",
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/octet-stream" },
+        body: new Uint8Array([1, 2, 3]),
+      },
+    );
+
+    expect(invokeMock).toHaveBeenCalledWith("google_drive_request", {
+      url: "https://www.googleapis.com/upload/drive/v3/files/file-1?uploadType=media",
+      method: "PATCH",
+      headers: [["Content-Type", "application/octet-stream"]],
+      body: [1, 2, 3],
+    });
+    expect(response.ok).toBe(true);
+  });
+
+  it("supports empty 204 Drive responses", async () => {
+    invokeMock.mockResolvedValueOnce({
+      status: 204,
+      headers: [],
+      body: [],
+    });
+
+    const { googleDriveFetchViaTauri } = await import("./google-drive");
+    const response = await googleDriveFetchViaTauri(
+      "https://www.googleapis.com/drive/v3/files/file-1",
+      { method: "DELETE" },
+    );
+
+    expect(response.status).toBe(204);
+    await expect(response.text()).resolves.toBe("");
+  });
+});

--- a/packages/desktop/src/lib/google-drive.ts
+++ b/packages/desktop/src/lib/google-drive.ts
@@ -1,0 +1,53 @@
+import { invoke } from "@tauri-apps/api/core";
+
+interface NativeGoogleDriveResponse {
+  status: number;
+  headers: Array<[string, string]>;
+  body: number[];
+}
+
+function throwIfAborted(signal?: AbortSignal | null): void {
+  if (signal?.aborted) {
+    const error = new Error("Google Drive request canceled.");
+    error.name = "AbortError";
+    throw error;
+  }
+}
+
+function headersToEntries(headers?: HeadersInit): Array<[string, string]> {
+  if (!headers) return [];
+  if (headers instanceof Headers) return Array.from(headers.entries());
+  if (Array.isArray(headers)) return headers.map(([key, value]) => [key, value]);
+  return Object.entries(headers).map(([key, value]) => [key, String(value)]);
+}
+
+function bodyToBytes(body?: BodyInit | null): number[] | undefined {
+  if (!body) return undefined;
+  if (typeof body === "string") return Array.from(new TextEncoder().encode(body));
+  if (body instanceof Uint8Array) return Array.from(body);
+  if (body instanceof ArrayBuffer) return Array.from(new Uint8Array(body));
+  throw new Error("Google Drive native requests only support string and binary bodies.");
+}
+
+export async function googleDriveFetchViaTauri(
+  input: RequestInfo | URL,
+  init: RequestInit = {},
+): Promise<Response> {
+  const url = String(input);
+  throwIfAborted(init.signal);
+
+  const response = await invoke<NativeGoogleDriveResponse>("google_drive_request", {
+    url,
+    method: init.method ?? "GET",
+    headers: headersToEntries(init.headers),
+    body: bodyToBytes(init.body),
+  });
+
+  throwIfAborted(init.signal);
+
+  const body = response.body.length > 0 ? new Uint8Array(response.body) : null;
+  return new Response(body, {
+    status: response.status,
+    headers: response.headers,
+  });
+}

--- a/packages/desktop/src/lib/sync.ts
+++ b/packages/desktop/src/lib/sync.ts
@@ -19,6 +19,7 @@ import {
   dropboxDownloadLatest,
   dropboxDeleteFile,
   type CloudProvider,
+  type GoogleDriveFetch,
 } from "@freed/sync/cloud";
 import { getDocBinary, mergeDoc, subscribe, setRelayClientCount } from "./automerge";
 import { addDebugEvent } from "@freed/ui/lib/debug-store";
@@ -29,6 +30,12 @@ import {
   isBackgroundRuntimeDeferredError,
   runBackgroundJob,
 } from "./background-runtime-coordinator";
+
+let googleDriveFetch: GoogleDriveFetch | undefined;
+
+export function setGoogleDriveFetch(fetcher: GoogleDriveFetch | undefined): void {
+  googleDriveFetch = fetcher;
+}
 
 const FALLBACK_SYNC_PORT = import.meta.env.VITE_FREED_SYNC_PORT || "8765";
 const RELAY_POLL_TIMEOUT_MS = 5_000;
@@ -710,8 +717,9 @@ export async function startCloudSync(provider: CloudProvider, token: string): Pr
 
   // Immediate pull to catch up on any changes since last session.
   try {
-    const download = provider === "gdrive" ? gdriveDownloadLatest : dropboxDownloadLatest;
-    const remote = await download(await resolveToken(), signal);
+    const remote = provider === "gdrive"
+      ? await gdriveDownloadLatest(await resolveToken(), signal, googleDriveFetch)
+      : await dropboxDownloadLatest(await resolveToken(), signal);
     if (remote) {
       await mergeDoc(remote);
       console.log("[CloudSync/%s] Initial merge (%d bytes)", provider, remote.length);
@@ -789,7 +797,7 @@ export async function startCloudSync(provider: CloudProvider, token: string): Pr
       while (!signal.aborted) {
         const pollToken = await resolveToken();
         try {
-          await gdriveStartPollLoop(pollToken, onRemoteChange, signal, cloudLog);
+          await gdriveStartPollLoop(pollToken, onRemoteChange, signal, cloudLog, googleDriveFetch);
           return;
         } catch (error) {
           if (signal.aborted) return;
@@ -875,7 +883,7 @@ export function stopAllCloudSyncs(): void {
 export async function deleteCloudFile(provider: CloudProvider, token: string): Promise<void> {
   stopCloudSync(provider);
   if (provider === "gdrive") {
-    await gdriveDeleteFile(token);
+    await gdriveDeleteFile(token, googleDriveFetch);
   } else {
     await dropboxDeleteFile(token);
   }
@@ -913,7 +921,7 @@ export function scheduleCloudUpload(provider: CloudProvider, token?: string): vo
               const uploadToken = token ?? await getValidCloudToken(provider);
               if (!uploadToken) throw new Error("Cloud token missing. Reconnect the provider.");
               if (provider === "gdrive") {
-                await gdriveUploadSafe(uploadToken, binary);
+                await gdriveUploadSafe(uploadToken, binary, googleDriveFetch);
               } else {
                 await dropboxUploadSafe(uploadToken, binary);
               }

--- a/packages/desktop/tests/e2e/fixtures/tauri-init.ts
+++ b/packages/desktop/tests/e2e/fixtures/tauri-init.ts
@@ -28,6 +28,7 @@ export function tauriInitScript(): string {
       broadcast_doc: timedHandler('broadcast_doc', function() { return null; }),
       fetch_url: () => '',
       google_api_request: () => '{"connections":[],"nextSyncToken":"test-sync-token"}',
+      google_drive_request: () => ({ status: 200, headers: [['content-type', 'application/json']], body: Array.from(new TextEncoder().encode('{"files":[]}')) }),
       fetch_binary_url: () => [],
       get_local_ip: () => '127.0.0.1',
       get_all_local_ips: () => [],

--- a/packages/sync/src/cloud/gdrive.ts
+++ b/packages/sync/src/cloud/gdrive.ts
@@ -20,9 +20,43 @@ const MAX_RETRIES = 3;
 /** Per-iteration network timeout. Prevents a stalled fetch from freezing the loop. */
 const ITERATION_TIMEOUT_MS = 90_000;
 const HEARTBEAT_EVERY_N_ITERS = 120; // every 120 * 5 s = 10 minutes
+export type GoogleDriveFetch = typeof fetch;
 
-function gdriveError(message: string, status: number): Error & { status: number } {
-  return Object.assign(new Error(`${message}: ${status}`), { status });
+function parseGoogleDriveErrorBody(body: string): string | null {
+  if (!body.trim()) return null;
+  try {
+    const parsed = JSON.parse(body) as {
+      error?: {
+        message?: unknown;
+        status?: unknown;
+        errors?: Array<{ reason?: unknown; message?: unknown }>;
+      };
+    };
+    const googleMessage = typeof parsed.error?.message === "string"
+      ? parsed.error.message
+      : null;
+    const reason = typeof parsed.error?.errors?.[0]?.reason === "string"
+      ? parsed.error.errors[0].reason
+      : null;
+    if (googleMessage && reason) return `${googleMessage} (${reason})`;
+    if (googleMessage) return googleMessage;
+    if (reason) return reason;
+  } catch {
+    // Fall through to a trimmed plain text body.
+  }
+  return body.trim().slice(0, 500);
+}
+
+async function gdriveError(message: string, response: Response): Promise<Error & { status: number }> {
+  const body = await response.text().catch(() => "");
+  const detail = parseGoogleDriveErrorBody(body);
+  const statusLabel = response.statusText
+    ? `${response.status} ${response.statusText}`
+    : String(response.status);
+  const fullMessage = detail
+    ? `${message}: ${statusLabel} - ${detail}`
+    : `${message}: ${statusLabel}`;
+  return Object.assign(new Error(fullMessage), { status: response.status });
 }
 
 interface DownloadResult {
@@ -32,17 +66,21 @@ interface DownloadResult {
 }
 
 /** Return the fileId of `freed.automerge` in appDataFolder, creating it if absent. */
-async function ensureFile(token: string, signal?: AbortSignal): Promise<string> {
-  const listRes = await fetch(
+async function ensureFile(
+  token: string,
+  signal?: AbortSignal,
+  googleFetch: GoogleDriveFetch = fetch,
+): Promise<string> {
+  const listRes = await googleFetch(
     `${GDRIVE_FILES}?spaces=appDataFolder&q=name%3D'${FILE_NAME}'&fields=files(id)`,
     { headers: { Authorization: `Bearer ${token}` }, signal },
   );
-  if (!listRes.ok) throw gdriveError("GDrive list failed", listRes.status);
+  if (!listRes.ok) throw await gdriveError("GDrive list failed", listRes);
 
   const { files } = await listRes.json();
   if (files.length > 0) return files[0].id as string;
 
-  const createRes = await fetch(GDRIVE_FILES, {
+  const createRes = await googleFetch(GDRIVE_FILES, {
     method: "POST",
     headers: {
       Authorization: `Bearer ${token}`,
@@ -51,7 +89,7 @@ async function ensureFile(token: string, signal?: AbortSignal): Promise<string> 
     body: JSON.stringify({ name: FILE_NAME, parents: ["appDataFolder"] }),
     signal,
   });
-  if (!createRes.ok) throw gdriveError("GDrive create failed", createRes.status);
+  if (!createRes.ok) throw await gdriveError("GDrive create failed", createRes);
 
   const { id } = await createRes.json();
   return id as string;
@@ -61,12 +99,13 @@ async function download(
   token: string,
   fileId: string,
   signal?: AbortSignal,
+  googleFetch: GoogleDriveFetch = fetch,
 ): Promise<DownloadResult> {
-  const metaRes = await fetch(
+  const metaRes = await googleFetch(
     `${GDRIVE_FILES}/${fileId}?fields=md5Checksum,size`,
     { headers: { Authorization: `Bearer ${token}` }, signal },
   );
-  if (!metaRes.ok) throw gdriveError("GDrive meta failed", metaRes.status);
+  if (!metaRes.ok) throw await gdriveError("GDrive meta failed", metaRes);
   const etag = metaRes.headers.get("ETag");
   const { size } = await metaRes.json();
 
@@ -74,11 +113,11 @@ async function download(
     return { binary: null, etag, fileId };
   }
 
-  const contentRes = await fetch(`${GDRIVE_FILES}/${fileId}?alt=media`, {
+  const contentRes = await googleFetch(`${GDRIVE_FILES}/${fileId}?alt=media`, {
     headers: { Authorization: `Bearer ${token}` },
     signal,
   });
-  if (!contentRes.ok) throw gdriveError("GDrive download failed", contentRes.status);
+  if (!contentRes.ok) throw await gdriveError("GDrive download failed", contentRes);
 
   return {
     binary: new Uint8Array(await contentRes.arrayBuffer()),
@@ -91,14 +130,18 @@ async function download(
  * Safe upload: always download remote first, CRDT-merge, then upload with
  * If-Match so a concurrent desktop write returns 412 → retry with back-off.
  */
-export async function gdriveUploadSafe(token: string, localBinary: Uint8Array): Promise<void> {
-  const fileId = await ensureFile(token);
+export async function gdriveUploadSafe(
+  token: string,
+  localBinary: Uint8Array,
+  googleFetch: GoogleDriveFetch = fetch,
+): Promise<void> {
+  const fileId = await ensureFile(token, undefined, googleFetch);
 
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
-    const { binary: remoteBinary, etag } = await download(token, fileId);
+    const { binary: remoteBinary, etag } = await download(token, fileId, undefined, googleFetch);
     const merged = remoteBinary ? mergeBinaries(localBinary, remoteBinary) : localBinary;
 
-    const res = await fetch(`${GDRIVE_UPLOAD}/${fileId}?uploadType=media`, {
+    const res = await googleFetch(`${GDRIVE_UPLOAD}/${fileId}?uploadType=media`, {
       method: "PATCH",
       headers: {
         Authorization: `Bearer ${token}`,
@@ -113,7 +156,7 @@ export async function gdriveUploadSafe(token: string, localBinary: Uint8Array): 
       await delay(200 * 2 ** attempt);
       continue;
     }
-    throw gdriveError("GDrive upload failed", res.status);
+    throw await gdriveError("GDrive upload failed", res);
   }
 
   throw new Error("GDrive upload failed after max retries (concurrent write conflict)");
@@ -122,9 +165,10 @@ export async function gdriveUploadSafe(token: string, localBinary: Uint8Array): 
 export async function gdriveDownloadLatest(
   token: string,
   signal?: AbortSignal,
+  googleFetch: GoogleDriveFetch = fetch,
 ): Promise<Uint8Array | null> {
-  const fileId = await ensureFile(token, signal);
-  const { binary } = await download(token, fileId, signal);
+  const fileId = await ensureFile(token, signal, googleFetch);
+  const { binary } = await download(token, fileId, signal, googleFetch);
   return binary;
 }
 
@@ -133,22 +177,25 @@ export async function gdriveDownloadLatest(
  * Used during factory reset when the user opts to also wipe cloud storage.
  * Silently succeeds if the file does not exist (404).
  */
-export async function gdriveDeleteFile(token: string): Promise<void> {
-  const listRes = await fetch(
+export async function gdriveDeleteFile(
+  token: string,
+  googleFetch: GoogleDriveFetch = fetch,
+): Promise<void> {
+  const listRes = await googleFetch(
     `${GDRIVE_FILES}?spaces=appDataFolder&q=name%3D'${FILE_NAME}'&fields=files(id)`,
     { headers: { Authorization: `Bearer ${token}` } },
   );
-  if (!listRes.ok) throw gdriveError("GDrive list failed", listRes.status);
+  if (!listRes.ok) throw await gdriveError("GDrive list failed", listRes);
 
   const { files } = await listRes.json();
   if (files.length === 0) return; // Nothing to delete.
 
-  const deleteRes = await fetch(`${GDRIVE_FILES}/${files[0].id}`, {
+  const deleteRes = await googleFetch(`${GDRIVE_FILES}/${files[0].id}`, {
     method: "DELETE",
     headers: { Authorization: `Bearer ${token}` },
   });
   if (!deleteRes.ok && deleteRes.status !== 404) {
-    throw gdriveError("GDrive delete failed", deleteRes.status);
+    throw await gdriveError("GDrive delete failed", deleteRes);
   }
 }
 
@@ -167,16 +214,17 @@ export async function gdriveStartPollLoop(
   onRemoteChange: (binary: Uint8Array) => void,
   signal: AbortSignal,
   onLog?: (level: "info" | "warn" | "error", msg: string) => void,
+  googleFetch: GoogleDriveFetch = fetch,
 ): Promise<void> {
   const log = (level: "info" | "warn" | "error", msg: string) => onLog?.(level, msg);
 
-  const startRes = await fetch(`${GDRIVE_CHANGES}/startPageToken`, {
+  const startRes = await googleFetch(`${GDRIVE_CHANGES}/startPageToken`, {
     headers: { Authorization: `Bearer ${token}` },
   });
-  if (!startRes.ok) throw gdriveError("GDrive startPageToken failed", startRes.status);
+  if (!startRes.ok) throw await gdriveError("GDrive startPageToken failed", startRes);
   let { startPageToken: cursor } = await startRes.json();
 
-  const fileId = await ensureFile(token);
+  const fileId = await ensureFile(token, undefined, googleFetch);
 
   log("info", "[cloud/gdrive] poll loop started");
   let iterCount = 0;
@@ -195,13 +243,13 @@ export async function gdriveStartPollLoop(
       // stalled GDrive fetch doesn't hold the loop open overnight.
       const iterSignal = AbortSignal.any([signal, AbortSignal.timeout(ITERATION_TIMEOUT_MS)]);
 
-      const changesRes = await fetch(
+      const changesRes = await googleFetch(
         `${GDRIVE_CHANGES}?pageToken=${cursor}&spaces=appDataFolder&fields=nextPageToken,newStartPageToken,changes(fileId)`,
         { headers: { Authorization: `Bearer ${token}` }, signal: iterSignal },
       );
       if (!changesRes.ok) {
         if (changesRes.status === 401 || changesRes.status === 403) {
-          throw gdriveError("GDrive changes failed", changesRes.status);
+          throw await gdriveError("GDrive changes failed", changesRes);
         }
         continue;
       }
@@ -214,7 +262,7 @@ export async function gdriveStartPollLoop(
       );
 
       if (changed) {
-        const binary = await gdriveDownloadLatest(token, iterSignal);
+        const binary = await gdriveDownloadLatest(token, iterSignal, googleFetch);
         if (binary) onRemoteChange(binary);
       }
     } catch (err) {

--- a/packages/sync/src/cloud/index.ts
+++ b/packages/sync/src/cloud/index.ts
@@ -11,7 +11,13 @@
  */
 
 export type { CloudProvider } from "./types.js";
-export { gdriveUploadSafe, gdriveDownloadLatest, gdriveStartPollLoop, gdriveDeleteFile } from "./gdrive.js";
+export {
+  gdriveUploadSafe,
+  gdriveDownloadLatest,
+  gdriveStartPollLoop,
+  gdriveDeleteFile,
+  type GoogleDriveFetch,
+} from "./gdrive.js";
 export {
   dropboxUploadSafe,
   dropboxDownloadLatest,


### PR DESCRIPTION
(AI Generated).

## Summary
- Route Freed Desktop Google Drive sync through a native Tauri request command instead of renderer fetch.
- Keep Google Contacts and Google Drive on the same Google token path while preventing Drive startup failures from poisoning Contacts auth state.
- Preserve Google Drive API error body details in sync diagnostics so release logs show scope and permission failures directly.

## Testing
- npm run validate:feature
- cd packages/desktop && npm run test:unit -- src/lib/gdrive-sync.test.ts src/lib/google-drive.test.ts src/lib/google-contacts-platform.test.ts google-contacts-section.test.tsx
- cd packages/desktop && PATH=/Users/aubreyfalconer/dev/freed-google-contacts-finish/node_modules/.bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/usr/local/MacGPG2/bin:/Applications/VMware Fusion.app/Contents/Public:/usr/local/share/dotnet:~/.dotnet/tools:/usr/local/go/bin:/Library/Frameworks/Mono.framework/Versions/Current/Commands:/Users/aubreyfalconer/.nvm/versions/node/v24.14.1/bin:/Users/aubreyfalconer/.codex/tmp/arg0/codex-arg05cJIJd:/Users/aubreyfalconer/.local/bin:/opt/homebrew/opt/mysql-client/bin:/opt/homebrew/bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/Users/aubreyfalconer/.cargo/bin:/Users/aubreyfalconer/go/bin:/Users/aubreyfalconer/.cache/lm-studio/bin:/Users/aubreyfalconer/.safe-chain/bin:/Applications/Codex.app/Contents/Resources:/usr/local/bin npm run build
- cd packages/desktop/src-tauri && cargo check