### PR TITLE
fix: flag stalled Facebook empty syncs

### DIFF
--- a/packages/desktop/src/lib/fb-capture.ts
+++ b/packages/desktop/src/lib/fb-capture.ts
@@ -155,6 +155,11 @@ function formatFacebookNormalizationSummary(
 
 function formatFacebookEmptySyncMessage(diag: FbSyncDiag): string {
   const details: string[] = [];
+  const scrollAppearsStuck =
+    diag.extractionPasses >= 3 &&
+    diag.lastCandidateCount === 0 &&
+    typeof diag.lastScrollY === "number" &&
+    diag.lastScrollY < 250;
 
   if (diag.extractionPasses > 0) {
     details.push(
@@ -174,6 +179,9 @@ function formatFacebookEmptySyncMessage(diag: FbSyncDiag): string {
   }
   if (typeof diag.feedContainerFound === "boolean") {
     details.push(`feed container ${diag.feedContainerFound ? "found" : "not found"}`);
+  }
+  if (scrollAppearsStuck) {
+    details.push("scroll appears stuck near the top");
   }
 
   return details.length > 0

--- a/packages/desktop/src/lib/social-capture-memory-pressure.test.ts
+++ b/packages/desktop/src/lib/social-capture-memory-pressure.test.ts
@@ -319,6 +319,55 @@ describe("social capture completion", () => {
     );
     expect(mocks.storeState.fbAuth.lastCapturedAt).toBe(123_456);
   });
+
+  it("flags the Facebook zero-post pattern where scroll never advances", async () => {
+    const listeners = new Map<string, (event: { payload: unknown }) => void>();
+    mocks.prepareSocialScrapeMemory.mockResolvedValue({
+      before: {},
+      after: { appResidentBytes: 512 * 1024 * 1024 },
+      recycledScraperWindows: false,
+      cacheTrimmed: false,
+      mayProceed: true,
+    });
+    mocks.listen.mockImplementation(async (eventName: string, callback: (event: { payload: unknown }) => void) => {
+      listeners.set(eventName, callback);
+      return vi.fn();
+    });
+    mocks.invoke.mockImplementation(async (command: string) => {
+      if (command !== "fb_scrape_feed") return null;
+
+      for (let pass = 0; pass < 8; pass++) {
+        listeners.get("fb-feed-data")?.({
+          payload: {
+            posts: [],
+            extractedAt: Date.now(),
+            url: "https://www.facebook.com/",
+            strategy: "role-main-fallback",
+            candidateCount: 0,
+            scrollY: 135,
+            feedContainerFound: false,
+          },
+        });
+      }
+      return null;
+    });
+
+    const { captureFbFeed } = await import("./fb-capture");
+
+    const result = await captureFbFeed();
+    const expectedMessage =
+      "Feed returned no posts. Facebook may need a moment to load. " +
+      "8 extraction passes, last strategy role-main-fallback, 0 candidates on the last pass, " +
+      "scrollY 135, feed container not found, scroll appears stuck near the top.";
+
+    expect(result.items).toEqual([]);
+    expect(mocks.storeState.setError).toHaveBeenCalledWith(expectedMessage);
+    expect(mocks.storeState.setFbAuth).toHaveBeenCalledWith({
+      isAuthenticated: true,
+      lastCapturedAt: 123_456,
+      lastCaptureError: expectedMessage,
+    });
+  });
 });
 
 describe("social capture memory pressure gate", () => {


### PR DESCRIPTION
(AI Generated).

## Summary
- Detect the zero-post Facebook failure signature where repeated extraction passes leave scroll near the top with no candidates.
- Surface that stalled-scroll diagnosis in the empty sync error and provider health reason.

## Testing
- npm run test:unit -- src/lib/social-capture-memory-pressure.test.ts src/lib/fb-extract-dom.test.ts src/lib/fb-stories-extract.test.ts
- npm run validate:feature