### PR TITLE
fix: mark uploaded media backup as beta

### DIFF
--- a/docs/PHASE-7-SOCIAL-CAPTURE.md
+++ b/docs/PHASE-7-SOCIAL-CAPTURE.md
@@ -219,7 +219,7 @@ const RATE_LIMITS = {
 - [x] Source indicators in sidebar for both platforms
 - [x] Sync indicator panel shows both platforms
 - [x] Direct Facebook and Instagram source views expose All, Posts, and Stories filters in the top toolbar
-- [x] Facebook and Instagram settings expose `Back up my uploaded media`, `Import Meta export`, `Backfill from profile`, `Back up now`, and `Open vault folder`
+- [x] Facebook and Instagram settings expose `(Beta) Back up my uploaded media`, `Import Meta export`, `Backfill from profile`, `Back up now`, and `Open vault folder`
 - [x] Meta export ZIP import copies Facebook and Instagram media into a permanent local vault with a local manifest
 - [x] Permanent media archive state stays outside Automerge and is not synced
 - [x] Continuous backup archives recent own-account media after provider sync when the account handle is known

--- a/packages/desktop/src/components/MediaVaultSettingsCard.test.tsx
+++ b/packages/desktop/src/components/MediaVaultSettingsCard.test.tsx
@@ -117,10 +117,10 @@ describe("MediaVaultSettingsCard", () => {
   it("renders disabled controls before the archive is enabled", async () => {
     await renderCard(false);
 
-    expect(container.textContent).toContain("Back up my uploaded media");
+    expect(container.textContent).toContain("(Beta) Back up my uploaded media");
     expect(container.textContent).toContain("Files 0");
     expect(container.textContent).toContain("Last backup Never");
-    expect(container.querySelector("button[aria-label='Back up my uploaded media']")?.getAttribute("aria-checked")).toBe("false");
+    expect(container.querySelector("button[aria-label='(Beta) Back up my uploaded media']")?.getAttribute("aria-checked")).toBe("false");
 
     const backfill = Array.from(container.querySelectorAll("button")).find((button) =>
       button.textContent?.includes("Backfill from profile")
@@ -139,7 +139,7 @@ describe("MediaVaultSettingsCard", () => {
 
     await renderCard(true);
 
-    expect(container.querySelector("button[aria-label='Back up my uploaded media']")?.getAttribute("aria-checked")).toBe("true");
+    expect(container.querySelector("button[aria-label='(Beta) Back up my uploaded media']")?.getAttribute("aria-checked")).toBe("true");
     expect(container.textContent).toContain("Files 1");
     expect(container.textContent).toContain("Size 3 B");
     expect(container.textContent).toContain("Known account @ada");

--- a/packages/desktop/src/components/MediaVaultSettingsCard.tsx
+++ b/packages/desktop/src/components/MediaVaultSettingsCard.tsx
@@ -163,7 +163,7 @@ export function MediaVaultSettingsCard({
   return (
     <div className="space-y-3 rounded-xl border border-white/10 bg-white/5 p-3">
       <SettingsToggle
-        label="Back up my uploaded media"
+        label="(Beta) Back up my uploaded media"
         checked={summary.enabled}
         onChange={(enabled) => {
           void handleToggle(enabled);


### PR DESCRIPTION
(AI Generated).

## Summary
- Prefix the uploaded media backup toggle with (Beta) in Freed Desktop settings.
- Update the media vault test expectations and Phase 7 checklist copy to match.

## Testing
- npm run test:unit -- MediaVaultSettingsCard.test.tsx
- npm run validate:feature