### PR TITLE
chore: refresh changelog for v26.6.302

### DIFF
--- a/release-notes/daily/production/26.6.3.json
+++ b/release-notes/daily/production/26.6.3.json
@@ -2,17 +2,21 @@
   "channel": "production",
   "dayKey": "26.6.3",
   "date": "2026-06-03",
-  "preferredDeck": "Stabilize Google Drive sync and large-library feed adds",
+  "preferredDeck": "Stabilize Facebook and Instagram sync under memory pressure",
   "editorialGuidance": [
     "Keep the tone concise, professional, and specific.",
     "Lead with user-facing outcomes, shipping milestones, trust wins, and installability improvements.",
     "Demote internal cleanup unless it clearly changes the shipped product."
   ],
   "pinnedHighlights": [
+    "Facebook and Instagram sync now fail loudly when a provider returns an empty extraction instead of recording a false success.",
+    "Instagram sync records feed readiness, scroll targets, rejection counts, extraction passes, and store-write details so failed syncs are diagnosable from the field.",
+    "Freed Desktop now gates social sync on effective memory pressure instead of raw WebKit RSS, with detailed app RSS and WebKit RSS shown in provider errors.",
+    "Background semantic classification no longer blocks social sync, and social scraper listener cleanup avoids a Tauri event teardown crash.",
     "Google Drive sync now uploads local changes from Freed Desktop and the PWA instead of only downloading remote data.",
     "The PWA waits for its Automerge document to initialize before Google Drive sync, manual sync, OAuth callback sync, or relay resume can merge remote data.",
     "Freed Desktop avoids a fatal Automerge worker timeout when adding RSS feed metadata to a large library."
   ],
   "editorialNotes": [],
-  "updatedAt": "2026-06-03T15:25:41.173Z"
+  "updatedAt": "2026-06-03T19:56:38.613Z"
 }

