### PR TITLE
fix: filter stale release-note feature repeats

### DIFF
--- a/scripts/prepare-release-notes.mjs
+++ b/scripts/prepare-release-notes.mjs
@@ -13,6 +13,7 @@ import {
   dayDateFromVersion,
   MAX_FEATURES,
   normalizeReleaseText,
+  removePreviousDayFeatureRepeats,
   renderReleaseBody,
   sanitizeReleaseShape,
   summarizeFallbackText,
@@ -1117,13 +1118,20 @@ async function main() {
   }
 
   const draftedRelease = sanitizeReleaseShape(structured?.release ?? cumulativeDraftRelease);
-  const finalRelease = withComputedDeck(
+  const generatedRelease = withComputedDeck(
     context.isLatestOfDay
       ? mergePriorSameDayReleases(draftedRelease, carriedForwardReleases)
       : draftedRelease,
     context,
     existingDaily,
   );
+  const finalRelease = previousDayRelease
+    ? withComputedDeck(
+        removePreviousDayFeatureRepeats(generatedRelease, previousDayRelease),
+        context,
+        existingDaily,
+      )
+    : generatedRelease;
   const validation = validateReleaseShape(finalRelease, {
     earlierReleases: context.isLatestOfDay ? carriedForwardReleases : [],
     previousDayRelease,

--- a/scripts/release-notes-shared.mjs
+++ b/scripts/release-notes-shared.mjs
@@ -909,6 +909,27 @@ function releaseVisibleEntries(release) {
   ].filter((entry) => entry.text);
 }
 
+export function removePreviousDayFeatureRepeats(release, previousDayRelease) {
+  const normalized = sanitizeReleaseShape(release);
+  const previousDayFeatures = previousDayRelease
+    ? dedupeSimilarStrings(coerceReleaseShape(previousDayRelease).features)
+    : [];
+
+  if (previousDayFeatures.length === 0) {
+    return normalized;
+  }
+
+  const isNotPreviousDayFeature = (item) =>
+    !previousDayFeatures.some((feature) => areNearDuplicates(item, feature));
+
+  return sanitizeReleaseShape({
+    ...normalized,
+    features: normalized.features.filter(isNotPreviousDayFeature),
+    fixes: normalized.fixes.filter(isNotPreviousDayFeature),
+    followUps: normalized.followUps.filter(isNotPreviousDayFeature),
+  });
+}
+
 function isCoveredByConsolidation(priorEntry, normalizedRelease) {
   if (priorEntry.kind !== "fix" && priorEntry.kind !== "followUp") {
     return false;
@@ -1052,7 +1073,9 @@ export function validateReleaseShape(release, options = {}) {
   }
 
   if (options.previousDayRelease) {
-    const currentVisibleItems = releaseVisibleItems(normalized);
+    const currentVisibleItems = releaseVisibleEntries(normalized)
+      .filter((entry) => entry.kind !== "deck")
+      .map((entry) => entry.text);
 
     for (const feature of previousDayFeatures) {
       const isRepeated = currentVisibleItems.some((item) =>

--- a/scripts/release-notes-shared.test.mjs
+++ b/scripts/release-notes-shared.test.mjs
@@ -7,6 +7,7 @@ import {
   compareVersionDays,
   coerceReleaseShape,
   dayDateFromVersion,
+  removePreviousDayFeatureRepeats,
   renderReleaseBody,
   validateReleaseShape,
   versionDayKey,
@@ -170,6 +171,65 @@ test("validateReleaseShape does not force stale previous-day features forward", 
           followUps: [],
         },
       ],
+    },
+  );
+
+  assert.equal(result.errors.length, 0);
+});
+
+test("removePreviousDayFeatureRepeats strips generated stale feature repeats", () => {
+  const release = removePreviousDayFeatureRepeats(
+    {
+      deck: "Dev build 1808",
+      features: [
+        "Dev-channel prereleases now include a terminal helper for installed-build sync soaks",
+      ],
+      fixes: [
+        "Renderer recovery now ignores reclaimable WebKit RSS tail while footprint is healthy",
+        "Dev-channel prereleases now include a terminal helper for installed-build sync soaks",
+      ],
+      followUps: [
+        "Terminal trigger docs stay available for unattended soaks",
+      ],
+    },
+    {
+      deck: "Dev-channel prereleases and terminal sync soaks",
+      features: [
+        "Dev-channel prereleases now include a terminal helper for installed-build sync soaks",
+      ],
+      fixes: [],
+      followUps: [],
+    },
+  );
+
+  assert.deepEqual(release.features, []);
+  assert.deepEqual(release.fixes, [
+    "Renderer recovery now ignores reclaimable WebKit RSS tail while footprint is healthy",
+  ]);
+  assert.deepEqual(release.followUps, [
+    "Terminal trigger docs stay available for unattended soaks",
+  ]);
+});
+
+test("validateReleaseShape allows previous-day theme overlap in the deck", () => {
+  const result = validateReleaseShape(
+    {
+      deck: "Dev-channel prereleases and renderer recovery",
+      features: [],
+      fixes: [
+        "Renderer recovery now ignores reclaimable WebKit RSS tail while footprint is healthy",
+      ],
+      followUps: [],
+    },
+    {
+      previousDayRelease: {
+        deck: "Dev-channel prereleases",
+        features: [
+          "Dev-channel prereleases now include a terminal helper for installed-build sync soaks",
+        ],
+        fixes: [],
+        followUps: [],
+      },
     },
   );
 


### PR DESCRIPTION
(AI Generated).

## Summary
- Filter generated latest-of-day release-note sections against previous-day features before validation.
- Allow deck theme overlap while keeping section-level previous-day feature repeats invalid.

## Testing
- node --test scripts/release-notes-shared.test.mjs
- OPENAI_API_KEY= node scripts/prepare-release-notes.mjs 26.6.1808-dev --force