### PR TITLE
chore: add v26.6.301 release notes to www

### DIFF
--- a/release-notes/daily/production/26.6.3.json
+++ b/release-notes/daily/production/26.6.3.json
@@ -1,0 +1,18 @@
+{
+  "channel": "production",
+  "dayKey": "26.6.3",
+  "date": "2026-06-03",
+  "preferredDeck": "Stabilize Google Drive sync and large-library feed adds",
+  "editorialGuidance": [
+    "Keep the tone concise, professional, and specific.",
+    "Lead with user-facing outcomes, shipping milestones, trust wins, and installability improvements.",
+    "Demote internal cleanup unless it clearly changes the shipped product."
+  ],
+  "pinnedHighlights": [
+    "Google Drive sync now uploads local changes from Freed Desktop and the PWA instead of only downloading remote data.",
+    "The PWA waits for its Automerge document to initialize before Google Drive sync, manual sync, OAuth callback sync, or relay resume can merge remote data.",
+    "Freed Desktop avoids a fatal Automerge worker timeout when adding RSS feed metadata to a large library."
+  ],
+  "editorialNotes": [],
+  "updatedAt": "2026-06-03T15:25:41.173Z"
+}

--- a/release-notes/releases/v26.6.301.json
+++ b/release-notes/releases/v26.6.301.json
@@ -1,0 +1,44 @@
+{
+  "tag": "v26.6.301",
+  "version": "26.6.301",
+  "channel": "production",
+  "dayKey": "26.6.3",
+  "approved": true,
+  "editorialNotes": [],
+  "generatedAt": "2026-06-03T15:25:41.173Z",
+  "model": "heuristic",
+  "source": {
+    "channel": "production",
+    "previousPublishedTag": "v26.6.204",
+    "previousPublishedDayTag": "v26.6.204",
+    "compareRef": "HEAD",
+    "isLatestOfDay": true,
+    "sameDayTagsIncluded": [
+      "v26.6.301"
+    ],
+    "relatedBuildTags": [
+      "v26.6.301"
+    ],
+    "prNumbers": [
+      730,
+      733
+    ],
+    "commitSubjects": [
+      "chore: promote dev into main for production release (#733)",
+      "docs: approve v26.6.300 release notes",
+      "release: v26.6.300",
+      "chore: promote dev into main for production release (#730)"
+    ]
+  },
+  "release": {
+    "deck": "Stabilize Google Drive sync and large-library feed adds",
+    "features": [],
+    "fixes": [
+      "Google Drive sync now uploads local changes from Freed Desktop and the PWA instead of only downloading remote data.",
+      "The PWA waits for its Automerge document to initialize before Google Drive sync, manual sync, OAuth callback sync, or relay resume can merge remote data.",
+      "Freed Desktop avoids a fatal Automerge worker timeout when adding RSS feed metadata to a large library."
+    ],
+    "followUps": []
+  },
+  "releaseBody": "(AI Generated).\n\n## Freed v26.6.301\n\nThis production build stabilizes Google Drive sync after the latest desktop and PWA fixes.\n\n### Fixes\n\n- Google Drive sync now uploads local changes from Freed Desktop and the PWA instead of only downloading remote data.\n- The PWA waits for its Automerge document to initialize before Google Drive sync, manual sync, OAuth callback sync, or relay resume can merge remote data.\n- Freed Desktop avoids a fatal Automerge worker timeout when adding RSS feed metadata to a large library.\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+}

--- a/release-notes/releases/v26.6.301.md
+++ b/release-notes/releases/v26.6.301.md
@@ -1,0 +1,19 @@
+(AI Generated).
+
+## Freed v26.6.301
+
+This production build stabilizes Google Drive sync after the latest desktop and PWA fixes.
+
+### Fixes
+
+- Google Drive sync now uploads local changes from Freed Desktop and the PWA instead of only downloading remote data.
+- The PWA waits for its Automerge document to initialize before Google Drive sync, manual sync, OAuth callback sync, or relay resume can merge remote data.
+- Freed Desktop avoids a fatal Automerge worker timeout when adding RSS feed metadata to a large library.
+
+### Downloads
+
+**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  
+**Windows:** `.exe` (NSIS installer)  
+**Linux:** `.AppImage`  
+
+> macOS downloads are signed and notarized for normal Gatekeeper installation.


### PR DESCRIPTION
(AI Generated).

Adds the reviewed v26.6.301 production release notes to www so the production release workflow can deploy the website after the GitHub release is published.

Validation: npm run build from website.