### PR TITLE
fix: prevent dev release note rollup repeats

### DIFF
--- a/release-notes/releases/v26.5.1010-dev.json
+++ b/release-notes/releases/v26.5.1010-dev.json
@@ -12,7 +12,7 @@
   "source": {
     "channel": "dev",
     "previousPublishedTag": "v26.5.1004-dev",
-    "previousPublishedDayTag": "v26.5.103-dev",
+    "previousPublishedDayTag": "v26.5.914-dev",
     "compareRef": "HEAD",
     "isLatestOfDay": true,
     "sameDayTagsIncluded": [
@@ -526,38 +526,25 @@
     ]
   },
   "release": {
-    "deck": "AI ranked friend suggestions, support Friends graph pinch zoom, and Friends relationship tiers",
-    "features": [
-      "AI ranked friend suggestions",
-      "Support Friends graph pinch zoom",
-      "Friends relationship tiers"
-    ],
+    "deck": "Settings, Friends, and Map interactions stay steadier under release validation",
+    "features": [],
     "fixes": [
-      "Test coverage and performance hardening",
-      "Release build and type-safety cleanup",
-      "Reader, feed, and header polish",
-      "Route Google Drive through native sync requests",
-      "Optimized social scraper frame drops",
-      "Dedupe Instagram story captures",
-      "Pause Settings descendant transitions while the dialog is moving",
+      "Pauses Settings descendant transitions while the dialog is moving",
+      "Isolates Settings scroll paint and reduces interaction invalidation",
+      "Flushes Friends detail to Map handoffs before selection changes",
+      "Flushes mobile Friends toolbar switches between Details and graph modes",
+      "Caches the Friends graph interaction layer during dense interaction",
+      "Stabilizes Friends empty graph, Tauri mock, and collapsed detail-card validation",
       "Open the full Map from Friends detail with one atomic store update",
       "Flush the Friends to Map handoff at the click boundary",
-      "Flush mobile Friends toolbar switches between Details and graph modes",
-      "Stabilize the collapsed Friends detail card empty-space regression"
+      "Friends graph perf telemetry now reports dense interaction rebuild count, with a release regression guard for the 1,600-person zoom and pan case"
     ],
     "followUps": [
-      "Reader, sidebar, and settings UX work",
-      "Trim reader rail work and stabilize friends perf",
-      "Isolate social scraper webkit stores",
-      "Gate startup social scraper pressure",
-      "Recycle blocked scraper windows",
-      "Reserve scraper memory headroom",
-      "Slim desktop e2e gates",
-      "Settings scrolling is lighter, and Friends view transitions are stable through the release regression gate",
+      "Continue the installed dev build soak while Settings scroll and Friends graph performance settle",
       "Continue passive soak metrics until Apple Events authorization is restored for active UI driving",
-      "Treat Settings scroll as the next measured performance surface because it remains the largest budget miss",
-      "Settings scroll and Friends graph stability"
+      "Settings scrolling is lighter, and Friends view transitions are stable through the release regression gate",
+      "Treat Settings scroll as the next measured performance surface because it remains the largest budget miss"
     ]
   },
-  "releaseBody": "(AI Generated).\n\n## Freed v26.5.1010-dev\n\nAI ranked friend suggestions, support Friends graph pinch zoom, and Friends relationship tiers\n\n### Features\n\n- AI ranked friend suggestions\n- Support Friends graph pinch zoom\n- Friends relationship tiers\n\n### Fixes\n\n- Test coverage and performance hardening\n- Release build and type-safety cleanup\n- Reader, feed, and header polish\n- Route Google Drive through native sync requests\n- Optimized social scraper frame drops\n- Dedupe Instagram story captures\n- Pause Settings descendant transitions while the dialog is moving\n- Open the full Map from Friends detail with one atomic store update\n- Flush the Friends to Map handoff at the click boundary\n- Flush mobile Friends toolbar switches between Details and graph modes\n- Stabilize the collapsed Friends detail card empty-space regression\n\n### Follow-ups\n\n- Reader, sidebar, and settings UX work\n- Trim reader rail work and stabilize friends perf\n- Isolate social scraper webkit stores\n- Gate startup social scraper pressure\n- Recycle blocked scraper windows\n- Reserve scraper memory headroom\n- Slim desktop e2e gates\n- Settings scrolling is lighter, and Friends view transitions are stable through the release regression gate\n- Continue passive soak metrics until Apple Events authorization is restored for active UI driving\n- Treat Settings scroll as the next measured performance surface because it remains the largest budget miss\n- Settings scroll and Friends graph stability\n- v26.5.1010-dev replaces the failed v26.5.1009-dev validation tag by narrowing the collapsed Friends empty-space regression to its owned behavior.\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+  "releaseBody": "(AI Generated).\n\n## Freed v26.5.1010-dev\n\nSettings, Friends, and Map interactions stay steadier under release validation\n\n### Fixes\n\n- Pauses Settings descendant transitions while the dialog is moving\n- Isolates Settings scroll paint and reduces interaction invalidation\n- Flushes Friends detail to Map handoffs before selection changes\n- Flushes mobile Friends toolbar switches between Details and graph modes\n- Caches the Friends graph interaction layer during dense interaction\n- Stabilizes Friends empty graph, Tauri mock, and collapsed detail-card validation\n- Open the full Map from Friends detail with one atomic store update\n- Flush the Friends to Map handoff at the click boundary\n- Friends graph perf telemetry now reports dense interaction rebuild count, with a release regression guard for the 1,600-person zoom and pan case\n\n### Follow-ups\n\n- Continue the installed dev build soak while Settings scroll and Friends graph performance settle\n- Continue passive soak metrics until Apple Events authorization is restored for active UI driving\n- Settings scrolling is lighter, and Friends view transitions are stable through the release regression gate\n- Treat Settings scroll as the next measured performance surface because it remains the largest budget miss\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
 }

--- a/release-notes/releases/v26.5.1010-dev.md
+++ b/release-notes/releases/v26.5.1010-dev.md
@@ -2,42 +2,26 @@
 
 ## Freed v26.5.1010-dev
 
-AI ranked friend suggestions, support Friends graph pinch zoom, and Friends relationship tiers
-
-### Features
-
-- AI ranked friend suggestions
-- Support Friends graph pinch zoom
-- Friends relationship tiers
+Settings, Friends, and Map interactions stay steadier under release validation
 
 ### Fixes
 
-- Test coverage and performance hardening
-- Release build and type-safety cleanup
-- Reader, feed, and header polish
-- Route Google Drive through native sync requests
-- Optimized social scraper frame drops
-- Dedupe Instagram story captures
-- Pause Settings descendant transitions while the dialog is moving
+- Pauses Settings descendant transitions while the dialog is moving
+- Isolates Settings scroll paint and reduces interaction invalidation
+- Flushes Friends detail to Map handoffs before selection changes
+- Flushes mobile Friends toolbar switches between Details and graph modes
+- Caches the Friends graph interaction layer during dense interaction
+- Stabilizes Friends empty graph, Tauri mock, and collapsed detail-card validation
 - Open the full Map from Friends detail with one atomic store update
 - Flush the Friends to Map handoff at the click boundary
-- Flush mobile Friends toolbar switches between Details and graph modes
-- Stabilize the collapsed Friends detail card empty-space regression
+- Friends graph perf telemetry now reports dense interaction rebuild count, with a release regression guard for the 1,600-person zoom and pan case
 
 ### Follow-ups
 
-- Reader, sidebar, and settings UX work
-- Trim reader rail work and stabilize friends perf
-- Isolate social scraper webkit stores
-- Gate startup social scraper pressure
-- Recycle blocked scraper windows
-- Reserve scraper memory headroom
-- Slim desktop e2e gates
-- Settings scrolling is lighter, and Friends view transitions are stable through the release regression gate
+- Continue the installed dev build soak while Settings scroll and Friends graph performance settle
 - Continue passive soak metrics until Apple Events authorization is restored for active UI driving
+- Settings scrolling is lighter, and Friends view transitions are stable through the release regression gate
 - Treat Settings scroll as the next measured performance surface because it remains the largest budget miss
-- Settings scroll and Friends graph stability
-- v26.5.1010-dev replaces the failed v26.5.1009-dev validation tag by narrowing the collapsed Friends empty-space regression to its owned behavior.
 
 ### Downloads
 

--- a/release-notes/releases/v26.5.1013-dev.json
+++ b/release-notes/releases/v26.5.1013-dev.json
@@ -12,7 +12,7 @@
   "source": {
     "channel": "dev",
     "previousPublishedTag": "v26.5.1010-dev",
-    "previousPublishedDayTag": "v26.5.103-dev",
+    "previousPublishedDayTag": "v26.5.914-dev",
     "compareRef": "HEAD",
     "isLatestOfDay": true,
     "sameDayTagsIncluded": [
@@ -539,41 +539,28 @@
     ]
   },
   "release": {
-    "deck": "Settings interaction work, Friends graph crash protection, and a steadier collapsed Friends detail card",
-    "features": [
-      "Friends graph pan and zoom now reuse the dense interaction layer across coarse viewport buckets instead of redrawing visible dense nodes every frame",
-      "Friends graph perf telemetry now reports dense interaction rebuild count, with a release regression guard for the 1,600-person zoom and pan case"
-    ],
+    "deck": "Settings interaction work, Friends graph crash protection, and the collapsed Friends detail card stay stable",
+    "features": [],
     "fixes": [
-      "Reader, feed, and header polish",
-      "Test coverage and performance hardening",
-      "Release build and type-safety cleanup",
-      "Route Google Drive through native sync requests",
-      "Optimized social scraper frame drops",
-      "Dedupe Instagram story captures",
-      "Pause Settings descendant transitions while the dialog is moving",
+      "Pauses Settings descendant transitions while the dialog is moving",
+      "Isolates Settings scroll paint and reduces interaction invalidation",
+      "Flushes Friends detail to Map handoffs before selection changes",
+      "Flushes mobile Friends toolbar switches between Details and graph modes",
+      "Caches the Friends graph interaction layer during dense interaction",
+      "Guards Friends graph Pixi teardown so the last-seen Map handoff cannot show the fatal error screen",
+      "Keeps the collapsed Friends detail-card regression focused on selected-person behavior",
       "Open the full Map from Friends detail with one atomic store update",
       "Flush the Friends to Map handoff at the click boundary",
-      "Flush mobile Friends toolbar switches between Details and graph modes",
-      "Settings scrolling is lighter, and Friends view transitions are stable through the release regression gate",
-      "Guarded Friends graph Pixi teardown so the Last seen to Map handoff cannot be replaced by the fatal error screen",
-      "Kept the collapsed Friends detail-card regression focused on selected-person behavior instead of a CI-sensitive graph node point lookup",
-      "v26.5.1013-dev replaces the failed v26.5.1012-dev validation tag, which produced no installable artifacts"
+      "Friends graph perf telemetry now reports dense interaction rebuild count, with a release regression guard for the 1,600-person zoom and pan case",
+      "Stabilizes Friends empty graph, Tauri mock, and collapsed detail-card validation"
     ],
     "followUps": [
-      "Friends relationship tiers",
-      "AI ranked friend suggestions",
-      "AI ranked friend suggestions, support Friends graph pinch zoom, and Friends relationship tiers",
-      "Reader, sidebar, and settings UX work",
-      "Trim reader rail work and stabilize friends perf",
-      "Isolate social scraper webkit stores",
-      "Gate startup social scraper pressure",
-      "Recycle blocked scraper windows",
-      "Reserve scraper memory headroom",
-      "Slim desktop e2e gates",
+      "Continue the installed dev build soak while Settings scroll and Friends graph performance settle",
       "Continue passive soak metrics until Apple Events authorization is restored for active UI driving",
-      "Treat Settings scroll as the next measured performance surface because it remains the largest budget miss"
+      "Settings scrolling is lighter, and Friends view transitions are stable through the release regression gate",
+      "Treat Settings scroll as the next measured performance surface because it remains the largest budget miss",
+      "Settings, Friends, and Map interactions stay steadier under release validation"
     ]
   },
-  "releaseBody": "(AI Generated).\n\n## Freed v26.5.1013-dev\n\nSettings interaction work, Friends graph crash protection, and a steadier collapsed Friends detail card\n\n### Features\n\n- AI ranked friend suggestions, support Friends graph pinch zoom, and Friends relationship tiers\n- AI ranked friend suggestions\n- Support Friends graph pinch zoom\n- Friends relationship tiers\n- Friends graph pan and zoom now reuse the dense interaction layer across coarse viewport buckets instead of redrawing visible dense nodes every frame\n- Friends graph perf telemetry now reports dense interaction rebuild count, with a release regression guard for the 1,600-person zoom and pan case\n\n### Fixes\n\n- Reader, feed, and header polish\n- Test coverage and performance hardening\n- Release build and type-safety cleanup\n- Route Google Drive through native sync requests\n- Optimized social scraper frame drops\n- Dedupe Instagram story captures\n- Pause Settings descendant transitions while the dialog is moving\n- Open the full Map from Friends detail with one atomic store update\n- Flush the Friends to Map handoff at the click boundary\n- Flush mobile Friends toolbar switches between Details and graph modes\n- Settings scrolling is lighter, and Friends view transitions are stable through the release regression gate\n- Guarded Friends graph Pixi teardown so the Last seen to Map handoff cannot be replaced by the fatal error screen\n- Kept the collapsed Friends detail-card regression focused on selected-person behavior instead of a CI-sensitive graph node point lookup\n- v26.5.1013-dev replaces the failed v26.5.1012-dev validation tag, which produced no installable artifacts\n\n### Follow-ups\n\n- Friends relationship tiers\n- AI ranked friend suggestions\n- AI ranked friend suggestions, support Friends graph pinch zoom, and Friends relationship tiers\n- Reader, sidebar, and settings UX work\n- Trim reader rail work and stabilize friends perf\n- Isolate social scraper webkit stores\n- Gate startup social scraper pressure\n- Recycle blocked scraper windows\n- Reserve scraper memory headroom\n- Slim desktop e2e gates\n- Continue passive soak metrics until Apple Events authorization is restored for active UI driving\n- Treat Settings scroll as the next measured performance surface because it remains the largest budget miss\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+  "releaseBody": "(AI Generated).\n\n## Freed v26.5.1013-dev\n\nSettings interaction work, Friends graph crash protection, and the collapsed Friends detail card stay stable\n\n### Fixes\n\n- Pauses Settings descendant transitions while the dialog is moving\n- Isolates Settings scroll paint and reduces interaction invalidation\n- Flushes Friends detail to Map handoffs before selection changes\n- Flushes mobile Friends toolbar switches between Details and graph modes\n- Caches the Friends graph interaction layer during dense interaction\n- Guards Friends graph Pixi teardown so the last-seen Map handoff cannot show the fatal error screen\n- Keeps the collapsed Friends detail-card regression focused on selected-person behavior\n- Open the full Map from Friends detail with one atomic store update\n- Flush the Friends to Map handoff at the click boundary\n- Friends graph perf telemetry now reports dense interaction rebuild count, with a release regression guard for the 1,600-person zoom and pan case\n- Stabilizes Friends empty graph, Tauri mock, and collapsed detail-card validation\n\n### Follow-ups\n\n- Continue the installed dev build soak while Settings scroll and Friends graph performance settle\n- Continue passive soak metrics until Apple Events authorization is restored for active UI driving\n- Settings scrolling is lighter, and Friends view transitions are stable through the release regression gate\n- Treat Settings scroll as the next measured performance surface because it remains the largest budget miss\n- Settings, Friends, and Map interactions stay steadier under release validation\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
 }

--- a/release-notes/releases/v26.5.1013-dev.md
+++ b/release-notes/releases/v26.5.1013-dev.md
@@ -2,48 +2,29 @@
 
 ## Freed v26.5.1013-dev
 
-Settings interaction work, Friends graph crash protection, and a steadier collapsed Friends detail card
-
-### Features
-
-- AI ranked friend suggestions, support Friends graph pinch zoom, and Friends relationship tiers
-- AI ranked friend suggestions
-- Support Friends graph pinch zoom
-- Friends relationship tiers
-- Friends graph pan and zoom now reuse the dense interaction layer across coarse viewport buckets instead of redrawing visible dense nodes every frame
-- Friends graph perf telemetry now reports dense interaction rebuild count, with a release regression guard for the 1,600-person zoom and pan case
+Settings interaction work, Friends graph crash protection, and the collapsed Friends detail card stay stable
 
 ### Fixes
 
-- Reader, feed, and header polish
-- Test coverage and performance hardening
-- Release build and type-safety cleanup
-- Route Google Drive through native sync requests
-- Optimized social scraper frame drops
-- Dedupe Instagram story captures
-- Pause Settings descendant transitions while the dialog is moving
+- Pauses Settings descendant transitions while the dialog is moving
+- Isolates Settings scroll paint and reduces interaction invalidation
+- Flushes Friends detail to Map handoffs before selection changes
+- Flushes mobile Friends toolbar switches between Details and graph modes
+- Caches the Friends graph interaction layer during dense interaction
+- Guards Friends graph Pixi teardown so the last-seen Map handoff cannot show the fatal error screen
+- Keeps the collapsed Friends detail-card regression focused on selected-person behavior
 - Open the full Map from Friends detail with one atomic store update
 - Flush the Friends to Map handoff at the click boundary
-- Flush mobile Friends toolbar switches between Details and graph modes
-- Settings scrolling is lighter, and Friends view transitions are stable through the release regression gate
-- Guarded Friends graph Pixi teardown so the Last seen to Map handoff cannot be replaced by the fatal error screen
-- Kept the collapsed Friends detail-card regression focused on selected-person behavior instead of a CI-sensitive graph node point lookup
-- v26.5.1013-dev replaces the failed v26.5.1012-dev validation tag, which produced no installable artifacts
+- Friends graph perf telemetry now reports dense interaction rebuild count, with a release regression guard for the 1,600-person zoom and pan case
+- Stabilizes Friends empty graph, Tauri mock, and collapsed detail-card validation
 
 ### Follow-ups
 
-- Friends relationship tiers
-- AI ranked friend suggestions
-- AI ranked friend suggestions, support Friends graph pinch zoom, and Friends relationship tiers
-- Reader, sidebar, and settings UX work
-- Trim reader rail work and stabilize friends perf
-- Isolate social scraper webkit stores
-- Gate startup social scraper pressure
-- Recycle blocked scraper windows
-- Reserve scraper memory headroom
-- Slim desktop e2e gates
+- Continue the installed dev build soak while Settings scroll and Friends graph performance settle
 - Continue passive soak metrics until Apple Events authorization is restored for active UI driving
+- Settings scrolling is lighter, and Friends view transitions are stable through the release regression gate
 - Treat Settings scroll as the next measured performance surface because it remains the largest budget miss
+- Settings, Friends, and Map interactions stay steadier under release validation
 
 ### Downloads
 

