### PR TITLE
perf: lighten settings moving chrome

### DIFF
--- a/packages/desktop/tests/e2e/perf-settings.spec.ts
+++ b/packages/desktop/tests/e2e/perf-settings.spec.ts
@@ -164,6 +164,7 @@ test("Settings dialog stays responsive with 1,600 RSS sources", async ({ app, pa
   const settingsShell = settingsDialog.locator(".theme-settings-shell");
   await expect(settingsShell).toHaveAttribute("data-moving", "true");
   await expect(settingsShell).toHaveCSS("transform", "none");
+  await expect(settingsShell).toHaveCSS("box-shadow", "none");
   await expect(scrollContainer).toHaveCSS("will-change", "auto");
   await expect(settingsDialog.locator(".theme-card-soft").first()).toHaveCSS("backdrop-filter", "none");
   const scrollInteraction = await collectLongTasksDuring(page, () =>

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -2081,15 +2081,6 @@ html.freed-mobile-sidebar-open body {
   transition: none;
 }
 
-.theme-settings-shell[data-moving="true"] {
-  box-shadow:
-    inset 0 1px 0 rgb(255 255 255 / 0.05),
-    0 20px 56px rgb(0 0 0 / 0.24),
-    0 0 0 1px rgb(255 255 255 / 0.025);
-  backdrop-filter: none;
-  -webkit-backdrop-filter: none;
-}
-
 .theme-settings-shell[data-moving="true"] .theme-card-soft {
   box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.035);
   backdrop-filter: none;
@@ -2187,7 +2178,7 @@ html[data-theme="scriptorium"] .theme-dialog-shell::before {
   overscroll-behavior: contain;
 }
 
-html[data-theme="scriptorium"] .theme-settings-shell {
+html[data-theme="scriptorium"] .theme-settings-shell:not([data-moving="true"]) {
   box-shadow:
     inset 0 1px 0 rgb(255 255 255 / 0.032),
     inset 0 0 0 0.5px rgb(255 255 255 / 0.018),
@@ -2195,6 +2186,12 @@ html[data-theme="scriptorium"] .theme-settings-shell {
     0 72px 188px rgb(84 58 35 / 0.34),
     0 0 56px rgb(84 58 35 / 0.08),
     0 0 0 1px rgb(255 255 255 / 0.04);
+}
+
+.theme-dialog-shell.theme-settings-shell[data-moving="true"] {
+  box-shadow: none;
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
 }
 
 .theme-dialog-divider {


### PR DESCRIPTION
(AI Generated).

## Summary
- Remove the Settings dialog shell shadow while the panel is moving or scrolling.
- Keep the Settings perf guard asserting that moving Settings chrome has no transform, shell shadow, or heavy backdrop work.

## Testing
- npx playwright test tests/e2e/perf-settings.spec.ts --repeat-each=5 --workers=1
- npm run validate:feature