### PR TITLE
fix: stop Google token refresh loops

### DIFF
--- a/packages/desktop/src/lib/cloud-sync-auth-refresh.test.ts
+++ b/packages/desktop/src/lib/cloud-sync-auth-refresh.test.ts
@@ -1,0 +1,193 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const invokeMock = vi.fn();
+const gdriveDownloadLatestMock = vi.fn();
+const gdriveStartPollLoopMock = vi.fn();
+const subscribeMock = vi.fn(() => vi.fn());
+const recordProviderHealthEventMock = vi.fn();
+const logInfoMock = vi.fn();
+const logWarnMock = vi.fn();
+const logErrorMock = vi.fn();
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: invokeMock,
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/plugin-shell", () => ({
+  open: vi.fn(),
+}));
+
+vi.mock("@freed/sync/cloud", () => ({
+  gdriveDownloadLatest: gdriveDownloadLatestMock,
+  gdriveStartPollLoop: gdriveStartPollLoopMock,
+  gdriveUploadSafe: vi.fn(),
+  gdriveDeleteFile: vi.fn(),
+  dropboxDownloadLatest: vi.fn(),
+  dropboxStartLongpollLoop: vi.fn(),
+  dropboxUploadSafe: vi.fn(),
+  dropboxDeleteFile: vi.fn(),
+}));
+
+vi.mock("./automerge", () => ({
+  getDocBinary: vi.fn(async () => new Uint8Array()),
+  mergeDoc: vi.fn(),
+  setRelayClientCount: vi.fn(),
+  subscribe: subscribeMock,
+}));
+
+vi.mock("@freed/ui/lib/debug-store", () => ({
+  addDebugEvent: vi.fn(),
+}));
+
+vi.mock("./logger.js", () => ({
+  log: {
+    info: logInfoMock,
+    warn: logWarnMock,
+    error: logErrorMock,
+  },
+}));
+
+vi.mock("./provider-health", () => ({
+  recordProviderHealthEvent: recordProviderHealthEventMock,
+}));
+
+describe("desktop cloud sync auth refresh", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.useRealTimers();
+    vi.stubEnv("VITE_GDRIVE_TOKEN_PROXY_URL", "https://app.freed.wtf/api/oauth/google");
+    vi.stubEnv(
+      "VITE_GDRIVE_DESKTOP_CLIENT_ID",
+      "304530272769-fkbpan1l071vdvum1j6kufvo8rbq6sm1.apps.googleusercontent.com",
+    );
+    invokeMock.mockReset();
+    gdriveDownloadLatestMock.mockReset();
+    gdriveStartPollLoopMock.mockReset();
+    subscribeMock.mockClear();
+    recordProviderHealthEventMock.mockReset();
+    logInfoMock.mockReset();
+    logWarnMock.mockReset();
+    logErrorMock.mockReset();
+    localStorage.clear();
+  });
+
+  afterEach(async () => {
+    const sync = await import("./sync");
+    sync.stopAllCloudSyncs();
+    vi.unstubAllEnvs();
+    localStorage.clear();
+  });
+
+  it("preserves the existing Google refresh token when reconnect only returns an access token", async () => {
+    const { storeCloudToken } = await import("./sync");
+
+    storeCloudToken("gdrive", {
+      accessToken: "old-access-token",
+      refreshToken: "existing-refresh-token",
+      expiresAt: Date.now() + 3_600_000,
+    });
+    storeCloudToken("gdrive", {
+      accessToken: "new-access-token",
+      expiresAt: Date.now() + 3_600_000,
+    });
+
+    const stored = JSON.parse(localStorage.getItem("freed_cloud_token_meta_gdrive") ?? "{}") as {
+      accessToken?: string;
+      refreshToken?: string;
+    };
+    expect(stored.accessToken).toBe("new-access-token");
+    expect(stored.refreshToken).toBe("existing-refresh-token");
+  });
+
+  it("does not refresh a valid Google token after a non-refreshable Drive 403", async () => {
+    const oauthCalls: string[] = [];
+    invokeMock.mockImplementation(async (cmd: string) => {
+      if (cmd === "google_oauth_proxy_request") {
+        oauthCalls.push(cmd);
+        return {
+          status: 200,
+          headers: [["content-type", "application/json"]],
+          body: Array.from(new TextEncoder().encode(JSON.stringify({
+            access_token: "unexpected-refresh",
+            expires_in: 3600,
+          }))),
+        };
+      }
+      return null;
+    });
+    gdriveDownloadLatestMock.mockResolvedValue(null);
+    gdriveStartPollLoopMock.mockRejectedValue(
+      Object.assign(new Error("GDrive changes failed: 403 Forbidden - insufficientPermissions"), {
+        status: 403,
+      }),
+    );
+    localStorage.setItem("freed_cloud_token_meta_gdrive", JSON.stringify({
+      accessToken: "valid-access-token",
+      refreshToken: "refresh-token",
+      expiresAt: Date.now() + 3_600_000,
+    }));
+
+    const { startCloudSync } = await import("./sync");
+    await startCloudSync("gdrive", "valid-access-token");
+
+    await vi.waitFor(() => {
+      expect(recordProviderHealthEventMock).toHaveBeenCalledWith(expect.objectContaining({
+        provider: "gdrive",
+        outcome: "error",
+        stage: "poll",
+      }));
+    });
+
+    expect(oauthCalls).toHaveLength(0);
+    expect(gdriveStartPollLoopMock).toHaveBeenCalledTimes(1);
+    expect(logWarnMock).toHaveBeenCalledWith(expect.stringContaining("auth failure is not refreshable status=403"));
+  });
+
+  it("refreshes only once when Drive keeps rejecting a token with 401", async () => {
+    const oauthCalls: string[] = [];
+    invokeMock.mockImplementation(async (cmd: string, args?: Record<string, unknown>) => {
+      if (cmd === "google_oauth_proxy_request") {
+        oauthCalls.push(String(args?.body ?? ""));
+        return {
+          status: 200,
+          headers: [["content-type", "application/json"]],
+          body: Array.from(new TextEncoder().encode(JSON.stringify({
+            access_token: "refreshed-access-token",
+            expires_in: 3600,
+          }))),
+        };
+      }
+      return null;
+    });
+    gdriveDownloadLatestMock.mockResolvedValue(null);
+    gdriveStartPollLoopMock.mockRejectedValue(
+      Object.assign(new Error("GDrive changes failed: 401 Unauthorized"), {
+        status: 401,
+      }),
+    );
+    localStorage.setItem("freed_cloud_token_meta_gdrive", JSON.stringify({
+      accessToken: "expired-access-token",
+      refreshToken: "refresh-token",
+      expiresAt: Date.now() + 3_600_000,
+    }));
+
+    const { startCloudSync } = await import("./sync");
+    await startCloudSync("gdrive", "expired-access-token");
+
+    await vi.waitFor(() => {
+      expect(recordProviderHealthEventMock).toHaveBeenCalledWith(expect.objectContaining({
+        provider: "gdrive",
+        outcome: "error",
+        stage: "poll",
+      }));
+    });
+
+    expect(oauthCalls).toHaveLength(1);
+    expect(gdriveStartPollLoopMock).toHaveBeenCalledTimes(2);
+    expect(logWarnMock).toHaveBeenCalledWith(expect.stringContaining("auth failure refresh suppressed"));
+  });
+});

