### PR TITLE
perf: reduce Automerge worker restart churn

### DIFF
--- a/docs/STABILITY-PROGRAM.md
+++ b/docs/STABILITY-PROGRAM.md
@@ -82,7 +82,7 @@ Must land AFTER the P1 dampers or the relay and cloud loops amplify each other.
 ## Wave 5 — Memory demand-side (summaries)
 
 - Raw-bytes transport: transferable Uint8Array postMessage + Tauri raw ArrayBuffer invoke (deletes the 16-20x number[]/JSON amplification).
-- Worker lifecycle: [W5-01](stability-tasks/W5-01-worker-idle-quiet-window.md) keeps immediate document release but holds the unloaded worker shell for a 30 second sliding quiet window. The candidate is implemented and awaiting an installed-build soak. Concurrent INIT coalescing remains a separate later slice.
+- Worker lifecycle: [W5-01](stability-tasks/W5-01-worker-idle-quiet-window.md) keeps immediate document release but holds the unloaded worker shell for a 30 second sliding quiet window. The candidate is implemented and awaiting a post-PR 949 measurement-only baseline, followed by its separate installed-build effect soak. Concurrent INIT coalescing remains a separate later slice.
 - UPDATE_FEED_ITEM through ITEM_PATCH; batch imports persist once.
 - Cloud merge moves into the Automerge worker.
 - Re-enable eviction for cloud users from markCloudSuccess (guarded by destructive-merge guard + snapshots).

--- a/docs/STABILITY-PROGRAM.md
+++ b/docs/STABILITY-PROGRAM.md
@@ -82,7 +82,7 @@ Must land AFTER the P1 dampers or the relay and cloud loops amplify each other.
 ## Wave 5 — Memory demand-side (summaries)
 
 - Raw-bytes transport: transferable Uint8Array postMessage + Tauri raw ArrayBuffer invoke (deletes the 16-20x number[]/JSON amplification).
-- Worker lifecycle: time-based idle unload (30-60s) instead of unload-on-queue-drain + 1s kill; persist compaction bookkeeping across unloads.
+- Worker lifecycle: [W5-01](stability-tasks/W5-01-worker-idle-quiet-window.md) keeps immediate document release but holds the unloaded worker shell for a 30 second sliding quiet window. The candidate is implemented and awaiting an installed-build soak. Concurrent INIT coalescing remains a separate later slice.
 - UPDATE_FEED_ITEM through ITEM_PATCH; batch imports persist once.
 - Cloud merge moves into the Automerge worker.
 - Re-enable eviction for cloud users from markCloudSuccess (guarded by destructive-merge guard + snapshots).

--- a/docs/STABILITY-PROGRAM.md
+++ b/docs/STABILITY-PROGRAM.md
@@ -82,7 +82,7 @@ Must land AFTER the P1 dampers or the relay and cloud loops amplify each other.
 ## Wave 5 — Memory demand-side (summaries)
 
 - Raw-bytes transport: transferable Uint8Array postMessage + Tauri raw ArrayBuffer invoke (deletes the 16-20x number[]/JSON amplification).
-- Worker lifecycle: [W5-01](stability-tasks/W5-01-worker-idle-quiet-window.md) keeps immediate document release but holds the unloaded worker shell for a 30 second sliding quiet window. The candidate is implemented and awaiting a post-PR 949 measurement-only baseline, followed by its separate installed-build effect soak. Concurrent INIT coalescing remains a separate later slice.
+- Worker lifecycle: [W5-01](stability-tasks/W5-01-worker-idle-quiet-window.md) keeps immediate document release but holds the unloaded worker shell for a 30 second sliding quiet window. The candidate is implemented and awaiting PR 949 plus separately approved native identity stamping, then a measurement-only baseline followed by its separate installed-build effect soak. Concurrent INIT coalescing remains a separate later slice.
 - UPDATE_FEED_ITEM through ITEM_PATCH; batch imports persist once.
 - Cloud merge moves into the Automerge worker.
 - Re-enable eviction for cloud users from markCloudSuccess (guarded by destructive-merge guard + snapshots).

--- a/docs/stability-tasks/W5-01-worker-idle-quiet-window.md
+++ b/docs/stability-tasks/W5-01-worker-idle-quiet-window.md
@@ -4,9 +4,11 @@ runner-safe: false | provider-visible: false | soak-gated: YES
 
 Finding: F20, repeated full Automerge initialization during sequential local bookkeeping.
 
-Prerequisites: the deterministic large-document worker harness from PR 950 and
-the schema 3 collector, metric registry, fingerprint, and outcome converter from
-PR 949.
+Prerequisites: the deterministic large-document worker harness from PR 950,
+the schema 3 collector, metric registry, fingerprint, and outcome converter
+from PR 949, and separately approved native runtime identity stamping. PR 949
+stamps renderer-originated counters, but native heartbeat, memory, recovery,
+window, and alarm records remain untagged until the gated native change lands.
 
 ## Evidence
 
@@ -49,13 +51,17 @@ Desktop 26.7.1000 predates the complete immutable runtime identity envelope. It
 can calibrate collection and document the causal trace, but it cannot be
 promoted into a lifecycle outcome or used as the measured-effect denominator.
 
-After PR 949 lands, install a measurement-only build from `dev` that does not
-contain W5-01. Run it for at least six credited app-alive hours and require a
-closed, healthy schema 3 verdict with a complete fingerprint, attributable
-build identity, and an artifact digest. Before W5-01 is installed, amend this
-task and the PR body with the exact frozen baseline verdict path and SHA-256.
-If that baseline is inconclusive, repair measurement and rerun it. Do not
-install the W5-01 behavior against an inadmissible denominator.
+After PR 949 and the separately approved native identity stamp land, install a
+measurement-only build from `dev` that does not contain W5-01. The central
+native runtime-health writer must stamp every metric-relevant event with one
+app version, full commit SHA, release channel, and native process-session ID.
+Derived invariant alarms must preserve the same identity. Run the build for at
+least six credited app-alive hours and require a closed, healthy schema 3
+verdict with a complete fingerprint, attributable build identity, and an
+artifact digest. Before W5-01 is installed, amend this task and the PR body with
+the exact frozen baseline verdict path and SHA-256. If that baseline is
+inconclusive, repair measurement and rerun it. Do not install the W5-01 behavior
+against an inadmissible denominator.
 
 Then install a different build containing only this behavioral change. Run it
 for at least six credited app-alive hours with this exact comparison context:

--- a/docs/stability-tasks/W5-01-worker-idle-quiet-window.md
+++ b/docs/stability-tasks/W5-01-worker-idle-quiet-window.md
@@ -1,0 +1,42 @@
+# W5-01: Automerge worker idle quiet window
+
+runner-safe: false | provider-visible: false | soak-gated: YES
+
+Finding: F20, repeated full Automerge initialization during sequential local bookkeeping.
+
+Prerequisite: the deterministic large-document worker harness from PR 950.
+
+## Evidence
+
+The untriggered Freed Desktop 26.7.1000 baseline at `~/.freed/automation/soaks/2026-07-11-1914` loaded a 15,466,044-byte Automerge document repeatedly. Sequential worker generations initialized about 4.5 seconds and 20 seconds apart around existing snapshot and cloud-upload bookkeeping. App-attributed WebKit resident memory reached multiple gigabytes while the document was loaded repeatedly.
+
+The complete launch segment recorded one INIT per worker generation. Concurrent INIT coalescing would not address this trace and stays outside this slice.
+
+## Behavior
+
+1. Continue releasing `currentDoc` as soon as the worker request queue drains.
+2. Retain only the unloaded worker shell and `currentBinary` for a 30 second sliding quiet window.
+3. Cancel the stop timer when document work begins, including binary reads that do not reload `currentDoc`.
+4. Start a fresh quiet window when a request settles or the worker reports document release.
+5. Preserve the one second retry when a stop attempt finds active requests.
+6. Terminate normally after 30 quiet seconds.
+
+This slice does not change cloud scheduling, upload cadence, provider requests, WebView behavior, watchdog thresholds, or Automerge document contents.
+
+## Verification
+
+- Unit lifecycle tests prove that the worker survives for 29,999 milliseconds, terminates at 30 seconds, remains alive while a request is pending, slides the quiet window after unloaded binary and relay-count activity, and still terminates after an unanswered request reaches its bounded timeout.
+- The real-worker browser test uses the deterministic large document, proves that a binary read reuses the same worker generation without another INIT, then proves eventual termination, reinitialization, mutation, and persistence.
+- The focused worker integration and memory contract tests remain green.
+- `npm run validate:feature` passes on the exact branch head.
+
+## Installed-build acceptance
+
+Install a build containing only this behavioral change. Run a bounded soak with the same document-size bucket and existing background schedule as the baseline.
+
+- Snapshot and cloud bookkeeping within 30 seconds reuse one worker generation and one INIT.
+- Worker INITs per hour move toward the registered target of fewer than 10.
+- Memory pressure is compared across attributable process generations. Raw RSS alone is not a verdict.
+- The worker still terminates after a genuine quiet window and reloads the document correctly on the next mutation.
+
+Do not install concurrent INIT coalescing, cloud coverage instrumentation, provider scheduling changes, or watchdog changes in this soak build.

