### PR TITLE
fix: recognize historical promotion commits

### DIFF
--- a/scripts/release-promotion-shared.mjs
+++ b/scripts/release-promotion-shared.mjs
@@ -37,7 +37,7 @@ export const PROMOTION_BRANCH_PATTERN =
   /^chore\/promote-dev-to-main(?:-[a-z0-9._-]+)?$/;
 export const RELEASE_PREP_BRANCH_PATTERN = /^chore\/release-[a-z0-9._-]+$/;
 export const PROMOTION_COMMIT_SUBJECT_PATTERN =
-  /^chore: promote dev into main(?: for production release)?(?: \(#\d+\))?$/;
+  /^chore: promote dev (?:into|to) main(?: for production release)?(?: \(#\d+\))?$/;
 export const REVERSE_INTEGRATION_COMMIT_SUBJECT_PATTERN =
   /^(?:chore|fix): (?:merge main (?:back )?into dev(?: .*)?|reverse integrate (?:main|v\d+\.\d+\.\d+)(?: into dev| after v\d+\.\d+\.\d+| production release)?|backflow v\d+\.\d+\.\d+ main into dev|sync main(?: release artifacts)?(?: back)? into dev(?: .*)?)(?: \(#\d+\))?$/;
 

--- a/scripts/release-promotion.test.mjs
+++ b/scripts/release-promotion.test.mjs
@@ -234,6 +234,43 @@ test("validate-main-backflow ignores squashed promotion content already in dev h
   assert.match(result.stdout, /Main backflow is in sync/);
 });
 
+test("validate-main-backflow accepts the historical promote dev to main subject", (t) => {
+  const cwd = makeTempRepo();
+  t.after(() => rmSync(cwd, { recursive: true, force: true }));
+
+  git(cwd, ["checkout", "dev"]);
+  writeRepoFile(
+    cwd,
+    "packages/pwa/src/app.ts",
+    "export const value = 'promoted';\n",
+  );
+  commitAll(cwd, "dev feature");
+  updateOriginRef(cwd, "dev");
+
+  git(cwd, ["checkout", "main"]);
+  git(cwd, ["merge", "--squash", "--no-commit", "dev"]);
+  git(cwd, ["commit", "-m", "chore: promote dev to main (#329)"]);
+  updateOriginRef(cwd, "main");
+
+  git(cwd, ["checkout", "dev"]);
+  writeRepoFile(
+    cwd,
+    "packages/pwa/src/app.ts",
+    "export const value = 'next dev change';\n",
+  );
+  commitAll(cwd, "next dev change");
+  updateOriginRef(cwd, "dev");
+
+  const result = runNode(VALIDATE_MAIN_BACKFLOW, [
+    `--cwd=${cwd}`,
+    "--dev-ref=origin/dev",
+    "--main-ref=origin/main",
+  ]);
+
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /Main backflow is in sync/);
+});
+
 test("validate-main-backflow fails when main has product content absent from dev", (t) => {
   const cwd = makeTempRepo();
   t.after(() => rmSync(cwd, { recursive: true, force: true }));


### PR DESCRIPTION
(AI Generated).

## Summary
- Accept the existing promote dev to main commit subject in main backflow validation so fresh feature work is not blocked by a false positive.

## Testing
- node --test scripts/release-promotion.test.mjs
- npm run validate:feature
- node scripts/validate-main-backflow.mjs --dev-ref=origin/dev --main-ref=origin/main