### PR TITLE
perf: cull dense friends graph during interaction

### DIFF
--- a/packages/desktop/tests/e2e/perf-friends.spec.ts
+++ b/packages/desktop/tests/e2e/perf-friends.spec.ts
@@ -14,6 +14,7 @@ const DROPPED_FRAME_BUDGET = 16;
 const CI_DROPPED_FRAME_BUDGET = 40;
 const LONG_TASK_COUNT_BUDGET = 2;
 const LONG_TASK_WORST_BUDGET_MS = 140;
+const DENSE_INTERACTION_NODE_BUDGET = 900;
 
 async function readGraphDebug(page: Page) {
   return page.evaluate(() => {
@@ -39,6 +40,10 @@ async function readGraphDebug(page: Page) {
           visibleLabelCount: number;
           visibleNodeLabelCount: number;
           transformOnlySyncCount: number;
+          denseRenderMode: "dense" | "containers";
+          denseInteractionEligible: boolean;
+          denseInteractionNodeCount: number;
+          denseInteractionCulled: boolean;
         };
       };
     }).__FREED_GRAPH_DEBUG__ ?? null;
@@ -241,6 +246,8 @@ test("Friends view handles 1,600 visible people while zooming and panning", asyn
 
   expect(mountElapsed).toBeLessThan(MOUNT_BUDGET_MS);
   expect(mountedRows).toBeLessThanOrEqual(FRIEND_ROW_MOUNT_BUDGET);
+  expect(initialDebug!.metrics.denseRenderMode).toBe("dense");
+  expect(initialDebug!.metrics.denseInteractionEligible).toBe(true);
   expect(initialDebug!.metrics.layoutMs).toBeLessThan(GRAPH_LAYOUT_BUDGET_MS);
   expect(initialDebug!.metrics.sceneSyncMs).toBeLessThan(GRAPH_SCENE_SYNC_BUDGET_MS);
   expect(initialDebug!.metrics.avatarDisplayCount).toBeLessThanOrEqual(PERSON_COUNT);
@@ -251,6 +258,7 @@ test("Friends view handles 1,600 visible people while zooming and panning", asyn
     await page.waitForTimeout(1_400);
   });
 
