### PR TITLE
perf: stream map location pins

### DIFF
--- a/docs/PHASE-8-FRIENDS.md
+++ b/docs/PHASE-8-FRIENDS.md
@@ -198,7 +198,7 @@ Default nudge intervals by care level:
 ## 8D: Location / Map View
 
 ```
-FeedItems → extractLocationFromItem() + optional time window → geocode() (Nominatim) → cache → MapLibre markers → Friends mode or All content mode → timeline scrubber → derived overlap views
+FeedItems are passed through extractLocationFromItem() plus optional time windows. geocode() resolves Nominatim results into cache-backed location groups. MapLibre markers then power Friends mode, All content mode, the timeline scrubber, and derived overlap views.
 ```
 
 Sources for location: Instagram geo-tags, Facebook check-ins, X geo-tags (rare), text patterns ("📍 Paris"), **and IG/FB story location stickers** (Phase 7.11). Low-confidence story labels are recovered from preserved Instagram location URLs when possible, or dropped when they cannot be trusted. Planned future sources such as Mozi add another class of signal: place windows that may sit in the future instead of the past.
@@ -227,7 +227,7 @@ Sources for location: Instagram geo-tags, Facebook check-ins, X geo-tags (rare),
 ### Files
 
 - `packages/shared/src/location.ts` — `GeoLocation` type, `extractLocationFromItem()`
-- `packages/ui/src/lib/geocoding.ts` — Nominatim integration with 1 req/s rate limiter
+- `packages/ui/src/lib/geocoding.ts`: Nominatim integration with 1 req/s rate limiter, in-memory reuse, and in-flight dedupe
 - `packages/ui/src/lib/geocoding-cache.ts` — IndexedDB cache (30-day TTL for hits, 7-day for misses)
 - `packages/ui/src/hooks/useResolvedLocations.ts` — shared async location resolution for map and friend detail
 - `packages/ui/src/components/map/MapView.tsx` — shared MapLibre map view for PWA and Freed Desktop
@@ -239,6 +239,7 @@ Sources for location: Instagram geo-tags, Facebook check-ins, X geo-tags (rare),
 - `packages/ui/src/components/Toast.tsx` — shared success/error feedback for sample refresh and other cross-shell actions
 
 `maplibre-gl` now lives in `@freed/ui` so both PWA and Freed Desktop use the same map runtime. The shared surface now uses theme-native cartography, not a one-size-fits-none filter pass, so each theme gets its own land, water, boundary, and label palette while the avatars stay readable.
+Named location resolution now groups identical place labels and streams each resolved group into the map as soon as it returns, so cached pins no longer wait behind slower uncached geocoding requests.
 Sample data batches now append friend-linked LinkedIn posts too, so repeated populates keep expanding the social graph instead of reseeding the same tiny cast.
 New sample data batches now carry an internal cleanup marker on generated feeds, items, people, and accounts, so the app can clear sample records without guessing from names or URLs.
 Friends and Map now use the same shared content header pattern as the rest of the app, instead of shipping bespoke top bars that wander off into their own little kingdoms.

