### PR TITLE
fix: show crash recovery when rendering fails

### DIFF
--- a/packages/ui/src/components/BugReportBoundary.test.tsx
+++ b/packages/ui/src/components/BugReportBoundary.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { BugReportBoundary } from "./BugReportBoundary";
+import { PlatformProvider, type PlatformConfig } from "../context/PlatformContext";
+import { getLastFatalRuntimeError, resetBugReportState } from "../lib/bug-report";
+
+function CrashProbe(): never {
+  throw new Error("route render failed");
+}
+
+async function renderBoundary(): Promise<{
+  container: HTMLDivElement;
+  root: Root;
+}> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  const platform = {
+    store: (() => undefined) as PlatformConfig["store"],
+  } as PlatformConfig;
+
+  await act(async () => {
+    root.render(
+      <PlatformProvider value={platform}>
+        <BugReportBoundary>
+          <CrashProbe />
+        </BugReportBoundary>
+      </PlatformProvider>,
+    );
+  });
+
+  return { container, root };
+}
+
+describe("BugReportBoundary", () => {
+  beforeAll(() => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  afterAll(() => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = false;
+  });
+
+  it("renders recovery UI instead of a blank shell after a render error", async () => {
+    resetBugReportState();
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const { container, root } = await renderBoundary();
+
+    expect(container.textContent).toContain("Freed Desktop hit a fatal error");
+    expect(container.textContent).toContain("route render failed");
+    expect(getLastFatalRuntimeError()?.message).toBe("route render failed");
+
+    await act(async () => root.unmount());
+    container.remove();
+    consoleError.mockRestore();
+    resetBugReportState();
+  });
+});

--- a/packages/ui/src/components/BugReportBoundary.tsx
+++ b/packages/ui/src/components/BugReportBoundary.tsx
@@ -1,26 +1,39 @@
 import { Component, type ErrorInfo, type ReactNode } from "react";
+import type { RuntimeErrorSnapshot } from "@freed/shared";
 import { recordRuntimeError } from "../lib/bug-report.js";
+import { FatalErrorScreen } from "./FatalErrorScreen.js";
 
 class InternalBugReportBoundary extends Component<{
   children: ReactNode;
+}, {
+  fatalError: RuntimeErrorSnapshot | { message: string } | null;
 }> {
-  state = { hasError: false };
+  state = { fatalError: null };
 
-  static getDerivedStateFromError() {
-    return { hasError: true };
+  static getDerivedStateFromError(error: Error) {
+    return { fatalError: { message: error.message } };
   }
 
   componentDidCatch(error: Error, info: ErrorInfo) {
-    recordRuntimeError({
+    const snapshot = recordRuntimeError({
       source: "react-boundary",
       error,
       fatal: true,
       componentStack: info.componentStack ?? undefined,
     });
+    this.setState({ fatalError: snapshot });
   }
 
   render() {
-    if (this.state.hasError) return null;
+    if (this.state.fatalError) {
+      return (
+        <FatalErrorScreen
+          error={this.state.fatalError}
+          productName="Freed Desktop"
+          onRetry={() => window.location.reload()}
+        />
+      );
+    }
     return this.props.children;
   }
 }


### PR DESCRIPTION
(AI Generated).

## Summary
- Render the existing fatal recovery surface from the React bug report boundary instead of leaving the desktop shell blank after a caught render error.

## Testing
- npm run validate:feature