### PR TITLE
fix: keep provider login prompts open

### DIFF
--- a/docs/PHASE-12-ADDITIONAL-PLATFORMS.md
+++ b/docs/PHASE-12-ADDITIONAL-PLATFORMS.md
@@ -266,7 +266,8 @@ packages/capture-youtube/
 - [x] LinkedIn desktop flows have regression coverage in Playwright
 - [x] LinkedIn shares the desktop provider health summaries, rate-limit pause state, resume controls, and the unified provider section used in Settings and Debug panel cards
 - [x] LinkedIn shares the same provider severity colors and per-provider sync spinner behavior as the other social sources
-- [x] LinkedIn login stays open after auth so users can finish platform prompts before sync starts
+- [x] LinkedIn login stays open after auth so users can finish platform prompts while sync starts, then closes only after scrape startup health is confirmed
+- [x] LinkedIn post-login sync uses the user's selected scraper window mode instead of switching modes for the first scrape
 - [ ] Mozi activity captured to FeedItem with plans, trips, attendance, or overlap-adjacent events
 - [ ] Mozi is visible in desktop Sources navigation and source status UI
 - [ ] Mozi desktop flows have regression coverage in Playwright

--- a/docs/PHASE-7-SOCIAL-CAPTURE.md
+++ b/docs/PHASE-7-SOCIAL-CAPTURE.md
@@ -1,6 +1,6 @@
 # Phase 7: Facebook + Instagram Capture
 
-> **Status:** 🚧 In Progress: Facebook and Instagram integrated into Desktop via Tauri WebView scraping, with feed pollution filtering, stricter Instagram story viewer validation, long-text expansion before extraction, silent background media guarding, provider health summaries, smart backoff, shared memory-preflight backoff, transient memory-pressure health recovery, memory-aware scrape pass planning, cloud-sync exclusion while social scrapes are active, Facebook group controls with stored-name repair and single-group leave verification, source-level post and story filtering, preserved Instagram story location metadata for map recovery, linked-account cross-post dedup across IG and FB, Instagram media-key duplicate repair, same-platform social story duplicate repair, explicit reply links with opt-in beta inline hydration for X, Facebook, and Instagram reader posts, captured authors now feeding the Phase 8 account catalog for identity review, and a local permanent media vault for a user's own Meta media
+> **Status:** 🚧 In Progress: Facebook and Instagram integrated into Desktop via Tauri WebView scraping, with feed pollution filtering, stricter Instagram story viewer validation, long-text expansion before extraction, silent background media guarding, provider health summaries, smart backoff, shared memory-preflight backoff, transient memory-pressure health recovery, memory-aware scrape pass planning, cloud-sync exclusion while social scrapes are active, Facebook group controls with stored-name repair and single-group leave verification, source-level post and story filtering, preserved Instagram story location metadata for map recovery, linked-account cross-post dedup across IG and FB, Instagram media-key duplicate repair, same-platform social story duplicate repair, explicit reply links with opt-in beta inline hydration for X, Facebook, and Instagram reader posts, captured authors now feeding the Phase 8 account catalog for identity review, post-login sync startup that closes login prompts only after scrape health is confirmed, and a local permanent media vault for a user's own Meta media
 > **Dependencies:** Phase 5 (Desktop App)
 
 ---
@@ -81,8 +81,11 @@ Both Facebook and Instagram use the same pattern:
 2. User authenticates through the real login flow (2FA, CAPTCHA, etc.)
 3. `on_navigation` handler detects redirect away from login page
 4. `*-auth-result` event is emitted while the WebView stays visible
-5. User finishes any platform prompts, closes the login window, and then sync begins
-6. Cookies persist in the WebView data store for future scraping sessions
+5. Freed marks the source connected and starts sync using the user's selected scraper window mode
+6. The login window stays open while the scrape starts so the user can finish platform prompts
+7. Freed closes the login window only after the scraper emits a healthy startup event
+8. If scrape startup fails, the login window remains open and the user can close it or click Sync Now
+9. Cookies persist in the WebView data store for future scraping sessions
 
 ### Feed Scraping
 
@@ -90,7 +93,8 @@ Both Facebook and Instagram use the same pattern:
 2. Waits for page load with randomized jitter (12-16s)
 3. Injects extraction script (`fb-extract.js` / `ig-extract.js`) at multiple scroll positions
 4. Script reads visible posts from the DOM and emits them via Tauri event IPC
-5. Frontend normalizes raw posts to `FeedItem[]` using `@freed/capture-*/browser`
+5. Native lifecycle events report scrape startup, healthy startup, and startup failure with window mode and interaction-method diagnostics
+6. Frontend normalizes raw posts to `FeedItem[]` using `@freed/capture-*/browser`
 
 ### Extraction Scripts
 
