### PR TITLE
fix: improve Facebook extraction startup headroom

### DIFF
--- a/packages/desktop/src-tauri/src/fb-extract.js
+++ b/packages/desktop/src-tauri/src/fb-extract.js
@@ -229,6 +229,27 @@
     );
   }
 
+  function hasTimestampCue(node) {
+    if (node.querySelector("time[datetime], abbr[data-utime]")) return true;
+    var links = node.querySelectorAll("a[href], a[aria-label]");
+    for (var i = 0; i < Math.min(links.length, 20); i++) {
+      var text = (
+        links[i].textContent ||
+        links[i].getAttribute("aria-label") ||
+        ""
+      ).trim();
+      if (
+        /^\d+\s*[hms]$/i.test(text) ||
+        /^\d+\s*(hour|minute|second|day|week|month)s?\s*ago$/i.test(text) ||
+        /^(yesterday|today|just now)$/i.test(text) ||
+        /^(january|february|march|april|may|june|july|august|september|october|november|december)\s+\d/i.test(text)
+      ) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   function isLikelyPostElement(node, container) {
     if (!node || node === container) return false;
     var h = elementHeight(node);
@@ -238,11 +259,12 @@
       role === "article" ||
       /^FeedUnit/i.test(pagelet) ||
       node.hasAttribute("aria-posinset");
+    var structurallyPost = semanticPost || (hasAuthorArea(node) && hasTimestampCue(node));
 
-    if (!semanticPost && (h < 150 || h > 2000)) return false;
-    if (semanticPost && h > 0 && h > 2600) return false;
+    if (!structurallyPost && (h < 150 || h > 2000)) return false;
+    if (structurallyPost && h > 0 && h > 2600) return false;
     if (!hasPostContent(node)) return false;
-    return semanticPost || hasAuthorArea(node);
+    return structurallyPost;
   }
 
   function uniquePostElements(elements) {

--- a/packages/desktop/src/lib/fb-extract-dom.test.ts
+++ b/packages/desktop/src/lib/fb-extract-dom.test.ts
@@ -66,4 +66,31 @@ describe("Facebook DOM extractor", () => {
     expect(payload?.posts).toEqual([]);
     expect(payload?.rejected).toMatchObject({ missingAuthor: 1 });
   });
+
+  it("extracts post blocks without role article or measurable height", () => {
+    const payload = runExtractor(`
+      <div role="main">
+        <section>
+          <div>
+            <div>
+              <h3><a href="https://www.facebook.com/bob.example">Bob Example</a></h3>
+              <a href="https://www.facebook.com/bob.example/posts/987654321">2 h</a>
+              <div dir="auto">Facebook sometimes hides useful feed structure from automation, but this plain block is still a real post.</div>
+            </div>
+          </div>
+        </section>
+      </div>
+    `);
+
+    expect(payload?.strategy).toBe("role-main-fallback");
+    expect(payload?.candidateCount).toBe(1);
+    expect(payload?.posts).toEqual([
+      expect.objectContaining({
+        id: "987654321",
+        authorName: "Bob Example",
+        authorProfileUrl: "https://www.facebook.com/bob.example",
+        text: "Facebook sometimes hides useful feed structure from automation, but this plain block is still a real post.",
+      }),
+    ]);
+  });
 });

--- a/packages/desktop/src/lib/rss-poller.test.ts
+++ b/packages/desktop/src/lib/rss-poller.test.ts
@@ -40,6 +40,40 @@ describe("rss poller", () => {
     vi.useRealTimers();
   });
 
+  it("delays the startup poll so launch stays responsive", async () => {
+    runBackgroundJob.mockResolvedValueOnce(undefined);
+
+    const poller = await loadPoller();
+    poller.startRssPoller(30 * 60 * 1000);
+    await vi.runAllTicks();
+
+    expect(runBackgroundJob).not.toHaveBeenCalled();
+    expect(addDebugEvent).toHaveBeenCalledWith(
+      "change",
+      "[RSS] startup poll scheduled in 300s",
+    );
+
+    await vi.advanceTimersByTimeAsync(5 * 60 * 1000 - 1);
+    expect(runBackgroundJob).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(runBackgroundJob).toHaveBeenCalledTimes(1);
+
+    poller.stopRssPoller();
+  });
+
+  it("still supports an immediate startup poll when requested", async () => {
+    runBackgroundJob.mockResolvedValueOnce(undefined);
+
+    const poller = await loadPoller();
+    poller.startRssPoller(30 * 60 * 1000, { startupDelayMs: 0 });
+    await vi.runAllTicks();
+
+    expect(runBackgroundJob).toHaveBeenCalledTimes(1);
+
+    poller.stopRssPoller();
+  });
+
   it("backs off a deferred startup poll before the normal interval", async () => {
     const deferredError = { reason: "waiting_for_renderer_heartbeat:1" };
     runBackgroundJob
@@ -47,7 +81,7 @@ describe("rss poller", () => {
       .mockResolvedValueOnce(undefined);
 
     const poller = await loadPoller();
-    poller.startRssPoller(30 * 60 * 1000);
+    poller.startRssPoller(30 * 60 * 1000, { startupDelayMs: 0 });
 
     await vi.runAllTicks();
     expect(runBackgroundJob).toHaveBeenCalledTimes(1);
@@ -85,7 +119,7 @@ describe("rss poller", () => {
     runBackgroundJob.mockRejectedValueOnce({ reason: "cooldown:120000" });
 
     const poller = await loadPoller();
-    poller.startRssPoller(30 * 60 * 1000);
+    poller.startRssPoller(30 * 60 * 1000, { startupDelayMs: 0 });
     await vi.runAllTicks();
 
     poller.stopRssPoller();
@@ -100,7 +134,7 @@ describe("rss poller", () => {
       .mockResolvedValueOnce(undefined);
 
     const poller = await loadPoller();
-    poller.startRssPoller(30 * 60 * 1000);
+    poller.startRssPoller(30 * 60 * 1000, { startupDelayMs: 0 });
     await vi.runAllTicks();
 
     await vi.advanceTimersByTimeAsync(119_999);
@@ -123,7 +157,7 @@ describe("rss poller", () => {
       .mockResolvedValueOnce(undefined);
 
     const poller = await loadPoller();
-    poller.startRssPoller(30 * 60 * 1000);
+    poller.startRssPoller(30 * 60 * 1000, { startupDelayMs: 0 });
     await vi.runAllTicks();
 
     await vi.advanceTimersByTimeAsync(60_000);

--- a/packages/desktop/src/lib/rss-poller.ts
+++ b/packages/desktop/src/lib/rss-poller.ts
@@ -18,6 +18,7 @@ import {
 
 /** Default poll interval: 30 minutes */
 const DEFAULT_INTERVAL_MS = 30 * 60 * 1000;
+const DEFAULT_STARTUP_POLL_DELAY_MS = 5 * 60 * 1000;
 const DEFERRED_RETRY_BASE_MS = 60_000;
 const DEFERRED_RETRY_MAX_MS = 30 * 60_000;
 const SCHEDULED_REFRESH_OPTIONS = {
@@ -25,8 +26,13 @@ const SCHEDULED_REFRESH_OPTIONS = {
   staleAfterMs: SCHEDULED_RSS_STALE_AFTER_MS,
 };
 
+interface RssPollerOptions {
+  startupDelayMs?: number;
+}
+
 let pollIntervalId: ReturnType<typeof setInterval> | null = null;
 let retryTimeoutId: ReturnType<typeof setTimeout> | null = null;
+let startupTimeoutId: ReturnType<typeof setTimeout> | null = null;
 let isPolling = false;
 let deferredRetryCount = 0;
 
@@ -36,6 +42,13 @@ function clearDeferredRetry(): void {
     retryTimeoutId = null;
   }
   deferredRetryCount = 0;
+}
+
+function clearStartupPoll(): void {
+  if (startupTimeoutId !== null) {
+    clearTimeout(startupTimeoutId);
+    startupTimeoutId = null;
+  }
 }
 
 function parseCooldownRetryMs(reason: string): number | null {
@@ -76,15 +89,30 @@ function scheduleDeferredRetry(reason: string): void {
  *
  * @param intervalMs Poll interval in milliseconds (default: 30 minutes)
  */
-export function startRssPoller(intervalMs = DEFAULT_INTERVAL_MS): void {
+export function startRssPoller(
+  intervalMs = DEFAULT_INTERVAL_MS,
+  options: RssPollerOptions = {},
+): void {
   if (pollIntervalId !== null) return; // Already running
 
-  // Do an immediate refresh on first start
-  void triggerPoll();
+  const startupDelayMs =
+    options.startupDelayMs ?? DEFAULT_STARTUP_POLL_DELAY_MS;
+  if (startupDelayMs > 0) {
+    startupTimeoutId = setTimeout(() => {
+      startupTimeoutId = null;
+      void triggerPoll();
+    }, startupDelayMs);
+    addDebugEvent(
+      "change",
+      `[RSS] startup poll scheduled in ${Math.round(startupDelayMs / 1000).toLocaleString()}s`,
+    );
+  } else {
+    void triggerPoll();
+  }
 
   pollIntervalId = setInterval(triggerPoll, intervalMs);
   console.log(
-    `[RssPoller] Started — polling every ${intervalMs / 60000} minutes`,
+    `[RssPoller] Started, polling every ${(intervalMs / 60000).toLocaleString()} minutes`,
   );
 }
 
@@ -92,6 +120,7 @@ export function startRssPoller(intervalMs = DEFAULT_INTERVAL_MS): void {
  * Stop background RSS polling.
  */
 export function stopRssPoller(): void {
+  clearStartupPoll();
   clearDeferredRetry();
   if (pollIntervalId !== null) {
     clearInterval(pollIntervalId);


### PR DESCRIPTION
(AI Generated).

## Summary
- Delay scheduled RSS work after launch and accept plain Facebook feed blocks that still have valid author and timestamp cues.

## Testing
- npm run validate:feature