### PR TITLE
perf: reduce renderer atmosphere memory

### DIFF
--- a/packages/ui/src/components/layout/BackgroundAtmosphere.tsx
+++ b/packages/ui/src/components/layout/BackgroundAtmosphere.tsx
@@ -24,6 +24,8 @@ const HERO_ZONE_HEIGHT = 800;
 const MOBILE_BREAKPOINT = 768;
 const DESKTOP_BASELINE_WIDTH = 1280;
 const MIN_WIDTH_SCALE = 0.58;
+const MIN_BACKGROUND_HEIGHT = 1200;
+const VIEWPORT_BACKGROUND_BUFFER = 480;
 
 interface Orb {
   channel: ChannelName;
@@ -71,6 +73,7 @@ function generateOrbs(
   recipe: ThemeBackgroundRecipe,
   compact: boolean,
   rendererMode: RendererMode,
+  backgroundHeight: number,
 ): Orb[] {
   const orbs: Orb[] = [];
   const rowRecipe = recipe.rowOrbs;
@@ -91,8 +94,13 @@ function generateOrbs(
     });
   });
 
+  const targetHeight = clamp(
+    backgroundHeight + VIEWPORT_BACKGROUND_BUFFER,
+    MIN_BACKGROUND_HEIGHT,
+    MAX_HEIGHT,
+  );
   const numRows =
-    Math.ceil((MAX_HEIGHT - HERO_ZONE_HEIGHT) / VERTICAL_SPACING) + 1;
+    Math.ceil((targetHeight - HERO_ZONE_HEIGHT) / VERTICAL_SPACING) + 1;
   for (let row = 0; row < numRows; row++) {
     const baseY = HERO_ZONE_HEIGHT + row * VERTICAL_SPACING;
     for (let i = 0; i < countPerRow; i++) {
@@ -205,6 +213,7 @@ function resolveTextureOpacity(
 export function BackgroundAtmosphere() {
   const [orbs, setOrbs] = useState<Orb[] | null>(null);
   const [viewportWidth, setViewportWidth] = useState(DESKTOP_BASELINE_WIDTH);
+  const [viewportHeight, setViewportHeight] = useState(MIN_BACKGROUND_HEIGHT);
   const [themeId, setThemeId] = useState<ThemeId>(DEFAULT_THEME_ID);
   const themeRecipe = useMemo(
     () => getThemeDefinition(themeId).background,
@@ -222,6 +231,7 @@ export function BackgroundAtmosphere() {
       document.documentElement.dataset.theme || DEFAULT_THEME_ID,
     );
     setViewportWidth(window.innerWidth);
+    setViewportHeight(window.innerHeight);
     setThemeId(initialThemeId);
 
     const observer = new MutationObserver(() => {
@@ -240,6 +250,7 @@ export function BackgroundAtmosphere() {
       cancelAnimationFrame(rafId);
       rafId = requestAnimationFrame(() => {
         setViewportWidth(window.innerWidth);
+        setViewportHeight(window.innerHeight);
       });
     };
     window.addEventListener("resize", onResize);
@@ -251,8 +262,15 @@ export function BackgroundAtmosphere() {
   }, []);
 
   useEffect(() => {
-    setOrbs(generateOrbs(themeRecipe, viewportProfile.compact, rendererMode));
-  }, [themeRecipe, viewportProfile.compact, rendererMode]);
+    setOrbs(
+      generateOrbs(
+        themeRecipe,
+        viewportProfile.compact,
+        rendererMode,
+        viewportHeight,
+      ),
+    );
+  }, [themeRecipe, viewportProfile.compact, rendererMode, viewportHeight]);
 
   const gradientBackgroundImage = useMemo(
     () =>
@@ -297,8 +315,6 @@ export function BackgroundAtmosphere() {
             backgroundImage: gradientBackgroundImage,
             backgroundRepeat: gradientBackgroundRepeat,
             backgroundSize: gradientBackgroundSize,
-            willChange: "transform",
-            transform: "translateZ(0)",
           }}
         />
       ) : (
@@ -312,8 +328,6 @@ export function BackgroundAtmosphere() {
                 backgroundRepeat: texture.repeat,
                 backgroundSize: resolveTextureSize(texture, viewportProfile),
                 opacity: resolveTextureOpacity(texture, viewportProfile),
-                willChange: "transform",
-                transform: "translateZ(0)",
               }}
             />
           ))}
@@ -323,8 +337,6 @@ export function BackgroundAtmosphere() {
               backgroundImage: gradientBackgroundImage,
               backgroundRepeat: gradientBackgroundRepeat,
               backgroundSize: gradientBackgroundSize,
-              willChange: "transform",
-              transform: "translateZ(0)",
             }}
           />
         </>


### PR DESCRIPTION
(AI Generated).

## Summary
- Reduce steady-state WebKit footprint by bounding decorative atmosphere gradients to the viewport.
- Stop forcing static atmosphere texture layers through translateZ compositor promotion.

## Testing
- npm run validate:feature
- npm run test:e2e:perf:friends
- Installed the branch build and compared runtime health against the previous build.