### PR TITLE
fix: make the CI perf regression gate actually fail on regressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,8 @@ jobs:
         env:
           CI: "true"
 
+      # Write the comparison to a file instead of piping through `tee`: the
+      # pipe swallowed perf-compare's exit(1), so the gate could never fail.
       - name: Run perf regression check
         if: always()
         run: |
@@ -113,10 +115,14 @@ jobs:
               packages/desktop/playwright-report/perf-results.json \
               packages/desktop/tests/e2e/perf-baselines.json \
               packages/desktop/tests/e2e/perf-budgets.json \
-              | tee perf-comparison.md
+              > perf-comparison.md
           else
             echo "No perf results found - skipping comparison"
           fi
+
+      - name: Print perf comparison
+        if: always() && hashFiles('perf-comparison.md') != ''
+        run: cat perf-comparison.md
 
       - name: Comment perf comparison on PR
         if: always() && hashFiles('perf-comparison.md') != ''

--- a/docs/STABILITY-PROGRAM.md
+++ b/docs/STABILITY-PROGRAM.md
@@ -38,7 +38,7 @@ Every claim above cites code in [stability-findings.json](stability-findings.jso
 | [W1-05](stability-tasks/W1-05-build-feature-skill-counters.md) | freed-build-feature: verification-counters step + outcome recording | no | ☑ |
 | [W1-06](stability-tasks/W1-06-provider-visible-single-source.md) | Single-source provider-visible path list; publish-time enforcement | no | ☑ |
 | [W1-07](stability-tasks/W1-07-docs-truth-pass.md) | Regenerate ARCHITECTURE.md; fix AGENTS.md roadmap rule; canonical soak doc | yes | ☑ |
-| [P0-01](stability-tasks/P0-01-perf-gate-pipefail.md) | Make the CI perf gate actually fail (tee swallows exit code) | yes | ☐ |
+| [P0-01](stability-tasks/P0-01-perf-gate-pipefail.md) | Make the CI perf gate actually fail (tee swallows exit code) | yes | ☑ |
 | [P0-02](stability-tasks/P0-02-window-kill-records.md) | Structured window_destroyed kill records | no | ☑ |
 | [P0-03](stability-tasks/P0-03-loop-counters.md) | Loop counters: uploads w/ heads-unchanged, broadcasts, worker INITs, scrape outcomes | no | ☑ |
 | [P0-04](stability-tasks/P0-04-runtime-health-rotation.md) | Daily runtime-health rotation replacing the 5 MiB halving cap | no | ☑ |


### PR DESCRIPTION
(AI Generated).

## Summary
- Stability program task [P0-01](https://github.com/freed-project/freed/blob/dev/docs/stability-tasks/P0-01-perf-gate-pipefail.md): the perf regression step in ci.yml piped perf-compare output through tee without pipefail, so exit(1) from scripts/perf-compare.ts was swallowed and the gate could never fail (stability-findings.json scaffolding finding: "CI perf regression gate never fails the build").
- Split the step per the task recommendation: perf-compare now redirects its report to perf-comparison.md so its exit code fails the step, and a separate always() step prints the report. The existing PR-comment and artifact-upload steps are unchanged and still run via always().
- Checked the P0-01 box in docs/STABILITY-PROGRAM.md per program rule 3.

## Testing
- Throwaway red-check: a branch with an intentionally regressed perf-baselines.json value must turn the Validation perf step red (run against this branch; see PR thread for result).
- Normal PRs stay green: this PR runs the same workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)