### PR TITLE
fix: resolve shared validity helper imports

### DIFF
--- a/website/next.config.ts
+++ b/website/next.config.ts
@@ -4,6 +4,14 @@ const nextConfig: NextConfig = {
   // Disable x-powered-by header
   poweredByHeader: false,
   transpilePackages: ["@freed/shared", "@freed/ui"],
+  webpack(config) {
+    config.resolve.extensionAlias = {
+      ...config.resolve.extensionAlias,
+      ".js": [".ts", ".tsx", ".js"],
+      ".mjs": [".mts", ".mjs"],
+    };
+    return config;
+  },
 
   // Configure redirects if needed
   async redirects() {


### PR DESCRIPTION
(AI Generated).

## Summary
- Teach the website build to resolve shared-package `.js` source specifiers to TypeScript files so the new shared social-account validity helper builds in Next.js without weakening Node-style package typecheck.

## Testing
- `npm run typecheck`
- `PATH=../node_modules/.bin:$PATH npm run build` from `website`
