### PR TITLE
fix: relay dev Google OAuth callback

### DIFF
--- a/docs/PHASE-4-SYNC.md
+++ b/docs/PHASE-4-SYNC.md
@@ -3,7 +3,7 @@
 > **Status:** 🚧 In Progress
 > **Dependencies:** Phase 1-2 (Capture layers ✓)
 >
-> Local relay, Google Drive cloud sync, desktop local snapshot rotation, "Sync Now" button, "Last synced" indicator, proxied Google token exchange for Freed Desktop, durable Google OAuth refresh, appDataFolder Drive polling, cloud sync health diagnostics, runtime-gated cloud backoff, and the no-cloud-sync launch banner are all working. Dropbox remains behind a coming-soon gate while its provider work is finished. iCloud sync is the remaining open item.
+> Local relay, Google Drive cloud sync, desktop local snapshot rotation, "Sync Now" button, "Last synced" indicator, proxied Google token exchange for Freed Desktop, durable Google OAuth refresh, a production callback relay for dev and preview PWA Google OAuth, appDataFolder Drive polling, cloud sync health diagnostics, runtime-gated cloud backoff, and the no-cloud-sync launch banner are all working. Dropbox remains behind a coming-soon gate while its provider work is finished. iCloud sync is the remaining open item.
 
 ---
 
@@ -289,7 +289,7 @@ Each provider stores a single Automerge binary file. CRDT handles merge conflict
 - [x] Desktop broadcasts doc changes to connected PWA clients via `broadcast_doc` Tauri command
 - [x] QR code or manual pairing connects PWA to Desktop (SyncConnectDialog with QR scanner)
 - [x] Sync connection status observable (`onStatusChange` listener in sync.ts)
-- [x] PWA falls back to cloud sync when away from home (Google Drive PKCE OAuth, Automerge merge-upload)
+- [x] PWA falls back to cloud sync when away from home (Google Drive PKCE OAuth, production callback relay for dev and preview app origins, Automerge merge-upload)
 - [x] Google Drive uses the server token proxy in Freed Desktop so the Google client secret stays out of the app bundle, watches appDataFolder changes, refreshes stored OAuth credentials before Drive or Contacts calls, and retries Contacts once after a 401 with a forced token refresh
 - [x] Google Drive startup downloads and uploads wait behind runtime health, memory pressure, and social-scrape gates, then retry with bounded backoff instead of repeatedly copying the Automerge document while the app is under pressure
 - [x] At least one cloud provider works: Google Drive is the active cloud sync provider while Dropbox remains disabled behind a coming-soon control

--- a/packages/pwa/src/components/OAuthCallback.tsx
+++ b/packages/pwa/src/components/OAuthCallback.tsx
@@ -18,6 +18,12 @@
 
 import { useEffect, useState } from "react";
 import { startCloudSync, storeCloudToken, type CloudProvider, type CloudTokenBundle } from "../lib/sync";
+import {
+  clearStoredGoogleOAuthRedirectUri,
+  createGoogleOAuthRelayTarget,
+  getOAuthCallbackUri,
+  getStoredGoogleOAuthRedirectUri,
+} from "../lib/oauth-redirect";
 
 const DROPBOX_TOKEN_ENDPOINT = "https://api.dropboxapi.com/oauth2/token";
 
@@ -25,19 +31,20 @@ const DROPBOX_TOKEN_ENDPOINT = "https://api.dropboxapi.com/oauth2/token";
 // (in SyncConnectDialog). The token exchange uses the server proxy at
 // /api/oauth/google, which holds the client_secret.
 const DROPBOX_CLIENT_ID = import.meta.env.VITE_DROPBOX_CLIENT_ID ?? "";
-const OAUTH_REDIRECT_URI = `${window.location.origin}/oauth-callback`;
+const OAUTH_REDIRECT_URI = getOAuthCallbackUri();
 
 type ExchangeResult =
   | { ok: true; token: CloudTokenBundle }
   | { ok: false; error: string };
 
 async function exchangeGDrive(code: string, verifier: string): Promise<ExchangeResult> {
+  const redirectUri = getStoredGoogleOAuthRedirectUri();
   // Token exchange is proxied server-side: Google requires a client_secret
   // even for PKCE, so we never expose it to the browser.
   const res = await fetch("/api/oauth/google", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ code, verifier, redirectUri: OAUTH_REDIRECT_URI }),
