### PR TITLE
fix: retain provider login prompts

### DIFF
--- a/docs/PHASE-12-ADDITIONAL-PLATFORMS.md
+++ b/docs/PHASE-12-ADDITIONAL-PLATFORMS.md
@@ -266,6 +266,7 @@ packages/capture-youtube/
 - [x] LinkedIn desktop flows have regression coverage in Playwright
 - [x] LinkedIn shares the desktop provider health summaries, rate-limit pause state, resume controls, and the unified provider section used in Settings and Debug panel cards
 - [x] LinkedIn shares the same provider severity colors and per-provider sync spinner behavior as the other social sources
+- [x] LinkedIn login stays open after auth so users can finish platform prompts before sync starts
 - [ ] Mozi activity captured to FeedItem with plans, trips, attendance, or overlap-adjacent events
 - [ ] Mozi is visible in desktop Sources navigation and source status UI
 - [ ] Mozi desktop flows have regression coverage in Playwright

--- a/docs/PHASE-7-SOCIAL-CAPTURE.md
+++ b/docs/PHASE-7-SOCIAL-CAPTURE.md
@@ -80,8 +80,9 @@ Both Facebook and Instagram use the same pattern:
 1. `*_show_login` opens a visible WebView to the platform's login page
 2. User authenticates through the real login flow (2FA, CAPTCHA, etc.)
 3. `on_navigation` handler detects redirect away from login page
-4. WebView is hidden and `*-auth-result` event is emitted
-5. Cookies persist in the WebView for future scraping sessions
+4. `*-auth-result` event is emitted while the WebView stays visible
+5. User finishes any platform prompts, closes the login window, and then sync begins
+6. Cookies persist in the WebView data store for future scraping sessions
 
 ### Feed Scraping
 
