### PR TITLE
feat: add nightly runner execution plan

### DIFF
--- a/docs/NIGHTLY-SELF-IMPROVE.md
+++ b/docs/NIGHTLY-SELF-IMPROVE.md
@@ -62,6 +62,7 @@ The generated run directory contains:
 - `report.md`: morning-readable summary
 - `targets.json`: full machine-readable candidate list
 - `tasks/*.md`: one implementation prompt per selected target
+- `execution-plan.md` and `execution-plan.json`: ordered phases, command hints, and stop gates
 - `outcome-template.jsonl`: lines to append back into the outcome ledger after the run
 
 Reports include an execution phase list so the night can move from evidence, to peer comparison, to implementation, validation, dev build shipping, installed-build soak, and the morning digest.
@@ -71,6 +72,8 @@ Reports include an execution phase list so the night can move from evidence, to 
 The runner excludes provider-visible tasks by default. Do not allow autonomous changes that alter authenticated WebView loads, provider navigation, provider API call frequency, scripted scrolling, cookies, headers, or scraping timing without explicit approval.
 
 Release work is also gated. A dev build should ship only after actual fixes merge into `dev`, not after planning artifacts alone.
+
+Every execution phase has a stop gate. The runner should stop rather than freestyle when evidence is missing, a peer branch is still changing, a provider-visible change needs approval, focused validation fails, or no real fix landed.
 
 ## Next Improvements
 

--- a/docs/PHASE-10-POLISH.md
+++ b/docs/PHASE-10-POLISH.md
@@ -126,7 +126,7 @@ The shared extension points now live in `packages/ui/src/lib/command-palette.ts`
 
 Freed now has a local nightly improvement planner in `scripts/nightly-self-improve.mjs`. It folds the installed-build soak, daily bug scan memory, crash-watch state, roadmap fallback memory, peer worktrees, prior outcome history, and current git state into a ranked queue of work that can run overnight.
 
-The runner can choose multiple targets in one night. Bug fixes are first-class targets through the existing daily bug scan memory, while peer worktree integration, performance, stability, release readiness, and roadmap work compete by score and machine-time budget. Provider-visible ideas stay blocked unless a human explicitly approves the fingerprinting risk.
+The runner can choose multiple targets in one night. Bug fixes are first-class targets through the existing daily bug scan memory, while peer worktree integration, performance, stability, release readiness, and roadmap work compete by score and machine-time budget. Each run now writes an execution plan with stop gates, command hints, task prompts, and outcome templates so overnight automation has a clear path from evidence to validation, dev build shipping, installed-build soak, and morning closeout. Provider-visible ideas stay blocked unless a human explicitly approves the fingerprinting risk.
 
 ### Keyboard Shortcuts
 

--- a/scripts/nightly-self-improve.mjs
+++ b/scripts/nightly-self-improve.mjs
@@ -988,15 +988,106 @@ function buildNightlyPhases(selected) {
   return phases;
 }
 
