### PR TITLE
fix: keep Friends fit all nodes visible

### DIFF
--- a/packages/pwa/src/lib/identity-graph-v2.test.ts
+++ b/packages/pwa/src/lib/identity-graph-v2.test.ts
@@ -4,6 +4,7 @@ import { buildProvisionalPersonCandidates } from "@freed/shared";
 import {
   nudgeOverlapsBucketed,
   buildIdentityGraphLayout,
+  fitTransformToNodes,
   type IdentityGraphLayoutNode,
 } from "../../../ui/src/lib/identity-graph-layout";
 import {
@@ -476,6 +477,30 @@ describe("identity graph v2 layout", () => {
           left.radius + right.radius + 9.5,
         );
       }
+    }
+  });
+
+  it("fits far apart graph items inside the padded viewport", () => {
+    const nodes = [
+      { x: 1_020, y: 240, radius: 210 },
+      { x: 1_200, y: 3_420, radius: 58 },
+    ];
+
+    const viewportWidth = 1_176;
+    const viewportHeight = 850;
+    const padding = 80;
+    const transform = fitTransformToNodes(nodes, viewportWidth, viewportHeight, padding);
+
+    for (const node of nodes) {
+      const left = node.x * transform.scale + transform.x - node.radius * transform.scale;
+      const right = node.x * transform.scale + transform.x + node.radius * transform.scale;
+      const top = node.y * transform.scale + transform.y - node.radius * transform.scale;
+      const bottom = node.y * transform.scale + transform.y + node.radius * transform.scale;
+
+      expect(left).toBeGreaterThanOrEqual(padding - 0.1);
+      expect(right).toBeLessThanOrEqual(viewportWidth - padding + 0.1);
+      expect(top).toBeGreaterThanOrEqual(padding - 0.1);
+      expect(bottom).toBeLessThanOrEqual(viewportHeight - padding + 0.1);
     }
   });
 

--- a/packages/ui/src/lib/identity-graph-layout.ts
+++ b/packages/ui/src/lib/identity-graph-layout.ts
@@ -72,10 +72,6 @@ function hashValue(value: string): number {
   return Math.abs(hash);
 }
 
-function clamp(value: number, min: number, max: number): number {
-  return Math.max(min, Math.min(max, value));
-}
-
 function safeText(value: unknown, fallback = ""): string {
   return typeof value === "string" && value.trim() ? value.trim() : fallback;
 }
@@ -589,9 +585,10 @@ export function fitTransformToNodes(
   const bottom = Math.max(...nodes.map((node) => node.y + node.radius));
   const contentWidth = Math.max(1, right - left);
   const contentHeight = Math.max(1, bottom - top);
-  const scale = clamp(
-    Math.min((width - padding * 2) / contentWidth, (height - padding * 2) / contentHeight),
-    0.22,
+  const availableWidth = Math.max(1, width - padding * 2);
+  const availableHeight = Math.max(1, height - padding * 2);
+  const scale = Math.min(
+    Math.min(availableWidth / contentWidth, availableHeight / contentHeight),
     1.5,
   );
   return {


### PR DESCRIPTION
(AI Generated).

## Summary
- Fixes Friends graph Fit all for sparse, far-apart graph layouts by allowing the transform to zoom out far enough to include every fitted node.

## Testing
- npm run validate:feature