### PR TITLE
perf: improve dense map movement headroom

### DIFF
--- a/packages/desktop/tests/e2e/smoke.spec.ts
+++ b/packages/desktop/tests/e2e/smoke.spec.ts
@@ -4394,7 +4394,12 @@ test("pinching the Friends graph zooms around the active two-touch midpoint", as
   await expect
     .poll(async () => (await readGraphDebug(page))?.nodes.length ?? 0, { timeout: 10_000 })
     .toBeGreaterThan(0);
-  await page.getByRole("button", { name: "Fit all" }).click();
+  await expect
+    .poll(async () => {
+      const debug = await readGraphSummary(page);
+      return Boolean(debug && debug.qualityMode === "settled" && debug.transform.scale > 0);
+    }, { timeout: 10_000 })
+    .toBe(true);
 
   const box = await viewport.boundingBox();
   if (!box) {

--- a/packages/ui/src/components/map/MapSurface.tsx
+++ b/packages/ui/src/components/map/MapSurface.tsx
@@ -368,6 +368,11 @@ function mapStyles(interactive: boolean) {
       filter: none;
     }
 
+    .freed-map-shell[data-map-moving="true"] .freed-map-grid-overlay,
+    .freed-map-shell[data-map-moving="true"] .freed-map-edge-overlay {
+      display: none;
+    }
+
     .freed-map-shell .freed-map-marker:hover .freed-map-marker-body {
       scale: 1.06;
       filter: brightness(1.06);
@@ -560,6 +565,7 @@ export function MapSurface({
     if (!focusedMarker) return baseRenderedMarkers;
     return [...baseRenderedMarkers.slice(0, MAP_DOM_MARKER_LIMIT - 1), focusedMarker];
   }, [baseRenderedMarkers, focusedMarkerKey, stableMarkers]);
+  const showMarkerAvatars = stableMarkers.length <= MAP_DOM_MARKER_LIMIT;
   const avatarPalette = useMemo(
     () => createFriendAvatarPalette(resolvedThemeId),
     [resolvedThemeId]
@@ -672,7 +678,9 @@ export function MapSurface({
     map.on("click", handleMapClick);
 
     for (const markerData of renderedMarkers) {
-      const element = createMarkerElement(markerData, avatarPalette);
+      const element = createMarkerElement(markerData, avatarPalette, {
+        showAvatar: showMarkerAvatars,
+      });
       const marker = new maplibre.Marker({ element }).setLngLat([
         markerData.lng,
         markerData.lat,
@@ -725,7 +733,7 @@ export function MapSurface({
       map.off("click", handleMapClick);
       closeActivePopup();
     };
-  }, [avatarPalette, closeActivePopup, interactive, mapReady, renderedMarkers]);
+  }, [avatarPalette, closeActivePopup, interactive, mapReady, renderedMarkers, showMarkerAvatars]);
 
   useEffect(() => {
     if (!mapReady || !mapRef.current) return;
@@ -749,14 +757,14 @@ export function MapSurface({
           className={`h-full w-full ${showFallback ? "invisible" : "visible"}`}
         />
         <div
-          className="pointer-events-none absolute inset-0 [background-size:88px_88px]"
+          className="freed-map-grid-overlay pointer-events-none absolute inset-0 [background-size:88px_88px]"
           style={{
             backgroundImage: mapGridBackground(mapPalette.boundary),
             opacity: mapPalette.gridOpacity,
           }}
         />
         <div
-          className="pointer-events-none absolute inset-0"
+          className="freed-map-edge-overlay pointer-events-none absolute inset-0"
           style={{
             background: mapEdgeVignetteBackground(),
           }}

--- a/packages/ui/src/components/map/MarkerElement.test.ts
+++ b/packages/ui/src/components/map/MarkerElement.test.ts
@@ -95,6 +95,13 @@ describe("createMarkerElement", () => {
     expect(element.textContent).toContain((1234).toLocaleString());
   });
 
+  it("can skip avatar images for dense map marker sets", () => {
+    const element = createMarkerElement(marker(), palette, { showAvatar: false });
+
+    expect(element.querySelector("img")).toBeNull();
+    expect(element.querySelector("[data-avatar-fallback]")?.textContent).toBe("L");
+  });
+
   it("labels decorative marker layers so map movement can suppress paint-heavy chrome", () => {
     const element = createMarkerElement(marker({ groupCount: 1234 }), palette);
 

--- a/packages/ui/src/components/map/MarkerElement.ts
+++ b/packages/ui/src/components/map/MarkerElement.ts
@@ -8,6 +8,10 @@ import type { FriendAvatarPalette } from "../../lib/friend-avatar-style.js";
 
 export type MarkerSize = "large" | "medium" | "small";
 
+interface MarkerElementOptions {
+  showAvatar?: boolean;
+}
+
 const SIZE_PX: Record<MarkerSize, number> = {
   large: 40,
   medium: 32,
@@ -45,13 +49,16 @@ function appendFallbackLabel(
 
 export function createMarkerElement(
   marker: LocationMarkerSummary,
-  avatarPalette: FriendAvatarPalette
+  avatarPalette: FriendAvatarPalette,
+  options: MarkerElementOptions = {},
 ): HTMLElement {
   const size = markerSize(marker.seenAt);
   const px = SIZE_PX[size];
   const friend = marker.friend;
   const item = marker.item;
-  const avatarUrl = resolveFriendAvatarUrl(friend, item.author.avatarUrl);
+  const avatarUrl = options.showAvatar === false
+    ? null
+    : resolveFriendAvatarUrl(friend, item.author.avatarUrl);
 
   const el = document.createElement("div");
   el.className = `freed-map-marker freed-map-marker--${size}`;


### PR DESCRIPTION
(AI Generated).

## Summary
- Suppress dense Map decoration during active movement, skip avatar image layers for dense marker sets, and stabilize the Friends pinch regression so release validation no longer depends on a visible Fit all button.

## Testing
- node ./node_modules/vitest/vitest.mjs run packages/ui/src/components/map/MarkerElement.test.ts
- node ../../node_modules/playwright/cli.js test smoke.spec.ts --grep "pinching the Friends graph zooms around the active two-touch midpoint"
- npm run test:e2e:perf:map
- npm run validate:feature