### PR TITLE
feat: check in soak collector and soak-assert with machine-readable verdict

### DIFF
--- a/docs/STABILITY-PROGRAM.md
+++ b/docs/STABILITY-PROGRAM.md
@@ -32,7 +32,7 @@ Every claim above cites code in [stability-findings.json](stability-findings.jso
 | Task | Title | runner-safe | Status |
 | ---- | ----- | ----------- | ------ |
 | [W1-01](stability-tasks/W1-01-automation-state-out-of-tmp.md) | Move loop state out of /tmp; auto-record outcomes on merge | yes | ☐ |
-| [W1-02](stability-tasks/W1-02-soak-collector-and-assert.md) | Check in soak collector + soak-assert with machine-readable verdict | yes | ☐ |
+| [W1-02](stability-tasks/W1-02-soak-collector-and-assert.md) | Check in soak collector + soak-assert with machine-readable verdict | yes | ☑ |
 | [W1-03](stability-tasks/W1-03-doctor-preflight.md) | scripts/doctor.mjs machine preflight for all loops | yes | ☐ |
 | [W1-04](stability-tasks/W1-04-fix-ship-build-skill.md) | Rewrite freed-ship-build skill against actual release scripts | no | ☑ |
 | [W1-05](stability-tasks/W1-05-build-feature-skill-counters.md) | freed-build-feature: verification-counters step + outcome recording | no | ☐ |

--- a/scripts/soak-assert.mjs
+++ b/scripts/soak-assert.mjs
@@ -1,0 +1,424 @@
+#!/usr/bin/env node
+
+// Machine-readable soak verdict.
+//
+// Reads a soak directory written by scripts/soak-collect.mjs plus the app's
+// runtime-health.jsonl, evaluates named assertions, and writes
+// soak-verdict.json into the soak dir. Loops gate on the verdict instead of
+// reading soak evidence by eye.
+//
+// Assertions (each cites the violating file:line):
+//   main_footprint_slope    idle main-process footprint slope < 25 MB/h over >= 4h
+//   renderer_recoveries     renderer_recovery_restart_requested count == 0
+//   stale_heartbeats        renderer_heartbeat_stale count == 0
+//   webkit_returns_to_baseline  machine-wide WebContent count returns to its
+//                           baseline between scrape cycles
+//   uploads_unchanged_heads / preflight_kills / scrape_zero_persist
+//                           P0-02/P0-03 counters; no-op (skipped) until the
+//                           app emits them
+//
+// Usage:
+//   node scripts/soak-assert.mjs                       # soak dir from the active pointer
+//   node scripts/soak-assert.mjs --soak-dir <dir>
+//   node scripts/soak-assert.mjs --json                # print the verdict JSON
+// Exit code: 1 when any assertion fails (pass/skip exit 0).
+
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+
+export const VERDICT_SCHEMA_VERSION = 1;
+const MB = 1024 * 1024;
+const SLOPE_LIMIT_MB_PER_HOUR = 25;
+const SLOPE_MIN_HOURS = 4;
+
+const DEFAULT_POINTER = path.join(os.homedir(), ".freed-automation", "current-soak-dir");
+const DEFAULT_APP_DATA_DIR = path.join(
+  os.homedir(),
+  "Library",
+  "Application Support",
+  "wtf.freed.desktop",
+);
+
+function usage() {
+  return `Usage:
+  node scripts/soak-assert.mjs [options]
+
+Options:
+  --soak-dir <path>   Soak directory. Defaults to the active pointer (${DEFAULT_POINTER}).
+  --pointer <path>    Pointer file used when --soak-dir is omitted.
+  --app-data <path>   App data dir holding runtime-health.jsonl.
+  --out <path>        Verdict output. Defaults to <soak-dir>/soak-verdict.json.
+  --json              Also print the verdict JSON to stdout.
+  --help              Show this help.
+`;
+}
+
+export function parseArgs(argv) {
+  const args = {
+    soakDir: "",
+    pointer: DEFAULT_POINTER,
+    appData: DEFAULT_APP_DATA_DIR,
+    out: "",
+    json: false,
+    help: false,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    switch (arg) {
+      case "--soak-dir":
+        args.soakDir = argv[index + 1] ?? "";
+        index += 1;
+        break;
+      case "--pointer":
+        args.pointer = argv[index + 1] ?? "";
+        index += 1;
+        break;
+      case "--app-data":
+        args.appData = argv[index + 1] ?? "";
+        index += 1;
+        break;
+      case "--out":
+        args.out = argv[index + 1] ?? "";
+        index += 1;
+        break;
+      case "--json":
+        args.json = true;
+        break;
+      case "--help":
+      case "-h":
+        args.help = true;
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return args;
+}
+
+export function parseMetricsTsv(text) {
+  const lines = String(text ?? "")
+    .split(/\r?\n/)
+    .filter(Boolean);
+  const headers = lines.shift()?.split("\t") ?? [];
+  return lines.map((line, index) => {
+    const values = line.split("\t");
+    const row = Object.fromEntries(
+      headers.map((header, column) => [header, Number(values[column] ?? "")]),
+    );
+    row.iso = values[headers.indexOf("iso")] ?? "";
+    row.line = index + 2; // 1-indexed, after the header row
+    return row;
+  });
+}
+
+export function readHealthLines(healthPath, { fromTsMs = 0, toTsMs = Number.POSITIVE_INFINITY } = {}) {
+  if (!existsSync(healthPath)) {
+    return [];
+  }
+  return readFileSync(healthPath, "utf8")
+    .split(/\r?\n/)
+    .map((raw, index) => {
+      if (!raw.trim()) {
+        return null;
+      }
+      try {
+        const entry = JSON.parse(raw);
+        return { entry, line: index + 1, raw };
+      } catch {
+        return null;
+      }
+    })
+    .filter(Boolean)
+    .filter(({ entry }) => {
+      const ts = Number(entry.tsMs ?? 0);
+      // Keep lines without timestamps: better to over-count than silently drop.
+      return ts === 0 || (ts >= fromTsMs && ts <= toTsMs);
+    });
+}
+
+// Least-squares slope in MB/h over [{tsMs, bytes}] points.
+export function footprintSlopeMbPerHour(points) {
+  const usable = points.filter((point) => point.bytes > 0 && point.tsMs > 0);
+  if (usable.length < 2) {
+    return null;
+  }
+  const t0 = usable[0].tsMs;
+  const xs = usable.map((point) => (point.tsMs - t0) / 3_600_000); // hours
+  const ys = usable.map((point) => point.bytes / MB);
+  const n = usable.length;
+  const meanX = xs.reduce((sum, value) => sum + value, 0) / n;
+  const meanY = ys.reduce((sum, value) => sum + value, 0) / n;
+  let numerator = 0;
+  let denominator = 0;
+  for (let index = 0; index < n; index += 1) {
+    numerator += (xs[index] - meanX) * (ys[index] - meanY);
+    denominator += (xs[index] - meanX) ** 2;
+  }
+  if (denominator === 0) {
+    return null;
+  }
+  return numerator / denominator;
+}
+
+function assertion(id, status, detail, violations = []) {
+  return { id, status, detail, violations };
+}
+
+function cite(file, line, excerpt) {
+  return { file, line, excerpt: String(excerpt).slice(0, 240) };
+}
+
+export function assertFootprintSlope(healthLines, metricsRows, metricsPath, healthPath) {
+  // Prefer the app's own heartbeat footprint (attributed); fall back to the
+  // collector's ps rss for the main process.
+  const heartbeatPoints = healthLines
+    .filter(({ entry }) => entry.event === "renderer_heartbeat")
+    .map(({ entry }) => ({
+      tsMs: Number(entry.tsMs ?? 0),
+      bytes: Number(entry.nativeFootprintBytes ?? entry.nativeResidentBytes ?? 0),
+    }));
+  const psPoints = metricsRows.map((row) => ({
+    tsMs: row.tsMs,
+    bytes: row.appRssKb * 1024,
+  }));
+  const source = heartbeatPoints.filter((p) => p.bytes > 0).length >= 2 ? "renderer_heartbeat.nativeFootprintBytes" : `${path.basename(metricsPath)}.appRssKb`;
+  const points = source.startsWith("renderer_heartbeat") ? heartbeatPoints : psPoints;
+
+  const usable = points.filter((point) => point.bytes > 0 && point.tsMs > 0);
+  if (usable.length < 2) {
+    return assertion("main_footprint_slope", "skipped", "No footprint samples available.");
+  }
+  const spanHours = (usable.at(-1).tsMs - usable[0].tsMs) / 3_600_000;
+  const slope = footprintSlopeMbPerHour(usable);
+  if (spanHours < SLOPE_MIN_HOURS) {
+    return assertion(
+      "main_footprint_slope",
+      "skipped",
+      `Window is ${spanHours.toFixed(2)}h; slope needs >= ${SLOPE_MIN_HOURS}h. Measured ${slope?.toFixed(1) ?? "n/a"} MB/h over ${usable.length} samples from ${source} (informational).`,
+    );
+  }
+  if (slope === null) {
+    return assertion("main_footprint_slope", "skipped", "Slope could not be computed.");
+  }
+  if (slope >= SLOPE_LIMIT_MB_PER_HOUR) {
+    return assertion(
+      "main_footprint_slope",
+      "fail",
+      `${slope.toFixed(1)} MB/h over ${spanHours.toFixed(1)}h (${usable.length} samples from ${source}); limit ${SLOPE_LIMIT_MB_PER_HOUR} MB/h.`,
+      [cite(source.startsWith("renderer_heartbeat") ? healthPath : metricsPath, 0, `first ${usable[0].bytes} bytes @ ${new Date(usable[0].tsMs).toISOString()}, last ${usable.at(-1).bytes} bytes @ ${new Date(usable.at(-1).tsMs).toISOString()}`)],
+    );
+  }
+  return assertion(
+    "main_footprint_slope",
+    "pass",
+    `${slope.toFixed(1)} MB/h over ${spanHours.toFixed(1)}h (${usable.length} samples from ${source}).`,
+  );
+}
+
+export function assertEventCountZero(id, healthLines, healthPath, eventName) {
+  const hits = healthLines.filter(({ entry }) => entry.event === eventName);
+  if (hits.length === 0) {
+    return assertion(id, "pass", `0 ${eventName} events in the soak window.`);
+  }
+  return assertion(
+    id,
+    "fail",
+    `${hits.length} ${eventName} event${hits.length === 1 ? "" : "s"} in the soak window.`,
+    hits.slice(0, 10).map(({ line, raw }) => cite(healthPath, line, raw)),
+  );
+}
+
+export function assertWebkitReturnsToBaseline(metricsRows, metricsPath) {
+  const rows = metricsRows.filter((row) => Number.isFinite(row.webkitWebContentCount));
+  if (rows.length < 3) {
+    return assertion(
+      "webkit_returns_to_baseline",
+      "skipped",
+      "Not enough collector samples to judge WebContent count.",
+    );
+  }
+  const baseline = Math.min(...rows.map((row) => row.webkitWebContentCount));
+  const tail = rows.slice(-Math.max(3, Math.floor(rows.length * 0.1)));
+  const tailMin = Math.min(...tail.map((row) => row.webkitWebContentCount));
+  if (tailMin > baseline) {
+    const worst = tail.find((row) => row.webkitWebContentCount === tailMin) ?? tail.at(-1);
+    return assertion(
+      "webkit_returns_to_baseline",
+      "fail",
+      `WebContent count never returned to its baseline of ${baseline} in the final samples (still ${tailMin}). Machine-wide count; app-attributed counts arrive with P0-02/P0-03.`,
+      [cite(metricsPath, worst.line, `${worst.iso} webkitWebContentCount=${worst.webkitWebContentCount}`)],
+    );
+  }
+  return assertion(
+    "webkit_returns_to_baseline",
+    "pass",
+    `WebContent count returned to its baseline of ${baseline} by the end of the soak.`,
+  );
+}
+
+// P0-02/P0-03 counters. Guarded: skipped until the app emits the fields.
+export function assertGuardedCounters(healthLines, healthPath) {
+  const results = [];
+
+  const uploadLines = healthLines.filter(({ entry }) => typeof entry.headsUnchanged === "boolean");
+  if (uploadLines.length === 0) {
+    results.push(
+      assertion("uploads_unchanged_heads", "skipped", "Counter not yet emitted (lands with P0-03)."),
+    );
+  } else {
+    const unchanged = uploadLines.filter(({ entry }) => entry.headsUnchanged === true);
+    results.push(
+      unchanged.length === 0
+        ? assertion("uploads_unchanged_heads", "pass", `0 of ${uploadLines.length} uploads had unchanged heads.`)
+        : assertion(
+            "uploads_unchanged_heads",
+            "fail",
+            `${unchanged.length} of ${uploadLines.length} uploads had unchanged heads (cloud loop signature, F01/F06).`,
+            unchanged.slice(0, 10).map(({ line, raw }) => cite(healthPath, line, raw)),
+          ),
+    );
+  }
+
+  const killLines = healthLines.filter(({ entry }) => entry.event === "window_destroyed");
+  if (killLines.length === 0) {
+    results.push(
+      assertion("preflight_kills", "skipped", "No window_destroyed records (lands with P0-02)."),
+    );
+  } else {
+    const preflightKills = killLines.filter(
+      ({ entry, raw }) => entry.sessionActive === true || raw.includes("preflight"),
+    );
+    results.push(
+      preflightKills.length === 0
+        ? assertion("preflight_kills", "pass", `0 of ${killLines.length} window_destroyed records killed an active session.`)
+        : assertion(
+            "preflight_kills",
+            "fail",
+            `${preflightKills.length} window_destroyed record${preflightKills.length === 1 ? "" : "s"} killed an active session or came from preflight (F04).`,
+            preflightKills.slice(0, 10).map(({ line, raw }) => cite(healthPath, line, raw)),
+          ),
+    );
+  }
+
+  const scrapeLines = healthLines.filter(
+    ({ entry }) => Number.isFinite(entry.itemsExtracted) && Number.isFinite(entry.itemsPersisted),
+  );
+  if (scrapeLines.length === 0) {
+    results.push(
+      assertion("scrape_zero_persist", "skipped", "Counter not yet emitted (lands with P0-03)."),
+    );
+  } else {
+    const zeroPersist = scrapeLines.filter(
+      ({ entry }) => entry.itemsExtracted >= 5 && entry.itemsPersisted === 0,
+    );
+    results.push(
+      zeroPersist.length === 0
+        ? assertion("scrape_zero_persist", "pass", `0 of ${scrapeLines.length} scrapes extracted items without persisting.`)
+        : assertion(
+            "scrape_zero_persist",
+            "fail",
+            `${zeroPersist.length} scrape${zeroPersist.length === 1 ? "" : "s"} extracted >= 5 items and persisted 0 (F03 signature).`,
+            zeroPersist.slice(0, 10).map(({ line, raw }) => cite(healthPath, line, raw)),
+          ),
+    );
+  }
+
+  return results;
+}
+
+export function buildVerdict({ soakDir, metricsText, metricsPath, healthLines, healthPath }) {
+  const metricsRows = parseMetricsTsv(metricsText);
+  const windowStart = metricsRows[0]?.tsMs ?? healthLines[0]?.entry?.tsMs ?? 0;
+  const windowEnd = metricsRows.at(-1)?.tsMs ?? healthLines.at(-1)?.entry?.tsMs ?? 0;
+
+  const assertions = [
+    assertFootprintSlope(healthLines, metricsRows, metricsPath, healthPath),
+    assertEventCountZero("renderer_recoveries", healthLines, healthPath, "renderer_recovery_restart_requested"),
+    assertEventCountZero("stale_heartbeats", healthLines, healthPath, "renderer_heartbeat_stale"),
+    assertWebkitReturnsToBaseline(metricsRows, metricsPath),
+    ...assertGuardedCounters(healthLines, healthPath),
+  ];
+
+  return {
+    schemaVersion: VERDICT_SCHEMA_VERSION,
+    soakDir,
+    generatedAt: new Date().toISOString(),
+    windowStart: windowStart ? new Date(windowStart).toISOString() : "",
+    windowEnd: windowEnd ? new Date(windowEnd).toISOString() : "",
+    spanHours: windowStart && windowEnd ? (windowEnd - windowStart) / 3_600_000 : 0,
+    sampleCount: metricsRows.length,
+    healthLineCount: healthLines.length,
+    assertions,
+    failures: assertions.filter((item) => item.status === "fail").length,
+    pass: assertions.every((item) => item.status !== "fail"),
+  };
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    process.stdout.write(usage());
+    return;
+  }
+
+  let soakDir = args.soakDir;
+  if (!soakDir) {
+    if (!existsSync(args.pointer)) {
+      throw new Error(`No --soak-dir given and no pointer at ${args.pointer}.`);
+    }
+    soakDir = readFileSync(args.pointer, "utf8").trim();
+  }
+  soakDir = path.resolve(soakDir);
+  if (!existsSync(soakDir)) {
+    throw new Error(`Soak dir does not exist: ${soakDir}`);
+  }
+
+  const metricsPath = path.join(soakDir, "metrics.tsv");
+  const metricsText = existsSync(metricsPath) ? readFileSync(metricsPath, "utf8") : "";
+  const metricsRows = parseMetricsTsv(metricsText);
+  const windowStart = metricsRows[0]?.tsMs ?? 0;
+  const windowEnd = metricsRows.at(-1)?.tsMs ?? Number.POSITIVE_INFINITY;
+
+  // Prefer a runtime-health copy inside the soak dir (older soaks stored one);
+  // otherwise read the app's live file sliced to the soak window.
+  const soakHealthPath = path.join(soakDir, "runtime-health.jsonl");
+  const healthPath = existsSync(soakHealthPath)
+    ? soakHealthPath
+    : path.join(args.appData, "runtime-health.jsonl");
+  const healthLines = readHealthLines(healthPath, {
+    fromTsMs: windowStart,
+    toTsMs: windowEnd === 0 ? Number.POSITIVE_INFINITY : windowEnd,
+  });
+
+  const verdict = buildVerdict({ soakDir, metricsText, metricsPath, healthLines, healthPath });
+  const outPath = args.out ? path.resolve(args.out) : path.join(soakDir, "soak-verdict.json");
+  writeFileSync(outPath, `${JSON.stringify(verdict, null, 2)}\n`);
+
+  if (args.json) {
+    process.stdout.write(`${JSON.stringify(verdict, null, 2)}\n`);
+  } else {
+    for (const item of verdict.assertions) {
+      process.stdout.write(`[${item.status.toUpperCase()}] ${item.id}: ${item.detail}\n`);
+      for (const violation of item.violations) {
+        process.stdout.write(`    ${violation.file}:${violation.line} ${violation.excerpt.slice(0, 120)}\n`);
+      }
+    }
+    process.stdout.write(
+      `Verdict: ${verdict.pass ? "PASS" : "FAIL"} (${verdict.failures} failing assertion${verdict.failures === 1 ? "" : "s"}) -> ${outPath}\n`,
+    );
+  }
+  process.exitCode = verdict.pass ? 0 : 1;
+}
+
+if (process.argv[1] === __filename) {
+  try {
+    main();
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/soak-collect.mjs
+++ b/scripts/soak-collect.mjs
@@ -1,0 +1,339 @@
+#!/usr/bin/env node
+
+// Installed-build soak collector.
+//
+// Samples the installed Freed Desktop app on an interval into a versioned
+// TSV/JSONL schema under a soak directory, and points the active-soak pointer
+// (~/.freed-automation/current-soak-dir) at it so the nightly planner and
+// scripts/soak-assert.mjs can find the evidence.
+//
+// What it records per sample:
+//   metrics.tsv            one row per sample (see COLUMNS below)
+//   webkit-processes.tsv   machine-wide WebKit XPC process table
+//   health-offsets.jsonl   byte/line offsets of the app's runtime-health.jsonl
+//   soak-info.json         schema version + config, written once at start
+//
+// WebKit attribution caveat: WebKit XPC processes are children of launchd
+// (ppid 1), so plain `ps` cannot attribute them to Freed (stability finding
+// F27). The webkit* columns are machine-wide totals; the app's own attributed
+// view lives in runtime-health.jsonl, which soak-assert reads alongside this.
+//
+// Usage:
+//   node scripts/soak-collect.mjs                    # sample every 60s until killed
+//   node scripts/soak-collect.mjs --detach           # survive terminal close
+//   node scripts/soak-collect.mjs --once             # single sample (smoke test)
+//   node scripts/soak-collect.mjs --interval-seconds 30 --duration-minutes 600
+
+import { execFileSync, spawn } from "node:child_process";
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+
+export const SOAK_SCHEMA_VERSION = 1;
+export const METRICS_COLUMNS = [
+  "tsMs", // sample wall-clock epoch ms
+  "iso", // same instant, ISO-8601, for humans
+  "appPid", // Freed Desktop main process pid, 0 when not running
+  "appRssKb", // main process resident set, KiB (ps rss)
+  "webkitWebContentCount", // machine-wide WebContent process count
+  "webkitWebContentRssKb", // machine-wide WebContent resident total, KiB
+  "webkitLargestRssKb", // largest single WebContent resident, KiB
+  "webkitOtherRssKb", // machine-wide GPU+Networking resident total, KiB
+  "healthFileBytes", // runtime-health.jsonl size at sample time
+  "healthFileLines", // runtime-health.jsonl line count at sample time
+];
+
+const DEFAULT_APP_DATA_DIR = path.join(
+  os.homedir(),
+  "Library",
+  "Application Support",
+  "wtf.freed.desktop",
+);
+const AUTOMATION_STATE_DIR = path.join(os.homedir(), ".freed-automation");
+
+function usage() {
+  return `Usage:
+  node scripts/soak-collect.mjs [options]
+
+Options:
+  --soak-dir <path>          Soak directory. Defaults to ~/.freed-automation/soaks/<timestamp>.
+  --pointer <path>           Active-soak pointer file. Defaults to ~/.freed-automation/current-soak-dir.
+  --app-data <path>          App data dir holding runtime-health.jsonl. Defaults to the installed Freed Desktop dir.
+  --app-binary <substring>   Main process match. Defaults to "Freed.app/Contents/MacOS".
+  --interval-seconds <n>     Sample interval. Defaults to 60.
+  --duration-minutes <n>     Stop after this long. Defaults to 0 (run until killed).
+  --once                     Take a single sample and exit.
+  --detach                   Re-spawn detached from the terminal and exit.
+  --help                     Show this help.
+`;
+}
+
+export function parseArgs(argv, now = new Date()) {
+  const args = {
+    soakDir: "",
+    pointer: path.join(AUTOMATION_STATE_DIR, "current-soak-dir"),
+    appData: DEFAULT_APP_DATA_DIR,
+    appBinary: "Freed.app/Contents/MacOS",
+    intervalSeconds: 60,
+    durationMinutes: 0,
+    once: false,
+    detach: false,
+    help: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    switch (arg) {
+      case "--soak-dir":
+        args.soakDir = argv[index + 1] ?? "";
+        index += 1;
+        break;
+      case "--pointer":
+        args.pointer = argv[index + 1] ?? "";
+        index += 1;
+        break;
+      case "--app-data":
+        args.appData = argv[index + 1] ?? "";
+        index += 1;
+        break;
+      case "--app-binary":
+        args.appBinary = argv[index + 1] ?? "";
+        index += 1;
+        break;
+      case "--interval-seconds":
+        args.intervalSeconds = Number(argv[index + 1]);
+        index += 1;
+        break;
+      case "--duration-minutes":
+        args.durationMinutes = Number(argv[index + 1]);
+        index += 1;
+        break;
+      case "--once":
+        args.once = true;
+        break;
+      case "--detach":
+        args.detach = true;
+        break;
+      case "--help":
+      case "-h":
+        args.help = true;
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (args.help) {
+    return args;
+  }
+  if (!Number.isFinite(args.intervalSeconds) || args.intervalSeconds < 5) {
+    throw new Error("interval-seconds must be at least 5.");
+  }
+  if (!Number.isFinite(args.durationMinutes) || args.durationMinutes < 0) {
+    throw new Error("duration-minutes must be 0 or more.");
+  }
+  if (!args.pointer) {
+    throw new Error("pointer requires a path.");
+  }
+  args.soakDir =
+    args.soakDir ||
+    path.join(
+      AUTOMATION_STATE_DIR,
+      "soaks",
+      now.toISOString().replace(/[:.]/g, "").replace("T", "-").slice(0, 15),
+    );
+  args.soakDir = path.resolve(args.soakDir);
+  args.pointer = path.resolve(args.pointer);
+  args.appData = path.resolve(args.appData);
+
+  return args;
+}
+
+// Parses `ps axo pid=,ppid=,rss=,command=` output into rows.
+export function parsePsTable(psOutput) {
+  return String(psOutput ?? "")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const match = line.match(/^(\d+)\s+(\d+)\s+(\d+)\s+(.*)$/);
+      if (!match) {
+        return null;
+      }
+      return {
+        pid: Number(match[1]),
+        ppid: Number(match[2]),
+        rssKb: Number(match[3]),
+        command: match[4],
+      };
+    })
+    .filter(Boolean);
+}
+
+// Builds one metrics row (plus the WebKit process sub-table) from a ps table.
+export function buildSample(psRows, { appBinary, tsMs }) {
+  const appRow = psRows.find((row) => row.command.includes(appBinary)) ?? null;
+  const webContent = psRows.filter((row) => row.command.includes("com.apple.WebKit.WebContent"));
+  const otherWebKit = psRows.filter(
+    (row) =>
+      row.command.includes("com.apple.WebKit.") &&
+      !row.command.includes("com.apple.WebKit.WebContent"),
+  );
+
+  return {
+    tsMs,
+    iso: new Date(tsMs).toISOString(),
+    appPid: appRow?.pid ?? 0,
+    appRssKb: appRow?.rssKb ?? 0,
+    webkitWebContentCount: webContent.length,
+    webkitWebContentRssKb: webContent.reduce((sum, row) => sum + row.rssKb, 0),
+    webkitLargestRssKb: webContent.reduce((max, row) => Math.max(max, row.rssKb), 0),
+    webkitOtherRssKb: otherWebKit.reduce((sum, row) => sum + row.rssKb, 0),
+    webkitRows: [...webContent, ...otherWebKit],
+  };
+}
+
+export function metricsRowToTsv(sample) {
+  return `${METRICS_COLUMNS.map((column) => String(sample[column] ?? "")).join("\t")}\n`;
+}
+
+function readHealthOffsets(appData) {
+  const healthPath = path.join(appData, "runtime-health.jsonl");
+  if (!existsSync(healthPath)) {
+    return { bytes: 0, lines: 0 };
+  }
+  try {
+    const stat = statSync(healthPath);
+    // The app rotates this file (5 MiB cap today), so a full read per sample
+    // is cheap.
+    const content = readFileSync(healthPath, "utf8");
+    return { bytes: stat.size, lines: content.split("\n").filter(Boolean).length };
+  } catch {
+    return { bytes: 0, lines: 0 };
+  }
+}
+
+function takeSample(args, now = Date.now()) {
+  let psOutput = "";
+  try {
+    psOutput = execFileSync("ps", ["axo", "pid=,ppid=,rss=,command="], {
+      encoding: "utf8",
+      maxBuffer: 32 * 1024 * 1024,
+    });
+  } catch {
+    psOutput = "";
+  }
+  const sample = buildSample(parsePsTable(psOutput), {
+    appBinary: args.appBinary,
+    tsMs: now,
+  });
+  const offsets = readHealthOffsets(args.appData);
+  sample.healthFileBytes = offsets.bytes;
+  sample.healthFileLines = offsets.lines;
+
+  appendFileSync(path.join(args.soakDir, "metrics.tsv"), metricsRowToTsv(sample));
+  for (const row of sample.webkitRows) {
+    appendFileSync(
+      path.join(args.soakDir, "webkit-processes.tsv"),
+      `${sample.tsMs}\t${row.pid}\t${row.ppid}\t${row.rssKb}\t${row.command.slice(0, 200)}\n`,
+    );
+  }
+  appendFileSync(
+    path.join(args.soakDir, "health-offsets.jsonl"),
+    `${JSON.stringify({ tsMs: sample.tsMs, ...offsets })}\n`,
+  );
+  return sample;
+}
+
+function initSoakDir(args) {
+  mkdirSync(args.soakDir, { recursive: true });
+  const infoPath = path.join(args.soakDir, "soak-info.json");
+  if (!existsSync(infoPath)) {
+    writeFileSync(
+      infoPath,
+      `${JSON.stringify(
+        {
+          schemaVersion: SOAK_SCHEMA_VERSION,
+          startedAt: new Date().toISOString(),
+          intervalSeconds: args.intervalSeconds,
+          durationMinutes: args.durationMinutes,
+          appData: args.appData,
+          appBinary: args.appBinary,
+          collectorPid: process.pid,
+          metricsColumns: METRICS_COLUMNS,
+          webkitProcessesColumns: ["tsMs", "pid", "ppid", "rssKb", "command"],
+          notes:
+            "webkit* metrics are machine-wide: WebKit XPC processes cannot be attributed to Freed from ps (ppid 1, finding F27). App-attributed telemetry lives in runtime-health.jsonl.",
+        },
+        null,
+        2,
+      )}\n`,
+    );
+  }
+  const metricsPath = path.join(args.soakDir, "metrics.tsv");
+  if (!existsSync(metricsPath)) {
+    writeFileSync(metricsPath, `${METRICS_COLUMNS.join("\t")}\n`);
+  }
+  mkdirSync(path.dirname(args.pointer), { recursive: true });
+  writeFileSync(args.pointer, `${args.soakDir}\n`);
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    process.stdout.write(usage());
+    return;
+  }
+
+  if (args.detach) {
+    const childArgs = process.argv.slice(1).filter((arg) => arg !== "--detach");
+    // Pin the soak dir so the parent can report where the detached child writes.
+    if (!childArgs.includes("--soak-dir")) {
+      childArgs.push("--soak-dir", args.soakDir);
+    }
+    const child = spawn(process.execPath, childArgs, {
+      detached: true,
+      stdio: "ignore",
+    });
+    child.unref();
+    process.stdout.write(`Detached collector pid ${child.pid}, soak dir ${args.soakDir}\n`);
+    return;
+  }
+
+  initSoakDir(args);
+  const startedAt = Date.now();
+  const sample = takeSample(args);
+  process.stdout.write(
+    `Soak dir ${args.soakDir}: sampling every ${args.intervalSeconds}s (app pid ${sample.appPid || "not running"}).\n`,
+  );
+  if (args.once) {
+    return;
+  }
+
+  const timer = setInterval(() => {
+    takeSample(args);
+    if (args.durationMinutes > 0 && Date.now() - startedAt >= args.durationMinutes * 60_000) {
+      clearInterval(timer);
+      process.stdout.write("Soak duration reached; collector exiting.\n");
+    }
+  }, args.intervalSeconds * 1_000);
+}
+
+if (process.argv[1] === __filename) {
+  try {
+    main();
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/soak.test.mjs
+++ b/scripts/soak.test.mjs
@@ -1,0 +1,305 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+import {
+  buildSample,
+  METRICS_COLUMNS,
+  metricsRowToTsv,
+  parsePsTable,
+  parseArgs as parseCollectArgs,
+} from "./soak-collect.mjs";
+import {
+  assertEventCountZero,
+  assertFootprintSlope,
+  assertGuardedCounters,
+  assertWebkitReturnsToBaseline,
+  buildVerdict,
+  footprintSlopeMbPerHour,
+  parseMetricsTsv,
+  readHealthLines,
+} from "./soak-assert.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const MB = 1024 * 1024;
+
+const PS_FIXTURE = [
+  "  312     1  92288 /System/Library/Frameworks/WebKit.framework/Versions/A/XPCServices/com.apple.WebKit.Networking.xpc/Contents/MacOS/com.apple.WebKit.Networking",
+  "10312     1 913728 /Applications/Freed.app/Contents/MacOS/freed-desktop",
+  "10316     1 173152 /System/Library/Frameworks/WebKit.framework/Versions/A/XPCServices/com.apple.WebKit.WebContent.xpc/Contents/MacOS/com.apple.WebKit.WebContent",
+  "18781     1 6706592 /System/Library/Frameworks/WebKit.framework/Versions/A/XPCServices/com.apple.WebKit.WebContent.xpc/Contents/MacOS/com.apple.WebKit.WebContent",
+  "99999     1   1000 /usr/sbin/somethingelse",
+].join("\n");
+
+function metricsFixture(rows) {
+  return [
+    METRICS_COLUMNS.join("\t"),
+    ...rows.map((row) => METRICS_COLUMNS.map((column) => row[column] ?? 0).join("\t")),
+  ].join("\n");
+}
+
+function healthFixtureFile(dir, lines) {
+  const healthPath = path.join(dir, "runtime-health.jsonl");
+  writeFileSync(healthPath, lines.map((line) => JSON.stringify(line)).join("\n") + "\n");
+  return healthPath;
+}
+
+test("parsePsTable and buildSample split app, WebContent, and other WebKit processes", () => {
+  const rows = parsePsTable(PS_FIXTURE);
+  assert.equal(rows.length, 5);
+
+  const sample = buildSample(rows, { appBinary: "Freed.app/Contents/MacOS", tsMs: 1_700_000_000_000 });
+  assert.equal(sample.appPid, 10312);
+  assert.equal(sample.appRssKb, 913728);
+  assert.equal(sample.webkitWebContentCount, 2);
+  assert.equal(sample.webkitWebContentRssKb, 173152 + 6706592);
+  assert.equal(sample.webkitLargestRssKb, 6706592);
+  assert.equal(sample.webkitOtherRssKb, 92288);
+
+  const tsv = metricsRowToTsv({ ...sample, healthFileBytes: 10, healthFileLines: 2 });
+  assert.equal(tsv.trim().split("\t").length, METRICS_COLUMNS.length);
+});
+
+test("soak-collect parseArgs derives a soaks dir under ~/.freed-automation", () => {
+  const args = parseCollectArgs([], new Date("2026-07-02T10:00:00Z"));
+  assert.ok(args.soakDir.includes(path.join(".freed-automation", "soaks")));
+  assert.ok(args.pointer.endsWith("current-soak-dir"));
+  assert.throws(() => parseCollectArgs(["--interval-seconds", "1"]), /at least 5/);
+});
+
+test("soak-collect --once writes metrics, offsets, info, and the pointer", () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "freed-soak-collect-"));
+  const soakDir = path.join(root, "soak");
+  const pointer = path.join(root, "state", "current-soak-dir");
+  execFileSync(
+    process.execPath,
+    [
+      path.join(__dirname, "soak-collect.mjs"),
+      "--once",
+      "--soak-dir",
+      soakDir,
+      "--pointer",
+      pointer,
+      "--app-data",
+      root,
+    ],
+    { encoding: "utf8" },
+  );
+
+  assert.ok(existsSync(path.join(soakDir, "metrics.tsv")));
+  assert.ok(existsSync(path.join(soakDir, "soak-info.json")));
+  assert.ok(existsSync(path.join(soakDir, "health-offsets.jsonl")));
+  assert.equal(readFileSync(pointer, "utf8").trim(), soakDir);
+
+  const metrics = readFileSync(path.join(soakDir, "metrics.tsv"), "utf8").trim().split("\n");
+  assert.equal(metrics[0], METRICS_COLUMNS.join("\t"));
+  assert.equal(metrics.length, 2);
+
+  const info = JSON.parse(readFileSync(path.join(soakDir, "soak-info.json"), "utf8"));
+  assert.equal(info.schemaVersion, 1);
+  assert.deepEqual(info.metricsColumns, METRICS_COLUMNS);
+});
+
+test("footprintSlopeMbPerHour measures a linear leak", () => {
+  const start = 1_700_000_000_000;
+  const points = Array.from({ length: 11 }, (_, i) => ({
+    tsMs: start + i * 3_600_000,
+    bytes: (1000 + 100 * i) * MB, // +100 MB/h
+  }));
+  const slope = footprintSlopeMbPerHour(points);
+  assert.ok(Math.abs(slope - 100) < 0.001, `slope was ${slope}`);
+});
+
+test("a synthetic leaky heartbeat trace fails the slope assertion; a flat trace passes", () => {
+  const start = 1_700_000_000_000;
+  const leaky = Array.from({ length: 21 }, (_, i) => ({
+    entry: {
+      event: "renderer_heartbeat",
+      tsMs: start + i * 15 * 60_000, // 5h of 15-min heartbeats
+      nativeFootprintBytes: (1000 + 20 * i) * MB, // +80 MB/h
+    },
+    line: i + 1,
+    raw: "{}",
+  }));
+  const flat = leaky.map((item, i) => ({
+    ...item,
+    entry: { ...item.entry, nativeFootprintBytes: 1000 * MB + (i % 2) * MB },
+  }));
+
+  const failing = assertFootprintSlope(leaky, [], "metrics.tsv", "runtime-health.jsonl");
+  assert.equal(failing.status, "fail");
+  assert.match(failing.detail, /MB\/h/);
+
+  const passing = assertFootprintSlope(flat, [], "metrics.tsv", "runtime-health.jsonl");
+  assert.equal(passing.status, "pass");
+});
+
+test("a short window skips the slope assertion instead of judging it", () => {
+  const start = 1_700_000_000_000;
+  const short = Array.from({ length: 10 }, (_, i) => ({
+    entry: {
+      event: "renderer_heartbeat",
+      tsMs: start + i * 60_000, // 10 minutes
+      nativeFootprintBytes: (1000 + 50 * i) * MB,
+    },
+    line: i + 1,
+    raw: "{}",
+  }));
+  const result = assertFootprintSlope(short, [], "metrics.tsv", "runtime-health.jsonl");
+  assert.equal(result.status, "skipped");
+  assert.match(result.detail, /needs >= 4h/);
+});
+
+test("recovery and stale-heartbeat assertions cite the violating lines", () => {
+  const lines = [
+    { entry: { event: "renderer_heartbeat", tsMs: 1 }, line: 1, raw: "{hb}" },
+    { entry: { event: "renderer_recovery_restart_requested", tsMs: 2 }, line: 2, raw: "{recovery}" },
+    { entry: { event: "renderer_heartbeat_stale", tsMs: 3 }, line: 3, raw: "{stale}" },
+  ];
+  const recoveries = assertEventCountZero(
+    "renderer_recoveries",
+    lines,
+    "runtime-health.jsonl",
+    "renderer_recovery_restart_requested",
+  );
+  assert.equal(recoveries.status, "fail");
+  assert.deepEqual(recoveries.violations, [
+    { file: "runtime-health.jsonl", line: 2, excerpt: "{recovery}" },
+  ]);
+
+  const stale = assertEventCountZero(
+    "stale_heartbeats",
+    lines,
+    "runtime-health.jsonl",
+    "renderer_heartbeat_stale",
+  );
+  assert.equal(stale.status, "fail");
+  assert.equal(stale.violations[0].line, 3);
+
+  const clean = assertEventCountZero(
+    "renderer_recoveries",
+    lines.slice(0, 1),
+    "runtime-health.jsonl",
+    "renderer_recovery_restart_requested",
+  );
+  assert.equal(clean.status, "pass");
+});
+
+test("webkit_returns_to_baseline fails when the tail never returns to baseline", () => {
+  const start = 1_700_000_000_000;
+  const growing = parseMetricsTsv(
+    metricsFixture(
+      Array.from({ length: 10 }, (_, i) => ({
+        tsMs: start + i * 60_000,
+        iso: "t",
+        webkitWebContentCount: i < 3 ? 4 : 9,
+      })),
+    ),
+  );
+  const failing = assertWebkitReturnsToBaseline(growing, "metrics.tsv");
+  assert.equal(failing.status, "fail");
+  assert.ok(failing.violations[0].line > 1);
+
+  const returning = parseMetricsTsv(
+    metricsFixture(
+      Array.from({ length: 10 }, (_, i) => ({
+        tsMs: start + i * 60_000,
+        iso: "t",
+        webkitWebContentCount: i > 3 && i < 7 ? 9 : 4,
+      })),
+    ),
+  );
+  assert.equal(assertWebkitReturnsToBaseline(returning, "metrics.tsv").status, "pass");
+});
+
+test("guarded P0-02/P0-03 counter assertions no-op until the counters exist", () => {
+  const withoutCounters = [
+    { entry: { event: "renderer_heartbeat", tsMs: 1 }, line: 1, raw: "{}" },
+  ];
+  const skipped = assertGuardedCounters(withoutCounters, "runtime-health.jsonl");
+  assert.deepEqual(
+    skipped.map((item) => [item.id, item.status]),
+    [
+      ["uploads_unchanged_heads", "skipped"],
+      ["preflight_kills", "skipped"],
+      ["scrape_zero_persist", "skipped"],
+    ],
+  );
+
+  const withCounters = [
+    { entry: { event: "cloud_upload", headsUnchanged: true, tsMs: 1 }, line: 1, raw: "{u}" },
+    { entry: { event: "cloud_upload", headsUnchanged: false, tsMs: 2 }, line: 2, raw: "{u2}" },
+    { entry: { event: "window_destroyed", sessionActive: true, tsMs: 3 }, line: 3, raw: "{kill}" },
+    { entry: { event: "scrape_outcome", itemsExtracted: 12, itemsPersisted: 0, tsMs: 4 }, line: 4, raw: "{s}" },
+  ];
+  const judged = assertGuardedCounters(withCounters, "runtime-health.jsonl");
+  assert.deepEqual(
+    judged.map((item) => [item.id, item.status]),
+    [
+      ["uploads_unchanged_heads", "fail"],
+      ["preflight_kills", "fail"],
+      ["scrape_zero_persist", "fail"],
+    ],
+  );
+  assert.equal(judged[0].violations[0].line, 1);
+});
+
+test("buildVerdict produces a machine-readable verdict with real numbers", () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "freed-soak-verdict-"));
+  const start = 1_700_000_000_000;
+  const healthPath = healthFixtureFile(
+    dir,
+    Array.from({ length: 21 }, (_, i) => ({
+      event: "renderer_heartbeat",
+      tsMs: start + i * 15 * 60_000,
+      nativeFootprintBytes: 1000 * MB,
+    })),
+  );
+  const metricsText = metricsFixture(
+    Array.from({ length: 6 }, (_, i) => ({
+      tsMs: start + i * 60 * 60_000,
+      iso: new Date(start + i * 60 * 60_000).toISOString(),
+      appPid: 1,
+      appRssKb: 1000,
+      webkitWebContentCount: 4,
+    })),
+  );
+
+  const verdict = buildVerdict({
+    soakDir: dir,
+    metricsText,
+    metricsPath: path.join(dir, "metrics.tsv"),
+    healthLines: readHealthLines(healthPath),
+    healthPath,
+  });
+
+  assert.equal(verdict.schemaVersion, 1);
+  assert.equal(verdict.pass, true);
+  assert.equal(verdict.failures, 0);
+  assert.ok(verdict.spanHours >= 5);
+  assert.equal(verdict.sampleCount, 6);
+  const byId = Object.fromEntries(verdict.assertions.map((item) => [item.id, item.status]));
+  assert.equal(byId.main_footprint_slope, "pass");
+  assert.equal(byId.renderer_recoveries, "pass");
+  assert.equal(byId.stale_heartbeats, "pass");
+  assert.equal(byId.uploads_unchanged_heads, "skipped");
+});
+
+test("readHealthLines slices by tsMs window and keeps malformed lines out", () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "freed-soak-health-"));
+  const healthPath = path.join(dir, "runtime-health.jsonl");
+  writeFileSync(
+    healthPath,
+    ['{"event":"a","tsMs":100}', "not-json", '{"event":"b","tsMs":200}', '{"event":"c","tsMs":300}'].join(
+      "\n",
+    ),
+  );
+  const lines = readHealthLines(healthPath, { fromTsMs: 150, toTsMs: 250 });
+  assert.equal(lines.length, 1);
+  assert.equal(lines[0].entry.event, "b");
+  assert.equal(lines[0].line, 3);
+});


