### PR TITLE
perf: cache time formatters and stabilize Friends graph

### DIFF
--- a/packages/desktop/src/components/ProviderActivityLog.tsx
+++ b/packages/desktop/src/components/ProviderActivityLog.tsx
@@ -1,4 +1,6 @@
+import { useMemo } from "react";
 import { useDebugStore, type HealthProviderId } from "@freed/ui/lib/debug-store";
+import { formatClockTime } from "@freed/ui/lib/date-format";
 import { SettingsListPanel } from "@freed/ui/components/settings/SettingsListPanel";
 import { useAppStore } from "../lib/store";
 
@@ -9,14 +11,6 @@ const PROVIDER_PREFIX: Partial<Record<HealthProviderId, string>> = {
   linkedin: "[LI]",
   rss: "[RSS]",
 };
-
-function formatLogTime(ts: number): string {
-  return new Date(ts).toLocaleTimeString([], {
-    hour: "numeric",
-    minute: "2-digit",
-    second: "2-digit",
-  });
-}
 
 export function ProviderActivityLog({
   provider,
@@ -31,10 +25,18 @@ export function ProviderActivityLog({
 
   if (!prefix) return null;
 
-  const lines = events
-    .filter((event) => event.detail?.startsWith(prefix))
-    .slice(0, 10)
-    .reverse();
+  const lines = useMemo(
+    () =>
+      events
+        .filter((event) => event.detail?.startsWith(prefix))
+        .slice(0, 10)
+        .reverse()
+        .map((event) => ({
+          event,
+          formattedTime: formatClockTime(event.ts),
+        })),
+    [events, prefix],
+  );
 
   if (!syncing && lines.length === 0) {
     return null;
@@ -66,12 +68,12 @@ export function ProviderActivityLog({
           scrollDataTestId={`provider-activity-log-scroll-${provider}`}
           className="border-0 bg-[var(--theme-bg-muted)] p-2"
           listClassName="space-y-1 font-mono text-[11px] text-[var(--theme-text-secondary)]"
-          itemKey={(event) => event.id}
-          getSearchText={(event) => `${formatLogTime(event.ts)} ${event.detail}`}
-          renderItem={(event) => (
+          itemKey={(line) => line.event.id}
+          getSearchText={(line) => `${line.formattedTime} ${line.event.detail}`}
+          renderItem={(line) => (
             <div className="flex gap-2 leading-relaxed">
-              <span className="shrink-0 text-[var(--theme-text-muted)]">{formatLogTime(event.ts)}</span>
-              <span className="break-words text-[var(--theme-text-primary)]">{event.detail}</span>
+              <span className="shrink-0 text-[var(--theme-text-muted)]">{line.formattedTime}</span>
+              <span className="break-words text-[var(--theme-text-primary)]">{line.event.detail}</span>
             </div>
           )}
         />

--- a/packages/desktop/src/lib/date-format-hot-path.test.ts
+++ b/packages/desktop/src/lib/date-format-hot-path.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatClockTime,
+  formatDebugClockTime,
+  formatMediumDateShortTime,
+  formatMonthDayClockTime,
+  formatShortClockTime,
+} from "@freed/ui/lib/date-format";
+
+describe("shared date formatters", () => {
+  const timestamp = Date.UTC(2026, 4, 6, 15, 4, 5);
+
+  it("matches the clock formats used by diagnostics surfaces", () => {
+    expect(formatClockTime(timestamp)).toBe(
+      new Intl.DateTimeFormat(undefined, {
+        hour: "numeric",
+        minute: "2-digit",
+        second: "2-digit",
+      }).format(new Date(timestamp)),
+    );
+    expect(formatShortClockTime(timestamp)).toBe(
+      new Intl.DateTimeFormat(undefined, {
+        hour: "numeric",
+        minute: "2-digit",
+      }).format(new Date(timestamp)),
+    );
+    expect(formatDebugClockTime(timestamp)).toBe(
+      new Intl.DateTimeFormat(undefined, {
+        hour12: false,
+        hour: "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
+      }).format(new Date(timestamp)),
+    );
+  });
+
+  it("matches the compact date and time formats used by settings surfaces", () => {
+    expect(formatMonthDayClockTime(timestamp)).toBe(
+      new Intl.DateTimeFormat(undefined, {
+        month: "short",
+        day: "numeric",
+        hour: "numeric",
+        minute: "2-digit",
+      }).format(new Date(timestamp)),
+    );
+    expect(formatMediumDateShortTime(timestamp)).toBe(
+      new Intl.DateTimeFormat(undefined, {
+        dateStyle: "medium",
+        timeStyle: "short",
+      }).format(new Date(timestamp)),
+    );
+  });
+});

--- a/packages/desktop/src/lib/fb-capture.ts
+++ b/packages/desktop/src/lib/fb-capture.ts
@@ -19,6 +19,7 @@ import {
   deduplicateFeedItems,
 } from "@freed/capture-facebook/browser";
 import type { FbGroupInfo, FeedItem } from "@freed/shared";
+import { formatClockTime } from "@freed/ui/lib/date-format";
 import { useAppStore } from "./store";
 import { addDebugEvent } from "@freed/ui/lib/debug-store";
 import { getFbScraperWindowMode } from "./scraper-prefs";
@@ -248,7 +249,7 @@ export async function captureFbFeed(): Promise<FbSyncResult> {
   const startedAt = Date.now();
   const providerPause = getProviderPause("facebook");
   if (providerPause) {
-    addDebugEvent("change", `[FB] paused until ${new Date(providerPause.pausedUntil).toLocaleTimeString()}`);
+    addDebugEvent("change", `[FB] paused until ${formatClockTime(providerPause.pausedUntil)}`);
     return {
       items: [],
       diag: {

--- a/packages/desktop/src/lib/hot-path-contract.test.ts
+++ b/packages/desktop/src/lib/hot-path-contract.test.ts
@@ -3,7 +3,19 @@ import { readFileSync, readdirSync, statSync } from "node:fs";
 import { join, relative } from "node:path";
 
 const LIB_DIR = join(process.cwd(), "src/lib");
+const DESKTOP_SRC_DIR = join(process.cwd(), "src");
+const UI_SRC_DIR = join(process.cwd(), "../../packages/ui/src");
 const ALLOWED_PLUGIN_STORE_IMPORTS = new Set(["secure-storage.ts"]);
+const HOT_TIME_FORMAT_PATHS = [
+  join(DESKTOP_SRC_DIR, "components/ProviderActivityLog.tsx"),
+  join(DESKTOP_SRC_DIR, "lib/fb-capture.ts"),
+  join(DESKTOP_SRC_DIR, "lib/instagram-capture.ts"),
+  join(DESKTOP_SRC_DIR, "lib/li-capture.ts"),
+  join(UI_SRC_DIR, "components/DebugPanel.tsx"),
+  join(UI_SRC_DIR, "components/ProviderHealthSummary.tsx"),
+  join(UI_SRC_DIR, "components/settings/AISection.tsx"),
+  join(UI_SRC_DIR, "lib/build-info.ts"),
+];
 
 function sourceFiles(dir: string): string[] {
   const files: string[] = [];
@@ -42,5 +54,18 @@ describe("desktop hot-path contract", () => {
     expect(storeSource).toContain("subscribe((_state, event) => cb(event))");
     expect(outboxSource).toContain("DocChangeEvent");
     expect(outboxSource).toContain("pendingChangedItems");
+  });
+
+  it("keeps hot diagnostics time formatting on cached formatters", () => {
+    const offenders = HOT_TIME_FORMAT_PATHS.flatMap((path) => {
+      const source = readFileSync(path, "utf8");
+      const relativePath = relative(process.cwd(), path);
+      const matches: string[] = [];
+      if (source.includes(".toLocaleTimeString(")) matches.push(`${relativePath}:toLocaleTimeString`);
+      if (source.includes("new Intl.DateTimeFormat(")) matches.push(`${relativePath}:Intl.DateTimeFormat`);
+      return matches;
+    });
+
+    expect(offenders).toEqual([]);
   });
 });

--- a/packages/desktop/src/lib/instagram-capture.ts
+++ b/packages/desktop/src/lib/instagram-capture.ts
@@ -18,6 +18,7 @@ import {
   igPostsToFeedItems,
   deduplicateFeedItems,
 } from "@freed/capture-instagram/browser";
+import { formatClockTime } from "@freed/ui/lib/date-format";
 import { useAppStore } from "./store";
 import { addDebugEvent } from "@freed/ui/lib/debug-store";
 import { getIgScraperWindowMode } from "./scraper-prefs";
@@ -183,7 +184,7 @@ export async function captureIgFeed(): Promise<IgSyncResult> {
   const startedAt = Date.now();
   const providerPause = getProviderPause("instagram");
   if (providerPause) {
-    addDebugEvent("change", `[IG] paused until ${new Date(providerPause.pausedUntil).toLocaleTimeString()}`);
+    addDebugEvent("change", `[IG] paused until ${formatClockTime(providerPause.pausedUntil)}`);
     return {
       items: [],
       diag: {

--- a/packages/desktop/src/lib/li-capture.ts
+++ b/packages/desktop/src/lib/li-capture.ts
@@ -14,6 +14,7 @@ import {
   liPostsToFeedItems,
   deduplicateFeedItems,
 } from "@freed/capture-linkedin/browser";
+import { formatClockTime } from "@freed/ui/lib/date-format";
 import { useAppStore } from "./store";
 import { addDebugEvent } from "@freed/ui/lib/debug-store";
 import { getLiScraperWindowMode } from "./scraper-prefs";
@@ -208,7 +209,7 @@ export async function captureLiFeed(): Promise<LiSyncResult> {
   const startedAt = Date.now();
   const providerPause = getProviderPause("linkedin");
   if (providerPause) {
-    addDebugEvent("change", `[LI] paused until ${new Date(providerPause.pausedUntil).toLocaleTimeString()}`);
+    addDebugEvent("change", `[LI] paused until ${formatClockTime(providerPause.pausedUntil)}`);
     return {
       items: [],
       diag: {

--- a/packages/ui/src/components/DebugPanel.tsx
+++ b/packages/ui/src/components/DebugPanel.tsx
@@ -13,6 +13,7 @@ import { useEffect, useState, type ReactNode } from "react";
 import { useDebugStore, type SyncEvent, type SyncEventKind, type CloudSyncStatus, type FpsSnapshot, type HealthProviderId, type RssFeedHealthSnapshot } from "../lib/debug-store";
 import { useFpsMonitor } from "../lib/perf-monitor";
 import { useAppStore, usePlatform } from "../context/PlatformContext.js";
+import { formatClockTime, formatDebugClockTime } from "../lib/date-format.js";
 import {
   ProviderHealthSummary,
   VolumeBars,
@@ -26,8 +27,7 @@ import {
 // ---------------------------------------------------------------------------
 
 function formatTs(ts: number): string {
-  const d = new Date(ts);
-  return d.toLocaleTimeString([], { hour12: false, hour: "2-digit", minute: "2-digit", second: "2-digit" });
+  return formatDebugClockTime(ts);
 }
 
 function formatBytes(bytes: number): string {
@@ -525,7 +525,7 @@ function DocumentTab() {
 
       <div className={DEBUG_CARD_CLASS}>
         <p className={DEBUG_LABEL_CLASS}>Snapshot Taken</p>
-        <p className="font-mono text-xs text-[var(--theme-text-muted)]">{new Date(docSnapshot.savedAt).toLocaleTimeString()}</p>
+        <p className="font-mono text-xs text-[var(--theme-text-muted)]">{formatClockTime(docSnapshot.savedAt)}</p>
       </div>
 
       {/* Actions */}

--- a/packages/ui/src/components/ProviderHealthSummary.tsx
+++ b/packages/ui/src/components/ProviderHealthSummary.tsx
@@ -6,6 +6,7 @@ import type {
   HealthProviderId,
   ProviderHealthSnapshot,
 } from "../lib/debug-store.js";
+import { formatShortClockTime } from "../lib/date-format.js";
 import { getHealthStatusLabel } from "../lib/provider-status.js";
 
 export function providerHealthLabel(provider: HealthProviderId): string {
@@ -34,10 +35,7 @@ export function formatHealthRelative(ts?: number): string {
 
 export function formatPauseUntil(ts?: number): string {
   if (!ts) return "Paused";
-  return `Paused until ${new Date(ts).toLocaleTimeString([], {
-    hour: "numeric",
-    minute: "2-digit",
-  })}`;
+  return `Paused until ${formatShortClockTime(ts)}`;
 }
 
 function barHeight(value: number, maxValue: number): string {
@@ -167,10 +165,7 @@ function RecentAttemptsList({
           <div key={attempt.id} className="rounded-lg bg-[var(--theme-bg-muted)] p-2 text-xs">
             <div className="flex items-center justify-between gap-3">
               <span className="font-mono text-[var(--theme-text-secondary)]">
-                {new Date(attempt.finishedAt).toLocaleTimeString([], {
-                  hour: "numeric",
-                  minute: "2-digit",
-                })}
+                {formatShortClockTime(attempt.finishedAt)}
               </span>
               <span className="text-[var(--theme-text-muted)]">{attempt.outcome}</span>
             </div>

--- a/packages/ui/src/components/friends/FriendGraph.tsx
+++ b/packages/ui/src/components/friends/FriendGraph.tsx
@@ -27,6 +27,7 @@ import type {
 } from "@freed/shared";
 import type { ThemeId } from "@freed/shared/themes";
 import {
+  buildIdentityGraphLayout,
   buildSpatialIndex,
   findHitNode,
   fitTransformToNodes,
@@ -186,6 +187,7 @@ const MIN_SCALE = 0.2;
 const MAX_SCALE = 2.8;
 const TRACKPAD_PINCH_ZOOM_SPEED = 0.005;
 const GRAPH_INTERACTION_SETTLE_DELAY_MS = 140;
+const GRAPH_LAYOUT_WORKER_TIMEOUT_MS = 4_000;
 const INTERACTIVE_LABEL_LIMIT = 16;
 const SETTLED_LABEL_LIMIT = 32;
 const FAST_LAYOUT_NODE_THRESHOLD = 1_600;
@@ -808,6 +810,7 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
   const hasFittedInitialLayoutRef = useRef(false);
   const latestLayoutRequestIdRef = useRef(0);
   const latestResolvedLayoutRequestIdRef = useRef(0);
+  const pendingLayoutTimeoutsRef = useRef<Map<number, number>>(new Map());
   const drawRafRef = useRef(0);
   const drawRafPendingRef = useRef(false);
   const settleTimerRef = useRef<number | null>(null);
@@ -832,6 +835,7 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
   const graphQualityModeRef = useRef<GraphQualityMode>("settled");
   const layoutReadyRef = useRef(false);
   const syncSceneRef = useRef<() => void>(() => {});
+  const canvasSizeRef = useRef({ width: 900, height: DEFAULT_HEIGHT });
   const perfSnapshotRef = useRef<GraphPerfSnapshot>({
     modelBuildMs: 0,
     layoutMs: 0,
@@ -850,6 +854,7 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
     qualityMode: "settled",
   });
   const [canvasSize, setCanvasSize] = useState({ width: 900, height: DEFAULT_HEIGHT });
+  canvasSizeRef.current = canvasSize;
   const [isInteracting, setIsInteracting] = useState(false);
   const [layoutReady, setLayoutReady] = useState(false);
   const [layoutVersion, setLayoutVersion] = useState(0);
@@ -1830,6 +1835,57 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
     };
   }, []);
 
+  const applyLayoutResult = useCallback((
+    requestId: number,
+    layout: IdentityGraphLayout,
+    durationMs: number,
+  ) => {
+    if (requestId < latestResolvedLayoutRequestIdRef.current) return;
+    const timeoutId = pendingLayoutTimeoutsRef.current.get(requestId);
+    if (timeoutId !== undefined) {
+      window.clearTimeout(timeoutId);
+      pendingLayoutTimeoutsRef.current.delete(requestId);
+    }
+    latestResolvedLayoutRequestIdRef.current = requestId;
+    layoutRef.current = layout;
+    layoutNodeByIdRef.current = buildNodeById(layout.nodes);
+    layoutDebugNodesRef.current = buildGraphDebugNodes(layout.nodes);
+    spatialIndexRef.current = buildSpatialIndex(layout.nodes);
+    lastLayoutMsRef.current = durationMs;
+    if (!hasFittedInitialLayoutRef.current) {
+      const latestCanvasSize = canvasSizeRef.current;
+      transformRef.current = fitTransformToNodes(
+        graphFitItems(layout),
+        latestCanvasSize.width,
+        latestCanvasSize.height,
+        FIT_PADDING,
+      );
+      hasFittedInitialLayoutRef.current = true;
+    }
+    setLayoutVersion((value) => value + 1);
+    requestAnimationFrame(() => syncSceneRef.current());
+  }, []);
+
+  const runLayoutOnMainThread = useCallback((
+    requestId: number,
+    requestModel: IdentityGraphModel,
+    width: number,
+    height: number,
+    quality: GraphLayoutQuality,
+  ) => {
+    window.setTimeout(() => {
+      if (requestId < latestResolvedLayoutRequestIdRef.current) return;
+      const startMs = nowMs();
+      const layout = buildIdentityGraphLayout({
+        model: requestModel,
+        width,
+        height,
+        quality,
+      });
+      applyLayoutResult(requestId, layout, nowMs() - startMs);
+    }, 0);
+  }, [applyLayoutResult]);
+
   useEffect(() => {
     const worker = new Worker(
       new URL("../../lib/identity-graph-layout.worker.ts", import.meta.url),
@@ -1837,34 +1893,29 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
     );
     workerRef.current = worker;
     worker.onmessage = (event: MessageEvent<{ requestId: number; layout: IdentityGraphLayout; durationMs: number }>) => {
-      if (event.data.requestId < latestResolvedLayoutRequestIdRef.current) return;
-      latestResolvedLayoutRequestIdRef.current = event.data.requestId;
-      layoutRef.current = event.data.layout;
-      layoutNodeByIdRef.current = buildNodeById(event.data.layout.nodes);
-      layoutDebugNodesRef.current = buildGraphDebugNodes(event.data.layout.nodes);
-      spatialIndexRef.current = buildSpatialIndex(event.data.layout.nodes);
-      lastLayoutMsRef.current = event.data.durationMs;
-      if (!hasFittedInitialLayoutRef.current) {
-        transformRef.current = fitTransformToNodes(
-          graphFitItems(event.data.layout),
-          canvasSize.width,
-          canvasSize.height,
-          FIT_PADDING,
-        );
-        hasFittedInitialLayoutRef.current = true;
+      applyLayoutResult(event.data.requestId, event.data.layout, event.data.durationMs);
+    };
+    worker.onerror = (event) => {
+      console.warn("[FriendGraph] layout worker failed", event.message);
+      if (workerRef.current === worker) {
+        workerRef.current = null;
       }
-      setLayoutVersion((value) => value + 1);
-      scheduleSyncScene();
     };
 
     return () => {
+      for (const timeoutId of pendingLayoutTimeoutsRef.current.values()) {
+        window.clearTimeout(timeoutId);
+      }
+      pendingLayoutTimeoutsRef.current.clear();
       worker.terminate();
-      workerRef.current = null;
+      if (workerRef.current === worker) {
+        workerRef.current = null;
+      }
     };
-  }, [canvasSize.height, canvasSize.width, scheduleSyncScene]);
+  }, [applyLayoutResult]);
 
   useEffect(() => {
-    if (!workerRef.current || canvasSize.width <= 0 || canvasSize.height <= 0) return;
+    if (canvasSize.width <= 0 || canvasSize.height <= 0) return;
     const previousSnapshot = previousRequestSnapshotRef.current;
     const sizeOnlyResize =
       previousSnapshot &&
@@ -1883,14 +1934,30 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
       height: canvasSize.height,
     };
     previousRequestedModelRef.current = model;
-    workerRef.current.postMessage({
+    const layoutRequest = {
       requestId,
       model,
       width: canvasSize.width,
       height: canvasSize.height,
       quality,
-    });
-  }, [canvasSize.height, canvasSize.width, model, modelSignature]);
+    };
+    const worker = workerRef.current;
+    if (!worker) {
+      runLayoutOnMainThread(requestId, model, canvasSize.width, canvasSize.height, quality);
+      return;
+    }
+    const timeoutId = window.setTimeout(() => {
+      pendingLayoutTimeoutsRef.current.delete(requestId);
+      if (requestId < latestResolvedLayoutRequestIdRef.current) return;
+      if (workerRef.current === worker) {
+        worker.terminate();
+        workerRef.current = null;
+      }
+      runLayoutOnMainThread(requestId, model, canvasSize.width, canvasSize.height, quality);
+    }, GRAPH_LAYOUT_WORKER_TIMEOUT_MS);
+    pendingLayoutTimeoutsRef.current.set(requestId, timeoutId);
+    worker.postMessage(layoutRequest);
+  }, [canvasSize.height, canvasSize.width, model, modelSignature, runLayoutOnMainThread]);
 
   useEffect(() => {
     if (!layoutReady && layoutRef.current.nodes.length > 0) {

--- a/packages/ui/src/components/settings/AISection.tsx
+++ b/packages/ui/src/components/settings/AISection.tsx
@@ -12,6 +12,7 @@ import type {
   LocalAIModelDownloadProgress,
   LocalAIModelViewState,
 } from "../../context/PlatformContext.js";
+import { formatMediumDateShortTime } from "../../lib/date-format.js";
 import { SettingsToggle } from "../SettingsToggle.js";
 import { ExternalLinkIcon } from "../icons.js";
 
@@ -120,10 +121,7 @@ function formatBytes(bytes: number): string {
 
 function formatLocalTime(timestamp?: number): string {
   if (!timestamp) return "Never";
-  return new Intl.DateTimeFormat(undefined, {
-    dateStyle: "medium",
-    timeStyle: "short",
-  }).format(new Date(timestamp));
+  return formatMediumDateShortTime(timestamp);
 }
 
 function formatMemorySummary(profile: LocalAIHardwareProfile | null): string {

--- a/packages/ui/src/lib/build-info.ts
+++ b/packages/ui/src/lib/build-info.ts
@@ -1,3 +1,5 @@
+import { formatMonthDayClockTime } from "./date-format.js";
+
 export type BuildKind = "release" | "snapshot" | "preview" | "local";
 
 export interface BuildMetadata {
@@ -23,12 +25,7 @@ function formatBuildTimestamp(value: string | null): string | null {
     return null;
   }
 
-  return new Intl.DateTimeFormat(undefined, {
-    month: "short",
-    day: "numeric",
-    hour: "numeric",
-    minute: "2-digit",
-  }).format(date);
+  return formatMonthDayClockTime(date);
 }
 
 function shortenCommitSha(commitSha: string | null): string | null {

--- a/packages/ui/src/lib/date-format.ts
+++ b/packages/ui/src/lib/date-format.ts
@@ -1,0 +1,53 @@
+const clockTimeFormatter = new Intl.DateTimeFormat(undefined, {
+  hour: "numeric",
+  minute: "2-digit",
+  second: "2-digit",
+});
+
+const shortClockTimeFormatter = new Intl.DateTimeFormat(undefined, {
+  hour: "numeric",
+  minute: "2-digit",
+});
+
+const debugClockTimeFormatter = new Intl.DateTimeFormat(undefined, {
+  hour12: false,
+  hour: "2-digit",
+  minute: "2-digit",
+  second: "2-digit",
+});
+
+const monthDayClockTimeFormatter = new Intl.DateTimeFormat(undefined, {
+  month: "short",
+  day: "numeric",
+  hour: "numeric",
+  minute: "2-digit",
+});
+
+const mediumDateShortTimeFormatter = new Intl.DateTimeFormat(undefined, {
+  dateStyle: "medium",
+  timeStyle: "short",
+});
+
+function toDate(value: number | string | Date): Date {
+  return value instanceof Date ? value : new Date(value);
+}
+
+export function formatClockTime(value: number | string | Date): string {
+  return clockTimeFormatter.format(toDate(value));
+}
+
+export function formatShortClockTime(value: number | string | Date): string {
+  return shortClockTimeFormatter.format(toDate(value));
+}
+
+export function formatDebugClockTime(value: number | string | Date): string {
+  return debugClockTimeFormatter.format(toDate(value));
+}
+
+export function formatMonthDayClockTime(value: number | string | Date): string {
+  return monthDayClockTimeFormatter.format(toDate(value));
+}
+
+export function formatMediumDateShortTime(value: number | string | Date): string {
+  return mediumDateShortTimeFormatter.format(toDate(value));
+}


### PR DESCRIPTION
(AI Generated).

## Summary
- Cache shared date and time formatters used by diagnostics, provider health, debug, and scraper status surfaces so frequent UI updates do not repeatedly initialize locale formatters.
- Keep the Friends graph layout worker alive across resize changes so large graph startup is not starved by worker churn.
- Add a timeout fallback that computes layout on the main thread if the worker fails or stalls, avoiding a permanent `Building graph...` state.

## Testing
- npm run test:unit -- date-format-hot-path.test.ts hot-path-contract.test.ts
- npm run typecheck --workspace=packages/pwa
- npm run test:e2e:perf:friends
- npm run validate:feature
