### PR TITLE
perf: skip unchanged Automerge history probes

### DIFF
--- a/packages/desktop/src/lib/automerge-worker-memory.test.ts
+++ b/packages/desktop/src/lib/automerge-worker-memory.test.ts
@@ -93,14 +93,13 @@ describe("automerge worker memory routing", () => {
 
     expect(workerSource).toContain("compactLoadedFeedText");
     expect(workerSource).toContain("FRESH_DOC_REBUILD_MIN_CHANGED_BINARY_BYTES = 4 * 1024 * 1024");
-    expect(workerSource).toContain("FRESH_DOC_REBUILD_MIN_HISTORY_BINARY_BYTES = 16 * 1024 * 1024");
     expect(initBody).toContain("compactLoadedFeedText(\"Compact oversized synced feed text\",");
     expect(replaceBody).toContain("compactLoadedFeedText(\"Compact oversized synced feed text\",");
     expect(mergeBody).toContain("compactLoadedFeedText(\"Compact oversized synced feed text after merge\",");
     expect(initBody.indexOf("compactLoadedFeedText")).toBeLessThan(initBody.indexOf("saveAndBroadcast"));
   });
 
-  it("rebuilds a fresh Automerge document after compacting oversized loaded history", () => {
+  it("rebuilds a fresh Automerge document only after compacting oversized text", () => {
     const compactBody = functionBody("compactLoadedFeedText");
     const initBody = caseBody("INIT");
     const replaceBody = caseBody("REPLACE_DOC");
@@ -108,8 +107,10 @@ describe("automerge worker memory routing", () => {
     expect(workerSource).toContain("createDocFromData");
     expect(compactBody).toContain("createDocFromData(plain)");
     expect(compactBody).toContain("rebuilt compacted document");
-    expect(compactBody).toContain("shouldProbeLargeHistory");
-    expect(compactBody).toContain("kept existing compacted document history");
+    expect(compactBody).toContain("summary.changed > 0");
+    expect(compactBody).not.toContain("shouldProbeLargeHistory");
+    expect(compactBody).not.toContain("kept existing compacted document history");
+    expect(workerSource).not.toContain("FRESH_DOC_REBUILD_MIN_HISTORY_BINARY_BYTES");
     expect(initBody.indexOf("currentBinary = saved")).toBeLessThan(initBody.indexOf("compactLoadedFeedText"));
     expect(replaceBody.indexOf("currentBinary = req.binary")).toBeLessThan(replaceBody.indexOf("compactLoadedFeedText"));
     expect(replaceBody).not.toContain("await storage.save(req.binary)");

--- a/packages/desktop/src/lib/automerge.worker.ts
+++ b/packages/desktop/src/lib/automerge.worker.ts
@@ -96,8 +96,6 @@ const DESKTOP_UI_CONTENT_TEXT_LIMIT = 280;
 const DESKTOP_UI_LINK_DESCRIPTION_LIMIT = 180;
 const DESKTOP_UI_EVENT_EVIDENCE_LIMIT = 220;
 const FRESH_DOC_REBUILD_MIN_CHANGED_BINARY_BYTES = 4 * 1024 * 1024;
-const FRESH_DOC_REBUILD_MIN_HISTORY_BINARY_BYTES = 16 * 1024 * 1024;
-const FRESH_DOC_REBUILD_MIN_SAVINGS_RATIO = 0.1;
 
 interface RequestTrace {
   reqId: number;
@@ -222,24 +220,12 @@ function compactLoadedFeedText(
   if (!options.rebuildHistory) return;
   const shouldRebuildForChangedText =
     summary.changed > 0 && previousBinaryBytes >= FRESH_DOC_REBUILD_MIN_CHANGED_BINARY_BYTES;
-  const shouldProbeLargeHistory = previousBinaryBytes >= FRESH_DOC_REBUILD_MIN_HISTORY_BINARY_BYTES;
-  if (!shouldRebuildForChangedText && !shouldProbeLargeHistory) return;
+  if (!shouldRebuildForChangedText) return;
 
   const plain = A.toJS(currentDoc) as Partial<FreedDoc>;
   const rebuiltDoc = createDocFromData(plain);
   const rebuiltBinary = A.save(rebuiltDoc);
   const bytesSaved = previousBinaryBytes - rebuiltBinary.byteLength;
-  const minHistorySavings = previousBinaryBytes * FRESH_DOC_REBUILD_MIN_SAVINGS_RATIO;
-  if (!shouldRebuildForChangedText && bytesSaved < minHistorySavings) {
-    emitWorkerTrace(
-      `[automerge-worker] kept existing compacted document history` +
-        ` previous_bytes=${previousBinaryBytes.toLocaleString()}` +
-        ` rebuilt_bytes=${rebuiltBinary.byteLength.toLocaleString()}`,
-      "change",
-    );
-    return;
-  }
-
   currentDoc = rebuiltDoc;
   currentBinary = rebuiltBinary;
   persistenceState = createPersistenceState(rebuiltBinary);


### PR DESCRIPTION
(AI Generated).

## Summary
- Stops loaded documents from converting and rebuilding the full Automerge doc solely to probe history savings when startup compaction changed no feed text.
- Keeps fresh history rebuilds for actual oversized text compaction, preserving the migration benefit without the idle launch allocation spike.

## Testing
- PATH=/Users/aubreyfalconer/dev/freed-automerge-history-probe/node_modules/.bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/usr/local/MacGPG2/bin:/Applications/VMware Fusion.app/Contents/Public:/usr/local/share/dotnet:~/.dotnet/tools:/usr/local/go/bin:/Library/Frameworks/Mono.framework/Versions/Current/Commands:/Users/aubreyfalconer/.nvm/versions/node/v24.14.1/bin:/Users/aubreyfalconer/.codex/tmp/arg0/codex-arg0ldxqj8:/Users/aubreyfalconer/.local/bin:/opt/homebrew/opt/mysql-client/bin:/opt/homebrew/bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/Users/aubreyfalconer/.cargo/bin:/Users/aubreyfalconer/go/bin:/Users/aubreyfalconer/.cache/lm-studio/bin:/Users/aubreyfalconer/.safe-chain/bin:/Applications/Codex.app/Contents/Resources:/usr/local/bin npx vitest run src/lib/automerge-worker-memory.test.ts
- npm run validate:feature