--- a/docs/stability-tasks/W5-01-worker-idle-quiet-window.md
+++ b/docs/stability-tasks/W5-01-worker-idle-quiet-window.md
@@ -4,13 +4,24 @@ runner-safe: false | provider-visible: false | soak-gated: YES
 
 Finding: F20, repeated full Automerge initialization during sequential local bookkeeping.
 
-Prerequisite: the deterministic large-document worker harness from PR 950.
+Prerequisites: the deterministic large-document worker harness from PR 950 and
+the schema 3 collector, metric registry, fingerprint, and outcome converter from
+PR 949.
 
 ## Evidence
 
-The untriggered Freed Desktop 26.7.1000 baseline at `~/.freed/automation/soaks/2026-07-11-1914` loaded a 15,466,044-byte Automerge document repeatedly. Sequential worker generations initialized about 4.5 seconds and 20 seconds apart around existing snapshot and cloud-upload bookkeeping. App-attributed WebKit resident memory reached multiple gigabytes while the document was loaded repeatedly.
+The exploratory Freed Desktop 26.7.1000 trace at
+`~/.freed/automation/soaks/2026-07-11-1914` loaded a 15,466,044-byte Automerge
+document repeatedly. Sequential worker generations initialized about 4.5
+seconds and 20 seconds apart around existing snapshot and cloud-upload
+bookkeeping. App-attributed WebKit resident memory reached multiple gigabytes
+while the document was loaded repeatedly.
 
-The complete launch segment recorded one INIT per worker generation. Concurrent INIT coalescing would not address this trace and stays outside this slice.
+The complete launch segment recorded one INIT per worker generation. Concurrent
+INIT coalescing would not address this trace and stays outside this slice. This
+trace has only 4.65 credited app-alive hours, unhealthy collector density,
+legacy schema 1 evidence, and incomplete build identity. It is diagnostic
+evidence only and must not be used as the W5-01 comparison denominator.
 
 ## Behavior
 
@@ -25,19 +36,56 @@ This slice does not change cloud scheduling, upload cadence, provider requests, 
 
 ## Verification
 
-- Unit lifecycle tests prove that the worker survives for 29,999 milliseconds, terminates at 30 seconds, remains alive while a request is pending, slides the quiet window after unloaded binary and relay-count activity, and still terminates after an unanswered request reaches its bounded timeout.
+- Unit lifecycle tests prove that the worker survives for 29,999 milliseconds, terminates at 30 seconds, remains alive while a request is pending, slides the quiet window after unloaded binary and acknowledged relay-count activity, cannot terminate during a slow document reinitialization, resets a reinitialization after its bounded timeout, and still terminates after other unanswered requests reach their bounded timeout.
 - The real-worker browser test uses the deterministic large document, proves that a binary read reuses the same worker generation without another INIT, then proves eventual termination, reinitialization, mutation, and persistence.
 - The focused worker integration and memory contract tests remain green.
 - `npm run validate:feature` passes on the exact branch head.
 
 ## Installed-build acceptance
 
-Install a build containing only this behavioral change. Run a bounded soak with the same document-size bucket and existing background schedule as the baseline.
+The current schema 3 current-behavior window at
+`~/.freed/automation/soaks/2026-07-12-1758` is also analytical because Freed
+Desktop 26.7.1000 predates the complete immutable runtime identity envelope. It
+can calibrate collection and document the causal trace, but it cannot be
+promoted into a lifecycle outcome or used as the measured-effect denominator.
 
-- Snapshot and cloud bookkeeping within 30 seconds reuse one worker generation and one INIT.
-- Worker INITs per hour move toward the registered target of fewer than 10.
-- `worker_idle_terminated` records prove normal quiet-window termination separately from worker resets and request-timeout cleanup, including the explicit scheduling reason, scheduled delay, actual timer elapsed time, and timer overrun caused by renderer throttling.
+After PR 949 lands, install a measurement-only build from `dev` that does not
+contain W5-01. Run it for at least six credited app-alive hours and require a
+closed, healthy schema 3 verdict with a complete fingerprint, attributable
+build identity, and an artifact digest. Before W5-01 is installed, amend this
+task and the PR body with the exact frozen baseline verdict path and SHA-256.
+If that baseline is inconclusive, repair measurement and rerun it. Do not
+install the W5-01 behavior against an inadmissible denominator.
+
+Then install a different build containing only this behavioral change. Run it
+for at least six credited app-alive hours with this exact comparison context:
+
+- Scenario: `background-current-behavior-no-manual-triggers`
+- Provider cohort: `social-state-unverified_gdrive-active_dropbox-unobserved`
+- Document-size bucket: `automerge-14-to-16-mib`
+- Host: Darwin, arm64, 64 GiB memory tier
+- Duration: 0.8 through 1.25 times the frozen baseline, with an exact six-hour pair preferred
+
+- Focused unit and real-worker tests prove that adjacent binary, snapshot, and cloud bookkeeping within 30 seconds reuse one worker generation. Installed runtime evidence does not claim operation-to-generation attribution.
+- `worker_init_rate` is below 10 events per app-alive hour and improves by more than the registered 0.25 events per app-alive hour tolerance.
+- `worker_idle_terminated` records distinguish normal quiet-window termination from pending-request retries and request-timeout cleanup. Scheduled delay, actual timer elapsed time, and timer overrun diagnose event-loop delay that can be consistent with renderer throttling. They do not prove its cause.
 - Memory pressure is compared across attributable process generations. Raw RSS alone is not a verdict.
 - The worker still terminates after a genuine quiet window and reloads the document correctly on the next mutation.
+
+Build the lifecycle outcome only from the two frozen raw verdicts:
+
+```bash
+node scripts/build-outcome-verdict.mjs \
+  --soak-verdict <effect-soak>/soak-verdict.json \
+  --task-id W5-01 \
+  --outcome verified_effective \
+  --metric worker-init-rate \
+  --baseline-reference <baseline-soak>/soak-verdict.json \
+  --out <effect-soak>/outcome-verdict.json
+```
+
+The converter must accept the different build commits, exact comparison
+context, comparable duration, complete fingerprints, and evidence-derived
+improvement. A hand-calculated rate is not a lifecycle outcome.
 
 Do not install concurrent INIT coalescing, cloud coverage instrumentation, provider scheduling changes, or watchdog changes in this soak build.

--- a/docs/stability-tasks/W5-01-worker-idle-quiet-window.md
+++ b/docs/stability-tasks/W5-01-worker-idle-quiet-window.md
@@ -36,6 +36,7 @@ Install a build containing only this behavioral change. Run a bounded soak with 
 
 - Snapshot and cloud bookkeeping within 30 seconds reuse one worker generation and one INIT.
 - Worker INITs per hour move toward the registered target of fewer than 10.
+- `worker_idle_terminated` records prove normal quiet-window termination separately from worker resets and request-timeout cleanup, including the explicit scheduling reason, scheduled delay, actual timer elapsed time, and timer overrun caused by renderer throttling.
 - Memory pressure is compared across attributable process generations. Raw RSS alone is not a verdict.
 - The worker still terminates after a genuine quiet window and reloads the document correctly on the next mutation.
 

--- a/packages/desktop/src/lib/automerge-types.ts
+++ b/packages/desktop/src/lib/automerge-types.ts
@@ -133,7 +133,7 @@ export type WorkerRequest =
   | { reqId: number; type: "GET_HEADS" }
   | { reqId: number; type: "GET_SAVED_YOUTUBE_URLS" }
   | { reqId: number; type: "GET_ITEM_PRESERVED_TEXT"; globalId: string }
-  // Relay management (fire-and-forget, reqId ignored)
+  // Relay management (bypasses the document queue but returns an ACK)
   | { reqId: number; type: "UPDATE_RELAY_CLIENT_COUNT"; count: number };
 
 export type DocChangeEvent =

