### PR TITLE
fix: require live auth for social source status

### DIFF
--- a/packages/desktop/src/lib/source-status.test.ts
+++ b/packages/desktop/src/lib/source-status.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import { getDesktopSourceStatus, type SourceStatusInput } from "./source-status";
+import type {
+  HealthProviderId,
+  ProviderHealthDebugState,
+  ProviderHealthSnapshot,
+} from "@freed/ui/lib/debug-store";
+
+function providerSnapshot(
+  provider: HealthProviderId,
+  overrides: Partial<ProviderHealthSnapshot> = {},
+): ProviderHealthSnapshot {
+  return {
+    provider,
+    status: "healthy",
+    pause: null,
+    dailyBuckets: [],
+    hourlyBuckets: [],
+    latestAttempts: [],
+    totalSeen7d: 0,
+    totalAdded7d: 0,
+    totalBytes7d: 0,
+    ...overrides,
+  };
+}
+
+function health(
+  overrides: Partial<ProviderHealthDebugState["providers"]> = {},
+): ProviderHealthDebugState {
+  return {
+    providers: {
+      rss: providerSnapshot("rss"),
+      x: providerSnapshot("x"),
+      facebook: providerSnapshot("facebook"),
+      instagram: providerSnapshot("instagram"),
+      linkedin: providerSnapshot("linkedin"),
+      gdrive: providerSnapshot("gdrive"),
+      dropbox: providerSnapshot("dropbox"),
+      ...overrides,
+    },
+    failingRssFeeds: [],
+    updatedAt: Date.now(),
+  };
+}
+
+function sourceState(overrides: Partial<SourceStatusInput> = {}): SourceStatusInput {
+  return {
+    feeds: {},
+    providerSyncCounts: {},
+    itemCountByPlatform: {},
+    ...overrides,
+  };
+}
+
+describe("desktop source status", () => {
+  it("does not use old Facebook items as proof of a live connection", () => {
+    const status = getDesktopSourceStatus(
+      "facebook",
+      sourceState({
+        fbAuth: { isAuthenticated: false },
+        itemCountByPlatform: { facebook: 132 },
+      }),
+      health({
+        facebook: providerSnapshot("facebook", {
+          status: "healthy",
+          lastOutcome: "success",
+          lastSuccessfulAt: Date.now() - 60_000,
+        }),
+      }),
+    );
+
+    expect(status).toBeNull();
+  });
+
+  it("still surfaces reconnect-required social source errors without a live connection", () => {
+    const status = getDesktopSourceStatus(
+      "facebook",
+      sourceState({
+        fbAuth: {
+          isAuthenticated: false,
+          lastCaptureError:
+            "Facebook did not render an authenticated feed. Reconnect Facebook and try again.",
+        },
+        itemCountByPlatform: { facebook: 132 },
+      }),
+      health({
+        facebook: providerSnapshot("facebook", {
+          status: "healthy",
+          lastOutcome: "success",
+        }),
+      }),
+    );
+
+    expect(status?.tone).toBe("critical");
+    expect(status?.label).toBe("Reconnect required");
+  });
+});

--- a/packages/desktop/src/lib/source-status.ts
+++ b/packages/desktop/src/lib/source-status.ts
@@ -79,14 +79,6 @@ export function getDesktopSourceStatus(
           : sourceId === "linkedin"
             ? desktopState.liAuth
             : null;
-  const sourceItemCount =
-    sourceId === "x" ||
-    sourceId === "facebook" ||
-    sourceId === "instagram" ||
-    sourceId === "linkedin"
-      ? (desktopState.itemCountByPlatform[sourceId] ?? 0)
-      : 0;
-
   const snapshot =
     sourceId === "x" ||
     sourceId === "facebook" ||
@@ -96,7 +88,7 @@ export function getDesktopSourceStatus(
       : undefined;
   const authError =
     typeof authState?.lastCaptureError === "string" ? authState.lastCaptureError : undefined;
-  const isConnected = authState?.isAuthenticated === true || sourceItemCount > 0;
+  const isConnected = authState?.isAuthenticated === true;
   const tone = getProviderStatusTone({
     isConnected,
     authError,


### PR DESCRIPTION
(AI Generated).

## Summary
- Stops old social posts from making Facebook, Instagram, LinkedIn, or X look connected after auth is gone.

## Testing
- npm run validate:feature