+export function buildExecutionPlan(selected) {
+  const phases = [
+    {
+      id: "evidence-snapshot",
+      title: "Snapshot evidence",
+      stopGate: "Stop if the repo is dirty with unrelated user changes or required evidence files cannot be read.",
+      commands: [
+        "git fetch --all --prune",
+        "git status --short",
+        "node scripts/nightly-self-improve.mjs --dry-run --json",
+      ],
+    },
+  ];
+
+  if (selected.some((candidate) => candidate.kind === "peer-worktree")) {
+    phases.push({
+      id: "peer-review",
+      title: "Review peer worktrees",
+      stopGate: "Stop before editing if the peer branch is still changing or the useful change is provider-visible.",
+      commands: [
+        "git worktree list --porcelain",
+        "git diff --stat origin/dev HEAD",
+        "git diff --name-only origin/dev HEAD",
+      ],
+    });
+  }
+
+  phases.push(
+    {
+      id: "implementation",
+      title: "Implement selected targets",
+      stopGate: "Stop if a target requires provider-visible behavior changes without explicit approval.",
+      commands: selected.map((candidate) => `# ${candidate.id}: ${candidate.prompt}`),
+    },
+    {
+      id: "focused-validation",
+      title: "Run focused validation",
+      stopGate: "Stop if the focused test for the touched code path fails.",
+      commands: [
+        "node --test scripts/nightly-self-improve.test.mjs",
+        "# Add the focused product test for any non-runner changes.",
+      ],
+    },
+    {
+      id: "feature-validation",
+      title: "Run feature validation",
+      stopGate: "Stop if validate:feature fails.",
+      commands: ["corepack npm run validate:feature"],
+    },
+    {
+      id: "publish",
+      title: "Publish or update draft PR",
+      stopGate: "Stop if the branch has no product or tooling improvement beyond generated run artifacts.",
+      commands: [
+        './scripts/worktree-publish.sh --title "feat: improve nightly runner" --summary "<summary>" --test "<tests>"',
+      ],
+    },
+    {
+      id: "release-and-soak",
+      title: "Ship and soak only after real fixes",
+      stopGate: "Skip this phase when only planning artifacts changed.",
+      commands: [
+        "# Use freed-ship-build dev after fixes merge into dev.",
+        "# Install the new dev build, restart the installed-build soak, and append outcome-template.jsonl to the outcome ledger.",
+      ],
+    },
+  );
+
+  return phases;
+}
+
+function renderExecutionPlanMarkdown(phases) {
+  return [
+    "# Nightly Execution Plan",
+    "",
+    ...phases.flatMap((phase, index) => [
+      `## ${index + 1}. ${phase.title}`,
+      "",
+      `Stop gate: ${phase.stopGate}`,
+      "",
+      "Commands:",
+      "",
+      ...phase.commands.map((command) => `- \`${command}\``),
+      "",
+    ]),
+  ].join("\n");
+}
+
 export function writeRunPlan({ runDir, repo, soak, peerWorktrees = [], candidates, selected, options }) {
   mkdirSync(runDir, { recursive: true });
   const tasksDir = path.join(runDir, "tasks");
   mkdirSync(tasksDir, { recursive: true });
 
   const outcomeLedger = options.outcomeLedgerSummary ?? { path: options.outcomeLedger, entries: [] };
+  const executionPlan = buildExecutionPlan(selected);
   const report = buildReport({ repo, soak, outcomeLedger, candidates, selected, options });
   writeFileSync(path.join(runDir, "report.md"), report);
-  writeFileSync(path.join(runDir, "targets.json"), `${JSON.stringify({ repo, soak, peerWorktrees, outcomeLedger, candidates, selected }, null, 2)}\n`);
+  writeFileSync(path.join(runDir, "targets.json"), `${JSON.stringify({ repo, soak, peerWorktrees, outcomeLedger, executionPlan, candidates, selected }, null, 2)}\n`);
+  writeFileSync(path.join(runDir, "execution-plan.json"), `${JSON.stringify(executionPlan, null, 2)}\n`);
+  writeFileSync(path.join(runDir, "execution-plan.md"), renderExecutionPlanMarkdown(executionPlan));
   writeFileSync(
     path.join(runDir, "outcome-template.jsonl"),
     selected
@@ -1021,6 +1112,7 @@ export function writeRunPlan({ runDir, repo, soak, peerWorktrees = [], candidate
     runDir,
     reportPath: path.join(runDir, "report.md"),
     tasksDir,
+    executionPlanPath: path.join(runDir, "execution-plan.md"),
     outcomeTemplatePath: path.join(runDir, "outcome-template.jsonl"),
   };
 }
@@ -1062,6 +1154,7 @@ function textSummary(plan, writeResult, args) {
   if (writeResult) {
     lines.push(`Report: ${writeResult.reportPath}`);
     lines.push(`Tasks: ${writeResult.tasksDir}`);
+    lines.push(`Execution plan: ${writeResult.executionPlanPath}`);
     lines.push(`Outcome template: ${writeResult.outcomeTemplatePath}`);
   }
 

--- a/scripts/nightly-self-improve.test.mjs
+++ b/scripts/nightly-self-improve.test.mjs
@@ -7,6 +7,7 @@ import test from "node:test";
 import {
   applyOutcomeFeedback,
   buildCandidates,
+  buildExecutionPlan,
   formatBytes,
   parseArgs,
   parseGitWorktreePorcelain,
@@ -280,7 +281,27 @@ test("writeRunPlan emits report, targets, and task prompts", () => {
 
   assert.equal(path.basename(result.reportPath), "report.md");
   assert.equal(path.basename(result.tasksDir), "tasks");
+  assert.equal(path.basename(result.executionPlanPath), "execution-plan.md");
   assert.equal(path.basename(result.outcomeTemplatePath), "outcome-template.jsonl");
+});
+
+test("execution plan includes peer review and release soak gates", () => {
+  const phases = buildExecutionPlan([
+    {
+      id: "peer-perf-scraper-recycle-verification",
+      kind: "peer-worktree",
+      prompt: "Review peer work.",
+    },
+    {
+      id: "webkit-memory-pressure",
+      kind: "performance",
+      prompt: "Reduce WebKit memory.",
+    },
+  ]);
+
+  assert.ok(phases.some((phase) => phase.id === "peer-review"));
+  assert.ok(phases.some((phase) => phase.id === "release-and-soak"));
+  assert.ok(phases.every((phase) => phase.stopGate));
 });
 
 test("argument parsing validates numeric budgets", () => {


### PR DESCRIPTION
(AI Generated).

## Summary
- Adds execution-plan JSON and Markdown artifacts with ordered phases, command hints, and stop gates for overnight runs.
- Includes release and soak gates so the runner skips dev build shipping when only planning artifacts changed.

## Testing
- node --test scripts/nightly-self-improve.test.mjs
- corepack npm run test:scripts
- corepack npm run validate:feature