### PR TITLE
chore: refresh changelog for v26.6.1702-dev

### DIFF
--- a/release-notes/daily/dev/26.6.17.json
+++ b/release-notes/daily/dev/26.6.17.json
@@ -1,0 +1,14 @@
+{
+  "channel": "dev",
+  "dayKey": "26.6.17",
+  "date": "2026-06-17",
+  "preferredDeck": null,
+  "editorialGuidance": [
+    "Keep the tone concise, professional, and specific.",
+    "Lead with user-facing outcomes, shipping milestones, trust wins, and installability improvements.",
+    "Demote internal cleanup unless it clearly changes the shipped product."
+  ],
+  "pinnedHighlights": [],
+  "editorialNotes": [],
+  "updatedAt": "2026-06-18T05:29:22.823Z"
+}

--- a/release-notes/releases/v26.6.1702-dev.json
+++ b/release-notes/releases/v26.6.1702-dev.json
@@ -1,0 +1,98 @@
+{
+  "tag": "v26.6.1702-dev",
+  "version": "26.6.1702-dev",
+  "channel": "dev",
+  "dayKey": "26.6.17",
+  "approved": true,
+  "editorialNotes": [],
+  "generatedAt": "2026-06-18T05:29:22.821Z",
+  "model": "heuristic",
+  "source": {
+    "channel": "dev",
+    "previousPublishedTag": "v26.6.603-dev",
+    "previousPublishedDayTag": "v26.6.603-dev",
+    "compareRef": "HEAD",
+    "isLatestOfDay": true,
+    "sameDayTagsIncluded": [
+      "v26.6.1702-dev"
+    ],
+    "relatedBuildTags": [
+      "v26.6.1702-dev"
+    ],
+    "prNumbers": [
+      793,
+      795,
+      796,
+      797,
+      799,
+      801,
+      804,
+      806,
+      809,
+      810,
+      811,
+      812,
+      818,
+      819,
+      820,
+      823,
+      826,
+      829,
+      830,
+      831,
+      832,
+      836
+    ],
+    "commitSubjects": [
+      "fix: keep provider login prompts open (#832)",
+      "chore: merge latest dev after v26.6.1701-dev release prep",
+      "release: approve v26.6.1701-dev notes",
+      "perf: stream map location pins (#836)",
+      "release: v26.6.1701-dev",
+      "fix: harden desktop sync recovery",
+      "release: approve v26.6.1700-dev notes",
+      "release: v26.6.1700-dev",
+      "feat: add clipboard save shortcut",
+      "fix: prioritize nightly bug scans over stale peers",
+      "fix: correct nightly bug scan summary parsing (#831)",
+      "fix: ignore generated peer artifacts in nightly planner (#830)",
+      "fix: restore nightly validation regressions (#823)",
+      "chore: reverse integrate v26.6.901 into dev (#829)",
+      "fix: stabilize production validation (#826)",
+      "fix: make safe mutations respond instantly (#809)",
+      "fix: collapse toolbar feed controls",
+      "feat: move activity monitor to top toolbar (#820)",
+      "fix: show cloud sync elapsed status",
+      "fix: keep settings backdrop blurred while scrolling (#819)",
+      "chore: reverse integrate v26.6.805 (#818)",
+      "chore: reverse integrate v26.6.804 (#810)",
+      "fix: align story grid top padding (#811)",
+      "fix: harden PWA sync hydration (#812)",
+      "fix: stabilize PWA Drive merge import (#806)",
+      "fix: restore fullscreen reader drag region (#804)",
+      "chore: reverse integrate v26.6.800 (#801)",
+      "fix: polish mobile menu touch interactions (#799)",
+      "fix: stabilize PWA Google Drive sync recovery (#797)",
+      "fix: relax nightly preflight false blockers (#796)",
+      "chore: reverse integrate v26.6.604 (#795)",
+      "fix: repair PWA Google Drive sync resolution (#793)"
+    ]
+  },
+  "release": {
+    "deck": "Move activity monitor to top toolbar, clipboard save shortcut, and reverse integrate v26.6.901 into dev",
+    "features": [
+      "Move activity monitor to top toolbar",
+      "Clipboard save shortcut"
+    ],
+    "fixes": [
+      "Harden desktop sync recovery",
+      "Show cloud sync elapsed status",
+      "Harden PWA sync hydration",
+      "Repair PWA Google Drive sync resolution"
+    ],
+    "followUps": [
+      "Merge latest dev after v26.6.1701-dev release prep"
+    ]
+  },
+  "releaseBody": "(AI Generated).\n\n## Freed v26.6.1702-dev\n\nMove activity monitor to top toolbar, clipboard save shortcut, and reverse integrate v26.6.901 into dev\n\n### Features\n\n- Move activity monitor to top toolbar\n- Clipboard save shortcut\n\n### Fixes\n\n- Harden desktop sync recovery\n- Show cloud sync elapsed status\n- Harden PWA sync hydration\n- Repair PWA Google Drive sync resolution\n\n### Follow-ups\n\n- Merge latest dev after v26.6.1701-dev release prep\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+}

--- a/release-notes/releases/v26.6.1702-dev.md
+++ b/release-notes/releases/v26.6.1702-dev.md
@@ -1,0 +1,29 @@
+(AI Generated).
+
+## Freed v26.6.1702-dev
+
+Move activity monitor to top toolbar, clipboard save shortcut, and reverse integrate v26.6.901 into dev
+
+### Features
+
+- Move activity monitor to top toolbar
+- Clipboard save shortcut
+
+### Fixes
+
+- Harden desktop sync recovery
+- Show cloud sync elapsed status
+- Harden PWA sync hydration
+- Repair PWA Google Drive sync resolution
+
+### Follow-ups
+
+- Merge latest dev after v26.6.1701-dev release prep
+
+### Downloads
+
+**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  
+**Windows:** `.exe` (NSIS installer)  
+**Linux:** `.AppImage`  
+
+> macOS downloads are signed and notarized for normal Gatekeeper installation.

--- a/website/public/atom.xml
+++ b/website/public/atom.xml
@@ -2,7 +2,7 @@
 <feed xmlns="http://www.w3.org/2005/Atom">
     <id>https://freed.wtf</id>
     <title>Freed Blog</title>
-    <updated>2026-06-09T20:31:19.572Z</updated>
+    <updated>2026-06-18T06:10:45.541Z</updated>
     <generator>https://github.com/jpmonette/feed</generator>
     <author>
         <name>The Freed Team</name>

--- a/website/public/feed.xml
+++ b/website/public/feed.xml
@@ -4,7 +4,7 @@
         <title>Freed Blog</title>
         <link>https://freed.wtf</link>
         <description>Progress reports, technical deep-dives, and philosophical rants about the attention economy. From the team building Freed.</description>
-        <lastBuildDate>Tue, 09 Jun 2026 20:31:19 GMT</lastBuildDate>
+        <lastBuildDate>Thu, 18 Jun 2026 06:10:45 GMT</lastBuildDate>
         <docs>https://validator.w3.org/feed/docs/rss2.html</docs>
         <generator>https://github.com/jpmonette/feed</generator>
         <language>en</language>

--- a/website/src/content/changelog.generated.json
+++ b/website/src/content/changelog.generated.json
@@ -1,5 +1,86 @@
 [
   {
+    "version": "26.6.1702-dev",
+    "tagName": "v26.6.1702-dev",
+    "channel": "dev",
+    "date": "2026-06-18T06:07:29Z",
+    "deck": "Move activity monitor to top toolbar, clipboard save shortcut, and reverse integrate v26.6.901 into dev",
+    "features": [
+      {
+        "text": "Move activity monitor to top toolbar"
+      },
+      {
+        "text": "Clipboard save shortcut"
+      }
+    ],
+    "fixes": [
+      {
+        "text": "Harden desktop sync recovery"
+      },
+      {
+        "text": "Show cloud sync elapsed status"
+      },
+      {
+        "text": "Harden PWA sync hydration"
+      },
+      {
+        "text": "Repair PWA Google Drive sync resolution"
+      }
+    ],
+    "followUps": [
+      {
+        "text": "Merge latest dev after v26.6.1701-dev release prep"
+      }
+    ],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.1702-dev",
+    "prNumbers": [
+      793,
+      795,
+      796,
+      797,
+      799,
+      801,
+      804,
+      806,
+      809,
+      810,
+      811,
+      812,
+      818,
+      819,
+      820,
+      823,
+      826,
+      829,
+      830,
+      831,
+      832,
+      836
+    ],
+    "builds": [
+      "26.6.1700-dev",
+      "26.6.1701-dev",
+      "26.6.1702-dev"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.6.1700-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.1700-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.6.1701-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.1701-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.6.1702-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.1702-dev",
+        "channel": "dev"
+      }
+    ]
+  },
+  {
     "version": "26.6.901",
     "tagName": "v26.6.901",
     "channel": "production",


### PR DESCRIPTION
(AI Generated).

## Summary
- add the v26.6.1702-dev release-note artifacts to www
- regenerate the public changelog snapshot and feeds

## Tests
- npm run build from website