### PR TITLE
fix: initialize desktop sync trigger store

### DIFF
--- a/packages/desktop/src/lib/dev-sync-triggers.test.ts
+++ b/packages/desktop/src/lib/dev-sync-triggers.test.ts
@@ -5,6 +5,8 @@ const writeNativeJsonFile = vi.fn();
 const refreshSocialProvider = vi.fn();
 const loadDesktopReleaseChannelState = vi.fn();
 const getStoreState = vi.fn();
+const initializeStore = vi.fn();
+const hasAcceptedDesktopBundle = vi.fn();
 
 vi.mock("@tauri-apps/api/core", () => ({
   isTauri: () => true,
@@ -23,6 +25,10 @@ vi.mock("./release-channel", () => ({
   loadDesktopReleaseChannelState,
 }));
 
+vi.mock("./legal-consent", () => ({
+  hasAcceptedDesktopBundle,
+}));
+
 vi.mock("./store", () => ({
   useAppStore: {
     getState: getStoreState,
@@ -38,7 +44,7 @@ vi.mock("./logger", () => ({
 }));
 
 async function flushImmediatePoll() {
-  for (let index = 0; index < 5; index += 1) {
+  for (let index = 0; index < 10; index += 1) {
     await Promise.resolve();
   }
 }
@@ -51,6 +57,9 @@ describe("dev sync triggers", () => {
     refreshSocialProvider.mockReset();
     loadDesktopReleaseChannelState.mockReset();
     getStoreState.mockReset();
+    initializeStore.mockReset();
+    hasAcceptedDesktopBundle.mockReset();
+    hasAcceptedDesktopBundle.mockResolvedValue(true);
     getStoreState.mockReturnValue({ isInitialized: true });
     loadDesktopReleaseChannelState.mockResolvedValue({
       selectedChannel: "production",
@@ -132,12 +141,13 @@ describe("dev sync triggers", () => {
     );
   });
 
-  it("waits for startup initialization before running a provider trigger", async () => {
+  it("initializes the store before running a provider trigger", async () => {
     const { installDevSyncTriggerBridge } = await import("./dev-sync-triggers");
     refreshSocialProvider.mockResolvedValue(undefined);
+    initializeStore.mockResolvedValue(undefined);
     getStoreState
-      .mockReturnValueOnce({ isInitialized: false })
-      .mockReturnValueOnce({ isInitialized: false })
+      .mockReturnValueOnce({ isInitialized: false, initialize: initializeStore })
+      .mockReturnValueOnce({ isInitialized: false, initialize: initializeStore })
       .mockReturnValue({ isInitialized: true });
 
     const stop = installDevSyncTriggerBridge();
@@ -145,10 +155,10 @@ describe("dev sync triggers", () => {
       id: "request-native-startup",
       provider: "facebook",
     });
-    await vi.advanceTimersByTimeAsync(500);
     await triggerPromise;
     stop();
 
+    expect(initializeStore).toHaveBeenCalled();
     expect(refreshSocialProvider).toHaveBeenCalledWith("facebook");
     expect(writeNativeJsonFile).toHaveBeenLastCalledWith(
       "dev-sync-trigger-result.json",
@@ -156,6 +166,30 @@ describe("dev sync triggers", () => {
         id: "request-native-startup",
         provider: "facebook",
         status: "completed",
+      }),
+      "dev-sync-trigger",
+    );
+  });
+
+  it("fails before provider traffic when Desktop legal consent is missing", async () => {
+    const { installDevSyncTriggerBridge } = await import("./dev-sync-triggers");
+    hasAcceptedDesktopBundle.mockResolvedValue(false);
+
+    const stop = installDevSyncTriggerBridge();
+    await window.__FREED_RUN_SOCIAL_SYNC__?.({
+      id: "request-native-legal",
+      provider: "facebook",
+    });
+    stop();
+
+    expect(initializeStore).not.toHaveBeenCalled();
+    expect(refreshSocialProvider).not.toHaveBeenCalled();
+    expect(writeNativeJsonFile).toHaveBeenCalledWith(
+      "dev-sync-trigger-result.json",
+      expect.objectContaining({
+        id: "request-native-legal",
+        provider: "facebook",
+        status: "error",
       }),
       "dev-sync-trigger",
     );

--- a/packages/desktop/src/lib/dev-sync-triggers.ts
+++ b/packages/desktop/src/lib/dev-sync-triggers.ts
@@ -2,14 +2,13 @@ import { isTauri } from "@tauri-apps/api/core";
 import { log } from "./logger";
 import { readNativeJsonFile, writeNativeJsonFile } from "./native-json-store";
 import { refreshSocialProvider, type RetriableSocialProvider } from "./capture";
+import { hasAcceptedDesktopBundle } from "./legal-consent";
 import { loadDesktopReleaseChannelState } from "./release-channel";
 import { useAppStore } from "./store";
 
 const DEV_SYNC_TRIGGER_FILE = "dev-sync-trigger.json";
 const DEV_SYNC_TRIGGER_RESULT_FILE = "dev-sync-trigger-result.json";
 const DEV_SYNC_TRIGGER_POLL_MS = 5_000;
-const DEV_SYNC_TRIGGER_READY_TIMEOUT_MS = 120_000;
-const DEV_SYNC_TRIGGER_READY_POLL_MS = 250;
 const DEV_SYNC_TRIGGERS_ENABLED =
   import.meta.env.VITE_ENABLE_DEV_SYNC_TRIGGERS === "1" ||
   import.meta.env.VITE_TEST_TAURI === "1";
@@ -37,18 +36,9 @@ function parseProvider(value: unknown): RetriableSocialProvider | null {
     : null;
 }
 
-function wait(ms: number): Promise<void> {
-  return new Promise((resolve) => window.setTimeout(resolve, ms));
-}
-
-async function waitForInitializedStore(
-  timeoutMs = DEV_SYNC_TRIGGER_READY_TIMEOUT_MS,
-): Promise<boolean> {
-  const startedAt = Date.now();
-  while (Date.now() - startedAt < timeoutMs) {
-    if (useAppStore.getState().isInitialized) return true;
-    await wait(DEV_SYNC_TRIGGER_READY_POLL_MS);
-  }
+async function ensureInitializedStore(): Promise<boolean> {
+  if (useAppStore.getState().isInitialized) return true;
+  await useAppStore.getState().initialize();
   return useAppStore.getState().isInitialized;
 }
 
@@ -107,21 +97,31 @@ async function runDevSyncTrigger(request: DevSyncTriggerBridgeRequest): Promise<
     return;
   }
 
-  const ready = await waitForInitializedStore();
-  if (!ready) {
+  const accepted = await hasAcceptedDesktopBundle();
+  if (!accepted) {
     await writeResult(
       requestId,
       provider,
       "error",
-      "Freed did not finish initializing before the sync trigger timeout.",
+      "Freed Desktop legal consent has not been accepted.",
     );
     return;
   }
 
-  await writeResult(requestId, provider, "started");
-  log.info(`[dev-sync-trigger] starting ${provider} sync request ${requestId}`);
-
   try {
+    const ready = await ensureInitializedStore();
+    if (!ready) {
+      await writeResult(
+        requestId,
+        provider,
+        "error",
+        "Freed did not finish initializing before the sync trigger could run.",
+      );
+      return;
+    }
+
+    await writeResult(requestId, provider, "started");
+    log.info(`[dev-sync-trigger] starting ${provider} sync request ${requestId}`);
     await refreshSocialProvider(provider);
     await writeResult(requestId, provider, "completed");
     log.info(`[dev-sync-trigger] completed ${provider} sync request ${requestId}`);


### PR DESCRIPTION
(AI Generated).

## Summary
- Have terminal sync triggers verify Desktop consent and initialize the app store before invoking the normal provider refresh path.

## Testing
- npm run validate:feature
- node ../../node_modules/vitest/vitest.mjs run src/lib/dev-sync-triggers.test.ts