### PR TITLE
feat: add private vulnerability reporting

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,6 +30,7 @@
 /packages/desktop/src/hooks/usePostLoginAutoSync.ts @AubreyF
 /packages/desktop/src/hooks/useProviderRiskGate.tsx @AubreyF
 /packages/desktop/src/lib/background-runtime-coordinator.ts @AubreyF
+/packages/desktop/src/lib/bug-report.ts @AubreyF
 /packages/desktop/src/lib/capture.ts @AubreyF
 /packages/desktop/src/lib/content-fetcher.ts @AubreyF
 /packages/desktop/src/lib/dev-sync-triggers.ts @AubreyF
@@ -72,21 +73,29 @@
 /packages/capture-medium/ @AubreyF
 /packages/capture-*/src/ @AubreyF
 /packages/pwa/api/oauth/google.ts @AubreyF
+/packages/pwa/api/fetch-url.ts @AubreyF
+/packages/pwa/api/security-report.ts @AubreyF
 /packages/pwa/src/components/OAuthCallback.tsx @AubreyF
 /packages/pwa/src/components/PwaSyncSettings.tsx @AubreyF
 /packages/pwa/src/components/SyncConnectDialog.tsx @AubreyF
 /packages/pwa/src/lib/cloud-oauth.ts @AubreyF
+/packages/pwa/src/lib/bug-report.ts @AubreyF
 /packages/pwa/src/lib/contacts.ts @AubreyF
 /packages/pwa/src/lib/oauth-redirect.ts @AubreyF
 /packages/pwa/src/lib/reader-cache.ts @AubreyF
 /packages/pwa/src/lib/sync.ts @AubreyF
 /packages/pwa/src/lib/youtube-handoff.ts @AubreyF
 /packages/shared/src/google-contacts-automation.ts @AubreyF
+/packages/shared/src/bug-report.ts @AubreyF
+/packages/shared/src/redact-sensitive.ts @AubreyF
 /packages/shared/src/google-contacts.ts @AubreyF
 /packages/shared/src/legal.ts @AubreyF
 /packages/shared/src/schema.ts @AubreyF
 /packages/shared/src/youtube.ts @AubreyF
 /packages/ui/src/components/feed/ReaderView.tsx @AubreyF
+/packages/ui/src/components/report/ReportComposer.tsx @AubreyF
+/packages/ui/src/context/PlatformContext.tsx @AubreyF
+/packages/ui/src/lib/bug-report.ts @AubreyF
 /packages/ui/src/components/feed/YouTubeFocusPlayer.tsx @AubreyF
 
 # Stability automation, validation, provider gates, and release tooling.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    target-branch: dev
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    groups:
+      development-tooling:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: cargo
+    directory: /packages/desktop/src-tauri
+    target-branch: dev
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: github-actions
+    directory: /
+    target-branch: dev
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version-file: ".nvmrc"
           cache: "npm"
@@ -42,12 +42,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version-file: ".nvmrc"
 
@@ -72,12 +72,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version-file: ".nvmrc"
           cache: "npm"
@@ -104,13 +104,13 @@ jobs:
 
       - name: Install Rust toolchain
         if: steps.feature-plan.outputs.needs_native == 'true'
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           components: clippy
 
       - name: Cache Rust build artifacts
         if: steps.feature-plan.outputs.needs_native == 'true'
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: packages/desktop/src-tauri -> target
 
@@ -168,7 +168,7 @@ jobs:
 
       - name: Upload perf results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: perf-results-${{ github.sha }}
           path: packages/desktop/playwright-report/perf-results.json
@@ -177,7 +177,7 @@ jobs:
 
       - name: Upload test artifacts on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: playwright-report
           path: packages/desktop/playwright-report/
@@ -185,7 +185,7 @@ jobs:
 
       - name: Upload test results on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: test-results
           path: packages/desktop/test-results/
@@ -202,12 +202,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version-file: ".nvmrc"
           cache: "npm"
@@ -216,12 +216,12 @@ jobs:
         run: npm ci
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           components: clippy
 
       - name: Cache Rust build artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: packages/desktop/src-tauri -> target
 
@@ -252,7 +252,7 @@ jobs:
 
       - name: Upload test artifacts on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: playwright-report
           path: packages/desktop/playwright-report/
@@ -260,7 +260,7 @@ jobs:
 
       - name: Upload test results on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: test-results
           path: packages/desktop/test-results/

--- a/.github/workflows/main-release-validation.yml
+++ b/.github/workflows/main-release-validation.yml
@@ -24,12 +24,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version-file: ".nvmrc"
           cache: "npm"
@@ -38,12 +38,12 @@ jobs:
         run: npm ci
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           components: clippy
 
       - name: Cache Rust build artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: packages/desktop/src-tauri -> target
 
@@ -74,7 +74,7 @@ jobs:
 
       - name: Upload test artifacts on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: playwright-report
           path: packages/desktop/playwright-report/
@@ -82,7 +82,7 @@ jobs:
 
       - name: Upload test results on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: test-results
           path: packages/desktop/test-results/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   FREED_BUILD_KIND: release
@@ -20,12 +23,12 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version-file: ".nvmrc"
 
