### PR TITLE
fix: harden PWA sync hydration

### DIFF
--- a/packages/pwa/src/lib/automerge.worker.ts
+++ b/packages/pwa/src/lib/automerge.worker.ts
@@ -73,6 +73,7 @@ const storage = new IndexedDBStorage();
 let currentDoc: FreedDoc | null = null;
 let searchCorpusVersion = 0;
 let requestChain: Promise<void> = Promise.resolve();
+const HYDRATED_FEED_ITEM_LIMIT = 2_500;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -184,12 +185,13 @@ function feedItemUpdatesAffectSearchCorpus(updates: Partial<FeedItem>): boolean 
 }
 
 /**
- * Convert the Automerge proxy document to a plain-JS DocState for postMessage.
- * A.toJS() converts CRDT proxies to regular objects, safe for structured clone.
+ * Convert the Automerge document to a DocState for postMessage.
+ * A.view() creates a cheap immutable read view at the current heads. That avoids
+ * the extra eager root clone from A.toJS(), which is expensive on iOS during a
+ * large first cloud import.
  */
 function hydrateFromDoc(doc: FreedDoc): DocState {
-  // A.toJS must receive the document root, not a sub-property.
-  const plain = A.toJS(doc) as FreedDoc;
+  const plain = A.view(doc, A.getHeads(doc)) as FreedDoc;
   const plainItems = Object.values(plain.feedItems as Record<string, FeedItem>);
   const feeds = plain.rssFeeds as Record<string, RssFeed>;
   const persons = (plain.persons ?? {}) as Record<string, Person>;
@@ -205,6 +207,9 @@ function hydrateFromDoc(doc: FreedDoc): DocState {
       { persons, accounts },
     ),
   );
+  const hydratedItems = rankedItems.length > HYDRATED_FEED_ITEM_LIMIT
+    ? rankedItems.slice(0, HYDRATED_FEED_ITEM_LIMIT)
+    : rankedItems;
 
   const feedUnreadCounts: Record<string, number> = {};
   const feedTotalCounts: Record<string, number> = {};
