### PR TITLE
fix: save content details in the background

### DIFF
--- a/docs/PHASE-3-SAVE-FOR-LATER.md
+++ b/docs/PHASE-3-SAVE-FOR-LATER.md
@@ -3,11 +3,12 @@
 > **Status:** Current  
 > **Dependencies:** Phase 1-2 (Capture layers)
 >
-> Save for Later is functional across desktop and PWA. Desktop has full article
-> extraction, local HTML caching, Markdown import/export, background fetch
-> healing, user-visible AI controls, and hierarchical tag navigation. The PWA
-> now attempts full article capture through a server fetch proxy and falls back
-> to a sync-healed stub when a site blocks extraction or exceeds limits. Saved
+> Save for Later is functional across desktop and PWA. Saved URLs now write a
+> lightweight stub first so the dialog can close immediately, then Freed pulls
+> article details in the background where the platform can fetch them. Desktop
+> has full article extraction, local HTML caching, Markdown import/export,
+> background fetch healing, user-visible AI controls, and hierarchical tag
+> navigation. PWA saves sync-healed stubs for Freed Desktop to hydrate. Saved
 > content is pinned in the device-local reader cache by default.
 
 ---
@@ -17,8 +18,9 @@
 Phase 3 covers manually saved URLs and the reader flow around them. The core
 architecture is now:
 
-1. Save a URL from desktop or PWA.
-2. Extract metadata plus article content with Readability-safe browser parsing.
+1. Save a URL from desktop or PWA by writing a lightweight stub item.
+2. Pull metadata plus article content in the background with Readability-safe
+   browser parsing where the platform can fetch the page.
 3. Keep full HTML in a device-local cache, never in Automerge.
 4. Sync compact preserved text through Automerge for cross-device fallback.
 5. Render reader content through a layered waterfall:
@@ -32,18 +34,20 @@ architecture is now:
 
 ### Save Flow
 
-- **Desktop:** fetches raw HTML through Tauri, extracts readable content, caches
-  article HTML locally, and writes a sync-safe saved item to Automerge.
-- **PWA:** posts the URL to a same-origin server fetch proxy, extracts readable
-  content in the browser, caches article HTML in the Cache API, and writes a
-  full saved item to Automerge.
-- **Saved cache pinning:** saved URL creation writes readable HTML into the
-  permanent device-local cache tier. Unsaving does not immediately remove the
-  local reader copy.
-- **Post-save reader handoff:** after a URL save succeeds, Freed switches to
-  Saved and opens the newly saved item in reader mode.
-- **PWA fallback:** when proxy fetch or extraction fails, the app writes a stub
-  saved item so desktop sync can heal it later.
+- **Desktop:** writes a saved stub immediately, closes the Save Content dialog,
+  and queues a priority background detail fetch that caches readable HTML
+  locally and updates Automerge with compact preserved text.
+- **PWA:** writes a saved stub immediately. Freed Desktop can hydrate the
+  details after sync.
+- **Saved cache pinning:** saved URLs, posts, and stories enter the permanent
+  device-local cache path when readable content is available. Unsaving does not
+  immediately remove the local reader copy.
+- **Post-save reader handoff:** after stub persistence succeeds, Freed switches
+  to Saved and opens the newly saved item in reader mode while details load in
+  the background.
+- **Save failure recovery:** if stub persistence or background detail fetching
+  fails for a user-initiated save, the Save Content dialog reopens with the URL
+  and the error message.
 
 ### Reader And Cache Layers
 
@@ -76,8 +80,8 @@ architecture is now:
 | ---- | ----------- | ------ | ----- |
 | 3.1 | Create `@freed/capture-save` package scaffold | ✓ Complete | Package exists in `packages/capture-save/` |
 | 3.2 | Implement browser-safe metadata and article extraction | ✓ Complete | Shared browser parser used by desktop and PWA |
-| 3.3 | Implement desktop full save flow with local HTML cache | ✓ Complete | Uses Tauri `fetch_url` + FS cache, then opens the saved item in reader mode |
-| 3.4 | Implement PWA full save flow with fallback stub mode | ✓ Complete | Uses `/api/fetch-url` plus Cache API and returns a saved item id for reader navigation |
+| 3.3 | Implement desktop full save flow with local HTML cache | ✓ Complete | Saves a stub first, then uses Tauri `fetch_url` plus FS cache in the background |
+| 3.4 | Implement PWA full save flow with fallback stub mode | ✓ Complete | Saves a stub immediately and returns a saved item id for reader navigation |
 | 3.5 | Layered reader fallback for offline reading | ✓ Complete | Cache → preserved text → live fetch |
 | 3.6 | Hierarchical tag navigation | ✓ Complete | Sidebar tag tree is live |
 | 3.7 | Freed Markdown import/export | ✓ Complete | Import, export, and background fetch healing shipped |
@@ -89,8 +93,9 @@ architecture is now:
 
 ## Current Constraints
 
-- The PWA fetch proxy only accepts `http` and `https` URLs.
-- Oversized articles are rejected server-side and fall back to stub mode.
+- Save URL validation only accepts `http` and `https` URLs.
+- Oversized background article fetches leave the saved stub in place and report
+  the detail error to the user.
 - AI summarization still runs on desktop because API key storage is device-local
   there.
 - Phase 3 remains marked `Current` until broader mobile validation is complete,

