### PR TITLE
fix: repair PWA Google Drive sync resolution

### DIFF
--- a/packages/desktop/src/lib/automerge.worker.ts
+++ b/packages/desktop/src/lib/automerge.worker.ts
@@ -19,6 +19,7 @@ import { IndexedDBStorage } from "@freed/sync/storage/indexeddb";
 import type { FreedDoc } from "@freed/shared/schema";
 import {
   assertNonDestructiveMerge,
+  choosePopulatedInputForEmptyMerge,
   createEmptyDoc,
   createDocFromData,
   addAccount,
@@ -1076,10 +1077,13 @@ async function handleRequest(
         const beforeCount = Object.keys(currentDoc.feedItems ?? {}).length;
         const incomingDoc = A.load<FreedDoc>(req.binary);
         const mergedDoc = A.merge(currentDoc, incomingDoc);
-        const guard = assertNonDestructiveMerge(currentDoc, incomingDoc, mergedDoc, {
+        const populatedSide = choosePopulatedInputForEmptyMerge(currentDoc, incomingDoc, mergedDoc);
+        const resolvedDoc =
+          populatedSide === "local" ? currentDoc : populatedSide === "incoming" ? incomingDoc : mergedDoc;
+        const guard = assertNonDestructiveMerge(currentDoc, incomingDoc, resolvedDoc, {
           source: "Desktop sync",
         });
-        currentDoc = mergedDoc;
+        currentDoc = populatedSide ? A.clone(resolvedDoc) : resolvedDoc;
         migrateLoadedIdentityGraph("Migrate legacy identity graph");
         compactLoadedFeedText("Compact oversized synced feed text after merge", {
           rebuildHistory: true,
@@ -1093,6 +1097,14 @@ async function handleRequest(
           detail: delta !== 0 ? `${delta > 0 ? "+" : ""}${delta} items` : "no new items",
           bytes: req.binary.byteLength,
         });
+        if (populatedSide) {
+          send({
+            type: "DEBUG_EVENT",
+            kind: "merge_ok",
+            detail: `adopted ${populatedSide} document because the other sync input was empty`,
+            bytes: req.binary.byteLength,
+          });
+        }
         if (guard.deletedItemCount > 0) {
           send({
             type: "DEBUG_EVENT",

--- a/packages/desktop/src/lib/gdrive-sync.test.ts
+++ b/packages/desktop/src/lib/gdrive-sync.test.ts
@@ -53,6 +53,27 @@ function makeTrustedAndDeleteHeavyDocs(): { trusted: Uint8Array; deleteHeavy: Ui
   };
 }
 
+function makePopulatedAndStaleEmptyDocs(): { populated: Uint8Array; staleEmpty: Uint8Array } {
+  let populatedDoc = createEmptyDoc();
+  populatedDoc = A.change(populatedDoc, (doc) => {
+    for (let i = 0; i < 600; i += 1) {
+      addFeedItem(doc, makeItem(`cloud-item-${i}`));
+    }
+  });
+
+  let staleEmptyDoc = A.clone(populatedDoc) as FreedDoc;
+  staleEmptyDoc = A.change(staleEmptyDoc, (doc) => {
+    for (const id of Object.keys(doc.feedItems)) {
+      delete doc.feedItems[id];
+    }
+  });
+
+  return {
+    populated: A.save(populatedDoc),
+    staleEmpty: A.save(staleEmptyDoc),
+  };
+}
+
 describe("Google Drive cloud sync", () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -159,6 +180,40 @@ describe("Google Drive cloud sync", () => {
       expect.stringContaining("/upload/drive/v3/files/file-1"),
       expect.anything(),
     );
+  });
+
+  it("keeps the populated Drive document when the local first-sync doc is empty", async () => {
+    const { populated, staleEmpty } = makePopulatedAndStaleEmptyDocs();
+    const uploadBodies: Array<BodyInit | null | undefined> = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/files?")) {
+        return jsonResponse({ files: [{ id: "file-1" }] });
+      }
+      if (url.includes("/files/file-1?fields=")) {
+        return jsonResponse(
+          { size: populated.byteLength.toLocaleString("en-US", { useGrouping: false }) },
+          { headers: { ETag: '"server-etag"' } },
+        );
+      }
+      if (url.includes("/files/file-1?alt=media")) {
+        return new Response(responseBodyFromBytes(populated));
+      }
+      if (url.includes("/upload/drive/v3/files/file-1")) {
+        uploadBodies.push(init?.body);
+        return jsonResponse({});
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await gdriveUploadSafe("token", staleEmpty);
+    expect(result.uploadedBytes).toBe(populated.byteLength);
+    expect(uploadBodies).toHaveLength(1);
+
+    const uploaded = new Uint8Array(uploadBodies[0] as ArrayBuffer);
+    const doc = A.load<FreedDoc>(uploaded);
+    expect(Object.keys(doc.feedItems)).toHaveLength(600);
   });
 
   it("replaces Drive contents without downloading remote history for conflict recovery", async () => {

--- a/packages/pwa/src/lib/automerge.worker.ts
+++ b/packages/pwa/src/lib/automerge.worker.ts
@@ -16,6 +16,7 @@ import { hashSavedUrl } from "@freed/capture-save/normalize";
 import type { FreedDoc } from "@freed/shared/schema";
 import {
   assertNonDestructiveMerge,
+  choosePopulatedInputForEmptyMerge,
   createEmptyDoc,
   addAccount,
   addAccounts,
@@ -70,6 +71,7 @@ import type { DocState, WorkerRequest, WorkerResponse } from "./automerge-types"
 const storage = new IndexedDBStorage();
 let currentDoc: FreedDoc | null = null;
 let searchCorpusVersion = 0;
+let requestChain: Promise<void> = Promise.resolve();
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -299,9 +301,7 @@ async function applyChange(
 // Message handler
 // ---------------------------------------------------------------------------
 
-self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
-  const req = event.data;
-
+async function handleRequest(req: WorkerRequest): Promise<void> {
   try {
     switch (req.type) {
       case "INIT": {
@@ -650,10 +650,13 @@ self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
         const beforeCount = Object.keys(currentDoc.feedItems ?? {}).length;
         const incomingDoc = A.load<FreedDoc>(req.binary);
         const mergedDoc = A.merge(currentDoc, incomingDoc);
-        const guard = assertNonDestructiveMerge(currentDoc, incomingDoc, mergedDoc, {
+        const populatedSide = choosePopulatedInputForEmptyMerge(currentDoc, incomingDoc, mergedDoc);
+        const resolvedDoc =
+          populatedSide === "local" ? currentDoc : populatedSide === "incoming" ? incomingDoc : mergedDoc;
+        const guard = assertNonDestructiveMerge(currentDoc, incomingDoc, resolvedDoc, {
           source: "PWA sync",
         });
-        currentDoc = mergedDoc;
+        currentDoc = populatedSide ? A.clone(resolvedDoc) : resolvedDoc;
         migrateLoadedIdentityGraph("Migrate legacy identity graph");
         const afterCount = Object.keys(currentDoc.feedItems ?? {}).length;
         const delta = afterCount - beforeCount;
@@ -663,6 +666,14 @@ self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
           detail: delta !== 0 ? `${delta > 0 ? "+" : ""}${delta} items` : "no new items",
           bytes: req.binary.byteLength,
         });
+        if (populatedSide) {
+          send({
+            type: "DEBUG_EVENT",
+            kind: "merge_ok",
+            detail: `adopted ${populatedSide} document because the other sync input was empty`,
+            bytes: req.binary.byteLength,
+          });
+        }
         if (guard.deletedItemCount > 0) {
           send({
             type: "DEBUG_EVENT",
@@ -693,6 +704,18 @@ self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
   } catch (err) {
     ack(req.reqId, err instanceof Error ? err.message : String(err));
   }
+}
+
+function enqueueRequest(req: WorkerRequest): void {
+  requestChain = requestChain
+    .then(() => handleRequest(req))
+    .catch((err) => {
+      ack(req.reqId, err instanceof Error ? err.message : String(err));
+    });
+}
+
+self.onmessage = (event: MessageEvent<WorkerRequest>) => {
+  enqueueRequest(event.data);
 };
 
 // Signal the main thread that the module finished loading and the onmessage

--- a/packages/pwa/src/lib/schema.test.ts
+++ b/packages/pwa/src/lib/schema.test.ts
@@ -25,6 +25,7 @@ import {
   hideItem,
   addRssFeed,
   assertNonDestructiveMerge,
+  choosePopulatedInputForEmptyMerge,
   evaluateDestructiveMergeGuard,
   removeRssFeed,
   updateAccount,
@@ -931,6 +932,34 @@ describe("Automerge merge / sync simulation", () => {
     expect(() =>
       assertNonDestructiveMerge(trusted, deleteHeavy, merged, { source: "test sync" }),
     ).toThrow(/Freed blocked a sync merge/);
+  });
+
+  it("adopts a populated peer when stale empty delete history wins first sync", () => {
+    let populated = createEmptyDoc();
+    populated = A.change(populated, (d) => {
+      addRssFeed(d, makeFeed({ url: "https://example.com/feed.xml", title: "Example" }));
+      for (let i = 0; i < 600; i += 1) {
+        addFeedItem(d, makeItem({ globalId: `cloud-item-${i}` }));
+      }
+    });
+
+    let staleEmpty = A.clone(populated);
+    staleEmpty = A.change(staleEmpty, (d) => {
+      for (const id of Object.keys(d.feedItems)) {
+        delete d.feedItems[id];
+      }
+      for (const url of Object.keys(d.rssFeeds)) {
+        delete d.rssFeeds[url];
+      }
+    });
+
+    const merged = A.merge(staleEmpty, populated);
+    expect(Object.keys(merged.feedItems)).toHaveLength(0);
+    expect(choosePopulatedInputForEmptyMerge(staleEmpty, populated, merged)).toBe("incoming");
+
+    expect(() =>
+      assertNonDestructiveMerge(staleEmpty, populated, populated, { source: "test sync" }),
+    ).not.toThrow();
   });
 
   it("serializes and deserializes without data loss", () => {

--- a/packages/pwa/tests/app.spec.ts
+++ b/packages/pwa/tests/app.spec.ts
@@ -1,4 +1,24 @@
 import { test, expect } from "@playwright/test";
+import {
+  SAMPLE_SHOWCASE_FEED_COUNT,
+  SAMPLE_SHOWCASE_FRIEND_COUNT,
+  SAMPLE_SHOWCASE_ITEM_COUNT,
+} from "@freed/shared";
+
+const SAMPLE_AUTHOR_PERSON_COUNT = 20;
+const SAMPLE_LINKEDIN_POST_COUNT = 10;
+const EXPECTED_LINKEDIN_ITEMS_PER_BATCH =
+  SAMPLE_SHOWCASE_FRIEND_COUNT + SAMPLE_LINKEDIN_POST_COUNT;
+const EXPECTED_FIRST_SAMPLE_LIBRARY_COUNTS = {
+  feeds: SAMPLE_SHOWCASE_FEED_COUNT,
+  friends: SAMPLE_SHOWCASE_FRIEND_COUNT + SAMPLE_AUTHOR_PERSON_COUNT,
+  items: SAMPLE_SHOWCASE_ITEM_COUNT,
+};
+const EXPECTED_ADDITIONAL_SAMPLE_LIBRARY_COUNTS = {
+  feeds: SAMPLE_SHOWCASE_FEED_COUNT,
+  friends: SAMPLE_SHOWCASE_FRIEND_COUNT,
+  items: SAMPLE_SHOWCASE_ITEM_COUNT,
+};
 
 async function waitForPwaDocumentReady(
   page: import("@playwright/test").Page,
@@ -624,24 +644,39 @@ async function seedFriendsWorkspace(
 async function openDangerZone(
   page: import("@playwright/test").Page,
 ): Promise<void> {
-  await page.getByRole("button", { name: "Settings" }).click();
-  await expect(page.getByRole("heading", { name: "Settings" })).toBeVisible();
+  const settingsHeading = page.getByRole("heading", { name: "Settings" });
+  const settingsOpen = await settingsHeading.isVisible({ timeout: 1_000 }).catch(() => false);
+  if (!settingsOpen) {
+    await page.getByTestId("sidebar-settings-button").click();
+  }
+  await expect(settingsHeading).toBeVisible();
   await page.getByRole("button", { name: "Danger Zone" }).click();
 }
 
 async function populateSampleData(
   page: import("@playwright/test").Page,
   previousCounts: { friends: number; items: number; feeds: number },
+  expectedCounts: { friends: number; items: number; feeds: number },
 ): Promise<void> {
-  const populateButton = page.getByRole("button", {
-    name: /Populate sample data|Add more sample data/,
+  let populateButton = page.getByRole("button", {
+    name: /^(Populate sample data|Add more sample data)$/,
   });
+  const exactButtonVisible = await populateButton.isVisible({ timeout: 2_000 }).catch(() => false);
+  if (!exactButtonVisible) {
+    populateButton = page.getByRole("button", {
+      name: /^(Populate sample data|Add more sample data) /,
+    }).first();
+  }
   await expect(populateButton).toBeVisible();
-  await populateButton.click();
+  await populateButton.evaluate((element) => {
+    (element as HTMLButtonElement).click();
+  });
 
   const confirmButton = page.getByRole("button", { name: "Populate anyway" });
   if (await confirmButton.isVisible().catch(() => false)) {
-    await confirmButton.click();
+    await confirmButton.evaluate((element) => {
+      (element as HTMLButtonElement).click();
+    });
   }
 
   await expect(page.getByText("Sample data added:")).toBeVisible({
@@ -652,9 +687,9 @@ async function populateSampleData(
       timeout: 15_000,
     })
     .toEqual({
-      friends: previousCounts.friends + 25,
-      items: previousCounts.items + 155,
-      feeds: previousCounts.feeds + 10,
+      friends: previousCounts.friends + expectedCounts.friends,
+      items: previousCounts.items + expectedCounts.items,
+      feeds: previousCounts.feeds + expectedCounts.feeds,
     });
   await expect(page.getByText("Cannot assign undefined value")).toBeHidden();
 }
@@ -1999,17 +2034,18 @@ test.describe("FREED PWA", () => {
     const before = await getLibraryCounts(page);
     await openDangerZone(page);
 
-    await populateSampleData(page, before);
+    await populateSampleData(page, before, EXPECTED_FIRST_SAMPLE_LIBRARY_COUNTS);
     const afterFirst = await getLibraryCounts(page);
-    expect(afterFirst.friends - before.friends).toBe(25);
-    expect(afterFirst.items - before.items).toBe(155);
-    expect(afterFirst.feeds - before.feeds).toBe(10);
+    expect(afterFirst.friends - before.friends).toBe(EXPECTED_FIRST_SAMPLE_LIBRARY_COUNTS.friends);
+    expect(afterFirst.items - before.items).toBe(EXPECTED_FIRST_SAMPLE_LIBRARY_COUNTS.items);
+    expect(afterFirst.feeds - before.feeds).toBe(EXPECTED_FIRST_SAMPLE_LIBRARY_COUNTS.feeds);
 
-    await populateSampleData(page, afterFirst);
+    await openDangerZone(page);
+    await populateSampleData(page, afterFirst, EXPECTED_ADDITIONAL_SAMPLE_LIBRARY_COUNTS);
     const afterSecond = await getLibraryCounts(page);
-    expect(afterSecond.friends - afterFirst.friends).toBe(25);
-    expect(afterSecond.items - afterFirst.items).toBe(155);
-    expect(afterSecond.feeds - afterFirst.feeds).toBe(10);
+    expect(afterSecond.friends - afterFirst.friends).toBe(EXPECTED_ADDITIONAL_SAMPLE_LIBRARY_COUNTS.friends);
+    expect(afterSecond.items - afterFirst.items).toBe(EXPECTED_ADDITIONAL_SAMPLE_LIBRARY_COUNTS.items);
+    expect(afterSecond.feeds - afterFirst.feeds).toBe(EXPECTED_ADDITIONAL_SAMPLE_LIBRARY_COUNTS.feeds);
 
     const batchSummary = await page.evaluate(() => {
       const store = (window as Record<string, unknown>).__FREED_STORE__ as {
@@ -2039,7 +2075,7 @@ test.describe("FREED PWA", () => {
 
     expect(batchSummary.friendIds.some((id) => id === "sample-friend-maya")).toBe(false);
     expect(batchSummary.linkedInFriendCount).toBeGreaterThan(0);
-    expect(batchSummary.linkedInItemCount).toBe(20);
+    expect(batchSummary.linkedInItemCount).toBe(EXPECTED_LINKEDIN_ITEMS_PER_BATCH * 2);
   });
 });
 

--- a/packages/shared/src/schema.ts
+++ b/packages/shared/src/schema.ts
@@ -2044,6 +2044,36 @@ function countFeedItems(doc: FreedDoc): number {
   return Object.keys(doc.feedItems ?? {}).length;
 }
 
+function countDocumentLibraryEntries(doc: FreedDoc): number {
+  return (
+    Object.keys(doc.feedItems ?? {}).length +
+    Object.keys(doc.rssFeeds ?? {}).length +
+    Object.keys(doc.persons ?? {}).length +
+    Object.keys(doc.accounts ?? {}).length
+  );
+}
+
+export type PopulatedEmptyMergeInput = "local" | "incoming";
+
+/**
+ * When an empty first-sync document carries stale delete history, Automerge can
+ * merge a populated peer down to an empty result. In that exact case, keep the
+ * populated side instead of treating an empty library as a destructive winner.
+ */
+export function choosePopulatedInputForEmptyMerge(
+  localDoc: FreedDoc,
+  incomingDoc: FreedDoc,
+  mergedDoc: FreedDoc,
+): PopulatedEmptyMergeInput | null {
+  if (countDocumentLibraryEntries(mergedDoc) > 0) return null;
+
+  const localEntries = countDocumentLibraryEntries(localDoc);
+  const incomingEntries = countDocumentLibraryEntries(incomingDoc);
+  if (localEntries === 0 && incomingEntries > 0) return "incoming";
+  if (incomingEntries === 0 && localEntries > 0) return "local";
+  return null;
+}
+
 function formatDestructiveMergeMessage(
   report: Omit<DestructiveMergeGuardReport, "message">,
 ): string {

--- a/packages/sync/src/cloud/merge.ts
+++ b/packages/sync/src/cloud/merge.ts
@@ -6,6 +6,7 @@
 import * as A from "@automerge/automerge";
 import {
   assertNonDestructiveMerge,
+  choosePopulatedInputForEmptyMerge,
   type DestructiveMergeGuardOptions,
   type FreedDoc,
 } from "@freed/shared/schema";
@@ -22,11 +23,13 @@ export function mergeBinaries(
   const docA = A.load<FreedDoc>(a);
   const docB = A.load<FreedDoc>(b);
   const merged = A.merge(docA, docB);
-  assertNonDestructiveMerge(docA, docB, merged, {
+  const populatedSide = choosePopulatedInputForEmptyMerge(docA, docB, merged);
+  const resolved = populatedSide === "local" ? docA : populatedSide === "incoming" ? docB : merged;
+  assertNonDestructiveMerge(docA, docB, resolved, {
     source: "cloud upload",
     ...options,
   });
-  return A.save(merged);
+  return A.save(resolved);
 }
 
 export function delay(ms: number): Promise<void> {


### PR DESCRIPTION
(AI Generated).

## Summary
- Adopt the populated sync input when an empty first-sync document would otherwise collapse a Drive merge to zero items.
- Serialize PWA Automerge worker requests so sample data and sync mutations cannot race on an outdated document.
- Refresh the PWA sample-data regression test for the current generated showcase dataset and Settings flow.

## Testing
- PATH=/Users/aubreyfalconer/dev/freed-fix-pwa-drive-sync/node_modules/.bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/usr/local/MacGPG2/bin:/Applications/VMware Fusion.app/Contents/Public:/usr/local/share/dotnet:~/.dotnet/tools:/usr/local/go/bin:/Library/Frameworks/Mono.framework/Versions/Current/Commands:/Users/aubreyfalconer/.nvm/versions/node/v24.14.1/bin:/Users/aubreyfalconer/.codex/tmp/arg0/codex-arg0jhObyX:/Users/aubreyfalconer/.local/bin:/opt/homebrew/opt/mysql-client/bin:/opt/homebrew/bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/Users/aubreyfalconer/.cargo/bin:/Users/aubreyfalconer/go/bin:/Users/aubreyfalconer/.cache/lm-studio/bin:/Users/aubreyfalconer/.safe-chain/bin:/Applications/Codex.app/Contents/Resources:/usr/local/bin npm run test:unit -- src/lib/schema.test.ts, from packages/pwa.
- npm run test:unit -- src/lib/gdrive-sync.test.ts, from packages/desktop.
- PATH=/Users/aubreyfalconer/dev/freed-fix-pwa-drive-sync/node_modules/.bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/usr/local/MacGPG2/bin:/Applications/VMware Fusion.app/Contents/Public:/usr/local/share/dotnet:~/.dotnet/tools:/usr/local/go/bin:/Library/Frameworks/Mono.framework/Versions/Current/Commands:/Users/aubreyfalconer/.nvm/versions/node/v24.14.1/bin:/Users/aubreyfalconer/.codex/tmp/arg0/codex-arg0jhObyX:/Users/aubreyfalconer/.local/bin:/opt/homebrew/opt/mysql-client/bin:/opt/homebrew/bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/Users/aubreyfalconer/.cargo/bin:/Users/aubreyfalconer/go/bin:/Users/aubreyfalconer/.cache/lm-studio/bin:/Users/aubreyfalconer/.safe-chain/bin:/Applications/Codex.app/Contents/Resources:/usr/local/bin npm run test -- app.spec.ts --grep 'populate sample data appends a fresh batch each time', from packages/pwa.
- npm run validate:feature.