### PR TITLE
feat: break the desktop cloud upload loop (mutation filter + heads guard, stability P1-01)

### DIFF
--- a/docs/stability-tasks/P1-01-cloud-loop-damper-desktop.md
+++ b/docs/stability-tasks/P1-01-cloud-loop-damper-desktop.md
@@ -20,3 +20,12 @@ Desktop cloud scheduling only. Worst failure: a missed upload, bounded by the ne
 
 - Unit tests: MERGE_DOC event does not schedule; local mutation does; merge-that-changes-heads does.
 - Soak (idle overnight, GDrive connected): uploads/hour with headsUnchanged=true drops from the P0-03 baseline (hundreds) to ~single digits; idle WebKit footprint slope flattens vs baseline soak.
+
+## Implementation notes (2026-07-08 build)
+
+- Subscriber filter is heads-qualified, not unconditional: MERGE_DOC/REPLACE_DOC events schedule only when heads moved past the last successful upload — this is how "a genuine merge must still upload" and "the merge-back echo must not" coexist.
+- Post-upload heads are recorded AFTER the safe-upload merge-back settles, so the recorded heads are exactly the state the cloud holds and the echo event compares equal.
+- Execution-time re-check inside performCloudUpload (cause=subscriber only) closes the debounce race where the echo event arms the timer before the post-upload record lands. Manual "Sync now" and authoritative replaces always upload.
+- Invalidation: deleteCloudFile and an empty initial download clear the recorded heads so a reconnect can never be suppressed into leaving the cloud empty.
+- New runtime-health counter `cloud_upload_skipped` (reason: merge_heads_unchanged | execution_heads_unchanged): a healthy damper shows skips replacing unchanged-heads attempts; zero attempts AND zero skips would mean sync is broken, not damped.
+- Frozen pre-damper baseline (soaks/2026-07-08-0202, 6.23h): uploads_unchanged_heads 98/102 (~16/h), cloud_loop alarm ×7. Post-merge soak must show cloud_loop→0 and unchanged-heads uploads →~single digits/h.

