### PR TITLE
perf: prevent accidental dense friends graph pins

### DIFF
--- a/packages/desktop/tests/e2e/perf-friends.spec.ts
+++ b/packages/desktop/tests/e2e/perf-friends.spec.ts
@@ -18,7 +18,7 @@ const LONG_TASK_COUNT_BUDGET = 2;
 const CI_LONG_TASK_COUNT_BUDGET = 40;
 const LONG_TASK_WORST_BUDGET_MS = 140;
 const CI_LONG_TASK_WORST_BUDGET_MS = 700;
-const DENSE_INTERACTION_NODE_BUDGET = 96;
+const DENSE_INTERACTION_NODE_BUDGET = 72;
 
 async function readGraphDebug(page: Page) {
   return page.evaluate(() => {
@@ -376,6 +376,19 @@ test("Friends view handles 1,600 visible people while zooming and panning", asyn
 
   const afterInteraction = await readGraphDebug(page);
   expect(afterInteraction).not.toBeNull();
+  const pinnedNodeCount = await page.evaluate(() => {
+    const store = (window as Record<string, unknown>).__FREED_STORE__ as {
+      getState: () => {
+        persons: Record<string, { graphPinned?: boolean }>;
+        accounts: Record<string, { graphPinned?: boolean }>;
+      };
+    };
+    const state = store.getState();
+    return [
+      ...Object.values(state.persons),
+      ...Object.values(state.accounts),
+    ].filter((node) => node.graphPinned === true).length;
+  });
   const p95Budget = process.env.CI
     ? Math.max(CI_FRAME_P95_BUDGET_MS, idleFrames.p95Ms + 34)
     : Math.max(FRAME_P95_BUDGET_MS, idleFrames.p95Ms + 34);
@@ -399,6 +412,7 @@ test("Friends view handles 1,600 visible people while zooming and panning", asyn
   console.log(`[PERF] Friends interaction scene sync: ${afterInteraction!.metrics.sceneSyncMs.toFixed(1)} ms`);
   console.log(`[PERF] Friends dense interaction nodes: ${denseInteractionNodeCount.toLocaleString()}`);
   console.log(`[PERF] Friends dense interaction rebuilds: ${afterInteraction!.metrics.denseInteractionRebuildCount.toLocaleString()}`);
+  console.log(`[PERF] Friends accidental pinned nodes after pan: ${pinnedNodeCount.toLocaleString()}`);
 
   expect(afterInteraction!.transform.scale).toBeGreaterThan(initialDebug!.transform.scale);
   expect(interaction.result.sampleCount).toBeGreaterThan(0);
@@ -406,6 +420,7 @@ test("Friends view handles 1,600 visible people while zooming and panning", asyn
   expect(denseInteractionNodeCount).toBeLessThanOrEqual(DENSE_INTERACTION_NODE_BUDGET);
   expect(maxInteractiveProviderLabelCount).toBe(0);
   expect(afterInteraction!.metrics.denseInteractionRebuildCount).toBeLessThanOrEqual(16);
+  expect(pinnedNodeCount).toBe(0);
   expect(interaction.result.p95Ms).toBeLessThanOrEqual(p95Budget);
   expect(interaction.result.droppedFrames).toBeLessThanOrEqual(droppedFrameBudget);
   expect(interaction.count).toBeLessThanOrEqual(

--- a/packages/ui/src/components/friends/FriendGraph.tsx
+++ b/packages/ui/src/components/friends/FriendGraph.tsx
@@ -222,7 +222,7 @@ const NODE_LAYER_TEXTURE_CACHE_MAX_NODES = 1_200;
 const INTERACTIVE_NODE_CULL_THRESHOLD = 1_200;
 const DENSE_GRAPH_SINGLE_LAYER_THRESHOLD = 1_200;
 const DENSE_INTERACTION_CULL_THRESHOLD = 1_600;
-const DENSE_INTERACTION_NODE_LIMIT = 96;
+const DENSE_INTERACTION_NODE_LIMIT = 64;
 const DENSE_SETTLED_VIEWPORT_NODE_LIMIT = 560;
 const DENSE_INTERACTION_VIEWPORT_PADDING = 72;
 const DENSE_INTERACTION_TRANSFORM_BUCKET_PX = 900;
@@ -2274,8 +2274,12 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
     }
 
     const hit = hitNodeAt(event.clientX, event.clientY);
+    const shouldStartNodeDrag = !!hit && (
+      layoutRef.current.nodes.length < DENSE_INTERACTION_CULL_THRESHOLD ||
+      isSelectedGraphNode(hit, selectedPersonId, selectedAccountId)
+    );
 
-    if (hit?.accountId) {
+    if (shouldStartNodeDrag && hit?.accountId) {
       const point = viewportToWorld(event.clientX, event.clientY);
       dragStateRef.current = {
         kind: "account-drag",
@@ -2289,7 +2293,7 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
         currentWorldX: point.x,
         currentWorldY: point.y,
       };
-    } else if (hit?.personId) {
+    } else if (shouldStartNodeDrag && hit?.personId) {
       const point = viewportToWorld(event.clientX, event.clientY);
       dragStateRef.current = {
         kind: "person-drag",
@@ -2315,7 +2319,7 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
     }
     setInteractionCursor(true);
     markInteractive();
-  }, [hitNodeAt, markInteractive, setInteractionCursor, viewportToWorld]);
+  }, [hitNodeAt, markInteractive, selectedAccountId, selectedPersonId, setInteractionCursor, viewportToWorld]);
 
   const handlePointerMove = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
     if (event.pointerType === "touch") {


### PR DESCRIPTION
(AI Generated).

## Summary
- Dense Friends graphs now pan by default unless the hit node is already selected, avoiding accidental position saves during pan gestures.
- The dense interaction overlay now renders 64 nodes instead of 96 while moving.
- The 1,600 person Friends perf case now asserts that pan and zoom leaves zero accidentally pinned graph nodes.

## Testing
- npm run test:e2e:perf:friends
- npm run validate:feature