### PR TITLE
feat: add nightly preflight actions

### DIFF
--- a/docs/NIGHTLY-SELF-IMPROVE.md
+++ b/docs/NIGHTLY-SELF-IMPROVE.md
@@ -17,6 +17,7 @@ The first rule is simple: evidence first, code second. If a target has weak evid
 - Duplicate peer work indicators such as shared changed files, shared package surfaces, and shared provider-visible risk
 - Prior outcome ledger at `/tmp/freed-nightly-self-improve/outcomes.jsonl`
 - Preflight risks such as dirty worktrees, generated artifacts, stale or thin soak samples, missing dependencies, missing evidence files, and paused automations
+- Preflight actions that separate safe local commands from manual or agent-tool-only remediation
 
 ## Target Types
 
@@ -77,6 +78,7 @@ The generated run directory contains:
 - `report.md`: morning-readable summary
 - `targets.json`: full machine-readable candidate list
 - `risk-snapshot.md` and `risk-snapshot.json`: preflight blockers, warnings, evidence, and remediation steps
+- `preflight-actions.md` and `preflight-actions.json`: machine-readable local, manual, and automation-tool risk actions
 - `duplicate-work.md` and `duplicate-work.json`: peer worktree overlap by file and surface
 - `tasks/*.md`: one implementation prompt per selected target
 - `execution-plan.md` and `execution-plan.json`: ordered phases, command hints, and stop gates
@@ -91,7 +93,7 @@ The runner excludes provider-visible tasks by default. Do not allow autonomous c
 
 Release work is also gated. A dev build should ship only after actual fixes merge into `dev`, not after planning artifacts alone.
 
-Every execution phase has a stop gate. The runner should stop rather than freestyle when evidence is missing, a peer branch is still changing, a provider-visible change needs approval, focused validation fails, or no real fix landed. The preflight risk snapshot is now also a selectable target, so blocker risks like a dirty current worktree or missing dependencies can win the queue before the runner starts editing. If the active soak pointer is empty, the runner falls back to the newest readable soak and records that fallback in the risk snapshot. When the fix is purely local, `--repair-soak-pointer` can update the active pointer to that readable soak so later runs no longer start from a dead evidence path. Performance targets need at least three fresh soak samples, so a single stale heartbeat can inform the report without pretending to be a real budget miss.
+Every execution phase has a stop gate. The runner should stop rather than freestyle when evidence is missing, a peer branch is still changing, a provider-visible change needs approval, focused validation fails, or no real fix landed. The preflight risk snapshot is now also a selectable target, so blocker risks like a dirty current worktree or missing dependencies can win the queue before the runner starts editing. If the active soak pointer is empty, the runner falls back to the newest readable soak and records that fallback in the risk snapshot. When the fix is purely local, `--repair-soak-pointer` can update the active pointer to that readable soak so later runs no longer start from a dead evidence path. Performance targets need at least three fresh soak samples, so a single stale heartbeat can inform the report without pretending to be a real budget miss. Preflight actions label each remediation as a safe local command, manual review, or automation-tool action before an overnight agent touches it.
 
 ## Next Improvements
 

--- a/docs/PHASE-10-POLISH.md
+++ b/docs/PHASE-10-POLISH.md
@@ -126,7 +126,7 @@ The shared extension points now live in `packages/ui/src/lib/command-palette.ts`
 
 Freed now has a local nightly improvement planner in `scripts/nightly-self-improve.mjs`. It folds the installed-build soak, daily bug scan memory, crash-watch state, roadmap fallback memory, peer worktrees, prior outcome history, and current git state into a ranked queue of work that can run overnight.
 
