### PR TITLE
fix: harden Playwright browser install in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,9 @@ jobs:
 
       - name: Install Playwright browsers
         if: steps.feature-plan.outputs.needs_playwright == 'true'
-        run: npx playwright install --with-deps chromium
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/azure-cli.list /etc/apt/sources.list.d/azure-cli.sources
+          npx playwright install --with-deps chromium
         working-directory: packages/desktop
 
       - name: Run feature validation
@@ -168,7 +170,9 @@ jobs:
         run: npm ci
 
       - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/azure-cli.list /etc/apt/sources.list.d/azure-cli.sources
+          npx playwright install --with-deps chromium
         working-directory: packages/desktop
 
       - name: Run dev validation

--- a/.github/workflows/main-release-validation.yml
+++ b/.github/workflows/main-release-validation.yml
@@ -73,7 +73,9 @@ jobs:
         run: npm ci
 
       - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/azure-cli.list /etc/apt/sources.list.d/azure-cli.sources
+          npx playwright install --with-deps chromium
         working-directory: packages/desktop
 
       - name: Run production validation

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,7 +170,9 @@ jobs:
         run: npm ci
 
       - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/azure-cli.list /etc/apt/sources.list.d/azure-cli.sources
+          npx playwright install --with-deps chromium
         working-directory: packages/desktop
 
       - name: Run channel validation


### PR DESCRIPTION
(AI Generated).

## Summary
- Removes the stale Azure CLI apt source before Playwright installs browser dependencies on GitHub-hosted Ubuntu runners.
- Applies the same cleanup to PR feature validation, dev validation, production validation, and release validation.

## Testing
- git diff --check