### PR TITLE
fix: defer social sync while Mac is locked

### DIFF
--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -270,6 +270,22 @@ struct SocialProviderCookieState {
     error: Option<String>,
 }
 
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DesktopSessionState {
+    available: bool,
+    screen_locked: bool,
+    error: Option<String>,
+}
+
+#[cfg(target_os = "macos")]
+fn parse_screen_locked_from_ioreg_plist(text: &str) -> Option<bool> {
+    let locked_key = "<key>CGSSessionScreenIsLocked</key>";
+    text.split(locked_key)
+        .nth(1)
+        .map(|tail| tail.trim_start().starts_with("<true/>"))
+}
+
 fn data_store_identifier_folder(identifier: [u8; 16]) -> String {
     format!(
         "{:02x}{:02x}{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
@@ -495,6 +511,52 @@ fn get_social_provider_cookie_state(
             cookie_names,
             error: None,
         })
+    }
+}
+
+#[tauri::command]
+fn get_desktop_session_state() -> DesktopSessionState {
+    #[cfg(not(target_os = "macos"))]
+    {
+        return DesktopSessionState {
+            available: false,
+            screen_locked: false,
+            error: Some("Desktop session diagnostics are only available on macOS.".to_string()),
+        };
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        let output = match std::process::Command::new("/usr/sbin/ioreg")
+            .args(["-a", "-d", "1", "-c", "IORegistryEntry"])
+            .output()
+        {
+            Ok(output) => output,
+            Err(error) => {
+                return DesktopSessionState {
+                    available: false,
+                    screen_locked: false,
+                    error: Some(error.to_string()),
+                };
+            }
+        };
+
+        if !output.status.success() {
+            return DesktopSessionState {
+                available: false,
+                screen_locked: false,
+                error: Some(format!("ioreg exited with status {}", output.status)),
+            };
+        }
+
+        let text = String::from_utf8_lossy(&output.stdout);
+        let screen_locked = parse_screen_locked_from_ioreg_plist(&text).unwrap_or(false);
+
+        DesktopSessionState {
+            available: parse_screen_locked_from_ioreg_plist(&text).is_some(),
+            screen_locked,
+            error: None,
+        }
     }
 }
 
