### PR TITLE
perf: avoid redundant reader hydration

### DIFF
--- a/packages/ui/src/components/feed/ReaderView.test.tsx
+++ b/packages/ui/src/components/feed/ReaderView.test.tsx
@@ -1,0 +1,156 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import type { FeedItem as FeedItemType } from "@freed/shared";
+import { PlatformProvider, type PlatformConfig } from "../../context/PlatformContext.js";
+import { ReaderView } from "./ReaderView";
+
+const NOW = 1_712_147_200_000;
+
+function makeArticleItem(overrides: Partial<FeedItemType> = {}): FeedItemType {
+  return {
+    globalId: "rss:reader-cache-first",
+    platform: "rss",
+    contentType: "article",
+    capturedAt: NOW,
+    publishedAt: NOW - 60_000,
+    author: {
+      id: "rss-author",
+      handle: "rss-author",
+      displayName: "RSS Author",
+    },
+    content: {
+      text: "Cached preview",
+      mediaUrls: [],
+      mediaTypes: [],
+      linkPreview: {
+        url: "https://example.com/cached-reader",
+        title: "Cached Reader",
+        description: "Cached preview",
+      },
+    },
+    userState: {
+      hidden: false,
+      saved: false,
+      archived: false,
+      tags: [],
+    },
+    topics: [],
+    sourceUrl: "https://example.com/cached-reader",
+    ...overrides,
+  };
+}
+
+const testStoreState = {
+  preferences: {
+    display: {
+      reading: {
+        focusMode: false,
+        focusIntensity: "normal",
+      },
+    },
+  },
+  toggleSaved: vi.fn(),
+  toggleArchived: vi.fn(),
+  updatePreferences: vi.fn(),
+};
+
+const basePlatformConfig = {
+  feedMediaPreviews: "reader-only",
+  store: ((selector: (state: typeof testStoreState) => unknown) => selector(testStoreState)) as PlatformConfig["store"],
+  SourceIndicator: null,
+  HeaderSyncIndicator: null,
+  SettingsExtraSections: null,
+  LegalSettingsContent: null,
+  FeedEmptyState: null,
+  XSettingsContent: null,
+  FacebookSettingsContent: null,
+  InstagramSettingsContent: null,
+  LinkedInSettingsContent: null,
+  GoogleContactsSettingsContent: null,
+} as unknown as PlatformConfig;
+
+async function renderReaderView(platform: PlatformConfig): Promise<{
+  container: HTMLDivElement;
+  root: Root;
+}> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  await act(async () => {
+    root.render(
+      <PlatformProvider value={platform}>
+        <ReaderView item={makeArticleItem()} onClose={() => {}} />
+      </PlatformProvider>,
+    );
+  });
+
+  return { container, root };
+}
+
+describe("ReaderView cache-first hydration", () => {
+  beforeAll(() => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    localStorage.removeItem("freed.reader.offlineCacheMode");
+    vi.restoreAllMocks();
+  });
+
+  it("does not run live hydration when full cached content is already available", async () => {
+    Object.defineProperty(window.navigator, "onLine", { configurable: true, value: true });
+    const hydrateReaderItem = vi.fn(async () => ({
+      html: "<article><p>Live content should not load.</p></article>",
+      status: "hydrated" as const,
+    }));
+    const platform = {
+      ...basePlatformConfig,
+      getLocalContent: vi.fn(async () => "<article><p>Cached content loaded first.</p></article>"),
+      hydrateReaderItem,
+    } as unknown as PlatformConfig;
+
+    const { container, root } = await renderReaderView(platform);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain("Cached content loaded first.");
+    expect(container.textContent).not.toContain("Live content should not load.");
+    expect(hydrateReaderItem).not.toHaveBeenCalled();
+
+    await act(async () => root.unmount());
+  });
+
+  it("keeps live hydration for synced text when the cache mode pins opened items", async () => {
+    localStorage.setItem("freed.reader.offlineCacheMode", "everything_opened");
+    Object.defineProperty(window.navigator, "onLine", { configurable: true, value: true });
+    const hydrateReaderItem = vi.fn(async () => ({
+      html: "<article><p>Pinned live content.</p></article>",
+      status: "hydrated" as const,
+    }));
+    const platform = {
+      ...basePlatformConfig,
+      getLocalContent: vi.fn(async () => null),
+      getLocalPreservedText: vi.fn(async () => "Synced text"),
+      hydrateReaderItem,
+    } as unknown as PlatformConfig;
+
+    const { container, root } = await renderReaderView(platform);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain("Pinned live content.");
+    expect(hydrateReaderItem).toHaveBeenCalledOnce();
+
+    await act(async () => root.unmount());
+  });
+});

