### PR TITLE
perf: pause settings transitions while moving

### DIFF
--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -2099,6 +2099,13 @@ html[data-settings-dialog-moving="true"] .theme-settings-shell .theme-dialog-sec
   box-shadow: none;
 }
 
+html[data-settings-dialog-moving="true"] .theme-settings-shell *,
+html[data-settings-dialog-moving="true"] .theme-settings-shell *::before,
+html[data-settings-dialog-moving="true"] .theme-settings-shell *::after {
+  animation: none !important;
+  transition: none !important;
+}
+
 html[data-memory-pressure="critical"] .theme-settings-overlay,
 html[data-renderer-safe-mode="true"] .theme-settings-overlay {
   background: rgb(var(--theme-shell-rgb) / 0.18);


### PR DESCRIPTION
(AI Generated).

## Summary
- Disable descendant animations and transitions inside Settings only while the dialog is actively moving.
- Preserve the static blurred Settings background and restore normal transitions after the existing idle timer clears moving state.

## Validation
- npm run test:e2e:perf:settings -- perf-settings.spec.ts
- npm run test:e2e:perf:settings -- perf-settings.spec.ts --repeat-each=3
- npm run test:e2e:regression -- smoke.spec.ts --grep "settings nav highlight follows scroll position|settings backdrop stays blurred"
- npm run validate:feature

## Notes
- This removes useless transition work during scroll. Settings outer scroll remains the remaining noisy compositor-budget miss, so follow-up paint work is still needed.