-The runner can choose multiple targets in one night. Bug fixes are first-class targets through the existing daily bug scan memory, while peer worktree integration, duplicate-work detection, performance, stability, release readiness, and roadmap work compete by score and machine-time budget. Each run now writes a preflight risk snapshot plus an execution plan with stop gates, command hints, task prompts, outcome templates, and ready-to-run ledger closeout commands so overnight automation has a clear path from clean evidence to validation, dev build shipping, installed-build soak, learned scoring, and morning closeout. When the active soak pointer has no samples, the runner falls back to the newest readable soak and records that fallback as preflight evidence. It can also repair the pointer to that readable soak when the remediation is unambiguous and local only. Performance targets require enough fresh soak samples before WebKit RSS or heartbeat evidence can win the queue. Provider-visible ideas stay blocked unless a human explicitly approves the fingerprinting risk.
+The runner can choose multiple targets in one night. Bug fixes are first-class targets through the existing daily bug scan memory, while peer worktree integration, duplicate-work detection, performance, stability, release readiness, and roadmap work compete by score and machine-time budget. Each run now writes a preflight risk snapshot plus an execution plan with stop gates, command hints, task prompts, outcome templates, and ready-to-run ledger closeout commands so overnight automation has a clear path from clean evidence to validation, dev build shipping, installed-build soak, learned scoring, and morning closeout. When the active soak pointer has no samples, the runner falls back to the newest readable soak and records that fallback as preflight evidence. It can also repair the pointer to that readable soak when the remediation is unambiguous and local only. Performance targets require enough fresh soak samples before WebKit RSS or heartbeat evidence can win the queue. Preflight actions now label each remediation as a safe local command, manual review, or automation-tool action. Provider-visible ideas stay blocked unless a human explicitly approves the fingerprinting risk.
 
 ### Keyboard Shortcuts
 
@@ -472,7 +472,7 @@ Reward security researchers for responsible disclosure.
 - [ ] Discord server active
 - [ ] Bug bounty program published
 - [ ] Regular release schedule established
-- [x] Local nightly improvement runner ranks preflight risks, duplicate peer work, peer worktree, bug fix, performance, stability, release, and roadmap targets before autonomous work begins, with local soak pointer repair when active evidence is unreadable
+- [x] Local nightly improvement runner ranks preflight risks, duplicate peer work, peer worktree, bug fix, performance, stability, release, and roadmap targets before autonomous work begins, with local soak pointer repair and typed preflight actions
 - [ ] Documentation site live
 
 ### Resilience

--- a/scripts/nightly-self-improve.mjs
+++ b/scripts/nightly-self-improve.mjs
@@ -984,8 +984,20 @@ export function collectRepoSnapshot(repo) {
   };
 }
 
-function riskItem({ id, severity, title, evidence, remediation }) {
-  return { id, severity, title, evidence, remediation };
+function riskAction({
+  id,
+  kind,
+  title,
+  safety = "manual",
+  command = "",
+  automationId = "",
+  notes = "",
+}) {
+  return { id, kind, title, safety, command, automationId, notes };
+}
+
+function riskItem({ id, severity, title, evidence, remediation, actions = [] }) {
+  return { id, severity, title, evidence, remediation, actions };
 }
 
 export function collectRiskSnapshot({
@@ -1010,6 +1022,15 @@ export function collectRiskSnapshot({
         evidence: repoStatusPaths.slice(0, 12),
         remediation:
           "Inspect the current worktree before starting autonomous edits so generated files or user changes do not get mixed into the next fix.",
+        actions: [
+          riskAction({
+            id: "inspect-current-worktree",
+            kind: "manual",
+            title: "Inspect current worktree changes before editing",
+            notes:
+              "Do not auto-clean a dirty worktree because the changes may belong to another agent or the user.",
+          }),
+        ],
       }),
     );
   }
@@ -1030,6 +1051,17 @@ export function collectRiskSnapshot({
           evidence: [absolutePath, `${numberFormatter.format(fileCount)} files`],
           remediation:
             "Remove generated reports or intentionally stage them before publishing so validation leftovers do not pollute the branch.",
+          actions: [
+            riskAction({
+              id: `remove-generated-${relativePath.replace(/[^a-z0-9]+/gi, "-").toLowerCase()}`,
+              kind: "local-command",
+              title: `Remove generated artifacts from ${relativePath}`,
+              safety: "safe-local",
+              command: `rm -rf ${JSON.stringify(relativePath)}`,
+              notes:
+                "Only removes known generated validation artifacts inside the current worktree.",
+            }),
+          ],
         }),
       );
     }
