### PR TITLE
fix: restore Facebook sync extraction

### DIFF
--- a/packages/desktop/src-tauri/src/fb-extract.js
+++ b/packages/desktop/src-tauri/src/fb-extract.js
@@ -321,6 +321,15 @@
     return false;
   }
 
+  function hasPostPermalink(node) {
+    if (!node || !node.querySelector) return false;
+    return (
+      node.querySelector(
+        'a[href*="story_fbid="], a[href*="/posts/"], a[href*="/permalink/"], a[href*="pfbid"], a[href*="/groups/"][href*="/posts/"]'
+      ) !== null
+    );
+  }
+
   function isLikelyPostElement(node, container) {
     if (!node || node === container) return false;
     var h = elementHeight(node);
@@ -330,12 +339,51 @@
       role === "article" ||
       /^FeedUnit/i.test(pagelet) ||
       node.hasAttribute("aria-posinset");
-    var structurallyPost = semanticPost || (hasAuthorArea(node) && hasTimestampCue(node));
+    var structurallyPost =
+      semanticPost ||
+      (hasAuthorArea(node) && hasTimestampCue(node)) ||
+      hasPostPermalink(node);
 
     if (!structurallyPost && (h < 150 || h > 2000)) return false;
     if (structurallyPost && h > 0 && h > 2600) return false;
     if (!hasPostContent(node)) return false;
     return structurallyPost;
+  }
+
+  function postCandidateKey(node) {
+    var pagelet = node.getAttribute && node.getAttribute("data-pagelet");
+    if (pagelet) return "pagelet:" + pagelet;
+    var permalink = node.querySelector &&
+      node.querySelector('a[href*="story_fbid="], a[href*="/posts/"], a[href*="/permalink/"], a[href*="pfbid"], a[href*="/groups/"][href*="/posts/"]');
+    if (permalink && permalink.href) return "href:" + permalink.href;
+    var rect = node.getBoundingClientRect ? node.getBoundingClientRect() : null;
+    var top = rect ? Math.round(rect.top + window.scrollY) : node.offsetTop;
+    return "shape:" + top + ":" + elementHeight(node) + ":" + textValue(node, 400).length;
+  }
+
+  function pushCandidate(posts, seen, node, container) {
+    if (!node || !isLikelyPostElement(node, container)) return false;
+    var id = postCandidateKey(node);
+    if (seen.has(id)) return false;
+    seen.add(id);
+    posts.push(node);
+    return true;
+  }
+
+  function closestPostCandidate(seed, container) {
+    var node = seed;
+    var best = null;
+    var depth = 0;
+    while (node && node !== container && depth < 10) {
+      if (node.nodeType === 1 && isLikelyPostElement(node, container)) {
+        best = node;
+        var h = elementHeight(node);
+        if (h >= 180 && h <= 1800 && hasAuthorArea(node)) break;
+      }
+      node = node.parentElement;
+      depth++;
+    }
+    return best;
   }
 
   function uniquePostElements(elements) {
@@ -374,22 +422,30 @@
       ].join(",")
     );
     for (var s = 0; s < semanticCandidates.length && posts.length < 50; s++) {
-      var candidate = semanticCandidates[s];
-      if (isLikelyPostElement(candidate, container)) {
-        posts.push(candidate);
+      if (pushCandidate(posts, seen, semanticCandidates[s], container)) {
         continue;
       }
 
-      var ancestor = candidate.parentElement;
+      var ancestor = semanticCandidates[s].parentElement;
       var depth = 0;
       while (ancestor && ancestor !== container && depth < 8) {
-        if (isLikelyPostElement(ancestor, container)) {
-          posts.push(ancestor);
+        if (pushCandidate(posts, seen, ancestor, container)) {
           break;
         }
         ancestor = ancestor.parentElement;
         depth++;
       }
+    }
+
+    if (posts.length > 0) {
+      return uniquePostElements(posts);
+    }
+
+    var permalinkCandidates = container.querySelectorAll(
+      'a[href*="story_fbid="], a[href*="/posts/"], a[href*="/permalink/"], a[href*="pfbid"], a[href*="/groups/"][href*="/posts/"]'
+    );
+    for (var p = 0; p < permalinkCandidates.length && posts.length < 50; p++) {
+      pushCandidate(posts, seen, closestPostCandidate(permalinkCandidates[p], container), container);
     }
 
     if (posts.length > 0) {
@@ -410,12 +466,7 @@
       // - Contain some text or images
       // - NOT be the entire feed container itself
       if (isLikelyPostElement(node, container)) {
-        var nodeText = textValue(node, 4000);
-        var id =
-          node.offsetTop + ":" + h + ":" + nodeText.length;
-        if (!seen.has(id)) {
-          seen.add(id);
-          posts.push(node);
+        if (pushCandidate(posts, seen, node, container)) {
           return; // Don't recurse into found posts
         }
       }

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -252,7 +252,7 @@ fn stored_or_default_user_agent(agent: &std::sync::Mutex<String>) -> String {
 
 fn social_scraper_data_store_identifier(label: &str) -> Option<[u8; 16]> {
     match label {
-        "fb-scraper" => Some(FB_SCRAPER_DATA_STORE_IDENTIFIER),
+        "fb-login" | "fb-scraper" => Some(FB_SCRAPER_DATA_STORE_IDENTIFIER),
         "ig-scraper" => Some(IG_SCRAPER_DATA_STORE_IDENTIFIER),
         "li-scraper" => Some(LI_SCRAPER_DATA_STORE_IDENTIFIER),
         _ => None,
@@ -4850,8 +4850,8 @@ async fn probe_fb_page_state(
 /// Show a visible WebView window navigated to facebook.com/login so the
 /// user can authenticate through the real Facebook login flow.
 ///
-/// The window reuses the "fb-scraper" label. If it already exists it is
-/// shown and focused; otherwise a new window is created.
+/// The window uses the "fb-login" label and shares the Facebook scraper data
+/// store, so login cookies remain available to feed scraping.
 ///
 /// An `on_navigation` handler detects when the user completes login
 /// (URL leaves /login) and emits `fb-auth-result`.
@@ -4863,13 +4863,29 @@ async fn fb_show_login(
 ) -> Result<(), String> {
     use tauri::WebviewWindowBuilder;
 
-    recycle_webview_window(&app, "fb-scraper", "login restart");
+    info!("[FB] opening login window");
+    recycle_webview_window(&app, "fb-scraper", "facebook reconnect");
+
+    if let Some(existing) = app.get_webview_window("fb-login") {
+        let _ = set_background_scraper_window_cloak(&existing, false);
+        let _ = set_background_scraper_media_guard(&existing, false);
+        existing
+            .navigate("https://www.facebook.com/login".parse().unwrap())
+            .map_err(|e| e.to_string())?;
+        let _ = existing.show();
+        let _ = existing.set_focus();
+        *capture.fb_user_agent.lock().unwrap() = user_agent;
+        info!("[FB] focused existing login window");
+        return Ok(());
+    }
 
     let app_handle = app.clone();
+    let auth_emitted = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let auth_emitted_for_nav = auth_emitted.clone();
 
-    WebviewWindowBuilder::new(
+    let login_window = WebviewWindowBuilder::new(
         &app,
-        "fb-scraper",
+        "fb-login",
         tauri::WebviewUrl::External("https://www.facebook.com/login".parse().unwrap()),
     )
     .data_store_identifier(FB_SCRAPER_DATA_STORE_IDENTIFIER)
@@ -4888,23 +4904,20 @@ async fn fb_show_login(
     )
     .center()
     .visible(true)
-    .on_window_event(|window, event| {
-        if let tauri::WindowEvent::CloseRequested { .. } = event {
-            let _ = window
-                .app_handle()
-                .emit("fb-login-window-closed", serde_json::json!({ "closed": true }));
-        }
-    })
     .on_navigation(move |url| {
         let path = url.path();
         let host = url.host_str().unwrap_or("");
 
         // Detect likely login completion, then verify with page evidence.
-        if host.contains("facebook.com") && path != "/login" && path != "/login/" {
+        if host.contains("facebook.com")
+            && path != "/login"
+            && path != "/login/"
+            && !auth_emitted_for_nav.swap(true, std::sync::atomic::Ordering::SeqCst)
+        {
             let check_app = app_handle.clone();
             tauri::async_runtime::spawn(async move {
                 tokio::time::sleep(Duration::from_millis(1800)).await;
-                if let Some(w) = check_app.get_webview_window("fb-scraper") {
+                if let Some(w) = check_app.get_webview_window("fb-login") {
                     let _ = w.eval(fb_auth_result_script());
                 }
             });
@@ -4914,8 +4927,18 @@ async fn fb_show_login(
     })
     .build()
     .map_err(|e| e.to_string())?;
+    let close_app = app.clone();
+    login_window.on_window_event(move |event| {
+        if let tauri::WindowEvent::CloseRequested { .. } = event {
+            let _ = close_app.emit(
+                "fb-login-window-closed",
+                serde_json::json!({ "closed": true }),
+            );
+        }
+    });
 
     *capture.fb_user_agent.lock().unwrap() = user_agent;
+    info!("[FB] created login window");
 
     Ok(())
 }
@@ -4927,7 +4950,7 @@ async fn fb_hide_login(app: tauri::AppHandle) -> Result<(), String> {
         "fb-login-window-closed",
         serde_json::json!({ "closed": true }),
     );
-    recycle_webview_window(&app, "fb-scraper", "login dismissed");
+    recycle_webview_window(&app, "fb-login", "login dismissed");
     Ok(())
 }
 
@@ -5699,7 +5722,7 @@ async fn ig_show_login(
     // Track whether we've already emitted the auth result (one-shot)
     let auth_emitted = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
 
-    WebviewWindowBuilder::new(
+    let login_window = WebviewWindowBuilder::new(
         &app,
         "ig-scraper",
         tauri::WebviewUrl::External("https://www.instagram.com/accounts/login/".parse().unwrap()),
@@ -5720,13 +5743,6 @@ async fn ig_show_login(
     )
     .center()
     .visible(true)
-    .on_window_event(|window, event| {
-        if let tauri::WindowEvent::CloseRequested { .. } = event {
-            let _ = window
-                .app_handle()
-                .emit("ig-login-window-closed", serde_json::json!({ "closed": true }));
-        }
-    })
     .on_navigation(move |url| {
         let path = url.path();
         let host = url.host_str().unwrap_or("");
@@ -5745,6 +5761,15 @@ async fn ig_show_login(
     })
     .build()
     .map_err(|e| e.to_string())?;
+    let close_app = app.clone();
+    login_window.on_window_event(move |event| {
+        if let tauri::WindowEvent::CloseRequested { .. } = event {
+            let _ = close_app.emit(
+                "ig-login-window-closed",
+                serde_json::json!({ "closed": true }),
+            );
+        }
+    });
 
     *capture.ig_user_agent.lock().unwrap() = user_agent;
 
@@ -6332,7 +6357,7 @@ async fn li_show_login(
     // Track whether we've already emitted the auth result (one-shot)
     let auth_emitted = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
 
-    WebviewWindowBuilder::new(
+    let login_window = WebviewWindowBuilder::new(
         &app,
         "li-scraper",
         tauri::WebviewUrl::External("https://www.linkedin.com/login".parse().unwrap()),
@@ -6353,13 +6378,6 @@ async fn li_show_login(
     )
     .center()
     .visible(true)
-    .on_window_event(|window, event| {
-        if let tauri::WindowEvent::CloseRequested { .. } = event {
-            let _ = window
-                .app_handle()
-                .emit("li-login-window-closed", serde_json::json!({ "closed": true }));
-        }
-    })
     .on_navigation(move |url| {
         let path = url.path();
         let host = url.host_str().unwrap_or("");
@@ -6379,6 +6397,15 @@ async fn li_show_login(
     })
     .build()
     .map_err(|e| e.to_string())?;
+    let close_app = app.clone();
+    login_window.on_window_event(move |event| {
+        if let tauri::WindowEvent::CloseRequested { .. } = event {
+            let _ = close_app.emit(
+                "li-login-window-closed",
+                serde_json::json!({ "closed": true }),
+            );
+        }
+    });
 
     *capture.li_user_agent.lock().unwrap() = user_agent;
 
@@ -7150,18 +7177,15 @@ fn schedule_main_window_occlusion_recovery(
     tauri::async_runtime::spawn(async move {
         tokio::time::sleep(delay).await;
         let app_for_probe = app.clone();
-        let probe = run_main_window_step_on_main_thread(
-            &app,
-            "main window occlusion probe",
-            move || {
+        let probe =
+            run_main_window_step_on_main_thread(&app, "main window occlusion probe", move || {
                 let Some(window) = live_main_window(&app_for_probe) else {
                     return Ok(None);
                 };
                 let occlusion_state = main_window_native_occlusion_state(&window);
                 let is_occluded = main_window_native_is_occluded(&window).unwrap_or(false);
                 Ok(Some((is_occluded, occlusion_state)))
-            },
-        );
+            });
 
         let Ok(Some((true, occlusion_state))) = probe else {
             return;
@@ -8909,6 +8933,10 @@ mod tests {
     fn social_scraper_data_stores_are_provider_specific() {
         assert_eq!(
             social_scraper_data_store_identifier("fb-scraper"),
+            Some(FB_SCRAPER_DATA_STORE_IDENTIFIER)
+        );
+        assert_eq!(
+            social_scraper_data_store_identifier("fb-login"),
             Some(FB_SCRAPER_DATA_STORE_IDENTIFIER)
         );
         assert_eq!(

--- a/packages/desktop/src/App.tsx
+++ b/packages/desktop/src/App.tsx
@@ -989,7 +989,15 @@ function App() {
       pickContact: pickContactViaTauri,
       googleContacts: tauriRuntimeAvailable
         ? {
-            getToken: () => getValidCloudToken("gdrive"),
+            getToken: async () => {
+              try {
+                return await getValidCloudToken("gdrive");
+              } catch (error) {
+                const message = error instanceof Error ? error.message : String(error);
+                log.warn(`[contacts] Google token lookup failed: ${message}`);
+                return null;
+              }
+            },
             connect: connectGoogleContacts,
             fetchContacts: fetchGoogleContactsForDesktop,
           }

--- a/packages/desktop/src/components/FacebookSettingsSection.tsx
+++ b/packages/desktop/src/components/FacebookSettingsSection.tsx
@@ -10,7 +10,7 @@ import { useState, useCallback, useEffect, useRef, type ReactNode } from "react"
 import { isTauri } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { usePlatform, type SyncProviderSectionProps } from "@freed/ui/context";
-import { useDebugStore } from "@freed/ui/lib/debug-store";
+import { addDebugEvent, useDebugStore } from "@freed/ui/lib/debug-store";
 import {
   getProviderStatusLabel,
   getProviderStatusTone,
@@ -52,6 +52,7 @@ import { clearProviderPause, resetProviderPauseState } from "../lib/provider-hea
 import { MediaVaultSettingsCard } from "./MediaVaultSettingsCard";
 import { socialProviderCopy } from "../lib/social-provider-copy";
 import { isRuntimeDeferredStage } from "../lib/social-capture-runtime";
+import { log } from "../lib/logger";
 
 // =============================================================================
 // Diagnostic Panel
@@ -183,6 +184,23 @@ function FbDiagPanel({ diag }: { diag: FbSyncDiag }) {
           warn={diag.postsExtracted === 0}
         />
         <DiagRow
+          label="Extraction passes"
+          value={diag.extractionPasses.toLocaleString()}
+        />
+        <DiagRow
+          label="Candidates seen"
+          value={diag.totalCandidateCount.toLocaleString()}
+          warn={diag.postsExtracted === 0 && diag.totalCandidateCount === 0}
+        />
+        <DiagRow
+          label="Rejected candidates"
+          value={(
+            diag.totalRejected.suggestedOrSponsored +
+            diag.totalRejected.missingAuthor +
+            diag.totalRejected.missingContent
+          ).toLocaleString()}
+        />
+        <DiagRow
           label="After normalize"
           value={diag.itemsNormalized.toLocaleString()}
           warn={diag.itemsNormalized === 0 && diag.postsExtracted > 0}
@@ -248,14 +266,20 @@ export function FacebookSettingsSection({
     if (!isTauri() && import.meta.env.VITE_TEST_TAURI !== "1") return;
 
     const unlisten = listen<{ loggedIn: boolean }>("fb-auth-result", (event) => {
+      log.info(`[FB] auth result received logged_in=${event.payload.loggedIn}`);
       const newState = {
         ...useAppStore.getState().fbAuth,
         isAuthenticated: event.payload.loggedIn,
         lastCheckedAt: Date.now(),
+        lastCaptureError: event.payload.loggedIn
+          ? undefined
+          : useAppStore.getState().fbAuth.lastCaptureError,
       };
       setFbAuth(newState);
       storeFbAuthState(newState);
       if (event.payload.loggedIn) {
+        setActionError(null);
+        addDebugEvent("change", "[FB] connection restored");
         loginWindowPendingSyncRef.current = true;
         setLoginWindowPendingSync(true);
       } else {
@@ -272,15 +296,24 @@ export function FacebookSettingsSection({
   }, [fbAuth.isAuthenticated, items]);
 
   const handleLogin = useCallback(async () => {
+    log.info(
+      `[FB] reconnect click auth=${fbAuth.isAuthenticated} reconnect=${needsProviderReconnect(fbAuth.lastCaptureError ?? actionError ?? null)}`,
+    );
+    addDebugEvent("change", "[FB] reconnect requested");
     await confirm(async () => {
+      log.info("[FB] reconnect consent cleared");
       setActionError(null);
       try {
         await showFbLogin();
+        log.info("[FB] reconnect login window requested");
       } catch (err) {
-        setActionError(err instanceof Error ? err.message : "Failed to open login window");
+        const message = err instanceof Error ? err.message : "Failed to open login window";
+        log.error(`[FB] reconnect failed: ${message}`);
+        addDebugEvent("error", `[FB] reconnect failed: ${message}`);
+        setActionError(message);
       }
     });
-  }, [confirm]);
+  }, [actionError, confirm, fbAuth.isAuthenticated, fbAuth.lastCaptureError]);
 
   const handleCheckAuth = useCallback(async () => {
     await confirm(async () => {

--- a/packages/desktop/src/hooks/useProviderRiskGate.tsx
+++ b/packages/desktop/src/hooks/useProviderRiskGate.tsx
@@ -6,6 +6,7 @@ import {
   acceptProviderRisk,
   hasAcceptedProviderRisk,
 } from "../lib/legal-consent";
+import { log } from "../lib/logger";
 
 export function useProviderRiskGate(provider: ProviderRiskId) {
   const [open, setOpen] = useState(false);
@@ -13,12 +14,16 @@ export function useProviderRiskGate(provider: ProviderRiskId) {
 
   const confirm = useCallback(
     async (action: () => Promise<void> | void) => {
+      log.info(`[provider-risk/${provider}] confirm requested`);
       if (await hasAcceptedProviderRisk(provider)) {
+        log.info(`[provider-risk/${provider}] already accepted, running action`);
         await action();
         return;
       }
 
+      log.info(`[provider-risk/${provider}] showing consent dialog`);
       pendingAction.current = async () => {
+        log.info(`[provider-risk/${provider}] accepted, running pending action`);
         await action();
       };
       setOpen(true);

--- a/packages/desktop/src/lib/fb-auth.ts
+++ b/packages/desktop/src/lib/fb-auth.ts
@@ -9,6 +9,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { selectPlatformUA, clearPlatformUA } from "./user-agent";
+import { log } from "./logger";
 
 export interface FbAuthState {
   isAuthenticated: boolean;
@@ -33,7 +34,15 @@ const FB_AUTH_KEY = "fb_auth_state";
 export async function showFbLogin(): Promise<void> {
   // Generate and persist a fresh session UA at connect time.
   const userAgent = selectPlatformUA("facebook");
-  await invoke("fb_show_login", { userAgent });
+  log.info("[FB] show login requested");
+  try {
+    await invoke("fb_show_login", { userAgent });
+    log.info("[FB] show login IPC completed");
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    log.error(`[FB] show login IPC failed: ${message}`);
+    throw error;
+  }
 }
 
 /**

--- a/packages/desktop/src/lib/fb-capture.ts
+++ b/packages/desktop/src/lib/fb-capture.ts
@@ -529,6 +529,9 @@ export async function fetchFbFeed(): Promise<FbSyncResult> {
     if (diag.totalCandidateCount > 0 && parseRejectCount > 0) {
       diag.errorStage = "extract";
       diag.errorMessage = formatFacebookParseFailureMessage(diag);
+    } else {
+      diag.errorStage = "extract_empty";
+      diag.errorMessage = formatFacebookEmptySyncMessage(diag);
     }
     return { items: [], diag };
   }

--- a/packages/desktop/src/lib/fb-extract-dom.test.ts
+++ b/packages/desktop/src/lib/fb-extract-dom.test.ts
@@ -182,4 +182,30 @@ describe("Facebook DOM extractor", () => {
       }),
     ]);
   });
+
+  it("climbs from post permalinks when semantic article boundaries are missing", () => {
+    const payload = runExtractor(`
+      <div role="main">
+        <section>
+          <div>
+            <div>
+              <h3><a href="https://www.facebook.com/ada.example">Ada Example</a></h3>
+              <a href="https://www.facebook.com/ada.example/posts/123456789">Open post</a>
+              <div dir="auto">A permalink can be the only reliable post boundary on the current Facebook feed.</div>
+            </div>
+          </div>
+        </section>
+      </div>
+    `);
+
+    expect(payload?.candidateCount).toBe(1);
+    expect(payload?.posts).toEqual([
+      expect.objectContaining({
+        id: "123456789",
+        authorName: "Ada Example",
+        authorProfileUrl: "https://www.facebook.com/ada.example",
+        text: "A permalink can be the only reliable post boundary on the current Facebook feed.",
+      }),
+    ]);
+  });
 });

--- a/packages/desktop/src/lib/social-capture-memory-pressure.test.ts
+++ b/packages/desktop/src/lib/social-capture-memory-pressure.test.ts
@@ -314,8 +314,9 @@ describe("social capture completion", () => {
     expect(recordProviderHealthEvent).toHaveBeenCalledWith(
       expect.objectContaining({
         provider: "facebook",
-        outcome: "empty",
-        stage: "empty",
+        outcome: "error",
+        stage: "extract_empty",
+        reason: expectedMessage,
         itemsSeen: 0,
         itemsAdded: 0,
       }),

--- a/packages/desktop/tests/e2e/facebook-capture.spec.ts
+++ b/packages/desktop/tests/e2e/facebook-capture.spec.ts
@@ -94,6 +94,54 @@ test("Facebook connect form accepts cookies and triggers sync", async ({
   ).toBeVisible({ timeout: 5_000 });
 });
 
+test("Facebook reconnect opens the login WebView from connected error state", async ({
+  app,
+  ipc,
+}) => {
+  await app.goto();
+  await app.waitForReady();
+
+  const { page } = app;
+  await page.evaluate(() => {
+    const store = (window as Record<string, unknown>).__FREED_STORE__ as {
+      setState: (partial: Record<string, unknown>) => void;
+    };
+    store.setState({
+      fbAuth: {
+        isAuthenticated: true,
+        lastCheckedAt: Date.now(),
+        lastCaptureError: "Facebook session expired. Reconnect to keep syncing.",
+      },
+    });
+  });
+
+  const settingsBtn = page
+    .locator("button")
+    .filter({ hasText: /settings/i })
+    .first();
+  await expect(settingsBtn).toBeVisible({ timeout: 5_000 });
+  await settingsBtn.click();
+  await expect(page.getByText("Settings").first()).toBeVisible({
+    timeout: 5_000,
+  });
+
+  const fbSection = getSettingsDialog(page).getByRole("button", {
+    name: /Facebook.*Reconnect required/,
+  });
+  await expect(fbSection).toBeVisible({ timeout: 3_000 });
+  await fbSection.click();
+
+  const reconnectButton = page.getByTestId("provider-sync-action-facebook");
+  await expect(reconnectButton).toHaveText(/Reconnect Facebook/);
+  await reconnectButton.click();
+  await app.acceptProviderRiskIfPresent("facebook");
+
+  await expect.poll(async () => {
+    const invocations = await ipc.invocations();
+    return invocations.filter((call) => call.cmd === "fb_show_login").length;
+  }).toBe(1);
+});
+
 test("Facebook sync excludes posts from filtered groups", async ({
   app,
   ipc,

--- a/packages/desktop/tests/e2e/social-memory-preflight.spec.ts
+++ b/packages/desktop/tests/e2e/social-memory-preflight.spec.ts
@@ -61,6 +61,23 @@ async function clickFacebookSync(page: import("@playwright/test").Page) {
   await button.click();
 }
 
+async function waitForFacebookCaptureError(
+  page: import("@playwright/test").Page,
+): Promise<string | undefined> {
+  await page.waitForFunction(() => {
+    const store = (window as Record<string, unknown>).__FREED_STORE__ as {
+      getState: () => { fbAuth: { lastCaptureError?: string } };
+    };
+    return Boolean(store.getState().fbAuth.lastCaptureError);
+  });
+  return page.evaluate(() => {
+    const store = (window as Record<string, unknown>).__FREED_STORE__ as {
+      getState: () => { fbAuth: { lastCaptureError?: string } };
+    };
+    return store.getState().fbAuth.lastCaptureError;
+  });
+}
+
 function installEmptyFacebookScrape(ipc: {
   setHandler: (cmd: string, handler: (args: unknown) => unknown) => Promise<void>;
 }) {
@@ -136,13 +153,9 @@ test("facebook scrape proceeds when unrelated WebKit memory is high", async ({ a
 
   await clickFacebookSync(page);
   await app.acceptProviderRiskIfPresent("facebook");
-  const authState = await page.evaluate(() => {
-    const store = (window as Record<string, unknown>).__FREED_STORE__ as {
-      getState: () => { fbAuth: { lastCaptureError?: string } };
-    };
-    return store.getState().fbAuth;
-  });
-  expect(authState.lastCaptureError).toBeUndefined();
+  await expect(await waitForFacebookCaptureError(page)).toContain(
+    "Feed returned no posts",
+  );
   const invocations = await ipc.invocations();
   expect(invocations.some((call) => call.cmd === "fb_scrape_feed")).toBe(true);
 });
@@ -203,13 +216,9 @@ test("facebook scrape proceeds after Freed memory cleanup recovers", async ({ ap
 
   await clickFacebookSync(page);
   await app.acceptProviderRiskIfPresent("facebook");
-  const authState = await page.evaluate(() => {
-    const store = (window as Record<string, unknown>).__FREED_STORE__ as {
-      getState: () => { fbAuth: { lastCaptureError?: string } };
-    };
-    return store.getState().fbAuth;
-  });
-  expect(authState.lastCaptureError).toBeUndefined();
+  await expect(await waitForFacebookCaptureError(page)).toContain(
+    "Feed returned no posts",
+  );
   const invocations = await ipc.invocations();
   expect(invocations.some((call) => call.cmd === "fb_scrape_feed")).toBe(true);
 });


### PR DESCRIPTION
(AI Generated).

## Summary
- (AI Generated).
Restores Facebook sync by separating the login WebView from the scraper window, adding permalink fallback extraction, and making zero-post scrapes fail with diagnostic detail instead of looking healthy.

## Testing
- Live installed Freed Desktop Facebook sync: 6 posts extracted, 5 new items written. npm run validate:feature -- --changed-files ... passed. Focused unit, e2e, build, cargo fmt, and cargo check passed.