### PR TITLE
fix: render map as full background layer

### DIFF
--- a/packages/desktop/tests/e2e/theme-switching.spec.ts
+++ b/packages/desktop/tests/e2e/theme-switching.spec.ts
@@ -173,6 +173,27 @@ test("map view repaints across all themes without using the old canvas filter", 
   await page.getByRole("button", { name: /^Map/ }).click();
   await expect(page.getByTestId("map-surface")).toBeVisible({ timeout: 10_000 });
 
+  await expect.poll(async () => {
+    return page.evaluate(() => {
+      const mapSurface = document.querySelector('[data-testid="map-surface"]');
+      const sidebar = document.querySelector('[data-testid="app-sidebar"]');
+      if (!(mapSurface instanceof HTMLElement)) return null;
+      if (!(sidebar instanceof HTMLElement)) return null;
+
+      const rect = mapSurface.getBoundingClientRect();
+      const sidebarRect = sidebar.getBoundingClientRect();
+      return {
+        leftGapPx: Math.round(rect.left - sidebarRect.right),
+        rightGapPx: Math.round(window.innerWidth - rect.right),
+        bottomGapPx: Math.round(window.innerHeight - rect.bottom),
+      };
+    });
+  }).toEqual({
+    leftGapPx: 0,
+    rightGapPx: 0,
+    bottomGapPx: 0,
+  });
+
   await page.evaluate((width) => {
     const mapSurface = document.querySelector('[data-testid="map-surface"]') as HTMLElement | null;
     if (!mapSurface) {
@@ -188,6 +209,22 @@ test("map view repaints across all themes without using the old canvas filter", 
     mapSurface.style.maxHeight = "654px";
   }, stableMapSurfaceWidth);
   await page.waitForTimeout(100);
+
+  await expect.poll(async () => {
+    return page.evaluate(() => {
+      const overlay = document.querySelector(".freed-map-edge-overlay");
+      if (!(overlay instanceof HTMLElement)) return null;
+
+      const backgroundImage = window.getComputedStyle(overlay).backgroundImage;
+      return {
+        twentyPxStops: backgroundImage.match(/20px/g)?.length ?? 0,
+        fiftySixPxStops: backgroundImage.match(/56px/g)?.length ?? 0,
+      };
+    });
+  }).toEqual({
+    twentyPxStops: 6,
+    fiftySixPxStops: 6,
+  });
 
   const themeIds = ["ember", "neon", "midas", "scriptorium"] as const;
 
@@ -235,4 +272,109 @@ test("map view repaints across all themes without using the old canvas filter", 
       maxDiffPixelRatio: 0.02,
     });
   }
+});
+
+test("map view removes the left frame when the desktop sidebar is closed", async ({ app, page }) => {
+  await page.setViewportSize({ width: 900, height: 1390 });
+  await app.goto();
+  await app.waitForReady();
+  await app.seedFriendLocation();
+  await dismissCloudSyncNudgeIfPresent(page);
+
+  await page.getByRole("button", { name: /^Map/ }).click();
+  await expect(page.getByTestId("map-surface")).toBeVisible({ timeout: 10_000 });
+
+  await page.evaluate(async () => {
+    const w = window as Record<string, unknown>;
+    const store = w.__FREED_STORE__ as
+      | {
+          getState: () => {
+            updatePreferences: (patch: { display: { sidebarMode: "closed" } }) => Promise<void>;
+          };
+        }
+      | undefined;
+    await store?.getState().updatePreferences({
+      display: {
+        sidebarMode: "closed",
+      },
+    });
+  });
+
+  await expect(page.getByTestId("app-sidebar")).toHaveCount(0);
+
+  await expect.poll(async () => {
+    return page.evaluate(() => {
+      const mapSurface = document.querySelector('[data-testid="map-surface"]');
+      if (!(mapSurface instanceof HTMLElement)) return null;
+
+      const rect = mapSurface.getBoundingClientRect();
+      return {
+        leftGapPx: Math.round(rect.left),
+        rightGapPx: Math.round(window.innerWidth - rect.right),
+        bottomGapPx: Math.round(window.innerHeight - rect.bottom),
+      };
+    });
+  }).toEqual({
+    leftGapPx: 0,
+    rightGapPx: 0,
+    bottomGapPx: 0,
+  });
+});
+
+test("friends graph uses the same full-canvas edge frame as map view", async ({ app, page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await app.goto();
+  await app.waitForReady();
+  await app.seedFriendLocation();
+  await dismissCloudSyncNudgeIfPresent(page);
+
+  await page.evaluate(async () => {
+    const w = window as Record<string, unknown>;
+    const store = w.__FREED_STORE__ as
+      | {
+          getState: () => {
+            updatePreferences: (patch: { display: { friendsMode: "friends"; friendsSidebarOpen: boolean } }) => Promise<void>;
+            setActiveView: (view: string) => void;
+          };
+        }
+      | undefined;
+    await store?.getState().updatePreferences({
+      display: {
+        friendsMode: "friends",
+        friendsSidebarOpen: true,
+      },
+    });
+    store?.getState().setActiveView("friends");
+  });
+
+  await expect(page.getByTestId("friend-graph-viewport")).toBeVisible({ timeout: 10_000 });
+
+  await expect.poll(async () => {
+    return page.evaluate(() => {
+      const graph = document.querySelector('[data-testid="friend-graph-viewport"]');
+      const sidebar = document.querySelector('[data-testid="app-sidebar"]');
+      const handle = document.querySelector('[aria-label="Resize friends sidebar"]');
+      const header = document.querySelector("header");
+      if (!(graph instanceof HTMLElement)) return null;
+      if (!(sidebar instanceof HTMLElement)) return null;
+      if (!(handle instanceof HTMLElement)) return null;
+      if (!(header instanceof HTMLElement)) return null;
+
+      const graphRect = graph.getBoundingClientRect();
+      const sidebarRect = sidebar.getBoundingClientRect();
+      const handleRect = handle.getBoundingClientRect();
+      const headerRect = header.getBoundingClientRect();
+      return {
+        leftGapPx: Math.round(graphRect.left - sidebarRect.right),
+        topGapPx: Math.round(graphRect.top - headerRect.bottom),
+        rightGapPx: Math.round(handleRect.left - graphRect.right),
+        bottomGapPx: Math.round(window.innerHeight - graphRect.bottom),
+      };
+    });
+  }).toEqual({
+    leftGapPx: 0,
+    topGapPx: 0,
+    rightGapPx: 0,
+    bottomGapPx: 0,
+  });
 });

--- a/packages/desktop/tests/e2e/theme-switching.spec.ts
+++ b/packages/desktop/tests/e2e/theme-switching.spec.ts
@@ -176,23 +176,114 @@ test("map view repaints across all themes without using the old canvas filter", 
   await expect.poll(async () => {
     return page.evaluate(() => {
       const mapSurface = document.querySelector('[data-testid="map-surface"]');
+      const mapBackground = document.querySelector('[data-testid="map-background-layer"]');
+      const main = document.querySelector("main");
       const sidebar = document.querySelector('[data-testid="app-sidebar"]');
       if (!(mapSurface instanceof HTMLElement)) return null;
+      if (!(mapBackground instanceof HTMLElement)) return null;
+      if (!(main instanceof HTMLElement)) return null;
       if (!(sidebar instanceof HTMLElement)) return null;
 
       const rect = mapSurface.getBoundingClientRect();
+      const mainRect = main.getBoundingClientRect();
       const sidebarRect = sidebar.getBoundingClientRect();
+      const backgroundStyle = window.getComputedStyle(mapBackground);
       return {
-        leftGapPx: Math.round(rect.left - sidebarRect.right),
+        leftGapPx: Math.round(rect.left),
         rightGapPx: Math.round(window.innerWidth - rect.right),
         bottomGapPx: Math.round(window.innerHeight - rect.bottom),
+        foregroundLeftInsetPx: Math.round(Number.parseFloat(backgroundStyle.getPropertyValue("--freed-canvas-viewport-inset-left"))),
+        foregroundRightInsetPx: Math.round(Number.parseFloat(backgroundStyle.getPropertyValue("--freed-canvas-viewport-inset-right"))),
+        foregroundMatchesMainLeft: Math.round(mainRect.left - rect.left),
+        foregroundMatchesMainRight: Math.round(rect.right - mainRect.right),
+        sidebarLeftPx: Math.round(sidebarRect.left),
+        sidebarOverlapsMap: sidebarRect.left >= rect.left && sidebarRect.right <= rect.right,
       };
     });
   }).toEqual({
     leftGapPx: 0,
     rightGapPx: 0,
     bottomGapPx: 0,
+    foregroundLeftInsetPx: 272,
+    foregroundRightInsetPx: 8,
+    foregroundMatchesMainLeft: 272,
+    foregroundMatchesMainRight: 8,
+    sidebarLeftPx: 8,
+    sidebarOverlapsMap: true,
   });
+
+  await expect(page.locator(".freed-map-marker")).toBeVisible({ timeout: 20_000 });
+  await expect.poll(async () => {
+    return page.evaluate(() => {
+      const marker = document.querySelector(".freed-map-marker");
+      const main = document.querySelector("main");
+      if (!(marker instanceof HTMLElement)) return null;
+      if (!(main instanceof HTMLElement)) return null;
+
+      const markerRect = marker.getBoundingClientRect();
+      const mainRect = main.getBoundingClientRect();
+      const markerCenterX = markerRect.left + markerRect.width / 2;
+      const foregroundCenterX = mainRect.left + mainRect.width / 2;
+      return Math.round(Math.abs(markerCenterX - foregroundCenterX));
+    });
+  }, { timeout: 20_000 }).toBeLessThanOrEqual(24);
+
+  await page.evaluate(() => {
+    const w = window as Window & {
+      __freed?: {
+        debug?: () => { setVisible: (visible: boolean) => void };
+      };
+    };
+    w.__freed?.debug?.()?.setVisible(true);
+  });
+  await expect(page.getByTestId("debug-panel-drawer")).not.toHaveCSS("width", "0px", { timeout: 5_000 });
+  await expect.poll(async () => {
+    return page.evaluate(() => {
+      const marker = document.querySelector(".freed-map-marker");
+      const main = document.querySelector("main");
+      const mapBackground = document.querySelector('[data-testid="map-background-layer"]');
+      if (!(marker instanceof HTMLElement)) return null;
+      if (!(main instanceof HTMLElement)) return null;
+      if (!(mapBackground instanceof HTMLElement)) return null;
+
+      const markerRect = marker.getBoundingClientRect();
+      const mainRect = main.getBoundingClientRect();
+      const backgroundStyle = window.getComputedStyle(mapBackground);
+      const markerCenterX = markerRect.left + markerRect.width / 2;
+      const foregroundCenterX = mainRect.left + mainRect.width / 2;
+      return {
+        markerCenterDiffPx: Math.round(Math.abs(markerCenterX - foregroundCenterX)),
+        foregroundRightInsetPx: Math.round(Number.parseFloat(backgroundStyle.getPropertyValue("--freed-canvas-viewport-inset-right"))),
+      };
+    });
+  }, { timeout: 20_000 }).toEqual({
+    markerCenterDiffPx: expect.any(Number),
+    foregroundRightInsetPx: 340,
+  });
+  await expect.poll(async () => {
+    return page.evaluate(() => {
+      const marker = document.querySelector(".freed-map-marker");
+      const main = document.querySelector("main");
+      if (!(marker instanceof HTMLElement)) return null;
+      if (!(main instanceof HTMLElement)) return null;
+
+      const markerRect = marker.getBoundingClientRect();
+      const mainRect = main.getBoundingClientRect();
+      const markerCenterX = markerRect.left + markerRect.width / 2;
+      const foregroundCenterX = mainRect.left + mainRect.width / 2;
+      return Math.round(Math.abs(markerCenterX - foregroundCenterX));
+    });
+  }, { timeout: 20_000 }).toBeLessThanOrEqual(24);
+
+  await page.evaluate(() => {
+    const w = window as Window & {
+      __freed?: {
+        debug?: () => { setVisible: (visible: boolean) => void };
+      };
+    };
+    w.__freed?.debug?.()?.setVisible(false);
+  });
+  await expect(page.getByTestId("debug-panel-drawer")).toHaveCSS("width", "0px", { timeout: 5_000 });
 
   await page.evaluate((width) => {
     const mapSurface = document.querySelector('[data-testid="map-surface"]') as HTMLElement | null;
@@ -212,18 +303,20 @@ test("map view repaints across all themes without using the old canvas filter", 
 
   await expect.poll(async () => {
     return page.evaluate(() => {
-      const overlay = document.querySelector(".freed-map-edge-overlay");
-      if (!(overlay instanceof HTMLElement)) return null;
+      const mapSurface = document.querySelector('[data-testid="map-surface"]');
+      if (!(mapSurface instanceof HTMLElement)) return null;
 
-      const backgroundImage = window.getComputedStyle(overlay).backgroundImage;
+      const style = window.getComputedStyle(mapSurface);
       return {
-        twentyPxStops: backgroundImage.match(/20px/g)?.length ?? 0,
-        fiftySixPxStops: backgroundImage.match(/56px/g)?.length ?? 0,
+        edgeOverlayCount: document.querySelectorAll(".freed-map-edge-overlay").length,
+        maskImage: style.maskImage,
+        webkitMaskImage: style.webkitMaskImage,
       };
     });
   }).toEqual({
-    twentyPxStops: 6,
-    fiftySixPxStops: 6,
+    edgeOverlayCount: 0,
+    maskImage: "none",
+    webkitMaskImage: "none",
   });
 
   const themeIds = ["ember", "neon", "midas", "scriptorium"] as const;
@@ -274,6 +367,27 @@ test("map view repaints across all themes without using the old canvas filter", 
   }
 });
 
+test("top toolbar uses a single bottom border", async ({ app, page }) => {
+  await app.goto();
+  await app.waitForReady();
+
+  await expect.poll(async () => {
+    return page.evaluate(() => {
+      const toolbar = document.querySelector('[data-testid="workspace-toolbar"]');
+      if (!(toolbar instanceof HTMLElement)) return null;
+
+      const style = window.getComputedStyle(toolbar);
+      return {
+        borderBottomWidth: style.borderBottomWidth,
+        boxShadow: style.boxShadow,
+      };
+    });
+  }).toEqual({
+    borderBottomWidth: "1px",
+    boxShadow: "none",
+  });
+});
+
 test("map view removes the left frame when the desktop sidebar is closed", async ({ app, page }) => {
   await page.setViewportSize({ width: 900, height: 1390 });
   await app.goto();
@@ -321,7 +435,7 @@ test("map view removes the left frame when the desktop sidebar is closed", async
   });
 });
 
-test("friends graph uses the same full-canvas edge frame as map view", async ({ app, page }) => {
+test("friends graph controls align to the graph lane between sidebars", async ({ app, page }) => {
   await page.setViewportSize({ width: 1440, height: 900 });
   await app.goto();
   await app.waitForReady();
@@ -352,15 +466,20 @@ test("friends graph uses the same full-canvas edge frame as map view", async ({ 
   await expect.poll(async () => {
     return page.evaluate(() => {
       const graph = document.querySelector('[data-testid="friend-graph-viewport"]');
+      const fitAll = Array.from(document.querySelectorAll("button")).find((button) =>
+        button.textContent?.trim() === "Fit all",
+      );
       const sidebar = document.querySelector('[data-testid="app-sidebar"]');
       const handle = document.querySelector('[aria-label="Resize friends sidebar"]');
       const header = document.querySelector("header");
       if (!(graph instanceof HTMLElement)) return null;
+      if (!(fitAll instanceof HTMLElement)) return null;
       if (!(sidebar instanceof HTMLElement)) return null;
       if (!(handle instanceof HTMLElement)) return null;
       if (!(header instanceof HTMLElement)) return null;
 
       const graphRect = graph.getBoundingClientRect();
+      const fitAllRect = fitAll.getBoundingClientRect();
       const sidebarRect = sidebar.getBoundingClientRect();
       const handleRect = handle.getBoundingClientRect();
       const headerRect = header.getBoundingClientRect();
@@ -369,6 +488,8 @@ test("friends graph uses the same full-canvas edge frame as map view", async ({ 
         topGapPx: Math.round(graphRect.top - headerRect.bottom),
         rightGapPx: Math.round(handleRect.left - graphRect.right),
         bottomGapPx: Math.round(window.innerHeight - graphRect.bottom),
+        fitAllTopGapPx: Math.round(fitAllRect.top - graphRect.top),
+        fitAllRightGapPx: Math.round(graphRect.right - fitAllRect.right),
       };
     });
   }).toEqual({
@@ -376,5 +497,7 @@ test("friends graph uses the same full-canvas edge frame as map view", async ({ 
     topGapPx: 0,
     rightGapPx: 0,
     bottomGapPx: 0,
+    fitAllTopGapPx: 16,
+    fitAllRightGapPx: 16,
   });
 });

--- a/packages/ui/src/components/friends/FriendGraph.tsx
+++ b/packages/ui/src/components/friends/FriendGraph.tsx
@@ -38,6 +38,7 @@ import {
   type IdentityGraphLayoutNode,
   type SpatialIndex,
   type ViewTransform,
+  type ViewportPadding,
 } from "../../lib/identity-graph-layout.js";
 import {
   buildIdentityGraphModel,
@@ -207,6 +208,20 @@ type GraphDebugNode = Pick<
   "id" | "personId" | "accountId" | "feedUrl" | "linkedPersonId" | "kind" | "x" | "y" | "radius"
 >;
 
+type GraphViewportInsets = {
+  top: number;
+  right: number;
+  bottom: number;
+  left: number;
+};
+
+const EMPTY_GRAPH_VIEWPORT_INSETS: GraphViewportInsets = {
+  top: 0,
+  right: 0,
+  bottom: 0,
+  left: 0,
+};
+
 const DEFAULT_HEIGHT = 560;
 const FIT_PADDING = 84;
 const MIN_SCALE = 0.2;
@@ -230,6 +245,52 @@ const DENSE_INTERACTION_SCALE_BUCKET_FACTOR = 2;
 const DENSE_SETTLED_VIEWPORT_SCALE_THRESHOLD = 0.55;
 const CONTROL_BASE = "theme-graph-control rounded-xl px-3 py-1.5 text-xs";
 const RELATIONSHIP_TIER_DROP_SELECTOR = "[data-friend-tier-drop-value]";
+
+function readCanvasViewportInset(element: HTMLElement, name: string): number {
+  const raw = window.getComputedStyle(element).getPropertyValue(name).trim();
+  const parsed = Number.parseFloat(raw);
+  return Number.isFinite(parsed) ? Math.max(0, Math.round(parsed)) : 0;
+}
+
+function readCanvasViewportInsets(element: HTMLElement): GraphViewportInsets {
+  return {
+    top: readCanvasViewportInset(element, "--freed-canvas-viewport-inset-top"),
+    right: readCanvasViewportInset(element, "--freed-canvas-viewport-inset-right"),
+    bottom: readCanvasViewportInset(element, "--freed-canvas-viewport-inset-bottom"),
+    left: readCanvasViewportInset(element, "--freed-canvas-viewport-inset-left"),
+  };
+}
+
+function sameGraphViewportInsets(
+  left: GraphViewportInsets,
+  right: GraphViewportInsets,
+): boolean {
+  return (
+    left.top === right.top &&
+    left.right === right.right &&
+    left.bottom === right.bottom &&
+    left.left === right.left
+  );
+}
+
+function graphViewportPadding(insets: GraphViewportInsets): ViewportPadding {
+  return {
+    top: FIT_PADDING + insets.top,
+    right: FIT_PADDING + insets.right,
+    bottom: FIT_PADDING + insets.bottom,
+    left: FIT_PADDING + insets.left,
+  };
+}
+
+function graphViewportCenter(
+  canvasSize: { width: number; height: number },
+  insets: GraphViewportInsets,
+): { x: number; y: number } {
+  return {
+    x: insets.left + Math.max(1, canvasSize.width - insets.left - insets.right) / 2,
+    y: insets.top + Math.max(1, canvasSize.height - insets.top - insets.bottom) / 2,
+  };
+}
 
 interface RgbColor {
   r: number;
@@ -929,6 +990,7 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
   const syncSceneRef = useRef<() => void>(() => {});
   const syncSceneErrorLoggedRef = useRef(false);
   const canvasSizeRef = useRef({ width: 900, height: DEFAULT_HEIGHT });
+  const graphViewportInsetsRef = useRef<GraphViewportInsets>(EMPTY_GRAPH_VIEWPORT_INSETS);
   const perfSnapshotRef = useRef<GraphPerfSnapshot>({
     modelBuildMs: 0,
     layoutMs: 0,
@@ -952,7 +1014,10 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
     qualityMode: "settled",
   });
   const [canvasSize, setCanvasSize] = useState({ width: 900, height: DEFAULT_HEIGHT });
+  const [graphViewportInsets, setGraphViewportInsets] =
+    useState<GraphViewportInsets>(EMPTY_GRAPH_VIEWPORT_INSETS);
   canvasSizeRef.current = canvasSize;
+  graphViewportInsetsRef.current = graphViewportInsets;
   const [layoutReady, setLayoutReady] = useState(false);
   const [layoutVersion, setLayoutVersion] = useState(0);
 
@@ -1884,10 +1949,10 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
       graphFitItems(layoutRef.current),
       canvasSize.width,
       canvasSize.height,
-      FIT_PADDING,
+      graphViewportPadding(graphViewportInsets),
     );
     scheduleSyncScene();
-  }, [canvasSize.height, canvasSize.width, scheduleSyncScene]);
+  }, [canvasSize.height, canvasSize.width, graphViewportInsets, scheduleSyncScene]);
 
   const focusNode = useCallback((id: string) => {
     const hit = layoutRef.current.nodes.find(
@@ -1895,13 +1960,14 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
     );
     if (!hit) return;
     const scale = transformRef.current.scale;
+    const center = graphViewportCenter(canvasSize, graphViewportInsets);
     transformRef.current = {
-      x: canvasSize.width / 2 - hit.x * scale,
-      y: canvasSize.height / 2 - hit.y * scale,
+      x: center.x - hit.x * scale,
+      y: center.y - hit.y * scale,
       scale,
     };
     scheduleSyncScene();
-  }, [canvasSize.height, canvasSize.width, scheduleSyncScene]);
+  }, [canvasSize, graphViewportInsets, scheduleSyncScene]);
 
   useImperativeHandle(
     ref,
@@ -2009,10 +2075,14 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
     if (!container) return;
 
     const updateSize = () => {
+      const nextInsets = readCanvasViewportInsets(container);
       setCanvasSize({
         width: Math.max(320, container.clientWidth),
         height: Math.max(320, container.clientHeight || DEFAULT_HEIGHT),
       });
+      setGraphViewportInsets((current) =>
+        sameGraphViewportInsets(current, nextInsets) ? current : nextInsets,
+      );
     };
 
     updateSize();
@@ -2071,7 +2141,7 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
         graphFitItems(layout),
         latestCanvasSize.width,
         latestCanvasSize.height,
-        FIT_PADDING,
+        graphViewportPadding(graphViewportInsetsRef.current),
       );
       hasFittedInitialLayoutRef.current = true;
       pendingFitAllRef.current = false;
@@ -2579,7 +2649,13 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
           className="absolute inset-0 cursor-grab"
         />
       </div>
-      <div className="absolute right-4 top-4 z-10 flex items-center gap-2">
+      <div
+        className="absolute z-10 flex items-center gap-2"
+        style={{
+          right: "calc(var(--freed-canvas-viewport-inset-right, 0px) + 1rem)",
+          top: "calc(var(--freed-canvas-viewport-inset-top, 0px) + 1rem)",
+        }}
+      >
         <button
           type="button"
           className={CONTROL_BASE}

--- a/packages/ui/src/components/friends/FriendsView.tsx
+++ b/packages/ui/src/components/friends/FriendsView.tsx
@@ -1716,7 +1716,7 @@ export function FriendsView({
   return (
     <div className="app-theme-shell flex h-full flex-col overflow-hidden">
       <div
-        className={`relative flex min-h-0 flex-1 pt-[var(--feed-card-gap,8px)] ${isMobile ? "flex-col" : "flex-row"}`}
+        className={`relative flex min-h-0 flex-1 ${isMobile ? "flex-col pt-[var(--feed-card-gap,8px)]" : "flex-row"}`}
       >
         {showGraphSurface ? (
           <div className="relative min-h-0 min-w-0 flex-1">

--- a/packages/ui/src/components/layout/AppShell.tsx
+++ b/packages/ui/src/components/layout/AppShell.tsx
@@ -1,4 +1,14 @@
-import { Suspense, lazy, useEffect, useState, useRef, useCallback, type ReactNode } from "react";
+import {
+  Suspense,
+  lazy,
+  useEffect,
+  useLayoutEffect,
+  useState,
+  useRef,
+  useCallback,
+  type CSSProperties,
+  type ReactNode,
+} from "react";
 import { Sidebar } from "./Sidebar.js";
 import { Header } from "./Header.js";
 import { DebugPanel } from "../DebugPanel.js";
@@ -50,6 +60,36 @@ interface AppShellProps {
 
 type FriendsMobileSurface = "graph" | "details";
 
+type CanvasViewportInsets = {
+  top: number;
+  right: number;
+  bottom: number;
+  left: number;
+};
+
+const EMPTY_CANVAS_VIEWPORT_INSETS: CanvasViewportInsets = {
+  top: 0,
+  right: 0,
+  bottom: 0,
+  left: 0,
+};
+
+function roundInset(value: number): number {
+  return Math.max(0, Math.round(value));
+}
+
+function sameCanvasViewportInsets(
+  left: CanvasViewportInsets,
+  right: CanvasViewportInsets,
+): boolean {
+  return (
+    left.top === right.top &&
+    left.right === right.right &&
+    left.bottom === right.bottom &&
+    left.left === right.left
+  );
+}
+
 export function AppShell({ children }: AppShellProps) {
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
   const [friendsMobileSurface, setFriendsMobileSurface] =
@@ -98,12 +138,15 @@ export function AppShell({ children }: AppShellProps) {
   const [dragWidth, setDragWidth] = useState<number | null>(null);
   const [committedDebugWidth, setCommittedDebugWidth] = useState(persistedDebugWidth);
   const [desktopSidebarMode, setDesktopSidebarMode] = useState<SidebarMode>(persistedDesktopSidebarMode);
-  const usesFullCanvasFrame = activeView === "map" || activeView === "friends";
+  const contentFrameRef = useRef<HTMLDivElement | null>(null);
+  const mainRef = useRef<HTMLElement | null>(null);
+  const [mapViewportInsets, setMapViewportInsets] = useState<CanvasViewportInsets>(EMPTY_CANVAS_VIEWPORT_INSETS);
+  const usesFullCanvasFrame = activeView === "friends";
   const contentFrameSpacingClass = usesFullCanvasFrame
-    ? desktopSidebarMode === "closed"
-      ? ""
-      : "pl-[var(--feed-card-gap,8px)]"
-    : "px-[var(--feed-card-gap,8px)] pb-[var(--feed-card-gap,8px)]";
+      ? desktopSidebarMode === "closed"
+        ? ""
+        : "pl-[var(--feed-card-gap,8px)]"
+      : "px-[var(--feed-card-gap,8px)] pb-[var(--feed-card-gap,8px)]";
   const [desktopSidebarDisplayMode, setDesktopSidebarDisplayMode] = useState<SidebarMode>(persistedDesktopSidebarMode);
   const dragging = useRef(false);
   const pendingPersistedDebugWidth = useRef<number | null>(null);
@@ -160,6 +203,59 @@ export function AppShell({ children }: AppShellProps) {
   }, [persistedDesktopSidebarMode]);
 
   const debugWidth = dragWidth ?? committedDebugWidth;
+  const mapViewportInsetStyle = {
+    "--freed-canvas-viewport-inset-top": `${mapViewportInsets.top}px`,
+    "--freed-canvas-viewport-inset-right": `${mapViewportInsets.right}px`,
+    "--freed-canvas-viewport-inset-bottom": `${mapViewportInsets.bottom}px`,
+    "--freed-canvas-viewport-inset-left": `${mapViewportInsets.left}px`,
+  } as CSSProperties;
+
+  useLayoutEffect(() => {
+    if (activeView !== "map") {
+      setMapViewportInsets((current) =>
+        sameCanvasViewportInsets(current, EMPTY_CANVAS_VIEWPORT_INSETS)
+          ? current
+          : EMPTY_CANVAS_VIEWPORT_INSETS,
+      );
+      return;
+    }
+
+    const contentFrame = contentFrameRef.current;
+    const main = mainRef.current;
+    if (!contentFrame || !main) return;
+
+    let frame = 0;
+    const updateInsets = () => {
+      frame = 0;
+      const frameRect = contentFrame.getBoundingClientRect();
+      const mainRect = main.getBoundingClientRect();
+      const next = {
+        top: roundInset(mainRect.top - frameRect.top),
+        right: roundInset(frameRect.right - mainRect.right),
+        bottom: roundInset(frameRect.bottom - mainRect.bottom),
+        left: roundInset(mainRect.left - frameRect.left),
+      };
+      setMapViewportInsets((current) =>
+        sameCanvasViewportInsets(current, next) ? current : next,
+      );
+    };
+
+    const scheduleUpdate = () => {
+      if (frame !== 0) return;
+      frame = window.requestAnimationFrame(updateInsets);
+    };
+
+    updateInsets();
+    const observer = new ResizeObserver(scheduleUpdate);
+    observer.observe(contentFrame);
+    observer.observe(main);
+    window.addEventListener("resize", scheduleUpdate);
+    return () => {
+      if (frame !== 0) window.cancelAnimationFrame(frame);
+      observer.disconnect();
+      window.removeEventListener("resize", scheduleUpdate);
+    };
+  }, [activeView, debugVisible, debugWidth, desktopSidebarMode, effectiveDesktopSidebarDisplayMode, isMobileDevice]);
 
   const persistDesktopSidebarMode = useCallback((nextMode: SidebarMode) => {
     setDesktopSidebarMode(nextMode);
@@ -412,20 +508,35 @@ export function AppShell({ children }: AppShellProps) {
         />
 
         <div
+          ref={contentFrameRef}
           className={`relative z-10 flex flex-1 ${contentFrameSpacingClass} ${
             isMobileDevice ? "" : "min-h-0 overflow-hidden"
           }`}
         >
-          <Sidebar
-            mobileOpen={mobileSidebarOpen}
-            onMobileClose={() => setMobileSidebarOpen(false)}
-            desktopMode={desktopSidebarMode}
-            onDesktopModeChange={persistDesktopSidebarMode}
-            onDesktopDisplayModeChange={setDesktopSidebarDisplayMode}
-            desktopGapWidthPx={usesFullCanvasFrame ? 0 : undefined}
-          />
+          {activeView === "map" ? (
+            <div
+              className="absolute inset-0 z-0"
+              data-testid="map-background-layer"
+              style={mapViewportInsetStyle}
+            >
+              <MapView viewportInsets={mapViewportInsets} />
+            </div>
+          ) : null}
+          <div className="relative z-10 flex flex-none">
+            <Sidebar
+              mobileOpen={mobileSidebarOpen}
+              onMobileClose={() => setMobileSidebarOpen(false)}
+              desktopMode={desktopSidebarMode}
+              onDesktopModeChange={persistDesktopSidebarMode}
+              onDesktopDisplayModeChange={setDesktopSidebarDisplayMode}
+              desktopGapWidthPx={usesFullCanvasFrame ? 0 : undefined}
+            />
+          </div>
           <main
-            className={`min-w-0 flex-1 ${isMobileDevice ? "" : "min-h-0 overflow-hidden"}`}
+            ref={mainRef}
+            className={`relative z-10 min-w-0 flex-1 ${activeView === "map" ? "pointer-events-none" : ""} ${
+              isMobileDevice ? "" : "min-h-0 overflow-hidden"
+            }`}
           >
             {activeView === "friends"
               ? (
@@ -438,13 +549,13 @@ export function AppShell({ children }: AppShellProps) {
                 </Suspense>
               )
               : activeView === "map"
-                ? <MapView />
+                ? null
                 : children}
           </main>
 
           <div
             data-testid="debug-panel-drawer"
-            className="relative hidden sm:flex flex-none overflow-hidden"
+            className="relative z-10 hidden sm:flex flex-none overflow-hidden"
             style={{
               width: debugVisible ? debugWidth + AUXILIARY_DRAWER_GAP_WIDTH_PX : 0,
               opacity: debugVisible ? 1 : 0,

--- a/packages/ui/src/components/layout/AppShell.tsx
+++ b/packages/ui/src/components/layout/AppShell.tsx
@@ -98,6 +98,12 @@ export function AppShell({ children }: AppShellProps) {
   const [dragWidth, setDragWidth] = useState<number | null>(null);
   const [committedDebugWidth, setCommittedDebugWidth] = useState(persistedDebugWidth);
   const [desktopSidebarMode, setDesktopSidebarMode] = useState<SidebarMode>(persistedDesktopSidebarMode);
+  const usesFullCanvasFrame = activeView === "map" || activeView === "friends";
+  const contentFrameSpacingClass = usesFullCanvasFrame
+    ? desktopSidebarMode === "closed"
+      ? ""
+      : "pl-[var(--feed-card-gap,8px)]"
+    : "px-[var(--feed-card-gap,8px)] pb-[var(--feed-card-gap,8px)]";
   const [desktopSidebarDisplayMode, setDesktopSidebarDisplayMode] = useState<SidebarMode>(persistedDesktopSidebarMode);
   const dragging = useRef(false);
   const pendingPersistedDebugWidth = useRef<number | null>(null);
@@ -406,7 +412,7 @@ export function AppShell({ children }: AppShellProps) {
         />
 
         <div
-          className={`relative z-10 flex flex-1 px-[var(--feed-card-gap,8px)] pb-[var(--feed-card-gap,8px)] ${
+          className={`relative z-10 flex flex-1 ${contentFrameSpacingClass} ${
             isMobileDevice ? "" : "min-h-0 overflow-hidden"
           }`}
         >
@@ -416,6 +422,7 @@ export function AppShell({ children }: AppShellProps) {
             desktopMode={desktopSidebarMode}
             onDesktopModeChange={persistDesktopSidebarMode}
             onDesktopDisplayModeChange={setDesktopSidebarDisplayMode}
+            desktopGapWidthPx={usesFullCanvasFrame ? 0 : undefined}
           />
           <main
             className={`min-w-0 flex-1 ${isMobileDevice ? "" : "min-h-0 overflow-hidden"}`}

--- a/packages/ui/src/components/layout/Sidebar.tsx
+++ b/packages/ui/src/components/layout/Sidebar.tsx
@@ -227,6 +227,7 @@ interface SidebarProps {
   desktopMode: SidebarMode;
   onDesktopModeChange: (nextMode: SidebarMode) => void;
   onDesktopDisplayModeChange?: (nextMode: SidebarMode) => void;
+  desktopGapWidthPx?: number;
 }
 
 function SidebarSection({
@@ -573,6 +574,7 @@ export function Sidebar({
   desktopMode,
   onDesktopModeChange,
   onDesktopDisplayModeChange,
+  desktopGapWidthPx,
 }: SidebarProps) {
   const { SourceIndicator, syncRssNow, syncSourceNow, getSourceStatus } = usePlatform();
   const isMobileViewport = useIsMobile();
@@ -718,9 +720,11 @@ export function Sidebar({
           ? DEFAULT_WIDTH
           : committedWidth);
   const effectiveGapWidthPx =
-    activeView === "friends"
-      ? FRIENDS_SIDEBAR_GAP_WIDTH_PX
-      : PRIMARY_SIDEBAR_GAP_WIDTH_PX;
+    desktopGapWidthPx ?? (
+      activeView === "friends"
+        ? FRIENDS_SIDEBAR_GAP_WIDTH_PX
+        : PRIMARY_SIDEBAR_GAP_WIDTH_PX
+    );
   const compactReaderRailVisible =
     activeView === "feed" &&
     !!selectedItemId &&

--- a/packages/ui/src/components/map/MapSurface.tsx
+++ b/packages/ui/src/components/map/MapSurface.tsx
@@ -4,7 +4,6 @@ import {
   useMemo,
   useRef,
   useState,
-  type CSSProperties,
   type PointerEvent,
   type WheelEvent,
 } from "react";
@@ -33,6 +32,7 @@ interface MapSurfaceProps {
   focusedMarkerKey?: string | null;
   interactive?: boolean;
   themeId?: ThemeId;
+  viewportInsets?: MapViewportInsets;
   onOpenFriend?: (marker: LocationMarkerSummary) => void;
   onPromoteAccount?: (marker: LocationMarkerSummary) => void;
   onLinkAccount?: (marker: LocationMarkerSummary) => void;
@@ -40,6 +40,18 @@ interface MapSurfaceProps {
   emptyTitle?: string;
   emptyBody?: string;
 }
+
+type MapViewportInsets = {
+  top: number;
+  right: number;
+  bottom: number;
+  left: number;
+};
+
+type MapSurfaceSize = {
+  width: number;
+  height: number;
+};
 
 let mapLibreLoader: Promise<MapLibreModule> | null = null;
 const popupDateFormatter = new Intl.DateTimeFormat(undefined, {
@@ -53,11 +65,7 @@ const MAP_POPUP_VIEWPORT_MARGIN = 40;
 const MAP_DOM_MARKER_LIMIT = 160;
 const MAP_MOVING_MARKER_PAINT_LIMIT = 24;
 const MAP_DENSE_MARKER_RESTORE_DELAY_MS = 420;
-const MAP_EDGE_TOP_BOTTOM_FADE_PX = 56;
-const MAP_EDGE_SIDE_FADE_PX = 20;
-const MAP_VIEWPORT_MASK_STYLE = {
-  "--theme-soft-viewport-mask-size": "20px",
-} as CSSProperties;
+const MAP_CAMERA_PADDING_PX = 72;
 
 function shouldForceMapFallback() {
   if (typeof window === "undefined") return false;
@@ -400,8 +408,7 @@ function mapStyles(interactive: boolean) {
       filter: none;
     }
 
-    .freed-map-shell[data-map-moving="true"] .freed-map-grid-overlay,
-    .freed-map-shell[data-map-moving="true"] .freed-map-edge-overlay {
+    .freed-map-shell[data-map-moving="true"] .freed-map-grid-overlay {
       display: none;
     }
 
@@ -420,12 +427,22 @@ function mapStyles(interactive: boolean) {
   `;
 }
 
-function fallbackPosition(marker: LocationMarkerSummary) {
-  const left = ((marker.lng + 180) / 360) * 100;
-  const top = ((90 - marker.lat) / 180) * 100;
+function fallbackPosition(
+  marker: LocationMarkerSummary,
+  viewportInsets: MapViewportInsets | undefined,
+  surfaceSize: MapSurfaceSize,
+) {
+  const leftRatio = Math.min(0.96, Math.max(0.04, (marker.lng + 180) / 360));
+  const topRatio = Math.min(0.94, Math.max(0.06, (90 - marker.lat) / 180));
+  const leftInset = viewportInsets?.left ?? 0;
+  const rightInset = viewportInsets?.right ?? 0;
+  const topInset = viewportInsets?.top ?? 0;
+  const bottomInset = viewportInsets?.bottom ?? 0;
+  const availableWidth = Math.max(1, surfaceSize.width - leftInset - rightInset);
+  const availableHeight = Math.max(1, surfaceSize.height - topInset - bottomInset);
   return {
-    left: `${Math.min(96, Math.max(4, left)).toFixed(2)}%`,
-    top: `${Math.min(94, Math.max(6, top)).toFixed(2)}%`,
+    left: `${Math.round(leftInset + availableWidth * leftRatio)}px`,
+    top: `${Math.round(topInset + availableHeight * topRatio)}px`,
   };
 }
 
@@ -559,52 +576,28 @@ function fallbackScanBackground(background: string, water: string) {
   `;
 }
 
-function mapEdgeVignetteBackground() {
-  return `
-    radial-gradient(
-      ${MAP_EDGE_SIDE_FADE_PX}px ${MAP_EDGE_TOP_BOTTOM_FADE_PX}px at 0% 0%,
-      rgb(var(--theme-shell-rgb) / 0.18) 0%,
-      transparent 76%
-    ),
-    radial-gradient(
-      ${MAP_EDGE_SIDE_FADE_PX}px ${MAP_EDGE_TOP_BOTTOM_FADE_PX}px at 100% 0%,
-      rgb(var(--theme-shell-rgb) / 0.18) 0%,
-      transparent 76%
-    ),
-    radial-gradient(
-      ${MAP_EDGE_SIDE_FADE_PX}px ${MAP_EDGE_TOP_BOTTOM_FADE_PX}px at 0% 100%,
-      rgb(var(--theme-shell-rgb) / 0.18) 0%,
-      transparent 76%
-    ),
-    radial-gradient(
-      ${MAP_EDGE_SIDE_FADE_PX}px ${MAP_EDGE_TOP_BOTTOM_FADE_PX}px at 100% 100%,
-      rgb(var(--theme-shell-rgb) / 0.18) 0%,
-      transparent 76%
-    ),
-    linear-gradient(
-      to bottom,
-      rgb(var(--theme-shell-rgb) / 0.22) 0%,
-      transparent ${MAP_EDGE_TOP_BOTTOM_FADE_PX}px
-    ),
-    linear-gradient(
-      to top,
-      rgb(var(--theme-shell-rgb) / 0.22) 0%,
-      transparent ${MAP_EDGE_TOP_BOTTOM_FADE_PX}px
-    ),
-    linear-gradient(
-      to right,
-      rgb(var(--theme-shell-rgb) / 0.22) 0%,
-      transparent ${MAP_EDGE_SIDE_FADE_PX}px
-    ),
-    linear-gradient(
-      to left,
-      rgb(var(--theme-shell-rgb) / 0.22) 0%,
-      transparent ${MAP_EDGE_SIDE_FADE_PX}px
-    )
-  `;
+function mapCameraPadding(viewportInsets?: MapViewportInsets) {
+  return {
+    top: MAP_CAMERA_PADDING_PX + (viewportInsets?.top ?? 0),
+    right: MAP_CAMERA_PADDING_PX + (viewportInsets?.right ?? 0),
+    bottom: MAP_CAMERA_PADDING_PX + (viewportInsets?.bottom ?? 0),
+    left: MAP_CAMERA_PADDING_PX + (viewportInsets?.left ?? 0),
+  };
 }
 
-function fitMarkers(map: MapInstance, markers: LocationMarkerSummary[], focusedMarkerKey?: string | null) {
+function mapCameraOffset(viewportInsets?: MapViewportInsets): [number, number] {
+  return [
+    ((viewportInsets?.left ?? 0) - (viewportInsets?.right ?? 0)) / 2,
+    ((viewportInsets?.top ?? 0) - (viewportInsets?.bottom ?? 0)) / 2,
+  ];
+}
+
+function fitMarkers(
+  map: MapInstance,
+  markers: LocationMarkerSummary[],
+  focusedMarkerKey?: string | null,
+  viewportInsets?: MapViewportInsets,
+) {
   if (markers.length === 0) return;
 
   const focusedMarker = focusedMarkerKey
@@ -616,6 +609,7 @@ function fitMarkers(map: MapInstance, markers: LocationMarkerSummary[], focusedM
       center: [focusedMarker.lng, focusedMarker.lat],
       zoom: 7.5,
       duration: 600,
+      offset: mapCameraOffset(viewportInsets),
     });
     return;
   }
@@ -626,6 +620,7 @@ function fitMarkers(map: MapInstance, markers: LocationMarkerSummary[], focusedM
       center: [marker.lng, marker.lat],
       zoom: 4.5,
       duration: 600,
+      offset: mapCameraOffset(viewportInsets),
     });
     return;
   }
@@ -648,7 +643,7 @@ function fitMarkers(map: MapInstance, markers: LocationMarkerSummary[], focusedM
       [minLng, minLat],
       [maxLng, maxLat],
     ],
-    { padding: 72, duration: 600 }
+    { padding: mapCameraPadding(viewportInsets), duration: 600 }
   );
 }
 
@@ -657,6 +652,7 @@ export function MapSurface({
   focusedMarkerKey,
   interactive = true,
   themeId,
+  viewportInsets,
   onOpenFriend,
   onPromoteAccount,
   onLinkAccount,
@@ -677,6 +673,7 @@ export function MapSurface({
   const [mapReady, setMapReady] = useState(false);
   const [loadFailed, setLoadFailed] = useState(false);
   const [fallbackMoving, setFallbackMoving] = useState(false);
+  const [surfaceSize, setSurfaceSize] = useState<MapSurfaceSize>({ width: 900, height: 560 });
   const [selectedFallbackMarkerKey, setSelectedFallbackMarkerKey] = useState<string | null>(null);
   const activePopupRef = useRef<PopupInstance | null>(null);
   const activePopupKeyRef = useRef<string | null>(null);
@@ -795,6 +792,29 @@ export function MapSurface({
     clearNativeMarkerRestoreTimeout();
     setShellMoving(false);
   }, [clearFallbackMovingTimeout, clearNativeMarkerRestoreTimeout, setShellMoving]);
+
+  useEffect(() => {
+    const shell = shellRef.current;
+    if (!shell) return;
+
+    const updateSize = () => {
+      const rect = shell.getBoundingClientRect();
+      setSurfaceSize((current) => {
+        const next = {
+          width: Math.max(1, Math.round(rect.width)),
+          height: Math.max(1, Math.round(rect.height)),
+        };
+        return current.width === next.width && current.height === next.height
+          ? current
+          : next;
+      });
+    };
+
+    updateSize();
+    const observer = new ResizeObserver(updateSize);
+    observer.observe(shell);
+    return () => observer.disconnect();
+  }, []);
 
   useEffect(() => {
     if (showFallback) return;
@@ -1005,8 +1025,8 @@ export function MapSurface({
 
   useEffect(() => {
     if (!mapReady || !mapRef.current) return;
-    fitMarkers(mapRef.current, stableMarkers, focusedMarkerKey);
-  }, [focusedMarkerKey, mapReady, stableMarkers]);
+    fitMarkers(mapRef.current, stableMarkers, focusedMarkerKey, viewportInsets);
+  }, [focusedMarkerKey, mapReady, stableMarkers, viewportInsets]);
 
   return (
     <div
@@ -1018,14 +1038,13 @@ export function MapSurface({
       data-map-dense={useDenseMarkers ? "true" : "false"}
       data-map-ready={mapReady && !loadFailed ? "true" : "false"}
       data-map-moving="false"
-      className="freed-map-shell theme-soft-viewport relative h-full w-full"
-      style={MAP_VIEWPORT_MASK_STYLE}
+      className="freed-map-shell relative h-full w-full overflow-hidden"
       onWheel={showFallback ? handleFallbackWheel : undefined}
       onPointerDown={showFallback ? handleFallbackPointerDown : undefined}
       onPointerMove={showFallback ? handleFallbackPointerMove : undefined}
     >
       <style>{mapStyles(interactive)}</style>
-      <div className="theme-soft-viewport-content">
+      <div className="absolute inset-0 overflow-hidden">
         <div
           ref={containerRef}
           className={`h-full w-full ${showFallback ? "invisible" : "visible"}`}
@@ -1037,13 +1056,6 @@ export function MapSurface({
             opacity: mapPalette.gridOpacity,
           }}
         />
-        <div
-          className="freed-map-edge-overlay pointer-events-none absolute inset-0"
-          style={{
-            background: mapEdgeVignetteBackground(),
-          }}
-        />
-
         {showFallback && renderedMarkers.length > 0 && (
           <div
             className="freed-map-fallback-scan absolute inset-0 overflow-hidden"
@@ -1079,7 +1091,7 @@ export function MapSurface({
             }}
           />
           {fallbackRenderedMarkers.map((marker) => {
-            const position = fallbackPosition(marker);
+            const position = fallbackPosition(marker, viewportInsets, surfaceSize);
             const renderedMarkerIndex = renderedMarkers.findIndex((entry) => entry.key === marker.key);
             return (
               <button
@@ -1107,7 +1119,14 @@ export function MapSurface({
           })}
 
           {interactive && selectedFallbackMarker && (
-            <div data-testid="map-fallback-popup" className="theme-dialog-shell absolute bottom-4 left-4 w-[min(560px,calc(100%-2rem))] p-5">
+            <div
+              data-testid="map-fallback-popup"
+              className="theme-dialog-shell absolute bottom-4 p-5"
+              style={{
+                left: "calc(var(--freed-canvas-viewport-inset-left, 0px) + 1rem)",
+                width: "min(560px, calc(100% - var(--freed-canvas-viewport-inset-left, 0px) - var(--freed-canvas-viewport-inset-right, 0px) - 2rem))",
+              }}
+            >
               <div className="flex items-start justify-between gap-3">
                 <div className="min-w-0">
                   <div className="flex flex-wrap items-center gap-2">

--- a/packages/ui/src/components/map/MapSurface.tsx
+++ b/packages/ui/src/components/map/MapSurface.tsx
@@ -53,6 +53,8 @@ const MAP_POPUP_VIEWPORT_MARGIN = 40;
 const MAP_DOM_MARKER_LIMIT = 160;
 const MAP_MOVING_MARKER_PAINT_LIMIT = 24;
 const MAP_DENSE_MARKER_RESTORE_DELAY_MS = 420;
+const MAP_EDGE_TOP_BOTTOM_FADE_PX = 56;
+const MAP_EDGE_SIDE_FADE_PX = 20;
 const MAP_VIEWPORT_MASK_STYLE = {
   "--theme-soft-viewport-mask-size": "20px",
 } as CSSProperties;
@@ -560,44 +562,44 @@ function fallbackScanBackground(background: string, water: string) {
 function mapEdgeVignetteBackground() {
   return `
     radial-gradient(
-      56px 56px at 0% 0%,
+      ${MAP_EDGE_SIDE_FADE_PX}px ${MAP_EDGE_TOP_BOTTOM_FADE_PX}px at 0% 0%,
       rgb(var(--theme-shell-rgb) / 0.18) 0%,
       transparent 76%
     ),
     radial-gradient(
-      56px 56px at 100% 0%,
+      ${MAP_EDGE_SIDE_FADE_PX}px ${MAP_EDGE_TOP_BOTTOM_FADE_PX}px at 100% 0%,
       rgb(var(--theme-shell-rgb) / 0.18) 0%,
       transparent 76%
     ),
     radial-gradient(
-      56px 56px at 0% 100%,
+      ${MAP_EDGE_SIDE_FADE_PX}px ${MAP_EDGE_TOP_BOTTOM_FADE_PX}px at 0% 100%,
       rgb(var(--theme-shell-rgb) / 0.18) 0%,
       transparent 76%
     ),
     radial-gradient(
-      56px 56px at 100% 100%,
+      ${MAP_EDGE_SIDE_FADE_PX}px ${MAP_EDGE_TOP_BOTTOM_FADE_PX}px at 100% 100%,
       rgb(var(--theme-shell-rgb) / 0.18) 0%,
       transparent 76%
     ),
     linear-gradient(
       to bottom,
       rgb(var(--theme-shell-rgb) / 0.22) 0%,
-      transparent 56px
+      transparent ${MAP_EDGE_TOP_BOTTOM_FADE_PX}px
     ),
     linear-gradient(
       to top,
       rgb(var(--theme-shell-rgb) / 0.22) 0%,
-      transparent 56px
+      transparent ${MAP_EDGE_TOP_BOTTOM_FADE_PX}px
     ),
     linear-gradient(
       to right,
       rgb(var(--theme-shell-rgb) / 0.22) 0%,
-      transparent 56px
+      transparent ${MAP_EDGE_SIDE_FADE_PX}px
     ),
     linear-gradient(
       to left,
       rgb(var(--theme-shell-rgb) / 0.22) 0%,
-      transparent 56px
+      transparent ${MAP_EDGE_SIDE_FADE_PX}px
     )
   `;
 }

--- a/packages/ui/src/components/map/MapView.tsx
+++ b/packages/ui/src/components/map/MapView.tsx
@@ -25,6 +25,17 @@ const DEFAULT_TIMELINE_INDEX: Record<Exclude<MapTimeMode, "current">, number> = 
   future: 0,
 };
 
+type MapViewportInsets = {
+  top: number;
+  right: number;
+  bottom: number;
+  left: number;
+};
+
+interface MapViewProps {
+  viewportInsets?: MapViewportInsets;
+}
+
 function getMapTimeRefreshMs(): number {
   if (typeof window === "undefined") return MAP_TIME_REFRESH_MS;
   const override = (
@@ -45,7 +56,7 @@ function formatTimelineEdge(value: number): string {
   return timelineEdgeFormatter.format(value);
 }
 
-export function MapView() {
+export function MapView({ viewportInsets }: MapViewProps) {
   const items = useAppStore((state) => state.items);
   const persons = useAppStore((state) => state.persons);
   const accounts = useAppStore((state) => state.accounts);
@@ -164,7 +175,13 @@ export function MapView() {
   return (
     <div className="app-theme-shell relative h-full overflow-hidden">
       {savedTimeMode !== "current" && timelineMoments.length > 0 && effectiveTimelineIndex !== null ? (
-        <div className="pointer-events-none absolute bottom-4 left-4 z-20 flex justify-start">
+        <div
+          className="pointer-events-none absolute bottom-4 z-20 flex justify-start"
+          style={{
+            left: "calc(var(--freed-canvas-viewport-inset-left, 0px) + 1rem)",
+            maxWidth: "calc(100% - var(--freed-canvas-viewport-inset-left, 0px) - var(--freed-canvas-viewport-inset-right, 0px) - 2rem)",
+          }}
+        >
           <div
             className="pointer-events-auto theme-floating-panel w-[min(25rem,calc(100vw-2rem))] px-4 py-3"
             data-testid="map-timeline-scrubber"
@@ -197,6 +214,7 @@ export function MapView() {
         markers={markers}
         focusedMarkerKey={focusedMarker?.key ?? null}
         themeId={themeId}
+        viewportInsets={viewportInsets}
         onOpenFriend={(marker) => {
           openFriendFromMap(marker, {
             setActiveView,

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -1551,7 +1551,7 @@ html[data-theme="scriptorium"] .theme-floating-panel {
   border-bottom-right-radius: 0;
   backdrop-filter: none;
   -webkit-backdrop-filter: none;
-  box-shadow: inset 0 -1px 0 color-mix(in oklab, var(--theme-header-border) 82%, transparent);
+  box-shadow: none;
 }
 
 .theme-attached-topbar::before {

--- a/packages/ui/src/lib/identity-graph-layout.ts
+++ b/packages/ui/src/lib/identity-graph-layout.ts
@@ -18,6 +18,13 @@ export interface ViewTransform {
   scale: number;
 }
 
+export type ViewportPadding = number | {
+  top: number;
+  right: number;
+  bottom: number;
+  left: number;
+};
+
 export const FRIEND_GRAPH_DEFAULT_TRANSFORM: ViewTransform = {
   x: 0,
   y: 0,
@@ -575,25 +582,30 @@ export function fitTransformToNodes(
   nodes: Array<{ x: number; y: number; radius: number }>,
   width: number,
   height: number,
-  padding: number = 80,
+  padding: ViewportPadding = 80,
 ): ViewTransform {
   if (nodes.length === 0) return { ...FRIEND_GRAPH_DEFAULT_TRANSFORM };
 
+  const resolvedPadding = typeof padding === "number"
+    ? { top: padding, right: padding, bottom: padding, left: padding }
+    : padding;
   const left = Math.min(...nodes.map((node) => node.x - node.radius));
   const right = Math.max(...nodes.map((node) => node.x + node.radius));
   const top = Math.min(...nodes.map((node) => node.y - node.radius));
   const bottom = Math.max(...nodes.map((node) => node.y + node.radius));
   const contentWidth = Math.max(1, right - left);
   const contentHeight = Math.max(1, bottom - top);
-  const availableWidth = Math.max(1, width - padding * 2);
-  const availableHeight = Math.max(1, height - padding * 2);
+  const availableWidth = Math.max(1, width - resolvedPadding.left - resolvedPadding.right);
+  const availableHeight = Math.max(1, height - resolvedPadding.top - resolvedPadding.bottom);
   const scale = Math.min(
     Math.min(availableWidth / contentWidth, availableHeight / contentHeight),
     1.5,
   );
+  const viewportCenterX = resolvedPadding.left + availableWidth / 2;
+  const viewportCenterY = resolvedPadding.top + availableHeight / 2;
   return {
-    x: width / 2 - ((left + right) / 2) * scale,
-    y: height / 2 - ((top + bottom) / 2) * scale,
+    x: viewportCenterX - ((left + right) / 2) * scale,
+    y: viewportCenterY - ((top + bottom) / 2) * scale,
     scale,
   };
 }


### PR DESCRIPTION
(AI Generated).

## Summary
- Alternative to PR #744 that renders Map View as an absolute background layer below the shared toolbar.
- Keep the left sidebar and right drawer in their normal foreground layout, including the sidebar normal left margin.
- Remove the Map View edge vignette and soft viewport mask so the map has no gradient borders.
- Fit Map View camera bounds, single-marker focus, fallback markers, and map overlays to the foreground lane between sidebars.
- Make Friends graph fit and Fit all control placement inset-aware so graph controls align to the graph lane.
- Reduce the attached top toolbar bottom edge to a single 1px border by removing the extra inset line.

## Testing
- npm run test:e2e -- theme-switching.spec.ts --grep "map view repaints|map view removes|friends graph controls|top toolbar uses"
- npm run validate:feature

## Notes
- This branch is intentionally an alternative visual direction to PR #744, not a replacement commit on that PR.