### PR TITLE
feat: loop counters — cloud uploads w/ heads-unchanged, relay broadcasts, worker INITs, scrape outcomes (stability P0-03)

### DIFF
--- a/docs/STABILITY-PROGRAM.md
+++ b/docs/STABILITY-PROGRAM.md
@@ -40,7 +40,7 @@ Every claim above cites code in [stability-findings.json](stability-findings.jso
 | [W1-07](stability-tasks/W1-07-docs-truth-pass.md) | Regenerate ARCHITECTURE.md; fix AGENTS.md roadmap rule; canonical soak doc | yes | ☑ |
 | [P0-01](stability-tasks/P0-01-perf-gate-pipefail.md) | Make the CI perf gate actually fail (tee swallows exit code) | yes | ☐ |
 | [P0-02](stability-tasks/P0-02-window-kill-records.md) | Structured window_destroyed kill records | no | ☑ |
-| [P0-03](stability-tasks/P0-03-loop-counters.md) | Loop counters: uploads w/ heads-unchanged, broadcasts, worker INITs, scrape outcomes | no | ☐ |
+| [P0-03](stability-tasks/P0-03-loop-counters.md) | Loop counters: uploads w/ heads-unchanged, broadcasts, worker INITs, scrape outcomes | no | ☑ |
 | [P0-04](stability-tasks/P0-04-runtime-health-rotation.md) | Daily runtime-health rotation replacing the 5 MiB halving cap | no | ☑ |
 
 Done when: every counter in the scorecard below has a baseline number from one overnight soak.

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -6801,6 +6801,41 @@ async fn trim_webkit_network_cache_now(
     Ok(result)
 }
 
+/// Renderer-originated runtime-health counters (stability program P0-03):
+/// cloud_upload_attempt, scrape_outcome, worker_init/worker_spawn. Accepts
+/// only small fixed-shape JSON objects with an `event` string so the
+/// renderer cannot flood or malform the health log.
+#[tauri::command]
+fn record_runtime_health_event(
+    app: tauri::AppHandle,
+    payload: serde_json::Value,
+) -> Result<(), String> {
+    const MAX_RENDERER_HEALTH_EVENT_BYTES: usize = 4096;
+
+    let serde_json::Value::Object(fields) = &payload else {
+        return Err("payload must be a JSON object".to_string());
+    };
+    if !fields
+        .get("event")
+        .map(|value| value.is_string())
+        .unwrap_or(false)
+    {
+        return Err("payload.event must be a string".to_string());
+    }
+    let serialized_len = serde_json::to_string(&payload)
+        .map(|line| line.len())
+        .unwrap_or(usize::MAX);
+    if serialized_len > MAX_RENDERER_HEALTH_EVENT_BYTES {
+        return Err(format!(
+            "payload too large ({} > {} bytes)",
+            serialized_len, MAX_RENDERER_HEALTH_EVENT_BYTES
+        ));
+    }
+
+    append_runtime_health(&app, payload);
+    Ok(())
+}
+
 #[tauri::command]
 async fn get_recent_runtime_health(
     app: tauri::AppHandle,
@@ -6891,16 +6926,82 @@ async fn get_ai_hardware_profile(
     })
 }
 
+/// Relay broadcast volume counters (stability program P0-03, F07/F10).
+/// Aggregated over ~60 s windows so the counter itself cannot bloat
+/// runtime-health.jsonl at full-doc-per-mutation broadcast rates.
+struct RelayBroadcastAggregate {
+    window_started_at: Instant,
+    count: u64,
+    total_bytes: u64,
+}
+
+static RELAY_BROADCAST_AGGREGATE: StdMutex<Option<RelayBroadcastAggregate>> = StdMutex::new(None);
+const RELAY_BROADCAST_AGGREGATE_WINDOW: Duration = Duration::from_secs(60);
+
+/// Fold one broadcast into the current window. Returns the finished window
+/// to flush when this broadcast starts a new one. The trailing window is
+/// flushed by the first broadcast after it closes; a final partial window
+/// with no successor is dropped (acceptable for a rate counter).
+fn relay_broadcast_aggregate_update(
+    slot: &mut Option<RelayBroadcastAggregate>,
+    now: Instant,
+    doc_bytes: u64,
+) -> Option<RelayBroadcastAggregate> {
+    match slot {
+        Some(aggregate)
+            if now.duration_since(aggregate.window_started_at)
+                < RELAY_BROADCAST_AGGREGATE_WINDOW =>
+        {
+            aggregate.count += 1;
+            aggregate.total_bytes = aggregate.total_bytes.saturating_add(doc_bytes);
+            None
+        }
+        _ => {
+            let finished = slot.take();
+            *slot = Some(RelayBroadcastAggregate {
+                window_started_at: now,
+                count: 1,
+                total_bytes: doc_bytes,
+            });
+            finished
+        }
+    }
+}
+
+fn note_relay_broadcast(app: &tauri::AppHandle, doc_bytes: u64, client_count: u64) {
+    let now = Instant::now();
+    let finished = {
+        let mut slot = RELAY_BROADCAST_AGGREGATE.lock().unwrap();
+        relay_broadcast_aggregate_update(&mut slot, now, doc_bytes)
+    };
+    if let Some(aggregate) = finished {
+        append_runtime_health(
+            app,
+            serde_json::json!({
+                "event": "relay_broadcast_aggregate",
+                "count": aggregate.count,
+                "totalBytes": aggregate.total_bytes,
+                "clientCount": client_count,
+                "windowMs": now.duration_since(aggregate.window_started_at).as_millis(),
+            }),
+        );
+    }
+}
+
 /// Push a document update to all connected clients.
-#[cfg_attr(feature = "perf", tracing::instrument(skip(state, doc_bytes), fields(bytes = doc_bytes.len())))]
+#[cfg_attr(feature = "perf", tracing::instrument(skip(app, state, doc_bytes), fields(bytes = doc_bytes.len())))]
 #[tauri::command]
 async fn broadcast_doc(
+    app: tauri::AppHandle,
     state: tauri::State<'_, RelayState>,
     doc_bytes: Vec<u8>,
 ) -> Result<(), String> {
+    let byte_len = doc_bytes.len() as u64;
     let doc_bytes = Arc::new(doc_bytes);
     *state.current_doc.write().await = Some(doc_bytes.clone());
     let _ = state.broadcast_tx.send(doc_bytes);
+    let client_count = *state.client_count.read().await as u64;
+    note_relay_broadcast(&app, byte_len, client_count);
     Ok(())
 }
 
