### PR TITLE
fix: polish mobile PWA layout

### DIFF
--- a/docs/PHASE-10-POLISH.md
+++ b/docs/PHASE-10-POLISH.md
@@ -473,6 +473,7 @@ Reward security researchers for responsible disclosure.
 - [x] On hard crash or unreachable JSON update bundle, a friendly recovery dialog is shown outside the React tree, auto-checks for updates immediately, offers in-place install and restart when available, and keeps a channel-aware browser download fallback for the latest installer
 - [x] Desktop and PWA expose a shared bug report flow with public-safe bundles by default and private diagnostics as an explicit opt-in path
 - [x] Shared bug report actions now reflect the selected bundle privacy tier, bulk-toggle private diagnostics, and disable public GitHub issue drafts while private artifacts are selected
+- [x] Settings keeps Support out of the primary section list and opens the existing report composer from a dedicated Support modal launched at the top of Danger Zone
 
 ---
 

--- a/docs/PHASE-6-PWA.md
+++ b/docs/PHASE-6-PWA.md
@@ -1,6 +1,6 @@
 # Phase 6: PWA Reader
 
-> **Status:** ✅ Complete (first-run legal gate shipped, public-safe bug reporting shipped, homescreen install flow shipped, offline article and image caching shipped, local reader cache modes shipped)
+> **Status:** ✅ Complete (first-run legal gate shipped, public-safe bug reporting shipped, homescreen install flow shipped, offline article and image caching shipped, local reader cache modes shipped, mobile toolbar and reader polish shipped)
 > **Dependencies:** Phase 4 (Sync Layer), Phase 5 (Desktop App)
 
 ---
@@ -20,6 +20,7 @@ Mobile companion to Freed Desktop for on-the-go reading. Timeline-focused, minim
 - **Desktop handoff in source settings** — PWA Settings exposes X / Twitter, Facebook, Instagram, and LinkedIn with clear Freed Desktop sync and download handoff states
 - **Blank-state testing escape hatch** — PWA empty states now include a secondary sample-data section below the main handoff prompt for quick local testing
 - **Archived saved-item repair control** — Archived views now surface a one-click `Unarchive Saved Content` action when legacy or imported items end up both saved and archived
+- **Mobile chrome polish:** The PWA mobile toolbar uses balanced menu and format controls, the mobile drawer starts with search, Settings stacks compact sections, and the reader keeps fixed menus plus sane article spacing
 
 ---
 
