### PR TITLE
test: stabilize sidebar toggle regression

### DIFF
--- a/packages/desktop/tests/e2e/smoke.spec.ts
+++ b/packages/desktop/tests/e2e/smoke.spec.ts
@@ -665,7 +665,8 @@ test("desktop sidebar toggle still clicks normally from the shared toolbar", asy
 
   await sidebarToggle.click();
   await expect(sidebarToggle).toHaveAttribute("aria-label", "Show sidebar");
-  await expectDesktopSidebarShellWidthAtMost(page, 2, 1_000);
+  await waitForDesktopSidebarMode(page, "closed");
+  await expectDesktopSidebarShellWidthAtMost(page, 2, 3_000);
 });
 
 test("narrow desktop viewports keep the desktop compact rail instead of switching to the mobile drawer", async ({ app, page }) => {


### PR DESCRIPTION
(AI Generated).

## Summary

- Wait for the app store to report the desktop sidebar as closed before asserting the shell width.
- Extend the shell-width settle window from 1 second to 3 seconds to cover slow CI transition/persistence timing.

## Validation

- `node ../../node_modules/playwright/cli.js test smoke.spec.ts --grep "desktop sidebar toggle still clicks normally from the shared toolbar" --repeat-each=10`
- `node ../../node_modules/playwright/cli.js test smoke.spec.ts --grep "desktop workspace keeps a single top toolbar|desktop sidebar toggle still clicks normally" --repeat-each=3`