@@ -12344,6 +12445,7 @@ pub fn run() {
             trim_webkit_network_cache_now,
             get_recent_runtime_health,
             get_runtime_health_history,
+            record_runtime_health_event,
             get_ai_hardware_profile,
             get_desktop_session_state,
             get_social_provider_cookie_state,
@@ -12591,6 +12693,38 @@ mod tests {
         assert!(take_window_age_seconds(label).is_some());
         // The destroy consumed the entry.
         assert_eq!(take_window_age_seconds(label), None);
+    }
+
+    #[test]
+    fn relay_broadcast_aggregate_flushes_on_window_rollover() {
+        let mut slot: Option<RelayBroadcastAggregate> = None;
+        let start = Instant::now();
+
+        assert!(relay_broadcast_aggregate_update(&mut slot, start, 100).is_none());
+        assert!(relay_broadcast_aggregate_update(
+            &mut slot,
+            start + Duration::from_secs(10),
+            200
+        )
+        .is_none());
+        {
+            let aggregate = slot.as_ref().unwrap();
+            assert_eq!(aggregate.count, 2);
+            assert_eq!(aggregate.total_bytes, 300);
+        }
+
+        let finished = relay_broadcast_aggregate_update(
+            &mut slot,
+            start + RELAY_BROADCAST_AGGREGATE_WINDOW + Duration::from_secs(1),
+            50,
+        )
+        .expect("window rollover flushes the finished aggregate");
+        assert_eq!(finished.count, 2);
+        assert_eq!(finished.total_bytes, 300);
+
+        let successor = slot.as_ref().unwrap();
+        assert_eq!(successor.count, 1);
+        assert_eq!(successor.total_bytes, 50);
     }
 
     #[test]

--- a/packages/desktop/src/App.tsx
+++ b/packages/desktop/src/App.tsx
@@ -1099,7 +1099,7 @@ function App() {
           if (isPaused) {
             await clearProviderPause("x");
           }
-          await withProviderSyncing("x", () => captureXTimeline(state.xAuth.cookies!));
+          await withProviderSyncing("x", () => captureXTimeline(state.xAuth.cookies!, undefined, "manual"));
           return;
         }
 
@@ -1107,7 +1107,7 @@ function App() {
           if (isPaused) {
             await clearProviderPause("facebook");
           }
-          await withProviderSyncing("facebook", () => captureFbFeed());
+          await withProviderSyncing("facebook", () => captureFbFeed("manual"));
           return;
         }
 
@@ -1115,7 +1115,7 @@ function App() {
           if (isPaused) {
             await clearProviderPause("instagram");
           }
-          await withProviderSyncing("instagram", () => captureIgFeed());
+          await withProviderSyncing("instagram", () => captureIgFeed("manual"));
           return;
         }
 
@@ -1123,7 +1123,7 @@ function App() {
           if (isPaused) {
             await clearProviderPause("linkedin");
           }
-          await withProviderSyncing("linkedin", () => captureLiFeed());
+          await withProviderSyncing("linkedin", () => captureLiFeed("manual"));
         }
       },
       getSourceStatus: (sourceId) => {

--- a/packages/desktop/src/components/FacebookFeedEmptyState.tsx
+++ b/packages/desktop/src/components/FacebookFeedEmptyState.tsx
@@ -38,7 +38,7 @@ export function FacebookFeedEmptyState() {
     setActionError(null);
     setSyncing(true);
     try {
-      await captureFbFeed();
+      await captureFbFeed("manual");
     } catch (err) {
       console.error("Facebook sync failed:", err);
       setActionError(err instanceof Error ? err.message : "Facebook sync failed");

--- a/packages/desktop/src/components/FacebookSettingsSection.tsx
+++ b/packages/desktop/src/components/FacebookSettingsSection.tsx
@@ -274,10 +274,10 @@ export function FacebookSettingsSection({
   );
   const activeGroupCount = groups.filter((group) => !excludedGroupIds[group.id]).length;
 
-  const runSync = useCallback(async () => {
+  const runSync = useCallback(async (trigger: "manual" | "post_login" = "manual") => {
     setLastDiag(null);
     try {
-      const result = await withProviderSyncing("facebook", () => captureFbFeed());
+      const result = await withProviderSyncing("facebook", () => captureFbFeed(trigger));
       setLastDiag(result.diag);
     } catch (err) {
       console.error("Facebook feed capture failed:", err);

--- a/packages/desktop/src/components/InstagramFeedEmptyState.tsx
+++ b/packages/desktop/src/components/InstagramFeedEmptyState.tsx
@@ -40,7 +40,7 @@ export function InstagramFeedEmptyState() {
     setActionError(null);
     setSyncing(true);
     try {
-      await captureIgFeed();
+      await captureIgFeed("manual");
     } catch (err) {
       console.error("Instagram sync failed:", err);
       setActionError(err instanceof Error ? err.message : "Instagram sync failed");

--- a/packages/desktop/src/components/InstagramSettingsSection.tsx
+++ b/packages/desktop/src/components/InstagramSettingsSection.tsx
@@ -129,10 +129,10 @@ export function InstagramSettingsSection({
   const copy = socialProviderCopy("instagram");
   const { confirm, dialog } = useProviderRiskGate("instagram");
 
-  const runSync = useCallback(async () => {
+  const runSync = useCallback(async (trigger: "manual" | "post_login" = "manual") => {
     setLastDiag(null);
     try {
-      const result = await withProviderSyncing("instagram", () => captureIgFeed());
+      const result = await withProviderSyncing("instagram", () => captureIgFeed(trigger));
       setLastDiag(result.diag);
     } catch (err) {
       console.error("Instagram feed capture failed:", err);

--- a/packages/desktop/src/components/LinkedInSettingsSection.tsx
+++ b/packages/desktop/src/components/LinkedInSettingsSection.tsx
@@ -121,10 +121,10 @@ export function LinkedInSettingsSection({
   const copy = socialProviderCopy("linkedin");
   const { confirm, dialog } = useProviderRiskGate("linkedin");
 
-  const runSync = useCallback(async () => {
+  const runSync = useCallback(async (trigger: "manual" | "post_login" = "manual") => {
     setLastDiag(null);
     try {
-      const result = await withProviderSyncing("linkedin", () => captureLiFeed());
+      const result = await withProviderSyncing("linkedin", () => captureLiFeed(trigger));
       setLastDiag(result.diag);
     } catch (err) {
       console.error("LinkedIn feed capture failed:", err);

--- a/packages/desktop/src/components/XFeedEmptyState.tsx
+++ b/packages/desktop/src/components/XFeedEmptyState.tsx
@@ -43,7 +43,7 @@ export function XFeedEmptyState() {
     setActionError(null);
     setSyncing(true);
     try {
-      await captureXTimeline(cookies);
+      await captureXTimeline(cookies, undefined, "manual");
     } catch (err) {
       console.error("X sync failed:", err);
       setActionError(err instanceof Error ? err.message : "X sync failed");

--- a/packages/desktop/src/components/XSettingsSection.tsx
+++ b/packages/desktop/src/components/XSettingsSection.tsx
@@ -206,7 +206,7 @@ export function XSettingsSection({
   const runSync = async (cookies: Parameters<typeof captureXTimeline>[0]) => {
     setLastDiag(null);
     try {
-      const result = await withProviderSyncing("x", () => captureXTimeline(cookies));
+      const result = await withProviderSyncing("x", () => captureXTimeline(cookies, undefined, "manual"));
       setLastDiag(result.diag);
     } catch (err) {
       console.error("X timeline capture failed:", err);

--- a/packages/desktop/src/hooks/usePostLoginAutoSync.ts
+++ b/packages/desktop/src/hooks/usePostLoginAutoSync.ts
@@ -14,7 +14,7 @@ interface UsePostLoginAutoSyncOptions {
   providerLabel: string;
   isAuthenticated: () => boolean;
   onAuthResult: (loggedIn: boolean) => void;
-  runSync: () => Promise<void>;
+  runSync: (trigger?: "post_login") => Promise<void>;
 }
 
 interface PostLoginAutoSyncState {
@@ -111,7 +111,7 @@ export function usePostLoginAutoSync({
       statusRef.current = "starting";
       setPending(true);
       setStatus("starting");
-      void runSyncRef.current().then(() => {
+      void runSyncRef.current("post_login").then(() => {
         if (!pendingRef.current || statusRef.current === "healthy") return;
         statusRef.current = "failed";
         setStatus("failed");

--- a/packages/desktop/src/lib/automerge-types.ts
+++ b/packages/desktop/src/lib/automerge-types.ts
@@ -123,6 +123,7 @@ export type WorkerRequest =
   | { reqId: number; type: "BACKFILL_CONTENT_SIGNALS"; batchSize?: number }
   | { reqId: number; type: "GET_ALL_ITEM_IDS" }
   | { reqId: number; type: "GET_DOC_BINARY" }
+  | { reqId: number; type: "GET_HEADS" }
   | { reqId: number; type: "GET_ITEM_PRESERVED_TEXT"; globalId: string }
   // Relay management (fire-and-forget, reqId ignored)
   | { reqId: number; type: "UPDATE_RELAY_CLIENT_COUNT"; count: number };
@@ -198,6 +199,13 @@ export type WorkerResponse =
   | { reqId: number; type: "ALL_ITEM_IDS"; ids: string[] }
   /** On-demand full document binary for relay, snapshots, and cloud uploads. */
   | { reqId: number; type: "DOC_BINARY"; binary: Uint8Array }
+  /**
+   * Current Automerge heads (or heads at last save when the doc is idle-
+   * unloaded). Never forces a document load; null before the first INIT.
+   */
+  | { reqId: number; type: "DOC_HEADS"; heads: string[] | null }
+  /** Sent once per INIT with its cost, for the worker-INIT runtime counter. */
+  | { type: "INIT_STATS"; durationMs: number; docBytes: number }
   /** On-demand preserved article text for the active reader item. */
   | { reqId: number; type: "ITEM_PRESERVED_TEXT"; globalId: string; text: string | null }
   /** One-batch content signal backfill summary. */

--- a/packages/desktop/src/lib/automerge.ts
+++ b/packages/desktop/src/lib/automerge.ts
@@ -34,6 +34,7 @@ import type {
 import type { DocChangeEvent, DocState, DocStats, WorkerRequest, WorkerResponse } from "./automerge-types";
 import { applyItemPatchesToState, createItemIndex, type ItemIndex } from "./automerge-state-patches";
 import { log } from "./logger.js";
+import { recordRuntimeHealthEvent, recordWorkerInit } from "./runtime-health-events";
 export type { DocChangeEvent, DocState } from "./automerge-types";
 
 /**
@@ -71,6 +72,7 @@ function startWorker(): void {
   worker = nextWorker;
   workerDocumentInitialized = false;
   log.info("[automerge-worker] started worker");
+  recordRuntimeHealthEvent({ event: "worker_spawn" });
   workerReady = new Promise<void>((resolve, reject) => {
     const timeout = setTimeout(() => {
       reject(new Error("Automerge worker failed to start within 15 seconds"));
@@ -109,6 +111,7 @@ function hasPendingWorkerRequests(): boolean {
     pending.size > 0 ||
     pendingAllItemIds.size > 0 ||
     pendingDocBinary.size > 0 ||
+    pendingDocHeads.size > 0 ||
     pendingPreservedText.size > 0 ||
     pendingContentSignalBackfill.size > 0 ||
     pendingSampleDataClear.size > 0
@@ -173,6 +176,14 @@ const pendingDocBinary = new Map<
   number,
   {
     resolve: (binary: Uint8Array) => void;
+    reject: (err: Error) => void;
+    timer: ReturnType<typeof setTimeout>;
+  }
+>();
+const pendingDocHeads = new Map<
+  number,
+  {
+    resolve: (heads: string[] | null) => void;
     reject: (err: Error) => void;
     timer: ReturnType<typeof setTimeout>;
   }
@@ -391,6 +402,11 @@ function handleWorkerMessage(event: MessageEvent<WorkerResponse>) {
     return;
   }
 
+  if (msg.type === "INIT_STATS") {
+    recordWorkerInit({ durationMs: msg.durationMs, docBytes: msg.docBytes });
+    return;
+  }
+
   if (msg.type === "DEBUG_SNAPSHOT") {
     lastDocStats = { binaryBytes: msg.binarySize, itemCount: msg.itemCount };
     setDocSnapshot({
@@ -418,6 +434,15 @@ function handleWorkerMessage(event: MessageEvent<WorkerResponse>) {
     clearTimeout(pendingBinary.timer);
     pendingDocBinary.delete(msg.reqId);
     pendingBinary.resolve(msg.binary);
+    return;
+  }
+
+  if (msg.type === "DOC_HEADS") {
+    const pendingHeads = pendingDocHeads.get(msg.reqId);
+    if (!pendingHeads) return;
+    clearTimeout(pendingHeads.timer);
+    pendingDocHeads.delete(msg.reqId);
+    pendingHeads.resolve(msg.heads);
     return;
   }
 
@@ -582,6 +607,31 @@ export async function getDocBinary(): Promise<Uint8Array> {
 
     pendingDocBinary.set(reqId, { resolve, reject, timer });
     activeWorker.postMessage({ reqId, type: "GET_DOC_BINARY" } satisfies WorkerRequest);
+  });
+}
+
+/**
+ * Current document heads for upload-loop accounting (stability P0-03).
+ * Never forces a document load or a worker re-INIT: an idle worker answers
+ * with the heads at last save, and a fresh worker answers null.
+ */
+export async function getDocHeads(): Promise<string[] | null> {
+  await ensureWorkerReady();
+  const activeWorker = getWorker();
+  return new Promise((resolve, reject) => {
+    const reqId = nextReqId++;
+    const timer = setTimeout(() => {
+      if (!pendingDocHeads.has(reqId)) return;
+      pendingDocHeads.delete(reqId);
+      reject(
+        new Error(
+          `[automerge-worker] request TIMEOUT op=GET_HEADS reqId=${reqId} timeout_ms=${WORKER_REQUEST_TIMEOUT_MS.toLocaleString()}`,
+        ),
+      );
+    }, WORKER_REQUEST_TIMEOUT_MS);
+
+    pendingDocHeads.set(reqId, { resolve, reject, timer });
+    activeWorker.postMessage({ reqId, type: "GET_HEADS" } satisfies WorkerRequest);
   });
 }
 

--- a/packages/desktop/src/lib/automerge.worker.ts
+++ b/packages/desktop/src/lib/automerge.worker.ts
@@ -219,6 +219,21 @@ function bumpSearchCorpusVersion(): void {
   searchCorpusVersion += 1;
 }
 
+/**
+ * Heads as of the last save/load, answered by GET_HEADS without forcing a
+ * full A.load when the document is idle-unloaded (an unloaded doc cannot
+ * have diverged from its last save). Null until the first INIT.
+ */
+let lastSavedHeads: string[] | null = null;
+
+function refreshLastSavedHeads(doc: FreedDoc | null): void {
+  try {
+    lastSavedHeads = doc ? A.getHeads(doc) : null;
+  } catch {
+    lastSavedHeads = null;
+  }
+}
+
 function cancelDocIdleUnload(): void {
   // Kept as a named lifecycle hook so request startup documents the intent.
 }
@@ -287,6 +302,7 @@ function compactLoadedFeedText(
   const bytesSaved = previousBinaryBytes - rebuiltBinary.byteLength;
   currentDoc = rebuiltDoc;
   currentBinary = rebuiltBinary;
+  refreshLastSavedHeads(rebuiltDoc);
   persistenceState = createPersistenceState(rebuiltBinary);
   emitWorkerTrace(
     `[automerge-worker] rebuilt compacted document` +
@@ -612,6 +628,7 @@ async function saveAndBroadcast(trace?: RequestTrace): Promise<void> {
   const binary = persisted.binary;
   persistenceState = persisted.persistence;
   currentBinary = binary;
+  refreshLastSavedHeads(doc);
   const afterSerializeAt = performance.now();
   await storage.save(binary);
   const afterPersistAt = performance.now();
@@ -693,6 +710,7 @@ async function persistAndBroadcastWithoutHydration(trace?: RequestTrace): Promis
   const binary = persisted.binary;
   persistenceState = persisted.persistence;
   currentBinary = binary;
+  refreshLastSavedHeads(doc);
   const afterSerializeAt = performance.now();
   await storage.save(binary);
   const afterPersistAt = performance.now();
@@ -985,7 +1003,8 @@ async function handleRequest(
     req.type !== "INIT" &&
     req.type !== "CLEAR_LOCAL" &&
     req.type !== "REPLACE_DOC" &&
-    req.type !== "GET_DOC_BINARY"
+    req.type !== "GET_DOC_BINARY" &&
+    req.type !== "GET_HEADS"
   ) {
     ensureCurrentDocLoaded(req.type);
   }
@@ -1028,6 +1047,7 @@ async function handleRequest(
           persistenceState = createPersistenceState(binary);
           await storage.save(binary);
         }
+        refreshLastSavedHeads(currentDoc);
         searchCorpusVersion = 1;
         const initializedDoc = currentDoc;
         if (!initializedDoc) throw new Error("Document not initialized");
@@ -1038,6 +1058,11 @@ async function handleRequest(
         } else {
           await hydrateAndBroadcastWithoutPersist(trace);
         }
+        send({
+          type: "INIT_STATS",
+          durationMs: Math.round(performance.now() - startedAt),
+          docBytes: currentBinary?.byteLength ?? 0,
+        });
         ack(req.reqId);
         break;
       }
@@ -1047,6 +1072,7 @@ async function handleRequest(
         await storage.clear();
         currentDoc = null;
         currentBinary = null;
+        refreshLastSavedHeads(null);
         persistenceState = createPersistenceState(null);
         linkPreviewUrlCounts = new Map();
         searchCorpusVersion = 0;
@@ -1056,6 +1082,7 @@ async function handleRequest(
       case "REPLACE_DOC":
         currentDoc = A.load<FreedDoc>(req.binary);
         currentBinary = req.binary;
+        refreshLastSavedHeads(currentDoc);
         persistenceState = createPersistenceState(req.binary);
         migrateLoadedIdentityGraph("Migrate legacy identity graph");
         compactLoadedFeedText("Compact oversized synced feed text", {
@@ -1071,9 +1098,18 @@ async function handleRequest(
         if (!currentBinary) {
           const doc = ensureCurrentDocLoaded(req.type);
           currentBinary = A.save(doc);
+          refreshLastSavedHeads(doc);
           persistenceState = createPersistenceState(currentBinary);
         }
         send({ reqId: req.reqId, type: "DOC_BINARY", binary: currentBinary });
+        break;
+
+      case "GET_HEADS":
+        send({
+          reqId: req.reqId,
+          type: "DOC_HEADS",
+          heads: currentDoc ? A.getHeads(currentDoc) : lastSavedHeads,
+        });
         break;
 
       case "MERGE_DOC": {

--- a/packages/desktop/src/lib/bug-report.test.ts
+++ b/packages/desktop/src/lib/bug-report.test.ts
@@ -9,6 +9,7 @@ const { mockInvoke } = vi.hoisted(() => ({
 
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: mockInvoke,
+  isTauri: () => true,
 }));
 
 vi.mock("@tauri-apps/plugin-shell", () => ({

--- a/packages/desktop/src/lib/capture.ts
+++ b/packages/desktop/src/lib/capture.ts
@@ -27,6 +27,7 @@ import {
   type RssRefreshPlanOptions,
 } from "./rss-refresh-plan";
 import { isRuntimeDeferredStage } from "./social-capture-runtime";
+import type { SocialScrapeTrigger } from "./runtime-health-events";
 
 export type SocialProviderRefreshStatus =
   | "success"
@@ -207,7 +208,7 @@ function scheduleSocialDeferredRetry(
   );
   const timer = setTimeout(() => {
     socialDeferredRetryTimers.delete(provider);
-    void refreshSocialProvider(provider);
+    void refreshSocialProvider(provider, "deferred_retry");
   }, retryMs);
   socialDeferredRetryTimers.set(provider, timer);
 }
@@ -225,6 +226,7 @@ function handleSocialResult(
 
 export async function refreshSocialProvider(
   provider: RetriableSocialProvider,
+  trigger: SocialScrapeTrigger = "unknown",
 ): Promise<SocialProviderRefreshResult> {
   if (!isTauri()) {
     clearSocialDeferredRetry(provider);
@@ -248,17 +250,17 @@ export async function refreshSocialProvider(
   const store = useAppStore.getState();
   try {
     if (provider === "facebook" && store.fbAuth.isAuthenticated) {
-      const result = await withProviderSyncing("facebook", () => captureFbFeed());
+      const result = await withProviderSyncing("facebook", () => captureFbFeed(trigger));
       handleSocialResult("facebook", result.diag.errorStage);
       return summarizeSocialRefreshResult("facebook", result.diag);
     }
     if (provider === "instagram" && store.igAuth.isAuthenticated) {
-      const result = await withProviderSyncing("instagram", () => captureIgFeed());
+      const result = await withProviderSyncing("instagram", () => captureIgFeed(trigger));
       handleSocialResult("instagram", result.diag.errorStage);
       return summarizeSocialRefreshResult("instagram", result.diag);
     }
     if (provider === "linkedin" && store.liAuth.isAuthenticated) {
-      const result = await withProviderSyncing("linkedin", () => captureLiFeed());
+      const result = await withProviderSyncing("linkedin", () => captureLiFeed(trigger));
       handleSocialResult("linkedin", result.diag.errorStage);
       return summarizeSocialRefreshResult("linkedin", result.diag);
     }
@@ -558,7 +560,7 @@ export async function refreshAllFeeds(
       !isProviderPaused("x")
     ) {
       try {
-        await withProviderSyncing("x", () => captureXTimeline(xCookies));
+        await withProviderSyncing("x", () => captureXTimeline(xCookies, undefined, "scheduled"));
       } catch (xError) {
         const msg =
           xError instanceof Error ? xError.message : "X timeline sync failed";
@@ -570,9 +572,9 @@ export async function refreshAllFeeds(
       }
     }
 
-    await refreshSocialProvider("facebook");
-    await refreshSocialProvider("instagram");
-    await refreshSocialProvider("linkedin");
+    await refreshSocialProvider("facebook", "scheduled");
+    await refreshSocialProvider("instagram", "scheduled");
+    await refreshSocialProvider("linkedin", "scheduled");
   } finally {
     store.setSyncing(false);
   }

--- a/packages/desktop/src/lib/dev-sync-triggers.test.ts
+++ b/packages/desktop/src/lib/dev-sync-triggers.test.ts
@@ -103,7 +103,7 @@ describe("dev sync triggers", () => {
     });
     stop();
 
-    expect(refreshSocialProvider).toHaveBeenCalledWith("facebook");
+    expect(refreshSocialProvider).toHaveBeenCalledWith("facebook", "dev_trigger");
     expect(writeNativeJsonFile).toHaveBeenCalledWith(
       "dev-sync-trigger-result.json",
       expect.objectContaining({
@@ -136,7 +136,7 @@ describe("dev sync triggers", () => {
     await flushImmediatePoll();
     stop();
 
-    expect(refreshSocialProvider).toHaveBeenCalledWith("facebook");
+    expect(refreshSocialProvider).toHaveBeenCalledWith("facebook", "dev_trigger");
     expect(writeNativeJsonFile).toHaveBeenCalledWith(
       "dev-sync-trigger-result.json",
       expect.objectContaining({
@@ -240,7 +240,7 @@ describe("dev sync triggers", () => {
     stop();
 
     expect(initializeStore).toHaveBeenCalled();
-    expect(refreshSocialProvider).toHaveBeenCalledWith("facebook");
+    expect(refreshSocialProvider).toHaveBeenCalledWith("facebook", "dev_trigger");
     expect(writeNativeJsonFile).toHaveBeenLastCalledWith(
       "dev-sync-trigger-result.json",
       expect.objectContaining({
@@ -378,6 +378,6 @@ describe("dev sync triggers", () => {
     stop();
 
     expect(loadDesktopReleaseChannelState).toHaveBeenCalled();
-    expect(refreshSocialProvider).toHaveBeenCalledWith("facebook");
+    expect(refreshSocialProvider).toHaveBeenCalledWith("facebook", "dev_trigger");
   });
 });

--- a/packages/desktop/src/lib/dev-sync-triggers.ts
+++ b/packages/desktop/src/lib/dev-sync-triggers.ts
@@ -152,7 +152,7 @@ async function runDevSyncTrigger(
     log.info(
       `[dev-sync-trigger] starting ${provider} sync request ${requestId}`,
     );
-    const result = await refreshSocialProvider(provider);
+    const result = await refreshSocialProvider(provider, "dev_trigger");
     const status = mapRefreshResultToTriggerStatus(result);
     await writeResult(
       requestId,

--- a/packages/desktop/src/lib/fb-capture.ts
+++ b/packages/desktop/src/lib/fb-capture.ts
@@ -27,6 +27,7 @@ import { getFbScraperWindowMode } from "./scraper-prefs";
 import { storeFbAuthState } from "./fb-auth";
 import { attachScraperMediaDiagListener } from "./scraper-media-diag";
 import { getProviderPause, recordProviderHealthEvent } from "./provider-health";
+import { recordScrapeOutcome, type SocialScrapeTrigger } from "./runtime-health-events";
 import {
   formatBytesForMemoryLog,
   formatScrapeMemoryPressureDetails,
@@ -771,7 +772,35 @@ export async function verifyFacebookGroupLeave(
  * Capture Facebook feed and add items to the store.
  * Respects rate limiting to avoid triggering Facebook's anti-bot measures.
  */
-export async function captureFbFeed(): Promise<FbSyncResult> {
+export async function captureFbFeed(
+  trigger: SocialScrapeTrigger = "unknown",
+): Promise<FbSyncResult> {
+  const scrapeStartedAt = Date.now();
+  try {
+    const result = await captureFbFeedInternal();
+    recordScrapeOutcome({
+      provider: "facebook",
+      trigger,
+      itemsExtracted: result.diag.postsExtracted,
+      itemsPersisted: result.diag.itemsAdded,
+      stage: result.diag.errorStage ?? "ok",
+      durationMs: Date.now() - scrapeStartedAt,
+    });
+    return result;
+  } catch (error) {
+    recordScrapeOutcome({
+      provider: "facebook",
+      trigger,
+      itemsExtracted: 0,
+      itemsPersisted: 0,
+      stage: "exception",
+      durationMs: Date.now() - scrapeStartedAt,
+    });
+    throw error;
+  }
+}
+
+async function captureFbFeedInternal(): Promise<FbSyncResult> {
   const startedAt = Date.now();
   const providerPause = getProviderPause("facebook");
   if (providerPause) {

--- a/packages/desktop/src/lib/instagram-capture.ts
+++ b/packages/desktop/src/lib/instagram-capture.ts
@@ -25,6 +25,7 @@ import { getIgScraperWindowMode } from "./scraper-prefs";
 import { storeIgAuthState } from "./instagram-auth";
 import { attachScraperMediaDiagListener } from "./scraper-media-diag";
 import { getProviderPause, recordProviderHealthEvent } from "./provider-health";
+import { recordScrapeOutcome, type SocialScrapeTrigger } from "./runtime-health-events";
 import {
   formatScrapeMemoryPressureDetails,
   prepareSocialScrapeMemory,
@@ -353,7 +354,35 @@ export async function fetchIgFeed(): Promise<IgSyncResult> {
  * Capture Instagram feed and add items to the store.
  * Respects rate limiting to avoid triggering Instagram's anti-bot measures.
  */
-export async function captureIgFeed(): Promise<IgSyncResult> {
+export async function captureIgFeed(
+  trigger: SocialScrapeTrigger = "unknown",
+): Promise<IgSyncResult> {
+  const scrapeStartedAt = Date.now();
+  try {
+    const result = await captureIgFeedInternal();
+    recordScrapeOutcome({
+      provider: "instagram",
+      trigger,
+      itemsExtracted: result.diag.postsExtracted,
+      itemsPersisted: result.diag.itemsAdded,
+      stage: result.diag.errorStage ?? "ok",
+      durationMs: Date.now() - scrapeStartedAt,
+    });
+    return result;
+  } catch (error) {
+    recordScrapeOutcome({
+      provider: "instagram",
+      trigger,
+      itemsExtracted: 0,
+      itemsPersisted: 0,
+      stage: "exception",
+      durationMs: Date.now() - scrapeStartedAt,
+    });
+    throw error;
+  }
+}
+
+async function captureIgFeedInternal(): Promise<IgSyncResult> {
   const startedAt = Date.now();
   const providerPause = getProviderPause("instagram");
   if (providerPause) {

--- a/packages/desktop/src/lib/li-capture.ts
+++ b/packages/desktop/src/lib/li-capture.ts
@@ -21,6 +21,7 @@ import { getLiScraperWindowMode } from "./scraper-prefs";
 import { attachScraperMediaDiagListener } from "./scraper-media-diag";
 import { storeLiAuthState } from "./li-auth";
 import { getProviderPause, recordProviderHealthEvent } from "./provider-health";
+import { recordScrapeOutcome, type SocialScrapeTrigger } from "./runtime-health-events";
 import {
   formatScrapeMemoryPressureDetails,
   prepareSocialScrapeMemory,
@@ -315,12 +316,40 @@ export async function fetchLiFeed(): Promise<LiSyncResult> {
  * Capture LinkedIn feed and add items to the store.
  * Respects rate limiting to avoid triggering LinkedIn's anti-bot measures.
  */
-export async function captureLiFeed(): Promise<LiSyncResult> {
+export async function captureLiFeed(
+  trigger: SocialScrapeTrigger = "unknown",
+): Promise<LiSyncResult> {
   if (!isTauri()) {
     addDebugEvent("change", "[LI] browser preview skips native LinkedIn capture");
     return createEmptyLiSyncResult();
   }
 
+  const scrapeStartedAt = Date.now();
+  try {
+    const result = await captureLiFeedInternal();
+    recordScrapeOutcome({
+      provider: "linkedin",
+      trigger,
+      itemsExtracted: result.diag.postsExtracted,
+      itemsPersisted: result.diag.itemsAdded,
+      stage: result.diag.errorStage ?? "ok",
+      durationMs: Date.now() - scrapeStartedAt,
+    });
+    return result;
+  } catch (error) {
+    recordScrapeOutcome({
+      provider: "linkedin",
+      trigger,
+      itemsExtracted: 0,
+      itemsPersisted: 0,
+      stage: "exception",
+      durationMs: Date.now() - scrapeStartedAt,
+    });
+    throw error;
+  }
+}
+
+async function captureLiFeedInternal(): Promise<LiSyncResult> {
   const startedAt = Date.now();
   const providerPause = getProviderPause("linkedin");
   if (providerPause) {

--- a/packages/desktop/src/lib/runtime-health-events.ts
+++ b/packages/desktop/src/lib/runtime-health-events.ts
@@ -1,0 +1,75 @@
+/**
+ * Renderer-side runtime-health counters (stability program P0-03).
+ *
+ * Small fixed-shape events appended to runtime-health.jsonl through the
+ * record_runtime_health_event Tauri command so soak tooling can count the
+ * verified idle-churn loops (cloud upload echo, relay broadcast volume,
+ * worker INIT churn, scrape outcomes). Logging only: every helper swallows
+ * failures so counters can never affect sync or capture behavior.
+ */
+
+import { invoke, isTauri } from "@tauri-apps/api/core";
+
+export type CloudUploadCause = "subscriber" | "manual" | "poll";
+
+export type SocialScrapeTrigger =
+  | "manual"
+  | "scheduled"
+  | "deferred_retry"
+  | "dev_trigger"
+  | "post_login"
+  | "unknown";
+
+export type ScrapeOutcomeProvider = "facebook" | "instagram" | "linkedin" | "x";
+
+export function recordRuntimeHealthEvent(
+  payload: { event: string } & Record<string, unknown>,
+): void {
+  try {
+    if (!isTauri()) return;
+    void invoke("record_runtime_health_event", { payload }).catch(() => {});
+  } catch {
+    // Counters must never propagate into sync or capture paths.
+  }
+}
+
+/**
+ * One line per cloud upload attempt. `headsUnchanged` is the cloud-loop
+ * signature (F01/F06): hundreds of uploads per idle hour with unchanged
+ * heads means the upload→merge→STATE_UPDATE→upload echo is live.
+ */
+export function recordCloudUploadAttempt(input: {
+  provider: string;
+  cause: CloudUploadCause;
+  headsBefore: string[] | null;
+  headsUnchanged: boolean;
+}): void {
+  recordRuntimeHealthEvent({ event: "cloud_upload_attempt", ...input });
+}
+
+/**
+ * One line per scrape settlement across all four capture paths.
+ * `itemsExtracted >= 5 && itemsPersisted == 0` is the scrape_zero_persist
+ * signature (F03: results discarded by mid-invoke renderer recovery).
+ */
+export function recordScrapeOutcome(input: {
+  provider: ScrapeOutcomeProvider;
+  trigger: SocialScrapeTrigger;
+  itemsExtracted: number;
+  itemsPersisted: number;
+  stage: string;
+  durationMs: number;
+}): void {
+  recordRuntimeHealthEvent({ event: "scrape_outcome", ...input });
+}
+
+/**
+ * One line per Automerge worker INIT (full A.load of the document).
+ * INITs/hour during a content backlog is the F20 worker-churn counter.
+ */
+export function recordWorkerInit(input: {
+  durationMs: number;
+  docBytes: number;
+}): void {
+  recordRuntimeHealthEvent({ event: "worker_init", ...input });
+}

--- a/packages/desktop/src/lib/sync.ts
+++ b/packages/desktop/src/lib/sync.ts
@@ -23,7 +23,8 @@ import {
   type CloudProvider,
   type GoogleDriveFetch,
 } from "@freed/sync/cloud";
-import { getDocBinary, mergeDoc, replaceLocalDoc, subscribe, setRelayClientCount } from "./automerge";
+import { getDocBinary, getDocHeads, mergeDoc, replaceLocalDoc, subscribe, setRelayClientCount } from "./automerge";
+import { recordCloudUploadAttempt, type CloudUploadCause } from "./runtime-health-events";
 import {
   addDebugEvent,
   recordCloudProviderEvent,
@@ -1409,7 +1410,7 @@ export async function resolveCloudSyncConflict(
         timeoutMs: 180_000,
         waitForActiveJobMs: CONFLICT_RECOVERY_ACTIVE_JOB_WAIT_MS,
         run: async () => {
-          await performCloudUpload(provider, token, { authoritativeReplace: true });
+          await performCloudUpload(provider, token, { authoritativeReplace: true, cause: "manual" });
         },
       });
       await startCloudSync(provider, token);
@@ -1466,16 +1467,43 @@ export async function resolveCloudSyncConflict(
   }
 }
 
+/**
+ * Heads at the previous upload attempt, per provider. An attempt whose heads
+ * match is the cloud-loop signature counted by cloud_upload_attempt (F01/F06).
+ */
+const lastUploadHeadsByProvider = new Map<CloudProvider, string>();
+
+async function recordCloudUploadAttemptCounters(
+  provider: CloudProvider,
+  cause: CloudUploadCause,
+): Promise<void> {
+  try {
+    const heads = await getDocHeads();
+    const headsKey = heads && heads.length > 0 ? heads.join(",") : null;
+    const previousKey = lastUploadHeadsByProvider.get(provider) ?? null;
+    if (headsKey !== null) lastUploadHeadsByProvider.set(provider, headsKey);
+    recordCloudUploadAttempt({
+      provider,
+      cause,
+      headsBefore: heads,
+      headsUnchanged: headsKey !== null && headsKey === previousKey,
+    });
+  } catch {
+    // Counters never block or fail an upload.
+  }
+}
+
 async function performCloudUpload(
   provider: CloudProvider,
   token?: string,
-  options: { authoritativeReplace?: boolean } = {},
+  options: { authoritativeReplace?: boolean; cause?: CloudUploadCause } = {},
 ): Promise<void> {
   const startedAt = Date.now();
   let byteLength = 0;
   try {
     const binary = await getDocBinary();
     byteLength = binary.byteLength;
+    await recordCloudUploadAttemptCounters(provider, options.cause ?? "subscriber");
     const uploadToken = token ?? await getValidCloudToken(provider);
     if (!uploadToken) throw new Error("Cloud token missing. Reconnect the provider.");
     markCloudAttempt(provider, "upload", "Uploading local document to cloud storage.");
@@ -1661,7 +1689,7 @@ export async function syncCloudProviderNow(provider: CloudProvider): Promise<voi
       timeoutMs: 180_000,
       waitForActiveJobMs: UPLOAD_ACTIVE_JOB_WAIT_MS,
       waitForActiveJobKinds: UPLOAD_WAIT_FOR_ACTIVE_JOB_KINDS,
-      run: () => performCloudUpload(provider),
+      run: () => performCloudUpload(provider, undefined, { cause: "manual" }),
     });
   } catch (error) {
     if (isBackgroundRuntimeDeferredError(error)) {

--- a/packages/desktop/src/lib/x-capture.ts
+++ b/packages/desktop/src/lib/x-capture.ts
@@ -31,6 +31,7 @@ import { useAppStore } from "./store";
 import { addDebugEvent } from "@freed/ui/lib/debug-store";
 import { getPlatformUA, extractChromeVersion, osPlatformHeader } from "./user-agent";
 import { getProviderPause, recordProviderHealthEvent } from "./provider-health";
+import { recordScrapeOutcome, type SocialScrapeTrigger } from "./runtime-health-events";
 import { clearStoredCookies } from "./x-auth";
 
 // =============================================================================
@@ -469,10 +470,41 @@ export async function unfavoriteTweet(
  *
  * @param cookies   Valid X session cookies.
  * @param requester Optional transport override for testing.
+ * @param trigger   What initiated this capture, for the scrape_outcome counter.
  */
 export async function captureXTimeline(
   cookies: XCookies,
   requester: XRequester = defaultRequester,
+  trigger: SocialScrapeTrigger = "unknown",
+): Promise<XSyncResult> {
+  const scrapeStartedAt = Date.now();
+  try {
+    const result = await captureXTimelineInternal(cookies, requester);
+    recordScrapeOutcome({
+      provider: "x",
+      trigger,
+      itemsExtracted: result.diag.tweetsExtracted,
+      itemsPersisted: result.diag.itemsAdded,
+      stage: result.diag.errorStage ?? "ok",
+      durationMs: Date.now() - scrapeStartedAt,
+    });
+    return result;
+  } catch (error) {
+    recordScrapeOutcome({
+      provider: "x",
+      trigger,
+      itemsExtracted: 0,
+      itemsPersisted: 0,
+      stage: "exception",
+      durationMs: Date.now() - scrapeStartedAt,
+    });
+    throw error;
+  }
+}
+
+async function captureXTimelineInternal(
+  cookies: XCookies,
+  requester: XRequester,
 ): Promise<XSyncResult> {
   const store = useAppStore.getState();
   const startedAt = Date.now();

--- a/packages/pwa/src/lib/automerge-types.ts
+++ b/packages/pwa/src/lib/automerge-types.ts
@@ -98,6 +98,7 @@ export type WorkerRequest =
   | { reqId: number; type: "BACKFILL_CONTENT_SIGNALS"; batchSize?: number }
   | { reqId: number; type: "MERGE_DOC"; binary: Uint8Array }
   | { reqId: number; type: "GET_DOC_BINARY" }
+  | { reqId: number; type: "GET_HEADS" }
   | { reqId: number; type: "CLEAR_LOCAL" };
 
 // ---------------------------------------------------------------------------
@@ -110,6 +111,10 @@ export type WorkerResponse =
   /** Broadcast on every doc mutation — main thread uses this to update UI */
   | { type: "STATE_UPDATE"; state: DocState; binary?: Uint8Array }
   | { reqId: number; type: "DOC_BINARY"; binary: Uint8Array }
+  /** Current Automerge heads for upload-loop accounting; null before INIT. */
+  | { reqId: number; type: "DOC_HEADS"; heads: string[] | null }
+  /** Sent once per INIT with its cost, for the worker-INIT debug counter. */
+  | { type: "INIT_STATS"; durationMs: number; docBytes: number }
   /** Debug panel event forwarding */
   | { type: "DEBUG_EVENT"; kind: string; detail?: string; bytes?: number }
   /** Doc size snapshot for the debug panel */

--- a/packages/pwa/src/lib/automerge.ts
+++ b/packages/pwa/src/lib/automerge.ts
@@ -78,6 +78,13 @@ const pendingDocBinary = new Map<
     reject: (err: Error) => void;
   }
 >();
+const pendingDocHeads = new Map<
+  number,
+  {
+    resolve: (heads: string[] | null) => void;
+    reject: (err: Error) => void;
+  }
+>();
 
 async function request(msg: WorkerRequest): Promise<void> {
   await workerReady;
@@ -126,6 +133,23 @@ worker.onmessage = (event: MessageEvent<WorkerResponse>) => {
     pendingDocBinary.delete(msg.reqId);
     lastBinary = msg.binary;
     pendingBinary.resolve(msg.binary);
+    return;
+  }
+
+  if (msg.type === "DOC_HEADS") {
+    const pendingHeads = pendingDocHeads.get(msg.reqId);
+    if (!pendingHeads) return;
+    pendingDocHeads.delete(msg.reqId);
+    pendingHeads.resolve(msg.heads);
+    return;
+  }
+
+  if (msg.type === "INIT_STATS") {
+    // Worker-INIT counter (stability P0-03) on the PWA debug channel, same
+    // field names as the desktop runtime-health worker_init event.
+    const detail = `worker_init durationMs=${msg.durationMs.toLocaleString()} docBytes=${msg.docBytes.toLocaleString()}`;
+    addDebugEvent("change", detail, msg.docBytes);
+    persistWorkerDebugEvent({ kind: "worker_init", detail, bytes: msg.docBytes });
     return;
   }
 
@@ -267,6 +291,19 @@ export async function getDocBinary(): Promise<Uint8Array> {
   return new Promise((resolve, reject) => {
     pendingDocBinary.set(reqId, { resolve, reject });
     worker.postMessage({ reqId, type: "GET_DOC_BINARY" } satisfies WorkerRequest);
+  });
+}
+
+/**
+ * Current document heads for upload-loop accounting (stability P0-03).
+ * Null before the first INIT completes.
+ */
+export async function getDocHeads(): Promise<string[] | null> {
+  await workerReady;
+  const reqId = nextReqId++;
+  return new Promise((resolve, reject) => {
+    pendingDocHeads.set(reqId, { resolve, reject });
+    worker.postMessage({ reqId, type: "GET_HEADS" } satisfies WorkerRequest);
   });
 }
 

--- a/packages/pwa/src/lib/automerge.worker.ts
+++ b/packages/pwa/src/lib/automerge.worker.ts
@@ -330,10 +330,13 @@ async function handleRequest(req: WorkerRequest): Promise<void> {
   try {
     switch (req.type) {
       case "INIT": {
+        const initStartedAt = performance.now();
+        let docBytes = 0;
         const saved = await storage.load();
         if (saved) {
           try {
             currentDoc = A.load<FreedDoc>(saved);
+            docBytes = saved.byteLength;
             migrateLoadedIdentityGraph("Migrate legacy identity graph");
           } catch {
             await storage.clear();
@@ -343,12 +346,18 @@ async function handleRequest(req: WorkerRequest): Promise<void> {
         if (!currentDoc) {
           currentDoc = createEmptyDoc();
           const binary = A.save(currentDoc);
+          docBytes = binary.byteLength;
           await storage.save(binary);
         }
         searchCorpusVersion = 1;
         const deviceId = (currentDoc.meta?.deviceId as string | undefined) ?? "unknown";
         send({ type: "DEBUG_EVENT", kind: "init", detail: `device ...${deviceId.slice(-8)}` });
         await saveAndBroadcast();
+        send({
+          type: "INIT_STATS",
+          durationMs: Math.round(performance.now() - initStartedAt),
+          docBytes,
+        });
         ack(req.reqId);
         break;
       }
@@ -469,6 +478,15 @@ async function handleRequest(req: WorkerRequest): Promise<void> {
       case "GET_DOC_BINARY": {
         if (!currentDoc) throw new Error("Document not initialized");
         send({ reqId: req.reqId, type: "DOC_BINARY", binary: A.save(currentDoc) });
+        break;
+      }
+
+      case "GET_HEADS": {
+        send({
+          reqId: req.reqId,
+          type: "DOC_HEADS",
+          heads: currentDoc ? A.getHeads(currentDoc) : null,
+        });
         break;
       }
 

--- a/packages/pwa/src/lib/sync.ts
+++ b/packages/pwa/src/lib/sync.ts
@@ -12,7 +12,7 @@
  * protected by optimistic locking — see @freed/sync/cloud for details.
  */
 
-import { getDocBinary, initDoc, mergeDoc, subscribe } from "./automerge";
+import { getDocBinary, getDocHeads, initDoc, mergeDoc, subscribe } from "./automerge";
 import {
   addDebugEvent,
   recordCloudProviderEvent,
@@ -681,9 +681,42 @@ export function stopCloudSync(): void {
   }
 }
 
-async function performCloudUpload(provider: CloudProvider, token?: string): Promise<void> {
+type CloudUploadCause = "subscriber" | "manual" | "poll";
+
+/**
+ * Heads at the previous upload attempt. An attempt whose heads match is the
+ * cloud-loop signature (stability P0-03, F01/F06). Logged to the PWA debug
+ * channel with the same field names as the desktop runtime-health event.
+ */
+let lastUploadHeadsKey: string | null = null;
+
+async function recordCloudUploadAttempt(
+  provider: CloudProvider,
+  cause: CloudUploadCause,
+): Promise<void> {
+  try {
+    const heads = await getDocHeads();
+    const headsKey = heads && heads.length > 0 ? heads.join(",") : null;
+    const previousKey = lastUploadHeadsKey;
+    if (headsKey !== null) lastUploadHeadsKey = headsKey;
+    const headsUnchanged = headsKey !== null && headsKey === previousKey;
+    addDebugEvent(
+      "change",
+      `cloud_upload_attempt ${JSON.stringify({ provider, cause, headsBefore: heads, headsUnchanged })}`,
+    );
+  } catch {
+    // Counters never block or fail an upload.
+  }
+}
+
+async function performCloudUpload(
+  provider: CloudProvider,
+  token?: string,
+  cause: CloudUploadCause = "subscriber",
+): Promise<void> {
   await ensureDocumentReady();
   const binary = await getDocBinary();
+  await recordCloudUploadAttempt(provider, cause);
   try {
     const uploadToken = token ?? await getValidCloudToken(provider);
     if (!uploadToken) throw new Error("Cloud token missing. Reconnect the provider.");
@@ -830,7 +863,7 @@ export async function syncCloudProviderNow(provider: CloudProvider): Promise<voi
       const currentToken = provider === "gdrive" ? await getValidCloudToken(provider) : token;
       return currentToken ?? token;
     });
-    await performCloudUpload(provider);
+    await performCloudUpload(provider, undefined, "manual");
   } catch (error) {
     markCloudError(provider, isDestructiveMergeError(error) ? "merge" : "download", error);
     throw error;


### PR DESCRIPTION
Executes [P0-03](../blob/dev/docs/stability-tasks/P0-03-loop-counters.md) from the stability program (docs/STABILITY-PROGRAM.md, Wave 1). **Logging only — no behavior changes, no watchdog changes.** The verified idle-churn loops are invisible in telemetry today; this PR makes their live signatures countable so each Wave-2 damper can attribute its delta.

## What

**1. Cloud upload attempts (F01/F06 — the upload→merge→STATE_UPDATE→upload echo).** New `GET_HEADS` worker request (`automerge-types.ts` + both workers) answering from the loaded doc, or from heads-at-last-save when the doc is idle-unloaded — it never forces an `A.load` and never re-INITs an idle worker, so the counter cannot worsen F20. Every upload attempt logs `cloud_upload_attempt {provider, cause (subscriber|manual|poll), headsBefore, headsUnchanged}` — desktop to runtime-health.jsonl, PWA to its debug channel with the same field names. The pathological baseline expectation: hundreds/hour with `headsUnchanged=true` on an idle machine.

**2. Relay broadcasts (F07/F10 — full-doc frames per mutation).** `broadcast_doc` folds each invoke into a ~60 s aggregate and flushes `relay_broadcast_aggregate {count, totalBytes, clientCount, windowMs}` on window rollover — aggregated so the counter itself cannot bloat the health log at per-mutation broadcast rates (the 5 MiB halving cap is still live until P0-04).

**3. Worker INITs (F20 — full A.load per isolated mutation).** New `INIT_STATS` worker response; desktop logs `worker_init {durationMs, docBytes}` + `worker_spawn` to runtime-health, PWA mirrors on its debug channel. INITs/hour during a content backlog is the scorecard counter.

**4. Scrape outcomes (F03 — results discarded by mid-invoke recovery).** Shared helper `recordScrapeOutcome` (new `packages/desktop/src/lib/runtime-health-events.ts`) wrapped around all four capture entry points (fb/instagram/li/x-capture.ts), emitting `scrape_outcome {provider, trigger, itemsExtracted, itemsPersisted, stage, durationMs}` at settlement. `itemsExtracted >= 5 && itemsPersisted == 0` is the scrape_zero_persist signature. `trigger` (manual | scheduled | deferred_retry | dev_trigger | post_login | unknown) is threaded from the scheduler, dev triggers, post-login auto-sync hook, and UI sync buttons.

**Plumbing:** renderer events reach runtime-health.jsonl through a new `record_runtime_health_event` Tauri command (object-with-event-string only, 4 KiB cap, reuses `append_runtime_health`). All JS helpers swallow failures — counters can never block or fail a sync or capture.

## Verification

- Desktop vitest 490/490, PWA vitest 230/230, `cargo test --lib` incl. new `relay_broadcast_aggregate_flushes_on_window_rollover`; `tsc` clean for both apps; `cargo check` clean.
- Test updates: dev-sync-trigger expectations now include the `dev_trigger` arg; bug-report test mock gained the `isTauri` export.
- Next: one overnight idle soak with GDrive connected + paired phone fills the scorecard baselines (uploads/hour with headsUnchanged, broadcast volume, INITs/hour, scrape outcomes).

Checks the P0-03 box in docs/STABILITY-PROGRAM.md.

**runner-safe: false — touches sync/worker/capture code plus a small lib.rs region (broadcast_doc counter + renderer event command); owner review required before merge. Left in draft.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)