### PR TITLE
feat: triage loop — alarms + canary + red CI become ranked task files (stability W2-02)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,3 +201,23 @@ jobs:
           name: test-results
           path: packages/desktop/test-results/
           retention-days: 7
+
+      # Stability W2-02: red dev CI becomes a triage-readable issue instead of
+      # a problem the nightly planner rediscovers from scratch.
+      - name: Open or update the automation-triage issue on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          title="CI failure: dev validation on dev"
+          body="Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
+          Commit: ${GITHUB_SHA}
+          Job: dev (validate:dev)
+
+          Auto-filed for scripts/triage.mjs (label: automation-triage). Latest failure comments on the open issue; close it when the fix merges."
+          existing=$(gh issue list --label automation-triage --state open --search "in:title \"$title\"" --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$body"
+          else
+            gh issue create --title "$title" --label automation-triage --body "$body"
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -563,3 +563,29 @@ jobs:
             exit 0
           fi
           ./scripts/vercel-deploy-production.sh pwa "$VERCEL_TOKEN"
+
+  # Stability W2-02: a red release pipeline becomes a triage-readable issue
+  # (label automation-triage) that scripts/triage.mjs ranks against alarms,
+  # soak verdicts, and canary regressions.
+  triage-on-failure:
+    needs: [promotion, notes, validation, create-release, release, updater-manifest, publish, publish-website, publish-pwa]
+    if: failure()
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Open or update the automation-triage issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          title="Release pipeline failure: ${GITHUB_REF_NAME}"
+          body="Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
+          Ref: ${GITHUB_REF_NAME} (${GITHUB_SHA})
+
+          One or more jobs failed in the Release Desktop App workflow. Open the run to see which platform or stage went red. Auto-filed for scripts/triage.mjs; close after the follow-up release ships."
+          existing=$(gh issue list --label automation-triage --state open --search "in:title \"$title\"" --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$body"
+          else
+            gh issue create --title "$title" --label automation-triage --body "$body"
+          fi

--- a/docs/STABILITY-PROGRAM.md
+++ b/docs/STABILITY-PROGRAM.md
@@ -55,7 +55,7 @@ Done when: every counter in the scorecard below has a baseline number from one o
 | [P1-04](stability-tasks/P1-04-preflight-recycle-guard.md) | Preflight recycle guard + login-in-progress latch | no | ☐ |
 | [P1-05](stability-tasks/P1-05-recovery-invoke-latch.md) | Recovery never outruns a scrape invoke; persist lastScrapeAt | no | ☐ |
 | [W2-01](stability-tasks/W2-01-invariant-alarms.md) | Invariant alarms: cloud_loop, scrape_zero_persist, preflight_kill, auth_zombie, relay_divergence, watchdog_thrash | no | ◐ observing — cloud_loop positive control CONFIRMED (v26.7.701-dev); breakers + relay_divergence deferred |
-| [W2-02](stability-tasks/W2-02-triage-loop.md) | Triage loop: alarms + canary + red CI → ranked task files; CI-failure issue hook | yes | ☐ |
+| [W2-02](stability-tasks/W2-02-triage-loop.md) | Triage loop: alarms + canary + red CI → ranked task files; CI-failure issue hook | yes | ☑ |
 | [W2-03](stability-tasks/W2-03-canary-replay-bisect.md) | canary-summarize, watchdog-replay, bisect-regression scripts | yes | ☑ |
 | [W2-04](stability-tasks/W2-04-new-skills.md) | New skills: freed-soak, freed-triage, freed-canary | yes | ☐ |
 

--- a/scripts/nightly-self-improve.mjs
+++ b/scripts/nightly-self-improve.mjs
@@ -38,6 +38,14 @@ const LEGACY_OUTCOME_LEDGER = "/tmp/freed-nightly-self-improve/outcomes.jsonl";
 const DEFAULT_SOAK_POINTER = path.join(AUTOMATION_STATE_DIR, "current-soak-dir");
 const DEFAULT_OUTCOME_LEDGER = path.join(AUTOMATION_STATE_DIR, "outcomes.jsonl");
 const LEGACY_SOAK_ROOT = "/tmp/freed-perf-soak";
+// Ranked task files emitted by scripts/triage.mjs (stability W2-02).
+export const DEFAULT_TRIAGE_CANDIDATE_DIR = path.join(
+  AUTOMATION_STATE_DIR,
+  "triage",
+  "candidates",
+);
+// Triage evidence older than this no longer outranks roadmap work.
+const TRIAGE_FRESH_MS = 48 * 60 * 60 * 1000;
 
 export function resolveStatePathWithLegacyFallback(preferredPath, legacyPath, fsOps = {}) {
   const ops = { existsSync, mkdirSync, copyFileSync, ...fsOps };
@@ -1613,6 +1621,48 @@ export function collectRiskSnapshot({
   };
 }
 
+/**
+ * Read ranked triage task files (scripts/triage.mjs, stability W2-02) from
+ * the candidate directory. Each T-<rank>-<bucket>.md carries evidence
+ * pointers; files older than TRIAGE_FRESH_MS still load but are marked
+ * stale so ranking can drop them below roadmap work.
+ */
+export function loadTriageCandidates(dirPath = DEFAULT_TRIAGE_CANDIDATE_DIR, nowMs = Date.now()) {
+  if (!existsSync(dirPath)) return [];
+  const candidates = [];
+  for (const name of readdirSync(dirPath).sort()) {
+    const match = name.match(/^T-(\d{2})-(.+)\.md$/);
+    if (!match) continue;
+    const filePath = path.join(dirPath, name);
+    let text;
+    try {
+      text = readFileSync(filePath, "utf8");
+    } catch {
+      continue;
+    }
+    if (text.startsWith("# stale:")) continue;
+    const titleMatch = text.match(/^# T-\d+: (.+)$/m);
+    const programTaskMatch = text.match(/^Program task: (.+)$/m);
+    const evidence = [...text.matchAll(/^- (.+)$/gm)].map((m) => m[1]).slice(0, 6);
+    let mtimeMs = 0;
+    try {
+      mtimeMs = statSync(filePath).mtimeMs;
+    } catch {
+      /* treat as stale */
+    }
+    candidates.push({
+      rank: Number(match[1]),
+      bucketId: match[2],
+      title: titleMatch?.[1] ?? match[2],
+      programTask: programTaskMatch?.[1] ?? null,
+      evidence,
+      filePath,
+      fresh: nowMs - mtimeMs <= TRIAGE_FRESH_MS,
+    });
+  }
+  return candidates.sort((left, right) => left.rank - right.rank);
+}
+
 function target({
   id,
   kind,
@@ -1653,9 +1703,41 @@ export function buildCandidates({
   crashAutomationExists,
   devBotMemoryExists,
   memoryBudgetBytes,
+  triageCandidates = [],
 }) {
   const candidates = [];
   const soakEvidenceQuality = assessSoakEvidenceQuality(soak);
+
+  // Triage loop output (stability W2-02): evidence-ranked task files from
+  // scripts/triage.mjs. Fresh alarm/verdict/canary evidence ranks ABOVE
+  // roadmap work (score 94 down by rank vs roadmap's 48); stale files sink
+  // below it instead of silently vanishing.
+  for (const triage of triageCandidates.slice(0, 3)) {
+    candidates.push(
+      target({
+        id: `triage-${triage.bucketId}`,
+        kind: "stability",
+        title: `Triage: ${triage.title}`,
+        score: triage.fresh ? Math.max(60, 94 - (triage.rank - 1) * 4) : 40,
+        confidence: 0.85,
+        estimatedMinutes: 90,
+        rationale:
+          "The triage loop folded live runtime-health alarms, the latest soak verdict, canary regressions, and CI state into this ranked bucket. Execute the mapped stability-program task instead of re-deriving the problem.",
+        evidence: [
+          `Triage file: ${triage.filePath}`,
+          ...(triage.programTask ? [`Program task: ${triage.programTask}`] : []),
+          ...triage.evidence,
+        ],
+        prompt:
+          `Read ${triage.filePath} and the program task it maps to (${triage.programTask ?? "see file"}). ` +
+          "Execute that task under its own runner-safe/provider-visible/soak-gated header rules — a runner-safe:false task means open the PR and stop for owner review. Attach the triage evidence to the PR body.",
+        validation: [
+          "The mapped program task's counter-based verification governs; cite the counters that must move.",
+          "Respect docs/STABILITY-PROGRAM.md rules: watchdog freeze, one behavioral change per soak cycle, provider-visible approval lane.",
+        ],
+      }),
+    );
+  }
 
   if ((riskSnapshot?.blockerCount ?? 0) > 0 || (riskSnapshot?.warningCount ?? 0) > 0) {
     candidates.push(
@@ -2468,6 +2550,7 @@ export function planNightlyRun(args) {
     crashAutomationExists: existsSync(args.crashAutomation),
     devBotMemoryExists: existsSync(args.devBotMemory),
     memoryBudgetBytes: args.memoryGib * GIB,
+    triageCandidates: loadTriageCandidates(),
   });
   const candidates = applyOutcomeFeedback(baseCandidates, outcomeLedger);
   const selected = selectTargets(candidates, args);

--- a/scripts/triage.mjs
+++ b/scripts/triage.mjs
@@ -1,0 +1,415 @@
+#!/usr/bin/env node
+/**
+ * triage.mjs (stability W2-02)
+ *
+ * Evidence in, ranked tasks out. Reads four evidence streams —
+ * invariant-alarm aggregates from rotated runtime-health, the latest
+ * soak-verdict.json failures, canary-ledger regression entries (W2-03), and
+ * open `automation-triage` CI-failure issues — dedupes them into root-cause
+ * buckets, ranks by severity x frequency x freshness, and emits one task
+ * file per bucket (docs/stability-tasks format, evidence pointers included)
+ * into the nightly runner's candidate directory.
+ *
+ * Buckets deliberately map to EXISTING program tasks where one exists: the
+ * emitted candidate says "execute P1-04, here is tonight's evidence", so the
+ * queue converges on the program instead of forking it.
+ */
+
+import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const REPO_ROOT = path.resolve(path.dirname(__filename), "..");
+const AUTOMATION_DIR = path.join(os.homedir(), ".freed/automation");
+const DEFAULT_APP_DATA = path.join(
+  os.homedir(),
+  "Library/Application Support/wtf.freed.desktop",
+);
+const DEFAULT_CANDIDATE_DIR = path.join(AUTOMATION_DIR, "triage/candidates");
+const DEFAULT_POINTER = path.join(AUTOMATION_DIR, "current-soak-dir");
+const DEFAULT_LEDGER_DIR = path.join(REPO_ROOT, "canary-ledger");
+
+/**
+ * Root-cause buckets. Each maps the signals that indict it (alarm names,
+ * soak-verdict assertion ids, canary metrics) to the program task that fixes
+ * it. severity 1-5 follows stability-findings.json.
+ */
+export const BUCKETS = [
+  {
+    id: "cloud-loop",
+    title: "Idle cloud upload loop is live",
+    severity: 5,
+    alarms: ["cloud_loop"],
+    assertions: ["uploads_unchanged_heads"],
+    canaryMetrics: ["uploadsUnchangedPerHour", "uploadsPerHour"],
+    programTask: "P1-01-cloud-loop-damper-desktop.md (then P1-02/P1-03)",
+    findings: "F01/F06",
+  },
+  {
+    id: "preflight-kill",
+    title: "Window recycles are killing held scraper/login sessions",
+    severity: 5,
+    alarms: ["preflight_kill"],
+    assertions: ["preflight_kills"],
+    canaryMetrics: [],
+    programTask: "P1-04-preflight-recycle-guard.md",
+    findings: "F04",
+  },
+  {
+    id: "scrape-zero-persist",
+    title: "Scrapes extract items but persist nothing",
+    severity: 5,
+    alarms: ["scrape_zero_persist"],
+    assertions: ["scrape_zero_persist"],
+    canaryMetrics: [],
+    programTask: "P1-05-recovery-invoke-latch.md",
+    findings: "F03",
+  },
+  {
+    id: "renderer-churn",
+    title: "Watchdog is thrashing the main renderer",
+    severity: 4,
+    alarms: ["watchdog_thrash"],
+    assertions: ["renderer_recoveries", "stale_heartbeats"],
+    canaryMetrics: ["recoveriesPerDay"],
+    programTask: "demand-side dampers first (P1-*); thresholds stay frozen per program rules",
+    findings: "F16/F23",
+  },
+  {
+    id: "auth-zombie",
+    title: "A provider is scraping empty while believed authenticated",
+    severity: 3,
+    alarms: ["auth_zombie"],
+    assertions: [],
+    canaryMetrics: [],
+    programTask: "Wave 4 auth-truth tasks (see docs/STABILITY-PROGRAM.md)",
+    findings: "auth misclassification theme",
+  },
+  {
+    id: "memory-growth",
+    title: "Idle memory footprint is growing or peaking high",
+    severity: 4,
+    alarms: [],
+    assertions: ["main_footprint_slope", "webkit_returns_to_baseline"],
+    canaryMetrics: ["idleGrowthMbPerHour", "peakAppResidentBytes", "peakWebkitLargestResidentBytes"],
+    programTask: "Wave 5 demand-side tasks (see docs/STABILITY-PROGRAM.md)",
+    findings: "F-memory themes",
+  },
+  {
+    id: "worker-churn",
+    title: "Automerge worker INIT churn",
+    severity: 3,
+    alarms: [],
+    assertions: [],
+    canaryMetrics: ["workerInitsPerHour"],
+    programTask: "Wave 5 worker lifecycle task",
+    findings: "F20",
+  },
+  {
+    id: "ci-red",
+    title: "CI is red",
+    severity: 5,
+    alarms: [],
+    assertions: [],
+    canaryMetrics: [],
+    programTask: "fix the failing job first; nothing ships over red CI",
+    findings: "ci",
+  },
+];
+
+export function readHealthEntries(appDataDir, { sinceMs }) {
+  const entries = [];
+  if (!existsSync(appDataDir)) return entries;
+  const files = readdirSync(appDataDir)
+    .filter((name) => /^runtime-health-\d{8}\.jsonl$/.test(name))
+    .sort()
+    .map((name) => path.join(appDataDir, name));
+  for (const file of files) {
+    const lines = readFileSync(file, "utf8").split("\n");
+    lines.forEach((raw, index) => {
+      if (!raw.trim()) return;
+      try {
+        const entry = JSON.parse(raw);
+        if (Number(entry.tsMs ?? 0) >= sinceMs) {
+          entries.push({ entry, file, line: index + 1 });
+        }
+      } catch {
+        /* skip malformed */
+      }
+    });
+  }
+  return entries;
+}
+
+/** Aggregate invariant alarms by name with evidence pointers. */
+export function aggregateAlarms(healthEntries) {
+  const byName = {};
+  for (const { entry, file, line } of healthEntries) {
+    if (entry.event !== "invariant_alarm") continue;
+    const name = entry.name ?? "unknown";
+    const bucket = (byName[name] ??= { count: 0, lastTsMs: 0, evidence: [] });
+    bucket.count += 1;
+    bucket.lastTsMs = Math.max(bucket.lastTsMs, Number(entry.tsMs ?? 0));
+    if (bucket.evidence.length < 5) {
+      bucket.evidence.push({ file, line, detail: entry.detail ?? "" });
+    }
+  }
+  return byName;
+}
+
+export function readLatestVerdict(pointerPath = DEFAULT_POINTER) {
+  try {
+    const soakDir = readFileSync(pointerPath, "utf8").trim();
+    const verdictPath = path.join(soakDir, "soak-verdict.json");
+    if (!existsSync(verdictPath)) return null;
+    return { verdict: JSON.parse(readFileSync(verdictPath, "utf8")), verdictPath };
+  } catch {
+    return null;
+  }
+}
+
+export function readLatestCanary(ledgerDir = DEFAULT_LEDGER_DIR) {
+  if (!existsSync(ledgerDir)) return null;
+  const records = readdirSync(ledgerDir)
+    .filter((name) => /^canary-.+\.json$/.test(name))
+    .map((name) => {
+      try {
+        return { record: JSON.parse(readFileSync(path.join(ledgerDir, name), "utf8")), file: path.join(ledgerDir, name) };
+      } catch {
+        return null;
+      }
+    })
+    .filter(Boolean)
+    .sort((a, b) => String(a.record.windowEnd).localeCompare(String(b.record.windowEnd)));
+  return records.at(-1) ?? null;
+}
+
+export function readCiIssues({ exec = execFileSync } = {}) {
+  try {
+    const raw = exec(
+      "/opt/homebrew/bin/gh",
+      [
+        "issue",
+        "list",
+        "--label",
+        "automation-triage",
+        "--state",
+        "open",
+        "--json",
+        "number,title,updatedAt,url",
+      ],
+      { cwd: REPO_ROOT, encoding: "utf8", timeout: 30_000 },
+    );
+    return JSON.parse(raw);
+  } catch {
+    return []; // Offline or gh unavailable: triage degrades, never fails.
+  }
+}
+
+/**
+ * Fold the four evidence streams into scored bucket candidates.
+ * score = severity * ln(1 + hits) * freshness, freshness 1.0 for <24h-old
+ * evidence decaying to 0.25 at 7 days. CI issues pin to their own bucket.
+ */
+export function buildCandidates({ alarms, verdictInfo, canaryInfo, ciIssues, nowMs }) {
+  const candidates = new Map();
+  const touch = (bucketId) => {
+    const bucket = BUCKETS.find((b) => b.id === bucketId);
+    if (!bucket) return null;
+    if (!candidates.has(bucketId)) {
+      candidates.set(bucketId, { bucket, hits: 0, lastEvidenceMs: 0, evidence: [] });
+    }
+    return candidates.get(bucketId);
+  };
+
+  for (const [name, aggregate] of Object.entries(alarms ?? {})) {
+    const bucket = BUCKETS.find((b) => b.alarms.includes(name));
+    if (!bucket) continue;
+    const candidate = touch(bucket.id);
+    candidate.hits += aggregate.count;
+    candidate.lastEvidenceMs = Math.max(candidate.lastEvidenceMs, aggregate.lastTsMs);
+    for (const item of aggregate.evidence) {
+      candidate.evidence.push(`alarm ${name} x${aggregate.count}: ${item.file}:${item.line} ${item.detail}`.trim());
+    }
+  }
+
+  if (verdictInfo?.verdict?.assertions) {
+    const verdictEndMs = Date.parse(verdictInfo.verdict.windowEnd ?? "") || nowMs;
+    for (const assertion of verdictInfo.verdict.assertions) {
+      if (assertion.status !== "fail") continue;
+      const bucket = BUCKETS.find((b) => b.assertions.includes(assertion.id));
+      if (!bucket) continue;
+      const candidate = touch(bucket.id);
+      candidate.hits += 1;
+      candidate.lastEvidenceMs = Math.max(candidate.lastEvidenceMs, verdictEndMs);
+      candidate.evidence.push(`soak-verdict ${assertion.id}: ${assertion.detail} (${verdictInfo.verdictPath})`);
+    }
+  }
+
+  if (canaryInfo?.record?.regressions) {
+    const canaryEndMs = Date.parse(canaryInfo.record.windowEnd ?? "") || nowMs;
+    for (const regression of canaryInfo.record.regressions) {
+      const bucket = BUCKETS.find((b) => b.canaryMetrics.includes(regression.metric));
+      if (!bucket) continue;
+      const candidate = touch(bucket.id);
+      candidate.hits += 1;
+      candidate.lastEvidenceMs = Math.max(candidate.lastEvidenceMs, canaryEndMs);
+      candidate.evidence.push(
+        `canary ${canaryInfo.record.version} ${regression.metric}=${regression.current} vs median ${regression.trailingMedian} (${canaryInfo.file})`,
+      );
+    }
+  }
+
+  for (const issue of ciIssues ?? []) {
+    const candidate = touch("ci-red");
+    candidate.hits += 1;
+    candidate.lastEvidenceMs = Math.max(candidate.lastEvidenceMs, Date.parse(issue.updatedAt ?? "") || nowMs);
+    candidate.evidence.push(`CI issue #${issue.number}: ${issue.title} (${issue.url})`);
+  }
+
+  const scored = [...candidates.values()].map((candidate) => {
+    const ageDays = Math.max(0, (nowMs - candidate.lastEvidenceMs) / 86_400_000);
+    const freshness = ageDays <= 1 ? 1 : Math.max(0.25, 1 - (ageDays - 1) * 0.125);
+    return {
+      ...candidate,
+      score: Number((candidate.bucket.severity * Math.log(1 + candidate.hits) * freshness).toFixed(3)),
+    };
+  });
+  return scored.sort((a, b) => b.score - a.score);
+}
+
+/** Render one ranked candidate as a docs/stability-tasks-format task file. */
+export function renderTaskFile(candidate, rank, generatedAtIso) {
+  const { bucket } = candidate;
+  const lines = [
+    `# T-${rank}: ${bucket.title}`,
+    "",
+    `runner-safe: false (triage candidate; the mapped program task's own header governs) | provider-visible: false | soak-gated: see program task`,
+    `Findings: ${bucket.findings}. Generated by scripts/triage.mjs at ${generatedAtIso}. Score ${candidate.score} (severity ${bucket.severity}, ${candidate.hits} evidence hit${candidate.hits === 1 ? "" : "s"}).`,
+    "",
+    "## Context",
+    "",
+    `Live evidence indicts this root-cause bucket. Do not re-derive: execute the mapped program task with tonight's evidence attached.`,
+    "",
+    `Program task: ${bucket.programTask}`,
+    "",
+    "## Evidence",
+    "",
+    ...candidate.evidence.slice(0, 10).map((item) => `- ${item}`),
+    "",
+    "## Verify",
+    "",
+    "- The program task's own counter-based verification governs; a follow-up soak/canary window must show this bucket's signals at or trending to target (docs/STABILITY-PROGRAM.md scorecard).",
+    "",
+  ];
+  return lines.join("\n");
+}
+
+export function emitCandidates(ranked, candidateDir, { nowIso, keep = 8 } = {}) {
+  mkdirSync(candidateDir, { recursive: true });
+  const written = [];
+  ranked.slice(0, keep).forEach((candidate, index) => {
+    const rank = index + 1;
+    const name = `T-${String(rank).padStart(2, "0")}-${candidate.bucket.id}.md`;
+    const filePath = path.join(candidateDir, name);
+    writeFileSync(filePath, renderTaskFile(candidate, rank, nowIso));
+    written.push(filePath);
+  });
+  // Clear stale higher-ranked leftovers from previous runs.
+  for (const name of readdirSync(candidateDir)) {
+    if (!/^T-\d{2}-.+\.md$/.test(name)) continue;
+    const rank = Number(name.slice(2, 4));
+    if (rank > ranked.length || rank > keep) {
+      writeFileSync(path.join(candidateDir, name), "# stale: superseded by a newer triage run\n");
+    }
+  }
+  return written;
+}
+
+function usage() {
+  return `Usage:
+  node scripts/triage.mjs [options]
+
+Options:
+  --app-data <path>       Runtime-health dir. Defaults to the installed app dir.
+  --hours <n>             Alarm aggregation window. Defaults to 48.
+  --pointer <path>        Soak pointer for the latest verdict.
+  --ledger-dir <path>     Canary ledger dir. Defaults to <repo>/canary-ledger.
+  --candidate-dir <path>  Output dir. Defaults to ~/.freed/automation/triage/candidates.
+  --no-ci                 Skip the GitHub CI-issue lookup (offline).
+  --json                  Print the ranked candidates as JSON.
+  --help                  Show this help.
+`;
+}
+
+export function parseArgs(argv) {
+  const args = {
+    appData: DEFAULT_APP_DATA,
+    hours: 48,
+    pointer: DEFAULT_POINTER,
+    ledgerDir: DEFAULT_LEDGER_DIR,
+    candidateDir: DEFAULT_CANDIDATE_DIR,
+    ci: true,
+    json: false,
+    help: false,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--app-data") args.appData = argv[++i];
+    else if (arg === "--hours") args.hours = Number(argv[++i]);
+    else if (arg === "--pointer") args.pointer = argv[++i];
+    else if (arg === "--ledger-dir") args.ledgerDir = argv[++i];
+    else if (arg === "--candidate-dir") args.candidateDir = argv[++i];
+    else if (arg === "--no-ci") args.ci = false;
+    else if (arg === "--json") args.json = true;
+    else if (arg === "--help" || arg === "-h") args.help = true;
+    else throw new Error(`Unknown argument: ${arg}`);
+  }
+  return args;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    process.stdout.write(usage());
+    return;
+  }
+  const nowMs = Date.now();
+  const healthEntries = readHealthEntries(args.appData, {
+    sinceMs: nowMs - args.hours * 3_600_000,
+  });
+  const ranked = buildCandidates({
+    alarms: aggregateAlarms(healthEntries),
+    verdictInfo: readLatestVerdict(args.pointer),
+    canaryInfo: readLatestCanary(args.ledgerDir),
+    ciIssues: args.ci ? readCiIssues() : [],
+    nowMs,
+  });
+  const written = emitCandidates(ranked, args.candidateDir, {
+    nowIso: new Date(nowMs).toISOString(),
+  });
+
+  if (args.json) {
+    process.stdout.write(
+      `${JSON.stringify(ranked.map(({ bucket, hits, score, evidence }) => ({ id: bucket.id, hits, score, evidence })), null, 2)}\n`,
+    );
+  }
+  process.stdout.write(`${ranked.length} candidate bucket${ranked.length === 1 ? "" : "s"} -> ${written.length} task file${written.length === 1 ? "" : "s"} in ${args.candidateDir}\n`);
+  for (const [index, candidate] of ranked.entries()) {
+    process.stdout.write(
+      `  ${index + 1}. [${candidate.score}] ${candidate.bucket.id} (${candidate.hits} hits) -> ${candidate.bucket.programTask}\n`,
+    );
+  }
+}
+
+if (process.argv[1] === __filename) {
+  try {
+    main();
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/triage.test.mjs
+++ b/scripts/triage.test.mjs
@@ -1,0 +1,235 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, readdirSync, utimesSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  aggregateAlarms,
+  buildCandidates,
+  emitCandidates,
+  renderTaskFile,
+} from "./triage.mjs";
+import { buildCandidates as buildNightlyCandidates, loadTriageCandidates } from "./nightly-self-improve.mjs";
+
+const NOW = Date.parse("2026-07-09T08:00:00Z");
+
+function healthEntry(entry, line = 1) {
+  return { entry, file: "runtime-health-20260709.jsonl", line };
+}
+
+/** Minimal valid buildCandidates inputs, mirroring nightly-self-improve.test.mjs. */
+function nightlyInputs() {
+  return {
+    soak: {
+      exists: true,
+      soakDir: "/tmp/example-soak",
+      sampleCount: 20,
+      maxWebKitResidentBytes: 1024 ** 3,
+      maxEventLoopLagMs: 9,
+      maxDomNodes: 600,
+      staleHeartbeatCount: 0,
+      throttledHeartbeatCount: 0,
+      lastEvent: "renderer_heartbeat",
+    },
+    dailyBug: {
+      exists: true,
+      path: "/tmp/memory.md",
+      latestDate: "2026-07-08",
+      latestHadNoNewCommits: false,
+      latestHadFix: false,
+    },
+    repo: {
+      branch: "dev",
+      head: "abc1234",
+      originDev: "abc1234",
+      originMain: "0000000",
+      status: "",
+    },
+    peerWorktrees: [],
+    crashAutomationExists: true,
+    devBotMemoryExists: true,
+    memoryBudgetBytes: 8 * 1024 ** 3,
+  };
+}
+
+test("alarm aggregation groups by name with capped evidence pointers", () => {
+  const entries = [];
+  for (let i = 0; i < 8; i += 1) {
+    entries.push(
+      healthEntry(
+        { event: "invariant_alarm", name: "cloud_loop", detail: `burst ${i}`, tsMs: NOW - i * 1000 },
+        i + 1,
+      ),
+    );
+  }
+  entries.push(healthEntry({ event: "invariant_alarm", name: "preflight_kill", detail: "held", tsMs: NOW }, 99));
+  entries.push(healthEntry({ event: "renderer_heartbeat", tsMs: NOW }, 100));
+
+  const alarms = aggregateAlarms(entries);
+  assert.equal(alarms.cloud_loop.count, 8);
+  assert.equal(alarms.cloud_loop.evidence.length, 5, "evidence pointers are capped");
+  assert.equal(alarms.preflight_kill.count, 1);
+  assert.equal(alarms.preflight_kill.evidence[0].line, 99);
+});
+
+test("a synthetic alarm aggregate + failed verdict produce ranked task files with evidence pointers", () => {
+  const alarms = {
+    cloud_loop: {
+      count: 7,
+      lastTsMs: NOW - 3_600_000,
+      evidence: [{ file: "runtime-health-20260709.jsonl", line: 42, detail: "5 uploads unchanged heads" }],
+    },
+    auth_zombie: {
+      count: 1,
+      lastTsMs: NOW - 3_600_000,
+      evidence: [{ file: "runtime-health-20260709.jsonl", line: 50, detail: "linkedin ok-empty x3" }],
+    },
+  };
+  const verdictInfo = {
+    verdictPath: "/soak/soak-verdict.json",
+    verdict: {
+      windowEnd: new Date(NOW - 3_600_000).toISOString(),
+      assertions: [
+        { id: "uploads_unchanged_heads", status: "fail", detail: "98 of 102 uploads had unchanged heads" },
+        { id: "renderer_recoveries", status: "pass", detail: "0 events" },
+      ],
+    },
+  };
+  const canaryInfo = {
+    file: "/repo/canary-ledger/canary-26.7.800.json",
+    record: {
+      version: "26.7.800",
+      windowEnd: new Date(NOW - 3_600_000).toISOString(),
+      regressions: [{ metric: "workerInitsPerHour", current: 40, trailingMedian: 10, limit: 15 }],
+    },
+  };
+
+  const ranked = buildCandidates({ alarms, verdictInfo, canaryInfo, ciIssues: [], nowMs: NOW });
+  assert.equal(ranked[0].bucket.id, "cloud-loop", "alarm x7 + verdict fail must rank first");
+  const ids = ranked.map((c) => c.bucket.id);
+  assert.ok(ids.includes("worker-churn"), "canary regression maps to its bucket");
+  assert.ok(ids.includes("auth-zombie"));
+  assert.ok(
+    ranked[0].evidence.some((line) => line.includes("runtime-health-20260709.jsonl:42")),
+    "ledger line pointer survives into the candidate",
+  );
+  assert.ok(
+    ranked[0].evidence.some((line) => line.includes("soak-verdict") && line.includes("98 of 102")),
+    "verdict entry pointer survives",
+  );
+
+  const dir = mkdtempSync(path.join(os.tmpdir(), "freed-triage-"));
+  const written = emitCandidates(ranked, dir, { nowIso: new Date(NOW).toISOString() });
+  assert.equal(path.basename(written[0]), "T-01-cloud-loop.md");
+  const rendered = readFileSync(written[0], "utf8");
+  assert.match(rendered, /^# T-1: /m);
+  assert.match(rendered, /runner-safe: false/);
+  assert.match(rendered, /P1-01-cloud-loop-damper-desktop\.md/);
+  assert.match(rendered, /## Evidence/);
+  assert.match(rendered, /runtime-health-20260709\.jsonl:42/);
+});
+
+test("CI issues rank at the top when fresh", () => {
+  const ranked = buildCandidates({
+    alarms: { cloud_loop: { count: 2, lastTsMs: NOW - 6 * 86_400_000, evidence: [] } },
+    verdictInfo: null,
+    canaryInfo: null,
+    ciIssues: [{ number: 940, title: "CI failure: dev validation on dev", updatedAt: new Date(NOW).toISOString(), url: "https://x" }],
+    nowMs: NOW,
+  });
+  assert.equal(ranked[0].bucket.id, "ci-red");
+  assert.ok(ranked[0].score > ranked[1].score, "fresh CI outranks week-old alarms");
+});
+
+test("renderTaskFile follows the stability-tasks header format", () => {
+  const candidate = {
+    bucket: {
+      id: "preflight-kill",
+      title: "Window recycles are killing held scraper/login sessions",
+      severity: 5,
+      programTask: "P1-04-preflight-recycle-guard.md",
+      findings: "F04",
+    },
+    hits: 1,
+    score: 3.47,
+    evidence: ["alarm preflight_kill x1: file:1 detail"],
+  };
+  const text = renderTaskFile(candidate, 2, "2026-07-09T08:00:00.000Z");
+  const lines = text.split("\n");
+  assert.match(lines[0], /^# T-2: Window recycles/);
+  assert.match(lines[2], /^runner-safe: .+ \| provider-visible: .+ \| soak-gated: /);
+  assert.ok(text.includes("## Context") && text.includes("## Evidence") && text.includes("## Verify"));
+});
+
+test("nightly planner loads fresh triage files and ranks them above roadmap work", () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "freed-triage-nightly-"));
+  const filePath = path.join(dir, "T-01-cloud-loop.md");
+  writeFileSync(
+    filePath,
+    [
+      "# T-1: Idle cloud upload loop is live",
+      "",
+      "runner-safe: false | provider-visible: false | soak-gated: see program task",
+      "Findings: F01/F06.",
+      "",
+      "## Context",
+      "",
+      "Program task: P1-01-cloud-loop-damper-desktop.md",
+      "",
+      "## Evidence",
+      "",
+      "- alarm cloud_loop x7: runtime-health-20260709.jsonl:42",
+      "",
+      "## Verify",
+      "",
+    ].join("\n"),
+  );
+  // Also a stale-marked file that must be skipped.
+  writeFileSync(path.join(dir, "T-02-auth-zombie.md"), "# stale: superseded by a newer triage run\n");
+
+  const loaded = loadTriageCandidates(dir, Date.now());
+  assert.equal(loaded.length, 1);
+  assert.equal(loaded[0].bucketId, "cloud-loop");
+  assert.equal(loaded[0].fresh, true);
+  assert.equal(loaded[0].programTask, "P1-01-cloud-loop-damper-desktop.md");
+
+  const candidates = buildNightlyCandidates({
+    ...nightlyInputs(),
+    triageCandidates: loaded,
+  });
+  const triage = candidates.find((c) => c.id === "triage-cloud-loop");
+  const roadmap = candidates.find((c) => c.id === "roadmap-autonomous-task");
+  assert.ok(triage, "triage candidate present");
+  assert.ok(roadmap, "roadmap candidate present");
+  assert.ok(triage.score > roadmap.score, "fresh triage outranks roadmap");
+  assert.ok(triage.evidence.some((line) => line.includes(filePath)));
+
+  // Stale files sink below roadmap instead of vanishing.
+  const past = new Date(Date.now() - 3 * 86_400_000);
+  utimesSync(filePath, past, past);
+  const staleLoaded = loadTriageCandidates(dir, Date.now());
+  assert.equal(staleLoaded[0].fresh, false);
+  const staleCandidates = buildNightlyCandidates({
+    ...nightlyInputs(),
+    triageCandidates: staleLoaded,
+  });
+  const staleTriage = staleCandidates.find((c) => c.id === "triage-cloud-loop");
+  assert.ok(staleTriage.score < roadmap.score, "stale triage sinks below roadmap");
+});
+
+test("emitCandidates marks leftover higher ranks from previous runs as stale", () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "freed-triage-stale-"));
+  writeFileSync(path.join(dir, "T-03-memory-growth.md"), "# T-3: old leftover\n");
+  const ranked = buildCandidates({
+    alarms: { cloud_loop: { count: 5, lastTsMs: NOW, evidence: [] } },
+    verdictInfo: null,
+    canaryInfo: null,
+    ciIssues: [],
+    nowMs: NOW,
+  });
+  emitCandidates(ranked, dir, { nowIso: new Date(NOW).toISOString() });
+  const names = readdirSync(dir).sort();
+  assert.deepEqual(names, ["T-01-cloud-loop.md", "T-03-memory-growth.md"]);
+  assert.match(readFileSync(path.join(dir, "T-03-memory-growth.md"), "utf8"), /^# stale:/);
+});


### PR DESCRIPTION
(AI Generated).

W2-02 (`runner-safe: true`). Closes the evidence loop: soak verdicts, invariant alarms, canary regressions, and CI failures now become **ranked task files** the nightly runner consumes, instead of problems it rediscovers nightly.

## scripts/triage.mjs
Four evidence streams → root-cause buckets → ranked task files (docs/stability-tasks format, evidence pointers included) in `~/.freed/automation/triage/candidates/`. Buckets **map to existing program tasks** (cloud-loop → P1-01, preflight-kill → P1-04, scrape-zero-persist → P1-05, …) so the queue converges on the program instead of forking it. Scoring: severity × ln(1+hits) × freshness decay. Degrades gracefully offline (`--no-ci`).

**Live smoke on this machine ranked exactly right:** `1. cloud-loop (9 alarm hits) → P1-01` (the damper PR currently awaiting owner review, #934) and `2. preflight-kill (2 hits) → P1-04` — including a second real held-session kill caught tonight.

## CI hooks
- `ci.yml` dev job: on failure, opens/updates an `automation-triage` issue (top-level permissions already had `issues: write`).
- `release.yml`: new terminal `triage-on-failure` job (`needs` the full chain, `if: failure()`, own `permissions: issues: write` — release jobs don't inherit it).
- The `automation-triage` label exists (created).

## Nightly planner integration
`loadTriageCandidates()` + a new source block in `buildCandidates`: fresh (<48h) triage candidates enter at **score 94−4·(rank−1)** — above `roadmap-autonomous-task` (48) per the task spec — and stale ones sink to 40 instead of vanishing. Candidate prompts explicitly defer to each mapped task's own `runner-safe`/`provider-visible`/`soak-gated` header, so triage can never smuggle a `runner-safe: false` task into autonomous merge.

## Verification
- 6 fixture tests (`scripts/triage.test.mjs`): the task's required "synthetic alarm aggregate + failed verdict → correctly ranked task files with evidence pointers", CI-freshness ranking, header-format conformance, fresh>roadmap>stale nightly ordering, stale-file supersession.
- `nightly-self-improve.test.mjs` still 36/36; both workflows YAML-parse with the new jobs.
- The live-cycle check (seeded alarm appears as the runner's top candidate next night) is armed: tonight's real alarms already produce the candidate files.

Checks W2-02 in docs/STABILITY-PROGRAM.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)