### PR TITLE
feat: add nightly runner duplicate detection

### DIFF
--- a/docs/NIGHTLY-SELF-IMPROVE.md
+++ b/docs/NIGHTLY-SELF-IMPROVE.md
@@ -13,6 +13,7 @@ The first rule is simple: evidence first, code second. If a target has weak evid
 - Hourly dev bot memory as a roadmap fallback
 - Git state for the current checkout
 - Local git worktrees with unmerged or uncommitted changes
+- Duplicate peer work indicators such as shared changed files, shared package surfaces, and shared provider-visible risk
 - Prior outcome ledger at `/tmp/freed-nightly-self-improve/outcomes.jsonl`
 - Preflight risks such as dirty worktrees, generated artifacts, stale soak samples, missing dependencies, missing evidence files, and paused automations
 
@@ -69,6 +70,7 @@ The generated run directory contains:
 - `report.md`: morning-readable summary
 - `targets.json`: full machine-readable candidate list
 - `risk-snapshot.md` and `risk-snapshot.json`: preflight blockers, warnings, evidence, and remediation steps
+- `duplicate-work.md` and `duplicate-work.json`: peer worktree overlap by file and surface
 - `tasks/*.md`: one implementation prompt per selected target
 - `execution-plan.md` and `execution-plan.json`: ordered phases, command hints, and stop gates
 - `outcome-closeout.md`: one ready-to-run ledger command per selected target
@@ -89,6 +91,6 @@ Every execution phase has a stop gate. The runner should stop rather than freest
 - Compare each recorded outcome to the prior target score so repeated misses automatically lower future priority.
 - Compare every morning report against the previous installed build, especially WebKit RSS and frame budget deltas.
 - Let a run split itself into phases: plan, fix, validate, publish PR, merge when green, ship dev build, install, then soak.
-- Add a duplicate-work detector that notices when two night agents are chasing the same bottleneck.
+- Let duplicate-work findings assign an owner automatically when one branch already has passing validation.
 - Promote preflight risk fixes into automatic cleanup steps when the remediation is unambiguous and local only.
 - Turn recurring failure signatures into reusable focused test recipes.

--- a/docs/PHASE-10-POLISH.md
+++ b/docs/PHASE-10-POLISH.md
@@ -126,7 +126,7 @@ The shared extension points now live in `packages/ui/src/lib/command-palette.ts`
 
 Freed now has a local nightly improvement planner in `scripts/nightly-self-improve.mjs`. It folds the installed-build soak, daily bug scan memory, crash-watch state, roadmap fallback memory, peer worktrees, prior outcome history, and current git state into a ranked queue of work that can run overnight.
 
-The runner can choose multiple targets in one night. Bug fixes are first-class targets through the existing daily bug scan memory, while peer worktree integration, performance, stability, release readiness, and roadmap work compete by score and machine-time budget. Each run now writes a preflight risk snapshot plus an execution plan with stop gates, command hints, task prompts, outcome templates, and ready-to-run ledger closeout commands so overnight automation has a clear path from clean evidence to validation, dev build shipping, installed-build soak, learned scoring, and morning closeout. Provider-visible ideas stay blocked unless a human explicitly approves the fingerprinting risk.
+The runner can choose multiple targets in one night. Bug fixes are first-class targets through the existing daily bug scan memory, while peer worktree integration, duplicate-work detection, performance, stability, release readiness, and roadmap work compete by score and machine-time budget. Each run now writes a preflight risk snapshot plus an execution plan with stop gates, command hints, task prompts, outcome templates, and ready-to-run ledger closeout commands so overnight automation has a clear path from clean evidence to validation, dev build shipping, installed-build soak, learned scoring, and morning closeout. Provider-visible ideas stay blocked unless a human explicitly approves the fingerprinting risk.
 
 ### Keyboard Shortcuts
 
@@ -472,7 +472,7 @@ Reward security researchers for responsible disclosure.
 - [ ] Discord server active
 - [ ] Bug bounty program published
 - [ ] Regular release schedule established
-- [x] Local nightly improvement runner ranks preflight risks, peer worktree, bug fix, performance, stability, release, and roadmap targets before autonomous work begins
+- [x] Local nightly improvement runner ranks preflight risks, duplicate peer work, peer worktree, bug fix, performance, stability, release, and roadmap targets before autonomous work begins
 - [ ] Documentation site live
 
 ### Resilience