--- a/packages/ui/src/hooks/useResolvedLocations.test.tsx
+++ b/packages/ui/src/hooks/useResolvedLocations.test.tsx
@@ -1,0 +1,170 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act, useEffect } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import type { Account, FeedItem, Person } from "@freed/shared";
+import { useResolvedLocations } from "./useResolvedLocations";
+
+const geocodeMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../lib/geocoding.js", () => ({
+  geocode: geocodeMock,
+}));
+
+type ResolvedLocationsSnapshot = ReturnType<typeof useResolvedLocations>;
+
+function makeItem(
+  globalId: string,
+  name: string,
+  publishedAt: number,
+  authorId: string = globalId,
+): FeedItem {
+  return {
+    globalId,
+    platform: "instagram",
+    contentType: "post",
+    capturedAt: publishedAt,
+    publishedAt,
+    author: {
+      id: authorId,
+      handle: authorId,
+      displayName: `Author ${authorId}`,
+    },
+    content: {
+      text: `Post from ${name}`,
+      mediaUrls: [],
+      mediaTypes: [],
+    },
+    location: {
+      name,
+      source: "geo_tag",
+    },
+    userState: {
+      hidden: false,
+      saved: false,
+      archived: false,
+      tags: [],
+    },
+    topics: [],
+  };
+}
+
+function ResolvedLocationsHarness({
+  accounts,
+  items,
+  onSnapshot,
+  persons,
+}: {
+  accounts: Record<string, Account>;
+  items: FeedItem[];
+  onSnapshot: (snapshot: ResolvedLocationsSnapshot) => void;
+  persons: Record<string, Person>;
+}) {
+  const snapshot = useResolvedLocations(items, persons, accounts);
+
+  useEffect(() => {
+    onSnapshot(snapshot);
+  }, [onSnapshot, snapshot]);
+
+  return null;
+}
+
+describe("useResolvedLocations", () => {
+  let container: HTMLDivElement | null = null;
+  let root: Root | null = null;
+
+  beforeAll(() => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  afterAll(() => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = false;
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root?.unmount();
+    });
+    container?.remove();
+    root = null;
+    container = null;
+    geocodeMock.mockReset();
+  });
+
+  it("streams resolved named locations without waiting for the slowest geocode", async () => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    let resolveLondon: ((value: { latitude: number; longitude: number; name: string }) => void) | null = null;
+    geocodeMock.mockImplementation((query: string) => {
+      if (query === "Paris") {
+        return Promise.resolve({
+          latitude: 48.8566,
+          longitude: 2.3522,
+          name: "Paris, France",
+        });
+      }
+
+      if (query === "London") {
+        return new Promise((resolve) => {
+          resolveLondon = resolve;
+        });
+      }
+
+      return Promise.resolve(null);
+    });
+
+    const snapshots: ResolvedLocationsSnapshot[] = [];
+    const items = [
+      makeItem("paris-1", "Paris", 300, "ada"),
+      makeItem("paris-2", "Paris", 200, "ada"),
+      makeItem("london-1", "London", 100, "maya"),
+    ];
+
+    await act(async () => {
+      root!.render(
+        <ResolvedLocationsHarness
+          accounts={{}}
+          items={items}
+          persons={{}}
+          onSnapshot={(snapshot) => snapshots.push(snapshot)}
+        />,
+      );
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const partialSnapshot = snapshots.at(-1)!;
+    expect(geocodeMock).toHaveBeenCalledTimes(2);
+    expect(geocodeMock).toHaveBeenNthCalledWith(1, "Paris");
+    expect(geocodeMock).toHaveBeenNthCalledWith(2, "London");
+    expect(partialSnapshot.resolvedItems.map((resolved) => resolved.item.globalId)).toEqual([
+      "paris-1",
+      "paris-2",
+    ]);
+    expect(partialSnapshot.resolvingCount).toBe(1);
+
+    await act(async () => {
+      resolveLondon?.({
+        latitude: 51.5072,
+        longitude: -0.1276,
+        name: "London, United Kingdom",
+      });
+      await Promise.resolve();
+    });
+
+    const completeSnapshot = snapshots.at(-1)!;
+    expect(completeSnapshot.resolvedItems.map((resolved) => resolved.item.globalId).sort()).toEqual([
+      "london-1",
+      "paris-1",
+      "paris-2",
+    ]);
+    expect(completeSnapshot.resolvingCount).toBe(0);
+    expect(completeSnapshot.lastResolvedAt).toEqual(expect.any(Number));
+  });
+});

--- a/packages/ui/src/hooks/useResolvedLocations.ts
+++ b/packages/ui/src/hooks/useResolvedLocations.ts
@@ -36,11 +36,40 @@ interface NamedLocationRequest {
   name: string;
 }
 
+interface NamedLocationGroup {
+  name: string;
+  requests: NamedLocationRequest[];
+}
+
 const EMPTY_STATE: ResolvedLocationsCacheState = {
   resolvedItems: [],
   lastResolvedAt: null,
   resolvingCount: 0,
 };
+
+function namedLocationKey(name: string): string {
+  return name.trim().toLowerCase();
+}
+
+function groupNamedLocationRequests(requests: NamedLocationRequest[]): NamedLocationGroup[] {
+  const groups = new Map<string, NamedLocationGroup>();
+
+  for (const request of requests) {
+    const key = namedLocationKey(request.name);
+    const existing = groups.get(key);
+    if (existing) {
+      existing.requests.push(request);
+      continue;
+    }
+
+    groups.set(key, {
+      name: request.name,
+      requests: [request],
+    });
+  }
+
+  return Array.from(groups.values());
+}
 
 export function useResolvedLocations(
   feedItems: FeedItem[],
@@ -92,7 +121,8 @@ export function useResolvedLocations(
 
     return {
       coordinateItems,
-      namedRequests,
+      namedGroups: groupNamedLocationRequests(namedRequests),
+      namedRequestCount: namedRequests.length,
     };
   }, [feedItems, personBySourceKey]);
 
