### PR TITLE
chore: add v26.6.204 release notes to www

### DIFF
--- a/release-notes/daily/production/26.6.2.json
+++ b/release-notes/daily/production/26.6.2.json
@@ -2,33 +2,29 @@
   "channel": "production",
   "dayKey": "26.6.2",
   "date": "2026-06-02",
-  "preferredDeck": null,
+  "preferredDeck": "Google Drive sync now has a manual Sync now action and visible diagnostics in Freed Desktop and app.freed.wtf, including queued, started, deferred, completed, waiting, and failed sync events.",
   "editorialGuidance": [
     "Keep the tone concise, professional, and specific.",
-    "Lead with Facebook sync reliability and the lower-profile social capture changes.",
-    "Mention memory and validation improvements only when they directly affect shipped behavior."
+    "Lead with Google Drive manual sync and diagnostics.",
+    "Mention prior social sync fixes only if they are needed for same-day release context."
   ],
   "pinnedHighlights": [
     {
-      "text": "Facebook sync treats stalled, logged-out, and zero-usable-post pages as actionable sync failures instead of healthy empty pulls.",
-      "sourceTag": "v26.6.201"
+      "text": "Freed Desktop and app.freed.wtf now show a Sync now button for connected Google Drive accounts.",
+      "sourceTag": "v26.6.204"
     },
     {
-      "text": "Facebook extraction restores DOM-based feed parsing and reports why extracted posts normalize to zero usable items.",
-      "sourceTag": "v26.6.201"
+      "text": "Google Drive sync diagnostics now report queued, started, deferred, completed, waiting, and failed work.",
+      "sourceTag": "v26.6.204"
     },
     {
-      "text": "macOS Intel release builds now run on Intel GitHub runners, avoiding the x64 DMG cross-packaging failure from v26.6.201.",
-      "sourceTag": "v26.6.202"
-    },
-    {
-      "text": "Release validation now avoids transient restored-sidebar geometry samples after the stable width assertion passes.",
-      "sourceTag": "v26.6.203"
+      "text": "Sync diagnostics now explain why Last upload can be blank instead of leaving users to infer cloud state.",
+      "sourceTag": "v26.6.204"
     }
   ],
   "editorialNotes": [
-    "This production build includes the June 1 dev release train plus post-dev Facebook sync reliability fixes through PR 707.",
-    "v26.6.203 replaces failed v26.6.200, v26.6.201, and v26.6.202 release workflow attempts, and adds the macOS Intel runner fix plus sidebar release-validation stabilization."
+    "This production build carries the Google Drive sync diagnostics and manual sync work from PR 722.",
+    "v26.6.204 follows v26.6.203 and should focus on the new cloud sync observability rather than repeating the prior Facebook release train."
   ],
-  "updatedAt": "2026-06-02T22:44:48.000Z"
+  "updatedAt": "2026-06-03T05:52:33.648Z"
 }

