### PR TITLE
chore: refresh changelog for v26.6.804

### DIFF
--- a/release-notes/daily/production/26.6.8.json
+++ b/release-notes/daily/production/26.6.8.json
@@ -2,13 +2,16 @@
   "channel": "production",
   "dayKey": "26.6.8",
   "date": "2026-06-08",
-  "preferredDeck": "Phone Google Drive sync is safer, and mobile navigation now feels calmer on touch screens.",
+  "preferredDeck": "This build reduces phone import memory pressure and carries the latest same-day production fixes.",
   "editorialGuidance": [
     "Keep the tone concise, professional, and specific.",
     "Lead with user-facing outcomes, shipping milestones, trust wins, and installability improvements.",
     "Demote internal cleanup unless it clearly changes the shipped product."
   ],
   "pinnedHighlights": [
+    "Phone Google Drive sync now avoids an eager Automerge root clone while hydrating large cloud libraries.",
+    "The mobile app now renders a bounded feed window after large imports while keeping the full synced document and item counts intact.",
+    "First-sync imports can reuse a trusted incoming Drive binary when no migration is needed, reducing extra save work during merge recovery.",
     "Phone Google Drive sync now keeps populated cloud feed history when stale local delete history would otherwise merge the phone down to zero items.",
     "The mobile app now pauses Google Drive polling after a destructive merge block instead of retrying the same blocked merge in the background.",
     "The empty feed state now shows a spinner while cloud sync is actively running and links blocked sync states directly to Sync settings.",
@@ -17,5 +20,5 @@
     "Fullscreen reader windows keep their native title drag area."
   ],
   "editorialNotes": [],
-  "updatedAt": "2026-06-08T20:10:17.768Z"
+  "updatedAt": "2026-06-09T00:10:40.302Z"
 }

