### PR TITLE
chore: move automation loop state out of /tmp and auto-record merge outcomes

### DIFF
--- a/docs/NIGHTLY-SELF-IMPROVE.md
+++ b/docs/NIGHTLY-SELF-IMPROVE.md
@@ -6,9 +6,9 @@ The first rule is simple: evidence first, code second. If a target has weak evid
 
 ## What It Reads
 
-- Active soak pointer at `~/.freed-automation/current-soak-dir` (legacy `/tmp/freed-perf-soak/current-soak-dir` is still read and migrated for one release)
+- Active soak pointer at `~/.freed/automation/current-soak-dir` (legacy `/tmp/freed-perf-soak/current-soak-dir` is still read and migrated for one release)
 - Soak files such as `metrics.tsv` and `runtime-health.jsonl`
-- The newest readable soak under `~/.freed-automation/soaks` (or the legacy `/tmp/freed-perf-soak`) when the active pointer has no samples
+- The newest readable soak under `~/.freed/automation/soaks` (or the legacy `/tmp/freed-perf-soak`) when the active pointer has no samples
 - Daily bug scan memory at `/Users/aubreyfalconer/.codex/automations/daily-bug-scan/memory.md`
 - Crash-watch automation state
 - Hourly dev bot memory as a roadmap fallback
@@ -16,7 +16,7 @@ The first rule is simple: evidence first, code second. If a target has weak evid
 - Local git worktrees with unmerged or uncommitted changes
 - Duplicate peer work indicators such as shared changed files, shared package surfaces, and shared provider-visible risk
 - Provider-visible peer worktrees, even when they are not runner branches
-- Prior outcome ledger at `~/.freed-automation/outcomes.jsonl` (legacy `/tmp/freed-nightly-self-improve/outcomes.jsonl` is still read and migrated for one release)
+- Prior outcome ledger at `~/.freed/automation/outcomes.jsonl` (legacy `/tmp/freed-nightly-self-improve/outcomes.jsonl` is still read and migrated for one release)
 - Preflight risks such as dirty worktrees, generated artifacts, stale or thin soak samples, missing dependencies, missing evidence files, and paused automations
 - Preflight actions that separate safe local commands from manual or agent-tool-only remediation
 
@@ -71,13 +71,13 @@ node scripts/nightly-self-improve.mjs --repair-soak-pointer
 Use a custom outcome ledger:
 
 ```bash
-node scripts/nightly-self-improve.mjs --outcome-ledger ~/.freed-automation/outcomes.jsonl
+node scripts/nightly-self-improve.mjs --outcome-ledger ~/.freed/automation/outcomes.jsonl
 ```
 
 Record a finished target directly into the ledger:
 
 ```bash
-node scripts/nightly-self-improve.mjs --outcome-ledger ~/.freed-automation/outcomes.jsonl --record-outcome webkit-memory-pressure --record-kind performance --record-status shipped --record-pr 617 --record-build v26.5.2900-dev --record-notes "Merged, installed, and soaked."
+node scripts/nightly-self-improve.mjs --outcome-ledger ~/.freed/automation/outcomes.jsonl --record-outcome webkit-memory-pressure --record-kind performance --record-status shipped --record-pr 617 --record-build v26.5.2900-dev --record-notes "Merged, installed, and soaked."
 ```
 
 The short form for post-merge recording is `scripts/record-outcome.mjs`. `scripts/worktree-cleanup.sh` calls it automatically when it removes a merged worktree or branch, so routine merges land in the ledger without a manual step:
@@ -86,7 +86,7 @@ The short form for post-merge recording is `scripts/record-outcome.mjs`. `script
 node scripts/record-outcome.mjs --id W1-01 --status shipped --pr 897 --build v26.7.204-dev
 ```
 
-State files live under `~/.freed-automation/` (`outcomes.jsonl`, `current-soak-dir`, and generated run directories under `runs/`) so they survive reboots; macOS clears `/tmp`, which used to erase the planner's memory.
+State files live under `~/.freed/automation/` (`outcomes.jsonl`, `current-soak-dir`, and generated run directories under `runs/`) so they survive reboots; macOS clears `/tmp`, which used to erase the planner's memory.
 
 The generated run directory contains:
 

