### PR TITLE
perf: skip hidden stale deep diagnostics

### DIFF
--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -1599,6 +1599,13 @@ fn renderer_stale_log_should_pause_background(is_visible: bool, last_visibility:
     renderer_is_effectively_visible(is_visible, last_visibility)
 }
 
+fn renderer_stale_log_should_capture_deep_diagnostic(
+    is_visible: bool,
+    last_visibility: &str,
+) -> bool {
+    renderer_is_effectively_visible(is_visible, last_visibility)
+}
+
 fn format_bytes_for_log(bytes: u64) -> String {
     const KIB: f64 = 1024.0;
     const MIB: f64 = KIB * 1024.0;
@@ -1666,8 +1673,26 @@ mod renderer_watchdog_tests {
     fn hidden_renderer_stale_log_keeps_background_work_eligible() {
         assert!(renderer_stale_log_should_pause_background(true, "visible"));
         assert!(!renderer_stale_log_should_pause_background(true, "hidden"));
-        assert!(!renderer_stale_log_should_pause_background(false, "visible"));
+        assert!(!renderer_stale_log_should_pause_background(
+            false, "visible"
+        ));
         assert!(!renderer_stale_log_should_pause_background(false, "hidden"));
+    }
+
+    #[test]
+    fn hidden_renderer_stale_log_skips_deep_diagnostics() {
+        assert!(renderer_stale_log_should_capture_deep_diagnostic(
+            true, "visible"
+        ));
+        assert!(!renderer_stale_log_should_capture_deep_diagnostic(
+            true, "hidden"
+        ));
+        assert!(!renderer_stale_log_should_capture_deep_diagnostic(
+            false, "visible"
+        ));
+        assert!(!renderer_stale_log_should_capture_deep_diagnostic(
+            false, "hidden"
+        ));
     }
 
     #[test]
@@ -6556,6 +6581,11 @@ pub fn run() {
                                     is_main_visible,
                                     &health.last_visibility,
                                 );
+                            let capture_deep_diagnostic =
+                                renderer_stale_log_should_capture_deep_diagnostic(
+                                    is_main_visible,
+                                    &health.last_visibility,
+                                );
                             if pause_background_work {
                                 background_runtime_for_watchdog
                                     .note_renderer_stale("renderer heartbeat stale");
@@ -6588,6 +6618,7 @@ pub fn run() {
                                     "settingsOpen": health.last_settings_open,
                                     "dialogOpen": health.last_dialog_open,
                                     "backgroundWorkPaused": pause_background_work,
+                                    "deepDiagnosticCaptured": capture_deep_diagnostic,
                                     "nativeResidentBytes": stats.process_resident_bytes,
                                     "webkitResidentBytes": stats.webkit_total_resident_bytes,
                                     "webkitLargestProcessId": stats.webkit_largest_process_id,
@@ -6620,15 +6651,17 @@ pub fn run() {
                                     "recoveriesInLongWindow": recoveries_long
                                 }),
                             );
-                            capture_deep_runtime_diagnostic(
-                                &app_for_renderer_watchdog,
-                                "renderer_heartbeat_stale",
-                                "renderer heartbeat stale",
-                                &stats,
-                                active_job,
-                                active_job_age_ms,
-                                false,
-                            );
+                            if capture_deep_diagnostic {
+                                capture_deep_runtime_diagnostic(
+                                    &app_for_renderer_watchdog,
+                                    "renderer_heartbeat_stale",
+                                    "renderer heartbeat stale",
+                                    &stats,
+                                    active_job,
+                                    active_job_age_ms,
+                                    false,
+                                );
+                            }
                         }
 
                         if should_recover {

--- a/packages/desktop/tests/e2e/smoke.spec.ts
+++ b/packages/desktop/tests/e2e/smoke.spec.ts
@@ -4502,6 +4502,7 @@ test("zooming the Friends graph keeps labels visible without collapsing the view
       return debug.nodeCount;
     }, { timeout: 15_000 })
     .toBeGreaterThan(1);
+  await waitForGraphPerfToSettle(page);
 
   const initial = await viewport.evaluate((element) => ({
     labels: Number((element as HTMLElement).dataset.visibleLabelCount ?? "0"),
@@ -4517,22 +4518,17 @@ test("zooming the Friends graph keeps labels visible without collapsing the view
   expect(initialDebug).not.toBeNull();
   expect(initialDebug!.metrics.visibleNodeLabelCount).toBeGreaterThan(0);
 
-  await viewport.evaluate((element) => {
-    const dispatchZoom = (deltaY: number) => {
-      element.dispatchEvent(new WheelEvent("wheel", {
-        bubbles: true,
-        cancelable: true,
-        ctrlKey: true,
-        clientX: element.getBoundingClientRect().left + element.getBoundingClientRect().width / 2,
-        clientY: element.getBoundingClientRect().top + element.getBoundingClientRect().height / 2,
-        deltaY,
-      }));
-    };
-    dispatchZoom(-260);
-    dispatchZoom(-260);
-    dispatchZoom(-260);
-    dispatchZoom(-260);
-  });
+  const box = await viewport.boundingBox();
+  expect(box).not.toBeNull();
+  await page.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2);
+  await page.keyboard.down("Control");
+  try {
+    for (let index = 0; index < 4; index += 1) {
+      await page.mouse.wheel(0, -260);
+    }
+  } finally {
+    await page.keyboard.up("Control");
+  }
 
   await expect
     .poll(async () => {

--- a/packages/ui/src/components/friends/FriendGraph.tsx
+++ b/packages/ui/src/components/friends/FriendGraph.tsx
@@ -809,6 +809,7 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
   const hoveredNodeIdRef = useRef<string | null>(null);
   const transformRef = useRef<ViewTransform>({ ...FRIEND_GRAPH_DEFAULT_TRANSFORM });
   const hasFittedInitialLayoutRef = useRef(false);
+  const hasUserAdjustedTransformRef = useRef(false);
   const latestLayoutRequestIdRef = useRef(0);
   const latestResolvedLayoutRequestIdRef = useRef(0);
   const pendingLayoutTimeoutsRef = useRef<Map<number, number>>(new Map());
@@ -1962,7 +1963,11 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
 
   useEffect(() => {
     if (!layoutReady && layoutRef.current.nodes.length > 0) {
-      fitAll();
+      if (!hasUserAdjustedTransformRef.current) {
+        fitAll();
+      } else {
+        scheduleSyncScene();
+      }
       return;
     }
     scheduleSyncScene();
@@ -2005,6 +2010,7 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
 
   const handleWheel = useCallback((event: React.WheelEvent<HTMLDivElement>) => {
     event.preventDefault();
+    hasUserAdjustedTransformRef.current = true;
     markInteractive();
     if (event.ctrlKey || event.metaKey) {
       const delta = Math.exp(-event.deltaY * TRACKPAD_PINCH_ZOOM_SPEED);
@@ -2133,6 +2139,7 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
         x: localX - pinch.initialWorldPoint.x * scale,
         y: localY - pinch.initialWorldPoint.y * scale,
       };
+      hasUserAdjustedTransformRef.current = true;
       scheduleSyncScene();
       markInteractive();
       event.preventDefault();
@@ -2164,6 +2171,7 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
         x: drag.originX + deltaX,
         y: drag.originY + deltaY,
       };
+      hasUserAdjustedTransformRef.current = true;
       if (event.pointerType === "touch") {
         event.preventDefault();
       }


### PR DESCRIPTION
(AI Generated).

## Summary
- Keeps hidden renderer heartbeat stale events lightweight by skipping expensive sample and vmmap diagnostics unless the renderer was visibly foregrounded. Also keeps Friends graph wheel and pinch transforms from being overwritten by a late pre-ready auto-fit.

## Testing
- cargo test renderer_watchdog_tests
- npm run test:e2e -- smoke.spec.ts --grep "zooming the Friends graph|pinching the Friends graph"
- npm run test:e2e:perf:friends
- npm run validate:feature