### PR TITLE
fix: restore nightly dev build typing

### DIFF
--- a/packages/desktop/src/lib/social-capture-memory-pressure.test.ts
+++ b/packages/desktop/src/lib/social-capture-memory-pressure.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { BackgroundRuntimeTask } from "./background-runtime-coordinator";
 
 const mocks = vi.hoisted(() => {
   const recordProviderHealthEvent = vi.fn();
@@ -49,7 +50,9 @@ const mocks = vi.hoisted(() => {
     invoke: vi.fn(),
     listen: vi.fn(),
     prepareSocialScrapeMemory: vi.fn(),
-    runBackgroundJob: vi.fn(async <T>(task: { run: () => Promise<T> | T }) => await task.run()),
+    runBackgroundJob: vi.fn(
+      async <T>(task: BackgroundRuntimeTask<T>) => await task.run(),
+    ),
     resetBackgroundRuntimeForTests: vi.fn(),
     recordProviderHealthEvent,
     storeState,
@@ -149,8 +152,8 @@ beforeEach(() => {
   mocks.invoke.mockReset();
   mocks.listen.mockReset();
   mocks.runBackgroundJob.mockReset();
-  mocks.runBackgroundJob.mockImplementation(async <T>(task: { run: () => Promise<T> | T }) =>
-    await task.run(),
+  mocks.runBackgroundJob.mockImplementation(
+    async <T>(task: BackgroundRuntimeTask<T>) => await task.run(),
   );
   mocks.resetBackgroundRuntimeForTests.mockReset();
   mocks.fbPostsToFeedItems.mockClear();


### PR DESCRIPTION
(AI Generated).

## Summary
- type the `runBackgroundJob` mock against the real `BackgroundRuntimeTask` contract
- restore the `packages/desktop/src/lib/social-capture-memory-pressure.test.ts` compile path that broke `dev` Validation after PR #861

## Testing
- node ../../node_modules/vitest/vitest.mjs run src/lib/social-capture-memory-pressure.test.ts
- npm run validate:feature
