### PR TITLE
fix: surface Facebook DOM diagnostics

### DIFF
--- a/packages/desktop/src/lib/fb-capture.ts
+++ b/packages/desktop/src/lib/fb-capture.ts
@@ -231,9 +231,18 @@ export async function fetchFbFeed(): Promise<FbSyncResult> {
 
     // Listen for diagnostics (fires before extraction)
     unlistenDiag = await listen("fb-diag", (diagEvent) => {
-      const diag = diagEvent.payload as Record<string, unknown>;
-      addDebugEvent("change", `[FB] DOM diag: feedUnits=${diag.feedUnits}, fallback=${diag.feedUnitsFallback}, feed=${diag.feedContainer}, h4s=${diag.h4Count}, bodyLen=${diag.bodyLen}, url=${diag.url}, tauriEmit=${diag.hasTauriEmit}`);
-      console.log("[FB] DOM diagnostics:", diag);
+      const payload = diagEvent.payload as Record<string, unknown>;
+      const url = typeof payload.url === "string" ? payload.url : "?";
+      const title = typeof payload.title === "string" ? payload.title : "?";
+      const scrollHeight =
+        typeof payload.scrollHeight === "number"
+          ? payload.scrollHeight.toLocaleString()
+          : "?";
+      addDebugEvent(
+        "change",
+        `[FB] DOM diag: title="${title}", scrollHeight=${scrollHeight}, url=${url}`,
+      );
+      console.log("[FB] DOM diagnostics:", payload);
     });
 
     // Listen for every extraction pass. The native scraper emits multiple

--- a/packages/desktop/src/lib/social-capture-memory-pressure.test.ts
+++ b/packages/desktop/src/lib/social-capture-memory-pressure.test.ts
@@ -111,6 +111,13 @@ describe("social capture completion", () => {
     mocks.invoke.mockImplementation(async (command: string) => {
       if (command !== "fb_scrape_feed") return null;
 
+      listeners.get("fb-diag")?.({
+        payload: {
+          title: "Facebook",
+          scrollHeight: 12_345,
+          url: "https://www.facebook.com/",
+        },
+      });
       listeners.get("fb-feed-data")?.({
         payload: {
           posts: [{ id: "post-one", authorName: "One", text: "First" }],
@@ -133,11 +140,16 @@ describe("social capture completion", () => {
     });
 
     const { fetchFbFeed } = await import("./fb-capture");
+    const { addDebugEvent } = await import("@freed/ui/lib/debug-store");
     const result = await fetchFbFeed();
 
     expect(result.diag.errorStage).toBeNull();
     expect(result.diag.postsExtracted).toBe(2);
     expect(result.items).toHaveLength(2);
+    expect(addDebugEvent).toHaveBeenCalledWith(
+      "change",
+      '[FB] DOM diag: title="Facebook", scrollHeight=12,345, url=https://www.facebook.com/',
+    );
   });
 
   it("treats extracted Facebook posts that normalize to zero items as a sync failure", async () => {


### PR DESCRIPTION
(AI Generated).

## Summary
- Log the Facebook DOM diagnostic fields that the native scraper actually emits
- Cover the diagnostic log line in the Facebook sync unit test

## Validation
- npm run test:unit -- src/lib/social-capture-memory-pressure.test.ts src/lib/facebook-normalize.test.ts src/lib/fb-extract-dom.test.ts
- npm run validate:feature