@@ -194,11 +198,12 @@ const RATE_LIMITS = {
 - [x] Instagram feed integrated into Desktop via Tauri WebView scraping
 - [x] Both platforms integrated into Desktop refreshAllFeeds()
 - [x] Settings UI for both platforms (login, check connection, sync, disconnect), with the same provider section also reused inside Debug panel health cards
-- [x] Facebook and Instagram login windows stay open after auth so users can finish platform prompts before sync starts
+- [x] Facebook and Instagram login windows stay open after auth so users can finish platform prompts while sync starts, then close only after scrape startup health is confirmed
 - [x] Feed pollution filtering blocks promoted X entries and suggested FB/IG posts
 - [x] Facebook Settings includes per-group include/exclude controls for joined groups inside a filtered inner scroller that prevents late group loads from shifting the outer Settings view, plus a browser handoff action for leaving a group on Facebook
 - [x] Facebook group discovery rejects activity-only labels and numeric ID fallbacks, scrolls the joined-groups directory during explicit refresh, reads nearby rendered card text and image alt text when group links only expose timestamps, preserves good stored names, repairs missing stored names from already captured group posts or individual group pages, verifies a single group after the leave handoff before removing it locally, and keeps joined-groups refresh behind explicit provider-risk confirmation
 - [x] Desktop Sources settings expose per-source scraper window modes: shown, cloaked, hidden
+- [x] Post-login sync uses the user's selected scraper window mode instead of switching modes for the first scrape
 - [x] Background FB and IG scraper WebViews force provider media silent during scrape and auth-check flows
 - [x] Social providers surface paused/degraded health summaries in settings and the sidebar source surfaces
 - [x] Explicit and heuristic rate-limit signals auto-pause social sync, notify the user, and allow manual resume

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -761,6 +761,36 @@ fn prepare_background_scraper_window(
     Ok(())
 }
 
+fn unix_millis_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+fn emit_social_scrape_lifecycle(
+    app: &tauri::AppHandle,
+    event_name: &str,
+    provider: &str,
+    window: Option<&tauri::WebviewWindow>,
+    window_mode: ScraperWindowMode,
+    reason: Option<&str>,
+) {
+    let _ = app.emit(
+        event_name,
+        serde_json::json!({
+            "provider": provider,
+            "windowMode": window_mode.as_str(),
+            "nativeVisible": window.and_then(|wv| wv.is_visible().ok()),
+            "nativeFocused": window.and_then(|wv| wv.is_focused().ok()),
+            "scrollInput": "script-scroll",
+            "clickInput": "script-click",
+            "reason": reason,
+            "emittedAt": unix_millis_now()
+        }),
+    );
+}
+
 async fn restore_scraper_feed(
     window: &tauri::WebviewWindow,
     feed_url: &str,
@@ -5848,6 +5878,14 @@ async fn fb_scrape_feed(
         scrape_run_id,
         window_mode.as_str()
     );
+    emit_social_scrape_lifecycle(
+        &app,
+        "fb-scrape-started",
+        "facebook",
+        Some(&wv),
+        window_mode,
+        None,
+    );
 
     tokio::time::sleep(Duration::from_millis(gaussian_ms(13000.0, 1500.0))).await;
 
@@ -5923,8 +5961,25 @@ async fn fb_scrape_feed(
                 }
             }),
         );
+        emit_social_scrape_lifecycle(
+            &app,
+            "fb-scrape-start-failed",
+            "facebook",
+            Some(&wv),
+            window_mode,
+            Some(message),
+        );
         return Err(message.to_string());
     }
+
+    emit_social_scrape_lifecycle(
+        &app,
+        "fb-scrape-healthy",
+        "facebook",
+        Some(&wv),
+        window_mode,
+        Some("authenticated feed rendered"),
+    );
 
     let scrape_plan_stats = collect_runtime_memory_stats(&app, 0, 0);
     let scrape_plan = social_scrape_plan_for_memory(&scrape_plan_stats, 6, 10);
@@ -6702,6 +6757,14 @@ async fn ig_scrape_feed(
         "[IG] scrape started (window_mode={}), waiting for feed to render...",
         window_mode.as_str()
     );
+    emit_social_scrape_lifecycle(
+        &app,
+        "ig-scrape-started",
+        "instagram",
+        Some(&wv),
+        window_mode,
+        None,
+    );
 
     tokio::time::sleep(Duration::from_millis(gaussian_ms(9000.0, 1200.0))).await;
 
