### PR TITLE
fix: stabilize PWA Drive merge import

### DIFF
--- a/packages/pwa/src/lib/automerge-worker-debug.ts
+++ b/packages/pwa/src/lib/automerge-worker-debug.ts
@@ -1,0 +1,38 @@
+const WORKER_DEBUG_STORAGE_KEY = "freed:pwa:automerge-worker-debug:v1";
+const MAX_PERSISTED_WORKER_DEBUG_EVENTS = 30;
+
+export interface PersistedWorkerDebugEvent {
+  ts: number;
+  kind: string;
+  detail?: string;
+  bytes?: number;
+}
+
+export function getPersistedWorkerDebugEvents(): PersistedWorkerDebugEvent[] {
+  try {
+    const raw = window.localStorage.getItem(WORKER_DEBUG_STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((entry): entry is PersistedWorkerDebugEvent => (
+      typeof entry === "object" &&
+      entry !== null &&
+      typeof entry.ts === "number" &&
+      typeof entry.kind === "string"
+    ));
+  } catch {
+    return [];
+  }
+}
+
+export function persistWorkerDebugEvent(event: Omit<PersistedWorkerDebugEvent, "ts">): void {
+  try {
+    const nextEvents = [
+      { ...event, ts: Date.now() },
+      ...getPersistedWorkerDebugEvents(),
+    ].slice(0, MAX_PERSISTED_WORKER_DEBUG_EVENTS);
+    window.localStorage.setItem(WORKER_DEBUG_STORAGE_KEY, JSON.stringify(nextEvents));
+  } catch {
+    // Diagnostics should never affect sync behavior.
+  }
+}

--- a/packages/pwa/src/lib/automerge.ts
+++ b/packages/pwa/src/lib/automerge.ts
@@ -22,6 +22,7 @@ import type {
   UserPreferences,
 } from "@freed/shared";
 import type { DocState, WorkerRequest, WorkerResponse } from "./automerge-types";
+import { persistWorkerDebugEvent } from "./automerge-worker-debug";
 export type { DocState } from "./automerge-types";
 
 // ---------------------------------------------------------------------------
@@ -130,6 +131,7 @@ worker.onmessage = (event: MessageEvent<WorkerResponse>) => {
 
   if (msg.type === "DEBUG_EVENT") {
     addDebugEvent(msg.kind as Parameters<typeof addDebugEvent>[0], msg.detail, msg.bytes);
+    persistWorkerDebugEvent({ kind: msg.kind, detail: msg.detail, bytes: msg.bytes });
     return;
   }
 

--- a/packages/pwa/src/lib/automerge.worker.ts
+++ b/packages/pwa/src/lib/automerge.worker.ts
@@ -16,6 +16,7 @@ import { hashSavedUrl } from "@freed/capture-save/normalize";
 import type { FreedDoc } from "@freed/shared/schema";
 import {
   assertNonDestructiveMerge,
+  choosePopulatedInputForFeedEmptyPreMerge,
   choosePopulatedInputForEmptyMerge,
   createEmptyDoc,
   addAccount,
@@ -83,6 +84,10 @@ function send(msg: WorkerResponse): void {
 
 function ack(reqId: number, error?: string): void {
   send({ reqId, type: "ACK", error });
+}
+
+function sendSyncBreadcrumb(detail: string, bytes?: number): void {
+  send({ type: "DEBUG_EVENT", kind: "merge_ok", detail: `[sync-worker] ${detail}`, bytes });
 }
 
 function toLegacyContact(account: Account): LegacyDeviceContact {
@@ -262,11 +267,15 @@ function hydrateFromDoc(doc: FreedDoc): DocState {
  * Persist the doc to IndexedDB and broadcast the hydrated state + binary to
  * the main thread. Called after every mutation.
  */
-async function saveAndBroadcast(): Promise<void> {
+async function saveAndBroadcast(syncBreadcrumbLabel?: string): Promise<void> {
   if (!currentDoc) return;
+  if (syncBreadcrumbLabel) sendSyncBreadcrumb(`${syncBreadcrumbLabel}: saving binary`);
   const binary = A.save(currentDoc);
+  if (syncBreadcrumbLabel) sendSyncBreadcrumb(`${syncBreadcrumbLabel}: writing IndexedDB`, binary.byteLength);
   await storage.save(binary);
+  if (syncBreadcrumbLabel) sendSyncBreadcrumb(`${syncBreadcrumbLabel}: hydrating state`, binary.byteLength);
   const state = hydrateFromDoc(currentDoc);
+  if (syncBreadcrumbLabel) sendSyncBreadcrumb(`${syncBreadcrumbLabel}: posting state`, binary.byteLength);
 
   const snapshot: Extract<WorkerResponse, { type: "DEBUG_SNAPSHOT" }> = {
     type: "DEBUG_SNAPSHOT",
@@ -648,15 +657,44 @@ async function handleRequest(req: WorkerRequest): Promise<void> {
       case "MERGE_DOC": {
         if (!currentDoc) throw new Error("Document not initialized");
         const beforeCount = Object.keys(currentDoc.feedItems ?? {}).length;
+        sendSyncBreadcrumb(
+          `loading remote document, local feed items: ${beforeCount.toLocaleString()}`,
+          req.binary.byteLength,
+        );
         const incomingDoc = A.load<FreedDoc>(req.binary);
-        const mergedDoc = A.merge(currentDoc, incomingDoc);
-        const populatedSide = choosePopulatedInputForEmptyMerge(currentDoc, incomingDoc, mergedDoc);
-        const resolvedDoc =
-          populatedSide === "local" ? currentDoc : populatedSide === "incoming" ? incomingDoc : mergedDoc;
+        const incomingCount = Object.keys(incomingDoc.feedItems ?? {}).length;
+        sendSyncBreadcrumb(
+          `loaded remote document, remote feed items: ${incomingCount.toLocaleString()}`,
+          req.binary.byteLength,
+        );
+        const preMergePopulatedSide = choosePopulatedInputForFeedEmptyPreMerge(currentDoc, incomingDoc);
+        if (!preMergePopulatedSide) {
+          sendSyncBreadcrumb("running Automerge merge", req.binary.byteLength);
+        }
+        const mergedDoc = preMergePopulatedSide ? null : A.merge(currentDoc, incomingDoc);
+        const populatedSide = preMergePopulatedSide ?? (
+          mergedDoc ? choosePopulatedInputForEmptyMerge(currentDoc, incomingDoc, mergedDoc) : null
+        );
+        const resolvedDoc = populatedSide === "local"
+          ? currentDoc
+          : populatedSide === "incoming"
+            ? incomingDoc
+            : mergedDoc;
+        if (!resolvedDoc) throw new Error("PWA sync merge did not produce a document");
         const guard = assertNonDestructiveMerge(currentDoc, incomingDoc, resolvedDoc, {
           source: "PWA sync",
         });
-        currentDoc = populatedSide ? A.clone(resolvedDoc) : resolvedDoc;
+        if (preMergePopulatedSide) {
+          sendSyncBreadcrumb(
+            `skipped Automerge merge and adopted ${preMergePopulatedSide} feed library`,
+            req.binary.byteLength,
+          );
+        }
+        currentDoc = preMergePopulatedSide
+          ? resolvedDoc
+          : populatedSide
+            ? A.clone(resolvedDoc)
+            : resolvedDoc;
         migrateLoadedIdentityGraph("Migrate legacy identity graph");
         const afterCount = Object.keys(currentDoc.feedItems ?? {}).length;
         const delta = afterCount - beforeCount;
@@ -683,7 +721,8 @@ async function handleRequest(req: WorkerRequest): Promise<void> {
           });
         }
         bumpSearchCorpusVersion();
-        await saveAndBroadcast();
+        await saveAndBroadcast("merge");
+        sendSyncBreadcrumb("merge broadcast complete", req.binary.byteLength);
         ack(req.reqId);
         break;
       }

--- a/packages/pwa/src/lib/bug-report.test.ts
+++ b/packages/pwa/src/lib/bug-report.test.ts
@@ -7,6 +7,7 @@ import { useAppStore } from "./store";
 
 describe("pwa bug reporting", () => {
   beforeEach(() => {
+    window.localStorage.clear();
     resetBugReportState();
     useDebugStore.setState({ events: [], visible: false, docSnapshot: null, cloudProviders: null, perfSnapshot: null, perfResetGeneration: 0 });
     useAppStore.setState({
@@ -28,6 +29,39 @@ describe("pwa bug reporting", () => {
       fatal: true,
       error: new Error("PWA crash with token=super-secret"),
     });
+  });
+
+  it("includes persisted worker debug breadcrumbs in private bundles", async () => {
+    window.localStorage.setItem(
+      "freed:pwa:automerge-worker-debug:v1",
+      JSON.stringify([
+        {
+          ts: 1_783_000_000_000,
+          kind: "merge_ok",
+          detail: "[sync-worker] merge: hydrating state access_token=secret-value",
+          bytes: 1234,
+        },
+      ]),
+    );
+
+    const bundle = await pwaBugReporting.generateBundle({
+      privacyTier: "private",
+      draft: {
+        issueType: "crash",
+        title: "PWA crash",
+        description: "It crashed",
+        reproSteps: "Connect Google Drive",
+        expectedBehavior: "No crash",
+        actualBehavior: "Crash",
+        selectedArtifacts: ["diagnostic-events"],
+      },
+    });
+
+    const zip = await JSZip.loadAsync(bundle.blob);
+    const workerDebug = await zip.file("diagnostics/worker-debug-events.json")?.async("string");
+
+    expect(workerDebug).toContain("[sync-worker] merge: hydrating state");
+    expect(workerDebug).not.toContain("secret-value");
   });
 
   it("filters private artifacts out of public-safe bundles", async () => {

--- a/packages/pwa/src/lib/bug-report.ts
+++ b/packages/pwa/src/lib/bug-report.ts
@@ -19,6 +19,7 @@ import {
 import type { BugReportingConfig } from "@freed/ui/context";
 import { getCloudProvider } from "./sync";
 import { useAppStore } from "./store";
+import { getPersistedWorkerDebugEvents } from "./automerge-worker-debug";
 
 const GITHUB_REPO = "freed-project/freed";
 const SUPPORT_EMAIL = "support@freed.wtf";
@@ -80,6 +81,14 @@ async function buildPwaBundle(input: {
       bytes: event.bytes,
       ts: event.ts,
     }));
+  const workerDebugEvents = getPersistedWorkerDebugEvents()
+    .slice(0, input.privacyTier === "private" ? 30 : 15)
+    .map((event) => ({
+      kind: event.kind,
+      detail: event.detail ? redactSensitiveText(event.detail) : undefined,
+      bytes: event.bytes,
+      ts: event.ts,
+    }));
   const stateSummary = createStateSummary();
   const manifest = buildBugReportManifest({
     appName: APP_NAME,
@@ -113,6 +122,7 @@ async function buildPwaBundle(input: {
   if (includedArtifacts.includes("diagnostic-events")) {
     diagnostics.reportEvents = reportEvents;
     diagnostics.debugEvents = debugEvents;
+    diagnostics.workerDebugEvents = workerDebugEvents;
   }
   if (includedArtifacts.includes("crash-context")) {
     diagnostics.fatalError = fatalError;
@@ -131,6 +141,7 @@ async function buildPwaBundle(input: {
   if (includedArtifacts.includes("diagnostic-events")) {
     addJson(zip, "diagnostics/report-events.json", reportEvents);
     addJson(zip, "diagnostics/debug-events.json", debugEvents);
+    addJson(zip, "diagnostics/worker-debug-events.json", workerDebugEvents);
   }
   if (includedArtifacts.includes("state-summary")) {
     addJson(zip, "diagnostics/state-summary.json", stateSummary);

--- a/packages/pwa/src/lib/schema.test.ts
+++ b/packages/pwa/src/lib/schema.test.ts
@@ -26,6 +26,7 @@ import {
   addRssFeed,
   assertNonDestructiveMerge,
   choosePopulatedInputForEmptyMerge,
+  choosePopulatedInputForFeedEmptyPreMerge,
   evaluateDestructiveMergeGuard,
   removeRssFeed,
   updateAccount,
@@ -955,6 +956,7 @@ describe("Automerge merge / sync simulation", () => {
 
     const merged = A.merge(staleEmpty, populated);
     expect(Object.keys(merged.feedItems)).toHaveLength(0);
+    expect(choosePopulatedInputForFeedEmptyPreMerge(staleEmpty, populated)).toBe("incoming");
     expect(choosePopulatedInputForEmptyMerge(staleEmpty, populated, merged)).toBe("incoming");
 
     expect(() =>
@@ -985,11 +987,26 @@ describe("Automerge merge / sync simulation", () => {
     const merged = A.merge(staleFeedEmpty, populated);
     expect(Object.keys(merged.feedItems)).toHaveLength(0);
     expect(Object.keys(merged.rssFeeds).length).toBeGreaterThan(0);
+    expect(choosePopulatedInputForFeedEmptyPreMerge(staleFeedEmpty, populated)).toBe("incoming");
     expect(choosePopulatedInputForEmptyMerge(staleFeedEmpty, populated, merged)).toBe("incoming");
 
     expect(() =>
       assertNonDestructiveMerge(staleFeedEmpty, populated, populated, { source: "test sync" }),
     ).not.toThrow();
+  });
+
+  it("does not bypass Automerge when both peers have feed items", () => {
+    let local = createEmptyDoc();
+    local = A.change(local, (d) => {
+      addFeedItem(d, makeItem({ globalId: "local-item" }));
+    });
+
+    let incoming = createEmptyDoc();
+    incoming = A.change(incoming, (d) => {
+      addFeedItem(d, makeItem({ globalId: "incoming-item" }));
+    });
+
+    expect(choosePopulatedInputForFeedEmptyPreMerge(local, incoming)).toBeNull();
   });
 
   it("serializes and deserializes without data loss", () => {

--- a/packages/shared/src/schema.ts
+++ b/packages/shared/src/schema.ts
@@ -2056,6 +2056,22 @@ function countDocumentLibraryEntries(doc: FreedDoc): number {
 export type PopulatedEmptyMergeInput = "local" | "incoming";
 
 /**
+ * Skip Automerge's expensive merge when one feed library is empty and the
+ * other side already has feed history. This is intentionally feed-scoped:
+ * normal populated peers still go through CRDT merge semantics.
+ */
+export function choosePopulatedInputForFeedEmptyPreMerge(
+  localDoc: FreedDoc,
+  incomingDoc: FreedDoc,
+): PopulatedEmptyMergeInput | null {
+  const localItemCount = countFeedItems(localDoc);
+  const incomingItemCount = countFeedItems(incomingDoc);
+  if (localItemCount === 0 && incomingItemCount > 0) return "incoming";
+  if (incomingItemCount === 0 && localItemCount > 0) return "local";
+  return null;
+}
+
+/**
  * When an empty first-sync document carries stale delete history, Automerge can
  * merge a populated peer down to an empty result. In that exact case, keep the
  * populated side instead of treating an empty library as a destructive winner.


### PR DESCRIPTION
(AI Generated). 

## Summary
- Skip the expensive PWA Automerge merge when the local feed is empty and the Google Drive document already has feed history.
- Keep normal bidirectional Automerge merge behavior when both peers have feed items.
- Persist recent Automerge worker breadcrumbs into localStorage so a PWA crash reload can still include the last sync phase in diagnostics.

## Validation
- PASS: PATH=/Users/aubreyfalconer/dev/freed-pwa-mobile-merge-diagnostics/node_modules/.bin:$PATH npm run test:unit -- src/lib/schema.test.ts src/lib/bug-report.test.ts, from packages/pwa
- PASS: PATH=/Users/aubreyfalconer/dev/freed-pwa-mobile-merge-diagnostics/node_modules/.bin:$PATH npm run build, from packages/pwa
- PASS: PATH=/Users/aubreyfalconer/dev/freed-pwa-mobile-merge-diagnostics/node_modules/.bin:$PATH npm run test:unit -- src/lib/identity-graph-v2.test.ts, from packages/pwa
- PASS: PATH=/Users/aubreyfalconer/dev/freed-pwa-mobile-merge-diagnostics/node_modules/.bin:$PATH npm run test:unit -- src/lib/gdrive-sync.test.ts src/lib/social-capture-memory-pressure.test.ts, from packages/desktop
- PASS: PATH=/Users/aubreyfalconer/dev/freed-pwa-mobile-merge-diagnostics/node_modules/.bin:$PATH npm run test:e2e:smoke, from packages/desktop
- PASS: desktop perf feed focused rerun for 1k cold load, 1,167 ms
- PASS: desktop perf graph, friends focused rerun, sidebar, and settings

## Notes
- Full validate:feature reached PWA unit tests twice and failed only the existing identity graph benchmark under full-suite contention. Focused reruns passed at 1,079 ms and 1,989 ms.
- Desktop full unit run was contended with smoke e2e and timed out two unrelated tests. Focused rerun of those specs passed, 30 tests.
- Desktop perf Map View currently fails p95 frame budget independently of this PWA sync change. It failed twice with stable marker counts and no relation to touched code.