### PR TITLE
fix: stabilize unlinked map marker test

### DIFF
--- a/packages/desktop/tests/e2e/smoke.spec.ts
+++ b/packages/desktop/tests/e2e/smoke.spec.ts
@@ -2863,7 +2863,15 @@ test("unlinked map markers route into the friends account workflow and can link 
     timeout: 10_000,
   });
   await expect(page.getByText("Link to existing friend")).toBeVisible({ timeout: 10_000 });
-  await page.getByRole("button", { name: /Ada Lovelace/ }).first().click();
+  await page.waitForFunction(() => {
+    const adaRow = Array.from(document.querySelectorAll<HTMLButtonElement>("button")).find((element) => {
+      const label = element.textContent ?? "";
+      return /Ada Lovelace/i.test(label) && element.getClientRects().length > 0;
+    });
+    if (!adaRow) return false;
+    adaRow.click();
+    return true;
+  }, { timeout: 5_000 });
 
   await page.waitForFunction(() => {
     const w = window as Record<string, unknown>;


### PR DESCRIPTION
(AI Generated).

## Summary
- Stabilize the unlinked map marker account linking E2E interaction that detached during release validation
- Keep coverage for routing into the Friends account workflow and linking the unlinked account to Ada

## Validation
- npm run test:e2e -- smoke.spec.ts --grep "unlinked map markers route into the friends account workflow and can link to an existing friend"
- npm run validate:feature