### PR TITLE
fix: remove unused sync test callback

### DIFF
--- a/packages/pwa/src/lib/cloud-sync-auth-refresh.test.ts
+++ b/packages/pwa/src/lib/cloud-sync-auth-refresh.test.ts
@@ -152,7 +152,7 @@ describe("PWA cloud sync auth refresh", () => {
 
   it("uploads after local document changes while connected by Google Drive only", async () => {
     vi.useFakeTimers();
-    subscribeMock.mockImplementation((_callback: () => void) => {
+    subscribeMock.mockImplementation(() => {
       return vi.fn();
     });
     gdriveDownloadLatestMock.mockResolvedValue(null);


### PR DESCRIPTION
(AI Generated).

Fixes the validation failure by removing an unused test callback parameter in the PWA cloud sync auth refresh test.

Validation: npm run lint from packages/pwa.