### PR TITLE
perf: reduce sync frame pressure

### DIFF
--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -100,6 +100,8 @@ const WEBKIT_HIDDEN_TIMER_THROTTLE_AFTER: Duration = Duration::from_secs(480);
 const RENDERER_HIDDEN_STALE_LOG_AFTER: Duration = Duration::from_secs(570);
 const RENDERER_VISIBLE_RECOVERY_AFTER: Duration = Duration::from_secs(75);
 const RENDERER_HIDDEN_RECOVERY_AFTER: Duration = Duration::from_secs(900);
+const MAIN_RENDERER_MEMORY_RECOVERY_MIN_AGE_SECONDS: u64 = 5 * 60;
+const RENDERER_EVENT_LOOP_LAG_RECOVERY_MS: f64 = 45_000.0;
 const BACKGROUND_REQUIRED_HEALTHY_HEARTBEATS: u64 = 2;
 const BACKGROUND_RECOVERY_COOLDOWN: Duration = Duration::from_secs(120);
 const BACKGROUND_MEMORY_HIGH_COOLDOWN: Duration = Duration::from_secs(120);
@@ -1494,6 +1496,8 @@ impl BackgroundRuntimeCoordinator {
         state.healthy_heartbeats = state.healthy_heartbeats.saturating_add(1);
         if state.healthy_heartbeats >= BACKGROUND_REQUIRED_HEALTHY_HEARTBEATS {
             state.renderer_stale = false;
+            state.cooldown_until = None;
+            state.last_recovery_reason = None;
         }
     }
 
@@ -2173,6 +2177,38 @@ fn renderer_stale_should_recover(is_visible: bool, last_visibility: &str) -> boo
     renderer_is_effectively_visible(is_visible, last_visibility)
 }
 
