### PR TITLE
fix: stabilize friends graph regression tests

### DIFF
--- a/packages/desktop/tests/e2e/smoke.spec.ts
+++ b/packages/desktop/tests/e2e/smoke.spec.ts
@@ -2625,6 +2625,7 @@ test("Friends workspace keeps a visible sidebar and supports back navigation", a
         getState: () => {
           setActiveView: (view: string) => void;
           setSelectedPerson: (personId: string | null) => void;
+          setSelectedAccount: (accountId: string | null) => void;
           updatePreferences: (update: unknown) => Promise<void>;
         };
       }
@@ -2675,13 +2676,16 @@ test("Friends workspace keeps a visible sidebar and supports back navigation", a
     await store?.getState().updatePreferences({
       display: {
         friendsSidebarWidth: 388,
+        friendsSidebarOpen: true,
       },
     });
+    store?.getState().setSelectedPerson(null);
+    store?.getState().setSelectedAccount(null);
     store?.getState().setActiveView("friends");
   });
 
-  await expect(page.getByTestId("friends-sidebar")).toBeVisible({ timeout: 5_000 });
-  await expect(page.getByPlaceholder("Search friends")).toBeVisible({ timeout: 5_000 });
+  await expect(page.getByTestId("friends-sidebar")).toBeVisible({ timeout: 10_000 });
+  await expect(page.getByPlaceholder("Search friends")).toBeVisible({ timeout: 10_000 });
   await page.evaluate(() => {
     const store = (window as Record<string, unknown>).__FREED_STORE__ as
       | { getState: () => { setSelectedPerson: (personId: string | null) => void } }
@@ -2695,7 +2699,7 @@ test("Friends workspace keeps a visible sidebar and supports back navigation", a
     button.click();
     return true;
   }, undefined, { timeout: 5_000 });
-  await expect(page.getByPlaceholder("Search friends")).toBeVisible({ timeout: 5_000 });
+  await expect(page.getByPlaceholder("Search friends")).toBeVisible({ timeout: 10_000 });
 });
 
 test("Map view popup exposes friend actions and supports post navigation", async ({ app }) => {
@@ -3224,6 +3228,8 @@ test("Friends detail rail visibility preference hides and restores the desktop s
           getState: () => {
             updatePreferences: (patch: { display: { friendsSidebarWidth: number; friendsSidebarOpen: boolean } }) => Promise<void>;
             setActiveView: (view: string) => void;
+            setSelectedPerson: (personId: string | null) => void;
+            setSelectedAccount: (accountId: string | null) => void;
           };
         }
       | undefined;
@@ -3322,12 +3328,14 @@ test("Friends detail rail resize caps at 400 pixels", async ({ app, page }) => {
         friendsSidebarOpen: true,
       },
     });
+    store?.getState().setSelectedPerson(null);
+    store?.getState().setSelectedAccount(null);
     store?.getState().setActiveView("friends");
   });
 
-  await expect(page.getByTestId("friends-sidebar")).toBeVisible({ timeout: 5_000 });
+  await expect(page.getByTestId("friends-sidebar")).toBeVisible({ timeout: 10_000 });
   const handle = page.getByRole("separator", { name: "Resize friends sidebar" });
-  await expect(handle).toBeVisible({ timeout: 5_000 });
+  await expect(handle).toBeVisible({ timeout: 10_000 });
   const sidebar = page.getByTestId("friends-sidebar");
   let sidebarBox: { x: number; y: number; width: number; height: number } | null = null;
   await expect
@@ -3345,7 +3353,7 @@ test("Friends detail rail resize caps at 400 pixels", async ({ app, page }) => {
         };
       }).catch(() => null);
       return sidebarBox !== null;
-    }, { timeout: 5_000 })
+    }, { timeout: 10_000 })
     .toBe(true);
   if (!sidebarBox) {
     throw new Error("Friends sidebar did not expose browser geometry");
@@ -3420,6 +3428,8 @@ test("selecting a graph node shows a compact detail card when the Friends detail
           getState: () => {
             updatePreferences: (patch: { display: { friendsSidebarOpen: boolean } }) => Promise<void>;
             setActiveView: (view: string) => void;
+            setSelectedPerson: (personId: string | null) => void;
+            setSelectedAccount: (accountId: string | null) => void;
           };
         }
       | undefined;
@@ -3428,6 +3438,8 @@ test("selecting a graph node shows a compact detail card when the Friends detail
         friendsSidebarOpen: false,
       },
     });