--- a/release-notes/releases/v26.6.804.json
+++ b/release-notes/releases/v26.6.804.json
@@ -1,0 +1,70 @@
+{
+  "tag": "v26.6.804",
+  "version": "26.6.804",
+  "channel": "production",
+  "dayKey": "26.6.8",
+  "approved": true,
+  "editorialNotes": [],
+  "generatedAt": "2026-06-09T00:10:40.299Z",
+  "model": "heuristic",
+  "source": {
+    "channel": "production",
+    "previousPublishedTag": "v26.6.803",
+    "previousPublishedDayTag": "v26.6.604",
+    "compareRef": "HEAD",
+    "isLatestOfDay": true,
+    "sameDayTagsIncluded": [
+      "v26.6.800",
+      "v26.6.803",
+      "v26.6.804"
+    ],
+    "relatedBuildTags": [
+      "v26.6.800",
+      "v26.6.803",
+      "v26.6.804"
+    ],
+    "prNumbers": [
+      798,
+      800,
+      814
+    ],
+    "commitSubjects": [
+      "chore: promote dev into main for production release (#814)",
+      "release: approve v26.6.803 notes",
+      "release: v26.6.803",
+      "chore: promote dev into main for production release",
+      "chore: promote dev into main for production release",
+      "fix: preserve release note rollup validation",
+      "release: approve v26.6.802 notes",
+      "release: v26.6.802",
+      "fix: restore fullscreen reader drag region",
+      "release: approve v26.6.801 notes",
+      "release: v26.6.801",
+      "chore: promote dev into main for production release (#800)",
+      "release: approve v26.6.800 notes",
+      "release: v26.6.800",
+      "chore: promote dev into main for PWA sync recovery (#798)"
+    ]
+  },
+  "release": {
+    "deck": "This build reduces phone import memory pressure and carries the latest same-day production fixes.",
+    "features": [],
+    "fixes": [
+      "Phone Google Drive sync now avoids an eager Automerge root clone while hydrating large cloud libraries.",
+      "The mobile app now renders a bounded feed window after large imports while keeping the full synced document and item counts intact.",
+      "First-sync imports can reuse a trusted incoming Drive binary when no migration is needed, reducing extra save work during merge recovery.",
+      "Phone Google Drive sync now keeps populated cloud feed history when stale local delete history would otherwise merge the phone down to zero items.",
+      "The mobile app now pauses Google Drive polling after a destructive merge block instead of retrying the same blocked merge in the background.",
+      "The Google Drive card now shows a short merge-blocked sentence while the full recovery details stay in Sync diagnostics.",
+      "The empty feed state now shows a spinner while cloud sync is actively running and links blocked sync states directly to Sync settings.",
+      "Populate sample data remains stable on the phone with the latest Automerge document state.",
+      "Mobile top toolbar buttons no longer flash focus or active borders after touch taps.",
+      "The mobile navigation drawer now opens full width with aligned spacing, no shadow, and hidden action controls while open.",
+      "Mobile settings now uses a Freed Settings breadcrumb with compact caret separators, stable close-button placement, and mobile-only taller search sizing.",
+      "Touch devices now open feed and story cards on the first tap by removing hover-only quick actions from mobile cards.",
+      "Fullscreen reader windows now expose the title as a direct native drag region again, restoring production release validation."
+    ],
+    "followUps": []
+  },
+  "releaseBody": "(AI Generated).\n\n## Freed v26.6.804\n\nThis build reduces phone import memory pressure and carries the latest same-day production fixes.\n\n### Fixes\n\n- Phone Google Drive sync now avoids an eager Automerge root clone while hydrating large cloud libraries.\n- The mobile app now renders a bounded feed window after large imports while keeping the full synced document and item counts intact.\n- First-sync imports can reuse a trusted incoming Drive binary when no migration is needed, reducing extra save work during merge recovery.\n- Phone Google Drive sync now keeps populated cloud feed history when stale local delete history would otherwise merge the phone down to zero items.\n- The mobile app now pauses Google Drive polling after a destructive merge block instead of retrying the same blocked merge in the background.\n- The Google Drive card now shows a short merge-blocked sentence while the full recovery details stay in Sync diagnostics.\n- The empty feed state now shows a spinner while cloud sync is actively running and links blocked sync states directly to Sync settings.\n- Populate sample data remains stable on the phone with the latest Automerge document state.\n- Mobile top toolbar buttons no longer flash focus or active borders after touch taps.\n- The mobile navigation drawer now opens full width with aligned spacing, no shadow, and hidden action controls while open.\n- Mobile settings now uses a Freed Settings breadcrumb with compact caret separators, stable close-button placement, and mobile-only taller search sizing.\n- Touch devices now open feed and story cards on the first tap by removing hover-only quick actions from mobile cards.\n- Fullscreen reader windows now expose the title as a direct native drag region again, restoring production release validation.\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+}

--- a/release-notes/releases/v26.6.804.md
+++ b/release-notes/releases/v26.6.804.md
@@ -1,0 +1,29 @@
+(AI Generated).
+
+## Freed v26.6.804
+
+This build reduces phone import memory pressure and carries the latest same-day production fixes.
+
+### Fixes
+
+- Phone Google Drive sync now avoids an eager Automerge root clone while hydrating large cloud libraries.
+- The mobile app now renders a bounded feed window after large imports while keeping the full synced document and item counts intact.
+- First-sync imports can reuse a trusted incoming Drive binary when no migration is needed, reducing extra save work during merge recovery.
+- Phone Google Drive sync now keeps populated cloud feed history when stale local delete history would otherwise merge the phone down to zero items.
+- The mobile app now pauses Google Drive polling after a destructive merge block instead of retrying the same blocked merge in the background.
+- The Google Drive card now shows a short merge-blocked sentence while the full recovery details stay in Sync diagnostics.
+- The empty feed state now shows a spinner while cloud sync is actively running and links blocked sync states directly to Sync settings.
+- Populate sample data remains stable on the phone with the latest Automerge document state.
+- Mobile top toolbar buttons no longer flash focus or active borders after touch taps.
+- The mobile navigation drawer now opens full width with aligned spacing, no shadow, and hidden action controls while open.
+- Mobile settings now uses a Freed Settings breadcrumb with compact caret separators, stable close-button placement, and mobile-only taller search sizing.
+- Touch devices now open feed and story cards on the first tap by removing hover-only quick actions from mobile cards.
+- Fullscreen reader windows now expose the title as a direct native drag region again, restoring production release validation.
+
+### Downloads
+
+**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  
+**Windows:** `.exe` (NSIS installer)  
+**Linux:** `.AppImage`  
+
+> macOS downloads are signed and notarized for normal Gatekeeper installation.

--- a/website/public/atom.xml
+++ b/website/public/atom.xml
@@ -2,7 +2,7 @@
 <feed xmlns="http://www.w3.org/2005/Atom">
     <id>https://freed.wtf</id>
     <title>Freed Blog</title>
-    <updated>2026-06-08T23:24:48.888Z</updated>
+    <updated>2026-06-09T01:01:41.939Z</updated>
     <generator>https://github.com/jpmonette/feed</generator>
     <author>
         <name>The Freed Team</name>

--- a/website/public/feed.xml
+++ b/website/public/feed.xml
@@ -4,7 +4,7 @@
         <title>Freed Blog</title>
         <link>https://freed.wtf</link>
         <description>Progress reports, technical deep-dives, and philosophical rants about the attention economy. From the team building Freed.</description>
-        <lastBuildDate>Mon, 08 Jun 2026 23:24:48 GMT</lastBuildDate>
+        <lastBuildDate>Tue, 09 Jun 2026 01:01:41 GMT</lastBuildDate>
         <docs>https://validator.w3.org/feed/docs/rss2.html</docs>
         <generator>https://github.com/jpmonette/feed</generator>
         <language>en</language>

--- a/website/src/content/changelog.generated.json
+++ b/website/src/content/changelog.generated.json
@@ -1,12 +1,21 @@
 [
   {
-    "version": "26.6.803",
-    "tagName": "v26.6.803",
+    "version": "26.6.804",
+    "tagName": "v26.6.804",
     "channel": "production",
-    "date": "2026-06-08T20:48:54Z",
-    "deck": "Phone Google Drive sync is safer, mobile navigation is calmer on touch screens, and fullscreen reader windows keep their native drag area.",
+    "date": "2026-06-09T00:56:44Z",
+    "deck": "This build reduces phone import memory pressure and carries the latest same-day production fixes.",
     "features": [],
     "fixes": [
+      {
+        "text": "Phone Google Drive sync now avoids an eager Automerge root clone while hydrating large cloud libraries."
+      },
+      {
+        "text": "The mobile app now renders a bounded feed window after large imports while keeping the full synced document and item counts intact."
+      },
+      {
+        "text": "First-sync imports can reuse a trusted incoming Drive binary when no migration is needed, reducing extra save work during merge recovery."
+      },
       {
         "text": "Phone Google Drive sync now keeps populated cloud feed history when stale local delete history would otherwise merge the phone down to zero items."
       },
@@ -39,14 +48,16 @@
       }
     ],
     "followUps": [],
-    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.803",
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.804",
     "prNumbers": [
       798,
-      800
+      800,
+      814
     ],
     "builds": [
       "26.6.800",
-      "26.6.803"
+      "26.6.803",
+      "26.6.804"
     ],
     "buildLinks": [
       {
@@ -57,6 +68,11 @@
       {
         "version": "26.6.803",
         "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.803",
+        "channel": "production"
+      },
+      {
+        "version": "26.6.804",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.804",
         "channel": "production"
       }
     ]


### PR DESCRIPTION
(AI Generated).

## Summary
- Add reviewed v26.6.804 release notes to the www branch
- Refresh the static changelog snapshot and feeds so the production website can deploy the new release

## Validation
- npm run build in website