### PR TITLE
fix: stabilize Google Contacts sync state

### DIFF
--- a/packages/desktop/src/lib/content-fetcher.test.ts
+++ b/packages/desktop/src/lib/content-fetcher.test.ts
@@ -511,4 +511,28 @@ describe("content fetcher", () => {
     expect(mockCacheSet).toHaveBeenCalledWith("rss:1", expect.stringContaining("Article title"));
     expect(statuses.at(-1)?.pending).toBe(1);
   });
+
+  it("defers background article parsing while settings are open", async () => {
+    vi.useFakeTimers();
+    const settingsShell = document.createElement("div");
+    settingsShell.className = "theme-settings-shell";
+    document.body.appendChild(settingsShell);
+    const { mod, subscriberRef, mockInvoke } = await loadContentFetcherModule();
+
+    mod.start();
+    subscriberRef.current?.({ items: [makeStubItem()], docItemCount: 1 });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(mockInvoke).not.toHaveBeenCalled();
+    expect(mod.getStatus()).toEqual(expect.objectContaining({
+      pending: 1,
+      active: false,
+      nextDelayMs: 15_000,
+    }));
+
+    settingsShell.remove();
+    await vi.advanceTimersByTimeAsync(15_000);
+    mod.stop();
+
+    expect(mockInvoke).toHaveBeenCalledOnce();
+  });
 });

--- a/packages/desktop/src/lib/content-fetcher.ts
+++ b/packages/desktop/src/lib/content-fetcher.ts
@@ -45,6 +45,8 @@ const HEARTBEAT_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
 const FAILED_RETRY_COOLDOWN_MS = 24 * 60 * 60 * 1000;
 const MAX_FAILED_TRACKED = 2_000;
 const RESPONSE_TOO_LARGE_PREFIX = "response_too_large";
