### PR TITLE
chore: promote dev into main for PWA sync recovery

### DIFF
--- a/packages/pwa/src/components/PwaFeedEmptyState.test.ts
+++ b/packages/pwa/src/components/PwaFeedEmptyState.test.ts
@@ -1,0 +1,130 @@
+import { act, createElement, type ReactNode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PlatformProvider, type PlatformConfig } from "@freed/ui/context";
+import { useDebugStore } from "@freed/ui/lib/debug-store";
+import { useAppStore } from "../lib/store";
+import { PwaFeedEmptyState } from "./PwaFeedEmptyState";
+
+function createPlatform(): PlatformConfig {
+  return {
+    store: useAppStore,
+    SourceIndicator: null,
+    HeaderSyncIndicator: null,
+    SettingsExtraSections: null,
+    LegalSettingsContent: null,
+    FeedEmptyState: null,
+    XSettingsContent: null,
+    FacebookSettingsContent: null,
+    InstagramSettingsContent: null,
+    LinkedInSettingsContent: null,
+    GoogleContactsSettingsContent: null,
+    releaseChannel: "production",
+  };
+}
+
+function renderWithPlatform(node: ReactNode): { container: HTMLDivElement; root: Root } {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(createElement(PlatformProvider, { value: createPlatform(), children: node }));
+  });
+  return { container, root };
+}
+
+describe("PwaFeedEmptyState", () => {
+  beforeEach(() => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    vi.clearAllMocks();
+    useAppStore.setState({
+      syncConnected: true,
+      isSyncing: false,
+      activeFilter: {},
+      feeds: {},
+      items: [],
+      persons: {},
+      accounts: {},
+    });
+    useDebugStore.setState({ cloudProviders: null });
+  });
+
+  afterEach(() => {
+    useAppStore.setState({
+      syncConnected: false,
+      isSyncing: false,
+      activeFilter: {},
+      feeds: {},
+      items: [],
+      persons: {},
+      accounts: {},
+    });
+    useDebugStore.setState({ cloudProviders: null });
+    document.body.innerHTML = "";
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = false;
+  });
+
+  it("points the blank feed state to Sync settings when cloud sync is blocked", () => {
+    const blockedMessage =
+      "Freed blocked a sync merge because it would remove too much feed history. Source: PWA sync. Largest input: 11,238 items. Merged result: 0 items. Potential loss: 11,238 items (100%). Restore from a trusted snapshot or reconnect sync after confirming which copy should win.";
+    const openSettings = vi.fn();
+    window.addEventListener("freed:open-settings", openSettings);
+    useDebugStore.setState({
+      cloudProviders: {
+        dropbox: { status: "idle" },
+        gdrive: {
+          status: "error",
+          stage: "merge",
+          error: blockedMessage,
+          statusMessage: "Merge blocked.",
+          pendingReason: "Resolve this error, then reconnect or run Sync now.",
+          events: [],
+        },
+      },
+    });
+
+    const { container, root } = renderWithPlatform(createElement(PwaFeedEmptyState));
+    const button = Array.from(container.querySelectorAll("button")).find(
+      (candidate) => candidate.textContent === "Open Sync settings",
+    );
+
+    expect(container.textContent).toContain("Sync is blocked");
+    expect(container.textContent).toContain("Open Sync settings to choose how to recover your Google Drive library.");
+    expect(button).toBeDefined();
+
+    act(() => {
+      button?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(openSettings).toHaveBeenCalledTimes(1);
+
+    window.removeEventListener("freed:open-settings", openSettings);
+    act(() => {
+      root.unmount();
+    });
+  });
+
+  it("shows a spinner while cloud sync is actively downloading", () => {
+    useDebugStore.setState({
+      cloudProviders: {
+        dropbox: { status: "idle" },
+        gdrive: {
+          status: "connecting",
+          stage: "download",
+          statusMessage: "Checking cloud storage for remote changes.",
+          events: [],
+        },
+      },
+    });
+
+    const { container, root } = renderWithPlatform(createElement(PwaFeedEmptyState));
+
+    expect(container.querySelector("[aria-label='Syncing']")).toBeTruthy();
+    expect(container.textContent).toContain("Waiting for content...");
+    expect(container.textContent).not.toContain("Sync is blocked");
+
+    act(() => {
+      root.unmount();
+    });
+  });
+});

--- a/packages/pwa/src/components/PwaFeedEmptyState.tsx
+++ b/packages/pwa/src/components/PwaFeedEmptyState.tsx
@@ -1,13 +1,42 @@
 import { useAppStore } from "../lib/store";
+import { useDebugStore } from "@freed/ui/lib/debug-store";
 import { SampleDataTestingSection } from "@freed/ui/components/SampleDataTestingSection";
 
 const openSyncSettings = () =>
   window.dispatchEvent(new CustomEvent("freed:open-settings", { detail: { scrollTo: "sync" } }));
 
+function isMergeBlocked(message?: string): boolean {
+  return message?.includes("blocked a sync merge") ?? false;
+}
+
+function SyncSpinner() {
+  return (
+    <div
+      aria-label="Syncing"
+      className="mb-4 h-10 w-10 animate-spin rounded-full border-2 border-[rgb(var(--theme-accent-secondary-rgb)/0.24)] border-t-[var(--theme-accent-secondary)]"
+    />
+  );
+}
+
 export function PwaFeedEmptyState() {
   const syncConnected = useAppStore((s) => s.syncConnected);
+  const isSyncing = useAppStore((s) => s.isSyncing);
   const activeFilter = useAppStore((s) => s.activeFilter);
   const feeds = useAppStore((s) => s.feeds);
+  const cloudProviders = useDebugStore((s) => s.cloudProviders);
+  const cloudState = cloudProviders?.gdrive ?? cloudProviders?.dropbox ?? null;
+  const cloudError = cloudState?.error;
+  const syncBlocked = syncConnected && isMergeBlocked(cloudError);
+  const cloudStage = cloudState?.stage;
+  const cloudTransferRunning =
+    syncConnected &&
+    !syncBlocked &&
+    (isSyncing ||
+      cloudState?.status === "connecting" ||
+      cloudStage === "auth" ||
+      cloudStage === "download" ||
+      cloudStage === "merge" ||
+      cloudStage === "upload");
 
   // Per-feed view: a specific feed is selected but has no items yet.
   // `lastFetched` is absent until Freed Desktop polls the feed.
@@ -65,15 +94,18 @@ export function PwaFeedEmptyState() {
 
   return (
     <>
+      {cloudTransferRunning && <SyncSpinner />}
       <p className="text-lg font-medium mb-2">
-        {syncConnected ? "Waiting for content..." : "No content yet"}
+        {syncBlocked ? "Sync is blocked" : syncConnected ? "Waiting for content..." : "No content yet"}
       </p>
       <p className="max-w-xs text-sm text-[var(--theme-text-muted)]">
-        {syncConnected
+        {syncBlocked
+          ? "Open Sync settings to choose how to recover your Google Drive library."
+          : syncConnected
           ? "Freed Desktop is connected. New feed content will appear here once fetched."
           : "Connect to Freed Desktop to sync your feeds."}
       </p>
-      {!syncConnected && (
+      {(syncBlocked || !syncConnected) && (
       <button
         onClick={openSyncSettings}
         className="theme-accent-button mt-4 flex items-center gap-2 rounded-xl px-5 py-2.5 text-sm font-medium transition-colors"
@@ -91,7 +123,7 @@ export function PwaFeedEmptyState() {
             d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"
           />
         </svg>
-        Connect
+        {syncBlocked ? "Open Sync settings" : "Connect"}
       </button>
       )}
       <SampleDataTestingSection />

--- a/packages/pwa/src/components/PwaSyncSettings.test.ts
+++ b/packages/pwa/src/components/PwaSyncSettings.test.ts
@@ -128,4 +128,34 @@ describe("PwaSyncSettings cloud diagnostics", () => {
       root.unmount();
     });
   });
+
+  it("summarizes blocked merge errors in the provider card and shows details only in diagnostics", () => {
+    const blockedMessage =
+      "Freed blocked a sync merge because it would remove too much feed history. Source: PWA sync. Largest input: 11,238 items. Merged result: 0 items. Potential loss: 11,238 items (100%). Restore from a trusted snapshot or reconnect sync after confirming which copy should win.";
+    useDebugStore.setState({
+      cloudProviders: {
+        dropbox: { status: "idle" },
+        gdrive: {
+          status: "error",
+          stage: "merge",
+          error: blockedMessage,
+          statusMessage: "Merge blocked.",
+          pendingReason: "Resolve this error, then reconnect or run Sync now.",
+          events: [],
+        },
+      },
+    });
+
+    const { container, root } = renderWithPlatform(createElement(PwaSyncSettings));
+    const text = container.textContent ?? "";
+    const diagnostics = container.querySelector("[data-testid='pwa-cloud-sync-diagnostics']");
+
+    expect(text).toContain("Merge blocked. Review Sync diagnostics below.");
+    expect(diagnostics?.textContent).toContain(blockedMessage);
+    expect((text.match(/Freed blocked a sync merge/g) ?? [])).toHaveLength(1);
+
+    act(() => {
+      root.unmount();
+    });
+  });
 });

--- a/packages/pwa/src/components/PwaSyncSettings.tsx
+++ b/packages/pwa/src/components/PwaSyncSettings.tsx
@@ -78,6 +78,15 @@ function describeUploadGap(state: CloudProviderDebugState | null): string {
   return "No upload has completed yet. Use Sync now to force a full pass.";
 }
 
+function isMergeBlocked(message?: string): boolean {
+  return message?.includes("blocked a sync merge") ?? false;
+}
+
+function describeProviderError(message: string): string {
+  if (isMergeBlocked(message)) return "Merge blocked. Review Sync diagnostics below.";
+  return "Sync needs attention. Review Sync diagnostics below.";
+}
+
 function ProviderLogo({ provider }: { provider: Provider }) {
   switch (provider) {
     case "gdrive":
@@ -205,10 +214,15 @@ export function PwaSyncSettings() {
   }
 
   // Connected, polished status card.
-  const statusText = isSyncing ? "Syncing now" : "Connected";
-  const dotColor = isSyncing
-    ? "bg-[var(--theme-accent-secondary)] animate-pulse"
-    : "bg-[rgb(var(--theme-feedback-success-rgb))]";
+  const providerError = cloudProviderState?.error;
+  const statusText = providerError
+    ? isMergeBlocked(providerError) ? "Merge blocked" : "Needs attention"
+    : isSyncing ? "Syncing now" : "Connected";
+  const dotColor = providerError
+    ? "bg-[rgb(var(--theme-feedback-danger-rgb))]"
+    : isSyncing
+      ? "bg-[var(--theme-accent-secondary)] animate-pulse"
+      : "bg-[rgb(var(--theme-feedback-success-rgb))]";
 
   return (
     <div className="space-y-4">
@@ -225,9 +239,9 @@ export function PwaSyncSettings() {
               Last synced {formatRelativeTime(lastSyncTime)}
             </p>
           )}
-          {cloudProviderState?.error && (
+          {providerError && (
             <p className="theme-feedback-text-danger mt-2 break-words text-xs">
-              {cloudProviderState.error}
+              {describeProviderError(providerError)}
             </p>
           )}
         </div>

--- a/packages/pwa/src/lib/cloud-sync-auth-refresh.test.ts
+++ b/packages/pwa/src/lib/cloud-sync-auth-refresh.test.ts
@@ -115,6 +115,38 @@ describe("PWA cloud sync auth refresh", () => {
     }));
   });
 
+  it("pauses Google Drive sync after an initial destructive merge block", async () => {
+    const remote = new Uint8Array([9, 8, 7]);
+    const blocked = new Error(
+      "Freed blocked a sync merge because it would remove too much feed history. Source: PWA sync. Largest input: 11,238 items. Merged result: 0 items. Potential loss: 11,238 items (100%). Restore from a trusted snapshot or reconnect sync after confirming which copy should win.",
+    );
+    gdriveDownloadLatestMock.mockResolvedValue(remote);
+    mergeDocMock.mockRejectedValue(blocked);
+    localStorage.setItem("freed_cloud_token_meta_gdrive", JSON.stringify({
+      accessToken: "valid-access-token",
+      refreshToken: "refresh-token",
+      expiresAt: Date.now() + 120_000,
+    }));
+
+    const { startCloudSync } = await import("./sync");
+    await startCloudSync("gdrive", "valid-access-token");
+
+    expect(mergeDocMock).toHaveBeenCalledWith(remote);
+    expect(gdriveStartPollLoopMock).not.toHaveBeenCalled();
+    expect(subscribeMock).not.toHaveBeenCalled();
+    expect(updateCloudProviderMock).toHaveBeenCalledWith("gdrive", expect.objectContaining({
+      status: "error",
+      stage: "merge",
+      statusMessage: "Merge blocked.",
+      error: blocked.message,
+    }));
+    expect(recordCloudProviderEventMock).toHaveBeenCalledWith("gdrive", expect.objectContaining({
+      kind: "waiting",
+      stage: "merge",
+      message: "Cloud sync paused until merge recovery is resolved.",
+    }));
+  });
+
   it("runs an immediate Google Drive download and upload for manual sync", async () => {
     gdriveDownloadLatestMock.mockResolvedValue(null);
     gdriveUploadSafeMock.mockResolvedValue({

--- a/packages/pwa/src/lib/schema.test.ts
+++ b/packages/pwa/src/lib/schema.test.ts
@@ -962,6 +962,36 @@ describe("Automerge merge / sync simulation", () => {
     ).not.toThrow();
   });
 
+  it("adopts a feed-populated peer when stale feed delete history leaves other local data", () => {
+    let populated = createEmptyDoc();
+    populated = A.change(populated, (d) => {
+      addRssFeed(d, makeFeed({ url: "https://example.com/feed.xml", title: "Example" }));
+      for (let i = 0; i < 600; i += 1) {
+        addFeedItem(d, makeItem({ globalId: `cloud-item-${i}` }));
+      }
+    });
+
+    let staleFeedEmpty = A.clone(populated);
+    staleFeedEmpty = A.change(staleFeedEmpty, (d) => {
+      for (const id of Object.keys(d.feedItems)) {
+        delete d.feedItems[id];
+      }
+      d.rssFeeds["https://local.example/feed.xml"] = makeFeed({
+        url: "https://local.example/feed.xml",
+        title: "Local only",
+      });
+    });
+
+    const merged = A.merge(staleFeedEmpty, populated);
+    expect(Object.keys(merged.feedItems)).toHaveLength(0);
+    expect(Object.keys(merged.rssFeeds).length).toBeGreaterThan(0);
+    expect(choosePopulatedInputForEmptyMerge(staleFeedEmpty, populated, merged)).toBe("incoming");
+
+    expect(() =>
+      assertNonDestructiveMerge(staleFeedEmpty, populated, populated, { source: "test sync" }),
+    ).not.toThrow();
+  });
+
   it("serializes and deserializes without data loss", () => {
     let doc = createEmptyDoc();
     doc = A.change(doc, (d) => {

--- a/packages/pwa/src/lib/sync.ts
+++ b/packages/pwa/src/lib/sync.ts
@@ -235,6 +235,10 @@ function describeSyncError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+function isDestructiveMergeError(error: unknown): boolean {
+  return describeSyncError(error).includes("blocked a sync merge");
+}
+
 type CloudStage = "auth" | "download" | "merge" | "poll" | "upload" | "idle";
 
 function recordCloudStep(
@@ -307,11 +311,14 @@ function markCloudSuccess(
 
 function markCloudError(provider: CloudProvider, stage: "auth" | "download" | "merge" | "poll" | "upload", error: unknown): void {
   const message = describeSyncError(error);
+  const statusMessage = isDestructiveMergeError(error)
+    ? "Merge blocked."
+    : `${stage[0].toUpperCase()}${stage.slice(1)} failed.`;
   updateCloudProvider(provider, {
     status: "error",
     stage,
     error: message,
-    statusMessage: message,
+    statusMessage,
     pendingReason: "Resolve this error, then reconnect or run Sync now.",
     lastErrorAt: Date.now(),
   });
@@ -554,7 +561,12 @@ export async function startCloudSync(provider: CloudProvider, token: string): Pr
     if (!signal.aborted) {
       console.error("[CloudSync] Initial download failed:", err);
       addDebugEvent("error", `[Cloud/${provider}] initial download failed: ${describeSyncError(err)}`);
-      markCloudError(provider, "download", err);
+      const failedStage = isDestructiveMergeError(err) ? "merge" : "download";
+      markCloudError(provider, failedStage, err);
+      if (failedStage === "merge") {
+        recordCloudStep(provider, "waiting", "merge", "Cloud sync paused until merge recovery is resolved.");
+        return;
+      }
     }
   }
 
@@ -813,9 +825,14 @@ export async function syncCloudProviderNow(provider: CloudProvider): Promise<voi
     error: undefined,
   });
 
-  await runInitialCloudDownload(provider, signal, async () => {
-    const currentToken = provider === "gdrive" ? await getValidCloudToken(provider) : token;
-    return currentToken ?? token;
-  });
-  await performCloudUpload(provider);
+  try {
+    await runInitialCloudDownload(provider, signal, async () => {
+      const currentToken = provider === "gdrive" ? await getValidCloudToken(provider) : token;
+      return currentToken ?? token;
+    });
+    await performCloudUpload(provider);
+  } catch (error) {
+    markCloudError(provider, isDestructiveMergeError(error) ? "merge" : "download", error);
+    throw error;
+  }
 }

--- a/packages/pwa/tests/app.spec.ts
+++ b/packages/pwa/tests/app.spec.ts
@@ -1053,7 +1053,7 @@ test.describe("FREED PWA", () => {
 
     // Should show empty state message
     await expect(page.locator("text=No content yet")).toBeVisible();
-    await expect(page.locator("text=Connect to your desktop app")).toBeVisible();
+    await expect(page.locator("text=Connect to Freed Desktop")).toBeVisible();
     await expect(page.locator("text=Alternatively, for preview & testing:")).toBeVisible();
     await expect(page.getByRole("button", { name: /Populate sample data/i })).toBeVisible();
   });

--- a/packages/shared/src/schema.ts
+++ b/packages/shared/src/schema.ts
@@ -2065,6 +2065,14 @@ export function choosePopulatedInputForEmptyMerge(
   incomingDoc: FreedDoc,
   mergedDoc: FreedDoc,
 ): PopulatedEmptyMergeInput | null {
+  const localItemCount = countFeedItems(localDoc);
+  const incomingItemCount = countFeedItems(incomingDoc);
+  const mergedItemCount = countFeedItems(mergedDoc);
+  if (mergedItemCount === 0) {
+    if (localItemCount === 0 && incomingItemCount > 0) return "incoming";
+    if (incomingItemCount === 0 && localItemCount > 0) return "local";
+  }
+
   if (countDocumentLibraryEntries(mergedDoc) > 0) return null;
 
   const localEntries = countDocumentLibraryEntries(localDoc);

--- a/scripts/nightly-self-improve.mjs
+++ b/scripts/nightly-self-improve.mjs
@@ -847,8 +847,7 @@ export function summarizePeerWorktree(worktreePath, currentRepo) {
     "diff",
     "--name-only",
     "--diff-filter=ACDMRTUXB",
-    "origin/dev",
-    "HEAD",
+    "origin/dev...HEAD",
   ]);
   const workingFiles = unique([
     ...shortStatusPaths(status),
@@ -1037,6 +1036,19 @@ function riskItem({ id, severity, title, evidence, remediation, actions = [] }) 
   return { id, severity, title, evidence, remediation, actions };
 }
 
+function expectedBranchHead(repo, expectedBranch) {
+  if (expectedBranch === "dev") return repo.originDev || "";
+  if (expectedBranch === "main") return repo.originMain || "";
+  return "";
+}
+
+function matchesExpectedBranch(repo, expectedBranch) {
+  if (!expectedBranch) return true;
+  if (repo.branch === expectedBranch) return true;
+  const expectedHead = expectedBranchHead(repo, expectedBranch);
+  return repo.branch === "HEAD" && Boolean(repo.head) && Boolean(expectedHead) && repo.head === expectedHead;
+}
+
 export function collectRiskSnapshot({
   repoPath,
   repo,
@@ -1050,7 +1062,7 @@ export function collectRiskSnapshot({
   nowMs = Date.now(),
 }) {
   const risks = [];
-  if (expectedBranch && repo.branch !== expectedBranch) {
+  if (!matchesExpectedBranch(repo, expectedBranch)) {
     risks.push(
       riskItem({
         id: "unexpected-repo-branch",

--- a/scripts/nightly-self-improve.test.mjs
+++ b/scripts/nightly-self-improve.test.mjs
@@ -23,6 +23,7 @@ import {
   resolveReadableSoak,
   selectTargets,
   shouldRetainPeerWorktree,
+  summarizePeerWorktree,
   summarizeOutcomeLedger,
   summarizeDailyBugMemory,
   summarizeSoak,
@@ -580,6 +581,38 @@ test("duplicate work detector reports file and surface overlap", () => {
   assert.equal(duplicateWork.blockerCount, 1);
 });
 
+test("summarizePeerWorktree ignores behind-only detached snapshots as active changes", () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "freed-peer-summary-"));
+  const origin = path.join(dir, "origin.git");
+  const repo = path.join(dir, "repo");
+  const peer = path.join(dir, "peer");
+
+  execFileSync("git", ["init", "--bare", origin]);
+  execFileSync("git", ["clone", origin, repo]);
+  execFileSync("git", ["-C", repo, "config", "user.name", "Freed Tests"]);
+  execFileSync("git", ["-C", repo, "config", "user.email", "tests@example.com"]);
+  execFileSync("git", ["-C", repo, "checkout", "-b", "dev"]);
+  writeFileSync(path.join(repo, "notes.txt"), "first\n");
+  execFileSync("git", ["-C", repo, "add", "notes.txt"]);
+  execFileSync("git", ["-C", repo, "commit", "-m", "first"]);
+  const firstHead = execFileSync("git", ["-C", repo, "rev-parse", "HEAD"], { encoding: "utf8" }).trim();
+  execFileSync("git", ["-C", repo, "push", "-u", "origin", "dev"]);
+
+  writeFileSync(path.join(repo, "notes.txt"), "second\n");
+  execFileSync("git", ["-C", repo, "commit", "-am", "second"]);
+  execFileSync("git", ["-C", repo, "push"]);
+
+  execFileSync("git", ["clone", origin, peer]);
+  execFileSync("git", ["-C", peer, "fetch", "origin", "dev"]);
+  execFileSync("git", ["-C", peer, "checkout", "--detach", firstHead]);
+
+  const summary = summarizePeerWorktree(peer, repo);
+  assert.equal(summary?.branch, "HEAD");
+  assert.equal(summary?.aheadCount, 0);
+  assert.equal(summary?.behindCount, 1);
+  assert.equal(summary?.changedFileCount, 0);
+});
+
 test("duplicate work candidates are selected before generic roadmap fallback", () => {
   const duplicateWork = {
     findingCount: 1,
@@ -773,6 +806,29 @@ test("risk snapshot warns when the dev worktree is stale", () => {
   assert.equal(snapshot.risks.some((item) => item.id === "unexpected-repo-branch"), false);
   assert.equal(risk?.severity, "warning");
   assert.ok(risk?.actions.some((action) => action.id === "refresh-dev-worktree"));
+});
+
+test("risk snapshot allows detached HEAD when it matches origin/dev", () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "freed-detached-dev-risk-"));
+  mkdirSync(path.join(dir, "node_modules"), { recursive: true });
+  const snapshot = collectRiskSnapshot({
+    repoPath: dir,
+    repo: {
+      branch: "HEAD",
+      head: "abc1234",
+      originDev: "abc1234",
+      originMain: "def5678",
+      status: "",
+    },
+    soak: { exists: false },
+    crashAutomation: "",
+    dailyBugMemory: "",
+    devBotMemory: "",
+    expectedBranch: "dev",
+  });
+
+  assert.equal(snapshot.risks.some((item) => item.id === "unexpected-repo-branch"), false);
+  assert.equal(snapshot.risks.some((item) => item.id === "stale-dev-worktree"), false);
 });
 
 test("writeRunPlan emits report, targets, and task prompts", () => {


### PR DESCRIPTION
(AI Generated).

## Summary
- Promote the PWA Google Drive sync recovery fix into main
- Carry the feed-aware merge recovery and blocked-sync UI into the production lane
- Carry the latest nightly preflight tooling fix already merged on dev

## Validation
- node scripts/validate-release-promotion.mjs --from-ref=origin/dev --to-ref=HEAD
- node scripts/validate-main-pr.mjs --base-ref=origin/main --head-ref=HEAD --head-branch=chore/promote-dev-to-main-20260608-103040