+    body: JSON.stringify({ code, verifier, redirectUri }),
   });
 
   const data = await res.json().catch(() => ({ error: "invalid JSON from proxy" }));
@@ -103,6 +110,12 @@ export function OAuthCallback() {
 
     const run = async () => {
       const params = new URLSearchParams(window.location.search);
+      const relayTarget = createGoogleOAuthRelayTarget(window.location.origin, params);
+      if (relayTarget) {
+        window.location.replace(relayTarget);
+        return;
+      }
+
       const code = params.get("code");
       const oauthError = params.get("error");
 
@@ -112,6 +125,7 @@ export function OAuthCallback() {
       // Clean up PKCE state immediately, single-use.
       sessionStorage.removeItem("freed_pkce_provider");
       sessionStorage.removeItem("freed_pkce_verifier");
+      clearStoredGoogleOAuthRedirectUri();
 
       if (oauthError) {
         if (!cancelled) {

--- a/packages/pwa/src/lib/cloud-oauth.ts
+++ b/packages/pwa/src/lib/cloud-oauth.ts
@@ -1,5 +1,10 @@
+import {
+  createGoogleOAuthState,
+  getGoogleOAuthRedirectUri,
+  storeGoogleOAuthRedirectUri,
+} from "./oauth-redirect";
+
 const GDRIVE_CLIENT_ID = import.meta.env.VITE_GDRIVE_CLIENT_ID ?? "";
-const OAUTH_REDIRECT_URI = `${window.location.origin}/oauth-callback`;
 
 function generateCodeVerifier(): string {
   const array = new Uint8Array(64);
@@ -22,12 +27,14 @@ async function generateCodeChallenge(verifier: string): Promise<string> {
 export async function initiateGDriveOAuth(): Promise<void> {
   const verifier = generateCodeVerifier();
   const challenge = await generateCodeChallenge(verifier);
+  const redirectUri = getGoogleOAuthRedirectUri();
   sessionStorage.setItem("freed_pkce_verifier", verifier);
   sessionStorage.setItem("freed_pkce_provider", "gdrive");
+  storeGoogleOAuthRedirectUri(redirectUri);
 
   const params = new URLSearchParams({
     client_id: GDRIVE_CLIENT_ID,
-    redirect_uri: OAUTH_REDIRECT_URI,
+    redirect_uri: redirectUri,
     response_type: "code",
     scope: "https://www.googleapis.com/auth/drive.appdata https://www.googleapis.com/auth/contacts.readonly",
     include_granted_scopes: "true",
@@ -35,6 +42,7 @@ export async function initiateGDriveOAuth(): Promise<void> {
     code_challenge_method: "S256",
     access_type: "offline",
     prompt: "consent",
+    state: createGoogleOAuthState(),
   });
 
   window.location.href = `https://accounts.google.com/o/oauth2/v2/auth?${params}`;

--- a/packages/pwa/src/lib/oauth-redirect.test.ts
+++ b/packages/pwa/src/lib/oauth-redirect.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  createGoogleOAuthRelayTarget,
+  createGoogleOAuthState,
+  getGoogleOAuthRedirectUri,
+  getOAuthCallbackUri,
+} from "./oauth-redirect";
+
+describe("OAuth redirect helpers", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("uses the production callback for dev Google OAuth", () => {
+    expect(getGoogleOAuthRedirectUri("https://dev-app.freed.wtf")).toBe(
+      "https://app.freed.wtf/oauth-callback",
+    );
+    expect(getGoogleOAuthRedirectUri("https://app.freed.wtf")).toBe(
+      "https://app.freed.wtf/oauth-callback",
+    );
+    expect(getGoogleOAuthRedirectUri("http://localhost:1421")).toBe(
+      "http://localhost:1421/oauth-callback",
+    );
+  });
+
+  it("relays a Google callback back to the original dev app origin", () => {
+    vi.setSystemTime(new Date("2026-05-31T18:00:00.000Z"));
+
+    const state = createGoogleOAuthState("https://dev-app.freed.wtf", "nonce");
+    const params = new URLSearchParams({
+      code: "auth-code",
+      state,
+      scope: "https://www.googleapis.com/auth/contacts.readonly",
+    });
+
+    expect(createGoogleOAuthRelayTarget("https://app.freed.wtf", params)).toBe(
+      "https://dev-app.freed.wtf/oauth-callback?code=auth-code&state=" +
+        encodeURIComponent(state) +
+        "&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fcontacts.readonly&oauth_relay=1",
+    );
+  });
+
+  it("does not relay to untrusted origins", () => {
+    const state = createGoogleOAuthState("https://dev-app.freed.wtf", "nonce");
+    const decoded = JSON.parse(atob(state));
+    decoded.returnOrigin = "https://attacker.example";
+    const hostileState = btoa(JSON.stringify(decoded)).replace(/\+/g, "-").replace(/\//g, "_");
+
+    expect(
+      createGoogleOAuthRelayTarget(
+        "https://app.freed.wtf",
+        new URLSearchParams({ code: "auth-code", state: hostileState }),
+      ),
+    ).toBeNull();
+  });
+
+  it("builds callback URLs from explicit origins", () => {
+    expect(getOAuthCallbackUri("https://preview-aubreyfs-projects.vercel.app")).toBe(
+      "https://preview-aubreyfs-projects.vercel.app/oauth-callback",
+    );
+  });
+});

--- a/packages/pwa/src/lib/oauth-redirect.ts
+++ b/packages/pwa/src/lib/oauth-redirect.ts
@@ -1,0 +1,143 @@
+const OAUTH_CALLBACK_PATH = "/oauth-callback";
+const GOOGLE_OAUTH_PROVIDER = "gdrive";
+const GOOGLE_OAUTH_STATE_VERSION = 1;
+const GOOGLE_OAUTH_RELAY_ORIGIN = "https://app.freed.wtf";
+
+const GOOGLE_REDIRECT_URI_STORAGE_KEY = "freed_pkce_google_redirect_uri";
+
+export interface GoogleOAuthState {
+  version: typeof GOOGLE_OAUTH_STATE_VERSION;
+  provider: typeof GOOGLE_OAUTH_PROVIDER;
+  returnOrigin: string;
+  redirectOrigin: string;
+  nonce: string;
+  issuedAt: number;
+}
+
+export function getOAuthCallbackUri(origin: string = window.location.origin): string {
+  return `${origin}${OAUTH_CALLBACK_PATH}`;
+}
+
+export function getGoogleOAuthRedirectUri(origin: string = window.location.origin): string {
+  return getOAuthCallbackUri(getGoogleOAuthRedirectOrigin(origin));
+}
+
+export function getStoredGoogleOAuthRedirectUri(): string {
+  return sessionStorage.getItem(GOOGLE_REDIRECT_URI_STORAGE_KEY) ?? getOAuthCallbackUri();
+}
+
+export function storeGoogleOAuthRedirectUri(redirectUri: string): void {
+  sessionStorage.setItem(GOOGLE_REDIRECT_URI_STORAGE_KEY, redirectUri);
+}
+
+export function clearStoredGoogleOAuthRedirectUri(): void {
+  sessionStorage.removeItem(GOOGLE_REDIRECT_URI_STORAGE_KEY);
+}
+
+export function createGoogleOAuthState(
+  origin: string = window.location.origin,
+  nonce: string = crypto.randomUUID(),
+): string {
+  const state: GoogleOAuthState = {
+    version: GOOGLE_OAUTH_STATE_VERSION,
+    provider: GOOGLE_OAUTH_PROVIDER,
+    returnOrigin: origin,
+    redirectOrigin: getGoogleOAuthRedirectOrigin(origin),
+    nonce,
+    issuedAt: Date.now(),
+  };
+
+  return toBase64Url(JSON.stringify(state));
+}
+
+export function createGoogleOAuthRelayTarget(
+  currentOrigin: string,
+  params: URLSearchParams,
+): string | null {
+  const state = parseGoogleOAuthState(params.get("state"));
+  if (!state || state.returnOrigin === currentOrigin) {
+    return null;
+  }
+
+  if (state.redirectOrigin !== currentOrigin || !isAllowedPwaOrigin(state.returnOrigin)) {
+    return null;
+  }
+
+  const target = new URL(getOAuthCallbackUri(state.returnOrigin));
+  for (const [key, value] of params.entries()) {
+    target.searchParams.append(key, value);
+  }
+  target.searchParams.set("oauth_relay", "1");
+  return target.toString();
+}
+
+function getGoogleOAuthRedirectOrigin(origin: string): string {
+  return shouldUseGoogleOAuthRelay(origin) ? GOOGLE_OAUTH_RELAY_ORIGIN : origin;
+}
+
+function parseGoogleOAuthState(value: string | null): GoogleOAuthState | null {
+  if (!value) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(fromBase64Url(value)) as Partial<GoogleOAuthState>;
+    if (
+      parsed.version !== GOOGLE_OAUTH_STATE_VERSION ||
+      parsed.provider !== GOOGLE_OAUTH_PROVIDER ||
+      typeof parsed.returnOrigin !== "string" ||
+      typeof parsed.redirectOrigin !== "string" ||
+      typeof parsed.nonce !== "string" ||
+      typeof parsed.issuedAt !== "number"
+    ) {
+      return null;
+    }
+    return parsed as GoogleOAuthState;
+  } catch {
+    return null;
+  }
+}
+
+function isAllowedPwaOrigin(origin: string): boolean {
+  try {
+    const url = new URL(origin);
+    return (
+      url.protocol === "https:" &&
+      (
+        url.hostname === "app.freed.wtf" ||
+        url.hostname === "dev-app.freed.wtf" ||
+        url.hostname.endsWith("-aubreyfs-projects.vercel.app")
+      )
+    );
+  } catch {
+    return false;
+  }
+}
+
+function shouldUseGoogleOAuthRelay(origin: string): boolean {
+  try {
+    const url = new URL(origin);
+    return (
+      url.protocol === "https:" &&
+      (
+        url.hostname === "dev-app.freed.wtf" ||
+        url.hostname.endsWith("-aubreyfs-projects.vercel.app")
+      )
+    );
+  } catch {
+    return false;
+  }
+}
+
+function toBase64Url(value: string): string {
+  return btoa(value)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
+}
+
+function fromBase64Url(value: string): string {
+  const normalized = value.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, "=");
+  return atob(padded);
+}

--- a/website/src/app/roadmap/RoadmapContent.tsx
+++ b/website/src/app/roadmap/RoadmapContent.tsx
@@ -728,7 +728,7 @@ const phases: Phase[] = [
     number: 4,
     title: "Sync Layer",
     description:
-      "Local relay and GDrive/Dropbox sync are working, with server-proxied Google token exchange, appDataFolder Drive polling, durable Google OAuth refresh, cloud health diagnostics, retry and reconnect actions, debug charts, the timed no-cloud-sync launch banner, and desktop snapshot restore. iCloud remains the open item.",
+      "Local relay and Google Drive sync are working, with server-proxied Google token exchange, dev and preview PWA callback relay, appDataFolder Drive polling, durable Google OAuth refresh, cloud health diagnostics, retry and reconnect actions, debug charts, the timed no-cloud-sync launch banner, and desktop snapshot restore. Dropbox remains gated while its provider work finishes, and iCloud remains the open item.",
     status: "current",
     planLink:
       "https://github.com/freed-project/freed/blob/dev/docs/PHASE-4-SYNC.md",


### PR DESCRIPTION
(AI Generated).

## Summary
- Route dev and preview PWA Google OAuth through the production callback, then relay the authorization response back to the originating app so Google does not reject dev-app.freed.wtf with redirect_uri_mismatch.

## Testing
- npm run validate:feature