### PR TITLE
fix: reject Facebook story chrome

### DIFF
--- a/packages/desktop/src-tauri/src/fb-stories-extract.js
+++ b/packages/desktop/src-tauri/src/fb-stories-extract.js
@@ -23,6 +23,124 @@
         }
       : function () {};
 
+  var FACEBOOK_UI_LABELS = new Set([
+    "account",
+    "ads manager",
+    "create new account",
+    "events",
+    "facebook",
+    "feeds",
+    "friends",
+    "gaming",
+    "groups",
+    "home",
+    "log in",
+    "marketplace",
+    "memories",
+    "menu",
+    "messenger",
+    "meta",
+    "notifications",
+    "pages",
+    "profile",
+    "reels",
+    "saved",
+    "search facebook",
+    "see less",
+    "see more",
+    "sign up",
+    "video",
+    "watch",
+    "your shortcuts",
+  ]);
+
+  var FACEBOOK_BLOCKED_PATHS = new Set([
+    "ads",
+    "bookmarks",
+    "events",
+    "friends",
+    "gaming",
+    "groups",
+    "help",
+    "home",
+    "login",
+    "marketplace",
+    "me",
+    "memories",
+    "messages",
+    "notifications",
+    "pages",
+    "privacy",
+    "recover",
+    "reg",
+    "reel",
+    "reels",
+    "saved",
+    "settings",
+    "stories",
+    "watch",
+  ]);
+
+  function normalizeLabel(value) {
+    return (value || "")
+      .normalize("NFKD")
+      .replace(/[\u0300-\u036f]/g, "")
+      .replace(/\s+/g, " ")
+      .trim()
+      .toLowerCase();
+  }
+
+  function isFacebookUiChromeLabel(value) {
+    var normalized = normalizeLabel(value);
+    if (!normalized) return true;
+    if (FACEBOOK_UI_LABELS.has(normalized)) return true;
+    if (/^(create|log in|sign up|search|switch|manage)\b/.test(normalized)) return true;
+    if (/\b(shortcuts|notifications|messenger|marketplace)\b/.test(normalized)) return true;
+    return false;
+  }
+
+  function isUsableFacebookAuthorProfileUrl(value) {
+    if (!value) return false;
+    try {
+      var url = new URL(value, "https://www.facebook.com/");
+      var host = url.hostname.toLowerCase();
+      if (host !== "facebook.com" && !host.endsWith(".facebook.com")) return false;
+
+      var parts = url.pathname.split("/").filter(Boolean);
+      var first = parts[0] ? parts[0].toLowerCase() : "";
+      if (!first || FACEBOOK_BLOCKED_PATHS.has(first)) return false;
+
+      if (first === "profile.php") {
+        return /^\d+$/.test(url.searchParams.get("id") || "");
+      }
+
+      return /^[a-z0-9][a-z0-9._-]{1,79}$/i.test(parts[0]);
+    } catch (_) {
+      return false;
+    }
+  }
+
+  function isValidFacebookAuthor(name, profileUrl) {
+    return !isFacebookUiChromeLabel(name) && isUsableFacebookAuthorProfileUrl(profileUrl);
+  }
+
+  function emitStorySkip(reason, rejected) {
+    emit("fb-feed-data", {
+      posts: [],
+      extractedAt: Date.now(),
+      url: window.location.href,
+      strategy: "story-viewer-skip",
+      candidateCount: 0,
+      scrollY: 0,
+      feedContainerFound: false,
+      rejected: rejected || {
+        suggestedOrSponsored: 0,
+        missingAuthor: reason === "missing-author" ? 1 : 0,
+        missingContent: reason === "missing-content" ? 1 : 0,
+      },
+    });
+  }
+
   // ── Extract story ID from current URL ────────────────────────────────────
 
   function extractStoryId() {
@@ -65,7 +183,7 @@
       return ancestor;
     }
 
-    return document.body;
+    return null;
   }
 
   // ── Extract author ────────────────────────────────────────────────────────
