### PR TITLE
fix: allow promotion website build config

### DIFF
--- a/scripts/release-promotion-shared.mjs
+++ b/scripts/release-promotion-shared.mjs
@@ -29,6 +29,10 @@ export const FORBIDDEN_MAIN_PR_PREFIXES = [
   "website/",
 ];
 
+export const PROMOTION_WEBSITE_CONFIG_FILES = [
+  "website/next.config.ts",
+];
+
 export const PROMOTION_BRANCH_PATTERN = /^chore\/promote-dev-to-main(?:-[a-z0-9._-]+)?$/;
 
 function runGit(args, { cwd } = {}) {
@@ -67,6 +71,10 @@ export function isReleaseOnlyFile(filePath) {
 }
 
 export function isPromotionScopeFile(filePath) {
+  if (PROMOTION_WEBSITE_CONFIG_FILES.includes(filePath)) {
+    return true;
+  }
+
   return PROMOTION_SCOPE_PATHS.some((scopePath) => (
     filePath === scopePath || filePath.startsWith(`${scopePath}/`)
   ));
@@ -81,12 +89,21 @@ export function listChangedFiles({ fromRef, toRef, cwd, pathspec = [] }) {
 }
 
 export function listPromotionDiffFiles({ fromRef, toRef, cwd }) {
-  return listChangedFiles({
+  const promotionScopeFiles = listChangedFiles({
     fromRef,
     toRef,
     cwd,
     pathspec: PROMOTION_SCOPE_PATHS,
-  }).filter((filePath) => !isReleaseOnlyFile(filePath));
+  });
+  const websiteConfigFiles = listChangedFiles({
+    fromRef,
+    toRef,
+    cwd,
+    pathspec: PROMOTION_WEBSITE_CONFIG_FILES,
+  });
+
+  return uniqueSorted([...promotionScopeFiles, ...websiteConfigFiles])
+    .filter((filePath) => !isReleaseOnlyFile(filePath));
 }
 
 export function listComparisonFiles({ baseRef, headRef, cwd }) {
@@ -139,7 +156,8 @@ export function listMainBackflowDiffFiles({ devRef, mainRef, cwd }) {
 
 export function listForbiddenMainPrFiles(files) {
   return files.filter((filePath) => (
-    FORBIDDEN_MAIN_PR_PREFIXES.some((prefix) => filePath.startsWith(prefix))
+    !PROMOTION_WEBSITE_CONFIG_FILES.includes(filePath)
+    && FORBIDDEN_MAIN_PR_PREFIXES.some((prefix) => filePath.startsWith(prefix))
   ));
 }
 

--- a/scripts/release-promotion.test.mjs
+++ b/scripts/release-promotion.test.mjs
@@ -50,6 +50,7 @@ function makeTempRepo() {
   writeRepoFile(cwd, "packages/desktop/src-tauri/tauri.conf.json", "{\n  \"version\": \"0.0.0\"\n}\n");
   writeRepoFile(cwd, "scripts/release.sh", "#!/usr/bin/env bash\n");
   writeRepoFile(cwd, "docs/PHASE-1-FOUNDATION.md", "# Phase 1\n");
+  writeRepoFile(cwd, "website/next.config.ts", "export default {};\n");
   writeRepoFile(cwd, "release-notes/releases/v0.0.0.json", "{\n  \"approved\": true\n}\n");
   commitAll(cwd, "initial");
 
@@ -179,6 +180,31 @@ test("validate-main-pr passes for a fresh promotion branch", (t) => {
   git(cwd, ["checkout", "dev"]);
   writeRepoFile(cwd, "packages/pwa/src/app.ts", "export const value = 'dev';\n");
   commitAll(cwd, "dev change");
+  updateOriginRef(cwd, "dev");
+
+  git(cwd, ["checkout", "-b", "chore/promote-dev-to-main-20260421", "main"]);
+  git(cwd, ["merge", "--squash", "--no-commit", "dev"]);
+  git(cwd, ["commit", "-m", "chore: promote dev into main for production release"]);
+
+  const result = runNode(VALIDATE_MAIN_PR, [
+    `--cwd=${cwd}`,
+    "--base-ref=origin/main",
+    "--head-ref=HEAD",
+    "--head-branch=chore/promote-dev-to-main-20260421",
+  ]);
+
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /Promotion branch matches origin\/dev/);
+});
+
+test("validate-main-pr allows website build config in promotion branches", (t) => {
+  const cwd = makeTempRepo();
+  t.after(() => rmSync(cwd, { recursive: true, force: true }));
+
+  git(cwd, ["checkout", "dev"]);
+  writeRepoFile(cwd, "packages/pwa/src/app.ts", "export const value = 'dev';\n");
+  writeRepoFile(cwd, "website/next.config.ts", "export default { transpilePackages: ['@freed/shared'] };\n");
+  commitAll(cwd, "dev build config");
   updateOriginRef(cwd, "dev");
 
   git(cwd, ["checkout", "-b", "chore/promote-dev-to-main-20260421", "main"]);


### PR DESCRIPTION
(AI Generated).

## Summary
- Allow promotion PRs to include the website Next config when it is part of the exact dev snapshot being promoted.
- Keep other website-owned files blocked from main PRs.

## Testing
- node --test scripts/release-promotion.test.mjs
- npm run validate:feature