### PR TITLE
fix: flag unusable Facebook sync results

### DIFF
--- a/packages/desktop/src/lib/fb-capture.ts
+++ b/packages/desktop/src/lib/fb-capture.ts
@@ -243,6 +243,13 @@ export async function fetchFbFeed(): Promise<FbSyncResult> {
   try {
     const normalized = fbPostsToFeedItems(allRawPosts);
     diag.itemsNormalized = normalized.length;
+    if (normalized.length === 0) {
+      diag.errorStage = "normalize";
+      diag.errorMessage =
+        `Extracted ${allRawPosts.length.toLocaleString()} Facebook post` +
+        `${allRawPosts.length === 1 ? "" : "s"}, but none passed normalization.`;
+      return { items: [], diag };
+    }
 
     const items = deduplicateFeedItems(normalized);
     diag.itemsDeduplicated = items.length;

--- a/packages/desktop/src/lib/provider-status-transient.test.ts
+++ b/packages/desktop/src/lib/provider-status-transient.test.ts
@@ -76,4 +76,31 @@ describe("provider status transient failures", () => {
       }),
     ).toBe(currentMessage);
   });
+
+  it("keeps empty social syncs out of the healthy connected state", () => {
+    const emptySnapshot = snapshot({
+      status: "healthy",
+      lastOutcome: "empty",
+      currentMessage: "No posts pulled",
+    });
+
+    expect(
+      getProviderStatusTone({
+        isConnected: true,
+        snapshot: emptySnapshot,
+      }),
+    ).toBe("warning");
+    expect(
+      getProviderStatusLabel({
+        isConnected: true,
+        snapshot: emptySnapshot,
+      }),
+    ).toBe("No posts pulled");
+    expect(
+      getProviderStatusDetail({
+        isConnected: true,
+        snapshot: emptySnapshot,
+      }),
+    ).toBe("No posts pulled");
+  });
 });

--- a/packages/desktop/src/lib/social-capture-memory-pressure.test.ts
+++ b/packages/desktop/src/lib/social-capture-memory-pressure.test.ts
@@ -4,18 +4,6 @@ const mocks = vi.hoisted(() => ({
   invoke: vi.fn(),
   listen: vi.fn(),
   prepareSocialScrapeMemory: vi.fn(),
-}));
-
-vi.mock("@tauri-apps/api/core", () => ({
-  invoke: mocks.invoke,
-  isTauri: () => true,
-}));
-
-vi.mock("@tauri-apps/api/event", () => ({
-  listen: mocks.listen,
-}));
-
-vi.mock("@freed/capture-facebook/browser", () => ({
   fbPostsToFeedItems: vi.fn((posts: Array<{ id?: string }>) =>
     posts.map((post, index) => ({
       globalId: post.id ?? `post-${index}`,
@@ -28,6 +16,19 @@ vi.mock("@freed/capture-facebook/browser", () => ({
       topics: [],
     })),
   ),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: mocks.invoke,
+  isTauri: () => true,
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: mocks.listen,
+}));
+
+vi.mock("@freed/capture-facebook/browser", () => ({
+  fbPostsToFeedItems: mocks.fbPostsToFeedItems,
   deduplicateFeedItems: vi.fn((items: unknown[]) => items),
 }));
 
@@ -70,6 +71,19 @@ beforeEach(() => {
   vi.resetModules();
   mocks.invoke.mockReset();
   mocks.listen.mockReset();
+  mocks.fbPostsToFeedItems.mockClear();
+  mocks.fbPostsToFeedItems.mockImplementation((posts: Array<{ id?: string }>) =>
+    posts.map((post, index) => ({
+      globalId: post.id ?? `post-${index}`,
+      platform: "facebook",
+      content: { text: "post", mediaUrls: [], mediaTypes: [] },
+      author: { displayName: "Facebook" },
+      createdAt: Date.now(),
+      savedAt: Date.now(),
+      tags: [],
+      topics: [],
+    })),
+  );
   mocks.prepareSocialScrapeMemory.mockReset();
   mocks.prepareSocialScrapeMemory.mockResolvedValue({
     before: {},
@@ -124,6 +138,47 @@ describe("social capture completion", () => {
     expect(result.diag.errorStage).toBeNull();
     expect(result.diag.postsExtracted).toBe(2);
     expect(result.items).toHaveLength(2);
+  });
+
+  it("treats extracted Facebook posts that normalize to zero items as a sync failure", async () => {
+    const listeners = new Map<string, (event: { payload: unknown }) => void>();
+    mocks.prepareSocialScrapeMemory.mockResolvedValue({
+      before: {},
+      after: { appResidentBytes: 512 * 1024 * 1024 },
+      recycledScraperWindows: false,
+      cacheTrimmed: false,
+      mayProceed: true,
+    });
+    mocks.fbPostsToFeedItems.mockReturnValue([]);
+    mocks.listen.mockImplementation(async (eventName: string, callback: (event: { payload: unknown }) => void) => {
+      listeners.set(eventName, callback);
+      return vi.fn();
+    });
+    mocks.invoke.mockImplementation(async (command: string) => {
+      if (command !== "fb_scrape_feed") return null;
+
+      listeners.get("fb-feed-data")?.({
+        payload: {
+          posts: [{ id: "raw-post", authorName: "Raw", text: "Rejected" }],
+          extractedAt: Date.now(),
+          url: "https://www.facebook.com/",
+          strategy: "test",
+          candidateCount: 1,
+        },
+      });
+      return null;
+    });
+
+    const { fetchFbFeed } = await import("./fb-capture");
+    const result = await fetchFbFeed();
+
+    expect(result.items).toEqual([]);
+    expect(result.diag.postsExtracted).toBe(1);
+    expect(result.diag.itemsNormalized).toBe(0);
+    expect(result.diag.errorStage).toBe("normalize");
+    expect(result.diag.errorMessage).toBe(
+      "Extracted 1 Facebook post, but none passed normalization.",
+    );
   });
 });
 

--- a/packages/ui/src/lib/provider-status.ts
+++ b/packages/ui/src/lib/provider-status.ts
@@ -20,10 +20,6 @@ export function getHealthStatusLabel(snapshot?: ProviderHealthSnapshot | null): 
     return "Paused";
   }
 
-  if (snapshot.status === "healthy") {
-    return "Healthy";
-  }
-
   if (snapshot.lastOutcome === "cooldown") {
     return "Cooling down";
   }
@@ -34,6 +30,10 @@ export function getHealthStatusLabel(snapshot?: ProviderHealthSnapshot | null): 
 
   if (snapshot.lastOutcome === "empty") {
     return "No posts pulled";
+  }
+
+  if (snapshot.status === "healthy") {
+    return "Healthy";
   }
 
   if (snapshot.status === "degraded") {
@@ -84,6 +84,7 @@ export function getProviderStatusTone({
   if (
     snapshot?.status === "paused" ||
     snapshot?.status === "degraded" ||
+    snapshot?.lastOutcome === "empty" ||
     snapshot?.lastOutcome === "provider_rate_limit" ||
     (!!usableAuthError && !hasAuthLikeIssue(usableAuthError))
   ) {


### PR DESCRIPTION
(AI Generated).

## Summary
- Treat Facebook scrapes that extract raw posts but normalize to zero usable items as sync failures instead of healthy empty runs.
- Show empty provider health as a warning state instead of a green connected badge.

## Testing
- cd packages/desktop && npm run test:unit -- src/lib/social-capture-memory-pressure.test.ts src/lib/provider-status-transient.test.ts src/lib/fb-extract-dom.test.ts src/lib/facebook-normalize.test.ts
- npm run validate:feature