### PR TITLE
perf: shed feed media under WebKit pressure

### DIFF
--- a/packages/ui/src/components/feed/FeedItem.test.tsx
+++ b/packages/ui/src/components/feed/FeedItem.test.tsx
@@ -382,6 +382,35 @@ describe("FeedItem story media", () => {
       (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = false;
     }
   });
+
+  it("suppresses inline media when WebKit RSS approaches the live hidden-session pressure range", async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    setMemoryPressure("normal", {
+      webkitTotalResidentBytes: Math.floor(1.7 * 1024 * 1024 * 1024),
+    });
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root: Root = createRoot(container);
+
+    try {
+      await act(async () => {
+        root.render(
+          <PlatformProvider value={platformConfig}>
+            <FeedItem item={makeItem()} />
+          </PlatformProvider>,
+        );
+      });
+
+      expect(container.querySelector("img[src='https://example.com/story.jpg']")).toBeNull();
+      expect(container.querySelector(".bg-gradient-to-br")).not.toBeNull();
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+      (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = false;
+    }
+  });
 });
 
 describe("FeedItem channel avatars", () => {

--- a/packages/ui/src/components/feed/FeedItem.tsx
+++ b/packages/ui/src/components/feed/FeedItem.tsx
@@ -64,7 +64,7 @@ const COMPACT_CARD_TEXT_LIMIT = 500;
 const FIXED_CARD_TEXT_LIMIT = 900;
 const FULL_CARD_TEXT_LIMIT = 1_500;
 const FEED_IMAGE_SHED_APP_PRESSURE_BYTES = 2.25 * 1024 * 1024 * 1024;
-const FEED_IMAGE_SHED_WEBKIT_BYTES = 2 * 1024 * 1024 * 1024;
+const FEED_IMAGE_SHED_WEBKIT_BYTES = 1.5 * 1024 * 1024 * 1024;
 const EVENT_DATE_FORMAT = new Intl.DateTimeFormat(undefined, {
   month: "short",
   day: "numeric",


### PR DESCRIPTION
(AI Generated).

## Summary
- Lower the inline feed media WebKit RSS shed threshold from 2 GB to 1.5 GB so image-heavy feeds release pressure before the hidden-session range seen in the soak.
- Add a regression case that simulates 1.7 GB aggregate WebKit RSS and verifies feed story media falls back instead of mounting the image.

## Testing
- Focused FeedItem unit test passed: 18/18.
- npm run validate:feature passed, including desktop smoke and perf lanes.