### PR TITLE
feat: add saved content sorting

### DIFF
--- a/docs/PHASE-10-POLISH.md
+++ b/docs/PHASE-10-POLISH.md
@@ -415,7 +415,7 @@ Reward security researchers for responsible disclosure.
 | 10.13 | Sentiment analysis       | Medium     | ✓ Complete (AISummary.sentiment field)
 | 10.14 | Smart notifications      | High       |
 | 10.15 | AI settings UI           | Medium     | ✓ Complete (Freed Desktop provider selector for Integrated AI, Ollama, OpenAI, Anthropic, and Gemini with provider-scoped sharing tags, optimistic selection, default workflows when AI is enabled, and no PWA controls for AI paths the browser cannot run)
-| 10.25 | Local content signals    | Medium     | ✓ Complete (rule-based contentSignals metadata, automatic ingestion inference, resumable desktop and PWA semantic backfill, inclusive saved toolbar filter presets, expanded signal taxonomy, and compact event candidate extraction)
+| 10.25 | Local content signals    | Medium     | ✓ Complete (rule-based contentSignals metadata, automatic ingestion inference, resumable desktop and PWA semantic backfill, inclusive saved toolbar filter presets, saved sort controls, expanded signal taxonomy, and compact event candidate extraction)
 | 10.26 | Optional local AI packs  | High       | ✓ Complete (disabled-by-default Light, Balanced, and Pro Integrated AI packs, hardware-based recommendations, pinned download manifests, semantic scan health, source links, resumable desktop downloads, raw-file checksum verification, and removal controls)
 | 10.27 | Local AI signal consumers | Medium | ✓ Complete (Friends suggestions improve from Integrated AI `Topics and ranking` contentSignals while still working deterministically when AI is off)
 
@@ -462,7 +462,7 @@ Reward security researchers for responsible disclosure.
 - [ ] Topic extraction works (at least one method)
 - [ ] Summarization available for long content
 - [x] AI settings in Freed Desktop start with a single provider choice that determines whether content stays local, goes to Ollama, or goes to a selected API provider, without selection flicker while preferences persist. The PWA hides AI controls because it cannot run those providers, downloads, or key storage paths.
-- [x] Local content signals classify existing and newly ingested items without cloud AI on Desktop and PWA, with inclusive saved feed filter presets, expanded semantic signals, and compact event metadata for high-confidence upcoming items
+- [x] Local content signals classify existing and newly ingested items without cloud AI on Desktop and PWA, with inclusive saved feed filter presets, saved sort controls, expanded semantic signals, and compact event metadata for high-confidence upcoming items
 - [x] Optional local AI stays out of the installer, remains off by default, recommends Light, Balanced, or Pro from local hardware, stores pack selection plus model files in device-local state, and refreshes semantic scan health while settings is open
 - [x] Friend suggestions consume local `contentSignals` and optional Integrated AI enrichment without adding a cloud prompt path or automatic friend promotion
 - [ ] Smart notifications reduce noise

