### PR TITLE
fix: relax nightly preflight false blockers

### DIFF
--- a/scripts/nightly-self-improve.mjs
+++ b/scripts/nightly-self-improve.mjs
@@ -847,8 +847,7 @@ export function summarizePeerWorktree(worktreePath, currentRepo) {
     "diff",
     "--name-only",
     "--diff-filter=ACDMRTUXB",
-    "origin/dev",
-    "HEAD",
+    "origin/dev...HEAD",
   ]);
   const workingFiles = unique([
     ...shortStatusPaths(status),
@@ -1037,6 +1036,19 @@ function riskItem({ id, severity, title, evidence, remediation, actions = [] }) 
   return { id, severity, title, evidence, remediation, actions };
 }
 
+function expectedBranchHead(repo, expectedBranch) {
+  if (expectedBranch === "dev") return repo.originDev || "";
+  if (expectedBranch === "main") return repo.originMain || "";
+  return "";
+}
+
+function matchesExpectedBranch(repo, expectedBranch) {
+  if (!expectedBranch) return true;
+  if (repo.branch === expectedBranch) return true;
+  const expectedHead = expectedBranchHead(repo, expectedBranch);
+  return repo.branch === "HEAD" && Boolean(repo.head) && Boolean(expectedHead) && repo.head === expectedHead;
+}
+
 export function collectRiskSnapshot({
   repoPath,
   repo,
@@ -1050,7 +1062,7 @@ export function collectRiskSnapshot({
   nowMs = Date.now(),
 }) {
   const risks = [];
-  if (expectedBranch && repo.branch !== expectedBranch) {
+  if (!matchesExpectedBranch(repo, expectedBranch)) {
     risks.push(
       riskItem({
         id: "unexpected-repo-branch",

--- a/scripts/nightly-self-improve.test.mjs
+++ b/scripts/nightly-self-improve.test.mjs
@@ -23,6 +23,7 @@ import {
   resolveReadableSoak,
   selectTargets,
   shouldRetainPeerWorktree,
+  summarizePeerWorktree,
   summarizeOutcomeLedger,
   summarizeDailyBugMemory,
   summarizeSoak,
@@ -580,6 +581,38 @@ test("duplicate work detector reports file and surface overlap", () => {
   assert.equal(duplicateWork.blockerCount, 1);
 });
 
+test("summarizePeerWorktree ignores behind-only detached snapshots as active changes", () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "freed-peer-summary-"));
+  const origin = path.join(dir, "origin.git");
+  const repo = path.join(dir, "repo");
+  const peer = path.join(dir, "peer");
+
+  execFileSync("git", ["init", "--bare", origin]);
+  execFileSync("git", ["clone", origin, repo]);
+  execFileSync("git", ["-C", repo, "config", "user.name", "Freed Tests"]);
+  execFileSync("git", ["-C", repo, "config", "user.email", "tests@example.com"]);
+  execFileSync("git", ["-C", repo, "checkout", "-b", "dev"]);
+  writeFileSync(path.join(repo, "notes.txt"), "first\n");
+  execFileSync("git", ["-C", repo, "add", "notes.txt"]);
+  execFileSync("git", ["-C", repo, "commit", "-m", "first"]);
+  const firstHead = execFileSync("git", ["-C", repo, "rev-parse", "HEAD"], { encoding: "utf8" }).trim();
+  execFileSync("git", ["-C", repo, "push", "-u", "origin", "dev"]);
+
+  writeFileSync(path.join(repo, "notes.txt"), "second\n");
+  execFileSync("git", ["-C", repo, "commit", "-am", "second"]);
+  execFileSync("git", ["-C", repo, "push"]);
+
+  execFileSync("git", ["clone", origin, peer]);
+  execFileSync("git", ["-C", peer, "fetch", "origin", "dev"]);
+  execFileSync("git", ["-C", peer, "checkout", "--detach", firstHead]);
+
+  const summary = summarizePeerWorktree(peer, repo);
+  assert.equal(summary?.branch, "HEAD");
+  assert.equal(summary?.aheadCount, 0);
+  assert.equal(summary?.behindCount, 1);
+  assert.equal(summary?.changedFileCount, 0);
+});
+
 test("duplicate work candidates are selected before generic roadmap fallback", () => {
   const duplicateWork = {
     findingCount: 1,
@@ -773,6 +806,29 @@ test("risk snapshot warns when the dev worktree is stale", () => {
   assert.equal(snapshot.risks.some((item) => item.id === "unexpected-repo-branch"), false);
   assert.equal(risk?.severity, "warning");
   assert.ok(risk?.actions.some((action) => action.id === "refresh-dev-worktree"));
+});
+
+test("risk snapshot allows detached HEAD when it matches origin/dev", () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "freed-detached-dev-risk-"));
+  mkdirSync(path.join(dir, "node_modules"), { recursive: true });
+  const snapshot = collectRiskSnapshot({
+    repoPath: dir,
+    repo: {
+      branch: "HEAD",
+      head: "abc1234",
+      originDev: "abc1234",
+      originMain: "def5678",
+      status: "",
+    },
+    soak: { exists: false },
+    crashAutomation: "",
+    dailyBugMemory: "",
+    devBotMemory: "",
+    expectedBranch: "dev",
+  });
+
+  assert.equal(snapshot.risks.some((item) => item.id === "unexpected-repo-branch"), false);
+  assert.equal(snapshot.risks.some((item) => item.id === "stale-dev-worktree"), false);
 });
 
 test("writeRunPlan emits report, targets, and task prompts", () => {


### PR DESCRIPTION
(AI Generated).

## Summary
- Allow detached dev snapshots and ignore behind-only peer diffs in nightly planning.

## Testing
- node --test scripts/nightly-self-improve.test.mjs && npm run validate:feature