### PR TITLE
fix: guard friends map surface handoff

### DIFF
--- a/packages/ui/src/components/friends/FriendsView.tsx
+++ b/packages/ui/src/components/friends/FriendsView.tsx
@@ -1436,8 +1436,12 @@ export function FriendsView({
             feedItems={feedItems}
             onLogReachOut={handleLogReachOut}
             onOpenMap={() => {
+              const personId = selectedPerson.id;
               flushSync(() => {
-                openMapForPerson(selectedPerson.id);
+                openMapForPerson(personId);
+              });
+              window.requestAnimationFrame(() => {
+                openMapForPerson(personId);
               });
             }}
           />


### PR DESCRIPTION
(AI Generated).

## Summary
- Guard the Friends Last seen to Map handoff with a second next-frame `openMapForPerson` notification.
- Keep the existing synchronous handoff so the normal path still commits immediately.
- Replace the failed v26.5.1014 release validation blocker, where store state reached Map but `map-surface` did not mount before the assertion timeout.

## Validation
- Focused Last seen to Map test repeated 80 times.
- Adjacent Friends and Map smoke subset repeated 10 times before the guard.
- `npm run validate:feature`