### PR TITLE
fix: flush friends mobile surface switch

### DIFF
--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -10,6 +10,7 @@ import {
   type ChangeEvent,
   type ReactNode,
 } from "react";
+import { flushSync } from "react-dom";
 import {
   applyFeedSignalModesToFilter,
   FEED_SIGNAL_FILTER_PRESETS,
@@ -701,11 +702,15 @@ export function Header({
 
   const handleFriendsToolbarModeChange = useCallback((mode: FriendsToolbarMode) => {
     if (mode === "details") {
-      onFriendsMobileSurfaceChange("details");
+      flushSync(() => {
+        onFriendsMobileSurfaceChange("details");
+      });
       return;
     }
-    handleIdentityModeChange("friendsMode", mode);
-    onFriendsMobileSurfaceChange("graph");
+    flushSync(() => {
+      handleIdentityModeChange("friendsMode", mode);
+      onFriendsMobileSurfaceChange("graph");
+    });
   }, [handleIdentityModeChange, onFriendsMobileSurfaceChange]);
 
   const handleMapTimeModeChange = useCallback((mode: MapTimeMode) => {


### PR DESCRIPTION
(AI Generated).

## Summary

- Force the mobile Friends toolbar Details and graph surface switches through React sync commit.
- Keep the fix scoped to the parent state handoff between Header and FriendsView.
- Stabilize the release regression case that failed after the Friends Map handoff started passing.

## Validation

- Repeated the mobile Friends toolbar Details case 30 times locally.
- Ran npm run validate:feature.

## Release context

- v26.5.1002-dev passed the previous Friends Map handoff failure at test 90.
- It then failed the mobile Friends toolbar Details mode case at test 100 because the sidebar did not commit before the release runner assertion.