### PR TITLE
perf: settle dense map marker restoration

### DIFF
--- a/packages/desktop/src/lib/content-signals.test.ts
+++ b/packages/desktop/src/lib/content-signals.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { FeedItem } from "@freed/shared";
 import {
   applyFeedSignalModeToFilter,
@@ -49,6 +49,10 @@ function makeItem(overrides: Partial<FeedItem> = {}): FeedItem {
 }
 
 describe("content signals", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("infers multiple signals for promoted events", () => {
     const signals = inferContentSignals(
       makeItem({
@@ -227,6 +231,9 @@ describe("content signals", () => {
   });
 
   it("stores compact event metadata during schema insertion", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-25T12:00:00Z"));
+
     const doc = plainDoc();
     addFeedItem(doc, makeItem({
       content: {
@@ -245,6 +252,9 @@ describe("content signals", () => {
   });
 
   it("does not overwrite stronger existing locations", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-25T12:00:00Z"));
+
     const doc = plainDoc();
     addFeedItem(doc, makeItem({
       location: {

--- a/packages/ui/src/components/map/MapSurface.tsx
+++ b/packages/ui/src/components/map/MapSurface.tsx
@@ -768,7 +768,7 @@ export function MapSurface({
       fallbackMovingTimeoutRef.current = null;
       setFallbackMoving(false);
       setShellMoving(false);
-    }, 220);
+    }, MAP_DENSE_MARKER_RESTORE_DELAY_MS);
   }, [clearFallbackMovingTimeout, setShellMoving, showFallback]);
   const handleFallbackWheel = useCallback((_event: WheelEvent<HTMLDivElement>) => {
     markFallbackMoving();


### PR DESCRIPTION
(AI Generated).

## Summary
- Keep fallback dense Map markers culled through the same motion settle tail used by the native Map path.
- Pin date-sensitive content-signal event tests so validation does not rot as the real calendar moves.

## Testing
- Focused Map E2E in CI mode: p95 25.9 ms, 2 dropped frames, 0 long tasks.
- npm run validate:feature: passed, including Map p95 25.3 ms and 0 long tasks.