### PR TITLE
perf: classify hidden renderer timer throttling

### DIFF
--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -1420,6 +1420,7 @@ struct RendererHeartbeatPayload {
     uptime_ms: Option<u64>,
     app_phase: Option<String>,
     event_loop_lag_ms: Option<f64>,
+    hidden_timer_throttled: Option<bool>,
     dom_node_count: Option<u64>,
     renderer_heap_used_bytes: Option<u64>,
     renderer_heap_total_bytes: Option<u64>,
@@ -1439,6 +1440,7 @@ struct RendererHeartbeatStatus {
     last_uptime_ms: Option<u64>,
     last_app_phase: Option<String>,
     last_event_loop_lag_ms: Option<f64>,
+    last_hidden_timer_throttled: Option<bool>,
     last_dom_node_count: Option<u64>,
     last_renderer_heap_used_bytes: Option<u64>,
     last_renderer_heap_total_bytes: Option<u64>,
@@ -1465,6 +1467,7 @@ impl RendererHeartbeatStatus {
             last_uptime_ms: None,
             last_app_phase: None,
             last_event_loop_lag_ms: None,
+            last_hidden_timer_throttled: None,
             last_dom_node_count: None,
             last_renderer_heap_used_bytes: None,
             last_renderer_heap_total_bytes: None,
@@ -1500,6 +1503,7 @@ impl RendererHeartbeatStatus {
         self.last_uptime_ms = payload.uptime_ms;
         self.last_app_phase = payload.app_phase.clone();
         self.last_event_loop_lag_ms = payload.event_loop_lag_ms;
+        self.last_hidden_timer_throttled = payload.hidden_timer_throttled;
         self.last_dom_node_count = payload.dom_node_count;
         self.last_renderer_heap_used_bytes = payload.renderer_heap_used_bytes;
         self.last_renderer_heap_total_bytes = payload.renderer_heap_total_bytes;
@@ -1524,6 +1528,7 @@ impl RendererHeartbeatStatus {
         self.last_uptime_ms = None;
         self.last_app_phase = None;
         self.last_event_loop_lag_ms = None;
+        self.last_hidden_timer_throttled = None;
         self.last_dom_node_count = None;
         self.last_renderer_heap_used_bytes = None;
         self.last_renderer_heap_total_bytes = None;
@@ -1722,6 +1727,7 @@ mod renderer_watchdog_tests {
             uptime_ms: Some(1_000),
             app_phase: Some("ready".to_string()),
             event_loop_lag_ms: Some(4.0),
+            hidden_timer_throttled: Some(false),
             dom_node_count: Some(100),
             renderer_heap_used_bytes: Some(1024),
             renderer_heap_total_bytes: Some(2048),
@@ -1737,6 +1743,7 @@ mod renderer_watchdog_tests {
         assert!(status.last_recovery_at.is_none());
         assert_eq!(status.last_seq, 7);
         assert_eq!(status.last_page_load_id.as_deref(), Some("page-1"));
+        assert_eq!(status.last_hidden_timer_throttled, Some(false));
     }
 
     #[test]
@@ -6453,6 +6460,7 @@ pub fn run() {
                         "uptimeMs": payload.uptime_ms,
                         "appPhase": payload.app_phase.clone(),
                         "eventLoopLagMs": payload.event_loop_lag_ms,
+                        "hiddenTimerThrottled": payload.hidden_timer_throttled,
                         "domNodeCount": payload.dom_node_count,
                         "rendererHeapUsedBytes": payload.renderer_heap_used_bytes,
                         "rendererHeapTotalBytes": payload.renderer_heap_total_bytes,
@@ -6622,6 +6630,7 @@ pub fn run() {
                                     "uptimeMs": health.last_uptime_ms,
                                     "appPhase": health.last_app_phase.clone(),
                                     "eventLoopLagMs": health.last_event_loop_lag_ms,
+                                    "hiddenTimerThrottled": health.last_hidden_timer_throttled,
                                     "domNodeCount": health.last_dom_node_count,
                                     "rendererHeapUsedBytes": health.last_renderer_heap_used_bytes,
                                     "rendererHeapTotalBytes": health.last_renderer_heap_total_bytes,

--- a/packages/desktop/src/App.tsx
+++ b/packages/desktop/src/App.tsx
@@ -106,6 +106,7 @@ import {
   type PendingDesktopUpdate,
   resolveDesktopDownloadFallbackUrl,
 } from "./lib/desktop-updater";
+import { rendererHeartbeatTiming } from "./lib/renderer-heartbeat";
 
 const UPDATE_CHECK_INTERVAL_MS = 30 * 60 * 1000; // 30 minutes
 const IS_LOCAL_PREVIEW = import.meta.env.DEV && import.meta.env.VITE_TEST_TAURI !== "1";
@@ -315,16 +316,24 @@ function App() {
           totalJSHeapSize?: number;
         };
       };
+      const visibility = document.visibilityState;
+      const timing = rendererHeartbeatTiming(
+        visibility,
+        now,
+        expectedHeartbeatAt,
+        RENDERER_HEARTBEAT_INTERVAL_MS,
+      );
       const payload = {
         seq: heartbeatSeq,
         ts: Date.now(),
         reason,
-        visibility: document.visibilityState,
+        visibility,
         href: window.location.href,
         pageLoadId,
         uptimeMs: Math.max(0, Math.round(now - startedAt)),
         appPhase: legalAccepted ? "ready" : "legal",
-        eventLoopLagMs: Math.max(0, now - expectedHeartbeatAt),
+        eventLoopLagMs: timing.eventLoopLagMs,
+        hiddenTimerThrottled: timing.hiddenTimerThrottled,
         domNodeCount: document.getElementsByTagName("*").length,
         rendererHeapUsedBytes: perf.memory?.usedJSHeapSize,
         rendererHeapTotalBytes: perf.memory?.totalJSHeapSize,

--- a/packages/desktop/src/lib/renderer-heartbeat.test.ts
+++ b/packages/desktop/src/lib/renderer-heartbeat.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { rendererHeartbeatTiming } from "./renderer-heartbeat";
+
+describe("rendererHeartbeatTiming", () => {
+  it("reports foreground event-loop lag while visible", () => {
+    expect(rendererHeartbeatTiming("visible", 46_000, 31_000, 15_000)).toEqual({
+      eventLoopLagMs: 15_000,
+      hiddenTimerThrottled: false,
+    });
+  });
+
+  it("does not count hidden timer throttling as foreground event-loop lag", () => {
+    expect(rendererHeartbeatTiming("hidden", 496_000, 16_000, 15_000)).toEqual({
+      eventLoopLagMs: null,
+      hiddenTimerThrottled: true,
+    });
+  });
+
+  it("keeps normal hidden heartbeats distinct from throttled hidden heartbeats", () => {
+    expect(rendererHeartbeatTiming("hidden", 20_000, 16_000, 15_000)).toEqual({
+      eventLoopLagMs: null,
+      hiddenTimerThrottled: false,
+    });
+  });
+});

--- a/packages/desktop/src/lib/renderer-heartbeat.ts
+++ b/packages/desktop/src/lib/renderer-heartbeat.ts
@@ -1,0 +1,18 @@
+export interface RendererHeartbeatTiming {
+  eventLoopLagMs: number | null;
+  hiddenTimerThrottled: boolean;
+}
+
+export function rendererHeartbeatTiming(
+  visibility: DocumentVisibilityState,
+  nowMs: number,
+  expectedHeartbeatAtMs: number,
+  intervalMs: number,
+): RendererHeartbeatTiming {
+  const lagMs = Math.max(0, nowMs - expectedHeartbeatAtMs);
+  const hidden = visibility !== "visible";
+  return {
+    eventLoopLagMs: hidden ? null : lagMs,
+    hiddenTimerThrottled: hidden && lagMs > intervalMs,
+  };
+}


### PR DESCRIPTION
(AI Generated).

## Summary
- Stop reporting hidden-page WebKit timer throttling as foreground event-loop lag in renderer heartbeat telemetry.
- Add a hiddenTimerThrottled runtime-health field so soak logs can distinguish normal hidden renderer throttling from real jank.

## Testing
- node ../../node_modules/vitest/vitest.mjs run src/lib/renderer-heartbeat.test.ts
- PATH=/Users/aubreyfalconer/dev/freed-hidden-heartbeat-telemetry/node_modules/.bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/usr/local/MacGPG2/bin:/Applications/VMware Fusion.app/Contents/Public:/usr/local/share/dotnet:~/.dotnet/tools:/usr/local/go/bin:/Library/Frameworks/Mono.framework/Versions/Current/Commands:/Users/aubreyfalconer/.nvm/versions/node/v24.14.1/bin:/Users/aubreyfalconer/.codex/tmp/arg0/codex-arg05cJIJd:/Users/aubreyfalconer/.local/bin:/opt/homebrew/opt/mysql-client/bin:/opt/homebrew/bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/Users/aubreyfalconer/.cargo/bin:/Users/aubreyfalconer/go/bin:/Users/aubreyfalconer/.cache/lm-studio/bin:/Users/aubreyfalconer/.safe-chain/bin:/Applications/Codex.app/Contents/Resources:/usr/local/bin npm run build
- cargo test heartbeat_after_recovery_resets_recovery_state -- --nocapture && cargo test renderer_stale_log_threshold_uses_hidden_timer_slack -- --nocapture && cargo test hidden_renderer_stale_skips_renderer_recovery -- --nocapture
- npm run validate:feature