### PR TITLE
perf: reduce desktop hydration and friends graph work

### DIFF
--- a/packages/desktop/src/lib/automerge-worker-memory.test.ts
+++ b/packages/desktop/src/lib/automerge-worker-memory.test.ts
@@ -63,8 +63,17 @@ describe("automerge worker memory routing", () => {
     expect(workerSource).toContain("linkDescription.slice(0, DESKTOP_UI_LINK_DESCRIPTION_LIMIT)");
     expect(workerSource).toContain("const tags = next.contentSignals.tags ?? []");
     expect(workerSource).toContain("contentSignals: tags.length > 0 ? ({ tags } as FeedItem[\"contentSignals\"]) : undefined");
-    expect(workerSource).toContain(".map(trimFeedItemForDesktopUi)");
+    expect(workerSource).toContain("cloneFeedItemsForDesktopUi");
     expect(patchBody).toContain("trimFeedItemForDesktopUi(cloned)");
+  });
+
+  it("hydrates desktop UI state without deep cloning the whole document first", () => {
+    const body = functionBody("hydrateFromDoc");
+
+    expect(body).not.toContain("A.toJS(doc)");
+    expect(body).toContain("cloneFeedItemsForDesktopUi");
+    expect(body).toContain("cloneRecordValues(doc.rssFeeds");
+    expect(body).toContain("docItemCount");
   });
 
   it("reader text requests fall back to full synced feed text", () => {

--- a/packages/desktop/src/lib/automerge.worker.ts
+++ b/packages/desktop/src/lib/automerge.worker.ts
@@ -281,6 +281,29 @@ function cloneFeedItemForPatch(item: FeedItem): FeedItem {
   return trimFeedItemForDesktopUi(cloned);
 }
 
+function cloneRecordValues<T>(record: Record<string, T> | undefined): Record<string, T> {
+  const cloned: Record<string, T> = {};
+  for (const [key, value] of Object.entries(record ?? {})) {
+    cloned[key] = JSON.parse(JSON.stringify(value)) as T;
+  }
+  return cloned;
+}
+
+function cloneFeedItemsForDesktopUi(record: Record<string, FeedItem> | undefined): {
+  items: FeedItem[];
+  totalCount: number;
+} {
+  const items: FeedItem[] = [];
+  let totalCount = 0;
+
+  for (const item of Object.values(record ?? {})) {
+    totalCount++;
+    items.push(cloneFeedItemForPatch(item));
+  }
+
+  return { items, totalCount };
+}
+
 function trimFeedItemForDesktopUi(item: FeedItem): FeedItem {
   let next: FeedItem = item;
   const preservedContent = item.preservedContent;
@@ -394,16 +417,18 @@ function healUntitledFeedTitles(doc: FreedDoc): number {
 
 /**
  * Convert the Automerge proxy document to a plain-JS DocState for postMessage.
- * Identical to the PWA worker — runs entirely off the main thread.
+ * Build the projection incrementally so large synced article bodies are
+ * trimmed before we hold a full deep clone of the document in worker memory.
  */
 function hydrateFromDoc(doc: FreedDoc): DocState {
-  const plain = A.toJS(doc) as FreedDoc;
-  const plainItems = Object.values(plain.feedItems as Record<string, FeedItem>).map(trimFeedItemForDesktopUi);
-  const feeds = plain.rssFeeds as Record<string, RssFeed>;
-  const persons = (plain.persons ?? {}) as Record<string, Person>;
-  const accounts = (plain.accounts ?? {}) as Record<string, Account>;
+  const { items: plainItems, totalCount: docItemCount } = cloneFeedItemsForDesktopUi(
+    doc.feedItems as Record<string, FeedItem> | undefined,
+  );
+  const feeds = cloneRecordValues(doc.rssFeeds as Record<string, RssFeed> | undefined);
+  const persons = cloneRecordValues(doc.persons as Record<string, Person> | undefined);
+  const accounts = cloneRecordValues(doc.accounts as Record<string, Account> | undefined);
   const friends = projectLegacyFriends(persons, accounts);
-  const preferences = mergeDefaultPreferences(plain.preferences as Partial<UserPreferences> | undefined);
+  const preferences = mergeDefaultPreferences(doc.preferences as Partial<UserPreferences> | undefined);
 
   const visibleItems = plainItems.filter((item) => !item.userState.hidden);
   const rankedItems = sortByPriority(
@@ -469,7 +494,7 @@ function hydrateFromDoc(doc: FreedDoc): DocState {
     archivableFeedCounts,
     mapFriendLocationCount: countFriendsWithRecentLocationUpdates(rankedItems, persons, accounts),
     mapAllContentLocationCount: countAuthorsWithRecentLocationUpdates(rankedItems),
-    docItemCount: Object.keys(plain.feedItems as Record<string, FeedItem>).length,
+    docItemCount,
   };
 }
 

--- a/packages/desktop/tests/e2e/perf-friends.spec.ts
+++ b/packages/desktop/tests/e2e/perf-friends.spec.ts
@@ -75,6 +75,20 @@ async function readLastRendererHeartbeat(page: Page) {
   });
 }
 
+async function readGraphPerf(page: Page) {
+  return page.evaluate(() => {
+    return (window as typeof window & {
+      __FREED_GRAPH_PERF__?: {
+        nodeCount?: number;
+        qualityMode?: "interactive" | "settled";
+        visibleProviderLabelCount?: number;
+        denseInteractionNodeCount?: number;
+        denseInteractionRebuildCount?: number;
+      };
+    }).__FREED_GRAPH_PERF__ ?? null;
+  });
+}
+
 async function seedLargeFriendsWorkspace(page: Page): Promise<void> {
   await page.evaluate(async ({ personCount, accountCount, itemCount }) => {
     const w = window as Record<string, unknown>;
@@ -186,7 +200,13 @@ async function measureFps(
 async function collectLongTasksDuring<T>(
   page: Page,
   fn: () => Promise<T>,
-): Promise<{ result: T; count: number; worstMs: number }> {
+): Promise<{
+  result: T;
+  count: number;
+  worstMs: number;
+  marks: Array<{ name: string; startTime: number }>;
+  tasks: Array<{ startTime: number; duration: number }>;
+}> {
   await page.evaluate(() => {
     const w = window as Record<string, unknown>;
     w.__FRIENDS_PERF_LONG_TASKS__ = [] as PerformanceEntry[];
@@ -208,6 +228,16 @@ async function collectLongTasksDuring<T>(
     return {
       count: tasks.length,
       worstMs: Math.max(0, ...tasks.map((task) => task.duration)),
+      tasks: tasks.map((task) => ({
+        startTime: Math.round(task.startTime * 10) / 10,
+        duration: Math.round(task.duration * 10) / 10,
+      })),
+      marks: performance.getEntriesByType("mark")
+        .filter((entry) => entry.name.startsWith("friends-"))
+        .map((entry) => ({
+          name: entry.name,
+          startTime: Math.round(entry.startTime * 10) / 10,
+        })),
     };
   });
 
@@ -215,6 +245,8 @@ async function collectLongTasksDuring<T>(
     result,
     count: taskData.count,
     worstMs: Math.round(taskData.worstMs * 10) / 10,
+    marks: taskData.marks,
+    tasks: taskData.tasks,
   };
 }
 
@@ -250,8 +282,8 @@ test("Friends view handles 1,600 visible people while zooming and panning", asyn
   await expect(viewport).toBeVisible({ timeout: 30_000 });
   await expect
     .poll(async () => {
-      const debug = await readGraphDebug(page);
-      return debug?.nodes.length ?? 0;
+      const perf = await readGraphPerf(page);
+      return perf?.nodeCount ?? 0;
     }, { timeout: 60_000 })
     .toBeGreaterThanOrEqual(PERSON_COUNT);
 
@@ -300,6 +332,7 @@ test("Friends view handles 1,600 visible people while zooming and panning", asyn
   let maxInteractiveProviderLabelCount = 0;
   const interaction = await collectLongTasksDuring(page, () =>
     measureFps(page, async () => {
+      await page.evaluate(() => performance.mark("friends-wheel-start"));
       for (let index = 0; index < 18; index += 1) {
         await viewport.evaluate((element) => {
           const rect = element.getBoundingClientRect();
@@ -314,26 +347,29 @@ test("Friends view handles 1,600 visible people while zooming and panning", asyn
         });
         await page.waitForTimeout(16);
       }
+      await page.evaluate(() => performance.mark("friends-wheel-end"));
 
       await expect
         .poll(async () => {
-          const debug = await readGraphDebug(page);
-          const nodeCount = debug?.metrics.denseInteractionNodeCount ?? 0;
+          const perf = await readGraphPerf(page);
+          const nodeCount = perf?.denseInteractionNodeCount ?? 0;
           denseInteractionNodeCount = Math.max(denseInteractionNodeCount, nodeCount);
-          if (debug?.qualityMode === "interactive") {
+          if (perf?.qualityMode === "interactive") {
             maxInteractiveProviderLabelCount = Math.max(
               maxInteractiveProviderLabelCount,
-              debug.metrics.visibleProviderLabelCount,
+              perf.visibleProviderLabelCount ?? 0,
             );
           }
           return nodeCount;
         }, { timeout: 5_000 })
         .toBeGreaterThan(0);
 
+      await page.evaluate(() => performance.mark("friends-drag-start"));
       await page.mouse.move(box.x + box.width * 0.52, box.y + box.height * 0.46);
       await page.mouse.down();
       await page.mouse.move(box.x + box.width * 0.7, box.y + box.height * 0.58, { steps: 24 });
       await page.mouse.up();
+      await page.evaluate(() => performance.mark("friends-drag-end"));
       await page.waitForTimeout(180);
     }),
   );
@@ -358,6 +394,8 @@ test("Friends view handles 1,600 visible people while zooming and panning", asyn
   console.log(`[PERF] Friends interaction dropped frames: ${interaction.result.droppedFrames.toLocaleString()}`);
   console.log(`[PERF] Friends interaction long tasks: ${interaction.count.toLocaleString()}`);
   console.log(`[PERF] Friends interaction worst long task: ${interaction.worstMs.toFixed(1)} ms`);
+  console.log(`[PERF] Friends interaction marks: ${JSON.stringify(interaction.marks)}`);
+  console.log(`[PERF] Friends interaction long task entries: ${JSON.stringify(interaction.tasks)}`);
   console.log(`[PERF] Friends interaction scene sync: ${afterInteraction!.metrics.sceneSyncMs.toFixed(1)} ms`);
   console.log(`[PERF] Friends dense interaction nodes: ${denseInteractionNodeCount.toLocaleString()}`);
   console.log(`[PERF] Friends dense interaction rebuilds: ${afterInteraction!.metrics.denseInteractionRebuildCount.toLocaleString()}`);

--- a/packages/ui/src/components/friends/FriendGraph.tsx
+++ b/packages/ui/src/components/friends/FriendGraph.tsx
@@ -873,6 +873,7 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
 ) {
   const containerRef = useRef<HTMLDivElement>(null);
   const canvasHostRef = useRef<HTMLDivElement>(null);
+  const canvasOverlayRef = useRef<HTMLDivElement>(null);
   const pixiRef = useRef<PixiScene | null>(null);
   const workerRef = useRef<Worker | null>(null);
   const layoutRef = useRef<IdentityGraphLayout>({ nodes: [], edges: [], regions: [] });
@@ -952,9 +953,15 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
   });
   const [canvasSize, setCanvasSize] = useState({ width: 900, height: DEFAULT_HEIGHT });
   canvasSizeRef.current = canvasSize;
-  const [isInteracting, setIsInteracting] = useState(false);
   const [layoutReady, setLayoutReady] = useState(false);
   const [layoutVersion, setLayoutVersion] = useState(0);
+
+  const setInteractionCursor = useCallback((interacting: boolean) => {
+    const overlay = canvasOverlayRef.current;
+    if (!overlay) return;
+    overlay.classList.toggle("cursor-grabbing", interacting);
+    overlay.classList.toggle("cursor-grab", !interacting);
+  }, []);
   const personsById = useMemo(
     () => Object.fromEntries(persons.map((person) => [person.id, person])),
     [persons],
@@ -1090,8 +1097,11 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
       scene.nodeLayer.cacheAsTexture(false);
     }
     scene.edgeLayer.visible = !isInteractivePaint;
+    scene.edgeLayer.renderable = !isInteractivePaint;
     scene.edgeHighlightLayer.visible = highlighted.size > 0;
+    scene.edgeHighlightLayer.renderable = highlighted.size > 0;
     scene.regionLabelLayer.visible = !isInteractivePaint;
+    scene.regionLabelLayer.renderable = !isInteractivePaint;
 
     if (lastStaticRenderKeyRef.current !== staticRenderKey || !!accountDrag) {
       didStaticRender = true;
@@ -1140,8 +1150,11 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
       perfSnapshotRef.current.edgeRebuildCount += 1;
 
       scene.denseNodeLayer.visible = denseRenderMode === "dense" && !useDenseInteractionLayer;
+      scene.denseNodeLayer.renderable = denseRenderMode === "dense" && !useDenseInteractionLayer;
       scene.denseInteractionNodeLayer.visible = useDenseInteractionLayer;
+      scene.denseInteractionNodeLayer.renderable = useDenseInteractionLayer;
       scene.nodeLayer.visible = denseRenderMode !== "dense";
+      scene.nodeLayer.renderable = denseRenderMode !== "dense";
       if (denseRenderMode === "dense") {
         scene.denseNodeLayer.clear();
         scene.denseInteractionNodeLayer.clear();
@@ -1331,7 +1344,9 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
 
     if (denseRenderMode === "dense") {
       scene.denseNodeLayer.visible = !useDenseInteractionLayer;
+      scene.denseNodeLayer.renderable = !useDenseInteractionLayer;
       scene.denseInteractionNodeLayer.visible = useDenseInteractionLayer;
+      scene.denseInteractionNodeLayer.renderable = useDenseInteractionLayer;
       if (useDenseInteractionLayer) {
         const denseNodeLimit =
           qualityMode === "interactive"
@@ -1399,6 +1414,7 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
       }
     } else {
       scene.denseInteractionNodeLayer.visible = false;
+      scene.denseInteractionNodeLayer.renderable = false;
       if (lastDenseInteractionRenderKeyRef.current) {
         scene.denseInteractionNodeLayer.clear();
         lastDenseInteractionRenderKeyRef.current = "";
@@ -1764,7 +1780,7 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
       transformScale: transform.scale,
     };
     if (shouldExposeGraphDebug()) {
-      const debugNodes = drag
+      const debugNodes = drag && drag.kind !== "pan"
         ? layoutRef.current.nodes.map((node) => ({
             id: node.id,
             personId: node.personId,
@@ -2248,7 +2264,7 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
               moved: false,
             };
             dragStateRef.current = null;
-            setIsInteracting(true);
+            setInteractionCursor(true);
             markInteractive();
             event.preventDefault();
             return;
@@ -2297,9 +2313,9 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
         moved: false,
       };
     }
-    setIsInteracting(true);
+    setInteractionCursor(true);
     markInteractive();
-  }, [hitNodeAt, markInteractive, viewportToWorld]);
+  }, [hitNodeAt, markInteractive, setInteractionCursor, viewportToWorld]);
 
   const handlePointerMove = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
     if (event.pointerType === "touch") {
@@ -2415,7 +2431,7 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
       pinchStateRef.current = null;
       dragStateRef.current = null;
       emitRelationshipTierDragOver(null);
-      setIsInteracting(activeTouchPointsRef.current.size > 0);
+      setInteractionCursor(activeTouchPointsRef.current.size > 0);
       scheduleSyncScene();
       return;
     }
@@ -2423,7 +2439,7 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
     const drag = dragStateRef.current;
     if (!drag || drag.pointerId !== event.pointerId) return;
     dragStateRef.current = null;
-    setIsInteracting(false);
+    setInteractionCursor(false);
     emitRelationshipTierDragOver(null);
 
     if (
@@ -2472,7 +2488,6 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
     }
 
     if (drag.moved) {
-      scheduleSyncScene();
       return;
     }
 
@@ -2494,7 +2509,7 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
       }
     }
     scheduleSyncScene();
-  }, [accounts, hitNodeAt, onClearSelection, onDropNodeToRelationshipTier, onLinkAccountToPerson, onPinAccountPosition, onPinPersonPosition, onSelectAccount, onSelectPerson, personsById, scheduleSyncScene]);
+  }, [accounts, hitNodeAt, onClearSelection, onDropNodeToRelationshipTier, onLinkAccountToPerson, onPinAccountPosition, onPinPersonPosition, onSelectAccount, onSelectPerson, personsById, scheduleSyncScene, setInteractionCursor]);
 
   const handlePointerLeave = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
     if (hoveredNodeIdRef.current) {
@@ -2509,7 +2524,7 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
       pinchStateRef.current = null;
       dragStateRef.current = null;
       emitRelationshipTierDragOver(null);
-      setIsInteracting(activeTouchPointsRef.current.size > 0);
+      setInteractionCursor(activeTouchPointsRef.current.size > 0);
       scheduleSyncScene();
       return;
     }
@@ -2523,9 +2538,9 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
     }
     dragStateRef.current = null;
     emitRelationshipTierDragOver(null);
-    setIsInteracting(false);
+    setInteractionCursor(false);
     scheduleSyncScene();
-  }, [onDropNodeToRelationshipTier, scheduleSyncScene]);
+  }, [onDropNodeToRelationshipTier, scheduleSyncScene, setInteractionCursor]);
 
   const handleDoubleClick = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
     event.preventDefault();
