### PR TITLE
fix: ignore generated peer artifacts in nightly planner

### DIFF
--- a/scripts/nightly-self-improve.mjs
+++ b/scripts/nightly-self-improve.mjs
@@ -32,6 +32,11 @@ const STALE_SOAK_MS = 2 * 60 * 60 * 1000;
 const MIN_PERFORMANCE_SOAK_SAMPLES = 3;
 const DEFAULT_MAX_TARGETS = 6;
 const DEFAULT_MINIMUM_NIGHT_MINUTES = 180;
+const KNOWN_GENERATED_ARTIFACT_PATHS = [
+  "packages/desktop/playwright-report",
+  "packages/desktop/test-results",
+  "packages/desktop/.playwright-mcp",
+];
 
 const GIB = 1024 * 1024 * 1024;
 const numberFormatter = new Intl.NumberFormat("en-US", {
@@ -768,6 +773,26 @@ function shortStatusPaths(statusText) {
     .filter(Boolean);
 }
 
+function normalizeRepoFilePath(filePath) {
+  return filePath.replace(/\\/g, "/").replace(/\/+$/u, "");
+}
+
+function isKnownGeneratedArtifactPath(filePath) {
+  const normalizedPath = normalizeRepoFilePath(filePath);
+  return KNOWN_GENERATED_ARTIFACT_PATHS.some(
+    (artifactPath) =>
+      normalizedPath === artifactPath || normalizedPath.startsWith(`${artifactPath}/`),
+  );
+}
+
+function filterGeneratedArtifactStatus(statusText) {
+  return statusText
+    .split(/\r?\n/)
+    .filter((line) => !isKnownGeneratedArtifactPath(line.slice(3).trim().replace(/^.* -> /, "")))
+    .filter(Boolean)
+    .join("\n")
+}
+
 function providerVisiblePath(filePath) {
   return (
     filePath.startsWith("packages/capture-") ||
@@ -842,7 +867,9 @@ export function summarizePeerWorktree(worktreePath, currentRepo) {
     git(resolved, ["rev-parse", "--abbrev-ref", "HEAD"]) ||
     "unknown";
   const head = git(resolved, ["rev-parse", "--short", "HEAD"]);
-  const status = git(resolved, ["status", "--short"]);
+  const status = filterGeneratedArtifactStatus(
+    git(resolved, ["status", "--short", "--untracked-files=all"]),
+  );
   const committedFiles = git(resolved, [
     "diff",
     "--name-only",
@@ -1136,11 +1163,7 @@ export function collectRiskSnapshot({
     );
   }
 
-  for (const relativePath of [
-    "packages/desktop/playwright-report",
-    "packages/desktop/test-results",
-    "packages/desktop/.playwright-mcp",
-  ]) {
+  for (const relativePath of KNOWN_GENERATED_ARTIFACT_PATHS) {
     const absolutePath = path.join(repoPath, relativePath);
     const fileCount = countFiles(absolutePath);
     if (fileCount > 0) {

--- a/scripts/nightly-self-improve.test.mjs
+++ b/scripts/nightly-self-improve.test.mjs
@@ -12,6 +12,7 @@ import {
   buildCandidates,
   buildExecutionPlan,
   collectDuplicateWork,
+  collectPeerWorktrees,
   collectRepoSnapshot,
   collectRiskSnapshot,
   findLatestReadableSoakDir,
@@ -611,6 +612,37 @@ test("summarizePeerWorktree ignores behind-only detached snapshots as active cha
   assert.equal(summary?.aheadCount, 0);
   assert.equal(summary?.behindCount, 1);
   assert.equal(summary?.changedFileCount, 0);
+});
+
+test("collectPeerWorktrees ignores peers with only generated validation artifacts", () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "freed-peer-artifacts-"));
+  const origin = path.join(dir, "origin.git");
+  const repo = path.join(dir, "repo");
+  const peer = path.join(dir, "peer");
+
+  execFileSync("git", ["init", "--bare", origin]);
+  execFileSync("git", ["clone", origin, repo]);
+  execFileSync("git", ["-C", repo, "config", "user.name", "Freed Tests"]);
+  execFileSync("git", ["-C", repo, "config", "user.email", "tests@example.com"]);
+  execFileSync("git", ["-C", repo, "checkout", "-b", "dev"]);
+  writeFileSync(path.join(repo, "notes.txt"), "first\n");
+  execFileSync("git", ["-C", repo, "add", "notes.txt"]);
+  execFileSync("git", ["-C", repo, "commit", "-m", "first"]);
+  execFileSync("git", ["-C", repo, "push", "-u", "origin", "dev"]);
+
+  execFileSync("git", ["clone", origin, peer]);
+  execFileSync("git", ["-C", peer, "checkout", "-b", "chore/nightly-peer", "origin/dev"]);
+  mkdirSync(path.join(peer, "packages/desktop/playwright-report"), { recursive: true });
+  mkdirSync(path.join(peer, "packages/desktop/test-results"), { recursive: true });
+  writeFileSync(path.join(peer, "packages/desktop/playwright-report/index.html"), "<html></html>");
+  writeFileSync(path.join(peer, "packages/desktop/test-results/out.txt"), "artifact\n");
+
+  const summary = summarizePeerWorktree(peer, repo);
+  assert.equal(summary?.status, "");
+  assert.equal(summary?.changedFileCount, 0);
+
+  const peers = collectPeerWorktrees(repo, [peer], false);
+  assert.deepEqual(peers, []);
 });
 
 test("duplicate work candidates are selected before generic roadmap fallback", () => {


### PR DESCRIPTION
(AI Generated).

## Summary
- Stops nightly peer scans from treating generated Playwright reports as active work.

## Testing
- node --test scripts/nightly-self-improve.test.mjs
- npm run validate:feature