--- a/packages/ui/src/components/feed/ReaderView.tsx
+++ b/packages/ui/src/components/feed/ReaderView.tsx
@@ -295,6 +295,7 @@ export function ReaderView({
       const cacheMode = getReaderOfflineCacheMode();
       const shouldPin = item.userState.saved || shouldPinOpenedReaderItem(cacheMode);
       let hasReaderContent = false;
+      let readerContentSource: ContentSource = null;
 
       setIsLoading(true);
       setIsCaching(false);
@@ -320,6 +321,7 @@ export function ReaderView({
           setContentSource("cache");
           setIsLoading(false);
           hasReaderContent = true;
+          readerContentSource = "cache";
         }
       } else if (articleUrl && "caches" in window) {
         try {
@@ -332,6 +334,7 @@ export function ReaderView({
               setContentSource("cache");
               setIsLoading(false);
               hasReaderContent = true;
+              readerContentSource = "cache";
             }
           }
         } catch {
@@ -356,12 +359,18 @@ export function ReaderView({
           setContentSource("text");
           setIsLoading(false);
           hasReaderContent = true;
+          readerContentSource = "text";
         }
       }
 
       // Layer 3: platform hydration. Desktop uses native fetch or authenticated
       // provider paths here, so reader failures are not confused with CORS.
-      if (hydrateReaderItem && navigator.onLine) {
+      const shouldHydrateLive =
+        Boolean(hydrateReaderItem) &&
+        navigator.onLine &&
+        (!hasReaderContent || (readerContentSource !== "cache" && shouldPin));
+
+      if (shouldHydrateLive && hydrateReaderItem) {
         setIsCaching(true);
         try {
           const hydrated = await hydrateReaderItem(item, { cacheMode, pin: shouldPin });


### PR DESCRIPTION
(AI Generated).

## Summary
- Render cached reader content without running another live hydration pass.
- Keep synced-text live hydration only when the offline cache mode needs the opened item pinned.
- Add ReaderView coverage for cache-first behavior and pinned cache modes.

## Testing
- PATH=/Users/aubreyfalconer/dev/freed-reader-cache-first/node_modules/.bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/usr/local/MacGPG2/bin:/Applications/VMware Fusion.app/Contents/Public:/usr/local/share/dotnet:~/.dotnet/tools:/usr/local/go/bin:/Library/Frameworks/Mono.framework/Versions/Current/Commands:/Users/aubreyfalconer/.nvm/versions/node/v24.14.1/bin:/Users/aubreyfalconer/.codex/tmp/arg0/codex-arg0ldxqj8:/Users/aubreyfalconer/.local/bin:/opt/homebrew/opt/mysql-client/bin:/opt/homebrew/bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/Users/aubreyfalconer/.cargo/bin:/Users/aubreyfalconer/go/bin:/Users/aubreyfalconer/.cache/lm-studio/bin:/Users/aubreyfalconer/.safe-chain/bin:/Applications/Codex.app/Contents/Resources:/usr/local/bin vitest run packages/ui/src/components/feed/ReaderView.test.tsx
- cd packages/desktop && npm run test:e2e -- reader-hydration.spec.ts
- npm run validate:feature