### PR TITLE
fix: hide YouTube window after login

### DIFF
--- a/docs/PHASE-12-ADDITIONAL-PLATFORMS.md
+++ b/docs/PHASE-12-ADDITIONAL-PLATFORMS.md
@@ -221,6 +221,8 @@ packages/capture-youtube/
 
 - Freed Desktop maintains a persistent YouTube WebView data store, matching the
   existing authenticated provider pattern.
+- The interactive login window hides as soon as authentication is confirmed.
+  Initial capture continues in the same persistent background session.
 - An explicit sync captures the signed-in user's followed-channel roster and
   recent Subscriptions page video cards.
 - Routine scheduled refreshes capture only recent Subscriptions videos. Full
@@ -348,6 +350,8 @@ audio-first resolver plan, encryption, provider risk, milestones, and tests.
       YouTube developer project, OAuth grant, Data API client, or shared quota
 - [x] Recent YouTube videos are captured from the signed-in Subscriptions page
       rather than generated RSS feeds or the algorithmic Home surface
+- [x] The YouTube login window hides as soon as authentication is confirmed,
+      while the initial subscription sync continues in the persistent background session
 - [x] YouTube videos offer click-to-load focused playback without autoplay or automatic next-video behavior
 - [x] YouTube videos offer a canonical exact-video handoff for the YouTube application
 - [x] An authenticated YouTube website session can create or reuse a private

