### PR TITLE
fix: satisfy PWA refresh lint

### DIFF
--- a/packages/pwa/src/lib/sync.ts
+++ b/packages/pwa/src/lib/sync.ts
@@ -269,8 +269,7 @@ async function refreshCloudToken(provider: CloudProvider, bundle: CloudTokenBund
   const existingRefresh = cloudTokenRefreshes.get(provider);
   if (existingRefresh) return existingRefresh;
 
-  let refreshPromise!: Promise<string | null>;
-  refreshPromise = refreshCloudTokenInner(provider, bundle).finally(() => {
+  const refreshPromise = refreshCloudTokenInner(provider, bundle).finally(() => {
     if (cloudTokenRefreshes.get(provider) === refreshPromise) {
       cloudTokenRefreshes.delete(provider);
     }


### PR DESCRIPTION
(AI Generated).

## Summary
- Make the PWA Google token refresh promise declaration satisfy lint after the refresh coalescing fix.

## Validation
- corepack npm run lint, from packages/pwa
- corepack npm run typecheck, from packages/pwa