--- a/docs/NIGHTLY-SELF-IMPROVE.md
+++ b/docs/NIGHTLY-SELF-IMPROVE.md
@@ -6,9 +6,9 @@ The first rule is simple: evidence first, code second. If a target has weak evid
 
 ## What It Reads
 
-- Active soak pointer at `/tmp/freed-perf-soak/current-soak-dir`
+- Active soak pointer at `~/.freed-automation/current-soak-dir` (legacy `/tmp/freed-perf-soak/current-soak-dir` is still read and migrated for one release)
 - Soak files such as `metrics.tsv` and `runtime-health.jsonl`
-- The newest readable soak under `/tmp/freed-perf-soak` when the active pointer has no samples
+- The newest readable soak under `~/.freed-automation/soaks` (or the legacy `/tmp/freed-perf-soak`) when the active pointer has no samples
 - Daily bug scan memory at `/Users/aubreyfalconer/.codex/automations/daily-bug-scan/memory.md`
 - Crash-watch automation state
 - Hourly dev bot memory as a roadmap fallback
@@ -16,7 +16,7 @@ The first rule is simple: evidence first, code second. If a target has weak evid
 - Local git worktrees with unmerged or uncommitted changes
 - Duplicate peer work indicators such as shared changed files, shared package surfaces, and shared provider-visible risk
 - Provider-visible peer worktrees, even when they are not runner branches
-- Prior outcome ledger at `/tmp/freed-nightly-self-improve/outcomes.jsonl`
+- Prior outcome ledger at `~/.freed-automation/outcomes.jsonl` (legacy `/tmp/freed-nightly-self-improve/outcomes.jsonl` is still read and migrated for one release)
 - Preflight risks such as dirty worktrees, generated artifacts, stale or thin soak samples, missing dependencies, missing evidence files, and paused automations
 - Preflight actions that separate safe local commands from manual or agent-tool-only remediation
 
@@ -71,14 +71,22 @@ node scripts/nightly-self-improve.mjs --repair-soak-pointer
 Use a custom outcome ledger:
 
 ```bash
-node scripts/nightly-self-improve.mjs --outcome-ledger /tmp/freed-nightly-self-improve/outcomes.jsonl
+node scripts/nightly-self-improve.mjs --outcome-ledger ~/.freed-automation/outcomes.jsonl
 ```
 
 Record a finished target directly into the ledger:
 
 ```bash
-node scripts/nightly-self-improve.mjs --outcome-ledger /tmp/freed-nightly-self-improve/outcomes.jsonl --record-outcome webkit-memory-pressure --record-kind performance --record-status shipped --record-pr 617 --record-build v26.5.2900-dev --record-notes "Merged, installed, and soaked."
+node scripts/nightly-self-improve.mjs --outcome-ledger ~/.freed-automation/outcomes.jsonl --record-outcome webkit-memory-pressure --record-kind performance --record-status shipped --record-pr 617 --record-build v26.5.2900-dev --record-notes "Merged, installed, and soaked."
 ```
+
+The short form for post-merge recording is `scripts/record-outcome.mjs`. `scripts/worktree-cleanup.sh` calls it automatically when it removes a merged worktree or branch, so routine merges land in the ledger without a manual step:
+
+```bash
+node scripts/record-outcome.mjs --id W1-01 --status shipped --pr 897 --build v26.7.204-dev
+```
+
+State files live under `~/.freed-automation/` (`outcomes.jsonl`, `current-soak-dir`, and generated run directories under `runs/`) so they survive reboots; macOS clears `/tmp`, which used to erase the planner's memory.
 
 The generated run directory contains:
 

