### PR TITLE
fix: report terminal sync trigger outcomes

### DIFF
--- a/docs/PHASE-5-DESKTOP.md
+++ b/docs/PHASE-5-DESKTOP.md
@@ -337,6 +337,7 @@ export async function captureDomFeed(
 - [x] High-risk background work now waits for healthy renderer startup, active outbox drains, social scrapes, and memory pressure cooldowns before running content fetches, RSS polls, automatic snapshots, cloud uploads, cloud startup downloads, outbox drains, or native social scrapes
 - [x] Installed dev-channel builds can run Facebook, Instagram, and LinkedIn sync soaks from the terminal through a native app-data trigger, without System Events clicks or foreground focus theft
 - [x] Internal desktop soak guidance now treats terminal triggers and the 10 minute timeout path as the required unattended workflow, including generated nightly plans, release soak notes, and handoff prompts
+- [x] Desktop terminal sync triggers now report real provider outcomes, fail zero-post or deferred runs, and ignore stale native timeouts instead of overwriting newer trigger results
 - [x] Renderer recovery now requires both native window visibility and renderer document visibility before treating heartbeat gaps as foreground stalls, so background provider work is not paused by normal hidden WebKit timer throttling
 - [x] Native renderer recovery now marks failed recovery state, requests relaunch, and forces the old process to exit if the main WebView label stays stuck after a destroyed renderer
 - [x] Native relay broadcasts now reuse shared document buffers and stop writing a full snapshot on every live document push, reducing clone pressure during heavy sync churn

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -1420,7 +1420,7 @@ dependencies = [
 
 [[package]]
 name = "freed-desktop"
-version = "26.6.1801"
+version = "26.6.1803"
 dependencies = [
  "base64 0.22.1",
  "criterion",

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -1086,6 +1086,31 @@ fn load_dev_sync_trigger_result_status(data_dir: &Path, id: &str) -> Option<Stri
     (result.id == id).then_some(result.status)
 }
 
+fn is_current_dev_sync_trigger_request(data_dir: &Path, id: &str) -> bool {
+    load_dev_sync_trigger_request(data_dir)
+        .and_then(|request| request.id)
+        .as_deref()
+        == Some(id)
+}
+
+fn write_current_dev_sync_trigger_result(
+    data_dir: &Path,
+    id: &str,
+    provider: Option<&str>,
+    status: &str,
+    detail: Option<&str>,
+) -> bool {
+    if !is_current_dev_sync_trigger_request(data_dir, id) {
+        info!(
+            "[dev-sync-trigger] ignored stale result id={} status={}",
+            id, status
+        );
+        return false;
+    }
+    write_dev_sync_trigger_result(data_dir, id, provider, status, detail);
+    true
+}
+
 fn is_dev_sync_trigger_terminal_status(status: &str) -> bool {
     matches!(status, "completed" | "error" | "ignored")
 }
@@ -1187,7 +1212,7 @@ fn start_dev_sync_trigger_keepalive(app: tauri::AppHandle, data_dir: PathBuf, re
                     "[dev-sync-trigger] renderer keepalive timed out for request {}",
                     request_id
                 );
-                write_dev_sync_trigger_result(
+                write_current_dev_sync_trigger_result(
                     &data_dir,
                     &request_id,
                     None,
@@ -1215,7 +1240,7 @@ fn handle_dev_sync_trigger_result_event(data_dir: &Path, payload: &str) {
         warn!("[dev-sync-trigger] failed to parse renderer result payload");
         return;
     };
-    write_dev_sync_trigger_result(
+    write_current_dev_sync_trigger_result(
         data_dir,
         &result.id,
         result.provider.as_deref(),
@@ -10696,6 +10721,51 @@ mod tests {
         assert!(parsed.get("updatedAt").is_some());
         assert!(is_dev_sync_trigger_terminal_status("completed"));
         assert!(!is_dev_sync_trigger_terminal_status("started"));
+    }
+
+    #[test]
+    fn dev_sync_trigger_stale_results_do_not_replace_current_result() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dev_sync_trigger_path(temp.path()),
+            r#"{"enabled":true,"id":"facebook-new","provider":"facebook"}"#,
+        )
+        .unwrap();
+
+        write_dev_sync_trigger_result(
+            temp.path(),
+            "facebook-new",
+            Some("facebook"),
+            "started",
+            None,
+        );
+
+        assert!(!write_current_dev_sync_trigger_result(
+            temp.path(),
+            "facebook-old",
+            Some("facebook"),
+            "error",
+            Some("Old renderer timeout."),
+        ));
+
+        let raw = std::fs::read_to_string(dev_sync_trigger_result_path(temp.path())).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(parsed["id"], serde_json::json!("facebook-new"));
+        assert_eq!(parsed["status"], serde_json::json!("started"));
+
+        assert!(write_current_dev_sync_trigger_result(
+            temp.path(),
+            "facebook-new",
+            Some("facebook"),
+            "completed",
+            Some("Current request finished."),
+        ));
+
+        let raw = std::fs::read_to_string(dev_sync_trigger_result_path(temp.path())).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(parsed["id"], serde_json::json!("facebook-new"));
+        assert_eq!(parsed["status"], serde_json::json!("completed"));
+        assert_eq!(parsed["detail"], serde_json::json!("Current request finished."));
     }
 
     #[test]

--- a/packages/desktop/src/lib/capture-social-retry.test.ts
+++ b/packages/desktop/src/lib/capture-social-retry.test.ts
@@ -131,4 +131,63 @@ describe("scheduled social capture retries", () => {
       expect.any(Function),
     );
   });
+
+  it("returns success details when Facebook sees posts", async () => {
+    mocks.captureFbFeed.mockResolvedValueOnce({
+      items: [],
+      diag: {
+        errorStage: null,
+        errorMessage: null,
+        postsExtracted: 4,
+        itemsAdded: 0,
+      },
+    });
+
+    const { refreshSocialProvider } = await import("./capture");
+    const result = await refreshSocialProvider("facebook");
+
+    expect(result).toMatchObject({
+      provider: "facebook",
+      status: "success",
+      postsExtracted: 4,
+      itemsAdded: 0,
+    });
+  });
+
+  it("returns empty when Facebook sees no posts", async () => {
+    mocks.captureFbFeed.mockResolvedValueOnce({
+      items: [],
+      diag: {
+        errorStage: null,
+        errorMessage: null,
+        postsExtracted: 0,
+        itemsAdded: 0,
+      },
+    });
+
+    const { refreshSocialProvider } = await import("./capture");
+    const result = await refreshSocialProvider("facebook");
+
+    expect(result).toMatchObject({
+      provider: "facebook",
+      status: "empty",
+      stage: "empty",
+      postsExtracted: 0,
+      itemsAdded: 0,
+    });
+  });
+
+  it("returns ignored when Facebook is not authenticated", async () => {
+    mocks.state.fbAuth = { isAuthenticated: false };
+
+    const { refreshSocialProvider } = await import("./capture");
+    const result = await refreshSocialProvider("facebook");
+
+    expect(mocks.captureFbFeed).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      provider: "facebook",
+      status: "ignored",
+      stage: "auth",
+    });
+  });
 });

