### PR TITLE
chore: refresh changelog for v26.6.901

### DIFF
--- a/release-notes/daily/production/26.6.9.json
+++ b/release-notes/daily/production/26.6.9.json
@@ -1,0 +1,14 @@
+{
+  "channel": "production",
+  "dayKey": "26.6.9",
+  "date": "2026-06-09",
+  "preferredDeck": null,
+  "editorialGuidance": [
+    "Keep the tone concise, professional, and specific.",
+    "Lead with user-facing outcomes, shipping milestones, trust wins, and installability improvements.",
+    "Demote internal cleanup unless it clearly changes the shipped product."
+  ],
+  "pinnedHighlights": [],
+  "editorialNotes": [],
+  "updatedAt": "2026-06-09T19:39:34.359Z"
+}

--- a/release-notes/releases/v26.6.901.json
+++ b/release-notes/releases/v26.6.901.json
@@ -1,0 +1,62 @@
+{
+  "tag": "v26.6.901",
+  "version": "26.6.901",
+  "channel": "production",
+  "dayKey": "26.6.9",
+  "approved": true,
+  "editorialNotes": [],
+  "generatedAt": "2026-06-09T19:39:34.357Z",
+  "model": "heuristic",
+  "source": {
+    "channel": "production",
+    "previousPublishedTag": "v26.6.805",
+    "previousPublishedDayTag": "v26.6.805",
+    "compareRef": "HEAD",
+    "isLatestOfDay": true,
+    "sameDayTagsIncluded": [
+      "v26.6.901"
+    ],
+    "relatedBuildTags": [
+      "v26.6.901"
+    ],
+    "prNumbers": [
+      824,
+      827
+    ],
+    "commitSubjects": [
+      "fix: stabilize production validation (#827)",
+      "release: approve v26.6.900 notes",
+      "release: v26.6.900",
+      "chore: promote dev into main for production release (#824)"
+    ]
+  },
+  "release": {
+    "deck": "Safe local mutations, sync recovery, and production validation fixes",
+    "features": [],
+    "fixes": [
+      {
+        "text": "Safe local mutations now respond immediately while heavy Automerge work waits for the first async turn"
+      },
+      {
+        "text": "Background activity moved into the top toolbar with collapsed feed controls that stay reachable at narrow widths"
+      },
+      {
+        "text": "Cloud sync status now shows elapsed activity and clearer recovery states for Google Drive conflicts"
+      },
+      {
+        "text": "PWA sync hydration and Google Drive recovery now avoid destructive first-sync merges and blocked retry loops"
+      },
+      {
+        "text": "Settings scrolling disables the moving overlay blur so large settings lists stay within the frame budget"
+      },
+      {
+        "text": "Production validation now covers the collapsed filter menu and waits for durable graph persistence before reload checks"
+      },
+      {
+        "text": "Settings, reader, story grid, and mobile menu polish make dense app surfaces more consistent"
+      }
+    ],
+    "followUps": []
+  },
+  "releaseBody": "(AI Generated).\n\n## Freed v26.6.901\n\nSafe local mutations, sync recovery, and production validation fixes\n\n### Fixes\n\n- Safe local mutations now respond immediately while heavy Automerge work waits for the first async turn\n- Background activity moved into the top toolbar with collapsed feed controls that stay reachable at narrow widths\n- Cloud sync status now shows elapsed activity and clearer recovery states for Google Drive conflicts\n- PWA sync hydration and Google Drive recovery now avoid destructive first-sync merges and blocked retry loops\n- Settings scrolling disables the moving overlay blur so large settings lists stay within the frame budget\n- Production validation now covers the collapsed filter menu and waits for durable graph persistence before reload checks\n- Settings, reader, story grid, and mobile menu polish make dense app surfaces more consistent\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+}

--- a/release-notes/releases/v26.6.901.md
+++ b/release-notes/releases/v26.6.901.md
@@ -1,0 +1,23 @@
+(AI Generated).
+
+## Freed v26.6.901
+
+Safe local mutations, sync recovery, and production validation fixes
+
+### Fixes
+
+- Safe local mutations now respond immediately while heavy Automerge work waits for the first async turn
+- Background activity moved into the top toolbar with collapsed feed controls that stay reachable at narrow widths
+- Cloud sync status now shows elapsed activity and clearer recovery states for Google Drive conflicts
+- PWA sync hydration and Google Drive recovery now avoid destructive first-sync merges and blocked retry loops
+- Settings scrolling disables the moving overlay blur so large settings lists stay within the frame budget
+- Production validation now covers the collapsed filter menu and waits for durable graph persistence before reload checks
+- Settings, reader, story grid, and mobile menu polish make dense app surfaces more consistent
+
+### Downloads
+
+**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  
+**Windows:** `.exe` (NSIS installer)  
+**Linux:** `.AppImage`  
+
+> macOS downloads are signed and notarized for normal Gatekeeper installation.

--- a/website/public/atom.xml
+++ b/website/public/atom.xml
@@ -2,7 +2,7 @@
 <feed xmlns="http://www.w3.org/2005/Atom">
     <id>https://freed.wtf</id>
     <title>Freed Blog</title>
-    <updated>2026-06-09T02:10:56.247Z</updated>
+    <updated>2026-06-09T20:31:19.572Z</updated>
     <generator>https://github.com/jpmonette/feed</generator>
     <author>
         <name>The Freed Team</name>

--- a/website/public/feed.xml
+++ b/website/public/feed.xml
@@ -4,7 +4,7 @@
         <title>Freed Blog</title>
         <link>https://freed.wtf</link>
         <description>Progress reports, technical deep-dives, and philosophical rants about the attention economy. From the team building Freed.</description>
-        <lastBuildDate>Tue, 09 Jun 2026 02:10:56 GMT</lastBuildDate>
+        <lastBuildDate>Tue, 09 Jun 2026 20:31:19 GMT</lastBuildDate>
         <docs>https://validator.w3.org/feed/docs/rss2.html</docs>
         <generator>https://github.com/jpmonette/feed</generator>
         <language>en</language>

--- a/website/src/content/changelog.generated.json
+++ b/website/src/content/changelog.generated.json
@@ -1,5 +1,52 @@
 [
   {
+    "version": "26.6.901",
+    "tagName": "v26.6.901",
+    "channel": "production",
+    "date": "2026-06-09T20:26:21Z",
+    "deck": "Safe local mutations, sync recovery, and production validation fixes",
+    "features": [],
+    "fixes": [
+      {
+        "text": "Safe local mutations now respond immediately while heavy Automerge work waits for the first async turn"
+      },
+      {
+        "text": "Background activity moved into the top toolbar with collapsed feed controls that stay reachable at narrow widths"
+      },
+      {
+        "text": "Cloud sync status now shows elapsed activity and clearer recovery states for Google Drive conflicts"
+      },
+      {
+        "text": "PWA sync hydration and Google Drive recovery now avoid destructive first-sync merges and blocked retry loops"
+      },
+      {
+        "text": "Settings scrolling disables the moving overlay blur so large settings lists stay within the frame budget"
+      },
+      {
+        "text": "Production validation now covers the collapsed filter menu and waits for durable graph persistence before reload checks"
+      },
+      {
+        "text": "Settings, reader, story grid, and mobile menu polish make dense app surfaces more consistent"
+      }
+    ],
+    "followUps": [],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.901",
+    "prNumbers": [
+      824,
+      827
+    ],
+    "builds": [
+      "26.6.901"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.6.901",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.901",
+        "channel": "production"
+      }
+    ]
+  },
+  {
     "version": "26.6.805",
     "tagName": "v26.6.805",
     "channel": "production",


### PR DESCRIPTION
(AI Generated).

## Summary
- add the v26.6.901 production release notes to www
- regenerate the public changelog snapshot and feeds

## Verification
- npm run build, from website
- npm run lint, from website
- node scripts/validate-release-notes.mjs release-notes/releases/v26.6.901.json