--- a/docs/STABILITY-PROGRAM.md
+++ b/docs/STABILITY-PROGRAM.md
@@ -31,7 +31,7 @@ Every claim above cites code in [stability-findings.json](stability-findings.jso
 
 | Task | Title | runner-safe | Status |
 | ---- | ----- | ----------- | ------ |
-| [W1-01](stability-tasks/W1-01-automation-state-out-of-tmp.md) | Move loop state out of /tmp; auto-record outcomes on merge | yes | ☐ |
+| [W1-01](stability-tasks/W1-01-automation-state-out-of-tmp.md) | Move loop state out of /tmp; auto-record outcomes on merge | yes | ☑ |
 | [W1-02](stability-tasks/W1-02-soak-collector-and-assert.md) | Check in soak collector + soak-assert with machine-readable verdict | yes | ☑ |
 | [W1-03](stability-tasks/W1-03-doctor-preflight.md) | scripts/doctor.mjs machine preflight for all loops | yes | ☐ |
 | [W1-04](stability-tasks/W1-04-fix-ship-build-skill.md) | Rewrite freed-ship-build skill against actual release scripts | no | ☑ |

--- a/docs/stability-tasks/W1-01-automation-state-out-of-tmp.md
+++ b/docs/stability-tasks/W1-01-automation-state-out-of-tmp.md
@@ -8,7 +8,7 @@ The nightly self-improve planner learns from an outcome ledger and an active-soa
 
 ## Change
 
-1. Move default state locations to `~/.freed-automation/` (create on demand): `outcomes.jsonl`, `current-soak-dir`, and any other /tmp-resident planner state. Keep CLI flags as overrides. Migrate/read legacy /tmp paths as fallback for one release.
+1. Move default state locations to `~/.freed/automation/` (create on demand): `outcomes.jsonl`, `current-soak-dir`, and any other /tmp-resident planner state. Keep CLI flags as overrides. Migrate/read legacy /tmp paths as fallback for one release.
 2. Auto-record outcomes: when a PR merges via the normal flow, append a ledger line automatically. Implement as a small `scripts/record-outcome.mjs` invoked from `scripts/worktree-publish.sh`'s merge-adjacent path or a post-merge helper the loops call; entry carries target id (e.g. this repo's stability task id or nightly target id), PR number, build, status.
 3. Update `docs/NIGHTLY-SELF-IMPROVE.md` paths.
 

--- a/scripts/nightly-self-improve.mjs
+++ b/scripts/nightly-self-improve.mjs
@@ -3,6 +3,7 @@
 import { execFileSync } from "node:child_process";
 import {
   appendFileSync,
+  copyFileSync,
   existsSync,
   mkdirSync,
   readdirSync,
@@ -27,8 +28,33 @@ const DEFAULT_CRASH_AUTOMATION =
   "/Users/aubreyfalconer/.codex/automations/crash-watch/automation.toml";
 const DEFAULT_DEV_BOT_MEMORY =
   "/Users/aubreyfalconer/.codex/automations/hourly-dev-bot/memory.md";
-const DEFAULT_SOAK_POINTER = "/tmp/freed-perf-soak/current-soak-dir";
-const DEFAULT_OUTCOME_LEDGER = "/tmp/freed-nightly-self-improve/outcomes.jsonl";
+// Planner learning state lives under the home directory so it survives
+// reboots; macOS periodically clears /tmp, which made the outcome ledger and
+// active-soak pointer amnesiac. The /tmp paths remain readable as a legacy
+// fallback for one release (see resolveStatePathWithLegacyFallback).
+export const AUTOMATION_STATE_DIR = path.join(os.homedir(), ".freed-automation");
+const LEGACY_SOAK_POINTER = "/tmp/freed-perf-soak/current-soak-dir";
+const LEGACY_OUTCOME_LEDGER = "/tmp/freed-nightly-self-improve/outcomes.jsonl";
+const DEFAULT_SOAK_POINTER = path.join(AUTOMATION_STATE_DIR, "current-soak-dir");
+const DEFAULT_OUTCOME_LEDGER = path.join(AUTOMATION_STATE_DIR, "outcomes.jsonl");
+const LEGACY_SOAK_ROOT = "/tmp/freed-perf-soak";
+
+export function resolveStatePathWithLegacyFallback(preferredPath, legacyPath, fsOps = {}) {
+  const ops = { existsSync, mkdirSync, copyFileSync, ...fsOps };
+  if (ops.existsSync(preferredPath)) {
+    return preferredPath;
+  }
+  if (legacyPath && ops.existsSync(legacyPath)) {
+    try {
+      ops.mkdirSync(path.dirname(preferredPath), { recursive: true });
+      ops.copyFileSync(legacyPath, preferredPath);
+      return preferredPath;
+    } catch {
+      return legacyPath;
+    }
+  }
+  return preferredPath;
+}
 const MAX_PEER_EVIDENCE_FILES = 12;
 const STALE_SOAK_MS = 2 * 60 * 60 * 1000;
 const MIN_PERFORMANCE_SOAK_SAMPLES = 3;
@@ -259,16 +285,21 @@ export function parseArgs(argv) {
   }
 
   args.repo = path.resolve(args.repo);
+  if (args.soakPointer === DEFAULT_SOAK_POINTER) {
+    args.soakPointer = resolveStatePathWithLegacyFallback(DEFAULT_SOAK_POINTER, LEGACY_SOAK_POINTER);
+  }
+  if (args.outcomeLedger === DEFAULT_OUTCOME_LEDGER) {
+    args.outcomeLedger = resolveStatePathWithLegacyFallback(
+      DEFAULT_OUTCOME_LEDGER,
+      LEGACY_OUTCOME_LEDGER,
+    );
+  }
   args.soakPointer = path.resolve(args.soakPointer);
   args.outcomeLedger = path.resolve(args.outcomeLedger);
   args.peerWorktrees = args.peerWorktrees.filter(Boolean).map((item) => path.resolve(item));
   args.runDir =
     args.runDir ||
-    path.join(
-      os.tmpdir(),
-      "freed-nightly-self-improve",
-      new Date().toISOString().replace(/[:.]/g, ""),
-    );
+    path.join(AUTOMATION_STATE_DIR, "runs", new Date().toISOString().replace(/[:.]/g, ""));
 
   return args;
 }
