### PR TITLE
fix: slim map view side gradients

### DIFF
--- a/packages/desktop/tests/e2e/theme-switching.spec.ts
+++ b/packages/desktop/tests/e2e/theme-switching.spec.ts
@@ -173,6 +173,27 @@ test("map view repaints across all themes without using the old canvas filter", 
   await page.getByRole("button", { name: /^Map/ }).click();
   await expect(page.getByTestId("map-surface")).toBeVisible({ timeout: 10_000 });
 
+  await expect.poll(async () => {
+    return page.evaluate(() => {
+      const mapSurface = document.querySelector('[data-testid="map-surface"]');
+      const sidebar = document.querySelector('[data-testid="app-sidebar"]');
+      if (!(mapSurface instanceof HTMLElement)) return null;
+      if (!(sidebar instanceof HTMLElement)) return null;
+
+      const rect = mapSurface.getBoundingClientRect();
+      const sidebarRect = sidebar.getBoundingClientRect();
+      return {
+        leftGapPx: Math.round(rect.left - sidebarRect.right),
+        rightGapPx: Math.round(window.innerWidth - rect.right),
+        bottomGapPx: Math.round(window.innerHeight - rect.bottom),
+      };
+    });
+  }).toEqual({
+    leftGapPx: 0,
+    rightGapPx: 0,
+    bottomGapPx: 0,
+  });
+
   await page.evaluate((width) => {
     const mapSurface = document.querySelector('[data-testid="map-surface"]') as HTMLElement | null;
     if (!mapSurface) {
@@ -188,6 +209,22 @@ test("map view repaints across all themes without using the old canvas filter", 
     mapSurface.style.maxHeight = "654px";
   }, stableMapSurfaceWidth);
   await page.waitForTimeout(100);
+
+  await expect.poll(async () => {
+    return page.evaluate(() => {
+      const overlay = document.querySelector(".freed-map-edge-overlay");
+      if (!(overlay instanceof HTMLElement)) return null;
+
+      const backgroundImage = window.getComputedStyle(overlay).backgroundImage;
+      return {
+        twentyPxStops: backgroundImage.match(/20px/g)?.length ?? 0,
+        fiftySixPxStops: backgroundImage.match(/56px/g)?.length ?? 0,
+      };
+    });
+  }).toEqual({
+    twentyPxStops: 6,
+    fiftySixPxStops: 6,
+  });
 
   const themeIds = ["ember", "neon", "midas", "scriptorium"] as const;
 
@@ -235,4 +272,109 @@ test("map view repaints across all themes without using the old canvas filter", 
       maxDiffPixelRatio: 0.02,
     });
   }
+});
+
+test("map view removes the left frame when the desktop sidebar is closed", async ({ app, page }) => {
+  await page.setViewportSize({ width: 900, height: 1390 });
+  await app.goto();
+  await app.waitForReady();
+  await app.seedFriendLocation();
+  await dismissCloudSyncNudgeIfPresent(page);
+
+  await page.getByRole("button", { name: /^Map/ }).click();
+  await expect(page.getByTestId("map-surface")).toBeVisible({ timeout: 10_000 });
+
+  await page.evaluate(async () => {
+    const w = window as Record<string, unknown>;
+    const store = w.__FREED_STORE__ as
+      | {
+          getState: () => {
+            updatePreferences: (patch: { display: { sidebarMode: "closed" } }) => Promise<void>;
+          };
+        }
+      | undefined;
+    await store?.getState().updatePreferences({
+      display: {
+        sidebarMode: "closed",
+      },
+    });
+  });
+
+  await expect(page.getByTestId("app-sidebar")).toHaveCount(0);
+
+  await expect.poll(async () => {
+    return page.evaluate(() => {
+      const mapSurface = document.querySelector('[data-testid="map-surface"]');
+      if (!(mapSurface instanceof HTMLElement)) return null;
+
+      const rect = mapSurface.getBoundingClientRect();
+      return {
+        leftGapPx: Math.round(rect.left),
+        rightGapPx: Math.round(window.innerWidth - rect.right),
+        bottomGapPx: Math.round(window.innerHeight - rect.bottom),
+      };
+    });
+  }).toEqual({
+    leftGapPx: 0,
+    rightGapPx: 0,
+    bottomGapPx: 0,
+  });
+});
+
+test("friends graph uses the same full-canvas edge frame as map view", async ({ app, page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await app.goto();
+  await app.waitForReady();
+  await app.seedFriendLocation();
+  await dismissCloudSyncNudgeIfPresent(page);
+
+  await page.evaluate(async () => {
+    const w = window as Record<string, unknown>;
+    const store = w.__FREED_STORE__ as
+      | {
+          getState: () => {
+            updatePreferences: (patch: { display: { friendsMode: "friends"; friendsSidebarOpen: boolean } }) => Promise<void>;
+            setActiveView: (view: string) => void;
+          };
+        }
+      | undefined;
+    await store?.getState().updatePreferences({
+      display: {
+        friendsMode: "friends",
+        friendsSidebarOpen: true,
+      },
+    });
+    store?.getState().setActiveView("friends");
+  });
+
+  await expect(page.getByTestId("friend-graph-viewport")).toBeVisible({ timeout: 10_000 });
+
+  await expect.poll(async () => {
+    return page.evaluate(() => {
+      const graph = document.querySelector('[data-testid="friend-graph-viewport"]');
+      const sidebar = document.querySelector('[data-testid="app-sidebar"]');
+      const handle = document.querySelector('[aria-label="Resize friends sidebar"]');
+      const header = document.querySelector("header");
+      if (!(graph instanceof HTMLElement)) return null;
+      if (!(sidebar instanceof HTMLElement)) return null;
+      if (!(handle instanceof HTMLElement)) return null;
+      if (!(header instanceof HTMLElement)) return null;
+
+      const graphRect = graph.getBoundingClientRect();
+      const sidebarRect = sidebar.getBoundingClientRect();
+      const handleRect = handle.getBoundingClientRect();
+      const headerRect = header.getBoundingClientRect();
+      return {
+        leftGapPx: Math.round(graphRect.left - sidebarRect.right),
+        topGapPx: Math.round(graphRect.top - headerRect.bottom),
+        rightGapPx: Math.round(handleRect.left - graphRect.right),
+        bottomGapPx: Math.round(window.innerHeight - graphRect.bottom),
+      };
+    });
+  }).toEqual({
+    leftGapPx: 0,
+    topGapPx: 0,
+    rightGapPx: 0,
+    bottomGapPx: 0,
+  });
 });

--- a/packages/ui/src/components/friends/FriendsView.tsx
+++ b/packages/ui/src/components/friends/FriendsView.tsx
@@ -1716,7 +1716,7 @@ export function FriendsView({
   return (
     <div className="app-theme-shell flex h-full flex-col overflow-hidden">
       <div
-        className={`relative flex min-h-0 flex-1 pt-[var(--feed-card-gap,8px)] ${isMobile ? "flex-col" : "flex-row"}`}
+        className={`relative flex min-h-0 flex-1 ${isMobile ? "flex-col pt-[var(--feed-card-gap,8px)]" : "flex-row"}`}
       >
         {showGraphSurface ? (
           <div className="relative min-h-0 min-w-0 flex-1">

--- a/packages/ui/src/components/layout/AppShell.tsx
+++ b/packages/ui/src/components/layout/AppShell.tsx
@@ -98,6 +98,12 @@ export function AppShell({ children }: AppShellProps) {
   const [dragWidth, setDragWidth] = useState<number | null>(null);
   const [committedDebugWidth, setCommittedDebugWidth] = useState(persistedDebugWidth);
   const [desktopSidebarMode, setDesktopSidebarMode] = useState<SidebarMode>(persistedDesktopSidebarMode);
+  const usesFullCanvasFrame = activeView === "map" || activeView === "friends";
+  const contentFrameSpacingClass = usesFullCanvasFrame
+    ? desktopSidebarMode === "closed"
+      ? ""
+      : "pl-[var(--feed-card-gap,8px)]"
+    : "px-[var(--feed-card-gap,8px)] pb-[var(--feed-card-gap,8px)]";
   const [desktopSidebarDisplayMode, setDesktopSidebarDisplayMode] = useState<SidebarMode>(persistedDesktopSidebarMode);
   const dragging = useRef(false);
   const pendingPersistedDebugWidth = useRef<number | null>(null);
@@ -406,7 +412,7 @@ export function AppShell({ children }: AppShellProps) {
         />
 
         <div
-          className={`relative z-10 flex flex-1 px-[var(--feed-card-gap,8px)] pb-[var(--feed-card-gap,8px)] ${
+          className={`relative z-10 flex flex-1 ${contentFrameSpacingClass} ${
             isMobileDevice ? "" : "min-h-0 overflow-hidden"
           }`}
         >
@@ -416,6 +422,7 @@ export function AppShell({ children }: AppShellProps) {
             desktopMode={desktopSidebarMode}
             onDesktopModeChange={persistDesktopSidebarMode}
             onDesktopDisplayModeChange={setDesktopSidebarDisplayMode}
+            desktopGapWidthPx={usesFullCanvasFrame ? 0 : undefined}
           />
           <main
             className={`min-w-0 flex-1 ${isMobileDevice ? "" : "min-h-0 overflow-hidden"}`}

--- a/packages/ui/src/components/layout/Sidebar.tsx
+++ b/packages/ui/src/components/layout/Sidebar.tsx
@@ -227,6 +227,7 @@ interface SidebarProps {
   desktopMode: SidebarMode;
   onDesktopModeChange: (nextMode: SidebarMode) => void;
   onDesktopDisplayModeChange?: (nextMode: SidebarMode) => void;
+  desktopGapWidthPx?: number;
 }
 
 function SidebarSection({
@@ -573,6 +574,7 @@ export function Sidebar({
   desktopMode,
   onDesktopModeChange,
   onDesktopDisplayModeChange,
+  desktopGapWidthPx,
 }: SidebarProps) {
   const { SourceIndicator, syncRssNow, syncSourceNow, getSourceStatus } = usePlatform();
   const isMobileViewport = useIsMobile();
@@ -718,9 +720,11 @@ export function Sidebar({
           ? DEFAULT_WIDTH
           : committedWidth);
   const effectiveGapWidthPx =
-    activeView === "friends"
-      ? FRIENDS_SIDEBAR_GAP_WIDTH_PX
-      : PRIMARY_SIDEBAR_GAP_WIDTH_PX;
+    desktopGapWidthPx ?? (
+      activeView === "friends"
+        ? FRIENDS_SIDEBAR_GAP_WIDTH_PX
+        : PRIMARY_SIDEBAR_GAP_WIDTH_PX
+    );
   const compactReaderRailVisible =
     activeView === "feed" &&
     !!selectedItemId &&

--- a/packages/ui/src/components/map/MapSurface.tsx
+++ b/packages/ui/src/components/map/MapSurface.tsx
@@ -53,6 +53,8 @@ const MAP_POPUP_VIEWPORT_MARGIN = 40;
 const MAP_DOM_MARKER_LIMIT = 160;
 const MAP_MOVING_MARKER_PAINT_LIMIT = 24;
 const MAP_DENSE_MARKER_RESTORE_DELAY_MS = 420;
+const MAP_EDGE_TOP_BOTTOM_FADE_PX = 56;
+const MAP_EDGE_SIDE_FADE_PX = 20;
 const MAP_VIEWPORT_MASK_STYLE = {
   "--theme-soft-viewport-mask-size": "20px",
 } as CSSProperties;
@@ -560,44 +562,44 @@ function fallbackScanBackground(background: string, water: string) {
 function mapEdgeVignetteBackground() {
   return `
     radial-gradient(
-      56px 56px at 0% 0%,
+      ${MAP_EDGE_SIDE_FADE_PX}px ${MAP_EDGE_TOP_BOTTOM_FADE_PX}px at 0% 0%,
       rgb(var(--theme-shell-rgb) / 0.18) 0%,
       transparent 76%
     ),
     radial-gradient(
-      56px 56px at 100% 0%,
+      ${MAP_EDGE_SIDE_FADE_PX}px ${MAP_EDGE_TOP_BOTTOM_FADE_PX}px at 100% 0%,
       rgb(var(--theme-shell-rgb) / 0.18) 0%,
       transparent 76%
     ),
     radial-gradient(
-      56px 56px at 0% 100%,
+      ${MAP_EDGE_SIDE_FADE_PX}px ${MAP_EDGE_TOP_BOTTOM_FADE_PX}px at 0% 100%,
       rgb(var(--theme-shell-rgb) / 0.18) 0%,
       transparent 76%
     ),
     radial-gradient(
-      56px 56px at 100% 100%,
+      ${MAP_EDGE_SIDE_FADE_PX}px ${MAP_EDGE_TOP_BOTTOM_FADE_PX}px at 100% 100%,
       rgb(var(--theme-shell-rgb) / 0.18) 0%,
       transparent 76%
     ),
     linear-gradient(
       to bottom,
       rgb(var(--theme-shell-rgb) / 0.22) 0%,
-      transparent 56px
+      transparent ${MAP_EDGE_TOP_BOTTOM_FADE_PX}px
     ),
     linear-gradient(
       to top,
       rgb(var(--theme-shell-rgb) / 0.22) 0%,
-      transparent 56px
+      transparent ${MAP_EDGE_TOP_BOTTOM_FADE_PX}px
     ),
     linear-gradient(
       to right,
       rgb(var(--theme-shell-rgb) / 0.22) 0%,
-      transparent 56px
+      transparent ${MAP_EDGE_SIDE_FADE_PX}px
     ),
     linear-gradient(
       to left,
       rgb(var(--theme-shell-rgb) / 0.22) 0%,
-      transparent 56px
+      transparent ${MAP_EDGE_SIDE_FADE_PX}px
     )
   `;
 }


### PR DESCRIPTION
(AI Generated).

## Summary
- Remove the feed layout right and bottom gutter for Map View so the map surface reaches the viewport edge under the header.
- Let Map View and the Friends graph collapse the desktop sidebar shell gap so full-canvas surfaces start at the sidebar rail edge.
- Remove the remaining Map View left frame when the desktop sidebar is closed.
- Remove the desktop Friends graph top inset so its soft viewport sits flush under the shared toolbar, while keeping the mobile inset.
- Keep the smooth existing map edge fade values and add focused e2e coverage for zero Map and Friends graph viewport gaps.

## Testing
- npm run test:e2e -- theme-switching.spec.ts --grep "map view repaints|map view removes|friends graph uses"
- npm run validate:feature