### PR TITLE
chore: refresh website changelog for v26.6.504

### DIFF
--- a/release-notes/daily/production/26.6.5.json
+++ b/release-notes/daily/production/26.6.5.json
@@ -1,0 +1,14 @@
+{
+  "channel": "production",
+  "dayKey": "26.6.5",
+  "date": "2026-06-05",
+  "preferredDeck": null,
+  "editorialGuidance": [
+    "Keep the tone concise, professional, and specific.",
+    "Lead with user-facing outcomes, shipping milestones, trust wins, and installability improvements.",
+    "Demote internal cleanup unless it clearly changes the shipped product."
+  ],
+  "pinnedHighlights": [],
+  "editorialNotes": [],
+  "updatedAt": "2026-06-05T22:27:30.351Z"
+}

--- a/release-notes/releases/v26.6.504.json
+++ b/release-notes/releases/v26.6.504.json
@@ -1,0 +1,53 @@
+{
+  "tag": "v26.6.504",
+  "version": "26.6.504",
+  "channel": "production",
+  "dayKey": "26.6.5",
+  "approved": true,
+  "editorialNotes": [],
+  "generatedAt": "2026-06-05T22:27:30.350Z",
+  "model": "heuristic",
+  "source": {
+    "channel": "production",
+    "previousPublishedTag": "v26.6.407",
+    "previousPublishedDayTag": "v26.6.407",
+    "compareRef": "HEAD",
+    "isLatestOfDay": true,
+    "sameDayTagsIncluded": [
+      "v26.6.504"
+    ],
+    "relatedBuildTags": [
+      "v26.6.502-dev",
+      "v26.6.504"
+    ],
+    "prNumbers": [
+      763,
+      764,
+      766,
+      769,
+      772,
+      774,
+      775,
+      777,
+      780
+    ],
+    "commitSubjects": [
+      "chore: promote dev changelog preview fix (#780)",
+      "release: v26.6.503",
+      "chore: promote dev into main for production release (#777)"
+    ]
+  },
+  "release": {
+    "deck": "Recent story media now loads in Freed Desktop with safer feed memory handling, more reliable cloud merge recovery, and clearer sync UI feedback.",
+    "features": [],
+    "fixes": [
+      "Recent story cards show captured media previews again",
+      "Feed image shedding now follows native memory pressure limits instead of blanking media too early",
+      "Cloud merge recovery and mobile sidebar behavior are more stable"
+    ],
+    "followUps": [
+      "Stabilize update hover regression"
+    ]
+  },
+  "releaseBody": "(AI Generated).\n\n## Freed v26.6.504\n\nRecent story media now loads in Freed Desktop with safer feed memory handling, more reliable cloud merge recovery, and clearer sync UI feedback.\n\n### Fixes\n\n- Recent story cards show captured media previews again\n- Feed image shedding now follows native memory pressure limits instead of blanking media too early\n- Cloud merge recovery and mobile sidebar behavior are more stable\n\n### Follow-ups\n\n- Stabilize update hover regression\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+}

--- a/release-notes/releases/v26.6.504.md
+++ b/release-notes/releases/v26.6.504.md
@@ -1,0 +1,23 @@
+(AI Generated).
+
+## Freed v26.6.504
+
+Recent story media now loads in Freed Desktop with safer feed memory handling, more reliable cloud merge recovery, and clearer sync UI feedback.
+
+### Fixes
+
+- Recent story cards show captured media previews again
+- Feed image shedding now follows native memory pressure limits instead of blanking media too early
+- Cloud merge recovery and mobile sidebar behavior are more stable
+
+### Follow-ups
+
+- Stabilize update hover regression
+
+### Downloads
+
+**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  
+**Windows:** `.exe` (NSIS installer)  
+**Linux:** `.AppImage`  
+
+> macOS downloads are signed and notarized for normal Gatekeeper installation.

--- a/website/public/atom.xml
+++ b/website/public/atom.xml
@@ -2,7 +2,7 @@
 <feed xmlns="http://www.w3.org/2005/Atom">
     <id>https://freed.wtf</id>
     <title>Freed Blog</title>
-    <updated>2026-06-04T22:37:26.735Z</updated>
+    <updated>2026-06-05T23:11:52.553Z</updated>
     <generator>https://github.com/jpmonette/feed</generator>
     <author>
         <name>The Freed Team</name>

--- a/website/public/feed.xml
+++ b/website/public/feed.xml
@@ -4,7 +4,7 @@
         <title>Freed Blog</title>
         <link>https://freed.wtf</link>
         <description>Progress reports, technical deep-dives, and philosophical rants about the attention economy. From the team building Freed.</description>
-        <lastBuildDate>Thu, 04 Jun 2026 22:37:26 GMT</lastBuildDate>
+        <lastBuildDate>Fri, 05 Jun 2026 23:11:52 GMT</lastBuildDate>
         <docs>https://validator.w3.org/feed/docs/rss2.html</docs>
         <generator>https://github.com/jpmonette/feed</generator>
         <language>en</language>

--- a/website/src/content/changelog.generated.json
+++ b/website/src/content/changelog.generated.json
@@ -1,5 +1,93 @@
 [
   {
+    "version": "26.6.504",
+    "tagName": "v26.6.504",
+    "channel": "production",
+    "date": "2026-06-05T23:06:10Z",
+    "deck": "Recent story media now loads in Freed Desktop with safer feed memory handling, more reliable cloud merge recovery, and clearer sync UI feedback.",
+    "features": [],
+    "fixes": [
+      {
+        "text": "Recent story cards show captured media previews again"
+      },
+      {
+        "text": "Feed image shedding now follows native memory pressure limits instead of blanking media too early"
+      },
+      {
+        "text": "Cloud merge recovery and mobile sidebar behavior are more stable"
+      }
+    ],
+    "followUps": [
+      {
+        "text": "Stabilize update hover regression"
+      }
+    ],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.504",
+    "prNumbers": [
+      763,
+      764,
+      766,
+      769,
+      772,
+      774,
+      775,
+      777,
+      780
+    ],
+    "builds": [
+      "26.6.504"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.6.504",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.504",
+        "channel": "production"
+      }
+    ]
+  },
+  {
+    "version": "26.6.502-dev",
+    "tagName": "v26.6.502-dev",
+    "channel": "dev",
+    "date": "2026-06-05T16:30:34Z",
+    "deck": "Recent story media now loads in Freed Desktop with safer feed media memory handling",
+    "features": [],
+    "fixes": [
+      {
+        "text": "Recent story cards show captured media previews again"
+      },
+      {
+        "text": "Feed image shedding now follows native memory pressure limits instead of blanking media too early"
+      },
+      {
+        "text": "Cloud merge recovery and mobile sidebar behavior are more stable"
+      }
+    ],
+    "followUps": [
+      {
+        "text": "Polish activity popover placement"
+      },
+      {
+        "text": "Stabilize update hover regression"
+      },
+      {
+        "text": "Loosen changelog preview release assertion"
+      }
+    ],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.502-dev",
+    "prNumbers": [],
+    "builds": [
+      "26.6.502-dev"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.6.502-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.502-dev",
+        "channel": "dev"
+      }
+    ]
+  },
+  {
     "version": "26.6.407",
     "tagName": "v26.6.407",
     "channel": "production",


### PR DESCRIPTION
(AI Generated).

Refreshes the public changelog and feeds for the published v26.6.504 production release.

Validation: PATH=/Users/aubreyfalconer/dev/freed-www-v26-6-504-changelog/node_modules/.bin:$PATH npm run build