@@ -6803,6 +6866,16 @@ async fn ig_scrape_feed(
             .map_err(|e| format!("Failed to inject extraction script: {}", e))?;
 
         tokio::time::sleep(Duration::from_millis(300)).await;
+        if i == 0 {
+            emit_social_scrape_lifecycle(
+                &app,
+                "ig-scrape-healthy",
+                "instagram",
+                Some(&wv),
+                window_mode,
+                Some("first extraction pass injected"),
+            );
+        }
         cleanup_background_scraper_media(&wv);
         completed_passes = i + 1;
         if !social_scrape_may_continue(&app, "Instagram", "feed scrape", i + 1, num_passes) {
@@ -7374,6 +7447,14 @@ async fn li_scrape_feed(
         "[LI] scrape started (window_mode={}), waiting for feed to render...",
         window_mode.as_str()
     );
+    emit_social_scrape_lifecycle(
+        &app,
+        "li-scrape-started",
+        "linkedin",
+        Some(&wv),
+        window_mode,
+        None,
+    );
 
     // LinkedIn's feed takes slightly longer to hydrate than Facebook.
     // Use a longer initial wait with more variance.
@@ -7418,6 +7499,16 @@ async fn li_scrape_feed(
         let is_last = i + 1 == num_passes;
         inject_script(&wv, is_last)?;
         tokio::time::sleep(Duration::from_millis(300)).await;
+        if i == 0 {
+            emit_social_scrape_lifecycle(
+                &app,
+                "li-scrape-healthy",
+                "linkedin",
+                Some(&wv),
+                window_mode,
+                Some("first extraction pass injected"),
+            );
+        }
         cleanup_background_scraper_media(&wv);
         if !social_scrape_may_continue(&app, "LinkedIn", "feed scrape", i + 1, num_passes) {
             break;

--- a/packages/desktop/src/components/FacebookSettingsSection.tsx
+++ b/packages/desktop/src/components/FacebookSettingsSection.tsx
@@ -7,8 +7,6 @@
  */
 
 import { useState, useCallback, useEffect, useRef, type ReactNode } from "react";
-import { isTauri } from "@tauri-apps/api/core";
-import { listen } from "@tauri-apps/api/event";
 import { usePlatform, type SyncProviderSectionProps } from "@freed/ui/context";
 import { addDebugEvent, useDebugStore } from "@freed/ui/lib/debug-store";
 import {
@@ -54,6 +52,7 @@ import { MediaVaultSettingsCard } from "./MediaVaultSettingsCard";
 import { socialProviderCopy } from "../lib/social-provider-copy";
 import { isRuntimeDeferredStage } from "../lib/social-capture-runtime";
 import { log } from "../lib/logger";
+import { usePostLoginAutoSync } from "../hooks/usePostLoginAutoSync";
 
 const FACEBOOK_LEAVE_CHECK_DELAY_MS = import.meta.env.VITE_TEST_TAURI === "1" ? 100 : 60_000;
 const FACEBOOK_LEAVE_CHECK_FOCUS_GRACE_MS = import.meta.env.VITE_TEST_TAURI === "1" ? 0 : 5_000;
@@ -254,9 +253,7 @@ export function FacebookSettingsSection({
   const [lastDiag, setLastDiag] = useState<FbSyncDiag | null>(null);
   const [windowMode, setWindowMode] = useState(() => getFbScraperWindowMode());
   const [actionError, setActionError] = useState<string | null>(null);
-  const [loginWindowPendingSync, setLoginWindowPendingSync] = useState(false);
   const [checkingLeaveGroupIds, setCheckingLeaveGroupIds] = useState<Record<string, true>>({});
-  const loginWindowPendingSyncRef = useRef(false);
   const pendingLeaveCheckRef = useRef<{ group: FbGroupInfo; openedAt: number } | null>(null);
   const leaveCheckTimerRef = useRef<number | null>(null);
   const leaveCheckInFlightRef = useRef(false);
@@ -271,34 +268,47 @@ export function FacebookSettingsSection({
   );
   const activeGroupCount = groups.filter((group) => !excludedGroupIds[group.id]).length;
 
-  // Auto-detect login success from the WebView's on_navigation callback
-  useEffect(() => {
-    if (!isTauri() && import.meta.env.VITE_TEST_TAURI !== "1") return;
+  const runSync = useCallback(async () => {
+    setLastDiag(null);
+    try {
+      const result = await withProviderSyncing("facebook", () => captureFbFeed());
+      setLastDiag(result.diag);
+    } catch (err) {
+      console.error("Facebook feed capture failed:", err);
+    }
+  }, []);
 
-    const unlisten = listen<{ loggedIn: boolean }>("fb-auth-result", (event) => {
-      log.info(`[FB] auth result received logged_in=${event.payload.loggedIn}`);
+  const handleAuthResult = useCallback(
+    (loggedIn: boolean) => {
+      log.info(`[FB] auth result received logged_in=${loggedIn}`);
+      const currentAuth = useAppStore.getState().fbAuth;
       const newState = {
-        ...useAppStore.getState().fbAuth,
-        isAuthenticated: event.payload.loggedIn,
+        ...currentAuth,
+        isAuthenticated: loggedIn,
         lastCheckedAt: Date.now(),
-        lastCaptureError: event.payload.loggedIn
-          ? undefined
-          : useAppStore.getState().fbAuth.lastCaptureError,
+        lastCaptureError: loggedIn ? undefined : currentAuth.lastCaptureError,
       };
       setFbAuth(newState);
       storeFbAuthState(newState);
-      if (event.payload.loggedIn) {
+      if (loggedIn) {
         setActionError(null);
         addDebugEvent("change", "[FB] connection restored");
-        loginWindowPendingSyncRef.current = true;
-        setLoginWindowPendingSync(true);
-      } else {
-        loginWindowPendingSyncRef.current = false;
-        setLoginWindowPendingSync(false);
       }
-    });
-    return () => { unlisten.then((fn) => fn()); };
-  }, [setFbAuth]);
+    },
+    [setFbAuth],
+  );
+
+  const postLoginSync = usePostLoginAutoSync({
+    authEvent: "fb-auth-result",
+    loginWindowClosedEvent: "fb-login-window-closed",
+    scrapeHealthyEvent: "fb-scrape-healthy",
+    scrapeStartFailedEvent: "fb-scrape-start-failed",
+    hideLoginCommand: "fb_hide_login",
+    providerLabel: "Facebook",
+    isAuthenticated: () => useAppStore.getState().fbAuth.isAuthenticated,
+    onAuthResult: handleAuthResult,
+    runSync,
+  });
 
   useEffect(() => {
     if (!fbAuth.isAuthenticated || items.length === 0) return;
@@ -345,33 +355,6 @@ export function FacebookSettingsSection({
       }
     });
   }, [confirm, setFbAuth]);
-
-  const runSync = useCallback(async () => {
-    loginWindowPendingSyncRef.current = false;
-    setLoginWindowPendingSync(false);
-    setLastDiag(null);
-    try {
-      const result = await withProviderSyncing("facebook", () => captureFbFeed());
-      setLastDiag(result.diag);
-    } catch (err) {
-      console.error("Facebook feed capture failed:", err);
-    }
-  }, []);
-
-  useEffect(() => {
-    if (!isTauri() && import.meta.env.VITE_TEST_TAURI !== "1") return;
-
-    const unlisten = listen<{ closed: boolean }>("fb-login-window-closed", (event) => {
-      const shouldSync = event.payload.closed && useAppStore.getState().fbAuth.isAuthenticated;
-      const pending = loginWindowPendingSyncRef.current;
-      loginWindowPendingSyncRef.current = false;
-      setLoginWindowPendingSync(false);
-      if (pending && shouldSync) {
-        void runSync();
-      }
-    });
-    return () => { unlisten.then((fn) => fn()); };
-  }, [runSync]);
 
   const setExcludedGroups = useCallback(
     async (nextExcludedGroupIds: Record<string, true>) => {
@@ -585,9 +568,9 @@ export function FacebookSettingsSection({
             </span>
           </div>
 
-          {loginWindowPendingSync && (
+          {postLoginSync.message && (
             <p className="text-xs text-[#a1a1aa] leading-relaxed">
-              Connected. Finish any Facebook prompts, then close the login window.
+              {postLoginSync.message}
             </p>
           )}
 
@@ -599,6 +582,7 @@ export function FacebookSettingsSection({
                   return;
                 }
                 void confirm(async () => {
+                  postLoginSync.cancel();
                   if (isPaused) {
                     await clearProviderPause("facebook");
                   }

--- a/packages/desktop/src/components/InstagramSettingsSection.tsx
+++ b/packages/desktop/src/components/InstagramSettingsSection.tsx
@@ -6,9 +6,7 @@
  * authenticates, the WebView's cookies are shared with the scraper.
  */
 
-import { useState, useCallback, useEffect, useRef } from "react";
-import { isTauri } from "@tauri-apps/api/core";
-import { listen } from "@tauri-apps/api/event";
+import { useState, useCallback } from "react";
 import type { SyncProviderSectionProps } from "@freed/ui/context";
 import { useDebugStore } from "@freed/ui/lib/debug-store";
 import {
@@ -43,6 +41,7 @@ import { clearProviderPause, resetProviderPauseState } from "../lib/provider-hea
 import { MediaVaultSettingsCard } from "./MediaVaultSettingsCard";
 import { socialProviderCopy } from "../lib/social-provider-copy";
 import { isRuntimeDeferredStage } from "../lib/social-capture-runtime";
+import { usePostLoginAutoSync } from "../hooks/usePostLoginAutoSync";
 
 // =============================================================================
 // Diagnostic Panel
@@ -127,26 +126,45 @@ export function InstagramSettingsSection({
   const [lastDiag, setLastDiag] = useState<IgSyncDiag | null>(null);
   const [windowMode, setWindowMode] = useState(() => getIgScraperWindowMode());
   const [actionError, setActionError] = useState<string | null>(null);
-  const [loginWindowPendingSync, setLoginWindowPendingSync] = useState(false);
-  const loginWindowPendingSyncRef = useRef(false);
   const copy = socialProviderCopy("instagram");
   const { confirm, dialog } = useProviderRiskGate("instagram");
 
-  // Auto-detect login success from the WebView's on_navigation callback
-  useEffect(() => {
-    if (!isTauri() && import.meta.env.VITE_TEST_TAURI !== "1") return;
+  const runSync = useCallback(async () => {
+    setLastDiag(null);
+    try {
+      const result = await withProviderSyncing("instagram", () => captureIgFeed());
+      setLastDiag(result.diag);
+    } catch (err) {
+      console.error("Instagram feed capture failed:", err);
+    }
+  }, []);
 
-    const unlisten = listen<{ loggedIn: boolean }>("ig-auth-result", (event) => {
-      if (event.payload.loggedIn) {
+  const handleAuthResult = useCallback(
+    (loggedIn: boolean) => {
+      if (loggedIn) {
         const newState = { isAuthenticated: true, lastCheckedAt: Date.now() };
         setIgAuth(newState);
         storeIgAuthState(newState);
-        loginWindowPendingSyncRef.current = true;
-        setLoginWindowPendingSync(true);
+      } else {
+        const newState = { isAuthenticated: false, lastCheckedAt: Date.now() };
+        setIgAuth(newState);
+        storeIgAuthState(newState);
       }
-    });
-    return () => { unlisten.then((fn) => fn()); };
-  }, [setIgAuth]);
+    },
+    [setIgAuth],
+  );
+
+  const postLoginSync = usePostLoginAutoSync({
+    authEvent: "ig-auth-result",
+    loginWindowClosedEvent: "ig-login-window-closed",
+    scrapeHealthyEvent: "ig-scrape-healthy",
+    scrapeStartFailedEvent: "ig-scrape-start-failed",
+    hideLoginCommand: "ig_hide_login",
+    providerLabel: "Instagram",
+    isAuthenticated: () => useAppStore.getState().igAuth.isAuthenticated,
+    onAuthResult: handleAuthResult,
+    runSync,
+  });
 
   const handleLogin = useCallback(async () => {
     await confirm(async () => {
@@ -179,33 +197,6 @@ export function InstagramSettingsSection({
       }
     });
   }, [confirm, setIgAuth]);
-
-  const runSync = useCallback(async () => {
-    loginWindowPendingSyncRef.current = false;
-    setLoginWindowPendingSync(false);
-    setLastDiag(null);
-    try {
-      const result = await withProviderSyncing("instagram", () => captureIgFeed());
-      setLastDiag(result.diag);
-    } catch (err) {
-      console.error("Instagram feed capture failed:", err);
-    }
-  }, []);
-
-  useEffect(() => {
-    if (!isTauri() && import.meta.env.VITE_TEST_TAURI !== "1") return;
-
-    const unlisten = listen<{ closed: boolean }>("ig-login-window-closed", (event) => {
-      const shouldSync = event.payload.closed && useAppStore.getState().igAuth.isAuthenticated;
-      const pending = loginWindowPendingSyncRef.current;
-      loginWindowPendingSyncRef.current = false;
-      setLoginWindowPendingSync(false);
-      if (pending && shouldSync) {
-        void runSync();
-      }
-    });
-    return () => { unlisten.then((fn) => fn()); };
-  }, [runSync]);
 
   const handleDisconnect = useCallback(async () => {
     try {
@@ -274,9 +265,9 @@ export function InstagramSettingsSection({
             </span>
           </div>
 
-          {loginWindowPendingSync && (
+          {postLoginSync.message && (
             <p className="text-xs text-[#a1a1aa] leading-relaxed">
-              Connected. Finish any Instagram prompts, then close the login window.
+              {postLoginSync.message}
             </p>
           )}
 
@@ -288,6 +279,7 @@ export function InstagramSettingsSection({
                   return;
                 }
                 void confirm(async () => {
+                  postLoginSync.cancel();
                   if (isPaused) {
                     await clearProviderPause("instagram");
                   }

--- a/packages/desktop/src/components/LinkedInSettingsSection.tsx
+++ b/packages/desktop/src/components/LinkedInSettingsSection.tsx
@@ -6,9 +6,7 @@
  * authenticates, the WebView's cookies are shared with the scraper.
  */
 
-import { useState, useCallback, useEffect, useRef } from "react";
-import { isTauri } from "@tauri-apps/api/core";
-import { listen } from "@tauri-apps/api/event";
+import { useState, useCallback } from "react";
 import type { SyncProviderSectionProps } from "@freed/ui/context";
 import { useDebugStore } from "@freed/ui/lib/debug-store";
 import {
@@ -41,6 +39,7 @@ import { SyncProviderSectionSurface } from "./SyncProviderSectionSurface";
 import { withProviderSyncing } from "../lib/store";
 import { clearProviderPause, resetProviderPauseState } from "../lib/provider-health";
 import { socialProviderCopy } from "../lib/social-provider-copy";
+import { usePostLoginAutoSync } from "../hooks/usePostLoginAutoSync";
 
 // =============================================================================
 // Diagnostic Panel
@@ -119,14 +118,10 @@ export function LinkedInSettingsSection({
   const [lastDiag, setLastDiag] = useState<LiSyncDiag | null>(null);
   const [windowMode, setWindowMode] = useState(() => getLiScraperWindowMode());
   const [actionError, setActionError] = useState<string | null>(null);
-  const [loginWindowPendingSync, setLoginWindowPendingSync] = useState(false);
-  const loginWindowPendingSyncRef = useRef(false);
   const copy = socialProviderCopy("linkedin");
   const { confirm, dialog } = useProviderRiskGate("linkedin");
 
   const runSync = useCallback(async () => {
-    loginWindowPendingSyncRef.current = false;
-    setLoginWindowPendingSync(false);
     setLastDiag(null);
     try {
       const result = await withProviderSyncing("linkedin", () => captureLiFeed());
@@ -136,36 +131,32 @@ export function LinkedInSettingsSection({
     }
   }, []);
 
-  // Auto-detect login success from the WebView's on_navigation callback
-  useEffect(() => {
-    if (!isTauri() && import.meta.env.VITE_TEST_TAURI !== "1") return;
-
-    const unlisten = listen<{ loggedIn: boolean }>("li-auth-result", (event) => {
-      if (event.payload.loggedIn) {
+  const handleAuthResult = useCallback(
+    (loggedIn: boolean) => {
+      if (loggedIn) {
         const newState = { isAuthenticated: true, lastCheckedAt: Date.now() };
         setLiAuth(newState);
         storeLiAuthState(newState);
-        loginWindowPendingSyncRef.current = true;
-        setLoginWindowPendingSync(true);
+      } else {
+        const newState = { isAuthenticated: false, lastCheckedAt: Date.now() };
+        setLiAuth(newState);
+        storeLiAuthState(newState);
       }
-    });
-    return () => { unlisten.then((fn) => fn()); };
-  }, [setLiAuth]);
+    },
+    [setLiAuth],
+  );
 
-  useEffect(() => {
-    if (!isTauri() && import.meta.env.VITE_TEST_TAURI !== "1") return;
-
-    const unlisten = listen<{ closed: boolean }>("li-login-window-closed", (event) => {
-      const shouldSync = event.payload.closed && useAppStore.getState().liAuth.isAuthenticated;
-      const pending = loginWindowPendingSyncRef.current;
-      loginWindowPendingSyncRef.current = false;
-      setLoginWindowPendingSync(false);
-      if (pending && shouldSync) {
-        void runSync();
-      }
-    });
-    return () => { unlisten.then((fn) => fn()); };
-  }, [runSync]);
+  const postLoginSync = usePostLoginAutoSync({
+    authEvent: "li-auth-result",
+    loginWindowClosedEvent: "li-login-window-closed",
+    scrapeHealthyEvent: "li-scrape-healthy",
+    scrapeStartFailedEvent: "li-scrape-start-failed",
+    hideLoginCommand: "li_hide_login",
+    providerLabel: "LinkedIn",
+    isAuthenticated: () => useAppStore.getState().liAuth.isAuthenticated,
+    onAuthResult: handleAuthResult,
+    runSync,
+  });
 
   const handleLogin = useCallback(async () => {
     await confirm(async () => {
@@ -266,9 +257,9 @@ export function LinkedInSettingsSection({
             </span>
           </div>
 
-          {loginWindowPendingSync && (
+          {postLoginSync.message && (
             <p className="text-xs text-[#a1a1aa] leading-relaxed">
-              Connected. Finish any LinkedIn prompts, then close the login window.
+              {postLoginSync.message}
             </p>
           )}
 
@@ -280,6 +271,7 @@ export function LinkedInSettingsSection({
                   return;
                 }
                 void confirm(async () => {
+                  postLoginSync.cancel();
                   if (isPaused) {
                     await clearProviderPause("linkedin");
                   }

--- a/packages/desktop/src/hooks/usePostLoginAutoSync.ts
+++ b/packages/desktop/src/hooks/usePostLoginAutoSync.ts
@@ -1,0 +1,186 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import { canUseTauriEvents } from "../lib/tauri-runtime";
+
+type PostLoginSyncState = "idle" | "starting" | "healthy" | "failed";
+
+interface UsePostLoginAutoSyncOptions {
+  authEvent: string;
+  loginWindowClosedEvent: string;
+  scrapeHealthyEvent: string;
+  scrapeStartFailedEvent: string;
+  hideLoginCommand: string;
+  providerLabel: string;
+  isAuthenticated: () => boolean;
+  onAuthResult: (loggedIn: boolean) => void;
+  runSync: () => Promise<void>;
+}
+
+interface PostLoginAutoSyncState {
+  pending: boolean;
+  status: PostLoginSyncState;
+  message: string | null;
+  cancel: () => void;
+}
+
+function closeDelayMs(): number {
+  return 1_200 + Math.floor(Math.random() * 3_600);
+}
+
+export function usePostLoginAutoSync({
+  authEvent,
+  loginWindowClosedEvent,
+  scrapeHealthyEvent,
+  scrapeStartFailedEvent,
+  hideLoginCommand,
+  providerLabel,
+  isAuthenticated,
+  onAuthResult,
+  runSync,
+}: UsePostLoginAutoSyncOptions): PostLoginAutoSyncState {
+  const [status, setStatus] = useState<PostLoginSyncState>("idle");
+  const [pending, setPending] = useState(false);
+  const pendingRef = useRef(false);
+  const statusRef = useRef<PostLoginSyncState>("idle");
+  const closeTimerRef = useRef<number | null>(null);
+  const runSyncRef = useRef(runSync);
+  const isAuthenticatedRef = useRef(isAuthenticated);
+  const onAuthResultRef = useRef(onAuthResult);
+
+  useEffect(() => {
+    runSyncRef.current = runSync;
+  }, [runSync]);
+
+  useEffect(() => {
+    isAuthenticatedRef.current = isAuthenticated;
+  }, [isAuthenticated]);
+
+  useEffect(() => {
+    onAuthResultRef.current = onAuthResult;
+  }, [onAuthResult]);
+
+  const clearCloseTimer = useCallback(() => {
+    if (closeTimerRef.current === null) return;
+    window.clearTimeout(closeTimerRef.current);
+    closeTimerRef.current = null;
+  }, []);
+
+  const cancel = useCallback(() => {
+    clearCloseTimer();
+    pendingRef.current = false;
+    statusRef.current = "idle";
+    setPending(false);
+    setStatus("idle");
+  }, [clearCloseTimer]);
+
+  const scheduleLoginClose = useCallback(() => {
+    clearCloseTimer();
+    closeTimerRef.current = window.setTimeout(() => {
+      closeTimerRef.current = null;
+      if (!pendingRef.current || !isAuthenticatedRef.current()) return;
+      pendingRef.current = false;
+      statusRef.current = "idle";
+      setPending(false);
+      setStatus("idle");
+      invoke(hideLoginCommand).catch(() => {});
+    }, closeDelayMs());
+  }, [clearCloseTimer, hideLoginCommand]);
+
+  useEffect(() => {
+    return clearCloseTimer;
+  }, [clearCloseTimer]);
+
+  useEffect(() => {
+    if (!canUseTauriEvents()) return;
+
+    const unlisten = listen<{ loggedIn: boolean }>(authEvent, (event) => {
+      const loggedIn = event.payload.loggedIn;
+      onAuthResultRef.current(loggedIn);
+      clearCloseTimer();
+
+      if (!loggedIn) {
+        pendingRef.current = false;
+        statusRef.current = "idle";
+        setPending(false);
+        setStatus("idle");
+        return;
+      }
+
+      pendingRef.current = true;
+      statusRef.current = "starting";
+      setPending(true);
+      setStatus("starting");
+      void runSyncRef.current().then(() => {
+        if (!pendingRef.current || statusRef.current === "healthy") return;
+        statusRef.current = "failed";
+        setStatus("failed");
+      }).catch(() => {
+        if (!pendingRef.current) return;
+        statusRef.current = "failed";
+        setStatus("failed");
+      });
+    });
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, [authEvent, clearCloseTimer]);
+
+  useEffect(() => {
+    if (!canUseTauriEvents()) return;
+
+    const unlisten = listen<{ closed: boolean }>(loginWindowClosedEvent, (event) => {
+      if (!event.payload.closed) return;
+      cancel();
+    });
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, [cancel, loginWindowClosedEvent]);
+
+  useEffect(() => {
+    if (!canUseTauriEvents()) return;
+
+    const unlisten = listen(scrapeHealthyEvent, () => {
+      if (!pendingRef.current || !isAuthenticatedRef.current()) return;
+      statusRef.current = "healthy";
+      setStatus("healthy");
+      scheduleLoginClose();
+    });
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, [scheduleLoginClose, scrapeHealthyEvent]);
+
+  useEffect(() => {
+    if (!canUseTauriEvents()) return;
+
+    const unlisten = listen(scrapeStartFailedEvent, () => {
+      if (!pendingRef.current) return;
+      clearCloseTimer();
+      statusRef.current = "failed";
+      setStatus("failed");
+    });
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, [clearCloseTimer, scrapeStartFailedEvent]);
+
+  const message = (() => {
+    if (!pending) return null;
+    if (status === "failed") {
+      return `Connected, but sync did not start. Finish any ${providerLabel} prompts, then close the login window or click Sync Now.`;
+    }
+    if (status === "healthy") {
+      return `Connected. Sync started. Finish any ${providerLabel} prompts while Freed closes the login window.`;
+    }
+    return `Connected. Starting sync. Finish any ${providerLabel} prompts while Freed checks the session.`;
+  })();
+
+  return {
+    pending,
+    status,
+    message,
+    cancel,
+  };
+}

--- a/packages/desktop/src/lib/tauri-runtime.ts
+++ b/packages/desktop/src/lib/tauri-runtime.ts
@@ -1,0 +1,7 @@
+import { isTauri } from "@tauri-apps/api/core";
+
+export function canUseTauriEvents(): boolean {
+  if (isTauri()) return true;
+  if (typeof window === "undefined") return false;
+  return import.meta.env.VITE_TEST_TAURI === "1" || "__TAURI_INTERNALS__" in window;
+}

--- a/packages/desktop/tests/e2e/provider-login-retention.spec.ts
+++ b/packages/desktop/tests/e2e/provider-login-retention.spec.ts
@@ -6,11 +6,15 @@ type ProviderCase = {
   loginButton: string;
   authEvent: string;
   closeEvent: string;
+  healthyEvent: string;
+  failedEvent: string;
   showCommand: string;
   hideCommand: string;
   scrapeCommand: string;
-  promptCopy: string;
-  closeEvidenceText?: string;
+  browserPreviewSyncText?: string;
+  startingCopy: string;
+  healthyCopy: string;
+  failedCopy: string;
 };
 
 const providers: ProviderCase[] = [
@@ -20,10 +24,14 @@ const providers: ProviderCase[] = [
     loginButton: "Log in with Facebook",
     authEvent: "fb-auth-result",
     closeEvent: "fb-login-window-closed",
+    healthyEvent: "fb-scrape-healthy",
+    failedEvent: "fb-scrape-start-failed",
     showCommand: "fb_show_login",
     hideCommand: "fb_hide_login",
     scrapeCommand: "fb_scrape_feed",
-    promptCopy: "Connected. Finish any Facebook prompts, then close the login window.",
+    startingCopy: "Connected. Starting sync. Finish any Facebook prompts while Freed checks the session.",
+    healthyCopy: "Connected. Sync started. Finish any Facebook prompts while Freed closes the login window.",
+    failedCopy: "Connected, but sync did not start. Finish any Facebook prompts, then close the login window or click Sync Now.",
   },
   {
     provider: "instagram",
@@ -31,10 +39,14 @@ const providers: ProviderCase[] = [
     loginButton: "Log in with Instagram",
     authEvent: "ig-auth-result",
     closeEvent: "ig-login-window-closed",
+    healthyEvent: "ig-scrape-healthy",
+    failedEvent: "ig-scrape-start-failed",
     showCommand: "ig_show_login",
     hideCommand: "ig_hide_login",
     scrapeCommand: "ig_scrape_feed",
-    promptCopy: "Connected. Finish any Instagram prompts, then close the login window.",
+    startingCopy: "Connected. Starting sync. Finish any Instagram prompts while Freed checks the session.",
+    healthyCopy: "Connected. Sync started. Finish any Instagram prompts while Freed closes the login window.",
+    failedCopy: "Connected, but sync did not start. Finish any Instagram prompts, then close the login window or click Sync Now.",
   },
   {
     provider: "linkedin",
@@ -42,11 +54,15 @@ const providers: ProviderCase[] = [
     loginButton: "Log in with LinkedIn",
     authEvent: "li-auth-result",
     closeEvent: "li-login-window-closed",
+    healthyEvent: "li-scrape-healthy",
+    failedEvent: "li-scrape-start-failed",
     showCommand: "li_show_login",
     hideCommand: "li_hide_login",
     scrapeCommand: "li_scrape_feed",
-    promptCopy: "Connected. Finish any LinkedIn prompts, then close the login window.",
-    closeEvidenceText: "[LI] browser preview skips native LinkedIn capture",
+    browserPreviewSyncText: "[LI] browser preview skips native LinkedIn capture",
+    startingCopy: "Connected. Starting sync. Finish any LinkedIn prompts while Freed checks the session.",
+    healthyCopy: "Connected. Sync started. Finish any LinkedIn prompts while Freed closes the login window.",
+    failedCopy: "Connected, but sync did not start. Finish any LinkedIn prompts, then close the login window or click Sync Now.",
   },
 ];
 
@@ -94,7 +110,7 @@ async function emitTauriEvent(
 }
 
 for (const providerCase of providers) {
-  test(`${providerCase.label} login stays open after auth and syncs after close`, async ({
+  test(`${providerCase.label} auth starts sync and closes login after healthy scrape`, async ({
     app,
     page,
     ipc,
@@ -111,26 +127,109 @@ for (const providerCase of providers) {
     )).toBe(true);
 
     await emitTauriEvent(page, providerCase.authEvent, { loggedIn: true });
-    await expect(page.getByText(providerCase.promptCopy)).toBeVisible({ timeout: 5_000 });
+    if (providerCase.browserPreviewSyncText) {
+      await emitTauriEvent(page, providerCase.healthyEvent, {
+        provider: providerCase.provider,
+        windowMode: "hidden",
+      });
+    } else {
+      await expect(page.getByText(providerCase.startingCopy)).toBeVisible({ timeout: 5_000 });
+    }
     await expect(page.getByTestId(`provider-sync-action-${providerCase.provider}`)).toBeVisible({
       timeout: 5_000,
     });
 
     const afterAuthInvocations = await ipc.invocations();
     expect(afterAuthInvocations.some((call) => call.cmd === providerCase.hideCommand)).toBe(false);
-    expect(afterAuthInvocations.some((call) => call.cmd === providerCase.scrapeCommand)).toBe(false);
-    if (providerCase.closeEvidenceText) {
-      await expect(page.getByText(providerCase.closeEvidenceText)).toHaveCount(0);
+
+    if (providerCase.browserPreviewSyncText) {
+      await expect(page.getByText(providerCase.browserPreviewSyncText)).toBeVisible({
+        timeout: 5_000,
+      });
+    } else {
+      await expect.poll(async () => {
+        const scrapeCall = (await ipc.invocations()).find(
+          (call) => call.cmd === providerCase.scrapeCommand,
+        );
+        return (scrapeCall?.args as { windowMode?: string } | undefined)?.windowMode;
+      }).toBe("hidden");
     }
 
-    await emitTauriEvent(page, providerCase.closeEvent, { closed: true });
-    if (providerCase.closeEvidenceText) {
-      await expect(page.getByText(providerCase.closeEvidenceText)).toBeVisible({ timeout: 5_000 });
-    } else {
-      await expect.poll(async () => (await ipc.invocations()).some(
-        (call) => call.cmd === providerCase.scrapeCommand,
-      )).toBe(true);
+    if (!providerCase.browserPreviewSyncText) {
+      await emitTauriEvent(page, providerCase.healthyEvent, {
+        provider: providerCase.provider,
+        windowMode: "hidden",
+      });
     }
-    await expect(page.getByText(providerCase.promptCopy)).toBeHidden({ timeout: 5_000 });
+    await expect(page.getByText(providerCase.healthyCopy)).toBeVisible({ timeout: 5_000 });
+    await expect.poll(async () => (await ipc.invocations()).some(
+      (call) => call.cmd === providerCase.hideCommand,
+    ), { timeout: 7_000 }).toBe(true);
+    await expect(page.getByText(providerCase.healthyCopy)).toBeHidden({ timeout: 7_000 });
+  });
+
+  test(`${providerCase.label} failed scrape startup leaves login prompt open`, async ({
+    app,
+    page,
+    ipc,
+  }) => {
+    await app.goto();
+    await app.waitForReady();
+    await ipc.setHandler(providerCase.scrapeCommand, () => null);
+
+    await openSettingsSection(page, providerCase.label);
+    await page.getByText(providerCase.loginButton).click();
+    await app.acceptProviderRiskIfPresent(providerCase.provider);
+    await expect.poll(async () => (await ipc.invocations()).some(
+      (call) => call.cmd === providerCase.showCommand,
+    )).toBe(true);
+
+    await emitTauriEvent(page, providerCase.authEvent, { loggedIn: true });
+    if (providerCase.browserPreviewSyncText) {
+      await expect(page.getByText(providerCase.failedCopy)).toBeVisible({ timeout: 5_000 });
+    } else {
+      await expect(page.getByText(providerCase.startingCopy)).toBeVisible({ timeout: 5_000 });
+    }
+
+    await emitTauriEvent(page, providerCase.failedEvent, {
+      provider: providerCase.provider,
+      windowMode: "hidden",
+      reason: "test failure",
+    });
+    await expect(page.getByText(providerCase.failedCopy)).toBeVisible({ timeout: 5_000 });
+    expect((await ipc.invocations()).some((call) => call.cmd === providerCase.hideCommand)).toBe(false);
+  });
+
+  test(`${providerCase.label} explicit close clears retained login prompt`, async ({
+    app,
+    page,
+    ipc,
+  }) => {
+    await app.goto();
+    await app.waitForReady();
+    await ipc.setHandler(providerCase.scrapeCommand, () => null);
+
+    await openSettingsSection(page, providerCase.label);
+    await page.getByText(providerCase.loginButton).click();
+    await app.acceptProviderRiskIfPresent(providerCase.provider);
+    await expect.poll(async () => (await ipc.invocations()).some(
+      (call) => call.cmd === providerCase.showCommand,
+    )).toBe(true);
+
+    await emitTauriEvent(page, providerCase.authEvent, { loggedIn: true });
+    if (providerCase.browserPreviewSyncText) {
+      await expect(page.getByText(providerCase.failedCopy)).toBeVisible({ timeout: 5_000 });
+    } else {
+      await expect(page.getByText(providerCase.startingCopy)).toBeVisible({ timeout: 5_000 });
+    }
+    await emitTauriEvent(page, providerCase.closeEvent, { closed: true });
+    await expect(page.getByText(
+      providerCase.browserPreviewSyncText ? providerCase.failedCopy : providerCase.startingCopy,
+    )).toBeHidden({ timeout: 5_000 });
+    await emitTauriEvent(page, providerCase.healthyEvent, {
+      provider: providerCase.provider,
+      windowMode: "hidden",
+    });
+    expect((await ipc.invocations()).some((call) => call.cmd === providerCase.hideCommand)).toBe(false);
   });
 }


### PR DESCRIPTION
(AI Generated).

## Summary
- Start Facebook, Instagram, and LinkedIn sync automatically after auth while keeping the provider login window open.
- Close the login window only after native scrape startup reports healthy, using the user's selected scraper window mode.
- Add runtime scrape lifecycle diagnostics for window mode, native visibility and focus, and interaction method.
- Add regression coverage for healthy startup, failed startup, and explicit close paths.

## Tests
- `PATH=/Users/aubreyfalconer/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm run test:e2e -- provider-login-retention.spec.ts`
- `PATH=/Users/aubreyfalconer/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm run validate:feature`
- `cargo check` with a temporary `packages/desktop/dist` directory for Tauri `frontendDist`

## Notes
- Validation was run with bundled Node `v24.14.0`. Homebrew Node 25 currently trips this repo's Vitest localStorage setup before it reaches this patch.