### PR TITLE
fix: run macOS Intel releases on Intel runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,7 +132,7 @@ jobs:
             exit 1
           fi
 
-          PRIMARY_RELEASE_MATRIX='{"include":[{"platform":"macos-latest","args":"--target aarch64-apple-darwin","rust_target":"aarch64-apple-darwin"},{"platform":"macos-latest","args":"--target x86_64-apple-darwin","rust_target":"x86_64-apple-darwin"},{"platform":"windows-latest","args":"--target x86_64-pc-windows-msvc","rust_target":"x86_64-pc-windows-msvc"},{"platform":"ubuntu-22.04","args":"","rust_target":"x86_64-unknown-linux-gnu"}]}'
+          PRIMARY_RELEASE_MATRIX='{"include":[{"platform":"macos-latest","args":"--target aarch64-apple-darwin","rust_target":"aarch64-apple-darwin"},{"platform":"macos-15-intel","args":"--target x86_64-apple-darwin","rust_target":"x86_64-apple-darwin"},{"platform":"windows-latest","args":"--target x86_64-pc-windows-msvc","rust_target":"x86_64-pc-windows-msvc"},{"platform":"ubuntu-22.04","args":"","rust_target":"x86_64-unknown-linux-gnu"}]}'
 
           # Write to GITHUB_OUTPUT using heredoc to handle multiline
           {

--- a/scripts/release-workflow-matrix.test.mjs
+++ b/scripts/release-workflow-matrix.test.mjs
@@ -36,7 +36,7 @@ test("dev and production releases use the same primary platform matrix", () => {
       rust_target: "aarch64-apple-darwin",
     },
     {
-      platform: "macos-latest",
+      platform: "macos-15-intel",
       args: "--target x86_64-apple-darwin",
       rust_target: "x86_64-apple-darwin",
     },


### PR DESCRIPTION
(AI Generated).

## Summary
- Promote the release workflow runner fix from dev to main.
- Move the x86_64 macOS release matrix entry from macos-latest to macos-15-intel.
- Keep Apple Silicon on macos-latest and update the matrix test to guard the runner split.

## Why
- v26.6.201 built, signed, and notarized the Intel app, then failed while bundling the x64 DMG on the arm64 macOS runner.
- The Intel target should package on an Intel runner before the next production tag.

## Validation
- node --test scripts/release-workflow-matrix.test.mjs
- node scripts/validate-main-pr.mjs --base-ref=origin/main --head-ref=HEAD --head-branch=chore/promote-dev-to-main-macos-intel-release-runner
- npm run validate:feature -- --changed-files .github/workflows/release.yml scripts/release-workflow-matrix.test.mjs