--- a/packages/desktop/src/lib/capture.ts
+++ b/packages/desktop/src/lib/capture.ts
@@ -28,6 +28,22 @@ import {
 } from "./rss-refresh-plan";
 import { isRuntimeDeferredStage } from "./social-capture-runtime";
 
+export type SocialProviderRefreshStatus =
+  | "success"
+  | "empty"
+  | "deferred"
+  | "error"
+  | "ignored";
+
+export type SocialProviderRefreshResult = {
+  provider: RetriableSocialProvider;
+  status: SocialProviderRefreshStatus;
+  stage?: string;
+  detail?: string;
+  postsExtracted?: number;
+  itemsAdded?: number;
+};
+
 /**
  * Fetch URL via Tauri backend (bypasses CORS)
  */
@@ -209,10 +225,24 @@ function handleSocialResult(
 
 export async function refreshSocialProvider(
   provider: RetriableSocialProvider,
-): Promise<void> {
-  if (!isTauri() || isProviderPaused(provider)) {
+): Promise<SocialProviderRefreshResult> {
+  if (!isTauri()) {
     clearSocialDeferredRetry(provider);
-    return;
+    return {
+      provider,
+      status: "ignored",
+      detail: "Native provider sync is only available in Freed Desktop.",
+    };
+  }
+
+  if (isProviderPaused(provider)) {
+    clearSocialDeferredRetry(provider);
+    return {
+      provider,
+      status: "ignored",
+      stage: "paused",
+      detail: `${socialDebugLabels[provider]} sync is currently paused.`,
+    };
   }
 
   const store = useAppStore.getState();
@@ -220,19 +250,25 @@ export async function refreshSocialProvider(
     if (provider === "facebook" && store.fbAuth.isAuthenticated) {
       const result = await withProviderSyncing("facebook", () => captureFbFeed());
       handleSocialResult("facebook", result.diag.errorStage);
-      return;
+      return summarizeSocialRefreshResult("facebook", result.diag);
     }
     if (provider === "instagram" && store.igAuth.isAuthenticated) {
       const result = await withProviderSyncing("instagram", () => captureIgFeed());
       handleSocialResult("instagram", result.diag.errorStage);
-      return;
+      return summarizeSocialRefreshResult("instagram", result.diag);
     }
     if (provider === "linkedin" && store.liAuth.isAuthenticated) {
       const result = await withProviderSyncing("linkedin", () => captureLiFeed());
       handleSocialResult("linkedin", result.diag.errorStage);
-      return;
+      return summarizeSocialRefreshResult("linkedin", result.diag);
     }
     clearSocialDeferredRetry(provider);
+    return {
+      provider,
+      status: "ignored",
+      stage: "auth",
+      detail: `${socialDebugLabels[provider]} is not authenticated.`,
+    };
   } catch (error) {
     const msg =
       error instanceof Error
@@ -244,7 +280,59 @@ export async function refreshSocialProvider(
       store.setError(msg);
     }
     clearSocialDeferredRetry(provider);
+    return {
+      provider,
+      status: "error",
+      stage: "exception",
+      detail: msg,
+    };
   }
+}
+
+function summarizeSocialRefreshResult(
+  provider: RetriableSocialProvider,
+  diag: {
+    errorStage?: string | null;
+    errorMessage?: string | null;
+    postsExtracted?: number;
+    itemsAdded?: number;
+  },
+): SocialProviderRefreshResult {
+  const postsExtracted = diag.postsExtracted ?? 0;
+  const itemsAdded = diag.itemsAdded ?? 0;
+
+  if (diag.errorStage) {
+    const runtimeDeferred = isRuntimeDeferredStage(diag.errorStage);
+    return {
+      provider,
+      status: runtimeDeferred ? "deferred" : "error",
+      stage: diag.errorStage,
+      detail:
+        diag.errorMessage ??
+        `${socialDebugLabels[provider]} sync ${runtimeDeferred ? "deferred" : "failed"} at ${diag.errorStage}.`,
+      postsExtracted,
+      itemsAdded,
+    };
+  }
+
+  if (postsExtracted <= 0) {
+    return {
+      provider,
+      status: "empty",
+      stage: "empty",
+      detail: `${socialDebugLabels[provider]} sync returned 0 posts.`,
+      postsExtracted,
+      itemsAdded,
+    };
+  }
+
+  return {
+    provider,
+    status: "success",
+    detail: `${socialDebugLabels[provider]} sync saw ${postsExtracted.toLocaleString()} post${postsExtracted === 1 ? "" : "s"} and added ${itemsAdded.toLocaleString()} item${itemsAdded === 1 ? "" : "s"}.`,
+    postsExtracted,
+    itemsAdded,
+  };
 }
 
 async function refreshEnabledRssFeeds(

--- a/packages/desktop/src/lib/dev-sync-triggers.test.ts
+++ b/packages/desktop/src/lib/dev-sync-triggers.test.ts
@@ -8,6 +8,14 @@ const getStoreState = vi.fn();
 const initializeStore = vi.fn();
 const hasAcceptedDesktopBundle = vi.fn();
 
+const successfulFacebookResult = {
+  provider: "facebook",
+  status: "success",
+  postsExtracted: 3,
+  itemsAdded: 1,
+  detail: "Facebook sync saw 3 posts and added 1 item.",
+} as const;
+
 vi.mock("@tauri-apps/api/core", () => ({
   isTauri: () => true,
 }));
@@ -74,7 +82,7 @@ describe("dev sync triggers", () => {
 
   it("exposes a renderer bridge for native trigger dispatch", async () => {
     const { installDevSyncTriggerBridge } = await import("./dev-sync-triggers");
-    refreshSocialProvider.mockResolvedValue(undefined);
+    refreshSocialProvider.mockResolvedValue(successfulFacebookResult);
 
     const stop = installDevSyncTriggerBridge();
     const runSocialSync = window.__FREED_RUN_SOCIAL_SYNC__;
@@ -102,6 +110,7 @@ describe("dev sync triggers", () => {
         id: "request-native-1",
         provider: "facebook",
         status: "completed",
+        detail: expect.stringContaining("Posts: 3"),
       }),
       "dev-sync-trigger",
     );
@@ -114,7 +123,7 @@ describe("dev sync triggers", () => {
       id: "request-1",
       provider: "facebook",
     });
-    refreshSocialProvider.mockResolvedValue(undefined);
+    refreshSocialProvider.mockResolvedValue(successfulFacebookResult);
 
     const stop = startDevSyncTriggerPoller({ enabled: true, pollMs: 10 });
     await flushImmediatePoll();
@@ -136,6 +145,65 @@ describe("dev sync triggers", () => {
         id: "request-1",
         provider: "facebook",
         status: "completed",
+        detail: expect.stringContaining("Posts: 3"),
+      }),
+      "dev-sync-trigger",
+    );
+  });
+
+  it("treats empty provider results as a failed terminal trigger", async () => {
+    const { installDevSyncTriggerBridge } = await import("./dev-sync-triggers");
+    refreshSocialProvider.mockResolvedValue({
+      provider: "facebook",
+      status: "empty",
+      stage: "empty",
+      postsExtracted: 0,
+      itemsAdded: 0,
+      detail: "Facebook sync returned 0 posts.",
+    });
+
+    const stop = installDevSyncTriggerBridge();
+    await window.__FREED_RUN_SOCIAL_SYNC__?.({
+      id: "request-native-empty",
+      provider: "facebook",
+    });
+    stop();
+
+    expect(writeNativeJsonFile).toHaveBeenLastCalledWith(
+      "dev-sync-trigger-result.json",
+      expect.objectContaining({
+        id: "request-native-empty",
+        provider: "facebook",
+        status: "error",
+        detail: expect.stringContaining("Posts: 0"),
+      }),
+      "dev-sync-trigger",
+    );
+  });
+
+  it("surfaces unauthenticated provider triggers as ignored", async () => {
+    const { installDevSyncTriggerBridge } = await import("./dev-sync-triggers");
+    refreshSocialProvider.mockResolvedValue({
+      provider: "facebook",
+      status: "ignored",
+      stage: "auth",
+      detail: "Facebook is not authenticated.",
+    });
+
+    const stop = installDevSyncTriggerBridge();
+    await window.__FREED_RUN_SOCIAL_SYNC__?.({
+      id: "request-native-auth",
+      provider: "facebook",
+    });
+    stop();
+
+    expect(writeNativeJsonFile).toHaveBeenLastCalledWith(
+      "dev-sync-trigger-result.json",
+      expect.objectContaining({
+        id: "request-native-auth",
+        provider: "facebook",
+        status: "ignored",
+        detail: expect.stringContaining("not authenticated"),
       }),
       "dev-sync-trigger",
     );
@@ -143,7 +211,7 @@ describe("dev sync triggers", () => {
 
   it("initializes the store before running a provider trigger", async () => {
     const { installDevSyncTriggerBridge } = await import("./dev-sync-triggers");
-    refreshSocialProvider.mockResolvedValue(undefined);
+    refreshSocialProvider.mockResolvedValue(successfulFacebookResult);
     initializeStore.mockResolvedValue(undefined);
     getStoreState
       .mockReturnValueOnce({ isInitialized: false, initialize: initializeStore })
@@ -241,7 +309,7 @@ describe("dev sync triggers", () => {
       id: "request-3",
       provider: "facebook",
     });
-    refreshSocialProvider.mockResolvedValue(undefined);
+    refreshSocialProvider.mockResolvedValue(successfulFacebookResult);
 
     const { startDevSyncTriggerPoller } = await import("./dev-sync-triggers");
 

--- a/packages/desktop/src/lib/dev-sync-triggers.ts
+++ b/packages/desktop/src/lib/dev-sync-triggers.ts
@@ -1,7 +1,11 @@
 import { isTauri } from "@tauri-apps/api/core";
 import { log } from "./logger";
 import { readNativeJsonFile, writeNativeJsonFile } from "./native-json-store";
-import { refreshSocialProvider, type RetriableSocialProvider } from "./capture";
+import {
+  refreshSocialProvider,
+  type RetriableSocialProvider,
+  type SocialProviderRefreshResult,
+} from "./capture";
 import { hasAcceptedDesktopBundle } from "./legal-consent";
 import { loadDesktopReleaseChannelState } from "./release-channel";
 import { useAppStore } from "./store";
@@ -122,9 +126,12 @@ async function runDevSyncTrigger(request: DevSyncTriggerBridgeRequest): Promise<
 
     await writeResult(requestId, provider, "started");
     log.info(`[dev-sync-trigger] starting ${provider} sync request ${requestId}`);
-    await refreshSocialProvider(provider);
-    await writeResult(requestId, provider, "completed");
-    log.info(`[dev-sync-trigger] completed ${provider} sync request ${requestId}`);
+    const result = await refreshSocialProvider(provider);
+    const status = mapRefreshResultToTriggerStatus(result);
+    await writeResult(requestId, provider, status, formatRefreshResultDetail(result));
+    log.info(
+      `[dev-sync-trigger] ${provider} sync request ${requestId} finished status=${status} outcome=${result.status}`,
+    );
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     await writeResult(requestId, provider, "error", message);
@@ -132,6 +139,23 @@ async function runDevSyncTrigger(request: DevSyncTriggerBridgeRequest): Promise<
       `[dev-sync-trigger] ${provider} sync request ${requestId} failed: ${message}`,
     );
   }
+}
+
+function mapRefreshResultToTriggerStatus(
+  result: SocialProviderRefreshResult,
+): "completed" | "error" | "ignored" {
+  if (result.status === "success") return "completed";
+  if (result.status === "ignored") return "ignored";
+  return "error";
+}
+
+function formatRefreshResultDetail(result: SocialProviderRefreshResult): string {
+  const counts =
+    result.postsExtracted === undefined
+      ? ""
+      : ` Posts: ${result.postsExtracted.toLocaleString()}. Added: ${(result.itemsAdded ?? 0).toLocaleString()}.`;
+  const stage = result.stage ? ` Stage: ${result.stage}.` : "";
+  return `${result.detail ?? `${result.provider} sync finished with ${result.status}.`}${stage}${counts}`;
 }
 
 export function installDevSyncTriggerBridge(): () => void {


### PR DESCRIPTION
(AI Generated).

## Summary
- Makes terminal provider sync triggers fail on zero-post, deferred, or unauthenticated outcomes instead of reporting a false success, and prevents stale native timeouts from overwriting newer trigger results.

## Testing
- npm run validate:feature
- node ../../node_modules/vitest/vitest.mjs run src/lib/dev-sync-triggers.test.ts src/lib/capture-social-retry.test.ts
- cargo test --manifest-path packages/desktop/src-tauri/Cargo.toml dev_sync_trigger --lib
- npm run build (packages/desktop)