### PR TITLE
fix: stabilize graph pin release validation

### DIFF
--- a/packages/desktop/tests/e2e/smoke.spec.ts
+++ b/packages/desktop/tests/e2e/smoke.spec.ts
@@ -4857,6 +4857,21 @@ test("pinning a person from the graph context menu survives reload", async ({ ap
   }, { timeout: 10_000 });
   const expectedPinnedPosition = await storedPinnedPosition.jsonValue() as { graphX: number; graphY: number };
 
+  await page.waitForFunction((expected) => {
+    const w = window as Record<string, unknown>;
+    const automerge = w.__FREED_AUTOMERGE__ as
+      | {
+          getDocState: () => {
+            persons: Record<string, { graphPinned?: boolean; graphX?: number; graphY?: number }>;
+          } | null;
+        }
+      | undefined;
+    const person = automerge?.getDocState()?.persons["friend-pinned"];
+    return person?.graphPinned === true &&
+      person.graphX === expected.graphX &&
+      person.graphY === expected.graphY;
+  }, expectedPinnedPosition, { timeout: 10_000 });
+
   await page.reload();
   await app.waitForReady();
   await page.waitForFunction((expected) => {

--- a/scripts/worktree-add.sh
+++ b/scripts/worktree-add.sh
@@ -24,6 +24,8 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./lib/node-tooling.sh
+source "${SCRIPT_DIR}/lib/node-tooling.sh"
 # shellcheck source=./lib/worktree-runtime.sh
 source "${SCRIPT_DIR}/lib/worktree-runtime.sh"
 


### PR DESCRIPTION
(AI Generated).

## Summary
- Wait for graph pin coordinates to reach the Automerge document before reloading the Friends graph persistence test.
- Source the shared Node tooling helpers in worktree-add so its preflight function is defined.

## Tests
- npm run test:e2e -- smoke.spec.ts --grep "pinning a person from the graph context menu survives reload", packages/desktop
- npm run validate:feature -- --changed-files packages/desktop/tests/e2e/smoke.spec.ts scripts/worktree-add.sh
