### PR TITLE
chore: refresh changelog for v26.6.805

### DIFF
--- a/release-notes/daily/production/26.6.8.json
+++ b/release-notes/daily/production/26.6.8.json
@@ -20,5 +20,5 @@
     "Fullscreen reader windows keep their native title drag area."
   ],
   "editorialNotes": [],
-  "updatedAt": "2026-06-09T00:10:40.302Z"
+  "updatedAt": "2026-06-09T01:24:53.067Z"
 }

--- a/release-notes/releases/v26.6.805.json
+++ b/release-notes/releases/v26.6.805.json
@@ -1,0 +1,80 @@
+{
+  "tag": "v26.6.805",
+  "version": "26.6.805",
+  "channel": "production",
+  "dayKey": "26.6.8",
+  "approved": true,
+  "editorialNotes": [],
+  "generatedAt": "2026-06-09T01:24:53.064Z",
+  "model": "heuristic",
+  "source": {
+    "channel": "production",
+    "previousPublishedTag": "v26.6.804",
+    "previousPublishedDayTag": "v26.6.604",
+    "compareRef": "HEAD",
+    "isLatestOfDay": true,
+    "sameDayTagsIncluded": [
+      "v26.6.800",
+      "v26.6.803",
+      "v26.6.804",
+      "v26.6.805"
+    ],
+    "relatedBuildTags": [
+      "v26.6.800",
+      "v26.6.803",
+      "v26.6.804",
+      "v26.6.805"
+    ],
+    "prNumbers": [
+      798,
+      800,
+      814,
+      816
+    ],
+    "commitSubjects": [
+      "chore: promote dev into main for production release (#816)",
+      "release: approve v26.6.804 notes",
+      "release: v26.6.804",
+      "chore: promote dev into main for production release (#814)",
+      "release: approve v26.6.803 notes",
+      "release: v26.6.803",
+      "chore: promote dev into main for production release",
+      "chore: promote dev into main for production release",
+      "fix: preserve release note rollup validation",
+      "release: approve v26.6.802 notes",
+      "release: v26.6.802",
+      "fix: restore fullscreen reader drag region",
+      "release: approve v26.6.801 notes",
+      "release: v26.6.801",
+      "chore: promote dev into main for production release (#800)",
+      "release: approve v26.6.800 notes",
+      "release: v26.6.800",
+      "chore: promote dev into main for PWA sync recovery (#798)"
+    ]
+  },
+  "release": {
+    "deck": "This build tightens phone Google Drive imports and polishes story grid alignment.",
+    "features": [],
+    "fixes": [
+      "Preserve release note rollup validation",
+      "Fullscreen reader drag region restored",
+      "Phone Google Drive sync now keeps populated cloud feed history when stale local delete history would otherwise merge the phone down to zero items",
+      "The mobile app now pauses Google Drive polling after a destructive merge block instead of retrying the same blocked merge in the background",
+      "The Google Drive card now shows a short merge-blocked sentence while the full recovery details stay in Sync diagnostics",
+      "The empty feed state now shows a spinner while cloud sync is actively running and links blocked sync states directly to Sync settings",
+      "Populate sample data remains stable on the phone with the latest Automerge document state",
+      "Mobile top toolbar buttons no longer flash focus or active borders after touch taps",
+      "The mobile navigation drawer now opens full width with aligned spacing, no shadow, and hidden action controls while open",
+      "Mobile settings now uses a Freed Settings breadcrumb with compact caret separators, stable close-button placement, and mobile-only taller search sizing",
+      "Touch devices now open feed and story cards on the first tap by removing hover-only quick actions from mobile cards",
+      "Phone Google Drive sync now avoids an eager Automerge root clone while hydrating large cloud libraries",
+      "The mobile app now renders a bounded feed window after large imports while keeping the full synced document and item counts intact",
+      "First-sync imports can reuse a trusted incoming Drive binary when no migration is needed, reducing extra save work during merge recovery",
+      "Story rows now line up with the sidebar panel edge, removing the one-pixel top offset in the story grid."
+    ],
+    "followUps": [
+      "Phone Google Drive sync now imports populated cloud libraries without reload loops, and blocked sync states are easier to recover from"
+    ]
+  },
+  "releaseBody": "(AI Generated).\n\n## Freed v26.6.805\n\nThis build tightens phone Google Drive imports and polishes story grid alignment.\n\n### Fixes\n\n- Preserve release note rollup validation\n- Fullscreen reader drag region restored\n- Phone Google Drive sync now keeps populated cloud feed history when stale local delete history would otherwise merge the phone down to zero items\n- The mobile app now pauses Google Drive polling after a destructive merge block instead of retrying the same blocked merge in the background\n- The Google Drive card now shows a short merge-blocked sentence while the full recovery details stay in Sync diagnostics\n- The empty feed state now shows a spinner while cloud sync is actively running and links blocked sync states directly to Sync settings\n- Populate sample data remains stable on the phone with the latest Automerge document state\n- Mobile top toolbar buttons no longer flash focus or active borders after touch taps\n- The mobile navigation drawer now opens full width with aligned spacing, no shadow, and hidden action controls while open\n- Mobile settings now uses a Freed Settings breadcrumb with compact caret separators, stable close-button placement, and mobile-only taller search sizing\n- Touch devices now open feed and story cards on the first tap by removing hover-only quick actions from mobile cards\n- Phone Google Drive sync now avoids an eager Automerge root clone while hydrating large cloud libraries\n- The mobile app now renders a bounded feed window after large imports while keeping the full synced document and item counts intact\n- First-sync imports can reuse a trusted incoming Drive binary when no migration is needed, reducing extra save work during merge recovery\n- Story rows now line up with the sidebar panel edge, removing the one-pixel top offset in the story grid.\n\n### Follow-ups\n\n- Phone Google Drive sync now imports populated cloud libraries without reload loops, and blocked sync states are easier to recover from\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+}

--- a/release-notes/releases/v26.6.805.md
+++ b/release-notes/releases/v26.6.805.md
@@ -1,0 +1,35 @@
+(AI Generated).
+
+## Freed v26.6.805
+
+This build tightens phone Google Drive imports and polishes story grid alignment.
+
+### Fixes
+
+- Preserve release note rollup validation
+- Fullscreen reader drag region restored
+- Phone Google Drive sync now keeps populated cloud feed history when stale local delete history would otherwise merge the phone down to zero items
+- The mobile app now pauses Google Drive polling after a destructive merge block instead of retrying the same blocked merge in the background
+- The Google Drive card now shows a short merge-blocked sentence while the full recovery details stay in Sync diagnostics
+- The empty feed state now shows a spinner while cloud sync is actively running and links blocked sync states directly to Sync settings
+- Populate sample data remains stable on the phone with the latest Automerge document state
+- Mobile top toolbar buttons no longer flash focus or active borders after touch taps
+- The mobile navigation drawer now opens full width with aligned spacing, no shadow, and hidden action controls while open
+- Mobile settings now uses a Freed Settings breadcrumb with compact caret separators, stable close-button placement, and mobile-only taller search sizing
+- Touch devices now open feed and story cards on the first tap by removing hover-only quick actions from mobile cards
+- Phone Google Drive sync now avoids an eager Automerge root clone while hydrating large cloud libraries
+- The mobile app now renders a bounded feed window after large imports while keeping the full synced document and item counts intact
+- First-sync imports can reuse a trusted incoming Drive binary when no migration is needed, reducing extra save work during merge recovery
+- Story rows now line up with the sidebar panel edge, removing the one-pixel top offset in the story grid.
+
+### Follow-ups
+
+- Phone Google Drive sync now imports populated cloud libraries without reload loops, and blocked sync states are easier to recover from
+
+### Downloads
+
+**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  
+**Windows:** `.exe` (NSIS installer)  
+**Linux:** `.AppImage`  
+
+> macOS downloads are signed and notarized for normal Gatekeeper installation.

--- a/website/public/atom.xml
+++ b/website/public/atom.xml
@@ -2,7 +2,7 @@
 <feed xmlns="http://www.w3.org/2005/Atom">
     <id>https://freed.wtf</id>
     <title>Freed Blog</title>
-    <updated>2026-06-09T01:01:41.939Z</updated>
+    <updated>2026-06-09T02:10:56.247Z</updated>
     <generator>https://github.com/jpmonette/feed</generator>
     <author>
         <name>The Freed Team</name>

--- a/website/public/feed.xml
+++ b/website/public/feed.xml
@@ -4,7 +4,7 @@
         <title>Freed Blog</title>
         <link>https://freed.wtf</link>
         <description>Progress reports, technical deep-dives, and philosophical rants about the attention economy. From the team building Freed.</description>
-        <lastBuildDate>Tue, 09 Jun 2026 01:01:41 GMT</lastBuildDate>
+        <lastBuildDate>Tue, 09 Jun 2026 02:10:56 GMT</lastBuildDate>
         <docs>https://validator.w3.org/feed/docs/rss2.html</docs>
         <generator>https://github.com/jpmonette/feed</generator>
         <language>en</language>

--- a/website/src/content/changelog.generated.json
+++ b/website/src/content/changelog.generated.json
@@ -1,63 +1,75 @@
 [
   {
-    "version": "26.6.804",
-    "tagName": "v26.6.804",
+    "version": "26.6.805",
+    "tagName": "v26.6.805",
     "channel": "production",
-    "date": "2026-06-09T00:56:44Z",
-    "deck": "This build reduces phone import memory pressure and carries the latest same-day production fixes.",
+    "date": "2026-06-09T02:05:25Z",
+    "deck": "This build tightens phone Google Drive imports and polishes story grid alignment.",
     "features": [],
     "fixes": [
       {
-        "text": "Phone Google Drive sync now avoids an eager Automerge root clone while hydrating large cloud libraries."
+        "text": "Preserve release note rollup validation"
       },
       {
-        "text": "The mobile app now renders a bounded feed window after large imports while keeping the full synced document and item counts intact."
+        "text": "Fullscreen reader drag region restored"
       },
       {
-        "text": "First-sync imports can reuse a trusted incoming Drive binary when no migration is needed, reducing extra save work during merge recovery."
+        "text": "Phone Google Drive sync now keeps populated cloud feed history when stale local delete history would otherwise merge the phone down to zero items"
       },
       {
-        "text": "Phone Google Drive sync now keeps populated cloud feed history when stale local delete history would otherwise merge the phone down to zero items."
+        "text": "The mobile app now pauses Google Drive polling after a destructive merge block instead of retrying the same blocked merge in the background"
       },
       {
-        "text": "The mobile app now pauses Google Drive polling after a destructive merge block instead of retrying the same blocked merge in the background."
+        "text": "The Google Drive card now shows a short merge-blocked sentence while the full recovery details stay in Sync diagnostics"
       },
       {
-        "text": "The Google Drive card now shows a short merge-blocked sentence while the full recovery details stay in Sync diagnostics."
+        "text": "The empty feed state now shows a spinner while cloud sync is actively running and links blocked sync states directly to Sync settings"
       },
       {
-        "text": "The empty feed state now shows a spinner while cloud sync is actively running and links blocked sync states directly to Sync settings."
+        "text": "Populate sample data remains stable on the phone with the latest Automerge document state"
       },
       {
-        "text": "Populate sample data remains stable on the phone with the latest Automerge document state."
+        "text": "Mobile top toolbar buttons no longer flash focus or active borders after touch taps"
       },
       {
-        "text": "Mobile top toolbar buttons no longer flash focus or active borders after touch taps."
+        "text": "The mobile navigation drawer now opens full width with aligned spacing, no shadow, and hidden action controls while open"
       },
       {
-        "text": "The mobile navigation drawer now opens full width with aligned spacing, no shadow, and hidden action controls while open."
+        "text": "Mobile settings now uses a Freed Settings breadcrumb with compact caret separators, stable close-button placement, and mobile-only taller search sizing"
       },
       {
-        "text": "Mobile settings now uses a Freed Settings breadcrumb with compact caret separators, stable close-button placement, and mobile-only taller search sizing."
+        "text": "Touch devices now open feed and story cards on the first tap by removing hover-only quick actions from mobile cards"
       },
       {
-        "text": "Touch devices now open feed and story cards on the first tap by removing hover-only quick actions from mobile cards."
+        "text": "Phone Google Drive sync now avoids an eager Automerge root clone while hydrating large cloud libraries"
       },
       {
-        "text": "Fullscreen reader windows now expose the title as a direct native drag region again, restoring production release validation."
+        "text": "The mobile app now renders a bounded feed window after large imports while keeping the full synced document and item counts intact"
+      },
+      {
+        "text": "First-sync imports can reuse a trusted incoming Drive binary when no migration is needed, reducing extra save work during merge recovery"
+      },
+      {
+        "text": "Story rows now line up with the sidebar panel edge, removing the one-pixel top offset in the story grid."
       }
     ],
-    "followUps": [],
-    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.804",
+    "followUps": [
+      {
+        "text": "Phone Google Drive sync now imports populated cloud libraries without reload loops, and blocked sync states are easier to recover from"
+      }
+    ],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.805",
     "prNumbers": [
       798,
       800,
-      814
+      814,
+      816
     ],
     "builds": [
       "26.6.800",
       "26.6.803",
-      "26.6.804"
+      "26.6.804",
+      "26.6.805"
     ],
     "buildLinks": [
       {
@@ -73,6 +85,11 @@
       {
         "version": "26.6.804",
         "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.804",
+        "channel": "production"
+      },
+      {
+        "version": "26.6.805",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.805",
         "channel": "production"
       }
     ]


### PR DESCRIPTION
(AI Generated).

## Summary
- Add reviewed release notes for v26.6.805 to the www branch.
- Regenerate the public changelog snapshot and RSS/Atom feeds.

## Testing
- npx tsx src/content/changelog.test.ts
- PATH=/Users/aubreyfalconer/dev/freed-www-v26-6-805-changelog/node_modules/.bin:$PATH npm run build
- CI