@@ -60,12 +63,12 @@ jobs:
       release_matrix: ${{ steps.gen.outputs.release_matrix }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version-file: ".nvmrc"
 
@@ -160,12 +163,12 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version-file: ".nvmrc"
           cache: "npm"
@@ -174,12 +177,12 @@ jobs:
         run: npm ci
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           components: clippy
 
       - name: Cache Rust build artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: packages/desktop/src-tauri -> target
 
@@ -275,23 +278,23 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version-file: ".nvmrc"
           cache: "npm"
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           targets: ${{ matrix.rust_target }}
 
       - name: Rust cache
-        uses: swatinem/rust-cache@v2
+        uses: swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: packages/desktop/src-tauri
 
@@ -380,7 +383,7 @@ jobs:
           security list-keychains -d user -s "$KEYCHAIN_PATH"
 
       - name: Build and release
-        uses: tauri-apps/tauri-action@v0
+        uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5 # v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
@@ -454,10 +457,10 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version-file: ".nvmrc"
 
@@ -507,13 +510,13 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: www
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version-file: ".nvmrc"
           cache: "npm"
@@ -571,10 +574,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version-file: ".nvmrc"
           cache: "npm"

--- a/.github/workflows/website-preview.yml
+++ b/.github/workflows/website-preview.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version-file: ".nvmrc"
           cache: "npm"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security policy
+
+## Reporting a vulnerability
+
+Do not open a public issue for a suspected vulnerability or include sensitive diagnostics in a public discussion.
+
+Use one of these private channels:
+
+1. Select **Report a vulnerability** on the repository's Security page.
+2. In Freed, enable the private diagnostics you want to include, review the report, then select **Submit private report to GitHub**. Freed sends redacted text and selected stack traces. The diagnostic zip stays on your device.
+3. If neither option works, email `support@freed.wtf` and ask for a secure follow-up channel. Do not attach secrets to the first email.
+
+Include the affected version, impact, reproduction steps, and any mitigation you have already tried. Remove credentials, personal content, and unrelated local files. Freed applies automated redaction, but you should still review the report before sending it.
+
+The security team will acknowledge the report, investigate it privately, and coordinate disclosure after a fix is available. Please do not publish details before that coordination is complete.
+
+## Supported versions
+
+Security fixes are shipped through the current Freed Desktop and PWA releases. Update to the newest available build before reporting an issue that may already be fixed.

--- a/docs/PHASE-10-POLISH.md
+++ b/docs/PHASE-10-POLISH.md
@@ -447,7 +447,7 @@ Reward security researchers for responsible disclosure.
 | Task  | Description                                                         | Complexity |
 | ----- | ------------------------------------------------------------------- | ---------- |
 | 10.23 | Crash / stale-bundle recovery dialog with in-place updater fallback | Medium     |
-| 10.24 | Public-safe and private bug reporting flow                          | Medium     |
+| 10.24 | Public-safe bundles and private GitHub vulnerability reports        | Medium     |
 
 ---
 
@@ -487,6 +487,7 @@ Reward security researchers for responsible disclosure.
 - [x] On hard crash or unreachable JSON update bundle, a friendly recovery dialog is shown outside the React tree, auto-checks for updates immediately, offers in-place install and restart when available, and keeps a channel-aware browser download fallback for the latest installer
 - [x] Desktop and PWA expose a shared bug report flow with public-safe bundles by default and private diagnostics as an explicit opt-in path
 - [x] Shared bug report actions now reflect the selected bundle privacy tier, bulk-toggle private diagnostics, and disable public GitHub issue drafts while private artifacts are selected
+- [x] Shared bug reports can submit redacted text and selected stack traces to the private GitHub vulnerability inbox after an explicit click, while keeping the diagnostic zip on the user's device and avoiding automatic retries
 - [x] Settings keeps Support out of the primary section list and opens the existing report composer from a dedicated Support modal launched at the top of Danger Zone
 
 ---

--- a/docs/PHASE-2-CAPTURE-SKILLS.md
+++ b/docs/PHASE-2-CAPTURE-SKILLS.md
@@ -291,6 +291,11 @@ capture-rss recent [count]
 | 2.10 | Normalize RSS items to FeedItem                      | ✓      |
 | 2.11 | Add OPML import/export                               | ✓      |
 | 2.12 | Create OpenClaw skill wrapper for RSS                | ✓      |
+| 2.13 | Bound XML entities in RSS and OPML parsing            | ✓      |
+
+The RSS and OPML parsers accept ordinary document entities, but reject oversized,
+deeply nested, or excessively repeated entity expansion before it can consume
+unbounded memory or CPU.
 
 ---
 

--- a/docs/PHASE-5-DESKTOP.md
+++ b/docs/PHASE-5-DESKTOP.md
@@ -224,7 +224,7 @@ export async function captureDomFeed(
 | 5.30 | Reviewed AI-assisted release notes and cumulative daily changelog cards | Medium     |
 | 5.31 | Provider health dashboard, charts, and unsubscribe flow                 | Medium     |
 | 5.32 | Rotating local database snapshots + restore UI                          | Medium     |
-| 5.33 | Public-safe and private bug report bundles                              | Medium     |
+| 5.33 | Public-safe bundles and private GitHub vulnerability reports             | Medium     |
 | 5.34 | Native startup recovery window outside the React tree                  | Medium     |
 | 5.35 | Hot-path side-effect scheduling for persistence, sync, and outbox work  | Medium     |
 | 5.36 | Event-aware Automerge subscription metadata for item-patch outbox drains | Medium     |
@@ -268,6 +268,7 @@ export async function captureDomFeed(
 - [x] Settings and crash recovery surfaces can export public-safe bug report bundles
 - [x] Private diagnostic bundles are opt-in, redacted, and steered toward email instead of public GitHub attachment
 - [x] Bug report actions now label whether they download a public-safe or private bundle, bulk-toggle private diagnostics, and block public GitHub issue drafts while private diagnostics remain selected
+- [x] Private reports can send a redacted description and selected stack traces to the repository's private GitHub vulnerability inbox after an explicit click, with no automatic retry and no diagnostic zip upload
 - [x] Browser desktop preview now guards native-only LinkedIn auth listeners, background social refresh paths, and local snapshot controls, so opening Settings and switching themes no longer crashes the preview
 - [x] Freed Desktop emits native renderer heartbeats and warns in the local log when the main window goes silent long enough to suggest a renderer hang or crash
 - [x] If the renderer dies before the app finishes booting, the next launch opens a native recovery window with retry, immediate in-place update install, and channel-aware browser download fallback actions outside the React tree

--- a/docs/PHASE-6-PWA.md
+++ b/docs/PHASE-6-PWA.md
@@ -218,7 +218,7 @@ export function filterByAuthor(
 | 6.13 | Add to homescreen prompt               | Low        |
 | 6.14 | First-run legal gate with local-only acceptance storage | Low |
 | 6.15 | URL navigation state with browser back/forward support | Low |
-| 6.16 | Public-safe and private bug report bundles | Medium |
+| 6.16 | Public-safe bundles and private GitHub vulnerability reports | Medium |
 
 ---
 
@@ -252,6 +252,7 @@ Build chain: `@freed/shared` → `@freed/sync` → `vite build` (configured in `
 - [x] Active view, feed filters, and reader selection round-trip through the URL for browser back/forward navigation
 - [x] Settings and crash recovery surfaces can export public-safe bug report bundles
 - [x] Bug report actions now label whether they download a public-safe or private bundle, and private diagnostics can be toggled as one group before emailing a report
+- [x] Private reports can send a redacted description and selected stack traces to the repository's private GitHub vulnerability inbox after an explicit click, with no automatic retry and no diagnostic zip upload
 - [x] PWA Settings surfaces Feeds, X / Twitter, Facebook, Instagram, LinkedIn, and Google Contacts as status-only sections with Freed Desktop sync and download handoff states
 - [x] PWA Settings surfaces cloud sync diagnostics for connected Google Drive accounts so users can see whether the browser downloaded, merged, uploaded, hit an error, is waiting for local changes, or needs a manual `Sync now` pass, while local PWA edits schedule Drive uploads even when no LAN relay is connected
 - [x] PWA Google Drive resume, manual sync, OAuth callback sync, and LAN relay resume wait until the Automerge worker has initialized the local document before merging remote Drive data
@@ -267,6 +268,7 @@ Build chain: `@freed/shared` → `@freed/sync` → `vite build` (configured in `
 - [x] Private diagnostics stay opt-in and are clearly separated from public GitHub sharing
 - [x] PWA installable on mobile (add to homescreen) — manifest ids and scope set, browser install notice shipped, iOS Safari homescreen guidance shipped, Playwright coverage added
 - [x] Offline access works (service worker + image cache), article HTML and cacheable reader images are warmed locally for offline reading
+- [x] The article proxy resolves and pins public addresses, revalidates every bounded redirect, rejects non-HTML responses, and stops oversized response bodies before they exhaust server memory
 - [x] Saved reader content uses the permanent pinned cache tier by default, with local cache modes for Saved Only, Everything Opened, Recent Feed, and Manual Only
 
 ---

--- a/docs/SECURITY-AUDIT-2026-07-13.md
+++ b/docs/SECURITY-AUDIT-2026-07-13.md
@@ -1,0 +1,183 @@
+# Security Audit, July 13, 2026
+
+## Scope
+
+The `freed-project` organization controls one GitHub repository, the public
+`freed-project/freed` monorepo. The audit covered organization policy,
+repository security settings, Actions, release environments, dependencies,
+CodeQL results, credential storage, user-controlled network access, parser
+boundaries, and private vulnerability intake.
+
+The repository is public, but the product handles OAuth tokens, API keys,
+authenticated provider sessions, local content, and diagnostic data. Those
+assets make the product security boundary larger than the repository visibility
+suggests.
+
+## Live GitHub posture
+
+| Control | Before audit | Current state |
+| --- | --- | --- |
+| Organization two-factor requirement | Enabled | Enabled |
+| Default repository permission | Read | Read |
+| Organization security baseline | Missing | Enforced on `freed` and the default for all new repositories |
+| Private vulnerability reporting | Disabled | Enabled |
+| Private reporting GitHub App | Missing | Installed only on `freed` with advisory write and metadata read |
+| Dependabot security updates | Disabled | Enabled |
+| Secret scanning | Disabled | Enabled |
+| Push protection | Disabled | Enabled |
+| CodeQL default setup | Missing | Enabled with the extended suite for Actions, JavaScript, TypeScript, and Rust |
+| Actions allowlist | All actions | GitHub-owned and verified actions only |
+| Immutable Action references | Disabled | Workflow files pinned in this change, repository enforcement waits for merge |
+| Branch rulesets | None | Governed rules exist in the repository, but live activation still needs a distinct publisher identity and owner-reviewed evidence |
+| Production environment protection | None | Still open, because applying approval gates to Vercel-created environments without confirming their branch mapping could stop production deployments |
+
+Secret scanning found no open alerts after enablement. The enforced `Freed
+security baseline` enables validity checks, non-provider patterns, generic
+secret detection, extended metadata, Dependabot security updates, CodeQL
+default setup, push protection, and private vulnerability reporting. It is
+attached to `freed` and applies by default to every new repository type.
+
+## Material findings
+
+### High: Desktop secrets are not consistently encrypted at rest
+
+Cloud OAuth access and refresh tokens are stored in renderer `localStorage`.
+The shared `secure-storage.ts` wrapper also states that `tauri-plugin-store`
+encrypts `secure.json`, but Tauri Store is persistent key-value storage, not an
+encrypted secret vault. API keys saved through that wrapper should therefore
+be treated as clear text at rest.
+
+Remediation requires a separate Desktop migration to Tauri Stronghold or an OS
+credential vault, removal of legacy clear-text values after successful import,
+failure-safe rollback, and tests covering upgrade, disconnect, and recovery.
+This bridge change does not disguise the storage bug with a comment edit.
+
+### High: The PWA article proxy allowed server-side requests to private networks
+
+The article proxy accepted an arbitrary URL and followed the runtime fetch
+stack without validating DNS results or redirects. A caller could attempt to
+reach loopback, private, link-local, or cloud metadata addresses through the
+Vercel function.
+
+This change resolves every destination, rejects mixed public and private DNS
+answers, pins the validated address into the connection, revalidates up to
+three redirects, rejects non-HTML responses, caps bodies at 2 MB, and avoids
+returning upstream error details. Focused tests cover private IPv4, private
+IPv6, mapped IPv4, mixed DNS, redirects, rebinding resistance, content type,
+and response size.
+
+### High: Dependency backlog included exploitable production packages
+
+The live default branch had 91 Dependabot alerts: 2 critical, 39 high, 36
+medium, and 14 low. Fifty affected runtime dependencies. The lockfile and safe
+direct dependency upgrades in this change reduce the local npm audit result to
+six moderate findings, with no critical or high findings.
+
+The remaining moderate findings are constrained as follows:
+
+- Automerge and `vite-plugin-top-level-await` retain a transitive `uuid` issue
+  with no compatible upstream fix. The vulnerable operation requires callers
+  to supply a destination buffer. Freed does not intentionally expose that
+  operation to untrusted input.
+- The website lane retains a Next-bundled PostCSS advisory. npm proposes an
+  invalid downgrade as its automatic fix. The website dependency must be
+  updated and validated separately from the product lane.
+
+### Medium: XML entity expansion was unbounded
+
+RSS and OPML parsing accepted XML entity declarations without explicit size,
+depth, count, or expanded-output limits. This change upgrades the parser and
+adds finite entity limits with tests for normal entities and malicious
+expansion.
+
+### Medium: Dynamic property writes need prototype-key guards
+
+CodeQL identified 36 related property injection and prototype pollution paths,
+primarily in Automerge schema mutation helpers. Many keys are IDs in intentional
+record maps, but some can originate in imported or synced data. Every dynamic
+write should reject `__proto__`, `prototype`, and `constructor` before touching
+a normal JavaScript object. That remediation belongs in a focused shared-schema
+change with sync compatibility tests.
+
+### Medium: Untrusted text reaches costly regular expressions
+
+CodeQL identified 16 polynomial regular expression paths across RSS
+normalization, Markdown import, Facebook status parsing, and content signals.
+The RSS and Markdown paths process externally supplied or imported text and
+deserve bounded input sizes plus linear parsing or proven-safe expressions.
+These should be remediated in a focused parser hardening change.
+
+CodeQL also flagged the bridge's initial private-key block expression before
+publication. This change replaces it with a bounded linear scanner and covers
+all supported key formats, incomplete markers, and 20,000 repeated headers.
+
+### Medium: Provider URL recognition uses substring checks
+
+Sixteen findings use URL substrings such as `youtube.com` or `facebook.com`
+instead of parsed hostname equality or suffix-bound checks. Most only influence
+classification or deduplication, but native extraction paths should not accept
+lookalike hosts. Replace them with one shared hostname matcher and test apex,
+subdomain, lookalike, credential, and malformed URL cases.
+
+## CodeQL disposition
+
+The first extended CodeQL run produced 125 open alerts. Scanner volume is not a
+vulnerability count. The grouped disposition is:
+
+| Alert class | Count | Disposition |
+| --- | ---: | --- |
+| Unpinned Actions and missing workflow permissions | 12 | Fixed in this change |
+| Clear-text storage | 8 | Two confirmed cloud token paths, six auth-state or redirect metadata false positives |
+| Property injection and prototype pollution | 36 | Defense required for imported and synced keys |
+| Polynomial regular expressions | 16 | Parser hardening required |
+| Provider URL substring and anchor checks | 22 | Shared hostname parsing required, two alerts are test-only |
+| File race and temporary-file handling | 14 | Local automation paths need atomic-open review, two are test or bounded local cases |
+| Network data and local files crossing boundaries | 10 | Expected release and test tooling, path and destination constraints need verification |
+| Worker message origin checks | 4 | False positives for dedicated workers, which do not accept arbitrary window senders |
+| Clear-text cookie | 1 | False positive in a test fixture using a fake cookie |
+| Insecure randomness | 1 | Non-security runtime event identifier, use `crypto.randomUUID()` for clean intent |
+| Double escaping | 1 | RSS normalization correctness review required |
+
+Alerts should be closed only after the fixing commit lands or a reviewed false
+positive explanation is recorded. Bulk dismissal would convert uncertainty into
+green paint.
+
+## Private vulnerability report bridge
+
+The new bridge sends only user-initiated, redacted text and selected stack
+traces to a private draft GitHub security advisory. GitHub's researcher report
+endpoint returned HTTP 500 for a valid installation token despite documenting
+that token type as supported, while the maintainer draft advisory endpoint
+accepted the same repository-scoped App token. Redaction occurs on both the
+client and server. Runtime metadata is allowlisted. Request size, origin, and
+warm-instance rate limits are enforced. The GitHub App token is restricted to
+the `freed` repository and repository advisory write permission. There is no
+background submission and no automatic retry. The diagnostic zip stays on the
+user's device.
+
+The App is installed only on `freed`. Its App ID and installation ID are stored
+in all three PWA deployment environments. The private key is encrypted in
+Production and Preview only. Development has no advisory-writing credential. A
+production Vercel Firewall rule limits `/api/security-report` to five requests
+per hour per client address.
+
+Production activation still requires:
+
+1. Merge and deploy this change.
+2. Submit a fake-secret smoke report and verify redaction in the private
+   advisory inbox.
+
+## Ordered follow-up work
+
+1. Migrate Desktop OAuth tokens and API keys to encrypted native storage.
+2. Guard dynamic record keys across shared schema and worker mutations.
+3. Replace provider substring recognition with shared parsed-host matching.
+4. Remove the remaining polynomial regular expression paths and bound imported
+   text.
+5. Review local automation file opens for atomic creation and no-follow safety.
+6. Update the website's Next and PostCSS chain in the `www` lane.
+7. Establish a distinct pull request publisher identity, produce one
+   owner-reviewed evidence pull request, then activate the checked-in branch
+   rulesets.
+8. Add production environment branch restrictions after mapping each
+   Vercel-created environment to its actual release lane.

--- a/docs/SECURITY-REPORTING.md
+++ b/docs/SECURITY-REPORTING.md
@@ -1,0 +1,72 @@
+# Private Vulnerability Reporting
+
+Freed can send a user-initiated vulnerability report from Freed Desktop or the
+PWA to the private vulnerability inbox for `freed-project/freed`.
+
+## Data flow
+
+1. The report composer collects the user's title and description.
+2. Private diagnostics remain opt-in. Only selected stack traces and a small
+   allowlist of build metadata are eligible for submission.
+3. The client redacts credentials, tokens, private keys, home directory names,
+   email addresses, and sensitive URL parameters.
+4. The reporting endpoint validates the origin, size, shape, and rate limit,
+   then applies the same redaction again.
+5. The endpoint creates a private draft security advisory through a repository
+   scoped GitHub App installation token. GitHub's researcher report endpoint
+   returns HTTP 500 for installation tokens even though its API documentation
+   lists them as supported. A direct draft advisory reaches the same internal
+   security team without misrepresenting the App as a human reporter.
+
+The diagnostic zip is never sent through this bridge. It stays on the user's
+device for manual review and a separate support exchange if needed.
+
+The bridge does not submit in the background and does not retry failed reports.
+One explicit click produces at most one GitHub advisory request.
+
+## GitHub App
+
+Use a dedicated GitHub App installed only on `freed-project/freed`. Grant only
+the repository permission `Repository security advisories: Read and write`.
+Do not grant organization permissions, contents access, issues access, or
+webhook delivery.
+
+Configure these server-side environment variables:
+
+| Variable | Purpose |
+| --- | --- |
+| `FREED_SECURITY_REPORT_APP_ID` | GitHub App identifier |
+| `FREED_SECURITY_REPORT_INSTALLATION_ID` | Installation identifier for the Freed repository |
+| `FREED_SECURITY_REPORT_PRIVATE_KEY` | PEM private key for the GitHub App |
+| `FREED_SECURITY_REPORT_ALLOWED_ORIGINS` | Optional comma-separated replacement for the built-in Freed origins |
+
+The endpoint exchanges a short-lived app JWT for a one-hour installation token.
+The exchange narrows the token to the `freed` repository and the advisory write
+permission. A token is cached only in server memory and refreshed before expiry.
+
+## Abuse controls
+
+The endpoint accepts JSON bodies no larger than 64 KB and limits each observed
+client address to three attempts per 15 minutes on a warm server instance. The
+production deployment should also enforce an edge rate limit for
+`/api/security-report`, because an in-memory serverless limit is not a complete
+distributed abuse control.
+
+GitHub may reject abusive or invalid submissions. The endpoint returns a generic
+failure to the client and does not expose GitHub credentials or response bodies.
+
+## Verification
+
+Before enabling the production route:
+
+1. Install the dedicated App only on the Freed repository.
+2. Add the environment variables without exposing the private key to build logs.
+3. Apply an edge rate limit to `/api/security-report`.
+4. Submit a test report containing fake secrets and a fake stack trace.
+5. Confirm the private draft advisory appears under the repository Security tab.
+6. Confirm the fake secrets are redacted and no zip attachment exists.
+7. Close the test advisory and record the test date in the release evidence.
+
+To disable the bridge, remove the App installation or its private key from the
+deployment environment. The report composer will keep local bundle download and
+email paths available.

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
       "version": "0.9.31",
       "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
       "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
@@ -39,23 +38,25 @@
       }
     },
     "node_modules/@asamuzakjp/css-color": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
-      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
       "license": "MIT",
       "dependencies": {
-        "@csstools/css-calc": "^2.1.3",
-        "@csstools/css-color-parser": "^3.0.9",
-        "@csstools/css-parser-algorithms": "^3.0.4",
-        "@csstools/css-tokenizer": "^3.0.3",
-        "lru-cache": "^10.4.3"
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/@asamuzakjp/dom-selector": {
       "version": "6.8.1",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
       "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@asamuzakjp/nwsapi": "^2.3.9",
@@ -65,21 +66,19 @@
         "lru-cache": "^11.2.6"
       }
     },
-    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
-      "version": "11.2.6",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
-      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "license": "MIT",
       "engines": {
-        "node": "20 || >=22"
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/@asamuzakjp/nwsapi": {
       "version": "2.3.9",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@automerge/automerge": {
@@ -1750,7 +1749,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
       "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "css-tree": "^3.0.0"
@@ -1850,9 +1848,9 @@
       }
     },
     "node_modules/@csstools/color-helpers": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
-      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
       "funding": [
         {
           "type": "github",
@@ -1865,13 +1863,13 @@
       ],
       "license": "MIT-0",
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@csstools/css-calc": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
-      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
       "funding": [
         {
           "type": "github",
@@ -1884,17 +1882,17 @@
       ],
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^3.0.5",
-        "@csstools/css-tokenizer": "^3.0.4"
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
       }
     },
     "node_modules/@csstools/css-color-parser": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
-      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.9.tgz",
+      "integrity": "sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==",
       "funding": [
         {
           "type": "github",
@@ -1907,21 +1905,21 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@csstools/color-helpers": "^5.1.0",
-        "@csstools/css-calc": "^2.1.4"
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.2.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^3.0.5",
-        "@csstools/css-tokenizer": "^3.0.4"
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
       }
     },
     "node_modules/@csstools/css-parser-algorithms": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
-      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
       "funding": [
         {
           "type": "github",
@@ -1934,17 +1932,16 @@
       ],
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "@csstools/css-tokenizer": "^3.0.4"
+        "@csstools/css-tokenizer": "^4.0.0"
       }
     },
     "node_modules/@csstools/css-syntax-patches-for-csstree": {
-      "version": "1.0.29",
-      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.29.tgz",
-      "integrity": "sha512-jx9GjkkP5YHuTmko2eWAvpPnb0mB4mGRr2U7XwVNwevm8nlpobZEVk+GNmiYMk2VuA75v+plfXWyroWKmICZXg==",
-      "dev": true,
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.6.tgz",
+      "integrity": "sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==",
       "funding": [
         {
           "type": "github",
@@ -1955,12 +1952,20 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
-      "license": "MIT-0"
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@csstools/css-tokenizer": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
-      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
       "funding": [
         {
           "type": "github",
@@ -1973,7 +1978,7 @@
       ],
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@dimforge/rapier3d-compat": {
@@ -2632,7 +2637,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.14.1.tgz",
       "integrity": "sha512-OhkBFWI6GcRMUroChZiopRiSp2iAMvEBK47NhJooDqz1RERO4QuZIZnjP63TXX8GAiLABkYmX+fuQsdJ1dd2QQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
@@ -3480,9 +3484,9 @@
       "license": "ISC"
     },
     "node_modules/@mozilla/readability": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@mozilla/readability/-/readability-0.5.0.tgz",
-      "integrity": "sha512-Z+CZ3QaosfFaTqvhQsIktyGrjFjSC0Fa4EMph4mqKnWhmyoGICsV/8QK+8HpXut6zV7zwfWwqDmEjtk1Qf6EgQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@mozilla/readability/-/readability-0.6.0.tgz",
+      "integrity": "sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14.0.0"
@@ -3698,6 +3702,18 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -6304,37 +6320,6 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
-    "node_modules/@vitest/coverage-v8": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.0.18.tgz",
-      "integrity": "sha512-7i+N2i0+ME+2JFZhfuz7Tg/FqKtilHjGyGvoHYQ6iLV0zahbsJ9sljC9OcFcPDbhYKCet+sG8SsVqlyGvPflZg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.0.18",
-        "ast-v8-to-istanbul": "^0.3.10",
-        "istanbul-lib-coverage": "^3.2.2",
-        "istanbul-lib-report": "^3.0.1",
-        "istanbul-reports": "^3.2.0",
-        "magicast": "^0.5.1",
-        "obug": "^2.1.1",
-        "std-env": "^3.10.0",
-        "tinyrainbow": "^3.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "@vitest/browser": "4.0.18",
-        "vitest": "4.0.18"
-      },
-      "peerDependenciesMeta": {
-        "@vitest/browser": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@vitest/expect": {
       "version": "4.0.18",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
@@ -6558,6 +6543,18 @@
         "node": ">= 8"
       }
     },
+    "node_modules/anynum": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+      "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
@@ -6758,36 +6755,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/ast-v8-to-istanbul": {
-      "version": "0.3.11",
-      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.11.tgz",
-      "integrity": "sha512-Qya9fkoofMjCBNVdWINMjB5KZvkYfaO9/anwkWnjxibpWUxo5iHl2sOdP7/uAqaRuUYuoo8rDwnbaaKVFxoUvw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.31",
-        "estree-walker": "^3.0.3",
-        "js-tokens": "^10.0.0"
-      }
-    },
-    "node_modules/ast-v8-to-istanbul/node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.31",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
-      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.1.0",
-        "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
-    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
-      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/async": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
@@ -6804,12 +6771,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
@@ -6973,7 +6934,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
       "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
@@ -7099,6 +7059,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -7287,18 +7248,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -7398,14 +7347,13 @@
       }
     },
     "node_modules/css-tree": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
