### PR TITLE
chore: promote dev into main for production release

### DIFF
--- a/scripts/prepare-release-notes.mjs
+++ b/scripts/prepare-release-notes.mjs
@@ -1139,6 +1139,7 @@ async function main() {
   const validation = validateReleaseShape(releaseWithPinnedHighlights, {
     earlierReleases: context.isLatestOfDay ? carriedForwardReleases : [],
     previousDayRelease,
+    allowEarlierFeatureOmission: channel === "production",
   });
 
   if (validation.errors.length > 0) {

--- a/scripts/release-notes-shared.mjs
+++ b/scripts/release-notes-shared.mjs
@@ -1116,6 +1116,9 @@ export function validateReleaseShape(release, options = {}) {
       );
 
       if (!isPresent && !isCoveredByConsolidation(priorEntry, normalized)) {
+        if (priorEntry.kind === "feature" && options.allowEarlierFeatureOmission) {
+          continue;
+        }
         errors.push(`Latest-of-day release is missing earlier same-day item: ${priorEntry.text}`);
       }
     }

--- a/scripts/release-notes-shared.test.mjs
+++ b/scripts/release-notes-shared.test.mjs
@@ -171,6 +171,37 @@ test("validateReleaseShape allows production carry-forward feature consolidation
   assert.equal(result.errors.length, 0);
 });
 
+test("validateReleaseShape can relax production carry-forward feature omissions", () => {
+  const release = {
+    deck: "Capture stability and map controls",
+    features: ["Provider capture controls stay consent-gated"],
+    fixes: [],
+    followUps: ["Release workflow and build-system work"],
+  };
+  const options = {
+    earlierReleases: [
+      {
+        deck: "Mobile pairing shipped",
+        features: ["Google Drive sync recovery"],
+        fixes: [],
+        followUps: [],
+      },
+    ],
+  };
+
+  assert.match(
+    validateReleaseShape(release, options).errors.join("\n"),
+    /missing earlier same-day item/i,
+  );
+  assert.equal(
+    validateReleaseShape(release, {
+      ...options,
+      allowEarlierFeatureOmission: true,
+    }).errors.length,
+    0,
+  );
+});
+
 test("validateReleaseShape rejects previous-day feature repeats", () => {
   const result = validateReleaseShape(
     {

--- a/scripts/validate-release-notes.mjs
+++ b/scripts/validate-release-notes.mjs
@@ -45,6 +45,7 @@ function main() {
   const result = validateReleaseShape(artifact.release ?? {}, {
     earlierReleases: priorArtifacts,
     previousDayRelease: previousDayArtifact?.release,
+    allowEarlierFeatureOmission: artifact.channel === "production",
   });
 
   if (result.errors.length > 0) {


### PR DESCRIPTION
(AI Generated).

## Summary
- Promote the production release-note carry-forward validation fix into main before preparing the release.

## Testing
- node scripts/validate-main-pr.mjs --base-ref=origin/main --head-ref=HEAD --head-branch=chore/promote-dev-to-main-release-notes-carry-forward-20260707
- node scripts/validate-release-promotion.mjs --from-ref=origin/dev --to-ref=HEAD