@@ -1044,6 +1076,15 @@ export function collectRiskSnapshot({
         evidence: [path.join(repoPath, "node_modules")],
         remediation:
           "Bootstrap the worktree before running validation or planning work that depends on repo scripts.",
+        actions: [
+          riskAction({
+            id: "bootstrap-root-dependencies",
+            kind: "local-command",
+            title: "Install root dependencies",
+            safety: "safe-local",
+            command: "corepack npm ci",
+          }),
+        ],
       }),
     );
   }
@@ -1063,6 +1104,15 @@ export function collectRiskSnapshot({
           ],
           remediation:
             "Restart the installed-build soak before using its memory, lag, or heartbeat data to pick the next performance fix.",
+          actions: [
+            riskAction({
+              id: "restart-installed-build-soak",
+              kind: "manual",
+              title: "Restart the installed-build soak",
+              notes:
+                "This runner can identify stale soak evidence, but the soak loop itself is environment-specific and should be restarted by the active soak workflow.",
+            }),
+          ],
         }),
       );
     }
@@ -1077,6 +1127,17 @@ export function collectRiskSnapshot({
         evidence: [soak.soakDir],
         remediation:
           "Inspect the soak loop and restart it before treating soak-backed performance targets as measured evidence.",
+        actions: [
+          riskAction({
+            id: "repair-soak-pointer",
+            kind: "local-command",
+            title: "Try repairing the active soak pointer",
+            safety: "safe-local",
+            command: "node scripts/nightly-self-improve.mjs --repair-soak-pointer",
+            notes:
+              "Repairs only when a newer readable soak exists under the same soak root.",
+          }),
+        ],
       }),
     );
   }
@@ -1094,6 +1155,15 @@ export function collectRiskSnapshot({
         ],
         remediation:
           "Restart or continue the installed-build soak before using memory, lag, or heartbeat data to select a performance fix.",
+        actions: [
+          riskAction({
+            id: "continue-installed-build-soak",
+            kind: "manual",
+            title: "Continue or restart the installed-build soak",
+            notes:
+              "The runner needs more fresh samples before treating performance evidence as a target.",
+          }),
+        ],
       }),
     );
   }
@@ -1111,6 +1181,17 @@ export function collectRiskSnapshot({
         ],
         remediation:
           "Refresh the current soak pointer after the soak loop restarts so future runs use the active installed-build evidence directly.",
+        actions: [
+          riskAction({
+            id: "repair-soak-pointer",
+            kind: "local-command",
+            title: "Repair the active soak pointer",
+            safety: "safe-local",
+            command: "node scripts/nightly-self-improve.mjs --repair-soak-pointer",
+            notes:
+              "Updates the pointer to the newest readable soak without contacting providers or launching the app.",
+          }),
+        ],
       }),
     );
   }
@@ -1125,6 +1206,15 @@ export function collectRiskSnapshot({
           evidence: [peer.path, ...shortStatusPaths(peer.status).slice(0, 8)],
           remediation:
             "Treat the peer as active work. Compare it read-only and do not cherry-pick from it until its state is understood.",
+          actions: [
+            riskAction({
+              id: "inspect-dirty-peer",
+              kind: "manual",
+              title: "Inspect dirty peer worktree",
+              notes:
+                "Peer changes may belong to another active agent, so the runner should not auto-clean them.",
+            }),
+          ],
         }),
       );
     }
@@ -1140,6 +1230,15 @@ export function collectRiskSnapshot({
           ],
           remediation:
             "Prefer reimplementing the useful idea on current dev over merging or cherry-picking stale work directly.",
+          actions: [
+            riskAction({
+              id: "review-stale-peer",
+              kind: "manual",
+              title: "Review stale peer worktree before reuse",
+              notes:
+                "Use the peer only as read-only evidence unless it is rebased and revalidated.",
+            }),
+          ],
         }),
       );
     }
