### PR TITLE
chore: refresh website changelog for v26.7.700

### DIFF
--- a/website/public/atom.xml
+++ b/website/public/atom.xml
@@ -2,7 +2,7 @@
 <feed xmlns="http://www.w3.org/2005/Atom">
     <id>https://freed.wtf</id>
     <title>Freed Blog</title>
-    <updated>2026-07-05T22:56:05.176Z</updated>
+    <updated>2026-07-08T01:22:27.580Z</updated>
     <generator>https://github.com/jpmonette/feed</generator>
     <author>
         <name>The Freed Team</name>

--- a/website/public/feed.xml
+++ b/website/public/feed.xml
@@ -4,7 +4,7 @@
         <title>Freed Blog</title>
         <link>https://freed.wtf</link>
         <description>Progress reports, technical deep-dives, and philosophical rants about the attention economy. From the team building Freed.</description>
-        <lastBuildDate>Sun, 05 Jul 2026 22:56:05 GMT</lastBuildDate>
+        <lastBuildDate>Wed, 08 Jul 2026 01:22:27 GMT</lastBuildDate>
         <docs>https://validator.w3.org/feed/docs/rss2.html</docs>
         <generator>https://github.com/jpmonette/feed</generator>
         <language>en</language>

--- a/website/src/content/changelog.generated.json
+++ b/website/src/content/changelog.generated.json
@@ -1,5 +1,156 @@
 [
   {
+    "version": "26.7.700",
+    "tagName": "v26.7.700",
+    "channel": "production",
+    "date": "2026-07-08T01:20:00Z",
+    "deck": "Map controls, clipboard capture, and stronger sync diagnostics",
+    "features": [
+      {
+        "text": "Map now has a lower-left time range slider with all-time, today, and last-week shortcuts."
+      },
+      {
+        "text": "Freed Desktop adds a clipboard save shortcut and moves activity monitoring into the top toolbar."
+      },
+      {
+        "text": "Installed sync soaks now produce structured runtime-health evidence with loop counters and window recovery records."
+      }
+    ],
+    "fixes": [
+      {
+        "text": "Provider scrape recovery now records memory pressure, zero-post failures, and safe local next actions without adding provider traffic."
+      },
+      {
+        "text": "Instagram, Facebook, LinkedIn, and X diagnostics now separate local stalls from provider failures more clearly."
+      },
+      {
+        "text": "Map presets, graph pins, and content-detail saves now wait for durable state before reloads."
+      },
+      {
+        "text": "Production validation now catches real performance regressions and uses the pinned Node toolchain on runners."
+      }
+    ],
+    "followUps": [
+      {
+        "text": "Capture release checks now use a shared provider-safety path list and require recorded owner approval before higher-risk capture changes publish."
+      },
+      {
+        "text": "Soak and automation state now lives under Freed automation storage with machine-readable verdicts."
+      },
+      {
+        "text": "Freed Desktop provider sync soaks now avoid duplicate traffic and record when LinkedIn returns zero posts."
+      }
+    ],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.7.700",
+    "prNumbers": [
+      746,
+      793,
+      795,
+      796,
+      797,
+      799,
+      801,
+      804,
+      806,
+      809,
+      810,
+      811,
+      812,
+      818,
+      819,
+      820,
+      823,
+      826,
+      829,
+      830,
+      831,
+      832,
+      836,
+      840,
+      841,
+      842,
+      843,
+      844,
+      845,
+      846,
+      847,
+      848,
+      849,
+      850,
+      851,
+      852,
+      854,
+      855,
+      856,
+      857,
+      858,
+      859,
+      860,
+      861,
+      862,
+      863,
+      864,
+      865,
+      866,
+      867,
+      868,
+      869,
+      870,
+      871,
+      872,
+      873,
+      874,
+      875,
+      876,
+      877,
+      878,
+      879,
+      880,
+      881,
+      882,
+      883,
+      884,
+      885,
+      886,
+      887,
+      888,
+      889,
+      890,
+      891,
+      892,
+      893,
+      894,
+      895,
+      897,
+      899,
+      903,
+      904,
+      905,
+      906,
+      908,
+      909,
+      910,
+      911,
+      912,
+      913,
+      914,
+      918,
+      921,
+      923,
+      925
+    ],
+    "builds": [
+      "26.7.700"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.7.700",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.7.700",
+        "channel": "production"
+      }
+    ]
+  },
+  {
     "version": "26.7.301-dev",
     "tagName": "v26.7.301-dev",
     "channel": "dev",


### PR DESCRIPTION
(AI Generated). 

## Summary
- Refresh the generated website changelog after the v26.7.700 production release published.
- Regenerate public feed timestamps from the website build.

## Tests
- cd website && source ../scripts/lib/node-tooling.sh && PATH=../node_modules/.bin:$PATH npm run build