### PR TITLE
fix: preserve release note rollup validation

### DIFF
--- a/release-notes/releases/v26.6.801.json
+++ b/release-notes/releases/v26.6.801.json
@@ -33,9 +33,14 @@
     ]
   },
   "release": {
-    "deck": "Mobile navigation now feels calmer on touch screens, with cleaner settings menus and single-tap story cards.",
+    "deck": "Phone Google Drive sync is safer, and mobile navigation now feels calmer on touch screens.",
     "features": [],
     "fixes": [
+      "Phone Google Drive sync now keeps populated cloud feed history when stale local delete history would otherwise merge the phone down to zero items.",
+      "The mobile app now pauses Google Drive polling after a destructive merge block instead of retrying the same blocked merge in the background.",
+      "The Google Drive card now shows a short merge-blocked sentence while the full recovery details stay in Sync diagnostics.",
+      "The empty feed state now shows a spinner while cloud sync is actively running and links blocked sync states directly to Sync settings.",
+      "Populate sample data remains stable on the phone with the latest Automerge document state.",
       "Mobile top toolbar buttons no longer flash focus or active borders after touch taps.",
       "The mobile navigation drawer now opens full width with aligned spacing, no shadow, and hidden action controls while open.",
       "Mobile settings now uses a Freed Settings breadcrumb with compact caret separators, stable close-button placement, and mobile-only taller search sizing.",
@@ -43,5 +48,5 @@
     ],
     "followUps": []
   },
-  "releaseBody": "(AI Generated).\n\n## Freed v26.6.801\n\nMobile navigation now feels calmer on touch screens, with cleaner settings menus and single-tap story cards.\n\n### Fixes\n\n- Mobile top toolbar buttons no longer flash focus or active borders after touch taps.\n- The mobile navigation drawer now opens full width with aligned spacing, no shadow, and hidden action controls while open.\n- Mobile settings now uses a Freed Settings breadcrumb with compact caret separators, stable close-button placement, and mobile-only taller search sizing.\n- Touch devices now open feed and story cards on the first tap by removing hover-only quick actions from mobile cards.\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+  "releaseBody": "(AI Generated).\n\n## Freed v26.6.801\n\nPhone Google Drive sync is safer, and mobile navigation now feels calmer on touch screens.\n\n### Fixes\n\n- Phone Google Drive sync now keeps populated cloud feed history when stale local delete history would otherwise merge the phone down to zero items.\n- The mobile app now pauses Google Drive polling after a destructive merge block instead of retrying the same blocked merge in the background.\n- The Google Drive card now shows a short merge-blocked sentence while the full recovery details stay in Sync diagnostics.\n- The empty feed state now shows a spinner while cloud sync is actively running and links blocked sync states directly to Sync settings.\n- Populate sample data remains stable on the phone with the latest Automerge document state.\n- Mobile top toolbar buttons no longer flash focus or active borders after touch taps.\n- The mobile navigation drawer now opens full width with aligned spacing, no shadow, and hidden action controls while open.\n- Mobile settings now uses a Freed Settings breadcrumb with compact caret separators, stable close-button placement, and mobile-only taller search sizing.\n- Touch devices now open feed and story cards on the first tap by removing hover-only quick actions from mobile cards.\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
 }


### PR DESCRIPTION
(AI Generated).

## Summary
- preserve the v26.6.800 same-day highlights inside the failed v26.6.801 artifact
- keep all checked-in production release artifacts valid before cutting the next production tag

## Validation
- `node scripts/validate-release-notes.mjs release-notes/releases/v26.6.801.json release-notes/releases/v26.6.800.json`
- `node scripts/validate-release-notes.mjs release-notes/releases/v26.6.802.json release-notes/releases/v26.6.801.json release-notes/releases/v26.6.800.json`
- aggregate release artifact loop over `release-notes/releases/*.json`
