### PR TITLE
perf: isolate dense map marker paint

### DIFF
--- a/packages/ui/src/components/map/MapSurface.tsx
+++ b/packages/ui/src/components/map/MapSurface.tsx
@@ -356,6 +356,10 @@ function mapStyles(interactive: boolean) {
       filter: none;
     }
 
+    .freed-map-shell[data-map-moving="true"] .freed-map-marker {
+      will-change: transform;
+    }
+
     .freed-map-shell[data-map-moving="true"] .freed-map-marker-glow,
     .freed-map-shell[data-map-moving="true"] .freed-map-marker-tint,
     .freed-map-shell[data-map-moving="true"] .freed-map-marker-halo,

--- a/packages/ui/src/components/map/MarkerElement.test.ts
+++ b/packages/ui/src/components/map/MarkerElement.test.ts
@@ -106,6 +106,7 @@ describe("createMarkerElement", () => {
     const element = createMarkerElement(marker({ groupCount: 1234 }), palette);
 
     expect(element.querySelector(".freed-map-marker-body")).toBeInstanceOf(HTMLDivElement);
+    expect(element.style.contain).toBe("layout paint style");
     expect(element.querySelector(".freed-map-marker-glow")).toBeInstanceOf(HTMLDivElement);
     expect(element.querySelector(".freed-map-marker-image")).toBeInstanceOf(HTMLImageElement);
     expect(element.querySelector(".freed-map-marker-tint")).toBeInstanceOf(HTMLDivElement);

--- a/packages/ui/src/components/map/MarkerElement.ts
+++ b/packages/ui/src/components/map/MarkerElement.ts
@@ -73,6 +73,7 @@ export function createMarkerElement(
   }
   el.style.cssText = [
     "position:absolute",
+    "contain:layout paint style",
     "transform-origin:center center",
   ].join(";");
 


### PR DESCRIPTION
(AI Generated).

## Summary
- Contain map marker layout and paint so dense marker sets do less style and paint work during zoom or pan.
- Limit transform compositing hints to active map movement, keeping idle marker cost unchanged.

## Testing
- node node_modules/vitest/vitest.mjs run packages/ui/src/components/map/MarkerElement.test.ts
- npm run test:e2e -- perf-map.spec.ts
- npm run validate:feature