### PR TITLE
perf: defer feed search index preparation

### DIFF
--- a/packages/desktop/src/search-index-lazy.test.ts
+++ b/packages/desktop/src/search-index-lazy.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = join(process.cwd(), "../..");
+const searchFieldSource = readFileSync(
+  join(repoRoot, "packages/ui/src/components/layout/SearchJumpField.tsx"),
+  "utf8",
+);
+const searchHookSource = readFileSync(
+  join(repoRoot, "packages/ui/src/hooks/useSearchResults.ts"),
+  "utf8",
+);
+
+describe("feed search index lifecycle", () => {
+  it("does not prewarm the full search index from an empty search field", () => {
+    expect(searchFieldSource).not.toContain("prepareSearchIndex");
+  });
+
+  it("only builds the full search index after a non-empty query is active", () => {
+    const effectBody = searchHookSource.match(
+      /useEffect\(\(\) => \{[\s\S]*?\n  \}, \[accounts, items, searchCorpusVersion, trimmedQuery\]\);/,
+    )?.[0] ?? "";
+
+    expect(effectBody).toContain("if (!trimmedQuery)");
+    expect(effectBody.indexOf("if (!trimmedQuery)")).toBeLessThan(
+      effectBody.indexOf("prepareSearchIndex(items, searchCorpusVersion, accounts)"),
+    );
+  });
+});

--- a/packages/ui/src/components/layout/SearchJumpField.tsx
+++ b/packages/ui/src/components/layout/SearchJumpField.tsx
@@ -15,7 +15,7 @@ import {
 } from "@freed/shared";
 
 import { useAppStore, usePlatform } from "../../context/PlatformContext.js";
-import { prepareSearchIndex, useSearchResults } from "../../hooks/useSearchResults.js";
+import { useSearchResults } from "../../hooks/useSearchResults.js";
 import { buildCommandPaletteActions } from "../../lib/command-palette-registry.js";
 import {
   filterCommandPaletteActions,
@@ -479,9 +479,6 @@ export function SearchJumpField({
     setConfirmValue("");
     setIsTriggerOpen(false);
   }, []);
-  const prepareSearch = useCallback(() => {
-    void prepareSearchIndex(items, searchCorpusVersion, accounts);
-  }, [accounts, items, searchCorpusVersion]);
   const clearQueryForNavigation = useCallback(() => {
     setSearchQuery("");
     setInputValue("");
@@ -638,7 +635,6 @@ export function SearchJumpField({
       openSavedContentDialog,
       openSettingsTo,
       openUrl,
-      prepareSearch,
       importMarkdown,
       exportMarkdown,
       saveUrl,
@@ -969,7 +965,6 @@ export function SearchJumpField({
                 autoFocus
                 value={inputValue}
                 onChange={(event) => setInputValue(event.target.value)}
-                onFocus={prepareSearch}
                 onKeyDown={handleInputKeyDown}
                 onClear={clearSearch}
                 placeholder="Search or run"
@@ -1067,7 +1062,6 @@ export function SearchJumpField({
             type="button"
             data-testid="compact-sidebar-search-trigger"
             onClick={() => {
-              prepareSearch();
               setIsTriggerOpen((value) => !value);
             }}
             className={compactSidebar
@@ -1120,7 +1114,6 @@ export function SearchJumpField({
         value={inputValue}
         onChange={(event) => setInputValue(event.target.value)}
         onFocus={() => {
-          prepareSearch();
           setIsFocused(true);
         }}
         onBlur={() => {


### PR DESCRIPTION
(AI Generated).

## Summary
- Defers full feed search index construction until the user has typed a non-empty query, avoiding a large empty-search prewarm in the Desktop renderer.

## Testing
- npm run validate:feature