@@ -671,7 +702,16 @@ export function resolveReadableSoak(soakDir = "", pointerPath = DEFAULT_SOAK_POI
     return preferred;
   }
 
-  const fallbackDir = findLatestReadableSoakDir(path.dirname(preferredDir || DEFAULT_SOAK_POINTER), preferredDir);
+  // Only default invocations may widen the search to the machine-global soak
+  // roots (including the legacy /tmp root, kept readable for one release).
+  // Explicit --soak-dir/--soak-pointer callers stay scoped to their own root.
+  const usingDefaults = !soakDir && pointerPath === DEFAULT_SOAK_POINTER;
+  const fallbackDir =
+    findLatestReadableSoakDir(path.dirname(preferredDir || pointerPath), preferredDir) ||
+    (usingDefaults
+      ? findLatestReadableSoakDir(path.join(AUTOMATION_STATE_DIR, "soaks"), preferredDir) ||
+        findLatestReadableSoakDir(LEGACY_SOAK_ROOT, preferredDir)
+      : "");
   if (!fallbackDir) {
     return preferred;
   }
@@ -697,7 +737,12 @@ export function repairSoakPointer(pointerPath = DEFAULT_SOAK_POINTER, options = 
   }
 
   const rootDir = path.dirname(currentDir || pointerPath);
