### PR TITLE
perf: keep RSS polling out of social scraping

### DIFF
--- a/packages/desktop/src/App.tsx
+++ b/packages/desktop/src/App.tsx
@@ -22,7 +22,7 @@ import { useDebugStore } from "@freed/ui/lib/debug-store";
 import { UpdateNotification, type UpdateState } from "./components/UpdateNotification";
 import { CloudSyncNudge } from "./components/CloudSyncNudge";
 import { useAppStore } from "./lib/store";
-import { addRssFeed, importOPMLFeeds, exportFeedsAsOPML, refreshAllFeeds } from "./lib/capture";
+import { addRssFeed, importOPMLFeeds, exportFeedsAsOPML, refreshAllFeeds, refreshRssFeeds } from "./lib/capture";
 import { startRssPoller, stopRssPoller } from "./lib/rss-poller";
 import { exit, relaunch } from "@tauri-apps/plugin-process";
 import { open as shellOpen } from "@tauri-apps/plugin-shell";
@@ -829,7 +829,7 @@ function App() {
       retryCloudProvider,
       reconnectCloudProvider,
       forgetRssFeedHealth,
-      syncRssNow: refreshAllFeeds,
+      syncRssNow: refreshRssFeeds,
       syncSourceNow: async (sourceId) => {
         const state = useDesktopStore.getState();
         const health = useDebugStore.getState().health;
@@ -841,7 +841,7 @@ function App() {
           health?.providers[sourceId]?.status === "paused";
 
         if (sourceId === "rss") {
-          await refreshAllFeeds();
+          await refreshRssFeeds();
           return;
         }
 

--- a/packages/desktop/src/lib/capture.ts
+++ b/packages/desktop/src/lib/capture.ts
@@ -9,7 +9,11 @@
 import { invoke, isTauri } from "@tauri-apps/api/core";
 import type { FeedItem, RssFeed, OPMLFeedEntry } from "@freed/shared";
 import { generateOPML, downloadFile } from "@freed/shared";
-import { parseFeedXml, feedToFeedItems, feedToRssFeed } from "@freed/capture-rss/browser";
+import {
+  parseFeedXml,
+  feedToFeedItems,
+  feedToRssFeed,
+} from "@freed/capture-rss/browser";
 import { captureXTimeline } from "./x-capture";
 import { captureFbFeed } from "./fb-capture";
 import { captureIgFeed } from "./instagram-capture";
@@ -84,7 +88,7 @@ export async function addRssFeed(feedUrl: string): Promise<void> {
     await store.addItems(items);
   } catch (error) {
     store.setError(
-      error instanceof Error ? error.message : "Failed to add feed"
+      error instanceof Error ? error.message : "Failed to add feed",
     );
     throw error;
   } finally {
@@ -95,22 +99,190 @@ export async function addRssFeed(feedUrl: string): Promise<void> {
 /** Max concurrent feed fetches — avoids saturating Tauri's HTTP layer. */
 const FETCH_CONCURRENCY = 5;
 
+async function refreshEnabledRssFeeds(
+  store: ReturnType<typeof useAppStore.getState>,
+  feeds: RssFeed[],
+): Promise<void> {
+  if (feeds.length === 0) return;
+  try {
+    await withProviderSyncing("rss", async () => {
+      const allNewItems: FeedItem[] = [];
+      const fetchedFeeds: RssFeed[] = [];
+      const feedErrors: string[] = [];
+      const rssStartedAt = Date.now();
+      const rssBefore = store.items.filter(
+        (item) => item.platform === "rss",
+      ).length;
+      let rssSeen = 0;
+
+      for (let i = 0; i < feeds.length; i += FETCH_CONCURRENCY) {
+        const batch = feeds.slice(i, i + FETCH_CONCURRENCY);
+        const results = await Promise.allSettled(
+          batch.map(async (feed) => {
+            const { items, liveTitle, liveSiteUrl } = await fetchRssFeed(
+              feed.url,
+            );
+            const isUntitled =
+              feed.title === "Untitled Feed" || feed.title === feed.url;
+
+            let healedTitle: string | undefined;
+            if (isUntitled) {
+              try {
+                healedTitle =
+                  liveTitle ??
+                  new URL(feed.url).hostname.replace(/^(?:www|feeds?)\./, "");
+              } catch {
+                healedTitle = liveTitle;
+              }
+              console.log(
+                `[Heal] ${feed.url} | stored="${feed.title}" liveTitle="${liveTitle}" healedTitle="${healedTitle}"`,
+              );
+            }
+
+            return {
+              feed: {
+                ...feed,
+                lastFetched: Date.now(),
+                ...(healedTitle ? { title: healedTitle } : {}),
+                ...(!feed.siteUrl && liveSiteUrl
+                  ? { siteUrl: liveSiteUrl }
+                  : {}),
+              },
+              items,
+            };
+          }),
+        );
+
+        for (const [resultIndex, result] of results.entries()) {
+          if (result.status === "fulfilled") {
+            fetchedFeeds.push(result.value.feed);
+            allNewItems.push(...result.value.items);
+            rssSeen += result.value.items.length;
+            await recordProviderHealthEvent({
+              provider: "rss",
+              scope: "rss_feed",
+              feedUrl: result.value.feed.url,
+              feedTitle: result.value.feed.title,
+              outcome: result.value.items.length > 0 ? "success" : "empty",
+              stage: result.value.items.length > 0 ? undefined : "empty",
+              reason:
+                result.value.items.length > 0 ? undefined : "No entries pulled",
+              startedAt: rssStartedAt,
+              finishedAt: Date.now(),
+              itemsSeen: result.value.items.length,
+              itemsAdded: result.value.items.length,
+            });
+          } else {
+            const msg =
+              result.reason instanceof Error
+                ? result.reason.message
+                : String(result.reason);
+            console.error("[Refresh] Feed fetch failed:", result.reason);
+            feedErrors.push(msg);
+            addDebugEvent("error", `[RSS] feed fetch failed: ${msg}`);
+            const failedFeed = batch[resultIndex];
+            if (failedFeed) {
+              await recordProviderHealthEvent({
+                provider: "rss",
+                scope: "rss_feed",
+                feedUrl: failedFeed.url,
+                feedTitle: failedFeed.title,
+                outcome: "error",
+                stage: "fetch",
+                reason: msg,
+                startedAt: rssStartedAt,
+                finishedAt: Date.now(),
+              });
+            }
+          }
+        }
+      }
+
+      if (fetchedFeeds.length > 0 || allNewItems.length > 0) {
+        await docBatchRefreshFeeds(fetchedFeeds, allNewItems);
+      }
+      const rssAfter = useAppStore
+        .getState()
+        .items.filter((item) => item.platform === "rss").length;
+      const rssItemsAdded = Math.max(0, rssAfter - rssBefore);
+      await recordProviderHealthEvent({
+        provider: "rss",
+        outcome: fetchedFeeds.length > 0 ? "success" : "error",
+        stage: fetchedFeeds.length > 0 ? undefined : "fetch",
+        reason:
+          fetchedFeeds.length > 0
+            ? feedErrors.length > 0
+              ? `${feedErrors.length.toLocaleString()} feed failure${feedErrors.length === 1 ? "" : "s"} in batch`
+              : undefined
+            : (feedErrors[0] ?? "RSS refresh failed"),
+        startedAt: rssStartedAt,
+        finishedAt: Date.now(),
+        itemsSeen: rssSeen,
+        itemsAdded: rssItemsAdded,
+      });
+
+      if (feedErrors.length > 0) {
+        if (feedErrors.length === feeds.length) {
+          store.setError(
+            feedErrors.length === 1
+              ? `Feed failed to load: ${feedErrors[0]}`
+              : `All ${feedErrors.length.toLocaleString()} feeds failed to load. Check your network connection.`,
+          );
+        } else {
+          console.warn(
+            `[Refresh] ${feedErrors.length.toLocaleString()}/${feeds.length.toLocaleString()} feeds failed (partial):`,
+            feedErrors,
+          );
+        }
+      }
+    });
+  } catch (rssError) {
+    const msg =
+      rssError instanceof Error ? rssError.message : "RSS refresh failed";
+    console.error("[Refresh] RSS batch failed:", rssError);
+    store.setError(msg);
+    addDebugEvent("error", `[RSS] batch refresh failed: ${msg}`);
+    await recordProviderHealthEvent({
+      provider: "rss",
+      outcome: "error",
+      stage: "merge",
+      reason: msg,
+      finishedAt: Date.now(),
+    });
+  }
+}
+
+export async function refreshRssFeeds(): Promise<void> {
+  if (!isTauri()) {
+    addDebugEvent(
+      "change",
+      "[Capture] Browser preview skips native RSS refresh",
+    );
+    return;
+  }
+  const store = useAppStore.getState();
+  const feeds = Object.values(store.feeds).filter((f) => f.enabled);
+  if (feeds.length === 0) return;
+
+  store.setSyncing(true);
+  store.setError(null);
+
+  try {
+    await refreshEnabledRssFeeds(store, feeds);
+  } finally {
+    store.setSyncing(false);
+  }
+}
+
 /**
- * Refresh all subscribed RSS feeds and the X timeline.
- *
- * Key performance contract: ALL feed fetches run in parallel batches, and the
- * entire result (feed timestamps + new items) is committed as ONE Automerge
- * change. Previously this was N sequential changes → N full-doc IndexedDB
- * writes → N React re-renders → N rankFeedItems passes. Now it's 1.
- *
- * Error isolation contract: RSS and X are fully independent. A failure in
- * either path is logged and surfaces a user notification, but never prevents
- * the other path from running. Individual feed fetch failures are logged
- * silently unless every single feed failed (in which case the user is told).
+ * Refresh all subscribed RSS feeds and authenticated social providers.
  */
 export async function refreshAllFeeds(): Promise<void> {
   if (!isTauri()) {
-    addDebugEvent("change", "[Capture] Browser preview skips native background refresh");
+    addDebugEvent(
+      "change",
+      "[Capture] Browser preview skips native background refresh",
+    );
     return;
   }
   const store = useAppStore.getState();
@@ -123,178 +295,29 @@ export async function refreshAllFeeds(): Promise<void> {
       store.igAuth.isAuthenticated ||
       store.liAuth.isAuthenticated);
 
-  // Skip only when there is truly nothing to do.
   if (feeds.length === 0 && !hasNativeSocialRefresh) return;
 
   store.setSyncing(true);
   store.setError(null);
 
   try {
-    // ── RSS feeds ─────────────────────────────────────────────────────────────
-    // Each feed fetch is already isolated by Promise.allSettled. The Automerge
-    // commit is wrapped in its own try/catch so a CRDT write error can't
-    // prevent the X capture below from running.
-    try {
-      await withProviderSyncing("rss", async () => {
-        const allNewItems: FeedItem[] = [];
-        const fetchedFeeds: RssFeed[] = [];
-        const feedErrors: string[] = [];
-        const rssStartedAt = Date.now();
-        const rssBefore = store.items.filter((item) => item.platform === "rss").length;
-        let rssSeen = 0;
-
-        // Parallel fetch with concurrency cap
-        for (let i = 0; i < feeds.length; i += FETCH_CONCURRENCY) {
-          const batch = feeds.slice(i, i + FETCH_CONCURRENCY);
-          const results = await Promise.allSettled(
-            batch.map(async (feed) => {
-              const { items, liveTitle, liveSiteUrl } = await fetchRssFeed(feed.url);
-
-              // Sentinel check: OPML fallback or raw URL as title both indicate a broken import.
-              const isUntitled = feed.title === "Untitled Feed" || feed.title === feed.url;
-
-              // Resolve the best available title:
-              //   1. Live XML title (if the parser found one)
-              //   2. Hostname of the feed URL (e.g. "news.ycombinator.com") as a
-              //      last resort so the feed doesn't stay labelled "Untitled Feed"
-              //      forever when the XML genuinely omits a <title> element.
-              let healedTitle: string | undefined;
-              if (isUntitled) {
-                try {
-                  healedTitle = liveTitle ?? new URL(feed.url).hostname.replace(/^(?:www|feeds?)\./, "");
-                } catch {
-                  healedTitle = liveTitle;
-                }
-                console.log(
-                  `[Heal] ${feed.url} | stored="${feed.title}" liveTitle="${liveTitle}" healedTitle="${healedTitle}"`,
-                );
-              }
-
-              return {
-                feed: {
-                  ...feed,
-                  lastFetched: Date.now(),
-                  ...(healedTitle ? { title: healedTitle } : {}),
-                  ...(!feed.siteUrl && liveSiteUrl ? { siteUrl: liveSiteUrl } : {}),
-                },
-                items,
-              };
-            }),
-          );
-
-          for (const [resultIndex, result] of results.entries()) {
-            if (result.status === "fulfilled") {
-              fetchedFeeds.push(result.value.feed);
-              allNewItems.push(...result.value.items);
-              rssSeen += result.value.items.length;
-              await recordProviderHealthEvent({
-                provider: "rss",
-                scope: "rss_feed",
-                feedUrl: result.value.feed.url,
-                feedTitle: result.value.feed.title,
-                outcome: result.value.items.length > 0 ? "success" : "empty",
-                stage: result.value.items.length > 0 ? undefined : "empty",
-                reason: result.value.items.length > 0 ? undefined : "No entries pulled",
-                startedAt: rssStartedAt,
-                finishedAt: Date.now(),
-                itemsSeen: result.value.items.length,
-                itemsAdded: result.value.items.length,
-              });
-            } else {
-              const msg = result.reason instanceof Error
-                ? result.reason.message
-                : String(result.reason);
-              console.error("[Refresh] Feed fetch failed:", result.reason);
-              feedErrors.push(msg);
-              addDebugEvent("error", `[RSS] feed fetch failed: ${msg}`);
-              const failedFeed = batch[resultIndex];
-              if (failedFeed) {
-                await recordProviderHealthEvent({
-                  provider: "rss",
-                  scope: "rss_feed",
-                  feedUrl: failedFeed.url,
-                  feedTitle: failedFeed.title,
-                  outcome: "error",
-                  stage: "fetch",
-                  reason: msg,
-                  startedAt: rssStartedAt,
-                  finishedAt: Date.now(),
-                });
-              }
-            }
-          }
-        }
-
-        // Single Automerge change for ALL feed + item updates
-        if (fetchedFeeds.length > 0 || allNewItems.length > 0) {
-          await docBatchRefreshFeeds(fetchedFeeds, allNewItems);
-        }
-        const rssAfter = useAppStore.getState().items.filter((item) => item.platform === "rss").length;
-        const rssItemsAdded = Math.max(0, rssAfter - rssBefore);
-        if (feeds.length > 0) {
-          await recordProviderHealthEvent({
-            provider: "rss",
-            outcome: fetchedFeeds.length > 0 ? "success" : "error",
-            stage:
-              fetchedFeeds.length > 0
-                ? undefined
-                : "fetch",
-            reason:
-              fetchedFeeds.length > 0
-                ? feedErrors.length > 0
-                  ? `${feedErrors.length.toLocaleString()} feed failure${feedErrors.length === 1 ? "" : "s"} in batch`
-                  : undefined
-                : feedErrors[0] ?? "RSS refresh failed",
-            startedAt: rssStartedAt,
-            finishedAt: Date.now(),
-            itemsSeen: rssSeen,
-            itemsAdded: rssItemsAdded,
-          });
-        }
-
-        // Surface per-feed failures to the user only when every feed failed.
-        // Partial failures are logged but kept silent - some fresh content is
-        // better than a scary error banner.
-        if (feedErrors.length > 0) {
-          if (feedErrors.length === feeds.length) {
-            store.setError(
-              feedErrors.length === 1
-                ? `Feed failed to load: ${feedErrors[0]}`
-                : `All ${feedErrors.length} feeds failed to load. Check your network connection.`,
-            );
-          } else {
-            console.warn(
-              `[Refresh] ${feedErrors.length}/${feeds.length} feeds failed (partial):`,
-              feedErrors,
-            );
-          }
-        }
-      });
-    } catch (rssError) {
-      // Automerge commit error or unexpected RSS failure — log and notify,
-      // but continue so the X capture below still runs.
-      const msg = rssError instanceof Error ? rssError.message : "RSS refresh failed";
-      console.error("[Refresh] RSS batch failed:", rssError);
-      store.setError(msg);
-      addDebugEvent("error", `[RSS] batch refresh failed: ${msg}`);
-      await recordProviderHealthEvent({
-        provider: "rss",
-        outcome: "error",
-        stage: "merge",
-        reason: msg,
-        finishedAt: Date.now(),
-      });
-    }
+    await refreshEnabledRssFeeds(store, feeds);
 
     // ── X timeline ────────────────────────────────────────────────────────────
     // Always runs, fully independent of RSS outcome.
     const { xAuth } = useAppStore.getState();
     const xCookies = xAuth.cookies;
-    if (tauriAvailable && xAuth.isAuthenticated && xCookies && !isProviderPaused("x")) {
+    if (
+      tauriAvailable &&
+      xAuth.isAuthenticated &&
+      xCookies &&
+      !isProviderPaused("x")
+    ) {
       try {
         await withProviderSyncing("x", () => captureXTimeline(xCookies));
       } catch (xError) {
-        const msg = xError instanceof Error ? xError.message : "X timeline sync failed";
+        const msg =
+          xError instanceof Error ? xError.message : "X timeline sync failed";
         console.error("[Refresh] X timeline failed:", xError);
         addDebugEvent("error", `[X] timeline sync threw: ${msg}`);
         if (!useAppStore.getState().error) {
@@ -306,11 +329,18 @@ export async function refreshAllFeeds(): Promise<void> {
     // ── Facebook feed ─────────────────────────────────────────────────────────
     // Independent of both RSS and X outcomes.
     const { fbAuth } = useAppStore.getState();
-    if (tauriAvailable && fbAuth.isAuthenticated && !isProviderPaused("facebook")) {
+    if (
+      tauriAvailable &&
+      fbAuth.isAuthenticated &&
+      !isProviderPaused("facebook")
+    ) {
       try {
         await withProviderSyncing("facebook", () => captureFbFeed());
       } catch (fbError) {
-        const msg = fbError instanceof Error ? fbError.message : "Facebook feed sync failed";
+        const msg =
+          fbError instanceof Error
+            ? fbError.message
+            : "Facebook feed sync failed";
         console.error("[Refresh] Facebook feed failed:", fbError);
         addDebugEvent("error", `[FB] feed sync threw: ${msg}`);
         if (!useAppStore.getState().error) {
@@ -322,11 +352,18 @@ export async function refreshAllFeeds(): Promise<void> {
     // ── Instagram feed ───────────────────────────────────────────────────────
     // Independent of RSS, X, and Facebook outcomes.
     const { igAuth } = useAppStore.getState();
-    if (tauriAvailable && igAuth.isAuthenticated && !isProviderPaused("instagram")) {
+    if (
+      tauriAvailable &&
+      igAuth.isAuthenticated &&
+      !isProviderPaused("instagram")
+    ) {
       try {
         await withProviderSyncing("instagram", () => captureIgFeed());
       } catch (igError) {
-        const msg = igError instanceof Error ? igError.message : "Instagram feed sync failed";
+        const msg =
+          igError instanceof Error
+            ? igError.message
+            : "Instagram feed sync failed";
         console.error("[Refresh] Instagram feed failed:", igError);
         addDebugEvent("error", `[IG] feed sync threw: ${msg}`);
         if (!useAppStore.getState().error) {
@@ -338,11 +375,18 @@ export async function refreshAllFeeds(): Promise<void> {
     // ── LinkedIn feed ─────────────────────────────────────────────────────────
     // Independent of RSS, X, Facebook, and Instagram outcomes.
     const { liAuth } = useAppStore.getState();
-    if (tauriAvailable && liAuth.isAuthenticated && !isProviderPaused("linkedin")) {
+    if (
+      tauriAvailable &&
+      liAuth.isAuthenticated &&
+      !isProviderPaused("linkedin")
+    ) {
       try {
         await withProviderSyncing("linkedin", () => captureLiFeed());
       } catch (liError) {
-        const msg = liError instanceof Error ? liError.message : "LinkedIn feed sync failed";
+        const msg =
+          liError instanceof Error
+            ? liError.message
+            : "LinkedIn feed sync failed";
         console.error("[Refresh] LinkedIn feed failed:", liError);
         addDebugEvent("error", `[LI] feed sync threw: ${msg}`);
         if (!useAppStore.getState().error) {
@@ -432,8 +476,8 @@ export async function importOPMLFeeds(
 
   // Trigger refresh to fetch items for newly subscribed feeds
   if (progress.added > 0) {
-    // Fire-and-forget — the UI shows sync spinner via store state
-    refreshAllFeeds();
+    // Fire-and-forget. The UI shows sync spinner via store state.
+    void refreshRssFeeds();
   }
 
   return progress;

--- a/packages/desktop/src/lib/rss-poller.test.ts
+++ b/packages/desktop/src/lib/rss-poller.test.ts
@@ -1,17 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const refreshAllFeeds = vi.fn();
+const refreshRssFeeds = vi.fn();
 const addDebugEvent = vi.fn();
 const runBackgroundJob = vi.fn();
 const isBackgroundRuntimeDeferredError = vi.fn(
   (error: unknown) =>
-    typeof error === "object" &&
-    error !== null &&
-    "reason" in error,
+    typeof error === "object" && error !== null && "reason" in error,
 );
 
 vi.mock("./capture", () => ({
-  refreshAllFeeds,
+  refreshRssFeeds,
 }));
 
 vi.mock("@freed/ui/lib/debug-store", () => ({
@@ -31,7 +29,7 @@ async function loadPoller() {
 describe("rss poller", () => {
   beforeEach(() => {
     vi.useFakeTimers();
-    refreshAllFeeds.mockReset();
+    refreshRssFeeds.mockReset();
     addDebugEvent.mockReset();
     runBackgroundJob.mockReset();
     isBackgroundRuntimeDeferredError.mockClear();
@@ -53,6 +51,12 @@ describe("rss poller", () => {
 
     await vi.runAllTicks();
     expect(runBackgroundJob).toHaveBeenCalledTimes(1);
+    expect(runBackgroundJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "rss-poll",
+        run: refreshRssFeeds,
+      }),
+    );
 
     await vi.advanceTimersByTimeAsync(14_999);
     expect(runBackgroundJob).toHaveBeenCalledTimes(1);

--- a/packages/desktop/src/lib/rss-poller.ts
+++ b/packages/desktop/src/lib/rss-poller.ts
@@ -5,7 +5,7 @@
  * Runs in the JavaScript layer so it works regardless of Tauri's background state.
  */
 
-import { refreshAllFeeds } from "./capture";
+import { refreshRssFeeds } from "./capture";
 import { addDebugEvent } from "@freed/ui/lib/debug-store";
 import {
   isBackgroundRuntimeDeferredError,
@@ -77,7 +77,7 @@ async function triggerPoll(): Promise<void> {
       kind: "rss-poll",
       source: "rss-poller",
       timeoutMs: 180_000,
-      run: refreshAllFeeds,
+      run: refreshRssFeeds,
     });
     clearDeferredRetry();
   } catch (err) {


### PR DESCRIPTION
(AI Generated).

## Summary
- Adds an RSS-only refresh path for background polling, OPML imports, and RSS source sync.
- Keeps explicit social provider sync on the existing provider paths instead of the generic RSS poller.

## Testing
- Focused desktop unit tests for RSS poller and social memory preflight passed.
- Desktop root typecheck passed.
- npm run validate:feature passed.
- Desktop regression E2E passed with 125 tests.