### PR TITLE
perf: cap background article fetch size

### DIFF
--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -1288,7 +1288,7 @@ dependencies = [
 
 [[package]]
 name = "freed-desktop"
-version = "26.5.2700"
+version = "26.5.2903"
 dependencies = [
  "base64 0.22.1",
  "criterion",

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -2175,7 +2175,7 @@ async fn pick_contact() -> Result<Option<ContactResult>, String> {
 
 /// Fetch any URL and return its body as text (bypasses browser CORS).
 #[tauri::command]
-async fn fetch_url(url: String) -> Result<String, String> {
+async fn fetch_url(url: String, max_bytes: Option<usize>) -> Result<String, String> {
     let client = reqwest::Client::builder()
         .user_agent("Freed/1.0 (https://freed.wtf)")
         .build()
@@ -2191,7 +2191,33 @@ async fn fetch_url(url: String) -> Result<String, String> {
         return Err(format!("HTTP {}: {}", response.status(), url));
     }
 
-    response.text().await.map_err(|e| e.to_string())
+    let Some(limit) = max_bytes else {
+        return response.text().await.map_err(|e| e.to_string());
+    };
+
+    if let Some(content_length) = response.content_length() {
+        if content_length > limit as u64 {
+            return Err(format!(
+                "response_too_large content_length={} limit={} url={}",
+                content_length, limit, url
+            ));
+        }
+    }
+
+    let mut body: Vec<u8> = Vec::new();
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|e| e.to_string())?;
+        if body.len().saturating_add(chunk.len()) > limit {
+            return Err(format!(
+                "response_too_large bytes_exceeded limit={} url={}",
+                limit, url
+            ));
+        }
+        body.extend_from_slice(&chunk);
+    }
+
+    Ok(String::from_utf8_lossy(&body).into_owned())
 }
 
 #[derive(serde::Serialize)]

--- a/packages/desktop/src/lib/content-fetcher.test.ts
+++ b/packages/desktop/src/lib/content-fetcher.test.ts
@@ -141,6 +141,7 @@ async function loadContentFetcherModule() {
   return {
     mod,
     subscriberRef,
+    mockInvoke,
     mockCacheSet,
     mockDocUpdateFeedItem,
   };
@@ -245,6 +246,8 @@ async function loadContentFetcherModuleWithAi({
   return {
     mod,
     subscriberRef,
+    mockInvoke,
+    mockCacheSet,
     mockDocUpdateFeedItem,
     mockSummarize,
     mockGetApiKey,
@@ -261,13 +264,17 @@ afterEach(() => {
 describe("content fetcher", () => {
   it("keeps full HTML in the local cache but syncs only a compact excerpt", async () => {
     vi.useFakeTimers();
-    const { mod, subscriberRef, mockCacheSet, mockDocUpdateFeedItem } = await loadContentFetcherModule();
+    const { mod, subscriberRef, mockInvoke, mockCacheSet, mockDocUpdateFeedItem } = await loadContentFetcherModule();
 
     mod.start();
     subscriberRef.current?.({ items: [makeStubItem()], docItemCount: 1 });
     await vi.advanceTimersByTimeAsync(0);
     mod.stop();
 
+    expect(mockInvoke).toHaveBeenCalledWith("fetch_url", {
+      url: SAMPLE_URL,
+      maxBytes: 2 * 1024 * 1024,
+    });
     expect(mockCacheSet).toHaveBeenCalledWith("rss:1", SAMPLE_ARTICLE_HTML);
     expect(mockDocUpdateFeedItem).toHaveBeenCalledOnce();
 
@@ -420,6 +427,28 @@ describe("content fetcher", () => {
       backoffLevel: 0,
       pending: 0,
       completed: 1,
+    }));
+  });
+
+  it("skips oversized background article fetches without parsing or retry backoff", async () => {
+    vi.useFakeTimers();
+    const { mod, subscriberRef, mockCacheSet, mockDocUpdateFeedItem } = await loadContentFetcherModuleWithAi({
+      autoSummarize: false,
+      extractTopics: false,
+      invokeImpl: () => Promise.reject(new Error("response_too_large content_length=22000000 limit=2097152 url=https://example.com/articles/memory-landfill")),
+    });
+
+    mod.start();
+    subscriberRef.current?.({ items: [makeStubItem()], docItemCount: 1 });
+    await vi.advanceTimersByTimeAsync(0);
+    mod.stop();
+
+    expect(mockCacheSet).not.toHaveBeenCalled();
+    expect(mockDocUpdateFeedItem).not.toHaveBeenCalled();
+    expect(mod.getStatus()).toEqual(expect.objectContaining({
+      backoffLevel: 0,
+      failedCount: 1,
+      pending: 0,
     }));
   });
 

--- a/packages/desktop/src/lib/content-fetcher.ts
+++ b/packages/desktop/src/lib/content-fetcher.ts
@@ -37,12 +37,14 @@ import {
 const FETCH_TIMEOUT_MS = 30_000;
 const AI_SUMMARY_TIMEOUT_MS = 60_000;
 const AI_SUMMARY_TIMEOUT_MESSAGE = "ai_summarize TIMEOUT";
+const MAX_BACKGROUND_HTML_BYTES = 2 * 1024 * 1024;
 const BASE_DELAY_MIN_MS = 2_500;
 const BASE_DELAY_MAX_MS = 7_500;
 const MAX_BACKOFF_LEVEL = 5;
 const HEARTBEAT_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
 const FAILED_RETRY_COOLDOWN_MS = 24 * 60 * 60 * 1000;
 const MAX_FAILED_TRACKED = 2_000;
+const RESPONSE_TOO_LARGE_PREFIX = "response_too_large";
 
 export interface FetcherStatus {
   pending: number;
@@ -207,7 +209,7 @@ function maybeScanVisibleItems(items: FeedItem[], docItemCount: number): void {
   enqueue(items);
 }
 
-type ProcessOutcome = "success" | "backoff" | "deferred" | "idle";
+type ProcessOutcome = "success" | "skipped" | "backoff" | "deferred" | "idle";
 
 function randomDelayForBackoff(level: number): number {
   const multiplier = 2 ** Math.min(level, MAX_BACKOFF_LEVEL);
@@ -252,6 +254,10 @@ async function withAiTimeout<T>(
 
 function isAiTimeoutError(error: unknown): boolean {
   return error instanceof Error && error.message === AI_SUMMARY_TIMEOUT_MESSAGE;
+}
+
+function isResponseTooLargeError(message: string): boolean {
+  return message.startsWith(RESPONSE_TOO_LARGE_PREFIX);
 }
 
 function scheduleWorker(delayMs: number): void {
@@ -325,7 +331,7 @@ async function processNext(): Promise<ProcessOutcome> {
     // Race against a 30s timeout so a stalled network request on a sleeping
     // machine can't freeze the interval forever.
     const html = await Promise.race([
-      invoke<string>("fetch_url", { url: entry.url }),
+      invoke<string>("fetch_url", { url: entry.url, maxBytes: MAX_BACKGROUND_HTML_BYTES }),
       new Promise<never>((_, reject) =>
         setTimeout(() => reject(new Error("fetch_url TIMEOUT")), FETCH_TIMEOUT_MS),
       ),
@@ -403,6 +409,15 @@ async function processNext(): Promise<ProcessOutcome> {
       // Re-enqueue so the item is retried next cycle rather than permanently failed.
       queue.push(entry);
       outcome = "backoff";
+    } else if (isResponseTooLargeError(msg)) {
+      log.warn(
+        `[content-fetcher] skipped oversized article url=${entry.url} ` +
+          `limit_bytes=${MAX_BACKGROUND_HTML_BYTES.toLocaleString()} err=${msg}`,
+      );
+      failed.set(entry.globalId, Date.now());
+      pruneFailed();
+      addDebugEvent("error", `[Fetcher] skipped oversized article: ${entry.url}`);
+      outcome = "skipped";
     } else {
       log.warn(`[content-fetcher] fetch failed url=${entry.url} err=${msg}`);
       failed.set(entry.globalId, Date.now());


### PR DESCRIPTION
(AI Generated).

## Summary
- Caps background article HTML fetches before they enter WebKit, so oversized pages are skipped instead of being parsed in the desktop renderer.

## Testing
- npm run validate:feature