### PR TITLE
fix: preserve event candidate projection type

### DIFF
--- a/packages/desktop/src/lib/automerge.worker.ts
+++ b/packages/desktop/src/lib/automerge.worker.ts
@@ -355,12 +355,13 @@ function trimFeedItemForDesktopUi(item: FeedItem): FeedItem {
     };
   }
 
-  const eventEvidence = next.eventCandidate?.evidence;
-  if (eventEvidence && eventEvidence.length > DESKTOP_UI_EVENT_EVIDENCE_LIMIT) {
+  const eventCandidate = next.eventCandidate;
+  const eventEvidence = eventCandidate?.evidence;
+  if (eventCandidate && eventEvidence && eventEvidence.length > DESKTOP_UI_EVENT_EVIDENCE_LIMIT) {
     next = {
       ...next,
       eventCandidate: {
-        ...next.eventCandidate,
+        ...eventCandidate,
         evidence: eventEvidence.slice(0, DESKTOP_UI_EVENT_EVIDENCE_LIMIT),
       },
     };


### PR DESCRIPTION
(AI Generated).

## Summary

- Preserves the narrowed `EventCandidate` object before trimming oversized event evidence in the Freed Desktop projection.
- Fixes the dev and release CI TypeScript failure from PR #603 without changing provider scrape behavior or WebView lifecycle.

## Tests

- `npm run build` in `packages/desktop`
- `npm run test:unit -- src/lib/automerge-worker-memory.test.ts` in `packages/desktop`
- `npm run test:e2e:smoke` in `packages/desktop`
- `npm run validate:feature`