### PR TITLE
fix: mirror runtime-health into the soak dir so rotation cannot shrink the evidence window

### DIFF
--- a/scripts/soak-collect.mjs
+++ b/scripts/soak-collect.mjs
@@ -10,7 +10,11 @@
 // What it records per sample:
 //   metrics.tsv            one row per sample (see COLUMNS below)
 //   webkit-processes.tsv   machine-wide WebKit XPC process table
-//   health-offsets.jsonl   byte/line offsets of the app's runtime-health.jsonl
+//   runtime-health.jsonl   incremental mirror of the app's runtime-health.jsonl,
+//                          appended from the last recorded byte offset so daily
+//                          rotation (P0-04) cannot shrink a long soak's evidence
+//                          window; soak-assert prefers this copy
+//   health-offsets.jsonl   byte/line cursor of the app's runtime-health.jsonl
 //   soak-info.json         schema version + config, written once at start
 //
 // WebKit attribution caveat: WebKit XPC processes are children of launchd
@@ -30,7 +34,6 @@ import {
   existsSync,
   mkdirSync,
   readFileSync,
-  statSync,
   writeFileSync,
 } from "node:fs";
 import os from "node:os";
@@ -207,23 +210,53 @@ export function metricsRowToTsv(sample) {
   return `${METRICS_COLUMNS.map((column) => String(sample[column] ?? "")).join("\t")}\n`;
 }
 
