### PR TITLE
fix: stabilize friends empty click regression

### DIFF
--- a/packages/desktop/tests/e2e/smoke.spec.ts
+++ b/packages/desktop/tests/e2e/smoke.spec.ts
@@ -3521,8 +3521,9 @@ test("clicking empty graph space closes the collapsed Friends detail card", asyn
   const viewport = page.getByTestId("friend-graph-viewport");
   await expect(viewport).toBeVisible({ timeout: 10_000 });
   await page.getByRole("button", { name: "Fit all" }).click();
+  await waitForGraphPerfToSettle(page, 20_000);
 
-  const friendPoint = await waitForGraphNodeScreenPoint(page, { personId: "friend-ada" });
+  const friendPoint = await waitForGraphNodeScreenPoint(page, { personId: "friend-ada" }, 20_000);
   await page.mouse.click(friendPoint.x, friendPoint.y);
   await page.waitForFunction(() => {
     const store = (window as Record<string, unknown>).__FREED_STORE__ as


### PR DESCRIPTION
(AI Generated).

## Summary
- The collapsed Friends detail-card empty-click regression now waits for Fit all scene stability before clicking the graph node.

## Testing
- npm run test:e2e -- smoke.spec.ts --grep 'clicking empty graph space closes the collapsed Friends detail card' --repeat-each=5
- npm run validate:feature