### PR TITLE
fix: restore changelog history and PR counts

### DIFF
--- a/website/public/atom.xml
+++ b/website/public/atom.xml
@@ -2,7 +2,7 @@
 <feed xmlns="http://www.w3.org/2005/Atom">
     <id>https://freed.wtf</id>
     <title>Freed Blog</title>
-    <updated>2026-06-01T04:35:16.489Z</updated>
+    <updated>2026-06-01T05:38:18.902Z</updated>
     <generator>https://github.com/jpmonette/feed</generator>
     <author>
         <name>The Freed Team</name>

--- a/website/public/feed.xml
+++ b/website/public/feed.xml
@@ -4,7 +4,7 @@
         <title>Freed Blog</title>
         <link>https://freed.wtf</link>
         <description>Progress reports, technical deep-dives, and philosophical rants about the attention economy. From the team building Freed.</description>
-        <lastBuildDate>Mon, 01 Jun 2026 04:35:16 GMT</lastBuildDate>
+        <lastBuildDate>Mon, 01 Jun 2026 05:38:18 GMT</lastBuildDate>
         <docs>https://validator.w3.org/feed/docs/rss2.html</docs>
         <generator>https://github.com/jpmonette/feed</generator>
         <language>en</language>

--- a/website/scripts/generate-changelog.ts
+++ b/website/scripts/generate-changelog.ts
@@ -4,6 +4,7 @@ import {
   groupReleasesByDay,
   normalizeGitHubReleases,
   type ParsedRelease,
+  type ReleaseBuild,
   type ReleaseChannel,
   type ReleaseItem,
 } from "../src/content/changelog";
