### PR TITLE
fix: restore friends graph lane interactions

### DIFF
--- a/packages/desktop/tests/e2e/theme-switching.spec.ts
+++ b/packages/desktop/tests/e2e/theme-switching.spec.ts
@@ -469,17 +469,20 @@ test("friends graph controls align to the graph lane between sidebars", async ({
       const fitAll = Array.from(document.querySelectorAll("button")).find((button) =>
         button.textContent?.trim() === "Fit all",
       );
+      const controls = document.querySelector('[data-testid="friend-graph-controls"]');
       const sidebar = document.querySelector('[data-testid="app-sidebar"]');
       const handle = document.querySelector('[aria-label="Resize friends sidebar"]');
       const header = document.querySelector("header");
       if (!(graph instanceof HTMLElement)) return null;
       if (!(fitAll instanceof HTMLElement)) return null;
+      if (!(controls instanceof HTMLElement)) return null;
       if (!(sidebar instanceof HTMLElement)) return null;
       if (!(handle instanceof HTMLElement)) return null;
       if (!(header instanceof HTMLElement)) return null;
 
       const graphRect = graph.getBoundingClientRect();
       const fitAllRect = fitAll.getBoundingClientRect();
+      const controlsRect = controls.getBoundingClientRect();
       const sidebarRect = sidebar.getBoundingClientRect();
       const handleRect = handle.getBoundingClientRect();
       const headerRect = header.getBoundingClientRect();
@@ -489,7 +492,7 @@ test("friends graph controls align to the graph lane between sidebars", async ({
         rightGapPx: Math.round(handleRect.left - graphRect.right),
         bottomGapPx: Math.round(window.innerHeight - graphRect.bottom),
         fitAllTopGapPx: Math.round(fitAllRect.top - graphRect.top),
-        fitAllRightGapPx: Math.round(graphRect.right - fitAllRect.right),
+        controlsRightGapPx: Math.round(graphRect.right - controlsRect.right),
       };
     });
   }).toEqual({
@@ -498,6 +501,6 @@ test("friends graph controls align to the graph lane between sidebars", async ({
     rightGapPx: 0,
     bottomGapPx: 0,
     fitAllTopGapPx: 16,
-    fitAllRightGapPx: 16,
+    controlsRightGapPx: 16,
   });
 });

--- a/packages/ui/src/components/friends/FriendGraph.tsx
+++ b/packages/ui/src/components/friends/FriendGraph.tsx
@@ -1965,7 +1965,10 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
           )}
         </div>
       ) : null}
-      <div className="absolute right-4 top-4 z-10 flex items-center gap-2">
+      <div
+        data-testid="friend-graph-controls"
+        className="absolute right-4 top-4 z-10 flex items-center gap-2"
+      >
         <button type="button" className={CONTROL_BASE} onClick={fitAll}>
           Fit all
         </button>

--- a/packages/ui/src/components/friends/FriendsView.tsx
+++ b/packages/ui/src/components/friends/FriendsView.tsx
@@ -1725,32 +1725,30 @@ export function FriendsView({
       >
         {showGraphSurface ? (
           <div className="relative min-h-0 min-w-0 flex-1 overflow-visible">
-            <div className={`absolute inset-y-0 right-0 ${isMobile ? "left-0" : "left-[calc(-1*var(--freed-sidebar-shell-width,0px)-var(--feed-card-gap,8px))]"}`}>
-              {(effectiveMode === "friends" && friendList.length === 0) || (effectiveMode === "all_content" && socialAccountCount === 0 && friendList.length === 0) ? (
-                renderGraphEmptyState()
-              ) : (
-                <FriendGraph
-                  ref={graphRef}
-                  persons={allPersons}
-                  accounts={accounts}
-                  feeds={feeds}
-                  activitySummaries={graphActivitySummaries}
-                  mode={effectiveMode}
-                  selectedPersonId={selectedPerson?.id ?? null}
-                  selectedAccountId={selectedAccount?.id ?? null}
-                  onSelectPerson={(person) => handleSelectPerson(person, false)}
-                  onSelectAccount={(account) => handleSelectAccount(account, false)}
-                  onClearSelection={showCollapsedSelectionCard ? handleClearSelection : undefined}
-                  onLinkAccountToPerson={handleLinkAccountToPerson}
-                  onPinPersonPosition={handlePinPersonPosition}
-                  onPinAccountPosition={handlePinAccountPosition}
-                  onDropNodeToRelationshipTier={handleDropGraphNodeToRelationshipTier}
-                  friendSuggestionStrengthByPerson={friendSuggestionStrengthByPerson}
-                  friendSuggestionStrengthByAccount={friendSuggestionStrengthByAccount}
-                  themeId={themeId}
-                />
-              )}
-            </div>
+            {(effectiveMode === "friends" && friendList.length === 0) || (effectiveMode === "all_content" && socialAccountCount === 0 && friendList.length === 0) ? (
+              renderGraphEmptyState()
+            ) : (
+              <FriendGraph
+                ref={graphRef}
+                persons={allPersons}
+                accounts={accounts}
+                feeds={feeds}
+                activitySummaries={graphActivitySummaries}
+                mode={effectiveMode}
+                selectedPersonId={selectedPerson?.id ?? null}
+                selectedAccountId={selectedAccount?.id ?? null}
+                onSelectPerson={(person) => handleSelectPerson(person, false)}
+                onSelectAccount={(account) => handleSelectAccount(account, false)}
+                onClearSelection={showCollapsedSelectionCard ? handleClearSelection : undefined}
+                onLinkAccountToPerson={handleLinkAccountToPerson}
+                onPinPersonPosition={handlePinPersonPosition}
+                onPinAccountPosition={handlePinAccountPosition}
+                onDropNodeToRelationshipTier={handleDropGraphNodeToRelationshipTier}
+                friendSuggestionStrengthByPerson={friendSuggestionStrengthByPerson}
+                friendSuggestionStrengthByAccount={friendSuggestionStrengthByAccount}
+                themeId={themeId}
+              />
+            )}
           </div>
         ) : null}
 


### PR DESCRIPTION
(AI Generated).

## Summary
- Keeps the Friends graph viewport inside the visible lane so empty-space clicks clear the collapsed selection card again.
- Updates the lane regression to measure the full control cluster now that Copy diagnostics sits to the right of Fit all.

## Testing
- cd packages/desktop && PATH=/Users/aubreyfalconer/.codex/worktrees/ae93/freed/node_modules/.bin:$PATH /Users/aubreyfalconer/.nvm/versions/node/v24.14.1/bin/node ../../node_modules/playwright/cli.js test tests/e2e/smoke.spec.ts tests/e2e/theme-switching.spec.ts --grep "clicking empty graph space closes the collapsed Friends detail card|friends graph controls align to the graph lane between sidebars"
- PATH=/Users/aubreyfalconer/.nvm/versions/node/v24.14.1/bin:$PATH npm run validate:feature -- --changed-files packages/desktop/tests/e2e/theme-switching.spec.ts packages/ui/src/components/friends/FriendGraph.tsx packages/ui/src/components/friends/FriendsView.tsx