--- a/packages/desktop/src/lib/cloud-loop-damper.test.ts
+++ b/packages/desktop/src/lib/cloud-loop-damper.test.ts
@@ -1,0 +1,302 @@
+/**
+ * P1-01: break the desktop cloud upload loop (stability findings F01/F06).
+ *
+ * The verified defect: after every safe upload the caller merges the uploaded
+ * binary back; MERGE_DOC emits a STATE_UPDATE; the cloud subscriber scheduled
+ * an upload on EVERY state event, so upload→merge→state-update→upload ran
+ * forever on idle machines. The damper (a) stops MERGE_DOC/REPLACE_DOC events
+ * from scheduling unless the doc heads moved past the last successful upload,
+ * and (b) re-checks heads when a debounced subscriber upload fires. Manual
+ * "Sync now" and authoritative replaces are exempt.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { DocChangeEvent, DocState } from "./automerge-types";
+
+const invokeMock = vi.fn();
+const gdriveDownloadLatestMock = vi.fn();
+const gdriveStartPollLoopMock = vi.fn();
+const subscribeMock = vi.fn((_callback: (state: DocState, event: DocChangeEvent) => void) => vi.fn());
+const recordProviderHealthEventMock = vi.fn();
+const updateCloudProviderMock = vi.fn();
+const recordCloudProviderEventMock = vi.fn();
+const gdriveUploadSafeMock = vi.fn();
+const gdriveUploadReplaceMock = vi.fn();
+const gdriveDeleteFileMock = vi.fn();
+const getDocBinaryMock = vi.fn(async () => new Uint8Array([1, 2, 3]));
+const getDocHeadsMock = vi.fn(async (): Promise<string[] | null> => ["h1"]);
+const mergeDocMock = vi.fn(async () => {});
+const recordCloudUploadAttemptMock = vi.fn();
+const recordCloudUploadSkippedMock = vi.fn();
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke: invokeMock }));
+vi.mock("@tauri-apps/api/event", () => ({ listen: vi.fn() }));
+vi.mock("@tauri-apps/plugin-shell", () => ({ open: vi.fn() }));
+
+vi.mock("@freed/sync/cloud", () => ({
+  gdriveDownloadLatest: gdriveDownloadLatestMock,
+  gdriveStartPollLoop: gdriveStartPollLoopMock,
+  gdriveUploadSafe: gdriveUploadSafeMock,
+  gdriveUploadReplace: gdriveUploadReplaceMock,
+  gdriveDeleteFile: gdriveDeleteFileMock,
+  dropboxDownloadLatest: vi.fn(),
+  dropboxStartLongpollLoop: vi.fn(),
+  dropboxUploadSafe: vi.fn(),
+  dropboxUploadReplace: vi.fn(),
+  dropboxDeleteFile: vi.fn(),
+}));
+
+vi.mock("./automerge", () => ({
+  getDocBinary: getDocBinaryMock,
+  getDocHeads: getDocHeadsMock,
+  mergeDoc: mergeDocMock,
+  replaceLocalDoc: vi.fn(),
+  setRelayClientCount: vi.fn(),
+  subscribe: subscribeMock,
+}));
+
+vi.mock("./runtime-health-events", () => ({
+  recordCloudUploadAttempt: recordCloudUploadAttemptMock,
+  recordCloudUploadSkipped: recordCloudUploadSkippedMock,
+}));
+
+vi.mock("@freed/ui/lib/debug-store", () => ({
+  addDebugEvent: vi.fn(),
+  recordCloudProviderEvent: recordCloudProviderEventMock,
+  updateCloudProvider: updateCloudProviderMock,
+}));
+
+vi.mock("./logger.js", () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("./provider-health", () => ({
+  recordProviderHealthEvent: recordProviderHealthEventMock,
+}));
+
+function docState(): DocState {
+  return {} as DocState;
+}
+
+function changeEvent(mutation: DocChangeEvent["mutation"]): DocChangeEvent {
+  return { source: "state_update", mutation, changedItemIds: null, requiresFullScan: true };
+}
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+async function startSyncAndCaptureSubscriber(): Promise<(event: DocChangeEvent) => void> {
+  const { startCloudSync, storeCloudToken } = await import("./sync");
+  storeCloudToken("gdrive", {
+    accessToken: "valid-access-token",
+    refreshToken: "refresh-token",
+    expiresAt: Date.now() + 3_600_000,
+  });
+  gdriveDownloadLatestMock.mockResolvedValue(null);
+  gdriveStartPollLoopMock.mockResolvedValue(undefined);
+  await startCloudSync("gdrive", "valid-access-token");
+  expect(subscribeMock).toHaveBeenCalledTimes(1);
+  const callback = subscribeMock.mock.calls[0][0];
+  return (event) => callback(docState(), event);
+}
+
+function expectUploadQueued(times: number): void {
+  const queued = updateCloudProviderMock.mock.calls.filter(
+    ([, update]) => (update as { statusMessage?: string }).statusMessage === "Upload queued.",
+  );
+  expect(queued).toHaveLength(times);
+}
+
+describe("P1-01 desktop cloud upload loop damper", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.useRealTimers();
+    vi.stubEnv("VITE_GDRIVE_TOKEN_PROXY_URL", "https://app.freed.wtf/api/oauth/google");
+    vi.stubEnv(
+      "VITE_GDRIVE_DESKTOP_CLIENT_ID",
+      "304530272769-fkbpan1l071vdvum1j6kufvo8rbq6sm1.apps.googleusercontent.com",
+    );
+    for (const mock of [
+      invokeMock,
+      gdriveDownloadLatestMock,
+      gdriveStartPollLoopMock,
+      recordProviderHealthEventMock,
+      updateCloudProviderMock,
+      recordCloudProviderEventMock,
+      gdriveUploadSafeMock,
+      gdriveUploadReplaceMock,
+      gdriveDeleteFileMock,
+      recordCloudUploadAttemptMock,
+      recordCloudUploadSkippedMock,
+      mergeDocMock,
+    ]) {
+      mock.mockReset();
+    }
+    subscribeMock.mockClear();
+    getDocHeadsMock.mockReset();
+    getDocHeadsMock.mockResolvedValue(["h1"]);
+    getDocBinaryMock.mockClear();
+    localStorage.clear();
+    const coordinator = await import("./background-runtime-coordinator");
+    coordinator.resetBackgroundRuntimeForTests({ requireRendererHealth: false });
+  });
+
+  afterEach(async () => {
+    const sync = await import("./sync");
+    sync.stopAllCloudSyncs();
+    vi.unstubAllEnvs();
+    localStorage.clear();
+  });
+
+  it("local mutations still schedule an upload", async () => {
+    const emit = await startSyncAndCaptureSubscriber();
+    updateCloudProviderMock.mockClear();
+
+    emit(changeEvent("ADD_PERSON"));
+    await flush();
+
+    expectUploadQueued(1);
+    expect(recordCloudUploadSkippedMock).not.toHaveBeenCalled();
+  });
+
+  it("MERGE_DOC with unchanged heads after a successful upload does not schedule (the loop edge)", async () => {
+    const emit = await startSyncAndCaptureSubscriber();
+
+    // A successful upload whose merge-back settles at heads h-uploaded.
+    getDocHeadsMock.mockResolvedValue(["h-uploaded"]);
+    gdriveUploadSafeMock.mockResolvedValue({
+      fileId: "file-1",
+      uploadedBinary: new Uint8Array([9]),
+      uploadedBytes: 1,
+      remoteBytes: 1,
+      mergedRemote: true,
+    });
+    const { syncCloudProviderNow } = await import("./sync");
+    await syncCloudProviderNow("gdrive");
+    expect(mergeDocMock).toHaveBeenCalledTimes(1);
+    updateCloudProviderMock.mockClear();
+
+    // The merge-back's own MERGE_DOC event arrives with identical heads.
+    emit(changeEvent("MERGE_DOC"));
+    await flush();
+
+    expectUploadQueued(0);
+    expect(recordCloudUploadSkippedMock).toHaveBeenCalledWith({
+      provider: "gdrive",
+      cause: "subscriber",
+      reason: "merge_heads_unchanged",
+    });
+  });
+
+  it("a genuine merge that moves the heads still schedules an upload", async () => {
+    const emit = await startSyncAndCaptureSubscriber();
+
+    getDocHeadsMock.mockResolvedValue(["h-uploaded"]);
+    gdriveUploadSafeMock.mockResolvedValue({
+      fileId: "file-1",
+      uploadedBinary: new Uint8Array([9]),
+      uploadedBytes: 1,
+      remoteBytes: 1,
+      mergedRemote: false,
+    });
+    const { syncCloudProviderNow } = await import("./sync");
+    await syncCloudProviderNow("gdrive");
+    updateCloudProviderMock.mockClear();
+
+    // Remote data merged later moves the heads past the recorded upload.
+    getDocHeadsMock.mockResolvedValue(["h-uploaded", "h-remote"]);
+    emit(changeEvent("MERGE_DOC"));
+    await flush();
+
+    expectUploadQueued(1);
+    expect(recordCloudUploadSkippedMock).not.toHaveBeenCalled();
+  });
+
+  it("REPLACE_DOC follows the same heads guard as MERGE_DOC", async () => {
+    const emit = await startSyncAndCaptureSubscriber();
+
+    getDocHeadsMock.mockResolvedValue(["h-uploaded"]);
+    gdriveUploadSafeMock.mockResolvedValue({
+      fileId: "file-1",
+      uploadedBinary: new Uint8Array([9]),
+      uploadedBytes: 1,
+      remoteBytes: 1,
+      mergedRemote: false,
+    });
+    const { syncCloudProviderNow } = await import("./sync");
+    await syncCloudProviderNow("gdrive");
+    updateCloudProviderMock.mockClear();
+
+    emit(changeEvent("REPLACE_DOC"));
+    await flush();
+
+    expectUploadQueued(0);
+    expect(recordCloudUploadSkippedMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("MERGE_DOC before any successful upload schedules (no recorded heads yet)", async () => {
+    const emit = await startSyncAndCaptureSubscriber();
+    updateCloudProviderMock.mockClear();
+
+    emit(changeEvent("MERGE_DOC"));
+    await flush();
+
+    expectUploadQueued(1);
+    expect(recordCloudUploadSkippedMock).not.toHaveBeenCalled();
+  });
+
+  it("heads lookup failure fails open: the upload is scheduled", async () => {
+    const emit = await startSyncAndCaptureSubscriber();
+    getDocHeadsMock.mockRejectedValue(new Error("worker unavailable"));
+    updateCloudProviderMock.mockClear();
+
+    emit(changeEvent("MERGE_DOC"));
+    await flush();
+
+    expectUploadQueued(1);
+    expect(recordCloudUploadSkippedMock).not.toHaveBeenCalled();
+  });
+
+  it("manual Sync now always uploads even with unchanged heads", async () => {
+    await startSyncAndCaptureSubscriber();
+    getDocHeadsMock.mockResolvedValue(["h-uploaded"]);
+    gdriveUploadSafeMock.mockResolvedValue({
+      fileId: "file-1",
+      uploadedBinary: new Uint8Array([9]),
+      uploadedBytes: 1,
+      remoteBytes: 1,
+      mergedRemote: false,
+    });
+    const { syncCloudProviderNow } = await import("./sync");
+
+    await syncCloudProviderNow("gdrive");
+    await syncCloudProviderNow("gdrive");
+
+    expect(gdriveUploadSafeMock).toHaveBeenCalledTimes(2);
+    expect(recordCloudUploadSkippedMock).not.toHaveBeenCalled();
+  });
+
+  it("deleteCloudFile clears the recorded heads so the next merge event uploads again", async () => {
+    const emit = await startSyncAndCaptureSubscriber();
+
+    getDocHeadsMock.mockResolvedValue(["h-uploaded"]);
+    gdriveUploadSafeMock.mockResolvedValue({
+      fileId: "file-1",
+      uploadedBinary: new Uint8Array([9]),
+      uploadedBytes: 1,
+      remoteBytes: 1,
+      mergedRemote: false,
+    });
+    const sync = await import("./sync");
+    await sync.syncCloudProviderNow("gdrive");
+
+    await sync.deleteCloudFile("gdrive", "valid-access-token");
+    updateCloudProviderMock.mockClear();
+
+    // Same heads as the recorded upload, but the cloud file is gone — the
+    // guard must not suppress re-seeding the cloud.
+    emit(changeEvent("MERGE_DOC"));
+    await flush();
+
+    expectUploadQueued(1);
+    expect(recordCloudUploadSkippedMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/desktop/src/lib/runtime-health-events.ts
+++ b/packages/desktop/src/lib/runtime-health-events.ts
@@ -48,6 +48,20 @@ export function recordCloudUploadAttempt(input: {
 }
 
 /**
+ * One line per cloud upload the P1-01 damper skipped because the doc heads
+ * had not moved since the last successful upload. A healthy damper shows
+ * skips replacing the unchanged-heads attempts counted above; a broken sync
+ * would instead show zero attempts AND zero skips.
+ */
+export function recordCloudUploadSkipped(input: {
+  provider: string;
+  cause: CloudUploadCause;
+  reason: "merge_heads_unchanged" | "execution_heads_unchanged";
+}): void {
+  recordRuntimeHealthEvent({ event: "cloud_upload_skipped", ...input });
+}
+
+/**
  * One line per scrape settlement across all four capture paths.
  * `itemsExtracted >= 5 && itemsPersisted == 0` is the scrape_zero_persist
  * signature (F03: results discarded by mid-invoke renderer recovery).

--- a/packages/desktop/src/lib/sync.ts
+++ b/packages/desktop/src/lib/sync.ts
@@ -24,7 +24,7 @@ import {
   type GoogleDriveFetch,
 } from "@freed/sync/cloud";
 import { getDocBinary, getDocHeads, mergeDoc, replaceLocalDoc, subscribe, setRelayClientCount } from "./automerge";
-import { recordCloudUploadAttempt, type CloudUploadCause } from "./runtime-health-events";
+import { recordCloudUploadAttempt, recordCloudUploadSkipped, type CloudUploadCause } from "./runtime-health-events";
 import {
   addDebugEvent,
   recordCloudProviderEvent,
@@ -1081,6 +1081,10 @@ async function runInitialCloudDownload(
     });
   } else {
     cloudInitialDownloadDeferredAttempts.delete(provider);
+    // Empty cloud: whatever heads we recorded from an earlier connection are
+    // not what the cloud holds. Clear them so the P1-01 guard cannot skip the
+    // first upload of this connection.
+    lastSuccessfulUploadHeadsByProvider.delete(provider);
     markCloudSuccess(provider, {
       stage: "idle",
       lastDownloadAt: Date.now(),
@@ -1300,7 +1304,18 @@ export async function startCloudSync(provider: CloudProvider, token: string): Pr
 
   // Subscribe to local doc changes so every mutation is uploaded back.
   // Debounced by scheduleCloudUpload. Rapid edits coalesce into one upload.
-  const unsubscribe = subscribe(() => {
+  //
+  // P1-01 damper (F01/F06): MERGE_DOC/REPLACE_DOC events are cloud- or
+  // relay-sourced, not user edits. Scheduling unconditionally on them is the
+  // self-sustaining loop — after every safe upload the merge-back emits a
+  // STATE_UPDATE tagged MERGE_DOC, which re-scheduled the next upload
+  // forever. Those events only upload when the heads actually moved past the
+  // last successful upload; every other mutation schedules as before.
+  const unsubscribe = subscribe((_state, event) => {
+    if (event.mutation === "MERGE_DOC" || event.mutation === "REPLACE_DOC") {
+      void scheduleCloudUploadIfHeadsMoved(provider);
+      return;
+    }
     scheduleCloudUpload(provider);
   });
   cloudChangeUnsubscribes.set(provider, unsubscribe);
@@ -1364,6 +1379,9 @@ export async function deleteCloudFile(provider: CloudProvider, token: string): P
   } else {
     await dropboxDeleteFile(token);
   }
+  // The cloud no longer holds the recorded state; the P1-01 heads guard must
+  // not suppress the next upload after a reconnect.
+  lastSuccessfulUploadHeadsByProvider.delete(provider);
 }
 
 export type CloudConflictWinner = "local" | "cloud";
@@ -1473,6 +1491,54 @@ export async function resolveCloudSyncConflict(
  */
 const lastUploadHeadsByProvider = new Map<CloudProvider, string>();
 
