### PR TITLE
fix: stabilize social sync scheduling

### DIFF
--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -3436,8 +3436,12 @@ fn macos_process_has_open_file_under_roots(pid: u32, roots: &[PathBuf]) -> bool 
         .any(|path| path_is_under_any_root(Path::new(path), roots))
 }
 
-fn webkit_process_belongs_to_current_launch(webkit_age_seconds: u64, app_age_seconds: u64) -> bool {
+fn webkit_process_started_after_app_start(webkit_age_seconds: u64, app_age_seconds: u64) -> bool {
     webkit_age_seconds <= app_age_seconds.saturating_add(WEBKIT_PROCESS_START_GRACE_SECONDS)
+}
+
+fn webkit_process_started_with_app(webkit_age_seconds: u64, app_age_seconds: u64) -> bool {
+    webkit_age_seconds.abs_diff(app_age_seconds) <= WEBKIT_PROCESS_START_GRACE_SECONDS
 }
 
 fn freed_webkit_process_role(
@@ -3445,13 +3449,16 @@ fn freed_webkit_process_role(
     webkit_age_seconds: u64,
     app_age_seconds: u64,
 ) -> Option<&'static str> {
-    if !webkit_process_belongs_to_current_launch(webkit_age_seconds, app_age_seconds) {
-        return None;
-    }
     if has_open_file_under_roots {
-        Some("freed-webcontent")
-    } else {
+        if webkit_process_started_after_app_start(webkit_age_seconds, app_age_seconds) {
+            Some("freed-webcontent")
+        } else {
+            None
+        }
+    } else if webkit_process_started_with_app(webkit_age_seconds, app_age_seconds) {
         Some("freed-webcontent-age-matched")
+    } else {
+        None
     }
 }
 
@@ -8961,19 +8968,45 @@ mod tests {
     fn webkit_process_filter_excludes_prior_launches() {
         let app_age = 60;
 
-        assert!(webkit_process_belongs_to_current_launch(0, app_age));
-        assert!(webkit_process_belongs_to_current_launch(
+        assert!(webkit_process_started_after_app_start(0, app_age));
+        assert!(webkit_process_started_after_app_start(
             app_age + WEBKIT_PROCESS_START_GRACE_SECONDS,
             app_age
         ));
-        assert!(!webkit_process_belongs_to_current_launch(
+        assert!(!webkit_process_started_after_app_start(
             app_age + WEBKIT_PROCESS_START_GRACE_SECONDS + 1,
             app_age
         ));
+
+        assert!(webkit_process_started_with_app(app_age, app_age));
+        assert!(webkit_process_started_with_app(
+            app_age.saturating_sub(WEBKIT_PROCESS_START_GRACE_SECONDS),
+            app_age
+        ));
+        assert!(!webkit_process_started_with_app(0, app_age));
     }
 
     #[test]
-    fn webkit_process_role_keeps_current_launch_after_root_files_close() {
+    fn webkit_process_role_counts_rooted_current_launches() {
+        let app_age = 60;
+
+        assert_eq!(
+            freed_webkit_process_role(true, app_age, app_age),
+            Some("freed-webcontent")
+        );
+        assert_eq!(freed_webkit_process_role(true, 0, app_age), Some("freed-webcontent"));
+        assert_eq!(
+            freed_webkit_process_role(
+                true,
+                app_age + WEBKIT_PROCESS_START_GRACE_SECONDS + 1,
+                app_age
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn webkit_process_role_keeps_only_app_start_rootless_processes() {
         let app_age = 60;
 
         assert_eq!(
@@ -8981,9 +9014,14 @@ mod tests {
             Some("freed-webcontent-age-matched")
         );
         assert_eq!(
-            freed_webkit_process_role(true, app_age, app_age),
-            Some("freed-webcontent")
+            freed_webkit_process_role(
+                false,
+                app_age.saturating_sub(WEBKIT_PROCESS_START_GRACE_SECONDS),
+                app_age
+            ),
+            Some("freed-webcontent-age-matched")
         );
+        assert_eq!(freed_webkit_process_role(false, 0, app_age), None);
         assert_eq!(
             freed_webkit_process_role(
                 false,

--- a/packages/desktop/src/lib/background-runtime-coordinator.test.ts
+++ b/packages/desktop/src/lib/background-runtime-coordinator.test.ts
@@ -85,6 +85,19 @@ describe("background runtime coordinator", () => {
     ).resolves.toBe("ok");
   });
 
+  it("formats active semantic work without leaking runtime tokens", async () => {
+    const coordinator = await loadCoordinator();
+
+    const message = coordinator.formatBackgroundRuntimeDeferredReason(
+      "active:semantic-classifier:content-signals",
+    );
+
+    expect(message).toBe("Freed is finishing local indexing. Try again in a moment.");
+    expect(message).not.toContain("active:");
+    expect(message).not.toContain("semantic-classifier");
+    expect(message).not.toContain("content-signals");
+  });
+
   it("keeps cloud sync behind active social scrapes", async () => {
     const coordinator = await loadCoordinator();
     coordinator.resetBackgroundRuntimeForTests({ requireRendererHealth: true });

--- a/packages/desktop/src/lib/background-runtime-coordinator.ts
+++ b/packages/desktop/src/lib/background-runtime-coordinator.ts
@@ -92,6 +92,28 @@ function isActiveJobReason(reason: string): boolean {
   return reason.startsWith("active:");
 }
 
+export function formatBackgroundRuntimeDeferredReason(reason: string): string {
+  if (reason.startsWith("active:semantic-classifier:")) {
+    return "Freed is finishing local indexing. Try again in a moment.";
+  }
+  if (reason.startsWith("active:content-signal-backfill:")) {
+    return "Freed is finishing local indexing. Try again in a moment.";
+  }
+  if (reason.startsWith("active:")) {
+    return "Freed is finishing local background work. Try again in a moment.";
+  }
+  if (reason.startsWith("waiting_for_renderer_heartbeat:")) {
+    return "Freed is waiting for the app window to report healthy. Try again in a moment.";
+  }
+  if (reason.startsWith("renderer_safe_mode:") || reason.startsWith("cooldown:")) {
+    return "Freed paused background work while the app recovers. Try again in a moment.";
+  }
+  if (reason === "high_memory_pressure" || reason === "critical_memory_pressure") {
+    return "Freed paused background work because memory is high. Try again after memory settles.";
+  }
+  return "Freed deferred background work. Try again in a moment.";
+}
+
 function activeKindFromReason(reason: string): BackgroundJobKind | null {
   if (!isActiveJobReason(reason)) return null;
   const [, kind] = reason.split(":");

--- a/packages/desktop/src/lib/capture-social-retry.test.ts
+++ b/packages/desktop/src/lib/capture-social-retry.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const state = {
+    feeds: {},
+    items: [],
+    xAuth: { isAuthenticated: false, cookies: null },
+    fbAuth: { isAuthenticated: true },
+    igAuth: { isAuthenticated: false },
+    liAuth: { isAuthenticated: false },
+    setSyncing: vi.fn(),
+    setError: vi.fn(),
+  };
+
+  return {
+    state,
+    addDebugEvent: vi.fn(),
+    captureFbFeed: vi.fn(),
+    captureIgFeed: vi.fn(),
+    captureLiFeed: vi.fn(),
+    captureXTimeline: vi.fn(),
+    docBatchRefreshFeeds: vi.fn(),
+    isProviderPaused: vi.fn(() => false),
+    recordProviderHealthEvent: vi.fn(),
+    withProviderSyncing: vi.fn(
+      async (_provider: string, run: () => Promise<unknown>) => run(),
+    ),
+  };
+});
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+  isTauri: () => true,
+}));
+
+vi.mock("@freed/ui/lib/debug-store", () => ({
+  addDebugEvent: mocks.addDebugEvent,
+}));
+
+vi.mock("./automerge", () => ({
+  docBatchRefreshFeeds: mocks.docBatchRefreshFeeds,
+}));
+
+vi.mock("./fb-capture", () => ({
+  captureFbFeed: mocks.captureFbFeed,
+}));
+
+vi.mock("./instagram-capture", () => ({
+  captureIgFeed: mocks.captureIgFeed,
+}));
+
+vi.mock("./li-capture", () => ({
+  captureLiFeed: mocks.captureLiFeed,
+}));
+
+vi.mock("./x-capture", () => ({
+  captureXTimeline: mocks.captureXTimeline,
+}));
+
+vi.mock("./provider-health", () => ({
+  isProviderPaused: mocks.isProviderPaused,
+  recordProviderHealthEvent: mocks.recordProviderHealthEvent,
+}));
+
+vi.mock("./store", () => ({
+  useAppStore: {
+    getState: () => mocks.state,
+  },
+  withProviderSyncing: mocks.withProviderSyncing,
+}));
+
+describe("scheduled social capture retries", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    mocks.addDebugEvent.mockClear();
+    mocks.captureFbFeed.mockReset();
+    mocks.captureIgFeed.mockReset();
+    mocks.captureLiFeed.mockReset();
+    mocks.captureXTimeline.mockReset();
+    mocks.docBatchRefreshFeeds.mockReset();
+    mocks.isProviderPaused.mockClear();
+    mocks.recordProviderHealthEvent.mockClear();
+    mocks.withProviderSyncing.mockClear();
+    mocks.state.setSyncing.mockClear();
+    mocks.state.setError.mockClear();
+    mocks.state.fbAuth = { isAuthenticated: true };
+    mocks.state.igAuth = { isAuthenticated: false };
+    mocks.state.liAuth = { isAuthenticated: false };
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("retries a Facebook memory deferral before the next scheduled poll", async () => {
+    mocks.captureFbFeed
+      .mockResolvedValueOnce({
+        items: [],
+        diag: {
+          errorStage: "memory_pressure",
+          errorMessage: "Facebook sync did not start because Freed Desktop memory is high.",
+        },
+      })
+      .mockResolvedValueOnce({
+        items: [],
+        diag: {
+          errorStage: null,
+          errorMessage: null,
+        },
+      });
+
+    const { refreshAllFeeds } = await import("./capture");
+    await refreshAllFeeds();
+
+    expect(mocks.captureFbFeed).toHaveBeenCalledTimes(1);
+    expect(mocks.addDebugEvent).toHaveBeenCalledWith(
+      "change",
+      "[FB] retry scheduled in 120s after memory_pressure",
+    );
+
+    await vi.advanceTimersByTimeAsync(119_999);
+    expect(mocks.captureFbFeed).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(mocks.captureFbFeed).toHaveBeenCalledTimes(2);
+    expect(mocks.withProviderSyncing).toHaveBeenLastCalledWith(
+      "facebook",
+      expect.any(Function),
+    );
+  });
+});

--- a/packages/desktop/src/lib/capture.ts
+++ b/packages/desktop/src/lib/capture.ts
@@ -26,6 +26,7 @@ import {
   selectRssFeedsForRefresh,
   type RssRefreshPlanOptions,
 } from "./rss-refresh-plan";
+import { isRuntimeDeferredStage } from "./social-capture-runtime";
 
 /**
  * Fetch URL via Tauri backend (bypasses CORS)
@@ -104,6 +105,21 @@ export async function addRssFeed(feedUrl: string): Promise<void> {
 const FETCH_CONCURRENCY = 5;
 const RSS_FAILURE_RETRY_BASE_MS = 2 * 60 * 60 * 1000;
 const RSS_FAILURE_RETRY_MAX_MS = 24 * 60 * 60 * 1000;
+const SOCIAL_DEFERRED_RETRY_BASE_MS = 2 * 60 * 1000;
+const SOCIAL_DEFERRED_RETRY_MAX_MS = 10 * 60 * 1000;
+
+type RetriableSocialProvider = "facebook" | "instagram" | "linkedin";
+
+const socialDeferredRetryTimers = new Map<
+  RetriableSocialProvider,
+  ReturnType<typeof setTimeout>
+>();
+const socialDeferredRetryCounts = new Map<RetriableSocialProvider, number>();
+const socialDebugLabels: Record<RetriableSocialProvider, string> = {
+  facebook: "FB",
+  instagram: "IG",
+  linkedin: "LI",
+};
 
 function nextFailedFeedRetryMs(feed: RssFeed): number {
   const failureCount = Math.max(0, feed.consecutiveFailures ?? 0);
@@ -132,6 +148,103 @@ function markFeedFetchFailed(feed: RssFeed, message: string, now: number): RssFe
     consecutiveFailures: (feed.consecutiveFailures ?? 0) + 1,
     lastFetchError: message.slice(0, 500),
   };
+}
+
+function shouldRetrySocialStage(stage: string | null): boolean {
+  return stage === "memory_pressure" || isRuntimeDeferredStage(stage);
+}
+
+function nextSocialDeferredRetryMs(provider: RetriableSocialProvider): number {
+  const retryCount = socialDeferredRetryCounts.get(provider) ?? 0;
+  const exponentialMs =
+    SOCIAL_DEFERRED_RETRY_BASE_MS * Math.pow(2, Math.min(retryCount, 3));
+  const jitterMs = Math.floor(Math.random() * 30_000);
+  return Math.min(
+    SOCIAL_DEFERRED_RETRY_MAX_MS,
+    exponentialMs + jitterMs,
+  );
+}
+
+function clearSocialDeferredRetry(provider: RetriableSocialProvider): void {
+  const timer = socialDeferredRetryTimers.get(provider);
+  if (timer) {
+    clearTimeout(timer);
+    socialDeferredRetryTimers.delete(provider);
+  }
+  socialDeferredRetryCounts.delete(provider);
+}
+
+function scheduleSocialDeferredRetry(
+  provider: RetriableSocialProvider,
+  stage: string,
+): void {
+  if (socialDeferredRetryTimers.has(provider)) return;
+  const retryMs = nextSocialDeferredRetryMs(provider);
+  socialDeferredRetryCounts.set(
+    provider,
+    (socialDeferredRetryCounts.get(provider) ?? 0) + 1,
+  );
+  const label = socialDebugLabels[provider];
+  addDebugEvent(
+    "change",
+    `[${label}] retry scheduled in ${Math.round(retryMs / 1000).toLocaleString()}s after ${stage}`,
+  );
+  const timer = setTimeout(() => {
+    socialDeferredRetryTimers.delete(provider);
+    void refreshSocialProvider(provider);
+  }, retryMs);
+  socialDeferredRetryTimers.set(provider, timer);
+}
+
+function handleSocialResult(
+  provider: RetriableSocialProvider,
+  stage: string | null,
+): void {
+  if (shouldRetrySocialStage(stage)) {
+    scheduleSocialDeferredRetry(provider, stage ?? "deferred");
+  } else {
+    clearSocialDeferredRetry(provider);
+  }
+}
+
+async function refreshSocialProvider(
+  provider: RetriableSocialProvider,
+): Promise<void> {
+  if (!isTauri() || isProviderPaused(provider)) {
+    clearSocialDeferredRetry(provider);
+    return;
+  }
+
+  const store = useAppStore.getState();
+  try {
+    if (provider === "facebook" && store.fbAuth.isAuthenticated) {
+      const result = await withProviderSyncing("facebook", () => captureFbFeed());
+      handleSocialResult("facebook", result.diag.errorStage);
+      return;
+    }
+    if (provider === "instagram" && store.igAuth.isAuthenticated) {
+      const result = await withProviderSyncing("instagram", () => captureIgFeed());
+      handleSocialResult("instagram", result.diag.errorStage);
+      return;
+    }
+    if (provider === "linkedin" && store.liAuth.isAuthenticated) {
+      const result = await withProviderSyncing("linkedin", () => captureLiFeed());
+      handleSocialResult("linkedin", result.diag.errorStage);
+      return;
+    }
+    clearSocialDeferredRetry(provider);
+  } catch (error) {
+    const msg =
+      error instanceof Error
+        ? error.message
+        : `${provider} feed sync failed`;
+    console.error(`[Refresh] ${provider} feed failed:`, error);
+    addDebugEvent("error", `[${socialDebugLabels[provider]}] feed sync threw: ${msg}`);
+    if (!useAppStore.getState().error) {
+      store.setError(msg);
+    }
+    clearSocialDeferredRetry(provider);
+  }
 }
 
 async function refreshEnabledRssFeeds(
@@ -317,7 +430,9 @@ export async function refreshRssFeeds(
 /**
  * Refresh all subscribed RSS feeds and authenticated social providers.
  */
-export async function refreshAllFeeds(): Promise<void> {
+export async function refreshAllFeeds(
+  options: RssRefreshPlanOptions = {},
+): Promise<void> {
   if (!isTauri()) {
     addDebugEvent(
       "change",
@@ -326,7 +441,8 @@ export async function refreshAllFeeds(): Promise<void> {
     return;
   }
   const store = useAppStore.getState();
-  const feeds = Object.values(store.feeds).filter((f) => f.enabled);
+  const enabledFeeds = Object.values(store.feeds).filter((f) => f.enabled);
+  const feeds = selectRssFeedsForRefresh(enabledFeeds, options);
   const tauriAvailable = isTauri();
   const hasNativeSocialRefresh =
     tauriAvailable &&
@@ -366,74 +482,9 @@ export async function refreshAllFeeds(): Promise<void> {
       }
     }
 
-    // ── Facebook feed ─────────────────────────────────────────────────────────
-    // Independent of both RSS and X outcomes.
-    const { fbAuth } = useAppStore.getState();
-    if (
-      tauriAvailable &&
-      fbAuth.isAuthenticated &&
-      !isProviderPaused("facebook")
-    ) {
-      try {
-        await withProviderSyncing("facebook", () => captureFbFeed());
-      } catch (fbError) {
-        const msg =
-          fbError instanceof Error
-            ? fbError.message
-            : "Facebook feed sync failed";
-        console.error("[Refresh] Facebook feed failed:", fbError);
-        addDebugEvent("error", `[FB] feed sync threw: ${msg}`);
-        if (!useAppStore.getState().error) {
-          store.setError(msg);
-        }
-      }
-    }
-
-    // ── Instagram feed ───────────────────────────────────────────────────────
-    // Independent of RSS, X, and Facebook outcomes.
-    const { igAuth } = useAppStore.getState();
-    if (
-      tauriAvailable &&
-      igAuth.isAuthenticated &&
-      !isProviderPaused("instagram")
-    ) {
-      try {
-        await withProviderSyncing("instagram", () => captureIgFeed());
-      } catch (igError) {
-        const msg =
-          igError instanceof Error
-            ? igError.message
-            : "Instagram feed sync failed";
-        console.error("[Refresh] Instagram feed failed:", igError);
-        addDebugEvent("error", `[IG] feed sync threw: ${msg}`);
-        if (!useAppStore.getState().error) {
-          store.setError(msg);
-        }
-      }
-    }
-
-    // ── LinkedIn feed ─────────────────────────────────────────────────────────
-    // Independent of RSS, X, Facebook, and Instagram outcomes.
-    const { liAuth } = useAppStore.getState();
-    if (
-      tauriAvailable &&
-      liAuth.isAuthenticated &&
-      !isProviderPaused("linkedin")
-    ) {
-      try {
-        await withProviderSyncing("linkedin", () => captureLiFeed());
-      } catch (liError) {
-        const msg =
-          liError instanceof Error
-            ? liError.message
-            : "LinkedIn feed sync failed";
-        console.error("[Refresh] LinkedIn feed failed:", liError);
-        addDebugEvent("error", `[LI] feed sync threw: ${msg}`);
-        if (!useAppStore.getState().error) {
-          store.setError(msg);
-        }
-      }
-    }
+    await refreshSocialProvider("facebook");
+    await refreshSocialProvider("instagram");
+    await refreshSocialProvider("linkedin");
   } finally {
     store.setSyncing(false);
   }

--- a/packages/desktop/src/lib/fb-capture.ts
+++ b/packages/desktop/src/lib/fb-capture.ts
@@ -34,6 +34,7 @@ import { runBackgroundJob } from "./background-runtime-coordinator";
 import {
   applyRuntimeDeferredDiag,
   applyLockedSessionDeferredDiag,
+  applyNativeMemoryPressureDiag,
   isRuntimeDeferredStage,
   SOCIAL_SCRAPE_WAIT_FOR_JOB_KINDS,
   SOCIAL_SCRAPE_WAIT_FOR_LOCAL_WORK_MS,
@@ -506,6 +507,9 @@ export async function fetchFbFeed(): Promise<FbSyncResult> {
   } catch (err) {
     if (!diag.errorStage) {
       if (applyRuntimeDeferredDiag(diag, err)) {
+        return { items: [], diag };
+      }
+      if (applyNativeMemoryPressureDiag(diag, err, "facebook")) {
         return { items: [], diag };
       }
       diag.errorStage = "invoke";

--- a/packages/desktop/src/lib/instagram-capture.ts
+++ b/packages/desktop/src/lib/instagram-capture.ts
@@ -32,6 +32,7 @@ import { runBackgroundJob } from "./background-runtime-coordinator";
 import {
   applyRuntimeDeferredDiag,
   applyLockedSessionDeferredDiag,
+  applyNativeMemoryPressureDiag,
   isRuntimeDeferredStage,
   SOCIAL_SCRAPE_WAIT_FOR_JOB_KINDS,
   SOCIAL_SCRAPE_WAIT_FOR_LOCAL_WORK_MS,
@@ -163,6 +164,9 @@ export async function fetchIgFeed(): Promise<IgSyncResult> {
     await new Promise<void>((r) => setTimeout(r, 500));
   } catch (err) {
     if (applyRuntimeDeferredDiag(diag, err)) {
+      return { items: [], diag };
+    }
+    if (applyNativeMemoryPressureDiag(diag, err, "instagram")) {
       return { items: [], diag };
     }
     diag.errorStage = "invoke";

--- a/packages/desktop/src/lib/li-capture.ts
+++ b/packages/desktop/src/lib/li-capture.ts
@@ -25,6 +25,7 @@ import { formatBytesForMemoryLog, prepareSocialScrapeMemory } from "./memory-mon
 import { socialProviderCopy } from "./social-provider-copy";
 import {
   applyLockedSessionDeferredDiag,
+  applyNativeMemoryPressureDiag,
   isRuntimeDeferredStage,
 } from "./social-capture-runtime";
 
@@ -167,6 +168,9 @@ export async function fetchLiFeed(): Promise<LiSyncResult> {
     await new Promise<void>((resolve) => setTimeout(resolve, 500));
   } catch (err) {
     if (!diag.errorStage) {
+      if (applyNativeMemoryPressureDiag(diag, err, "linkedin")) {
+        return { items: [], diag };
+      }
       diag.errorStage = "invoke";
       diag.errorMessage = err instanceof Error ? err.message : String(err);
     }

--- a/packages/desktop/src/lib/outbox.ts
+++ b/packages/desktop/src/lib/outbox.ts
@@ -26,6 +26,7 @@ import type { DocChangeEvent } from "./automerge-types";
 import { addDebugEvent } from "@freed/ui/lib/debug-store";
 import { scheduleSideEffect } from "./side-effect-scheduler";
 import {
+  formatBackgroundRuntimeDeferredReason,
   isBackgroundRuntimeDeferredError,
   runBackgroundJob,
 } from "./background-runtime-coordinator";
@@ -279,7 +280,7 @@ export function startOutboxProcessor(
       drainTimer = null;
       drain().catch((err) => {
         if (isBackgroundRuntimeDeferredError(err)) {
-          addDebugEvent("change", `[Outbox] drain deferred: ${err.reason}`);
+          addDebugEvent("change", `[Outbox] drain deferred: ${formatBackgroundRuntimeDeferredReason(err.reason)}`);
           isDraining = false;
           scheduleDrain();
           return;
@@ -296,7 +297,7 @@ export function startOutboxProcessor(
   // Run an immediate drain on startup (catch anything queued while offline)
   drain().catch((err) => {
     if (isBackgroundRuntimeDeferredError(err)) {
-      addDebugEvent("change", `[Outbox] startup drain deferred: ${err.reason}`);
+      addDebugEvent("change", `[Outbox] startup drain deferred: ${formatBackgroundRuntimeDeferredReason(err.reason)}`);
       isDraining = false;
       scheduleDrain();
       return;

--- a/packages/desktop/src/lib/rss-poller.test.ts
+++ b/packages/desktop/src/lib/rss-poller.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const refreshRssFeeds = vi.fn();
+const refreshAllFeeds = vi.fn();
 const addDebugEvent = vi.fn();
 const runBackgroundJob = vi.fn();
 const isBackgroundRuntimeDeferredError = vi.fn(
@@ -9,7 +9,7 @@ const isBackgroundRuntimeDeferredError = vi.fn(
 );
 
 vi.mock("./capture", () => ({
-  refreshRssFeeds,
+  refreshAllFeeds,
 }));
 
 vi.mock("@freed/ui/lib/debug-store", () => ({
@@ -19,6 +19,18 @@ vi.mock("@freed/ui/lib/debug-store", () => ({
 vi.mock("./background-runtime-coordinator", () => ({
   runBackgroundJob,
   isBackgroundRuntimeDeferredError,
+  formatBackgroundRuntimeDeferredReason: (reason: string) => {
+    if (reason.startsWith("waiting_for_renderer_heartbeat:")) {
+      return "Freed is waiting for the app window to report healthy. Try again in a moment.";
+    }
+    if (reason.startsWith("cooldown:")) {
+      return "Freed paused background work while the app recovers. Try again in a moment.";
+    }
+    if (reason === "high_memory_pressure") {
+      return "Freed paused background work because memory is high. Try again after memory settles.";
+    }
+    return "Freed deferred background work. Try again in a moment.";
+  },
 }));
 
 async function loadPoller() {
@@ -29,7 +41,7 @@ async function loadPoller() {
 describe("rss poller", () => {
   beforeEach(() => {
     vi.useFakeTimers();
-    refreshRssFeeds.mockReset();
+    refreshAllFeeds.mockReset();
     addDebugEvent.mockReset();
     runBackgroundJob.mockReset();
     isBackgroundRuntimeDeferredError.mockClear();
@@ -50,7 +62,7 @@ describe("rss poller", () => {
     expect(runBackgroundJob).not.toHaveBeenCalled();
     expect(addDebugEvent).toHaveBeenCalledWith(
       "change",
-      "[RSS] startup poll scheduled in 300s",
+      "[Sync] startup refresh scheduled in 300s",
     );
 
     await vi.advanceTimersByTimeAsync(5 * 60 * 1000 - 1);
@@ -93,7 +105,7 @@ describe("rss poller", () => {
     );
     const task = runBackgroundJob.mock.calls[0]?.[0];
     await task.run();
-    expect(refreshRssFeeds).toHaveBeenCalledWith({
+    expect(refreshAllFeeds).toHaveBeenCalledWith({
       maxFeeds: 80,
       staleAfterMs: 2 * 60 * 60 * 1000,
     });
@@ -105,11 +117,11 @@ describe("rss poller", () => {
     expect(runBackgroundJob).toHaveBeenCalledTimes(2);
     expect(addDebugEvent).toHaveBeenCalledWith(
       "change",
-      "[RSS] poll deferred: waiting_for_renderer_heartbeat:1",
+      "[Sync] poll deferred: Freed is waiting for the app window to report healthy. Try again in a moment.",
     );
     expect(addDebugEvent).toHaveBeenCalledWith(
       "change",
-      "[RSS] poll retry scheduled in 60s after waiting_for_renderer_heartbeat:1",
+      "[Sync] poll retry scheduled in 60s. Freed is waiting for the app window to report healthy. Try again in a moment.",
     );
 
     poller.stopRssPoller();
@@ -144,7 +156,7 @@ describe("rss poller", () => {
     expect(runBackgroundJob).toHaveBeenCalledTimes(2);
     expect(addDebugEvent).toHaveBeenCalledWith(
       "change",
-      "[RSS] poll retry scheduled in 120s after cooldown:120,000",
+      "[Sync] poll retry scheduled in 120s. Freed paused background work while the app recovers. Try again in a moment.",
     );
 
     poller.stopRssPoller();
@@ -169,11 +181,11 @@ describe("rss poller", () => {
     expect(runBackgroundJob).toHaveBeenCalledTimes(3);
     expect(addDebugEvent).toHaveBeenCalledWith(
       "change",
-      "[RSS] poll retry scheduled in 60s after high_memory_pressure",
+      "[Sync] poll retry scheduled in 60s. Freed paused background work because memory is high. Try again after memory settles.",
     );
     expect(addDebugEvent).toHaveBeenCalledWith(
       "change",
-      "[RSS] poll retry scheduled in 120s after high_memory_pressure",
+      "[Sync] poll retry scheduled in 120s. Freed paused background work because memory is high. Try again after memory settles.",
     );
 
     poller.stopRssPoller();

--- a/packages/desktop/src/lib/rss-poller.ts
+++ b/packages/desktop/src/lib/rss-poller.ts
@@ -1,13 +1,14 @@
 /**
- * Background RSS polling service
+ * Background sync polling service
  *
- * Automatically refreshes all subscribed feeds on a regular interval.
+ * Automatically refreshes subscribed feeds and connected social providers.
  * Runs in the JavaScript layer so it works regardless of Tauri's background state.
  */
 
-import { refreshRssFeeds } from "./capture";
+import { refreshAllFeeds } from "./capture";
 import { addDebugEvent } from "@freed/ui/lib/debug-store";
 import {
+  formatBackgroundRuntimeDeferredReason,
   isBackgroundRuntimeDeferredError,
   runBackgroundJob,
 } from "./background-runtime-coordinator";
@@ -73,9 +74,10 @@ function scheduleDeferredRetry(reason: string): void {
   if (retryTimeoutId !== null) return;
   const retryMs = nextDeferredRetryMs(reason);
   deferredRetryCount += 1;
+  const displayReason = formatBackgroundRuntimeDeferredReason(reason);
   addDebugEvent(
     "change",
-    `[RSS] poll retry scheduled in ${Math.round(retryMs / 1000).toLocaleString()}s after ${reason}`,
+    `[Sync] poll retry scheduled in ${Math.round(retryMs / 1000).toLocaleString()}s. ${displayReason}`,
   );
   retryTimeoutId = setTimeout(() => {
     retryTimeoutId = null;
@@ -104,7 +106,7 @@ export function startRssPoller(
     }, startupDelayMs);
     addDebugEvent(
       "change",
-      `[RSS] startup poll scheduled in ${Math.round(startupDelayMs / 1000).toLocaleString()}s`,
+      `[Sync] startup refresh scheduled in ${Math.round(startupDelayMs / 1000).toLocaleString()}s`,
     );
   } else {
     void triggerPoll();
@@ -112,7 +114,7 @@ export function startRssPoller(
 
   pollIntervalId = setInterval(triggerPoll, intervalMs);
   console.log(
-    `[RssPoller] Started, polling every ${(intervalMs / 60000).toLocaleString()} minutes`,
+    `[SyncPoller] Started, polling every ${(intervalMs / 60000).toLocaleString()} minutes`,
   );
 }
 
@@ -125,7 +127,7 @@ export function stopRssPoller(): void {
   if (pollIntervalId !== null) {
     clearInterval(pollIntervalId);
     pollIntervalId = null;
-    console.log("[RssPoller] Stopped");
+    console.log("[SyncPoller] Stopped");
   }
 }
 
@@ -141,19 +143,19 @@ async function triggerPoll(): Promise<void> {
       kind: "rss-poll",
       source: "rss-poller",
       timeoutMs: 180_000,
-      run: () => refreshRssFeeds(SCHEDULED_REFRESH_OPTIONS),
+      run: () => refreshAllFeeds(SCHEDULED_REFRESH_OPTIONS),
     });
     clearDeferredRetry();
   } catch (err) {
     if (isBackgroundRuntimeDeferredError(err)) {
-      addDebugEvent("change", `[RSS] poll deferred: ${err.reason}`);
+      addDebugEvent("change", `[Sync] poll deferred: ${formatBackgroundRuntimeDeferredReason(err.reason)}`);
       scheduleDeferredRetry(err.reason);
       return;
     }
     clearDeferredRetry();
     const msg = err instanceof Error ? err.message : String(err);
-    console.error("[RssPoller] Error during poll:", err);
-    addDebugEvent("error", `[RSS] poller crashed: ${msg}`);
+    console.error("[SyncPoller] Error during poll:", err);
+    addDebugEvent("error", `[Sync] poller crashed: ${msg}`);
   } finally {
     isPolling = false;
   }

--- a/packages/desktop/src/lib/social-capture-memory-pressure.test.ts
+++ b/packages/desktop/src/lib/social-capture-memory-pressure.test.ts
@@ -758,6 +758,16 @@ describe("social capture completion", () => {
 });
 
 describe("social capture memory pressure gate", () => {
+  function allowRendererMemoryPreflight(): void {
+    mocks.prepareSocialScrapeMemory.mockResolvedValue({
+      before: {},
+      after: { appResidentBytes: 512 * 1024 * 1024 },
+      recycledScraperWindows: false,
+      cacheTrimmed: false,
+      mayProceed: true,
+    });
+  }
+
   it("returns Facebook memory diagnostics before invoking the native scraper", async () => {
     const { fetchFbFeed } = await import("./fb-capture");
     const result = await fetchFbFeed();
@@ -785,6 +795,46 @@ describe("social capture memory pressure gate", () => {
     expect(mocks.invoke).not.toHaveBeenCalledWith("ig_scrape_feed", expect.anything());
   });
 
+  it("classifies native Instagram memory rejections after renderer preflight", async () => {
+    allowRendererMemoryPreflight();
+    mocks.listen.mockResolvedValue(vi.fn());
+    mocks.invoke.mockImplementation(async (command: string) => {
+      if (command === "ig_scrape_feed") {
+        throw new Error(
+          "Instagram sync paused because Freed Desktop memory remains high after cleanup.",
+        );
+      }
+      return null;
+    });
+
+    const { fetchIgFeed } = await import("./instagram-capture");
+    const result = await fetchIgFeed();
+
+    expect(result.diag.errorStage).toBe("memory_pressure");
+    expect(result.diag.errorMessage).toContain("Instagram sync did not start");
+    expect(mocks.invoke).toHaveBeenCalledWith("ig_scrape_feed", expect.anything());
+  });
+
+  it("classifies native Facebook memory rejections after renderer preflight", async () => {
+    allowRendererMemoryPreflight();
+    mocks.listen.mockResolvedValue(vi.fn());
+    mocks.invoke.mockImplementation(async (command: string) => {
+      if (command === "fb_scrape_feed") {
+        throw new Error(
+          "Facebook sync paused because Freed Desktop memory remains high after cleanup.",
+        );
+      }
+      return null;
+    });
+
+    const { fetchFbFeed } = await import("./fb-capture");
+    const result = await fetchFbFeed();
+
+    expect(result.diag.errorStage).toBe("memory_pressure");
+    expect(result.diag.errorMessage).toContain("Facebook sync did not start");
+    expect(mocks.invoke).toHaveBeenCalledWith("fb_scrape_feed", expect.anything());
+  });
+
   it("returns LinkedIn memory diagnostics before invoking the native scraper", async () => {
     const { fetchLiFeed } = await import("./li-capture");
     const result = await fetchLiFeed();
@@ -792,5 +842,25 @@ describe("social capture memory pressure gate", () => {
     expect(result.diag.errorStage).toBe("memory_pressure");
     expect(mocks.prepareSocialScrapeMemory).toHaveBeenCalledWith("linkedin", "feed scrape");
     expect(mocks.invoke).not.toHaveBeenCalledWith("li_scrape_feed", expect.anything());
+  });
+
+  it("classifies native LinkedIn memory rejections after renderer preflight", async () => {
+    allowRendererMemoryPreflight();
+    mocks.listen.mockResolvedValue(vi.fn());
+    mocks.invoke.mockImplementation(async (command: string) => {
+      if (command === "li_scrape_feed") {
+        throw new Error(
+          "LinkedIn sync paused because Freed Desktop memory remains high after cleanup.",
+        );
+      }
+      return null;
+    });
+
+    const { fetchLiFeed } = await import("./li-capture");
+    const result = await fetchLiFeed();
+
+    expect(result.diag.errorStage).toBe("memory_pressure");
+    expect(result.diag.errorMessage).toContain("LinkedIn sync did not start");
+    expect(mocks.invoke).toHaveBeenCalledWith("li_scrape_feed", expect.anything());
   });
 });

--- a/packages/desktop/src/lib/social-capture-runtime.ts
+++ b/packages/desktop/src/lib/social-capture-runtime.ts
@@ -1,6 +1,10 @@
 import { invoke, isTauri } from "@tauri-apps/api/core";
 import type { BackgroundJobKind } from "./background-runtime-coordinator";
-import { isBackgroundRuntimeDeferredError } from "./background-runtime-coordinator";
+import {
+  formatBackgroundRuntimeDeferredReason,
+  isBackgroundRuntimeDeferredError,
+} from "./background-runtime-coordinator";
+import { socialProviderCopy, type SocialProviderId } from "./social-provider-copy";
 
 export const SOCIAL_SCRAPE_WAIT_FOR_LOCAL_WORK_MS = 150_000;
 export const SOCIAL_SCRAPE_WAIT_FOR_JOB_KINDS = [
@@ -14,6 +18,7 @@ export const SOCIAL_SCRAPE_WAIT_FOR_JOB_KINDS = [
 ] satisfies BackgroundJobKind[];
 
 export const RUNTIME_DEFERRED_STAGE = "runtime_deferred";
+export const NATIVE_MEMORY_PRESSURE_STAGE = "memory_pressure";
 
 export interface RuntimeDeferredDiag {
   errorStage: string | null;
@@ -27,25 +32,7 @@ interface DesktopSessionState {
 }
 
 export function runtimeDeferredMessage(reason: string): string {
-  if (reason.startsWith("active:semantic-classifier:")) {
-    return "Freed is finishing local semantic indexing. Try syncing again in a moment.";
-  }
-  if (reason.startsWith("active:content-signal-backfill:")) {
-    return "Freed is finishing local content-signal indexing. Try syncing again in a moment.";
-  }
-  if (reason.startsWith("active:")) {
-    return "Freed is finishing local background work. Try syncing again in a moment.";
-  }
-  if (reason.startsWith("waiting_for_renderer_heartbeat:")) {
-    return "Freed is waiting for the app window to report healthy. Try syncing again in a moment.";
-  }
-  if (reason.startsWith("renderer_safe_mode:") || reason.startsWith("cooldown:")) {
-    return "Freed paused background work while the app recovers. Try syncing again in a moment.";
-  }
-  if (reason === "high_memory_pressure" || reason === "critical_memory_pressure") {
-    return "Freed paused provider sync because memory is high. Try syncing again after memory settles.";
-  }
-  return "Freed deferred provider sync for local background work. Try syncing again in a moment.";
+  return formatBackgroundRuntimeDeferredReason(reason).replaceAll("Try again", "Try syncing again");
 }
 
 export function applyRuntimeDeferredDiag(
@@ -55,6 +42,29 @@ export function applyRuntimeDeferredDiag(
   if (!isBackgroundRuntimeDeferredError(error)) return false;
   diag.errorStage = RUNTIME_DEFERRED_STAGE;
   diag.errorMessage = runtimeDeferredMessage(error.reason);
+  return true;
+}
+
+function nativeErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function isNativeSocialMemoryPressureError(error: unknown): boolean {
+  const message = nativeErrorMessage(error).toLocaleLowerCase();
+  return (
+    message.includes("sync paused because freed desktop memory remains high after cleanup") ||
+    message.includes("memory remains high after cleanup")
+  );
+}
+
+export function applyNativeMemoryPressureDiag(
+  diag: RuntimeDeferredDiag,
+  error: unknown,
+  provider: SocialProviderId,
+): boolean {
+  if (!isNativeSocialMemoryPressureError(error)) return false;
+  diag.errorStage = NATIVE_MEMORY_PRESSURE_STAGE;
+  diag.errorMessage = `${socialProviderCopy(provider).memoryPressure} Try syncing again in a moment.`;
   return true;
 }
 

--- a/packages/desktop/src/lib/sync.ts
+++ b/packages/desktop/src/lib/sync.ts
@@ -32,6 +32,7 @@ import { log } from "./logger.js";
 import { recordProviderHealthEvent } from "./provider-health";
 import { scheduleSideEffect } from "./side-effect-scheduler";
 import {
+  formatBackgroundRuntimeDeferredReason,
   isBackgroundRuntimeDeferredError,
   runBackgroundJob,
   type BackgroundJobKind,
@@ -1061,9 +1062,10 @@ function scheduleInitialCloudDownloadRetry(
     INITIAL_DOWNLOAD_DEFER_BACKOFF_BASE_MS,
     INITIAL_DOWNLOAD_DEFER_BACKOFF_MAX_MS,
   );
+  const displayReason = formatBackgroundRuntimeDeferredReason(reason);
   addDebugEvent(
     "change",
-    `[Cloud/${provider}] initial download deferred: ${reason}; retry_ms=${delayMs.toLocaleString()}`,
+    `[Cloud/${provider}] initial download deferred: ${displayReason} Retry in ${delayMs.toLocaleString()} ms.`,
   );
   const existing = initialDownloadTimers.get(provider);
   if (existing) clearTimeout(existing);
@@ -1419,21 +1421,22 @@ export function scheduleCloudUpload(provider: CloudProvider, token?: string): vo
         }).catch((error) => {
           if (isBackgroundRuntimeDeferredError(error)) {
             const delayMs = nextUploadRetryMs(provider, error.reason);
+            const displayReason = formatBackgroundRuntimeDeferredReason(error.reason);
             addDebugEvent(
               "change",
-              `[Cloud/${provider}] upload deferred: ${error.reason}; retry_ms=${delayMs.toLocaleString()}`,
+              `[Cloud/${provider}] upload deferred: ${displayReason} Retry in ${delayMs.toLocaleString()} ms.`,
             );
             updateCloudProvider(provider, {
               status: "connected",
               stage: "idle",
               statusMessage: "Upload deferred.",
-              pendingReason: `${error.reason}. Retrying in ${delayMs.toLocaleString()} ms.`,
+              pendingReason: `${displayReason} Retrying in ${delayMs.toLocaleString()} ms.`,
             });
             recordCloudStep(
               provider,
               "deferred",
               "upload",
-              `Upload deferred: ${error.reason}. Retrying in ${delayMs.toLocaleString()} ms.`,
+              `Upload deferred: ${displayReason} Retrying in ${delayMs.toLocaleString()} ms.`,
             );
             const retryTimer = setTimeout(() => {
               uploadTimers.delete(provider);
@@ -1495,13 +1498,14 @@ export async function syncCloudProviderNow(provider: CloudProvider): Promise<voi
     });
   } catch (error) {
     if (isBackgroundRuntimeDeferredError(error)) {
+      const displayReason = formatBackgroundRuntimeDeferredReason(error.reason);
       updateCloudProvider(provider, {
         status: "connected",
         stage: "idle",
         statusMessage: "Manual sync deferred.",
-        pendingReason: error.reason,
+        pendingReason: displayReason,
       });
-      recordCloudStep(provider, "deferred", "idle", `Manual sync deferred: ${error.reason}.`);
+      recordCloudStep(provider, "deferred", "idle", `Manual sync deferred: ${displayReason}`);
     }
     throw error;
   }


### PR DESCRIPTION
(AI Generated).

## Summary
- Run scheduled background sync through the full provider refresh path so connected social channels are polled with RSS.
- Retry Facebook, Instagram, and LinkedIn memory deferrals after a short cooldown without treating them as broken auth.
- Tighten native WebKit memory ownership and replace internal runtime reason tokens with human copy.

## Testing
- npm run validate:feature
- PATH=/Users/aubreyfalconer/dev/freed-social-sync-reliability/node_modules/.bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/usr/local/MacGPG2/bin:/Applications/VMware Fusion.app/Contents/Public:/usr/local/share/dotnet:~/.dotnet/tools:/usr/local/go/bin:/Library/Frameworks/Mono.framework/Versions/Current/Commands:/Users/aubreyfalconer/.nvm/versions/node/v24.14.1/bin:/Users/aubreyfalconer/.codex/tmp/arg0/codex-arg0jhObyX:/Users/aubreyfalconer/.local/bin:/opt/homebrew/opt/mysql-client/bin:/opt/homebrew/bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/Users/aubreyfalconer/.cargo/bin:/Users/aubreyfalconer/go/bin:/Users/aubreyfalconer/.cache/lm-studio/bin:/Users/aubreyfalconer/.safe-chain/bin:/Applications/Codex.app/Contents/Resources:/usr/local/bin npm run test:unit -- capture-social-retry.test.ts rss-poller.test.ts
- PATH=/Users/aubreyfalconer/dev/freed-social-sync-reliability/node_modules/.bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/usr/local/MacGPG2/bin:/Applications/VMware Fusion.app/Contents/Public:/usr/local/share/dotnet:~/.dotnet/tools:/usr/local/go/bin:/Library/Frameworks/Mono.framework/Versions/Current/Commands:/Users/aubreyfalconer/.nvm/versions/node/v24.14.1/bin:/Users/aubreyfalconer/.codex/tmp/arg0/codex-arg0jhObyX:/Users/aubreyfalconer/.local/bin:/opt/homebrew/opt/mysql-client/bin:/opt/homebrew/bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/Users/aubreyfalconer/.cargo/bin:/Users/aubreyfalconer/go/bin:/Users/aubreyfalconer/.cache/lm-studio/bin:/Users/aubreyfalconer/.safe-chain/bin:/Applications/Codex.app/Contents/Resources:/usr/local/bin npm run build
- cargo test webkit_process --lib