@@ -221,10 +339,24 @@
   try {
     var rawStoryId = extractStoryId();
     var container = findStoryContainer();
+    if (!container) {
+      emitStorySkip("missing-content");
+      return;
+    }
     var author = extractAuthor(container);
     var media = extractMedia(container);
     var timestampIso = extractTimestamp(container);
     var location = extractLocation(container);
+
+    if (!isValidFacebookAuthor(author.name, author.profileUrl)) {
+      emitStorySkip("missing-author");
+      return;
+    }
+
+    if (media.urls.length === 0 && !media.isVideo) {
+      emitStorySkip("missing-content");
+      return;
+    }
 
     var storyId = rawStoryId
       ? "fbstory_" + rawStoryId

--- a/packages/desktop/src/lib/fb-capture.ts
+++ b/packages/desktop/src/lib/fb-capture.ts
@@ -65,6 +65,18 @@ export interface FbSyncDiag {
   itemsNormalized: number;
   itemsDeduplicated: number;
   itemsAdded: number;
+  extractionPasses: number;
+  lastExtractionStrategy: string | null;
+  lastCandidateCount: number | null;
+  lastRejected:
+    | {
+        suggestedOrSponsored?: number;
+        missingAuthor?: number;
+        missingContent?: number;
+      }
+    | null;
+  lastScrollY: number | null;
+  feedContainerFound: boolean | null;
   errorStage: string | null;
   errorMessage: string | null;
 }
@@ -141,6 +153,34 @@ function formatFacebookNormalizationSummary(
   );
 }
 