--- a/release-notes/releases/v26.5.1015-dev.json
+++ b/release-notes/releases/v26.5.1015-dev.json
@@ -12,7 +12,7 @@
   "source": {
     "channel": "dev",
     "previousPublishedTag": "v26.5.1013-dev",
-    "previousPublishedDayTag": "v26.5.103-dev",
+    "previousPublishedDayTag": "v26.5.914-dev",
     "compareRef": "HEAD",
     "isLatestOfDay": true,
     "sameDayTagsIncluded": [
@@ -547,41 +547,29 @@
     ]
   },
   "release": {
-    "deck": "AI ranked friend suggestions, support Friends graph pinch zoom, and Friends relationship tiers",
-    "features": [
-      "AI ranked friend suggestions",
-      "Support Friends graph pinch zoom",
-      "Friends relationship tiers"
-    ],
+    "deck": "Settings, Friends graph, and Map handoffs stay stable through release validation",
+    "features": [],
     "fixes": [
-      "Reader, feed, and header polish",
-      "Test coverage and performance hardening",
-      "Release build and type-safety cleanup",
-      "Route Google Drive through native sync requests",
-      "Optimized social scraper frame drops",
-      "Dedupe Instagram story captures",
-      "Pause Settings descendant transitions while the dialog is moving",
+      "Pauses Settings descendant transitions while the dialog is moving",
+      "Reduces Settings scroll paint work and interaction invalidation",
+      "Flushes Friends detail to Map handoffs before selection changes",
+      "Flushes mobile Friends toolbar switches between Details and graph modes",
+      "Caches the Friends graph interaction layer during dense interaction",
+      "Guards Friends graph Pixi teardown so the last-seen Map handoff cannot show the fatal error screen",
+      "Keeps the collapsed Friends detail-card regression focused on selected-person behavior",
+      "Guards the Friends Map surface handoff during route changes",
       "Open the full Map from Friends detail with one atomic store update",
       "Flush the Friends to Map handoff at the click boundary",
-      "Flush mobile Friends toolbar switches between Details and graph modes",
-      "The collapsed Friends detail card empty-space regression are now more stable",
-      "Settings scrolling is lighter, and Friends view transitions are stable through the release regression gate",
-      "Guarded Friends graph Pixi teardown so the Last seen to Map handoff cannot be replaced by the fatal error screen",
-      "Kept the collapsed Friends detail-card regression focused on selected-person behavior instead of a CI-sensitive graph node point lookup",
-      "V26.5.1013-dev replaces the failed v26.5.1012-dev validation tag, which produced no installable artifacts"
+      "Friends graph perf telemetry now reports dense interaction rebuild count, with a release regression guard for the 1,600-person zoom and pan case",
+      "Stabilizes Friends empty graph, Tauri mock, and collapsed detail-card validation"
     ],
     "followUps": [
-      "Reader, sidebar, and settings UX work",
-      "Trim reader rail work and stabilize friends perf",
-      "Isolate social scraper webkit stores",
-      "Gate startup social scraper pressure",
-      "Recycle blocked scraper windows",
-      "Reserve scraper memory headroom",
-      "Slim desktop e2e gates",
+      "Continue the installed dev build soak while Settings scroll and Friends graph performance settle",
       "Continue passive soak metrics until Apple Events authorization is restored for active UI driving",
+      "Settings scrolling is lighter, and Friends view transitions are stable through the release regression gate",
       "Treat Settings scroll as the next measured performance surface because it remains the largest budget miss",
-      "Settings scroll and Friends graph stability"
+      "Settings interaction work, Friends graph crash protection, and the collapsed Friends detail card stay stable"
     ]
   },
-  "releaseBody": "(AI Generated).\n\n## Freed v26.5.1015-dev\n\nAI ranked friend suggestions, support Friends graph pinch zoom, and Friends relationship tiers\n\n### Features\n\n- AI ranked friend suggestions\n- Support Friends graph pinch zoom\n- Friends relationship tiers\n\n### Fixes\n\n- Reader, feed, and header polish\n- Test coverage and performance hardening\n- Release build and type-safety cleanup\n- Route Google Drive through native sync requests\n- Optimized social scraper frame drops\n- Dedupe Instagram story captures\n- Pause Settings descendant transitions while the dialog is moving\n- Open the full Map from Friends detail with one atomic store update\n- Flush the Friends to Map handoff at the click boundary\n- Flush mobile Friends toolbar switches between Details and graph modes\n- The collapsed Friends detail card empty-space regression are now more stable\n- Settings scrolling is lighter, and Friends view transitions are stable through the release regression gate\n- Guarded Friends graph Pixi teardown so the Last seen to Map handoff cannot be replaced by the fatal error screen\n- Kept the collapsed Friends detail-card regression focused on selected-person behavior instead of a CI-sensitive graph node point lookup\n- V26.5.1013-dev replaces the failed v26.5.1012-dev validation tag, which produced no installable artifacts\n\n### Follow-ups\n\n- Reader, sidebar, and settings UX work\n- Trim reader rail work and stabilize friends perf\n- Isolate social scraper webkit stores\n- Gate startup social scraper pressure\n- Recycle blocked scraper windows\n- Reserve scraper memory headroom\n- Slim desktop e2e gates\n- Continue passive soak metrics until Apple Events authorization is restored for active UI driving\n- Treat Settings scroll as the next measured performance surface because it remains the largest budget miss\n- Settings scroll and Friends graph stability\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+  "releaseBody": "(AI Generated).\n\n## Freed v26.5.1015-dev\n\nSettings, Friends graph, and Map handoffs stay stable through release validation\n\n### Fixes\n\n- Pauses Settings descendant transitions while the dialog is moving\n- Reduces Settings scroll paint work and interaction invalidation\n- Flushes Friends detail to Map handoffs before selection changes\n- Flushes mobile Friends toolbar switches between Details and graph modes\n- Caches the Friends graph interaction layer during dense interaction\n- Guards Friends graph Pixi teardown so the last-seen Map handoff cannot show the fatal error screen\n- Keeps the collapsed Friends detail-card regression focused on selected-person behavior\n- Guards the Friends Map surface handoff during route changes\n- Open the full Map from Friends detail with one atomic store update\n- Flush the Friends to Map handoff at the click boundary\n- Friends graph perf telemetry now reports dense interaction rebuild count, with a release regression guard for the 1,600-person zoom and pan case\n- Stabilizes Friends empty graph, Tauri mock, and collapsed detail-card validation\n\n### Follow-ups\n\n- Continue the installed dev build soak while Settings scroll and Friends graph performance settle\n- Continue passive soak metrics until Apple Events authorization is restored for active UI driving\n- Settings scrolling is lighter, and Friends view transitions are stable through the release regression gate\n- Treat Settings scroll as the next measured performance surface because it remains the largest budget miss\n- Settings interaction work, Friends graph crash protection, and the collapsed Friends detail card stay stable\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
 }

--- a/release-notes/releases/v26.5.1015-dev.md
+++ b/release-notes/releases/v26.5.1015-dev.md
@@ -2,44 +2,30 @@
 
 ## Freed v26.5.1015-dev
 
-AI ranked friend suggestions, support Friends graph pinch zoom, and Friends relationship tiers
-
-### Features
-
-- AI ranked friend suggestions
-- Support Friends graph pinch zoom
-- Friends relationship tiers
+Settings, Friends graph, and Map handoffs stay stable through release validation
 
 ### Fixes
 
-- Reader, feed, and header polish
-- Test coverage and performance hardening
-- Release build and type-safety cleanup
-- Route Google Drive through native sync requests
-- Optimized social scraper frame drops
-- Dedupe Instagram story captures
-- Pause Settings descendant transitions while the dialog is moving
+- Pauses Settings descendant transitions while the dialog is moving
+- Reduces Settings scroll paint work and interaction invalidation
+- Flushes Friends detail to Map handoffs before selection changes
+- Flushes mobile Friends toolbar switches between Details and graph modes
+- Caches the Friends graph interaction layer during dense interaction
+- Guards Friends graph Pixi teardown so the last-seen Map handoff cannot show the fatal error screen
+- Keeps the collapsed Friends detail-card regression focused on selected-person behavior
+- Guards the Friends Map surface handoff during route changes
 - Open the full Map from Friends detail with one atomic store update
 - Flush the Friends to Map handoff at the click boundary
-- Flush mobile Friends toolbar switches between Details and graph modes
-- The collapsed Friends detail card empty-space regression are now more stable
-- Settings scrolling is lighter, and Friends view transitions are stable through the release regression gate
-- Guarded Friends graph Pixi teardown so the Last seen to Map handoff cannot be replaced by the fatal error screen
-- Kept the collapsed Friends detail-card regression focused on selected-person behavior instead of a CI-sensitive graph node point lookup
-- V26.5.1013-dev replaces the failed v26.5.1012-dev validation tag, which produced no installable artifacts
+- Friends graph perf telemetry now reports dense interaction rebuild count, with a release regression guard for the 1,600-person zoom and pan case
+- Stabilizes Friends empty graph, Tauri mock, and collapsed detail-card validation
 
 ### Follow-ups
 
-- Reader, sidebar, and settings UX work
-- Trim reader rail work and stabilize friends perf
-- Isolate social scraper webkit stores
-- Gate startup social scraper pressure
-- Recycle blocked scraper windows
-- Reserve scraper memory headroom
-- Slim desktop e2e gates
+- Continue the installed dev build soak while Settings scroll and Friends graph performance settle
 - Continue passive soak metrics until Apple Events authorization is restored for active UI driving
+- Settings scrolling is lighter, and Friends view transitions are stable through the release regression gate
 - Treat Settings scroll as the next measured performance surface because it remains the largest budget miss
-- Settings scroll and Friends graph stability
+- Settings interaction work, Friends graph crash protection, and the collapsed Friends detail card stay stable
 
 ### Downloads
 

--- a/release-notes/releases/v26.5.1100-dev.json
+++ b/release-notes/releases/v26.5.1100-dev.json
@@ -33,41 +33,14 @@
     ]
   },
   "release": {
-    "deck": "AI ranked friend suggestions, support Friends graph pinch zoom, and Friends relationship tiers",
-    "features": [
-      "AI ranked friend suggestions",
-      "Support Friends graph pinch zoom",
-      "Friends relationship tiers"
-    ],
+    "deck": "Friends navigation recovers from late Map mounting",
+    "features": [],
     "fixes": [
-      "Reader, feed, and header polish",
-      "Test coverage and performance hardening",
-      "Release build and type-safety cleanup",
-      "Route Google Drive through native sync requests",
-      "Optimized social scraper frame drops",
-      "Dedupe Instagram story captures",
-      "Pause Settings descendant transitions while the dialog is moving",
-      "Open the full Map from Friends detail with one atomic store update",
-      "Friends last seen cards now retry the route commit if the store reaches Map before the full Map surface mounts.",
-      "Flush mobile Friends toolbar switches between Details and graph modes",
-      "The collapsed Friends detail card empty-space regression are now more stable",
-      "Settings scrolling is lighter, and Friends view transitions are stable through the release regression gate",
-      "Guarded Friends graph Pixi teardown so the Last seen to Map handoff cannot be replaced by the fatal error screen",
-      "Kept the collapsed Friends detail-card regression focused on selected-person behavior instead of a CI-sensitive graph node point lookup",
-      "V26.5.1013-dev replaces the failed v26.5.1012-dev validation tag, which produced no installable artifacts"
+      "Retries the Friends last-seen route commit when the store reaches Map before the full Map surface mounts"
     ],
     "followUps": [
-      "Reader, sidebar, and settings UX work",
-      "Trim reader rail work and stabilize friends perf",
-      "Isolate social scraper webkit stores",
-      "Gate startup social scraper pressure",
-      "Recycle blocked scraper windows",
-      "Reserve scraper memory headroom",
-      "Slim desktop e2e gates",
-      "Continue passive soak metrics until Apple Events authorization is restored for active UI driving",
-      "Treat Settings scroll as the next measured performance surface because it remains the largest budget miss",
-      "Settings scroll and Friends graph stability"
+      "Continue monitoring Friends to Map handoffs under installed dev builds"
     ]
   },
-  "releaseBody": "(AI Generated).\n\n## Freed v26.5.1100-dev\n\nAI ranked friend suggestions, support Friends graph pinch zoom, and Friends relationship tiers\n\n### Features\n\n- AI ranked friend suggestions\n- Support Friends graph pinch zoom\n- Friends relationship tiers\n\n### Fixes\n\n- Reader, feed, and header polish\n- Test coverage and performance hardening\n- Release build and type-safety cleanup\n- Route Google Drive through native sync requests\n- Optimized social scraper frame drops\n- Dedupe Instagram story captures\n- Pause Settings descendant transitions while the dialog is moving\n- Open the full Map from Friends detail with one atomic store update\n- Friends last seen cards now retry the route commit if the store reaches Map before the full Map surface mounts.\n- Flush mobile Friends toolbar switches between Details and graph modes\n- The collapsed Friends detail card empty-space regression are now more stable\n- Settings scrolling is lighter, and Friends view transitions are stable through the release regression gate\n- Guarded Friends graph Pixi teardown so the Last seen to Map handoff cannot be replaced by the fatal error screen\n- Kept the collapsed Friends detail-card regression focused on selected-person behavior instead of a CI-sensitive graph node point lookup\n- V26.5.1013-dev replaces the failed v26.5.1012-dev validation tag, which produced no installable artifacts\n\n### Follow-ups\n\n- Reader, sidebar, and settings UX work\n- Trim reader rail work and stabilize friends perf\n- Isolate social scraper webkit stores\n- Gate startup social scraper pressure\n- Recycle blocked scraper windows\n- Reserve scraper memory headroom\n- Slim desktop e2e gates\n- Continue passive soak metrics until Apple Events authorization is restored for active UI driving\n- Treat Settings scroll as the next measured performance surface because it remains the largest budget miss\n- Settings scroll and Friends graph stability\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+  "releaseBody": "(AI Generated).\n\n## Freed v26.5.1100-dev\n\nFriends navigation recovers from late Map mounting\n\n### Fixes\n\n- Retries the Friends last-seen route commit when the store reaches Map before the full Map surface mounts\n\n### Follow-ups\n\n- Continue monitoring Friends to Map handoffs under installed dev builds\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
 }

--- a/release-notes/releases/v26.5.1100-dev.md
+++ b/release-notes/releases/v26.5.1100-dev.md
@@ -2,44 +2,15 @@
 
 ## Freed v26.5.1100-dev
 
-AI ranked friend suggestions, support Friends graph pinch zoom, and Friends relationship tiers
-
-### Features
-
-- AI ranked friend suggestions
-- Support Friends graph pinch zoom
-- Friends relationship tiers
+Friends navigation recovers from late Map mounting
 
 ### Fixes
 
-- Reader, feed, and header polish
-- Test coverage and performance hardening
-- Release build and type-safety cleanup
-- Route Google Drive through native sync requests
-- Optimized social scraper frame drops
-- Dedupe Instagram story captures
-- Pause Settings descendant transitions while the dialog is moving
-- Open the full Map from Friends detail with one atomic store update
-- Friends last seen cards now retry the route commit if the store reaches Map before the full Map surface mounts.
-- Flush mobile Friends toolbar switches between Details and graph modes
-- The collapsed Friends detail card empty-space regression are now more stable
-- Settings scrolling is lighter, and Friends view transitions are stable through the release regression gate
-- Guarded Friends graph Pixi teardown so the Last seen to Map handoff cannot be replaced by the fatal error screen
-- Kept the collapsed Friends detail-card regression focused on selected-person behavior instead of a CI-sensitive graph node point lookup
-- V26.5.1013-dev replaces the failed v26.5.1012-dev validation tag, which produced no installable artifacts
+- Retries the Friends last-seen route commit when the store reaches Map before the full Map surface mounts
 
 ### Follow-ups
 
-- Reader, sidebar, and settings UX work
-- Trim reader rail work and stabilize friends perf
-- Isolate social scraper webkit stores
-- Gate startup social scraper pressure
-- Recycle blocked scraper windows
-- Reserve scraper memory headroom
-- Slim desktop e2e gates
-- Continue passive soak metrics until Apple Events authorization is restored for active UI driving
-- Treat Settings scroll as the next measured performance surface because it remains the largest budget miss
-- Settings scroll and Friends graph stability
+- Continue monitoring Friends to Map handoffs under installed dev builds
 
 ### Downloads
 

--- a/release-notes/releases/v26.5.1101-dev.json
+++ b/release-notes/releases/v26.5.1101-dev.json
@@ -39,43 +39,16 @@
     ]
   },
   "release": {
-    "deck": "AI ranked friend suggestions, support Friends graph pinch zoom, and Friends relationship tiers",
-    "features": [
-      "AI ranked friend suggestions",
-      "Support Friends graph pinch zoom",
-      "Friends relationship tiers"
-    ],
+    "deck": "Friends navigation and dense Map movement get steadier",
+    "features": [],
     "fixes": [
-      "Dense Map pan and zoom movement now paints fewer primary markers, keeping the 1,600-author perf gate within budget",
-      "Friends map handoff is now more stable",
-      "Reader, feed, and header polish",
-      "Test coverage and performance hardening",
-      "Release build and type-safety cleanup",
-      "Route Google Drive through native sync requests",
-      "Optimized social scraper frame drops",
-      "Dedupe Instagram story captures",
-      "Pause Settings descendant transitions while the dialog is moving",
-      "Open the full Map from Friends detail with one atomic store update",
-      "Friends last seen cards now retry the route commit if the store reaches Map before the full Map surface mounts",
-      "Flush mobile Friends toolbar switches between Details and graph modes",
-      "Settings scrolling is lighter, and Friends view transitions are stable through the release regression gate",
-      "Guarded Friends graph Pixi teardown so the Last seen to Map handoff cannot be replaced by the fatal error screen",
-      "Kept the collapsed Friends detail-card regression focused on selected-person behavior instead of a CI-sensitive graph node point lookup",
-      "V26.5.1013-dev replaces the failed v26.5.1012-dev validation tag, which produced no installable artifacts"
+      "Retries the Friends last-seen route commit when the store reaches Map before the full Map surface mounts",
+      "Paints fewer primary markers during dense Map pan and zoom movement"
     ],
     "followUps": [
-      "Reduce settings scroll overdraw",
-      "Reader, sidebar, and settings UX work",
-      "Trim reader rail work and stabilize friends perf",
-      "Isolate social scraper webkit stores",
-      "Gate startup social scraper pressure",
-      "Recycle blocked scraper windows",
-      "Reserve scraper memory headroom",
-      "Slim desktop e2e gates",
-      "Continue passive soak metrics until Apple Events authorization is restored for active UI driving",
-      "Treat Settings scroll as the next measured performance surface because it remains the largest budget miss",
-      "Settings scroll and Friends graph stability"
+      "Continue monitoring Friends to Map handoffs and dense Map movement under installed dev builds",
+      "Friends navigation recovers from late Map mounting"
     ]
   },
-  "releaseBody": "(AI Generated).\n\n## Freed v26.5.1101-dev\n\nAI ranked friend suggestions, support Friends graph pinch zoom, and Friends relationship tiers\n\n### Features\n\n- AI ranked friend suggestions\n- Support Friends graph pinch zoom\n- Friends relationship tiers\n\n### Fixes\n\n- Dense Map pan and zoom movement now paints fewer primary markers, keeping the 1,600-author perf gate within budget\n- Friends map handoff is now more stable\n- Reader, feed, and header polish\n- Test coverage and performance hardening\n- Release build and type-safety cleanup\n- Route Google Drive through native sync requests\n- Optimized social scraper frame drops\n- Dedupe Instagram story captures\n- Pause Settings descendant transitions while the dialog is moving\n- Open the full Map from Friends detail with one atomic store update\n- Friends last seen cards now retry the route commit if the store reaches Map before the full Map surface mounts\n- Flush mobile Friends toolbar switches between Details and graph modes\n- Settings scrolling is lighter, and Friends view transitions are stable through the release regression gate\n- Guarded Friends graph Pixi teardown so the Last seen to Map handoff cannot be replaced by the fatal error screen\n- Kept the collapsed Friends detail-card regression focused on selected-person behavior instead of a CI-sensitive graph node point lookup\n- V26.5.1013-dev replaces the failed v26.5.1012-dev validation tag, which produced no installable artifacts\n\n### Follow-ups\n\n- Reduce settings scroll overdraw\n- Reader, sidebar, and settings UX work\n- Trim reader rail work and stabilize friends perf\n- Isolate social scraper webkit stores\n- Gate startup social scraper pressure\n- Recycle blocked scraper windows\n- Reserve scraper memory headroom\n- Slim desktop e2e gates\n- Continue passive soak metrics until Apple Events authorization is restored for active UI driving\n- Treat Settings scroll as the next measured performance surface because it remains the largest budget miss\n- Settings scroll and Friends graph stability\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+  "releaseBody": "(AI Generated).\n\n## Freed v26.5.1101-dev\n\nFriends navigation and dense Map movement get steadier\n\n### Fixes\n\n- Retries the Friends last-seen route commit when the store reaches Map before the full Map surface mounts\n- Paints fewer primary markers during dense Map pan and zoom movement\n\n### Follow-ups\n\n- Continue monitoring Friends to Map handoffs and dense Map movement under installed dev builds\n- Friends navigation recovers from late Map mounting\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
 }

