### PR TITLE
fix: restore nightly validation regressions

### DIFF
--- a/packages/desktop/src/lib/store-optimistic-mutations.test.ts
+++ b/packages/desktop/src/lib/store-optimistic-mutations.test.ts
@@ -261,6 +261,25 @@ describe("store optimistic mutations", () => {
     await preferencesPromise;
   });
 
+  it("waits for account relink persistence before exposing the new person", async () => {
+    const accountUpdate = deferred();
+    mockDocUpdateAccount.mockReturnValueOnce(accountUpdate.promise);
+    useAppStore.setState({
+      accounts: { account: makeAccount("account") },
+    });
+
+    const relinkPromise = useAppStore.getState().linkAccountToPerson("account", "person");
+
+    expect(useAppStore.getState().accounts.account?.personId).toBeUndefined();
+    expect(mockDocUpdateAccount).toHaveBeenCalledWith(
+      "account",
+      expect.objectContaining({ personId: "person" }),
+    );
+
+    accountUpdate.resolve();
+    await relinkPromise;
+  });
+
   it("projects batched read marks after the batch timer flushes", async () => {
     vi.useFakeTimers();
     const readUpdate = deferred();

--- a/packages/desktop/src/lib/store.ts
+++ b/packages/desktop/src/lib/store.ts
@@ -931,13 +931,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       personId: personId ?? undefined,
       updatedAt: Date.now(),
     };
-    await runOptimisticMutation(
-      get,
-      set,
-      "desktop:linkAccountToPerson",
-      (state) => projectUpdateAccount(state, accountId, updates),
-      () => docUpdateAccount(accountId, updates),
-    );
+    await docUpdateAccount(accountId, updates);
     await pruneConnectionPersonIfNeeded(get, previousPersonId, [accountId]);
   },
 

--- a/packages/desktop/tests/e2e/social-story-filter.spec.ts
+++ b/packages/desktop/tests/e2e/social-story-filter.spec.ts
@@ -90,19 +90,19 @@ test("Instagram source toolbar filters posts, stories, and all items", async ({ 
   await page.getByTestId("source-row-instagram").first().click();
   const filter = page.getByTestId("social-content-toolbar-filter");
   await expect(filter).toBeVisible();
-  const signalFilter = page.getByTestId("mobile-toolbar-filter-button");
-  await expect(signalFilter).toBeVisible();
+  const filterButton = page.getByTestId("mobile-toolbar-filter-button");
+  await expect(filterButton).toBeVisible();
+  await expect(page.getByTestId("feed-signal-filter-button")).toHaveCount(0);
 
   const filterBox = await filter.boundingBox();
-  const signalFilterBox = await signalFilter.boundingBox();
+  const filterButtonBox = await filterButton.boundingBox();
   expect(filterBox).not.toBeNull();
-  expect(signalFilterBox).not.toBeNull();
-  expect((signalFilterBox?.x ?? 0) - ((filterBox?.x ?? 0) + (filterBox?.width ?? 0))).toBeGreaterThanOrEqual(8);
+  expect(filterButtonBox).not.toBeNull();
+  expect((filterButtonBox?.x ?? 0) - ((filterBox?.x ?? 0) + (filterBox?.width ?? 0))).toBeGreaterThanOrEqual(8);
   const toolbarControlHeights = await page.getByTestId("workspace-toolbar").evaluate((toolbar) => {
     const selectors = [
       '[data-testid="feed-toolbar-lens"]',
       '[data-testid="social-content-toolbar-filter"]',
-      '[data-testid="feed-card-density-control"]',
       '[data-testid="mobile-toolbar-filter-button"]',
       '[data-testid="toolbar-overflow-button"]',
     ];
@@ -117,12 +117,12 @@ test("Instagram source toolbar filters posts, stories, and all items", async ({ 
   expect(toolbarControlHeights.length).toBeGreaterThanOrEqual(4);
   expect(new Set(toolbarControlHeights)).toEqual(new Set([36]));
 
-  await signalFilter.click();
-  const signalMenu = page.getByTestId("feed-signal-filter-menu");
-  await expect(signalMenu.getByRole("menuitemcheckbox", { name: /Everything/ })).toBeVisible();
-  await expect(signalMenu.getByRole("menuitemcheckbox", { name: /Inspiring/ })).toBeVisible();
-  await signalFilter.click();
-  await expect(signalMenu).toBeHidden();
+  await filterButton.click();
+  const filterMenu = page.getByTestId("feed-signal-filter-menu");
+  await expect(filterMenu.getByText("Classification", { exact: true })).toBeVisible();
+  await expect(filterMenu.getByRole("menuitemcheckbox", { name: /Everything/ })).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(filterMenu).toBeHidden();
 
   await expect(page.getByText("Instagram filter post item")).toBeVisible();
   await expect(page.getByText("Instagram filter reel item")).toBeVisible();

--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -103,7 +103,6 @@ const TOOLBAR_ICON_BUTTON_CLASS =
 const TOOLBAR_READER_LAYOUT_TOGGLE_BUTTON_CLASS =
   "theme-toolbar-reader-layout-button rounded-lg";
 const TOOLBAR_ICON_BUTTON_SIZE = "2.25rem";
-const COLLAPSED_TOOLBAR_PAIR_WIDTH = "5rem";
 const READER_LAYOUT_CONTROL_BUTTON_SIZE_PX = 32;
 const READER_LAYOUT_CONTROL_ICON_SIZE_PX = 20;
 const READER_LAYOUT_CONTROL_BUTTON_GAP_PX = 0;
@@ -1961,7 +1960,11 @@ export function Header({
 
                 <ToolbarAnimatedSlot
                   visible={showToolbarOverflowMenuButton || showCollapsedToolbarFilterMenu}
-                  width={showToolbarOverflowMenuButton && showCollapsedToolbarFilterMenu ? COLLAPSED_TOOLBAR_PAIR_WIDTH : TOOLBAR_ICON_BUTTON_SIZE}
+                  width={
+                    showToolbarOverflowMenuButton && showCollapsedToolbarFilterMenu
+                      ? TOOLBAR_SLOT_WIDTH_CONTENT
+                      : TOOLBAR_ICON_BUTTON_SIZE
+                  }
                 >
                   {showToolbarOverflowMenuButton || showCollapsedToolbarFilterMenu ? (
                     <div className="flex items-center gap-2">


### PR DESCRIPTION
(AI Generated).

## Summary
- Keep the narrow toolbar overflow and filter controls inside the desktop header.
- Make friend-graph account relinks wait for durable persistence before they appear in the store.
- Update the desktop social toolbar regression spec to match the shipped filter split.

## Testing
- `node ../../node_modules/vitest/vitest.mjs run src/lib/store-optimistic-mutations.test.ts` from `packages/desktop`
- `node ../../node_modules/playwright/cli.js test tests/e2e/smoke.spec.ts tests/e2e/social-story-filter.spec.ts --grep "narrow feed toolbar moves bulk actions into the overflow menu|dragging a channel onto a person re-links it and the graph state survives reload|Instagram source toolbar filters posts, stories, and all items"` from `packages/desktop`
- `npm run validate:feature`