-      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
-      "dev": true,
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
       "license": "MIT",
       "dependencies": {
-        "mdn-data": "2.12.2",
-        "source-map-js": "^1.0.1"
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
@@ -7425,23 +7373,19 @@
       }
     },
     "node_modules/cssstyle": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
-      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-6.2.0.tgz",
+      "integrity": "sha512-Fm5NvhYathRnXNVndkUsCCuR63DCLVVwGOOwQw782coXFi5HhkXdu289l59HlXZBawsyNccXfWRYvLzcDCdDig==",
       "license": "MIT",
       "dependencies": {
-        "@asamuzakjp/css-color": "^3.2.0",
-        "rrweb-cssom": "^0.8.0"
+        "@asamuzakjp/css-color": "^5.0.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.28",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.6"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
-    },
-    "node_modules/cssstyle/node_modules/rrweb-cssom": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
-      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
-      "license": "MIT"
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -7499,16 +7443,16 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/data-urls": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
-      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
       "license": "MIT",
       "dependencies": {
-        "whatwg-mimetype": "^4.0.0",
-        "whatwg-url": "^14.0.0"
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/data-view-buffer": {
@@ -7651,15 +7595,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -7710,6 +7645,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -7852,6 +7788,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7861,6 +7798,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7905,6 +7843,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -7917,6 +7856,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -8579,10 +8519,10 @@
       ],
       "license": "BSD-3-Clause"
     },
-    "node_modules/fast-xml-parser": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz",
-      "integrity": "sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==",
+    "node_modules/fast-xml-builder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.3.0.tgz",
+      "integrity": "sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==",
       "funding": [
         {
           "type": "github",
@@ -8591,7 +8531,28 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "strnum": "^1.1.1"
+        "path-expression-matcher": "^1.6.2",
+        "xml-naming": "^0.3.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.10.0.tgz",
+      "integrity": "sha512-SLhnTEqE5QpJHq/6zl9bsmImEP2adv+y6Wy+cJa7nVTRzQh1OZfCe9k29M5xN74LWnu0xa1zrUrq3KnOKl92Fg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.2.0",
+        "fast-xml-builder": "^1.2.0",
+        "is-unsafe": "^2.0.0",
+        "path-expression-matcher": "^1.6.2",
+        "strnum": "^2.4.1",
+        "xml-naming": "^0.3.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -8757,22 +8718,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/fraction.js": {
       "version": "5.3.4",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
@@ -8832,6 +8777,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -8892,6 +8838,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -8923,6 +8870,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -9092,6 +9040,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -9163,6 +9112,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -9175,6 +9125,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -9190,6 +9141,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -9216,15 +9168,15 @@
       }
     },
     "node_modules/html-encoding-sniffer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
-      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
       "license": "MIT",
       "dependencies": {
-        "whatwg-encoding": "^3.1.1"
+        "@exodus/bytes": "^1.6.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/html-escaper": {
@@ -9258,18 +9210,6 @@
       },
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/idb": {
@@ -9341,6 +9281,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.4.0.tgz",
+      "integrity": "sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/is-array-buffer": {
@@ -9758,6 +9707,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-unsafe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-2.0.0.tgz",
+      "integrity": "sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/is-weakmap": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
@@ -9951,43 +9912,67 @@
       }
     },
     "node_modules/jsdom": {
-      "version": "24.1.3",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-24.1.3.tgz",
-      "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
+      "version": "28.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.1.0.tgz",
+      "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
       "license": "MIT",
       "dependencies": {
-        "cssstyle": "^4.0.1",
-        "data-urls": "^5.0.0",
-        "decimal.js": "^10.4.3",
-        "form-data": "^4.0.0",
-        "html-encoding-sniffer": "^4.0.0",
+        "@acemir/cssom": "^0.9.31",
+        "@asamuzakjp/dom-selector": "^6.8.1",
+        "@bramus/specificity": "^2.4.2",
+        "@exodus/bytes": "^1.11.0",
+        "cssstyle": "^6.0.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
         "http-proxy-agent": "^7.0.2",
-        "https-proxy-agent": "^7.0.5",
+        "https-proxy-agent": "^7.0.6",
         "is-potential-custom-element-name": "^1.0.1",
-        "nwsapi": "^2.2.12",
-        "parse5": "^7.1.2",
-        "rrweb-cssom": "^0.7.1",
+        "parse5": "^8.0.0",
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
-        "tough-cookie": "^4.1.4",
+        "tough-cookie": "^6.0.0",
+        "undici": "^7.21.0",
         "w3c-xmlserializer": "^5.0.0",
-        "webidl-conversions": "^7.0.0",
-        "whatwg-encoding": "^3.1.1",
-        "whatwg-mimetype": "^4.0.0",
-        "whatwg-url": "^14.0.0",
-        "ws": "^8.18.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0",
         "xml-name-validator": "^5.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "canvas": "^2.11.2"
+        "canvas": "^3.0.0"
       },
       "peerDependenciesMeta": {
         "canvas": {
           "optional": true
         }
+      }
+    },
+    "node_modules/jsdom/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/jsdom/node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/jsesc": {
@@ -10560,10 +10545,13 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "license": "ISC"
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -10659,16 +10647,16 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/mdn-data": {
-      "version": "2.12.2",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
-      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
-      "dev": true,
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "license": "CC0-1.0"
     },
     "node_modules/merge2": {
@@ -10700,27 +10688,6 @@
       },
       "engines": {
         "node": ">=8.6"
-      }
-    },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {
@@ -10786,9 +10753,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -10937,12 +10904,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/nwsapi": {
-      "version": "2.2.23",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
-      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
-      "license": "MIT"
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -11191,6 +11152,7 @@
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
       "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "entities": "^6.0.0"
@@ -11203,6 +11165,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
       "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -11219,6 +11182,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
+      "integrity": "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/path-key": {
@@ -11253,16 +11231,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "11.2.6",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
-      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
       }
     },
     "node_modules/pathe": {
@@ -11406,9 +11374,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
       "dev": true,
       "funding": [
         {
@@ -11426,7 +11394,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -11620,18 +11588,6 @@
       "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==",
       "license": "MIT"
     },
-    "node_modules/psl": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
-      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.3.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/lupomontero"
-      }
-    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -11645,12 +11601,6 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/qr.js/-/qr.js-0.0.0.tgz",
       "integrity": "sha512-c4iYnWb+k2E+vYpRimHqSu575b1/wKl4XFeJGpFmrJQz5I88v9aY2czh7s0w36srfCM1sXgC/xpoJz5dJfq+OQ==",
-      "license": "MIT"
-    },
-    "node_modules/querystringify": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
       "license": "MIT"
     },
     "node_modules/queue-microtask": {
@@ -11750,9 +11700,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.0.tgz",
-      "integrity": "sha512-PZgus8ETambRT17BUm/LL8lX3Of+oiLaPuVTRH3l1eLvSPpKO3AvhAEb5N7ihAFZQrYDqkvvWfFh9p0z9VsjLw==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
+      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -11772,12 +11722,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.0.tgz",
-      "integrity": "sha512-5CO/l5Yahi2SKC6rGZ+HDEjpjkGaG/ncEP7eWFTvFxbHP8yeeI0PxTDjimtpXYlR3b3i9/WIL4VJttPrESIf2g==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
+      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.13.0"
+        "react-router": "7.18.1"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -11916,17 +11866,10 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -12033,12 +11976,6 @@
         "@rollup/rollup-win32-x64-msvc": "4.57.1",
         "fsevents": "~2.3.2"
       }
-    },
-    "node_modules/rrweb-cssom": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
-      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
-      "license": "MIT"
     },
     "node_modules/rss-parser": {
       "version": "3.13.0",
@@ -12155,12 +12092,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "license": "MIT"
     },
     "node_modules/sax": {
       "version": "1.4.4",
@@ -12712,16 +12643,19 @@
       }
     },
     "node_modules/strnum": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
-      "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
+      "integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.1"
+      }
     },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
@@ -13046,9 +12980,9 @@
       "license": "ISC"
     },
     "node_modules/tinyrainbow": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
-      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -13056,23 +12990,21 @@
       }
     },
     "node_modules/tldts": {
-      "version": "7.0.23",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.23.tgz",
-      "integrity": "sha512-ASdhgQIBSay0R/eXggAkQ53G4nTJqTXqC2kbaBbdDwM7SkjyZyO0OaaN1/FH7U/yCeqOHDwFO5j8+Os/IS1dXw==",
-      "dev": true,
+      "version": "7.4.8",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.8.tgz",
+      "integrity": "sha512-htwgN/8KRB3z3vnC0BOETVh2m499g5GmyTK9Wq5JBLX3FNz6tSBveAd+fQhzy9hkjif8vy2jwDMR1sGhLtZl2A==",
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.0.23"
+        "tldts-core": "^7.4.8"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.0.23",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.23.tgz",
-      "integrity": "sha512-0g9vrtDQLrNIiCj22HSe9d4mLVG3g5ph5DZ8zCKBr4OtrspmNB6ss7hVyzArAeE88ceZocIEGkyW1Ime7fxPtQ==",
-      "dev": true,
+      "version": "7.4.8",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.8.tgz",
+      "integrity": "sha512-c1P7u0EhACHj7lPy4MJm8iTFEU8+nB0LCtddH0fhP7noaVoXAqafMtOOeX+ulpuPBqnrRgRhw494RICT3mbhnw==",
       "license": "MIT"
     },
     "node_modules/to-regex-range": {
@@ -13089,30 +13021,27 @@
       }
     },
     "node_modules/tough-cookie": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
-      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "psl": "^1.1.33",
-        "punycode": "^2.1.1",
-        "universalify": "^0.2.0",
-        "url-parse": "^1.5.3"
+        "tldts": "^7.0.5"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
-      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
       "license": "MIT",
       "dependencies": {
         "punycode": "^2.3.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -13371,10 +13300,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.22.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
-      "integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
-      "dev": true,
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -13441,15 +13369,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/universalify": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
-      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
       }
     },
     "node_modules/unrs-resolver": {
@@ -13539,16 +13458,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/url-parse": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
-      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-      "license": "MIT",
-      "dependencies": {
-        "querystringify": "^2.1.1",
-        "requires-port": "^1.0.0"
-      }
-    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -13575,13 +13484,13 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.27.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "fdir": "^6.5.0",
         "picomatch": "^4.0.3",
         "postcss": "^8.5.6",
@@ -13894,51 +13803,39 @@
       }
     },
     "node_modules/webidl-conversions": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
       "license": "BSD-2-Clause",
       "engines": {
-        "node": ">=12"
+        "node": ">=20"
       }
     },
     "node_modules/website": {
       "resolved": "website",
       "link": true
     },
-    "node_modules/whatwg-encoding": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
-      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
-      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
-      "license": "MIT",
-      "dependencies": {
-        "iconv-lite": "0.6.3"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/whatwg-mimetype": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
-      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/whatwg-url": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
-      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
       "license": "MIT",
       "dependencies": {
-        "tr46": "^5.1.0",
-        "webidl-conversions": "^7.0.0"
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/which": {
@@ -14432,9 +14329,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -14471,6 +14368,21 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.3.0.tgz",
+      "integrity": "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/xml2js": {
@@ -14638,7 +14550,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@freed/shared": "*",
-        "fast-xml-parser": "^4.3.0",
+        "fast-xml-parser": "^5.10.0",
         "rss-parser": "^3.13.0"
       },
       "devDependencies": {
@@ -14651,8 +14563,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@freed/shared": "*",
-        "@mozilla/readability": "^0.5.0",
-        "jsdom": "^24.0.0",
+        "@mozilla/readability": "^0.6.0",
+        "jsdom": "^28.1.0",
         "jszip": "^3.10.1",
         "marked": "^17.0.3"
       },
@@ -14691,12 +14603,242 @@
       },
       "devDependencies": {
         "typescript": "^5.3.0",
-        "vitest": "^4.0.18"
+        "vitest": "^4.1.10"
+      }
+    },
+    "packages/capture-youtube/node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/capture-youtube/node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/capture-youtube/node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/capture-youtube/node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/capture-youtube/node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/capture-youtube/node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/capture-youtube/node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/capture-youtube/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "packages/capture-youtube/node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/capture-youtube/node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "packages/capture-youtube/node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
       }
     },
     "packages/desktop": {
       "name": "@freed/desktop",
-      "version": "26.7.900",
+      "version": "26.7.1301",
       "dependencies": {
         "@automerge/automerge": "^2.2.8",
         "@freed/capture-facebook": "*",
@@ -14705,8 +14847,8 @@
         "@freed/capture-rss": "*",
         "@freed/capture-save": "*",
         "@freed/capture-substack": "*",
-        "@freed/capture-youtube": "*",
         "@freed/capture-x": "*",
+        "@freed/capture-youtube": "*",
         "@freed/shared": "*",
         "@freed/sync": "*",
         "@freed/ui": "*",
@@ -14725,7 +14867,7 @@
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-qr-code": "^2.0.18",
-        "react-router-dom": "^7.1.1",
+        "react-router-dom": "^7.18.1",
         "zustand": "^5.0.3"
       },
       "devDependencies": {
@@ -14736,145 +14878,13 @@
         "@vitejs/plugin-react": "^5.1.1",
         "autoprefixer": "^10.4.20",
         "jsdom": "^28.1.0",
-        "postcss": "^8.4.49",
+        "postcss": "^8.5.19",
         "tailwindcss": "^3.4.17",
         "typescript": "~5.9.3",
-        "vite": "7.3.1",
+        "vite": "7.3.6",
         "vite-plugin-top-level-await": "^1.6.0",
         "vite-plugin-wasm": "^3.5.0",
-        "vitest": "^4.0.18"
-      }
-    },
-    "packages/desktop/node_modules/@asamuzakjp/css-color": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.0.1.tgz",
-      "integrity": "sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@csstools/css-calc": "^3.1.1",
-        "@csstools/css-color-parser": "^4.0.2",
-        "@csstools/css-parser-algorithms": "^4.0.0",
-        "@csstools/css-tokenizer": "^4.0.0",
-        "lru-cache": "^11.2.6"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      }
-    },
-    "packages/desktop/node_modules/@csstools/color-helpers": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
-      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT-0",
-      "engines": {
-        "node": ">=20.19.0"
-      }
-    },
-    "packages/desktop/node_modules/@csstools/css-calc": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
-      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^4.0.0",
-        "@csstools/css-tokenizer": "^4.0.0"
-      }
-    },
-    "packages/desktop/node_modules/@csstools/css-color-parser": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
-      "integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@csstools/color-helpers": "^6.0.2",
-        "@csstools/css-calc": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^4.0.0",
-        "@csstools/css-tokenizer": "^4.0.0"
-      }
-    },
-    "packages/desktop/node_modules/@csstools/css-parser-algorithms": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
-      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "peerDependencies": {
-        "@csstools/css-tokenizer": "^4.0.0"
-      }
-    },
-    "packages/desktop/node_modules/@csstools/css-tokenizer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
-      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.19.0"
+        "vitest": "^4.1.10"
       }
     },
     "packages/desktop/node_modules/@tauri-apps/plugin-clipboard-manager": {
@@ -14895,190 +14905,239 @@
         "@tauri-apps/api": "^2.0.0"
       }
     },
-    "packages/desktop/node_modules/cssstyle": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-6.2.0.tgz",
-      "integrity": "sha512-Fm5NvhYathRnXNVndkUsCCuR63DCLVVwGOOwQw782coXFi5HhkXdu289l59HlXZBawsyNccXfWRYvLzcDCdDig==",
+    "packages/desktop/node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@asamuzakjp/css-color": "^5.0.1",
-        "@csstools/css-syntax-patches-for-csstree": "^1.0.28",
-        "css-tree": "^3.1.0",
-        "lru-cache": "^11.2.6"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "packages/desktop/node_modules/data-urls": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
-      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-mimetype": "^5.0.0",
-        "whatwg-url": "^16.0.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      }
-    },
-    "packages/desktop/node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
+        "url": "https://opencollective.com/vitest"
       }
     },
