### PR TITLE
perf: pace startup content backfill

### DIFF
--- a/packages/desktop/src/App.tsx
+++ b/packages/desktop/src/App.tsx
@@ -318,6 +318,7 @@ function App() {
       void startSnapshotManager();
     }
     // Start background content fetcher, which processes the article HTML queue.
+    void contentCache.pruneOversized();
     startContentFetcher();
     startSemanticClassifier({
       isEnabled: () => {

--- a/packages/desktop/src/lib/background-runtime-coordinator.ts
+++ b/packages/desktop/src/lib/background-runtime-coordinator.ts
@@ -5,6 +5,7 @@ import { log } from "./logger";
 export type BackgroundJobKind =
   | "cloud-sync"
   | "content-fetch"
+  | "content-signal-backfill"
   | "outbox"
   | "rss-poll"
   | "semantic-classifier"

--- a/packages/desktop/src/lib/content-cache.test.ts
+++ b/packages/desktop/src/lib/content-cache.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@tauri-apps/api/path", async () => {
+  const actual = await import("../__mocks__/@tauri-apps/api/path");
+  return actual;
+});
+
+vi.mock("@tauri-apps/plugin-fs", async () => {
+  const actual = await import("../__mocks__/@tauri-apps/plugin-fs/index");
+  return actual;
+});
+
+import {
+  __readMemfs,
+  __resetMemfs,
+} from "../__mocks__/@tauri-apps/plugin-fs/index";
+import { writeTextFile } from "@tauri-apps/plugin-fs";
+import {
+  contentCache,
+  MAX_CONTENT_CACHE_HTML_BYTES,
+} from "./content-cache";
+
+function cachePath(globalId: string): string {
+  return `/mock/app-data/content/${globalId}.html`;
+}
+
+describe("desktop content cache", () => {
+  beforeEach(() => {
+    __resetMemfs();
+  });
+
+  it("stores and reads HTML within the renderer budget", async () => {
+    await contentCache.set("article-small", "<article>Readable</article>");
+
+    expect(new TextDecoder().decode(__readMemfs(cachePath("article-small")))).toContain("Readable");
+    await expect(contentCache.get("article-small")).resolves.toContain("Readable");
+  });
+
+  it("skips oversized HTML writes and removes stale cache content for that item", async () => {
+    await writeTextFile(cachePath("article-huge"), "<article>old</article>");
+
+    await contentCache.set("article-huge", "x".repeat(MAX_CONTENT_CACHE_HTML_BYTES + 1));
+
+    expect(__readMemfs(cachePath("article-huge"))).toBeUndefined();
+    await expect(contentCache.get("article-huge")).resolves.toBeNull();
+  });
+
+  it("deletes oversized legacy files before returning cached HTML", async () => {
+    await writeTextFile(cachePath("article-legacy"), "x".repeat(MAX_CONTENT_CACHE_HTML_BYTES + 1));
+
+    await expect(contentCache.get("article-legacy")).resolves.toBeNull();
+    expect(__readMemfs(cachePath("article-legacy"))).toBeUndefined();
+  });
+
+  it("prunes oversized legacy files without touching small cached articles", async () => {
+    await writeTextFile(cachePath("article-small"), "<article>small</article>");
+    await writeTextFile(cachePath("article-legacy"), "x".repeat(MAX_CONTENT_CACHE_HTML_BYTES + 1));
+
+    await expect(contentCache.pruneOversized()).resolves.toBe(1);
+
+    expect(__readMemfs(cachePath("article-small"))).toBeDefined();
+    expect(__readMemfs(cachePath("article-legacy"))).toBeUndefined();
+  });
+});

--- a/packages/desktop/src/lib/content-cache.ts
+++ b/packages/desktop/src/lib/content-cache.ts
@@ -18,10 +18,12 @@ import {
   exists,
   mkdir,
   readDir,
+  size,
 } from "@tauri-apps/plugin-fs";
 
 // Cached base directory path to avoid repeated IPC calls
 let _contentDir: string | null = null;
+export const MAX_CONTENT_CACHE_HTML_BYTES = 2 * 1024 * 1024;
 
 /** Return the content cache directory, creating it on first use */
 async function getContentDir(): Promise<string> {
@@ -42,6 +44,15 @@ function idToFilename(globalId: string): string {
   return globalId.replace(/[<>:"/\\|?*\x00-\x1f]/g, "_") + ".html";
 }
 
+function htmlByteLength(html: string): number {
+  return new TextEncoder().encode(html).byteLength;
+}
+
+async function contentPathForId(globalId: string): Promise<string> {
+  const dir = await getContentDir();
+  return `${dir}/${idToFilename(globalId)}`;
+}
+
 export const contentCache = {
   /**
    * Retrieve cached HTML for a globalId.
@@ -49,8 +60,16 @@ export const contentCache = {
    */
   async get(globalId: string): Promise<string | null> {
     try {
-      const dir = await getContentDir();
-      return await readTextFile(`${dir}/${idToFilename(globalId)}`);
+      const path = await contentPathForId(globalId);
+      const bytes = await size(path);
+      if (bytes > MAX_CONTENT_CACHE_HTML_BYTES) {
+        await remove(path).catch(() => {});
+        console.warn(
+          `[content-cache] skipped oversized cached HTML id=${globalId} size_bytes=${bytes.toLocaleString()} limit_bytes=${MAX_CONTENT_CACHE_HTML_BYTES.toLocaleString()}`,
+        );
+        return null;
+      }
+      return await readTextFile(path);
     } catch {
       return null;
     }
@@ -61,8 +80,16 @@ export const contentCache = {
    * Creates or overwrites the file.
    */
   async set(globalId: string, html: string): Promise<void> {
-    const dir = await getContentDir();
-    await writeTextFile(`${dir}/${idToFilename(globalId)}`, html);
+    const path = await contentPathForId(globalId);
+    const bytes = htmlByteLength(html);
+    if (bytes > MAX_CONTENT_CACHE_HTML_BYTES) {
+      await remove(path).catch(() => {});
+      console.warn(
+        `[content-cache] skipped oversized HTML write id=${globalId} size_bytes=${bytes.toLocaleString()} limit_bytes=${MAX_CONTENT_CACHE_HTML_BYTES.toLocaleString()}`,
+      );
+      return;
+    }
+    await writeTextFile(path, html);
   },
 
   /**
@@ -70,8 +97,7 @@ export const contentCache = {
    */
   async has(globalId: string): Promise<boolean> {
     try {
-      const dir = await getContentDir();
-      return await exists(`${dir}/${idToFilename(globalId)}`);
+      return await exists(await contentPathForId(globalId));
     } catch {
       return false;
     }
@@ -83,8 +109,7 @@ export const contentCache = {
    */
   async delete(globalId: string): Promise<void> {
     try {
-      const dir = await getContentDir();
-      await remove(`${dir}/${idToFilename(globalId)}`);
+      await remove(await contentPathForId(globalId));
     } catch {
       // Already gone
     }
@@ -103,6 +128,35 @@ export const contentCache = {
         .map((e) => e.name!.slice(0, -5)); // strip ".html"
     } catch {
       return [];
+    }
+  },
+
+  /**
+   * Delete legacy cache files that are too large to safely hand to the renderer.
+   */
+  async pruneOversized(): Promise<number> {
+    try {
+      const dir = await getContentDir();
+      const entries = await readDir(dir);
+      let removed = 0;
+      for (const entry of entries) {
+        if (!entry.name?.endsWith(".html")) continue;
+        const path = `${dir}/${entry.name}`;
+        try {
+          const bytes = await size(path);
+          if (bytes <= MAX_CONTENT_CACHE_HTML_BYTES) continue;
+          await remove(path);
+          removed += 1;
+          console.warn(
+            `[content-cache] pruned oversized cached HTML file=${entry.name} size_bytes=${bytes.toLocaleString()} limit_bytes=${MAX_CONTENT_CACHE_HTML_BYTES.toLocaleString()}`,
+          );
+        } catch {
+          // Ignore individual files that disappear or cannot be inspected.
+        }
+      }
+      return removed;
+    } catch {
+      return 0;
     }
   },
 };

--- a/packages/desktop/src/lib/store-startup-migrations.test.ts
+++ b/packages/desktop/src/lib/store-startup-migrations.test.ts
@@ -1,0 +1,174 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDefaultPreferences } from "@freed/shared";
+
+const {
+  mockDocBackfillContentSignals,
+  mockDocDeduplicateFeedItems,
+  mockDocHealUntitledFeedTitles,
+  mockDocPruneArchivedItems,
+  mockInitDoc,
+  mockRunBackgroundJob,
+  mockStartOutboxProcessor,
+  mockSubscribe,
+} = vi.hoisted(() => ({
+  mockDocBackfillContentSignals: vi.fn(),
+  mockDocDeduplicateFeedItems: vi.fn(),
+  mockDocHealUntitledFeedTitles: vi.fn(),
+  mockDocPruneArchivedItems: vi.fn(),
+  mockInitDoc: vi.fn(),
+  mockRunBackgroundJob: vi.fn(),
+  mockStartOutboxProcessor: vi.fn(),
+  mockSubscribe: vi.fn(() => () => {}),
+}));
+
+vi.mock("./automerge", () => ({
+  initDoc: mockInitDoc,
+  subscribe: mockSubscribe,
+  getDocState: vi.fn(() => null),
+  docAddFeedItems: vi.fn(),
+  docAddRssFeed: vi.fn(),
+  docRemoveRssFeed: vi.fn(),
+  docRemoveAllFeeds: vi.fn(),
+  docUpdateRssFeed: vi.fn(),
+  docUpdateFeedItem: vi.fn(),
+  docMarkItemsAsRead: vi.fn(),
+  docMarkAllAsRead: vi.fn(),
+  docToggleSaved: vi.fn(),
+  docRemoveFeedItem: vi.fn(),
+  docToggleArchived: vi.fn(),
+  docArchiveItems: vi.fn(),
+  docArchiveAllReadUnsaved: vi.fn(),
+  docUnarchiveSavedItems: vi.fn(),
+  docDeleteAllArchived: vi.fn(),
+  docPruneArchivedItems: mockDocPruneArchivedItems,
+  docUpdatePreferences: vi.fn(),
+  docBackfillContentSignals: mockDocBackfillContentSignals,
+  docDeduplicateFeedItems: mockDocDeduplicateFeedItems,
+  docHealUntitledFeedTitles: mockDocHealUntitledFeedTitles,
+  docAddAccount: vi.fn(),
+  docAddAccounts: vi.fn(),
+  docAddPerson: vi.fn(),
+  docAddPersons: vi.fn(),
+  docUpdateAccount: vi.fn(),
+  docUpdatePerson: vi.fn(),
+  docUpsertConnectionPersons: vi.fn(),
+  docRemoveAccount: vi.fn(),
+  docRemovePerson: vi.fn(),
+  docLogReachOut: vi.fn(),
+  docToggleLiked: vi.fn(),
+  docConfirmLikedSynced: vi.fn(),
+  docConfirmSeenSynced: vi.fn(),
+}));
+
+vi.mock("./background-runtime-coordinator", () => ({
+  isBackgroundRuntimeDeferredError: () => false,
+  runBackgroundJob: mockRunBackgroundJob,
+}));
+
+vi.mock("./platform-actions", () => ({
+  buildPlatformActionsRegistry: vi.fn(() => ({})),
+}));
+
+vi.mock("./outbox", () => ({
+  startOutboxProcessor: mockStartOutboxProcessor,
+}));
+
+vi.mock("./x-auth", () => ({
+  loadStoredCookies: vi.fn(() => null),
+}));
+
+vi.mock("./fb-auth", () => ({
+  initFbAuth: vi.fn(() => ({ isAuthenticated: false })),
+}));
+
+vi.mock("./instagram-auth", () => ({
+  initIgAuth: vi.fn(() => ({ isAuthenticated: false })),
+}));
+
+vi.mock("./li-auth", () => ({
+  initLiAuth: vi.fn(() => ({ isAuthenticated: false })),
+}));
+
+vi.mock("./logger", () => ({
+  log: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+function createDocState() {
+  return {
+    items: [],
+    searchCorpusVersion: 0,
+    feeds: {},
+    persons: {},
+    accounts: {},
+    friends: {},
+    preferences: createDefaultPreferences(),
+    feedUnreadCounts: {},
+    feedTotalCounts: {},
+    totalUnreadCount: 0,
+    unreadCountByPlatform: {},
+    totalItemCount: 0,
+    itemCountByPlatform: {},
+    totalArchivableCount: 0,
+    archivableCountByPlatform: {},
+    archivableFeedCounts: {},
+    mapFriendLocationCount: 0,
+    mapAllContentLocationCount: 0,
+    docItemCount: 0,
+  };
+}
+
+describe("store startup migrations", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.useFakeTimers();
+    mockDocBackfillContentSignals.mockReset();
+    mockDocBackfillContentSignals.mockResolvedValue({ updated: 50, remaining: 0, total: 50 });
+    mockDocDeduplicateFeedItems.mockReset();
+    mockDocDeduplicateFeedItems.mockResolvedValue(undefined);
+    mockDocHealUntitledFeedTitles.mockReset();
+    mockDocHealUntitledFeedTitles.mockResolvedValue(undefined);
+    mockDocPruneArchivedItems.mockReset();
+    mockDocPruneArchivedItems.mockResolvedValue(undefined);
+    mockInitDoc.mockReset();
+    mockInitDoc.mockResolvedValue(createDocState());
+    mockRunBackgroundJob.mockReset();
+    mockRunBackgroundJob.mockImplementation(async (task) => task.run());
+    mockStartOutboxProcessor.mockReset();
+    mockStartOutboxProcessor.mockReturnValue(() => {});
+    mockSubscribe.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("defers content signal backfill instead of running it during launch", async () => {
+    const { useAppStore } = await import("./store");
+
+    await useAppStore.getState().initialize();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(mockDocHealUntitledFeedTitles).toHaveBeenCalledTimes(1);
+    expect(mockDocDeduplicateFeedItems).toHaveBeenCalledTimes(1);
+    expect(mockDocPruneArchivedItems).toHaveBeenCalledTimes(1);
+    expect(mockDocBackfillContentSignals).not.toHaveBeenCalled();
+    expect(mockRunBackgroundJob).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(119_999);
+    expect(mockDocBackfillContentSignals).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(mockRunBackgroundJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "content-signal-backfill",
+        source: "startup-migration",
+      }),
+    );
+    expect(mockDocBackfillContentSignals).toHaveBeenCalledWith(50);
+  });
+});

--- a/packages/desktop/src/lib/store.ts
+++ b/packages/desktop/src/lib/store.ts
@@ -63,11 +63,18 @@ import { startOutboxProcessor } from "./outbox";
 import { loadStoredCookies, type XAuthState } from "./x-auth";
 import { recordBugReportEvent, recordRuntimeError } from "@freed/ui/lib/bug-report";
 import { pinReaderItem } from "./content-fetcher";
-
-let outboxTeardown: (() => void) | null = null;
+import {
+  isBackgroundRuntimeDeferredError,
+  runBackgroundJob,
+} from "./background-runtime-coordinator";
+import { log } from "./logger";
 import { initFbAuth, type FbAuthState } from "./fb-auth";
 import { initIgAuth, type IgAuthState } from "./instagram-auth";
 import { initLiAuth, type LiAuthState } from "./li-auth";
+
+let outboxTeardown: (() => void) | null = null;
+let startupContentSignalTimer: ReturnType<typeof setTimeout> | null = null;
+let startupContentSignalBackfillRunning = false;
 
 export type SyncProviderId =
   | "rss"
@@ -291,13 +298,7 @@ async function runStartupMigrations(archivePruneDays: number): Promise<void> {
       await docPruneArchivedItems(archivePruneDays * 24 * 60 * 60 * 1000);
     }
   } catch { /* non-fatal */ }
-  try {
-    for (;;) {
-      const summary = await docBackfillContentSignals(200);
-      if (summary.updated === 0 || summary.remaining === 0) break;
-      await new Promise((resolve) => setTimeout(resolve, 25));
-    }
-  } catch { /* non-fatal */ }
+  scheduleStartupContentSignalBackfill(STARTUP_CONTENT_SIGNAL_INITIAL_DELAY_MS);
 }
 
 const READ_MARK_BATCH_DELAY_MS = 50;
@@ -336,6 +337,54 @@ function recordReadStateInfo(message: string, detail: Record<string, unknown>): 
     message,
     JSON.stringify(detail),
   );
+}
+
+const STARTUP_CONTENT_SIGNAL_INITIAL_DELAY_MS = 2 * 60 * 1000;
+const STARTUP_CONTENT_SIGNAL_RETRY_DELAY_MS = 30 * 1000;
+const STARTUP_CONTENT_SIGNAL_INTERVAL_MS = 60 * 1000;
+const STARTUP_CONTENT_SIGNAL_BATCH_SIZE = 50;
+
+function scheduleStartupContentSignalBackfill(delayMs: number): void {
+  if (startupContentSignalTimer) return;
+  startupContentSignalTimer = setTimeout(() => {
+    startupContentSignalTimer = null;
+    void runStartupContentSignalBackfill();
+  }, delayMs);
+}
+
+async function runStartupContentSignalBackfill(): Promise<void> {
+  if (startupContentSignalBackfillRunning) return;
+  startupContentSignalBackfillRunning = true;
+
+  try {
+    const summary = await runBackgroundJob({
+      kind: "content-signal-backfill",
+      source: "startup-migration",
+      timeoutMs: 120_000,
+      run: () => docBackfillContentSignals(STARTUP_CONTENT_SIGNAL_BATCH_SIZE),
+    });
+
+    if (summary.updated > 0) {
+      log.info(
+        `[content-signals] startup backfilled ${summary.updated.toLocaleString()} item${summary.updated === 1 ? "" : "s"}, ${summary.remaining.toLocaleString()} remaining`,
+      );
+    }
+
+    if (summary.remaining > 0) {
+      scheduleStartupContentSignalBackfill(STARTUP_CONTENT_SIGNAL_INTERVAL_MS);
+    }
+  } catch (error) {
+    if (isBackgroundRuntimeDeferredError(error)) {
+      log.info(`[content-signals] startup backfill deferred reason=${error.reason}`);
+      scheduleStartupContentSignalBackfill(STARTUP_CONTENT_SIGNAL_RETRY_DELAY_MS);
+      return;
+    }
+
+    const message = error instanceof Error ? error.message : String(error);
+    log.warn(`[content-signals] startup backfill failed err=${message}`);
+  } finally {
+    startupContentSignalBackfillRunning = false;
+  }
 }
 
 async function flushPendingReadMarks(): Promise<void> {

--- a/packages/shared/src/schema.ts
+++ b/packages/shared/src/schema.ts
@@ -1156,49 +1156,81 @@ function createEmptyContentSignalCounts(): Record<ContentSignal, number> {
   ) as Record<ContentSignal, number>;
 }
 
+function createContentSignalSummaryState(): {
+  counts: Record<ContentSignal, number>;
+  samples: Partial<Record<ContentSignal, string[]>>;
+  multiSignalCount: number;
+  untaggedCount: number;
+  total: number;
+} {
+  return {
+    counts: createEmptyContentSignalCounts(),
+    samples: {},
+    multiSignalCount: 0,
+    untaggedCount: 0,
+    total: 0,
+  };
+}
+
+function addFeedItemToContentSignalSummary(
+  item: FeedItem,
+  state: ReturnType<typeof createContentSignalSummaryState>,
+): void {
+  state.total += 1;
+  const tags = item.contentSignals?.tags ?? [];
+  if (tags.length === 0) {
+    state.untaggedCount += 1;
+    return;
+  }
+
+  if (tags.length > 1) {
+    state.multiSignalCount += 1;
+  }
+
+  for (const tag of tags) {
+    state.counts[tag] += 1;
+    const signalSamples = state.samples[tag] ?? [];
+    if (signalSamples.length < 5) {
+      signalSamples.push(`...${item.globalId.slice(-8)}`);
+      state.samples[tag] = signalSamples;
+    }
+  }
+}
+
+function createContentSignalBackfillSummary(
+  state: ReturnType<typeof createContentSignalSummaryState>,
+  updated: number,
+  scanned: number,
+  remaining: number,
+): ContentSignalBackfillSummary {
+  return {
+    version: CONTENT_SIGNAL_VERSION,
+    total: state.total,
+    scanned,
+    updated,
+    remaining,
+    counts: state.counts,
+    multiSignalCount: state.multiSignalCount,
+    untaggedCount: state.untaggedCount,
+    samples: state.samples,
+  };
+}
+
 function summarizeContentSignals(
   doc: FreedDoc,
   updated: number,
   scanned: number,
   remaining: number,
 ): ContentSignalBackfillSummary {
-  const counts = createEmptyContentSignalCounts();
-  const samples: Partial<Record<ContentSignal, string[]>> = {};
-  let multiSignalCount = 0;
-  let untaggedCount = 0;
-  let total = 0;
+  const state = createContentSignalSummaryState();
 
-  for (const item of Object.values(doc.feedItems) as FeedItem[]) {
-    total += 1;
-    const tags = item.contentSignals?.tags ?? [];
-    if (tags.length === 0) {
-      untaggedCount += 1;
-      continue;
-    }
-    if (tags.length > 1) {
-      multiSignalCount += 1;
-    }
-    for (const tag of tags) {
-      counts[tag] += 1;
-      const signalSamples = samples[tag] ?? [];
-      if (signalSamples.length < 5) {
-        signalSamples.push(`...${item.globalId.slice(-8)}`);
-        samples[tag] = signalSamples;
-      }
-    }
+  for (const globalId in doc.feedItems) {
+    const item = doc.feedItems[globalId];
+    if (!item) continue;
+    addFeedItemToContentSignalSummary(item, state);
   }
 
-  return {
-    version: CONTENT_SIGNAL_VERSION,
-    total,
-    scanned,
-    updated,
-    remaining,
-    counts,
-    multiSignalCount,
-    untaggedCount,
-    samples,
-  };
+  return createContentSignalBackfillSummary(state, updated, scanned, remaining);
 }
 
 export function summarizeDocContentSignals(doc: FreedDoc): ContentSignalBackfillSummary {
@@ -1206,30 +1238,42 @@ export function summarizeDocContentSignals(doc: FreedDoc): ContentSignalBackfill
 }
 
 export function countContentSignalBackfillItems(doc: FreedDoc): number {
-  return (Object.values(doc.feedItems) as FeedItem[]).filter(
-    (item) => !hasCurrentContentSignals(item),
-  ).length;
+  let count = 0;
+  for (const globalId in doc.feedItems) {
+    const item = doc.feedItems[globalId];
+    if (item && !hasCurrentContentSignals(item)) {
+      count += 1;
+    }
+  }
+  return count;
 }
 
 export function backfillContentSignals(
   doc: FreedDoc,
   batchSize: number = 200,
 ): ContentSignalBackfillSummary {
-  const staleItems = (Object.values(doc.feedItems) as FeedItem[]).filter(
-    (item) => !hasCurrentContentSignals(item),
-  );
-  const batch = staleItems.slice(0, Math.max(1, batchSize));
+  const maxBatchSize = Math.max(1, batchSize);
+  const state = createContentSignalSummaryState();
+  let updated = 0;
+  let remaining = 0;
 
-  for (const item of batch) {
-    applySemanticEnrichmentToItem(item);
+  for (const globalId in doc.feedItems) {
+    const item = doc.feedItems[globalId];
+    if (!item) continue;
+
+    if (!hasCurrentContentSignals(item)) {
+      if (updated < maxBatchSize) {
+        applySemanticEnrichmentToItem(item);
+        updated += 1;
+      } else {
+        remaining += 1;
+      }
+    }
+
+    addFeedItemToContentSignalSummary(item, state);
   }
 
-  return summarizeContentSignals(
-    doc,
-    batch.length,
-    batch.length,
-    Math.max(0, staleItems.length - batch.length),
-  );
+  return createContentSignalBackfillSummary(state, updated, updated, remaining);
 }
 
 /**


### PR DESCRIPTION
(AI Generated).

## Summary
- Caps desktop reader HTML cache entries at 2 MB, prunes oversized legacy cache files at startup, and skips oversized reads before loading them into WebKit.
- Moves startup content signal backfill out of the launch path, routes it through the background runtime gate, and paces remaining work in small batches.
- Reworks shared content signal backfill to scan feed items in one pass instead of allocating stale item arrays for every batch.

## Testing
- Focused desktop unit tests for content cache, startup migrations, and semantic classifier passed.
- packages/shared typecheck passed.
- packages/desktop production build passed.
- npm run validate:feature passed.