### PR TITLE
perf: reduce dense map marker work

### DIFF
--- a/packages/desktop/tests/e2e/perf-map.spec.ts
+++ b/packages/desktop/tests/e2e/perf-map.spec.ts
@@ -7,8 +7,8 @@ const MAP_MOUNT_BUDGET_MS = process.env.CI ? 4_500 : 1_500;
 const MAP_FRAME_P95_BUDGET_MS = process.env.CI ? 67 : 50;
 const MAP_DROPPED_FRAME_BUDGET = process.env.CI ? 40 : 12;
 const MAP_LONG_TASK_COUNT_BUDGET = process.env.CI ? 4 : 2;
-const MAP_MARKER_DOM_BUDGET = 240;
-const MAP_MOVING_MARKER_PAINT_BUDGET = 120;
+const MAP_MARKER_DOM_BUDGET = 160;
+const MAP_MOVING_MARKER_PAINT_BUDGET = 80;
 
 async function seedLargeMapWorkspace(page: Page): Promise<void> {
   await page.evaluate(async ({ authorCount, itemCount }) => {

--- a/packages/ui/src/components/map/MapSurface.tsx
+++ b/packages/ui/src/components/map/MapSurface.tsx
@@ -44,8 +44,8 @@ const popupDateFormatter = new Intl.DateTimeFormat(undefined, {
 });
 const MAP_POPUP_MAX_WIDTH = 560;
 const MAP_POPUP_VIEWPORT_MARGIN = 40;
-const MAP_DOM_MARKER_LIMIT = 240;
-const MAP_MOVING_MARKER_PAINT_LIMIT = 120;
+const MAP_DOM_MARKER_LIMIT = 160;
+const MAP_MOVING_MARKER_PAINT_LIMIT = 80;
 const MAP_VIEWPORT_MASK_STYLE = {
   "--theme-soft-viewport-mask-size": "20px",
 } as CSSProperties;


### PR DESCRIPTION
(AI Generated).

## Summary
- Reduce the dense Map marker cap from 240 to 160.
- Reduce the moving marker paint cap from 120 to 80.
- Keep the 1,600 author Map performance guard aligned with the lower active marker budget so CI catches cap regressions.

## Testing
- npm run validate:feature