+/**
+ * Heads recorded after the last SUCCESSFUL upload settled, per provider —
+ * including the safe-upload merge-back, so after a completed cycle these are
+ * the heads of the exact document state the cloud now holds (P1-01 damper).
+ * Distinct from lastUploadHeadsByProvider above, which is attempt-time
+ * telemetry for the cloud_upload_attempt counter and must keep measuring
+ * attempts as they happen.
+ */
+const lastSuccessfulUploadHeadsByProvider = new Map<CloudProvider, string>();
+
+/** Current doc heads as a comparable key, or null when unavailable. */
+async function currentHeadsKey(): Promise<string | null> {
+  const heads = await getDocHeads();
+  return heads && heads.length > 0 ? heads.join(",") : null;
+}
+
+/**
+ * P1-01 belt-and-suspenders (F01/F06): called for MERGE_DOC/REPLACE_DOC
+ * subscriber events instead of scheduling unconditionally. Schedules only
+ * when the doc heads moved past the last successful upload — a genuine merge
+ * that changed local state still uploads; the safe-upload merge-back echo
+ * (whose merged state IS what the cloud already holds) does not.
+ */
+async function scheduleCloudUploadIfHeadsMoved(provider: CloudProvider): Promise<void> {
+  try {
+    const headsKey = await currentHeadsKey();
+    const lastUploaded = lastSuccessfulUploadHeadsByProvider.get(provider) ?? null;
+    if (headsKey !== null && headsKey === lastUploaded) {
+      recordCloudUploadSkipped({ provider, cause: "subscriber", reason: "merge_heads_unchanged" });
+      return;
+    }
+  } catch {
+    // Heads unavailable: prefer a redundant upload over a missed one.
+  }
+  scheduleCloudUpload(provider);
+}
+
+/** Record the settled post-upload heads; never lets telemetry fail an upload. */
+async function recordSuccessfulUploadHeads(provider: CloudProvider): Promise<void> {
+  try {
+    const headsKey = await currentHeadsKey();
+    if (headsKey !== null) lastSuccessfulUploadHeadsByProvider.set(provider, headsKey);
+  } catch {
+    // Missing record means the next subscriber event schedules an upload —
+    // the safe failure direction.
+  }
+}
+
 async function recordCloudUploadAttemptCounters(
   provider: CloudProvider,
   cause: CloudUploadCause,
@@ -1501,9 +1567,33 @@ async function performCloudUpload(
   const startedAt = Date.now();
   let byteLength = 0;
   try {
+    const cause = options.cause ?? "subscriber";
+    // P1-01 damper, execution-time check: the debounced timer may have been
+    // armed by a merge-back event that raced ahead of the post-upload heads
+    // record. Re-check at fire time and skip when nothing moved since the
+    // last successful upload. Manual "Sync now" and authoritative replaces
+    // always upload.
+    if (cause === "subscriber" && !options.authoritativeReplace) {
+      try {
+        const headsKey = await currentHeadsKey();
+        if (headsKey !== null && headsKey === lastSuccessfulUploadHeadsByProvider.get(provider)) {
+          recordCloudUploadSkipped({ provider, cause, reason: "execution_heads_unchanged" });
+          updateCloudProvider(provider, {
+            status: "connected",
+            stage: "idle",
+            statusMessage: "Nothing new to upload.",
+            pendingReason: "Waiting for local document changes or Sync now.",
+          });
+          recordCloudStep(provider, "waiting", "idle", "Skipped upload: no changes since the last upload.");
+          return;
+        }
+      } catch {
+        // Heads unavailable: fall through and upload (redundant beats missed).
+      }
+    }
     const binary = await getDocBinary();
     byteLength = binary.byteLength;
-    await recordCloudUploadAttemptCounters(provider, options.cause ?? "subscriber");
+    await recordCloudUploadAttemptCounters(provider, cause);
     const uploadToken = token ?? await getValidCloudToken(provider);
     if (!uploadToken) throw new Error("Cloud token missing. Reconnect the provider.");
     markCloudAttempt(provider, "upload", "Uploading local document to cloud storage.");
@@ -1515,6 +1605,10 @@ async function performCloudUpload(
         markCloudAttempt(provider, "merge", "Merging remote data discovered during upload.");
         await mergeDoc(result.uploadedBinary);
       }
+      // Record heads AFTER the merge-back settles: these are the heads of the
+      // exact state the cloud now holds, so the merge-back's own MERGE_DOC
+      // event compares equal and does not re-schedule (P1-01).
+      await recordSuccessfulUploadHeads(provider);
       markCloudSuccess(provider, {
         stage: "idle",
         lastUploadAt: Date.now(),
@@ -1533,6 +1627,7 @@ async function performCloudUpload(
       } else {
         await dropboxUploadSafe(uploadToken, binary);
       }
+      await recordSuccessfulUploadHeads(provider);
       markCloudSuccess(provider, {
         stage: "idle",
         lastUploadAt: Date.now(),


### PR DESCRIPTION
(AI Generated).

**P1-01 — the first behavioral change of the stability program.** `runner-safe: false`, `soak-gated: YES` → **owner review required; do not let an autonomous loop merge this.** Lands alone in its soak cycle per program rules.

## Defect (F01/F06, sev-5)
Desktop cloud sync is a self-sustaining loop: every safe upload merges the uploaded binary back → `MERGE_DOC` emits a STATE_UPDATE → the subscriber scheduled an upload on **every** state event with no mutation filtering. Upload→merge→state-update→upload, forever, independent of user activity. Frozen pre-damper baseline (`soaks/2026-07-08-0202`, 6.23 h idle): **98 of 102 uploads with unchanged heads (~16/h), cloud_loop alarm ×7**.

## Change
1. **Mutation filter (heads-qualified):** `MERGE_DOC`/`REPLACE_DOC` subscriber events schedule an upload **only when the doc heads moved past the last successful upload**. This is how the task's two requirements coexist: a genuine merge that changed local state still uploads; the merge-back echo (whose merged state is exactly what the cloud now holds) does not. All other mutations schedule exactly as before.
2. **Post-upload heads recorded after the merge-back settles** — so the echo event compares equal by construction, not by luck.
3. **Execution-time re-check** in `performCloudUpload` (cause=`subscriber` only): closes the debounce race where the echo arms the timer before the post-upload record lands. **Manual "Sync now" and authoritative replaces always upload.**
4. **Invalidation:** `deleteCloudFile` and an empty initial download clear the record, so a reconnect can never be suppressed into leaving the cloud empty.
5. **Observability:** new `cloud_upload_skipped` runtime-health counter (`merge_heads_unchanged` / `execution_heads_unchanged`). A healthy damper shows skips replacing unchanged-heads attempts; zero attempts **and** zero skips would mean sync broke, not damped.

## Blast radius
Desktop cloud scheduling only (per task file). Every guard **fails open** — heads unavailable → upload anyway. Worst failure: one missed upload, bounded by the next genuine local mutation.

## Tests
8-case suite (`cloud-loop-damper.test.ts`, mirrors the cloud-sync-auth-refresh harness): the loop edge (unchanged-heads MERGE_DOC does not schedule), genuine merge-that-moves-heads schedules, REPLACE_DOC guard, cold start with no record schedules, fail-open on heads error, manual exemption uploads twice with unchanged heads, delete-invalidation re-seeds. Neighboring suites (auth-refresh, outbox) pass; `tsc` clean vs the known 6-error baseline.

## Verification (soak-gated)
After merge + next dev build installed: overnight idle soak must show **cloud_loop alarm → 0** and **unchanged-heads uploads → ~single digits/h** against the frozen baseline; `cloud_upload_skipped` events present (proof of damping, not breakage); `soak-assert uploads_unchanged_heads` flips to pass. Cites F01/F06 in `stability-findings.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)