### PR TITLE
perf: reduce provider health memory churn

### DIFF
--- a/docs/PHASE-5-DESKTOP.md
+++ b/docs/PHASE-5-DESKTOP.md
@@ -328,6 +328,7 @@ export async function captureDomFeed(
 - [x] Background fetch no longer rescans the entire visible feed on every document mutation, it only rescans when the document item count changes, which cuts repeated O(n) churn during read toggles and preference writes
 - [x] Outbox retry bookkeeping now drops completed and terminally failed IDs instead of keeping a session-long retry map for every action it has ever seen
 - [x] Removing RSS feeds now also drops their retained provider-health diagnostics instead of keeping dead feed histories in memory and storage forever
+- [x] Provider-health persistence now compacts RSS feed attempt history, derives per-feed charts from retained attempts, trims oversized error reasons, updates failing-feed diagnostics incrementally, and batches hot RSS writes so renderer memory is not burned repeatedly on `sync-health.json` parse and stringify cycles
 - [x] Desktop live UI state now caps preserved article text previews and fetches full preserved text on demand for the active reader item, instead of cloning entire article bodies through every feed-state update
 - [x] Desktop native JSON persistence, encrypted secret store calls, cloud uploads, and outbox drains now run through typed side-effect queues with slow-task diagnostics, so common UI actions do not directly wait on native storage or broad outbox scans
 - [x] Desktop Automerge subscriptions now carry change metadata, so item-patch mutations let the outbox drain only changed items while startup and full document updates keep the full scan path

--- a/packages/desktop/src/lib/native-json-store.ts
+++ b/packages/desktop/src/lib/native-json-store.ts
@@ -99,3 +99,26 @@ export async function writeNativeJsonValue(
     },
   });
 }
+
+export async function writeNativeJsonFile(
+  file: string,
+  contents: Record<string, unknown>,
+  source: string,
+): Promise<void> {
+  if (!isTauri()) {
+    writeMockStoreFile(file, contents);
+    return;
+  }
+  await scheduleSideEffect({
+    queue: "nativeStore",
+    source,
+    kind: `write:${file}`,
+    run: async () => {
+      const path = await nativeJsonPath(file);
+      const tempPath = `${path}.tmp`;
+      await writeTextFile(tempPath, JSON.stringify(contents));
+      await rename(tempPath, path);
+      writeMockStoreFile(file, contents);
+    },
+  });
+}

--- a/packages/desktop/src/lib/provider-health.test.ts
+++ b/packages/desktop/src/lib/provider-health.test.ts
@@ -137,12 +137,14 @@ describe("provider health", () => {
     ).toBe(12);
   });
 
