### PR TITLE
chore: refresh changelog for v26.7.800-dev

### DIFF
--- a/release-notes/daily/dev/26.7.8.json
+++ b/release-notes/daily/dev/26.7.8.json
@@ -1,0 +1,14 @@
+{
+  "channel": "dev",
+  "dayKey": "26.7.8",
+  "date": "2026-07-08",
+  "preferredDeck": null,
+  "editorialGuidance": [
+    "Keep the tone concise, professional, and specific.",
+    "Lead with user-facing outcomes, shipping milestones, trust wins, and installability improvements.",
+    "Demote internal cleanup unless it clearly changes the shipped product."
+  ],
+  "pinnedHighlights": [],
+  "editorialNotes": [],
+  "updatedAt": "2026-07-08T17:00:13.310Z"
+}

--- a/release-notes/releases/v26.7.800-dev.json
+++ b/release-notes/releases/v26.7.800-dev.json
@@ -1,0 +1,48 @@
+{
+  "tag": "v26.7.800-dev",
+  "version": "26.7.800-dev",
+  "channel": "dev",
+  "dayKey": "26.7.8",
+  "approved": true,
+  "editorialNotes": [
+    "Reviewed 2026-07-08: replaced the heuristic fallback copy with specific notes for Automerge worker recovery, v26.7.700 release-note parity, and the lifecycle fixture build fix."
+  ],
+  "generatedAt": "2026-07-08T17:00:13.310Z",
+  "model": "heuristic",
+  "source": {
+    "channel": "dev",
+    "previousPublishedTag": "v26.7.701-dev",
+    "previousPublishedDayTag": "v26.7.701-dev",
+    "compareRef": "HEAD",
+    "isLatestOfDay": true,
+    "sameDayTagsIncluded": [
+      "v26.7.800-dev"
+    ],
+    "relatedBuildTags": [
+      "v26.7.800-dev"
+    ],
+    "prNumbers": [
+      927,
+      929,
+      932
+    ],
+    "commitSubjects": [
+      "fix: restore automerge lifecycle test build (#932)",
+      "chore: merge main back into dev after v26.7.700 (#929)",
+      "fix: recover Automerge worker startup failures (#927)",
+      "docs: record W2-01 full pre-damper baseline from 6.23h soak (#931)",
+      "docs: record W2-01 cloud_loop positive control confirmed (#930)"
+    ]
+  },
+  "release": {
+    "deck": "Automerge worker recovery, v26.7.700 release-note parity, and restored dev validation",
+    "features": [],
+    "fixes": [
+      "Automerge worker startup failures now reset the failed worker, retry the active document request once, reject pending worker requests on runtime failure, and record worker_start_failed or worker_runtime_failed runtime-health events for future soaks",
+      "Dev now carries the v26.7.700 production release-note artifacts back from main, keeping release history aligned across branches",
+      "The Automerge worker lifecycle test fixture now includes the required user-state tags field, so root build and dev Validation compile cleanly after the worker recovery fix"
+    ],
+    "followUps": []
+  },
+  "releaseBody": "(AI Generated).\n\n## Freed v26.7.800-dev\n\nAutomerge worker recovery, v26.7.700 release-note parity, and restored dev validation.\n\n### Fixes\n\n- Automerge worker startup failures now reset the failed worker, retry the active document request once, reject pending worker requests on runtime failure, and record worker_start_failed or worker_runtime_failed runtime-health events for future soaks\n- Dev now carries the v26.7.700 production release-note artifacts back from main, keeping release history aligned across branches\n- The Automerge worker lifecycle test fixture now includes the required user-state tags field, so root build and dev Validation compile cleanly after the worker recovery fix\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+}

--- a/release-notes/releases/v26.7.800-dev.md
+++ b/release-notes/releases/v26.7.800-dev.md
@@ -1,0 +1,19 @@
+(AI Generated).
+
+## Freed v26.7.800-dev
+
+Automerge worker recovery, v26.7.700 release-note parity, and restored dev validation.
+
+### Fixes
+
+- Automerge worker startup failures now reset the failed worker, retry the active document request once, reject pending worker requests on runtime failure, and record worker_start_failed or worker_runtime_failed runtime-health events for future soaks
+- Dev now carries the v26.7.700 production release-note artifacts back from main, keeping release history aligned across branches
+- The Automerge worker lifecycle test fixture now includes the required user-state tags field, so root build and dev Validation compile cleanly after the worker recovery fix
+
+### Downloads
+
+**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  
+**Windows:** `.exe` (NSIS installer)  
+**Linux:** `.AppImage`  
+
+> macOS downloads are signed and notarized for normal Gatekeeper installation.

--- a/website/public/atom.xml
+++ b/website/public/atom.xml
@@ -2,7 +2,7 @@
 <feed xmlns="http://www.w3.org/2005/Atom">
     <id>https://freed.wtf</id>
     <title>Freed Blog</title>
-    <updated>2026-07-08T01:22:27.580Z</updated>
+    <updated>2026-07-08T17:45:24.124Z</updated>
     <generator>https://github.com/jpmonette/feed</generator>
     <author>
         <name>The Freed Team</name>

--- a/website/public/feed.xml
+++ b/website/public/feed.xml
@@ -4,7 +4,7 @@
         <title>Freed Blog</title>
         <link>https://freed.wtf</link>
         <description>Progress reports, technical deep-dives, and philosophical rants about the attention economy. From the team building Freed.</description>
-        <lastBuildDate>Wed, 08 Jul 2026 01:22:27 GMT</lastBuildDate>
+        <lastBuildDate>Wed, 08 Jul 2026 17:45:24 GMT</lastBuildDate>
         <docs>https://validator.w3.org/feed/docs/rss2.html</docs>
         <generator>https://github.com/jpmonette/feed</generator>
         <language>en</language>

--- a/website/src/content/changelog.generated.json
+++ b/website/src/content/changelog.generated.json
@@ -1,5 +1,75 @@
 [
   {
+    "version": "26.7.800-dev",
+    "tagName": "v26.7.800-dev",
+    "channel": "dev",
+    "date": "2026-07-08T17:41:30Z",
+    "deck": "Automerge worker recovery, v26.7.700 release-note parity, and restored dev validation",
+    "features": [],
+    "fixes": [
+      {
+        "text": "Automerge worker startup failures now reset the failed worker, retry the active document request once, reject pending worker requests on runtime failure, and record worker_start_failed or worker_runtime_failed runtime-health events for future soaks"
+      },
+      {
+        "text": "Dev now carries the v26.7.700 production release-note artifacts back from main, keeping release history aligned across branches"
+      },
+      {
+        "text": "The Automerge worker lifecycle test fixture now includes the required user-state tags field, so root build and dev Validation compile cleanly after the worker recovery fix"
+      }
+    ],
+    "followUps": [],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.7.800-dev",
+    "prNumbers": [
+      927,
+      929,
+      932
+    ],
+    "builds": [
+      "26.7.800-dev"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.7.800-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.7.800-dev",
+        "channel": "dev"
+      }
+    ]
+  },
+  {
+    "version": "26.7.701-dev",
+    "tagName": "v26.7.701-dev",
+    "channel": "dev",
+    "date": "2026-07-08T02:00:36Z",
+    "deck": "Stability W2-01: a passive invariant-alarm monitor that names verified pathologies loudly in the runtime-health log instead of letting them loop silently.",
+    "features": [
+      {
+        "text": "Invariant-alarm monitor (stability W2-01): watches the runtime-health event stream and raises named invariant_alarm records with a runbook string when a verified pathology signature trips , cloud_loop (idle cloud upload loop), scrape_zero_persist, preflight_kill, watchdog_thrash, and an auth_zombie heuristic"
+      }
+    ],
+    "fixes": [
+      {
+        "text": "Release-note validation relaxed for production carry-forward, feature consolidation, and support omissions"
+      }
+    ],
+    "followUps": [
+      {
+        "text": "Alarms are observation-only this build; their circuit breakers land next, one per soak cycle, so each alarm first observes its pathology as a positive control"
+      }
+    ],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.7.701-dev",
+    "prNumbers": [],
+    "builds": [
+      "26.7.701-dev"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.7.701-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.7.701-dev",
+        "channel": "dev"
+      }
+    ]
+  },
+  {
     "version": "26.7.700",
     "tagName": "v26.7.700",
     "channel": "production",


### PR DESCRIPTION
(AI Generated). 

## Summary
- add the v26.7.800-dev release-note artifacts to www
- regenerate the website changelog snapshot and public feeds

## Validation
- npm run build from website with the repo hoisted binary path
- npx tsx src/content/changelog.test.ts