@@ -1157,6 +1256,15 @@ export function collectRiskSnapshot({
         ]),
         remediation:
           "Pick one owner or merge the safer subset before continuing so parallel agents do not publish competing fixes for the same surface.",
+        actions: [
+          riskAction({
+            id: "dedupe-peer-work",
+            kind: "manual",
+            title: "Assign a single owner for overlapping peer work",
+            notes:
+              "Duplicate code ownership needs a human or active agent decision before publishing.",
+          }),
+        ],
       }),
     );
   }
@@ -1184,6 +1292,15 @@ export function collectRiskSnapshot({
           evidence: [automation.path],
           remediation:
             "Continue only if this evidence source is optional for the selected target, otherwise recreate or refresh it first.",
+          actions: [
+            riskAction({
+              id: `refresh-${automation.name}`,
+              kind: "manual",
+              title: `Refresh ${automation.name} evidence`,
+              notes:
+                "The runner records the missing evidence but does not guess how to recreate this source.",
+            }),
+          ],
         }),
       );
     } else if (/paused/i.test(automation.status)) {
@@ -1195,6 +1312,17 @@ export function collectRiskSnapshot({
           evidence: [automation.path, `status ${automation.status}`],
           remediation:
             "Resume or account for the paused automation before trusting overnight health or bug-scan coverage.",
+          actions: [
+            riskAction({
+              id: `resume-${automation.name}`,
+              kind: "automation-update",
+              title: `Resume ${automation.name} automation`,
+              safety: "agent-tool",
+              automationId: automation.name,
+              notes:
+                "Requires the Codex automation tool because this is not a repo-local file edit.",
+            }),
+          ],
         }),
       );
     }
@@ -1207,6 +1335,7 @@ export function collectRiskSnapshot({
     warningCount: risks.filter((risk) => risk.severity === "warning").length,
     infoCount: risks.filter((risk) => risk.severity === "info").length,
     automationStatuses,
+    actionCount: risks.reduce((count, risk) => count + (risk.actions?.length ?? 0), 0),
     risks,
   };
 }
@@ -1627,6 +1756,7 @@ export function buildReport({ repo, soak, riskSnapshot, duplicateWork, outcomeLe
     `- Blockers: ${numberFormatter.format(riskSnapshot?.blockerCount ?? 0)}`,
     `- Warnings: ${numberFormatter.format(riskSnapshot?.warningCount ?? 0)}`,
     `- Info: ${numberFormatter.format(riskSnapshot?.infoCount ?? 0)}`,
+    `- Actions: ${numberFormatter.format(riskSnapshot?.actionCount ?? 0)}`,
     "",
     ...(riskSnapshot?.risks ?? []).slice(0, 8).map(
       (risk) => `- ${risk.severity}: ${risk.title}`,
@@ -1731,6 +1861,18 @@ function renderRiskSnapshotMarkdown(riskSnapshot) {
           "",
           risk.remediation,
           "",
+          ...(risk.actions?.length
+            ? [
+                "Actions:",
+                "",
+                ...risk.actions.map((action) =>
+                  `- ${action.title} (${action.kind}, ${action.safety})${
+                    action.command ? `: \`${action.command}\`` : ""
+                  }`,
+                ),
+                "",
+              ]
+            : []),
         ])
       : ["No preflight risks detected.", ""]),
     "## Automation Statuses",
@@ -1742,6 +1884,41 @@ function renderRiskSnapshotMarkdown(riskSnapshot) {
         )
       : ["- No automation status files checked."]),
     "",
+  ].join("\n");
+}
+
+function flattenRiskActions(riskSnapshot) {
+  return (riskSnapshot.risks ?? []).flatMap((risk) =>
+    (risk.actions ?? []).map((action) => ({
+      ...action,
+      riskId: risk.id,
+      riskTitle: risk.title,
+      severity: risk.severity,
+    })),
+  );
+}
+
+function renderPreflightActionsMarkdown(riskSnapshot) {
+  const actions = flattenRiskActions(riskSnapshot);
+  return [
+    "# Nightly Preflight Actions",
+    "",
+    `Actions: ${numberFormatter.format(actions.length)}`,
+    "",
+    ...(actions.length > 0
+      ? actions.flatMap((action) => [
+          `## ${action.title}`,
+          "",
+          `Risk: ${action.riskTitle}`,
+          `Severity: ${action.severity}`,
+          `Kind: ${action.kind}`,
+          `Safety: ${action.safety}`,
+          ...(action.command ? [`Command: \`${action.command}\``] : []),
+          ...(action.automationId ? [`Automation: ${action.automationId}`] : []),
+          ...(action.notes ? ["", action.notes] : []),
+          "",
+        ])
+      : ["No preflight actions available.", ""]),
   ].join("\n");
 }
 
@@ -1770,6 +1947,7 @@ export function buildExecutionPlan(selected) {
         "git fetch --all --prune",
         "git status --short",
         "node scripts/nightly-self-improve.mjs --dry-run --json",
+        "# Read preflight-actions.md before manually fixing risk-snapshot warnings.",
       ],
     },
   ];
