### PR TITLE
chore: nest automation state under ~/.freed/automation

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -83,7 +83,7 @@ Three long-lived branches: `dev` (product work, default), `main` (production rel
 
 ## Automation substrate
 
-- `scripts/nightly-self-improve.mjs`: nightly planner that turns soak/scan evidence into ranked overnight tasks (docs/NIGHTLY-SELF-IMPROVE.md). Learning state lives in `~/.freed-automation/`.
+- `scripts/nightly-self-improve.mjs`: nightly planner that turns soak/scan evidence into ranked overnight tasks (docs/NIGHTLY-SELF-IMPROVE.md). Learning state lives in `~/.freed/automation/`.
 - `scripts/doctor.mjs`: machine preflight (pinned Node toolchain, gh, credential helpers, python3) run warn-only by the worktree helpers.
 - `scripts/soak-collect.mjs` / `scripts/soak-assert.mjs`: installed-soak evidence collection and machine-readable verdicts (docs/SOAK-AND-TRIGGERS.md is the canonical soak contract).
 - `scripts/dev-sync-trigger.mjs`: terminal-driven provider sync trigger for installed dev builds (same doc).

--- a/docs/SOAK-AND-TRIGGERS.md
+++ b/docs/SOAK-AND-TRIGGERS.md
@@ -6,7 +6,7 @@ Canonical contract for validating installed Freed Desktop builds on the user's p
 
 An installed soak observes a real Freed Desktop build over hours using terminal evidence only.
 
-- Start collection with `node scripts/soak-collect.mjs` (`--detach` to survive terminal close). It samples the app process, the machine-wide WebKit process table, and `runtime-health.jsonl` offsets into a soak directory under `~/.freed-automation/soaks/`, and points `~/.freed-automation/current-soak-dir` at it.
+- Start collection with `node scripts/soak-collect.mjs` (`--detach` to survive terminal close). It samples the app process, the machine-wide WebKit process table, and `runtime-health.jsonl` offsets into a soak directory under `~/.freed/automation/soaks/`, and points `~/.freed/automation/current-soak-dir` at it.
 - Judge the soak with `node scripts/soak-assert.mjs`. It writes `soak-verdict.json` with named assertions (footprint slope, renderer recoveries, stale heartbeats, WebKit baseline return, and the P0-02/P0-03 counters once they exist), each citing violating file:line evidence. Loops gate on the verdict, not on eyeballed TSVs.
 - The nightly planner (docs/NIGHTLY-SELF-IMPROVE.md) reads the same pointer and soak files as evidence.
 

--- a/scripts/soak-assert.mjs
+++ b/scripts/soak-assert.mjs
@@ -35,7 +35,7 @@ const MB = 1024 * 1024;
 const SLOPE_LIMIT_MB_PER_HOUR = 25;
 const SLOPE_MIN_HOURS = 4;
 
-const DEFAULT_POINTER = path.join(os.homedir(), ".freed-automation", "current-soak-dir");
+const DEFAULT_POINTER = path.join(os.homedir(), ".freed", "automation", "current-soak-dir");
 const DEFAULT_APP_DATA_DIR = path.join(
   os.homedir(),
   "Library",

--- a/scripts/soak-collect.mjs
+++ b/scripts/soak-collect.mjs
@@ -4,7 +4,7 @@
 //
 // Samples the installed Freed Desktop app on an interval into a versioned
 // TSV/JSONL schema under a soak directory, and points the active-soak pointer
-// (~/.freed-automation/current-soak-dir) at it so the nightly planner and
+// (~/.freed/automation/current-soak-dir) at it so the nightly planner and
 // scripts/soak-assert.mjs can find the evidence.
 //
 // What it records per sample:
@@ -59,15 +59,15 @@ const DEFAULT_APP_DATA_DIR = path.join(
   "Application Support",
   "wtf.freed.desktop",
 );
-const AUTOMATION_STATE_DIR = path.join(os.homedir(), ".freed-automation");
+const AUTOMATION_STATE_DIR = path.join(os.homedir(), ".freed", "automation");
 
 function usage() {
   return `Usage:
   node scripts/soak-collect.mjs [options]
 
 Options:
-  --soak-dir <path>          Soak directory. Defaults to ~/.freed-automation/soaks/<timestamp>.
-  --pointer <path>           Active-soak pointer file. Defaults to ~/.freed-automation/current-soak-dir.
+  --soak-dir <path>          Soak directory. Defaults to ~/.freed/automation/soaks/<timestamp>.
+  --pointer <path>           Active-soak pointer file. Defaults to ~/.freed/automation/current-soak-dir.
   --app-data <path>          App data dir holding runtime-health.jsonl. Defaults to the installed Freed Desktop dir.
   --app-binary <substring>   Main process match. Defaults to "Freed.app/Contents/MacOS".
   --interval-seconds <n>     Sample interval. Defaults to 60.

--- a/scripts/soak.test.mjs
+++ b/scripts/soak.test.mjs
@@ -64,9 +64,9 @@ test("parsePsTable and buildSample split app, WebContent, and other WebKit proce
   assert.equal(tsv.trim().split("\t").length, METRICS_COLUMNS.length);
 });
 
-test("soak-collect parseArgs derives a soaks dir under ~/.freed-automation", () => {
+test("soak-collect parseArgs derives a soaks dir under ~/.freed/automation", () => {
   const args = parseCollectArgs([], new Date("2026-07-02T10:00:00Z"));
-  assert.ok(args.soakDir.includes(path.join(".freed-automation", "soaks")));
+  assert.ok(args.soakDir.includes(path.join(".freed", "automation", "soaks")));
   assert.ok(args.pointer.endsWith("current-soak-dir"));
   assert.throws(() => parseCollectArgs(["--interval-seconds", "1"]), /at least 5/);
 });


### PR DESCRIPTION
(AI Generated).

## Summary
- Owner review on #903: use `~/.freed/automation/` (one Freed dotfile namespace with room for future state) instead of a top-level `~/.freed-automation/`.
- #908 (soak collector/assert) and #907 (ARCHITECTURE.md, SOAK-AND-TRIGGERS.md) merged before their rename commits landed, so this follow-up carries the rename for those already-merged files. The still-open #903 and #906 were rebased and already carry their own rename.
- Local machine state has been moved to `~/.freed/automation/` accordingly.

## Testing
- `node --test scripts/soak.test.mjs`: 11 pass with the new default path.
- `grep -rn freed-automation` over the touched files: no residuals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)