### PR TITLE
fix: preserve recovered map labels

### DIFF
--- a/packages/ui/src/hooks/useResolvedLocations.ts
+++ b/packages/ui/src/hooks/useResolvedLocations.ts
@@ -71,18 +71,21 @@ export function useResolvedLocations(
     for (const item of feedItems) {
       const friend = personBySourceKey.get(`${item.platform}:${item.author.id}`) ?? null;
       const coordinates = item.location?.coordinates;
+      const signal = extractLocationFromItem(item);
       if (coordinates) {
+        const label = signal && "coordinates" in signal
+          ? signal.name ?? item.location?.name
+          : item.location?.name;
         coordinateItems.push({
           item,
           friend,
           lat: coordinates.lat,
           lng: coordinates.lng,
-          label: item.location?.name,
+          label,
         });
         continue;
       }
 
-      const signal = extractLocationFromItem(item);
       if (!signal || "coordinates" in signal) continue;
       namedRequests.push({
         item,


### PR DESCRIPTION
(AI Generated).

## Summary
- Keeps coordinate-backed Map items on the synchronous path while preserving sanitized labels recovered from low-confidence location URLs.

## Testing
- npm run test:e2e:regression -- --grep 'recoverable story locations appear in All content mode and the mode persists'; npm run validate:feature