### PR TITLE
chore: prepare v26.7.1300-dev

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freed/desktop",
   "private": true,
-  "version": "26.7.1200",
+  "version": "26.7.1300",
   "type": "module",
   "scripts": {
     "dev": "node ../../node_modules/vite/bin/vite.js",

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -1420,7 +1420,7 @@ dependencies = [
 
 [[package]]
 name = "freed-desktop"
-version = "26.7.301"
+version = "26.7.1300"
 dependencies = [
  "base64 0.22.1",
  "criterion",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freed-desktop"
-version = "26.7.1200"
+version = "26.7.1300"
 description = "Freed Desktop - Escape algorithmic manipulation"
 authors = ["Freed"]
 edition = "2021"

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Freed",
-  "version": "26.7.1200",
+  "version": "26.7.1300",
   "identifier": "wtf.freed.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freed/pwa",
   "private": true,
-  "version": "26.7.1200",
+  "version": "26.7.1300",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/release-notes/daily/dev/26.7.13.json
+++ b/release-notes/daily/dev/26.7.13.json
@@ -1,0 +1,14 @@
+{
+  "channel": "dev",
+  "dayKey": "26.7.13",
+  "date": "2026-07-13",
+  "preferredDeck": null,
+  "editorialGuidance": [
+    "Keep the tone concise, professional, and specific.",
+    "Lead with user-facing outcomes, shipping milestones, trust wins, and installability improvements.",
+    "Demote internal cleanup unless it clearly changes the shipped product."
+  ],
+  "pinnedHighlights": [],
+  "editorialNotes": [],
+  "updatedAt": "2026-07-13T20:44:43.335Z"
+}

--- a/release-notes/daily/dev/26.7.13.json
+++ b/release-notes/daily/dev/26.7.13.json
@@ -2,13 +2,18 @@
   "channel": "dev",
   "dayKey": "26.7.13",
   "date": "2026-07-13",
-  "preferredDeck": null,
+  "preferredDeck": "Unattended YouTube validation now runs through the normal authenticated sync path with stricter build and soak evidence",
   "editorialGuidance": [
     "Keep the tone concise, professional, and specific.",
     "Lead with user-facing outcomes, shipping milestones, trust wins, and installability improvements.",
     "Demote internal cleanup unless it clearly changes the shipped product."
   ],
-  "pinnedHighlights": [],
-  "editorialNotes": [],
+  "pinnedHighlights": [
+    "Start the normal authenticated YouTube sync from a dev build through the terminal without foreground clicks.",
+    "Require complete subscription roster evidence, recent Subscriptions media evidence, and exact installed-build identity during the soak."
+  ],
+  "editorialNotes": [
+    "Do not claim historical archive crawling. The authenticated capture reconciles the complete subscription roster and the recent media rendered by the Subscriptions page."
+  ],
   "updatedAt": "2026-07-13T20:44:43.335Z"
 }

--- a/release-notes/releases/v26.7.1300-dev.json
+++ b/release-notes/releases/v26.7.1300-dev.json
@@ -1,0 +1,42 @@
+{
+  "tag": "v26.7.1300-dev",
+  "version": "26.7.1300-dev",
+  "channel": "dev",
+  "dayKey": "26.7.13",
+  "approved": false,
+  "editorialNotes": [],
+  "generatedAt": "2026-07-13T20:44:43.335Z",
+  "model": "heuristic",
+  "source": {
+    "channel": "dev",
+    "previousPublishedTag": "v26.7.1200-dev",
+    "previousPublishedDayTag": "v26.7.1200-dev",
+    "compareRef": "HEAD",
+    "productCommitSha": "9023047b3f52947d9b29ec39f32e8839e359e36d",
+    "promotedDevCommitSha": null,
+    "isLatestOfDay": true,
+    "sameDayTagsIncluded": [
+      "v26.7.1300-dev"
+    ],
+    "relatedBuildTags": [
+      "v26.7.1300-dev"
+    ],
+    "prNumbers": [
+      949,
+      955,
+      957
+    ],
+    "commitSubjects": [
+      "fix: harden the stability control plane (#949)",
+      "fix: enable YouTube terminal sync soaks (#955)",
+      "fix: resolve pinned Node when sourced by zsh (#957)"
+    ]
+  },
+  "release": {
+    "deck": "Harden the stability control plane, youTube terminal sync soaks, and pinned Node when sourced by zsh resolved",
+    "features": [],
+    "fixes": [],
+    "followUps": []
+  },
+  "releaseBody": "(AI Generated).\n\n## Freed v26.7.1300-dev\n\nHarden the stability control plane, youTube terminal sync soaks, and pinned Node when sourced by zsh resolved\n\n### Fixes\n\n- Bug fixes and improvements\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+}

--- a/release-notes/releases/v26.7.1300-dev.json
+++ b/release-notes/releases/v26.7.1300-dev.json
@@ -3,8 +3,10 @@
   "version": "26.7.1300-dev",
   "channel": "dev",
   "dayKey": "26.7.13",
-  "approved": false,
-  "editorialNotes": [],
+  "approved": true,
+  "editorialNotes": [
+    "Reviewed 2026-07-13: led with unattended YouTube validation, kept the capture scope to the complete subscription roster and recent Subscriptions media, and summarized the stability control-plane work as a build-trust improvement."
+  ],
   "generatedAt": "2026-07-13T20:44:43.335Z",
   "model": "heuristic",
   "source": {
@@ -33,10 +35,15 @@
     ]
   },
   "release": {
-    "deck": "Harden the stability control plane, youTube terminal sync soaks, and pinned Node when sourced by zsh resolved",
-    "features": [],
-    "fixes": [],
+    "deck": "Unattended YouTube validation now runs through the normal authenticated sync path with stricter build and soak evidence",
+    "features": [
+      "Dev builds can start the normal authenticated YouTube sync from the terminal, allowing unattended validation of the complete subscription roster and recent Subscriptions media without foreground clicks"
+    ],
+    "fixes": [
+      "Release and soak evidence now fails closed on incomplete sessions and binds installed builds to their exact source commits",
+      "Repository tooling now keeps Node, npm, and npx on the pinned toolchain when sourced from zsh"
+    ],
     "followUps": []
   },
-  "releaseBody": "(AI Generated).\n\n## Freed v26.7.1300-dev\n\nHarden the stability control plane, youTube terminal sync soaks, and pinned Node when sourced by zsh resolved\n\n### Fixes\n\n- Bug fixes and improvements\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+  "releaseBody": "(AI Generated).\n\n## Freed v26.7.1300-dev\n\nUnattended YouTube validation now runs through the normal authenticated sync path with stricter build and soak evidence.\n\n### Features\n\n- Dev builds can start the normal authenticated YouTube sync from the terminal, allowing unattended validation of the complete subscription roster and recent Subscriptions media without foreground clicks\n\n### Fixes\n\n- Release and soak evidence now fails closed on incomplete sessions and binds installed builds to their exact source commits\n- Repository tooling now keeps Node, npm, and npx on the pinned toolchain when sourced from zsh\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
 }

--- a/release-notes/releases/v26.7.1300-dev.md
+++ b/release-notes/releases/v26.7.1300-dev.md
@@ -2,11 +2,16 @@
 
 ## Freed v26.7.1300-dev
 
-Harden the stability control plane, youTube terminal sync soaks, and pinned Node when sourced by zsh resolved
+Unattended YouTube validation now runs through the normal authenticated sync path with stricter build and soak evidence.
+
+### Features
+
+- Dev builds can start the normal authenticated YouTube sync from the terminal, allowing unattended validation of the complete subscription roster and recent Subscriptions media without foreground clicks
 
 ### Fixes
 
-- Bug fixes and improvements
+- Release and soak evidence now fails closed on incomplete sessions and binds installed builds to their exact source commits
+- Repository tooling now keeps Node, npm, and npx on the pinned toolchain when sourced from zsh
 
 ### Downloads
 

--- a/release-notes/releases/v26.7.1300-dev.md
+++ b/release-notes/releases/v26.7.1300-dev.md
@@ -1,0 +1,17 @@
+(AI Generated).
+
+## Freed v26.7.1300-dev
+
+Harden the stability control plane, youTube terminal sync soaks, and pinned Node when sourced by zsh resolved
+
+### Fixes
+
+- Bug fixes and improvements
+
+### Downloads
+
+**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  
+**Windows:** `.exe` (NSIS installer)  
+**Linux:** `.AppImage`  
+
+> macOS downloads are signed and notarized for normal Gatekeeper installation.

--- a/release-notes/releases/v26.7.1300-dev.md
+++ b/release-notes/releases/v26.7.1300-dev.md
@@ -15,8 +15,8 @@ Unattended YouTube validation now runs through the normal authenticated sync pat
 
 ### Downloads
 
-**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  
-**Windows:** `.exe` (NSIS installer)  
-**Linux:** `.AppImage`  
+**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)
+**Windows:** `.exe` (NSIS installer)
+**Linux:** `.AppImage`
 
 > macOS downloads are signed and notarized for normal Gatekeeper installation.


### PR DESCRIPTION
(AI Generated).

## Summary
- Prepare the July 13 dev build from the exact reviewed dev commit.
- Approve release notes for unattended YouTube terminal sync validation and stricter build evidence.
- Keep the YouTube scope precise: complete subscription roster plus recent Subscriptions media.

## Testing
- npm run validate:feature
- node scripts/validate-roadmap-status.mjs