### PR TITLE
feat: add --ready closeout flag to worktree-publish so finished PRs leave draft

### DIFF
--- a/.agents/skills/freed-build-feature/SKILL.md
+++ b/.agents/skills/freed-build-feature/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: freed-build-feature
-description: Scaffold product work in a dev-based worktree, implement a runnable slice, launch the lightest useful local preview early, validate it with the shared feature-tier runner before publish, and finish by committing, pushing, and opening a draft PR targeting dev. Use for Desktop, PWA, shared packages, sync, capture packages, release tooling, app behavior, and product docs targeting dev. Do not use for public marketing changes targeting www.
+description: Scaffold product work in a dev-based worktree, implement a runnable slice, launch the lightest useful local preview early, validate it with the shared feature-tier runner before publish, and finish by committing, pushing, and opening a PR targeting dev (draft while iterating, marked ready for review at closeout). Use for Desktop, PWA, shared packages, sync, capture packages, release tooling, app behavior, and product docs targeting dev. Do not use for public marketing changes targeting www.
 disable-model-invocation: true
 ---
 
 # Build Feature
 
-Create a product worktree branch from the latest remote `dev`, implement enough of the feature or fix to run, launch the lightest useful local preview early, iterate against that preview, then validate with the shared feature-tier runner before committing the work, pushing the branch, and opening a draft PR to `dev`.
+Create a product worktree branch from the latest remote `dev`, implement enough of the feature or fix to run, launch the lightest useful local preview early, iterate against that preview, then validate with the shared feature-tier runner before committing the work, pushing the branch, and publishing the PR to `dev` (draft during iteration; `--ready` at closeout).
 
 Feature threads inherit the stability program rules in [docs/STABILITY-PROGRAM.md](../../../docs/STABILITY-PROGRAM.md) ("Program rules"): the watchdog freeze (no threshold, recovery-reason, or process-attribution changes), one product PR per soak cycle for behavioral changes, and the provider-visible lane (anything changing WebView loads, provider navigation, request frequency, cookies, headers, or extractor scripts stops for explicit owner approval first).
 
