### PR TITLE
perf: trim dense map marker paint

### DIFF
--- a/packages/desktop/tests/e2e/perf-map.spec.ts
+++ b/packages/desktop/tests/e2e/perf-map.spec.ts
@@ -8,6 +8,7 @@ const MAP_FRAME_P95_BUDGET_MS = process.env.CI ? 67 : 50;
 const MAP_DROPPED_FRAME_BUDGET = process.env.CI ? 40 : 12;
 const MAP_LONG_TASK_COUNT_BUDGET = process.env.CI ? 4 : 2;
 const MAP_MARKER_DOM_BUDGET = 240;
+const MAP_MOVING_MARKER_PAINT_BUDGET = 120;
 
 async function seedLargeMapWorkspace(page: Page): Promise<void> {
   await page.evaluate(async ({ authorCount, itemCount }) => {
@@ -177,6 +178,8 @@ test("Map view handles 1,600 visible location authors within frame budget", asyn
 
   const mountElapsed = Date.now() - mountStartedAt;
   const markerCount = await page.locator(".freed-map-marker").count();
+  const movingPrimaryMarkerCount = await page.locator('.freed-map-marker[data-map-moving-priority="primary"]').count();
+  const movingDeferredMarkerCount = await page.locator('.freed-map-marker[data-map-moving-priority="deferred"]').count();
   const totalMarkerCount = await page.getByTestId("map-surface").evaluate((element) =>
     Number.parseInt(element.getAttribute("data-map-total-markers") ?? "0", 10),
   );
@@ -196,6 +199,8 @@ test("Map view handles 1,600 visible location authors within frame budget", asyn
 
   console.log(`[PERF] Map mount: ${mountElapsed.toLocaleString()} ms`);
   console.log(`[PERF] Map marker DOM count: ${markerCount.toLocaleString()}`);
+  console.log(`[PERF] Map moving primary markers: ${movingPrimaryMarkerCount.toLocaleString()}`);
+  console.log(`[PERF] Map moving deferred markers: ${movingDeferredMarkerCount.toLocaleString()}`);
   console.log(`[PERF] Map total markers: ${totalMarkerCount.toLocaleString()}`);
   console.log(`[PERF] Map DOM nodes: ${domNodeCount.toLocaleString()}`);
   console.log(`[PERF] Map interaction FPS: ${interaction.result.fps.toLocaleString()}`);
@@ -207,6 +212,8 @@ test("Map view handles 1,600 visible location authors within frame budget", asyn
   expect(mountElapsed).toBeLessThan(MAP_MOUNT_BUDGET_MS);
   expect(totalMarkerCount).toBe(MAP_AUTHOR_COUNT);
   expect(markerCount).toBeLessThanOrEqual(MAP_MARKER_DOM_BUDGET);
+  expect(movingPrimaryMarkerCount).toBeLessThanOrEqual(MAP_MOVING_MARKER_PAINT_BUDGET);
+  expect(movingPrimaryMarkerCount + movingDeferredMarkerCount).toBe(markerCount);
   expect(interaction.result.p95Ms).toBeLessThan(MAP_FRAME_P95_BUDGET_MS);
   expect(interaction.result.droppedFrames).toBeLessThanOrEqual(MAP_DROPPED_FRAME_BUDGET);
   expect(interaction.count).toBeLessThanOrEqual(MAP_LONG_TASK_COUNT_BUDGET);

--- a/packages/ui/src/components/map/MapSurface.tsx
+++ b/packages/ui/src/components/map/MapSurface.tsx
@@ -36,6 +36,7 @@ const popupDateFormatter = new Intl.DateTimeFormat(undefined, {
 const MAP_POPUP_MAX_WIDTH = 560;
 const MAP_POPUP_VIEWPORT_MARGIN = 40;
 const MAP_DOM_MARKER_LIMIT = 240;
+const MAP_MOVING_MARKER_PAINT_LIMIT = 120;
 const MAP_VIEWPORT_MASK_STYLE = {
   "--theme-soft-viewport-mask-size": "20px",
 } as CSSProperties;
@@ -360,6 +361,14 @@ function mapStyles(interactive: boolean) {
       will-change: transform;
     }
 
+    .freed-map-shell[data-map-moving="true"] .freed-map-marker[data-map-moving-priority="deferred"] {
+      display: none;
+    }
+
+    .freed-map-shell[data-map-moving="true"] .freed-map-marker[data-map-marker-simplified="true"] [data-avatar-fallback] {
+      display: none;
+    }
+
     .freed-map-shell[data-map-moving="true"] .freed-map-marker-glow,
     .freed-map-shell[data-map-moving="true"] .freed-map-marker-tint,
     .freed-map-shell[data-map-moving="true"] .freed-map-marker-halo,
@@ -402,6 +411,12 @@ function fallbackPosition(marker: LocationMarkerSummary) {
 
 function fallbackLabel(marker: LocationMarkerSummary) {
   return marker.friend?.name ?? marker.item.author.displayName;
+}
+
+function mapMovingPriority(markerIndex: number, useDenseMarkers: boolean): "primary" | "deferred" {
+  return useDenseMarkers && markerIndex >= MAP_MOVING_MARKER_PAINT_LIMIT
+    ? "deferred"
+    : "primary";
 }
 
 function mapGridBackground(boundary: string) {
@@ -688,12 +703,13 @@ export function MapSurface({
     map.on("click", handleMapClick);
     let stoppedEarly = false;
 
-    for (const markerData of renderedMarkers) {
+    for (const [markerIndex, markerData] of renderedMarkers.entries()) {
       if (stoppedEarly) break;
       const element = createMarkerElement(markerData, avatarPalette, {
         showAvatar: showMarkerAvatars,
         simplified: useDenseMarkers,
       });
+      element.dataset.mapMovingPriority = mapMovingPriority(markerIndex, useDenseMarkers);
       const marker = new maplibre.Marker({ element }).setLngLat([
         markerData.lng,
         markerData.lat,
@@ -775,6 +791,7 @@ export function MapSurface({
       data-map-rendered-markers={renderedMarkers.length}
       data-map-total-markers={stableMarkers.length}
       data-map-dense={useDenseMarkers ? "true" : "false"}
+      data-map-ready={mapReady && !loadFailed ? "true" : "false"}
       data-map-moving="false"
       className="freed-map-shell theme-soft-viewport relative h-full w-full"
       style={MAP_VIEWPORT_MASK_STYLE}
@@ -833,12 +850,13 @@ export function MapSurface({
               )`,
             }}
           />
-          {renderedMarkers.map((marker) => {
+          {renderedMarkers.map((marker, markerIndex) => {
             const position = fallbackPosition(marker);
             return (
               <button
                 key={marker.key}
                 type="button"
+                data-map-moving-priority={mapMovingPriority(markerIndex, useDenseMarkers)}
                 className="freed-map-marker absolute -translate-x-1/2 -translate-y-1/2 rounded-full px-2.5 py-1.5 text-[11px] text-[color:var(--theme-text-primary)]"
                 style={{
                   ...position,


### PR DESCRIPTION
(AI Generated).

## Summary
- Defers lower-priority dense map markers and marker initials while the map is actively moving so zoom and pan frames have less DOM paint work.
- Adds perf coverage for the dense map moving-marker split so future changes preserve the interaction cap.

## Testing
- npm run test:e2e:perf:map --workspace=packages/desktop
- npm run validate:feature