### PR TITLE
fix: keep hidden renderer throttling from pausing sync

### DIFF
--- a/docs/PHASE-5-DESKTOP.md
+++ b/docs/PHASE-5-DESKTOP.md
@@ -320,7 +320,7 @@ export async function captureDomFeed(
 - [x] Social scrape memory preflight now records whether recycled WebKit process IDs exited, were retained, or were replaced, plus the RSS delta after cleanup
 - [x] Desktop now records rotating runtime-health diagnostics with renderer heartbeat state, memory preflight results, recovery attempts, and active background work so blank-renderer reports include the last bad minute of runtime context
 - [x] High-risk background work now waits for healthy renderer startup and memory pressure cooldowns before running content fetches, RSS polls, automatic snapshots, cloud uploads, cloud startup downloads, outbox drains, or native social scrapes
-- [x] Renderer recovery treats a visible native window with a hidden renderer heartbeat as stale instead of benign hidden-tab throttling, so visible freezes can recover instead of sitting silent
+- [x] Renderer recovery now requires both native window visibility and renderer document visibility before treating heartbeat gaps as foreground stalls, so background provider work is not paused by normal hidden WebKit timer throttling
 - [x] Native renderer recovery now marks failed recovery state, requests relaunch, and forces the old process to exit if the main WebView label stays stuck after a destroyed renderer
 - [x] Native relay broadcasts now reuse shared document buffers and stop writing a full snapshot on every live document push, reducing clone pressure during heavy sync churn
 - [x] Desktop worker state no longer ships the full `allItemIds` list or full Automerge binary back to the main thread on every mutation, and the content fetcher now bounds its failed-item cooldown cache instead of keeping an immortal set of every fetch miss

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -1288,7 +1288,7 @@ dependencies = [
 
 [[package]]
 name = "freed-desktop"
-version = "26.5.3008"
+version = "26.5.3010"
 dependencies = [
  "base64 0.22.1",
  "criterion",

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -1742,7 +1742,7 @@ fn renderer_recovery_threshold_for_count(
 }
 
 fn renderer_is_effectively_visible(is_visible: bool, last_visibility: &str) -> bool {
-    is_visible || last_visibility == "visible"
+    is_visible && last_visibility != "hidden"
 }
 
 fn renderer_stale_log_after(is_visible: bool, last_visibility: &str) -> Duration {
@@ -1771,7 +1771,7 @@ fn renderer_gap_is_expected_hidden_throttle(
     age: Duration,
     _recovery_threshold: Duration,
 ) -> bool {
-    !is_visible
+    !renderer_is_effectively_visible(is_visible, last_visibility)
         && (last_visibility == "hidden" || last_hidden_timer_throttled == Some(true))
         && age >= WEBKIT_HIDDEN_TIMER_THROTTLE_AFTER
 }
@@ -1816,14 +1816,14 @@ mod renderer_watchdog_tests {
     fn renderer_recovery_threshold_prefers_visible_windows() {
         assert_eq!(
             renderer_recovery_threshold(true, "hidden"),
-            RENDERER_VISIBLE_RECOVERY_AFTER
-        );
-        assert_eq!(
-            renderer_recovery_threshold(false, "visible"),
-            RENDERER_VISIBLE_RECOVERY_AFTER
+            RENDERER_HIDDEN_RECOVERY_AFTER
         );
         assert_eq!(
             renderer_recovery_threshold(false, "hidden"),
+            RENDERER_HIDDEN_RECOVERY_AFTER
+        );
+        assert_eq!(
+            renderer_recovery_threshold(false, "visible"),
             RENDERER_HIDDEN_RECOVERY_AFTER
         );
         assert_eq!(
@@ -1840,11 +1840,11 @@ mod renderer_watchdog_tests {
         );
         assert_eq!(
             renderer_stale_log_after(true, "hidden"),
-            RENDERER_STALE_LOG_AFTER
+            RENDERER_HIDDEN_STALE_LOG_AFTER
         );
         assert_eq!(
             renderer_stale_log_after(false, "visible"),
-            RENDERER_STALE_LOG_AFTER
+            RENDERER_HIDDEN_STALE_LOG_AFTER
         );
     }
 
@@ -1857,8 +1857,10 @@ mod renderer_watchdog_tests {
     #[test]
     fn truly_hidden_renderer_stale_log_keeps_background_work_eligible() {
         assert!(renderer_stale_log_should_pause_background(true, "visible"));
-        assert!(renderer_stale_log_should_pause_background(true, "hidden"));
-        assert!(renderer_stale_log_should_pause_background(false, "visible"));
+        assert!(!renderer_stale_log_should_pause_background(true, "hidden"));
+        assert!(!renderer_stale_log_should_pause_background(
+            false, "visible"
+        ));
         assert!(!renderer_stale_log_should_pause_background(false, "hidden"));
     }
 
@@ -1867,10 +1869,10 @@ mod renderer_watchdog_tests {
         assert!(renderer_stale_log_should_capture_deep_diagnostic(
             true, "visible"
         ));
-        assert!(renderer_stale_log_should_capture_deep_diagnostic(
+        assert!(!renderer_stale_log_should_capture_deep_diagnostic(
             true, "hidden"
         ));
-        assert!(renderer_stale_log_should_capture_deep_diagnostic(
+        assert!(!renderer_stale_log_should_capture_deep_diagnostic(
             false, "visible"
         ));
         assert!(!renderer_stale_log_should_capture_deep_diagnostic(
@@ -1881,8 +1883,8 @@ mod renderer_watchdog_tests {
     #[test]
     fn truly_hidden_renderer_stale_skips_renderer_recovery() {
         assert!(renderer_stale_should_recover(true, "visible"));
-        assert!(renderer_stale_should_recover(true, "hidden"));
-        assert!(renderer_stale_should_recover(false, "visible"));
+        assert!(!renderer_stale_should_recover(true, "hidden"));
+        assert!(!renderer_stale_should_recover(false, "visible"));
         assert!(!renderer_stale_should_recover(false, "hidden"));
     }
 
@@ -1895,7 +1897,7 @@ mod renderer_watchdog_tests {
             RENDERER_HIDDEN_STALE_LOG_AFTER + Duration::from_secs(1),
             RENDERER_HIDDEN_RECOVERY_AFTER,
         ));
-        assert!(!renderer_gap_is_expected_hidden_throttle(
+        assert!(renderer_gap_is_expected_hidden_throttle(
             true,
             "hidden",
             Some(false),


### PR DESCRIPTION
(AI Generated).

## Summary
- Treat the renderer as foreground only when both the native window and document visibility are foreground.
- Classify visible native windows with hidden renderer heartbeats as hidden WebKit timer throttling instead of stale renderer failures.
- Update the desktop phase notes for the watchdog behavior.

## Validation
- cargo test renderer_watchdog_tests --manifest-path packages/desktop/src-tauri/Cargo.toml
- npm run validate:feature