### PR TITLE
fix: refine map time presets

### DIFF
--- a/docs/PHASE-8-FRIENDS.md
+++ b/docs/PHASE-8-FRIENDS.md
@@ -274,7 +274,7 @@ Map popovers now use a wider card layout and deliberately omit the old MapLibre 
 Friends and Map now consume the same shared theme tokens, button treatments, shell backgrounds, surface recipes, and theme-native map palettes as the rest of Freed, so themes like Neon, Midas, Vesper, Ember, and Scriptorium land consistently across the graph, sidebars, popovers, mini-map cards, editor, contact-sync flows, and map basemap itself.
 The shared map now includes a persisted `Friends` / `All content` toggle. It restores the user's last mode from preferences and defaults to `All content` when the library has geolocatable followed accounts but no friend-linked pins yet.
 That same `Friends` / `All content` lens now lives in the shared toolbar for feed surfaces too, so the operator can collapse Freed down to real-world people without leaving the main reading views.
-The shared map now exposes a persistent lower-left time range slider. The left handle starts at the earliest location timestamp, the right handle starts at the farthest future timestamp, and all available time is visible by default. Dragging either handle narrows the visible location windows without sending the operator back to the toolbar, and the handle labels travel underneath the selected start and end points. The card header also exposes `all time`, `today`, and `last week` text presets, with the active range highlighted.
+The shared map now exposes a persistent lower-left time range slider. The left handle starts at the earliest location day, the right handle starts at the farthest future location day, and all available time is visible by default. Dragging either handle snaps to whole-day values and narrows the visible location windows without sending the operator back to the toolbar. Handle labels travel underneath the selected start and end points, offset sideways on tight ranges so they stay on one row without overlapping. The card header also exposes `all time`, `today + future`, `today`, and `last week` text presets, with the active range highlighted.
 Friends and Map now use the shared top toolbar for identity controls, and feed-only bulk actions no longer appear in those workspaces.
 The Friends graph now auto-discovers likely human identities as provisional `connection` people from unlinked social accounts, persists those middle-ring nodes across sessions, and removes empty provisional identities when all linked channels move away.
 The Friends graph also now renders followed RSS feeds in the same graph, so the operator can see confirmed people, provisional people, linked channels, stray channels, and feed subscriptions in one zoomable workspace instead of splitting the world across separate mental models.
@@ -317,7 +317,7 @@ Reader author names now route directly into the matching Friends channel detail 
 | 8.19 | Google Contacts source, refreshable sync lifecycle, matching, and Friend creation flow | Medium | Done |
 | 8.20 | Wire Map to live sidebar navigation | Low | Done |
 | 8.21 | Add future-aware map filtering for location-bearing items | Medium | Done |
-| 8.22 | Replace map time mode buttons with an always-visible time range slider, handle labels, and quick presets for past, current, and future playback | Medium | Done |
+| 8.22 | Replace map time mode buttons with an always-visible time range slider, non-overlapping handle labels, and quick presets for past, current, today plus future, and all-time playback | Medium | Done |
 | 8.23 | Replace embedded Friend identity with canonical `Person` + `Account` schema and Automerge migration | High | Done |
 | 8.24 | Backfill followed-account catalog from captured authors and stories | Medium | Done |
 | 8.25 | Google Contacts imports create friend persons with linked contact accounts | Medium | Done |
@@ -419,7 +419,7 @@ Reader author names now route directly into the matching Friends channel detail 
 - [x] Map promoted to live sidebar navigation
 - [x] Future-aware map filtering supports past, current, and future location windows
 - [x] Range filtering works across historical posts and future planning items
-- [x] Time-card presets and handle-following labels work across historical posts and future planning items
+- [x] Time-card presets, including today plus future, and handle-following labels work across historical posts and future planning items without label collisions
 - [ ] Overlaps render as derived read-time views, not persisted source records
 - [ ] Mozi-backed friend/location events appear in Friend identity and map flows
 

