### PR TITLE
perf: reduce settings scroll paint work

### DIFF
--- a/packages/desktop/tests/e2e/perf-settings.spec.ts
+++ b/packages/desktop/tests/e2e/perf-settings.spec.ts
@@ -160,9 +160,12 @@ test("Settings dialog stays responsive with 1,600 RSS sources", async ({ app, pa
   const initialDomNodes = await page.evaluate(() => document.querySelectorAll("*").length);
 
   const scrollContainer = page.getByTestId("settings-scroll-container");
+  await scrollContainer.hover();
+  const settingsShell = settingsDialog.locator(".theme-settings-shell");
+  await expect(settingsShell).toHaveAttribute("data-moving", "true");
+  await expect(settingsDialog.locator(".theme-card-soft").first()).toHaveCSS("backdrop-filter", "none");
   const scrollInteraction = await collectLongTasksDuring(page, () =>
     measureFps(page, async () => {
-      await scrollContainer.hover();
       await scrollContainer.evaluate((element) => new Promise<void>((resolve) => {
         let frame = 0;
         const scrollable = element as HTMLElement;

--- a/packages/ui/src/components/SettingsDialog.tsx
+++ b/packages/ui/src/components/SettingsDialog.tsx
@@ -488,6 +488,10 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
   const suppressBackdropDuringInteraction = useCallback(() => {
     const now = typeof performance !== "undefined" ? performance.now() : Date.now();
     interactionBlurLastAtRef.current = now;
+    if (interactionBlurRestoreTimerRef.current) {
+      return;
+    }
+
     const overlay = settingsOverlayRef.current;
     const shell = settingsShellRef.current;
     if (overlay && overlay.dataset.moving !== "true") {
@@ -495,10 +499,6 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
     }
     if (shell && shell.dataset.moving !== "true") {
       shell.dataset.moving = "true";
-    }
-
-    if (interactionBlurRestoreTimerRef.current) {
-      return;
     }
 
     const restoreWhenIdle = () => {

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -2093,6 +2093,13 @@ html.freed-mobile-sidebar-open body {
 
 .theme-settings-shell[data-moving="true"] .theme-card-soft {
   box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.035);
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+}
+
+.theme-settings-shell[data-moving="true"] .theme-settings-scrollport {
+  transform: translateZ(0);
+  will-change: scroll-position;
 }
 
 .theme-settings-shell[data-moving="true"] .theme-dialog-section {


### PR DESCRIPTION
(AI Generated).

## Summary
- Reduce Settings scroll-time paint work by disabling nested soft-card blur while the dialog is moving.
- Avoid repeated Settings overlay and shell dataset reads during active scroll suppression.
- Add a perf assertion that the moving-state blur bypass is active before measuring Settings scroll.

## Validation
- Focused Settings perf repeated 5 times.
- `npm run validate:feature`