### PR TITLE
fix: polish mobile menu touch interactions

### DIFF
--- a/packages/pwa/tests/app.spec.ts
+++ b/packages/pwa/tests/app.spec.ts
@@ -1697,6 +1697,7 @@ test.describe("FREED PWA", () => {
 
     const menuButton = page.getByRole("button", { name: "Close menu" });
     const geometry = await page.evaluate(() => {
+      const toolbar = document.querySelector('[data-testid="workspace-toolbar"]') as HTMLElement | null;
       const button = document.querySelector('button[aria-label="Close menu"]') as HTMLElement | null;
       const icon = button?.querySelector("[aria-hidden='true']") as HTMLElement | null;
       const sidebar = document.querySelector('[data-testid="app-sidebar-mobile"]') as HTMLElement | null;
@@ -1705,9 +1706,10 @@ test.describe("FREED PWA", () => {
       const firstControl = sidebar?.querySelector("input, button") as HTMLElement | null;
       const settingsFooter = sidebar?.querySelector('[data-testid="mobile-sidebar-settings-footer"]') as HTMLElement | null;
       const settingsButton = sidebar?.querySelector('[data-testid="mobile-sidebar-settings-button"]') as HTMLElement | null;
-      if (!button || !icon || !sidebar || !search || !firstSourceButton || !firstControl || !settingsFooter || !settingsButton) {
+      if (!toolbar || !button || !icon || !sidebar || !search || !firstSourceButton || !firstControl || !settingsFooter || !settingsButton) {
         throw new Error("Mobile menu geometry elements were not found");
       }
+      const toolbarRect = toolbar.getBoundingClientRect();
       const buttonRect = button.getBoundingClientRect();
       const iconRect = icon.getBoundingClientRect();
       const sidebarRect = sidebar.getBoundingClientRect();
@@ -1715,6 +1717,7 @@ test.describe("FREED PWA", () => {
       const firstSourceButtonRect = firstSourceButton.getBoundingClientRect();
       const footerRect = settingsFooter.getBoundingClientRect();
       const settingsButtonRect = settingsButton.getBoundingClientRect();
+      const toolbarStyle = window.getComputedStyle(toolbar);
       const sidebarStyle = window.getComputedStyle(sidebar);
       const sourceStyle = window.getComputedStyle(firstSourceButton);
       const settingsButtonStyle = window.getComputedStyle(settingsButton);
@@ -1727,14 +1730,26 @@ test.describe("FREED PWA", () => {
           (buttonRect.left + buttonRect.width / 2) -
           (iconRect.left + iconRect.width / 2),
         ),
+        menuEdgeGap: Math.round(buttonRect.left - toolbarRect.left),
         firstControlIsSearch: firstControl === search,
         sourceCenterHitsSidebar: !!hitElement && sidebar.contains(hitElement),
+        toolbarBorderBottomColor: toolbarStyle.borderBottomColor,
         sidebarZIndex: Number.parseInt(sidebarStyle.zIndex, 10),
+        sidebarWidth: Math.round(sidebarRect.width),
+        viewportWidth: window.innerWidth,
+        sidebarBoxShadow: sidebarStyle.boxShadow,
+        searchEdgeGap: Math.round(searchRect.left - sidebarRect.left),
+        searchHeight: Math.round(searchRect.height),
+        sourceEdgeGap: Math.round(firstSourceButtonRect.left - sidebarRect.left),
+        settingsEdgeGap: Math.round(settingsButtonRect.left - sidebarRect.left),
         searchTop: Math.round(searchRect.top),
         sidebarTop: Math.round(sidebarRect.top),
+        searchToFirstRowGap: Math.round(firstSourceButtonRect.top - searchRect.bottom),
         footerBottomGap: Math.round(sidebarRect.bottom - footerRect.bottom),
+        settingsButtonBottomGap: Math.round(sidebarRect.bottom - settingsButtonRect.bottom),
         footerBorderTopWidth: footerStyle.borderTopWidth,
         sourceFontSize: sourceStyle.fontSize,
+        sourceButtonHeight: Math.round(firstSourceButtonRect.height),
         sourcePaddingTop: sourceStyle.paddingTop,
         sourcePaddingBottom: sourceStyle.paddingBottom,
         sourceColumnGap: sourceStyle.columnGap,
@@ -1744,11 +1759,21 @@ test.describe("FREED PWA", () => {
       };
     });
     expect(geometry.centerDelta).toBeLessThanOrEqual(1);
+    expect(geometry.menuEdgeGap).toBeGreaterThanOrEqual(8);
     expect(geometry.firstControlIsSearch).toBe(true);
     expect(geometry.sourceCenterHitsSidebar).toBe(true);
+    expect(geometry.toolbarBorderBottomColor).toBe("rgba(0, 0, 0, 0)");
     expect(geometry.sidebarZIndex).toBeGreaterThan(50);
+    expect(geometry.sidebarWidth).toBe(geometry.viewportWidth);
+    expect(geometry.sidebarBoxShadow).toBe("none");
+    expect(geometry.searchEdgeGap).toBe(geometry.menuEdgeGap);
+    expect(Math.abs(geometry.searchHeight - geometry.sourceButtonHeight)).toBeLessThanOrEqual(1);
+    expect(Math.abs(geometry.sourceEdgeGap - geometry.menuEdgeGap)).toBeLessThanOrEqual(1);
+    expect(Math.abs(geometry.settingsEdgeGap - geometry.menuEdgeGap)).toBeLessThanOrEqual(1);
     expect(geometry.searchTop - geometry.sidebarTop).toBeGreaterThanOrEqual(8);
+    expect(geometry.searchToFirstRowGap).toBeGreaterThanOrEqual(16);
     expect(geometry.footerBottomGap).toBeLessThanOrEqual(1);
+    expect(geometry.settingsButtonBottomGap).toBeGreaterThanOrEqual(8);
     expect(geometry.footerBorderTopWidth).toBe("0px");
     expect(geometry.sourceFontSize).toBe("17px");
     expect(geometry.sourcePaddingTop).toBe("8px");
@@ -1756,7 +1781,7 @@ test.describe("FREED PWA", () => {
     expect(geometry.sourceColumnGap).toBe("8px");
     expect(geometry.settingsButtonFontSize).toBe("17px");
     expect(geometry.settingsButtonPaddingTop).toBe("8px");
-    expect(geometry.settingsButtonHeight).toBeLessThanOrEqual(44);
+    expect(geometry.settingsButtonHeight).toBeGreaterThanOrEqual(geometry.sourceButtonHeight);
 
     await menuButton.click();
     await expect(sidebar).toHaveClass(/-translate-x-full/);
@@ -1776,9 +1801,17 @@ test.describe("FREED PWA", () => {
       (element as HTMLButtonElement).click();
     });
 
-    await expect(page.getByRole("heading", { name: "Settings" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Freed Settings" })).toBeVisible();
     await expect(page.getByRole("button", { name: "Appearance" })).toBeVisible();
     await expect(page.getByRole("heading", { name: "Appearance" })).toHaveCount(0);
+    await expect(page.getByTestId("settings-nav-panel")).toHaveCSS("border-bottom-width", "0px");
+    const settingsSearchHeight = await page.getByLabel("Search settings").evaluate((input) =>
+      Math.round(input.getBoundingClientRect().height),
+    );
+    const appearanceButtonHeight = await page.getByRole("button", { name: "Appearance" }).evaluate((button) =>
+      Math.round(button.getBoundingClientRect().height),
+    );
+    expect(settingsSearchHeight).toBe(appearanceButtonHeight);
     const overviewFontSize = await page.getByRole("button", { name: "Appearance" }).evaluate((button) =>
       Number.parseFloat(window.getComputedStyle(button).fontSize),
     );
@@ -1797,13 +1830,14 @@ test.describe("FREED PWA", () => {
     await page.getByRole("button", { name: "Settings" }).evaluate((element) => {
       (element as HTMLButtonElement).click();
     });
-    await expect(page.getByRole("heading", { name: "Settings" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Freed Settings" })).toBeVisible();
     await expect(page.getByRole("button", { name: "Appearance" })).toBeVisible();
     await expect(page.getByRole("button", { name: "Support", exact: true })).toHaveCount(0);
     await expect(page.getByRole("heading", { name: "Appearance" })).toHaveCount(0);
 
     await page.getByRole("button", { name: "Updates" }).click();
-    await expect(page.getByTestId("settings-mobile-section-title")).toHaveText("Updates");
+    await expect(page.getByTestId("settings-mobile-section-title")).toHaveText("Freed SettingsUpdates");
+    await expect(page.getByTestId("settings-mobile-breadcrumb-caret")).toHaveCount(1);
 
     const scrollContainer = page.getByTestId("settings-scroll-container");
     await scrollContainer.evaluate((container) => {
@@ -1831,9 +1865,16 @@ test.describe("FREED PWA", () => {
     expect(sectionMetrics.sectionGap).toBeLessThanOrEqual(64);
 
     await page.getByLabel("Back to settings").click();
-    await expect(page.getByRole("heading", { name: "Settings" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Freed Settings" })).toBeVisible();
+    await page.getByTestId("settings-nav-panel").getByRole("button", { name: "Saved" }).click();
+    await expect(page.getByTestId("settings-mobile-section-title")).toHaveText("Freed SettingsSourcesSaved");
+    await expect(page.getByTestId("settings-mobile-breadcrumb-caret")).toHaveCount(2);
+
+    await page.getByLabel("Back to settings").click();
+    await expect(page.getByRole("heading", { name: "Freed Settings" })).toBeVisible();
     await page.getByRole("button", { name: "Danger Zone" }).click();
-    await expect(page.getByTestId("settings-mobile-section-title")).toHaveText("Danger Zone");
+    await expect(page.getByTestId("settings-mobile-section-title")).toHaveText("Freed SettingsDanger Zone");
+    await expect(page.getByTestId("settings-mobile-breadcrumb-caret")).toHaveCount(1);
 
     await scrollContainer.evaluate((container) => {
       const danger = container.querySelector('[data-section="danger"]') as HTMLElement | null;
@@ -1901,6 +1942,9 @@ test.describe("FREED PWA", () => {
       const overflowRect = overflow.getBoundingClientRect();
       const formatRect = format.getBoundingClientRect();
       const formatIconRect = formatIcon.getBoundingClientRect();
+      const menuStyle = window.getComputedStyle(menu);
+      const overflowStyle = window.getComputedStyle(overflow);
+      const formatStyle = window.getComputedStyle(format);
       return {
         toolbarLeft: toolbarRect.left,
         toolbarRight: toolbarRect.right,
@@ -1908,19 +1952,23 @@ test.describe("FREED PWA", () => {
         menuRight: menuRect.right,
         menuIconLeft: menuIconRect.left,
         menuVisibleLeft,
+        menuEdgeGap: Math.round(menuRect.left - toolbarRect.left),
         menuBarWidths,
         overflowRight: overflowRect.right,
         formatLeft: formatRect.left,
         formatRight: formatRect.right,
         formatIconRight: formatIconRect.right,
+        menuBorderColor: menuStyle.borderColor,
+        overflowBorderColor: overflowStyle.borderColor,
+        formatBorderColor: formatStyle.borderColor,
         viewportRight: window.innerWidth,
         widths: [menuRect.width, overflowRect.width, formatRect.width],
       };
     });
-    expect(
-      Math.abs((geometry.menuVisibleLeft - geometry.toolbarLeft) - (geometry.toolbarRight - geometry.formatIconRight)),
-      JSON.stringify(geometry),
-    ).toBeLessThanOrEqual(2);
+    expect(geometry.menuEdgeGap).toBeGreaterThanOrEqual(8);
+    expect(geometry.menuBorderColor).toBe("rgba(0, 0, 0, 0)");
+    expect(geometry.overflowBorderColor).toBe("rgba(0, 0, 0, 0)");
+    expect(geometry.formatBorderColor).toBe("rgba(0, 0, 0, 0)");
     for (const barWidth of geometry.menuBarWidths) {
       expect(Math.abs(barWidth - geometry.menuBarWidths[0])).toBeLessThanOrEqual(1);
     }
@@ -1928,10 +1976,11 @@ test.describe("FREED PWA", () => {
     expect(geometry.overflowRight).toBeLessThanOrEqual(geometry.formatLeft);
     expect(geometry.formatRight).toBeGreaterThan(geometry.overflowRight);
     for (const width of geometry.widths) {
-      expect(Math.abs(width - 40)).toBeLessThanOrEqual(1);
+      expect(Math.abs(width - 36)).toBeLessThanOrEqual(1);
     }
 
     await overflowButton.click();
+    await expect(overflowButton).toHaveCSS("border-color", "rgba(0, 0, 0, 0)");
     const menuTop = await page.getByTestId("toolbar-overflow-menu").evaluate((menu) =>
       Math.round(menu.getBoundingClientRect().top),
     );
@@ -1941,6 +1990,13 @@ test.describe("FREED PWA", () => {
         Math.round(menu.getBoundingClientRect().top),
       ))
       .toBe(menuTop);
+
+    await page.keyboard.press("Escape");
+    await menuButton.click();
+    await expect(page.getByRole("button", { name: "Close menu" })).toHaveCSS("border-color", "rgba(0, 0, 0, 0)");
+    await expect(page.getByTestId("toolbar-overflow-button")).toHaveCount(0);
+    await expect(page.getByTestId("feed-signal-filter-button")).toHaveCount(0);
+    await expect(page.getByTestId("mobile-toolbar-filter-button")).toHaveCount(0);
   });
 
   test("mobile feed and reader spacing stay balanced", async ({ page }) => {
@@ -1983,6 +2039,25 @@ test.describe("FREED PWA", () => {
     expect(readerMetrics.bodyOverflow).toBe("hidden");
     expect(readerMetrics.paddingLeft).toBeGreaterThanOrEqual(20);
     expect(readerMetrics.paddingRight).toBeGreaterThanOrEqual(20);
+  });
+
+  test("mobile story cards open on first tap without quick actions", async ({ page }) => {
+    await emulateMobileDevice(page);
+    await page.setViewportSize({ width: 393, height: 852 });
+    await page.goto("/");
+    await acceptLegalGate(page);
+    await waitForPwaReady(page);
+    await seedSocialReaderItem(page);
+
+    const storyCard = page.getByRole("button", {
+      name: /Reader Author.*Social author navigation item/i,
+    });
+    await expect(storyCard).toBeVisible();
+    await expect(storyCard.locator('button[aria-label="Bookmark"]')).toHaveCount(0);
+    await expect(storyCard.locator('button[aria-label="Archive"]')).toHaveCount(0);
+
+    await storyCard.click();
+    await expect(page.getByTestId("reader-article")).toBeVisible();
   });
 
   test("inline reader does not add a second toolbar divider", async ({ page }) => {

--- a/packages/ui/src/components/SettingsDialog.tsx
+++ b/packages/ui/src/components/SettingsDialog.tsx
@@ -71,6 +71,7 @@ import { ThemePreviewButton } from "./ThemePreviewButton.js";
 import { Tooltip } from "./Tooltip.js";
 import { ExternalLinkIcon, GoogleContactsIcon, StoryWallIcon } from "./icons.js";
 import { useIsMobile } from "../hooks/useIsMobile.js";
+import { useHasTouchOnlyPointer } from "../hooks/useHasTouchOnlyPointer.js";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -537,12 +538,11 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
       sectionById,
     ],
   );
-
   // ── Preferences state ────────────────────────────────────────────────────
   const [display, setDisplay] = useState(() => preferences.display);
   const [themePreviewHovering, setThemePreviewHovering] = useState(false);
   const [themePreviewTouchActive, setThemePreviewTouchActive] = useState(false);
-  const [hasCoarsePointer, setHasCoarsePointer] = useState(false);
+  const hasCoarsePointer = useHasTouchOnlyPointer();
 
   useEffect(() => {
     committedThemeIdRef.current = preferences.display.themeId;
@@ -575,24 +575,6 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
   useEffect(() => {
     setDisplay(preferences.display);
   }, [preferences.display]);
-
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-
-    const coarsePointerMedia = window.matchMedia("(pointer: coarse)");
-    const hoverCapableMedia = window.matchMedia("(any-hover: hover)");
-    const updatePointerMode = () => {
-      setHasCoarsePointer(coarsePointerMedia.matches && !hoverCapableMedia.matches);
-    };
-
-    updatePointerMode();
-    coarsePointerMedia.addEventListener?.("change", updatePointerMode);
-    hoverCapableMedia.addEventListener?.("change", updatePointerMode);
-    return () => {
-      coarsePointerMedia.removeEventListener?.("change", updatePointerMode);
-      hoverCapableMedia.removeEventListener?.("change", updatePointerMode);
-    };
-  }, []);
 
   const flushPendingThemeSelection = useCallback((themeId: ThemeId, saveSeq: number) => {
     pendingThemeIdRef.current = null;
@@ -962,6 +944,18 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
   const [mobileView, setMobileView] = useState<"nav" | "section">("nav");
   const [scrollportHeight, setScrollportHeight] = useState(0);
   const scrollRef = useRef<HTMLDivElement>(null);
+  const activeSectionBreadcrumb = useMemo(() => {
+    const section = allSections.find((candidate) => candidate.id === activeSection);
+    if (!section) return ["Freed Settings"];
+
+    for (const item of navStructure) {
+      if ("kind" in item && item.children.some((child) => child.id === section.id)) {
+        return ["Freed Settings", item.label, section.label];
+      }
+    }
+
+    return ["Freed Settings", section.label];
+  }, [activeSection, allSections, navStructure]);
   const activeSectionRef = useRef(activeSection);
   const scrollAnchorRef = useRef<SettingsScrollAnchor>({ sectionId: "appearance", offset: 0 });
   const renderedSectionIds = useMemo(() => {
@@ -1973,9 +1967,10 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
       >
         {/* ── Left column ────────────────────────────────────────────────── */}
         <div
+          data-testid="settings-nav-panel"
           className={`
-            theme-dialog-divider flex shrink-0 flex-col border-b
-            sm:w-52 sm:border-b-0 sm:border-r
+            theme-dialog-divider flex shrink-0 flex-col
+            sm:w-52 sm:border-r
             ${mobileView === "section" ? "hidden sm:flex" : "flex"}
           `}
         >
@@ -1992,10 +1987,10 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
             className="flex shrink-0 items-center justify-between px-4 pb-1.5 pt-2 sm:hidden"
             style={{ paddingTop: "calc(env(safe-area-inset-top, 0px) + 0.5rem)" }}
           >
-            <h2 className="text-base font-semibold text-text-primary">Settings</h2>
+            <h2 className="text-base font-semibold text-text-primary">Freed Settings</h2>
             <CloseButton
               testId={isMobile && mobileView === "nav" ? "settings-close-button-mobile" : undefined}
-              className="-mr-1"
+              className="-mr-2"
             />
           </div>
 
@@ -2008,6 +2003,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
               placeholder="Search settings"
               aria-label="Search settings"
               density="compact"
+              inputClassName="h-10 text-base sm:h-auto sm:text-sm"
             />
           </div>
 
@@ -2058,15 +2054,36 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
               </svg>
               <span
-                className="truncate text-sm font-medium text-text-primary"
+                className="flex min-w-0 items-center gap-1.5 truncate text-sm font-medium text-text-primary"
                 data-testid="settings-mobile-section-title"
               >
-                {allSections.find((s) => s.id === activeSection)?.label}
+                {activeSectionBreadcrumb.map((label, index) => (
+                  <Fragment key={`${label}-${index}`}>
+                    {index > 0 ? (
+                      <svg
+                        aria-hidden="true"
+                        className="h-2.5 w-2.5 shrink-0 text-[color:color-mix(in_srgb,var(--theme-text-muted)_72%,transparent)]"
+                        data-testid="settings-mobile-breadcrumb-caret"
+                        fill="none"
+                        viewBox="0 0 12 12"
+                      >
+                        <path
+                          d="M4.5 2.75 7.25 6 4.5 9.25"
+                          stroke="currentColor"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth="1.6"
+                        />
+                      </svg>
+                    ) : null}
+                    <span className="truncate">{label}</span>
+                  </Fragment>
+                ))}
               </span>
             </button>
             <CloseButton
               testId={isMobile && mobileView === "section" ? "settings-close-button-mobile" : undefined}
-              className="-mr-1 shrink-0"
+              className="-mr-2 shrink-0"
             />
           </div>
 

--- a/packages/ui/src/components/feed/FeedItem.test.tsx
+++ b/packages/ui/src/components/feed/FeedItem.test.tsx
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 import { act, type ComponentProps } from "react";
 import { createRoot, type Root } from "react-dom/client";
@@ -108,7 +108,41 @@ function setMemoryPressure(
 
 beforeEach(() => {
   useDebugStore.setState({ runtimeMemory: null });
+  setMobileNavigator(false);
+  setTouchOnlyPointer(false);
 });
+
+function setMobileNavigator(mobile: boolean): void {
+  Object.defineProperty(navigator, "userAgentData", {
+    configurable: true,
+    value: { mobile },
+  });
+  Object.defineProperty(navigator, "maxTouchPoints", {
+    configurable: true,
+    value: mobile ? 5 : 0,
+  });
+}
+
+function setTouchOnlyPointer(touchOnly: boolean): void {
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    writable: true,
+    value: (query: string) => ({
+      matches: query === "(pointer: coarse)"
+        ? touchOnly
+        : query === "(any-hover: hover)"
+          ? !touchOnly
+          : false,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }),
+  });
+}
 
 function renderFeedItemToStaticMarkup(
   item: FeedItemType,
@@ -197,6 +231,115 @@ describe("FeedItem story media", () => {
     const html = renderFeedItemToStaticMarkup(makeItem({ globalId: "ig:story/transition proof" }));
 
     expect(html).toContain("view-transition-name:feed-card-ig-story-transition-proof");
+  });
+
+  it("opens touch mobile story cards on the first tap without quick actions", async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    setMobileNavigator(true);
+    const onClick = vi.fn();
+    const onSave = vi.fn();
+    const onArchive = vi.fn();
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root: Root = createRoot(container);
+
+    try {
+      await act(async () => {
+        root.render(
+          <PlatformProvider value={platformConfig}>
+            <FeedItem
+              item={makeItem()}
+              onClick={onClick}
+              onSave={onSave}
+              onArchive={onArchive}
+            />
+          </PlatformProvider>,
+        );
+      });
+
+      expect(container.querySelector('button[aria-label="Bookmark"]')).toBeNull();
+      expect(container.querySelector('button[aria-label="Archive"]')).toBeNull();
+
+      const card = container.querySelector('[role="button"]') as HTMLElement | null;
+      expect(card).toBeInstanceOf(HTMLElement);
+      await act(async () => {
+        card?.click();
+      });
+
+      expect(onClick).toHaveBeenCalledTimes(1);
+      expect(onSave).not.toHaveBeenCalled();
+      expect(onArchive).not.toHaveBeenCalled();
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+      setMobileNavigator(false);
+      (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = false;
+    }
+  });
+
+  it("opens touch mobile regular cards without rendering quick action buttons", async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    setTouchOnlyPointer(true);
+    const onClick = vi.fn();
+    const onSave = vi.fn();
+    const onArchive = vi.fn();
+    const onLike = vi.fn();
+    const onOpenCommentUrl = vi.fn();
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root: Root = createRoot(container);
+
+    try {
+      await act(async () => {
+        root.render(
+          <PlatformProvider value={platformConfig}>
+            <FeedItem
+              item={makeItem({
+                platform: "facebook",
+                contentType: "post",
+                sourceUrl: "https://example.com/post",
+                content: {
+                  text: "Post text",
+                  mediaUrls: [],
+                  mediaTypes: [],
+                },
+              })}
+              fixedHeight={220}
+              onClick={onClick}
+              onSave={onSave}
+              onArchive={onArchive}
+              onLike={onLike}
+              onOpenCommentUrl={onOpenCommentUrl}
+            />
+          </PlatformProvider>,
+        );
+      });
+
+      for (const label of ["Like", "Comment on Facebook", "Bookmark", "Archive", "Open"]) {
+        expect(container.querySelector(`button[aria-label="${label}"]`)).toBeNull();
+      }
+
+      const card = container.querySelector('[role="button"]') as HTMLElement | null;
+      expect(card).toBeInstanceOf(HTMLElement);
+      await act(async () => {
+        card?.click();
+      });
+
+      expect(onClick).toHaveBeenCalledTimes(1);
+      expect(onSave).not.toHaveBeenCalled();
+      expect(onArchive).not.toHaveBeenCalled();
+      expect(onLike).not.toHaveBeenCalled();
+      expect(onOpenCommentUrl).not.toHaveBeenCalled();
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+      setMobileNavigator(false);
+      (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = false;
+    }
   });
 
   it("shares the feed card view transition name in compact story tiles", () => {

--- a/packages/ui/src/components/feed/FeedItem.tsx
+++ b/packages/ui/src/components/feed/FeedItem.tsx
@@ -4,6 +4,8 @@ import { PLATFORM_LABELS, type FeedItem as FeedItemType } from "@freed/shared";
 import { usePlatform } from "../../context/PlatformContext.js";
 import type { FeedCardDensity } from "../../lib/feed-card-density.js";
 import { useDebugStore, type RuntimeMemorySnapshot } from "../../lib/debug-store.js";
+import { useHasTouchOnlyPointer } from "../../hooks/useHasTouchOnlyPointer.js";
+import { useIsMobileDevice } from "../../hooks/useIsMobileDevice.js";
 import { ChannelAvatar } from "../ChannelAvatar.js";
 import { Tooltip } from "../Tooltip.js";
 import {
@@ -230,6 +232,9 @@ export const FeedItem = memo(function FeedItem({
   const { feedMediaPreviews = "inline" } = usePlatform();
   const feedMediaPreviewMode = item.contentType === "story" ? "inline" : feedMediaPreviews;
   const { showInlineMedia, showAvatarImages } = useFeedImageBudget(feedMediaPreviewMode);
+  const isTouchMobileDevice = useIsMobileDevice();
+  const hasTouchOnlyPointer = useHasTouchOnlyPointer();
+  const quickActionsEnabled = !isTouchMobileDevice && !hasTouchOnlyPointer;
   const sharedTransitionStyle = {
     viewTransitionName: feedCardTransitionName(item.globalId),
   } as React.CSSProperties;
@@ -392,7 +397,7 @@ export const FeedItem = memo(function FeedItem({
 
   const swipeProgress = Math.min(Math.abs(swipeX) / SWIPE_THRESHOLD, 1);
   const pastThreshold = swipeX < -SWIPE_THRESHOLD;
-  const enableSwipe = !compact && !!onArchive && !item.userState.saved;
+  const enableSwipe = quickActionsEnabled && !compact && !!onArchive && !item.userState.saved;
   const handleActivateClick = (event: MouseEvent<HTMLElement>) => {
     event.currentTarget.focus();
     onClick?.();
@@ -419,7 +424,7 @@ export const FeedItem = memo(function FeedItem({
           data-focused={focused ? "true" : "false"}
           data-selected={selected ? "true" : "false"}
           data-feed-card-density={density}
-          className={`relative overflow-hidden rounded-[var(--feed-card-radius)] cursor-pointer group select-none w-full transition-opacity ${readVisualClass}`}
+          className={`relative overflow-hidden rounded-[var(--feed-card-radius)] cursor-pointer select-none w-full transition-opacity ${quickActionsEnabled ? "group" : ""} ${readVisualClass}`}
           style={{ height: storyHeight }}
           onClick={handleActivateClick}
           onMouseEnter={onMouseEnter}
@@ -445,7 +450,7 @@ export const FeedItem = memo(function FeedItem({
               loading="lazy"
               decoding="async"
               onError={() => setMediaFailed(true)}
-              className="absolute inset-0 w-full h-full object-cover transition-transform duration-300 group-hover:scale-[1.03]"
+              className={`absolute inset-0 w-full h-full object-cover ${quickActionsEnabled ? "transition-transform duration-300 group-hover:scale-[1.03]" : ""}`}
             />
           ) : (
             <div className={`absolute inset-0 bg-gradient-to-br ${gradientFallback}`} />
@@ -493,7 +498,7 @@ export const FeedItem = memo(function FeedItem({
               )}
             </div>
 
-            {(onSave || onArchive) && (
+            {quickActionsEnabled && (onSave || onArchive) && (
               <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity shrink-0">
                 {onSave && (
                   <Tooltip label={item.userState.saved ? "Remove bookmark" : "Bookmark"} side="top">
@@ -538,10 +543,12 @@ export const FeedItem = memo(function FeedItem({
           data-feed-item-id={item.globalId}
           data-focused={focused ? "true" : "false"}
           data-selected={selected ? "true" : "false"}
-          className={`feed-card group relative min-w-0 cursor-pointer aspect-square overflow-hidden p-3 flex flex-col transition-colors ${
+          className={`feed-card ${quickActionsEnabled ? "group" : ""} relative min-w-0 cursor-pointer aspect-square overflow-hidden p-3 flex flex-col transition-colors ${
             selected
               ? "border-l-2 border-l-[var(--theme-accent-secondary)] bg-[color:rgb(var(--theme-accent-secondary-rgb)/0.12)]"
-              : "hover:bg-[var(--theme-bg-muted)]"
+              : quickActionsEnabled
+                ? "hover:bg-[var(--theme-bg-muted)]"
+                : ""
           } ${readVisualClass}`}
           style={FEED_CARD_LAYOUT_CONTAINMENT_STYLE}
           onClick={handleActivateClick}
@@ -652,7 +659,7 @@ export const FeedItem = memo(function FeedItem({
           data-feed-item-id={item.globalId}
           data-focused={focused ? "true" : "false"}
           data-feed-card-density={density}
-          className={`feed-card group min-w-0 cursor-pointer active:scale-[0.99] transition-transform ${fixedCardDensity.article} ${focused ? "ring-2 ring-[color:rgb(var(--theme-accent-secondary-rgb)/0.6)] ring-inset" : ""} ${readVisualClass}`}
+          className={`feed-card ${quickActionsEnabled ? "group" : ""} min-w-0 cursor-pointer active:scale-[0.99] transition-transform ${fixedCardDensity.article} ${focused ? "ring-2 ring-[color:rgb(var(--theme-accent-secondary-rgb)/0.6)] ring-inset" : ""} ${readVisualClass}`}
           style={{
             ...FEED_CARD_LAYOUT_CONTAINMENT_STYLE,
             height: fixedHeight,
@@ -695,118 +702,120 @@ export const FeedItem = memo(function FeedItem({
                   </div>
                 </div>
 
-                <div className="flex shrink-0 items-center gap-1">
-                  {onLike && (
-                    <div className="relative group/reactions">
-                      {hasReactionPalette && (
-                        <div className="pointer-events-none absolute right-0 bottom-full mb-2 flex translate-y-1 rounded-xl border border-[var(--theme-border-subtle)] bg-[var(--theme-bg-elevated)] p-1 opacity-0 shadow-lg shadow-black/30 transition-all group-hover/reactions:pointer-events-auto group-hover/reactions:translate-y-0 group-hover/reactions:opacity-100 group-focus-within/reactions:pointer-events-auto group-focus-within/reactions:translate-y-0 group-focus-within/reactions:opacity-100">
-                          {reactions.map((reaction) => (
-                            <Tooltip key={reaction.label} label={reaction.label} side="top">
-                              <button
-                                type="button"
-                                onClick={(e) => { e.stopPropagation(); onLike(e as unknown as React.MouseEvent); }}
-                                className="flex h-8 w-8 items-center justify-center rounded-lg text-base transition-transform hover:scale-110 hover:bg-white/10"
-                                aria-label={reaction.label}
-                              >
-                                <span aria-hidden="true">{reaction.emoji}</span>
-                              </button>
-                            </Tooltip>
-                          ))}
-                        </div>
-                      )}
+                {quickActionsEnabled ? (
+                  <div className="flex shrink-0 items-center gap-1">
+                    {onLike && (
+                      <div className="relative group/reactions">
+                        {hasReactionPalette && (
+                          <div className="pointer-events-none absolute right-0 bottom-full mb-2 flex translate-y-1 rounded-xl border border-[var(--theme-border-subtle)] bg-[var(--theme-bg-elevated)] p-1 opacity-0 shadow-lg shadow-black/30 transition-all group-hover/reactions:pointer-events-auto group-hover/reactions:translate-y-0 group-hover/reactions:opacity-100 group-focus-within/reactions:pointer-events-auto group-focus-within/reactions:translate-y-0 group-focus-within/reactions:opacity-100">
+                            {reactions.map((reaction) => (
+                              <Tooltip key={reaction.label} label={reaction.label} side="top">
+                                <button
+                                  type="button"
+                                  onClick={(e) => { e.stopPropagation(); onLike(e as unknown as React.MouseEvent); }}
+                                  className="flex h-8 w-8 items-center justify-center rounded-lg text-base transition-transform hover:scale-110 hover:bg-white/10"
+                                  aria-label={reaction.label}
+                                >
+                                  <span aria-hidden="true">{reaction.emoji}</span>
+                                </button>
+                              </Tooltip>
+                            ))}
+                          </div>
+                        )}
 
-                      <Tooltip label={likeLabel} side="top">
+                        <Tooltip label={likeLabel} side="top">
+                          <button
+                            onClick={(e) => { e.stopPropagation(); onLike(e); }}
+                            aria-label={likeLabel}
+                            className={`flex items-center gap-1 rounded-lg px-2 py-1 text-xs transition-colors ${
+                              likeStatus !== "none" ? "opacity-100" : "opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"
+                            } ${
+                              likeStatus === "synced"
+                                ? "text-red-400"
+                                : likeStatus === "noted"
+                                ? "text-amber-400"
+                                : likeStatus === "failed"
+                                ? "text-orange-400"
+                                : "text-[var(--theme-text-soft)] hover:text-red-400"
+                            }`}
+                          >
+                            <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill={likeStatus !== "none" ? "currentColor" : "none"} stroke="currentColor" strokeWidth={2}>
+                              <path strokeLinecap="round" strokeLinejoin="round" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
+                            </svg>
+                            {showEngagement && likeCount !== null && <span>{likeCount}</span>}
+                            {likeStatus === "noted" && (
+                              <svg className="w-2.5 h-2.5 animate-spin opacity-70" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5}>
+                                <path strokeLinecap="round" strokeLinejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                              </svg>
+                            )}
+                            {likeStatus === "failed" && (
+                              <svg className="w-2.5 h-2.5 opacity-70" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5}>
+                                <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                              </svg>
+                            )}
+                          </button>
+                        </Tooltip>
+                      </div>
+                    )}
+
+                    {onOpenCommentUrl && item.sourceUrl && (
+                      <Tooltip label={`Comment on ${PLATFORM_LABELS[item.platform] ?? item.platform}`} side="top">
                         <button
-                          onClick={(e) => { e.stopPropagation(); onLike(e); }}
-                          aria-label={likeLabel}
-                          className={`flex items-center gap-1 rounded-lg px-2 py-1 text-xs transition-colors ${
-                            likeStatus !== "none" ? "opacity-100" : "opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"
-                          } ${
-                            likeStatus === "synced"
-                              ? "text-red-400"
-                              : likeStatus === "noted"
-                              ? "text-amber-400"
-                              : likeStatus === "failed"
-                              ? "text-orange-400"
-                              : "text-[var(--theme-text-soft)] hover:text-red-400"
-                          }`}
+                          onClick={(e) => { e.stopPropagation(); onOpenCommentUrl(item.sourceUrl!); }}
+                          aria-label={`Comment on ${PLATFORM_LABELS[item.platform] ?? item.platform}`}
+                          className="flex items-center gap-1 rounded-lg px-2 py-1 text-xs text-[var(--theme-text-soft)] hover:text-[var(--theme-text-secondary)] transition-colors opacity-0 group-hover:opacity-100"
                         >
-                          <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill={likeStatus !== "none" ? "currentColor" : "none"} stroke="currentColor" strokeWidth={2}>
-                            <path strokeLinecap="round" strokeLinejoin="round" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
+                          <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
                           </svg>
-                          {showEngagement && likeCount !== null && <span>{likeCount}</span>}
-                          {likeStatus === "noted" && (
-                            <svg className="w-2.5 h-2.5 animate-spin opacity-70" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5}>
-                              <path strokeLinecap="round" strokeLinejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-                            </svg>
-                          )}
-                          {likeStatus === "failed" && (
-                            <svg className="w-2.5 h-2.5 opacity-70" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5}>
-                              <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
-                            </svg>
-                          )}
+                          {showEngagement && commentCount !== null && <span>{commentCount}</span>}
                         </button>
                       </Tooltip>
-                    </div>
-                  )}
+                    )}
 
-                  {onOpenCommentUrl && item.sourceUrl && (
-                    <Tooltip label={`Comment on ${PLATFORM_LABELS[item.platform] ?? item.platform}`} side="top">
-                      <button
-                        onClick={(e) => { e.stopPropagation(); onOpenCommentUrl(item.sourceUrl!); }}
-                        aria-label={`Comment on ${PLATFORM_LABELS[item.platform] ?? item.platform}`}
-                        className="flex items-center gap-1 rounded-lg px-2 py-1 text-xs text-[var(--theme-text-soft)] hover:text-[var(--theme-text-secondary)] transition-colors opacity-0 group-hover:opacity-100"
-                      >
-                        <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
-                          <path strokeLinecap="round" strokeLinejoin="round" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
-                        </svg>
-                        {showEngagement && commentCount !== null && <span>{commentCount}</span>}
-                      </button>
-                    </Tooltip>
-                  )}
+                    {onSave && (
+                      <Tooltip label={item.userState.saved ? "Remove bookmark" : "Bookmark"} side="top">
+                        <button
+                          onClick={onSave}
+                          aria-label={item.userState.saved ? "Remove bookmark" : "Bookmark"}
+                          className={`p-1.5 rounded-lg transition-colors ${
+                            item.userState.saved
+                              ? "text-[var(--theme-accent-secondary)]"
+                              : "text-[var(--theme-text-soft)] hover:text-[var(--theme-accent-secondary)] opacity-0 group-hover:opacity-100"
+                          }`}
+                        >
+                          <svg className="w-4 h-4" fill={item.userState.saved ? "currentColor" : "none"} viewBox="0 0 24 24" stroke="currentColor">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
+                          </svg>
+                        </button>
+                      </Tooltip>
+                    )}
 
-                  {onSave && (
-                    <Tooltip label={item.userState.saved ? "Remove bookmark" : "Bookmark"} side="top">
-                      <button
-                        onClick={onSave}
-                        aria-label={item.userState.saved ? "Remove bookmark" : "Bookmark"}
-                        className={`p-1.5 rounded-lg transition-colors ${
-                          item.userState.saved
-                            ? "text-[var(--theme-accent-secondary)]"
-                            : "text-[var(--theme-text-soft)] hover:text-[var(--theme-accent-secondary)] opacity-0 group-hover:opacity-100"
-                        }`}
-                      >
-                        <svg className="w-4 h-4" fill={item.userState.saved ? "currentColor" : "none"} viewBox="0 0 24 24" stroke="currentColor">
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
-                        </svg>
-                      </button>
-                    </Tooltip>
-                  )}
+                    {onArchive && !item.userState.saved && (
+                      <Tooltip label="Archive" side="top">
+                        <button
+                          onClick={onArchive}
+                          aria-label="Archive"
+                          className="p-1.5 rounded-lg transition-colors text-[var(--theme-text-soft)] hover:text-[rgb(var(--theme-feedback-success-rgb))] opacity-0 group-hover:opacity-100"
+                        >
+                          <TrashIcon className="w-4 h-4" />
+                        </button>
+                      </Tooltip>
+                    )}
 
-                  {onArchive && !item.userState.saved && (
-                    <Tooltip label="Archive" side="top">
-                      <button
-                        onClick={onArchive}
-                        aria-label="Archive"
-                        className="p-1.5 rounded-lg transition-colors text-[var(--theme-text-soft)] hover:text-[rgb(var(--theme-feedback-success-rgb))] opacity-0 group-hover:opacity-100"
-                      >
-                        <TrashIcon className="w-4 h-4" />
-                      </button>
-                    </Tooltip>
-                  )}
-
-                  {onOpenCommentUrl && item.sourceUrl && (
-                    <Tooltip label="Open" side="top">
-                      <button
-                        onClick={(e) => { e.stopPropagation(); onOpenCommentUrl(item.sourceUrl!); }}
-                        aria-label="Open"
-                        className="p-1.5 rounded-lg text-[var(--theme-text-soft)] hover:text-[var(--theme-text-secondary)] transition-colors opacity-0 group-hover:opacity-100"
-                      >
-                        <ExternalLinkIcon className="w-4 h-4" />
-                      </button>
-                    </Tooltip>
-                  )}
-                </div>
+                    {onOpenCommentUrl && item.sourceUrl && (
+                      <Tooltip label="Open" side="top">
+                        <button
+                          onClick={(e) => { e.stopPropagation(); onOpenCommentUrl(item.sourceUrl!); }}
+                          aria-label="Open"
+                          className="p-1.5 rounded-lg text-[var(--theme-text-soft)] hover:text-[var(--theme-text-secondary)] transition-colors opacity-0 group-hover:opacity-100"
+                        >
+                          <ExternalLinkIcon className="w-4 h-4" />
+                        </button>
+                      </Tooltip>
+                    )}
+                  </div>
+                ) : null}
               </div>
 
               {item.content.linkPreview?.title && (
@@ -882,7 +891,7 @@ export const FeedItem = memo(function FeedItem({
         data-feed-item-id={item.globalId}
         data-focused={focused ? "true" : "false"}
         data-feed-card-density={density}
-        className={`feed-card group min-w-0 cursor-pointer active:scale-[0.99] transition-transform ${fullCardDensity.article} ${focused ? "ring-2 ring-[color:rgb(var(--theme-accent-secondary-rgb)/0.6)] ring-inset" : ""} ${readVisualClass}`}
+        className={`feed-card ${quickActionsEnabled ? "group" : ""} min-w-0 cursor-pointer active:scale-[0.99] transition-transform ${fullCardDensity.article} ${focused ? "ring-2 ring-[color:rgb(var(--theme-accent-secondary-rgb)/0.6)] ring-inset" : ""} ${readVisualClass}`}
         style={{
           ...FEED_CARD_LAYOUT_CONTAINMENT_STYLE,
           padding: fullCardDensity.padding,
@@ -923,118 +932,120 @@ export const FeedItem = memo(function FeedItem({
             </div>
           </div>
 
-          <div className="flex items-center gap-1 shrink-0">
-            {onLike && (
-              <div className="relative group/reactions">
-                {hasReactionPalette && (
-                  <div className="pointer-events-none absolute right-0 bottom-full mb-2 flex translate-y-1 rounded-xl border border-[var(--theme-border-subtle)] bg-[var(--theme-bg-elevated)] p-1 opacity-0 shadow-lg shadow-black/30 transition-all group-hover/reactions:pointer-events-auto group-hover/reactions:translate-y-0 group-hover/reactions:opacity-100 group-focus-within/reactions:pointer-events-auto group-focus-within/reactions:translate-y-0 group-focus-within/reactions:opacity-100">
-                    {reactions.map((reaction) => (
-                      <Tooltip key={reaction.label} label={reaction.label} side="top">
-                        <button
-                          type="button"
-                          onClick={(e) => { e.stopPropagation(); onLike(e as unknown as React.MouseEvent); }}
-                          className="flex h-8 w-8 items-center justify-center rounded-lg text-base transition-transform hover:scale-110 hover:bg-white/10"
-                          aria-label={reaction.label}
-                        >
-                          <span aria-hidden="true">{reaction.emoji}</span>
-                        </button>
-                      </Tooltip>
-                    ))}
-                  </div>
-                )}
+          {quickActionsEnabled ? (
+            <div className="flex items-center gap-1 shrink-0">
+              {onLike && (
+                <div className="relative group/reactions">
+                  {hasReactionPalette && (
+                    <div className="pointer-events-none absolute right-0 bottom-full mb-2 flex translate-y-1 rounded-xl border border-[var(--theme-border-subtle)] bg-[var(--theme-bg-elevated)] p-1 opacity-0 shadow-lg shadow-black/30 transition-all group-hover/reactions:pointer-events-auto group-hover/reactions:translate-y-0 group-hover/reactions:opacity-100 group-focus-within/reactions:pointer-events-auto group-focus-within/reactions:translate-y-0 group-focus-within/reactions:opacity-100">
+                      {reactions.map((reaction) => (
+                        <Tooltip key={reaction.label} label={reaction.label} side="top">
+                          <button
+                            type="button"
+                            onClick={(e) => { e.stopPropagation(); onLike(e as unknown as React.MouseEvent); }}
+                            className="flex h-8 w-8 items-center justify-center rounded-lg text-base transition-transform hover:scale-110 hover:bg-white/10"
+                            aria-label={reaction.label}
+                          >
+                            <span aria-hidden="true">{reaction.emoji}</span>
+                          </button>
+                        </Tooltip>
+                      ))}
+                    </div>
+                  )}
 
-                <Tooltip label={likeLabel} side="top">
+                  <Tooltip label={likeLabel} side="top">
+                    <button
+                      onClick={(e) => { e.stopPropagation(); onLike(e); }}
+                      aria-label={likeLabel}
+                      className={`flex items-center gap-1 rounded-lg px-2 py-1 text-xs transition-colors ${
+                        likeStatus !== "none" ? "opacity-100" : "opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"
+                      } ${
+                        likeStatus === "synced"
+                          ? "text-red-400"
+                          : likeStatus === "noted"
+                          ? "text-amber-400"
+                          : likeStatus === "failed"
+                          ? "text-orange-400"
+                          : "text-[var(--theme-text-soft)] hover:text-red-400"
+                      }`}
+                    >
+                      <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill={likeStatus !== "none" ? "currentColor" : "none"} stroke="currentColor" strokeWidth={2}>
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
+                      </svg>
+                      {showEngagement && likeCount !== null && <span>{likeCount}</span>}
+                      {likeStatus === "noted" && (
+                        <svg className="w-2.5 h-2.5 animate-spin opacity-70" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5}>
+                          <path strokeLinecap="round" strokeLinejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                        </svg>
+                      )}
+                      {likeStatus === "failed" && (
+                        <svg className="w-2.5 h-2.5 opacity-70" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5}>
+                          <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                        </svg>
+                      )}
+                    </button>
+                  </Tooltip>
+                </div>
+              )}
+
+              {onOpenCommentUrl && item.sourceUrl && (
+                <Tooltip label={`Comment on ${PLATFORM_LABELS[item.platform] ?? item.platform}`} side="top">
                   <button
-                    onClick={(e) => { e.stopPropagation(); onLike(e); }}
-                    aria-label={likeLabel}
-                    className={`flex items-center gap-1 rounded-lg px-2 py-1 text-xs transition-colors ${
-                      likeStatus !== "none" ? "opacity-100" : "opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"
-                    } ${
-                      likeStatus === "synced"
-                        ? "text-red-400"
-                        : likeStatus === "noted"
-                        ? "text-amber-400"
-                        : likeStatus === "failed"
-                        ? "text-orange-400"
-                        : "text-[var(--theme-text-soft)] hover:text-red-400"
-                    }`}
+                    onClick={(e) => { e.stopPropagation(); onOpenCommentUrl(item.sourceUrl!); }}
+                    aria-label={`Comment on ${PLATFORM_LABELS[item.platform] ?? item.platform}`}
+                    className="flex items-center gap-1 rounded-lg px-2 py-1 text-xs text-[var(--theme-text-soft)] hover:text-[var(--theme-text-secondary)] transition-colors opacity-0 group-hover:opacity-100"
                   >
-                    <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill={likeStatus !== "none" ? "currentColor" : "none"} stroke="currentColor" strokeWidth={2}>
-                      <path strokeLinecap="round" strokeLinejoin="round" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
+                    <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
                     </svg>
-                    {showEngagement && likeCount !== null && <span>{likeCount}</span>}
-                    {likeStatus === "noted" && (
-                      <svg className="w-2.5 h-2.5 animate-spin opacity-70" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5}>
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-                      </svg>
-                    )}
-                    {likeStatus === "failed" && (
-                      <svg className="w-2.5 h-2.5 opacity-70" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5}>
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
-                      </svg>
-                    )}
+                    {showEngagement && commentCount !== null && <span>{commentCount}</span>}
                   </button>
                 </Tooltip>
-              </div>
-            )}
+              )}
 
-            {onOpenCommentUrl && item.sourceUrl && (
-              <Tooltip label={`Comment on ${PLATFORM_LABELS[item.platform] ?? item.platform}`} side="top">
-                <button
-                  onClick={(e) => { e.stopPropagation(); onOpenCommentUrl(item.sourceUrl!); }}
-                  aria-label={`Comment on ${PLATFORM_LABELS[item.platform] ?? item.platform}`}
-                  className="flex items-center gap-1 rounded-lg px-2 py-1 text-xs text-[var(--theme-text-soft)] hover:text-[var(--theme-text-secondary)] transition-colors opacity-0 group-hover:opacity-100"
-                >
-                  <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
-                  </svg>
-                  {showEngagement && commentCount !== null && <span>{commentCount}</span>}
-                </button>
-              </Tooltip>
-            )}
+              {onSave && (
+                <Tooltip label={item.userState.saved ? "Remove bookmark" : "Bookmark"} side="top">
+                  <button
+                    onClick={onSave}
+                    aria-label={item.userState.saved ? "Remove bookmark" : "Bookmark"}
+                    className={`p-1.5 rounded-lg transition-colors ${
+                      item.userState.saved
+                        ? "text-[var(--theme-accent-secondary)]"
+                        : "text-[var(--theme-text-soft)] hover:text-[var(--theme-accent-secondary)] opacity-0 group-hover:opacity-100"
+                    }`}
+                  >
+                    <svg className="w-4 h-4" fill={item.userState.saved ? "currentColor" : "none"} viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
+                    </svg>
+                  </button>
+                </Tooltip>
+              )}
 
-            {onSave && (
-              <Tooltip label={item.userState.saved ? "Remove bookmark" : "Bookmark"} side="top">
-                <button
-                  onClick={onSave}
-                  aria-label={item.userState.saved ? "Remove bookmark" : "Bookmark"}
-                  className={`p-1.5 rounded-lg transition-colors ${
-                    item.userState.saved
-                      ? "text-[var(--theme-accent-secondary)]"
-                      : "text-[var(--theme-text-soft)] hover:text-[var(--theme-accent-secondary)] opacity-0 group-hover:opacity-100"
-                  }`}
-                >
-                  <svg className="w-4 h-4" fill={item.userState.saved ? "currentColor" : "none"} viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
-                  </svg>
-                </button>
-              </Tooltip>
-            )}
+              {onArchive && !item.userState.saved && (
+                <Tooltip label="Archive" side="top">
+                  <button
+                    onClick={onArchive}
+                    aria-label="Archive"
+                    className="p-1.5 rounded-lg transition-colors text-[var(--theme-text-soft)] hover:text-[rgb(var(--theme-feedback-success-rgb))] opacity-0 group-hover:opacity-100"
+                  >
+                    <TrashIcon className="w-4 h-4" />
+                  </button>
+                </Tooltip>
+              )}
 
-            {onArchive && !item.userState.saved && (
-              <Tooltip label="Archive" side="top">
-                <button
-                  onClick={onArchive}
-                  aria-label="Archive"
-                  className="p-1.5 rounded-lg transition-colors text-[var(--theme-text-soft)] hover:text-[rgb(var(--theme-feedback-success-rgb))] opacity-0 group-hover:opacity-100"
-                >
-                  <TrashIcon className="w-4 h-4" />
-                </button>
-              </Tooltip>
-            )}
-
-            {onOpenCommentUrl && item.sourceUrl && (
-              <Tooltip label="Open" side="top">
-                <button
-                  onClick={(e) => { e.stopPropagation(); onOpenCommentUrl(item.sourceUrl!); }}
-                  aria-label="Open"
-                  className="p-1.5 rounded-lg text-[var(--theme-text-soft)] hover:text-[var(--theme-text-secondary)] transition-colors opacity-0 group-hover:opacity-100"
-                >
-                  <ExternalLinkIcon className="w-4 h-4" />
-                </button>
-              </Tooltip>
-            )}
-          </div>
+              {onOpenCommentUrl && item.sourceUrl && (
+                <Tooltip label="Open" side="top">
+                  <button
+                    onClick={(e) => { e.stopPropagation(); onOpenCommentUrl(item.sourceUrl!); }}
+                    aria-label="Open"
+                    className="p-1.5 rounded-lg text-[var(--theme-text-soft)] hover:text-[var(--theme-text-secondary)] transition-colors opacity-0 group-hover:opacity-100"
+                  >
+                    <ExternalLinkIcon className="w-4 h-4" />
+                  </button>
+                </Tooltip>
+              )}
+            </div>
+          ) : null}
         </div>
 
         {item.content.linkPreview?.title && (

--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -494,7 +494,9 @@ export function Header({
     showMapTimeControls && !collapseToolbarViewControls;
   const showInlineSocialContentControls =
     showSocialContentControls && !collapseToolbarViewControls;
+  const hideMobileDrawerToolbarActions = mobileSidebarOpen;
   const showCollapsedToolbarFilterMenu =
+    !hideMobileDrawerToolbarActions &&
     !selectedItem &&
     (
       (collapseToolbarViewControls && (
@@ -506,7 +508,9 @@ export function Header({
       ((isMobile || collapseToolbarViewControls) && showFeedSignalFilter)
     );
   const showInlineFeedSignalFilter =
-    showFeedSignalFilter && !showCollapsedToolbarFilterMenu;
+    !hideMobileDrawerToolbarActions &&
+    showFeedSignalFilter &&
+    !showCollapsedToolbarFilterMenu;
   const showInlineSavedSortControl =
     showSavedSortControl && !showCollapsedToolbarFilterMenu;
   const showFeedCardDensityControl =
@@ -993,8 +997,9 @@ export function Header({
     unreadCount,
   ]);
   const showToolbarOverflowMenuButton =
-    toolbarOverflowActions.length > 0 ||
-    showOverflowFeedCardDensityControl;
+    !hideMobileDrawerToolbarActions &&
+    (toolbarOverflowActions.length > 0 ||
+    showOverflowFeedCardDensityControl);
 
   const showReaderLayoutToggle =
     !isMobile &&
@@ -1211,6 +1216,12 @@ export function Header({
     setToolbarOverflowMenuOpen(false);
   }, [showOverflowFeedCardDensityControl, toolbarOverflowActions.length]);
 
+  useEffect(() => {
+    if (!hideMobileDrawerToolbarActions) return;
+    setToolbarOverflowMenuOpen(false);
+    setSignalFilterMenuOpen(false);
+  }, [hideMobileDrawerToolbarActions]);
+
   useLayoutEffect(() => {
     if (isMobileDevice) return undefined;
 
@@ -1400,7 +1411,7 @@ export function Header({
           style={toolbarContainerStyle}
         >
           <div
-            className="theme-toolbar-cluster theme-toolbar-cluster-tight flex shrink-0 items-center"
+            className={`theme-toolbar-cluster theme-toolbar-cluster-tight flex shrink-0 items-center ${isMobileDevice ? "pl-2" : ""}`}
           >
             <div
               ref={layoutControlHostRef}
@@ -1412,7 +1423,7 @@ export function Header({
                   <button
                     onClick={onMobileMenuToggle}
                     {...getToolbarControlProps()}
-                    className={`${TOOLBAR_ICON_BUTTON_CLASS} ${mobileSidebarOpen ? "theme-toolbar-button-neutral" : "theme-toolbar-button-ghost"}`}
+                    className={`${TOOLBAR_ICON_BUTTON_CLASS} theme-toolbar-button-ghost`}
                     aria-label={mobileSidebarOpen ? "Close menu" : "Open menu"}
                     aria-pressed={mobileSidebarOpen}
                   >
@@ -1824,7 +1835,7 @@ export function Header({
                           onClick={toggleSignalFilterMenu}
                           {...getToolbarControlProps()}
                           data-testid="feed-signal-filter-button"
-                          className="theme-toolbar-button-neutral inline-flex h-9 items-center gap-2 rounded-lg px-3 text-sm font-semibold shadow-sm"
+                          className={`${isMobile ? "theme-toolbar-button-ghost shadow-none" : "theme-toolbar-button-neutral shadow-sm"} inline-flex h-9 items-center gap-2 rounded-lg px-3 text-sm font-semibold`}
                           aria-haspopup="menu"
                           aria-expanded={signalFilterMenuOpen}
                           aria-label="Filter feed"

--- a/packages/ui/src/components/layout/SearchJumpField.tsx
+++ b/packages/ui/src/components/layout/SearchJumpField.tsx
@@ -1134,7 +1134,7 @@ export function SearchJumpField({
         style={narrowSidebar && !inputValue ? { paddingRight: 0 } : undefined}
         inputClassName={
           mobileSidebar
-            ? "h-12 rounded-xl pl-10 pr-8 text-base"
+            ? "h-10 rounded-lg pl-10 pr-8 text-base"
             : compactSidebar
             ? "pl-7 pr-6"
             : narrowSidebar

--- a/packages/ui/src/components/layout/Sidebar.tsx
+++ b/packages/ui/src/components/layout/Sidebar.tsx
@@ -54,8 +54,6 @@ const FEEDS_PAGE_SIZE = 10;
 const SOURCE_ACTION_SLOT_WITH_COUNTS_CLASS = "ml-1.5 w-16";
 const RESIZE_HANDLE_HIT_AREA_WIDTH_PX = 16;
 const COMPACT_READER_RAIL_VISUAL_GAP_WIDTH_PX = 8;
-const MOBILE_SIDEBAR_WIDTH_PX = DEFAULT_PRIMARY_SIDEBAR_WIDTH_PX + 50;
-const MOBILE_SIDEBAR_VIEWPORT_MARGIN_PX = 24;
 const MOBILE_MENU_TOP_PX = COMPACT_PRIMARY_SIDEBAR_WIDTH_PX + PRIMARY_SIDEBAR_GAP_WIDTH_PX / 2;
 
 function MoreIcon() {
@@ -772,7 +770,7 @@ export function Sidebar({
   const expandedSidebarUsesCondensedPadding =
     renderMode === "expanded" && desktopWidth < EXPANDED_SIDEBAR_PADDING_CROSSOVER_WIDTH_PX;
   const sidebarPaddingInlinePx = isMobileDevice
-    ? 12
+    ? 8
     : compactRail
     ? COMPACT_RAIL_OUTER_INSET_PX
     : expandedSidebarUsesCondensedPadding
@@ -844,8 +842,7 @@ export function Sidebar({
   const rowVerticalPaddingClass = isMobileDevice ? "py-2" : "py-1.5";
   const feedRowVerticalPaddingClass = "py-2";
   const countTextClass = isMobileDevice ? "text-xs" : "text-[10px]";
-  const mobileSidebarWidth = `min(${MOBILE_SIDEBAR_WIDTH_PX}px, calc(100vw - ${MOBILE_SIDEBAR_VIEWPORT_MARGIN_PX}px))`;
-  const inlineSearchGapPx = sidebarPaddingBlockPx;
+  const inlineSearchGapPx = isMobileDevice ? sidebarPaddingBlockPx + 8 : sidebarPaddingBlockPx;
   const desktopShellTransition = animationIntensity === "none" || (dragWidth !== null && !snapPreviewActive)
     ? "none"
     : snapPreviewActive
@@ -1866,7 +1863,8 @@ export function Sidebar({
           ${mobileOpen ? "translate-x-0" : "-translate-x-full"}
         `}
         style={{
-          width: mobileSidebarWidth,
+          boxSizing: "border-box",
+          width: "100vw",
           top: `calc(env(safe-area-inset-top, 0px) + ${MOBILE_MENU_TOP_PX}px)`,
           height: `calc(100dvh - env(safe-area-inset-top, 0px) - ${MOBILE_MENU_TOP_PX}px)`,
           maxHeight: `calc(100dvh - env(safe-area-inset-top, 0px) - ${MOBILE_MENU_TOP_PX}px)`,
@@ -1879,7 +1877,7 @@ export function Sidebar({
           style={{
             paddingInline: `${sidebarPaddingInlinePx}px`,
             paddingTop: "4px",
-            paddingBottom: "env(safe-area-inset-bottom, 0px)",
+            paddingBottom: `calc(env(safe-area-inset-bottom, 0px) + ${sidebarPaddingBlockPx}px)`,
           }}
         >
           <div className={`flex w-full items-center rounded-lg text-base text-[color:var(--theme-text-secondary)] hover:bg-[color:var(--theme-bg-muted)] hover:text-[color:var(--theme-text-primary)] transition-all`}>
@@ -1887,7 +1885,7 @@ export function Sidebar({
               type="button"
               data-testid="mobile-sidebar-settings-button"
               onClick={handleOpenSettingsFromMobileSidebar}
-              className={`flex min-w-0 flex-1 cursor-pointer items-center gap-2 ${rowPaddingClass} ${rowVerticalPaddingClass} text-left`}
+              className={`flex min-h-11 min-w-0 flex-1 cursor-pointer items-center gap-2 ${rowPaddingClass} ${rowVerticalPaddingClass} text-left`}
             >
               {settingsButtonContent}
             </button>

--- a/packages/ui/src/hooks/useHasTouchOnlyPointer.ts
+++ b/packages/ui/src/hooks/useHasTouchOnlyPointer.ts
@@ -1,0 +1,37 @@
+import { useEffect, useState } from "react";
+
+function detectTouchOnlyPointer(): boolean {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+    return false;
+  }
+
+  const coarsePointerMedia = window.matchMedia("(pointer: coarse)");
+  const hoverCapableMedia = window.matchMedia("(any-hover: hover)");
+  return coarsePointerMedia.matches && !hoverCapableMedia.matches;
+}
+
+export function useHasTouchOnlyPointer(): boolean {
+  const [hasTouchOnlyPointer, setHasTouchOnlyPointer] = useState(detectTouchOnlyPointer);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return;
+    }
+
+    const coarsePointerMedia = window.matchMedia("(pointer: coarse)");
+    const hoverCapableMedia = window.matchMedia("(any-hover: hover)");
+    const updatePointerMode = () => {
+      setHasTouchOnlyPointer(coarsePointerMedia.matches && !hoverCapableMedia.matches);
+    };
+
+    updatePointerMode();
+    coarsePointerMedia.addEventListener?.("change", updatePointerMode);
+    hoverCapableMedia.addEventListener?.("change", updatePointerMode);
+    return () => {
+      coarsePointerMedia.removeEventListener?.("change", updatePointerMode);
+      hoverCapableMedia.removeEventListener?.("change", updatePointerMode);
+    };
+  }, []);
+
+  return hasTouchOnlyPointer;
+}

--- a/packages/ui/src/hooks/useIsMobile.ts
+++ b/packages/ui/src/hooks/useIsMobile.ts
@@ -6,7 +6,12 @@ export function useIsMobile(): boolean {
     () => typeof window !== "undefined" && window.innerWidth < 768,
   );
   useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return;
+    }
+
     const mq = window.matchMedia("(max-width: 767px)");
+    setIsMobile(mq.matches);
     const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
     mq.addEventListener("change", handler);
     return () => mq.removeEventListener("change", handler);

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -1472,13 +1472,15 @@ html[data-theme="scriptorium"] .feed-card {
     0 8px 18px rgb(84 58 35 / 0.03);
 }
 
-.feed-card:hover {
-  background: color-mix(in oklab, var(--theme-bg-surface) 94%, transparent);
-  border-color: color-mix(
-    in oklab,
-    var(--theme-border-strong) 68%,
-    var(--theme-border-subtle)
-  );
+@media (hover: hover) and (pointer: fine) {
+  .feed-card:hover {
+    background: color-mix(in oklab, var(--theme-bg-surface) 94%, transparent);
+    border-color: color-mix(
+      in oklab,
+      var(--theme-border-strong) 68%,
+      var(--theme-border-subtle)
+    );
+  }
 }
 
 @media (prefers-reduced-motion: no-preference) {
@@ -1566,13 +1568,20 @@ html[data-theme="scriptorium"] .theme-floating-panel {
   background: var(--theme-attached-topbar-background);
 }
 
+html.freed-mobile-sidebar-open .theme-attached-topbar {
+  border-bottom-color: transparent;
+}
+
+html.freed-mobile-sidebar-open [data-testid="toolbar-overflow-button"],
+html.freed-mobile-sidebar-open [data-testid="feed-signal-filter-button"],
+html.freed-mobile-sidebar-open [data-testid="mobile-toolbar-filter-button"] {
+  display: none;
+}
+
 .theme-mobile-sidebar {
   background: var(--theme-attached-topbar-background);
   border-right: 1px solid var(--theme-header-border);
-  box-shadow: 28px 0 80px rgb(0 0 0 / 0.34);
-}
-
-.theme-mobile-sidebar[data-open="false"] {
+  border-top: 0;
   box-shadow: none;
 }
 
@@ -1650,10 +1659,12 @@ html.freed-mobile-sidebar-open body {
     border-color 0.18s ease;
 }
 
-.theme-toolbar-button-neutral:hover {
-  color: var(--theme-text-secondary);
-  background: var(--theme-bg-muted);
-  border-color: var(--theme-border-subtle);
+@media (hover: hover) and (pointer: fine) {
+  .theme-toolbar-button-neutral:hover {
+    color: var(--theme-text-secondary);
+    background: var(--theme-bg-muted);
+    border-color: var(--theme-border-subtle);
+  }
 }
 
 .theme-toolbar-button-ghost {
@@ -1667,10 +1678,12 @@ html.freed-mobile-sidebar-open body {
     border-color 0.18s ease;
 }
 
-.theme-toolbar-button-ghost:hover {
-  color: var(--theme-text-secondary);
-  background: var(--theme-bg-muted);
-  border-color: var(--theme-border-subtle);
+@media (hover: hover) and (pointer: fine) {
+  .theme-toolbar-button-ghost:hover {
+    color: var(--theme-text-secondary);
+    background: var(--theme-bg-muted);
+    border-color: var(--theme-border-subtle);
+  }
 }
 
 .theme-toolbar-button-active {
@@ -1686,9 +1699,11 @@ html.freed-mobile-sidebar-open body {
     box-shadow 0.18s ease;
 }
 
-.theme-toolbar-button-active:hover {
-  background: rgb(var(--theme-accent-secondary-rgb) / 0.2);
-  border-color: rgb(var(--theme-accent-secondary-rgb) / 0.82);
+@media (hover: hover) and (pointer: fine) {
+  .theme-toolbar-button-active:hover {
+    background: rgb(var(--theme-accent-secondary-rgb) / 0.2);
+    border-color: rgb(var(--theme-accent-secondary-rgb) / 0.82);
+  }
 }
 
 .theme-toolbar-button-success-active {
@@ -1702,9 +1717,34 @@ html.freed-mobile-sidebar-open body {
     border-color 0.18s ease;
 }
 
-.theme-toolbar-button-success-active:hover {
-  background: rgb(var(--theme-feedback-success-rgb) / 0.18);
-  border-color: rgb(var(--theme-feedback-success-rgb) / 0.72);
+@media (hover: hover) and (pointer: fine) {
+  .theme-toolbar-button-success-active:hover {
+    background: rgb(var(--theme-feedback-success-rgb) / 0.18);
+    border-color: rgb(var(--theme-feedback-success-rgb) / 0.72);
+  }
+}
+
+@media (hover: none) and (pointer: coarse) {
+  .theme-attached-topbar .theme-toolbar-button-neutral,
+  .theme-attached-topbar .theme-toolbar-button-ghost,
+  .theme-attached-topbar .theme-toolbar-button-active,
+  .theme-attached-topbar .theme-toolbar-button-success-active {
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  .theme-attached-topbar .theme-toolbar-button-neutral:focus-visible,
+  .theme-attached-topbar .theme-toolbar-button-ghost:focus-visible,
+  .theme-attached-topbar .theme-toolbar-button-active:focus-visible,
+  .theme-attached-topbar .theme-toolbar-button-success-active:focus-visible,
+  .theme-attached-topbar .theme-toolbar-button-neutral:active,
+  .theme-attached-topbar .theme-toolbar-button-ghost:active,
+  .theme-attached-topbar .theme-toolbar-button-active:active,
+  .theme-attached-topbar .theme-toolbar-button-success-active:active {
+    outline: none;
+    background: transparent;
+    border-color: transparent;
+    box-shadow: none;
+  }
 }
 
 .theme-toolbar-icon-button {


### PR DESCRIPTION
(AI Generated).

## Summary
- Polish mobile sidebar and settings menu spacing, headings, breadcrumbs, and toolbar touch states.
- Disable feed card hover quick actions on touch mobile devices so a single tap opens cards.

## Testing
- npm run validate:feature