### PR TITLE
perf: reduce dense map movement paint

### DIFF
--- a/packages/desktop/tests/e2e/perf-map.spec.ts
+++ b/packages/desktop/tests/e2e/perf-map.spec.ts
@@ -8,7 +8,7 @@ const MAP_FRAME_P95_BUDGET_MS = process.env.CI ? 67 : 50;
 const MAP_DROPPED_FRAME_BUDGET = process.env.CI ? 40 : 12;
 const MAP_LONG_TASK_COUNT_BUDGET = process.env.CI ? 4 : 2;
 const MAP_MARKER_DOM_BUDGET = 160;
-const MAP_MOVING_MARKER_PAINT_BUDGET = 48;
+const MAP_MOVING_MARKER_PAINT_BUDGET = 32;
 
 async function seedLargeMapWorkspace(page: Page): Promise<void> {
   await page.evaluate(async ({ authorCount, itemCount }) => {

--- a/packages/ui/src/components/map/MapSurface.tsx
+++ b/packages/ui/src/components/map/MapSurface.tsx
@@ -45,7 +45,7 @@ const popupDateFormatter = new Intl.DateTimeFormat(undefined, {
 const MAP_POPUP_MAX_WIDTH = 560;
 const MAP_POPUP_VIEWPORT_MARGIN = 40;
 const MAP_DOM_MARKER_LIMIT = 160;
-const MAP_MOVING_MARKER_PAINT_LIMIT = 48;
+const MAP_MOVING_MARKER_PAINT_LIMIT = 32;
 const MAP_VIEWPORT_MASK_STYLE = {
   "--theme-soft-viewport-mask-size": "20px",
 } as CSSProperties;
@@ -367,7 +367,7 @@ function mapStyles(interactive: boolean) {
       filter: none;
     }
 
-    .freed-map-shell[data-map-moving="true"] .freed-map-marker {
+    .freed-map-shell[data-map-moving="true"] .freed-map-marker[data-map-moving-priority="primary"] {
       will-change: transform;
     }
 


### PR DESCRIPTION
(AI Generated).

## Summary
- Reduce dense Map movement painting from 48 to 32 primary markers.
- Limit movement-time will-change to visible primary markers instead of all rendered markers.

## Testing
- npx playwright test tests/e2e/perf-map.spec.ts --repeat-each=3 --workers=1
- npm run validate:feature