### PR TITLE
test: stabilize sidebar snap validation

### DIFF
--- a/packages/desktop/tests/e2e/smoke.spec.ts
+++ b/packages/desktop/tests/e2e/smoke.spec.ts
@@ -219,10 +219,11 @@ async function expectDesktopSidebarWidthBetween(
   timeout = 1_000,
 ) {
   await expect
-    .poll(async () => (await readDesktopSidebarGeometry(page)).sidebarWidth, { timeout })
-    .toBeLessThanOrEqual(maximumWidth);
-  const width = (await readDesktopSidebarGeometry(page)).sidebarWidth;
-  expect(width).toBeGreaterThanOrEqual(minimumWidth);
+    .poll(async () => {
+      const width = (await readDesktopSidebarGeometry(page)).sidebarWidth;
+      return width >= minimumWidth && width <= maximumWidth;
+    }, { timeout })
+    .toBe(true);
 }
 
 async function waitForDesktopSidebarMode(page: Page, mode: "expanded" | "compact" | "closed") {
@@ -961,11 +962,9 @@ test("desktop sidebar snaps to compact and closed, then reopens at the default e
   await page.mouse.up();
 
   await sidebarToggle.click();
-  await expect
-    .poll(async () => (await readDesktopSidebarGeometry(page)).sidebarWidth, { timeout: 1_000 })
-    .toBeGreaterThanOrEqual(252);
   await waitForDesktopSidebarMode(page, "expanded");
   await expect(desktopSidebar).toBeVisible();
+  await expectDesktopSidebarWidthBetween(page, 252, 260);
   const restoredExpandedGeometry = await readDesktopSidebarGeometry(page);
   expect(restoredExpandedGeometry.sidebarWidth).toBeGreaterThanOrEqual(252);
   expect(restoredExpandedGeometry.sidebarWidth).toBeLessThanOrEqual(260);


### PR DESCRIPTION
(AI Generated).

## Summary
- Make the desktop sidebar width helper wait for the full expected range in one poll.
- Use that helper for the release-blocking restored sidebar assertion.
- Fixes the v26.6.200 release validation failure where one transient frame reported sidebarWidth=0 after reopen.

## Validation
- npm run test:e2e -- smoke.spec.ts --grep "desktop sidebar snaps to compact and closed"
- npm run validate:feature -- --changed-files packages/desktop/tests/e2e/smoke.spec.ts