### PR DESCRIPTION
(AI Generated).

## Summary
- Stability program task [W1-02](https://github.com/freed-project/freed/blob/dev/docs/stability-tasks/W1-02-soak-collector-and-assert.md): installed-build soaks used an uncommitted collector and were judged by eye; the program needs every soak to yield a verdict loops can gate on.
- New `scripts/soak-collect.mjs`: samples the installed app (main process rss via ps, machine-wide WebKit XPC process table, runtime-health.jsonl byte/line offsets) on an interval into a versioned schema under `~/.freed-automation/soaks/<ts>/` (`soak-info.json` schemaVersion 1 + documented columns, `metrics.tsv`, `webkit-processes.tsv`, `health-offsets.jsonl`), writes the `~/.freed-automation/current-soak-dir` pointer (W1-01 location), and supports `--detach` (survives terminal close), `--once`, `--interval-seconds`, `--duration-minutes`. WebKit attribution caveat (finding F27: XPC processes are children of launchd) is documented in the schema notes; the machine-wide numbers complement the app-attributed telemetry in runtime-health.jsonl.
- New `scripts/soak-assert.mjs`: reads a soak dir plus the app's runtime-health.jsonl sliced to the soak window and writes `soak-verdict.json` with named assertions, each citing violating file:line: footprint slope < 25 MB/h over >= 4h (skips with informational numbers on shorter windows), renderer_recovery_restart_requested == 0, renderer_heartbeat_stale == 0, WebContent count returns to baseline, and the P0-02/P0-03 counters (uploads with unchanged heads, preflight kills, scrape extracted>=5/persisted==0) guarded to no-op until those counters exist. Exit 1 on failing verdict.
- Both scripts have node --test coverage in `scripts/soak.test.mjs` (11 tests), picked up by `npm run test:scripts`.
- Checked the W1-02 box in docs/STABILITY-PROGRAM.md.

## Testing
- Fixture-driven: a synthetic leaky heartbeat trace (+80 MB/h over 5h) fails the slope assertion; a flat trace passes; a 10-minute window skips instead of judging; recovery/stale assertions cite exact line numbers; guarded counters skip without P0-02/P0-03 fields and judge with them; `--once` smoke run asserts all files plus pointer.
- Live verify per the task: ran the collector against the running installed build (pid 10312) for 10 minutes at 30s intervals, then `node scripts/soak-assert.mjs` produced a verdict with real numbers: 21 samples, 49 health lines in window, renderer_recoveries pass (0), stale_heartbeats pass (0), webkit_returns_to_baseline pass (baseline 31), slope skipped (0.16h < 4h) with informational measurement, three guarded counters skipped. Verdict PASS, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)