### PR TITLE
fix: block Facebook chrome from friend suggestions

### DIFF
--- a/packages/capture-facebook/src/normalize.ts
+++ b/packages/capture-facebook/src/normalize.ts
@@ -5,6 +5,7 @@
  */
 
 import type { FeedItem, Author, Content, Engagement, Location } from "@freed/shared";
+import { isValidFacebookAuthorIdentity } from "@freed/shared";
 import type { RawFbPost } from "./types.js";
 
 // =============================================================================
@@ -123,6 +124,12 @@ function buildFbGroup(post: RawFbPost): FeedItem["fbGroup"] | undefined {
  */
 export function fbPostToFeedItem(post: RawFbPost): FeedItem | null {
   if (!post.id && !post.url) return null;
+  if (!isValidFacebookAuthorIdentity({
+    displayName: post.authorName,
+    profileUrl: post.authorProfileUrl,
+  })) {
+    return null;
+  }
 
   const globalId = `fb:${post.id ?? encodeURIComponent(post.url ?? "")}`;
   const publishedAt = extractTimestamp(post);

--- a/packages/desktop/src-tauri/src/fb-extract.js
+++ b/packages/desktop/src-tauri/src/fb-extract.js
@@ -35,6 +35,107 @@
     return Math.round(num);
   }
 
+  var FACEBOOK_UI_LABELS = new Set([
+    "account",
+    "ads manager",
+    "create new account",
+    "events",
+    "facebook",
+    "feeds",
+    "friends",
+    "gaming",
+    "groups",
+    "home",
+    "log in",
+    "marketplace",
+    "memories",
+    "menu",
+    "messenger",
+    "meta",
+    "notifications",
+    "pages",
+    "profile",
+    "reels",
+    "saved",
+    "search facebook",
+    "see less",
+    "see more",
+    "sign up",
+    "video",
+    "watch",
+    "your shortcuts",
+  ]);
+
+  var FACEBOOK_BLOCKED_PATHS = new Set([
+    "ads",
+    "bookmarks",
+    "events",
+    "friends",
+    "gaming",
+    "groups",
+    "help",
+    "home",
+    "login",
+    "marketplace",
+    "me",
+    "memories",
+    "messages",
+    "notifications",
+    "pages",
+    "privacy",
+    "recover",
+    "reg",
+    "reel",
+    "reels",
+    "saved",
+    "settings",
+    "stories",
+    "watch",
+  ]);
+
+  function normalizeLabel(value) {
+    return (value || "")
+      .normalize("NFKD")
+      .replace(/[\u0300-\u036f]/g, "")
+      .replace(/\s+/g, " ")
+      .trim()
+      .toLowerCase();
+  }
+
+  function isFacebookUiChromeLabel(value) {
+    var normalized = normalizeLabel(value);
+    if (!normalized) return true;
+    if (FACEBOOK_UI_LABELS.has(normalized)) return true;
+    if (/^(create|log in|sign up|search|switch|manage)\b/.test(normalized)) return true;
+    if (/\b(shortcuts|notifications|messenger|marketplace)\b/.test(normalized)) return true;
+    return false;
+  }
+
+  function isValidFacebookActorUrl(value) {
+    if (!value) return false;
+    try {
+      var url = new URL(value, "https://www.facebook.com/");
+      var host = url.hostname.toLowerCase();
+      if (host !== "facebook.com" && !host.endsWith(".facebook.com")) return false;
+
+      var parts = url.pathname.split("/").filter(Boolean);
+      var first = parts[0] ? parts[0].toLowerCase() : "";
+      if (!first || FACEBOOK_BLOCKED_PATHS.has(first)) return false;
+
+      if (first === "profile.php") {
+        return /^\d+$/.test(url.searchParams.get("id") || "");
+      }
+
+      return /^[a-z0-9][a-z0-9._-]{1,79}$/i.test(parts[0]);
+    } catch (_) {
+      return false;
+    }
+  }
+
+  function isValidFacebookAuthor(name, profileUrl) {
+    return !isFacebookUiChromeLabel(name) && isValidFacebookActorUrl(profileUrl);
+  }
+
   function extractHashtags(text) {
     return (text.match(/#(\w+)/g) || []).map(function (h) {
       return h.slice(1).toLowerCase();
@@ -176,7 +277,7 @@
       var h3link = h3.querySelector("a[href]");
       if (h3link) {
         var h3text = (h3link.textContent || "").trim();
-        if (h3text.length > 1 && h3text.length < 80) {
+        if (h3text.length > 1 && h3text.length < 80 && isValidFacebookAuthor(h3text, h3link.href)) {
           name = h3text;
           profileUrl = h3link.href;
         }
@@ -191,8 +292,11 @@
     if (!name) {
       var h4 = el.querySelector("h4 a[href]");
       if (h4) {
-        name = (h4.textContent || "").trim();
-        profileUrl = h4.href;
+        var h4text = (h4.textContent || "").trim();
+        if (isValidFacebookAuthor(h4text, h4.href)) {
+          name = h4text;
+          profileUrl = h4.href;
+        }
       }
     }
 
@@ -204,6 +308,7 @@
         if (
           label.length > 2 &&
           label.length < 80 &&
+          isValidFacebookAuthor(label, ariaLinks[i].href) &&
           !/^(Like|Comment|Share|Reply|More|See|View|Photo|Video|Haha|Wow|Sad|Angry|Love|Care|Open|Close|Play|Mute)/i.test(
             label
           )
@@ -225,10 +330,11 @@
           !href.includes("/groups/") &&
           !href.includes("/pages/") &&
           !href.includes("/settings") &&
-          !href.includes("/marketplace")
+          !href.includes("/marketplace") &&
+          isValidFacebookActorUrl(href)
         ) {
           var lt = (links[j].textContent || "").trim();
-          if (lt.length > 1 && lt.length < 80) {
+          if (lt.length > 1 && lt.length < 80 && !isFacebookUiChromeLabel(lt)) {
             name = lt;
             profileUrl = href;
             break;
@@ -246,6 +352,10 @@
         avatarUrl = imgs[m].src;
         break;
       }
+    }
+
+    if (!isValidFacebookAuthor(name, profileUrl)) {
+      return { name: null, profileUrl: null, avatarUrl: null };
     }
 
     return { name: name, profileUrl: profileUrl, avatarUrl: avatarUrl };
@@ -428,6 +538,8 @@
       var ts = extractTimestamp(el);
       var postRef = extractPostId(el);
       var group = extractGroup(el);
+
+      if (!author.name || !author.profileUrl) continue;
 
       // Extract media
       var imgEls = el.querySelectorAll(

--- a/packages/desktop/src/lib/facebook-normalize.test.ts
+++ b/packages/desktop/src/lib/facebook-normalize.test.ts
@@ -1,15 +1,16 @@
 import { describe, expect, it } from "vitest";
+import type { RawFbPost } from "@freed/capture-facebook/browser";
 import { fbPostToFeedItem } from "@freed/capture-facebook/browser";
 
 describe("fbPostToFeedItem", () => {
-  it("maps raw Facebook group metadata to feedItem.fbGroup", () => {
-    const item = fbPostToFeedItem({
+  function rawPost(overrides: Partial<RawFbPost> = {}): RawFbPost {
+    return {
       id: "123",
-      url: "https://www.facebook.com/groups/my-group/posts/123",
+      url: "https://www.facebook.com/story.php?story_fbid=123&id=999",
       authorName: "Alice Example",
       authorProfileUrl: "https://www.facebook.com/alice.example",
       authorAvatarUrl: null,
-      text: "Group post",
+      text: "Facebook post",
       timestampSeconds: 1_700_000_000,
       timestampIso: null,
       mediaUrls: [],
@@ -22,17 +23,52 @@ describe("fbPostToFeedItem", () => {
       hashtags: [],
       isShare: false,
       sharedFrom: null,
+      group: null,
+      ...overrides,
+    };
+  }
+
+  it("maps raw Facebook group metadata to feedItem.fbGroup", () => {
+    const item = fbPostToFeedItem(rawPost({
+      url: "https://www.facebook.com/groups/my-group/posts/123",
+      text: "Group post",
       group: {
         id: "my-group",
         name: "My Group",
         url: "https://www.facebook.com/groups/my-group",
       },
-    });
+    }));
 
     expect(item?.fbGroup).toEqual({
       id: "my-group",
       name: "My Group",
       url: "https://www.facebook.com/groups/my-group",
+    });
+  });
+
+  it("rejects Facebook registration UI as an author", () => {
+    expect(fbPostToFeedItem(rawPost({
+      authorName: "Create New Account",
+      authorProfileUrl: "https://www.facebook.com/r.php",
+    }))).toBeNull();
+  });
+
+  it("rejects Facebook shortcut UI as an author", () => {
+    expect(fbPostToFeedItem(rawPost({
+      authorName: "Your Shortcuts",
+      authorProfileUrl: "https://www.facebook.com/bookmarks",
+    }))).toBeNull();
+  });
+
+  it("keeps a normal Facebook author", () => {
+    const item = fbPostToFeedItem(rawPost({
+      authorName: "Zana Prana",
+      authorProfileUrl: "https://www.facebook.com/zana.prana",
+    }));
+
+    expect(item?.author).toMatchObject({
+      id: "fb:zana.prana",
+      displayName: "Zana Prana",
     });
   });
 });

--- a/packages/desktop/tests/e2e/facebook-capture.spec.ts
+++ b/packages/desktop/tests/e2e/facebook-capture.spec.ts
@@ -189,6 +189,48 @@ test("Facebook sync excludes posts from filtered groups", async ({
             sharedFrom: null,
             group: null,
           },
+          {
+            id: "create-account-post",
+            url: "https://www.facebook.com/story.php?story_fbid=4&id=5",
+            authorName: "Create New Account",
+            authorProfileUrl: "https://www.facebook.com/r.php",
+            authorAvatarUrl: null,
+            text: "This is Facebook registration chrome and should be ignored",
+            timestampSeconds: 1709640002,
+            timestampIso: null,
+            mediaUrls: [],
+            hasVideo: false,
+            likeCount: null,
+            commentCount: null,
+            shareCount: null,
+            postType: "post",
+            location: null,
+            hashtags: [],
+            isShare: false,
+            sharedFrom: null,
+            group: null,
+          },
+          {
+            id: "shortcuts-post",
+            url: "https://www.facebook.com/story.php?story_fbid=6&id=7",
+            authorName: "Your Shortcuts",
+            authorProfileUrl: "https://www.facebook.com/bookmarks",
+            authorAvatarUrl: null,
+            text: "This is Facebook shortcut chrome and should be ignored",
+            timestampSeconds: 1709640003,
+            timestampIso: null,
+            mediaUrls: [],
+            hasVideo: false,
+            likeCount: null,
+            commentCount: null,
+            shareCount: null,
+            postType: "post",
+            location: null,
+            hashtags: [],
+            isShare: false,
+            sharedFrom: null,
+            group: null,
+          },
         ],
         extractedAt: Date.now(),
         url: "https://www.facebook.com/",
@@ -258,4 +300,26 @@ test("Facebook sync excludes posts from filtered groups", async ({
 
   expect(itemIds).toContain("fb:feed-post-2");
   expect(itemIds).not.toContain("fb:group-post-1");
+  expect(itemIds).not.toContain("fb:create-account-post");
+  expect(itemIds).not.toContain("fb:shortcuts-post");
+
+  await page.waitForFunction(() => {
+    const w = window as Record<string, unknown>;
+    const store = w.__FREED_STORE__ as {
+      getState: () => { accounts: Record<string, { displayName?: string }> };
+    };
+    return Object.values(store.getState().accounts).some((account) => account.displayName === "Bob Builder");
+  });
+
+  const accountNames = await page.evaluate(() => {
+    const w = window as Record<string, unknown>;
+    const store = w.__FREED_STORE__ as {
+      getState: () => { accounts: Record<string, { displayName?: string }> };
+    };
+    return Object.values(store.getState().accounts).map((account) => account.displayName);
+  });
+
+  expect(accountNames).toContain("Bob Builder");
+  expect(accountNames).not.toContain("Create New Account");
+  expect(accountNames).not.toContain("Your Shortcuts");
 });

--- a/packages/pwa/src/lib/friend-suggestions.test.ts
+++ b/packages/pwa/src/lib/friend-suggestions.test.ts
@@ -117,6 +117,29 @@ describe("buildFriendCandidateSuggestions", () => {
     expect(suggestions).toEqual([]);
   });
 
+  it("hides Facebook UI chrome accounts", () => {
+    const suggestions = buildFriendCandidateSuggestions({
+      persons: [],
+      accounts: {
+        "social:facebook:unknown": {
+          ...account("social:facebook:unknown", "Create New Account", "unknown", undefined, "facebook"),
+          profileUrl: "https://www.facebook.com/r.php",
+        },
+        "social:facebook:bookmarks": {
+          ...account("social:facebook:bookmarks", "Your Shortcuts", "bookmarks", undefined, "facebook"),
+          profileUrl: "https://www.facebook.com/bookmarks",
+        },
+      },
+      feedItems: [
+        { ...item("facebook:unknown:1", "unknown", ["life_update", "moment"]), platform: "facebook" },
+        { ...item("facebook:bookmarks:1", "bookmarks", ["life_update", "place"]), platform: "facebook" },
+      ],
+      now: NOW,
+    });
+
+    expect(suggestions).toEqual([]);
+  });
+
   it("orders deterministically and keeps ids stable", () => {
     const input = {
       persons: [

--- a/packages/shared/src/friend-suggestions.ts
+++ b/packages/shared/src/friend-suggestions.ts
@@ -10,6 +10,7 @@ import type {
   IdentitySuggestion,
   Person,
 } from "./types.js";
+import { isValidDiscoveredSocialAccount } from "./social-account-validity.js";
 
 export interface BuildFriendCandidateSuggestionsInput {
   persons: Person[] | Record<string, Person>;
@@ -349,7 +350,9 @@ export function buildFriendCandidateSuggestions({
     for (const accountId of suggestion.accountIds) contactAccountIds.add(accountId);
   }
 
-  const socialAccounts = Object.values(accounts).filter((account) => account.kind === "social");
+  const socialAccounts = Object.values(accounts).filter((account) =>
+    account.kind === "social" && isValidDiscoveredSocialAccount(account)
+  );
   const accountsByPerson = new Map<string, Account[]>();
   for (const account of socialAccounts) {
     if (!account.personId) continue;

--- a/packages/shared/src/friends.ts
+++ b/packages/shared/src/friends.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Account, FeedItem, Friend, Person, Platform } from "./types.js";
+import { isValidDiscoveredSocialFeedAuthor } from "./social-account-validity.js";
 
 const DEFAULT_INTERVALS: Record<1 | 2 | 3 | 4 | 5, number | null> = {
   5: 7,
@@ -106,6 +107,7 @@ export function buildDiscoveredAccountsFromItems(
 
   for (const item of items) {
     if (!SOCIAL_PLATFORMS.has(item.platform)) continue;
+    if (!isValidDiscoveredSocialFeedAuthor(item)) continue;
     const key = `${item.platform}:${item.author.id}`;
     if (seen.has(key)) continue;
     seen.add(key);

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -30,6 +30,7 @@ export * from "./friends";
 export * from "./friend-suggestions";
 export * from "./identity-graph";
 export * from "./contact-sync-state";
+export * from "./social-account-validity";
 
 // Re-export location extraction utilities (browser-safe, no deps)
 export * from "./location";

--- a/packages/shared/src/social-account-validity.ts
+++ b/packages/shared/src/social-account-validity.ts
@@ -1,0 +1,141 @@
+import type { Account, FeedItem } from "./types.js";
+
+const FACEBOOK_UI_LABELS = new Set([
+  "account",
+  "ads manager",
+  "create new account",
+  "events",
+  "facebook",
+  "feeds",
+  "friends",
+  "gaming",
+  "groups",
+  "home",
+  "log in",
+  "marketplace",
+  "memories",
+  "menu",
+  "messenger",
+  "meta",
+  "notifications",
+  "pages",
+  "profile",
+  "reels",
+  "saved",
+  "search facebook",
+  "see less",
+  "see more",
+  "sign up",
+  "video",
+  "watch",
+  "your shortcuts",
+]);
+
+const FACEBOOK_BLOCKED_PATHS = new Set([
+  "ads",
+  "bookmarks",
+  "events",
+  "friends",
+  "gaming",
+  "groups",
+  "help",
+  "home",
+  "login",
+  "marketplace",
+  "me",
+  "memories",
+  "messages",
+  "notifications",
+  "pages",
+  "privacy",
+  "recover",
+  "reg",
+  "reel",
+  "reels",
+  "saved",
+  "settings",
+  "stories",
+  "watch",
+]);
+
+function normalizeLabel(value: string | null | undefined): string {
+  return (value ?? "")
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .toLowerCase();
+}
+
+export function isFacebookUiChromeLabel(value: string | null | undefined): boolean {
+  const normalized = normalizeLabel(value);
+  if (!normalized) return true;
+  if (FACEBOOK_UI_LABELS.has(normalized)) return true;
+  if (/^(create|log in|sign up|search|switch|manage)\b/.test(normalized)) return true;
+  if (/\b(shortcuts|notifications|messenger|marketplace)\b/.test(normalized)) return true;
+  return false;
+}
+
+export function isUsableFacebookAuthorProfileUrl(value: string | null | undefined): boolean {
+  if (!value) return false;
+  try {
+    const url = new URL(value, "https://www.facebook.com/");
+    const host = url.hostname.toLowerCase();
+    if (host !== "facebook.com" && !host.endsWith(".facebook.com")) return false;
+
+    const parts = url.pathname.split("/").filter(Boolean);
+    const first = parts[0]?.toLowerCase();
+    if (!first || FACEBOOK_BLOCKED_PATHS.has(first)) return false;
+
+    if (first === "profile.php") {
+      return /^\d+$/.test(url.searchParams.get("id") ?? "");
+    }
+
+    if (!/^[a-z0-9][a-z0-9._-]{1,79}$/i.test(parts[0])) return false;
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function isValidFacebookAuthorIdentity(input: {
+  displayName?: string | null;
+  profileUrl?: string | null;
+}): boolean {
+  return (
+    !isFacebookUiChromeLabel(input.displayName) &&
+    isUsableFacebookAuthorProfileUrl(input.profileUrl)
+  );
+}
+
+export function isValidDiscoveredSocialAccount(account: Account): boolean {
+  if (account.kind !== "social") return true;
+  if (account.provider !== "facebook") return true;
+  if (isFacebookUiChromeLabel(account.displayName ?? account.handle ?? account.externalId)) {
+    return false;
+  }
+  if (account.profileUrl && !isUsableFacebookAuthorProfileUrl(account.profileUrl)) {
+    return false;
+  }
+  return true;
+}
+
+export function isPrunableInvalidDiscoveredSocialAccount(account: Account): boolean {
+  if (account.kind !== "social") return false;
+  if (account.provider !== "facebook") return false;
+  if (account.personId) return false;
+  if (account.discoveredFrom !== "captured_item" && account.discoveredFrom !== "story_author") {
+    return false;
+  }
+  return !isValidDiscoveredSocialAccount(account);
+}
+
+export function isValidDiscoveredSocialFeedAuthor(item: FeedItem): boolean {
+  if (item.platform !== "facebook") return true;
+  return isValidFacebookAuthorIdentity({
+    displayName: item.author.displayName,
+    profileUrl: item.author.handle && item.author.handle !== "unknown"
+      ? `https://www.facebook.com/${item.author.handle.replace(/^fb:/, "")}`
+      : undefined,
+  });
+}

--- a/packages/ui/src/components/layout/AppShell.tsx
+++ b/packages/ui/src/components/layout/AppShell.tsx
@@ -17,6 +17,7 @@ import { useSettingsStore } from "../../lib/settings-store.js";
 import {
   buildProvisionalPersonCandidates,
   buildDiscoveredAccountsFromItems,
+  isPrunableInvalidDiscoveredSocialAccount,
   type GoogleContact,
   type IdentitySuggestion,
   type SidebarMode,
@@ -64,6 +65,7 @@ export function AppShell({ children }: AppShellProps) {
   const persons = useAppStore((s) => s.persons);
   const addPerson = useAppStore((s) => s.addPerson);
   const addAccounts = useAppStore((s) => s.addAccounts);
+  const removeAccount = useAppStore((s) => s.removeAccount);
   const createConnectionPersonsFromCandidates = useAppStore((s) => s.createConnectionPersonsFromCandidates);
   const isInitialized = useAppStore((s) => s.isInitialized);
   const themeId = useAppStore((s) => s.preferences.display.themeId);
@@ -104,6 +106,7 @@ export function AppShell({ children }: AppShellProps) {
   );
   const discoveredAccountScanRef = useRef({ itemCount: 0, accountCount: 0 });
   const provisionalPersonScanRef = useRef({ personCount: 0, accountCount: 0 });
+  const invalidAccountCleanupRef = useRef("");
   const blockingModalOpen =
     settingsOpen ||
     addFeedOpen ||
@@ -259,6 +262,28 @@ export function AppShell({ children }: AppShellProps) {
     if (activeView === "friends" && isMobileViewport) return;
     setFriendsMobileSurface("graph");
   }, [activeView, isMobileViewport]);
+
+  useEffect(() => {
+    if (!isInitialized) return;
+    const prunableAccounts = Object.values(accounts).filter(isPrunableInvalidDiscoveredSocialAccount);
+    if (prunableAccounts.length === 0) return;
+    const cleanupSignature = prunableAccounts.map((account) => account.id).sort().join("|");
+    if (cleanupSignature === invalidAccountCleanupRef.current) return;
+    invalidAccountCleanupRef.current = cleanupSignature;
+    void Promise.all(prunableAccounts.map((account) => removeAccount(account.id)))
+      .then(() => {
+        invalidAccountCleanupRef.current = "";
+        addDebugEvent(
+          "change",
+          `[Identity] removed ${prunableAccounts.length.toLocaleString()} invalid Facebook account${prunableAccounts.length === 1 ? "" : "s"}`,
+        );
+      })
+      .catch((error) => {
+        const message = error instanceof Error ? error.message : String(error);
+        addDebugEvent("error", `[Identity] invalid Facebook account cleanup failed: ${message}`);
+        invalidAccountCleanupRef.current = "";
+      });
+  }, [accounts, isInitialized, removeAccount]);
 
   useEffect(() => {
     const itemCount = items.length;


### PR DESCRIPTION
(AI Generated).

## Summary
- Reject Facebook UI labels and non-actor URLs before captured posts become feed items.
- Filter invalid discovered Facebook accounts out of account discovery and friend suggestions, and prune existing unlinked UI-label accounts.

## Testing
- npm run test:unit -- facebook-normalize
- node ../../node_modules/vitest/vitest.mjs run src/lib/friend-suggestions.test.ts
- npm run test:e2e -- facebook-capture.spec.ts
- npm run test:e2e:perf:friends
- npm run validate:feature