--- a/release-notes/releases/v26.6.204.json
+++ b/release-notes/releases/v26.6.204.json
@@ -1,0 +1,105 @@
+{
+  "tag": "v26.6.204",
+  "version": "26.6.204",
+  "channel": "production",
+  "dayKey": "26.6.2",
+  "approved": true,
+  "editorialNotes": [
+    "Approved for production release after rewriting the generated notes to focus on the Google Drive sync diagnostics shipped in PR 722."
+  ],
+  "generatedAt": "2026-06-03T05:52:33.645Z",
+  "model": "heuristic",
+  "source": {
+    "channel": "production",
+    "previousPublishedTag": "v26.6.203",
+    "previousPublishedDayTag": "v26.5.3113",
+    "compareRef": "HEAD",
+    "isLatestOfDay": true,
+    "sameDayTagsIncluded": [
+      "v26.6.203",
+      "v26.6.204"
+    ],
+    "relatedBuildTags": [
+      "v26.6.203",
+      "v26.6.204"
+    ],
+    "prNumbers": [
+      681,
+      682,
+      683,
+      684,
+      685,
+      686,
+      687,
+      688,
+      689,
+      690,
+      691,
+      692,
+      693,
+      694,
+      695,
+      696,
+      697,
+      698,
+      699,
+      700,
+      701,
+      702,
+      703,
+      704,
+      705,
+      706,
+      707,
+      708,
+      711,
+      712,
+      716,
+      717,
+      719,
+      720,
+      722,
+      723
+    ],
+    "commitSubjects": [
+      "chore: promote dev into main for production release (#723)",
+      "fix: add manual cloud sync diagnostics (#722)"
+    ]
+  },
+  "release": {
+    "deck": "Manual cloud troubleshooting joins the June 2 production rollup",
+    "features": [],
+    "fixes": [
+      "Facebook, Instagram, and LinkedIn sync now share lower-profile feed scrolling behavior",
+      "Facebook page checks now require a live cookie, the Feed posts heading, or rendered feed units before marking a page feed-like",
+      "Logged-out Facebook pages with generic main content and tall layout now fail closed instead of wasting scrape passes",
+      "Facebook extraction diagnostics now include feed unit and login chrome evidence for faster follow-up debugging",
+      "Facebook extraction restores DOM-based feed parsing and reports why extracted posts normalize to zero usable items",
+      "Facebook sync now reports unauthenticated or stalled feed pages as real sync failures instead of a successful zero-post pull",
+      "Zero usable Facebook scrape results still surface as sync issues instead of healthy success",
+      "Social source status now requires live auth state before showing a connected badge, so old items do not mask a lost provider session",
+      "Provider login prompts stay visible for disconnected Facebook, Instagram, and LinkedIn accounts instead of being hidden by stale state",
+      "Social sync defers while the Mac is locked, and Freed Desktop startup waits until the session can safely initialize",
+      "RSS scheduled polling backs off after runtime deferrals instead of retrying every 15 seconds",
+      "RSS content backfill defers under WebKit pressure",
+      "Idle Automerge workers stop reliably after queued work drains",
+      "Google Drive sync now retries token-refresh download failures and exposes clearer diagnostics before falling back to an empty cursor",
+      "Google Contacts token refresh failures now stay recoverable in Settings instead of opening the fatal recovery screen",
+      "Freed Desktop and app.freed.wtf now show a Sync now button for connected Google Drive accounts.",
+      "Google Drive sync records visible activity events for queued, started, deferred, completed, waiting, and failed work.",
+      "Sync diagnostics now explain why Last upload can be blank, including when there is no remote file yet or no local change has been uploaded.",
+      "Desktop and PWA Google Drive token refresh failures now surface as recoverable sync diagnostics instead of falling through silently.",
+      "The shared sync debug store now records richer transfer state so the same problem can be diagnosed from either connected device."
+    ],
+    "followUps": [
+      "Facebook group leave now hands off to the provider safely without folding group refresh into normal feed sync",
+      "Hidden atmosphere layers release memory and skip hidden startup work",
+      "Provider validation now has a fast lane so future social sync fixes can be proven without running every heavy validation tier",
+      "Desktop startup diagnostics now capture occluded-window cases that can look like a frozen launch",
+      "macOS Intel release builds now run on Intel GitHub runners so x64 DMG bundling avoids Apple Silicon cross packaging",
+      "Release validation now avoids transient restored-sidebar geometry samples after the stable width assertion passes",
+      "Phase 4, Phase 5, Phase 6, and the public roadmap now describe the manual sync and diagnostics behavior as shipped."
+    ]
+  },
+  "releaseBody": "(AI Generated).\n\n## Freed v26.6.204\n\nManual cloud troubleshooting joins the June 2 production rollup\n\n### Fixes\n\n- Facebook, Instagram, and LinkedIn sync now share lower-profile feed scrolling behavior\n- Facebook page checks now require a live cookie, the Feed posts heading, or rendered feed units before marking a page feed-like\n- Logged-out Facebook pages with generic main content and tall layout now fail closed instead of wasting scrape passes\n- Facebook extraction diagnostics now include feed unit and login chrome evidence for faster follow-up debugging\n- Facebook extraction restores DOM-based feed parsing and reports why extracted posts normalize to zero usable items\n- Facebook sync now reports unauthenticated or stalled feed pages as real sync failures instead of a successful zero-post pull\n- Zero usable Facebook scrape results still surface as sync issues instead of healthy success\n- Social source status now requires live auth state before showing a connected badge, so old items do not mask a lost provider session\n- Provider login prompts stay visible for disconnected Facebook, Instagram, and LinkedIn accounts instead of being hidden by stale state\n- Social sync defers while the Mac is locked, and Freed Desktop startup waits until the session can safely initialize\n- RSS scheduled polling backs off after runtime deferrals instead of retrying every 15 seconds\n- RSS content backfill defers under WebKit pressure\n- Idle Automerge workers stop reliably after queued work drains\n- Google Drive sync now retries token-refresh download failures and exposes clearer diagnostics before falling back to an empty cursor\n- Google Contacts token refresh failures now stay recoverable in Settings instead of opening the fatal recovery screen\n- Freed Desktop and app.freed.wtf now show a Sync now button for connected Google Drive accounts.\n- Google Drive sync records visible activity events for queued, started, deferred, completed, waiting, and failed work.\n- Sync diagnostics now explain why Last upload can be blank, including when there is no remote file yet or no local change has been uploaded.\n- Desktop and PWA Google Drive token refresh failures now surface as recoverable sync diagnostics instead of falling through silently.\n- The shared sync debug store now records richer transfer state so the same problem can be diagnosed from either connected device.\n\n### Follow-ups\n\n- Facebook group leave now hands off to the provider safely without folding group refresh into normal feed sync\n- Hidden atmosphere layers release memory and skip hidden startup work\n- Provider validation now has a fast lane so future social sync fixes can be proven without running every heavy validation tier\n- Desktop startup diagnostics now capture occluded-window cases that can look like a frozen launch\n- macOS Intel release builds now run on Intel GitHub runners so x64 DMG bundling avoids Apple Silicon cross packaging\n- Release validation now avoids transient restored-sidebar geometry samples after the stable width assertion passes\n- Phase 4, Phase 5, Phase 6, and the public roadmap now describe the manual sync and diagnostics behavior as shipped.\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed and notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+}

--- a/release-notes/releases/v26.6.204.md
+++ b/release-notes/releases/v26.6.204.md
@@ -1,0 +1,46 @@
+(AI Generated).
+
+## Freed v26.6.204
+
+Manual cloud troubleshooting joins the June 2 production rollup
+
+### Fixes
+
+- Facebook, Instagram, and LinkedIn sync now share lower-profile feed scrolling behavior
+- Facebook page checks now require a live cookie, the Feed posts heading, or rendered feed units before marking a page feed-like
+- Logged-out Facebook pages with generic main content and tall layout now fail closed instead of wasting scrape passes
+- Facebook extraction diagnostics now include feed unit and login chrome evidence for faster follow-up debugging
+- Facebook extraction restores DOM-based feed parsing and reports why extracted posts normalize to zero usable items
+- Facebook sync now reports unauthenticated or stalled feed pages as real sync failures instead of a successful zero-post pull
+- Zero usable Facebook scrape results still surface as sync issues instead of healthy success
+- Social source status now requires live auth state before showing a connected badge, so old items do not mask a lost provider session
+- Provider login prompts stay visible for disconnected Facebook, Instagram, and LinkedIn accounts instead of being hidden by stale state
+- Social sync defers while the Mac is locked, and Freed Desktop startup waits until the session can safely initialize
+- RSS scheduled polling backs off after runtime deferrals instead of retrying every 15 seconds
+- RSS content backfill defers under WebKit pressure
+- Idle Automerge workers stop reliably after queued work drains
+- Google Drive sync now retries token-refresh download failures and exposes clearer diagnostics before falling back to an empty cursor
+- Google Contacts token refresh failures now stay recoverable in Settings instead of opening the fatal recovery screen
+- Freed Desktop and app.freed.wtf now show a Sync now button for connected Google Drive accounts.
+- Google Drive sync records visible activity events for queued, started, deferred, completed, waiting, and failed work.
+- Sync diagnostics now explain why Last upload can be blank, including when there is no remote file yet or no local change has been uploaded.
+- Desktop and PWA Google Drive token refresh failures now surface as recoverable sync diagnostics instead of falling through silently.
+- The shared sync debug store now records richer transfer state so the same problem can be diagnosed from either connected device.
+
+### Follow-ups
+
+- Facebook group leave now hands off to the provider safely without folding group refresh into normal feed sync
+- Hidden atmosphere layers release memory and skip hidden startup work
+- Provider validation now has a fast lane so future social sync fixes can be proven without running every heavy validation tier
+- Desktop startup diagnostics now capture occluded-window cases that can look like a frozen launch
+- macOS Intel release builds now run on Intel GitHub runners so x64 DMG bundling avoids Apple Silicon cross packaging
+- Release validation now avoids transient restored-sidebar geometry samples after the stable width assertion passes
+- Phase 4, Phase 5, Phase 6, and the public roadmap now describe the manual sync and diagnostics behavior as shipped.
+
+### Downloads
+
+**macOS:** `.dmg` (Apple Silicon or Intel, signed and notarized)  
+**Windows:** `.exe` (NSIS installer)  
+**Linux:** `.AppImage`  
+
+> macOS downloads are signed and notarized for normal Gatekeeper installation.

--- a/website/public/atom.xml
+++ b/website/public/atom.xml
@@ -2,7 +2,7 @@
 <feed xmlns="http://www.w3.org/2005/Atom">
     <id>https://freed.wtf</id>
     <title>Freed Blog</title>
-    <updated>2026-06-01T05:38:18.902Z</updated>
+    <updated>2026-06-03T06:39:24.118Z</updated>
     <generator>https://github.com/jpmonette/feed</generator>
     <author>
         <name>The Freed Team</name>

--- a/website/public/feed.xml
+++ b/website/public/feed.xml
@@ -4,7 +4,7 @@
         <title>Freed Blog</title>
         <link>https://freed.wtf</link>
         <description>Progress reports, technical deep-dives, and philosophical rants about the attention economy. From the team building Freed.</description>
-        <lastBuildDate>Mon, 01 Jun 2026 05:38:18 GMT</lastBuildDate>
+        <lastBuildDate>Wed, 03 Jun 2026 06:39:24 GMT</lastBuildDate>
         <docs>https://validator.w3.org/feed/docs/rss2.html</docs>
         <generator>https://github.com/jpmonette/feed</generator>
         <language>en</language>

--- a/website/src/content/changelog.generated.json
+++ b/website/src/content/changelog.generated.json
@@ -1,9 +1,219 @@
 [
   {
-    "version": "26.5.3116-dev",
-    "tagName": "v26.5.3116-dev",
+    "version": "26.6.204",
+    "tagName": "v26.6.204",
+    "channel": "production",
+    "date": "2026-06-03T06:35:36Z",
+    "deck": "Manual cloud troubleshooting joins the June 2 production rollup",
+    "features": [],
+    "fixes": [
+      {
+        "text": "Facebook, Instagram, and LinkedIn sync now share lower-profile feed scrolling behavior"
+      },
+      {
+        "text": "Facebook page checks now require a live cookie, the Feed posts heading, or rendered feed units before marking a page feed-like"
+      },
+      {
+        "text": "Logged-out Facebook pages with generic main content and tall layout now fail closed instead of wasting scrape passes"
+      },
+      {
+        "text": "Facebook extraction diagnostics now include feed unit and login chrome evidence for faster follow-up debugging"
+      },
+      {
+        "text": "Facebook extraction restores DOM-based feed parsing and reports why extracted posts normalize to zero usable items"
+      },
+      {
+        "text": "Facebook sync now reports unauthenticated or stalled feed pages as real sync failures instead of a successful zero-post pull"
+      },
+      {
+        "text": "Zero usable Facebook scrape results still surface as sync issues instead of healthy success"
+      },
+      {
+        "text": "Social source status now requires live auth state before showing a connected badge, so old items do not mask a lost provider session"
+      },
+      {
+        "text": "Provider login prompts stay visible for disconnected Facebook, Instagram, and LinkedIn accounts instead of being hidden by stale state"
+      },
+      {
+        "text": "Social sync defers while the Mac is locked, and Freed Desktop startup waits until the session can safely initialize"
+      },
+      {
+        "text": "RSS scheduled polling backs off after runtime deferrals instead of retrying every 15 seconds"
+      },
+      {
+        "text": "RSS content backfill defers under WebKit pressure"
+      },
+      {
+        "text": "Idle Automerge workers stop reliably after queued work drains"
+      },
+      {
+        "text": "Google Drive sync now retries token-refresh download failures and exposes clearer diagnostics before falling back to an empty cursor"
+      },
+      {
+        "text": "Google Contacts token refresh failures now stay recoverable in Settings instead of opening the fatal recovery screen"
+      },
+      {
+        "text": "Freed Desktop and app.freed.wtf now show a Sync now button for connected Google Drive accounts."
+      },
+      {
+        "text": "Google Drive sync records visible activity events for queued, started, deferred, completed, waiting, and failed work."
+      },
+      {
+        "text": "Sync diagnostics now explain why Last upload can be blank, including when there is no remote file yet or no local change has been uploaded."
+      },
+      {
+        "text": "Desktop and PWA Google Drive token refresh failures now surface as recoverable sync diagnostics instead of falling through silently."
+      },
+      {
+        "text": "The shared sync debug store now records richer transfer state so the same problem can be diagnosed from either connected device."
+      }
+    ],
+    "followUps": [
+      {
+        "text": "Facebook group leave now hands off to the provider safely without folding group refresh into normal feed sync"
+      },
+      {
+        "text": "Hidden atmosphere layers release memory and skip hidden startup work"
+      },
+      {
+        "text": "Provider validation now has a fast lane so future social sync fixes can be proven without running every heavy validation tier"
+      },
+      {
+        "text": "Desktop startup diagnostics now capture occluded-window cases that can look like a frozen launch"
+      },
+      {
+        "text": "macOS Intel release builds now run on Intel GitHub runners so x64 DMG bundling avoids Apple Silicon cross packaging"
+      },
+      {
+        "text": "Release validation now avoids transient restored-sidebar geometry samples after the stable width assertion passes"
+      },
+      {
+        "text": "Phase 4, Phase 5, Phase 6, and the public roadmap now describe the manual sync and diagnostics behavior as shipped."
+      }
+    ],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.204",
+    "prNumbers": [
+      681,
+      682,
+      683,
+      684,
+      685,
+      686,
+      687,
+      688,
+      689,
+      690,
+      691,
+      692,
+      693,
+      694,
+      695,
+      696,
+      697,
+      698,
+      699,
+      700,
+      701,
+      702,
+      703,
+      704,
+      705,
+      706,
+      707,
+      708,
+      711,
+      712,
+      716,
+      717,
+      719,
+      720,
+      722,
+      723
+    ],
+    "builds": [
+      "26.6.203",
+      "26.6.204"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.6.203",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.203",
+        "channel": "production"
+      },
+      {
+        "version": "26.6.204",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.204",
+        "channel": "production"
+      }
+    ]
+  },
+  {
+    "version": "26.6.103-dev",
+    "tagName": "v26.6.103-dev",
     "channel": "dev",
-    "date": "2026-06-01T05:20:23Z",
+    "date": "2026-06-02T01:28:17Z",
+    "deck": "Facebook sync now requires real feed evidence before treating a page as scrapeable, so tall logged-out Facebook shells fail fast instead of looking like empty feeds.",
+    "features": [],
+    "fixes": [
+      {
+        "text": "Facebook page checks now require a live cookie, the Feed posts heading, or rendered feed units before marking a page feed-like"
+      },
+      {
+        "text": "Logged-out Facebook pages with generic main content and tall layout now fail closed instead of wasting scrape passes"
+      },
+      {
+        "text": "Facebook extraction diagnostics now include feed unit and login chrome evidence for faster follow-up debugging"
+      },
+      {
+        "text": "Facebook sync now reports unauthenticated or stalled feed pages as real sync failures instead of a successful zero-post pull"
+      },
+      {
+        "text": "Social source status now requires live auth state before showing a connected badge, so old items do not mask a lost provider session"
+      },
+      {
+        "text": "Google Drive sync now retries token-refresh download failures and exposes clearer sync diagnostics before falling back to an empty cursor"
+      },
+      {
+        "text": "Google Contacts token refresh failures now stay recoverable in Settings instead of opening the fatal recovery screen"
+      }
+    ],
+    "followUps": [],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.103-dev",
+    "prNumbers": [],
+    "builds": [
+      "26.6.100-dev",
+      "26.6.101-dev",
+      "26.6.102-dev",
+      "26.6.103-dev"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.6.100-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.100-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.6.101-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.101-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.6.102-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.102-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.6.103-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.103-dev",
+        "channel": "dev"
+      }
+    ]
+  },
+  {
+    "version": "26.5.3117-dev",
+    "tagName": "v26.5.3117-dev",
+    "channel": "dev",
+    "date": "2026-06-01T06:11:30Z",
     "deck": "This dev build adds Facebook zero-post diagnostics and keeps RSS retry pacing and installed dev-channel validation ready for the next soak",
     "features": [],
     "fixes": [
@@ -55,7 +265,7 @@
         "text": "Install this build and verify RSS failures stop piling up in sync health"
       }
     ],
