### PR TITLE
fix: show latest provider scrape failure

### DIFF
--- a/docs/PHASE-5-DESKTOP.md
+++ b/docs/PHASE-5-DESKTOP.md
@@ -282,7 +282,7 @@ export async function captureDomFeed(
 - [x] Debug panel Health tab charts provider reliability plus daily and hourly pull volume across RSS, X, Facebook, Instagram, LinkedIn, Google Drive, and Dropbox, with an in-card duration dropdown for each provider
 - [x] Failing RSS feeds can be reviewed and unsubscribed from the health panel, with optional article/history deletion
 - [x] Provider status indicators switch to a live spinner while that provider is actively syncing
-- [x] Social provider sections surface a filtered inner scrape log with line-by-line progress while capture is running
+- [x] Social provider sections surface a filtered inner scrape log with line-by-line progress while capture is running, and paused or degraded summaries keep the latest failure reason plus timestamp visible outside the debug panel
 - [x] Settings modal includes an explicit close button in the sidebar on larger screens and at the mobile header edge on small screens
 - [x] Risk dialogs and other central overlay modals stay vertically scrollable on tiny mobile screens so action buttons remain reachable
 - [x] Desktop sync header and source settings surface degraded or paused provider health outside the debug panel

--- a/docs/PHASE-7-SOCIAL-CAPTURE.md
+++ b/docs/PHASE-7-SOCIAL-CAPTURE.md
@@ -211,7 +211,7 @@ const RATE_LIMITS = {
 - [x] Settings Sources nav shows visible right-edge status dots, while the primary Sources sidebar keeps smaller inline status dots after each social provider name
 - [x] Social sync actions show an inline spinner only while that specific provider is actively syncing
 - [x] Social provider status dots switch to a live spinner while that provider is actively syncing
-- [x] Social provider sections include a filtered line-by-line scrape log so users can see what the scraper is doing in real time without expanding the outer Settings view
+- [x] Social provider sections include a filtered line-by-line scrape log so users can see what the scraper is doing in real time without expanding the outer Settings view, and paused or degraded health summaries keep the latest failure reason plus timestamp visible after the live log expires
 - [x] Desktop social scraper commands serialize behind a shared native session lock so background WebKit jobs cannot overlap and starve the main renderer
 - [x] Social memory preflight blocks fan-out across providers when Freed Desktop memory remains high after cleanup
 - [x] Memory-pressure preflight deferrals stay in diagnostics but age out of the current sidebar and source-menu warning state

--- a/packages/desktop/tests/e2e/provider-health.spec.ts
+++ b/packages/desktop/tests/e2e/provider-health.spec.ts
@@ -1073,6 +1073,21 @@ test("cooldown states use a specific label instead of generic attention copy", a
             bytesMoved: 0,
             signalType: "none",
           },
+          {
+            id: "instagram-extract-failure",
+            provider: "instagram",
+            scope: "provider",
+            outcome: "error",
+            stage: "extract",
+            reason: "Extractor saw the login prompt instead of posts.",
+            startedAt: now - 2 * 60_000,
+            finishedAt: now - 90_000,
+            durationMs: 30_000,
+            itemsSeen: 0,
+            itemsAdded: 0,
+            bytesMoved: 0,
+            signalType: "none",
+          },
         ],
         totalSeen7d: 0,
         totalAdded7d: 0,
@@ -1208,6 +1223,8 @@ test("cooldown states use a specific label instead of generic attention copy", a
   await openSettingsSection(page, "Instagram");
 
   await expect(page.getByText("Cooling down").first()).toBeVisible();
+  await expect(page.getByText(/Last failure .* at /)).toBeVisible();
+  await expect(page.getByText("Extractor saw the login prompt instead of posts.")).toBeVisible();
   await expect(page.getByTestId("settings-provider-status-instagram")).toHaveAttribute(
     "title",
     "Cooling down",

--- a/packages/ui/src/components/ProviderHealthSummary.tsx
+++ b/packages/ui/src/components/ProviderHealthSummary.tsx
@@ -182,6 +182,25 @@ function RecentAttemptsList({
   );
 }
 
+function isSuccessfulAttempt(attempt: ProviderHealthAttempt): boolean {
+  return attempt.outcome === "success";
+}
+
+function describeAttemptOutcome(attempt: ProviderHealthAttempt): string {
+  if (attempt.reason) return attempt.reason;
+  if (attempt.outcome === "cooldown") return "Cooling down";
+  if (attempt.outcome === "provider_rate_limit") return "Rate limit detected";
+  if (attempt.outcome === "empty") return "No posts pulled";
+  return "Sync failed";
+}
+
+function latestVisibleIssue(attempts: ProviderHealthAttempt[]): ProviderHealthAttempt | undefined {
+  const directFailure = attempts.find(
+    (attempt) => !isSuccessfulAttempt(attempt) && attempt.outcome !== "cooldown",
+  );
+  return directFailure ?? attempts.find((attempt) => !isSuccessfulAttempt(attempt));
+}
+
 export function ProviderHealthSummary({
   snapshot,
   defaultRange = "daily",
@@ -216,6 +235,13 @@ export function ProviderHealthSummary({
     !!snapshot.currentMessage &&
     snapshot.status !== "healthy" &&
     snapshot.currentMessage !== snapshot.lastError;
+  const latestIssue =
+    snapshot.status === "healthy" ? undefined : latestVisibleIssue(snapshot.latestAttempts);
+  const latestIssueMessage = latestIssue ? describeAttemptOutcome(latestIssue) : undefined;
+  const showCurrentStatusMessage =
+    showMessages && showCurrentMessage && snapshot.currentMessage !== latestIssueMessage;
+  const showLastErrorMessage =
+    showMessages && !!snapshot.lastError && snapshot.lastError !== latestIssueMessage;
 
   const content = (
     <>
@@ -287,16 +313,26 @@ export function ProviderHealthSummary({
         <RecentAttemptsList attempts={snapshot.latestAttempts} />
       )}
 
+      {latestIssue && (
+        <div className="space-y-1 rounded-lg bg-[var(--theme-bg-muted)] px-2 py-2 text-xs">
+          <p className="font-medium text-[var(--theme-text-secondary)]">
+            Last failure {formatHealthRelative(latestIssue.finishedAt)} at{" "}
+            {formatShortClockTime(latestIssue.finishedAt)}
+          </p>
+          <p className="text-amber-400">{latestIssueMessage}</p>
+        </div>
+      )}
+
       {actions && (
         <div className="flex flex-wrap gap-2">
           {actions}
         </div>
       )}
 
-      {showMessages && showCurrentMessage && (
+      {showCurrentStatusMessage && (
         <p className="text-xs text-[var(--theme-text-muted)]">{snapshot.currentMessage}</p>
       )}
-      {showMessages && snapshot.lastError && (
+      {showLastErrorMessage && (
         <p className="text-xs text-amber-400">{snapshot.lastError}</p>
       )}
     </>


### PR DESCRIPTION
(AI Generated).

## Summary
- Show the latest provider scrape failure reason and timestamp in paused or degraded provider summaries.

## Testing
- npm run test:e2e -- provider-health.spec.ts --grep 'cooldown states use a specific label'
- npm run validate:feature