### PR TITLE
fix: pace RSS retries under pressure

### DIFF
--- a/packages/desktop/src/lib/automerge.worker.ts
+++ b/packages/desktop/src/lib/automerge.worker.ts
@@ -1191,6 +1191,10 @@ async function handleRequest(
             const stored = doc.rssFeeds[feed.url] as RssFeed | undefined;
             if (!stored) continue;
             if (feed.lastFetched !== undefined) stored.lastFetched = feed.lastFetched;
+            if (feed.lastFetchAttemptedAt !== undefined) stored.lastFetchAttemptedAt = feed.lastFetchAttemptedAt;
+            if (feed.nextFetchAfter !== undefined) stored.nextFetchAfter = feed.nextFetchAfter;
+            if (feed.consecutiveFailures !== undefined) stored.consecutiveFailures = feed.consecutiveFailures;
+            if (feed.lastFetchError !== undefined) stored.lastFetchError = feed.lastFetchError;
             if (feed.title && feed.title !== "Untitled Feed" && feed.title !== feed.url) {
               if (stored.title === "Untitled Feed" || stored.title === stored.url) {
                 stored.title = feed.title;

--- a/packages/desktop/src/lib/capture.ts
+++ b/packages/desktop/src/lib/capture.ts
@@ -102,6 +102,37 @@ export async function addRssFeed(feedUrl: string): Promise<void> {
 
 /** Max concurrent feed fetches — avoids saturating Tauri's HTTP layer. */
 const FETCH_CONCURRENCY = 5;
+const RSS_FAILURE_RETRY_BASE_MS = 2 * 60 * 60 * 1000;
+const RSS_FAILURE_RETRY_MAX_MS = 24 * 60 * 60 * 1000;
+
+function nextFailedFeedRetryMs(feed: RssFeed): number {
+  const failureCount = Math.max(0, feed.consecutiveFailures ?? 0);
+  return Math.min(
+    RSS_FAILURE_RETRY_MAX_MS,
+    RSS_FAILURE_RETRY_BASE_MS * Math.pow(2, Math.min(failureCount, 4)),
+  );
+}
+
+function markFeedFetchSucceeded(feed: RssFeed, now: number): RssFeed {
+  return {
+    ...feed,
+    lastFetched: now,
+    lastFetchAttemptedAt: now,
+    nextFetchAfter: 0,
+    consecutiveFailures: 0,
+    lastFetchError: "",
+  };
+}
+
+function markFeedFetchFailed(feed: RssFeed, message: string, now: number): RssFeed {
+  return {
+    ...feed,
+    lastFetchAttemptedAt: now,
+    nextFetchAfter: now + nextFailedFeedRetryMs(feed),
+    consecutiveFailures: (feed.consecutiveFailures ?? 0) + 1,
+    lastFetchError: message.slice(0, 500),
+  };
+}
 
 async function refreshEnabledRssFeeds(
   store: ReturnType<typeof useAppStore.getState>,
@@ -112,6 +143,7 @@ async function refreshEnabledRssFeeds(
     await withProviderSyncing("rss", async () => {
       const allNewItems: FeedItem[] = [];
       const fetchedFeeds: RssFeed[] = [];
+      const feedUpdates: RssFeed[] = [];
       const feedErrors: string[] = [];
       const rssStartedAt = Date.now();
       const rssBefore = store.items.filter(
@@ -145,8 +177,7 @@ async function refreshEnabledRssFeeds(
 
             return {
               feed: {
-                ...feed,
-                lastFetched: Date.now(),
+                ...markFeedFetchSucceeded(feed, Date.now()),
                 ...(healedTitle ? { title: healedTitle } : {}),
                 ...(!feed.siteUrl && liveSiteUrl
                   ? { siteUrl: liveSiteUrl }
@@ -160,6 +191,7 @@ async function refreshEnabledRssFeeds(
         for (const [resultIndex, result] of results.entries()) {
           if (result.status === "fulfilled") {
             fetchedFeeds.push(result.value.feed);
+            feedUpdates.push(result.value.feed);
             allNewItems.push(...result.value.items);
             rssSeen += result.value.items.length;
             await recordProviderHealthEvent({
@@ -186,6 +218,7 @@ async function refreshEnabledRssFeeds(
             addDebugEvent("error", `[RSS] feed fetch failed: ${msg}`);
             const failedFeed = batch[resultIndex];
             if (failedFeed) {
+              feedUpdates.push(markFeedFetchFailed(failedFeed, msg, Date.now()));
               await recordProviderHealthEvent({
                 provider: "rss",
                 scope: "rss_feed",
@@ -202,8 +235,8 @@ async function refreshEnabledRssFeeds(
         }
       }
 
-      if (fetchedFeeds.length > 0 || allNewItems.length > 0) {
-        await docBatchRefreshFeeds(fetchedFeeds, allNewItems);
+      if (feedUpdates.length > 0 || allNewItems.length > 0) {
+        await docBatchRefreshFeeds(feedUpdates, allNewItems);
       }
       const rssAfter = useAppStore
         .getState()

--- a/packages/desktop/src/lib/rss-poller.test.ts
+++ b/packages/desktop/src/lib/rss-poller.test.ts
@@ -40,7 +40,7 @@ describe("rss poller", () => {
     vi.useRealTimers();
   });
 
-  it("retries a deferred startup poll before the normal interval", async () => {
+  it("backs off a deferred startup poll before the normal interval", async () => {
     const deferredError = { reason: "waiting_for_renderer_heartbeat:1" };
     runBackgroundJob
       .mockRejectedValueOnce(deferredError)
@@ -64,7 +64,7 @@ describe("rss poller", () => {
       staleAfterMs: 2 * 60 * 60 * 1000,
     });
 
-    await vi.advanceTimersByTimeAsync(14_999);
+    await vi.advanceTimersByTimeAsync(59_999);
     expect(runBackgroundJob).toHaveBeenCalledTimes(1);
 
     await vi.advanceTimersByTimeAsync(1);
@@ -72,6 +72,10 @@ describe("rss poller", () => {
     expect(addDebugEvent).toHaveBeenCalledWith(
       "change",
       "[RSS] poll deferred: waiting_for_renderer_heartbeat:1",
+    );
+    expect(addDebugEvent).toHaveBeenCalledWith(
+      "change",
+      "[RSS] poll retry scheduled in 60s after waiting_for_renderer_heartbeat:1",
     );
 
     poller.stopRssPoller();
@@ -85,8 +89,59 @@ describe("rss poller", () => {
     await vi.runAllTicks();
 
     poller.stopRssPoller();
-    await vi.advanceTimersByTimeAsync(15_000);
+    await vi.advanceTimersByTimeAsync(120_000);
 
     expect(runBackgroundJob).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the runtime cooldown when it is longer than the base retry", async () => {
+    runBackgroundJob
+      .mockRejectedValueOnce({ reason: "cooldown:120,000" })
+      .mockResolvedValueOnce(undefined);
+
+    const poller = await loadPoller();
+    poller.startRssPoller(30 * 60 * 1000);
+    await vi.runAllTicks();
+
+    await vi.advanceTimersByTimeAsync(119_999);
+    expect(runBackgroundJob).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(runBackgroundJob).toHaveBeenCalledTimes(2);
+    expect(addDebugEvent).toHaveBeenCalledWith(
+      "change",
+      "[RSS] poll retry scheduled in 120s after cooldown:120,000",
+    );
+
+    poller.stopRssPoller();
+  });
+
+  it("doubles repeated deferred retries up to the cap", async () => {
+    runBackgroundJob
+      .mockRejectedValueOnce({ reason: "high_memory_pressure" })
+      .mockRejectedValueOnce({ reason: "high_memory_pressure" })
+      .mockResolvedValueOnce(undefined);
+
+    const poller = await loadPoller();
+    poller.startRssPoller(30 * 60 * 1000);
+    await vi.runAllTicks();
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(runBackgroundJob).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(119_999);
+    expect(runBackgroundJob).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(runBackgroundJob).toHaveBeenCalledTimes(3);
+    expect(addDebugEvent).toHaveBeenCalledWith(
+      "change",
+      "[RSS] poll retry scheduled in 60s after high_memory_pressure",
+    );
+    expect(addDebugEvent).toHaveBeenCalledWith(
+      "change",
+      "[RSS] poll retry scheduled in 120s after high_memory_pressure",
+    );
+
+    poller.stopRssPoller();
   });
 });

--- a/packages/desktop/src/lib/rss-poller.ts
+++ b/packages/desktop/src/lib/rss-poller.ts
@@ -18,7 +18,8 @@ import {
 
 /** Default poll interval: 30 minutes */
 const DEFAULT_INTERVAL_MS = 30 * 60 * 1000;
-const DEFERRED_RETRY_MS = 15_000;
+const DEFERRED_RETRY_BASE_MS = 60_000;
+const DEFERRED_RETRY_MAX_MS = 30 * 60_000;
 const SCHEDULED_REFRESH_OPTIONS = {
   maxFeeds: SCHEDULED_RSS_MAX_FEEDS,
   staleAfterMs: SCHEDULED_RSS_STALE_AFTER_MS,
@@ -27,20 +28,46 @@ const SCHEDULED_REFRESH_OPTIONS = {
 let pollIntervalId: ReturnType<typeof setInterval> | null = null;
 let retryTimeoutId: ReturnType<typeof setTimeout> | null = null;
 let isPolling = false;
+let deferredRetryCount = 0;
 
 function clearDeferredRetry(): void {
   if (retryTimeoutId !== null) {
     clearTimeout(retryTimeoutId);
     retryTimeoutId = null;
   }
+  deferredRetryCount = 0;
 }
 
-function scheduleDeferredRetry(): void {
+function parseCooldownRetryMs(reason: string): number | null {
+  const match = reason.match(/^cooldown:([\d,]+)$/);
+  if (!match) return null;
+
+  const value = Number.parseInt(match[1].replaceAll(",", ""), 10);
+  return Number.isFinite(value) && value > 0 ? value : null;
+}
+
+function nextDeferredRetryMs(reason: string): number {
+  const exponentialMs =
+    DEFERRED_RETRY_BASE_MS * Math.pow(2, Math.min(deferredRetryCount, 8));
+  const cooldownMs = parseCooldownRetryMs(reason) ?? 0;
+  return Math.min(
+    DEFERRED_RETRY_MAX_MS,
+    Math.max(DEFERRED_RETRY_BASE_MS, exponentialMs, cooldownMs),
+  );
+}
+
+function scheduleDeferredRetry(reason: string): void {
   if (retryTimeoutId !== null) return;
+  const retryMs = nextDeferredRetryMs(reason);
+  deferredRetryCount += 1;
+  addDebugEvent(
+    "change",
+    `[RSS] poll retry scheduled in ${Math.round(retryMs / 1000).toLocaleString()}s after ${reason}`,
+  );
   retryTimeoutId = setTimeout(() => {
     retryTimeoutId = null;
     void triggerPoll();
-  }, DEFERRED_RETRY_MS);
+  }, retryMs);
 }
 
 /**
@@ -91,9 +118,10 @@ async function triggerPoll(): Promise<void> {
   } catch (err) {
     if (isBackgroundRuntimeDeferredError(err)) {
       addDebugEvent("change", `[RSS] poll deferred: ${err.reason}`);
-      scheduleDeferredRetry();
+      scheduleDeferredRetry(err.reason);
       return;
     }
+    clearDeferredRetry();
     const msg = err instanceof Error ? err.message : String(err);
     console.error("[RssPoller] Error during poll:", err);
     addDebugEvent("error", `[RSS] poller crashed: ${msg}`);

--- a/packages/desktop/src/lib/rss-refresh-plan.test.ts
+++ b/packages/desktop/src/lib/rss-refresh-plan.test.ts
@@ -71,4 +71,21 @@ describe("rss refresh plan", () => {
       "https://second.example/feed",
     ]);
   });
+
+  it("skips feeds whose retry window is still closed", () => {
+    const now = 10 * SCHEDULED_RSS_STALE_AFTER_MS;
+    const eligible = feed("https://eligible.example/feed", 100);
+    const delayed = {
+      ...feed("https://delayed.example/feed", 100),
+      nextFetchAfter: now + 1,
+    };
+
+    expect(
+      selectRssFeedsForRefresh([delayed, eligible], {
+        staleAfterMs: 1,
+        maxFeeds: SCHEDULED_RSS_MAX_FEEDS,
+        now,
+      }).map((entry) => entry.url),
+    ).toEqual(["https://eligible.example/feed"]);
+  });
 });

--- a/packages/desktop/src/lib/rss-refresh-plan.ts
+++ b/packages/desktop/src/lib/rss-refresh-plan.ts
@@ -15,6 +15,14 @@ function lastFetchedAt(feed: RssFeed): number {
     : 0;
 }
 
+function isRetryWindowOpen(feed: RssFeed, now: number): boolean {
+  return (
+    typeof feed.nextFetchAfter !== "number" ||
+    !Number.isFinite(feed.nextFetchAfter) ||
+    feed.nextFetchAfter <= now
+  );
+}
+
 function compareFeedsForRefresh(left: RssFeed, right: RssFeed): number {
   return (
     lastFetchedAt(left) - lastFetchedAt(right) ||
@@ -30,13 +38,14 @@ export function selectRssFeedsForRefresh(
   const enabled = feeds.filter((feed) => feed.enabled);
   const maxFeeds = options.maxFeeds ?? enabled.length;
   if (maxFeeds <= 0) return [];
+  const now = options.now ?? Date.now();
+  const eligible = enabled.filter((feed) => isRetryWindowOpen(feed, now));
 
   if (options.staleAfterMs === undefined) {
-    return enabled.slice().sort(compareFeedsForRefresh).slice(0, maxFeeds);
+    return eligible.slice().sort(compareFeedsForRefresh).slice(0, maxFeeds);
   }
 
-  const now = options.now ?? Date.now();
-  const due = enabled.filter((feed) => {
+  const due = eligible.filter((feed) => {
     const fetchedAt = lastFetchedAt(feed);
     return fetchedAt === 0 || now - fetchedAt >= options.staleAfterMs!;
   });

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -652,6 +652,18 @@ export interface RssFeed {
   /** Last successful fetch timestamp */
   lastFetched?: number;
 
+  /** Last fetch attempt timestamp, including failed attempts */
+  lastFetchAttemptedAt?: number;
+
+  /** Earliest timestamp for the next scheduled retry after a failed fetch */
+  nextFetchAfter?: number;
+
+  /** Consecutive fetch failure count used to pace scheduled retries */
+  consecutiveFailures?: number;
+
+  /** Last fetch error, used for diagnostics only */
+  lastFetchError?: string;
+
   /** ETag for conditional GET */
   etag?: string;
 


### PR DESCRIPTION
(AI Generated).

## Summary
- Paces scheduled RSS retries when the runtime defers background work.
- Records failed-feed retry windows so broken RSS sources stop being retried on every scheduled pass.

## Testing
- npm run validate:feature