### PR TITLE
perf: slim desktop renderer item projection

### DIFF
--- a/packages/desktop/src/lib/automerge-worker-memory.test.ts
+++ b/packages/desktop/src/lib/automerge-worker-memory.test.ts
@@ -55,13 +55,14 @@ describe("automerge worker memory routing", () => {
     const body = functionBody("trimFeedItemForDesktopUi");
     const patchBody = functionBody("cloneFeedItemForPatch");
 
-    expect(workerSource).toContain("DESKTOP_UI_CONTENT_TEXT_LIMIT = 600");
+    expect(workerSource).toContain("DESKTOP_UI_CONTENT_TEXT_LIMIT = 280");
     expect(workerSource).toContain("DESKTOP_UI_PRESERVED_TEXT_LIMIT = 0");
     expect(workerSource).toContain("DESKTOP_UI_LINK_DESCRIPTION_LIMIT = 180");
     expect(body).toContain("contentText.slice(0, DESKTOP_UI_CONTENT_TEXT_LIMIT)");
     expect(body).toContain("preservedText.slice(0, DESKTOP_UI_PRESERVED_TEXT_LIMIT)");
     expect(workerSource).toContain("linkDescription.slice(0, DESKTOP_UI_LINK_DESCRIPTION_LIMIT)");
-    expect(workerSource).toContain("scores: {}");
+    expect(workerSource).toContain("const tags = next.contentSignals.tags ?? []");
+    expect(workerSource).toContain("contentSignals: tags.length > 0 ? ({ tags } as FeedItem[\"contentSignals\"]) : undefined");
     expect(workerSource).toContain(".map(trimFeedItemForDesktopUi)");
     expect(patchBody).toContain("trimFeedItemForDesktopUi(cloned)");
   });

--- a/packages/desktop/src/lib/automerge.worker.ts
+++ b/packages/desktop/src/lib/automerge.worker.ts
@@ -92,7 +92,7 @@ const SLOW_QUEUE_WAIT_MS = 1_000;
 const SLOW_REQUEST_PROCESS_MS = 5_000;
 const SLOW_SAVE_AND_BROADCAST_MS = 2_000;
 const DESKTOP_UI_PRESERVED_TEXT_LIMIT = 0;
-const DESKTOP_UI_CONTENT_TEXT_LIMIT = 600;
+const DESKTOP_UI_CONTENT_TEXT_LIMIT = 280;
 const DESKTOP_UI_LINK_DESCRIPTION_LIMIT = 180;
 const FRESH_DOC_REBUILD_MIN_CHANGED_BINARY_BYTES = 4 * 1024 * 1024;
 const FRESH_DOC_REBUILD_MIN_HISTORY_BINARY_BYTES = 16 * 1024 * 1024;
@@ -323,13 +323,11 @@ function trimFeedItemForDesktopUi(item: FeedItem): FeedItem {
     };
   }
 
-  if (next.contentSignals && Object.keys(next.contentSignals.scores ?? {}).length > 0) {
+  if (next.contentSignals) {
+    const tags = next.contentSignals.tags ?? [];
     next = {
       ...next,
-      contentSignals: {
-        ...next.contentSignals,
-        scores: {},
-      },
+      contentSignals: tags.length > 0 ? ({ tags } as FeedItem["contentSignals"]) : undefined,
     };
   }
 


### PR DESCRIPTION
(AI Generated).

## Summary
- Caps Desktop renderer feed text snippets at 280 characters while keeping full reader text available from the Automerge worker on demand.
- Projects content signals down to tags for renderer state and drops empty signal objects to reduce large-library WebKit allocations.

## Testing
- npm run build from packages/desktop
- npm run test:unit -- automerge-worker-memory.test.ts automerge-state-patches.test.ts from packages/desktop
- npm run test:e2e:regression -- --grep 'uncached online articles hydrate|X post reader hydration|Facebook post reader hydration|Instagram reader hydration' from packages/desktop
- npm run test:e2e:perf:feed -- --grep 'Search input|Reader view open' from packages/desktop
- npm run validate:feature