### PR TITLE
chore: promote dev changelog preview fix

### DIFF
--- a/packages/desktop/tests/e2e/update-channel.spec.ts
+++ b/packages/desktop/tests/e2e/update-channel.spec.ts
@@ -148,7 +148,7 @@ test("updates settings shows recent changelog entries and opens the full changel
   await expect(preview).toBeVisible({ timeout: 5_000 });
   await expect(settingsDialog.getByText(/Installed version:\s*v\d+\.\d+\.\d+(?:-dev)?/)).toBeVisible();
   await expect(preview.getByRole("article")).toHaveCount(5);
-  await expect(preview.getByText("v26.5.702")).toBeVisible();
+  await expect(preview.getByRole("article").first().getByText(/^v\d+\.\d+\.\d+$/)).toBeVisible();
   await expect(preview.getByText(/-dev/)).toHaveCount(0);
 
   await preview.getByRole("button", { name: "Show full changelog" }).click();


### PR DESCRIPTION
(AI Generated).

Promotes the dev changelog preview test fix into main so production release validation can pass before the follow-up build.

Validation: node scripts/validate-release-promotion.mjs --from-ref=origin/dev --to-ref=HEAD; node scripts/validate-main-pr.mjs --base-ref=origin/main --head-ref=HEAD --head-branch=chore/promote-dev-to-main-20260605-changelog-preview