-  const readableDir = findLatestReadableSoakDir(rootDir, currentDir);
+  const readableDir =
+    findLatestReadableSoakDir(rootDir, currentDir) ||
+    (pointerPath === DEFAULT_SOAK_POINTER
+      ? findLatestReadableSoakDir(path.join(AUTOMATION_STATE_DIR, "soaks"), currentDir) ||
+        findLatestReadableSoakDir(LEGACY_SOAK_ROOT, currentDir)
+      : "");
   if (!readableDir) {
     return {
       repaired: false,

--- a/scripts/nightly-self-improve.mjs
+++ b/scripts/nightly-self-improve.mjs
@@ -32,7 +32,7 @@ const DEFAULT_DEV_BOT_MEMORY =
 // reboots; macOS periodically clears /tmp, which made the outcome ledger and
 // active-soak pointer amnesiac. The /tmp paths remain readable as a legacy
 // fallback for one release (see resolveStatePathWithLegacyFallback).
-export const AUTOMATION_STATE_DIR = path.join(os.homedir(), ".freed-automation");
+export const AUTOMATION_STATE_DIR = path.join(os.homedir(), ".freed", "automation");
 const LEGACY_SOAK_POINTER = "/tmp/freed-perf-soak/current-soak-dir";
 const LEGACY_OUTCOME_LEDGER = "/tmp/freed-nightly-self-improve/outcomes.jsonl";
 const DEFAULT_SOAK_POINTER = path.join(AUTOMATION_STATE_DIR, "current-soak-dir");

--- a/scripts/record-outcome.mjs
+++ b/scripts/record-outcome.mjs
@@ -12,7 +12,7 @@
 //     [--status shipped|validated|blocked|failed] [--pr <number-or-url>] \
 //     [--build <version>] [--notes <text>] [--ledger <path>]
 //
-// The ledger defaults to ~/.freed-automation/outcomes.jsonl (see W1-01 in
+// The ledger defaults to ~/.freed/automation/outcomes.jsonl (see W1-01 in
 // docs/STABILITY-PROGRAM.md); it is created on demand.
 
 import path from "node:path";

--- a/scripts/record-outcome.mjs
+++ b/scripts/record-outcome.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+
+// Post-merge outcome recorder for the automation loops.
+//
+// The nightly self-improve planner learns from the outcome ledger. Recording
+// used to depend on someone remembering to run a long --record-outcome
+// invocation, so the ledger stayed empty. This helper is the short path:
+// loops (and worktree-cleanup.sh) call it right after a PR merges.
+//
+// Usage:
+//   node scripts/record-outcome.mjs --id <target-or-task-id> [--kind <kind>] \
+//     [--status shipped|validated|blocked|failed] [--pr <number-or-url>] \
+//     [--build <version>] [--notes <text>] [--ledger <path>]
+//
+// The ledger defaults to ~/.freed-automation/outcomes.jsonl (see W1-01 in
+// docs/STABILITY-PROGRAM.md); it is created on demand.
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  appendOutcomeLedger,
+  AUTOMATION_STATE_DIR,
+} from "./nightly-self-improve.mjs";
+
+const __filename = fileURLToPath(import.meta.url);
+
+function usage() {
+  return `Usage:
+  node scripts/record-outcome.mjs --id <target-or-task-id> [options]
+
+Options:
+  --id <id>          Target id, stability task id (e.g. W1-01), or branch name. Required.
+  --kind <kind>      Target kind for the ledger. Defaults to "task".
+  --status <status>  shipped, validated, blocked, or failed. Defaults to "shipped".
+  --pr <number>      Pull request number or URL.
+  --build <version>  Build version the outcome shipped in.
+  --notes <text>     Free-form notes.
+  --ledger <path>    Ledger file. Defaults to ${path.join(AUTOMATION_STATE_DIR, "outcomes.jsonl")}.
+  --help             Show this help.
+`;
+}
+
+export function parseArgs(argv) {
+  const args = {
+    id: "",
+    kind: "task",
+    status: "shipped",
+    pr: "",
+    build: "",
+    notes: "",
+    ledger: path.join(AUTOMATION_STATE_DIR, "outcomes.jsonl"),
+    help: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    switch (arg) {
+      case "--id":
+        args.id = argv[index + 1] ?? "";
+        index += 1;
+        break;
+      case "--kind":
+        args.kind = argv[index + 1] ?? "";
+        index += 1;
+        break;
+      case "--status":
+        args.status = argv[index + 1] ?? "";
+        index += 1;
+        break;
+      case "--pr":
+        args.pr = argv[index + 1] ?? "";
+        index += 1;
+        break;
+      case "--build":
+        args.build = argv[index + 1] ?? "";
+        index += 1;
+        break;
+      case "--notes":
+        args.notes = argv[index + 1] ?? "";
+        index += 1;
+        break;
+      case "--ledger":
+        args.ledger = argv[index + 1] ?? "";
+        index += 1;
+        break;
+      case "--help":
+      case "-h":
+        args.help = true;
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (args.help) {
+    return args;
+  }
+  if (!args.id) {
+    throw new Error("--id is required.");
+  }
+  if (!args.ledger) {
+    throw new Error("--ledger requires a path.");
+  }
+  args.ledger = path.resolve(args.ledger);
+
+  return args;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    process.stdout.write(usage());
+    return;
+  }
+
+  const entry = appendOutcomeLedger(args.ledger, {
+    id: args.id,
+    kind: args.kind,
+    outcome: args.status,
+    notes: args.notes,
+    pr: args.pr,
+    build: args.build,
+  });
+  process.stdout.write(`Recorded ${entry.outcome} outcome for ${entry.id} in ${args.ledger}.\n`);
+}
+
+if (process.argv[1] === __filename) {
+  try {
+    main();
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.stderr.write(usage());
+    process.exitCode = 1;
+  }
+}

--- a/scripts/record-outcome.test.mjs
+++ b/scripts/record-outcome.test.mjs
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+import { parseArgs } from "./record-outcome.mjs";
+import { resolveStatePathWithLegacyFallback } from "./nightly-self-improve.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CLI_PATH = path.join(__dirname, "record-outcome.mjs");
+
+test("resolveStatePathWithLegacyFallback prefers an existing new-location file", () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "freed-state-fallback-"));
+  const preferred = path.join(dir, "new", "outcomes.jsonl");
+  const legacy = path.join(dir, "legacy", "outcomes.jsonl");
+  writeFileSync(path.join(dir, "new-file"), "");
+  const newPath = path.join(dir, "new-file");
+  assert.equal(resolveStatePathWithLegacyFallback(newPath, legacy), newPath);
+  assert.equal(resolveStatePathWithLegacyFallback(preferred, legacy), preferred);
+});
+
+test("resolveStatePathWithLegacyFallback migrates legacy state to the new location", () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "freed-state-migrate-"));
+  const preferred = path.join(dir, "new", "outcomes.jsonl");
+  const legacy = path.join(dir, "legacy-outcomes.jsonl");
+  writeFileSync(legacy, '{"id":"old","kind":"task","outcome":"shipped"}\n');
+
+  const resolved = resolveStatePathWithLegacyFallback(preferred, legacy);
+
+  assert.equal(resolved, preferred);
+  assert.ok(existsSync(preferred));
+  assert.match(readFileSync(preferred, "utf8"), /"id":"old"/);
+});
+
+test("resolveStatePathWithLegacyFallback keeps the legacy path when migration fails", () => {
+  const failingOps = {
+    existsSync: (p) => p === "/legacy/outcomes.jsonl",
+    mkdirSync: () => {
+      throw new Error("read-only");
+    },
+    copyFileSync: () => {
+      throw new Error("read-only");
+    },
+  };
+  assert.equal(
+    resolveStatePathWithLegacyFallback("/new/outcomes.jsonl", "/legacy/outcomes.jsonl", failingOps),
+    "/legacy/outcomes.jsonl",
+  );
+});
+
+test("record-outcome parseArgs requires an id and applies defaults", () => {
+  assert.throws(() => parseArgs([]), /--id is required/);
+  const args = parseArgs(["--id", "W1-01", "--pr", "897"]);
+  assert.equal(args.kind, "task");
+  assert.equal(args.status, "shipped");
+  assert.equal(args.pr, "897");
+  assert.ok(args.ledger.includes(".freed-automation"));
+  assert.throws(() => parseArgs(["--id", "x", "--bogus"]), /Unknown argument/);
+});
+
+test("record-outcome CLI appends a ledger line at the given path", () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "freed-record-outcome-"));
+  const ledger = path.join(dir, "state", "outcomes.jsonl");
+
+  const stdout = execFileSync(
+    process.execPath,
+    [
+      CLI_PATH,
+      "--id",
+      "W1-01",
+      "--kind",
+      "task",
+      "--status",
+      "shipped",
+      "--pr",
+      "897",
+      "--build",
+      "v26.7.203-dev",
+      "--notes",
+      "test entry",
+      "--ledger",
+      ledger,
+    ],
+    { encoding: "utf8" },
+  );
+
+  assert.match(stdout, /Recorded shipped outcome for W1-01/);
+  const lines = readFileSync(ledger, "utf8").trim().split("\n");
+  assert.equal(lines.length, 1);
+  const entry = JSON.parse(lines[0]);
+  assert.equal(entry.id, "W1-01");
+  assert.equal(entry.kind, "task");
+  assert.equal(entry.outcome, "shipped");
+  assert.equal(entry.pr, "897");
+  assert.equal(entry.build, "v26.7.203-dev");
+  assert.ok(entry.ts);
+});
+
+test("record-outcome CLI rejects an invalid status", () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "freed-record-outcome-bad-"));
+  const ledger = path.join(dir, "outcomes.jsonl");
+  assert.throws(() =>
+    execFileSync(process.execPath, [CLI_PATH, "--id", "x", "--status", "done", "--ledger", ledger], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }),
+  );
+  assert.equal(existsSync(ledger), false);
+});

