### PR TITLE
fix: preserve preference patch state

### DIFF
--- a/packages/desktop/src/lib/automerge-types.ts
+++ b/packages/desktop/src/lib/automerge-types.ts
@@ -145,7 +145,7 @@ export type WorkerResponse =
   /** Broadcast on every doc mutation - main thread uses this to update UI */
   | { type: "STATE_UPDATE"; state: DocState; mutation?: WorkerRequest["type"] }
   /** Preference-only mutation that avoids cloning, ranking, and hydrating every feed item. */
-  | { type: "PREFERENCES_PATCH"; preferences: UserPreferences; mutation?: WorkerRequest["type"] }
+  | { type: "PREFERENCES_PATCH"; updates: Partial<UserPreferences>; mutation?: WorkerRequest["type"] }
   /** Small mutation update that avoids cloning and hydrating the full document. */
   | { type: "ITEM_PATCH"; patches: FeedItemPatch[]; changedItemIds: string[]; mutation?: WorkerRequest["type"] }
   /** Debug panel event forwarding */

--- a/packages/desktop/src/lib/automerge-worker-memory.test.ts
+++ b/packages/desktop/src/lib/automerge-worker-memory.test.ts
@@ -127,7 +127,9 @@ describe("automerge worker memory routing", () => {
     expect(body).not.toContain("applyRequestChange");
     expect(applyBody).toContain("persistAndBroadcastWithoutHydration");
     expect(applyBody).toContain("PREFERENCES_PATCH");
+    expect(applyBody).toContain("updates, mutation");
     expect(applyBody).toContain("saveAndBroadcast");
+    expect(workerSource).not.toContain("A.toJS(doc.preferences");
     expect(requiresBody).toContain("updates.weights !== undefined");
   });
 

--- a/packages/desktop/src/lib/automerge.ts
+++ b/packages/desktop/src/lib/automerge.ts
@@ -141,6 +141,29 @@ export function subscribe(callback: Subscriber): () => void {
   return () => subscribers.delete(callback);
 }
 
+function isMergeablePreferenceObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function mergePreferencePatch<T extends object>(
+  current: T,
+  update: Partial<T>,
+): T {
+  const next = { ...current };
+
+  for (const key of Object.keys(update) as Array<keyof T>) {
+    const currentValue = current[key];
+    const updateValue = update[key];
+    next[key] = (
+      isMergeablePreferenceObject(currentValue) && isMergeablePreferenceObject(updateValue)
+        ? mergePreferencePatch<Record<string, unknown>>(currentValue, updateValue)
+        : updateValue
+    ) as T[typeof key];
+  }
+
+  return next;
+}
+
 function publishState(state: DocState, event: DocChangeEvent): void {
   lastDocState = state;
   if (event.requiresFullScan) {
@@ -183,8 +206,9 @@ worker.onmessage = (event: MessageEvent<WorkerResponse>) => {
 
   if (msg.type === "PREFERENCES_PATCH") {
     if (!lastDocState) return;
+    const preferences = mergePreferencePatch(lastDocState.preferences, msg.updates);
     publishState(
-      { ...lastDocState, preferences: msg.preferences },
+      { ...lastDocState, preferences },
       {
         source: "preferences_patch",
         mutation: msg.mutation,

--- a/packages/desktop/src/lib/automerge.worker.ts
+++ b/packages/desktop/src/lib/automerge.worker.ts
@@ -473,10 +473,6 @@ function hydrateFromDoc(doc: FreedDoc): DocState {
   };
 }
 
-function hydratePreferencesFromDoc(doc: FreedDoc): UserPreferences {
-  return mergeDefaultPreferences(A.toJS(doc.preferences ?? {}) as Partial<UserPreferences>);
-}
-
 function preferenceUpdateRequiresFullHydration(updates: Partial<UserPreferences>): boolean {
   return updates.weights !== undefined;
 }
@@ -603,9 +599,8 @@ async function applyPreferenceChange(
     return;
   }
 
-  const preferences = hydratePreferencesFromDoc(currentDoc);
   await persistAndBroadcastWithoutHydration(trace);
-  send({ type: "PREFERENCES_PATCH", preferences, mutation: trace?.opType });
+  send({ type: "PREFERENCES_PATCH", updates, mutation: trace?.opType });
 }
 
 async function applyCountedChange(


### PR DESCRIPTION
(AI Generated).

## Summary
- (AI Generated). Preserves display preference state on the fast worker patch path by sending the original update across the worker boundary instead of serializing a nested Automerge proxy.

## Testing
- npm run test:unit -- automerge-worker-memory.test.ts
- PATH=/Users/aubreyfalconer/dev/freed-preference-patch-state/node_modules/.bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/usr/local/MacGPG2/bin:/Applications/VMware Fusion.app/Contents/Public:/usr/local/share/dotnet:~/.dotnet/tools:/usr/local/go/bin:/Library/Frameworks/Mono.framework/Versions/Current/Commands:/Users/aubreyfalconer/.nvm/versions/node/v24.14.1/bin:/Users/aubreyfalconer/.codex/tmp/arg0/codex-arg05cJIJd:/Users/aubreyfalconer/.local/bin:/opt/homebrew/opt/mysql-client/bin:/opt/homebrew/bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/Users/aubreyfalconer/.cargo/bin:/Users/aubreyfalconer/go/bin:/Users/aubreyfalconer/.cache/lm-studio/bin:/Users/aubreyfalconer/.safe-chain/bin:/Applications/Codex.app/Contents/Resources:/usr/local/bin npm run build
- npm run test:e2e -- smoke.spec.ts --grep 'recoverable story locations|map time filters|map timeline playback|Friends detail rail toggle|selecting a graph node|clicking empty graph space|dragging a person|zooming the Friends graph'
- npm run test:e2e -- feed-card-ui.spec.ts smoke.spec.ts --grep 'feed card overhaul actions|desktop hide previews skips|feed toolbar title describes|Friends workspace keeps'
- npm run validate:feature