@@ -193,6 +194,7 @@ const RATE_LIMITS = {
 - [x] Instagram feed integrated into Desktop via Tauri WebView scraping
 - [x] Both platforms integrated into Desktop refreshAllFeeds()
 - [x] Settings UI for both platforms (login, check connection, sync, disconnect), with the same provider section also reused inside Debug panel health cards
+- [x] Facebook and Instagram login windows stay open after auth so users can finish platform prompts before sync starts
 - [x] Feed pollution filtering blocks promoted X entries and suggested FB/IG posts
 - [x] Facebook Settings includes per-group include/exclude controls for joined groups inside a filtered inner scroller that prevents late group loads from shifting the outer Settings view
 - [x] Facebook group discovery rejects activity-only labels and numeric ID fallbacks, preserves good stored names, repairs missing stored names from already captured group posts during normal sync, and keeps joined-groups refresh behind explicit provider-risk confirmation

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -4854,7 +4854,7 @@ async fn probe_fb_page_state(
 /// shown and focused; otherwise a new window is created.
 ///
 /// An `on_navigation` handler detects when the user completes login
-/// (URL leaves /login) and auto-hides the window + emits `fb-auth-result`.
+/// (URL leaves /login) and emits `fb-auth-result`.
 #[tauri::command]
 async fn fb_show_login(
     app: tauri::AppHandle,
@@ -4888,6 +4888,13 @@ async fn fb_show_login(
     )
     .center()
     .visible(true)
+    .on_window_event(|window, event| {
+        if let tauri::WindowEvent::CloseRequested { .. } = event {
+            let _ = window
+                .app_handle()
+                .emit("fb-login-window-closed", serde_json::json!({ "closed": true }));
+        }
+    })
     .on_navigation(move |url| {
         let path = url.path();
         let host = url.host_str().unwrap_or("");
@@ -4916,6 +4923,10 @@ async fn fb_show_login(
 /// Hide the Facebook login window after successful authentication.
 #[tauri::command]
 async fn fb_hide_login(app: tauri::AppHandle) -> Result<(), String> {
+    let _ = app.emit(
+        "fb-login-window-closed",
+        serde_json::json!({ "closed": true }),
+    );
     recycle_webview_window(&app, "fb-scraper", "login dismissed");
     Ok(())
 }
@@ -5673,8 +5684,7 @@ const IG_COMMENTS_EXTRACT_SCRIPT: &str = include_str!("ig-comments-extract.js");
 /// so the user can authenticate through the real Instagram login flow.
 ///
 /// An `on_navigation` handler detects when the user completes login
-/// (URL leaves /accounts/login) and auto-hides the window + emits
-/// `ig-auth-result`.
+/// (URL leaves /accounts/login) and emits `ig-auth-result`.
 #[tauri::command]
 async fn ig_show_login(
     app: tauri::AppHandle,
@@ -5683,17 +5693,7 @@ async fn ig_show_login(
 ) -> Result<(), String> {
     use tauri::WebviewWindowBuilder;
 
-    if let Some(existing) = app.get_webview_window("ig-scraper") {
-        let _ = set_background_scraper_window_cloak(&existing, false);
-        let _ = set_background_scraper_media_guard(&existing, false);
-        existing
-            .navigate("https://www.instagram.com/accounts/login/".parse().unwrap())
-            .map_err(|e| e.to_string())?;
-        let _ = existing.show();
-        let _ = existing.set_focus();
-        *capture.ig_user_agent.lock().unwrap() = user_agent;
-        return Ok(());
-    }
+    recycle_webview_window(&app, "ig-scraper", "login restart");
 
     let app_handle = app.clone();
     // Track whether we've already emitted the auth result (one-shot)
@@ -5720,6 +5720,13 @@ async fn ig_show_login(
     )
     .center()
     .visible(true)
+    .on_window_event(|window, event| {
+        if let tauri::WindowEvent::CloseRequested { .. } = event {
+            let _ = window
+                .app_handle()
+                .emit("ig-login-window-closed", serde_json::json!({ "closed": true }));
+        }
+    })
     .on_navigation(move |url| {
         let path = url.path();
         let host = url.host_str().unwrap_or("");
@@ -5731,26 +5738,7 @@ async fn ig_show_login(
             && path != "/accounts/login/"
             && !auth_emitted.swap(true, std::sync::atomic::Ordering::SeqCst)
         {
-            // Hide the login UI while the post-login scrape spins up.
-            // ig_scrape_feed now recycles the WebView when the scrape ends.
-            if let Some(w) = app_handle.get_webview_window("ig-scraper") {
-                let _ = w.hide();
-            }
             let _ = app_handle.emit("ig-auth-result", serde_json::json!({ "loggedIn": true }));
-
-            // Auto-trigger a scrape shortly after login so the user doesn't need
-            // to manually click "Sync Now".
-            let scrape_app = app_handle.clone();
-            tauri::async_runtime::spawn(async move {
-                info!("[IG] login detected, auto-scraping...");
-                tokio::time::sleep(Duration::from_millis(gaussian_ms(4000.0, 800.0))).await;
-                let capture = scrape_app.state::<CaptureState>();
-                // Post-login auto-scrapes use hidden mode so they do not compete with the main renderer.
-                match ig_scrape_feed(scrape_app.clone(), capture, ScraperWindowMode::Hidden).await {
-                    Ok(()) => info!("[IG] post-login auto-scrape complete"),
-                    Err(e) => info!("[IG] post-login auto-scrape error: {}", e),
-                }
-            });
         }
 
         true
@@ -5766,6 +5754,10 @@ async fn ig_show_login(
 /// Hide the Instagram login window after successful authentication.
 #[tauri::command]
 async fn ig_hide_login(app: tauri::AppHandle) -> Result<(), String> {
+    let _ = app.emit(
+        "ig-login-window-closed",
+        serde_json::json!({ "closed": true }),
+    );
     recycle_webview_window(&app, "ig-scraper", "login dismissed");
     Ok(())
 }
@@ -6325,7 +6317,7 @@ const LI_EXTRACT_SCRIPT: &str = include_str!("li-extract.js");
 /// user can authenticate through the real LinkedIn login flow.
 ///
 /// An `on_navigation` handler detects when the user completes login
-/// (URL leaves /login) and auto-hides the window + emits `li-auth-result`.
+/// (URL leaves /login) and emits `li-auth-result`.
 #[tauri::command]
 async fn li_show_login(
     app: tauri::AppHandle,
@@ -6334,17 +6326,7 @@ async fn li_show_login(
 ) -> Result<(), String> {
     use tauri::WebviewWindowBuilder;
 
-    if let Some(existing) = app.get_webview_window("li-scraper") {
-        let _ = set_background_scraper_window_cloak(&existing, false);
-        let _ = set_background_scraper_media_guard(&existing, false);
-        existing
-            .navigate("https://www.linkedin.com/login".parse().unwrap())
-            .map_err(|e| e.to_string())?;
-        let _ = existing.show();
-        let _ = existing.set_focus();
-        *capture.li_user_agent.lock().unwrap() = user_agent;
-        return Ok(());
-    }
+    recycle_webview_window(&app, "li-scraper", "login restart");
 
     let app_handle = app.clone();
     // Track whether we've already emitted the auth result (one-shot)
@@ -6371,6 +6353,13 @@ async fn li_show_login(
     )
     .center()
     .visible(true)
+    .on_window_event(|window, event| {
+        if let tauri::WindowEvent::CloseRequested { .. } = event {
+            let _ = window
+                .app_handle()
+                .emit("li-login-window-closed", serde_json::json!({ "closed": true }));
+        }
+    })
     .on_navigation(move |url| {
         let path = url.path();
         let host = url.host_str().unwrap_or("");
@@ -6383,9 +6372,6 @@ async fn li_show_login(
             && path != "/uas/login"
             && !auth_emitted.swap(true, std::sync::atomic::Ordering::SeqCst)
         {
-            if let Some(w) = app_handle.get_webview_window("li-scraper") {
-                let _ = w.hide();
-            }
             let _ = app_handle.emit("li-auth-result", serde_json::json!({ "loggedIn": true }));
         }
 
@@ -6402,6 +6388,10 @@ async fn li_show_login(
 /// Hide the LinkedIn login window after successful authentication.
 #[tauri::command]
 async fn li_hide_login(app: tauri::AppHandle) -> Result<(), String> {
+    let _ = app.emit(
+        "li-login-window-closed",
+        serde_json::json!({ "closed": true }),
+    );
     recycle_webview_window(&app, "li-scraper", "login dismissed");
     Ok(())
 }

--- a/packages/desktop/src/components/FacebookSettingsSection.tsx
+++ b/packages/desktop/src/components/FacebookSettingsSection.tsx
@@ -6,7 +6,7 @@
  * authenticates, the WebView's cookies are shared with the scraper.
  */
 
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
 import { isTauri } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import type { SyncProviderSectionProps } from "@freed/ui/context";
@@ -23,7 +23,6 @@ import {
   showFbLogin,
   checkFbAuth,
   disconnectFb,
-  hideFbLogin,
   storeFbAuthState,
 } from "../lib/fb-auth";
 import {
@@ -218,6 +217,8 @@ export function FacebookSettingsSection({
   const [lastDiag, setLastDiag] = useState<FbSyncDiag | null>(null);
   const [windowMode, setWindowMode] = useState(() => getFbScraperWindowMode());
   const [actionError, setActionError] = useState<string | null>(null);
+  const [loginWindowPendingSync, setLoginWindowPendingSync] = useState(false);
+  const loginWindowPendingSyncRef = useRef(false);
   const copy = socialProviderCopy("facebook");
   const { confirm, dialog } = useProviderRiskGate("facebook");
 
@@ -230,7 +231,7 @@ export function FacebookSettingsSection({
 
   // Auto-detect login success from the WebView's on_navigation callback
   useEffect(() => {
-    if (!isTauri()) return;
+    if (!isTauri() && import.meta.env.VITE_TEST_TAURI !== "1") return;
 
     const unlisten = listen<{ loggedIn: boolean }>("fb-auth-result", (event) => {
       const newState = {
@@ -241,7 +242,11 @@ export function FacebookSettingsSection({
       setFbAuth(newState);
       storeFbAuthState(newState);
       if (event.payload.loggedIn) {
-        void hideFbLogin().catch(() => {});
+        loginWindowPendingSyncRef.current = true;
+        setLoginWindowPendingSync(true);
+      } else {
+        loginWindowPendingSyncRef.current = false;
+        setLoginWindowPendingSync(false);
       }
     });
     return () => { unlisten.then((fn) => fn()); };
@@ -285,6 +290,8 @@ export function FacebookSettingsSection({
   }, [confirm, setFbAuth]);
 
   const runSync = useCallback(async () => {
+    loginWindowPendingSyncRef.current = false;
+    setLoginWindowPendingSync(false);
     setLastDiag(null);
     try {
       const result = await withProviderSyncing("facebook", () => captureFbFeed());
@@ -293,6 +300,21 @@ export function FacebookSettingsSection({
       console.error("Facebook feed capture failed:", err);
     }
   }, []);
+
+  useEffect(() => {
+    if (!isTauri() && import.meta.env.VITE_TEST_TAURI !== "1") return;
+
+    const unlisten = listen<{ closed: boolean }>("fb-login-window-closed", (event) => {
+      const shouldSync = event.payload.closed && useAppStore.getState().fbAuth.isAuthenticated;
+      const pending = loginWindowPendingSyncRef.current;
+      loginWindowPendingSyncRef.current = false;
+      setLoginWindowPendingSync(false);
+      if (pending && shouldSync) {
+        void runSync();
+      }
+    });
+    return () => { unlisten.then((fn) => fn()); };
+  }, [runSync]);
 
   const setExcludedGroups = useCallback(
     async (nextExcludedGroupIds: Record<string, true>) => {
@@ -441,6 +463,12 @@ export function FacebookSettingsSection({
               {statusLabel}
             </span>
           </div>
+
+          {loginWindowPendingSync && (
+            <p className="text-xs text-[#a1a1aa] leading-relaxed">
+              Connected. Finish any Facebook prompts, then close the login window.
+            </p>
+          )}
 
           <div className="flex gap-2">
             <ProviderSyncActionButton

--- a/packages/desktop/src/components/InstagramSettingsSection.tsx
+++ b/packages/desktop/src/components/InstagramSettingsSection.tsx
@@ -6,7 +6,7 @@
  * authenticates, the WebView's cookies are shared with the scraper.
  */
 
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
 import { isTauri } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import type { SyncProviderSectionProps } from "@freed/ui/context";
@@ -127,18 +127,22 @@ export function InstagramSettingsSection({
   const [lastDiag, setLastDiag] = useState<IgSyncDiag | null>(null);
   const [windowMode, setWindowMode] = useState(() => getIgScraperWindowMode());
   const [actionError, setActionError] = useState<string | null>(null);
+  const [loginWindowPendingSync, setLoginWindowPendingSync] = useState(false);
+  const loginWindowPendingSyncRef = useRef(false);
   const copy = socialProviderCopy("instagram");
   const { confirm, dialog } = useProviderRiskGate("instagram");
 
   // Auto-detect login success from the WebView's on_navigation callback
   useEffect(() => {
-    if (!isTauri()) return;
+    if (!isTauri() && import.meta.env.VITE_TEST_TAURI !== "1") return;
 
     const unlisten = listen<{ loggedIn: boolean }>("ig-auth-result", (event) => {
       if (event.payload.loggedIn) {
         const newState = { isAuthenticated: true, lastCheckedAt: Date.now() };
         setIgAuth(newState);
         storeIgAuthState(newState);
+        loginWindowPendingSyncRef.current = true;
+        setLoginWindowPendingSync(true);
       }
     });
     return () => { unlisten.then((fn) => fn()); };
@@ -177,6 +181,8 @@ export function InstagramSettingsSection({
   }, [confirm, setIgAuth]);
 
   const runSync = useCallback(async () => {
+    loginWindowPendingSyncRef.current = false;
+    setLoginWindowPendingSync(false);
     setLastDiag(null);
     try {
       const result = await withProviderSyncing("instagram", () => captureIgFeed());
@@ -185,6 +191,21 @@ export function InstagramSettingsSection({
       console.error("Instagram feed capture failed:", err);
     }
   }, []);
+
+  useEffect(() => {
+    if (!isTauri() && import.meta.env.VITE_TEST_TAURI !== "1") return;
+
+    const unlisten = listen<{ closed: boolean }>("ig-login-window-closed", (event) => {
+      const shouldSync = event.payload.closed && useAppStore.getState().igAuth.isAuthenticated;
+      const pending = loginWindowPendingSyncRef.current;
+      loginWindowPendingSyncRef.current = false;
+      setLoginWindowPendingSync(false);
+      if (pending && shouldSync) {
+        void runSync();
+      }
+    });
+    return () => { unlisten.then((fn) => fn()); };
+  }, [runSync]);
 
   const handleDisconnect = useCallback(async () => {
     try {
@@ -252,6 +273,12 @@ export function InstagramSettingsSection({
               {statusLabel}
             </span>
           </div>
+
+          {loginWindowPendingSync && (
+            <p className="text-xs text-[#a1a1aa] leading-relaxed">
+              Connected. Finish any Instagram prompts, then close the login window.
+            </p>
+          )}
 
           <div className="flex gap-2">
             <ProviderSyncActionButton

--- a/packages/desktop/src/components/LinkedInSettingsSection.tsx
+++ b/packages/desktop/src/components/LinkedInSettingsSection.tsx
@@ -6,7 +6,7 @@
  * authenticates, the WebView's cookies are shared with the scraper.
  */
 
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
 import { isTauri } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import type { SyncProviderSectionProps } from "@freed/ui/context";
@@ -119,10 +119,14 @@ export function LinkedInSettingsSection({
   const [lastDiag, setLastDiag] = useState<LiSyncDiag | null>(null);
   const [windowMode, setWindowMode] = useState(() => getLiScraperWindowMode());
   const [actionError, setActionError] = useState<string | null>(null);
+  const [loginWindowPendingSync, setLoginWindowPendingSync] = useState(false);
+  const loginWindowPendingSyncRef = useRef(false);
   const copy = socialProviderCopy("linkedin");
   const { confirm, dialog } = useProviderRiskGate("linkedin");
 
   const runSync = useCallback(async () => {
+    loginWindowPendingSyncRef.current = false;
+    setLoginWindowPendingSync(false);
     setLastDiag(null);
     try {
       const result = await withProviderSyncing("linkedin", () => captureLiFeed());
@@ -134,20 +138,34 @@ export function LinkedInSettingsSection({
 
   // Auto-detect login success from the WebView's on_navigation callback
   useEffect(() => {
-    if (!isTauri()) return;
+    if (!isTauri() && import.meta.env.VITE_TEST_TAURI !== "1") return;
 
     const unlisten = listen<{ loggedIn: boolean }>("li-auth-result", (event) => {
       if (event.payload.loggedIn) {
         const newState = { isAuthenticated: true, lastCheckedAt: Date.now() };
         setLiAuth(newState);
         storeLiAuthState(newState);
-        if (!liAuth.isAuthenticated) {
-          void runSync();
-        }
+        loginWindowPendingSyncRef.current = true;
+        setLoginWindowPendingSync(true);
       }
     });
     return () => { unlisten.then((fn) => fn()); };
-  }, [liAuth.isAuthenticated, runSync, setLiAuth]);
+  }, [setLiAuth]);
+
+  useEffect(() => {
+    if (!isTauri() && import.meta.env.VITE_TEST_TAURI !== "1") return;
+
+    const unlisten = listen<{ closed: boolean }>("li-login-window-closed", (event) => {
+      const shouldSync = event.payload.closed && useAppStore.getState().liAuth.isAuthenticated;
+      const pending = loginWindowPendingSyncRef.current;
+      loginWindowPendingSyncRef.current = false;
+      setLoginWindowPendingSync(false);
+      if (pending && shouldSync) {
+        void runSync();
+      }
+    });
+    return () => { unlisten.then((fn) => fn()); };
+  }, [runSync]);
 
   const handleLogin = useCallback(async () => {
     await confirm(async () => {
@@ -247,6 +265,12 @@ export function LinkedInSettingsSection({
               {statusLabel}
             </span>
           </div>
+
+          {loginWindowPendingSync && (
+            <p className="text-xs text-[#a1a1aa] leading-relaxed">
+              Connected. Finish any LinkedIn prompts, then close the login window.
+            </p>
+          )}
 
           <div className="flex gap-2">
             <ProviderSyncActionButton

--- a/packages/desktop/src/lib/fb-auth.ts
+++ b/packages/desktop/src/lib/fb-auth.ts
@@ -28,7 +28,7 @@ const FB_AUTH_KEY = "fb_auth_state";
 /**
  * Open the Facebook login WebView so the user can authenticate.
  * The window is visible and allows normal Facebook login. Once logged
- * in, the user closes the window (or we hide it after detecting auth).
+ * in, Freed marks the session connected and the user closes the window.
  */
 export async function showFbLogin(): Promise<void> {
   // Generate and persist a fresh session UA at connect time.
@@ -37,7 +37,7 @@ export async function showFbLogin(): Promise<void> {
 }
 
 /**
- * Hide the login WebView (called after successful auth detection).
+ * Hide the login WebView after the user is done with provider prompts.
  */
 export async function hideFbLogin(): Promise<void> {
   await invoke("fb_hide_login");

--- a/packages/desktop/src/lib/instagram-auth.ts
+++ b/packages/desktop/src/lib/instagram-auth.ts
@@ -27,7 +27,7 @@ const IG_AUTH_KEY = "ig_auth_state";
 /**
  * Open the Instagram login WebView so the user can authenticate.
  * The window is visible and allows normal Instagram login. Once logged
- * in, the on_navigation handler detects the redirect and hides the window.
+ * in, Freed marks the session connected and the user closes the window.
  */
 export async function showIgLogin(): Promise<void> {
   const userAgent = selectPlatformUA("instagram");
@@ -35,7 +35,7 @@ export async function showIgLogin(): Promise<void> {
 }
 
 /**
- * Hide the login WebView (called after successful auth detection).
+ * Hide the login WebView after the user is done with provider prompts.
  */
 export async function hideIgLogin(): Promise<void> {
   await invoke("ig_hide_login");

--- a/packages/desktop/src/lib/li-auth.ts
+++ b/packages/desktop/src/lib/li-auth.ts
@@ -28,7 +28,7 @@ const LI_AUTH_KEY = "li_auth_state";
 /**
  * Open the LinkedIn login WebView so the user can authenticate.
  * The window is visible and allows normal LinkedIn login. Once logged
- * in, the user closes the window (or we hide it after detecting auth).
+ * in, Freed marks the session connected and the user closes the window.
  */
 export async function showLiLogin(): Promise<void> {
   // Generate and persist a fresh session UA at connect time.
@@ -37,7 +37,7 @@ export async function showLiLogin(): Promise<void> {
 }
 
 /**
- * Hide the login WebView (called after successful auth detection).
+ * Hide the login WebView after the user is done with provider prompts.
  */
 export async function hideLiLogin(): Promise<void> {
   await invoke("li_hide_login");

--- a/packages/desktop/tests/e2e/provider-login-retention.spec.ts
+++ b/packages/desktop/tests/e2e/provider-login-retention.spec.ts
@@ -1,0 +1,136 @@
+import { test, expect } from "./fixtures/app";
+
+type ProviderCase = {
+  provider: "facebook" | "instagram" | "linkedin";
+  label: "Facebook" | "Instagram" | "LinkedIn";
+  loginButton: string;
+  authEvent: string;
+  closeEvent: string;
+  showCommand: string;
+  hideCommand: string;
+  scrapeCommand: string;
+  promptCopy: string;
+  closeEvidenceText?: string;
+};
+
+const providers: ProviderCase[] = [
+  {
+    provider: "facebook",
+    label: "Facebook",
+    loginButton: "Log in with Facebook",
+    authEvent: "fb-auth-result",
+    closeEvent: "fb-login-window-closed",
+    showCommand: "fb_show_login",
+    hideCommand: "fb_hide_login",
+    scrapeCommand: "fb_scrape_feed",
+    promptCopy: "Connected. Finish any Facebook prompts, then close the login window.",
+  },
+  {
+    provider: "instagram",
+    label: "Instagram",
+    loginButton: "Log in with Instagram",
+    authEvent: "ig-auth-result",
+    closeEvent: "ig-login-window-closed",
+    showCommand: "ig_show_login",
+    hideCommand: "ig_hide_login",
+    scrapeCommand: "ig_scrape_feed",
+    promptCopy: "Connected. Finish any Instagram prompts, then close the login window.",
+  },
+  {
+    provider: "linkedin",
+    label: "LinkedIn",
+    loginButton: "Log in with LinkedIn",
+    authEvent: "li-auth-result",
+    closeEvent: "li-login-window-closed",
+    showCommand: "li_show_login",
+    hideCommand: "li_hide_login",
+    scrapeCommand: "li_scrape_feed",
+    promptCopy: "Connected. Finish any LinkedIn prompts, then close the login window.",
+    closeEvidenceText: "[LI] browser preview skips native LinkedIn capture",
+  },
+];
+
+function settingsDialog(page: import("@playwright/test").Page) {
+  return page.locator(".fixed.inset-0.z-50").last();
+}
+
+async function openSettingsSection(
+  page: import("@playwright/test").Page,
+  sectionName: string,
+): Promise<void> {
+  const settingsBtn = page
+    .locator("button")
+    .filter({ hasText: /settings/i })
+    .first();
+  await expect(settingsBtn).toBeVisible({ timeout: 5_000 });
+  await settingsBtn.click();
+  await expect(page.getByText("Settings").first()).toBeVisible({
+    timeout: 5_000,
+  });
+
+  const section = settingsDialog(page).getByRole("button", { name: sectionName });
+  await expect(section).toBeVisible({ timeout: 3_000 });
+  await section.evaluate((button) => {
+    (button as HTMLButtonElement).click();
+  });
+}
+
+async function emitTauriEvent(
+  page: import("@playwright/test").Page,
+  event: string,
+  payload: unknown,
+): Promise<void> {
+  await page.evaluate(
+    ({ eventName, eventPayload }) => {
+      const listeners =
+        (window as unknown as Record<string, Array<(event: { payload: unknown }) => void>>)
+          .__TAURI_EVENT_LISTENERS__ ?? {};
+      for (const listener of listeners[eventName] ?? []) {
+        listener({ payload: eventPayload });
+      }
+    },
+    { eventName: event, eventPayload: payload },
+  );
+}
+
+for (const providerCase of providers) {
+  test(`${providerCase.label} login stays open after auth and syncs after close`, async ({
+    app,
+    page,
+    ipc,
+  }) => {
+    await app.goto();
+    await app.waitForReady();
+    await ipc.setHandler(providerCase.scrapeCommand, () => null);
+
+    await openSettingsSection(page, providerCase.label);
+    await page.getByText(providerCase.loginButton).click();
+    await app.acceptProviderRiskIfPresent(providerCase.provider);
+    await expect.poll(async () => (await ipc.invocations()).some(
+      (call) => call.cmd === providerCase.showCommand,
+    )).toBe(true);
+
+    await emitTauriEvent(page, providerCase.authEvent, { loggedIn: true });
+    await expect(page.getByText(providerCase.promptCopy)).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByTestId(`provider-sync-action-${providerCase.provider}`)).toBeVisible({
+      timeout: 5_000,
+    });
+
+    const afterAuthInvocations = await ipc.invocations();
+    expect(afterAuthInvocations.some((call) => call.cmd === providerCase.hideCommand)).toBe(false);
+    expect(afterAuthInvocations.some((call) => call.cmd === providerCase.scrapeCommand)).toBe(false);
+    if (providerCase.closeEvidenceText) {
+      await expect(page.getByText(providerCase.closeEvidenceText)).toHaveCount(0);
+    }
+
+    await emitTauriEvent(page, providerCase.closeEvent, { closed: true });
+    if (providerCase.closeEvidenceText) {
+      await expect(page.getByText(providerCase.closeEvidenceText)).toBeVisible({ timeout: 5_000 });
+    } else {
+      await expect.poll(async () => (await ipc.invocations()).some(
+        (call) => call.cmd === providerCase.scrapeCommand,
+      )).toBe(true);
+    }
+    await expect(page.getByText(providerCase.promptCopy)).toBeHidden({ timeout: 5_000 });
+  });
+}


### PR DESCRIPTION
(AI Generated).

## Summary
- Keep Facebook, Instagram, and LinkedIn login windows open after auth so users can finish provider prompts before sync.
- Defer provider sync until the login window closes or the user clicks Sync Now.
- Update Phase 7 and Phase 12 docs for the new login lifecycle.

## Testing
- npm run test:e2e -- provider-login-retention.spec.ts
- npm run validate:feature