### PR TITLE
test: type cloud token mock

### DIFF
--- a/packages/desktop/src/hooks/useCloudProviders.test.tsx
+++ b/packages/desktop/src/hooks/useCloudProviders.test.tsx
@@ -5,7 +5,7 @@ import { useCloudProviders } from "./useCloudProviders";
 
 const mocks = vi.hoisted(() => ({
   clearCloudProvider: vi.fn(),
-  getCloudToken: vi.fn(() => null),
+  getCloudToken: vi.fn((_provider: string): string | null => null),
   initiateDesktopOAuth: vi.fn(),
   isOAuthCanceledError: vi.fn((error: unknown) => error instanceof Error && error.name === "AbortError"),
   startCloudSync: vi.fn(),


### PR DESCRIPTION
(AI Generated).

## Summary
- Type the Google Drive token test mock with the same provider argument shape used by production code.
- Unblock the full desktop TypeScript build after the cloud conflict click feedback fix.

## Validation
- npm run test:unit -- useCloudProviders.test.tsx
- PATH=/Users/aubreyfalconer/dev/freed-cloud-conflict-test-typing/node_modules/.bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/usr/local/MacGPG2/bin:/Applications/VMware Fusion.app/Contents/Public:/usr/local/share/dotnet:~/.dotnet/tools:/usr/local/go/bin:/Library/Frameworks/Mono.framework/Versions/Current/Commands:/Users/aubreyfalconer/.nvm/versions/node/v24.14.1/bin:/Users/aubreyfalconer/.codex/tmp/arg0/codex-arg0jhObyX:/Users/aubreyfalconer/.local/bin:/opt/homebrew/opt/mysql-client/bin:/opt/homebrew/bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/Users/aubreyfalconer/.cargo/bin:/Users/aubreyfalconer/go/bin:/Users/aubreyfalconer/.cache/lm-studio/bin:/Users/aubreyfalconer/.safe-chain/bin:/Applications/Codex.app/Contents/Resources:/usr/local/bin npm run build, from packages/desktop after clearing desktop tsbuildinfo
- npm run validate:feature