-    "packages/desktop/node_modules/html-encoding-sniffer": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
-      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+    "packages/desktop/node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@exodus/bytes": "^1.6.0"
+        "tinyrainbow": "^3.1.0"
       },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
-    "packages/desktop/node_modules/jsdom": {
-      "version": "28.1.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.1.0.tgz",
-      "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
+    "packages/desktop/node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@acemir/cssom": "^0.9.31",
-        "@asamuzakjp/dom-selector": "^6.8.1",
-        "@bramus/specificity": "^2.4.2",
-        "@exodus/bytes": "^1.11.0",
-        "cssstyle": "^6.0.1",
-        "data-urls": "^7.0.0",
-        "decimal.js": "^10.6.0",
-        "html-encoding-sniffer": "^6.0.0",
-        "http-proxy-agent": "^7.0.2",
-        "https-proxy-agent": "^7.0.6",
-        "is-potential-custom-element-name": "^1.0.1",
-        "parse5": "^8.0.0",
-        "saxes": "^6.0.0",
-        "symbol-tree": "^3.2.4",
-        "tough-cookie": "^6.0.0",
-        "undici": "^7.21.0",
-        "w3c-xmlserializer": "^5.0.0",
-        "webidl-conversions": "^8.0.1",
-        "whatwg-mimetype": "^5.0.0",
-        "whatwg-url": "^16.0.0",
-        "xml-name-validator": "^5.0.0"
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/desktop/node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/desktop/node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/desktop/node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/desktop/node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/desktop/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "packages/desktop/node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/desktop/node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "canvas": "^3.0.0"
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
-        "canvas": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "packages/desktop/node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
           "optional": true
         }
       }
     },
-    "packages/desktop/node_modules/lru-cache": {
-      "version": "11.2.6",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
-      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "packages/desktop/node_modules/parse5": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
-      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "entities": "^6.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
-    "packages/desktop/node_modules/tough-cookie": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
-      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "tldts": "^7.0.5"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "packages/desktop/node_modules/tr46": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
-      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "packages/desktop/node_modules/webidl-conversions": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
-      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "packages/desktop/node_modules/whatwg-mimetype": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
-      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "packages/desktop/node_modules/whatwg-url": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
-      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@exodus/bytes": "^1.11.0",
-        "tr46": "^6.0.0",
-        "webidl-conversions": "^8.0.1"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      }
-    },
     "packages/pwa": {
       "name": "@freed/pwa",
-      "version": "26.7.900",
+      "version": "26.7.1301",
       "dependencies": {
         "@automerge/automerge": "^2.2.8",
         "@freed/capture-save": "*",
@@ -15087,11 +15146,13 @@
         "@freed/ui": "*",
         "@tanstack/react-virtual": "^3.13.6",
         "date-fns": "^4.1.0",
+        "ipaddr.js": "^2.4.0",
         "jsqr": "^1.4.0",
         "jszip": "^3.10.1",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
-        "react-router-dom": "^7.1.1",
+        "react-router-dom": "^7.18.1",
+        "undici": "^7.27.3",
         "zustand": "^5.0.3"
       },
       "devDependencies": {
@@ -15102,152 +15163,34 @@
         "@types/react": "^19.2.5",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.1.1",
-        "@vitest/coverage-v8": "^4.0.18",
+        "@vitest/coverage-v8": "^4.1.10",
         "autoprefixer": "^10.4.20",
         "eslint": "^9.39.1",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.24",
         "globals": "^16.5.0",
         "jsdom": "^28.1.0",
-        "postcss": "^8.4.49",
+        "postcss": "^8.5.19",
         "tailwindcss": "^3.4.17",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.46.4",
-        "vite": "7.3.1",
+        "vite": "7.3.6",
         "vite-plugin-pwa": "^1.2.0",
         "vite-plugin-top-level-await": "^1.6.0",
         "vite-plugin-wasm": "^3.5.0",
-        "vitest": "^4.0.18",
+        "vitest": "^4.1.10",
         "workbox-window": "^7.4.0"
       }
     },
-    "packages/pwa/node_modules/@asamuzakjp/css-color": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
-      "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
+    "packages/pwa/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@csstools/css-calc": "^3.0.0",
-        "@csstools/css-color-parser": "^4.0.1",
-        "@csstools/css-parser-algorithms": "^4.0.0",
-        "@csstools/css-tokenizer": "^4.0.0",
-        "lru-cache": "^11.2.5"
-      }
-    },
-    "packages/pwa/node_modules/@csstools/color-helpers": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.1.tgz",
-      "integrity": "sha512-NmXRccUJMk2AWA5A7e5a//3bCIMyOu2hAtdRYrhPPHjDxINuCwX1w6rnIZ4xjLcp0ayv6h8Pc3X0eJUGiAAXHQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT-0",
-      "engines": {
-        "node": ">=20.19.0"
-      }
-    },
-    "packages/pwa/node_modules/@csstools/css-calc": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
-      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^4.0.0",
-        "@csstools/css-tokenizer": "^4.0.0"
-      }
-    },
-    "packages/pwa/node_modules/@csstools/css-color-parser": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.1.tgz",
-      "integrity": "sha512-vYwO15eRBEkeF6xjAno/KQ61HacNhfQuuU/eGwH67DplL0zD5ZixUa563phQvUelA07yDczIXdtmYojCphKJcw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@csstools/color-helpers": "^6.0.1",
-        "@csstools/css-calc": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^4.0.0",
-        "@csstools/css-tokenizer": "^4.0.0"
-      }
-    },
-    "packages/pwa/node_modules/@csstools/css-parser-algorithms": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
-      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "peerDependencies": {
-        "@csstools/css-tokenizer": "^4.0.0"
-      }
-    },
-    "packages/pwa/node_modules/@csstools/css-tokenizer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
-      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.19.0"
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "packages/pwa/node_modules/@types/node": {
@@ -15260,185 +15203,284 @@
         "undici-types": "~7.16.0"
       }
     },
-    "packages/pwa/node_modules/cssstyle": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-6.0.1.tgz",
-      "integrity": "sha512-IoJs7La+oFp/AB033wBStxNOJt4+9hHMxsXUPANcoXL2b3W4DZKghlJ2cI/eyeRZIQ9ysvYEorVhjrcYctWbog==",
+    "packages/pwa/node_modules/@vitest/coverage-v8": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.10.tgz",
+      "integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@asamuzakjp/css-color": "^4.1.2",
-        "@csstools/css-syntax-patches-for-csstree": "^1.0.26",
-        "css-tree": "^3.1.0",
-        "lru-cache": "^11.2.5"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "packages/pwa/node_modules/data-urls": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
-      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-mimetype": "^5.0.0",
-        "whatwg-url": "^16.0.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      }
-    },
-    "packages/pwa/node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.10",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "packages/pwa/node_modules/html-encoding-sniffer": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
-      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@exodus/bytes": "^1.6.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      }
-    },
-    "packages/pwa/node_modules/jsdom": {
-      "version": "28.1.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.1.0.tgz",
-      "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@acemir/cssom": "^0.9.31",
-        "@asamuzakjp/dom-selector": "^6.8.1",
-        "@bramus/specificity": "^2.4.2",
-        "@exodus/bytes": "^1.11.0",
-        "cssstyle": "^6.0.1",
-        "data-urls": "^7.0.0",
-        "decimal.js": "^10.6.0",
-        "html-encoding-sniffer": "^6.0.0",
-        "http-proxy-agent": "^7.0.2",
-        "https-proxy-agent": "^7.0.6",
-        "is-potential-custom-element-name": "^1.0.1",
-        "parse5": "^8.0.0",
-        "saxes": "^6.0.0",
-        "symbol-tree": "^3.2.4",
-        "tough-cookie": "^6.0.0",
-        "undici": "^7.21.0",
-        "w3c-xmlserializer": "^5.0.0",
-        "webidl-conversions": "^8.0.1",
-        "whatwg-mimetype": "^5.0.0",
-        "whatwg-url": "^16.0.0",
-        "xml-name-validator": "^5.0.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+        "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "canvas": "^3.0.0"
+        "@vitest/browser": "4.1.10",
+        "vitest": "4.1.10"
       },
       "peerDependenciesMeta": {
-        "canvas": {
+        "@vitest/browser": {
           "optional": true
         }
       }
     },
-    "packages/pwa/node_modules/lru-cache": {
-      "version": "11.2.6",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
-      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "packages/pwa/node_modules/parse5": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
-      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+    "packages/pwa/node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "entities": "^6.0.0"
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
+        "url": "https://opencollective.com/vitest"
       }
     },
-    "packages/pwa/node_modules/tough-cookie": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
-      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "tldts": "^7.0.5"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "packages/pwa/node_modules/tr46": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
-      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+    "packages/pwa/node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "punycode": "^2.3.1"
+        "tinyrainbow": "^3.1.0"
       },
-      "engines": {
-        "node": ">=20"
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
-    "packages/pwa/node_modules/webidl-conversions": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
-      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "packages/pwa/node_modules/whatwg-mimetype": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
-      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "packages/pwa/node_modules/whatwg-url": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.0.tgz",
-      "integrity": "sha512-9CcxtEKsf53UFwkSUZjG+9vydAsFO4lFHBpJUtjBcoJOCJpKnSJNwCw813zrYJHpCJ7sgfbtOe0V5Ku7Pa1XMQ==",
+    "packages/pwa/node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@exodus/bytes": "^1.11.0",
-        "tr46": "^6.0.0",
-        "webidl-conversions": "^8.0.1"
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/pwa/node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/pwa/node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/pwa/node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/pwa/node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.5.tgz",
+      "integrity": "sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "packages/pwa/node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/pwa/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/pwa/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "packages/pwa/node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/pwa/node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "packages/pwa/node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
       }
     },
     "packages/shared": {
@@ -15458,7 +15500,7 @@
         "@automerge/automerge": "^2.2.8",
         "@automerge/automerge-repo": "^1.2.1",
         "@freed/shared": "*",
-        "ws": "^8.16.0"
+        "ws": "^8.21.0"
       },
       "devDependencies": {
         "@types/ws": "^8.5.10",

--- a/packages/capture-rss/package.json
+++ b/packages/capture-rss/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@freed/shared": "*",
     "rss-parser": "^3.13.0",
-    "fast-xml-parser": "^4.3.0"
+    "fast-xml-parser": "^5.10.0"
   },
   "devDependencies": {
     "typescript": "^5.3.0",

--- a/packages/capture-rss/src/browser.ts
+++ b/packages/capture-rss/src/browser.ts
@@ -13,6 +13,7 @@
 
 import { XMLParser } from "fast-xml-parser";
 import type { ParsedFeed, ParsedFeedItem } from "./types.js";
+import { SECURE_XML_ENTITY_OPTIONS } from "./xml-security.js";
 
 // Re-export everything that is Node-free
 export * from "./types.js";
@@ -41,6 +42,7 @@ const XML = new XMLParser({
   attributeNamePrefix: "@_",
   textNodeName: "#text",
   parseAttributeValue: false,
+  processEntities: SECURE_XML_ENTITY_OPTIONS,
   isArray: (_name, jpath) =>
     jpath === "rss.channel.item" ||
     jpath === "feed.entry" ||

--- a/packages/capture-rss/src/opml.ts
+++ b/packages/capture-rss/src/opml.ts
@@ -9,6 +9,7 @@
 import { XMLParser, XMLBuilder } from "fast-xml-parser";
 import type { OPMLDocument, OPMLOutline, OPMLFeed } from "./types.js";
 import type { RssFeed } from "@freed/shared";
+import { SECURE_XML_ENTITY_OPTIONS } from "./xml-security.js";
 
 // =============================================================================
 // OPML Parsing
@@ -24,6 +25,7 @@ export function parseOPML(xml: string): OPMLFeed[] {
   const parser = new XMLParser({
     ignoreAttributes: false,
     attributeNamePrefix: "@_",
+    processEntities: SECURE_XML_ENTITY_OPTIONS,
   });
 
   let doc: OPMLDocument;

--- a/packages/capture-rss/src/xml-security.test.ts
+++ b/packages/capture-rss/src/xml-security.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { parseFeedXml } from "./browser";
+import { generateOPML, parseOPML } from "./opml";
+
+describe("bounded XML parsing", () => {
+  it("parses normal RSS and XML entities", async () => {
+    const feed = await parseFeedXml(
+      `<?xml version="1.0"?>
+      <rss version="2.0"><channel>
+        <title>Security &amp; Privacy</title>
+        <link>https://example.com</link>
+        <item><title>Safe item</title><link>https://example.com/item</link></item>
+      </channel></rss>`,
+      "https://example.com/feed.xml",
+    );
+
+    expect(feed.title).toBe("Security & Privacy");
+    expect(feed.items).toHaveLength(1);
+  });
+
+  it("round trips normal OPML after parser hardening", () => {
+    const generated = generateOPML(
+      [
+        {
+          url: "https://example.com/feed.xml",
+          title: "Example feed",
+          siteUrl: "https://example.com",
+          enabled: true,
+          trackUnread: false,
+        },
+      ],
+      "Security test",
+    );
+
+    expect(parseOPML(generated)).toMatchObject([
+      {
+        url: "https://example.com/feed.xml",
+        title: "Example feed",
+      },
+    ]);
+  });
+
+  it("rejects excessive entity expansion before producing a feed", async () => {
+    const repeatedEntity = "&a;".repeat(300);
+    const malicious = `<?xml version="1.0"?>
+      <!DOCTYPE rss [
+        <!ENTITY a "1234567890">
+      ]>
+      <rss version="2.0"><channel><title>${repeatedEntity}</title><link>https://example.com</link></channel></rss>`;
+
+    await expect(parseFeedXml(malicious, "https://example.com/feed.xml")).rejects.toThrow(
+      /entity|expansion|expanded/i,
+    );
+  });
+});

--- a/packages/capture-rss/src/xml-security.ts
+++ b/packages/capture-rss/src/xml-security.ts
@@ -1,0 +1,9 @@
+export const SECURE_XML_ENTITY_OPTIONS = {
+  enabled: true,
+  maxEntitySize: 1_024,
+  maxExpansionDepth: 8,
+  maxTotalExpansions: 256,
+  maxExpandedLength: 64 * 1_024,
+  maxEntityCount: 32,
+  appliesTo: "all" as const,
+};

--- a/packages/capture-save/package.json
+++ b/packages/capture-save/package.json
@@ -18,8 +18,8 @@
   },
   "dependencies": {
     "@freed/shared": "*",
-    "@mozilla/readability": "^0.5.0",
-    "jsdom": "^24.0.0",
+    "@mozilla/readability": "^0.6.0",
+    "jsdom": "^28.1.0",
     "jszip": "^3.10.1",
     "marked": "^17.0.3"
   },

--- a/packages/capture-save/src/browser.ts
+++ b/packages/capture-save/src/browser.ts
@@ -91,12 +91,16 @@ export function extractContentBrowser(html: string, url: string): ExtractedConte
     throw new Error(`Readability could not extract content from ${url}`);
   }
 
-  const text = article.textContent.trim();
+  const text = article.textContent?.trim();
+  const content = article.content;
+  if (!text || !content) {
+    throw new Error(`Readability returned empty content for ${url}`);
+  }
   const wordCount = text.split(/\s+/).filter(Boolean).length;
   const readingTime = Math.max(1, Math.ceil(wordCount / 200));
 
   return {
-    html: article.content,
+    html: content,
     text,
     wordCount,
     readingTime,

--- a/packages/capture-save/src/readability.ts
+++ b/packages/capture-save/src/readability.ts
@@ -30,12 +30,16 @@ export async function extractContent(url: string): Promise<ExtractedContent> {
     throw new Error(`Could not extract article content from ${url}`);
   }
 
-  const text = article.textContent.trim();
+  const text = article.textContent?.trim();
+  const content = article.content;
+  if (!text || !content) {
+    throw new Error(`Readability returned empty content for ${url}`);
+  }
   const wordCount = text.split(/\s+/).filter(Boolean).length;
   const readingTime = Math.max(1, Math.ceil(wordCount / 200)); // 200 WPM
 
   return {
-    html: article.content,
+    html: content,
     text,
     wordCount,
     readingTime,

--- a/packages/capture-youtube/package.json
+++ b/packages/capture-youtube/package.json
@@ -20,6 +20,6 @@
   },
   "devDependencies": {
     "typescript": "^5.3.0",
-    "vitest": "^4.0.18"
+    "vitest": "^4.1.10"
   }
 }

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -10,7 +10,7 @@
     "tauri": "node ./scripts/tauri-cli.mjs",
     "tauri:dev": "node ./scripts/tauri-cli.mjs dev",
     "tauri:build": "node ./scripts/tauri-cli.mjs build",
-    "test:unit": "node ../../node_modules/vitest/vitest.mjs run",
+    "test:unit": "node ../../node_modules/vitest/vitest.mjs run --maxWorkers=1",
     "test:unit:watch": "node ../../node_modules/vitest/vitest.mjs",
     "test:e2e": "node ../../node_modules/playwright/cli.js test",
     "test:e2e:automerge-worker": "node ../../node_modules/playwright/cli.js test automerge-worker-lifecycle.spec.ts",
@@ -56,7 +56,7 @@
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-qr-code": "^2.0.18",
-    "react-router-dom": "^7.1.1",
+    "react-router-dom": "^7.18.1",
     "zustand": "^5.0.3"
   },
   "devDependencies": {
@@ -67,12 +67,12 @@
     "@vitejs/plugin-react": "^5.1.1",
     "autoprefixer": "^10.4.20",
     "jsdom": "^28.1.0",
-    "postcss": "^8.4.49",
+    "postcss": "^8.5.19",
     "tailwindcss": "^3.4.17",
     "typescript": "~5.9.3",
-    "vite": "7.3.1",
+    "vite": "7.3.6",
     "vite-plugin-top-level-await": "^1.6.0",
     "vite-plugin-wasm": "^3.5.0",
-    "vitest": "^4.0.18"
+    "vitest": "^4.1.10"
   }
 }

