### PR TITLE
chore: refresh changelog for v26.6.301

### DIFF
--- a/website/public/atom.xml
+++ b/website/public/atom.xml
@@ -2,7 +2,7 @@
 <feed xmlns="http://www.w3.org/2005/Atom">
     <id>https://freed.wtf</id>
     <title>Freed Blog</title>
-    <updated>2026-06-03T06:39:24.118Z</updated>
+    <updated>2026-06-03T16:35:15.486Z</updated>
     <generator>https://github.com/jpmonette/feed</generator>
     <author>
         <name>The Freed Team</name>

--- a/website/public/feed.xml
+++ b/website/public/feed.xml
@@ -4,7 +4,7 @@
         <title>Freed Blog</title>
         <link>https://freed.wtf</link>
         <description>Progress reports, technical deep-dives, and philosophical rants about the attention economy. From the team building Freed.</description>
-        <lastBuildDate>Wed, 03 Jun 2026 06:39:24 GMT</lastBuildDate>
+        <lastBuildDate>Wed, 03 Jun 2026 16:35:15 GMT</lastBuildDate>
         <docs>https://validator.w3.org/feed/docs/rss2.html</docs>
         <generator>https://github.com/jpmonette/feed</generator>
         <language>en</language>

--- a/website/src/content/changelog.generated.json
+++ b/website/src/content/changelog.generated.json
@@ -1,5 +1,40 @@
 [
   {
+    "version": "26.6.301",
+    "tagName": "v26.6.301",
+    "channel": "production",
+    "date": "2026-06-03T16:19:20Z",
+    "deck": "Stabilize Google Drive sync and large-library feed adds",
+    "features": [],
+    "fixes": [
+      {
+        "text": "Google Drive sync now uploads local changes from Freed Desktop and the PWA instead of only downloading remote data."
+      },
+      {
+        "text": "The PWA waits for its Automerge document to initialize before Google Drive sync, manual sync, OAuth callback sync, or relay resume can merge remote data."
+      },
+      {
+        "text": "Freed Desktop avoids a fatal Automerge worker timeout when adding RSS feed metadata to a large library."
+      }
+    ],
+    "followUps": [],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.301",
+    "prNumbers": [
+      730,
+      733
+    ],
+    "builds": [
+      "26.6.301"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.6.301",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.301",
+        "channel": "production"
+      }
+    ]
+  },
+  {
     "version": "26.6.204",
     "tagName": "v26.6.204",
     "channel": "production",


### PR DESCRIPTION
(AI Generated).

Refreshes the generated public changelog and feeds after the published v26.6.301 production release.

Validation:
- PATH=/Users/aubreyfalconer/dev/freed-www-changelog-26-6-301/node_modules/.bin:$PATH npm run build