### PR TITLE
perf: simplify Friends last seen mini map

### DIFF
--- a/packages/ui/src/components/map/MiniFriendMapCard.tsx
+++ b/packages/ui/src/components/map/MiniFriendMapCard.tsx
@@ -2,12 +2,20 @@ import { formatDistanceToNow } from "date-fns";
 import type { FeedItem, Person } from "@freed/shared";
 import { useAppStore } from "../../context/PlatformContext.js";
 import { useFriendLastSeenLocation } from "../../hooks/useResolvedLocations.js";
-import { MapSurface } from "./MapSurface.js";
 
 interface MiniFriendMapCardProps {
   friend: Person;
   feedItems: FeedItem[];
   onOpenMap: () => void;
+}
+
+function miniMapPosition(lat: number, lng: number): { left: string; top: string } {
+  const left = ((lng + 180) / 360) * 100;
+  const top = ((90 - lat) / 180) * 100;
+  return {
+    left: `${Math.min(92, Math.max(8, left)).toFixed(2)}%`,
+    top: `${Math.min(88, Math.max(12, top)).toFixed(2)}%`,
+  };
 }
 
 export function MiniFriendMapCard({
@@ -17,9 +25,10 @@ export function MiniFriendMapCard({
 }: MiniFriendMapCardProps) {
   const accounts = useAppStore((state) => state.accounts);
   const { lastSeen, resolvingCount } = useFriendLastSeenLocation(friend, accounts, feedItems);
-  const themeId = useAppStore((state) => state.preferences.display.themeId);
 
   if (!lastSeen && resolvingCount === 0) return null;
+
+  const markerPosition = lastSeen ? miniMapPosition(lastSeen.lat, lastSeen.lng) : null;
 
   return (
     <div
@@ -54,15 +63,18 @@ export function MiniFriendMapCard({
       </div>
 
       {lastSeen && (
-        <div className="theme-dialog-divider h-36 border-t">
-          <MapSurface
-            markers={[lastSeen]}
-            focusedMarkerKey={lastSeen.key}
-            interactive={false}
-            themeId={themeId}
-            emptyTitle="Resolving location"
-            emptyBody="The mini map will appear here."
-          />
+        <div className="theme-dialog-divider relative h-36 overflow-hidden border-t bg-[color:var(--theme-map-fallback-card-background)]">
+          <div className="absolute inset-0 opacity-55 [background-size:48px_48px] [background-image:linear-gradient(var(--theme-border-subtle)_1px,transparent_1px),linear-gradient(90deg,var(--theme-border-subtle)_1px,transparent_1px)]" />
+          <div className="absolute inset-0 bg-[radial-gradient(circle_at_24%_18%,color-mix(in_oklab,var(--theme-accent-secondary)_22%,transparent)_0%,transparent_42%),radial-gradient(circle_at_76%_78%,color-mix(in_oklab,var(--theme-accent-primary)_16%,transparent)_0%,transparent_36%)]" />
+          {markerPosition ? (
+            <div
+              className="absolute h-7 w-7 -translate-x-1/2 -translate-y-1/2 rounded-full border border-[color:var(--theme-border-strong)] bg-[color:var(--theme-button-primary-background)] shadow-[var(--theme-marker-shadow-soft)]"
+              style={markerPosition}
+              aria-hidden="true"
+            >
+              <div className="absolute inset-1 rounded-full bg-[color:var(--theme-bg-surface)]" />
+            </div>
+          ) : null}
         </div>
       )}
     </div>


### PR DESCRIPTION
(AI Generated).

## Summary
- Replaces the Friends detail last-seen card's embedded MapSurface with a lightweight static preview so opening a friend no longer loads MapLibre just for a tiny map card.
- Keeps the full Map view as the click target and reduces the race surface seen in v26.5.806-dev release validation.

## Testing
- npm run test:e2e:regression -- --grep "Friend detail last seen card opens"
- npm run validate:feature