### PR TITLE
perf: lazy load friends graph

### DIFF
--- a/packages/ui/src/components/layout/AppShell.tsx
+++ b/packages/ui/src/components/layout/AppShell.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef, useCallback, type ReactNode } from "react";
+import { Suspense, lazy, useEffect, useState, useRef, useCallback, type ReactNode } from "react";
 import { Sidebar } from "./Sidebar.js";
 import { Header } from "./Header.js";
 import { DebugPanel } from "../DebugPanel.js";
@@ -8,7 +8,6 @@ import { LibraryDialog } from "../LibraryDialog.js";
 import { addDebugEvent, useDebugStore } from "../../lib/debug-store.js";
 import { useAppStore } from "../../context/PlatformContext.js";
 import { useCommandSurfaceStore } from "../../lib/command-surface-store.js";
-import { FriendsView } from "../friends/FriendsView.js";
 import { ContactSyncModal } from "../friends/ContactSyncModal.js";
 import { useContactSync } from "../../hooks/useContactSync.js";
 import { ContactSyncContext } from "../../context/ContactSyncContext.js";
@@ -41,6 +40,9 @@ import {
 const DEFAULT_DEBUG_WIDTH = 320;
 const MIN_DEBUG_WIDTH = 280;
 const MAX_DEBUG_WIDTH = 600;
+const LazyFriendsView = lazy(() =>
+  import("../friends/FriendsView.js").then((module) => ({ default: module.FriendsView })),
+);
 
 interface AppShellProps {
   children: ReactNode;
@@ -383,11 +385,13 @@ export function AppShell({ children }: AppShellProps) {
           >
             {activeView === "friends"
               ? (
-                <FriendsView
-                  friendsSidebarOpen={friendsSidebarOpen}
-                  onFriendsSidebarOpenChange={handleFriendsSidebarOpenChange}
-                  mobileSurface={friendsMobileSurface}
-                />
+                <Suspense fallback={<div className="h-full min-h-0" data-testid="friends-view-loading" />}>
+                  <LazyFriendsView
+                    friendsSidebarOpen={friendsSidebarOpen}
+                    onFriendsSidebarOpenChange={handleFriendsSidebarOpenChange}
+                    mobileSurface={friendsMobileSurface}
+                  />
+                </Suspense>
               )
               : activeView === "map"
                 ? <MapView />


### PR DESCRIPTION
(AI Generated).

## Summary
- Lazy load the Friends route so Pixi and graph rendering code no longer ship in the initial app chunk.
- Move 751.75 KB of Friends code into a route chunk and reduce the production index chunk from roughly 3.34 MB to 2.59 MB.
- Keep the 1,600 connection Friends perf case under budget after the route split.

## Testing
- PATH=/Users/aubreyfalconer/dev/freed-lazy-friends-graph/node_modules/.bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/usr/local/MacGPG2/bin:/Applications/VMware Fusion.app/Contents/Public:/usr/local/share/dotnet:~/.dotnet/tools:/usr/local/go/bin:/Library/Frameworks/Mono.framework/Versions/Current/Commands:/Users/aubreyfalconer/.nvm/versions/node/v24.14.1/bin:/Users/aubreyfalconer/.codex/tmp/arg0/codex-arg0ldxqj8:/Users/aubreyfalconer/.local/bin:/opt/homebrew/opt/mysql-client/bin:/opt/homebrew/bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/Users/aubreyfalconer/.cargo/bin:/Users/aubreyfalconer/go/bin:/Users/aubreyfalconer/.cache/lm-studio/bin:/Users/aubreyfalconer/.safe-chain/bin:/Applications/Codex.app/Contents/Resources:/usr/local/bin npm run build from packages/pwa
- npm run test:e2e:perf:friends
- npm run test:e2e:smoke with startup and Friends graph greps
- npm run validate:feature