### PR TITLE
perf: isolate settings scroll paint

### DIFF
--- a/packages/ui/src/components/SettingsDialog.tsx
+++ b/packages/ui/src/components/SettingsDialog.tsx
@@ -1683,7 +1683,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
             ref={scrollRef}
             data-testid="settings-scroll-container"
             onPointerEnter={suppressBackdropDuringInteraction}
-            className="flex-1 overflow-y-auto px-4 pt-2 text-base sm:px-6 sm:pt-6 sm:text-sm sm:[&>section+section]:mt-24 [&>section+section]:mt-6"
+            className="theme-settings-scrollport flex-1 overflow-y-auto px-4 pt-2 text-base sm:px-6 sm:pt-6 sm:text-sm sm:[&>section+section]:mt-24 [&>section+section]:mt-6"
             style={{
               paddingBottom: scrollContainerBottomPadding,
             }}

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -2160,6 +2160,7 @@ html[data-theme="scriptorium"] .theme-dialog-shell::before {
 }
 
 .theme-settings-shell {
+  contain: layout paint;
   box-shadow:
     inset 0 1px 0 rgb(255 255 255 / 0.06),
     inset 0 0 0 0.5px rgb(255 255 255 / 0.028),
@@ -2167,6 +2168,11 @@ html[data-theme="scriptorium"] .theme-dialog-shell::before {
     0 88px 228px rgb(var(--theme-shell-rgb) / 0.7),
     0 0 72px rgb(0 0 0 / 0.1),
     0 0 0 1px rgb(255 255 255 / 0.025);
+}
+
+.theme-settings-scrollport {
+  contain: layout paint;
+  overscroll-behavior: contain;
 }
 
 html[data-theme="scriptorium"] .theme-settings-shell {


### PR DESCRIPTION
(AI Generated).

## Summary
- Add a dedicated Settings scrollport class and isolate its paint and layout work.
- Add layout and paint containment to the Settings shell so scroll invalidation stays local to the dialog.

## Validation
- npm run test:e2e:perf:settings -- perf-settings.spec.ts
- npm run test:e2e:regression -- smoke.spec.ts --grep "settings nav highlight follows scroll position"
- npm run validate:feature

## Notes
- This is a small paint-isolation follow-up. Full validation still shows Settings outer scroll as the remaining noisy compositor-budget miss, so this is not the final cure.