### PR TITLE
fix: stabilize changelog preview test

### DIFF
--- a/packages/desktop/tests/e2e/update-channel.spec.ts
+++ b/packages/desktop/tests/e2e/update-channel.spec.ts
@@ -148,7 +148,7 @@ test("updates settings shows recent changelog entries and opens the full changel
   await expect(preview).toBeVisible({ timeout: 5_000 });
   await expect(settingsDialog.getByText(/Installed version:\s*v\d+\.\d+\.\d+(?:-dev)?/)).toBeVisible();
   await expect(preview.getByRole("article")).toHaveCount(5);
-  await expect(preview.getByText("v26.5.702")).toBeVisible();
+  await expect(preview.getByRole("article").first().getByText(/^v\d+\.\d+\.\d+$/)).toBeVisible();
   await expect(preview.getByText(/-dev/)).toHaveCount(0);
 
   await preview.getByRole("button", { name: "Show full changelog" }).click();


### PR DESCRIPTION
(AI Generated).

Fixes the production release validation failure by making the update-channel changelog preview test assert the production channel shape instead of one stale historical release number.

Validation: npm run test:e2e -- update-channel.spec.ts
