### PR TITLE
perf: slim desktop feed item projection

### DIFF
--- a/packages/desktop/src/lib/automerge-worker-memory.test.ts
+++ b/packages/desktop/src/lib/automerge-worker-memory.test.ts
@@ -58,9 +58,11 @@ describe("automerge worker memory routing", () => {
     expect(workerSource).toContain("DESKTOP_UI_CONTENT_TEXT_LIMIT = 280");
     expect(workerSource).toContain("DESKTOP_UI_PRESERVED_TEXT_LIMIT = 0");
     expect(workerSource).toContain("DESKTOP_UI_LINK_DESCRIPTION_LIMIT = 180");
+    expect(workerSource).toContain("DESKTOP_UI_EVENT_EVIDENCE_LIMIT = 220");
     expect(body).toContain("contentText.slice(0, DESKTOP_UI_CONTENT_TEXT_LIMIT)");
     expect(body).toContain("preservedText.slice(0, DESKTOP_UI_PRESERVED_TEXT_LIMIT)");
     expect(workerSource).toContain("linkDescription.slice(0, DESKTOP_UI_LINK_DESCRIPTION_LIMIT)");
+    expect(workerSource).toContain("eventEvidence.slice(0, DESKTOP_UI_EVENT_EVIDENCE_LIMIT)");
     expect(workerSource).toContain("const tags = next.contentSignals.tags ?? []");
     expect(workerSource).toContain("contentSignals: tags.length > 0 ? ({ tags } as FeedItem[\"contentSignals\"]) : undefined");
     expect(workerSource).toContain("cloneFeedItemsForDesktopUi");

--- a/packages/desktop/src/lib/automerge.worker.ts
+++ b/packages/desktop/src/lib/automerge.worker.ts
@@ -94,6 +94,7 @@ const SLOW_SAVE_AND_BROADCAST_MS = 2_000;
 const DESKTOP_UI_PRESERVED_TEXT_LIMIT = 0;
 const DESKTOP_UI_CONTENT_TEXT_LIMIT = 280;
 const DESKTOP_UI_LINK_DESCRIPTION_LIMIT = 180;
+const DESKTOP_UI_EVENT_EVIDENCE_LIMIT = 220;
 const FRESH_DOC_REBUILD_MIN_CHANGED_BINARY_BYTES = 4 * 1024 * 1024;
 const FRESH_DOC_REBUILD_MIN_HISTORY_BINARY_BYTES = 16 * 1024 * 1024;
 const FRESH_DOC_REBUILD_MIN_SAVINGS_RATIO = 0.1;
@@ -351,6 +352,17 @@ function trimFeedItemForDesktopUi(item: FeedItem): FeedItem {
     next = {
       ...next,
       contentSignals: tags.length > 0 ? ({ tags } as FeedItem["contentSignals"]) : undefined,
+    };
+  }
+
+  const eventEvidence = next.eventCandidate?.evidence;
+  if (eventEvidence && eventEvidence.length > DESKTOP_UI_EVENT_EVIDENCE_LIMIT) {
+    next = {
+      ...next,
+      eventCandidate: {
+        ...next.eventCandidate,
+        evidence: eventEvidence.slice(0, DESKTOP_UI_EVENT_EVIDENCE_LIMIT),
+      },
     };
   }
 


### PR DESCRIPTION
(AI Generated).

## Summary
- Trim oversized event evidence from the Freed Desktop renderer feed-item projection so feed, search, and map surfaces do not retain full event evidence strings for every item.

## Testing
- npm run test:unit -- src/lib/automerge-worker-memory.test.ts
- npm run validate:feature