### PR TITLE
chore: refresh changelog for v26.7.301-dev

### DIFF
--- a/release-notes/daily/dev/26.7.3.json
+++ b/release-notes/daily/dev/26.7.3.json
@@ -1,0 +1,14 @@
+{
+  "channel": "dev",
+  "dayKey": "26.7.3",
+  "date": "2026-07-03",
+  "preferredDeck": null,
+  "editorialGuidance": [
+    "Keep the tone concise, professional, and specific.",
+    "Lead with user-facing outcomes, shipping milestones, trust wins, and installability improvements.",
+    "Demote internal cleanup unless it clearly changes the shipped product."
+  ],
+  "pinnedHighlights": [],
+  "editorialNotes": [],
+  "updatedAt": "2026-07-03T22:07:26.170Z"
+}

--- a/release-notes/releases/v26.7.301-dev.json
+++ b/release-notes/releases/v26.7.301-dev.json
@@ -1,0 +1,87 @@
+{
+  "tag": "v26.7.301-dev",
+  "version": "26.7.301-dev",
+  "channel": "dev",
+  "dayKey": "26.7.3",
+  "approved": true,
+  "editorialNotes": [
+    "Reviewed 2026-07-03: same reviewed copy as the failed v26.7.300-dev tag (Linux matrix build failed; this is the follow-up build) plus the Linux libc/cfg(unix) compile fix."
+  ],
+  "generatedAt": "2026-07-03T22:07:26.168Z",
+  "model": "heuristic",
+  "source": {
+    "channel": "dev",
+    "previousPublishedTag": "v26.7.203-dev",
+    "previousPublishedDayTag": "v26.7.203-dev",
+    "compareRef": "HEAD",
+    "isLatestOfDay": true,
+    "sameDayTagsIncluded": [
+      "v26.7.301-dev"
+    ],
+    "relatedBuildTags": [
+      "v26.7.301-dev"
+    ],
+    "prNumbers": [
+      894,
+      897,
+      899,
+      903,
+      904,
+      905,
+      906,
+      908,
+      909,
+      910,
+      911,
+      912,
+      913,
+      914
+    ],
+    "commitSubjects": [
+      "fix: make runtime-health rotation compile on Linux by scoping libc to cfg(unix) (#914)",
+      "release: approve v26.7.300-dev",
+      "release: v26.7.300-dev",
+      "fix: mirror runtime-health into the soak dir so rotation cannot shrink the evidence window (#913)",
+      "feat: add --ready closeout flag to worktree-publish so finished PRs leave draft (#911)",
+      "fix: make the CI perf regression gate actually fail on regressions (#899)",
+      "chore: nest automation state under ~/.freed/automation (#912)",
+      "feat: add scripts/doctor.mjs machine preflight for loops and worktree helpers (#906)",
+      "chore: move automation loop state out of /tmp and auto-record merge outcomes (#903)",
+      "feat: loop counters for cloud uploads, relay broadcasts, worker INITs, scrape outcomes (stability P0-03) (#909)",
+      "feat: structured window_destroyed kill records (stability P0-02) (#905)",
+      "docs: rewrite ARCHITECTURE.md from current code, fix roadmap rule, add canonical soak doc (#907)",
+      "feat: check in soak collector and soak-assert with machine-readable verdict (#908)",
+      "feat: daily runtime-health rotation replacing the 5 MiB halving cap (stability P0-04) (#910)",
+      "feat: single-source provider-visible path list with publish-time enforcement (W1-06) (#904)",
+      "docs: add verification-counters step and outcome recording to freed-build-feature skill (W1-05) (#902)",
+      "docs: rewrite freed-ship-build skill against actual release scripts (W1-04) (#901)",
+      "fix: refine map time presets (#894)",
+      "fix: save content details in the background",
+      "fix: bound social loop diagnostics parsing (#897)",
+      "docs: add stability program plan with verified findings and task queue (#896)"
+    ]
+  },
+  "release": {
+    "deck": "Stability-instrumentation build: structured window-kill records, sync and worker loop counters, and daily runtime-health rotation to baseline the stability program's first overnight soak",
+    "features": [
+      "Structured window_destroyed kill records: every watchdog window teardown now logs a structured runtime-health record with the destruction reason (stability P0-02)",
+      "Loop counters for cloud uploads (including uploads with unchanged heads), relay broadcasts, Automerge worker INITs, and scrape outcomes (stability P0-03)",
+      "Daily runtime-health rotation replacing the 5 MiB halving cap, so long soaks keep a full evidence window (stability P0-04)"
+    ],
+    "fixes": [
+      "Runtime-health rotation now compiles on Linux (libc scoped to all unix targets)",
+      "The CI perf regression gate now fails on real regressions instead of always passing",
+      "Runtime-health is mirrored into the active soak directory so rotation cannot shrink soak evidence",
+      "Bounded social loop diagnostics parsing",
+      "Map time presets refined; content details save in the background"
+    ],
+    "followUps": [
+      "Soak collector and soak-assert scripts with a machine-readable verdict",
+      "scripts/doctor.mjs machine preflight for loops and worktree helpers",
+      "Automation loop state moved out of /tmp into ~/.freed/automation, with merge outcomes auto-recorded",
+      "Single-source provider-visible path list with publish-time enforcement (W1-06)",
+      "worktree-publish --ready closeout flag so finished PRs leave draft"
+    ]
+  },
+  "releaseBody": "(AI Generated).\n\n## Freed v26.7.301-dev\n\nStability-instrumentation build: structured window-kill records, sync and worker loop counters, and daily runtime-health rotation to baseline the stability program's first overnight soak.\n\n### Features\n\n- Structured window_destroyed kill records: every watchdog window teardown now logs a structured runtime-health record with the destruction reason (stability P0-02)\n- Loop counters for cloud uploads (including uploads with unchanged heads), relay broadcasts, Automerge worker INITs, and scrape outcomes (stability P0-03)\n- Daily runtime-health rotation replacing the 5 MiB halving cap, so long soaks keep a full evidence window (stability P0-04)\n\n### Fixes\n\n- Runtime-health rotation now compiles on Linux (libc scoped to all unix targets)\n- The CI perf regression gate now fails on real regressions instead of always passing\n- Runtime-health is mirrored into the active soak directory so rotation cannot shrink soak evidence\n- Bounded social loop diagnostics parsing\n- Map time presets refined; content details save in the background\n\n### Follow-ups\n\n- Soak collector and soak-assert scripts with a machine-readable verdict\n- scripts/doctor.mjs machine preflight for loops and worktree helpers\n- Automation loop state moved out of /tmp into ~/.freed/automation, with merge outcomes auto-recorded\n- Single-source provider-visible path list with publish-time enforcement (W1-06)\n- worktree-publish --ready closeout flag so finished PRs leave draft\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+}

--- a/release-notes/releases/v26.7.301-dev.md
+++ b/release-notes/releases/v26.7.301-dev.md
@@ -1,0 +1,35 @@
+(AI Generated).
+
+## Freed v26.7.301-dev
+
+Stability-instrumentation build: structured window-kill records, sync and worker loop counters, and daily runtime-health rotation to baseline the stability program's first overnight soak.
+
+### Features
+
+- Structured window_destroyed kill records: every watchdog window teardown now logs a structured runtime-health record with the destruction reason (stability P0-02)
+- Loop counters for cloud uploads (including uploads with unchanged heads), relay broadcasts, Automerge worker INITs, and scrape outcomes (stability P0-03)
+- Daily runtime-health rotation replacing the 5 MiB halving cap, so long soaks keep a full evidence window (stability P0-04)
+
+### Fixes
+
+- Runtime-health rotation now compiles on Linux (libc scoped to all unix targets)
+- The CI perf regression gate now fails on real regressions instead of always passing
+- Runtime-health is mirrored into the active soak directory so rotation cannot shrink soak evidence
+- Bounded social loop diagnostics parsing
+- Map time presets refined; content details save in the background
+
+### Follow-ups
+
+- Soak collector and soak-assert scripts with a machine-readable verdict
+- scripts/doctor.mjs machine preflight for loops and worktree helpers
+- Automation loop state moved out of /tmp into ~/.freed/automation, with merge outcomes auto-recorded
+- Single-source provider-visible path list with publish-time enforcement (W1-06)
+- worktree-publish --ready closeout flag so finished PRs leave draft
+
+### Downloads
+
+**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  
+**Windows:** `.exe` (NSIS installer)  
+**Linux:** `.AppImage`  
+
+> macOS downloads are signed and notarized for normal Gatekeeper installation.

--- a/website/public/atom.xml
+++ b/website/public/atom.xml
@@ -2,7 +2,7 @@
 <feed xmlns="http://www.w3.org/2005/Atom">
     <id>https://freed.wtf</id>
     <title>Freed Blog</title>
-    <updated>2026-06-18T06:10:45.541Z</updated>
+    <updated>2026-07-05T22:56:05.176Z</updated>
     <generator>https://github.com/jpmonette/feed</generator>
     <author>
         <name>The Freed Team</name>

--- a/website/public/feed.xml
+++ b/website/public/feed.xml
@@ -4,7 +4,7 @@
         <title>Freed Blog</title>
         <link>https://freed.wtf</link>
         <description>Progress reports, technical deep-dives, and philosophical rants about the attention economy. From the team building Freed.</description>
-        <lastBuildDate>Thu, 18 Jun 2026 06:10:45 GMT</lastBuildDate>
+        <lastBuildDate>Sun, 05 Jul 2026 22:56:05 GMT</lastBuildDate>
         <docs>https://validator.w3.org/feed/docs/rss2.html</docs>
         <generator>https://github.com/jpmonette/feed</generator>
         <language>en</language>

--- a/website/src/content/changelog.generated.json
+++ b/website/src/content/changelog.generated.json
@@ -1,11 +1,467 @@
 [
   {
-    "version": "26.6.1702-dev",
-    "tagName": "v26.6.1702-dev",
+    "version": "26.7.301-dev",
+    "tagName": "v26.7.301-dev",
     "channel": "dev",
-    "date": "2026-06-18T06:07:29Z",
-    "deck": "Move activity monitor to top toolbar, clipboard save shortcut, and reverse integrate v26.6.901 into dev",
+    "date": "2026-07-03T22:39:53Z",
+    "deck": "Stability-instrumentation build: structured window-kill records, sync and worker loop counters, and daily runtime-health rotation to baseline the stability program's first overnight soak",
     "features": [
+      {
+        "text": "Structured window_destroyed kill records: every watchdog window teardown now logs a structured runtime-health record with the destruction reason (stability P0-02)"
+      },
+      {
+        "text": "Loop counters for cloud uploads (including uploads with unchanged heads), relay broadcasts, Automerge worker INITs, and scrape outcomes (stability P0-03)"
+      },
+      {
+        "text": "Daily runtime-health rotation replacing the 5 MiB halving cap, so long soaks keep a full evidence window (stability P0-04)"
+      }
+    ],
+    "fixes": [
+      {
+        "text": "Runtime-health rotation now compiles on Linux (libc scoped to all unix targets)"
+      },
+      {
+        "text": "The CI perf regression gate now fails on real regressions instead of always passing"
+      },
+      {
+        "text": "Runtime-health is mirrored into the active soak directory so rotation cannot shrink soak evidence"
+      },
+      {
+        "text": "Bounded social loop diagnostics parsing"
+      },
+      {
+        "text": "Map time presets refined; content details save in the background"
+      }
+    ],
+    "followUps": [
+      {
+        "text": "Soak collector and soak-assert scripts with a machine-readable verdict"
+      },
+      {
+        "text": "scripts/doctor.mjs machine preflight for loops and worktree helpers"
+      },
+      {
+        "text": "Automation loop state moved out of /tmp into ~/.freed/automation, with merge outcomes auto-recorded"
+      },
+      {
+        "text": "Single-source provider-visible path list with publish-time enforcement (W1-06)"
+      },
+      {
+        "text": "worktree-publish --ready closeout flag so finished PRs leave draft"
+      }
+    ],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.7.301-dev",
+    "prNumbers": [
+      894,
+      897,
+      899,
+      903,
+      904,
+      905,
+      906,
+      908,
+      909,
+      910,
+      911,
+      912,
+      913,
+      914
+    ],
+    "builds": [
+      "26.7.301-dev"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.7.301-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.7.301-dev",
+        "channel": "dev"
+      }
+    ]
+  },
+  {
+    "version": "26.7.203-dev",
+    "tagName": "v26.7.203-dev",
+    "channel": "dev",
+    "date": "2026-07-02T23:31:18Z",
+    "deck": "Social scraping now has stronger memory recovery diagnostics, local loop locking, and zero-post failure reporting, with graph pin release validation stabilized",
+    "features": [
+      {
+        "text": "Map time range slider"
+      }
+    ],
+    "fixes": [
+      {
+        "text": "Social scrape memory preflight now records recovery state and avoids treating stale local memory deferrals as durable provider failures"
+      },
+      {
+        "text": "Facebook, Instagram, LinkedIn, and X scrape diagnostics now rank safe local next actions without increasing provider-visible traffic"
+      },
+      {
+        "text": "Instagram zero-post failures now surface in the local optimization loop even when runtime diagnostics are sparse"
+      },
+      {
+        "text": "Graph pin release validation now waits for Automerge persistence before reloading"
+      },
+      {
+        "text": "Worktree creation now sources the shared Node tooling helpers before running its preflight"
+      },
+      {
+        "text": "Release validation now removes a stale Azure CLI apt source before installing Playwright browser dependencies on GitHub-hosted Ubuntu runners"
+      }
+    ],
+    "followUps": [],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.7.203-dev",
+    "prNumbers": [],
+    "builds": [
+      "26.7.201-dev",
+      "26.7.203-dev"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.7.201-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.7.201-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.7.203-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.7.203-dev",
+        "channel": "dev"
+      }
+    ]
+  },
+  {
+    "version": "26.6.2901-dev",
+    "tagName": "v26.6.2901-dev",
+    "channel": "dev",
+    "date": "2026-06-29T23:38:31Z",
+    "deck": "Social sync memory cleanup now runs after failed provider scrapes",
+    "features": [],
+    "fixes": [
+      {
+        "text": "Run post-sync memory cleanup after Instagram placeholder-feed failures"
+      },
+      {
+        "text": "Recover reclaimable WebKit memory tails after social scrapes before later providers stall"
+      },
+      {
+        "text": "Report LinkedIn zero-event scrapes as IPC timeouts instead of successful empty feeds"
+      }
+    ],
+    "followUps": [],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.2901-dev",
+    "prNumbers": [],
+    "builds": [
+      "26.6.2900-dev",
+      "26.6.2901-dev"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.6.2900-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.2900-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.6.2901-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.2901-dev",
+        "channel": "dev"
+      }
+    ]
+  },
+  {
+    "version": "26.6.2804-dev",
+    "tagName": "v26.6.2804-dev",
+    "channel": "dev",
+    "date": "2026-06-29T05:38:56Z",
+    "deck": "Freed Desktop keeps locked installed sync soaks quiet and avoids waking WebKit while waiting for the workstation to unlock.",
+    "features": [],
+    "fixes": [
+      {
+        "text": "Destroy and rebuild the main WebView when idle WebKit memory is reclaimable but still resident."
+      },
+      {
+        "text": "Recover visible main-renderer WebKit resident tails once they cross the high-memory threshold."
+      },
+      {
+        "text": "Ignore stale age-matched WebKit process telemetry after a rebuild, which prevents repeated recovery loops and unnecessary background safe mode."
+      },
+      {
+        "text": "Record post-recovery memory verification so failed WebKit reclaim can be diagnosed from the health log."
+      },
+      {
+        "text": "Restart Freed Desktop when a renderer rebuild leaves the same main WebKit process above the high-memory line."
+      },
+      {
+        "text": "Keep post-scrape reclaimable WebKit resident-tail cleanup below the high-memory threshold from rebuilding the main renderer, so Instagram and LinkedIn retries do not trip recovery backoff while memory is still under budget."
+      },
+      {
+        "text": "Prevent the installed sync trigger helper from requeueing Instagram or LinkedIn during provider-safe cooldown windows."
+      },
+      {
+        "text": "Stop the native trigger watcher from replaying a request when the renderer rebuild happens after the provider run already finished."
+      },
+      {
+        "text": "Fail LinkedIn zero-post runs with local DOM diagnostics for candidate counts, activity URNs, login chrome, feed containers, and URL instead of treating them as successful empty syncs."
+      },
+      {
+        "text": "Slow locked-machine terminal sync trigger retries to 10 minutes, with an explicit long-soak timeout override for unattended testing."
+      },
+      {
+        "text": "Short-circuit locked-machine terminal sync triggers in native code before waking the main renderer, so locked soak retries do not inflate WebKit memory."
+      }
+    ],
+    "followUps": [],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.2804-dev",
+    "prNumbers": [],
+    "builds": [
+      "26.6.2800-dev",
+      "26.6.2801-dev",
+      "26.6.2802-dev",
+      "26.6.2803-dev",
+      "26.6.2804-dev"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.6.2800-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.2800-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.6.2801-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.2801-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.6.2802-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.2802-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.6.2803-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.2803-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.6.2804-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.2804-dev",
+        "channel": "dev"
+      }
+    ]
+  },
+  {
+    "version": "26.6.2703-dev",
+    "tagName": "v26.6.2703-dev",
+    "channel": "dev",
+    "date": "2026-06-28T05:21:40Z",
+    "deck": "Improves social sync reliability after renderer recovery",
+    "features": [],
+    "fixes": [
+      {
+        "text": "Prevents dev sync trigger recovery from launching a duplicate Facebook, Instagram, or LinkedIn sync while the original provider job is still finishing."
+      },
+      {
+        "text": "Recovers hidden main renderers when WebKit resident memory grows past the idle cap, so stale WebKit memory does not block social sync preflight."
+      },
+      {
+        "text": "Recovers dev sync triggers that were left waiting after Freed Desktop rebuilt the renderer at the end of a social sync."
+      },
+      {
+        "text": "Reduces desktop sync renderer pressure after long social sync runs."
+      }
+    ],
+    "followUps": [],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.2703-dev",
+    "prNumbers": [],
+    "builds": [
+      "26.6.2700-dev",
+      "26.6.2701-dev",
+      "26.6.2702-dev",
+      "26.6.2703-dev"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.6.2700-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.2700-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.6.2701-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.2701-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.6.2702-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.2702-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.6.2703-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.2703-dev",
+        "channel": "dev"
+      }
+    ]
+  },
+  {
+    "version": "26.6.2600-dev",
+    "tagName": "v26.6.2600-dev",
+    "channel": "dev",
+    "date": "2026-06-26T15:56:05Z",
+    "deck": "Freed now ships safer app recovery and steadier desktop validation.",
+    "features": [],
+    "fixes": [
+      {
+        "text": "Prevented the Linux social scraper window from crashing as it opens."
+      },
+      {
+        "text": "Cleaned up app recovery deferrals so Facebook, Instagram, and LinkedIn no longer show raw safe-mode timing noise in provider status."
+      },
+      {
+        "text": "Aligned LinkedIn feed sync with the shared social scrape queue so recovery pauses do not poison provider health or block later retries."
+      },
+      {
+        "text": "Reduced Friends graph interaction churn and stabilized desktop window compositing during recovery."
+      },
+      {
+        "text": "Pinned release-script Node routing, relaxed the scripted settings perf buffer that blocked the last dev build, and kept perf comparison comments from failing validation on read-only pull request tokens."
+      }
+    ],
+    "followUps": [],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.2600-dev",
+    "prNumbers": [],
+    "builds": [
+      "26.6.2600-dev"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.6.2600-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.2600-dev",
+        "channel": "dev"
+      }
+    ]
+  },
+  {
+    "version": "26.6.1810-dev",
+    "tagName": "v26.6.1810-dev",
+    "channel": "dev",
+    "date": "2026-06-18T18:33:53Z",
+    "deck": "Hot WebKit recovery and unattended sync validation",
+    "features": [],
+    "fixes": [
+      {
+        "text": "Freed Desktop now recovers CPU-hot multi-GB WebKit renderer growth before the global high-memory ceiling"
+      },
+      {
+        "text": "Facebook group refresh now reports group-list refresh state separately from Facebook post sync"
+      },
+      {
+        "text": "Release notes now honor pinned same-day highlights so latest dev builds keep required carry-forward items"
+      },
+      {
+        "text": "Release build and type-safety cleanup"
+      },
+      {
+        "text": "Reader, feed, and header polish"
+      },
+      {
+        "text": "Capture and scraper reliability fixes"
+      },
+      {
+        "text": "Terminal Facebook, Instagram, and LinkedIn sync triggers now fail zero-post, deferred, paused, or unauthenticated runs instead of reporting false success"
+      },
+      {
+        "text": "Sync trigger output now includes provider outcome details, post counts, added-item counts, and failure stage data so unattended runs can tell whether Facebook actually returned posts"
+      },
+      {
+        "text": "The quiet startup contract now records the occlusion recovery policy in native tests and the desktop phase notes"
+      }
+    ],
+    "followUps": [
+      {
+        "text": "Testing guidance policy"
+      },
+      {
+        "text": "Let installed dev sync soaks run without stealing focus"
+      },
+      {
+        "text": "No-focus sync validation hardening"
+      },
+      {
+        "text": "Consent-gated auth loading"
+      },
+      {
+        "text": "Honest terminal sync results"
+      }
+    ],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.1810-dev",
+    "prNumbers": [],
+    "builds": [
+      "26.6.1801-dev",
+      "26.6.1802-dev",
+      "26.6.1803-dev",
+      "26.6.1804-dev",
+      "26.6.1805-dev",
+      "26.6.1806-dev",
+      "26.6.1807-dev",
+      "26.6.1808-dev",
+      "26.6.1810-dev"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.6.1801-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.1801-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.6.1802-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.1802-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.6.1803-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.1803-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.6.1804-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.1804-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.6.1805-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.1805-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.6.1806-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.1806-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.6.1807-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.1807-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.6.1808-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.1808-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.6.1810-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.1810-dev",
+        "channel": "dev"
+      }
+    ]
+  },
+  {
+    "version": "26.6.1703-dev",
+    "tagName": "v26.6.1703-dev",
+    "channel": "dev",
+    "date": "2026-06-18T07:16:24Z",
+    "deck": "Run installed sync soaks from the terminal",
+    "features": [
+      {
+        "text": "Dev-channel prereleases now include a terminal helper for installed-build sync soaks"
+      },
       {
         "text": "Move activity monitor to top toolbar"
       },
@@ -14,6 +470,9 @@
       }
     ],
     "fixes": [
+      {
+        "text": "Enable dev release sync triggers"
+      },
       {
         "text": "Harden desktop sync recovery"
       },
@@ -25,6 +484,36 @@
       },
       {
         "text": "Repair PWA Google Drive sync resolution"
+      },
+      {
+        "text": "Prioritize nightly bug scans over stale peers"
+      },
+      {
+        "text": "Ignore generated peer artifacts in nightly planner"
+      },
+      {
+        "text": "Nightly validation regressions restored"
+      },
+      {
+        "text": "Production validation is now more stable"
+      },
+      {
+        "text": "Make safe mutations respond instantly"
+      },
+      {
+        "text": "Collapse toolbar feed controls"
+      },
+      {
+        "text": "Keep settings backdrop blurred while scrolling"
+      },
+      {
+        "text": "Align story grid top padding"
+      },
+      {
+        "text": "Polish mobile menu touch interactions"
+      },
+      {
+        "text": "Relax nightly preflight false blockers"
       }
     ],
     "followUps": [
@@ -32,7 +521,7 @@
         "text": "Merge latest dev after v26.6.1701-dev release prep"
       }
     ],
-    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.1702-dev",
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.1703-dev",
     "prNumbers": [
       793,
       795,
@@ -60,7 +549,8 @@
     "builds": [
       "26.6.1700-dev",
       "26.6.1701-dev",
-      "26.6.1702-dev"
+      "26.6.1702-dev",
+      "26.6.1703-dev"
     ],
     "buildLinks": [
       {
@@ -76,6 +566,11 @@
       {
         "version": "26.6.1702-dev",
         "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.1702-dev",
+        "channel": "dev"
+      },
+      {
+        "version": "26.6.1703-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.6.1703-dev",
         "channel": "dev"
       }
     ]


### PR DESCRIPTION
Static changelog refresh after the v26.7.301-dev dev-channel release published (freed-ship-build step 14 / freed-ship-www refresh mode).

- Copies the reviewed release-notes artifacts for v26.7.301-dev (and the 26.7.3 daily file) from `dev`
- Regenerates `changelog.generated.json` and the atom/rss feeds; picks up all releases published since the last refresh (v26.6.1702-dev)
- No merge/fast-forward of `www` to `dev`

Deploy via `./scripts/vercel-deploy-production.sh website` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)