### PR TITLE
docs: freed-soak, freed-canary, and freed-triage skills (stability W2-04)

### DIFF
--- a/.agents/skills/freed-canary/SKILL.md
+++ b/.agents/skills/freed-canary/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: freed-canary
+description: Judge an installed Freed Desktop release against the trailing canary ledger — run canary-summarize over the release's runtime-health window, commit the ledger record, and if a metric regressed, plan a bisect with bisect-regression. Use when asked whether a release regressed the machine, after a release has run for a day, or when a soak verdict looks worse than usual.
+disable-model-invocation: true
+---
+
+# Canary
+
+The owner machine is the de-facto canary fleet: releases are near-daily and there is no remote telemetry. This skill turns "did this release regress it" into a ledger lookup, and "which commit" into a planned bisect. Program rules bind: **regressions become tasks or bisects, never watchdog threshold edits** ([docs/STABILITY-PROGRAM.md](../../../docs/STABILITY-PROGRAM.md)).
+
+## Workflow
+
+1. Confirm the installed version and how long it has been running: `defaults read /Applications/Freed.app/Contents/Info.plist CFBundleShortVersionString`; prefer ≥24h of runtime-health history for a fair record (rotated files cover 14 days).
+2. Summarize the window: `node scripts/canary-summarize.mjs --hours 24` (pass `--version` to override attribution, `--since-ms/--until-ms` for an exact window). This writes `canary-ledger/canary-<version>.json` with recoveries/day, window kills by reason, invariant alarms by name, uploads + damper skips, worker INITs/hour, scrape success by provider, peak memory, and the idle growth slope — and flags regressions vs the trailing-7-record median.
+3. Read the record, not the vibes: report the metrics table and the `regressions` array. An empty trailing ledger means "first record, nothing to compare" — say so.
+4. Commit the ledger record on a small branch → PR to dev (`canary: record <version>`), so the ledger is durable history the triage loop and nightly runner can read.
+5. If a metric regressed, plan the bisect: `node scripts/bisect-regression.mjs --metric <name> --good <last-good-version> --bad <this-version> --threshold <n>`. The default is a DRY RUN printing the commit range, step count, and exact `git bisect run` commands — a 90-min-per-step soak bisect is an operator commitment, so present the plan and get an explicit go (10-minute-timeout contract applies) before `--execute`.
+6. When the culprit range is found, hand off: cite the range and the regressed counter in a task file or PR comment; the fix flows through the normal owner-review lanes (`runner-safe: false` for product code).
+
+## Success criteria (counters, not vibes)
+
+- `canary-ledger/canary-<version>.json` exists, is committed, and its `regressions` array is either empty or each entry names metric, current value, trailing median, and limit.
+- A flagged regression produces either a bisect plan (with commit range and step estimate) or a written reason why bisecting is not worth it — never silence.

