### PR TITLE
fix: complete YouTube capture lifecycle

### DIFF
--- a/packages/desktop/src-tauri/src/youtube-extract.js
+++ b/packages/desktop/src-tauri/src/youtube-extract.js
@@ -7,17 +7,83 @@
   const REQUIRED_STABLE_PASSES = 3;
   const SCROLL_SETTLE_MS = 900;
   const READY_TIMEOUT_MS = 15000;
-  const normalizedPath = location.pathname.replace(/\/$/, "");
-  const stage = normalizedPath === "/feed/channels"
-    ? "channels"
-    : normalizedPath === "/feed/subscriptions"
-      ? "subscriptions"
-      : "unsupported";
+  const SCRIPT_DEADLINE_MS = 60000;
+  const MAX_OBJECT_VISITS = 400000;
+  const DEADLINE_CHECK_INTERVAL = 256;
+  const captureId = "__YOUTUBE_CAPTURE_ID__";
+  const stage = "__EXPECTED_YOUTUBE_CAPTURE_STAGE__";
+  const expectedPath = "__EXPECTED_YOUTUBE_CAPTURE_PATH__";
+  const startedAt = Date.now();
+  const deadlineAt = startedAt + SCRIPT_DEADLINE_MS;
 
   const channels = new Map();
   const videos = new Map();
   const unresolved = new Set();
+  const persistentVideoIssues = new Set();
   const candidateSources = new Set();
+  const seenInitialObjects = new WeakSet();
+  const renderedElementIds = new WeakMap();
+  const objectRevisionIds = new WeakMap();
+  const chargedObjectRevisions = new WeakMap();
+  const selectedEmptyRendererObjects = new WeakSet();
+  const selectedEmptyRendererFingerprints = new Set();
+  const emittedChannels = new Map();
+  const emittedVideos = new Map();
+  const supportedRenderedCandidates = new Set();
+  const unsupportedRenderedCandidates = new Set();
+  let initialDataScanned = false;
+  let nextRenderedElementId = 1;
+  let nextObjectRevisionId = 1;
+  let visitedObjectCount = 0;
+  let workBudgetExceeded = false;
+  let deadlineExceeded = false;
+  let scrollPasses = 0;
+  let stablePasses = 0;
+  let stopReason = "starting";
+
+  function normalizePath(path) {
+    const normalized = typeof path === "string" ? path.replace(/\/+$/, "") : "";
+    return normalized || "/";
+  }
+
+  function isYouTubeHost(hostname) {
+    return hostname === "youtube.com" || hostname.endsWith(".youtube.com");
+  }
+
+  function elapsedMs() {
+    return Math.max(0, Date.now() - startedAt);
+  }
+
+  function remainingMs() {
+    return Math.max(0, deadlineAt - Date.now());
+  }
+
+  function checkDeadline() {
+    if (Date.now() < deadlineAt) return false;
+    deadlineExceeded = true;
+    return true;
+  }
+
+  function workMustStop() {
+    return workBudgetExceeded || deadlineExceeded || checkDeadline();
+  }
+
+  function assertExpectedPage() {
+    const requiredPath = stage === "channels"
+      ? "/feed/channels"
+      : stage === "subscriptions"
+        ? "/feed/subscriptions"
+        : null;
+    if (!captureId || captureId.startsWith("__YOUTUBE_")) {
+      throw new Error("YouTube capture identity was not initialized.");
+    }
+    if (!requiredPath || normalizePath(expectedPath) !== requiredPath) {
+      throw new Error("YouTube capture received an unsupported stage or path.");
+    }
+    if (!isYouTubeHost(location.hostname) || normalizePath(location.pathname) !== requiredPath) {
+      throw new Error("YouTube opened an unexpected page for capture.");
+    }
+  }
 
   function textOf(value) {
     if (!value) return "";
@@ -96,8 +162,35 @@
     return match ? match[2] : undefined;
   }
 
-  function addChannel(renderer, source) {
-    if (!renderer || typeof renderer !== "object") return;
+  function markUnresolved(issueTarget, key, trackUnresolved) {
+    if (trackUnresolved) issueTarget.add(key);
+  }
+
+  function clearUnresolved(issueTarget, key) {
+    issueTarget.delete(key);
+  }
+
+  function clearPersistentVideoIssue(key) {
+    persistentVideoIssues.delete(key);
+    unresolved.delete(key);
+  }
+
+  function recordPersistentVideoIssue(key) {
+    if (key.startsWith("video-owner:") || key.startsWith("video-title:")) {
+      const videoId = key.slice(key.indexOf(":") + 1);
+      if (videos.has(videoId)) return;
+    }
+    persistentVideoIssues.add(key);
+    unresolved.add(key);
+  }
+
+  function addChannel(
+    renderer,
+    source,
+    trackUnresolved = true,
+    issueTarget = unresolved,
+  ) {
+    if (!renderer || typeof renderer !== "object") return false;
     const candidateKey = `channel:${source}`;
     candidateSources.add(candidateKey);
     const channelId = browseIdFrom(renderer)
@@ -107,10 +200,10 @@
       || browseIdFrom(renderer.shortBylineText)
       || browseIdFrom(renderer.longBylineText);
     if (!channelId) {
-      unresolved.add(candidateKey);
-      return;
+      markUnresolved(issueTarget, candidateKey, trackUnresolved);
+      return false;
     }
-    unresolved.delete(candidateKey);
+    clearUnresolved(issueTarget, candidateKey);
 
     const title = textOf(renderer.title)
       || textOf(renderer.channelTitle)
@@ -151,6 +244,7 @@
       channelUrl: `https://www.youtube.com/channel/${channelId}`,
       profileUrl: `https://www.youtube.com/channel/${channelId}`,
     });
+    return true;
   }
 
   function videoIdFrom(renderer) {
@@ -159,7 +253,10 @@
       return renderer.videoId;
     }
     const endpoint = endpointOf(renderer);
-    const id = endpoint && endpoint.watchEndpoint && endpoint.watchEndpoint.videoId;
+    const id = endpoint && (
+      endpoint.watchEndpoint && endpoint.watchEndpoint.videoId
+      || endpoint.reelWatchEndpoint && endpoint.reelWatchEndpoint.videoId
+    );
     return typeof id === "string" && VIDEO_ID_PATTERN.test(id) ? id : undefined;
   }
 
@@ -186,16 +283,28 @@
     });
   }
 
