### PR TITLE
fix: harden Facebook feed extraction

### DIFF
--- a/packages/desktop/src-tauri/src/fb-extract.js
+++ b/packages/desktop/src-tauri/src/fb-extract.js
@@ -24,6 +24,20 @@
     return value.trim();
   }
 
+  function elementHeight(node) {
+    if (!node) return 0;
+    var h = node.offsetHeight || 0;
+    if (h > 0) return h;
+    if (typeof node.getBoundingClientRect === "function") {
+      try {
+        h = node.getBoundingClientRect().height || 0;
+        if (h > 0) return h;
+      } catch (_) {}
+    }
+    var testHeight = parseInt(node.getAttribute && node.getAttribute("data-freed-test-height"), 10);
+    return isNaN(testHeight) ? 0 : testHeight;
+  }
+
   function parseEngagement(text) {
     if (!text) return null;
     var cleaned = text.replace(/[^0-9.KMkm]/g, "").trim();
@@ -200,16 +214,81 @@
   // a div that contains at least some text and/or images, and is a
   // reasonable height for a post.
 
+  function hasPostContent(node) {
+    var nodeText = textValue(node, 4000);
+    var hasScontent =
+      node.querySelector('img[src*="scontent"], img[src*="fbcdn"]') !== null;
+    var hasVideo = node.querySelector("video") !== null;
+    return nodeText.length > 40 || hasScontent || hasVideo;
+  }
+
+  function hasAuthorArea(node) {
+    return (
+      node.querySelector("h3 a, h4 a") !== null ||
+      node.querySelector('a[aria-label][role="link"]') !== null
+    );
+  }
+
+  function isLikelyPostElement(node, container) {
+    if (!node || node === container) return false;
+    var h = elementHeight(node);
+    var role = (node.getAttribute("role") || "").toLowerCase();
+    var pagelet = node.getAttribute("data-pagelet") || "";
+    var semanticPost =
+      role === "article" ||
+      /^FeedUnit/i.test(pagelet) ||
+      node.hasAttribute("aria-posinset");
+
+    if (!semanticPost && (h < 150 || h > 2000)) return false;
+    if (semanticPost && h > 0 && h > 2600) return false;
+    if (!hasPostContent(node)) return false;
+    return semanticPost || hasAuthorArea(node);
+  }
+
+  function uniquePostElements(elements) {
+    var unique = [];
+    for (var i = 0; i < elements.length; i++) {
+      var el = elements[i];
+      if (!el) continue;
+      var alreadyNested = false;
+      for (var j = 0; j < unique.length; j++) {
+        if (unique[j].contains(el) && unique[j] !== el) {
+          alreadyNested = true;
+          break;
+        }
+        if (el.contains(unique[j]) && unique[j] !== el) {
+          unique.splice(j, 1);
+          j--;
+        }
+      }
+      if (!alreadyNested) unique.push(el);
+    }
+    return unique;
+  }
+
   function findPostsInContainer(container) {
     var posts = [];
     var seen = new Set();
+
+    var semanticCandidates = container.querySelectorAll(
+      '[role="article"], div[data-pagelet^="FeedUnit"], div[aria-posinset]'
+    );
+    for (var s = 0; s < semanticCandidates.length && posts.length < 50; s++) {
+      if (isLikelyPostElement(semanticCandidates[s], container)) {
+        posts.push(semanticCandidates[s]);
+      }
+    }
+
+    if (posts.length > 0) {
+      return uniquePostElements(posts);
+    }
 
     // Recursive walker: find leaf-ish content blocks
     function walk(node, depth) {
       if (depth > 20 || posts.length > 50) return;
       if (!node || node.nodeType !== 1) return;
 
-      var h = node.offsetHeight;
+      var h = elementHeight(node);
       var children = node.children || [];
       var cc = children.length;
 
@@ -217,31 +296,14 @@
       // - Tall enough (> 150px) to be a real post, not a header
       // - Contain some text or images
       // - NOT be the entire feed container itself
-      if (h >= 150 && h <= 2000 && node !== container) {
+      if (isLikelyPostElement(node, container)) {
         var nodeText = textValue(node, 4000);
-        var hasScontent =
-          node.querySelector('img[src*="scontent"], img[src*="fbcdn"]') !==
-          null;
-        var hasVideo = node.querySelector("video") !== null;
-
-        // Post-like: has substantial text or media
-        if (nodeText.length > 40 || hasScontent || hasVideo) {
-          // Check if this is a profile/author link area (h3/h4 with name + text below)
-          var hasAuthorArea =
-            node.querySelector("h3 a, h4 a") !== null ||
-            node.querySelector('a[aria-label][role="link"]') !== null;
-
-          // Looks like a post if it has author-area + content,
-          // or if it has media + some text
-          if (hasAuthorArea || hasScontent || hasVideo) {
-            var id =
-              node.offsetTop + ":" + h + ":" + nodeText.length;
-            if (!seen.has(id)) {
-              seen.add(id);
-              posts.push(node);
-              return; // Don't recurse into found posts
-            }
-          }
+        var id =
+          node.offsetTop + ":" + h + ":" + nodeText.length;
+        if (!seen.has(id)) {
+          seen.add(id);
+          posts.push(node);
+          return; // Don't recurse into found posts
         }
       }
 
@@ -254,14 +316,7 @@
     walk(container, 0);
 
     // Deduplicate: remove elements that are children of other found posts
-    return posts.filter(function (p, i) {
-      for (var j = 0; j < posts.length; j++) {
-        if (i !== j && posts[j].contains(p) && posts[j] !== p) {
-          return false;
-        }
-      }
-      return true;
-    });
+    return uniquePostElements(posts);
   }
 
   // ── Extract author info ──────────────────────────────────────────────────
@@ -450,6 +505,7 @@
       var href = links[i].href || "";
       var m =
         href.match(/story_fbid=(\d+)/) ||
+        href.match(/\/groups\/[^/]+\/posts\/(\d+)/) ||
         href.match(/\/posts\/(\d+)/) ||
         href.match(/\/permalink\/(\d+)/) ||
         href.match(/(pfbid\w+)/);
@@ -527,11 +583,19 @@
     }
 
     var posts = [];
+    var rejected = {
+      suggestedOrSponsored: 0,
+      missingAuthor: 0,
+      missingContent: 0,
+    };
     for (var idx = 0; idx < postEls.length && posts.length < 50; idx++) {
       var el = postEls[idx];
       expandLongTextControls(el);
 
-      if (isSuggestedOrSponsored(el)) continue;
+      if (isSuggestedOrSponsored(el)) {
+        rejected.suggestedOrSponsored++;
+        continue;
+      }
 
       var author = extractAuthor(el);
       var text = extractText(el);
@@ -539,7 +603,10 @@
       var postRef = extractPostId(el);
       var group = extractGroup(el);
 
-      if (!author.name || !author.profileUrl) continue;
+      if (!author.name || !author.profileUrl) {
+        rejected.missingAuthor++;
+        continue;
+      }
 
       // Extract media
       var imgEls = el.querySelectorAll(
@@ -559,9 +626,12 @@
       var hasVideo = el.querySelector("video") !== null;
 
       // Must have SOME meaningful content
-      if (!text && mediaUrls.length === 0 && !hasVideo) continue;
+      if (!text && mediaUrls.length === 0 && !hasVideo) {
+        rejected.missingContent++;
+        continue;
+      }
 
-      var id = postRef.id || contentHash(author.name, text);
+      var id = postRef.id || contentHash(author.name, text || mediaUrls[0] || postRef.url);
 
       var reactionSpan = el.querySelector(
         'span[aria-label*="reaction"], span[aria-label*=" people"]'
@@ -611,9 +681,11 @@
       posts: posts,
       extractedAt: Date.now(),
       url: window.location.href,
+      strategy: strategy,
       candidateCount: postEls.length,
       scrollY: window.scrollY,
       feedContainerFound: !!feedContainer,
+      rejected: rejected,
     });
   } catch (err) {
     emit("fb-feed-data", {

--- a/packages/desktop/src/lib/fb-capture.ts
+++ b/packages/desktop/src/lib/fb-capture.ts
@@ -170,12 +170,30 @@ export async function fetchFbFeed(): Promise<FbSyncResult> {
 
     // Listen for every extraction pass. The native scraper emits multiple
     // batches while it scrolls through the virtualized feed.
-    unlisten = await listen<{ posts: RawFbPost[]; error?: string; extractedAt: number; url: string; strategy?: string; candidateCount?: number }>(
+    unlisten = await listen<{
+      posts: RawFbPost[];
+      error?: string;
+      extractedAt: number;
+      url: string;
+      strategy?: string;
+      candidateCount?: number;
+      rejected?: {
+        suggestedOrSponsored?: number;
+        missingAuthor?: number;
+        missingContent?: number;
+      };
+    }>(
       "fb-feed-data",
       (event) => {
-        const { posts, error, strategy, candidateCount } = event.payload;
+        const { posts, error, strategy, candidateCount, rejected } = event.payload;
 
-        addDebugEvent("change", `[FB] extraction: strategy=${strategy ?? "?"}, candidates=${candidateCount ?? "?"}, posts=${posts.length}`);
+        const rejectionSummary = rejected
+          ? `, rejected={sponsored:${(rejected.suggestedOrSponsored ?? 0).toLocaleString()}, author:${(rejected.missingAuthor ?? 0).toLocaleString()}, content:${(rejected.missingContent ?? 0).toLocaleString()}}`
+          : "";
+        addDebugEvent(
+          "change",
+          `[FB] extraction: strategy=${strategy ?? "?"}, candidates=${candidateCount ?? "?"}, posts=${posts.length.toLocaleString()}${rejectionSummary}`,
+        );
 
         if (error) {
           addDebugEvent("error", `[FB] extraction error: ${error}`);
@@ -228,6 +246,10 @@ export async function fetchFbFeed(): Promise<FbSyncResult> {
 
     const items = deduplicateFeedItems(normalized);
     diag.itemsDeduplicated = items.length;
+    addDebugEvent(
+      "change",
+      `[FB] normalization: raw=${allRawPosts.length.toLocaleString()}, normalized=${normalized.length.toLocaleString()}, deduplicated=${items.length.toLocaleString()}`,
+    );
 
     return { items, diag };
   } catch (err) {
@@ -354,11 +376,15 @@ export async function captureFbFeed(): Promise<FbSyncResult> {
       const excludedGroupIds =
         useAppStore.getState().preferences.fbCapture?.excludedGroupIds ?? {};
       const filteredItems = filterExcludedGroups(result.items, excludedGroupIds);
+      const beforeState = useAppStore.getState();
+      const beforeFacebookItems = beforeState.items.filter((i) => i.platform === "facebook");
+      const beforeFacebookIds = new Set(beforeFacebookItems.map((item) => item.globalId));
+      const existingCandidateCount = filteredItems.filter((item) => beforeFacebookIds.has(item.globalId)).length;
       addDebugEvent(
         "change",
-        `[FB] writing ${filteredItems.length.toLocaleString()} candidate item${filteredItems.length === 1 ? "" : "s"} to the library`,
+        `[FB] writing ${filteredItems.length.toLocaleString()} candidate item${filteredItems.length === 1 ? "" : "s"} to the library (${existingCandidateCount.toLocaleString()} already present)`,
       );
-      const before = store.items.filter((i) => i.platform === "facebook").length;
+      const before = beforeFacebookItems.length;
       await store.addItems(filteredItems);
       const after = useAppStore
         .getState()

--- a/packages/desktop/src/lib/fb-extract-dom.test.ts
+++ b/packages/desktop/src/lib/fb-extract-dom.test.ts
@@ -1,0 +1,69 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { JSDOM } from "jsdom";
+import { describe, expect, it } from "vitest";
+
+const script = readFileSync(
+  resolve(process.cwd(), "src-tauri/src/fb-extract.js"),
+  "utf8",
+);
+
+function runExtractor(html: string) {
+  const dom = new JSDOM(html, {
+    url: "https://www.facebook.com/",
+    runScripts: "outside-only",
+  });
+  const payloads: Array<{ name: string; data: Record<string, unknown> }> = [];
+  Object.defineProperty(dom.window, "__TAURI__", {
+    value: {
+      event: {
+        emit(name: string, data: Record<string, unknown>) {
+          payloads.push({ name, data });
+        },
+      },
+    },
+  });
+
+  dom.window.eval(script);
+  return payloads.find((payload) => payload.name === "fb-feed-data")?.data;
+}
+
+describe("Facebook DOM extractor", () => {
+  it("extracts modern role article feed units without relying on the Feed posts heading", () => {
+    const payload = runExtractor(`
+      <div role="main">
+        <div role="article">
+          <h3><a href="https://www.facebook.com/alice.example">Alice Example</a></h3>
+          <a href="https://www.facebook.com/groups/my-group/posts/123456789">1 h</a>
+          <div dir="auto">This is a real Facebook post with enough text to clear the content heuristic.</div>
+        </div>
+      </div>
+    `);
+
+    expect(payload?.strategy).toBe("role-main-fallback");
+    expect(payload?.candidateCount).toBe(1);
+    expect(payload?.posts).toEqual([
+      expect.objectContaining({
+        id: "123456789",
+        authorName: "Alice Example",
+        authorProfileUrl: "https://www.facebook.com/alice.example",
+        text: "This is a real Facebook post with enough text to clear the content heuristic.",
+      }),
+    ]);
+  });
+
+  it("reports author rejections when Facebook renders non-post chrome as candidates", () => {
+    const payload = runExtractor(`
+      <div role="main">
+        <div role="article">
+          <h3><a href="https://www.facebook.com/bookmarks">Your shortcuts</a></h3>
+          <div dir="auto">This chrome block is tall and text-heavy, but it is not a real post.</div>
+        </div>
+      </div>
+    `);
+
+    expect(payload?.candidateCount).toBe(1);
+    expect(payload?.posts).toEqual([]);
+    expect(payload?.rejected).toMatchObject({ missingAuthor: 1 });
+  });
+});


### PR DESCRIPTION
(AI Generated).

## Summary
- Recognize current Facebook article and feed-unit containers instead of relying on the old Feed posts heading path.
- Emit Facebook extraction strategy, rejection counts, normalization counts, and existing-item counts for zero-added syncs.
- Preserve group post IDs and use media URLs as a fallback for image-heavy Facebook posts.

## Testing
- cd packages/desktop && npm run test:unit -- src/lib/fb-extract-dom.test.ts src/lib/facebook-normalize.test.ts src/lib/social-capture-memory-pressure.test.ts
- npm run validate:feature