### PR TITLE
fix: show cloud sync elapsed status

### DIFF
--- a/packages/pwa/src/components/PwaFeedEmptyState.test.ts
+++ b/packages/pwa/src/components/PwaFeedEmptyState.test.ts
@@ -36,6 +36,8 @@ function renderWithPlatform(node: ReactNode): { container: HTMLDivElement; root:
 describe("PwaFeedEmptyState", () => {
   beforeEach(() => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-09T12:00:30Z"));
     vi.clearAllMocks();
     useAppStore.setState({
       syncConnected: true,
@@ -50,6 +52,7 @@ describe("PwaFeedEmptyState", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     useAppStore.setState({
       syncConnected: false,
       isSyncing: false,
@@ -105,14 +108,24 @@ describe("PwaFeedEmptyState", () => {
   });
 
   it("shows a spinner while cloud sync is actively downloading", () => {
+    const startedAt = Date.now() - 30_000;
     useDebugStore.setState({
       cloudProviders: {
         dropbox: { status: "idle" },
         gdrive: {
           status: "connecting",
           stage: "download",
+          lastAttemptAt: startedAt,
           statusMessage: "Checking cloud storage for remote changes.",
-          events: [],
+          events: [
+            {
+              id: "download-started",
+              ts: startedAt,
+              kind: "started",
+              stage: "download",
+              message: "Checking cloud storage for remote changes.",
+            },
+          ],
         },
       },
     });
@@ -121,7 +134,14 @@ describe("PwaFeedEmptyState", () => {
 
     expect(container.querySelector("[aria-label='Syncing']")).toBeTruthy();
     expect(container.textContent).toContain("Waiting for content...");
+    expect(container.textContent).toContain("Checking Google Drive for remote changes. Running for 30s.");
     expect(container.textContent).not.toContain("Sync is blocked");
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(container.textContent).toContain("Running for 31s.");
 
     act(() => {
       root.unmount();

--- a/packages/pwa/src/components/PwaFeedEmptyState.tsx
+++ b/packages/pwa/src/components/PwaFeedEmptyState.tsx
@@ -1,6 +1,7 @@
 import { useAppStore } from "../lib/store";
 import { useDebugStore } from "@freed/ui/lib/debug-store";
 import { SampleDataTestingSection } from "@freed/ui/components/SampleDataTestingSection";
+import { useCloudSyncActivity } from "./cloudSyncActivity";
 
 const openSyncSettings = () =>
   window.dispatchEvent(new CustomEvent("freed:open-settings", { detail: { scrollTo: "sync" } }));
@@ -24,7 +25,10 @@ export function PwaFeedEmptyState() {
   const activeFilter = useAppStore((s) => s.activeFilter);
   const feeds = useAppStore((s) => s.feeds);
   const cloudProviders = useDebugStore((s) => s.cloudProviders);
-  const cloudState = cloudProviders?.gdrive ?? cloudProviders?.dropbox ?? null;
+  const activeCloudProvider = cloudProviders?.gdrive?.status !== "idle" ? "gdrive" : cloudProviders?.dropbox?.status !== "idle" ? "dropbox" : "gdrive";
+  const cloudState = activeCloudProvider === "gdrive" ? cloudProviders?.gdrive ?? null : cloudProviders?.dropbox ?? null;
+  const cloudProviderName = activeCloudProvider === "gdrive" ? "Google Drive" : "Dropbox";
+  const cloudActivity = useCloudSyncActivity(cloudState, cloudProviderName);
   const cloudError = cloudState?.error;
   const syncBlocked = syncConnected && isMergeBlocked(cloudError);
   const cloudStage = cloudState?.stage;
@@ -101,6 +105,8 @@ export function PwaFeedEmptyState() {
       <p className="max-w-xs text-sm text-[var(--theme-text-muted)]">
         {syncBlocked
           ? "Open Sync settings to choose how to recover your Google Drive library."
+          : cloudTransferRunning && cloudActivity
+          ? `${cloudActivity.detailLabel}. Running for ${cloudActivity.elapsedLabel}.`
           : syncConnected
           ? "Freed Desktop is connected. New feed content will appear here once fetched."
           : "Connect to Freed Desktop to sync your feeds."}

--- a/packages/pwa/src/components/PwaSyncSettings.test.ts
+++ b/packages/pwa/src/components/PwaSyncSettings.test.ts
@@ -54,6 +54,8 @@ function renderWithPlatform(node: ReactNode): { container: HTMLDivElement; root:
 describe("PwaSyncSettings cloud diagnostics", () => {
   beforeEach(() => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-09T12:00:30Z"));
     vi.clearAllMocks();
     useAppStore.setState({
       syncConnected: true,
@@ -92,6 +94,7 @@ describe("PwaSyncSettings cloud diagnostics", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     useAppStore.setState({
       syncConnected: false,
       isSyncing: false,
@@ -153,6 +156,48 @@ describe("PwaSyncSettings cloud diagnostics", () => {
     expect(text).toContain("Merge blocked. Review Sync diagnostics below.");
     expect(diagnostics?.textContent).toContain(blockedMessage);
     expect((text.match(/Freed blocked a sync merge/g) ?? [])).toHaveLength(1);
+
+    act(() => {
+      root.unmount();
+    });
+  });
+
+  it("shows the active cloud sync stage and elapsed time while a merge is running", () => {
+    const startedAt = Date.now() - 30_000;
+    useDebugStore.setState({
+      cloudProviders: {
+        dropbox: { status: "idle" },
+        gdrive: {
+          status: "connected",
+          stage: "merge",
+          lastAttemptAt: startedAt,
+          statusMessage: "Merging remote document into the local library.",
+          events: [
+            {
+              id: "merge-started",
+              ts: startedAt,
+              kind: "started",
+              stage: "merge",
+              message: "Merging remote document into the local library.",
+            },
+          ],
+        },
+      },
+    });
+
+    const { container, root } = renderWithPlatform(createElement(PwaSyncSettings));
+    const activeCounter = container.querySelector("[data-testid='pwa-cloud-sync-active-counter']");
+
+    expect(container.textContent).toContain("Merging 30s");
+    expect(activeCounter?.textContent).toContain("Merging Google Drive data into this library");
+    expect(activeCounter?.textContent).toContain("30s");
+    expect(activeCounter?.querySelector("[aria-label='Syncing']")).toBeTruthy();
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(activeCounter?.textContent).toContain("31s");
 
     act(() => {
       root.unmount();

--- a/packages/pwa/src/components/PwaSyncSettings.tsx
+++ b/packages/pwa/src/components/PwaSyncSettings.tsx
@@ -23,6 +23,7 @@ import {
   syncCloudProviderNow,
 } from "../lib/sync";
 import { SyncConnectContent } from "./SyncConnectDialog";
+import { useCloudSyncActivity } from "./cloudSyncActivity";
 
 type Provider = "gdrive" | "dropbox" | "local";
 
@@ -138,6 +139,8 @@ export function PwaSyncSettings() {
     ? cloudProviders?.[provider]
     : null;
   const activeCloudProvider = provider === "gdrive" || provider === "dropbox" ? provider : null;
+  const activeCloudProviderName = activeCloudProvider === "dropbox" ? "Dropbox" : "Google Drive";
+  const cloudActivity = useCloudSyncActivity(cloudProviderState, activeCloudProviderName);
   const isManualSyncing = manualSyncingProvider !== null;
   const uploadExplanation = describeUploadGap(cloudProviderState ?? null);
   const diagnosticError = cloudProviderState?.error ?? manualSyncError;
@@ -217,6 +220,7 @@ export function PwaSyncSettings() {
   const providerError = cloudProviderState?.error;
   const statusText = providerError
     ? isMergeBlocked(providerError) ? "Merge blocked" : "Needs attention"
+    : cloudActivity ? `${cloudActivity.shortLabel} ${cloudActivity.elapsedLabel}`
     : isSyncing ? "Syncing now" : "Connected";
   const dotColor = providerError
     ? "bg-[rgb(var(--theme-feedback-danger-rgb))]"
@@ -282,6 +286,23 @@ export function PwaSyncSettings() {
           data-testid="pwa-cloud-sync-status-message"
           className="mb-3 rounded-lg bg-[var(--theme-bg-muted)] px-3 py-2 text-xs text-[var(--theme-text-secondary)]"
         >
+          {cloudActivity && (
+            <div
+              data-testid="pwa-cloud-sync-active-counter"
+              className="mb-2 flex items-center gap-2 text-[var(--theme-text-secondary)]"
+            >
+              <span
+                aria-label="Syncing"
+                className="h-3 w-3 shrink-0 animate-spin rounded-full border-2 border-[rgb(var(--theme-accent-secondary-rgb)/0.24)] border-t-[var(--theme-accent-secondary)]"
+              />
+              <span className="font-medium text-[var(--theme-text-primary)]">
+                {cloudActivity.detailLabel}
+              </span>
+              <span className="shrink-0 font-mono tabular-nums text-[var(--theme-text-muted)]">
+                {cloudActivity.elapsedLabel}
+              </span>
+            </div>
+          )}
           <p className="font-medium text-[var(--theme-text-primary)]">
             {cloudProviderState?.statusMessage ?? "No cloud sync activity yet."}
           </p>

--- a/packages/pwa/src/components/cloudSyncActivity.ts
+++ b/packages/pwa/src/components/cloudSyncActivity.ts
@@ -1,0 +1,122 @@
+import { useEffect, useMemo, useState } from "react";
+import type {
+  CloudProviderDebugEvent,
+  CloudProviderDebugState,
+  CloudSyncStage,
+} from "@freed/ui/lib/debug-store";
+
+type ProviderName = "Google Drive" | "Dropbox";
+
+type CloudSyncActivity = {
+  stage: Exclude<CloudSyncStage, "idle">;
+  startedAt: number;
+  elapsedMs: number;
+  elapsedLabel: string;
+  shortLabel: string;
+  detailLabel: string;
+};
+
+const ACTIVE_STAGES = new Set<CloudSyncStage>(["auth", "download", "merge", "poll", "upload"]);
+
+function formatCloudSyncElapsed(ms: number): string {
+  const seconds = Math.max(0, Math.floor(ms / 1000));
+  if (seconds < 60) return `${seconds.toLocaleString()}s`;
+
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+  if (minutes < 60) return `${minutes.toLocaleString()}m ${remainingSeconds.toLocaleString()}s`;
+
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  return `${hours.toLocaleString()}h ${remainingMinutes.toLocaleString()}m`;
+}
+
+function stageShortLabel(stage: Exclude<CloudSyncStage, "idle">): string {
+  switch (stage) {
+    case "auth":
+      return "Refreshing auth";
+    case "download":
+      return "Downloading";
+    case "merge":
+      return "Merging";
+    case "poll":
+      return "Watching";
+    case "upload":
+      return "Uploading";
+  }
+}
+
+function stageDetailLabel(stage: Exclude<CloudSyncStage, "idle">, providerName: ProviderName): string {
+  switch (stage) {
+    case "auth":
+      return `Refreshing ${providerName} access`;
+    case "download":
+      return `Checking ${providerName} for remote changes`;
+    case "merge":
+      return `Merging ${providerName} data into this library`;
+    case "poll":
+      return `Watching ${providerName} for changes`;
+    case "upload":
+      return `Uploading local changes to ${providerName}`;
+  }
+}
+
+function latestStartedEventForStage(
+  events: CloudProviderDebugEvent[] | undefined,
+  stage: Exclude<CloudSyncStage, "idle">,
+): CloudProviderDebugEvent | null {
+  return events?.find((event) => event.kind === "started" && event.stage === stage) ?? null;
+}
+
+function getActivityStartedAt(
+  state: CloudProviderDebugState,
+  stage: Exclude<CloudSyncStage, "idle">,
+): number | null {
+  return latestStartedEventForStage(state.events, stage)?.ts
+    ?? state.lastAttemptAt
+    ?? state.lastActivityAt
+    ?? null;
+}
+
+function getCloudSyncActivity(
+  state: CloudProviderDebugState | null | undefined,
+  providerName: ProviderName,
+  now: number,
+): CloudSyncActivity | null {
+  if (!state?.stage || !ACTIVE_STAGES.has(state.stage) || state.stage === "idle" || state.status === "error") {
+    return null;
+  }
+
+  const startedAt = getActivityStartedAt(state, state.stage);
+  if (typeof startedAt !== "number") return null;
+
+  const elapsedMs = Math.max(0, now - startedAt);
+  return {
+    stage: state.stage,
+    startedAt,
+    elapsedMs,
+    elapsedLabel: formatCloudSyncElapsed(elapsedMs),
+    shortLabel: stageShortLabel(state.stage),
+    detailLabel: stageDetailLabel(state.stage, providerName),
+  };
+}
+
+export function useCloudSyncActivity(
+  state: CloudProviderDebugState | null | undefined,
+  providerName: ProviderName,
+): CloudSyncActivity | null {
+  const [now, setNow] = useState(() => Date.now());
+  const isActive = !!state?.stage && ACTIVE_STAGES.has(state.stage) && state.stage !== "idle" && state.status !== "error";
+
+  useEffect(() => {
+    if (!isActive) return undefined;
+    const refresh = window.setTimeout(() => setNow(Date.now()), 0);
+    const interval = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => {
+      window.clearTimeout(refresh);
+      window.clearInterval(interval);
+    };
+  }, [isActive, state?.stage, state?.lastAttemptAt, state?.lastActivityAt]);
+
+  return useMemo(() => getCloudSyncActivity(state, providerName, now), [now, providerName, state]);
+}


### PR DESCRIPTION
(AI Generated).

## Summary
- Show the active Google Drive or Dropbox sync stage with an elapsed counter in Sync settings.
- Show the same background sync stage and running time on the blank feed state while content is still loading.

## Testing
- npm run validate:feature
- PATH=/Users/aubreyfalconer/dev/freed-sync-elapsed-status/node_modules/.bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/usr/local/MacGPG2/bin:/Applications/VMware Fusion.app/Contents/Public:/usr/local/share/dotnet:~/.dotnet/tools:/usr/local/go/bin:/Library/Frameworks/Mono.framework/Versions/Current/Commands:/Users/aubreyfalconer/.nvm/versions/node/v24.14.1/bin:/Users/aubreyfalconer/.codex/tmp/arg0/codex-arg0jhObyX:/Users/aubreyfalconer/.local/bin:/opt/homebrew/opt/mysql-client/bin:/opt/homebrew/bin:/opt/local/bin:/opt/local/sbin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/Users/aubreyfalconer/.cargo/bin:/Users/aubreyfalconer/go/bin:/Users/aubreyfalconer/.cache/lm-studio/bin:/Users/aubreyfalconer/.safe-chain/bin:/Applications/Codex.app/Contents/Resources:/usr/local/bin npm run test:unit -- PwaSyncSettings.test.ts PwaFeedEmptyState.test.ts