### PR TITLE
fix: dedupe saved reader title and media

### DIFF
--- a/packages/ui/src/components/feed/ReaderView.test.tsx
+++ b/packages/ui/src/components/feed/ReaderView.test.tsx
@@ -73,7 +73,26 @@ const basePlatformConfig = {
   GoogleContactsSettingsContent: null,
 } as unknown as PlatformConfig;
 
-async function renderReaderView(platform: PlatformConfig): Promise<{
+function installLocalStorageMock(): void {
+  const values = new Map<string, string>();
+  Object.defineProperty(window, "localStorage", {
+    configurable: true,
+    value: {
+      getItem: (key: string) => values.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        values.set(key, value);
+      },
+      removeItem: (key: string) => {
+        values.delete(key);
+      },
+      clear: () => {
+        values.clear();
+      },
+    },
+  });
+}
+
+async function renderReaderView(platform: PlatformConfig, item: FeedItemType = makeArticleItem()): Promise<{
   container: HTMLDivElement;
   root: Root;
 }> {
@@ -84,7 +103,7 @@ async function renderReaderView(platform: PlatformConfig): Promise<{
   await act(async () => {
     root.render(
       <PlatformProvider value={platform}>
-        <ReaderView item={makeArticleItem()} onClose={() => {}} />
+        <ReaderView item={item} onClose={() => {}} />
       </PlatformProvider>,
     );
   });
@@ -92,14 +111,23 @@ async function renderReaderView(platform: PlatformConfig): Promise<{
   return { container, root };
 }
 
+async function flushReaderEffects(): Promise<void> {
+  for (let index = 0; index < 4; index += 1) {
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+  }
+}
+
 describe("ReaderView cache-first hydration", () => {
   beforeAll(() => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    installLocalStorageMock();
   });
 
   afterEach(() => {
     document.body.innerHTML = "";
-    localStorage.removeItem("freed.reader.offlineCacheMode");
+    window.localStorage.clear();
     vi.restoreAllMocks();
   });
 
@@ -116,10 +144,7 @@ describe("ReaderView cache-first hydration", () => {
     } as unknown as PlatformConfig;
 
     const { container, root } = await renderReaderView(platform);
-    await act(async () => {
-      await Promise.resolve();
-      await Promise.resolve();
-    });
+    await flushReaderEffects();
 
     expect(container.textContent).toContain("Cached content loaded first.");
     expect(container.textContent).not.toContain("Live content should not load.");
@@ -129,7 +154,7 @@ describe("ReaderView cache-first hydration", () => {
   });
 
   it("keeps live hydration for synced text when the cache mode pins opened items", async () => {
-    localStorage.setItem("freed.reader.offlineCacheMode", "everything_opened");
+    window.localStorage.setItem("freed.reader.offlineCacheMode", "everything_opened");
     Object.defineProperty(window.navigator, "onLine", { configurable: true, value: true });
     const hydrateReaderItem = vi.fn(async () => ({
       html: "<article><p>Pinned live content.</p></article>",
@@ -143,13 +168,54 @@ describe("ReaderView cache-first hydration", () => {
     } as unknown as PlatformConfig;
 
     const { container, root } = await renderReaderView(platform);
-    await act(async () => {
-      await Promise.resolve();
-      await Promise.resolve();
-    });
+    await flushReaderEffects();
 
     expect(container.textContent).toContain("Pinned live content.");
     expect(hydrateReaderItem).toHaveBeenCalledOnce();
+
+    await act(async () => root.unmount());
+  });
+
+  it("uses the article title and lead image once when cached content includes them", async () => {
+    Object.defineProperty(window.navigator, "onLine", { configurable: true, value: true });
+    const platform = {
+      ...basePlatformConfig,
+      getLocalContent: vi.fn(async () => `
+        <article>
+          <h1>Hydrated Article Title</h1>
+          <figure>
+            <img src="https://cdn.example.com/article-hero.jpg" alt="Article hero" />
+          </figure>
+          <p>The full article body appears after the lead media.</p>
+        </article>
+      `),
+      hydrateReaderItem: vi.fn(),
+    } as unknown as PlatformConfig;
+    const item = makeArticleItem({
+      content: {
+        text: "Preview body only.",
+        mediaUrls: ["https://cdn.example.com/preview-card.jpg"],
+        mediaTypes: ["image"],
+        linkPreview: {
+          url: "https://example.com/cached-reader",
+          title: "Preview Card Title",
+          description: "Preview body only.",
+        },
+      },
+    });
+
+    const { container, root } = await renderReaderView(platform, item);
+    await flushReaderEffects();
+
+    const article = container.querySelector("[data-testid='reader-article']");
+    expect(article?.querySelector("h1")?.textContent).toBe("Hydrated Article Title");
+    expect(article?.textContent).not.toContain("Preview Card Title");
+    expect(article?.textContent).toContain("The full article body appears after the lead media.");
+
+    const images = Array.from(article?.querySelectorAll("img") ?? []);
+    expect(images).toHaveLength(1);
+    expect(images[0].getAttribute("src")).toBe("https://cdn.example.com/article-hero.jpg");
+    expect(images[0].getAttribute("alt")).toBe("Article hero");
 
     await act(async () => root.unmount());
   });

--- a/packages/ui/src/components/feed/ReaderView.tsx
+++ b/packages/ui/src/components/feed/ReaderView.tsx
@@ -50,6 +50,14 @@ type ContentBlock =
   | { kind: "code"; content: string }
   | { kind: "list"; ordered: boolean; items: string[] };
 
+type ReaderLeadImage = { src: string; alt: string };
+
+type ReaderPresentation = {
+  title: string;
+  leadImage: ReaderLeadImage | null;
+  bodyBlocks: ContentBlock[];
+};
+
 const BLOCK_TAGS = new Set([
   "p", "div", "h1", "h2", "h3", "h4", "h5", "h6",
   "blockquote", "pre", "ul", "ol", "figure", "section",
@@ -191,6 +199,113 @@ function textToBlocks(text: string): ContentBlock[] {
 function htmlToPlainText(html: string): string {
   const doc = new DOMParser().parseFromString(html, "text/html");
   return doc.body.textContent ?? "";
+}
+
+function normalizeReaderText(value: string | null | undefined): string {
+  return (value ?? "").trim().replace(/\s+/g, " ").toLocaleLowerCase();
+}
+
+function normalizeImageSrc(src: string): string {
+  try {
+    const parsed = new URL(src);
+    parsed.hash = "";
+    return parsed.toString();
+  } catch {
+    return src.trim();
+  }
+}
+
+function sameImageSrc(left: string | null | undefined, right: string | null | undefined): boolean {
+  if (!left || !right) return false;
+  return normalizeImageSrc(left) === normalizeImageSrc(right);
+}
+
+function findLeadingTitleIndex(blocks: readonly ContentBlock[]): number | null {
+  for (let index = 0; index < blocks.length; index += 1) {
+    const block = blocks[index];
+    if (block.kind === "heading" && block.level <= 2) return index;
+    if (block.kind === "image") continue;
+    return null;
+  }
+  return null;
+}
+
+function findLeadingImageIndex(blocks: readonly ContentBlock[], titleIndex: number | null): number | null {
+  for (let index = 0; index < blocks.length; index += 1) {
+    if (index === titleIndex) continue;
+    const block = blocks[index];
+    if (block.kind === "image") return index;
+    if (block.kind === "heading" && block.level <= 2) continue;
+    return null;
+  }
+  return null;
+}
+
+function fallbackReaderTitle(item: FeedItemType): string {
+  return item.content.linkPreview?.title || item.content.text?.slice(0, 100) || "Untitled";
+}
+
+function buildReaderPresentation(
+  blocks: readonly ContentBlock[],
+  item: FeedItemType,
+  isStory: boolean,
+): ReaderPresentation {
+  const titleIndex = findLeadingTitleIndex(blocks);
+  const titleBlock = titleIndex === null ? null : blocks[titleIndex];
+  const articleTitle = titleBlock?.kind === "heading" ? titleBlock.content : null;
+  const title = articleTitle || fallbackReaderTitle(item);
+  const titleKey = normalizeReaderText(title);
+
+  const leadingImageIndex = findLeadingImageIndex(blocks, titleIndex);
+  const leadingImageBlock = leadingImageIndex === null ? null : blocks[leadingImageIndex];
+  const articleLeadImage =
+    leadingImageBlock?.kind === "image"
+      ? { src: leadingImageBlock.src, alt: leadingImageBlock.alt }
+      : null;
+  const previewLeadImage = !isStory && item.content.mediaUrls[0]
+    ? { src: item.content.mediaUrls[0], alt: "" }
+    : null;
+  const leadImage = articleLeadImage ?? previewLeadImage;
+
+  const bodyBlocks = blocks.filter((block, index) => {
+    if (
+      index === titleIndex &&
+      block.kind === "heading" &&
+      normalizeReaderText(block.content) === titleKey
+    ) {
+      return false;
+    }
+
+    if (
+      index === leadingImageIndex &&
+      block.kind === "image" &&
+      sameImageSrc(block.src, leadImage?.src)
+    ) {
+      return false;
+    }
+
+    return true;
+  });
+
+  return { title, leadImage, bodyBlocks };
+}
+
+function plainTextFromBlocks(blocks: readonly ContentBlock[]): string {
+  return blocks
+    .flatMap((block) => {
+      switch (block.kind) {
+        case "text":
+        case "heading":
+        case "blockquote":
+        case "code":
+          return [block.content];
+        case "list":
+          return block.items;
+        case "image":
+          return block.caption ? [block.caption] : [];
+      }
+    })
+    .join("\n\n");
 }
 
 // ─── Heading size classes by level ───────────────────────────────────────────
@@ -570,11 +685,16 @@ export function ReaderView({
     return [];
   }, [html, preservedText, item.content.text]);
 
-  // Plain text for focus mode rendering
-  const plainText = useMemo(
-    () => htmlToPlainText(html ?? preservedText ?? item.content.text ?? ""),
-    [html, preservedText, item.content.text],
+  const readerPresentation = useMemo(
+    () => buildReaderPresentation(articleBlocks, item, isStory),
+    [articleBlocks, item, isStory],
   );
+
+  // Plain text for focus mode rendering
+  const plainText = useMemo(() => {
+    const bodyText = plainTextFromBlocks(readerPresentation.bodyBlocks);
+    return bodyText || htmlToPlainText(preservedText ?? item.content.text ?? "");
+  }, [readerPresentation.bodyBlocks, preservedText, item.content.text]);
 
   useEffect(() => {
     if (inline) return;
@@ -775,7 +895,7 @@ export function ReaderView({
           </div>
 
           <h1 className="theme-display-large text-2xl sm:text-3xl font-bold mb-4 leading-tight">
-            {item.content.linkPreview?.title || item.content.text?.slice(0, 100)}
+            {readerPresentation.title}
           </h1>
 
           {articleUrl && (
@@ -796,10 +916,10 @@ export function ReaderView({
         {/* Media */}
         {isStory && displayMediaUrls.length > 0 ? (
           <StoryMediaGallery urls={displayMediaUrls} types={displayMediaTypes} />
-        ) : !isStory && item.content.mediaUrls[0] ? (
+        ) : !isStory && readerPresentation.leadImage ? (
           <img
-            src={item.content.mediaUrls[0]}
-            alt=""
+            src={readerPresentation.leadImage.src}
+            alt={readerPresentation.leadImage.alt}
             loading="lazy"
             decoding="async"
             className="mb-8 w-full rounded-xl bg-[var(--theme-bg-muted)] ring-1 ring-[var(--theme-border-subtle)]"
@@ -841,8 +961,8 @@ export function ReaderView({
           <div className="text-lg leading-relaxed text-[var(--theme-text-secondary)]">
             <FocusText text={plainText ?? ""} options={focusOptions} />
           </div>
-        ) : articleBlocks.length > 0 ? (
-          <ArticleContent blocks={articleBlocks} />
+        ) : readerPresentation.bodyBlocks.length > 0 ? (
+          <ArticleContent blocks={readerPresentation.bodyBlocks} />
         ) : (
           <div className="text-lg leading-relaxed text-[var(--theme-text-secondary)]">
             {item.content.text || (


### PR DESCRIPTION
(AI Generated).

## Summary
- Reader view now prefers the hydrated article title and lead image, then removes those lead blocks from the rendered body so saved articles do not show the same title or image twice.

## Testing
- node node_modules/vitest/vitest.mjs run packages/ui/src/components/feed/ReaderView.test.tsx
- npm run validate:feature under Node 24
