### PR TITLE
fix: detect stale social provider auth state

### DIFF
--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -1288,7 +1288,7 @@ dependencies = [
 
 [[package]]
 name = "freed-desktop"
-version = "26.5.3117"
+version = "26.6.103"
 dependencies = [
  "base64 0.22.1",
  "criterion",

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -257,6 +257,245 @@ fn social_scraper_data_store_identifier(label: &str) -> Option<[u8; 16]> {
     }
 }
 
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SocialProviderCookieState {
+    provider: String,
+    available: bool,
+    has_auth_cookie: bool,
+    cookie_count: usize,
+    cookie_names: Vec<String>,
+    error: Option<String>,
+}
+
+fn data_store_identifier_folder(identifier: [u8; 16]) -> String {
+    format!(
+        "{:02x}{:02x}{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
+        identifier[0],
+        identifier[1],
+        identifier[2],
+        identifier[3],
+        identifier[4],
+        identifier[5],
+        identifier[6],
+        identifier[7],
+        identifier[8],
+        identifier[9],
+        identifier[10],
+        identifier[11],
+        identifier[12],
+        identifier[13],
+        identifier[14],
+        identifier[15],
+    )
+}
+
+fn social_auth_cookie_config(
+    provider: &str,
+) -> Option<(&'static str, [u8; 16], &'static [&'static str])> {
+    match provider {
+        "facebook" => Some((
+            "facebook",
+            FB_SCRAPER_DATA_STORE_IDENTIFIER,
+            &["c_user", "xs"],
+        )),
+        "instagram" => Some((
+            "instagram",
+            IG_SCRAPER_DATA_STORE_IDENTIFIER,
+            &["sessionid"],
+        )),
+        "linkedin" => Some(("linkedin", LI_SCRAPER_DATA_STORE_IDENTIFIER, &["li_at"])),
+        _ => None,
+    }
+}
+
+fn read_u32_be(data: &[u8], offset: usize) -> Option<u32> {
+    let bytes = data.get(offset..offset + 4)?;
+    Some(u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]))
+}
+
+fn read_u32_le(data: &[u8], offset: usize) -> Option<u32> {
+    let bytes = data.get(offset..offset + 4)?;
+    Some(u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]))
+}
+
+fn cookie_record_string(record: &[u8], offset: usize) -> Option<String> {
+    if offset == 0 || offset >= record.len() {
+        return None;
+    }
+    let end = record[offset..]
+        .iter()
+        .position(|byte| *byte == 0)
+        .map(|relative| offset + relative)
+        .unwrap_or(record.len());
+    std::str::from_utf8(record.get(offset..end)?)
+        .ok()
+        .filter(|value| !value.is_empty())
+        .map(|value| value.to_string())
+}
+
+fn parse_webkit_binary_cookie_names(data: &[u8]) -> Result<Vec<String>, String> {
+    if data.len() < 8 || data.get(0..4) != Some(b"cook") {
+        return Err("Invalid WebKit cookie store header".to_string());
+    }
+
+    let page_count = read_u32_be(data, 4).ok_or_else(|| "Missing page count".to_string())? as usize;
+    let sizes_start = 8usize;
+    let sizes_end = sizes_start
+        .checked_add(page_count.saturating_mul(4))
+        .ok_or_else(|| "Cookie page table is too large".to_string())?;
+    if sizes_end > data.len() {
+        return Err("Cookie page table exceeds file size".to_string());
+    }
+
+    let mut page_sizes = Vec::with_capacity(page_count);
+    for index in 0..page_count {
+        let offset = sizes_start + index * 4;
+        page_sizes.push(read_u32_be(data, offset).unwrap_or(0) as usize);
+    }
+
+    let mut names = HashSet::new();
+    let mut page_start = sizes_end;
+    for page_size in page_sizes {
+        let Some(page_end) = page_start.checked_add(page_size) else {
+            break;
+        };
+        let Some(page) = data.get(page_start..page_end) else {
+            break;
+        };
+        page_start = page_end;
+
+        if page.len() < 8 {
+            continue;
+        }
+        let cookie_count = read_u32_le(page, 4).unwrap_or(0) as usize;
+        for index in 0..cookie_count {
+            let offset_offset = 8 + index * 4;
+            let Some(record_offset) = read_u32_le(page, offset_offset).map(|value| value as usize)
+            else {
+                continue;
+            };
+            let Some(record_size) = read_u32_le(page, record_offset).map(|value| value as usize)
+            else {
+                continue;
+            };
+            if record_size == 0 {
+                continue;
+            }
+            let Some(record_end) = record_offset.checked_add(record_size) else {
+                continue;
+            };
+            let Some(record) = page.get(record_offset..record_end) else {
+                continue;
+            };
+            let Some(name_offset) = read_u32_le(record, 20).map(|value| value as usize) else {
+                continue;
+            };
+            if let Some(name) = cookie_record_string(record, name_offset) {
+                names.insert(name);
+            }
+        }
+    }
+
+    let mut names: Vec<String> = names.into_iter().collect();
+    names.sort();
+    Ok(names)
+}
+
+#[cfg(target_os = "macos")]
+fn webkit_cookie_store_path(
+    app: &tauri::AppHandle,
+    identifier: [u8; 16],
+) -> Result<PathBuf, String> {
+    let home = app.path().home_dir().map_err(|error| error.to_string())?;
+    Ok(home
+        .join("Library")
+        .join("WebKit")
+        .join(app.config().identifier.as_str())
+        .join("WebsiteDataStore")
+        .join(data_store_identifier_folder(identifier))
+        .join("Cookies")
+        .join("Cookies.binarycookies"))
+}
+
+#[tauri::command]
+fn get_social_provider_cookie_state(
+    app: tauri::AppHandle,
+    provider: String,
+) -> Result<SocialProviderCookieState, String> {
+    let Some((provider, identifier, auth_cookie_names)) =
+        social_auth_cookie_config(provider.as_str())
+    else {
+        return Err(format!("Unsupported social provider: {}", provider));
+    };
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        return Ok(SocialProviderCookieState {
+            provider: provider.to_string(),
+            available: false,
+            has_auth_cookie: false,
+            cookie_count: 0,
+            cookie_names: Vec::new(),
+            error: Some("Provider cookie diagnostics are only available on macOS.".to_string()),
+        });
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        let path = webkit_cookie_store_path(&app, identifier)?;
+        let data = match std::fs::read(&path) {
+            Ok(data) => data,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(SocialProviderCookieState {
+                    provider: provider.to_string(),
+                    available: false,
+                    has_auth_cookie: false,
+                    cookie_count: 0,
+                    cookie_names: Vec::new(),
+                    error: None,
+                });
+            }
+            Err(error) => {
+                return Ok(SocialProviderCookieState {
+                    provider: provider.to_string(),
+                    available: false,
+                    has_auth_cookie: false,
+                    cookie_count: 0,
+                    cookie_names: Vec::new(),
+                    error: Some(error.to_string()),
+                });
+            }
+        };
+
+        let cookie_names = match parse_webkit_binary_cookie_names(&data) {
+            Ok(cookie_names) => cookie_names,
+            Err(error) => {
+                return Ok(SocialProviderCookieState {
+                    provider: provider.to_string(),
+                    available: false,
+                    has_auth_cookie: false,
+                    cookie_count: 0,
+                    cookie_names: Vec::new(),
+                    error: Some(error),
+                });
+            }
+        };
+        let has_auth_cookie = cookie_names
+            .iter()
+            .any(|name| auth_cookie_names.iter().any(|auth_name| name == auth_name));
+
+        Ok(SocialProviderCookieState {
+            provider: provider.to_string(),
+            available: true,
+            has_auth_cookie,
+            cookie_count: cookie_names.len(),
+            cookie_names,
+            error: None,
+        })
+    }
+}
+
 fn recycle_webview_window(app: &tauri::AppHandle, label: &str, reason: &str) {
     if let Some(window) = app.get_webview_window(label) {
         scrub_webview_before_destroy(&window);
@@ -7990,6 +8229,7 @@ pub fn run() {
             trim_webkit_network_cache_now,
             get_recent_runtime_health,
             get_ai_hardware_profile,
+            get_social_provider_cookie_state,
             prepare_social_scrape_memory,
             broadcast_doc,
             reset_pairing_token,
@@ -8170,6 +8410,73 @@ mod tests {
             title: "Facebook".to_string(),
         };
         assert!(cookie_session_without_rendered_units.feed_like());
+    }
+
+    fn binary_cookie_record(name: &str) -> Vec<u8> {
+        let domain = b".facebook.com\0";
+        let mut name_bytes = name.as_bytes().to_vec();
+        name_bytes.push(0);
+        let path = b"/\0";
+        let cookie_value = b"redacted\0";
+        let strings_start = 48usize;
+        let domain_offset = strings_start;
+        let name_offset = domain_offset + domain.len();
+        let path_offset = name_offset + name_bytes.len();
+        let value_offset = path_offset + path.len();
+        let size = value_offset + cookie_value.len();
+        let mut record = vec![0u8; strings_start];
+        record[0..4].copy_from_slice(&(size as u32).to_le_bytes());
+        record[16..20].copy_from_slice(&(domain_offset as u32).to_le_bytes());
+        record[20..24].copy_from_slice(&(name_offset as u32).to_le_bytes());
+        record[24..28].copy_from_slice(&(path_offset as u32).to_le_bytes());
+        record[28..32].copy_from_slice(&(value_offset as u32).to_le_bytes());
+        record.extend_from_slice(domain);
+        record.extend_from_slice(&name_bytes);
+        record.extend_from_slice(path);
+        record.extend_from_slice(cookie_value);
+        record
+    }
+
+    fn binary_cookie_store(names: &[&str]) -> Vec<u8> {
+        let mut page = vec![0u8; 8 + names.len() * 4];
+        page[4..8].copy_from_slice(&(names.len() as u32).to_le_bytes());
+        for (index, name) in names.iter().enumerate() {
+            let record_offset = page.len();
+            page[8 + index * 4..12 + index * 4]
+                .copy_from_slice(&(record_offset as u32).to_le_bytes());
+            page.extend_from_slice(&binary_cookie_record(name));
+        }
+
+        let mut data = Vec::new();
+        data.extend_from_slice(b"cook");
+        data.extend_from_slice(&1u32.to_be_bytes());
+        data.extend_from_slice(&(page.len() as u32).to_be_bytes());
+        data.extend_from_slice(&page);
+        data
+    }
+
+    #[test]
+    fn social_cookie_parser_reads_names_without_values() {
+        let parsed = parse_webkit_binary_cookie_names(&binary_cookie_store(&["datr", "c_user"]))
+            .expect("cookie store should parse");
+
+        assert_eq!(parsed, vec!["c_user".to_string(), "datr".to_string()]);
+    }
+
+    #[test]
+    fn data_store_identifier_folder_matches_webkit_directory_names() {
+        assert_eq!(
+            data_store_identifier_folder(FB_SCRAPER_DATA_STORE_IDENTIFIER),
+            "66726565-64fb-0001-9a7d-370102fb0001"
+        );
+        assert_eq!(
+            data_store_identifier_folder(IG_SCRAPER_DATA_STORE_IDENTIFIER),
+            "66726565-641a-0002-9a7d-3701021a0002"
+        );
+        assert_eq!(
+            data_store_identifier_folder(LI_SCRAPER_DATA_STORE_IDENTIFIER),
+            "66726565-641d-0003-9a7d-3701021d0003"
+        );
     }
 
     #[test]

--- a/packages/desktop/src/__mocks__/@tauri-apps/api/core.ts
+++ b/packages/desktop/src/__mocks__/@tauri-apps/api/core.ts
@@ -241,6 +241,17 @@ const handlers: Record<string, Handler> = {
   check_x_login_cookies: () => ({ status: "closed" }),
   close_x_login_window: () => null,
   pick_contact: () => null,
+  get_social_provider_cookie_state: (args?: { provider?: string }) => ({
+    provider: args?.provider ?? "facebook",
+    ...(((window as unknown as { __TAURI_MOCK_SOCIAL_COOKIE_STATES__?: Record<string, unknown> })
+      .__TAURI_MOCK_SOCIAL_COOKIE_STATES__?.[args?.provider ?? "facebook"] as Record<string, unknown> | undefined) ?? {
+      available: false,
+      hasAuthCookie: false,
+      cookieCount: 0,
+      cookieNames: [],
+      error: null,
+    }),
+  }),
   fb_show_login: () => null,
   fb_hide_login: () => null,
   fb_check_auth: () => true,

--- a/packages/desktop/src/lib/social-auth-cookie-state.test.ts
+++ b/packages/desktop/src/lib/social-auth-cookie-state.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import {
+  reconcileSocialAuthStateHint,
+  type SocialProviderCookieState,
+} from "./social-auth-cookie-state";
+
+function cookieState(
+  provider: SocialProviderCookieState["provider"],
+  hasAuthCookie: boolean,
+): SocialProviderCookieState {
+  return {
+    provider,
+    available: true,
+    hasAuthCookie,
+    cookieCount: hasAuthCookie ? 1 : 0,
+    cookieNames: hasAuthCookie ? ["c_user"] : [],
+    error: null,
+  };
+}
+
+describe("social auth cookie state", () => {
+  it("clears stale Facebook auth when the local WebView cookie store lacks auth cookies", () => {
+    const reconciled = reconcileSocialAuthStateHint(
+      "facebook",
+      { isAuthenticated: true, lastCheckedAt: 123 },
+      cookieState("facebook", false),
+    );
+
+    expect(reconciled).toEqual({
+      isAuthenticated: false,
+      lastCheckedAt: 123,
+      lastCaptureError:
+        "Facebook is not connected in the local WebView session. Reconnect Facebook and try again.",
+    });
+  });
+
+  it("keeps auth state when local cookie diagnostics are unavailable", () => {
+    const auth = { isAuthenticated: true, lastCheckedAt: 123 };
+
+    expect(reconcileSocialAuthStateHint("facebook", auth, null)).toBe(auth);
+  });
+
+  it("does not mark disconnected providers connected from cookie names alone", () => {
+    const auth = { isAuthenticated: false };
+
+    expect(reconcileSocialAuthStateHint("facebook", auth, cookieState("facebook", true))).toBe(auth);
+  });
+});

--- a/packages/desktop/src/lib/social-auth-cookie-state.ts
+++ b/packages/desktop/src/lib/social-auth-cookie-state.ts
@@ -1,0 +1,78 @@
+import { invoke } from "@tauri-apps/api/core";
+import type { FbAuthState } from "./fb-auth";
+import type { IgAuthState } from "./instagram-auth";
+import type { LiAuthState } from "./li-auth";
+
+type SocialProviderId = "facebook" | "instagram" | "linkedin";
+
+export interface SocialProviderCookieState {
+  provider: SocialProviderId;
+  available: boolean;
+  hasAuthCookie: boolean;
+  cookieCount: number;
+  cookieNames: string[];
+  error?: string | null;
+}
+
+interface SocialAuthStateHints {
+  fbAuth: FbAuthState;
+  igAuth: IgAuthState;
+  liAuth: LiAuthState;
+}
+
+const AUTH_MISSING_MESSAGES: Record<SocialProviderId, string> = {
+  facebook: "Facebook is not connected in the local WebView session. Reconnect Facebook and try again.",
+  instagram: "Instagram is not connected in the local WebView session. Reconnect Instagram and try again.",
+  linkedin: "LinkedIn is not connected in the local WebView session. Reconnect LinkedIn and try again.",
+};
+
+function withMissingAuthCookieMessage<T extends { isAuthenticated: boolean; lastCaptureError?: string }>(
+  provider: SocialProviderId,
+  auth: T,
+  cookieState: SocialProviderCookieState,
+): T {
+  if (!auth.isAuthenticated || !cookieState.available || cookieState.hasAuthCookie) {
+    return auth;
+  }
+
+  return {
+    ...auth,
+    isAuthenticated: false,
+    lastCaptureError: AUTH_MISSING_MESSAGES[provider],
+  };
+}
+
+export async function loadSocialProviderCookieState(
+  provider: SocialProviderId,
+): Promise<SocialProviderCookieState | null> {
+  try {
+    return await invoke<SocialProviderCookieState>("get_social_provider_cookie_state", { provider });
+  } catch {
+    return null;
+  }
+}
+
+export function reconcileSocialAuthStateHint(
+  provider: SocialProviderId,
+  auth: FbAuthState | IgAuthState | LiAuthState,
+  cookieState: SocialProviderCookieState | null,
+): FbAuthState | IgAuthState | LiAuthState {
+  if (!cookieState) return auth;
+  return withMissingAuthCookieMessage(provider, auth, cookieState);
+}
+
+export async function reconcileSocialAuthStateHints(
+  auth: SocialAuthStateHints,
+): Promise<SocialAuthStateHints> {
+  const [facebook, instagram, linkedin] = await Promise.all([
+    loadSocialProviderCookieState("facebook"),
+    loadSocialProviderCookieState("instagram"),
+    loadSocialProviderCookieState("linkedin"),
+  ]);
+
+  return {
+    fbAuth: reconcileSocialAuthStateHint("facebook", auth.fbAuth, facebook) as FbAuthState,
+    igAuth: reconcileSocialAuthStateHint("instagram", auth.igAuth, instagram) as IgAuthState,
+    liAuth: reconcileSocialAuthStateHint("linkedin", auth.liAuth, linkedin) as LiAuthState,
+  };
+}

--- a/packages/desktop/src/lib/store.ts
+++ b/packages/desktop/src/lib/store.ts
@@ -9,6 +9,7 @@
  */
 
 import { create } from "zustand";
+import { isTauri } from "@tauri-apps/api/core";
 import type { Account, FeedItem, FilterOptions, Friend, Person, ReachOutLog, SampleDataClearSummary, UserPreferences, RssFeed, RemoveFeedOptions } from "@freed/shared";
 import {
   applyFeedSignalModesToFilter,
@@ -69,9 +70,10 @@ import {
   runBackgroundJob,
 } from "./background-runtime-coordinator";
 import { log } from "./logger";
-import { initFbAuth, type FbAuthState } from "./fb-auth";
-import { initIgAuth, type IgAuthState } from "./instagram-auth";
-import { initLiAuth, type LiAuthState } from "./li-auth";
+import { initFbAuth, storeFbAuthState, type FbAuthState } from "./fb-auth";
+import { initIgAuth, storeIgAuthState, type IgAuthState } from "./instagram-auth";
+import { initLiAuth, storeLiAuthState, type LiAuthState } from "./li-auth";
+import { reconcileSocialAuthStateHints } from "./social-auth-cookie-state";
 
 let outboxTeardown: (() => void) | null = null;
 let startupContentSignalTimer: ReturnType<typeof setTimeout> | null = null;
@@ -512,9 +514,20 @@ export const useAppStore = create<AppState>((set, get) => ({
         ? { isAuthenticated: true, cookies: xCookies }
         : { isAuthenticated: false };
 
-      const fbAuth = initFbAuth();
-      const igAuth = initIgAuth();
-      const liAuth = initLiAuth();
+      let fbAuth = initFbAuth();
+      let igAuth = initIgAuth();
+      let liAuth = initLiAuth();
+
+      if (isTauri() || import.meta.env.VITE_TEST_TAURI === "1") {
+        const previousAuth = { fbAuth, igAuth, liAuth };
+        const reconciledAuth = await reconcileSocialAuthStateHints({ fbAuth, igAuth, liAuth });
+        fbAuth = reconciledAuth.fbAuth;
+        igAuth = reconciledAuth.igAuth;
+        liAuth = reconciledAuth.liAuth;
+        if (fbAuth !== previousAuth.fbAuth) storeFbAuthState(fbAuth);
+        if (igAuth !== previousAuth.igAuth) storeIgAuthState(igAuth);
+        if (liAuth !== previousAuth.liAuth) storeLiAuthState(liAuth);
+      }
 
       // Hydrate immediately from the initial DocState returned by the worker.
       set({

--- a/packages/desktop/tests/e2e/fixtures/tauri-init.ts
+++ b/packages/desktop/tests/e2e/fixtures/tauri-init.ts
@@ -149,6 +149,21 @@ export function tauriInitScript(): string {
       check_x_login_cookies: () => ({ status: 'closed' }),
       close_x_login_window: () => null,
       pick_contact: () => null,
+      get_social_provider_cookie_state: (args) => ({
+        provider: args && args.provider ? args.provider : 'facebook',
+        ...(window.__TAURI_MOCK_SOCIAL_COOKIE_STATES__ &&
+        args &&
+        args.provider &&
+        window.__TAURI_MOCK_SOCIAL_COOKIE_STATES__[args.provider]
+          ? window.__TAURI_MOCK_SOCIAL_COOKIE_STATES__[args.provider]
+          : {
+              available: false,
+              hasAuthCookie: false,
+              cookieCount: 0,
+              cookieNames: [],
+              error: null,
+            }),
+      }),
       fb_show_login: () => null,
       fb_hide_login: () => null,
       fb_check_auth: () => true,

--- a/packages/desktop/tests/e2e/social-auth-cookie-state.spec.ts
+++ b/packages/desktop/tests/e2e/social-auth-cookie-state.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from "./fixtures/app";
+
+test("startup clears stale Facebook auth when local WebView cookies are logged out", async ({
+  app,
+  page,
+}) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem(
+      "__TAURI_MOCK_STORE__:legal.json",
+      JSON.stringify({
+        "legal.bundle.desktop": {
+          version: "2026-03-31.1",
+          acceptedAt: 1775146800000,
+          surface: "desktop-first-run",
+        },
+      }),
+    );
+    window.localStorage.setItem(
+      "fb_auth_state",
+      JSON.stringify({ isAuthenticated: true, lastCheckedAt: 1775146800000 }),
+    );
+
+    (window as unknown as {
+      __TAURI_MOCK_SOCIAL_COOKIE_STATES__: Record<string, unknown>;
+    }).__TAURI_MOCK_SOCIAL_COOKIE_STATES__ = {
+      facebook: {
+        available: true,
+        hasAuthCookie: false,
+        cookieCount: 6,
+        cookieNames: ["datr", "fr", "ps_l", "ps_n", "sb", "wd"],
+        error: null,
+      },
+    };
+  });
+
+  await app.goto();
+  await app.waitForReady();
+
+  const authState = await page.evaluate(() => {
+    const store = (window as unknown as {
+      __FREED_STORE__: {
+        getState: () => {
+          fbAuth: { isAuthenticated: boolean; lastCaptureError?: string };
+        };
+      };
+    }).__FREED_STORE__;
+    return store.getState().fbAuth;
+  });
+
+  expect(authState).toEqual({
+    isAuthenticated: false,
+    lastCheckedAt: 1775146800000,
+    lastCaptureError:
+      "Facebook is not connected in the local WebView session. Reconnect Facebook and try again.",
+  });
+
+  await expect
+    .poll(() => page.evaluate(() => window.localStorage.getItem("fb_auth_state")))
+    .toContain('"isAuthenticated":false');
+});


### PR DESCRIPTION
(AI Generated).

## Summary
- Add local macOS cookie diagnostics for Facebook, Instagram, and LinkedIn provider WebView sessions without reading or logging cookie values.
- Clear stale connected state at startup when the isolated provider cookie store exists but lacks the provider auth cookie.
- Add focused unit, e2e, and native parser coverage for stale Facebook auth detection.

## Testing
- npm run validate:feature
- cargo test social_cookie_parser_reads_names_without_values --manifest-path packages/desktop/src-tauri/Cargo.toml --offline
- cargo test data_store_identifier_folder_matches_webkit_directory_names --manifest-path packages/desktop/src-tauri/Cargo.toml --offline