--- a/packages/desktop/src-tauri/src/youtube.rs
+++ b/packages/desktop/src-tauri/src/youtube.rs
@@ -116,6 +116,72 @@ const YOUTUBE_AUTH_PROBE_SCRIPT: &str = r#"
 
 static YOUTUBE_SESSION_OPERATION: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum YouTubeWindowPresentation {
+    Interactive,
+    Hidden,
+}
+
+impl YouTubeWindowPresentation {
+    fn from_interactive(interactive: bool) -> Self {
+        if interactive {
+            Self::Interactive
+        } else {
+            Self::Hidden
+        }
+    }
+}
+
+trait YouTubeWindowControls {
+    fn set_youtube_always_on_bottom(&self, always_on_bottom: bool);
+    fn set_youtube_focusable(&self, focusable: bool);
+    fn show_youtube_window(&self) -> Result<(), String>;
+    fn hide_youtube_window(&self) -> Result<(), String>;
+    fn focus_youtube_window(&self);
+}
+
+impl<R: tauri::Runtime> YouTubeWindowControls for tauri::WebviewWindow<R> {
+    fn set_youtube_always_on_bottom(&self, always_on_bottom: bool) {
+        let _ = self.set_always_on_bottom(always_on_bottom);
+    }
+
+    fn set_youtube_focusable(&self, focusable: bool) {
+        let _ = self.set_focusable(focusable);
+    }
+
+    fn show_youtube_window(&self) -> Result<(), String> {
+        self.show().map_err(|error| error.to_string())
+    }
+
+    fn hide_youtube_window(&self) -> Result<(), String> {
+        self.hide().map_err(|error| error.to_string())
+    }
+
+    fn focus_youtube_window(&self) {
+        let _ = self.set_focus();
+    }
+}
+
+fn apply_youtube_window_presentation(
+    window: &impl YouTubeWindowControls,
+    presentation: YouTubeWindowPresentation,
+) -> Result<(), String> {
+    match presentation {
+        YouTubeWindowPresentation::Interactive => {
+            window.set_youtube_always_on_bottom(false);
+            window.set_youtube_focusable(true);
+            window.show_youtube_window()?;
+            window.focus_youtube_window();
+        }
+        YouTubeWindowPresentation::Hidden => {
+            window.set_youtube_always_on_bottom(true);
+            window.set_youtube_focusable(false);
+            window.hide_youtube_window()?;
+        }
+    }
+    Ok(())
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct YouTubeAuthPayload {
@@ -146,6 +212,7 @@ fn build_youtube_session_window(
     url: &str,
     interactive: bool,
 ) -> Result<tauri::WebviewWindow, String> {
+    let presentation = YouTubeWindowPresentation::from_interactive(interactive);
     let window = tauri::WebviewWindowBuilder::new(
         app,
         YOUTUBE_SESSION_WINDOW_LABEL,
@@ -156,8 +223,9 @@ fn build_youtube_session_window(
     .title("YouTube with Freed")
     .inner_size(1280.0, 900.0)
     .center()
-    .visible(true)
+    .visible(presentation == YouTubeWindowPresentation::Interactive)
     .focused(interactive)
+    .focusable(interactive)
     .always_on_bottom(!interactive)
     .build()
     .map_err(|error| error.to_string())?;
@@ -179,8 +247,12 @@ fn ensure_youtube_session_window(
     url: &str,
     interactive: bool,
 ) -> Result<tauri::WebviewWindow, String> {
+    let presentation = YouTubeWindowPresentation::from_interactive(interactive);
     let window = match app.get_webview_window(YOUTUBE_SESSION_WINDOW_LABEL) {
         Some(window) => {
+            if presentation == YouTubeWindowPresentation::Hidden {
+                apply_youtube_window_presentation(&window, presentation)?;
+            }
             window
                 .navigate(youtube_url(url)?)
                 .map_err(|error| error.to_string())?;
@@ -189,25 +261,23 @@ fn ensure_youtube_session_window(
         None => build_youtube_session_window(app, url, interactive)?,
     };
 
-    window.show().map_err(|error| error.to_string())?;
-    if interactive {
-        let _ = window.set_always_on_bottom(false);
-        let _ = window.set_focusable(true);
-        let _ = window.set_focus();
-    } else {
-        let _ = window.set_always_on_bottom(true);
-    }
+    apply_youtube_window_presentation(&window, presentation)?;
     Ok(window)
 }
 
-fn demote_youtube_session_window(app: &tauri::AppHandle) {
+fn hide_youtube_session_window(
+    app: &tauri::AppHandle,
+    restore_main_focus: bool,
+) -> Result<(), String> {
     if let Some(window) = app.get_webview_window(YOUTUBE_SESSION_WINDOW_LABEL) {
-        let _ = window.show();
-        let _ = window.set_always_on_bottom(true);
+        apply_youtube_window_presentation(&window, YouTubeWindowPresentation::Hidden)?;
     }
-    if let Some(main) = app.get_webview_window("main") {
-        let _ = main.set_focus();
+    if restore_main_focus {
+        if let Some(main) = app.get_webview_window("main") {
+            let _ = main.set_focus();
+        }
     }
+    Ok(())
 }
 
 fn canonical_watch_url(video_url: &str) -> Result<(String, String), String> {
@@ -387,12 +457,7 @@ pub async fn yt_show_login(app: tauri::AppHandle) -> Result<(), String> {
 
 #[tauri::command]
 pub async fn yt_hide_login(app: tauri::AppHandle) -> Result<(), String> {
-    let _ = app.emit(
-        "yt-login-window-closed",
-        serde_json::json!({ "closed": true }),
-    );
-    demote_youtube_session_window(&app);
-    Ok(())
+    hide_youtube_session_window(&app, true)
 }
 
 #[tauri::command]
@@ -404,7 +469,7 @@ pub async fn yt_check_auth(app: tauri::AppHandle) -> Result<bool, String> {
         wait_for_auth_result(&app, &window).await
     }
     .await;
-    demote_youtube_session_window(&app);
+    let _ = hide_youtube_session_window(&app, false);
     result
 }
 
@@ -439,7 +504,7 @@ pub async fn yt_capture(app: tauri::AppHandle, include_roster: Option<bool>) -> 
         Ok(())
     }
     .await;
-    demote_youtube_session_window(&app);
+    let _ = hide_youtube_session_window(&app, false);
     result
 }
 
@@ -460,7 +525,7 @@ pub async fn yt_add_to_offline_playlist(
         Ok(())
     }
     .await;
-    demote_youtube_session_window(&app);
+    let _ = hide_youtube_session_window(&app, false);
     result
 }
 
@@ -495,6 +560,88 @@ pub async fn yt_disconnect(app: tauri::AppHandle) -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::cell::RefCell;
+
+    #[derive(Debug, Eq, PartialEq)]
+    enum RecordedYouTubeWindowAction {
+        AlwaysOnBottom(bool),
+        Focusable(bool),
+        Show,
+        Hide,
+        Focus,
+    }
+
+    #[derive(Default)]
+    struct RecordingYouTubeWindow {
+        actions: RefCell<Vec<RecordedYouTubeWindowAction>>,
+    }
+
+    impl YouTubeWindowControls for RecordingYouTubeWindow {
+        fn set_youtube_always_on_bottom(&self, always_on_bottom: bool) {
+            self.actions
+                .borrow_mut()
+                .push(RecordedYouTubeWindowAction::AlwaysOnBottom(
+                    always_on_bottom,
+                ));
+        }
+
+        fn set_youtube_focusable(&self, focusable: bool) {
+            self.actions
+                .borrow_mut()
+                .push(RecordedYouTubeWindowAction::Focusable(focusable));
+        }
+
+        fn show_youtube_window(&self) -> Result<(), String> {
+            self.actions
+                .borrow_mut()
+                .push(RecordedYouTubeWindowAction::Show);
+            Ok(())
+        }
+
+        fn hide_youtube_window(&self) -> Result<(), String> {
+            self.actions
+                .borrow_mut()
+                .push(RecordedYouTubeWindowAction::Hide);
+            Ok(())
+        }
+
+        fn focus_youtube_window(&self) {
+            self.actions
+                .borrow_mut()
+                .push(RecordedYouTubeWindowAction::Focus);
+        }
+    }
+
+    #[test]
+    fn hidden_youtube_presentation_hides_without_showing_or_focusing() {
+        let window = RecordingYouTubeWindow::default();
+        apply_youtube_window_presentation(&window, YouTubeWindowPresentation::Hidden).unwrap();
+
+        assert_eq!(
+            *window.actions.borrow(),
+            vec![
+                RecordedYouTubeWindowAction::AlwaysOnBottom(true),
+                RecordedYouTubeWindowAction::Focusable(false),
+                RecordedYouTubeWindowAction::Hide,
+            ]
+        );
+    }
+
+    #[test]
+    fn interactive_youtube_presentation_shows_and_focuses() {
+        let window = RecordingYouTubeWindow::default();
+        apply_youtube_window_presentation(&window, YouTubeWindowPresentation::Interactive).unwrap();
+
+        assert_eq!(
+            *window.actions.borrow(),
+            vec![
+                RecordedYouTubeWindowAction::AlwaysOnBottom(false),
+                RecordedYouTubeWindowAction::Focusable(true),
+                RecordedYouTubeWindowAction::Show,
+                RecordedYouTubeWindowAction::Focus,
+            ]
+        );
+    }
 
     #[test]
     fn canonical_watch_url_accepts_supported_youtube_routes() {

--- a/packages/desktop/src/__mocks__/@tauri-apps/api/core.ts
+++ b/packages/desktop/src/__mocks__/@tauri-apps/api/core.ts
@@ -60,6 +60,11 @@ function timedHandler(cmd: string, handler: Handler): Handler {
   };
 }
 
+function setMockYouTubeWindowVisible(visible: boolean): null {
+  (window as unknown as Record<string, unknown>).__TAURI_MOCK_YOUTUBE_WINDOW_VISIBLE__ = visible;
+  return null;
+}
+
 /**
  * Route an HTTP request through the Vite dev server proxy so it can make
  * real network calls server-side, bypassing CORS. Mirrors what the Rust
@@ -295,12 +300,12 @@ const handlers: Record<string, Handler> = {
   li_check_auth: () => true,
   li_scrape_feed: () => null,
   li_disconnect: () => null,
-  yt_show_login: () => null,
-  yt_hide_login: () => null,
+  yt_show_login: () => setMockYouTubeWindowVisible(true),
+  yt_hide_login: () => setMockYouTubeWindowVisible(false),
   yt_check_auth: () => true,
-  yt_capture: () => null,
-  yt_add_to_offline_playlist: () => null,
-  yt_disconnect: () => null,
+  yt_capture: () => setMockYouTubeWindowVisible(false),
+  yt_add_to_offline_playlist: () => setMockYouTubeWindowVisible(false),
+  yt_disconnect: () => setMockYouTubeWindowVisible(false),
 };
 
 // Expose handler map so tests and tauri-init.ts can override defaults.
@@ -310,6 +315,7 @@ const handlers: Record<string, Handler> = {
   cmd: string;
   args: Record<string, unknown> | undefined;
 }>;
+(window as unknown as Record<string, unknown>).__TAURI_MOCK_YOUTUBE_WINDOW_VISIBLE__ = false;
 
 const callbackStore = (
   (window as unknown as Record<string, unknown>).__TAURI_MOCK_CALLBACKS__ ??

--- a/packages/desktop/src/components/YouTubeSettingsSection.tsx
+++ b/packages/desktop/src/components/YouTubeSettingsSection.tsx
@@ -84,11 +84,12 @@ export function YouTubeSettingsSection({
       if (!loggedIn || !loginPendingRef.current) return;
 
       loginPendingRef.current = false;
-      setMessage("Connected. Syncing your subscriptions while the YouTube window stays open.");
-      void runSync("post_login")
-        .then(async () => {
+      setMessage("Connected. Syncing your subscriptions in the background.");
+      void hideYouTubeLogin()
+        .catch(() => {})
+        .then(() => runSync("post_login"))
+        .then(() => {
           setMessage("Connected. Subscription sync finished.");
-          await hideYouTubeLogin();
         })
         .catch((error) => {
           setMessage(null);
@@ -97,8 +98,9 @@ export function YouTubeSettingsSection({
     });
     const closeUnlisten = listen<{ closed: boolean }>("yt-login-window-closed", (event) => {
       if (!event.payload.closed) return;
+      const wasPending = loginPendingRef.current;
       loginPendingRef.current = false;
-      setMessage(null);
+      if (wasPending) setMessage(null);
     });
 
     return () => {

--- a/packages/desktop/src/lib/youtube-auth.ts
+++ b/packages/desktop/src/lib/youtube-auth.ts
@@ -21,7 +21,7 @@ export async function showYouTubeLogin(): Promise<void> {
   await invoke("yt_show_login");
 }
 
-/** Close the visible login window after the user has finished account prompts. */
+/** Hide the visible login window while preserving its authenticated session. */
 export async function hideYouTubeLogin(): Promise<void> {
   await invoke("yt_hide_login");
 }

--- a/packages/desktop/tests/e2e/fixtures/tauri-init.ts
+++ b/packages/desktop/tests/e2e/fixtures/tauri-init.ts
@@ -22,6 +22,7 @@ export function tauriInitScript(): string {
       return window[name];
     }
     window.__TAURI_MOCK_IPC_TIMINGS__ = [];
+    window.__TAURI_MOCK_YOUTUBE_WINDOW_VISIBLE__ = false;
     function timedHandler(cmd, fn) {
       return function(args) {
         var start = performance.now();
@@ -200,12 +201,27 @@ export function tauriInitScript(): string {
       li_check_auth: () => true,
       li_scrape_feed: () => null,
       li_disconnect: () => null,
-      yt_show_login: () => null,
-      yt_hide_login: () => null,
+      yt_show_login: () => {
+        window.__TAURI_MOCK_YOUTUBE_WINDOW_VISIBLE__ = true;
+        return null;
+      },
+      yt_hide_login: () => {
+        window.__TAURI_MOCK_YOUTUBE_WINDOW_VISIBLE__ = false;
+        return null;
+      },
       yt_check_auth: () => true,
-      yt_capture: () => null,
-      yt_add_to_offline_playlist: () => null,
-      yt_disconnect: () => null,
+      yt_capture: () => {
+        window.__TAURI_MOCK_YOUTUBE_WINDOW_VISIBLE__ = false;
+        return null;
+      },
+      yt_add_to_offline_playlist: () => {
+        window.__TAURI_MOCK_YOUTUBE_WINDOW_VISIBLE__ = false;
+        return null;
+      },
+      yt_disconnect: () => {
+        window.__TAURI_MOCK_YOUTUBE_WINDOW_VISIBLE__ = false;
+        return null;
+      },
     };
     window.__TAURI_MOCK_INVOCATIONS__ = [];
     window.__TAURI_MOCK_OPENED_URLS__ = [];

--- a/packages/desktop/tests/e2e/youtube-capture.spec.ts
+++ b/packages/desktop/tests/e2e/youtube-capture.spec.ts
@@ -41,26 +41,9 @@ test("authenticated YouTube login captures followed channels and recent videos",
   const channelId = "UC1111111111111111111111";
   await app.goto();
   await app.waitForReady();
-  await ipc.setHandler("yt_capture", () => {
-    const listeners = (window as unknown as Record<string, Record<string, Array<(event: { payload: unknown }) => void>>>).__TAURI_EVENT_LISTENERS__ ?? {};
-    const payload = {
-      channels: [{ channelId: "UC1111111111111111111111", title: "Learning Channel" }],
-      videos: [{
-        videoId: "dQw4w9WgXcQ",
-        title: "Focused Study",
-        channelId: "UC1111111111111111111111",
-        channelTitle: "Learning Channel",
-      }],
-      rosterComplete: true,
-      complete: true,
-      unresolvedCount: 0,
-      scrollPasses: 2,
-      stopReason: "stable",
-      done: true,
-    };
-    for (const listener of listeners["yt-capture-data"] ?? []) listener({ payload });
-    return null;
-  });
+  await ipc.setHandler("yt_capture", () => new Promise((resolve) => {
+    (window as unknown as Record<string, unknown>).__YOUTUBE_CAPTURE_RESOLVE__ = resolve;
+  }));
 
   await openYouTubeSettings(page);
   await page.getByText("Log in with YouTube").click();
@@ -68,16 +51,51 @@ test("authenticated YouTube login captures followed channels and recent videos",
   await expect.poll(async () =>
     (await ipc.invocations()).some((call) => call.cmd === "yt_show_login")
   ).toBe(true);
+  await expect.poll(() => page.evaluate(() =>
+    (window as unknown as Record<string, unknown>).__TAURI_MOCK_YOUTUBE_WINDOW_VISIBLE__
+  )).toBe(true);
 
   await emitTauriEvent(page, "yt-auth-result", { loggedIn: true });
+
+  await expect(page.getByText("Connected. Syncing your subscriptions in the background.")).toBeVisible({
+    timeout: 10_000,
+  });
+  await expect.poll(() => page.evaluate(() =>
+    (window as unknown as Record<string, unknown>).__TAURI_MOCK_YOUTUBE_WINDOW_VISIBLE__
+  )).toBe(false);
+  await expect.poll(async () => {
+    const calls = await ipc.invocations();
+    const hideIndex = calls.findIndex((call) => call.cmd === "yt_hide_login");
+    const captureIndex = calls.findIndex((call) => call.cmd === "yt_capture");
+    return hideIndex >= 0 && captureIndex > hideIndex;
+  }).toBe(true);
+
+  await emitTauriEvent(page, "yt-capture-data", {
+    channels: [{ channelId, title: "Learning Channel" }],
+    videos: [{
+      videoId: "dQw4w9WgXcQ",
+      title: "Focused Study",
+      channelId,
+      channelTitle: "Learning Channel",
+    }],
+    rosterComplete: true,
+    complete: true,
+    unresolvedCount: 0,
+    scrollPasses: 2,
+    stopReason: "stable",
+    done: true,
+  });
+  await page.evaluate(() => {
+    const globals = window as unknown as Record<string, unknown>;
+    const resolve = globals.__YOUTUBE_CAPTURE_RESOLVE__ as ((value: unknown) => void) | undefined;
+    resolve?.(null);
+    delete globals.__YOUTUBE_CAPTURE_RESOLVE__;
+  });
 
   await expect(page.getByText("Connected. Subscription sync finished.")).toBeVisible({
     timeout: 10_000,
   });
   await expect(page.getByText("Found 1 followed channel and 1 video.")).toBeVisible();
-  await expect.poll(async () =>
-    (await ipc.invocations()).some((call) => call.cmd === "yt_hide_login")
-  ).toBe(true);
 
   const stored = await page.evaluate(({ expectedChannelId }) => {
     const store = (window as unknown as Record<string, unknown>).__FREED_STORE__ as {
@@ -93,6 +111,57 @@ test("authenticated YouTube login captures followed channels and recent videos",
     };
   }, { expectedChannelId: channelId });
   expect(stored).toEqual({ hasChannel: true, hasVideo: true });
+});
+
+test("YouTube login still syncs when the first hide request fails", async ({
+  app,
+  page,
+  ipc,
+}) => {
+  await app.goto();
+  await app.waitForReady();
+  await ipc.setHandler("yt_hide_login", () => {
+    throw new Error("Transient hide failure");
+  });
+  await ipc.setHandler("yt_capture", () => {
+    (window as unknown as Record<string, unknown>).__TAURI_MOCK_YOUTUBE_WINDOW_VISIBLE__ = false;
+    const listeners = (
+      window as unknown as Record<
+        string,
+        Record<string, Array<(event: { payload: unknown }) => void>>
+      >
+    ).__TAURI_EVENT_LISTENERS__ ?? {};
+    const payload = {
+      channels: [],
+      videos: [],
+      rosterComplete: true,
+      complete: true,
+      unresolvedCount: 0,
+      scrollPasses: 1,
+      stopReason: "stable",
+      done: true,
+    };
+    for (const listener of listeners["yt-capture-data"] ?? []) listener({ payload });
+    return null;
+  });
+
+  await openYouTubeSettings(page);
+  await page.getByText("Log in with YouTube").click();
+  await app.acceptProviderRiskIfPresent("youtube");
+  await emitTauriEvent(page, "yt-auth-result", { loggedIn: true });
+
+  await expect(page.getByText("Connected. Subscription sync finished.")).toBeVisible({
+    timeout: 10_000,
+  });
+  await expect.poll(async () => {
+    const calls = await ipc.invocations();
+    const hideIndex = calls.findIndex((call) => call.cmd === "yt_hide_login");
+    const captureIndex = calls.findIndex((call) => call.cmd === "yt_capture");
+    return hideIndex >= 0 && captureIndex > hideIndex;
+  }).toBe(true);
+  await expect.poll(() => page.evaluate(() =>
+    (window as unknown as Record<string, unknown>).__TAURI_MOCK_YOUTUBE_WINDOW_VISIBLE__
+  )).toBe(false);
 });
 
 test("manually saved YouTube URLs sync through the rendered Freed Offline action", async ({


### PR DESCRIPTION
(AI Generated).

## Summary
- Hide the persistent YouTube WebView before post-login and routine background capture.
- Separate programmatic hiding from real window-close events and restore Freed focus only after interactive login.
- Document the lifecycle contract and cover native presentation plus renderer ordering, including transient hide failure recovery.

## Testing
- cargo test --manifest-path packages/desktop/src-tauri/Cargo.toml youtube::tests::
- npm run test:e2e -- youtube-capture.spec.ts
- npm run validate:feature
- npm run typecheck
- Native desktop preview launched as youtube-window-hide.

## Provider-Visible Approval
- Owner approved the YouTube window visibility-only fix on 2026-07-12; no request, navigation, timing, cookie, header, or extractor changes.

Provider-visible paths in this diff:
- `packages/desktop/src-tauri/src/youtube.rs`
- `packages/desktop/src/components/YouTubeSettingsSection.tsx`
- `packages/desktop/src/lib/youtube-auth.ts`