--- a/release-notes/releases/v26.5.1101-dev.md
+++ b/release-notes/releases/v26.5.1101-dev.md
@@ -2,46 +2,17 @@
 
 ## Freed v26.5.1101-dev
 
-AI ranked friend suggestions, support Friends graph pinch zoom, and Friends relationship tiers
-
-### Features
-
-- AI ranked friend suggestions
-- Support Friends graph pinch zoom
-- Friends relationship tiers
+Friends navigation and dense Map movement get steadier
 
 ### Fixes
 
-- Dense Map pan and zoom movement now paints fewer primary markers, keeping the 1,600-author perf gate within budget
-- Friends map handoff is now more stable
-- Reader, feed, and header polish
-- Test coverage and performance hardening
-- Release build and type-safety cleanup
-- Route Google Drive through native sync requests
-- Optimized social scraper frame drops
-- Dedupe Instagram story captures
-- Pause Settings descendant transitions while the dialog is moving
-- Open the full Map from Friends detail with one atomic store update
-- Friends last seen cards now retry the route commit if the store reaches Map before the full Map surface mounts
-- Flush mobile Friends toolbar switches between Details and graph modes
-- Settings scrolling is lighter, and Friends view transitions are stable through the release regression gate
-- Guarded Friends graph Pixi teardown so the Last seen to Map handoff cannot be replaced by the fatal error screen
-- Kept the collapsed Friends detail-card regression focused on selected-person behavior instead of a CI-sensitive graph node point lookup
-- V26.5.1013-dev replaces the failed v26.5.1012-dev validation tag, which produced no installable artifacts
+- Retries the Friends last-seen route commit when the store reaches Map before the full Map surface mounts
+- Paints fewer primary markers during dense Map pan and zoom movement
 
 ### Follow-ups
 
-- Reduce settings scroll overdraw
-- Reader, sidebar, and settings UX work
-- Trim reader rail work and stabilize friends perf
-- Isolate social scraper webkit stores
-- Gate startup social scraper pressure
-- Recycle blocked scraper windows
-- Reserve scraper memory headroom
-- Slim desktop e2e gates
-- Continue passive soak metrics until Apple Events authorization is restored for active UI driving
-- Treat Settings scroll as the next measured performance surface because it remains the largest budget miss
-- Settings scroll and Friends graph stability
+- Continue monitoring Friends to Map handoffs and dense Map movement under installed dev builds
+- Friends navigation recovers from late Map mounting
 
 ### Downloads
 

--- a/release-notes/releases/v26.5.1102-dev.json
+++ b/release-notes/releases/v26.5.1102-dev.json
@@ -45,35 +45,18 @@
     ]
   },
   "release": {
-    "deck": "AI ranked friend suggestions, support Friends graph pinch zoom, and Friends relationship tiers",
-    "features": [
-      "AI ranked friend suggestions",
-      "Support Friends graph pinch zoom",
-      "Friends relationship tiers"
-    ],
+    "deck": "Map navigation, dense movement, and Settings motion get steadier",
+    "features": [],
     "fixes": [
-      "Reader, feed, and header polish",
-      "Test coverage and performance hardening",
-      "Release build and type-safety cleanup",
-      "Route Google Drive through native sync requests",
-      "Capture and scraper reliability fixes",
-      "Open the full Map from Friends detail with one atomic store update"
+      "Retries the Friends last-seen route commit when the store reaches Map before the full Map surface mounts",
+      "Paints fewer primary markers during dense Map pan and zoom movement",
+      "Lightens Settings moving chrome while the dialog is in motion"
     ],
     "followUps": [
-      "Lighten settings moving chrome",
-      "Reduce dense map movement paint",
-      "Reduce settings scroll overdraw",
-      "Reader, sidebar, and settings UX work",
-      "Trim reader rail work and stabilize friends perf",
-      "Isolate social scraper webkit stores",
-      "Gate startup social scraper pressure",
-      "Recycle blocked scraper windows",
-      "Reserve scraper memory headroom",
-      "Slim desktop e2e gates",
-      "Continue passive soak metrics until Apple Events authorization is restored for active UI driving",
-      "Treat Settings scroll as the next measured performance surface because it remains the largest budget miss",
-      "Settings scroll and Friends graph stability"
+      "Continue reducing Settings scroll overdraw in installed dev builds",
+      "Friends navigation recovers from late Map mounting",
+      "Continue monitoring Friends to Map handoffs under installed dev builds"
     ]
   },
-  "releaseBody": "(AI Generated).\n\n## Freed v26.5.1102-dev\n\nAI ranked friend suggestions, support Friends graph pinch zoom, and Friends relationship tiers\n\n### Features\n\n- AI ranked friend suggestions\n- Support Friends graph pinch zoom\n- Friends relationship tiers\n\n### Fixes\n\n- Reader, feed, and header polish\n- Test coverage and performance hardening\n- Release build and type-safety cleanup\n- Route Google Drive through native sync requests\n- Capture and scraper reliability fixes\n- Open the full Map from Friends detail with one atomic store update\n\n### Follow-ups\n\n- Lighten settings moving chrome\n- Reduce dense map movement paint\n- Reduce settings scroll overdraw\n- Reader, sidebar, and settings UX work\n- Trim reader rail work and stabilize friends perf\n- Isolate social scraper webkit stores\n- Gate startup social scraper pressure\n- Recycle blocked scraper windows\n- Reserve scraper memory headroom\n- Slim desktop e2e gates\n- Continue passive soak metrics until Apple Events authorization is restored for active UI driving\n- Treat Settings scroll as the next measured performance surface because it remains the largest budget miss\n- Settings scroll and Friends graph stability\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+  "releaseBody": "(AI Generated).\n\n## Freed v26.5.1102-dev\n\nMap navigation, dense movement, and Settings motion get steadier\n\n### Fixes\n\n- Retries the Friends last-seen route commit when the store reaches Map before the full Map surface mounts\n- Paints fewer primary markers during dense Map pan and zoom movement\n- Lightens Settings moving chrome while the dialog is in motion\n\n### Follow-ups\n\n- Continue reducing Settings scroll overdraw in installed dev builds\n- Friends navigation recovers from late Map mounting\n- Continue monitoring Friends to Map handoffs under installed dev builds\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
 }

--- a/release-notes/releases/v26.5.1102-dev.md
+++ b/release-notes/releases/v26.5.1102-dev.md
@@ -2,38 +2,19 @@
 
 ## Freed v26.5.1102-dev
 
-AI ranked friend suggestions, support Friends graph pinch zoom, and Friends relationship tiers
-
-### Features
-
-- AI ranked friend suggestions
-- Support Friends graph pinch zoom
-- Friends relationship tiers
+Map navigation, dense movement, and Settings motion get steadier
 
 ### Fixes
 
-- Reader, feed, and header polish
-- Test coverage and performance hardening
-- Release build and type-safety cleanup
-- Route Google Drive through native sync requests
-- Capture and scraper reliability fixes
-- Open the full Map from Friends detail with one atomic store update
+- Retries the Friends last-seen route commit when the store reaches Map before the full Map surface mounts
+- Paints fewer primary markers during dense Map pan and zoom movement
+- Lightens Settings moving chrome while the dialog is in motion
 
 ### Follow-ups
 
-- Lighten settings moving chrome
-- Reduce dense map movement paint
-- Reduce settings scroll overdraw
-- Reader, sidebar, and settings UX work
-- Trim reader rail work and stabilize friends perf
-- Isolate social scraper webkit stores
-- Gate startup social scraper pressure
-- Recycle blocked scraper windows
-- Reserve scraper memory headroom
-- Slim desktop e2e gates
-- Continue passive soak metrics until Apple Events authorization is restored for active UI driving
-- Treat Settings scroll as the next measured performance surface because it remains the largest budget miss
-- Settings scroll and Friends graph stability
+- Continue reducing Settings scroll overdraw in installed dev builds
+- Friends navigation recovers from late Map mounting
+- Continue monitoring Friends to Map handoffs under installed dev builds
 
 ### Downloads
 

--- a/release-notes/releases/v26.5.1104-dev.json
+++ b/release-notes/releases/v26.5.1104-dev.json
@@ -53,36 +53,21 @@
     ]
   },
   "release": {
-    "deck": "Friends and Map handoffs stay recoverable, with clearer renderer health telemetry",
-    "features": [
-      "AI ranked friend suggestions",
-      "Support Friends graph pinch zoom",
-      "Friends relationship tiers"
-    ],
+    "deck": "Friends recovery and renderer health reporting improve",
+    "features": [],
     "fixes": [
-      "Keep friends graph sync errors recoverable",
-      "Reader, feed, and header polish",
-      "Test coverage and performance hardening",
-      "Release build and type-safety cleanup",
-      "Route Google Drive through native sync requests",
-      "Capture and scraper reliability fixes",
-      "Open the full Map from Friends detail with one atomic store update"
+      "Keeps Friends graph sync errors recoverable",
+      "Reports throttled renderer heartbeats with clearer context",
+      "Retries the Friends last-seen route commit when the store reaches Map before the full Map surface mounts",
+      "Paints fewer primary markers during dense Map pan and zoom movement",
+      "Lightens Settings moving chrome while the dialog is in motion"
     ],
     "followUps": [
-      "Lighten settings moving chrome",
-      "Reduce dense map movement paint",
-      "Reduce settings scroll overdraw",
-      "Reader, sidebar, and settings UX work",
-      "Trim reader rail work and stabilize friends perf",
-      "Isolate social scraper webkit stores",
-      "Gate startup social scraper pressure",
-      "Recycle blocked scraper windows",
-      "Reserve scraper memory headroom",
-      "Slim desktop e2e gates",
-      "Continue passive soak metrics while active UI driving is available",
-      "Treat Settings scroll as the next measured performance surface because it remains the largest budget miss",
-      "Settings scroll and Friends graph stability"
+      "Continue monitoring Settings scroll and renderer heartbeat telemetry under installed dev builds",
+      "Friends navigation recovers from late Map mounting",
+      "Friends navigation and dense Map movement get steadier",
+      "Continue monitoring Friends to Map handoffs and dense Map movement under installed dev builds"
     ]
   },
-  "releaseBody": "(AI Generated).\n\n## Freed v26.5.1104-dev\n\nFriends and Map handoffs stay recoverable, with clearer renderer health telemetry\n\n### Features\n\n- AI ranked friend suggestions\n- Support Friends graph pinch zoom\n- Friends relationship tiers\n\n### Fixes\n\n- Keep friends graph sync errors recoverable\n- Reader, feed, and header polish\n- Test coverage and performance hardening\n- Release build and type-safety cleanup\n- Route Google Drive through native sync requests\n- Capture and scraper reliability fixes\n- Open the full Map from Friends detail with one atomic store update\n\n### Follow-ups\n\n- Lighten settings moving chrome\n- Reduce dense map movement paint\n- Reduce settings scroll overdraw\n- Reader, sidebar, and settings UX work\n- Trim reader rail work and stabilize friends perf\n- Isolate social scraper webkit stores\n- Gate startup social scraper pressure\n- Recycle blocked scraper windows\n- Reserve scraper memory headroom\n- Slim desktop e2e gates\n- Continue passive soak metrics while active UI driving is available\n- Treat Settings scroll as the next measured performance surface because it remains the largest budget miss\n- Settings scroll and Friends graph stability\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+  "releaseBody": "(AI Generated).\n\n## Freed v26.5.1104-dev\n\nFriends recovery and renderer health reporting improve\n\n### Fixes\n\n- Keeps Friends graph sync errors recoverable\n- Reports throttled renderer heartbeats with clearer context\n- Retries the Friends last-seen route commit when the store reaches Map before the full Map surface mounts\n- Paints fewer primary markers during dense Map pan and zoom movement\n- Lightens Settings moving chrome while the dialog is in motion\n\n### Follow-ups\n\n- Continue monitoring Settings scroll and renderer heartbeat telemetry under installed dev builds\n- Friends navigation recovers from late Map mounting\n- Friends navigation and dense Map movement get steadier\n- Continue monitoring Friends to Map handoffs and dense Map movement under installed dev builds\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
 }

--- a/release-notes/releases/v26.5.1104-dev.md
+++ b/release-notes/releases/v26.5.1104-dev.md
@@ -2,39 +2,22 @@
 
 ## Freed v26.5.1104-dev
 
-Friends and Map handoffs stay recoverable, with clearer renderer health telemetry
-
-### Features
-
-- AI ranked friend suggestions
-- Support Friends graph pinch zoom
-- Friends relationship tiers
+Friends recovery and renderer health reporting improve
 
 ### Fixes
 
-- Keep friends graph sync errors recoverable
-- Reader, feed, and header polish
-- Test coverage and performance hardening
-- Release build and type-safety cleanup
-- Route Google Drive through native sync requests
-- Capture and scraper reliability fixes
-- Open the full Map from Friends detail with one atomic store update
+- Keeps Friends graph sync errors recoverable
+- Reports throttled renderer heartbeats with clearer context
+- Retries the Friends last-seen route commit when the store reaches Map before the full Map surface mounts
+- Paints fewer primary markers during dense Map pan and zoom movement
+- Lightens Settings moving chrome while the dialog is in motion
 
 ### Follow-ups
 
-- Lighten settings moving chrome
-- Reduce dense map movement paint
-- Reduce settings scroll overdraw
-- Reader, sidebar, and settings UX work
-- Trim reader rail work and stabilize friends perf
-- Isolate social scraper webkit stores
-- Gate startup social scraper pressure
-- Recycle blocked scraper windows
-- Reserve scraper memory headroom
-- Slim desktop e2e gates
-- Continue passive soak metrics while active UI driving is available
-- Treat Settings scroll as the next measured performance surface because it remains the largest budget miss
-- Settings scroll and Friends graph stability
+- Continue monitoring Settings scroll and renderer heartbeat telemetry under installed dev builds
+- Friends navigation recovers from late Map mounting
+- Friends navigation and dense Map movement get steadier
+- Continue monitoring Friends to Map handoffs and dense Map movement under installed dev builds
 
 ### Downloads
 

--- a/release-notes/releases/v26.5.1105-dev.json
+++ b/release-notes/releases/v26.5.1105-dev.json
@@ -62,39 +62,27 @@
     ]
   },
   "release": {
-    "deck": "Google OAuth now runs natively in Freed Desktop, Settings and Map stay smoother, Friends and Map handoffs stay recoverable, and AI ranked friend suggestions support Friends graph pinch zoom",
+    "deck": "Google sync, Story wall, and recovery fixes land",
     "features": [
-      "Story wall publishing",
-      "AI ranked friend suggestions",
-      "Support Friends graph pinch zoom"
+      "Story wall publishing"
     ],
     "fixes": [
-      "Complete Google Contacts sync in Freed Desktop",
-      "Share native Google OAuth credentials between Drive and Contacts refresh",
-      "Surface Google OAuth and People API failure details in Settings instead of generic load errors",
-      "Reader, feed, and header polish",
-      "Keep friends graph sync errors recoverable",
-      "Test coverage and performance hardening",
-      "Release build and type-safety cleanup",
-      "Route Google Drive through native sync requests",
-      "Capture and scraper reliability fixes",
-      "Open the full Map from Friends detail with one atomic store update"
+      "Completes Google Contacts sync in Freed Desktop",
+      "Shares native Google OAuth credentials between Drive and Contacts refresh",
+      "Surfaces Google OAuth and People API failure details in Settings instead of generic load errors",
+      "Keeps dense Map focused markers visible during movement",
+      "Keeps Friends graph sync errors recoverable",
+      "Reports throttled renderer heartbeats with clearer context",
+      "Retries the Friends last-seen route commit when the store reaches Map before the full Map surface mounts",
+      "Lightens Settings moving chrome while the dialog is in motion"
     ],
     "followUps": [
-      "Lighten settings moving chrome",
-      "Reduce dense map movement paint",
-      "Reduce settings scroll overdraw",
-      "Friends relationship tiers",
-      "Reader, sidebar, and settings UX work",
-      "Trim reader rail work and stabilize friends perf",
-      "Isolate social scraper webkit stores",
-      "Gate startup social scraper pressure",
-      "Recycle blocked scraper windows",
-      "Reserve scraper memory headroom",
-      "Slim desktop e2e gates",
-      "Continue passive soak metrics until Apple Events authorization is restored for active UI driving",
-      "Treat Settings scroll as the next measured performance surface because it remains the largest budget miss"
+      "Continue monitoring Settings scroll and scraper memory pressure under installed dev builds",
+      "Friends navigation recovers from late Map mounting",
+      "Friends navigation and dense Map movement get steadier",
+      "Continue monitoring Friends to Map handoffs and dense Map movement under installed dev builds",
+      "Friends recovery and renderer health reporting improve"
     ]
   },
-  "releaseBody": "(AI Generated).\n\n## Freed v26.5.1105-dev\n\nGoogle OAuth now runs natively in Freed Desktop, Settings and Map stay smoother, Friends and Map handoffs stay recoverable, and AI ranked friend suggestions support Friends graph pinch zoom\n\n### Features\n\n- Story wall publishing\n- AI ranked friend suggestions\n- Support Friends graph pinch zoom\n\n### Fixes\n\n- Complete Google Contacts sync in Freed Desktop\n- Share native Google OAuth credentials between Drive and Contacts refresh\n- Surface Google OAuth and People API failure details in Settings instead of generic load errors\n- Reader, feed, and header polish\n- Keep friends graph sync errors recoverable\n- Test coverage and performance hardening\n- Release build and type-safety cleanup\n- Route Google Drive through native sync requests\n- Capture and scraper reliability fixes\n- Open the full Map from Friends detail with one atomic store update\n\n### Follow-ups\n\n- Lighten settings moving chrome\n- Reduce dense map movement paint\n- Reduce settings scroll overdraw\n- Friends relationship tiers\n- Reader, sidebar, and settings UX work\n- Trim reader rail work and stabilize friends perf\n- Isolate social scraper webkit stores\n- Gate startup social scraper pressure\n- Recycle blocked scraper windows\n- Reserve scraper memory headroom\n- Slim desktop e2e gates\n- Continue passive soak metrics until Apple Events authorization is restored for active UI driving\n- Treat Settings scroll as the next measured performance surface because it remains the largest budget miss\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+  "releaseBody": "(AI Generated).\n\n## Freed v26.5.1105-dev\n\nGoogle sync, Story wall, and recovery fixes land\n\n### Features\n\n- Story wall publishing\n\n### Fixes\n\n- Completes Google Contacts sync in Freed Desktop\n- Shares native Google OAuth credentials between Drive and Contacts refresh\n- Surfaces Google OAuth and People API failure details in Settings instead of generic load errors\n- Keeps dense Map focused markers visible during movement\n- Keeps Friends graph sync errors recoverable\n- Reports throttled renderer heartbeats with clearer context\n- Retries the Friends last-seen route commit when the store reaches Map before the full Map surface mounts\n- Lightens Settings moving chrome while the dialog is in motion\n\n### Follow-ups\n\n- Continue monitoring Settings scroll and scraper memory pressure under installed dev builds\n- Friends navigation recovers from late Map mounting\n- Friends navigation and dense Map movement get steadier\n- Continue monitoring Friends to Map handoffs and dense Map movement under installed dev builds\n- Friends recovery and renderer health reporting improve\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
 }

