### PR TITLE
fix: stabilize Friends sidebar resize

### DIFF
--- a/packages/desktop/tests/e2e/smoke.spec.ts
+++ b/packages/desktop/tests/e2e/smoke.spec.ts
@@ -3174,50 +3174,50 @@ test("Friends detail rail resize caps at 400 pixels", async ({ app, page }) => {
   await app.goto();
   await app.waitForReady();
   await app.seedFriendLocation();
-
-  await page.getByTestId("source-row-friends").click();
-  await expect(page.getByTestId("friends-sidebar")).toBeVisible({ timeout: 5_000 });
+  await dismissCloudSyncNudgeIfPresent(page);
 
   await page.evaluate(async () => {
-    const handle = document.querySelector('[aria-label="Resize friends sidebar"]') as HTMLElement | null;
-    if (!handle) {
-      throw new Error("Friends sidebar resize handle was not found");
-    }
-    const rect = handle.getBoundingClientRect();
-    const startX = rect.left + rect.width / 2;
-    const pointerY = rect.top + Math.max(1, rect.height / 2);
-    const endX = startX - 300;
-
-    handle.dispatchEvent(
-      new MouseEvent("mousedown", {
-        bubbles: true,
-        clientX: startX,
-        clientY: pointerY,
-      }),
-    );
-    document.dispatchEvent(
-      new MouseEvent("mousemove", {
-        bubbles: true,
-        clientX: endX,
-        clientY: pointerY,
-      }),
-    );
-    document.dispatchEvent(
-      new MouseEvent("mouseup", {
-        bubbles: true,
-        clientX: endX,
-        clientY: pointerY,
-      }),
-    );
-
-    await new Promise((resolve) => window.setTimeout(resolve, 250));
+    const store = (window as Record<string, unknown>).__FREED_STORE__ as
+      | {
+          getState: () => {
+            updatePreferences: (patch: { display: { friendsSidebarWidth: number; friendsSidebarOpen: boolean } }) => Promise<void>;
+            setActiveView: (view: string) => void;
+          };
+        }
+      | undefined;
+    await store?.getState().updatePreferences({
+      display: {
+        friendsSidebarWidth: 388,
+        friendsSidebarOpen: true,
+      },
+    });
+    store?.getState().setActiveView("friends");
   });
 
+  await expect(page.getByTestId("friends-sidebar")).toBeVisible({ timeout: 5_000 });
+  const handle = page.getByRole("separator", { name: "Resize friends sidebar" });
+  await expect(handle).toBeVisible({ timeout: 5_000 });
+  const handleBox = await handle.boundingBox();
+  if (!handleBox) {
+    throw new Error("Friends sidebar resize handle did not expose browser geometry");
+  }
+  const startX = handleBox.x + handleBox.width / 2;
+  const pointerY = handleBox.y + Math.max(1, handleBox.height / 2);
+
+  await page.mouse.move(startX, pointerY);
+  await page.mouse.down();
+  await page.mouse.move(startX - 300, pointerY, { steps: 8 });
+  await page.mouse.up();
+
+  await expect.poll(async () =>
+    page.getByTestId("friends-sidebar").evaluate((element) =>
+      Math.round(element.getBoundingClientRect().width),
+    ),
+  { timeout: 5_000 }).toBeGreaterThanOrEqual(396);
   const sidebarWidth = await page.getByTestId("friends-sidebar").evaluate((element) =>
     Math.round(element.getBoundingClientRect().width),
   );
   expect(sidebarWidth).toBeLessThanOrEqual(400);
-  expect(sidebarWidth).toBeGreaterThanOrEqual(396);
 
   await page.waitForFunction(() => {
     const w = window as Record<string, unknown>;

--- a/packages/ui/src/components/friends/FriendsView.tsx
+++ b/packages/ui/src/components/friends/FriendsView.tsx
@@ -562,6 +562,7 @@ export function FriendsView({
   const graphRef = useRef<FriendGraphHandle>(null);
   const friendOverviewScrollRef = useRef<HTMLDivElement>(null);
   const isDraggingSidebar = useRef(false);
+  const sidebarDragCleanup = useRef<(() => void) | null>(null);
   const pendingPersistedSidebarWidth = useRef<number | null>(null);
   const isMobile = useIsMobile();
 
@@ -1061,32 +1062,54 @@ export function FriendsView({
     });
   }, []);
 
-  const handleSidebarDragStart = useCallback((event: React.MouseEvent) => {
+  useEffect(() => () => {
+    sidebarDragCleanup.current?.();
+    sidebarDragCleanup.current = null;
+  }, []);
+
+  const handleSidebarDragStart = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
     if (isMobile) return;
+    if (event.pointerType === "mouse" && event.button !== 0) return;
     event.preventDefault();
+    sidebarDragCleanup.current?.();
     isDraggingSidebar.current = true;
     const startX = event.clientX;
     const startWidth = sidebarWidth;
+    let latestWidth = startWidth;
+    const resizeHandle = event.currentTarget;
+    const pointerId = event.pointerId;
     const previousCursor = document.body.style.cursor;
     const previousUserSelect = document.body.style.userSelect;
 
     document.body.style.cursor = "col-resize";
     document.body.style.userSelect = "none";
+    resizeHandle.setPointerCapture?.(pointerId);
 
-    const onMove = (moveEvent: MouseEvent) => {
-      if (!isDraggingSidebar.current) return;
-      const next = Math.min(
+    const nextWidthFromClientX = (clientX: number) =>
+      Math.min(
         MAX_SIDEBAR_WIDTH,
-        Math.max(MIN_SIDEBAR_WIDTH, startWidth - (moveEvent.clientX - startX))
+        Math.max(MIN_SIDEBAR_WIDTH, startWidth - (clientX - startX)),
       );
-      setDragWidth(next);
+
+    const cleanup = () => {
+      document.body.style.cursor = previousCursor;
+      document.body.style.userSelect = previousUserSelect;
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onUp);
+      window.removeEventListener("pointercancel", onCancel);
+      window.removeEventListener("blur", onBlur);
+      try {
+        resizeHandle.releasePointerCapture?.(pointerId);
+      } catch {
+        // The browser may already have released capture after pointerup.
+      }
+      if (sidebarDragCleanup.current === cleanup) {
+        sidebarDragCleanup.current = null;
+      }
     };
-    const onUp = (upEvent: MouseEvent) => {
+
+    const finishDrag = (finalWidth: number) => {
       isDraggingSidebar.current = false;
-      const finalWidth = Math.min(
-        MAX_SIDEBAR_WIDTH,
-        Math.max(MIN_SIDEBAR_WIDTH, startWidth - (upEvent.clientX - startX))
-      );
       pendingPersistedSidebarWidth.current = finalWidth;
       setCommittedSidebarWidth(finalWidth);
       setDragWidth(null);
@@ -1095,14 +1118,37 @@ export function FriendsView({
           pendingPersistedSidebarWidth.current = null;
         }
       });
-      document.body.style.cursor = previousCursor;
-      document.body.style.userSelect = previousUserSelect;
-      document.removeEventListener("mousemove", onMove);
-      document.removeEventListener("mouseup", onUp);
+      cleanup();
     };
 
-    document.addEventListener("mousemove", onMove);
-    document.addEventListener("mouseup", onUp);
+    function onMove(moveEvent: PointerEvent) {
+      if (moveEvent.pointerId !== pointerId) return;
+      if (!isDraggingSidebar.current) return;
+      latestWidth = nextWidthFromClientX(moveEvent.clientX);
+      setDragWidth(latestWidth);
+    }
+
+    function onUp(upEvent: PointerEvent) {
+      if (upEvent.pointerId !== pointerId) return;
+      finishDrag(nextWidthFromClientX(upEvent.clientX));
+    }
+
+    function onCancel(cancelEvent: PointerEvent) {
+      if (cancelEvent.pointerId !== pointerId) return;
+      finishDrag(latestWidth);
+    }
+
+    function onBlur() {
+      isDraggingSidebar.current = false;
+      setDragWidth(null);
+      cleanup();
+    }
+
+    sidebarDragCleanup.current = cleanup;
+    window.addEventListener("pointermove", onMove);
+    window.addEventListener("pointerup", onUp);
+    window.addEventListener("pointercancel", onCancel);
+    window.addEventListener("blur", onBlur);
   }, [isMobile, sidebarWidth, updatePreferences]);
 
   const renderOverviewSidebar = () => (
@@ -1668,8 +1714,8 @@ export function FriendsView({
 
         {showDesktopSidebar && (
           <div
-            className="theme-resize-gap-handle w-3 shrink-0 self-end"
-            onMouseDown={handleSidebarDragStart}
+            className="theme-resize-gap-handle w-3 shrink-0 self-stretch"
+            onPointerDown={handleSidebarDragStart}
             role="separator"
             aria-orientation="vertical"
             aria-label="Resize friends sidebar"


### PR DESCRIPTION
(AI Generated).

## Summary
- (AI Generated). Stabilizes the Friends detail rail resize path by using pointer events with cleanup and making the resize separator visible to real browser input.

## Testing
- npm run test:e2e -- smoke.spec.ts --grep 'Friends detail rail resize caps at 400 pixels'
- npm run test:e2e -- smoke.spec.ts --grep 'Friends'
- PATH=/Users/aubreyfalconer/dev/freed-friends-sidebar-resize-ci/node_modules/.bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/usr/local/MacGPG2/bin:/Applications/VMware Fusion.app/Contents/Public:/usr/local/share/dotnet:~/.dotnet/tools:/usr/local/go/bin:/Library/Frameworks/Mono.framework/Versions/Current/Commands:/Users/aubreyfalconer/.nvm/versions/node/v24.14.1/bin:/Users/aubreyfalconer/.codex/tmp/arg0/codex-arg05cJIJd:/Users/aubreyfalconer/.local/bin:/opt/homebrew/opt/mysql-client/bin:/opt/homebrew/bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/Users/aubreyfalconer/.cargo/bin:/Users/aubreyfalconer/go/bin:/Users/aubreyfalconer/.cache/lm-studio/bin:/Users/aubreyfalconer/.safe-chain/bin:/Applications/Codex.app/Contents/Resources:/usr/local/bin npm run build
- npm run validate:feature