### PR TITLE
fix: stabilize friends map handoff

### DIFF
--- a/packages/desktop/src/lib/store-preferences.test.ts
+++ b/packages/desktop/src/lib/store-preferences.test.ts
@@ -111,6 +111,26 @@ describe("store.updatePreferences", () => {
     });
   });
 
+  it("opens the full map for a person in one state transition", () => {
+    useAppStore.setState({
+      activeView: "friends",
+      selectedPersonId: null,
+      selectedAccountId: "account-ada",
+      selectedFriendId: null,
+      selectedItemId: "ig:ada:paris",
+    });
+
+    useAppStore.getState().openMapForPerson("friend-ada");
+
+    expect(useAppStore.getState()).toMatchObject({
+      activeView: "map",
+      selectedPersonId: "friend-ada",
+      selectedAccountId: null,
+      selectedFriendId: "friend-ada",
+      selectedItemId: null,
+    });
+  });
+
   it("records non-fatal diagnostics when persistence rejects", async () => {
     const error = new Error("[automerge-worker] request TIMEOUT op=UPDATE_PREFERENCES reqId=126");
     mockDocUpdatePreferences.mockRejectedValueOnce(error);

--- a/packages/desktop/src/lib/store.ts
+++ b/packages/desktop/src/lib/store.ts
@@ -206,6 +206,7 @@ interface AppState {
   // View navigation
   activeView: "feed" | "friends" | "map";
   setActiveView: (view: "feed" | "friends" | "map") => void;
+  openMapForPerson: (personId: string) => void;
   pendingMatchCount: number;
   setPendingMatchCount: (count: number) => void;
 }
@@ -796,6 +797,14 @@ export const useAppStore = create<AppState>((set, get) => ({
   setError: (error) => set({ error }),
   setSearchQuery: (searchQuery) => set({ searchQuery }),
   setActiveView: (activeView) => set({ activeView }),
+  openMapForPerson: (personId) =>
+    set({
+      activeView: "map",
+      selectedPersonId: personId,
+      selectedAccountId: null,
+      selectedFriendId: personId,
+      selectedItemId: null,
+    }),
   setPendingMatchCount: (pendingMatchCount) => set({ pendingMatchCount }),
 }));
 

--- a/packages/desktop/tests/e2e/smoke.spec.ts
+++ b/packages/desktop/tests/e2e/smoke.spec.ts
@@ -2821,21 +2821,9 @@ test("Friend detail last seen card opens the full Map view", async ({ app }) => 
 
   await expect(page.getByTestId("friends-sidebar")).toBeVisible({ timeout: 5_000 });
   await expect(page.getByText("Last seen")).toBeVisible({ timeout: 5_000 });
-  await expect(page.getByRole("button", { name: /last seen paris/i })).toBeVisible({ timeout: 5_000 });
-  await page.waitForFunction(() => {
-    const lastSeenCard = Array.from(document.querySelectorAll<HTMLElement>('[role="button"]')).find((element) => {
-      const label = element.textContent ?? "";
-      return (
-        /last seen/i.test(label) &&
-        /paris/i.test(label) &&
-        /open map/i.test(label) &&
-        element.getClientRects().length > 0
-      );
-    });
-    if (!lastSeenCard) return false;
-    lastSeenCard.click();
-    return true;
-  }, { timeout: 5_000 });
+  const lastSeenCard = page.getByRole("button", { name: /last seen paris/i });
+  await expect(lastSeenCard).toBeVisible({ timeout: 5_000 });
+  await lastSeenCard.click();
 
   await page.waitForFunction(() => {
     const w = window as Record<string, unknown>;

--- a/packages/pwa/src/lib/command-palette.test.ts
+++ b/packages/pwa/src/lib/command-palette.test.ts
@@ -248,6 +248,16 @@ function createTestStore(overrides: Partial<BaseAppState> = {}) {
     setSearchQuery: overrides.setSearchQuery ?? ((query: string) => set({ searchQuery: query })),
     activeView: overrides.activeView ?? "feed",
     setActiveView: overrides.setActiveView ?? ((view: "feed" | "friends" | "map") => set({ activeView: view })),
+    openMapForPerson:
+      overrides.openMapForPerson
+      ?? ((personId: string) =>
+        set({
+          activeView: "map",
+          selectedPersonId: personId,
+          selectedAccountId: null,
+          selectedFriendId: personId,
+          selectedItemId: null,
+        })),
     pendingMatchCount: 0,
     setPendingMatchCount: noop,
   }));

--- a/packages/pwa/src/lib/store.ts
+++ b/packages/pwa/src/lib/store.ts
@@ -460,5 +460,13 @@ export const useAppStore = create<AppState>((set, get) => ({
   setError: (error) => set({ error }),
   setSearchQuery: (searchQuery) => set({ searchQuery }),
   setActiveView: (activeView) => set({ activeView }),
+  openMapForPerson: (personId) =>
+    set({
+      activeView: "map",
+      selectedPersonId: personId,
+      selectedAccountId: null,
+      selectedFriendId: personId,
+      selectedItemId: null,
+    }),
   setPendingMatchCount: (pendingMatchCount) => set({ pendingMatchCount }),
 }));

--- a/packages/shared/src/store-types.ts
+++ b/packages/shared/src/store-types.ts
@@ -175,6 +175,8 @@ export interface BaseAppState {
   activeView: "feed" | "friends" | "map";
   /** Switch the top-level view. */
   setActiveView: (view: "feed" | "friends" | "map") => void;
+  /** Open the full Map view focused on one person. */
+  openMapForPerson: (personId: string) => void;
   /** Number of unreviewed Google Contacts match suggestions. */
   pendingMatchCount: number;
   /** Update the pending match count (set by useContactSync). */

--- a/packages/ui/src/components/friends/FriendsView.tsx
+++ b/packages/ui/src/components/friends/FriendsView.tsx
@@ -549,7 +549,7 @@ export function FriendsView({
   const selectedAccountId = useAppStore((s) => s.selectedAccountId);
   const setSelectedPerson = useAppStore((s) => s.setSelectedPerson);
   const setSelectedAccount = useAppStore((s) => s.setSelectedAccount);
-  const setActiveView = useAppStore((s) => s.setActiveView);
+  const openMapForPerson = useAppStore((s) => s.openMapForPerson);
   const pendingMatchCount = useAppStore((s) => s.pendingMatchCount);
   const display = useAppStore((s) => s.preferences.display);
   const friendSuggestionPreferences = useAppStore((s) => s.preferences.friendSuggestions);
@@ -1435,8 +1435,7 @@ export function FriendsView({
             feedItems={feedItems}
             onLogReachOut={handleLogReachOut}
             onOpenMap={() => {
-              setActiveView("map");
-              setSelectedPerson(selectedPerson.id);
+              openMapForPerson(selectedPerson.id);
             }}
           />
         </div>


### PR DESCRIPTION
(AI Generated).

## Summary

- Make the Friends detail last-seen Map jump a single store transition.
- Clear stale selected item and account state when focusing the full Map for a person.
- Use a real Playwright click for the last-seen card regression instead of a DOM click from inside a polling predicate.

## Validation

- npm run test:unit -- store-preferences.test.ts
- npm run test:e2e -- smoke.spec.ts --grep "Friend detail last seen card opens the full Map view" --repeat-each=20
- npm run validate:feature

## Release context

- v26.5.1000-dev release workflow failed this smoke case twice while the separate dev validation workflow passed on the same commit.
- This patch removes the split store notification that allowed state to reach map while the Map surface did not mount in the release lane.