### PR TITLE
fix: suppress hidden renderer stale cycles

### DIFF
--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -1288,7 +1288,7 @@ dependencies = [
 
 [[package]]
 name = "freed-desktop"
-version = "26.5.900"
+version = "26.5.1004"
 dependencies = [
  "base64 0.22.1",
  "criterion",

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -1615,11 +1615,11 @@ fn renderer_gap_is_expected_hidden_throttle(
     last_visibility: &str,
     last_hidden_timer_throttled: Option<bool>,
     age: Duration,
-    recovery_threshold: Duration,
+    _recovery_threshold: Duration,
 ) -> bool {
     !renderer_is_effectively_visible(is_visible, last_visibility)
-        && last_hidden_timer_throttled == Some(true)
-        && age < recovery_threshold
+        && (last_visibility == "hidden" || last_hidden_timer_throttled == Some(true))
+        && age >= WEBKIT_HIDDEN_TIMER_THROTTLE_AFTER
 }
 
 fn renderer_stale_should_recover(is_visible: bool, last_visibility: &str) -> bool {
@@ -1732,6 +1732,13 @@ mod renderer_watchdog_tests {
             RENDERER_HIDDEN_STALE_LOG_AFTER + Duration::from_secs(1),
             RENDERER_HIDDEN_RECOVERY_AFTER,
         ));
+        assert!(renderer_gap_is_expected_hidden_throttle(
+            true,
+            "hidden",
+            Some(false),
+            RENDERER_HIDDEN_STALE_LOG_AFTER + Duration::from_secs(1),
+            RENDERER_HIDDEN_RECOVERY_AFTER,
+        ));
         assert!(!renderer_gap_is_expected_hidden_throttle(
             true,
             "visible",
@@ -1739,7 +1746,7 @@ mod renderer_watchdog_tests {
             RENDERER_HIDDEN_STALE_LOG_AFTER + Duration::from_secs(1),
             RENDERER_HIDDEN_RECOVERY_AFTER,
         ));
-        assert!(!renderer_gap_is_expected_hidden_throttle(
+        assert!(renderer_gap_is_expected_hidden_throttle(
             false,
             "hidden",
             Some(false),
@@ -1747,6 +1754,13 @@ mod renderer_watchdog_tests {
             RENDERER_HIDDEN_RECOVERY_AFTER,
         ));
         assert!(!renderer_gap_is_expected_hidden_throttle(
+            false,
+            "hidden",
+            Some(true),
+            WEBKIT_HIDDEN_TIMER_THROTTLE_AFTER - Duration::from_secs(1),
+            RENDERER_HIDDEN_RECOVERY_AFTER,
+        ));
+        assert!(renderer_gap_is_expected_hidden_throttle(
             false,
             "hidden",
             Some(true),


### PR DESCRIPTION
(AI Generated).

## Summary
- Keeps hidden WebKit timer gaps in the throttled heartbeat path instead of escalating them to stale renderer warnings when recovery is disabled.
- Covers the first hidden startup gap and later gaps beyond the hidden recovery threshold.

## Testing
- cargo test renderer_watchdog_tests --lib
- npm run validate:feature