### PR TITLE
fix: stabilize friends pinch regression

### DIFF
--- a/packages/desktop/tests/e2e/smoke.spec.ts
+++ b/packages/desktop/tests/e2e/smoke.spec.ts
@@ -4596,6 +4596,7 @@ test("pinching the Friends graph zooms around the active two-touch midpoint", as
       return Boolean(debug && debug.qualityMode === "settled" && debug.transform.scale > 0);
     }, { timeout: 10_000 })
     .toBe(true);
+  await waitForGraphPerfToSettle(page);
 
   const box = await readGraphViewportBox(page);
   if (!box) {
@@ -4604,6 +4605,7 @@ test("pinching the Friends graph zooms around the active two-touch midpoint", as
 
   const before = await readGraphDebug(page);
   expect(before).not.toBeNull();
+  const sceneSyncBeforeGesture = before!.metrics.sceneSyncCount;
   const centerX = box.x + box.width / 2;
   const centerY = box.y + box.height / 2;
   const initialWorldPoint = {
@@ -4651,8 +4653,16 @@ test("pinching the Friends graph zooms around the active two-touch midpoint", as
     await nextFrame();
     dispatchTouchPointer("pointermove", 12, gesture.centerX + 140 + gesture.panDelta.x, gesture.centerY + 18 + gesture.panDelta.y, false);
     await nextFrame();
+    dispatchTouchPointer("pointermove", 11, gesture.centerX - 140 + gesture.panDelta.x, gesture.centerY - 18 + gesture.panDelta.y, true);
+    dispatchTouchPointer("pointermove", 12, gesture.centerX + 140 + gesture.panDelta.x, gesture.centerY + 18 + gesture.panDelta.y, false);
+    await nextFrame();
   }, { centerX, centerY, panDelta });
 
+  await expect
+    .poll(async () => (await readGraphDebug(page))?.metrics.sceneSyncCount ?? 0, {
+      timeout: 8_000,
+    })
+    .toBeGreaterThanOrEqual(sceneSyncBeforeGesture + 2);
   await expect
     .poll(async () => (await readGraphDebug(page))?.transform.scale ?? before!.transform.scale, {
       timeout: 8_000,


### PR DESCRIPTION
(AI Generated).

## Summary
- The Friends graph pinch regression now waits for a settled baseline and final scene syncs before checking the pinch midpoint.

## Testing
- npm run test:e2e -- smoke.spec.ts --grep 'pinching the Friends graph zooms around the active two-touch midpoint' --repeat-each=5
- npm run validate:feature