### PR TITLE
fix: keep perf comments from failing validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ concurrency:
 
 permissions:
   contents: read
+  issues: write
   pull-requests: write
 
 env:
@@ -117,18 +118,9 @@ jobs:
 
       - name: Comment perf comparison on PR
         if: always() && hashFiles('perf-comparison.md') != ''
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            if (!fs.existsSync('perf-comparison.md')) return;
-            const body = fs.readFileSync('perf-comparison.md', 'utf8');
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request?.number ?? context.issue.number,
-              body: `(AI Generated).\n\n## Performance Benchmark Results\n\n\`\`\`\n${body}\n\`\`\``,
-            });
+        run: node scripts/post-perf-comment.mjs
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Upload perf results
         if: always()

--- a/scripts/post-perf-comment.mjs
+++ b/scripts/post-perf-comment.mjs
@@ -1,0 +1,149 @@
+import fs from "node:fs";
+import { fileURLToPath } from "node:url";
+
+export function buildPerfCommentBody(body) {
+  return `(AI Generated).\n\n## Performance Benchmark Results\n\n\`\`\`\n${body}\n\`\`\``;
+}
+
+export function shouldSkipPerfComment({ eventName, pullRequest, repository }) {
+  if (eventName !== "pull_request") {
+    return "Skipping perf comment because this run is not a pull request.";
+  }
+
+  const issueNumber = pullRequest?.number;
+  if (!Number.isInteger(issueNumber)) {
+    return "Skipping perf comment because the pull request payload did not include a number.";
+  }
+
+  const headRepository = pullRequest?.head?.repo?.full_name;
+  if (headRepository && repository && headRepository !== repository) {
+    return `Skipping perf comment because ${headRepository} does not match ${repository}.`;
+  }
+
+  return null;
+}
+
+export function shouldDowngradeCommentError(status, message = "") {
+  return status === 403 && /resource not accessible by integration/i.test(message);
+}
+
+export async function postPerfComment({
+  owner,
+  repo,
+  issueNumber,
+  token,
+  body,
+  fetchImpl = globalThis.fetch,
+}) {
+  const response = await fetchImpl(
+    `https://api.github.com/repos/${owner}/${repo}/issues/${issueNumber}/comments`,
+    {
+      method: "POST",
+      headers: {
+        accept: "application/vnd.github+json",
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json; charset=utf-8",
+        "user-agent": "freed-perf-comment",
+      },
+      body: JSON.stringify({ body: buildPerfCommentBody(body) }),
+    },
+  );
+
+  if (response.ok) {
+    return;
+  }
+
+  let errorMessage = response.statusText;
+  try {
+    const payload = await response.json();
+    if (typeof payload?.message === "string" && payload.message) {
+      errorMessage = payload.message;
+    }
+  } catch {
+    // Keep the HTTP status text when the body is empty or invalid JSON.
+  }
+
+  const error = new Error(
+    `GitHub perf comment request failed with ${response.status}: ${errorMessage}`,
+  );
+  error.status = response.status;
+  error.responseMessage = errorMessage;
+  throw error;
+}
+
+function appendStepSummary(message) {
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  if (!summaryPath) {
+    return;
+  }
+
+  fs.appendFileSync(summaryPath, `${message}\n`);
+}
+
+function readGitHubEvent(eventPath) {
+  return JSON.parse(fs.readFileSync(eventPath, "utf8"));
+}
+
+async function main() {
+  const comparisonPath = "perf-comparison.md";
+  if (!fs.existsSync(comparisonPath)) {
+    console.log("No perf comparison file found, skipping comment.");
+    return;
+  }
+
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  const eventName = process.env.GITHUB_EVENT_NAME;
+  const repository = process.env.GITHUB_REPOSITORY;
+  const token = process.env.GITHUB_TOKEN;
+
+  if (!eventPath || !fs.existsSync(eventPath)) {
+    console.log("No GitHub event payload found, skipping perf comment.");
+    return;
+  }
+
+  if (!token) {
+    console.log("No GitHub token found, skipping perf comment.");
+    return;
+  }
+
+  const event = readGitHubEvent(eventPath);
+  const skipReason = shouldSkipPerfComment({
+    eventName,
+    pullRequest: event.pull_request,
+    repository,
+  });
+
+  if (skipReason) {
+    console.log(skipReason);
+    appendStepSummary(skipReason);
+    return;
+  }
+
+  const [owner, repo] = String(repository ?? "").split("/");
+  const body = fs.readFileSync(comparisonPath, "utf8");
+
+  try {
+    await postPerfComment({
+      owner,
+      repo,
+      issueNumber: event.pull_request.number,
+      token,
+      body,
+    });
+    const successMessage = `Posted perf comparison comment to PR #${event.pull_request.number}.`;
+    console.log(successMessage);
+    appendStepSummary(successMessage);
+  } catch (error) {
+    if (shouldDowngradeCommentError(error.status, error.responseMessage)) {
+      const warning = `Skipping perf comment after GitHub denied write access: ${error.responseMessage}.`;
+      console.warn(warning);
+      appendStepSummary(warning);
+      return;
+    }
+    throw error;
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  await main();
+}

--- a/scripts/post-perf-comment.test.mjs
+++ b/scripts/post-perf-comment.test.mjs
@@ -1,0 +1,105 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  buildPerfCommentBody,
+  postPerfComment,
+  shouldDowngradeCommentError,
+  shouldSkipPerfComment,
+} from "./post-perf-comment.mjs";
+
+test("shouldSkipPerfComment skips non pull request runs", () => {
+  assert.equal(
+    shouldSkipPerfComment({
+      eventName: "push",
+      pullRequest: { number: 12, head: { repo: { full_name: "freed-project/freed" } } },
+      repository: "freed-project/freed",
+    }),
+    "Skipping perf comment because this run is not a pull request.",
+  );
+});
+
+test("shouldSkipPerfComment skips fork pull requests", () => {
+  assert.equal(
+    shouldSkipPerfComment({
+      eventName: "pull_request",
+      pullRequest: {
+        number: 864,
+        head: { repo: { full_name: "abramclark/freed" } },
+      },
+      repository: "freed-project/freed",
+    }),
+    "Skipping perf comment because abramclark/freed does not match freed-project/freed.",
+  );
+});
+
+test("shouldSkipPerfComment allows same-repo pull requests", () => {
+  assert.equal(
+    shouldSkipPerfComment({
+      eventName: "pull_request",
+      pullRequest: {
+        number: 872,
+        head: { repo: { full_name: "freed-project/freed" } },
+      },
+      repository: "freed-project/freed",
+    }),
+    null,
+  );
+});
+
+test("buildPerfCommentBody preserves the nightly post prefix", () => {
+  assert.equal(
+    buildPerfCommentBody("delta"),
+    "(AI Generated).\n\n## Performance Benchmark Results\n\n```\ndelta\n```",
+  );
+});
+
+test("shouldDowngradeCommentError only downgrades read-only integration failures", () => {
+  assert.equal(shouldDowngradeCommentError(403, "Resource not accessible by integration"), true);
+  assert.equal(shouldDowngradeCommentError(403, "Forbidden"), false);
+  assert.equal(shouldDowngradeCommentError(500, "Resource not accessible by integration"), false);
+});
+
+test("postPerfComment sends an issue comment request", async () => {
+  let request = null;
+  await postPerfComment({
+    owner: "freed-project",
+    repo: "freed",
+    issueNumber: 872,
+    token: "token",
+    body: "delta",
+    fetchImpl: async (url, init) => {
+      request = { url, init };
+      return {
+        ok: true,
+      };
+    },
+  });
+
+  assert.equal(request.url, "https://api.github.com/repos/freed-project/freed/issues/872/comments");
+  assert.equal(request.init.method, "POST");
+  assert.match(request.init.headers.authorization, /^Bearer token$/);
+  assert.equal(
+    JSON.parse(request.init.body).body,
+    "(AI Generated).\n\n## Performance Benchmark Results\n\n```\ndelta\n```",
+  );
+});
+
+test("postPerfComment surfaces GitHub API failures with response details", async () => {
+  await assert.rejects(
+    postPerfComment({
+      owner: "freed-project",
+      repo: "freed",
+      issueNumber: 864,
+      token: "token",
+      body: "delta",
+      fetchImpl: async () => ({
+        ok: false,
+        status: 403,
+        statusText: "Forbidden",
+        json: async () => ({ message: "Resource not accessible by integration" }),
+      }),
+    }),
+    /GitHub perf comment request failed with 403: Resource not accessible by integration/,
+  );
+});


### PR DESCRIPTION
(AI Generated).

## Summary
- move perf comment posting into a small tested script
- skip fork PR comment attempts and downgrade GitHub read-only token errors to summaries
- request issues write permission for same-repo PR comments

## Validation
- node --test scripts/post-perf-comment.test.mjs
- npm run validate:feature