### PR TITLE
docs: update roadmap for YouTube focus

### DIFF
--- a/website/src/app/roadmap/RoadmapContent.tsx
+++ b/website/src/app/roadmap/RoadmapContent.tsx
@@ -731,7 +731,7 @@ const phases: Phase[] = [
     number: 4,
     title: "Sync Layer",
     description:
-      "Local relay, Google Drive, and Dropbox sync are working, with health checks, retries, debug charts, and desktop snapshots. iCloud is still open.",
+      "Local relay, Google Drive, and Dropbox sync are working, with health checks, retries, debug charts, and desktop snapshots. iCloud is still open. Large offline media will use a separate future transport outside the synced Freed document.",
     status: "current",
     planLink:
       "https://github.com/freed-project/freed/blob/dev/docs/PHASE-4-SYNC.md",
@@ -804,7 +804,7 @@ const phases: Phase[] = [
     number: 12,
     title: "Additional Platforms",
     description:
-      "LinkedIn and YouTube are in. YouTube adds focused click-to-load viewing, exact-video app handoff, followed-channel sync, and a private playlist users can download in YouTube Premium. Next up: Mozi, TikTok, Threads, Bluesky, and Reddit.",
+      "LinkedIn and YouTube are in. YouTube adds focused viewing, exact-video app handoff, followed-channel sync, and a private playlist for Premium downloads. Future work explores offline audio prepared by Freed Desktop and transferred over the local network or encrypted user cloud. Next up: Mozi, TikTok, Threads, Bluesky, and Reddit.",
     status: "current",
     planLink:
       "https://github.com/freed-project/freed/blob/dev/docs/PHASE-12-ADDITIONAL-PLATFORMS.md",

--- a/website/src/app/roadmap/RoadmapContent.tsx
+++ b/website/src/app/roadmap/RoadmapContent.tsx
@@ -804,7 +804,7 @@ const phases: Phase[] = [
     number: 12,
     title: "Additional Platforms",
     description:
-      "LinkedIn is live. Next up: Mozi, TikTok, Threads, Bluesky, Reddit, and YouTube, all with the same guarded capture and health model.",
+      "LinkedIn and YouTube are in. YouTube adds focused click-to-load viewing, exact-video app handoff, followed-channel sync, and a private playlist users can download in YouTube Premium. Next up: Mozi, TikTok, Threads, Bluesky, and Reddit.",
     status: "current",
     planLink:
       "https://github.com/freed-project/freed/blob/dev/docs/PHASE-12-ADDITIONAL-PLATFORMS.md",


### PR DESCRIPTION
(AI Generated).

## Summary
- Update Phase 4 roadmap copy to keep large offline media outside the synced Freed document.
- Update Phase 12 roadmap copy for focused YouTube capture, Premium playlist handoff, and the documented future offline audio transport.

## Testing
- `cd website && PATH=../node_modules/.bin:$PATH npm run build`
- Local roadmap preview returns the updated copy at `http://localhost:3001/roadmap`