### PR TITLE
feat: add nightly improvement runner

### DIFF
--- a/docs/NIGHTLY-SELF-IMPROVE.md
+++ b/docs/NIGHTLY-SELF-IMPROVE.md
@@ -13,6 +13,7 @@ The first rule is simple: evidence first, code second. If a target has weak evid
 - Hourly dev bot memory as a roadmap fallback
 - Git state for the current checkout
 - Local git worktrees with unmerged or uncommitted changes
+- Prior outcome ledger at `/tmp/freed-nightly-self-improve/outcomes.jsonl`
 
 ## Target Types
 
@@ -50,11 +51,18 @@ Dry run:
 node scripts/nightly-self-improve.mjs --dry-run --json
 ```
 
+Use a custom outcome ledger:
+
+```bash
+node scripts/nightly-self-improve.mjs --outcome-ledger /tmp/freed-nightly-self-improve/outcomes.jsonl
+```
+
 The generated run directory contains:
 
 - `report.md`: morning-readable summary
 - `targets.json`: full machine-readable candidate list
 - `tasks/*.md`: one implementation prompt per selected target
+- `outcome-template.jsonl`: lines to append back into the outcome ledger after the run
 
 Reports include an execution phase list so the night can move from evidence, to peer comparison, to implementation, validation, dev build shipping, installed-build soak, and the morning digest.
 
@@ -66,7 +74,7 @@ Release work is also gated. A dev build should ship only after actual fixes merg
 
 ## Next Improvements
 
-- Add a score feedback file so the runner learns which target types produced shipped fixes.
+- Wire the generated outcome template into the actual overnight closeout so target scoring learns without manual copying.
 - Compare every morning report against the previous installed build, especially WebKit RSS and frame budget deltas.
 - Let a run split itself into phases: plan, fix, validate, publish PR, merge when green, ship dev build, install, then soak.
 - Add a duplicate-work detector that notices when two night agents are chasing the same bottleneck.

--- a/docs/NIGHTLY-SELF-IMPROVE.md
+++ b/docs/NIGHTLY-SELF-IMPROVE.md
@@ -12,9 +12,11 @@ The first rule is simple: evidence first, code second. If a target has weak evid
 - Crash-watch automation state
 - Hourly dev bot memory as a roadmap fallback
 - Git state for the current checkout
+- Local git worktrees with unmerged or uncommitted changes
 
 ## Target Types
 
+- Peer worktree: active local branch work that may contain useful fixes or measurement
 - Performance: WebKit memory, event loop lag, DOM growth, stale heartbeat cycles
 - Bug fix: recent commit scans using the existing daily bug scan rules
 - Stability: crash-watch and blank-window evidence
@@ -22,7 +24,7 @@ The first rule is simple: evidence first, code second. If a target has weak evid
 - Roadmap: small autonomous product work after evidence-backed targets are exhausted
 - Blocked: provider-visible ideas that need explicit approval before execution
 
-The runner can select more than one target when the night has enough budget. A typical run should pick WebKit memory first when it is over budget, then a bug scan, then crash-watch triage or release readiness.
+The runner can select more than one target when the night has enough budget. A typical run should first compare peer worktrees, then pick WebKit memory when it is over budget, then a bug scan, then crash-watch triage or release readiness.
 
 ## Usage
 
@@ -34,6 +36,12 @@ Useful direct form:
 
 ```bash
 node scripts/nightly-self-improve.mjs --max-targets 3 --duration-minutes 480
+```
+
+Compare a known peer branch directly:
+
+```bash
+node scripts/nightly-self-improve.mjs --peer-worktree /Users/aubreyfalconer/dev/freed-scraper-recycle-verification
 ```
 
 Dry run:
@@ -48,6 +56,8 @@ The generated run directory contains:
 - `targets.json`: full machine-readable candidate list
 - `tasks/*.md`: one implementation prompt per selected target
 
+Reports include an execution phase list so the night can move from evidence, to peer comparison, to implementation, validation, dev build shipping, installed-build soak, and the morning digest.
+
 ## Safety Gates
 
 The runner excludes provider-visible tasks by default. Do not allow autonomous changes that alter authenticated WebView loads, provider navigation, provider API call frequency, scripted scrolling, cookies, headers, or scraping timing without explicit approval.
@@ -59,6 +69,6 @@ Release work is also gated. A dev build should ship only after actual fixes merg
 - Add a score feedback file so the runner learns which target types produced shipped fixes.
 - Compare every morning report against the previous installed build, especially WebKit RSS and frame budget deltas.
 - Let a run split itself into phases: plan, fix, validate, publish PR, merge when green, ship dev build, install, then soak.
-- Add a duplicate-work detector so two night agents do not chase the same bottleneck.
+- Add a duplicate-work detector that notices when two night agents are chasing the same bottleneck.
 - Add a stale-risk detector for generated artifacts, dirty worktrees, missing dependencies, and paused automations.
 - Turn recurring failure signatures into reusable focused test recipes.

--- a/docs/NIGHTLY-SELF-IMPROVE.md
+++ b/docs/NIGHTLY-SELF-IMPROVE.md
@@ -1,0 +1,64 @@
+# Nightly Self Improvement Runner
+
+The nightly runner turns existing evidence into a queue of safe work for an overnight agent run. It combines the installed-build soak, daily bug scan memory, crash-watch state, and roadmap context into ranked targets.
+
+The first rule is simple: evidence first, code second. If a target has weak evidence, the runner can still write a task prompt, but it should not ship a fix.
+
+## What It Reads
+
+- Active soak pointer at `/tmp/freed-perf-soak/current-soak-dir`
+- Soak files such as `metrics.tsv` and `runtime-health.jsonl`
+- Daily bug scan memory at `/Users/aubreyfalconer/.codex/automations/daily-bug-scan/memory.md`
+- Crash-watch automation state
+- Hourly dev bot memory as a roadmap fallback
+- Git state for the current checkout
+
+## Target Types
+
+- Performance: WebKit memory, event loop lag, DOM growth, stale heartbeat cycles
+- Bug fix: recent commit scans using the existing daily bug scan rules
+- Stability: crash-watch and blank-window evidence
+- Release: dev build readiness after real fixes land
+- Roadmap: small autonomous product work after evidence-backed targets are exhausted
+- Blocked: provider-visible ideas that need explicit approval before execution
+
+The runner can select more than one target when the night has enough budget. A typical run should pick WebKit memory first when it is over budget, then a bug scan, then crash-watch triage or release readiness.
+
+## Usage
+
+```bash
+npm run nightly:self-improve
+```
+
+Useful direct form:
+
+```bash
+node scripts/nightly-self-improve.mjs --max-targets 3 --duration-minutes 480
+```
+
+Dry run:
+
+```bash
+node scripts/nightly-self-improve.mjs --dry-run --json
+```
+
+The generated run directory contains:
+
+- `report.md`: morning-readable summary
+- `targets.json`: full machine-readable candidate list
+- `tasks/*.md`: one implementation prompt per selected target
+
+## Safety Gates
+
+The runner excludes provider-visible tasks by default. Do not allow autonomous changes that alter authenticated WebView loads, provider navigation, provider API call frequency, scripted scrolling, cookies, headers, or scraping timing without explicit approval.
+
+Release work is also gated. A dev build should ship only after actual fixes merge into `dev`, not after planning artifacts alone.
+
+## Next Improvements
+
+- Add a score feedback file so the runner learns which target types produced shipped fixes.
+- Compare every morning report against the previous installed build, especially WebKit RSS and frame budget deltas.
+- Let a run split itself into phases: plan, fix, validate, publish PR, merge when green, ship dev build, install, then soak.
+- Add a duplicate-work detector so two night agents do not chase the same bottleneck.
+- Add a stale-risk detector for generated artifacts, dirty worktrees, missing dependencies, and paused automations.
+- Turn recurring failure signatures into reusable focused test recipes.

--- a/docs/PHASE-10-POLISH.md
+++ b/docs/PHASE-10-POLISH.md
@@ -122,6 +122,12 @@ Blank suggestions now stay compact. Individual RSS feeds and danger actions are 
 
 The shared extension points now live in `packages/ui/src/lib/command-palette.ts`, `packages/ui/src/lib/command-palette-registry.ts`, and `packages/ui/src/lib/command-surface-store.ts`.
 
+### Nightly Improvement Runner
+
+Freed now has a local nightly improvement planner in `scripts/nightly-self-improve.mjs`. It folds the installed-build soak, daily bug scan memory, crash-watch state, roadmap fallback memory, and current git state into a ranked queue of work that can run overnight.
+
+The runner can choose multiple targets in one night. Bug fixes are first-class targets through the existing daily bug scan memory, while performance, stability, release readiness, and roadmap work compete by score and machine-time budget. Provider-visible ideas stay blocked unless a human explicitly approves the fingerprinting risk.
+
 ### Keyboard Shortcuts
 
 ```typescript
@@ -466,6 +472,7 @@ Reward security researchers for responsible disclosure.
 - [ ] Discord server active
 - [ ] Bug bounty program published
 - [ ] Regular release schedule established
+- [x] Local nightly improvement runner ranks bug fix, performance, stability, release, and roadmap targets before autonomous work begins
 - [ ] Documentation site live
 
 ### Resilience

--- a/docs/PHASE-10-POLISH.md
+++ b/docs/PHASE-10-POLISH.md
@@ -124,7 +124,7 @@ The shared extension points now live in `packages/ui/src/lib/command-palette.ts`
 
 ### Nightly Improvement Runner
 
-Freed now has a local nightly improvement planner in `scripts/nightly-self-improve.mjs`. It folds the installed-build soak, daily bug scan memory, crash-watch state, roadmap fallback memory, peer worktrees, and current git state into a ranked queue of work that can run overnight.
+Freed now has a local nightly improvement planner in `scripts/nightly-self-improve.mjs`. It folds the installed-build soak, daily bug scan memory, crash-watch state, roadmap fallback memory, peer worktrees, prior outcome history, and current git state into a ranked queue of work that can run overnight.
 
 The runner can choose multiple targets in one night. Bug fixes are first-class targets through the existing daily bug scan memory, while peer worktree integration, performance, stability, release readiness, and roadmap work compete by score and machine-time budget. Provider-visible ideas stay blocked unless a human explicitly approves the fingerprinting risk.
 

--- a/docs/PHASE-10-POLISH.md
+++ b/docs/PHASE-10-POLISH.md
@@ -124,9 +124,9 @@ The shared extension points now live in `packages/ui/src/lib/command-palette.ts`
 
 ### Nightly Improvement Runner
 
-Freed now has a local nightly improvement planner in `scripts/nightly-self-improve.mjs`. It folds the installed-build soak, daily bug scan memory, crash-watch state, roadmap fallback memory, and current git state into a ranked queue of work that can run overnight.
+Freed now has a local nightly improvement planner in `scripts/nightly-self-improve.mjs`. It folds the installed-build soak, daily bug scan memory, crash-watch state, roadmap fallback memory, peer worktrees, and current git state into a ranked queue of work that can run overnight.
 
-The runner can choose multiple targets in one night. Bug fixes are first-class targets through the existing daily bug scan memory, while performance, stability, release readiness, and roadmap work compete by score and machine-time budget. Provider-visible ideas stay blocked unless a human explicitly approves the fingerprinting risk.
+The runner can choose multiple targets in one night. Bug fixes are first-class targets through the existing daily bug scan memory, while peer worktree integration, performance, stability, release readiness, and roadmap work compete by score and machine-time budget. Provider-visible ideas stay blocked unless a human explicitly approves the fingerprinting risk.
 
 ### Keyboard Shortcuts
 
@@ -472,7 +472,7 @@ Reward security researchers for responsible disclosure.
 - [ ] Discord server active
 - [ ] Bug bounty program published
 - [ ] Regular release schedule established
-- [x] Local nightly improvement runner ranks bug fix, performance, stability, release, and roadmap targets before autonomous work begins
+- [x] Local nightly improvement runner ranks peer worktree, bug fix, performance, stability, release, and roadmap targets before autonomous work begins
 - [ ] Documentation site live
 
 ### Resilience

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build": "node scripts/run-workspace-fanout.mjs build",
     "dev": "node scripts/run-workspace-fanout.mjs dev",
     "lint": "node scripts/run-workspace-fanout.mjs lint",
+    "nightly:self-improve": "node scripts/nightly-self-improve.mjs",
     "session:clean": "bash scripts/dev-session-clean.sh",
     "test": "node scripts/run-workspace-fanout.mjs test",
     "test:scripts": "bash -n scripts/*.sh scripts/lib/*.sh && node --test scripts/*.test.mjs",

--- a/scripts/nightly-self-improve.mjs
+++ b/scripts/nightly-self-improve.mjs
@@ -24,6 +24,7 @@ const DEFAULT_CRASH_AUTOMATION =
 const DEFAULT_DEV_BOT_MEMORY =
   "/Users/aubreyfalconer/.codex/automations/hourly-dev-bot/memory.md";
 const DEFAULT_SOAK_POINTER = "/tmp/freed-perf-soak/current-soak-dir";
+const DEFAULT_OUTCOME_LEDGER = "/tmp/freed-nightly-self-improve/outcomes.jsonl";
 const MAX_PEER_EVIDENCE_FILES = 12;
 
 const GIB = 1024 * 1024 * 1024;
@@ -42,6 +43,7 @@ Options:
   --daily-bug-memory <path>     Daily bug scan memory file to fold into target selection.
   --peer-worktree <path>        Extra local worktree to compare and rank as a peer target.
   --no-peer-scan                Skip automatic git worktree discovery.
+  --outcome-ledger <path>       JSONL file with prior target outcomes.
   --max-targets <count>         Maximum targets to select. Defaults to 3.
   --duration-minutes <count>    Planning budget for one night. Defaults to 480.
   --memory-gib <count>          WebKit RSS budget before memory work wins. Defaults to 2.5.
@@ -60,6 +62,7 @@ export function parseArgs(argv) {
     dailyBugMemory: DEFAULT_DAILY_BUG_MEMORY,
     crashAutomation: DEFAULT_CRASH_AUTOMATION,
     devBotMemory: DEFAULT_DEV_BOT_MEMORY,
+    outcomeLedger: DEFAULT_OUTCOME_LEDGER,
     peerWorktrees: [],
     peerScan: true,
     maxTargets: 3,
@@ -96,6 +99,10 @@ export function parseArgs(argv) {
         break;
       case "--no-peer-scan":
         args.peerScan = false;
+        break;
+      case "--outcome-ledger":
+        args.outcomeLedger = argv[index + 1] ?? "";
+        index += 1;
         break;
       case "--max-targets":
         args.maxTargets = Number.parseInt(argv[index + 1] ?? "", 10);
@@ -145,6 +152,7 @@ export function parseArgs(argv) {
   }
 
   args.repo = path.resolve(args.repo);
+  args.outcomeLedger = path.resolve(args.outcomeLedger);
   args.peerWorktrees = args.peerWorktrees.filter(Boolean).map((item) => path.resolve(item));
   args.runDir =
     args.runDir ||
@@ -175,6 +183,50 @@ function readJsonLines(filePath) {
         return [];
       }
     });
+}
+
+export function summarizeOutcomeLedger(filePath) {
+  const entries = readJsonLines(filePath);
+  const byKind = new Map();
+  const byId = new Map();
+
+  for (const entry of entries) {
+    const kind = String(entry.kind ?? "");
+    const id = String(entry.id ?? "");
+    const outcome = String(entry.outcome ?? "");
+    if (!kind || !id) {
+      continue;
+    }
+    for (const [key, map] of [
+      [kind, byKind],
+      [id, byId],
+    ]) {
+      const current = map.get(key) ?? {
+        key,
+        attempts: 0,
+        shipped: 0,
+        validated: 0,
+        failed: 0,
+      };
+      current.attempts += 1;
+      if (outcome === "shipped") {
+        current.shipped += 1;
+      } else if (outcome === "validated") {
+        current.validated += 1;
+      } else if (outcome === "failed" || outcome === "blocked") {
+        current.failed += 1;
+      }
+      map.set(key, current);
+    }
+  }
+
+  return {
+    path: filePath,
+    exists: entries.length > 0,
+    entries,
+    byKind: Object.fromEntries(byKind),
+    byId: Object.fromEntries(byId),
+  };
 }
 
 export function parseTsv(text) {
@@ -783,6 +835,29 @@ export function buildCandidates({
   return candidates.sort((left, right) => right.score - left.score);
 }
 
+export function applyOutcomeFeedback(candidates, outcomeLedger) {
+  return candidates
+    .map((candidate) => {
+      const kindStats = outcomeLedger.byKind?.[candidate.kind];
+      const idStats = outcomeLedger.byId?.[candidate.id];
+      const shipped = (kindStats?.shipped ?? 0) + (idStats?.shipped ?? 0);
+      const validated = (kindStats?.validated ?? 0) + (idStats?.validated ?? 0);
+      const failed = (kindStats?.failed ?? 0) + (idStats?.failed ?? 0);
+      const adjustment = Math.max(-12, Math.min(12, shipped * 3 + validated * 1.5 - failed * 4));
+      return {
+        ...candidate,
+        score: Math.max(1, Math.min(99, candidate.score + adjustment)),
+        outcomeFeedback: {
+          shipped,
+          validated,
+          failed,
+          adjustment,
+        },
+      };
+    })
+    .sort((left, right) => right.score - left.score);
+}
+
 export function selectTargets(candidates, options) {
   const budget = options.durationMinutes;
   const selected = [];
@@ -841,7 +916,7 @@ function formatCandidate(candidate, index) {
   ].join("\n");
 }
 
-export function buildReport({ repo, soak, candidates, selected, options }) {
+export function buildReport({ repo, soak, outcomeLedger, candidates, selected, options }) {
   const blockedProvider = candidates.filter((candidate) => candidate.providerVisible);
   const phases = buildNightlyPhases(selected);
   return [
@@ -861,6 +936,11 @@ export function buildReport({ repo, soak, candidates, selected, options }) {
     `- Max DOM nodes: ${numberFormatter.format(soak.maxDomNodes ?? 0)}`,
     `- Stale heartbeat events: ${numberFormatter.format(soak.staleHeartbeatCount)}`,
     `- Hidden timer throttled events: ${numberFormatter.format(soak.throttledHeartbeatCount)}`,
+    "",
+    "## Learning Signals",
+    "",
+    `- Outcome ledger: ${outcomeLedger?.path ?? "none"}`,
+    `- Prior outcomes loaded: ${numberFormatter.format(outcomeLedger?.entries?.length ?? 0)}`,
     "",
     "## Selected Queue",
     "",
@@ -913,16 +993,36 @@ export function writeRunPlan({ runDir, repo, soak, peerWorktrees = [], candidate
   const tasksDir = path.join(runDir, "tasks");
   mkdirSync(tasksDir, { recursive: true });
 
-  const report = buildReport({ repo, soak, candidates, selected, options });
+  const outcomeLedger = options.outcomeLedgerSummary ?? { path: options.outcomeLedger, entries: [] };
+  const report = buildReport({ repo, soak, outcomeLedger, candidates, selected, options });
   writeFileSync(path.join(runDir, "report.md"), report);
-  writeFileSync(path.join(runDir, "targets.json"), `${JSON.stringify({ repo, soak, peerWorktrees, candidates, selected }, null, 2)}\n`);
+  writeFileSync(path.join(runDir, "targets.json"), `${JSON.stringify({ repo, soak, peerWorktrees, outcomeLedger, candidates, selected }, null, 2)}\n`);
+  writeFileSync(
+    path.join(runDir, "outcome-template.jsonl"),
+    selected
+      .map((candidate) =>
+        JSON.stringify({
+          ts: new Date().toISOString(),
+          id: candidate.id,
+          kind: candidate.kind,
+          outcome: "validated",
+          notes: "Replace outcome with shipped, validated, blocked, or failed after the run.",
+        }),
+      )
+      .join("\n") + "\n",
+  );
 
   selected.forEach((candidate, index) => {
     const name = `${String(index + 1).padStart(2, "0")}-${candidate.id}.md`;
     writeFileSync(path.join(tasksDir, name), formatCandidate(candidate, index));
   });
 
-  return { runDir, reportPath: path.join(runDir, "report.md"), tasksDir };
+  return {
+    runDir,
+    reportPath: path.join(runDir, "report.md"),
+    tasksDir,
+    outcomeTemplatePath: path.join(runDir, "outcome-template.jsonl"),
+  };
 }
 
 export function planNightlyRun(args) {
@@ -931,7 +1031,8 @@ export function planNightlyRun(args) {
   const dailyBug = summarizeDailyBugMemory(args.dailyBugMemory);
   const repo = collectRepoSnapshot(args.repo);
   const peerWorktrees = collectPeerWorktrees(args.repo, args.peerWorktrees, args.peerScan);
-  const candidates = buildCandidates({
+  const outcomeLedger = summarizeOutcomeLedger(args.outcomeLedger);
+  const baseCandidates = buildCandidates({
     soak,
     dailyBug,
     repo,
@@ -940,8 +1041,9 @@ export function planNightlyRun(args) {
     devBotMemoryExists: existsSync(args.devBotMemory),
     memoryBudgetBytes: args.memoryGib * GIB,
   });
+  const candidates = applyOutcomeFeedback(baseCandidates, outcomeLedger);
   const selected = selectTargets(candidates, args);
-  return { repo, soak, dailyBug, peerWorktrees, candidates, selected };
+  return { repo, soak, dailyBug, peerWorktrees, outcomeLedger, candidates, selected };
 }
 
 function textSummary(plan, writeResult, args) {
@@ -950,6 +1052,7 @@ function textSummary(plan, writeResult, args) {
     `Max WebKit RSS: ${formatBytes(plan.soak.maxWebKitResidentBytes)}.`,
     `Stale heartbeat events: ${numberFormatter.format(plan.soak.staleHeartbeatCount)}.`,
     `Peer worktrees with changes: ${numberFormatter.format(plan.peerWorktrees.length)}.`,
+    `Prior outcomes loaded: ${numberFormatter.format(plan.outcomeLedger.entries.length)}.`,
   ];
 
   for (const [index, selected] of plan.selected.entries()) {
@@ -959,6 +1062,7 @@ function textSummary(plan, writeResult, args) {
   if (writeResult) {
     lines.push(`Report: ${writeResult.reportPath}`);
     lines.push(`Tasks: ${writeResult.tasksDir}`);
+    lines.push(`Outcome template: ${writeResult.outcomeTemplatePath}`);
   }
 
   if (args.dryRun) {
@@ -989,7 +1093,7 @@ export function main(argv = process.argv.slice(2)) {
         peerWorktrees: plan.peerWorktrees,
         candidates: plan.candidates,
         selected: plan.selected,
-        options: args,
+        options: { ...args, outcomeLedgerSummary: plan.outcomeLedger },
       });
 
   if (args.json) {

--- a/scripts/nightly-self-improve.mjs
+++ b/scripts/nightly-self-improve.mjs
@@ -1,0 +1,744 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+export const REPO_ROOT = path.resolve(__dirname, "..");
+
+const DEFAULT_DAILY_BUG_MEMORY =
+  "/Users/aubreyfalconer/.codex/automations/daily-bug-scan/memory.md";
+const DEFAULT_CRASH_AUTOMATION =
+  "/Users/aubreyfalconer/.codex/automations/crash-watch/automation.toml";
+const DEFAULT_DEV_BOT_MEMORY =
+  "/Users/aubreyfalconer/.codex/automations/hourly-dev-bot/memory.md";
+const DEFAULT_SOAK_POINTER = "/tmp/freed-perf-soak/current-soak-dir";
+
+const GIB = 1024 * 1024 * 1024;
+const numberFormatter = new Intl.NumberFormat("en-US", {
+  maximumFractionDigits: 1,
+});
+
+function usage() {
+  return `Usage:
+  node scripts/nightly-self-improve.mjs [options]
+
+Options:
+  --repo <path>                 Repo to inspect. Defaults to the current Freed checkout.
+  --run-dir <path>              Directory for generated nightly plan files.
+  --soak-dir <path>             Installed-build soak directory to inspect.
+  --daily-bug-memory <path>     Daily bug scan memory file to fold into target selection.
+  --max-targets <count>         Maximum targets to select. Defaults to 3.
+  --duration-minutes <count>    Planning budget for one night. Defaults to 480.
+  --memory-gib <count>          WebKit RSS budget before memory work wins. Defaults to 2.5.
+  --allow-provider-visible      Permit targets that could touch third-party providers.
+  --dry-run                     Print the plan without writing files.
+  --json                        Print JSON instead of a text summary.
+  --help                        Show this help.
+`;
+}
+
+export function parseArgs(argv) {
+  const args = {
+    repo: process.cwd(),
+    runDir: "",
+    soakDir: "",
+    dailyBugMemory: DEFAULT_DAILY_BUG_MEMORY,
+    crashAutomation: DEFAULT_CRASH_AUTOMATION,
+    devBotMemory: DEFAULT_DEV_BOT_MEMORY,
+    maxTargets: 3,
+    durationMinutes: 480,
+    memoryGib: 2.5,
+    allowProviderVisible: false,
+    dryRun: false,
+    json: false,
+    help: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    switch (arg) {
+      case "--repo":
+        args.repo = argv[index + 1] ?? "";
+        index += 1;
+        break;
+      case "--run-dir":
+        args.runDir = argv[index + 1] ?? "";
+        index += 1;
+        break;
+      case "--soak-dir":
+        args.soakDir = argv[index + 1] ?? "";
+        index += 1;
+        break;
+      case "--daily-bug-memory":
+        args.dailyBugMemory = argv[index + 1] ?? "";
+        index += 1;
+        break;
+      case "--max-targets":
+        args.maxTargets = Number.parseInt(argv[index + 1] ?? "", 10);
+        index += 1;
+        break;
+      case "--duration-minutes":
+        args.durationMinutes = Number.parseInt(argv[index + 1] ?? "", 10);
+        index += 1;
+        break;
+      case "--memory-gib":
+        args.memoryGib = Number.parseFloat(argv[index + 1] ?? "");
+        index += 1;
+        break;
+      case "--allow-provider-visible":
+        args.allowProviderVisible = true;
+        break;
+      case "--dry-run":
+        args.dryRun = true;
+        break;
+      case "--json":
+        args.json = true;
+        break;
+      case "--help":
+      case "-h":
+        args.help = true;
+        break;
+      default:
+        throw new Error(`Unexpected argument '${arg}'.\n\n${usage()}`);
+    }
+  }
+
+  if (args.help) {
+    return args;
+  }
+
+  if (!args.repo) {
+    throw new Error("A repo path is required.");
+  }
+  if (!Number.isFinite(args.maxTargets) || args.maxTargets < 1) {
+    throw new Error("maxTargets must be at least 1.");
+  }
+  if (!Number.isFinite(args.durationMinutes) || args.durationMinutes < 30) {
+    throw new Error("durationMinutes must be at least 30.");
+  }
+  if (!Number.isFinite(args.memoryGib) || args.memoryGib <= 0) {
+    throw new Error("memoryGib must be greater than 0.");
+  }
+
+  args.repo = path.resolve(args.repo);
+  args.runDir =
+    args.runDir ||
+    path.join(
+      os.tmpdir(),
+      "freed-nightly-self-improve",
+      new Date().toISOString().replace(/[:.]/g, ""),
+    );
+
+  return args;
+}
+
+function readText(filePath) {
+  if (!filePath || !existsSync(filePath)) {
+    return "";
+  }
+  return readFileSync(filePath, "utf8");
+}
+
+function readJsonLines(filePath) {
+  return readText(filePath)
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .flatMap((line) => {
+      try {
+        return [JSON.parse(line)];
+      } catch {
+        return [];
+      }
+    });
+}
+
+export function parseTsv(text) {
+  const lines = text.split(/\r?\n/).filter(Boolean);
+  const headers = lines.shift()?.split("\t") ?? [];
+  return lines.map((line) => {
+    const values = line.split("\t");
+    return Object.fromEntries(headers.map((header, index) => [header, values[index] ?? ""]));
+  });
+}
+
+function numeric(value) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function maxNumber(rows, field) {
+  let max = null;
+  for (const row of rows) {
+    const value = numeric(row[field]);
+    if (value === null) {
+      continue;
+    }
+    max = max === null ? value : Math.max(max, value);
+  }
+  return max;
+}
+
+function lastValue(rows, field) {
+  for (let index = rows.length - 1; index >= 0; index -= 1) {
+    const value = rows[index]?.[field];
+    if (value !== undefined && value !== "") {
+      return value;
+    }
+  }
+  return "";
+}
+
+export function resolveCurrentSoakDir(pointerPath = DEFAULT_SOAK_POINTER) {
+  const pointed = readText(pointerPath).trim();
+  if (!pointed) {
+    return "";
+  }
+  try {
+    return realpathSync(pointed);
+  } catch {
+    return pointed;
+  }
+}
+
+export function summarizeSoak(soakDir) {
+  if (!soakDir || !existsSync(soakDir)) {
+    return {
+      exists: false,
+      soakDir,
+      sampleCount: 0,
+      maxWebKitResidentBytes: null,
+      maxEventLoopLagMs: null,
+      maxDomNodes: null,
+      staleHeartbeatCount: 0,
+      throttledHeartbeatCount: 0,
+      lastEvent: "",
+      firstTimestamp: "",
+      lastTimestamp: "",
+    };
+  }
+
+  const metricsPath = path.join(soakDir, "metrics.tsv");
+  const healthPath = path.join(soakDir, "runtime-health.jsonl");
+  const rows = parseTsv(readText(metricsPath));
+  const healthRows = readJsonLines(healthPath);
+
+  const healthMaxWebKit = healthRows.reduce((max, row) => {
+    const value = numeric(row.webkitResidentBytes ?? row.webkitLargestResidentBytes);
+    return value === null ? max : Math.max(max ?? value, value);
+  }, null);
+
+  const healthMaxLag = healthRows.reduce((max, row) => {
+    const value = numeric(row.eventLoopLagMs);
+    return value === null ? max : Math.max(max ?? value, value);
+  }, null);
+
+  const metricsMaxWebKitKb = maxNumber(rows, "health_webkit_rss_bytes");
+  const fallbackWebKitKb = maxNumber(rows, "webkit_rss_kb_all");
+  const metricsMaxWebKit =
+    metricsMaxWebKitKb !== null
+      ? metricsMaxWebKitKb
+      : fallbackWebKitKb !== null
+        ? fallbackWebKitKb * 1024
+        : null;
+
+  const staleHeartbeatCount =
+    rows.filter((row) => row.health_event === "renderer_heartbeat_stale").length +
+    healthRows.filter((row) => row.event === "renderer_heartbeat_stale").length;
+  const throttledHeartbeatCount =
+    rows.filter((row) => row.health_hidden_timer_throttled === "true").length +
+    healthRows.filter((row) => row.hiddenTimerThrottled === true).length;
+
+  return {
+    exists: true,
+    soakDir,
+    sampleCount: Math.max(rows.length, healthRows.length),
+    maxWebKitResidentBytes: Math.max(
+      healthMaxWebKit ?? 0,
+      metricsMaxWebKit ?? 0,
+    ),
+    maxEventLoopLagMs: Math.max(
+      healthMaxLag ?? 0,
+      maxNumber(rows, "health_event_loop_lag_ms") ?? 0,
+    ),
+    maxDomNodes: Math.max(
+      maxNumber(rows, "health_dom_nodes") ?? 0,
+      healthRows.reduce((max, row) => Math.max(max, numeric(row.domNodeCount) ?? 0), 0),
+    ),
+    staleHeartbeatCount,
+    throttledHeartbeatCount,
+    lastEvent:
+      lastValue(rows, "health_event") ||
+      String(healthRows.at(-1)?.event ?? ""),
+    firstTimestamp: rows[0]?.ts ?? String(healthRows[0]?.tsMs ?? ""),
+    lastTimestamp: rows.at(-1)?.ts ?? String(healthRows.at(-1)?.tsMs ?? ""),
+  };
+}
+
+function latestDatedSection(markdown) {
+  const matches = [...markdown.matchAll(/^##\s+(\d{4}-\d{2}-\d{2})\s*$/gm)];
+  if (matches.length === 0) {
+    return { date: "", text: "" };
+  }
+  const match = matches.at(-1);
+  const start = match.index ?? 0;
+  const next = markdown.indexOf("\n## ", start + 1);
+  return {
+    date: match[1],
+    text: markdown.slice(start, next === -1 ? markdown.length : next).trim(),
+  };
+}
+
+export function summarizeDailyBugMemory(memoryPath) {
+  const text = readText(memoryPath);
+  const latest = latestDatedSection(text);
+  const latestHadNoFix = /no\s+(evidence-backed\s+)?(bug|fix)|no fix applied/i.test(latest.text);
+  return {
+    exists: Boolean(text),
+    path: memoryPath,
+    latestDate: latest.date,
+    latestSection: latest.text,
+    latestHadNoNewCommits: /0`\s+commits|0 commits|no new repo evidence/i.test(latest.text),
+    latestHadFix:
+      !latestHadNoFix &&
+      /outcome:\s+.*(fix applied|implemented|merged)|fix applied/i.test(latest.text),
+  };
+}
+
+function git(repo, args) {
+  try {
+    return execFileSync("git", args, { cwd: repo, encoding: "utf8" }).trim();
+  } catch {
+    return "";
+  }
+}
+
+export function collectRepoSnapshot(repo) {
+  return {
+    branch: git(repo, ["branch", "--show-current"]) || git(repo, ["rev-parse", "--abbrev-ref", "HEAD"]),
+    head: git(repo, ["rev-parse", "--short", "HEAD"]),
+    originDev: git(repo, ["rev-parse", "--short", "origin/dev"]),
+    originMain: git(repo, ["rev-parse", "--short", "origin/main"]),
+    status: git(repo, ["status", "--short"]),
+  };
+}
+
+function target({
+  id,
+  kind,
+  title,
+  score,
+  confidence,
+  estimatedMinutes,
+  rationale,
+  evidence,
+  prompt,
+  validation,
+  providerVisible = false,
+  canModify = true,
+}) {
+  return {
+    id,
+    kind,
+    title,
+    score,
+    confidence,
+    estimatedMinutes,
+    providerVisible,
+    canModify,
+    rationale,
+    evidence,
+    prompt,
+    validation,
+  };
+}
+
+export function buildCandidates({
+  soak,
+  dailyBug,
+  repo,
+  crashAutomationExists,
+  devBotMemoryExists,
+  memoryBudgetBytes,
+}) {
+  const candidates = [];
+
+  if (soak.exists && (soak.maxWebKitResidentBytes ?? 0) > memoryBudgetBytes) {
+    candidates.push(
+      target({
+        id: "webkit-memory-pressure",
+        kind: "performance",
+        title: "Reduce installed-build WebKit memory growth",
+        score: 98,
+        confidence: 0.9,
+        estimatedMinutes: 150,
+        rationale:
+          `The active soak observed WebKit RSS at ${formatBytes(soak.maxWebKitResidentBytes)}, above the ${formatBytes(memoryBudgetBytes)} budget.`,
+        evidence: [
+          soak.soakDir,
+          `${numberFormatter.format(soak.sampleCount)} runtime samples`,
+          `Max event loop lag ${numberFormatter.format(soak.maxEventLoopLagMs ?? 0)} ms`,
+        ],
+        prompt:
+          "Inspect the active soak evidence and current desktop memory instrumentation. Find the largest retained WebKit memory source that can be fixed without changing provider-visible scraping behavior. Prefer cache disposal, virtualized UI retention, image lifecycle, or worker cleanup fixes with focused regression coverage.",
+        validation: [
+          "Run the focused unit or desktop perf test that covers the touched surface.",
+          "Run npm run validate:feature before publishing.",
+          "Start an installed-build soak after merge and compare max WebKit RSS to the prior run.",
+        ],
+      }),
+    );
+  }
+
+  if (soak.exists && soak.staleHeartbeatCount > 0) {
+    candidates.push(
+      target({
+        id: "renderer-heartbeat-stale",
+        kind: "stability",
+        title: "Diagnose stale renderer heartbeat cycles",
+        score: 88,
+        confidence: 0.82,
+        estimatedMinutes: 90,
+        rationale:
+          `The active soak recorded ${numberFormatter.format(soak.staleHeartbeatCount)} stale heartbeat events.`,
+        evidence: [soak.soakDir, `Last health event ${soak.lastEvent || "unknown"}`],
+        prompt:
+          "Preserve runtime-health and native logs, then distinguish real renderer stalls from hidden timer throttling. Patch the state machine or telemetry only when evidence proves a false positive or missed recovery path.",
+        validation: [
+          "Add state-machine coverage for stale, throttled, recovered, and visible heartbeat paths.",
+          "Run the focused renderer health test plus validate:feature.",
+        ],
+      }),
+    );
+  }
+
+  if (dailyBug.exists) {
+    candidates.push(
+      target({
+        id: "daily-bug-fix-scan",
+        kind: "bug-fix",
+        title: "Run evidence-backed nightly bug fix scan",
+        score: dailyBug.latestHadNoNewCommits ? 58 : 82,
+        confidence: dailyBug.latestHadNoNewCommits ? 0.65 : 0.86,
+        estimatedMinutes: dailyBug.latestHadNoNewCommits ? 25 : 90,
+        rationale: dailyBug.latestHadNoNewCommits
+          ? "The last bug scan found no new commits, but bug fixing remains an executable nightly target once the commit window moves."
+          : "The daily bug scan memory has fresh repo evidence that should be reviewed before choosing speculative work.",
+        evidence: [
+          dailyBug.path,
+          dailyBug.latestDate ? `Latest scan ${dailyBug.latestDate}` : "No dated scan section found",
+        ],
+        prompt:
+          "Read the daily bug scan memory first, use the last completed cutoff, fetch origin dev, main, and www, inspect only new non-release product commits, and implement the smallest evidence-backed fix if one survives targeted validation. If evidence is weak, report no evidence-backed bug found.",
+        validation: [
+          "Run the focused test for the touched code path.",
+          "Append the scan outcome to daily bug scan memory.",
+          "Run validate:feature before publishing any code fix.",
+        ],
+      }),
+    );
+  }
+
+  if (crashAutomationExists) {
+    candidates.push(
+      target({
+        id: "crash-watch-triage",
+        kind: "stability",
+        title: "Review crash watch signals before shipping",
+        score: 64,
+        confidence: 0.7,
+        estimatedMinutes: 45,
+        rationale:
+          "Crash watch exists as a separate heartbeat. Nightly runs should inspect it before choosing polish work.",
+        evidence: [DEFAULT_CRASH_AUTOMATION],
+        prompt:
+          "Inspect the crash-watch automation state, recent macOS crash reports, and Freed logs. Only implement a fix if there is concrete evidence of a Freed-owned crash, blank window, or renderer stall.",
+        validation: [
+          "Add diagnostics or regression coverage for the exact failure state.",
+          "Run the focused native or desktop test that proves the recovery path.",
+        ],
+      }),
+    );
+  }
+
+  if (devBotMemoryExists) {
+    candidates.push(
+      target({
+        id: "roadmap-autonomous-task",
+        kind: "roadmap",
+        title: "Choose the next small roadmap task after evidence targets",
+        score: 48,
+        confidence: 0.6,
+        estimatedMinutes: 120,
+        rationale:
+          "The paused hourly dev bot already records autonomous roadmap selection. It should be a fallback target after performance, crashes, and bugs.",
+        evidence: [DEFAULT_DEV_BOT_MEMORY],
+        prompt:
+          "Compare current repo state to docs/PHASE files and choose one small, validation-friendly product task. Do not touch provider-visible scraping, auth, cookies, timing, or background navigation without explicit approval.",
+        validation: [
+          "Update affected docs/PHASE files and roadmap status or copy.",
+          "Run focused tests for the changed product surface.",
+          "Run validate:feature before publishing.",
+        ],
+      }),
+    );
+  }
+
+  if (!repo.status) {
+    candidates.push(
+      target({
+        id: "release-readiness-check",
+        kind: "release",
+        title: "Check whether validated fixes should ship as a dev build",
+        score: 52,
+        confidence: 0.62,
+        estimatedMinutes: 40,
+        rationale:
+          "A clean worktree can safely decide whether merged fixes deserve a dev prerelease, but release shipping should happen after actual fixes land.",
+        evidence: [
+          `branch ${repo.branch || "unknown"}`,
+          `HEAD ${repo.head || "unknown"}`,
+          `origin/dev ${repo.originDev || "unknown"}`,
+        ],
+        prompt:
+          "If one or more fixes merged into dev during the night, use the Freed release workflow to prepare, review, publish, and verify a dev build. Do not ship a release when only planning artifacts changed.",
+        validation: [
+          "Use the existing release note validator.",
+          "Verify the GitHub release workflow and updater manifest.",
+        ],
+      }),
+    );
+  }
+
+  candidates.push(
+    target({
+      id: "provider-visible-backlog",
+      kind: "blocked",
+      title: "List provider-visible optimizations that need explicit approval",
+      score: 35,
+      confidence: 0.95,
+      estimatedMinutes: 20,
+      providerVisible: true,
+      canModify: false,
+      rationale:
+        "Some tempting performance wins involve changing how Freed touches third-party providers. Those must stay out of autonomous execution until approved.",
+      evidence: ["Provider fingerprinting guardrail"],
+      prompt:
+        "Prepare a short approval request before changing authenticated WebView loads, provider navigation, background API calls, scripted scrolling, cookie behavior, headers, or provider contact frequency.",
+      validation: ["No code changes are allowed for this target without approval."],
+    }),
+  );
+
+  return candidates.sort((left, right) => right.score - left.score);
+}
+
+export function selectTargets(candidates, options) {
+  const budget = options.durationMinutes;
+  const selected = [];
+  let used = 0;
+
+  for (const candidate of candidates) {
+    if (selected.length >= options.maxTargets) {
+      break;
+    }
+    if (candidate.providerVisible && !options.allowProviderVisible) {
+      continue;
+    }
+    if (used + candidate.estimatedMinutes > budget && selected.length > 0) {
+      continue;
+    }
+    selected.push(candidate);
+    used += candidate.estimatedMinutes;
+  }
+
+  return selected;
+}
+
+export function formatBytes(bytes) {
+  if (bytes === null || bytes === undefined || !Number.isFinite(bytes)) {
+    return "unknown";
+  }
+  return `${numberFormatter.format(bytes / GIB)} GiB`;
+}
+
+function formatCandidate(candidate, index) {
+  return [
+    `# ${index + 1}. ${candidate.title}`,
+    "",
+    `Kind: ${candidate.kind}`,
+    `Score: ${numberFormatter.format(candidate.score)}`,
+    `Confidence: ${numberFormatter.format(candidate.confidence * 100)}%`,
+    `Estimated machine time: ${numberFormatter.format(candidate.estimatedMinutes)} min`,
+    `Provider-visible: ${candidate.providerVisible ? "yes" : "no"}`,
+    "",
+    "## Rationale",
+    "",
+    candidate.rationale,
+    "",
+    "## Evidence",
+    "",
+    ...candidate.evidence.map((item) => `- ${item}`),
+    "",
+    "## Implementation Prompt",
+    "",
+    candidate.prompt,
+    "",
+    "## Validation",
+    "",
+    ...candidate.validation.map((item) => `- ${item}`),
+    "",
+  ].join("\n");
+}
+
+export function buildReport({ repo, soak, candidates, selected, options }) {
+  const blockedProvider = candidates.filter((candidate) => candidate.providerVisible);
+  return [
+    "# Freed Nightly Improvement Plan",
+    "",
+    `Generated: ${new Date().toISOString()}`,
+    `Repo: ${repo.branch || "unknown"} at ${repo.head || "unknown"}`,
+    `Budget: ${numberFormatter.format(options.durationMinutes)} min`,
+    `Selected targets: ${numberFormatter.format(selected.length)}`,
+    "",
+    "## Current Evidence",
+    "",
+    `- Soak directory: ${soak.soakDir || "none"}`,
+    `- Soak samples: ${numberFormatter.format(soak.sampleCount)}`,
+    `- Max WebKit RSS: ${formatBytes(soak.maxWebKitResidentBytes)}`,
+    `- Max event loop lag: ${numberFormatter.format(soak.maxEventLoopLagMs ?? 0)} ms`,
+    `- Max DOM nodes: ${numberFormatter.format(soak.maxDomNodes ?? 0)}`,
+    `- Stale heartbeat events: ${numberFormatter.format(soak.staleHeartbeatCount)}`,
+    `- Hidden timer throttled events: ${numberFormatter.format(soak.throttledHeartbeatCount)}`,
+    "",
+    "## Selected Queue",
+    "",
+    ...selected.flatMap((candidate, index) => [
+      `${index + 1}. ${candidate.title}`,
+      `   Kind: ${candidate.kind}. Score: ${numberFormatter.format(candidate.score)}. Machine time: ${numberFormatter.format(candidate.estimatedMinutes)} min.`,
+    ]),
+    "",
+    "## Provider Visibility Gate",
+    "",
+    blockedProvider.length > 0
+      ? "Provider-visible candidates were detected and excluded unless the run was started with explicit approval."
+      : "No provider-visible candidates were detected.",
+    "",
+    ...blockedProvider.map((candidate) => `- ${candidate.title}`),
+    "",
+    "## Next Ideas",
+    "",
+    "- Add a learned target scorer that compares each night's fix outcome against the previous run budget.",
+    "- Keep a small local knowledge base of recurring failure signatures and the focused tests that proved prior fixes.",
+    "- Teach the runner to split one night into planning, fix, validation, dev build, install, and soak phases with stop conditions.",
+    "- Require evidence snapshots before every rare crash or memory fix so the next failure has better diagnostics.",
+    "- Add a morning digest that ranks shipped value, residual risk, and the single next highest leverage bottleneck.",
+    "",
+  ].join("\n");
+}
+
+export function writeRunPlan({ runDir, repo, soak, candidates, selected, options }) {
+  mkdirSync(runDir, { recursive: true });
+  const tasksDir = path.join(runDir, "tasks");
+  mkdirSync(tasksDir, { recursive: true });
+
+  const report = buildReport({ repo, soak, candidates, selected, options });
+  writeFileSync(path.join(runDir, "report.md"), report);
+  writeFileSync(path.join(runDir, "targets.json"), `${JSON.stringify({ repo, soak, candidates, selected }, null, 2)}\n`);
+
+  selected.forEach((candidate, index) => {
+    const name = `${String(index + 1).padStart(2, "0")}-${candidate.id}.md`;
+    writeFileSync(path.join(tasksDir, name), formatCandidate(candidate, index));
+  });
+
+  return { runDir, reportPath: path.join(runDir, "report.md"), tasksDir };
+}
+
+export function planNightlyRun(args) {
+  const soakDir = args.soakDir || resolveCurrentSoakDir();
+  const soak = summarizeSoak(soakDir);
+  const dailyBug = summarizeDailyBugMemory(args.dailyBugMemory);
+  const repo = collectRepoSnapshot(args.repo);
+  const candidates = buildCandidates({
+    soak,
+    dailyBug,
+    repo,
+    crashAutomationExists: existsSync(args.crashAutomation),
+    devBotMemoryExists: existsSync(args.devBotMemory),
+    memoryBudgetBytes: args.memoryGib * GIB,
+  });
+  const selected = selectTargets(candidates, args);
+  return { repo, soak, dailyBug, candidates, selected };
+}
+
+function textSummary(plan, writeResult, args) {
+  const lines = [
+    `Selected ${numberFormatter.format(plan.selected.length)} targets from ${numberFormatter.format(plan.candidates.length)} candidates.`,
+    `Max WebKit RSS: ${formatBytes(plan.soak.maxWebKitResidentBytes)}.`,
+    `Stale heartbeat events: ${numberFormatter.format(plan.soak.staleHeartbeatCount)}.`,
+  ];
+
+  for (const [index, selected] of plan.selected.entries()) {
+    lines.push(`${index + 1}. ${selected.title} (${selected.kind}, score ${numberFormatter.format(selected.score)})`);
+  }
+
+  if (writeResult) {
+    lines.push(`Report: ${writeResult.reportPath}`);
+    lines.push(`Tasks: ${writeResult.tasksDir}`);
+  }
+
+  if (args.dryRun) {
+    lines.push("Dry run only. No files were written.");
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const args = parseArgs(argv);
+  if (args.help) {
+    process.stdout.write(usage());
+    return;
+  }
+
+  if (!existsSync(args.repo) || !statSync(args.repo).isDirectory()) {
+    throw new Error(`Repo path does not exist: ${args.repo}`);
+  }
+
+  const plan = planNightlyRun(args);
+  const writeResult = args.dryRun
+    ? null
+    : writeRunPlan({
+        runDir: args.runDir,
+        repo: plan.repo,
+        soak: plan.soak,
+        candidates: plan.candidates,
+        selected: plan.selected,
+        options: args,
+      });
+
+  if (args.json) {
+    process.stdout.write(`${JSON.stringify({ ...plan, writeResult }, null, 2)}\n`);
+  } else {
+    process.stdout.write(textSummary(plan, writeResult, args));
+  }
+}
+
+if (process.argv[1] === __filename) {
+  try {
+    main();
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/nightly-self-improve.mjs
+++ b/scripts/nightly-self-improve.mjs
@@ -24,6 +24,7 @@ const DEFAULT_CRASH_AUTOMATION =
 const DEFAULT_DEV_BOT_MEMORY =
   "/Users/aubreyfalconer/.codex/automations/hourly-dev-bot/memory.md";
 const DEFAULT_SOAK_POINTER = "/tmp/freed-perf-soak/current-soak-dir";
+const MAX_PEER_EVIDENCE_FILES = 12;
 
 const GIB = 1024 * 1024 * 1024;
 const numberFormatter = new Intl.NumberFormat("en-US", {
@@ -39,6 +40,8 @@ Options:
   --run-dir <path>              Directory for generated nightly plan files.
   --soak-dir <path>             Installed-build soak directory to inspect.
   --daily-bug-memory <path>     Daily bug scan memory file to fold into target selection.
+  --peer-worktree <path>        Extra local worktree to compare and rank as a peer target.
+  --no-peer-scan                Skip automatic git worktree discovery.
   --max-targets <count>         Maximum targets to select. Defaults to 3.
   --duration-minutes <count>    Planning budget for one night. Defaults to 480.
   --memory-gib <count>          WebKit RSS budget before memory work wins. Defaults to 2.5.
@@ -57,6 +60,8 @@ export function parseArgs(argv) {
     dailyBugMemory: DEFAULT_DAILY_BUG_MEMORY,
     crashAutomation: DEFAULT_CRASH_AUTOMATION,
     devBotMemory: DEFAULT_DEV_BOT_MEMORY,
+    peerWorktrees: [],
+    peerScan: true,
     maxTargets: 3,
     durationMinutes: 480,
     memoryGib: 2.5,
@@ -84,6 +89,13 @@ export function parseArgs(argv) {
       case "--daily-bug-memory":
         args.dailyBugMemory = argv[index + 1] ?? "";
         index += 1;
+        break;
+      case "--peer-worktree":
+        args.peerWorktrees.push(argv[index + 1] ?? "");
+        index += 1;
+        break;
+      case "--no-peer-scan":
+        args.peerScan = false;
         break;
       case "--max-targets":
         args.maxTargets = Number.parseInt(argv[index + 1] ?? "", 10);
@@ -133,6 +145,7 @@ export function parseArgs(argv) {
   }
 
   args.repo = path.resolve(args.repo);
+  args.peerWorktrees = args.peerWorktrees.filter(Boolean).map((item) => path.resolve(item));
   args.runDir =
     args.runDir ||
     path.join(
@@ -171,6 +184,49 @@ export function parseTsv(text) {
     const values = line.split("\t");
     return Object.fromEntries(headers.map((header, index) => [header, values[index] ?? ""]));
   });
+}
+
+export function parseGitWorktreePorcelain(text) {
+  const entries = [];
+  let current = null;
+
+  for (const line of text.split(/\r?\n/)) {
+    if (!line.trim()) {
+      if (current) {
+        entries.push(current);
+        current = null;
+      }
+      continue;
+    }
+
+    const [key, ...rest] = line.split(" ");
+    const value = rest.join(" ");
+    if (key === "worktree") {
+      if (current) {
+        entries.push(current);
+      }
+      current = { path: value, head: "", branch: "", detached: false };
+      continue;
+    }
+
+    if (!current) {
+      continue;
+    }
+
+    if (key === "HEAD") {
+      current.head = value;
+    } else if (key === "branch") {
+      current.branch = value.replace(/^refs\/heads\//, "");
+    } else if (key === "detached") {
+      current.detached = true;
+    }
+  }
+
+  if (current) {
+    entries.push(current);
+  }
+
+  return entries;
 }
 
 function numeric(value) {
@@ -324,6 +380,158 @@ function git(repo, args) {
   }
 }
 
+function unique(values) {
+  return [...new Set(values.filter(Boolean))];
+}
+
+function shortStatusPaths(statusText) {
+  return statusText
+    .split(/\r?\n/)
+    .map((line) => line.slice(3).trim())
+    .map((filePath) => filePath.replace(/^.* -> /, ""))
+    .filter(Boolean);
+}
+
+function providerVisiblePath(filePath) {
+  return (
+    filePath.startsWith("packages/capture-") ||
+    filePath.includes("/capture-") ||
+    filePath.includes("facebook") ||
+    filePath.includes("instagram") ||
+    filePath.includes("linkedin") ||
+    filePath.includes("x-capture") ||
+    filePath.includes("li-capture") ||
+    filePath.includes("scraper-prefs") ||
+    filePath.includes("scraper-window")
+  );
+}
+
+function peerWorktreeScore(peer) {
+  let score = 46;
+  if (peer.explicit) {
+    score += 12;
+  }
+  if (peer.branch.includes("scraper-recycle-verification")) {
+    score += 42;
+  }
+  if (peer.touchesNightlyRunner) {
+    score += 48;
+  }
+  if (peer.touchesMemoryTelemetry) {
+    score += 28;
+  }
+  if (peer.changedFileCount >= 6) {
+    score += 8;
+  }
+  if (peer.providerVisible) {
+    score -= 15;
+  }
+  return Math.min(99, Math.max(1, score));
+}
+
+export function summarizePeerWorktree(worktreePath, currentRepo) {
+  if (!worktreePath || !existsSync(worktreePath)) {
+    return null;
+  }
+
+  let resolved = worktreePath;
+  let current = currentRepo;
+  try {
+    resolved = realpathSync(worktreePath);
+    current = realpathSync(currentRepo);
+  } catch {
+    return null;
+  }
+
+  if (resolved === current) {
+    return null;
+  }
+
+  const branch =
+    git(resolved, ["branch", "--show-current"]) ||
+    git(resolved, ["rev-parse", "--abbrev-ref", "HEAD"]) ||
+    "unknown";
+  const head = git(resolved, ["rev-parse", "--short", "HEAD"]);
+  const status = git(resolved, ["status", "--short"]);
+  const committedFiles = git(resolved, [
+    "diff",
+    "--name-only",
+    "--diff-filter=ACDMRTUXB",
+    "origin/dev",
+    "HEAD",
+  ]);
+  const workingFiles = unique([
+    ...shortStatusPaths(status),
+    ...committedFiles.split(/\r?\n/),
+  ]).sort();
+  const aheadCount = Number.parseInt(git(resolved, ["rev-list", "--count", "origin/dev..HEAD"]) || "0", 10);
+  const behindCount = Number.parseInt(git(resolved, ["rev-list", "--count", "HEAD..origin/dev"]) || "0", 10);
+
+  const touchesMemoryTelemetry = workingFiles.some(
+    (filePath) =>
+      filePath.includes("memory-monitor") ||
+      filePath.includes("runtime-health") ||
+      filePath.includes("src-tauri/src/lib.rs") ||
+      filePath.includes("perf-") ||
+      filePath.includes("playwright.config"),
+  );
+  const touchesNightlyRunner = workingFiles.some(
+    (filePath) =>
+      filePath.includes("nightly-self-improve") ||
+      filePath.includes("automation") ||
+      filePath.includes("self-improve"),
+  );
+  const providerVisible = workingFiles.some(providerVisiblePath);
+
+  return {
+    path: resolved,
+    branch,
+    head,
+    status,
+    aheadCount: Number.isFinite(aheadCount) ? aheadCount : 0,
+    behindCount: Number.isFinite(behindCount) ? behindCount : 0,
+    changedFiles: workingFiles,
+    changedFileCount: workingFiles.length,
+    touchesMemoryTelemetry,
+    touchesNightlyRunner,
+    providerVisible,
+    explicit: false,
+    score: 0,
+  };
+}
+
+export function collectPeerWorktrees(repo, explicitWorktrees = [], scan = true) {
+  const explicitPaths = new Set(
+    explicitWorktrees.flatMap((worktreePath) => {
+      try {
+        return [realpathSync(worktreePath)];
+      } catch {
+        return [];
+      }
+    }),
+  );
+  const worktreePaths = [...explicitWorktrees];
+  if (scan) {
+    const worktreeList = git(repo, ["worktree", "list", "--porcelain"]);
+    for (const entry of parseGitWorktreePorcelain(worktreeList)) {
+      worktreePaths.push(entry.path);
+    }
+  }
+
+  return unique(worktreePaths)
+    .map((worktreePath) => summarizePeerWorktree(worktreePath, repo))
+    .filter(Boolean)
+    .map((peer) => ({ ...peer, explicit: explicitPaths.has(peer.path) }))
+    .filter(
+      (peer) =>
+        peer.explicit ||
+        /nightly|self|runner|automation|scraper-recycle/i.test(peer.branch),
+    )
+    .filter((peer) => peer.changedFileCount > 0 || peer.aheadCount > 0)
+    .map((peer) => ({ ...peer, score: peerWorktreeScore(peer) }))
+    .sort((left, right) => right.score - left.score);
+}
+
 export function collectRepoSnapshot(repo) {
   return {
     branch: git(repo, ["branch", "--show-current"]) || git(repo, ["rev-parse", "--abbrev-ref", "HEAD"]),
@@ -368,11 +576,43 @@ export function buildCandidates({
   soak,
   dailyBug,
   repo,
+  peerWorktrees = [],
   crashAutomationExists,
   devBotMemoryExists,
   memoryBudgetBytes,
 }) {
   const candidates = [];
+
+  for (const peer of peerWorktrees) {
+    candidates.push(
+      target({
+        id: `peer-${peer.branch.replace(/[^a-z0-9]+/gi, "-").replace(/^-|-$/g, "").toLowerCase()}`,
+        kind: "peer-worktree",
+        title: `Review and incorporate peer worktree ${peer.branch}`,
+        score: peer.score,
+        confidence: peer.branch.includes("scraper-recycle-verification") ? 0.88 : 0.72,
+        estimatedMinutes: peer.touchesNightlyRunner ? 75 : 55,
+        providerVisible: peer.providerVisible,
+        rationale: peer.touchesMemoryTelemetry
+          ? "A local peer worktree has memory or performance diagnostics changes that should be compared before selecting overnight fixes."
+          : "A local peer worktree has unmerged changes that may overlap the nightly improvement path.",
+        evidence: [
+          peer.path,
+          `Branch ${peer.branch}`,
+          `Changed files ${numberFormatter.format(peer.changedFileCount)}`,
+          `Ahead ${numberFormatter.format(peer.aheadCount)}, behind ${numberFormatter.format(peer.behindCount)}`,
+          ...peer.changedFiles.slice(0, MAX_PEER_EVIDENCE_FILES),
+        ],
+        prompt:
+          "Compare the peer worktree diff against this runner branch. Reimplement or cherry-pick safe measurement and orchestration ideas only after checking for active work, validation coverage, and provider-visible behavior. Do not modify the peer worktree.",
+        validation: [
+          "Run focused tests for any imported script, native, or desktop changes.",
+          "Run validate:feature before publishing.",
+          "Call out any peer changes that were intentionally not absorbed.",
+        ],
+      }),
+    );
+  }
 
   if (soak.exists && (soak.maxWebKitResidentBytes ?? 0) > memoryBudgetBytes) {
     candidates.push(
@@ -603,6 +843,7 @@ function formatCandidate(candidate, index) {
 
 export function buildReport({ repo, soak, candidates, selected, options }) {
   const blockedProvider = candidates.filter((candidate) => candidate.providerVisible);
+  const phases = buildNightlyPhases(selected);
   return [
     "# Freed Nightly Improvement Plan",
     "",
@@ -628,6 +869,10 @@ export function buildReport({ repo, soak, candidates, selected, options }) {
       `   Kind: ${candidate.kind}. Score: ${numberFormatter.format(candidate.score)}. Machine time: ${numberFormatter.format(candidate.estimatedMinutes)} min.`,
     ]),
     "",
+    "## Execution Phases",
+    "",
+    ...phases.map((phase, index) => `${index + 1}. ${phase}`),
+    "",
     "## Provider Visibility Gate",
     "",
     blockedProvider.length > 0
@@ -641,20 +886,36 @@ export function buildReport({ repo, soak, candidates, selected, options }) {
     "- Add a learned target scorer that compares each night's fix outcome against the previous run budget.",
     "- Keep a small local knowledge base of recurring failure signatures and the focused tests that proved prior fixes.",
     "- Teach the runner to split one night into planning, fix, validation, dev build, install, and soak phases with stop conditions.",
+    "- Promote peer worktree comparison into an automatic import step before any new task starts.",
     "- Require evidence snapshots before every rare crash or memory fix so the next failure has better diagnostics.",
     "- Add a morning digest that ranks shipped value, residual risk, and the single next highest leverage bottleneck.",
     "",
   ].join("\n");
 }
 
-export function writeRunPlan({ runDir, repo, soak, candidates, selected, options }) {
+function buildNightlyPhases(selected) {
+  const phases = [
+    "Snapshot evidence from soak, logs, automations, git state, and peer worktrees.",
+  ];
+  if (selected.some((candidate) => candidate.kind === "peer-worktree")) {
+    phases.push("Compare peer worktrees and import safe measurement improvements.");
+  }
+  phases.push("Execute selected targets in score order while respecting provider visibility gates.");
+  phases.push("Run focused validation for each changed surface.");
+  phases.push("Run validate:feature before publishing or updating a PR.");
+  phases.push("Ship a dev build only if real product fixes landed and checks are green.");
+  phases.push("Install the new build, restart the soak, and write the morning digest.");
+  return phases;
+}
+
+export function writeRunPlan({ runDir, repo, soak, peerWorktrees = [], candidates, selected, options }) {
   mkdirSync(runDir, { recursive: true });
   const tasksDir = path.join(runDir, "tasks");
   mkdirSync(tasksDir, { recursive: true });
 
   const report = buildReport({ repo, soak, candidates, selected, options });
   writeFileSync(path.join(runDir, "report.md"), report);
-  writeFileSync(path.join(runDir, "targets.json"), `${JSON.stringify({ repo, soak, candidates, selected }, null, 2)}\n`);
+  writeFileSync(path.join(runDir, "targets.json"), `${JSON.stringify({ repo, soak, peerWorktrees, candidates, selected }, null, 2)}\n`);
 
   selected.forEach((candidate, index) => {
     const name = `${String(index + 1).padStart(2, "0")}-${candidate.id}.md`;
@@ -669,16 +930,18 @@ export function planNightlyRun(args) {
   const soak = summarizeSoak(soakDir);
   const dailyBug = summarizeDailyBugMemory(args.dailyBugMemory);
   const repo = collectRepoSnapshot(args.repo);
+  const peerWorktrees = collectPeerWorktrees(args.repo, args.peerWorktrees, args.peerScan);
   const candidates = buildCandidates({
     soak,
     dailyBug,
     repo,
+    peerWorktrees,
     crashAutomationExists: existsSync(args.crashAutomation),
     devBotMemoryExists: existsSync(args.devBotMemory),
     memoryBudgetBytes: args.memoryGib * GIB,
   });
   const selected = selectTargets(candidates, args);
-  return { repo, soak, dailyBug, candidates, selected };
+  return { repo, soak, dailyBug, peerWorktrees, candidates, selected };
 }
 
 function textSummary(plan, writeResult, args) {
@@ -686,6 +949,7 @@ function textSummary(plan, writeResult, args) {
     `Selected ${numberFormatter.format(plan.selected.length)} targets from ${numberFormatter.format(plan.candidates.length)} candidates.`,
     `Max WebKit RSS: ${formatBytes(plan.soak.maxWebKitResidentBytes)}.`,
     `Stale heartbeat events: ${numberFormatter.format(plan.soak.staleHeartbeatCount)}.`,
+    `Peer worktrees with changes: ${numberFormatter.format(plan.peerWorktrees.length)}.`,
   ];
 
   for (const [index, selected] of plan.selected.entries()) {
@@ -722,6 +986,7 @@ export function main(argv = process.argv.slice(2)) {
         runDir: args.runDir,
         repo: plan.repo,
         soak: plan.soak,
+        peerWorktrees: plan.peerWorktrees,
         candidates: plan.candidates,
         selected: plan.selected,
         options: args,

--- a/scripts/nightly-self-improve.test.mjs
+++ b/scripts/nightly-self-improve.test.mjs
@@ -5,12 +5,14 @@ import path from "node:path";
 import test from "node:test";
 
 import {
+  applyOutcomeFeedback,
   buildCandidates,
   formatBytes,
   parseArgs,
   parseGitWorktreePorcelain,
   parseTsv,
   selectTargets,
+  summarizeOutcomeLedger,
   summarizeDailyBugMemory,
   summarizeSoak,
   writeRunPlan,
@@ -214,6 +216,33 @@ test("peer worktree candidates outrank generic roadmap work", () => {
   assert.equal(selected[0].providerVisible, false);
 });
 
+test("outcome feedback raises shipped target kinds and lowers failed ones", () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "freed-outcomes-"));
+  const ledgerPath = path.join(dir, "outcomes.jsonl");
+  writeFileSync(
+    ledgerPath,
+    [
+      JSON.stringify({ id: "webkit-memory-pressure", kind: "performance", outcome: "shipped" }),
+      JSON.stringify({ id: "daily-bug-fix-scan", kind: "bug-fix", outcome: "failed" }),
+      "",
+    ].join("\n"),
+  );
+
+  const ledger = summarizeOutcomeLedger(ledgerPath);
+  const adjusted = applyOutcomeFeedback(
+    [
+      { id: "webkit-memory-pressure", kind: "performance", score: 80 },
+      { id: "daily-bug-fix-scan", kind: "bug-fix", score: 80 },
+    ],
+    ledger,
+  );
+
+  assert.equal(ledger.entries.length, 2);
+  assert.equal(adjusted[0].id, "webkit-memory-pressure");
+  assert.ok(adjusted[0].score > adjusted[1].score);
+  assert.equal(adjusted[1].outcomeFeedback.failed, 2);
+});
+
 test("writeRunPlan emits report, targets, and task prompts", () => {
   const dir = mkdtempSync(path.join(os.tmpdir(), "freed-nightly-plan-"));
   const selected = [
@@ -251,6 +280,7 @@ test("writeRunPlan emits report, targets, and task prompts", () => {
 
   assert.equal(path.basename(result.reportPath), "report.md");
   assert.equal(path.basename(result.tasksDir), "tasks");
+  assert.equal(path.basename(result.outcomeTemplatePath), "outcome-template.jsonl");
 });
 
 test("argument parsing validates numeric budgets", () => {

--- a/scripts/nightly-self-improve.test.mjs
+++ b/scripts/nightly-self-improve.test.mjs
@@ -8,6 +8,7 @@ import {
   buildCandidates,
   formatBytes,
   parseArgs,
+  parseGitWorktreePorcelain,
   parseTsv,
   selectTargets,
   summarizeDailyBugMemory,
@@ -122,6 +123,7 @@ test("candidate selection prioritizes memory work while preserving bug scans", (
       originMain: "0000000",
       status: "",
     },
+    peerWorktrees: [],
     crashAutomationExists: true,
     devBotMemoryExists: true,
     memoryBudgetBytes: 2.5 * GIB,
@@ -136,6 +138,80 @@ test("candidate selection prioritizes memory work while preserving bug scans", (
   assert.equal(selected[0].id, "webkit-memory-pressure");
   assert.ok(selected.some((candidate) => candidate.id === "daily-bug-fix-scan"));
   assert.ok(!selected.some((candidate) => candidate.providerVisible));
+});
+
+test("parseGitWorktreePorcelain reads branch entries", () => {
+  const entries = parseGitWorktreePorcelain(
+    [
+      "worktree /repo/main",
+      "HEAD abc",
+      "branch refs/heads/main",
+      "",
+      "worktree /repo/peer",
+      "HEAD def",
+      "branch refs/heads/perf/scraper-recycle-verification",
+      "",
+    ].join("\n"),
+  );
+
+  assert.deepEqual(entries, [
+    { path: "/repo/main", head: "abc", branch: "main", detached: false },
+    {
+      path: "/repo/peer",
+      head: "def",
+      branch: "perf/scraper-recycle-verification",
+      detached: false,
+    },
+  ]);
+});
+
+test("peer worktree candidates outrank generic roadmap work", () => {
+  const candidates = buildCandidates({
+    soak: {
+      exists: false,
+      soakDir: "",
+      sampleCount: 0,
+      maxWebKitResidentBytes: null,
+      maxEventLoopLagMs: null,
+      maxDomNodes: null,
+      staleHeartbeatCount: 0,
+      throttledHeartbeatCount: 0,
+      lastEvent: "",
+    },
+    dailyBug: { exists: false },
+    repo: { branch: "feature", head: "abc1234", status: " M script" },
+    peerWorktrees: [
+      {
+        path: "/peer",
+        branch: "perf/scraper-recycle-verification",
+        head: "def5678",
+        aheadCount: 0,
+        behindCount: 1,
+        changedFileCount: 3,
+        changedFiles: [
+          "packages/desktop/src-tauri/src/lib.rs",
+          "packages/desktop/src/lib/memory-monitor.ts",
+          "packages/desktop/tests/e2e/smoke.spec.ts",
+        ],
+        touchesMemoryTelemetry: true,
+        touchesNightlyRunner: false,
+        providerVisible: false,
+        score: 99,
+      },
+    ],
+    crashAutomationExists: false,
+    devBotMemoryExists: true,
+    memoryBudgetBytes: 2.5 * GIB,
+  });
+
+  const selected = selectTargets(candidates, {
+    maxTargets: 2,
+    durationMinutes: 480,
+    allowProviderVisible: false,
+  });
+
+  assert.equal(selected[0].kind, "peer-worktree");
+  assert.equal(selected[0].providerVisible, false);
 });
 
 test("writeRunPlan emits report, targets, and task prompts", () => {
@@ -180,6 +256,7 @@ test("writeRunPlan emits report, targets, and task prompts", () => {
 test("argument parsing validates numeric budgets", () => {
   assert.throws(() => parseArgs(["--max-targets", "0"]), /maxTargets/);
   assert.equal(parseArgs(["--memory-gib", "3"]).memoryGib, 3);
+  assert.equal(parseArgs(["--peer-worktree", "/tmp/peer", "--no-peer-scan"]).peerScan, false);
 });
 
 test("formatBytes uses GiB with grouped decimal output", () => {

--- a/scripts/nightly-self-improve.test.mjs
+++ b/scripts/nightly-self-improve.test.mjs
@@ -1,0 +1,191 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  buildCandidates,
+  formatBytes,
+  parseArgs,
+  parseTsv,
+  selectTargets,
+  summarizeDailyBugMemory,
+  summarizeSoak,
+  writeRunPlan,
+} from "./nightly-self-improve.mjs";
+
+const GIB = 1024 * 1024 * 1024;
+
+test("summarizeSoak reads WebKit memory, heartbeat, and DOM evidence", () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "freed-soak-test-"));
+  writeFileSync(
+    path.join(dir, "metrics.tsv"),
+    [
+      "ts\thealth_event\thealth_dom_nodes\thealth_event_loop_lag_ms\thealth_webkit_rss_bytes\thealth_hidden_timer_throttled",
+      `2026-05-29T01:00:00Z\trenderer_heartbeat\t450\t4\t${3 * GIB}\tfalse`,
+      `2026-05-29T01:00:15Z\trenderer_heartbeat_stale\t900\t65\t${4 * GIB}\ttrue`,
+      "",
+    ].join("\n"),
+  );
+  writeFileSync(
+    path.join(dir, "runtime-health.jsonl"),
+    [
+      JSON.stringify({
+        event: "renderer_heartbeat",
+        domNodeCount: 700,
+        eventLoopLagMs: 12,
+        webkitResidentBytes: 2 * GIB,
+      }),
+      "",
+    ].join("\n"),
+  );
+
+  const summary = summarizeSoak(dir);
+  assert.equal(summary.exists, true);
+  assert.equal(summary.sampleCount, 2);
+  assert.equal(summary.maxWebKitResidentBytes, 4 * GIB);
+  assert.equal(summary.maxEventLoopLagMs, 65);
+  assert.equal(summary.maxDomNodes, 900);
+  assert.equal(summary.staleHeartbeatCount, 1);
+  assert.equal(summary.throttledHeartbeatCount, 1);
+});
+
+test("daily bug memory summary keeps the latest dated scan", () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "freed-bug-memory-"));
+  const memoryPath = path.join(dir, "memory.md");
+  writeFileSync(
+    memoryPath,
+    [
+      "# Daily Bug Scan Memory",
+      "",
+      "## 2026-05-28",
+      "- Outcome: fix applied.",
+      "",
+      "## 2026-05-29",
+      "- Commit counts since the prior scan cutoff: `origin/dev` `0`, `origin/main` `0`, `origin/www` `0`.",
+      "- Outcome: no new repo evidence to review, no evidence-backed bug found.",
+      "",
+    ].join("\n"),
+  );
+
+  const summary = summarizeDailyBugMemory(memoryPath);
+  assert.equal(summary.exists, true);
+  assert.equal(summary.latestDate, "2026-05-29");
+  assert.equal(summary.latestHadNoNewCommits, true);
+  assert.equal(summary.latestHadFix, false);
+});
+
+test("daily bug memory does not treat a referenced old PR as a new fix", () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "freed-bug-memory-pr-"));
+  const memoryPath = path.join(dir, "memory.md");
+  writeFileSync(
+    memoryPath,
+    [
+      "# Daily Bug Scan Memory",
+      "",
+      "## 2026-05-29",
+      "- Latest unchanged `origin/dev` commits remain `ef7bd47d` from PR `#605`.",
+      "- Outcome: no new repo evidence to review, no evidence-backed bug found, and no fix applied.",
+      "",
+    ].join("\n"),
+  );
+
+  const summary = summarizeDailyBugMemory(memoryPath);
+  assert.equal(summary.latestHadFix, false);
+});
+
+test("candidate selection prioritizes memory work while preserving bug scans", () => {
+  const candidates = buildCandidates({
+    soak: {
+      exists: true,
+      soakDir: "/tmp/freed-perf-soak/example",
+      sampleCount: 20,
+      maxWebKitResidentBytes: 4 * GIB,
+      maxEventLoopLagMs: 9,
+      maxDomNodes: 600,
+      staleHeartbeatCount: 0,
+      throttledHeartbeatCount: 0,
+      lastEvent: "renderer_heartbeat",
+    },
+    dailyBug: {
+      exists: true,
+      path: "/tmp/memory.md",
+      latestDate: "2026-05-29",
+      latestHadNoNewCommits: false,
+      latestHadFix: false,
+    },
+    repo: {
+      branch: "feat/nightly-improvement-runner",
+      head: "abc1234",
+      originDev: "def5678",
+      originMain: "0000000",
+      status: "",
+    },
+    crashAutomationExists: true,
+    devBotMemoryExists: true,
+    memoryBudgetBytes: 2.5 * GIB,
+  });
+
+  const selected = selectTargets(candidates, {
+    maxTargets: 3,
+    durationMinutes: 480,
+    allowProviderVisible: false,
+  });
+
+  assert.equal(selected[0].id, "webkit-memory-pressure");
+  assert.ok(selected.some((candidate) => candidate.id === "daily-bug-fix-scan"));
+  assert.ok(!selected.some((candidate) => candidate.providerVisible));
+});
+
+test("writeRunPlan emits report, targets, and task prompts", () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "freed-nightly-plan-"));
+  const selected = [
+    {
+      id: "daily-bug-fix-scan",
+      kind: "bug-fix",
+      title: "Run evidence-backed nightly bug fix scan",
+      score: 82,
+      confidence: 0.86,
+      estimatedMinutes: 90,
+      providerVisible: false,
+      rationale: "Fresh commits need review.",
+      evidence: ["/tmp/memory.md"],
+      prompt: "Inspect commits and fix only evidence-backed bugs.",
+      validation: ["Run focused tests."],
+    },
+  ];
+
+  const result = writeRunPlan({
+    runDir: dir,
+    repo: { branch: "feature", head: "abc1234" },
+    soak: {
+      soakDir: "/tmp/soak",
+      sampleCount: 10,
+      maxWebKitResidentBytes: 3 * GIB,
+      maxEventLoopLagMs: 4,
+      maxDomNodes: 500,
+      staleHeartbeatCount: 0,
+      throttledHeartbeatCount: 0,
+    },
+    candidates: selected,
+    selected,
+    options: { durationMinutes: 480 },
+  });
+
+  assert.equal(path.basename(result.reportPath), "report.md");
+  assert.equal(path.basename(result.tasksDir), "tasks");
+});
+
+test("argument parsing validates numeric budgets", () => {
+  assert.throws(() => parseArgs(["--max-targets", "0"]), /maxTargets/);
+  assert.equal(parseArgs(["--memory-gib", "3"]).memoryGib, 3);
+});
+
+test("formatBytes uses GiB with grouped decimal output", () => {
+  assert.equal(formatBytes(3.25 * GIB), "3.3 GiB");
+});
+
+test("parseTsv maps headers to row fields", () => {
+  assert.deepEqual(parseTsv("a\tb\n1\t2\n"), [{ a: "1", b: "2" }]);
+});

--- a/website/src/app/roadmap/RoadmapContent.tsx
+++ b/website/src/app/roadmap/RoadmapContent.tsx
@@ -783,7 +783,7 @@ const phases: Phase[] = [
     number: 10,
     title: "Polish",
     description:
-      "Onboarding, statistics, global animation controls, expanded local content signals with Desktop and PWA backfill, inclusive saved feed filter presets, compact event extraction, local semantic enrichment for friend suggestions, unified AI provider settings, Light, Balanced, and Pro Integrated AI packs with semantic scan health, plugin API, community infrastructure, and deeper crash recovery hardening.",
+      "Onboarding, statistics, global animation controls, expanded local content signals with Desktop and PWA backfill, inclusive saved feed filter presets, compact event extraction, local semantic enrichment for friend suggestions, unified AI provider settings, Light, Balanced, and Pro Integrated AI packs with semantic scan health, plugin API, community infrastructure, nightly improvement planning, and deeper crash recovery hardening.",
     status: "upcoming",
     planLink:
       "https://github.com/freed-project/freed/blob/dev/docs/PHASE-10-POLISH.md",

--- a/website/src/app/roadmap/RoadmapContent.tsx
+++ b/website/src/app/roadmap/RoadmapContent.tsx
@@ -783,7 +783,7 @@ const phases: Phase[] = [
     number: 10,
     title: "Polish",
     description:
-      "Onboarding, statistics, global animation controls, expanded local content signals with Desktop and PWA backfill, inclusive saved feed filter presets, compact event extraction, local semantic enrichment for friend suggestions, unified AI provider settings, Light, Balanced, and Pro Integrated AI packs with semantic scan health, plugin API, community infrastructure, nightly improvement planning, and deeper crash recovery hardening.",
+      "Onboarding, statistics, global animation controls, expanded local content signals with Desktop and PWA backfill, inclusive saved feed filter presets, compact event extraction, local semantic enrichment for friend suggestions, unified AI provider settings, Light, Balanced, and Pro Integrated AI packs with semantic scan health, plugin API, community infrastructure, peer-aware nightly improvement planning, and deeper crash recovery hardening.",
     status: "upcoming",
     planLink:
       "https://github.com/freed-project/freed/blob/dev/docs/PHASE-10-POLISH.md",


### PR DESCRIPTION
(AI Generated).

## Summary
- Adds a local nightly planner that scores performance, bug fix, stability, release, roadmap, and peer-worktree targets from soak and automation evidence.
- Detects the active perf/scraper-recycle-verification worktree and ranks it ahead of new work so this runner can absorb safe competing-agent measurements first.
- Adds an outcome ledger and generated outcome template so future runs can adjust target scores based on shipped, validated, blocked, or failed work.
- Keeps provider-visible work behind an explicit approval gate and writes report, target JSON, execution phases, and task prompt artifacts for each selected target.

## Testing
- node --test scripts/nightly-self-improve.test.mjs
- corepack npm run test:scripts
- corepack npm run validate:feature