### PR TITLE
fix: enable sync triggers from dev channel

### DIFF
--- a/packages/desktop/src/lib/dev-sync-triggers.test.ts
+++ b/packages/desktop/src/lib/dev-sync-triggers.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const readNativeJsonFile = vi.fn();
 const writeNativeJsonFile = vi.fn();
 const refreshSocialProvider = vi.fn();
+const loadDesktopReleaseChannelState = vi.fn();
 
 vi.mock("@tauri-apps/api/core", () => ({
   isTauri: () => true,
@@ -15,6 +16,10 @@ vi.mock("./native-json-store", () => ({
 
 vi.mock("./capture", () => ({
   refreshSocialProvider,
+}));
+
+vi.mock("./release-channel", () => ({
+  loadDesktopReleaseChannelState,
 }));
 
 vi.mock("./logger", () => ({
@@ -37,6 +42,11 @@ describe("dev sync triggers", () => {
     readNativeJsonFile.mockReset();
     writeNativeJsonFile.mockReset();
     refreshSocialProvider.mockReset();
+    loadDesktopReleaseChannelState.mockReset();
+    loadDesktopReleaseChannelState.mockResolvedValue({
+      selectedChannel: "production",
+      installedChannel: "production",
+    });
   });
 
   afterEach(() => {
@@ -110,5 +120,28 @@ describe("dev sync triggers", () => {
 
     expect(readNativeJsonFile).not.toHaveBeenCalled();
     expect(refreshSocialProvider).not.toHaveBeenCalled();
+  });
+
+  it("runs for installed apps on the dev release channel", async () => {
+    vi.resetModules();
+    loadDesktopReleaseChannelState.mockResolvedValue({
+      selectedChannel: "dev",
+      installedChannel: "production",
+    });
+    readNativeJsonFile.mockResolvedValue({
+      enabled: true,
+      id: "request-3",
+      provider: "facebook",
+    });
+    refreshSocialProvider.mockResolvedValue(undefined);
+
+    const { startDevSyncTriggerPoller } = await import("./dev-sync-triggers");
+
+    const stop = startDevSyncTriggerPoller({ pollMs: 10 });
+    await flushImmediatePoll();
+    stop();
+
+    expect(loadDesktopReleaseChannelState).toHaveBeenCalled();
+    expect(refreshSocialProvider).toHaveBeenCalledWith("facebook");
   });
 });

--- a/packages/desktop/src/lib/dev-sync-triggers.ts
+++ b/packages/desktop/src/lib/dev-sync-triggers.ts
@@ -2,6 +2,7 @@ import { isTauri } from "@tauri-apps/api/core";
 import { log } from "./logger";
 import { readNativeJsonFile, writeNativeJsonFile } from "./native-json-store";
 import { refreshSocialProvider, type RetriableSocialProvider } from "./capture";
+import { loadDesktopReleaseChannelState } from "./release-channel";
 
 const DEV_SYNC_TRIGGER_FILE = "dev-sync-trigger.json";
 const DEV_SYNC_TRIGGER_RESULT_FILE = "dev-sync-trigger-result.json";
@@ -27,6 +28,19 @@ type DevSyncTriggerPollerOptions = {
   pollMs?: number;
 };
 
+async function resolveDevSyncTriggersEnabled(explicit: boolean | undefined): Promise<boolean> {
+  if (explicit !== undefined) return explicit;
+  if (DEV_SYNC_TRIGGERS_ENABLED) return true;
+  if (!isTauri()) return false;
+
+  try {
+    const state = await loadDesktopReleaseChannelState();
+    return state.selectedChannel === "dev" || state.installedChannel === "dev";
+  } catch {
+    return false;
+  }
+}
+
 async function writeResult(
   requestId: string,
   provider: RetriableSocialProvider | null,
@@ -49,17 +63,17 @@ async function writeResult(
 export function startDevSyncTriggerPoller(
   options: DevSyncTriggerPollerOptions = {},
 ): () => void {
-  const enabled = options.enabled ?? DEV_SYNC_TRIGGERS_ENABLED;
-  if (!enabled || !isTauri()) {
-    return () => {};
-  }
-
   let stopped = false;
   let inFlight = false;
   let lastHandledId: string | null = null;
+  let enabledPromise: Promise<boolean> | null = null;
 
   const poll = async () => {
     if (stopped || inFlight) return;
+
+    enabledPromise ??= resolveDevSyncTriggersEnabled(options.enabled);
+    const enabled = await enabledPromise;
+    if (!enabled || !isTauri()) return;
 
     let request: DevSyncTriggerRequest | null = null;
     try {


### PR DESCRIPTION
(AI Generated).

## Summary
- Enable the terminal sync trigger when the installed app is on the dev release channel, even if the Vite compile-time env is absent.
- Keep the explicit trigger override for local soak builds and tests.
- Add unit coverage for the runtime dev-channel gate.

## Why
The `v26.6.1703-dev` build had the trigger workflow env configured, but the installed app did not respond to `dev-sync-trigger.json`. The gate should not rely on a single compile-time path when the app already persists the selected release channel at runtime.

## Validation
- `PATH=/Users/aubreyfalconer/.nvm/versions/node/v24.14.1/bin:$PATH node ../../node_modules/vitest/vitest.mjs run src/lib/dev-sync-triggers.test.ts`
- `PATH=/Users/aubreyfalconer/.nvm/versions/node/v24.14.1/bin:$PATH npm run validate:feature`
