### PR TITLE
fix: keep cloud conflict recovery responsive

### DIFF
--- a/packages/desktop/src/components/MobileSyncTab.test.tsx
+++ b/packages/desktop/src/components/MobileSyncTab.test.tsx
@@ -136,7 +136,7 @@ describe("MobileSyncTab cloud diagnostics", () => {
         },
       },
     });
-    const confirmMock = vi.spyOn(window, "confirm").mockReturnValue(true);
+    const confirmMock = vi.spyOn(window, "confirm");
 
     await act(async () => {
       root.render(<MobileSyncTab />);
@@ -158,7 +158,7 @@ describe("MobileSyncTab cloud diagnostics", () => {
       await Promise.resolve();
     });
 
-    expect(confirmMock).toHaveBeenCalledWith(expect.stringContaining("replace the Google Drive cloud backup"));
+    expect(confirmMock).not.toHaveBeenCalled();
     expect(mocks.resolveCloudSyncConflict).toHaveBeenCalledWith("gdrive", "local");
 
     await act(async () => {
@@ -188,7 +188,7 @@ describe("MobileSyncTab cloud diagnostics", () => {
         },
       },
     });
-    const confirmMock = vi.spyOn(window, "confirm").mockReturnValue(true);
+    const confirmMock = vi.spyOn(window, "confirm");
 
     await act(async () => {
       root.render(<MobileSyncTab />);
@@ -202,6 +202,7 @@ describe("MobileSyncTab cloud diagnostics", () => {
 
     expect(container.querySelector("[data-testid='cloud-sync-keep-local-spinner']")).toBeTruthy();
     expect(keepLocal?.disabled).toBe(true);
+    expect(confirmMock).not.toHaveBeenCalled();
 
     await act(async () => {
       useDebugStore.setState({

--- a/packages/desktop/src/components/MobileSyncTab.tsx
+++ b/packages/desktop/src/components/MobileSyncTab.tsx
@@ -210,20 +210,10 @@ export function MobileSyncTab() {
 
   const handleResolveCloudConflict = useCallback(async (winner: CloudConflictWinner) => {
     if (!activeProvider || resolvingConflictWinner) return;
-    const providerLabel = activeProvider === "gdrive" ? "Google Drive" : "Dropbox";
     flushSync(() => {
       setResolvingConflictWinner(winner);
       setManualSyncError(null);
     });
-    const confirmed = window.confirm(
-      winner === "local"
-        ? `Keep this device's library and replace the ${providerLabel} cloud backup?\n\nOther devices will sync from this copy after they reconnect.`
-        : `Keep the ${providerLabel} cloud backup and replace this device's library?\n\nLocal items that are missing from the cloud backup will be removed from this device.`,
-    );
-    if (!confirmed) {
-      setResolvingConflictWinner(null);
-      return;
-    }
 
     try {
       await resolveCloudSyncConflict(activeProvider, winner);

--- a/packages/desktop/src/hooks/useCloudProviders.test.tsx
+++ b/packages/desktop/src/hooks/useCloudProviders.test.tsx
@@ -103,4 +103,22 @@ describe("useCloudProviders", () => {
     expect(mocks.storeCloudToken).not.toHaveBeenCalled();
     expect(mocks.startCloudSync).not.toHaveBeenCalled();
   });
+
+  it("does not clear existing cloud sync errors when a provider is connected", async () => {
+    mocks.getCloudToken.mockImplementation((provider: string) =>
+      provider === "gdrive" ? "test-access-token" : null,
+    );
+
+    await act(async () => {
+      root.render(<Harness />);
+    });
+
+    expect(container.querySelector("[data-testid='gdrive-status']")?.textContent).toBe("connected");
+    expect(mocks.updateCloudProvider).toHaveBeenCalledWith("gdrive", { status: "connected" });
+    const gdriveCall = mocks.updateCloudProvider.mock.calls.find(
+      ([provider]) => provider === "gdrive",
+    );
+    expect(gdriveCall?.[1]).toEqual({ status: "connected" });
+    expect(Object.hasOwn(gdriveCall?.[1] ?? {}, "error")).toBe(false);
+  });
 });

--- a/packages/desktop/src/hooks/useCloudProviders.ts
+++ b/packages/desktop/src/hooks/useCloudProviders.ts
@@ -112,10 +112,10 @@ export function useCloudProviders() {
   // Keep the debug panel's cloud sync section in sync with live provider state.
   useEffect(() => {
     (["gdrive", "dropbox"] as const).forEach((provider) => {
-      updateCloudProvider(provider, {
-        status: providers[provider].status,
-        error: providers[provider].status === "error" ? providers[provider].error : undefined,
-      });
+      const providerState = providers[provider];
+      updateCloudProvider(provider, providerState.status === "error"
+        ? { status: providerState.status, error: providerState.error }
+        : { status: providerState.status });
     });
   }, [providers]);
 

--- a/packages/desktop/tests/e2e/cloud-conflict-recovery.spec.ts
+++ b/packages/desktop/tests/e2e/cloud-conflict-recovery.spec.ts
@@ -1,0 +1,99 @@
+import { test, expect, resolveViteFsModulePath } from "./fixtures/app";
+
+const DEBUG_STORE_PATH = resolveViteFsModulePath(
+  "../../../ui/src/lib/debug-store.ts",
+  import.meta.url,
+);
+
+async function seedAcceptedDesktopConsent(page: import("@playwright/test").Page) {
+  await page.addInitScript(() => {
+    window.localStorage.setItem(
+      "__TAURI_MOCK_STORE__:legal.json",
+      JSON.stringify({
+        "legal.bundle.desktop": {
+          version: "2026-03-31.1",
+          acceptedAt: 1775146800000,
+          surface: "desktop-first-run",
+        },
+      }),
+    );
+  });
+}
+
+test("cloud conflict recovery click shows progress without a blocking browser confirm", async ({
+  app,
+  page,
+  ipc,
+}) => {
+  await seedAcceptedDesktopConsent(page);
+
+  await app.goto();
+  await app.waitForReady();
+  await ipc.setHandler("google_drive_request", () => new Promise(() => {}));
+
+  await page.evaluate(async (debugStorePath) => {
+    window.localStorage.setItem("freed_cloud_token_gdrive", "test-access-token");
+    window.localStorage.setItem(
+      "freed_cloud_token_meta_gdrive",
+      JSON.stringify({
+        accessToken: "test-access-token",
+        refreshToken: "test-refresh-token",
+        expiresAt: Date.now() + 3_600_000,
+      }),
+    );
+    window.localStorage.setItem("freed_cloud_token_dropbox", "");
+    window.localStorage.removeItem("freed_cloud_token_meta_dropbox");
+    (window as Window & { __cloudConflictConfirmCalls?: number }).__cloudConflictConfirmCalls = 0;
+    window.confirm = () => {
+      (window as Window & { __cloudConflictConfirmCalls?: number }).__cloudConflictConfirmCalls =
+        ((window as Window & { __cloudConflictConfirmCalls?: number }).__cloudConflictConfirmCalls ?? 0) + 1;
+      return true;
+    };
+
+    const debugMod = await import(debugStorePath);
+    debugMod.useDebugStore.setState({
+      docSnapshot: {
+        deviceId: "device-1",
+        itemCount: 10880,
+        feedCount: 106,
+        binarySize: 13_150_000,
+        savedAt: Date.now(),
+      },
+      cloudProviders: {
+        dropbox: { status: "idle" },
+        gdrive: {
+          status: "connected",
+          stage: "idle",
+          error: "Freed blocked a sync merge because it would remove too much feed history.",
+          statusMessage: "Freed blocked a sync merge because it would remove too much feed history.",
+          pendingReason: "Choose which copy should win before cloud sync retries.",
+        },
+      },
+    });
+  }, DEBUG_STORE_PATH);
+
+  const settingsButton = page.locator("button").filter({ hasText: /settings/i }).first();
+  await expect(settingsButton).toBeVisible({ timeout: 5_000 });
+  await settingsButton.click();
+
+  const settingsDialog = page.locator(".fixed.inset-0.z-50").last();
+  const nav = settingsDialog.locator("nav").first();
+  await nav.getByRole("button", { name: "Sync", exact: true }).click();
+
+  const recovery = settingsDialog.getByTestId("cloud-sync-conflict-recovery");
+  await expect(recovery).toBeVisible({ timeout: 5_000 });
+  const keepLocal = settingsDialog.getByTestId("cloud-sync-keep-local-button");
+  await expect(keepLocal).toBeVisible();
+  await keepLocal.click();
+
+  await expect(settingsDialog.getByTestId("cloud-sync-keep-local-spinner")).toBeVisible({
+    timeout: 1_000,
+  });
+  await expect(keepLocal).toBeDisabled();
+  await expect(settingsDialog.getByTestId("cloud-sync-now-button")).toBeDisabled();
+  await expect.poll(async () => {
+    return page.evaluate(
+      () => (window as Window & { __cloudConflictConfirmCalls?: number }).__cloudConflictConfirmCalls ?? 0,
+    );
+  }).toBe(0);
+});


### PR DESCRIPTION
(AI Generated).

## Summary
- Remove the blocking browser confirm from the cloud conflict recovery buttons so the first click immediately shows the in-app spinner and starts recovery.
- Preserve existing cloud sync diagnostic errors when Settings mounts a connected cloud provider, instead of clearing the recovery state from the connection-state hook.
- Add desktop e2e coverage for the cloud conflict recovery click path.

## Validation
- `npm run test:e2e -- cloud-conflict-recovery.spec.ts` in `packages/desktop`
- `npm run test:unit -- MobileSyncTab.test.tsx useCloudProviders.test.tsx` in `packages/desktop`
- `npm run validate:feature`
