### PR TITLE
fix: coalesce Google token refreshes

### DIFF
--- a/packages/desktop/src/lib/cloud-oauth.test.ts
+++ b/packages/desktop/src/lib/cloud-oauth.test.ts
@@ -246,6 +246,87 @@ describe("desktop Google OAuth", () => {
     });
   });
 
+  it("coalesces concurrent Google desktop token refreshes", async () => {
+    const oauthCalls: Array<{ url: string; body: string; contentType: string }> = [];
+    invokeMock.mockImplementation(async (cmd: string, args?: Record<string, unknown>) => {
+      if (cmd === "google_oauth_proxy_request") {
+        oauthCalls.push({
+          url: String(args?.url ?? ""),
+          body: String(args?.body ?? ""),
+          contentType: String(args?.contentType ?? ""),
+        });
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        return {
+          status: 200,
+          headers: [["content-type", "application/json"]],
+          body: Array.from(new TextEncoder().encode(JSON.stringify({
+            access_token: "shared-refreshed-access-token",
+            expires_in: 3600,
+          }))),
+        };
+      }
+      return null;
+    });
+    localStorage.setItem("freed_cloud_token_meta_gdrive", JSON.stringify({
+      accessToken: "expired-access-token",
+      refreshToken: "refresh-token",
+      expiresAt: Date.now() - 1,
+    }));
+
+    const { getValidCloudToken } = await import("./sync");
+
+    await expect(Promise.all([
+      getValidCloudToken("gdrive"),
+      getValidCloudToken("gdrive"),
+      getValidCloudToken("gdrive"),
+    ])).resolves.toEqual([
+      "shared-refreshed-access-token",
+      "shared-refreshed-access-token",
+      "shared-refreshed-access-token",
+    ]);
+    expect(oauthCalls).toHaveLength(1);
+  });
+
+  it("does not immediately refresh again when the token proxy omits expires_in", async () => {
+    const oauthCalls: Array<{ url: string; body: string; contentType: string }> = [];
+    invokeMock.mockImplementation(async (cmd: string, args?: Record<string, unknown>) => {
+      if (cmd === "google_oauth_proxy_request") {
+        oauthCalls.push({
+          url: String(args?.url ?? ""),
+          body: String(args?.body ?? ""),
+          contentType: String(args?.contentType ?? ""),
+        });
+        return {
+          status: 200,
+          headers: [["content-type", "application/json"]],
+          body: Array.from(new TextEncoder().encode(JSON.stringify({
+            access_token: "fallback-expiring-access-token",
+          }))),
+        };
+      }
+      return null;
+    });
+    localStorage.setItem("freed_cloud_token_meta_gdrive", JSON.stringify({
+      accessToken: "expired-access-token",
+      refreshToken: "refresh-token",
+      expiresAt: Date.now() - 1,
+    }));
+
+    const { getValidCloudToken } = await import("./sync");
+
+    await expect(getValidCloudToken("gdrive")).resolves.toBe("fallback-expiring-access-token");
+    await expect(getValidCloudToken("gdrive")).resolves.toBe("fallback-expiring-access-token");
+    expect(oauthCalls).toHaveLength(1);
+
+    const stored = JSON.parse(localStorage.getItem("freed_cloud_token_meta_gdrive") ?? "{}") as {
+      expiresAt?: number;
+      refreshToken?: string;
+    };
+    expect(stored.refreshToken).toBe("refresh-token");
+    expect(typeof stored.expiresAt).toBe("number");
+    expect(stored.expiresAt).toBeGreaterThan(Date.now() + 50 * 60 * 1000);
+  });
+
   it("cancels a pending Google desktop callback wait", async () => {
     shellOpenMock.mockResolvedValue(undefined);
 

--- a/packages/desktop/src/lib/sync.ts
+++ b/packages/desktop/src/lib/sync.ts
@@ -295,11 +295,13 @@ const CLOUD_TOKEN_KEY = (p: CloudProvider) => `freed_cloud_token_${p}`;
 const CLOUD_TOKEN_META_KEY = (p: CloudProvider) => `freed_cloud_token_meta_${p}`;
 const UPLOAD_DEBOUNCE_MS = 2_000;
 const TOKEN_REFRESH_SKEW_MS = 60_000;
+const GOOGLE_TOKEN_REFRESH_FALLBACK_TTL_MS = 55 * 60 * 1000;
 
 /** Per-provider abort controllers, upload timers, and doc-change unsubscribers. */
 const cloudAborts = new Map<CloudProvider, AbortController>();
 const uploadTimers = new Map<CloudProvider, ReturnType<typeof setTimeout>>();
 const cloudChangeUnsubscribes = new Map<CloudProvider, () => void>();
+const cloudTokenRefreshes = new Map<CloudProvider, Promise<string | null>>();
 
 // Desktop OAuth client IDs. These are public and embedded in the app bundle.
 const DEFAULT_GDRIVE_DESKTOP_CLIENT_ID =
@@ -354,12 +356,20 @@ function throwIfOAuthCanceled(signal?: AbortSignal): void {
   }
 }
 
-function tokenBundleFromResponse(data: TokenExchangeResponse): CloudTokenBundle {
+function tokenBundleFromResponse(
+  data: TokenExchangeResponse,
+  options: { fallbackTtlMs?: number } = {},
+): CloudTokenBundle {
   if (!data.access_token) throw new Error("Token exchange returned no access_token");
+  const expiresAt = typeof data.expires_in === "number" && Number.isFinite(data.expires_in) && data.expires_in > 0
+    ? Date.now() + data.expires_in * 1000
+    : options.fallbackTtlMs
+      ? Date.now() + options.fallbackTtlMs
+      : undefined;
   return {
     accessToken: data.access_token,
     refreshToken: data.refresh_token,
-    expiresAt: data.expires_in ? Date.now() + data.expires_in * 1000 : undefined,
+    expiresAt,
   };
 }
 
@@ -372,7 +382,9 @@ function readCloudTokenBundle(provider: CloudProvider): CloudTokenBundle | null 
         return {
           accessToken: parsed.accessToken,
           refreshToken: typeof parsed.refreshToken === "string" ? parsed.refreshToken : undefined,
-          expiresAt: typeof parsed.expiresAt === "number" ? parsed.expiresAt : undefined,
+          expiresAt: typeof parsed.expiresAt === "number" && Number.isFinite(parsed.expiresAt)
+            ? parsed.expiresAt
+            : undefined,
         };
       }
     } catch {
@@ -396,16 +408,38 @@ export function getCloudToken(provider: CloudProvider): string | null {
   return readCloudTokenBundle(provider)?.accessToken ?? null;
 }
 
+function shouldRefreshCloudToken(bundle: CloudTokenBundle, now = Date.now()): boolean {
+  return typeof bundle.expiresAt === "number"
+    && Number.isFinite(bundle.expiresAt)
+    && bundle.expiresAt - now <= TOKEN_REFRESH_SKEW_MS;
+}
+
 async function refreshCloudToken(provider: CloudProvider, bundle: CloudTokenBundle): Promise<string | null> {
   if (!bundle.refreshToken) return bundle.accessToken;
+  const existingRefresh = cloudTokenRefreshes.get(provider);
+  if (existingRefresh) return existingRefresh;
+
+  let refreshPromise!: Promise<string | null>;
+  refreshPromise = refreshCloudTokenInner(provider, bundle).finally(() => {
+    if (cloudTokenRefreshes.get(provider) === refreshPromise) {
+      cloudTokenRefreshes.delete(provider);
+    }
+  });
+  cloudTokenRefreshes.set(provider, refreshPromise);
+  return refreshPromise;
+}
+
+async function refreshCloudTokenInner(provider: CloudProvider, bundle: CloudTokenBundle): Promise<string | null> {
+  const refreshToken = bundle.refreshToken;
+  if (!refreshToken) return bundle.accessToken;
 
   if (provider === "gdrive" && shouldUseGoogleTokenProxy()) {
-    return refreshGoogleTokenViaProxy(bundle.refreshToken);
+    return refreshGoogleTokenViaProxy(refreshToken);
   }
 
   const params = new URLSearchParams({
     grant_type: "refresh_token",
-    refresh_token: bundle.refreshToken,
+    refresh_token: refreshToken,
   });
 
   let tokenUrl: string;
@@ -414,7 +448,10 @@ async function refreshCloudToken(provider: CloudProvider, bundle: CloudTokenBund
     if (GDRIVE_CLIENT_SECRET) {
       params.set("client_secret", GDRIVE_CLIENT_SECRET);
     }
-    const refreshed = tokenBundleFromResponse(await postGoogleToken(params, "Google token refresh failed"));
+    const refreshed = tokenBundleFromResponse(
+      await postGoogleToken(params, "Google token refresh failed"),
+      { fallbackTtlMs: GOOGLE_TOKEN_REFRESH_FALLBACK_TTL_MS },
+    );
     const nextBundle = {
       ...refreshed,
       refreshToken: refreshed.refreshToken ?? bundle.refreshToken,
@@ -451,7 +488,7 @@ function shouldUseGoogleTokenProxy(): boolean {
 }
 
 function tokenBundleFromProxyResponse(data: TokenExchangeResponse): CloudTokenBundle {
-  return tokenBundleFromResponse(data);
+  return tokenBundleFromResponse(data, { fallbackTtlMs: GOOGLE_TOKEN_REFRESH_FALLBACK_TTL_MS });
 }
 
 function decodeNativeBody(body: number[]): string {
@@ -557,7 +594,7 @@ async function refreshGoogleTokenViaProxy(refreshToken: string): Promise<string 
 export async function getValidCloudToken(provider: CloudProvider): Promise<string | null> {
   const bundle = readCloudTokenBundle(provider);
   if (!bundle) return null;
-  if (bundle.expiresAt && bundle.expiresAt - Date.now() <= TOKEN_REFRESH_SKEW_MS) {
+  if (shouldRefreshCloudToken(bundle)) {
     return refreshCloudToken(provider, bundle);
   }
   return bundle.accessToken;

--- a/packages/pwa/src/lib/sync.ts
+++ b/packages/pwa/src/lib/sync.ts
@@ -210,9 +210,11 @@ const CLOUD_TOKEN_META_KEY = (provider: CloudProvider) => `freed_cloud_token_met
 const CLOUD_PROVIDER_KEY = "freed_cloud_provider";
 const UPLOAD_DEBOUNCE_MS = 2_000;
 const TOKEN_REFRESH_SKEW_MS = 60_000;
+const GOOGLE_TOKEN_REFRESH_FALLBACK_TTL_MS = 55 * 60 * 1000;
 
 let cloudAbort: AbortController | null = null;
 let uploadTimer: ReturnType<typeof setTimeout> | null = null;
+const cloudTokenRefreshes = new Map<CloudProvider, Promise<string | null>>();
 
 export interface CloudTokenBundle {
   accessToken: string;
@@ -229,7 +231,9 @@ function readCloudTokenBundle(provider: CloudProvider): CloudTokenBundle | null 
         return {
           accessToken: parsed.accessToken,
           refreshToken: typeof parsed.refreshToken === "string" ? parsed.refreshToken : undefined,
-          expiresAt: typeof parsed.expiresAt === "number" ? parsed.expiresAt : undefined,
+          expiresAt: typeof parsed.expiresAt === "number" && Number.isFinite(parsed.expiresAt)
+            ? parsed.expiresAt
+            : undefined,
         };
       }
     } catch {
@@ -254,21 +258,45 @@ export function getCloudToken(provider: CloudProvider): string | null {
   return readCloudTokenBundle(provider)?.accessToken ?? null;
 }
 
+function shouldRefreshCloudToken(bundle: CloudTokenBundle, now = Date.now()): boolean {
+  return typeof bundle.expiresAt === "number"
+    && Number.isFinite(bundle.expiresAt)
+    && bundle.expiresAt - now <= TOKEN_REFRESH_SKEW_MS;
+}
+
 async function refreshCloudToken(provider: CloudProvider, bundle: CloudTokenBundle): Promise<string | null> {
   if (!bundle.refreshToken) return bundle.accessToken;
+  const existingRefresh = cloudTokenRefreshes.get(provider);
+  if (existingRefresh) return existingRefresh;
+
+  let refreshPromise!: Promise<string | null>;
+  refreshPromise = refreshCloudTokenInner(provider, bundle).finally(() => {
+    if (cloudTokenRefreshes.get(provider) === refreshPromise) {
+      cloudTokenRefreshes.delete(provider);
+    }
+  });
+  cloudTokenRefreshes.set(provider, refreshPromise);
+  return refreshPromise;
+}
+
+async function refreshCloudTokenInner(provider: CloudProvider, bundle: CloudTokenBundle): Promise<string | null> {
+  const refreshToken = bundle.refreshToken;
+  if (!refreshToken) return bundle.accessToken;
 
   if (provider === "gdrive") {
     const res = await fetch("/api/oauth/google", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ grantType: "refresh_token", refreshToken: bundle.refreshToken }),
+      body: JSON.stringify({ grantType: "refresh_token", refreshToken }),
     });
     const data = await res.json().catch(() => ({ error: "invalid JSON from proxy" }));
     if (!res.ok) throw new Error(`GDrive token refresh failed: ${data.error ?? res.status}`);
     const nextBundle = {
       accessToken: data.access_token as string,
-      refreshToken: (data.refresh_token as string | undefined) ?? bundle.refreshToken,
-      expiresAt: typeof data.expires_in === "number" ? Date.now() + data.expires_in * 1000 : undefined,
+      refreshToken: (data.refresh_token as string | undefined) ?? refreshToken,
+      expiresAt: typeof data.expires_in === "number" && Number.isFinite(data.expires_in) && data.expires_in > 0
+        ? Date.now() + data.expires_in * 1000
+        : Date.now() + GOOGLE_TOKEN_REFRESH_FALLBACK_TTL_MS,
     };
     if (!nextBundle.accessToken) throw new Error("GDrive proxy returned no access_token");
     storeCloudToken(provider, nextBundle);
@@ -282,7 +310,7 @@ async function refreshCloudToken(provider: CloudProvider, bundle: CloudTokenBund
 export async function getValidCloudToken(provider: CloudProvider): Promise<string | null> {
   const bundle = readCloudTokenBundle(provider);
   if (!bundle) return null;
-  if (bundle.expiresAt && bundle.expiresAt - Date.now() <= TOKEN_REFRESH_SKEW_MS) {
+  if (shouldRefreshCloudToken(bundle)) {
     return refreshCloudToken(provider, bundle);
   }
   return bundle.accessToken;

--- a/packages/ui/src/hooks/useContactSync.test.tsx
+++ b/packages/ui/src/hooks/useContactSync.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act, useEffect } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { CONTACT_SYNC_STORAGE_KEY, type ContactSyncState } from "@freed/shared";
+import { PlatformProvider, type PlatformConfig } from "../context/PlatformContext";
+import { useContactSync } from "./useContactSync";
+
+type ContactSyncActions = ReturnType<typeof useContactSync>;
+
+function ContactSyncHarness({ onReady }: { onReady: (actions: ContactSyncActions) => void }) {
+  const actions = useContactSync();
+
+  useEffect(() => {
+    onReady(actions);
+  }, [actions, onReady]);
+
+  return null;
+}
+
+describe("useContactSync", () => {
+  let container: HTMLDivElement | null = null;
+  let root: Root | null = null;
+
+  beforeAll(() => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  afterAll(() => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = false;
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root?.unmount();
+    });
+    container?.remove();
+    root = null;
+    container = null;
+    localStorage.removeItem(CONTACT_SYNC_STORAGE_KEY);
+    vi.restoreAllMocks();
+  });
+
+  it("coalesces overlapping Google Contacts sync requests", async () => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    let resolveFetch: ((value: { contacts: []; nextSyncToken: string; deleted: [] }) => void) | null = null;
+    const getToken = vi.fn(async () => "google-access-token");
+    const fetchContacts = vi.fn(() => new Promise<{ contacts: []; nextSyncToken: string; deleted: [] }>((resolve) => {
+      resolveFetch = resolve;
+    }));
+    const setPendingMatchCount = vi.fn();
+    const store = <T,>(selector: (state: unknown) => T): T => selector({
+      persons: {},
+      accounts: {},
+      items: [],
+      setPendingMatchCount,
+    });
+    const platformValue = {
+      store,
+      googleContacts: {
+        getToken,
+        connect: vi.fn(async () => {}),
+        fetchContacts,
+      },
+    } as unknown as PlatformConfig;
+    let actions: ContactSyncActions | null = null;
+
+    await act(async () => {
+      root.render(
+        <PlatformProvider value={platformValue}>
+          <ContactSyncHarness onReady={(nextActions) => {
+            actions = nextActions;
+          }} />
+        </PlatformProvider>,
+      );
+    });
+
+    let firstSync: Promise<ContactSyncState> | null = null;
+    let secondSync: Promise<ContactSyncState> | null = null;
+    await act(async () => {
+      firstSync = actions!.syncNow();
+      secondSync = actions!.syncNow();
+      await Promise.resolve();
+    });
+
+    expect(firstSync).toBe(secondSync);
+    expect(getToken).toHaveBeenCalledTimes(1);
+    expect(fetchContacts).toHaveBeenCalledTimes(1);
+    expect(fetchContacts).toHaveBeenCalledWith("google-access-token", null);
+
+    await act(async () => {
+      resolveFetch?.({ contacts: [], nextSyncToken: "next-token", deleted: [] });
+      await firstSync;
+    });
+
+    expect(actions?.getSyncState()).toMatchObject({
+      authStatus: "connected",
+      syncStatus: "idle",
+      syncToken: "next-token",
+    });
+  });
+});

--- a/packages/ui/src/hooks/useContactSync.ts
+++ b/packages/ui/src/hooks/useContactSync.ts
@@ -95,6 +95,7 @@ export function useContactSync() {
   const syncStateRef = useRef(syncState);
   syncStateRef.current = syncState;
   const matchesRef = useRef<Map<string, ContactMatch>>(new Map());
+  const syncPromiseRef = useRef<Promise<ContactSyncState> | null>(null);
 
   useEffect(() => {
     setPendingMatchCount(syncState.pendingSuggestions.length);
@@ -106,76 +107,86 @@ export function useContactSync() {
     saveSyncState(nextState);
   }, []);
 
-  const runSync = useCallback(async () => {
-    const current = syncStateRef.current;
-    const contactsApi = googleContacts;
-    const token = contactsApi ? await contactsApi.getToken() : null;
+  const runSync = useCallback(() => {
+    if (syncPromiseRef.current) return syncPromiseRef.current;
 
-    if (!token) {
-      const nextState = withError(current, "missing_token", "Reconnect Google to sync contacts.");
-      commitSyncState(nextState);
-      return nextState;
-    }
+    let syncPromise!: Promise<ContactSyncState>;
+    syncPromise = (async () => {
+      const current = syncStateRef.current;
+      const contactsApi = googleContacts;
+      const token = contactsApi ? await contactsApi.getToken() : null;
 
-    commitSyncState({
-      ...current,
-      authStatus: "connected",
-      syncStatus: "syncing",
-      lastErrorCode: undefined,
-      lastErrorMessage: undefined,
+      if (!token) {
+        const nextState = withError(current, "missing_token", "Reconnect Google to sync contacts.");
+        commitSyncState(nextState);
+        return nextState;
+      }
+
+      commitSyncState({
+        ...current,
+        authStatus: "connected",
+        syncStatus: "syncing",
+        lastErrorCode: undefined,
+        lastErrorMessage: undefined,
+      });
+
+      try {
+        const result: GoogleContactsResult = contactsApi?.fetchContacts
+          ? await contactsApi.fetchContacts(token, current.syncToken)
+          : await fetchGoogleContacts(token, current.syncToken);
+        const merged = mergeContactChanges(current.cachedContacts, result.contacts, result.deleted);
+        const allMatches = matchContacts(
+          merged,
+          personsRef.current,
+          accountsRef.current,
+          itemsRef.current,
+        );
+        matchesRef.current = new Map(
+          allMatches.map((match) => [suggestionIdForMatch(match), match])
+        );
+
+        const pendingSuggestions = allMatches
+          .map((match) => buildSuggestion(match, itemsRef.current))
+          .filter((suggestion): suggestion is IdentitySuggestion => suggestion !== null)
+          .filter((suggestion) => !current.dismissedSuggestionIds.includes(suggestion.id));
+
+        const nextState: ContactSyncState = {
+          authStatus: "connected",
+          syncStatus: "idle",
+          syncToken: result.nextSyncToken,
+          lastSyncedAt: Date.now(),
+          cachedContacts: merged,
+          pendingSuggestions,
+          dismissedSuggestionIds: current.dismissedSuggestionIds,
+          createdFriendCount: current.createdFriendCount,
+        };
+
+        commitSyncState(nextState);
+        return nextState;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Google Contacts sync failed.";
+        const status = typeof error === "object" && error !== null && "status" in error
+          ? (error as { status?: number }).status
+          : undefined;
+        const code = status === 401 || status === 403 ? "auth" : "network";
+        const nextState = withError(current, code, message);
+        commitSyncState(nextState);
+        return nextState;
+      }
+    })().finally(() => {
+      if (syncPromiseRef.current === syncPromise) {
+        syncPromiseRef.current = null;
+      }
     });
 
-    try {
-      const result: GoogleContactsResult = contactsApi?.fetchContacts
-        ? await contactsApi.fetchContacts(token, current.syncToken)
-        : await fetchGoogleContacts(token, current.syncToken);
-      const merged = mergeContactChanges(current.cachedContacts, result.contacts, result.deleted);
-      const allMatches = matchContacts(
-        merged,
-        personsRef.current,
-        accountsRef.current,
-        itemsRef.current,
-      );
-      matchesRef.current = new Map(
-        allMatches.map((match) => [suggestionIdForMatch(match), match])
-      );
-
-      const pendingSuggestions = allMatches
-        .map((match) => buildSuggestion(match, itemsRef.current))
-        .filter((suggestion): suggestion is IdentitySuggestion => suggestion !== null)
-        .filter((suggestion) => !current.dismissedSuggestionIds.includes(suggestion.id));
-
-      const nextState: ContactSyncState = {
-        authStatus: "connected",
-        syncStatus: "idle",
-        syncToken: result.nextSyncToken,
-        lastSyncedAt: Date.now(),
-        cachedContacts: merged,
-        pendingSuggestions,
-        dismissedSuggestionIds: current.dismissedSuggestionIds,
-        createdFriendCount: current.createdFriendCount,
-      };
-
-      commitSyncState(nextState);
-      return nextState;
-    } catch (error) {
-      const message = error instanceof Error ? error.message : "Google Contacts sync failed.";
-      const status = typeof error === "object" && error !== null && "status" in error
-        ? (error as { status?: number }).status
-        : undefined;
-      const code = status === 401 || status === 403 ? "auth" : "network";
-      const nextState = withError(current, code, message);
-      commitSyncState(nextState);
-      return nextState;
-    }
+    syncPromiseRef.current = syncPromise;
+    return syncPromise;
   }, [commitSyncState, googleContacts]);
 
   useEffect(() => {
     if (!googleContacts) return undefined;
     const id = setInterval(() => {
-      void Promise.resolve(googleContacts.getToken()).then((token) => {
-        if (token) void runSync();
-      });
+      void runSync();
     }, SYNC_INTERVAL_MS);
     return () => clearInterval(id);
   }, [googleContacts, runSync]);
@@ -183,16 +194,7 @@ export function useContactSync() {
   useEffect(() => {
     if (!googleContacts) return undefined;
     const onFocus = () => {
-      void Promise.resolve(googleContacts.getToken()).then((token) => {
-        if (token) {
-          void runSync();
-          return;
-        }
-        const current = syncStateRef.current;
-        if (current.authStatus !== "reconnect_required" || current.syncStatus !== "error") {
-          commitSyncState(withError(current, "missing_token", "Reconnect Google to sync contacts."));
-        }
-      });
+      void runSync();
     };
     window.addEventListener("focus", onFocus);
     return () => window.removeEventListener("focus", onFocus);


### PR DESCRIPTION
(AI Generated).

## Summary
- Coalesce Google Drive token refreshes so simultaneous Drive and Contacts callers share one refresh request.
- Add a fallback token expiry when Google proxy responses omit `expires_in`, which prevents an immediate refresh loop.
- Coalesce overlapping Google Contacts sync requests so focus, interval, and manual sync cannot stack People API work.
- Apply the same refresh coalescing guard to the PWA Google Drive token path.

## Testing
- `PATH=../../node_modules/.bin:$PATH npm run test:unit -- src/lib/cloud-oauth.test.ts`
- `node node_modules/vitest/vitest.mjs run packages/ui/src/hooks/useContactSync.test.tsx`
- `PATH=../../node_modules/.bin:$PATH npm run typecheck` from `packages/pwa`
- `PATH=../../node_modules/.bin:$PATH npm run build` from `packages/desktop`
- `PATH=../../node_modules/.bin:$PATH npm run test:e2e:smoke` from `packages/desktop`
- `PATH=../../node_modules/.bin:$PATH npm run test:e2e:regression -- google-contacts.spec.ts` from `packages/desktop` ran the full regression suite by script expansion: 130 passed
- GitHub Validation run 26691840822 passed
