### PR TITLE
fix: keep mobile sidebar above page content

### DIFF
--- a/packages/pwa/tests/app.spec.ts
+++ b/packages/pwa/tests/app.spec.ts
@@ -1666,39 +1666,68 @@ test.describe("FREED PWA", () => {
       const icon = button?.querySelector("[aria-hidden='true']") as HTMLElement | null;
       const sidebar = document.querySelector('[data-testid="app-sidebar-mobile"]') as HTMLElement | null;
       const search = sidebar?.querySelector('input[aria-label="Search or run"]') as HTMLElement | null;
+      const firstSourceButton = sidebar?.querySelector('[data-testid="source-row-all"]') as HTMLElement | null;
       const firstControl = sidebar?.querySelector("input, button") as HTMLElement | null;
       const settingsFooter = sidebar?.querySelector('[data-testid="mobile-sidebar-settings-footer"]') as HTMLElement | null;
       const settingsButton = sidebar?.querySelector('[data-testid="mobile-sidebar-settings-button"]') as HTMLElement | null;
-      if (!button || !icon || !sidebar || !search || !firstControl || !settingsFooter || !settingsButton) {
+      if (!button || !icon || !sidebar || !search || !firstSourceButton || !firstControl || !settingsFooter || !settingsButton) {
         throw new Error("Mobile menu geometry elements were not found");
       }
       const buttonRect = button.getBoundingClientRect();
       const iconRect = icon.getBoundingClientRect();
       const sidebarRect = sidebar.getBoundingClientRect();
       const searchRect = search.getBoundingClientRect();
+      const firstSourceButtonRect = firstSourceButton.getBoundingClientRect();
       const footerRect = settingsFooter.getBoundingClientRect();
       const settingsButtonRect = settingsButton.getBoundingClientRect();
+      const sidebarStyle = window.getComputedStyle(sidebar);
+      const sourceStyle = window.getComputedStyle(firstSourceButton);
+      const settingsButtonStyle = window.getComputedStyle(settingsButton);
+      const footerStyle = window.getComputedStyle(settingsFooter);
+      const sourceCenterX = firstSourceButtonRect.left + firstSourceButtonRect.width / 2;
+      const sourceCenterY = firstSourceButtonRect.top + firstSourceButtonRect.height / 2;
+      const hitElement = document.elementFromPoint(sourceCenterX, sourceCenterY);
       return {
         centerDelta: Math.abs(
           (buttonRect.left + buttonRect.width / 2) -
           (iconRect.left + iconRect.width / 2),
         ),
         firstControlIsSearch: firstControl === search,
+        sourceCenterHitsSidebar: !!hitElement && sidebar.contains(hitElement),
+        sidebarZIndex: Number.parseInt(sidebarStyle.zIndex, 10),
         searchTop: Math.round(searchRect.top),
         sidebarTop: Math.round(sidebarRect.top),
         footerBottomGap: Math.round(sidebarRect.bottom - footerRect.bottom),
-        dividerToBottom: Math.round(sidebarRect.bottom - footerRect.top),
+        footerBorderTopWidth: footerStyle.borderTopWidth,
+        sourceFontSize: sourceStyle.fontSize,
+        sourcePaddingTop: sourceStyle.paddingTop,
+        sourcePaddingBottom: sourceStyle.paddingBottom,
+        sourceColumnGap: sourceStyle.columnGap,
+        settingsButtonFontSize: settingsButtonStyle.fontSize,
+        settingsButtonPaddingTop: settingsButtonStyle.paddingTop,
         settingsButtonHeight: Math.round(settingsButtonRect.height),
       };
     });
     expect(geometry.centerDelta).toBeLessThanOrEqual(1);
     expect(geometry.firstControlIsSearch).toBe(true);
+    expect(geometry.sourceCenterHitsSidebar).toBe(true);
+    expect(geometry.sidebarZIndex).toBeGreaterThan(50);
     expect(geometry.searchTop - geometry.sidebarTop).toBeGreaterThanOrEqual(8);
     expect(geometry.footerBottomGap).toBeLessThanOrEqual(1);
-    expect(geometry.dividerToBottom - geometry.settingsButtonHeight).toBeLessThanOrEqual(2);
+    expect(geometry.footerBorderTopWidth).toBe("0px");
+    expect(geometry.sourceFontSize).toBe("17px");
+    expect(geometry.sourcePaddingTop).toBe("8px");
+    expect(geometry.sourcePaddingBottom).toBe("8px");
+    expect(geometry.sourceColumnGap).toBe("8px");
+    expect(geometry.settingsButtonFontSize).toBe("17px");
+    expect(geometry.settingsButtonPaddingTop).toBe("8px");
+    expect(geometry.settingsButtonHeight).toBeLessThanOrEqual(44);
 
     await menuButton.click();
     await expect(sidebar).toHaveClass(/-translate-x-full/);
+    await expect
+      .poll(() => sidebar.evaluate((element) => window.getComputedStyle(element).boxShadow))
+      .toBe("none");
   });
 
   test("mobile settings opens without hitting recovery", async ({ page }) => {

--- a/packages/ui/src/components/layout/Sidebar.tsx
+++ b/packages/ui/src/components/layout/Sidebar.tsx
@@ -772,14 +772,14 @@ export function Sidebar({
   const expandedSidebarUsesCondensedPadding =
     renderMode === "expanded" && desktopWidth < EXPANDED_SIDEBAR_PADDING_CROSSOVER_WIDTH_PX;
   const sidebarPaddingInlinePx = isMobileDevice
-    ? 20
+    ? 12
     : compactRail
     ? COMPACT_RAIL_OUTER_INSET_PX
     : expandedSidebarUsesCondensedPadding
       ? EXPANDED_SIDEBAR_CONDENSED_PADDING_PX
       : EXPANDED_SIDEBAR_ROOMY_PADDING_PX;
   const sidebarPaddingBlockPx = isMobileDevice
-    ? 14
+    ? 8
     : compactRail
     ? COMPACT_RAIL_OUTER_INSET_PX
     : expandedSidebarUsesCondensedPadding
@@ -819,30 +819,30 @@ export function Sidebar({
   const desktopAsideRenderedWidth = closedPreviewActive ? COMPACT_WIDTH : desktopAsideWidth;
   const compactSidebar = compactRail;
   const rowPaddingClass = isMobileDevice
-    ? "px-3"
+    ? "px-2"
     : compactRail
       ? "px-1.5"
       : narrowLabeledSidebar
         ? "pl-2 pr-0"
         : "px-2.5";
   const rowLeadingPaddingClass = isMobileDevice
-    ? "pl-3"
+    ? "pl-2"
     : compactRail
       ? "pl-1.5"
       : narrowLabeledSidebar
         ? "pl-2"
         : "pl-2.5";
   const rowTrailingPaddingClass = isMobileDevice
-    ? "pr-3"
+    ? "pr-2"
     : compactRail
       ? "pr-1.5"
       : narrowLabeledSidebar
         ? "pr-1.5"
         : "pr-2.5";
-  const rowGapClass = isMobileDevice ? "gap-3.5" : narrowLabeledSidebar ? "gap-2" : "gap-3";
+  const rowGapClass = isMobileDevice ? "gap-2" : narrowLabeledSidebar ? "gap-2" : "gap-3";
   const rowTextClass = isMobileDevice ? "text-base" : "text-sm";
-  const rowVerticalPaddingClass = isMobileDevice ? "py-3" : "py-1.5";
-  const feedRowVerticalPaddingClass = isMobileDevice ? "py-2.5" : "py-2";
+  const rowVerticalPaddingClass = isMobileDevice ? "py-2" : "py-1.5";
+  const feedRowVerticalPaddingClass = "py-2";
   const countTextClass = isMobileDevice ? "text-xs" : "text-[10px]";
   const mobileSidebarWidth = `min(${MOBILE_SIDEBAR_WIDTH_PX}px, calc(100vw - ${MOBILE_SIDEBAR_VIEWPORT_MARGIN_PX}px))`;
   const inlineSearchGapPx = sidebarPaddingBlockPx;
@@ -1847,15 +1847,66 @@ export function Sidebar({
     </nav>
   );
 
-  return (
+  const mobileSidebarLayer = isMobileDevice ? (
     <>
-      {isMobileDevice && mobileOpen && (
+      {mobileOpen && (
         <div
-          className="fixed bottom-0 left-0 right-0 z-20 bg-black/60 md:hidden"
+          className="fixed bottom-0 left-0 right-0 z-[145] bg-black/60 md:hidden"
           style={{ top: `calc(env(safe-area-inset-top, 0px) + ${MOBILE_MENU_TOP_PX}px)` }}
           onClick={onMobileClose}
         />
       )}
+
+      <aside
+        data-testid="app-sidebar-mobile"
+        data-open={mobileOpen ? "true" : "false"}
+        className={`
+          theme-mobile-sidebar fixed left-0 z-[150] flex min-h-0 flex-col overflow-hidden
+          transform transition-transform duration-200 ease-in-out
+          ${mobileOpen ? "translate-x-0" : "-translate-x-full"}
+        `}
+        style={{
+          width: mobileSidebarWidth,
+          top: `calc(env(safe-area-inset-top, 0px) + ${MOBILE_MENU_TOP_PX}px)`,
+          height: `calc(100dvh - env(safe-area-inset-top, 0px) - ${MOBILE_MENU_TOP_PX}px)`,
+          maxHeight: `calc(100dvh - env(safe-area-inset-top, 0px) - ${MOBILE_MENU_TOP_PX}px)`,
+        }}
+        >
+        {sidebarBody}
+        <div
+          data-testid="mobile-sidebar-settings-footer"
+          className="shrink-0"
+          style={{
+            paddingInline: `${sidebarPaddingInlinePx}px`,
+            paddingTop: "4px",
+            paddingBottom: "env(safe-area-inset-bottom, 0px)",
+          }}
+        >
+          <div className={`flex w-full items-center rounded-lg text-base text-[color:var(--theme-text-secondary)] hover:bg-[color:var(--theme-bg-muted)] hover:text-[color:var(--theme-text-primary)] transition-all`}>
+            <button
+              type="button"
+              data-testid="mobile-sidebar-settings-button"
+              onClick={handleOpenSettingsFromMobileSidebar}
+              className={`flex min-w-0 flex-1 cursor-pointer items-center gap-2 ${rowPaddingClass} ${rowVerticalPaddingClass} text-left`}
+            >
+              {settingsButtonContent}
+            </button>
+            <div className="pr-2">
+              {renderActivityButton("background-activity-trigger-mobile")}
+            </div>
+          </div>
+        </div>
+      </aside>
+    </>
+  ) : null;
+  const renderedMobileSidebarLayer =
+    mobileSidebarLayer && typeof document !== "undefined"
+      ? createPortal(mobileSidebarLayer, document.body)
+      : mobileSidebarLayer;
+
+  return (
+    <>
+      {renderedMobileSidebarLayer}
 
       {!isMobileDevice ? (
       <div
@@ -1891,47 +1942,6 @@ export function Sidebar({
           ) : null}
         </div>
       </div>
-      ) : null}
-
-      {isMobileDevice ? (
-      <aside
-        data-testid="app-sidebar-mobile"
-        className={`
-          theme-mobile-sidebar fixed left-0 z-40 flex min-h-0 flex-col overflow-hidden
-          transform transition-transform duration-200 ease-in-out
-          ${mobileOpen ? "translate-x-0" : "-translate-x-full"}
-        `}
-        style={{
-          width: mobileSidebarWidth,
-          top: `calc(env(safe-area-inset-top, 0px) + ${MOBILE_MENU_TOP_PX}px)`,
-          height: `calc(100dvh - env(safe-area-inset-top, 0px) - ${MOBILE_MENU_TOP_PX}px)`,
-          maxHeight: `calc(100dvh - env(safe-area-inset-top, 0px) - ${MOBILE_MENU_TOP_PX}px)`,
-        }}
-        >
-        {sidebarBody}
-        <div
-          data-testid="mobile-sidebar-settings-footer"
-          className="shrink-0 border-t border-[var(--theme-border-subtle)]"
-          style={{
-            paddingInline: `${sidebarPaddingInlinePx}px`,
-            paddingBottom: "env(safe-area-inset-bottom, 0px)",
-          }}
-        >
-          <div className={`flex w-full items-center rounded-lg text-base text-[color:var(--theme-text-secondary)] hover:bg-[color:var(--theme-bg-muted)] hover:text-[color:var(--theme-text-primary)] transition-all`}>
-            <button
-              type="button"
-              data-testid="mobile-sidebar-settings-button"
-              onClick={handleOpenSettingsFromMobileSidebar}
-              className={`flex min-w-0 flex-1 cursor-pointer items-center gap-3 ${rowPaddingClass} ${rowVerticalPaddingClass} text-left`}
-            >
-              {settingsButtonContent}
-            </button>
-            <div className="pr-2">
-              {renderActivityButton("background-activity-trigger-mobile")}
-            </div>
-          </div>
-        </div>
-      </aside>
       ) : null}
 
       <SettingsDialog open={showSettings} onClose={closeSettings} />

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -1572,6 +1572,10 @@ html[data-theme="scriptorium"] .theme-floating-panel {
   box-shadow: 28px 0 80px rgb(0 0 0 / 0.34);
 }
 
+.theme-mobile-sidebar[data-open="false"] {
+  box-shadow: none;
+}
+
 html.freed-mobile-sidebar-open,
 html.freed-mobile-sidebar-open body {
   overflow: hidden;


### PR DESCRIPTION
(AI Generated).

## Summary
- render the mobile sidebar layer through a body portal so page content cannot stack over it
- tighten mobile sidebar spacing to match the mobile settings nav rhythm
- remove the mobile settings footer divider and collapsed drawer shadow
- expand PWA responsive sidebar coverage for layering, spacing, footer chrome, and collapsed shadow

## Validation
- BASE_URL=http://127.0.0.1:15421 PATH=/Users/aubreyfalconer/dev/freed-mobile-sidebar-dev-fix/node_modules/.bin:$PATH npm run test -- app.spec.ts -g "responsive sidebar behavior"
- npm run validate:feature