--- a/release-notes/releases/v26.5.1105-dev.md
+++ b/release-notes/releases/v26.5.1105-dev.md
@@ -2,42 +2,30 @@
 
 ## Freed v26.5.1105-dev
 
-Google OAuth now runs natively in Freed Desktop, Settings and Map stay smoother, Friends and Map handoffs stay recoverable, and AI ranked friend suggestions support Friends graph pinch zoom
+Google sync, Story wall, and recovery fixes land
 
 ### Features
 
 - Story wall publishing
-- AI ranked friend suggestions
-- Support Friends graph pinch zoom
 
 ### Fixes
 
-- Complete Google Contacts sync in Freed Desktop
-- Share native Google OAuth credentials between Drive and Contacts refresh
-- Surface Google OAuth and People API failure details in Settings instead of generic load errors
-- Reader, feed, and header polish
-- Keep friends graph sync errors recoverable
-- Test coverage and performance hardening
-- Release build and type-safety cleanup
-- Route Google Drive through native sync requests
-- Capture and scraper reliability fixes
-- Open the full Map from Friends detail with one atomic store update
+- Completes Google Contacts sync in Freed Desktop
+- Shares native Google OAuth credentials between Drive and Contacts refresh
+- Surfaces Google OAuth and People API failure details in Settings instead of generic load errors
+- Keeps dense Map focused markers visible during movement
+- Keeps Friends graph sync errors recoverable
+- Reports throttled renderer heartbeats with clearer context
+- Retries the Friends last-seen route commit when the store reaches Map before the full Map surface mounts
+- Lightens Settings moving chrome while the dialog is in motion
 
 ### Follow-ups
 
-- Lighten settings moving chrome
-- Reduce dense map movement paint
-- Reduce settings scroll overdraw
-- Friends relationship tiers
-- Reader, sidebar, and settings UX work
-- Trim reader rail work and stabilize friends perf
-- Isolate social scraper webkit stores
-- Gate startup social scraper pressure
-- Recycle blocked scraper windows
-- Reserve scraper memory headroom
-- Slim desktop e2e gates
-- Continue passive soak metrics until Apple Events authorization is restored for active UI driving
-- Treat Settings scroll as the next measured performance surface because it remains the largest budget miss
+- Continue monitoring Settings scroll and scraper memory pressure under installed dev builds
+- Friends navigation recovers from late Map mounting
+- Friends navigation and dense Map movement get steadier
+- Continue monitoring Friends to Map handoffs and dense Map movement under installed dev builds
+- Friends recovery and renderer health reporting improve
 
 ### Downloads
 

--- a/release-notes/releases/v26.5.1106-dev.json
+++ b/release-notes/releases/v26.5.1106-dev.json
@@ -66,40 +66,28 @@
     ]
   },
   "release": {
-    "deck": "Google OAuth now runs natively in Freed Desktop, Settings and Map stay smoother, Friends and Map handoffs stay recoverable, and AI ranked friend suggestions support Friends graph pinch zoom",
+    "deck": "Google sync, Story wall, and scraper memory gates improve",
     "features": [
-      "Story wall publishing",
-      "AI ranked friend suggestions",
-      "Support Friends graph pinch zoom"
+      "Story wall publishing"
     ],
     "fixes": [
-      "Gate social scrapes on resident WebKit memory",
-      "Complete Google Contacts sync in Freed Desktop",
-      "Share native Google OAuth credentials between Drive and Contacts refresh",
-      "Surface Google OAuth and People API failure details in Settings instead of generic load errors",
-      "Reader, feed, and header polish",
-      "Keep friends graph sync errors recoverable",
-      "Test coverage and performance hardening",
-      "Release build and type-safety cleanup",
-      "Route Google Drive through native sync requests",
-      "Capture and scraper reliability fixes",
-      "Open the full Map from Friends detail with one atomic store update"
+      "Completes Google Contacts sync in Freed Desktop",
+      "Shares native Google OAuth credentials between Drive and Contacts refresh",
+      "Surfaces Google OAuth and People API failure details in Settings instead of generic load errors",
+      "Gates social scrapes on resident WebKit memory pressure",
+      "Keeps dense Map focused markers visible during movement",
+      "Keeps Friends graph sync errors recoverable",
+      "Retries the Friends last-seen route commit when the store reaches Map before the full Map surface mounts",
+      "Lightens Settings moving chrome while the dialog is in motion",
+      "Reports throttled renderer heartbeats with clearer context"
     ],
     "followUps": [
-      "Lighten settings moving chrome",
-      "Reduce dense map movement paint",
-      "Reduce settings scroll overdraw",
-      "Friends relationship tiers",
-      "Reader, sidebar, and settings UX work",
-      "Trim reader rail work and stabilize friends perf",
-      "Isolate social scraper webkit stores",
-      "Gate startup social scraper pressure",
-      "Recycle blocked scraper windows",
-      "Reserve scraper memory headroom",
-      "Slim desktop e2e gates",
-      "Continue passive soak metrics until Apple Events authorization is restored for active UI driving",
-      "Treat Settings scroll as the next measured performance surface because it remains the largest budget miss"
+      "Continue monitoring scraper memory pressure under installed dev builds",
+      "Friends navigation recovers from late Map mounting",
+      "Friends navigation and dense Map movement get steadier",
+      "Continue reducing Settings scroll overdraw in installed dev builds",
+      "Friends recovery and renderer health reporting improve"
     ]
   },
-  "releaseBody": "(AI Generated).\n\n## Freed v26.5.1106-dev\n\nGoogle OAuth now runs natively in Freed Desktop, Settings and Map stay smoother, Friends and Map handoffs stay recoverable, and AI ranked friend suggestions support Friends graph pinch zoom\n\n### Features\n\n- Story wall publishing\n- AI ranked friend suggestions\n- Support Friends graph pinch zoom\n\n### Fixes\n\n- Gate social scrapes on resident WebKit memory\n- Complete Google Contacts sync in Freed Desktop\n- Share native Google OAuth credentials between Drive and Contacts refresh\n- Surface Google OAuth and People API failure details in Settings instead of generic load errors\n- Reader, feed, and header polish\n- Keep friends graph sync errors recoverable\n- Test coverage and performance hardening\n- Release build and type-safety cleanup\n- Route Google Drive through native sync requests\n- Capture and scraper reliability fixes\n- Open the full Map from Friends detail with one atomic store update\n\n### Follow-ups\n\n- Lighten settings moving chrome\n- Reduce dense map movement paint\n- Reduce settings scroll overdraw\n- Friends relationship tiers\n- Reader, sidebar, and settings UX work\n- Trim reader rail work and stabilize friends perf\n- Isolate social scraper webkit stores\n- Gate startup social scraper pressure\n- Recycle blocked scraper windows\n- Reserve scraper memory headroom\n- Slim desktop e2e gates\n- Continue passive soak metrics until Apple Events authorization is restored for active UI driving\n- Treat Settings scroll as the next measured performance surface because it remains the largest budget miss\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+  "releaseBody": "(AI Generated).\n\n## Freed v26.5.1106-dev\n\nGoogle sync, Story wall, and scraper memory gates improve\n\n### Features\n\n- Story wall publishing\n\n### Fixes\n\n- Completes Google Contacts sync in Freed Desktop\n- Shares native Google OAuth credentials between Drive and Contacts refresh\n- Surfaces Google OAuth and People API failure details in Settings instead of generic load errors\n- Gates social scrapes on resident WebKit memory pressure\n- Keeps dense Map focused markers visible during movement\n- Keeps Friends graph sync errors recoverable\n- Retries the Friends last-seen route commit when the store reaches Map before the full Map surface mounts\n- Lightens Settings moving chrome while the dialog is in motion\n- Reports throttled renderer heartbeats with clearer context\n\n### Follow-ups\n\n- Continue monitoring scraper memory pressure under installed dev builds\n- Friends navigation recovers from late Map mounting\n- Friends navigation and dense Map movement get steadier\n- Continue reducing Settings scroll overdraw in installed dev builds\n- Friends recovery and renderer health reporting improve\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
 }

--- a/release-notes/releases/v26.5.1106-dev.md
+++ b/release-notes/releases/v26.5.1106-dev.md
@@ -2,43 +2,31 @@
 
 ## Freed v26.5.1106-dev
 
-Google OAuth now runs natively in Freed Desktop, Settings and Map stay smoother, Friends and Map handoffs stay recoverable, and AI ranked friend suggestions support Friends graph pinch zoom
+Google sync, Story wall, and scraper memory gates improve
 
 ### Features
 
 - Story wall publishing
-- AI ranked friend suggestions
-- Support Friends graph pinch zoom
 
 ### Fixes
 
-- Gate social scrapes on resident WebKit memory
-- Complete Google Contacts sync in Freed Desktop
-- Share native Google OAuth credentials between Drive and Contacts refresh
-- Surface Google OAuth and People API failure details in Settings instead of generic load errors
-- Reader, feed, and header polish
-- Keep friends graph sync errors recoverable
-- Test coverage and performance hardening
-- Release build and type-safety cleanup
-- Route Google Drive through native sync requests
-- Capture and scraper reliability fixes
-- Open the full Map from Friends detail with one atomic store update
+- Completes Google Contacts sync in Freed Desktop
+- Shares native Google OAuth credentials between Drive and Contacts refresh
+- Surfaces Google OAuth and People API failure details in Settings instead of generic load errors
+- Gates social scrapes on resident WebKit memory pressure
+- Keeps dense Map focused markers visible during movement
+- Keeps Friends graph sync errors recoverable
+- Retries the Friends last-seen route commit when the store reaches Map before the full Map surface mounts
+- Lightens Settings moving chrome while the dialog is in motion
+- Reports throttled renderer heartbeats with clearer context
 
 ### Follow-ups
 
-- Lighten settings moving chrome
-- Reduce dense map movement paint
-- Reduce settings scroll overdraw
-- Friends relationship tiers
-- Reader, sidebar, and settings UX work
-- Trim reader rail work and stabilize friends perf
-- Isolate social scraper webkit stores
-- Gate startup social scraper pressure
-- Recycle blocked scraper windows
-- Reserve scraper memory headroom
-- Slim desktop e2e gates
-- Continue passive soak metrics until Apple Events authorization is restored for active UI driving
-- Treat Settings scroll as the next measured performance surface because it remains the largest budget miss
+- Continue monitoring scraper memory pressure under installed dev builds
+- Friends navigation recovers from late Map mounting
+- Friends navigation and dense Map movement get steadier
+- Continue reducing Settings scroll overdraw in installed dev builds
+- Friends recovery and renderer health reporting improve
 
 ### Downloads
 

--- a/release-notes/releases/v26.5.1107-dev.json
+++ b/release-notes/releases/v26.5.1107-dev.json
@@ -70,42 +70,30 @@
     ]
   },
   "release": {
-    "deck": "Google OAuth now runs natively in Freed Desktop, Settings and Map stay smoother, Friends and Map handoffs stay recoverable, and social scraping respects tighter memory backpressure",
+    "deck": "Google sync, Story wall, and scraper session pressure improve",
     "features": [
-      "Story wall publishing",
-      "AI ranked friend suggestions",
-      "Support Friends graph pinch zoom"
+      "Story wall publishing"
     ],
     "fixes": [
-      "Gate scraper memory before session slots",
-      "Gate social scrapes on resident WebKit memory",
-      "Complete Google Contacts sync in Freed Desktop",
-      "Share native Google OAuth credentials between Drive and Contacts refresh",
-      "Surface Google OAuth and People API failure details in Settings instead of generic load errors",
-      "Reader, feed, and header polish",
-      "Keep friends graph sync errors recoverable",
-      "Test coverage and performance hardening",
-      "Release build and type-safety cleanup",
-      "Route Google Drive through native sync requests",
-      "Capture and scraper reliability fixes",
-      "Open the full Map from Friends detail with one atomic store update"
+      "Completes Google Contacts sync in Freed Desktop",
+      "Shares native Google OAuth credentials between Drive and Contacts refresh",
+      "Gates social scrapes before session slots are reserved",
+      "Gates social scrapes on resident WebKit memory pressure",
+      "Keeps dense Map focused markers visible during movement",
+      "Keeps Friends graph sync errors recoverable",
+      "Retries the Friends last-seen route commit when the store reaches Map before the full Map surface mounts",
+      "Lightens Settings moving chrome while the dialog is in motion",
+      "Reports throttled renderer heartbeats with clearer context",
+      "Surfaces Google OAuth and People API failure details in Settings instead of generic load errors"
     ],
     "followUps": [
-      "Lighten settings moving chrome",
-      "Reduce dense map movement paint",
-      "Reduce settings scroll overdraw",
-      "Friends relationship tiers",
-      "Reader, sidebar, and settings UX work",
-      "Trim reader rail work and stabilize friends perf",
-      "Isolate social scraper webkit stores",
-      "Gate startup social scraper pressure",
-      "Recycle blocked scraper windows",
-      "Reserve scraper memory headroom",
-      "Slim desktop e2e gates",
       "Keep memory-blocked scrapes from holding the shared scraper slot",
-      "Continue passive soak metrics until Apple Events authorization is restored for active UI driving",
-      "Treat Settings scroll as the next measured performance surface because it remains the largest budget miss"
+      "Friends navigation recovers from late Map mounting",
+      "Continue monitoring Friends to Map handoffs under installed dev builds",
+      "Friends navigation and dense Map movement get steadier",
+      "Continue reducing Settings scroll overdraw in installed dev builds",
+      "Friends recovery and renderer health reporting improve"
     ]
   },
-  "releaseBody": "(AI Generated).\n\n## Freed v26.5.1107-dev\n\nGoogle OAuth now runs natively in Freed Desktop, Settings and Map stay smoother, Friends and Map handoffs stay recoverable, and social scraping respects tighter memory backpressure\n\n### Features\n\n- Story wall publishing\n- AI ranked friend suggestions\n- Support Friends graph pinch zoom\n\n### Fixes\n\n- Gate scraper memory before session slots\n- Gate social scrapes on resident WebKit memory\n- Complete Google Contacts sync in Freed Desktop\n- Share native Google OAuth credentials between Drive and Contacts refresh\n- Surface Google OAuth and People API failure details in Settings instead of generic load errors\n- Reader, feed, and header polish\n- Keep friends graph sync errors recoverable\n- Test coverage and performance hardening\n- Release build and type-safety cleanup\n- Route Google Drive through native sync requests\n- Capture and scraper reliability fixes\n- Open the full Map from Friends detail with one atomic store update\n\n### Follow-ups\n\n- Lighten settings moving chrome\n- Reduce dense map movement paint\n- Reduce settings scroll overdraw\n- Friends relationship tiers\n- Reader, sidebar, and settings UX work\n- Trim reader rail work and stabilize friends perf\n- Isolate social scraper webkit stores\n- Gate startup social scraper pressure\n- Recycle blocked scraper windows\n- Reserve scraper memory headroom\n- Slim desktop e2e gates\n- Keep memory-blocked scrapes from holding the shared scraper slot\n- Continue passive soak metrics until Apple Events authorization is restored for active UI driving\n- Treat Settings scroll as the next measured performance surface because it remains the largest budget miss\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+  "releaseBody": "(AI Generated).\n\n## Freed v26.5.1107-dev\n\nGoogle sync, Story wall, and scraper session pressure improve\n\n### Features\n\n- Story wall publishing\n\n### Fixes\n\n- Completes Google Contacts sync in Freed Desktop\n- Shares native Google OAuth credentials between Drive and Contacts refresh\n- Gates social scrapes before session slots are reserved\n- Gates social scrapes on resident WebKit memory pressure\n- Keeps dense Map focused markers visible during movement\n- Keeps Friends graph sync errors recoverable\n- Retries the Friends last-seen route commit when the store reaches Map before the full Map surface mounts\n- Lightens Settings moving chrome while the dialog is in motion\n- Reports throttled renderer heartbeats with clearer context\n- Surfaces Google OAuth and People API failure details in Settings instead of generic load errors\n\n### Follow-ups\n\n- Keep memory-blocked scrapes from holding the shared scraper slot\n- Friends navigation recovers from late Map mounting\n- Continue monitoring Friends to Map handoffs under installed dev builds\n- Friends navigation and dense Map movement get steadier\n- Continue reducing Settings scroll overdraw in installed dev builds\n- Friends recovery and renderer health reporting improve\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
 }

--- a/release-notes/releases/v26.5.1107-dev.md
+++ b/release-notes/releases/v26.5.1107-dev.md
@@ -2,45 +2,33 @@
 
 ## Freed v26.5.1107-dev
 
-Google OAuth now runs natively in Freed Desktop, Settings and Map stay smoother, Friends and Map handoffs stay recoverable, and social scraping respects tighter memory backpressure
+Google sync, Story wall, and scraper session pressure improve
 
 ### Features
 
 - Story wall publishing
-- AI ranked friend suggestions
-- Support Friends graph pinch zoom
 
 ### Fixes
 
-- Gate scraper memory before session slots
-- Gate social scrapes on resident WebKit memory
-- Complete Google Contacts sync in Freed Desktop
-- Share native Google OAuth credentials between Drive and Contacts refresh
-- Surface Google OAuth and People API failure details in Settings instead of generic load errors
-- Reader, feed, and header polish
-- Keep friends graph sync errors recoverable
-- Test coverage and performance hardening
-- Release build and type-safety cleanup
-- Route Google Drive through native sync requests
-- Capture and scraper reliability fixes
-- Open the full Map from Friends detail with one atomic store update
+- Completes Google Contacts sync in Freed Desktop
+- Shares native Google OAuth credentials between Drive and Contacts refresh
+- Gates social scrapes before session slots are reserved
+- Gates social scrapes on resident WebKit memory pressure
+- Keeps dense Map focused markers visible during movement
+- Keeps Friends graph sync errors recoverable
+- Retries the Friends last-seen route commit when the store reaches Map before the full Map surface mounts
+- Lightens Settings moving chrome while the dialog is in motion
+- Reports throttled renderer heartbeats with clearer context
+- Surfaces Google OAuth and People API failure details in Settings instead of generic load errors
 
 ### Follow-ups
 
-- Lighten settings moving chrome
-- Reduce dense map movement paint
-- Reduce settings scroll overdraw
-- Friends relationship tiers
-- Reader, sidebar, and settings UX work
-- Trim reader rail work and stabilize friends perf
-- Isolate social scraper webkit stores
-- Gate startup social scraper pressure
-- Recycle blocked scraper windows
-- Reserve scraper memory headroom
-- Slim desktop e2e gates
 - Keep memory-blocked scrapes from holding the shared scraper slot
-- Continue passive soak metrics until Apple Events authorization is restored for active UI driving
-- Treat Settings scroll as the next measured performance surface because it remains the largest budget miss
+- Friends navigation recovers from late Map mounting
+- Continue monitoring Friends to Map handoffs under installed dev builds
+- Friends navigation and dense Map movement get steadier
+- Continue reducing Settings scroll overdraw in installed dev builds
+- Friends recovery and renderer health reporting improve
 
 ### Downloads
 