-  it("persists native health state through the filesystem instead of Tauri store", async () => {
+  it("persists native health state through the filesystem and debounces RSS feed writes", async () => {
     vi.useFakeTimers();
     const now = new Date("2026-04-02T19:15:00.000Z");
     vi.setSystemTime(now);
 
     const { mod, nativeFiles, nativeWrites } = await loadProviderHealthModule({ native: true });
+    await mod.initProviderHealth();
+    const writesAfterInit = nativeWrites.length;
 
     await mod.recordProviderHealthEvent({
       provider: "rss",
@@ -154,6 +156,10 @@ describe("provider health", () => {
       itemsSeen: 42,
       itemsAdded: 5,
     });
+
+    expect(nativeWrites).toHaveLength(writesAfterInit);
+
+    await vi.advanceTimersByTimeAsync(5_000);
 
     const stored = JSON.parse(
       nativeFiles.get("/mock/app-data/sync-health.json") ?? "{}",
@@ -217,6 +223,44 @@ describe("provider health", () => {
     const provider = debugStore.useDebugStore.getState().health?.providers.x;
     expect(provider?.lastOutcome).toBe("error");
     expect(provider?.lastError).toBe("Rate limit exceeded");
+  });
+
+  it("compacts retained RSS feed attempts before writing diagnostics", async () => {
+    vi.useFakeTimers();
+    const now = new Date("2026-04-02T19:15:00.000Z");
+    vi.setSystemTime(now);
+
+    const { mod, nativeFiles } = await loadProviderHealthModule({ native: true });
+    const feedUrl = "https://example.com/rss.xml";
+    const longReason = "Connection refused while loading ".repeat(20);
+
+    for (let index = 0; index < 8; index += 1) {
+      await mod.recordProviderHealthEvent({
+        provider: "rss",
+        scope: "rss_feed",
+        feedUrl,
+        feedTitle: "Example Feed",
+        outcome: "error",
+        stage: "fetch",
+        reason: longReason,
+        finishedAt: now.getTime() + index * 1_000,
+      });
+    }
+
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    const stored = JSON.parse(
+      nativeFiles.get("/mock/app-data/sync-health.json") ?? "{}",
+    ) as {
+      "provider-health"?: {
+        rssFeeds?: Record<string, { latestAttempts?: Array<{ reason?: string }> }>;
+      };
+    };
+    const attempts = stored["provider-health"]?.rssFeeds?.[feedUrl]?.latestAttempts ?? [];
+
+    expect(attempts).toHaveLength(5);
+    expect(attempts[0]?.reason?.length).toBeLessThanOrEqual(240);
+    expect(attempts[0]?.reason?.endsWith("...")).toBe(true);
   });
 
   it("does not auto-pause on cooldown outcomes", async () => {

--- a/packages/desktop/src/lib/provider-health.ts
+++ b/packages/desktop/src/lib/provider-health.ts
@@ -18,14 +18,17 @@ import { useAppStore } from "./store";
 import { storeFbAuthState } from "./fb-auth";
 import { storeIgAuthState } from "./instagram-auth";
 import { storeLiAuthState } from "./li-auth";
-import { readNativeJsonFile, writeNativeJsonValue } from "./native-json-store";
+import { readNativeJsonFile, writeNativeJsonFile } from "./native-json-store";
 
 const HEALTH_STORE_FILE = "sync-health.json";
 const HEALTH_STORE_KEY = "provider-health";
 const FALLBACK_STORAGE_KEY = "freed.provider-health";
 const MOCK_STORE_STORAGE_KEY = `__TAURI_MOCK_STORE__:${HEALTH_STORE_FILE}`;
 const MAX_PROVIDER_ATTEMPTS = 20;
-const MAX_FEED_ATTEMPTS = 20;
+const MAX_FEED_ATTEMPTS = 5;
+const MAX_ATTEMPT_REASON_CHARS = 240;
+const MAX_FEED_TITLE_CHARS = 180;
+const RSS_HEALTH_PERSIST_DEBOUNCE_MS = 5_000;
 const PROVIDERS: HealthProviderId[] = [
   "rss",
   "x",
@@ -109,6 +112,9 @@ interface PersistedHealthState {
 
 let currentState: PersistedHealthState | null = null;
 let initPromise: Promise<void> | null = null;
+let pendingPersistState: PersistedHealthState | null = null;
+let pendingPersistTimer: ReturnType<typeof setTimeout> | null = null;
+let latestFailingRssFeeds: RssFeedHealthSnapshot[] = [];
 
 function defaultDailyBuckets(now = Date.now()): HealthDailyBucket[] {
   return Array.from({ length: DEFAULT_DAILY_BUCKETS }, (_unused, index) => {
@@ -253,6 +259,20 @@ function coerceAttempts(
     .slice(0, max);
 }
 
+function compactText(value: string | undefined, max: number): string | undefined {
+  if (!value) return undefined;
+  if (value.length <= max) return value;
+  return `${value.slice(0, max - 3)}...`;
+}
+
+function compactAttempt(attempt: ProviderHealthAttempt): ProviderHealthAttempt {
+  return {
+    ...attempt,
+    feedTitle: compactText(attempt.feedTitle, MAX_FEED_TITLE_CHARS),
+    reason: compactText(attempt.reason, MAX_ATTEMPT_REASON_CHARS),
+  };
+}
+
 function coerceAttempt(value: unknown): ProviderHealthAttempt | null {
   if (!value || typeof value !== "object") return null;
   const attempt = value as Partial<ProviderHealthAttempt>;
@@ -264,10 +284,16 @@ function coerceAttempt(value: unknown): ProviderHealthAttempt | null {
     provider: attempt.provider as HealthProviderId,
     scope: attempt.scope === "rss_feed" ? "rss_feed" : "provider",
     feedUrl: typeof attempt.feedUrl === "string" ? attempt.feedUrl : undefined,
-    feedTitle: typeof attempt.feedTitle === "string" ? attempt.feedTitle : undefined,
+    feedTitle: compactText(
+      typeof attempt.feedTitle === "string" ? attempt.feedTitle : undefined,
+      MAX_FEED_TITLE_CHARS,
+    ),
     outcome: attempt.outcome as HealthOutcome,
     stage: typeof attempt.stage === "string" ? attempt.stage : undefined,
-    reason: typeof attempt.reason === "string" ? attempt.reason : undefined,
+    reason: compactText(
+      typeof attempt.reason === "string" ? attempt.reason : undefined,
+      MAX_ATTEMPT_REASON_CHARS,
+    ),
     startedAt: Number(attempt.startedAt ?? Date.now()),
     finishedAt: Number(attempt.finishedAt ?? Date.now()),
     durationMs: Number(attempt.durationMs ?? 0),
@@ -499,8 +525,8 @@ function coercePersistedHealthState(value: unknown): PersistedHealthState {
       ),
       latestAttempts:
         latestAttempts.length > 0
-          ? latestAttempts
-          : synthesizeProviderAttempts(provider, next),
+          ? latestAttempts.map(compactAttempt)
+          : synthesizeProviderAttempts(provider, next).map(compactAttempt),
       pause: coercePause(next.pause),
       lastPauseLevel:
         next.lastPauseLevel === 2 || next.lastPauseLevel === 3
@@ -522,22 +548,17 @@ function coercePersistedHealthState(value: unknown): PersistedHealthState {
     const next = feedState as Partial<PersistedFeedHealth>;
     rssFeeds[feedUrl] = {
       feedUrl,
-      feedTitle: typeof next.feedTitle === "string" && next.feedTitle.length > 0 ? next.feedTitle : feedUrl,
-      dailyBuckets: coerceBuckets(
-        next.dailyBuckets,
-        defaultDailyBuckets(now),
-        "dateKey",
-      ),
-      hourlyBuckets: coerceBuckets(
-        next.hourlyBuckets,
-        defaultHourlyBuckets(now),
-        "hourKey",
-      ),
+      feedTitle: compactText(
+        typeof next.feedTitle === "string" && next.feedTitle.length > 0 ? next.feedTitle : feedUrl,
+        MAX_FEED_TITLE_CHARS,
+      ) ?? feedUrl,
+      dailyBuckets: [],
+      hourlyBuckets: [],
       latestAttempts: (() => {
         const latestAttempts = coerceAttempts(next.latestAttempts, MAX_FEED_ATTEMPTS);
         return latestAttempts.length > 0
-          ? latestAttempts
-          : synthesizeFeedAttempts(feedUrl, next);
+          ? latestAttempts.map(compactAttempt)
+          : synthesizeFeedAttempts(feedUrl, next).map(compactAttempt);
       })(),
     };
   }
@@ -550,25 +571,19 @@ function coercePersistedHealthState(value: unknown): PersistedHealthState {
       }
       rssFeeds[feedState.feedUrl] = {
         feedUrl: feedState.feedUrl,
-        feedTitle:
+        feedTitle: compactText(
           typeof feedState.feedTitle === "string" && feedState.feedTitle.length > 0
             ? feedState.feedTitle
             : feedState.feedUrl,
-        dailyBuckets: coerceBuckets(
-          feedState.dailyBuckets,
-          defaultDailyBuckets(now),
-          "dateKey",
-        ),
-        hourlyBuckets: coerceBuckets(
-          feedState.hourlyBuckets,
-          defaultHourlyBuckets(now),
-          "hourKey",
-        ),
+          MAX_FEED_TITLE_CHARS,
+        ) ?? feedState.feedUrl,
+        dailyBuckets: [],
+        hourlyBuckets: [],
         latestAttempts: (() => {
           const latestAttempts = coerceAttempts(feedState.latestAttempts, MAX_FEED_ATTEMPTS);
           return latestAttempts.length > 0
-            ? latestAttempts
-            : synthesizeFeedAttempts(feedState.feedUrl, feedState);
+            ? latestAttempts.map(compactAttempt)
+            : synthesizeFeedAttempts(feedState.feedUrl, feedState).map(compactAttempt);
         })(),
       };
     }
@@ -580,6 +595,31 @@ function coercePersistedHealthState(value: unknown): PersistedHealthState {
     rssFeeds,
     updatedAt: typeof raw.updatedAt === "number" ? raw.updatedAt : now,
   };
+}
+
+function compactPersistedHealthState(state: PersistedHealthState): PersistedHealthState {
+  for (const provider of PROVIDERS) {
+    state.providers[provider] = {
+      ...state.providers[provider],
+      latestAttempts: state.providers[provider].latestAttempts
+        .map(compactAttempt)
+        .slice(0, MAX_PROVIDER_ATTEMPTS),
+    };
+  }
+
+  for (const [feedUrl, feedState] of Object.entries(state.rssFeeds)) {
+    state.rssFeeds[feedUrl] = {
+      ...feedState,
+      feedTitle: compactText(feedState.feedTitle, MAX_FEED_TITLE_CHARS) ?? feedUrl,
+      dailyBuckets: [],
+      hourlyBuckets: [],
+      latestAttempts: feedState.latestAttempts
+        .map(compactAttempt)
+        .slice(0, MAX_FEED_ATTEMPTS),
+    };
+  }
+
+  return state;
 }
 
 function bucketSuccess(outcome: HealthOutcome): boolean {
@@ -649,7 +689,13 @@ function upsertAttempt(
   attempt: ProviderHealthAttempt,
   max: number,
 ): ProviderHealthAttempt[] {
-  return [attempt, ...attempts].slice(0, max);
+  const compactedAttempt = compactAttempt(attempt);
+  return [
+    compactedAttempt,
+    ...attempts
+      .filter((existing) => existing.id !== compactedAttempt.id)
+      .map(compactAttempt),
+  ].slice(0, max);
 }
 
 function clearExpiredPause(providerState: PersistedProviderHealth, now = Date.now()): PersistedProviderHealth {
@@ -825,6 +871,40 @@ function snapshotForProvider(providerState: PersistedProviderHealth): ProviderHe
   };
 }
 
+function dailyBucketsForFeed(feedState: PersistedFeedHealth): HealthDailyBucket[] {
+  return [...feedState.latestAttempts]
+    .sort((a, b) => a.finishedAt - b.finishedAt)
+    .reduce(
+      (buckets, attempt) =>
+        bumpDailyBuckets(
+          buckets,
+          attempt.finishedAt,
+          attempt.outcome,
+          attempt.itemsSeen,
+          attempt.itemsAdded,
+          attempt.bytesMoved,
+        ),
+      defaultDailyBuckets(),
+    );
+}
+
+function hourlyBucketsForFeed(feedState: PersistedFeedHealth): HealthHourlyBucket[] {
+  return [...feedState.latestAttempts]
+    .sort((a, b) => a.finishedAt - b.finishedAt)
+    .reduce(
+      (buckets, attempt) =>
+        bumpHourlyBuckets(
+          buckets,
+          attempt.finishedAt,
+          attempt.outcome,
+          attempt.itemsSeen,
+          attempt.itemsAdded,
+          attempt.bytesMoved,
+        ),
+      defaultHourlyBuckets(),
+    );
+}
+
 function snapshotForFeed(feedState: PersistedFeedHealth): RssFeedHealthSnapshot {
   const lastSuccess = feedState.latestAttempts.find((attempt) => bucketSuccess(attempt.outcome));
   const failedSinceSuccess = feedState.latestAttempts.filter((attempt) => {
@@ -851,17 +931,18 @@ function snapshotForFeed(feedState: PersistedFeedHealth): RssFeedHealthSnapshot 
     lastError: feedState.latestAttempts.find(
       (attempt) => !bucketSuccess(attempt.outcome) && attempt.reason,
     )?.reason,
-    dailyBuckets: feedState.dailyBuckets,
-    hourlyBuckets: feedState.hourlyBuckets,
+    dailyBuckets: feedState.dailyBuckets.length > 0
+      ? feedState.dailyBuckets
+      : dailyBucketsForFeed(feedState),
+    hourlyBuckets: feedState.hourlyBuckets.length > 0
+      ? feedState.hourlyBuckets
+      : hourlyBucketsForFeed(feedState),
     latestAttempts: feedState.latestAttempts,
   };
 }
 
-function publishState(state: PersistedHealthState): void {
-  const providers = Object.fromEntries(
-    PROVIDERS.map((provider) => [provider, snapshotForProvider(state.providers[provider])]),
-  ) as Record<HealthProviderId, ProviderHealthSnapshot>;
-  const failingRssFeeds = Object.values(state.rssFeeds)
+function computeFailingRssFeeds(state: PersistedHealthState): RssFeedHealthSnapshot[] {
+  return Object.values(state.rssFeeds)
     .map(snapshotForFeed)
     .filter((feed) => feed.status === "failing")
     .sort((a, b) => {
@@ -869,20 +950,49 @@ function publishState(state: PersistedHealthState): void {
       const bOutage = b.outageSince ?? 0;
       return aOutage - bOutage;
     });
+}
+
+function updateFailingRssFeed(
+  state: PersistedHealthState,
+  feedUrl: string,
+): RssFeedHealthSnapshot[] {
+  const next = latestFailingRssFeeds.filter((feed) => feed.feedUrl !== feedUrl);
+  const feedState = state.rssFeeds[feedUrl];
+  if (feedState) {
+    const feedSnapshot = snapshotForFeed(feedState);
+    if (feedSnapshot.status === "failing") {
+      next.push(feedSnapshot);
+    }
+  }
+  return next.sort((a, b) => {
+    const aOutage = a.outageSince ?? 0;
+    const bOutage = b.outageSince ?? 0;
+    return aOutage - bOutage;
+  });
+}
+
+function publishState(state: PersistedHealthState, changedFeedUrl?: string): void {
+  const providers = Object.fromEntries(
+    PROVIDERS.map((provider) => [provider, snapshotForProvider(state.providers[provider])]),
+  ) as Record<HealthProviderId, ProviderHealthSnapshot>;
+  latestFailingRssFeeds = changedFeedUrl
+    ? updateFailingRssFeed(state, changedFeedUrl)
+    : computeFailingRssFeeds(state);
 
   setProviderHealth({
     providers,
-    failingRssFeeds,
+    failingRssFeeds: latestFailingRssFeeds,
     updatedAt: state.updatedAt,
   });
 }
 
 async function persistState(state: PersistedHealthState): Promise<void> {
+  const compactedState = compactPersistedHealthState(state);
   if (!isTauri()) {
-    fallbackWrite(state);
+    fallbackWrite(compactedState);
     return;
   }
-  await persistNativeState(state);
+  await persistNativeState(compactedState);
 }
 
 async function readState(): Promise<PersistedHealthState> {
@@ -905,12 +1015,7 @@ async function readState(): Promise<PersistedHealthState> {
 
 async function persistNativeState(state: PersistedHealthState): Promise<void> {
   try {
-    await writeNativeJsonValue(
-      HEALTH_STORE_FILE,
-      HEALTH_STORE_KEY,
-      state,
-      "provider-health",
-    );
+    await writeNativeJsonFile(HEALTH_STORE_FILE, { [HEALTH_STORE_KEY]: state }, "provider-health");
   } catch (error) {
     log.error(
       `[provider-health] failed to persist health file, falling back: ${
@@ -919,6 +1024,38 @@ async function persistNativeState(state: PersistedHealthState): Promise<void> {
     );
     fallbackWrite(state);
   }
+}
+
+function persistStateAndLog(state: PersistedHealthState): void {
+  void persistState(state).catch((error) => {
+    log.error(
+      `[provider-health] failed to persist deferred health state: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  });
+}
+
+function schedulePersistState(state: PersistedHealthState): void {
+  pendingPersistState = state;
+  if (pendingPersistTimer) return;
+  pendingPersistTimer = setTimeout(() => {
+    pendingPersistTimer = null;
+    const stateToPersist = pendingPersistState;
+    pendingPersistState = null;
+    if (stateToPersist) {
+      persistStateAndLog(stateToPersist);
+    }
+  }, RSS_HEALTH_PERSIST_DEBOUNCE_MS);
+}
+
+async function persistStateNow(state: PersistedHealthState): Promise<void> {
+  if (pendingPersistTimer) {
+    clearTimeout(pendingPersistTimer);
+    pendingPersistTimer = null;
+  }
+  pendingPersistState = null;
+  await persistState(state);
 }
 
 function assertState(): PersistedHealthState {
@@ -1011,14 +1148,14 @@ function normalizeAttempt(input: ProviderHealthEventInput): ProviderHealthAttemp
 export async function initProviderHealth(): Promise<void> {
   if (!initPromise) {
     initPromise = (async () => {
-      currentState = await readState();
+      currentState = compactPersistedHealthState(await readState());
       for (const provider of PROVIDERS) {
         currentState.providers[provider] = clearExpiredPause(
           currentState.providers[provider],
         );
       }
       publishState(currentState);
-      await persistState(currentState);
+      await persistStateNow(currentState);
     })();
   }
   await initPromise;
@@ -1048,7 +1185,7 @@ export async function clearProviderPause(provider: HealthProviderId): Promise<vo
   state.updatedAt = Date.now();
   currentState = state;
   publishState(state);
-  await persistState(state);
+  await persistStateNow(state);
 }
 
 export async function resetProviderPauseState(provider: HealthProviderId): Promise<void> {
@@ -1066,7 +1203,7 @@ export async function resetProviderPauseState(provider: HealthProviderId): Promi
   state.updatedAt = Date.now();
   currentState = state;
   publishState(state);
-  await persistState(state);
+  await persistStateNow(state);
 }
 
 export async function forgetRssFeedHealth(feedUrl: string): Promise<void> {
@@ -1076,8 +1213,8 @@ export async function forgetRssFeedHealth(feedUrl: string): Promise<void> {
   delete state.rssFeeds[feedUrl];
   state.updatedAt = Date.now();
   currentState = state;
-  publishState(state);
-  await persistState(state);
+  publishState(state, feedUrl);
+  await persistStateNow(state);
 }
 
 export async function recordProviderHealthEvent(
@@ -1116,29 +1253,15 @@ export async function recordProviderHealthEvent(
     const feedState = state.rssFeeds[attempt.feedUrl] ?? {
       feedUrl: attempt.feedUrl,
       feedTitle: attempt.feedTitle ?? attempt.feedUrl,
-      dailyBuckets: defaultDailyBuckets(attempt.finishedAt),
-      hourlyBuckets: defaultHourlyBuckets(attempt.finishedAt),
+      dailyBuckets: [],
+      hourlyBuckets: [],
       latestAttempts: [],
     };
     state.rssFeeds[attempt.feedUrl] = {
       ...feedState,
       feedTitle: attempt.feedTitle ?? feedState.feedTitle,
-      dailyBuckets: bumpDailyBuckets(
-        feedState.dailyBuckets,
-        attempt.finishedAt,
-        attempt.outcome,
-        attempt.itemsSeen,
-        attempt.itemsAdded,
-        attempt.bytesMoved,
-      ),
-      hourlyBuckets: bumpHourlyBuckets(
-        feedState.hourlyBuckets,
-        attempt.finishedAt,
-        attempt.outcome,
-        attempt.itemsSeen,
-        attempt.itemsAdded,
-        attempt.bytesMoved,
-      ),
+      dailyBuckets: [],
+      hourlyBuckets: [],
       latestAttempts: upsertAttempt(
         feedState.latestAttempts,
         attempt,
@@ -1150,7 +1273,11 @@ export async function recordProviderHealthEvent(
   maybeAutoPause(state, attempt);
   state.updatedAt = attempt.finishedAt;
   currentState = state;
-  publishState(state);
-  await persistState(state);
+  publishState(state, attempt.scope === "rss_feed" ? attempt.feedUrl : undefined);
+  if (attempt.scope === "rss_feed") {
+    schedulePersistState(state);
+  } else {
+    await persistStateNow(state);
+  }
   return attempt;
 }


### PR DESCRIPTION
(AI Generated).

## Summary
- Compact retained RSS provider-health diagnostics and derive per-feed charts from retained attempts instead of persisting bucket arrays for every feed.
- Batch hot RSS feed health writes and update failing-feed diagnostics incrementally so regular polling does not repeatedly parse and stringify the full sync-health store.
- Write the provider-health JSON file directly instead of routing this large single-key store through the generic read-modify-write helper.

## Testing
- npm run validate:feature
- npm run build --workspace=packages/desktop