@@ -2555,8 +2570,9 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
           </div>
         ) : null}
         <div
+          ref={canvasOverlayRef}
           data-testid="friend-graph-canvas-overlay"
-          className={`absolute inset-0 ${isInteracting ? "cursor-grabbing" : "cursor-grab"}`}
+          className="absolute inset-0 cursor-grab"
         />
       </div>
       <div className="absolute right-4 top-4 z-10 flex items-center gap-2">


### PR DESCRIPTION
(AI Generated).

## Summary
- Build the Freed Desktop Automerge UI projection incrementally so large synced article bodies are trimmed before renderer state hydration.
- Avoid full graph debug snapshot cloning during Friends pan validation and switch the perf test to lightweight graph perf telemetry.
- Reduce Friends graph interaction work by removing React cursor state from the drag path, skipping redundant pan-end scene sync, and marking hidden Pixi layers as non-renderable during dense interactive paint.

## Testing
- npm run test:unit -- src/lib/automerge-worker-memory.test.ts
- npm run test:e2e:perf:feed
- npm run test:e2e:smoke
- npm run test:e2e:perf:friends
- npm run validate:feature

## Notes
- The installed v26.5.2600 soak remains healthy with renderer heartbeats and no recurring false renderer_heartbeat_stale loop observed.
- The provider scrape preflight remains blocked by resident memory accounting. Changing that would alter Facebook contact behavior, so it needs explicit fingerprinting-risk approval before implementation.