+    store?.getState().setSelectedPerson(null);
+    store?.getState().setSelectedAccount(null);
     store?.getState().setActiveView("friends");
   });
 
@@ -3501,18 +3513,18 @@ test("clicking empty graph space closes the collapsed Friends detail card", asyn
   const viewport = page.getByTestId("friend-graph-viewport");
   await expect(viewport).toBeVisible({ timeout: 10_000 });
 
-  let friendPoint: { x: number; y: number } | null = null;
-  await expect
-    .poll(async () => {
-      friendPoint = await graphNodeScreenPoint(page, { personId: "friend-ada" });
-      return friendPoint !== null;
-    }, { timeout: 10_000 })
-    .toBe(true);
+  const friendPoint = await waitForGraphNodeScreenPoint(page, { personId: "friend-ada" });
 
-  await page.mouse.click(friendPoint!.x, friendPoint!.y);
+  await page.mouse.click(friendPoint.x, friendPoint.y);
+  await page.waitForFunction(() => {
+    const store = (window as Record<string, unknown>).__FREED_STORE__ as
+      | { getState: () => { selectedPersonId: string | null } }
+      | undefined;
+    return store?.getState().selectedPersonId === "friend-ada";
+  }, undefined, { timeout: 10_000 });
 
   const compactCard = page.getByTestId("friends-collapsed-selection-card");
-  await expect(compactCard).toBeVisible({ timeout: 5_000 });
+  await expect(compactCard).toBeVisible({ timeout: 10_000 });
 
   const viewportBox = await viewport.boundingBox();
   if (!viewportBox) {
@@ -4639,15 +4651,23 @@ test("pinching the Friends graph zooms around the active two-touch midpoint", as
     })
     .toBeGreaterThan(before!.transform.scale);
 
-  const after = await readGraphDebug(page);
-  expect(after).not.toBeNull();
-  const projectedInitialMidpoint = {
-    x: box.x + initialWorldPoint.x * after!.transform.scale + after!.transform.x,
-    y: box.y + initialWorldPoint.y * after!.transform.scale + after!.transform.y,
-  };
   const midpointTolerancePx = 4;
-  expect(Math.abs(projectedInitialMidpoint.x - (centerX + panDelta.x))).toBeLessThanOrEqual(midpointTolerancePx);
-  expect(Math.abs(projectedInitialMidpoint.y - (centerY + panDelta.y))).toBeLessThanOrEqual(midpointTolerancePx);
+  await expect
+    .poll(async () => {
+      const after = await readGraphDebug(page);
+      if (!after) {
+        return Number.POSITIVE_INFINITY;
+      }
+      const projectedInitialMidpoint = {
+        x: box.x + initialWorldPoint.x * after.transform.scale + after.transform.x,
+        y: box.y + initialWorldPoint.y * after.transform.scale + after.transform.y,
+      };
+      return Math.max(
+        Math.abs(projectedInitialMidpoint.x - (centerX + panDelta.x)),
+        Math.abs(projectedInitialMidpoint.y - (centerY + panDelta.y)),
+      );
+    }, { timeout: 8_000 })
+    .toBeLessThanOrEqual(midpointTolerancePx);
 });
 
 test("stress Friends graph degrades labels during motion and avoids expensive redraws on pan", async ({ app, page }) => {


### PR DESCRIPTION
(AI Generated).

Stabilizes Friends graph regression coverage by setting the local Friends view state each test needs, clearing stale selections before assertions, waiting for selected graph state before compact-card assertions, and polling the pinch midpoint transform until the gesture settles.

Local validation:
- npm run test:e2e:regression -- --grep "Friends workspace keeps a visible sidebar|Friends detail rail resize caps|clicking empty graph space closes|pinching the Friends graph zooms"
- npm run validate:feature