### PR TITLE
docs: record W2-01 cloud_loop positive control confirmed

### DIFF
--- a/docs/STABILITY-PROGRAM.md
+++ b/docs/STABILITY-PROGRAM.md
@@ -54,7 +54,7 @@ Done when: every counter in the scorecard below has a baseline number from one o
 | [P1-03](stability-tasks/P1-03-gdrive-self-write-filter.md) | GDrive self-write filtering + no-op upload skip | no | ☐ |
 | [P1-04](stability-tasks/P1-04-preflight-recycle-guard.md) | Preflight recycle guard + login-in-progress latch | no | ☐ |
 | [P1-05](stability-tasks/P1-05-recovery-invoke-latch.md) | Recovery never outruns a scrape invoke; persist lastScrapeAt | no | ☐ |
-| [W2-01](stability-tasks/W2-01-invariant-alarms.md) | Invariant alarms: cloud_loop, scrape_zero_persist, preflight_kill, auth_zombie, relay_divergence, watchdog_thrash | no | ◐ observing (breakers + relay_divergence deferred) |
+| [W2-01](stability-tasks/W2-01-invariant-alarms.md) | Invariant alarms: cloud_loop, scrape_zero_persist, preflight_kill, auth_zombie, relay_divergence, watchdog_thrash | no | ◐ observing — cloud_loop positive control CONFIRMED (v26.7.701-dev); breakers + relay_divergence deferred |
 | [W2-02](stability-tasks/W2-02-triage-loop.md) | Triage loop: alarms + canary + red CI → ranked task files; CI-failure issue hook | yes | ☐ |
 | [W2-03](stability-tasks/W2-03-canary-replay-bisect.md) | canary-summarize, watchdog-replay, bisect-regression scripts | yes | ☐ |
 | [W2-04](stability-tasks/W2-04-new-skills.md) | New skills: freed-soak, freed-triage, freed-canary | yes | ☐ |
@@ -112,7 +112,7 @@ Baseline measured 2026-07-07 from a 6.05 h idle overnight soak of v26.7.301-dev 
 | Dead-session WebView spins/day/provider | night's single scheduled sweep: li 1 full 100 s WebView spin → event_timeout, x 1 api_error (auth misclassification, F-auth theme) | ≤3 then pause+prompt |
 | Worker INITs/hour during content backlog | 19.3/h while idle (117 / 6.05 h); 82/h during launch-hour backlog | <10 |
 | Renderer recoveries/day (thresholds frozen) | 1 attempt / 6 h idle (≈4/day); launch hour: 5 attempts + 3 restart requests in 57 min, ending in silent app death | →0 |
-| invariant_alarms/day by name (W2-01) | pending first alarm-build soak (cloud_loop expected to fire as positive control) | each →0 as its damper lands |
+| invariant_alarms/day by name (W2-01) | cloud_loop CONFIRMED firing on v26.7.701-dev — tripped ~3 min into the elevated post-launch upload burst ("5 uploads with unchanged heads in 15 min"); soak-assert `invariant_alarms: cloud_loop=1` alongside `uploads_unchanged_heads` FAIL (5/6). Note: threshold is 5-in-15min (~20/h); deep-idle drip was ~11/h, so cloud_loop is burst-triggered and may sit below threshold in steady idle | each →0 as its damper lands |
 | fix:/perf: share of non-release commits | ~78% | trending down |
 
 ## What NOT to do


### PR DESCRIPTION
(AI Generated).

Records the result of the first W2-01 alarm-build soak (v26.7.701-dev, dev channel). Docs only — no product change.

## Positive control: confirmed
The `cloud_loop` invariant alarm **fires** against the same idle cloud loop the Wave-1 baseline measured (11.1 uploads/h at 96% heads-unchanged). It tripped **~3 min into the elevated post-launch upload burst**:

> `{"name":"cloud_loop","action":"observe","detail":"5 cloud uploads with unchanged heads in the last 15 min (F01/F06 cloud loop)","provider":"gdrive", ...}`

Cross-confirmed two ways in the same soak:
- **Runtime monitor** emitted the `invariant_alarm` record, `action:"observe"` (no behavioral change, as designed).
- **soak-assert** independently: `[PASS] invariant_alarms: cloud_loop=1` (informational) alongside `[FAIL] uploads_unchanged_heads: 5 of 6 uploads had unchanged heads`.

This closes W2-01's verification loop: the alarm observes the live pathology as a positive control. P1-01's damper is what flips it to zero on the next cycle — and this soak is that "before" baseline.

## Threshold finding (recorded, not retuned)
`cloud_loop` trips at 5-unchanged-in-15-min (~20/h sustained). The baseline **deep-idle** rate was ~11/h (~2.75 per 15-min window), below threshold — so the alarm is **burst-triggered** and may sit below threshold in steady idle. Not a monitor bug; a calibration note for the breaker/threshold work in a later cycle.

Scorecard `invariant_alarms/day` line and the W2-01 status row updated accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)