### PR TITLE
chore: promote dev into main for production release

### DIFF
--- a/scripts/release-notes-shared.mjs
+++ b/scripts/release-notes-shared.mjs
@@ -54,6 +54,14 @@ const COMMON_ITEM_PREFIX =
   /^(feat|fix|perf|refactor|style|chore|docs|test|build|ci)(\([^)]+\))?!?:\s*/i;
 
 const SECTION_CONSOLIDATIONS = {
+  feature: {
+    build: "Release workflow and build-system work",
+    capture: "Capture, login, and scraping platform work",
+    ui: "Reader, sidebar, and settings UX work",
+    sync: "Sync, cloud, and pairing infrastructure",
+    tests: "Testing, diagnostics, and developer tooling",
+    content: "Content and documentation work",
+  },
   fix: {
     build: "Release build and type-safety cleanup",
     capture: "Capture and scraper reliability fixes",
@@ -971,7 +979,7 @@ export function removePreviousDayFeatureRepeats(release, previousDayRelease) {
 }
 
 function isCoveredByConsolidation(priorEntry, normalizedRelease) {
-  if (priorEntry.kind !== "fix" && priorEntry.kind !== "followUp") {
+  if (!["feature", "fix", "followUp"].includes(priorEntry.kind)) {
     return false;
   }
 
@@ -981,8 +989,9 @@ function isCoveredByConsolidation(priorEntry, normalizedRelease) {
     return false;
   }
 
-  const candidates =
-    priorEntry.kind === "fix" ? normalizedRelease.fixes : normalizedRelease.followUps;
+  const candidates = priorEntry.kind === "fix"
+    ? normalizedRelease.fixes
+    : [...normalizedRelease.features, ...normalizedRelease.followUps];
 
   return candidates.some((item) => areNearDuplicates(item, consolidatedText));
 }

--- a/scripts/release-notes-shared.test.mjs
+++ b/scripts/release-notes-shared.test.mjs
@@ -129,6 +129,48 @@ test("validateReleaseShape allows same-day consolidation for follow-ups", () => 
   assert.equal(result.errors.length, 0);
 });
 
+test("validateReleaseShape allows production carry-forward feature consolidation", () => {
+  const result = validateReleaseShape(
+    {
+      deck: "Capture stability and map controls",
+      features: [
+        "Map now uses a lower-left time range slider",
+        "Provider capture controls stay consent-gated",
+      ],
+      fixes: [],
+      followUps: [
+        "Capture, login, and scraping platform work",
+        "Reader, sidebar, and settings UX work",
+        "Testing, diagnostics, and developer tooling",
+      ],
+    },
+    {
+      earlierReleases: [
+        {
+          deck: "Consent-gated auth loading",
+          features: ["Consent-gated auth loading"],
+          fixes: [],
+          followUps: [],
+        },
+        {
+          deck: "Map time range slider",
+          features: ["Map time range slider"],
+          fixes: [],
+          followUps: [],
+        },
+        {
+          deck: "Structured window_destroyed kill records",
+          features: ["Structured window_destroyed kill records"],
+          fixes: [],
+          followUps: [],
+        },
+      ],
+    },
+  );
+
+  assert.equal(result.errors.length, 0);
+});
+
 test("validateReleaseShape rejects previous-day feature repeats", () => {
   const result = validateReleaseShape(
     {


### PR DESCRIPTION
(AI Generated).

## Summary
- Promote the release-note validator fix from dev into main before rerunning production release prep.

## Testing
- node scripts/validate-main-pr.mjs --base-ref=origin/main --head-ref=HEAD --head-branch=chore/promote-dev-to-main-release-notes-20260707
- node scripts/validate-release-promotion.mjs --from-ref=origin/dev --to-ref=HEAD