### PR TITLE
fix: restore release channel build coverage

### DIFF
--- a/scripts/release-workflow-matrix.test.mjs
+++ b/scripts/release-workflow-matrix.test.mjs
@@ -77,3 +77,13 @@ test("desktop releases force Google token exchange through the server proxy", ()
     "release workflow should not embed a Google client secret in the desktop app bundle",
   );
 });
+
+test("desktop releases pass the reviewed channel into build metadata", () => {
+  const workflow = readFileSync(releaseWorkflowPath, "utf8");
+
+  assert.match(
+    workflow,
+    /FREED_BUILD_CHANNEL:\s*\$\{\{ needs\.notes\.outputs\.release_channel \}\}/,
+    "release builds should stamp the reviewed release channel into runtime identity",
+  );
+});


### PR DESCRIPTION
(AI Generated).

## Summary
- Restore the release workflow assertion removed by the main to dev ancestry repair. The test confirms every release build receives the reviewed channel in its runtime identity metadata.

## Testing
- node --test scripts/release-workflow-matrix.test.mjs scripts/release-promotion.test.mjs; npm run validate:feature