### PR TITLE
fix: keep dense map focused marker visible

### DIFF
--- a/packages/ui/src/components/map/MapSurface.test.ts
+++ b/packages/ui/src/components/map/MapSurface.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { LocationMarkerSummary } from "@freed/shared";
-import { areLocationMarkerListsRenderEquivalent } from "./MapSurface";
+import {
+  areLocationMarkerListsRenderEquivalent,
+  getMapMovingPriority,
+  getRenderedMapMarkers,
+} from "./MapSurface";
 
 const NOW = Date.UTC(2026, 4, 9, 18, 0, 0);
 
@@ -82,5 +86,41 @@ describe("areLocationMarkerListsRenderEquivalent", () => {
     ];
 
     expect(areLocationMarkerListsRenderEquivalent(current, next)).toBe(false);
+  });
+});
+
+describe("dense map marker prioritization", () => {
+  it("keeps the focused marker visible during dense-map movement", () => {
+    const markers = Array.from({ length: 161 }, (_, index) =>
+      marker({
+        key: `friend:${index}`,
+        authorKey: `author:instagram:${index}`,
+        item: {
+          ...marker().item,
+          globalId: `instagram:${index}`,
+          author: {
+            ...marker().item.author,
+            id: `ada-ig-${index}`,
+            handle: `ada-${index}`,
+            displayName: `Ada ${index.toLocaleString()}`,
+          },
+        },
+      })
+    );
+    const focusedMarkerKey = "friend:160";
+
+    const renderedMarkers = getRenderedMapMarkers(markers, focusedMarkerKey);
+    const focusedMarkerIndex = renderedMarkers.findIndex((entry) => entry.key === focusedMarkerKey);
+
+    expect(renderedMarkers).toHaveLength(160);
+    expect(focusedMarkerIndex).toBe(159);
+    expect(
+      getMapMovingPriority(
+        focusedMarkerIndex,
+        focusedMarkerKey,
+        true,
+        focusedMarkerKey,
+      ),
+    ).toBe("primary");
   });
 });

--- a/packages/ui/src/components/map/MapSurface.tsx
+++ b/packages/ui/src/components/map/MapSurface.tsx
@@ -430,6 +430,33 @@ function mapMovingPriority(markerIndex: number, useDenseMarkers: boolean): "prim
     : "primary";
 }
 
+export function getRenderedMapMarkers(
+  markers: LocationMarkerSummary[],
+  focusedMarkerKey?: string | null,
+): LocationMarkerSummary[] {
+  const baseRenderedMarkers = markers.length <= MAP_DOM_MARKER_LIMIT
+    ? markers
+    : markers.slice(0, MAP_DOM_MARKER_LIMIT);
+  if (markers.length <= MAP_DOM_MARKER_LIMIT) return baseRenderedMarkers;
+  if (!focusedMarkerKey || baseRenderedMarkers.some((marker) => marker.key === focusedMarkerKey)) {
+    return baseRenderedMarkers;
+  }
+
+  const focusedMarker = markers.find((marker) => marker.key === focusedMarkerKey);
+  if (!focusedMarker) return baseRenderedMarkers;
+  return [...baseRenderedMarkers.slice(0, MAP_DOM_MARKER_LIMIT - 1), focusedMarker];
+}
+
+export function getMapMovingPriority(
+  markerIndex: number,
+  markerKey: string,
+  useDenseMarkers: boolean,
+  focusedMarkerKey?: string | null,
+): "primary" | "deferred" {
+  if (markerKey === focusedMarkerKey) return "primary";
+  return mapMovingPriority(markerIndex, useDenseMarkers);
+}
+
 function areLocationMarkersRenderEquivalent(
   current: LocationMarkerSummary,
   next: LocationMarkerSummary,
@@ -649,22 +676,9 @@ export function MapSurface({
   });
 
   const stableMarkers = useStableLocationMarkers(markers);
-  const baseRenderedMarkers = useMemo(
-    () => stableMarkers.length <= MAP_DOM_MARKER_LIMIT
-      ? stableMarkers
-      : stableMarkers.slice(0, MAP_DOM_MARKER_LIMIT),
-    [stableMarkers],
-  );
   const renderedMarkers = useMemo(() => {
-    if (stableMarkers.length <= MAP_DOM_MARKER_LIMIT) return baseRenderedMarkers;
-    if (!focusedMarkerKey || baseRenderedMarkers.some((marker) => marker.key === focusedMarkerKey)) {
-      return baseRenderedMarkers;
-    }
-
-    const focusedMarker = stableMarkers.find((marker) => marker.key === focusedMarkerKey);
-    if (!focusedMarker) return baseRenderedMarkers;
-    return [...baseRenderedMarkers.slice(0, MAP_DOM_MARKER_LIMIT - 1), focusedMarker];
-  }, [baseRenderedMarkers, focusedMarkerKey, stableMarkers]);
+    return getRenderedMapMarkers(stableMarkers, focusedMarkerKey);
+  }, [focusedMarkerKey, stableMarkers]);
   const useDenseMarkers = stableMarkers.length > MAP_DOM_MARKER_LIMIT;
   const showMarkerAvatars = !useDenseMarkers;
   const avatarPalette = useMemo(
@@ -823,7 +837,12 @@ export function MapSurface({
         showAvatar: showMarkerAvatars,
         simplified: useDenseMarkers,
       });
-      element.dataset.mapMovingPriority = mapMovingPriority(markerIndex, useDenseMarkers);
+      element.dataset.mapMovingPriority = getMapMovingPriority(
+        markerIndex,
+        markerData.key,
+        useDenseMarkers,
+        focusedMarkerKey,
+      );
       const marker = new maplibre.Marker({ element }).setLngLat([
         markerData.lng,
         markerData.lat,
@@ -974,7 +993,12 @@ export function MapSurface({
               <button
                 key={marker.key}
                 type="button"
-                data-map-moving-priority={mapMovingPriority(markerIndex, useDenseMarkers)}
+                data-map-moving-priority={getMapMovingPriority(
+                  markerIndex,
+                  marker.key,
+                  useDenseMarkers,
+                  focusedMarkerKey,
+                )}
                 className="freed-map-marker absolute -translate-x-1/2 -translate-y-1/2 rounded-full px-2.5 py-1.5 text-[11px] text-[color:var(--theme-text-primary)]"
                 style={{
                   ...position,


### PR DESCRIPTION
(AI Generated).

## What changed
- keep dense-map marker truncation and movement priority in shared helpers
- exempt the focused marker from deferred movement priority in both the MapLibre and fallback marker paths
- add a regression test that covers a 161-marker dense set with the focused marker appended at the tail

## Why
`5ff7beae` lowered `MAP_MOVING_MARKER_PAINT_LIMIT` from `48` to `32`, which made the existing focused-marker handoff bug easier to trigger. A focused marker appended beyond the dense slice could still be tagged `deferred` while the map was moving, so the selected marker disappeared during handoff.

## Validation
- `PATH=../../node_modules/.bin:$PATH vitest run src/components/map/MapSurface.test.ts`