-  function addVideo(renderer, source) {
-    if (!renderer || typeof renderer !== "object") return;
+  function addVideo(
+    renderer,
+    source,
+    trackUnresolved = true,
+    issueTarget = unresolved,
+  ) {
+    if (!renderer || typeof renderer !== "object") return false;
     const candidateKey = `video:${source}`;
     candidateSources.add(candidateKey);
     const videoId = videoIdFrom(renderer);
     if (!videoId) {
-      unresolved.add(candidateKey);
-      return;
+      markUnresolved(issueTarget, candidateKey, trackUnresolved);
+      return false;
     }
-    unresolved.delete(candidateKey);
+    clearUnresolved(issueTarget, candidateKey);
+
+    const path = endpointUrl(renderer)
+      || endpointUrl(renderer.title)
+      || (source.includes("reel") ? `/shorts/${videoId}` : `/watch?v=${videoId}`);
+    const isShortCandidate = path.startsWith("/shorts/") || source.includes("reel");
+    const styles = overlayStyles(renderer);
+    const thumbnailUrl = bestThumbnail(renderer.thumbnail);
 
     const owner = renderer.ownerText
       || renderer.shortBylineText
@@ -203,11 +312,70 @@
       || renderer.channelName;
     const channelId = browseIdFrom(owner) || browseIdFrom(renderer);
     const channelTitle = textOf(owner) || textOf(renderer.channelName);
-    if (!channelId || !channelTitle) {
-      unresolved.add(`video-owner:${videoId}`);
-      return;
+    const title = textOf(renderer.title) || textOf(renderer.headline);
+    const existing = videos.get(videoId);
+    const conflictKey = `video-channel-conflict:${videoId}`;
+    if (existing?.channelId && channelId && existing.channelId !== channelId) {
+      markUnresolved(issueTarget, conflictKey, trackUnresolved);
+      return false;
     }
-    unresolved.delete(`video-owner:${videoId}`);
+
+    if (isShortCandidate && (!channelId || !channelTitle || !title)) {
+      clearUnresolved(issueTarget, `video-owner:${videoId}`);
+      clearUnresolved(issueTarget, `video-title:${videoId}`);
+      clearPersistentVideoIssue(`video-owner:${videoId}`);
+      clearPersistentVideoIssue(`video-title:${videoId}`);
+      if (channelId && channelTitle) {
+        addChannel({
+          channelId,
+          title: owner,
+          thumbnail: renderer.channelThumbnailSupportedRenderers
+            && renderer.channelThumbnailSupportedRenderers.channelThumbnailWithLinkRenderer
+            && renderer.channelThumbnailSupportedRenderers.channelThumbnailWithLinkRenderer.thumbnail,
+        }, `video-owner:${videoId}`, trackUnresolved, issueTarget);
+      }
+      const channel = channelId ? channels.get(channelId) : undefined;
+      videos.set(videoId, {
+        ...existing,
+        videoId,
+        title: existing?.title && existing.title !== videoId
+          ? existing.title
+          : title || videoId,
+        ...(existing?.channelId || channelId
+          ? { channelId: existing?.channelId || channelId }
+          : {}),
+        ...(existing?.channelTitle || channelTitle
+          ? { channelTitle: existing?.channelTitle || channelTitle }
+          : {}),
+        ...(existing?.channelHandle || channel?.handle
+          ? { channelHandle: existing?.channelHandle || channel?.handle }
+          : {}),
+        ...(existing?.channelAvatarUrl || channel?.avatarUrl
+          ? { channelAvatarUrl: existing?.channelAvatarUrl || channel?.avatarUrl }
+          : {}),
+        ...(existing?.channelUrl || channelId
+          ? { channelUrl: existing?.channelUrl || `https://www.youtube.com/channel/${channelId}` }
+          : {}),
+        watchUrl: `https://www.youtube.com/watch?v=${videoId}`,
+        sourceUrl: `https://www.youtube.com/watch?v=${videoId}`,
+        ...(existing?.thumbnailUrl || thumbnailUrl
+          ? { thumbnailUrl: existing?.thumbnailUrl || thumbnailUrl }
+          : {}),
+        isShort: true,
+        isLive: Boolean(existing?.isLive)
+          || styles.some((value) => value.includes("LIVE")),
+        isUpcoming: Boolean(existing?.isUpcoming)
+          || styles.some((value) => value.includes("UPCOMING")),
+      });
+      return true;
+    }
+
+    if (!channelId || !channelTitle) {
+      markUnresolved(issueTarget, `video-owner:${videoId}`, trackUnresolved);
+      return false;
+    }
+    clearUnresolved(issueTarget, `video-owner:${videoId}`);
+    clearPersistentVideoIssue(`video-owner:${videoId}`);
 
     addChannel({
       channelId,
@@ -215,47 +383,52 @@
       thumbnail: renderer.channelThumbnailSupportedRenderers
         && renderer.channelThumbnailSupportedRenderers.channelThumbnailWithLinkRenderer
         && renderer.channelThumbnailSupportedRenderers.channelThumbnailWithLinkRenderer.thumbnail,
-    }, `video-owner:${videoId}`);
+    }, `video-owner:${videoId}`, trackUnresolved, issueTarget);
 
-    const title = textOf(renderer.title) || textOf(renderer.headline);
     if (!title) {
-      unresolved.add(`video-title:${videoId}`);
-      return;
+      markUnresolved(issueTarget, `video-title:${videoId}`, trackUnresolved);
+      return false;
     }
-    unresolved.delete(`video-title:${videoId}`);
+    clearUnresolved(issueTarget, `video-title:${videoId}`);
+    clearPersistentVideoIssue(`video-title:${videoId}`);
 
-    const path = endpointUrl(renderer)
-      || endpointUrl(renderer.title)
-      || `/watch?v=${videoId}`;
-    const styles = overlayStyles(renderer);
-    const thumbnailUrl = bestThumbnail(renderer.thumbnail);
     const channel = channels.get(channelId);
+    const channelHandle = existing?.channelHandle || channel?.handle;
+    const channelAvatarUrl = existing?.channelAvatarUrl || channel?.avatarUrl;
+    const description = existing?.description
+      || textOf(renderer.descriptionSnippet)
+      || undefined;
+    const publishedText = existing?.publishedText
+      || textOf(renderer.publishedTimeText)
+      || undefined;
+    const durationText = existing?.durationText
+      || textOf(renderer.lengthText)
+      || undefined;
     videos.set(videoId, {
       videoId,
-      title,
+      title: existing?.title && existing.title !== videoId ? existing.title : title,
       channelId,
-      channelTitle,
-      ...(channel && channel.handle ? { channelHandle: channel.handle } : {}),
-      ...(channel && channel.avatarUrl
-        ? { channelAvatarUrl: channel.avatarUrl }
-        : {}),
+      channelTitle: existing?.channelTitle || channelTitle,
+      ...(channelHandle ? { channelHandle } : {}),
+      ...(channelAvatarUrl ? { channelAvatarUrl } : {}),
       channelUrl: `https://www.youtube.com/channel/${channelId}`,
       watchUrl: `https://www.youtube.com/watch?v=${videoId}`,
       sourceUrl: `https://www.youtube.com/watch?v=${videoId}`,
-      ...(thumbnailUrl ? { thumbnailUrl } : {}),
-      ...(textOf(renderer.descriptionSnippet)
-        ? { description: textOf(renderer.descriptionSnippet) }
+      ...(existing?.thumbnailUrl || thumbnailUrl
+        ? { thumbnailUrl: existing?.thumbnailUrl || thumbnailUrl }
         : {}),
-      ...(textOf(renderer.publishedTimeText)
-        ? { publishedText: textOf(renderer.publishedTimeText) }
-        : {}),
-      ...(textOf(renderer.lengthText)
-        ? { durationText: textOf(renderer.lengthText) }
-        : {}),
-      isShort: path.startsWith("/shorts/") || source.includes("reel"),
-      isLive: styles.some((value) => value.includes("LIVE")),
-      isUpcoming: styles.some((value) => value.includes("UPCOMING")),
+      ...(description ? { description } : {}),
+      ...(publishedText ? { publishedText } : {}),
+      ...(durationText ? { durationText } : {}),
+      isShort: Boolean(existing?.isShort)
+        || path.startsWith("/shorts/")
+        || source.includes("reel"),
+      isLive: Boolean(existing?.isLive)
+        || styles.some((value) => value.includes("LIVE")),
+      isUpcoming: Boolean(existing?.isUpcoming)
+        || styles.some((value) => value.includes("UPCOMING")),
     });
+    return true;
   }
 
   const CHANNEL_RENDERER_KEYS = new Set([
@@ -271,77 +444,337 @@
     "reelItemRenderer",
   ]);
 
-  function collectTree(root, source) {
-    if (!root || typeof root !== "object") return;
+  function emptyCollectionStats() {
+    return {
+      channelCandidates: 0,
+      videoCandidates: 0,
+      channelResolved: 0,
+      videoResolved: 0,
+    };
+  }
+
+  function objectRevisionId(value) {
+    const existing = objectRevisionIds.get(value);
+    if (existing) return existing;
+    const id = nextObjectRevisionId;
+    nextObjectRevisionId += 1;
+    objectRevisionIds.set(value, id);
+    return id;
+  }
+
+  function mixRevision(hash, text) {
+    let mixed = hash;
+    for (let index = 0; index < text.length; index += 1) {
+      mixed ^= text.charCodeAt(index);
+      mixed = Math.imul(mixed, 16777619);
+    }
+    return mixed >>> 0;
+  }
+
+  function objectRevision(entries) {
+    let hash = 2166136261;
+    for (const [key, child] of entries) {
+      hash = mixRevision(hash, key);
+      if (child && typeof child === "object") {
+        hash = mixRevision(hash, `object:${objectRevisionId(child)}`);
+      } else {
+        hash = mixRevision(hash, `${typeof child}:${String(child)}`);
+      }
+    }
+    return `${entries.length}:${hash >>> 0}`;
+  }
+
+  function chargeObjectRevision(value, entries) {
+    const revision = objectRevision(entries);
+    if (chargedObjectRevisions.get(value) === revision) return true;
+    if (visitedObjectCount >= MAX_OBJECT_VISITS) {
+      workBudgetExceeded = true;
+      return false;
+    }
+    chargedObjectRevisions.set(value, revision);
+    visitedObjectCount += 1;
+    return true;
+  }
+
+  function emptyRendererFingerprint(renderer) {
+    if (!renderer || typeof renderer !== "object") return null;
+    const title = textOf(renderer.title);
+    const body = textOf(renderer.bodyText)
+      || textOf(renderer.descriptionText)
+      || textOf(renderer.subtitle);
+    const icon = renderer.icon && typeof renderer.icon.iconType === "string"
+      ? renderer.icon.iconType
+      : "";
+    if (!title && !body && !icon) return null;
+    return JSON.stringify({ title, body, icon });
+  }
+
+  function rememberSelectedEmptyRenderer(renderer) {
+    if (!renderer || typeof renderer !== "object") return;
+    selectedEmptyRendererObjects.add(renderer);
+    const fingerprint = emptyRendererFingerprint(renderer);
+    if (fingerprint) selectedEmptyRendererFingerprints.add(fingerprint);
+  }
+
+  function collectTree(
+    root,
+    source,
+    seen,
+    stats = emptyCollectionStats(),
+    trackUnresolved = true,
+    issueTarget = unresolved,
+    selectedInitialContent = false,
+  ) {
+    if (!root || typeof root !== "object") return stats;
     const pending = [{ value: root, path: source }];
-    const seen = new WeakSet();
-    let visited = 0;
-    while (pending.length > 0 && visited < 200000) {
+    while (pending.length > 0) {
       const entry = pending.pop();
       const value = entry.value;
       if (!value || typeof value !== "object" || seen.has(value)) continue;
       seen.add(value);
-      visited += 1;
-      for (const [key, child] of Object.entries(value)) {
+      const entries = Object.entries(value);
+      if (!chargeObjectRevision(value, entries)) return stats;
+      if (visitedObjectCount % DEADLINE_CHECK_INTERVAL === 0 && checkDeadline()) return stats;
+      for (const [key, child] of entries) {
         if (!child || typeof child !== "object") continue;
-        const childPath = `${entry.path}.${key}`;
-        if (CHANNEL_RENDERER_KEYS.has(key)) addChannel(child, childPath);
-        if (stage === "subscriptions" && VIDEO_RENDERER_KEYS.has(key)) {
-          addVideo(child, childPath);
+        const childSource = `${entry.path}.${key}`;
+        if (selectedInitialContent && key === "backgroundPromoRenderer") {
+          rememberSelectedEmptyRenderer(child);
         }
-        pending.push({ value: child, path: childPath });
+        if (CHANNEL_RENDERER_KEYS.has(key)) {
+          stats.channelCandidates += 1;
+          if (addChannel(child, childSource, trackUnresolved, issueTarget)) {
+            stats.channelResolved += 1;
+          }
+        }
+        if (stage === "subscriptions" && VIDEO_RENDERER_KEYS.has(key)) {
+          stats.videoCandidates += 1;
+          if (addVideo(child, childSource, trackUnresolved, issueTarget)) {
+            stats.videoResolved += 1;
+          }
+        }
+        pending.push({ value: child, path: childSource });
       }
     }
+    return stats;
   }
 
-  function treeHasKey(root, expectedKey) {
+  function renderedElementId(element) {
+    const existing = renderedElementIds.get(element);
+    if (existing) return existing;
+    const id = nextRenderedElementId;
+    nextRenderedElementId += 1;
+    renderedElementIds.set(element, id);
+    return id;
+  }
+
+  function elementDataRoots(element) {
+    const roots = [];
+    const data = element && element.data;
+    if (data && typeof data === "object") roots.push({ root: data, suffix: "data" });
+    const privateData = element && element.__data && element.__data.data;
+    if (privateData && typeof privateData === "object" && privateData !== data) {
+      roots.push({ root: privateData, suffix: "private-data" });
+    }
+    return roots;
+  }
+
+  function selectedFeedContentRoots(initialData) {
+    if (!initialData || typeof initialData !== "object") return [];
+    const contents = initialData.contents;
+    if (!contents || typeof contents !== "object") return [];
+    const browseRenderers = [
+      contents.twoColumnBrowseResultsRenderer,
+      contents.singleColumnBrowseResultsRenderer,
+    ];
+    const roots = [];
+    for (const browseRenderer of browseRenderers) {
+      if (!browseRenderer || !Array.isArray(browseRenderer.tabs)) continue;
+      for (const tab of browseRenderer.tabs) {
+        const tabRenderer = tab && tab.tabRenderer;
+        if (!tabRenderer || tabRenderer.selected !== true) continue;
+        if (tabRenderer.content && typeof tabRenderer.content === "object") {
+          roots.push(tabRenderer.content);
+        }
+      }
+    }
+    return roots;
+  }
+
+  function matchesSelectedEmptyRenderer(renderer) {
+    if (!renderer || typeof renderer !== "object") return false;
+    if (selectedEmptyRendererObjects.has(renderer)) return true;
+    const fingerprint = emptyRendererFingerprint(renderer);
+    return Boolean(fingerprint && selectedEmptyRendererFingerprints.has(fingerprint));
+  }
+
+  function dataRootMatchesSelectedEmptyRenderer(root) {
     if (!root || typeof root !== "object") return false;
     const pending = [root];
     const seen = new WeakSet();
-    let visited = 0;
-    while (pending.length > 0 && visited < 200000) {
+    let inspected = 0;
+    while (pending.length > 0 && inspected < 64) {
       const value = pending.pop();
       if (!value || typeof value !== "object" || seen.has(value)) continue;
       seen.add(value);
-      visited += 1;
+      inspected += 1;
+      if (matchesSelectedEmptyRenderer(value)) return true;
       for (const [key, child] of Object.entries(value)) {
-        if (key === expectedKey) return true;
-        if (child && typeof child === "object") pending.push(child);
+        if (!child || typeof child !== "object") continue;
+        if (key === "backgroundPromoRenderer" && matchesSelectedEmptyRenderer(child)) {
+          return true;
+        }
+        pending.push(child);
       }
     }
     return false;
   }
 
-  function hasPositiveChannelPageEvidence() {
-    if (stage !== "channels" || !window.ytInitialData) return false;
+  function hasExplicitEmptyEvidence() {
     const browse = document.querySelector("ytd-browse");
     if (!browse) return false;
-    if (channels.size > 0) return true;
-    return Boolean(browse.querySelector("ytd-background-promo-renderer"))
-      && treeHasKey(window.ytInitialData, "backgroundPromoRenderer");
+    if (supportedRenderedCandidates.size > 0 || unsupportedRenderedCandidates.size > 0) {
+      return false;
+    }
+    const promo = browse.querySelector("ytd-background-promo-renderer");
+    if (!promo) return false;
+    return elementDataRoots(promo).some(({ root }) => (
+      dataRootMatchesSelectedEmptyRenderer(root)
+    ));
   }
 
-  function collectBackingData() {
-    collectTree(window.ytInitialData, "ytInitialData");
-    const selectors = stage === "channels"
-      ? ["ytd-channel-renderer", "ytd-grid-channel-renderer", "ytd-item-section-renderer"]
-      : [
-          "ytd-rich-item-renderer",
-          "ytd-video-renderer",
-          "ytd-grid-video-renderer",
-          "ytd-reel-item-renderer",
-          "ytd-item-section-renderer",
-        ];
-    for (const selector of selectors) {
-      document.querySelectorAll(selector).forEach((element, index) => {
-        collectTree(element.data, `${selector}:${index}:data`);
-        collectTree(element.__data && element.__data.data, `${selector}:${index}:private-data`);
-      });
+  function hasPositiveStagePageEvidence() {
+    if (!window.ytInitialData || !document.querySelector("ytd-browse")) return false;
+    if (document.querySelector("ytd-error-screen-renderer, ytd-unavailable-message-renderer")) {
+      return false;
+    }
+    if (hasExplicitEmptyEvidence()) return true;
+    if (supportedRenderedCandidates.size === 0) return false;
+    return stage === "channels" ? channels.size > 0 : videos.size > 0;
+  }
+
+  function collectLiveElement(element, selector, rootKind) {
+    const elementId = renderedElementId(element);
+    const source = `${selector}:element-${elementId}`;
+    const unsupportedKey = `${stage}:${source}`;
+    const roots = elementDataRoots(element);
+    if (roots.length === 0) {
+      unsupportedRenderedCandidates.add(unsupportedKey);
+      return;
+    }
+    const stats = emptyCollectionStats();
+    const elementIssues = new Set();
+    const elementSeen = new WeakSet();
+    for (const { root, suffix } of roots) {
+      const rootSource = `${source}.${suffix}`;
+      const rootKeys = new Set(Object.keys(root));
+      if (rootKind === "channel"
+        && !Array.from(CHANNEL_RENDERER_KEYS).some((key) => rootKeys.has(key))) {
+        stats.channelCandidates += 1;
+        if (addChannel(root, `${rootSource}.root`, true, elementIssues)) {
+          stats.channelResolved += 1;
+        }
+      } else if (rootKind === "video"
+        && !Array.from(VIDEO_RENDERER_KEYS).some((key) => rootKeys.has(key))) {
+        stats.videoCandidates += 1;
+        if (addVideo(root, `${rootSource}.root`, true, elementIssues)) {
+          stats.videoResolved += 1;
+        }
+      } else if (stage === "subscriptions" && videoIdFrom(root)) {
+        stats.videoCandidates += 1;
+        if (addVideo(root, `${rootSource}.root`, true, elementIssues)) {
+          stats.videoResolved += 1;
+        }
+      }
+      collectTree(root, rootSource, elementSeen, stats, true, elementIssues);
+      if (workMustStop()) break;
+    }
+
+    const relevantCandidates = stage === "channels"
+      ? stats.channelCandidates
+      : stats.videoCandidates;
+    const relevantResolved = stage === "channels"
+      ? stats.channelResolved
+      : stats.videoResolved;
+    for (const issue of elementIssues) {
+      if (issue.startsWith("video-channel-conflict:")) {
+        recordPersistentVideoIssue(issue);
+      }
+    }
+    if (relevantCandidates === 0) {
+      unsupportedRenderedCandidates.add(unsupportedKey);
+    } else {
+      supportedRenderedCandidates.add(unsupportedKey);
+      if (relevantResolved === 0) {
+        for (const issue of elementIssues) {
+          if (issue.startsWith("video-owner:") || issue.startsWith("video-title:")) {
+            recordPersistentVideoIssue(issue);
+          } else {
+            unresolved.add(issue);
+          }
+        }
+      }
     }
   }
 
+  function collectBackingData() {
+    if (!initialDataScanned && window.ytInitialData
+      && typeof window.ytInitialData === "object") {
+      initialDataScanned = true;
+      const selectedRoots = selectedFeedContentRoots(window.ytInitialData);
+      selectedRoots.forEach((root, index) => {
+        collectTree(
+          root,
+          `ytInitialData.selected-${index}`,
+          seenInitialObjects,
+          emptyCollectionStats(),
+          false,
+          unresolved,
+          true,
+        );
+      });
+    }
+    if (workMustStop()) return;
+
+    supportedRenderedCandidates.clear();
+    unsupportedRenderedCandidates.clear();
+    unresolved.clear();
+    for (const issue of persistentVideoIssues) unresolved.add(issue);
+
+    const selectors = stage === "channels"
+      ? [
+          ["ytd-channel-renderer", "channel"],
+          ["ytd-grid-channel-renderer", "channel"],
+        ]
+      : [
+          ["ytd-rich-item-renderer", "container"],
+          ["ytd-video-renderer", "video"],
+          ["ytd-grid-video-renderer", "video"],
+          ["ytd-reel-item-renderer", "video"],
+        ];
+    for (const [selector, rootKind] of selectors) {
+      for (const element of document.querySelectorAll(selector)) {
+        collectLiveElement(element, selector, rootKind);
+        if (workMustStop()) return;
+      }
+    }
+  }
+
+  function hasPendingContinuation() {
+    const browse = document.querySelector("ytd-browse");
+    if (!browse) return false;
+    for (const element of browse.querySelectorAll("ytd-continuation-item-renderer")) {
+      if (element.hasAttribute("hidden") || element.getAttribute("aria-hidden") === "true") {
+        continue;
+      }
+      return true;
+    }
+    return false;
+  }
+
   function pageReady() {
-    if (!location.hostname.endsWith("youtube.com")) return false;
+    if (!isYouTubeHost(location.hostname)) return false;
+    if (normalizePath(location.pathname) !== normalizePath(expectedPath)) return false;
     if (!document.querySelector("ytd-app")) return false;
     if (window.ytcfg && typeof window.ytcfg.get === "function"
       && window.ytcfg.get("LOGGED_IN") === false) {
@@ -356,9 +789,9 @@
   }
 
   async function waitUntilReady() {
-    const startedAt = Date.now();
-    while (!pageReady() && Date.now() - startedAt < READY_TIMEOUT_MS) {
-      await sleep(250);
+    const readyStartedAt = Date.now();
+    while (!pageReady() && Date.now() - readyStartedAt < READY_TIMEOUT_MS && !checkDeadline()) {
+      await sleep(Math.min(250, remainingMs()));
     }
     return pageReady();
   }
@@ -390,21 +823,93 @@
     return window.__TAURI__.event.emit("yt-capture-data", payload);
   }
 
-  async function run() {
-    if (stage === "unsupported") {
-      throw new Error("YouTube opened an unexpected page for capture.");
+  function changedRecords(records, emittedFingerprints) {
+    const changed = [];
+    for (const [id, record] of records) {
+      const fingerprint = JSON.stringify(record);
+      if (emittedFingerprints.get(id) === fingerprint) continue;
+      emittedFingerprints.set(id, fingerprint);
+      changed.push(record);
     }
+    return changed;
+  }
+
+  function progressFields() {
+    return {
+      captureId,
+      stage,
+      channelTotal: channels.size,
+      videoTotal: stage === "subscriptions" ? videos.size : 0,
+      candidateCount: candidateSources.size,
+      unresolvedCount: unresolved.size,
+      supportedCandidateCount: supportedRenderedCandidates.size,
+      unsupportedCandidateCount: unsupportedRenderedCandidates.size,
+      scrollPasses,
+      stablePasses,
+      elapsedMs: elapsedMs(),
+      visitedObjectCount,
+      visitBudget: MAX_OBJECT_VISITS,
+      workBudgetExceeded,
+      deadlineExceeded,
+      pendingContinuation: hasPendingContinuation(),
+      pageEvidence: hasPositiveStagePageEvidence(),
+      explicitEmpty: hasExplicitEmptyEvidence(),
+      stopReason,
+      extractedAt: Date.now(),
+    };
+  }
+
+  function dataPayload() {
+    return {
+      channels: changedRecords(channels, emittedChannels),
+      videos: stage === "subscriptions"
+        ? changedRecords(videos, emittedVideos)
+        : [],
+    };
+  }
+
+  function fullDataPayload() {
+    return {
+      channels: Array.from(channels.values()),
+      videos: stage === "subscriptions" ? Array.from(videos.values()) : [],
+    };
+  }
+
+  async function emitProgress() {
+    await emit({
+      ...dataPayload(),
+      ...progressFields(),
+      rosterComplete: false,
+      complete: false,
+      done: false,
+    });
+  }
+
+  async function run() {
+    assertExpectedPage();
     const ready = await waitUntilReady();
-    if (!ready) throw new Error("YouTube did not finish rendering the requested page.");
+    if (!ready) {
+      if (deadlineExceeded) throw new Error("YouTube capture reached its script deadline.");
+      throw new Error("YouTube did not finish rendering the requested page.");
+    }
+    assertExpectedPage();
     if (!isLoggedIn()) throw new Error("The YouTube website session is not signed in.");
 
     let previousHeight = 0;
     let previousResultCount = 0;
-    let stablePasses = 0;
-    let scrollPasses = 0;
-    let stopReason = "max-passes";
+    let previousCandidateCount = 0;
+    let previousUnresolvedCount = 0;
+    let previousUnsupportedCount = 0;
+    let previousPendingContinuation = false;
+    stopReason = "max-passes";
 
     for (let pass = 0; pass < MAX_SCROLL_PASSES; pass += 1) {
+      assertExpectedPage();
+      if (checkDeadline()) {
+        stopReason = "deadline";
+        break;
+      }
+
       collectBackingData();
       scrollPasses = pass + 1;
       const height = Math.max(
@@ -412,61 +917,103 @@
         document.body ? document.body.scrollHeight : 0,
       );
       const resultCount = channels.size + videos.size;
+      const candidateCount = candidateSources.size;
+      const unresolvedCount = unresolved.size;
+      const unsupportedCount = unsupportedRenderedCandidates.size;
+      const pendingContinuation = hasPendingContinuation();
       const atEnd = reachedDocumentEnd();
 
-      if (height === previousHeight && resultCount === previousResultCount) {
+      if (height === previousHeight
+        && resultCount === previousResultCount
+        && candidateCount === previousCandidateCount
+        && unresolvedCount === previousUnresolvedCount
+        && unsupportedCount === previousUnsupportedCount
+        && pendingContinuation === previousPendingContinuation) {
         stablePasses += 1;
       } else {
         stablePasses = 0;
       }
 
-      if (atEnd && stablePasses >= REQUIRED_STABLE_PASSES) {
+      if (workBudgetExceeded) {
+        stopReason = "work-budget";
+        break;
+      }
+      if (deadlineExceeded) {
+        stopReason = "deadline";
+        break;
+      }
+      if (atEnd && !pendingContinuation && stablePasses >= REQUIRED_STABLE_PASSES) {
         stopReason = "end-stable";
+        break;
+      }
+      if (pass === MAX_SCROLL_PASSES - 1) {
+        stopReason = "max-passes";
         break;
       }
 
       previousHeight = height;
       previousResultCount = resultCount;
+      previousCandidateCount = candidateCount;
+      previousUnresolvedCount = unresolvedCount;
+      previousUnsupportedCount = unsupportedCount;
+      previousPendingContinuation = pendingContinuation;
+      stopReason = "scrolling";
+      await emitProgress();
+      if (checkDeadline()) {
+        stopReason = "deadline";
+        break;
+      }
       window.scrollTo({ top: height, behavior: "auto" });
-      await sleep(SCROLL_SETTLE_MS);
+      await sleep(Math.min(SCROLL_SETTLE_MS, remainingMs()));
     }
 
-    collectBackingData();
-    const pageEvidence = hasPositiveChannelPageEvidence();
-    const rosterComplete = stage === "channels"
-      && stopReason === "end-stable"
+    const pageEvidence = hasPositiveStagePageEvidence();
+    const pendingContinuation = hasPendingContinuation();
+    if (stopReason === "end-stable" && unresolved.size > 0) {
+      stopReason = "unresolved";
+    } else if (stopReason === "end-stable" && unsupportedRenderedCandidates.size > 0) {
+      stopReason = "unsupported-candidates";
+    } else if (stopReason === "end-stable" && pendingContinuation) {
+      stopReason = "pending-continuation";
+    } else if (stopReason === "end-stable" && !pageEvidence) {
+      stopReason = "page-evidence-missing";
+    }
+    const captureComplete = stopReason === "end-stable"
       && unresolved.size === 0
+      && unsupportedRenderedCandidates.size === 0
+      && !workBudgetExceeded
+      && !deadlineExceeded
+      && !pendingContinuation
+      && pageEvidence;
+    const rosterComplete = stage === "channels"
+      && captureComplete
       && pageEvidence;
     await emit({
-      channels: Array.from(channels.values()),
-      videos: stage === "subscriptions" ? Array.from(videos.values()) : [],
+      ...fullDataPayload(),
+      ...progressFields(),
       rosterComplete,
-      complete: stage === "subscriptions",
-      unresolvedCount: unresolved.size,
-      candidateCount: candidateSources.size,
-      scrollPasses,
-      stopReason,
-      pageEvidence,
-      extractedAt: Date.now(),
-      done: stage === "subscriptions",
-      stage,
+      complete: stage === "subscriptions" && captureComplete,
+      done: true,
     });
   }
 
-  run().catch((error) => {
-    void emit({
-      channels: [],
-      videos: [],
-      rosterComplete: false,
-      complete: stage === "subscriptions",
-      unresolvedCount: unresolved.size,
-      candidateCount: candidateSources.size,
-      scrollPasses: 0,
-      stopReason: "error",
-      extractedAt: Date.now(),
-      done: stage === "subscriptions",
-      stage,
-      error: error instanceof Error ? error.message : String(error),
-    });
+  void run().catch(async (error) => {
+    stopReason = deadlineExceeded
+      ? "deadline"
+      : workBudgetExceeded
+        ? "work-budget"
+        : "error";
+    try {
+      await emit({
+        ...fullDataPayload(),
+        ...progressFields(),
+        rosterComplete: false,
+        complete: false,
+        done: true,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    } catch {
+      // The event bridge itself is unavailable, so there is nowhere else to report.
+    }
   });
 })();

--- a/packages/desktop/src-tauri/src/youtube.rs
+++ b/packages/desktop/src-tauri/src/youtube.rs
@@ -1,8 +1,9 @@
-use serde::Deserialize;
-use std::sync::{Arc, Mutex};
+use serde::{Deserialize, Serialize};
+use std::sync::{Arc, LazyLock, Mutex};
+use tauri::webview::PageLoadEvent;
 use tauri::{Emitter, Listener, Manager};
-use tokio::sync::oneshot;
-use tokio::time::{timeout, Duration};
+use tokio::sync::{oneshot, Notify};
+use tokio::time::{sleep_until, timeout, timeout_at, Duration, Instant};
 use url::Url;
 
 const YOUTUBE_SESSION_WINDOW_LABEL: &str = "youtube-session";
@@ -10,6 +11,10 @@ const YOUTUBE_SUBSCRIPTIONS_URL: &str = "https://www.youtube.com/feed/subscripti
 const YOUTUBE_CHANNELS_URL: &str = "https://www.youtube.com/feed/channels";
 const YOUTUBE_CAPTURE_SCRIPT: &str = include_str!("youtube-extract.js");
 const YOUTUBE_PLAYLIST_ACTION_SCRIPT: &str = include_str!("youtube-playlist-action.js");
+const YOUTUBE_CAPTURE_QUEUE_TIMEOUT: Duration = Duration::from_secs(70);
+const YOUTUBE_CAPTURE_OVERALL_TIMEOUT: Duration = Duration::from_secs(190);
+const YOUTUBE_CAPTURE_STAGE_TIMEOUT: Duration = Duration::from_secs(70);
+const YOUTUBE_CAPTURE_NAVIGATION_TIMEOUT: Duration = Duration::from_secs(20);
 const YOUTUBE_SESSION_DATA_STORE_IDENTIFIER: [u8; 16] = [
     0x66, 0x72, 0x65, 0x65, 0x64, 0x79, 0x74, 0x01, 0x9a, 0x7d, 0x37, 0x01, 0x02, 0x79, 0x74, 0x01,
 ];
@@ -115,6 +120,130 @@ const YOUTUBE_AUTH_PROBE_SCRIPT: &str = r#"
 "#;
 
 static YOUTUBE_SESSION_OPERATION: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+static YOUTUBE_PAGE_LOAD_STATE: LazyLock<Mutex<YouTubePageLoadState>> =
+    LazyLock::new(|| Mutex::new(YouTubePageLoadState::default()));
+static YOUTUBE_PAGE_LOAD_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
+static YOUTUBE_ACTIVE_CAPTURE: LazyLock<Mutex<Option<YouTubeActiveCapture>>> =
+    LazyLock::new(|| Mutex::new(None));
+static YOUTUBE_CAPTURE_CANCEL_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
+static YOUTUBE_CAPTURE_FINISHED_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct YouTubeNavigationAttemptToken {
+    webview_generation: u64,
+    attempt_id: u64,
+    expected_path: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct YouTubeNavigationAttemptState {
+    token: YouTubeNavigationAttemptToken,
+    started: bool,
+    finished: bool,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+struct YouTubePageLoadState {
+    next_webview_generation: u64,
+    current_webview_generation: Option<u64>,
+    next_attempt_id: u64,
+    active_attempt: Option<YouTubeNavigationAttemptState>,
+}
+
+impl YouTubePageLoadState {
+    fn reserve_webview_generation(&mut self) -> u64 {
+        self.next_webview_generation = self.next_webview_generation.saturating_add(1);
+        let generation = self.next_webview_generation;
+        self.current_webview_generation = Some(generation);
+        self.active_attempt = None;
+        generation
+    }
+
+    fn current_webview_generation(&self) -> Result<u64, String> {
+        self.current_webview_generation
+            .ok_or_else(|| "YouTube session window generation is unavailable.".to_string())
+    }
+
+    fn begin_navigation_attempt(
+        &mut self,
+        expected_path: &str,
+    ) -> Result<YouTubeNavigationAttemptToken, String> {
+        let webview_generation = self.current_webview_generation()?;
+        self.next_attempt_id = self.next_attempt_id.saturating_add(1);
+        let token = YouTubeNavigationAttemptToken {
+            webview_generation,
+            attempt_id: self.next_attempt_id,
+            expected_path: expected_path.to_string(),
+        };
+        self.active_attempt = Some(YouTubeNavigationAttemptState {
+            token: token.clone(),
+            started: false,
+            finished: false,
+        });
+        Ok(token)
+    }
+
+    fn record_page_load(
+        &mut self,
+        webview_generation: u64,
+        url: &Url,
+        event: PageLoadEvent,
+    ) -> bool {
+        if self.current_webview_generation != Some(webview_generation) {
+            return false;
+        }
+        let Some(attempt) = self.active_attempt.as_mut() else {
+            return false;
+        };
+        if attempt.token.webview_generation != webview_generation
+            || !youtube_url_matches_path(url, &attempt.token.expected_path)
+        {
+            return false;
+        }
+        match event {
+            PageLoadEvent::Started => {
+                attempt.started = true;
+                attempt.finished = false;
+                true
+            }
+            PageLoadEvent::Finished if attempt.started => {
+                attempt.finished = true;
+                true
+            }
+            PageLoadEvent::Finished => false,
+        }
+    }
+
+    fn navigation_attempt_finished(&self, token: &YouTubeNavigationAttemptToken) -> bool {
+        self.active_attempt
+            .as_ref()
+            .is_some_and(|attempt| attempt.token == *token && attempt.started && attempt.finished)
+    }
+
+    fn clear_navigation_attempt(&mut self, token: &YouTubeNavigationAttemptToken) {
+        if self
+            .active_attempt
+            .as_ref()
+            .is_some_and(|attempt| attempt.token == *token)
+        {
+            self.active_attempt = None;
+        }
+    }
+
+    fn retire_webview_generation(&mut self, webview_generation: u64) {
+        if self.current_webview_generation == Some(webview_generation) {
+            self.current_webview_generation = None;
+            self.active_attempt = None;
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct YouTubeActiveCapture {
+    capture_id: String,
+    cancelled: bool,
+    session_claimed: bool,
+}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum YouTubeWindowPresentation {
@@ -188,12 +317,37 @@ struct YouTubeAuthPayload {
     logged_in: bool,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 struct YouTubeCapturePayload {
+    capture_id: Option<String>,
     stage: Option<String>,
     done: Option<bool>,
     error: Option<String>,
+    roster_complete: Option<bool>,
+    complete: Option<bool>,
+    channel_total: Option<u64>,
+    video_total: Option<u64>,
+    candidate_count: Option<u64>,
+    unresolved_count: Option<u64>,
+    scroll_passes: Option<u64>,
+    stop_reason: Option<String>,
+    page_evidence: Option<bool>,
+    explicit_empty: Option<bool>,
+    unsupported_candidate_count: Option<u64>,
+    pending_continuation: Option<bool>,
+    work_budget_exceeded: Option<bool>,
+    deadline_exceeded: Option<bool>,
+    #[serde(default)]
+    channels: Vec<serde_json::Value>,
+    #[serde(default)]
+    videos: Vec<serde_json::Value>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct YouTubeCaptureResult {
+    stages: Vec<YouTubeCapturePayload>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -203,14 +357,357 @@ struct YouTubePlaylistPayload {
     result: Option<String>,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum YouTubeCaptureEventDisposition {
+    Ignore,
+    Progress,
+    Complete,
+    Error,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum YouTubeCaptureCancellation {
+    NoMatch,
+    Queued,
+    SessionActive,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum YouTubeDataRetention {
+    Preserve,
+    ClearForDisconnect,
+}
+
+impl YouTubeDataRetention {
+    fn clears_browsing_data(self) -> bool {
+        self == Self::ClearForDisconnect
+    }
+
+    fn scrubs_before_destroy(self) -> bool {
+        self == Self::Preserve
+    }
+}
+
+struct YouTubeCaptureGuard {
+    capture_id: String,
+}
+
+struct YouTubeListenerGuard {
+    app: tauri::AppHandle,
+    listener_id: Option<tauri::EventId>,
+}
+
+impl YouTubeListenerGuard {
+    fn new(app: &tauri::AppHandle, listener_id: tauri::EventId) -> Self {
+        Self {
+            app: app.clone(),
+            listener_id: Some(listener_id),
+        }
+    }
+}
+
+impl Drop for YouTubeListenerGuard {
+    fn drop(&mut self) {
+        if let Some(listener_id) = self.listener_id.take() {
+            self.app.unlisten(listener_id);
+        }
+    }
+}
+
+impl YouTubeCaptureGuard {
+    fn begin(capture_id: &str) -> Result<Self, String> {
+        if capture_id.trim().is_empty() {
+            return Err("YouTube capture ID is required.".to_string());
+        }
+
+        let mut active = YOUTUBE_ACTIVE_CAPTURE.lock().unwrap();
+        if active.is_some() {
+            return Err("Another YouTube capture is already active.".to_string());
+        }
+        *active = Some(YouTubeActiveCapture {
+            capture_id: capture_id.to_string(),
+            cancelled: false,
+            session_claimed: false,
+        });
+        Ok(Self {
+            capture_id: capture_id.to_string(),
+        })
+    }
+}
+
+impl Drop for YouTubeCaptureGuard {
+    fn drop(&mut self) {
+        let mut active = YOUTUBE_ACTIVE_CAPTURE.lock().unwrap();
+        if active
+            .as_ref()
+            .is_some_and(|capture| capture.capture_id == self.capture_id)
+        {
+            *active = None;
+        }
+        drop(active);
+        YOUTUBE_CAPTURE_FINISHED_NOTIFY.notify_waiters();
+    }
+}
+
+fn youtube_capture_path(stage: &str) -> Result<&'static str, String> {
+    match stage {
+        "channels" => Ok("/feed/channels"),
+        "subscriptions" => Ok("/feed/subscriptions"),
+        _ => Err("Unsupported YouTube capture stage.".to_string()),
+    }
+}
+
+fn reserve_youtube_webview_generation() -> u64 {
+    YOUTUBE_PAGE_LOAD_STATE
+        .lock()
+        .unwrap()
+        .reserve_webview_generation()
+}
+
+fn current_youtube_webview_generation() -> Result<u64, String> {
+    YOUTUBE_PAGE_LOAD_STATE
+        .lock()
+        .unwrap()
+        .current_webview_generation()
+}
+
+fn retire_youtube_webview_generation(webview_generation: u64) {
+    YOUTUBE_PAGE_LOAD_STATE
+        .lock()
+        .unwrap()
+        .retire_webview_generation(webview_generation);
+}
+
+fn begin_youtube_navigation_attempt(
+    expected_path: &str,
+) -> Result<YouTubeNavigationAttemptToken, String> {
+    YOUTUBE_PAGE_LOAD_STATE
+        .lock()
+        .unwrap()
+        .begin_navigation_attempt(expected_path)
+}
+
+fn record_youtube_page_load(webview_generation: u64, url: &Url, event: PageLoadEvent) {
+    let mut state = YOUTUBE_PAGE_LOAD_STATE.lock().unwrap();
+    let attempt_changed = state.record_page_load(webview_generation, url, event);
+    drop(state);
+    if attempt_changed {
+        YOUTUBE_PAGE_LOAD_NOTIFY.notify_one();
+    }
+}
+
+fn youtube_navigation_attempt_finished(token: &YouTubeNavigationAttemptToken) -> bool {
+    YOUTUBE_PAGE_LOAD_STATE
+        .lock()
+        .unwrap()
+        .navigation_attempt_finished(token)
+}
+
+fn clear_youtube_navigation_attempt(token: &YouTubeNavigationAttemptToken) {
+    YOUTUBE_PAGE_LOAD_STATE
+        .lock()
+        .unwrap()
+        .clear_navigation_attempt(token);
+}
+
+fn youtube_url_matches_path(url: &Url, expected_path: &str) -> bool {
+    matches!(
+        url.host_str()
+            .map(|host| host.to_ascii_lowercase())
+            .as_deref(),
+        Some("youtube.com" | "www.youtube.com" | "m.youtube.com")
+    ) && url.path().trim_end_matches('/') == expected_path.trim_end_matches('/')
+}
+
+fn sanitized_youtube_path(url: &Url) -> String {
+    match url.host_str() {
+        Some(host) => format!("{}{}", host.to_ascii_lowercase(), url.path()),
+        None => url.path().to_string(),
+    }
+}
+
+fn current_youtube_window_path(window: &tauri::WebviewWindow) -> String {
+    window
+        .url()
+        .map(|url| sanitized_youtube_path(&url))
+        .unwrap_or_else(|_| "unavailable".to_string())
+}
+
+fn classify_capture_event(
+    payload: &YouTubeCapturePayload,
+    expected_capture_id: &str,
+    expected_stage: &str,
+) -> YouTubeCaptureEventDisposition {
+    if payload.capture_id.as_deref() != Some(expected_capture_id)
+        || payload.stage.as_deref() != Some(expected_stage)
+    {
+        return YouTubeCaptureEventDisposition::Ignore;
+    }
+    if payload
+        .error
+        .as_ref()
+        .is_some_and(|error| !error.is_empty())
+    {
+        return YouTubeCaptureEventDisposition::Error;
+    }
+    if payload.done == Some(true) {
+        return YouTubeCaptureEventDisposition::Complete;
+    }
+    YouTubeCaptureEventDisposition::Progress
+}
+
+fn capture_cancellation_matches(
+    active_capture_id: Option<&str>,
+    requested_capture_id: &str,
+) -> bool {
+    active_capture_id == Some(requested_capture_id)
+}
+
+fn cancel_youtube_capture(capture_id: &str) -> YouTubeCaptureCancellation {
+    let mut active = YOUTUBE_ACTIVE_CAPTURE.lock().unwrap();
+    let active_id = active.as_ref().map(|capture| capture.capture_id.as_str());
+    if !capture_cancellation_matches(active_id, capture_id) {
+        return YouTubeCaptureCancellation::NoMatch;
+    }
+    let cancellation = active
+        .as_mut()
+        .map(|capture| {
+            capture.cancelled = true;
+            if capture.session_claimed {
+                YouTubeCaptureCancellation::SessionActive
+            } else {
+                YouTubeCaptureCancellation::Queued
+            }
+        })
+        .unwrap_or(YouTubeCaptureCancellation::NoMatch);
+    drop(active);
+    YOUTUBE_CAPTURE_CANCEL_NOTIFY.notify_one();
+    cancellation
+}
+
+fn youtube_capture_is_cancelled(capture_id: &str) -> bool {
+    YOUTUBE_ACTIVE_CAPTURE
+        .lock()
+        .unwrap()
+        .as_ref()
+        .is_some_and(|capture| capture.capture_id == capture_id && capture.cancelled)
+}
+
+fn ensure_youtube_capture_active(capture_id: &str) -> Result<(), String> {
+    if youtube_capture_is_cancelled(capture_id) {
+        Err("YouTube capture was cancelled.".to_string())
+    } else {
+        Ok(())
+    }
+}
+
+async fn wait_for_youtube_capture_cancellation(capture_id: &str) {
+    loop {
+        let notification = YOUTUBE_CAPTURE_CANCEL_NOTIFY.notified();
+        if youtube_capture_is_cancelled(capture_id) {
+            return;
+        }
+        notification.await;
+    }
+}
+
+async fn wait_for_youtube_capture_finished(capture_id: &str) {
+    loop {
+        let notification = YOUTUBE_CAPTURE_FINISHED_NOTIFY.notified();
+        let still_active = YOUTUBE_ACTIVE_CAPTURE
+            .lock()
+            .unwrap()
+            .as_ref()
+            .is_some_and(|capture| capture.capture_id == capture_id);
+        if !still_active {
+            return;
+        }
+        notification.await;
+    }
+}
+
+fn begin_youtube_capture_session<T>(
+    capture_id: &str,
+    operation: impl FnOnce() -> Result<T, String>,
+) -> Result<T, String> {
+    let mut active = YOUTUBE_ACTIVE_CAPTURE.lock().unwrap();
+    let capture = active
+        .as_mut()
+        .filter(|capture| capture.capture_id == capture_id)
+        .ok_or_else(|| "YouTube capture is no longer active.".to_string())?;
+    if capture.cancelled {
+        return Err("YouTube capture was cancelled.".to_string());
+    }
+    capture.session_claimed = true;
+    operation()
+}
+
+fn capture_stop_reason(payload: &YouTubeCapturePayload) -> &str {
+    payload.stop_reason.as_deref().unwrap_or("not reported")
+}
+
+fn validate_capture_terminal(stage: &str, payload: &YouTubeCapturePayload) -> Result<(), String> {
+    if let Some(error) = payload.error.as_ref().filter(|error| !error.is_empty()) {
+        return Err(error.clone());
+    }
+    if payload.done != Some(true) {
+        return Err(format!(
+            "YouTube {stage} capture ended without a final marker."
+        ));
+    }
+    if payload.stop_reason.as_deref() != Some("end-stable")
+        || payload.unresolved_count != Some(0)
+        || payload.page_evidence != Some(true)
+        || payload.unsupported_candidate_count != Some(0)
+        || payload.pending_continuation != Some(false)
+        || payload.work_budget_exceeded != Some(false)
+        || payload.deadline_exceeded != Some(false)
+    {
+        return Err(format!(
+            "YouTube {stage} capture ended without complete page evidence. Stage: {stage}. Stop reason: {}.",
+            capture_stop_reason(payload)
+        ));
+    }
+    let channel_total_matches = payload.channel_total == u64::try_from(payload.channels.len()).ok();
+    let video_total_matches = payload.video_total == u64::try_from(payload.videos.len()).ok();
+    if !channel_total_matches || !video_total_matches {
+        return Err(format!(
+            "YouTube {stage} capture record totals did not match its terminal receipt."
+        ));
+    }
+    let stage_records_empty = match stage {
+        "channels" => payload.channels.is_empty(),
+        "subscriptions" => payload.videos.is_empty(),
+        _ => false,
+    };
+    if stage_records_empty && payload.explicit_empty != Some(true) {
+        return Err(format!(
+            "YouTube {stage} capture did not prove an explicit empty state."
+        ));
+    }
+    match stage {
+        "channels" if payload.roster_complete != Some(true) => Err(format!(
+            "YouTube channels capture ended before the full roster was resolved. Stage: channels. Stop reason: {}.",
+            capture_stop_reason(payload)
+        )),
+        "subscriptions" if payload.complete != Some(true) => Err(format!(
+            "YouTube subscriptions capture ended before extraction completed. Stage: subscriptions. Stop reason: {}.",
+            capture_stop_reason(payload)
+        )),
+        "channels" | "subscriptions" => Ok(()),
+        _ => Err("Unsupported YouTube capture stage.".to_string()),
+    }
+}
+
 fn youtube_url(path: &str) -> Result<Url, String> {
     path.parse::<Url>().map_err(|error| error.to_string())
 }
 
-fn build_youtube_session_window(
+fn build_youtube_session_window_for_generation(
     app: &tauri::AppHandle,
     url: &str,
     interactive: bool,
+    webview_generation: u64,
 ) -> Result<tauri::WebviewWindow, String> {
     let presentation = YouTubeWindowPresentation::from_interactive(interactive);
     let window = tauri::WebviewWindowBuilder::new(
@@ -227,8 +724,12 @@ fn build_youtube_session_window(
     .focused(interactive)
     .focusable(interactive)
     .always_on_bottom(!interactive)
+    .on_page_load(move |_window, payload| {
+        record_youtube_page_load(webview_generation, payload.url(), payload.event());
+    })
     .build()
     .map_err(|error| error.to_string())?;
+    super::observe_window_created(YOUTUBE_SESSION_WINDOW_LABEL);
 
     let close_app = app.clone();
     window.on_window_event(move |event| {
@@ -240,6 +741,21 @@ fn build_youtube_session_window(
         }
     });
     Ok(window)
+}
+
+fn build_youtube_session_window(
+    app: &tauri::AppHandle,
+    url: &str,
+    interactive: bool,
+) -> Result<tauri::WebviewWindow, String> {
+    let webview_generation = reserve_youtube_webview_generation();
+    match build_youtube_session_window_for_generation(app, url, interactive, webview_generation) {
+        Ok(window) => Ok(window),
+        Err(error) => {
+            retire_youtube_webview_generation(webview_generation);
+            Err(error)
+        }
+    }
 }
 
 fn ensure_youtube_session_window(
@@ -265,6 +781,68 @@ fn ensure_youtube_session_window(
     Ok(window)
 }
 
+fn navigate_youtube_capture_session_window(
+    window: &tauri::WebviewWindow,
+    url: &str,
+    stage: &str,
+) -> Result<YouTubeNavigationAttemptToken, String> {
+    let navigation_url = youtube_url(url)?;
+    let attempt = begin_youtube_navigation_attempt(youtube_capture_path(stage)?)?;
+    if let Err(error) = window
+        .navigate(navigation_url)
+        .map_err(|error| error.to_string())
+    {
+        clear_youtube_navigation_attempt(&attempt);
+        return Err(error);
+    }
+    Ok(attempt)
+}
+
+fn ensure_youtube_capture_session_window(
+    app: &tauri::AppHandle,
+    url: &str,
+    stage: &str,
+) -> Result<(tauri::WebviewWindow, YouTubeNavigationAttemptToken), String> {
+    let presentation = YouTubeWindowPresentation::Hidden;
+    let (window, attempt) = match app.get_webview_window(YOUTUBE_SESSION_WINDOW_LABEL) {
+        Some(window) => {
+            apply_youtube_window_presentation(&window, presentation)?;
+            let attempt = navigate_youtube_capture_session_window(&window, url, stage)?;
+            (window, attempt)
+        }
+        None => {
+            let webview_generation = reserve_youtube_webview_generation();
+            let attempt = match begin_youtube_navigation_attempt(youtube_capture_path(stage)?) {
+                Ok(attempt) => attempt,
+                Err(error) => {
+                    retire_youtube_webview_generation(webview_generation);
+                    return Err(error);
+                }
+            };
+            let window = match build_youtube_session_window_for_generation(
+                app,
+                url,
+                false,
+                webview_generation,
+            ) {
+                Ok(window) => window,
+                Err(error) => {
+                    clear_youtube_navigation_attempt(&attempt);
+                    retire_youtube_webview_generation(webview_generation);
+                    return Err(error);
+                }
+            };
+            (window, attempt)
+        }
+    };
+
+    if let Err(error) = apply_youtube_window_presentation(&window, presentation) {
+        clear_youtube_navigation_attempt(&attempt);
+        return Err(error);
+    }
+    Ok((window, attempt))
+}
+
 fn hide_youtube_session_window(
     app: &tauri::AppHandle,
     restore_main_focus: bool,
@@ -278,6 +856,50 @@ fn hide_youtube_session_window(
         }
     }
     Ok(())
+}
+
+fn destroy_youtube_session_window(
+    app: &tauri::AppHandle,
+    restore_main_focus: bool,
+    retention: YouTubeDataRetention,
+    reason: super::WindowDestroyedReason,
+    detail: &str,
+) -> Result<(), String> {
+    let webview_generation = current_youtube_webview_generation().ok();
+    if let Some(window) = app.get_webview_window(YOUTUBE_SESSION_WINDOW_LABEL) {
+        if retention.scrubs_before_destroy() {
+            let _ = apply_youtube_window_presentation(&window, YouTubeWindowPresentation::Hidden);
+            super::scrub_webview_before_destroy(&window);
+        }
+        if retention.clears_browsing_data() {
+            let _ = window.clear_all_browsing_data();
+        }
+        window.destroy().map_err(|error| error.to_string())?;
+        super::record_window_destroyed(app, YOUTUBE_SESSION_WINDOW_LABEL, reason, detail);
+    }
+    if let Some(webview_generation) = webview_generation {
+        retire_youtube_webview_generation(webview_generation);
+    }
+    if restore_main_focus {
+        if let Some(main) = app.get_webview_window("main") {
+            let _ = main.set_focus();
+        }
+    }
+    Ok(())
+}
+
+fn operation_with_cleanup<T>(
+    operation: Result<T, String>,
+    cleanup: Result<(), String>,
+) -> Result<T, String> {
+    match (operation, cleanup) {
+        (Ok(value), Ok(())) => Ok(value),
+        (Ok(_), Err(cleanup_error)) => Err(cleanup_error),
+        (Err(operation_error), Ok(())) => Err(operation_error),
+        (Err(operation_error), Err(cleanup_error)) => Err(format!(
+            "{operation_error} YouTube session cleanup also failed: {cleanup_error}"
+        )),
+    }
 }
 
 fn canonical_watch_url(video_url: &str) -> Result<(String, String), String> {
@@ -328,11 +950,31 @@ fn is_youtube_video_id(value: &str) -> bool {
             .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'-')
 }
 
-fn capture_script(stage: &str) -> Result<String, String> {
-    match stage {
-        "channels" | "subscriptions" => Ok(YOUTUBE_CAPTURE_SCRIPT.to_string()),
-        _ => Err("Unsupported YouTube capture stage.".to_string()),
+fn replace_quoted_script_placeholder(
+    script: String,
+    placeholder: &str,
+    value: &str,
+) -> Result<String, String> {
+    let quoted_placeholder = format!("\"{placeholder}\"");
+    if !script.contains(&quoted_placeholder) {
+        return Err(format!(
+            "YouTube capture script is missing the {placeholder} placeholder."
+        ));
     }
+    let encoded = serde_json::to_string(value).map_err(|error| error.to_string())?;
+    Ok(script.replacen(&quoted_placeholder, &encoded, 1))
+}
+
+fn capture_script(stage: &str, capture_id: &str) -> Result<String, String> {
+    let expected_path = youtube_capture_path(stage)?;
+    let script = replace_quoted_script_placeholder(
+        YOUTUBE_CAPTURE_SCRIPT.to_string(),
+        "__YOUTUBE_CAPTURE_ID__",
+        capture_id,
+    )?;
+    let script =
+        replace_quoted_script_placeholder(script, "__EXPECTED_YOUTUBE_CAPTURE_STAGE__", stage)?;
+    replace_quoted_script_placeholder(script, "__EXPECTED_YOUTUBE_CAPTURE_PATH__", expected_path)
 }
 
 fn playlist_script(video_id: &str) -> Result<String, String> {
@@ -348,37 +990,97 @@ async fn wait_for_capture_stage(
     app: &tauri::AppHandle,
     window: &tauri::WebviewWindow,
     stage: &str,
+    capture_id: &str,
 ) -> Result<YouTubeCapturePayload, String> {
-    let (sender, receiver) = oneshot::channel::<Result<YouTubeCapturePayload, String>>();
+    let (sender, receiver) = oneshot::channel::<YouTubeCapturePayload>();
     let sender = Arc::new(Mutex::new(Some(sender)));
+    let latest_progress = Arc::new(Mutex::new(None::<YouTubeCapturePayload>));
     let listener_sender = sender.clone();
+    let listener_progress = latest_progress.clone();
     let expected_stage = stage.to_string();
+    let expected_capture_id = capture_id.to_string();
     let listener_id = app.listen("yt-capture-data", move |event| {
-        let payload = serde_json::from_str::<YouTubeCapturePayload>(event.payload())
-            .map_err(|error| error.to_string());
-        let matches = payload.as_ref().is_ok_and(|payload| {
-            payload.stage.as_deref() == Some(expected_stage.as_str()) || payload.error.is_some()
-        });
-        if matches {
-            if let Some(sender) = listener_sender.lock().unwrap().take() {
-                let _ = sender.send(payload);
+        let Ok(payload) = serde_json::from_str::<YouTubeCapturePayload>(event.payload()) else {
+            return;
+        };
+        match classify_capture_event(&payload, &expected_capture_id, &expected_stage) {
+            YouTubeCaptureEventDisposition::Ignore => {}
+            YouTubeCaptureEventDisposition::Progress => {
+                *listener_progress.lock().unwrap() = Some(payload);
+            }
+            YouTubeCaptureEventDisposition::Complete | YouTubeCaptureEventDisposition::Error => {
+                if let Some(sender) = listener_sender.lock().unwrap().take() {
+                    let _ = sender.send(payload);
+                }
             }
         }
     });
+    let listener_guard = YouTubeListenerGuard::new(app, listener_id);
 
-    if let Err(error) = window.eval(&capture_script(stage)?) {
-        app.unlisten(listener_id);
-        return Err(error.to_string());
+    window
+        .eval(&capture_script(stage, capture_id)?)
+        .map_err(|error| error.to_string())?;
+
+    let deadline = Instant::now() + YOUTUBE_CAPTURE_STAGE_TIMEOUT;
+    let result = tokio::select! {
+        received = receiver => received
+            .map_err(|_| format!("YouTube {stage} capture listener closed.")),
+        _ = sleep_until(deadline) => {
+            let progress = latest_progress.lock().unwrap().clone().unwrap_or_default();
+            Err(format!(
+                "YouTube {stage} capture timed out. Stage: {stage}. Path: {}. Stop reason: {}.",
+                current_youtube_window_path(window),
+                capture_stop_reason(&progress),
+            ))
+        },
+        _ = wait_for_youtube_capture_cancellation(capture_id) => {
+            Err("YouTube capture was cancelled.".to_string())
+        },
+    };
+    drop(listener_guard);
+    result
+}
+
+async fn wait_for_capture_navigation(
+    window: &tauri::WebviewWindow,
+    stage: &str,
+    capture_id: &str,
+    attempt: YouTubeNavigationAttemptToken,
+) -> Result<(), String> {
+    let expected_path = youtube_capture_path(stage)?;
+    if attempt.expected_path != expected_path {
+        clear_youtube_navigation_attempt(&attempt);
+        return Err("YouTube capture navigation attempt did not match its stage.".to_string());
     }
-
-    let result = timeout(Duration::from_secs(50), receiver)
-        .await
-        .map_err(|_| format!("YouTube {stage} capture timed out."))
-        .and_then(|received| {
-            received.map_err(|_| format!("YouTube {stage} capture listener closed."))
-        });
-    app.unlisten(listener_id);
-    result?
+    let deadline = Instant::now() + YOUTUBE_CAPTURE_NAVIGATION_TIMEOUT;
+    let result = loop {
+        let load_notification = YOUTUBE_PAGE_LOAD_NOTIFY.notified();
+        if youtube_navigation_attempt_finished(&attempt)
+            && window
+                .url()
+                .ok()
+                .is_some_and(|url| youtube_url_matches_path(&url, expected_path))
+        {
+            break Ok(());
+        }
+        if let Err(error) = ensure_youtube_capture_active(capture_id) {
+            break Err(error);
+        }
+        tokio::select! {
+            _ = load_notification => {}
+            _ = sleep_until(deadline) => {
+                break Err(format!(
+                    "YouTube {stage} navigation timed out. Stage: {stage}. Path: {}. Stop reason: page load did not finish.",
+                    current_youtube_window_path(window),
+                ));
+            }
+            _ = wait_for_youtube_capture_cancellation(capture_id) => {
+                break Err("YouTube capture was cancelled.".to_string());
+            }
+        }
+    };
+    clear_youtube_navigation_attempt(&attempt);
+    result
 }
 
 async fn wait_for_playlist_result(
@@ -455,8 +1157,28 @@ pub async fn yt_show_login(app: tauri::AppHandle) -> Result<(), String> {
     Ok(())
 }
 
-#[tauri::command]
-pub async fn yt_hide_login(app: tauri::AppHandle) -> Result<(), String> {
+#[tauri::command(rename_all = "camelCase")]
+pub async fn yt_hide_login(
+    app: tauri::AppHandle,
+    capture_id: Option<String>,
+) -> Result<(), String> {
+    if let Some(capture_id) = capture_id {
+        let cancellation = cancel_youtube_capture(&capture_id);
+        let cleanup = match cancellation {
+            YouTubeCaptureCancellation::NoMatch | YouTubeCaptureCancellation::Queued => Ok(()),
+            YouTubeCaptureCancellation::SessionActive => destroy_youtube_session_window(
+                &app,
+                false,
+                YouTubeDataRetention::Preserve,
+                super::WindowDestroyedReason::JobComplete,
+                "youtube_capture_cancelled",
+            ),
+        };
+        if cancellation != YouTubeCaptureCancellation::NoMatch {
+            wait_for_youtube_capture_finished(&capture_id).await;
+        }
+        return cleanup;
+    }
     hide_youtube_session_window(&app, true)
 }
 
@@ -474,38 +1196,93 @@ pub async fn yt_check_auth(app: tauri::AppHandle) -> Result<bool, String> {
 }
 
 #[tauri::command(rename_all = "camelCase")]
-pub async fn yt_capture(app: tauri::AppHandle, include_roster: Option<bool>) -> Result<(), String> {
-    let _operation = YOUTUBE_SESSION_OPERATION.lock().await;
-    let result = async {
+pub async fn yt_capture(
+    app: tauri::AppHandle,
+    include_roster: Option<bool>,
+    capture_id: String,
+) -> Result<YouTubeCaptureResult, String> {
+    let _capture_guard = YouTubeCaptureGuard::begin(&capture_id)?;
+    let queue_deadline = Instant::now() + YOUTUBE_CAPTURE_QUEUE_TIMEOUT;
+    let _operation = tokio::select! {
+        operation = YOUTUBE_SESSION_OPERATION.lock() => operation,
+        _ = sleep_until(queue_deadline) => {
+            return Err("YouTube capture waited too long for the session window.".to_string());
+        },
+        _ = wait_for_youtube_capture_cancellation(&capture_id) => {
+            return Err("YouTube capture was cancelled.".to_string());
+        },
+    };
+    let overall_deadline = Instant::now() + YOUTUBE_CAPTURE_OVERALL_TIMEOUT;
+    let capture_result = timeout_at(overall_deadline, async {
         let include_roster = capture_includes_roster(include_roster);
+        let mut stages = Vec::with_capacity(if include_roster { 2 } else { 1 });
         let first_url = if include_roster {
             YOUTUBE_CHANNELS_URL
         } else {
             YOUTUBE_SUBSCRIPTIONS_URL
         };
-        let window = ensure_youtube_session_window(&app, first_url, false)?;
-        tokio::time::sleep(Duration::from_secs(3)).await;
+        let first_stage = if include_roster {
+            "channels"
+        } else {
+            "subscriptions"
+        };
+        let (window, navigation_attempt) = begin_youtube_capture_session(&capture_id, || {
+            ensure_youtube_capture_session_window(&app, first_url, first_stage)
+        })?;
+        wait_for_capture_navigation(
+            &window,
+            first_stage,
+            &capture_id,
+            navigation_attempt,
+        )
+        .await?;
 
         if include_roster {
-            let channels = wait_for_capture_stage(&app, &window, "channels").await?;
-            if channels.error.is_some() {
-                return Ok(());
-            }
-            window
-                .navigate(youtube_url(YOUTUBE_SUBSCRIPTIONS_URL)?)
-                .map_err(|error| error.to_string())?;
-            tokio::time::sleep(Duration::from_secs(3)).await;
+            let channels = wait_for_capture_stage(&app, &window, "channels", &capture_id).await?;
+            validate_capture_terminal("channels", &channels)?;
+            stages.push(channels);
+            ensure_youtube_capture_active(&capture_id)?;
+
+            let navigation_attempt = navigate_youtube_capture_session_window(
+                &window,
+                YOUTUBE_SUBSCRIPTIONS_URL,
+                "subscriptions",
+            )?;
+            wait_for_capture_navigation(
+                &window,
+                "subscriptions",
+                &capture_id,
+                navigation_attempt,
+            )
+            .await?;
         }
 
-        let subscriptions = wait_for_capture_stage(&app, &window, "subscriptions").await?;
-        if subscriptions.done != Some(true) && subscriptions.error.is_none() {
-            return Err("YouTube subscriptions capture ended without a final marker.".to_string());
-        }
-        Ok(())
-    }
-    .await;
-    let _ = hide_youtube_session_window(&app, false);
-    result
+        let subscriptions =
+            wait_for_capture_stage(&app, &window, "subscriptions", &capture_id).await?;
+        validate_capture_terminal("subscriptions", &subscriptions)?;
+        stages.push(subscriptions);
+        ensure_youtube_capture_active(&capture_id)?;
+        Ok(YouTubeCaptureResult { stages })
+    })
+    .await
+    .map_err(|_| {
+        let path = app
+            .get_webview_window(YOUTUBE_SESSION_WINDOW_LABEL)
+            .map(|window| current_youtube_window_path(&window))
+            .unwrap_or_else(|| "unavailable".to_string());
+        format!(
+            "YouTube capture reached its overall deadline. Stage: overall. Path: {path}. Stop reason: overall deadline reached."
+        )
+    })
+    .and_then(|result| result);
+    let cleanup = destroy_youtube_session_window(
+        &app,
+        false,
+        YouTubeDataRetention::Preserve,
+        super::WindowDestroyedReason::JobComplete,
+        "youtube_capture_complete",
+    );
+    operation_with_cleanup(capture_result, cleanup)
 }
 
 #[tauri::command(rename_all = "camelCase")]
@@ -532,11 +1309,14 @@ pub async fn yt_add_to_offline_playlist(
 #[tauri::command]
 pub async fn yt_disconnect(app: tauri::AppHandle) -> Result<(), String> {
     let _operation = YOUTUBE_SESSION_OPERATION.lock().await;
-    if let Some(window) = app.get_webview_window(YOUTUBE_SESSION_WINDOW_LABEL) {
-        let _ = window.clear_all_browsing_data();
-        window.destroy().map_err(|error| error.to_string())?;
-        tokio::time::sleep(Duration::from_millis(250)).await;
-    }
+    destroy_youtube_session_window(
+        &app,
+        false,
+        YouTubeDataRetention::ClearForDisconnect,
+        super::WindowDestroyedReason::User,
+        "youtube_disconnect",
+    )?;
+    tokio::time::sleep(Duration::from_millis(250)).await;
 
     #[cfg(target_vendor = "apple")]
     {
@@ -675,24 +1455,294 @@ mod tests {
 
     #[test]
     fn capture_script_declares_the_requested_stage() {
-        let script = capture_script("channels").unwrap();
+        let script = capture_script("channels", "capture-123").unwrap();
         assert!(script.contains("/feed/channels"));
         assert!(script.contains("/feed/subscriptions"));
+        assert!(script.contains("capture-123"));
+        assert!(!script.contains("__YOUTUBE_CAPTURE_ID__"));
+        assert!(!script.contains("__EXPECTED_YOUTUBE_CAPTURE_STAGE__"));
+        assert!(!script.contains("__EXPECTED_YOUTUBE_CAPTURE_PATH__"));
         assert!(script.contains("unresolved.size === 0"));
-        assert!(script.contains("hasPositiveChannelPageEvidence"));
+        assert!(script.contains("hasPositiveStagePageEvidence"));
         assert!(script.contains("yt-capture-data"));
         for field in [
+            "captureId",
             "channels",
             "videos",
+            "channelTotal",
+            "videoTotal",
+            "candidateCount",
             "rosterComplete",
             "complete",
             "unresolvedCount",
+            "pageEvidence",
+            "explicitEmpty",
+            "unsupportedCandidateCount",
+            "pendingContinuation",
             "scrollPasses",
             "stopReason",
             "done",
         ] {
             assert!(script.contains(field), "capture script is missing {field}");
         }
+    }
+
+    #[test]
+    fn capture_script_json_encodes_injected_values() {
+        let script = capture_script("subscriptions", "capture-\"quoted\"").unwrap();
+        assert!(script.contains(r#""capture-\"quoted\"""#));
+        assert!(!script.contains(r#"const captureId = "capture-"quoted""#));
+    }
+
+    fn capture_payload(capture_id: &str, stage: &str) -> YouTubeCapturePayload {
+        YouTubeCapturePayload {
+            capture_id: Some(capture_id.to_string()),
+            stage: Some(stage.to_string()),
+            ..YouTubeCapturePayload::default()
+        }
+    }
+
+    fn complete_capture_payload(capture_id: &str, stage: &str) -> YouTubeCapturePayload {
+        YouTubeCapturePayload {
+            done: Some(true),
+            stop_reason: Some("end-stable".to_string()),
+            page_evidence: Some(true),
+            explicit_empty: Some(true),
+            unresolved_count: Some(0),
+            unsupported_candidate_count: Some(0),
+            pending_continuation: Some(false),
+            work_budget_exceeded: Some(false),
+            deadline_exceeded: Some(false),
+            channel_total: Some(0),
+            video_total: Some(0),
+            ..capture_payload(capture_id, stage)
+        }
+    }
+
+    #[test]
+    fn capture_events_require_exact_capture_and_stage_matches() {
+        let matching = capture_payload("capture-123", "channels");
+        assert_eq!(
+            classify_capture_event(&matching, "capture-123", "channels"),
+            YouTubeCaptureEventDisposition::Progress
+        );
+
+        let wrong_capture = capture_payload("capture-456", "channels");
+        assert_eq!(
+            classify_capture_event(&wrong_capture, "capture-123", "channels"),
+            YouTubeCaptureEventDisposition::Ignore
+        );
+
+        let wrong_stage = capture_payload("capture-123", "subscriptions");
+        assert_eq!(
+            classify_capture_event(&wrong_stage, "capture-123", "channels"),
+            YouTubeCaptureEventDisposition::Ignore
+        );
+    }
+
+    #[test]
+    fn capture_progress_is_nonterminal_until_done_or_error() {
+        let mut payload = capture_payload("capture-123", "channels");
+        payload.channel_total = Some(120);
+        payload.scroll_passes = Some(4);
+        assert_eq!(
+            classify_capture_event(&payload, "capture-123", "channels"),
+            YouTubeCaptureEventDisposition::Progress
+        );
+
+        payload.done = Some(true);
+        assert_eq!(
+            classify_capture_event(&payload, "capture-123", "channels"),
+            YouTubeCaptureEventDisposition::Complete
+        );
+
+        payload.done = Some(false);
+        payload.error = Some("capture failed".to_string());
+        assert_eq!(
+            classify_capture_event(&payload, "capture-123", "channels"),
+            YouTubeCaptureEventDisposition::Error
+        );
+    }
+
+    #[test]
+    fn terminal_capture_requires_stage_completeness() {
+        let mut channels = complete_capture_payload("capture-123", "channels");
+        channels.stop_reason = Some("max-passes".to_string());
+        let channels_error = validate_capture_terminal("channels", &channels).unwrap_err();
+        assert!(channels_error.contains("Stage: channels"));
+        assert!(channels_error.contains("max-passes"));
+        channels.stop_reason = Some("end-stable".to_string());
+        channels.roster_complete = Some(true);
+        assert!(validate_capture_terminal("channels", &channels).is_ok());
+
+        let mut subscriptions = complete_capture_payload("capture-123", "subscriptions");
+        assert!(validate_capture_terminal("subscriptions", &subscriptions).is_err());
+        subscriptions.complete = Some(true);
+        assert!(validate_capture_terminal("subscriptions", &subscriptions).is_ok());
+
+        subscriptions.video_total = Some(1);
+        assert!(validate_capture_terminal("subscriptions", &subscriptions).is_err());
+    }
+
+    #[test]
+    fn terminal_capture_requires_explicit_safe_evidence_flags() {
+        let mut channels = complete_capture_payload("capture-123", "channels");
+        channels.roster_complete = Some(true);
+
+        channels.work_budget_exceeded = None;
+        assert!(validate_capture_terminal("channels", &channels).is_err());
+
+        channels.work_budget_exceeded = Some(false);
+        channels.deadline_exceeded = None;
+        assert!(validate_capture_terminal("channels", &channels).is_err());
+
+        channels.deadline_exceeded = Some(false);
+        channels.pending_continuation = None;
+        assert!(validate_capture_terminal("channels", &channels).is_err());
+
+        channels.pending_continuation = Some(true);
+        assert!(validate_capture_terminal("channels", &channels).is_err());
+
+        channels.pending_continuation = Some(false);
+        assert!(validate_capture_terminal("channels", &channels).is_ok());
+    }
+
+    #[test]
+    fn capture_timeout_envelope_covers_every_native_phase() {
+        let phase_ceiling = YOUTUBE_CAPTURE_NAVIGATION_TIMEOUT.as_secs() * 2
+            + YOUTUBE_CAPTURE_STAGE_TIMEOUT.as_secs() * 2;
+        assert!(YOUTUBE_CAPTURE_OVERALL_TIMEOUT.as_secs() >= phase_ceiling);
+    }
+
+    #[test]
+    fn cancellation_only_matches_the_active_capture() {
+        assert!(capture_cancellation_matches(
+            Some("capture-123"),
+            "capture-123"
+        ));
+        assert!(!capture_cancellation_matches(
+            Some("capture-456"),
+            "capture-123"
+        ));
+        assert!(!capture_cancellation_matches(None, "capture-123"));
+    }
+
+    #[test]
+    fn cancellation_distinguishes_queued_and_active_capture_sessions() {
+        let queued = YouTubeCaptureGuard::begin("capture-queued").unwrap();
+        assert_eq!(
+            cancel_youtube_capture("capture-queued"),
+            YouTubeCaptureCancellation::Queued
+        );
+        drop(queued);
+
+        let active = YouTubeCaptureGuard::begin("capture-active").unwrap();
+        assert_eq!(
+            begin_youtube_capture_session("capture-active", || Ok(42)).unwrap(),
+            42
+        );
+        assert_eq!(
+            cancel_youtube_capture("capture-active"),
+            YouTubeCaptureCancellation::SessionActive
+        );
+        drop(active);
+    }
+
+    #[test]
+    fn timeout_paths_omit_queries_and_fragments() {
+        let url = Url::parse(
+            "https://www.youtube.com/feed/subscriptions?account=private#sensitive-fragment",
+        )
+        .unwrap();
+        assert_eq!(
+            sanitized_youtube_path(&url),
+            "www.youtube.com/feed/subscriptions"
+        );
+    }
+
+    #[test]
+    fn capture_page_matches_require_youtube_host_and_exact_path() {
+        assert!(youtube_url_matches_path(
+            &Url::parse("https://www.youtube.com/feed/channels?flow=1").unwrap(),
+            "/feed/channels"
+        ));
+        assert!(!youtube_url_matches_path(
+            &Url::parse("https://example.com/feed/channels").unwrap(),
+            "/feed/channels"
+        ));
+        assert!(!youtube_url_matches_path(
+            &Url::parse("https://www.youtube.com/feed/subscriptions").unwrap(),
+            "/feed/channels"
+        ));
+    }
+
+    #[test]
+    fn capture_navigation_requires_matching_started_then_finished_events() {
+        let mut state = YouTubePageLoadState::default();
+        let generation = state.reserve_webview_generation();
+        let attempt = state
+            .begin_navigation_attempt("/feed/subscriptions")
+            .unwrap();
+        let subscriptions = Url::parse("https://www.youtube.com/feed/subscriptions").unwrap();
+        let channels = Url::parse("https://www.youtube.com/feed/channels").unwrap();
+        let blank = Url::parse("about:blank").unwrap();
+
+        assert!(!state.record_page_load(generation, &subscriptions, PageLoadEvent::Finished));
+        assert!(!state.navigation_attempt_finished(&attempt));
+        assert!(!state.record_page_load(generation, &channels, PageLoadEvent::Started));
+        assert!(!state.record_page_load(generation, &blank, PageLoadEvent::Finished));
+        assert!(!state.record_page_load(
+            generation.saturating_add(1),
+            &subscriptions,
+            PageLoadEvent::Started,
+        ));
+        assert!(state.record_page_load(generation, &subscriptions, PageLoadEvent::Started));
+        assert!(!state.record_page_load(
+            generation.saturating_add(1),
+            &subscriptions,
+            PageLoadEvent::Finished,
+        ));
+        assert!(state.record_page_load(generation, &subscriptions, PageLoadEvent::Finished));
+        assert!(state.navigation_attempt_finished(&attempt));
+    }
+
+    #[test]
+    fn same_path_reuse_rejects_a_finished_event_from_the_previous_attempt() {
+        let mut state = YouTubePageLoadState::default();
+        let generation = state.reserve_webview_generation();
+        let subscriptions = Url::parse("https://www.youtube.com/feed/subscriptions").unwrap();
+        let first = state
+            .begin_navigation_attempt("/feed/subscriptions")
+            .unwrap();
+        assert!(state.record_page_load(generation, &subscriptions, PageLoadEvent::Started));
+        assert!(state.record_page_load(generation, &subscriptions, PageLoadEvent::Finished));
+        assert!(state.navigation_attempt_finished(&first));
+
+        let second = state
+            .begin_navigation_attempt("/feed/subscriptions")
+            .unwrap();
+        assert!(!state.record_page_load(generation, &subscriptions, PageLoadEvent::Finished));
+        assert!(!state.navigation_attempt_finished(&second));
+        assert!(state.record_page_load(generation, &subscriptions, PageLoadEvent::Started));
+        assert!(state.record_page_load(generation, &subscriptions, PageLoadEvent::Finished));
+        assert!(state.navigation_attempt_finished(&second));
+    }
+
+    #[test]
+    fn capture_navigation_rejects_events_from_a_retired_webview_generation() {
+        let mut state = YouTubePageLoadState::default();
+        let retired_generation = state.reserve_webview_generation();
+        let retired_attempt = state.begin_navigation_attempt("/feed/channels").unwrap();
+        let current_generation = state.reserve_webview_generation();
+        let current_attempt = state.begin_navigation_attempt("/feed/channels").unwrap();
+        let channels = Url::parse("https://www.youtube.com/feed/channels").unwrap();
+
+        assert!(!state.record_page_load(retired_generation, &channels, PageLoadEvent::Started));
+        assert!(!state.record_page_load(retired_generation, &channels, PageLoadEvent::Finished));
+        assert!(!state.navigation_attempt_finished(&retired_attempt));
+        assert!(state.record_page_load(current_generation, &channels, PageLoadEvent::Started));
+        assert!(state.record_page_load(current_generation, &channels, PageLoadEvent::Finished));
+        assert!(state.navigation_attempt_finished(&current_attempt));
     }
 
     #[test]
@@ -757,5 +1807,20 @@ mod tests {
     fn youtube_session_has_a_dedicated_persistent_store() {
         assert_ne!(YOUTUBE_SESSION_DATA_STORE_IDENTIFIER, [0; 16]);
         assert_eq!(YOUTUBE_SESSION_DATA_STORE_IDENTIFIER.len(), 16);
+        assert!(!YouTubeDataRetention::Preserve.clears_browsing_data());
+        assert!(YouTubeDataRetention::ClearForDisconnect.clears_browsing_data());
+        assert!(YouTubeDataRetention::Preserve.scrubs_before_destroy());
+        assert!(!YouTubeDataRetention::ClearForDisconnect.scrubs_before_destroy());
+    }
+
+    #[test]
+    fn cleanup_failure_is_reported_with_an_operation_failure() {
+        let error = operation_with_cleanup::<()>(
+            Err("capture failed".to_string()),
+            Err("destroy failed".to_string()),
+        )
+        .unwrap_err();
+        assert!(error.contains("capture failed"));
+        assert!(error.contains("destroy failed"));
     }
 }

--- a/packages/desktop/src/lib/youtube-capture.ts
+++ b/packages/desktop/src/lib/youtube-capture.ts
@@ -22,7 +22,7 @@ import {
   type SocialScrapeTrigger,
 } from "./runtime-health-events";
 
-const CAPTURE_TIMEOUT_MS = 120_000;
+const CAPTURE_TIMEOUT_MS = 275_000;
 let captureOperationChain: Promise<void> = Promise.resolve();
 
 function enqueueCaptureOperation<T>(operation: () => Promise<T>): Promise<T> {
@@ -51,6 +51,7 @@ interface YouTubeNativeVideo extends Partial<YouTubeCapturedVideo> {
 }
 
 export interface YouTubeCaptureEventPayload {
+  captureId?: string;
   stage?: string;
   channels?: YouTubeNativeChannel[];
   videos?: YouTubeNativeVideo[];
@@ -59,10 +60,22 @@ export interface YouTubeCaptureEventPayload {
   done?: boolean;
   extractedAt?: number;
   candidateCount?: number;
+  channelTotal?: number;
+  videoTotal?: number;
   unresolvedCount?: number;
   scrollPasses?: number;
   stopReason?: string;
+  pageEvidence?: boolean;
+  explicitEmpty?: boolean;
+  unsupportedCandidateCount?: number;
+  pendingContinuation?: boolean;
+  workBudgetExceeded?: boolean;
+  deadlineExceeded?: boolean;
   error?: string;
+}
+
+interface YouTubeCaptureCommandResult {
+  stages?: YouTubeCaptureEventPayload[];
 }
 
 export interface YouTubeSyncDiag {
@@ -172,73 +185,254 @@ function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+function classifyYouTubeCaptureErrorStage(message: string, fallback: string): string {
+  return /not signed in|session (?:is )?(?:expired|invalid)/i.test(message)
+    ? "auth"
+    : fallback;
+}
+
+interface YouTubeCaptureProgress {
+  receivedAt: number;
+  stage: string | null;
+  channelCount: number;
+  videoCount: number;
+  candidateCount: number;
+  unresolvedCount: number;
+  scrollPasses: number;
+}
+
+interface YouTubeStageTerminal {
+  authoritative: boolean;
+  succeeded: boolean;
+  stopReason: string | null;
+  progress: YouTubeCaptureProgress;
+}
+
+function mergeDefined<T extends object>(current: T | undefined, incoming: T): T {
+  if (!current) return incoming;
+  return Object.fromEntries(
+    Object.entries({ ...current, ...incoming }).filter(([, value]) => value !== undefined),
+  ) as T;
+}
+
+function progressDiagnostic(progress: YouTubeCaptureProgress | null): string {
+  if (!progress) return "No matching progress event was received.";
+  const ageMs = Math.max(0, Date.now() - progress.receivedAt);
+  return [
+    `Last progress stage=${progress.stage ?? "unknown"}`,
+    `channels=${progress.channelCount.toLocaleString()}`,
+    `videos=${progress.videoCount.toLocaleString()}`,
+    `candidates=${progress.candidateCount.toLocaleString()}`,
+    `unresolved=${progress.unresolvedCount.toLocaleString()}`,
+    `scrollPasses=${progress.scrollPasses.toLocaleString()}`,
+    `ageMs=${ageMs.toLocaleString()}.`,
+  ].join(" ");
+}
+
+function appendProgressDiagnostic(
+  message: string,
+  progress: YouTubeCaptureProgress | null,
+): string {
+  if (message.includes("Last progress stage=")
+    || message.includes("No matching progress event was received.")) {
+    return message;
+  }
+  return `${message} ${progressDiagnostic(progress)}`;
+}
+
+async function cancelYouTubeCapture(captureId: string): Promise<void> {
+  try {
+    await invoke("yt_hide_login", { captureId });
+  } catch (error) {
+    addDebugEvent(
+      "error",
+      `[YouTube] emergency capture cleanup failed: ${errorMessage(error)}`,
+    );
+  }
+}
+
 async function fetchYouTubeCaptureOnce(
   includeRoster: boolean = true,
 ): Promise<YouTubeSyncResult> {
   const result = emptyResult();
-  const nativeChannels: YouTubeNativeChannel[] = [];
-  const nativeVideos: YouTubeNativeVideo[] = [];
-  let receivedEvent = false;
+  const captureId = globalThis.crypto.randomUUID();
+  const nativeChannelsById = new Map<string, YouTubeNativeChannel>();
+  const nativeVideosById = new Map<string, YouTubeNativeVideo>();
+  const stageTerminals = new Map<string, YouTubeStageTerminal>();
+  const latestProgressByStage = new Map<string, YouTubeCaptureProgress>();
+  const requiredFinalStages = includeRoster
+    ? ["channels", "subscriptions"]
+    : ["subscriptions"];
+  let receivedMatchingData = false;
+  let latestProgress: YouTubeCaptureProgress | null = null;
+  let needsEmergencyCancellation = false;
   let unlisten: UnlistenFn | null = null;
   let timeout: number | null = null;
 
+  const applyCapturePayload = (
+    payload: YouTubeCaptureEventPayload,
+    authoritative: boolean,
+  ): void => {
+    if (payload.captureId !== captureId) return;
+    receivedMatchingData = true;
+    if (payload.error) {
+      result.diag.errorStage = classifyYouTubeCaptureErrorStage(
+        payload.error,
+        payload.stage ?? "extract",
+      );
+      result.diag.errorMessage = payload.error;
+      return;
+    }
+    for (const channel of payload.channels ?? []) {
+      if (!channel.channelId) continue;
+      nativeChannelsById.set(
+        channel.channelId,
+        mergeDefined(nativeChannelsById.get(channel.channelId), channel),
+      );
+    }
+    for (const video of payload.videos ?? []) {
+      if (!video.videoId) continue;
+      nativeVideosById.set(
+        video.videoId,
+        mergeDefined(nativeVideosById.get(video.videoId), video),
+      );
+    }
+    result.diag.scrollPasses = Math.max(
+      result.diag.scrollPasses,
+      payload.scrollPasses ?? 0,
+    );
+    if (payload.stopReason) result.diag.stopReason = payload.stopReason;
+    if (Number.isFinite(payload.extractedAt)) {
+      result.capturedAt = Math.max(result.capturedAt, payload.extractedAt ?? result.capturedAt);
+    }
+    latestProgress = {
+      receivedAt: Date.now(),
+      stage: payload.stage ?? latestProgress?.stage ?? null,
+      channelCount: nativeChannelsById.size,
+      videoCount: nativeVideosById.size,
+      candidateCount: payload.candidateCount ?? latestProgress?.candidateCount ?? 0,
+      unresolvedCount: payload.unresolvedCount ?? latestProgress?.unresolvedCount ?? 0,
+      scrollPasses: payload.scrollPasses ?? latestProgress?.scrollPasses ?? 0,
+    };
+    if (payload.stage) latestProgressByStage.set(payload.stage, latestProgress);
+    if (payload.done === true && payload.stage) {
+      const existing = stageTerminals.get(payload.stage);
+      if (!existing?.authoritative || authoritative) {
+        const receiptChannelIds = new Set(
+          (payload.channels ?? []).map((channel) => channel.channelId).filter(Boolean),
+        );
+        const receiptVideoIds = new Set(
+          (payload.videos ?? []).map((video) => video.videoId).filter(Boolean),
+        );
+        const recordTotalsMatch = !authoritative || (
+          payload.channelTotal === (payload.channels?.length ?? 0)
+          && payload.videoTotal === (payload.videos?.length ?? 0)
+          && receiptChannelIds.size === (payload.channels?.length ?? 0)
+          && receiptVideoIds.size === (payload.videos?.length ?? 0)
+        );
+        const primaryRecordCount = payload.stage === "channels"
+          ? payload.channels?.length ?? 0
+          : payload.videos?.length ?? 0;
+        const evidenceComplete = payload.stopReason === "end-stable"
+          && payload.unresolvedCount === 0
+          && payload.pageEvidence === true
+          && (primaryRecordCount > 0 || payload.explicitEmpty === true)
+          && payload.unsupportedCandidateCount === 0
+          && payload.pendingContinuation === false
+          && payload.workBudgetExceeded === false
+          && payload.deadlineExceeded === false;
+        const succeeded = authoritative
+          && recordTotalsMatch
+          && evidenceComplete
+          && (payload.stage === "channels"
+            ? payload.rosterComplete === true
+            : payload.stage === "subscriptions" && payload.complete === true);
+        stageTerminals.set(payload.stage, {
+          authoritative,
+          succeeded,
+          stopReason: payload.stopReason ?? null,
+          progress: latestProgress,
+        });
+        if (authoritative && payload.stage === "channels") {
+          result.diag.rosterComplete = succeeded;
+        }
+      }
+    }
+    addDebugEvent(
+      "change",
+      `[YouTube] extraction pass channels=${(payload.channels?.length ?? 0).toLocaleString()} videos=${(payload.videos?.length ?? 0).toLocaleString()} candidates=${(payload.candidateCount ?? 0).toLocaleString()}${payload.done ? " final" : ""}`,
+    );
+  };
+
   try {
     unlisten = await listen<YouTubeCaptureEventPayload>("yt-capture-data", (event) => {
-      receivedEvent = true;
-      const payload = event.payload;
-      if (payload.error) {
-        result.diag.errorStage = /not signed in|session (?:is )?(?:expired|invalid)/i.test(payload.error)
-          ? "auth"
-          : payload.stage ?? "extract";
-        result.diag.errorMessage = payload.error;
-        return;
-      }
-      nativeChannels.push(...(payload.channels ?? []));
-      nativeVideos.push(...(payload.videos ?? []));
-      result.diag.rosterComplete ||=
-        payload.rosterComplete === true ||
-        (payload.rosterComplete === undefined && payload.complete === true);
-      result.diag.unresolvedCount = Math.max(
-        result.diag.unresolvedCount,
-        payload.unresolvedCount ?? 0,
-      );
-      result.diag.scrollPasses = Math.max(
-        result.diag.scrollPasses,
-        payload.scrollPasses ?? 0,
-      );
-      if (payload.stopReason) result.diag.stopReason = payload.stopReason;
-      if (Number.isFinite(payload.extractedAt)) {
-        result.capturedAt = Math.max(result.capturedAt, payload.extractedAt ?? result.capturedAt);
-      }
-      addDebugEvent(
-        "change",
-        `[YouTube] extraction pass channels=${(payload.channels?.length ?? 0).toLocaleString()} videos=${(payload.videos?.length ?? 0).toLocaleString()} candidates=${(payload.candidateCount ?? 0).toLocaleString()}${payload.done ? " final" : ""}`,
-      );
+      applyCapturePayload(event.payload, false);
     });
 
-    await Promise.race([
-      invoke("yt_capture", { includeRoster }),
+    const commandResult = await Promise.race([
+      invoke<YouTubeCaptureCommandResult>("yt_capture", { includeRoster, captureId }),
       new Promise<never>((_resolve, reject) => {
         timeout = window.setTimeout(
-          () => reject(new Error("YouTube capture timed out.")),
+          () => reject(new Error(`YouTube capture timed out. ${progressDiagnostic(latestProgress)}`)),
           CAPTURE_TIMEOUT_MS,
         );
       }),
     ]);
-    await new Promise<void>((resolve) => window.setTimeout(resolve, 250));
+    for (const payload of commandResult?.stages ?? []) {
+      applyCapturePayload(payload, true);
+    }
+    if (!result.diag.errorStage) {
+      if (!receivedMatchingData) {
+        result.diag.errorStage = "extract";
+        result.diag.errorMessage = "YouTube returned no capture data.";
+      } else {
+        const missingFinalStages = requiredFinalStages.filter(
+          (stage) => stageTerminals.get(stage)?.authoritative !== true,
+        );
+        if (missingFinalStages.length > 0) {
+          result.diag.errorStage = "extract";
+          result.diag.errorMessage = `YouTube capture ended without final markers for ${missingFinalStages.join(", ")}. ${progressDiagnostic(latestProgress)}`;
+        } else {
+          const incompleteStages = requiredFinalStages.filter(
+            (stage) => stageTerminals.get(stage)?.succeeded !== true,
+          );
+          if (incompleteStages.length > 0) {
+            const terminalDetails = incompleteStages.map((stage) => {
+              const terminal = stageTerminals.get(stage);
+              return `${stage} stopReason=${terminal?.stopReason ?? "unknown"}`;
+            }).join(", ");
+            const terminalProgress = stageTerminals.get(incompleteStages.at(-1) ?? "")?.progress
+              ?? latestProgress;
+            result.diag.errorStage = "extract";
+            result.diag.errorMessage = `YouTube capture ended incomplete for ${terminalDetails}. ${progressDiagnostic(terminalProgress)}`;
+          }
+        }
+      }
+    }
+    needsEmergencyCancellation = result.diag.errorStage !== null;
   } catch (error) {
-    result.diag.errorStage = result.diag.errorStage ?? "invoke";
-    result.diag.errorMessage = result.diag.errorMessage ?? errorMessage(error);
+    const message = result.diag.errorMessage ?? errorMessage(error);
+    result.diag.errorStage = result.diag.errorStage
+      ?? classifyYouTubeCaptureErrorStage(message, "invoke");
+    result.diag.errorMessage = appendProgressDiagnostic(
+      message,
+      latestProgress,
+    );
+    needsEmergencyCancellation = true;
   } finally {
     if (timeout !== null) window.clearTimeout(timeout);
     safeUnlisten(unlisten, "yt-capture-data");
+    if (needsEmergencyCancellation) await cancelYouTubeCapture(captureId);
   }
 
-  if (!receivedEvent && !result.diag.errorStage) {
-    result.diag.errorStage = "extract";
-    result.diag.errorMessage = "YouTube returned no capture data.";
-  }
+  const rosterProgress = latestProgressByStage.get("channels");
+  const subscriptionsProgress = latestProgressByStage.get("subscriptions");
+  result.diag.unresolvedCount = includeRoster
+    ? rosterProgress?.unresolvedCount ?? 0
+    : subscriptionsProgress?.unresolvedCount ?? 0;
 
+  const nativeChannels = Array.from(nativeChannelsById.values());
+  const nativeVideos = Array.from(nativeVideosById.values());
   const channels = normalizeNativeChannels(nativeChannels);
   const eligibleVideos = nativeVideos.filter((video) => video.isShort !== true);
   const videos = normalizeNativeVideos(eligibleVideos, channels, result.capturedAt);

--- a/packages/desktop/src/lib/youtube-extract-script.test.ts
+++ b/packages/desktop/src/lib/youtube-extract-script.test.ts
@@ -1,0 +1,762 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { JSDOM } from "jsdom";
+import { describe, expect, it } from "vitest";
+
+const extractorTemplate = readFileSync(
+  resolve(process.cwd(), "src-tauri/src/youtube-extract.js"),
+  "utf8",
+);
+
+const CHANNEL_A = "UCaaaaaaaaaaaaaaaaaaaaaa";
+const CHANNEL_B = "UCbbbbbbbbbbbbbbbbbbbbbb";
+const VIDEO_A = "videoaaaaaa";
+const VIDEO_B = "videobbbbbb";
+
+interface CapturePayload {
+  captureId: string;
+  stage: "channels" | "subscriptions";
+  channels: Array<Record<string, unknown>>;
+  videos: Array<Record<string, unknown>>;
+  rosterComplete: boolean;
+  complete: boolean;
+  done: boolean;
+  pageEvidence: boolean;
+  explicitEmpty: boolean;
+  unsupportedCandidateCount: number;
+  supportedCandidateCount: number;
+  unresolvedCount: number;
+  scrollPasses: number;
+  visitedObjectCount: number;
+  stopReason: string;
+  workBudgetExceeded: boolean;
+  deadlineExceeded: boolean;
+  pendingContinuation: boolean;
+}
+
+interface ExtractorContext {
+  dom: JSDOM;
+  setHeight: (height: number) => void;
+}
+
+interface ExtractorOptions {
+  stage?: "channels" | "subscriptions";
+  html?: string;
+  initialData?: Record<string, unknown>;
+  configure?: (dom: JSDOM) => void;
+  onScroll?: (scrollCount: number, context: ExtractorContext) => void;
+}
+
+function injectedExtractor(stage: "channels" | "subscriptions") {
+  const captureId = "capture-fixture";
+  const expectedPath = stage === "channels" ? "/feed/channels" : "/feed/subscriptions";
+  return extractorTemplate
+    .replace('"__YOUTUBE_CAPTURE_ID__"', JSON.stringify(captureId))
+    .replace('"__EXPECTED_YOUTUBE_CAPTURE_STAGE__"', JSON.stringify(stage))
+    .replace('"__EXPECTED_YOUTUBE_CAPTURE_PATH__"', JSON.stringify(expectedPath));
+}
+
+function setElementData(element: Element | null, data: Record<string, unknown>) {
+  if (!element) throw new Error("Fixture element was not found.");
+  Object.defineProperty(element, "data", {
+    configurable: true,
+    writable: true,
+    value: data,
+  });
+}
+
+function setElementPrivateData(element: Element | null, data: Record<string, unknown>) {
+  if (!element) throw new Error("Fixture element was not found.");
+  Object.defineProperty(element, "__data", {
+    configurable: true,
+    writable: true,
+    value: { data },
+  });
+}
+
+function ownerText(channelId = CHANNEL_A, title = "Channel A") {
+  return {
+    runs: [{
+      text: title,
+      navigationEndpoint: {
+        browseEndpoint: {
+          browseId: channelId,
+          canonicalBaseUrl: `/@${title.toLowerCase().replace(/\s+/g, "")}`,
+        },
+      },
+    }],
+  };
+}
+
+function videoRenderer(options: {
+  videoId?: string;
+  channelId?: string;
+  channelTitle?: string;
+  includeOwner?: boolean;
+  includeTitle?: boolean;
+  path?: string;
+  rich?: boolean;
+  live?: boolean;
+} = {}) {
+  const videoId = options.videoId ?? VIDEO_A;
+  const channelId = options.channelId ?? CHANNEL_A;
+  const channelTitle = options.channelTitle ?? "Channel A";
+  const renderer: Record<string, unknown> = {
+    navigationEndpoint: {
+      watchEndpoint: { videoId },
+      commandMetadata: {
+        webCommandMetadata: { url: options.path ?? `/watch?v=${videoId}` },
+      },
+    },
+    ...(options.includeTitle === false ? {} : { title: { simpleText: `Title ${videoId}` } }),
+    ...(options.includeOwner === false ? {} : { ownerText: ownerText(channelId, channelTitle) }),
+    ...(options.rich
+      ? {
+          thumbnail: {
+            thumbnails: [{
+              url: `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`,
+              width: 480,
+              height: 360,
+            }],
+          },
+          descriptionSnippet: { simpleText: "A useful description" },
+          publishedTimeText: { simpleText: "2 hours ago" },
+          lengthText: { simpleText: "12:34" },
+        }
+      : {}),
+    ...(options.live
+      ? {
+          thumbnailOverlays: [{
+            thumbnailOverlayTimeStatusRenderer: { style: "LIVE" },
+          }],
+        }
+      : {}),
+  };
+  if (options.videoId !== "") renderer.videoId = videoId;
+  return renderer;
+}
+
+function selectedFeedInitialData(
+  content: Record<string, unknown>,
+  extra: Record<string, unknown> = {},
+) {
+  return {
+    ...extra,
+    contents: {
+      twoColumnBrowseResultsRenderer: {
+        tabs: [{
+          tabRenderer: {
+            selected: true,
+            content,
+          },
+        }],
+      },
+    },
+  };
+}
+
+async function runExtractor(options: ExtractorOptions = {}) {
+  const stage = options.stage ?? "subscriptions";
+  const path = stage === "channels" ? "/feed/channels" : "/feed/subscriptions";
+  const dom = new JSDOM(
+    options.html ?? "<ytd-app><ytd-browse></ytd-browse></ytd-app>",
+    {
+      url: `https://www.youtube.com${path}`,
+      runScripts: "outside-only",
+    },
+  );
+  let documentHeight = 1_000;
+  let scrollY = 0;
+  let scrollCount = 0;
+  const payloads: CapturePayload[] = [];
+  let resolveFinal: ((payload: CapturePayload) => void) | undefined;
+  const finalPayload = new Promise<CapturePayload>((resolve) => {
+    resolveFinal = resolve;
+  });
+  const context: ExtractorContext = {
+    dom,
+    setHeight(height) {
+      documentHeight = height;
+    },
+  };
+
+  Object.defineProperty(dom.window.document.documentElement, "scrollHeight", {
+    configurable: true,
+    get: () => documentHeight,
+  });
+  Object.defineProperty(dom.window.document.body, "scrollHeight", {
+    configurable: true,
+    get: () => documentHeight,
+  });
+  Object.defineProperty(dom.window, "innerHeight", {
+    configurable: true,
+    value: 1_000,
+  });
+  Object.defineProperty(dom.window, "scrollY", {
+    configurable: true,
+    get: () => scrollY,
+  });
+  Object.defineProperty(dom.window, "scrollTo", {
+    configurable: true,
+    value: ({ top }: { top: number }) => {
+      scrollY = top;
+      scrollCount += 1;
+      options.onScroll?.(scrollCount, context);
+    },
+  });
+  Object.defineProperty(dom.window, "setTimeout", {
+    configurable: true,
+    value: (callback: () => void) => {
+      queueMicrotask(callback);
+      return 1;
+    },
+  });
+  Object.defineProperty(dom.window, "ytcfg", {
+    configurable: true,
+    value: { get: (key: string) => key === "LOGGED_IN" ? true : undefined },
+  });
+  Object.defineProperty(dom.window, "ytInitialData", {
+    configurable: true,
+    value: {
+      responseContext: {
+        mainAppWebResponseContext: { loggedOut: false },
+      },
+      ...options.initialData,
+    },
+  });
+  Object.defineProperty(dom.window, "__TAURI__", {
+    configurable: true,
+    value: {
+      event: {
+        emit: async (_name: string, payload: CapturePayload) => {
+          payloads.push(payload);
+          if (payload.done) resolveFinal?.(payload);
+        },
+      },
+    },
+  });
+
+  options.configure?.(dom);
+  dom.window.eval(injectedExtractor(stage));
+  const final = await Promise.race([
+    finalPayload,
+    delay(2_000).then(() => {
+      throw new Error("YouTube extractor fixture did not emit a final payload.");
+    }),
+  ]);
+  dom.window.close();
+  return { final, payloads };
+}
+
+describe("youtube-extract.js", () => {
+  it("revisits a live data object after its owner hydrates in place", async () => {
+    const renderer = videoRenderer({ includeOwner: false });
+    const result = await runExtractor({
+      html: "<ytd-app><ytd-browse><ytd-rich-item-renderer id='item'></ytd-rich-item-renderer></ytd-browse></ytd-app>",
+      configure(dom) {
+        setElementData(dom.window.document.querySelector("#item"), {
+          content: { videoRenderer: renderer },
+        });
+      },
+      onScroll(scrollCount) {
+        if (scrollCount === 1) renderer.ownerText = ownerText();
+      },
+    });
+
+    expect(result.final.complete).toBe(true);
+    expect(result.final.unresolvedCount).toBe(0);
+    expect(result.final.videos).toEqual([
+      expect.objectContaining({ videoId: VIDEO_A, channelId: CHANNEL_A }),
+    ]);
+  });
+
+  it("uses the same candidate identity when an element replaces its data object", async () => {
+    let item: Element | null = null;
+    const result = await runExtractor({
+      html: "<ytd-app><ytd-browse><ytd-rich-item-renderer id='item'></ytd-rich-item-renderer></ytd-browse></ytd-app>",
+      configure(dom) {
+        item = dom.window.document.querySelector("#item");
+        setElementData(item, {
+          content: {
+            videoRenderer: videoRenderer({ videoId: "", includeOwner: false }),
+          },
+        });
+      },
+      onScroll(scrollCount) {
+        if (scrollCount === 1) {
+          setElementData(item, { content: { videoRenderer: videoRenderer() } });
+        }
+      },
+    });
+
+    expect(result.final.complete).toBe(true);
+    expect(result.final.unresolvedCount).toBe(0);
+    expect(result.final.videos).toHaveLength(1);
+  });
+
+  it("discovers a renderer appended to an existing live root and keeps the final payload full", async () => {
+    const root: Record<string, unknown> = {
+      content: { videoRenderer: videoRenderer() },
+    };
+    const result = await runExtractor({
+      html: "<ytd-app><ytd-browse><ytd-rich-item-renderer id='item'></ytd-rich-item-renderer></ytd-browse></ytd-app>",
+      configure(dom) {
+        setElementData(dom.window.document.querySelector("#item"), root);
+      },
+      onScroll(scrollCount) {
+        if (scrollCount === 1) {
+          root.continuation = {
+            videoRenderer: videoRenderer({ videoId: VIDEO_B }),
+          };
+        }
+      },
+    });
+
+    const progress = result.payloads.filter((payload) => !payload.done);
+    expect(progress.some((payload) => payload.videos.some(
+      (video) => video.videoId === VIDEO_A,
+    ))).toBe(true);
+    expect(progress.some((payload) => payload.videos.some(
+      (video) => video.videoId === VIDEO_B,
+    ))).toBe(true);
+    expect(progress.every((payload) => payload.videos.length <= 1)).toBe(true);
+    expect(result.final.videos.map((video) => video.videoId).sort()).toEqual([
+      VIDEO_A,
+      VIDEO_B,
+    ]);
+    expect(result.final.complete).toBe(true);
+  });
+
+  it("lets a valid private Polymer root resolve an incomplete public root", async () => {
+    const result = await runExtractor({
+      html: "<ytd-app><ytd-browse><ytd-rich-item-renderer id='item'></ytd-rich-item-renderer></ytd-browse></ytd-app>",
+      configure(dom) {
+        const item = dom.window.document.querySelector("#item");
+        setElementData(item, {
+          content: {
+            videoRenderer: videoRenderer({ includeOwner: false, includeTitle: false }),
+          },
+        });
+        setElementPrivateData(item, {
+          content: { videoRenderer: videoRenderer() },
+        });
+      },
+    });
+
+    expect(result.final.complete).toBe(true);
+    expect(result.final.videos).toEqual([
+      expect.objectContaining({ videoId: VIDEO_A }),
+    ]);
+  });
+
+  it("accepts a valid public data root when a stale private copy is incomplete", async () => {
+    const result = await runExtractor({
+      html: "<ytd-app><ytd-browse><ytd-rich-item-renderer id='item'></ytd-rich-item-renderer></ytd-browse></ytd-app>",
+      configure(dom) {
+        const item = dom.window.document.querySelector("#item");
+        setElementData(item, {
+          content: { videoRenderer: videoRenderer() },
+        });
+        setElementPrivateData(item, {
+          content: {
+            videoRenderer: videoRenderer({ includeOwner: false, includeTitle: false }),
+          },
+        });
+      },
+    });
+
+    expect(result.final.complete).toBe(true);
+    expect(result.final.unresolvedCount).toBe(0);
+    expect(result.final.videos).toEqual([
+      expect.objectContaining({ videoId: VIDEO_A, channelId: CHANNEL_A }),
+    ]);
+  });
+
+  it("does not call a signed-in subscriptions shell complete without feed evidence", async () => {
+    const result = await runExtractor();
+
+    expect(result.final.done).toBe(true);
+    expect(result.final.complete).toBe(false);
+    expect(result.final.pageEvidence).toBe(false);
+    expect(result.final.stopReason).toBe("page-evidence-missing");
+  });
+
+  it("does not use stale initial data as evidence on a rendered error page", async () => {
+    const result = await runExtractor({
+      html: "<ytd-app><ytd-browse><ytd-error-screen-renderer></ytd-error-screen-renderer></ytd-browse></ytd-app>",
+      initialData: {
+        staleSidebar: { videoRenderer: videoRenderer() },
+      },
+    });
+
+    expect(result.final.videos).toHaveLength(0);
+    expect(result.final.supportedCandidateCount).toBe(0);
+    expect(result.final.pageEvidence).toBe(false);
+    expect(result.final.complete).toBe(false);
+    expect(result.final.stopReason).toBe("page-evidence-missing");
+  });
+
+  it("only reads initial data from the selected feed tab", async () => {
+    const result = await runExtractor({
+      html: "<ytd-app><ytd-browse><ytd-rich-item-renderer id='item'></ytd-rich-item-renderer></ytd-browse></ytd-app>",
+      initialData: selectedFeedInitialData(
+        {
+          richGridRenderer: {
+            contents: [{
+              richItemRenderer: {
+                content: { videoRenderer: videoRenderer({ videoId: VIDEO_B }) },
+              },
+            }],
+          },
+        },
+        {
+          sidebar: { videoRenderer: videoRenderer({ videoId: VIDEO_A }) },
+        },
+      ),
+      configure(dom) {
+        setElementData(dom.window.document.querySelector("#item"), {
+          content: { videoRenderer: videoRenderer({ videoId: VIDEO_B }) },
+        });
+      },
+    });
+
+    expect(result.final.complete).toBe(true);
+    expect(result.final.videos.map((video) => video.videoId)).toEqual([VIDEO_B]);
+  });
+
+  it("revokes earlier feed evidence when the page becomes an error screen", async () => {
+    const result = await runExtractor({
+      html: "<ytd-app><ytd-browse><ytd-rich-item-renderer id='item'></ytd-rich-item-renderer></ytd-browse></ytd-app>",
+      configure(dom) {
+        setElementData(dom.window.document.querySelector("#item"), {
+          content: { videoRenderer: videoRenderer() },
+        });
+      },
+      onScroll(scrollCount, context) {
+        if (scrollCount === 1) {
+          const browse = context.dom.window.document.querySelector("ytd-browse");
+          if (browse) browse.innerHTML = "<ytd-error-screen-renderer></ytd-error-screen-renderer>";
+        }
+      },
+    });
+
+    expect(result.final.videos).toHaveLength(1);
+    expect(result.final.pageEvidence).toBe(false);
+    expect(result.final.complete).toBe(false);
+    expect(result.final.stopReason).toBe("page-evidence-missing");
+  });
+
+  it("accepts an explicit empty-feed renderer as complete evidence", async () => {
+    const result = await runExtractor({
+      html: "<ytd-app><ytd-browse><ytd-background-promo-renderer id='empty'></ytd-background-promo-renderer></ytd-browse></ytd-app>",
+      initialData: selectedFeedInitialData({
+        sectionListRenderer: {
+          contents: [{
+            itemSectionRenderer: {
+              contents: [{
+                backgroundPromoRenderer: { title: { simpleText: "No videos" } },
+              }],
+            },
+          }],
+        },
+      }),
+      configure(dom) {
+        setElementData(dom.window.document.querySelector("#empty"), {
+          title: { simpleText: "No videos" },
+        });
+      },
+    });
+
+    expect(result.final.complete).toBe(true);
+    expect(result.final.explicitEmpty).toBe(true);
+    expect(result.final.pageEvidence).toBe(true);
+    expect(result.final.videos).toEqual([]);
+  });
+
+  it("rejects a rendered promo that only matches unrelated initial data", async () => {
+    const result = await runExtractor({
+      html: "<ytd-app><ytd-browse><ytd-background-promo-renderer id='promo'></ytd-background-promo-renderer></ytd-browse></ytd-app>",
+      initialData: selectedFeedInitialData(
+        { sectionListRenderer: { contents: [] } },
+        {
+          sidebar: {
+            backgroundPromoRenderer: { title: { simpleText: "No videos" } },
+          },
+        },
+      ),
+      configure(dom) {
+        setElementData(dom.window.document.querySelector("#promo"), {
+          title: { simpleText: "No videos" },
+        });
+      },
+    });
+
+    expect(result.final.complete).toBe(false);
+    expect(result.final.explicitEmpty).toBe(false);
+    expect(result.final.pageEvidence).toBe(false);
+    expect(result.final.stopReason).toBe("page-evidence-missing");
+  });
+
+  it("requires positive channel-page evidence before completing the roster", async () => {
+    const result = await runExtractor({
+      stage: "channels",
+      html: "<ytd-app><ytd-browse><ytd-channel-renderer id='channel'></ytd-channel-renderer></ytd-browse></ytd-app>",
+      configure(dom) {
+        setElementData(dom.window.document.querySelector("#channel"), {
+          channelId: CHANNEL_A,
+          title: { simpleText: "Channel A" },
+        });
+      },
+    });
+
+    expect(result.final.rosterComplete).toBe(true);
+    expect(result.final.pageEvidence).toBe(true);
+    expect(result.final.channels).toEqual([
+      expect.objectContaining({ channelId: CHANNEL_A, title: "Channel A" }),
+    ]);
+  });
+
+  it("represents an ownerless and titleless Short for downstream filtering", async () => {
+    const result = await runExtractor({
+      html: "<ytd-app><ytd-browse><ytd-reel-item-renderer id='short'></ytd-reel-item-renderer></ytd-browse></ytd-app>",
+      configure(dom) {
+        setElementData(dom.window.document.querySelector("#short"), {
+          navigationEndpoint: {
+            reelWatchEndpoint: { videoId: VIDEO_A },
+            commandMetadata: {
+              webCommandMetadata: { url: `/shorts/${VIDEO_A}` },
+            },
+          },
+        });
+      },
+    });
+
+    expect(result.final.complete).toBe(true);
+    expect(result.final.unresolvedCount).toBe(0);
+    expect(result.final.videos).toEqual([
+      expect.objectContaining({
+        videoId: VIDEO_A,
+        title: VIDEO_A,
+        isShort: true,
+      }),
+    ]);
+    expect(result.final.videos[0]).not.toHaveProperty("channelId");
+  });
+
+  it("blocks completion when a rendered feed item uses an unsupported renderer", async () => {
+    const result = await runExtractor({
+      html: "<ytd-app><ytd-browse><ytd-rich-item-renderer id='item'></ytd-rich-item-renderer></ytd-browse></ytd-app>",
+      configure(dom) {
+        setElementData(dom.window.document.querySelector("#item"), {
+          content: { futureLockupViewModel: { contentId: VIDEO_A } },
+        });
+      },
+    });
+
+    expect(result.final.done).toBe(true);
+    expect(result.final.complete).toBe(false);
+    expect(result.final.unsupportedCandidateCount).toBe(1);
+    expect(result.final.stopReason).toBe("unsupported-candidates");
+  });
+
+  it("drops live candidate failures after their elements leave the feed", async () => {
+    const result = await runExtractor({
+      html: [
+        "<ytd-app><ytd-browse>",
+        "<ytd-rich-item-renderer id='unsupported'></ytd-rich-item-renderer>",
+        "<ytd-video-renderer id='partial'></ytd-video-renderer>",
+        "<ytd-rich-item-renderer id='valid'></ytd-rich-item-renderer>",
+        "</ytd-browse></ytd-app>",
+      ].join(""),
+      configure(dom) {
+        setElementData(dom.window.document.querySelector("#unsupported"), {
+          content: { futureLockupViewModel: { contentId: "future-video" } },
+        });
+        setElementData(dom.window.document.querySelector("#partial"), {});
+        setElementData(dom.window.document.querySelector("#valid"), {
+          content: { videoRenderer: videoRenderer() },
+        });
+      },
+      onScroll(scrollCount, context) {
+        if (scrollCount === 1) {
+          context.dom.window.document.querySelector("#unsupported")?.remove();
+          context.dom.window.document.querySelector("#partial")?.remove();
+        }
+      },
+    });
+
+    expect(result.final.complete).toBe(true);
+    expect(result.final.unsupportedCandidateCount).toBe(0);
+    expect(result.final.unresolvedCount).toBe(0);
+    expect(result.final.videos).toHaveLength(1);
+  });
+
+  it("keeps an identified video incomplete after its unresolved card is virtualized away", async () => {
+    const result = await runExtractor({
+      html: [
+        "<ytd-app><ytd-browse>",
+        "<ytd-video-renderer id='unresolved'></ytd-video-renderer>",
+        "<ytd-rich-item-renderer id='valid'></ytd-rich-item-renderer>",
+        "</ytd-browse></ytd-app>",
+      ].join(""),
+      configure(dom) {
+        setElementData(dom.window.document.querySelector("#unresolved"), {
+          ...videoRenderer({ includeOwner: false }),
+        });
+        setElementData(dom.window.document.querySelector("#valid"), {
+          content: { videoRenderer: videoRenderer({ videoId: VIDEO_B }) },
+        });
+      },
+      onScroll(scrollCount, context) {
+        if (scrollCount === 1) {
+          context.dom.window.document.querySelector("#unresolved")?.remove();
+        }
+      },
+    });
+
+    expect(result.final.complete).toBe(false);
+    expect(result.final.unresolvedCount).toBeGreaterThan(0);
+    expect(result.final.stopReason).toBe("unresolved");
+    expect(result.final.videos.map((video) => video.videoId)).toEqual([VIDEO_B]);
+  });
+
+  it("merges sparse duplicates without losing rich metadata or true flags", async () => {
+    const result = await runExtractor({
+      html: [
+        "<ytd-app><ytd-browse>",
+        "<ytd-rich-item-renderer id='rich'></ytd-rich-item-renderer>",
+        "<ytd-rich-item-renderer id='sparse'></ytd-rich-item-renderer>",
+        "</ytd-browse></ytd-app>",
+      ].join(""),
+      configure(dom) {
+        setElementData(dom.window.document.querySelector("#rich"), {
+          content: {
+            reelItemRenderer: videoRenderer({
+              path: `/shorts/${VIDEO_A}`,
+              rich: true,
+              live: true,
+            }),
+          },
+        });
+        setElementData(dom.window.document.querySelector("#sparse"), {
+          content: { compactVideoRenderer: videoRenderer() },
+        });
+      },
+    });
+
+    expect(result.final.complete).toBe(true);
+    expect(result.final.videos).toEqual([
+      expect.objectContaining({
+        videoId: VIDEO_A,
+        description: "A useful description",
+        publishedText: "2 hours ago",
+        durationText: "12:34",
+        thumbnailUrl: `https://i.ytimg.com/vi/${VIDEO_A}/hqdefault.jpg`,
+        isShort: true,
+        isLive: true,
+      }),
+    ]);
+  });
+
+  it("fails closed when duplicate renderers disagree about the channel", async () => {
+    const result = await runExtractor({
+      html: [
+        "<ytd-app><ytd-browse>",
+        "<ytd-rich-item-renderer id='first'></ytd-rich-item-renderer>",
+        "<ytd-rich-item-renderer id='second'></ytd-rich-item-renderer>",
+        "</ytd-browse></ytd-app>",
+      ].join(""),
+      configure(dom) {
+        setElementData(dom.window.document.querySelector("#first"), {
+          content: { videoRenderer: videoRenderer() },
+        });
+        setElementData(dom.window.document.querySelector("#second"), {
+          content: {
+            videoRenderer: videoRenderer({
+              channelId: CHANNEL_B,
+              channelTitle: "Channel B",
+            }),
+          },
+        });
+      },
+    });
+
+    expect(result.final.complete).toBe(false);
+    expect(result.final.unresolvedCount).toBeGreaterThan(0);
+    expect(result.final.stopReason).toBe("unresolved");
+  });
+
+  it("does not complete while a continuation item is still pending", async () => {
+    const result = await runExtractor({
+      html: [
+        "<ytd-app><ytd-browse>",
+        "<ytd-rich-item-renderer id='item'></ytd-rich-item-renderer>",
+        "<ytd-continuation-item-renderer id='continuation'></ytd-continuation-item-renderer>",
+        "</ytd-browse></ytd-app>",
+      ].join(""),
+      configure(dom) {
+        setElementData(dom.window.document.querySelector("#item"), {
+          content: { videoRenderer: videoRenderer() },
+        });
+        setElementData(dom.window.document.querySelector("#continuation"), {
+          continuationEndpoint: {
+            continuationCommand: { token: "next-page" },
+          },
+        });
+      },
+    });
+
+    expect(result.final.done).toBe(true);
+    expect(result.final.complete).toBe(false);
+    expect(result.final.pendingContinuation).toBe(true);
+    expect(result.final.stopReason).toBe("max-passes");
+    expect(result.final.scrollPasses).toBe(32);
+  });
+
+  it("charges unchanged live object identities only once across stable passes", async () => {
+    const nestedRoot: Record<string, unknown> = {};
+    let cursor = nestedRoot;
+    for (let index = 0; index < 120; index += 1) {
+      const next: Record<string, unknown> = {};
+      cursor.next = next;
+      cursor = next;
+    }
+    const result = await runExtractor({
+      html: "<ytd-app><ytd-browse><ytd-rich-item-renderer id='item'></ytd-rich-item-renderer></ytd-browse></ytd-app>",
+      configure(dom) {
+        setElementData(dom.window.document.querySelector("#item"), {
+          nestedRoot,
+          content: { videoRenderer: videoRenderer() },
+        });
+      },
+    });
+
+    expect(result.final.complete).toBe(true);
+    expect(result.final.scrollPasses).toBeGreaterThanOrEqual(4);
+    expect(result.final.visitedObjectCount).toBeGreaterThan(120);
+    expect(result.final.visitedObjectCount).toBeLessThan(250);
+  });
+
+  it("emits a terminal but incomplete result after the maximum scroll passes", async () => {
+    const result = await runExtractor({
+      html: "<ytd-app><ytd-browse><ytd-rich-item-renderer id='item'></ytd-rich-item-renderer></ytd-browse></ytd-app>",
+      configure(dom) {
+        setElementData(dom.window.document.querySelector("#item"), {
+          content: { videoRenderer: videoRenderer() },
+        });
+      },
+      onScroll(_scrollCount, context) {
+        const current = context.dom.window.document.documentElement.scrollHeight;
+        context.setHeight(current + 2_000);
+      },
+    });
+
+    expect(result.final.done).toBe(true);
+    expect(result.final.complete).toBe(false);
+    expect(result.final.stopReason).toBe("max-passes");
+    expect(result.final.scrollPasses).toBe(32);
+    expect(result.final.workBudgetExceeded).toBe(false);
+    expect(result.final.deadlineExceeded).toBe(false);
+  });
+});

--- a/packages/desktop/src/lib/youtube-native-bridge.test.ts
+++ b/packages/desktop/src/lib/youtube-native-bridge.test.ts
@@ -78,6 +78,73 @@ function emit(event: string, payload: unknown): void {
   handler({ payload });
 }
 
+interface CaptureArgs {
+  includeRoster: boolean;
+  captureId: string;
+}
+
+function expectCaptureArgs(args: unknown, includeRoster: boolean): CaptureArgs {
+  expect(args).toEqual({
+    includeRoster,
+    captureId: expect.any(String),
+  });
+  const captureArgs = args as CaptureArgs;
+  expect(captureArgs.captureId).toMatch(
+    /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+  );
+  return captureArgs;
+}
+
+function emitCapture(args: CaptureArgs, payload: Record<string, unknown>): void {
+  emit("yt-capture-data", { captureId: args.captureId, ...payload });
+}
+
+type CaptureStage = "channels" | "subscriptions";
+
+interface CaptureStageRecords {
+  channels?: Array<Record<string, unknown>>;
+  videos?: Array<Record<string, unknown>>;
+}
+
+function terminalStage(
+  args: CaptureArgs,
+  stage: CaptureStage,
+  records: CaptureStageRecords = {},
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  const channels = records.channels ?? [];
+  const videos = records.videos ?? [];
+  const primaryRecords = stage === "channels" ? channels : videos;
+  return {
+    captureId: args.captureId,
+    stage,
+    channels,
+    videos,
+    rosterComplete: stage === "channels",
+    complete: stage === "subscriptions",
+    channelTotal: channels.length,
+    videoTotal: videos.length,
+    candidateCount: primaryRecords.length,
+    unresolvedCount: 0,
+    scrollPasses: 1,
+    stopReason: "end-stable",
+    pageEvidence: true,
+    explicitEmpty: primaryRecords.length === 0,
+    unsupportedCandidateCount: 0,
+    pendingContinuation: false,
+    workBudgetExceeded: false,
+    deadlineExceeded: false,
+    done: true,
+    ...overrides,
+  };
+}
+
+function captureResult(...stages: Array<Record<string, unknown>>): {
+  stages: Array<Record<string, unknown>>;
+} {
+  return { stages };
+}
+
 describe("YouTube native bridge", () => {
   beforeEach(() => {
     mocks.listeners.clear();
@@ -107,36 +174,52 @@ describe("YouTube native bridge", () => {
 
   it("normalizes a complete authenticated roster and subscriptions capture", async () => {
     const channelId = "UC1111111111111111111111";
+    const channels = [{ channelId, title: "Learning Channel", handle: "@learning" }];
+    const videos = [{
+      videoId: "dQw4w9WgXcQ",
+      title: "Focused Study",
+      channelId,
+      channelTitle: "Learning Channel",
+    }, {
+      videoId: "abcdefghijk",
+      title: "Short distraction",
+      channelId,
+      channelTitle: "Learning Channel",
+      isShort: true,
+    }, {
+      videoId: "lmNOPqrST_-",
+      title: "Second focused lesson",
+      channelId,
+      channelTitle: "Learning Channel",
+    }];
     mocks.invoke.mockImplementation(async (command: string, args?: unknown) => {
       expect(command).toBe("yt_capture");
-      expect(args).toEqual({ includeRoster: true });
-      emit("yt-capture-data", {
-        channels: [{ channelId, title: "Learning Channel", handle: "@learning" }],
-        videos: [{
-          videoId: "dQw4w9WgXcQ",
-          title: "Focused Study",
-          channelId,
-          channelTitle: "Learning Channel",
-        }, {
-          videoId: "abcdefghijk",
-          title: "Short distraction",
-          channelId,
-          channelTitle: "Learning Channel",
-          isShort: true,
-        }, {
-          videoId: "lmNOPqrST_-",
-          title: "Second focused lesson",
-          channelId,
-          channelTitle: "Learning Channel",
-        }],
-        rosterComplete: true,
-        complete: true,
-        unresolvedCount: 0,
-        scrollPasses: 3,
-        stopReason: "stable",
-        done: true,
+      const captureArgs = expectCaptureArgs(args, true);
+      emitCapture(captureArgs, {
+        stage: "channels",
+        channels,
+        candidateCount: 1,
+        unresolvedCount: 1,
+        scrollPasses: 1,
+        done: false,
       });
-      return null;
+      emitCapture(captureArgs, {
+        stage: "subscriptions",
+        videos,
+        candidateCount: 3,
+        scrollPasses: 1,
+        done: false,
+      });
+      return captureResult(
+        terminalStage(captureArgs, "channels", { channels }, {
+          candidateCount: 1,
+          scrollPasses: 3,
+        }),
+        terminalStage(captureArgs, "subscriptions", { videos }, {
+          candidateCount: 3,
+          scrollPasses: 2,
+        }),
+      );
     });
 
     const result = await fetchYouTubeCapture();
@@ -150,27 +233,500 @@ describe("YouTube native bridge", () => {
       unresolvedCount: 0,
       scrollPasses: 3,
       shortsSkipped: 1,
-      stopReason: "stable",
+      stopReason: "end-stable",
       errorStage: null,
     });
   });
 
-  it("skips the full roster page during scheduled recent-video refreshes", async () => {
+  it("aggregates matching progress idempotently and ignores stale capture events", async () => {
     const channelId = "UC1111111111111111111111";
     mocks.invoke.mockImplementation(async (command: string, args?: unknown) => {
       expect(command).toBe("yt_capture");
-      expect(args).toEqual({ includeRoster: false });
+      const captureArgs = expectCaptureArgs(args, true);
       emit("yt-capture-data", {
+        captureId: "11111111-1111-4111-8111-111111111111",
+        stage: "subscriptions",
+        videos: [{
+          videoId: "staleVideo1",
+          title: "Stale lesson",
+          channelId,
+          channelTitle: "Learning Channel",
+        }],
+        done: true,
+        error: "The YouTube website session is not signed in.",
+      });
+      emitCapture(captureArgs, {
+        stage: "channels",
+        channels: [{ channelId, title: "Learning Channel" }],
+        candidateCount: 4,
+        scrollPasses: 1,
+        done: false,
+      });
+      emitCapture(captureArgs, {
+        stage: "channels",
+        channels: [{ channelId, title: "Learning Channel", handle: "@learning" }],
+        rosterComplete: true,
+        candidateCount: 4,
+        scrollPasses: 2,
+        done: true,
+      });
+      emitCapture(captureArgs, {
+        stage: "subscriptions",
         videos: [{
           videoId: "dQw4w9WgXcQ",
           title: "Focused Study",
           channelId,
           channelTitle: "Learning Channel",
         }],
-        rosterComplete: false,
+        candidateCount: 1,
+        scrollPasses: 1,
+        done: false,
+      });
+      emitCapture(captureArgs, {
+        stage: "subscriptions",
+        videos: [{
+          videoId: "dQw4w9WgXcQ",
+          title: "Focused Study",
+          description: "A deeper description from a later pass.",
+          channelId,
+          channelTitle: "Learning Channel",
+        }, {
+          videoId: "lmNOPqrST_-",
+          title: "Second focused lesson",
+          channelId,
+          channelTitle: "Learning Channel",
+        }],
+        candidateCount: 2,
+        complete: true,
+        scrollPasses: 2,
         done: true,
       });
-      return null;
+      return captureResult(
+        terminalStage(captureArgs, "channels", {
+          channels: [{ channelId, title: "Learning Channel", handle: "@learning" }],
+        }, { candidateCount: 4, scrollPasses: 2 }),
+        terminalStage(captureArgs, "subscriptions", {
+          videos: [{
+            videoId: "dQw4w9WgXcQ",
+            title: "Focused Study",
+            description: "A deeper description from the native terminal receipt.",
+            channelId,
+            channelTitle: "Learning Channel",
+          }, {
+            videoId: "lmNOPqrST_-",
+            title: "Second focused lesson",
+            channelId,
+            channelTitle: "Learning Channel",
+          }],
+        }, { candidateCount: 2, scrollPasses: 2 }),
+      );
+    });
+
+    const result = await fetchYouTubeCapture();
+
+    expect(result.accounts).toHaveLength(1);
+    expect(result.items.map((item) => item.globalId)).toEqual([
+      "youtube:yt:video:dQw4w9WgXcQ",
+      "youtube:yt:video:lmNOPqrST_-",
+    ]);
+    expect(result.items[0]?.content.text).toContain("deeper description");
+    expect(result.diag).toMatchObject({
+      channelsExtracted: 1,
+      videosExtracted: 2,
+      accountsNormalized: 1,
+      itemsNormalized: 2,
+      rosterComplete: true,
+      errorStage: null,
+    });
+  });
+
+  it("rejects renderer event finals without an authoritative native return", async () => {
+    const channelId = "UC1111111111111111111111";
+    let captureId = "";
+    mocks.invoke.mockImplementation(async (command: string, args?: unknown) => {
+      if (command === "yt_hide_login") {
+        expect(args).toEqual({ captureId });
+        return null;
+      }
+      expect(command).toBe("yt_capture");
+      const captureArgs = expectCaptureArgs(args, true);
+      captureId = captureArgs.captureId;
+      emit("yt-capture-data", terminalStage(captureArgs, "channels", {
+        channels: [{ channelId, title: "Learning Channel" }],
+      }));
+      emit("yt-capture-data", {
+        captureId: "22222222-2222-4222-8222-222222222222",
+        stage: "subscriptions",
+        done: true,
+      });
+      emit("yt-capture-data", terminalStage(captureArgs, "subscriptions", {}, {
+        candidateCount: 7,
+        scrollPasses: 4,
+      }));
+      return captureResult();
+    });
+
+    const result = await captureYouTube("manual");
+
+    expect(result.diag.errorStage).toBe("extract");
+    expect(result.diag.errorMessage).toContain(
+      "ended without final markers for channels, subscriptions",
+    );
+    expect(result.diag.errorMessage).toContain("stage=subscriptions");
+    expect(result.diag.errorMessage).toContain("candidates=7");
+    expect(mocks.reconcile).not.toHaveBeenCalled();
+    expect(mocks.invoke).toHaveBeenLastCalledWith("yt_hide_login", { captureId });
+    expect(mocks.listeners.has("yt-capture-data")).toBe(false);
+  });
+
+  it("rejects mismatched authoritative totals and cancels the exact capture", async () => {
+    const channelId = "UC1111111111111111111111";
+    let captureId = "";
+    mocks.invoke.mockImplementation(async (command: string, args?: unknown) => {
+      if (command === "yt_hide_login") {
+        expect(args).toEqual({ captureId });
+        return null;
+      }
+      expect(command).toBe("yt_capture");
+      const captureArgs = expectCaptureArgs(args, true);
+      captureId = captureArgs.captureId;
+      return captureResult(
+        terminalStage(captureArgs, "channels", {
+          channels: [{ channelId, title: "Learning Channel" }],
+        }, { channelTotal: 2 }),
+        terminalStage(captureArgs, "subscriptions"),
+      );
+    });
+
+    const result = await captureYouTube("manual");
+
+    expect(result.diag.errorStage).toBe("extract");
+    expect(result.diag.errorMessage).toContain(
+      "ended incomplete for channels stopReason=end-stable",
+    );
+    expect(mocks.reconcile).not.toHaveBeenCalled();
+    expect(mocks.invoke).toHaveBeenLastCalledWith("yt_hide_login", { captureId });
+    expect(mocks.listeners.has("yt-capture-data")).toBe(false);
+  });
+
+  it.each([
+    "workBudgetExceeded",
+    "deadlineExceeded",
+    "pendingContinuation",
+  ] as const)(
+    "rejects an authoritative terminal missing %s",
+    async (missingField) => {
+      let captureId = "";
+      mocks.invoke.mockImplementation(async (command: string, args?: unknown) => {
+        if (command === "yt_hide_login") {
+          expect(args).toEqual({ captureId });
+          return null;
+        }
+        expect(command).toBe("yt_capture");
+        const captureArgs = expectCaptureArgs(args, false);
+        captureId = captureArgs.captureId;
+        const terminal = terminalStage(captureArgs, "subscriptions");
+        delete terminal[missingField];
+        return captureResult(terminal);
+      });
+
+      const result = await fetchYouTubeCapture(false);
+
+      expect(result.diag.errorStage).toBe("extract");
+      expect(result.diag.errorMessage).toContain(
+        "ended incomplete for subscriptions stopReason=end-stable",
+      );
+      expect(mocks.reconcile).not.toHaveBeenCalled();
+      expect(mocks.invoke).toHaveBeenLastCalledWith("yt_hide_login", { captureId });
+    },
+  );
+
+  it("rejects an authoritative terminal with a pending continuation", async () => {
+    let captureId = "";
+    mocks.invoke.mockImplementation(async (command: string, args?: unknown) => {
+      if (command === "yt_hide_login") {
+        expect(args).toEqual({ captureId });
+        return null;
+      }
+      expect(command).toBe("yt_capture");
+      const captureArgs = expectCaptureArgs(args, false);
+      captureId = captureArgs.captureId;
+      return captureResult(
+        terminalStage(
+          captureArgs,
+          "subscriptions",
+          {},
+          { pendingContinuation: true },
+        ),
+      );
+    });
+
+    const result = await fetchYouTubeCapture(false);
+
+    expect(result.diag.errorStage).toBe("extract");
+    expect(result.diag.errorMessage).toContain(
+      "ended incomplete for subscriptions stopReason=end-stable",
+    );
+    expect(mocks.reconcile).not.toHaveBeenCalled();
+    expect(mocks.invoke).toHaveBeenLastCalledWith("yt_hide_login", { captureId });
+  });
+
+  it("accepts authoritative zero unresolved after positive progress", async () => {
+    const channelId = "UC1111111111111111111111";
+    const channels = [{ channelId, title: "Learning Channel" }];
+    mocks.invoke.mockImplementation(async (command: string, args?: unknown) => {
+      expect(command).toBe("yt_capture");
+      const captureArgs = expectCaptureArgs(args, true);
+      emitCapture(captureArgs, {
+        stage: "channels",
+        channels,
+        candidateCount: 3,
+        unresolvedCount: 2,
+        scrollPasses: 1,
+        done: false,
+      });
+      return captureResult(
+        terminalStage(captureArgs, "channels", { channels }, {
+          candidateCount: 3,
+          scrollPasses: 2,
+        }),
+        terminalStage(captureArgs, "subscriptions"),
+      );
+    });
+
+    const result = await captureYouTube("manual");
+
+    expect(result.diag).toMatchObject({
+      errorStage: null,
+      rosterComplete: true,
+      unresolvedCount: 0,
+    });
+    expect(mocks.reconcile).toHaveBeenCalledOnce();
+  });
+
+  it("uses complete native finals when renderer delivery is delayed or absent", async () => {
+    const channelId = "UC1111111111111111111111";
+    const channels = [{ channelId, title: "Learning Channel" }];
+    const videos = [{
+      videoId: "dQw4w9WgXcQ",
+      title: "Focused Study",
+      channelId,
+      channelTitle: "Learning Channel",
+    }, {
+      videoId: "lmNOPqrST_-",
+      title: "Second focused lesson",
+      channelId,
+      channelTitle: "Learning Channel",
+    }];
+    mocks.invoke.mockImplementation(async (command: string, args?: unknown) => {
+      expect(command).toBe("yt_capture");
+      const captureArgs = expectCaptureArgs(args, true);
+      await new Promise<void>((resolve) => window.setTimeout(resolve, 5));
+      emitCapture(captureArgs, {
+        stage: "channels",
+        channels: [{ channelId, title: "Learning" }],
+        unresolvedCount: 1,
+        done: false,
+      });
+      return captureResult(
+        terminalStage(captureArgs, "channels", { channels }),
+        terminalStage(captureArgs, "subscriptions", { videos }),
+      );
+    });
+
+    const result = await fetchYouTubeCapture();
+
+    expect(result.accounts).toHaveLength(1);
+    expect(result.items.map((item) => item.globalId)).toEqual([
+      "youtube:yt:video:dQw4w9WgXcQ",
+      "youtube:yt:video:lmNOPqrST_-",
+    ]);
+    expect(result.diag).toMatchObject({ errorStage: null, unresolvedCount: 0 });
+  });
+
+  it("rejects an incomplete channel final and does not reconcile partial results", async () => {
+    const channelId = "UC1111111111111111111111";
+    let captureId = "";
+    mocks.invoke.mockImplementation(async (command: string, args?: unknown) => {
+      if (command === "yt_hide_login") {
+        expect(args).toEqual({ captureId });
+        return null;
+      }
+      expect(command).toBe("yt_capture");
+      const captureArgs = expectCaptureArgs(args, true);
+      captureId = captureArgs.captureId;
+      emitCapture(captureArgs, {
+        stage: "channels",
+        channels: [{ channelId, title: "Learning Channel" }],
+        rosterComplete: false,
+        unresolvedCount: 2,
+        candidateCount: 3,
+        scrollPasses: 5,
+        stopReason: "unresolved",
+        done: true,
+      });
+      emitCapture(captureArgs, {
+        stage: "subscriptions",
+        videos: [],
+        complete: true,
+        stopReason: "end-stable",
+        done: true,
+      });
+      return captureResult(
+        terminalStage(captureArgs, "channels", {
+          channels: [{ channelId, title: "Learning Channel" }],
+        }, {
+          rosterComplete: false,
+          unresolvedCount: 2,
+          candidateCount: 3,
+          scrollPasses: 5,
+          stopReason: "unresolved",
+        }),
+        terminalStage(captureArgs, "subscriptions"),
+      );
+    });
+
+    const result = await captureYouTube("manual");
+
+    expect(result.diag.errorStage).toBe("extract");
+    expect(result.diag.errorMessage).toContain(
+      "ended incomplete for channels stopReason=unresolved",
+    );
+    expect(result.diag.errorMessage).toContain("stage=channels");
+    expect(result.diag.errorMessage).toContain("candidates=3");
+    expect(mocks.reconcile).not.toHaveBeenCalled();
+    expect(mocks.invoke).toHaveBeenLastCalledWith("yt_hide_login", { captureId });
+  });
+
+  it("rejects an incomplete subscriptions final in a roster-free capture", async () => {
+    let captureId = "";
+    mocks.invoke.mockImplementation(async (command: string, args?: unknown) => {
+      if (command === "yt_hide_login") {
+        expect(args).toEqual({ captureId });
+        return null;
+      }
+      expect(command).toBe("yt_capture");
+      const captureArgs = expectCaptureArgs(args, false);
+      captureId = captureArgs.captureId;
+      emitCapture(captureArgs, {
+        stage: "subscriptions",
+        videos: [],
+        complete: false,
+        candidateCount: 18,
+        scrollPasses: 7,
+        stopReason: "deadline",
+        done: true,
+      });
+      return captureResult(terminalStage(captureArgs, "subscriptions", {}, {
+        complete: false,
+        candidateCount: 18,
+        scrollPasses: 7,
+        stopReason: "deadline",
+      }));
+    });
+
+    const result = await captureYouTube("scheduled");
+
+    expect(result.diag.errorStage).toBe("extract");
+    expect(result.diag.errorMessage).toContain(
+      "ended incomplete for subscriptions stopReason=deadline",
+    );
+    expect(result.diag.errorMessage).toContain("stage=subscriptions");
+    expect(result.diag.errorMessage).toContain("candidates=18");
+    expect(mocks.reconcile).not.toHaveBeenCalled();
+    expect(mocks.invoke).toHaveBeenLastCalledWith("yt_hide_login", { captureId });
+  });
+
+  it("adds matching progress diagnostics to a native capture rejection", async () => {
+    let captureId = "";
+    mocks.invoke.mockImplementation(async (command: string, args?: unknown) => {
+      if (command === "yt_hide_login") {
+        expect(args).toEqual({ captureId });
+        return null;
+      }
+      expect(command).toBe("yt_capture");
+      const captureArgs = expectCaptureArgs(args, false);
+      captureId = captureArgs.captureId;
+      emitCapture(captureArgs, {
+        stage: "subscriptions",
+        candidateCount: 1_234,
+        scrollPasses: 9,
+        done: false,
+      });
+      throw new Error("YouTube subscriptions capture timed out.");
+    });
+
+    const result = await fetchYouTubeCapture(false);
+
+    expect(result.diag.errorStage).toBe("invoke");
+    expect(result.diag.errorMessage).toContain(
+      "YouTube subscriptions capture timed out.",
+    );
+    expect(result.diag.errorMessage).toContain("stage=subscriptions");
+    expect(result.diag.errorMessage).toContain(
+      `candidates=${(1_234).toLocaleString()}`,
+    );
+    expect(result.diag.errorMessage?.match(/Last progress stage=/g)).toHaveLength(1);
+    expect(mocks.invoke).toHaveBeenLastCalledWith("yt_hide_login", { captureId });
+  });
+
+  it("times out with latest progress and cancels only the active capture", async () => {
+    vi.useFakeTimers();
+    let captureId = "";
+    try {
+      mocks.invoke.mockImplementation((command: string, args?: unknown) => {
+        if (command === "yt_hide_login") {
+          expect(args).toEqual({ captureId });
+          return Promise.resolve(null);
+        }
+        expect(command).toBe("yt_capture");
+        const captureArgs = expectCaptureArgs(args, false);
+        captureId = captureArgs.captureId;
+        emitCapture(captureArgs, {
+          stage: "subscriptions",
+          candidateCount: 18,
+          scrollPasses: 6,
+          done: false,
+        });
+        return new Promise(() => undefined);
+      });
+
+      const pending = fetchYouTubeCapture(false);
+      await vi.advanceTimersByTimeAsync(275_000);
+      const result = await pending;
+
+      expect(result.diag.errorStage).toBe("invoke");
+      expect(result.diag.errorMessage).toContain("YouTube capture timed out.");
+      expect(result.diag.errorMessage).toContain("stage=subscriptions");
+      expect(result.diag.errorMessage).toContain("candidates=18");
+      expect(result.diag.errorMessage).toContain("scrollPasses=6");
+      expect(result.diag.errorMessage?.match(/Last progress stage=/g)).toHaveLength(1);
+      expect(mocks.invoke).toHaveBeenLastCalledWith("yt_hide_login", { captureId });
+      expect(mocks.listeners.has("yt-capture-data")).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("skips the full roster page during scheduled recent-video refreshes", async () => {
+    const channelId = "UC1111111111111111111111";
+    const videos = [{
+      videoId: "dQw4w9WgXcQ",
+      title: "Focused Study",
+      channelId,
+      channelTitle: "Learning Channel",
+    }];
+    mocks.invoke.mockImplementation(async (command: string, args?: unknown) => {
+      expect(command).toBe("yt_capture");
+      const captureArgs = expectCaptureArgs(args, false);
+      emitCapture(captureArgs, {
+        stage: "subscriptions",
+        videos,
+        rosterComplete: false,
+        complete: true,
+        done: true,
+      });
+      return captureResult(terminalStage(captureArgs, "subscriptions", { videos }));
     });
 
     const result = await captureYouTube("scheduled");
@@ -188,21 +744,39 @@ describe("YouTube native bridge", () => {
   it("serializes concurrent capture listeners so events cannot cross requests", async () => {
     const channelId = "UC1111111111111111111111";
     let call = 0;
-    mocks.invoke.mockImplementation(async (_command: string, args?: { includeRoster?: boolean }) => {
+    const captureIds: string[] = [];
+    mocks.invoke.mockImplementation(async (_command: string, args?: unknown) => {
+      const captureArgs = expectCaptureArgs(args, call === 0);
+      captureIds.push(captureArgs.captureId);
       const videoId = call === 0 ? "dQw4w9WgXcQ" : "lmNOPqrST_-";
-      emit("yt-capture-data", {
-        videos: [{
-          videoId,
-          title: `Lesson ${call.toLocaleString()}`,
-          channelId,
-          channelTitle: "Learning Channel",
-        }],
+      const channels = [{ channelId, title: "Learning Channel" }];
+      const videos = [{
+        videoId,
+        title: `Lesson ${call.toLocaleString()}`,
+        channelId,
+        channelTitle: "Learning Channel",
+      }];
+      if (call === 0) {
+        emitCapture(captureArgs, {
+          stage: "channels",
+          channels,
+          rosterComplete: true,
+          done: true,
+        });
+      }
+      emitCapture(captureArgs, {
+        stage: "subscriptions",
+        videos,
         rosterComplete: false,
+        complete: true,
         done: true,
       });
-      expect(args?.includeRoster).toBe(call === 0);
+      const stages = call === 0
+        ? [terminalStage(captureArgs, "channels", { channels })]
+        : [];
+      stages.push(terminalStage(captureArgs, "subscriptions", { videos }));
       call += 1;
-      return null;
+      return captureResult(...stages);
     });
 
     const [full, incremental] = await Promise.all([
@@ -216,23 +790,37 @@ describe("YouTube native bridge", () => {
     expect(incremental.items.map((item) => item.globalId)).toEqual([
       "youtube:yt:video:lmNOPqrST_-",
     ]);
+    expect(new Set(captureIds).size).toBe(2);
   });
 
   it("persists the capture once and records bounded health evidence", async () => {
     const channelId = "UC1111111111111111111111";
-    mocks.invoke.mockImplementation(async () => {
-      emit("yt-capture-data", {
-        channels: [{ channelId, title: "Learning Channel" }],
-        videos: [{
-          videoId: "dQw4w9WgXcQ",
-          title: "Focused Study",
-          channelId,
-          channelTitle: "Learning Channel",
-        }],
+    const channels = [{ channelId, title: "Learning Channel" }];
+    const videos = [{
+      videoId: "dQw4w9WgXcQ",
+      title: "Focused Study",
+      channelId,
+      channelTitle: "Learning Channel",
+    }];
+    mocks.invoke.mockImplementation(async (command: string, args?: unknown) => {
+      expect(command).toBe("yt_capture");
+      const captureArgs = expectCaptureArgs(args, true);
+      emitCapture(captureArgs, {
+        stage: "channels",
+        channels,
         rosterComplete: true,
         done: true,
       });
-      return null;
+      emitCapture(captureArgs, {
+        stage: "subscriptions",
+        videos,
+        complete: true,
+        done: true,
+      });
+      return captureResult(
+        terminalStage(captureArgs, "channels", { channels }),
+        terminalStage(captureArgs, "subscriptions", { videos }),
+      );
     });
 
     const result = await captureYouTube("manual");
@@ -259,8 +847,11 @@ describe("YouTube native bridge", () => {
       playlistId: "PL-freed-offline",
       playlistUrl: "https://www.youtube.com/playlist?list=PL-freed-offline",
     }));
-    mocks.invoke.mockImplementation(async () => {
-      emit("yt-capture-data", {
+    mocks.invoke.mockImplementation(async (command: string, args?: unknown) => {
+      if (command === "yt_hide_login") return null;
+      expect(command).toBe("yt_capture");
+      const captureArgs = expectCaptureArgs(args, true);
+      emitCapture(captureArgs, {
         stage: "subscriptions",
         done: true,
         error: "The YouTube website session is not signed in.",
@@ -275,6 +866,34 @@ describe("YouTube native bridge", () => {
       isAuthenticated: false,
     }));
     expect(getYouTubePlaylistState()).toEqual({});
+  });
+
+  it("classifies a native signed-out rejection without a renderer event", async () => {
+    localStorage.setItem("youtube_offline_playlist_state", JSON.stringify({
+      playlistId: "PL-freed-offline",
+      playlistUrl: "https://www.youtube.com/playlist?list=PL-freed-offline",
+    }));
+    let captureId = "";
+    mocks.invoke.mockImplementation(async (command: string, args?: unknown) => {
+      if (command === "yt_hide_login") {
+        expect(args).toEqual({ captureId });
+        return null;
+      }
+      expect(command).toBe("yt_capture");
+      const captureArgs = expectCaptureArgs(args, true);
+      captureId = captureArgs.captureId;
+      throw new Error("The YouTube website session is not signed in.");
+    });
+
+    const result = await captureYouTube("manual");
+
+    expect(result.diag.errorStage).toBe("auth");
+    expect(mocks.state.setYtAuth).toHaveBeenCalledWith(expect.objectContaining({
+      isAuthenticated: false,
+    }));
+    expect(getYouTubePlaylistState()).toEqual({});
+    expect(mocks.reconcile).not.toHaveBeenCalled();
+    expect(mocks.invoke).toHaveBeenLastCalledWith("yt_hide_login", { captureId });
   });
 
   it("uses the rendered playlist result and stores only nonsecret playlist metadata", async () => {

--- a/packages/desktop/tests/e2e/youtube-capture.spec.ts
+++ b/packages/desktop/tests/e2e/youtube-capture.spec.ts
@@ -70,27 +70,128 @@ test("authenticated YouTube login captures followed channels and recent videos",
     return hideIndex >= 0 && captureIndex > hideIndex;
   }).toBe(true);
 
+  let captureId = "";
+  await expect.poll(async () => {
+    const captureCall = (await ipc.invocations())
+      .findLast((call) => call.cmd === "yt_capture");
+    captureId = (captureCall?.args as { captureId?: string } | undefined)?.captureId ?? "";
+    return captureId.length;
+  }).toBeGreaterThan(0);
+
   await emitTauriEvent(page, "yt-capture-data", {
+    captureId,
+    stage: "channels",
     channels: [{ channelId, title: "Learning Channel" }],
+    videos: [],
+    channelTotal: 1,
+    videoTotal: 0,
+    unresolvedCount: 0,
+    scrollPasses: 1,
+    stopReason: "progress",
+    done: false,
+  });
+  await emitTauriEvent(page, "yt-capture-data", {
+    captureId,
+    stage: "channels",
+    channels: [],
+    videos: [],
+    rosterComplete: true,
+    complete: false,
+    channelTotal: 1,
+    videoTotal: 0,
+    unresolvedCount: 0,
+    scrollPasses: 2,
+    stopReason: "end-stable",
+    done: true,
+  });
+  await emitTauriEvent(page, "yt-capture-data", {
+    captureId,
+    stage: "subscriptions",
+    channels: [],
     videos: [{
       videoId: "dQw4w9WgXcQ",
       title: "Focused Study",
       channelId,
       channelTitle: "Learning Channel",
     }],
-    rosterComplete: true,
+    rosterComplete: false,
+    complete: false,
+    channelTotal: 1,
+    videoTotal: 1,
+    unresolvedCount: 0,
+    scrollPasses: 1,
+    stopReason: "progress",
+    done: false,
+  });
+  await emitTauriEvent(page, "yt-capture-data", {
+    captureId,
+    stage: "subscriptions",
+    channels: [],
+    videos: [],
+    rosterComplete: false,
     complete: true,
+    channelTotal: 1,
+    videoTotal: 1,
     unresolvedCount: 0,
     scrollPasses: 2,
-    stopReason: "stable",
+    stopReason: "end-stable",
     done: true,
   });
-  await page.evaluate(() => {
+  await page.evaluate(({ expectedCaptureId, expectedChannelId }) => {
     const globals = window as unknown as Record<string, unknown>;
     const resolve = globals.__YOUTUBE_CAPTURE_RESOLVE__ as ((value: unknown) => void) | undefined;
-    resolve?.(null);
+    const channel = { channelId: expectedChannelId, title: "Learning Channel" };
+    const video = {
+      videoId: "dQw4w9WgXcQ",
+      title: "Focused Study",
+      channelId: expectedChannelId,
+      channelTitle: "Learning Channel",
+    };
+    resolve?.({
+      stages: [{
+        captureId: expectedCaptureId,
+        stage: "channels",
+        channels: [channel],
+        videos: [],
+        rosterComplete: true,
+        complete: false,
+        channelTotal: 1,
+        videoTotal: 0,
+        candidateCount: 1,
+        unresolvedCount: 0,
+        scrollPasses: 2,
+        stopReason: "end-stable",
+        pageEvidence: true,
+        explicitEmpty: false,
+        unsupportedCandidateCount: 0,
+        workBudgetExceeded: false,
+        deadlineExceeded: false,
+        pendingContinuation: false,
+        done: true,
+      }, {
+        captureId: expectedCaptureId,
+        stage: "subscriptions",
+        channels: [channel],
+        videos: [video],
+        rosterComplete: false,
+        complete: true,
+        channelTotal: 1,
+        videoTotal: 1,
+        candidateCount: 1,
+        unresolvedCount: 0,
+        scrollPasses: 2,
+        stopReason: "end-stable",
+        pageEvidence: true,
+        explicitEmpty: false,
+        unsupportedCandidateCount: 0,
+        workBudgetExceeded: false,
+        deadlineExceeded: false,
+        pendingContinuation: false,
+        done: true,
+      }],
+    });
     delete globals.__YOUTUBE_CAPTURE_RESOLVE__;
-  });
+  }, { expectedCaptureId: captureId, expectedChannelId: channelId });
 
   await expect(page.getByText("Connected. Subscription sync finished.")).toBeVisible({
     timeout: 10_000,
@@ -123,7 +224,7 @@ test("YouTube login still syncs when the first hide request fails", async ({
   await ipc.setHandler("yt_hide_login", () => {
     throw new Error("Transient hide failure");
   });
-  await ipc.setHandler("yt_capture", () => {
+  await ipc.setHandler("yt_capture", (args) => {
     (window as unknown as Record<string, unknown>).__TAURI_MOCK_YOUTUBE_WINDOW_VISIBLE__ = false;
     const listeners = (
       window as unknown as Record<
@@ -131,18 +232,55 @@ test("YouTube login still syncs when the first hide request fails", async ({
         Record<string, Array<(event: { payload: unknown }) => void>>
       >
     ).__TAURI_EVENT_LISTENERS__ ?? {};
-    const payload = {
+    const captureId = (args as { captureId?: string } | undefined)?.captureId;
+    if (!captureId) throw new Error("Missing YouTube capture ID");
+    const channelsPayload = {
+      captureId,
+      stage: "channels",
       channels: [],
       videos: [],
       rosterComplete: true,
-      complete: true,
+      complete: false,
+      channelTotal: 0,
+      videoTotal: 0,
+      candidateCount: 0,
       unresolvedCount: 0,
       scrollPasses: 1,
-      stopReason: "stable",
+      stopReason: "end-stable",
+      pageEvidence: true,
+      explicitEmpty: true,
+      unsupportedCandidateCount: 0,
+      workBudgetExceeded: false,
+      deadlineExceeded: false,
+      pendingContinuation: false,
       done: true,
     };
-    for (const listener of listeners["yt-capture-data"] ?? []) listener({ payload });
-    return null;
+    const subscriptionsPayload = {
+      captureId,
+      stage: "subscriptions",
+      channels: [],
+      videos: [],
+      rosterComplete: false,
+      complete: true,
+      channelTotal: 0,
+      videoTotal: 0,
+      candidateCount: 0,
+      unresolvedCount: 0,
+      scrollPasses: 1,
+      stopReason: "end-stable",
+      pageEvidence: true,
+      explicitEmpty: true,
+      unsupportedCandidateCount: 0,
+      workBudgetExceeded: false,
+      deadlineExceeded: false,
+      pendingContinuation: false,
+      done: true,
+    };
+    for (const listener of listeners["yt-capture-data"] ?? []) {
+      listener({ payload: channelsPayload });
+      listener({ payload: subscriptionsPayload });
+    }
+    return { stages: [channelsPayload, subscriptionsPayload] };
   });
 
   await openYouTubeSettings(page);


### PR DESCRIPTION
(AI Generated).

## Summary
- Finish authenticated YouTube roster and subscriptions capture with bounded progress, cancellation, and exact terminal receipts.
- Destroy hidden YouTube capture windows after completion while preserving interactive login and playlist behavior.
- Fail closed on incomplete, ambiguous, or stale extraction evidence.

## Testing
- npm run validate:feature
- Independent exact diff review passed.

## Provider Visible Approval
- Approval ID: `youtube-capture-completion-timeout-20260714014018860`
- Approved by: AubreyF
- Owner reference: thread:019f4ce4-2558-7193-adac-728b6c3b2c74
- Approval source: owner-confirmation `thread:019f4ce4-2558-7193-adac-728b6c3b2c74`
- Owner authorization digest: `sha256:1edd1ea48ce116091b75e5543777c2c4b2689616f79f2f59ae7aa76059bb2fbe`
- Providers: youtube
- Observable behavior: Freed will keep the authenticated YouTube WebView open for a bounded capture window, perform incremental scripted scrolling on the followed channels and subscriptions pages, emit local progress events, cancel timed out work, and destroy the hidden session window when the operation finishes.
- Fingerprinting risk: YouTube can observe the longer page dwell time and regular scripted scrolling cadence. Those signals can make Freed capture traffic easier to distinguish from ordinary user browsing.
- Lowest profile alternative: Limit capture to the first visible subscriptions viewport and require the user to run each sync manually. This has a lower profile but cannot provide complete followed channel coverage.
- Approved diff: `758d2bada807921bc968c0b504e9f26f79ee03d3`
- Approved at: 2026-07-14T01:40:18.860Z
- Expires at: 2026-07-20T01:40:18.860Z

Provider visible paths in this diff:
- `packages/desktop/src-tauri/src/youtube-extract.js`
- `packages/desktop/src-tauri/src/youtube.rs`
- `packages/desktop/src/lib/youtube-capture.ts`