@@ -100,7 +130,7 @@ export function useResolvedLocations(
     let cancelled = false;
 
     async function resolveLocations() {
-      if (locationPlan.namedRequests.length === 0) {
+      if (locationPlan.namedRequestCount === 0) {
         setState((current) =>
           current.resolvedItems.length === 0 && current.resolvingCount === 0
             ? current
@@ -113,29 +143,40 @@ export function useResolvedLocations(
         return;
       }
 
-      setState((current) => ({ ...current, resolvingCount: locationPlan.namedRequests.length }));
-
-      const resolvedItems = (await Promise.all(
-        locationPlan.namedRequests.map(({ item, friend, name }) =>
-          geocode(name).then((geo): ResolvedLocationItem | null => {
-            if (!geo) return null;
-            return {
-              item,
-              friend,
-              lat: geo.latitude,
-              lng: geo.longitude,
-              label: geo.name ?? name,
-            };
-          })
-        )
-      )).filter((resolved): resolved is ResolvedLocationItem => resolved !== null);
-      if (cancelled) return;
-
       setState({
-        resolvedItems,
-        resolvingCount: 0,
-        lastResolvedAt: Date.now(),
+        resolvedItems: [],
+        resolvingCount: locationPlan.namedRequestCount,
+        lastResolvedAt: null,
       });
+
+      let remainingCount = locationPlan.namedRequestCount;
+
+      for (const group of locationPlan.namedGroups) {
+        void geocode(group.name).then((geo) => {
+          if (cancelled) return;
+
+          remainingCount = Math.max(0, remainingCount - group.requests.length);
+          const groupResolvedItems: ResolvedLocationItem[] = geo
+            ? group.requests.map(({ item, friend, name }) => ({
+                item,
+                friend,
+                lat: geo.latitude,
+                lng: geo.longitude,
+                label: geo.name ?? name,
+              }))
+            : [];
+          const completedAt = remainingCount === 0 ? Date.now() : null;
+
+          setState((current) => ({
+            resolvedItems:
+              groupResolvedItems.length === 0
+                ? current.resolvedItems
+                : [...current.resolvedItems, ...groupResolvedItems],
+            resolvingCount: remainingCount,
+            lastResolvedAt: completedAt ?? current.lastResolvedAt,
+          }));
+        });
+      }
     }
 
     void resolveLocations();
@@ -143,7 +184,7 @@ export function useResolvedLocations(
     return () => {
       cancelled = true;
     };
-  }, [locationPlan.namedRequests]);
+  }, [locationPlan.namedGroups, locationPlan.namedRequestCount]);
 
   const resolvedItems = useMemo(
     () => [...locationPlan.coordinateItems, ...state.resolvedItems],

--- a/packages/ui/src/lib/geocoding.ts
+++ b/packages/ui/src/lib/geocoding.ts
@@ -5,6 +5,8 @@ const NOMINATIM_URL = "https://nominatim.openstreetmap.org/search";
 const USER_AGENT = "Freed/1.0 (app.freed.wtf)";
 const MIN_INTERVAL_MS = 1100;
 const pendingQueue: Array<() => void> = [];
+const memoryCache = new Map<string, GeoLocation | null>();
+const inFlightRequests = new Map<string, Promise<GeoLocation | null>>();
 let lastRequestAt = 0;
 let draining = false;
 
@@ -53,9 +55,37 @@ function throttledFetch(url: string): Promise<Response> {
 }
 
 export async function geocode(query: string): Promise<GeoLocation | null> {
-  const cached = await getFromCache(query);
-  if (cached !== undefined) return cached;
+  if (memoryCache.has(query)) {
+    return memoryCache.get(query) ?? null;
+  }
 
+  const inFlight = inFlightRequests.get(query);
+  if (inFlight) return inFlight;
+
+  const request = geocodeWithCache(query);
+  inFlightRequests.set(query, request);
+
+  try {
+    const location = await request;
+    return location;
+  } finally {
+    inFlightRequests.delete(query);
+  }
+}
+
+async function geocodeWithCache(query: string): Promise<GeoLocation | null> {
+  const cached = await getFromCache(query);
+  if (cached !== undefined) {
+    memoryCache.set(query, cached);
+    return cached;
+  }
+
+  const location = await geocodeUncached(query);
+  memoryCache.set(query, location);
+  return location;
+}
+
+async function geocodeUncached(query: string): Promise<GeoLocation | null> {
   try {
     const url = `${NOMINATIM_URL}?q=${encodeURIComponent(query)}&format=json&limit=1&addressdetails=1`;
     const res = await throttledFetch(url);


### PR DESCRIPTION
(AI Generated).

## Summary
- Grouped named map locations by place label so duplicate place names resolve once.
- Streamed each resolved location group into the map immediately instead of waiting for the slowest geocode.
- Added in-memory and in-flight geocode reuse.

## Testing
- node node_modules/vitest/vitest.mjs run packages/ui/src/hooks/useResolvedLocations.test.tsx
- npm run validate:feature