### PR TITLE
fix: loosen changelog preview release assertion

### DIFF
--- a/packages/desktop/tests/e2e/update-channel.spec.ts
+++ b/packages/desktop/tests/e2e/update-channel.spec.ts
@@ -156,7 +156,7 @@ test("updates settings shows recent changelog entries and opens the full changel
 
   await page.getByTestId("settings-release-channel-select").selectOption("dev");
   await expect(preview.getByRole("article")).toHaveCount(5);
-  await expect(preview.getByText(/v26\.5\.\d+-dev/).first()).toBeVisible();
+  await expect(preview.getByText(/v\d+\.\d+\.\d+-dev/).first()).toBeVisible();
   await page.evaluate(() => {
     const store = window as unknown as Record<string, unknown>;
     delete store.__FREED_E2E_FORCE_MAP_FALLBACK__;


### PR DESCRIPTION
(AI Generated).

## Summary
- Allow the update-channel changelog preview test to match current dev release tags instead of hard-coding an older month.

## Testing
- npm run test:e2e -- update-channel.spec.ts