--- a/packages/desktop/src/lib/bug-report.ts
+++ b/packages/desktop/src/lib/bug-report.ts
@@ -14,15 +14,20 @@ import {
   buildBugReportSummaryMarkdown,
   getLastFatalRuntimeError,
   getRecentBugReportEvents,
+  recordRuntimeError,
   redactSensitiveText,
   resolveArtifactsForTier,
   summarizeStateForReport,
+  submitPrivateVulnerabilityReport,
 } from "@freed/ui/lib/bug-report";
 import type { BugReportingConfig } from "@freed/ui/context";
 import { useAppStore } from "./store";
 
 const GITHUB_REPO = "freed-project/freed";
 const SUPPORT_EMAIL = "support@freed.wtf";
+const PRIVATE_REPORT_ENDPOINT =
+  import.meta.env.VITE_PRIVATE_VULNERABILITY_REPORT_URL ||
+  "https://app.freed.wtf/api/security-report";
 const APP_NAME = "Freed Desktop";
 
 interface DesktopRuntimeInfo {
@@ -135,7 +140,14 @@ async function buildDesktopBundle(input: {
     input.draft.selectedArtifacts,
     input.privacyTier,
   );
-  const fatalError = getLastFatalRuntimeError();
+  const startupError = useAppStore.getState().error;
+  const fatalError = getLastFatalRuntimeError() ?? (startupError
+    ? recordRuntimeError({
+        source: "desktop:startup",
+        error: new Error(startupError),
+        fatal: true,
+      })
+    : null);
   const platform = await getPlatformName();
   const runtimeInfo = getRuntimeInfo(platform);
   const logLines = includedArtifacts.some((artifact) => artifact === "expanded-logs")
@@ -249,6 +261,8 @@ export const desktopBugReporting: BugReportingConfig = {
   githubRepo: GITHUB_REPO,
   privateShareEmail: SUPPORT_EMAIL,
   generateBundle: buildDesktopBundle,
+  submitPrivateReport: (payload) =>
+    submitPrivateVulnerabilityReport(PRIVATE_REPORT_ENDPOINT, payload),
   openUrl: (url) => {
     void shellOpen(url);
   },

--- a/packages/desktop/tests/e2e/bug-report.spec.ts
+++ b/packages/desktop/tests/e2e/bug-report.spec.ts
@@ -54,6 +54,23 @@ test("fatal recovery still surfaces available app updates", async ({ app }) => {
 });
 
 test("bug report export actions track private diagnostics", async ({ app, ipc }) => {
+  let submittedReport: Record<string, unknown> | null = null;
+  let submittedReportCount = 0;
+  await app.page.route(
+    "https://app.freed.wtf/api/security-report",
+    async (route) => {
+      submittedReport = route.request().postDataJSON() as Record<string, unknown>;
+      submittedReportCount += 1;
+      await route.fulfill({
+        status: 201,
+        contentType: "application/json",
+        body: JSON.stringify({
+          advisoryUrl:
+            "https://github.com/freed-project/freed/security/advisories/GHSA-abcd-1234-efgh",
+        }),
+      });
+    },
+  );
   await app.goto("/");
   await app.waitForReady();
 
@@ -99,6 +116,18 @@ test("bug report export actions track private diagnostics", async ({ app, ipc })
   await expect.poll(async () => (await ipc.openedUrls()).at(-1)).toContain(
     "mailto:support@freed.wtf?",
   );
+
+  await app.page.getByRole("button", { name: "Submit private report to GitHub" }).dblclick();
+  await expect(
+    app.page.getByText(
+      "Private report submitted to the Freed security team through GitHub. The zip bundle stayed on this device.",
+    ),
+  ).toBeVisible();
+  expect(submittedReport).toMatchObject({
+    title: "Freed vulnerability report",
+    stackTrace: expect.stringContaining("Synthetic fatal crash"),
+  });
+  expect(submittedReportCount).toBe(1);
 
   await app.page.getByLabel("Private diagnostics").click();
   await expect(app.page.getByLabel("Expanded logs")).not.toBeChecked();

--- a/packages/pwa/api/fetch-url.ts
+++ b/packages/pwa/api/fetch-url.ts
@@ -1,17 +1,182 @@
-/**
- * Server-side article fetch proxy for PWA saved URLs.
- *
- * The browser cannot reliably fetch arbitrary articles because of CORS, so the
- * PWA posts a URL here and receives the raw HTML body as plain text.
- */
+import { lookup as dnsLookup } from "node:dns/promises";
+import { Agent } from "undici";
+import ipaddr from "ipaddr.js";
 
 const FETCH_TIMEOUT_MS = 15_000;
 const MAX_HTML_BYTES = 2 * 1024 * 1024;
+const MAX_REDIRECTS = 3;
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+interface ResolvedAddress {
+  address: string;
+  family: number;
+}
+
+type ResolveHost = (hostname: string) => Promise<ResolvedAddress[]>;
+
+function allowedOrigin(origin: string): boolean {
+  if (origin === "https://app.freed.wtf") return true;
+  if (process.env.VERCEL_URL && origin === `https://${process.env.VERCEL_URL}`) return true;
+  if (process.env.VERCEL_ENV !== "production") {
+    try {
+      const parsed = new URL(origin);
+      return (
+        parsed.protocol === "http:" &&
+        ["localhost", "127.0.0.1", "[::1]"].includes(parsed.hostname)
+      );
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}
+
+export function isPublicAddress(address: string): boolean {
+  try {
+    const parsed = ipaddr.parse(address);
+    if (parsed instanceof ipaddr.IPv6 && parsed.isIPv4MappedAddress()) {
+      return parsed.toIPv4Address().range() === "unicast";
+    }
+    return parsed.range() === "unicast";
+  } catch {
+    return false;
+  }
+}
+
+async function resolvePublicHost(
+  hostname: string,
+  resolveHost: ResolveHost,
+): Promise<ResolvedAddress[]> {
+  const addresses = ipaddr.isValid(hostname)
+    ? [
+        {
+          address: hostname,
+          family: ipaddr.parse(hostname).kind() === "ipv4" ? 4 : 6,
+        },
+      ]
+    : await resolveHost(hostname);
+  if (
+    addresses.length === 0 ||
+    addresses.some((entry) => !isPublicAddress(entry.address))
+  ) {
+    throw new Error("Destination must resolve only to public network addresses.");
+  }
+  return addresses;
+}
+
+async function readBoundedText(response: Response): Promise<string> {
+  const declaredLength = Number(response.headers.get("content-length"));
+  if (Number.isFinite(declaredLength) && declaredLength > MAX_HTML_BYTES) {
+    throw new Error("Article too large to save through the PWA.");
+  }
+  if (!response.body) return "";
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let byteLength = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      byteLength += value.byteLength;
+      if (byteLength > MAX_HTML_BYTES) {
+        await reader.cancel();
+        throw new Error("Article too large to save through the PWA.");
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  const joined = new Uint8Array(byteLength);
+  let offset = 0;
+  for (const chunk of chunks) {
+    joined.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(joined);
+}
+
+export async function fetchPublicHtml(
+  input: URL,
+  {
+    resolveHost = (hostname) =>
+      dnsLookup(hostname, { all: true, verbatim: true }),
+    fetchImpl = fetch,
+  }: {
+    resolveHost?: ResolveHost;
+    fetchImpl?: typeof fetch;
+  } = {},
+): Promise<{ html: string; status: number }> {
+  let current = input;
+  for (
+    let redirectCount = 0;
+    redirectCount <= MAX_REDIRECTS;
+    redirectCount += 1
+  ) {
+    if (!["http:", "https:"].includes(current.protocol)) {
+      throw new Error("Only http and https URLs are supported.");
+    }
+    if (current.username || current.password) {
+      throw new Error("Credentialed URLs are not supported.");
+    }
+    const addresses = await resolvePublicHost(current.hostname, resolveHost);
+    const dispatcher = new Agent({
+      connect: {
+        lookup: (_hostname, options, callback) => {
+          const family = typeof options === "number" ? options : options.family;
+          const candidates = family
+            ? addresses.filter((entry) => entry.family === family)
+            : addresses;
+          const selected = candidates[0] ?? addresses[0]!;
+          if (typeof options !== "number" && options.all) {
+            callback(null, candidates.length > 0 ? candidates : addresses);
+          } else {
+            callback(null, selected.address, selected.family);
+          }
+        },
+      },
+    });
+    let response: Response;
+    try {
+      response = await fetchImpl(current, {
+        redirect: "manual",
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+        dispatcher,
+      } as RequestInit & { dispatcher: Agent });
+    } finally {
+      await dispatcher.close();
+    }
+    if ([301, 302, 303, 307, 308].includes(response.status)) {
+      const location = response.headers.get("location");
+      if (!location) throw new Error("Upstream redirect is missing a location.");
+      if (redirectCount === MAX_REDIRECTS) {
+        throw new Error("Too many article redirects.");
+      }
+      current = new URL(location, current);
+      continue;
+    }
+    if (!response.ok) return { html: "", status: response.status };
+    const contentType = response.headers.get("content-type")?.toLowerCase() ?? "";
+    if (
+      !contentType.includes("text/html") &&
+      !contentType.includes("application/xhtml+xml")
+    ) {
+      throw new Error("The destination did not return an HTML document.");
+    }
+    return { html: await readBoundedText(response), status: response.status };
+  }
+  throw new Error("Too many article redirects.");
+}
+
 export default async function handler(req: any, res: any): Promise<void> {
   if (req.method !== "POST") {
     res.status(405).send("Method Not Allowed");
+    return;
+  }
+  const origin = Array.isArray(req.headers?.origin)
+    ? req.headers.origin[0] ?? ""
+    : req.headers?.origin ?? "";
+  if (!allowedOrigin(origin)) {
+    res.status(403).send("Origin rejected");
     return;
   }
 
@@ -29,38 +194,23 @@ export default async function handler(req: any, res: any): Promise<void> {
     return;
   }
 
-  if (!["http:", "https:"].includes(parsed.protocol)) {
-    res.status(400).send("Only http and https URLs are supported");
-    return;
-  }
-
   try {
-    const upstream = await fetch(parsed.toString(), {
-      redirect: "follow",
-      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
-    });
-
-    if (!upstream.ok) {
-      res.status(upstream.status).send(`Upstream fetch failed with ${upstream.status}`);
+    const result = await fetchPublicHtml(parsed);
+    if (result.status < 200 || result.status >= 300) {
+      res.status(result.status).send(`Upstream fetch failed with ${result.status}`);
       return;
     }
-
-    const contentLength = upstream.headers.get("content-length");
-    if (contentLength && Number.parseInt(contentLength, 10) > MAX_HTML_BYTES) {
-      res.status(413).send("Article too large to save through the PWA");
-      return;
-    }
-
-    const html = await upstream.text();
-    if (Buffer.byteLength(html, "utf8") > MAX_HTML_BYTES) {
-      res.status(413).send("Article too large to save through the PWA");
-      return;
-    }
-
+    res.setHeader("Cache-Control", "no-store");
     res.setHeader("Content-Type", "text/plain; charset=utf-8");
-    res.status(200).send(html);
+    res.status(200).send(result.html);
   } catch (error) {
-    const message = error instanceof Error ? error.message : "Unknown fetch failure";
-    res.status(500).send(`Article fetch failed: ${message}`);
+    const message = error instanceof Error ? error.message : "Article fetch failed.";
+    const clientError =
+      /(?:supported|public network|credentialed|HTML document|redirect|too large)/i.test(
+        message,
+      );
+    res
+      .status(clientError ? 400 : 502)
+      .send(clientError ? message : "Article fetch failed.");
   }
 }

--- a/packages/pwa/api/security-report.ts
+++ b/packages/pwa/api/security-report.ts
@@ -1,0 +1,326 @@
+import { createSign } from "node:crypto";
+import type { PrivateVulnerabilityReportPayload } from "../../shared/src/bug-report.js";
+import { redactSensitiveText } from "../../shared/src/redact-sensitive.js";
+
+const GITHUB_API = "https://api.github.com";
+const GITHUB_API_VERSION = "2026-03-10";
+const REPOSITORY_OWNER = "freed-project";
+const REPOSITORY_NAME = "freed";
+const MAX_REQUEST_BYTES = 64 * 1024;
+const MAX_TITLE_LENGTH = 256;
+const MAX_DESCRIPTION_LENGTH = 16 * 1024;
+const MAX_STACK_LENGTH = 20 * 1024;
+const RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000;
+const RATE_LIMIT_REQUESTS = 3;
+const TOKEN_REFRESH_SKEW_MS = 5 * 60 * 1000;
+const DEFAULT_ALLOWED_ORIGINS = new Set([
+  "https://app.freed.wtf",
+  "tauri://localhost",
+  "http://tauri.localhost",
+  "https://tauri.localhost",
+]);
+
+interface InstallationToken {
+  token: string;
+  expiresAt: number;
+}
+
+interface RateLimitEntry {
+  count: number;
+  resetAt: number;
+}
+
+let cachedInstallationToken: InstallationToken | null = null;
+const rateLimits = new Map<string, RateLimitEntry>();
+
+function headerValue(value: string | string[] | undefined): string {
+  return Array.isArray(value) ? value[0] ?? "" : value ?? "";
+}
+
+function allowedOrigins(): Set<string> {
+  const configured = process.env.FREED_SECURITY_REPORT_ALLOWED_ORIGINS;
+  if (!configured) return DEFAULT_ALLOWED_ORIGINS;
+  return new Set(
+    configured
+      .split(",")
+      .map((origin) => origin.trim())
+      .filter(Boolean),
+  );
+}
+
+function requestOrigin(req: { headers?: Record<string, string | string[] | undefined> }): string {
+  return headerValue(req.headers?.origin);
+}
+
+function requestIp(req: { headers?: Record<string, string | string[] | undefined> }): string {
+  const forwarded =
+    headerValue(req.headers?.["x-vercel-forwarded-for"]) ||
+    headerValue(req.headers?.["x-forwarded-for"]);
+  return forwarded.split(",")[0]?.trim() || "unknown";
+}
+
+function consumeRateLimit(ip: string, now = Date.now()): boolean {
+  if (rateLimits.size > 5_000) {
+    for (const [key, entry] of rateLimits) {
+      if (entry.resetAt <= now) rateLimits.delete(key);
+    }
+  }
+  const current = rateLimits.get(ip);
+  if (!current || current.resetAt <= now) {
+    rateLimits.set(ip, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
+    return true;
+  }
+  if (current.count >= RATE_LIMIT_REQUESTS) return false;
+  current.count += 1;
+  return true;
+}
+
+function parseOptionalText(
+  value: unknown,
+  field: string,
+  maxLength: number,
+): string | undefined {
+  if (value === undefined || value === null || value === "") return undefined;
+  if (typeof value !== "string") throw new Error(`${field} must be text.`);
+  const redacted = redactSensitiveText(value.trim());
+  if (redacted.length > maxLength) throw new Error(`${field} is too long.`);
+  return redacted;
+}
+
+function parseFingerprint(value: unknown, field: string): string | undefined {
+  const parsed = parseOptionalText(value, field, 128);
+  if (!parsed) return undefined;
+  if (!/^[a-f0-9]{8,128}$/i.test(parsed)) throw new Error(`${field} is invalid.`);
+  return parsed;
+}
+
+function parseMetadata(value: unknown): Record<string, string | boolean> | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("appMetadata must be an object.");
+  }
+  const allowed = new Set([
+    "version",
+    "releaseChannel",
+    "buildKind",
+    "commitSha",
+    "commitRef",
+    "deployedAt",
+    "platform",
+    "appMode",
+  ]);
+  const metadata: Record<string, string | boolean> = {};
+  for (const [key, candidate] of Object.entries(value)) {
+    if (!allowed.has(key)) continue;
+    if (typeof candidate === "boolean") {
+      metadata[key] = candidate;
+      continue;
+    }
+    if (typeof candidate !== "string") throw new Error(`appMetadata.${key} is invalid.`);
+    metadata[key] = redactSensitiveText(candidate.slice(0, 512));
+  }
+  return Object.keys(metadata).length > 0 ? metadata : undefined;
+}
+
+export function parsePrivateReportPayload(value: unknown): PrivateVulnerabilityReportPayload {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("The report body must be a JSON object.");
+  }
+  const body = value as Record<string, unknown>;
+  const title = parseOptionalText(body.title, "title", MAX_TITLE_LENGTH);
+  const description = parseOptionalText(
+    body.description,
+    "description",
+    MAX_DESCRIPTION_LENGTH,
+  );
+  if (!title) throw new Error("title is required.");
+  if (!description) throw new Error("description is required.");
+  return {
+    title,
+    description,
+    stackTrace: parseOptionalText(body.stackTrace, "stackTrace", MAX_STACK_LENGTH),
+    componentStack: parseOptionalText(
+      body.componentStack,
+      "componentStack",
+      MAX_STACK_LENGTH,
+    ),
+    crashFingerprint: parseFingerprint(body.crashFingerprint, "crashFingerprint"),
+    stackFingerprint: parseFingerprint(body.stackFingerprint, "stackFingerprint"),
+    appMetadata: parseMetadata(body.appMetadata),
+  };
+}
+
+function indentedBlock(value: string): string {
+  return value
+    .split("\n")
+    .map((line) => `    ${line}`)
+    .join("\n");
+}
+
+export function formatPrivateReportDescription(
+  payload: PrivateVulnerabilityReportPayload,
+): string {
+  const sections = [payload.description];
+  const metadata = payload.appMetadata
+    ? Object.entries(payload.appMetadata).map(([key, value]) => `- ${key}: ${String(value)}`)
+    : [];
+  const fingerprints = [
+    payload.crashFingerprint ? `- Crash fingerprint: ${payload.crashFingerprint}` : null,
+    payload.stackFingerprint ? `- Stack fingerprint: ${payload.stackFingerprint}` : null,
+  ].filter((value): value is string => Boolean(value));
+  if (metadata.length > 0 || fingerprints.length > 0) {
+    sections.push(["## Redacted runtime details", ...metadata, ...fingerprints].join("\n"));
+  }
+  if (payload.stackTrace) {
+    sections.push(`## Redacted stack trace\n\n${indentedBlock(payload.stackTrace)}`);
+  }
+  if (payload.componentStack) {
+    sections.push(`## Redacted component stack\n\n${indentedBlock(payload.componentStack)}`);
+  }
+  sections.push(
+    "The Freed reporting bridge applied client-side and server-side secret redaction. The diagnostic zip was not uploaded.",
+  );
+  return sections.join("\n\n");
+}
+
+function base64UrlJson(value: unknown): string {
+  return Buffer.from(JSON.stringify(value)).toString("base64url");
+}
+
+export function createGitHubAppJwt(appId: string, privateKey: string, now = Date.now()): string {
+  const issuedAt = Math.floor(now / 1000) - 60;
+  const header = base64UrlJson({ alg: "RS256", typ: "JWT" });
+  const payload = base64UrlJson({ iat: issuedAt, exp: issuedAt + 600, iss: appId });
+  const unsigned = `${header}.${payload}`;
+  const signer = createSign("RSA-SHA256");
+  signer.update(unsigned);
+  signer.end();
+  const signature = signer.sign(privateKey.replace(/\\n/g, "\n"), "base64url");
+  return `${unsigned}.${signature}`;
+}
+
+async function installationToken(): Promise<string> {
+  if (
+    cachedInstallationToken &&
+    cachedInstallationToken.expiresAt - TOKEN_REFRESH_SKEW_MS > Date.now()
+  ) {
+    return cachedInstallationToken.token;
+  }
+  const appId = process.env.FREED_SECURITY_REPORT_APP_ID;
+  const installationId = process.env.FREED_SECURITY_REPORT_INSTALLATION_ID;
+  const privateKey = process.env.FREED_SECURITY_REPORT_PRIVATE_KEY;
+  if (!appId || !installationId || !privateKey) {
+    throw new Error("The private reporting bridge is not configured.");
+  }
+  const response = await fetch(
+    `${GITHUB_API}/app/installations/${encodeURIComponent(installationId)}/access_tokens`,
+    {
+      method: "POST",
+      headers: {
+        accept: "application/vnd.github+json",
+        authorization: `Bearer ${createGitHubAppJwt(appId, privateKey)}`,
+        "x-github-api-version": GITHUB_API_VERSION,
+      },
+      body: JSON.stringify({
+        repositories: [REPOSITORY_NAME],
+        permissions: { repository_advisories: "write" },
+      }),
+      signal: AbortSignal.timeout(10_000),
+    },
+  );
+  const body = (await response.json().catch(() => null)) as
+    | { token?: unknown; expires_at?: unknown }
+    | null;
+  if (
+    !response.ok ||
+    typeof body?.token !== "string" ||
+    typeof body.expires_at !== "string"
+  ) {
+    throw new Error(`GitHub App authentication failed with status ${response.status}.`);
+  }
+  const expiresAt = Date.parse(body.expires_at);
+  if (!Number.isFinite(expiresAt)) throw new Error("GitHub returned an invalid token expiry.");
+  cachedInstallationToken = { token: body.token, expiresAt };
+  return body.token;
+}
+
+async function submitToGitHub(payload: PrivateVulnerabilityReportPayload) {
+  const token = await installationToken();
+  const response = await fetch(
+    `${GITHUB_API}/repos/${REPOSITORY_OWNER}/${REPOSITORY_NAME}/security-advisories`,
+    {
+      method: "POST",
+      headers: {
+        accept: "application/vnd.github+json",
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json",
+        "x-github-api-version": GITHUB_API_VERSION,
+      },
+      body: JSON.stringify({
+        summary: payload.title,
+        description: formatPrivateReportDescription(payload),
+        vulnerabilities: [],
+        severity: null,
+        start_private_fork: false,
+      }),
+      signal: AbortSignal.timeout(10_000),
+    },
+  );
+  const body = (await response.json().catch(() => null)) as
+    | { html_url?: unknown }
+    | null;
+  if (!response.ok || typeof body?.html_url !== "string") {
+    throw new Error(`GitHub rejected the private advisory with status ${response.status}.`);
+  }
+  return { advisoryUrl: body.html_url };
+}
+
+function setResponseHeaders(
+  res: { setHeader: (name: string, value: string) => void },
+  origin: string,
+) {
+  res.setHeader("cache-control", "no-store");
+  res.setHeader("content-type", "application/json; charset=utf-8");
+  res.setHeader("vary", "Origin");
+  if (allowedOrigins().has(origin)) {
+    res.setHeader("access-control-allow-origin", origin);
+    res.setHeader("access-control-allow-methods", "POST, OPTIONS");
+    res.setHeader("access-control-allow-headers", "content-type");
+  }
+}
+
+export default async function handler(req: any, res: any) {
+  const origin = requestOrigin(req);
+  setResponseHeaders(res, origin);
+  if (req.method === "OPTIONS") {
+    if (!allowedOrigins().has(origin)) return res.status(403).json({ error: "Origin rejected." });
+    return res.status(204).end();
+  }
+  if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed." });
+  if (!allowedOrigins().has(origin)) return res.status(403).json({ error: "Origin rejected." });
+  const contentType = headerValue(req.headers?.["content-type"]);
+  if (!contentType.toLowerCase().startsWith("application/json")) {
+    return res.status(415).json({ error: "Content type must be application/json." });
+  }
+  const contentLength = Number(headerValue(req.headers?.["content-length"]));
+  if (Number.isFinite(contentLength) && contentLength > MAX_REQUEST_BYTES) {
+    return res.status(413).json({ error: "Report is too large." });
+  }
+  if (!consumeRateLimit(requestIp(req))) {
+    res.setHeader("retry-after", String(Math.ceil(RATE_LIMIT_WINDOW_MS / 1000)));
+    return res.status(429).json({ error: "Too many private reports. Try again later." });
+  }
+  try {
+    const rawBody = typeof req.body === "string" ? JSON.parse(req.body) : req.body;
+    const payload = parsePrivateReportPayload(rawBody);
+    const result = await submitToGitHub(payload);
+    return res.status(201).json(result);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Private report submission failed.";
+    const clientError = /(?:required|invalid|too long|must be|JSON object)/i.test(message);
+    if (!clientError) console.error("Private report bridge failure", { message });
+    return res.status(clientError ? 400 : 502).json({
+      error: clientError ? message : "The private report could not be submitted securely.",
+    });
+  }
+}

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
     "test": "node ../../node_modules/playwright/cli.js test",
-    "test:unit": "vitest run",
+    "test:unit": "vitest run --maxWorkers=1",
     "test:unit:watch": "vitest",
     "test:ui": "node ../../node_modules/playwright/cli.js test --ui",
     "test:headed": "node ../../node_modules/playwright/cli.js test --headed"
@@ -25,9 +25,11 @@
     "date-fns": "^4.1.0",
     "jsqr": "^1.4.0",
     "jszip": "^3.10.1",
+    "ipaddr.js": "^2.4.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "react-router-dom": "^7.1.1",
+    "react-router-dom": "^7.18.1",
+    "undici": "^7.27.3",
     "zustand": "^5.0.3"
   },
   "devDependencies": {
@@ -38,22 +40,22 @@
     "@types/react": "^19.2.5",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.1",
-    "@vitest/coverage-v8": "^4.0.18",
+    "@vitest/coverage-v8": "^4.1.10",
     "autoprefixer": "^10.4.20",
     "eslint": "^9.39.1",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",
     "jsdom": "^28.1.0",
-    "postcss": "^8.4.49",
+    "postcss": "^8.5.19",
     "tailwindcss": "^3.4.17",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.46.4",
-    "vite": "7.3.1",
+    "vite": "7.3.6",
     "vite-plugin-pwa": "^1.2.0",
     "vite-plugin-top-level-await": "^1.6.0",
     "vite-plugin-wasm": "^3.5.0",
-    "vitest": "^4.0.18",
+    "vitest": "^4.1.10",
     "workbox-window": "^7.4.0"
   }
 }

--- a/packages/pwa/src/lib/bug-report.test.ts
+++ b/packages/pwa/src/lib/bug-report.test.ts
@@ -1,7 +1,11 @@
 import JSZip from "jszip";
 import { beforeEach, describe, expect, it } from "vitest";
 import { useDebugStore } from "@freed/ui/lib/debug-store";
-import { recordRuntimeError, resetBugReportState } from "@freed/ui/lib/bug-report";
+import {
+  buildPrivateVulnerabilityReportPayload,
+  recordRuntimeError,
+  resetBugReportState,
+} from "@freed/ui/lib/bug-report";
 import { pwaBugReporting } from "./bug-report";
 import { useAppStore } from "./store";
 
@@ -87,6 +91,37 @@ describe("pwa bug reporting", () => {
     const zip = await JSZip.loadAsync(bundle.blob);
     expect(bundle.manifest.includedArtifacts).not.toContain("raw-stack");
     expect(Object.keys(zip.files).some((path) => path.startsWith("screenshots/"))).toBe(false);
+  });
+
+  it("pre-populates redacted stack traces for private vulnerability reports", async () => {
+    const bundle = await pwaBugReporting.generateBundle({
+      privacyTier: "private",
+      draft: {
+        issueType: "crash",
+        title: "Sensitive crash",
+        description: "It crashed",
+        reproSteps: "Open the reader",
+        expectedBehavior: "No crash",
+        actualBehavior: "Crash",
+        selectedArtifacts: ["app-metadata", "raw-stack"],
+      },
+    });
+    const payload = buildPrivateVulnerabilityReportPayload({
+      draft: {
+        issueType: "crash",
+        title: "Sensitive crash",
+        description: "It crashed",
+        reproSteps: "Open the reader",
+        expectedBehavior: "No crash",
+        actualBehavior: "Crash",
+        selectedArtifacts: ["app-metadata", "raw-stack"],
+      },
+      bundle,
+    });
+
+    expect(payload.stackTrace).toContain("PWA crash with token=[REDACTED]");
+    expect(payload.stackTrace).not.toContain("super-secret");
+    expect(payload.appMetadata).toMatchObject({ platform: expect.any(String) });
   });
 
   it("omits unchecked public-safe artifacts from exported zips", async () => {

--- a/packages/pwa/src/lib/bug-report.ts
+++ b/packages/pwa/src/lib/bug-report.ts
@@ -15,6 +15,7 @@ import {
   redactSensitiveText,
   resolveArtifactsForTier,
   summarizeStateForReport,
+  submitPrivateVulnerabilityReport,
 } from "@freed/ui/lib/bug-report";
 import type { BugReportingConfig } from "@freed/ui/context";
 import { getCloudProvider } from "./sync";
@@ -165,6 +166,8 @@ export const pwaBugReporting: BugReportingConfig = {
   githubRepo: GITHUB_REPO,
   privateShareEmail: SUPPORT_EMAIL,
   generateBundle: buildPwaBundle,
+  submitPrivateReport: (payload) =>
+    submitPrivateVulnerabilityReport("/api/security-report", payload),
   openUrl: (url) => {
     window.open(url, "_blank", "noopener,noreferrer");
   },

--- a/packages/pwa/src/lib/fetch-url-api.test.ts
+++ b/packages/pwa/src/lib/fetch-url-api.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from "vitest";
+import { fetchPublicHtml, isPublicAddress } from "../../api/fetch-url";
+
+const publicDns = async () => [{ address: "93.184.216.34", family: 4 }];
+
+describe("article fetch proxy security", () => {
+  it.each([
+    ["8.8.8.8", true],
+    ["127.0.0.1", false],
+    ["10.0.0.1", false],
+    ["169.254.169.254", false],
+    ["192.168.1.10", false],
+    ["::1", false],
+    ["fc00::1", false],
+    ["fe80::1", false],
+    ["::ffff:127.0.0.1", false],
+  ])("classifies %s public=%s", (address, expected) => {
+    expect(isPublicAddress(address)).toBe(expected);
+  });
+
+  it("fetches bounded public HTML with pinned public DNS", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      new Response("<html><body>Article</body></html>", {
+        status: 200,
+        headers: { "content-type": "text/html; charset=utf-8" },
+      }),
+    );
+
+    const result = await fetchPublicHtml(new URL("https://example.com/article"), {
+      resolveHost: publicDns,
+      fetchImpl,
+    });
+
+    expect(result).toEqual({
+      html: "<html><body>Article</body></html>",
+      status: 200,
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(fetchImpl.mock.calls[0]?.[1]).toMatchObject({ redirect: "manual" });
+  });
+
+  it("rejects a redirect into loopback before a second request", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      new Response(null, {
+        status: 302,
+        headers: { location: "http://127.0.0.1:3000/secrets" },
+      }),
+    );
+
+    await expect(
+      fetchPublicHtml(new URL("https://example.com/redirect"), {
+        resolveHost: publicDns,
+        fetchImpl,
+      }),
+    ).rejects.toThrow(/public network/i);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects mixed public and private DNS answers", async () => {
+    const fetchImpl = vi.fn();
+
+    await expect(
+      fetchPublicHtml(new URL("https://rebinding.example/article"), {
+        resolveHost: async () => [
+          { address: "93.184.216.34", family: 4 },
+          { address: "127.0.0.1", family: 4 },
+        ],
+        fetchImpl,
+      }),
+    ).rejects.toThrow(/public network/i);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("rejects credentialed URLs and non-HTML responses", async () => {
+    await expect(
+      fetchPublicHtml(new URL("https://user:password@example.com/article"), {
+        resolveHost: publicDns,
+        fetchImpl: vi.fn(),
+      }),
+    ).rejects.toThrow(/credentialed/i);
+
+    await expect(
+      fetchPublicHtml(new URL("https://example.com/archive.zip"), {
+        resolveHost: publicDns,
+        fetchImpl: vi.fn().mockResolvedValue(
+          new Response("zip", {
+            status: 200,
+            headers: { "content-type": "application/zip" },
+          }),
+        ),
+      }),
+    ).rejects.toThrow(/HTML document/i);
+  });
+
+  it("rejects a declared body above the byte cap before reading it", async () => {
+    await expect(
+      fetchPublicHtml(new URL("https://example.com/large"), {
+        resolveHost: publicDns,
+        fetchImpl: vi.fn().mockResolvedValue(
+          new Response("small fixture", {
+            status: 200,
+            headers: {
+              "content-type": "text/html",
+              "content-length": String(2 * 1024 * 1024 + 1),
+            },
+          }),
+        ),
+      }),
+    ).rejects.toThrow(/too large/i);
+  });
+});

--- a/packages/pwa/src/lib/security-report-api.test.ts
+++ b/packages/pwa/src/lib/security-report-api.test.ts
@@ -1,0 +1,209 @@
+import { generateKeyPairSync } from "node:crypto";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { redactSensitiveText } from "@freed/shared/redact-sensitive";
+import handler, {
+  createGitHubAppJwt,
+  formatPrivateReportDescription,
+  parsePrivateReportPayload,
+} from "../../api/security-report";
+
+function createResponse() {
+  const headers = new Map<string, string>();
+  const state: { status: number; body: unknown } = { status: 200, body: null };
+  const response = {
+    setHeader(name: string, value: string) {
+      headers.set(name.toLowerCase(), value);
+    },
+    status(status: number) {
+      state.status = status;
+      return response;
+    },
+    json(body: unknown) {
+      state.body = body;
+      return response;
+    },
+    end() {
+      return response;
+    },
+  };
+  return { response, state, headers };
+}
+
+describe("private security report API", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete process.env.FREED_SECURITY_REPORT_APP_ID;
+    delete process.env.FREED_SECURITY_REPORT_INSTALLATION_ID;
+    delete process.env.FREED_SECURITY_REPORT_PRIVATE_KEY;
+  });
+
+  it.each([
+    ["token=super-secret", "token=[REDACTED]"],
+    ["https://user:password@example.com/path", "https://[REDACTED]@example.com/path"],
+    ["/Users/alice/project/app.ts", "/Users/[REDACTED]/project/app.ts"],
+    ["C:\\Users\\alice\\project\\app.ts", "C:\\Users\\[REDACTED]\\project\\app.ts"],
+    ["reporter@example.com", "[REDACTED_EMAIL]"],
+    ["github_pat_123456789012345678901234567890", "[REDACTED_GITHUB_TOKEN]"],
+    ["AKIA1234567890ABCDEF", "[REDACTED_AWS_KEY]"],
+  ])("redacts sensitive diagnostic text in %s", (input, expected) => {
+    expect(redactSensitiveText(input)).toBe(expected);
+  });
+
+  it("redacts private key blocks in linear time under repeated headers", () => {
+    const repeatedHeaders = "-----BEGIN PRIVATE KEY-----\n".repeat(20_000);
+    const input = `before\n${repeatedHeaders}payload\n-----END PRIVATE KEY-----\nafter`;
+
+    expect(redactSensitiveText(input)).toBe(
+      "before\n[REDACTED_PRIVATE_KEY]\nafter",
+    );
+  });
+
+  it.each(["", "RSA ", "EC ", "OPENSSH "])(
+    "redacts %sprivate key blocks",
+    (keyType) => {
+      const input = `before\n-----BEGIN ${keyType}PRIVATE KEY-----\nsecret\n-----END ${keyType}PRIVATE KEY-----\nafter`;
+
+      expect(redactSensitiveText(input)).toBe(
+        "before\n[REDACTED_PRIVATE_KEY]\nafter",
+      );
+    },
+  );
+
+  it("preserves an incomplete private key marker", () => {
+    const input = "before\n-----BEGIN PRIVATE KEY-----\nincomplete";
+
+    expect(redactSensitiveText(input)).toBe(input);
+  });
+
+  it("redacts payloads again at the server boundary", () => {
+    const payload = parsePrivateReportPayload({
+      title: "Token leak",
+      description: "authorization: Bearer a-secret-token",
+      stackTrace: "at /home/alice/app.ts?key=secret-value",
+      crashFingerprint: "deadbeef",
+      appMetadata: { version: "1.2.3", userAgent: "not accepted" },
+    });
+
+    expect(payload.description).toBe("authorization=[REDACTED]");
+    expect(payload.stackTrace).toContain("/home/[REDACTED]/app.ts?key=[REDACTED]");
+    expect(payload.appMetadata).toEqual({ version: "1.2.3" });
+    const formatted = formatPrivateReportDescription(payload);
+    expect(formatted).toContain("## Redacted stack trace");
+    expect(formatted).toContain("diagnostic zip was not uploaded");
+    expect(formatted).not.toContain("alice");
+    expect(formatted).not.toContain("secret-value");
+  });
+
+  it("creates a ten minute RS256 GitHub App JWT", () => {
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    const now = 1_800_000_000_000;
+    const jwt = createGitHubAppJwt(
+      "1234",
+      privateKey.export({ type: "pkcs8", format: "pem" }).toString(),
+      now,
+    );
+    const [header, payload, signature] = jwt.split(".");
+    expect(JSON.parse(Buffer.from(header!, "base64url").toString())).toEqual({
+      alg: "RS256",
+      typ: "JWT",
+    });
+    expect(JSON.parse(Buffer.from(payload!, "base64url").toString())).toEqual({
+      iat: Math.floor(now / 1000) - 60,
+      exp: Math.floor(now / 1000) + 540,
+      iss: "1234",
+    });
+    expect(signature).toBeTruthy();
+  });
+
+  it("rejects untrusted origins before contacting GitHub", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const { response, state } = createResponse();
+
+    await handler(
+      {
+        method: "POST",
+        headers: {
+          origin: "https://attacker.example",
+          "content-type": "application/json",
+          "x-forwarded-for": "192.0.2.10",
+        },
+        body: { title: "A", description: "B" },
+      },
+      response,
+    );
+
+    expect(state.status).toBe(403);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("uses a repository-scoped installation token and submits one advisory", async () => {
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    process.env.FREED_SECURITY_REPORT_APP_ID = "1234";
+    process.env.FREED_SECURITY_REPORT_INSTALLATION_ID = "5678";
+    process.env.FREED_SECURITY_REPORT_PRIVATE_KEY = privateKey
+      .export({ type: "pkcs8", format: "pem" })
+      .toString();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            token: "installation-token",
+            expires_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+          }),
+          { status: 201 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            html_url:
+              "https://github.com/freed-project/freed/security/advisories/GHSA-abcd-1234-efgh",
+          }),
+          { status: 201 },
+        ),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+    const { response, state, headers } = createResponse();
+
+    await handler(
+      {
+        method: "POST",
+        headers: {
+          origin: "https://app.freed.wtf",
+          "content-type": "application/json",
+          "x-forwarded-for": "192.0.2.11",
+        },
+        body: {
+          title: "Sensitive failure",
+          description: "Reproduction details",
+          stackTrace: "at capture (app.ts:10:2)",
+        },
+      },
+      response,
+    );
+
+    expect(state.status).toBe(201);
+    expect(headers.get("cache-control")).toBe("no-store");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const tokenRequest = fetchMock.mock.calls[0]!;
+    expect(tokenRequest[0]).toBe(
+      "https://api.github.com/app/installations/5678/access_tokens",
+    );
+    expect(JSON.parse(String(tokenRequest[1]?.body))).toEqual({
+      repositories: ["freed"],
+      permissions: { repository_advisories: "write" },
+    });
+    const reportRequest = fetchMock.mock.calls[1]!;
+    expect(reportRequest[0]).toBe(
+      "https://api.github.com/repos/freed-project/freed/security-advisories",
+    );
+    const reportBody = JSON.parse(String(reportRequest[1]?.body));
+    expect(reportBody.summary).toBe("Sensitive failure");
+    expect(reportBody.description).toContain("## Redacted stack trace");
+    expect(reportBody.vulnerabilities).toEqual([]);
+    expect(reportBody.severity).toBeNull();
+    expect(reportBody.start_private_fork).toBe(false);
+  });
+});

--- a/packages/pwa/tsconfig.node.json
+++ b/packages/pwa/tsconfig.node.json
@@ -22,5 +22,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "api/**/*.ts"]
 }

--- a/packages/pwa/vercel.json
+++ b/packages/pwa/vercel.json
@@ -3,5 +3,10 @@
   "framework": "vite",
   "buildCommand": "PATH=../../node_modules/.bin:$PATH npm run build",
   "outputDirectory": "dist",
+  "functions": {
+    "api/security-report.ts": {
+      "includeFiles": "../../packages/shared/src/redact-sensitive.ts"
+    }
+  },
   "rewrites": [{ "source": "/((?!api/).*)", "destination": "/index.html" }]
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -14,6 +14,7 @@
     "./opml": "./src/opml.ts",
     "./google-contacts": "./src/google-contacts.ts",
     "./google-contacts-automation": "./src/google-contacts-automation.ts",
+    "./redact-sensitive": "./src/redact-sensitive.ts",
     "./contact-matching": "./src/contact-matching.ts"
   },
   "scripts": {

--- a/packages/shared/src/bug-report.ts
+++ b/packages/shared/src/bug-report.ts
@@ -98,3 +98,17 @@ export interface BugReportBundleData {
 export interface GeneratedBugReportBundle extends BugReportBundleData {
   blob: Blob;
 }
+
+export interface PrivateVulnerabilityReportPayload {
+  title: string;
+  description: string;
+  stackTrace?: string;
+  componentStack?: string;
+  crashFingerprint?: string;
+  stackFingerprint?: string;
+  appMetadata?: Record<string, unknown>;
+}
+
+export interface PrivateVulnerabilityReportResult {
+  advisoryUrl: string;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -47,6 +47,7 @@ export * from "./release-channel";
 export * from "./legal";
 export * from "./legal-storage";
 export * from "./bug-report";
+export * from "./redact-sensitive";
 export * from "./story-wall";
 export * from "./youtube";
 

--- a/packages/shared/src/redact-sensitive.ts
+++ b/packages/shared/src/redact-sensitive.ts
@@ -1,0 +1,106 @@
+const PRIVATE_KEY_BEGIN_MARKERS = [
+  "-----BEGIN PRIVATE KEY-----",
+  "-----BEGIN RSA PRIVATE KEY-----",
+  "-----BEGIN EC PRIVATE KEY-----",
+  "-----BEGIN OPENSSH PRIVATE KEY-----",
+] as const;
+
+const PRIVATE_KEY_END_MARKERS = [
+  "-----END PRIVATE KEY-----",
+  "-----END RSA PRIVATE KEY-----",
+  "-----END EC PRIVATE KEY-----",
+  "-----END OPENSSH PRIVATE KEY-----",
+] as const;
+
+function markerLengthAt(
+  input: string,
+  index: number,
+  markers: readonly string[],
+): number {
+  for (const marker of markers) {
+    if (input.startsWith(marker, index)) return marker.length;
+  }
+  return 0;
+}
+
+function redactPrivateKeyBlocks(input: string): string {
+  const chunks: string[] = [];
+  let blockStart = -1;
+  let copyStart = 0;
+  let index = 0;
+
+  while (index < input.length) {
+    if (input.charCodeAt(index) !== 45) {
+      index += 1;
+      continue;
+    }
+
+    if (blockStart < 0) {
+      const markerLength = markerLengthAt(
+        input,
+        index,
+        PRIVATE_KEY_BEGIN_MARKERS,
+      );
+      if (markerLength > 0) {
+        chunks.push(input.slice(copyStart, index));
+        blockStart = index;
+        index += markerLength;
+        continue;
+      }
+    } else {
+      const markerLength = markerLengthAt(
+        input,
+        index,
+        PRIVATE_KEY_END_MARKERS,
+      );
+      if (markerLength > 0) {
+        chunks.push("[REDACTED_PRIVATE_KEY]");
+        index += markerLength;
+        copyStart = index;
+        blockStart = -1;
+        continue;
+      }
+    }
+
+    index += 1;
+  }
+
+  chunks.push(input.slice(blockStart >= 0 ? blockStart : copyStart));
+  return chunks.join("");
+}
+
+const SECRET_ASSIGNMENT =
+  /\b(auth(?:orization)?|token|auth[_-]?token|access[_-]?token|refresh[_-]?token|key|api[_-]?key|client[_-]?secret|password|passwd|cookie|session|secret|signature|sig)\b(?:\s*[:=]\s*|["']\s*:\s*["'])(?:Bearer\s+|Basic\s+)?["']?([^\s,"'};]+)/gi;
+
+/**
+ * Remove credentials and local identity details from diagnostics before they
+ * leave the device. Callers at trust boundaries should apply this even when
+ * the input was already redacted by a collector.
+ */
+export function redactSensitiveText(input: string): string {
+  return redactPrivateKeyBlocks(input)
+    .replace(
+      /\b(?:Bearer|Basic)\s+[A-Za-z0-9+/_=.:-]+/gi,
+      "Bearer [REDACTED]",
+    )
+    .replace(SECRET_ASSIGNMENT, "$1=[REDACTED]")
+    .replace(
+      /([?&](?:token|code|state|auth|key|api_key|client_secret|sig|signature|session|password)=)[^&\s#]+/gi,
+      "$1[REDACTED]",
+    )
+    .replace(/\bgh[pousr]_[A-Za-z0-9_]{20,}\b/g, "[REDACTED_GITHUB_TOKEN]")
+    .replace(/\bgithub_pat_[A-Za-z0-9_]{20,}\b/g, "[REDACTED_GITHUB_TOKEN]")
+    .replace(/\bAKIA[0-9A-Z]{16}\b/g, "[REDACTED_AWS_KEY]")
+    .replace(
+      /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b/g,
+      "[REDACTED_JWT]",
+    )
+    .replace(/(https?:\/\/)[^/@\s]+:[^/@\s]+@/gi, "$1[REDACTED]@")
+    .replace(/\/Users\/[^/\s]+/g, "/Users/[REDACTED]")
+    .replace(/\/home\/[^/\s]+/g, "/home/[REDACTED]")
+    .replace(/C:\\Users\\[^\\\s]+/gi, "C:\\Users\\[REDACTED]")
+    .replace(
+      /\b[A-Za-z0-9_+.-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g,
+      "[REDACTED_EMAIL]",
+    );
+}

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -19,7 +19,7 @@
     "@freed/shared": "*",
     "@automerge/automerge": "^2.2.8",
     "@automerge/automerge-repo": "^1.2.1",
-    "ws": "^8.16.0"
+    "ws": "^8.21.0"
   },
   "devDependencies": {
     "@types/ws": "^8.5.10",

--- a/packages/ui/src/components/report/ReportComposer.tsx
+++ b/packages/ui/src/components/report/ReportComposer.tsx
@@ -8,6 +8,7 @@ import type {
 } from "@freed/shared";
 import {
   createDefaultBugReportDraft,
+  buildPrivateVulnerabilityReportPayload,
   createGithubIssueUrl,
   getReportPrivacyTier,
   PRIVATE_ARTIFACTS,
@@ -109,9 +110,12 @@ export function ReportComposer({
     ...createDefaultBugReportDraft(initialIssueType),
     ...(bugReporting?.createDraft?.(initialIssueType) ?? {}),
   }));
-  const [working, setWorking] = useState<null | "export" | "github" | "private-share">(null);
+  const [working, setWorking] = useState<
+    null | "export" | "github" | "private-share" | "private-submit"
+  >(null);
   const [lastBundleName, setLastBundleName] = useState<string | null>(null);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
+  const privateSubmitInFlightRef = useRef(false);
 
   const privacyTier = getReportPrivacyTier(draft.selectedArtifacts);
   const selectedArtifactSet = useMemo(
@@ -262,6 +266,37 @@ export function ReportComposer({
     }
   };
 
+  const handlePrivateSubmit = async () => {
+    if (
+      !bugReporting.submitPrivateReport ||
+      privacyTier !== "private" ||
+      privateSubmitInFlightRef.current
+    ) {
+      return;
+    }
+    privateSubmitInFlightRef.current = true;
+    setWorking("private-submit");
+    setStatusMessage(null);
+    try {
+      const bundle = await bugReporting.generateBundle({ draft, privacyTier: "private" });
+      const payload = buildPrivateVulnerabilityReportPayload({ draft, bundle });
+      await bugReporting.submitPrivateReport(payload);
+      setStatusMessage(
+        "Private report submitted to the Freed security team through GitHub. The zip bundle stayed on this device.",
+      );
+      toast.info("Private security report submitted.");
+    } catch (error) {
+      const message = error instanceof Error
+        ? error.message
+        : "The private report could not be submitted.";
+      setStatusMessage(message);
+      toast.error(message);
+    } finally {
+      privateSubmitInFlightRef.current = false;
+      setWorking(null);
+    }
+  };
+
   const issueTypeOptions: Array<{ value: BugReportIssueType; label: string }> = [
     { value: "crash", label: "Crash" },
     { value: "broken-feature", label: "Broken feature" },
@@ -391,7 +426,7 @@ export function ReportComposer({
         <p className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
           {privacyTier === "public-safe"
             ? "This bundle is intended to be safe for a public GitHub issue."
-            : "This bundle may include details you may not want to post publicly. Use email or private sharing."}
+            : "This bundle may include local details. You can download it, email it, or send a redacted text report privately through GitHub."}
         </p>
         <p className="mt-3 text-xs text-[color:var(--theme-text-muted)]">
           Bundle type: {privacyTier === "public-safe" ? "Public-safe zip" : "Private zip"}
@@ -429,6 +464,17 @@ export function ReportComposer({
         >
           Download and email
         </button>
+        {privacyTier === "private" && bugReporting.submitPrivateReport ? (
+          <button
+            onClick={handlePrivateSubmit}
+            disabled={working !== null}
+            className="btn-secondary rounded-xl px-4 py-2.5 text-sm disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {working === "private-submit"
+              ? "Submitting private report..."
+              : "Submit private report to GitHub"}
+          </button>
+        ) : null}
         {githubIssueDisabledByPrivacy ? (
           <Tooltip
             label="Turn off private diagnostics first"

--- a/packages/ui/src/context/PlatformContext.tsx
+++ b/packages/ui/src/context/PlatformContext.tsx
@@ -20,6 +20,8 @@ import type {
   BugReportIssueType,
   FeedItem,
   GeneratedBugReportBundle,
+  PrivateVulnerabilityReportPayload,
+  PrivateVulnerabilityReportResult,
   ImportProgress,
   LocalAIModelId,
   LocalAIHardwareProfile,
@@ -127,6 +129,9 @@ export interface BugReportingConfig {
     privacyTier: ReportPrivacyTier;
   }) => Promise<GeneratedBugReportBundle>;
   exportBundle?: (bundle: GeneratedBugReportBundle) => Promise<void>;
+  submitPrivateReport?: (
+    payload: PrivateVulnerabilityReportPayload,
+  ) => Promise<PrivateVulnerabilityReportResult>;
   openUrl?: (url: string) => void;
 }
 

--- a/packages/ui/src/lib/bug-report.ts
+++ b/packages/ui/src/lib/bug-report.ts
@@ -8,9 +8,13 @@ import type {
   BugReportArtifactDefinition,
   BugReportBundleManifest,
   GeneratedBugReportBundle,
+  PrivateVulnerabilityReportPayload,
+  PrivateVulnerabilityReportResult,
   ReportPrivacyTier,
   RuntimeErrorSnapshot,
 } from "@freed/shared";
+export { redactSensitiveText } from "@freed/shared/redact-sensitive";
+import { redactSensitiveText } from "@freed/shared/redact-sensitive";
 
 const MAX_REPORT_EVENTS = 250;
 
@@ -125,15 +129,6 @@ function stableHash(input: string): string {
     hash = Math.imul(hash, 16777619);
   }
   return Math.abs(hash >>> 0).toString(16).padStart(8, "0");
-}
-
-export function redactSensitiveText(input: string): string {
-  return input
-    .replace(/(auth[_-]?token|access[_-]?token|refresh[_-]?token|cookie|authorization)["'=:\s]+([^,\s]+)/gi, "$1=[REDACTED]")
-    .replace(/([?&](?:token|code|state|auth|key|sig|signature|session)=)[^&\s]+/gi, "$1[REDACTED]")
-    .replace(/\/Users\/[^/\s]+/g, "/Users/[REDACTED]")
-    .replace(/C:\\Users\\[^\\\s]+/g, "C:\\Users\\[REDACTED]")
-    .replace(/\b[A-Za-z0-9_\-.]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g, "[REDACTED_EMAIL]");
 }
 
 function createErrorSnapshot(input: {
@@ -402,6 +397,78 @@ export function buildBugReportSummaryMarkdown(input: {
   ]
     .filter(Boolean)
     .join("\n");
+}
+
+function pickPrivateReportMetadata(value: unknown): Record<string, unknown> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const source = value as Record<string, unknown>;
+  const allowedKeys = [
+    "version",
+    "releaseChannel",
+    "buildKind",
+    "commitSha",
+    "commitRef",
+    "deployedAt",
+    "platform",
+    "appMode",
+  ];
+  const metadata = Object.fromEntries(
+    allowedKeys.flatMap((key) => {
+      const candidate = source[key];
+      if (typeof candidate !== "string" && typeof candidate !== "boolean") return [];
+      return [[key, candidate]];
+    }),
+  );
+  return Object.keys(metadata).length > 0 ? metadata : undefined;
+}
+
+export function buildPrivateVulnerabilityReportPayload(input: {
+  draft: BugReportDraft;
+  bundle: GeneratedBugReportBundle;
+}): PrivateVulnerabilityReportPayload {
+  const includesRawStack = input.bundle.manifest.includedArtifacts.includes("raw-stack");
+  const stackTrace = includesRawStack && typeof input.bundle.diagnostics.rawStack === "string"
+    ? redactSensitiveText(input.bundle.diagnostics.rawStack)
+    : undefined;
+  const componentStack =
+    includesRawStack && typeof input.bundle.diagnostics.componentStack === "string"
+      ? redactSensitiveText(input.bundle.diagnostics.componentStack)
+      : undefined;
+
+  return {
+    title: redactSensitiveText(input.draft.title.trim() || "Freed vulnerability report"),
+    description: redactSensitiveText(input.bundle.summaryMarkdown),
+    stackTrace,
+    componentStack,
+    crashFingerprint: input.bundle.manifest.crashFingerprint,
+    stackFingerprint: input.bundle.manifest.stackFingerprint,
+    appMetadata: pickPrivateReportMetadata(input.bundle.diagnostics.runtime),
+  };
+}
+
+export async function submitPrivateVulnerabilityReport(
+  endpoint: string,
+  payload: PrivateVulnerabilityReportPayload,
+): Promise<PrivateVulnerabilityReportResult> {
+  const response = await fetch(endpoint, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(payload),
+    signal: AbortSignal.timeout(15_000),
+  });
+  const body = (await response.json().catch(() => null)) as
+    | { advisoryUrl?: unknown; error?: unknown }
+    | null;
+  if (!response.ok) {
+    const message = typeof body?.error === "string"
+      ? body.error
+      : "The private report could not be submitted.";
+    throw new Error(message);
+  }
+  if (typeof body?.advisoryUrl !== "string" || !body.advisoryUrl.startsWith("https://github.com/")) {
+    throw new Error("GitHub accepted the report without returning a valid advisory URL.");
+  }
+  return { advisoryUrl: body.advisoryUrl };
 }
 
 export function summarizeStateForReport(input: {

--- a/scripts/lib/provider-visible-paths.mjs
+++ b/scripts/lib/provider-visible-paths.mjs
@@ -106,6 +106,7 @@ export const SOCIAL_PROVIDER_PACKAGE_PREFIXES = [
 // providers can observe but have no dedicated focused provider test lane, so
 // validate-worktree intentionally does not narrow validation for them.
 export const PROVIDER_VISIBLE_EXTRA_FILES = new Set([
+  "packages/desktop/src/lib/bug-report.ts",
   "packages/desktop/src/components/YouTubeSettingsSection.tsx",
   "packages/desktop/src-tauri/gen/schemas/capabilities.json",
   "packages/desktop/src/lib/rss-refresh-plan.ts",
@@ -114,21 +115,29 @@ export const PROVIDER_VISIBLE_EXTRA_FILES = new Set([
   "packages/desktop/src/lib/user-agent.ts",
   "packages/desktop/src-tauri/src/webkit-mask.js",
   "packages/pwa/api/oauth/google.ts",
+  "packages/pwa/api/fetch-url.ts",
+  "packages/pwa/api/security-report.ts",
   "packages/pwa/src/components/OAuthCallback.tsx",
   "packages/pwa/src/components/PwaSyncSettings.tsx",
   "packages/pwa/src/components/SyncConnectDialog.tsx",
   "packages/pwa/src/lib/cloud-oauth.ts",
+  "packages/pwa/src/lib/bug-report.ts",
   "packages/pwa/src/lib/contacts.ts",
   "packages/pwa/src/lib/oauth-redirect.ts",
   "packages/pwa/src/lib/reader-cache.ts",
   "packages/pwa/src/lib/sync.ts",
   "packages/pwa/src/lib/youtube-handoff.ts",
   "packages/shared/src/google-contacts-automation.ts",
+  "packages/shared/src/bug-report.ts",
+  "packages/shared/src/redact-sensitive.ts",
   "packages/shared/src/google-contacts.ts",
   "packages/shared/src/legal.ts",
   "packages/shared/src/schema.ts",
   "packages/shared/src/youtube.ts",
   "packages/ui/src/components/feed/ReaderView.tsx",
+  "packages/ui/src/components/report/ReportComposer.tsx",
+  "packages/ui/src/context/PlatformContext.tsx",
+  "packages/ui/src/lib/bug-report.ts",
   "packages/ui/src/components/feed/YouTubeFocusPlayer.tsx",
 ]);
 
@@ -316,6 +325,15 @@ export function providerIdsForPath(filePath) {
   )
     return ["youtube"];
   if (
+    normalizedPath.startsWith("packages/desktop/src/lib/bug-report") ||
+    normalizedPath.startsWith("packages/pwa/api/security-report") ||
+    normalizedPath.startsWith("packages/pwa/api/fetch-url") ||
+    normalizedPath.startsWith("packages/pwa/src/lib/bug-report") ||
+    normalizedPath.startsWith("packages/shared/src/bug-report") ||
+    normalizedPath.startsWith("packages/shared/src/redact-sensitive") ||
+    normalizedPath.startsWith("packages/ui/src/components/report/reportcomposer") ||
+    normalizedPath.startsWith("packages/ui/src/context/platformcontext") ||
+    normalizedPath.startsWith("packages/ui/src/lib/bug-report") ||
     normalizedPath.startsWith("packages/sync/src/cloud/") ||
     normalizedPath.startsWith("packages/pwa/api/oauth/google") ||
     normalizedPath.startsWith("packages/pwa/src/components/oauthcallback") ||
@@ -331,7 +349,9 @@ export function providerIdsForPath(filePath) {
     /\/(?:google|gdrive|dropbox)(?:[-_.\/]|$)/.test(normalizedPath)
   )
     return ["other"];
-  return [];
+  return CAPTURE_PROVIDER_CONTACT_FILE_PATTERN.test(normalizedPath)
+    ? ["other"]
+    : [];
 }
 
 function requireApprovalText(record, field, errors) {

--- a/scripts/lib/provider-visible-paths.test.mjs
+++ b/scripts/lib/provider-visible-paths.test.mjs
@@ -331,6 +331,12 @@ test("background media and Google sync network surfaces are provider-visible", (
     true,
   );
   assert.equal(isProviderVisiblePath("packages/pwa/api/oauth/google.ts"), true);
+  assert.equal(isProviderVisiblePath("packages/pwa/api/security-report.ts"), true);
+  assert.equal(isProviderVisiblePath("packages/pwa/api/fetch-url.ts"), true);
+  assert.deepEqual(
+    providerIdsForPath("packages/pwa/api/security-report.ts"),
+    ["other"],
+  );
   assert.equal(isProviderVisiblePath("packages/pwa/src/lib/sync.ts"), true);
   assert.equal(
     isProviderVisiblePath("packages/shared/src/google-contacts.ts"),
@@ -832,6 +838,12 @@ test("provider-specific paths infer the provider used to validate approval scope
     ["other"],
   );
   assert.deepEqual(providerIdsForPath("packages/sync/src/cloud/gdrive.ts"), [
+    "other",
+  ]);
+  assert.deepEqual(providerIdsForPath("packages/capture-rss/src/browser.ts"), [
+    "other",
+  ]);
+  assert.deepEqual(providerIdsForPath("packages/capture-save/src/browser.ts"), [
     "other",
   ]);
   assert.deepEqual(


### PR DESCRIPTION
(AI Generated).

## Summary
- Add private GitHub vulnerability report submission with pre-populated redacted diagnostics
- Harden fetched XML and HTML inputs and document the organization security audit
- Use the CODEOWNER GitHub reaction for the reviewed provider-only diff

## Testing
- 3 RSS XML security tests passed
- 35 PWA security and bug report tests passed
- 3 Desktop bug report unit tests passed
- 3 Desktop bug report browser tests passed
- Desktop legal gate startup smoke passed after workspace refresh

## Provider Review
- Status: Draft publication is allowed. Ready and merge require provider authority.
- Review action: A provider CODEOWNER reacts with a GitHub thumbs-up on the generated provider review comment.
- Provider subdiff: `fba6cf1fa264c0665fe92a7f18734c689dfae110`
- Draft publication does not authorize new live provider traffic. Gate 1 behavior approval still applies.

Files bound into this provider review:
- `packages/capture-rss/src/browser.ts`
- `packages/capture-save/src/browser.ts`
- `packages/capture-youtube/package.json`
- `packages/desktop/src/lib/bug-report.ts`
- `packages/pwa/api/fetch-url.ts`
- `packages/pwa/api/security-report.ts`
- `packages/pwa/src/lib/bug-report.ts`
- `packages/shared/src/bug-report.ts`
- `packages/shared/src/redact-sensitive.ts`
- `packages/ui/src/components/report/ReportComposer.tsx`
- `packages/ui/src/context/PlatformContext.tsx`
- `packages/ui/src/lib/bug-report.ts`