### PR TITLE
perf: reduce dense map interaction work

### DIFF
--- a/packages/ui/src/components/map/MapSurface.tsx
+++ b/packages/ui/src/components/map/MapSurface.tsx
@@ -565,7 +565,8 @@ export function MapSurface({
     if (!focusedMarker) return baseRenderedMarkers;
     return [...baseRenderedMarkers.slice(0, MAP_DOM_MARKER_LIMIT - 1), focusedMarker];
   }, [baseRenderedMarkers, focusedMarkerKey, stableMarkers]);
-  const showMarkerAvatars = stableMarkers.length <= MAP_DOM_MARKER_LIMIT;
+  const useDenseMarkers = stableMarkers.length > MAP_DOM_MARKER_LIMIT;
+  const showMarkerAvatars = !useDenseMarkers;
   const avatarPalette = useMemo(
     () => createFriendAvatarPalette(resolvedThemeId),
     [resolvedThemeId]
@@ -680,6 +681,7 @@ export function MapSurface({
     for (const markerData of renderedMarkers) {
       const element = createMarkerElement(markerData, avatarPalette, {
         showAvatar: showMarkerAvatars,
+        simplified: useDenseMarkers,
       });
       const marker = new maplibre.Marker({ element }).setLngLat([
         markerData.lng,
@@ -687,30 +689,6 @@ export function MapSurface({
       ]);
 
       if (interactive) {
-        const currentHandlers = actionHandlersRef.current;
-        const popup = new maplibre.Popup({
-          closeButton: false,
-          closeOnClick: false,
-          offset: 12,
-          maxWidth: `${MAP_POPUP_MAX_WIDTH}px`,
-          className: "freed-map-popup",
-        })
-          .setLngLat([markerData.lng, markerData.lat])
-          .setDOMContent(buildPopupContent(
-            markerData,
-            currentHandlers.onOpenFriend
-              ? (marker) => actionHandlersRef.current.onOpenFriend?.(marker)
-              : undefined,
-            currentHandlers.onPromoteAccount
-              ? (marker) => actionHandlersRef.current.onPromoteAccount?.(marker)
-              : undefined,
-            currentHandlers.onLinkAccount
-              ? (marker) => actionHandlersRef.current.onLinkAccount?.(marker)
-              : undefined,
-            currentHandlers.onOpenPost
-              ? (marker) => actionHandlersRef.current.onOpenPost?.(marker)
-              : undefined,
-          ));
         element.addEventListener("click", (event) => {
           event.preventDefault();
           event.stopPropagation();
@@ -719,6 +697,30 @@ export function MapSurface({
             return;
           }
           closeActivePopup();
+          const currentHandlers = actionHandlersRef.current;
+          const popup = new maplibre.Popup({
+            closeButton: false,
+            closeOnClick: false,
+            offset: 12,
+            maxWidth: `${MAP_POPUP_MAX_WIDTH}px`,
+            className: "freed-map-popup",
+          })
+            .setLngLat([markerData.lng, markerData.lat])
+            .setDOMContent(buildPopupContent(
+              markerData,
+              currentHandlers.onOpenFriend
+                ? (marker) => actionHandlersRef.current.onOpenFriend?.(marker)
+                : undefined,
+              currentHandlers.onPromoteAccount
+                ? (marker) => actionHandlersRef.current.onPromoteAccount?.(marker)
+                : undefined,
+              currentHandlers.onLinkAccount
+                ? (marker) => actionHandlersRef.current.onLinkAccount?.(marker)
+                : undefined,
+              currentHandlers.onOpenPost
+                ? (marker) => actionHandlersRef.current.onOpenPost?.(marker)
+                : undefined,
+            ));
           popup.addTo(map);
           activePopupRef.current = popup;
           activePopupKeyRef.current = markerData.key;
@@ -733,7 +735,7 @@ export function MapSurface({
       map.off("click", handleMapClick);
       closeActivePopup();
     };
-  }, [avatarPalette, closeActivePopup, interactive, mapReady, renderedMarkers, showMarkerAvatars]);
+  }, [avatarPalette, closeActivePopup, interactive, mapReady, renderedMarkers, showMarkerAvatars, useDenseMarkers]);
 
   useEffect(() => {
     if (!mapReady || !mapRef.current) return;
@@ -746,6 +748,7 @@ export function MapSurface({
       data-map-theme={resolvedThemeId}
       data-map-rendered-markers={renderedMarkers.length}
       data-map-total-markers={stableMarkers.length}
+      data-map-dense={useDenseMarkers ? "true" : "false"}
       data-map-moving="false"
       className="freed-map-shell theme-soft-viewport relative h-full w-full"
       style={MAP_VIEWPORT_MASK_STYLE}

--- a/packages/ui/src/components/map/MarkerElement.test.ts
+++ b/packages/ui/src/components/map/MarkerElement.test.ts
@@ -112,4 +112,19 @@ describe("createMarkerElement", () => {
     expect(element.querySelector(".freed-map-marker-halo")).toBeInstanceOf(HTMLDivElement);
     expect(element.querySelector(".freed-map-marker-badge")).toBeInstanceOf(HTMLDivElement);
   });
+
+  it("can simplify dense marker chrome", () => {
+    const element = createMarkerElement(marker({ groupCount: 1234 }), palette, {
+      showAvatar: false,
+      simplified: true,
+    });
+
+    expect(element.getAttribute("data-map-marker-simplified")).toBe("true");
+    expect(element.querySelector("img")).toBeNull();
+    expect(element.querySelector("[data-avatar-fallback]")?.textContent).toBe("L");
+    expect(element.querySelector(".freed-map-marker-glow")).toBeNull();
+    expect(element.querySelector(".freed-map-marker-tint")).toBeNull();
+    expect(element.querySelector(".freed-map-marker-halo")).toBeNull();
+    expect(element.querySelector(".freed-map-marker-badge")).toBeNull();
+  });
 });

--- a/packages/ui/src/components/map/MarkerElement.ts
+++ b/packages/ui/src/components/map/MarkerElement.ts
@@ -10,6 +10,7 @@ export type MarkerSize = "large" | "medium" | "small";
 
 interface MarkerElementOptions {
   showAvatar?: boolean;
+  simplified?: boolean;
 }
 
 const SIZE_PX: Record<MarkerSize, number> = {
@@ -56,6 +57,7 @@ export function createMarkerElement(
   const px = SIZE_PX[size];
   const friend = marker.friend;
   const item = marker.item;
+  const simplified = options.simplified === true;
   const avatarUrl = options.showAvatar === false
     ? null
     : resolveFriendAvatarUrl(friend, item.author.avatarUrl);
@@ -66,6 +68,9 @@ export function createMarkerElement(
   el.setAttribute("aria-label", displayName(item, friend));
   el.setAttribute("data-avatar-url", avatarUrl ?? "");
   el.setAttribute("data-avatar-name", displayName(item, friend));
+  if (simplified) {
+    el.setAttribute("data-map-marker-simplified", "true");
+  }
   el.style.cssText = [
     "position:absolute",
     "transform-origin:center center",
@@ -79,13 +84,17 @@ export function createMarkerElement(
     "position:relative",
     "border-radius:999px",
     `border:1px solid ${avatarPalette.borderStrong}`,
-    `box-shadow:0 0 0 1px ${avatarPalette.borderSoft},0 0 18px ${avatarPalette.glow},var(--theme-marker-shadow)`,
+    simplified
+      ? `box-shadow:0 0 0 1px ${avatarPalette.borderSoft}`
+      : `box-shadow:0 0 0 1px ${avatarPalette.borderSoft},0 0 18px ${avatarPalette.glow},var(--theme-marker-shadow)`,
     "overflow:hidden",
     "display:flex",
     "align-items:center",
     "justify-content:center",
     "cursor:pointer",
-    `background:radial-gradient(circle at 30% 28%,${avatarPalette.gradientStart},${avatarPalette.gradientMid} 34%,${avatarPalette.gradientEnd} 100%)`,
+    simplified
+      ? `background:${avatarPalette.gradientMid}`
+      : `background:radial-gradient(circle at 30% 28%,${avatarPalette.gradientStart},${avatarPalette.gradientMid} 34%,${avatarPalette.gradientEnd} 100%)`,
     `font-size:${Math.max(8, px * 0.35)}px`,
     "font-weight:700",
     `color:${avatarPalette.text}`,
@@ -94,18 +103,20 @@ export function createMarkerElement(
   ].join(";");
   el.appendChild(body);
 
-  const glowRing = document.createElement("div");
-  glowRing.className = "freed-map-marker-glow";
-  glowRing.style.cssText = [
-    "position:absolute",
-    "inset:-6px",
-    "border-radius:999px",
-    `border:1px solid ${avatarPalette.ring}`,
-    `background:radial-gradient(circle,${avatarPalette.glowSoft},transparent 72%)`,
-    "pointer-events:none",
-    "z-index:0",
-  ].join(";");
-  body.appendChild(glowRing);
+  if (!simplified) {
+    const glowRing = document.createElement("div");
+    glowRing.className = "freed-map-marker-glow";
+    glowRing.style.cssText = [
+      "position:absolute",
+      "inset:-6px",
+      "border-radius:999px",
+      `border:1px solid ${avatarPalette.ring}`,
+      `background:radial-gradient(circle,${avatarPalette.glowSoft},transparent 72%)`,
+      "pointer-events:none",
+      "z-index:0",
+    ].join(";");
+    body.appendChild(glowRing);
+  }
 
   const initials = markerInitials(item, friend);
 
@@ -121,35 +132,37 @@ export function createMarkerElement(
     };
     body.appendChild(img);
 
-    const tintOverlay = document.createElement("div");
-    tintOverlay.className = "freed-map-marker-tint";
-    tintOverlay.style.cssText = [
-      "position:absolute",
-      "inset:0",
-      "border-radius:999px",
-      `background:${avatarPalette.imageOverlay}`,
-      "pointer-events:none",
-      "z-index:2",
-    ].join(";");
-    body.appendChild(tintOverlay);
+    if (!simplified) {
+      const tintOverlay = document.createElement("div");
+      tintOverlay.className = "freed-map-marker-tint";
+      tintOverlay.style.cssText = [
+        "position:absolute",
+        "inset:0",
+        "border-radius:999px",
+        `background:${avatarPalette.imageOverlay}`,
+        "pointer-events:none",
+        "z-index:2",
+      ].join(";");
+      body.appendChild(tintOverlay);
 
-    const halo = document.createElement("div");
-    halo.className = "freed-map-marker-halo";
-    halo.style.cssText = [
-      "position:absolute",
-      "inset:4px",
-      "border-radius:999px",
-      `border:1px solid ${avatarPalette.ring}`,
-      `background:radial-gradient(circle at 30% 30%, ${avatarPalette.imageHighlight}, transparent 65%)`,
-      "pointer-events:none",
-      "z-index:3",
-    ].join(";");
-    body.appendChild(halo);
+      const halo = document.createElement("div");
+      halo.className = "freed-map-marker-halo";
+      halo.style.cssText = [
+        "position:absolute",
+        "inset:4px",
+        "border-radius:999px",
+        `border:1px solid ${avatarPalette.ring}`,
+        `background:radial-gradient(circle at 30% 30%, ${avatarPalette.imageHighlight}, transparent 65%)`,
+        "pointer-events:none",
+        "z-index:3",
+      ].join(";");
+      body.appendChild(halo);
+    }
   } else {
     appendFallbackLabel(body, initials, avatarPalette);
   }
 
-  if (marker.groupCount > 1) {
+  if (marker.groupCount > 1 && !simplified) {
     const badge = document.createElement("div");
     badge.className = "freed-map-marker-badge";
     badge.textContent = marker.groupCount.toLocaleString();


### PR DESCRIPTION
(AI Generated).

## Summary
- Create dense Map marker popups lazily instead of eagerly building popup DOM for every visible marker.
- Render simplified marker chrome when a Map has more markers than the DOM marker limit, reducing dense marker DOM and paint work.

## Testing
- PATH=/Users/aubreyfalconer/dev/freed-map-interaction-pressure/node_modules/.bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/usr/local/MacGPG2/bin:/Applications/VMware Fusion.app/Contents/Public:/usr/local/share/dotnet:~/.dotnet/tools:/usr/local/go/bin:/Library/Frameworks/Mono.framework/Versions/Current/Commands:/Users/aubreyfalconer/.nvm/versions/node/v24.14.1/bin:/Users/aubreyfalconer/.codex/tmp/arg0/codex-arg05cJIJd:/Users/aubreyfalconer/.local/bin:/opt/homebrew/opt/mysql-client/bin:/opt/homebrew/bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/Users/aubreyfalconer/.cargo/bin:/Users/aubreyfalconer/go/bin:/Users/aubreyfalconer/.cache/lm-studio/bin:/Users/aubreyfalconer/.safe-chain/bin:/Applications/Codex.app/Contents/Resources:/usr/local/bin npx vitest run packages/ui/src/components/map/MarkerElement.test.ts
- PATH=/Users/aubreyfalconer/dev/freed-map-interaction-pressure/node_modules/.bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/usr/local/MacGPG2/bin:/Applications/VMware Fusion.app/Contents/Public:/usr/local/share/dotnet:~/.dotnet/tools:/usr/local/go/bin:/Library/Frameworks/Mono.framework/Versions/Current/Commands:/Users/aubreyfalconer/.nvm/versions/node/v24.14.1/bin:/Users/aubreyfalconer/.codex/tmp/arg0/codex-arg05cJIJd:/Users/aubreyfalconer/.local/bin:/opt/homebrew/opt/mysql-client/bin:/opt/homebrew/bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/Users/aubreyfalconer/.cargo/bin:/Users/aubreyfalconer/go/bin:/Users/aubreyfalconer/.cache/lm-studio/bin:/Users/aubreyfalconer/.safe-chain/bin:/Applications/Codex.app/Contents/Resources:/usr/local/bin node ../../node_modules/playwright/cli.js test perf-map.spec.ts --grep '1,600 visible location authors'
- npm run validate:feature