### PR TITLE
perf: prefilter feed location text scans

### DIFF
--- a/packages/pwa/src/lib/map-locations.test.ts
+++ b/packages/pwa/src/lib/map-locations.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   extractLocationFromItem,
+  extractLocationFromText,
   filterResolvedLocationsByTime,
   getDefaultMapMode,
   getLatestAuthorLocationMarkers,
@@ -71,6 +72,12 @@ function markerFromResolved(resolved: ResolvedLocationItem[]): LocationMarkerSum
 }
 
 describe("location grouping", () => {
+  it("extracts text locations after a cheap signal prefilter", () => {
+    expect(extractLocationFromText("Article body without a place hint.")).toBeNull();
+    expect(extractLocationFromText("Bonjour from Paris")).toBe("Paris");
+    expect(extractLocationFromText("📍 New York")).toBe("New York");
+  });
+
   it("collapses repeated friend posts at the same coordinates into one marker", () => {
     const friend = makeFriend({ id: "friend-1" });
     const resolved: ResolvedLocationItem[] = [

--- a/packages/shared/src/location.ts
+++ b/packages/shared/src/location.ts
@@ -70,12 +70,17 @@ const LOCATION_PATTERNS: RegExp[] = [
   /🌏\s*([^\n,]{2,60})/u,                               // 🌏 Tokyo
   /(?:^|\s)(?:in|at|from)\s+([A-Z][a-z]+(?: [A-Z][a-z]+)*)/u, // "in Paris"
 ];
+const LOCATION_TEXT_SIGNAL_PATTERN = /[📍🌍🌎🌏]|\b(?:in|at|from)\s+[A-Z]/u;
 
 /**
  * Try to extract a place name from free text.
  * Returns the first match or null.
  */
 export function extractLocationFromText(text: string): string | null {
+  if (!LOCATION_TEXT_SIGNAL_PATTERN.test(text)) {
+    return null;
+  }
+
   for (const pattern of LOCATION_PATTERNS) {
     const m = pattern.exec(text);
     if (m?.[1]) return m[1].trim();


### PR DESCRIPTION
(AI Generated).

## Summary
- Skips full location regex extraction for feed text that cannot match any supported location signal, preserving map location matches while reducing hydrate-time scan work on ordinary article text.

## Testing
- PATH=... npm run test:unit -- --run src/lib/map-locations.test.ts, focused 5k feed perf, npm run validate:feature