### PR TITLE
fix: harden Friends resize geometry check

### DIFF
--- a/packages/desktop/tests/e2e/smoke.spec.ts
+++ b/packages/desktop/tests/e2e/smoke.spec.ts
@@ -3230,7 +3230,24 @@ test("Friends detail rail resize caps at 400 pixels", async ({ app, page }) => {
   await expect(page.getByTestId("friends-sidebar")).toBeVisible({ timeout: 5_000 });
   const handle = page.getByRole("separator", { name: "Resize friends sidebar" });
   await expect(handle).toBeVisible({ timeout: 5_000 });
-  const handleBox = await handle.boundingBox();
+  let handleBox: { x: number; y: number; width: number; height: number } | null = null;
+  await expect
+    .poll(async () => {
+      handleBox = await handle.evaluate((element) => {
+        const rect = element.getBoundingClientRect();
+        if (rect.width <= 0 || rect.height <= 0) {
+          return null;
+        }
+        return {
+          x: rect.left,
+          y: rect.top,
+          width: rect.width,
+          height: rect.height,
+        };
+      }).catch(() => null);
+      return handleBox !== null;
+    }, { timeout: 5_000 })
+    .toBe(true);
   if (!handleBox) {
     throw new Error("Friends sidebar resize handle did not expose browser geometry");
   }


### PR DESCRIPTION
(AI Generated).

## Summary
- (AI Generated). Hardens the Friends resize regression by reading the handle geometry from the DOM before driving mouse input.

## Testing
- npm run test:e2e -- smoke.spec.ts --grep 'Friends detail rail resize caps at 400 pixels'
- npm run validate:feature