--- a/docs/PHASE-5-DESKTOP.md
+++ b/docs/PHASE-5-DESKTOP.md
@@ -264,7 +264,7 @@ export async function captureDomFeed(
 - [x] Desktop E2E gates are split into smoke, functional regression, performance, and visual lanes, with dev build validation running the performance and visual lanes instead of hiding them until production release prep
 - [x] Local desktop preview now defaults to the mocked browser harness, while tracked preview slots keep concurrent local threads to one desktop preview at a time unless native Tauri behavior is explicitly requested, native preview windows carry a visible worktree and thread label, and feature previews auto-accept local legal gates plus seed sample data
 - [x] Desktop navigation history supports browser-style back and forward shortcuts for views and reader state
-- [x] Freed Desktop registers a device-local OS-wide Save Content shortcut that opens the existing Save Content dialog, pre-fills the URL field from the clipboard when it holds an HTTP or HTTPS link, and opens the saved item in reader mode after persistence
+- [x] Freed Desktop registers a device-local OS-wide Save Content shortcut that opens the existing Save Content dialog, pre-fills the URL field from the clipboard when it holds an HTTP or HTTPS link, opens the saved item in reader mode after stub persistence, and pulls readable details in the background
 - [x] Settings and crash recovery surfaces can export public-safe bug report bundles
 - [x] Private diagnostic bundles are opt-in, redacted, and steered toward email instead of public GitHub attachment
 - [x] Bug report actions now label whether they download a public-safe or private bundle, bulk-toggle private diagnostics, and block public GitHub issue drafts while private diagnostics remain selected

--- a/docs/PHASE-6-PWA.md
+++ b/docs/PHASE-6-PWA.md
@@ -13,7 +13,7 @@ Mobile companion to Freed Desktop for on-the-go reading. Timeline-focused, minim
 
 - **Shared codebase** — Same React app embedded in Desktop WebView and deployed to [app.freed.wtf](https://app.freed.wtf), with the dev channel on `dev-app.freed.wtf`
 - **Thin client** — Displays pre-computed rankings from Desktop/OpenClaw, minimal local computation
-- **Light saves** — Can save URLs with metadata extraction (og tags); full article extraction requires Desktop
+- **Light saves:** Saves URL stubs immediately; full detail extraction requires Freed Desktop
 - **Offline-first:** Service worker caches feed data, saved reader HTML, and images for offline reading
 - **Versioned first-run consent** — PWA startup is blocked until the current legal bundle is accepted locally in the browser
 - **URL-driven navigation** — Active view, feed scope, and open reader state serialize into the URL so browser back and forward behave naturally

--- a/packages/desktop/src/lib/content-fetcher.test.ts
+++ b/packages/desktop/src/lib/content-fetcher.test.ts
@@ -560,6 +560,42 @@ describe("content fetcher", () => {
     );
   });
 
+  it("bypasses startup delay and reopens the save dialog when manual detail fetch fails", async () => {
+    vi.useFakeTimers();
+    const events: Array<{ initialUrl?: string; errorMessage?: string }> = [];
+    const listener = (event: Event) => {
+      events.push((event as CustomEvent<{ initialUrl?: string; errorMessage?: string }>).detail);
+    };
+    window.addEventListener("freed:save-content-details-error", listener);
+    const { mod, mockInvoke } = await loadContentFetcherModuleWithAi({
+      autoSummarize: false,
+      extractTopics: false,
+      invokeImpl: () => Promise.reject(new Error("Network unreachable")),
+    });
+
+    mod.start({ startupDelayMs: 60_000 });
+    mod.enqueue([makeStubItem("saved:1")], {
+      priority: true,
+      force: true,
+      bypassStartupDelay: true,
+      reopenSaveDialogOnError: true,
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    mod.stop();
+    window.removeEventListener("freed:save-content-details-error", listener);
+
+    expect(mockInvoke).toHaveBeenCalledWith(
+      "fetch_url",
+      expect.objectContaining({ url: SAMPLE_URL }),
+    );
+    expect(events).toEqual([
+      {
+        initialUrl: SAMPLE_URL,
+        errorMessage: "Network unreachable",
+      },
+    ]);
+  });
+
   it("defers content parsing when the main WebKit process is already large", async () => {
     vi.useFakeTimers();
     let highMemory = true;

--- a/packages/desktop/src/lib/content-fetcher.ts
+++ b/packages/desktop/src/lib/content-fetcher.ts
@@ -71,6 +71,13 @@ interface QueueEntry {
   url: string;
 }
 
+interface EnqueueOptions {
+  priority?: boolean;
+  force?: boolean;
+  bypassStartupDelay?: boolean;
+  reopenSaveDialogOnError?: boolean;
+}
+
 interface ContentFetchMemoryStats {
   appResidentBytes?: number;
   webkitFootprintBytes?: number;
@@ -88,6 +95,7 @@ interface ContentFetchMemoryStats {
 const queue: QueueEntry[] = [];
 const inFlight = new Set<string>();
 const failed = new Map<string, number>();
+const reopenSaveDialogOnErrorIds = new Set<string>();
 let completed = 0;
 let running = false;
 let workerTimer: ReturnType<typeof setTimeout> | null = null;
@@ -220,14 +228,22 @@ function hasRecentFailure(globalId: string, now = Date.now()): boolean {
  * Add items to the fetch queue.
  * Skips items already queued, already failed, or that already have content.
  */
-export function enqueue(items: FeedItem[], options: { priority?: boolean; force?: boolean } = {}): void {
+export function enqueue(items: FeedItem[], options: EnqueueOptions = {}): void {
   const newEntries = newStubItems(items, { force: options.force });
+  if (options.reopenSaveDialogOnError) {
+    for (const entry of newEntries) {
+      reopenSaveDialogOnErrorIds.add(entry.globalId);
+    }
+  }
   if (options.priority) {
     queue.unshift(...newEntries.reverse());
   } else {
     queue.push(...newEntries);
   }
   if (newEntries.length > 0) {
+    if (options.bypassStartupDelay) {
+      clearStartupDelay();
+    }
     notifyStatus();
     if (running && activeStartedAt === null && workerTimer === null) {
       scheduleWorker(0);
@@ -335,6 +351,19 @@ function isAiTimeoutError(error: unknown): boolean {
 
 function isResponseTooLargeError(message: string): boolean {
   return message.startsWith(RESPONSE_TOO_LARGE_PREFIX);
+}
+
+function dispatchSaveContentError(entry: QueueEntry, message: string): void {
+  if (!reopenSaveDialogOnErrorIds.delete(entry.globalId)) return;
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(
+    new CustomEvent("freed:save-content-details-error", {
+      detail: {
+        initialUrl: entry.url,
+        errorMessage: message,
+      },
+    }),
+  );
 }
 
 function scheduleWorker(delayMs: number): void {
@@ -553,6 +582,7 @@ async function processNext(): Promise<ProcessOutcome> {
     });
 
     completed++;
+    reopenSaveDialogOnErrorIds.delete(entry.globalId);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     const isTimeout = msg === "fetch_url TIMEOUT";
@@ -570,12 +600,14 @@ async function processNext(): Promise<ProcessOutcome> {
       failed.set(entry.globalId, Date.now());
       pruneFailed();
       addDebugEvent("error", `[Fetcher] skipped oversized article: ${entry.url}`);
+      dispatchSaveContentError(entry, "Freed could not save details for this URL because the response was too large.");
       outcome = "skipped";
     } else {
       log.warn(`[content-fetcher] fetch failed url=${entry.url} err=${msg}`);
       failed.set(entry.globalId, Date.now());
       pruneFailed();
       addDebugEvent("error", `[Fetcher] failed to fetch ${entry.url}: ${msg}`);
+      dispatchSaveContentError(entry, msg || "Freed could not save details for this URL.");
       outcome = "backoff";
     }
   } finally {

--- a/packages/desktop/src/lib/save-url.test.ts
+++ b/packages/desktop/src/lib/save-url.test.ts
@@ -1,153 +1,91 @@
-/**
- * Unit tests for saveUrlInDesktop
- *
- * Tauri IPC, content extraction, content cache, and Automerge are all mocked
- * so these tests run in jsdom without any native runtime dependencies.
- */
-
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { FeedItem } from "@freed/shared";
-import { MAX_SYNCED_PRESERVED_TEXT_CHARS } from "./preserved-text.js";
 
-// ── Module mocks ──────────────────────────────────────────────────────────────
-
-const mockInvoke = vi.fn();
-vi.mock("@tauri-apps/api/core", () => ({ invoke: mockInvoke }));
-
-const mockExtractMetadata = vi.fn();
-const mockExtractContent = vi.fn();
-vi.mock("@freed/capture-save/browser", () => ({
-  extractMetadataBrowser: mockExtractMetadata,
-  extractContentBrowser: mockExtractContent,
-}));
-
-const mockCacheSet = vi.fn();
-vi.mock("./content-cache.js", () => ({
-  contentCache: { set: mockCacheSet, get: vi.fn() },
-}));
-
-const mockDocAdd = vi.fn<(item: FeedItem) => Promise<void>>();
-vi.mock("./automerge.js", () => ({ docAddFeedItem: mockDocAdd }));
-
-// ── Helpers ───────────────────────────────────────────────────────────────────
-
-const SAMPLE_HTML = "<html><head><title>Test Article</title></head><body><p>Hello world.</p></body></html>";
 const SAMPLE_URL = "https://example.com/articles/hello-world";
 
-function makeMetadata(overrides: Record<string, unknown> = {}) {
-  return {
-    title: "Test Article",
-    description: "A short description.",
-    siteName: "Example",
-    author: "Jane Doe",
-    imageUrl: "https://example.com/img.jpg",
-    publishedAt: 1_700_000_000_000,
-    ...overrides,
-  };
-}
+const stubItem: FeedItem = {
+  globalId: "saved:abc123",
+  platform: "saved",
+  contentType: "article",
+  capturedAt: 1,
+  publishedAt: 1,
+  author: { id: "example.com", handle: "example.com", displayName: "example.com" },
+  content: {
+    text: SAMPLE_URL,
+    mediaUrls: [],
+    mediaTypes: [],
+    linkPreview: { url: SAMPLE_URL, title: SAMPLE_URL },
+  },
+  userState: { hidden: false, saved: true, savedAt: 1, archived: false, tags: ["research"] },
+  topics: [],
+};
 
-function makeContent(overrides: Record<string, unknown> = {}) {
-  return {
-    html: "<article><p>Hello world.</p></article>",
-    text: "Hello world. This is the full article body.",
-    author: "Jane Doe",
-    wordCount: 8,
-    readingTime: 1,
-    ...overrides,
-  };
-}
+const mockDocAddStubItem = vi.fn(async () => stubItem);
+const mockEnqueue = vi.fn();
 
-// ── Tests ─────────────────────────────────────────────────────────────────────
+vi.mock("./automerge.js", () => ({
+  docAddStubItem: mockDocAddStubItem,
+}));
+
+vi.mock("./content-fetcher.js", () => ({
+  enqueue: mockEnqueue,
+}));
 
 describe("saveUrlInDesktop", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockInvoke.mockResolvedValue(SAMPLE_HTML);
-    mockExtractMetadata.mockReturnValue(makeMetadata());
-    mockExtractContent.mockReturnValue(makeContent());
-    mockCacheSet.mockResolvedValue(undefined);
-    mockDocAdd.mockResolvedValue(undefined);
+    mockDocAddStubItem.mockResolvedValue(stubItem);
   });
 
-  it("invokes fetch_url with the provided URL", async () => {
+  it("writes a saved stub and queues background detail fetching", async () => {
     const { saveUrlInDesktop } = await import("./save-url.js");
-    await saveUrlInDesktop(SAMPLE_URL);
-    expect(mockInvoke).toHaveBeenCalledWith("fetch_url", { url: SAMPLE_URL });
+
+    const result = await saveUrlInDesktop(SAMPLE_URL, { tags: ["research"] });
+
+    expect(mockDocAddStubItem).toHaveBeenCalledWith(SAMPLE_URL, ["research"]);
+    expect(mockEnqueue).toHaveBeenCalledWith([stubItem], {
+      priority: true,
+      force: true,
+      bypassStartupDelay: true,
+      reopenSaveDialogOnError: true,
+    });
+    expect(result).toEqual({ globalId: "saved:abc123" });
   });
 
-  it("writes HTML to the content cache under the item's globalId", async () => {
+  it("normalizes URLs before saving", async () => {
     const { saveUrlInDesktop } = await import("./save-url.js");
-    const item = await saveUrlInDesktop(SAMPLE_URL);
-    expect(mockCacheSet).toHaveBeenCalledWith(
-      item.globalId,
-      "<article><p>Hello world.</p></article>",
+
+    await saveUrlInDesktop("https://example.com/articles/hello-world#section");
+
+    expect(mockDocAddStubItem).toHaveBeenCalledWith(
+      "https://example.com/articles/hello-world#section",
+      undefined,
     );
   });
 
-  it("persists the item to Automerge with saved=true and platform=saved", async () => {
+  it("rejects invalid URLs instead of creating a stub", async () => {
     const { saveUrlInDesktop } = await import("./save-url.js");
-    const item = await saveUrlInDesktop(SAMPLE_URL);
-    expect(item.platform).toBe("saved");
-    expect(item.userState.saved).toBe(true);
-    expect(item.globalId).toMatch(/^saved:/);
-    expect(mockDocAdd).toHaveBeenCalledWith(item);
+
+    await expect(saveUrlInDesktop("notaurl")).rejects.toThrow("Invalid URL");
+    expect(mockDocAddStubItem).not.toHaveBeenCalled();
+    expect(mockEnqueue).not.toHaveBeenCalled();
   });
 
-  it("sets the linkPreview URL, title, and description from metadata", async () => {
+  it("rejects unsupported protocols with a specific error", async () => {
     const { saveUrlInDesktop } = await import("./save-url.js");
-    const item = await saveUrlInDesktop(SAMPLE_URL);
-    expect(item.content.linkPreview?.url).toBe(SAMPLE_URL);
-    expect(item.content.linkPreview?.title).toBe("Test Article");
-    expect(item.content.linkPreview?.description).toBe("A short description.");
-  });
 
-  it("does NOT include html in preservedContent (keeps Automerge small)", async () => {
-    const { saveUrlInDesktop } = await import("./save-url.js");
-    const item = await saveUrlInDesktop(SAMPLE_URL);
-    expect("html" in (item.preservedContent ?? {})).toBe(false);
-  });
-
-  it("stores only a compact synced excerpt in preservedContent.text", async () => {
-    mockExtractContent.mockReturnValue(
-      makeContent({
-        text: `${"Paragraph with   noisy spacing. ".repeat(120)}Tail text that should never survive the trim.`,
-      }),
+    await expect(saveUrlInDesktop("ftp://example.com/article")).rejects.toThrow(
+      "Only http and https URLs are supported",
     );
-
-    const { saveUrlInDesktop } = await import("./save-url.js");
-    const item = await saveUrlInDesktop(SAMPLE_URL);
-
-    expect(item.preservedContent?.text.length).toBeLessThanOrEqual(MAX_SYNCED_PRESERVED_TEXT_CHARS);
-    expect(item.preservedContent?.text).not.toContain("  ");
-    expect(item.preservedContent?.text).not.toContain("Tail text that should never survive the trim.");
+    expect(mockDocAddStubItem).not.toHaveBeenCalled();
+    expect(mockEnqueue).not.toHaveBeenCalled();
   });
 
-  it("assigns user-supplied tags to the item", async () => {
+  it("does not enqueue details when stub persistence fails", async () => {
+    mockDocAddStubItem.mockRejectedValueOnce(new Error("Automerge unavailable"));
     const { saveUrlInDesktop } = await import("./save-url.js");
-    const item = await saveUrlInDesktop(SAMPLE_URL, { tags: ["Tech/AI", "Reading"] });
-    expect(item.userState.tags).toEqual(["Tech/AI", "Reading"]);
-  });
 
-  it("uses hostname as fallback author when siteName is absent", async () => {
-    mockExtractMetadata.mockReturnValue(makeMetadata({ siteName: undefined }));
-    const { saveUrlInDesktop } = await import("./save-url.js");
-    const item = await saveUrlInDesktop(SAMPLE_URL);
-    expect(item.author.displayName).toBe("example.com");
-  });
-
-  it("produces a stable globalId for the same URL", async () => {
-    const { saveUrlInDesktop } = await import("./save-url.js");
-    const a = await saveUrlInDesktop(SAMPLE_URL);
-    const b = await saveUrlInDesktop(SAMPLE_URL);
-    expect(a.globalId).toBe(b.globalId);
-  });
-
-  it("propagates IPC errors so callers can display toast.error", async () => {
-    mockInvoke.mockRejectedValue(new Error("Network unreachable"));
-    const { saveUrlInDesktop } = await import("./save-url.js");
-    await expect(saveUrlInDesktop(SAMPLE_URL)).rejects.toThrow("Network unreachable");
-    // Cache and Automerge must NOT have been touched
-    expect(mockCacheSet).not.toHaveBeenCalled();
-    expect(mockDocAdd).not.toHaveBeenCalled();
+    await expect(saveUrlInDesktop(SAMPLE_URL)).rejects.toThrow("Automerge unavailable");
+    expect(mockEnqueue).not.toHaveBeenCalled();
   });
 });

--- a/packages/desktop/src/lib/save-url.ts
+++ b/packages/desktop/src/lib/save-url.ts
@@ -2,60 +2,50 @@
  * Desktop URL save flow
  *
  * Architecture:
- *  1. Fetch raw HTML via `fetch_url` Tauri IPC (bypasses CORS + uses native HTTP)
- *  2. Extract metadata + article content in the renderer (DOMParser + Readability)
- *  3. Write full HTML to the device content cache (Layer 2 -- NOT Automerge)
- *  4. Build a FeedItem with only preservedContent.text (no html) in Automerge
- *  5. Write the item to Automerge via docAddFeedItem()
+ *  1. Validate and normalize the URL.
+ *  2. Write a lightweight saved stub to Automerge.
+ *  3. Queue background detail fetching and cache hydration.
  */
 
-import { invoke } from "@tauri-apps/api/core";
-import {
-  extractMetadataBrowser,
-  extractContentBrowser,
-} from "@freed/capture-save/browser";
-import { buildSavedFeedItem } from "@freed/capture-save/normalize";
-import type { FeedItem } from "@freed/shared";
-import { contentCache } from "./content-cache.js";
-import { docAddFeedItem } from "./automerge.js";
-import { toSyncedPreservedText } from "./preserved-text.js";
+import { docAddStubItem } from "./automerge.js";
+import { enqueue } from "./content-fetcher.js";
 
 export interface SaveUrlOptions {
   tags?: string[];
 }
 
+export interface SaveUrlResult {
+  globalId: string;
+}
+
 /**
  * Save a URL to the Freed desktop library.
  *
- * Fetches, extracts, caches HTML locally, then writes metadata to Automerge.
- * Full HTML never touches Automerge -- that keeps the CRDT small and sync fast.
+ * The user-visible save path only writes a stub. Detail fetching runs through
+ * the background content fetcher so the modal can close immediately.
  */
 export async function saveUrlInDesktop(
   url: string,
   options: SaveUrlOptions = {},
-): Promise<FeedItem> {
-  // Step 1: Fetch raw HTML via Tauri IPC
-  const html = await invoke<string>("fetch_url", { url });
+): Promise<SaveUrlResult> {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error("Invalid URL");
+  }
 
-  // Step 2: Extract metadata and content in the renderer (browser-safe)
-  const metadata = {
-    ...extractMetadataBrowser(html, url),
-    url,
-  };
-  const content = extractContentBrowser(html, url);
-  const item = buildSavedFeedItem(metadata, content, {
-    tags: options.tags,
-    includeSourceUrl: true,
-    preservedText: toSyncedPreservedText(content.text),
+  if (!["http:", "https:"].includes(parsed.protocol)) {
+    throw new Error("Only http and https URLs are supported");
+  }
+
+  const stableUrl = parsed.toString();
+  const item = await docAddStubItem(stableUrl, options.tags);
+  enqueue([item], {
+    priority: true,
+    force: true,
+    bypassStartupDelay: true,
+    reopenSaveDialogOnError: true,
   });
-
-  // Step 3: Write Readability-extracted article HTML to device content cache.
-  // Intentionally NOT the raw page HTML -- that contains <style>, <script>,
-  // and other full-page elements that would leak into the app DOM.
-  await contentCache.set(item.globalId, content.html);
-
-  // Step 5: Write to Automerge (syncs to all devices via relay)
-  await docAddFeedItem(item);
-
-  return item;
+  return { globalId: item.globalId };
 }

--- a/packages/pwa/src/lib/save-url.test.ts
+++ b/packages/pwa/src/lib/save-url.test.ts
@@ -1,146 +1,36 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi, beforeEach } from "vitest";
 
-const mockDocAddFeedItem = vi.fn(async () => undefined);
 const mockDocAddStubItem = vi.fn(async () => undefined);
-const mockToastInfo = vi.fn();
-const mockBuildSavedFeedItem = vi.fn();
-const mockExtractMetadataBrowser = vi.fn();
-const mockExtractContentBrowser = vi.fn();
-const mockCacheArticleHtml = vi.fn(async () => undefined);
-const mockWarmArticleImageCache = vi.fn(async () => undefined);
 
 vi.mock("./automerge", () => ({
-  docAddFeedItem: mockDocAddFeedItem,
   docAddStubItem: mockDocAddStubItem,
 }));
 
-vi.mock("@freed/ui/components/Toast", () => ({
-  toast: {
-    info: mockToastInfo,
-  },
-}));
-
-vi.mock("@freed/capture-save/browser", () => ({
-  extractMetadataBrowser: mockExtractMetadataBrowser,
-  extractContentBrowser: mockExtractContentBrowser,
-}));
-
 vi.mock("@freed/capture-save/normalize", () => ({
-  buildSavedFeedItem: mockBuildSavedFeedItem,
   hashSavedUrl: (url: string) => url === "https://example.com/article" ? "abc123" : "stub123",
-}));
-
-vi.mock("@freed/ui/lib/article-cache", () => ({
-  cacheArticleHtml: mockCacheArticleHtml,
-  warmArticleImageCache: mockWarmArticleImageCache,
 }));
 
 describe("saveUrlInPwa", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-
-    mockExtractMetadataBrowser.mockReturnValue({
-      url: "https://example.com/article",
-      title: "Saved Article",
-      description: "Short summary",
-      siteName: "example.com",
-    });
-    mockExtractContentBrowser.mockReturnValue({
-      html: "<article><p>Readable body</p></article>",
-      text: "Readable body",
-      wordCount: 2,
-      readingTime: 1,
-    });
-    mockBuildSavedFeedItem.mockReturnValue({
-      globalId: "saved:abc123",
-      platform: "saved",
-      contentType: "article",
-      capturedAt: 1,
-      publishedAt: 1,
-      author: { id: "example.com", handle: "example.com", displayName: "example.com" },
-      content: {
-        text: "Short summary",
-        mediaUrls: [],
-        mediaTypes: [],
-        linkPreview: {
-          url: "https://example.com/article",
-          title: "Saved Article",
-          description: "Short summary",
-        },
-      },
-      preservedContent: {
-        text: "Readable body",
-        wordCount: 2,
-        readingTime: 1,
-        preservedAt: 1,
-      },
-      userState: { hidden: false, saved: true, savedAt: 1, archived: false, tags: ["research"] },
-      topics: [],
-      sourceUrl: "https://example.com/article",
-      priority: 50,
-      priorityComputedAt: 1,
-    });
-
-    vi.stubGlobal("fetch", vi.fn(async () => ({
-      ok: true,
-      text: async () => "<html><body><article><p>Readable body</p></article></body></html>",
-    })));
   });
 
-  afterEach(() => {
-    vi.unstubAllGlobals();
-  });
-
-  it("writes a full saved item and caches readable HTML when proxy fetch succeeds", async () => {
+  it("writes a saved stub without foreground article fetching", async () => {
+    vi.stubGlobal("fetch", vi.fn());
     const { saveUrlInPwa } = await import("./save-url");
 
     const result = await saveUrlInPwa("https://example.com/article", { tags: ["research"] });
 
-    expect(fetch).toHaveBeenCalledWith("/api/fetch-url", expect.objectContaining({
-      method: "POST",
-    }));
-    expect(mockDocAddFeedItem).toHaveBeenCalledWith(
-      expect.objectContaining({
-        globalId: "saved:abc123",
-        platform: "saved",
-      }),
-    );
-    expect(mockDocAddStubItem).not.toHaveBeenCalled();
-    expect(mockCacheArticleHtml).toHaveBeenCalledWith(
-      "https://example.com/article",
-      "saved:abc123",
-      "<article><p>Readable body</p></article>",
-      { pinned: true },
-    );
-    expect(mockWarmArticleImageCache).toHaveBeenCalledWith(
-      "<article><p>Readable body</p></article>",
-      "https://example.com/article",
-    );
-    expect(result).toEqual({ globalId: "saved:abc123" });
-  });
-
-  it("falls back to a stub item and shows an info toast when proxy fetch fails", async () => {
-    vi.stubGlobal("fetch", vi.fn(async () => ({
-      ok: false,
-      text: async () => "blocked",
-    })));
-
-    const { saveUrlInPwa } = await import("./save-url");
-    const result = await saveUrlInPwa("https://example.com/article", { tags: ["research"] });
-
-    expect(mockDocAddFeedItem).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
     expect(mockDocAddStubItem).toHaveBeenCalledWith("https://example.com/article", ["research"]);
-    expect(mockToastInfo).toHaveBeenCalledWith(
-      "Saved a stub. Full article content will arrive after your next desktop sync.",
-    );
-    expect(result.globalId).toMatch(/^saved:/);
+    expect(result).toEqual({ globalId: "saved:abc123" });
+    vi.unstubAllGlobals();
   });
 
   it("rejects invalid URLs instead of silently creating a stub", async () => {
     const { saveUrlInPwa } = await import("./save-url");
 
     await expect(saveUrlInPwa("notaurl")).rejects.toThrow("Invalid URL");
-    expect(mockDocAddFeedItem).not.toHaveBeenCalled();
     expect(mockDocAddStubItem).not.toHaveBeenCalled();
   });
 
@@ -150,19 +40,15 @@ describe("saveUrlInPwa", () => {
     await expect(saveUrlInPwa("ftp://example.com/article")).rejects.toThrow(
       "Only http and https URLs are supported",
     );
-    expect(mockDocAddFeedItem).not.toHaveBeenCalled();
     expect(mockDocAddStubItem).not.toHaveBeenCalled();
   });
 
-  it("does not fall back to a stub when Automerge persistence fails", async () => {
-    mockDocAddFeedItem.mockRejectedValueOnce(new Error("Automerge unavailable"));
-
+  it("propagates Automerge persistence failures", async () => {
+    mockDocAddStubItem.mockRejectedValueOnce(new Error("Automerge unavailable"));
     const { saveUrlInPwa } = await import("./save-url");
 
     await expect(saveUrlInPwa("https://example.com/article")).rejects.toThrow(
       "Automerge unavailable",
     );
-    expect(mockDocAddStubItem).not.toHaveBeenCalled();
-    expect(mockToastInfo).not.toHaveBeenCalled();
   });
 });

--- a/packages/pwa/src/lib/save-url.ts
+++ b/packages/pwa/src/lib/save-url.ts
@@ -1,13 +1,5 @@
-import {
-  extractContentBrowser,
-  extractMetadataBrowser,
-} from "@freed/capture-save/browser";
-import { buildSavedFeedItem, hashSavedUrl } from "@freed/capture-save/normalize";
-import { cacheArticleHtml, warmArticleImageCache } from "@freed/ui/lib/article-cache";
-import { toast } from "@freed/ui/components/Toast";
-import { docAddFeedItem, docAddStubItem } from "./automerge";
-
-const FETCH_ENDPOINT = "/api/fetch-url";
+import { hashSavedUrl } from "@freed/capture-save/normalize";
+import { docAddStubItem } from "./automerge";
 
 export interface SaveUrlOptions {
   tags?: string[];
@@ -15,21 +7,6 @@ export interface SaveUrlOptions {
 
 export interface SaveUrlResult {
   globalId: string;
-}
-
-async function fetchArticleHtml(url: string): Promise<string> {
-  const response = await fetch(FETCH_ENDPOINT, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ url }),
-    signal: AbortSignal.timeout(20_000),
-  });
-
-  const body = await response.text();
-  if (!response.ok) {
-    throw new Error(body || "Failed to fetch article HTML");
-  }
-  return body;
 }
 
 export async function saveUrlInPwa(
@@ -48,27 +25,6 @@ export async function saveUrlInPwa(
   }
 
   const stableUrl = parsed.toString();
-  let articleHtml: string;
-  let item: ReturnType<typeof buildSavedFeedItem>;
-
-  try {
-    const rawHtml = await fetchArticleHtml(stableUrl);
-    const metadata = extractMetadataBrowser(rawHtml, stableUrl);
-    const content = extractContentBrowser(rawHtml, stableUrl);
-    item = buildSavedFeedItem(metadata, content, {
-      tags: options.tags,
-      includeSourceUrl: true,
-      includePriorityFields: true,
-    });
-    articleHtml = content.html;
-  } catch {
-    await docAddStubItem(stableUrl, options.tags);
-    toast.info("Saved a stub. Full article content will arrive after your next desktop sync.");
-    return { globalId: `saved:${hashSavedUrl(stableUrl)}` };
-  }
-
-  await cacheArticleHtml(stableUrl, item.globalId, articleHtml, { pinned: true });
-  void warmArticleImageCache(articleHtml, stableUrl);
-  await docAddFeedItem(item);
-  return { globalId: item.globalId };
+  await docAddStubItem(stableUrl, options.tags);
+  return { globalId: `saved:${hashSavedUrl(stableUrl)}` };
 }

--- a/packages/ui/src/components/SavedContentDialog.tsx
+++ b/packages/ui/src/components/SavedContentDialog.tsx
@@ -13,12 +13,14 @@ import { useAppStore, usePlatform } from "../context/PlatformContext.js";
 interface SavedContentDialogProps {
   open: boolean;
   initialUrl?: string;
+  initialError?: string;
   onClose: () => void;
 }
 
 export function SavedContentDialog({
   open,
   initialUrl = "",
+  initialError = "",
   onClose,
 }: SavedContentDialogProps) {
   const { saveUrl } = usePlatform();
@@ -27,7 +29,7 @@ export function SavedContentDialog({
 
   return (
     <BottomSheet open={open} onClose={handleClose} title="Save Content" maxWidth="sm:max-w-lg" headerDivider={false}>
-      {saveUrl && <SaveUrlTab initialUrl={initialUrl} open={open} onClose={handleClose} />}
+      {saveUrl && <SaveUrlTab initialUrl={initialUrl} initialError={initialError} open={open} onClose={handleClose} />}
     </BottomSheet>
   );
 }
@@ -36,10 +38,12 @@ export function SavedContentDialog({
 
 function SaveUrlTab({
   initialUrl,
+  initialError,
   open,
   onClose,
 }: {
   initialUrl: string;
+  initialError: string;
   open: boolean;
   onClose: () => void;
 }) {
@@ -50,39 +54,63 @@ function SaveUrlTab({
   const setSelectedPerson = useAppStore((s) => s.setSelectedPerson);
   const setSelectedAccount = useAppStore((s) => s.setSelectedAccount);
   const [url, setUrl] = useState(initialUrl);
-  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(initialError);
 
   useEffect(() => {
     if (open) {
       setUrl(initialUrl);
+      setError(initialError);
     }
-  }, [initialUrl, open]);
+  }, [initialError, initialUrl, open]);
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     const trimmed = url.trim();
     if (!trimmed || !saveUrl) return;
 
-    setLoading(true);
+    let parsed: URL;
     try {
-      const saved = await saveUrl(trimmed);
-      setUrl("");
-      toast.success("Saved to library");
-      setActiveView("feed");
-      setFilter({ savedOnly: true });
-      setSelectedPerson(null);
-      setSelectedAccount(null);
-      setSelectedItem(saved.globalId);
-      onClose();
-    } catch (err) {
-      toast.error(err instanceof Error ? err.message : "Failed to save URL");
-    } finally {
-      setLoading(false);
+      parsed = new URL(trimmed);
+    } catch {
+      setError("Invalid URL");
+      return;
     }
+
+    if (!["http:", "https:"].includes(parsed.protocol)) {
+      setError("Only http and https URLs are supported");
+      return;
+    }
+
+    const stableUrl = parsed.toString();
+    setError("");
+    setUrl("");
+    toast.success("Saved to library");
+    onClose();
+
+    void saveUrl(stableUrl)
+      .then((saved) => {
+        setActiveView("feed");
+        setFilter({ savedOnly: true });
+        setSelectedPerson(null);
+        setSelectedAccount(null);
+        setSelectedItem(saved.globalId);
+      })
+      .catch((err) => {
+        const message = err instanceof Error ? err.message : "Failed to save URL";
+        toast.error(message);
+        window.dispatchEvent(
+          new CustomEvent("freed:save-content-details-error", {
+            detail: {
+              initialUrl: stableUrl,
+              errorMessage: message,
+            },
+          }),
+        );
+      });
   };
 
   return (
-    <form onSubmit={handleSubmit}>
+    <form onSubmit={handleSubmit} noValidate>
       <div className="mb-4">
         <label htmlFor="save-url-input" className="mb-2 block text-sm text-[var(--theme-text-secondary)]">
           Article or page URL
@@ -91,27 +119,27 @@ function SaveUrlTab({
           id="save-url-input"
           type="url"
           value={url}
-          onChange={(e) => setUrl(e.target.value)}
+          onChange={(e) => {
+            setUrl(e.target.value);
+            if (error) setError("");
+          }}
           placeholder="https://example.com/article"
           className="w-full rounded-xl border border-[var(--theme-border-subtle)] bg-[var(--theme-bg-input)] px-4 py-3 text-[var(--theme-text-primary)] placeholder-[var(--theme-text-muted)] transition-colors focus:outline-none focus:border-[var(--theme-border-strong)]"
-          disabled={loading}
           autoFocus
         />
+        {error && (
+          <p className="mt-2 rounded-lg border border-amber-500/25 bg-amber-500/10 px-3 py-2 text-sm text-amber-200">
+            {error}
+          </p>
+        )}
       </div>
       <div className="flex justify-end">
         <button
           type="submit"
           className="btn-primary px-6 py-2.5 disabled:opacity-50 disabled:cursor-not-allowed"
-          disabled={loading || !url.trim()}
+          disabled={!url.trim()}
         >
-          {loading ? (
-            <span className="flex items-center gap-2">
-              <span className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
-              Saving...
-            </span>
-          ) : (
-            "Save"
-          )}
+          Save
         </button>
       </div>
     </form>

--- a/packages/ui/src/components/feed/ReaderView.tsx
+++ b/packages/ui/src/components/feed/ReaderView.tsx
@@ -380,6 +380,12 @@ export function ReaderView({
   const [threadReplyMessage, setThreadReplyMessage] = useState<string | null>(null);
 
   const articleUrl = item.content.linkPreview?.url;
+  const pendingSavedUrlDetails =
+    item.platform === "saved" &&
+    item.userState.saved &&
+    Boolean(articleUrl) &&
+    !item.preservedContent?.text &&
+    item.content.text === articleUrl;
   const displayMediaUrls = readerMediaUrls ?? item.content.mediaUrls;
   const displayMediaTypes = readerMediaTypes ?? item.content.mediaTypes;
   const isStory = item.contentType === "story";
@@ -483,6 +489,7 @@ export function ReaderView({
       const shouldHydrateLive =
         Boolean(hydrateReaderItem) &&
         navigator.onLine &&
+        !pendingSavedUrlDetails &&
         (!hasReaderContent || (readerContentSource !== "cache" && shouldPin));
 
       if (shouldHydrateLive && hydrateReaderItem) {
@@ -530,7 +537,7 @@ export function ReaderView({
       }
 
       // Layer 4: browser fetch fallback for platforms without a native hydrator.
-      if (articleUrl && navigator.onLine) {
+      if (articleUrl && navigator.onLine && !pendingSavedUrlDetails) {
         setIsCaching(true);
         liveFetch(
           articleUrl,
@@ -558,6 +565,10 @@ export function ReaderView({
         if (!cancelled) {
           setHtml(null);
           setContentSource(null);
+          if (pendingSavedUrlDetails) {
+            setHydrationStatus("partial");
+            setHydrationMessage("Freed is saving details for this URL in the background.");
+          }
           if (isStory && displayMediaUrls.length === 0) {
             setHydrationStatus("expired");
             setHydrationMessage("This story media was not captured before the source expired it.");
@@ -583,6 +594,7 @@ export function ReaderView({
     pinReaderItem,
     item.preservedContent?.text,
     item.userState.saved,
+    pendingSavedUrlDetails,
   ]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleLoadThreadReplies = useCallback(async () => {
@@ -953,7 +965,7 @@ export function ReaderView({
         )}
 
         {/* Content */}
-        {isLoading ? (
+        {isLoading || pendingSavedUrlDetails ? (
           <div className="flex justify-center py-16">
             <div className="w-8 h-8 rounded-full border-2 border-[var(--theme-border-quiet)] border-t-[var(--theme-accent-secondary)] animate-spin" />
           </div>

--- a/packages/ui/src/components/layout/AppShell.tsx
+++ b/packages/ui/src/components/layout/AppShell.tsx
@@ -122,6 +122,7 @@ export function AppShell({ children }: AppShellProps) {
   const savedContentInitialUrl = useCommandSurfaceStore((s) => s.savedContentInitialUrl);
   const openSavedContentDialog = useCommandSurfaceStore((s) => s.openSavedContentDialog);
   const closeSavedContentDialog = useCommandSurfaceStore((s) => s.closeSavedContentDialog);
+  const [savedContentError, setSavedContentError] = useState("");
   const libraryDialogOpen = useCommandSurfaceStore((s) => s.libraryDialogOpen);
   const libraryDialogTab = useCommandSurfaceStore((s) => s.libraryDialogTab);
   const closeLibraryDialog = useCommandSurfaceStore((s) => s.closeLibraryDialog);
@@ -174,13 +175,28 @@ export function AppShell({ children }: AppShellProps) {
 
   useEffect(() => {
     const handleOpenSavedContent = (event: Event) => {
-      const detail = (event as CustomEvent<{ initialUrl?: string }>).detail;
+      const detail = (event as CustomEvent<{ initialUrl?: string; errorMessage?: string }>).detail;
+      setSavedContentError(detail?.errorMessage ?? "");
+      openSavedContentDialog(detail?.initialUrl);
+    };
+    const handleSaveDetailsError = (event: Event) => {
+      const detail = (event as CustomEvent<{ initialUrl?: string; errorMessage?: string }>).detail;
+      setSavedContentError(detail?.errorMessage ?? "Freed could not save details for this URL.");
       openSavedContentDialog(detail?.initialUrl);
     };
 
     window.addEventListener("freed:open-save-content-dialog", handleOpenSavedContent);
-    return () => window.removeEventListener("freed:open-save-content-dialog", handleOpenSavedContent);
+    window.addEventListener("freed:save-content-details-error", handleSaveDetailsError);
+    return () => {
+      window.removeEventListener("freed:open-save-content-dialog", handleOpenSavedContent);
+      window.removeEventListener("freed:save-content-details-error", handleSaveDetailsError);
+    };
   }, [openSavedContentDialog]);
+
+  const handleCloseSavedContentDialog = useCallback(() => {
+    setSavedContentError("");
+    closeSavedContentDialog();
+  }, [closeSavedContentDialog]);
 
   const forceCompactDesktopSidebar = !isMobileDevice && isMobileViewport;
   const effectiveDesktopSidebarDisplayMode =
@@ -601,7 +617,8 @@ export function AppShell({ children }: AppShellProps) {
         <SavedContentDialog
           open={savedContentOpen}
           initialUrl={savedContentInitialUrl}
-          onClose={closeSavedContentDialog}
+          initialError={savedContentError}
+          onClose={handleCloseSavedContentDialog}
         />
         {libraryDialogOpen ? (
           <LibraryDialog


### PR DESCRIPTION
(AI Generated).

Summary:
- Save URL submissions now persist a lightweight stub first so the Save Content dialog closes immediately.
- Queue Desktop detail hydration through the background content fetcher, with startup delay bypass for user initiated saves.
- Reopen the Save Content dialog with the URL and error message when stub persistence or background detail hydration fails.
- Show a reader spinner for saved URL stubs while details are still loading.
- Update phase docs for the stub first save flow.

Tests:
- npm run validate:feature
- PATH=/Users/aubreyfalconer/dev/freed-background-content-details/node_modules/.bin:$PATH npm run test:unit -- save-url.test.ts content-fetcher.test.ts, from packages/desktop
- PATH=/Users/aubreyfalconer/dev/freed-background-content-details/node_modules/.bin:$PATH npm run test:unit -- save-url.test.ts, from packages/pwa

Preview:
- http://localhost:1421