--- a/.agents/skills/freed-soak/SKILL.md
+++ b/.agents/skills/freed-soak/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: freed-soak
+description: Run an installed-build soak of Freed Desktop terminal-first — launch with open -g, start the soak collector, optionally kick provider syncs with dev-sync-trigger, and judge the window with soak-assert. Use when asked to soak a build, observe an installed release overnight, or produce a soak verdict for the stability program.
+disable-model-invocation: true
+---
+
+# Soak
+
+Observe an installed Freed Desktop build over hours using terminal evidence only, then judge the window with a machine-readable verdict. The canonical contract lives in [docs/SOAK-AND-TRIGGERS.md](../../../docs/SOAK-AND-TRIGGERS.md); if this skill and that document disagree, the document wins. Program rules in [docs/STABILITY-PROGRAM.md](../../../docs/STABILITY-PROGRAM.md) bind every soak: **no watchdog changes, one behavioral change per soak cycle, provider-visible work needs owner approval first.**
+
+## Workflow
+
+1. Confirm what is installed and running: `defaults read /Applications/Freed.app/Contents/Info.plist CFBundleShortVersionString` and `pgrep -fl "Freed.app/Contents/MacOS"`. If the app is not running, launch it in the background with `open -g /Applications/Freed.app` — never a foregrounding click path.
+2. Start collection: `node scripts/soak-collect.mjs --detach`. It samples the app process, the WebKit process table, and runtime-health offsets into `~/.freed/automation/soaks/<timestamp>/` and repoints `~/.freed/automation/current-soak-dir`. For unattended overnight windows, hold the machine awake with `caffeinate -is` (record its pid; kill it at soak end).
+3. Write a `soak-context.md` into the soak dir at start: build version, why this soak is running, cloud/provider/relay connection state (verified from local logs — sync-health.json, runtime-health.jsonl — never by opening the app UI), and which program cycle this window belongs to (baseline, positive control, post-damper).
+4. If a provider sync must be triggered for signal, use `node scripts/dev-sync-trigger.mjs <provider>` per the canonical doc, including its locked-machine spacing rules. Dev-channel builds enable the trigger automatically.
+5. Never stall overnight waiting for a click: follow the 10-minute-timeout contract — ask with a 10-minute response window, then proceed; ship a terminal trigger for anything recurring.
+6. While the soak runs, heartbeat hourly: app + collector pids alive, `metrics.tsv` growing. If the app died, append the death time and any runtime-health/crash evidence to `soak-context.md`, relaunch with `open -g`, and record the relaunch — deaths are evidence, not something to fix mid-soak.
+7. After the target window (≥6h for program soaks), judge it: `node scripts/soak-assert.mjs`. It writes `soak-verdict.json` with named, file:line-cited assertions. Report the verdict path and the assertion table.
+8. Close out: stop caffeinate, decide whether the collector keeps running for the next cycle, and record the verdict's headline counters wherever the requesting cycle needs them (scorecard column, canary ledger via freed-canary, or a PR).
+
+## Success criteria (counters, not vibes)
+
+- A `soak-verdict.json` exists for the window with every assertion judged (pass/fail/skipped), each failure citing file:line evidence.
+- `soak-context.md` records build, purpose, connection state, and any mid-soak deaths/relaunches.
+- The window is attributable: one build, known start/end, collector samples covering it.

--- a/.agents/skills/freed-triage/SKILL.md
+++ b/.agents/skills/freed-triage/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: freed-triage
+description: Run the stability triage loop — fold invariant alarms, the latest soak verdict, canary regressions, and open CI-failure issues into ranked task files, then either execute the top candidate through its program task or leave the queue for the nightly runner. Use when asked to triage stability evidence, decide what to fix next, or after a soak/canary produced failures.
+disable-model-invocation: true
+---
+
+# Triage
+
+Evidence in, ranked tasks out. This skill drives `scripts/triage.mjs` (stability W2-02), which dedupes live evidence into root-cause buckets that map to EXISTING program tasks — the point is convergence on [docs/STABILITY-PROGRAM.md](../../../docs/STABILITY-PROGRAM.md), never a fork of it. Program rules bind: **watchdog freeze, one behavioral change per soak cycle, provider-visible approval lane, runner-safe:false means owner reviews the PR.**
+
+## Workflow
+
+1. Run the loop: `node scripts/triage.mjs` (add `--no-ci` offline; `--json` for the full evidence). It reads rotated runtime-health alarms (last 48h), the latest `soak-verdict.json` via the automation pointer, the newest `canary-ledger/` record's regressions, and open `automation-triage` GitHub issues, then writes ranked `T-<rank>-<bucket>.md` files into `~/.freed/automation/triage/candidates/`.
+2. Present the ranked candidates with their evidence pointers (file:line into runtime-health, verdict entries, canary records, issue links). Every claim must trace to a pointer — no vibes.
+3. Decide the handoff:
+   - **Execute now:** open the top candidate's mapped program task (e.g. `docs/stability-tasks/P1-04-preflight-recycle-guard.md`) and run it through `freed-build-feature`, obeying that task's own `runner-safe` / `provider-visible` / `soak-gated` header. A `runner-safe: false` task ends at an owner-review PR, never an autonomous merge. A `soak-gated` task must not batch with another behavioral change.
+   - **Queue for the nightly runner:** do nothing further — the candidate directory is already a first-class source in `scripts/nightly-self-improve.mjs`, ranked above roadmap work while the evidence is fresh (<48h).
+4. If the top candidate is `ci-red`: fix CI first; nothing ships over a red pipeline. Close the `automation-triage` issue when the fix merges so the bucket drains.
+5. Re-run after the next soak/canary window and confirm executed buckets STOP appearing — a bucket that persists after its fix merged means the fix didn't move the counter; say so loudly.
+
+## Success criteria (counters, not vibes)
+
+- `~/.freed/automation/triage/candidates/` contains freshly ranked `T-*.md` files whose evidence pointers resolve.
+- Each surfaced bucket either becomes an executed program task (PR opened under its own governance) or is explicitly left for the nightly runner — never silently dropped.
+- After the mapped fix lands, the next triage run shows that bucket gone or falling; the program scorecard row it maps to moves toward target.