--- a/packages/desktop/tests/e2e/saved-sort.spec.ts
+++ b/packages/desktop/tests/e2e/saved-sort.spec.ts
@@ -1,0 +1,206 @@
+import type { Page } from "@playwright/test";
+import { test, expect } from "./fixtures/app";
+
+type SavedSortMode = "date_saved" | "date_published" | "recommended" | "shortest_read";
+
+const SAVED_SORT_ITEM_IDS = [
+  "rss:https://saved-sort.example/feed.xml:saved-newest",
+  "rss:https://saved-sort.example/feed.xml:published-newest",
+  "rss:https://saved-sort.example/feed.xml:recommended-top",
+  "rss:https://saved-sort.example/feed.xml:shortest-read",
+] as const;
+
+async function seedSavedSortItems(page: Page): Promise<void> {
+  await page.evaluate(async () => {
+    const w = window as Record<string, unknown>;
+    const automerge = w.__FREED_AUTOMERGE__ as {
+      docBatchImportItems: (items: unknown[]) => Promise<unknown>;
+    };
+    const store = w.__FREED_STORE__ as {
+      getState: () => {
+        setFilter: (filter: { savedOnly: true }) => void;
+        updatePreferences: (update: unknown) => Promise<void>;
+      };
+    };
+    const now = Date.now();
+    const feedUrl = "https://saved-sort.example/feed.xml";
+    const base = {
+      platform: "rss",
+      contentType: "article",
+      capturedAt: now,
+      author: {
+        id: "saved-sort-feed",
+        handle: "saved-sort-feed",
+        displayName: "Saved Sort Feed",
+      },
+      content: {
+        text: "Saved sort fixture article.",
+        mediaUrls: [],
+        mediaTypes: [],
+        linkPreview: {
+          url: "https://saved-sort.example/article",
+          description: "A saved sorting fixture.",
+        },
+      },
+      topics: [],
+      rssSource: {
+        feedUrl,
+        feedTitle: "Saved Sort Feed",
+      },
+    };
+
+    await automerge.docBatchImportItems([
+      {
+        ...base,
+        globalId: "rss:https://saved-sort.example/feed.xml:saved-newest",
+        publishedAt: now - 10 * 86_400_000,
+        content: {
+          ...base.content,
+          linkPreview: { ...base.content.linkPreview, title: "Date saved wins" },
+        },
+        preservedContent: {
+          text: "Date saved wins.",
+          wordCount: 900,
+          readingTime: 9,
+          preservedAt: now,
+        },
+        userState: { hidden: false, saved: true, savedAt: now - 86_400_000, archived: false, tags: [] },
+      },
+      {
+        ...base,
+        globalId: "rss:https://saved-sort.example/feed.xml:published-newest",
+        publishedAt: now - 86_400_000,
+        content: {
+          ...base.content,
+          linkPreview: { ...base.content.linkPreview, title: "Date published wins" },
+        },
+        preservedContent: {
+          text: "Date published wins.",
+          wordCount: 500,
+          readingTime: 5,
+          preservedAt: now,
+        },
+        userState: { hidden: false, saved: true, savedAt: now - 4 * 86_400_000, archived: false, tags: [] },
+      },
+      {
+        ...base,
+        globalId: "rss:https://saved-sort.example/feed.xml:recommended-top",
+        publishedAt: now - 5 * 86_400_000,
+        content: {
+          ...base.content,
+          linkPreview: { ...base.content.linkPreview, title: "Recommended wins" },
+        },
+        preservedContent: {
+          text: "Recommended wins.",
+          wordCount: 300,
+          readingTime: 3,
+          preservedAt: now,
+        },
+        userState: { hidden: false, saved: true, savedAt: now - 3 * 86_400_000, archived: false, tags: [] },
+      },
+      {
+        ...base,
+        globalId: "rss:https://saved-sort.example/feed.xml:shortest-read",
+        publishedAt: now - 7 * 86_400_000,
+        content: {
+          ...base.content,
+          linkPreview: { ...base.content.linkPreview, title: "Shortest read wins" },
+        },
+        preservedContent: {
+          text: "Shortest read wins.",
+          wordCount: 100,
+          readingTime: 1,
+          preservedAt: now,
+        },
+        userState: { hidden: false, saved: true, savedAt: now - 2 * 86_400_000, archived: false, tags: [] },
+      },
+    ]);
+    await store.getState().updatePreferences({
+      display: { savedContentSortMode: "date_saved" },
+    });
+    store.getState().setFilter({ savedOnly: true });
+  });
+
+  await expect(page.locator('[data-feed-item-id="rss:https://saved-sort.example/feed.xml:saved-newest"]')).toBeVisible();
+}
+
+async function visibleSavedSortIds(page: Page): Promise<string[]> {
+  return page.locator('[data-feed-item-id^="rss:https://saved-sort.example/feed.xml"]').evaluateAll((nodes) =>
+    nodes
+      .map((node) => node.getAttribute("data-feed-item-id"))
+      .filter((id): id is string => Boolean(id)),
+  );
+}
+
+async function expectFirstSavedSortItem(page: Page, id: (typeof SAVED_SORT_ITEM_IDS)[number]): Promise<void> {
+  await expect.poll(() => visibleSavedSortIds(page)).toEqual(expect.arrayContaining([...SAVED_SORT_ITEM_IDS]));
+  await expect.poll(async () => (await visibleSavedSortIds(page))[0]).toBe(id);
+}
+
+test("Saved content can sort by saved date, published date, recommendations, and read time", async ({ app, page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await app.goto();
+  await app.waitForReady();
+  await seedSavedSortItems(page);
+
+  const sortSelect = page.getByTestId("saved-sort-select");
+  await expect(page.getByTestId("saved-sort-control")).toBeVisible();
+  await expect(sortSelect).toHaveValue("date_saved");
+  await expect(page.getByTestId("feed-signal-filter-button")).toBeVisible();
+
+  await expectFirstSavedSortItem(page, "rss:https://saved-sort.example/feed.xml:saved-newest");
+
+  await sortSelect.selectOption("date_published");
+  await expectFirstSavedSortItem(page, "rss:https://saved-sort.example/feed.xml:published-newest");
+
+  await expect(sortSelect.locator("option")).toContainText([
+    "Date saved",
+    "Date published",
+    "Recommended",
+    "Shortest read",
+  ]);
+  await sortSelect.selectOption("recommended");
+  await expect(sortSelect).toHaveValue("recommended");
+
+  await sortSelect.selectOption("shortest_read");
+  await expectFirstSavedSortItem(page, "rss:https://saved-sort.example/feed.xml:shortest-read");
+});
+
+test("Saved sort collapses into the mobile filter menu", async ({ app, page }) => {
+  await page.setViewportSize({ width: 430, height: 720 });
+  await app.goto();
+  await app.waitForReady();
+  await seedSavedSortItems(page);
+
+  await expect(page.getByTestId("saved-sort-control")).toHaveCount(0);
+  const filterButton = page.getByTestId("mobile-toolbar-filter-button");
+  await expect(filterButton).toBeVisible({ timeout: 5_000 });
+  await filterButton.click();
+
+  const filterMenu = page.getByTestId("feed-signal-filter-menu");
+  await expect(filterMenu.getByText("Sort", { exact: true })).toBeVisible();
+  const sortSection = filterMenu.getByText("Sort", { exact: true }).locator("..");
+  const sortControl = filterMenu.getByTestId("saved-sort-control");
+  const sortSelect = filterMenu.getByTestId("saved-sort-select");
+  await expect(sortSelect).toBeVisible();
+
+  const menuGeometry = await sortSection.evaluate((section) => {
+    const control = section.querySelector('[data-testid="saved-sort-control"]') as HTMLElement | null;
+    if (!control) throw new Error("Saved sort control is missing");
+    const controlRect = control.getBoundingClientRect();
+    const sectionRect = section.getBoundingClientRect();
+    const sectionStyle = window.getComputedStyle(section);
+    const horizontalPadding =
+      Number.parseFloat(sectionStyle.paddingLeft) +
+      Number.parseFloat(sectionStyle.paddingRight);
+    return {
+      controlWidth: Math.round(controlRect.width),
+      contentWidth: Math.round(sectionRect.width - horizontalPadding),
+    };
+  });
+  expect(menuGeometry.controlWidth).toBe(menuGeometry.contentWidth);
+
+  await sortSelect.selectOption("date_published");
+  await expect(sortControl).toBeVisible();
+  await expectFirstSavedSortItem(page, "rss:https://saved-sort.example/feed.xml:published-newest");
+});

--- a/packages/shared/src/ranking.ts
+++ b/packages/shared/src/ranking.ts
@@ -5,7 +5,7 @@
  * Runs on Desktop/OpenClaw, results synced to edge devices.
  */
 
-import type { Account, ContentSignal, FeedItem, Person, WeightPreferences } from "./types.js";
+import type { Account, ContentSignal, FeedItem, Person, SavedContentSortMode, WeightPreferences } from "./types.js";
 import type { SocialContentFilter } from "./store-types.js";
 
 /**
@@ -147,6 +147,41 @@ function normalizeEngagement(engagement: {
  */
 export function sortByPriority(items: FeedItem[]): FeedItem[] {
   return [...items].sort((a, b) => (b.priority ?? 0) - (a.priority ?? 0));
+}
+
+function compareNewestTimestamp(
+  left: FeedItem,
+  right: FeedItem,
+  timestamp: (item: FeedItem) => number,
+): number {
+  const delta = timestamp(right) - timestamp(left);
+  return delta || left.globalId.localeCompare(right.globalId);
+}
+
+/**
+ * Sort saved items for the Saved view.
+ */
+export function sortSavedFeedItems(
+  items: FeedItem[],
+  mode: SavedContentSortMode = "date_saved",
+): FeedItem[] {
+  if (mode === "recommended") {
+    return sortByPriority(items);
+  }
+
+  return [...items].sort((left, right) => {
+    if (mode === "date_published") {
+      return compareNewestTimestamp(left, right, (item) => item.publishedAt || item.capturedAt);
+    }
+
+    if (mode === "shortest_read") {
+      const delta = (left.preservedContent?.readingTime ?? Number.POSITIVE_INFINITY) -
+        (right.preservedContent?.readingTime ?? Number.POSITIVE_INFINITY);
+      return delta || compareNewestTimestamp(left, right, (item) => item.userState.savedAt ?? item.capturedAt);
+    }
+
+    return compareNewestTimestamp(left, right, (item) => item.userState.savedAt ?? item.capturedAt);
+  });
 }
 
 /**

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -788,6 +788,7 @@ export interface ReadingEnhancements {
 
 export type SidebarMode = "expanded" | "compact" | "closed";
 export type FeedSignalMode = "all" | "inspiring" | "events" | "personal" | "conversation" | "news";
+export type SavedContentSortMode = "date_saved" | "date_published" | "recommended" | "shortest_read";
 
 export interface DisplayPreferences {
   /** Items per page */
@@ -840,6 +841,9 @@ export interface DisplayPreferences {
 
   /** Saved unified feed signal filter modes. Empty means show all items. */
   feedSignalModes?: FeedSignalMode[];
+
+  /** Saved content sort mode. Unset means newest saved items first. */
+  savedContentSortMode?: SavedContentSortMode;
 
   /** Days to keep archived items before pruning (default: 30, 0 = never prune) */
   archivePruneDays: number;
@@ -1059,6 +1063,7 @@ export function createDefaultPreferences(): UserPreferences {
       mapTimeMode: "current",
       feedSignalMode: "all",
       feedSignalModes: [],
+      savedContentSortMode: "date_saved",
       archivePruneDays: 30,
     },
     xCapture: {

--- a/packages/ui/src/components/feed/FeedView.tsx
+++ b/packages/ui/src/components/feed/FeedView.tsx
@@ -13,6 +13,7 @@ import { useIsMobileDevice } from "../../hooks/useIsMobileDevice.js";
 import {
   buildDiscoveredAccountsFromItems,
   socialAccountForAuthor,
+  sortSavedFeedItems,
   type Account,
   type FeedItem,
 } from "@freed/shared";
@@ -265,6 +266,7 @@ export function FeedView() {
   const toggleArchived = useAppStore((s) => s.toggleArchived);
   const toggleLiked = useAppStore((s) => s.toggleLiked);
   const friendsMode = useAppStore((s) => s.preferences.display.friendsMode ?? "all_content");
+  const savedContentSortMode = useAppStore((s) => s.preferences.display.savedContentSortMode ?? "date_saved");
 
   const handleItemSave = useCallback(
     (item: FeedItem) => toggleSaved(item.globalId),
@@ -323,6 +325,12 @@ export function FeedView() {
     accounts,
     friends,
   );
+  const visibleItems = useMemo(
+    () => activeFilter.savedOnly
+      ? sortSavedFeedItems(filteredItems, savedContentSortMode)
+      : filteredItems,
+    [activeFilter.savedOnly, filteredItems, savedContentSortMode],
+  );
 
   const dualColumnMode = useAppStore((s) => s.preferences.display.reading.dualColumnMode);
   const markReadOnScroll = useAppStore((s) => s.preferences.display.reading.markReadOnScroll);
@@ -347,14 +355,14 @@ export function FeedView() {
   const [keyboardFocusDirection, setKeyboardFocusDirection] = useState<-1 | 0 | 1>(0);
   const [compactSelectionDirection, setCompactSelectionDirection] = useState<-1 | 0 | 1>(0);
   const readerItems = useMemo(() => {
-    if (!readerOrderIds) return filteredItems;
+    if (!readerOrderIds) return visibleItems;
 
-    const itemById = new Map(filteredItems.map((item) => [item.globalId, item]));
+    const itemById = new Map(visibleItems.map((item) => [item.globalId, item]));
     const stableItems = readerOrderIds
       .map((id) => itemById.get(id))
       .filter((item): item is FeedItem => Boolean(item));
-    return stableItems.length > 0 ? stableItems : filteredItems;
-  }, [filteredItems, readerOrderIds]);
+    return stableItems.length > 0 ? stableItems : visibleItems;
+  }, [readerOrderIds, visibleItems]);
   // Store only the ID so the rendered item stays in sync with the store.
   // Holding the full FeedItem in state would freeze userState (saved, archived,
   // tags) at the moment the user clicked, making toolbar toggles appear broken.
@@ -362,10 +370,10 @@ export function FeedView() {
     () =>
       selectedItemId
         ? readerItems.find((item) => item.globalId === selectedItemId) ??
-          filteredItems.find((item) => item.globalId === selectedItemId) ??
+          visibleItems.find((item) => item.globalId === selectedItemId) ??
           null
         : null,
-    [filteredItems, readerItems, selectedItemId],
+    [readerItems, selectedItemId, visibleItems],
   );
 
   const openItem = useCallback(
@@ -376,14 +384,14 @@ export function FeedView() {
       };
 
       if (showDualColumn && !selectedItemId) {
-        setReaderOrderIds(filteredItems.map((candidate) => candidate.globalId));
+        setReaderOrderIds(visibleItems.map((candidate) => candidate.globalId));
         runFeedLayoutTransition(selectItem);
         return;
       }
 
       selectItem();
     },
-    [filteredItems, markAsRead, runFeedLayoutTransition, selectedItemId, setSelectedItem, showDualColumn],
+    [markAsRead, runFeedLayoutTransition, selectedItemId, setSelectedItem, showDualColumn, visibleItems],
   );
 
   const openItemDirect = useCallback((item: FeedItem) => {
@@ -442,20 +450,20 @@ export function FeedView() {
       if (e.key === "j" || e.key === "ArrowDown") {
         e.preventDefault();
         setKeyboardFocusDirection(1);
-        setFocusedIndex((prev) => Math.min(prev + 1, filteredItems.length - 1));
+        setFocusedIndex((prev) => Math.min(prev + 1, visibleItems.length - 1));
       } else if (e.key === "k" || e.key === "ArrowUp") {
         e.preventDefault();
         setKeyboardFocusDirection(-1);
         setFocusedIndex((prev) => Math.max(prev - 1, 0));
       } else if ((e.key === "Enter" || e.key === "o") && focusedIndex >= 0) {
-        const item = filteredItems[focusedIndex];
+        const item = visibleItems[focusedIndex];
         if (item) openItemDirect(item);
       }
     };
 
     document.addEventListener("keydown", handleKey, { capture: true });
     return () => document.removeEventListener("keydown", handleKey, { capture: true });
-  }, [selectedItemId, showDualColumn, filteredItems, readerItems, focusedIndex, openItem, openItemDirect, closeItem]);
+  }, [selectedItemId, showDualColumn, visibleItems, readerItems, focusedIndex, openItem, openItemDirect, closeItem]);
 
   // Reset keyboard focus when the active filter or search query changes.
   useEffect(() => {
@@ -463,7 +471,7 @@ export function FeedView() {
     setKeyboardFocusDirection(0);
     setFocusedIndex(-1);
     setReaderOrderIds(null);
-  }, [activeFilter, searchQuery]);
+  }, [activeFilter, searchQuery, savedContentSortMode]);
 
   const handleFocusChange = useCallback((index: number) => {
     setKeyboardFocusDirection(0);
@@ -627,7 +635,7 @@ export function FeedView() {
   return (
     <div className="h-full flex flex-col">
       <FeedList
-        items={filteredItems}
+        items={visibleItems}
         onItemClick={openItemDirect}
         focusedIndex={focusedIndex}
         focusMoveDirection={keyboardFocusDirection}

--- a/packages/ui/src/components/icons.tsx
+++ b/packages/ui/src/components/icons.tsx
@@ -73,6 +73,19 @@ export function FilterIcon({ className = "w-4 h-4", style }: IconProps) {
   );
 }
 
+/** Sort lines with descending emphasis. */
+export function SortIcon({ className = "w-4 h-4", style }: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round" className={className} style={style} aria-hidden="true">
+      <path d="M5 7h10" />
+      <path d="M5 12h7" />
+      <path d="M5 17h4" />
+      <path d="M17 7v10" />
+      <path d="M14 14l3 3 3-3" />
+    </svg>
+  );
+}
+
 export function MenuIcon({ className = "w-5 h-5", style }: IconProps) {
   return (
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className} style={style} aria-hidden="true">

--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -20,6 +20,7 @@ import {
   type FeedSignalMode,
   type MapMode,
   type MapTimeMode,
+  type SavedContentSortMode,
   type SidebarMode,
   type SocialContentFilter,
   resolveMapMode,
@@ -34,6 +35,7 @@ import {
   ReaderRailShowIcon,
   SidebarCollapseIcon,
   SidebarExpandIcon,
+  SortIcon,
 } from "../icons.js";
 import { useSearchResults } from "../../hooks/useSearchResults.js";
 import { useIsMobile } from "../../hooks/useIsMobile.js";
@@ -109,6 +111,12 @@ const DEFAULT_LAYOUT_CONTROL_RESERVED_WIDTH_PX = 280;
 const TOOLBAR_SLOT_WIDTH_CONTENT = "max-content";
 const TOOLBAR_COLLAPSE_BREAKPOINT_PX = 1200;
 const READER_BOOKMARK_INLINE_MIN_WIDTH_PX = 980;
+const SAVED_SORT_OPTIONS: Array<{ value: SavedContentSortMode; label: string }> = [
+  { value: "date_saved", label: "Date saved" },
+  { value: "date_published", label: "Date published" },
+  { value: "recommended", label: "Recommended" },
+  { value: "shortest_read", label: "Shortest read" },
+];
 
 function formatItemCount(count: number): string {
   return `${count.toLocaleString()} item${count === 1 ? "" : "s"}`;
@@ -258,6 +266,46 @@ function FeedCardDensitySlider({
           <span />
           <span />
         </span>
+      </div>
+    </Tooltip>
+  );
+}
+
+function SavedSortSelect({
+  value,
+  onChange,
+  fullWidth = false,
+  style,
+}: {
+  value: SavedContentSortMode;
+  onChange: (value: SavedContentSortMode) => void;
+  fullWidth?: boolean;
+  style?: CSSProperties;
+}) {
+  return (
+    <Tooltip label="Sort saved content" className={fullWidth ? "w-full" : undefined}>
+      <div
+        data-testid="saved-sort-control"
+        className={`theme-toolbar-select-control ${fullWidth ? "w-full" : ""}`}
+        style={{
+          ...(fullWidth ? { width: "100%" } : {}),
+          ...style,
+        }}
+        onPointerDown={(event) => event.stopPropagation()}
+      >
+        <SortIcon className="h-4 w-4" />
+        <select
+          data-testid="saved-sort-select"
+          value={value}
+          onChange={(event) => onChange(event.target.value as SavedContentSortMode)}
+          aria-label="Sort saved content"
+        >
+          {SAVED_SORT_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
       </div>
     </Tooltip>
   );
@@ -422,6 +470,7 @@ export function Header({
   const showMapTimeControls = activeView === "map";
   const showFeedBulkActions = activeView === "feed";
   const showFeedSignalFilter = activeView === "feed" && !selectedItem;
+  const showSavedSortControl = showFeedSignalFilter && activeFilter.savedOnly === true;
   const showArchivedToolbar = activeView === "feed" && activeFilter.archivedOnly === true;
   const showArchivedDeleteAction = showArchivedToolbar && (display.archivePruneDays ?? 30) > 0;
   const showSocialContentControls =
@@ -449,12 +498,15 @@ export function Header({
       (collapseToolbarViewControls && (
         showWorkspaceIdentityControls ||
         showMapTimeControls ||
-        showSocialContentControls
+        showSocialContentControls ||
+        showSavedSortControl
       )) ||
       ((isMobile || collapseToolbarViewControls) && showFeedSignalFilter)
     );
   const showInlineFeedSignalFilter =
     showFeedSignalFilter && !showCollapsedToolbarFilterMenu;
+  const showInlineSavedSortControl =
+    showSavedSortControl && !showCollapsedToolbarFilterMenu;
   const showFeedCardDensityControl =
     activeView === "feed" &&
     !selectedItem &&
@@ -593,6 +645,7 @@ export function Header({
     : activeFeedSignalModes.length === 1
       ? FEED_SIGNAL_FILTER_PRESETS.find((preset) => preset.mode === activeFeedSignalModes[0])?.label ?? "Custom"
       : `${activeFeedSignalModes.length.toLocaleString()} filters`;
+  const savedContentSortMode = display.savedContentSortMode ?? "date_saved";
   const contextualListTitle = useMemo(() => {
     if (activeView !== "feed") return currentListTitle;
     return contextualFeedTitle({
@@ -718,6 +771,10 @@ export function Header({
 
   const handleMapTimeModeChange = useCallback((mode: MapTimeMode) => {
     updateDisplayPreference({ mapTimeMode: mode });
+  }, [updateDisplayPreference]);
+
+  const handleSavedContentSortModeChange = useCallback((mode: SavedContentSortMode) => {
+    updateDisplayPreference({ savedContentSortMode: mode });
   }, [updateDisplayPreference]);
 
   const handleCloseReader = useCallback(() => {
@@ -1745,6 +1802,16 @@ export function Header({
                   ) : null}
                 </ToolbarAnimatedSlot>
 
+                <ToolbarAnimatedSlot visible={showInlineSavedSortControl} width="10.75rem" className="hidden lg:flex">
+                  {showInlineSavedSortControl ? (
+                    <SavedSortSelect
+                      value={savedContentSortMode}
+                      onChange={handleSavedContentSortModeChange}
+                      style={headerDragRegion ? toolbarControlStyle : undefined}
+                    />
+                  ) : null}
+                </ToolbarAnimatedSlot>
+
                 <ToolbarAnimatedSlot visible={showInlineFeedSignalFilter} width={TOOLBAR_SLOT_WIDTH_CONTENT}>
                   {showInlineFeedSignalFilter ? (
                     <div className="relative flex">
@@ -1929,7 +1996,7 @@ export function Header({
           ) : null}
 
           {showCollapsedToolbarFilterMenu && showWorkspaceIdentityControls ? (
-            <div className={`${showMapTimeControls || showFeedSignalFilter ? "border-b border-[var(--theme-border-subtle)]" : ""} px-3 py-3`}>
+            <div className={`${showMapTimeControls || showSavedSortControl || showFeedSignalFilter ? "border-b border-[var(--theme-border-subtle)]" : ""} px-3 py-3`}>
               <p className="mb-2 px-1 text-[0.68rem] font-semibold uppercase tracking-[0.18em] text-[var(--theme-text-muted)]">
                 Connections
               </p>
@@ -1945,7 +2012,7 @@ export function Header({
           ) : null}
 
           {showCollapsedToolbarFilterMenu && showMapTimeControls ? (
-            <div className="px-3 py-3">
+            <div className={`${showSavedSortControl || showFeedSignalFilter ? "border-b border-[var(--theme-border-subtle)]" : ""} px-3 py-3`}>
               <p className="mb-2 px-1 text-[0.68rem] font-semibold uppercase tracking-[0.18em] text-[var(--theme-text-muted)]">
                 Time
               </p>
@@ -1960,6 +2027,20 @@ export function Header({
                 onChange={handleMapTimeModeChange}
                 compact
                 fullWidth
+              />
+            </div>
+          ) : null}
+
+          {showCollapsedToolbarFilterMenu && showSavedSortControl ? (
+            <div className={`${showFeedSignalFilter ? "border-b border-[var(--theme-border-subtle)]" : ""} px-3 py-3`}>
+              <p className="mb-2 px-1 text-[0.68rem] font-semibold uppercase tracking-[0.18em] text-[var(--theme-text-muted)]">
+                Sort
+              </p>
+              <SavedSortSelect
+                value={savedContentSortMode}
+                onChange={handleSavedContentSortModeChange}
+                fullWidth
+                style={headerDragRegion ? toolbarControlStyle : undefined}
               />
             </div>
           ) : null}

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -1861,6 +1861,45 @@ html.freed-mobile-sidebar-open body {
     0 2px 8px rgb(0 0 0 / 0.18);
 }
 
+.theme-toolbar-select-control {
+  display: inline-flex;
+  box-sizing: border-box;
+  align-items: center;
+  gap: 0.5rem;
+  height: 2.25rem;
+  width: 10.75rem;
+  min-width: 0;
+  padding: 0 0.65rem;
+  border: 1px solid var(--theme-border-subtle);
+  border-radius: var(--button-radius);
+  background: var(--theme-button-secondary-background);
+  color: var(--theme-text-muted);
+}
+
+.theme-toolbar-select-control > svg {
+  flex-shrink: 0;
+}
+
+.theme-toolbar-select-control select {
+  min-width: 0;
+  flex: 1;
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: var(--theme-text-secondary);
+  font-size: 0.875rem;
+  font-weight: 600;
+  line-height: 1;
+  outline: none;
+  cursor: pointer;
+}
+
+.theme-toolbar-select-control select:focus-visible {
+  outline: 2px solid rgb(var(--theme-accent-secondary-rgb) / 0.65);
+  outline-offset: 3px;
+  border-radius: calc(var(--button-radius) - 2px);
+}
+
 .theme-fab-button {
   background: color-mix(
     in oklab,


### PR DESCRIPTION
(AI Generated).

## Summary
- Added a Saved sort control with Date saved, Date published, Recommended, and Shortest read options.
- Kept the control inline on wide toolbars and moved it into the collapsed filter menu on narrow and mobile widths.
- Applied the selected sort to the Saved feed list, keyboard navigation, and reader rail order.

## Testing
- PATH=/Users/aubreyfalconer/dev/freed-saved-sort/node_modules/.bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/usr/local/MacGPG2/bin:/Applications/VMware Fusion.app/Contents/Public:/usr/local/share/dotnet:~/.dotnet/tools:/usr/local/go/bin:/Library/Frameworks/Mono.framework/Versions/Current/Commands:/Users/aubreyfalconer/.nvm/versions/node/v24.14.1/bin:/Users/aubreyfalconer/.codex/tmp/arg0/codex-arg0jhObyX:/Users/aubreyfalconer/.local/bin:/opt/homebrew/opt/mysql-client/bin:/opt/homebrew/bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/Users/aubreyfalconer/.cargo/bin:/Users/aubreyfalconer/go/bin:/Users/aubreyfalconer/.cache/lm-studio/bin:/Users/aubreyfalconer/.safe-chain/bin:/Applications/Codex.app/Contents/Resources:/usr/local/bin npm run test:e2e -- saved-sort.spec.ts (from packages/desktop)
- npm run typecheck
- npm run validate:feature