--- a/release-notes/releases/v26.5.1108-dev.json
+++ b/release-notes/releases/v26.5.1108-dev.json
@@ -74,43 +74,31 @@
     ]
   },
   "release": {
-    "deck": "Google OAuth now runs natively in Freed Desktop, Friends graph motion stays lighter, Settings and Map stay smoother, and social scraping respects tighter memory backpressure",
+    "deck": "Google sync, Story wall, Friends motion, and scraper pressure improve",
     "features": [
-      "Story wall publishing",
-      "AI ranked friend suggestions",
-      "Support Friends graph pinch zoom"
+      "Story wall publishing"
     ],
     "fixes": [
-      "Skip hidden Friends provider labels during graph motion",
-      "Gate scraper memory before session slots",
-      "Gate social scrapes on resident WebKit memory",
-      "Complete Google Contacts sync in Freed Desktop",
-      "Share native Google OAuth credentials between Drive and Contacts refresh",
-      "Surface Google OAuth and People API failure details in Settings instead of generic load errors",
-      "Reader, feed, and header polish",
-      "Keep friends graph sync errors recoverable",
-      "Test coverage and performance hardening",
-      "Release build and type-safety cleanup",
-      "Route Google Drive through native sync requests",
-      "Capture and scraper reliability fixes",
-      "Open the full Map from Friends detail with one atomic store update"
+      "Skips hidden Friends provider labels during graph motion",
+      "Gates social scrapes before session slots are reserved",
+      "Gates social scrapes on resident WebKit memory pressure",
+      "Completes Google Contacts sync in Freed Desktop",
+      "Shares native Google OAuth credentials between Drive and Contacts refresh",
+      "Keeps dense Map focused markers visible during movement",
+      "Retries the Friends last-seen route commit when the store reaches Map before the full Map surface mounts",
+      "Lightens Settings moving chrome while the dialog is in motion",
+      "Keeps Friends graph sync errors recoverable",
+      "Reports throttled renderer heartbeats with clearer context",
+      "Surfaces Google OAuth and People API failure details in Settings instead of generic load errors"
     ],
     "followUps": [
-      "Lighten settings moving chrome",
-      "Reduce dense map movement paint",
-      "Reduce settings scroll overdraw",
-      "Friends relationship tiers",
-      "Reader, sidebar, and settings UX work",
-      "Trim reader rail work and stabilize friends perf",
-      "Isolate social scraper webkit stores",
-      "Gate startup social scraper pressure",
-      "Recycle blocked scraper windows",
-      "Reserve scraper memory headroom",
-      "Slim desktop e2e gates",
       "Keep memory-blocked scrapes from holding the shared scraper slot",
-      "Continue passive soak metrics until Apple Events authorization is restored for active UI driving",
-      "Treat Settings scroll as the next measured performance surface because it remains the largest budget miss"
+      "Friends navigation recovers from late Map mounting",
+      "Continue monitoring Friends to Map handoffs under installed dev builds",
+      "Friends navigation and dense Map movement get steadier",
+      "Continue reducing Settings scroll overdraw in installed dev builds",
+      "Friends recovery and renderer health reporting improve"
     ]
   },
-  "releaseBody": "(AI Generated).\n\n## Freed v26.5.1108-dev\n\nGoogle OAuth now runs natively in Freed Desktop, Friends graph motion stays lighter, Settings and Map stay smoother, and social scraping respects tighter memory backpressure\n\n### Features\n\n- Story wall publishing\n- AI ranked friend suggestions\n- Support Friends graph pinch zoom\n\n### Fixes\n\n- Skip hidden Friends provider labels during graph motion\n- Gate scraper memory before session slots\n- Gate social scrapes on resident WebKit memory\n- Complete Google Contacts sync in Freed Desktop\n- Share native Google OAuth credentials between Drive and Contacts refresh\n- Surface Google OAuth and People API failure details in Settings instead of generic load errors\n- Reader, feed, and header polish\n- Keep friends graph sync errors recoverable\n- Test coverage and performance hardening\n- Release build and type-safety cleanup\n- Route Google Drive through native sync requests\n- Capture and scraper reliability fixes\n- Open the full Map from Friends detail with one atomic store update\n\n### Follow-ups\n\n- Lighten settings moving chrome\n- Reduce dense map movement paint\n- Reduce settings scroll overdraw\n- Friends relationship tiers\n- Reader, sidebar, and settings UX work\n- Trim reader rail work and stabilize friends perf\n- Isolate social scraper webkit stores\n- Gate startup social scraper pressure\n- Recycle blocked scraper windows\n- Reserve scraper memory headroom\n- Slim desktop e2e gates\n- Keep memory-blocked scrapes from holding the shared scraper slot\n- Continue passive soak metrics until Apple Events authorization is restored for active UI driving\n- Treat Settings scroll as the next measured performance surface because it remains the largest budget miss\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+  "releaseBody": "(AI Generated).\n\n## Freed v26.5.1108-dev\n\nGoogle sync, Story wall, Friends motion, and scraper pressure improve\n\n### Features\n\n- Story wall publishing\n\n### Fixes\n\n- Skips hidden Friends provider labels during graph motion\n- Gates social scrapes before session slots are reserved\n- Gates social scrapes on resident WebKit memory pressure\n- Completes Google Contacts sync in Freed Desktop\n- Shares native Google OAuth credentials between Drive and Contacts refresh\n- Keeps dense Map focused markers visible during movement\n- Retries the Friends last-seen route commit when the store reaches Map before the full Map surface mounts\n- Lightens Settings moving chrome while the dialog is in motion\n- Keeps Friends graph sync errors recoverable\n- Reports throttled renderer heartbeats with clearer context\n- Surfaces Google OAuth and People API failure details in Settings instead of generic load errors\n\n### Follow-ups\n\n- Keep memory-blocked scrapes from holding the shared scraper slot\n- Friends navigation recovers from late Map mounting\n- Continue monitoring Friends to Map handoffs under installed dev builds\n- Friends navigation and dense Map movement get steadier\n- Continue reducing Settings scroll overdraw in installed dev builds\n- Friends recovery and renderer health reporting improve\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
 }

--- a/release-notes/releases/v26.5.1108-dev.md
+++ b/release-notes/releases/v26.5.1108-dev.md
@@ -2,46 +2,34 @@
 
 ## Freed v26.5.1108-dev
 
-Google OAuth now runs natively in Freed Desktop, Friends graph motion stays lighter, Settings and Map stay smoother, and social scraping respects tighter memory backpressure
+Google sync, Story wall, Friends motion, and scraper pressure improve
 
 ### Features
 
 - Story wall publishing
-- AI ranked friend suggestions
-- Support Friends graph pinch zoom
 
 ### Fixes
 
-- Skip hidden Friends provider labels during graph motion
-- Gate scraper memory before session slots
-- Gate social scrapes on resident WebKit memory
-- Complete Google Contacts sync in Freed Desktop
-- Share native Google OAuth credentials between Drive and Contacts refresh
-- Surface Google OAuth and People API failure details in Settings instead of generic load errors
-- Reader, feed, and header polish
-- Keep friends graph sync errors recoverable
-- Test coverage and performance hardening
-- Release build and type-safety cleanup
-- Route Google Drive through native sync requests
-- Capture and scraper reliability fixes
-- Open the full Map from Friends detail with one atomic store update
+- Skips hidden Friends provider labels during graph motion
+- Gates social scrapes before session slots are reserved
+- Gates social scrapes on resident WebKit memory pressure
+- Completes Google Contacts sync in Freed Desktop
+- Shares native Google OAuth credentials between Drive and Contacts refresh
+- Keeps dense Map focused markers visible during movement
+- Retries the Friends last-seen route commit when the store reaches Map before the full Map surface mounts
+- Lightens Settings moving chrome while the dialog is in motion
+- Keeps Friends graph sync errors recoverable
+- Reports throttled renderer heartbeats with clearer context
+- Surfaces Google OAuth and People API failure details in Settings instead of generic load errors
 
 ### Follow-ups
 
-- Lighten settings moving chrome
-- Reduce dense map movement paint
-- Reduce settings scroll overdraw
-- Friends relationship tiers
-- Reader, sidebar, and settings UX work
-- Trim reader rail work and stabilize friends perf
-- Isolate social scraper webkit stores
-- Gate startup social scraper pressure
-- Recycle blocked scraper windows
-- Reserve scraper memory headroom
-- Slim desktop e2e gates
 - Keep memory-blocked scrapes from holding the shared scraper slot
-- Continue passive soak metrics until Apple Events authorization is restored for active UI driving
-- Treat Settings scroll as the next measured performance surface because it remains the largest budget miss
+- Friends navigation recovers from late Map mounting
+- Continue monitoring Friends to Map handoffs under installed dev builds
+- Friends navigation and dense Map movement get steadier
+- Continue reducing Settings scroll overdraw in installed dev builds
+- Friends recovery and renderer health reporting improve
 
 ### Downloads
 

--- a/release-notes/releases/v26.5.1109-dev.json
+++ b/release-notes/releases/v26.5.1109-dev.json
@@ -78,44 +78,32 @@
     ]
   },
   "release": {
-    "deck": "Google OAuth now runs natively in Freed Desktop, Friends graph motion stays lighter, Settings and Map stay smoother, and social scraping uses stricter resident memory backpressure",
+    "deck": "Google sync, Story wall, Friends motion, and scraper memory budgets improve",
     "features": [
-      "Story wall publishing",
-      "AI ranked friend suggestions",
-      "Support Friends graph pinch zoom"
+      "Story wall publishing"
     ],
     "fixes": [
-      "Tighten social scraper resident memory start budget",
-      "Skip hidden Friends provider labels during graph motion",
-      "Gate scraper memory before session slots",
-      "Gate social scrapes on resident WebKit memory",
-      "Complete Google Contacts sync in Freed Desktop",
-      "Share native Google OAuth credentials between Drive and Contacts refresh",
-      "Surface Google OAuth and People API failure details in Settings instead of generic load errors",
-      "Reader, feed, and header polish",
-      "Keep friends graph sync errors recoverable",
-      "Test coverage and performance hardening",
-      "Release build and type-safety cleanup",
-      "Route Google Drive through native sync requests",
-      "Capture and scraper reliability fixes",
-      "Open the full Map from Friends detail with one atomic store update"
+      "Tightens the social scraper resident memory start budget",
+      "Skips hidden Friends provider labels during graph motion",
+      "Gates social scrapes before session slots are reserved",
+      "Completes Google Contacts sync in Freed Desktop",
+      "Shares native Google OAuth credentials between Drive and Contacts refresh",
+      "Keeps dense Map focused markers visible during movement",
+      "Retries the Friends last-seen route commit when the store reaches Map before the full Map surface mounts",
+      "Lightens Settings moving chrome while the dialog is in motion",
+      "Keeps Friends graph sync errors recoverable",
+      "Reports throttled renderer heartbeats with clearer context",
+      "Surfaces Google OAuth and People API failure details in Settings instead of generic load errors",
+      "Gates social scrapes on resident WebKit memory pressure"
     ],
     "followUps": [
-      "Lighten settings moving chrome",
-      "Reduce dense map movement paint",
-      "Reduce settings scroll overdraw",
-      "Friends relationship tiers",
-      "Reader, sidebar, and settings UX work",
-      "Trim reader rail work and stabilize friends perf",
-      "Isolate social scraper webkit stores",
-      "Gate startup social scraper pressure",
-      "Recycle blocked scraper windows",
-      "Reserve scraper memory headroom",
-      "Slim desktop e2e gates",
       "Keep memory-blocked scrapes from holding the shared scraper slot",
-      "Continue passive soak metrics until Apple Events authorization is restored for active UI driving",
-      "Treat Settings scroll as the next measured performance surface because it remains the largest budget miss"
+      "Friends navigation recovers from late Map mounting",
+      "Continue monitoring Friends to Map handoffs under installed dev builds",
+      "Friends navigation and dense Map movement get steadier",
+      "Continue reducing Settings scroll overdraw in installed dev builds",
+      "Friends recovery and renderer health reporting improve"
     ]
   },
-  "releaseBody": "(AI Generated).\n\n## Freed v26.5.1109-dev\n\nGoogle OAuth now runs natively in Freed Desktop, Friends graph motion stays lighter, Settings and Map stay smoother, and social scraping uses stricter resident memory backpressure\n\n### Features\n\n- Story wall publishing\n- AI ranked friend suggestions\n- Support Friends graph pinch zoom\n\n### Fixes\n\n- Tighten social scraper resident memory start budget\n- Skip hidden Friends provider labels during graph motion\n- Gate scraper memory before session slots\n- Gate social scrapes on resident WebKit memory\n- Complete Google Contacts sync in Freed Desktop\n- Share native Google OAuth credentials between Drive and Contacts refresh\n- Surface Google OAuth and People API failure details in Settings instead of generic load errors\n- Reader, feed, and header polish\n- Keep friends graph sync errors recoverable\n- Test coverage and performance hardening\n- Release build and type-safety cleanup\n- Route Google Drive through native sync requests\n- Capture and scraper reliability fixes\n- Open the full Map from Friends detail with one atomic store update\n\n### Follow-ups\n\n- Lighten settings moving chrome\n- Reduce dense map movement paint\n- Reduce settings scroll overdraw\n- Friends relationship tiers\n- Reader, sidebar, and settings UX work\n- Trim reader rail work and stabilize friends perf\n- Isolate social scraper webkit stores\n- Gate startup social scraper pressure\n- Recycle blocked scraper windows\n- Reserve scraper memory headroom\n- Slim desktop e2e gates\n- Keep memory-blocked scrapes from holding the shared scraper slot\n- Continue passive soak metrics until Apple Events authorization is restored for active UI driving\n- Treat Settings scroll as the next measured performance surface because it remains the largest budget miss\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+  "releaseBody": "(AI Generated).\n\n## Freed v26.5.1109-dev\n\nGoogle sync, Story wall, Friends motion, and scraper memory budgets improve\n\n### Features\n\n- Story wall publishing\n\n### Fixes\n\n- Tightens the social scraper resident memory start budget\n- Skips hidden Friends provider labels during graph motion\n- Gates social scrapes before session slots are reserved\n- Completes Google Contacts sync in Freed Desktop\n- Shares native Google OAuth credentials between Drive and Contacts refresh\n- Keeps dense Map focused markers visible during movement\n- Retries the Friends last-seen route commit when the store reaches Map before the full Map surface mounts\n- Lightens Settings moving chrome while the dialog is in motion\n- Keeps Friends graph sync errors recoverable\n- Reports throttled renderer heartbeats with clearer context\n- Surfaces Google OAuth and People API failure details in Settings instead of generic load errors\n- Gates social scrapes on resident WebKit memory pressure\n\n### Follow-ups\n\n- Keep memory-blocked scrapes from holding the shared scraper slot\n- Friends navigation recovers from late Map mounting\n- Continue monitoring Friends to Map handoffs under installed dev builds\n- Friends navigation and dense Map movement get steadier\n- Continue reducing Settings scroll overdraw in installed dev builds\n- Friends recovery and renderer health reporting improve\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
 }

--- a/release-notes/releases/v26.5.1109-dev.md
+++ b/release-notes/releases/v26.5.1109-dev.md
@@ -2,47 +2,35 @@
 
 ## Freed v26.5.1109-dev
 
-Google OAuth now runs natively in Freed Desktop, Friends graph motion stays lighter, Settings and Map stay smoother, and social scraping uses stricter resident memory backpressure
+Google sync, Story wall, Friends motion, and scraper memory budgets improve
 
 ### Features
 
 - Story wall publishing
-- AI ranked friend suggestions
-- Support Friends graph pinch zoom
 
 ### Fixes
 
-- Tighten social scraper resident memory start budget
-- Skip hidden Friends provider labels during graph motion
-- Gate scraper memory before session slots
-- Gate social scrapes on resident WebKit memory
-- Complete Google Contacts sync in Freed Desktop
-- Share native Google OAuth credentials between Drive and Contacts refresh
-- Surface Google OAuth and People API failure details in Settings instead of generic load errors
-- Reader, feed, and header polish
-- Keep friends graph sync errors recoverable
-- Test coverage and performance hardening
-- Release build and type-safety cleanup
-- Route Google Drive through native sync requests
-- Capture and scraper reliability fixes
-- Open the full Map from Friends detail with one atomic store update
+- Tightens the social scraper resident memory start budget
+- Skips hidden Friends provider labels during graph motion
+- Gates social scrapes before session slots are reserved
+- Completes Google Contacts sync in Freed Desktop
+- Shares native Google OAuth credentials between Drive and Contacts refresh
+- Keeps dense Map focused markers visible during movement
+- Retries the Friends last-seen route commit when the store reaches Map before the full Map surface mounts
+- Lightens Settings moving chrome while the dialog is in motion
+- Keeps Friends graph sync errors recoverable
+- Reports throttled renderer heartbeats with clearer context
+- Surfaces Google OAuth and People API failure details in Settings instead of generic load errors
+- Gates social scrapes on resident WebKit memory pressure
 
 ### Follow-ups
 
-- Lighten settings moving chrome
-- Reduce dense map movement paint
-- Reduce settings scroll overdraw
-- Friends relationship tiers
-- Reader, sidebar, and settings UX work
-- Trim reader rail work and stabilize friends perf
-- Isolate social scraper webkit stores
-- Gate startup social scraper pressure
-- Recycle blocked scraper windows
-- Reserve scraper memory headroom
-- Slim desktop e2e gates
 - Keep memory-blocked scrapes from holding the shared scraper slot
-- Continue passive soak metrics until Apple Events authorization is restored for active UI driving
-- Treat Settings scroll as the next measured performance surface because it remains the largest budget miss
+- Friends navigation recovers from late Map mounting
+- Continue monitoring Friends to Map handoffs under installed dev builds
+- Friends navigation and dense Map movement get steadier
+- Continue reducing Settings scroll overdraw in installed dev builds
+- Friends recovery and renderer health reporting improve
 
 ### Downloads
 

