### PR TITLE
perf: relax hidden renderer watchdog

### DIFF
--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -1288,7 +1288,7 @@ dependencies = [
 
 [[package]]
 name = "freed-desktop"
-version = "26.5.805"
+version = "26.5.807"
 dependencies = [
  "base64 0.22.1",
  "criterion",

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -93,9 +93,11 @@ const RECOVERY_WINDOW_LABEL: &str = "startup-recovery";
 const RECOVERY_WINDOW_ROUTE: &str = "startup-recovery.html";
 const RENDERER_HEARTBEAT_WATCHDOG_INTERVAL: Duration = Duration::from_secs(15);
 const RENDERER_STALE_LOG_AFTER: Duration = Duration::from_secs(45);
-const RENDERER_HIDDEN_STALE_LOG_AFTER: Duration = Duration::from_secs(480);
+#[cfg(test)]
+const WEBKIT_HIDDEN_TIMER_THROTTLE_AFTER: Duration = Duration::from_secs(480);
+const RENDERER_HIDDEN_STALE_LOG_AFTER: Duration = Duration::from_secs(570);
 const RENDERER_VISIBLE_RECOVERY_AFTER: Duration = Duration::from_secs(75);
-const RENDERER_HIDDEN_RECOVERY_AFTER: Duration = Duration::from_secs(600);
+const RENDERER_HIDDEN_RECOVERY_AFTER: Duration = Duration::from_secs(900);
 const BACKGROUND_REQUIRED_HEALTHY_HEARTBEATS: u64 = 2;
 const BACKGROUND_RECOVERY_COOLDOWN: Duration = Duration::from_secs(120);
 const BACKGROUND_MEMORY_HIGH_COOLDOWN: Duration = Duration::from_secs(120);
@@ -1667,7 +1669,7 @@ mod renderer_watchdog_tests {
 
     #[test]
     fn hidden_renderer_stale_log_waits_past_webkit_timer_throttling() {
-        assert!(RENDERER_HIDDEN_STALE_LOG_AFTER > Duration::from_secs(300));
+        assert!(RENDERER_HIDDEN_STALE_LOG_AFTER > WEBKIT_HIDDEN_TIMER_THROTTLE_AFTER);
         assert!(RENDERER_HIDDEN_STALE_LOG_AFTER < RENDERER_HIDDEN_RECOVERY_AFTER);
     }
 


### PR DESCRIPTION
(AI Generated).

## Summary
- Treat normal hidden WebKit timer throttling as a longer background interval so the native watchdog stops collecting expensive stale-renderer diagnostics during ordinary hidden or locked sessions.

## Testing
- cargo test renderer_watchdog_tests
- npm run validate:feature