### PR TITLE
fix: clean up renderer safe mode sync deferrals

### DIFF
--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -1420,7 +1420,7 @@ dependencies = [
 
 [[package]]
 name = "freed-desktop"
-version = "26.6.1809"
+version = "26.6.1810"
 dependencies = [
  "base64 0.22.1",
  "criterion",

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -2098,10 +2098,10 @@ impl BackgroundRuntimeCoordinator {
 
         if let Some(cooldown_until) = state.cooldown_until {
             if cooldown_until > now {
-                let wait_ms = cooldown_until.duration_since(now).as_millis();
+                let wait = format_duration_for_user(cooldown_until.duration_since(now));
                 return Err(format!(
-                    "background work is cooling down for {} ms after renderer recovery",
-                    wait_ms
+                    "background work is cooling down for {} after renderer recovery",
+                    wait
                 ));
             }
             state.cooldown_until = None;
@@ -2109,14 +2109,14 @@ impl BackgroundRuntimeCoordinator {
 
         if let Some(memory_cooldown_until) = state.memory_cooldown_until {
             if memory_cooldown_until > now {
-                let wait_ms = memory_cooldown_until.duration_since(now).as_millis();
+                let wait = format_duration_for_user(memory_cooldown_until.duration_since(now));
                 let reason = state
                     .last_memory_pressure_reason
                     .as_deref()
                     .unwrap_or("recent memory pressure");
                 return Err(format!(
-                    "background work is cooling down for {} ms after {}",
-                    wait_ms, reason
+                    "background work is cooling down for {} after {}",
+                    wait, reason
                 ));
             }
             state.memory_cooldown_until = None;
@@ -2125,10 +2125,10 @@ impl BackgroundRuntimeCoordinator {
 
         if let Some(safe_mode_until) = state.safe_mode_until {
             if safe_mode_until > now {
-                let wait_ms = safe_mode_until.duration_since(now).as_millis();
+                let wait = format_duration_for_user(safe_mode_until.duration_since(now));
                 return Err(format!(
-                    "background work is paused for {} ms while renderer safe mode is active",
-                    wait_ms
+                    "background work is paused for {} while the app recovers",
+                    wait
                 ));
             }
             state.safe_mode_until = None;
@@ -2818,6 +2818,24 @@ fn format_bytes_for_log(bytes: u64) -> String {
     }
 }
 
+fn format_duration_for_user(duration: Duration) -> String {
+    let total_seconds = duration.as_secs().max(1);
+    if total_seconds < 60 {
+        format!(
+            "{} second{}",
+            total_seconds,
+            if total_seconds == 1 { "" } else { "s" }
+        )
+    } else {
+        let minutes = ((total_seconds + 59) / 60).max(1);
+        format!(
+            "about {} minute{}",
+            minutes,
+            if minutes == 1 { "" } else { "s" }
+        )
+    }
+}
+
 #[cfg(test)]
 mod renderer_watchdog_tests {
     use super::*;
@@ -3427,7 +3445,29 @@ mod renderer_watchdog_tests {
         assert!(safe_mode_remaining_ms.unwrap_or(0) > 0);
         assert_eq!(recoveries_short, 2);
         assert_eq!(recoveries_long, 2);
-        assert!(runtime.begin_job("fb_scrape_feed").is_err());
+        runtime.note_renderer_heartbeat();
+        runtime.note_renderer_heartbeat();
+        let err = runtime.begin_job("fb_scrape_feed").unwrap_err();
+        assert!(err.contains("about 10 minutes"));
+        assert!(err.contains("while the app recovers"));
+        assert!(!err.contains(" ms"));
+        assert!(!err.contains("renderer safe mode"));
+    }
+
+    #[test]
+    fn user_duration_formatter_avoids_raw_milliseconds() {
+        assert_eq!(
+            format_duration_for_user(Duration::from_millis(500)),
+            "1 second"
+        );
+        assert_eq!(
+            format_duration_for_user(Duration::from_secs(42)),
+            "42 seconds"
+        );
+        assert_eq!(
+            format_duration_for_user(Duration::from_millis(487_586)),
+            "about 9 minutes"
+        );
     }
 }
 

--- a/packages/desktop/src/lib/li-capture.ts
+++ b/packages/desktop/src/lib/li-capture.ts
@@ -28,10 +28,15 @@ import {
 import { socialProviderCopy } from "./social-provider-copy";
 import { safeUnlisten } from "./safe-unlisten";
 import {
+  applyRuntimeDeferredDiag,
   applyLockedSessionDeferredDiag,
   applyNativeMemoryPressureDiag,
   isRuntimeDeferredStage,
+  SOCIAL_SCRAPE_WAIT_FOR_JOB_KINDS,
+  SOCIAL_SCRAPE_WAIT_FOR_LOCAL_WORK_MS,
+  waitForSocialScrapeEvents,
 } from "./social-capture-runtime";
+import { runBackgroundJob } from "./background-runtime-coordinator";
 
 // =============================================================================
 // Rate Limiting
@@ -168,10 +173,20 @@ export async function fetchLiFeed(): Promise<LiSyncResult> {
       },
     );
 
-    await invoke("li_scrape_feed", { windowMode: getLiScraperWindowMode() });
-    await new Promise<void>((resolve) => setTimeout(resolve, 500));
+    await runBackgroundJob({
+      kind: "social-scrape",
+      source: "linkedin:feed",
+      timeoutMs: 600_000,
+      waitForActiveJobMs: SOCIAL_SCRAPE_WAIT_FOR_LOCAL_WORK_MS,
+      waitForActiveJobKinds: SOCIAL_SCRAPE_WAIT_FOR_JOB_KINDS,
+      run: () => invoke("li_scrape_feed", { windowMode: getLiScraperWindowMode() }),
+    });
+    await waitForSocialScrapeEvents();
   } catch (err) {
     if (!diag.errorStage) {
+      if (applyRuntimeDeferredDiag(diag, err)) {
+        return { items: [], diag };
+      }
       if (applyNativeMemoryPressureDiag(diag, err, "linkedin")) {
         return { items: [], diag };
       }

--- a/packages/desktop/src/lib/provider-health.test.ts
+++ b/packages/desktop/src/lib/provider-health.test.ts
@@ -541,4 +541,28 @@ describe("provider health", () => {
     expect(provider?.lastError).toBeUndefined();
     expect(provider?.currentMessage).toBeUndefined();
   });
+
+  it("sanitizes active runtime-deferred provider attempts before exposing status", async () => {
+    vi.useFakeTimers();
+    const now = new Date("2026-04-02T19:15:00.000Z");
+    vi.setSystemTime(now);
+
+    const { mod, debugStore } = await loadProviderHealthModule();
+
+    await mod.recordProviderHealthEvent({
+      provider: "linkedin",
+      outcome: "error",
+      stage: "runtime_deferred",
+      reason: "background work is paused for 487586 ms while renderer safe mode is active",
+      finishedAt: now.getTime(),
+    });
+
+    const provider = debugStore.useDebugStore.getState().health?.providers.linkedin;
+    const expected =
+      "Freed paused background work while the app recovers. Try syncing again in a moment.";
+    expect(provider?.status).toBe("degraded");
+    expect(provider?.lastError).toBe(expected);
+    expect(provider?.currentMessage).toBe(expected);
+    expect(provider?.latestAttempts[0]?.reason).toContain("487586 ms");
+  });
 });

--- a/packages/desktop/src/lib/provider-health.ts
+++ b/packages/desktop/src/lib/provider-health.ts
@@ -1,5 +1,6 @@
 import { isTauri } from "@tauri-apps/api/core";
 import { toast } from "@freed/ui/components/Toast";
+import { formatProviderStatusMessage } from "@freed/ui/lib/provider-status";
 import {
   setProviderHealth,
   type HealthDailyBucket,
@@ -832,10 +833,10 @@ function messageFor(providerState: PersistedProviderHealth): string | undefined 
   const latest = latestStatusAttempt(providerState);
   if (!latest) return undefined;
   if (providerState.pause && providerState.pause.pausedUntil > Date.now()) {
-    return providerState.pause.pauseReason;
+    return formatProviderStatusMessage(providerState.pause.pauseReason);
   }
   if (latest.outcome === "success") return undefined;
-  if (latest.reason) return latest.reason;
+  if (latest.reason) return formatProviderStatusMessage(latest.reason);
   if (latest.outcome === "cooldown") return "Cooling down";
   if (latest.outcome === "provider_rate_limit") return "Rate limit detected";
   if (latest.outcome === "empty") return "No posts pulled";
@@ -886,7 +887,7 @@ function snapshotForProvider(providerState: PersistedProviderHealth): ProviderHe
     lastAttemptAt: latestAttempt?.finishedAt,
     lastSuccessfulAt: lastSuccessfulAt(providerState.latestAttempts),
     lastOutcome: latestAttempt?.outcome,
-    lastError: latestWasSuccessful ? undefined : latestAttempt?.reason,
+    lastError: latestWasSuccessful ? undefined : formatProviderStatusMessage(latestAttempt?.reason),
     currentMessage: messageFor(providerState),
     pause: providerState.pause,
     dailyBuckets: providerState.dailyBuckets,

--- a/packages/desktop/src/lib/provider-status-transient.test.ts
+++ b/packages/desktop/src/lib/provider-status-transient.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  formatProviderStatusMessage,
   getProviderStatusDetail,
   getProviderStatusLabel,
   getProviderStatusTone,
@@ -24,6 +25,17 @@ function snapshot(
 }
 
 describe("provider status transient failures", () => {
+  it("formats raw renderer recovery details for user-facing provider copy", () => {
+    expect(
+      formatProviderStatusMessage(
+        "background work is paused for 487586 ms while renderer safe mode is active",
+      ),
+    ).toBe("Freed paused background work while the app recovers. Try syncing again in a moment.");
+    expect(formatProviderStatusMessage("renderer_safe_mode:515828")).toBe(
+      "Freed paused background work while the app recovers. Try syncing again in a moment.",
+    );
+  });
+
   it("does not turn stale memory-pressure auth errors into sidebar warnings", () => {
     const authError =
       "Facebook sync did not start because Freed Desktop memory is high. App RSS is 2.62 GB after cleanup.";
@@ -102,6 +114,20 @@ describe("provider status transient failures", () => {
         }),
       }),
     ).toBe(currentMessage);
+  });
+
+  it("shows app recovery copy instead of raw renderer safe-mode milliseconds", () => {
+    expect(
+      getProviderStatusDetail({
+        isConnected: true,
+        snapshot: snapshot({
+          status: "degraded",
+          lastOutcome: "error",
+          currentMessage:
+            "background work is paused for 515828 ms while renderer safe mode is active",
+        }),
+      }),
+    ).toBe("Freed paused background work while the app recovers. Try syncing again in a moment.");
   });
 
   it("keeps empty social syncs out of the healthy connected state", () => {

--- a/packages/desktop/src/lib/social-capture-memory-pressure.test.ts
+++ b/packages/desktop/src/lib/social-capture-memory-pressure.test.ts
@@ -900,6 +900,40 @@ describe("social capture completion", () => {
     expect(mocks.storeState.setIgAuth).not.toHaveBeenCalled();
     expect(mocks.recordProviderHealthEvent).not.toHaveBeenCalled();
   });
+
+  it("does not poison LinkedIn health when app recovery defers the scrape", async () => {
+    mocks.prepareSocialScrapeMemory.mockResolvedValue({
+      before: {},
+      after: { appResidentBytes: 512 * 1024 * 1024 },
+      recycledScraperWindows: false,
+      cacheTrimmed: false,
+      mayProceed: true,
+    });
+    mocks.listen.mockResolvedValue(vi.fn());
+
+    const { BackgroundRuntimeDeferredError } = await import("./background-runtime-coordinator");
+    mocks.runBackgroundJob.mockImplementation(async <T>(task: BackgroundRuntimeTask<T>) => {
+      if (task.kind === "social-scrape" && task.source === "linkedin:feed") {
+        throw new BackgroundRuntimeDeferredError("renderer_safe_mode:487586");
+      }
+      return await task.run();
+    });
+
+    const { captureLiFeed } = await import("./li-capture");
+    const result = await captureLiFeed();
+
+    expect(result.diag.errorStage).toBe("runtime_deferred");
+    expect(result.diag.errorMessage).toBe(
+      "Freed paused background work while the app recovers. Try syncing again in a moment.",
+    );
+    expect(mocks.invoke).not.toHaveBeenCalledWith("li_scrape_feed", expect.anything());
+    expect(mocks.storeState.setError).toHaveBeenCalledWith(null);
+    expect(mocks.storeState.setError).not.toHaveBeenCalledWith(
+      expect.stringContaining("renderer"),
+    );
+    expect(mocks.storeState.setLiAuth).not.toHaveBeenCalled();
+    expect(mocks.recordProviderHealthEvent).not.toHaveBeenCalled();
+  });
 });
 
 describe("social capture memory pressure gate", () => {

--- a/packages/ui/src/components/ProviderHealthSummary.tsx
+++ b/packages/ui/src/components/ProviderHealthSummary.tsx
@@ -7,7 +7,10 @@ import type {
   ProviderHealthSnapshot,
 } from "../lib/debug-store.js";
 import { formatShortClockTime } from "../lib/date-format.js";
-import { getHealthStatusLabel } from "../lib/provider-status.js";
+import {
+  formatProviderStatusMessage,
+  getHealthStatusLabel,
+} from "../lib/provider-status.js";
 
 export function providerHealthLabel(provider: HealthProviderId): string {
   return {
@@ -187,7 +190,7 @@ function isSuccessfulAttempt(attempt: ProviderHealthAttempt): boolean {
 }
 
 function describeAttemptOutcome(attempt: ProviderHealthAttempt): string {
-  if (attempt.reason) return attempt.reason;
+  if (attempt.reason) return formatProviderStatusMessage(attempt.reason) ?? attempt.reason;
   if (attempt.outcome === "cooldown") return "Cooling down";
   if (attempt.outcome === "provider_rate_limit") return "Rate limit detected";
   if (attempt.outcome === "empty") return "No posts pulled";
@@ -238,10 +241,12 @@ export function ProviderHealthSummary({
   const latestIssue =
     snapshot.status === "healthy" ? undefined : latestVisibleIssue(snapshot.latestAttempts);
   const latestIssueMessage = latestIssue ? describeAttemptOutcome(latestIssue) : undefined;
+  const currentStatusMessage = formatProviderStatusMessage(snapshot.currentMessage);
+  const lastErrorMessage = formatProviderStatusMessage(snapshot.lastError);
   const showCurrentStatusMessage =
-    showMessages && showCurrentMessage && snapshot.currentMessage !== latestIssueMessage;
+    showMessages && showCurrentMessage && currentStatusMessage !== latestIssueMessage;
   const showLastErrorMessage =
-    showMessages && !!snapshot.lastError && snapshot.lastError !== latestIssueMessage;
+    showMessages && !!lastErrorMessage && lastErrorMessage !== latestIssueMessage;
 
   const content = (
     <>
@@ -330,10 +335,10 @@ export function ProviderHealthSummary({
       )}
 
       {showCurrentStatusMessage && (
-        <p className="text-xs text-[var(--theme-text-muted)]">{snapshot.currentMessage}</p>
+        <p className="text-xs text-[var(--theme-text-muted)]">{currentStatusMessage}</p>
       )}
       {showLastErrorMessage && (
-        <p className="text-xs text-amber-400">{snapshot.lastError}</p>
+        <p className="text-xs text-amber-400">{lastErrorMessage}</p>
       )}
     </>
   );

--- a/packages/ui/src/lib/provider-status.ts
+++ b/packages/ui/src/lib/provider-status.ts
@@ -82,6 +82,27 @@ export function isTransientProviderIssue(error?: string | null): boolean {
   return isTransientMemoryPressureIssue(error) || isTransientRuntimeDeferredIssue(error);
 }
 
+export function formatProviderStatusMessage(message?: string | null): string | undefined {
+  if (!message) return undefined;
+  const normalized = message.toLocaleLowerCase();
+
+  if (
+    normalized.includes("renderer_safe_mode") ||
+    normalized.includes("renderer safe mode") ||
+    normalized.includes("background work is paused") ||
+    normalized.includes("background work is cooling down") ||
+    normalized.includes("app recovers")
+  ) {
+    return "Freed paused background work while the app recovers. Try syncing again in a moment.";
+  }
+
+  if (normalized.includes("app window to report healthy")) {
+    return "Freed is waiting for the app window to report healthy. Try syncing again in a moment.";
+  }
+
+  return message;
+}
+
 export function getProviderStatusTone({
   isConnected,
   authError,
@@ -157,7 +178,7 @@ export function getProviderStatusDetail({
   snapshot?: ProviderHealthSnapshot | null;
 }): string | undefined {
   if (snapshot?.currentMessage) {
-    return snapshot.currentMessage;
+    return formatProviderStatusMessage(snapshot.currentMessage);
   }
   const usableAuthError = isTransientProviderIssue(authError)
     ? undefined
@@ -168,11 +189,11 @@ export function getProviderStatusDetail({
   }
 
   if (snapshot?.lastError) {
-    return snapshot.lastError;
+    return formatProviderStatusMessage(snapshot.lastError);
   }
 
   if (usableAuthError) {
-    return usableAuthError;
+    return formatProviderStatusMessage(usableAuthError);
   }
 
   if (snapshot?.status === "healthy" || isConnected) {


### PR DESCRIPTION
(AI Generated).

## Summary
- Sanitizes renderer recovery and safe-mode messages so provider status no longer shows raw millisecond counters or the internal renderer safe-mode label.
- Formats native recovery cooldowns in user-readable time before they can escape through native sync errors.
- Routes LinkedIn feed sync through the same background runtime gate as Instagram so app recovery defers sync without marking LinkedIn or Instagram as failed.

## Testing
- PATH="$HOME/.nvm/versions/node/v24.14.1/bin:$PATH" npm run validate:feature
- cargo test renderer_watchdog_tests
- cargo test background_runtime
- PATH="$HOME/.nvm/versions/node/v24.14.1/bin:$PATH" node ../../node_modules/vitest/vitest.mjs run src/lib/background-runtime-coordinator.test.ts src/lib/provider-status-transient.test.ts src/lib/provider-health.test.ts src/lib/social-capture-memory-pressure.test.ts
