### PR TITLE
chore: promote dev into main for production release

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freed/desktop",
   "private": true,
-  "version": "26.6.403",
+  "version": "26.6.402",
   "type": "module",
   "scripts": {
     "dev": "node ../../node_modules/vite/bin/vite.js",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freed-desktop"
-version = "26.6.403"
+version = "26.6.402"
 description = "Freed Desktop - Escape algorithmic manipulation"
 authors = ["Freed"]
 edition = "2021"

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Freed",
-  "version": "26.6.403",
+  "version": "26.6.402",
   "identifier": "wtf.freed.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/packages/desktop/tests/e2e/update-channel.spec.ts
+++ b/packages/desktop/tests/e2e/update-channel.spec.ts
@@ -156,7 +156,7 @@ test("updates settings shows recent changelog entries and opens the full changel
 
   await page.getByTestId("settings-release-channel-select").selectOption("dev");
   await expect(preview.getByRole("article")).toHaveCount(5);
-  await expect(preview.getByText(/v26\.5\.\d+-dev/).first()).toBeVisible();
+  await expect(preview.getByText(/v\d+\.\d+\.\d+-dev/).first()).toBeVisible();
   await page.evaluate(() => {
     const store = window as unknown as Record<string, unknown>;
     delete store.__FREED_E2E_FORCE_MAP_FALLBACK__;

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freed/pwa",
   "private": true,
-  "version": "26.6.403",
+  "version": "26.6.402",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
(AI Generated).

## Summary
- Promote the latest origin/dev product snapshot into main after the changelog preview release validation fix.
- Keeps website-owned files out of the main promotion PR.

## Testing
- `node scripts/validate-release-promotion.mjs --from-ref=origin/dev --to-ref=HEAD`
- `node scripts/validate-main-pr.mjs --base-ref=origin/main --head-ref=HEAD --head-branch=chore/promote-dev-to-main-20260604-changelog-fix`