### PR TITLE
perf: defer sidebar feed search

### DIFF
--- a/packages/ui/src/components/layout/Sidebar.tsx
+++ b/packages/ui/src/components/layout/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useRef, useMemo, cloneElement, isValidElement, type CSSProperties, type KeyboardEvent as ReactKeyboardEvent, type ReactNode } from "react";
+import { useDeferredValue, useState, useCallback, useEffect, useRef, useMemo, cloneElement, isValidElement, type CSSProperties, type KeyboardEvent as ReactKeyboardEvent, type ReactNode } from "react";
 
 import {
   resolveMapMode,
@@ -958,7 +958,8 @@ export function Sidebar({
   const handleSidebarSearchInputChange = useCallback((value: string) => {
     setSidebarSearchInput(value);
   }, []);
-  const trimmedSearchQuery = sidebarSearchInput.trim().toLocaleLowerCase();
+  const deferredSidebarSearchInput = useDeferredValue(sidebarSearchInput);
+  const trimmedSearchQuery = deferredSidebarSearchInput.trim().toLocaleLowerCase();
   const searchTerms = useMemo(
     () => trimmedSearchQuery.split(/\s+/).filter(Boolean),
     [trimmedSearchQuery],


### PR DESCRIPTION
(AI Generated).

## Summary
- Use deferred sidebar search input so typing can paint before scoring and sorting large RSS feed lists.
- Keep the visible input responsive while the existing memoized feed filtering catches up on the deferred value.

## Testing
- npm run test:e2e:perf:sidebar
- npm run validate:feature