### PR TITLE
fix: open map before selecting friend detail

### DIFF
--- a/packages/ui/src/components/friends/FriendsView.tsx
+++ b/packages/ui/src/components/friends/FriendsView.tsx
@@ -1435,8 +1435,8 @@ export function FriendsView({
             feedItems={feedItems}
             onLogReachOut={handleLogReachOut}
             onOpenMap={() => {
-              setSelectedPerson(selectedPerson.id);
               setActiveView("map");
+              setSelectedPerson(selectedPerson.id);
             }}
           />
         </div>


### PR DESCRIPTION
(AI Generated).

## Summary

- Open the Map view before applying the selected friend from the Friends detail last seen card.
- Avoids making the Friends surface do selected-person rerender work before it unmounts.

## Validation

- Focused Friends detail to Map regression, repeated 20 times.
- Feature validation passed.