-    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.5.3116-dev",
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.5.3117-dev",
     "prNumbers": [],
     "builds": [
       "26.5.3105-dev",
@@ -65,7 +275,8 @@
       "26.5.3112-dev",
       "26.5.3114-dev",
       "26.5.3115-dev",
-      "26.5.3116-dev"
+      "26.5.3116-dev",
+      "26.5.3117-dev"
     ],
     "buildLinks": [
       {
@@ -106,6 +317,11 @@
       {
         "version": "26.5.3116-dev",
         "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.5.3116-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.5.3117-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.5.3117-dev",
         "channel": "dev"
       }
     ]


### PR DESCRIPTION
(AI Generated).

## Summary
- Add the reviewed v26.6.204 release notes to the website production branch.
- Regenerate the static changelog and public feeds so freed.wtf can show the new release.

## Testing
- PATH=/Users/aubreyfalconer/dev/freed-www-release-26-6-204/node_modules/.bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/usr/local/MacGPG2/bin:/Applications/VMware Fusion.app/Contents/Public:/usr/local/share/dotnet:~/.dotnet/tools:/usr/local/go/bin:/Library/Frameworks/Mono.framework/Versions/Current/Commands:/Users/aubreyfalconer/.nvm/versions/node/v24.14.1/bin:/Users/aubreyfalconer/.codex/tmp/arg0/codex-arg0jhObyX:/Users/aubreyfalconer/.local/bin:/opt/homebrew/opt/mysql-client/bin:/opt/homebrew/bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/Users/aubreyfalconer/.cargo/bin:/Users/aubreyfalconer/go/bin:/Users/aubreyfalconer/.cache/lm-studio/bin:/Users/aubreyfalconer/.safe-chain/bin:/Applications/Codex.app/Contents/Resources:/usr/local/bin npm run build in website