### PR TITLE
fix: gate Facebook sync on local auth cookies

### DIFF
--- a/packages/desktop/src/lib/fb-capture.ts
+++ b/packages/desktop/src/lib/fb-capture.ts
@@ -41,6 +41,10 @@ import {
   facebookGroupsFromFeedItems,
   mergeFacebookGroupRecords,
 } from "./facebook-groups";
+import {
+  loadSocialProviderCookieState,
+  socialProviderMissingAuthCookieMessage,
+} from "./social-auth-cookie-state";
 
 // =============================================================================
 // Rate Limiting
@@ -198,6 +202,23 @@ function formatFacebookEmptySyncMessage(diag: FbSyncDiag): string {
     : socialProviderCopy("facebook").feedReturnedEmpty;
 }
 
+function formatFacebookNoNewItemsMessage(diag: FbSyncDiag): string {
+  const details: string[] = [];
+  if (diag.existingItems > 0) {
+    details.push(`${diag.existingItems.toLocaleString()} already present`);
+  }
+  if (diag.excludedItems > 0) {
+    details.push(`${diag.excludedItems.toLocaleString()} excluded`);
+  }
+  if (diag.candidateItems > 0) {
+    details.push(`${diag.candidateItems.toLocaleString()} write candidate${diag.candidateItems === 1 ? "" : "s"}`);
+  }
+
+  return details.length > 0
+    ? `No new Facebook items: ${details.join(", ")}.`
+    : "No new Facebook items.";
+}
+
 function filterExcludedGroups(
   items: FeedItem[],
   excludedGroupIds: Record<string, true>,
@@ -277,6 +298,13 @@ export async function fetchFbFeed(): Promise<FbSyncResult> {
     errorStage: null,
     errorMessage: null,
   };
+
+  const cookieState = await loadSocialProviderCookieState("facebook");
+  if (cookieState && cookieState.available && !cookieState.hasAuthCookie) {
+    diag.errorStage = "auth";
+    diag.errorMessage = socialProviderMissingAuthCookieMessage("facebook");
+    return { items: [], diag };
+  }
 
   const memoryPrep = await prepareSocialScrapeMemory("facebook", "feed scrape");
   if (!memoryPrep.mayProceed) {
@@ -655,7 +683,12 @@ export async function captureFbFeed(): Promise<FbSyncResult> {
       provider: "facebook",
       outcome: result.diag.postsExtracted > 0 ? "success" : "empty",
       stage: result.diag.postsExtracted > 0 ? undefined : "empty",
-      reason: result.diag.postsExtracted > 0 ? undefined : "No posts pulled",
+      reason:
+        result.diag.postsExtracted > 0 && result.diag.itemsAdded === 0
+          ? formatFacebookNoNewItemsMessage(result.diag)
+          : result.diag.postsExtracted > 0
+            ? undefined
+            : "No posts pulled",
       startedAt,
       finishedAt: Date.now(),
       itemsSeen: result.diag.postsExtracted,

--- a/packages/desktop/src/lib/social-auth-cookie-state.ts
+++ b/packages/desktop/src/lib/social-auth-cookie-state.ts
@@ -26,6 +26,10 @@ const AUTH_MISSING_MESSAGES: Record<SocialProviderId, string> = {
   linkedin: "LinkedIn is not connected in the local WebView session. Reconnect LinkedIn and try again.",
 };
 
+export function socialProviderMissingAuthCookieMessage(provider: SocialProviderId): string {
+  return AUTH_MISSING_MESSAGES[provider];
+}
+
 function withMissingAuthCookieMessage<T extends { isAuthenticated: boolean; lastCaptureError?: string }>(
   provider: SocialProviderId,
   auth: T,
@@ -38,7 +42,7 @@ function withMissingAuthCookieMessage<T extends { isAuthenticated: boolean; last
   return {
     ...auth,
     isAuthenticated: false,
-    lastCaptureError: AUTH_MISSING_MESSAGES[provider],
+    lastCaptureError: socialProviderMissingAuthCookieMessage(provider),
   };
 }
 

--- a/packages/desktop/src/lib/social-capture-memory-pressure.test.ts
+++ b/packages/desktop/src/lib/social-capture-memory-pressure.test.ts
@@ -323,6 +323,105 @@ describe("social capture completion", () => {
     expect(mocks.storeState.fbAuth.lastCapturedAt).toBe(123_456);
   });
 
+  it("fails Facebook sync locally when the isolated WebView has no auth cookies", async () => {
+    mocks.invoke.mockImplementation(async (command: string) => {
+      if (command === "get_social_provider_cookie_state") {
+        return {
+          provider: "facebook",
+          available: true,
+          hasAuthCookie: false,
+          cookieCount: 6,
+          cookieNames: ["datr", "fr", "ps_l", "ps_n", "sb", "wd"],
+          error: null,
+        };
+      }
+      return null;
+    });
+
+    const { captureFbFeed } = await import("./fb-capture");
+    const { recordProviderHealthEvent } = await import("./provider-health");
+    const { storeFbAuthState } = await import("./fb-auth");
+
+    const result = await captureFbFeed();
+    const expectedMessage =
+      "Facebook is not connected in the local WebView session. Reconnect Facebook and try again.";
+
+    expect(result.diag.errorStage).toBe("auth");
+    expect(result.items).toEqual([]);
+    expect(mocks.prepareSocialScrapeMemory).not.toHaveBeenCalled();
+    expect(mocks.invoke).not.toHaveBeenCalledWith("fb_scrape_feed", expect.anything());
+    expect(mocks.storeState.setError).toHaveBeenCalledWith(expectedMessage);
+    expect(mocks.storeState.setFbAuth).toHaveBeenCalledWith({
+      isAuthenticated: false,
+      lastCapturedAt: 123_456,
+      lastCaptureError: expectedMessage,
+    });
+    expect(storeFbAuthState).toHaveBeenCalledWith({
+      isAuthenticated: false,
+      lastCapturedAt: 123_456,
+      lastCaptureError: expectedMessage,
+    });
+    expect(recordProviderHealthEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "facebook",
+        outcome: "error",
+        stage: "auth",
+        reason: expectedMessage,
+        itemsSeen: 0,
+        itemsAdded: 0,
+      }),
+    );
+  });
+
+  it("records why Facebook saw posts but added no new items", async () => {
+    const listeners = new Map<string, (event: { payload: unknown }) => void>();
+    mocks.storeState.items = [{ platform: "facebook", globalId: "existing-post" }];
+    mocks.storeState.addItems.mockImplementationOnce(async () => undefined);
+    mocks.prepareSocialScrapeMemory.mockResolvedValue({
+      before: {},
+      after: { appResidentBytes: 512 * 1024 * 1024 },
+      recycledScraperWindows: false,
+      cacheTrimmed: false,
+      mayProceed: true,
+    });
+    mocks.listen.mockImplementation(async (eventName: string, callback: (event: { payload: unknown }) => void) => {
+      listeners.set(eventName, callback);
+      return vi.fn();
+    });
+    mocks.invoke.mockImplementation(async (command: string) => {
+      if (command !== "fb_scrape_feed") return null;
+
+      listeners.get("fb-feed-data")?.({
+        payload: {
+          posts: [{ id: "existing-post", authorName: "Existing", text: "Already here" }],
+          extractedAt: Date.now(),
+          url: "https://www.facebook.com/",
+          strategy: "test",
+          candidateCount: 1,
+        },
+      });
+      return null;
+    });
+
+    const { captureFbFeed } = await import("./fb-capture");
+    const { recordProviderHealthEvent } = await import("./provider-health");
+
+    const result = await captureFbFeed();
+
+    expect(result.diag.postsExtracted).toBe(1);
+    expect(result.diag.itemsAdded).toBe(0);
+    expect(result.diag.existingItems).toBe(1);
+    expect(recordProviderHealthEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "facebook",
+        outcome: "success",
+        reason: "No new Facebook items: 1 already present, 1 write candidate.",
+        itemsSeen: 1,
+        itemsAdded: 0,
+      }),
+    );
+  });
+
   it("clears Facebook auth when the scraper reports an unauthenticated page", async () => {
     const listeners = new Map<string, (event: { payload: unknown }) => void>();
     mocks.prepareSocialScrapeMemory.mockResolvedValue({


### PR DESCRIPTION
(AI Generated).

Summary:
- Refuses Facebook feed sync locally when the isolated WebView cookie store is present but missing Facebook auth cookies.
- Reuses the shared social auth-cookie missing message so stale connected state is reported consistently.
- Records a provider-health reason when Facebook sees posts but adds no new items, distinguishing already-present or excluded results from a zero-post scrape.

Validation:
- npm run validate:providers -- --changed-files packages/desktop/src/lib/fb-capture.ts packages/desktop/src/lib/social-auth-cookie-state.ts packages/desktop/src/lib/social-capture-memory-pressure.test.ts
- PATH=/Users/aubreyfalconer/dev/freed-facebook-sync-local-gates/node_modules/.bin:$PATH npm run build from packages/desktop