### PR TITLE
chore: promote dev into main for production release

### DIFF
--- a/packages/desktop/src/hooks/useCloudProviders.test.tsx
+++ b/packages/desktop/src/hooks/useCloudProviders.test.tsx
@@ -5,7 +5,7 @@ import { useCloudProviders } from "./useCloudProviders";
 
 const mocks = vi.hoisted(() => ({
   clearCloudProvider: vi.fn(),
-  getCloudToken: vi.fn(() => null),
+  getCloudToken: vi.fn((_provider: string): string | null => null),
   initiateDesktopOAuth: vi.fn(),
   isOAuthCanceledError: vi.fn((error: unknown) => error instanceof Error && error.name === "AbortError"),
   startCloudSync: vi.fn(),


### PR DESCRIPTION
(AI Generated).

## Summary
- Promote the current dev product snapshot into main before the replacement production release.
- Keep main release version metadata from the failed v26.6.600 prep.
- Bring in the cloud token mock typing fix that unblocks production CI.

## Testing
- node scripts/validate-release-promotion.mjs --from-ref=origin/dev --to-ref=HEAD
- node scripts/validate-main-pr.mjs --base-ref=origin/main --head-ref=HEAD --head-branch=chore/promote-dev-to-main-20260606-cloud-conflict-typing