### PR TITLE
chore: refresh website changelog for v26.6.601

### DIFF
--- a/release-notes/daily/production/26.6.6.json
+++ b/release-notes/daily/production/26.6.6.json
@@ -1,0 +1,17 @@
+{
+  "channel": "production",
+  "dayKey": "26.6.6",
+  "date": "2026-06-06",
+  "preferredDeck": "Cloud conflict recovery now responds immediately when choosing which copy should win.",
+  "editorialGuidance": [
+    "Keep the tone concise, professional, and specific.",
+    "Lead with user-facing outcomes, shipping milestones, trust wins, and installability improvements.",
+    "Demote internal cleanup unless it clearly changes the shipped product."
+  ],
+  "pinnedHighlights": [
+    "Keep this device and Keep cloud copy now show progress immediately instead of waiting behind a blocking browser confirmation.",
+    "Opening Sync settings no longer clears the cloud conflict warning before the recovery controls can run."
+  ],
+  "editorialNotes": [],
+  "updatedAt": "2026-06-06T14:26:58.317Z"
+}

--- a/release-notes/releases/v26.6.601.json
+++ b/release-notes/releases/v26.6.601.json
@@ -1,0 +1,42 @@
+{
+  "tag": "v26.6.601",
+  "version": "26.6.601",
+  "channel": "production",
+  "dayKey": "26.6.6",
+  "approved": true,
+  "editorialNotes": [],
+  "generatedAt": "2026-06-06T14:26:58.317Z",
+  "model": "heuristic",
+  "source": {
+    "channel": "production",
+    "previousPublishedTag": "v26.6.504",
+    "previousPublishedDayTag": "v26.6.504",
+    "compareRef": "HEAD",
+    "isLatestOfDay": true,
+    "sameDayTagsIncluded": [
+      "v26.6.601"
+    ],
+    "relatedBuildTags": [
+      "v26.6.601"
+    ],
+    "prNumbers": [
+      784,
+      786
+    ],
+    "commitSubjects": [
+      "chore: promote dev into main for production release (#786)",
+      "release: v26.6.600",
+      "chore: promote dev into main for cloud conflict recovery (#784)"
+    ]
+  },
+  "release": {
+    "deck": "Cloud conflict recovery now responds immediately when choosing which copy should win.",
+    "features": [],
+    "fixes": [
+      "Keep this device and Keep cloud copy now show progress immediately instead of waiting behind a blocking browser confirmation.",
+      "Opening Sync settings no longer clears the cloud conflict warning before the recovery controls can run."
+    ],
+    "followUps": []
+  },
+  "releaseBody": "(AI Generated).\n\n## Freed v26.6.601\n\nCloud conflict recovery now responds immediately when choosing which copy should win.\n\n### Fixes\n\n- Keep this device and Keep cloud copy now show progress immediately instead of waiting behind a blocking browser confirmation.\n- Opening Sync settings no longer clears the cloud conflict warning before the recovery controls can run.\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+}

--- a/release-notes/releases/v26.6.601.md
+++ b/release-notes/releases/v26.6.601.md
@@ -1,0 +1,18 @@
+(AI Generated).
+
+## Freed v26.6.601
+
+Cloud conflict recovery now responds immediately when choosing which copy should win.
+
+### Fixes
+
+- Keep this device and Keep cloud copy now show progress immediately instead of waiting behind a blocking browser confirmation.
+- Opening Sync settings no longer clears the cloud conflict warning before the recovery controls can run.
+
+### Downloads
+
+**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  
+**Windows:** `.exe` (NSIS installer)  
+**Linux:** `.AppImage`  
+
+> macOS downloads are signed and notarized for normal Gatekeeper installation.

--- a/website/public/atom.xml
+++ b/website/public/atom.xml
@@ -2,7 +2,7 @@
 <feed xmlns="http://www.w3.org/2005/Atom">
     <id>https://freed.wtf</id>
     <title>Freed Blog</title>
-    <updated>2026-06-05T23:11:52.553Z</updated>
+    <updated>2026-06-06T15:07:36.656Z</updated>
     <generator>https://github.com/jpmonette/feed</generator>
     <author>
         <name>The Freed Team</name>

--- a/website/public/feed.xml
+++ b/website/public/feed.xml
@@ -4,7 +4,7 @@
         <title>Freed Blog</title>
         <link>https://freed.wtf</link>
         <description>Progress reports, technical deep-dives, and philosophical rants about the attention economy. From the team building Freed.</description>
-        <lastBuildDate>Fri, 05 Jun 2026 23:11:52 GMT</lastBuildDate>
+        <lastBuildDate>Sat, 06 Jun 2026 15:07:36 GMT</lastBuildDate>
         <docs>https://validator.w3.org/feed/docs/rss2.html</docs>
         <generator>https://github.com/jpmonette/feed</generator>
         <language>en</language>

--- a/website/src/content/changelog.generated.json
+++ b/website/src/content/changelog.generated.json
@@ -1,5 +1,37 @@
 [
   {
+    "version": "26.6.601",
+    "tagName": "v26.6.601",
+    "channel": "production",
+    "date": "2026-06-06T15:03:20Z",
+    "deck": "Cloud conflict recovery now responds immediately when choosing which copy should win.",
+    "features": [],
+    "fixes": [
+      {
+        "text": "Keep this device and Keep cloud copy now show progress immediately instead of waiting behind a blocking browser confirmation."
+      },
+      {
+        "text": "Opening Sync settings no longer clears the cloud conflict warning before the recovery controls can run."
+      }
+    ],
+    "followUps": [],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.601",
+    "prNumbers": [
+      784,
+      786
+    ],
+    "builds": [
+      "26.6.601"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.6.601",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.601",
+        "channel": "production"
+      }
+    ]
+  },
+  {
     "version": "26.6.504",
     "tagName": "v26.6.504",
     "channel": "production",


### PR DESCRIPTION
(AI Generated).

## Summary
- Add reviewed release notes for v26.6.601 to the website branch.
- Regenerate the public changelog snapshot and RSS/Atom feeds.

## Validation
- node scripts/validate-release-notes.mjs release-notes/releases/v26.6.601.json
- PATH=/Users/aubreyfalconer/dev/freed-www-release-26-6-601/node_modules/.bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/usr/local/MacGPG2/bin:/Applications/VMware Fusion.app/Contents/Public:/usr/local/share/dotnet:~/.dotnet/tools:/usr/local/go/bin:/Library/Frameworks/Mono.framework/Versions/Current/Commands:/Users/aubreyfalconer/.nvm/versions/node/v24.14.1/bin:/Users/aubreyfalconer/.codex/tmp/arg0/codex-arg0jhObyX:/Users/aubreyfalconer/.local/bin:/opt/homebrew/opt/mysql-client/bin:/opt/homebrew/bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/Users/aubreyfalconer/.cargo/bin:/Users/aubreyfalconer/go/bin:/Users/aubreyfalconer/.cache/lm-studio/bin:/Users/aubreyfalconer/.safe-chain/bin:/Applications/Codex.app/Contents/Resources:/usr/local/bin npm run build, from website