--- a/release-notes/releases/v26.5.1110-dev.json
+++ b/release-notes/releases/v26.5.1110-dev.json
@@ -82,45 +82,33 @@
     ]
   },
   "release": {
-    "deck": "Google OAuth now runs natively in Freed Desktop, Friends graph motion stays lighter, Settings and Map stay smoother, and background story checks back off sooner under high memory",
+    "deck": "Google sync, Story wall, Friends motion, and story checks handle high memory better",
     "features": [
-      "Story wall publishing",
-      "AI ranked friend suggestions",
-      "Support Friends graph pinch zoom"
+      "Story wall publishing"
     ],
     "fixes": [
-      "Gate optional story scraping on resident memory pressure",
-      "Tighten social scraper resident memory start budget",
-      "Skip hidden Friends provider labels during graph motion",
-      "Gate scraper memory before session slots",
-      "Gate social scrapes on resident WebKit memory",
-      "Complete Google Contacts sync in Freed Desktop",
-      "Share native Google OAuth credentials between Drive and Contacts refresh",
-      "Surface Google OAuth and People API failure details in Settings instead of generic load errors",
-      "Reader, feed, and header polish",
-      "Keep friends graph sync errors recoverable",
-      "Test coverage and performance hardening",
-      "Release build and type-safety cleanup",
-      "Route Google Drive through native sync requests",
-      "Capture and scraper reliability fixes",
-      "Open the full Map from Friends detail with one atomic store update"
+      "Gates optional story scraping on resident memory pressure",
+      "Tightens the social scraper resident memory start budget",
+      "Skips hidden Friends provider labels during graph motion",
+      "Gates social scrapes before session slots are reserved",
+      "Completes Google Contacts sync in Freed Desktop",
+      "Shares native Google OAuth credentials between Drive and Contacts refresh",
+      "Retries the Friends last-seen route commit when the store reaches Map before the full Map surface mounts",
+      "Paints fewer primary markers during dense Map pan and zoom movement",
+      "Lightens Settings moving chrome while the dialog is in motion",
+      "Keeps Friends graph sync errors recoverable",
+      "Reports throttled renderer heartbeats with clearer context",
+      "Surfaces Google OAuth and People API failure details in Settings instead of generic load errors",
+      "Gates social scrapes on resident WebKit memory pressure"
     ],
     "followUps": [
-      "Lighten settings moving chrome",
-      "Reduce dense map movement paint",
-      "Reduce settings scroll overdraw",
-      "Friends relationship tiers",
-      "Reader, sidebar, and settings UX work",
-      "Trim reader rail work and stabilize friends perf",
-      "Isolate social scraper webkit stores",
-      "Gate startup social scraper pressure",
-      "Recycle blocked scraper windows",
-      "Reserve scraper memory headroom",
-      "Slim desktop e2e gates",
       "Keep memory-blocked scrapes from holding the shared scraper slot",
-      "Continue passive soak metrics until Apple Events authorization is restored for active UI driving",
-      "Treat Settings scroll as the next measured performance surface because it remains the largest budget miss"
+      "Friends navigation recovers from late Map mounting",
+      "Continue monitoring Friends to Map handoffs under installed dev builds",
+      "Friends navigation and dense Map movement get steadier",
+      "Continue reducing Settings scroll overdraw in installed dev builds",
+      "Friends recovery and renderer health reporting improve"
     ]
   },
-  "releaseBody": "(AI Generated).\n\n## Freed v26.5.1110-dev\n\nGoogle OAuth now runs natively in Freed Desktop, Friends graph motion stays lighter, Settings and Map stay smoother, and background story checks back off sooner under high memory\n\n### Features\n\n- Story wall publishing\n- AI ranked friend suggestions\n- Support Friends graph pinch zoom\n\n### Fixes\n\n- Gate optional story scraping on resident memory pressure\n- Tighten social scraper resident memory start budget\n- Skip hidden Friends provider labels during graph motion\n- Gate scraper memory before session slots\n- Gate social scrapes on resident WebKit memory\n- Complete Google Contacts sync in Freed Desktop\n- Share native Google OAuth credentials between Drive and Contacts refresh\n- Surface Google OAuth and People API failure details in Settings instead of generic load errors\n- Reader, feed, and header polish\n- Keep friends graph sync errors recoverable\n- Test coverage and performance hardening\n- Release build and type-safety cleanup\n- Route Google Drive through native sync requests\n- Capture and scraper reliability fixes\n- Open the full Map from Friends detail with one atomic store update\n\n### Follow-ups\n\n- Lighten settings moving chrome\n- Reduce dense map movement paint\n- Reduce settings scroll overdraw\n- Friends relationship tiers\n- Reader, sidebar, and settings UX work\n- Trim reader rail work and stabilize friends perf\n- Isolate social scraper webkit stores\n- Gate startup social scraper pressure\n- Recycle blocked scraper windows\n- Reserve scraper memory headroom\n- Slim desktop e2e gates\n- Keep memory-blocked scrapes from holding the shared scraper slot\n- Continue passive soak metrics until Apple Events authorization is restored for active UI driving\n- Treat Settings scroll as the next measured performance surface because it remains the largest budget miss\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+  "releaseBody": "(AI Generated).\n\n## Freed v26.5.1110-dev\n\nGoogle sync, Story wall, Friends motion, and story checks handle high memory better\n\n### Features\n\n- Story wall publishing\n\n### Fixes\n\n- Gates optional story scraping on resident memory pressure\n- Tightens the social scraper resident memory start budget\n- Skips hidden Friends provider labels during graph motion\n- Gates social scrapes before session slots are reserved\n- Completes Google Contacts sync in Freed Desktop\n- Shares native Google OAuth credentials between Drive and Contacts refresh\n- Retries the Friends last-seen route commit when the store reaches Map before the full Map surface mounts\n- Paints fewer primary markers during dense Map pan and zoom movement\n- Lightens Settings moving chrome while the dialog is in motion\n- Keeps Friends graph sync errors recoverable\n- Reports throttled renderer heartbeats with clearer context\n- Surfaces Google OAuth and People API failure details in Settings instead of generic load errors\n- Gates social scrapes on resident WebKit memory pressure\n\n### Follow-ups\n\n- Keep memory-blocked scrapes from holding the shared scraper slot\n- Friends navigation recovers from late Map mounting\n- Continue monitoring Friends to Map handoffs under installed dev builds\n- Friends navigation and dense Map movement get steadier\n- Continue reducing Settings scroll overdraw in installed dev builds\n- Friends recovery and renderer health reporting improve\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
 }

--- a/release-notes/releases/v26.5.1110-dev.md
+++ b/release-notes/releases/v26.5.1110-dev.md
@@ -2,48 +2,36 @@
 
 ## Freed v26.5.1110-dev
 
-Google OAuth now runs natively in Freed Desktop, Friends graph motion stays lighter, Settings and Map stay smoother, and background story checks back off sooner under high memory
+Google sync, Story wall, Friends motion, and story checks handle high memory better
 
 ### Features
 
 - Story wall publishing
-- AI ranked friend suggestions
-- Support Friends graph pinch zoom
 
 ### Fixes
 
-- Gate optional story scraping on resident memory pressure
-- Tighten social scraper resident memory start budget
-- Skip hidden Friends provider labels during graph motion
-- Gate scraper memory before session slots
-- Gate social scrapes on resident WebKit memory
-- Complete Google Contacts sync in Freed Desktop
-- Share native Google OAuth credentials between Drive and Contacts refresh
-- Surface Google OAuth and People API failure details in Settings instead of generic load errors
-- Reader, feed, and header polish
-- Keep friends graph sync errors recoverable
-- Test coverage and performance hardening
-- Release build and type-safety cleanup
-- Route Google Drive through native sync requests
-- Capture and scraper reliability fixes
-- Open the full Map from Friends detail with one atomic store update
+- Gates optional story scraping on resident memory pressure
+- Tightens the social scraper resident memory start budget
+- Skips hidden Friends provider labels during graph motion
+- Gates social scrapes before session slots are reserved
+- Completes Google Contacts sync in Freed Desktop
+- Shares native Google OAuth credentials between Drive and Contacts refresh
+- Retries the Friends last-seen route commit when the store reaches Map before the full Map surface mounts
+- Paints fewer primary markers during dense Map pan and zoom movement
+- Lightens Settings moving chrome while the dialog is in motion
+- Keeps Friends graph sync errors recoverable
+- Reports throttled renderer heartbeats with clearer context
+- Surfaces Google OAuth and People API failure details in Settings instead of generic load errors
+- Gates social scrapes on resident WebKit memory pressure
 
 ### Follow-ups
 
-- Lighten settings moving chrome
-- Reduce dense map movement paint
-- Reduce settings scroll overdraw
-- Friends relationship tiers
-- Reader, sidebar, and settings UX work
-- Trim reader rail work and stabilize friends perf
-- Isolate social scraper webkit stores
-- Gate startup social scraper pressure
-- Recycle blocked scraper windows
-- Reserve scraper memory headroom
-- Slim desktop e2e gates
 - Keep memory-blocked scrapes from holding the shared scraper slot
-- Continue passive soak metrics until Apple Events authorization is restored for active UI driving
-- Treat Settings scroll as the next measured performance surface because it remains the largest budget miss
+- Friends navigation recovers from late Map mounting
+- Continue monitoring Friends to Map handoffs under installed dev builds
+- Friends navigation and dense Map movement get steadier
+- Continue reducing Settings scroll overdraw in installed dev builds
+- Friends recovery and renderer health reporting improve
 
 ### Downloads
 

--- a/release-notes/releases/v26.5.1111-dev.json
+++ b/release-notes/releases/v26.5.1111-dev.json
@@ -86,46 +86,33 @@
     ]
   },
   "release": {
-    "deck": "Google OAuth now runs natively in Freed Desktop, Friends graph motion stays lighter, Settings and Map stay smoother, and runtime memory monitoring separates Freed WebKit from machine-wide totals",
+    "deck": "Google sync, Story wall, scraper gates, and renderer memory reporting improve",
     "features": [
-      "Story wall publishing",
-      "AI ranked friend suggestions",
-      "Support Friends graph pinch zoom"
+      "Story wall publishing"
     ],
     "fixes": [
-      "Report app-scoped native and WebKit memory in renderer heartbeats",
-      "Gate optional story scraping on resident memory pressure",
-      "Tighten social scraper resident memory start budget",
-      "Skip hidden Friends provider labels during graph motion",
-      "Gate scraper memory before session slots",
-      "Gate social scrapes on resident WebKit memory",
-      "Complete Google Contacts sync in Freed Desktop",
-      "Share native Google OAuth credentials between Drive and Contacts refresh",
-      "Surface Google OAuth and People API failure details in Settings instead of generic load errors",
-      "Reader, feed, and header polish",
-      "Keep friends graph sync errors recoverable",
-      "Test coverage and performance hardening",
-      "Release build and type-safety cleanup",
-      "Route Google Drive through native sync requests",
-      "Capture and scraper reliability fixes",
-      "Open the full Map from Friends detail with one atomic store update"
+      "Reports throttled renderer heartbeats clearly and separates Freed WebKit memory from machine-wide totals",
+      "Gates optional story scraping on resident memory pressure",
+      "Tightens the social scraper resident memory start budget",
+      "Skips hidden Friends provider labels during graph motion",
+      "Gates social scrapes before session slots are reserved",
+      "Completes Google Contacts sync in Freed Desktop",
+      "Shares native Google OAuth credentials between Drive and Contacts refresh",
+      "Retries the Friends last-seen route commit when the store reaches Map before the full Map surface mounts",
+      "Paints fewer primary markers during dense Map pan and zoom movement",
+      "Lightens Settings moving chrome while the dialog is in motion",
+      "Keeps Friends graph sync errors recoverable",
+      "Surfaces Google OAuth and People API failure details in Settings instead of generic load errors",
+      "Gates social scrapes on resident WebKit memory pressure"
     ],
     "followUps": [
-      "Lighten settings moving chrome",
-      "Reduce dense map movement paint",
-      "Reduce settings scroll overdraw",
-      "Friends relationship tiers",
-      "Reader, sidebar, and settings UX work",
-      "Trim reader rail work and stabilize friends perf",
-      "Isolate social scraper webkit stores",
-      "Gate startup social scraper pressure",
-      "Recycle blocked scraper windows",
-      "Reserve scraper memory headroom",
-      "Slim desktop e2e gates",
       "Keep memory-blocked scrapes from holding the shared scraper slot",
-      "Continue passive soak metrics until Apple Events authorization is restored for active UI driving",
-      "Treat Settings scroll as the next measured performance surface because it remains the largest budget miss"
+      "Friends navigation recovers from late Map mounting",
+      "Continue monitoring Friends to Map handoffs under installed dev builds",
+      "Friends navigation and dense Map movement get steadier",
+      "Continue reducing Settings scroll overdraw in installed dev builds",
+      "Friends recovery and renderer health reporting improve"
     ]
   },
-  "releaseBody": "(AI Generated).\n\n## Freed v26.5.1111-dev\n\nGoogle OAuth now runs natively in Freed Desktop, Friends graph motion stays lighter, Settings and Map stay smoother, and runtime memory monitoring separates Freed WebKit from machine-wide totals\n\n### Features\n\n- Story wall publishing\n- AI ranked friend suggestions\n- Support Friends graph pinch zoom\n\n### Fixes\n\n- Report app-scoped native and WebKit memory in renderer heartbeats\n- Gate optional story scraping on resident memory pressure\n- Tighten social scraper resident memory start budget\n- Skip hidden Friends provider labels during graph motion\n- Gate scraper memory before session slots\n- Gate social scrapes on resident WebKit memory\n- Complete Google Contacts sync in Freed Desktop\n- Share native Google OAuth credentials between Drive and Contacts refresh\n- Surface Google OAuth and People API failure details in Settings instead of generic load errors\n- Reader, feed, and header polish\n- Keep friends graph sync errors recoverable\n- Test coverage and performance hardening\n- Release build and type-safety cleanup\n- Route Google Drive through native sync requests\n- Capture and scraper reliability fixes\n- Open the full Map from Friends detail with one atomic store update\n\n### Follow-ups\n\n- Lighten settings moving chrome\n- Reduce dense map movement paint\n- Reduce settings scroll overdraw\n- Friends relationship tiers\n- Reader, sidebar, and settings UX work\n- Trim reader rail work and stabilize friends perf\n- Isolate social scraper webkit stores\n- Gate startup social scraper pressure\n- Recycle blocked scraper windows\n- Reserve scraper memory headroom\n- Slim desktop e2e gates\n- Keep memory-blocked scrapes from holding the shared scraper slot\n- Continue passive soak metrics until Apple Events authorization is restored for active UI driving\n- Treat Settings scroll as the next measured performance surface because it remains the largest budget miss\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+  "releaseBody": "(AI Generated).\n\n## Freed v26.5.1111-dev\n\nGoogle sync, Story wall, scraper gates, and renderer memory reporting improve\n\n### Features\n\n- Story wall publishing\n\n### Fixes\n\n- Reports throttled renderer heartbeats clearly and separates Freed WebKit memory from machine-wide totals\n- Gates optional story scraping on resident memory pressure\n- Tightens the social scraper resident memory start budget\n- Skips hidden Friends provider labels during graph motion\n- Gates social scrapes before session slots are reserved\n- Completes Google Contacts sync in Freed Desktop\n- Shares native Google OAuth credentials between Drive and Contacts refresh\n- Retries the Friends last-seen route commit when the store reaches Map before the full Map surface mounts\n- Paints fewer primary markers during dense Map pan and zoom movement\n- Lightens Settings moving chrome while the dialog is in motion\n- Keeps Friends graph sync errors recoverable\n- Surfaces Google OAuth and People API failure details in Settings instead of generic load errors\n- Gates social scrapes on resident WebKit memory pressure\n\n### Follow-ups\n\n- Keep memory-blocked scrapes from holding the shared scraper slot\n- Friends navigation recovers from late Map mounting\n- Continue monitoring Friends to Map handoffs under installed dev builds\n- Friends navigation and dense Map movement get steadier\n- Continue reducing Settings scroll overdraw in installed dev builds\n- Friends recovery and renderer health reporting improve\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
 }

--- a/release-notes/releases/v26.5.1111-dev.md
+++ b/release-notes/releases/v26.5.1111-dev.md
@@ -2,49 +2,36 @@
 
 ## Freed v26.5.1111-dev
 
-Google OAuth now runs natively in Freed Desktop, Friends graph motion stays lighter, Settings and Map stay smoother, and runtime memory monitoring separates Freed WebKit from machine-wide totals
+Google sync, Story wall, scraper gates, and renderer memory reporting improve
 
 ### Features
 
 - Story wall publishing
-- AI ranked friend suggestions
-- Support Friends graph pinch zoom
 
 ### Fixes
 
-- Report app-scoped native and WebKit memory in renderer heartbeats
-- Gate optional story scraping on resident memory pressure
-- Tighten social scraper resident memory start budget
-- Skip hidden Friends provider labels during graph motion
-- Gate scraper memory before session slots
-- Gate social scrapes on resident WebKit memory
-- Complete Google Contacts sync in Freed Desktop
-- Share native Google OAuth credentials between Drive and Contacts refresh
-- Surface Google OAuth and People API failure details in Settings instead of generic load errors
-- Reader, feed, and header polish
-- Keep friends graph sync errors recoverable
-- Test coverage and performance hardening
-- Release build and type-safety cleanup
-- Route Google Drive through native sync requests
-- Capture and scraper reliability fixes
-- Open the full Map from Friends detail with one atomic store update
+- Reports throttled renderer heartbeats clearly and separates Freed WebKit memory from machine-wide totals
+- Gates optional story scraping on resident memory pressure
+- Tightens the social scraper resident memory start budget
+- Skips hidden Friends provider labels during graph motion
+- Gates social scrapes before session slots are reserved
+- Completes Google Contacts sync in Freed Desktop
+- Shares native Google OAuth credentials between Drive and Contacts refresh
+- Retries the Friends last-seen route commit when the store reaches Map before the full Map surface mounts
+- Paints fewer primary markers during dense Map pan and zoom movement
+- Lightens Settings moving chrome while the dialog is in motion
+- Keeps Friends graph sync errors recoverable
+- Surfaces Google OAuth and People API failure details in Settings instead of generic load errors
+- Gates social scrapes on resident WebKit memory pressure
 
 ### Follow-ups
 
-- Lighten settings moving chrome
-- Reduce dense map movement paint
-- Reduce settings scroll overdraw
-- Friends relationship tiers
-- Reader, sidebar, and settings UX work
-- Trim reader rail work and stabilize friends perf
-- Isolate social scraper webkit stores
-- Gate startup social scraper pressure
-- Recycle blocked scraper windows
-- Reserve scraper memory headroom
-- Slim desktop e2e gates
 - Keep memory-blocked scrapes from holding the shared scraper slot
-- Continue passive soak metrics until Apple Events authorization is restored for active UI driving
-- Treat Settings scroll as the next measured performance surface because it remains the largest budget miss
+- Friends navigation recovers from late Map mounting
+- Continue monitoring Friends to Map handoffs under installed dev builds
+- Friends navigation and dense Map movement get steadier
+- Continue reducing Settings scroll overdraw in installed dev builds
+- Friends recovery and renderer health reporting improve
 
 ### Downloads
 

--- a/release-notes/releases/v26.5.1112-dev.json
+++ b/release-notes/releases/v26.5.1112-dev.json
@@ -90,43 +90,32 @@
     ]
   },
   "release": {
-    "deck": "Google OAuth runs natively in Freed Desktop, Story wall publishing lands, scraper memory gates tighten, and dense Map motion stays inside the frame budget",
+    "deck": "Google sync, Story wall, scraper gates, and dense Map movement improve",
     "features": [
       "Story wall publishing"
     ],
     "fixes": [
-      "Reduce dense Map motion paint during pan and zoom",
-      "Report app-scoped native and WebKit memory in renderer heartbeats",
-      "Gate optional story scraping on resident memory pressure",
-      "Tighten social scraper resident memory start budget",
-      "Skip hidden Friends provider labels during graph motion",
-      "Gate scraper memory before session slots",
-      "Gate social scrapes on resident WebKit memory",
-      "Complete Google Contacts sync in Freed Desktop",
-      "Share native Google OAuth credentials between Drive and Contacts refresh",
-      "Surface Google OAuth and People API failure details in Settings instead of generic load errors",
-      "Reader, feed, and header polish",
-      "Keep friends graph sync errors recoverable",
-      "Test coverage and performance hardening",
-      "Release build and type-safety cleanup",
-      "Route Google Drive through native sync requests",
-      "Capture and scraper reliability fixes",
-      "Open the full Map from Friends detail with one atomic store update"
+      "Completes Google Contacts sync in Freed Desktop",
+      "Shares native Google OAuth credentials between Drive and Contacts refresh",
+      "Surfaces Google OAuth and People API failure details in Settings instead of generic load errors",
+      "Keeps dense Map focused markers visible during movement",
+      "Keeps Friends graph sync errors recoverable",
+      "Reports throttled renderer heartbeats clearly and separates Freed WebKit memory from machine-wide totals",
+      "Gates social scrapes, session slots, and optional story checks on resident memory pressure",
+      "Keeps dense Map motion inside the frame budget",
+      "Skips hidden Friends provider labels during graph motion",
+      "Retries the Friends last-seen route commit when the store reaches Map before the full Map surface mounts",
+      "Lightens Settings moving chrome while the dialog is in motion",
+      "Tightens the social scraper resident memory start budget"
     ],
     "followUps": [
-      "Lighten settings moving chrome",
-      "Reduce settings scroll overdraw",
-      "Reader, sidebar, and settings UX work",
-      "Trim reader rail work and stabilize friends perf",
-      "Isolate social scraper webkit stores",
-      "Gate startup social scraper pressure",
-      "Recycle blocked scraper windows",
-      "Reserve scraper memory headroom",
-      "Slim desktop e2e gates",
-      "Keep memory-blocked scrapes from holding the shared scraper slot",
-      "Continue passive soak metrics until Apple Events authorization is restored for active UI driving",
-      "Treat Settings scroll as the next measured performance surface because it remains the largest budget miss"
+      "Continue monitoring Settings scroll and scraper memory pressure under installed dev builds",
+      "Friends navigation recovers from late Map mounting",
+      "Friends navigation and dense Map movement get steadier",
+      "Continue monitoring Friends to Map handoffs and dense Map movement under installed dev builds",
+      "Friends recovery and renderer health reporting improve",
+      "Keep memory-blocked scrapes from holding the shared scraper slot"
     ]
   },
