### PR TITLE
feat: add nightly soak pointer repair

### DIFF
--- a/docs/NIGHTLY-SELF-IMPROVE.md
+++ b/docs/NIGHTLY-SELF-IMPROVE.md
@@ -54,6 +54,12 @@ Dry run:
 node scripts/nightly-self-improve.mjs --dry-run --json
 ```
 
+Repair an unreadable active soak pointer when a newer readable soak exists:
+
+```bash
+node scripts/nightly-self-improve.mjs --repair-soak-pointer
+```
+
 Use a custom outcome ledger:
 
 ```bash
@@ -85,7 +91,7 @@ The runner excludes provider-visible tasks by default. Do not allow autonomous c
 
 Release work is also gated. A dev build should ship only after actual fixes merge into `dev`, not after planning artifacts alone.
 
-Every execution phase has a stop gate. The runner should stop rather than freestyle when evidence is missing, a peer branch is still changing, a provider-visible change needs approval, focused validation fails, or no real fix landed. The preflight risk snapshot is now also a selectable target, so blocker risks like a dirty current worktree or missing dependencies can win the queue before the runner starts editing. If the active soak pointer is empty, the runner falls back to the newest readable soak and records that fallback in the risk snapshot.
+Every execution phase has a stop gate. The runner should stop rather than freestyle when evidence is missing, a peer branch is still changing, a provider-visible change needs approval, focused validation fails, or no real fix landed. The preflight risk snapshot is now also a selectable target, so blocker risks like a dirty current worktree or missing dependencies can win the queue before the runner starts editing. If the active soak pointer is empty, the runner falls back to the newest readable soak and records that fallback in the risk snapshot. When the fix is purely local, `--repair-soak-pointer` can update the active pointer to that readable soak so later runs no longer start from a dead evidence path.
 
 ## Next Improvements
 

--- a/docs/PHASE-10-POLISH.md
+++ b/docs/PHASE-10-POLISH.md
@@ -126,7 +126,7 @@ The shared extension points now live in `packages/ui/src/lib/command-palette.ts`
 
 Freed now has a local nightly improvement planner in `scripts/nightly-self-improve.mjs`. It folds the installed-build soak, daily bug scan memory, crash-watch state, roadmap fallback memory, peer worktrees, prior outcome history, and current git state into a ranked queue of work that can run overnight.
 
-The runner can choose multiple targets in one night. Bug fixes are first-class targets through the existing daily bug scan memory, while peer worktree integration, duplicate-work detection, performance, stability, release readiness, and roadmap work compete by score and machine-time budget. Each run now writes a preflight risk snapshot plus an execution plan with stop gates, command hints, task prompts, outcome templates, and ready-to-run ledger closeout commands so overnight automation has a clear path from clean evidence to validation, dev build shipping, installed-build soak, learned scoring, and morning closeout. When the active soak pointer has no samples, the runner falls back to the newest readable soak and records that fallback as preflight evidence. Provider-visible ideas stay blocked unless a human explicitly approves the fingerprinting risk.
+The runner can choose multiple targets in one night. Bug fixes are first-class targets through the existing daily bug scan memory, while peer worktree integration, duplicate-work detection, performance, stability, release readiness, and roadmap work compete by score and machine-time budget. Each run now writes a preflight risk snapshot plus an execution plan with stop gates, command hints, task prompts, outcome templates, and ready-to-run ledger closeout commands so overnight automation has a clear path from clean evidence to validation, dev build shipping, installed-build soak, learned scoring, and morning closeout. When the active soak pointer has no samples, the runner falls back to the newest readable soak and records that fallback as preflight evidence. It can also repair the pointer to that readable soak when the remediation is unambiguous and local only. Provider-visible ideas stay blocked unless a human explicitly approves the fingerprinting risk.
 
 ### Keyboard Shortcuts
 
@@ -472,7 +472,7 @@ Reward security researchers for responsible disclosure.
 - [ ] Discord server active
 - [ ] Bug bounty program published
 - [ ] Regular release schedule established
