### PR TITLE
perf: keep hidden heartbeat throttling from pausing scrapers

### DIFF
--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -1595,6 +1595,10 @@ fn renderer_stale_log_after(is_visible: bool, last_visibility: &str) -> Duration
     }
 }
 
+fn renderer_stale_log_should_pause_background(is_visible: bool, last_visibility: &str) -> bool {
+    renderer_is_effectively_visible(is_visible, last_visibility)
+}
+
 fn format_bytes_for_log(bytes: u64) -> String {
     const KIB: f64 = 1024.0;
     const MIB: f64 = KIB * 1024.0;
@@ -1656,6 +1660,14 @@ mod renderer_watchdog_tests {
     fn hidden_renderer_stale_log_waits_past_webkit_timer_throttling() {
         assert!(RENDERER_HIDDEN_STALE_LOG_AFTER > Duration::from_secs(300));
         assert!(RENDERER_HIDDEN_STALE_LOG_AFTER < RENDERER_HIDDEN_RECOVERY_AFTER);
+    }
+
+    #[test]
+    fn hidden_renderer_stale_log_keeps_background_work_eligible() {
+        assert!(renderer_stale_log_should_pause_background(true, "visible"));
+        assert!(!renderer_stale_log_should_pause_background(true, "hidden"));
+        assert!(!renderer_stale_log_should_pause_background(false, "visible"));
+        assert!(!renderer_stale_log_should_pause_background(false, "hidden"));
     }
 
     #[test]
@@ -6507,6 +6519,7 @@ pub fn run() {
                                 .last_recovery_at
                                 .map(|last| last.elapsed() > recovery_threshold)
                                 .unwrap_or(true);
+                        let mut should_recycle_background_scrapers = false;
 
                         if should_log_stale {
                             let stats = collect_runtime_memory_stats(&app_for_renderer_watchdog, 0, 0);
@@ -6538,8 +6551,16 @@ pub fn run() {
                                 webkit_details
                             );
                             health.stale_logged = true;
-                            background_runtime_for_watchdog
-                                .note_renderer_stale("renderer heartbeat stale");
+                            let pause_background_work =
+                                renderer_stale_log_should_pause_background(
+                                    is_main_visible,
+                                    &health.last_visibility,
+                                );
+                            if pause_background_work {
+                                background_runtime_for_watchdog
+                                    .note_renderer_stale("renderer heartbeat stale");
+                                should_recycle_background_scrapers = true;
+                            }
                             let (active_job, active_job_age_ms) =
                                 background_runtime_for_watchdog.active_job_for_health();
                             let (safe_mode_active, safe_mode_remaining_ms, recoveries_short, recoveries_long) =
@@ -6566,6 +6587,7 @@ pub fn run() {
                                     "lastInputAgeMs": health.last_input_age_ms,
                                     "settingsOpen": health.last_settings_open,
                                     "dialogOpen": health.last_dialog_open,
+                                    "backgroundWorkPaused": pause_background_work,
                                     "nativeResidentBytes": stats.process_resident_bytes,
                                     "webkitResidentBytes": stats.webkit_total_resident_bytes,
                                     "webkitLargestProcessId": stats.webkit_largest_process_id,
@@ -6678,7 +6700,7 @@ pub fn run() {
                             );
                         }
 
-                        (should_log_stale, should_recover)
+                        (should_recycle_background_scrapers || should_recover, should_recover)
                     };
 
                     if should_recycle_scrapers {


### PR DESCRIPTION
(AI Generated).

## Summary
- Keep hidden renderer heartbeat stale diagnostics observable without marking background work stale.
- Only pause background scraper work and recycle scraper windows when the main renderer is effectively visible or recovery actually starts.

## Testing
- PATH=/Users/aubreyfalconer/dev/freed-hidden-heartbeat-backpressure/node_modules/.bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/usr/local/MacGPG2/bin:/Applications/VMware Fusion.app/Contents/Public:/usr/local/share/dotnet:~/.dotnet/tools:/usr/local/go/bin:/Library/Frameworks/Mono.framework/Versions/Current/Commands:/Users/aubreyfalconer/.nvm/versions/node/v24.14.1/bin:/Users/aubreyfalconer/.codex/tmp/arg0/codex-arg05cJIJd:/Users/aubreyfalconer/.local/bin:/opt/homebrew/opt/mysql-client/bin:/opt/homebrew/bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/Users/aubreyfalconer/.cargo/bin:/Users/aubreyfalconer/go/bin:/Users/aubreyfalconer/.cache/lm-studio/bin:/Users/aubreyfalconer/.safe-chain/bin:/Applications/Codex.app/Contents/Resources:/usr/local/bin npm run build
- cargo test renderer_watchdog_tests --manifest-path packages/desktop/src-tauri/Cargo.toml
- PATH=/Users/aubreyfalconer/dev/freed-hidden-heartbeat-backpressure/node_modules/.bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/usr/local/MacGPG2/bin:/Applications/VMware Fusion.app/Contents/Public:/usr/local/share/dotnet:~/.dotnet/tools:/usr/local/go/bin:/Library/Frameworks/Mono.framework/Versions/Current/Commands:/Users/aubreyfalconer/.nvm/versions/node/v24.14.1/bin:/Users/aubreyfalconer/.codex/tmp/arg0/codex-arg05cJIJd:/Users/aubreyfalconer/.local/bin:/opt/homebrew/opt/mysql-client/bin:/opt/homebrew/bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/Users/aubreyfalconer/.cargo/bin:/Users/aubreyfalconer/go/bin:/Users/aubreyfalconer/.cache/lm-studio/bin:/Users/aubreyfalconer/.safe-chain/bin:/Applications/Codex.app/Contents/Resources:/usr/local/bin npm run validate:feature