+function formatFacebookEmptySyncMessage(diag: FbSyncDiag): string {
+  const details: string[] = [];
+
+  if (diag.extractionPasses > 0) {
+    details.push(
+      `${diag.extractionPasses.toLocaleString()} extraction pass${diag.extractionPasses === 1 ? "" : "es"}`,
+    );
+  }
+  if (diag.lastExtractionStrategy) {
+    details.push(`last strategy ${diag.lastExtractionStrategy}`);
+  }
+  if (typeof diag.lastCandidateCount === "number") {
+    details.push(
+      `${diag.lastCandidateCount.toLocaleString()} candidate${diag.lastCandidateCount === 1 ? "" : "s"} on the last pass`,
+    );
+  }
+  if (typeof diag.lastScrollY === "number") {
+    details.push(`scrollY ${diag.lastScrollY.toLocaleString()}`);
+  }
+  if (typeof diag.feedContainerFound === "boolean") {
+    details.push(`feed container ${diag.feedContainerFound ? "found" : "not found"}`);
+  }
+
+  return details.length > 0
+    ? `${socialProviderCopy("facebook").feedReturnedEmpty} ${details.join(", ")}.`
+    : socialProviderCopy("facebook").feedReturnedEmpty;
+}
+
 function filterExcludedGroups(
   items: FeedItem[],
   excludedGroupIds: Record<string, true>,
@@ -208,6 +248,12 @@ export async function fetchFbFeed(): Promise<FbSyncResult> {
     itemsNormalized: 0,
     itemsDeduplicated: 0,
     itemsAdded: 0,
+    extractionPasses: 0,
+    lastExtractionStrategy: null,
+    lastCandidateCount: null,
+    lastRejected: null,
+    lastScrollY: null,
+    feedContainerFound: null,
     errorStage: null,
     errorMessage: null,
   };
@@ -259,17 +305,39 @@ export async function fetchFbFeed(): Promise<FbSyncResult> {
         missingAuthor?: number;
         missingContent?: number;
       };
+      scrollY?: number;
+      feedContainerFound?: boolean;
     }>(
       "fb-feed-data",
       (event) => {
-        const { posts, error, strategy, candidateCount, rejected } = event.payload;
+        const {
+          posts,
+          error,
+          strategy,
+          candidateCount,
+          rejected,
+          scrollY,
+          feedContainerFound,
+        } = event.payload;
+        diag.extractionPasses++;
+        diag.lastExtractionStrategy = strategy ?? null;
+        diag.lastCandidateCount = typeof candidateCount === "number" ? candidateCount : null;
+        diag.lastRejected = rejected ?? null;
+        diag.lastScrollY = typeof scrollY === "number" ? scrollY : null;
+        diag.feedContainerFound = typeof feedContainerFound === "boolean" ? feedContainerFound : null;
 
         const rejectionSummary = rejected
           ? `, rejected={sponsored:${(rejected.suggestedOrSponsored ?? 0).toLocaleString()}, author:${(rejected.missingAuthor ?? 0).toLocaleString()}, content:${(rejected.missingContent ?? 0).toLocaleString()}}`
           : "";
+        const scrollSummary =
+          typeof scrollY === "number" ? `, scrollY=${scrollY.toLocaleString()}` : "";
+        const feedSummary =
+          typeof feedContainerFound === "boolean"
+            ? `, feedContainer=${feedContainerFound ? "y" : "n"}`
+            : "";
         addDebugEvent(
           "change",
-          `[FB] extraction: strategy=${strategy ?? "?"}, candidates=${candidateCount ?? "?"}, posts=${posts.length.toLocaleString()}${rejectionSummary}`,
+          `[FB] extraction: strategy=${strategy ?? "?"}, candidates=${candidateCount?.toLocaleString() ?? "?"}, posts=${posts.length.toLocaleString()}${rejectionSummary}${scrollSummary}${feedSummary}`,
         );
 
         if (error) {
@@ -393,6 +461,12 @@ export async function captureFbFeed(): Promise<FbSyncResult> {
         itemsNormalized: 0,
         itemsDeduplicated: 0,
         itemsAdded: 0,
+        extractionPasses: 0,
+        lastExtractionStrategy: null,
+        lastCandidateCount: null,
+        lastRejected: null,
+        lastScrollY: null,
+        feedContainerFound: null,
         errorStage: "provider_rate_limit",
         errorMessage: providerPause.pauseReason,
       },
@@ -422,6 +496,12 @@ export async function captureFbFeed(): Promise<FbSyncResult> {
         itemsNormalized: 0,
         itemsDeduplicated: 0,
         itemsAdded: 0,
+        extractionPasses: 0,
+        lastExtractionStrategy: null,
+        lastCandidateCount: null,
+        lastRejected: null,
+        lastScrollY: null,
+        feedContainerFound: null,
         errorStage: "cooldown",
         errorMessage: `Cooling down. Try again in ~${minutesRemaining} minutes.`,
       },
@@ -494,7 +574,26 @@ export async function captureFbFeed(): Promise<FbSyncResult> {
         `[FB] synced: ${result.diag.postsExtracted.toLocaleString()} posts extracted, ${result.diag.itemsAdded.toLocaleString()} new items`,
       );
     } else {
-      addDebugEvent("change", "[FB] sync complete: feed returned 0 posts");
+      const emptyMessage = formatFacebookEmptySyncMessage(result.diag);
+      addDebugEvent("change", `[FB] sync complete: ${emptyMessage}`);
+      store.setError(emptyMessage);
+      const emptyState = {
+        ...useAppStore.getState().fbAuth,
+        lastCaptureError: emptyMessage,
+      };
+      store.setFbAuth(emptyState);
+      storeFbAuthState(emptyState);
+      await recordProviderHealthEvent({
+        provider: "facebook",
+        outcome: "empty",
+        stage: "empty",
+        reason: emptyMessage,
+        startedAt,
+        finishedAt: Date.now(),
+        itemsSeen: result.diag.postsExtracted,
+        itemsAdded: result.diag.itemsAdded,
+      });
+      return result;
     }
 
     // Persist success timestamp so the sync dropdown shows "Synced X ago"

--- a/packages/desktop/src/lib/fb-stories-extract.test.ts
+++ b/packages/desktop/src/lib/fb-stories-extract.test.ts
@@ -1,0 +1,128 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { beforeEach, describe, expect, it } from "vitest";
+
+const script = readFileSync(
+  resolve(process.cwd(), "src-tauri/src/fb-stories-extract.js"),
+  "utf8",
+);
+
+function setReadonlyNumber(target: object, key: string, value: number) {
+  Object.defineProperty(target, key, {
+    configurable: true,
+    value,
+  });
+}
+
+function installTauriCapture<T>() {
+  const payloads: T[] = [];
+  (
+    window as unknown as {
+      __TAURI__: { event: { emit: (_name: string, payload: unknown) => void } };
+    }
+  ).__TAURI__ = {
+    event: {
+      emit: (_name, payload) => {
+        payloads.push(payload as T);
+      },
+    },
+  };
+  return payloads;
+}
+
+describe("fb-stories-extract.js", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    window.history.replaceState({}, "", "/");
+  });
+
+  it("does not emit create-account chrome as a Facebook story", () => {
+    document.body.innerHTML = `
+      <main>
+        <div role="dialog">
+          <h3><a href="https://www.facebook.com/reg/">Create new account</a></h3>
+        </div>
+      </main>
+    `;
+
+    const dialog = document.querySelector('[role="dialog"]') as HTMLElement;
+    setReadonlyNumber(dialog, "offsetHeight", 800);
+
+    const payloads = installTauriCapture<Array<{ posts: unknown[]; strategy: string }>[number]>();
+
+    window.eval(script);
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0].strategy).toBe("story-viewer-skip");
+    expect(payloads[0].posts).toEqual([]);
+    expect(payloads[0]).toMatchObject({
+      rejected: { missingAuthor: 1 },
+    });
+  });
+
+  it("does not emit a story when no story viewer exists", () => {
+    document.body.innerHTML = `
+      <main>
+        <div role="article">
+          <h3><a href="https://www.facebook.com/alice.example">Alice Example</a></h3>
+          <img src="https://scontent.example/feed-card.jpg" alt="feed post" />
+        </div>
+      </main>
+    `;
+
+    const image = document.querySelector("img") as HTMLImageElement;
+    setReadonlyNumber(image, "width", 1080);
+    setReadonlyNumber(image, "height", 1350);
+
+    const payloads = installTauriCapture<Array<{ posts: unknown[]; strategy: string }>[number]>();
+
+    window.eval(script);
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0].strategy).toBe("story-viewer-skip");
+    expect(payloads[0].posts).toEqual([]);
+  });
+
+  it("extracts a real Facebook story with valid author and media", () => {
+    window.history.replaceState({}, "", "/stories/alice.example/FRAME123/");
+    document.body.innerHTML = `
+      <div role="dialog">
+        <h3><a href="https://www.facebook.com/alice.example">Alice Example</a></h3>
+        <img src="https://cdn.example/avatar.jpg" alt="avatar" />
+        <img src="https://scontent.example/story-frame.jpg" alt="story" />
+        <time datetime="2026-03-23T12:00:00.000Z"></time>
+      </div>
+    `;
+
+    const dialog = document.querySelector('[role="dialog"]') as HTMLElement;
+    const images = Array.from(document.querySelectorAll("img")) as HTMLImageElement[];
+    setReadonlyNumber(dialog, "offsetHeight", 800);
+    setReadonlyNumber(images[0], "width", 40);
+    setReadonlyNumber(images[0], "height", 40);
+    setReadonlyNumber(images[1], "width", 1080);
+    setReadonlyNumber(images[1], "height", 1920);
+
+    const payloads = installTauriCapture<Array<{
+      posts: Array<{
+        authorName: string;
+        authorProfileUrl: string;
+        mediaUrls: string[];
+        postType: string;
+        strategy: string;
+      }>;
+      strategy?: string;
+    }>[number]>();
+
+    window.eval(script);
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0].posts).toHaveLength(1);
+    expect(payloads[0].posts[0]).toMatchObject({
+      authorName: "Alice Example",
+      authorProfileUrl: "https://www.facebook.com/alice.example",
+      mediaUrls: ["https://scontent.example/story-frame.jpg"],
+      postType: "story",
+      strategy: "story-viewer",
+    });
+  });
+});

