### PR TITLE
fix: bound social loop diagnostics parsing

### DIFF
--- a/scripts/social-scrape-loop.mjs
+++ b/scripts/social-scrape-loop.mjs
@@ -6,6 +6,7 @@ import {
   mkdirSync,
   openSync,
   readFileSync,
+  readSync,
   statSync,
   unlinkSync,
   writeFileSync,
@@ -30,6 +31,8 @@ const DEFAULT_DIAGNOSTICS_LOG = path.join(DEFAULT_APP_SUPPORT_DIR, "runtime-diag
 const DEFAULT_PROVIDER_HEALTH_STORE = path.join(DEFAULT_APP_SUPPORT_DIR, "sync-health.json");
 const DEFAULT_OUTPUT = path.join("/tmp", "freed-social-scrape-loop", "latest-report.json");
 const DEFAULT_LOCK_PATH = path.join("/tmp", "freed-social-scrape-loop", "run.lock");
+const DEFAULT_JSONL_TAIL_BYTES = 8 * 1024 * 1024;
+const HEAVY_DIAGNOSTIC_FIELDS = ["sampleSummary", "vmmapSummary"];
 const PROVIDERS = ["facebook", "instagram", "linkedin", "x"];
 const PROVIDER_LABELS = {
   facebook: "Facebook",
@@ -270,22 +273,57 @@ export function releaseRunLock({ lockPath = DEFAULT_LOCK_PATH, token }) {
   return { released: true, reason: "released" };
 }
 
+function readTailText(filePath, maxBytes = DEFAULT_JSONL_TAIL_BYTES) {
+  const size = statSync(filePath).size;
+  if (size <= maxBytes) {
+    return readFileSync(filePath, "utf8");
+  }
+
+  const fd = openSync(filePath, "r");
+  try {
+    const start = Math.max(0, size - maxBytes);
+    const buffer = Buffer.alloc(size - start);
+    readSync(fd, buffer, 0, buffer.length, start);
+    const text = buffer.toString("utf8");
+    const firstNewline = text.indexOf("\n");
+    return firstNewline >= 0 ? text.slice(firstNewline + 1) : "";
+  } finally {
+    closeSync(fd);
+  }
+}
+
 function tailLines(text, count) {
   const lines = text.split(/\r?\n/).filter(Boolean);
   return count >= lines.length ? lines : lines.slice(lines.length - count);
 }
 
-export function readJsonl(filePath, { tail = 5000 } = {}) {
+function compactRuntimeRow(row) {
+  if (!row || typeof row !== "object") {
+    return row;
+  }
+
+  const compacted = { ...row };
+  for (const field of HEAVY_DIAGNOSTIC_FIELDS) {
+    if (typeof compacted[field] !== "string") {
+      continue;
+    }
+    compacted[`${field}Bytes`] = Buffer.byteLength(compacted[field]);
+    delete compacted[field];
+  }
+  return compacted;
+}
+
+export function readJsonl(filePath, { tail = 5000, maxBytes = DEFAULT_JSONL_TAIL_BYTES } = {}) {
   if (!filePath || !existsSync(filePath)) {
     return { exists: false, rows: [], parseErrors: 0 };
   }
 
-  const lines = tailLines(readFileSync(filePath, "utf8"), tail);
+  const lines = tailLines(readTailText(filePath, maxBytes), tail);
   const rows = [];
   let parseErrors = 0;
   for (const line of lines) {
     try {
-      rows.push(JSON.parse(line));
+      rows.push(compactRuntimeRow(JSON.parse(line)));
     } catch {
       parseErrors += 1;
     }

--- a/scripts/social-scrape-loop.test.mjs
+++ b/scripts/social-scrape-loop.test.mjs
@@ -48,6 +48,48 @@ test("readJsonl tails rows and counts parse errors", () => {
   assert.deepEqual(result.rows.map((row) => row.event), ["newer", "newest"]);
 });
 
+test("readJsonl reads only the byte tail for large logs", () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "freed-social-loop-jsonl-tail-"));
+  const filePath = path.join(dir, "runtime-diagnostics.jsonl");
+  writeFileSync(
+    filePath,
+    [
+      JSON.stringify({ event: "old", detail: "x".repeat(1024) }),
+      JSON.stringify({ event: "recent-a" }),
+      JSON.stringify({ event: "recent-b" }),
+      "",
+    ].join("\n"),
+  );
+
+  const result = readJsonl(filePath, { tail: 10, maxBytes: 96 });
+
+  assert.equal(result.exists, true);
+  assert.equal(result.parseErrors, 0);
+  assert.deepEqual(result.rows.map((row) => row.event), ["recent-a", "recent-b"]);
+});
+
+test("readJsonl compacts heavyweight diagnostic text fields", () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "freed-social-loop-jsonl-compact-"));
+  const filePath = path.join(dir, "runtime-diagnostics.jsonl");
+  writeFileSync(
+    filePath,
+    `${JSON.stringify({
+      event: "renderer_memory_recovery_attempt",
+      sampleSummary: "sample".repeat(100),
+      vmmapSummary: "vmmap".repeat(100),
+    })}\n`,
+  );
+
+  const result = readJsonl(filePath);
+
+  assert.equal(result.exists, true);
+  assert.equal(result.rows.length, 1);
+  assert.equal(result.rows[0].sampleSummary, undefined);
+  assert.equal(result.rows[0].vmmapSummary, undefined);
+  assert.equal(result.rows[0].sampleSummaryBytes, 600);
+  assert.equal(result.rows[0].vmmapSummaryBytes, 500);
+});
+
 test("readJsonFile reads optional provider health stores", () => {
   const dir = mkdtempSync(path.join(os.tmpdir(), "freed-social-loop-json-"));
   const filePath = path.join(dir, "sync-health.json");


### PR DESCRIPTION
(AI Generated).

## Summary
- Tail social scrape loop JSONL input by byte window before line parsing so large runtime diagnostics do not get fully loaded every pass.
- Drop heavyweight `sampleSummary` and `vmmapSummary` text after recording their byte sizes, keeping planner metadata small.
- Add focused tests for byte-tail parsing and diagnostic compaction.

## Validation
- `node --test scripts/social-scrape-loop.test.mjs`
- `npm run validate:feature -- --changed-files scripts/social-scrape-loop.mjs scripts/social-scrape-loop.test.mjs`

## Provider risk
- Local-only. No provider navigation, requests, timing, scrolling, or authenticated behavior changes.