### PR TITLE
fix: make runtime-health rotation compile on Linux by scoping libc to cfg(unix)

### DIFF
--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -1420,7 +1420,7 @@ dependencies = [
 
 [[package]]
 name = "freed-desktop"
-version = "26.7.203"
+version = "26.7.300"
 dependencies = [
  "base64 0.22.1",
  "criterion",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -42,8 +42,10 @@ url = "2"
 sysinfo = "0.37"
 sha2 = "0.10"
 
-[target.'cfg(target_os = "macos")'.dependencies]
+[target.'cfg(unix)'.dependencies]
 libc = "0.2"
+
+[target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6"
 objc2-app-kit = { version = "0.3", default-features = false, features = ["NSApplication", "NSRunningApplication"] }
 objc2-foundation = { version = "0.3", default-features = false, features = ["std", "NSString", "NSKeyValueCoding", "NSObject", "NSThread"] }

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -8,7 +8,7 @@ use log::{error, info, warn};
 use rand::RngCore;
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet, VecDeque};
-#[cfg(target_os = "macos")]
+#[cfg(unix)]
 use std::mem::MaybeUninit;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};


### PR DESCRIPTION
## Problem

The v26.7.300-dev release run ([28683540328](https://github.com/freed-project/freed/actions/runs/28683540328)) failed on the Linux x64 matrix build with E0433: the P0-04 daily runtime-health rotation added `local_date_yyyymmdd()` gated `#[cfg(unix)]` (src/lib.rs:1190), but `libc` was only declared under `[target.'cfg(target_os = "macos")'.dependencies]` and the `MaybeUninit` import was macOS-gated. macOS and Windows builds passed (`fail-fast: false`).

## Fix

- Move `libc = "0.2"` to `[target.'cfg(unix)'.dependencies]` so Linux links it too.
- Widen `use std::mem::MaybeUninit;` from `#[cfg(target_os = "macos")]` to `#[cfg(unix)]`.
- Cargo.lock picks up the 26.7.300 crate version from the release commit (release.sh bumps Cargo.toml only).

`libc::time`/`localtime_r`/`tm` are portable across unix targets; the macOS-only `proc_pid_rusage` usage stays under its existing `#[cfg(target_os = "macos")]` gate. Verified with `cargo check` locally on macOS; Linux compile is exercised by the release workflow (PR CI does not build the Rust crate).

A follow-up dev release (v26.7.301-dev) will be cut after this merges, per the freed-ship-build skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)