-  "releaseBody": "(AI Generated).\n\n## Freed v26.5.1112-dev\n\nGoogle OAuth runs natively in Freed Desktop, Story wall publishing lands, scraper memory gates tighten, and dense Map motion stays inside the frame budget\n\n### Features\n\n- Story wall publishing\n\n### Fixes\n\n- Reader, feed, and header polish\n- Capture and scraper reliability fixes\n- Complete Google Contacts sync in Freed Desktop\n- Keep friends graph sync errors recoverable\n- Test coverage and performance hardening\n- Release build and type-safety cleanup\n- Route Google Drive through native sync requests\n- Open the full Map from Friends detail with one atomic store update\n\n### Follow-ups\n\n- Lighten settings moving chrome\n- Reduce settings scroll overdraw\n- Reader, sidebar, and settings UX work\n- Trim reader rail work and stabilize friends perf\n- Isolate social scraper webkit stores\n- Gate startup social scraper pressure\n- Recycle blocked scraper windows\n- Reserve scraper memory headroom\n- Slim desktop e2e gates\n- Keep memory-blocked scrapes from holding the shared scraper slot\n- Continue passive soak metrics until Apple Events authorization is restored for active UI driving\n- Treat Settings scroll as the next measured performance surface because it remains the largest budget miss\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+  "releaseBody": "(AI Generated).\n\n## Freed v26.5.1112-dev\n\nGoogle sync, Story wall, scraper gates, and dense Map movement improve\n\n### Features\n\n- Story wall publishing\n\n### Fixes\n\n- Completes Google Contacts sync in Freed Desktop\n- Shares native Google OAuth credentials between Drive and Contacts refresh\n- Surfaces Google OAuth and People API failure details in Settings instead of generic load errors\n- Keeps dense Map focused markers visible during movement\n- Keeps Friends graph sync errors recoverable\n- Reports throttled renderer heartbeats clearly and separates Freed WebKit memory from machine-wide totals\n- Gates social scrapes, session slots, and optional story checks on resident memory pressure\n- Keeps dense Map motion inside the frame budget\n- Skips hidden Friends provider labels during graph motion\n- Retries the Friends last-seen route commit when the store reaches Map before the full Map surface mounts\n- Lightens Settings moving chrome while the dialog is in motion\n- Tightens the social scraper resident memory start budget\n\n### Follow-ups\n\n- Continue monitoring Settings scroll and scraper memory pressure under installed dev builds\n- Friends navigation recovers from late Map mounting\n- Friends navigation and dense Map movement get steadier\n- Continue monitoring Friends to Map handoffs and dense Map movement under installed dev builds\n- Friends recovery and renderer health reporting improve\n- Keep memory-blocked scrapes from holding the shared scraper slot\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
 }

--- a/release-notes/releases/v26.5.1112-dev.json
+++ b/release-notes/releases/v26.5.1112-dev.json
@@ -90,11 +90,9 @@
     ]
   },
   "release": {
-    "deck": "Google OAuth now runs natively in Freed Desktop, Friends graph motion stays lighter, Settings and Map stay smoother, runtime memory monitoring separates Freed WebKit from machine-wide totals, and dense Map motion now stays inside the frame budget",
+    "deck": "Google OAuth runs natively in Freed Desktop, Story wall publishing lands, scraper memory gates tighten, and dense Map motion stays inside the frame budget",
     "features": [
-      "Story wall publishing",
-      "AI ranked friend suggestions",
-      "Support Friends graph pinch zoom"
+      "Story wall publishing"
     ],
     "fixes": [
       "Reduce dense Map motion paint during pan and zoom",
@@ -118,7 +116,6 @@
     "followUps": [
       "Lighten settings moving chrome",
       "Reduce settings scroll overdraw",
-      "Friends relationship tiers",
       "Reader, sidebar, and settings UX work",
       "Trim reader rail work and stabilize friends perf",
       "Isolate social scraper webkit stores",
@@ -131,5 +128,5 @@
       "Treat Settings scroll as the next measured performance surface because it remains the largest budget miss"
     ]
   },
-  "releaseBody": "(AI Generated).\n\n## Freed 26.5.1112-dev\n\nGoogle OAuth now runs natively in Freed Desktop, Friends graph motion stays lighter, Settings and Map stay smoother, runtime memory monitoring separates Freed WebKit from machine-wide totals, and dense Map motion now stays inside the frame budget\n\n### Features\n\n- Story wall publishing\n- AI ranked friend suggestions\n- Support Friends graph pinch zoom\n\n### Fixes\n\n- Reduce dense Map motion paint during pan and zoom\n- Report app-scoped native and WebKit memory in renderer heartbeats\n- Gate optional story scraping on resident memory pressure\n- Tighten social scraper resident memory start budget\n- Skip hidden Friends provider labels during graph motion\n- Gate scraper memory before session slots\n- Gate social scrapes on resident WebKit memory\n- Complete Google Contacts sync in Freed Desktop\n- Share native Google OAuth credentials between Drive and Contacts refresh\n- Surface Google OAuth and People API failure details in Settings instead of generic load errors\n- Reader, feed, and header polish\n- Keep friends graph sync errors recoverable\n- Test coverage and performance hardening\n- Release build and type-safety cleanup\n- Route Google Drive through native sync requests\n- Capture and scraper reliability fixes\n- Open the full Map from Friends detail with one atomic store update\n\n### Follow-ups\n\n- Lighten settings moving chrome\n- Reduce settings scroll overdraw\n- Friends relationship tiers\n- Reader, sidebar, and settings UX work\n- Trim reader rail work and stabilize friends perf\n- Isolate social scraper webkit stores\n- Gate startup social scraper pressure\n- Recycle blocked scraper windows\n- Reserve scraper memory headroom\n- Slim desktop e2e gates\n- Keep memory-blocked scrapes from holding the shared scraper slot\n- Continue passive soak metrics until Apple Events authorization is restored for active UI driving\n- Treat Settings scroll as the next measured performance surface because it remains the largest budget miss\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+  "releaseBody": "(AI Generated).\n\n## Freed v26.5.1112-dev\n\nGoogle OAuth runs natively in Freed Desktop, Story wall publishing lands, scraper memory gates tighten, and dense Map motion stays inside the frame budget\n\n### Features\n\n- Story wall publishing\n\n### Fixes\n\n- Reader, feed, and header polish\n- Capture and scraper reliability fixes\n- Complete Google Contacts sync in Freed Desktop\n- Keep friends graph sync errors recoverable\n- Test coverage and performance hardening\n- Release build and type-safety cleanup\n- Route Google Drive through native sync requests\n- Open the full Map from Friends detail with one atomic store update\n\n### Follow-ups\n\n- Lighten settings moving chrome\n- Reduce settings scroll overdraw\n- Reader, sidebar, and settings UX work\n- Trim reader rail work and stabilize friends perf\n- Isolate social scraper webkit stores\n- Gate startup social scraper pressure\n- Recycle blocked scraper windows\n- Reserve scraper memory headroom\n- Slim desktop e2e gates\n- Keep memory-blocked scrapes from holding the shared scraper slot\n- Continue passive soak metrics until Apple Events authorization is restored for active UI driving\n- Treat Settings scroll as the next measured performance surface because it remains the largest budget miss\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
 }

--- a/release-notes/releases/v26.5.1112-dev.md
+++ b/release-notes/releases/v26.5.1112-dev.md
@@ -2,7 +2,7 @@
 
 ## Freed v26.5.1112-dev
 
-Google OAuth runs natively in Freed Desktop, Story wall publishing lands, scraper memory gates tighten, and dense Map motion stays inside the frame budget
+Google sync, Story wall, scraper gates, and dense Map movement improve
 
 ### Features
 
@@ -10,29 +10,27 @@ Google OAuth runs natively in Freed Desktop, Story wall publishing lands, scrape
 
 ### Fixes
 
-- Reader, feed, and header polish
-- Capture and scraper reliability fixes
-- Complete Google Contacts sync in Freed Desktop
-- Keep friends graph sync errors recoverable
-- Test coverage and performance hardening
-- Release build and type-safety cleanup
-- Route Google Drive through native sync requests
-- Open the full Map from Friends detail with one atomic store update
+- Completes Google Contacts sync in Freed Desktop
+- Shares native Google OAuth credentials between Drive and Contacts refresh
+- Surfaces Google OAuth and People API failure details in Settings instead of generic load errors
+- Keeps dense Map focused markers visible during movement
+- Keeps Friends graph sync errors recoverable
+- Reports throttled renderer heartbeats clearly and separates Freed WebKit memory from machine-wide totals
+- Gates social scrapes, session slots, and optional story checks on resident memory pressure
+- Keeps dense Map motion inside the frame budget
+- Skips hidden Friends provider labels during graph motion
+- Retries the Friends last-seen route commit when the store reaches Map before the full Map surface mounts
+- Lightens Settings moving chrome while the dialog is in motion
+- Tightens the social scraper resident memory start budget
 
 ### Follow-ups
 
-- Lighten settings moving chrome
-- Reduce settings scroll overdraw
-- Reader, sidebar, and settings UX work
-- Trim reader rail work and stabilize friends perf
-- Isolate social scraper webkit stores
-- Gate startup social scraper pressure
-- Recycle blocked scraper windows
-- Reserve scraper memory headroom
-- Slim desktop e2e gates
+- Continue monitoring Settings scroll and scraper memory pressure under installed dev builds
+- Friends navigation recovers from late Map mounting
+- Friends navigation and dense Map movement get steadier
+- Continue monitoring Friends to Map handoffs and dense Map movement under installed dev builds
+- Friends recovery and renderer health reporting improve
 - Keep memory-blocked scrapes from holding the shared scraper slot
-- Continue passive soak metrics until Apple Events authorization is restored for active UI driving
-- Treat Settings scroll as the next measured performance surface because it remains the largest budget miss
 
 ### Downloads
 

--- a/release-notes/releases/v26.5.1112-dev.md
+++ b/release-notes/releases/v26.5.1112-dev.md
@@ -1,40 +1,28 @@
 (AI Generated).
 
-## Freed 26.5.1112-dev
+## Freed v26.5.1112-dev
 
-Google OAuth now runs natively in Freed Desktop, Friends graph motion stays lighter, Settings and Map stay smoother, runtime memory monitoring separates Freed WebKit from machine-wide totals, and dense Map motion now stays inside the frame budget
+Google OAuth runs natively in Freed Desktop, Story wall publishing lands, scraper memory gates tighten, and dense Map motion stays inside the frame budget
 
 ### Features
 
 - Story wall publishing
-- AI ranked friend suggestions
-- Support Friends graph pinch zoom
 
 ### Fixes
 
-- Reduce dense Map motion paint during pan and zoom
-- Report app-scoped native and WebKit memory in renderer heartbeats
-- Gate optional story scraping on resident memory pressure
-- Tighten social scraper resident memory start budget
-- Skip hidden Friends provider labels during graph motion
-- Gate scraper memory before session slots
-- Gate social scrapes on resident WebKit memory
-- Complete Google Contacts sync in Freed Desktop
-- Share native Google OAuth credentials between Drive and Contacts refresh
-- Surface Google OAuth and People API failure details in Settings instead of generic load errors
 - Reader, feed, and header polish
+- Capture and scraper reliability fixes
+- Complete Google Contacts sync in Freed Desktop
 - Keep friends graph sync errors recoverable
 - Test coverage and performance hardening
 - Release build and type-safety cleanup
 - Route Google Drive through native sync requests
-- Capture and scraper reliability fixes
 - Open the full Map from Friends detail with one atomic store update
 
 ### Follow-ups
 
 - Lighten settings moving chrome
 - Reduce settings scroll overdraw
-- Friends relationship tiers
 - Reader, sidebar, and settings UX work
 - Trim reader rail work and stabilize friends perf
 - Isolate social scraper webkit stores

--- a/release-notes/releases/v26.5.1200-dev.json
+++ b/release-notes/releases/v26.5.1200-dev.json
@@ -27,48 +27,12 @@
     ]
   },
   "release": {
-    "deck": "Google OAuth now runs natively in Freed Desktop, Friends graph motion stays lighter, Settings and Map stay smoother, runtime memory monitoring separates Freed WebKit from machine-wide totals, and dense Map motion now stays inside the frame budget",
-    "features": [
-      "Story wall publishing",
-      "AI ranked friend suggestions",
-      "Support Friends graph pinch zoom"
-    ],
+    "deck": "Dense Friends graph motion stays lighter",
+    "features": [],
     "fixes": [
-      "Keep large Friends graphs responsive by holding active pan and zoom to a stable 160-node paint layer, then refreshing viewport detail after motion settles",
-      "Add regression coverage for 1,600-person Friends graphs, including mount time, zoom, pan, scene sync, long tasks, dropped frames, and sidebar row virtualization",
-      "Reduce dense Map motion paint during pan and zoom",
-      "Report app-scoped native and WebKit memory in renderer heartbeats",
-      "Gate optional story scraping on resident memory pressure",
-      "Tighten social scraper resident memory start budget",
-      "Skip hidden Friends provider labels during graph motion",
-      "Gate scraper memory before session slots",
-      "Gate social scrapes on resident WebKit memory",
-      "Complete Google Contacts sync in Freed Desktop",
-      "Share native Google OAuth credentials between Drive and Contacts refresh",
-      "Surface Google OAuth and People API failure details in Settings instead of generic load errors",
-      "Reader, feed, and header polish",
-      "Keep friends graph sync errors recoverable",
-      "Test coverage and performance hardening",
-      "Release build and type-safety cleanup",
-      "Route Google Drive through native sync requests",
-      "Capture and scraper reliability fixes",
-      "Open the full Map from Friends detail with one atomic store update"
+      "Keep large relationship graphs on a smaller 96-node paint layer during active motion before refreshing viewport detail"
     ],
-    "followUps": [
-      "Lighten settings moving chrome",
-      "Reduce settings scroll overdraw",
-      "Friends relationship tiers",
-      "Reader, sidebar, and settings UX work",
-      "Trim reader rail work and stabilize friends perf",
-      "Isolate social scraper webkit stores",
-      "Gate startup social scraper pressure",
-      "Recycle blocked scraper windows",
-      "Reserve scraper memory headroom",
-      "Slim desktop e2e gates",
-      "Keep memory-blocked scrapes from holding the shared scraper slot",
-      "Continue passive soak metrics until Apple Events authorization is restored for active UI driving",
-      "Treat Settings scroll as the next measured performance surface because it remains the largest budget miss"
-    ]
+    "followUps": []
   },
-  "releaseBody": "(AI Generated).\n\n## Freed v26.5.1200-dev\n\nGoogle OAuth now runs natively in Freed Desktop, Friends graph motion stays lighter, Settings and Map stay smoother, runtime memory monitoring separates Freed WebKit from machine-wide totals, and dense Map motion now stays inside the frame budget\n\n### Features\n\n- Story wall publishing\n- AI ranked friend suggestions\n- Support Friends graph pinch zoom\n\n### Fixes\n\n- Keep large Friends graphs responsive by holding active pan and zoom to a stable 160-node paint layer, then refreshing viewport detail after motion settles\n- Add regression coverage for 1,600-person Friends graphs, including mount time, zoom, pan, scene sync, long tasks, dropped frames, and sidebar row virtualization\n- Reduce dense Map motion paint during pan and zoom\n- Report app-scoped native and WebKit memory in renderer heartbeats\n- Gate optional story scraping on resident memory pressure\n- Tighten social scraper resident memory start budget\n- Skip hidden Friends provider labels during graph motion\n- Gate scraper memory before session slots\n- Gate social scrapes on resident WebKit memory\n- Complete Google Contacts sync in Freed Desktop\n- Share native Google OAuth credentials between Drive and Contacts refresh\n- Surface Google OAuth and People API failure details in Settings instead of generic load errors\n- Reader, feed, and header polish\n- Keep friends graph sync errors recoverable\n- Test coverage and performance hardening\n- Release build and type-safety cleanup\n- Route Google Drive through native sync requests\n- Capture and scraper reliability fixes\n- Open the full Map from Friends detail with one atomic store update\n\n### Follow-ups\n\n- Lighten settings moving chrome\n- Reduce settings scroll overdraw\n- Friends relationship tiers\n- Reader, sidebar, and settings UX work\n- Trim reader rail work and stabilize friends perf\n- Isolate social scraper webkit stores\n- Gate startup social scraper pressure\n- Recycle blocked scraper windows\n- Reserve scraper memory headroom\n- Slim desktop e2e gates\n- Keep memory-blocked scrapes from holding the shared scraper slot\n- Continue passive soak metrics until Apple Events authorization is restored for active UI driving\n- Treat Settings scroll as the next measured performance surface because it remains the largest budget miss\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+  "releaseBody": "(AI Generated).\n\n## Freed v26.5.1200-dev\n\nDense Friends graph motion stays lighter\n\n### Fixes\n\n- Keep large relationship graphs on a smaller 96-node paint layer during active motion before refreshing viewport detail\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
 }

--- a/release-notes/releases/v26.5.1200-dev.md
+++ b/release-notes/releases/v26.5.1200-dev.md
@@ -2,51 +2,11 @@
 
 ## Freed v26.5.1200-dev
 
-Google OAuth now runs natively in Freed Desktop, Friends graph motion stays lighter, Settings and Map stay smoother, runtime memory monitoring separates Freed WebKit from machine-wide totals, and dense Map motion now stays inside the frame budget
-
-### Features
-
-- Story wall publishing
-- AI ranked friend suggestions
-- Support Friends graph pinch zoom
+Dense Friends graph motion stays lighter
 
 ### Fixes
 