--- a/scripts/nightly-self-improve.mjs
+++ b/scripts/nightly-self-improve.mjs
@@ -717,6 +717,99 @@ export function collectPeerWorktrees(repo, explicitWorktrees = [], scan = true) 
     .sort((left, right) => right.score - left.score);
 }
 
+function peerWorkTags(peer) {
+  const tags = [];
+  if (peer.touchesNightlyRunner) {
+    tags.push("nightly-runner");
+  }
+  if (peer.touchesMemoryTelemetry) {
+    tags.push("memory-telemetry");
+  }
+  if (peer.providerVisible) {
+    tags.push("provider-visible");
+  }
+  for (const filePath of peer.changedFiles ?? []) {
+    if (filePath.startsWith("packages/desktop/")) {
+      tags.push("desktop");
+    } else if (filePath.startsWith("packages/ui/")) {
+      tags.push("ui");
+    } else if (filePath.startsWith("packages/shared/")) {
+      tags.push("shared");
+    } else if (filePath.startsWith("website/")) {
+      tags.push("website");
+    } else if (filePath.startsWith("scripts/")) {
+      tags.push("scripts");
+    }
+  }
+  return unique(tags);
+}
+
+export function collectDuplicateWork(peerWorktrees = []) {
+  const findings = [];
+  const peers = peerWorktrees.map((peer) => ({
+    ...peer,
+    tags: peerWorkTags(peer),
+  }));
+  const fileOwners = new Map();
+  const tagOwners = new Map();
+
+  for (const peer of peers) {
+    for (const filePath of peer.changedFiles ?? []) {
+      const owners = fileOwners.get(filePath) ?? [];
+      owners.push(peer);
+      fileOwners.set(filePath, owners);
+    }
+    for (const tag of peer.tags) {
+      const owners = tagOwners.get(tag) ?? [];
+      owners.push(peer);
+      tagOwners.set(tag, owners);
+    }
+  }
+
+  for (const [filePath, owners] of fileOwners) {
+    if (owners.length < 2) {
+      continue;
+    }
+    findings.push({
+      id: `file-${filePath.replace(/[^a-z0-9]+/gi, "-").replace(/^-|-$/g, "").toLowerCase()}`,
+      kind: "file-overlap",
+      severity: "blocker",
+      title: `Multiple peer worktrees changed ${filePath}`,
+      key: filePath,
+      peers: owners.map((peer) => ({
+        branch: peer.branch,
+        path: peer.path,
+        head: peer.head,
+      })),
+    });
+  }
+
+  for (const [tag, owners] of tagOwners) {
+    if (owners.length < 2) {
+      continue;
+    }
+    findings.push({
+      id: `tag-${tag}`,
+      kind: "surface-overlap",
+      severity: tag === "provider-visible" ? "blocker" : "warning",
+      title: `Multiple peer worktrees are touching ${tag}`,
+      key: tag,
+      peers: owners.map((peer) => ({
+        branch: peer.branch,
+        path: peer.path,
+        head: peer.head,
+      })),
+    });
+  }
+
+  return {
+    findingCount: findings.length,
+    blockerCount: findings.filter((finding) => finding.severity === "blocker").length,
+    warningCount: findings.filter((finding) => finding.severity === "warning").length,
+    findings,
+  };
+}
+
 export function collectRepoSnapshot(repo) {
   return {
     branch: git(repo, ["branch", "--show-current"]) || git(repo, ["rev-parse", "--abbrev-ref", "HEAD"]),
@@ -736,6 +829,7 @@ export function collectRiskSnapshot({
   repo,
   soak,
   peerWorktrees = [],
+  duplicateWork,
   crashAutomation,
   dailyBugMemory,
   devBotMemory,
@@ -853,6 +947,22 @@ export function collectRiskSnapshot({
     }
   }
 
+  for (const finding of duplicateWork?.findings ?? []) {
+    risks.push(
+      riskItem({
+        id: `duplicate-work-${finding.id}`,
+        severity: finding.severity,
+        title: finding.title,
+        evidence: finding.peers.flatMap((peer) => [
+          `Branch ${peer.branch}`,
+          peer.path,
+        ]),
+        remediation:
+          "Pick one owner or merge the safer subset before continuing so parallel agents do not publish competing fixes for the same surface.",
+      }),
+    );
+  }
+
   const automationStatuses = [
     ["crash-watch", crashAutomation],
     ["daily-bug-memory", dailyBugMemory],
@@ -938,6 +1048,7 @@ export function buildCandidates({
   dailyBug,
   repo,
   riskSnapshot,
+  duplicateWork,
   peerWorktrees = [],
   crashAutomationExists,
   devBotMemoryExists,
@@ -970,6 +1081,36 @@ export function buildCandidates({
           "Regenerate the nightly plan and confirm blockerCount is 0 before publishing.",
           "Run the focused validation for any cleanup or script change.",
           "Run validate:feature before publishing code changes.",
+        ],
+      }),
+    );
+  }
+
+  if ((duplicateWork?.findingCount ?? 0) > 0) {
+    candidates.push(
+      target({
+        id: "nightly-duplicate-work",
+        kind: "stability",
+        title: "Deduplicate overlapping overnight work before publishing",
+        score: (duplicateWork?.blockerCount ?? 0) > 0 ? 96 : 76,
+        confidence: (duplicateWork?.blockerCount ?? 0) > 0 ? 0.88 : 0.74,
+        estimatedMinutes: 35,
+        rationale:
+          (duplicateWork?.blockerCount ?? 0) > 0
+            ? `Duplicate work detection found ${numberFormatter.format(duplicateWork.blockerCount)} blocker overlap across peer worktrees.`
+            : `Duplicate work detection found ${numberFormatter.format(duplicateWork.warningCount)} warning overlap across peer worktrees.`,
+        evidence: (duplicateWork?.findings ?? [])
+          .slice(0, 6)
+          .flatMap((finding) => [
+            `${finding.severity}: ${finding.title}`,
+            ...finding.peers.map((peer) => `${peer.branch} at ${peer.path}`),
+          ]),
+        prompt:
+          "Read duplicate-work.md before publishing. Decide which branch owns each overlapped file or surface, absorb only the safer validated subset, and record skipped duplicate work in the morning report.",
+        validation: [
+          "Regenerate duplicate-work.md after any peer branch changes.",
+          "Run focused validation for whichever branch absorbs the overlap.",
+          "Run validate:feature before publishing.",
         ],
       }),
     );
@@ -1256,7 +1397,7 @@ function formatCandidate(candidate, index) {
   ].join("\n");
 }
 
-export function buildReport({ repo, soak, riskSnapshot, outcomeLedger, candidates, selected, options }) {
+export function buildReport({ repo, soak, riskSnapshot, duplicateWork, outcomeLedger, candidates, selected, options }) {
   const blockedProvider = candidates.filter((candidate) => candidate.providerVisible);
   const phases = buildNightlyPhases(selected);
   return [
@@ -1285,6 +1426,16 @@ export function buildReport({ repo, soak, riskSnapshot, outcomeLedger, candidate
     "",
     ...(riskSnapshot?.risks ?? []).slice(0, 8).map(
       (risk) => `- ${risk.severity}: ${risk.title}`,
+    ),
+    "",
+    "## Duplicate Work",
+    "",
+    `- Findings: ${numberFormatter.format(duplicateWork?.findingCount ?? 0)}`,
+    `- Blockers: ${numberFormatter.format(duplicateWork?.blockerCount ?? 0)}`,
+    `- Warnings: ${numberFormatter.format(duplicateWork?.warningCount ?? 0)}`,
+    "",
+    ...(duplicateWork?.findings ?? []).slice(0, 8).map(
+      (finding) => `- ${finding.severity}: ${finding.title}`,
     ),
     "",
     "## Learning Signals",
@@ -1320,6 +1471,33 @@ export function buildReport({ repo, soak, riskSnapshot, outcomeLedger, candidate
     "- Require evidence snapshots before every rare crash or memory fix so the next failure has better diagnostics.",
     "- Add a morning digest that ranks shipped value, residual risk, and the single next highest leverage bottleneck.",
     "",
+  ].join("\n");
+}
+
+function renderDuplicateWorkMarkdown(duplicateWork) {
+  return [
+    "# Nightly Duplicate Work",
+    "",
+    `Findings: ${numberFormatter.format(duplicateWork.findingCount)}`,
+    `Blockers: ${numberFormatter.format(duplicateWork.blockerCount)}`,
+    `Warnings: ${numberFormatter.format(duplicateWork.warningCount)}`,
+    "",
+    ...(duplicateWork.findings.length > 0
+      ? duplicateWork.findings.flatMap((finding) => [
+          `## ${finding.title}`,
+          "",
+          `Severity: ${finding.severity}`,
+          `Kind: ${finding.kind}`,
+          `Key: ${finding.key}`,
+          "",
+          "Peer worktrees:",
+          "",
+          ...finding.peers.map(
+            (peer) => `- ${peer.branch} at ${peer.path} (${peer.head || "unknown"})`,
+          ),
+          "",
+        ])
+      : ["No duplicate peer work detected.", ""]),
   ].join("\n");
 }
 
@@ -1499,7 +1677,7 @@ function renderOutcomeCloseoutMarkdown({ selected, outcomeLedger }) {
   ].join("\n");
 }
 
-export function writeRunPlan({ runDir, repo, soak, riskSnapshot, peerWorktrees = [], candidates, selected, options }) {
+export function writeRunPlan({ runDir, repo, soak, riskSnapshot, duplicateWork, peerWorktrees = [], candidates, selected, options }) {
   mkdirSync(runDir, { recursive: true });
   const tasksDir = path.join(runDir, "tasks");
   mkdirSync(tasksDir, { recursive: true });
@@ -1517,16 +1695,35 @@ export function writeRunPlan({ runDir, repo, soak, riskSnapshot, peerWorktrees =
       automationStatuses: [],
       risks: [],
     };
+  const safeDuplicateWork =
+    duplicateWork ??
+    {
+      findingCount: 0,
+      blockerCount: 0,
+      warningCount: 0,
+      findings: [],
+    };
   const executionPlan = buildExecutionPlan(selected);
-  const report = buildReport({ repo, soak, riskSnapshot: safeRiskSnapshot, outcomeLedger, candidates, selected, options });
+  const report = buildReport({
+    repo,
+    soak,
+    riskSnapshot: safeRiskSnapshot,
+    duplicateWork: safeDuplicateWork,
+    outcomeLedger,
+    candidates,
+    selected,
+    options,
+  });
   const outcomeCloseout = renderOutcomeCloseoutMarkdown({
     selected,
     outcomeLedger: outcomeLedgerPath,
   });
   writeFileSync(path.join(runDir, "report.md"), report);
-  writeFileSync(path.join(runDir, "targets.json"), `${JSON.stringify({ repo, soak, riskSnapshot: safeRiskSnapshot, peerWorktrees, outcomeLedger, executionPlan, candidates, selected }, null, 2)}\n`);
+  writeFileSync(path.join(runDir, "targets.json"), `${JSON.stringify({ repo, soak, riskSnapshot: safeRiskSnapshot, duplicateWork: safeDuplicateWork, peerWorktrees, outcomeLedger, executionPlan, candidates, selected }, null, 2)}\n`);
   writeFileSync(path.join(runDir, "risk-snapshot.json"), `${JSON.stringify(safeRiskSnapshot, null, 2)}\n`);
   writeFileSync(path.join(runDir, "risk-snapshot.md"), renderRiskSnapshotMarkdown(safeRiskSnapshot));
+  writeFileSync(path.join(runDir, "duplicate-work.json"), `${JSON.stringify(safeDuplicateWork, null, 2)}\n`);
+  writeFileSync(path.join(runDir, "duplicate-work.md"), renderDuplicateWorkMarkdown(safeDuplicateWork));
   writeFileSync(path.join(runDir, "execution-plan.json"), `${JSON.stringify(executionPlan, null, 2)}\n`);
   writeFileSync(path.join(runDir, "execution-plan.md"), renderExecutionPlanMarkdown(executionPlan));
   writeFileSync(path.join(runDir, "outcome-closeout.md"), outcomeCloseout);
@@ -1556,6 +1753,7 @@ export function writeRunPlan({ runDir, repo, soak, riskSnapshot, peerWorktrees =
     reportPath: path.join(runDir, "report.md"),
     tasksDir,
     riskSnapshotPath: path.join(runDir, "risk-snapshot.md"),
+    duplicateWorkPath: path.join(runDir, "duplicate-work.md"),
     executionPlanPath: path.join(runDir, "execution-plan.md"),
     outcomeCloseoutPath: path.join(runDir, "outcome-closeout.md"),
     outcomeTemplatePath: path.join(runDir, "outcome-template.jsonl"),
@@ -1569,11 +1767,13 @@ export function planNightlyRun(args) {
   const repo = collectRepoSnapshot(args.repo);
   const peerWorktrees = collectPeerWorktrees(args.repo, args.peerWorktrees, args.peerScan);
   const outcomeLedger = summarizeOutcomeLedger(args.outcomeLedger);
+  const duplicateWork = collectDuplicateWork(peerWorktrees);
   const riskSnapshot = collectRiskSnapshot({
     repoPath: args.repo,
     repo,
     soak,
     peerWorktrees,
+    duplicateWork,
     crashAutomation: args.crashAutomation,
     dailyBugMemory: args.dailyBugMemory,
     devBotMemory: args.devBotMemory,
@@ -1583,6 +1783,7 @@ export function planNightlyRun(args) {
     dailyBug,
     repo,
     riskSnapshot,
+    duplicateWork,
     peerWorktrees,
     crashAutomationExists: existsSync(args.crashAutomation),
     devBotMemoryExists: existsSync(args.devBotMemory),
@@ -1590,7 +1791,7 @@ export function planNightlyRun(args) {
   });
   const candidates = applyOutcomeFeedback(baseCandidates, outcomeLedger);
   const selected = selectTargets(candidates, args);
-  return { repo, soak, dailyBug, riskSnapshot, peerWorktrees, outcomeLedger, candidates, selected };
+  return { repo, soak, dailyBug, riskSnapshot, duplicateWork, peerWorktrees, outcomeLedger, candidates, selected };
 }
 
 function textSummary(plan, writeResult, args) {
@@ -1599,6 +1800,7 @@ function textSummary(plan, writeResult, args) {
     `Max WebKit RSS: ${formatBytes(plan.soak.maxWebKitResidentBytes)}.`,
     `Stale heartbeat events: ${numberFormatter.format(plan.soak.staleHeartbeatCount)}.`,
     `Preflight risks: ${numberFormatter.format(plan.riskSnapshot.blockerCount)} blockers, ${numberFormatter.format(plan.riskSnapshot.warningCount)} warnings.`,
+    `Duplicate work: ${numberFormatter.format(plan.duplicateWork.findingCount)} findings.`,
     `Peer worktrees with changes: ${numberFormatter.format(plan.peerWorktrees.length)}.`,
     `Prior outcomes loaded: ${numberFormatter.format(plan.outcomeLedger.entries.length)}.`,
   ];
@@ -1611,6 +1813,7 @@ function textSummary(plan, writeResult, args) {
     lines.push(`Report: ${writeResult.reportPath}`);
     lines.push(`Tasks: ${writeResult.tasksDir}`);
     lines.push(`Risk snapshot: ${writeResult.riskSnapshotPath}`);
+    lines.push(`Duplicate work: ${writeResult.duplicateWorkPath}`);
     lines.push(`Execution plan: ${writeResult.executionPlanPath}`);
     lines.push(`Outcome closeout: ${writeResult.outcomeCloseoutPath}`);
     lines.push(`Outcome template: ${writeResult.outcomeTemplatePath}`);
@@ -1662,6 +1865,7 @@ export function main(argv = process.argv.slice(2)) {
         repo: plan.repo,
         soak: plan.soak,
         riskSnapshot: plan.riskSnapshot,
+        duplicateWork: plan.duplicateWork,
         peerWorktrees: plan.peerWorktrees,
         candidates: plan.candidates,
         selected: plan.selected,

--- a/scripts/nightly-self-improve.test.mjs
+++ b/scripts/nightly-self-improve.test.mjs
@@ -10,6 +10,7 @@ import {
   appendOutcomeLedger,
   buildCandidates,
   buildExecutionPlan,
+  collectDuplicateWork,
   collectRepoSnapshot,
   collectRiskSnapshot,
   formatBytes,
@@ -277,6 +278,81 @@ test("peer worktree candidates outrank generic roadmap work", () => {
   assert.equal(selected[0].providerVisible, false);
 });
 
+test("duplicate work detector reports file and surface overlap", () => {
+  const duplicateWork = collectDuplicateWork([
+    {
+      branch: "feat/nightly-one",
+      path: "/tmp/one",
+      head: "abc1234",
+      changedFiles: [
+        "scripts/nightly-self-improve.mjs",
+        "docs/NIGHTLY-SELF-IMPROVE.md",
+      ],
+      touchesNightlyRunner: true,
+      touchesMemoryTelemetry: false,
+      providerVisible: false,
+    },
+    {
+      branch: "feat/nightly-two",
+      path: "/tmp/two",
+      head: "def5678",
+      changedFiles: [
+        "scripts/nightly-self-improve.mjs",
+        "scripts/nightly-self-improve.test.mjs",
+      ],
+      touchesNightlyRunner: true,
+      touchesMemoryTelemetry: false,
+      providerVisible: false,
+    },
+  ]);
+
+  assert.ok(duplicateWork.findingCount >= 2);
+  assert.ok(duplicateWork.findings.some((finding) => finding.kind === "file-overlap"));
+  assert.ok(duplicateWork.findings.some((finding) => finding.key === "nightly-runner"));
+  assert.equal(duplicateWork.blockerCount, 1);
+});
+
+test("duplicate work candidates are selected before generic roadmap fallback", () => {
+  const duplicateWork = {
+    findingCount: 1,
+    blockerCount: 0,
+    warningCount: 1,
+    findings: [
+      {
+        severity: "warning",
+        title: "Multiple peer worktrees are touching scripts",
+        peers: [{ branch: "feat/nightly-one", path: "/tmp/one" }],
+      },
+    ],
+  };
+  const candidates = buildCandidates({
+    soak: {
+      exists: false,
+      soakDir: "",
+      sampleCount: 0,
+      maxWebKitResidentBytes: null,
+      maxEventLoopLagMs: null,
+      maxDomNodes: null,
+      staleHeartbeatCount: 0,
+      throttledHeartbeatCount: 0,
+      lastEvent: "",
+    },
+    dailyBug: { exists: false },
+    repo: { branch: "feature", head: "abc1234", status: "" },
+    duplicateWork,
+    peerWorktrees: [],
+    crashAutomationExists: false,
+    devBotMemoryExists: true,
+    memoryBudgetBytes: 2.5 * GIB,
+  });
+
+  assert.ok(candidates.findIndex((candidate) => candidate.id === "nightly-duplicate-work") >= 0);
+  assert.ok(
+    candidates.findIndex((candidate) => candidate.id === "nightly-duplicate-work") <
+      candidates.findIndex((candidate) => candidate.id === "roadmap-autonomous-task"),
+  );
+});
+
 test("outcome feedback raises shipped target kinds and lowers failed ones", () => {
   const dir = mkdtempSync(path.join(os.tmpdir(), "freed-outcomes-"));
   const ledgerPath = path.join(dir, "outcomes.jsonl");
@@ -409,6 +485,7 @@ test("writeRunPlan emits report, targets, and task prompts", () => {
   assert.equal(path.basename(result.reportPath), "report.md");
   assert.equal(path.basename(result.tasksDir), "tasks");
   assert.equal(path.basename(result.riskSnapshotPath), "risk-snapshot.md");
+  assert.equal(path.basename(result.duplicateWorkPath), "duplicate-work.md");
   assert.equal(path.basename(result.executionPlanPath), "execution-plan.md");
   assert.equal(path.basename(result.outcomeCloseoutPath), "outcome-closeout.md");
   assert.equal(path.basename(result.outcomeTemplatePath), "outcome-template.jsonl");

--- a/website/src/app/roadmap/RoadmapContent.tsx
+++ b/website/src/app/roadmap/RoadmapContent.tsx
@@ -783,7 +783,7 @@ const phases: Phase[] = [
     number: 10,
     title: "Polish",
     description:
-      "Onboarding, statistics, global animation controls, expanded local content signals with Desktop and PWA backfill, inclusive saved feed filter presets, compact event extraction, local semantic enrichment for friend suggestions, unified AI provider settings, Light, Balanced, and Pro Integrated AI packs with semantic scan health, plugin API, community infrastructure, preflight-aware nightly improvement planning with learned closeout, and deeper crash recovery hardening.",
+      "Onboarding, statistics, global animation controls, expanded local content signals with Desktop and PWA backfill, inclusive saved feed filter presets, compact event extraction, local semantic enrichment for friend suggestions, unified AI provider settings, Light, Balanced, and Pro Integrated AI packs with semantic scan health, plugin API, community infrastructure, duplicate-aware nightly improvement planning with learned closeout, and deeper crash recovery hardening.",
     status: "upcoming",
     planLink:
       "https://github.com/freed-project/freed/blob/dev/docs/PHASE-10-POLISH.md",


### PR DESCRIPTION
(AI Generated).

## Summary
- Adds duplicate work detection for peer worktrees by shared changed file and shared surface tag before overnight agents publish overlapping fixes.
- Writes duplicate-work Markdown and JSON artifacts, folds overlaps into preflight risk, and ranks duplicate work as a selectable target.

## Testing
- node --test scripts/nightly-self-improve.test.mjs
- corepack npm run test:scripts
- corepack npm run validate:feature