### PR TITLE
fix: restore macOS edit menu shortcuts

### DIFF
--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -16,9 +16,9 @@ use std::process::Command;
 use std::sync::{Arc, Mutex as StdMutex, RwLock as StdRwLock};
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use sysinfo::{Disks, Pid, ProcessRefreshKind, ProcessesToUpdate, System};
-#[cfg(target_os = "macos")]
-use tauri::menu::Submenu;
 use tauri::menu::{Menu, MenuItem};
+#[cfg(target_os = "macos")]
+use tauri::menu::{PredefinedMenuItem, Submenu};
 use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
 use tauri::{Emitter, Listener, Manager};
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
@@ -8315,8 +8315,31 @@ fn build_macos_app_menu<R: tauri::Runtime, M: Manager<R>>(manager: &M) -> tauri:
         true,
         &[&show_item, &quit_item],
     )?;
+    let undo_item = PredefinedMenuItem::undo(manager, None)?;
+    let redo_item = PredefinedMenuItem::redo(manager, None)?;
+    let edit_history_separator = PredefinedMenuItem::separator(manager)?;
+    let cut_item = PredefinedMenuItem::cut(manager, None)?;
+    let copy_item = PredefinedMenuItem::copy(manager, None)?;
+    let paste_item = PredefinedMenuItem::paste(manager, None)?;
+    let edit_selection_separator = PredefinedMenuItem::separator(manager)?;
+    let select_all_item = PredefinedMenuItem::select_all(manager, None)?;
+    let edit_menu = Submenu::with_items(
+        manager,
+        "Edit",
+        true,
+        &[
+            &undo_item,
+            &redo_item,
+            &edit_history_separator,
+            &cut_item,
+            &copy_item,
+            &paste_item,
+            &edit_selection_separator,
+            &select_all_item,
+        ],
+    )?;
 
-    Menu::with_items(manager, &[&app_menu])
+    Menu::with_items(manager, &[&app_menu, &edit_menu])
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]


### PR DESCRIPTION
(AI Generated).

## Summary
- Restore the standard macOS Edit menu in Freed Desktop so Command+C, Command+V, cut, undo, redo, and select all route through the native responder chain.
- Keep the existing custom Freed app menu and Show/Quit actions.

## Testing
- PATH=/Users/aubreyfalconer/dev/freed-fix-macos-edit-menu/node_modules/.bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/usr/local/MacGPG2/bin:/Applications/VMware Fusion.app/Contents/Public:/usr/local/share/dotnet:~/.dotnet/tools:/usr/local/go/bin:/Library/Frameworks/Mono.framework/Versions/Current/Commands:/Users/aubreyfalconer/.nvm/versions/node/v24.14.1/bin:/Users/aubreyfalconer/.codex/tmp/arg0/codex-arg0jhObyX:/Users/aubreyfalconer/.local/bin:/opt/homebrew/opt/mysql-client/bin:/opt/homebrew/bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/Users/aubreyfalconer/.cargo/bin:/Users/aubreyfalconer/go/bin:/Users/aubreyfalconer/.cache/lm-studio/bin:/Users/aubreyfalconer/.safe-chain/bin:/Applications/Codex.app/Contents/Resources:/usr/local/bin npm run build (packages/desktop)
- cargo check (packages/desktop/src-tauri, passes with existing dead-code warnings for snapshot helpers)
- npm run validate:feature -- --changed-files packages/desktop/src-tauri/src/lib.rs