--- a/packages/desktop/tests/e2e/smoke.spec.ts
+++ b/packages/desktop/tests/e2e/smoke.spec.ts
@@ -311,6 +311,37 @@ function formatMapRangeDate(value: number): string {
   return mapRangeFormatter.format(value);
 }
 
+function startOfLocalDay(value: number): number {
+  const date = new Date(value);
+  date.setHours(0, 0, 0, 0);
+  return date.getTime();
+}
+
+function endOfLocalDay(value: number): number {
+  const date = new Date(value);
+  date.setHours(23, 59, 59, 999);
+  return date.getTime();
+}
+
+function addLocalDays(value: number, days: number): number {
+  const date = new Date(value);
+  date.setHours(0, 0, 0, 0);
+  date.setDate(date.getDate() + days);
+  return date.getTime();
+}
+
+function boxesOverlap(
+  a: { x: number; y: number; width: number; height: number },
+  b: { x: number; y: number; width: number; height: number },
+): boolean {
+  return (
+    a.x < b.x + b.width &&
+    a.x + a.width > b.x &&
+    a.y < b.y + b.height &&
+    a.y + a.height > b.y
+  );
+}
+
 async function readDesktopSidebarPadding(page: Page) {
   return page.evaluate(() => {
     const sidebarBody = document.querySelector('[data-testid="app-sidebar-body"]') as HTMLElement | null;
@@ -3359,6 +3390,35 @@ test("map time range defaults to all available location windows", async ({ app, 
     const now = Date.now();
     await automerge.docAddFeedItems([
       {
+        globalId: "ig:grace:rome-memory",
+        platform: "instagram",
+        contentType: "post",
+        capturedAt: now - 14 * 24 * 60 * 60_000,
+        publishedAt: now - 14 * 24 * 60 * 60_000,
+        author: {
+          id: "grace-ig",
+          handle: "grace",
+          displayName: "Grace Hopper",
+        },
+        content: {
+          text: "Still thinking about Rome.",
+          mediaUrls: [],
+          mediaTypes: [],
+        },
+        location: {
+          name: "Rome",
+          coordinates: { lat: 41.9028, lng: 12.4964 },
+          source: "geo_tag",
+        },
+        userState: {
+          hidden: false,
+          saved: false,
+          archived: false,
+          tags: [],
+        },
+        topics: [],
+      },
+      {
         globalId: "ig:ada:lisbon-plan",
         platform: "instagram",
         contentType: "post",
@@ -3419,10 +3479,12 @@ test("map time range defaults to all available location windows", async ({ app, 
   await expect(page.getByTestId("map-time-range-slider")).toBeVisible({ timeout: 10_000 });
   await expect(page.getByTestId("map-time-preset-all")).toHaveAttribute("aria-pressed", "true");
   await expect(page.getByTestId("map-time-preset-today")).toHaveAttribute("aria-pressed", "false");
+  await expect(page.getByTestId("map-time-preset-today-future")).toHaveAttribute("aria-pressed", "false");
   await expect(page.getByTestId("map-time-preset-last-week")).toHaveAttribute("aria-pressed", "false");
   await expect(page.getByTestId("map-time-range-slider").locator("button")).toHaveText([
     "last week",
     "today",
+    "today + future",
     "all time",
   ]);
   await expect(page.getByRole("button", { name: "Current", exact: true })).toHaveCount(0);
@@ -3434,6 +3496,26 @@ test("map time range defaults to all available location windows", async ({ app, 
 
   await page.getByTestId("map-time-preset-today").click();
   await expect(page.getByTestId("map-time-preset-today")).toHaveAttribute("aria-pressed", "true");
+  const todayStartAt = Number(await page.getByTestId("map-time-range-start").inputValue());
+  const todayEndAt = Number(await page.getByTestId("map-time-range-end").inputValue());
+  const maxRangeAt = Number(await page.getByTestId("map-time-range-end").getAttribute("max"));
+  expect(todayStartAt).toBe(addLocalDays(seededNow, -1));
+  expect(todayEndAt).toBe(endOfLocalDay(seededNow));
+  expect(todayEndAt).toBeLessThan(maxRangeAt);
+  await expect(page.getByTestId("map-time-range-start-label")).toHaveText(formatMapRangeDate(addLocalDays(seededNow, -1)));
+  await expect(page.getByTestId("map-time-range-end-label")).toHaveText(formatMapRangeDate(seededNow));
+  const startLabelBox = await page.getByTestId("map-time-range-start-label").boundingBox();
+  const endLabelBox = await page.getByTestId("map-time-range-end-label").boundingBox();
+  expect(startLabelBox).not.toBeNull();
+  expect(endLabelBox).not.toBeNull();
+  expect(boxesOverlap(startLabelBox!, endLabelBox!)).toBe(false);
+  expect(Math.abs(startLabelBox!.y - endLabelBox!.y)).toBeLessThan(2);
+  expect(startLabelBox!.x).toBeLessThan(endLabelBox!.x);
+
+  await page.getByTestId("map-time-preset-today-future").click();
+  await expect(page.getByTestId("map-time-preset-today-future")).toHaveAttribute("aria-pressed", "true");
+  expect(Number(await page.getByTestId("map-time-range-end").inputValue())).toBe(maxRangeAt);
+
   await page.getByTestId("map-time-preset-all").click();
   await expect(page.getByTestId("map-time-preset-all")).toHaveAttribute("aria-pressed", "true");
 
@@ -3448,6 +3530,8 @@ test("map time range defaults to all available location windows", async ({ app, 
   await setMapTimeRange(page, startAt, endAt);
   const clampedStartAt = Number(await page.getByTestId("map-time-range-start").inputValue());
   const clampedEndAt = Number(await page.getByTestId("map-time-range-end").inputValue());
+  expect(clampedStartAt).toBe(startOfLocalDay(startAt));
+  expect(clampedEndAt).toBe(endOfLocalDay(endAt));
   await expect(page.getByTestId("map-time-range-start-label")).toHaveText(formatMapRangeDate(clampedStartAt));
   await expect(page.getByTestId("map-time-range-end-label")).toHaveText(formatMapRangeDate(clampedEndAt));
   await expect(page.getByTestId("map-time-preset-all")).toHaveAttribute("aria-pressed", "false");

--- a/packages/ui/src/components/map/MapView.tsx
+++ b/packages/ui/src/components/map/MapView.tsx
@@ -11,14 +11,12 @@ import { useResolvedLocations } from "../../hooks/useResolvedLocations.js";
 import { openAccountFromMap, openFriendFromMap, openPostFromMap } from "../../lib/map-navigation.js";
 import { MapSurface } from "./MapSurface.js";
 
-const RANGE_STEP_MS = 60 * 60 * 1000;
-const DAY_MS = 24 * 60 * 60 * 1000;
 const timeRangeFormatter = new Intl.DateTimeFormat(undefined, {
   month: "short",
   day: "numeric",
 });
 
-type TimePreset = "all" | "today" | "last-week";
+type TimePreset = "all" | "today-future" | "today" | "last-week";
 
 type MapViewportInsets = {
   top: number;
@@ -59,6 +57,13 @@ function endOfLocalDay(value: number): number {
   return date.getTime();
 }
 
+function addLocalDays(value: number, days: number): number {
+  const date = new Date(value);
+  date.setHours(0, 0, 0, 0);
+  date.setDate(date.getDate() + days);
+  return date.getTime();
+}
+
 function clampTimeRangeToBounds(range: LocationTimeRange, bounds: LocationTimeRange): LocationTimeRange {
   const startAt = clamp(range.startAt, bounds.startAt, bounds.endAt);
   const endAt = clamp(range.endAt, bounds.startAt, bounds.endAt);
@@ -72,18 +77,57 @@ function presetTimeRange(preset: Exclude<TimePreset, "all">, bounds: LocationTim
   const now = Date.now();
   if (preset === "today") {
     return clampTimeRangeToBounds({
-      startAt: startOfLocalDay(now),
+      startAt: addLocalDays(now, -1),
       endAt: endOfLocalDay(now),
+    }, bounds);
+  }
+  if (preset === "today-future") {
+    return clampTimeRangeToBounds({
+      startAt: addLocalDays(now, -1),
+      endAt: bounds.endAt,
     }, bounds);
   }
 
   return clampTimeRangeToBounds({
-    startAt: startOfLocalDay(now - 6 * DAY_MS),
+    startAt: addLocalDays(now, -7),
     endAt: endOfLocalDay(now),
   }, bounds);
 }
 
-function labelPositionStyle(percent: number): { left: string; transform: string } {
+function snapTimeBoundsToDays(bounds: LocationTimeRange): LocationTimeRange {
+  return {
+    startAt: startOfLocalDay(bounds.startAt),
+    endAt: endOfLocalDay(bounds.endAt),
+  };
+}
+
+function snapRangeStartToDay(value: number): number {
+  return startOfLocalDay(value);
+}
+
+function snapRangeEndToDay(value: number): number {
+  return endOfLocalDay(value);
+}
+
+function labelPositionStyle(
+  percent: number,
+  edge: "start" | "end",
+  offsetForCollision = false,
+): { left: string; transform: string } {
+  if (offsetForCollision) {
+    if (edge === "start") {
+      if (percent <= 8) {
+        return { left: `${percent}%`, transform: "translateX(0)" };
+      }
+      return { left: `${percent}%`, transform: "translateX(calc(-100% - 0.375rem))" };
+    }
+
+    if (percent >= 92) {
+      return { left: `${percent}%`, transform: "translateX(-100%)" };
+    }
+    return { left: `${percent}%`, transform: "translateX(0.375rem)" };
+  }
+
   if (percent <= 2) {
     return { left: "0%", transform: "translateX(0)" };
   }
@@ -109,7 +153,11 @@ export function MapView({ viewportInsets }: MapViewProps) {
   const [rangeSelection, setRangeSelection] = useState<LocationTimeRange | null>(null);
 
   const { resolvedItems } = useResolvedLocations(items, persons, accounts);
-  const timeBounds = useMemo(() => getLocationTimelineBounds(resolvedItems), [resolvedItems]);
+  const rawTimeBounds = useMemo(() => getLocationTimelineBounds(resolvedItems), [resolvedItems]);
+  const timeBounds = useMemo(
+    () => (rawTimeBounds ? snapTimeBoundsToDays(rawTimeBounds) : null),
+    [rawTimeBounds],
+  );
   const effectiveTimeRange = useMemo<LocationTimeRange | null>(() => {
     if (!timeBounds) return null;
     if (!rangeSelection) return timeBounds;
@@ -165,8 +213,9 @@ export function MapView({ viewportInsets }: MapViewProps) {
 
     setRangeSelection((current) => {
       const currentRange = current ?? timeBounds;
+      const maxStartAt = startOfLocalDay(currentRange.endAt);
       const next = {
-        startAt: clamp(value, timeBounds.startAt, currentRange.endAt),
+        startAt: clamp(snapRangeStartToDay(value), timeBounds.startAt, maxStartAt),
         endAt: currentRange.endAt,
       };
       return isFullTimeRange(next, timeBounds) ? null : next;
@@ -178,9 +227,10 @@ export function MapView({ viewportInsets }: MapViewProps) {
 
     setRangeSelection((current) => {
       const currentRange = current ?? timeBounds;
+      const minEndAt = endOfLocalDay(currentRange.startAt);
       const next = {
         startAt: currentRange.startAt,
-        endAt: clamp(value, currentRange.startAt, timeBounds.endAt),
+        endAt: clamp(snapRangeEndToDay(value), minEndAt, timeBounds.endAt),
       };
       return isFullTimeRange(next, timeBounds) ? null : next;
     });
@@ -212,22 +262,26 @@ export function MapView({ viewportInsets }: MapViewProps) {
       ? ((effectiveTimeRange.endAt - timeBounds.startAt) / rangeDuration) * 100
       : 100;
   const rangeWidthPercent = Math.max(0, rangeEndPercent - rangeStartPercent);
+  const labelsAreClose = Math.abs(rangeEndPercent - rangeStartPercent) < 12;
   const minRangeValue = timeBounds?.startAt ?? 0;
   const maxRangeValue = timeBounds?.endAt ?? 0;
-  const rangeStep = timeBounds ? Math.max(1, Math.min(RANGE_STEP_MS, rangeDuration)) : 1;
+  const rangeStep = timeBounds ? "any" : 1;
   const activePreset =
     timeBounds && effectiveTimeRange
       ? isFullTimeRange(effectiveTimeRange, timeBounds)
         ? "all"
         : sameTimeRange(effectiveTimeRange, presetTimeRange("today", timeBounds))
           ? "today"
-          : sameTimeRange(effectiveTimeRange, presetTimeRange("last-week", timeBounds))
-            ? "last-week"
-            : null
+          : sameTimeRange(effectiveTimeRange, presetTimeRange("today-future", timeBounds))
+            ? "today-future"
+            : sameTimeRange(effectiveTimeRange, presetTimeRange("last-week", timeBounds))
+              ? "last-week"
+              : null
       : null;
   const timePresets: Array<{ value: TimePreset; label: string; testId: string }> = [
     { value: "last-week", label: "last week", testId: "map-time-preset-last-week" },
     { value: "today", label: "today", testId: "map-time-preset-today" },
+    { value: "today-future", label: "today + future", testId: "map-time-preset-today-future" },
     { value: "all", label: "all time", testId: "map-time-preset-all" },
   ];
   const emptyTitle = effectiveMode === "friends" ? "No friend pins in this time range." : "No location pins in this time range.";
@@ -246,12 +300,12 @@ export function MapView({ viewportInsets }: MapViewProps) {
         }}
       >
         <div
-          className="pointer-events-auto theme-floating-panel w-[min(26rem,calc(100vw-2rem))] px-4 py-3"
+          className="pointer-events-auto theme-floating-panel w-[min(32rem,calc(100vw-2rem))] px-4 py-3"
           data-testid="map-time-range-slider"
         >
           <div className="flex items-center justify-between gap-3 text-[10px] font-medium text-[color:var(--theme-text-muted)]">
             <span>Time</span>
-            <div className="flex items-center gap-1 text-right">
+            <div className="flex flex-wrap items-center justify-end gap-1 text-right">
               {timePresets.map((preset) => {
                 const active = activePreset === preset.value;
                 return (
@@ -310,14 +364,14 @@ export function MapView({ viewportInsets }: MapViewProps) {
             <span
               className="absolute top-8 whitespace-nowrap text-[10px] text-[color:var(--theme-text-soft)]"
               data-testid="map-time-range-start-label"
-              style={labelPositionStyle(rangeStartPercent)}
+              style={labelPositionStyle(rangeStartPercent, "start", labelsAreClose)}
             >
               {effectiveTimeRange ? formatRangeEdge(effectiveTimeRange.startAt) : "Start"}
             </span>
             <span
               className="absolute top-8 whitespace-nowrap text-[10px] text-[color:var(--theme-text-soft)]"
               data-testid="map-time-range-end-label"
-              style={labelPositionStyle(rangeEndPercent)}
+              style={labelPositionStyle(rangeEndPercent, "end", labelsAreClose)}
             >
               {effectiveTimeRange ? formatRangeEdge(effectiveTimeRange.endAt) : "End"}
             </span>


### PR DESCRIPTION
(AI Generated).

## Summary
- Adds a today + future quick preset between today and all time for future-dated map location data.
- Stacks close start and end labels vertically so same-day ranges do not overlap.
- Updates Phase 8 docs for the refined map time-card behavior.

## Tests
- npm run test:e2e -- --grep 'map time range defaults to all available location windows' (packages/desktop)\n- npm run validate:feature