--- a/scripts/record-outcome.test.mjs
+++ b/scripts/record-outcome.test.mjs
@@ -57,7 +57,7 @@ test("record-outcome parseArgs requires an id and applies defaults", () => {
   assert.equal(args.kind, "task");
   assert.equal(args.status, "shipped");
   assert.equal(args.pr, "897");
-  assert.ok(args.ledger.includes(".freed-automation"));
+  assert.ok(args.ledger.includes(path.join(".freed", "automation")));
   assert.throws(() => parseArgs(["--id", "x", "--bogus"]), /Unknown argument/);
 });
 

--- a/scripts/worktree-cleanup.sh
+++ b/scripts/worktree-cleanup.sh
@@ -24,6 +24,23 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./lib/node-tooling.sh
+source "${SCRIPT_DIR}/lib/node-tooling.sh"
+
+# Append a ledger line for a merged PR so the nightly planner learns from it.
+# Best-effort: never blocks cleanup.
+record_merge_outcome() {
+  local branch="$1"
+  local pr_number="$2"
+  "$(resolve_node_bin)" "${SCRIPT_DIR}/record-outcome.mjs" \
+    --id "${branch}" \
+    --kind pr-merge \
+    --status shipped \
+    --pr "${pr_number}" \
+    --notes "auto-recorded by worktree-cleanup.sh" || true
+}
+
 YES=false
 if [[ "${1:-}" == "--yes" ]]; then
   YES=true