--- a/packages/desktop/src/lib/sync.ts
+++ b/packages/desktop/src/lib/sync.ts
@@ -296,12 +296,14 @@ const CLOUD_TOKEN_META_KEY = (p: CloudProvider) => `freed_cloud_token_meta_${p}`
 const UPLOAD_DEBOUNCE_MS = 2_000;
 const TOKEN_REFRESH_SKEW_MS = 60_000;
 const GOOGLE_TOKEN_REFRESH_FALLBACK_TTL_MS = 55 * 60 * 1000;
+const AUTH_FAILURE_REFRESH_COOLDOWN_MS = 5 * 60 * 1000;
 
 /** Per-provider abort controllers, upload timers, and doc-change unsubscribers. */
 const cloudAborts = new Map<CloudProvider, AbortController>();
 const uploadTimers = new Map<CloudProvider, ReturnType<typeof setTimeout>>();
 const cloudChangeUnsubscribes = new Map<CloudProvider, () => void>();
 const cloudTokenRefreshes = new Map<CloudProvider, Promise<string | null>>();
+const cloudAuthFailureRefreshes = new Map<CloudProvider, number>();
 
 // Desktop OAuth client IDs. These are public and embedded in the app bundle.
 const DEFAULT_GDRIVE_DESKTOP_CLIENT_ID =
@@ -398,9 +400,14 @@ function readCloudTokenBundle(provider: CloudProvider): CloudTokenBundle | null 
 
 /** Persist OAuth credentials for a cloud provider. */
 export function storeCloudToken(provider: CloudProvider, token: string | CloudTokenBundle): void {
+  const previous = readCloudTokenBundle(provider);
   const bundle = typeof token === "string" ? { accessToken: token } : token;
-  localStorage.setItem(CLOUD_TOKEN_KEY(provider), bundle.accessToken);
-  localStorage.setItem(CLOUD_TOKEN_META_KEY(provider), JSON.stringify(bundle));
+  const storedBundle: CloudTokenBundle = {
+    ...bundle,
+    refreshToken: bundle.refreshToken ?? previous?.refreshToken,
+  };
+  localStorage.setItem(CLOUD_TOKEN_KEY(provider), storedBundle.accessToken);
+  localStorage.setItem(CLOUD_TOKEN_META_KEY(provider), JSON.stringify(storedBundle));
 }
 
 /** Retrieve the stored OAuth access token for a cloud provider. */
