### PR TITLE
perf: reduce settings scroll paint work

### DIFF
--- a/packages/ui/src/components/SettingsDialog.tsx
+++ b/packages/ui/src/components/SettingsDialog.tsx
@@ -887,6 +887,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
     const root = scrollRef.current;
     if (!root || searchLower || (isMobile && mobileView === "nav")) return;
     let scrollIdleTimer: ReturnType<typeof setTimeout> | undefined;
+    const supportsScrollEnd = "onscrollend" in root;
 
     const updateActiveSectionFromScroll = () => {
       if (isScrollingProgrammatically.current) return;
@@ -917,6 +918,9 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
 
     const scheduleActiveSectionUpdate = () => {
       suppressBackdropDuringInteraction();
+      if (supportsScrollEnd) {
+        return;
+      }
       clearTimeout(scrollIdleTimer);
       scrollIdleTimer = setTimeout(() => {
         updateActiveSectionFromScroll();
@@ -925,11 +929,17 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
 
     updateActiveSectionFromScroll();
     root.addEventListener("scroll", scheduleActiveSectionUpdate, { passive: true });
+    if (supportsScrollEnd) {
+      root.addEventListener("scrollend", updateActiveSectionFromScroll);
+    }
     window.addEventListener("resize", scheduleActiveSectionUpdate);
 
     return () => {
       clearTimeout(scrollIdleTimer);
       root.removeEventListener("scroll", scheduleActiveSectionUpdate);
+      if (supportsScrollEnd) {
+        root.removeEventListener("scrollend", updateActiveSectionFromScroll);
+      }
       window.removeEventListener("resize", scheduleActiveSectionUpdate);
     };
   }, [isMobile, mobileView, open, searchLower, suppressBackdropDuringInteraction]);

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -2081,6 +2081,22 @@ html[data-settings-dialog-moving="true"] .theme-settings-overlay {
   transition: none;
 }
 
+html[data-settings-dialog-moving="true"] .theme-settings-shell {
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 0.05),
+    0 20px 56px rgb(0 0 0 / 0.24),
+    0 0 0 1px rgb(255 255 255 / 0.025);
+  transform: translateZ(0);
+}
+
+html[data-settings-dialog-moving="true"] .theme-settings-shell .theme-card-soft {
+  box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.035);
+}
+
+html[data-settings-dialog-moving="true"] .theme-settings-shell .theme-dialog-section {
+  box-shadow: none;
+}
+
 html[data-memory-pressure="critical"] .theme-settings-overlay,
 html[data-renderer-safe-mode="true"] .theme-settings-overlay {
   background: rgb(var(--theme-shell-rgb) / 0.18);


### PR DESCRIPTION
(AI Generated).

## Summary
- Use scrollend for Settings scrollspy updates in browsers that support it, avoiding debounce timer churn during active scrolling.
- Simplify moving-state Settings shell and card shadows while preserving the static blurred background treatment.

## Testing
- Focused Settings perf E2E: scroll p95 held at 50.1 ms in repeated focused runs, with no long tasks.
- Focused Settings smoke coverage for backdrop blur, nav scrollspy, and close button.
- npm run validate:feature