### PR TITLE
fix: relax production release note support omissions

### DIFF
--- a/scripts/prepare-release-notes.mjs
+++ b/scripts/prepare-release-notes.mjs
@@ -1139,7 +1139,7 @@ async function main() {
   const validation = validateReleaseShape(releaseWithPinnedHighlights, {
     earlierReleases: context.isLatestOfDay ? carriedForwardReleases : [],
     previousDayRelease,
-    allowEarlierFeatureOmission: channel === "production",
+    allowEarlierItemOmission: channel === "production",
   });
 
   if (validation.errors.length > 0) {

--- a/scripts/release-notes-shared.mjs
+++ b/scripts/release-notes-shared.mjs
@@ -1116,7 +1116,10 @@ export function validateReleaseShape(release, options = {}) {
       );
 
       if (!isPresent && !isCoveredByConsolidation(priorEntry, normalized)) {
-        if (priorEntry.kind === "feature" && options.allowEarlierFeatureOmission) {
+        if (
+          options.allowEarlierItemOmission ||
+          (priorEntry.kind === "feature" && options.allowEarlierFeatureOmission)
+        ) {
           continue;
         }
         errors.push(`Latest-of-day release is missing earlier same-day item: ${priorEntry.text}`);

--- a/scripts/release-notes-shared.test.mjs
+++ b/scripts/release-notes-shared.test.mjs
@@ -202,6 +202,37 @@ test("validateReleaseShape can relax production carry-forward feature omissions"
   );
 });
 
+test("validateReleaseShape can relax production carry-forward support omissions", () => {
+  const release = {
+    deck: "Capture stability and map controls",
+    features: ["Provider capture controls stay consent-gated"],
+    fixes: ["Scraper login prompts now stay open until the provider window closes"],
+    followUps: ["Release workflow and build-system work"],
+  };
+  const options = {
+    earlierReleases: [
+      {
+        deck: "Tooling and soak support",
+        features: [],
+        fixes: ["Soak collector and soak assert scripts with a machine readable verdict"],
+        followUps: ["Automation loop state moved out of tmp into Freed automation storage"],
+      },
+    ],
+  };
+
+  assert.match(
+    validateReleaseShape(release, options).errors.join("\n"),
+    /missing earlier same-day item/i,
+  );
+  assert.equal(
+    validateReleaseShape(release, {
+      ...options,
+      allowEarlierItemOmission: true,
+    }).errors.length,
+    0,
+  );
+});
+
 test("validateReleaseShape rejects previous-day feature repeats", () => {
   const result = validateReleaseShape(
     {

--- a/scripts/validate-release-notes.mjs
+++ b/scripts/validate-release-notes.mjs
@@ -45,7 +45,7 @@ function main() {
   const result = validateReleaseShape(artifact.release ?? {}, {
     earlierReleases: priorArtifacts,
     previousDayRelease: previousDayArtifact?.release,
-    allowEarlierFeatureOmission: artifact.channel === "production",
+    allowEarlierItemOmission: artifact.channel === "production",
   });
 
   if (result.errors.length > 0) {


### PR DESCRIPTION
(AI Generated).

## Summary
- allow production release-note validation to omit earlier dev support items from cumulative notes
- keep the existing feature-only option compatible for callers that still use it
- add coverage for omitted carry-forward fixes and follow-ups

## Testing
- source scripts/lib/node-tooling.sh && node --test scripts/release-notes-shared.test.mjs