@@ -8375,6 +8437,7 @@ pub fn run() {
             trim_webkit_network_cache_now,
             get_recent_runtime_health,
             get_ai_hardware_profile,
+            get_desktop_session_state,
             get_social_provider_cookie_state,
             prepare_social_scrape_memory,
             broadcast_doc,
@@ -8556,6 +8619,24 @@ mod tests {
             title: "Facebook".to_string(),
         };
         assert!(cookie_session_without_rendered_units.feed_like());
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn parses_macos_screen_lock_state_from_ioreg_plist() {
+        assert_eq!(
+            parse_screen_locked_from_ioreg_plist(
+                r#"<dict><key>CGSSessionScreenIsLocked</key><true/></dict>"#,
+            ),
+            Some(true),
+        );
+        assert_eq!(
+            parse_screen_locked_from_ioreg_plist(
+                r#"<dict><key>CGSSessionScreenIsLocked</key><false/></dict>"#,
+            ),
+            Some(false),
+        );
+        assert_eq!(parse_screen_locked_from_ioreg_plist("<dict></dict>"), None);
     }
 
     fn binary_cookie_record(name: &str) -> Vec<u8> {

--- a/packages/desktop/src/lib/fb-capture.ts
+++ b/packages/desktop/src/lib/fb-capture.ts
@@ -33,6 +33,7 @@ import { socialProviderCopy } from "./social-provider-copy";
 import { runBackgroundJob } from "./background-runtime-coordinator";
 import {
   applyRuntimeDeferredDiag,
+  applyLockedSessionDeferredDiag,
   isRuntimeDeferredStage,
   SOCIAL_SCRAPE_WAIT_FOR_JOB_KINDS,
   SOCIAL_SCRAPE_WAIT_FOR_LOCAL_WORK_MS,
@@ -366,6 +367,10 @@ export async function fetchFbFeed(): Promise<FbSyncResult> {
   if (cookieState && cookieState.available && !cookieState.hasAuthCookie) {
     diag.errorStage = "auth";
     diag.errorMessage = socialProviderMissingAuthCookieMessage("facebook");
+    return { items: [], diag };
+  }
+
+  if (await applyLockedSessionDeferredDiag(diag)) {
     return { items: [], diag };
   }
 

--- a/packages/desktop/src/lib/instagram-capture.ts
+++ b/packages/desktop/src/lib/instagram-capture.ts
@@ -31,6 +31,7 @@ import { socialProviderCopy } from "./social-provider-copy";
 import { runBackgroundJob } from "./background-runtime-coordinator";
 import {
   applyRuntimeDeferredDiag,
+  applyLockedSessionDeferredDiag,
   isRuntimeDeferredStage,
   SOCIAL_SCRAPE_WAIT_FOR_JOB_KINDS,
   SOCIAL_SCRAPE_WAIT_FOR_LOCAL_WORK_MS,
@@ -95,6 +96,10 @@ export async function fetchIgFeed(): Promise<IgSyncResult> {
     errorStage: null,
     errorMessage: null,
   };
+
+  if (await applyLockedSessionDeferredDiag(diag)) {
+    return { items: [], diag };
+  }
 
   const memoryPrep = await prepareSocialScrapeMemory("instagram", "feed scrape");
   if (!memoryPrep.mayProceed) {

--- a/packages/desktop/src/lib/li-capture.ts
+++ b/packages/desktop/src/lib/li-capture.ts
@@ -23,6 +23,10 @@ import { storeLiAuthState } from "./li-auth";
 import { getProviderPause, recordProviderHealthEvent } from "./provider-health";
 import { formatBytesForMemoryLog, prepareSocialScrapeMemory } from "./memory-monitor";
 import { socialProviderCopy } from "./social-provider-copy";
+import {
+  applyLockedSessionDeferredDiag,
+  isRuntimeDeferredStage,
+} from "./social-capture-runtime";
 
 // =============================================================================
 // Rate Limiting
@@ -99,6 +103,10 @@ export async function fetchLiFeed(): Promise<LiSyncResult> {
 
   if (!isTauri()) {
     return emptyResult;
+  }
+
+  if (await applyLockedSessionDeferredDiag(diag)) {
+    return { items: [], diag };
   }
 
   const memoryPrep = await prepareSocialScrapeMemory("linkedin", "feed scrape");
@@ -261,8 +269,12 @@ export async function captureLiFeed(): Promise<LiSyncResult> {
     const result = await fetchLiFeed();
 
     if (result.diag.errorStage) {
-      const detail = `[LI] sync failed at stage="${result.diag.errorStage}": ${result.diag.errorMessage ?? "(no message)"}`;
-      addDebugEvent("error", detail);
+      const runtimeDeferred = isRuntimeDeferredStage(result.diag.errorStage);
+      const detail = `[LI] sync ${runtimeDeferred ? "deferred" : "failed"} at stage="${result.diag.errorStage}": ${result.diag.errorMessage ?? "(no message)"}`;
+      addDebugEvent(runtimeDeferred ? "change" : "error", detail);
+      if (runtimeDeferred) {
+        return result;
+      }
       if (result.diag.errorStage !== "memory_pressure") {
         store.setError(result.diag.errorMessage ?? result.diag.errorStage);
         const errState = {

--- a/packages/desktop/src/lib/social-capture-memory-pressure.test.ts
+++ b/packages/desktop/src/lib/social-capture-memory-pressure.test.ts
@@ -600,6 +600,85 @@ describe("social capture completion", () => {
     );
   });
 
+  it("defers Facebook sync before scraping when the Mac session is locked", async () => {
+    mocks.invoke.mockImplementation(async (command: string) => {
+      if (command === "get_desktop_session_state") {
+        return {
+          available: true,
+          screenLocked: true,
+          error: null,
+        };
+      }
+      return null;
+    });
+
+    const { captureFbFeed } = await import("./fb-capture");
+    const { recordProviderHealthEvent } = await import("./provider-health");
+
+    const result = await captureFbFeed();
+    const expectedMessage =
+      "Freed paused provider sync because the Mac is locked. Unlock the Mac and try syncing again.";
+
+    expect(result.diag.errorStage).toBe("runtime_deferred");
+    expect(result.diag.errorMessage).toBe(expectedMessage);
+    expect(mocks.prepareSocialScrapeMemory).not.toHaveBeenCalled();
+    expect(mocks.invoke).not.toHaveBeenCalledWith("fb_scrape_feed", expect.anything());
+    expect(mocks.storeState.setError).toHaveBeenCalledWith(null);
+    expect(mocks.storeState.setError).not.toHaveBeenCalledWith(expectedMessage);
+    expect(mocks.storeState.setFbAuth).not.toHaveBeenCalled();
+    expect(recordProviderHealthEvent).not.toHaveBeenCalled();
+  });
+
+  it("defers LinkedIn sync before scraping when the Mac session is locked", async () => {
+    mocks.invoke.mockImplementation(async (command: string) => {
+      if (command === "get_desktop_session_state") {
+        return {
+          available: true,
+          screenLocked: true,
+          error: null,
+        };
+      }
+      return null;
+    });
+
+    const { captureLiFeed } = await import("./li-capture");
+    const { recordProviderHealthEvent } = await import("./provider-health");
+
+    const result = await captureLiFeed();
+
+    expect(result.diag.errorStage).toBe("runtime_deferred");
+    expect(mocks.prepareSocialScrapeMemory).not.toHaveBeenCalled();
+    expect(mocks.invoke).not.toHaveBeenCalledWith("li_scrape_feed", expect.anything());
+    expect(mocks.storeState.setError).toHaveBeenCalledWith(null);
+    expect(mocks.storeState.setLiAuth).not.toHaveBeenCalled();
+    expect(recordProviderHealthEvent).not.toHaveBeenCalled();
+  });
+
+  it("defers Instagram sync before scraping when the Mac session is locked", async () => {
+    mocks.invoke.mockImplementation(async (command: string) => {
+      if (command === "get_desktop_session_state") {
+        return {
+          available: true,
+          screenLocked: true,
+          error: null,
+        };
+      }
+      return null;
+    });
+
+    const { captureIgFeed } = await import("./instagram-capture");
+    const { recordProviderHealthEvent } = await import("./provider-health");
+
+    const result = await captureIgFeed();
+
+    expect(result.diag.errorStage).toBe("runtime_deferred");
+    expect(mocks.prepareSocialScrapeMemory).not.toHaveBeenCalled();
+    expect(mocks.invoke).not.toHaveBeenCalledWith("ig_scrape_feed", expect.anything());
+    expect(mocks.storeState.setError).toHaveBeenCalledWith(null);
+    expect(mocks.storeState.setIgAuth).not.toHaveBeenCalled();
+    expect(recordProviderHealthEvent).not.toHaveBeenCalled();
+  });
+
   it("waits for local semantic indexing before invoking Instagram scrape", async () => {
     mocks.prepareSocialScrapeMemory.mockResolvedValue({
       before: {},

--- a/packages/desktop/src/lib/social-capture-runtime.ts
+++ b/packages/desktop/src/lib/social-capture-runtime.ts
@@ -1,3 +1,4 @@
+import { invoke, isTauri } from "@tauri-apps/api/core";
 import type { BackgroundJobKind } from "./background-runtime-coordinator";
 import { isBackgroundRuntimeDeferredError } from "./background-runtime-coordinator";
 
@@ -17,6 +18,12 @@ export const RUNTIME_DEFERRED_STAGE = "runtime_deferred";
 export interface RuntimeDeferredDiag {
   errorStage: string | null;
   errorMessage: string | null;
+}
+
+interface DesktopSessionState {
+  available: boolean;
+  screenLocked: boolean;
+  error?: string | null;
 }
 
 export function runtimeDeferredMessage(reason: string): string {
@@ -49,6 +56,23 @@ export function applyRuntimeDeferredDiag(
   diag.errorStage = RUNTIME_DEFERRED_STAGE;
   diag.errorMessage = runtimeDeferredMessage(error.reason);
   return true;
+}
+
+export async function applyLockedSessionDeferredDiag(
+  diag: RuntimeDeferredDiag,
+): Promise<boolean> {
+  if (!isTauri() && import.meta.env.VITE_TEST_TAURI !== "1") return false;
+
+  try {
+    const state = await invoke<DesktopSessionState>("get_desktop_session_state");
+    if (!state?.screenLocked) return false;
+    diag.errorStage = RUNTIME_DEFERRED_STAGE;
+    diag.errorMessage =
+      "Freed paused provider sync because the Mac is locked. Unlock the Mac and try syncing again.";
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 export function isRuntimeDeferredStage(stage: string | null): boolean {


### PR DESCRIPTION
(AI Generated).

## Summary
- Detect a locked macOS session before authenticated social provider scraping and defer Facebook, Instagram, and LinkedIn sync instead of opening hidden provider WebViews.

## Testing
- npm run test:unit -- social-capture-memory-pressure.test.ts
- cargo test parses_macos_screen_lock_state_from_ioreg_plist --lib
- npm run validate:providers
- npm run validate:feature