@@ -57,9 +57,10 @@ Feature threads inherit the stability program rules in [docs/STABILITY-PROGRAM.m
    - Before reporting final status, list this thread's preview with `./scripts/worktree-processes.sh list --worktree <worktree>` so the URL and owner are clear.
    - When the PR is merged, the worktree is removed, or the thread is archived, stop only this thread's preview with `./scripts/worktree-processes.sh stop --worktree <worktree> --target <pwa|desktop>`.
    - Never stop previews from other worktrees unless the user explicitly asks for global cleanup.
-17. Finish the branch with `./scripts/worktree-publish.sh --title "<conventional-commit title>" --summary "<user-facing change>" --test "<focused check>"`.
+17. Finish the branch with `./scripts/worktree-publish.sh --title "<conventional-commit title>" --summary "<user-facing change>" --test "<focused check>" --ready`.
+   - Pass `--ready` only at closeout, once validation has passed and the work is complete. Interim publishes omit it so the PR stays draft while the thread iterates.
    - If the branch intentionally adds new files, stage them yourself first or re-run with `--include-untracked`.
-18. Confirm the branch is pushed to `origin` and the PR targeting `dev` stays in draft state. Include the local preview URL or native preview label in the closeout.
+18. Confirm the branch is pushed to `origin` and the PR targeting `dev` is marked ready for review (or intentionally left draft if the thread is still iterating, blocked, or needs discussion — say which in the closeout). Include the local preview URL or native preview label in the closeout.
    - When a changed surface includes buttons, dialogs, or native fallback HTML, follow the repo's established primary and secondary control styling. Do not add hover lift, vertical motion, bounce, or ad hoc glossy or gradient CTA treatments.
 19. When the PR merges, append an outcome ledger entry via the W1-01 helper so the nightly planner learns from the result (see "Outcome recording" in docs/STABILITY-PROGRAM.md and docs/stability-tasks/W1-01-automation-state-out-of-tmp.md). Until the W1-01 helper (`scripts/record-outcome.mjs`) has landed, append the ledger line manually with the target or task id, PR number, build, and status.
 

--- a/.agents/skills/freed-build-www/SKILL.md
+++ b/.agents/skills/freed-build-www/SKILL.md
@@ -28,9 +28,9 @@ Create a marketing worktree branch from `www`, implement the website change, ver
    - Before reporting final status, list this thread's preview with `./scripts/worktree-processes.sh list --worktree <worktree>` so the URL and owner are clear.
    - When the PR is merged, the worktree is removed, or the thread is archived, stop only this thread's preview with `./scripts/worktree-processes.sh stop --worktree <worktree> --target website`.
    - Never stop previews from other worktrees unless the user explicitly asks for global cleanup.
-11. Finish the branch with `./scripts/worktree-publish.sh --title "<conventional-commit title>" --base www --summary "<user-facing change>" --test "cd website && PATH=../node_modules/.bin:$PATH npm run build"`.
+11. Finish the branch with `./scripts/worktree-publish.sh --title "<conventional-commit title>" --base www --summary "<user-facing change>" --test "cd website && PATH=../node_modules/.bin:$PATH npm run build" --ready` (omit `--ready` for interim publishes so the PR stays draft while iterating).
    - If the branch intentionally adds new files, stage them yourself first or re-run `./scripts/worktree-publish.sh` with `--include-untracked`.
-12. Confirm the branch is pushed to `origin`, the draft PR targets `www`, and the closeout includes the local preview URL.
+12. Confirm the branch is pushed to `origin`, the PR targets `www` and is marked ready for review (or intentionally left draft with the reason stated), and the closeout includes the local preview URL.
 
 Never run `npm run <script> --workspace=...` from the repo root in this monorepo. Run website commands from `website/`, and prefix `PATH` with the worktree root `node_modules/.bin` when a hoisted binary like `next` or `tsx` is required.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,7 @@ Prefer the lightest useful local preview before opening a draft PR:
 - the root fanout scripts now fail fast if you try the dangerous workspace-dispatch pattern, treat that error as a routing mistake and re-run from the workspace
 - if a workspace command needs a hoisted binary, prefix `PATH` with the worktree root `node_modules/.bin`
 - expect the worktree helpers to print the resolved `node` and `npm` pair before they do real work, and treat a surprising path there as a machine issue to fix before debugging the repo
-- rerunning `./scripts/worktree-publish.sh` should update the existing draft PR body and title, and push a ready PR back to draft when the local branch changes underneath it
+- rerunning `./scripts/worktree-publish.sh` should update the existing draft PR body and title, and push a ready PR back to draft when the local branch changes underneath it. At closeout, publish with `--ready` so a finished, validated PR is marked ready for review; draft means "still iterating, blocked, or needs discussion", not "authored by automation"
 - browser tooling is opt-in only, do not launch Chrome DevTools MCP, Playwright MCP, or Computer Use unless the task explicitly needs browser automation or browser debugging
 - after browser tooling work, do not run broad cleanup while the preview should remain open. If cleanup is needed, scope it with `./scripts/dev-session-clean.sh --worktree <worktree>`.
 - when a PR is merged, the worktree is removed, or the thread is archived, close only that thread's preview with `./scripts/worktree-processes.sh stop --worktree <worktree> --target <pwa|desktop|website>`.

--- a/scripts/worktree-publish.sh
+++ b/scripts/worktree-publish.sh
@@ -9,7 +9,12 @@ source "${SCRIPT_DIR}/lib/node-tooling.sh"
 usage() {
   cat <<'EOF'
 Usage:
-  ./scripts/worktree-publish.sh --title "<conventional-commit title>" [--summary "<bullet>"]... [--test "<bullet>"]... [--base <branch>] [--body-file <path>] [--include-untracked] [--approved-provider-risk "<one-line owner approval reference>"]
+  ./scripts/worktree-publish.sh --title "<conventional-commit title>" [--summary "<bullet>"]... [--test "<bullet>"]... [--base <branch>] [--body-file <path>] [--include-untracked] [--ready] [--approved-provider-risk "<one-line owner approval reference>"]
+
+Draft is the default so interim publishes never look reviewable. Pass --ready at
+closeout, once validation has passed and the work is complete, to mark the PR
+ready for review. Re-running without --ready after the branch changes demotes a
+ready PR back to draft on purpose: the content moved since the owner saw it.
 
 Stages local changes, commits them when needed, pushes the current branch to origin,
 and opens a draft pull request.
@@ -145,6 +150,7 @@ TITLE=""
 BASE_BRANCH="dev"
 BODY_FILE=""
 INCLUDE_UNTRACKED=false
+READY_FOR_REVIEW=false
 PROVIDER_RISK_APPROVAL=""
 SUMMARY_ARGS=()
 TEST_ARGS=()
@@ -178,6 +184,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --include-untracked)
       INCLUDE_UNTRACKED=true
+      shift
+      ;;
+    --ready)
+      READY_FOR_REVIEW=true
       shift
       ;;
     --approved-provider-risk)
@@ -320,6 +330,16 @@ EXISTING_PR_URL="$(pr_field "${EXISTING_PR_JSON}" "url")"
 EXISTING_PR_IS_DRAFT="$(pr_field "${EXISTING_PR_JSON}" "isDraft")"
 
 if [[ -n "${EXISTING_PR_NUMBER}" ]]; then