--- a/packages/desktop/src/lib/automerge-worker-integration.test.ts
+++ b/packages/desktop/src/lib/automerge-worker-integration.test.ts
@@ -230,11 +230,17 @@ describe("real Automerge worker module", () => {
       fixture.manifest.binaryBytes,
     );
 
+    const relayCountStart = posts.length;
     sendRequest(scope, {
       reqId: 5,
       type: "UPDATE_RELAY_CLIENT_COUNT",
       count: 1,
     });
+    await waitForPost(
+      posts,
+      (message) => message.type === "ACK" && message.reqId === 5,
+      relayCountStart,
+    );
     const mutationStart = posts.length;
     sendRequest(scope, {
       reqId: 6,

--- a/packages/desktop/src/lib/automerge-worker-lifecycle.test.ts
+++ b/packages/desktop/src/lib/automerge-worker-lifecycle.test.ts
@@ -71,6 +71,12 @@ class MockWorker {
     for (const listener of this.listeners.get("message") ?? []) listener(event);
     this.onmessage?.(event);
   }
+
+  emitError(message: string): void {
+    const event = { message, currentTarget: this };
+    for (const listener of this.listeners.get("error") ?? []) listener(event);
+    this.onerror?.(event);
+  }
 }
 
 function makeItem(): FeedItem {
@@ -379,13 +385,187 @@ describe("automerge worker lifecycle", () => {
     await vi.advanceTimersByTimeAsync(20_000);
 
     automerge.setRelayClientCount(1);
-    await waitForWorkerRequest(worker, "UPDATE_RELAY_CLIENT_COUNT");
+    const relayRequest = await waitForWorkerRequest(
+      worker,
+      "UPDATE_RELAY_CLIENT_COUNT",
+    );
     expect(MockWorker.instances).toHaveLength(1);
 
-    await vi.advanceTimersByTimeAsync(20_000);
+    await vi.advanceTimersByTimeAsync(30_000);
     expect(worker.terminated).toBe(false);
-    await vi.advanceTimersByTimeAsync(11_000);
+    worker.emitMessage({ reqId: relayRequest.reqId, type: "ACK" });
+    await vi.advanceTimersByTimeAsync(29_999);
+    expect(worker.terminated).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
     expect(worker.terminated).toBe(true);
+  });
+
+  it("does not terminate while a large document reinitialization is pending", async () => {
+    const automerge = await import("./automerge");
+    const firstWorker = MockWorker.instances[0];
+    firstWorker.emitMessage({ type: "READY" });
+    await completeWorkerInit(firstWorker, automerge.initDoc(), makeState(), 6_291_456);
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(firstWorker.terminated).toBe(true);
+
+    const mutation = automerge.docAddFeedItem(makeItem());
+    const secondWorker = MockWorker.instances[1];
+    secondWorker.emitMessage({ type: "READY" });
+    const reinitRequest = await waitForWorkerRequest(secondWorker, "INIT");
+
+    automerge.setRelayClientCount(1);
+    const relayRequest = await waitForWorkerRequest(
+      secondWorker,
+      "UPDATE_RELAY_CLIENT_COUNT",
+    );
+    secondWorker.emitMessage({ reqId: relayRequest.reqId, type: "ACK" });
+
+    await vi.advanceTimersByTimeAsync(31_000);
+    expect(secondWorker.terminated).toBe(false);
+
+    secondWorker.emitMessage({ type: "STATE_UPDATE", state: makeState() });
+    secondWorker.emitMessage({
+      type: "INIT_STATS",
+      durationMs: 31_000,
+      docBytes: 6_291_456,
+    });
+    secondWorker.emitMessage({ reqId: reinitRequest.reqId, type: "ACK" });
+
+    const addRequest = await waitForWorkerRequest(
+      secondWorker,
+      "ADD_FEED_ITEM",
+    );
+    secondWorker.emitMessage({ reqId: addRequest.reqId, type: "ACK" });
+    await expect(mutation).resolves.toBeUndefined();
+
+    await vi.advanceTimersByTimeAsync(29_999);
+    expect(secondWorker.terminated).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(secondWorker.terminated).toBe(true);
+  });
+
+  it("resets a worker whose document reinitialization times out", async () => {
+    const automerge = await import("./automerge");
+    const firstWorker = MockWorker.instances[0];
+    firstWorker.emitMessage({ type: "READY" });
+    await completeWorkerInit(firstWorker, automerge.initDoc());
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(firstWorker.terminated).toBe(true);
+
+    const mutation = automerge.docAddFeedItem(makeItem());
+    const mutationResult = mutation.then(
+      () => null,
+      (error: unknown) => error,
+    );
+    const secondWorker = MockWorker.instances[1];
+    secondWorker.emitMessage({ type: "READY" });
+    await waitForWorkerRequest(secondWorker, "INIT");
+
+    await vi.advanceTimersByTimeAsync(180_000);
+    expect(secondWorker.terminated).toBe(true);
+    await expect(mutationResult).resolves.toMatchObject({
+      message: expect.stringContaining("request TIMEOUT op=INIT"),
+    });
+    expect(recordRuntimeHealthEventMock).toHaveBeenCalledWith({
+      event: "worker_runtime_failed",
+      phase: "runtime_init_timeout",
+      message: expect.stringContaining("request TIMEOUT op=INIT"),
+    });
+  });
+
+  it("does not clear local data when the initial document load times out", async () => {
+    const automerge = await import("./automerge");
+    const worker = MockWorker.instances[0];
+    worker.emitMessage({ type: "READY" });
+
+    const initResult = automerge.initDoc().then(
+      () => null,
+      (error: unknown) => error,
+    );
+    await waitForWorkerRequest(worker, "INIT");
+    await vi.advanceTimersByTimeAsync(180_000);
+
+    expect(worker.terminated).toBe(true);
+    await expect(initResult).resolves.toMatchObject({
+      message: expect.stringContaining("request TIMEOUT op=INIT"),
+    });
+    expect(MockWorker.instances).toHaveLength(1);
+    expect(
+      worker.messages.some(
+        (message) =>
+          typeof message === "object" &&
+          message !== null &&
+          "type" in message &&
+          (message as { type?: unknown }).type === "CLEAR_LOCAL",
+      ),
+    ).toBe(false);
+  });
+
+  it("does not clear local data when the initial worker generation crashes", async () => {
+    const automerge = await import("./automerge");
+    const worker = MockWorker.instances[0];
+    worker.emitMessage({ type: "READY" });
+
+    const initResult = automerge.initDoc().then(
+      () => null,
+      (error: unknown) => error,
+    );
+    await waitForWorkerRequest(worker, "INIT");
+    worker.emitError("worker crashed during INIT");
+
+    expect(worker.terminated).toBe(true);
+    await expect(initResult).resolves.toMatchObject({
+      message: "worker crashed during INIT",
+    });
+    expect(MockWorker.instances).toHaveLength(1);
+    expect(
+      worker.messages.some(
+        (message) =>
+          typeof message === "object" &&
+          message !== null &&
+          "type" in message &&
+          (message as { type?: unknown }).type === "CLEAR_LOCAL",
+      ),
+    ).toBe(false);
+  });
+
+  it("ignores lifecycle messages from a terminated worker generation", async () => {
+    const automerge = await import("./automerge");
+    const firstWorker = MockWorker.instances[0];
+    firstWorker.emitMessage({ type: "READY" });
+    await completeWorkerInit(firstWorker, automerge.initDoc());
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(firstWorker.terminated).toBe(true);
+
+    const mutation = automerge.docAddFeedItem(makeItem());
+    const secondWorker = MockWorker.instances[1];
+    secondWorker.emitMessage({ type: "READY" });
+    await completeWorkerInit(secondWorker, Promise.resolve(makeState()));
+    const addRequest = await waitForWorkerRequest(
+      secondWorker,
+      "ADD_FEED_ITEM",
+    );
+    secondWorker.emitMessage({ reqId: addRequest.reqId, type: "ACK" });
+    await mutation;
+
+    await vi.advanceTimersByTimeAsync(20_000);
+    firstWorker.emitMessage({
+      type: "DEBUG_EVENT",
+      kind: "change",
+      detail:
+        "[automerge-worker] released idle document after request queue drained",
+    });
+    firstWorker.emitMessage({
+      type: "STATE_UPDATE",
+      state: makeState([makeItem()]),
+    });
+
+    expect(automerge.getDocState()?.items).toHaveLength(0);
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(secondWorker.terminated).toBe(true);
   });
 
   it.todo(

--- a/packages/desktop/src/lib/automerge-worker-lifecycle.test.ts
+++ b/packages/desktop/src/lib/automerge-worker-lifecycle.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { DocState } from "./automerge-types";
 
 const recordWorkerInitMock = vi.hoisted(() => vi.fn());
+const recordRuntimeHealthEventMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: vi.fn(),
@@ -24,7 +25,7 @@ vi.mock("./logger.js", () => ({
 }));
 
 vi.mock("./runtime-health-events", () => ({
-  recordRuntimeHealthEvent: vi.fn(),
+  recordRuntimeHealthEvent: recordRuntimeHealthEventMock,
   recordWorkerInit: recordWorkerInitMock,
 }));
 
@@ -163,6 +164,7 @@ describe("automerge worker lifecycle", () => {
     vi.useFakeTimers();
     MockWorker.instances = [];
     recordWorkerInitMock.mockReset();
+    recordRuntimeHealthEventMock.mockReset();
     vi.stubGlobal("Worker", MockWorker);
   });
 
@@ -207,16 +209,26 @@ describe("automerge worker lifecycle", () => {
       docBytes: 6_291_456,
     });
 
+    const scheduledAtMs = Date.now();
     firstWorker.emitMessage({
       type: "DEBUG_EVENT",
       kind: "change",
       detail:
         "[automerge-worker] released idle document after request queue drained",
     });
+    vi.setSystemTime(scheduledAtMs + 15_000);
     await vi.advanceTimersByTimeAsync(29_999);
     expect(firstWorker.terminated).toBe(false);
     await vi.advanceTimersByTimeAsync(1);
     expect(firstWorker.terminated).toBe(true);
+    expect(recordRuntimeHealthEventMock).toHaveBeenCalledWith({
+      event: "worker_idle_terminated",
+      reason: "quiet_window",
+      quietWindowTargetMs: 30_000,
+      scheduledDelayMs: 30_000,
+      timerElapsedMs: 45_000,
+      timerOverrunMs: 15_000,
+    });
 
     const mutation = automerge.docAddFeedItem(makeItem());
     expect(MockWorker.instances).toHaveLength(2);
@@ -342,6 +354,14 @@ describe("automerge worker lifecycle", () => {
     expect(worker.terminated).toBe(false);
     await vi.advanceTimersByTimeAsync(1_000);
     expect(worker.terminated).toBe(true);
+    expect(recordRuntimeHealthEventMock).toHaveBeenCalledWith({
+      event: "worker_idle_terminated",
+      reason: "request_timeout_cleanup",
+      quietWindowTargetMs: 30_000,
+      scheduledDelayMs: 1_000,
+      timerElapsedMs: 1_000,
+      timerOverrunMs: 0,
+    });
   });
 
   it("restarts the quiet window after a relay client-count update", async () => {

--- a/packages/desktop/src/lib/automerge-worker-lifecycle.test.ts
+++ b/packages/desktop/src/lib/automerge-worker-lifecycle.test.ts
@@ -213,7 +213,9 @@ describe("automerge worker lifecycle", () => {
       detail:
         "[automerge-worker] released idle document after request queue drained",
     });
-    await vi.advanceTimersByTimeAsync(1_000);
+    await vi.advanceTimersByTimeAsync(29_999);
+    expect(firstWorker.terminated).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
     expect(firstWorker.terminated).toBe(true);
 
     const mutation = automerge.docAddFeedItem(makeItem());
@@ -264,12 +266,105 @@ describe("automerge worker lifecycle", () => {
         "[automerge-worker] released idle document after request queue drained",
     });
 
-    await vi.advanceTimersByTimeAsync(1_000);
+    await vi.advanceTimersByTimeAsync(30_000);
     expect(worker.terminated).toBe(false);
 
     worker.emitMessage({ reqId: request.reqId, type: "ACK" });
     await mutation;
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(worker.terminated).toBe(true);
+  });
+
+  it("restarts the quiet window after an unloaded binary read", async () => {
+    const automerge = await import("./automerge");
+    const worker = MockWorker.instances[0];
+    worker.emitMessage({ type: "READY" });
+    await completeWorkerInit(worker, automerge.initDoc());
+
+    worker.emitMessage({
+      type: "DEBUG_EVENT",
+      kind: "change",
+      detail:
+        "[automerge-worker] released idle document after request queue drained",
+    });
+    await vi.advanceTimersByTimeAsync(20_000);
+
+    const binaryPromise = automerge.getDocBinary();
+    const request = await waitForWorkerRequest(worker, "GET_DOC_BINARY");
+    expect(MockWorker.instances).toHaveLength(1);
+    expect(
+      worker.messages.filter(
+        (message) =>
+          typeof message === "object" &&
+          message !== null &&
+          "type" in message &&
+          (message as { type?: unknown }).type === "INIT",
+      ),
+    ).toHaveLength(1);
+
+    worker.emitMessage({
+      reqId: request.reqId,
+      type: "DOC_BINARY",
+      binary: new Uint8Array([1, 2, 3]),
+    });
+    await expect(binaryPromise).resolves.toEqual(new Uint8Array([1, 2, 3]));
+
+    await vi.advanceTimersByTimeAsync(20_000);
+    expect(worker.terminated).toBe(false);
+    await vi.advanceTimersByTimeAsync(11_000);
+    expect(worker.terminated).toBe(true);
+  });
+
+  it("stops the worker after an unanswered request times out", async () => {
+    const automerge = await import("./automerge");
+    const worker = MockWorker.instances[0];
+    worker.emitMessage({ type: "READY" });
+    await completeWorkerInit(worker, automerge.initDoc());
+
+    worker.emitMessage({
+      type: "DEBUG_EVENT",
+      kind: "change",
+      detail:
+        "[automerge-worker] released idle document after request queue drained",
+    });
+
+    const binaryPromise = automerge.getDocBinary();
+    const binaryResult = binaryPromise.then(
+      () => null,
+      (error: unknown) => error,
+    );
+    await waitForWorkerRequest(worker, "GET_DOC_BINARY");
+    await vi.advanceTimersByTimeAsync(180_000);
+    await expect(binaryResult).resolves.toMatchObject({
+      message: expect.stringContaining("request TIMEOUT op=GET_DOC_BINARY"),
+    });
+
+    expect(worker.terminated).toBe(false);
     await vi.advanceTimersByTimeAsync(1_000);
+    expect(worker.terminated).toBe(true);
+  });
+
+  it("restarts the quiet window after a relay client-count update", async () => {
+    const automerge = await import("./automerge");
+    const worker = MockWorker.instances[0];
+    worker.emitMessage({ type: "READY" });
+    await completeWorkerInit(worker, automerge.initDoc());
+
+    worker.emitMessage({
+      type: "DEBUG_EVENT",
+      kind: "change",
+      detail:
+        "[automerge-worker] released idle document after request queue drained",
+    });
+    await vi.advanceTimersByTimeAsync(20_000);
+
+    automerge.setRelayClientCount(1);
+    await waitForWorkerRequest(worker, "UPDATE_RELAY_CLIENT_COUNT");
+    expect(MockWorker.instances).toHaveLength(1);
+
+    await vi.advanceTimersByTimeAsync(20_000);
+    expect(worker.terminated).toBe(false);
+    await vi.advanceTimersByTimeAsync(11_000);
     expect(worker.terminated).toBe(true);
   });
 

--- a/packages/desktop/src/lib/automerge-worker-memory.test.ts
+++ b/packages/desktop/src/lib/automerge-worker-memory.test.ts
@@ -141,16 +141,22 @@ describe("automerge worker memory routing", () => {
     expect(handleBody).toContain("ensureCurrentDocLoaded(req.type)");
   });
 
-  it("terminates idle workers and restarts them before later requests", () => {
+  it("keeps the unloaded worker shell through a bounded quiet window", () => {
     expect(clientSource).toContain("let worker: Worker | null = null");
     expect(clientSource).toContain("let idleWorkerStopTimer");
+    expect(clientSource).toContain("IDLE_WORKER_STOP_DELAY_MS = 30_000");
     expect(clientSource).toContain("IDLE_WORKER_STOP_RETRY_MS = 1_000");
     expect(clientSource).toContain("function hasPendingWorkerRequests()");
     expect(clientSource).toContain("function stopIdleWorker()");
-    expect(clientSource).toContain("function scheduleIdleWorkerStop()");
-    expect(clientSource).toContain("if (!stopIdleWorker() && worker)");
+    expect(clientSource).toContain("function cancelIdleWorkerStop()");
+    expect(clientSource).toContain("function completeWorkerActivity(");
+    expect(clientSource).toContain("function scheduleIdleWorkerStop(");
+    expect(clientSource).toContain("scheduleIdleWorkerStop(IDLE_WORKER_STOP_RETRY_MS)");
     expect(clientSource).toContain("worker.terminate()");
     expect(clientSource).toContain("ensureWorkerDocumentReadyFor(msg.type)");
+    expect(clientSource).toContain("cancelIdleWorkerStop();");
+    expect(clientSource).toContain("completeWorkerActivity(IDLE_WORKER_STOP_RETRY_MS)");
+    expect(clientSource).toContain('if ("reqId" in msg && appDocumentInitialized)');
     expect(clientSource).toContain("await sendInit()");
     expect(clientSource).toContain("(msg.detail ?? \"\").startsWith(\"[automerge-worker] released idle document\")");
     expect(clientSource).toContain("scheduleIdleWorkerStop();");

--- a/packages/desktop/src/lib/automerge-worker-memory.test.ts
+++ b/packages/desktop/src/lib/automerge-worker-memory.test.ts
@@ -151,11 +151,15 @@ describe("automerge worker memory routing", () => {
     expect(clientSource).toContain("function cancelIdleWorkerStop()");
     expect(clientSource).toContain("function completeWorkerActivity(");
     expect(clientSource).toContain("function scheduleIdleWorkerStop(");
-    expect(clientSource).toContain("scheduleIdleWorkerStop(IDLE_WORKER_STOP_RETRY_MS)");
+    expect(clientSource).toMatch(
+      /scheduleIdleWorkerStop\(\s*IDLE_WORKER_STOP_RETRY_MS,\s*"pending_request_retry",?\s*\)/,
+    );
     expect(clientSource).toContain("worker.terminate()");
     expect(clientSource).toContain("ensureWorkerDocumentReadyFor(msg.type)");
     expect(clientSource).toContain("cancelIdleWorkerStop();");
-    expect(clientSource).toContain("completeWorkerActivity(IDLE_WORKER_STOP_RETRY_MS)");
+    expect(clientSource).toMatch(
+      /completeWorkerActivity\(\s*IDLE_WORKER_STOP_RETRY_MS,\s*"request_timeout_cleanup",?\s*\)/,
+    );
     expect(clientSource).toContain('if ("reqId" in msg && appDocumentInitialized)');
     expect(clientSource).toContain("await sendInit()");
     expect(clientSource).toContain("(msg.detail ?? \"\").startsWith(\"[automerge-worker] released idle document\")");

--- a/packages/desktop/src/lib/automerge-worker-memory.test.ts
+++ b/packages/desktop/src/lib/automerge-worker-memory.test.ts
@@ -147,6 +147,8 @@ describe("automerge worker memory routing", () => {
     expect(clientSource).toContain("IDLE_WORKER_STOP_DELAY_MS = 30_000");
     expect(clientSource).toContain("IDLE_WORKER_STOP_RETRY_MS = 1_000");
     expect(clientSource).toContain("function hasPendingWorkerRequests()");
+    expect(clientSource).toContain("pendingInit.size > 0");
+    expect(clientSource).toContain("pendingRelayClientCount.size > 0");
     expect(clientSource).toContain("function stopIdleWorker()");
     expect(clientSource).toContain("function cancelIdleWorkerStop()");
     expect(clientSource).toContain("function completeWorkerActivity(");
@@ -164,6 +166,15 @@ describe("automerge worker memory routing", () => {
     expect(clientSource).toContain("await sendInit()");
     expect(clientSource).toContain("(msg.detail ?? \"\").startsWith(\"[automerge-worker] released idle document\")");
     expect(clientSource).toContain("scheduleIdleWorkerStop();");
+    expect(clientSource).toContain("pendingInit.set(reqId, {");
+    expect(clientSource).toContain("idleWorkerStopTimer !== scheduledTimer");
+    expect(clientSource).toContain("worker !== scheduledWorker");
+    expect(clientSource).toContain("sourceWorker !== worker");
+    expect(clientSource).toContain("error instanceof WorkerInitFailureError");
+    expect(clientSource).toContain("error instanceof WorkerInitResponseError");
+    expect(workerSource).toMatch(
+      /if \(req\.type === "UPDATE_RELAY_CLIENT_COUNT"\) \{[\s\S]*?ack\(req\.reqId\);[\s\S]*?return;/,
+    );
   });
 
   it("rebuilds a fresh Automerge document only after compacting oversized text", () => {

--- a/packages/desktop/src/lib/automerge.ts
+++ b/packages/desktop/src/lib/automerge.ts
@@ -56,6 +56,10 @@ type IdleWorkerStopReason =
   | "pending_request_retry"
   | "request_timeout_cleanup";
 
+class WorkerInitFailureError extends Error {}
+class WorkerInitResponseError extends Error {}
+class WorkerInitTimeoutError extends WorkerInitFailureError {}
+
 // ---------------------------------------------------------------------------
 // Worker lifecycle
 // ---------------------------------------------------------------------------
@@ -102,6 +106,8 @@ function rejectPendingWorkerRequests(error: Error): void {
   rejectPendingMap(pendingPreservedText, error);
   rejectPendingMap(pendingContentSignalBackfill, error);
   rejectPendingMap(pendingSampleDataClear, error);
+  rejectPendingMap(pendingInit, error);
+  rejectPendingMap(pendingRelayClientCount, error);
 }
 
 function resetFailedWorker(failedWorker: Worker, error: Error, phase: string): void {
@@ -178,11 +184,7 @@ function startWorker(): void {
   if (latestRelayClientCount > 0) {
     void workerReady.then(() => {
       if (worker !== nextWorker) return;
-      nextWorker.postMessage({
-        reqId: nextReqId++,
-        type: "UPDATE_RELAY_CLIENT_COUNT",
-        count: latestRelayClientCount,
-      } satisfies WorkerRequest);
+      postRelayClientCount(nextWorker, latestRelayClientCount);
     }).catch(() => {});
   }
 }
@@ -215,7 +217,9 @@ function hasPendingWorkerRequests(): boolean {
     pendingSavedYouTubeUrls.size > 0 ||
     pendingPreservedText.size > 0 ||
     pendingContentSignalBackfill.size > 0 ||
-    pendingSampleDataClear.size > 0
+    pendingSampleDataClear.size > 0 ||
+    pendingInit.size > 0 ||
+    pendingRelayClientCount.size > 0
   );
 }
 
@@ -245,8 +249,15 @@ function scheduleIdleWorkerStop(
 ): void {
   if (!worker) return;
   cancelIdleWorkerStop();
+  const scheduledWorker = worker;
   const scheduledAtMs = Date.now();
-  idleWorkerStopTimer = setTimeout(() => {
+  const scheduledTimer = setTimeout(() => {
+    if (
+      idleWorkerStopTimer !== scheduledTimer ||
+      worker !== scheduledWorker
+    ) {
+      return;
+    }
     idleWorkerStopTimer = null;
     const firedAtMs = Date.now();
     if (stopIdleWorker()) {
@@ -266,6 +277,7 @@ function scheduleIdleWorkerStop(
       );
     }
   }, delayMs);
+  idleWorkerStopTimer = scheduledTimer;
 }
 
 function completeWorkerActivity(
@@ -362,6 +374,46 @@ const pendingSampleDataClear = new Map<
     timer: ReturnType<typeof setTimeout>;
   }
 >();
+const pendingInit = new Map<number, PendingRequestFailureHandler>();
+const pendingRelayClientCount = new Map<
+  number,
+  PendingRequestFailureHandler
+>();
+
+function postRelayClientCount(activeWorker: Worker, count: number): void {
+  cancelIdleWorkerStop();
+  const reqId = nextReqId++;
+  const timer = setTimeout(() => {
+    if (!pendingRelayClientCount.has(reqId)) return;
+    pendingRelayClientCount.delete(reqId);
+    completeTimedOutWorkerActivity();
+    const message =
+      `[automerge-worker] request TIMEOUT op=UPDATE_RELAY_CLIENT_COUNT` +
+      ` reqId=${reqId} timeout_ms=${WORKER_REQUEST_TIMEOUT_MS.toLocaleString()}`;
+    log.error(message);
+    addDebugEvent("error", message);
+    recordRuntimeHealthEvent({
+      event: "worker_runtime_failed",
+      phase: "relay_client_count_timeout",
+      message,
+    });
+  }, WORKER_REQUEST_TIMEOUT_MS);
+
+  pendingRelayClientCount.set(reqId, {
+    timer,
+    reject: (error) => {
+      log.warn(
+        `[automerge-worker] relay client-count update cancelled: ${error.message}`,
+      );
+    },
+  });
+  activeWorker.postMessage({
+    reqId,
+    type: "UPDATE_RELAY_CLIENT_COUNT",
+    count,
+  } satisfies WorkerRequest);
+}
+
 async function request(msg: WorkerRequest): Promise<void> {
   await ensureWorkerDocumentReadyFor(msg.type);
   const activeWorker = getWorker();
@@ -443,13 +495,7 @@ export function setRelayClientCount(n: number): void {
   const activeWorker = worker;
   void ensureWorkerReady().then(() => {
     if (worker !== activeWorker) return;
-    cancelIdleWorkerStop();
-    activeWorker.postMessage({
-      reqId: nextReqId++,
-      type: "UPDATE_RELAY_CLIENT_COUNT",
-      count: n,
-    } satisfies WorkerRequest);
-    completeWorkerActivity();
+    postRelayClientCount(activeWorker, n);
   });
 }
 
@@ -458,6 +504,8 @@ export function setRelayClientCount(n: number): void {
 // ---------------------------------------------------------------------------
 
 function handleWorkerMessage(event: MessageEvent<WorkerResponse>) {
+  const sourceWorker = event.currentTarget as Worker | null;
+  if (sourceWorker && sourceWorker !== worker) return;
   const msg = event.data;
 
   if (msg.type === "READY") return;
@@ -641,6 +689,14 @@ function handleWorkerMessage(event: MessageEvent<WorkerResponse>) {
     return;
   }
 
+  const pendingRelay = pendingRelayClientCount.get(msg.reqId);
+  if (pendingRelay) {
+    clearTimeout(pendingRelay.timer);
+    pendingRelayClientCount.delete(msg.reqId);
+    if (msg.error) pendingRelay.reject(new Error(msg.error));
+    return;
+  }
+
   // ACK
   const pendingBackfill = pendingContentSignalBackfill.get(msg.reqId);
   if (pendingBackfill && msg.error) {
@@ -675,20 +731,22 @@ function handleWorkerMessage(event: MessageEvent<WorkerResponse>) {
 }
 
 function handleWorkerError(err: ErrorEvent) {
+  const failedWorker = (err.currentTarget as Worker | null) ?? worker;
+  if (failedWorker && failedWorker !== worker) return;
   const msg = workerErrorMessage(err);
   log.error(`[automerge-worker] unhandled error: ${msg}`);
   addDebugEvent("error", `[AutomergeWorker] unhandled error: ${msg}`);
-  const failedWorker = (err.currentTarget as Worker | null) ?? worker;
   if (failedWorker) {
     resetFailedWorker(failedWorker, new Error(msg), "runtime_error");
   }
 }
 
 function handleWorkerMessageError(err: MessageEvent) {
+  const failedWorker = (err.currentTarget as Worker | null) ?? worker;
+  if (failedWorker && failedWorker !== worker) return;
   const msg = workerErrorMessage(err);
   log.error(`[automerge-worker] message error: ${msg}`);
   addDebugEvent("error", `[AutomergeWorker] message error: ${msg}`);
-  const failedWorker = (err.currentTarget as Worker | null) ?? worker;
   if (failedWorker) {
     resetFailedWorker(failedWorker, new Error(msg), "runtime_message_error");
   }
@@ -721,17 +779,40 @@ function sendInit(): Promise<DocState> {
 
     let initialState: DocState | null = null;
     let initAcked = false;
-    let resolved = false;
+    let settled = false;
+
+    function cleanup() {
+      const pendingRequest = pendingInit.get(reqId);
+      if (pendingRequest) clearTimeout(pendingRequest.timer);
+      pendingInit.delete(reqId);
+      activeWorker.removeEventListener("message", stateHandler);
+    }
+
+    function fail(error: Error) {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(error);
+    }
 
     function tryResolve() {
-      if (!initialState || !initAcked || resolved) return;
-      resolved = true;
+      if (!initialState || !initAcked || settled) return;
+      settled = true;
+      cleanup();
       appDocumentInitialized = true;
       workerDocumentInitialized = true;
+      completeWorkerActivity();
       resolve(initialState);
     }
 
     const stateHandler = (event: MessageEvent<WorkerResponse>) => {
+      const sourceWorker = event.currentTarget as Worker | null;
+      if (
+        (sourceWorker && sourceWorker !== activeWorker) ||
+        worker !== activeWorker
+      ) {
+        return;
+      }
       const msg = event.data;
       if (msg.type === "STATE_UPDATE" && !initialState) {
         lastDocState = msg.state;
@@ -744,9 +825,8 @@ function sendInit(): Promise<DocState> {
           () => "(doc lives in worker - not directly accessible)",
           () => new Uint8Array(0),
         );
-        activeWorker.removeEventListener("message", stateHandler);
         if (msg.error) {
-          reject(new Error(msg.error));
+          fail(new WorkerInitResponseError(msg.error));
         } else {
           initAcked = true;
           tryResolve();
@@ -754,6 +834,26 @@ function sendInit(): Promise<DocState> {
       }
     };
 
+    const timer = setTimeout(() => {
+      if (!pendingInit.has(reqId)) return;
+      pendingInit.delete(reqId);
+      const error = new WorkerInitTimeoutError(
+        `[automerge-worker] request TIMEOUT op=INIT reqId=${reqId}` +
+          ` timeout_ms=${WORKER_REQUEST_TIMEOUT_MS.toLocaleString()}`,
+      );
+      resetFailedWorker(activeWorker, error, "runtime_init_timeout");
+      fail(error);
+    }, WORKER_REQUEST_TIMEOUT_MS);
+
+    pendingInit.set(reqId, {
+      timer,
+      reject: (error) =>
+        fail(
+          error instanceof WorkerInitFailureError
+            ? error
+            : new WorkerInitFailureError(error.message),
+        ),
+    });
     activeWorker.addEventListener("message", stateHandler);
     activeWorker.postMessage({ reqId, type: "INIT" } satisfies WorkerRequest);
   });
@@ -766,7 +866,8 @@ export async function initDoc(): Promise<DocState> {
     appDocumentInitialized = true;
     workerDocumentInitialized = true;
     return state;
-  } catch {
+  } catch (error) {
+    if (!(error instanceof WorkerInitResponseError)) throw error;
     await clearLocalDoc();
     const state = await sendInit();
     appDocumentInitialized = true;

--- a/packages/desktop/src/lib/automerge.ts
+++ b/packages/desktop/src/lib/automerge.ts
@@ -45,6 +45,10 @@ export type { DocChangeEvent, DocState } from "./automerge-types";
  */
 const WORKER_REQUEST_TIMEOUT_MS = 180_000;
 const WORKER_START_TIMEOUT_MS = 15_000;
+// The worker releases currentDoc as soon as its request queue drains. Keep the
+// unloaded shell and currentBinary briefly so sequential snapshot and cloud
+// bookkeeping can reuse one generation without another full A.load.
+const IDLE_WORKER_STOP_DELAY_MS = 30_000;
 const IDLE_WORKER_STOP_RETRY_MS = 1_000;
 
 // ---------------------------------------------------------------------------
@@ -224,18 +228,33 @@ function stopIdleWorker(): boolean {
   return true;
 }
 
-function scheduleIdleWorkerStop(): void {
-  if (idleWorkerStopTimer || !worker) return;
+function cancelIdleWorkerStop(): void {
+  if (!idleWorkerStopTimer) return;
+  clearTimeout(idleWorkerStopTimer);
+  idleWorkerStopTimer = null;
+}
+
+function scheduleIdleWorkerStop(delayMs = IDLE_WORKER_STOP_DELAY_MS): void {
+  if (!worker) return;
+  cancelIdleWorkerStop();
   idleWorkerStopTimer = setTimeout(() => {
     idleWorkerStopTimer = null;
     if (!stopIdleWorker() && worker) {
-      scheduleIdleWorkerStop();
+      scheduleIdleWorkerStop(IDLE_WORKER_STOP_RETRY_MS);
     }
-  }, IDLE_WORKER_STOP_RETRY_MS);
+  }, delayMs);
+}
+
+function completeWorkerActivity(
+  delayMs = IDLE_WORKER_STOP_DELAY_MS,
+): void {
+  if (!appDocumentInitialized) return;
+  scheduleIdleWorkerStop(delayMs);
 }
 
 async function ensureWorkerDocumentReadyFor(type: WorkerRequest["type"]): Promise<void> {
   await ensureWorkerReady();
+  cancelIdleWorkerStop();
   if (
     !appDocumentInitialized ||
     workerDocumentInitialized ||
@@ -320,6 +339,7 @@ async function request(msg: WorkerRequest): Promise<void> {
       if (!pending.has(msg.reqId)) return;
       const pendingCount = pending.size;
       pending.delete(msg.reqId);
+      completeWorkerActivity(IDLE_WORKER_STOP_RETRY_MS);
       const opType = (msg as { type: string }).type;
       const errMsg =
         `[automerge-worker] request TIMEOUT op=${opType} reqId=${msg.reqId} ` +
@@ -392,11 +412,13 @@ export function setRelayClientCount(n: number): void {
   const activeWorker = worker;
   void ensureWorkerReady().then(() => {
     if (worker !== activeWorker) return;
+    cancelIdleWorkerStop();
     activeWorker.postMessage({
       reqId: nextReqId++,
       type: "UPDATE_RELAY_CLIENT_COUNT",
       count: n,
     } satisfies WorkerRequest);
+    completeWorkerActivity();
   });
 }
 
@@ -408,6 +430,12 @@ function handleWorkerMessage(event: MessageEvent<WorkerResponse>) {
   const msg = event.data;
 
   if (msg.type === "READY") return;
+
+  // Some reads use currentBinary and do not emit a document-release trace.
+  // A terminal response still starts a fresh quiet window for the worker shell.
+  if ("reqId" in msg && appDocumentInitialized) {
+    completeWorkerActivity();
+  }
 
   if (msg.type === "STATE_UPDATE") {
     publishState(msg.state, {
@@ -729,6 +757,7 @@ export async function getDocBinary(): Promise<Uint8Array> {
     const timer = setTimeout(() => {
       if (!pendingDocBinary.has(reqId)) return;
       pendingDocBinary.delete(reqId);
+      completeWorkerActivity(IDLE_WORKER_STOP_RETRY_MS);
       reject(
         new Error(
           `[automerge-worker] request TIMEOUT op=GET_DOC_BINARY reqId=${reqId} timeout_ms=${WORKER_REQUEST_TIMEOUT_MS.toLocaleString()}`,
@@ -748,12 +777,14 @@ export async function getDocBinary(): Promise<Uint8Array> {
  */
 export async function getDocHeads(): Promise<string[] | null> {
   await ensureWorkerReady();
+  cancelIdleWorkerStop();
   const activeWorker = getWorker();
   return new Promise((resolve, reject) => {
     const reqId = nextReqId++;
     const timer = setTimeout(() => {
       if (!pendingDocHeads.has(reqId)) return;
       pendingDocHeads.delete(reqId);
+      completeWorkerActivity(IDLE_WORKER_STOP_RETRY_MS);
       reject(
         new Error(
           `[automerge-worker] request TIMEOUT op=GET_HEADS reqId=${reqId} timeout_ms=${WORKER_REQUEST_TIMEOUT_MS.toLocaleString()}`,
@@ -775,6 +806,7 @@ export async function getSavedYouTubeVideoUrls(): Promise<string[]> {
     const timer = setTimeout(() => {
       if (!pendingSavedYouTubeUrls.has(reqId)) return;
       pendingSavedYouTubeUrls.delete(reqId);
+      completeWorkerActivity(IDLE_WORKER_STOP_RETRY_MS);
       reject(
         new Error(
           `[automerge-worker] request TIMEOUT op=GET_SAVED_YOUTUBE_URLS reqId=${reqId} timeout_ms=${WORKER_REQUEST_TIMEOUT_MS.toLocaleString()}`,
@@ -799,6 +831,7 @@ export async function getAllItemIds(): Promise<string[]> {
     const timer = setTimeout(() => {
       if (!pendingAllItemIds.has(reqId)) return;
       pendingAllItemIds.delete(reqId);
+      completeWorkerActivity(IDLE_WORKER_STOP_RETRY_MS);
       reject(
         new Error(
           `[automerge-worker] request TIMEOUT op=GET_ALL_ITEM_IDS reqId=${reqId} timeout_ms=${WORKER_REQUEST_TIMEOUT_MS.toLocaleString()}`,
@@ -819,6 +852,7 @@ export async function getItemPreservedText(globalId: string): Promise<string | n
     const timer = setTimeout(() => {
       if (!pendingPreservedText.has(reqId)) return;
       pendingPreservedText.delete(reqId);
+      completeWorkerActivity(IDLE_WORKER_STOP_RETRY_MS);
       reject(
         new Error(
           `[automerge-worker] request TIMEOUT op=GET_ITEM_PRESERVED_TEXT reqId=${reqId} timeout_ms=${WORKER_REQUEST_TIMEOUT_MS.toLocaleString()}`,
@@ -906,6 +940,7 @@ export async function docClearSampleData(): Promise<SampleDataClearSummary> {
     const timer = setTimeout(() => {
       if (!pendingSampleDataClear.has(reqId)) return;
       pendingSampleDataClear.delete(reqId);
+      completeWorkerActivity(IDLE_WORKER_STOP_RETRY_MS);
       reject(
         new Error(
           `[automerge-worker] request TIMEOUT op=CLEAR_SAMPLE_DATA reqId=${reqId} timeout_ms=${WORKER_REQUEST_TIMEOUT_MS.toLocaleString()}`,
@@ -1141,6 +1176,7 @@ export async function docBackfillContentSignals(
     const timer = setTimeout(() => {
       if (!pendingContentSignalBackfill.has(reqId)) return;
       pendingContentSignalBackfill.delete(reqId);
+      completeWorkerActivity(IDLE_WORKER_STOP_RETRY_MS);
       reject(
         new Error(
           `[automerge-worker] request TIMEOUT op=BACKFILL_CONTENT_SIGNALS reqId=${reqId} timeout_ms=${WORKER_REQUEST_TIMEOUT_MS.toLocaleString()}`,

--- a/packages/desktop/src/lib/automerge.ts
+++ b/packages/desktop/src/lib/automerge.ts
@@ -51,6 +51,11 @@ const WORKER_START_TIMEOUT_MS = 15_000;
 const IDLE_WORKER_STOP_DELAY_MS = 30_000;
 const IDLE_WORKER_STOP_RETRY_MS = 1_000;
 
+type IdleWorkerStopReason =
+  | "quiet_window"
+  | "pending_request_retry"
+  | "request_timeout_cleanup";
+
 // ---------------------------------------------------------------------------
 // Worker lifecycle
 // ---------------------------------------------------------------------------
@@ -234,22 +239,48 @@ function cancelIdleWorkerStop(): void {
   idleWorkerStopTimer = null;
 }
 
-function scheduleIdleWorkerStop(delayMs = IDLE_WORKER_STOP_DELAY_MS): void {
+function scheduleIdleWorkerStop(
+  delayMs = IDLE_WORKER_STOP_DELAY_MS,
+  reason: IdleWorkerStopReason = "quiet_window",
+): void {
   if (!worker) return;
   cancelIdleWorkerStop();
+  const scheduledAtMs = Date.now();
   idleWorkerStopTimer = setTimeout(() => {
     idleWorkerStopTimer = null;
-    if (!stopIdleWorker() && worker) {
-      scheduleIdleWorkerStop(IDLE_WORKER_STOP_RETRY_MS);
+    const firedAtMs = Date.now();
+    if (stopIdleWorker()) {
+      const timerElapsedMs = Math.max(0, firedAtMs - scheduledAtMs);
+      recordRuntimeHealthEvent({
+        event: "worker_idle_terminated",
+        reason,
+        quietWindowTargetMs: IDLE_WORKER_STOP_DELAY_MS,
+        scheduledDelayMs: delayMs,
+        timerElapsedMs,
+        timerOverrunMs: Math.max(0, timerElapsedMs - delayMs),
+      });
+    } else if (worker) {
+      scheduleIdleWorkerStop(
+        IDLE_WORKER_STOP_RETRY_MS,
+        "pending_request_retry",
+      );
     }
   }, delayMs);
 }
 
 function completeWorkerActivity(
   delayMs = IDLE_WORKER_STOP_DELAY_MS,
+  reason: IdleWorkerStopReason = "quiet_window",
 ): void {
   if (!appDocumentInitialized) return;
-  scheduleIdleWorkerStop(delayMs);
+  scheduleIdleWorkerStop(delayMs, reason);
+}
+
+function completeTimedOutWorkerActivity(): void {
+  completeWorkerActivity(
+    IDLE_WORKER_STOP_RETRY_MS,
+    "request_timeout_cleanup",
+  );
 }
 
 async function ensureWorkerDocumentReadyFor(type: WorkerRequest["type"]): Promise<void> {
@@ -339,7 +370,7 @@ async function request(msg: WorkerRequest): Promise<void> {
       if (!pending.has(msg.reqId)) return;
       const pendingCount = pending.size;
       pending.delete(msg.reqId);
-      completeWorkerActivity(IDLE_WORKER_STOP_RETRY_MS);
+      completeTimedOutWorkerActivity();
       const opType = (msg as { type: string }).type;
       const errMsg =
         `[automerge-worker] request TIMEOUT op=${opType} reqId=${msg.reqId} ` +
@@ -757,7 +788,7 @@ export async function getDocBinary(): Promise<Uint8Array> {
     const timer = setTimeout(() => {
       if (!pendingDocBinary.has(reqId)) return;
       pendingDocBinary.delete(reqId);
-      completeWorkerActivity(IDLE_WORKER_STOP_RETRY_MS);
+      completeTimedOutWorkerActivity();
       reject(
         new Error(
           `[automerge-worker] request TIMEOUT op=GET_DOC_BINARY reqId=${reqId} timeout_ms=${WORKER_REQUEST_TIMEOUT_MS.toLocaleString()}`,
@@ -784,7 +815,7 @@ export async function getDocHeads(): Promise<string[] | null> {
     const timer = setTimeout(() => {
       if (!pendingDocHeads.has(reqId)) return;
       pendingDocHeads.delete(reqId);
-      completeWorkerActivity(IDLE_WORKER_STOP_RETRY_MS);
+      completeTimedOutWorkerActivity();
       reject(
         new Error(
           `[automerge-worker] request TIMEOUT op=GET_HEADS reqId=${reqId} timeout_ms=${WORKER_REQUEST_TIMEOUT_MS.toLocaleString()}`,
@@ -806,7 +837,7 @@ export async function getSavedYouTubeVideoUrls(): Promise<string[]> {
     const timer = setTimeout(() => {
       if (!pendingSavedYouTubeUrls.has(reqId)) return;
       pendingSavedYouTubeUrls.delete(reqId);
-      completeWorkerActivity(IDLE_WORKER_STOP_RETRY_MS);
+      completeTimedOutWorkerActivity();
       reject(
         new Error(
           `[automerge-worker] request TIMEOUT op=GET_SAVED_YOUTUBE_URLS reqId=${reqId} timeout_ms=${WORKER_REQUEST_TIMEOUT_MS.toLocaleString()}`,
@@ -831,7 +862,7 @@ export async function getAllItemIds(): Promise<string[]> {
     const timer = setTimeout(() => {
       if (!pendingAllItemIds.has(reqId)) return;
       pendingAllItemIds.delete(reqId);
-      completeWorkerActivity(IDLE_WORKER_STOP_RETRY_MS);
+      completeTimedOutWorkerActivity();
       reject(
         new Error(
           `[automerge-worker] request TIMEOUT op=GET_ALL_ITEM_IDS reqId=${reqId} timeout_ms=${WORKER_REQUEST_TIMEOUT_MS.toLocaleString()}`,
@@ -852,7 +883,7 @@ export async function getItemPreservedText(globalId: string): Promise<string | n
     const timer = setTimeout(() => {
       if (!pendingPreservedText.has(reqId)) return;
       pendingPreservedText.delete(reqId);
-      completeWorkerActivity(IDLE_WORKER_STOP_RETRY_MS);
+      completeTimedOutWorkerActivity();
       reject(
         new Error(
           `[automerge-worker] request TIMEOUT op=GET_ITEM_PRESERVED_TEXT reqId=${reqId} timeout_ms=${WORKER_REQUEST_TIMEOUT_MS.toLocaleString()}`,
@@ -940,7 +971,7 @@ export async function docClearSampleData(): Promise<SampleDataClearSummary> {
     const timer = setTimeout(() => {
       if (!pendingSampleDataClear.has(reqId)) return;
       pendingSampleDataClear.delete(reqId);
-      completeWorkerActivity(IDLE_WORKER_STOP_RETRY_MS);
+      completeTimedOutWorkerActivity();
       reject(
         new Error(
           `[automerge-worker] request TIMEOUT op=CLEAR_SAMPLE_DATA reqId=${reqId} timeout_ms=${WORKER_REQUEST_TIMEOUT_MS.toLocaleString()}`,
@@ -1176,7 +1207,7 @@ export async function docBackfillContentSignals(
     const timer = setTimeout(() => {
       if (!pendingContentSignalBackfill.has(reqId)) return;
       pendingContentSignalBackfill.delete(reqId);
-      completeWorkerActivity(IDLE_WORKER_STOP_RETRY_MS);
+      completeTimedOutWorkerActivity();
       reject(
         new Error(
           `[automerge-worker] request TIMEOUT op=BACKFILL_CONTENT_SIGNALS reqId=${reqId} timeout_ms=${WORKER_REQUEST_TIMEOUT_MS.toLocaleString()}`,

--- a/packages/desktop/src/lib/automerge.worker.ts
+++ b/packages/desktop/src/lib/automerge.worker.ts
@@ -1669,6 +1669,7 @@ self.onmessage = (event: MessageEvent<WorkerRequest>) => {
   const req = event.data;
   if (req.type === "UPDATE_RELAY_CLIENT_COUNT") {
     relayClientCount = req.count;
+    ack(req.reqId);
     return;
   }
 

--- a/packages/desktop/tests/e2e/automerge-worker-lifecycle.spec.ts
+++ b/packages/desktop/tests/e2e/automerge-worker-lifecycle.spec.ts
@@ -49,7 +49,7 @@ test("large document survives real worker idle termination and reinitialization"
   app,
   page,
 }, testInfo) => {
-  test.setTimeout(120_000);
+  test.setTimeout(150_000);
 
   const fixture = createLargeAutomergeFixture();
   expect(fixture.manifest.binaryBytes).toBeGreaterThanOrEqual(
@@ -249,6 +249,41 @@ test("large document survives real worker idle termination and reinitialization"
     )
     .toBe(true);
 
+  const quietWindowBinaryBytes = await page.evaluate(async () => {
+    const automerge = (
+      window as Window & {
+        __FREED_AUTOMERGE__?: {
+          getDocBinary: () => Promise<Uint8Array>;
+        };
+      }
+    ).__FREED_AUTOMERGE__;
+    if (!automerge) throw new Error("Automerge test API is unavailable");
+    return (await automerge.getDocBinary()).byteLength;
+  });
+  expect(quietWindowBinaryBytes).toBeGreaterThan(0);
+
+  const recordsAfterQuietWindowRead = await readWorkerProbeRecords(page);
+  const quietWindowWorker = recordsAfterQuietWindowRead.find(
+    (record) => record.generation === replacementGeneration,
+  );
+  if (!quietWindowWorker) {
+    throw new Error("Replacement worker disappeared during quiet-window read");
+  }
+  expect(
+    quietWindowWorker.outbound.some(
+      (message) =>
+        message.sequence > replacementSequence &&
+        message.type === "GET_DOC_BINARY",
+    ),
+  ).toBe(true);
+  expect(
+    recordsAfterQuietWindowRead.filter(
+      (record) =>
+        record.url.includes("automerge.worker") &&
+        record.generation > replacementGeneration,
+    ),
+  ).toHaveLength(0);
+
   await expect
     .poll(
       async () => {
@@ -257,7 +292,7 @@ test("large document survives real worker idle termination and reinitialization"
         );
         return record?.terminatedSequence ?? 0;
       },
-      { timeout: 30_000 },
+      { timeout: 75_000 },
     )
     .toBeGreaterThan(replacementSequence);
 


### PR DESCRIPTION
(AI Generated).

## Summary
- Keep the unloaded Automerge worker shell for a 30 second quiet window while releasing the loaded document immediately.
- Track INIT and relay control activity so idle termination cannot interrupt a live request or a replacement worker generation.
- Require PR 949, separately approved native identity stamping, and a measurement-only baseline before W5-01 is installed.

## Testing
- Focused Automerge worker suites: 43 passed, 1 explicit later-slice todo.
- Independent lifecycle audit found no remaining P0 or P1 install blocker.
- Documentation diff check and canonical provider-visible classifier passed with no provider paths.