--- a/packages/desktop/src/lib/social-capture-memory-pressure.test.ts
+++ b/packages/desktop/src/lib/social-capture-memory-pressure.test.ts
@@ -1,22 +1,82 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const mocks = vi.hoisted(() => ({
-  invoke: vi.fn(),
-  listen: vi.fn(),
-  prepareSocialScrapeMemory: vi.fn(),
-  fbPostsToFeedItems: vi.fn((posts: Array<{ id?: string }>) =>
-    posts.map((post, index) => ({
-      globalId: post.id ?? `post-${index}`,
-      platform: "facebook",
-      content: { text: "post", mediaUrls: [], mediaTypes: [] },
-      author: { displayName: "Facebook" },
-      createdAt: Date.now(),
-      savedAt: Date.now(),
-      tags: [],
-      topics: [],
-    })),
-  ),
-}));
+const mocks = vi.hoisted(() => {
+  const storeState = {
+    items: [] as Array<{ platform: string; globalId?: string }>,
+    preferences: {},
+    fbAuth: { isAuthenticated: true, lastCapturedAt: 123_456 },
+    igAuth: { isAuthenticated: true, lastCapturedAt: 123_456 },
+    liAuth: { isAuthenticated: true, lastCapturedAt: 123_456 },
+    setLoading: vi.fn(),
+    setError: vi.fn(),
+    setFbAuth: vi.fn(
+      (next: {
+        isAuthenticated?: boolean;
+        lastCapturedAt?: number;
+        lastCaptureError?: string;
+      }) => {
+        storeState.fbAuth = { ...storeState.fbAuth, ...next };
+      },
+    ),
+    setIgAuth: vi.fn(
+      (next: {
+        isAuthenticated?: boolean;
+        lastCapturedAt?: number;
+        lastCaptureError?: string;
+      }) => {
+        storeState.igAuth = { ...storeState.igAuth, ...next };
+      },
+    ),
+    setLiAuth: vi.fn(
+      (next: {
+        isAuthenticated?: boolean;
+        lastCapturedAt?: number;
+        lastCaptureError?: string;
+      }) => {
+        storeState.liAuth = { ...storeState.liAuth, ...next };
+      },
+    ),
+    addItems: vi.fn(async (items: Array<{ platform: string; globalId?: string }>) => {
+      storeState.items.push(...items);
+    }),
+    updatePreferences: vi.fn(async (next: Record<string, unknown>) => {
+      storeState.preferences = { ...storeState.preferences, ...next };
+    }),
+  };
+
+  return {
+    invoke: vi.fn(),
+    listen: vi.fn(),
+    prepareSocialScrapeMemory: vi.fn(),
+    storeState,
+    resetStoreState: () => {
+      storeState.items = [];
+      storeState.preferences = {};
+      storeState.fbAuth = { isAuthenticated: true, lastCapturedAt: 123_456 };
+      storeState.igAuth = { isAuthenticated: true, lastCapturedAt: 123_456 };
+      storeState.liAuth = { isAuthenticated: true, lastCapturedAt: 123_456 };
+      storeState.setLoading.mockClear();
+      storeState.setError.mockClear();
+      storeState.setFbAuth.mockClear();
+      storeState.setIgAuth.mockClear();
+      storeState.setLiAuth.mockClear();
+      storeState.addItems.mockClear();
+      storeState.updatePreferences.mockClear();
+    },
+    fbPostsToFeedItems: vi.fn((posts: Array<{ id?: string }>) =>
+      posts.map((post, index) => ({
+        globalId: post.id ?? `post-${index}`,
+        platform: "facebook",
+        content: { text: "post", mediaUrls: [], mediaTypes: [] },
+        author: { displayName: "Facebook" },
+        createdAt: Date.now(),
+        savedAt: Date.now(),
+        tags: [],
+        topics: [],
+      })),
+    ),
+  };
+});
 
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: mocks.invoke,
@@ -43,10 +103,7 @@ vi.mock("./memory-monitor", () => ({
 
 vi.mock("./store", () => ({
   useAppStore: {
-    getState: () => ({
-      addFeedItems: vi.fn(),
-      preferences: {},
-    }),
+    getState: () => mocks.storeState,
   },
 }));
 
@@ -69,6 +126,7 @@ vi.mock("./media-vault", () => ({
 
 beforeEach(() => {
   vi.resetModules();
+  mocks.resetStoreState();
   mocks.invoke.mockReset();
   mocks.listen.mockReset();
   mocks.fbPostsToFeedItems.mockClear();
@@ -104,10 +162,15 @@ describe("social capture completion", () => {
       cacheTrimmed: false,
       mayProceed: true,
     });
-    mocks.listen.mockImplementation(async (eventName: string, callback: (event: { payload: unknown }) => void) => {
-      listeners.set(eventName, callback);
-      return vi.fn();
-    });
+    mocks.listen.mockImplementation(
+      async (
+        eventName: string,
+        callback: (event: { payload: unknown }) => void,
+      ) => {
+        listeners.set(eventName, callback);
+        return vi.fn();
+      },
+    );
     mocks.invoke.mockImplementation(async (command: string) => {
       if (command !== "fb_scrape_feed") return null;
 
@@ -191,6 +254,70 @@ describe("social capture completion", () => {
     expect(result.diag.errorMessage).toBe(
       "Extracted 1 Facebook post, but none passed normalization. accepted=0, missingId=0, invalidAuthor=1, unexpected=0, firstRejected=invalidAuthor(id:y,url:n,author:y,profile:n,text:8,media:0)",
     );
+  });
+
+  it("does not mark an empty Facebook feed scrape as a successful account sync", async () => {
+    const listeners = new Map<string, (event: { payload: unknown }) => void>();
+    mocks.prepareSocialScrapeMemory.mockResolvedValue({
+      before: {},
+      after: { appResidentBytes: 512 * 1024 * 1024 },
+      recycledScraperWindows: false,
+      cacheTrimmed: false,
+      mayProceed: true,
+    });
+    mocks.listen.mockImplementation(async (eventName: string, callback: (event: { payload: unknown }) => void) => {
+      listeners.set(eventName, callback);
+      return vi.fn();
+    });
+    mocks.invoke.mockImplementation(async (command: string) => {
+      if (command !== "fb_scrape_feed") return null;
+
+      listeners.get("fb-feed-data")?.({
+        payload: {
+          posts: [],
+          extractedAt: Date.now(),
+          url: "https://www.facebook.com/",
+          strategy: "feed-pass",
+          candidateCount: 0,
+          scrollY: 135,
+          feedContainerFound: false,
+        },
+      });
+      return null;
+    });
+
+    const { captureFbFeed } = await import("./fb-capture");
+    const { recordProviderHealthEvent } = await import("./provider-health");
+    const { storeFbAuthState } = await import("./fb-auth");
+
+    const result = await captureFbFeed();
+    const expectedMessage =
+      "Feed returned no posts. Facebook may need a moment to load. " +
+      "1 extraction pass, last strategy feed-pass, 0 candidates on the last pass, " +
+      "scrollY 135, feed container not found.";
+
+    expect(result.items).toEqual([]);
+    expect(mocks.storeState.setError).toHaveBeenCalledWith(expectedMessage);
+    expect(mocks.storeState.setFbAuth).toHaveBeenCalledWith({
+      isAuthenticated: true,
+      lastCapturedAt: 123_456,
+      lastCaptureError: expectedMessage,
+    });
+    expect(storeFbAuthState).toHaveBeenCalledWith({
+      isAuthenticated: true,
+      lastCapturedAt: 123_456,
+      lastCaptureError: expectedMessage,
+    });
+    expect(recordProviderHealthEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "facebook",
+        outcome: "empty",
+        stage: "empty",
+        itemsSeen: 0,
+        itemsAdded: 0,
+      }),
+    );
+    expect(mocks.storeState.fbAuth.lastCapturedAt).toBe(123_456);
   });
 });
 


### PR DESCRIPTION
(AI Generated).

## Summary
- Reject Facebook story viewer chrome like Create new account before it can count as a synced post.
- Preserve empty Facebook syncs as visible empty failures with extraction-pass diagnostics instead of clearing the account error.
- Add regression coverage for story chrome skips, no-story fallback skips, real story extraction, and empty sync auth state.

## Testing
- npm run test:unit -- src/lib/fb-stories-extract.test.ts src/lib/fb-extract-dom.test.ts src/lib/facebook-normalize.test.ts src/lib/social-capture-memory-pressure.test.ts
- npm run validate:feature