### PR TITLE
fix: prevent cloud startup pruning before sync

### DIFF
--- a/packages/desktop/src/lib/store-startup-migrations.test.ts
+++ b/packages/desktop/src/lib/store-startup-migrations.test.ts
@@ -141,10 +141,12 @@ describe("store startup migrations", () => {
     mockStartOutboxProcessor.mockReset();
     mockStartOutboxProcessor.mockReturnValue(() => {});
     mockSubscribe.mockClear();
+    localStorage.clear();
   });
 
   afterEach(() => {
     vi.useRealTimers();
+    localStorage.clear();
   });
 
   it("defers content signal backfill instead of running it during launch", async () => {
@@ -171,5 +173,21 @@ describe("store startup migrations", () => {
       }),
     );
     expect(mockDocBackfillContentSignals).toHaveBeenCalledWith(50);
+  });
+
+  it("does not run cleanup migrations before cloud sync catches up", async () => {
+    localStorage.setItem("freed_cloud_token_meta_gdrive", JSON.stringify({
+      accessToken: "token",
+      expiresAt: Date.now() + 120_000,
+    }));
+    const { useAppStore } = await import("./store");
+
+    await useAppStore.getState().initialize();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(mockDocHealUntitledFeedTitles).not.toHaveBeenCalled();
+    expect(mockDocDeduplicateFeedItems).not.toHaveBeenCalled();
+    expect(mockDocPruneArchivedItems).not.toHaveBeenCalled();
+    expect(mockDocBackfillContentSignals).not.toHaveBeenCalled();
   });
 });

--- a/packages/desktop/src/lib/store.ts
+++ b/packages/desktop/src/lib/store.ts
@@ -305,6 +305,17 @@ async function runStartupMigrations(archivePruneDays: number): Promise<void> {
   scheduleStartupContentSignalBackfill(STARTUP_CONTENT_SIGNAL_INITIAL_DELAY_MS);
 }
 
+function hasStoredCloudSyncCredentials(): boolean {
+  try {
+    return (
+      localStorage.getItem("freed_cloud_token_meta_gdrive") !== null ||
+      localStorage.getItem("freed_cloud_token_meta_dropbox") !== null
+    );
+  } catch {
+    return false;
+  }
+}
+
 const READ_MARK_BATCH_DELAY_MS = 50;
 const pendingReadIds = new Set<string>();
 let readMarkBatchTimer: ReturnType<typeof setTimeout> | null = null;
@@ -562,8 +573,10 @@ export const useAppStore = create<AppState>((set, get) => ({
         async (id, syncedAt) => { await docConfirmSeenSynced(id, syncedAt); },
       );
 
-      // Run cleanup migrations in the background via worker.
-      void runStartupMigrations(docState.preferences.display.archivePruneDays ?? 30);
+      // Do not mutate the local doc before cloud sync has reconciled it.
+      if (!hasStoredCloudSyncCredentials()) {
+        void runStartupMigrations(docState.preferences.display.archivePruneDays ?? 30);
+      }
     } catch (error) {
       recordRuntimeError({ source: "desktop:initialize", error, fatal: false });
       recordBugReportEvent("desktop:initialize", "error", "Initialization failed");

--- a/packages/pwa/src/lib/automerge-types.ts
+++ b/packages/pwa/src/lib/automerge-types.ts
@@ -89,6 +89,7 @@ export type WorkerRequest =
   | { reqId: number; type: "ADD_STUB_ITEM"; url: string; tags: string[] }
   | { reqId: number; type: "BACKFILL_CONTENT_SIGNALS"; batchSize?: number }
   | { reqId: number; type: "MERGE_DOC"; binary: Uint8Array }
+  | { reqId: number; type: "GET_DOC_BINARY" }
   | { reqId: number; type: "CLEAR_LOCAL" };
 
 // ---------------------------------------------------------------------------
@@ -99,7 +100,8 @@ export type WorkerResponse =
   /** Simple acknowledgement for mutations that return void */
   | { reqId: number; type: "ACK"; error?: string }
   /** Broadcast on every doc mutation — main thread uses this to update UI */
-  | { type: "STATE_UPDATE"; state: DocState; binary: Uint8Array }
+  | { type: "STATE_UPDATE"; state: DocState; binary?: Uint8Array }
+  | { reqId: number; type: "DOC_BINARY"; binary: Uint8Array }
   /** Debug panel event forwarding */
   | { type: "DEBUG_EVENT"; kind: string; detail?: string; bytes?: number }
   /** Doc size snapshot for the debug panel */

--- a/packages/pwa/src/lib/automerge.ts
+++ b/packages/pwa/src/lib/automerge.ts
@@ -70,6 +70,13 @@ const pendingSampleDataClear = new Map<
     reject: (err: Error) => void;
   }
 >();
+const pendingDocBinary = new Map<
+  number,
+  {
+    resolve: (binary: Uint8Array) => void;
+    reject: (err: Error) => void;
+  }
+>();
 
 async function request(msg: WorkerRequest): Promise<void> {
   await workerReady;
@@ -79,8 +86,7 @@ async function request(msg: WorkerRequest): Promise<void> {
   });
 }
 