@@ -1896,6 +2074,7 @@ export function writeRunPlan({ runDir, repo, soak, riskSnapshot, duplicateWork, 
       blockerCount: 0,
       warningCount: 0,
       infoCount: 0,
+      actionCount: 0,
       automationStatuses: [],
       risks: [],
     };
@@ -1926,6 +2105,8 @@ export function writeRunPlan({ runDir, repo, soak, riskSnapshot, duplicateWork, 
   writeFileSync(path.join(runDir, "targets.json"), `${JSON.stringify({ repo, soak, riskSnapshot: safeRiskSnapshot, duplicateWork: safeDuplicateWork, peerWorktrees, outcomeLedger, executionPlan, candidates, selected }, null, 2)}\n`);
   writeFileSync(path.join(runDir, "risk-snapshot.json"), `${JSON.stringify(safeRiskSnapshot, null, 2)}\n`);
   writeFileSync(path.join(runDir, "risk-snapshot.md"), renderRiskSnapshotMarkdown(safeRiskSnapshot));
+  writeFileSync(path.join(runDir, "preflight-actions.json"), `${JSON.stringify(flattenRiskActions(safeRiskSnapshot), null, 2)}\n`);
+  writeFileSync(path.join(runDir, "preflight-actions.md"), renderPreflightActionsMarkdown(safeRiskSnapshot));
   writeFileSync(path.join(runDir, "duplicate-work.json"), `${JSON.stringify(safeDuplicateWork, null, 2)}\n`);
   writeFileSync(path.join(runDir, "duplicate-work.md"), renderDuplicateWorkMarkdown(safeDuplicateWork));
   writeFileSync(path.join(runDir, "execution-plan.json"), `${JSON.stringify(executionPlan, null, 2)}\n`);
@@ -1957,6 +2138,7 @@ export function writeRunPlan({ runDir, repo, soak, riskSnapshot, duplicateWork, 
     reportPath: path.join(runDir, "report.md"),
     tasksDir,
     riskSnapshotPath: path.join(runDir, "risk-snapshot.md"),
+    preflightActionsPath: path.join(runDir, "preflight-actions.md"),
     duplicateWorkPath: path.join(runDir, "duplicate-work.md"),
     executionPlanPath: path.join(runDir, "execution-plan.md"),
     outcomeCloseoutPath: path.join(runDir, "outcome-closeout.md"),
@@ -2016,6 +2198,7 @@ function textSummary(plan, writeResult, args) {
     lines.push(`Report: ${writeResult.reportPath}`);
     lines.push(`Tasks: ${writeResult.tasksDir}`);
     lines.push(`Risk snapshot: ${writeResult.riskSnapshotPath}`);
+    lines.push(`Preflight actions: ${writeResult.preflightActionsPath}`);
     lines.push(`Duplicate work: ${writeResult.duplicateWorkPath}`);
     lines.push(`Execution plan: ${writeResult.executionPlanPath}`);
     lines.push(`Outcome closeout: ${writeResult.outcomeCloseoutPath}`);

--- a/scripts/nightly-self-improve.test.mjs
+++ b/scripts/nightly-self-improve.test.mjs
@@ -585,9 +585,20 @@ test("risk snapshot reports dirty worktrees, generated artifacts, stale soak, an
 
   assert.equal(snapshot.blockerCount, 1);
   assert.ok(snapshot.warningCount >= 4);
+  assert.ok(snapshot.actionCount >= 4);
   assert.ok(snapshot.risks.some((risk) => risk.id === "dirty-current-worktree"));
   assert.ok(snapshot.risks.some((risk) => risk.id === "stale-soak-evidence"));
   assert.ok(snapshot.risks.some((risk) => risk.id === "paused-crash-watch"));
+  assert.ok(
+    snapshot.risks
+      .find((risk) => risk.id === "generated-artifacts-packages-desktop-playwright-report")
+      ?.actions.some((action) => action.kind === "local-command"),
+  );
+  assert.ok(
+    snapshot.risks
+      .find((risk) => risk.id === "paused-crash-watch")
+      ?.actions.some((action) => action.kind === "automation-update"),
+  );
 });
 
 test("writeRunPlan emits report, targets, and task prompts", () => {
@@ -628,6 +639,7 @@ test("writeRunPlan emits report, targets, and task prompts", () => {
   assert.equal(path.basename(result.reportPath), "report.md");
   assert.equal(path.basename(result.tasksDir), "tasks");
   assert.equal(path.basename(result.riskSnapshotPath), "risk-snapshot.md");
+  assert.equal(path.basename(result.preflightActionsPath), "preflight-actions.md");
   assert.equal(path.basename(result.duplicateWorkPath), "duplicate-work.md");
   assert.equal(path.basename(result.executionPlanPath), "execution-plan.md");
   assert.equal(path.basename(result.outcomeCloseoutPath), "outcome-closeout.md");

--- a/website/src/app/roadmap/RoadmapContent.tsx
+++ b/website/src/app/roadmap/RoadmapContent.tsx
@@ -783,7 +783,7 @@ const phases: Phase[] = [
     number: 10,
     title: "Polish",
     description:
-      "Onboarding, statistics, global animation controls, expanded local content signals with Desktop and PWA backfill, inclusive saved feed filter presets, compact event extraction, local semantic enrichment for friend suggestions, unified AI provider settings, Light, Balanced, and Pro Integrated AI packs with semantic scan health, plugin API, community infrastructure, duplicate-aware nightly improvement planning with learned closeout, fresh soak quality gates, self-repairing soak evidence, and deeper crash recovery hardening.",
+      "Onboarding, statistics, global animation controls, expanded local content signals with Desktop and PWA backfill, inclusive saved feed filter presets, compact event extraction, local semantic enrichment for friend suggestions, unified AI provider settings, Light, Balanced, and Pro Integrated AI packs with semantic scan health, plugin API, community infrastructure, duplicate-aware nightly improvement planning with learned closeout, typed preflight actions, fresh soak quality gates, self-repairing soak evidence, and deeper crash recovery hardening.",
     status: "upcoming",
     planLink:
       "https://github.com/freed-project/freed/blob/dev/docs/PHASE-10-POLISH.md",


### PR DESCRIPTION
(AI Generated).

## Summary
- Add typed preflight action metadata to nightly runner risks.
- Write preflight-actions.md and preflight-actions.json next to the risk snapshot so overnight runs can separate safe local commands from manual and automation-tool remediation.
- Update nightly runner docs, phase notes, and roadmap copy.

## Testing
- node --test scripts/nightly-self-improve.test.mjs
- corepack npm run test:scripts
- corepack npm run validate:feature