### PR TITLE
fix: restore story media previews

### DIFF
--- a/packages/ui/src/components/feed/FeedItem.test.tsx
+++ b/packages/ui/src/components/feed/FeedItem.test.tsx
@@ -216,7 +216,43 @@ describe("FeedItem story media", () => {
     expect(html).not.toContain("<video");
   });
 
-  it("suppresses feed media when the platform uses reader-only previews", async () => {
+  it("suppresses non-story feed media when the platform uses reader-only previews", async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root: Root = createRoot(container);
+
+    try {
+      await act(async () => {
+        root.render(
+          <PlatformProvider value={readerOnlyPlatformConfig}>
+            <FeedItem
+              item={makeItem({
+                contentType: "post",
+                content: {
+                  text: "Post text",
+                  mediaUrls: ["https://example.com/post.jpg"],
+                  mediaTypes: ["image"],
+                },
+              })}
+              fixedHeight={220}
+            />
+          </PlatformProvider>,
+        );
+      });
+
+      expect(container.querySelector("img[src='https://example.com/post.jpg']")).toBeNull();
+      expect(container.textContent).toContain("Post text");
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+      (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = false;
+    }
+  });
+
+  it("renders story media when the platform uses reader-only previews", async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     const container = document.createElement("div");
     document.body.appendChild(container);
@@ -231,8 +267,7 @@ describe("FeedItem story media", () => {
         );
       });
 
-      expect(container.querySelector("img[src='https://example.com/post.jpg']")).toBeNull();
-      expect(container.querySelector(".bg-gradient-to-br")).not.toBeNull();
+      expect(container.querySelector("img[src='https://example.com/story.jpg']")).toBeInstanceOf(HTMLImageElement);
     } finally {
       await act(async () => {
         root.unmount();
@@ -354,10 +389,100 @@ describe("FeedItem story media", () => {
     }
   });
 
-  it("suppresses inline media before app pressure reaches the high threshold", async () => {
+  it("keeps inline media below the native app pressure threshold", async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     setMemoryPressure("normal", {
       appMemoryPressureBytes: Math.floor(2.5 * 1024 * 1024 * 1024),
+      memoryHighBytes: Math.floor(5.5 * 1024 * 1024 * 1024),
+    });
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root: Root = createRoot(container);
+
+    try {
+      await act(async () => {
+        root.render(
+          <PlatformProvider value={platformConfig}>
+            <FeedItem item={makeItem()} />
+          </PlatformProvider>,
+        );
+      });
+
+      expect(container.querySelector("img[src='https://example.com/story.jpg']")).toBeInstanceOf(HTMLImageElement);
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+      (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = false;
+    }
+  });
+
+  it("keeps inline media below the native WebKit pressure threshold", async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    setMemoryPressure("normal", {
+      webkitTotalResidentBytes: Math.floor(1.7 * 1024 * 1024 * 1024),
+      memoryHighBytes: Math.floor(5.5 * 1024 * 1024 * 1024),
+    });
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root: Root = createRoot(container);
+
+    try {
+      await act(async () => {
+        root.render(
+          <PlatformProvider value={platformConfig}>
+            <FeedItem item={makeItem()} />
+          </PlatformProvider>,
+        );
+      });
+
+      expect(container.querySelector("img[src='https://example.com/story.jpg']")).toBeInstanceOf(HTMLImageElement);
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+      (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = false;
+    }
+  });
+
+  it("keeps inline media when WebKit resident is high but footprint is below pressure limits", async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    setMemoryPressure("normal", {
+      appMemoryPressureBytes: Math.floor(2.6 * 1024 * 1024 * 1024),
+      memoryHighBytes: Math.floor(5.5 * 1024 * 1024 * 1024),
+      webkitTotalFootprintBytes: Math.floor(2.5 * 1024 * 1024 * 1024),
+      webkitLargestResidentBytes: Math.floor(4.7 * 1024 * 1024 * 1024),
+    });
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root: Root = createRoot(container);
+
+    try {
+      await act(async () => {
+        root.render(
+          <PlatformProvider value={platformConfig}>
+            <FeedItem item={makeItem()} />
+          </PlatformProvider>,
+        );
+      });
+
+      expect(container.querySelector("img[src='https://example.com/story.jpg']")).toBeInstanceOf(HTMLImageElement);
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+      (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = false;
+    }
+  });
+
+  it("suppresses inline media near the adaptive native pressure threshold", async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    setMemoryPressure("normal", {
+      appMemoryPressureBytes: Math.floor(5 * 1024 * 1024 * 1024),
+      memoryHighBytes: Math.floor(5.5 * 1024 * 1024 * 1024),
     });
     const container = document.createElement("div");
     document.body.appendChild(container);
@@ -383,10 +508,10 @@ describe("FeedItem story media", () => {
     }
   });
 
-  it("suppresses inline media when WebKit RSS approaches the live hidden-session pressure range", async () => {
+  it("uses the legacy fixed threshold when native pressure limits are unavailable", async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     setMemoryPressure("normal", {
-      webkitTotalResidentBytes: Math.floor(1.7 * 1024 * 1024 * 1024),
+      appMemoryPressureBytes: Math.floor(2.5 * 1024 * 1024 * 1024),
     });
     const container = document.createElement("div");
     document.body.appendChild(container);

--- a/packages/ui/src/components/feed/FeedItem.tsx
+++ b/packages/ui/src/components/feed/FeedItem.tsx
@@ -65,6 +65,8 @@ const FIXED_CARD_TEXT_LIMIT = 900;
 const FULL_CARD_TEXT_LIMIT = 1_500;
 const FEED_IMAGE_SHED_APP_PRESSURE_BYTES = 2.25 * 1024 * 1024 * 1024;
 const FEED_IMAGE_SHED_WEBKIT_BYTES = 1.5 * 1024 * 1024 * 1024;
+const FEED_IMAGE_SHED_APP_HIGH_FRACTION = 0.85;
+const FEED_IMAGE_SHED_WEBKIT_HIGH_FRACTION = 0.75;
 const EVENT_DATE_FORMAT = new Intl.DateTimeFormat(undefined, {
   month: "short",
   day: "numeric",
@@ -142,16 +144,25 @@ function shouldShedFeedImages(memory: RuntimeMemorySnapshot | null): boolean {
   if (!memory) return false;
   if (memory.pressureLevel === "high" || memory.pressureLevel === "critical") return true;
   const appPressureBytes = memory.appMemoryPressureBytes ?? memory.appResidentBytes ?? memory.processResidentBytes;
-  if (appPressureBytes >= FEED_IMAGE_SHED_APP_PRESSURE_BYTES) return true;
-  const webkitBytes = Math.max(
+  const appShedBytes = memory.memoryHighBytes
+    ? memory.memoryHighBytes * FEED_IMAGE_SHED_APP_HIGH_FRACTION
+    : FEED_IMAGE_SHED_APP_PRESSURE_BYTES;
+  if (appPressureBytes >= appShedBytes) return true;
+  const webkitFootprintBytes = Math.max(
     memory.webkitTotalFootprintBytes ?? 0,
     memory.webkitLargestFootprintBytes ?? 0,
     memory.webkitFootprintBytes ?? 0,
+  );
+  const webkitResidentBytes = Math.max(
     memory.webkitTotalResidentBytes ?? 0,
     memory.webkitLargestResidentBytes ?? 0,
     memory.webkitResidentBytes ?? 0,
   );
-  return webkitBytes >= FEED_IMAGE_SHED_WEBKIT_BYTES;
+  const webkitBytes = webkitFootprintBytes > 0 ? webkitFootprintBytes : webkitResidentBytes;
+  const webkitShedBytes = memory.memoryHighBytes
+    ? memory.memoryHighBytes * FEED_IMAGE_SHED_WEBKIT_HIGH_FRACTION
+    : FEED_IMAGE_SHED_WEBKIT_BYTES;
+  return webkitBytes >= webkitShedBytes;
 }
 
 function useFeedImageBudget(feedMediaPreviews: "inline" | "reader-only"): {
@@ -217,7 +228,8 @@ export const FeedItem = memo(function FeedItem({
   fixedHeight,
 }: FeedItemProps) {
   const { feedMediaPreviews = "inline" } = usePlatform();
-  const { showInlineMedia, showAvatarImages } = useFeedImageBudget(feedMediaPreviews);
+  const feedMediaPreviewMode = item.contentType === "story" ? "inline" : feedMediaPreviews;
+  const { showInlineMedia, showAvatarImages } = useFeedImageBudget(feedMediaPreviewMode);
   const sharedTransitionStyle = {
     viewTransitionName: feedCardTransitionName(item.globalId),
   } as React.CSSProperties;


### PR DESCRIPTION
(AI Generated).

## Summary
- Render captured story media in feed cards even when Desktop keeps ordinary remote post previews reader-only.
- Use native memory pressure thresholds before shedding feed images so normal large-library sessions do not blank story cards.

## Testing
- node node_modules/vitest/vitest.mjs run packages/ui/src/components/feed/FeedItem.test.tsx
- npm run validate:feature