--- a/release-notes/releases/v26.6.302.json
+++ b/release-notes/releases/v26.6.302.json
@@ -1,0 +1,54 @@
+{
+  "tag": "v26.6.302",
+  "version": "26.6.302",
+  "channel": "production",
+  "dayKey": "26.6.3",
+  "approved": true,
+  "editorialNotes": [],
+  "generatedAt": "2026-06-03T19:56:38.612Z",
+  "model": "heuristic",
+  "source": {
+    "channel": "production",
+    "previousPublishedTag": "v26.6.301",
+    "previousPublishedDayTag": "v26.6.204",
+    "compareRef": "HEAD",
+    "isLatestOfDay": true,
+    "sameDayTagsIncluded": [
+      "v26.6.301",
+      "v26.6.302"
+    ],
+    "relatedBuildTags": [
+      "v26.6.301",
+      "v26.6.302"
+    ],
+    "prNumbers": [
+      730,
+      733,
+      740
+    ],
+    "commitSubjects": [
+      "chore: promote dev into main for production release (#740)",
+      "docs: approve v26.6.301 release notes",
+      "release: v26.6.301",
+      "chore: promote dev into main for production release (#733)",
+      "docs: approve v26.6.300 release notes",
+      "release: v26.6.300",
+      "chore: promote dev into main for production release (#730)"
+    ]
+  },
+  "release": {
+    "deck": "Stabilize Facebook and Instagram sync under memory pressure",
+    "features": [],
+    "fixes": [
+      "Facebook and Instagram sync now fail loudly when a provider returns an empty extraction instead of recording a false success",
+      "Instagram sync records feed readiness, scroll targets, rejection counts, extraction passes, and store-write details so failed syncs are diagnosable from the field",
+      "Freed Desktop now gates social sync on effective memory pressure instead of raw WebKit RSS, with detailed app RSS and WebKit RSS shown in provider errors",
+      "Background semantic classification no longer blocks social sync, and social scraper listener cleanup avoids a Tauri event teardown crash",
+      "Google Drive sync now uploads local changes from Freed Desktop and the PWA instead of only downloading remote data",
+      "The PWA waits for its Automerge document to initialize before Google Drive sync, manual sync, OAuth callback sync, or relay resume can merge remote data",
+      "Freed Desktop avoids a fatal Automerge worker timeout when adding RSS feed metadata to a large library"
+    ],
+    "followUps": []
+  },
+  "releaseBody": "(AI Generated).\n\n## Freed v26.6.302\n\nStabilize Facebook and Instagram sync under memory pressure\n\n### Fixes\n\n- Facebook and Instagram sync now fail loudly when a provider returns an empty extraction instead of recording a false success\n- Instagram sync records feed readiness, scroll targets, rejection counts, extraction passes, and store-write details so failed syncs are diagnosable from the field\n- Freed Desktop now gates social sync on effective memory pressure instead of raw WebKit RSS, with detailed app RSS and WebKit RSS shown in provider errors\n- Background semantic classification no longer blocks social sync, and social scraper listener cleanup avoids a Tauri event teardown crash\n- Google Drive sync now uploads local changes from Freed Desktop and the PWA instead of only downloading remote data\n- The PWA waits for its Automerge document to initialize before Google Drive sync, manual sync, OAuth callback sync, or relay resume can merge remote data\n- Freed Desktop avoids a fatal Automerge worker timeout when adding RSS feed metadata to a large library\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+}

--- a/release-notes/releases/v26.6.302.md
+++ b/release-notes/releases/v26.6.302.md
@@ -1,0 +1,23 @@
+(AI Generated).
+
+## Freed v26.6.302
+
+Stabilize Facebook and Instagram sync under memory pressure
+
+### Fixes
+
+- Facebook and Instagram sync now fail loudly when a provider returns an empty extraction instead of recording a false success
+- Instagram sync records feed readiness, scroll targets, rejection counts, extraction passes, and store-write details so failed syncs are diagnosable from the field
+- Freed Desktop now gates social sync on effective memory pressure instead of raw WebKit RSS, with detailed app RSS and WebKit RSS shown in provider errors
+- Background semantic classification no longer blocks social sync, and social scraper listener cleanup avoids a Tauri event teardown crash
+- Google Drive sync now uploads local changes from Freed Desktop and the PWA instead of only downloading remote data
+- The PWA waits for its Automerge document to initialize before Google Drive sync, manual sync, OAuth callback sync, or relay resume can merge remote data
+- Freed Desktop avoids a fatal Automerge worker timeout when adding RSS feed metadata to a large library
+
+### Downloads
+
+**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  
+**Windows:** `.exe` (NSIS installer)  
+**Linux:** `.AppImage`  
+
+> macOS downloads are signed and notarized for normal Gatekeeper installation.

--- a/website/public/atom.xml
+++ b/website/public/atom.xml
@@ -2,7 +2,7 @@
 <feed xmlns="http://www.w3.org/2005/Atom">
     <id>https://freed.wtf</id>
     <title>Freed Blog</title>
-    <updated>2026-06-03T16:35:15.486Z</updated>
+    <updated>2026-06-03T21:04:05.092Z</updated>
     <generator>https://github.com/jpmonette/feed</generator>
     <author>
         <name>The Freed Team</name>

--- a/website/public/feed.xml
+++ b/website/public/feed.xml
@@ -4,7 +4,7 @@
         <title>Freed Blog</title>
         <link>https://freed.wtf</link>
         <description>Progress reports, technical deep-dives, and philosophical rants about the attention economy. From the team building Freed.</description>
-        <lastBuildDate>Wed, 03 Jun 2026 16:35:15 GMT</lastBuildDate>
+        <lastBuildDate>Wed, 03 Jun 2026 21:04:05 GMT</lastBuildDate>
         <docs>https://validator.w3.org/feed/docs/rss2.html</docs>
         <generator>https://github.com/jpmonette/feed</generator>
         <language>en</language>

--- a/website/src/content/changelog.generated.json
+++ b/website/src/content/changelog.generated.json
@@ -1,35 +1,54 @@
 [
   {
-    "version": "26.6.301",
-    "tagName": "v26.6.301",
+    "version": "26.6.302",
+    "tagName": "v26.6.302",
     "channel": "production",
-    "date": "2026-06-03T16:19:20Z",
-    "deck": "Stabilize Google Drive sync and large-library feed adds",
+    "date": "2026-06-03T20:34:47Z",
+    "deck": "Stabilize Facebook and Instagram sync under memory pressure",
     "features": [],
     "fixes": [
       {
-        "text": "Google Drive sync now uploads local changes from Freed Desktop and the PWA instead of only downloading remote data."
+        "text": "Facebook and Instagram sync now fail loudly when a provider returns an empty extraction instead of recording a false success"
       },
       {
-        "text": "The PWA waits for its Automerge document to initialize before Google Drive sync, manual sync, OAuth callback sync, or relay resume can merge remote data."
+        "text": "Instagram sync records feed readiness, scroll targets, rejection counts, extraction passes, and store-write details so failed syncs are diagnosable from the field"
       },
       {
-        "text": "Freed Desktop avoids a fatal Automerge worker timeout when adding RSS feed metadata to a large library."
+        "text": "Freed Desktop now gates social sync on effective memory pressure instead of raw WebKit RSS, with detailed app RSS and WebKit RSS shown in provider errors"
+      },
+      {
+        "text": "Background semantic classification no longer blocks social sync, and social scraper listener cleanup avoids a Tauri event teardown crash"
+      },
+      {
+        "text": "Google Drive sync now uploads local changes from Freed Desktop and the PWA instead of only downloading remote data"
+      },
+      {
+        "text": "The PWA waits for its Automerge document to initialize before Google Drive sync, manual sync, OAuth callback sync, or relay resume can merge remote data"
+      },
+      {
+        "text": "Freed Desktop avoids a fatal Automerge worker timeout when adding RSS feed metadata to a large library"
       }
     ],
     "followUps": [],
-    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.301",
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.302",
     "prNumbers": [
       730,
-      733
+      733,
+      740
     ],
     "builds": [
-      "26.6.301"
+      "26.6.301",
+      "26.6.302"
     ],
     "buildLinks": [
       {
         "version": "26.6.301",
         "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.301",
+        "channel": "production"
+      },
+      {
+        "version": "26.6.302",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.302",
         "channel": "production"
       }
     ]


### PR DESCRIPTION
(AI Generated).

## Summary
- Add the reviewed v26.6.302 release notes to the website branch and refresh the checked-in changelog plus feeds.

## Testing
- cd website && npm run build