### PR TITLE
fix: stabilize friends empty graph click

### DIFF
--- a/packages/desktop/tests/e2e/smoke.spec.ts
+++ b/packages/desktop/tests/e2e/smoke.spec.ts
@@ -3539,15 +3539,18 @@ test("clicking empty graph space closes the collapsed Friends detail card", asyn
   await page.getByRole("button", { name: "Fit all" }).click();
   await waitForGraphPerfToSettle(page, 20_000);
 
-  const friendPoint = await waitForGraphNodeScreenPoint(page, { personId: "friend-ada" }, 20_000);
-  await page.mouse.click(friendPoint.x, friendPoint.y);
-  await page.waitForFunction(() => {
+  await page.evaluate(() => {
     const store = (window as Record<string, unknown>).__FREED_STORE__ as
-      | { getState: () => { selectedPersonId: string | null; selectedAccountId: string | null } }
+      | {
+          getState: () => {
+            setSelectedPerson: (personId: string | null) => void;
+            setSelectedAccount: (accountId: string | null) => void;
+          };
+        }
       | undefined;
-    const state = store?.getState();
-    return state?.selectedPersonId === "friend-ada" && state.selectedAccountId === null;
-  }, undefined, { timeout: 10_000 });
+    store?.getState().setSelectedAccount(null);
+    store?.getState().setSelectedPerson("friend-ada");
+  });
 
   const compactCard = page.getByTestId("friends-collapsed-selection-card");
   await expect(compactCard).toBeVisible({ timeout: 10_000 });


### PR DESCRIPTION
(AI Generated).

## Summary
- Narrow the collapsed Friends detail card dismissal regression to the behavior it owns.
- Seed the collapsed selection state directly instead of first waiting for a graph node to settle inside the viewport.
- Keep graph node selection covered by the neighboring graph interaction smoke tests.

## Validation
- npm run validate:feature
- cd packages/desktop && CI=true node ../../node_modules/playwright/cli.js test smoke.spec.ts --grep "clicking empty graph space closes the collapsed Friends detail card" --repeat-each=20 --workers=1