### PR TITLE
fix: restore compact read-scroll session resets

### DIFF
--- a/packages/ui/src/components/feed/FeedView.tsx
+++ b/packages/ui/src/components/feed/FeedView.tsx
@@ -4,6 +4,7 @@ import { FeedList } from "./FeedList.js";
 import { ReaderView } from "./ReaderView.js";
 import { FeedItem as FeedItemCard } from "./FeedItem.js";
 import { useReadOnScrollTracker } from "./useReadOnScrollTracker.js";
+import { buildReadTrackListKey } from "./read-on-scroll.js";
 import { AddFeedDialog } from "../AddFeedDialog.js";
 import { useAppStore, usePlatform } from "../../context/PlatformContext.js";
 import { useSearchResults } from "../../hooks/useSearchResults.js";
@@ -99,11 +100,7 @@ const CompactFeedPanel = memo(function CompactFeedPanel({
     [items, itemHeight, storyItemHeight],
   );
   const readListKey = useMemo(
-    () => {
-      const firstId = items[0]?.globalId ?? "";
-      const lastId = items[items.length - 1]?.globalId ?? "";
-      return `compact:${items.length}:${firstId}:${lastId}`;
-    },
+    () => buildReadTrackListKey(items),
     [items],
   );
   const getReadScrollMetrics = useCallback(() => ({

--- a/packages/ui/src/components/feed/read-on-scroll.ts
+++ b/packages/ui/src/components/feed/read-on-scroll.ts
@@ -16,6 +16,12 @@ export interface ListViewportMetrics {
   viewportBottom: number;
 }
 
+export function buildReadTrackListKey<TItem extends { globalId: string }>(
+  items: TItem[],
+): string {
+  return items.map((item) => item.globalId).join("|");
+}
+
 export function collectUnreadIdsFromRows<TItem extends { globalId: string; userState: { readAt?: number } }>(
   rows: Array<ReadTrackSourceRow<TItem>>,
   startIndex: number,

--- a/packages/ui/src/components/feed/useReadOnScrollTracker.test.tsx
+++ b/packages/ui/src/components/feed/useReadOnScrollTracker.test.tsx
@@ -1,0 +1,118 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act, useEffect, useMemo } from "react";
+import type { Root } from "react-dom/client";
+import { createRoot } from "react-dom/client";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { useReadOnScrollTracker } from "./useReadOnScrollTracker";
+import { buildReadTrackListKey } from "./read-on-scroll";
+
+type TestItem = {
+  globalId: string;
+  userState: {
+    readAt?: number;
+  };
+};
+
+type ReadProcessor = ReturnType<typeof useReadOnScrollTracker<TestItem>>;
+
+function item(globalId: string, readAt?: number): TestItem {
+  return { globalId, userState: { readAt } };
+}
+
+function TrackerHarness({
+  items,
+  markItemsAsRead,
+  onReady,
+}: {
+  items: TestItem[];
+  markItemsAsRead: (ids: string[]) => Promise<void>;
+  onReady: (process: ReadProcessor) => void;
+}) {
+  const listKey = useMemo(() => buildReadTrackListKey(items), [items]);
+  const processReadOnScroll = useReadOnScrollTracker({
+    surface: "compact-feed",
+    listKey,
+    rows: items,
+    items,
+    markReadOnScroll: true,
+    getScrollMetrics: () => ({
+      rawScrollTop: 0,
+      viewportHeight: 400,
+      scrollMargin: 0,
+    }),
+    markItemsAsRead,
+  });
+
+  useEffect(() => {
+    onReady(processReadOnScroll);
+  }, [onReady, processReadOnScroll]);
+
+  return null;
+}
+
+describe("useReadOnScrollTracker", () => {
+  beforeAll(() => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  afterAll(() => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = false;
+  });
+
+  it("resets compact-feed session state when the item ids change", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root: Root = createRoot(container);
+    const markItemsAsRead = vi.fn<(ids: string[]) => Promise<void>>().mockResolvedValue(undefined);
+    let processReadOnScroll: ReadProcessor | null = null;
+    const onReady = (process: ReadProcessor) => {
+      processReadOnScroll = process;
+    };
+    const virtualizer = {
+      getVirtualItems: () => [{ index: 0, end: 200 }],
+      getTotalSize: () => 400,
+      options: { scrollMargin: 0 },
+    };
+
+    await act(async () => {
+      root.render(
+        <TrackerHarness
+          items={[item("a", 1), item("b"), item("c"), item("d", 1)]}
+          markItemsAsRead={markItemsAsRead}
+          onReady={onReady}
+        />,
+      );
+    });
+
+    await act(async () => {
+      processReadOnScroll?.(virtualizer, "element");
+    });
+
+    expect(markItemsAsRead).toHaveBeenCalledTimes(1);
+    expect(markItemsAsRead).toHaveBeenLastCalledWith(["b", "c"]);
+
+    await act(async () => {
+      root.render(
+        <TrackerHarness
+          items={[item("a", 1), item("x"), item("y"), item("d", 1)]}
+          markItemsAsRead={markItemsAsRead}
+          onReady={onReady}
+        />,
+      );
+    });
+
+    await act(async () => {
+      processReadOnScroll?.(virtualizer, "element");
+    });
+
+    expect(markItemsAsRead).toHaveBeenLastCalledWith(["x", "y"]);
+    expect(markItemsAsRead.mock.calls).toContainEqual([["x", "y"]]);
+
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+});


### PR DESCRIPTION
(AI Generated).

## Summary
- restore exact compact feed read-on-scroll session keys by hashing the full item id list
- keep the key builder in the shared read-on-scroll helper so the tracker and tests share one code path
- add a regression test that proves a middle-of-list swap still marks unread items after the list identity changes

## Testing
- node node_modules/vitest/vitest.mjs run packages/ui/src/components/feed/useReadOnScrollTracker.test.tsx packages/ui/src/components/feed/read-on-scroll.test.ts
- npm run validate:feature

## Notes
- validate:feature cleared typecheck, builds, unit lanes, and smoke lanes locally
- the desktop Friends perf lane was nondeterministic locally while this feed-only patch was under test, so I also reran the targeted feed regression and isolated Friends perf spec separately during verification