### PR TITLE
feat: add scripts/doctor.mjs machine preflight for loops and worktree helpers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,10 @@
     - Website: `./scripts/vercel-deploy-preview.sh website`
     - PWA: `./scripts/vercel-deploy-preview.sh pwa`
 
+## Machine Preflight
+
+`node scripts/doctor.mjs` checks the machine before loop or worktree work: the pinned Node toolchain from `.nvmrc`, PATH `node` consistency, `gh` (presence, that it runs, and binary architecture on macOS), git credential helpers that point at missing binaries, `git`, `curl`, `python3`, and `~/.freed-automation/`. It prints exact remediation for anything broken, including the curl-based GitHub API fallback when `gh` is unusable. `worktree-add.sh`, `worktree-publish.sh`, and the nightly runner run it automatically in warn-only mode; loops and CI gates should run `node scripts/doctor.mjs --strict` and stop on failures. A surprising `node`/`npm` path or a broken `gh` is a machine issue to fix before debugging the repo.
+
 ## Versioning
 
 CalVer `YY.M.DDBUILD` — patch segment encodes the day and build number:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@
 
 ## Machine Preflight
 
-`node scripts/doctor.mjs` checks the machine before loop or worktree work: the pinned Node toolchain from `.nvmrc`, PATH `node` consistency, `gh` (presence, that it runs, and binary architecture on macOS), git credential helpers that point at missing binaries, `git`, `curl`, `python3`, and `~/.freed-automation/`. It prints exact remediation for anything broken, including the curl-based GitHub API fallback when `gh` is unusable. `worktree-add.sh`, `worktree-publish.sh`, and the nightly runner run it automatically in warn-only mode; loops and CI gates should run `node scripts/doctor.mjs --strict` and stop on failures. A surprising `node`/`npm` path or a broken `gh` is a machine issue to fix before debugging the repo.
+`node scripts/doctor.mjs` checks the machine before loop or worktree work: the pinned Node toolchain from `.nvmrc`, PATH `node` consistency, `gh` (presence, that it runs, and binary architecture on macOS), git credential helpers that point at missing binaries, `git`, `curl`, `python3`, and `~/.freed/automation/`. It prints exact remediation for anything broken, including the curl-based GitHub API fallback when `gh` is unusable. `worktree-add.sh`, `worktree-publish.sh`, and the nightly runner run it automatically in warn-only mode; loops and CI gates should run `node scripts/doctor.mjs --strict` and stop on failures. A surprising `node`/`npm` path or a broken `gh` is a machine issue to fix before debugging the repo.
 
 ## Versioning
 

