### PR TITLE
fix: collapse toolbar feed controls

### DIFF
--- a/packages/desktop/tests/e2e/feed-card-ui.spec.ts
+++ b/packages/desktop/tests/e2e/feed-card-ui.spec.ts
@@ -445,7 +445,7 @@ test("liking an X post keeps it in the unified feed", async ({ app, ipc }) => {
   expect(userState?.likedSyncedAt).toEqual(expect.any(Number));
 });
 
-test("top toolbar card density slider persists locally", async ({ app, page }) => {
+test("filter menu card density slider persists locally", async ({ app, page }) => {
   await page.setViewportSize({ width: 1440, height: 900 });
   await page.addInitScript(() => {
     if (window.sessionStorage.getItem("feed-card-density-test-started") === "1") return;
@@ -456,7 +456,19 @@ test("top toolbar card density slider persists locally", async ({ app, page }) =
   await app.waitForReady();
   await injectCardUiItems(page);
 
-  const slider = page.getByTestId("feed-card-density-slider");
+  await expect(page.getByTestId("social-content-toolbar-filter")).toBeVisible({ timeout: 5_000 });
+  await expect(page.getByTestId("feed-toolbar-lens")).toBeVisible({ timeout: 5_000 });
+  await expect(page.getByTestId("feed-card-density-slider")).toHaveCount(0);
+
+  const filterButton = page.getByTestId("mobile-toolbar-filter-button");
+  await expect(filterButton).toBeVisible({ timeout: 5_000 });
+  await filterButton.click();
+
+  const filterMenu = page.getByTestId("feed-signal-filter-menu");
+  await expect(filterMenu.getByText("Format", { exact: true })).toHaveCount(0);
+  await expect(filterMenu.getByText("Connections", { exact: true })).toHaveCount(0);
+  await expect(filterMenu.getByText("Classification", { exact: true })).toBeVisible();
+  const slider = filterMenu.getByTestId("feed-card-density-slider");
   const card = page.locator('[data-feed-item-id="test-facebook-card-ui-overhaul"]').first();
 
   await expect(slider).toBeVisible();
@@ -480,10 +492,11 @@ test("top toolbar card density slider persists locally", async ({ app, page }) =
 
   await page.reload();
   await app.waitForReady();
-  await expect(page.getByTestId("feed-card-density-slider")).toHaveValue("2");
+  await page.getByTestId("mobile-toolbar-filter-button").click();
+  await expect(page.getByTestId("feed-signal-filter-menu").getByTestId("feed-card-density-slider")).toHaveValue("2");
 });
 
-test("narrow desktop toolbar exposes card density slider in overflow", async ({ app, page }) => {
+test("narrow desktop toolbar exposes card density slider in the filter menu", async ({ app, page }) => {
   await page.setViewportSize({ width: 1100, height: 800 });
   await page.addInitScript(() => {
     window.localStorage.removeItem("freed-feed-card-density");
@@ -499,15 +512,21 @@ test("narrow desktop toolbar exposes card density slider in overflow", async ({ 
   const overflowButton = page.getByTestId("toolbar-overflow-button");
   await expect(overflowButton).toBeVisible({ timeout: 5_000 });
   await overflowButton.click();
-
   const overflowMenu = page.getByTestId("toolbar-overflow-menu");
-  const densitySection = overflowMenu.getByTestId("toolbar-overflow-density-section");
-  const actionsSection = overflowMenu.getByTestId("toolbar-overflow-actions-section");
-  const densityControl = overflowMenu.getByTestId("feed-card-density-control");
-  const slider = overflowMenu.getByTestId("feed-card-density-slider");
+  await expect(overflowMenu.getByTestId("toolbar-overflow-density-section")).toHaveCount(0);
+  await expect(overflowMenu.getByTestId("toolbar-overflow-actions-section").getByText("Actions", { exact: true })).toBeVisible();
+  await page.keyboard.press("Escape");
+
+  const filterButton = page.getByTestId("mobile-toolbar-filter-button");
+  await expect(filterButton).toBeVisible({ timeout: 5_000 });
+  await filterButton.click();
+
+  const filterMenu = page.getByTestId("feed-signal-filter-menu");
+  const densitySection = filterMenu.getByTestId("feed-filter-density-section");
+  const densityControl = filterMenu.getByTestId("feed-card-density-control");
+  const slider = filterMenu.getByTestId("feed-card-density-slider");
   await expect(slider).toBeVisible();
   await expect(densitySection.getByText("Card density", { exact: true })).toBeVisible();
-  await expect(actionsSection.getByText("Actions", { exact: true })).toBeVisible();
 
   const menuGeometry = await densitySection.evaluate((section) => {
     const control = section.querySelector('[data-testid="feed-card-density-control"]') as HTMLElement | null;

--- a/packages/desktop/tests/e2e/smoke.spec.ts
+++ b/packages/desktop/tests/e2e/smoke.spec.ts
@@ -1157,6 +1157,35 @@ test("reader toolbar keeps back button clickable while title text is a drag targ
   await expect(page.locator("[data-feed-item-id]")).toHaveCount(8);
 });
 
+test("reader toolbar keeps the Focus toggle text vertically centered", async ({ app, page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await app.goto();
+  await app.waitForReady();
+  await app.injectRssItems(4);
+
+  await page.locator("[data-feed-item-id]").first().click();
+  const focusButton = page.getByRole("button", { name: "Toggle focus reading mode" });
+  await expect(focusButton).toBeVisible({ timeout: 5_000 });
+
+  const geometry = await focusButton.evaluate((button) => {
+    const label = button.querySelector("[aria-hidden='true']") as HTMLElement | null;
+    if (!label) throw new Error("Focus toggle label is missing");
+
+    const buttonRect = button.getBoundingClientRect();
+    const labelRect = label.getBoundingClientRect();
+    return {
+      buttonHeight: Math.round(buttonRect.height),
+      centerDelta: Math.abs(
+        (labelRect.top + labelRect.height / 2) -
+        (buttonRect.top + buttonRect.height / 2),
+      ),
+    };
+  });
+
+  expect(geometry.buttonHeight).toBe(36);
+  expect(geometry.centerDelta).toBeLessThanOrEqual(1);
+});
+
 test("fullscreen reader toolbar passive targets expose direct native drag attributes", async ({ app, page }) => {
   await page.addInitScript(() => {
     Object.defineProperty(navigator, "userAgentData", {
@@ -2381,12 +2410,13 @@ test("narrow feed filter menu labels collapsed sections", async ({ app, page }) 
   await filterButton.click();
 
   const filterMenu = page.getByTestId("feed-signal-filter-menu");
+  await expect(filterMenu.getByText("Card density", { exact: true })).toBeVisible();
   await expect(filterMenu.getByText("Format", { exact: true })).toBeVisible();
   await expect(filterMenu.getByText("Connections", { exact: true })).toBeVisible();
   await expect(filterMenu.getByText("Classification", { exact: true })).toBeVisible();
   await expect(filterMenu.getByText("View", { exact: true })).toHaveCount(0);
   const headingLefts = await filterMenu.evaluate((menu) => {
-    const headings = ["Format", "Connections", "Classification"];
+    const headings = ["Card density", "Format", "Connections", "Classification"];
     return headings.map((heading) => {
       const element = Array.from(menu.querySelectorAll("p")).find((candidate) =>
         candidate.textContent?.trim() === heading

--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -497,18 +497,26 @@ export function Header({
     showMapTimeControls && !collapseToolbarViewControls;
   const showInlineSocialContentControls =
     showSocialContentControls && !collapseToolbarViewControls;
+  const showFeedCardDensityControl =
+    activeView === "feed" &&
+    !selectedItem &&
+    !isMobile;
   const hideMobileDrawerToolbarActions = mobileSidebarOpen;
+  const showCollapsedFeedControlMenu =
+    showFeedSignalFilter ||
+    showSavedSortControl ||
+    showFeedCardDensityControl;
   const showCollapsedToolbarFilterMenu =
     !hideMobileDrawerToolbarActions &&
     !selectedItem &&
     (
+      showCollapsedFeedControlMenu ||
       (collapseToolbarViewControls && (
         showWorkspaceIdentityControls ||
         showMapTimeControls ||
         showSocialContentControls ||
         showSavedSortControl
-      )) ||
-      ((isMobile || collapseToolbarViewControls) && showFeedSignalFilter)
+      ))
     );
   const showInlineFeedSignalFilter =
     !hideMobileDrawerToolbarActions &&
@@ -516,14 +524,8 @@ export function Header({
     !showCollapsedToolbarFilterMenu;
   const showInlineSavedSortControl =
     showSavedSortControl && !showCollapsedToolbarFilterMenu;
-  const showFeedCardDensityControl =
-    activeView === "feed" &&
-    !selectedItem &&
-    !isMobile;
-  const showInlineFeedCardDensityControl =
-    showFeedCardDensityControl && !isBelowLargeToolbar;
-  const showOverflowFeedCardDensityControl =
-    showFeedCardDensityControl && isBelowLargeToolbar;
+  const showFilterMenuFeedCardDensityControl =
+    showFeedCardDensityControl;
   const showInlineReaderBookmark =
     !!selectedItem && !isBelowReaderBookmarkToolbar;
   const collapsedReaderTitlePaddingClass = selectedItem?.sourceUrl
@@ -1034,8 +1036,7 @@ export function Header({
   ]);
   const showToolbarOverflowMenuButton =
     !hideMobileDrawerToolbarActions &&
-    (toolbarOverflowActions.length > 0 ||
-    showOverflowFeedCardDensityControl);
+    toolbarOverflowActions.length > 0;
 
   const showReaderLayoutToggle =
     !isMobile &&
@@ -1248,9 +1249,8 @@ export function Header({
 
   useEffect(() => {
     if (toolbarOverflowActions.length > 0) return;
-    if (showOverflowFeedCardDensityControl) return;
     setToolbarOverflowMenuOpen(false);
-  }, [showOverflowFeedCardDensityControl, toolbarOverflowActions.length]);
+  }, [toolbarOverflowActions.length]);
 
   useEffect(() => {
     if (!hideMobileDrawerToolbarActions) return;
@@ -1636,7 +1636,7 @@ export function Header({
                         ...(headerDragRegion ? toolbarControlStyle : undefined),
                         width: "4.5rem",
                       }}
-                      className={`h-9 w-full justify-center rounded-lg px-2.5 py-0 text-sm font-bold lg:inline-flex ${
+                      className={`inline-flex h-9 w-full items-center justify-center rounded-lg px-2.5 py-0 text-sm font-bold leading-none ${
                         display.reading.focusMode
                           ? "theme-toolbar-button-active"
                           : "theme-toolbar-button-neutral"
@@ -1644,7 +1644,7 @@ export function Header({
                       aria-pressed={display.reading.focusMode}
                       aria-label="Toggle focus reading mode"
                     >
-                      <span aria-hidden="true">
+                      <span className="inline-flex items-baseline leading-none" aria-hidden="true">
                         <span className="font-black">F</span>
                         <span className="text-xs font-light">ocus</span>
                       </span>
@@ -1841,16 +1841,6 @@ export function Header({
                   ) : null}
                 </ToolbarAnimatedSlot>
 
-                <ToolbarAnimatedSlot visible={showInlineFeedCardDensityControl} width="7.25rem" className="hidden lg:flex">
-                  {showInlineFeedCardDensityControl ? (
-                    <FeedCardDensitySlider
-                      value={feedCardDensity}
-                      onChange={setFeedCardDensity}
-                      style={headerDragRegion ? toolbarControlStyle : undefined}
-                    />
-                  ) : null}
-                </ToolbarAnimatedSlot>
-
                 <ToolbarAnimatedSlot visible={showInlineSavedSortControl} width="10.75rem" className="hidden lg:flex">
                   {showInlineSavedSortControl ? (
                     <SavedSortSelect
@@ -1967,22 +1957,6 @@ export function Header({
           className="theme-dialog-shell theme-menu-shell fixed z-[300] w-[16rem] max-w-[calc(100vw-1rem)] py-1.5 shadow-2xl shadow-black/35"
           style={toolbarOverflowMenuStyle}
         >
-          {showOverflowFeedCardDensityControl ? (
-            <div
-              data-testid="toolbar-overflow-density-section"
-              className={`${toolbarOverflowActions.length > 0 ? "border-b border-[var(--theme-border-subtle)]" : ""} px-4 pb-3 pt-2`}
-            >
-              <p className="mb-2 text-[0.68rem] font-semibold uppercase tracking-[0.18em] text-[var(--theme-text-muted)]">
-                Card density
-              </p>
-              <FeedCardDensitySlider
-                value={feedCardDensity}
-                onChange={setFeedCardDensity}
-                fullWidth
-                style={headerDragRegion ? toolbarControlStyle : undefined}
-              />
-            </div>
-          ) : null}
           {toolbarOverflowActions.length > 0 ? (
             <div data-testid="toolbar-overflow-actions-section" className="pt-2">
               <p className="px-4 pb-1 text-[0.68rem] font-semibold uppercase tracking-[0.18em] text-[var(--theme-text-muted)]">
@@ -2024,7 +1998,24 @@ export function Header({
           className="theme-dialog-shell theme-menu-shell fixed z-[300] w-[20rem] max-w-[calc(100vw-1rem)] py-2 shadow-2xl shadow-black/35"
           style={signalFilterMenuStyle}
         >
-          {showCollapsedToolbarFilterMenu && showSocialContentControls ? (
+          {showFilterMenuFeedCardDensityControl ? (
+            <div
+              data-testid="feed-filter-density-section"
+              className="border-b border-[var(--theme-border-subtle)] px-3 pb-3 pt-1"
+            >
+              <p className="mb-2 px-1 text-[0.68rem] font-semibold uppercase tracking-[0.18em] text-[var(--theme-text-muted)]">
+                Card density
+              </p>
+              <FeedCardDensitySlider
+                value={feedCardDensity}
+                onChange={setFeedCardDensity}
+                fullWidth
+                style={headerDragRegion ? toolbarControlStyle : undefined}
+              />
+            </div>
+          ) : null}
+
+          {collapseToolbarViewControls && showCollapsedToolbarFilterMenu && showSocialContentControls ? (
             <div className={`${showFeedSignalFilter ? "border-b border-[var(--theme-border-subtle)]" : ""} px-3 pb-3 pt-1`}>
               <p className="mb-2 px-1 text-[0.68rem] font-semibold uppercase tracking-[0.18em] text-[var(--theme-text-muted)]">
                 Format
@@ -2044,7 +2035,7 @@ export function Header({
             </div>
           ) : null}
 
-          {showCollapsedToolbarFilterMenu && showWorkspaceIdentityControls ? (
+          {collapseToolbarViewControls && showCollapsedToolbarFilterMenu && showWorkspaceIdentityControls ? (
             <div className={`${showMapTimeControls || showSavedSortControl || showFeedSignalFilter ? "border-b border-[var(--theme-border-subtle)]" : ""} px-3 py-3`}>
               <p className="mb-2 px-1 text-[0.68rem] font-semibold uppercase tracking-[0.18em] text-[var(--theme-text-muted)]">
                 Connections
@@ -2060,7 +2051,7 @@ export function Header({
             </div>
           ) : null}
 
-          {showCollapsedToolbarFilterMenu && showMapTimeControls ? (
+          {collapseToolbarViewControls && showCollapsedToolbarFilterMenu && showMapTimeControls ? (
             <div className={`${showSavedSortControl || showFeedSignalFilter ? "border-b border-[var(--theme-border-subtle)]" : ""} px-3 py-3`}>
               <p className="mb-2 px-1 text-[0.68rem] font-semibold uppercase tracking-[0.18em] text-[var(--theme-text-muted)]">
                 Time


### PR DESCRIPTION
(AI Generated).

## Summary
- Keep card density and feed classification controls inside the filter menu.
- Preserve wide inline lens and format controls until they need to collapse.
- Center the reader Focus toggle label vertically.

## Testing
- npm run test:e2e -- smoke.spec.ts feed-card-ui.spec.ts --grep \"reader toolbar keeps the Focus toggle text vertically centered|narrow feed filter menu labels collapsed sections|filter menu card density slider persists locally|narrow desktop toolbar exposes card density slider in the filter menu\" (packages/desktop)
- npm run validate:feature