@@ -93,6 +110,7 @@ for i in "${!PATHS[@]}"; do
     # -D because squash merges leave branch commits unreachable from the
     # target branch.
     git branch -D "$branch" 2>/dev/null || true
+    record_merge_outcome "$branch" "$pr_number"
     echo "  Removed."
     removed=$((removed + 1))
   else
@@ -114,6 +132,7 @@ while IFS= read -r line; do
     echo "  $branch -> PR #$pr_number merged"
     if confirm "Delete local branch '$branch'?"; then
       git branch -D "$branch"
+      record_merge_outcome "$branch" "$pr_number"
       echo "  Deleted."
       removed=$((removed + 1))
     else


### PR DESCRIPTION
(AI Generated).

## Summary
- Stability program task [W1-01](https://github.com/freed-project/freed/blob/dev/docs/stability-tasks/W1-01-automation-state-out-of-tmp.md): the nightly planner's outcome ledger and active-soak pointer lived under /tmp, which macOS clears, so the learning loop was amnesiac and outcome recording depended on a manual invocation nobody ran.
- Default state now lives under `~/.freed-automation/` (`outcomes.jsonl`, `current-soak-dir`, generated run dirs under `runs/`). Legacy /tmp paths are still read and migrated on first touch for one release via `resolveStatePathWithLegacyFallback`; CLI flags still override. Soak fallback scanning also checks `~/.freed-automation/soaks` and the legacy `/tmp/freed-perf-soak` root, but only for default invocations so explicit `--soak-dir`/`--soak-pointer` callers stay scoped.
- New `scripts/record-outcome.mjs` is the short post-merge recording path; `scripts/worktree-cleanup.sh` now calls it (best-effort) whenever it removes a merged worktree or merged stale branch, so routine merges land in the ledger automatically.
- Updated docs/NIGHTLY-SELF-IMPROVE.md paths and checked the W1-01 box in docs/STABILITY-PROGRAM.md.

## Testing
- `node --test scripts/nightly-self-improve.test.mjs`: 36 pass.
- New `scripts/record-outcome.test.mjs` (6 tests): legacy migration, migration-failure fallback, CLI append with real subprocess, invalid-status rejection. Runs under `npm run test:scripts`.
- `node scripts/nightly-self-improve.mjs --dry-run --json` resolves the ledger at `/Users/aubreyfalconer/.freed-automation/outcomes.jsonl` (not under /tmp, survives reboot).
- `bash -n scripts/worktree-cleanup.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)