@@ -412,6 +419,51 @@ function shouldRefreshCloudToken(bundle: CloudTokenBundle, now = Date.now()): bo
   return typeof bundle.expiresAt === "number"
     && Number.isFinite(bundle.expiresAt)
     && bundle.expiresAt - now <= TOKEN_REFRESH_SKEW_MS;
+}
+
+function cloudTokenExpiresInMs(bundle: CloudTokenBundle, now = Date.now()): number | null {
+  return typeof bundle.expiresAt === "number" && Number.isFinite(bundle.expiresAt)
+    ? bundle.expiresAt - now
+    : null;
+}
+
+function authFailureStatus(error: unknown): number | undefined {
+  return typeof error === "object" && error !== null && "status" in error
+    ? (error as { status?: number }).status
+    : undefined;
+}
+
+async function refreshCloudTokenAfterAuthFailure(
+  provider: CloudProvider,
+  bundle: CloudTokenBundle,
+  error: unknown,
+): Promise<string | null> {
+  const status = authFailureStatus(error);
+  if (status !== 401) {
+    const message = error instanceof Error ? error.message : String(error);
+    log.warn(`[cloud/${provider}] auth failure is not refreshable status=${status ?? "unknown"} reason=${message}`);
+    throw error;
+  }
+
+  if (!bundle.refreshToken) {
+    log.warn(`[cloud/${provider}] auth failure cannot refresh because no refresh token is stored`);
+    throw error;
+  }
+
+  const now = Date.now();
+  const lastRefreshAt = cloudAuthFailureRefreshes.get(provider);
+  if (typeof lastRefreshAt === "number" && now - lastRefreshAt < AUTH_FAILURE_REFRESH_COOLDOWN_MS) {
+    const ageMs = now - lastRefreshAt;
+    log.warn(`[cloud/${provider}] auth failure refresh suppressed age_ms=${ageMs.toLocaleString()}`);
+    throw error;
+  }
+
+  cloudAuthFailureRefreshes.set(provider, now);
+  const expiresInMs = cloudTokenExpiresInMs(bundle, now);
+  log.info(
+    `[cloud/${provider}] refreshing token after auth failure status=${status} expires_in_ms=${expiresInMs?.toLocaleString() ?? "unknown"}`,
+  );
+  return refreshCloudToken(provider, bundle);
 }
 
 async function refreshCloudToken(provider: CloudProvider, bundle: CloudTokenBundle): Promise<string | null> {
@@ -610,6 +662,7 @@ export function getActiveProviders(): CloudProvider[] {
 export function clearCloudProvider(provider: CloudProvider): void {
   localStorage.removeItem(CLOUD_TOKEN_KEY(provider));
   localStorage.removeItem(CLOUD_TOKEN_META_KEY(provider));
+  cloudAuthFailureRefreshes.delete(provider);
   stopCloudSync(provider);
 }
 
@@ -898,11 +951,13 @@ export async function startCloudSync(provider: CloudProvider, token: string): Pr
           return;
         } catch (error) {
           if (signal.aborted) return;
-          const status = typeof error === "object" && error !== null && "status" in error
-            ? (error as { status?: number }).status
-            : undefined;
+          const status = authFailureStatus(error);
           if (status !== 401 && status !== 403) throw error;
-          await refreshCloudToken("gdrive", readCloudTokenBundle("gdrive") ?? { accessToken: pollToken });
+          await refreshCloudTokenAfterAuthFailure(
+            "gdrive",
+            readCloudTokenBundle("gdrive") ?? { accessToken: pollToken },
+            error,
+          );
         }
       }
     };

--- a/packages/pwa/src/lib/sync.ts
+++ b/packages/pwa/src/lib/sync.ts
@@ -211,10 +211,12 @@ const CLOUD_PROVIDER_KEY = "freed_cloud_provider";
 const UPLOAD_DEBOUNCE_MS = 2_000;
 const TOKEN_REFRESH_SKEW_MS = 60_000;
 const GOOGLE_TOKEN_REFRESH_FALLBACK_TTL_MS = 55 * 60 * 1000;
+const AUTH_FAILURE_REFRESH_COOLDOWN_MS = 5 * 60 * 1000;
 
 let cloudAbort: AbortController | null = null;
 let uploadTimer: ReturnType<typeof setTimeout> | null = null;
 const cloudTokenRefreshes = new Map<CloudProvider, Promise<string | null>>();
