### PR TITLE
perf: trim webkit cache during memory monitoring

### DIFF
--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -1071,6 +1071,14 @@ struct ScrapeMemoryPreparation {
     may_proceed: bool,
 }
 
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WebkitCacheTrimResult {
+    before_bytes: u64,
+    after_bytes: u64,
+    cache_trimmed: bool,
+}
+
 struct WebkitMemoryStats {
     total_resident_bytes: u64,
     process_count: u64,
@@ -2620,10 +2628,14 @@ fn collect_webkit_network_cache_files(root: &Path, files: &mut Vec<(PathBuf, u64
     }
 }
 
-fn trim_webkit_network_cache_root(webkit_root: &Path) -> bool {
+fn trim_webkit_network_cache_root_with_result(webkit_root: &Path) -> WebkitCacheTrimResult {
     let webkit_bytes = dir_size_bytes(&webkit_root).unwrap_or(0);
     if webkit_bytes <= WEBKIT_CACHE_TRIM_AT_BYTES {
-        return false;
+        return WebkitCacheTrimResult {
+            before_bytes: webkit_bytes,
+            after_bytes: webkit_bytes,
+            cache_trimmed: false,
+        };
     }
 
     let network_cache_root = webkit_root.join("NetworkCache");
@@ -2643,14 +2655,22 @@ fn trim_webkit_network_cache_root(webkit_root: &Path) -> bool {
         }
     }
 
-    trimmed
+    WebkitCacheTrimResult {
+        before_bytes: webkit_bytes,
+        after_bytes: current_bytes,
+        cache_trimmed: trimmed,
+    }
 }
 
-fn trim_webkit_network_cache(app: &tauri::AppHandle) -> bool {
+fn trim_webkit_network_cache(app: &tauri::AppHandle) -> WebkitCacheTrimResult {
     let Ok(cache_root) = app.path().app_cache_dir() else {
-        return false;
+        return WebkitCacheTrimResult {
+            before_bytes: 0,
+            after_bytes: 0,
+            cache_trimmed: false,
+        };
     };
-    trim_webkit_network_cache_root(&cache_root.join("WebKit"))
+    trim_webkit_network_cache_root_with_result(&cache_root.join("WebKit"))
 }
 
 fn scrape_memory_start_budget_bytes(stats: &RuntimeMemoryStats) -> u64 {
@@ -2788,7 +2808,8 @@ async fn prepare_social_scrape_memory_internal(
     let reason = format!("{} {} memory preflight", provider, operation);
     let recycled_scraper_windows =
         recycle_social_scraper_windows_except(app, preserve_label, &reason);
-    let cache_trimmed = trim_webkit_network_cache(app);
+    let cache_trim_result = trim_webkit_network_cache(app);
+    let cache_trimmed = cache_trim_result.cache_trimmed;
 
     if recycled_scraper_windows || cache_trimmed {
         tokio::time::sleep(Duration::from_millis(700)).await;
@@ -2949,6 +2970,20 @@ async fn get_runtime_memory_stats(
         relay_doc_bytes,
         relay_client_count,
     ))
+}
+
+#[tauri::command]
+async fn trim_webkit_network_cache_now(
+    app: tauri::AppHandle,
+) -> Result<WebkitCacheTrimResult, String> {
+    let result = trim_webkit_network_cache(&app);
+    if result.cache_trimmed {
+        info!(
+            "[memory] webkit cache trimmed during monitor sample before_bytes={} after_bytes={}",
+            result.before_bytes, result.after_bytes
+        );
+    }
+    Ok(result)
 }
 
 #[tauri::command]
@@ -6671,6 +6706,7 @@ pub fn run() {
             cancel_local_ai_model_download,
             get_sync_client_count,
             get_runtime_memory_stats,
+            trim_webkit_network_cache_now,
             get_recent_runtime_health,
             get_ai_hardware_profile,
             prepare_social_scrape_memory,
@@ -6902,7 +6938,11 @@ mod tests {
             .unwrap();
         file.set_len(WEBKIT_CACHE_TRIM_AT_BYTES + 1).unwrap();
 
-        assert!(trim_webkit_network_cache_root(&temp.path().join("WebKit")));
+        let result = trim_webkit_network_cache_root_with_result(&temp.path().join("WebKit"));
+
+        assert!(result.cache_trimmed);
+        assert!(result.before_bytes > WEBKIT_CACHE_TRIM_AT_BYTES);
+        assert!(result.after_bytes <= WEBKIT_CACHE_TRIM_TARGET_BYTES);
         assert!(!record_file.exists());
     }
 

--- a/packages/desktop/src/__mocks__/@tauri-apps/api/core.ts
+++ b/packages/desktop/src/__mocks__/@tauri-apps/api/core.ts
@@ -142,6 +142,11 @@ const handlers: Record<string, Handler> = {
     relayDocBytes: 0,
     relayClientCount: 0,
   }),
+  trim_webkit_network_cache_now: () => ({
+    beforeBytes: 16 * 1024 * 1024,
+    afterBytes: 16 * 1024 * 1024,
+    cacheTrimmed: false,
+  }),
   get_ai_hardware_profile: (args: Record<string, unknown>) => ({
     totalMemoryBytes: 16 * 1024 * 1024 * 1024,
     availableMemoryBytes: 10 * 1024 * 1024 * 1024,

--- a/packages/desktop/src/lib/memory-monitor-social-preflight.test.ts
+++ b/packages/desktop/src/lib/memory-monitor-social-preflight.test.ts
@@ -37,6 +37,12 @@ async function loadMonitor() {
   return import("./memory-monitor");
 }
 
+async function flushPromises(count = 4): Promise<void> {
+  for (let index = 0; index < count; index += 1) {
+    await Promise.resolve();
+  }
+}
+
 function blockedPreparation() {
   const after = {
     totalPhysicalMemoryBytes: 16 * 1024 * 1024 * 1024,
@@ -93,5 +99,36 @@ describe("social scrape memory preflight scheduling", () => {
     await vi.advanceTimersByTimeAsync(60_001);
     await monitor.prepareSocialScrapeMemory("linkedin", "feed scrape");
     expect(mocks.invoke).toHaveBeenCalledTimes(2);
+  });
+
+  it("trims oversized WebKit cache during normal memory sampling", async () => {
+    const gib = 1024 * 1024 * 1024;
+    const after = {
+      ...blockedPreparation().after,
+      appResidentBytes: 512 * 1024 * 1024,
+      webkitCacheBytes: 900 * 1024 * 1024,
+      memoryHighBytes: 3 * gib,
+      memoryCriticalBytes: 4 * gib,
+    };
+    mocks.invoke.mockImplementation((cmd: string) => {
+      if (cmd === "get_runtime_memory_stats") {
+        return Promise.resolve(after);
+      }
+      if (cmd === "trim_webkit_network_cache_now") {
+        return Promise.resolve({
+          beforeBytes: 900 * 1024 * 1024,
+          afterBytes: 512 * 1024 * 1024,
+          cacheTrimmed: true,
+        });
+      }
+      return Promise.reject(new Error(`unexpected invoke: ${cmd}`));
+    });
+    const monitor = await loadMonitor();
+
+    monitor.startMemoryMonitor();
+
+    await flushPromises();
+    expect(mocks.invoke).toHaveBeenCalledWith("trim_webkit_network_cache_now");
+    monitor.stopMemoryMonitor();
   });
 });

--- a/packages/desktop/src/lib/memory-monitor.ts
+++ b/packages/desktop/src/lib/memory-monitor.ts
@@ -8,6 +8,8 @@ const MEMORY_LOG_INTERVAL = 4;
 const BYTES_PER_GIB = 1024 * 1024 * 1024;
 const MIN_CRITICAL_RESIDENT_BYTES = 3.5 * BYTES_PER_GIB;
 const MAX_CRITICAL_RESIDENT_BYTES = 4 * BYTES_PER_GIB;
+const WEBKIT_CACHE_TRIM_AT_BYTES = 768 * 1024 * 1024;
+const WEBKIT_CACHE_TRIM_COOLDOWN_MS = 5 * 60_000;
 const HIGH_RELAY_DOC_BYTES = 64 * 1024 * 1024;
 const PRESSURE_SAMPLE_MAX_AGE_MS = 30_000;
 
@@ -53,6 +55,12 @@ interface ScrapeMemoryPreparation {
   deferredReason?: string;
 }
 
+interface WebkitCacheTrimResult {
+  beforeBytes: number;
+  afterBytes: number;
+  cacheTrimmed: boolean;
+}
+
 interface BrowserMemoryStats {
   usedJSHeapSize: number;
   totalJSHeapSize: number;
@@ -74,6 +82,33 @@ function canSampleNativeMemoryStats(): boolean {
   return isTauri() || import.meta.env.VITE_TEST_TAURI === "1";
 }
 
+function scheduleWebkitCacheTrim(native: NativeRuntimeMemoryStats): void {
+  if (!canSampleNativeMemoryStats()) return;
+  const cacheBytes = native.webkitCacheBytes ?? 0;
+  if (cacheBytes <= WEBKIT_CACHE_TRIM_AT_BYTES) return;
+  if (webkitCacheTrimLease) return;
+
+  const now = Date.now();
+  if (now - lastWebkitCacheTrimAt < WEBKIT_CACHE_TRIM_COOLDOWN_MS) return;
+  lastWebkitCacheTrimAt = now;
+
+  webkitCacheTrimLease = invoke<WebkitCacheTrimResult>("trim_webkit_network_cache_now")
+    .then((result) => {
+      if (!result.cacheTrimmed) return;
+      log.warn(
+        `[memory] trimmed WebKit cache before=${formatBytesForMemoryLog(result.beforeBytes)} ` +
+          `after=${formatBytesForMemoryLog(result.afterBytes)}`,
+      );
+    })
+    .catch((error) => {
+      const msg = error instanceof Error ? error.message : String(error);
+      log.warn(`[memory] WebKit cache trim failed: ${msg}`);
+    })
+    .finally(() => {
+      webkitCacheTrimLease = null;
+    });
+}
+
 let intervalHandle: ReturnType<typeof setInterval> | null = null;
 let startupFollowupHandles: Array<ReturnType<typeof setTimeout>> = [];
 let sampleCount = 0;
@@ -87,6 +122,8 @@ let socialPreflightLease: Promise<ScrapeMemoryPreparation> | null = null;
 let socialPreflightDeferredUntil = 0;
 let socialPreflightDeferredResult: ScrapeMemoryPreparation | null = null;
 let socialPreflightDeferredReason = "";
+let webkitCacheTrimLease: Promise<void> | null = null;
+let lastWebkitCacheTrimAt = 0;
 
 type MemoryPressureLevel = "normal" | "high" | "critical";
 
@@ -230,6 +267,7 @@ async function sampleRuntimeMemory(
   };
   setRuntimeMemory(snapshot);
   options.onSample?.(snapshot);
+  scheduleWebkitCacheTrim(native);
 
   sampleCount += 1;
   const shouldLog =

--- a/packages/desktop/tests/e2e/fixtures/tauri-init.ts
+++ b/packages/desktop/tests/e2e/fixtures/tauri-init.ts
@@ -68,6 +68,11 @@ export function tauriInitScript(): string {
         relayDocBytes: 0,
         relayClientCount: 0,
       }),
+      trim_webkit_network_cache_now: () => ({
+        beforeBytes: 16 * 1024 * 1024,
+        afterBytes: 16 * 1024 * 1024,
+        cacheTrimmed: false,
+      }),
       get_ai_hardware_profile: (args) => ({
         totalMemoryBytes: 16 * 1024 * 1024 * 1024,
         availableMemoryBytes: 10 * 1024 * 1024 * 1024,


### PR DESCRIPTION
(AI Generated).

## Summary

- Add a native trim_webkit_network_cache_now command that returns before and after cache bytes.
- Have the renderer memory monitor trim oversized WebKit cache during normal samples, with a five minute cooldown.
- Keep the existing social scrape preflight trim as a backstop.

## Test Plan

- npm run test:unit -- memory-monitor-social-preflight.test.ts
- cargo test webkit_network_cache --lib
- npm run validate:feature