-// Latest binary from the worker — updated on every STATE_UPDATE.
-// Returned synchronously by getDocBinary() so sync.ts callers are unchanged.
+// Latest binary fetched from the worker for the debug escape hatch.
 let lastBinary: Uint8Array | null = null;
 let lastDocState: DocState | null = null;
 let initPromise: Promise<DocState> | null = null;
@@ -107,9 +113,18 @@ worker.onmessage = (event: MessageEvent<WorkerResponse>) => {
   if (msg.type === "READY") return;
 
   if (msg.type === "STATE_UPDATE") {
-    lastBinary = msg.binary;
+    if (msg.binary) lastBinary = msg.binary;
     lastDocState = msg.state;
     for (const sub of subscribers) sub(msg.state);
+    return;
+  }
+
+  if (msg.type === "DOC_BINARY") {
+    const pendingBinary = pendingDocBinary.get(msg.reqId);
+    if (!pendingBinary) return;
+    pendingDocBinary.delete(msg.reqId);
+    lastBinary = msg.binary;
+    pendingBinary.resolve(msg.binary);
     return;
   }
 
@@ -160,6 +175,13 @@ worker.onmessage = (event: MessageEvent<WorkerResponse>) => {
     return;
   }
 
+  const pendingBinary = pendingDocBinary.get(msg.reqId);
+  if (pendingBinary && msg.error) {
+    pendingDocBinary.delete(msg.reqId);
+    pendingBinary.reject(new Error(msg.error));
+    return;
+  }
+
   const p = pending.get(msg.reqId);
   if (!p) return;
   pending.delete(msg.reqId);
@@ -197,7 +219,7 @@ function sendInit(): Promise<DocState> {
     const stateHandler = (event: MessageEvent<WorkerResponse>) => {
       const msg = event.data;
       if (msg.type === "STATE_UPDATE" && !initialState) {
-        lastBinary = msg.binary;
+        if (msg.binary) lastBinary = msg.binary;
         lastDocState = msg.state;
         initialState = msg.state;
         tryResolve();
@@ -237,9 +259,13 @@ export async function initDoc(): Promise<DocState> {
 }
 
 /** Binary snapshot of the current doc — used by sync.ts for relay/cloud upload. */
-export function getDocBinary(): Uint8Array {
-  if (!lastBinary) throw new Error("Document not initialized");
-  return lastBinary;
+export async function getDocBinary(): Promise<Uint8Array> {
+  await workerReady;
+  const reqId = nextReqId++;
+  return new Promise((resolve, reject) => {
+    pendingDocBinary.set(reqId, { resolve, reject });
+    worker.postMessage({ reqId, type: "GET_DOC_BINARY" } satisfies WorkerRequest);
+  });
 }
 
 /** Merge incoming sync binary into the doc (relay / cloud download). */

--- a/packages/pwa/src/lib/automerge.worker.ts
+++ b/packages/pwa/src/lib/automerge.worker.ts
@@ -274,9 +274,7 @@ async function saveAndBroadcast(): Promise<void> {
   };
   send(snapshot);
 
-  // binary is cloned by structured-clone on postMessage (not transferred) so
-  // the copy in storage.save() above is not affected.
-  const stateUpdate: WorkerResponse = { type: "STATE_UPDATE", state, binary };
+  const stateUpdate: WorkerResponse = { type: "STATE_UPDATE", state };
   send(stateUpdate);
 }
 
@@ -423,6 +421,12 @@ self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
           summary = clearSampleData(doc);
         }, "Clear sample data", true);
         send({ reqId: req.reqId, type: "SAMPLE_DATA_CLEAR_RESULT", summary });
+        break;
+      }
+
+      case "GET_DOC_BINARY": {
+        if (!currentDoc) throw new Error("Document not initialized");
+        send({ reqId: req.reqId, type: "DOC_BINARY", binary: A.save(currentDoc) });
         break;
       }
 

--- a/packages/pwa/src/lib/cloud-sync-auth-refresh.test.ts
+++ b/packages/pwa/src/lib/cloud-sync-auth-refresh.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const gdriveDownloadLatestMock = vi.fn();
 const gdriveStartPollLoopMock = vi.fn();
 const gdriveUploadSafeMock = vi.fn();
+const getDocBinaryMock = vi.fn();
 const initDocMock = vi.fn();
 const mergeDocMock = vi.fn();
 const addDebugEventMock = vi.fn();
@@ -22,7 +23,7 @@ vi.mock("@freed/sync/cloud", () => ({
 }));
 
 vi.mock("./automerge", () => ({
-  getDocBinary: vi.fn(() => new Uint8Array()),
+  getDocBinary: getDocBinaryMock,
   initDoc: initDocMock,
   mergeDoc: mergeDocMock,
   subscribe: subscribeMock,
@@ -40,6 +41,8 @@ describe("PWA cloud sync auth refresh", () => {
     gdriveDownloadLatestMock.mockReset();
     gdriveStartPollLoopMock.mockReset();
     gdriveUploadSafeMock.mockReset();
+    getDocBinaryMock.mockReset();
+    getDocBinaryMock.mockResolvedValue(new Uint8Array());
     initDocMock.mockReset();
     initDocMock.mockResolvedValue({});
     mergeDocMock.mockReset();
@@ -148,6 +151,34 @@ describe("PWA cloud sync auth refresh", () => {
       kind: "queued",
       message: "Manual sync requested.",
     }));
+  });
+
+  it("reads the upload binary after the manual merge completes", async () => {
+    const remote = new Uint8Array([1, 2, 3]);
+    const mergedBinary = new Uint8Array([4, 5, 6]);
+    gdriveDownloadLatestMock.mockResolvedValue(remote);
+    getDocBinaryMock.mockResolvedValue(mergedBinary);
+    gdriveUploadSafeMock.mockResolvedValue({
+      fileId: "file-1",
+      uploadedBytes: mergedBinary.byteLength,
+      remoteBytes: remote.byteLength,
+      mergedRemote: false,
+      uploadedBinary: mergedBinary,
+    });
+    localStorage.setItem("freed_cloud_token_meta_gdrive", JSON.stringify({
+      accessToken: "valid-access-token",
+      refreshToken: "refresh-token",
+      expiresAt: Date.now() + 120_000,
+    }));
+
+    const { syncCloudProviderNow } = await import("./sync");
+    await syncCloudProviderNow("gdrive");
+
+    expect(mergeDocMock).toHaveBeenCalledWith(remote);
+    expect(mergeDocMock.mock.invocationCallOrder[0]).toBeLessThan(
+      getDocBinaryMock.mock.invocationCallOrder[0],
+    );
+    expect(gdriveUploadSafeMock).toHaveBeenCalledWith("valid-access-token", mergedBinary);
   });
 
   it("uploads after local document changes while connected by Google Drive only", async () => {

--- a/packages/pwa/src/lib/store-startup.test.ts
+++ b/packages/pwa/src/lib/store-startup.test.ts
@@ -96,6 +96,7 @@ function makeBackfillSummary(
 describe("PWA store startup maintenance", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    localStorage.clear();
     useAppStore.setState(useAppStore.getInitialState(), true);
     automerge.initDoc.mockResolvedValue(makeDocState());
     automerge.docBackfillContentSignals.mockResolvedValue(makeBackfillSummary(0, 0));
@@ -117,6 +118,18 @@ describe("PWA store startup maintenance", () => {
     });
     expect(automerge.docBackfillContentSignals).toHaveBeenNthCalledWith(1, 200);
     expect(automerge.docBackfillContentSignals).toHaveBeenNthCalledWith(2, 200);
+  });
+
+  it("does not mutate the local document before cloud sync catches up", async () => {
+    localStorage.setItem("freed_cloud_provider", "gdrive");
+
+    await useAppStore.getState().initialize();
+
+    await vi.waitFor(() => {
+      expect(automerge.initDoc).toHaveBeenCalledTimes(1);
+    });
+    expect(automerge.docPruneArchivedItems).not.toHaveBeenCalled();
+    expect(automerge.docBackfillContentSignals).not.toHaveBeenCalled();
   });
 
   it("delegates sample data clearing to the worker", async () => {

--- a/packages/pwa/src/lib/store.ts
+++ b/packages/pwa/src/lib/store.ts
@@ -123,6 +123,18 @@ async function runStartupMigrations(archivePruneDays: number): Promise<void> {
   }
 }
 
+function hasStoredCloudSyncCredentials(): boolean {
+  try {
+    return (
+      localStorage.getItem("freed_cloud_provider") !== null ||
+      localStorage.getItem("freed_cloud_token_meta_gdrive") !== null ||
+      localStorage.getItem("freed_cloud_token_meta_dropbox") !== null
+    );
+  } catch {
+    return false;
+  }
+}
+
 export const useAppStore = create<AppState>((set, get) => ({
   // Initial state
   items: [],
@@ -200,10 +212,11 @@ export const useAppStore = create<AppState>((set, get) => ({
         isLoading: false,
       });
 
-      // Run idempotent maintenance in the background. The subscriber above
-      // propagates doc changes to the UI automatically.
-      const pruneDays = state.preferences.display.archivePruneDays ?? 30;
-      void runStartupMigrations(pruneDays);
+      // Do not mutate the local doc before cloud sync has reconciled it.
+      if (!hasStoredCloudSyncCredentials()) {
+        const pruneDays = state.preferences.display.archivePruneDays ?? 30;
+        void runStartupMigrations(pruneDays);
+      }
     } catch (error) {
       recordRuntimeError({ source: "pwa:initialize", error, fatal: false });
       recordBugReportEvent("pwa:initialize", "error", "Initialization failed");

--- a/packages/pwa/src/lib/sync.ts
+++ b/packages/pwa/src/lib/sync.ts
@@ -64,15 +64,16 @@ function notifyStatus(): void {
  */
 export function broadcastDoc(): void {
   if (ws && ws.readyState === WebSocket.OPEN) {
-    try {
-      const doc = getDocBinary();
-      ws.send(doc);
+    const socket = ws;
+    void getDocBinary().then((doc) => {
+      if (socket.readyState !== WebSocket.OPEN) return;
+      socket.send(doc);
       console.log("[Sync] Broadcast document (%d bytes)", doc.byteLength);
       addDebugEvent("sent", undefined, doc.byteLength);
-    } catch (error) {
+    }).catch((error) => {
       console.error("[Sync] Failed to broadcast:", error);
       addDebugEvent("error", error instanceof Error ? error.message : String(error));
-    }
+    });
   }
 
   // Cloud backup — debounced to batch rapid changes.
@@ -668,7 +669,7 @@ export function stopCloudSync(): void {
 
 async function performCloudUpload(provider: CloudProvider, token?: string): Promise<void> {
   await ensureDocumentReady();
-  const binary = getDocBinary();
+  const binary = await getDocBinary();
   try {
     const uploadToken = token ?? await getValidCloudToken(provider);
     if (!uploadToken) throw new Error("Cloud token missing. Reconnect the provider.");

--- a/packages/ui/src/components/DebugPanel.tsx
+++ b/packages/ui/src/components/DebugPanel.tsx
@@ -502,8 +502,8 @@ function DocumentTab() {
     setTimeout(() => setCopied(false), 2000);
   };
 
-  const downloadBinary = () => {
-    const binary = window.__freed?.getDocBinary?.();
+  const downloadBinary = async () => {
+    const binary = await window.__freed?.getDocBinary?.();
     if (!binary) return;
     // Ensure we have a plain ArrayBuffer to satisfy Blob's type constraint
     const blob = new Blob([binary.buffer instanceof ArrayBuffer ? binary.buffer : new Uint8Array(binary).buffer], { type: "application/octet-stream" });

--- a/packages/ui/src/lib/debug-store.ts
+++ b/packages/ui/src/lib/debug-store.ts
@@ -463,7 +463,7 @@ declare global {
     __freed: {
       getDoc?: () => unknown;
       getDocJson?: () => string;
-      getDocBinary?: () => Uint8Array;
+      getDocBinary?: () => Uint8Array | Promise<Uint8Array>;
       debug?: () => DebugState;
     };
   }
@@ -472,7 +472,7 @@ declare global {
 export function registerDocAccessors(
   getDoc: () => unknown,
   getDocJson: () => string,
-  getDocBinary: () => Uint8Array,
+  getDocBinary: () => Uint8Array | Promise<Uint8Array>,
 ): void {
   window.__freed = {
     ...window.__freed,


### PR DESCRIPTION
(AI Generated).

## Summary
- Skip startup maintenance when cloud credentials are present so local deletes cannot race the first cloud merge.
- Request PWA Automerge binaries from the worker only when upload or relay needs them, reducing iPhone memory pressure during Google Drive sync.
- Keep the debug binary download working with async worker-backed accessors.

## Testing
- npm run validate:feature