-- [x] Local nightly improvement runner ranks preflight risks, duplicate peer work, peer worktree, bug fix, performance, stability, release, and roadmap targets before autonomous work begins
+- [x] Local nightly improvement runner ranks preflight risks, duplicate peer work, peer worktree, bug fix, performance, stability, release, and roadmap targets before autonomous work begins, with local soak pointer repair when active evidence is unreadable
 - [ ] Documentation site live
 
 ### Resilience

--- a/scripts/nightly-self-improve.mjs
+++ b/scripts/nightly-self-improve.mjs
@@ -43,6 +43,8 @@ Options:
   --repo <path>                 Repo to inspect. Defaults to the current Freed checkout.
   --run-dir <path>              Directory for generated nightly plan files.
   --soak-dir <path>             Installed-build soak directory to inspect.
+  --soak-pointer <path>         Pointer file for the active installed-build soak.
+  --repair-soak-pointer         Point an empty or unreadable active soak at the newest readable soak.
   --daily-bug-memory <path>     Daily bug scan memory file to fold into target selection.
   --peer-worktree <path>        Extra local worktree to compare and rank as a peer target.
   --no-peer-scan                Skip automatic git worktree discovery.
@@ -69,6 +71,8 @@ export function parseArgs(argv) {
     runDir: "",
     runDirProvided: false,
     soakDir: "",
+    soakPointer: DEFAULT_SOAK_POINTER,
+    repairSoakPointer: false,
     dailyBugMemory: DEFAULT_DAILY_BUG_MEMORY,
     crashAutomation: DEFAULT_CRASH_AUTOMATION,
     devBotMemory: DEFAULT_DEV_BOT_MEMORY,
@@ -105,6 +109,13 @@ export function parseArgs(argv) {
       case "--soak-dir":
         args.soakDir = argv[index + 1] ?? "";
         index += 1;
+        break;
+      case "--soak-pointer":
+        args.soakPointer = argv[index + 1] ?? "";
+        index += 1;
+        break;
+      case "--repair-soak-pointer":
+        args.repairSoakPointer = true;
         break;
       case "--daily-bug-memory":
         args.dailyBugMemory = argv[index + 1] ?? "";
@@ -182,6 +193,12 @@ export function parseArgs(argv) {
   if (!args.repo) {
     throw new Error("A repo path is required.");
   }
+  if (!args.soakPointer) {
+    throw new Error("A soak pointer path is required.");
+  }
+  if (args.repairSoakPointer && args.soakDir) {
+    throw new Error("repair-soak-pointer cannot be combined with an explicit soak-dir.");
+  }
   if (args.recordOutcome) {
     if (!args.recordKind) {
       throw new Error("record-kind is required when record-outcome is set.");
@@ -201,6 +218,7 @@ export function parseArgs(argv) {
   }
 
   args.repo = path.resolve(args.repo);
+  args.soakPointer = path.resolve(args.soakPointer);
   args.outcomeLedger = path.resolve(args.outcomeLedger);
   args.peerWorktrees = args.peerWorktrees.filter(Boolean).map((item) => path.resolve(item));
   args.runDir =
@@ -596,6 +614,52 @@ export function resolveReadableSoak(soakDir = "", pointerPath = DEFAULT_SOAK_POI
   return {
     ...summarizeSoak(fallbackDir),
     fallbackFrom: preferredDir,
+  };
+}
+
+export function repairSoakPointer(pointerPath = DEFAULT_SOAK_POINTER, options = {}) {
+  const currentDir = resolveCurrentSoakDir(pointerPath);
+  const current = summarizeSoak(currentDir);
+  if (current.sampleCount > 0) {
+    return {
+      repaired: false,
+      reason: "current-readable",
+      pointerPath,
+      previousDir: currentDir,
+      readableDir: currentDir,
+      sampleCount: current.sampleCount,
+      dryRun: Boolean(options.dryRun),
+    };
+  }
+
+  const rootDir = path.dirname(currentDir || pointerPath);
+  const readableDir = findLatestReadableSoakDir(rootDir, currentDir);
+  if (!readableDir) {
+    return {
+      repaired: false,
+      reason: "no-readable-soak",
+      pointerPath,
+      previousDir: currentDir,
+      readableDir: "",
+      sampleCount: 0,
+      dryRun: Boolean(options.dryRun),
+    };
+  }
+
+  const readable = summarizeSoak(readableDir);
+  if (!options.dryRun) {
+    mkdirSync(path.dirname(pointerPath), { recursive: true });
+    writeFileSync(pointerPath, `${readableDir}\n`);
+  }
+
+  return {
+    repaired: !options.dryRun,
+    reason: options.dryRun ? "dry-run" : "repaired",
+    pointerPath,
+    previousDir: currentDir,
+    readableDir,
+    sampleCount: readable.sampleCount,
+    dryRun: Boolean(options.dryRun),
   };
 }
 
@@ -1855,7 +1919,7 @@ export function writeRunPlan({ runDir, repo, soak, riskSnapshot, duplicateWork, 
 }
 
 export function planNightlyRun(args) {
-  const soak = resolveReadableSoak(args.soakDir);
+  const soak = resolveReadableSoak(args.soakDir, args.soakPointer);
   const dailyBug = summarizeDailyBugMemory(args.dailyBugMemory);
   const repo = collectRepoSnapshot(args.repo);
   const peerWorktrees = collectPeerWorktrees(args.repo, args.peerWorktrees, args.peerScan);
@@ -1941,6 +2005,22 @@ export function main(argv = process.argv.slice(2)) {
     } else {
       process.stdout.write(
         `Recorded ${entry.outcome} outcome for ${entry.id} in ${args.outcomeLedger}.\n`,
+      );
+    }
+    return;
+  }
+
+  if (args.repairSoakPointer) {
+    const repair = repairSoakPointer(args.soakPointer, { dryRun: args.dryRun });
+    if (args.json) {
+      process.stdout.write(`${JSON.stringify(repair, null, 2)}\n`);
+    } else if (repair.repaired) {
+      process.stdout.write(
+        `Repaired soak pointer ${repair.pointerPath} from ${repair.previousDir || "none"} to ${repair.readableDir} with ${numberFormatter.format(repair.sampleCount)} samples.\n`,
+      );
+    } else {
+      process.stdout.write(
+        `Did not repair soak pointer ${repair.pointerPath}: ${repair.reason}.\n`,
       );
     }
     return;

--- a/scripts/nightly-self-improve.test.mjs
+++ b/scripts/nightly-self-improve.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -18,6 +18,7 @@ import {
   parseArgs,
   parseGitWorktreePorcelain,
   parseTsv,
+  repairSoakPointer,
   resolveReadableSoak,
   selectTargets,
   summarizeOutcomeLedger,
@@ -98,6 +99,56 @@ test("resolveReadableSoak falls back from an empty current soak to the newest re
   assert.equal(summary.sampleCount, 1);
   assert.ok(summary.maxWebKitResidentBytes >= 3 * GIB);
   assert.equal(newer > older, true);
+});
+
+test("repairSoakPointer rewrites an unreadable pointer to the newest readable soak", () => {
+  const rootDir = mkdtempSync(path.join(os.tmpdir(), "freed-soak-repair-"));
+  const pointerPath = path.join(rootDir, "current-soak-dir");
+  const emptyDir = path.join(rootDir, "empty");
+  const readableDir = path.join(rootDir, "readable");
+  mkdirSync(emptyDir);
+  mkdirSync(readableDir);
+  writeFileSync(pointerPath, `${emptyDir}\n`);
+  writeFileSync(
+    path.join(readableDir, "metrics.tsv"),
+    [
+      "ts\thealth_event\thealth_webkit_rss_bytes",
+      `2026-05-29T01:00:00Z\trenderer_heartbeat\t${2 * GIB}`,
+      "",
+    ].join("\n"),
+  );
+
+  const repair = repairSoakPointer(pointerPath);
+  assert.equal(repair.repaired, true);
+  assert.equal(repair.reason, "repaired");
+  assert.equal(repair.previousDir, realpathSync(emptyDir));
+  assert.equal(repair.readableDir, realpathSync(readableDir));
+  assert.equal(repair.sampleCount, 1);
+  assert.equal(readFileSync(pointerPath, "utf8").trim(), realpathSync(readableDir));
+});
+
+test("repairSoakPointer dry run reports the target without changing the pointer", () => {
+  const rootDir = mkdtempSync(path.join(os.tmpdir(), "freed-soak-repair-dry-"));
+  const pointerPath = path.join(rootDir, "current-soak-dir");
+  const emptyDir = path.join(rootDir, "empty");
+  const readableDir = path.join(rootDir, "readable");
+  mkdirSync(emptyDir);
+  mkdirSync(readableDir);
+  writeFileSync(pointerPath, `${emptyDir}\n`);
+  writeFileSync(
+    path.join(readableDir, "runtime-health.jsonl"),
+    `${JSON.stringify({
+      tsMs: Date.parse("2026-05-29T02:00:00Z"),
+      event: "renderer_heartbeat",
+      webkitResidentBytes: 3 * GIB,
+    })}\n`,
+  );
+
+  const repair = repairSoakPointer(pointerPath, { dryRun: true });
+  assert.equal(repair.repaired, false);
+  assert.equal(repair.reason, "dry-run");
+  assert.equal(repair.readableDir, realpathSync(readableDir));
+  assert.equal(readFileSync(pointerPath, "utf8").trim(), emptyDir);
 });
 
 test("daily bug memory summary keeps the latest dated scan", () => {
@@ -566,6 +617,12 @@ test("argument parsing validates numeric budgets", () => {
     /record-status/,
   );
   assert.equal(parseArgs(["--memory-gib", "3"]).memoryGib, 3);
+  assert.equal(parseArgs(["--soak-pointer", "/tmp/pointer"]).soakPointer, "/tmp/pointer");
+  assert.equal(parseArgs(["--repair-soak-pointer"]).repairSoakPointer, true);
+  assert.throws(
+    () => parseArgs(["--repair-soak-pointer", "--soak-dir", "/tmp/soak"]),
+    /repair-soak-pointer/,
+  );
   assert.equal(
     parseArgs([
       "--record-outcome",

--- a/website/src/app/roadmap/RoadmapContent.tsx
+++ b/website/src/app/roadmap/RoadmapContent.tsx
@@ -783,7 +783,7 @@ const phases: Phase[] = [
     number: 10,
     title: "Polish",
     description:
-      "Onboarding, statistics, global animation controls, expanded local content signals with Desktop and PWA backfill, inclusive saved feed filter presets, compact event extraction, local semantic enrichment for friend suggestions, unified AI provider settings, Light, Balanced, and Pro Integrated AI packs with semantic scan health, plugin API, community infrastructure, duplicate-aware nightly improvement planning with learned closeout, and deeper crash recovery hardening.",
+      "Onboarding, statistics, global animation controls, expanded local content signals with Desktop and PWA backfill, inclusive saved feed filter presets, compact event extraction, local semantic enrichment for friend suggestions, unified AI provider settings, Light, Balanced, and Pro Integrated AI packs with semantic scan health, plugin API, community infrastructure, duplicate-aware nightly improvement planning with learned closeout, self-repairing soak evidence, and deeper crash recovery hardening.",
     status: "upcoming",
     planLink:
       "https://github.com/freed-project/freed/blob/dev/docs/PHASE-10-POLISH.md",


### PR DESCRIPTION
(AI Generated).

## Summary
- Add a local nightly runner command that repairs an unreadable installed-build soak pointer by pointing it at the newest readable soak evidence directory.
- Let planning read a custom soak pointer path, so test and automation callers can verify pointer behavior without mutating the default soak pointer.
- Document the repair path in the nightly runner docs, phase plan, and roadmap copy.

## Testing
- node --test scripts/nightly-self-improve.test.mjs
- corepack npm run test:scripts
- corepack npm run validate:feature