### PR TITLE
fix: stabilize provider sync under memory pressure

### DIFF
--- a/docs/PHASE-4-SYNC.md
+++ b/docs/PHASE-4-SYNC.md
@@ -3,7 +3,7 @@
 > **Status:** 🚧 In Progress
 > **Dependencies:** Phase 1-2 (Capture layers ✓)
 >
-> Local relay, GDrive/Dropbox cloud sync, desktop local snapshot rotation, "Sync Now" button, "Last synced" indicator, proxied Google token exchange for Freed Desktop, durable Google OAuth refresh, appDataFolder Drive polling, cloud sync health diagnostics, and the no-cloud-sync launch banner are all working. iCloud sync is the remaining open item.
+> Local relay, Google Drive cloud sync, desktop local snapshot rotation, "Sync Now" button, "Last synced" indicator, proxied Google token exchange for Freed Desktop, durable Google OAuth refresh, appDataFolder Drive polling, cloud sync health diagnostics, runtime-gated cloud backoff, and the no-cloud-sync launch banner are all working. Dropbox remains behind a coming-soon gate while its provider work is finished. iCloud sync is the remaining open item.
 
 ---
 
@@ -289,9 +289,10 @@ Each provider stores a single Automerge binary file. CRDT handles merge conflict
 - [x] Desktop broadcasts doc changes to connected PWA clients via `broadcast_doc` Tauri command
 - [x] QR code or manual pairing connects PWA to Desktop (SyncConnectDialog with QR scanner)
 - [x] Sync connection status observable (`onStatusChange` listener in sync.ts)
-- [x] PWA falls back to cloud sync when away from home (GDrive + Dropbox PKCE OAuth, Automerge merge-upload)
-- [x] Google Drive uses the server token proxy in Freed Desktop so the Google client secret stays out of the app bundle, watches appDataFolder changes, and refreshes stored OAuth credentials before Drive or Contacts calls
-- [x] At least one cloud provider works: GDrive and Dropbox both confirmed working on app.freed.wtf
+- [x] PWA falls back to cloud sync when away from home (Google Drive PKCE OAuth, Automerge merge-upload)
+- [x] Google Drive uses the server token proxy in Freed Desktop so the Google client secret stays out of the app bundle, watches appDataFolder changes, refreshes stored OAuth credentials before Drive or Contacts calls, and retries Contacts once after a 401 with a forced token refresh
+- [x] Google Drive startup downloads and uploads wait behind runtime health, memory pressure, and social-scrape gates, then retry with bounded backoff instead of repeatedly copying the Automerge document while the app is under pressure
+- [x] At least one cloud provider works: Google Drive is the active cloud sync provider while Dropbox remains disabled behind a coming-soon control
 - [x] Desktop surfaces cloud sync health with retry/reconnect actions, recent failures, and debug charts
 - [x] Desktop no-cloud-sync launch banner self-dismisses after 15 seconds with a gentle countdown ring
 - [x] Desktop writes rotating local snapshots and can restore an older Automerge copy from Settings

