### PR TITLE
fix: flush friends map handoff

### DIFF
--- a/packages/ui/src/components/friends/FriendsView.tsx
+++ b/packages/ui/src/components/friends/FriendsView.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, useMemo, useEffect, useRef, type ReactNode } from "react";
+import { flushSync } from "react-dom";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import type {
   Account,
@@ -1435,7 +1436,9 @@ export function FriendsView({
             feedItems={feedItems}
             onLogReachOut={handleLogReachOut}
             onOpenMap={() => {
-              openMapForPerson(selectedPerson.id);
+              flushSync(() => {
+                openMapForPerson(selectedPerson.id);
+              });
             }}
           />
         </div>


### PR DESCRIPTION
(AI Generated).

## Summary

- Force the Friends detail last seen Map handoff through React sync commit.
- Keep the atomic openMapForPerson store transition from PR 568.
- Prevent release CI from observing map state before the Map surface has committed.

## Validation

- npm run test:e2e with the Friends Map handoff case repeated 20 times
- npm run build for the PWA workspace
- npm run validate:feature

## Release context

- v26.5.1000-dev and v26.5.1001-dev failed the same release lane smoke case while local full regression and PR feature checks passed.
- This patch forces the view commit at the click boundary instead of relying on async React scheduling under the release runner.