### PR TITLE
perf: reduce settings scroll overdraw

### DIFF
--- a/packages/desktop/tests/e2e/perf-settings.spec.ts
+++ b/packages/desktop/tests/e2e/perf-settings.spec.ts
@@ -163,6 +163,8 @@ test("Settings dialog stays responsive with 1,600 RSS sources", async ({ app, pa
   await scrollContainer.hover();
   const settingsShell = settingsDialog.locator(".theme-settings-shell");
   await expect(settingsShell).toHaveAttribute("data-moving", "true");
+  await expect(settingsShell).toHaveCSS("transform", "none");
+  await expect(scrollContainer).toHaveCSS("will-change", "auto");
   await expect(settingsDialog.locator(".theme-card-soft").first()).toHaveCSS("backdrop-filter", "none");
   const scrollInteraction = await collectLongTasksDuring(page, () =>
     measureFps(page, async () => {

--- a/packages/ui/src/components/SettingsDialog.tsx
+++ b/packages/ui/src/components/SettingsDialog.tsx
@@ -1050,8 +1050,6 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
       : {
           minHeight: "calc(100% + 20rem)",
           contain: "layout paint style",
-          contentVisibility: "auto",
-          containIntrinsicSize: "54rem",
         };
     const shouldRenderContent = renderedSectionIds.has(id);
 

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -2088,7 +2088,6 @@ html.freed-mobile-sidebar-open body {
     0 0 0 1px rgb(255 255 255 / 0.025);
   backdrop-filter: none;
   -webkit-backdrop-filter: none;
-  transform: translateZ(0);
 }
 
 .theme-settings-shell[data-moving="true"] .theme-card-soft {
@@ -2098,8 +2097,7 @@ html.freed-mobile-sidebar-open body {
 }
 
 .theme-settings-shell[data-moving="true"] .theme-settings-scrollport {
-  transform: translateZ(0);
-  will-change: scroll-position;
+  will-change: auto;
 }
 
 .theme-settings-shell[data-moving="true"] .theme-dialog-section {


### PR DESCRIPTION
(AI Generated).

## Summary
- Reduces Settings scroll paint work by avoiding content-visibility bookkeeping on tall section placeholders.
- Stops promoting the full Settings shell and scrollport while the dialog is moving, which avoids an oversized composited layer during scroll.
- Adds a perf regression assertion so the moving state keeps backdrop blur disabled without transform or will-change promotion.

## Testing
- CI=true PATH="/Users/aubreyfalconer/dev/freed-settings-scroll-overdraw/node_modules/.bin:$PATH" node ../../node_modules/playwright/cli.js test perf-settings.spec.ts --repeat-each=5 --workers=1
- npm run validate:feature