-- Keep large Friends graphs responsive by holding active pan and zoom to a stable 160-node paint layer, then refreshing viewport detail after motion settles
-- Add regression coverage for 1,600-person Friends graphs, including mount time, zoom, pan, scene sync, long tasks, dropped frames, and sidebar row virtualization
-- Reduce dense Map motion paint during pan and zoom
-- Report app-scoped native and WebKit memory in renderer heartbeats
-- Gate optional story scraping on resident memory pressure
-- Tighten social scraper resident memory start budget
-- Skip hidden Friends provider labels during graph motion
-- Gate scraper memory before session slots
-- Gate social scrapes on resident WebKit memory
-- Complete Google Contacts sync in Freed Desktop
-- Share native Google OAuth credentials between Drive and Contacts refresh
-- Surface Google OAuth and People API failure details in Settings instead of generic load errors
-- Reader, feed, and header polish
-- Keep friends graph sync errors recoverable
-- Test coverage and performance hardening
-- Release build and type-safety cleanup
-- Route Google Drive through native sync requests
-- Capture and scraper reliability fixes
-- Open the full Map from Friends detail with one atomic store update
-
-### Follow-ups
-
-- Lighten settings moving chrome
-- Reduce settings scroll overdraw
-- Friends relationship tiers
-- Reader, sidebar, and settings UX work
-- Trim reader rail work and stabilize friends perf
-- Isolate social scraper webkit stores
-- Gate startup social scraper pressure
-- Recycle blocked scraper windows
-- Reserve scraper memory headroom
-- Slim desktop e2e gates
-- Keep memory-blocked scrapes from holding the shared scraper slot
-- Continue passive soak metrics until Apple Events authorization is restored for active UI driving
-- Treat Settings scroll as the next measured performance surface because it remains the largest budget miss
+- Keep large relationship graphs on a smaller 96-node paint layer during active motion before refreshing viewport detail
 
 ### Downloads
 

--- a/release-notes/releases/v26.5.1201-dev.json
+++ b/release-notes/releases/v26.5.1201-dev.json
@@ -14,9 +14,11 @@
     "compareRef": "HEAD",
     "isLatestOfDay": true,
     "sameDayTagsIncluded": [
+      "v26.5.1200-dev",
       "v26.5.1201-dev"
     ],
     "relatedBuildTags": [
+      "v26.5.1200-dev",
       "v26.5.1201-dev"
     ],
     "prNumbers": [
@@ -31,50 +33,15 @@
     ]
   },
   "release": {
-    "deck": "Google OAuth now runs natively in Freed Desktop, large relationship graphs stay lighter during motion, source filtering allocates less work, Map stays smoother, and runtime memory monitoring separates Freed WebKit from machine-wide totals",
-    "features": [
-      "Story wall publishing",
-      "AI ranked friend suggestions",
-      "Support Friends graph pinch zoom"
-    ],
+    "deck": "Dense Friends graph motion and source filtering stay lighter",
+    "features": [],
     "fixes": [
       "Keep large Friends graphs responsive by holding active pan and zoom to a stable 160-node paint layer, then refreshing viewport detail after motion settles",
       "Add regression coverage for 1,600-person Friends graphs, including mount time, zoom, pan, scene sync, long tasks, dropped frames, and sidebar row virtualization",
-      "Reduce dense Map motion paint during pan and zoom",
-      "Report app-scoped native and WebKit memory in renderer heartbeats",
-      "Gate optional story scraping on resident memory pressure",
-      "Tighten social scraper resident memory start budget",
-      "Skip hidden Friends provider labels during graph motion",
-      "Gate scraper memory before session slots",
-      "Gate social scrapes on resident WebKit memory",
-      "Complete Google Contacts sync in Freed Desktop",
-      "Share native Google OAuth credentials between Drive and Contacts refresh",
-      "Surface Google OAuth and People API failure details in Settings instead of generic load errors",
-      "Reader, feed, and header polish",
-      "Keep friends graph sync errors recoverable",
-      "Test coverage and performance hardening",
-      "Release build and type-safety cleanup",
-      "Route Google Drive through native sync requests",
-      "Capture and scraper reliability fixes",
-      "Open the full Map from Friends detail with one atomic store update",
       "Keep large relationship graphs on a smaller 96-node paint layer during active motion before refreshing viewport detail",
       "Reduce Source sidebar feed search allocation churn for large RSS collections"
     ],
-    "followUps": [
-      "Lighten settings moving chrome",
-      "Reduce settings scroll overdraw",
-      "Friends relationship tiers",
-      "Reader, sidebar, and settings UX work",
-      "Trim reader rail work and stabilize friends perf",
-      "Isolate social scraper webkit stores",
-      "Gate startup social scraper pressure",
-      "Recycle blocked scraper windows",
-      "Reserve scraper memory headroom",
-      "Slim desktop e2e gates",
-      "Keep memory-blocked scrapes from holding the shared scraper slot",
-      "Continue passive soak metrics until Apple Events authorization is restored for active UI driving",
-      "Treat Settings scroll as the next measured performance surface because it remains the largest budget miss"
-    ]
+    "followUps": []
   },
-  "releaseBody": "(AI Generated).\n\n## Freed v26.5.1201-dev\n\nGoogle OAuth now runs natively in Freed Desktop, large relationship graphs stay lighter during motion, source filtering allocates less work, Map stays smoother, and runtime memory monitoring separates Freed WebKit from machine-wide totals\n\n### Features\n\n- Story wall publishing\n- AI ranked friend suggestions\n- Support Friends graph pinch zoom\n\n### Fixes\n\n- Keep large Friends graphs responsive by holding active pan and zoom to a stable 160-node paint layer, then refreshing viewport detail after motion settles\n- Add regression coverage for 1,600-person Friends graphs, including mount time, zoom, pan, scene sync, long tasks, dropped frames, and sidebar row virtualization\n- Reduce dense Map motion paint during pan and zoom\n- Report app-scoped native and WebKit memory in renderer heartbeats\n- Gate optional story scraping on resident memory pressure\n- Tighten social scraper resident memory start budget\n- Skip hidden Friends provider labels during graph motion\n- Gate scraper memory before session slots\n- Gate social scrapes on resident WebKit memory\n- Complete Google Contacts sync in Freed Desktop\n- Share native Google OAuth credentials between Drive and Contacts refresh\n- Surface Google OAuth and People API failure details in Settings instead of generic load errors\n- Reader, feed, and header polish\n- Keep friends graph sync errors recoverable\n- Test coverage and performance hardening\n- Release build and type-safety cleanup\n- Route Google Drive through native sync requests\n- Capture and scraper reliability fixes\n- Open the full Map from Friends detail with one atomic store update\n- Keep large relationship graphs on a smaller 96-node paint layer during active motion before refreshing viewport detail\n- Reduce Source sidebar feed search allocation churn for large RSS collections\n\n### Follow-ups\n\n- Lighten settings moving chrome\n- Reduce settings scroll overdraw\n- Friends relationship tiers\n- Reader, sidebar, and settings UX work\n- Trim reader rail work and stabilize friends perf\n- Isolate social scraper webkit stores\n- Gate startup social scraper pressure\n- Recycle blocked scraper windows\n- Reserve scraper memory headroom\n- Slim desktop e2e gates\n- Keep memory-blocked scrapes from holding the shared scraper slot\n- Continue passive soak metrics until Apple Events authorization is restored for active UI driving\n- Treat Settings scroll as the next measured performance surface because it remains the largest budget miss\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+  "releaseBody": "(AI Generated).\n\n## Freed v26.5.1201-dev\n\nDense Friends graph motion and source filtering stay lighter\n\n### Fixes\n\n- Keep large Friends graphs responsive by holding active pan and zoom to a stable 160-node paint layer, then refreshing viewport detail after motion settles\n- Add regression coverage for 1,600-person Friends graphs, including mount time, zoom, pan, scene sync, long tasks, dropped frames, and sidebar row virtualization\n- Optimized source sidebar feed search allocation churn for large RSS collections\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
 }

--- a/release-notes/releases/v26.5.1201-dev.md
+++ b/release-notes/releases/v26.5.1201-dev.md
@@ -2,53 +2,13 @@
 
 ## Freed v26.5.1201-dev
 
-Google OAuth now runs natively in Freed Desktop, large relationship graphs stay lighter during motion, source filtering allocates less work, Map stays smoother, and runtime memory monitoring separates Freed WebKit from machine-wide totals
-
-### Features
-
-- Story wall publishing
-- AI ranked friend suggestions
-- Support Friends graph pinch zoom
+Dense Friends graph motion and source filtering stay lighter
 
 ### Fixes
 
 - Keep large Friends graphs responsive by holding active pan and zoom to a stable 160-node paint layer, then refreshing viewport detail after motion settles
 - Add regression coverage for 1,600-person Friends graphs, including mount time, zoom, pan, scene sync, long tasks, dropped frames, and sidebar row virtualization
-- Reduce dense Map motion paint during pan and zoom
-- Report app-scoped native and WebKit memory in renderer heartbeats
-- Gate optional story scraping on resident memory pressure
-- Tighten social scraper resident memory start budget
-- Skip hidden Friends provider labels during graph motion
-- Gate scraper memory before session slots
-- Gate social scrapes on resident WebKit memory
-- Complete Google Contacts sync in Freed Desktop
-- Share native Google OAuth credentials between Drive and Contacts refresh
-- Surface Google OAuth and People API failure details in Settings instead of generic load errors
-- Reader, feed, and header polish
-- Keep friends graph sync errors recoverable
-- Test coverage and performance hardening
-- Release build and type-safety cleanup
-- Route Google Drive through native sync requests
-- Capture and scraper reliability fixes
-- Open the full Map from Friends detail with one atomic store update
-- Keep large relationship graphs on a smaller 96-node paint layer during active motion before refreshing viewport detail
-- Reduce Source sidebar feed search allocation churn for large RSS collections
-
-### Follow-ups
-
-- Lighten settings moving chrome
-- Reduce settings scroll overdraw
-- Friends relationship tiers
-- Reader, sidebar, and settings UX work
-- Trim reader rail work and stabilize friends perf
-- Isolate social scraper webkit stores
-- Gate startup social scraper pressure
-- Recycle blocked scraper windows
-- Reserve scraper memory headroom
-- Slim desktop e2e gates
-- Keep memory-blocked scrapes from holding the shared scraper slot
-- Continue passive soak metrics until Apple Events authorization is restored for active UI driving
-- Treat Settings scroll as the next measured performance surface because it remains the largest budget miss
+- Optimized source sidebar feed search allocation churn for large RSS collections
 
 ### Downloads
 

--- a/scripts/prepare-release-notes.mjs
+++ b/scripts/prepare-release-notes.mjs
@@ -1065,6 +1065,9 @@ async function main() {
     .map((release) => loadPublishedReleaseSummary(release))
     .filter((summary) => releaseHasContent(summary.release));
   const carriedForwardReleases = carriedForwardSummaries.map((summary) => summary.release);
+  const previousDayRelease = channel === "dev" && context.previousPublishedDayTag
+    ? loadPublishedReleaseSummary({ tag_name: context.previousPublishedDayTag }).release
+    : null;
   const cumulativePrNumbers = dedupeNumericList([
     ...context.prNumbers,
     ...carriedForwardSummaries.flatMap((summary) => summary.prNumbers),
@@ -1124,6 +1127,7 @@ async function main() {
   );
   const validation = validateReleaseShape(finalRelease, {
     earlierReleases: context.isLatestOfDay ? carriedForwardReleases : [],
+    previousDayRelease,
   });
 
   if (validation.errors.length > 0) {

--- a/scripts/prepare-release-notes.mjs
+++ b/scripts/prepare-release-notes.mjs
@@ -8,6 +8,7 @@ import {
   areNearDuplicates,
   buildReleaseDeck,
   compareTags,
+  compareVersionDays,
   dedupeSimilarStrings,
   dayDateFromVersion,
   MAX_FEATURES,
@@ -547,10 +548,8 @@ function parseArguments(argv) {
 }
 
 function previousPublishedDayRelease(version, publishedReleases) {
-  const dayKey = versionDayKey(version);
-
   return [...publishedReleases]
-    .filter((release) => versionDayKey(release.tag_name.replace(/^v/, "")) < dayKey)
+    .filter((release) => compareVersionDays(release.tag_name, version) < 0)
     .pop() ?? null;
 }
 

--- a/scripts/release-notes-shared.mjs
+++ b/scripts/release-notes-shared.mjs
@@ -914,6 +914,9 @@ export function validateReleaseShape(release, options = {}) {
   const normalized = sanitizeReleaseShape(release);
   const rawNormalized = coerceReleaseShape(release);
   const rawComparable = rawComparableReleaseShape(release);
+  const previousDayFeatures = options.previousDayRelease
+    ? dedupeSimilarStrings(coerceReleaseShape(options.previousDayRelease).features)
+    : [];
 
   if (!normalized.deck) {
     errors.push("Deck is required.");
@@ -1010,12 +1013,37 @@ export function validateReleaseShape(release, options = {}) {
 
   for (const priorRelease of options.earlierReleases ?? []) {
     for (const priorEntry of releaseVisibleEntries(priorRelease)) {
+      if (priorEntry.kind === "deck") {
+        continue;
+      }
+
+      const repeatsPreviousDayFeature = previousDayFeatures.some((feature) =>
+        areNearDuplicates(feature, priorEntry.text),
+      );
+      if (repeatsPreviousDayFeature) {
+        continue;
+      }
+
       const isPresent = releaseVisibleItems(normalized).some((item) =>
         areNearDuplicates(item, priorEntry.text),
       );
 
       if (!isPresent && !isCoveredByConsolidation(priorEntry, normalized)) {
         errors.push(`Latest-of-day release is missing earlier same-day item: ${priorEntry.text}`);
+      }
+    }
+  }
+
+  if (options.previousDayRelease) {
+    const currentVisibleItems = releaseVisibleItems(normalized);
+
+    for (const feature of previousDayFeatures) {
+      const isRepeated = currentVisibleItems.some((item) =>
+        areNearDuplicates(item, feature),
+      );
+
+      if (isRepeated) {
+        errors.push(`Latest-of-day release repeats previous-day feature: ${feature}`);
       }
     }
   }

--- a/scripts/release-notes-shared.mjs
+++ b/scripts/release-notes-shared.mjs
@@ -111,6 +111,23 @@ export function compareTags(a, b) {
   return left.channel === "dev" ? -1 : 1;
 }
 
+export function compareVersionDays(a, b) {
+  const left = parseComparableVersion(a);
+  const right = parseComparableVersion(b);
+  const leftDay = Math.floor(left.patch / 100);
+  const rightDay = Math.floor(right.patch / 100);
+
+  if (left.yy !== right.yy) {
+    return left.yy - right.yy;
+  }
+
+  if (left.month !== right.month) {
+    return left.month - right.month;
+  }
+
+  return leftDay - rightDay;
+}
+
 export function versionDayKey(version) {
   const parts = String(version ?? "")
     .replace(DEV_SUFFIX, "")

--- a/scripts/release-notes-shared.test.mjs
+++ b/scripts/release-notes-shared.test.mjs
@@ -4,6 +4,7 @@ import assert from "node:assert/strict";
 import {
   buildReleaseDeck,
   compareTags,
+  compareVersionDays,
   coerceReleaseShape,
   dayDateFromVersion,
   renderReleaseBody,
@@ -224,6 +225,14 @@ test("compareTags sorts dev releases before production for the same base version
   assert.equal(compareTags("v26.4.1200-dev", "v26.4.1200"), -1);
   assert.equal(compareTags("v26.4.1200", "v26.4.1200-dev"), 1);
   assert.equal(compareTags("v26.4.1201-dev", "v26.4.1200"), 1);
+});
+
+test("compareVersionDays sorts CalVer days numerically", () => {
+  assert.ok(compareVersionDays("v26.5.914-dev", "v26.5.1000-dev") < 0);
+  assert.ok(compareVersionDays("v26.5.1016-dev", "v26.5.1100-dev") < 0);
+  assert.ok(compareVersionDays("v26.5.1300-dev", "v26.5.2600-dev") < 0);
+  assert.ok(compareVersionDays("v26.5.1000-dev", "v26.5.914-dev") > 0);
+  assert.ok(compareVersionDays("v26.4.3006-dev", "v26.5.100-dev") < 0);
 });
 
 test("day helpers ignore the dev suffix", () => {

--- a/scripts/release-notes-shared.test.mjs
+++ b/scripts/release-notes-shared.test.mjs
@@ -125,6 +125,56 @@ test("validateReleaseShape allows same-day consolidation for follow-ups", () => 
   assert.equal(result.errors.length, 0);
 });
 
+test("validateReleaseShape rejects previous-day feature repeats", () => {
+  const result = validateReleaseShape(
+    {
+      deck: "Story wall publishing and smoother dense graph motion",
+      features: ["Story wall publishing"],
+      fixes: ["Dense Friends graph motion paints fewer nodes while panning"],
+      followUps: [],
+    },
+    {
+      previousDayRelease: {
+        deck: "Story wall publishing",
+        features: ["Story wall publishing"],
+        fixes: ["Google Contacts sync in Freed Desktop"],
+        followUps: [],
+      },
+    },
+  );
+
+  assert.match(result.errors.join("\n"), /repeats previous-day feature/i);
+});
+
+test("validateReleaseShape does not force stale previous-day features forward", () => {
+  const result = validateReleaseShape(
+    {
+      deck: "Google OAuth and dense Map motion",
+      features: ["Story wall publishing"],
+      fixes: ["Complete Google Contacts sync in Freed Desktop"],
+      followUps: [],
+    },
+    {
+      previousDayRelease: {
+        deck: "AI ranked friend suggestions",
+        features: ["AI ranked friend suggestions"],
+        fixes: [],
+        followUps: [],
+      },
+      earlierReleases: [
+        {
+          deck: "AI ranked friend suggestions and Friends graph pinch zoom",
+          features: ["AI ranked friend suggestions"],
+          fixes: ["Complete Google Contacts sync in Freed Desktop"],
+          followUps: [],
+        },
+      ],
+    },
+  );
+
+  assert.equal(result.errors.length, 0);
+});
+
 test("renderReleaseBody uses the new headings", () => {
   const body = renderReleaseBody("v26.4.108", {
     deck: "Native macOS code signing for effortless installs",

--- a/scripts/validate-release-notes.mjs
+++ b/scripts/validate-release-notes.mjs
@@ -18,6 +18,17 @@ function loadArtifact(filePath) {
   return JSON.parse(readFileSync(path.resolve(REPO_ROOT, filePath), "utf8"));
 }
 
+function loadOptionalArtifact(filePath) {
+  try {
+    return loadArtifact(filePath);
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      return null;
+    }
+    throw error;
+  }
+}
+
 function main() {
   const filePath = process.argv[2];
   if (!filePath) {
@@ -26,8 +37,14 @@ function main() {
 
   const artifact = loadArtifact(filePath);
   const priorArtifacts = process.argv.slice(3).map((priorPath) => loadArtifact(priorPath).release ?? {});
+  const previousDayTag =
+    artifact.channel === "dev" ? artifact.source?.previousPublishedDayTag : null;
+  const previousDayArtifact = previousDayTag
+    ? loadOptionalArtifact(path.join("release-notes", "releases", `${previousDayTag}.json`))
+    : null;
   const result = validateReleaseShape(artifact.release ?? {}, {
     earlierReleases: priorArtifacts,
+    previousDayRelease: previousDayArtifact?.release,
   });
 
   if (result.errors.length > 0) {


### PR DESCRIPTION
(AI Generated).

## Summary
- Fix the release-note generator root cause by sorting CalVer day buckets numerically instead of comparing day keys as strings.
- Backfill the affected May 10 and May 11 dev release-note bodies so AI ranked friend suggestions, Friends graph pinch zoom, and relationship tiers no longer repeat into later dev cards.
- Keep the same-day cumulative release-note validation intact by preserving earlier same-day fixes and follow-ups without carrying stale previous-day features forward.

## Testing
- npm run validate:feature