-function readHealthOffsets(appData) {
-  const healthPath = path.join(appData, "runtime-health.jsonl");
+// Appends everything past lastBytes in the app's runtime-health.jsonl to the
+// soak-dir mirror. Rotation (P0-04 truncates daily) shows up as the file
+// shrinking below the cursor; then the whole new file is appended from byte 0.
+// Copying raw bytes from the exact prior offset means a partially written last
+// line is completed by the next sample, never duplicated.
+export function mirrorHealthDelta({ healthPath, mirrorPath, lastBytes }) {
   if (!existsSync(healthPath)) {
-    return { bytes: 0, lines: 0 };
+    return { bytes: 0, lines: 0, appendedBytes: 0, rotated: false };
+  }
+  let buffer;
+  try {
+    buffer = readFileSync(healthPath);
+  } catch {
+    // Keep the cursor where it was so a transient read failure cannot cause a
+    // duplicate append on the next sample.
+    return { bytes: lastBytes, lines: 0, appendedBytes: 0, rotated: false };
+  }
+  const bytes = buffer.length;
+  const rotated = bytes < lastBytes;
+  const delta = buffer.subarray(rotated ? 0 : lastBytes);
+  if (delta.length > 0) {
+    appendFileSync(mirrorPath, delta);
+  }
+  return {
+    bytes,
+    lines: buffer.toString("utf8").split("\n").filter(Boolean).length,
+    appendedBytes: delta.length,
+    rotated,
+  };
+}
+
+// Restores the mirror cursor from the last health-offsets.jsonl entry so a
+// restarted collector continues appending instead of re-copying the file.
+export function readLastHealthOffset(offsetsPath) {
+  if (!existsSync(offsetsPath)) {
+    return 0;
   }
   try {
-    const stat = statSync(healthPath);
-    // The app rotates this file (5 MiB cap today), so a full read per sample
-    // is cheap.
-    const content = readFileSync(healthPath, "utf8");
-    return { bytes: stat.size, lines: content.split("\n").filter(Boolean).length };
+    const lines = readFileSync(offsetsPath, "utf8").split("\n").filter(Boolean);
+    const bytes = Number(JSON.parse(lines.at(-1) ?? "{}").bytes);
+    return Number.isFinite(bytes) && bytes >= 0 ? bytes : 0;
   } catch {
-    return { bytes: 0, lines: 0 };
+    return 0;
   }
 }
 
-function takeSample(args, now = Date.now()) {
+function takeSample(args, cursor, now = Date.now()) {
   let psOutput = "";
   try {
     psOutput = execFileSync("ps", ["axo", "pid=,ppid=,rss=,command="], {
@@ -237,7 +270,12 @@ function takeSample(args, now = Date.now()) {
     appBinary: args.appBinary,
     tsMs: now,
   });
-  const offsets = readHealthOffsets(args.appData);
+  const offsets = mirrorHealthDelta({
+    healthPath: path.join(args.appData, "runtime-health.jsonl"),
+    mirrorPath: path.join(args.soakDir, "runtime-health.jsonl"),
+    lastBytes: cursor.healthBytes,
+  });
+  cursor.healthBytes = offsets.bytes;
   sample.healthFileBytes = offsets.bytes;
   sample.healthFileLines = offsets.lines;
 
@@ -311,8 +349,11 @@ function main() {
   }
 
   initSoakDir(args);
+  const cursor = {
+    healthBytes: readLastHealthOffset(path.join(args.soakDir, "health-offsets.jsonl")),
+  };
   const startedAt = Date.now();
-  const sample = takeSample(args);
+  const sample = takeSample(args, cursor);
   process.stdout.write(
     `Soak dir ${args.soakDir}: sampling every ${args.intervalSeconds}s (app pid ${sample.appPid || "not running"}).\n`,
   );
@@ -321,7 +362,7 @@ function main() {
   }
 
   const timer = setInterval(() => {
-    takeSample(args);
+    takeSample(args, cursor);
     if (args.durationMinutes > 0 && Date.now() - startedAt >= args.durationMinutes * 60_000) {
       clearInterval(timer);
       process.stdout.write("Soak duration reached; collector exiting.\n");

--- a/scripts/soak.test.mjs
+++ b/scripts/soak.test.mjs
@@ -10,8 +10,10 @@ import {
   buildSample,
   METRICS_COLUMNS,
   metricsRowToTsv,
+  mirrorHealthDelta,
   parsePsTable,
   parseArgs as parseCollectArgs,
+  readLastHealthOffset,
 } from "./soak-collect.mjs";
 import {
   assertEventCountZero,
@@ -102,6 +104,101 @@ test("soak-collect --once writes metrics, offsets, info, and the pointer", () =>
   const info = JSON.parse(readFileSync(path.join(soakDir, "soak-info.json"), "utf8"));
   assert.equal(info.schemaVersion, 1);
   assert.deepEqual(info.metricsColumns, METRICS_COLUMNS);
+});
+
+function runCollectOnce(root, soakDir, pointer) {
+  execFileSync(
+    process.execPath,
+    [
+      path.join(__dirname, "soak-collect.mjs"),
+      "--once",
+      "--soak-dir",
+      soakDir,
+      "--pointer",
+      pointer,
+      "--app-data",
+      root,
+    ],
+    { encoding: "utf8" },
+  );
+}
+
+test("soak-collect mirrors runtime-health incrementally across samples", () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "freed-soak-mirror-"));
+  const soakDir = path.join(root, "soak");
+  const pointer = path.join(root, "state", "current-soak-dir");
+  const healthPath = path.join(root, "runtime-health.jsonl");
+  const mirrorPath = path.join(soakDir, "runtime-health.jsonl");
+
+  writeFileSync(healthPath, '{"event":"a","tsMs":1}\n{"event":"b","tsMs":2}\n');
+  runCollectOnce(root, soakDir, pointer);
+  assert.equal(readFileSync(mirrorPath, "utf8"), readFileSync(healthPath, "utf8"));
+
+  // Each --once is a fresh process, so the cursor round-trips through
+  // health-offsets.jsonl; only the appended line may be copied again.
+  writeFileSync(healthPath, readFileSync(healthPath, "utf8") + '{"event":"c","tsMs":3}\n');
+  runCollectOnce(root, soakDir, pointer);
+  assert.equal(
+    readFileSync(mirrorPath, "utf8"),
+    '{"event":"a","tsMs":1}\n{"event":"b","tsMs":2}\n{"event":"c","tsMs":3}\n',
+  );
+
+  const offsets = readFileSync(path.join(soakDir, "health-offsets.jsonl"), "utf8")
+    .trim()
+    .split("\n")
+    .map((line) => JSON.parse(line));
+  assert.equal(offsets.length, 2);
+  assert.equal(offsets[0].rotated, false);
+  assert.equal(offsets[1].bytes, readFileSync(healthPath).length);
+  assert.equal(offsets[1].appendedBytes, '{"event":"c","tsMs":3}\n'.length);
+  assert.equal(readLastHealthOffset(path.join(soakDir, "health-offsets.jsonl")), offsets[1].bytes);
+});
+
+test("soak-collect re-mirrors from byte 0 after rotation without duplicating", () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "freed-soak-rotate-"));
+  const soakDir = path.join(root, "soak");
+  const pointer = path.join(root, "state", "current-soak-dir");
+  const healthPath = path.join(root, "runtime-health.jsonl");
+  const mirrorPath = path.join(soakDir, "runtime-health.jsonl");
+
+  writeFileSync(healthPath, '{"event":"old-1","tsMs":1}\n{"event":"old-2","tsMs":2}\n');
+  runCollectOnce(root, soakDir, pointer);
+
+  // Daily rotation truncates the live file; the mirror keeps the old window
+  // and appends the whole rotated file exactly once.
+  writeFileSync(healthPath, '{"event":"new-1","tsMs":3}\n');
+  runCollectOnce(root, soakDir, pointer);
+  assert.equal(
+    readFileSync(mirrorPath, "utf8"),
+    '{"event":"old-1","tsMs":1}\n{"event":"old-2","tsMs":2}\n{"event":"new-1","tsMs":3}\n',
+  );
+
+  const offsets = readFileSync(path.join(soakDir, "health-offsets.jsonl"), "utf8")
+    .trim()
+    .split("\n")
+    .map((line) => JSON.parse(line));
+  assert.equal(offsets[1].rotated, true);
+  assert.equal(offsets[1].bytes, '{"event":"new-1","tsMs":3}\n'.length);
+});
+
+test("mirrorHealthDelta completes a partially written line on the next sample", () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "freed-soak-partial-"));
+  const healthPath = path.join(root, "runtime-health.jsonl");
+  const mirrorPath = path.join(root, "mirror.jsonl");
+
+  writeFileSync(healthPath, '{"event":"a","tsMs":1}\n{"event":"b"');
+  const first = mirrorHealthDelta({ healthPath, mirrorPath, lastBytes: 0 });
+  assert.equal(first.rotated, false);
+
+  writeFileSync(healthPath, '{"event":"a","tsMs":1}\n{"event":"b","tsMs":2}\n');
+  const second = mirrorHealthDelta({ healthPath, mirrorPath, lastBytes: first.bytes });
+  assert.equal(second.rotated, false);
+  assert.equal(readFileSync(mirrorPath, "utf8"), readFileSync(healthPath, "utf8"));
+
+  // Unchanged file appends nothing.
+  const third = mirrorHealthDelta({ healthPath, mirrorPath, lastBytes: second.bytes });
+  assert.equal(third.appendedBytes, 0);
+  assert.equal(readFileSync(mirrorPath, "utf8"), readFileSync(healthPath, "utf8"));
 });
 
 test("footprintSlopeMbPerHour measures a linear leak", () => {


### PR DESCRIPTION
(AI Generated).

## Summary
- soak-collect.mjs now appends new runtime-health.jsonl bytes from the last recorded offset into <soak-dir>/runtime-health.jsonl on every sample, so P0-04 daily rotation can no longer rotate a long soak's health evidence away before soak-assert runs
- rotation is detected as the live file shrinking below the cursor; the whole rotated file is then appended from byte 0 exactly once (no duplication); byte-exact offsets mean a partially written last line is completed by the next sample
- the cursor persists through health-offsets.jsonl (entries gain appendedBytes/rotated fields) so a restarted collector continues appending instead of re-copying
- no soak-assert.mjs changes: verified it already prefers <soak-dir>/runtime-health.jsonl over the live app-data file

## Testing
- node --test scripts/soak.test.mjs: 14 pass (3 new: incremental append across --once samples, rotation shrink re-read without duplication, partial-line completion via mirrorHealthDelta)
- end-to-end: with app-data deleted after collection, soak-assert read the soak-dir mirror and failed renderer_recoveries on an event present only in the mirror