### PR TITLE
perf: stabilize map markers across refreshes

### DIFF
--- a/packages/desktop/tests/e2e/perf-map.spec.ts
+++ b/packages/desktop/tests/e2e/perf-map.spec.ts
@@ -132,6 +132,13 @@ async function collectLongTasksDuring<T>(
 
 test("Map view handles 1,600 visible location authors within frame budget", async ({ app, page }) => {
   test.setTimeout(90_000);
+  await page.addInitScript(() => {
+    (
+      window as Window & {
+        __FREED_E2E_MAP_TIME_REFRESH_MS__?: number;
+      }
+    ).__FREED_E2E_MAP_TIME_REFRESH_MS__ = 120;
+  });
   await page.setViewportSize({ width: 1440, height: 900 });
   await app.goto();
   await app.waitForReady();
@@ -183,6 +190,13 @@ test("Map view handles 1,600 visible location authors within frame budget", asyn
   const totalMarkerCount = await page.getByTestId("map-surface").evaluate((element) =>
     Number.parseInt(element.getAttribute("data-map-total-markers") ?? "0", 10),
   );
+  await page.locator(".freed-map-marker").evaluateAll((elements) => {
+    elements.forEach((element, index) => {
+      element.setAttribute("data-marker-stability-token", `marker-${index}`);
+    });
+  });
+  await page.waitForTimeout(360);
+  const retainedMarkerCount = await page.locator(".freed-map-marker[data-marker-stability-token]").count();
   const domNodeCount = await page.evaluate(() => document.querySelectorAll("*").length);
 
   const interaction = await collectLongTasksDuring(page, () =>
@@ -201,6 +215,7 @@ test("Map view handles 1,600 visible location authors within frame budget", asyn
   console.log(`[PERF] Map marker DOM count: ${markerCount.toLocaleString()}`);
   console.log(`[PERF] Map moving primary markers: ${movingPrimaryMarkerCount.toLocaleString()}`);
   console.log(`[PERF] Map moving deferred markers: ${movingDeferredMarkerCount.toLocaleString()}`);
+  console.log(`[PERF] Map stable markers after timer refresh: ${retainedMarkerCount.toLocaleString()}`);
   console.log(`[PERF] Map total markers: ${totalMarkerCount.toLocaleString()}`);
   console.log(`[PERF] Map DOM nodes: ${domNodeCount.toLocaleString()}`);
   console.log(`[PERF] Map interaction FPS: ${interaction.result.fps.toLocaleString()}`);
@@ -212,6 +227,7 @@ test("Map view handles 1,600 visible location authors within frame budget", asyn
   expect(mountElapsed).toBeLessThan(MAP_MOUNT_BUDGET_MS);
   expect(totalMarkerCount).toBe(MAP_AUTHOR_COUNT);
   expect(markerCount).toBeLessThanOrEqual(MAP_MARKER_DOM_BUDGET);
+  expect(retainedMarkerCount).toBe(markerCount);
   expect(movingPrimaryMarkerCount).toBeLessThanOrEqual(MAP_MOVING_MARKER_PAINT_BUDGET);
   expect(movingPrimaryMarkerCount + movingDeferredMarkerCount).toBe(markerCount);
   expect(interaction.result.p95Ms).toBeLessThan(MAP_FRAME_P95_BUDGET_MS);

--- a/packages/ui/src/components/map/MapSurface.test.ts
+++ b/packages/ui/src/components/map/MapSurface.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import type { LocationMarkerSummary } from "@freed/shared";
+import { areLocationMarkerListsRenderEquivalent } from "./MapSurface";
+
+const NOW = Date.UTC(2026, 4, 9, 18, 0, 0);
+
+function marker(overrides: Partial<LocationMarkerSummary> = {}): LocationMarkerSummary {
+  return {
+    key: "friend:ada",
+    authorKey: "author:instagram:ada",
+    friend: {
+      id: "ada",
+      name: "Ada Lovelace",
+      avatarUrl: "https://example.com/ada.jpg",
+      relationshipStatus: "friend",
+      careLevel: 5,
+      createdAt: NOW,
+      updatedAt: NOW,
+    },
+    item: {
+      globalId: "instagram:1",
+      platform: "instagram",
+      contentType: "post",
+      capturedAt: NOW,
+      publishedAt: NOW - 60_000,
+      author: {
+        id: "ada-ig",
+        handle: "ada",
+        displayName: "Ada Lovelace",
+        avatarUrl: "https://example.com/ada-source.jpg",
+      },
+      content: {
+        text: "At the observatory.",
+        mediaUrls: [],
+        mediaTypes: [],
+      },
+      userState: {
+        hidden: false,
+        saved: false,
+        archived: false,
+        tags: [],
+      },
+      topics: [],
+    },
+    lat: 48.8566,
+    lng: 2.3522,
+    label: "Paris",
+    groupCount: 1,
+    seenAt: NOW - 60_000,
+    ...overrides,
+  };
+}
+
+describe("areLocationMarkerListsRenderEquivalent", () => {
+  it("keeps equivalent marker snapshots stable across timer recomputes", () => {
+    const current = [marker()];
+    const next = [marker()];
+
+    expect(areLocationMarkerListsRenderEquivalent(current, next)).toBe(true);
+  });
+
+  it("detects marker changes that affect rendered map content", () => {
+    const current = [marker()];
+    const next = [marker({ label: "Berlin" })];
+
+    expect(areLocationMarkerListsRenderEquivalent(current, next)).toBe(false);
+  });
+
+  it("detects source content changes used by popups and marker avatars", () => {
+    const current = [marker()];
+    const next = [
+      marker({
+        item: {
+          ...marker().item,
+          content: {
+            text: "A new location note.",
+            mediaUrls: [],
+            mediaTypes: [],
+          },
+        },
+      }),
+    ];
+
+    expect(areLocationMarkerListsRenderEquivalent(current, next)).toBe(false);
+  });
+});

--- a/packages/ui/src/components/map/MapSurface.tsx
+++ b/packages/ui/src/components/map/MapSurface.tsx
@@ -419,6 +419,71 @@ function mapMovingPriority(markerIndex: number, useDenseMarkers: boolean): "prim
     : "primary";
 }
 
+function markerFriendSignature(marker: LocationMarkerSummary): string {
+  const friend = marker.friend;
+  if (!friend) return "";
+  return [
+    friend.id,
+    friend.name,
+    friend.avatarUrl ?? "",
+    friend.relationshipStatus,
+  ].join("\u0001");
+}
+
+function markerItemSignature(marker: LocationMarkerSummary): string {
+  const item = marker.item;
+  return [
+    item.globalId,
+    item.platform,
+    item.contentType,
+    item.author.id,
+    item.author.displayName,
+    item.author.avatarUrl ?? "",
+    item.content.text ?? "",
+  ].join("\u0001");
+}
+
+function areLocationMarkersRenderEquivalent(
+  current: LocationMarkerSummary,
+  next: LocationMarkerSummary,
+): boolean {
+  return (
+    current.key === next.key &&
+    current.authorKey === next.authorKey &&
+    current.lat === next.lat &&
+    current.lng === next.lng &&
+    current.label === next.label &&
+    current.groupCount === next.groupCount &&
+    current.seenAt === next.seenAt &&
+    markerFriendSignature(current) === markerFriendSignature(next) &&
+    markerItemSignature(current) === markerItemSignature(next)
+  );
+}
+
+export function areLocationMarkerListsRenderEquivalent(
+  current: LocationMarkerSummary[],
+  next: LocationMarkerSummary[],
+): boolean {
+  if (current === next) return true;
+  if (current.length !== next.length) return false;
+
+  for (let index = 0; index < current.length; index += 1) {
+    if (!areLocationMarkersRenderEquivalent(current[index], next[index])) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function useStableLocationMarkers(markers: LocationMarkerSummary[]): LocationMarkerSummary[] {
+  const stableMarkersRef = useRef(markers);
+  if (!areLocationMarkerListsRenderEquivalent(stableMarkersRef.current, markers)) {
+    stableMarkersRef.current = markers;
+  }
+  return stableMarkersRef.current;
+}
+
 function mapGridBackground(boundary: string) {
   return `
     linear-gradient(
@@ -565,10 +630,7 @@ export function MapSurface({
     onOpenPost,
   });
 
-  const stableMarkers = useMemo(
-    () => markers.map((marker) => ({ ...marker })),
-    [markers]
-  );
+  const stableMarkers = useStableLocationMarkers(markers);
   const baseRenderedMarkers = useMemo(
     () => stableMarkers.length <= MAP_DOM_MARKER_LIMIT
       ? stableMarkers

--- a/packages/ui/src/components/map/MapView.tsx
+++ b/packages/ui/src/components/map/MapView.tsx
@@ -25,6 +25,18 @@ const DEFAULT_TIMELINE_INDEX: Record<Exclude<MapTimeMode, "current">, number> = 
   future: 0,
 };
 
+function getMapTimeRefreshMs(): number {
+  if (typeof window === "undefined") return MAP_TIME_REFRESH_MS;
+  const override = (
+    window as Window & {
+      __FREED_E2E_MAP_TIME_REFRESH_MS__?: number;
+    }
+  ).__FREED_E2E_MAP_TIME_REFRESH_MS__;
+  return typeof override === "number" && Number.isFinite(override) && override > 0
+    ? override
+    : MAP_TIME_REFRESH_MS;
+}
+
 function formatTimelineMoment(value: number): string {
   return timelineMomentFormatter.format(value);
 }
@@ -105,7 +117,7 @@ export function MapView() {
   useEffect(() => {
     const interval = window.setInterval(() => {
       setReferenceNow(Date.now());
-    }, MAP_TIME_REFRESH_MS);
+    }, getMapTimeRefreshMs());
     return () => {
       window.clearInterval(interval);
     };


### PR DESCRIPTION
(AI Generated).

## Summary
- Keep equivalent Map marker snapshots referentially stable so timer refreshes do not rebuild MapLibre markers or refit the map.
- Add regression coverage that 1,600-author Map perf keeps all mounted marker DOM nodes through accelerated refresh ticks.

## Testing
- PATH=/Users/aubreyfalconer/dev/freed-map-marker-stability/node_modules/.bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/usr/local/MacGPG2/bin:/Applications/VMware Fusion.app/Contents/Public:/usr/local/share/dotnet:~/.dotnet/tools:/usr/local/go/bin:/Library/Frameworks/Mono.framework/Versions/Current/Commands:/Users/aubreyfalconer/.nvm/versions/node/v24.14.1/bin:/Users/aubreyfalconer/.codex/tmp/arg0/codex-arg0ljXs28:/Users/aubreyfalconer/.local/bin:/opt/homebrew/opt/mysql-client/bin:/opt/homebrew/bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/Users/aubreyfalconer/.cargo/bin:/Users/aubreyfalconer/go/bin:/Users/aubreyfalconer/.cache/lm-studio/bin:/Users/aubreyfalconer/.safe-chain/bin:/Applications/Codex.app/Contents/Resources:/usr/local/bin npx vitest run packages/ui/src/components/map/MapSurface.test.ts packages/ui/src/components/map/MarkerElement.test.ts
- PATH=/Users/aubreyfalconer/dev/freed-map-marker-stability/node_modules/.bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/usr/local/MacGPG2/bin:/Applications/VMware Fusion.app/Contents/Public:/usr/local/share/dotnet:~/.dotnet/tools:/usr/local/go/bin:/Library/Frameworks/Mono.framework/Versions/Current/Commands:/Users/aubreyfalconer/.nvm/versions/node/v24.14.1/bin:/Users/aubreyfalconer/.codex/tmp/arg0/codex-arg0ljXs28:/Users/aubreyfalconer/.local/bin:/opt/homebrew/opt/mysql-client/bin:/opt/homebrew/bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/Users/aubreyfalconer/.cargo/bin:/Users/aubreyfalconer/go/bin:/Users/aubreyfalconer/.cache/lm-studio/bin:/Users/aubreyfalconer/.safe-chain/bin:/Applications/Codex.app/Contents/Resources:/usr/local/bin npm run test:e2e:perf:map (from packages/desktop)
- PATH=/Users/aubreyfalconer/dev/freed-map-marker-stability/node_modules/.bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/usr/local/MacGPG2/bin:/Applications/VMware Fusion.app/Contents/Public:/usr/local/share/dotnet:~/.dotnet/tools:/usr/local/go/bin:/Library/Frameworks/Mono.framework/Versions/Current/Commands:/Users/aubreyfalconer/.nvm/versions/node/v24.14.1/bin:/Users/aubreyfalconer/.codex/tmp/arg0/codex-arg0ljXs28:/Users/aubreyfalconer/.local/bin:/opt/homebrew/opt/mysql-client/bin:/opt/homebrew/bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/Users/aubreyfalconer/.cargo/bin:/Users/aubreyfalconer/go/bin:/Users/aubreyfalconer/.cache/lm-studio/bin:/Users/aubreyfalconer/.safe-chain/bin:/Applications/Codex.app/Contents/Resources:/usr/local/bin npm run validate:feature