+const cloudAuthFailureRefreshes = new Map<CloudProvider, number>();
 
 export interface CloudTokenBundle {
   accessToken: string;
@@ -247,9 +249,14 @@ function readCloudTokenBundle(provider: CloudProvider): CloudTokenBundle | null 
 
 /** Persist OAuth credentials for a cloud provider. */
 export function storeCloudToken(provider: CloudProvider, token: string | CloudTokenBundle): void {
+  const previous = readCloudTokenBundle(provider);
   const bundle = typeof token === "string" ? { accessToken: token } : token;
-  localStorage.setItem(CLOUD_TOKEN_KEY(provider), bundle.accessToken);
-  localStorage.setItem(CLOUD_TOKEN_META_KEY(provider), JSON.stringify(bundle));
+  const storedBundle: CloudTokenBundle = {
+    ...bundle,
+    refreshToken: bundle.refreshToken ?? previous?.refreshToken,
+  };
+  localStorage.setItem(CLOUD_TOKEN_KEY(provider), storedBundle.accessToken);
+  localStorage.setItem(CLOUD_TOKEN_META_KEY(provider), JSON.stringify(storedBundle));
   localStorage.setItem(CLOUD_PROVIDER_KEY, provider);
 }
 
@@ -262,6 +269,48 @@ function shouldRefreshCloudToken(bundle: CloudTokenBundle, now = Date.now()): bo
   return typeof bundle.expiresAt === "number"
     && Number.isFinite(bundle.expiresAt)
     && bundle.expiresAt - now <= TOKEN_REFRESH_SKEW_MS;
+}
+
+function cloudTokenExpiresInMs(bundle: CloudTokenBundle, now = Date.now()): number | null {
+  return typeof bundle.expiresAt === "number" && Number.isFinite(bundle.expiresAt)
+    ? bundle.expiresAt - now
+    : null;
+}
+
+function authFailureStatus(error: unknown): number | undefined {
+  return typeof error === "object" && error !== null && "status" in error
+    ? (error as { status?: number }).status
+    : undefined;
+}
+
+async function refreshCloudTokenAfterAuthFailure(
+  provider: CloudProvider,
+  bundle: CloudTokenBundle,
+  error: unknown,
+): Promise<string | null> {
+  const status = authFailureStatus(error);
+  if (status !== 401) {
+    console.warn(`[CloudSync/${provider}] Auth failure is not refreshable status=${status ?? "unknown"}`, error);
+    throw error;
+  }
+  if (!bundle.refreshToken) {
+    console.warn(`[CloudSync/${provider}] Auth failure cannot refresh because no refresh token is stored`);
+    throw error;
+  }
+
+  const now = Date.now();
+  const lastRefreshAt = cloudAuthFailureRefreshes.get(provider);
+  if (typeof lastRefreshAt === "number" && now - lastRefreshAt < AUTH_FAILURE_REFRESH_COOLDOWN_MS) {
+    console.warn(`[CloudSync/${provider}] Auth failure refresh suppressed age_ms=${(now - lastRefreshAt).toLocaleString()}`);
+    throw error;
+  }
+
+  cloudAuthFailureRefreshes.set(provider, now);
+  const expiresInMs = cloudTokenExpiresInMs(bundle, now);
+  console.info(
+    `[CloudSync/${provider}] Refreshing token after auth failure status=${status} expires_in_ms=${expiresInMs?.toLocaleString() ?? "unknown"}`,
+  );
+  return refreshCloudToken(provider, bundle);
 }
 
 async function refreshCloudToken(provider: CloudProvider, bundle: CloudTokenBundle): Promise<string | null> {
@@ -325,6 +374,7 @@ export function clearCloudSync(provider: CloudProvider): void {
   localStorage.removeItem(CLOUD_TOKEN_KEY(provider));
   localStorage.removeItem(CLOUD_TOKEN_META_KEY(provider));
   localStorage.removeItem(CLOUD_PROVIDER_KEY);
+  cloudAuthFailureRefreshes.delete(provider);
   stopCloudSync();
 }
 
@@ -376,11 +426,13 @@ export async function startCloudSync(provider: CloudProvider, token: string): Pr
           return;
         } catch (error) {
           if (signal.aborted) return;
-          const status = typeof error === "object" && error !== null && "status" in error
-            ? (error as { status?: number }).status
-            : undefined;
+          const status = authFailureStatus(error);
           if (status !== 401 && status !== 403) throw error;
-          await refreshCloudToken("gdrive", readCloudTokenBundle("gdrive") ?? { accessToken: pollToken });
+          await refreshCloudTokenAfterAuthFailure(
+            "gdrive",
+            readCloudTokenBundle("gdrive") ?? { accessToken: pollToken },
+            error,
+          );
         }
       }
     };


### PR DESCRIPTION
(AI Generated).

## Summary
- (AI Generated).
Stops Google Drive poll failures from repeatedly refreshing valid tokens, preserves refresh tokens across reconnects, and applies the same guard in the PWA sync path.

## Testing
- corepack npm run validate:feature