--- a/docs/STABILITY-PROGRAM.md
+++ b/docs/STABILITY-PROGRAM.md
@@ -57,7 +57,7 @@ Done when: every counter in the scorecard below has a baseline number from one o
 | [W2-01](stability-tasks/W2-01-invariant-alarms.md) | Invariant alarms: cloud_loop, scrape_zero_persist, preflight_kill, auth_zombie, relay_divergence, watchdog_thrash | no | ◐ observing — cloud_loop positive control CONFIRMED (v26.7.701-dev); breakers + relay_divergence deferred |
 | [W2-02](stability-tasks/W2-02-triage-loop.md) | Triage loop: alarms + canary + red CI → ranked task files; CI-failure issue hook | yes | ☑ |
 | [W2-03](stability-tasks/W2-03-canary-replay-bisect.md) | canary-summarize, watchdog-replay, bisect-regression scripts | yes | ☑ |
-| [W2-04](stability-tasks/W2-04-new-skills.md) | New skills: freed-soak, freed-triage, freed-canary | yes | ☐ |
+| [W2-04](stability-tasks/W2-04-new-skills.md) | New skills: freed-soak, freed-triage, freed-canary | yes | ☑ |
 
 Ordering inside Wave 2: W2-01 alarms may land before their matching P1 dampers (positive control). P1-01 through P1-05 land one per soak cycle, in numeric order. W2-02/03/04 are substrate and run in parallel threads.
 


### PR DESCRIPTION
(AI Generated).

W2-04 (`runner-safe: true` — skills are docs). The program's three operational moves — run a soak, judge a release, triage evidence — each become a one-command skill any thread or loop can execute consistently, instead of re-reading prose.

- **freed-soak** — terminal-first installed-build soak: `open -g`, `soak-collect.mjs`, dev-sync-trigger + locked-machine rules by reference to the canonical doc, hourly heartbeats with death-as-evidence handling, `soak-assert.mjs` verdict, 10-minute-timeout contract included.
- **freed-canary** — `canary-summarize.mjs` → committed ledger record → trailing-median regression reading → `bisect-regression.mjs` dry-run plan with an explicit-go gate before `--execute`.
- **freed-triage** — `triage.mjs` → ranked candidates with evidence pointers → execute the top mapped program task under its own `runner-safe`/`provider-visible`/`soak-gated` header, or leave the queue for the nightly runner; `ci-red` drains first.

All three cite the program rules (watchdog freeze, provider-visible lane, one-behavioral-change-per-soak) and state counter-based success criteria.

## Verification (task's Verify section)
- Dry-read check: every referenced script/doc resolves (`scripts/{soak-collect,soak-assert,dev-sync-trigger,canary-summarize,bisect-regression,triage,nightly-self-improve}.mjs`, canonical docs, `canary-ledger/`).
- Live end-to-end artifacts already exist from this cycle: soak dirs + verdicts (freed-soak's flow ran three nights), `canary-ledger/canary-26.7.800.json` (freed-canary's flow), and ranked `T-*.md` triage candidates (freed-triage's flow, which correctly pointed at P1-01/P1-04).

Checks W2-04 in docs/STABILITY-PROGRAM.md — completing the Wave 2 substrate row (W2-02 ✑ #937, W2-03 ✑ #936).

🤖 Generated with [Claude Code](https://claude.com/claude-code)