### PR TITLE
perf: reduce dense map motion paint

### DIFF
--- a/packages/desktop/tests/e2e/perf-map.spec.ts
+++ b/packages/desktop/tests/e2e/perf-map.spec.ts
@@ -8,7 +8,7 @@ const MAP_FRAME_P95_BUDGET_MS = process.env.CI ? 67 : 50;
 const MAP_DROPPED_FRAME_BUDGET = process.env.CI ? 40 : 12;
 const MAP_LONG_TASK_COUNT_BUDGET = process.env.CI ? 4 : 2;
 const MAP_MARKER_DOM_BUDGET = 160;
-const MAP_MOVING_MARKER_PAINT_BUDGET = 32;
+const MAP_MOVING_MARKER_PAINT_BUDGET = 24;
 
 async function seedLargeMapWorkspace(page: Page): Promise<void> {
   await page.evaluate(async ({ authorCount, itemCount }) => {

--- a/packages/ui/src/components/map/MapSurface.test.ts
+++ b/packages/ui/src/components/map/MapSurface.test.ts
@@ -90,6 +90,12 @@ describe("areLocationMarkerListsRenderEquivalent", () => {
 });
 
 describe("dense map marker prioritization", () => {
+  it("limits paint-active markers while dense maps are moving", () => {
+    expect(getMapMovingPriority(23, "friend:23", true, null)).toBe("primary");
+    expect(getMapMovingPriority(24, "friend:24", true, null)).toBe("deferred");
+    expect(getMapMovingPriority(80, "friend:80", false, null)).toBe("primary");
+  });
+
   it("keeps the focused marker visible during dense-map movement", () => {
     const markers = Array.from({ length: 161 }, (_, index) =>
       marker({

--- a/packages/ui/src/components/map/MapSurface.tsx
+++ b/packages/ui/src/components/map/MapSurface.tsx
@@ -45,7 +45,7 @@ const popupDateFormatter = new Intl.DateTimeFormat(undefined, {
 const MAP_POPUP_MAX_WIDTH = 560;
 const MAP_POPUP_VIEWPORT_MARGIN = 40;
 const MAP_DOM_MARKER_LIMIT = 160;
-const MAP_MOVING_MARKER_PAINT_LIMIT = 32;
+const MAP_MOVING_MARKER_PAINT_LIMIT = 24;
 const MAP_VIEWPORT_MASK_STYLE = {
   "--theme-soft-viewport-mask-size": "20px",
 } as CSSProperties;


### PR DESCRIPTION
(AI Generated).

## Summary
- Keep fewer dense Map DOM markers paint-active during pan and zoom so WebKit does less marker layer work while MapLibre moves the camera.
- Preserve the 160 marker DOM cap and focused marker visibility while lowering the dense movement paint budget from 32 to 24 markers.

## Testing
- node node_modules/vitest/vitest.mjs run packages/ui/src/components/map/MapSurface.test.ts
- npm run test:e2e -- tests/e2e/perf-map.spec.ts
- npm run validate:feature