+fn renderer_event_loop_lag_should_recover(
+    is_visible: bool,
+    last_visibility: &str,
+    event_loop_lag_ms: Option<f64>,
+) -> bool {
+    renderer_is_effectively_visible(is_visible, last_visibility)
+        && event_loop_lag_ms
+            .map(|lag| lag >= RENDERER_EVENT_LOOP_LAG_RECOVERY_MS)
+            .unwrap_or(false)
+}
+
+fn main_renderer_memory_should_recover(
+    is_visible: bool,
+    last_visibility: &str,
+    stats: &RuntimeMemoryStats,
+) -> bool {
+    if !renderer_is_effectively_visible(is_visible, last_visibility) {
+        return false;
+    }
+    if stats.webkit_largest_role.as_deref() != Some("freed-webcontent-age-matched") {
+        return false;
+    }
+    let main_webkit_pressure_bytes = stats
+        .webkit_largest_footprint_bytes
+        .unwrap_or_else(|| stats.webkit_largest_resident_bytes.unwrap_or(0));
+    main_webkit_pressure_bytes >= stats.memory_high_bytes
+        && stats
+            .webkit_largest_age_seconds
+            .map(|age| age >= MAIN_RENDERER_MEMORY_RECOVERY_MIN_AGE_SECONDS)
+            .unwrap_or(false)
+}
+
 fn format_bytes_for_log(bytes: u64) -> String {
     const KIB: f64 = 1024.0;
     const MIB: f64 = KIB * 1024.0;
@@ -2268,6 +2304,87 @@ mod renderer_watchdog_tests {
         assert!(!renderer_stale_should_recover(true, "hidden"));
         assert!(!renderer_stale_should_recover(false, "visible"));
         assert!(!renderer_stale_should_recover(false, "hidden"));
+    }
+
+    #[test]
+    fn visible_renderer_recovers_from_high_event_loop_lag() {
+        assert!(renderer_event_loop_lag_should_recover(
+            true,
+            "visible",
+            Some(RENDERER_EVENT_LOOP_LAG_RECOVERY_MS)
+        ));
+        assert!(!renderer_event_loop_lag_should_recover(
+            true,
+            "visible",
+            Some(RENDERER_EVENT_LOOP_LAG_RECOVERY_MS - 1.0)
+        ));
+        assert!(!renderer_event_loop_lag_should_recover(
+            true,
+            "visible",
+            Some(5_500.0)
+        ));
+        assert!(!renderer_event_loop_lag_should_recover(
+            true,
+            "hidden",
+            Some(RENDERER_EVENT_LOOP_LAG_RECOVERY_MS)
+        ));
+        assert!(!renderer_event_loop_lag_should_recover(
+            false,
+            "visible",
+            Some(RENDERER_EVENT_LOOP_LAG_RECOVERY_MS)
+        ));
+    }
+
+    #[test]
+    fn visible_main_renderer_recovers_from_high_webkit_footprint() {
+        let stats = RuntimeMemoryStats {
+            total_physical_memory_bytes: 16 * BYTES_PER_GIB,
+            process_resident_bytes: 128,
+            process_footprint_bytes: Some(128),
+            process_virtual_bytes: 256,
+            app_resident_bytes: 9 * BYTES_PER_GIB,
+            app_memory_pressure_bytes: 7 * BYTES_PER_GIB,
+            webkit_resident_bytes: Some(8 * BYTES_PER_GIB),
+            webkit_footprint_bytes: Some(7 * BYTES_PER_GIB),
+            webkit_virtual_bytes: None,
+            webkit_process_id: Some(123),
+            webkit_total_resident_bytes: 8 * BYTES_PER_GIB,
+            webkit_total_footprint_bytes: Some(7 * BYTES_PER_GIB),
+            webkit_process_count: 1,
+            webkit_largest_resident_bytes: Some(8 * BYTES_PER_GIB),
+            webkit_largest_footprint_bytes: Some(7 * BYTES_PER_GIB),
+            webkit_largest_process_id: Some(123),
+            webkit_largest_cpu_usage: Some(0.0),
+            webkit_largest_age_seconds: Some(MAIN_RENDERER_MEMORY_RECOVERY_MIN_AGE_SECONDS),
+            webkit_largest_role: Some("freed-webcontent-age-matched".to_string()),
+            webkit_processes: Vec::new(),
+            webkit_telemetry_available: true,
+            indexed_db_bytes: None,
+            webkit_cache_bytes: None,
+            memory_high_bytes: MIN_CRITICAL_MEMORY_BYTES * 70 / 100,
+            memory_critical_bytes: MIN_CRITICAL_MEMORY_BYTES,
+            relay_doc_bytes: 0,
+            relay_client_count: 0,
+        };
+
+        assert!(main_renderer_memory_should_recover(true, "visible", &stats));
+        assert!(!main_renderer_memory_should_recover(true, "hidden", &stats));
+        assert!(!main_renderer_memory_should_recover(
+            true,
+            "visible",
+            &RuntimeMemoryStats {
+                webkit_largest_role: Some("ig-scraper".to_string()),
+                ..stats.clone()
+            }
+        ));
+        assert!(!main_renderer_memory_should_recover(
+            true,
+            "visible",
+            &RuntimeMemoryStats {
+                webkit_largest_age_seconds: Some(MAIN_RENDERER_MEMORY_RECOVERY_MIN_AGE_SECONDS - 1,),
+                ..stats
+            }
+        ));
     }
 
     #[test]
@@ -3912,18 +4029,50 @@ fn scrape_resident_start_budget_bytes(stats: &RuntimeMemoryStats) -> u64 {
         .saturating_sub(SCRAPE_MEMORY_HEADROOM_BYTES)
 }
 
+fn webkit_resident_tail_is_probably_reclaimable(stats: &RuntimeMemoryStats) -> bool {
+    if !stats.webkit_telemetry_available {
+        return false;
+    }
+    let Some(webkit_footprint_bytes) = stats.webkit_total_footprint_bytes else {
+        return false;
+    };
+    if stats.webkit_total_resident_bytes <= webkit_footprint_bytes {
+        return false;
+    }
+    let webkit_resident_tail_bytes = stats.webkit_total_resident_bytes - webkit_footprint_bytes;
+    let largest_webkit_cpu_usage = stats.webkit_largest_cpu_usage.unwrap_or(0.0);
+    stats.app_memory_pressure_bytes < scrape_memory_start_budget_bytes(stats)
+        && stats.app_resident_bytes
+            < stats
+                .memory_critical_bytes
+                .saturating_sub(SCRAPE_MEMORY_HEADROOM_BYTES)
+        && webkit_resident_tail_bytes >= BYTES_PER_GIB
+        && largest_webkit_cpu_usage <= 10.0
+}
+
+fn scrape_effective_resident_bytes(stats: &RuntimeMemoryStats) -> u64 {
+    if webkit_resident_tail_is_probably_reclaimable(stats) {
+        return stats
+            .process_resident_bytes
+            .saturating_add(stats.webkit_total_footprint_bytes.unwrap_or(0));
+    }
+    stats.app_resident_bytes
+}
+
 fn scrape_memory_may_proceed(stats: &RuntimeMemoryStats) -> bool {
     stats.app_memory_pressure_bytes < scrape_memory_start_budget_bytes(stats)
-        && stats.app_resident_bytes < scrape_resident_start_budget_bytes(stats)
+        && scrape_effective_resident_bytes(stats) < scrape_resident_start_budget_bytes(stats)
 }
 
 fn scrape_memory_pressure_level(stats: &RuntimeMemoryStats) -> &'static str {
+    let effective_resident_bytes = scrape_effective_resident_bytes(stats);
     if stats.app_memory_pressure_bytes >= stats.memory_critical_bytes
-        || stats.app_resident_bytes >= stats.memory_critical_bytes
+        || (stats.app_resident_bytes >= stats.memory_critical_bytes
+            && !webkit_resident_tail_is_probably_reclaimable(stats))
     {
         "critical"
     } else if stats.app_memory_pressure_bytes >= stats.memory_high_bytes
-        || stats.app_resident_bytes >= scrape_resident_start_budget_bytes(stats)
+        || effective_resident_bytes >= scrape_resident_start_budget_bytes(stats)
     {
         "high"
     } else {
@@ -3947,8 +4096,8 @@ fn optional_story_scrape_may_proceed(stats: &RuntimeMemoryStats) -> bool {
 fn scrape_memory_available_margin_bytes(stats: &RuntimeMemoryStats) -> u64 {
     let pressure_margin =
         scrape_memory_start_budget_bytes(stats).saturating_sub(stats.app_memory_pressure_bytes);
-    let resident_margin =
-        scrape_resident_start_budget_bytes(stats).saturating_sub(stats.app_resident_bytes);
+    let resident_margin = scrape_resident_start_budget_bytes(stats)
+        .saturating_sub(scrape_effective_resident_bytes(stats));
     pressure_margin.min(resident_margin)
 }
 
@@ -4280,6 +4429,8 @@ async fn prepare_social_scrape_memory_internal(
             "webkitProcessCount": after.webkit_process_count,
             "scrapeStartBudgetBytes": scrape_start_budget_bytes,
             "scrapeResidentBudgetBytes": scrape_resident_budget_bytes,
+            "effectiveResidentBytes": scrape_effective_resident_bytes(&after),
+            "webkitResidentTailReclaimable": webkit_resident_tail_is_probably_reclaimable(&after),
             "scrapeHeadroomBytes": SCRAPE_MEMORY_HEADROOM_BYTES,
             "memoryHighBytes": after.memory_high_bytes,
             "memoryCriticalBytes": after.memory_critical_bytes,
@@ -4366,6 +4517,8 @@ async fn ensure_social_scrape_memory(
             "webkitLargestResidentBytes": prep.after.webkit_largest_resident_bytes,
             "scrapeStartBudgetBytes": prep.scrape_start_budget_bytes,
             "scrapeResidentBudgetBytes": scrape_resident_start_budget_bytes(&prep.after),
+            "effectiveResidentBytes": scrape_effective_resident_bytes(&prep.after),
+            "webkitResidentTailReclaimable": webkit_resident_tail_is_probably_reclaimable(&prep.after),
             "memoryHighBytes": prep.after.memory_high_bytes,
             "memoryCriticalBytes": prep.after.memory_critical_bytes,
             "recycledAllScraperWindows": critical,
@@ -4867,7 +5020,11 @@ struct IgFeedStatePayload {
     article_count: u64,
     ready_article_count: u64,
     tiny_article_count: u64,
+    first_article_height: u64,
+    first_article_text_length: u64,
+    first_article_media_count: u64,
     scroll_height: u64,
+    document_ready_state: String,
     login_chrome: bool,
     main_found: bool,
     url: String,
@@ -4881,6 +5038,24 @@ impl IgFeedStatePayload {
 
     fn feed_ready(&self) -> bool {
         self.ready_article_count > 0 && !self.login_chrome
+    }
+
+    fn diagnostic_summary(&self) -> String {
+        format!(
+            "ready_articles={}, tiny_articles={}, articles={}, scroll_height={}, first_article_height={}, first_article_text_length={}, first_article_media_count={}, ready_state={}, logged_in_cookie={}, login_chrome={}, main_found={}, url={}",
+            self.ready_article_count,
+            self.tiny_article_count,
+            self.article_count,
+            self.scroll_height,
+            self.first_article_height,
+            self.first_article_text_length,
+            self.first_article_media_count,
+            self.document_ready_state,
+            self.logged_in_cookie,
+            self.login_chrome,
+            self.main_found,
+            &self.url[..self.url.len().min(80)]
+        )
     }
 }
 
@@ -4930,6 +5105,12 @@ fn ig_feed_state_probe_script() -> &'static str {
             var articles = Array.prototype.slice.call(document.querySelectorAll("article, [role='article']"));
             var ready = 0;
             var tiny = 0;
+            var firstArticle = articles[0] || null;
+            var firstArticleHeight = firstArticle ? (firstArticle.offsetHeight || 0) : 0;
+            var firstArticleTextLength = firstArticle ? ((firstArticle.textContent || "").trim().length) : 0;
+            var firstArticleMediaCount = firstArticle
+                ? firstArticle.querySelectorAll("img[src*='cdninstagram'], img[src*='scontent'], img[srcset], video").length
+                : 0;
             articles.forEach(function(article) {
                 var height = article.offsetHeight || 0;
                 if (height < 100) {
@@ -4951,7 +5132,11 @@ fn ig_feed_state_probe_script() -> &'static str {
                 articleCount: articles.length,
                 readyArticleCount: ready,
                 tinyArticleCount: tiny,
+                firstArticleHeight: firstArticleHeight,
+                firstArticleTextLength: firstArticleTextLength,
+                firstArticleMediaCount: firstArticleMediaCount,
                 scrollHeight: document.documentElement.scrollHeight || document.body.scrollHeight || 0,
+                documentReadyState: document.readyState || "",
                 loginChrome: /\blog in\b/.test(bodyText) ||
                     /\bsign up\b/.test(bodyText) ||
                     /\blog into instagram\b/.test(bodyText),
@@ -4965,7 +5150,11 @@ fn ig_feed_state_probe_script() -> &'static str {
                 articleCount: 0,
                 readyArticleCount: 0,
                 tinyArticleCount: 0,
+                firstArticleHeight: 0,
+                firstArticleTextLength: 0,
+                firstArticleMediaCount: 0,
                 scrollHeight: 0,
+                documentReadyState: document.readyState || "",
                 loginChrome: false,
                 mainFound: false,
                 url: window.location.href,
@@ -5087,17 +5276,10 @@ async fn wait_for_ig_feed_state(
         match probe_ig_feed_state(app, wv).await {
             Ok(state) => {
                 info!(
-                    "[IG] feed state attempt={}/{} ready_articles={} tiny_articles={} articles={} scroll_height={} logged_in_cookie={} login_chrome={} main_found={} url={}",
+                    "[IG] feed state attempt={}/{} {}",
                     attempt,
                     attempts.max(1),
-                    state.ready_article_count,
-                    state.tiny_article_count,
-                    state.article_count,
-                    state.scroll_height,
-                    state.logged_in_cookie,
-                    state.login_chrome,
-                    state.main_found,
-                    &state.url[..state.url.len().min(80)]
+                    state.diagnostic_summary()
                 );
                 let ready = state.feed_ready();
                 last_state = state;
@@ -6220,7 +6402,32 @@ async fn ig_scrape_feed(
     // Belt-and-suspenders: click the Following tab if present
     let _ = wv.eval(r#"document.querySelector('a[href="/?variant=following"]')?.click();"#);
     tokio::time::sleep(Duration::from_millis(2000)).await;
-    let initial_feed_state = wait_for_ig_feed_state(&app, &wv, 6).await;
+    let mut initial_feed_state = wait_for_ig_feed_state(&app, &wv, 6).await;
+    if initial_feed_state.placeholders_only() {
+        info!(
+            "[IG] placeholder feed detected before extraction, attempting one feed refresh: {}",
+            initial_feed_state.diagnostic_summary()
+        );
+        tokio::time::sleep(Duration::from_millis(gaussian_ms(1800.0, 450.0))).await;
+        wv.navigate(ig_feed_url.parse::<url::Url>().map_err(|e| e.to_string())?)
+            .map_err(|e| e.to_string())?;
+        tokio::time::sleep(Duration::from_millis(gaussian_ms(6500.0, 900.0))).await;
+        let _ = wv.eval(r#"document.querySelector('a[href="/?variant=following"]')?.click();"#);
+        tokio::time::sleep(Duration::from_millis(gaussian_ms(1400.0, 250.0))).await;
+        initial_feed_state = wait_for_ig_feed_state(&app, &wv, 6).await;
+        if initial_feed_state.placeholders_only() {
+            let message = format!(
+                "placeholder_feed: Instagram loaded placeholder feed articles after one refresh. {}",
+                initial_feed_state.diagnostic_summary()
+            );
+            warn!("[IG] {}", message);
+            return Err(message);
+        }
+        info!(
+            "[IG] placeholder feed recovered after one refresh: {}",
+            initial_feed_state.diagnostic_summary()
+        );
+    }
 
     let scrape_plan_stats = collect_runtime_memory_stats(&app, 0, 0);
     let scrape_plan = social_scrape_plan_for_memory(&scrape_plan_stats, 5, 9);
@@ -8273,7 +8480,7 @@ pub fn run() {
                     let stats = collect_runtime_memory_stats(&app_for_memory_monitor, 0, 0);
                     let memory_health_fields = {
                         let mut sample = renderer_memory_sample_for_memory_monitor.lock().unwrap();
-                        *sample = Some(RendererMemorySample::from_stats(now, stats));
+                        *sample = Some(RendererMemorySample::from_stats(now, stats.clone()));
                         renderer_memory_health_fields(sample.as_ref(), now, true)
                     };
                     let is_main_visible = app_for_memory_monitor
@@ -8334,6 +8541,136 @@ pub fn run() {
                         fields.extend(memory_health_fields);
                     }
                     append_runtime_health(&app_for_memory_monitor, health_payload);
+
+                    let should_recover_main_for_memory =
+                        active_job.is_none()
+                            && main_renderer_memory_should_recover(
+                                is_main_visible,
+                                &renderer_health_for_memory_monitor
+                                    .read()
+                                    .unwrap()
+                                    .last_visibility,
+                                &stats,
+                            );
+                    if should_recover_main_for_memory {
+                        let recovery = {
+                            let mut health = renderer_health_for_memory_monitor.write().unwrap();
+                            let recent_recovery_count = health
+                                .recent_recovery_count(BACKGROUND_SAFE_MODE_RECOVERY_WINDOW_SHORT);
+                            let recovery_threshold = renderer_recovery_threshold_for_count(
+                                is_main_visible,
+                                &health.last_visibility,
+                                recent_recovery_count,
+                            );
+                            let cooldown_elapsed = health
+                                .last_recovery_at
+                                .map(|last| last.elapsed() > recovery_threshold)
+                                .unwrap_or(true);
+                            if cooldown_elapsed {
+                                let attempt = health.note_recovery_attempt(std::time::Instant::now());
+                                Some((
+                                    attempt,
+                                    health.renderer_generation,
+                                    health.last_visibility.clone(),
+                                    health.last_page_load_id.clone(),
+                                    health.last_app_phase.clone(),
+                                    recovery_threshold,
+                                ))
+                            } else {
+                                None
+                            }
+                        };
+
+                        if let Some((
+                            attempt,
+                            renderer_generation,
+                            last_visibility,
+                            page_load_id,
+                            app_phase,
+                            recovery_threshold,
+                        )) = recovery
+                        {
+                            let reason = "main renderer WebKit memory high";
+                            background_runtime_for_memory_monitor.note_renderer_recovery_attempt(reason);
+                            let (
+                                safe_mode_active,
+                                safe_mode_remaining_ms,
+                                recoveries_short,
+                                recoveries_long,
+                            ) = background_runtime_for_memory_monitor.recovery_status_for_health();
+                            append_runtime_health(
+                                &app_for_memory_monitor,
+                                serde_json::json!({
+                                    "event": "renderer_recovery_attempt",
+                                    "reason": reason,
+                                    "rendererGeneration": renderer_generation,
+                                    "attempt": attempt,
+                                    "thresholdMs": recovery_threshold.as_millis(),
+                                    "visible": is_main_visible,
+                                    "lastVisibility": last_visibility,
+                                    "pageLoadId": page_load_id,
+                                    "appPhase": app_phase,
+                                    "rendererRecoveryAllowed": true,
+                                    "appMemoryPressureBytes": stats.app_memory_pressure_bytes,
+                                    "appResidentBytes": stats.app_resident_bytes,
+                                    "nativeResidentBytes": stats.process_resident_bytes,
+                                    "nativeFootprintBytes": stats.process_footprint_bytes,
+                                    "webkitFootprintBytes": stats.webkit_total_footprint_bytes,
+                                    "webkitResidentBytes": stats.webkit_total_resident_bytes,
+                                    "webkitLargestProcessId": stats.webkit_largest_process_id,
+                                    "webkitLargestFootprintBytes": stats.webkit_largest_footprint_bytes,
+                                    "webkitLargestResidentBytes": stats.webkit_largest_resident_bytes,
+                                    "webkitLargestCpuUsage": stats.webkit_largest_cpu_usage,
+                                    "webkitLargestAgeSeconds": stats.webkit_largest_age_seconds,
+                                    "webkitLargestRole": stats.webkit_largest_role,
+                                    "webkitProcessCount": stats.webkit_process_count,
+                                    "memoryHighBytes": stats.memory_high_bytes,
+                                    "memoryCriticalBytes": stats.memory_critical_bytes,
+                                    "safeModeActive": safe_mode_active,
+                                    "safeModeRemainingMs": safe_mode_remaining_ms,
+                                    "recoveriesInShortWindow": recoveries_short,
+                                    "recoveriesInLongWindow": recoveries_long
+                                }),
+                            );
+                            capture_deep_runtime_diagnostic(
+                                &app_for_memory_monitor,
+                                "renderer_memory_recovery_attempt",
+                                reason,
+                                &stats,
+                                None,
+                                None,
+                                true,
+                            );
+                            warn!(
+                                "[main-window] recovering renderer for memory attempt={} app_pressure={} app_rss={} webkit_pressure={} webkit_rss={} threshold_ms={} safe_mode={}",
+                                attempt,
+                                format_bytes_for_log(stats.app_memory_pressure_bytes),
+                                format_bytes_for_log(stats.app_resident_bytes),
+                                format_bytes_for_log(
+                                    stats
+                                        .webkit_largest_footprint_bytes
+                                        .unwrap_or_else(|| stats.webkit_largest_resident_bytes.unwrap_or(0))
+                                ),
+                                format_bytes_for_log(stats.webkit_total_resident_bytes),
+                                recovery_threshold.as_millis(),
+                                safe_mode_active
+                            );
+                            recycle_social_scraper_windows_unless_active(
+                                &app_for_memory_monitor,
+                                &background_runtime_for_memory_monitor,
+                                reason,
+                            );
+                            if let Err(error) = recover_main_window(
+                                &app_for_memory_monitor,
+                                reason,
+                            ) {
+                                error!(
+                                    "[main-window] memory recovery failed reason={} error={}",
+                                    reason, error
+                                );
+                            }
+                        }
+                    }
                 }
             });
 
@@ -8372,6 +8709,16 @@ pub fn run() {
                             is_main_visible,
                             &health.last_visibility,
                         );
+                        let lag_recovery_allowed = renderer_event_loop_lag_should_recover(
+                            is_main_visible,
+                            &health.last_visibility,
+                            health.last_event_loop_lag_ms,
+                        );
+                        let recovery_reason = if lag_recovery_allowed {
+                            "renderer event loop lag high"
+                        } else {
+                            "renderer heartbeat stale"
+                        };
                         let expected_hidden_throttle = renderer_gap_is_expected_hidden_throttle(
                             is_main_visible,
                             &health.last_visibility,
@@ -8386,7 +8733,7 @@ pub fn run() {
                         let should_log_stale = should_log_gap && !expected_hidden_throttle;
                         let should_recover =
                             recovery_allowed &&
-                            age > recovery_threshold &&
+                            (age > recovery_threshold || lag_recovery_allowed) &&
                             health
                                 .last_recovery_at
                                 .map(|last| last.elapsed() > recovery_threshold)
@@ -8568,9 +8915,13 @@ pub fn run() {
                         }
 
                         if should_recover {
+                            let recovery_last_visibility = health.last_visibility.clone();
+                            let recovery_event_loop_lag_ms = health.last_event_loop_lag_ms;
+                            let recovery_renderer_generation =
+                                health.renderer_generation.saturating_add(1);
                             let attempt = health.note_recovery_attempt(std::time::Instant::now());
                             background_runtime_for_watchdog
-                                .note_renderer_recovery_attempt("renderer heartbeat stale");
+                                .note_renderer_recovery_attempt(recovery_reason);
                             let stats = collect_runtime_memory_stats(&app_for_renderer_watchdog, 0, 0);
                             let (active_job, active_job_age_ms) =
                                 background_runtime_for_watchdog.active_job_for_health();
@@ -8580,13 +8931,15 @@ pub fn run() {
                                 &app_for_renderer_watchdog,
                                 serde_json::json!({
                                     "event": "renderer_recovery_attempt",
-                                    "rendererGeneration": health.renderer_generation,
+                                    "rendererGeneration": recovery_renderer_generation,
                                     "attempt": attempt,
                                     "ageMs": age.as_millis(),
+                                    "reason": recovery_reason,
                                     "thresholdMs": recovery_threshold.as_millis(),
                                     "visible": is_main_visible,
-                                    "lastVisibility": health.last_visibility.clone(),
+                                    "lastVisibility": recovery_last_visibility.clone(),
                                     "rendererRecoveryAllowed": recovery_allowed,
+                                    "eventLoopLagMs": recovery_event_loop_lag_ms,
                                     "webkitResidentBytes": stats.webkit_total_resident_bytes,
                                     "webkitLargestProcessId": stats.webkit_largest_process_id,
                                     "webkitLargestResidentBytes": stats.webkit_largest_resident_bytes,
@@ -8608,12 +8961,12 @@ pub fn run() {
                                 "renderer-recovery-state",
                                 serde_json::json!({
                                     "phase": if safe_mode_active { "safe_mode" } else { "recovery_attempt" },
-                                    "reason": "renderer heartbeat stale",
-                                    "rendererGeneration": health.renderer_generation,
+                                    "reason": recovery_reason,
+                                    "rendererGeneration": recovery_renderer_generation,
                                     "attempt": attempt,
                                     "ageMs": age.as_millis(),
                                     "thresholdMs": recovery_threshold.as_millis(),
-                                    "lastVisibility": health.last_visibility.clone(),
+                                    "lastVisibility": recovery_last_visibility,
                                     "rendererRecoveryAllowed": recovery_allowed,
                                     "safeModeActive": safe_mode_active,
                                     "safeModeRemainingMs": safe_mode_remaining_ms,
@@ -8624,16 +8977,18 @@ pub fn run() {
                             capture_deep_runtime_diagnostic(
                                 &app_for_renderer_watchdog,
                                 "renderer_recovery_attempt",
-                                "renderer heartbeat stale",
+                                recovery_reason,
                                 &stats,
                                 active_job,
                                 active_job_age_ms,
                                 true,
                             );
                             warn!(
-                                "[main-window] recovering stale renderer attempt={} age_ms={} threshold_ms={} visible={} safe_mode={}",
+                                "[main-window] recovering renderer attempt={} reason={} age_ms={} event_loop_lag_ms={} threshold_ms={} visible={} safe_mode={}",
                                 attempt,
+                                recovery_reason,
                                 age.as_millis(),
+                                recovery_event_loop_lag_ms.unwrap_or(0.0),
                                 recovery_threshold.as_millis(),
                                 is_main_visible,
                                 safe_mode_active
@@ -8654,7 +9009,7 @@ pub fn run() {
                     if should_recover_main {
                         if let Err(error) = recover_main_window(
                             &app_for_renderer_watchdog,
-                            "renderer heartbeat stale",
+                            "renderer watchdog recovery",
                         ) {
                             error!(
                                 "[main-window] failed to recover stale renderer: {}",
@@ -8917,7 +9272,11 @@ mod tests {
             article_count: 3,
             ready_article_count: 3,
             tiny_article_count: 0,
+            first_article_height: 612,
+            first_article_text_length: 120,
+            first_article_media_count: 1,
             scroll_height: 2589,
+            document_ready_state: "complete".to_string(),
             login_chrome: false,
             main_found: true,
             url: "https://www.instagram.com/?variant=following".to_string(),
@@ -8929,9 +9288,20 @@ mod tests {
             ready_article_count: 0,
             tiny_article_count: 2,
             article_count: 2,
-            ..state
+            ..state.clone()
         }
         .feed_ready());
+        assert!(IgFeedStatePayload {
+            ready_article_count: 0,
+            tiny_article_count: 2,
+            article_count: 2,
+            first_article_height: 56,
+            first_article_text_length: 0,
+            first_article_media_count: 0,
+            scroll_height: 1199,
+            ..state
+        }
+        .placeholders_only());
     }
 
     #[test]
@@ -9165,7 +9535,7 @@ mod tests {
     }
 
     #[test]
-    fn background_runtime_blocks_during_recovery_cooldown() {
+    fn background_runtime_resumes_after_healthy_recovery_heartbeats() {
         let runtime = BackgroundRuntimeCoordinator::new();
         runtime.note_renderer_heartbeat();
         runtime.note_renderer_heartbeat();
@@ -9184,12 +9554,10 @@ mod tests {
         runtime.note_renderer_heartbeat();
         runtime.note_renderer_heartbeat();
         let (paused, reason, remaining_ms) = runtime.pause_status_for_health();
-        assert!(paused);
-        assert_eq!(reason, Some("renderer_recovery_cooldown"));
-        assert!(remaining_ms.unwrap_or(0) > 0);
-
-        let err = runtime.begin_job("ig_scrape_feed").unwrap_err();
-        assert!(err.contains("cooling down"));
+        assert!(!paused);
+        assert_eq!(reason, None);
+        assert_eq!(remaining_ms, None);
+        assert!(runtime.begin_job("ig_scrape_feed").is_ok());
     }
 
     #[test]
@@ -9335,7 +9703,10 @@ mod tests {
             freed_webkit_process_role(true, app_age, app_age),
             Some("freed-webcontent")
         );
-        assert_eq!(freed_webkit_process_role(true, 0, app_age), Some("freed-webcontent"));
+        assert_eq!(
+            freed_webkit_process_role(true, 0, app_age),
+            Some("freed-webcontent")
+        );
         assert_eq!(
             freed_webkit_process_role(
                 true,
@@ -9513,7 +9884,7 @@ mod tests {
     }
 
     #[test]
-    fn scrape_memory_blocks_resident_rss_at_start_budget_when_footprint_is_low() {
+    fn scrape_memory_allows_reclaimable_webkit_rss_tail_below_critical_pressure() {
         let budget =
             (MIN_CRITICAL_MEMORY_BYTES * 70 / 100).saturating_sub(SCRAPE_MEMORY_HEADROOM_BYTES);
         let stats = RuntimeMemoryStats {
@@ -9552,17 +9923,58 @@ mod tests {
             app_memory_pressure_bytes: budget - 1,
             ..stats
         };
-        assert!(!scrape_memory_may_proceed(&high_resident_stats));
-        assert_eq!(scrape_memory_pressure_level(&high_resident_stats), "high");
+        assert!(webkit_resident_tail_is_probably_reclaimable(
+            &high_resident_stats
+        ));
+        assert!(scrape_memory_may_proceed(&high_resident_stats));
+        assert_eq!(scrape_memory_pressure_level(&high_resident_stats), "normal");
         assert_eq!(
             social_scrape_plan_for_memory(&high_resident_stats, 6, 10),
             SocialScrapePlan {
-                min_passes: 0,
-                max_passes: 0,
+                min_passes: 2,
+                max_passes: 3,
                 skip_stories: true,
-                reason: "blocked",
+                reason: "minimal-memory-margin",
             }
         );
+    }
+
+    #[test]
+    fn scrape_memory_blocks_high_resident_bytes_without_webkit_footprint_telemetry() {
+        let budget =
+            (MIN_CRITICAL_MEMORY_BYTES * 70 / 100).saturating_sub(SCRAPE_MEMORY_HEADROOM_BYTES);
+        let stats = RuntimeMemoryStats {
+            total_physical_memory_bytes: 16 * BYTES_PER_GIB,
+            process_resident_bytes: 128,
+            process_footprint_bytes: Some(128),
+            process_virtual_bytes: 256,
+            app_resident_bytes: budget,
+            app_memory_pressure_bytes: budget - 1,
+            webkit_resident_bytes: Some(budget - 1),
+            webkit_footprint_bytes: None,
+            webkit_virtual_bytes: None,
+            webkit_process_id: Some(123),
+            webkit_total_resident_bytes: budget - 1,
+            webkit_total_footprint_bytes: None,
+            webkit_process_count: 1,
+            webkit_largest_resident_bytes: Some(budget - 1),
+            webkit_largest_footprint_bytes: None,
+            webkit_largest_process_id: Some(123),
+            webkit_largest_cpu_usage: Some(0.0),
+            webkit_largest_age_seconds: Some(10),
+            webkit_largest_role: Some("freed-webcontent".to_string()),
+            webkit_processes: Vec::new(),
+            webkit_telemetry_available: false,
+            indexed_db_bytes: None,
+            webkit_cache_bytes: None,
+            memory_high_bytes: MIN_CRITICAL_MEMORY_BYTES * 70 / 100,
+            memory_critical_bytes: MIN_CRITICAL_MEMORY_BYTES,
+            relay_doc_bytes: 0,
+            relay_client_count: 0,
+        };
+
+        assert!(!scrape_memory_may_proceed(&stats));
+        assert_eq!(scrape_memory_pressure_level(&stats), "high");
     }
 
     #[test]

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -3912,15 +3912,9 @@ fn scrape_resident_start_budget_bytes(stats: &RuntimeMemoryStats) -> u64 {
         .saturating_sub(SCRAPE_MEMORY_HEADROOM_BYTES)
 }
 
-fn scrape_resident_critical_budget_bytes(stats: &RuntimeMemoryStats) -> u64 {
-    stats
-        .memory_critical_bytes
-        .saturating_sub(SCRAPE_MEMORY_HEADROOM_BYTES)
-}
-
 fn scrape_memory_may_proceed(stats: &RuntimeMemoryStats) -> bool {
     stats.app_memory_pressure_bytes < scrape_memory_start_budget_bytes(stats)
-        && stats.app_resident_bytes < scrape_resident_critical_budget_bytes(stats)
+        && stats.app_resident_bytes < scrape_resident_start_budget_bytes(stats)
 }
 
 fn scrape_memory_pressure_level(stats: &RuntimeMemoryStats) -> &'static str {
@@ -9519,7 +9513,7 @@ mod tests {
     }
 
     #[test]
-    fn scrape_memory_degrades_resident_rss_at_high_budget_when_footprint_is_low() {
+    fn scrape_memory_blocks_resident_rss_at_start_budget_when_footprint_is_low() {
         let budget =
             (MIN_CRITICAL_MEMORY_BYTES * 70 / 100).saturating_sub(SCRAPE_MEMORY_HEADROOM_BYTES);
         let stats = RuntimeMemoryStats {
@@ -9558,15 +9552,15 @@ mod tests {
             app_memory_pressure_bytes: budget - 1,
             ..stats
         };
-        assert!(scrape_memory_may_proceed(&high_resident_stats));
+        assert!(!scrape_memory_may_proceed(&high_resident_stats));
         assert_eq!(scrape_memory_pressure_level(&high_resident_stats), "high");
         assert_eq!(
             social_scrape_plan_for_memory(&high_resident_stats, 6, 10),
             SocialScrapePlan {
-                min_passes: 2,
-                max_passes: 3,
+                min_passes: 0,
+                max_passes: 0,
                 skip_stories: true,
-                reason: "minimal-memory-margin",
+                reason: "blocked",
             }
         );
     }

--- a/packages/desktop/src/components/FacebookSettingsSection.tsx
+++ b/packages/desktop/src/components/FacebookSettingsSection.tsx
@@ -579,7 +579,10 @@ export function FacebookSettingsSection({
             </p>
           )}
 
-          <ProviderHealthSectionSummary provider="facebook" showMessages={surface === "debug-card"} />
+          <ProviderHealthSectionSummary
+            provider="facebook"
+            showMessages={surface === "debug-card" && !syncError && !actionError}
+          />
 
           {statusLine}
 
@@ -738,7 +741,10 @@ export function FacebookSettingsSection({
         {actionError && !needsReconnect && (
           <p className="text-xs text-red-400 leading-relaxed">{actionError}</p>
         )}
-        <ProviderHealthSectionSummary provider="facebook" showMessages={surface === "debug-card"} />
+        <ProviderHealthSectionSummary
+          provider="facebook"
+          showMessages={surface === "debug-card" && !actionError}
+        />
       </div>
     </SyncProviderSectionSurface>
     {dialog}

--- a/packages/desktop/src/components/InstagramSettingsSection.tsx
+++ b/packages/desktop/src/components/InstagramSettingsSection.tsx
@@ -330,7 +330,10 @@ export function InstagramSettingsSection({
             </p>
           )}
 
-          <ProviderHealthSectionSummary provider="instagram" showMessages={surface === "debug-card"} />
+          <ProviderHealthSectionSummary
+            provider="instagram"
+            showMessages={surface === "debug-card" && !syncError && !actionError}
+          />
 
           {statusLine}
 
@@ -404,7 +407,10 @@ export function InstagramSettingsSection({
         {actionError && !needsReconnect && (
           <p className="text-xs text-red-400 leading-relaxed">{actionError}</p>
         )}
-        <ProviderHealthSectionSummary provider="instagram" showMessages={surface === "debug-card"} />
+        <ProviderHealthSectionSummary
+          provider="instagram"
+          showMessages={surface === "debug-card" && !actionError}
+        />
       </div>
     </SyncProviderSectionSurface>
     {dialog}

--- a/packages/desktop/src/components/LinkedInSettingsSection.tsx
+++ b/packages/desktop/src/components/LinkedInSettingsSection.tsx
@@ -322,7 +322,10 @@ export function LinkedInSettingsSection({
             </p>
           )}
 
-          <ProviderHealthSectionSummary provider="linkedin" showMessages={surface === "debug-card"} />
+          <ProviderHealthSectionSummary
+            provider="linkedin"
+            showMessages={surface === "debug-card" && !syncError && !actionError}
+          />
 
           {statusLine}
 
@@ -389,7 +392,10 @@ export function LinkedInSettingsSection({
         {actionError && !needsReconnect && (
           <p className="text-xs text-red-400 leading-relaxed">{actionError}</p>
         )}
-        <ProviderHealthSectionSummary provider="linkedin" showMessages={surface === "debug-card"} />
+        <ProviderHealthSectionSummary
+          provider="linkedin"
+          showMessages={surface === "debug-card" && !actionError}
+        />
       </div>
     </SyncProviderSectionSurface>
     {dialog}

--- a/packages/desktop/src/components/XSettingsSection.tsx
+++ b/packages/desktop/src/components/XSettingsSection.tsx
@@ -377,7 +377,10 @@ export function XSettingsSection({
             </p>
           )}
 
-          <ProviderHealthSectionSummary provider="x" showMessages={surface === "debug-card"} />
+          <ProviderHealthSectionSummary
+            provider="x"
+            showMessages={surface === "debug-card" && !syncError && !actionError}
+          />
 
           {statusLine}
 
@@ -511,7 +514,10 @@ export function XSettingsSection({
         >
           Manual cookie setup
         </button>
-        <ProviderHealthSectionSummary provider="x" showMessages={surface === "debug-card"} />
+        <ProviderHealthSectionSummary
+          provider="x"
+          showMessages={surface === "debug-card" && !actionError}
+        />
       </div>
     </SyncProviderSectionSurface>
     {dialog}

--- a/packages/desktop/src/components/provider-settings-status-copy.test.ts
+++ b/packages/desktop/src/components/provider-settings-status-copy.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const componentDir = join(process.cwd(), "src/components");
+const socialSettingsSources = [
+  "FacebookSettingsSection.tsx",
+  "InstagramSettingsSection.tsx",
+  "LinkedInSettingsSection.tsx",
+  "XSettingsSection.tsx",
+].map((file) => readFileSync(join(componentDir, file), "utf8"));
+
+describe("provider settings status copy", () => {
+  it("suppresses health messages when a primary sync error is visible", () => {
+    for (const source of socialSettingsSources) {
+      expect(source).toContain("<ProviderHealthSectionSummary");
+      expect(source).toContain('showMessages={surface === "debug-card" && !syncError && !actionError}');
+    }
+  });
+});

--- a/packages/desktop/src/lib/automerge-state-patches.test.ts
+++ b/packages/desktop/src/lib/automerge-state-patches.test.ts
@@ -140,6 +140,36 @@ describe("Automerge item patch state updates", () => {
     expect(result.state.totalArchivableCount).toBe(state.totalArchivableCount);
   });
 
+  it("adds new items with ranked order metadata without a full state update", () => {
+    const unread = makeItem("rss:unread");
+    const read = makeItem("rss:read", { readAt: 10 });
+    const state = makeState([unread, read]);
+    const index = createItemIndex(state.items);
+    const added = makeItem("rss:new");
+
+    const result = applyItemPatchesToState(state, [{ item: added }], index, {
+      orderedItemIds: ["rss:new", "rss:unread", "rss:read"],
+      searchCorpusVersion: 2,
+      docItemCount: 3,
+    });
+
+    expect(result.state.items.map((item) => item.globalId)).toEqual([
+      "rss:new",
+      "rss:unread",
+      "rss:read",
+    ]);
+    expect(result.itemIndex.get("rss:new")).toBe(0);
+    expect(result.state.searchCorpusVersion).toBe(2);
+    expect(result.state.docItemCount).toBe(3);
+    expect(result.state.totalUnreadCount).toBe(2);
+    expect(result.state.unreadCountByPlatform).toEqual({ rss: 2 });
+    expect(result.state.feedUnreadCounts).toEqual({ [FEED_URL]: 2 });
+    expect(result.state.totalItemCount).toBe(3);
+    expect(result.state.itemCountByPlatform).toEqual({ rss: 3 });
+    expect(result.state.feedTotalCounts).toEqual({ [FEED_URL]: 3 });
+    expect(result.state.totalArchivableCount).toBe(1);
+  });
+
   it("keeps a synced X like patch count-neutral and in place", () => {
     const { rssSource: _rssSource, ...baseXPost } = makeItem("x:2049705418436600244");
     const xPost = {

--- a/packages/desktop/src/lib/automerge-state-patches.ts
+++ b/packages/desktop/src/lib/automerge-state-patches.ts
@@ -97,8 +97,26 @@ export function applyItemPatchesToState(
   state: DocState,
   patches: FeedItemPatch[],
   itemIndex: ItemIndex,
+  options: {
+    orderedItemIds?: string[];
+    searchCorpusVersion?: number;
+    docItemCount?: number;
+  } = {},
 ): { state: DocState; itemIndex: ItemIndex } {
-  if (patches.length === 0) return { state, itemIndex };
+  if (patches.length === 0 && !options.orderedItemIds) {
+    const metadataChanged =
+      options.searchCorpusVersion !== undefined || options.docItemCount !== undefined;
+    return metadataChanged
+      ? {
+          state: {
+            ...state,
+            searchCorpusVersion: options.searchCorpusVersion ?? state.searchCorpusVersion,
+            docItemCount: options.docItemCount ?? state.docItemCount,
+          },
+          itemIndex,
+        }
+      : { state, itemIndex };
+  }
 
   let nextItems: FeedItem[] | null = null;
   let counts: CountState | null = null;
@@ -148,10 +166,43 @@ export function applyItemPatchesToState(
     }
   }
 
-  if (!nextItems) return { state, itemIndex };
+  const itemsForOrdering = nextItems as FeedItem[] | null;
+  if (itemsForOrdering && options.orderedItemIds) {
+    const itemById = new Map<string, FeedItem>(
+      itemsForOrdering.map((item) => [item.globalId, item]),
+    );
+    const reorderedItems: FeedItem[] = [];
+    for (const globalId of options.orderedItemIds) {
+      const item = itemById.get(globalId);
+      if (!item) continue;
+      reorderedItems.push(item);
+      itemById.delete(globalId);
+    }
+    if (reorderedItems.length > 0) {
+      nextItems = [...reorderedItems, ...itemById.values()];
+      indexNeedsRebuild = true;
+    }
+  }
+
+  if (!nextItems) {
+    return {
+      state: {
+        ...state,
+        searchCorpusVersion: options.searchCorpusVersion ?? state.searchCorpusVersion,
+        docItemCount: options.docItemCount ?? state.docItemCount,
+      },
+      itemIndex,
+    };
+  }
   const nextIndex = indexNeedsRebuild ? createItemIndex(nextItems) : itemIndex;
+  const metadataState = {
+    searchCorpusVersion: options.searchCorpusVersion ?? state.searchCorpusVersion,
+    docItemCount: options.docItemCount ?? state.docItemCount,
+  };
   return {
-    state: counts ? applyCountState({ ...state, items: nextItems }, counts) : { ...state, items: nextItems },
+    state: counts
+      ? applyCountState({ ...state, ...metadataState, items: nextItems }, counts)
+      : { ...state, ...metadataState, items: nextItems },
     itemIndex: nextIndex,
   };
 }

--- a/packages/desktop/src/lib/automerge-types.ts
+++ b/packages/desktop/src/lib/automerge-types.ts
@@ -161,7 +161,15 @@ export type WorkerResponse =
   /** Preference-only mutation that avoids cloning, ranking, and hydrating every feed item. */
   | { type: "PREFERENCES_PATCH"; updates: Partial<UserPreferences>; mutation?: WorkerRequest["type"] }
   /** Small mutation update that avoids cloning and hydrating the full document. */
-  | { type: "ITEM_PATCH"; patches: FeedItemPatch[]; changedItemIds: string[]; mutation?: WorkerRequest["type"] }
+  | {
+      type: "ITEM_PATCH";
+      patches: FeedItemPatch[];
+      changedItemIds: string[];
+      mutation?: WorkerRequest["type"];
+      orderedItemIds?: string[];
+      searchCorpusVersion?: number;
+      docItemCount?: number;
+    }
   /** RSS feed metadata mutation that avoids hydrating every feed item. */
   | { type: "FEEDS_PATCH"; patch: RssFeedPatch; mutation?: WorkerRequest["type"] }
   /** Debug panel event forwarding */

--- a/packages/desktop/src/lib/automerge-worker-memory.test.ts
+++ b/packages/desktop/src/lib/automerge-worker-memory.test.ts
@@ -167,10 +167,27 @@ describe("automerge worker memory routing", () => {
   });
 
   it("compacts oversized feed text before item writes", () => {
-    for (const caseName of ["ADD_FEED_ITEM", "ADD_FEED_ITEMS", "BATCH_REFRESH_FEEDS", "BATCH_IMPORT_ITEMS"]) {
+    for (const caseName of ["ADD_FEED_ITEM", "BATCH_REFRESH_FEEDS", "BATCH_IMPORT_ITEMS"]) {
       expect(caseBody(caseName)).toContain("compactFeedItemTextForSync");
     }
+    expect(workerSource).toContain("async function applyAddFeedItemsPatchChange");
+    expect(workerSource).toContain("compactFeedItemTextForSync(item)");
     expect(caseBody("UPDATE_FEED_ITEM")).toContain("compactFeedItemTextForSync(item)");
+  });
+
+  it("batch item writes use item patches unless social dedup rewrites existing records", () => {
+    const body = caseBody("ADD_FEED_ITEMS");
+
+    expect(body).toContain("applyAddFeedItemsPatchChange(req.items, trace)");
+    expect(body).not.toContain("applyRequestChange");
+    expect(body).not.toContain("saveAndBroadcast");
+    expect(workerSource).toContain("async function applyAddFeedItemsPatchChange");
+    expect(workerSource).toContain("await persistAndBroadcastWithoutHydration(trace)");
+    expect(workerSource).toContain("type: \"ITEM_PATCH\"");
+    expect(workerSource).toContain("orderedItemIds");
+    expect(workerSource).toContain("searchCorpusVersion");
+    expect(workerSource).toContain("docItemCount");
+    expect(workerSource).toContain("reason=social_dedup");
   });
 
   it("last sync persists without rehydrating the full document", () => {

--- a/packages/desktop/src/lib/automerge.ts
+++ b/packages/desktop/src/lib/automerge.ts
@@ -327,7 +327,11 @@ function handleWorkerMessage(event: MessageEvent<WorkerResponse>) {
   if (msg.type === "ITEM_PATCH") {
     if (!lastDocState) return;
     const changedItems = msg.patches.map((patch) => patch.item);
-    const patched = applyItemPatchesToState(lastDocState, msg.patches, lastItemIndexById);
+    const patched = applyItemPatchesToState(lastDocState, msg.patches, lastItemIndexById, {
+      orderedItemIds: msg.orderedItemIds,
+      searchCorpusVersion: msg.searchCorpusVersion,
+      docItemCount: msg.docItemCount,
+    });
     lastItemIndexById = patched.itemIndex;
     publishState(patched.state, {
       source: "item_patch",

--- a/packages/desktop/src/lib/automerge.worker.ts
+++ b/packages/desktop/src/lib/automerge.worker.ts
@@ -456,6 +456,22 @@ function healUntitledFeedTitles(doc: FreedDoc): number {
   return changed;
 }
 
+function rankedVisibleItemIdsFromDoc(doc: FreedDoc): string[] {
+  const preferences = mergeDefaultPreferences(doc.preferences as Partial<UserPreferences> | undefined);
+  const persons = doc.persons as Record<string, Person> | undefined;
+  const accounts = doc.accounts as Record<string, Account> | undefined;
+  const visibleItems = (Object.values(doc.feedItems ?? {}) as FeedItem[])
+    .filter((item) => !item.userState.hidden)
+    .sort((a, b) => b.publishedAt - a.publishedAt);
+
+  return sortByPriority(
+    rankFeedItems(visibleItems, preferences.weights, {
+      persons: persons ?? {},
+      accounts: accounts ?? {},
+    }),
+  ).map((item) => item.globalId);
+}
+
 /**
  * Convert the Automerge proxy document to a plain-JS DocState for postMessage.
  * Build the projection incrementally so large synced article bodies are
@@ -770,6 +786,65 @@ async function applyItemPatchChange(
   }
 }
 
+async function applyAddFeedItemsPatchChange(items: FeedItem[], trace?: RequestTrace): Promise<void> {
+  if (!currentDoc) throw new Error("Document not initialized");
+  let changedIds: string[] = [];
+  let dedupedCount = 0;
+  currentDoc = A.change(currentDoc, `Add ${items.length.toLocaleString()} feed items`, (doc) => {
+    for (const item of items) {
+      compactFeedItemTextForSync(item);
+      if (doc.feedItems[item.globalId]) continue;
+      addFeedItem(doc, item);
+      changedIds.push(item.globalId);
+    }
+    if (items.some((item) => item.platform === "facebook" || item.platform === "instagram")) {
+      dedupedCount = deduplicateDocFeedItems(doc);
+    }
+  });
+
+  if (changedIds.length === 0 && dedupedCount === 0) {
+    emitWorkerTrace(
+      `[automerge-worker] skip op=${trace?.opType ?? "unknown"} reason=no_changes`,
+      "change",
+    );
+    return;
+  }
+
+  bumpSearchCorpusVersion();
+  send({
+    type: "DEBUG_EVENT",
+    kind: "change",
+    detail: `Add ${items.length.toLocaleString()} feed items: ${changedIds.length.toLocaleString()} changed`,
+  });
+
+  if (dedupedCount > 0) {
+    emitWorkerTrace(
+      `[automerge-worker] full-hydrate op=${trace?.opType ?? "unknown"} reason=social_dedup deleted=${dedupedCount.toLocaleString()}`,
+    );
+    await saveAndBroadcast(trace);
+    return;
+  }
+
+  await persistAndBroadcastWithoutHydration(trace);
+  const doc = currentDoc;
+  const patches = changedIds
+    .map((globalId) => doc?.feedItems[globalId] as FeedItem | undefined)
+    .filter((item): item is FeedItem => Boolean(item))
+    .map((item) => ({ item: cloneFeedItemForPatch(item) }));
+
+  if (patches.length > 0) {
+    send({
+      type: "ITEM_PATCH",
+      patches,
+      changedItemIds: changedIds,
+      orderedItemIds: doc ? rankedVisibleItemIdsFromDoc(doc) : undefined,
+      searchCorpusVersion,
+      docItemCount: doc ? Object.keys(doc.feedItems ?? {}).length : undefined,
+      mutation: trace?.opType,
+    });
+  }
+}
+
 async function handleRequest(
   req: WorkerRequest,
   enqueuedAt: number,
@@ -1017,15 +1092,7 @@ async function handleRequest(
         break;
 
       case "ADD_FEED_ITEMS":
-        await applyRequestChange((doc) => {
-          for (const item of req.items) {
-            compactFeedItemTextForSync(item);
-            if (!doc.feedItems[item.globalId]) addFeedItem(doc, item);
-          }
-          if (req.items.some((item) => item.platform === "facebook" || item.platform === "instagram")) {
-            deduplicateDocFeedItems(doc);
-          }
-        }, `Add ${req.items.length} feed items`, true);
+        await applyAddFeedItemsPatchChange(req.items, trace);
         ack(req.reqId);
         break;
 

--- a/packages/desktop/src/lib/background-runtime-coordinator.test.ts
+++ b/packages/desktop/src/lib/background-runtime-coordinator.test.ts
@@ -351,4 +351,28 @@ describe("background runtime coordinator", () => {
       reason: "waiting_for_renderer_heartbeat:0",
     });
   });
+
+  it("resumes jobs after renderer recovery reports healthy heartbeats", async () => {
+    const coordinator = await loadCoordinator();
+    coordinator.resetBackgroundRuntimeForTests({ requireRendererHealth: true });
+    coordinator.noteRendererHeartbeat(heartbeat(1));
+    coordinator.noteRendererHeartbeat(heartbeat(2));
+
+    coordinator.noteRendererRecoveryState({
+      phase: "recovery_attempt",
+      reason: "renderer event loop lag high",
+    });
+
+    coordinator.noteRendererHeartbeat(heartbeat(3));
+    coordinator.noteRendererHeartbeat(heartbeat(4));
+
+    expect(coordinator.canStartBackgroundJob("social-scrape")).toEqual({ ok: true });
+    await expect(
+      coordinator.runBackgroundJob({
+        kind: "social-scrape",
+        source: "instagram:feed",
+        run: () => "scraped",
+      }),
+    ).resolves.toBe("scraped");
+  });
 });

--- a/packages/desktop/src/lib/background-runtime-coordinator.ts
+++ b/packages/desktop/src/lib/background-runtime-coordinator.ts
@@ -57,6 +57,7 @@ const DEFAULT_TIMEOUT_MS = 120_000;
 
 let healthyHeartbeats = 0;
 let cooldownUntil = 0;
+let cooldownReason: string | null = null;
 let safeModeUntil = 0;
 let lastRecoveryPhase: string | null = null;
 let lastRecoveryReason: string | null = null;
@@ -161,6 +162,7 @@ function waitForActiveJobChange(timeoutMs: number): Promise<void> {
 
 function markCooldown(durationMs: number, reason: string): void {
   cooldownUntil = Math.max(cooldownUntil, nowMs() + durationMs);
+  cooldownReason = reason;
   const message = `[background-runtime] paused reason=${reason} cooldown_ms=${durationMs.toLocaleString()}`;
   log.warn(message);
   addDebugEvent("error", message);
@@ -168,6 +170,13 @@ function markCooldown(durationMs: number, reason: string): void {
 
 export function noteRendererHeartbeat(_payload: RendererHeartbeatNote): void {
   healthyHeartbeats += 1;
+  if (
+    healthyHeartbeats >= REQUIRED_HEALTHY_HEARTBEATS &&
+    cooldownReason?.startsWith("renderer_")
+  ) {
+    cooldownUntil = 0;
+    cooldownReason = null;
+  }
 }
 
 export function noteRendererRecovery(reason: string): void {
@@ -315,6 +324,7 @@ export async function runBackgroundJob<T>(task: BackgroundRuntimeTask<T>): Promi
 export function resetBackgroundRuntimeForTests(options?: { requireRendererHealth?: boolean }): void {
   healthyHeartbeats = 0;
   cooldownUntil = 0;
+  cooldownReason = null;
   safeModeUntil = 0;
   lastRecoveryPhase = null;
   lastRecoveryReason = null;

--- a/packages/desktop/src/lib/fb-auth.ts
+++ b/packages/desktop/src/lib/fb-auth.ts
@@ -11,6 +11,7 @@ import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { selectPlatformUA, clearPlatformUA } from "./user-agent";
 import { log } from "./logger";
 import { safeUnlisten } from "./safe-unlisten";
+import { clearTransientLastCaptureError } from "./social-auth-transient-errors";
 
 export interface FbAuthState {
   isAuthenticated: boolean;
@@ -96,7 +97,7 @@ export async function disconnectFb(): Promise<void> {
  * Persist auth state to localStorage for fast startup.
  */
 export function storeFbAuthState(state: FbAuthState): void {
-  localStorage.setItem(FB_AUTH_KEY, JSON.stringify(state));
+  localStorage.setItem(FB_AUTH_KEY, JSON.stringify(clearTransientLastCaptureError(state)));
 }
 
 /**
@@ -108,7 +109,7 @@ export function initFbAuth(): FbAuthState {
   if (!stored) return { isAuthenticated: false };
   try {
     const parsed = JSON.parse(stored) as FbAuthState;
-    return {
+    return clearTransientLastCaptureError({
       isAuthenticated: !!parsed.isAuthenticated,
       lastCheckedAt: parsed.lastCheckedAt,
       lastCapturedAt: parsed.lastCapturedAt,
@@ -116,7 +117,7 @@ export function initFbAuth(): FbAuthState {
       pausedUntil: parsed.pausedUntil,
       pauseReason: parsed.pauseReason,
       pauseLevel: parsed.pauseLevel,
-    };
+    });
   } catch {
     return { isAuthenticated: false };
   }

--- a/packages/desktop/src/lib/fb-capture.ts
+++ b/packages/desktop/src/lib/fb-capture.ts
@@ -720,7 +720,7 @@ export async function captureFbFeed(): Promise<FbSyncResult> {
       await upsertMediaVaultRosterFromItems("facebook", filteredItems);
       const archivedCount = await archiveRecentProviderMedia(
         "facebook",
-        useAppStore.getState().items.filter((i) => i.platform === "facebook"),
+        filteredItems,
       );
       if (archivedCount > 0) {
         addDebugEvent(

--- a/packages/desktop/src/lib/instagram-auth.ts
+++ b/packages/desktop/src/lib/instagram-auth.ts
@@ -10,6 +10,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { selectPlatformUA, clearPlatformUA } from "./user-agent";
 import { safeUnlisten } from "./safe-unlisten";
+import { clearTransientLastCaptureError } from "./social-auth-transient-errors";
 
 export interface IgAuthState {
   isAuthenticated: boolean;
@@ -85,7 +86,7 @@ export async function disconnectIg(): Promise<void> {
  * Persist auth state to localStorage for fast startup.
  */
 export function storeIgAuthState(state: IgAuthState): void {
-  localStorage.setItem(IG_AUTH_KEY, JSON.stringify(state));
+  localStorage.setItem(IG_AUTH_KEY, JSON.stringify(clearTransientLastCaptureError(state)));
 }
 
 /**
@@ -97,7 +98,7 @@ export function initIgAuth(): IgAuthState {
   if (!stored) return { isAuthenticated: false };
   try {
     const parsed = JSON.parse(stored) as IgAuthState;
-    return {
+    return clearTransientLastCaptureError({
       isAuthenticated: !!parsed.isAuthenticated,
       lastCheckedAt: parsed.lastCheckedAt,
       lastCapturedAt: parsed.lastCapturedAt,
@@ -105,7 +106,7 @@ export function initIgAuth(): IgAuthState {
       pausedUntil: parsed.pausedUntil,
       pauseReason: parsed.pauseReason,
       pauseLevel: parsed.pauseLevel,
-    };
+    });
   } catch {
     return { isAuthenticated: false };
   }

--- a/packages/desktop/src/lib/instagram-capture.ts
+++ b/packages/desktop/src/lib/instagram-capture.ts
@@ -417,7 +417,7 @@ export async function captureIgFeed(): Promise<IgSyncResult> {
       await upsertMediaVaultRosterFromItems("instagram", result.items);
       const archivedCount = await archiveRecentProviderMedia(
         "instagram",
-        useAppStore.getState().items.filter((i) => i.platform === "instagram"),
+        result.items,
       );
       if (archivedCount > 0) {
         addDebugEvent(

--- a/packages/desktop/src/lib/instagram-capture.ts
+++ b/packages/desktop/src/lib/instagram-capture.ts
@@ -175,6 +175,18 @@ function formatInstagramEmptySyncMessage(diag: IgSyncDiag): string {
     : "Instagram feed returned 0 posts.";
 }
 
+function errorMessageFromUnknown(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function applyInstagramPlaceholderDiag(diag: IgSyncDiag, error: unknown): boolean {
+  const message = errorMessageFromUnknown(error);
+  if (!message.startsWith("placeholder_feed:")) return false;
+  diag.errorStage = "placeholder_feed";
+  diag.errorMessage = message.replace(/^placeholder_feed:\s*/, "");
+  return true;
+}
+
 // =============================================================================
 // Core scrape trigger
 // =============================================================================
@@ -284,8 +296,11 @@ export async function fetchIgFeed(): Promise<IgSyncResult> {
     if (applyNativeMemoryPressureDiag(diag, err, "instagram")) {
       return { items: [], diag };
     }
+    if (applyInstagramPlaceholderDiag(diag, err)) {
+      return { items: [], diag };
+    }
     diag.errorStage = "invoke";
-    diag.errorMessage = err instanceof Error ? err.message : String(err);
+    diag.errorMessage = errorMessageFromUnknown(err);
     return { items: [], diag };
   } finally {
     safeUnlisten(unlisten, "ig-feed-data");

--- a/packages/desktop/src/lib/provider-health.test.ts
+++ b/packages/desktop/src/lib/provider-health.test.ts
@@ -519,4 +519,26 @@ describe("provider health", () => {
     expect(provider?.lastError).toBeUndefined();
     expect(provider?.currentMessage).toBeUndefined();
   });
+
+  it("drops stale runtime-deferred provider attempts from visible status", async () => {
+    vi.useFakeTimers();
+    const now = new Date("2026-04-02T19:15:00.000Z");
+    vi.setSystemTime(now);
+
+    const { mod, debugStore } = await loadProviderHealthModule();
+
+    await mod.recordProviderHealthEvent({
+      provider: "instagram",
+      outcome: "error",
+      stage: "runtime_deferred",
+      reason: "background work is paused for 113949 ms while renderer safe mode is active",
+      finishedAt: now.getTime() - 16 * 60 * 1_000,
+    });
+
+    const provider = debugStore.useDebugStore.getState().health?.providers.instagram;
+    expect(provider?.status).toBe("idle");
+    expect(provider?.lastOutcome).toBeUndefined();
+    expect(provider?.lastError).toBeUndefined();
+    expect(provider?.currentMessage).toBeUndefined();
+  });
 });

--- a/packages/desktop/src/lib/provider-health.ts
+++ b/packages/desktop/src/lib/provider-health.ts
@@ -850,12 +850,29 @@ function isMemoryPressureAttempt(attempt: ProviderHealthAttempt): boolean {
   );
 }
 
+function isRuntimeDeferredAttempt(attempt: ProviderHealthAttempt): boolean {
+  const reason = attempt.reason?.toLocaleLowerCase() ?? "";
+  return (
+    attempt.stage === "runtime_deferred" ||
+    reason.includes("runtime_deferred") ||
+    reason.includes("renderer safe mode") ||
+    reason.includes("background work is paused") ||
+    reason.includes("background work is cooling down") ||
+    reason.includes("app window to report healthy") ||
+    reason.includes("app recovers")
+  );
+}
+
+function isTransientStatusAttempt(attempt: ProviderHealthAttempt): boolean {
+  return isMemoryPressureAttempt(attempt) || isRuntimeDeferredAttempt(attempt);
+}
+
 function latestStatusAttempt(
   providerState: PersistedProviderHealth,
   now = Date.now(),
 ): ProviderHealthAttempt | undefined {
   return providerState.latestAttempts.find((attempt) => {
-    if (!isMemoryPressureAttempt(attempt)) return true;
+    if (!isTransientStatusAttempt(attempt)) return true;
     return now - attempt.finishedAt <= TRANSIENT_MEMORY_PRESSURE_STATUS_MS;
   });
 }

--- a/packages/desktop/src/lib/provider-status-transient.test.ts
+++ b/packages/desktop/src/lib/provider-status-transient.test.ts
@@ -51,6 +51,33 @@ describe("provider status transient failures", () => {
     ).toBe("Sync looks healthy right now.");
   });
 
+  it("does not turn stale renderer safe-mode auth errors into sidebar warnings", () => {
+    const authError =
+      "background work is paused for 113949 ms while renderer safe mode is active";
+
+    expect(
+      getProviderStatusTone({
+        isConnected: true,
+        authError,
+        snapshot: snapshot({ status: "healthy" }),
+      }),
+    ).toBe("healthy");
+    expect(
+      getProviderStatusLabel({
+        isConnected: true,
+        authError,
+        snapshot: snapshot({ status: "healthy" }),
+      }),
+    ).toBe("Connected");
+    expect(
+      getProviderStatusDetail({
+        isConnected: true,
+        authError,
+        snapshot: snapshot({ status: "healthy" }),
+      }),
+    ).toBe("Sync looks healthy right now.");
+  });
+
   it("still warns while memory pressure is the active provider snapshot", () => {
     const currentMessage =
       "Facebook sync did not start because Freed Desktop memory is high. App RSS is 2.62 GB after cleanup.";

--- a/packages/desktop/src/lib/social-auth-transient-errors.ts
+++ b/packages/desktop/src/lib/social-auth-transient-errors.ts
@@ -1,0 +1,8 @@
+import { isTransientProviderIssue } from "@freed/ui/lib/provider-status";
+
+export function clearTransientLastCaptureError<
+  T extends { lastCaptureError?: string },
+>(state: T): T {
+  if (!isTransientProviderIssue(state.lastCaptureError)) return state;
+  return { ...state, lastCaptureError: undefined };
+}

--- a/packages/desktop/src/lib/social-capture-hot-path.test.ts
+++ b/packages/desktop/src/lib/social-capture-hot-path.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const fbSource = readFileSync(join(process.cwd(), "src/lib/fb-capture.ts"), "utf8");
+const igSource = readFileSync(join(process.cwd(), "src/lib/instagram-capture.ts"), "utf8");
+
+describe("social capture hot paths", () => {
+  it("archives continuous media from the current sync batch only", () => {
+    expect(fbSource).toContain(
+      'archiveRecentProviderMedia(\n        "facebook",\n        filteredItems,',
+    );
+    expect(igSource).toContain(
+      'archiveRecentProviderMedia(\n        "instagram",\n        result.items,',
+    );
+  });
+});

--- a/packages/desktop/src/lib/social-capture-memory-pressure.test.ts
+++ b/packages/desktop/src/lib/social-capture-memory-pressure.test.ts
@@ -798,6 +798,47 @@ describe("social capture completion", () => {
     );
   });
 
+  it("records Instagram placeholder feed recovery failures with a specific stage", async () => {
+    mocks.prepareSocialScrapeMemory.mockResolvedValue({
+      before: {},
+      after: { appResidentBytes: 512 * 1024 * 1024 },
+      recycledScraperWindows: false,
+      cacheTrimmed: false,
+      mayProceed: true,
+    });
+    mocks.listen.mockResolvedValue(vi.fn());
+    mocks.invoke.mockImplementation(async (command: string) => {
+      if (command === "ig_scrape_feed") {
+        throw new Error(
+          "placeholder_feed: Instagram loaded placeholder feed articles after one refresh. ready_articles=0, tiny_articles=2, articles=2, scroll_height=1,199",
+        );
+      }
+      return null;
+    });
+
+    const { captureIgFeed } = await import("./instagram-capture");
+    const { recordProviderHealthEvent } = await import("./provider-health");
+
+    const result = await captureIgFeed();
+
+    expect(result.items).toEqual([]);
+    expect(result.diag.errorStage).toBe("placeholder_feed");
+    expect(result.diag.errorMessage).toContain(
+      "Instagram loaded placeholder feed articles after one refresh",
+    );
+    expect(mocks.storeState.setError).toHaveBeenCalledWith(
+      expect.stringContaining("placeholder feed articles"),
+    );
+    expect(recordProviderHealthEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "instagram",
+        outcome: "error",
+        stage: "placeholder_feed",
+        reason: expect.stringContaining("placeholder feed articles"),
+      }),
+    );
+  });
+
   it("does not poison Instagram health when a provider scrape is already active", async () => {
     mocks.prepareSocialScrapeMemory.mockResolvedValue({
       before: {},

--- a/packages/desktop/src/lib/store-startup-migrations.test.ts
+++ b/packages/desktop/src/lib/store-startup-migrations.test.ts
@@ -149,11 +149,24 @@ describe("store startup migrations", () => {
     localStorage.clear();
   });
 
-  it("defers content signal backfill instead of running it during launch", async () => {
+  it("defers startup maintenance instead of running it during launch", async () => {
     const { useAppStore } = await import("./store");
 
     await useAppStore.getState().initialize();
     await vi.advanceTimersByTimeAsync(0);
+
+    expect(mockDocHealUntitledFeedTitles).not.toHaveBeenCalled();
+    expect(mockDocDeduplicateFeedItems).not.toHaveBeenCalled();
+    expect(mockDocPruneArchivedItems).not.toHaveBeenCalled();
+    expect(mockDocBackfillContentSignals).not.toHaveBeenCalled();
+    expect(mockRunBackgroundJob).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(15 * 60 * 1000 - 1);
+    expect(mockDocHealUntitledFeedTitles).not.toHaveBeenCalled();
+    expect(mockDocDeduplicateFeedItems).not.toHaveBeenCalled();
+    expect(mockDocPruneArchivedItems).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
 
     expect(mockDocHealUntitledFeedTitles).toHaveBeenCalledTimes(1);
     expect(mockDocDeduplicateFeedItems).toHaveBeenCalledTimes(1);

--- a/packages/desktop/src/lib/store.ts
+++ b/packages/desktop/src/lib/store.ts
@@ -76,6 +76,7 @@ import { initLiAuth, storeLiAuthState, type LiAuthState } from "./li-auth";
 import { reconcileSocialAuthStateHints } from "./social-auth-cookie-state";
 
 let outboxTeardown: (() => void) | null = null;
+let startupMaintenanceTimer: ReturnType<typeof setTimeout> | null = null;
 let startupContentSignalTimer: ReturnType<typeof setTimeout> | null = null;
 let startupContentSignalBackfillRunning = false;
 
@@ -285,10 +286,12 @@ async function pruneConnectionPersonIfNeeded(
 }
 
 /**
- * Run idempotent startup migrations in the background after the app renders.
+ * Run idempotent startup migrations after the app survives launch.
  * subscribe() is already wired up at call time, so any doc mutations propagate
  * to the UI automatically. Errors are swallowed - all three ops are non-fatal.
- * Migrations now run in the worker (zero main-thread cost).
+ * Migrations run in the worker, but WebKit still owns worker memory. Delaying
+ * them keeps large libraries from immediately reloading the Automerge document
+ * right after first paint.
  */
 async function runStartupMigrations(archivePruneDays: number): Promise<void> {
   try {
@@ -316,6 +319,7 @@ function hasStoredCloudSyncCredentials(): boolean {
   }
 }
 
+const STARTUP_MAINTENANCE_INITIAL_DELAY_MS = 15 * 60 * 1000;
 const READ_MARK_BATCH_DELAY_MS = 50;
 const pendingReadIds = new Set<string>();
 let readMarkBatchTimer: ReturnType<typeof setTimeout> | null = null;
@@ -358,6 +362,14 @@ const STARTUP_CONTENT_SIGNAL_INITIAL_DELAY_MS = 10 * 60 * 1000;
 const STARTUP_CONTENT_SIGNAL_RETRY_DELAY_MS = 30 * 1000;
 const STARTUP_CONTENT_SIGNAL_INTERVAL_MS = 60 * 1000;
 const STARTUP_CONTENT_SIGNAL_BATCH_SIZE = 50;
+
+function scheduleStartupMigrations(archivePruneDays: number): void {
+  if (startupMaintenanceTimer) return;
+  startupMaintenanceTimer = setTimeout(() => {
+    startupMaintenanceTimer = null;
+    void runStartupMigrations(archivePruneDays);
+  }, STARTUP_MAINTENANCE_INITIAL_DELAY_MS);
+}
 
 function scheduleStartupContentSignalBackfill(delayMs: number): void {
   if (startupContentSignalTimer) return;
@@ -575,7 +587,10 @@ export const useAppStore = create<AppState>((set, get) => ({
 
       // Do not mutate the local doc before cloud sync has reconciled it.
       if (!hasStoredCloudSyncCredentials()) {
-        void runStartupMigrations(docState.preferences.display.archivePruneDays ?? 30);
+        // Run cleanup migrations later. On large local libraries, immediate
+        // maintenance can force another full Automerge load while the renderer is
+        // still recovering from initial hydration.
+        scheduleStartupMigrations(docState.preferences.display.archivePruneDays ?? 30);
       }
     } catch (error) {
       recordRuntimeError({ source: "desktop:initialize", error, fatal: false });

--- a/packages/ui/src/hooks/useContactSync.test.tsx
+++ b/packages/ui/src/hooks/useContactSync.test.tsx
@@ -329,4 +329,59 @@ describe("useContactSync", () => {
 
     expect(fetchContacts).toHaveBeenCalledOnce();
   });
+
+  it("skips automatic focus syncs during the launch grace period", async () => {
+    localStorage.setItem(CONTACT_SYNC_STORAGE_KEY, JSON.stringify({
+      authStatus: "connected",
+      syncStatus: "idle",
+      syncStartedAt: null,
+      syncToken: "stale-token",
+      lastSyncedAt: Date.now() - 60 * 60 * 1000,
+      cachedContacts: [],
+      pendingSuggestions: [],
+      dismissedSuggestionIds: [],
+      createdFriendCount: 0,
+    }));
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    const fetchContacts = vi.fn(async () => ({ contacts: [], nextSyncToken: "next-token", deleted: [] }));
+    const platformValue = {
+      store: <T,>(selector: (state: unknown) => T): T => selector({
+        persons: {},
+        accounts: {},
+        items: [],
+        setPendingMatchCount: vi.fn(),
+      }),
+      googleContacts: {
+        getToken: vi.fn(async () => "google-access-token"),
+        connect: vi.fn(async () => {}),
+        fetchContacts,
+      },
+    } as unknown as PlatformConfig;
+
+    await act(async () => {
+      root.render(
+        <PlatformProvider value={platformValue}>
+          <ContactSyncHarness onReady={() => {}} />
+        </PlatformProvider>,
+      );
+    });
+
+    await act(async () => {
+      window.dispatchEvent(new Event("focus"));
+      await Promise.resolve();
+    });
+
+    expect(fetchContacts).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+      window.dispatchEvent(new Event("focus"));
+    });
+
+    expect(fetchContacts).toHaveBeenCalledOnce();
+  });
 });

--- a/packages/ui/src/hooks/useContactSync.ts
+++ b/packages/ui/src/hooks/useContactSync.ts
@@ -20,6 +20,7 @@ import { usePlatform } from "../context/PlatformContext.js";
 const SYNC_INTERVAL_MS = 15 * 60 * 1000;
 const CONTACT_SYNC_TIMEOUT_MS = 60 * 1000;
 const STALE_SYNCING_MS = 2 * CONTACT_SYNC_TIMEOUT_MS;
+const FOCUS_SYNC_LAUNCH_GRACE_MS = 5 * 60 * 1000;
 
 async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
   let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
@@ -143,6 +144,7 @@ export function useContactSync() {
   syncStateRef.current = syncState;
   const matchesRef = useRef<Map<string, ContactMatch>>(new Map());
   const syncPromiseRef = useRef<Promise<ContactSyncState> | null>(null);
+  const mountedAtRef = useRef(Date.now());
 
   useEffect(() => {
     setPendingMatchCount(syncState.pendingSuggestions.length);
@@ -277,6 +279,7 @@ export function useContactSync() {
   useEffect(() => {
     if (!googleContacts) return undefined;
     const onFocus = () => {
+      if (Date.now() - mountedAtRef.current < FOCUS_SYNC_LAUNCH_GRACE_MS) return;
       void runSync();
     };
     window.addEventListener("focus", onFocus);

--- a/packages/ui/src/lib/provider-status.ts
+++ b/packages/ui/src/lib/provider-status.ts
@@ -65,6 +65,23 @@ export function isTransientMemoryPressureIssue(error?: string | null): boolean {
   return normalized.includes("memory is high") && normalized.includes("after cleanup");
 }
 
+export function isTransientRuntimeDeferredIssue(error?: string | null): boolean {
+  if (!error) return false;
+  const normalized = error.toLocaleLowerCase();
+  return (
+    normalized.includes("runtime_deferred") ||
+    normalized.includes("renderer safe mode") ||
+    normalized.includes("background work is paused") ||
+    normalized.includes("background work is cooling down") ||
+    normalized.includes("app window to report healthy") ||
+    normalized.includes("app recovers")
+  );
+}
+
+export function isTransientProviderIssue(error?: string | null): boolean {
+  return isTransientMemoryPressureIssue(error) || isTransientRuntimeDeferredIssue(error);
+}
+
 export function getProviderStatusTone({
   isConnected,
   authError,
@@ -77,7 +94,7 @@ export function getProviderStatusTone({
   if (hasAuthLikeIssue(authError)) {
     return "critical";
   }
-  const usableAuthError = isTransientMemoryPressureIssue(authError)
+  const usableAuthError = isTransientProviderIssue(authError)
     ? undefined
     : authError;
 
@@ -142,7 +159,7 @@ export function getProviderStatusDetail({
   if (snapshot?.currentMessage) {
     return snapshot.currentMessage;
   }
-  const usableAuthError = isTransientMemoryPressureIssue(authError)
+  const usableAuthError = isTransientProviderIssue(authError)
     ? undefined
     : authError;
 


### PR DESCRIPTION
(AI Generated).

## Diagnosis
- Production diagnostics showed social sync running while Freed-owned WebKit RSS had climbed into multi-GB territory, including a renderer heartbeat stall with WebKit RSS near 9.8 GB.
- The native scrape planner could still select a minimal feed plan when resident-memory headroom had effectively reached zero, so social sync could continue after the UI was already under pressure.
- The renderer watchdog was recovering visible renderers after short event-loop lag spikes, then logging post-reset fields that made the recovery look like it happened with 0 ms lag.
- Older builds persisted runtime-deferred provider warnings in auth state, so Facebook, Instagram, and LinkedIn could still look blocked after the current runtime was already healthy.
- Instagram can load a placeholders-only feed state. That needed one safe same-URL refresh and a distinct `placeholder_feed` diagnostic instead of silently returning 0 posts.

## Summary
- Route batch feed item additions through item patches with ranked ID ordering instead of full state hydration when social dedup does not rewrite records.
- Enforce resident-memory scrape headroom before social sync proceeds, and limit continuous Facebook and Instagram media vault scans to the current batch.
- Treat reclaimable WebKit RSS as a tail when deciding whether social sync can start, while still logging both real RSS and effective resident pressure.
- Delay startup maintenance and contact auto-sync so heavy local work does not compete with early social sync.
- Raise visible-renderer event-loop recovery to sustained 45s lag, preserve pre-reset recovery diagnostics, and clear runtime cooldown only after healthy heartbeats.
- Clear stale runtime-deferred auth errors on Facebook and Instagram auth hydration, and hide stale safe-mode messages from provider status once current runtime health is clean.
- Add Instagram placeholders-only refresh and `placeholder_feed` diagnostics so future 0-post runs identify the real failure mode.

## Installed app evidence
- Built and installed the generated `/Applications/Freed.app` from this branch. The local `.app`, DMG, and updater tarball were produced. The build then hit the expected updater signing-key failure because this machine does not have `TAURI_SIGNING_PRIVATE_KEY`.
- After reinstall, the installed app pulled new local content while staying responsive: total content reached 10,569 items, Facebook reached 18 / 156, and Instagram reached 8 / 61 in the sidebar.
- Runtime soak showed event-loop lag around 3 to 5 ms, no safe mode, no renderer recoveries, and no background pause.
- Native memory telemetry showed sync pressure rising during provider work and then dropping from about 996 MB to about 261 MB without blocking the app.

## Testing
- npm run validate:feature
- cargo test --lib, from `packages/desktop/src-tauri`
- Vitest focused: `background-runtime-coordinator`, `social-capture-memory-pressure`, `renderer-heartbeat`, `provider-status-transient`, and `provider-health`
- npm run tauri:build, produced local app bundles, then failed only at updater signing because the private signing key is not installed locally