--- a/docs/PHASE-5-DESKTOP.md
+++ b/docs/PHASE-5-DESKTOP.md
@@ -319,7 +319,8 @@ export async function captureDomFeed(
 - [x] Desktop diagnostics now include Freed-owned WebKit renderer RSS, Automerge binary size, IndexedDB size, WebKit cache size, and adaptive memory guardrails that reclaim scraper windows and network-cache blobs before pausing social capture
 - [x] Social scrape memory preflight now records whether recycled WebKit process IDs exited, were retained, or were replaced, plus the RSS delta after cleanup
 - [x] Desktop now records rotating runtime-health diagnostics with renderer heartbeat state, memory preflight results, recovery attempts, and active background work so blank-renderer reports include the last bad minute of runtime context
-- [x] High-risk background work now waits for healthy renderer startup and memory pressure cooldowns before running content fetches, RSS polls, automatic snapshots, cloud uploads, outbox drains, or native social scrapes
+- [x] High-risk background work now waits for healthy renderer startup and memory pressure cooldowns before running content fetches, RSS polls, automatic snapshots, cloud uploads, cloud startup downloads, outbox drains, or native social scrapes
+- [x] Renderer recovery treats a visible native window with a hidden renderer heartbeat as stale instead of benign hidden-tab throttling, so visible freezes can recover instead of sitting silent
 - [x] Native renderer recovery now marks failed recovery state, requests relaunch, and forces the old process to exit if the main WebView label stays stuck after a destroyed renderer
 - [x] Native relay broadcasts now reuse shared document buffers and stop writing a full snapshot on every live document push, reducing clone pressure during heavy sync churn
 - [x] Desktop worker state no longer ships the full `allItemIds` list or full Automerge binary back to the main thread on every mutation, and the content fetcher now bounds its failed-item cooldown cache instead of keeping an immortal set of every fetch miss

--- a/docs/PHASE-7-SOCIAL-CAPTURE.md
+++ b/docs/PHASE-7-SOCIAL-CAPTURE.md
@@ -1,6 +1,6 @@
 # Phase 7: Facebook + Instagram Capture
 
-> **Status:** 🚧 In Progress: Facebook and Instagram integrated into Desktop via Tauri WebView scraping, with feed pollution filtering, stricter Instagram story viewer validation, long-text expansion before extraction, silent background media guarding, provider health summaries, smart backoff, shared memory-preflight backoff, Facebook group controls, source-level post and story filtering, preserved Instagram story location metadata for map recovery, linked-account cross-post dedup across IG and FB, Instagram media-key duplicate repair, same-platform social story duplicate repair, explicit reply links with opt-in beta inline hydration for X, Facebook, and Instagram reader posts, captured authors now feeding the Phase 8 account catalog for identity review, and a local permanent media vault for a user's own Meta media
+> **Status:** 🚧 In Progress: Facebook and Instagram integrated into Desktop via Tauri WebView scraping, with feed pollution filtering, stricter Instagram story viewer validation, long-text expansion before extraction, silent background media guarding, provider health summaries, smart backoff, shared memory-preflight backoff, cloud-sync exclusion while social scrapes are active, Facebook group controls, source-level post and story filtering, preserved Instagram story location metadata for map recovery, linked-account cross-post dedup across IG and FB, Instagram media-key duplicate repair, same-platform social story duplicate repair, explicit reply links with opt-in beta inline hydration for X, Facebook, and Instagram reader posts, captured authors now feeding the Phase 8 account catalog for identity review, and a local permanent media vault for a user's own Meta media
 > **Dependencies:** Phase 5 (Desktop App)
 
 ---
@@ -202,6 +202,7 @@ const RATE_LIMITS = {
 - [x] Social provider sections include a filtered line-by-line scrape log so users can see what the scraper is doing in real time without expanding the outer Settings view
 - [x] Desktop social scraper commands serialize behind a shared native session lock so background WebKit jobs cannot overlap and starve the main renderer
 - [x] Social memory preflight blocks fan-out across providers when Freed Desktop memory remains high after cleanup
+- [x] Facebook and Instagram feed scrapes now register with the shared background runtime so cloud sync, content fetches, RSS polls, snapshots, outbox drains, and semantic classifiers do not compete with active WebKit scraping
 - [x] Facebook, Instagram, and LinkedIn extractors expand common long-text controls before normalization
 - [x] Social provider source menus surface a quick status explanation for warning or reconnect states before routing into full settings
 - [x] Captured social authors can backfill the Phase 8 account catalog so followed accounts exist before identity confirmation

--- a/docs/PHASE-8-FRIENDS.md
+++ b/docs/PHASE-8-FRIENDS.md
@@ -349,7 +349,7 @@ Reader author names now route directly into the matching Friends channel detail 
 - [x] FriendEditor links social sources and imports contact info
 - [x] Friends shown in Sidebar as a live navigation destination
 - [x] Google Contacts import creates friend persons by default and suggests same-person matches without auto-linking
-- [x] Google Contacts sync reuses native, refreshable Google credentials in Freed Desktop so reconnect is not required after normal access-token expiry
+- [x] Google Contacts sync reuses native, refreshable Google credentials in Freed Desktop, retries once after an API 401 with a forced refresh, and streams People API pages into normalized results without retaining duplicate raw page arrays
 - [x] Desktop snapshot restore preserves cached Google contacts and pending match suggestions
 - [x] Google Contacts appears as a first-class source in Settings and Friends, with full management in Freed Desktop and status-only visibility in the PWA
 - [x] Captured social authors can backfill orphan followed-account records before the operator confirms identity

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -1288,7 +1288,7 @@ dependencies = [
 
 [[package]]
 name = "freed-desktop"
-version = "26.5.2903"
+version = "26.5.3008"
 dependencies = [
  "base64 0.22.1",
  "criterion",

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -1742,7 +1742,7 @@ fn renderer_recovery_threshold_for_count(
 }
 
 fn renderer_is_effectively_visible(is_visible: bool, last_visibility: &str) -> bool {
-    is_visible && last_visibility == "visible"
+    is_visible || last_visibility == "visible"
 }
 
 fn renderer_stale_log_after(is_visible: bool, last_visibility: &str) -> Duration {
@@ -1771,7 +1771,7 @@ fn renderer_gap_is_expected_hidden_throttle(
     age: Duration,
     _recovery_threshold: Duration,
 ) -> bool {
-    !renderer_is_effectively_visible(is_visible, last_visibility)
+    !is_visible
         && (last_visibility == "hidden" || last_hidden_timer_throttled == Some(true))
         && age >= WEBKIT_HIDDEN_TIMER_THROTTLE_AFTER
 }
@@ -1816,11 +1816,11 @@ mod renderer_watchdog_tests {
     fn renderer_recovery_threshold_prefers_visible_windows() {
         assert_eq!(
             renderer_recovery_threshold(true, "hidden"),
-            RENDERER_HIDDEN_RECOVERY_AFTER
+            RENDERER_VISIBLE_RECOVERY_AFTER
         );
         assert_eq!(
             renderer_recovery_threshold(false, "visible"),
-            RENDERER_HIDDEN_RECOVERY_AFTER
+            RENDERER_VISIBLE_RECOVERY_AFTER
         );
         assert_eq!(
             renderer_recovery_threshold(false, "hidden"),
@@ -1840,11 +1840,11 @@ mod renderer_watchdog_tests {
         );
         assert_eq!(
             renderer_stale_log_after(true, "hidden"),
-            RENDERER_HIDDEN_STALE_LOG_AFTER
+            RENDERER_STALE_LOG_AFTER
         );
         assert_eq!(
             renderer_stale_log_after(false, "visible"),
-            RENDERER_HIDDEN_STALE_LOG_AFTER
+            RENDERER_STALE_LOG_AFTER
         );
     }
 
@@ -1855,24 +1855,22 @@ mod renderer_watchdog_tests {
     }
 
     #[test]
-    fn hidden_renderer_stale_log_keeps_background_work_eligible() {
+    fn truly_hidden_renderer_stale_log_keeps_background_work_eligible() {
         assert!(renderer_stale_log_should_pause_background(true, "visible"));
-        assert!(!renderer_stale_log_should_pause_background(true, "hidden"));
-        assert!(!renderer_stale_log_should_pause_background(
-            false, "visible"
-        ));
+        assert!(renderer_stale_log_should_pause_background(true, "hidden"));
+        assert!(renderer_stale_log_should_pause_background(false, "visible"));
         assert!(!renderer_stale_log_should_pause_background(false, "hidden"));
     }
 
     #[test]
-    fn hidden_renderer_stale_log_skips_deep_diagnostics() {
+    fn truly_hidden_renderer_stale_log_skips_deep_diagnostics() {
         assert!(renderer_stale_log_should_capture_deep_diagnostic(
             true, "visible"
         ));
-        assert!(!renderer_stale_log_should_capture_deep_diagnostic(
+        assert!(renderer_stale_log_should_capture_deep_diagnostic(
             true, "hidden"
         ));
-        assert!(!renderer_stale_log_should_capture_deep_diagnostic(
+        assert!(renderer_stale_log_should_capture_deep_diagnostic(
             false, "visible"
         ));
         assert!(!renderer_stale_log_should_capture_deep_diagnostic(
@@ -1881,10 +1879,10 @@ mod renderer_watchdog_tests {
     }
 
     #[test]
-    fn hidden_renderer_stale_skips_renderer_recovery() {
+    fn truly_hidden_renderer_stale_skips_renderer_recovery() {
         assert!(renderer_stale_should_recover(true, "visible"));
-        assert!(!renderer_stale_should_recover(true, "hidden"));
-        assert!(!renderer_stale_should_recover(false, "visible"));
+        assert!(renderer_stale_should_recover(true, "hidden"));
+        assert!(renderer_stale_should_recover(false, "visible"));
         assert!(!renderer_stale_should_recover(false, "hidden"));
     }
 
@@ -1897,7 +1895,7 @@ mod renderer_watchdog_tests {
             RENDERER_HIDDEN_STALE_LOG_AFTER + Duration::from_secs(1),
             RENDERER_HIDDEN_RECOVERY_AFTER,
         ));
-        assert!(renderer_gap_is_expected_hidden_throttle(
+        assert!(!renderer_gap_is_expected_hidden_throttle(
             true,
             "hidden",
             Some(false),

--- a/packages/desktop/src/App.tsx
+++ b/packages/desktop/src/App.tsx
@@ -34,6 +34,7 @@ import {
   getActiveProviders,
   getCloudToken,
   getValidCloudToken,
+  forceRefreshCloudToken,
   clearCloudProvider,
   deleteCloudFile,
   startCloudSync,
@@ -736,6 +737,20 @@ function App() {
       );
       return result;
     } catch (error) {
+      const status = typeof error === "object" && error !== null && "status" in error
+        ? (error as { status?: number }).status
+        : undefined;
+      if (status === 401) {
+        const refreshedToken = await forceRefreshCloudToken("gdrive");
+        if (refreshedToken && refreshedToken !== accessToken) {
+          log.info("[contacts] Google sync retrying after token refresh");
+          const result = await fetchGoogleContactsViaTauri(refreshedToken, syncToken);
+          log.info(
+            `[contacts] Google sync fetched contacts=${result.contacts.length.toLocaleString()} deleted=${result.deleted.length.toLocaleString()} next_sync_token=${result.nextSyncToken ? "yes" : "no"}`,
+          );
+          return result;
+        }
+      }
       const message = error instanceof Error ? error.message : String(error);
       log.warn(`[contacts] Google sync failed: ${message}`);
       throw error;

--- a/packages/desktop/src/lib/background-runtime-coordinator.test.ts
+++ b/packages/desktop/src/lib/background-runtime-coordinator.test.ts
@@ -85,6 +85,34 @@ describe("background runtime coordinator", () => {
     ).resolves.toBe("ok");
   });
 
+  it("keeps cloud sync behind active social scrapes", async () => {
+    const coordinator = await loadCoordinator();
+    coordinator.resetBackgroundRuntimeForTests({ requireRendererHealth: true });
+    coordinator.noteRendererHeartbeat(heartbeat(1));
+    coordinator.noteRendererHeartbeat(heartbeat(2));
+
+    let releaseScrape: () => void = () => {};
+    const scrape = coordinator.runBackgroundJob({
+      kind: "social-scrape",
+      source: "facebook:feed",
+      run: () => new Promise<void>((resolve) => {
+        releaseScrape = resolve;
+      }),
+    });
+
+    await Promise.resolve();
+    await expect(
+      coordinator.runBackgroundJob({
+        kind: "cloud-sync",
+        source: "cloud:gdrive",
+        run: () => undefined,
+      }),
+    ).rejects.toMatchObject({ reason: "active:social-scrape:facebook:feed" });
+
+    releaseScrape();
+    await scrape;
+  });
+
   it("pauses jobs during memory pressure cooldown", async () => {
     vi.useFakeTimers();
     const coordinator = await loadCoordinator();

--- a/packages/desktop/src/lib/background-runtime-coordinator.ts
+++ b/packages/desktop/src/lib/background-runtime-coordinator.ts
@@ -9,6 +9,7 @@ export type BackgroundJobKind =
   | "outbox"
   | "rss-poll"
   | "semantic-classifier"
+  | "social-scrape"
   | "snapshot";
 
 export interface RendererHeartbeatNote {

--- a/packages/desktop/src/lib/cloud-oauth.test.ts
+++ b/packages/desktop/src/lib/cloud-oauth.test.ts
@@ -287,6 +287,55 @@ describe("desktop Google OAuth", () => {
     expect(oauthCalls).toHaveLength(1);
   });
 
+  it("force refreshes Google tokens for API 401 recovery even when expiry is valid", async () => {
+    const oauthCalls: Array<{ url: string; body: string; contentType: string }> = [];
+    invokeMock.mockImplementation(async (cmd: string, args?: Record<string, unknown>) => {
+      if (cmd === "google_oauth_proxy_request") {
+        oauthCalls.push({
+          url: String(args?.url ?? ""),
+          body: String(args?.body ?? ""),
+          contentType: String(args?.contentType ?? ""),
+        });
+        return {
+          status: 200,
+          headers: [["content-type", "application/json"]],
+          body: Array.from(new TextEncoder().encode(JSON.stringify({
+            access_token: "forced-refreshed-access-token",
+            expires_in: 3600,
+          }))),
+        };
+      }
+      return null;
+    });
+    localStorage.setItem("freed_cloud_token_meta_gdrive", JSON.stringify({
+      accessToken: "still-valid-access-token",
+      refreshToken: "refresh-token",
+      expiresAt: Date.now() + 3_600_000,
+    }));
+
+    const { forceRefreshCloudToken } = await import("./sync");
+
+    await expect(forceRefreshCloudToken("gdrive")).resolves.toBe("forced-refreshed-access-token");
+    expect(oauthCalls).toHaveLength(1);
+    expect(JSON.parse(oauthCalls[0]!.body)).toMatchObject({
+      grantType: "refresh_token",
+      refreshToken: "refresh-token",
+    });
+  });
+
+  it("does not auto resume unsupported cloud providers with stored tokens", async () => {
+    localStorage.setItem("freed_cloud_token_meta_gdrive", JSON.stringify({
+      accessToken: "google-token",
+    }));
+    localStorage.setItem("freed_cloud_token_meta_dropbox", JSON.stringify({
+      accessToken: "dropbox-token",
+    }));
+
+    const { getActiveProviders } = await import("./sync");
+
+    expect(getActiveProviders()).toEqual(["gdrive"]);
+  });
+
   it("does not immediately refresh again when the token proxy omits expires_in", async () => {
     const oauthCalls: Array<{ url: string; body: string; contentType: string }> = [];
     invokeMock.mockImplementation(async (cmd: string, args?: Record<string, unknown>) => {

--- a/packages/desktop/src/lib/fb-capture.ts
+++ b/packages/desktop/src/lib/fb-capture.ts
@@ -29,6 +29,7 @@ import { getProviderPause, recordProviderHealthEvent } from "./provider-health";
 import { formatBytesForMemoryLog, prepareSocialScrapeMemory } from "./memory-monitor";
 import { archiveRecentProviderMedia, upsertMediaVaultRosterFromItems } from "./media-vault";
 import { socialProviderCopy } from "./social-provider-copy";
+import { runBackgroundJob } from "./background-runtime-coordinator";
 
 // =============================================================================
 // Rate Limiting
@@ -162,7 +163,12 @@ export async function fetchFbFeed(): Promise<FbSyncResult> {
       },
     );
 
-    await invoke("fb_scrape_feed", { windowMode: getFbScraperWindowMode() });
+    await runBackgroundJob({
+      kind: "social-scrape",
+      source: "facebook:feed",
+      timeoutMs: 600_000,
+      run: () => invoke("fb_scrape_feed", { windowMode: getFbScraperWindowMode() }),
+    });
     await new Promise<void>((resolve) => setTimeout(resolve, 500));
   } catch (err) {
     if (!diag.errorStage) {

--- a/packages/desktop/src/lib/instagram-capture.ts
+++ b/packages/desktop/src/lib/instagram-capture.ts
@@ -28,6 +28,7 @@ import { getProviderPause, recordProviderHealthEvent } from "./provider-health";
 import { formatBytesForMemoryLog, prepareSocialScrapeMemory } from "./memory-monitor";
 import { archiveRecentProviderMedia, upsertMediaVaultRosterFromItems } from "./media-vault";
 import { socialProviderCopy } from "./social-provider-copy";
+import { runBackgroundJob } from "./background-runtime-coordinator";
 
 // =============================================================================
 // Rate Limiting
@@ -138,7 +139,12 @@ export async function fetchIgFeed(): Promise<IgSyncResult> {
       }
     });
 
-    await invoke("ig_scrape_feed", { windowMode: getIgScraperWindowMode() });
+    await runBackgroundJob({
+      kind: "social-scrape",
+      source: "instagram:feed",
+      timeoutMs: 600_000,
+      run: () => invoke("ig_scrape_feed", { windowMode: getIgScraperWindowMode() }),
+    });
 
     // Brief wait for any in-flight events to arrive after invoke resolves
     await new Promise<void>((r) => setTimeout(r, 500));

--- a/packages/desktop/src/lib/sync.ts
+++ b/packages/desktop/src/lib/sync.ts
@@ -294,6 +294,10 @@ export type { CloudProvider };
 const CLOUD_TOKEN_KEY = (p: CloudProvider) => `freed_cloud_token_${p}`;
 const CLOUD_TOKEN_META_KEY = (p: CloudProvider) => `freed_cloud_token_meta_${p}`;
 const UPLOAD_DEBOUNCE_MS = 2_000;
+const UPLOAD_DEFER_BACKOFF_BASE_MS = 10_000;
+const UPLOAD_DEFER_BACKOFF_MAX_MS = 120_000;
+const INITIAL_DOWNLOAD_DEFER_BACKOFF_BASE_MS = 15_000;
+const INITIAL_DOWNLOAD_DEFER_BACKOFF_MAX_MS = 180_000;
 const TOKEN_REFRESH_SKEW_MS = 60_000;
 const GOOGLE_TOKEN_REFRESH_FALLBACK_TTL_MS = 55 * 60 * 1000;
 const AUTH_FAILURE_REFRESH_COOLDOWN_MS = 5 * 60 * 1000;
@@ -301,9 +305,12 @@ const AUTH_FAILURE_REFRESH_COOLDOWN_MS = 5 * 60 * 1000;
 /** Per-provider abort controllers, upload timers, and doc-change unsubscribers. */
 const cloudAborts = new Map<CloudProvider, AbortController>();
 const uploadTimers = new Map<CloudProvider, ReturnType<typeof setTimeout>>();
+const initialDownloadTimers = new Map<CloudProvider, ReturnType<typeof setTimeout>>();
 const cloudChangeUnsubscribes = new Map<CloudProvider, () => void>();
 const cloudTokenRefreshes = new Map<CloudProvider, Promise<string | null>>();
 const cloudAuthFailureRefreshes = new Map<CloudProvider, number>();
+const cloudUploadDeferredAttempts = new Map<CloudProvider, number>();
+const cloudInitialDownloadDeferredAttempts = new Map<CloudProvider, number>();
 
 // Desktop OAuth client IDs. These are public and embedded in the app bundle.
 const DEFAULT_GDRIVE_DESKTOP_CLIENT_ID =
@@ -431,6 +438,17 @@ function authFailureStatus(error: unknown): number | undefined {
   return typeof error === "object" && error !== null && "status" in error
     ? (error as { status?: number }).status
     : undefined;
+}
+
+function nextDeferredBackoffMs(
+  attempts: Map<CloudProvider, number>,
+  provider: CloudProvider,
+  baseMs: number,
+  maxMs: number,
+): number {
+  const nextAttempt = (attempts.get(provider) ?? 0) + 1;
+  attempts.set(provider, nextAttempt);
+  return Math.min(maxMs, baseMs * 2 ** Math.min(nextAttempt - 1, 6));
 }
 
 async function refreshCloudTokenAfterAuthFailure(
@@ -652,9 +670,17 @@ export async function getValidCloudToken(provider: CloudProvider): Promise<strin
   return bundle.accessToken;
 }
 
-/** Return all providers that have a stored access token. */
+/** Refresh a provider token even when its stored expiry still looks valid. */
+export async function forceRefreshCloudToken(provider: CloudProvider): Promise<string | null> {
+  const bundle = readCloudTokenBundle(provider);
+  if (!bundle) return null;
+  if (!bundle.refreshToken) return bundle.accessToken;
+  return refreshCloudToken(provider, bundle);
+}
+
+/** Return all supported providers that have a stored access token. */
 export function getActiveProviders(): CloudProvider[] {
-  const all: CloudProvider[] = ["gdrive", "dropbox"];
+  const all: CloudProvider[] = ["gdrive"];
   return all.filter((p) => !!getCloudToken(p));
 }
 
@@ -852,6 +878,80 @@ async function exchangeCode(
 
 // ─── Sync loops ───────────────────────────────────────────────────────────────
 
+async function runInitialCloudDownload(
+  provider: CloudProvider,
+  signal: AbortSignal,
+  resolveToken: () => Promise<string>,
+): Promise<void> {
+  const startedAt = Date.now();
+  const remote = provider === "gdrive"
+    ? await gdriveDownloadLatest(await resolveToken(), signal, googleDriveFetch)
+    : await dropboxDownloadLatest(await resolveToken(), signal);
+  if (remote) {
+    await mergeDoc(remote);
+    cloudInitialDownloadDeferredAttempts.delete(provider);
+    console.log("[CloudSync/%s] Initial merge (%d bytes)", provider, remote.length);
+    await recordProviderHealthEvent({
+      provider,
+      outcome: "success",
+      stage: "download",
+      startedAt,
+      finishedAt: Date.now(),
+      bytesMoved: remote.length,
+    });
+  } else {
+    cloudInitialDownloadDeferredAttempts.delete(provider);
+    await recordProviderHealthEvent({
+      provider,
+      outcome: "empty",
+      stage: "download",
+      reason: "No remote changes",
+      startedAt,
+      finishedAt: Date.now(),
+    });
+  }
+}
+
+function scheduleInitialCloudDownloadRetry(
+  provider: CloudProvider,
+  token: string,
+  reason: string,
+): void {
+  const delayMs = nextDeferredBackoffMs(
+    cloudInitialDownloadDeferredAttempts,
+    provider,
+    INITIAL_DOWNLOAD_DEFER_BACKOFF_BASE_MS,
+    INITIAL_DOWNLOAD_DEFER_BACKOFF_MAX_MS,
+  );
+  addDebugEvent(
+    "change",
+    `[Cloud/${provider}] initial download deferred: ${reason}; retry_ms=${delayMs.toLocaleString()}`,
+  );
+  const existing = initialDownloadTimers.get(provider);
+  if (existing) clearTimeout(existing);
+  const timer = setTimeout(() => {
+    initialDownloadTimers.delete(provider);
+    const controller = cloudAborts.get(provider);
+    if (!controller) return;
+    const resolveToken = async () => (provider === "gdrive" ? (await getValidCloudToken(provider)) ?? token : token);
+    runBackgroundJob({
+      kind: "cloud-sync",
+      source: `cloud:${provider}:initial-download-retry`,
+      timeoutMs: 180_000,
+      run: () => runInitialCloudDownload(provider, controller.signal, resolveToken),
+    }).catch((error) => {
+      if (controller.signal.aborted) return;
+      if (isBackgroundRuntimeDeferredError(error)) {
+        scheduleInitialCloudDownloadRetry(provider, token, error.reason);
+        return;
+      }
+      const msg = error instanceof Error ? error.message : String(error);
+      addDebugEvent("error", `[Cloud/${provider}] initial download retry failed: ${msg}`);
+    });
+  }, delayMs);
+  initialDownloadTimers.set(provider, timer);
+}
+
 /**
  * Start the cloud sync loop for a single provider.
  * Downloads the latest remote state immediately, then runs the appropriate
@@ -867,32 +967,16 @@ export async function startCloudSync(provider: CloudProvider, token: string): Pr
 
   // Immediate pull to catch up on any changes since last session.
   try {
-    const remote = provider === "gdrive"
-      ? await gdriveDownloadLatest(await resolveToken(), signal, googleDriveFetch)
-      : await dropboxDownloadLatest(await resolveToken(), signal);
-    if (remote) {
-      await mergeDoc(remote);
-      console.log("[CloudSync/%s] Initial merge (%d bytes)", provider, remote.length);
-      await recordProviderHealthEvent({
-        provider,
-        outcome: "success",
-        stage: "download",
-        startedAt: Date.now(),
-        finishedAt: Date.now(),
-        bytesMoved: remote.length,
-      });
-    } else {
-      await recordProviderHealthEvent({
-        provider,
-        outcome: "empty",
-        stage: "download",
-        reason: "No remote changes",
-        startedAt: Date.now(),
-        finishedAt: Date.now(),
-      });
-    }
+    await runBackgroundJob({
+      kind: "cloud-sync",
+      source: `cloud:${provider}:initial-download`,
+      timeoutMs: 180_000,
+      run: () => runInitialCloudDownload(provider, signal, resolveToken),
+    });
   } catch (err) {
-    if (!signal.aborted) {
+    if (!signal.aborted && isBackgroundRuntimeDeferredError(err)) {
+      scheduleInitialCloudDownloadRetry(provider, token, err.reason);
+    } else if (!signal.aborted) {
       const msg = err instanceof Error ? err.message : String(err);
       console.error(`[CloudSync/${provider}] Initial download failed:`, err);
       addDebugEvent("error", `[Cloud/${provider}] initial download failed: ${msg}`);
@@ -1016,6 +1100,14 @@ export function stopCloudSync(provider: CloudProvider): void {
     uploadTimers.delete(provider);
   }
 
+  const initialTimer = initialDownloadTimers.get(provider);
+  if (initialTimer) {
+    clearTimeout(initialTimer);
+    initialDownloadTimers.delete(provider);
+  }
+
+  cloudUploadDeferredAttempts.delete(provider);
+  cloudInitialDownloadDeferredAttempts.delete(provider);
   cloudChangeUnsubscribes.get(provider)?.();
   cloudChangeUnsubscribes.delete(provider);
 }
@@ -1077,6 +1169,7 @@ export function scheduleCloudUpload(provider: CloudProvider, token?: string): vo
               } else {
                 await dropboxUploadSafe(uploadToken, binary);
               }
+              cloudUploadDeferredAttempts.delete(provider);
               console.log("[CloudSync/%s] Uploaded (%d bytes)", provider, binary.byteLength);
               await recordProviderHealthEvent({
                 provider,
@@ -1103,8 +1196,21 @@ export function scheduleCloudUpload(provider: CloudProvider, token?: string): vo
           },
         }).catch((error) => {
           if (isBackgroundRuntimeDeferredError(error)) {
-            addDebugEvent("change", `[Cloud/${provider}] upload deferred: ${error.reason}`);
-            scheduleCloudUpload(provider, token);
+            const delayMs = nextDeferredBackoffMs(
+              cloudUploadDeferredAttempts,
+              provider,
+              UPLOAD_DEFER_BACKOFF_BASE_MS,
+              UPLOAD_DEFER_BACKOFF_MAX_MS,
+            );
+            addDebugEvent(
+              "change",
+              `[Cloud/${provider}] upload deferred: ${error.reason}; retry_ms=${delayMs.toLocaleString()}`,
+            );
+            const retryTimer = setTimeout(() => {
+              uploadTimers.delete(provider);
+              scheduleCloudUpload(provider, token);
+            }, delayMs);
+            uploadTimers.set(provider, retryTimer);
             return;
           }
           throw error;

--- a/packages/shared/src/google-contacts.ts
+++ b/packages/shared/src/google-contacts.ts
@@ -76,7 +76,8 @@ export async function fetchGoogleContactsWithPageFetcher(
     baseParams.set("requestSyncToken", "true");
   }
 
-  const allRaw: NonNullable<GoogleContactsConnectionsResponse["connections"]> = [];
+  const contacts: GoogleContact[] = [];
+  const deleted: string[] = [];
   let nextSyncToken = "";
   let pageToken: string | undefined;
 
@@ -85,7 +86,13 @@ export async function fetchGoogleContactsWithPageFetcher(
       const params = new URLSearchParams(baseParams);
       if (pageToken) params.set("pageToken", pageToken);
       const page = await pageFetcher(accessToken, params);
-      allRaw.push(...(page.connections ?? []));
+      for (const raw of page.connections ?? []) {
+        if (raw.metadata?.deleted) {
+          deleted.push(raw.resourceName);
+        } else {
+          contacts.push(parseContact(raw));
+        }
+      }
       nextSyncToken = page.nextSyncToken ?? nextSyncToken;
       pageToken = page.nextPageToken;
     } while (pageToken);
@@ -101,17 +108,6 @@ export async function fetchGoogleContactsWithPageFetcher(
       return fetchGoogleContactsWithPageFetcher(accessToken, null, pageFetcher);
     }
     throw err;
-  }
-
-  const contacts: GoogleContact[] = [];
-  const deleted: string[] = [];
-
-  for (const raw of allRaw) {
-    if (raw.metadata?.deleted) {
-      deleted.push(raw.resourceName);
-    } else {
-      contacts.push(parseContact(raw));
-    }
   }
 
   return { contacts, nextSyncToken, deleted };


### PR DESCRIPTION
(AI Generated).

## Summary
- Retry Google Contacts once after a forced token refresh and keep People API page handling memory bounded.
- Gate Google Drive startup downloads and uploads behind runtime health, memory pressure, and active social scrape backoff.
- Treat visible native windows with hidden renderer heartbeats as stale so freezes recover instead of being classified as hidden timer throttling.
- Prevent Dropbox from auto-resuming while it is still behind the coming-soon gate.

## Testing
- npm run validate:feature
- cargo test renderer_watchdog_tests