@@ -242,7 +247,7 @@ function hydrateFromDoc(doc: FreedDoc): DocState {
   }
 
   return {
-    items: rankedItems,
+    items: hydratedItems,
     searchCorpusVersion,
     feeds,
     persons,
@@ -267,10 +272,10 @@ function hydrateFromDoc(doc: FreedDoc): DocState {
  * Persist the doc to IndexedDB and broadcast the hydrated state + binary to
  * the main thread. Called after every mutation.
  */
-async function saveAndBroadcast(syncBreadcrumbLabel?: string): Promise<void> {
+async function saveAndBroadcast(syncBreadcrumbLabel?: string, knownBinary?: Uint8Array): Promise<void> {
   if (!currentDoc) return;
   if (syncBreadcrumbLabel) sendSyncBreadcrumb(`${syncBreadcrumbLabel}: saving binary`);
-  const binary = A.save(currentDoc);
+  const binary = knownBinary ?? A.save(currentDoc);
   if (syncBreadcrumbLabel) sendSyncBreadcrumb(`${syncBreadcrumbLabel}: writing IndexedDB`, binary.byteLength);
   await storage.save(binary);
   if (syncBreadcrumbLabel) sendSyncBreadcrumb(`${syncBreadcrumbLabel}: hydrating state`, binary.byteLength);
@@ -285,6 +290,17 @@ async function saveAndBroadcast(syncBreadcrumbLabel?: string): Promise<void> {
     binarySize: binary.byteLength,
   };
   send(snapshot);
+
+  if (state.items.length < state.totalItemCount) {
+    send({
+      type: "DEBUG_EVENT",
+      kind: "change",
+      detail:
+        `[pwa] hydrated ${state.items.length.toLocaleString()} of ` +
+        `${state.totalItemCount.toLocaleString()} visible items for mobile memory safety`,
+      bytes: binary.byteLength,
+    });
+  }
 
   const stateUpdate: WorkerResponse = { type: "STATE_UPDATE", state };
   send(stateUpdate);
@@ -695,6 +711,8 @@ async function handleRequest(req: WorkerRequest): Promise<void> {
           : populatedSide
             ? A.clone(resolvedDoc)
             : resolvedDoc;
+        const adoptedIncomingWithoutMigration =
+          preMergePopulatedSide === "incoming" && !hasLegacyIdentityGraphData(resolvedDoc);
         migrateLoadedIdentityGraph("Migrate legacy identity graph");
         const afterCount = Object.keys(currentDoc.feedItems ?? {}).length;
         const delta = afterCount - beforeCount;
@@ -721,7 +739,7 @@ async function handleRequest(req: WorkerRequest): Promise<void> {
           });
         }
         bumpSearchCorpusVersion();
-        await saveAndBroadcast("merge");
+        await saveAndBroadcast("merge", adoptedIncomingWithoutMigration ? req.binary : undefined);
         sendSyncBreadcrumb("merge broadcast complete", req.binary.byteLength);
         ack(req.reqId);
         break;

--- a/packages/pwa/src/lib/schema.test.ts
+++ b/packages/pwa/src/lib/schema.test.ts
@@ -1009,6 +1009,36 @@ describe("Automerge merge / sync simulation", () => {
     expect(choosePopulatedInputForFeedEmptyPreMerge(local, incoming)).toBeNull();
   });
 
+  it("creates structured-cloneable Automerge views for large PWA hydration", () => {
+    let doc = createEmptyDoc();
+    doc = A.change(doc, (d) => {
+      addRssFeed(d, makeFeed({ url: "https://example.com/feed.xml", title: "Example" }));
+      for (let i = 0; i < 1_500; i += 1) {
+        addFeedItem(d, makeItem({
+          globalId: `cloud-item-${i}`,
+          publishedAt: 10_000 - i,
+          content: {
+            text: `Cloud item ${i}`,
+            mediaUrls: [],
+            mediaTypes: [],
+          },
+        }));
+      }
+    });
+
+    const view = A.view(doc, A.getHeads(doc)) as FreedDoc;
+    const cloned = structuredClone({
+      items: Object.values(view.feedItems),
+      feeds: view.rssFeeds,
+      persons: view.persons,
+      accounts: view.accounts,
+    });
+
+    expect(cloned.items).toHaveLength(1_500);
+    expect(cloned.items[0]).toMatchObject({ globalId: "cloud-item-0" });
+    expect(Object.keys(cloned.feeds)).toEqual(["https://example.com/feed.xml"]);
+  });
+
   it("serializes and deserializes without data loss", () => {
     let doc = createEmptyDoc();
     doc = A.change(doc, (d) => {

--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -401,6 +401,9 @@ export function Header({
 
   const items = useAppStore((s) => s.items);
   const feeds = useAppStore((s) => s.feeds);
+  const feedTotalCounts = useAppStore((s) => s.feedTotalCounts);
+  const totalItemCount = useAppStore((s) => s.totalItemCount);
+  const itemCountByPlatform = useAppStore((s) => s.itemCountByPlatform);
   const persons = useAppStore((s) => s.persons);
   const accounts = useAppStore((s) => s.accounts);
   const friends = useAppStore((s) => s.friends);
@@ -554,6 +557,38 @@ export function Header({
     return scopeLabel;
   }, [activeView, scopeLabel]);
 
+  const fullScopeItemCount = useMemo(() => {
+    if (
+      activeFilter.authorId ||
+      activeFilter.savedOnly ||
+      activeFilter.archivedOnly ||
+      activeFilter.socialContentFilter ||
+      (activeFilter.tags?.length ?? 0) > 0 ||
+      (activeFilter.signals?.length ?? 0) > 0
+    ) {
+      return null;
+    }
+    if (activeFilter.feedUrl) {
+      return feedTotalCounts[activeFilter.feedUrl] ?? null;
+    }
+    if (activeFilter.platform) {
+      return itemCountByPlatform[activeFilter.platform] ?? null;
+    }
+    return totalItemCount;
+  }, [
+    activeFilter.archivedOnly,
+    activeFilter.authorId,
+    activeFilter.feedUrl,
+    activeFilter.platform,
+    activeFilter.savedOnly,
+    activeFilter.signals,
+    activeFilter.socialContentFilter,
+    activeFilter.tags,
+    feedTotalCounts,
+    itemCountByPlatform,
+    totalItemCount,
+  ]);
+
   const currentListSubtitle = useMemo(() => {
     if (activeView === "friends") {
       if (pendingMatchCount > 0) {
@@ -576,12 +611,13 @@ export function Header({
     if (isSearching) {
       return `${resultCount.toLocaleString()} result${resultCount === 1 ? "" : "s"} in ${scopeLabel}`;
     }
-    return formatItemCount(filteredItems.length);
+    return formatItemCount(fullScopeItemCount ?? filteredItems.length);
   }, [
     activeView,
     effectiveFriendsMode,
     filteredItems.length,
     friendCount,
+    fullScopeItemCount,
     effectiveMapMode,
     isSearching,
     mappedAllContentCount,


### PR DESCRIPTION
(AI Generated).

## Summary
- Reduce mobile memory pressure after large Google Drive imports by avoiding an eager Automerge root clone, reusing adopted Drive binaries when safe, and bounding the PWA feed state broadcast while preserving full synced counts.

## Testing
- npm run validate:feature