### PR TITLE
perf: cull dense map markers during motion

### DIFF
--- a/packages/desktop/tests/e2e/perf-map.spec.ts
+++ b/packages/desktop/tests/e2e/perf-map.spec.ts
@@ -208,9 +208,11 @@ test("Map view handles 1,600 visible location authors within frame budget", asyn
       .filter((marker) => window.getComputedStyle(marker).display !== "none")
       .length,
   );
+  const movingAttachedMarkerCount = await page.locator(".freed-map-marker").count();
   await expect
     .poll(async () => page.getByTestId("map-surface").getAttribute("data-map-moving"), { timeout: 2_000 })
     .toBe("false");
+  const restoredMarkerCount = await page.locator(".freed-map-marker").count();
 
   const interaction = await collectLongTasksDuring(page, () =>
     measureFps(page, async () => {
@@ -229,6 +231,8 @@ test("Map view handles 1,600 visible location authors within frame budget", asyn
   console.log(`[PERF] Map moving primary markers: ${movingPrimaryMarkerCount.toLocaleString()}`);
   console.log(`[PERF] Map moving deferred markers: ${movingDeferredMarkerCount.toLocaleString()}`);
   console.log(`[PERF] Map visible markers while moving: ${movingVisibleMarkerCount.toLocaleString()}`);
+  console.log(`[PERF] Map attached markers while moving: ${movingAttachedMarkerCount.toLocaleString()}`);
+  console.log(`[PERF] Map restored markers after moving: ${restoredMarkerCount.toLocaleString()}`);
   console.log(`[PERF] Map stable markers after timer refresh: ${retainedMarkerCount.toLocaleString()}`);
   console.log(`[PERF] Map total markers: ${totalMarkerCount.toLocaleString()}`);
   console.log(`[PERF] Map DOM nodes: ${domNodeCount.toLocaleString()}`);
@@ -245,6 +249,8 @@ test("Map view handles 1,600 visible location authors within frame budget", asyn
   expect(movingPrimaryMarkerCount).toBeLessThanOrEqual(MAP_MOVING_MARKER_PAINT_BUDGET);
   expect(movingPrimaryMarkerCount + movingDeferredMarkerCount).toBe(markerCount);
   expect(movingVisibleMarkerCount).toBeLessThanOrEqual(MAP_MOVING_MARKER_PAINT_BUDGET);
+  expect(movingAttachedMarkerCount).toBeLessThanOrEqual(MAP_MOVING_MARKER_PAINT_BUDGET);
+  expect(restoredMarkerCount).toBe(markerCount);
   expect(interaction.result.p95Ms).toBeLessThan(MAP_FRAME_P95_BUDGET_MS);
   expect(interaction.result.droppedFrames).toBeLessThanOrEqual(MAP_DROPPED_FRAME_BUDGET);
   expect(interaction.count).toBeLessThanOrEqual(MAP_LONG_TASK_COUNT_BUDGET);

--- a/packages/ui/src/components/map/MapSurface.tsx
+++ b/packages/ui/src/components/map/MapSurface.tsx
@@ -19,6 +19,12 @@ import { buildThemedMapStyle } from "../../lib/map-style.js";
 type PopupInstance = MapLibrePopup;
 type MarkerInstance = MapLibreMarker;
 type MapInstance = MapLibreMap;
+type MapMarkerMovingPriority = "primary" | "deferred";
+interface MapMarkerRecord {
+  marker: MarkerInstance;
+  priority: MapMarkerMovingPriority;
+  attached: boolean;
+}
 
 type MapLibreModule = typeof import("maplibre-gl");
 
@@ -46,6 +52,7 @@ const MAP_POPUP_MAX_WIDTH = 560;
 const MAP_POPUP_VIEWPORT_MARGIN = 40;
 const MAP_DOM_MARKER_LIMIT = 160;
 const MAP_MOVING_MARKER_PAINT_LIMIT = 24;
+const MAP_DENSE_MARKER_RESTORE_DELAY_MS = 420;
 const MAP_VIEWPORT_MASK_STYLE = {
   "--theme-soft-viewport-mask-size": "20px",
 } as CSSProperties;
@@ -424,7 +431,7 @@ function fallbackLabel(marker: LocationMarkerSummary) {
   return marker.friend?.name ?? marker.item.author.displayName;
 }
 
-function mapMovingPriority(markerIndex: number, useDenseMarkers: boolean): "primary" | "deferred" {
+function mapMovingPriority(markerIndex: number, useDenseMarkers: boolean): MapMarkerMovingPriority {
   return useDenseMarkers && markerIndex >= MAP_MOVING_MARKER_PAINT_LIMIT
     ? "deferred"
     : "primary";
@@ -452,7 +459,7 @@ export function getMapMovingPriority(
   markerKey: string,
   useDenseMarkers: boolean,
   focusedMarkerKey?: string | null,
-): "primary" | "deferred" {
+): MapMarkerMovingPriority {
   if (markerKey === focusedMarkerKey) return "primary";
   return mapMovingPriority(markerIndex, useDenseMarkers);
 }
@@ -659,12 +666,15 @@ export function MapSurface({
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<MapInstance | null>(null);
   const mapModuleRef = useRef<MapLibreModule | null>(null);
-  const markersRef = useRef<MarkerInstance[]>([]);
+  const markersRef = useRef<MapMarkerRecord[]>([]);
   const shellRef = useRef<HTMLDivElement | null>(null);
   const fallbackMovingTimeoutRef = useRef<number | null>(null);
+  const nativeMarkerRestoreTimeoutRef = useRef<number | null>(null);
   const mapLifecycleRef = useRef(0);
+  const useDenseMarkersRef = useRef(false);
   const [mapReady, setMapReady] = useState(false);
   const [loadFailed, setLoadFailed] = useState(false);
+  const [fallbackMoving, setFallbackMoving] = useState(false);
   const [selectedFallbackMarkerKey, setSelectedFallbackMarkerKey] = useState<string | null>(null);
   const activePopupRef = useRef<PopupInstance | null>(null);
   const activePopupKeyRef = useRef<string | null>(null);
@@ -694,6 +704,17 @@ export function MapSurface({
     [renderedMarkers, selectedFallbackMarkerKey]
   );
   const showFallback = loadFailed || !mapReady;
+  const fallbackRenderedMarkers = useMemo(() => {
+    if (!showFallback || !fallbackMoving || !useDenseMarkers) return renderedMarkers;
+    return renderedMarkers.filter((marker, markerIndex) => {
+      return getMapMovingPriority(
+        markerIndex,
+        marker.key,
+        true,
+        focusedMarkerKey,
+      ) === "primary";
+    });
+  }, [fallbackMoving, focusedMarkerKey, renderedMarkers, showFallback, useDenseMarkers]);
   const closeActivePopup = useCallback(() => {
     activePopupRef.current?.remove();
     activePopupRef.current = null;
@@ -704,6 +725,35 @@ export function MapSurface({
     window.clearTimeout(fallbackMovingTimeoutRef.current);
     fallbackMovingTimeoutRef.current = null;
   }, []);
+  const clearNativeMarkerRestoreTimeout = useCallback(() => {
+    if (nativeMarkerRestoreTimeoutRef.current === null || typeof window === "undefined") return;
+    window.clearTimeout(nativeMarkerRestoreTimeoutRef.current);
+    nativeMarkerRestoreTimeoutRef.current = null;
+  }, []);
+  const syncNativeMarkerMotionLayer = useCallback((moving: boolean) => {
+    const map = mapRef.current;
+    if (!map) return;
+
+    const shouldCullDeferredMarkers = moving && useDenseMarkersRef.current;
+    for (const record of markersRef.current) {
+      const shouldAttach = !shouldCullDeferredMarkers || record.priority === "primary";
+      if (shouldAttach === record.attached) continue;
+
+      if (shouldAttach) {
+        try {
+          record.marker.addTo(map);
+          record.attached = true;
+        } catch (error) {
+          record.attached = false;
+          console.error("[MapSurface] Failed to restore map marker", error);
+        }
+        continue;
+      }
+
+      record.marker.remove();
+      record.attached = false;
+    }
+  }, []);
   const setShellMoving = useCallback((moving: boolean) => {
     const shell = shellRef.current;
     if (!shell) return;
@@ -711,10 +761,12 @@ export function MapSurface({
   }, []);
   const markFallbackMoving = useCallback(() => {
     if (!showFallback || typeof window === "undefined") return;
+    setFallbackMoving(true);
     setShellMoving(true);
     clearFallbackMovingTimeout();
     fallbackMovingTimeoutRef.current = window.setTimeout(() => {
       fallbackMovingTimeoutRef.current = null;
+      setFallbackMoving(false);
       setShellMoving(false);
     }, 220);
   }, [clearFallbackMovingTimeout, setShellMoving, showFallback]);
@@ -729,10 +781,24 @@ export function MapSurface({
     markFallbackMoving();
   }, [markFallbackMoving]);
 
+  useEffect(() => {
+    useDenseMarkersRef.current = useDenseMarkers;
+    if (!useDenseMarkers) {
+      syncNativeMarkerMotionLayer(false);
+    }
+  }, [syncNativeMarkerMotionLayer, useDenseMarkers]);
+
   useEffect(() => () => {
     clearFallbackMovingTimeout();
+    clearNativeMarkerRestoreTimeout();
     setShellMoving(false);
-  }, [clearFallbackMovingTimeout, setShellMoving]);
+  }, [clearFallbackMovingTimeout, clearNativeMarkerRestoreTimeout, setShellMoving]);
+
+  useEffect(() => {
+    if (showFallback) return;
+    clearFallbackMovingTimeout();
+    setFallbackMoving(false);
+  }, [clearFallbackMovingTimeout, showFallback]);
 
   useEffect(() => {
     actionHandlersRef.current = {
@@ -757,7 +823,8 @@ export function MapSurface({
       return () => {
         cancelled = true;
         closeActivePopup();
-        for (const marker of markersRef.current) marker.remove();
+        clearNativeMarkerRestoreTimeout();
+        for (const { marker } of markersRef.current) marker.remove();
         markersRef.current = [];
         mapRef.current?.remove();
         mapRef.current = null;
@@ -783,10 +850,17 @@ export function MapSurface({
         });
         mapRef.current = map;
         const setMoving = () => {
+          clearNativeMarkerRestoreTimeout();
+          syncNativeMarkerMotionLayer(true);
           setShellMoving(true);
         };
         const clearMoving = () => {
-          setShellMoving(false);
+          clearNativeMarkerRestoreTimeout();
+          nativeMarkerRestoreTimeoutRef.current = window.setTimeout(() => {
+            nativeMarkerRestoreTimeoutRef.current = null;
+            syncNativeMarkerMotionLayer(false);
+            setShellMoving(false);
+          }, MAP_DENSE_MARKER_RESTORE_DELAY_MS);
         };
         map.on("movestart", setMoving);
         map.on("zoomstart", setMoving);
@@ -809,20 +883,23 @@ export function MapSurface({
       cancelled = true;
       mapLifecycleRef.current += 1;
       closeActivePopup();
-      for (const marker of markersRef.current) marker.remove();
+      clearNativeMarkerRestoreTimeout();
+      for (const { marker } of markersRef.current) marker.remove();
       markersRef.current = [];
       mapRef.current?.remove();
       mapRef.current = null;
       setShellMoving(false);
     };
-  }, [closeActivePopup, interactive, resolvedThemeId, setShellMoving]);
+  }, [clearNativeMarkerRestoreTimeout, closeActivePopup, interactive, resolvedThemeId, setShellMoving, syncNativeMarkerMotionLayer]);
 
   useEffect(() => {
     if (!mapReady || !mapRef.current || !mapModuleRef.current) return;
 
     closeActivePopup();
-    for (const marker of markersRef.current) marker.remove();
+    clearNativeMarkerRestoreTimeout();
+    for (const { marker } of markersRef.current) marker.remove();
     markersRef.current = [];
+    setShellMoving(false);
 
     const map = mapRef.current;
     const maplibre = mapModuleRef.current;
@@ -833,16 +910,17 @@ export function MapSurface({
 
     for (const [markerIndex, markerData] of renderedMarkers.entries()) {
       if (stoppedEarly) break;
-      const element = createMarkerElement(markerData, avatarPalette, {
-        showAvatar: showMarkerAvatars,
-        simplified: useDenseMarkers,
-      });
-      element.dataset.mapMovingPriority = getMapMovingPriority(
+      const priority = getMapMovingPriority(
         markerIndex,
         markerData.key,
         useDenseMarkers,
         focusedMarkerKey,
       );
+      const element = createMarkerElement(markerData, avatarPalette, {
+        showAvatar: showMarkerAvatars,
+        simplified: useDenseMarkers,
+      });
+      element.dataset.mapMovingPriority = priority;
       const marker = new maplibre.Marker({ element }).setLngLat([
         markerData.lng,
         markerData.lat,
@@ -895,7 +973,7 @@ export function MapSurface({
 
       try {
         marker.addTo(map);
-        markersRef.current.push(marker);
+        markersRef.current.push({ marker, priority, attached: true });
       } catch (error) {
         marker.remove();
         if (mapRef.current === map && mapLifecycleRef.current === lifecycleId) {
@@ -910,7 +988,18 @@ export function MapSurface({
       map.off("click", handleMapClick);
       closeActivePopup();
     };
-  }, [avatarPalette, closeActivePopup, interactive, mapReady, renderedMarkers, showMarkerAvatars, useDenseMarkers]);
+  }, [
+    avatarPalette,
+    clearNativeMarkerRestoreTimeout,
+    closeActivePopup,
+    focusedMarkerKey,
+    interactive,
+    mapReady,
+    renderedMarkers,
+    setShellMoving,
+    showMarkerAvatars,
+    useDenseMarkers,
+  ]);
 
   useEffect(() => {
     if (!mapReady || !mapRef.current) return;
@@ -987,14 +1076,15 @@ export function MapSurface({
               )`,
             }}
           />
-          {renderedMarkers.map((marker, markerIndex) => {
+          {fallbackRenderedMarkers.map((marker) => {
             const position = fallbackPosition(marker);
+            const renderedMarkerIndex = renderedMarkers.findIndex((entry) => entry.key === marker.key);
             return (
               <button
                 key={marker.key}
                 type="button"
                 data-map-moving-priority={getMapMovingPriority(
-                  markerIndex,
+                  renderedMarkerIndex,
                   marker.key,
                   useDenseMarkers,
                   focusedMarkerKey,


### PR DESCRIPTION
(AI Generated).

## Summary
- Dense Map motion now keeps only the active marker budget attached while pan or zoom is in progress, then restores the full capped marker set after motion settles.
- The fallback renderer gets the same active-marker cull so headless Chromium and installed native Map both avoid carrying all 160 dense marker nodes through motion.
- The 1,600-author Map perf test now asserts attached marker count during motion, not just visible marker count.

## Tests
- CI=true npm run test:e2e -- tests/e2e/perf-map.spec.ts
- npm run validate:feature