### PR TITLE
fix: stabilize social scrape validation

### DIFF
--- a/packages/desktop/src/lib/fb-capture.ts
+++ b/packages/desktop/src/lib/fb-capture.ts
@@ -46,6 +46,7 @@ import {
   socialCaptureDurationMs,
   SOCIAL_SCRAPE_WAIT_FOR_JOB_KINDS,
   SOCIAL_SCRAPE_WAIT_FOR_LOCAL_WORK_MS,
+  waitForSocialScrapeEvents,
 } from "./social-capture-runtime";
 import {
   facebookGroupsFromFeedItems,
@@ -527,7 +528,7 @@ export async function fetchFbFeed(): Promise<FbSyncResult> {
       waitForActiveJobKinds: SOCIAL_SCRAPE_WAIT_FOR_JOB_KINDS,
       run: () => invoke("fb_scrape_feed", { windowMode: getFbScraperWindowMode() }),
     });
-    await new Promise<void>((resolve) => setTimeout(resolve, 500));
+    await waitForSocialScrapeEvents();
   } catch (err) {
     if (!diag.errorStage) {
       if (applyRuntimeDeferredDiag(diag, err)) {

--- a/packages/desktop/src/lib/instagram-capture.ts
+++ b/packages/desktop/src/lib/instagram-capture.ts
@@ -43,6 +43,7 @@ import {
   socialCaptureDurationMs,
   SOCIAL_SCRAPE_WAIT_FOR_JOB_KINDS,
   SOCIAL_SCRAPE_WAIT_FOR_LOCAL_WORK_MS,
+  waitForSocialScrapeEvents,
 } from "./social-capture-runtime";
 
 // =============================================================================
@@ -289,8 +290,7 @@ export async function fetchIgFeed(): Promise<IgSyncResult> {
       run: () => invoke("ig_scrape_feed", { windowMode: getIgScraperWindowMode() }),
     });
 
-    // Brief wait for any in-flight events to arrive after invoke resolves
-    await new Promise<void>((r) => setTimeout(r, 500));
+    await waitForSocialScrapeEvents();
   } catch (err) {
     if (applyRuntimeDeferredDiag(diag, err)) {
       return { items: [], diag };

--- a/packages/desktop/src/lib/social-capture-memory-pressure.test.ts
+++ b/packages/desktop/src/lib/social-capture-memory-pressure.test.ts
@@ -147,6 +147,7 @@ vi.mock("./media-vault", () => ({
 }));
 
 beforeEach(() => {
+  vi.useRealTimers();
   vi.resetModules();
   mocks.resetStoreState();
   mocks.invoke.mockReset();
@@ -716,10 +717,7 @@ describe("social capture completion", () => {
     mocks.invoke.mockResolvedValue(null);
 
     let releaseSemantic: () => void = () => {};
-    mocks.runBackgroundJob.mockImplementation(async <T>(task: {
-      kind: string;
-      run: () => Promise<T> | T;
-    }) => {
+    mocks.runBackgroundJob.mockImplementation(async <T>(task: BackgroundRuntimeTask<T>) => {
       if (task.kind === "semantic-classifier") {
         return await new Promise<T>((resolve) => {
           releaseSemantic = () => resolve(undefined as T);
@@ -882,11 +880,7 @@ describe("social capture completion", () => {
     mocks.listen.mockResolvedValue(vi.fn());
 
     const { BackgroundRuntimeDeferredError } = await import("./background-runtime-coordinator");
-    mocks.runBackgroundJob.mockImplementation(async <T>(task: {
-      kind: string;
-      source: string;
-      run: () => Promise<T> | T;
-    }) => {
+    mocks.runBackgroundJob.mockImplementation(async <T>(task: BackgroundRuntimeTask<T>) => {
       if (task.kind === "social-scrape" && task.source === "instagram:feed") {
         throw new BackgroundRuntimeDeferredError("active:social-scrape:facebook:feed");
       }

--- a/packages/desktop/src/lib/social-capture-runtime.ts
+++ b/packages/desktop/src/lib/social-capture-runtime.ts
@@ -19,6 +19,7 @@ export const SOCIAL_SCRAPE_WAIT_FOR_JOB_KINDS = [
 
 export const RUNTIME_DEFERRED_STAGE = "runtime_deferred";
 export const NATIVE_MEMORY_PRESSURE_STAGE = "memory_pressure";
+const SOCIAL_SCRAPE_EVENT_DRAIN_MS = import.meta.env.MODE === "test" ? 0 : 500;
 
 export interface RuntimeDeferredDiag {
   errorStage: string | null;
@@ -95,4 +96,11 @@ export function socialCaptureDurationMs(startedAtMs: number): number {
 
 export function formatSocialCaptureDuration(ms: number): string {
   return `${ms.toLocaleString()} ms`;
+}
+
+export function waitForSocialScrapeEvents(): Promise<void> {
+  if (SOCIAL_SCRAPE_EVENT_DRAIN_MS <= 0) {
+    return Promise.resolve();
+  }
+  return new Promise((resolve) => setTimeout(resolve, SOCIAL_SCRAPE_EVENT_DRAIN_MS));
 }


### PR DESCRIPTION
(AI Generated).

## Summary
- Fix social scrape test mocks so desktop builds accept the background task signature.
- Skip the post-invoke scrape drain delay in test mode so desktop social-capture tests stop timing out under local load.

## Testing
- npm run build --workspace=packages/desktop
- npm run test:unit --workspace=packages/desktop -- src/lib/social-capture-memory-pressure.test.ts
- npm run test:unit --workspace=packages/desktop -- --maxWorkers=4
- npm run test:e2e:smoke --workspace=packages/desktop -- --grep "launch-time auto-check"
- npm run validate:feature reached root typecheck, then hit local Vitest fork-worker startup timeouts in the desktop unit lane.