### PR TITLE
perf: avoid full hydration for display preferences

### DIFF
--- a/packages/desktop/src/lib/automerge-types.ts
+++ b/packages/desktop/src/lib/automerge-types.ts
@@ -121,6 +121,13 @@ export type DocChangeEvent =
       requiresFullScan: true;
     }
   | {
+      source: "preferences_patch";
+      mutation?: WorkerRequest["type"];
+      changedItemIds: null;
+      changedItems: [];
+      requiresFullScan: false;
+    }
+  | {
       source: "item_patch";
       mutation?: WorkerRequest["type"];
       changedItemIds: string[];
@@ -137,6 +144,8 @@ export type WorkerResponse =
   | { reqId: number; type: "ACK"; error?: string }
   /** Broadcast on every doc mutation - main thread uses this to update UI */
   | { type: "STATE_UPDATE"; state: DocState; mutation?: WorkerRequest["type"] }
+  /** Preference-only mutation that avoids cloning, ranking, and hydrating every feed item. */
+  | { type: "PREFERENCES_PATCH"; preferences: UserPreferences; mutation?: WorkerRequest["type"] }
   /** Small mutation update that avoids cloning and hydrating the full document. */
   | { type: "ITEM_PATCH"; patches: FeedItemPatch[]; changedItemIds: string[]; mutation?: WorkerRequest["type"] }
   /** Debug panel event forwarding */

--- a/packages/desktop/src/lib/automerge-worker-memory.test.ts
+++ b/packages/desktop/src/lib/automerge-worker-memory.test.ts
@@ -118,6 +118,19 @@ describe("automerge worker memory routing", () => {
     expect(body).not.toContain("saveAndBroadcast");
   });
 
+  it("display preference updates avoid full feed hydration", () => {
+    const body = caseBody("UPDATE_PREFERENCES");
+    const applyBody = functionBody("applyPreferenceChange");
+    const requiresBody = functionBody("preferenceUpdateRequiresFullHydration");
+
+    expect(body).toContain("applyPreferenceChange");
+    expect(body).not.toContain("applyRequestChange");
+    expect(applyBody).toContain("persistAndBroadcastWithoutHydration");
+    expect(applyBody).toContain("PREFERENCES_PATCH");
+    expect(applyBody).toContain("saveAndBroadcast");
+    expect(requiresBody).toContain("updates.weights !== undefined");
+  });
+
   it.each(["HEAL_UNTITLED_FEEDS", "DEDUPLICATE_ITEMS", "PRUNE_ARCHIVED_ITEMS"])(
     "%s skips full hydration when no records change",
     (caseName) => {

--- a/packages/desktop/src/lib/automerge.ts
+++ b/packages/desktop/src/lib/automerge.ts
@@ -181,6 +181,21 @@ worker.onmessage = (event: MessageEvent<WorkerResponse>) => {
     return;
   }
 
+  if (msg.type === "PREFERENCES_PATCH") {
+    if (!lastDocState) return;
+    publishState(
+      { ...lastDocState, preferences: msg.preferences },
+      {
+        source: "preferences_patch",
+        mutation: msg.mutation,
+        changedItemIds: null,
+        changedItems: [],
+        requiresFullScan: false,
+      },
+    );
+    return;
+  }
+
   if (msg.type === "ITEM_PATCH") {
     if (!lastDocState) return;
     const changedItems = msg.patches.map((patch) => patch.item);

--- a/packages/desktop/src/lib/automerge.worker.ts
+++ b/packages/desktop/src/lib/automerge.worker.ts
@@ -473,6 +473,14 @@ function hydrateFromDoc(doc: FreedDoc): DocState {
   };
 }
 
+function hydratePreferencesFromDoc(doc: FreedDoc): UserPreferences {
+  return mergeDefaultPreferences(A.toJS(doc.preferences ?? {}) as Partial<UserPreferences>);
+}
+
+function preferenceUpdateRequiresFullHydration(updates: Partial<UserPreferences>): boolean {
+  return updates.weights !== undefined;
+}
+
 /**
  * Persist, hydrate, and broadcast state plus, if relay clients are connected,
  * request a broadcast_doc IPC call from the main thread. The Array.from(binary)
@@ -578,6 +586,26 @@ async function applyChange(
   if (searchCorpusChanged) bumpSearchCorpusVersion();
   send({ type: "DEBUG_EVENT", kind: "change", detail: message });
   await saveAndBroadcast(trace);
+}
+
+async function applyPreferenceChange(
+  updates: Partial<UserPreferences>,
+  trace?: RequestTrace,
+): Promise<void> {
+  if (!currentDoc) throw new Error("Document not initialized");
+  currentDoc = A.change(currentDoc, "Update preferences", (doc) => {
+    updatePreferences(doc, updates);
+  });
+  send({ type: "DEBUG_EVENT", kind: "change", detail: "Update preferences" });
+
+  if (preferenceUpdateRequiresFullHydration(updates)) {
+    await saveAndBroadcast(trace);
+    return;
+  }
+
+  const preferences = hydratePreferencesFromDoc(currentDoc);
+  await persistAndBroadcastWithoutHydration(trace);
+  send({ type: "PREFERENCES_PATCH", preferences, mutation: trace?.opType });
 }
 
 async function applyCountedChange(
@@ -950,10 +978,7 @@ async function handleRequest(
         break;
 
       case "UPDATE_PREFERENCES":
-        await applyRequestChange(
-          (doc) => updatePreferences(doc, req.updates),
-          "Update preferences",
-        );
+        await applyPreferenceChange(req.updates, trace);
         ack(req.reqId);
         break;
 


### PR DESCRIPTION
(AI Generated).

## Summary
- (AI Generated). Avoids whole-library worker hydration for display-only preference updates so dense Friends workspaces can switch modes and mount without paying feed ranking cost.

## Testing
- npm run test:unit -- automerge-worker-memory.test.ts
- PATH=/Users/aubreyfalconer/dev/freed-friends-perf-mount-ready/node_modules/.bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/usr/local/MacGPG2/bin:/Applications/VMware Fusion.app/Contents/Public:/usr/local/share/dotnet:~/.dotnet/tools:/usr/local/go/bin:/Library/Frameworks/Mono.framework/Versions/Current/Commands:/Users/aubreyfalconer/.nvm/versions/node/v24.14.1/bin:/Users/aubreyfalconer/.codex/tmp/arg0/codex-arg05cJIJd:/Users/aubreyfalconer/.local/bin:/opt/homebrew/opt/mysql-client/bin:/opt/homebrew/bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/Users/aubreyfalconer/.cargo/bin:/Users/aubreyfalconer/go/bin:/Users/aubreyfalconer/.cache/lm-studio/bin:/Users/aubreyfalconer/.safe-chain/bin:/Applications/Codex.app/Contents/Resources:/usr/local/bin npm run build
- npm run test:e2e:perf
- npm run validate:feature