### PR TITLE
fix: avoid false social sync failures

### DIFF
--- a/packages/desktop/src/components/FacebookSettingsSection.tsx
+++ b/packages/desktop/src/components/FacebookSettingsSection.tsx
@@ -49,6 +49,7 @@ import { withProviderSyncing } from "../lib/store";
 import { clearProviderPause, resetProviderPauseState } from "../lib/provider-health";
 import { MediaVaultSettingsCard } from "./MediaVaultSettingsCard";
 import { socialProviderCopy } from "../lib/social-provider-copy";
+import { isRuntimeDeferredStage } from "../lib/social-capture-runtime";
 
 // =============================================================================
 // Diagnostic Panel
@@ -152,6 +153,7 @@ function Toggle({
 }
 
 function FbDiagPanel({ diag }: { diag: FbSyncDiag }) {
+  const runtimeDeferred = isRuntimeDeferredStage(diag.errorStage);
   return (
     <details className="group">
       <summary className="text-xs text-[#52525b] hover:text-[#71717a] cursor-pointer select-none list-none flex items-center gap-1">
@@ -183,8 +185,12 @@ function FbDiagPanel({ diag }: { diag: FbSyncDiag }) {
         />
 
         {diag.errorStage && (
-          <p className="text-red-400 pt-1 leading-relaxed">
-            Failed at{" "}
+          <p
+            className={`${
+              runtimeDeferred ? "text-[#a1a1aa]" : "text-red-400"
+            } pt-1 leading-relaxed`}
+          >
+            {runtimeDeferred ? "Deferred at" : "Failed at"}{" "}
             <span className="font-semibold">{diag.errorStage}</span>
             {diag.errorMessage ? `: ${diag.errorMessage}` : ""}
           </p>

--- a/packages/desktop/src/components/InstagramSettingsSection.tsx
+++ b/packages/desktop/src/components/InstagramSettingsSection.tsx
@@ -42,6 +42,7 @@ import { withProviderSyncing } from "../lib/store";
 import { clearProviderPause, resetProviderPauseState } from "../lib/provider-health";
 import { MediaVaultSettingsCard } from "./MediaVaultSettingsCard";
 import { socialProviderCopy } from "../lib/social-provider-copy";
+import { isRuntimeDeferredStage } from "../lib/social-capture-runtime";
 
 // =============================================================================
 // Diagnostic Panel
@@ -65,6 +66,7 @@ function DiagRow({ label, value, warn }: DiagRowProps) {
 }
 
 function IgDiagPanel({ diag }: { diag: IgSyncDiag }) {
+  const runtimeDeferred = isRuntimeDeferredStage(diag.errorStage);
   return (
     <details className="group">
       <summary className="text-xs text-[#52525b] hover:text-[#71717a] cursor-pointer select-none list-none flex items-center gap-1">
@@ -96,8 +98,12 @@ function IgDiagPanel({ diag }: { diag: IgSyncDiag }) {
         />
 
         {diag.errorStage && (
-          <p className="text-red-400 pt-1 leading-relaxed">
-            Failed at{" "}
+          <p
+            className={`${
+              runtimeDeferred ? "text-[#a1a1aa]" : "text-red-400"
+            } pt-1 leading-relaxed`}
+          >
+            {runtimeDeferred ? "Deferred at" : "Failed at"}{" "}
             <span className="font-semibold">{diag.errorStage}</span>
             {diag.errorMessage ? `: ${diag.errorMessage}` : ""}
           </p>

--- a/packages/desktop/src/lib/background-runtime-coordinator.test.ts
+++ b/packages/desktop/src/lib/background-runtime-coordinator.test.ts
@@ -113,6 +113,73 @@ describe("background runtime coordinator", () => {
     await scrape;
   });
 
+  it("lets social scrapes wait for active local semantic work", async () => {
+    const coordinator = await loadCoordinator();
+    coordinator.resetBackgroundRuntimeForTests({ requireRendererHealth: true });
+    coordinator.noteRendererHeartbeat(heartbeat(1));
+    coordinator.noteRendererHeartbeat(heartbeat(2));
+
+    let releaseSemantic: () => void = () => {};
+    const semantic = coordinator.runBackgroundJob({
+      kind: "semantic-classifier",
+      source: "content-signals",
+      run: () => new Promise<void>((resolve) => {
+        releaseSemantic = resolve;
+      }),
+    });
+
+    await Promise.resolve();
+    let completed = false;
+    const scrape = coordinator.runBackgroundJob({
+      kind: "social-scrape",
+      source: "instagram:feed",
+      waitForActiveJobMs: 1_000,
+      waitForActiveJobKinds: ["semantic-classifier"],
+      run: () => {
+        completed = true;
+        return "scraped";
+      },
+    });
+
+    await Promise.resolve();
+    expect(completed).toBe(false);
+
+    releaseSemantic();
+    await semantic;
+    await expect(scrape).resolves.toBe("scraped");
+    expect(completed).toBe(true);
+  });
+
+  it("keeps a second social scrape deferred instead of queueing another provider window", async () => {
+    const coordinator = await loadCoordinator();
+    coordinator.resetBackgroundRuntimeForTests({ requireRendererHealth: true });
+    coordinator.noteRendererHeartbeat(heartbeat(1));
+    coordinator.noteRendererHeartbeat(heartbeat(2));
+
+    let releaseScrape: () => void = () => {};
+    const first = coordinator.runBackgroundJob({
+      kind: "social-scrape",
+      source: "facebook:feed",
+      run: () => new Promise<void>((resolve) => {
+        releaseScrape = resolve;
+      }),
+    });
+
+    await Promise.resolve();
+    await expect(
+      coordinator.runBackgroundJob({
+        kind: "social-scrape",
+        source: "instagram:feed",
+        waitForActiveJobMs: 1_000,
+        waitForActiveJobKinds: ["semantic-classifier"],
+        run: () => "scraped",
+      }),
+    ).rejects.toMatchObject({ reason: "active:social-scrape:facebook:feed" });
+
+    releaseScrape();
+    await first;
+  });
+
   it("pauses jobs during memory pressure cooldown", async () => {
     vi.useFakeTimers();
     const coordinator = await loadCoordinator();

--- a/packages/desktop/src/lib/background-runtime-coordinator.ts
+++ b/packages/desktop/src/lib/background-runtime-coordinator.ts
@@ -44,6 +44,8 @@ export interface BackgroundRuntimeTask<T> {
   kind: BackgroundJobKind;
   source: string;
   timeoutMs?: number;
+  waitForActiveJobMs?: number;
+  waitForActiveJobKinds?: readonly BackgroundJobKind[];
   run: () => Promise<T> | T;
 }
 
@@ -64,6 +66,7 @@ let activeJob: {
   startedAt: number;
 } | null = null;
 let requireRendererHealth = import.meta.env.MODE !== "test";
+let activeJobWaiters: Array<() => void> = [];
 
 export class BackgroundRuntimeDeferredError extends Error {
   readonly reason: string;
@@ -83,6 +86,54 @@ export function isBackgroundRuntimeDeferredError(
 
 function nowMs(): number {
   return Date.now();
+}
+
+function isActiveJobReason(reason: string): boolean {
+  return reason.startsWith("active:");
+}
+
+function activeKindFromReason(reason: string): BackgroundJobKind | null {
+  if (!isActiveJobReason(reason)) return null;
+  const [, kind] = reason.split(":");
+  return (kind as BackgroundJobKind | undefined) ?? null;
+}
+
+function shouldWaitForActiveJob<T>(
+  task: BackgroundRuntimeTask<T>,
+  reason: string,
+): boolean {
+  if (!task.waitForActiveJobMs || task.waitForActiveJobMs <= 0) return false;
+  const activeKind = activeKindFromReason(reason);
+  if (!activeKind) return false;
+  return !task.waitForActiveJobKinds || task.waitForActiveJobKinds.includes(activeKind);
+}
+
+function notifyActiveJobWaiters(): void {
+  const waiters = activeJobWaiters;
+  activeJobWaiters = [];
+  for (const notify of waiters) {
+    notify();
+  }
+}
+
+function waitForActiveJobChange(timeoutMs: number): Promise<void> {
+  if (timeoutMs <= 0 || !activeJob) return Promise.resolve();
+
+  return new Promise((resolve) => {
+    let done = false;
+    let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+
+    const finish = () => {
+      if (done) return;
+      done = true;
+      if (timeoutHandle) clearTimeout(timeoutHandle);
+      activeJobWaiters = activeJobWaiters.filter((waiter) => waiter !== finish);
+      resolve();
+    };
+
+    activeJobWaiters.push(finish);
+    timeoutHandle = setTimeout(finish, timeoutMs);
+  });
 }
 
 function markCooldown(durationMs: number, reason: string): void {
@@ -190,7 +241,17 @@ export function canStartBackgroundJob(kind: BackgroundJobKind): { ok: true } | {
 }
 
 export async function runBackgroundJob<T>(task: BackgroundRuntimeTask<T>): Promise<T> {
-  const gate = canStartBackgroundJob(task.kind);
+  let gate = canStartBackgroundJob(task.kind);
+  if (!gate.ok && shouldWaitForActiveJob(task, gate.reason)) {
+    const deadline = nowMs() + (task.waitForActiveJobMs ?? 0);
+    while (!gate.ok && shouldWaitForActiveJob(task, gate.reason)) {
+      const remainingMs = deadline - nowMs();
+      if (remainingMs <= 0) break;
+      await waitForActiveJobChange(remainingMs);
+      gate = canStartBackgroundJob(task.kind);
+    }
+  }
+
   if (!gate.ok) {
     throw new BackgroundRuntimeDeferredError(gate.reason);
   }
@@ -219,6 +280,7 @@ export async function runBackgroundJob<T>(task: BackgroundRuntimeTask<T>): Promi
   } finally {
     if (timeoutHandle) clearTimeout(timeoutHandle);
     activeJob = null;
+    notifyActiveJobWaiters();
   }
 }
 
@@ -230,5 +292,6 @@ export function resetBackgroundRuntimeForTests(options?: { requireRendererHealth
   lastRecoveryReason = null;
   pressureLevel = "normal";
   activeJob = null;
+  notifyActiveJobWaiters();
   requireRendererHealth = options?.requireRendererHealth ?? false;
 }

--- a/packages/desktop/src/lib/fb-capture.ts
+++ b/packages/desktop/src/lib/fb-capture.ts
@@ -32,6 +32,12 @@ import { archiveRecentProviderMedia, upsertMediaVaultRosterFromItems } from "./m
 import { socialProviderCopy } from "./social-provider-copy";
 import { runBackgroundJob } from "./background-runtime-coordinator";
 import {
+  applyRuntimeDeferredDiag,
+  isRuntimeDeferredStage,
+  SOCIAL_SCRAPE_WAIT_FOR_JOB_KINDS,
+  SOCIAL_SCRAPE_WAIT_FOR_LOCAL_WORK_MS,
+} from "./social-capture-runtime";
+import {
   facebookGroupsFromFeedItems,
   mergeFacebookGroupRecords,
 } from "./facebook-groups";
@@ -369,11 +375,16 @@ export async function fetchFbFeed(): Promise<FbSyncResult> {
       kind: "social-scrape",
       source: "facebook:feed",
       timeoutMs: 600_000,
+      waitForActiveJobMs: SOCIAL_SCRAPE_WAIT_FOR_LOCAL_WORK_MS,
+      waitForActiveJobKinds: SOCIAL_SCRAPE_WAIT_FOR_JOB_KINDS,
       run: () => invoke("fb_scrape_feed", { windowMode: getFbScraperWindowMode() }),
     });
     await new Promise<void>((resolve) => setTimeout(resolve, 500));
   } catch (err) {
     if (!diag.errorStage) {
+      if (applyRuntimeDeferredDiag(diag, err)) {
+        return { items: [], diag };
+      }
       diag.errorStage = "invoke";
       diag.errorMessage = err instanceof Error ? err.message : String(err);
     }
@@ -523,11 +534,17 @@ export async function captureFbFeed(): Promise<FbSyncResult> {
   try {
     addDebugEvent("change", "[FB] sync started");
     const result = await fetchFbFeed();
-    recordScrape();
 
     if (result.diag.errorStage) {
-      const detail = `[FB] sync failed at stage="${result.diag.errorStage}": ${result.diag.errorMessage ?? "(no message)"}`;
-      addDebugEvent("error", detail);
+      const runtimeDeferred = isRuntimeDeferredStage(result.diag.errorStage);
+      const detail = `[FB] sync ${runtimeDeferred ? "deferred" : "failed"} at stage="${result.diag.errorStage}": ${result.diag.errorMessage ?? "(no message)"}`;
+      addDebugEvent(runtimeDeferred ? "change" : "error", detail);
+      if (runtimeDeferred) {
+        return result;
+      }
+      if (result.diag.errorStage !== "memory_pressure") {
+        recordScrape();
+      }
       if (result.diag.errorStage !== "memory_pressure") {
         store.setError(result.diag.errorMessage ?? result.diag.errorStage);
         const errState = { ...useAppStore.getState().fbAuth, lastCaptureError: result.diag.errorMessage ?? result.diag.errorStage ?? "Sync failed" };
@@ -547,6 +564,7 @@ export async function captureFbFeed(): Promise<FbSyncResult> {
       return result;
     }
 
+    recordScrape();
     if (result.items.length > 0) {
       await repairStoredFacebookGroupNamesFromItems(result.items);
       const excludedGroupIds =

--- a/packages/desktop/src/lib/instagram-capture.ts
+++ b/packages/desktop/src/lib/instagram-capture.ts
@@ -29,6 +29,12 @@ import { formatBytesForMemoryLog, prepareSocialScrapeMemory } from "./memory-mon
 import { archiveRecentProviderMedia, upsertMediaVaultRosterFromItems } from "./media-vault";
 import { socialProviderCopy } from "./social-provider-copy";
 import { runBackgroundJob } from "./background-runtime-coordinator";
+import {
+  applyRuntimeDeferredDiag,
+  isRuntimeDeferredStage,
+  SOCIAL_SCRAPE_WAIT_FOR_JOB_KINDS,
+  SOCIAL_SCRAPE_WAIT_FOR_LOCAL_WORK_MS,
+} from "./social-capture-runtime";
 
 // =============================================================================
 // Rate Limiting
@@ -143,12 +149,17 @@ export async function fetchIgFeed(): Promise<IgSyncResult> {
       kind: "social-scrape",
       source: "instagram:feed",
       timeoutMs: 600_000,
+      waitForActiveJobMs: SOCIAL_SCRAPE_WAIT_FOR_LOCAL_WORK_MS,
+      waitForActiveJobKinds: SOCIAL_SCRAPE_WAIT_FOR_JOB_KINDS,
       run: () => invoke("ig_scrape_feed", { windowMode: getIgScraperWindowMode() }),
     });
 
     // Brief wait for any in-flight events to arrive after invoke resolves
     await new Promise<void>((r) => setTimeout(r, 500));
   } catch (err) {
+    if (applyRuntimeDeferredDiag(diag, err)) {
+      return { items: [], diag };
+    }
     diag.errorStage = "invoke";
     diag.errorMessage = err instanceof Error ? err.message : String(err);
     return { items: [], diag };
@@ -240,11 +251,17 @@ export async function captureIgFeed(): Promise<IgSyncResult> {
   try {
     addDebugEvent("change", "[IG] sync started");
     const result = await fetchIgFeed();
-    recordScrape();
 
     if (result.diag.errorStage) {
-      const detail = `[IG] sync failed at stage="${result.diag.errorStage}": ${result.diag.errorMessage ?? "(no message)"}`;
-      addDebugEvent("error", detail);
+      const runtimeDeferred = isRuntimeDeferredStage(result.diag.errorStage);
+      const detail = `[IG] sync ${runtimeDeferred ? "deferred" : "failed"} at stage="${result.diag.errorStage}": ${result.diag.errorMessage ?? "(no message)"}`;
+      addDebugEvent(runtimeDeferred ? "change" : "error", detail);
+      if (runtimeDeferred) {
+        return result;
+      }
+      if (result.diag.errorStage !== "memory_pressure") {
+        recordScrape();
+      }
       if (result.diag.errorStage !== "memory_pressure") {
         store.setError(result.diag.errorMessage ?? result.diag.errorStage);
         const errState = { ...useAppStore.getState().igAuth, lastCaptureError: result.diag.errorMessage ?? result.diag.errorStage ?? "Sync failed" };
@@ -264,6 +281,7 @@ export async function captureIgFeed(): Promise<IgSyncResult> {
       return result;
     }
 
+    recordScrape();
     if (result.items.length > 0) {
       addDebugEvent(
         "change",

--- a/packages/desktop/src/lib/social-capture-memory-pressure.test.ts
+++ b/packages/desktop/src/lib/social-capture-memory-pressure.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => {
+  const recordProviderHealthEvent = vi.fn();
   const storeState = {
     items: [] as Array<{ platform: string; globalId?: string }>,
     preferences: {},
@@ -48,6 +49,7 @@ const mocks = vi.hoisted(() => {
     invoke: vi.fn(),
     listen: vi.fn(),
     prepareSocialScrapeMemory: vi.fn(),
+    recordProviderHealthEvent,
     storeState,
     resetStoreState: () => {
       storeState.items = [];
@@ -62,6 +64,7 @@ const mocks = vi.hoisted(() => {
       storeState.setLiAuth.mockClear();
       storeState.addItems.mockClear();
       storeState.updatePreferences.mockClear();
+      recordProviderHealthEvent.mockClear();
     },
     fbPostsToFeedItems: vi.fn((posts: Array<{ id?: string }>) =>
       posts.map((post, index) => ({
@@ -113,7 +116,7 @@ vi.mock("./scraper-media-diag", () => ({
 
 vi.mock("./provider-health", () => ({
   getProviderPause: vi.fn(() => null),
-  recordProviderHealthEvent: vi.fn(),
+  recordProviderHealthEvent: mocks.recordProviderHealthEvent,
 }));
 
 vi.mock("./fb-auth", () => ({ storeFbAuthState: vi.fn() }));
@@ -367,6 +370,82 @@ describe("social capture completion", () => {
       lastCapturedAt: 123_456,
       lastCaptureError: expectedMessage,
     });
+  });
+
+  it("waits for local semantic indexing before invoking Instagram scrape", async () => {
+    mocks.prepareSocialScrapeMemory.mockResolvedValue({
+      before: {},
+      after: { appResidentBytes: 512 * 1024 * 1024 },
+      recycledScraperWindows: false,
+      cacheTrimmed: false,
+      mayProceed: true,
+    });
+    mocks.listen.mockResolvedValue(vi.fn());
+    mocks.invoke.mockResolvedValue(null);
+
+    const coordinator = await import("./background-runtime-coordinator");
+    coordinator.resetBackgroundRuntimeForTests();
+    let releaseSemantic: () => void = () => {};
+    const semantic = coordinator.runBackgroundJob({
+      kind: "semantic-classifier",
+      source: "content-signals",
+      run: () => new Promise<void>((resolve) => {
+        releaseSemantic = resolve;
+      }),
+    });
+
+    await Promise.resolve();
+    const { fetchIgFeed } = await import("./instagram-capture");
+    const resultPromise = fetchIgFeed();
+
+    await Promise.resolve();
+    expect(mocks.invoke).not.toHaveBeenCalledWith("ig_scrape_feed", expect.anything());
+
+    releaseSemantic();
+    await semantic;
+    const result = await resultPromise;
+
+    expect(result.diag.errorStage).toBeNull();
+    expect(mocks.invoke).toHaveBeenCalledWith("ig_scrape_feed", expect.anything());
+  });
+
+  it("does not poison Instagram health when a provider scrape is already active", async () => {
+    mocks.prepareSocialScrapeMemory.mockResolvedValue({
+      before: {},
+      after: { appResidentBytes: 512 * 1024 * 1024 },
+      recycledScraperWindows: false,
+      cacheTrimmed: false,
+      mayProceed: true,
+    });
+    mocks.listen.mockResolvedValue(vi.fn());
+
+    const coordinator = await import("./background-runtime-coordinator");
+    coordinator.resetBackgroundRuntimeForTests();
+    let releaseScrape: () => void = () => {};
+    const activeScrape = coordinator.runBackgroundJob({
+      kind: "social-scrape",
+      source: "facebook:feed",
+      run: () => new Promise<void>((resolve) => {
+        releaseScrape = resolve;
+      }),
+    });
+
+    await Promise.resolve();
+    const { captureIgFeed } = await import("./instagram-capture");
+    const result = await captureIgFeed();
+
+    expect(result.diag.errorStage).toBe("runtime_deferred");
+    expect(result.diag.errorMessage).toContain("local background work");
+    expect(mocks.invoke).not.toHaveBeenCalledWith("ig_scrape_feed", expect.anything());
+    expect(mocks.storeState.setError).toHaveBeenCalledWith(null);
+    expect(mocks.storeState.setError).not.toHaveBeenCalledWith(
+      expect.stringContaining("background work"),
+    );
+    expect(mocks.storeState.setIgAuth).not.toHaveBeenCalled();
+    expect(mocks.recordProviderHealthEvent).not.toHaveBeenCalled();
+
+    releaseScrape();
+    await activeScrape;
   });
 });
 

--- a/packages/desktop/src/lib/social-capture-runtime.ts
+++ b/packages/desktop/src/lib/social-capture-runtime.ts
@@ -1,0 +1,56 @@
+import type { BackgroundJobKind } from "./background-runtime-coordinator";
+import { isBackgroundRuntimeDeferredError } from "./background-runtime-coordinator";
+
+export const SOCIAL_SCRAPE_WAIT_FOR_LOCAL_WORK_MS = 150_000;
+export const SOCIAL_SCRAPE_WAIT_FOR_JOB_KINDS = [
+  "cloud-sync",
+  "content-fetch",
+  "content-signal-backfill",
+  "outbox",
+  "rss-poll",
+  "semantic-classifier",
+  "snapshot",
+] satisfies BackgroundJobKind[];
+
+export const RUNTIME_DEFERRED_STAGE = "runtime_deferred";
+
+export interface RuntimeDeferredDiag {
+  errorStage: string | null;
+  errorMessage: string | null;
+}
+
+export function runtimeDeferredMessage(reason: string): string {
+  if (reason.startsWith("active:semantic-classifier:")) {
+    return "Freed is finishing local semantic indexing. Try syncing again in a moment.";
+  }
+  if (reason.startsWith("active:content-signal-backfill:")) {
+    return "Freed is finishing local content-signal indexing. Try syncing again in a moment.";
+  }
+  if (reason.startsWith("active:")) {
+    return "Freed is finishing local background work. Try syncing again in a moment.";
+  }
+  if (reason.startsWith("waiting_for_renderer_heartbeat:")) {
+    return "Freed is waiting for the app window to report healthy. Try syncing again in a moment.";
+  }
+  if (reason.startsWith("renderer_safe_mode:") || reason.startsWith("cooldown:")) {
+    return "Freed paused background work while the app recovers. Try syncing again in a moment.";
+  }
+  if (reason === "high_memory_pressure" || reason === "critical_memory_pressure") {
+    return "Freed paused provider sync because memory is high. Try syncing again after memory settles.";
+  }
+  return "Freed deferred provider sync for local background work. Try syncing again in a moment.";
+}
+
+export function applyRuntimeDeferredDiag(
+  diag: RuntimeDeferredDiag,
+  error: unknown,
+): boolean {
+  if (!isBackgroundRuntimeDeferredError(error)) return false;
+  diag.errorStage = RUNTIME_DEFERRED_STAGE;
+  diag.errorMessage = runtimeDeferredMessage(error.reason);
+  return true;
+}
+
+export function isRuntimeDeferredStage(stage: string | null): boolean {
+  return stage === RUNTIME_DEFERRED_STAGE;
+}


### PR DESCRIPTION
(AI Generated).

## Summary
- Wait for local semantic indexing before starting Facebook and Instagram scrapes, without opening extra provider windows.
- Treat runtime scheduling deferrals as local deferrals, not provider failures, so Instagram health and last capture errors are not poisoned.
- Show deferred sync diagnostics separately from failed provider diagnostics in Facebook and Instagram settings.

## Testing
- PATH=/Users/aubreyfalconer/dev/freed-social-sync-runtime-deferral/node_modules/.bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/usr/local/MacGPG2/bin:/Applications/VMware Fusion.app/Contents/Public:/usr/local/share/dotnet:~/.dotnet/tools:/usr/local/go/bin:/Library/Frameworks/Mono.framework/Versions/Current/Commands:/Users/aubreyfalconer/.nvm/versions/node/v24.14.1/bin:/Users/aubreyfalconer/.codex/tmp/arg0/codex-arg0jhObyX:/Users/aubreyfalconer/.local/bin:/opt/homebrew/opt/mysql-client/bin:/opt/homebrew/bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/Users/aubreyfalconer/.cargo/bin:/Users/aubreyfalconer/go/bin:/Users/aubreyfalconer/.cache/lm-studio/bin:/Users/aubreyfalconer/.safe-chain/bin:/Applications/Codex.app/Contents/Resources:/usr/local/bin npm run test:unit -- src/lib/background-runtime-coordinator.test.ts src/lib/social-capture-memory-pressure.test.ts
- PATH=/Users/aubreyfalconer/dev/freed-social-sync-runtime-deferral/node_modules/.bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/usr/local/MacGPG2/bin:/Applications/VMware Fusion.app/Contents/Public:/usr/local/share/dotnet:~/.dotnet/tools:/usr/local/go/bin:/Library/Frameworks/Mono.framework/Versions/Current/Commands:/Users/aubreyfalconer/.nvm/versions/node/v24.14.1/bin:/Users/aubreyfalconer/.codex/tmp/arg0/codex-arg0jhObyX:/Users/aubreyfalconer/.local/bin:/opt/homebrew/opt/mysql-client/bin:/opt/homebrew/bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/Users/aubreyfalconer/.cargo/bin:/Users/aubreyfalconer/go/bin:/Users/aubreyfalconer/.cache/lm-studio/bin:/Users/aubreyfalconer/.safe-chain/bin:/Applications/Codex.app/Contents/Resources:/usr/local/bin npm run test:e2e -- social-memory-preflight.spec.ts
- PATH=/Users/aubreyfalconer/dev/freed-social-sync-runtime-deferral/node_modules/.bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/usr/local/MacGPG2/bin:/Applications/VMware Fusion.app/Contents/Public:/usr/local/share/dotnet:~/.dotnet/tools:/usr/local/go/bin:/Library/Frameworks/Mono.framework/Versions/Current/Commands:/Users/aubreyfalconer/.nvm/versions/node/v24.14.1/bin:/Users/aubreyfalconer/.codex/tmp/arg0/codex-arg0jhObyX:/Users/aubreyfalconer/.local/bin:/opt/homebrew/opt/mysql-client/bin:/opt/homebrew/bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/Users/aubreyfalconer/.cargo/bin:/Users/aubreyfalconer/go/bin:/Users/aubreyfalconer/.cache/lm-studio/bin:/Users/aubreyfalconer/.safe-chain/bin:/Applications/Codex.app/Contents/Resources:/usr/local/bin npm run test:e2e:perf:settings
- npm run validate:feature