### PR TITLE
fix: ignore resolved soak alarms in triage

### DIFF
--- a/scripts/triage.mjs
+++ b/scripts/triage.mjs
@@ -209,6 +209,28 @@ export function readCiIssues({ exec = execFileSync } = {}) {
   }
 }
 
+function resolvedAlarmNamesFromVerdict(verdictInfo) {
+  const assertions = verdictInfo?.verdict?.assertions;
+  if (!assertions) return new Set();
+
+  const statusByAssertion = new Map(
+    assertions.map((assertion) => [assertion.id, assertion.status]),
+  );
+  const resolved = new Set();
+  for (const bucket of BUCKETS) {
+    if (bucket.alarms.length === 0 || bucket.assertions.length === 0) continue;
+    const bucketStatuses = bucket.assertions
+      .map((id) => statusByAssertion.get(id))
+      .filter(Boolean);
+    if (bucketStatuses.includes("pass") && !bucketStatuses.includes("fail")) {
+      for (const alarm of bucket.alarms) {
+        resolved.add(alarm);
+      }
+    }
+  }
+  return resolved;
+}
+
 /**
  * Fold the four evidence streams into scored bucket candidates.
  * score = severity * ln(1 + hits) * freshness, freshness 1.0 for <24h-old
@@ -216,6 +238,7 @@ export function readCiIssues({ exec = execFileSync } = {}) {
  */
 export function buildCandidates({ alarms, verdictInfo, canaryInfo, ciIssues, nowMs }) {
   const candidates = new Map();
+  const resolvedAlarmNames = resolvedAlarmNamesFromVerdict(verdictInfo);
   const touch = (bucketId) => {
     const bucket = BUCKETS.find((b) => b.id === bucketId);
     if (!bucket) return null;
@@ -226,6 +249,7 @@ export function buildCandidates({ alarms, verdictInfo, canaryInfo, ciIssues, now
   };
 
   for (const [name, aggregate] of Object.entries(alarms ?? {})) {
+    if (resolvedAlarmNames.has(name)) continue;
     const bucket = BUCKETS.find((b) => b.alarms.includes(name));
     if (!bucket) continue;
     const candidate = touch(bucket.id);

--- a/scripts/triage.test.mjs
+++ b/scripts/triage.test.mjs
@@ -130,6 +130,43 @@ test("a synthetic alarm aggregate + failed verdict produce ranked task files wit
   assert.match(rendered, /runtime-health-20260709\.jsonl:42/);
 });
 
+test("passed soak assertions suppress stale raw alarms for the same bucket", () => {
+  const alarms = {
+    preflight_kill: {
+      count: 13,
+      lastTsMs: NOW - 1_000,
+      evidence: [{ file: "runtime-health-20260709.jsonl", line: 1639, detail: "window destroyed during held session" }],
+    },
+    scrape_zero_persist: {
+      count: 1,
+      lastTsMs: NOW - 1_000,
+      evidence: [{ file: "runtime-health-20260709.jsonl", line: 2077, detail: "x scrape extracted 76 items but persisted 0" }],
+    },
+    cloud_loop: {
+      count: 2,
+      lastTsMs: NOW - 1_000,
+      evidence: [{ file: "runtime-health-20260709.jsonl", line: 1532, detail: "2 uploads unchanged heads" }],
+    },
+  };
+  const verdictInfo = {
+    verdictPath: "/soak/soak-verdict.json",
+    verdict: {
+      windowEnd: new Date(NOW).toISOString(),
+      assertions: [
+        { id: "preflight_kills", status: "pass", detail: "0 of 10 window_destroyed records killed an active session" },
+        { id: "scrape_zero_persist", status: "fail", detail: "1 scrape extracted >= 5 items and persisted 0" },
+        { id: "uploads_unchanged_heads", status: "fail", detail: "2 of 8 uploads had unchanged heads" },
+      ],
+    },
+  };
+
+  const ranked = buildCandidates({ alarms, verdictInfo, canaryInfo: null, ciIssues: [], nowMs: NOW });
+  const ids = ranked.map((candidate) => candidate.bucket.id);
+  assert.ok(!ids.includes("preflight-kill"), "resolved preflight assertions should clear raw positive-control alarms");
+  assert.ok(ids.includes("scrape-zero-persist"), "failing assertions still produce candidates");
+  assert.ok(ids.includes("cloud-loop"), "failing cloud-loop assertions still produce candidates");
+});
+
 test("CI issues rank at the top when fresh", () => {
   const ranked = buildCandidates({
     alarms: { cloud_loop: { count: 2, lastTsMs: NOW - 6 * 86_400_000, evidence: [] } },


### PR DESCRIPTION
(AI Generated).

## Summary
- Stops triage from ranking raw invariant alarms when the latest soak assertion for that same bucket passed.
- Keeps still-failing soak and canary buckets active, so unresolved cloud-loop and scrape-persist evidence still reaches the queue.

## Testing
- node --test scripts/triage.test.mjs
- node scripts/triage.mjs --json
- PATH=/Users/aubreyfalconer/.nvm/versions/node/v24.14.1/bin:$PATH npm run validate:feature