### PR TITLE
fix: preserve X like feed retention coverage

### DIFF
--- a/packages/desktop/src/lib/automerge-state-patches.test.ts
+++ b/packages/desktop/src/lib/automerge-state-patches.test.ts
@@ -140,6 +140,49 @@ describe("Automerge item patch state updates", () => {
     expect(result.state.totalArchivableCount).toBe(state.totalArchivableCount);
   });
 
+  it("keeps a synced X like patch count-neutral and in place", () => {
+    const { rssSource: _rssSource, ...baseXPost } = makeItem("x:2049705418436600244");
+    const xPost = {
+      ...baseXPost,
+      platform: "x" as const,
+    };
+    const read = makeItem("rss:read", { readAt: 10 });
+    const state = {
+      ...makeState([xPost, read]),
+      feedUnreadCounts: {},
+      feedTotalCounts: { [FEED_URL]: 1 },
+      totalUnreadCount: 1,
+      unreadCountByPlatform: { x: 1 },
+      totalItemCount: 2,
+      itemCountByPlatform: { x: 1, rss: 1 },
+      totalArchivableCount: 1,
+      archivableCountByPlatform: { rss: 1 },
+      archivableFeedCounts: { [FEED_URL]: 1 },
+    };
+    const index = createItemIndex(state.items);
+
+    const likedXPost = {
+      ...xPost,
+      userState: {
+        ...xPost.userState,
+        liked: true,
+        likedAt: 40,
+        likedSyncedAt: 50,
+      },
+    };
+    const result = applyItemPatchesToState(state, [{ item: likedXPost }], index);
+
+    expect(result.state.items).toEqual([likedXPost, read]);
+    expect(result.itemIndex.get("x:2049705418436600244")).toBe(0);
+    expect(result.state.totalUnreadCount).toBe(state.totalUnreadCount);
+    expect(result.state.unreadCountByPlatform).toBe(state.unreadCountByPlatform);
+    expect(result.state.totalItemCount).toBe(state.totalItemCount);
+    expect(result.state.itemCountByPlatform).toBe(state.itemCountByPlatform);
+    expect(result.state.totalArchivableCount).toBe(state.totalArchivableCount);
+    expect(result.state.mapFriendLocationCount).toBe(state.mapFriendLocationCount);
+    expect(result.state.mapAllContentLocationCount).toBe(state.mapAllContentLocationCount);
+  });
+
   it("applies a large archive patch batch to aggregate counts", () => {
     const items = Array.from({ length: 300 }, (_, index) =>
       makeItem(`rss:read-${index}`, { readAt: 10 + index })

--- a/packages/desktop/tests/e2e/feed-card-ui.spec.ts
+++ b/packages/desktop/tests/e2e/feed-card-ui.spec.ts
@@ -4,8 +4,10 @@ const FACEBOOK_TITLE = "Card UI Overhaul Facebook Item";
 const RSS_TITLE = "Card UI Overhaul RSS Item";
 const STORY_TITLE = "Story thumbnail proof";
 const BROKEN_TITLE = "Broken thumbnail fallback proof";
+const X_LIKE_TITLE = "X liked post retention proof";
 const FACEBOOK_URL = "https://example.com/facebook/card-ui-overhaul";
 const RSS_URL = "https://example.com/rss/card-ui-overhaul";
+const X_LIKE_URL = "https://x.com/coindesk/status/2049705418436600244";
 const FACEBOOK_MEDIA_URL = "/freed.svg?feed-card";
 const STORY_MEDIA_URL = "/freed.svg?story-tile";
 const BROKEN_MEDIA_URL = "/freed.svg?fallback";
@@ -170,6 +172,59 @@ async function injectCardUiItems(page: import("@playwright/test").Page): Promise
   );
 }
 
+async function injectXLikeRetentionItem(page: import("@playwright/test").Page): Promise<void> {
+  await page.evaluate(
+    async ({ title, sourceUrl }) => {
+      const now = Date.now();
+      const w = window as Record<string, unknown>;
+      const automerge = w.__FREED_AUTOMERGE__ as {
+        docBatchImportItems: (items: unknown[]) => Promise<unknown>;
+      };
+
+      await automerge.docBatchImportItems([
+        {
+          globalId: "x:2049705418436600244",
+          platform: "x",
+          contentType: "post",
+          capturedAt: now - 30_000,
+          publishedAt: now - 60_000,
+          author: {
+            id: "coindesk",
+            handle: "CoinDesk",
+            displayName: "CoinDesk",
+          },
+          content: {
+            text: "ICYMI: The U.S. Senate releases CLARITY Act compromise text.",
+            mediaUrls: [],
+            mediaTypes: [],
+            linkPreview: {
+              url: sourceUrl,
+              title,
+              description: "A seeded X post used to prove like actions stay in Unified Feed.",
+            },
+          },
+          engagement: {
+            likes: 385,
+            comments: 56,
+          },
+          userState: {
+            hidden: false,
+            saved: false,
+            archived: false,
+            tags: [],
+          },
+          topics: ["testing"],
+          sourceUrl,
+        },
+      ]);
+    },
+    {
+      title: X_LIKE_TITLE,
+      sourceUrl: X_LIKE_URL,
+    },
+  );
+}
+
 async function setShowEngagementCounts(
   page: import("@playwright/test").Page,
   show: boolean,
@@ -278,6 +333,71 @@ test("feed card overhaul actions and reader open flow work", async ({ app }) => 
 
   const openReaderButton = app.page.getByRole("button", { name: "Open", exact: true }).first();
   await expect(openReaderButton).toBeVisible();
+});
+
+test("liking an X post keeps it in the unified feed", async ({ app, ipc }) => {
+  await app.goto();
+  await app.waitForReady();
+  await ipc.setHandler("x_api_request", () => "{}");
+  await injectXLikeRetentionItem(app.page);
+  await setShowEngagementCounts(app.page, true);
+
+  await app.page.evaluate(() => {
+    const store = (window as Record<string, unknown>).__FREED_STORE__ as {
+      getState: () => {
+        setXAuth: (auth: unknown) => void;
+      };
+    };
+    store.getState().setXAuth({
+      isAuthenticated: true,
+      cookies: {
+        ct0: "test-csrf",
+        authToken: "test-auth",
+      },
+    });
+  });
+
+  const xCard = app.page.locator('[data-feed-item-id="x:2049705418436600244"]');
+  await expect(xCard).toBeVisible();
+  await expect(xCard).toContainText(X_LIKE_TITLE);
+  await xCard.hover();
+
+  await xCard.getByRole("button", { name: "Like", exact: true }).click();
+
+  await expect(xCard).toBeVisible();
+  await expect(xCard).toContainText(X_LIKE_TITLE);
+  await expect(xCard.getByRole("button", { name: /Liked/ })).toBeVisible();
+  await expect(xCard.getByRole("button", { name: "Liked on X" })).toBeVisible({
+    timeout: 8_000,
+  });
+  await expect(xCard).toBeVisible();
+  await expect(xCard).toContainText(X_LIKE_TITLE);
+
+  const userState = await app.page.evaluate(() => {
+    const store = (window as Record<string, unknown>).__FREED_STORE__ as {
+      getState: () => {
+        items: Array<{
+          globalId: string;
+          userState: {
+            archived: boolean;
+            hidden: boolean;
+            liked?: boolean;
+            likedAt?: number;
+            likedSyncedAt?: number;
+          };
+        }>;
+      };
+    };
+    return store.getState().items.find((item) => item.globalId === "x:2049705418436600244")?.userState;
+  });
+
+  expect(userState).toMatchObject({
+    archived: false,
+    hidden: false,
+    liked: true,
+  });
+  expect(userState?.likedAt).toEqual(expect.any(Number));
+  expect(userState?.likedSyncedAt).toEqual(expect.any(Number));
 });
 
 test("top toolbar card density slider persists locally", async ({ app, page }) => {


### PR DESCRIPTION
(AI Generated).

## Summary
- Ports the useful regression coverage from the closed stale X-like feed retention branch onto current dev.
- Covers count-neutral synced X like patches and the desktop feed card staying visible after Like.

## Testing
- PATH=/Users/aubreyfalconer/dev/freed-x-like-regression-coverage/node_modules/.bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/usr/local/MacGPG2/bin:/Applications/VMware Fusion.app/Contents/Public:/usr/local/share/dotnet:~/.dotnet/tools:/usr/local/go/bin:/Library/Frameworks/Mono.framework/Versions/Current/Commands:/Users/aubreyfalconer/.nvm/versions/node/v24.14.1/bin:/Users/aubreyfalconer/.codex/tmp/arg0/codex-arg0ldxqj8:/Users/aubreyfalconer/.local/bin:/opt/homebrew/opt/mysql-client/bin:/opt/homebrew/bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/Users/aubreyfalconer/.cargo/bin:/Users/aubreyfalconer/go/bin:/Users/aubreyfalconer/.cache/lm-studio/bin:/Users/aubreyfalconer/.safe-chain/bin:/Applications/Codex.app/Contents/Resources:/usr/local/bin npm run test:unit -- automerge-state-patches.test.ts
- PATH=/Users/aubreyfalconer/dev/freed-x-like-regression-coverage/node_modules/.bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/usr/local/MacGPG2/bin:/Applications/VMware Fusion.app/Contents/Public:/usr/local/share/dotnet:~/.dotnet/tools:/usr/local/go/bin:/Library/Frameworks/Mono.framework/Versions/Current/Commands:/Users/aubreyfalconer/.nvm/versions/node/v24.14.1/bin:/Users/aubreyfalconer/.codex/tmp/arg0/codex-arg0ldxqj8:/Users/aubreyfalconer/.local/bin:/opt/homebrew/opt/mysql-client/bin:/opt/homebrew/bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/Users/aubreyfalconer/.cargo/bin:/Users/aubreyfalconer/go/bin:/Users/aubreyfalconer/.cache/lm-studio/bin:/Users/aubreyfalconer/.safe-chain/bin:/Applications/Codex.app/Contents/Resources:/usr/local/bin npm run test:e2e -- feed-card-ui.spec.ts --grep 'liking an X post keeps it in the unified feed'
- npm run validate:feature -- --changed-files packages/desktop/src/lib/automerge-state-patches.test.ts packages/desktop/tests/e2e/feed-card-ui.spec.ts did not complete because desktop e2e smoke hit an unrelated settings-store Vite 403 harness failure.