### PR TITLE
chore: promote dev into main for production release

### DIFF
--- a/packages/pwa/src/lib/cloud-sync-auth-refresh.test.ts
+++ b/packages/pwa/src/lib/cloud-sync-auth-refresh.test.ts
@@ -152,7 +152,7 @@ describe("PWA cloud sync auth refresh", () => {
 
   it("uploads after local document changes while connected by Google Drive only", async () => {
     vi.useFakeTimers();
-    subscribeMock.mockImplementation((_callback: () => void) => {
+    subscribeMock.mockImplementation(() => {
       return vi.fn();
     });
     gdriveDownloadLatestMock.mockResolvedValue(null);


### PR DESCRIPTION
(AI Generated).

Promotes the latest dev validation fix into main so the production release can be retried after the failed v26.6.300 validation run.

Validation: validate-release-promotion and validate-main-pr passed locally.