### PR TITLE
test: promote sidebar snap validation fix

### DIFF
--- a/packages/desktop/tests/e2e/smoke.spec.ts
+++ b/packages/desktop/tests/e2e/smoke.spec.ts
@@ -219,10 +219,11 @@ async function expectDesktopSidebarWidthBetween(
   timeout = 1_000,
 ) {
   await expect
-    .poll(async () => (await readDesktopSidebarGeometry(page)).sidebarWidth, { timeout })
-    .toBeLessThanOrEqual(maximumWidth);
-  const width = (await readDesktopSidebarGeometry(page)).sidebarWidth;
-  expect(width).toBeGreaterThanOrEqual(minimumWidth);
+    .poll(async () => {
+      const width = (await readDesktopSidebarGeometry(page)).sidebarWidth;
+      return width >= minimumWidth && width <= maximumWidth;
+    }, { timeout })
+    .toBe(true);
 }
 
 async function waitForDesktopSidebarMode(page: Page, mode: "expanded" | "compact" | "closed") {
@@ -961,11 +962,9 @@ test("desktop sidebar snaps to compact and closed, then reopens at the default e
   await page.mouse.up();
 
   await sidebarToggle.click();
-  await expect
-    .poll(async () => (await readDesktopSidebarGeometry(page)).sidebarWidth, { timeout: 1_000 })
-    .toBeGreaterThanOrEqual(252);
   await waitForDesktopSidebarMode(page, "expanded");
   await expect(desktopSidebar).toBeVisible();
+  await expectDesktopSidebarWidthBetween(page, 252, 260);
   const restoredExpandedGeometry = await readDesktopSidebarGeometry(page);
   expect(restoredExpandedGeometry.sidebarWidth).toBeGreaterThanOrEqual(252);
   expect(restoredExpandedGeometry.sidebarWidth).toBeLessThanOrEqual(260);


### PR DESCRIPTION
(AI Generated).

## Summary
- Promote the sidebar snap validation fix from dev into main after the v26.6.200 release workflow exposed the transient-width failure.
- Preserve the existing production release version and release-note files on main.
- Keep main in sync with dev on product-owned paths.

## Validation
- node scripts/validate-release-promotion.mjs --from-ref=origin/dev --to-ref=HEAD
- node scripts/validate-main-pr.mjs --base-ref=origin/main --head-ref=HEAD --head-branch=chore/promote-dev-to-main-sidebar-snap-validation