### PR TITLE
perf: skip hidden friends provider labels

### DIFF
--- a/packages/desktop/tests/e2e/perf-friends.spec.ts
+++ b/packages/desktop/tests/e2e/perf-friends.spec.ts
@@ -39,6 +39,7 @@ async function readGraphDebug(page: Page) {
           avatarDisplayCount: number;
           visibleLabelCount: number;
           visibleNodeLabelCount: number;
+          visibleProviderLabelCount: number;
           transformOnlySyncCount: number;
           denseRenderMode: "dense" | "containers";
           denseInteractionEligible: boolean;
@@ -292,6 +293,7 @@ test("Friends view handles 1,600 visible people while zooming and panning", asyn
   });
 
   let denseInteractionNodeCount = 0;
+  let maxInteractiveProviderLabelCount = 0;
   const interaction = await collectLongTasksDuring(page, () =>
     measureFps(page, async () => {
       for (let index = 0; index < 18; index += 1) {
@@ -314,6 +316,12 @@ test("Friends view handles 1,600 visible people while zooming and panning", asyn
           const debug = await readGraphDebug(page);
           const nodeCount = debug?.metrics.denseInteractionNodeCount ?? 0;
           denseInteractionNodeCount = Math.max(denseInteractionNodeCount, nodeCount);
+          if (debug?.qualityMode === "interactive") {
+            maxInteractiveProviderLabelCount = Math.max(
+              maxInteractiveProviderLabelCount,
+              debug.metrics.visibleProviderLabelCount,
+            );
+          }
           return nodeCount;
         }, { timeout: 5_000 })
         .toBeGreaterThan(0);
@@ -354,6 +362,7 @@ test("Friends view handles 1,600 visible people while zooming and panning", asyn
   expect(interaction.result.sampleCount).toBeGreaterThan(0);
   expect(denseInteractionNodeCount).toBeGreaterThan(0);
   expect(denseInteractionNodeCount).toBeLessThanOrEqual(DENSE_INTERACTION_NODE_BUDGET);
+  expect(maxInteractiveProviderLabelCount).toBe(0);
   expect(afterInteraction!.metrics.denseInteractionRebuildCount).toBeLessThanOrEqual(16);
   if (process.env.CI) {
     expect(afterInteraction!.metrics.sceneSyncMs).toBeLessThan(GRAPH_SCENE_SYNC_BUDGET_MS);

--- a/packages/ui/src/components/friends/FriendGraph.tsx
+++ b/packages/ui/src/components/friends/FriendGraph.tsx
@@ -1475,58 +1475,60 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
     const providerMetrics = providerLabelMetrics(transform.scale);
     const providerLabelScale = 1 / transform.scale;
     let visibleProviderLabelCount = 0;
-    for (const region of layoutRef.current.regions) {
-      const display = scene.regionDisplays.get(region.id);
-      if (!display) continue;
-      const fill = providerColor(region.provider, graphPalette);
-      const point = screenPointForPosition({ x: region.x, y: region.y }, transform);
-      const onScreen =
-        point.x >= -160 &&
-        point.x <= canvasSize.width + 160 &&
-        point.y >= -160 &&
-        point.y <= canvasSize.height + 160;
-      display.container.visible = onScreen;
-      if (!onScreen) continue;
+    if (!isInteractivePaint) {
+      for (const region of layoutRef.current.regions) {
+        const display = scene.regionDisplays.get(region.id);
+        if (!display) continue;
+        const fill = providerColor(region.provider, graphPalette);
+        const point = screenPointForPosition({ x: region.x, y: region.y }, transform);
+        const onScreen =
+          point.x >= -160 &&
+          point.x <= canvasSize.width + 160 &&
+          point.y >= -160 &&
+          point.y <= canvasSize.height + 160;
+        display.container.visible = onScreen;
+        if (!onScreen) continue;
 
-      visibleProviderLabelCount += 1;
-      const label = `${region.label} ${region.count.toLocaleString()}`;
-      const labelWidth = estimateLabelWidth(label, providerMetrics.fontSize) +
-        providerMetrics.paddingX * 2;
-      display.container.position.set(
-        region.x,
-        region.y - region.radiusY - providerMetrics.gap / transform.scale,
-      );
-      display.container.scale.set(providerLabelScale);
-      display.container.alpha = highlighted.size > 0
-        ? providerMetrics.alpha * 0.52
-        : providerMetrics.alpha;
-      display.background.clear();
-      display.background.lineStyle(1.2, fill, 0.58);
-      display.background.beginFill(graphPalette.labelFill, 0.88);
-      display.background.drawRoundedRect(
-        -labelWidth / 2,
-        -providerMetrics.height / 2,
-        labelWidth,
-        providerMetrics.height,
-        providerMetrics.height / 2,
-      );
-      display.background.endFill();
-      display.text.text = label;
-      display.text.style = getCachedTextStyle(
-        [
-          "region",
-          themeId ?? "default",
-          region.provider,
-          providerMetrics.fontSize,
-        ].join(":"),
-        {
-          fill,
-          fontFamily: themeId === "scriptorium" ? "Georgia, serif" : "system-ui, sans-serif",
-          fontSize: providerMetrics.fontSize,
-          fontWeight: "700",
-          letterSpacing: 1,
-        },
-      );
+        visibleProviderLabelCount += 1;
+        const label = `${region.label} ${region.count.toLocaleString()}`;
+        const labelWidth = estimateLabelWidth(label, providerMetrics.fontSize) +
+          providerMetrics.paddingX * 2;
+        display.container.position.set(
+          region.x,
+          region.y - region.radiusY - providerMetrics.gap / transform.scale,
+        );
+        display.container.scale.set(providerLabelScale);
+        display.container.alpha = highlighted.size > 0
+          ? providerMetrics.alpha * 0.52
+          : providerMetrics.alpha;
+        display.background.clear();
+        display.background.lineStyle(1.2, fill, 0.58);
+        display.background.beginFill(graphPalette.labelFill, 0.88);
+        display.background.drawRoundedRect(
+          -labelWidth / 2,
+          -providerMetrics.height / 2,
+          labelWidth,
+          providerMetrics.height,
+          providerMetrics.height / 2,
+        );
+        display.background.endFill();
+        display.text.text = label;
+        display.text.style = getCachedTextStyle(
+          [
+            "region",
+            themeId ?? "default",
+            region.provider,
+            providerMetrics.fontSize,
+          ].join(":"),
+          {
+            fill,
+            fontFamily: themeId === "scriptorium" ? "Georgia, serif" : "system-ui, sans-serif",
+            fontSize: providerMetrics.fontSize,
+            fontWeight: "700",
+            letterSpacing: 1,
+          },
+        );
+      }
     }
 
     scene.hoverLayer.clear();


### PR DESCRIPTION
(AI Generated).

## Summary
- Skip provider-region label layout while the Friends graph is in interactive pan or zoom mode, since that layer is hidden during motion.

## Testing
- npm run test:e2e:perf:friends
- npm run validate:feature