### PR TITLE
fix: harden Facebook feed extraction

### DIFF
--- a/packages/desktop/src-tauri/src/fb-extract.js
+++ b/packages/desktop/src-tauri/src/fb-extract.js
@@ -290,7 +290,9 @@
   function hasAuthorArea(node) {
     return (
       node.querySelector("h3 a, h4 a") !== null ||
-      node.querySelector('a[aria-label][role="link"]') !== null
+      node.querySelector('a[aria-label][role="link"]') !== null ||
+      node.querySelector('a[aria-label][href]') !== null ||
+      node.querySelector('a[href*="facebook.com/profile.php"], a[href^="/profile.php"]') !== null
     );
   }
 
@@ -358,11 +360,31 @@
     var seen = new Set();
 
     var semanticCandidates = container.querySelectorAll(
-      '[role="article"], div[data-pagelet^="FeedUnit"], div[aria-posinset]'
+      [
+        '[role="article"]',
+        'div[data-pagelet^="FeedUnit"]',
+        'div[data-pagelet*="FeedUnit"]',
+        'div[aria-posinset]',
+        '[data-ft*="top_level_post_id"]',
+        '[data-testid="story-subtitle"]',
+      ].join(",")
     );
     for (var s = 0; s < semanticCandidates.length && posts.length < 50; s++) {
-      if (isLikelyPostElement(semanticCandidates[s], container)) {
-        posts.push(semanticCandidates[s]);
+      var candidate = semanticCandidates[s];
+      if (isLikelyPostElement(candidate, container)) {
+        posts.push(candidate);
+        continue;
+      }
+
+      var ancestor = candidate.parentElement;
+      var depth = 0;
+      while (ancestor && ancestor !== container && depth < 8) {
+        if (isLikelyPostElement(ancestor, container)) {
+          posts.push(ancestor);
+          break;
+        }
+        ancestor = ancestor.parentElement;
+        depth++;
       }
     }
 
@@ -444,7 +466,7 @@
 
     // aria-label links (skip generic labels)
     if (!name) {
-      var ariaLinks = el.querySelectorAll('a[aria-label][role="link"]');
+      var ariaLinks = el.querySelectorAll('a[aria-label][href]');
       for (var i = 0; i < ariaLinks.length; i++) {
         var label = ariaLinks[i].getAttribute("aria-label") || "";
         if (
@@ -475,7 +497,7 @@
           !href.includes("/marketplace") &&
           isValidFacebookActorUrl(href)
         ) {
-          var lt = (links[j].textContent || "").trim();
+          var lt = (links[j].textContent || links[j].getAttribute("aria-label") || "").trim();
           if (lt.length > 1 && lt.length < 80 && !isFacebookUiChromeLabel(lt)) {
             name = lt;
             profileUrl = href;
@@ -593,10 +615,16 @@
       var m =
         href.match(/story_fbid=(\d+)/) ||
         href.match(/\/groups\/[^/]+\/posts\/(\d+)/) ||
+        href.match(/\/groups\/[^/]+\/permalink\/(\d+)/) ||
         href.match(/\/posts\/(\d+)/) ||
         href.match(/\/permalink\/(\d+)/) ||
         href.match(/(pfbid\w+)/);
       if (m) return { id: m[1], url: href };
+    }
+    var dataFt = el.getAttribute("data-ft") || "";
+    var topLevelPost = dataFt.match(/top_level_post_id["']?\s*:\s*["']?([0-9]+)/);
+    if (topLevelPost) {
+      return { id: topLevelPost[1], url: null };
     }
     return { id: null, url: null };
   }
@@ -688,6 +716,13 @@
         postEls = findPostsInContainer(mainEl);
         strategy = "role-main-fallback";
       }
+    }
+
+    // Fallback: Facebook sometimes renders feed units without the old
+    // "Feed posts" h3 or a stable role=main container.
+    if (postEls.length === 0) {
+      postEls = findPostsInContainer(document.body);
+      strategy = "document-feedunit-fallback";
     }
 
     var posts = [];

--- a/packages/desktop/src/lib/facebook-extract-script.test.ts
+++ b/packages/desktop/src/lib/facebook-extract-script.test.ts
@@ -1,0 +1,104 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { beforeEach, describe, expect, it } from "vitest";
+
+type FbFeedEvent = {
+  posts?: Array<{
+    id: string | null;
+    authorName: string | null;
+    authorProfileUrl: string | null;
+    text: string | null;
+    strategy?: string;
+  }>;
+  strategy?: string;
+  candidateCount?: number;
+  error?: string;
+};
+
+const scriptPath = join(process.cwd(), "src-tauri/src/fb-extract.js");
+const extractScript = readFileSync(scriptPath, "utf8");
+
+function runFacebookExtractor(html: string): FbFeedEvent {
+  const events: FbFeedEvent[] = [];
+  document.documentElement.innerHTML = html;
+  Object.defineProperty(document, "cookie", {
+    value: "c_user=123; xs=session",
+    configurable: true,
+  });
+  Object.defineProperty(window, "scrollY", {
+    value: 0,
+    configurable: true,
+  });
+  Object.defineProperty(window, "__TAURI__", {
+    value: {
+      event: {
+        emit(name: string, payload: FbFeedEvent) {
+          if (name === "fb-feed-data") events.push(payload);
+        },
+      },
+    },
+    configurable: true,
+  });
+
+  window.eval(extractScript);
+  expect(events).toHaveLength(1);
+  return events[0];
+}
+
+describe("Facebook injected extractor", () => {
+  beforeEach(() => {
+    document.documentElement.innerHTML = "";
+  });
+
+  it("extracts a feed post without the legacy Feed posts heading", () => {
+    const event = runFacebookExtractor(`
+      <body>
+        <div role="main">
+          <div role="article" data-freed-test-height="420">
+            <a aria-label="Zana Prana" href="https://www.facebook.com/zana.prana"></a>
+            <a href="https://www.facebook.com/zana.prana/posts/pfbid02abc">3 hours ago</a>
+            <div dir="auto">Europe is calling, and we are listening. See you all soon.</div>
+          </div>
+        </div>
+      </body>
+    `);
+
+    expect(event.error).toBeUndefined();
+    expect(event.strategy).toBe("role-main-fallback");
+    expect(event.candidateCount).toBe(1);
+    expect(event.posts).toHaveLength(1);
+    expect(event.posts?.[0]).toMatchObject({
+      id: "pfbid02abc",
+      authorName: "Zana Prana",
+      authorProfileUrl: "https://www.facebook.com/zana.prana",
+      text: "Europe is calling, and we are listening. See you all soon.",
+    });
+  });
+
+  it("climbs from feed-unit markers to the enclosing post", () => {
+    const event = runFacebookExtractor(`
+      <body>
+        <section>
+          <div data-freed-test-height="520">
+            <div data-pagelet="FeedUnit_7">
+              <a aria-label="Gabriel Bakker" href="https://www.facebook.com/gabriel.bakker.1"></a>
+              <a href="https://www.facebook.com/groups/local-builders/permalink/987654321">about 1 month ago</a>
+              <div dir="auto">A community update with enough text to be treated as content.</div>
+            </div>
+          </div>
+        </section>
+      </body>
+    `);
+
+    expect(event.error).toBeUndefined();
+    expect(event.strategy).toBe("document-feedunit-fallback");
+    expect(event.candidateCount).toBe(1);
+    expect(event.posts).toHaveLength(1);
+    expect(event.posts?.[0]).toMatchObject({
+      id: "987654321",
+      authorName: "Gabriel Bakker",
+      authorProfileUrl: "https://www.facebook.com/gabriel.bakker.1",
+      text: "A community update with enough text to be treated as content.",
+    });
+  });
+});

--- a/packages/desktop/src/lib/fb-capture.ts
+++ b/packages/desktop/src/lib/fb-capture.ts
@@ -71,6 +71,9 @@ export interface FbSyncDiag {
   itemsNormalized: number;
   itemsDeduplicated: number;
   itemsAdded: number;
+  candidateItems: number;
+  existingItems: number;
+  excludedItems: number;
   extractionPasses: number;
   lastExtractionStrategy: string | null;
   lastCandidateCount: number | null;
@@ -262,6 +265,9 @@ export async function fetchFbFeed(): Promise<FbSyncResult> {
     itemsNormalized: 0,
     itemsDeduplicated: 0,
     itemsAdded: 0,
+    candidateItems: 0,
+    existingItems: 0,
+    excludedItems: 0,
     extractionPasses: 0,
     lastExtractionStrategy: null,
     lastCandidateCount: null,
@@ -485,6 +491,9 @@ export async function captureFbFeed(): Promise<FbSyncResult> {
         itemsNormalized: 0,
         itemsDeduplicated: 0,
         itemsAdded: 0,
+        candidateItems: 0,
+        existingItems: 0,
+        excludedItems: 0,
         extractionPasses: 0,
         lastExtractionStrategy: null,
         lastCandidateCount: null,
@@ -520,6 +529,9 @@ export async function captureFbFeed(): Promise<FbSyncResult> {
         itemsNormalized: 0,
         itemsDeduplicated: 0,
         itemsAdded: 0,
+        candidateItems: 0,
+        existingItems: 0,
+        excludedItems: 0,
         extractionPasses: 0,
         lastExtractionStrategy: null,
         lastCandidateCount: null,
@@ -580,13 +592,16 @@ export async function captureFbFeed(): Promise<FbSyncResult> {
       const excludedGroupIds =
         useAppStore.getState().preferences.fbCapture?.excludedGroupIds ?? {};
       const filteredItems = filterExcludedGroups(result.items, excludedGroupIds);
+      result.diag.candidateItems = filteredItems.length;
+      result.diag.excludedItems = result.items.length - filteredItems.length;
       const beforeState = useAppStore.getState();
       const beforeFacebookItems = beforeState.items.filter((i) => i.platform === "facebook");
       const beforeFacebookIds = new Set(beforeFacebookItems.map((item) => item.globalId));
       const existingCandidateCount = filteredItems.filter((item) => beforeFacebookIds.has(item.globalId)).length;
+      result.diag.existingItems = existingCandidateCount;
       addDebugEvent(
         "change",
-        `[FB] writing ${filteredItems.length.toLocaleString()} candidate item${filteredItems.length === 1 ? "" : "s"} to the library (${existingCandidateCount.toLocaleString()} already present)`,
+        `[FB] writing ${filteredItems.length.toLocaleString()} candidate item${filteredItems.length === 1 ? "" : "s"} to the library (${existingCandidateCount.toLocaleString()} already present, ${result.diag.excludedItems.toLocaleString()} excluded)`,
       );
       const before = beforeFacebookItems.length;
       await store.addItems(filteredItems);
@@ -607,7 +622,7 @@ export async function captureFbFeed(): Promise<FbSyncResult> {
       }
       addDebugEvent(
         "change",
-        `[FB] synced: ${result.diag.postsExtracted.toLocaleString()} posts extracted, ${result.diag.itemsAdded.toLocaleString()} new items`,
+        `[FB] synced: ${result.diag.postsExtracted.toLocaleString()} posts extracted, ${result.diag.itemsAdded.toLocaleString()} new item${result.diag.itemsAdded === 1 ? "" : "s"}, ${result.diag.existingItems.toLocaleString()} already present, ${result.diag.excludedItems.toLocaleString()} excluded`,
       );
     } else {
       const emptyMessage = formatFacebookEmptySyncMessage(result.diag);


### PR DESCRIPTION
(AI Generated).

## Summary
- (AI Generated). Harden Facebook feed extraction for modern feed units without increasing scrape frequency or adding provider requests. Adds diagnostics for extracted candidates that are already present or excluded.

## Testing
- npm run validate:feature