+  let denseInteractionNodeCount = 0;
   const interaction = await collectLongTasksDuring(page, () =>
     measureFps(page, async () => {
       for (let index = 0; index < 18; index += 1) {
@@ -267,6 +275,15 @@ test("Friends view handles 1,600 visible people while zooming and panning", asyn
         });
         await page.waitForTimeout(16);
       }
+
+      await expect
+        .poll(async () => {
+          const debug = await readGraphDebug(page);
+          const nodeCount = debug?.metrics.denseInteractionNodeCount ?? 0;
+          denseInteractionNodeCount = Math.max(denseInteractionNodeCount, nodeCount);
+          return nodeCount;
+        }, { timeout: 5_000 })
+        .toBeGreaterThan(0);
 
       await page.mouse.move(box.x + box.width * 0.52, box.y + box.height * 0.46);
       await page.mouse.down();
@@ -297,9 +314,12 @@ test("Friends view handles 1,600 visible people while zooming and panning", asyn
   console.log(`[PERF] Friends interaction long tasks: ${interaction.count.toLocaleString()}`);
   console.log(`[PERF] Friends interaction worst long task: ${interaction.worstMs.toFixed(1)} ms`);
   console.log(`[PERF] Friends interaction scene sync: ${afterInteraction!.metrics.sceneSyncMs.toFixed(1)} ms`);
+  console.log(`[PERF] Friends dense interaction nodes: ${denseInteractionNodeCount.toLocaleString()}`);
 
   expect(afterInteraction!.transform.scale).toBeGreaterThan(initialDebug!.transform.scale);
   expect(interaction.result.sampleCount).toBeGreaterThan(0);
+  expect(denseInteractionNodeCount).toBeGreaterThan(0);
+  expect(denseInteractionNodeCount).toBeLessThanOrEqual(DENSE_INTERACTION_NODE_BUDGET);
   if (process.env.CI) {
     expect(afterInteraction!.metrics.sceneSyncMs).toBeLessThan(GRAPH_SCENE_SYNC_BUDGET_MS);
     return;

--- a/packages/ui/src/components/friends/FriendGraph.tsx
+++ b/packages/ui/src/components/friends/FriendGraph.tsx
@@ -194,7 +194,7 @@ const FAST_LAYOUT_NODE_THRESHOLD = 1_600;
 const NODE_LAYER_TEXTURE_CACHE_MAX_NODES = 1_200;
 const INTERACTIVE_NODE_CULL_THRESHOLD = 1_200;
 const DENSE_GRAPH_SINGLE_LAYER_THRESHOLD = 1_200;
-const DENSE_INTERACTION_CULL_THRESHOLD = 4_800;
+const DENSE_INTERACTION_CULL_THRESHOLD = 1_600;
 const DENSE_INTERACTION_NODE_LIMIT = 900;
 const DENSE_INTERACTION_VIEWPORT_PADDING = 96;
 const CONTROL_BASE = "theme-graph-control rounded-xl px-3 py-1.5 text-xs";
@@ -240,6 +240,10 @@ interface GraphPerfSnapshot {
   visibleLabelCount: number;
   visibleNodeLabelCount: number;
   visibleProviderLabelCount: number;
+  denseRenderMode: "dense" | "containers";
+  denseInteractionEligible: boolean;
+  denseInteractionNodeCount: number;
+  denseInteractionCulled: boolean;
   qualityMode: GraphQualityMode;
 }
 
@@ -853,6 +857,10 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
     visibleLabelCount: 0,
     visibleNodeLabelCount: 0,
     visibleProviderLabelCount: 0,
+    denseRenderMode: "containers",
+    denseInteractionEligible: false,
+    denseInteractionNodeCount: 0,
+    denseInteractionCulled: false,
     qualityMode: "settled",
   });
   const [canvasSize, setCanvasSize] = useState({ width: 900, height: DEFAULT_HEIGHT });
@@ -945,12 +953,14 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
       highlighted.size === 0
         ? "dense"
         : "containers";
-    const useDenseInteractionLayer =
+    const denseInteractionEligible =
       denseRenderMode === "dense" &&
       graphNodeCount >= DENSE_INTERACTION_CULL_THRESHOLD &&
-      qualityMode === "interactive" &&
       !accountDrag &&
       highlighted.size === 0;
+    const useDenseInteractionLayer =
+      denseInteractionEligible &&
+      qualityMode === "interactive";
     const queueAvatarRefresh = () => {
       lastStaticRenderKeyRef.current = "";
       requestAnimationFrame(() => syncSceneRef.current());
@@ -967,6 +977,8 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
 
     scene.world.position.set(transform.x, transform.y);
     scene.world.scale.set(transform.scale);
+    let denseInteractionNodeCount = 0;
+    let denseInteractionCulled = false;
     const isInteractivePaint = qualityMode === "interactive" && !accountDrag;
     const shouldCacheNodeLayer =
       isInteractivePaint &&
@@ -1249,9 +1261,11 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
           drawDenseGraphNode(scene.denseInteractionNodeLayer, node, graphPalette);
           drawnVisibleNodes += 1;
           if (drawnVisibleNodes >= DENSE_INTERACTION_NODE_LIMIT) {
+            denseInteractionCulled = true;
             break;
           }
         }
+        denseInteractionNodeCount = drawnVisibleNodes;
       } else {
         scene.denseInteractionNodeLayer.clear();
       }
@@ -1575,6 +1589,10 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
     perfSnapshotRef.current.visibleLabelCount = visibleLabelCount;
     perfSnapshotRef.current.visibleNodeLabelCount = visibleLabelIdsRef.current.length;
     perfSnapshotRef.current.visibleProviderLabelCount = visibleProviderLabelCount;
+    perfSnapshotRef.current.denseRenderMode = denseRenderMode;
+    perfSnapshotRef.current.denseInteractionEligible = denseInteractionEligible;
+    perfSnapshotRef.current.denseInteractionNodeCount = denseInteractionNodeCount;
+    perfSnapshotRef.current.denseInteractionCulled = denseInteractionCulled;
     let avatarDisplayCount = 0;
     for (const display of scene.nodeDisplays.values()) {
       if (display.avatarSprite) avatarDisplayCount += 1;


### PR DESCRIPTION
(AI Generated).

## Summary
- Lower the dense Friends interaction culling threshold so 1,600-person graphs use the capped viewport-near interaction layer while panning and zooming.
- Expose dense interaction eligibility and node-count telemetry through the existing graph debug snapshot.

## Testing
- npm run validate:feature
