### PR TITLE
fix: align desktop titlebar controls

### DIFF
--- a/packages/desktop/tests/e2e/smoke.spec.ts
+++ b/packages/desktop/tests/e2e/smoke.spec.ts
@@ -734,6 +734,29 @@ test("desktop sidebar toggle still clicks normally from the shared toolbar", asy
   await expectDesktopSidebarClosed(page, 3_000);
 });
 
+test("desktop titlebar controls align with the macOS stoplight row", async ({ app, page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await app.goto();
+  await app.waitForReady();
+
+  const geometry = await page.evaluate(() => {
+    const toolbar = document.querySelector('[data-testid="workspace-toolbar"]') as HTMLElement | null;
+    const sidebarToggle = document.querySelector('[data-testid="desktop-sidebar-toggle"]') as HTMLElement | null;
+    if (!toolbar || !sidebarToggle) return null;
+
+    const toolbarRect = toolbar.getBoundingClientRect();
+    const toggleRect = sidebarToggle.getBoundingClientRect();
+    return {
+      toolbarHeight: Math.round(toolbarRect.height),
+      toggleCenterY: Math.round(toggleRect.top + toggleRect.height / 2 - toolbarRect.top),
+    };
+  });
+
+  expect(geometry).not.toBeNull();
+  expect(geometry?.toolbarHeight).toBe(52);
+  expect(geometry?.toggleCenterY).toBe(18);
+});
+
 test("narrow desktop viewports keep the desktop compact rail instead of switching to the mobile drawer", async ({ app, page }) => {
   await page.setViewportSize({ width: 700, height: 900 });
   await app.goto();

--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -46,6 +46,7 @@ import { useCommandSurfaceStore } from "../../lib/command-surface-store.js";
 import { runFeedLayoutTransition } from "../../lib/view-transitions.js";
 import {
   MACOS_TRAFFIC_LIGHT_INSET,
+  MACOS_TRAFFIC_LIGHT_ROW_CENTER_Y,
   useAppStore,
   usePlatform,
 } from "../../context/PlatformContext.js";
@@ -1153,6 +1154,16 @@ export function Header({
     pointerEvents: "auto",
     ...(headerDragRegion ? noDrag : {}),
   } as CSSProperties;
+  const layoutControlCenterlineStyle = headerDragRegion
+    ? ({
+        position: "absolute",
+        top: px(MACOS_TRAFFIC_LIGHT_ROW_CENTER_Y),
+        transform: "translateY(-50%)",
+      } as CSSProperties)
+    : undefined;
+  const layoutControlWrapperClass = headerDragRegion
+    ? "absolute inline-flex"
+    : "absolute top-1/2 inline-flex -translate-y-1/2";
   const toolbarContainerStyle = {
     ...(headerDragRegion ? dragStyle : {}),
     boxSizing: "border-box",
@@ -1473,7 +1484,7 @@ export function Header({
           style={toolbarContainerStyle}
         >
           <div
-            className={`theme-toolbar-cluster theme-toolbar-cluster-tight flex shrink-0 items-center ${isMobileDevice ? "pl-2" : ""}`}
+            className={`theme-toolbar-cluster theme-toolbar-cluster-tight flex h-full shrink-0 items-center ${isMobileDevice ? "pl-2" : ""}`}
           >
             <div
               ref={layoutControlHostRef}
@@ -1515,51 +1526,47 @@ export function Header({
                   className="absolute inset-y-0"
                   style={layoutControlClusterStyle}
                 >
-                  <span
-                    className="absolute top-1/2 inline-flex -translate-y-1/2"
-                    style={sidebarTogglePositionStyle}
+                  <Tooltip
+                    label={desktopSidebarToggleLabel}
+                    className={layoutControlWrapperClass}
+                    triggerStyle={{ ...sidebarTogglePositionStyle, ...layoutControlCenterlineStyle }}
                   >
+                    <button
+                      onClick={onDesktopSidebarToggle}
+                      {...getToolbarControlProps()}
+                      data-testid="desktop-sidebar-toggle"
+                      className={TOOLBAR_READER_LAYOUT_TOGGLE_BUTTON_CLASS}
+                      aria-label={desktopSidebarToggleLabel}
+                    >
+                      {visibleDesktopSidebarMode === "closed" ? (
+                        <SidebarExpandIcon className="h-5 w-5" />
+                      ) : (
+                        <SidebarCollapseIcon className="h-5 w-5" />
+                      )}
+                    </button>
+                  </Tooltip>
+
+                  {showDesktopReaderLayoutToggle ? (
                     <Tooltip
-                      label={desktopSidebarToggleLabel}
+                      label={display.reading.dualColumnMode ? "Hide Previews" : "Show Previews"}
+                      className={layoutControlWrapperClass}
+                      triggerStyle={{ ...previewTogglePositionStyle, ...layoutControlCenterlineStyle }}
                     >
                       <button
-                        onClick={onDesktopSidebarToggle}
+                        ref={handlePreviewToggleButtonRef}
+                        onClick={handleToggleDualColumn}
                         {...getToolbarControlProps()}
-                        data-testid="desktop-sidebar-toggle"
                         className={TOOLBAR_READER_LAYOUT_TOGGLE_BUTTON_CLASS}
-                        aria-label={desktopSidebarToggleLabel}
+                        aria-pressed={display.reading.dualColumnMode}
+                        aria-label={display.reading.dualColumnMode ? "Hide Previews" : "Show Previews"}
                       >
-                        {visibleDesktopSidebarMode === "closed" ? (
-                          <SidebarExpandIcon className="h-5 w-5" />
+                        {display.reading.dualColumnMode ? (
+                          <ReaderRailHideIcon className="h-5 w-5" />
                         ) : (
-                          <SidebarCollapseIcon className="h-5 w-5" />
+                          <ReaderRailShowIcon className="h-5 w-5" />
                         )}
                       </button>
                     </Tooltip>
-                  </span>
-
-                  {showDesktopReaderLayoutToggle ? (
-                    <span
-                      className="absolute top-1/2 inline-flex -translate-y-1/2"
-                      style={previewTogglePositionStyle}
-                    >
-                      <Tooltip label={display.reading.dualColumnMode ? "Hide Previews" : "Show Previews"}>
-                        <button
-                          ref={handlePreviewToggleButtonRef}
-                          onClick={handleToggleDualColumn}
-                          {...getToolbarControlProps()}
-                          className={TOOLBAR_READER_LAYOUT_TOGGLE_BUTTON_CLASS}
-                          aria-pressed={display.reading.dualColumnMode}
-                          aria-label={display.reading.dualColumnMode ? "Hide Previews" : "Show Previews"}
-                        >
-                          {display.reading.dualColumnMode ? (
-                            <ReaderRailHideIcon className="h-5 w-5" />
-                          ) : (
-                            <ReaderRailShowIcon className="h-5 w-5" />
-                          )}
-                        </button>
-                      </Tooltip>
-                    </span>
                   ) : null}
 
                 </div>

--- a/packages/ui/src/context/PlatformContext.tsx
+++ b/packages/ui/src/context/PlatformContext.tsx
@@ -39,6 +39,7 @@ import type { ReaderOfflineCacheMode } from "../lib/reader-cache-settings.js";
  * `headerDragRegion` is true. Apply as `paddingLeft` on the first toolbar row.
  */
 export const MACOS_TRAFFIC_LIGHT_INSET = 100;
+export const MACOS_TRAFFIC_LIGHT_ROW_CENTER_Y = 18;
 
 /**
  * A zustand store hook that can be called with a selector.


### PR DESCRIPTION
(AI Generated).

## Summary
- Aligned the toolbar sidebar and reader layout controls to the macOS stoplight row and added Desktop e2e coverage for the geometry.

## Testing
- PLAYWRIGHT_PORT=14624 npm run test:e2e -- --grep 'desktop (sidebar toggle still clicks normally|titlebar controls align|toolbar controls remain clickable)'
- npm run validate:feature