### PR TITLE
fix: resolve cloud conflict without remerging rejected backup

### DIFF
--- a/packages/desktop/src/components/MobileSyncTab.test.tsx
+++ b/packages/desktop/src/components/MobileSyncTab.test.tsx
@@ -130,7 +130,7 @@ describe("MobileSyncTab cloud diagnostics", () => {
         dropbox: { status: "idle" },
         gdrive: {
           status: "connected",
-          stage: "idle",
+          stage: "upload",
           error: "Freed blocked a sync merge because it would remove too much feed history.",
           statusMessage: "Watching for local document changes.",
         },
@@ -148,6 +148,8 @@ describe("MobileSyncTab cloud diagnostics", () => {
 
     expect(recovery?.textContent).toContain("Choose which copy should win.");
     expect(recovery?.textContent).toContain("Keep this device replaces the cloud backup.");
+    expect(container.textContent).toContain("Upload has not completed because sync needs attention.");
+    expect(container.textContent).not.toContain("Uploading now.");
     expect(keepLocal).toBeInstanceOf(HTMLButtonElement);
     expect(keepCloud).toBeInstanceOf(HTMLButtonElement);
 
@@ -198,6 +200,9 @@ describe("MobileSyncTab cloud diagnostics", () => {
       await Promise.resolve();
     });
 
+    expect(container.querySelector("[data-testid='cloud-sync-keep-local-spinner']")).toBeTruthy();
+    expect(keepLocal?.disabled).toBe(true);
+
     await act(async () => {
       useDebugStore.setState({
         cloudProviders: {
@@ -216,9 +221,11 @@ describe("MobileSyncTab cloud diagnostics", () => {
 
     const recovery = container.querySelector("[data-testid='cloud-sync-conflict-recovery']");
     const syncNow = container.querySelector<HTMLButtonElement>("[data-testid='cloud-sync-now-button']");
+    const localSpinner = container.querySelector("[data-testid='cloud-sync-keep-local-spinner']");
 
     expect(recovery?.textContent).toContain("Choose which copy should win.");
     expect(recovery?.textContent).toContain("Replacing...");
+    expect(localSpinner).toBeTruthy();
     expect(syncNow?.disabled).toBe(true);
 
     await act(async () => {

--- a/packages/desktop/src/components/MobileSyncTab.tsx
+++ b/packages/desktop/src/components/MobileSyncTab.tsx
@@ -11,6 +11,7 @@
  */
 
 import { useState, useEffect, useCallback } from "react";
+import { flushSync } from "react-dom";
 import { getPwaHostForChannel } from "@freed/shared";
 import type { CloudProvider } from "@freed/ui/components/CloudProviderCard";
 import { usePlatform } from "@freed/ui/context";
@@ -91,9 +92,9 @@ function DiagnosticCell({ label, value }: { label: string; value: string }) {
 
 function describeUploadGap(state: CloudProviderDebugState | null): string {
   if (!state) return "Connect Google Drive to start cloud sync.";
+  if (state.error) return "Upload has not completed because sync needs attention.";
   if (state.stage === "upload") return "Uploading now.";
   if (state.lastUploadAt) return state.pendingReason ?? "Last upload completed. Waiting for the next local change.";
-  if (state.error) return "Upload has not completed because sync needs attention.";
   if (state.pendingReason) return state.pendingReason;
   if (state.lastDownloadAt) return "Drive was checked, but no upload has completed yet. Use Sync now to upload immediately.";
   return "No upload has completed yet. Use Sync now to force a full pass.";
@@ -208,17 +209,22 @@ export function MobileSyncTab() {
   }, [activeProvider]);
 
   const handleResolveCloudConflict = useCallback(async (winner: CloudConflictWinner) => {
-    if (!activeProvider) return;
+    if (!activeProvider || resolvingConflictWinner) return;
     const providerLabel = activeProvider === "gdrive" ? "Google Drive" : "Dropbox";
+    flushSync(() => {
+      setResolvingConflictWinner(winner);
+      setManualSyncError(null);
+    });
     const confirmed = window.confirm(
       winner === "local"
         ? `Keep this device's library and replace the ${providerLabel} cloud backup?\n\nOther devices will sync from this copy after they reconnect.`
         : `Keep the ${providerLabel} cloud backup and replace this device's library?\n\nLocal items that are missing from the cloud backup will be removed from this device.`,
     );
-    if (!confirmed) return;
+    if (!confirmed) {
+      setResolvingConflictWinner(null);
+      return;
+    }
 
-    setResolvingConflictWinner(winner);
-    setManualSyncError(null);
     try {
       await resolveCloudSyncConflict(activeProvider, winner);
     } catch (error) {
@@ -226,7 +232,7 @@ export function MobileSyncTab() {
     } finally {
       setResolvingConflictWinner(null);
     }
-  }, [activeProvider]);
+  }, [activeProvider, resolvingConflictWinner]);
 
   return (
     <>
@@ -317,7 +323,15 @@ export function MobileSyncTab() {
                     disabled={isResolvingConflict}
                     className="btn-secondary rounded-lg px-3 py-1.5 text-xs disabled:opacity-50"
                   >
-                    {resolvingConflictWinner === "local" ? "Replacing..." : "Keep this device"}
+                    {resolvingConflictWinner === "local" ? (
+                      <span className="inline-flex items-center gap-2">
+                        <span
+                          data-testid="cloud-sync-keep-local-spinner"
+                          className="h-3 w-3 rounded-full border border-current border-t-transparent animate-spin"
+                        />
+                        Replacing...
+                      </span>
+                    ) : "Keep this device"}
                   </button>
                   <button
                     type="button"
@@ -326,7 +340,15 @@ export function MobileSyncTab() {
                     disabled={isResolvingConflict}
                     className="btn-secondary rounded-lg px-3 py-1.5 text-xs disabled:opacity-50"
                   >
-                    {resolvingConflictWinner === "cloud" ? "Replacing..." : "Keep cloud copy"}
+                    {resolvingConflictWinner === "cloud" ? (
+                      <span className="inline-flex items-center gap-2">
+                        <span
+                          data-testid="cloud-sync-keep-cloud-spinner"
+                          className="h-3 w-3 rounded-full border border-current border-t-transparent animate-spin"
+                        />
+                        Replacing...
+                      </span>
+                    ) : "Keep cloud copy"}
                   </button>
                 </div>
               </div>

--- a/packages/desktop/src/lib/cloud-sync-auth-refresh.test.ts
+++ b/packages/desktop/src/lib/cloud-sync-auth-refresh.test.ts
@@ -11,6 +11,7 @@ const logErrorMock = vi.fn();
 const updateCloudProviderMock = vi.fn();
 const recordCloudProviderEventMock = vi.fn();
 const gdriveUploadSafeMock = vi.fn();
+const gdriveUploadReplaceMock = vi.fn();
 const gdriveDeleteFileMock = vi.fn();
 const replaceLocalDocMock = vi.fn();
 
@@ -30,10 +31,12 @@ vi.mock("@freed/sync/cloud", () => ({
   gdriveDownloadLatest: gdriveDownloadLatestMock,
   gdriveStartPollLoop: gdriveStartPollLoopMock,
   gdriveUploadSafe: gdriveUploadSafeMock,
+  gdriveUploadReplace: gdriveUploadReplaceMock,
   gdriveDeleteFile: gdriveDeleteFileMock,
   dropboxDownloadLatest: vi.fn(),
   dropboxStartLongpollLoop: vi.fn(),
   dropboxUploadSafe: vi.fn(),
+  dropboxUploadReplace: vi.fn(),
   dropboxDeleteFile: vi.fn(),
 }));
 
@@ -83,6 +86,7 @@ describe("desktop cloud sync auth refresh", () => {
     updateCloudProviderMock.mockReset();
     recordCloudProviderEventMock.mockReset();
     gdriveUploadSafeMock.mockReset();
+    gdriveUploadReplaceMock.mockReset();
     gdriveDeleteFileMock.mockReset();
     replaceLocalDocMock.mockReset();
     localStorage.clear();
@@ -367,7 +371,7 @@ describe("desktop cloud sync auth refresh", () => {
       refreshToken: "refresh-token",
       expiresAt: Date.now() + 3_600_000,
     });
-    gdriveUploadSafeMock.mockResolvedValue({
+    gdriveUploadReplaceMock.mockResolvedValue({
       fileId: "file-1",
       uploadedBinary: new Uint8Array([1, 2, 3]),
       uploadedBytes: 3,
@@ -379,8 +383,9 @@ describe("desktop cloud sync auth refresh", () => {
     await resolveCloudSyncConflict("gdrive", "local");
     stopAllCloudSyncs();
 
-    expect(gdriveDeleteFileMock).toHaveBeenCalledWith("valid-access-token", undefined);
-    expect(gdriveUploadSafeMock).toHaveBeenCalledWith(
+    expect(gdriveDeleteFileMock).not.toHaveBeenCalled();
+    expect(gdriveUploadSafeMock).not.toHaveBeenCalled();
+    expect(gdriveUploadReplaceMock).toHaveBeenCalledWith(
       "valid-access-token",
       expect.any(Uint8Array),
       undefined,
@@ -419,10 +424,11 @@ describe("desktop cloud sync auth refresh", () => {
     expect(updateCloudProviderMock).toHaveBeenCalledWith("gdrive", expect.objectContaining({
       error: destructiveMergeMessage,
       pendingReason: "Choose which copy should win before cloud sync retries.",
+      stage: "idle",
       status: "error",
     }));
 
-    gdriveUploadSafeMock.mockResolvedValueOnce({
+    gdriveUploadReplaceMock.mockResolvedValueOnce({
       fileId: "file-1",
       uploadedBinary: new Uint8Array([1, 2, 3]),
       uploadedBytes: 3,
@@ -433,8 +439,52 @@ describe("desktop cloud sync auth refresh", () => {
     await resolveCloudSyncConflict("gdrive", "local");
     stopAllCloudSyncs();
 
-    expect(gdriveDeleteFileMock).toHaveBeenCalledWith("valid-access-token", undefined);
-    expect(gdriveUploadSafeMock).toHaveBeenCalledTimes(2);
+    expect(gdriveDeleteFileMock).not.toHaveBeenCalled();
+    expect(gdriveUploadSafeMock).toHaveBeenCalledTimes(1);
+    expect(gdriveUploadReplaceMock).toHaveBeenCalledTimes(1);
+    expect(updateCloudProviderMock).toHaveBeenCalledWith("gdrive", expect.objectContaining({
+      statusMessage: "This device replaced the cloud backup.",
+    }));
+  });
+
+  it("waits for active local indexing before applying a cloud conflict recovery", async () => {
+    const { resolveCloudSyncConflict, storeCloudToken, stopAllCloudSyncs } = await import("./sync");
+    const coordinator = await import("./background-runtime-coordinator");
+    coordinator.resetBackgroundRuntimeForTests({ requireRendererHealth: false });
+    storeCloudToken("gdrive", {
+      accessToken: "valid-access-token",
+      refreshToken: "refresh-token",
+      expiresAt: Date.now() + 3_600_000,
+    });
+    gdriveUploadReplaceMock.mockResolvedValue({
+      fileId: "file-1",
+      uploadedBinary: new Uint8Array([1, 2, 3]),
+      uploadedBytes: 3,
+      remoteBytes: 0,
+      mergedRemote: false,
+    });
+    gdriveDownloadLatestMock.mockResolvedValue(null);
+
+    let releaseIndexing!: () => void;
+    const indexing = coordinator.runBackgroundJob({
+      kind: "semantic-classifier",
+      source: "content-signals",
+      run: () => new Promise<void>((resolve) => {
+        releaseIndexing = resolve;
+      }),
+    });
+    await Promise.resolve();
+
+    const recovery = resolveCloudSyncConflict("gdrive", "local");
+    await Promise.resolve();
+    expect(gdriveUploadReplaceMock).not.toHaveBeenCalled();
+
+    releaseIndexing();
+    await indexing;
+    await recovery;
+    stopAllCloudSyncs();
+
+    expect(gdriveUploadReplaceMock).toHaveBeenCalledTimes(1);
     expect(updateCloudProviderMock).toHaveBeenCalledWith("gdrive", expect.objectContaining({
       statusMessage: "This device replaced the cloud backup.",
     }));

--- a/packages/desktop/src/lib/gdrive-sync.test.ts
+++ b/packages/desktop/src/lib/gdrive-sync.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as A from "@automerge/automerge";
 import { addFeedItem, createEmptyDoc, type FreedDoc } from "@freed/shared/schema";
 import type { FeedItem } from "@freed/shared";
-import { gdriveDownloadLatest, gdriveStartPollLoop, gdriveUploadSafe } from "@freed/sync/cloud";
+import { gdriveDownloadLatest, gdriveStartPollLoop, gdriveUploadReplace, gdriveUploadSafe } from "@freed/sync/cloud";
 
 function jsonResponse(body: unknown, init?: ResponseInit): Response {
   return new Response(JSON.stringify(body), {
@@ -159,6 +159,40 @@ describe("Google Drive cloud sync", () => {
       expect.stringContaining("/upload/drive/v3/files/file-1"),
       expect.anything(),
     );
+  });
+
+  it("replaces Drive contents without downloading remote history for conflict recovery", async () => {
+    const uploadHeaders: HeadersInit[] = [];
+    const uploadBodies: Array<BodyInit | null | undefined> = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/files?")) {
+        return jsonResponse({ files: [{ id: "file-1" }] });
+      }
+      if (url.includes("/files/file-1?fields=") || url.includes("/files/file-1?alt=media")) {
+        throw new Error("Authoritative replace should not download the cloud backup.");
+      }
+      if (url.includes("/upload/drive/v3/files/file-1")) {
+        uploadHeaders.push(init?.headers ?? {});
+        uploadBodies.push(init?.body);
+        return jsonResponse({});
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await gdriveUploadReplace("token", new Uint8Array([7, 8, 9]));
+
+    expect(uploadHeaders).toHaveLength(1);
+    expect(uploadHeaders[0]).not.toHaveProperty("If-Match");
+    expect(uploadBodies[0]).toBeInstanceOf(ArrayBuffer);
+    expect(Array.from(new Uint8Array(uploadBodies[0] as ArrayBuffer))).toEqual([7, 8, 9]);
+    expect(result).toMatchObject({
+      fileId: "file-1",
+      uploadedBytes: 3,
+      remoteBytes: 0,
+      mergedRemote: false,
+    });
   });
 
   it("can route Drive downloads through a platform fetcher", async () => {

--- a/packages/desktop/src/lib/sync.ts
+++ b/packages/desktop/src/lib/sync.ts
@@ -11,10 +11,12 @@ import { listen } from "@tauri-apps/api/event";
 import { open as shellOpen } from "@tauri-apps/plugin-shell";
 import {
   gdriveUploadSafe,
+  gdriveUploadReplace,
   gdriveStartPollLoop,
   gdriveDownloadLatest,
   gdriveDeleteFile,
   dropboxUploadSafe,
+  dropboxUploadReplace,
   dropboxStartLongpollLoop,
   dropboxDownloadLatest,
   dropboxDeleteFile,
@@ -312,6 +314,7 @@ const UPLOAD_DEFER_BACKOFF_MAX_MS = 120_000;
 const UPLOAD_ACTIVE_JOB_WAIT_MS = 30_000;
 const UPLOAD_ACTIVE_JOB_RETRY_MS = 5_000;
 const UPLOAD_WAIT_FOR_ACTIVE_JOB_KINDS = ["outbox", "social-scrape"] as const satisfies readonly BackgroundJobKind[];
+const CONFLICT_RECOVERY_ACTIVE_JOB_WAIT_MS = 120_000;
 const INITIAL_DOWNLOAD_DEFER_BACKOFF_BASE_MS = 15_000;
 const INITIAL_DOWNLOAD_DEFER_BACKOFF_MAX_MS = 180_000;
 const TOKEN_REFRESH_SKEW_MS = 60_000;
@@ -441,7 +444,7 @@ function markCloudError(provider: CloudProvider, stage: "auth" | "download" | "m
   }
   updateCloudProvider(provider, {
     status: "error",
-    stage,
+    stage: destructiveMergeBlocked ? "idle" : stage,
     error: message,
     statusMessage: message,
     pendingReason: destructiveMergeBlocked
@@ -1377,6 +1380,7 @@ export async function resolveCloudSyncConflict(
   const token = await getValidCloudToken(provider);
   if (!token) throw new Error("Cloud token missing. Reconnect the provider.");
 
+  const blockedMergeMessage = blockedDestructiveMergeProviders.get(provider);
   blockedDestructiveMergeProviders.delete(provider);
   stopCloudSync(provider);
   updateCloudProvider(provider, {
@@ -1403,11 +1407,9 @@ export async function resolveCloudSyncConflict(
         kind: "cloud-sync",
         source: `cloud:${provider}:conflict-local-wins`,
         timeoutMs: 180_000,
-        waitForActiveJobMs: UPLOAD_ACTIVE_JOB_WAIT_MS,
-        waitForActiveJobKinds: UPLOAD_WAIT_FOR_ACTIVE_JOB_KINDS,
+        waitForActiveJobMs: CONFLICT_RECOVERY_ACTIVE_JOB_WAIT_MS,
         run: async () => {
-          await deleteCloudFile(provider, token);
-          await performCloudUpload(provider, token);
+          await performCloudUpload(provider, token, { authoritativeReplace: true });
         },
       });
       await startCloudSync(provider, token);
@@ -1426,8 +1428,7 @@ export async function resolveCloudSyncConflict(
       kind: "cloud-sync",
       source: `cloud:${provider}:conflict-cloud-wins`,
       timeoutMs: 180_000,
-      waitForActiveJobMs: UPLOAD_ACTIVE_JOB_WAIT_MS,
-      waitForActiveJobKinds: UPLOAD_WAIT_FOR_ACTIVE_JOB_KINDS,
+      waitForActiveJobMs: CONFLICT_RECOVERY_ACTIVE_JOB_WAIT_MS,
       run: async () => {
         const remote = provider === "gdrive"
           ? await gdriveDownloadLatest(token, undefined, googleDriveFetch)
@@ -1446,12 +1447,30 @@ export async function resolveCloudSyncConflict(
     });
     recordCloudStep(provider, "success", "idle", "This device now uses the cloud backup.");
   } catch (error) {
+    if (isBackgroundRuntimeDeferredError(error) && blockedMergeMessage) {
+      const pendingReason = formatBackgroundRuntimeDeferredReason(error.reason);
+      blockedDestructiveMergeProviders.set(provider, blockedMergeMessage);
+      updateCloudProvider(provider, {
+        status: "error",
+        stage: "idle",
+        error: blockedMergeMessage,
+        statusMessage: blockedMergeMessage,
+        pendingReason,
+        lastErrorAt: Date.now(),
+      });
+      recordCloudStep(provider, "deferred", "idle", `Sync recovery deferred: ${pendingReason}`);
+      throw error;
+    }
     markCloudError(provider, winner === "local" ? "upload" : "download", error);
     throw error;
   }
 }
 
-async function performCloudUpload(provider: CloudProvider, token?: string): Promise<void> {
+async function performCloudUpload(
+  provider: CloudProvider,
+  token?: string,
+  options: { authoritativeReplace?: boolean } = {},
+): Promise<void> {
   const startedAt = Date.now();
   let byteLength = 0;
   try {
@@ -1461,7 +1480,9 @@ async function performCloudUpload(provider: CloudProvider, token?: string): Prom
     if (!uploadToken) throw new Error("Cloud token missing. Reconnect the provider.");
     markCloudAttempt(provider, "upload", "Uploading local document to cloud storage.");
     if (provider === "gdrive") {
-      const result = await gdriveUploadSafe(uploadToken, binary, googleDriveFetch);
+      const result = options.authoritativeReplace
+        ? await gdriveUploadReplace(uploadToken, binary, googleDriveFetch)
+        : await gdriveUploadSafe(uploadToken, binary, googleDriveFetch);
       if (result.mergedRemote) {
         markCloudAttempt(provider, "merge", "Merging remote data discovered during upload.");
         await mergeDoc(result.uploadedBinary);
@@ -1479,7 +1500,11 @@ async function performCloudUpload(provider: CloudProvider, token?: string): Prom
         eventBytes: result.uploadedBytes,
       });
     } else {
-      await dropboxUploadSafe(uploadToken, binary);
+      if (options.authoritativeReplace) {
+        await dropboxUploadReplace(uploadToken, binary);
+      } else {
+        await dropboxUploadSafe(uploadToken, binary);
+      }
       markCloudSuccess(provider, {
         stage: "idle",
         lastUploadAt: Date.now(),

--- a/packages/sync/src/cloud/dropbox.ts
+++ b/packages/sync/src/cloud/dropbox.ts
@@ -97,6 +97,30 @@ export async function dropboxUploadSafe(token: string, localBinary: Uint8Array):
   throw new Error("Dropbox upload failed after max retries (concurrent write conflict)");
 }
 
+/**
+ * Authoritative upload used only after the user chooses this device as the
+ * conflict winner. Normal uploads must use dropboxUploadSafe so concurrent
+ * writes still merge.
+ */
+export async function dropboxUploadReplace(token: string, localBinary: Uint8Array): Promise<void> {
+  const res = await fetch(DBX_UPLOAD, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/octet-stream",
+      "Dropbox-API-Arg": JSON.stringify({
+        path: DBX_PATH,
+        mode: { ".tag": "overwrite" },
+      }),
+    },
+    body: localBinary as BodyInit,
+  });
+
+  if (!res.ok) {
+    throw new Error(`Dropbox replace failed: ${res.status}`);
+  }
+}
+
 export async function dropboxDownloadLatest(
   token: string,
   signal?: AbortSignal,

--- a/packages/sync/src/cloud/gdrive.ts
+++ b/packages/sync/src/cloud/gdrive.ts
@@ -184,6 +184,38 @@ export async function gdriveUploadSafe(
   throw new Error("GDrive upload failed after max retries (concurrent write conflict)");
 }
 
+/**
+ * Authoritative upload used only after the user chooses this device as the
+ * conflict winner. Normal uploads must use gdriveUploadSafe so concurrent
+ * writes still merge. This path intentionally does not download or merge the
+ * remote binary because the user has already rejected that cloud copy.
+ */
+export async function gdriveUploadReplace(
+  token: string,
+  localBinary: Uint8Array,
+  googleFetch: GoogleDriveFetch = fetch,
+): Promise<CloudUploadResult> {
+  const fileId = await ensureFile(token, undefined, googleFetch);
+  const res = await googleFetch(`${GDRIVE_UPLOAD}/${fileId}?uploadType=media`, {
+    method: "PATCH",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/octet-stream",
+    },
+    body: bytesToUploadBody(localBinary),
+  });
+
+  if (!res.ok) throw await gdriveError("GDrive replace failed", res);
+
+  return {
+    fileId,
+    uploadedBinary: localBinary,
+    uploadedBytes: localBinary.byteLength,
+    remoteBytes: 0,
+    mergedRemote: false,
+  };
+}
+
 export async function gdriveDownloadLatest(
   token: string,
   signal?: AbortSignal,

--- a/packages/sync/src/cloud/index.ts
+++ b/packages/sync/src/cloud/index.ts
@@ -13,6 +13,7 @@
 export type { CloudProvider } from "./types.js";
 export {
   gdriveUploadSafe,
+  gdriveUploadReplace,
   gdriveDownloadLatest,
   gdriveStartPollLoop,
   gdriveDeleteFile,
@@ -21,6 +22,7 @@ export {
 } from "./gdrive.js";
 export {
   dropboxUploadSafe,
+  dropboxUploadReplace,
   dropboxDownloadLatest,
   dropboxStartLongpollLoop,
   dropboxDeleteFile,


### PR DESCRIPTION
(AI Generated).

## Summary
- Keeps normal cloud uploads on the safe merge path, but makes explicit conflict recovery replace the rejected cloud backup without downloading and merging it again.
- Shows an immediate spinner and disables the recovery buttons as soon as a winner is clicked, before token lookup or background work can lag.
- Lets conflict recovery wait behind any active background job instead of immediately resetting when local indexing is active.
- Fixes sync diagnostics so destructive-merge blocks do not claim an upload is still running.

## Testing
- npm run test:unit -- cloud-sync-auth-refresh.test.ts MobileSyncTab.test.tsx gdrive-sync.test.ts
- PATH="/Users/aubreyfalconer/dev/freed-cloud-conflict-loop/node_modules/.bin:$PATH" npm run test:unit -- schema.test.ts identity-graph-v2.test.ts
- npm run validate:feature (stopped in PWA unit tests due unrelated loaded-machine budget failures, then failed PWA specs passed on focused rerun)
