### PR TITLE
fix: stabilize friends graph resize lifecycle

### DIFF
--- a/packages/desktop/tests/e2e/smoke.spec.ts
+++ b/packages/desktop/tests/e2e/smoke.spec.ts
@@ -3226,7 +3226,7 @@ test("Friends detail rail visibility preference hides and restores the desktop s
     const store = (window as Record<string, unknown>).__FREED_STORE__ as
       | {
           getState: () => {
-            updatePreferences: (patch: { display: { friendsSidebarWidth: number; friendsSidebarOpen: boolean } }) => Promise<void>;
+            updatePreferences: (patch: { display: { friendsMode: "friends"; friendsSidebarWidth: number; friendsSidebarOpen: boolean } }) => Promise<void>;
             setActiveView: (view: string) => void;
             setSelectedPerson: (personId: string | null) => void;
             setSelectedAccount: (accountId: string | null) => void;
@@ -3235,6 +3235,7 @@ test("Friends detail rail visibility preference hides and restores the desktop s
       | undefined;
     await store?.getState().updatePreferences({
       display: {
+        friendsMode: "friends",
         friendsSidebarWidth: 388,
         friendsSidebarOpen: true,
       },
@@ -3282,7 +3283,6 @@ test("Friends detail rail visibility preference hides and restores the desktop s
       },
     });
   });
-  await expect(page.getByTestId("friends-sidebar")).toBeVisible({ timeout: 5_000 });
   await page.waitForFunction(() => {
     const store = (window as Record<string, unknown>).__FREED_STORE__ as
       | {
@@ -3294,6 +3294,7 @@ test("Friends detail rail visibility preference hides and restores the desktop s
     const display = store?.getState().preferences.display;
     return display?.friendsSidebarOpen === true && display?.friendsSidebarWidth === 388;
   }, { timeout: 5_000 });
+  await expect(page.getByTestId("friends-sidebar")).toBeVisible({ timeout: 5_000 });
 
   const after = await page.evaluate(() => {
     const shell = document.querySelector('[data-testid="friends-sidebar-shell"]') as HTMLElement | null;
@@ -3426,7 +3427,7 @@ test("selecting a graph node shows a compact detail card when the Friends detail
     const store = (window as Record<string, unknown>).__FREED_STORE__ as
       | {
           getState: () => {
-            updatePreferences: (patch: { display: { friendsSidebarOpen: boolean } }) => Promise<void>;
+            updatePreferences: (patch: { display: { friendsMode: "friends"; friendsSidebarOpen: boolean } }) => Promise<void>;
             setActiveView: (view: string) => void;
             setSelectedPerson: (personId: string | null) => void;
             setSelectedAccount: (accountId: string | null) => void;
@@ -3435,6 +3436,7 @@ test("selecting a graph node shows a compact detail card when the Friends detail
       | undefined;
     await store?.getState().updatePreferences({
       display: {
+        friendsMode: "friends",
         friendsSidebarOpen: false,
       },
     });
@@ -3497,7 +3499,7 @@ test("clicking empty graph space closes the collapsed Friends detail card", asyn
     const store = (window as Record<string, unknown>).__FREED_STORE__ as
       | {
           getState: () => {
-            updatePreferences: (patch: { display: { friendsSidebarOpen: boolean } }) => Promise<void>;
+            updatePreferences: (patch: { display: { friendsMode: "friends"; friendsSidebarOpen: boolean } }) => Promise<void>;
             setActiveView: (view: string) => void;
             setSelectedPerson: (personId: string | null) => void;
             setSelectedAccount: (accountId: string | null) => void;
@@ -3506,6 +3508,7 @@ test("clicking empty graph space closes the collapsed Friends detail card", asyn
       | undefined;
     await store?.getState().updatePreferences({
       display: {
+        friendsMode: "friends",
         friendsSidebarOpen: false,
       },
     });

--- a/packages/ui/src/components/friends/FriendGraph.tsx
+++ b/packages/ui/src/components/friends/FriendGraph.tsx
@@ -194,7 +194,7 @@ const FAST_LAYOUT_NODE_THRESHOLD = 1_600;
 const NODE_LAYER_TEXTURE_CACHE_MAX_NODES = 1_200;
 const INTERACTIVE_NODE_CULL_THRESHOLD = 1_200;
 const DENSE_GRAPH_SINGLE_LAYER_THRESHOLD = 1_200;
-const DENSE_INTERACTION_CULL_THRESHOLD = 3_200;
+const DENSE_INTERACTION_CULL_THRESHOLD = 4_800;
 const DENSE_INTERACTION_NODE_LIMIT = 900;
 const DENSE_INTERACTION_VIEWPORT_PADDING = 96;
 const CONTROL_BASE = "theme-graph-control rounded-xl px-3 py-1.5 text-xs";
@@ -1231,9 +1231,8 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
       scene.denseNodeLayer.visible = !useDenseInteractionLayer;
       scene.denseInteractionNodeLayer.visible = useDenseInteractionLayer;
       if (useDenseInteractionLayer) {
-        const viewportCenterX = canvasSize.width / 2;
-        const viewportCenterY = canvasSize.height / 2;
-        const visibleNodes: Array<{ node: IdentityGraphLayoutNode; distance: number }> = [];
+        let drawnVisibleNodes = 0;
+        scene.denseInteractionNodeLayer.clear();
         for (const node of layoutRef.current.nodes) {
           if (
             !isNodeNearViewport(
@@ -1246,18 +1245,11 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
           ) {
             continue;
           }
-          const point = screenPointForPosition(node, transform);
-          const dx = point.x - viewportCenterX;
-          const dy = point.y - viewportCenterY;
-          visibleNodes.push({ node, distance: dx * dx + dy * dy });
-        }
-        if (visibleNodes.length > DENSE_INTERACTION_NODE_LIMIT) {
-          visibleNodes.sort((left, right) => left.distance - right.distance);
-          visibleNodes.length = DENSE_INTERACTION_NODE_LIMIT;
-        }
-        scene.denseInteractionNodeLayer.clear();
-        for (const { node } of visibleNodes) {
           drawDenseGraphNode(scene.denseInteractionNodeLayer, node, graphPalette);
+          drawnVisibleNodes += 1;
+          if (drawnVisibleNodes >= DENSE_INTERACTION_NODE_LIMIT) {
+            break;
+          }
         }
       } else {
         scene.denseInteractionNodeLayer.clear();
@@ -1731,7 +1723,6 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
 
     void (async () => {
       await app.init({
-        resizeTo: canvasHost,
         backgroundAlpha: 0,
         antialias: false,
         preference: "webgl",
@@ -1747,6 +1738,7 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
       app.canvas.style.height = "100%";
       app.canvas.style.pointerEvents = "none";
       app.ticker.stop();
+      app.renderer.resize(canvasSizeRef.current.width, canvasSizeRef.current.height);
       canvasHost.appendChild(app.canvas);
 
       const world = new Container();
@@ -1785,7 +1777,7 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
         regionDisplays: new Map(),
         labelDisplays: new Map(),
       };
-      scheduleSyncScene();
+      syncSceneRef.current();
     })();
 
     return () => {
@@ -1799,7 +1791,7 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
       pixiRef.current?.app.destroy(true);
       pixiRef.current = null;
     };
-  }, [scheduleSyncScene]);
+  }, []);
 
   useEffect(() => {
     const container = containerRef.current;
@@ -1817,6 +1809,13 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
     observer.observe(container);
     return () => observer.disconnect();
   }, []);
+
+  useEffect(() => {
+    const scene = pixiRef.current;
+    if (!scene) return;
+    scene.app.renderer.resize(canvasSize.width, canvasSize.height);
+    scheduleSyncScene();
+  }, [canvasSize.height, canvasSize.width, scheduleSyncScene]);
 
   useEffect(() => {
     const container = containerRef.current;


### PR DESCRIPTION
(AI Generated).

## Summary
- (AI Generated).\nRemoves Pixi's global resize hook from the Friends graph, resizes the renderer from the component's own ResizeObserver state, keeps dense all-content interactions on the static graph layer for smoother frames, and makes Friends graph e2e cases set their own lens state.

## Testing
- npm run test:e2e -- smoke.spec.ts --grep 'map timeline playback|Friends detail rail visibility|Friends detail rail resize|selecting a graph node|clicking empty graph space|mobile Friends toolbar'\nnpm run test:e2e:perf:friends\nnpm run validate:feature