### PR TITLE
fix: stabilize desktop window compositing

### DIFF
--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -8945,6 +8945,14 @@ fn main_window_release_timeout_ms() -> u128 {
 
 #[cfg(target_os = "macos")]
 fn apply_main_window_vibrancy(window: &tauri::WebviewWindow, context: &str) -> bool {
+    if std::env::var("FREED_ENABLE_MAIN_WINDOW_VIBRANCY").ok().as_deref() != Some("1") {
+        info!(
+            "[main-window] vibrancy disabled for stable WebView compositing context={}",
+            context
+        );
+        return false;
+    }
+
     match apply_vibrancy(
         window,
         NSVisualEffectMaterial::UnderWindowBackground,

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -19,7 +19,7 @@
         "height": 800,
         "minWidth": 600,
         "minHeight": 600,
-        "transparent": true,
+        "transparent": false,
         "decorations": true,
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,


### PR DESCRIPTION
(AI Generated).

## Summary
- Keep the main desktop window opaque by default to avoid compositor instability.
- Gate macOS main-window vibrancy behind an explicit environment override for debugging.

## Testing
- npm run validate:feature