@@ -250,9 +251,12 @@ Build chain: `@freed/shared` → `@freed/sync` → `vite build` (configured in `
 - [x] PWA Settings surfaces X / Twitter, Facebook, Instagram, and LinkedIn with Freed Desktop sync and download handoff states
 - [x] Theme changes in Settings temporarily clear the frosted backdrop on touch devices so the active page treatment stays visible while previewing themes
 - [x] Mobile Settings now open as a full-height sheet with a persistent close button, larger back target, and reliable section jumps instead of snapping back to the last scrolled provider section
+- [x] Mobile Settings use full-size shared settings typography, compact stacked sections, and a dedicated Support modal launched from Danger Zone
 - [x] Shared Settings list panels keep RSS management and OPML previews inside filtered inner scrollers capped to the Settings sheet height
 - [x] Appearance exposes `Show read in grayscale`, and mark-read-on-scroll now subtracts the feed list offset before marking mobile rows as passed
 - [x] The shared floating mobile sidebar now behaves like a real toggle, so the same hamburger button opens and closes it cleanly
+- [x] The mobile toolbar keeps the hamburger furthest left, the format menu furthest right, and viewport-fixed action menus while reader content scrolls
+- [x] Mobile feed and reader gutters are balanced so cards and zoomed reader articles avoid lopsided spacing and excessive blank space under short content
 - [x] Private diagnostics stay opt-in and are clearly separated from public GitHub sharing
 - [x] PWA installable on mobile (add to homescreen) — manifest ids and scope set, browser install notice shipped, iOS Safari homescreen guidance shipped, Playwright coverage added
 - [x] Offline access works (service worker + image cache), article HTML and cacheable reader images are warmed locally for offline reading

--- a/packages/desktop/tests/e2e/smoke.spec.ts
+++ b/packages/desktop/tests/e2e/smoke.spec.ts
@@ -1474,9 +1474,6 @@ test("settings dialog closes from the mobile header close button", async ({ app,
     const mod = await import(settingsStorePath);
     mod.useSettingsStore.getState().openDefault();
   }, SETTINGS_STORE_PATH);
-  await expect(page.getByTestId("settings-close-button-sidebar")).toBeVisible({ timeout: 5_000 });
-
-  await page.getByRole("button", { name: "Appearance" }).last().click();
   await expect(page.getByTestId("settings-close-button-mobile")).toBeVisible({ timeout: 5_000 });
 
   await page.getByTestId("settings-close-button-mobile").click();
@@ -2430,7 +2427,7 @@ test("feed toolbar title describes active content filters", async ({ app, page }
   await expect(page.getByTestId("workspace-toolbar-title-block")).toContainText("1 item");
 });
 
-test("mobile feed toolbar keeps more actions as the rightmost control", async ({ app, page }) => {
+test("mobile feed toolbar keeps format as the rightmost control", async ({ app, page }) => {
   await page.setViewportSize({ width: 390, height: 844 });
   await app.goto();
   await app.waitForReady();
@@ -2451,16 +2448,25 @@ test("mobile feed toolbar keeps more actions as the rightmost control", async ({
     }
 
     return {
-      gap: overflowRect.left - filterRect.right,
+      gap: filterRect.left - overflowRect.right,
+      overflowRight: overflowRect.right,
+      filterLeft: filterRect.left,
       filterRight: filterRect.right,
-      overflowLeft: overflowRect.left,
+      viewportRight: window.innerWidth,
     };
   });
-  expect(geometry.filterRight).toBeLessThanOrEqual(geometry.overflowLeft);
+  expect(geometry.overflowRight).toBeLessThanOrEqual(geometry.filterLeft);
   expect(geometry.gap).toBeGreaterThanOrEqual(0);
+  expect(geometry.viewportRight - geometry.filterRight).toBeLessThanOrEqual(16);
 
   await overflowButton.click();
-  await expect(page.getByTestId("toolbar-overflow-menu").getByRole("menuitem", { name: /Mark .* unread as read/ })).toBeVisible();
+  const overflowMenu = page.getByTestId("toolbar-overflow-menu");
+  await expect(overflowMenu.getByRole("menuitem", { name: /Mark .* unread as read/ })).toBeVisible();
+  const menuTop = await overflowMenu.evaluate((menu) => Math.round(menu.getBoundingClientRect().top));
+  await page.evaluate(() => window.scrollBy(0, 180));
+  await expect
+    .poll(() => overflowMenu.evaluate((menu) => Math.round(menu.getBoundingClientRect().top)))
+    .toBe(menuTop);
 });
 
 test("dual-column reader toggles use shared view transitions when supported", async ({ app, page }) => {

--- a/packages/pwa/src/lib/command-palette.test.ts
+++ b/packages/pwa/src/lib/command-palette.test.ts
@@ -656,6 +656,49 @@ describe("command palette", () => {
     });
   });
 
+  it("renders with malformed stored feed and account labels", async () => {
+    const store = createTestStore({
+      feeds: {
+        "https://broken.example/feed.xml": {
+          url: "https://broken.example/feed.xml",
+          title: undefined,
+          enabled: true,
+        } as unknown as BaseAppState["feeds"][string],
+      },
+      accounts: {
+        "social:x:broken": {
+          id: "social:x:broken",
+          kind: "social",
+          provider: "x",
+          externalId: undefined,
+          firstSeenAt: 1,
+          lastSeenAt: 1,
+          discoveredFrom: "captured_item",
+          createdAt: 1,
+          updatedAt: 1,
+        } as unknown as Account,
+      },
+    });
+    const platform = createPlatform(store);
+    const render = renderNode(
+      createElement(
+        PlatformProvider,
+        { value: platform, children: createElement(SearchJumpField) },
+      ),
+    );
+    cleanups.push(render.cleanup);
+    await flush();
+
+    const input = document.querySelector<HTMLInputElement>('input[aria-label="Search or run"]');
+    expect(input).not.toBeNull();
+    act(() => input!.focus());
+    await flush();
+    changeInput(input!, "broken");
+    await flush();
+
+    expect(document.body.textContent).toContain("https://broken.example/feed.xml");
+  });
+
   it("archives current scope read items with one visible ID batch", async () => {
     const archiveItems = vi.fn(async () => {});
     const toggleArchived = vi.fn(async () => {});

--- a/packages/pwa/src/lib/friends-workspace.test.ts
+++ b/packages/pwa/src/lib/friends-workspace.test.ts
@@ -101,6 +101,28 @@ describe("friends workspace helpers", () => {
     expect(sorted[0]?.friend.name).toBe("Ada Lovelace");
   });
 
+  it("sorts malformed friend labels without crashing", () => {
+    const now = Date.now();
+    const ada = makeFriend("friend-ada", "Ada Lovelace", 5, "ada-ig");
+    const malformed = {
+      ...makeFriend("friend-malformed", "Missing Name", 3, "missing-ig"),
+      name: undefined as unknown as string,
+    };
+    const friends = {
+      [ada.id]: ada,
+      [malformed.id]: malformed,
+    };
+    const feedItems = {
+      "ada-post": makeItem("ada-post", "ada-ig", now - 60_000, false),
+      "missing-post": makeItem("missing-post", "missing-ig", now - 30_000, false),
+    };
+
+    const entries = buildFriendOverviewEntries(friends, feedItems, now);
+
+    expect(() => filterAndSortFriendOverview(entries, "", new Set(), "name")).not.toThrow();
+    expect(() => buildFrozenFriendGraphLayout(Object.values(friends), feedItems, 430, 700, undefined, now)).not.toThrow();
+  });
+
   it("builds stable graph layout signatures and positions", () => {
     const now = Date.now();
     const friends = [

--- a/packages/pwa/src/lib/identity-graph-v2.test.ts
+++ b/packages/pwa/src/lib/identity-graph-v2.test.ts
@@ -293,6 +293,45 @@ describe("identity graph v2 model", () => {
     );
   });
 
+  it("builds malformed persisted labels without crashing", () => {
+    const persons = [
+      createPerson({
+        id: "person-malformed",
+        name: undefined as unknown as string,
+        relationshipStatus: "friend",
+      }),
+    ];
+    const accounts = {
+      "account-malformed": createAccount({
+        id: "account-malformed",
+        personId: "person-malformed",
+        provider: undefined as unknown as Account["provider"],
+        externalId: undefined as unknown as string,
+        displayName: undefined,
+        handle: undefined,
+      }),
+    };
+
+    const model = buildIdentityGraphModel({
+      persons,
+      accounts,
+      feeds: {},
+      feedItems: {},
+      mode: "all_content",
+    });
+    const layout = buildIdentityGraphLayout({
+      model,
+      width: 430,
+      height: 700,
+      quality: "fast",
+    });
+
+    expect(model.nodes.map((node) => node.label)).toEqual(
+      expect.arrayContaining(["Unnamed friend", "Account"]),
+    );
+    expect(layout.nodes.length).toBe(model.nodes.length);
+  });
+
   it("rebuilds model and layout within budget for the benchmark graph", () => {
     const benchmarkPeople = 1_000;
     const benchmarkAccounts = 5_000;

--- a/packages/pwa/tests/app.spec.ts
+++ b/packages/pwa/tests/app.spec.ts
@@ -1825,6 +1825,31 @@ test.describe("FREED PWA", () => {
     expect(readerMetrics.paddingRight).toBeGreaterThanOrEqual(20);
   });
 
+  test("inline reader does not add a second toolbar divider", async ({ page }) => {
+    await page.setViewportSize({ width: 430, height: 932 });
+    await page.goto("/");
+    await acceptLegalGate(page);
+    await waitForPwaReady(page);
+    await seedNavigationFeed(page);
+
+    const firstCard = page.locator(".feed-card").filter({ hasText: "Navigation Item One" }).first();
+    await expect(firstCard).toBeVisible();
+    await firstCard.click();
+
+    const reader = page.getByTestId("reader-article");
+    await expect(reader).toBeVisible();
+    const metrics = await reader.evaluate((article) => {
+      const toolbar = document.querySelector('[data-testid="workspace-toolbar"]') as HTMLElement | null;
+      const scroller = article.parentElement;
+      return {
+        toolbarVisible: !!toolbar,
+        scrollerHasFadeMask: scroller?.classList.contains("theme-scroll-fade-y") ?? false,
+      };
+    });
+    expect(metrics.toolbarVisible).toBe(true);
+    expect(metrics.scrollerHasFadeMask).toBe(false);
+  });
+
   test("app has correct colors and styling", async ({ page }) => {
     await page.goto("/");
     await acceptLegalGate(page);

--- a/packages/pwa/tests/app.spec.ts
+++ b/packages/pwa/tests/app.spec.ts
@@ -1621,11 +1621,13 @@ test.describe("FREED PWA", () => {
     });
 
     await expect(page.getByRole("heading", { name: "Settings" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Appearance" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Appearance" })).toHaveCount(0);
     await expect(page.getByText("Freed hit a fatal error")).toHaveCount(0);
     await expect(page.getByText("Cannot access 'mobileView' before initialization")).toHaveCount(0);
   });
 
-  test("mobile settings uses stacked sections and opens support from danger zone", async ({ page }) => {
+  test("mobile settings keeps overview and opens support from danger zone", async ({ page }) => {
     await emulateMobileDevice(page);
     await page.setViewportSize({ width: 393, height: 852 });
     await page.goto("/");
@@ -1635,9 +1637,13 @@ test.describe("FREED PWA", () => {
     await page.getByRole("button", { name: "Settings" }).evaluate((element) => {
       (element as HTMLButtonElement).click();
     });
-    await expect(page.getByTestId("settings-mobile-section-title")).toHaveText("Settings");
+    await expect(page.getByRole("heading", { name: "Settings" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Appearance" })).toBeVisible();
     await expect(page.getByRole("button", { name: "Support", exact: true })).toHaveCount(0);
-    await expect(page.getByRole("heading", { name: "Appearance" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Appearance" })).toHaveCount(0);
+
+    await page.getByRole("button", { name: "Updates" }).click();
+    await expect(page.getByTestId("settings-mobile-section-title")).toHaveText("Updates");
 
     const scrollContainer = page.getByTestId("settings-scroll-container");
     await scrollContainer.evaluate((container) => {
@@ -1663,6 +1669,11 @@ test.describe("FREED PWA", () => {
     expect(sectionMetrics.legalVisible).toBe(true);
     expect(sectionMetrics.sectionGap).toBeGreaterThanOrEqual(24);
     expect(sectionMetrics.sectionGap).toBeLessThanOrEqual(64);
+
+    await page.getByLabel("Back to settings").click();
+    await expect(page.getByRole("heading", { name: "Settings" })).toBeVisible();
+    await page.getByRole("button", { name: "Danger Zone" }).click();
+    await expect(page.getByTestId("settings-mobile-section-title")).toHaveText("Danger Zone");
 
     await scrollContainer.evaluate((container) => {
       const danger = container.querySelector('[data-section="danger"]') as HTMLElement | null;

--- a/packages/pwa/tests/app.spec.ts
+++ b/packages/pwa/tests/app.spec.ts
@@ -1698,23 +1698,50 @@ test.describe("FREED PWA", () => {
     await expect(formatButton).toBeVisible();
 
     const geometry = await page.evaluate(() => {
+      const toolbar = document.querySelector('[data-testid="workspace-toolbar"]') as HTMLElement | null;
       const menu = document.querySelector('button[aria-label="Open menu"]') as HTMLElement | null;
       const overflow = document.querySelector('[data-testid="toolbar-overflow-button"]') as HTMLElement | null;
       const format = document.querySelector('[data-testid="mobile-toolbar-filter-button"]') as HTMLElement | null;
-      if (!menu || !overflow || !format) {
+      const menuIcon = menu?.querySelector("[aria-hidden='true']") as HTMLElement | null;
+      const formatIcon = format?.querySelector("svg") as SVGElement | null;
+      if (!toolbar || !menu || !overflow || !format || !menuIcon || !formatIcon) {
         throw new Error("Mobile toolbar buttons were not found");
       }
+      const toolbarRect = toolbar.getBoundingClientRect();
       const menuRect = menu.getBoundingClientRect();
+      const menuBarRects = Array.from(menuIcon.children)
+        .map((child) => child.getBoundingClientRect())
+        .filter((rect) => rect.width > 0 && rect.height > 0);
+      const menuIconRect = menuIcon.getBoundingClientRect();
+      const menuVisibleLeft = menuBarRects.length
+        ? Math.min(...menuBarRects.map((rect) => rect.left))
+        : menuIconRect.left;
       const overflowRect = overflow.getBoundingClientRect();
       const formatRect = format.getBoundingClientRect();
+      const formatIconRect = formatIcon.getBoundingClientRect();
       return {
+        toolbarLeft: toolbarRect.left,
+        toolbarRight: toolbarRect.right,
         menuLeft: menuRect.left,
+        menuRight: menuRect.right,
+        menuIconLeft: menuIconRect.left,
+        menuVisibleLeft,
+        menuBarWidths: menuBarRects.map((rect) => rect.width),
         overflowRight: overflowRect.right,
         formatLeft: formatRect.left,
         formatRight: formatRect.right,
+        formatIconRight: formatIconRect.right,
+        viewportRight: window.innerWidth,
         widths: [menuRect.width, overflowRect.width, formatRect.width],
       };
     });
+    expect(
+      Math.abs((geometry.menuLeft - geometry.toolbarLeft) - (geometry.toolbarRight - geometry.formatIconRight)),
+      JSON.stringify(geometry),
+    ).toBeLessThanOrEqual(1);
+    for (const barWidth of geometry.menuBarWidths) {
+      expect(Math.abs(barWidth - geometry.menuBarWidths[0])).toBeLessThanOrEqual(1);
+    }
     expect(geometry.menuLeft).toBeLessThan(geometry.overflowRight);
     expect(geometry.overflowRight).toBeLessThanOrEqual(geometry.formatLeft);
     expect(geometry.formatRight).toBeGreaterThan(geometry.overflowRight);

--- a/packages/pwa/tests/app.spec.ts
+++ b/packages/pwa/tests/app.spec.ts
@@ -121,6 +121,21 @@ async function waitForPwaReady(
   });
 }
 
+async function emulateMobileDevice(
+  page: import("@playwright/test").Page,
+): Promise<void> {
+  await page.addInitScript(() => {
+    Object.defineProperty(navigator, "userAgentData", {
+      configurable: true,
+      value: { mobile: true },
+    });
+    Object.defineProperty(navigator, "maxTouchPoints", {
+      configurable: true,
+      value: 5,
+    });
+  });
+}
+
 async function seedFriendLocation(
   page: import("@playwright/test").Page,
 ): Promise<void> {
@@ -1538,27 +1553,55 @@ test.describe("FREED PWA", () => {
   });
 
   test("responsive sidebar behavior", async ({ page }) => {
-    // Set mobile viewport
+    await emulateMobileDevice(page);
     await page.setViewportSize({ width: 375, height: 667 });
     await page.goto("/");
     await acceptLegalGate(page);
 
-    // Sidebar should be hidden on mobile
     const sidebar = page.getByTestId("app-sidebar-mobile");
     await expect(sidebar).toHaveClass(/-translate-x-full/);
 
-    // Click menu button to open sidebar
     await page.click('button[aria-label="Open menu"]');
 
-    // Sidebar should now be visible
     await expect(sidebar).toHaveClass(/translate-x-0/);
+    await expect
+      .poll(() => sidebar.evaluate((element) => Math.round(element.getBoundingClientRect().left)))
+      .toBe(0);
 
-    // Clicking the same menu button again should close the floating drawer.
-    await page.click('button[aria-label="Close menu"]');
+    const menuButton = page.getByRole("button", { name: "Close menu" });
+    const geometry = await page.evaluate(() => {
+      const button = document.querySelector('button[aria-label="Close menu"]') as HTMLElement | null;
+      const icon = button?.querySelector("span[aria-hidden='true']") as HTMLElement | null;
+      const sidebar = document.querySelector('[data-testid="app-sidebar-mobile"]') as HTMLElement | null;
+      const search = sidebar?.querySelector('input[aria-label="Search or run"]') as HTMLElement | null;
+      const firstControl = sidebar?.querySelector("input, button") as HTMLElement | null;
+      if (!button || !icon || !sidebar || !search || !firstControl) {
+        throw new Error("Mobile menu geometry elements were not found");
+      }
+      const buttonRect = button.getBoundingClientRect();
+      const iconRect = icon.getBoundingClientRect();
+      const sidebarRect = sidebar.getBoundingClientRect();
+      const searchRect = search.getBoundingClientRect();
+      return {
+        centerDelta: Math.abs(
+          (buttonRect.left + buttonRect.width / 2) -
+          (iconRect.left + iconRect.width / 2),
+        ),
+        firstControlIsSearch: firstControl === search,
+        searchTop: Math.round(searchRect.top),
+        sidebarTop: Math.round(sidebarRect.top),
+      };
+    });
+    expect(geometry.centerDelta).toBeLessThanOrEqual(1);
+    expect(geometry.firstControlIsSearch).toBe(true);
+    expect(geometry.searchTop - geometry.sidebarTop).toBeGreaterThanOrEqual(8);
+
+    await menuButton.click();
     await expect(sidebar).toHaveClass(/-translate-x-full/);
   });
 
   test("mobile settings opens without hitting recovery", async ({ page }) => {
+    await emulateMobileDevice(page);
     await page.setViewportSize({ width: 393, height: 852 });
     await page.goto("/");
     await acceptLegalGate(page);
@@ -1573,7 +1616,8 @@ test.describe("FREED PWA", () => {
     await expect(page.getByText("Cannot access 'mobileView' before initialization")).toHaveCount(0);
   });
 
-  test("mobile settings navigation keeps the selected heading in sync", async ({ page }) => {
+  test("mobile settings uses stacked sections and opens support from danger zone", async ({ page }) => {
+    await emulateMobileDevice(page);
     await page.setViewportSize({ width: 393, height: 852 });
     await page.goto("/");
     await acceptLegalGate(page);
@@ -1582,10 +1626,154 @@ test.describe("FREED PWA", () => {
     await page.getByRole("button", { name: "Settings" }).evaluate((element) => {
       (element as HTMLButtonElement).click();
     });
-    await page.getByRole("button", { name: "Updates", exact: true }).click();
+    await expect(page.getByTestId("settings-mobile-section-title")).toHaveText("Settings");
+    await expect(page.getByRole("button", { name: "Support", exact: true })).toHaveCount(0);
+    await expect(page.getByRole("heading", { name: "Appearance" })).toBeVisible();
 
-    await expect(page.getByTestId("settings-mobile-section-title")).toHaveText("Updates");
-    await expect(page.getByText("Installed version:", { exact: false }).first()).toBeVisible();
+    const scrollContainer = page.getByTestId("settings-scroll-container");
+    await scrollContainer.evaluate((container) => {
+      const updates = container.querySelector('[data-section="updates"]') as HTMLElement | null;
+      updates?.scrollIntoView();
+    });
+    const sectionMetrics = await scrollContainer.evaluate((container) => {
+      const updates = container.querySelector('[data-section="updates"]') as HTMLElement | null;
+      const legal = container.querySelector('[data-section="legal"]') as HTMLElement | null;
+      if (!updates || !legal) {
+        throw new Error("Expected mobile settings sections were not found");
+      }
+      const containerRect = container.getBoundingClientRect();
+      const updatesRect = updates.getBoundingClientRect();
+      const legalRect = legal.getBoundingClientRect();
+      return {
+        updatesVisible: updatesRect.bottom > containerRect.top && updatesRect.top < containerRect.bottom,
+        legalVisible: legalRect.bottom > containerRect.top && legalRect.top < containerRect.bottom,
+        sectionGap: Math.round(legalRect.top - updatesRect.bottom),
+      };
+    });
+    expect(sectionMetrics.updatesVisible).toBe(true);
+    expect(sectionMetrics.legalVisible).toBe(true);
+    expect(sectionMetrics.sectionGap).toBeGreaterThanOrEqual(24);
+    expect(sectionMetrics.sectionGap).toBeLessThanOrEqual(64);
+
+    await scrollContainer.evaluate((container) => {
+      const danger = container.querySelector('[data-section="danger"]') as HTMLElement | null;
+      danger?.scrollIntoView();
+    });
+    const supportButton = page.getByRole("button", { name: /Submit support ticket/ });
+    const debugButton = page.getByRole("button", { name: /Open Debug Panel/ });
+    await expect(supportButton).toBeVisible();
+    await expect(debugButton).toBeVisible();
+    const dangerOrder = await page.evaluate(() => {
+      const support = Array.from(document.querySelectorAll("button")).find((button) =>
+        button.textContent?.includes("Submit support ticket"),
+      ) as HTMLElement | undefined;
+      const debug = Array.from(document.querySelectorAll("button")).find((button) =>
+        button.textContent?.includes("Open Debug Panel"),
+      ) as HTMLElement | undefined;
+      if (!support || !debug) {
+        throw new Error("Danger buttons were not found");
+      }
+      return support.getBoundingClientRect().top < debug.getBoundingClientRect().top;
+    });
+    expect(dangerOrder).toBe(true);
+
+    await supportButton.click();
+    await expect(page.getByRole("heading", { name: "Support" })).toBeVisible();
+    await expect(page.getByText("What happened?", { exact: false })).toBeVisible();
+  });
+
+  test("mobile toolbar balances menu and format controls", async ({ page }) => {
+    await emulateMobileDevice(page);
+    await page.setViewportSize({ width: 393, height: 852 });
+    await page.goto("/");
+    await acceptLegalGate(page);
+    await waitForPwaReady(page);
+    await seedNavigationFeed(page);
+
+    const menuButton = page.getByRole("button", { name: "Open menu" });
+    const overflowButton = page.getByTestId("toolbar-overflow-button");
+    const formatButton = page.getByTestId("mobile-toolbar-filter-button");
+    await expect(menuButton).toBeVisible();
+    await expect(overflowButton).toBeVisible();
+    await expect(formatButton).toBeVisible();
+
+    const geometry = await page.evaluate(() => {
+      const menu = document.querySelector('button[aria-label="Open menu"]') as HTMLElement | null;
+      const overflow = document.querySelector('[data-testid="toolbar-overflow-button"]') as HTMLElement | null;
+      const format = document.querySelector('[data-testid="mobile-toolbar-filter-button"]') as HTMLElement | null;
+      if (!menu || !overflow || !format) {
+        throw new Error("Mobile toolbar buttons were not found");
+      }
+      const menuRect = menu.getBoundingClientRect();
+      const overflowRect = overflow.getBoundingClientRect();
+      const formatRect = format.getBoundingClientRect();
+      return {
+        menuLeft: menuRect.left,
+        overflowRight: overflowRect.right,
+        formatLeft: formatRect.left,
+        formatRight: formatRect.right,
+        widths: [menuRect.width, overflowRect.width, formatRect.width],
+      };
+    });
+    expect(geometry.menuLeft).toBeLessThan(geometry.overflowRight);
+    expect(geometry.overflowRight).toBeLessThanOrEqual(geometry.formatLeft);
+    expect(geometry.formatRight).toBeGreaterThan(geometry.overflowRight);
+    for (const width of geometry.widths) {
+      expect(Math.abs(width - 40)).toBeLessThanOrEqual(1);
+    }
+
+    await overflowButton.click();
+    const menuTop = await page.getByTestId("toolbar-overflow-menu").evaluate((menu) =>
+      Math.round(menu.getBoundingClientRect().top),
+    );
+    await page.evaluate(() => window.scrollBy(0, 180));
+    await expect
+      .poll(() => page.getByTestId("toolbar-overflow-menu").evaluate((menu) =>
+        Math.round(menu.getBoundingClientRect().top),
+      ))
+      .toBe(menuTop);
+  });
+
+  test("mobile feed and reader spacing stay balanced", async ({ page }) => {
+    await emulateMobileDevice(page);
+    await page.setViewportSize({ width: 393, height: 852 });
+    await page.goto("/");
+    await acceptLegalGate(page);
+    await waitForPwaReady(page);
+    await seedNavigationFeed(page);
+
+    const firstCard = page.locator(".feed-card").filter({ hasText: "Navigation Item One" }).first();
+    await expect(firstCard).toBeVisible();
+
+    const spacing = await page.evaluate(() => {
+      const toolbar = document.querySelector('[data-testid="workspace-toolbar"]') as HTMLElement | null;
+      const card = document.querySelector(".feed-card") as HTMLElement | null;
+      if (!toolbar || !card) {
+        throw new Error("Feed spacing elements were not found");
+      }
+      const toolbarRect = toolbar.getBoundingClientRect();
+      const cardRect = card.getBoundingClientRect();
+      return {
+        leftGap: Math.round(cardRect.left),
+        topGap: Math.round(cardRect.top - toolbarRect.bottom),
+      };
+    });
+    expect(Math.abs(spacing.leftGap - spacing.topGap)).toBeLessThanOrEqual(1);
+
+    await firstCard.click();
+    const reader = page.getByTestId("reader-article");
+    await expect(reader).toBeVisible();
+    const readerMetrics = await reader.evaluate((article) => {
+      const style = window.getComputedStyle(article);
+      return {
+        bodyOverflow: document.body.style.overflow,
+        paddingLeft: Number.parseFloat(style.paddingLeft),
+        paddingRight: Number.parseFloat(style.paddingRight),
+      };
+    });
+    expect(readerMetrics.bodyOverflow).toBe("hidden");
+    expect(readerMetrics.paddingLeft).toBeGreaterThanOrEqual(20);
+    expect(readerMetrics.paddingRight).toBeGreaterThanOrEqual(20);
   });
 
   test("app has correct colors and styling", async ({ page }) => {

--- a/packages/pwa/tests/app.spec.ts
+++ b/packages/pwa/tests/app.spec.ts
@@ -1571,7 +1571,7 @@ test.describe("FREED PWA", () => {
     const menuButton = page.getByRole("button", { name: "Close menu" });
     const geometry = await page.evaluate(() => {
       const button = document.querySelector('button[aria-label="Close menu"]') as HTMLElement | null;
-      const icon = button?.querySelector("span[aria-hidden='true']") as HTMLElement | null;
+      const icon = button?.querySelector("[aria-hidden='true']") as HTMLElement | null;
       const sidebar = document.querySelector('[data-testid="app-sidebar-mobile"]') as HTMLElement | null;
       const search = sidebar?.querySelector('input[aria-label="Search or run"]') as HTMLElement | null;
       const firstControl = sidebar?.querySelector("input, button") as HTMLElement | null;
@@ -1729,13 +1729,15 @@ test.describe("FREED PWA", () => {
       }
       const toolbarRect = toolbar.getBoundingClientRect();
       const menuRect = menu.getBoundingClientRect();
-      const menuBarRects = Array.from(menuIcon.children)
-        .map((child) => child.getBoundingClientRect())
-        .filter((rect) => rect.width > 0 && rect.height > 0);
       const menuIconRect = menuIcon.getBoundingClientRect();
-      const menuVisibleLeft = menuBarRects.length
-        ? Math.min(...menuBarRects.map((rect) => rect.left))
-        : menuIconRect.left;
+      const menuBarWidths = Array.from(menuIcon.querySelectorAll("path"))
+        .map((path) => (path as SVGGraphicsElement).getBBox().width)
+        .filter((width) => width > 0);
+      const menuVisibleLeft = Math.min(
+        ...Array.from(menuIcon.querySelectorAll("path"))
+          .map((path) => (path as SVGGraphicsElement).getBBox().x)
+          .map((x) => menuIconRect.left + (x / 24) * menuIconRect.width),
+      );
       const overflowRect = overflow.getBoundingClientRect();
       const formatRect = format.getBoundingClientRect();
       const formatIconRect = formatIcon.getBoundingClientRect();
@@ -1746,7 +1748,7 @@ test.describe("FREED PWA", () => {
         menuRight: menuRect.right,
         menuIconLeft: menuIconRect.left,
         menuVisibleLeft,
-        menuBarWidths: menuBarRects.map((rect) => rect.width),
+        menuBarWidths,
         overflowRight: overflowRect.right,
         formatLeft: formatRect.left,
         formatRight: formatRect.right,
@@ -1756,7 +1758,7 @@ test.describe("FREED PWA", () => {
       };
     });
     expect(
-      Math.abs((geometry.menuLeft - geometry.toolbarLeft) - (geometry.toolbarRight - geometry.formatIconRight)),
+      Math.abs((geometry.menuVisibleLeft - geometry.toolbarLeft) - (geometry.toolbarRight - geometry.formatIconRight)),
       JSON.stringify(geometry),
     ).toBeLessThanOrEqual(2);
     for (const barWidth of geometry.menuBarWidths) {

--- a/packages/pwa/tests/app.spec.ts
+++ b/packages/pwa/tests/app.spec.ts
@@ -1715,6 +1715,10 @@ test.describe("FREED PWA", () => {
     await expect(page.getByRole("heading", { name: "Settings" })).toBeVisible();
     await expect(page.getByRole("button", { name: "Appearance" })).toBeVisible();
     await expect(page.getByRole("heading", { name: "Appearance" })).toHaveCount(0);
+    const overviewFontSize = await page.getByRole("button", { name: "Appearance" }).evaluate((button) =>
+      Number.parseFloat(window.getComputedStyle(button).fontSize),
+    );
+    expect(overviewFontSize).toBeGreaterThanOrEqual(16);
     await expect(page.getByText("Freed hit a fatal error")).toHaveCount(0);
     await expect(page.getByText("Cannot access 'mobileView' before initialization")).toHaveCount(0);
   });

--- a/packages/pwa/tests/app.spec.ts
+++ b/packages/pwa/tests/app.spec.ts
@@ -835,6 +835,76 @@ async function seedNavigationFeed(
   }, NAV_FEED_URL);
 }
 
+async function seedSocialReaderItem(
+  page: import("@playwright/test").Page,
+): Promise<void> {
+  await page.evaluate(async () => {
+    const w = window as Record<string, unknown>;
+    const automerge = w.__FREED_AUTOMERGE__ as {
+      docAddFeedItems: (items: unknown[]) => Promise<void>;
+    };
+    const store = w.__FREED_STORE__ as {
+      getState: () => {
+        items: Array<{ globalId: string }>;
+      };
+    };
+
+    const now = Date.now();
+    await automerge.docAddFeedItems([
+      {
+        globalId: "facebook:reader-author:1",
+        platform: "facebook",
+        contentType: "story",
+        capturedAt: now,
+        publishedAt: now - 60_000,
+        author: {
+          id: "reader-author",
+          handle: "reader-author",
+          displayName: "Reader Author",
+        },
+        content: {
+          text: "Social author navigation item",
+          mediaUrls: [],
+          mediaTypes: [],
+        },
+        preservedContent: {
+          title: "Social Author Navigation Item",
+          byline: "Reader Author",
+          content: "Social author navigation item",
+          textContent: "Social author navigation item",
+          siteName: "Facebook",
+          readingTime: 1,
+          capturedAt: now,
+        },
+        userState: {
+          hidden: false,
+          saved: false,
+          archived: false,
+          tags: [],
+        },
+        topics: [],
+        sourceUrl: "https://facebook.com/reader-author/posts/1",
+      },
+    ]);
+
+    await new Promise<void>((resolve, reject) => {
+      const startedAt = Date.now();
+      const interval = window.setInterval(() => {
+        const state = store.getState();
+        if (state.items.some((item) => item.globalId === "facebook:reader-author:1")) {
+          clearInterval(interval);
+          resolve();
+          return;
+        }
+        if (Date.now() - startedAt > 5_000) {
+          clearInterval(interval);
+          reject(new Error("social reader seed timeout"));
+        }
+      }, 50);
+    });
+  });
+}
+
 test.describe("FREED PWA", () => {
   test("first load blocks the app shell until legal consent is accepted", async ({
     page,
@@ -1179,6 +1249,28 @@ test.describe("FREED PWA", () => {
       await page.goForward();
       await expect(page.getByLabel("Back")).toBeVisible();
       await expect.poll(() => new URL(page.url()).search).toBe("?item=rss%3Anavigation%3A1");
+    });
+
+    test("reader author link opens friends and browser back restores the article", async ({ page }) => {
+      await emulateMobileDevice(page);
+      await page.setViewportSize({ width: 430, height: 932 });
+      await page.goto("/");
+      await acceptLegalGate(page);
+      await waitForPwaReady(page);
+      await seedSocialReaderItem(page);
+
+      await page.getByRole("button", { name: /Reader Author.*Social author navigation item/i }).click();
+      await expect(page.getByTestId("reader-article")).toBeVisible();
+
+      await page.getByTestId("reader-author-friends-link").click();
+      await expect.poll(() => new URL(page.url()).pathname).toBe("/friends");
+      await expect(page.getByText("Freed hit a fatal error")).toHaveCount(0);
+      await expect(page.getByLabel("Friends identity graph")).toBeVisible();
+
+      await page.goBack();
+      await expect.poll(() => new URL(page.url()).search).toBe("?item=facebook%3Areader-author%3A1");
+      await expect(page.getByTestId("reader-article")).toBeVisible();
+      await expect(page.getByText("Freed hit a fatal error")).toHaveCount(0);
     });
 
     test("stale item URLs are cleaned up after initialization", async ({ page }) => {

--- a/packages/pwa/tests/app.spec.ts
+++ b/packages/pwa/tests/app.spec.ts
@@ -1575,13 +1575,17 @@ test.describe("FREED PWA", () => {
       const sidebar = document.querySelector('[data-testid="app-sidebar-mobile"]') as HTMLElement | null;
       const search = sidebar?.querySelector('input[aria-label="Search or run"]') as HTMLElement | null;
       const firstControl = sidebar?.querySelector("input, button") as HTMLElement | null;
-      if (!button || !icon || !sidebar || !search || !firstControl) {
+      const settingsFooter = sidebar?.querySelector('[data-testid="mobile-sidebar-settings-footer"]') as HTMLElement | null;
+      const settingsButton = sidebar?.querySelector('[data-testid="mobile-sidebar-settings-button"]') as HTMLElement | null;
+      if (!button || !icon || !sidebar || !search || !firstControl || !settingsFooter || !settingsButton) {
         throw new Error("Mobile menu geometry elements were not found");
       }
       const buttonRect = button.getBoundingClientRect();
       const iconRect = icon.getBoundingClientRect();
       const sidebarRect = sidebar.getBoundingClientRect();
       const searchRect = search.getBoundingClientRect();
+      const footerRect = settingsFooter.getBoundingClientRect();
+      const settingsButtonRect = settingsButton.getBoundingClientRect();
       return {
         centerDelta: Math.abs(
           (buttonRect.left + buttonRect.width / 2) -
@@ -1590,11 +1594,16 @@ test.describe("FREED PWA", () => {
         firstControlIsSearch: firstControl === search,
         searchTop: Math.round(searchRect.top),
         sidebarTop: Math.round(sidebarRect.top),
+        footerBottomGap: Math.round(sidebarRect.bottom - footerRect.bottom),
+        dividerToBottom: Math.round(sidebarRect.bottom - footerRect.top),
+        settingsButtonHeight: Math.round(settingsButtonRect.height),
       };
     });
     expect(geometry.centerDelta).toBeLessThanOrEqual(1);
     expect(geometry.firstControlIsSearch).toBe(true);
     expect(geometry.searchTop - geometry.sidebarTop).toBeGreaterThanOrEqual(8);
+    expect(geometry.footerBottomGap).toBeLessThanOrEqual(1);
+    expect(geometry.dividerToBottom - geometry.settingsButtonHeight).toBeLessThanOrEqual(2);
 
     await menuButton.click();
     await expect(sidebar).toHaveClass(/-translate-x-full/);
@@ -1738,7 +1747,7 @@ test.describe("FREED PWA", () => {
     expect(
       Math.abs((geometry.menuLeft - geometry.toolbarLeft) - (geometry.toolbarRight - geometry.formatIconRight)),
       JSON.stringify(geometry),
-    ).toBeLessThanOrEqual(1);
+    ).toBeLessThanOrEqual(2);
     for (const barWidth of geometry.menuBarWidths) {
       expect(Math.abs(barWidth - geometry.menuBarWidths[0])).toBeLessThanOrEqual(1);
     }

--- a/packages/ui/src/components/LocalPreviewBadge.tsx
+++ b/packages/ui/src/components/LocalPreviewBadge.tsx
@@ -147,8 +147,8 @@ export function LocalPreviewBadge({ label }: LocalPreviewBadgeProps) {
       onPointerCancel={finishDrag}
       onLostPointerCapture={finishDrag}
     >
-      <div className="theme-floating-panel flex items-center gap-3 rounded-2xl px-3 py-2 shadow-2xl shadow-black/30">
-        <div className="rounded-full bg-[color:color-mix(in_srgb,var(--theme-accent-secondary)_20%,transparent)] px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-[var(--theme-accent-secondary)]">
+      <div className="theme-floating-panel flex items-center gap-0 rounded-2xl px-3 py-2 shadow-2xl shadow-black/30 sm:gap-3">
+        <div className="hidden rounded-full bg-[color:color-mix(in_srgb,var(--theme-accent-secondary)_20%,transparent)] px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-[var(--theme-accent-secondary)] sm:block">
           Local preview
         </div>
         <p className="min-w-0 truncate font-mono text-xs text-[var(--theme-text-primary)]">

--- a/packages/ui/src/components/SettingsDialog.tsx
+++ b/packages/ui/src/components/SettingsDialog.tsx
@@ -661,6 +661,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
 
   // ── Scrollspy ────────────────────────────────────────────────────────────
   const [activeSection, setActiveSection] = useState<SectionId>("appearance");
+  const [mobileView, setMobileView] = useState<"nav" | "section">("nav");
   const scrollRef = useRef<HTMLDivElement>(null);
 
   // Keep a ref in sync with updateState.status so scroll/visibility callbacks
@@ -769,7 +770,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
 
   useEffect(() => {
     const root = scrollRef.current;
-    if (!root || searchLower) return;
+    if (!root || searchLower || (isMobile && mobileView === "nav")) return;
 
     const updateActiveSectionFromScroll = () => {
       if (isScrollingProgrammatically.current) return;
@@ -803,17 +804,32 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
       root.removeEventListener("scroll", updateActiveSectionFromScroll);
       window.removeEventListener("resize", updateActiveSectionFromScroll);
     };
-  }, [open, searchLower]);
+  }, [isMobile, mobileView, open, searchLower]);
 
   const scrollToSection = useCallback((id: SectionId) => {
     setActiveSection(id);
+    if (isMobile && mobileView === "nav") {
+      isScrollingProgrammatically.current = true;
+      clearTimeout(scrollEndTimerRef.current);
+      setMobileView("section");
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          scrollSectionIntoView(id, "auto");
+          setActiveSection(id);
+        });
+      });
+      return;
+    }
+
     scrollSectionIntoView(id, "smooth");
-  }, [scrollSectionIntoView]);
+    setMobileView("section");
+  }, [isMobile, mobileView, scrollSectionIntoView]);
 
   // Reset state on close
   useEffect(() => {
     if (!open) {
       setSearch("");
+      setMobileView("nav");
       setSupportModalOpen(false);
     }
   }, [open]);
@@ -835,6 +851,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
       setActiveSection(targetSection as SectionId);
       isScrollingProgrammatically.current = true;
       clearTimeout(scrollEndTimerRef.current);
+      setMobileView("section");
       requestAnimationFrame(() => {
         scrollSectionIntoView(targetSection as SectionId, "auto");
         setActiveSection(targetSection as SectionId);
@@ -1413,7 +1430,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
           className={`
             theme-dialog-divider flex shrink-0 flex-col border-b
             sm:w-52 sm:border-b-0 sm:border-r
-            hidden sm:flex
+            ${mobileView === "section" ? "hidden sm:flex" : "flex"}
           `}
         >
           {/* Header */}
@@ -1482,30 +1499,31 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
         <div
           className={`
             flex-1 flex flex-col overflow-hidden
+            ${mobileView === "nav" ? "hidden sm:flex" : "flex"}
           `}
         >
           <div
             className="theme-dialog-divider sm:hidden flex shrink-0 items-center justify-between gap-3 border-b px-4 pb-2 pt-2"
             style={{ paddingTop: "calc(env(safe-area-inset-top, 0px) + 0.5rem)" }}
           >
-            <h2
-              className="truncate text-base font-semibold text-text-primary"
-              data-testid="settings-mobile-section-title"
+            <button
+              onClick={() => setMobileView("nav")}
+              className="-ml-1 flex min-w-0 items-center gap-1.5 rounded-lg px-1.5 py-1.5 text-text-secondary transition-colors hover:bg-[color:color-mix(in_srgb,var(--theme-bg-surface)_72%,transparent)] hover:text-text-primary"
+              aria-label="Back to settings"
             >
-              Settings
-            </h2>
+              <svg className="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+              </svg>
+              <span
+                className="truncate text-sm font-medium text-text-primary"
+                data-testid="settings-mobile-section-title"
+              >
+                {allSections.find((s) => s.id === activeSection)?.label}
+              </span>
+            </button>
             <CloseButton
               testId="settings-close-button-mobile"
               className="-mr-1 shrink-0"
-            />
-          </div>
-          <div className="shrink-0 px-4 pb-3 pt-3 sm:hidden">
-            <SearchField
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              onClear={() => setSearch("")}
-              placeholder="Search settings"
-              aria-label="Search settings"
             />
           </div>
 

--- a/packages/ui/src/components/SettingsDialog.tsx
+++ b/packages/ui/src/components/SettingsDialog.tsx
@@ -102,6 +102,7 @@ type ProviderAuthSlices = {
 };
 const EMPTY_PROVIDER_SECTION_SYNC_COUNTS: Partial<Record<ProviderSectionId, number>> = {};
 const INSTALLED_BUILD_PRESENTATION = describeInstalledBuild(readBuildMetadata());
+const SETTINGS_OVERVIEW_ROW_TEXT = "text-base sm:text-xs";
 
 function isProviderSection(sectionId: SectionId): sectionId is ProviderSectionId {
   return (
@@ -1331,7 +1332,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
         onClick={() => scrollToSection(section.id)}
         aria-current={isActive ? "location" : undefined}
         data-active={isActive ? "true" : "false"}
-        className={`w-full flex items-center gap-2 text-left text-xs transition-colors rounded-md ${
+        className={`w-full flex items-center gap-2 text-left ${SETTINGS_OVERVIEW_ROW_TEXT} transition-colors rounded-md ${
           indented ? "pl-7 pr-2 py-2" : "px-2 py-2"
         } ${
           isActive
@@ -1377,7 +1378,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
                   onClick={() => scrollToSection(item.children[0].id)}
                   aria-current={isGroupActive ? "location" : undefined}
                   data-active={isGroupActive ? "true" : "false"}
-                  className={`w-full flex items-center gap-2 px-2 py-2 text-left text-xs transition-colors rounded-md ${
+                  className={`w-full flex items-center gap-2 px-2 py-2 text-left ${SETTINGS_OVERVIEW_ROW_TEXT} transition-colors rounded-md ${
                     isGroupActive
                       ? "text-[var(--theme-accent-secondary)]"
                       : "text-text-secondary hover:text-text-primary hover:bg-[color:color-mix(in_srgb,var(--theme-bg-surface)_72%,transparent)]"
@@ -1446,7 +1447,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
             className="flex shrink-0 items-center justify-between px-4 pb-1.5 pt-2 sm:hidden"
             style={{ paddingTop: "calc(env(safe-area-inset-top, 0px) + 0.5rem)" }}
           >
-            <h2 className="text-sm font-semibold text-text-primary">Settings</h2>
+            <h2 className="text-base font-semibold text-text-primary">Settings</h2>
             <CloseButton
               testId={isMobile ? "settings-close-button-sidebar" : undefined}
               className="-mr-1"

--- a/packages/ui/src/components/SettingsDialog.tsx
+++ b/packages/ui/src/components/SettingsDialog.tsx
@@ -5,8 +5,7 @@
  * sections stacked. Scroll position drives scrollspy so the nav always reflects
  * which section is currently in view.
  *
- * Mobile: single-column. The nav is a full-screen list; tapping any section
- * "pushes" to that section's content with a back button (iOS-style).
+ * Mobile: single-column with stacked sections and compact spacing.
  */
 
 import { Fragment, useCallback, useEffect, useRef, useState, type CSSProperties, type ReactNode } from "react";
@@ -182,11 +181,6 @@ const ICONS: Record<SectionId, ReactNode> = {
       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9.75 12.75l1.5 1.5 3-3.75" />
     </svg>
   ),
-  support: (
-    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M7 8h10M7 12h7m-5 8l-4-4H4a2 2 0 01-2-2V6a2 2 0 012-2h16a2 2 0 012 2v8a2 2 0 01-2 2h-7l-4 4z" />
-    </svg>
-  ),
   appearance: (
     <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
@@ -328,7 +322,6 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
     sectionById.ai,
     ...(checkForUpdates ? [sectionById.updates] : []),
     sectionById.legal,
-    sectionById.support,
     ...(factoryReset ? [sectionById.danger] : []),
   ];
 
@@ -588,6 +581,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
   const [deleteFromCloud, setDeleteFromCloud] = useState(false);
   const [resetting, setResetting] = useState(false);
   const [showSampleSeedConfirm, setShowSampleSeedConfirm] = useState(false);
+  const [supportModalOpen, setSupportModalOpen] = useState(false);
 
   const handleReset = useCallback(async () => {
     if (!factoryReset) return;
@@ -666,8 +660,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
     : allSections;
 
   // ── Scrollspy ────────────────────────────────────────────────────────────
-  const [activeSection, setActiveSection] = useState<SectionId>("legal");
-  const [mobileView, setMobileView] = useState<"nav" | "section">("nav");
+  const [activeSection, setActiveSection] = useState<SectionId>("appearance");
   const scrollRef = useRef<HTMLDivElement>(null);
 
   // Keep a ref in sync with updateState.status so scroll/visibility callbacks
@@ -776,7 +769,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
 
   useEffect(() => {
     const root = scrollRef.current;
-    if (!root || searchLower || (isMobile && mobileView === "nav")) return;
+    if (!root || searchLower) return;
 
     const updateActiveSectionFromScroll = () => {
       if (isScrollingProgrammatically.current) return;
@@ -810,44 +803,38 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
       root.removeEventListener("scroll", updateActiveSectionFromScroll);
       window.removeEventListener("resize", updateActiveSectionFromScroll);
     };
-  }, [isMobile, mobileView, open, searchLower]);
+  }, [open, searchLower]);
 
   const scrollToSection = useCallback((id: SectionId) => {
     setActiveSection(id);
-    if (isMobile && mobileView === "nav") {
-      isScrollingProgrammatically.current = true;
-      clearTimeout(scrollEndTimerRef.current);
-      setMobileView("section");
-      requestAnimationFrame(() => {
-        requestAnimationFrame(() => {
-          scrollSectionIntoView(id, "auto");
-          setActiveSection(id);
-        });
-      });
-      return;
-    }
-
     scrollSectionIntoView(id, "smooth");
-    setMobileView("section");
-  }, [isMobile, mobileView, scrollSectionIntoView]);
+  }, [scrollSectionIntoView]);
 
   // Reset state on close
   useEffect(() => {
     if (!open) {
       setSearch("");
-      setMobileView("nav");
+      setSupportModalOpen(false);
     }
   }, [open]);
 
-  // Scroll to a programmatically requested section (e.g. nudge → Sync)
+  // Scroll to a programmatically requested section.
   const { targetSection, clearTarget } = useSettingsStore();
   useEffect(() => {
     if (!open || !targetSection) return;
+    if (targetSection === "support") {
+      setSupportModalOpen(true);
+      clearTarget();
+      return;
+    }
+    if (!allSections.some((section) => section.id === targetSection)) {
+      clearTarget();
+      return;
+    }
     const rafId = requestAnimationFrame(() => {
       setActiveSection(targetSection as SectionId);
       isScrollingProgrammatically.current = true;
       clearTimeout(scrollEndTimerRef.current);
-      setMobileView("section");
       requestAnimationFrame(() => {
         scrollSectionIntoView(targetSection as SectionId, "auto");
         setActiveSection(targetSection as SectionId);
@@ -855,7 +842,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
       clearTarget();
     });
     return () => cancelAnimationFrame(rafId);
-  }, [clearTarget, open, scrollSectionIntoView, targetSection]);
+  }, [allSections, clearTarget, open, scrollSectionIntoView, targetSection]);
 
   // Body scroll lock
   useEffect(() => {
@@ -896,9 +883,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
   function renderSectionBlock(id: SectionId) {
     const isVisible = visibleSections.some((s) => s.id === id);
     if (!isVisible) return null;
-    const sectionMinHeight = isMobile && mobileView !== "section"
-      ? "100%"
-      : "calc(100% + 20rem)";
+    const sectionMinHeight = isMobile ? undefined : "calc(100% + 20rem)";
 
     // SectionContent and this wrapper both stay plain function calls because
     // they are defined inside SettingsDialog. Rendering either as JSX would
@@ -908,7 +893,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
     return (
       <section
         data-section={id}
-        className="flex flex-col pb-8"
+        className={isMobile ? "flex flex-col pb-2" : "flex flex-col pb-8"}
         style={{ minHeight: sectionMinHeight }}
       >
         {SectionContent({ id })}
@@ -1065,14 +1050,6 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
           <>
             <SectionHeading label="Legal" />
             {LegalSettingsContent ? <LegalSettingsContent /> : null}
-          </>
-        );
-
-      case "support":
-        return (
-          <>
-            <SectionHeading label="Support" />
-            <ReportComposer />
           </>
         );
 
@@ -1250,7 +1227,16 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
         return factoryReset ? (
           <>
             <SectionHeading label="Danger Zone" danger />
-            <div className="space-y-6">
+            <div className="space-y-3 sm:space-y-6">
+              <button
+                onClick={() => setSupportModalOpen(true)}
+                className="w-full rounded-xl bg-[var(--theme-bg-muted)] px-3 py-2.5 text-left transition-colors hover:bg-[var(--theme-bg-card-hover)]"
+              >
+                <div>
+                  <p className="text-sm text-[var(--theme-text-secondary)]">Submit support ticket</p>
+                  <p className="mt-0.5 text-xs text-[var(--theme-text-soft)]">Share diagnostics and describe what broke</p>
+                </div>
+              </button>
               <button
                 onClick={() => {
                   onClose();
@@ -1427,7 +1413,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
           className={`
             theme-dialog-divider flex shrink-0 flex-col border-b
             sm:w-52 sm:border-b-0 sm:border-r
-            ${mobileView === "section" ? "hidden sm:flex" : "flex"}
+            hidden sm:flex
           `}
         >
           {/* Header */}
@@ -1496,40 +1482,37 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
         <div
           className={`
             flex-1 flex flex-col overflow-hidden
-            ${mobileView === "nav" ? "hidden sm:flex" : "flex"}
           `}
         >
-          {/* Mobile back button + section title */}
           <div
             className="theme-dialog-divider sm:hidden flex shrink-0 items-center justify-between gap-3 border-b px-4 pb-2 pt-2"
             style={{ paddingTop: "calc(env(safe-area-inset-top, 0px) + 0.5rem)" }}
           >
-            <button
-              onClick={() => setMobileView("nav")}
-              className="-ml-1 flex min-w-0 items-center gap-1.5 rounded-lg px-1.5 py-1.5 text-text-secondary transition-colors hover:bg-[color:color-mix(in_srgb,var(--theme-bg-surface)_72%,transparent)] hover:text-text-primary"
-              aria-label="Back to settings"
+            <h2
+              className="truncate text-base font-semibold text-text-primary"
+              data-testid="settings-mobile-section-title"
             >
-              <svg className="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
-              </svg>
-              <span
-                className="truncate text-sm font-medium text-text-primary"
-                data-testid="settings-mobile-section-title"
-              >
-                {allSections.find((s) => s.id === activeSection)?.label}
-              </span>
-            </button>
+              Settings
+            </h2>
             <CloseButton
               testId="settings-close-button-mobile"
               className="-mr-1 shrink-0"
             />
           </div>
+          <div className="shrink-0 px-4 pb-3 pt-3 sm:hidden">
+            <SearchField
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              onClear={() => setSearch("")}
+              placeholder="Search settings"
+              aria-label="Search settings"
+            />
+          </div>
 
-          {/* Scrollable sections */}
           <div
             ref={scrollRef}
             data-testid="settings-scroll-container"
-            className="flex-1 overflow-y-auto px-6 pt-6 [&>section+section]:mt-24"
+            className="flex-1 overflow-y-auto px-4 pt-2 text-base sm:px-6 sm:pt-6 sm:text-sm sm:[&>section+section]:mt-24 [&>section+section]:mt-6"
             style={{ paddingBottom: scrollContainerBottomPadding }}
           >
             {searchLower && visibleSections.length === 0 ? (
@@ -1677,6 +1660,29 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
           </div>
         </div>
       )}
+
+      {supportModalOpen && (
+        <div className="theme-elevated-overlay absolute inset-0 z-20 flex items-start justify-center overflow-y-auto p-4 sm:items-center">
+          <div className="theme-dialog-shell theme-settings-shell my-auto flex max-h-[calc(100dvh-2rem)] w-full max-w-2xl flex-col overflow-hidden">
+            <div className="theme-dialog-divider flex shrink-0 items-center justify-between border-b px-4 py-3">
+              <h2 className="text-base font-semibold text-text-primary">Support</h2>
+              <button
+                type="button"
+                onClick={() => setSupportModalOpen(false)}
+                aria-label="Close support"
+                className="inline-flex h-10 w-10 items-center justify-center rounded-[28px] text-[var(--theme-text-muted)] transition-colors hover:bg-[var(--theme-bg-muted)] hover:text-[var(--theme-text-primary)]"
+              >
+                <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+            <div className="minimal-scroll flex-1 overflow-y-auto px-4 py-4 sm:px-6 sm:py-6">
+              <ReportComposer />
+            </div>
+          </div>
+        </div>
+      )}
     </div>,
     document.body,
   );
@@ -1733,7 +1739,7 @@ function UpToDateBadge() {
 function SectionHeading({ label, danger }: { label: string; danger?: boolean }) {
   return (
     <h3
-      className={`text-sm font-semibold uppercase tracking-wide mb-5 ${
+      className={`mb-4 text-base font-semibold uppercase tracking-wide sm:mb-5 sm:text-sm ${
         danger ? "text-[rgb(var(--theme-feedback-danger-rgb)/0.64)]" : "text-text-muted"
       }`}
     >

--- a/packages/ui/src/components/SettingsToggle.tsx
+++ b/packages/ui/src/components/SettingsToggle.tsx
@@ -42,8 +42,8 @@ export function SettingsToggle({
         />
       </div>
       <div className="min-w-0 flex-1">
-        <p className="text-sm text-[var(--theme-text-secondary)] transition-colors group-hover:text-[var(--theme-text-primary)]">{label}</p>
-        {description ? <p className="mt-0.5 text-xs text-[var(--theme-text-soft)]">{description}</p> : null}
+        <p className="text-base text-[var(--theme-text-secondary)] transition-colors group-hover:text-[var(--theme-text-primary)] sm:text-sm">{label}</p>
+        {description ? <p className="mt-0.5 text-sm text-[var(--theme-text-soft)] sm:text-xs">{description}</p> : null}
       </div>
     </button>
   );

--- a/packages/ui/src/components/feed/FeedList.tsx
+++ b/packages/ui/src/components/feed/FeedList.tsx
@@ -269,7 +269,7 @@ export function FeedList({
 
   const isMobile = useIsMobile();
   const feedCardHorizontalGutter = isMobile
-    ? FEED_CARD_GAP
+    ? 0
     : DESKTOP_FEED_CARD_HORIZONTAL_GUTTER;
   const { FeedEmptyState } = usePlatform();
   const isLoading = useAppStore((s) => s.isLoading);
@@ -587,7 +587,7 @@ export function FeedList({
                 <div
                   className="mx-auto w-full max-w-2xl max-[959px]:max-w-none"
                   style={{
-                    paddingInline: `${FEED_CARD_GAP}px`,
+                    paddingInline: `${feedCardHorizontalGutter}px`,
                     paddingBottom: `${FEED_CARD_GAP}px`,
                     paddingTop: virtualItem.index === 0 ? `${FEED_CARD_GAP}px` : undefined,
                   }}

--- a/packages/ui/src/components/feed/ReaderView.tsx
+++ b/packages/ui/src/components/feed/ReaderView.tsx
@@ -567,6 +567,15 @@ export function ReaderView({
     [html, preservedText, item.content.text],
   );
 
+  useEffect(() => {
+    if (inline) return;
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [inline]);
+
   return (
     <div
       className={
@@ -728,7 +737,7 @@ export function ReaderView({
       {/* Article content */}
       <article
         data-testid="reader-article"
-        className="mx-auto w-full max-w-3xl max-[959px]:max-w-none px-[var(--feed-card-gap,8px)] py-6 sm:py-8 min-[960px]:px-6"
+        className="mx-auto w-full max-w-3xl max-[959px]:max-w-none px-5 py-6 sm:py-8 min-[960px]:px-6"
       >
         {/* Meta */}
         <div className="mb-6">

--- a/packages/ui/src/components/feed/ReaderView.tsx
+++ b/packages/ui/src/components/feed/ReaderView.tsx
@@ -580,7 +580,7 @@ export function ReaderView({
     <div
       className={
         inline
-          ? "theme-scroll-fade-y flex-1 min-w-0 overflow-auto bg-transparent"
+          ? "flex-1 min-w-0 overflow-auto bg-transparent"
           : "theme-scroll-fade-y fixed inset-0 z-50 overflow-auto bg-[var(--theme-bg-root)]"
       }
     >

--- a/packages/ui/src/components/friends/AccountDetailPanel.tsx
+++ b/packages/ui/src/components/friends/AccountDetailPanel.tsx
@@ -43,6 +43,14 @@ function signalCountLabel(suggestion: FriendCandidateSuggestion): string {
     .join(", ");
 }
 
+function safeText(value: unknown, fallback = ""): string {
+  return typeof value === "string" && value.trim() ? value.trim() : fallback;
+}
+
+function personName(person: Pick<Person, "name"> | null | undefined): string {
+  return safeText(person?.name, "Unnamed friend");
+}
+
 export function AccountDetailPanel({
   account,
   linkedPerson = null,
@@ -73,7 +81,7 @@ export function AccountDetailPanel({
     if (!normalized) return next;
     return next.filter((person) => {
       return (
-        person.name.toLowerCase().includes(normalized) ||
+        personName(person).toLowerCase().includes(normalized) ||
         person.bio?.toLowerCase().includes(normalized) ||
         person.tags?.some((tag) => tag.toLowerCase().includes(normalized))
       );
@@ -153,11 +161,11 @@ export function AccountDetailPanel({
             </p>
             {confirmedLinkedPerson ? (
               <p className="mt-2 text-xs text-[color:var(--theme-accent-secondary)]">
-                Linked to {confirmedLinkedPerson.name}
+                Linked to {personName(confirmedLinkedPerson)}
               </p>
             ) : provisionalLinkedPerson ? (
               <p className="mt-2 text-xs text-[color:var(--theme-text-muted)]">
-                Linked to provisional identity {provisionalLinkedPerson.name}
+                Linked to provisional identity {personName(provisionalLinkedPerson)}
               </p>
             ) : (
               <p className="mt-2 text-xs text-[color:var(--theme-text-muted)]">
@@ -265,7 +273,7 @@ export function AccountDetailPanel({
                       <div className="flex items-center justify-between gap-3">
                         <div className="min-w-0">
                           <p className="truncate text-sm font-medium text-[color:var(--theme-text-primary)]">
-                            {person.name}
+                            {personName(person)}
                           </p>
                           <p className="mt-1 text-xs text-[color:var(--theme-text-muted)]">
                             {suggestion.reason}
@@ -318,7 +326,7 @@ export function AccountDetailPanel({
                   >
                     <div className="min-w-0">
                       <p className="truncate text-sm font-medium text-[color:var(--theme-text-primary)]">
-                        {person.name}
+                        {personName(person)}
                       </p>
                       <p className="mt-1 text-xs text-[color:var(--theme-text-muted)]">
                         Care level {person.careLevel.toLocaleString()}

--- a/packages/ui/src/components/friends/FriendDetailPanel.tsx
+++ b/packages/ui/src/components/friends/FriendDetailPanel.tsx
@@ -47,6 +47,10 @@ const platformIcons: Record<string, ReactNode> = {
   saved: <BookmarkIcon className={cls} />,
 };
 
+function safeText(value: unknown, fallback = ""): string {
+  return typeof value === "string" && value.trim() ? value.trim() : fallback;
+}
+
 // ---------------------------------------------------------------------------
 // Care level indicator
 // ---------------------------------------------------------------------------
@@ -224,14 +228,14 @@ export function FriendDetailPanel({
         <div className="flex items-start gap-3">
           {/* Avatar */}
           <FriendAvatar
-            name={friend.name}
+            name={safeText(friend.name, "Unnamed friend")}
             avatarUrl={avatarUrl}
             size={56}
           />
 
           <div className="min-w-0 flex-1">
             <p className="text-base font-semibold text-text-primary truncate">
-              {friend.name}
+              {safeText(friend.name, "Unnamed friend")}
             </p>
             <CareStars level={friend.careLevel} />
             {friend.bio && (

--- a/packages/ui/src/components/friends/FriendEditor.tsx
+++ b/packages/ui/src/components/friends/FriendEditor.tsx
@@ -84,6 +84,10 @@ interface AuthorCandidate {
   avatarUrl?: string;
 }
 
+function safeText(value: unknown, fallback = ""): string {
+  return typeof value === "string" && value.trim() ? value.trim() : fallback;
+}
+
 function useAuthorCandidates(
   existingSources: FriendSource[],
   allFriends: Record<string, Friend>
@@ -119,7 +123,7 @@ function useAuthorCandidates(
     }
 
     return Array.from(seen.values()).sort((a, b) =>
-      a.displayName.localeCompare(b.displayName)
+      safeText(a.displayName).localeCompare(safeText(b.displayName))
     );
   }, [items, existingSources, allFriends]);
 }

--- a/packages/ui/src/components/friends/FriendsView.tsx
+++ b/packages/ui/src/components/friends/FriendsView.tsx
@@ -74,6 +74,14 @@ const RELATIONSHIP_TIER_OPTIONS: Array<{ level: RelationshipTierLevel; label: st
   { level: 5, label: "Fam" },
 ];
 
+function safeText(value: unknown, fallback = ""): string {
+  return typeof value === "string" && value.trim() ? value.trim() : fallback;
+}
+
+function personName(person: Pick<Person, "name"> | null | undefined): string {
+  return safeText(person?.name, "Unnamed friend");
+}
+
 type EditorState =
   | { kind: "new"; draft?: Partial<Friend> | null }
   | { kind: "edit"; personId: string }
@@ -207,14 +215,16 @@ function FriendListRow({
     >
       <div className="flex items-start gap-3">
         <FriendAvatar
-          name={entry.friend.name}
+          name={safeText(entry.friend.name, "Unnamed friend")}
           avatarUrl={avatarUrl}
           size={40}
         />
 
         <div className="min-w-0 flex-1">
           <div className="flex items-center justify-between gap-2">
-            <p className="truncate text-sm font-medium text-[color:var(--theme-text-primary)]">{entry.friend.name}</p>
+            <p className="truncate text-sm font-medium text-[color:var(--theme-text-primary)]">
+              {safeText(entry.friend.name, "Unnamed friend")}
+            </p>
             <div className="flex shrink-0 items-center gap-2">
               <RelationshipTierBadge person={entry.friend} />
               <CareDots level={entry.friend.careLevel} />
@@ -592,11 +602,11 @@ export function FriendsView({
     () =>
       Object.values(persons)
         .filter((person) => person.relationshipStatus === "friend")
-        .sort((left, right) => left.name.localeCompare(right.name)),
+        .sort((left, right) => personName(left).localeCompare(personName(right))),
     [persons],
   );
   const allPersons = useMemo(
-    () => Object.values(persons).sort((left, right) => left.name.localeCompare(right.name)),
+    () => Object.values(persons).sort((left, right) => personName(left).localeCompare(personName(right))),
     [persons],
   );
   const friendsById = useMemo<Record<string, Friend>>(
@@ -1293,7 +1303,7 @@ export function FriendsView({
             </svg>
           </button>
           <div className="min-w-0">
-            <h2 className="truncate text-sm font-semibold text-[color:var(--theme-text-primary)]">{selectedPerson?.name}</h2>
+            <h2 className="truncate text-sm font-semibold text-[color:var(--theme-text-primary)]">{personName(selectedPerson)}</h2>
             <p className="mt-1 text-xs text-[color:var(--theme-text-muted)]">
               {selectedPerson ? relationshipTierLabelForPerson(selectedPerson) : "Followed"}
             </p>
@@ -1335,7 +1345,7 @@ export function FriendsView({
                 Suggested channels
               </p>
               <p className="mt-1 text-sm text-[color:var(--theme-text-primary)]">
-                Link likely accounts to {selectedPerson.name}.
+                Link likely accounts to {personName(selectedPerson)}.
               </p>
             </div>
           </div>
@@ -1496,7 +1506,7 @@ export function FriendsView({
                 <span>{selectedAccountFeedItems.length.toLocaleString()} captured post{selectedAccountFeedItems.length === 1 ? "" : "s"}</span>
                 <span>•</span>
                 <span>
-                  {linkedPerson ? `Linked to ${linkedPerson.name}` : "Not linked yet"}
+                  {linkedPerson ? `Linked to ${personName(linkedPerson)}` : "Not linked yet"}
                 </span>
               </div>
             </div>
@@ -1626,9 +1636,12 @@ export function FriendsView({
     : selectedPerson
       ? renderSelectedPersonSidebar()
       : renderOverviewSidebar();
-  const showGraphSurface = !isMobile || mobileSurface === "graph";
+  const hasMobileDetailSelection = Boolean(selectedPerson || selectedAccount);
+  const effectiveMobileSurface =
+    isMobile && mobileSurface === "details" && !hasMobileDetailSelection ? "graph" : mobileSurface;
+  const showGraphSurface = !isMobile || effectiveMobileSurface === "graph";
   const showDesktopSidebar = !isMobile && friendsSidebarOpen;
-  const showMobileSidebar = isMobile && mobileSurface === "details";
+  const showMobileSidebar = isMobile && effectiveMobileSurface === "details";
   const showCollapsedSelectionCard =
     !isMobile && !friendsSidebarOpen && (!!selectedPerson || !!selectedAccount);
 

--- a/packages/ui/src/components/icons.tsx
+++ b/packages/ui/src/components/icons.tsx
@@ -73,6 +73,25 @@ export function FilterIcon({ className = "w-4 h-4", style }: IconProps) {
   );
 }
 
+export function MenuIcon({ className = "w-5 h-5", style }: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className} style={style} aria-hidden="true">
+      <path d="M2 6h20" />
+      <path d="M2 12h20" />
+      <path d="M2 18h20" />
+    </svg>
+  );
+}
+
+export function CloseIcon({ className = "w-5 h-5", style }: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className} style={style} aria-hidden="true">
+      <path d="M6 6l12 12" />
+      <path d="M18 6L6 18" />
+    </svg>
+  );
+}
+
 export function AnimatedMenuIcon({
   open = false,
   className = "w-5 h-5",

--- a/packages/ui/src/components/icons.tsx
+++ b/packages/ui/src/components/icons.tsx
@@ -85,18 +85,18 @@ export function AnimatedMenuIcon({
       aria-hidden="true"
     >
       <span
-        className={`absolute left-[3px] h-[2px] rounded-full bg-current transition-all duration-200 ease-out ${
-          open ? "top-1/2 w-[18px] -translate-y-1/2 rotate-45" : "top-[5px] w-[18px]"
+        className={`absolute left-1/2 h-[2px] w-[18px] -translate-x-1/2 rounded-full bg-current transition-all duration-200 ease-out ${
+          open ? "top-1/2 -translate-y-1/2 rotate-45" : "top-[5px]"
         }`}
       />
       <span
-        className={`absolute left-[3px] top-1/2 h-[2px] -translate-y-1/2 rounded-full bg-current transition-all duration-200 ease-out ${
-          open ? "w-0 opacity-0" : "w-[14px] opacity-100"
+        className={`absolute left-1/2 top-1/2 h-[2px] -translate-x-1/2 -translate-y-1/2 rounded-full bg-current transition-all duration-200 ease-out ${
+          open ? "w-0 opacity-0" : "w-[18px] opacity-100"
         }`}
       />
       <span
-        className={`absolute left-[3px] h-[2px] rounded-full bg-current transition-all duration-200 ease-out ${
-          open ? "top-1/2 w-[18px] -translate-y-1/2 -rotate-45" : "top-[15px] w-[10px]"
+        className={`absolute left-1/2 h-[2px] w-[18px] -translate-x-1/2 rounded-full bg-current transition-all duration-200 ease-out ${
+          open ? "top-1/2 -translate-y-1/2 -rotate-45" : "top-[15px]"
         }`}
       />
     </span>

--- a/packages/ui/src/components/layout/AppShell.tsx
+++ b/packages/ui/src/components/layout/AppShell.tsx
@@ -373,7 +373,6 @@ export function AppShell({ children }: AppShellProps) {
           <Sidebar
             mobileOpen={mobileSidebarOpen}
             onMobileClose={() => setMobileSidebarOpen(false)}
-            onMobileToggle={() => setMobileSidebarOpen((value) => !value)}
             desktopMode={desktopSidebarMode}
             onDesktopModeChange={persistDesktopSidebarMode}
             onDesktopDisplayModeChange={setDesktopSidebarDisplayMode}

--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -1130,12 +1130,10 @@ export function Header({
     document.addEventListener("mousedown", handleClick);
     document.addEventListener("keydown", handleKey);
     window.addEventListener("resize", updateToolbarOverflowMenuPosition);
-    window.addEventListener("scroll", updateToolbarOverflowMenuPosition, true);
     return () => {
       document.removeEventListener("mousedown", handleClick);
       document.removeEventListener("keydown", handleKey);
       window.removeEventListener("resize", updateToolbarOverflowMenuPosition);
-      window.removeEventListener("scroll", updateToolbarOverflowMenuPosition, true);
     };
   }, [toolbarOverflowMenuOpen, updateToolbarOverflowMenuPosition]);
 
@@ -1346,7 +1344,7 @@ export function Header({
                   <button
                     onClick={onMobileMenuToggle}
                     {...getToolbarControlProps()}
-                    className={`${TOOLBAR_ICON_BUTTON_CLASS} theme-toolbar-button-ghost`}
+                    className={`${TOOLBAR_ICON_BUTTON_CLASS} ${mobileSidebarOpen ? "theme-toolbar-button-neutral" : "theme-toolbar-button-ghost"}`}
                     aria-label={mobileSidebarOpen ? "Close menu" : "Open menu"}
                     aria-pressed={mobileSidebarOpen}
                   >
@@ -1784,29 +1782,10 @@ export function Header({
 
                 <ToolbarAnimatedSlot
                   visible={showToolbarOverflowMenuButton || showCollapsedToolbarFilterMenu}
-                  width={showToolbarOverflowMenuButton && showCollapsedToolbarFilterMenu ? "5.375rem" : "2.5rem"}
+                  width={showToolbarOverflowMenuButton && showCollapsedToolbarFilterMenu ? "5rem" : "2.5rem"}
                 >
                   {showToolbarOverflowMenuButton || showCollapsedToolbarFilterMenu ? (
-                    <div className="flex items-center gap-2">
-                      {showCollapsedToolbarFilterMenu ? (
-                        <Tooltip label="Filter view">
-                          <button
-                            ref={signalFilterButtonRef}
-                            type="button"
-                            onClick={toggleSignalFilterMenu}
-                            {...getToolbarControlProps()}
-                            data-testid="mobile-toolbar-filter-button"
-                            className={`${TOOLBAR_ICON_BUTTON_CLASS} ${
-                              isMobileDevice ? "theme-toolbar-button-ghost" : "theme-toolbar-button-neutral"
-                            }`}
-                            aria-haspopup="menu"
-                            aria-expanded={signalFilterMenuOpen}
-                            aria-label="Filter view"
-                          >
-                            <FilterIcon className="h-5 w-5" />
-                          </button>
-                        </Tooltip>
-                      ) : null}
+                    <div className="flex items-center gap-0">
                       {showToolbarOverflowMenuButton ? (
                         <Tooltip label="More actions">
                           <button
@@ -1823,6 +1802,25 @@ export function Header({
                             aria-label="More actions"
                           >
                             <ToolbarOverflowIcon />
+                          </button>
+                        </Tooltip>
+                      ) : null}
+                      {showCollapsedToolbarFilterMenu ? (
+                        <Tooltip label="Filter view">
+                          <button
+                            ref={signalFilterButtonRef}
+                            type="button"
+                            onClick={toggleSignalFilterMenu}
+                            {...getToolbarControlProps()}
+                            data-testid="mobile-toolbar-filter-button"
+                            className={`${TOOLBAR_ICON_BUTTON_CLASS} ${
+                              isMobileDevice ? "theme-toolbar-button-ghost" : "theme-toolbar-button-neutral"
+                            }`}
+                            aria-haspopup="menu"
+                            aria-expanded={signalFilterMenuOpen}
+                            aria-label="Filter view"
+                          >
+                            <FilterIcon className="h-5 w-5" />
                           </button>
                         </Tooltip>
                       ) : null}

--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -1336,7 +1336,7 @@ export function Header({
           >
             <div
               ref={layoutControlHostRef}
-              className="relative flex h-full shrink-0 items-center pl-3 min-[960px]:pl-0"
+              className="relative flex h-full shrink-0 items-center pl-[13px] min-[960px]:pl-0"
               style={leftToolbarStyle}
             >
               {isMobileDevice ? (

--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -1336,7 +1336,7 @@ export function Header({
           >
             <div
               ref={layoutControlHostRef}
-              className="relative flex h-full shrink-0 items-center"
+              className="relative flex h-full shrink-0 items-center pl-3 min-[960px]:pl-0"
               style={leftToolbarStyle}
             >
               {isMobileDevice ? (

--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -26,8 +26,9 @@ import {
 import { Tooltip } from "../Tooltip.js";
 import {
   ArchiveIcon,
-  AnimatedMenuIcon,
+  CloseIcon,
   FilterIcon,
+  MenuIcon,
   ReaderRailHideIcon,
   ReaderRailShowIcon,
   SidebarCollapseIcon,
@@ -1336,7 +1337,7 @@ export function Header({
           >
             <div
               ref={layoutControlHostRef}
-              className="relative flex h-full shrink-0 items-center pl-[13px] min-[960px]:pl-0"
+              className="relative flex h-full shrink-0 items-center"
               style={leftToolbarStyle}
             >
               {isMobileDevice ? (
@@ -1348,7 +1349,7 @@ export function Header({
                     aria-label={mobileSidebarOpen ? "Close menu" : "Open menu"}
                     aria-pressed={mobileSidebarOpen}
                   >
-                    <AnimatedMenuIcon open={mobileSidebarOpen} className="h-5 w-5" />
+                    {mobileSidebarOpen ? <CloseIcon className="h-5 w-5" /> : <MenuIcon className="h-5 w-5" />}
                   </button>
                 </Tooltip>
               ) : null}

--- a/packages/ui/src/components/layout/SearchJumpField.tsx
+++ b/packages/ui/src/components/layout/SearchJumpField.tsx
@@ -65,6 +65,21 @@ function groupActionsBySection(actions: readonly CommandPaletteAction[]) {
   return sections;
 }
 
+function sortLabel(value: unknown, fallback = ""): string {
+  return typeof value === "string" && value.trim() ? value.trim() : fallback;
+}
+
+function accountSortLabel(account: {
+  displayName?: string;
+  handle?: string;
+  externalId?: string;
+}): string {
+  return sortLabel(account.displayName)
+    || sortLabel(account.handle)
+    || sortLabel(account.externalId)
+    || "";
+}
+
 function PaletteLineIcon({ children }: { children: ReactNode }) {
   return (
     <span
@@ -365,8 +380,12 @@ export function SearchJumpField({
   const enabledFeeds = useMemo(
     () =>
       Object.values(feeds)
-        .filter((feed) => feed.enabled)
-        .sort((left, right) => left.title.localeCompare(right.title)),
+        .filter((feed) => feed.enabled && typeof feed.url === "string" && feed.url.trim())
+        .sort((left, right) => {
+          const leftTitle = sortLabel(left.title, left.url);
+          const rightTitle = sortLabel(right.title, right.url);
+          return leftTitle.localeCompare(rightTitle);
+        }),
     [feeds],
   );
   const socialChannels = useMemo(
@@ -375,7 +394,9 @@ export function SearchJumpField({
         .filter((account) =>
           account.kind === "social" &&
           account.provider !== "rss" &&
-          account.provider !== "saved"
+          account.provider !== "saved" &&
+          typeof account.externalId === "string" &&
+          account.externalId.trim()
         )
         .map((account) => ({
           account,
@@ -383,8 +404,8 @@ export function SearchJumpField({
           personName: account.personId ? persons[account.personId]?.name : undefined,
         }))
         .sort((left, right) => {
-          const leftTitle = left.account.displayName ?? left.account.handle ?? left.account.externalId;
-          const rightTitle = right.account.displayName ?? right.account.handle ?? right.account.externalId;
+          const leftTitle = accountSortLabel(left.account);
+          const rightTitle = accountSortLabel(right.account);
           return leftTitle.localeCompare(rightTitle);
         }),
     [accounts, persons],
@@ -449,7 +470,7 @@ export function SearchJumpField({
         })),
         feeds: enabledFeeds.map((feed) => ({
           url: feed.url,
-          title: feed.title,
+          title: sortLabel(feed.title, feed.url),
         })),
         socialChannels,
         tagFilters,

--- a/packages/ui/src/components/layout/Sidebar.tsx
+++ b/packages/ui/src/components/layout/Sidebar.tsx
@@ -1832,17 +1832,18 @@ export function Sidebar({
       >
         {sidebarBody}
         <div
-          className="shrink-0 border-t border-[var(--theme-border-subtle)] pt-2"
+          data-testid="mobile-sidebar-settings-footer"
+          className="shrink-0 border-t border-[var(--theme-border-subtle)]"
           style={{
             paddingInline: `${sidebarPaddingInlinePx}px`,
-            paddingBottom: compactRail
-              ? `calc(${COMPACT_RAIL_OUTER_INSET_PX}px + env(safe-area-inset-bottom, 0px) + 0.5rem)`
-              : `calc(${sidebarPaddingBlockPx}px + env(safe-area-inset-bottom, 0px) + 0.5rem)`,
+            paddingBottom: "env(safe-area-inset-bottom, 0px)",
           }}
         >
           <button
+            type="button"
+            data-testid="mobile-sidebar-settings-button"
             onClick={handleOpenSettingsFromMobileSidebar}
-            className={`w-full cursor-pointer flex items-center gap-3 ${rowPaddingClass} py-2.5 rounded-xl text-left text-base text-[color:var(--theme-text-secondary)] hover:bg-[color:var(--theme-bg-muted)] hover:text-[color:var(--theme-text-primary)] transition-all`}
+            className={`w-full cursor-pointer flex items-center gap-3 ${rowPaddingClass} ${rowVerticalPaddingClass} rounded-lg text-left text-base text-[color:var(--theme-text-secondary)] hover:bg-[color:var(--theme-bg-muted)] hover:text-[color:var(--theme-text-primary)] transition-all`}
           >
             {settingsButtonContent}
           </button>

--- a/packages/ui/src/components/layout/Sidebar.tsx
+++ b/packages/ui/src/components/layout/Sidebar.tsx
@@ -13,7 +13,7 @@ import { toast } from "../Toast.js";
 import { Tooltip } from "../Tooltip.js";
 import { useDebugStore } from "../../lib/debug-store.js";
 import { useSettingsStore } from "../../lib/settings-store.js";
-import { AnimatedMenuIcon, MapPinIcon, RssIcon, BookmarkIcon, ArchiveIcon, UsersIcon } from "../icons.js";
+import { MapPinIcon, RssIcon, BookmarkIcon, ArchiveIcon, UsersIcon } from "../icons.js";
 import { getTopSourceItems, type SourceNavigationItem } from "../../lib/source-navigation.js";
 import { useIsMobile } from "../../hooks/useIsMobile.js";
 import { useIsMobileDevice } from "../../hooks/useIsMobileDevice.js";
@@ -53,6 +53,7 @@ const RESIZE_HANDLE_HIT_AREA_WIDTH_PX = 16;
 const COMPACT_READER_RAIL_VISUAL_GAP_WIDTH_PX = 8;
 const MOBILE_SIDEBAR_WIDTH_PX = DEFAULT_PRIMARY_SIDEBAR_WIDTH_PX + 50;
 const MOBILE_SIDEBAR_VIEWPORT_MARGIN_PX = 24;
+const MOBILE_MENU_TOP_PX = COMPACT_PRIMARY_SIDEBAR_WIDTH_PX + PRIMARY_SIDEBAR_GAP_WIDTH_PX / 2;
 
 function MoreIcon() {
   return (
@@ -220,7 +221,6 @@ function scoreFeedMatch(feed: RssFeed, queryTerms: string[]): number {
 interface SidebarProps {
   mobileOpen: boolean;
   onMobileClose: () => void;
-  onMobileToggle: () => void;
   desktopMode: SidebarMode;
   onDesktopModeChange: (nextMode: SidebarMode) => void;
   onDesktopDisplayModeChange?: (nextMode: SidebarMode) => void;
@@ -567,12 +567,11 @@ function getDesktopModeForWidth(width: number): SidebarMode {
 export function Sidebar({
   mobileOpen,
   onMobileClose,
-  onMobileToggle,
   desktopMode,
   onDesktopModeChange,
   onDesktopDisplayModeChange,
 }: SidebarProps) {
-  const { SourceIndicator, headerDragRegion, syncRssNow, syncSourceNow, getSourceStatus } = usePlatform();
+  const { SourceIndicator, syncRssNow, syncSourceNow, getSourceStatus } = usePlatform();
   const isMobileViewport = useIsMobile();
   const isMobileDevice = useIsMobileDevice();
   const forceCompactDesktopRail = !isMobileDevice && isMobileViewport;
@@ -767,7 +766,7 @@ export function Sidebar({
     paddingTop: `${sidebarPaddingBlockPx}px`,
     paddingInline: `${sidebarPaddingInlinePx}px`,
     paddingBottom: isMobileDevice
-      ? `calc(${sidebarPaddingBlockPx}px + env(safe-area-inset-bottom, 0px))`
+      ? `${sidebarPaddingBlockPx}px`
       : compactRail
       ? `${COMPACT_RAIL_OUTER_INSET_PX}px`
       : `calc(${sidebarPaddingBlockPx}px + 100lvh - 100dvh + env(safe-area-inset-bottom, 0px))`,
@@ -1774,7 +1773,8 @@ export function Sidebar({
     <>
       {isMobileDevice && mobileOpen && (
         <div
-          className="fixed inset-0 z-40 bg-black/60 md:hidden"
+          className="fixed bottom-0 left-0 right-0 z-20 bg-black/60 md:hidden"
+          style={{ top: `calc(env(safe-area-inset-top, 0px) + ${MOBILE_MENU_TOP_PX}px)` }}
           onClick={onMobileClose}
         />
       )}
@@ -1819,37 +1819,30 @@ export function Sidebar({
       <aside
         data-testid="app-sidebar-mobile"
         className={`
-          theme-mobile-sidebar fixed left-0 top-0 z-50 flex h-[100dvh] max-h-[100dvh] min-h-0 flex-col overflow-hidden
+          theme-mobile-sidebar fixed left-0 z-40 flex min-h-0 flex-col overflow-hidden
           transform transition-transform duration-200 ease-in-out
           ${mobileOpen ? "translate-x-0" : "-translate-x-full"}
         `}
-        style={{ width: mobileSidebarWidth }}
+        style={{
+          width: mobileSidebarWidth,
+          top: `calc(env(safe-area-inset-top, 0px) + ${MOBILE_MENU_TOP_PX}px)`,
+          height: `calc(100dvh - env(safe-area-inset-top, 0px) - ${MOBILE_MENU_TOP_PX}px)`,
+          maxHeight: `calc(100dvh - env(safe-area-inset-top, 0px) - ${MOBILE_MENU_TOP_PX}px)`,
+        }}
       >
-        <div className="flex shrink-0 items-center justify-between border-b border-[var(--theme-border-subtle)] px-5 py-4 pt-[calc(env(safe-area-inset-top)+1rem)]">
-          {!headerDragRegion && (
-            <span className="text-lg font-bold gradient-text font-logo">FREED</span>
-          )}
-          <button
-            onClick={onMobileToggle}
-            aria-label="Close menu"
-            className="ml-auto flex h-11 w-11 items-center justify-center rounded-xl text-[var(--theme-text-secondary)] transition-colors hover:bg-[var(--theme-bg-muted)] hover:text-[var(--theme-text-primary)]"
-          >
-            <AnimatedMenuIcon open className="h-5 w-5" />
-          </button>
-        </div>
         {sidebarBody}
         <div
-          className="shrink-0 border-t border-[var(--theme-border-subtle)] pt-3"
+          className="shrink-0 border-t border-[var(--theme-border-subtle)] pt-2"
           style={{
             paddingInline: `${sidebarPaddingInlinePx}px`,
             paddingBottom: compactRail
-              ? `calc(${COMPACT_RAIL_OUTER_INSET_PX}px + env(safe-area-inset-bottom) + 1rem)`
-              : `calc(${sidebarPaddingBlockPx}px + env(safe-area-inset-bottom) + 1rem)`,
+              ? `calc(${COMPACT_RAIL_OUTER_INSET_PX}px + env(safe-area-inset-bottom, 0px) + 0.5rem)`
+              : `calc(${sidebarPaddingBlockPx}px + env(safe-area-inset-bottom, 0px) + 0.5rem)`,
           }}
         >
           <button
             onClick={handleOpenSettingsFromMobileSidebar}
-            className={`w-full cursor-pointer flex items-center gap-3 ${rowPaddingClass} py-3 rounded-xl text-left text-base text-[color:var(--theme-text-secondary)] hover:bg-[color:var(--theme-bg-muted)] hover:text-[color:var(--theme-text-primary)] transition-all`}
+            className={`w-full cursor-pointer flex items-center gap-3 ${rowPaddingClass} py-2.5 rounded-xl text-left text-base text-[color:var(--theme-text-secondary)] hover:bg-[color:var(--theme-bg-muted)] hover:text-[color:var(--theme-text-primary)] transition-all`}
           >
             {settingsButtonContent}
           </button>

--- a/packages/ui/src/hooks/useSearchResults.ts
+++ b/packages/ui/src/hooks/useSearchResults.ts
@@ -56,28 +56,34 @@ function accountKey(platform: string, authorId: string): string {
   return `${platform}:${authorId}`;
 }
 
+function searchText(value: unknown, fallback = ""): string {
+  return typeof value === "string" && value.trim() ? value.trim() : fallback;
+}
+
 function buildAccountAliasMap(accounts: Record<string, Account>): Map<string, string> {
   const aliases = new Map<string, string>();
   for (const account of Object.values(accounts)) {
     if (account.kind !== "social") continue;
+    const externalId = searchText(account.externalId);
+    if (!externalId) continue;
     const values = [
       account.displayName,
       account.handle,
       account.handle?.startsWith("@") ? account.handle.slice(1) : undefined,
-      account.externalId,
-      account.externalId.slice(-8),
+      externalId,
+      externalId.slice(-8),
     ].filter((value): value is string => Boolean(value?.trim()));
-    aliases.set(accountKey(account.provider, account.externalId), values.join(" "));
+    aliases.set(accountKey(account.provider, externalId), values.join(" "));
   }
   return aliases;
 }
 
 function accountSignature(accounts: Record<string, Account>): string {
   return Object.values(accounts)
-    .filter((account) => account.kind === "social")
+    .filter((account) => account.kind === "social" && searchText(account.externalId))
     .map((account) => [
       account.provider,
-      account.externalId,
+      searchText(account.externalId),
       account.displayName ?? "",
       account.handle ?? "",
     ].join(":"))

--- a/packages/ui/src/lib/account-labels.ts
+++ b/packages/ui/src/lib/account-labels.ts
@@ -7,15 +7,19 @@ export function providerLabel(provider: Account["provider"]): string {
   if (provider === "ios_contacts") return "Contacts";
   if (provider === "android_contacts") return "Contacts";
   if (provider === "web_contact") return "Manual contact";
+  if (!provider) return "Account";
   return provider.charAt(0).toUpperCase() + provider.slice(1);
 }
 
 export function accountTitle(account: Account): string {
-  return account.displayName ?? account.handle ?? account.externalId;
+  return account.displayName?.trim()
+    || account.handle?.trim()
+    || account.externalId?.trim()
+    || providerLabel(account.provider);
 }
 
 export function accountSubtitle(account: Account): string {
   if (account.handle?.trim()) return account.handle;
-  if (account.displayName?.trim()) return account.externalId;
+  if (account.displayName?.trim()) return account.externalId?.trim() || providerLabel(account.provider);
   return providerLabel(account.provider);
 }

--- a/packages/ui/src/lib/command-palette-registry.ts
+++ b/packages/ui/src/lib/command-palette-registry.ts
@@ -73,6 +73,10 @@ interface BuildCommandPaletteActionsOptions {
 const MAX_TYPED_FEED_ACTIONS = 25;
 const MAX_TYPED_CHANNEL_ACTIONS = 25;
 
+function safeText(value: unknown, fallback = ""): string {
+  return typeof value === "string" && value.trim() ? value.trim() : fallback;
+}
+
 async function runWithToast(
   runner: () => void | Promise<void>,
   successMessage?: string,
@@ -238,6 +242,11 @@ export function buildCommandPaletteActions({
 
   if (trimmedQuery) {
     for (const feed of feeds
+      .map((feed) => ({
+        url: safeText(feed.url),
+        title: safeText(feed.title, safeText(feed.url)),
+      }))
+      .filter((feed) => feed.url)
       .filter((feed) => candidateMatchesQuery([feed.title, feed.url, "feed", "rss"], normalizedQuery))
       .slice(0, MAX_TYPED_FEED_ACTIONS)) {
       actions.push({
@@ -251,6 +260,7 @@ export function buildCommandPaletteActions({
     }
 
     for (const { account, person, personName } of socialChannels
+      .filter(({ account }) => safeText(account.externalId))
       .filter(({ account, person, personName }) =>
         candidateMatchesQuery(
           [
@@ -259,7 +269,7 @@ export function buildCommandPaletteActions({
             account.handle,
             withoutAtPrefix(account.handle),
             account.externalId,
-            account.externalId.slice(-8),
+            safeText(account.externalId).slice(-8),
             providerLabel(account.provider),
             person?.name,
             personName,
@@ -272,14 +282,15 @@ export function buildCommandPaletteActions({
       .slice(0, MAX_TYPED_CHANNEL_ACTIONS)) {
       const label = accountTitle(account);
       const provider = providerLabel(account.provider);
+      const externalId = safeText(account.externalId);
       actions.push({
-        id: `go-channel-${account.provider}-${account.externalId}`,
+        id: `go-channel-${account.provider}-${externalId}`,
         title: label,
         section: "Go to",
         keywords: [
           provider.toLocaleLowerCase(),
-          account.externalId.toLocaleLowerCase(),
-          account.externalId.slice(-8).toLocaleLowerCase(),
+          externalId.toLocaleLowerCase(),
+          externalId.slice(-8).toLocaleLowerCase(),
           account.handle?.toLocaleLowerCase() ?? "",
           withoutAtPrefix(account.handle)?.toLocaleLowerCase() ?? "",
           personName?.toLocaleLowerCase() ?? "",
@@ -287,7 +298,7 @@ export function buildCommandPaletteActions({
           "social",
         ].filter(Boolean),
         entity: true,
-        run: () => navigateToFeed({ platform: account.provider as Platform, authorId: account.externalId }),
+        run: () => navigateToFeed({ platform: account.provider as Platform, authorId: externalId }),
       });
 
       const profileLabel = profileActionLabel(account, person, personName);
@@ -300,7 +311,7 @@ export function buildCommandPaletteActions({
           section: "Go to",
           keywords: [
             profileLabel.toLocaleLowerCase(),
-            account.externalId.toLocaleLowerCase(),
+            externalId.toLocaleLowerCase(),
             account.handle?.toLocaleLowerCase() ?? "",
             withoutAtPrefix(account.handle)?.toLocaleLowerCase() ?? "",
             "friends",
@@ -320,7 +331,7 @@ export function buildCommandPaletteActions({
           section: "Go to",
           keywords: [
             profileLabel.toLocaleLowerCase(),
-            account.externalId.toLocaleLowerCase(),
+            externalId.toLocaleLowerCase(),
             account.handle?.toLocaleLowerCase() ?? "",
             withoutAtPrefix(account.handle)?.toLocaleLowerCase() ?? "",
             "map",
@@ -342,7 +353,7 @@ export function buildCommandPaletteActions({
             section: "People",
             keywords: [
               profileLabel.toLocaleLowerCase(),
-              account.externalId.toLocaleLowerCase(),
+              externalId.toLocaleLowerCase(),
               account.handle?.toLocaleLowerCase() ?? "",
               withoutAtPrefix(account.handle)?.toLocaleLowerCase() ?? "",
               "friend",
@@ -364,7 +375,7 @@ export function buildCommandPaletteActions({
             section: "People",
             keywords: [
               profileLabel.toLocaleLowerCase(),
-              account.externalId.toLocaleLowerCase(),
+              externalId.toLocaleLowerCase(),
               account.handle?.toLocaleLowerCase() ?? "",
               withoutAtPrefix(account.handle)?.toLocaleLowerCase() ?? "",
               "close friend",

--- a/packages/ui/src/lib/friends-graph-layout.ts
+++ b/packages/ui/src/lib/friends-graph-layout.ts
@@ -58,12 +58,17 @@ function hashId(value: string): number {
   return Math.abs(hash);
 }
 
+function safeText(value: unknown, fallback = ""): string {
+  return typeof value === "string" && value.trim() ? value.trim() : fallback;
+}
+
 function compareFriends(a: Friend, b: Friend): number {
-  return b.careLevel - a.careLevel || a.name.localeCompare(b.name);
+  return b.careLevel - a.careLevel || safeText(a.name).localeCompare(safeText(b.name));
 }
 
 function labelForFriend(friend: Friend): string {
-  return friend.name.length > 18 ? `${friend.name.slice(0, 17)}...` : friend.name;
+  const name = safeText(friend.name, "Unnamed friend");
+  return name.length > 18 ? `${name.slice(0, 17)}...` : name;
 }
 
 function estimateLabelWidth(label: string): number {

--- a/packages/ui/src/lib/friends-workspace.ts
+++ b/packages/ui/src/lib/friends-workspace.ts
@@ -49,6 +49,14 @@ function sourceKey(platform: string, authorId: string): string {
   return `${platform}:${authorId}`;
 }
 
+function safeText(value: unknown, fallback = ""): string {
+  return typeof value === "string" && value.trim() ? value.trim() : fallback;
+}
+
+function compareText(left: unknown, right: unknown): number {
+  return safeText(left).localeCompare(safeText(right));
+}
+
 export function buildFriendsWorkspaceIndexes(
   accounts: Record<string, Account>,
   feedItems: Record<string, FeedItem>,
@@ -163,12 +171,12 @@ function matchesQuery(friend: Friend, query: string): boolean {
   const normalized = query.trim().toLowerCase();
   if (!normalized) return true;
 
-  if (friend.name.toLowerCase().includes(normalized)) return true;
+  if (safeText(friend.name).toLowerCase().includes(normalized)) return true;
   if (friend.bio?.toLowerCase().includes(normalized)) return true;
   return friend.sources.some((source) =>
     source.handle?.toLowerCase().includes(normalized)
     || source.displayName?.toLowerCase().includes(normalized)
-    || source.authorId.toLowerCase().includes(normalized)
+    || safeText(source.authorId).toLowerCase().includes(normalized)
   );
 }
 
@@ -210,18 +218,18 @@ function sortEntries(entries: FriendOverviewEntry[], sort: FriendOverviewSort): 
       case "care_level":
         return b.friend.careLevel - a.friend.careLevel
           || compareNullableDesc(a.lastPostAt, b.lastPostAt)
-          || a.friend.name.localeCompare(b.friend.name);
+          || compareText(a.friend.name, b.friend.name);
       case "last_contact":
         return compareNullableDesc(a.lastContactAt, b.lastContactAt)
           || compareNullableDesc(a.lastPostAt, b.lastPostAt)
-          || a.friend.name.localeCompare(b.friend.name);
+          || compareText(a.friend.name, b.friend.name);
       case "name":
-        return a.friend.name.localeCompare(b.friend.name);
+        return compareText(a.friend.name, b.friend.name);
       case "recent_activity":
       default:
         return compareNullableDesc(a.lastPostAt, b.lastPostAt)
           || b.friend.careLevel - a.friend.careLevel
-          || a.friend.name.localeCompare(b.friend.name);
+          || compareText(a.friend.name, b.friend.name);
     }
   });
   return next;

--- a/packages/ui/src/lib/identity-graph-layout.ts
+++ b/packages/ui/src/lib/identity-graph-layout.ts
@@ -74,6 +74,10 @@ function clamp(value: number, min: number, max: number): number {
   return Math.max(min, Math.min(max, value));
 }
 
+function safeText(value: unknown, fallback = ""): string {
+  return typeof value === "string" && value.trim() ? value.trim() : fallback;
+}
+
 function seededUnit(value: string): number {
   return (hashValue(value) % 10_000) / 10_000;
 }
@@ -329,8 +333,8 @@ export function buildIdentityGraphLayout({
     const placedBucket: IdentityGraphLayoutNode[] = [];
     bucket
       .sort((left, right) =>
-        (left.provider ?? "").localeCompare(right.provider ?? "") ||
-        left.label.localeCompare(right.label),
+        safeText(left.provider).localeCompare(safeText(right.provider)) ||
+        safeText(left.label).localeCompare(safeText(right.label)),
       )
       .forEach((node, index) => {
         const ring = Math.floor(index / 10);
@@ -409,7 +413,7 @@ export function buildIdentityGraphLayout({
     bucket
       .sort((left, right) =>
         right.weight - left.weight ||
-        left.label.localeCompare(right.label),
+        safeText(left.label).localeCompare(safeText(right.label)),
       )
       .forEach((node, index) => {
         const col = index % rows;

--- a/packages/ui/src/lib/identity-graph-model.ts
+++ b/packages/ui/src/lib/identity-graph-model.ts
@@ -181,7 +181,11 @@ export function buildIdentityGraphActivityIndex(
 }
 
 function accountLabel(account: Account): string {
-  return account.displayName?.trim() || account.handle?.trim() || account.externalId;
+  return account.displayName?.trim() || account.handle?.trim() || account.externalId?.trim() || account.provider || "Account";
+}
+
+function safeText(value: unknown, fallback = ""): string {
+  return typeof value === "string" && value.trim() ? value.trim() : fallback;
 }
 
 function personRadius(person: Person, linkedAccountCount: number): number {
@@ -219,8 +223,8 @@ export function buildIdentityGraphModel({
     .filter((person) => mode === "all_content" || person.relationshipStatus === "friend")
     .sort((left, right) =>
       right.careLevel - left.careLevel ||
-      left.relationshipStatus.localeCompare(right.relationshipStatus) ||
-      left.name.localeCompare(right.name),
+      safeText(left.relationshipStatus).localeCompare(safeText(right.relationshipStatus)) ||
+      safeText(left.name).localeCompare(safeText(right.name)),
     );
   const visiblePersonIds = new Set(visiblePersons.map((person) => person.id));
 
@@ -232,13 +236,13 @@ export function buildIdentityGraphModel({
     const node: IdentityGraphNode = {
       id: `person:${person.id}`,
       kind: isFriend ? "friend_person" : "connection_person",
-      label: person.name,
+      label: safeText(person.name, "Unnamed friend"),
       radius: personRadius(person, linkedCount),
       labelPriority: isFriend ? 100 : 82,
       personId: person.id,
       ring: isFriend ? 0 : 1,
       weight: isFriend ? 100 + person.careLevel * 10 + linkedCount * 2 : 60 + linkedCount * 3,
-      initials: personInitialsForName(person.name),
+      initials: personInitialsForName(safeText(person.name, "Unnamed friend")),
       avatarUrl: person.avatarUrl ?? null,
       interactive: true,
       graphX: person.graphX,
@@ -271,8 +275,8 @@ export function buildIdentityGraphModel({
     })
     .sort((left, right) =>
       (left.personId ? 0 : 1) - (right.personId ? 0 : 1) ||
-      (left.personId ?? "").localeCompare(right.personId ?? "") ||
-      left.provider.localeCompare(right.provider) ||
+      safeText(left.personId).localeCompare(safeText(right.personId)) ||
+      safeText(left.provider).localeCompare(safeText(right.provider)) ||
       accountLabel(left).localeCompare(accountLabel(right)),
     );
 

--- a/packages/ui/src/lib/identity-graph.ts
+++ b/packages/ui/src/lib/identity-graph.ts
@@ -84,7 +84,11 @@ function truncateLabel(value: string, max: number): string {
 function accountDisplayLabel(account: Account): string {
   if (account.displayName?.trim()) return truncateLabel(account.displayName.trim(), 16);
   if (account.handle?.trim()) return truncateLabel(account.handle.trim(), 16);
-  return truncateLabel(account.externalId, 16);
+  return truncateLabel(account.externalId?.trim() || account.provider || "Account", 16);
+}
+
+function safeText(value: unknown, fallback = ""): string {
+  return typeof value === "string" && value.trim() ? value.trim() : fallback;
 }
 
 function accountAvatarUrl(account: Account): string | null {
@@ -141,7 +145,7 @@ function comparePersons(
   return (left: Person, right: Person) =>
     right.careLevel - left.careLevel ||
     recentPostCount(feedItems, accounts, right) - recentPostCount(feedItems, accounts, left) ||
-    left.name.localeCompare(right.name);
+    safeText(left.name).localeCompare(safeText(right.name));
 }
 
 function providerLabelOrder(provider: Account["provider"]): number {
@@ -185,7 +189,7 @@ function layoutPersonHubs(
     return {
       id: `person:${person.id}`,
       kind: "person" as const,
-      label: truncateLabel(person.name, 18),
+      label: truncateLabel(safeText(person.name, "Unnamed friend"), 18),
       radius: nodeRadius(person, feedItems, accounts) + 4,
       x,
       y,
@@ -258,7 +262,7 @@ function layoutUnlinkedAccounts(
   }
 
   const providers = Array.from(grouped.keys()).sort((left, right) =>
-    providerLabelOrder(left) - providerLabelOrder(right) || left.localeCompare(right)
+    providerLabelOrder(left) - providerLabelOrder(right) || safeText(left).localeCompare(safeText(right))
   );
   const centers = providerRegionCenters(width, height, providers);
   const nodes: IdentityGraphNode[] = [];

--- a/packages/ui/src/lib/settings-sections.ts
+++ b/packages/ui/src/lib/settings-sections.ts
@@ -8,7 +8,6 @@
 export type SectionId =
   | "legal"
   | "appearance"
-  | "support"
   | "feeds"
   | "saved"
   | "ai"
@@ -58,11 +57,6 @@ export const BASE_SECTION_METAS: readonly SectionMeta[] = [
     id: "legal",
     label: "Legal",
     keywords: ["terms", "privacy", "eula", "consent", "agreement", "risk", "experimental"],
-  },
-  {
-    id: "support",
-    label: "Support",
-    keywords: ["bug", "report", "problem", "issue", "diagnostics", "github", "logs", "crash"],
   },
   {
     id: "sync",
@@ -163,7 +157,6 @@ export function buildSettingsSectionMetas(
     AI_SECTION_META,
     ...(availability.hasUpdateChecks ? [UPDATES_SECTION_META] : []),
     baseSectionById.legal,
-    baseSectionById.support,
     ...(availability.hasFactoryReset ? [DANGER_SECTION_META] : []),
   ];
 }

--- a/website/src/app/roadmap/RoadmapContent.tsx
+++ b/website/src/app/roadmap/RoadmapContent.tsx
@@ -747,7 +747,7 @@ const phases: Phase[] = [
     number: 6,
     title: "PWA Reader",
     description:
-      "Primary mobile surface with first-run legal gating, URL-backed view state, pinned saved-reader caching, warmed offline article plus image caching, local offline cache modes, filtered inner Settings list panels for RSS management, homescreen install prompts for browser and iOS Safari flows, public-safe bug reporting with clearer private bundle controls, and switchable production or dev update channels across `app.freed.wtf` and the `dev` branch lane at `dev-app.freed.wtf`.",
+      "Primary mobile surface with first-run legal gating, URL-backed view state, pinned saved-reader caching, warmed offline article plus image caching, local offline cache modes, filtered inner Settings list panels for RSS management, compact stacked mobile settings, balanced mobile toolbar controls, viewport-fixed reader action menus, homescreen install prompts for browser and iOS Safari flows, public-safe bug reporting with clearer private bundle controls, and switchable production or dev update channels across `app.freed.wtf` and the `dev` branch lane at `dev-app.freed.wtf`.",
     status: "complete",
     planLink:
       "https://github.com/freed-project/freed/blob/dev/docs/PHASE-6-PWA.md",


### PR DESCRIPTION
(AI Generated).

## Summary
- Reorders mobile toolbar controls and tightens the mobile drawer so search is first with a centered close state.
- Moves support into a dedicated modal launched from Danger Zone and keeps mobile settings stacked with larger shared typography.
- Balances mobile feed and reader spacing and keeps reader action menus fixed while article content scrolls.

## Testing
- npm run test -- app.spec.ts --grep 'responsive sidebar behavior|mobile settings|mobile toolbar|mobile feed' from packages/pwa
- npm run test:e2e -- smoke.spec.ts --grep 'settings dialog closes from the mobile header close button|mobile feed toolbar keeps format as the rightmost control' from packages/desktop
- npm run build from packages/pwa
- npm run validate:feature
- PWA preview visual pass at 430x932 and 360x780