@@ -11,6 +12,7 @@ import {
 const OUTPUT_PATH = join(process.cwd(), "src/content/changelog.generated.json");
 const RELEASE_NOTES_ROOT = join(process.cwd(), "..", "release-notes");
 const RELEASE_NOTES_RELEASES_DIR = join(RELEASE_NOTES_ROOT, "releases");
+const GITHUB_RELEASE_PAGE_SIZE = 100;
 const authToken =
   process.env.GITHUB_RELEASES_TOKEN ??
   process.env.GITHUB_TOKEN ??
@@ -39,7 +41,9 @@ interface LocalReleaseArtifact {
   version: string;
   dayKey: string;
   source?: {
+    previousPublishedTag?: string;
     prNumbers?: number[];
+    relatedBuildTags?: string[];
   };
   release?: {
     deck?: string;
@@ -50,6 +54,14 @@ interface LocalReleaseArtifact {
     whatsNew?: string[];
     performance?: string[];
   };
+}
+
+interface GitHubCompare {
+  commits: Array<{
+    commit: {
+      message: string;
+    };
+  }>;
 }
 
 function dedupeItems(items: ReleaseItem[]): ReleaseItem[] {
@@ -85,6 +97,50 @@ async function fetchJson<T>(url: string): Promise<T> {
   return (await response.json()) as T;
 }
 
+async function fetchGitHubReleases(): Promise<GitHubRelease[]> {
+  const releases: GitHubRelease[] = [];
+
+  for (let page = 1; ; page += 1) {
+    const pageReleases = await fetchJson<GitHubRelease[]>(
+      `https://api.github.com/repos/freed-project/freed/releases?per_page=${GITHUB_RELEASE_PAGE_SIZE.toLocaleString(
+        "en-US",
+        { useGrouping: false },
+      )}&page=${page.toLocaleString("en-US", { useGrouping: false })}`,
+    );
+
+    releases.push(...pageReleases);
+
+    if (pageReleases.length < GITHUB_RELEASE_PAGE_SIZE) {
+      return releases;
+    }
+  }
+}
+
+function extractPrNumbersFromText(text: string): number[] {
+  return [...text.matchAll(/(?:#|\/pull\/)(\d+)/g)]
+    .map((match) => Number(match[1]))
+    .filter((num) => Number.isInteger(num) && num > 0);
+}
+
+async function fetchComparePrNumbers(
+  baseTag: string | undefined,
+  headTag: string,
+): Promise<number[]> {
+  if (!baseTag || baseTag === headTag) {
+    return [];
+  }
+
+  const compare = await fetchJson<GitHubCompare>(
+    `https://api.github.com/repos/freed-project/freed/compare/${encodeURIComponent(
+      baseTag,
+    )}...${encodeURIComponent(headTag)}`,
+  );
+
+  return compare.commits.flatMap((commit) =>
+    extractPrNumbersFromText(commit.commit.message),
+  );
+}
+
 function readLocalReleaseArtifacts(): Map<string, LocalReleaseArtifact> {
   const artifacts = new Map<string, LocalReleaseArtifact>();
 
@@ -109,10 +165,66 @@ function readLocalReleaseArtifacts(): Map<string, LocalReleaseArtifact> {
   return artifacts;
 }
 
-function releaseFromLocalArtifact(
+function buildLinksFromArtifact(
   artifact: LocalReleaseArtifact,
   release: GitHubRelease,
-): ParsedRelease {
+  releaseMap: Map<string, GitHubRelease>,
+): ReleaseBuild[] {
+  const relatedBuildTags = artifact.source?.relatedBuildTags ?? [];
+  const buildLinks = relatedBuildTags
+    .map((tag) => releaseMap.get(tag))
+    .filter((candidate): candidate is GitHubRelease => Boolean(candidate))
+    .map((candidate) => ({
+      version: candidate.tag_name.replace(/^v/, ""),
+      htmlUrl: candidate.html_url,
+      channel: (candidate.tag_name.endsWith("-dev") ? "dev" : "production") as ReleaseChannel,
+    }));
+
+  if (buildLinks.length > 0) {
+    return buildLinks;
+  }
+
+  return [
+    {
+      version: artifact.version || release.tag_name.replace(/^v/, ""),
+      htmlUrl: release.html_url,
+      channel: (release.tag_name.endsWith("-dev") ? "dev" : "production") as ReleaseChannel,
+    },
+  ];
+}
+
+async function collectPrNumbersFromArtifact(
+  artifact: LocalReleaseArtifact,
+  release: GitHubRelease,
+  localReleaseArtifacts: Map<string, LocalReleaseArtifact>,
+): Promise<number[]> {
+  const prNumbers = new Set(artifact.source?.prNumbers ?? []);
+
+  for (const relatedTag of artifact.source?.relatedBuildTags ?? []) {
+    const relatedArtifact = localReleaseArtifacts.get(relatedTag);
+    for (const prNumber of relatedArtifact?.source?.prNumbers ?? []) {
+      prNumbers.add(prNumber);
+    }
+  }
+
+  if (prNumbers.size === 0 && artifact.source?.previousPublishedTag) {
+    for (const prNumber of await fetchComparePrNumbers(
+      artifact.source.previousPublishedTag,
+      release.tag_name,
+    )) {
+      prNumbers.add(prNumber);
+    }
+  }
+
+  return [...prNumbers].sort((a, b) => a - b);
+}
+
+async function releaseFromLocalArtifact(
+  artifact: LocalReleaseArtifact,
+  release: GitHubRelease,
+  releaseMap: Map<string, GitHubRelease>,
+  localReleaseArtifacts: Map<string, LocalReleaseArtifact>,
+): Promise<ParsedRelease> {
   const releaseShape = artifact.release ?? {};
   const version = artifact.version || release.tag_name.replace(/^v/, "");
   const channel: ReleaseChannel = release.tag_name.endsWith("-dev")
@@ -124,6 +236,7 @@ function releaseFromLocalArtifact(
     ...(releaseShape.followUps ?? []),
     ...(releaseShape.performance ?? []),
   ]);
+  const buildLinks = buildLinksFromArtifact(artifact, release, releaseMap);
 
   return {
     version,
@@ -135,36 +248,37 @@ function releaseFromLocalArtifact(
     fixes,
     followUps,
     htmlUrl: release.html_url,
-    prNumbers: [...new Set(artifact.source?.prNumbers ?? [])].sort((a, b) => a - b),
-    builds: [release.tag_name.replace(/^v/, "")],
-    buildLinks: [
-      {
-        version,
-        htmlUrl: release.html_url,
-        channel,
-      },
-    ],
+    prNumbers: await collectPrNumbersFromArtifact(
+      artifact,
+      release,
+      localReleaseArtifacts,
+    ),
+    builds: buildLinks.map((build) => build.version),
+    buildLinks,
   };
 }
 
 async function fetchChangelog(): Promise<ParsedRelease[]> {
-  const releases = await fetchJson<GitHubRelease[]>(
-    "https://api.github.com/repos/freed-project/freed/releases?per_page=100",
-  );
+  const releases = await fetchGitHubReleases();
   const publishedReleases = normalizeGitHubReleases(releases);
   const releaseMap = new Map(releases.map((release) => [release.tag_name, release]));
   const localReleaseArtifacts = readLocalReleaseArtifacts();
 
-  const detailedReleases = publishedReleases.map((publishedRelease) => {
+  const detailedReleases = await Promise.all(publishedReleases.map((publishedRelease) => {
     const release = releaseMap.get(publishedRelease.tagName);
     const localArtifact = release ? localReleaseArtifacts.get(release.tag_name) : null;
 
     if (release && localArtifact?.release) {
-      return releaseFromLocalArtifact(localArtifact, release);
+      return releaseFromLocalArtifact(
+        localArtifact,
+        release,
+        releaseMap,
+        localReleaseArtifacts,
+      );
     }
 
     return publishedRelease;
-  });
+  }));
 
   return groupReleasesByDay(detailedReleases);
 }

--- a/website/src/content/changelog.generated.json
+++ b/website/src/content/changelog.generated.json
@@ -1,9 +1,9 @@
 [
   {
-    "version": "26.5.3115-dev",
-    "tagName": "v26.5.3115-dev",
+    "version": "26.5.3116-dev",
+    "tagName": "v26.5.3116-dev",
     "channel": "dev",
-    "date": "2026-06-01T04:27:43Z",
+    "date": "2026-06-01T05:20:23Z",
     "deck": "This dev build adds Facebook zero-post diagnostics and keeps RSS retry pacing and installed dev-channel validation ready for the next soak",
     "features": [],
     "fixes": [
@@ -55,7 +55,7 @@
         "text": "Install this build and verify RSS failures stop piling up in sync health"
       }
     ],
-    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.5.3115-dev",
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.5.3116-dev",
     "prNumbers": [],
     "builds": [
       "26.5.3105-dev",
@@ -64,7 +64,8 @@
       "26.5.3110-dev",
       "26.5.3112-dev",
       "26.5.3114-dev",
-      "26.5.3115-dev"
+      "26.5.3115-dev",
+      "26.5.3116-dev"
     ],
     "buildLinks": [
       {
@@ -100,6 +101,11 @@
       {
         "version": "26.5.3115-dev",
         "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.5.3115-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.5.3116-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.5.3116-dev",
         "channel": "dev"
       }
     ]
@@ -171,7 +177,103 @@
       }
     ],
     "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.5.3113",
-    "prNumbers": [],
+    "prNumbers": [
+      379,
+      405,
+      560,
+      563,
+      564,
+      565,
+      566,
+      567,
+      568,
+      569,
+      570,
+      571,
+      573,
+      574,
+      575,
+      576,
+      577,
+      578,
+      579,
+      580,
+      581,
+      582,
+      583,
+      584,
+      585,
+      586,
+      587,
+      588,
+      589,
+      591,
+      592,
+      595,
+      596,
+      597,
+      598,
+      599,
+      601,
+      602,
+      603,
+      604,
+      605,
+      606,
+      607,
+      608,
+      609,
+      610,
+      611,
+      612,
+      613,
+      614,
+      615,
+      616,
+      617,
+      618,
+      619,
+      620,
+      621,
+      622,
+      623,
+      624,
+      625,
+      626,
+      627,
+      628,
+      629,
+      630,
+      631,
+      632,
+      633,
+      634,
+      635,
+      636,
+      637,
+      638,
+      640,
+      641,
+      644,
+      645,
+      646,
+      647,
+      648,
+      649,
+      654,
+      655,
+      656,
+      657,
+      658,
+      659,
+      661,
+      665,
+      666,
+      668,
+      670,
+      671,
+      672
+    ],
     "builds": [
       "26.5.3113"
     ],
@@ -1654,13 +1756,2799 @@
     "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.5.406-dev",
     "prNumbers": [],
     "builds": [
+      "26.5.402-dev",
+      "26.5.404-dev",
+      "26.5.405-dev",
       "26.5.406-dev"
     ],
     "buildLinks": [
       {
+        "version": "26.5.402-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.5.402-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.5.404-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.5.404-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.5.405-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.5.405-dev",
+        "channel": "dev"
+      },
+      {
         "version": "26.5.406-dev",
         "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.5.406-dev",
         "channel": "dev"
+      }
+    ]
+  },
+  {
+    "version": "26.5.403",
+    "tagName": "v26.5.403",
+    "channel": "production",
+    "date": "2026-05-05T02:12:56Z",
+    "deck": "Freed Desktop reliability fixes",
+    "features": [],
+    "fixes": [
+      {
+        "text": "Native macOS window dragging now works from the FREED wordmark, nearby titlebar gap, passive toolbar title areas, and fullscreen reader titlebar."
+      },
+      {
+        "text": "Toolbar controls stay clickable because buttons remain explicit no-drag targets while passive titlebar surfaces handle native dragging."
+      },
+      {
+        "text": "Fix stale renderer recovery restarts."
+      },
+      {
+        "text": "Recover stale renderers without blocking the macOS main thread while the old main window unregisters."
+      },
+      {
+        "text": "Let the startup recovery screen scroll in shorter windows so recovery actions stay reachable."
+      },
+      {
+        "text": "Pause heavy background work before high renderer memory can force repeated recovery."
+      },
+      {
+        "text": "Retry deferred startup RSS polls instead of waiting for the next normal polling interval."
+      },
+      {
+        "text": "Batch visible archive actions more aggressively."
+      },
+      {
+        "text": "Restore Linux release compilation for renderer memory diagnostics."
+      }
+    ],
+    "followUps": [],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.5.403",
+    "prNumbers": [
+      408,
+      418,
+      419,
+      420,
+      421,
+      424,
+      425,
+      427,
+      428
+    ],
+    "builds": [
+      "26.5.400",
+      "26.5.403"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.5.400",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.5.400",
+        "channel": "production"
+      },
+      {
+        "version": "26.5.403",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.5.403",
+        "channel": "production"
+      }
+    ]
+  },
+  {
+    "version": "26.5.309",
+    "tagName": "v26.5.309",
+    "channel": "production",
+    "date": "2026-05-04T05:08:35Z",
+    "deck": "A larger Freed Desktop update focused on relationship views, optional local intelligence, reliable capture, and calmer reading.",
+    "features": [
+      {
+        "text": "Friends graph tools now include ranked suggestions, relationship tiers, shared Friends or All content scoping, and search profile actions."
+      },
+      {
+        "text": "Optional local AI model packs can be installed from settings to enrich semantic analysis without bundling model weights."
+      },
+      {
+        "text": "Reading layouts now keep feeds, stories, sidebars, and cards steadier while media and view transitions load."
+      }
+    ],
+    "fixes": [
+      {
+        "text": "Startup recovery now waits for healthy renderer heartbeats, records diagnostics, and keeps background work from running into stalled windows."
+      },
+      {
+        "text": "Social capture is more reliable across Instagram, Facebook, LinkedIn, and X, with stronger story dedupe, comment hydration, OAuth, and memory-pressure handling."
+      },
+      {
+        "text": "Sync and update flows are steadier across Google Drive, Dropbox, mobile pairing, updater channels, outbox persistence, and Automerge state patches."
+      },
+      {
+        "text": "Provider health, source action menus, graph selection, and graph label checks have stronger Freed Desktop validation coverage."
+      },
+      {
+        "text": "Cloud media vault setup, Google contacts sync, and local archive handling have clearer settings and safer storage paths."
+      },
+      {
+        "text": "Read-on-scroll, reader hydration, saved signals, search, map markers, and command state now preserve context more consistently."
+      }
+    ],
+    "followUps": [
+      {
+        "text": "Release validation now covers the full primary platform matrix and slimmer Freed Desktop E2E gates."
+      },
+      {
+        "text": "Website changelog and roadmap presentation will be refreshed from the production tag after the release workflow publishes."
+      },
+      {
+        "text": "Reverse integration will merge this production release back into dev after updater verification."
+      }
+    ],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.5.309",
+    "prNumbers": [
+      411,
+      412,
+      414,
+      416
+    ],
+    "builds": [
+      "26.5.309"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.5.309",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.5.309",
+        "channel": "production"
+      }
+    ]
+  },
+  {
+    "version": "26.5.308-dev",
+    "tagName": "v26.5.308-dev",
+    "channel": "dev",
+    "date": "2026-05-04T04:44:25Z",
+    "deck": "Stabilize feed layout, search, and capture cleanup",
+    "features": [
+      {
+        "text": "Friends relationship tiers"
+      },
+      {
+        "text": "Refine sidebar rows and card density"
+      },
+      {
+        "text": "Search profile actions"
+      }
+    ],
+    "fixes": [
+      {
+        "text": "Deduped duplicate Instagram story captures"
+      },
+      {
+        "text": "Desktop feed scroll layout is now more stable"
+      },
+      {
+        "text": "Freed Desktop startup recovery now waits for healthy renderer heartbeats before running high-risk jobs"
+      },
+      {
+        "text": "Added runtime-health diagnostics for blank renderer reports, including active background work, memory pressure, and recovery attempts"
+      },
+      {
+        "text": "Promote linked accounts without duplicate drafts"
+      },
+      {
+        "text": "Tightened collapsed feed filter menu headings, copy, spacing, and classification selection animation"
+      },
+      {
+        "text": "Floating menus now stay inside the viewport and scroll internally"
+      }
+    ],
+    "followUps": [
+      {
+        "text": "Friends graph validation now checks structural graph signals instead of provider label text"
+      },
+      {
+        "text": "Friends graph validation now fits the graph before checking visual labels"
+      },
+      {
+        "text": "Friends graph validation now waits for provider labels before checking the visual state"
+      },
+      {
+        "text": "Friends graph and feed perf gates now allow normal CI timing variance"
+      },
+      {
+        "text": "Slim desktop e2e gates"
+      },
+      {
+        "text": "Added fixed-height desktop feed cards and story rows so media loading no longer changes scroll position"
+      },
+      {
+        "text": "Added compact, comfortable, and expansive feed card density controls with matching skeleton heights and bounded internal scrolling for floating menus"
+      }
+    ],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.5.308-dev",
+    "prNumbers": [],
+    "builds": [
+      "26.5.300-dev",
+      "26.5.301-dev",
+      "26.5.302-dev",
+      "26.5.308-dev"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.5.300-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.5.300-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.5.301-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.5.301-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.5.302-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.5.302-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.5.308-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.5.308-dev",
+        "channel": "dev"
+      }
+    ]
+  },
+  {
+    "version": "26.5.201-dev",
+    "tagName": "v26.5.201-dev",
+    "channel": "dev",
+    "date": "2026-05-02T22:17:34Z",
+    "deck": "AI ranked friend suggestions and a shared friends lens across core views.",
+    "features": [],
+    "fixes": [],
+    "followUps": [],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.5.201-dev",
+    "prNumbers": [],
+    "builds": [
+      "26.5.201-dev"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.5.201-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.5.201-dev",
+        "channel": "dev"
+      }
+    ]
+  },
+  {
+    "version": "26.5.103-dev",
+    "tagName": "v26.5.103-dev",
+    "channel": "dev",
+    "date": "2026-05-02T06:07:30Z",
+    "deck": "Keeps crash recovery, AI downloads, and common desktop actions responsive",
+    "features": [],
+    "fixes": [
+      {
+        "text": "Startup recovery can now check for updates, install them, relaunch, and open fallback browser downloads"
+      },
+      {
+        "text": "Desktop AI downloads and renderer recovery are now more stable"
+      },
+      {
+        "text": "Update outbox test fixture types"
+      },
+      {
+        "text": "Preserve side-effect queue serialization on timeout"
+      },
+      {
+        "text": "Kept desktop side-effect queues serialized even when a queued task times out, so one slow persistence or sync action cannot let later work overlap out of order"
+      },
+      {
+        "text": "Moved provider health, secure storage, cloud upload, snapshots, and outbox side effects through typed queues so UI gestures return quickly"
+      },
+      {
+        "text": "Prevented read, like, archive, and sync-confirmation item patches from making the outbox rescan the full feed"
+      },
+      {
+        "text": "Updated desktop item patches incrementally on the main thread, including count-map identity preservation for like and sync-confirmation patches"
+      },
+      {
+        "text": "Fixed stale outbox test fixtures so release validation covers the new patch-drain path"
+      },
+      {
+        "text": "Integrated AI pack downloads now stream through native disk IO, which keeps large local model downloads out of the WebKit renderer"
+      },
+      {
+        "text": "Renderer recovery now rebuilds stale macOS windows on the main thread after heartbeat failure"
+      },
+      {
+        "text": "Local AI classification now stays off until Topics and ranking is enabled, and settings show classification as off while disabled"
+      },
+      {
+        "text": "Desktop scrapers now log and respect WebKit memory pressure before launching new provider work"
+      }
+    ],
+    "followUps": [
+      {
+        "text": "Preserve count maps for neutral patches"
+      },
+      {
+        "text": "Item patch state incrementally"
+      },
+      {
+        "text": "Route desktop hot-path side effects"
+      }
+    ],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.5.103-dev",
+    "prNumbers": [],
+    "builds": [
+      "26.5.101-dev",
+      "26.5.102-dev",
+      "26.5.103-dev"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.5.101-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.5.101-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.5.102-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.5.102-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.5.103-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.5.103-dev",
+        "channel": "dev"
+      }
+    ]
+  },
+  {
+    "version": "26.4.3006-dev",
+    "tagName": "v26.4.3006-dev",
+    "channel": "dev",
+    "date": "2026-05-01T03:01:14Z",
+    "deck": "Integrated AI pack ladder, constrain settings list growth, and an Appearance animation control with None, Light, and Detailed options, so app motion can be reduced or disabled across controlled fades, slides, layout transitions, shimmers, and theme changes",
+    "features": [
+      {
+        "text": "Integrated AI pack ladder"
+      },
+      {
+        "text": "An Appearance animation control with None, Light, and Detailed options, so app motion can be reduced or disabled across controlled fades, slides, layout transitions, shimmers, and theme changes"
+      },
+      {
+        "text": "Give story cards the same shared feed layout transition as regular cards, so opening a story can animate from the primary list into the compact sidebar rail instead of snapping"
+      }
+    ],
+    "fixes": [
+      {
+        "text": "Run background social scraper windows fully hidden by default and restart cleanly if Tauri cannot rebuild a stalled main window, so Freed Desktop does not strand users on a black window."
+      },
+      {
+        "text": "Rebuild the main window through a hidden keepalive window during renderer recovery, so watchdog recovery no longer quits the app before the replacement window opens"
+      },
+      {
+        "text": "Batch local AI model file writes and throttle progress updates during model pack installs to keep Settings responsive during large downloads"
+      },
+      {
+        "text": "Keep Pause available while an AI model download is active"
+      },
+      {
+        "text": "Feed card max width and desktop feed thumbnails so dense feeds stay readable restored"
+      },
+      {
+        "text": "Scale the desktop Settings dialog with the viewport so tall settings lists remain usable on smaller displays"
+      },
+      {
+        "text": "Social scrapes now measure Freed-owned WebKit memory, reclaim stale scraper windows and oversized network cache, and keep provider errors scoped to the right settings panel"
+      },
+      {
+        "text": "Renderer recovery and model installs are now more stable"
+      },
+      {
+        "text": "Main window reopen after renderer recovery restored"
+      },
+      {
+        "text": "Expanded provider rows now draw wider highlights, shift social icons left, and keep unread and total counts pinned in place"
+      },
+      {
+        "text": "Primary search suggestions now rank useful scopes, actions, and recent destinations more clearly"
+      },
+      {
+        "text": "Channel avatar fallbacks are shared across feed cards, Friends, and map markers for more consistent identity cues"
+      },
+      {
+        "text": "Cloud sync nudges now show a countdown before a delayed reminder becomes active"
+      },
+      {
+        "text": "Background AI summarization now runs through one paced fetcher worker with randomized delay, capped backoff, and 60-second AI timeouts, so slow local models cannot stack overlapping work"
+      },
+      {
+        "text": "Scope social provider error copy by provider, so Instagram, Facebook, LinkedIn, and X setup states say what actually failed"
+      }
+    ],
+    "followUps": [
+      {
+        "text": "Renderer heartbeat telemetry now has a clearer recovery path for future black-window reports."
+      },
+      {
+        "text": "Freed Desktop now keeps the app alive while rebuilding a stalled main window, and large AI model pack downloads put less pressure on the interface"
+      },
+      {
+        "text": "Motion preferences now have a synced default of Detailed, while None removes app-controlled animation for users who need a quiet interface"
+      },
+      {
+        "text": "Facebook, Instagram, and LinkedIn scraping should keep moving for larger libraries unless Freed itself remains under unsafe memory pressure after cleanup"
+      },
+      {
+        "text": "Source action menus and provider status surfaces now have tighter geometry coverage in the desktop E2E suite"
+      }
+    ],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.3006-dev",
+    "prNumbers": [],
+    "builds": [
+      "26.4.3000-dev",
+      "26.4.3001-dev",
+      "26.4.3002-dev",
+      "26.4.3003-dev",
+      "26.4.3005-dev",
+      "26.4.3006-dev"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.4.3000-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.3000-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.4.3001-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.3001-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.4.3002-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.3002-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.4.3003-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.3003-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.4.3005-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.3005-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.4.3006-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.3006-dev",
+        "channel": "dev"
+      }
+    ]
+  },
+  {
+    "version": "26.4.2904-dev",
+    "tagName": "v26.4.2904-dev",
+    "channel": "dev",
+    "date": "2026-04-30T04:19:00Z",
+    "deck": "Renderer recovery, semantic content enrichment, unified AI provider settings, and read-on-scroll fixes",
+    "features": [
+      {
+        "text": "Semantic content enrichment"
+      },
+      {
+        "text": "Unified AI provider settings"
+      }
+    ],
+    "fixes": [
+      {
+        "text": "Recover Freed Desktop after main renderer stalls instead of leaving the app without a main window"
+      },
+      {
+        "text": "Polish reader sidebar and toolbar layout"
+      },
+      {
+        "text": "Polish AI settings local pack"
+      },
+      {
+        "text": "Prevent health persistence from freezing dev preview"
+      },
+      {
+        "text": "Mark feed items read while scrolling"
+      },
+      {
+        "text": "Provider health persistence no longer uses the Tauri store mutex path that could freeze Freed Desktop shortly after launch"
+      }
+    ],
+    "followUps": [],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.2904-dev",
+    "prNumbers": [],
+    "builds": [
+      "26.4.2900-dev",
+      "26.4.2901-dev",
+      "26.4.2902-dev",
+      "26.4.2903-dev",
+      "26.4.2904-dev"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.4.2900-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.2900-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.4.2901-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.2901-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.4.2902-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.2902-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.4.2903-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.2903-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.4.2904-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.2904-dev",
+        "channel": "dev"
+      }
+    ]
+  },
+  {
+    "version": "26.4.2800-dev",
+    "tagName": "v26.4.2800-dev",
+    "channel": "dev",
+    "date": "2026-04-28T22:32:24Z",
+    "deck": "Dev releases now build for every primary supported platform.",
+    "features": [],
+    "fixes": [
+      {
+        "text": "Dev tagged releases now use the same primary build matrix as production, covering macOS Apple Silicon, macOS Intel, Windows x64, and Linux x64."
+      },
+      {
+        "text": "Paused local AI model downloads keep their progress after the app reloads or restarts."
+      }
+    ],
+    "followUps": [],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.2800-dev",
+    "prNumbers": [],
+    "builds": [
+      "26.4.2800-dev"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.4.2800-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.2800-dev",
+        "channel": "dev"
+      }
+    ]
+  },
+  {
+    "version": "26.4.2700-dev",
+    "tagName": "v26.4.2700-dev",
+    "channel": "dev",
+    "date": "2026-04-28T03:35:29Z",
+    "deck": "Optional local AI model downloads and complete Google integrations",
+    "features": [
+      {
+        "text": "Optional local AI model downloads"
+      },
+      {
+        "text": "Complete Google Drive and Google Contacts integrations"
+      }
+    ],
+    "fixes": [
+      {
+        "text": "Cancelable Google connection flows and native desktop Contacts API requests"
+      }
+    ],
+    "followUps": [],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.2700-dev",
+    "prNumbers": [],
+    "builds": [
+      "26.4.2700-dev"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.4.2700-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.2700-dev",
+        "channel": "dev"
+      }
+    ]
+  },
+  {
+    "version": "26.4.2606-dev",
+    "tagName": "v26.4.2606-dev",
+    "channel": "dev",
+    "date": "2026-04-26T23:04:34Z",
+    "deck": "Hydrate social comments in reader, improve reader offline hydration, and permanent social media archive",
+    "features": [
+      {
+        "text": "Hydrate social comments in reader"
+      },
+      {
+        "text": "Improve reader offline hydration"
+      },
+      {
+        "text": "Permanent social media archive"
+      }
+    ],
+    "fixes": [
+      {
+        "text": "Default app themes to Scriptorium"
+      },
+      {
+        "text": "Harden release validation assertions"
+      },
+      {
+        "text": "Preserve saved and archived signal filters"
+      },
+      {
+        "text": "Graph selection perf assertions are more stable"
+      },
+      {
+        "text": "Provider health status fallback tests are more stable"
+      },
+      {
+        "text": "Release validation E2E is more stable"
+      },
+      {
+        "text": "Production validation stress tests are faster"
+      },
+      {
+        "text": "RSS source test fixtures are more accurate"
+      },
+      {
+        "text": "Polish sidebar rail behavior"
+      },
+      {
+        "text": "Remember desktop release channel"
+      },
+      {
+        "text": "Archived items no longer clear saved feed choices"
+      }
+    ],
+    "followUps": [
+      {
+        "text": "Rebuild friends graph for scale"
+      }
+    ],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.2606-dev",
+    "prNumbers": [],
+    "builds": [
+      "26.4.2604-dev",
+      "26.4.2605-dev",
+      "26.4.2606-dev"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.4.2604-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.2604-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.4.2605-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.2605-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.4.2606-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.2606-dev",
+        "channel": "dev"
+      }
+    ]
+  },
+  {
+    "version": "26.4.2500-dev",
+    "tagName": "v26.4.2500-dev",
+    "channel": "dev",
+    "date": "2026-04-26T02:39:50Z",
+    "deck": "Social story filters",
+    "features": [],
+    "fixes": [],
+    "followUps": [],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.2500-dev",
+    "prNumbers": [],
+    "builds": [
+      "26.4.2500-dev"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.4.2500-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.2500-dev",
+        "channel": "dev"
+      }
+    ]
+  },
+  {
+    "version": "26.4.2401-dev",
+    "tagName": "v26.4.2401-dev",
+    "channel": "dev",
+    "date": "2026-04-24T17:42:26Z",
+    "deck": "Friends graph workspace and preview fixes, complete phase 3 save-for-later truth pass, and unify desktop shell chrome",
+    "features": [
+      {
+        "text": "Friends graph workspace and preview fixes"
+      },
+      {
+        "text": "Complete phase 3 save-for-later truth pass"
+      },
+      {
+        "text": "Unify desktop shell chrome"
+      }
+    ],
+    "fixes": [
+      {
+        "text": "Release build and type-safety cleanup"
+      },
+      {
+        "text": "Reader, feed, and header polish"
+      },
+      {
+        "text": "Sync google contacts platform test cast"
+      },
+      {
+        "text": "Prevent fatal google contacts oauth crash"
+      },
+      {
+        "text": "Warm PWA article images for offline reading"
+      },
+      {
+        "text": "Clarify desktop update channel state"
+      },
+      {
+        "text": "Raise update dialogs above floating new button"
+      },
+      {
+        "text": "Desktop e2e merge regression resolved"
+      }
+    ],
+    "followUps": [
+      {
+        "text": "Reverse integrate main after v26.4.2305"
+      },
+      {
+        "text": "Split dev and production validation tiers"
+      },
+      {
+        "text": "Merge latest dev before release"
+      },
+      {
+        "text": "Make feature workflow preview-first"
+      },
+      {
+        "text": "Promote latest dev into main"
+      },
+      {
+        "text": "Reduce desktop memory pressure"
+      },
+      {
+        "text": "Sync UI package exports before production release"
+      },
+      {
+        "text": "Global command palette"
+      },
+      {
+        "text": "Stop release workflow deploying website"
+      },
+      {
+        "text": "Tiered validation and reverse merge workflow"
+      }
+    ],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.2401-dev",
+    "prNumbers": [],
+    "builds": [
+      "26.4.2401-dev"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.4.2401-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.2401-dev",
+        "channel": "dev"
+      }
+    ]
+  },
+  {
+    "version": "26.4.2305",
+    "tagName": "v26.4.2305",
+    "channel": "production",
+    "date": "2026-04-24T04:22:57Z",
+    "deck": "Pixi WebGL Friends graph with linked people, channels, and feeds, desktop details rail controls and a mobile Details mode for the Friends workspace, and sync UI package exports before production release",
+    "features": [
+      {
+        "text": "Pixi WebGL Friends graph with linked people, channels, and feeds"
+      },
+      {
+        "text": "Desktop details rail controls and a mobile Details mode for the Friends workspace"
+      }
+    ],
+    "fixes": [
+      {
+        "text": "Smoother pan and pinch behavior with cleaner four-edge vignette feathering in the Friends graph"
+      },
+      {
+        "text": "Browser preview no longer crashes on native-only snapshot, LinkedIn, and capture paths"
+      },
+      {
+        "text": "Crash report exports now label and gate public-safe versus private bundles correctly"
+      }
+    ],
+    "followUps": [
+      {
+        "text": "Promote dev into main for production release and stop release workflow deploying website"
+      },
+      {
+        "text": "This build ships the new Friends graph workspace and hardens desktop preview, diagnostics, and graph performance"
+      }
+    ],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.2305",
+    "prNumbers": [
+      279,
+      285,
+      290,
+      294,
+      306
+    ],
+    "builds": [
+      "26.4.2300",
+      "26.4.2301",
+      "26.4.2303",
+      "26.4.2305"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.4.2300",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.2300",
+        "channel": "production"
+      },
+      {
+        "version": "26.4.2301",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.2301",
+        "channel": "production"
+      },
+      {
+        "version": "26.4.2303",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.2303",
+        "channel": "production"
+      },
+      {
+        "version": "26.4.2305",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.2305",
+        "channel": "production"
+      }
+    ]
+  },
+  {
+    "version": "26.4.2100",
+    "tagName": "v26.4.2100",
+    "channel": "production",
+    "date": "2026-04-21T20:57:19Z",
+    "deck": "Map timeline playback, cleaner identity migration, and smoother install and update flows",
+    "features": [
+      {
+        "text": "Filter maps with a shared timeline scrubber"
+      },
+      {
+        "text": "Replay historical posts and future plans from one map timeline"
+      },
+      {
+        "text": "Manage friends and map identities through the new person and account graph"
+      }
+    ],
+    "fixes": [
+      {
+        "text": "Migrates older friend data into the new person and account graph during startup so existing identities keep loading cleanly after the update"
+      },
+      {
+        "text": "Dedupes Facebook and Instagram cross-posts"
+      },
+      {
+        "text": "Keeps the install prompt and update channel labeling clearer across the app"
+      },
+      {
+        "text": "Tightens reader, feed, header, sync, and release reliability"
+      }
+    ],
+    "followUps": [
+      {
+        "text": "Adds a tri-state source sidebar for faster filtering"
+      },
+      {
+        "text": "Brings the Friends lens into the feed toolbar"
+      },
+      {
+        "text": "Polishes settings jumps and hardens helper workflow stability"
+      }
+    ],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.2100",
+    "prNumbers": [
+      227,
+      274
+    ],
+    "builds": [
+      "26.4.2100"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.4.2100",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.2100",
+        "channel": "production"
+      }
+    ]
+  },
+  {
+    "version": "26.4.2002-dev",
+    "tagName": "v26.4.2002-dev",
+    "channel": "dev",
+    "date": "2026-04-21T04:39:59Z",
+    "deck": "This dev build improves install flow and tightens startup, capture, and release stability.",
+    "features": [
+      {
+        "text": "PWA install prompt flow"
+      }
+    ],
+    "fixes": [
+      {
+        "text": "Stop the desktop dev launch crash and clean up the recovery dialog"
+      },
+      {
+        "text": "Dedupe Facebook and Instagram cross-posts"
+      },
+      {
+        "text": "Reset preview banners to bottom center on load"
+      },
+      {
+        "text": "Harden build fanout and swarm worktree setup"
+      },
+      {
+        "text": "Keep installed version stable across release channels"
+      },
+      {
+        "text": "Polish mobile settings navigation"
+      },
+      {
+        "text": "Refine live theme preview interactions"
+      }
+    ],
+    "followUps": [
+      {
+        "text": "Refine settings section jump alignment, harden worktree helper flow, and harden helper session workflow"
+      }
+    ],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.2002-dev",
+    "prNumbers": [],
+    "builds": [
+      "26.4.2001-dev",
+      "26.4.2002-dev"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.4.2001-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.2001-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.4.2002-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.2002-dev",
+        "channel": "dev"
+      }
+    ]
+  },
+  {
+    "version": "26.4.1901-dev",
+    "tagName": "v26.4.1901-dev",
+    "channel": "dev",
+    "date": "2026-04-20T03:41:16Z",
+    "deck": "Expand friends and map identity workflows, tri-state source sidebar, and Friends lens to feed toolbar",
+    "features": [
+      {
+        "text": "Expand friends and map identity workflows"
+      },
+      {
+        "text": "Tri-state source sidebar"
+      },
+      {
+        "text": "Friends lens to feed toolbar"
+      }
+    ],
+    "fixes": [
+      {
+        "text": "Redeploy dev pwa on dev merges"
+      },
+      {
+        "text": "Dismiss sticky tooltips after pointer activation"
+      },
+      {
+        "text": "Show -dev suffix for dev build versions"
+      },
+      {
+        "text": "Desktop toolbar dragging and back target restored"
+      },
+      {
+        "text": "Fall back to newer production updates on dev"
+      },
+      {
+        "text": "Add native startup recovery window"
+      },
+      {
+        "text": "Lets dev installs take a newer production update when no newer dev build exists, without switching release channels"
+      },
+      {
+        "text": "Shows the -dev suffix consistently in desktop update surfaces and settings"
+      }
+    ],
+    "followUps": [
+      {
+        "text": "Map timeline scrubber"
+      }
+    ],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1901-dev",
+    "prNumbers": [],
+    "builds": [
+      "26.4.1900-dev",
+      "26.4.1901-dev"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.4.1900-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1900-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.4.1901-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1901-dev",
+        "channel": "dev"
+      }
+    ]
+  },
+  {
+    "version": "26.4.1802-dev",
+    "tagName": "v26.4.1802-dev",
+    "channel": "dev",
+    "date": "2026-04-18T20:09:06Z",
+    "deck": "Time-aware map filtering and migrate legacy identity graph on startup",
+    "features": [
+      {
+        "text": "Time-aware map filtering"
+      }
+    ],
+    "fixes": [
+      {
+        "text": "Migrates older friend data into the person and account graph during startup so existing identities keep loading cleanly after the update."
+      }
+    ],
+    "followUps": [],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1802-dev",
+    "prNumbers": [],
+    "builds": [
+      "26.4.1800-dev",
+      "26.4.1802-dev"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.4.1800-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1800-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.4.1802-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1802-dev",
+        "channel": "dev"
+      }
+    ]
+  },
+  {
+    "version": "26.4.1700-dev",
+    "tagName": "v26.4.1700-dev",
+    "channel": "dev",
+    "date": "2026-04-18T04:42:45Z",
+    "deck": "Refactor friends into a person account identity graph",
+    "features": [],
+    "fixes": [],
+    "followUps": [],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1700-dev",
+    "prNumbers": [],
+    "builds": [
+      "26.4.1700-dev"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.4.1700-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1700-dev",
+        "channel": "dev"
+      }
+    ]
+  },
+  {
+    "version": "26.4.1602",
+    "tagName": "v26.4.1602",
+    "channel": "production",
+    "date": "2026-04-17T02:06:16Z",
+    "deck": "Freed Desktop keeps update dialogs visible, restores read state correctly, and makes release channel status clearer, the Updates settings view now labels the installed version clearly and rechecks when you switch release channels, and update dialogs now stay above the floating new button",
+    "features": [],
+    "fixes": [
+      {
+        "text": "Read state and related UI updates are restored correctly after merge recovery paths"
+      }
+    ],
+    "followUps": [],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1602",
+    "prNumbers": [],
+    "builds": [
+      "26.4.1600",
+      "26.4.1602"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.4.1600",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1600",
+        "channel": "production"
+      },
+      {
+        "version": "26.4.1602",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1602",
+        "channel": "production"
+      }
+    ]
+  },
+  {
+    "version": "26.4.1601-dev",
+    "tagName": "v26.4.1601-dev",
+    "channel": "dev",
+    "date": "2026-04-17T00:12:58Z",
+    "deck": "Map tiles are back, and desktop sync carries less preserved article text",
+    "features": [],
+    "fixes": [
+      {
+        "text": "Map view background tiles render again across the refreshed style palette"
+      },
+      {
+        "text": "Desktop sync now trims preserved article text before it reaches Automerge, which reduces sync memory growth on large saves"
+      }
+    ],
+    "followUps": [],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1601-dev",
+    "prNumbers": [],
+    "builds": [
+      "26.4.1601-dev"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.4.1601-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1601-dev",
+        "channel": "dev"
+      }
+    ]
+  },
+  {
+    "version": "26.4.1501-dev",
+    "tagName": "v26.4.1501-dev",
+    "channel": "dev",
+    "date": "2026-04-15T20:29:20Z",
+    "deck": "Explicit website release flow and stability fixes for recovery and UI checks",
+    "features": [
+      {
+        "text": "Explicit website release flow"
+      }
+    ],
+    "fixes": [
+      {
+        "text": "Crash reports now keep cleaner diagnostic state"
+      },
+      {
+        "text": "Map popup smoke tests and reader rail alignment checks are steadier"
+      },
+      {
+        "text": "Crash reporting and WebKit recovery are now more stable"
+      }
+    ],
+    "followUps": [],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1501-dev",
+    "prNumbers": [],
+    "builds": [
+      "26.4.1500-dev",
+      "26.4.1501-dev"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.4.1500-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1500-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.4.1501-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1501-dev",
+        "channel": "dev"
+      }
+    ]
+  },
+  {
+    "version": "26.4.1403-dev",
+    "tagName": "v26.4.1403-dev",
+    "channel": "dev",
+    "date": "2026-04-15T06:04:17Z",
+    "deck": "Theme-native map palettes, contacts settings and sync, and rotating desktop snapshots",
+    "features": [
+      {
+        "text": "Theme-native map palettes"
+      },
+      {
+        "text": "Finish Google Contacts settings and sync"
+      },
+      {
+        "text": "Rotating desktop snapshots"
+      }
+    ],
+    "fixes": [
+      {
+        "text": "Reader, feed, and header polish"
+      },
+      {
+        "text": "Release build and type-safety cleanup"
+      },
+      {
+        "text": "Copy and documentation cleanup"
+      },
+      {
+        "text": "Capture and scraper reliability fixes"
+      }
+    ],
+    "followUps": [
+      {
+        "text": "Reader, sidebar, and settings UX work"
+      },
+      {
+        "text": "Release workflow and build-system work"
+      },
+      {
+        "text": "Capture, login, and scraping platform work"
+      },
+      {
+        "text": "Sync, cloud, and pairing infrastructure"
+      },
+      {
+        "text": "Testing, diagnostics, and developer tooling"
+      },
+      {
+        "text": "Content and documentation work"
+      }
+    ],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1403-dev",
+    "prNumbers": [],
+    "builds": [
+      "26.4.1403-dev"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.4.1403-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1403-dev",
+        "channel": "dev"
+      }
+    ]
+  },
+  {
+    "version": "26.4.1400",
+    "tagName": "v26.4.1400",
+    "channel": "production",
+    "date": "2026-04-14T23:13:01Z",
+    "deck": "Theme-native map palettes, dev release channels and branch flow, and label macOS Activity Monitor web process as Freed",
+    "features": [
+      {
+        "text": "Theme-native map palettes"
+      },
+      {
+        "text": "Dev release channels and branch flow"
+      }
+    ],
+    "fixes": [],
+    "followUps": [],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1400",
+    "prNumbers": [
+      208,
+      209,
+      210,
+      211,
+      212
+    ],
+    "builds": [
+      "26.4.1400"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.4.1400",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1400",
+        "channel": "production"
+      }
+    ]
+  },
+  {
+    "version": "26.4.1300",
+    "tagName": "v26.4.1300",
+    "channel": "production",
+    "date": "2026-04-14T05:17:28Z",
+    "deck": "Desktop shell chrome is unified across the app, with theme-native maps, clearer recovery handoffs, and steadier reading surfaces.",
+    "features": [
+      {
+        "text": "Unified desktop shell chrome across the feed, reader, settings, and floating rails"
+      },
+      {
+        "text": "Added theme-native map palettes and improved Scriptorium readability"
+      },
+      {
+        "text": "Expanded empty-state recovery handoffs so sources are easier to reconnect"
+      }
+    ],
+    "fixes": [
+      {
+        "text": "Stabilized desktop side panels, reader toolbar alignment, and feed card spacing"
+      },
+      {
+        "text": "Improved keyboard navigation in the reader and kept focused rows in view"
+      },
+      {
+        "text": "Polished settings controls, provider dialogs, and marketing launch surfaces"
+      }
+    ],
+    "followUps": [],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1300",
+    "prNumbers": [
+      206,
+      207
+    ],
+    "builds": [
+      "26.4.1300"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.4.1300",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1300",
+        "channel": "production"
+      }
+    ]
+  },
+  {
+    "version": "26.4.1203",
+    "tagName": "v26.4.1203",
+    "channel": "production",
+    "date": "2026-04-13T02:44:48Z",
+    "deck": "Unify themes across website and app, refreshed theme system and typography polish, and privacy policy callout border removed",
+    "features": [
+      {
+        "text": "Unify themes across website and app"
+      },
+      {
+        "text": "Refreshed theme system and typography polish"
+      },
+      {
+        "text": "A shared theme system now keeps the website and app visually aligned"
+      }
+    ],
+    "fixes": [
+      {
+        "text": "Updater progress bar lag removed"
+      },
+      {
+        "text": "Refine sharing QR layout and footer hover states"
+      },
+      {
+        "text": "Reorder sidebar sources and fix the clipped QR heading"
+      },
+      {
+        "text": "Desktop scrapers now run in sequence, which helps avoid renderer stalls"
+      },
+      {
+        "text": "Paginate the changelog and polish roadmap motion"
+      }
+    ],
+    "followUps": [],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1203",
+    "prNumbers": [
+      184,
+      185,
+      186,
+      187,
+      188,
+      190,
+      191,
+      192,
+      193,
+      194,
+      195,
+      196,
+      197,
+      198,
+      199,
+      200,
+      201,
+      202,
+      203,
+      204,
+      205
+    ],
+    "builds": [
+      "26.4.1200",
+      "26.4.1201",
+      "26.4.1203"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.4.1200",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1200",
+        "channel": "production"
+      },
+      {
+        "version": "26.4.1201",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1201",
+        "channel": "production"
+      },
+      {
+        "version": "26.4.1203",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1203",
+        "channel": "production"
+      }
+    ]
+  },
+  {
+    "version": "26.4.1100",
+    "tagName": "v26.4.1100",
+    "channel": "production",
+    "date": "2026-04-12T06:06:18Z",
+    "deck": "Contacts settings and sync, rotating desktop snapshots, and unify theming across website and app",
+    "features": [
+      {
+        "text": "Finish Google Contacts settings and sync"
+      },
+      {
+        "text": "Rotating desktop snapshots"
+      },
+      {
+        "text": "Unify theming across website and app"
+      }
+    ],
+    "fixes": [
+      {
+        "text": "Desktop map and smoke assertions are now more stable"
+      },
+      {
+        "text": "Handle empty release validation args"
+      },
+      {
+        "text": "Support macOS bash in release publish"
+      },
+      {
+        "text": "Mark items read when scrolled past"
+      },
+      {
+        "text": "Make browser session copy more accurate"
+      },
+      {
+        "text": "Silence background social scrapers"
+      },
+      {
+        "text": "Redeploy website after release publish"
+      },
+      {
+        "text": "Overhaul changelog release notes and cards"
+      },
+      {
+        "text": "Backfill concise historical changelog notes"
+      }
+    ],
+    "followUps": [
+      {
+        "text": "Public-safe bug reporting"
+      },
+      {
+        "text": "Browser-style navigation history"
+      },
+      {
+        "text": "Move feeds into source accordion"
+      },
+      {
+        "text": "Provider health diagnostics and source management"
+      }
+    ],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1100",
+    "prNumbers": [
+      156,
+      158,
+      161,
+      162,
+      165,
+      172,
+      173,
+      174,
+      175,
+      176,
+      177,
+      178,
+      179,
+      180,
+      181,
+      182
+    ],
+    "builds": [
+      "26.4.1100"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.4.1100",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.1100",
+        "channel": "production"
+      }
+    ]
+  },
+  {
+    "version": "26.4.900",
+    "tagName": "v26.4.900",
+    "channel": "production",
+    "date": "2026-04-10T04:38:56Z",
+    "deck": "Provider health diagnostics and quieter background scrapers",
+    "features": [
+      {
+        "text": "New provider health diagnostics make it easier to spot auth issues and source problems."
+      }
+    ],
+    "fixes": [
+      {
+        "text": "Items now mark as read when you scroll past them."
+      },
+      {
+        "text": "Browser session copy is more accurate."
+      },
+      {
+        "text": "Background social scrapers stay quieter when they do not need attention."
+      }
+    ],
+    "followUps": [],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.900",
+    "prNumbers": [
+      158,
+      175,
+      176,
+      177
+    ],
+    "builds": [
+      "26.4.900"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.4.900",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.900",
+        "channel": "production"
+      }
+    ]
+  },
+  {
+    "version": "26.4.301",
+    "tagName": "v26.4.301",
+    "channel": "production",
+    "date": "2026-04-03T21:30:37Z",
+    "deck": "Website changelog catches same-day releases",
+    "features": [],
+    "fixes": [
+      {
+        "text": "freed.wtf now redeploys after a release publishes so the changelog includes the newly shipped build"
+      },
+      {
+        "text": "Release notes and changelog cards now use cleaner reviewed summaries"
+      },
+      {
+        "text": "Historical releases now keep concise daily rollups without losing major highlights"
+      },
+      {
+        "text": "Freed Desktop update prompts now show a cleaner single-line release summary"
+      }
+    ],
+    "followUps": [
+      {
+        "text": "Sharper release messaging"
+      }
+    ],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.301",
+    "prNumbers": [
+      172,
+      173,
+      174
+    ],
+    "builds": [
+      "26.4.300",
+      "26.4.301"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.4.300",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.300",
+        "channel": "production"
+      },
+      {
+        "version": "26.4.301",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.301",
+        "channel": "production"
+      }
+    ]
+  },
+  {
+    "version": "26.4.109",
+    "tagName": "v26.4.109",
+    "channel": "production",
+    "date": "2026-04-02T02:49:52Z",
+    "deck": "Map view, refined consent gates, and signed macOS installs",
+    "features": [
+      {
+        "text": "New map and Friends views"
+      },
+      {
+        "text": "Signed macOS installs"
+      },
+      {
+        "text": "Refined consent gates"
+      }
+    ],
+    "fixes": [
+      {
+        "text": "Optimized desktop feed webview media usage"
+      },
+      {
+        "text": "Social scraper webviews are now recycled after each run"
+      },
+      {
+        "text": "Settings toggles now stay shared across Freed Desktop and UI"
+      },
+      {
+        "text": "Desktop startup and scraper window modes are now more stable"
+      },
+      {
+        "text": "Scraper restore URL handling is now explicit"
+      },
+      {
+        "text": "Desktop startup now recovers when the consent store fails"
+      },
+      {
+        "text": "LinkedIn desktop integration is now complete"
+      }
+    ],
+    "followUps": [
+      {
+        "text": "Simplify legal consent surfaces"
+      },
+      {
+        "text": "Finalize qr landing page experience"
+      }
+    ],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.109",
+    "prNumbers": [
+      150,
+      151,
+      152,
+      153,
+      154,
+      155,
+      157,
+      159,
+      163,
+      164,
+      166,
+      167,
+      168,
+      169,
+      170,
+      171
+    ],
+    "builds": [
+      "26.4.100",
+      "26.4.101",
+      "26.4.102",
+      "26.4.103",
+      "26.4.105",
+      "26.4.107",
+      "26.4.108",
+      "26.4.109"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.4.100",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.100",
+        "channel": "production"
+      },
+      {
+        "version": "26.4.101",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.101",
+        "channel": "production"
+      },
+      {
+        "version": "26.4.102",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.102",
+        "channel": "production"
+      },
+      {
+        "version": "26.4.103",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.103",
+        "channel": "production"
+      },
+      {
+        "version": "26.4.105",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.105",
+        "channel": "production"
+      },
+      {
+        "version": "26.4.107",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.107",
+        "channel": "production"
+      },
+      {
+        "version": "26.4.108",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.108",
+        "channel": "production"
+      },
+      {
+        "version": "26.4.109",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.4.109",
+        "channel": "production"
+      }
+    ]
+  },
+  {
+    "version": "26.3.3100",
+    "tagName": "v26.3.3100",
+    "channel": "production",
+    "date": "2026-04-01T05:12:01Z",
+    "deck": "QR landing page and refined consent gates",
+    "features": [
+      {
+        "text": "Refined consent gates"
+      },
+      {
+        "text": "Finalize qr landing page experience"
+      }
+    ],
+    "fixes": [],
+    "followUps": [],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.3100",
+    "prNumbers": [
+      150,
+      151
+    ],
+    "builds": [
+      "26.3.3100"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.3.3100",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.3100",
+        "channel": "production"
+      }
+    ]
+  },
+  {
+    "version": "26.3.2402",
+    "tagName": "v26.3.2402",
+    "channel": "production",
+    "date": "2026-03-25T04:11:35Z",
+    "deck": "Friends view and contacts sync, LinkedIn capture, and feed card and reader actions",
+    "features": [
+      {
+        "text": "Friends view and contacts sync"
+      },
+      {
+        "text": "LinkedIn capture"
+      },
+      {
+        "text": "Feed card and reader actions"
+      }
+    ],
+    "fixes": [
+      {
+        "text": "Filter polluted social feed items and add Facebook group filters"
+      }
+    ],
+    "followUps": [
+      {
+        "text": "Surface update download progress inside the Settings card"
+      }
+    ],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.2402",
+    "prNumbers": [
+      131,
+      133,
+      145,
+      146,
+      147,
+      148
+    ],
+    "builds": [
+      "26.3.2400",
+      "26.3.2402"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.3.2400",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.2400",
+        "channel": "production"
+      },
+      {
+        "version": "26.3.2402",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.2402",
+        "channel": "production"
+      }
+    ]
+  },
+  {
+    "version": "26.3.1300",
+    "tagName": "v26.3.1300",
+    "channel": "production",
+    "date": "2026-03-13T14:44:55Z",
+    "deck": "Instagram and Facebook story scraping interleaved with feed scrolling",
+    "features": [
+      {
+        "text": "IG/FB story scraping interleaved with feed scrolling"
+      }
+    ],
+    "fixes": [],
+    "followUps": [],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.1300",
+    "prNumbers": [
+      136
+    ],
+    "builds": [
+      "26.3.1300"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.3.1300",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.1300",
+        "channel": "production"
+      }
+    ]
+  },
+  {
+    "version": "26.3.1200",
+    "tagName": "v26.3.1200",
+    "channel": "production",
+    "date": "2026-03-13T03:50:50Z",
+    "deck": "Daily changelog grouping and fB/IG scraper windows instead of moving them off-screen now stays out of the way",
+    "features": [
+      {
+        "text": "Group changelog cards by CalVer day"
+      }
+    ],
+    "fixes": [],
+    "followUps": [],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.1200",
+    "prNumbers": [
+      143,
+      144
+    ],
+    "builds": [
+      "26.3.1200"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.3.1200",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.1200",
+        "channel": "production"
+      }
+    ]
+  },
+  {
+    "version": "26.3.1101",
+    "tagName": "v26.3.1101",
+    "channel": "production",
+    "date": "2026-03-11T20:13:18Z",
+    "deck": "File logging and freeze guards",
+    "features": [
+      {
+        "text": "Structured file logging and freeze guards"
+      }
+    ],
+    "fixes": [
+      {
+        "text": "Clean CI test failures and automate PWA release deployment"
+      }
+    ],
+    "followUps": [],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.1101",
+    "prNumbers": [
+      141,
+      142
+    ],
+    "builds": [
+      "26.3.1100",
+      "26.3.1101"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.3.1100",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.1100",
+        "channel": "production"
+      },
+      {
+        "version": "26.3.1101",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.1101",
+        "channel": "production"
+      }
+    ]
+  },
+  {
+    "version": "26.3.1002",
+    "tagName": "v26.3.1002",
+    "channel": "production",
+    "date": "2026-03-11T06:10:34Z",
+    "deck": "Dual column reader view, capture hardening, and platform-specific install cautions",
+    "features": [
+      {
+        "text": "Dual column reader view"
+      },
+      {
+        "text": "Platform-specific install cautions"
+      },
+      {
+        "text": "Capture hardening"
+      }
+    ],
+    "fixes": [
+      {
+        "text": "Release build and type-safety cleanup"
+      },
+      {
+        "text": "Sync and update reliability fixes"
+      },
+      {
+        "text": "Reader, feed, and header polish"
+      },
+      {
+        "text": "Connect button to be enabled before clicking in X E2E test now waits for the correct ready state"
+      },
+      {
+        "text": "Scraper window after FB scrape, stop stealing focus on IG scrape now stays out of the way"
+      },
+      {
+        "text": "E2E social capture tests and post-migration perf baselines"
+      },
+      {
+        "text": "Stop Automerge undefined writes from crashing RSS and X sync"
+      },
+      {
+        "text": "PWA UI polish -- header, settings, update check, X settings"
+      },
+      {
+        "text": "Fix OAuth redirect URI, Google Drive client secret, offline status, and diagnostics panel"
+      },
+      {
+        "text": "Opaque surface background on update toast now uses the correct path"
+      }
+    ],
+    "followUps": [
+      {
+        "text": "Release workflow and build-system work"
+      },
+      {
+        "text": "Reader, sidebar, and settings UX work"
+      },
+      {
+        "text": "Capture, login, and scraping platform work"
+      },
+      {
+        "text": "Sync, cloud, and pairing infrastructure"
+      },
+      {
+        "text": "Testing, diagnostics, and developer tooling"
+      },
+      {
+        "text": "Content and documentation work"
+      },
+      {
+        "text": "Bookmarked items cannot be archived"
+      },
+      {
+        "text": "Archive toolbar with delete action and retention settings"
+      }
+    ],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.1002",
+    "prNumbers": [
+      6,
+      7,
+      8,
+      9,
+      10,
+      11,
+      12,
+      13,
+      16,
+      27,
+      31,
+      32,
+      34,
+      35,
+      36,
+      37,
+      38,
+      39,
+      40,
+      41,
+      42,
+      43,
+      44,
+      45,
+      46,
+      47,
+      48,
+      49,
+      50,
+      51,
+      52,
+      55,
+      56,
+      57,
+      58,
+      59,
+      71,
+      72,
+      73,
+      74,
+      75,
+      76,
+      77,
+      78,
+      79,
+      80,
+      81,
+      82,
+      83,
+      84,
+      85,
+      86,
+      87,
+      89,
+      90,
+      91,
+      92,
+      93,
+      94,
+      95,
+      96,
+      97,
+      98,
+      100,
+      101,
+      102,
+      103,
+      104,
+      105,
+      106,
+      107,
+      108,
+      109,
+      110,
+      111,
+      112,
+      113,
+      114,
+      115,
+      116,
+      117,
+      118,
+      119,
+      120,
+      121,
+      122,
+      123,
+      124,
+      125,
+      126,
+      127,
+      128,
+      129,
+      130,
+      132,
+      134,
+      135,
+      137,
+      138,
+      139,
+      140
+    ],
+    "builds": [
+      "26.3.1000",
+      "26.3.1001",
+      "26.3.1002"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.3.1000",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.1000",
+        "channel": "production"
+      },
+      {
+        "version": "26.3.1001",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.1001",
+        "channel": "production"
+      },
+      {
+        "version": "26.3.1002",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.1002",
+        "channel": "production"
+      }
+    ]
+  },
+  {
+    "version": "26.3.904",
+    "tagName": "v26.3.904",
+    "channel": "production",
+    "date": "2026-03-10T01:01:55Z",
+    "deck": "Changelog page, remove frosted glass, fix update banner, unused user-agent import from fb-capture.ts, and capture-x build step from release CI",
+    "features": [
+      {
+        "text": "Changelog page, remove frosted glass, fix update banner"
+      },
+      {
+        "text": "Remove unused user-agent import from fb-capture.ts"
+      },
+      {
+        "text": "Remove capture-x build step from release CI"
+      }
+    ],
+    "fixes": [
+      {
+        "text": "Scraper window after FB scrape, stop stealing focus on IG scrape now stays out of the way"
+      }
+    ],
+    "followUps": [
+      {
+        "text": "Anti-detection hardening for social media capture"
+      },
+      {
+        "text": "Switch reqwest and tauri-plugin-updater to rustls-tls"
+      }
+    ],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.904",
+    "prNumbers": [
+      118,
+      119,
+      120,
+      121,
+      122,
+      123,
+      124,
+      125,
+      126
+    ],
+    "builds": [
+      "26.3.903",
+      "26.3.904"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.3.903",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.903",
+        "channel": "production"
+      },
+      {
+        "version": "26.3.904",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.904",
+        "channel": "production"
+      }
+    ]
+  },
+  {
+    "version": "26.3.804",
+    "tagName": "v26.3.804",
+    "channel": "production",
+    "date": "2026-03-09T03:27:30Z",
+    "deck": "Sidebar purple dots, dev auto-seed, and social sample data and social engagement via outbox pattern (like, seen-sync, comment links)",
+    "features": [
+      {
+        "text": "Sidebar purple dots, dev auto-seed, and social sample data"
+      },
+      {
+        "text": "Social engagement via outbox pattern (like, seen-sync, comment links)"
+      }
+    ],
+    "fixes": [],
+    "followUps": [],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.804",
+    "prNumbers": [
+      113,
+      114,
+      115,
+      116,
+      117
+    ],
+    "builds": [
+      "26.3.804"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.3.804",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.804",
+        "channel": "production"
+      }
+    ]
+  },
+  {
+    "version": "26.3.703",
+    "tagName": "v26.3.703",
+    "channel": "production",
+    "date": "2026-03-08T05:30:11Z",
+    "deck": "Playwright e2e smoke test infrastructure for desktop, dual-column split view, and uI polish bundle - tooltips, hover states, scroll reset, save fix, sidebar counts",
+    "features": [
+      {
+        "text": "Playwright e2e smoke test infrastructure for desktop"
+      },
+      {
+        "text": "UI polish bundle - tooltips, hover states, scroll reset, save fix, sidebar counts"
+      },
+      {
+        "text": "Overhaul dual-column split view"
+      }
+    ],
+    "fixes": [
+      {
+        "text": "Archive cache staleness + scroll-read visibility model"
+      },
+      {
+        "text": "Redundant data wrapper from TimelineResponse type removed"
+      }
+    ],
+    "followUps": [
+      {
+        "text": "X and Facebook scrapers with Tauri WebView capture"
+      },
+      {
+        "text": "Manual cookie entry with native X login window"
+      },
+      {
+        "text": "Sample data seeding + fix PWA build and Automerge worker"
+      }
+    ],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.703",
+    "prNumbers": [
+      98,
+      102,
+      103,
+      104,
+      105,
+      106,
+      107,
+      108,
+      109,
+      110,
+      111,
+      112
+    ],
+    "builds": [
+      "26.3.702",
+      "26.3.703"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.3.702",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.702",
+        "channel": "production"
+      },
+      {
+        "version": "26.3.703",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.703",
+        "channel": "production"
+      }
+    ]
+  },
+  {
+    "version": "26.3.601",
+    "tagName": "v26.3.601",
+    "channel": "production",
+    "date": "2026-03-06T22:40:26Z",
+    "deck": "Fix focus mode showing raw HTML brackets from RSS feed descriptions and double-cast window through unknown to satisfy strict TS in mock files",
+    "features": [],
+    "fixes": [],
+    "followUps": [],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.601",
+    "prNumbers": [
+      101
+    ],
+    "builds": [
+      "26.3.601"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.3.601",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.601",
+        "channel": "production"
+      }
+    ]
+  },
+  {
+    "version": "26.3.504",
+    "tagName": "v26.3.504",
+    "channel": "production",
+    "date": "2026-03-05T18:19:48Z",
+    "deck": "Complete X/Twitter integration end-to-end, build out the archive system end-to-end, and universal full-text search across all sources",
+    "features": [
+      {
+        "text": "Complete X/Twitter integration end-to-end"
+      },
+      {
+        "text": "Command bar foundation with settings navigation and lower-contrast search"
+      },
+      {
+        "text": "Mark items as read when scrolled past in the feed list"
+      }
+    ],
+    "fixes": [
+      {
+        "text": "Stop Automerge undefined writes from crashing RSS and X sync"
+      },
+      {
+        "text": "Align sidebar section headers to same height as items"
+      },
+      {
+        "text": "PWA UI polish -- header, settings, update check, X settings"
+      },
+      {
+        "text": "Increase header toolbar gap from 8px to 24px"
+      },
+      {
+        "text": "Uniform header spacing and hide command palette on mobile"
+      },
+      {
+        "text": "Correct CSS @import order, hide swipe indicator at rest, polish search hover"
+      },
+      {
+        "text": "Trigger update check when button enters viewport, not scrollspy threshold"
+      },
+      {
+        "text": "Init flash and reduce desktop startup serialization overhead removed"
+      },
+      {
+        "text": "Import invoke/isTauri from @tauri-apps/api/core instead of window.__TAURI__"
+      },
+      {
+        "text": "Auto-update service worker and add purple F favicon"
+      },
+      {
+        "text": "Mobile feed to window scroll for Safari address bar collapse now uses the updated transport"
+      },
+      {
+        "text": "Highlight Updates nav item on individual post pages"
+      },
+      {
+        "text": "Open all How You Can Help links in new tab"
+      },
+      {
+        "text": "Never assign undefined into Automerge documents"
+      }
+    ],
+    "followUps": [
+      {
+        "text": "Fix feed reader lockup and move PWA Automerge to a Web Worker"
+      },
+      {
+        "text": "PWA X settings page and fix duplicate search clear button"
+      },
+      {
+        "text": "Instant app launch with deferred migrations and skeleton loading"
+      },
+      {
+        "text": "Enhance Ulysses Mode and Manifesto content for clarity and impact"
+      },
+      {
+        "text": "Unified two-column Settings dialog with scrollspy and I/O sections"
+      },
+      {
+        "text": "Consolidate global CSS into packages/UI/src/index.css"
+      },
+      {
+        "text": "Lockfile after installing plugin-fs and plugin-store"
+      },
+      {
+        "text": "Saved content modal, folder import, phased progress, unit tests"
+      },
+      {
+        "text": "Phase 8 friends CRM + social graph scaffolding"
+      },
+      {
+        "text": "Tighten introducing-freed post, cut technical architecture section"
+      },
+      {
+        "text": "Fix UI freeze when entering reading mode"
+      },
+      {
+        "text": "Move X connection to Settings > Sources > X page"
+      },
+      {
+        "text": "Hardcoded local path from .cargo/config.toml removed"
+      }
+    ],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.504",
+    "prNumbers": [
+      48,
+      49,
+      50,
+      51,
+      52,
+      55,
+      56,
+      57,
+      58,
+      59,
+      71,
+      72,
+      73,
+      74,
+      75,
+      76,
+      77,
+      78,
+      79,
+      80,
+      81,
+      82,
+      83,
+      84,
+      85,
+      86,
+      87,
+      89,
+      90,
+      91,
+      92,
+      93,
+      94,
+      95,
+      96,
+      97,
+      99,
+      100
+    ],
+    "builds": [
+      "26.3.502",
+      "26.3.503",
+      "26.3.504"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.3.502",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.502",
+        "channel": "production"
+      },
+      {
+        "version": "26.3.503",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.503",
+        "channel": "production"
+      },
+      {
+        "version": "26.3.504",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.504",
+        "channel": "production"
+      }
+    ]
+  },
+  {
+    "version": "26.3.303",
+    "tagName": "v26.3.303",
+    "channel": "production",
+    "date": "2026-03-04T00:57:10Z",
+    "deck": "Privacy policy page, heal untitled feed titles from live XML on sync, and syncConnectDialog UX",
+    "features": [
+      {
+        "text": "Privacy policy page"
+      },
+      {
+        "text": "Heal untitled feed titles from live XML on sync"
+      },
+      {
+        "text": "Subscribe to RSS feeds from the PWA with deferred metadata"
+      }
+    ],
+    "fixes": [],
+    "followUps": [
+      {
+        "text": "Startup feed-name healing, toolbar height, window drag"
+      },
+      {
+        "text": "Fix OAuth redirect URI, Google Drive client secret, and offline status"
+      },
+      {
+        "text": "Rewrite Google OAuth proxy as Node.js Lambda"
+      },
+      {
+        "text": "Locale-aware unread count formatting and number formatting rule"
+      },
+      {
+        "text": "OAuth client IDs to release workflow, adjust traffic light position"
+      },
+      {
+        "text": "Bulk unsubscribe and factory reset features"
+      }
+    ],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.303",
+    "prNumbers": [
+      31,
+      32,
+      34,
+      35,
+      36,
+      37,
+      38,
+      39,
+      40,
+      41,
+      42,
+      43,
+      44,
+      45,
+      46,
+      47
+    ],
+    "builds": [
+      "26.3.300",
+      "26.3.302",
+      "26.3.303"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.3.300",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.300",
+        "channel": "production"
+      },
+      {
+        "version": "26.3.302",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.302",
+        "channel": "production"
+      },
+      {
+        "version": "26.3.303",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.303",
+        "channel": "production"
+      }
+    ]
+  },
+  {
+    "version": "26.3.200",
+    "tagName": "v26.3.200",
+    "channel": "production",
+    "date": "2026-03-03T15:54:05Z",
+    "deck": "Sync section explains user-owned cloud storage + passphrase encryption and mDNS discovery, cloud file sync + desktop cloud sync",
+    "features": [
+      {
+        "text": "Sync section explains user-owned cloud storage + passphrase encryption"
+      },
+      {
+        "text": "MDNS discovery, cloud file sync + desktop cloud sync"
+      }
+    ],
+    "fixes": [],
+    "followUps": [],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.200",
+    "prNumbers": [
+      6,
+      7,
+      8,
+      9,
+      10,
+      11,
+      12,
+      13,
+      16,
+      27
+    ],
+    "builds": [
+      "26.3.200"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.3.200",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.200",
+        "channel": "production"
+      }
+    ]
+  },
+  {
+    "version": "26.3.104",
+    "tagName": "v26.3.104",
+    "channel": "production",
+    "date": "2026-03-02T05:30:02Z",
+    "deck": "Per-feed context menu with sync status, rename, and unsubscribe, system, CalVer DDBUILD, UI polish, and fix tab strip alignment in AddFeedDialog",
+    "features": [
+      {
+        "text": "Per-feed context menu with sync status, rename, and unsubscribe"
+      },
+      {
+        "text": "Sync button opens status popover instead of immediate refresh"
+      },
+      {
+        "text": "UI polish , settings cleanup, sync unification, sidebar refinements"
+      }
+    ],
+    "fixes": [
+      {
+        "text": "Logo in desktop mobile-layout to clear macOS traffic lights now stays out of the way"
+      },
+      {
+        "text": "Add top padding to first card in feed list"
+      },
+      {
+        "text": "Reader toolbar full-width layout and macOS inset constant"
+      },
+      {
+        "text": "RSS feed persistence, platform capability honesty, desktop UI polish"
+      },
+      {
+        "text": "Fix hero vertical centering and desktop text alignment"
+      },
+      {
+        "text": "Fix iOS keyboard occlusion and bottom viewport gap"
+      },
+      {
+        "text": "IPhone safe-area gaps, desktop sync to settings, traffic light alignment"
+      },
+      {
+        "text": "Auto-publish release after all builds complete"
+      },
+      {
+        "text": "Full iPhone mobile compatibility"
+      },
+      {
+        "text": "Read version from package.json instead of npm_package_version"
+      },
+      {
+        "text": "Newsletter modal subscribe button scrunched on mobile"
+      },
+      {
+        "text": "Case/esac instead of bash 4 associative arrays now uses the correct path"
+      },
+      {
+        "text": "Include PWA sources in desktop Tailwind content scan"
+      },
+      {
+        "text": "YY.M.D CalVer to stay within MSI 255 major version limit now uses the correct path"
+      }
+    ],
+    "followUps": [
+      {
+        "text": "Rename sidebar-scroll to minimal-scroll, apply to feed content area"
+      },
+      {
+        "text": "Lazy-load images, drop backdrop-filter blur, add scroll gutter"
+      },
+      {
+        "text": "Move X connect UI from sidebar into feed blank state"
+      },
+      {
+        "text": "Eliminate redundant re-renders on feed list scroll"
+      },
+      {
+        "text": "UI overhaul , unified header, draggable sidebar, modal consistency"
+      },
+      {
+        "text": "Early-build disclaimer and clarify app vs desktop roles"
+      },
+      {
+        "text": "Release.sh for CalVer and PWA version lockstep"
+      },
+      {
+        "text": "PWA and Desktop UI components via PlatformContext"
+      },
+      {
+        "text": "Deep-linkable /get modal, restore tooltip, disable subscribe"
+      },
+      {
+        "text": "Redesign Get Freed modal with app links and downloads"
+      }
+    ],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.104",
+    "prNumbers": [
+      4,
+      5
+    ],
+    "builds": [
+      "26.3.100",
+      "26.3.101",
+      "26.3.102",
+      "26.3.103",
+      "26.3.104"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.3.100",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.100",
+        "channel": "production"
+      },
+      {
+        "version": "26.3.101",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.101",
+        "channel": "production"
+      },
+      {
+        "version": "26.3.102",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.102",
+        "channel": "production"
+      },
+      {
+        "version": "26.3.103",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.103",
+        "channel": "production"
+      },
+      {
+        "version": "26.3.104",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.3.104",
+        "channel": "production"
+      }
+    ]
+  },
+  {
+    "version": "0.2.0",
+    "tagName": "v0.2.0",
+    "channel": "production",
+    "date": "2026-03-02T01:16:53Z",
+    "deck": "@freed/capture-facebook and @freed/capture-instagram packages, sync, cloud, and pairing infrastructure, and content and documentation work",
+    "features": [
+      {
+        "text": "@freed/capture-facebook and @freed/capture-instagram packages"
+      },
+      {
+        "text": "Mark all as read + unread count in desktop header"
+      },
+      {
+        "text": "Per-feed RSS sidebar with unread counts in desktop app"
+      }
+    ],
+    "fixes": [
+      {
+        "text": "Force Automerge base64 entry and use real signing password"
+      },
+      {
+        "text": "Skip Automerge WASM patch and fix signing password"
+      },
+      {
+        "text": "Release build and type-safety cleanup"
+      },
+      {
+        "text": "Update button text and comment out motion paragraph"
+      },
+      {
+        "text": "Sync pipeline, X capture wiring, save quick action on cards"
+      },
+      {
+        "text": "Honest copy and interaction affordances"
+      },
+      {
+        "text": "Update descriptions in HowItWorks component for clarity"
+      }
+    ],
+    "followUps": [
+      {
+        "text": "Testing, diagnostics, and developer tooling"
+      }
+    ],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v0.2.0",
+    "prNumbers": [],
+    "builds": [
+      "0.2.0"
+    ],
+    "buildLinks": [
+      {
+        "version": "0.2.0",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v0.2.0",
+        "channel": "production"
       }
     ]
   }


### PR DESCRIPTION
(AI Generated).

## Summary
- fetch all GitHub release pages before building the static changelog snapshot
- recover PR numbers for manual local release-note rollups from their release compare boundary
- regenerate the changelog snapshot so production history spans six pages and v26.5.3113 shows its merged PRs

## Tests
- GITHUB_TOKEN=$(gh auth token) PATH=../node_modules/.bin:$PATH npm run build
- ./scripts/worktree-preview.sh website --worktree /Users/aubreyfalconer/dev/freed-changelog-history-prs --label changelog-history-prs
- curl http://localhost:3001/changelog?verify=history-prs
- curl http://localhost:3001/changelog/6?verify=history-prs