### PR TITLE
perf: reduce feed search frame work

### DIFF
--- a/packages/pwa/src/lib/feed-action-scope.test.ts
+++ b/packages/pwa/src/lib/feed-action-scope.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 import type { FeedItem } from "@freed/shared";
-import { getFeedActionScope, getFeedArchiveCounts } from "../../../ui/src/lib/feed-action-scope";
+import {
+  collectArchivableFeedActionIds,
+  collectUnreadFeedActionIds,
+  getFeedActionCounts,
+  getFeedArchiveCounts,
+} from "../../../ui/src/lib/feed-action-scope";
 
 function makeItem(globalId: string, userState: Partial<FeedItem["userState"]> = {}): FeedItem {
   return {
@@ -34,7 +39,7 @@ function makeItem(globalId: string, userState: Partial<FeedItem["userState"]> = 
 }
 
 describe("feed action scope", () => {
-  it("collects unread and archivable IDs in one cached pass", () => {
+  it("counts bulk action candidates without collecting IDs during render", () => {
     const items = [
       makeItem("unread"),
       makeItem("read", { readAt: 1 }),
@@ -43,13 +48,12 @@ describe("feed action scope", () => {
       makeItem("archived", { archived: true }),
     ];
 
-    const scope = getFeedActionScope(items);
+    const counts = getFeedActionCounts(items);
 
-    expect(scope.unreadItemIds).toEqual(["unread"]);
-    expect(scope.archivableItemIds).toEqual(["read"]);
-    expect(scope.unreadCount).toBe(1);
-    expect(scope.archivableCount).toBe(1);
-    expect(getFeedActionScope(items)).toBe(scope);
+    expect(counts).toEqual({ unreadCount: 1, archivableCount: 1 });
+    expect(getFeedActionCounts(items)).toBe(counts);
+    expect(collectUnreadFeedActionIds(items)).toEqual(["unread"]);
+    expect(collectArchivableFeedActionIds(items)).toEqual(["read"]);
   });
 
   it("counts saved archived items separately from plain archived items", () => {

--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -50,7 +50,11 @@ import {
   useFeedCardDensity,
   type FeedCardDensity,
 } from "../../lib/feed-card-density.js";
-import { getFeedActionScope } from "../../lib/feed-action-scope.js";
+import {
+  collectArchivableFeedActionIds,
+  collectUnreadFeedActionIds,
+  getFeedActionCounts,
+} from "../../lib/feed-action-scope.js";
 import {
   dragRegionStyle as dragStyle,
   getPassiveDragRegionProps,
@@ -464,11 +468,9 @@ export function Header({
     : showInlineReaderBookmark ? "w-[6.5rem]" : "w-14";
 
   const {
-    unreadItemIds: filteredUnreadItemIds,
-    archivableItemIds: filteredArchivableItemIds,
     unreadCount,
     archivableCount,
-  } = useMemo(() => getFeedActionScope(filteredItems), [filteredItems]);
+  } = useMemo(() => getFeedActionCounts(filteredItems), [filteredItems]);
 
   const handleSocialContentFilterChange = useCallback(
     (value: SocialContentFilter) => {
@@ -796,12 +798,12 @@ export function Header({
   }, [unarchiveSavedItems]);
 
   const handleMarkFilteredUnreadAsRead = useCallback(() => {
-    void markItemsAsRead(filteredUnreadItemIds);
-  }, [filteredUnreadItemIds, markItemsAsRead]);
+    void markItemsAsRead(collectUnreadFeedActionIds(filteredItems));
+  }, [filteredItems, markItemsAsRead]);
 
   const handleArchiveFilteredRead = useCallback(() => {
-    void archiveItems(filteredArchivableItemIds);
-  }, [archiveItems, filteredArchivableItemIds]);
+    void archiveItems(collectArchivableFeedActionIds(filteredItems));
+  }, [archiveItems, filteredItems]);
 
   const toolbarOverflowActions = useMemo<ToolbarOverflowAction[]>(() => {
     const actions: ToolbarOverflowAction[] = [];

--- a/packages/ui/src/components/layout/SearchJumpField.tsx
+++ b/packages/ui/src/components/layout/SearchJumpField.tsx
@@ -24,7 +24,12 @@ import {
 import { useCommandSurfaceStore } from "../../lib/command-surface-store.js";
 import { useSettingsStore } from "../../lib/settings-store.js";
 import { buildSettingsSectionMetas } from "../../lib/settings-sections.js";
-import { getFeedActionScope, getFeedArchiveCounts } from "../../lib/feed-action-scope.js";
+import {
+  collectArchivableFeedActionIds,
+  collectUnreadFeedActionIds,
+  getFeedActionCounts,
+  getFeedArchiveCounts,
+} from "../../lib/feed-action-scope.js";
 import { buildTopLevelTagFilters, collectAllTags } from "../../lib/tag-navigation.js";
 import { applyFeedSearch, navigateToFeedView } from "../../lib/workspace-navigation.js";
 import { SearchField } from "../SearchField.js";
@@ -353,10 +358,9 @@ export function SearchJumpField({
   );
 
   const {
-    unreadItemIds: unreadScopeIds,
-    archivableItemIds: archivableScopeIds,
+    unreadCount: unreadScopeCount,
     archivableCount: archivableScopeCount,
-  } = useMemo(() => getFeedActionScope(commandScopeItems), [commandScopeItems]);
+  } = useMemo(() => getFeedActionCounts(commandScopeItems), [commandScopeItems]);
   const { archivedCount, savedArchivedCount } = useMemo(() => getFeedArchiveCounts(items), [items]);
   const enabledFeeds = useMemo(
     () =>
@@ -451,7 +455,7 @@ export function SearchJumpField({
         tagFilters,
         currentSourceId,
         selectedItem,
-        unreadScopeCount: activeView === "feed" ? unreadScopeIds.length : 0,
+        unreadScopeCount: activeView === "feed" ? unreadScopeCount : 0,
         archivableScopeCount: activeView === "feed" ? archivableScopeCount : 0,
         savedArchivedCount,
         archivedCount,
@@ -544,12 +548,12 @@ export function SearchJumpField({
         toggleCurrentItemLiked:
           selectedItem && toggleLiked ? () => toggleLiked(selectedItem.globalId) : null,
         markScopeRead:
-          activeView === "feed" && unreadScopeIds.length > 0
-            ? () => markItemsAsRead(unreadScopeIds)
+          activeView === "feed" && unreadScopeCount > 0
+            ? () => markItemsAsRead(collectUnreadFeedActionIds(commandScopeItems))
             : null,
         archiveScopeRead:
-          activeView === "feed" && archivableScopeIds.length > 0
-            ? () => archiveItems(archivableScopeIds)
+          activeView === "feed" && archivableScopeCount > 0
+            ? () => archiveItems(collectArchivableFeedActionIds(commandScopeItems))
             : null,
         unarchiveSavedItems,
         syncRssNow,
@@ -572,8 +576,8 @@ export function SearchJumpField({
       enabledFeeds,
       factoryReset,
       archiveItems,
-      archivableScopeIds,
       clearQueryForNavigation,
+      commandScopeItems,
       createConnectionPersonFromAccounts,
       inputValue,
       ensurePersonForAccount,
@@ -602,7 +606,7 @@ export function SearchJumpField({
       toggleArchived,
       toggleLiked,
       toggleSaved,
-      unreadScopeIds,
+      unreadScopeCount,
       unarchiveSavedItems,
       updatePerson,
       openLibraryDialog,

--- a/packages/ui/src/hooks/useSearchResults.ts
+++ b/packages/ui/src/hooks/useSearchResults.ts
@@ -32,7 +32,7 @@ import { filterFeedItems, isFriendAuthoredItem, sortByPriority } from "@freed/sh
 import type { Account, FeedItem, FilterOptions, Friend, Person } from "@freed/shared";
 
 const SEARCH_PRESERVED_TEXT_LIMIT = 1_200;
-const SEARCH_INDEX_CHUNK_SIZE = 250;
+const SEARCH_INDEX_CHUNK_SIZE = 100;
 const SEARCH_INDEX_RELEASE_DELAY_MS = 75;
 
 /** Flat document shape fed to MiniSearch (one per FeedItem). */

--- a/packages/ui/src/lib/feed-action-scope.ts
+++ b/packages/ui/src/lib/feed-action-scope.ts
@@ -1,8 +1,6 @@
 import type { FeedItem } from "@freed/shared";
 
-export interface FeedActionScope {
-  unreadItemIds: string[];
-  archivableItemIds: string[];
+interface FeedActionCounts {
   unreadCount: number;
   archivableCount: number;
 }
@@ -12,35 +10,50 @@ export interface FeedArchiveCounts {
   savedArchivedCount: number;
 }
 
-const actionScopeCache = new WeakMap<readonly FeedItem[], FeedActionScope>();
+const actionCountsCache = new WeakMap<readonly FeedItem[], FeedActionCounts>();
 const archiveCountsCache = new WeakMap<readonly FeedItem[], FeedArchiveCounts>();
 
-export function getFeedActionScope(items: readonly FeedItem[]): FeedActionScope {
-  const cached = actionScopeCache.get(items);
+export function getFeedActionCounts(items: readonly FeedItem[]): FeedActionCounts {
+  const cached = actionCountsCache.get(items);
   if (cached) return cached;
 
-  const unreadItemIds: string[] = [];
-  const archivableItemIds: string[] = [];
+  let unreadCount = 0;
+  let archivableCount = 0;
 
   for (const item of items) {
     if (item.userState.hidden || item.userState.archived) continue;
     if (!item.userState.readAt) {
-      unreadItemIds.push(item.globalId);
+      unreadCount += 1;
       continue;
     }
     if (!item.userState.saved) {
-      archivableItemIds.push(item.globalId);
+      archivableCount += 1;
     }
   }
 
-  const scope = {
-    unreadItemIds,
-    archivableItemIds,
-    unreadCount: unreadItemIds.length,
-    archivableCount: archivableItemIds.length,
-  };
-  actionScopeCache.set(items, scope);
-  return scope;
+  const counts = { unreadCount, archivableCount };
+  actionCountsCache.set(items, counts);
+  return counts;
+}
+
+export function collectUnreadFeedActionIds(items: readonly FeedItem[]): string[] {
+  const ids: string[] = [];
+  for (const item of items) {
+    if (item.userState.hidden || item.userState.archived || item.userState.readAt) continue;
+    ids.push(item.globalId);
+  }
+  return ids;
+}
+
+export function collectArchivableFeedActionIds(items: readonly FeedItem[]): string[] {
+  const ids: string[] = [];
+  for (const item of items) {
+    if (item.userState.hidden || item.userState.archived || !item.userState.readAt || item.userState.saved) {
+      continue;
+    }
+    ids.push(item.globalId);
+  }
+  return ids;
 }
 
 export function getFeedArchiveCounts(items: readonly FeedItem[]): FeedArchiveCounts {


### PR DESCRIPTION
(AI Generated).

## Summary
- reduce MiniSearch indexing chunk size so search prep yields more often during large-library typing
- stop allocating unread and archivable bulk-action ID arrays on every header and command palette render
- keep exact bulk action IDs lazy until the user invokes the action

## Test Plan
- PATH=/Users/aubreyfalconer/dev/freed-feed-search-scale/node_modules/.bin:$PATH vitest run packages/ui/src/lib/feed-action-scope.test.ts
- cd packages/desktop && PATH=/Users/aubreyfalconer/dev/freed-feed-search-scale/node_modules/.bin:$PATH npm run test:e2e:perf:feed -- --grep "Search input"
- npm run typecheck
- npm run validate:feature

## Perf Notes
- focused search guard before chunk reduction: 1 long task, worst 58 ms
- focused search guard after chunk reduction: 0 long tasks, worst 0 ms
- full feature validation search guard: 0 long tasks, worst 0 ms