+const RECENT_INPUT_IDLE_MS = 10_000;
+const UI_DEFER_DELAY_MS = 15_000;
 
 export interface FetcherStatus {
   pending: number;
@@ -74,6 +76,8 @@ let lastScannedDocItemCount: number | null = null;
 let activeStartedAt: number | null = null;
 let nextDelayMs: number | undefined;
 let backoffLevel = 0;
+let lastUserInteractionAt = 0;
+let removeUserInteractionListeners: (() => void) | null = null;
 
 // Status subscribers
 type StatusSubscriber = (status: FetcherStatus) => void;
@@ -211,6 +215,43 @@ function maybeScanVisibleItems(items: FeedItem[], docItemCount: number): void {
 
 type ProcessOutcome = "success" | "skipped" | "backoff" | "deferred" | "idle";
 
+function isInteractiveUiOpen(): boolean {
+  if (typeof document === "undefined") return false;
+  return Boolean(
+    document.querySelector(".theme-settings-shell") ||
+      document.querySelector(".theme-dialog-shell") ||
+      document.querySelector('[role="dialog"]'),
+  );
+}
+
+function recentUserInteractionAgeMs(now = Date.now()): number {
+  if (!lastUserInteractionAt) return Number.POSITIVE_INFINITY;
+  return now - lastUserInteractionAt;
+}
+
+function getUiDeferReason(now = Date.now()): string | null {
+  if (isInteractiveUiOpen()) return "interactive_ui_open";
+  const inputAgeMs = recentUserInteractionAgeMs(now);
+  if (inputAgeMs < RECENT_INPUT_IDLE_MS) {
+    return `recent_user_input:${Math.max(0, Math.round(inputAgeMs)).toLocaleString()}`;
+  }
+  return null;
+}
+
+function startUserInteractionTracking(): void {
+  if (removeUserInteractionListeners || typeof window === "undefined") return;
+  const markInput = () => {
+    lastUserInteractionAt = Date.now();
+  };
+  window.addEventListener("pointerdown", markInput, { passive: true });
+  window.addEventListener("keydown", markInput);
+  removeUserInteractionListeners = () => {
+    window.removeEventListener("pointerdown", markInput);
+    window.removeEventListener("keydown", markInput);
+    removeUserInteractionListeners = null;
+  };
+}
+
 function randomDelayForBackoff(level: number): number {
   const multiplier = 2 ** Math.min(level, MAX_BACKOFF_LEVEL);
   const min = BASE_DELAY_MIN_MS * multiplier;
@@ -275,6 +316,14 @@ async function runWorkerOnce(): Promise<void> {
   if (!running || activeStartedAt !== null) return;
   if (queue.length === 0) {
     notifyStatus();
+    return;
+  }
+
+  const uiDeferReason = getUiDeferReason();
+  if (uiDeferReason) {
+    log.info(`[content-fetcher] deferred by UI reason=${uiDeferReason}`);
+    notifyStatus();
+    scheduleWorker(UI_DEFER_DELAY_MS);
     return;
   }
 
@@ -458,6 +507,7 @@ export function start(): void {
   });
 
   log.info("[content-fetcher] started");
+  startUserInteractionTracking();
 
   scheduleWorker(0);
 
@@ -495,6 +545,9 @@ export function stop(): void {
     unsubscribeDoc();
     unsubscribeDoc = null;
   }
+
+  removeUserInteractionListeners?.();
+  lastUserInteractionAt = 0;
 
   log.info("[content-fetcher] stopped");
 }

--- a/packages/shared/src/contact-sync-state.ts
+++ b/packages/shared/src/contact-sync-state.ts
@@ -8,6 +8,7 @@ export function createEmptyContactSyncState(): ContactSyncState {
   return {
     authStatus: "reconnect_required",
     syncStatus: "idle",
+    syncStartedAt: null,
     syncToken: null,
     lastSyncedAt: null,
     lastErrorCode: undefined,
@@ -36,6 +37,7 @@ export function parseContactSyncState(raw: string | null | undefined): ContactSy
     return {
       authStatus: parsed.authStatus ?? "reconnect_required",
       syncStatus: parsed.syncStatus ?? "idle",
+      syncStartedAt: parsed.syncStartedAt ?? null,
       syncToken: parsed.syncToken ?? null,
       lastSyncedAt: parsed.lastSyncedAt ?? null,
       lastErrorCode: parsed.lastErrorCode,

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1279,6 +1279,7 @@ export interface IdentitySuggestion {
 export interface ContactSyncState {
   authStatus: "connected" | "reconnect_required";
   syncStatus: "idle" | "syncing" | "error";
+  syncStartedAt?: number | null;
   syncToken: string | null;
   lastSyncedAt: number | null;
   lastErrorCode?: "missing_token" | "auth" | "network" | "unknown";

--- a/packages/ui/src/components/settings/GoogleContactsSection.tsx
+++ b/packages/ui/src/components/settings/GoogleContactsSection.tsx
@@ -58,7 +58,7 @@ export function GoogleContactsSection() {
     try {
       await googleContacts.connect({ signal: abortController.signal });
       setConnectErrorMessage(null);
-      await syncNow();
+      await syncNow({ force: true });
     } catch (error) {
       if (error instanceof Error && error.name === "AbortError") {
         setConnectErrorMessage("Google Contacts connection canceled.");
@@ -87,7 +87,7 @@ export function GoogleContactsSection() {
 
   const handleSync = async () => {
     setConnectErrorMessage(null);
-    await syncNow();
+    await syncNow({ force: true });
   };
 
   const cachedCount = syncState.cachedContacts.length.toLocaleString();

--- a/packages/ui/src/context/ContactSyncContext.tsx
+++ b/packages/ui/src/context/ContactSyncContext.tsx
@@ -12,7 +12,7 @@ import type { ContactMatch, ContactSyncState } from "@freed/shared";
 export interface ContactSyncContextValue {
   syncState: ContactSyncState;
   getSyncState: () => ContactSyncState;
-  syncNow: () => Promise<ContactSyncState>;
+  syncNow: (options?: { force?: boolean }) => Promise<ContactSyncState>;
   dismissSuggestion: (suggestionId: string) => void;
   getMatchForSuggestion: (suggestionId: string) => ContactMatch | null;
   openReview: () => Promise<void>;

--- a/packages/ui/src/hooks/useContactSync.test.tsx
+++ b/packages/ui/src/hooks/useContactSync.test.tsx
@@ -104,4 +104,177 @@ describe("useContactSync", () => {
       syncToken: "next-token",
     });
   });
+
+  it("recovers a stale persisted syncing state after a successful sync", async () => {
+    localStorage.setItem(CONTACT_SYNC_STORAGE_KEY, JSON.stringify({
+      authStatus: "connected",
+      syncStatus: "syncing",
+      syncStartedAt: Date.now() - 180_000,
+      syncToken: "old-token",
+      lastSyncedAt: 1_700_000_000_000,
+      cachedContacts: [],
+      pendingSuggestions: [],
+      dismissedSuggestionIds: [],
+      createdFriendCount: 0,
+    }));
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    const platformValue = {
+      store: <T,>(selector: (state: unknown) => T): T => selector({
+        persons: {},
+        accounts: {},
+        items: [],
+        setPendingMatchCount: vi.fn(),
+      }),
+      googleContacts: {
+        getToken: vi.fn(async () => "google-access-token"),
+        connect: vi.fn(async () => {}),
+        fetchContacts: vi.fn(async () => ({ contacts: [], nextSyncToken: "next-token", deleted: [] })),
+      },
+    } as unknown as PlatformConfig;
+    let actions: ContactSyncActions | null = null;
+
+    await act(async () => {
+      root.render(
+        <PlatformProvider value={platformValue}>
+          <ContactSyncHarness onReady={(nextActions) => {
+            actions = nextActions;
+          }} />
+        </PlatformProvider>,
+      );
+    });
+
+    expect(actions?.getSyncState()).toMatchObject({
+      syncStatus: "idle",
+      syncStartedAt: null,
+      lastSyncedAt: 1_700_000_000_000,
+    });
+
+    await act(async () => {
+      await actions!.syncNow({ force: true });
+    });
+
+    expect(actions?.getSyncState()).toMatchObject({
+      authStatus: "connected",
+      syncStatus: "idle",
+      syncStartedAt: null,
+      syncToken: "next-token",
+    });
+  });
+
+  it("times out stalled People API requests instead of leaving the UI syncing", async () => {
+    vi.useFakeTimers();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    const platformValue = {
+      store: <T,>(selector: (state: unknown) => T): T => selector({
+        persons: {},
+        accounts: {},
+        items: [],
+        setPendingMatchCount: vi.fn(),
+      }),
+      googleContacts: {
+        getToken: vi.fn(async () => "google-access-token"),
+        connect: vi.fn(async () => {}),
+        fetchContacts: vi.fn(() => new Promise(() => undefined)),
+      },
+    } as unknown as PlatformConfig;
+    let actions: ContactSyncActions | null = null;
+
+    await act(async () => {
+      root.render(
+        <PlatformProvider value={platformValue}>
+          <ContactSyncHarness onReady={(nextActions) => {
+            actions = nextActions;
+          }} />
+        </PlatformProvider>,
+      );
+    });
+
+    let syncPromise: Promise<ContactSyncState> | null = null;
+    await act(async () => {
+      syncPromise = actions!.syncNow({ force: true });
+      await Promise.resolve();
+    });
+
+    expect(actions?.getSyncState()).toMatchObject({
+      authStatus: "connected",
+      syncStatus: "syncing",
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+      await syncPromise;
+    });
+
+    expect(actions?.getSyncState()).toMatchObject({
+      authStatus: "connected",
+      syncStatus: "error",
+      syncStartedAt: null,
+      lastErrorCode: "network",
+    });
+    expect(actions?.getSyncState().lastErrorMessage).toContain("Google Contacts sync timed out");
+  });
+
+  it("skips automatic focus syncs when Contacts synced recently", async () => {
+    const lastSyncedAt = Date.now();
+    localStorage.setItem(CONTACT_SYNC_STORAGE_KEY, JSON.stringify({
+      authStatus: "connected",
+      syncStatus: "idle",
+      syncStartedAt: null,
+      syncToken: "recent-token",
+      lastSyncedAt,
+      cachedContacts: [],
+      pendingSuggestions: [],
+      dismissedSuggestionIds: [],
+      createdFriendCount: 0,
+    }));
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    const fetchContacts = vi.fn(async () => ({ contacts: [], nextSyncToken: "next-token", deleted: [] }));
+    const platformValue = {
+      store: <T,>(selector: (state: unknown) => T): T => selector({
+        persons: {},
+        accounts: {},
+        items: [],
+        setPendingMatchCount: vi.fn(),
+      }),
+      googleContacts: {
+        getToken: vi.fn(async () => "google-access-token"),
+        connect: vi.fn(async () => {}),
+        fetchContacts,
+      },
+    } as unknown as PlatformConfig;
+    let actions: ContactSyncActions | null = null;
+
+    await act(async () => {
+      root.render(
+        <PlatformProvider value={platformValue}>
+          <ContactSyncHarness onReady={(nextActions) => {
+            actions = nextActions;
+          }} />
+        </PlatformProvider>,
+      );
+    });
+
+    await act(async () => {
+      await actions!.syncNow();
+    });
+
+    expect(fetchContacts).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await actions!.syncNow({ force: true });
+    });
+
+    expect(fetchContacts).toHaveBeenCalledOnce();
+  });
 });

--- a/packages/ui/src/hooks/useContactSync.ts
+++ b/packages/ui/src/hooks/useContactSync.ts
@@ -18,10 +18,43 @@ import { matchContacts } from "@freed/shared/contact-matching";
 import { usePlatform } from "../context/PlatformContext.js";
 
 const SYNC_INTERVAL_MS = 15 * 60 * 1000;
+const CONTACT_SYNC_TIMEOUT_MS = 60 * 1000;
+const STALE_SYNCING_MS = 2 * CONTACT_SYNC_TIMEOUT_MS;
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
+  let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timeoutHandle = setTimeout(() => {
+          reject(new Error(`${label} timed out after ${timeoutMs.toLocaleString()} ms`));
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeoutHandle !== null) clearTimeout(timeoutHandle);
+  }
+}
 
 function loadSyncState(): ContactSyncState {
   try {
-    return parseContactSyncState(localStorage.getItem(CONTACT_SYNC_STORAGE_KEY));
+    const parsed = parseContactSyncState(localStorage.getItem(CONTACT_SYNC_STORAGE_KEY));
+    if (
+      parsed.syncStatus === "syncing" &&
+      (!parsed.syncStartedAt || Date.now() - parsed.syncStartedAt > STALE_SYNCING_MS)
+    ) {
+      return {
+        ...parsed,
+        syncStatus: parsed.lastSyncedAt ? "idle" : "error",
+        syncStartedAt: null,
+        lastErrorCode: parsed.lastSyncedAt ? undefined : "network",
+        lastErrorMessage: parsed.lastSyncedAt
+          ? undefined
+          : "Google Contacts sync did not finish. Try syncing again.",
+      };
+    }
+    return parsed;
   } catch {
     return createEmptyContactSyncState();
   }
@@ -70,6 +103,7 @@ function withError(
       ? "reconnect_required"
       : current.authStatus,
     syncStatus: "error",
+    syncStartedAt: null,
     lastErrorCode: code,
     lastErrorMessage: message,
     createdFriendCount: current.createdFriendCount ?? 0,
@@ -107,14 +141,38 @@ export function useContactSync() {
     saveSyncState(nextState);
   }, []);
 
-  const runSync = useCallback(() => {
+  const runSync = useCallback((options: { force?: boolean } = {}) => {
     if (syncPromiseRef.current) return syncPromiseRef.current;
 
     let syncPromise!: Promise<ContactSyncState>;
     syncPromise = (async () => {
       const current = syncStateRef.current;
+      const now = Date.now();
+      if (!options.force && current.syncStatus === "syncing") {
+        const nextState: ContactSyncState = current.lastSyncedAt
+          ? { ...current, syncStatus: "idle", syncStartedAt: null }
+          : withError(current, "network", "Google Contacts sync did not finish. Try syncing again.");
+        commitSyncState(nextState);
+        return nextState;
+      }
+
+      if (
+        !options.force &&
+        current.syncStatus !== "error" &&
+        current.lastSyncedAt &&
+        now - current.lastSyncedAt < SYNC_INTERVAL_MS
+      ) {
+        return current;
+      }
+
       const contactsApi = googleContacts;
-      const token = contactsApi ? await contactsApi.getToken() : null;
+      const token = contactsApi
+        ? await withTimeout(
+            Promise.resolve(contactsApi.getToken()),
+            CONTACT_SYNC_TIMEOUT_MS,
+            "Google Contacts token lookup",
+          )
+        : null;
 
       if (!token) {
         const nextState = withError(current, "missing_token", "Reconnect Google to sync contacts.");
@@ -126,14 +184,20 @@ export function useContactSync() {
         ...current,
         authStatus: "connected",
         syncStatus: "syncing",
+        syncStartedAt: now,
         lastErrorCode: undefined,
         lastErrorMessage: undefined,
       });
 
       try {
-        const result: GoogleContactsResult = contactsApi?.fetchContacts
-          ? await contactsApi.fetchContacts(token, current.syncToken)
-          : await fetchGoogleContacts(token, current.syncToken);
+        const contactsPromise: Promise<GoogleContactsResult> = contactsApi?.fetchContacts
+          ? contactsApi.fetchContacts(token, current.syncToken)
+          : fetchGoogleContacts(token, current.syncToken);
+        const result = await withTimeout(
+          contactsPromise,
+          CONTACT_SYNC_TIMEOUT_MS,
+          "Google Contacts sync",
+        );
         const merged = mergeContactChanges(current.cachedContacts, result.contacts, result.deleted);
         const allMatches = matchContacts(
           merged,
@@ -153,6 +217,7 @@ export function useContactSync() {
         const nextState: ContactSyncState = {
           authStatus: "connected",
           syncStatus: "idle",
+          syncStartedAt: null,
           syncToken: result.nextSyncToken,
           lastSyncedAt: Date.now(),
           cachedContacts: merged,
@@ -169,7 +234,7 @@ export function useContactSync() {
           ? (error as { status?: number }).status
           : undefined;
         const code = status === 401 || status === 403 ? "auth" : "network";
-        const nextState = withError(current, code, message);
+        const nextState = withError(syncStateRef.current, code, message);
         commitSyncState(nextState);
         return nextState;
       }


### PR DESCRIPTION
(AI Generated).

## Summary
- recover stale Google Contacts `syncing` state on startup and auto-focus runs
- force manual reconnect and sync actions while throttling automatic focus syncs after a recent success
- add token and People API timeouts so a hung request cannot leave Settings stuck
- defer background article parsing while Settings or dialogs are open, and shortly after user input

## Validation
- `node node_modules/vitest/vitest.mjs run packages/ui/src/hooks/useContactSync.test.tsx --environment jsdom`
- `corepack npm run test:unit -- src/lib/content-fetcher.test.ts`
- `corepack npm run test:e2e -- google-contacts.spec.ts`
- `corepack npm run build` in `packages/desktop`
- `corepack npm run typecheck` in `packages/pwa`
- `corepack npm run validate:feature`