--- a/docs/STABILITY-PROGRAM.md
+++ b/docs/STABILITY-PROGRAM.md
@@ -33,7 +33,7 @@ Every claim above cites code in [stability-findings.json](stability-findings.jso
 | ---- | ----- | ----------- | ------ |
 | [W1-01](stability-tasks/W1-01-automation-state-out-of-tmp.md) | Move loop state out of /tmp; auto-record outcomes on merge | yes | ☐ |
 | [W1-02](stability-tasks/W1-02-soak-collector-and-assert.md) | Check in soak collector + soak-assert with machine-readable verdict | yes | ☑ |
-| [W1-03](stability-tasks/W1-03-doctor-preflight.md) | scripts/doctor.mjs machine preflight for all loops | yes | ☐ |
+| [W1-03](stability-tasks/W1-03-doctor-preflight.md) | scripts/doctor.mjs machine preflight for all loops | yes | ☑ |
 | [W1-04](stability-tasks/W1-04-fix-ship-build-skill.md) | Rewrite freed-ship-build skill against actual release scripts | no | ☑ |
 | [W1-05](stability-tasks/W1-05-build-feature-skill-counters.md) | freed-build-feature: verification-counters step + outcome recording | no | ☑ |
 | [W1-06](stability-tasks/W1-06-provider-visible-single-source.md) | Single-source provider-visible path list; publish-time enforcement | no | ☑ |

--- a/docs/stability-tasks/W1-03-doctor-preflight.md
+++ b/docs/stability-tasks/W1-03-doctor-preflight.md
@@ -12,7 +12,7 @@ On the primary dev machine, `gh` was an x86_64 binary that failed to load arm64-
    - `node`/`npm`/`npx` resolve from the repo-pinned toolchain (.nvmrc) and match each other.
    - `gh` exists, runs (`gh --version`), and its binary architecture matches the machine (`file $(which gh)` on darwin); if broken, print the exact remediation (reinstall arm64 gh) and the curl-based GitHub API fallback pattern.
    - `git`, `curl`, `/usr/bin/python3` are usable.
-   - Sandbox-sensitive paths exist (`~/.freed-automation/` per W1-01).
+   - Sandbox-sensitive paths exist (`~/.freed/automation/` per W1-01).
 2. Wire it as the first step of `scripts/nightly-self-improve.mjs`, `scripts/worktree-add.sh`, and `scripts/worktree-publish.sh` in warn-only mode (hard-fail only in loop/CI contexts via `--strict`).
 3. Add a short "Machine preflight" section to AGENTS.md pointing at it.
 

--- a/docs/stability-tasks/W1-03-doctor-preflight.md
+++ b/docs/stability-tasks/W1-03-doctor-preflight.md
@@ -4,7 +4,7 @@ runner-safe: true | provider-visible: false | soak-gated: no
 
 ## Context
 
-On the primary dev machine, `gh` is an x86_64 binary that fails to load arm64-only libxcrun, the default PATH `node` is ancient, and `python3` resolves through a broken safe-chain shim. Loops and agents hit these as silent fallbacks and confusing mid-task failures. AGENTS.md already says surprising node/npm paths are "a machine issue to fix before debugging the repo" — make that a script instead of prose.
+On the primary dev machine, `gh` was an x86_64 binary that failed to load arm64-only libxcrun (an arm64 gh has since been installed at /opt/homebrew/bin/gh, but the git credential helper still points at the removed /usr/local/bin/gh, so `git push` over https fails), the default PATH `node` is ancient, and `python3` resolves through a broken safe-chain shim. Loops and agents hit these as silent fallbacks and confusing mid-task failures. AGENTS.md already says surprising node/npm paths are "a machine issue to fix before debugging the repo" — make that a script instead of prose.
 
 ## Change
 
@@ -18,5 +18,5 @@ On the primary dev machine, `gh` is an x86_64 binary that fails to load arm64-on
 
 ## Verify
 
-- `node scripts/doctor.mjs` on the dev machine reports the known gh arch failure with remediation text.
+- `node scripts/doctor.mjs` on the dev machine reports the known machine failures (originally the gh arch mismatch; now the stale git credential helper) with remediation text.
 - `node --test` fixture test for the report formatting; `npm run test:scripts` stays green.

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -334,7 +334,7 @@ export function runChecks(options = {}) {
   const repoRoot = options.repoRoot ?? REPO_ROOT;
   const machineArch = options.machineArch ?? os.arch();
   const platform = options.platform ?? os.platform();
-  const stateDir = options.stateDir ?? path.join(home, ".freed-automation");
+  const stateDir = options.stateDir ?? path.join(home, ".freed", "automation");
 
   const checks = [
     checkPinnedToolchain(home, repoRoot),

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -1,0 +1,407 @@
+#!/usr/bin/env node
+
+// Machine preflight for the Freed automation loops.
+//
+// AGENTS.md says a surprising node/npm path is "a machine issue to fix before
+// debugging the repo". This script is that rule as code: it checks the pinned
+// Node toolchain, gh (including binary architecture on macOS), git, curl,
+// python3, and the automation state directory, and prints exact remediation
+// for anything broken.
+//
+// Usage:
+//   node scripts/doctor.mjs            # report only, always exits 0 (warn-only)
+//   node scripts/doctor.mjs --strict   # exit non-zero on hard failures (loops/CI)
+//   node scripts/doctor.mjs --json     # machine-readable report
+//
+// worktree-add.sh, worktree-publish.sh, and nightly-self-improve.mjs run this
+// automatically in warn-only mode. Loops and CI gates should use --strict.
+
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const REPO_ROOT = path.resolve(__dirname, "..");
+
+const CURL_FALLBACK_PATTERN = [
+  'TOKEN=$(security find-generic-password -s "gh:github.com" -w | sed \'s/^go-keyring-base64://\' | base64 -d)',
+  'curl -sS -H "Authorization: Bearer $TOKEN" -H "Accept: application/vnd.github+json" https://api.github.com/repos/<owner>/<repo>/...',
+].join("\n    ");
+
+function tryExec(command, args, options = {}) {
+  try {
+    const stdout = execFileSync(command, args, {
+      encoding: "utf8",
+      timeout: options.timeout ?? 10_000,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return { ok: true, stdout: stdout.trim(), error: "" };
+  } catch (error) {
+    return {
+      ok: false,
+      stdout: String(error?.stdout ?? "").trim(),
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+function whichCommand(name) {
+  const result = tryExec("/usr/bin/which", [name]);
+  return result.ok ? result.stdout.split("\n")[0].trim() : "";
+}
+
+export function readPinnedNodeVersion(repoRoot = REPO_ROOT) {
+  const nvmrcPath = path.join(repoRoot, ".nvmrc");
+  if (!existsSync(nvmrcPath)) {
+    return "";
+  }
+  return readFileSync(nvmrcPath, "utf8").trim().replace(/^v/, "");
+}
+
+// Parses `file <binary>` output on darwin and decides whether the binary can
+// run natively on this machine's architecture.
+export function classifyBinaryArch(fileOutput, machineArch) {
+  const text = String(fileOutput ?? "");
+  const detected = [];
+  if (/\bx86_64\b/.test(text)) {
+    detected.push("x86_64");
+  }
+  if (/\barm64e?\b/.test(text)) {
+    detected.push("arm64");
+  }
+  const wanted = machineArch === "arm64" ? "arm64" : "x86_64";
+  return {
+    detected,
+    matches: detected.length === 0 ? true : detected.includes(wanted),
+  };
+}
+
+function check(id, title, status, detail, remediation = "") {
+  return { id, title, status, detail, remediation };
+}
+
+function checkPinnedToolchain(home, repoRoot) {
+  const pinned = readPinnedNodeVersion(repoRoot);
+  if (!pinned) {
+    return check(
+      "node-toolchain",
+      "pinned Node toolchain",
+      "fail",
+      `.nvmrc not found in ${repoRoot}.`,
+      "Restore .nvmrc; repo scripts resolve node from it.",
+    );
+  }
+
+  const envNodeBin = process.env.NODE_BIN ?? "";
+  const pinnedBinDir = path.join(home, ".nvm", "versions", "node", `v${pinned}`, "bin");
+  const nodeBin = envNodeBin || path.join(pinnedBinDir, "node");
+
+  if (!existsSync(nodeBin)) {
+    return check(
+      "node-toolchain",
+      "pinned Node toolchain",
+      "fail",
+      `Node v${pinned} (.nvmrc) is not installed at ${nodeBin}.`,
+      `Run: nvm install ${pinned}`,
+    );
+  }
+
+  const versionResult = tryExec(nodeBin, ["-v"]);
+  const actual = versionResult.stdout.replace(/^v/, "");
+  if (!versionResult.ok || actual !== pinned) {
+    return check(
+      "node-toolchain",
+      "pinned Node toolchain",
+      "fail",
+      `${nodeBin} reports v${actual || "unknown"}, .nvmrc pins v${pinned}.`,
+      envNodeBin
+        ? `NODE_BIN points at the wrong node. Unset it or point it at Node v${pinned}.`
+        : `Run: nvm install ${pinned}`,
+    );
+  }
+
+  const binDir = path.dirname(nodeBin);
+  const missing = ["npm", "npx"].filter((tool) => !existsSync(path.join(binDir, tool)));
+  if (missing.length > 0) {
+    return check(
+      "node-toolchain",
+      "pinned Node toolchain",
+      "fail",
+      `${missing.join(" and ")} missing next to ${nodeBin}. Repo scripts require node, npm, and npx from the same install.`,
+      `Reinstall Node v${pinned} (nvm install ${pinned}).`,
+    );
+  }
+
+  return check(
+    "node-toolchain",
+    "pinned Node toolchain",
+    "ok",
+    `v${pinned} at ${nodeBin} with matching npm and npx.`,
+  );
+}
+
+function checkPathNode(home, repoRoot) {
+  const pinned = readPinnedNodeVersion(repoRoot);
+  const pathNode = whichCommand("node");
+  if (!pathNode) {
+    return check(
+      "path-node",
+      "PATH node",
+      "warn",
+      "No node on PATH. Repo scripts resolve the pinned toolchain themselves, but bare `node` commands will fail.",
+      `Prefix PATH with ${path.join(home, ".nvm", "versions", "node", `v${pinned}`, "bin")}.`,
+    );
+  }
+  const versionResult = tryExec(pathNode, ["-v"]);
+  const actual = versionResult.stdout.replace(/^v/, "");
+  if (pinned && actual !== pinned) {
+    return check(
+      "path-node",
+      "PATH node",
+      "warn",
+      `PATH node is v${actual || "unknown"} (${pathNode}); .nvmrc pins v${pinned}. Repo scripts resolve the pinned toolchain, but bare node/npm/npx commands use the stale one.`,
+      `Prefix PATH with ${path.join(home, ".nvm", "versions", "node", `v${pinned}`, "bin")} (or \`nvm use\`).`,
+    );
+  }
+  return check("path-node", "PATH node", "ok", `v${actual} (${pathNode}).`);
+}
+
+function checkGh(machineArch, platform) {
+  const ghPath = whichCommand("gh");
+  if (!ghPath) {
+    return check(
+      "gh",
+      "GitHub CLI",
+      "warn",
+      "gh is not installed.",
+      `Install gh (brew install gh), or use the curl-based GitHub API fallback:\n    ${CURL_FALLBACK_PATTERN}`,
+    );
+  }
+
+  const versionResult = tryExec(ghPath, ["--version"]);
+  if (versionResult.ok) {
+    return check("gh", "GitHub CLI", "ok", `${versionResult.stdout.split("\n")[0]} (${ghPath}).`);
+  }
+
+  let archDetail = "";
+  if (platform === "darwin") {
+    const fileResult = tryExec("/usr/bin/file", [ghPath]);
+    const arch = classifyBinaryArch(fileResult.stdout, machineArch);
+    if (!arch.matches) {
+      archDetail = ` Binary is ${arch.detected.join("+") || "unknown"} but this machine is ${machineArch}.`;
+    }
+  }
+
+  return check(
+    "gh",
+    "GitHub CLI",
+    "warn",
+    `gh exists at ${ghPath} but fails to run.${archDetail}`,
+    `Reinstall the ${machineArch} build of gh (brew install gh). Until then, use the curl-based GitHub API fallback:\n    ${CURL_FALLBACK_PATTERN}`,
+  );
+}
+
+// Extracts the executable path from a shell-style git credential helper value
+// like "!/usr/local/bin/gh auth git-credential". Returns "" for built-in
+// helpers such as "osxkeychain" or "cache".
+export function credentialHelperBinary(helperValue) {
+  const value = String(helperValue ?? "").trim();
+  if (!value.startsWith("!")) {
+    return "";
+  }
+  const command = value.slice(1).trim().split(/\s+/)[0] ?? "";
+  return command.startsWith("/") ? command : "";
+}
+
+function checkGitCredentialHelpers() {
+  // --get-regexp also catches URL-scoped helpers such as
+  // credential.https://github.com.helper, where stale gh paths tend to hide.
+  const result = tryExec("git", ["config", "--get-regexp", String.raw`^credential(\..+)?\.helper$`]);
+  const helpers = result.stdout
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => line.replace(/^\S+\s*/, ""))
+    .filter(Boolean);
+  const broken = [
+    ...new Set(
+      helpers
+        .map((helper) => credentialHelperBinary(helper))
+        .filter((binary) => binary && !existsSync(binary)),
+    ),
+  ];
+
+  if (broken.length > 0) {
+    const ghPath = whichCommand("gh");
+    return check(
+      "git-credential-helper",
+      "git credential helper",
+      "warn",
+      `git credential helper references ${broken.join(", ")}, which does not exist. git push/fetch over https will fail.`,
+      ghPath
+        ? `Point it at the working gh: git config --global credential.helper '!${ghPath} auth git-credential' (or remove the stale entry).`
+        : "Remove the stale credential.helper entry or reinstall gh.",
+    );
+  }
+
+  return check(
+    "git-credential-helper",
+    "git credential helper",
+    "ok",
+    helpers.length > 0 ? helpers.join("; ") : "none configured.",
+  );
+}
+
+function checkSimpleCommand(id, title, command, args, remediation) {
+  const commandPath = whichCommand(command) || command;
+  const result = tryExec(commandPath, args);
+  if (result.ok) {
+    return check(id, title, "ok", `${result.stdout.split("\n")[0]} (${commandPath}).`);
+  }
+  return check(id, title, "fail", `${command} is unusable: ${result.error}`, remediation);
+}
+
+function checkSystemPython() {
+  const systemPython = "/usr/bin/python3";
+  if (!existsSync(systemPython)) {
+    // Linux CI runners may only have python3 on PATH; treat that as ok there.
+    const pathPython = whichCommand("python3");
+    if (pathPython) {
+      const result = tryExec(pathPython, ["--version"]);
+      if (result.ok) {
+        return check("python3", "python3", "ok", `${result.stdout} (${pathPython}).`);
+      }
+    }
+    return check(
+      "python3",
+      "python3",
+      "fail",
+      "No usable python3 (checked /usr/bin/python3 and PATH).",
+      "Install python3 or repair the Xcode command line tools (xcode-select --install).",
+    );
+  }
+
+  const result = tryExec(systemPython, ["--version"]);
+  if (!result.ok) {
+    return check(
+      "python3",
+      "python3",
+      "fail",
+      `/usr/bin/python3 is unusable: ${result.error}`,
+      "Repair the Xcode command line tools (xcode-select --install).",
+    );
+  }
+
+  const pathPython = whichCommand("python3");
+  if (pathPython && pathPython !== systemPython) {
+    const pathResult = tryExec(pathPython, ["--version"]);
+    if (!pathResult.ok) {
+      return check(
+        "python3",
+        "python3",
+        "warn",
+        `/usr/bin/python3 works (${result.stdout}), but PATH python3 (${pathPython}) is broken: ${pathResult.error}`,
+        `Remove or repair the broken shim so PATH python3 works, or call /usr/bin/python3 explicitly.`,
+      );
+    }
+  }
+
+  return check("python3", "python3", "ok", `${result.stdout} (${systemPython}).`);
+}
+
+function checkAutomationStateDir(stateDir) {
+  if (existsSync(stateDir)) {
+    return check("automation-state-dir", "automation state dir", "ok", `${stateDir} exists.`);
+  }
+  try {
+    mkdirSync(stateDir, { recursive: true });
+    return check("automation-state-dir", "automation state dir", "ok", `${stateDir} created.`);
+  } catch (error) {
+    return check(
+      "automation-state-dir",
+      "automation state dir",
+      "fail",
+      `Cannot create ${stateDir}: ${error instanceof Error ? error.message : String(error)}`,
+      `Create it manually: mkdir -p ${stateDir}`,
+    );
+  }
+}
+
+export function runChecks(options = {}) {
+  const home = options.home ?? os.homedir();
+  const repoRoot = options.repoRoot ?? REPO_ROOT;
+  const machineArch = options.machineArch ?? os.arch();
+  const platform = options.platform ?? os.platform();
+  const stateDir = options.stateDir ?? path.join(home, ".freed-automation");
+
+  const checks = [
+    checkPinnedToolchain(home, repoRoot),
+    checkPathNode(home, repoRoot),
+    checkGh(machineArch, platform),
+    checkGitCredentialHelpers(),
+    checkSimpleCommand("git", "git", "git", ["--version"], "Install git (xcode-select --install)."),
+    checkSimpleCommand("curl", "curl", "curl", ["--version"], "Install curl."),
+    checkSystemPython(),
+    checkAutomationStateDir(stateDir),
+  ];
+
+  return {
+    checks,
+    failures: checks.filter((item) => item.status === "fail").length,
+    warnings: checks.filter((item) => item.status === "warn").length,
+  };
+}
+
+const STATUS_GLYPHS = { ok: "ok", warn: "WARN", fail: "FAIL" };
+
+export function formatReport(result) {
+  const lines = ["Freed machine preflight (scripts/doctor.mjs)"];
+  for (const item of result.checks) {
+    lines.push(`  [${STATUS_GLYPHS[item.status] ?? item.status}] ${item.title}: ${item.detail}`);
+    if (item.remediation && item.status !== "ok") {
+      lines.push(`    remediation: ${item.remediation}`);
+    }
+  }
+  const okCount = result.checks.length - result.failures - result.warnings;
+  lines.push(
+    `Summary: ${okCount} ok, ${result.warnings} warning${result.warnings === 1 ? "" : "s"}, ${result.failures} failure${result.failures === 1 ? "" : "s"}.`,
+  );
+  return `${lines.join("\n")}\n`;
+}
+
+export function resolveExitCode(result, { strict = false } = {}) {
+  if (strict && result.failures > 0) {
+    return 1;
+  }
+  return 0;
+}
+
+function main() {
+  const argv = process.argv.slice(2);
+  const strict = argv.includes("--strict");
+  const json = argv.includes("--json");
+  const unknown = argv.filter((arg) => !["--strict", "--json", "--help", "-h"].includes(arg));
+  if (argv.includes("--help") || argv.includes("-h") || unknown.length > 0) {
+    process.stdout.write(
+      "Usage: node scripts/doctor.mjs [--strict] [--json]\n" +
+        "  --strict  Exit non-zero on hard failures (loop/CI contexts).\n" +
+        "  --json    Machine-readable report.\n",
+    );
+    process.exitCode = unknown.length > 0 ? 1 : 0;
+    return;
+  }
+
+  const result = runChecks();
+  if (json) {
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  } else {
+    process.stdout.write(formatReport(result));
+  }
+  process.exitCode = resolveExitCode(result, { strict });
+}
+
+if (process.argv[1] === __filename) {
+  main();
+}

--- a/scripts/doctor.test.mjs
+++ b/scripts/doctor.test.mjs
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  classifyBinaryArch,
+  credentialHelperBinary,
+  formatReport,
+  resolveExitCode,
+  runChecks,
+} from "./doctor.mjs";
+
+test("classifyBinaryArch flags an x86_64 binary on an arm64 machine", () => {
+  const fileOutput = "/usr/local/bin/gh: Mach-O 64-bit executable x86_64";
+  const result = classifyBinaryArch(fileOutput, "arm64");
+  assert.deepEqual(result.detected, ["x86_64"]);
+  assert.equal(result.matches, false);
+});
+
+test("classifyBinaryArch accepts a universal binary containing the machine arch", () => {
+  const fileOutput = [
+    "/opt/homebrew/bin/gh: Mach-O universal binary with 2 architectures",
+    "gh (for architecture x86_64): Mach-O 64-bit executable x86_64",
+    "gh (for architecture arm64): Mach-O 64-bit executable arm64",
+  ].join("\n");
+  const result = classifyBinaryArch(fileOutput, "arm64");
+  assert.deepEqual(result.detected, ["x86_64", "arm64"]);
+  assert.equal(result.matches, true);
+});
+
+test("classifyBinaryArch stays quiet when file output has no arch info", () => {
+  assert.equal(classifyBinaryArch("", "arm64").matches, true);
+});
+
+test("credentialHelperBinary extracts absolute paths from shell helpers only", () => {
+  assert.equal(
+    credentialHelperBinary("!/usr/local/bin/gh auth git-credential"),
+    "/usr/local/bin/gh",
+  );
+  assert.equal(credentialHelperBinary("osxkeychain"), "");
+  assert.equal(credentialHelperBinary("!gh auth git-credential"), "");
+  assert.equal(credentialHelperBinary(""), "");
+});
+
+test("formatReport renders statuses, remediation, and a summary line", () => {
+  const report = formatReport({
+    checks: [
+      { id: "a", title: "pinned Node toolchain", status: "ok", detail: "v24.14.1.", remediation: "" },
+      {
+        id: "b",
+        title: "GitHub CLI",
+        status: "warn",
+        detail: "gh exists but fails to run. Binary is x86_64 but this machine is arm64.",
+        remediation: "Reinstall the arm64 build of gh (brew install gh).",
+      },
+      {
+        id: "c",
+        title: "git",
+        status: "fail",
+        detail: "git is unusable: boom",
+        remediation: "Install git.",
+      },
+    ],
+    failures: 1,
+    warnings: 1,
+  });
+
+  assert.match(report, /\[ok\] pinned Node toolchain: v24\.14\.1\./);
+  assert.match(report, /\[WARN\] GitHub CLI: .*x86_64 but this machine is arm64/);
+  assert.match(report, /remediation: Reinstall the arm64 build of gh/);
+  assert.match(report, /\[FAIL\] git: git is unusable: boom/);
+  assert.match(report, /Summary: 1 ok, 1 warning, 1 failure\./);
+});
+
+test("resolveExitCode is warn-only by default and hard-fails under --strict", () => {
+  const failing = { checks: [], failures: 2, warnings: 1 };
+  const clean = { checks: [], failures: 0, warnings: 3 };
+  assert.equal(resolveExitCode(failing), 0);
+  assert.equal(resolveExitCode(failing, { strict: true }), 1);
+  assert.equal(resolveExitCode(clean, { strict: true }), 0);
+});
+
+test("runChecks returns every check id with a valid status", () => {
+  const stateDir = path.join(mkdtempSync(path.join(os.tmpdir(), "freed-doctor-")), "state");
+  const result = runChecks({ stateDir });
+  const ids = result.checks.map((item) => item.id);
+  assert.deepEqual(ids, [
+    "node-toolchain",
+    "path-node",
+    "gh",
+    "git-credential-helper",
+    "git",
+    "curl",
+    "python3",
+    "automation-state-dir",
+  ]);
+  for (const item of result.checks) {
+    assert.ok(["ok", "warn", "fail"].includes(item.status), `${item.id} has status ${item.status}`);
+    assert.ok(item.detail.length > 0);
+  }
+  assert.equal(
+    result.failures,
+    result.checks.filter((item) => item.status === "fail").length,
+  );
+});

--- a/scripts/nightly-self-improve.mjs
+++ b/scripts/nightly-self-improve.mjs
@@ -2489,6 +2489,16 @@ export function main(argv = process.argv.slice(2)) {
     return;
   }
 
+  // Machine preflight, warn-only: report broken tooling on stderr before
+  // planning. Loops that must stop on a broken machine run doctor --strict.
+  try {
+    execFileSync(process.execPath, [path.join(__dirname, "doctor.mjs")], {
+      stdio: ["ignore", 2, 2],
+    });
+  } catch {
+    // Never block the planner on preflight reporting.
+  }
+
   if (args.repairSoakPointer) {
     const repair = repairSoakPointer(args.soakPointer, { dryRun: args.dryRun });
     if (args.json) {

--- a/scripts/worktree-add.sh
+++ b/scripts/worktree-add.sh
@@ -115,6 +115,8 @@ if [[ ${#PASSTHROUGH_ARGS[@]} -eq 0 ]]; then
 fi
 
 print_node_tooling_preflight
+# Machine preflight, warn-only: report broken tooling before worktree work.
+"$(resolve_node_bin)" "${SCRIPT_DIR}/doctor.mjs" || true
 
 EXISTING_WORKTREES=()
 while IFS= read -r line; do

--- a/scripts/worktree-publish.sh
+++ b/scripts/worktree-publish.sh
@@ -205,6 +205,9 @@ fi
 require_command git
 require_command gh
 print_node_tooling_preflight
+# Machine preflight, warn-only: surface broken gh/credential helpers with
+# remediation before the publish flow trips over them.
+"$(resolve_node_bin)" "${SCRIPT_DIR}/doctor.mjs" || true
 
 ensure_conventional_title "${TITLE}"
 

--- a/scripts/worktree-publish.test.mjs
+++ b/scripts/worktree-publish.test.mjs
@@ -113,10 +113,15 @@ process.exit(1);
 
 async function readGhLog(logFile) {
   const raw = await fs.readFile(logFile, "utf8");
-  return raw
-    .split("\n")
-    .filter(Boolean)
-    .map((line) => JSON.parse(line));
+  return (
+    raw
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line))
+      // The doctor preflight probes `gh --version`; these assertions only
+      // care about the publish flow's PR interactions.
+      .filter((call) => call.args[0] === "pr")
+  );
 }
 
 test("worktree-publish converts an existing ready PR back to draft and updates it", async (t) => {


### PR DESCRIPTION
(AI Generated).

## Summary
- Stability program task [W1-03](https://github.com/freed-project/freed/blob/dev/docs/stability-tasks/W1-03-doctor-preflight.md): loops and agents were hitting machine problems (stale PATH node, broken gh, broken python3 shims) as silent fallbacks and confusing mid-task failures. AGENTS.md called these "a machine issue to fix before debugging the repo"; this makes that rule a script.
- New `scripts/doctor.mjs` checks: pinned Node toolchain from .nvmrc (node/npm/npx from the same install, NODE_BIN honored), PATH node consistency (warn), gh presence + `gh --version` + binary architecture via `file` on darwin (warn, with reinstall remediation and the curl-based GitHub API fallback pattern), git credential helpers pointing at missing binaries (this is the machine's actual current failure: `credential.https://github.com.helper` still references the removed /usr/local/bin/gh, so https pushes fail even though an arm64 gh works at /opt/homebrew/bin/gh), git, curl, /usr/bin/python3 plus PATH python3 shim health, and `~/.freed-automation/` (created on demand, per W1-01).
- Default mode is warn-only (always exit 0); `--strict` exits non-zero on hard failures for loop/CI contexts; `--json` for machines.
- Wired warn-only into `worktree-add.sh`, `worktree-publish.sh` (report to the operator), and `nightly-self-improve.mjs` (report on stderr so --json stays clean; never blocks the planner).
- Added a Machine Preflight section to AGENTS.md, and updated the W1-03 task file premise per program rule 4: the gh binary itself has been fixed (arm64 2.95.0) since the task was written; the stale credential helper is the residual defect, and doctor detects it.
- `worktree-publish.test.mjs` gh-log reader now filters out the doctor's `gh --version` probe; its assertions are about the publish flow's PR interactions.
- Checked the W1-03 box in docs/STABILITY-PROGRAM.md.

## Testing
- New `scripts/doctor.test.mjs` (7 tests): arch-mismatch classification fixtures (x86_64-on-arm64, universal binary), credential-helper parsing, report formatting with remediation lines, exit-code semantics, and a live runChecks smoke asserting all 8 check ids.
- `node scripts/doctor.mjs` on the dev machine reports the stale credential helper with exact remediation; `--strict` exit semantics verified.
- `bash -n scripts/*.sh scripts/lib/*.sh` clean; `node --test` on doctor, nightly-self-improve, and worktree-publish suites: all pass. (Pre-existing, unrelated: `findFreePort skips a port that is only occupied on IPv6` fails on this machine even on untouched dev.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)