### PR TITLE
feat: add nightly runner outcome closeout

### DIFF
--- a/docs/NIGHTLY-SELF-IMPROVE.md
+++ b/docs/NIGHTLY-SELF-IMPROVE.md
@@ -58,6 +58,12 @@ Use a custom outcome ledger:
 node scripts/nightly-self-improve.mjs --outcome-ledger /tmp/freed-nightly-self-improve/outcomes.jsonl
 ```
 
+Record a finished target directly into the ledger:
+
+```bash
+node scripts/nightly-self-improve.mjs --outcome-ledger /tmp/freed-nightly-self-improve/outcomes.jsonl --record-outcome webkit-memory-pressure --record-kind performance --record-status shipped --record-pr 617 --record-build v26.5.2900-dev --record-notes "Merged, installed, and soaked."
+```
+
 The generated run directory contains:
 
 - `report.md`: morning-readable summary
@@ -65,9 +71,10 @@ The generated run directory contains:
 - `risk-snapshot.md` and `risk-snapshot.json`: preflight blockers, warnings, evidence, and remediation steps
 - `tasks/*.md`: one implementation prompt per selected target
 - `execution-plan.md` and `execution-plan.json`: ordered phases, command hints, and stop gates
+- `outcome-closeout.md`: one ready-to-run ledger command per selected target
 - `outcome-template.jsonl`: lines to append back into the outcome ledger after the run
 
-Reports include an execution phase list so the night can move from evidence, to peer comparison, to implementation, validation, dev build shipping, installed-build soak, and the morning digest.
+Reports include an execution phase list so the night can move from evidence, to peer comparison, to implementation, validation, dev build shipping, installed-build soak, ledger closeout, and the morning digest.
 
 ## Safety Gates
 
@@ -79,7 +86,7 @@ Every execution phase has a stop gate. The runner should stop rather than freest
 
 ## Next Improvements
 
-- Wire the generated outcome template into the actual overnight closeout so target scoring learns without manual copying.
+- Compare each recorded outcome to the prior target score so repeated misses automatically lower future priority.
 - Compare every morning report against the previous installed build, especially WebKit RSS and frame budget deltas.
 - Let a run split itself into phases: plan, fix, validate, publish PR, merge when green, ship dev build, install, then soak.
 - Add a duplicate-work detector that notices when two night agents are chasing the same bottleneck.

--- a/docs/PHASE-10-POLISH.md
+++ b/docs/PHASE-10-POLISH.md
@@ -126,7 +126,7 @@ The shared extension points now live in `packages/ui/src/lib/command-palette.ts`
 
 Freed now has a local nightly improvement planner in `scripts/nightly-self-improve.mjs`. It folds the installed-build soak, daily bug scan memory, crash-watch state, roadmap fallback memory, peer worktrees, prior outcome history, and current git state into a ranked queue of work that can run overnight.
 
-The runner can choose multiple targets in one night. Bug fixes are first-class targets through the existing daily bug scan memory, while peer worktree integration, performance, stability, release readiness, and roadmap work compete by score and machine-time budget. Each run now writes a preflight risk snapshot plus an execution plan with stop gates, command hints, task prompts, and outcome templates so overnight automation has a clear path from clean evidence to validation, dev build shipping, installed-build soak, and morning closeout. Provider-visible ideas stay blocked unless a human explicitly approves the fingerprinting risk.
+The runner can choose multiple targets in one night. Bug fixes are first-class targets through the existing daily bug scan memory, while peer worktree integration, performance, stability, release readiness, and roadmap work compete by score and machine-time budget. Each run now writes a preflight risk snapshot plus an execution plan with stop gates, command hints, task prompts, outcome templates, and ready-to-run ledger closeout commands so overnight automation has a clear path from clean evidence to validation, dev build shipping, installed-build soak, learned scoring, and morning closeout. Provider-visible ideas stay blocked unless a human explicitly approves the fingerprinting risk.
 
 ### Keyboard Shortcuts
 

--- a/scripts/nightly-self-improve.mjs
+++ b/scripts/nightly-self-improve.mjs
@@ -2,6 +2,7 @@
 
 import { execFileSync } from "node:child_process";
 import {
+  appendFileSync,
   existsSync,
   mkdirSync,
   readdirSync,
@@ -46,6 +47,12 @@ Options:
   --peer-worktree <path>        Extra local worktree to compare and rank as a peer target.
   --no-peer-scan                Skip automatic git worktree discovery.
   --outcome-ledger <path>       JSONL file with prior target outcomes.
+  --record-outcome <id>         Append a finished target outcome to the outcome ledger.
+  --record-kind <kind>          Target kind for --record-outcome.
+  --record-status <status>      Outcome status: shipped, validated, blocked, or failed.
+  --record-notes <text>         Notes for --record-outcome.
+  --record-pr <number>          Pull request number or URL for --record-outcome.
+  --record-build <version>      Dev build version for --record-outcome.
   --max-targets <count>         Maximum targets to select. Defaults to 3.
   --duration-minutes <count>    Planning budget for one night. Defaults to 480.
   --memory-gib <count>          WebKit RSS budget before memory work wins. Defaults to 2.5.
@@ -60,11 +67,18 @@ export function parseArgs(argv) {
   const args = {
     repo: process.cwd(),
     runDir: "",
+    runDirProvided: false,
     soakDir: "",
     dailyBugMemory: DEFAULT_DAILY_BUG_MEMORY,
     crashAutomation: DEFAULT_CRASH_AUTOMATION,
     devBotMemory: DEFAULT_DEV_BOT_MEMORY,
     outcomeLedger: DEFAULT_OUTCOME_LEDGER,
+    recordOutcome: "",
+    recordKind: "",
+    recordStatus: "validated",
+    recordNotes: "",
+    recordPr: "",
+    recordBuild: "",
     peerWorktrees: [],
     peerScan: true,
     maxTargets: 3,
@@ -85,6 +99,7 @@ export function parseArgs(argv) {
         break;
       case "--run-dir":
         args.runDir = argv[index + 1] ?? "";
+        args.runDirProvided = true;
         index += 1;
         break;
       case "--soak-dir":
@@ -104,6 +119,30 @@ export function parseArgs(argv) {
         break;
       case "--outcome-ledger":
         args.outcomeLedger = argv[index + 1] ?? "";
+        index += 1;
+        break;
+      case "--record-outcome":
+        args.recordOutcome = argv[index + 1] ?? "";
+        index += 1;
+        break;
+      case "--record-kind":
+        args.recordKind = argv[index + 1] ?? "";
+        index += 1;
+        break;
+      case "--record-status":
+        args.recordStatus = argv[index + 1] ?? "";
+        index += 1;
+        break;
+      case "--record-notes":
+        args.recordNotes = argv[index + 1] ?? "";
+        index += 1;
+        break;
+      case "--record-pr":
+        args.recordPr = argv[index + 1] ?? "";
+        index += 1;
+        break;
+      case "--record-build":
+        args.recordBuild = argv[index + 1] ?? "";
         index += 1;
         break;
       case "--max-targets":
@@ -142,6 +181,14 @@ export function parseArgs(argv) {
 
   if (!args.repo) {
     throw new Error("A repo path is required.");
+  }
+  if (args.recordOutcome) {
+    if (!args.recordKind) {
+      throw new Error("record-kind is required when record-outcome is set.");
+    }
+    if (!["shipped", "validated", "blocked", "failed"].includes(args.recordStatus)) {
+      throw new Error("record-status must be shipped, validated, blocked, or failed.");
+    }
   }
   if (!Number.isFinite(args.maxTargets) || args.maxTargets < 1) {
     throw new Error("maxTargets must be at least 1.");
@@ -279,6 +326,36 @@ export function summarizeOutcomeLedger(filePath) {
     byKind: Object.fromEntries(byKind),
     byId: Object.fromEntries(byId),
   };
+}
+
+export function appendOutcomeLedger(filePath, entry, now = new Date()) {
+  if (!entry?.id || !entry?.kind || !entry?.outcome) {
+    throw new Error("Outcome ledger entries require id, kind, and outcome.");
+  }
+  if (!["shipped", "validated", "blocked", "failed"].includes(entry.outcome)) {
+    throw new Error("Outcome must be shipped, validated, blocked, or failed.");
+  }
+
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  const cleanEntry = {
+    ts: now.toISOString(),
+    id: String(entry.id),
+    kind: String(entry.kind),
+    outcome: String(entry.outcome),
+    notes: String(entry.notes ?? ""),
+  };
+  if (entry.pr) {
+    cleanEntry.pr = String(entry.pr);
+  }
+  if (entry.build) {
+    cleanEntry.build = String(entry.build);
+  }
+  if (entry.runDir) {
+    cleanEntry.runDir = String(entry.runDir);
+  }
+
+  appendFileSync(filePath, `${JSON.stringify(cleanEntry)}\n`);
+  return cleanEntry;
 }
 
 export function parseTsv(text) {
@@ -1389,12 +1466,46 @@ function renderExecutionPlanMarkdown(phases) {
   ].join("\n");
 }
 
+function buildOutcomeCommand(candidate, outcomeLedger) {
+  return [
+    "node scripts/nightly-self-improve.mjs",
+    `--outcome-ledger ${JSON.stringify(outcomeLedger)}`,
+    `--record-outcome ${JSON.stringify(candidate.id)}`,
+    `--record-kind ${JSON.stringify(candidate.kind)}`,
+    "--record-status validated",
+    "--record-notes \"replace with closeout notes\"",
+  ].join(" ");
+}
+
+function renderOutcomeCloseoutMarkdown({ selected, outcomeLedger }) {
+  return [
+    "# Nightly Outcome Closeout",
+    "",
+    `Outcome ledger: ${outcomeLedger}`,
+    "",
+    "Run one command per selected target after the target finishes. Use `shipped` only after the fix is merged, released when applicable, installed, and soaked enough to compare evidence.",
+    "",
+    ...selected.flatMap((candidate, index) => [
+      `## ${index + 1}. ${candidate.title}`,
+      "",
+      `Target: ${candidate.id}`,
+      `Kind: ${candidate.kind}`,
+      "",
+      "Command:",
+      "",
+      `\`${buildOutcomeCommand(candidate, outcomeLedger)}\``,
+      "",
+    ]),
+  ].join("\n");
+}
+
 export function writeRunPlan({ runDir, repo, soak, riskSnapshot, peerWorktrees = [], candidates, selected, options }) {
   mkdirSync(runDir, { recursive: true });
   const tasksDir = path.join(runDir, "tasks");
   mkdirSync(tasksDir, { recursive: true });
 
-  const outcomeLedger = options.outcomeLedgerSummary ?? { path: options.outcomeLedger, entries: [] };
+  const outcomeLedgerPath = options.outcomeLedger ?? DEFAULT_OUTCOME_LEDGER;
+  const outcomeLedger = options.outcomeLedgerSummary ?? { path: outcomeLedgerPath, entries: [] };
   const safeRiskSnapshot =
     riskSnapshot ??
     {
@@ -1408,12 +1519,17 @@ export function writeRunPlan({ runDir, repo, soak, riskSnapshot, peerWorktrees =
     };
   const executionPlan = buildExecutionPlan(selected);
   const report = buildReport({ repo, soak, riskSnapshot: safeRiskSnapshot, outcomeLedger, candidates, selected, options });
+  const outcomeCloseout = renderOutcomeCloseoutMarkdown({
+    selected,
+    outcomeLedger: outcomeLedgerPath,
+  });
   writeFileSync(path.join(runDir, "report.md"), report);
   writeFileSync(path.join(runDir, "targets.json"), `${JSON.stringify({ repo, soak, riskSnapshot: safeRiskSnapshot, peerWorktrees, outcomeLedger, executionPlan, candidates, selected }, null, 2)}\n`);
   writeFileSync(path.join(runDir, "risk-snapshot.json"), `${JSON.stringify(safeRiskSnapshot, null, 2)}\n`);
   writeFileSync(path.join(runDir, "risk-snapshot.md"), renderRiskSnapshotMarkdown(safeRiskSnapshot));
   writeFileSync(path.join(runDir, "execution-plan.json"), `${JSON.stringify(executionPlan, null, 2)}\n`);
   writeFileSync(path.join(runDir, "execution-plan.md"), renderExecutionPlanMarkdown(executionPlan));
+  writeFileSync(path.join(runDir, "outcome-closeout.md"), outcomeCloseout);
   writeFileSync(
     path.join(runDir, "outcome-template.jsonl"),
     selected
@@ -1424,6 +1540,7 @@ export function writeRunPlan({ runDir, repo, soak, riskSnapshot, peerWorktrees =
           kind: candidate.kind,
           outcome: "validated",
           notes: "Replace outcome with shipped, validated, blocked, or failed after the run.",
+          command: buildOutcomeCommand(candidate, outcomeLedgerPath),
         }),
       )
       .join("\n") + "\n",
@@ -1440,6 +1557,7 @@ export function writeRunPlan({ runDir, repo, soak, riskSnapshot, peerWorktrees =
     tasksDir,
     riskSnapshotPath: path.join(runDir, "risk-snapshot.md"),
     executionPlanPath: path.join(runDir, "execution-plan.md"),
+    outcomeCloseoutPath: path.join(runDir, "outcome-closeout.md"),
     outcomeTemplatePath: path.join(runDir, "outcome-template.jsonl"),
   };
 }
@@ -1494,6 +1612,7 @@ function textSummary(plan, writeResult, args) {
     lines.push(`Tasks: ${writeResult.tasksDir}`);
     lines.push(`Risk snapshot: ${writeResult.riskSnapshotPath}`);
     lines.push(`Execution plan: ${writeResult.executionPlanPath}`);
+    lines.push(`Outcome closeout: ${writeResult.outcomeCloseoutPath}`);
     lines.push(`Outcome template: ${writeResult.outcomeTemplatePath}`);
   }
 
@@ -1508,6 +1627,26 @@ export function main(argv = process.argv.slice(2)) {
   const args = parseArgs(argv);
   if (args.help) {
     process.stdout.write(usage());
+    return;
+  }
+
+  if (args.recordOutcome) {
+    const entry = appendOutcomeLedger(args.outcomeLedger, {
+      id: args.recordOutcome,
+      kind: args.recordKind,
+      outcome: args.recordStatus,
+      notes: args.recordNotes,
+      pr: args.recordPr,
+      build: args.recordBuild,
+      runDir: args.runDirProvided ? args.runDir : "",
+    });
+    if (args.json) {
+      process.stdout.write(`${JSON.stringify(entry, null, 2)}\n`);
+    } else {
+      process.stdout.write(
+        `Recorded ${entry.outcome} outcome for ${entry.id} in ${args.outcomeLedger}.\n`,
+      );
+    }
     return;
   }
 

--- a/scripts/nightly-self-improve.test.mjs
+++ b/scripts/nightly-self-improve.test.mjs
@@ -1,12 +1,13 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
 import {
   applyOutcomeFeedback,
+  appendOutcomeLedger,
   buildCandidates,
   buildExecutionPlan,
   collectRepoSnapshot,
@@ -303,6 +304,31 @@ test("outcome feedback raises shipped target kinds and lowers failed ones", () =
   assert.equal(adjusted[1].outcomeFeedback.failed, 2);
 });
 
+test("appendOutcomeLedger records closeout entries for future scoring", () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "freed-outcome-append-"));
+  const ledgerPath = path.join(dir, "outcomes.jsonl");
+  const entry = appendOutcomeLedger(
+    ledgerPath,
+    {
+      id: "webkit-memory-pressure",
+      kind: "performance",
+      outcome: "shipped",
+      notes: "Merged and soaked.",
+      pr: "617",
+      build: "v26.5.2900-dev",
+      runDir: "/tmp/nightly-run",
+    },
+    new Date("2026-05-29T12:00:00Z"),
+  );
+
+  assert.equal(entry.ts, "2026-05-29T12:00:00.000Z");
+  const lines = readFileSync(ledgerPath, "utf8").trim().split("\n");
+  assert.equal(lines.length, 1);
+  const ledger = summarizeOutcomeLedger(ledgerPath);
+  assert.equal(ledger.byKind.performance.shipped, 1);
+  assert.equal(ledger.byId["webkit-memory-pressure"].shipped, 1);
+});
+
 test("risk snapshot reports dirty worktrees, generated artifacts, stale soak, and paused automation", () => {
   const dir = mkdtempSync(path.join(os.tmpdir(), "freed-risk-snapshot-"));
   const reportDir = path.join(dir, "packages/desktop/playwright-report");
@@ -384,6 +410,7 @@ test("writeRunPlan emits report, targets, and task prompts", () => {
   assert.equal(path.basename(result.tasksDir), "tasks");
   assert.equal(path.basename(result.riskSnapshotPath), "risk-snapshot.md");
   assert.equal(path.basename(result.executionPlanPath), "execution-plan.md");
+  assert.equal(path.basename(result.outcomeCloseoutPath), "outcome-closeout.md");
   assert.equal(path.basename(result.outcomeTemplatePath), "outcome-template.jsonl");
 });
 
@@ -408,7 +435,31 @@ test("execution plan includes peer review and release soak gates", () => {
 
 test("argument parsing validates numeric budgets", () => {
   assert.throws(() => parseArgs(["--max-targets", "0"]), /maxTargets/);
+  assert.throws(() => parseArgs(["--record-outcome", "target"]), /record-kind/);
+  assert.throws(
+    () =>
+      parseArgs([
+        "--record-outcome",
+        "target",
+        "--record-kind",
+        "performance",
+        "--record-status",
+        "maybe",
+      ]),
+    /record-status/,
+  );
   assert.equal(parseArgs(["--memory-gib", "3"]).memoryGib, 3);
+  assert.equal(
+    parseArgs([
+      "--record-outcome",
+      "target",
+      "--record-kind",
+      "performance",
+      "--record-status",
+      "shipped",
+    ]).recordStatus,
+    "shipped",
+  );
   assert.equal(parseArgs(["--peer-worktree", "/tmp/peer", "--no-peer-scan"]).peerScan, false);
 });
 

--- a/website/src/app/roadmap/RoadmapContent.tsx
+++ b/website/src/app/roadmap/RoadmapContent.tsx
@@ -783,7 +783,7 @@ const phases: Phase[] = [
     number: 10,
     title: "Polish",
     description:
-      "Onboarding, statistics, global animation controls, expanded local content signals with Desktop and PWA backfill, inclusive saved feed filter presets, compact event extraction, local semantic enrichment for friend suggestions, unified AI provider settings, Light, Balanced, and Pro Integrated AI packs with semantic scan health, plugin API, community infrastructure, preflight-aware nightly improvement planning, and deeper crash recovery hardening.",
+      "Onboarding, statistics, global animation controls, expanded local content signals with Desktop and PWA backfill, inclusive saved feed filter presets, compact event extraction, local semantic enrichment for friend suggestions, unified AI provider settings, Light, Balanced, and Pro Integrated AI packs with semantic scan health, plugin API, community infrastructure, preflight-aware nightly improvement planning with learned closeout, and deeper crash recovery hardening.",
     status: "upcoming",
     planLink:
       "https://github.com/freed-project/freed/blob/dev/docs/PHASE-10-POLISH.md",


### PR DESCRIPTION
(AI Generated).

## Summary
- Adds direct outcome recording so overnight target results can be appended to the learning ledger without manual JSONL copying.
- Writes outcome-closeout.md with ready-to-run commands for each selected target and keeps outcome-template.jsonl machine-readable.

## Testing
- node --test scripts/nightly-self-improve.test.mjs
- corepack npm run test:scripts
- corepack npm run validate:feature