+  if ${READY_FOR_REVIEW}; then
+    gh pr edit "${EXISTING_PR_NUMBER}" --title "${TITLE}" --body "${BODY_CONTENT}" >/dev/null
+    if [[ "${EXISTING_PR_IS_DRAFT}" == "true" ]]; then
+      gh pr ready "${EXISTING_PR_NUMBER}" >/dev/null
+    fi
+    printf 'Updated PR (ready for review): %s\n' "${EXISTING_PR_URL}"
+    exit 0
+  fi
+  # Without --ready, a changed branch demotes a ready PR back to draft so the
+  # owner knows the content moved since they last looked.
   if [[ "${EXISTING_PR_IS_DRAFT}" != "true" ]]; then
     gh pr ready "${EXISTING_PR_NUMBER}" --undo >/dev/null
   fi
@@ -328,9 +348,13 @@ if [[ -n "${EXISTING_PR_NUMBER}" ]]; then
   exit 0
 fi
 
-gh pr create \
-  --draft \
-  --base "${BASE_BRANCH}" \
-  --head "${BRANCH_NAME}" \
-  --title "${TITLE}" \
+CREATE_ARGS=(
+  --base "${BASE_BRANCH}"
+  --head "${BRANCH_NAME}"
+  --title "${TITLE}"
   --body "${BODY_CONTENT}"
+)
+if ! ${READY_FOR_REVIEW}; then
+  CREATE_ARGS=(--draft "${CREATE_ARGS[@]}")
+fi
+gh pr create "${CREATE_ARGS[@]}"

--- a/scripts/worktree-publish.test.mjs
+++ b/scripts/worktree-publish.test.mjs
@@ -329,3 +329,78 @@ test("worktree-publish requires a value for --approved-provider-risk", async (t)
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /--approved-provider-risk requires/);
 });
+
+test("worktree-publish --ready promotes an existing draft PR after updating it", async (t) => {
+  const fixture = await createPublishFixture(t);
+
+  await fs.writeFile(
+    fixture.ghStateFile,
+    JSON.stringify(
+      {
+        prList: [
+          {
+            number: 321,
+            url: "https://github.com/freed-project/freed/pull/321",
+            isDraft: true,
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+
+  await fs.writeFile(path.join(fixture.worktree, "README.md"), "ready closeout\n");
+
+  const result = run(
+    "bash",
+    [
+      publishScript,
+      "--title",
+      "fix: closeout ready publish helper",
+      "--summary",
+      "Close out the publish helper",
+      "--ready",
+    ],
+    {
+      cwd: fixture.worktree,
+      env: fixture.env,
+    },
+  );
+
+  assertSuccess(result);
+  assert.match(result.stdout, /Updated PR \(ready for review\)/);
+
+  const ghCalls = await readGhLog(fixture.ghLogFile);
+  const readyCalls = ghCalls.filter((call) => call.args[1] === "ready");
+  assert.deepEqual(readyCalls, [{ args: ["pr", "ready", "321"] }]);
+  const editIndex = ghCalls.findIndex((call) => call.args[1] === "edit");
+  const readyIndex = ghCalls.findIndex((call) => call.args[1] === "ready");
+  assert.ok(editIndex < readyIndex, "edit must run before the promotion");
+});
+
+test("worktree-publish --ready creates a new PR without --draft", async (t) => {
+  const fixture = await createPublishFixture(t);
+  await fs.writeFile(path.join(fixture.worktree, "README.md"), "fresh ready create\n");
+
+  const result = run(
+    "bash",
+    [
+      publishScript,
+      "--title",
+      "fix: create a ready publish helper",
+      "--summary",
+      "Create the ready publish helper",
+      "--ready",
+    ],
+    {
+      cwd: fixture.worktree,
+      env: fixture.env,
+    },
+  );
+
+  assertSuccess(result);
+  const ghCalls = await readGhLog(fixture.ghLogFile);
+  assert.equal(ghCalls.at(-1).args[1], "create");
+  assert.equal(ghCalls.at(-1).args.includes("--draft"), false);
+});


### PR DESCRIPTION
(AI Generated).

## Summary
- Owner feedback: draft PRs that are actually finished are indistinguishable from in-flight work at review time. Draft had come to mean "authored by automation" instead of "not ready".
- `worktree-publish.sh` gains `--ready`: at closeout it updates the PR then promotes it out of draft (`gh pr ready`), and new PRs are created non-draft. Default behavior is unchanged: interim publishes stay draft, and re-running without `--ready` after the branch changes still demotes a ready PR back to draft on purpose (content moved since the owner saw it). Usage text documents the semantics.
- Closeout prose updated to match: freed-build-feature step 17/18 and freed-build-www step 11/12 now publish with `--ready` once validation has passed (or state why the PR is intentionally left draft); the AGENTS.md publish note defines draft as "still iterating, blocked, or needs discussion".
- Stacked on #907 (docs/truth-pass) so the skill edits do not conflict with the W1-07 renumbering; merge #907 first and this diff collapses to just the --ready change.

## Testing
- Two new cases in scripts/worktree-publish.test.mjs: `--ready` on an existing draft edits first then emits `pr ready <n>` (and never `--undo`); `--ready` create path omits `--draft`. Existing demotion and draft-default tests still pass (8/8).
- `bash -n scripts/worktree-publish.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)