### PR TITLE
fix: harden Facebook zero-post diagnostics

### DIFF
--- a/packages/desktop/src-tauri/src/fb-extract.js
+++ b/packages/desktop/src-tauri/src/fb-extract.js
@@ -17,6 +17,10 @@
           window.__TAURI__.event.emit(name, data);
         }
       : function () {};
+  var scrapeRunId =
+    typeof window.__FREED_FB_SCRAPE_RUN_ID === "string"
+      ? window.__FREED_FB_SCRAPE_RUN_ID
+      : null;
 
   function textValue(node, maxChars) {
     var value = node && node.textContent ? node.textContent : "";
@@ -690,6 +694,7 @@
         error: pageState.message,
         extractedAt: Date.now(),
         url: window.location.href,
+        scrapeRunId: scrapeRunId,
         strategy: pageState.state,
         candidateCount: 0,
         scrollY: window.scrollY,
@@ -824,6 +829,7 @@
       posts: posts,
       extractedAt: Date.now(),
       url: window.location.href,
+      scrapeRunId: scrapeRunId,
       strategy: strategy,
       candidateCount: postEls.length,
       scrollY: window.scrollY,
@@ -837,6 +843,7 @@
       error: err.message || String(err),
       extractedAt: Date.now(),
       url: window.location.href,
+      scrapeRunId: scrapeRunId,
     });
   }
 })();

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -5154,6 +5154,10 @@ async fn fb_scrape_feed(
 
     let fb_feed_url = "https://www.facebook.com/";
     let scraper_user_agent = stored_or_default_user_agent(&capture.fb_user_agent);
+    let scrape_run_id = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| format!("fb-{}", duration.as_millis()))
+        .unwrap_or_else(|_| "fb-unknown".to_string());
     ensure_social_scrape_memory(
         &app,
         &capture.background_runtime,
@@ -5215,17 +5219,26 @@ async fn fb_scrape_feed(
     };
 
     info!(
-        "[FB] scrape started (window_mode={}), waiting for page load...",
+        "[FB] scrape started (run_id={}, window_mode={}), waiting for page load...",
+        scrape_run_id,
         window_mode.as_str()
     );
 
     tokio::time::sleep(Duration::from_millis(gaussian_ms(13000.0, 1500.0))).await;
+
+    let set_scrape_run_id_script = format!(
+        "window.__FREED_FB_SCRAPE_RUN_ID = {};",
+        serde_json::to_string(&scrape_run_id).map_err(|e| e.to_string())?
+    );
+    wv.eval(&set_scrape_run_id_script)
+        .map_err(|e| e.to_string())?;
 
     wv.eval(
         r#"
         (function() {
             if (window.__TAURI__ && window.__TAURI__.event && window.__TAURI__.event.emit) {
                 window.__TAURI__.event.emit('fb-diag', {
+                    scrapeRunId: window.__FREED_FB_SCRAPE_RUN_ID || null,
                     userAgent: navigator.userAgent,
                     url: window.location.href,
                     title: document.title,
@@ -5272,6 +5285,7 @@ async fn fb_scrape_feed(
                 "error": message,
                 "extractedAt": extracted_at,
                 "url": page_state.url,
+                "scrapeRunId": scrape_run_id,
                 "strategy": strategy,
                 "candidateCount": 0,
                 "scrollY": 0,
@@ -7445,12 +7459,27 @@ pub fn run() {
             let fb_unique_ids: Arc<StdRwLock<std::collections::HashSet<String>>> =
                 Arc::new(StdRwLock::new(std::collections::HashSet::new()));
             let fb_total_posts = Arc::new(AtomicUsize::new(0));
+            let fb_active_run_id: Arc<StdRwLock<Option<String>>> = Arc::new(StdRwLock::new(None));
             let fb_ids_clone = fb_unique_ids.clone();
             let fb_total_clone = fb_total_posts.clone();
+            let fb_run_id_clone = fb_active_run_id.clone();
 
             let app_for_fb = app.handle().clone();
             app_for_fb.listen("fb-feed-data", move |event| {
                 if let Ok(val) = serde_json::from_str::<serde_json::Value>(event.payload()) {
+                    let run_id = val.get("scrapeRunId")
+                        .and_then(|s| s.as_str())
+                        .unwrap_or("legacy")
+                        .to_string();
+                    {
+                        let mut active_run_id = fb_run_id_clone.write().unwrap();
+                        if active_run_id.as_deref() != Some(run_id.as_str()) {
+                            *active_run_id = Some(run_id.clone());
+                            fb_ids_clone.write().unwrap().clear();
+                            fb_total_clone.store(0, Ordering::Relaxed);
+                            info!("[FB] extraction run started: {}", run_id);
+                        }
+                    }
                     let scroll_y = val.get("scrollY")
                         .and_then(|s| s.as_f64())
                         .unwrap_or(0.0) as i64;
@@ -7469,8 +7498,8 @@ pub fn run() {
                             .and_then(|s| serde_json::to_string(s).ok())
                             .unwrap_or_else(|| "{}".to_string());
                         info!(
-                            "[FB] extraction error: {} strategy={} page_state={}",
-                            error, strategy, page_state
+                            "[FB] extraction error: {} run_id={} strategy={} page_state={}",
+                            error, run_id, strategy, page_state
                         );
                         return;
                     }
@@ -7504,8 +7533,8 @@ pub fn run() {
                     }
 
                     let total = fb_total_clone.load(Ordering::Relaxed);
-                    info!("[FB] pass @ scrollY={}: candidates={}, new={}, total_unique={}",
-                        scroll_y, candidates, new_count, total);
+                    info!("[FB] pass run_id={} @ scrollY={}: candidates={}, new={}, total_unique={}",
+                        run_id, scroll_y, candidates, new_count, total);
                 }
             });
 

--- a/packages/desktop/src/lib/facebook-extract-script.test.ts
+++ b/packages/desktop/src/lib/facebook-extract-script.test.ts
@@ -12,6 +12,7 @@ type FbFeedEvent = {
   }>;
   strategy?: string;
   candidateCount?: number;
+  scrapeRunId?: string | null;
   error?: string;
 };
 
@@ -48,6 +49,7 @@ function runFacebookExtractor(html: string): FbFeedEvent {
 describe("Facebook injected extractor", () => {
   beforeEach(() => {
     document.documentElement.innerHTML = "";
+    Reflect.deleteProperty(window, "__FREED_FB_SCRAPE_RUN_ID");
   });
 
   it("extracts a feed post without the legacy Feed posts heading", () => {
@@ -100,5 +102,26 @@ describe("Facebook injected extractor", () => {
       authorProfileUrl: "https://www.facebook.com/gabriel.bakker.1",
       text: "A community update with enough text to be treated as content.",
     });
+  });
+
+  it("emits the native scrape run id with extraction batches", () => {
+    Object.defineProperty(window, "__FREED_FB_SCRAPE_RUN_ID", {
+      value: "fb-test-run",
+      configurable: true,
+    });
+
+    const event = runFacebookExtractor(`
+      <body>
+        <div role="main">
+          <div role="article" data-freed-test-height="420">
+            <a aria-label="Zana Prana" href="https://www.facebook.com/zana.prana"></a>
+            <a href="https://www.facebook.com/zana.prana/posts/pfbid02abc">3 hours ago</a>
+            <div dir="auto">Europe is calling, and we are listening. See you all soon.</div>
+          </div>
+        </div>
+      </body>
+    `);
+
+    expect(event.scrapeRunId).toBe("fb-test-run");
   });
 });

--- a/packages/desktop/src/lib/fb-capture.ts
+++ b/packages/desktop/src/lib/fb-capture.ts
@@ -79,6 +79,12 @@ export interface FbSyncDiag {
   existingItems: number;
   excludedItems: number;
   extractionPasses: number;
+  totalCandidateCount: number;
+  totalRejected: {
+    suggestedOrSponsored: number;
+    missingAuthor: number;
+    missingContent: number;
+  };
   lastExtractionStrategy: string | null;
   lastCandidateCount: number | null;
   lastRejected:
@@ -89,7 +95,21 @@ export interface FbSyncDiag {
       }
     | null;
   lastScrollY: number | null;
+  maxScrollY: number | null;
   feedContainerFound: boolean | null;
+  scrapeRunId: string | null;
+  lastPageState:
+    | {
+        state?: string;
+        loggedInCookie?: boolean;
+        feedLike?: boolean;
+        feedUnitCount?: number;
+        loginChrome?: boolean;
+        scrollHeight?: number;
+        url?: string;
+        title?: string;
+      }
+    | null;
   errorStage: string | null;
   errorMessage: string | null;
 }
@@ -97,6 +117,41 @@ export interface FbSyncDiag {
 export interface FbSyncResult {
   items: ReturnType<typeof fbPostsToFeedItems>;
   diag: FbSyncDiag;
+}
+
+function createEmptyFbSyncDiag(
+  overrides: Partial<FbSyncDiag> = {},
+): FbSyncDiag {
+  const { totalRejected: rejectedOverrides, ...rest } = overrides;
+  const totalRejected = {
+    suggestedOrSponsored: 0,
+    missingAuthor: 0,
+    missingContent: 0,
+    ...rejectedOverrides,
+  };
+  return {
+    postsExtracted: 0,
+    itemsNormalized: 0,
+    itemsDeduplicated: 0,
+    itemsAdded: 0,
+    candidateItems: 0,
+    existingItems: 0,
+    excludedItems: 0,
+    extractionPasses: 0,
+    totalCandidateCount: 0,
+    lastExtractionStrategy: null,
+    lastCandidateCount: null,
+    lastRejected: null,
+    lastScrollY: null,
+    maxScrollY: null,
+    feedContainerFound: null,
+    scrapeRunId: null,
+    lastPageState: null,
+    errorStage: null,
+    errorMessage: null,
+    ...rest,
+    totalRejected,
+  };
 }
 
 interface FbNormalizationRejectionSummary {
@@ -202,6 +257,30 @@ function formatFacebookEmptySyncMessage(diag: FbSyncDiag): string {
     : socialProviderCopy("facebook").feedReturnedEmpty;
 }
 
+function formatFacebookParseFailureMessage(diag: FbSyncDiag): string {
+  const rejected = diag.totalRejected;
+  const details = [
+    `${diag.totalCandidateCount.toLocaleString()} candidate${diag.totalCandidateCount === 1 ? "" : "s"}`,
+    `${rejected.missingAuthor.toLocaleString()} missing author`,
+    `${rejected.missingContent.toLocaleString()} missing content`,
+  ];
+
+  if (rejected.suggestedOrSponsored > 0) {
+    details.push(`${rejected.suggestedOrSponsored.toLocaleString()} suggested or sponsored`);
+  }
+  if (diag.extractionPasses > 0) {
+    details.push(`${diag.extractionPasses.toLocaleString()} extraction pass${diag.extractionPasses === 1 ? "" : "es"}`);
+  }
+  if (typeof diag.maxScrollY === "number") {
+    details.push(`max scrollY ${diag.maxScrollY.toLocaleString()}`);
+  }
+  if (diag.lastPageState?.state) {
+    details.push(`page state ${diag.lastPageState.state}`);
+  }
+
+  return `Facebook rendered post-like blocks, but Freed Desktop could not parse any posts. ${details.join(", ")}.`;
+}
+
 function formatFacebookNoNewItemsMessage(diag: FbSyncDiag): string {
   const details: string[] = [];
   if (diag.existingItems > 0) {
@@ -281,23 +360,7 @@ export async function repairStoredFacebookGroupNamesFromItems(
  * 4. Normalize raw posts to FeedItem[]
  */
 export async function fetchFbFeed(): Promise<FbSyncResult> {
-  const diag: FbSyncDiag = {
-    postsExtracted: 0,
-    itemsNormalized: 0,
-    itemsDeduplicated: 0,
-    itemsAdded: 0,
-    candidateItems: 0,
-    existingItems: 0,
-    excludedItems: 0,
-    extractionPasses: 0,
-    lastExtractionStrategy: null,
-    lastCandidateCount: null,
-    lastRejected: null,
-    lastScrollY: null,
-    feedContainerFound: null,
-    errorStage: null,
-    errorMessage: null,
-  };
+  const diag = createEmptyFbSyncDiag();
 
   const cookieState = await loadSocialProviderCookieState("facebook");
   if (cookieState && cookieState.available && !cookieState.hasAuthCookie) {
@@ -355,6 +418,8 @@ export async function fetchFbFeed(): Promise<FbSyncResult> {
       };
       scrollY?: number;
       feedContainerFound?: boolean;
+      scrapeRunId?: string | null;
+      pageState?: FbSyncDiag["lastPageState"];
     }>(
       "fb-feed-data",
       (event) => {
@@ -366,13 +431,27 @@ export async function fetchFbFeed(): Promise<FbSyncResult> {
           rejected,
           scrollY,
           feedContainerFound,
+          scrapeRunId,
+          pageState,
         } = event.payload;
         diag.extractionPasses++;
         diag.lastExtractionStrategy = strategy ?? null;
         diag.lastCandidateCount = typeof candidateCount === "number" ? candidateCount : null;
         diag.lastRejected = rejected ?? null;
         diag.lastScrollY = typeof scrollY === "number" ? scrollY : null;
+        diag.maxScrollY =
+          typeof scrollY === "number"
+            ? Math.max(diag.maxScrollY ?? scrollY, scrollY)
+            : diag.maxScrollY;
         diag.feedContainerFound = typeof feedContainerFound === "boolean" ? feedContainerFound : null;
+        diag.scrapeRunId = typeof scrapeRunId === "string" ? scrapeRunId : diag.scrapeRunId;
+        diag.lastPageState = pageState ?? diag.lastPageState;
+        diag.totalCandidateCount += typeof candidateCount === "number" ? candidateCount : 0;
+        if (rejected) {
+          diag.totalRejected.suggestedOrSponsored += rejected.suggestedOrSponsored ?? 0;
+          diag.totalRejected.missingAuthor += rejected.missingAuthor ?? 0;
+          diag.totalRejected.missingContent += rejected.missingContent ?? 0;
+        }
 
         const rejectionSummary = rejected
           ? `, rejected={sponsored:${(rejected.suggestedOrSponsored ?? 0).toLocaleString()}, author:${(rejected.missingAuthor ?? 0).toLocaleString()}, content:${(rejected.missingContent ?? 0).toLocaleString()}}`
@@ -440,6 +519,12 @@ export async function fetchFbFeed(): Promise<FbSyncResult> {
   diag.postsExtracted = allRawPosts.length;
 
   if (allRawPosts.length === 0) {
+    const parseRejectCount =
+      diag.totalRejected.missingAuthor + diag.totalRejected.missingContent;
+    if (diag.totalCandidateCount > 0 && parseRejectCount > 0) {
+      diag.errorStage = "extract";
+      diag.errorMessage = formatFacebookParseFailureMessage(diag);
+    }
     return { items: [], diag };
   }
 
@@ -514,23 +599,10 @@ export async function captureFbFeed(): Promise<FbSyncResult> {
     addDebugEvent("change", `[FB] paused until ${formatClockTime(providerPause.pausedUntil)}`);
     return {
       items: [],
-      diag: {
-        postsExtracted: 0,
-        itemsNormalized: 0,
-        itemsDeduplicated: 0,
-        itemsAdded: 0,
-        candidateItems: 0,
-        existingItems: 0,
-        excludedItems: 0,
-        extractionPasses: 0,
-        lastExtractionStrategy: null,
-        lastCandidateCount: null,
-        lastRejected: null,
-        lastScrollY: null,
-        feedContainerFound: null,
+      diag: createEmptyFbSyncDiag({
         errorStage: "provider_rate_limit",
         errorMessage: providerPause.pauseReason,
-      },
+      }),
     };
   }
 
@@ -552,23 +624,10 @@ export async function captureFbFeed(): Promise<FbSyncResult> {
     });
     return {
       items: [],
-      diag: {
-        postsExtracted: 0,
-        itemsNormalized: 0,
-        itemsDeduplicated: 0,
-        itemsAdded: 0,
-        candidateItems: 0,
-        existingItems: 0,
-        excludedItems: 0,
-        extractionPasses: 0,
-        lastExtractionStrategy: null,
-        lastCandidateCount: null,
-        lastRejected: null,
-        lastScrollY: null,
-        feedContainerFound: null,
+      diag: createEmptyFbSyncDiag({
         errorStage: "cooldown",
         errorMessage: `Cooling down. Try again in ~${minutesRemaining} minutes.`,
-      },
+      }),
     };
   }
 

--- a/packages/desktop/src/lib/social-capture-memory-pressure.test.ts
+++ b/packages/desktop/src/lib/social-capture-memory-pressure.test.ts
@@ -524,6 +524,82 @@ describe("social capture completion", () => {
     });
   });
 
+  it("fails Facebook sync when rendered candidates cannot be parsed into posts", async () => {
+    const listeners = new Map<string, (event: { payload: unknown }) => void>();
+    mocks.prepareSocialScrapeMemory.mockResolvedValue({
+      before: {},
+      after: { appResidentBytes: 512 * 1024 * 1024 },
+      recycledScraperWindows: false,
+      cacheTrimmed: false,
+      mayProceed: true,
+    });
+    mocks.listen.mockImplementation(async (eventName: string, callback: (event: { payload: unknown }) => void) => {
+      listeners.set(eventName, callback);
+      return vi.fn();
+    });
+    mocks.invoke.mockImplementation(async (command: string) => {
+      if (command !== "fb_scrape_feed") return null;
+
+      listeners.get("fb-feed-data")?.({
+        payload: {
+          posts: [],
+          extractedAt: Date.now(),
+          url: "https://www.facebook.com/",
+          strategy: "role-main-fallback",
+          candidateCount: 3,
+          rejected: {
+            suggestedOrSponsored: 1,
+            missingAuthor: 2,
+            missingContent: 1,
+          },
+          scrollY: 640,
+          feedContainerFound: true,
+          scrapeRunId: "fb-test-run",
+          pageState: {
+            state: "feed_possible",
+            feedLike: true,
+            feedUnitCount: 3,
+            scrollHeight: 4_200,
+            url: "https://www.facebook.com/",
+            title: "Facebook",
+          },
+        },
+      });
+      return null;
+    });
+
+    const { captureFbFeed } = await import("./fb-capture");
+    const { recordProviderHealthEvent } = await import("./provider-health");
+
+    const result = await captureFbFeed();
+    const expectedMessage =
+      "Facebook rendered post-like blocks, but Freed Desktop could not parse any posts. " +
+      "3 candidates, 2 missing author, 1 missing content, 1 suggested or sponsored, " +
+      "1 extraction pass, max scrollY 640, page state feed_possible.";
+
+    expect(result.items).toEqual([]);
+    expect(result.diag.errorStage).toBe("extract");
+    expect(result.diag.errorMessage).toBe(expectedMessage);
+    expect(result.diag.totalCandidateCount).toBe(3);
+    expect(result.diag.totalRejected).toEqual({
+      suggestedOrSponsored: 1,
+      missingAuthor: 2,
+      missingContent: 1,
+    });
+    expect(result.diag.scrapeRunId).toBe("fb-test-run");
+    expect(mocks.storeState.setError).toHaveBeenCalledWith(expectedMessage);
+    expect(recordProviderHealthEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "facebook",
+        outcome: "error",
+        stage: "extract",
+        reason: expectedMessage,
+        itemsSeen: 0,
+        itemsAdded: 0,
+      }),
+    );
+  });
+
   it("waits for local semantic indexing before invoking Instagram scrape", async () => {
     mocks.prepareSocialScrapeMemory.mockResolvedValue({
       before: {},


### PR DESCRIPTION
(AI Generated).

## Summary
- Classify Facebook candidate parser failures separately from true empty feeds and tag native scrape batches with per-run IDs for reliable diagnostics.

## Testing
- npm run validate:providers
- cargo test social_feed_scroll_script --lib && cargo test facebook_page_state --lib
- npm run validate:feature