### PR TITLE
feat: add dedicated release tag publisher

### DIFF
--- a/docs/AUTOMATION-CONTROL-PLANE.md
+++ b/docs/AUTOMATION-CONTROL-PLANE.md
@@ -21,7 +21,7 @@ release.
 | `~/.freed/automation/control/task-transactions/`  | Recoverable write-ahead records that bind each task revision to its audit event                                                                           |
 | `~/.freed/automation/control/events.jsonl`        | Append-only audit history for task, authority, lease, and observer events                                                                                 |
 | `~/.freed/automation/control/leases/`             | Token-bound leases that prevent duplicate writers                                                                                                         |
-| `~/.freed/automation/control/actor-credentials/`  | Private local credential records used by pinned general actor launchers to acquire canonical role leases                                                   |
+| `~/.freed/automation/control/actor-credentials/`  | Private local credential records used by pinned general actor launchers to acquire canonical role leases                                                  |
 | `~/.freed/automation/control/owner-capabilities/` | Broker-signed one-use owner governance capabilities, split into pending and consumed records                                                              |
 | `~/.freed/automation/outcomes.jsonl`              | Versioned merge, install, and observed-effect outcomes                                                                                                    |
 | `~/.freed/automation/soaks/`                      | Installed-build evidence windows and verdicts                                                                                                             |
@@ -310,30 +310,35 @@ authority, provider policy, stored task authority, or lifecycle destinations.
 Release tags have a separate external trust boundary. The checked-in
 `release-tag-lockdown.json` is the bootstrap authority. Apply it with
 `--lock-release-tags --apply` before App provisioning. It restricts creation,
-update, and deletion with no bypass in one API mutation. The separate creation
-and immutability policies describe the activated end state. Activation first
-requires an owner-reviewed change that pins the creation policy to the exact App
-ID. It then uses
-`node scripts/sync-github-rulesets.mjs --release-tags --release-app-id <id> --release-app-slug <slug> --apply`.
-The command verifies the public App identity, an unsuspended installation with
-Contents write permission, exact repository access, and the fixed root-owned
-publisher binding at `/Library/Application Support/Freed/release-tag-publisher.json`
-before it applies either policy. It verifies both split policies live before it
-removes the bootstrap lockdown. The creation policy grants that App one bypass.
-The immutability policy grants none. The PR publisher App, user
-identities, administrator roles, teams, and deploy keys are never acceptable
-substitutes.
+update, and deletion with no bypass. `release-tag-publisher-install.mjs prepare`
+builds and installs the fixed root-owned native host and provisioner. The
+manifest helper then creates the private `Freed Release Publisher` organization
+App, pipes its private key into the native provisioner, activates the digest
+pinned binding, and requires a selected-repository installation for only
+`freed-project/freed`. The Keychain item uses service
+`freed-release-tag-publisher` and account `github-app-private-key`.
+
+Activation requires an owner-reviewed change that pins the App ID in the
+creation policy. The release ruleset command verifies the exact App,
+installation, repository, permission, native binding, and publisher proof. It
+then applies the creation and immutability policies, verifies both live, and
+only then removes the lockdown. The creation policy grants the release App one
+bypass. The immutability policy grants none. The full owner runbook is in
+`docs/RELEASE-SECRETS.md`.
 
 `scripts/release-publish.sh` fails closed until the live release-tag policy is
 active. It also requires the release commit to equal the current protected
 channel branch, validates the fixed product and promoted dev receipts, rejects
 an existing local or remote tag, and delegates one exact annotated-tag creation
 through the same fixed root-owned publisher binding used during activation. The
-binding, parent chain, executable digest, App identity, and broker attestation
-are rechecked immediately before use. That broker rechecks the branch tip and receipt at
-push time, then obtains a short-lived installation credential. The delayed
-workflow checks that the tag commit remains in protected channel history. It
-does not compare against a moving branch tip or a later dev snapshot.
+binding, parent chain, executable digest, App identity, Keychain credential,
+selected repository, and installation permissions are rechecked immediately
+before use. The native host rechecks the branch tip and receipt at publication,
+then obtains and revokes one short-lived installation token. It does not accept
+a user token, personal access token, general actor credential, or the separate
+PR publisher as a tag-creation fallback. The delayed workflow checks that the
+tag commit remains in protected channel history. It does not compare against a
+moving branch tip or a later dev snapshot.
 
 The optional broker-backed PR publisher uses a separate fail-closed identity contract. It does not
 accept `FREED_AUTOMATION_ACTOR_TOKEN` or

--- a/docs/PHASE-10-POLISH.md
+++ b/docs/PHASE-10-POLISH.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-Final polish, accessibility, UX refinements, global animation controls, Integrated AI pack selection, local semantic enrichment for friend suggestions, and community infrastructure.
+Final polish, accessibility, UX refinements, global animation controls, Integrated AI pack selection, local semantic enrichment for friend suggestions, governed release automation, and community infrastructure.
 
 ---
 
@@ -296,7 +296,7 @@ Generate summaries for long-form content.
 // packages/pwa/src/lib/ai/summarize.ts
 export async function summarizeContent(
   content: string,
-  maxLength: number = 200
+  maxLength: number = 200,
 ): Promise<string> {
   // Runs locally or via user-provided API
   const summarizer = await getSummarizer();
@@ -406,24 +406,24 @@ Reward security researchers for responsible disclosure.
 | 10.4  | Export to CSV                      | Low        |
 | 10.5  | Keyboard shortcuts                 | Medium     | ✓ Complete (PWA reader keys, command palette, navigation history keys, and Freed Desktop Save Content shortcut) |
 | 10.6  | Screen reader support              | Medium     |
-| 10.7  | Reduced motion support             | Low        | ✓ Complete (Appearance animation intensity controls plus global app motion gating)
+| 10.7  | Reduced motion support             | Low        | ✓ Complete (Appearance animation intensity controls plus global app motion gating)                              |
 | 10.8  | Color contrast audit               | Low        |
 | 10.9  | Native Liquid Glass buttons        | High       |
-| 10.24 | Command bar — full action launcher | High       | ✓ Complete (Global `Cmd/Ctrl+K` palette with navigation, creation, current-item, sync, and danger actions)
+| 10.24 | Command bar: full action launcher | High       | ✓ Complete (Global `Cmd/Ctrl+K` palette with navigation, creation, current-item, sync, and danger actions)      |
 
 ### AI Features
 
-| Task  | Description              | Complexity |
-| ----- | ------------------------ | ---------- |
-| 10.10 | Topic extraction (local) | High       | ✓ Complete (Ollama via ai-summarizer.ts)
-| 10.11 | Topic extraction (API)   | Medium     | ✓ Complete (OpenAI/Anthropic/Gemini adapters)
-| 10.12 | Content summarization    | High       | ✓ Complete (summarize() in content-fetcher.ts)
-| 10.13 | Sentiment analysis       | Medium     | ✓ Complete (AISummary.sentiment field)
-| 10.14 | Smart notifications      | High       |
-| 10.15 | AI settings UI           | Medium     | ✓ Complete (Freed Desktop provider selector for Integrated AI, Ollama, OpenAI, Anthropic, and Gemini with provider-scoped sharing tags, optimistic selection, default workflows when AI is enabled, and no PWA controls for AI paths the browser cannot run)
-| 10.25 | Local content signals    | Medium     | ✓ Complete (rule-based contentSignals metadata, automatic ingestion inference, resumable desktop and PWA semantic backfill, inclusive saved toolbar filter presets, saved sort controls, expanded signal taxonomy, and compact event candidate extraction)
-| 10.26 | Optional local AI packs  | High       | ✓ Complete (disabled-by-default Light, Balanced, and Pro Integrated AI packs, hardware-based recommendations, pinned download manifests, semantic scan health, source links, resumable desktop downloads, raw-file checksum verification, and removal controls)
-| 10.27 | Local AI signal consumers | Medium | ✓ Complete (Friends suggestions improve from Integrated AI `Topics and ranking` contentSignals while still working deterministically when AI is off)
+| Task  | Description               | Complexity |
+| ----- | ------------------------- | ---------- |
+| 10.10 | Topic extraction (local)  | High       | ✓ Complete (Ollama via ai-summarizer.ts)                                                                                                                                                                                                                        |
+| 10.11 | Topic extraction (API)    | Medium     | ✓ Complete (OpenAI/Anthropic/Gemini adapters)                                                                                                                                                                                                                   |
+| 10.12 | Content summarization     | High       | ✓ Complete (summarize() in content-fetcher.ts)                                                                                                                                                                                                                  |
+| 10.13 | Sentiment analysis        | Medium     | ✓ Complete (AISummary.sentiment field)                                                                                                                                                                                                                          |
+| 10.14 | Smart notifications       | High       |
+| 10.15 | AI settings UI            | Medium     | ✓ Complete (Freed Desktop provider selector for Integrated AI, Ollama, OpenAI, Anthropic, and Gemini with provider-scoped sharing tags, optimistic selection, default workflows when AI is enabled, and no PWA controls for AI paths the browser cannot run)    |
+| 10.25 | Local content signals     | Medium     | ✓ Complete (rule-based contentSignals metadata, automatic ingestion inference, resumable desktop and PWA semantic backfill, inclusive saved toolbar filter presets, saved sort controls, expanded signal taxonomy, and compact event candidate extraction)      |
+| 10.26 | Optional local AI packs   | High       | ✓ Complete (disabled-by-default Light, Balanced, and Pro Integrated AI packs, hardware-based recommendations, pinned download manifests, semantic scan health, source links, resumable desktop downloads, raw-file checksum verification, and removal controls) |
+| 10.27 | Local AI signal consumers | Medium     | ✓ Complete (Friends suggestions improve from Integrated AI `Topics and ranking` contentSignals while still working deterministically when AI is off)                                                                                                            |
 
 ### Extensibility
 
@@ -439,15 +439,15 @@ Reward security researchers for responsible disclosure.
 | ----- | -------------------- | ---------- |
 | 10.19 | Discord server setup | Low        |
 | 10.20 | Bug bounty program   | Medium     |
-| 10.21 | Release automation   | Medium     |
+| 10.21 | Release automation   | Medium     | ✓ Complete (reviewed release prep, protected branch promotion, dedicated release App provisioning, root-owned native tag publication, split tag rulesets, and fail-closed release identity checks) |
 | 10.22 | Documentation site   | Medium     |
 
 ### Resilience
 
-| Task  | Description                     | Complexity |
-| ----- | ------------------------------- | ---------- |
-| 10.23 | Crash / stale-bundle recovery dialog with in-place updater fallback | Medium |
-| 10.24 | Public-safe and private bug reporting flow | Medium |
+| Task  | Description                                                         | Complexity |
+| ----- | ------------------------------------------------------------------- | ---------- |
+| 10.23 | Crash / stale-bundle recovery dialog with in-place updater fallback | Medium     |
+| 10.24 | Public-safe and private bug reporting flow                          | Medium     |
 
 ---
 
@@ -478,6 +478,7 @@ Reward security researchers for responsible disclosure.
 - [ ] Discord server active
 - [ ] Bug bounty program published
 - [ ] Regular release schedule established
+- [x] Release automation permits only one dedicated selected-repository GitHub App to create the exact approved annotated tag through a root-owned native publisher, keeps tag updates and deletion without bypass, and fails closed on any identity, branch, receipt, installation, or digest mismatch
 - [x] Local nightly improvement runner ranks preflight risks, duplicate peer work, peer worktree, bug fix, performance, stability, release, and roadmap targets before autonomous work begins, with strict machine preflight, runnable canonical task gating, an atomic task and target-scoped lease control plane, checked-in actor authority, owner-run general actor provisioning with pinned root-owned runtimes and short-lived handoff, pending outcome transactions, evidence-derived comparisons, full installed identity, process-identity collector locks, portable dual-source canary bundles, verified historical cohorts, versioned stability artifacts, a separate signed publisher handoff scaffold with fail-closed host readiness, provider-visible draft review gates, local soak pointer repair, typed preflight actions, dev-branch context checks, and unattended app-interaction continuation rules
 - [ ] Documentation site live
 

--- a/docs/RELEASE-SECRETS.md
+++ b/docs/RELEASE-SECRETS.md
@@ -5,10 +5,10 @@ certain secrets to be configured in the GitHub repository settings.
 
 ## Required (for any release)
 
-| Secret | Description |
-|--------|-------------|
-| `TAURI_SIGNING_PRIVATE_KEY` | Contents of `~/.tauri/freed.key`. Used to sign update artifacts so the in-app updater can verify them. |
-| `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` | Password for the private key. Empty string if generated without one. |
+| Secret                               | Description                                                                                            |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------ |
+| `TAURI_SIGNING_PRIVATE_KEY`          | Contents of `~/.tauri/freed.key`. Used to sign update artifacts so the in-app updater can verify them. |
+| `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` | Password for the private key. Empty string if generated without one.                                   |
 
 The corresponding **public key** is already embedded in
 `packages/desktop/src-tauri/tauri.conf.json` under `plugins.updater.pubkey`.
@@ -19,15 +19,15 @@ These are required for macOS release builds. The release workflow now fails
 on macOS if any required Apple secret is missing so we never publish an
 unsigned DMG by accident.
 
-| Secret | Description |
-|--------|-------------|
-| `APPLE_CERTIFICATE` | Base64-encoded `.p12` Developer ID Application certificate |
-| `APPLE_CERTIFICATE_PASSWORD` | Password for the `.p12` file |
-| `APPLE_SIGNING_IDENTITY` | e.g. `Developer ID Application: Your Name (TEAMID)` |
-| `APPLE_TEAM_ID` | 10-character Apple Team ID |
-| `APPLE_ID` | Apple ID email for notarization |
-| `APPLE_PASSWORD` | App-specific password for notarization (generate at appleid.apple.com) |
-| `APPLE_PROVIDER_SHORT_NAME` | Optional. Required only if the Apple ID belongs to multiple provider teams |
+| Secret                       | Description                                                                |
+| ---------------------------- | -------------------------------------------------------------------------- |
+| `APPLE_CERTIFICATE`          | Base64-encoded `.p12` Developer ID Application certificate                 |
+| `APPLE_CERTIFICATE_PASSWORD` | Password for the `.p12` file                                               |
+| `APPLE_SIGNING_IDENTITY`     | e.g. `Developer ID Application: Your Name (TEAMID)`                        |
+| `APPLE_TEAM_ID`              | 10-character Apple Team ID                                                 |
+| `APPLE_ID`                   | Apple ID email for notarization                                            |
+| `APPLE_PASSWORD`             | App-specific password for notarization (generate at appleid.apple.com)     |
+| `APPLE_PROVIDER_SHORT_NAME`  | Optional. Required only if the Apple ID belongs to multiple provider teams |
 
 ### How to export the certificate
 
@@ -53,13 +53,13 @@ and disabled scaffold live in `docs/WINDOWS-SIGNING.md`.
 
 Planned GitHub configuration:
 
-| Secret or variable | Description |
-|--------------------|-------------|
-| `AZURE_TENANT_ID` | Microsoft Entra tenant ID |
-| `AZURE_CLIENT_ID` | App registration client ID for GitHub Actions OIDC |
-| `WINDOWS_TRUSTED_SIGNING_ACCOUNT_NAME` | Microsoft Artifact Signing account name |
-| `WINDOWS_TRUSTED_SIGNING_CERT_PROFILE` | Public Trust certificate profile name |
-| `WINDOWS_TRUSTED_SIGNING_ENDPOINT` | Region endpoint, for example `https://eus.codesigning.azure.net/` |
+| Secret or variable                     | Description                                                       |
+| -------------------------------------- | ----------------------------------------------------------------- |
+| `AZURE_TENANT_ID`                      | Microsoft Entra tenant ID                                         |
+| `AZURE_CLIENT_ID`                      | App registration client ID for GitHub Actions OIDC                |
+| `WINDOWS_TRUSTED_SIGNING_ACCOUNT_NAME` | Microsoft Artifact Signing account name                           |
+| `WINDOWS_TRUSTED_SIGNING_CERT_PROFILE` | Public Trust certificate profile name                             |
+| `WINDOWS_TRUSTED_SIGNING_ENDPOINT`     | Region endpoint, for example `https://eus.codesigning.azure.net/` |
 
 Do not add `AZURE_CLIENT_SECRET` unless GitHub Actions OIDC cannot be made to
 work. If a client secret is used temporarily, document its expiration and
@@ -120,65 +120,144 @@ On Vercel, the current project configuration uses `GITHUB_RELEASES_TOKEN`.
 
 Release tags are an external trust boundary. GitHub loads a tag-push workflow
 from the tagged commit, so a workflow cannot prove that its own source was
-reviewed. Two live rulesets form the root control. `Freed release tag creation`
-targets every `refs/tags/v*` tag and grants its only bypass to one dedicated
-release GitHub App with repository Contents write permission. `Freed release
-tag immutability` targets the same tags and restricts update and deletion with
-no bypass, including no bypass for the release App.
+reviewed. Release tags remain intentionally locked until the owner completes
+this runbook. Checked-in publisher code is not proof that the App or its live
+rulesets are active.
 
-The checked-in `.github/rulesets/release-tag-lockdown.json` policy is the safe
-bootstrap. Apply it before App provisioning. It blocks creation, update, and
-deletion with no bypass in one API mutation. The checked-in creation and
-immutability policies then describe the split activated state. Do not add a
-user, administrator role, team, deploy key, or the PR publisher App as a
-substitute.
+### Apply the bootstrap lockdown
+
+The checked-in `.github/rulesets/release-tag-lockdown.json` policy blocks
+creation, update, and deletion for every `refs/tags/v*` tag with no bypass.
+Select the repository Node version, then apply the lockdown before building or
+provisioning the publisher. The App helper uses that exact Node executable when
+it activates the binding:
 
 ```bash
+nvm use --silent
 node scripts/sync-github-rulesets.mjs --lock-release-tags --apply
 ```
 
-After the dedicated release App and root-owned publisher are installed for
-`freed-project/freed`, an owner-reviewed PR must pin the App ID in the creation
-policy and set that policy active. Then an owner can verify and apply both
-rulesets:
+Do not add a user, administrator role, team, deploy key, personal access token,
+general automation actor, or the PR publisher App as a bypass.
+
+### Prepare the native publisher
+
+Run the owner helper from the reviewed source checkout:
+
+```bash
+node scripts/release-tag-publisher-install.mjs prepare
+```
+
+The helper runs `scripts/release-tag-publisher-build.sh` in a private temporary
+directory, builds the native Swift host and provisioner, and installs them as
+root-owned, read-only executables at these fixed paths:
+
+- `/Library/Application Support/Freed/release-tag-publisher`
+- `/Library/Application Support/Freed/release-tag-publisher-provision`
+
+The binding does not exist yet, so publication still fails closed.
+
+### Create and install the release App
+
+Use the manifest helper for normal provisioning:
+
+```bash
+node scripts/create-release-github-app.mjs
+```
+
+The helper opens a loopback GitHub manifest flow for the private organization
+App `Freed Release Publisher`, with slug `freed-release-publisher`. The manifest
+requests only repository Contents write permission. GitHub adds Metadata read
+implicitly. The App subscribes to no events, has no OAuth flow, and keeps its
+required webhook inactive.
+
+The helper converts the manifest, pipes the returned private key directly to
+the fixed native provisioner, and never writes the key to disk. The provisioner
+stores it in the macOS Keychain with:
+
+- service `freed-release-tag-publisher`
+- account `github-app-private-key`
+
+The Keychain ACL permits only the installed native host and provisioner. The
+helper then installs the root-owned binding at
+`/Library/Application Support/Freed/release-tag-publisher.json`, opens the App
+installation page, and waits for an active selected-repository installation
+whose only repository is `freed-project/freed`.
+
+The binding pins the repository, App ID, App slug, publisher path, and publisher
+SHA-256 digest. The nonsecret App identity is also recorded at
+`~/.freed/automation/release-tag-publisher/github-app.json`. Neither file
+contains the private key.
+
+### Activate the split tag rulesets
+
+Add the returned App ID to `.github/rulesets/release-tags.json` as the only
+`Integration` bypass actor, then merge that change through an owner-reviewed
+pull request. After the exact App ID is present on the protected branch, apply
+the split policies:
 
 ```bash
 node scripts/sync-github-rulesets.mjs \
   --release-tags \
   --release-app-id <github-app-id> \
-  --release-app-slug <github-app-slug> \
+  --release-app-slug freed-release-publisher \
   --apply
 ```
 
-The fixed root-owned binding at
-`/Library/Application Support/Freed/release-tag-publisher.json` pins the App,
-publisher path, and executable SHA-256 digest. Activation and every publication
-recheck that file, its parent chain, the executable, and the broker attestation.
-The binding schema is:
+Activation verifies the live lockdown, private App metadata through the native
+App JWT, an independent unsuspended organization installation, exact selected
+repository, exact permissions, empty event list, root-owned binding, executable
+digest, Keychain-backed App proof, and native publisher attestation. It applies
+`Freed release tag creation` with the dedicated App as its only bypass and
+`Freed release tag immutability` with no bypass. It reads both policies back
+from GitHub before removing the bootstrap lockdown. A partial activation leaves
+the lockdown in place.
 
-```json
-{
-  "schemaVersion": 1,
-  "purpose": "freed-release-tag-publisher-binding",
-  "status": "active",
-  "repo": "freed-project/freed",
-  "appId": 123456,
-  "appSlug": "freed-release-publisher",
-  "publisherPath": "/Library/Application Support/Freed/release-tag-publisher",
-  "publisherSha256": "<64 lowercase hexadecimal characters>"
-}
+### Verify, publish, rotate, or revoke
+
+Verify the installed publisher and its live App installation at any time:
+
+```bash
+node scripts/release-tag-publisher-install.mjs verify
+node scripts/validate-release-tag-authority.mjs --repo=freed-project/freed
 ```
 
-The binding, publisher executable, and every parent directory must be owned by
-root and must not be group or world writable. The executable must attest the
-same repository, App identity, digest, short-lived installation-token mode, and
-single `create-annotated-tag` operation before ruleset activation or release.
-The release publisher must request a short-lived installation token and expose
-only one operation: create the exact approved annotated tag at the exact current
-protected branch commit. It must not expose arbitrary refs, commits, updates,
-or deletions. `release-publish.sh` fails before publication when the checked-in
-App ID, either live ruleset, the publisher path, or any tag precondition is
-missing.
+`./scripts/release-publish.sh <version>` remains the only release entry point.
+It rejects a dirty or wrong branch, a commit that differs from the protected
+remote tip, an unapproved or mismatched release receipt, an existing tag, a
+missing live policy, a changed publisher digest, or a mismatched App
+installation. The native host requests one short-lived installation token
+scoped to `freed-project/freed`, rechecks the remote branch and committed
+receipt, creates one annotated tag, verifies the result, and revokes the token.
+It exposes no arbitrary ref, update, or deletion operation.
+
+Read-only GitHub checks may use the current `gh` login. Tag creation never
+falls back to `GITHUB_TOKEN`, `GH_TOKEN`, a personal access token, a user push,
+or a general automation credential.
+
+For key rotation, create a replacement private key in the GitHub App settings
+and keep the previous GitHub key active until verification succeeds. Save the
+replacement briefly as an absolute, current-user-owned mode `0600` file, then
+run:
+
+```bash
+node scripts/release-tag-publisher-install.mjs rotate \
+  --private-key-file /absolute/path/to/replacement.pem
+node scripts/release-tag-publisher-install.mjs verify
+```
+
+After verification, delete the old key in GitHub and remove the temporary PEM.
+The installer also exposes `provision` and `activate` for controlled recovery,
+but the manifest helper is the normal setup path because it keeps the initial
+private key off disk.
+
+To retire the publisher, restore the no-bypass lockdown first, then revoke the
+local key and binding:
+
+```bash
+node scripts/sync-github-rulesets.mjs --lock-release-tags --apply
+node scripts/release-tag-publisher-install.mjs revoke
+```
 
 ## Drafting release notes
 
@@ -203,8 +282,8 @@ That command:
 
 Optional local environment variable:
 
-| Variable | Description |
-|----------|-------------|
+| Variable         | Description                                                                |
+| ---------------- | -------------------------------------------------------------------------- |
 | `OPENAI_API_KEY` | Enables stronger AI-generated draft release notes during the prepare step. |
 
 Review and edit:

--- a/docs/roadmap-status.json
+++ b/docs/roadmap-status.json
@@ -26,7 +26,11 @@
       "status": "upcoming",
       "source": "docs/PHASE-9-BROWSER-EXTENSION.md"
     },
-    { "id": 10, "status": "upcoming", "source": "docs/PHASE-10-POLISH.md" },
+    {
+      "id": 10,
+      "status": "upcoming",
+      "source": "docs/PHASE-10-POLISH.md"
+    },
     { "id": 11, "status": "upcoming", "source": "docs/PHASE-11-OPENCLAW.md" },
     {
       "id": 12,

--- a/scripts/create-release-github-app.mjs
+++ b/scripts/create-release-github-app.mjs
@@ -1,0 +1,633 @@
+#!/usr/bin/env node
+
+import { execFileSync, spawnSync } from "node:child_process";
+import { randomBytes, randomUUID, timingSafeEqual } from "node:crypto";
+import {
+  chmodSync,
+  closeSync,
+  existsSync,
+  fsyncSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { verifyReleaseTagPublisherInstallationReadiness } from "./lib/release-tag-publisher.mjs";
+
+export const RELEASE_GITHUB_APP_ORGANIZATION = "freed-project";
+export const RELEASE_GITHUB_APP_REPO = "freed-project/freed";
+export const RELEASE_GITHUB_APP_NAME = "Freed Release Publisher";
+export const RELEASE_GITHUB_APP_SLUG = "freed-release-publisher";
+export const RELEASE_TAG_PUBLISHER_PATH =
+  "/Library/Application Support/Freed/release-tag-publisher";
+export const RELEASE_TAG_PUBLISHER_PROVISIONER_PATH =
+  "/Library/Application Support/Freed/release-tag-publisher-provision";
+
+const CALLBACK_PATH = "/github-app/callback";
+const BOOTSTRAP_PATH = "/";
+const MANIFEST_TIMEOUT_MS = 15 * 60 * 1000;
+const INSTALLATION_TIMEOUT_MS = 15 * 60 * 1000;
+const INSTALLATION_POLL_MS = 2_000;
+const SCRIPT_DIRECTORY = path.dirname(fileURLToPath(import.meta.url));
+export const RELEASE_TAG_PUBLISHER_INSTALLER_PATH = path.join(
+  SCRIPT_DIRECTORY,
+  "release-tag-publisher-install.mjs",
+);
+
+function hasExactKeys(value, keys) {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    JSON.stringify(Object.keys(value).sort()) ===
+      JSON.stringify([...keys].sort())
+  );
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+function safeEqual(left, right) {
+  const leftBytes = Buffer.from(String(left));
+  const rightBytes = Buffer.from(String(right));
+  return (
+    leftBytes.length === rightBytes.length &&
+    timingSafeEqual(leftBytes, rightBytes)
+  );
+}
+
+function sleep(delayMs) {
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+function stateRoot(candidate = undefined) {
+  const configured =
+    candidate ??
+    process.env.FREED_AUTOMATION_STATE_ROOT ??
+    path.join(os.homedir(), ".freed", "automation");
+  if (!path.isAbsolute(configured)) {
+    throw new Error("The release App state root must be absolute.");
+  }
+  return path.resolve(configured);
+}
+
+function verifyPreparedExecutable(filePath, label) {
+  if (
+    !path.isAbsolute(filePath) ||
+    !existsSync(filePath) ||
+    realpathSync(filePath) !== filePath
+  ) {
+    throw new Error(`${label} is not installed at its fixed path.`);
+  }
+  const link = lstatSync(filePath);
+  const metadata = statSync(filePath);
+  if (
+    link.isSymbolicLink() ||
+    !metadata.isFile() ||
+    metadata.uid !== 0 ||
+    (metadata.mode & 0o022) !== 0 ||
+    (metadata.mode & 0o111) === 0
+  ) {
+    throw new Error(`${label} is not a trusted root-owned executable.`);
+  }
+  let parent = path.dirname(filePath);
+  while (true) {
+    const parentMetadata = statSync(parent);
+    if (
+      !parentMetadata.isDirectory() ||
+      parentMetadata.uid !== 0 ||
+      (parentMetadata.mode & 0o022) !== 0
+    ) {
+      throw new Error(`${label} has an untrusted parent directory.`);
+    }
+    const next = path.dirname(parent);
+    if (next === parent) break;
+    parent = next;
+  }
+}
+
+export function verifyPreparedReleaseTagPublisher({
+  publisherPath = RELEASE_TAG_PUBLISHER_PATH,
+  provisionerPath = RELEASE_TAG_PUBLISHER_PROVISIONER_PATH,
+} = {}) {
+  verifyPreparedExecutable(publisherPath, "The release tag publisher host");
+  verifyPreparedExecutable(
+    provisionerPath,
+    "The release tag publisher provisioner",
+  );
+  return { ready: true, publisherPath, provisionerPath };
+}
+
+export function buildReleaseGitHubAppManifest({ origin }) {
+  const callbackUrl = new URL(CALLBACK_PATH, origin).toString();
+  const webhookUrl = new URL("/github-app/inactive-webhook", origin).toString();
+  return {
+    name: RELEASE_GITHUB_APP_NAME,
+    url: "https://freed.wtf",
+    description:
+      "Creates one reviewed immutable release tag for freed-project/freed.",
+    hook_attributes: { url: webhookUrl, active: false },
+    redirect_url: callbackUrl,
+    public: false,
+    default_permissions: { contents: "write" },
+    default_events: [],
+    request_oauth_on_install: false,
+    setup_on_update: false,
+  };
+}
+
+export function buildManifestBootstrapHtml({ manifest, state }) {
+  const action = new URL(
+    `https://github.com/organizations/${RELEASE_GITHUB_APP_ORGANIZATION}/settings/apps/new`,
+  );
+  action.searchParams.set("state", state);
+  return `<!doctype html>
+<html lang="en">
+  <head><meta charset="utf-8"><title>Create Freed Release Publisher</title></head>
+  <body>
+    <p>Opening GitHub App registration.</p>
+    <form id="release-app-manifest" method="post" action="${escapeHtml(action)}">
+      <input type="hidden" name="manifest" value="${escapeHtml(JSON.stringify(manifest))}">
+    </form>
+    <script>document.getElementById("release-app-manifest").submit();</script>
+  </body>
+</html>`;
+}
+
+export function parseManifestCallback(requestUrl, expectedState, origin) {
+  const callback = new URL(requestUrl, origin);
+  if (callback.pathname !== CALLBACK_PATH) {
+    throw new Error("The GitHub App callback path is invalid.");
+  }
+  const states = callback.searchParams.getAll("state");
+  const codes = callback.searchParams.getAll("code");
+  if (states.length !== 1 || !safeEqual(states[0], expectedState)) {
+    throw new Error("The GitHub App callback state is invalid.");
+  }
+  if (codes.length !== 1 || !/^[A-Za-z0-9_-]{20,255}$/.test(codes[0])) {
+    throw new Error("The GitHub App callback code is invalid.");
+  }
+  return { code: codes[0] };
+}
+
+export async function exchangeManifestCode(
+  code,
+  { fetchImpl = globalThis.fetch } = {},
+) {
+  if (!/^[A-Za-z0-9_-]{20,255}$/.test(code)) {
+    throw new Error("The GitHub App manifest code is invalid.");
+  }
+  const response = await fetchImpl(
+    `https://api.github.com/app-manifests/${encodeURIComponent(code)}/conversions`,
+    {
+      method: "POST",
+      headers: {
+        Accept: "application/vnd.github+json",
+        "User-Agent": "Freed-release-app-bootstrap",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    },
+  );
+  if (!response?.ok) {
+    throw new Error(
+      `GitHub App manifest conversion failed with status ${Number(response?.status ?? 0).toLocaleString()}.`,
+    );
+  }
+  return response.json();
+}
+
+export function validateManifestConversion(conversion) {
+  const appId = Number(conversion?.id);
+  const ownerId = Number(conversion?.owner?.id);
+  const pem = conversion?.pem;
+  if (
+    !Number.isSafeInteger(appId) ||
+    appId <= 0 ||
+    conversion?.slug !== RELEASE_GITHUB_APP_SLUG ||
+    conversion?.name !== RELEASE_GITHUB_APP_NAME ||
+    conversion?.external_url !== "https://freed.wtf" ||
+    JSON.stringify(Object.keys(conversion?.permissions ?? {}).sort()) !==
+      JSON.stringify(["contents", "metadata"]) ||
+    conversion.permissions.contents !== "write" ||
+    conversion.permissions.metadata !== "read" ||
+    JSON.stringify(conversion?.events ?? []) !== JSON.stringify([]) ||
+    !Number.isSafeInteger(ownerId) ||
+    ownerId <= 0 ||
+    conversion?.owner?.login !== RELEASE_GITHUB_APP_ORGANIZATION ||
+    conversion?.owner?.type !== "Organization" ||
+    typeof pem !== "string" ||
+    pem.length < 256 ||
+    pem.length > 32 * 1024 ||
+    !/^-----BEGIN RSA PRIVATE KEY-----\n[\s\S]+\n-----END RSA PRIVATE KEY-----\n?$/.test(
+      pem,
+    )
+  ) {
+    throw new Error(
+      "GitHub App manifest conversion did not return the expected private organization App identity.",
+    );
+  }
+  const identity = {
+    schemaVersion: 1,
+    purpose: "freed-release-github-app-identity",
+    organization: RELEASE_GITHUB_APP_ORGANIZATION,
+    repo: RELEASE_GITHUB_APP_REPO,
+    appId,
+    appSlug: RELEASE_GITHUB_APP_SLUG,
+    ownerId,
+  };
+  return { identity, pem };
+}
+
+export function provisionReleaseAppPrivateKey(
+  pem,
+  {
+    spawn = spawnSync,
+    provisionerPath = RELEASE_TAG_PUBLISHER_PROVISIONER_PATH,
+    publisherPath = RELEASE_TAG_PUBLISHER_PATH,
+  } = {},
+) {
+  const result = spawn(
+    provisionerPath,
+    ["provision", "--host", publisherPath],
+    {
+      input: pem,
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "pipe"],
+      maxBuffer: 1024 * 1024,
+    },
+  );
+  if (result?.error || result?.status !== 0) {
+    throw new Error(
+      "The installed release tag publisher provisioner rejected the GitHub App private key.",
+    );
+  }
+}
+
+export function activateReleaseTagPublisherBinding(
+  identity,
+  {
+    exec = execFileSync,
+    nodePath = process.execPath,
+    installerPath = RELEASE_TAG_PUBLISHER_INSTALLER_PATH,
+  } = {},
+) {
+  try {
+    exec(
+      nodePath,
+      [
+        installerPath,
+        "activate",
+        "--app-id",
+        identity.appId.toLocaleString("en-US", { useGrouping: false }),
+        "--app-slug",
+        identity.appSlug,
+      ],
+      { stdio: "inherit" },
+    );
+  } catch {
+    throw new Error(
+      "The release tag publisher installer could not activate the App binding.",
+    );
+  }
+}
+
+export function releaseAppIdentityPath(candidateStateRoot = undefined) {
+  return path.join(
+    stateRoot(candidateStateRoot),
+    "release-tag-publisher",
+    "github-app.json",
+  );
+}
+
+export function writeReleaseAppIdentity(
+  identity,
+  { stateRoot: candidateStateRoot = undefined } = {},
+) {
+  if (
+    !hasExactKeys(identity, [
+      "appId",
+      "appSlug",
+      "organization",
+      "ownerId",
+      "purpose",
+      "repo",
+      "schemaVersion",
+    ]) ||
+    identity.schemaVersion !== 1 ||
+    identity.purpose !== "freed-release-github-app-identity" ||
+    identity.organization !== RELEASE_GITHUB_APP_ORGANIZATION ||
+    identity.repo !== RELEASE_GITHUB_APP_REPO ||
+    !Number.isSafeInteger(identity.appId) ||
+    identity.appId <= 0 ||
+    identity.appSlug !== RELEASE_GITHUB_APP_SLUG ||
+    !Number.isSafeInteger(identity.ownerId) ||
+    identity.ownerId <= 0
+  ) {
+    throw new Error("The release GitHub App identity record is invalid.");
+  }
+  const filePath = releaseAppIdentityPath(candidateStateRoot);
+  const root = stateRoot(candidateStateRoot);
+  const directory = path.dirname(filePath);
+  mkdirSync(root, { recursive: true, mode: 0o700 });
+  if (lstatSync(root).isSymbolicLink() || !lstatSync(root).isDirectory()) {
+    throw new Error("The release GitHub App state root is invalid.");
+  }
+  chmodSync(root, 0o700);
+  if (existsSync(directory)) {
+    if (
+      lstatSync(directory).isSymbolicLink() ||
+      !lstatSync(directory).isDirectory()
+    ) {
+      throw new Error("The release GitHub App identity directory is invalid.");
+    }
+  } else {
+    mkdirSync(directory, { mode: 0o700 });
+  }
+  if (lstatSync(directory).isSymbolicLink()) {
+    throw new Error("The release GitHub App identity directory is invalid.");
+  }
+  chmodSync(directory, 0o700);
+  const temporaryPath = path.join(
+    directory,
+    `.github-app.${process.pid.toLocaleString("en-US", { useGrouping: false })}.${randomUUID()}.tmp`,
+  );
+  let descriptor;
+  try {
+    descriptor = openSync(temporaryPath, "wx", 0o600);
+    writeFileSync(descriptor, `${JSON.stringify(identity, null, 2)}\n`, "utf8");
+    fsyncSync(descriptor);
+    closeSync(descriptor);
+    descriptor = undefined;
+    renameSync(temporaryPath, filePath);
+    chmodSync(filePath, 0o600);
+    const directoryDescriptor = openSync(directory, "r");
+    fsyncSync(directoryDescriptor);
+    closeSync(directoryDescriptor);
+  } catch (error) {
+    if (descriptor !== undefined) closeSync(descriptor);
+    rmSync(temporaryPath, { force: true });
+    throw error;
+  }
+  return filePath;
+}
+
+export function releaseAppInstallationUrl(identity) {
+  const url = new URL(
+    `https://github.com/apps/${encodeURIComponent(identity.appSlug)}/installations/new`,
+  );
+  url.searchParams.set(
+    "target_id",
+    identity.ownerId.toLocaleString("en-US", { useGrouping: false }),
+  );
+  return url.toString();
+}
+
+export function verifyInstalledReleaseApp(
+  identity,
+  { exec = execFileSync, publisherPath = RELEASE_TAG_PUBLISHER_PATH } = {},
+) {
+  const output = exec(
+    publisherPath,
+    [
+      "verify-installation",
+      "--repo",
+      identity.repo,
+      "--app-id",
+      identity.appId.toLocaleString("en-US", { useGrouping: false }),
+      "--app-slug",
+      identity.appSlug,
+    ],
+    { encoding: "utf8", maxBuffer: 1024 * 1024 },
+  );
+  let attestation;
+  try {
+    attestation = JSON.parse(output);
+  } catch {
+    throw new Error(
+      "The installed release tag publisher returned invalid installation evidence.",
+    );
+  }
+  return verifyReleaseTagPublisherInstallationReadiness(attestation, {
+    repo: identity.repo,
+    releaseAppId: identity.appId,
+    releaseAppSlug: identity.appSlug,
+  });
+}
+
+export async function pollReleaseAppInstallation(
+  identity,
+  {
+    verifyInstallation = verifyInstalledReleaseApp,
+    timeoutMs = INSTALLATION_TIMEOUT_MS,
+    intervalMs = INSTALLATION_POLL_MS,
+    now = Date.now,
+    wait = sleep,
+  } = {},
+) {
+  const startedAt = now();
+  while (now() - startedAt < timeoutMs) {
+    try {
+      return verifyInstallation(identity);
+    } catch {
+      await wait(intervalMs);
+    }
+  }
+  throw new Error(
+    "Timed out waiting for the release GitHub App installation on freed-project/freed.",
+  );
+}
+
+export async function completeReleaseGitHubAppCreation(
+  conversion,
+  {
+    provisionPrivateKey = provisionReleaseAppPrivateKey,
+    writeIdentity = writeReleaseAppIdentity,
+    activatePublisher = activateReleaseTagPublisherBinding,
+    openUrl = (url) =>
+      execFileSync("/usr/bin/open", [url], { stdio: "ignore" }),
+    pollInstallation = pollReleaseAppInstallation,
+    onStatus = () => {},
+  } = {},
+) {
+  const { identity, pem } = validateManifestConversion(conversion);
+  onStatus("Installing the private App credential in the release publisher.");
+  provisionPrivateKey(pem);
+  writeIdentity(identity);
+  onStatus("Activating the root-owned App identity binding.");
+  activatePublisher(identity);
+  const installationUrl = releaseAppInstallationUrl(identity);
+  onStatus("Opening the selected-repository installation page.");
+  openUrl(installationUrl);
+  const installation = await pollInstallation(identity);
+  return {
+    status: "ready",
+    repo: identity.repo,
+    appId: identity.appId,
+    appSlug: identity.appSlug,
+    installationId: installation.installationId,
+  };
+}
+
+function createCallbackServer({ state, timeoutMs = MANIFEST_TIMEOUT_MS }) {
+  let settle;
+  const callback = new Promise((resolve, reject) => {
+    settle = { resolve, reject };
+  });
+  let origin;
+  let settled = false;
+  const server = http.createServer((request, response) => {
+    try {
+      if (request.method === "GET" && request.url === BOOTSTRAP_PATH) {
+        const manifest = buildReleaseGitHubAppManifest({ origin });
+        response.writeHead(200, {
+          "Content-Type": "text/html; charset=utf-8",
+          "Cache-Control": "no-store",
+          "Content-Security-Policy":
+            "default-src 'none'; script-src 'unsafe-inline'; style-src 'none'; form-action https://github.com",
+          "Referrer-Policy": "no-referrer",
+        });
+        response.end(buildManifestBootstrapHtml({ manifest, state }));
+        return;
+      }
+      if (request.method === "GET" && request.url?.startsWith(CALLBACK_PATH)) {
+        const value = parseManifestCallback(request.url, state, origin);
+        response.writeHead(200, {
+          "Content-Type": "text/plain; charset=utf-8",
+          "Cache-Control": "no-store",
+          "Referrer-Policy": "no-referrer",
+        });
+        response.end(
+          "GitHub App registration received. Return to the terminal.\n",
+        );
+        if (!settled) {
+          settled = true;
+          settle.resolve(value);
+        }
+        return;
+      }
+      response.writeHead(404, { "Content-Type": "text/plain" });
+      response.end("Not found\n");
+    } catch (error) {
+      response.writeHead(403, {
+        "Content-Type": "text/plain; charset=utf-8",
+        "Cache-Control": "no-store",
+      });
+      response.end("GitHub App callback rejected.\n");
+      if (!settled) {
+        settled = true;
+        settle.reject(error);
+      }
+    }
+  });
+  const listening = new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("The release GitHub App loopback listener failed."));
+        return;
+      }
+      origin = `http://127.0.0.1:${address.port.toLocaleString("en-US", { useGrouping: false })}`;
+      resolve();
+    });
+  });
+  const timeout = setTimeout(() => {
+    if (!settled) {
+      settled = true;
+      settle.reject(
+        new Error("Timed out waiting for GitHub App registration."),
+      );
+    }
+  }, timeoutMs);
+  timeout.unref();
+  return {
+    server,
+    listening,
+    callback,
+    get origin() {
+      return origin;
+    },
+    close() {
+      clearTimeout(timeout);
+      server.close();
+    },
+  };
+}
+
+export async function createReleaseGitHubApp({
+  verifyPreparedHost = verifyPreparedReleaseTagPublisher,
+  openUrl = (url) => execFileSync("/usr/bin/open", [url], { stdio: "ignore" }),
+  exchangeCode = exchangeManifestCode,
+  completeCreation = completeReleaseGitHubAppCreation,
+  onStatus = () => {},
+} = {}) {
+  verifyPreparedHost();
+  const state = randomBytes(32).toString("hex");
+  const listener = createCallbackServer({ state });
+  try {
+    await listener.listening;
+    onStatus("Opening the private GitHub App manifest.");
+    openUrl(`${listener.origin}${BOOTSTRAP_PATH}`);
+    const { code } = await listener.callback;
+    const conversion = await exchangeCode(code);
+    return await completeCreation(conversion, { onStatus });
+  } finally {
+    listener.close();
+  }
+}
+
+function main() {
+  if (process.argv.length > 2) {
+    if (
+      process.argv.length === 3 &&
+      ["--help", "-h"].includes(process.argv[2])
+    ) {
+      process.stdout.write(
+        "Usage: node scripts/create-release-github-app.mjs\n",
+      );
+      return;
+    }
+    throw new Error("The release GitHub App helper does not accept arguments.");
+  }
+  if (
+    process.platform !== "darwin" ||
+    !Number.isSafeInteger(process.getuid?.()) ||
+    process.getuid() <= 0
+  ) {
+    throw new Error(
+      "The release GitHub App helper must run as the non-root owner on macOS.",
+    );
+  }
+  createReleaseGitHubApp({
+    onStatus(message) {
+      process.stderr.write(`${message}\n`);
+    },
+  })
+    .then((result) => {
+      process.stdout.write(`${JSON.stringify(result)}\n`);
+    })
+    .catch((error) => {
+      process.stderr.write(
+        `${error instanceof Error ? error.message : "Release GitHub App creation failed."}\n`,
+      );
+      process.exitCode = 1;
+    });
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/scripts/create-release-github-app.mjs
+++ b/scripts/create-release-github-app.mjs
@@ -3,9 +3,11 @@
 import { execFileSync, spawnSync } from "node:child_process";
 import { randomBytes, randomUUID, timingSafeEqual } from "node:crypto";
 import {
-  chmodSync,
   closeSync,
+  constants,
   existsSync,
+  fchmodSync,
+  fstatSync,
   fsyncSync,
   lstatSync,
   mkdirSync,
@@ -83,6 +85,34 @@ function stateRoot(candidate = undefined) {
     throw new Error("The release App state root must be absolute.");
   }
   return path.resolve(configured);
+}
+
+function openPrivateDirectory(directory, { recursive, label }) {
+  try {
+    mkdirSync(directory, { recursive, mode: 0o700 });
+  } catch (error) {
+    if (error?.code !== "EEXIST") throw error;
+  }
+  let descriptor;
+  try {
+    descriptor = openSync(
+      directory,
+      constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW,
+    );
+    const metadata = fstatSync(descriptor);
+    if (
+      !metadata.isDirectory() ||
+      metadata.uid !== process.getuid() ||
+      (metadata.mode & 0o077) !== 0
+    ) {
+      throw new Error(`${label} must be a private current-user directory.`);
+    }
+    fchmodSync(descriptor, 0o700);
+    return descriptor;
+  } catch {
+    if (descriptor !== undefined) closeSync(descriptor);
+    throw new Error(`${label} is invalid.`);
+  }
 }
 
 function verifyPreparedExecutable(filePath, label) {
@@ -342,45 +372,36 @@ export function writeReleaseAppIdentity(
   const filePath = releaseAppIdentityPath(candidateStateRoot);
   const root = stateRoot(candidateStateRoot);
   const directory = path.dirname(filePath);
-  mkdirSync(root, { recursive: true, mode: 0o700 });
-  if (lstatSync(root).isSymbolicLink() || !lstatSync(root).isDirectory()) {
-    throw new Error("The release GitHub App state root is invalid.");
-  }
-  chmodSync(root, 0o700);
-  if (existsSync(directory)) {
-    if (
-      lstatSync(directory).isSymbolicLink() ||
-      !lstatSync(directory).isDirectory()
-    ) {
-      throw new Error("The release GitHub App identity directory is invalid.");
-    }
-  } else {
-    mkdirSync(directory, { mode: 0o700 });
-  }
-  if (lstatSync(directory).isSymbolicLink()) {
-    throw new Error("The release GitHub App identity directory is invalid.");
-  }
-  chmodSync(directory, 0o700);
+  const rootDescriptor = openPrivateDirectory(root, {
+    recursive: true,
+    label: "The release GitHub App state root",
+  });
+  let directoryDescriptor;
   const temporaryPath = path.join(
     directory,
     `.github-app.${process.pid.toLocaleString("en-US", { useGrouping: false })}.${randomUUID()}.tmp`,
   );
   let descriptor;
   try {
+    directoryDescriptor = openPrivateDirectory(directory, {
+      recursive: false,
+      label: "The release GitHub App identity directory",
+    });
     descriptor = openSync(temporaryPath, "wx", 0o600);
     writeFileSync(descriptor, `${JSON.stringify(identity, null, 2)}\n`, "utf8");
     fsyncSync(descriptor);
     closeSync(descriptor);
     descriptor = undefined;
     renameSync(temporaryPath, filePath);
-    chmodSync(filePath, 0o600);
-    const directoryDescriptor = openSync(directory, "r");
     fsyncSync(directoryDescriptor);
-    closeSync(directoryDescriptor);
+    fsyncSync(rootDescriptor);
   } catch (error) {
     if (descriptor !== undefined) closeSync(descriptor);
     rmSync(temporaryPath, { force: true });
     throw error;
+  } finally {
+    if (directoryDescriptor !== undefined) closeSync(directoryDescriptor);
+    closeSync(rootDescriptor);
   }
   return filePath;
 }

--- a/scripts/create-release-github-app.test.mjs
+++ b/scripts/create-release-github-app.test.mjs
@@ -1,5 +1,12 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+} from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -13,6 +20,7 @@ import {
   parseManifestCallback,
   provisionReleaseAppPrivateKey,
   releaseAppIdentityPath,
+  validateManifestConversion,
   writeReleaseAppIdentity,
 } from "./create-release-github-app.mjs";
 
@@ -198,7 +206,13 @@ test("completed creation writes and logs only nonsecret App identity", async (t)
     "verify-installation",
   ]);
   assert.equal(opened.length, 1);
-  assert.match(opened[0], /github\.com\/apps\/freed-release-publisher/);
+  const installationUrl = new URL(opened[0]);
+  assert.equal(installationUrl.origin, "https://github.com");
+  assert.equal(
+    installationUrl.pathname,
+    "/apps/freed-release-publisher/installations/new",
+  );
+  assert.equal(installationUrl.searchParams.get("target_id"), "257444947");
   assert.deepEqual(result, {
     status: "ready",
     repo: "freed-project/freed",
@@ -229,4 +243,17 @@ test("completed creation writes and logs only nonsecret App identity", async (t)
     appSlug: "freed-release-publisher",
     ownerId: 257444947,
   });
+});
+
+test("identity persistence rejects a symlinked private directory", (t) => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "freed-release-app-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const target = path.join(root, "unexpected-target");
+  mkdirSync(target, { mode: 0o700 });
+  symlinkSync(target, path.join(root, "release-tag-publisher"), "dir");
+  const { identity } = validateManifestConversion(conversion());
+  assert.throws(
+    () => writeReleaseAppIdentity(identity, { stateRoot: root }),
+    /identity directory is invalid/,
+  );
 });

--- a/scripts/create-release-github-app.test.mjs
+++ b/scripts/create-release-github-app.test.mjs
@@ -1,0 +1,232 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  activateReleaseTagPublisherBinding,
+  buildManifestBootstrapHtml,
+  buildReleaseGitHubAppManifest,
+  completeReleaseGitHubAppCreation,
+  exchangeManifestCode,
+  parseManifestCallback,
+  provisionReleaseAppPrivateKey,
+  releaseAppIdentityPath,
+  writeReleaseAppIdentity,
+} from "./create-release-github-app.mjs";
+
+const pem = `-----BEGIN RSA PRIVATE KEY-----\n${"A".repeat(512)}\n-----END RSA PRIVATE KEY-----\n`;
+
+function conversion() {
+  return {
+    id: 123456,
+    slug: "freed-release-publisher",
+    name: "Freed Release Publisher",
+    external_url: "https://freed.wtf",
+    permissions: { contents: "write", metadata: "read" },
+    events: [],
+    owner: { id: 257444947, login: "freed-project", type: "Organization" },
+    pem,
+    client_secret: "client-secret-must-not-survive",
+    webhook_secret: "webhook-secret-must-not-survive",
+  };
+}
+
+test("release App manifest is private, event-free, and Contents-only", () => {
+  const manifest = buildReleaseGitHubAppManifest({
+    origin: "http://127.0.0.1:43123",
+  });
+  assert.deepEqual(manifest, {
+    name: "Freed Release Publisher",
+    url: "https://freed.wtf",
+    description:
+      "Creates one reviewed immutable release tag for freed-project/freed.",
+    hook_attributes: {
+      url: "http://127.0.0.1:43123/github-app/inactive-webhook",
+      active: false,
+    },
+    redirect_url: "http://127.0.0.1:43123/github-app/callback",
+    public: false,
+    default_permissions: { contents: "write" },
+    default_events: [],
+    request_oauth_on_install: false,
+    setup_on_update: false,
+  });
+  const html = buildManifestBootstrapHtml({
+    manifest,
+    state: "f".repeat(64),
+  });
+  assert.match(
+    html,
+    /organizations\/freed-project\/settings\/apps\/new\?state=/,
+  );
+  assert.match(html, /method="post"/);
+  assert.doesNotMatch(html, /client_secret|webhook_secret|BEGIN RSA/);
+});
+
+test("manifest callback rejects missing, duplicated, and incorrect CSRF state", () => {
+  const origin = "http://127.0.0.1:43123";
+  const state = "a".repeat(64);
+  const code = "b".repeat(40);
+  assert.deepEqual(
+    parseManifestCallback(
+      `/github-app/callback?code=${code}&state=${state}`,
+      state,
+      origin,
+    ),
+    { code },
+  );
+  for (const callback of [
+    `/github-app/callback?code=${code}`,
+    `/github-app/callback?code=${code}&state=${"c".repeat(64)}`,
+    `/github-app/callback?code=${code}&state=${state}&state=${state}`,
+  ]) {
+    assert.throws(
+      () => parseManifestCallback(callback, state, origin),
+      /callback state is invalid/,
+    );
+  }
+});
+
+test("manifest exchange never sends credentials", async () => {
+  const calls = [];
+  const result = await exchangeManifestCode("d".repeat(40), {
+    async fetchImpl(url, options) {
+      calls.push({ url, options });
+      return {
+        ok: true,
+        status: 201,
+        async json() {
+          return conversion();
+        },
+      };
+    },
+  });
+  assert.equal(result.id, 123456);
+  assert.deepEqual(calls[0].options.method, "POST");
+  assert.equal("body" in calls[0].options, false);
+  assert.equal("Authorization" in calls[0].options.headers, false);
+});
+
+test("private key is piped to the fixed provisioner and never placed in arguments", () => {
+  const calls = [];
+  provisionReleaseAppPrivateKey(pem, {
+    spawn(file, args, options) {
+      calls.push({ file, args, options });
+      return { status: 0 };
+    },
+  });
+  assert.deepEqual(calls[0].args, [
+    "provision",
+    "--host",
+    "/Library/Application Support/Freed/release-tag-publisher",
+  ]);
+  assert.equal(calls[0].options.input, pem);
+  assert.doesNotMatch(JSON.stringify(calls[0].args), /BEGIN RSA/);
+});
+
+test("publisher activation passes only the nonsecret App identity to pinned Node", () => {
+  const calls = [];
+  activateReleaseTagPublisherBinding(
+    { appId: 123456, appSlug: "freed-release-publisher" },
+    {
+      nodePath: "/pinned/node",
+      installerPath: "/repo/scripts/release-tag-publisher-install.mjs",
+      exec(file, args, options) {
+        calls.push({ file, args, options });
+      },
+    },
+  );
+  assert.deepEqual(calls, [
+    {
+      file: "/pinned/node",
+      args: [
+        "/repo/scripts/release-tag-publisher-install.mjs",
+        "activate",
+        "--app-id",
+        "123456",
+        "--app-slug",
+        "freed-release-publisher",
+      ],
+      options: { stdio: "inherit" },
+    },
+  ]);
+  assert.doesNotMatch(
+    JSON.stringify(calls),
+    /BEGIN RSA|client-secret|webhook-secret/,
+  );
+});
+
+test("completed creation writes and logs only nonsecret App identity", async (t) => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "freed-release-app-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const statuses = [];
+  const opened = [];
+  const sequence = [];
+  let provisionedPem = "";
+  const result = await completeReleaseGitHubAppCreation(conversion(), {
+    provisionPrivateKey(value) {
+      sequence.push("provision");
+      provisionedPem = value;
+    },
+    writeIdentity(identity) {
+      sequence.push("write-identity");
+      writeReleaseAppIdentity(identity, { stateRoot: root });
+    },
+    activatePublisher() {
+      sequence.push("activate-binding");
+    },
+    openUrl(url) {
+      sequence.push("open-installation");
+      opened.push(url);
+    },
+    async pollInstallation() {
+      sequence.push("verify-installation");
+      return { ready: true, installationId: 42 };
+    },
+    onStatus(message) {
+      statuses.push(message);
+    },
+  });
+  assert.equal(provisionedPem, pem);
+  assert.deepEqual(sequence, [
+    "provision",
+    "write-identity",
+    "activate-binding",
+    "open-installation",
+    "verify-installation",
+  ]);
+  assert.equal(opened.length, 1);
+  assert.match(opened[0], /github\.com\/apps\/freed-release-publisher/);
+  assert.deepEqual(result, {
+    status: "ready",
+    repo: "freed-project/freed",
+    appId: 123456,
+    appSlug: "freed-release-publisher",
+    installationId: 42,
+  });
+
+  const identityPath = releaseAppIdentityPath(root);
+  const persisted = readFileSync(identityPath, "utf8");
+  const observable = `${persisted}\n${statuses.join("\n")}\n${JSON.stringify(result)}\n${opened.join("\n")}`;
+  for (const secret of [
+    pem,
+    "client-secret-must-not-survive",
+    "webhook-secret-must-not-survive",
+  ]) {
+    assert.equal(observable.includes(secret), false);
+  }
+  assert.equal(statSync(identityPath).mode & 0o777, 0o600);
+  assert.equal(statSync(root).mode & 0o777, 0o700);
+  assert.equal(statSync(path.dirname(identityPath)).mode & 0o777, 0o700);
+  assert.deepEqual(JSON.parse(persisted), {
+    schemaVersion: 1,
+    purpose: "freed-release-github-app-identity",
+    organization: "freed-project",
+    repo: "freed-project/freed",
+    appId: 123456,
+    appSlug: "freed-release-publisher",
+    ownerId: 257444947,
+  });
+});

--- a/scripts/lib/release-tag-publisher.mjs
+++ b/scripts/lib/release-tag-publisher.mjs
@@ -6,6 +6,22 @@ import path from "node:path";
 export const RELEASE_TAG_PUBLISHER_CONFIG =
   "/Library/Application Support/Freed/release-tag-publisher.json";
 
+export const RELEASE_TAG_INSTALLATION_READINESS_PURPOSE =
+  "freed-release-tag-publisher-installation-readiness";
+
+const RELEASE_REPO = "freed-project/freed";
+const RELEASE_ACCOUNT = "freed-project";
+
+function hasExactKeys(value, expected) {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    JSON.stringify(Object.keys(value).sort()) ===
+      JSON.stringify([...expected].sort())
+  );
+}
+
 function verifyRootOwnedParents(filePath) {
   let current = path.dirname(filePath);
   while (true) {
@@ -75,12 +91,75 @@ export function verifyReleaseTagPublisherReadiness(
   return { ready: true, publisherDigest };
 }
 
+export function verifyReleaseTagPublisherInstallationReadiness(
+  attestation,
+  { repo, releaseAppId, releaseAppSlug },
+) {
+  const expectedAppId = Number(releaseAppId);
+  const expectedKeys = [
+    "accountLogin",
+    "accountType",
+    "appEvents",
+    "appExternalUrl",
+    "appId",
+    "appName",
+    "appOwnerLogin",
+    "appOwnerType",
+    "appPermissions",
+    "appSlug",
+    "installationId",
+    "permissions",
+    "purpose",
+    "repo",
+    "repositories",
+    "repositorySelection",
+    "schemaVersion",
+  ];
+  if (
+    !hasExactKeys(attestation, expectedKeys) ||
+    attestation.schemaVersion !== 1 ||
+    attestation.purpose !== RELEASE_TAG_INSTALLATION_READINESS_PURPOSE ||
+    attestation.repo !== repo ||
+    !Number.isSafeInteger(expectedAppId) ||
+    expectedAppId <= 0 ||
+    !Number.isSafeInteger(attestation.appId) ||
+    attestation.appId !== expectedAppId ||
+    attestation.appSlug !== releaseAppSlug ||
+    attestation.appName !== "Freed Release Publisher" ||
+    attestation.appExternalUrl !== "https://freed.wtf" ||
+    attestation.appOwnerLogin !== RELEASE_ACCOUNT ||
+    attestation.appOwnerType !== "Organization" ||
+    !hasExactKeys(attestation.appPermissions, ["contents", "metadata"]) ||
+    attestation.appPermissions.contents !== "write" ||
+    attestation.appPermissions.metadata !== "read" ||
+    JSON.stringify(attestation.appEvents) !== JSON.stringify([]) ||
+    !Number.isSafeInteger(attestation.installationId) ||
+    attestation.installationId <= 0 ||
+    attestation.accountLogin !== RELEASE_ACCOUNT ||
+    attestation.accountType !== "Organization" ||
+    attestation.repositorySelection !== "selected" ||
+    !hasExactKeys(attestation.permissions, ["contents", "metadata"]) ||
+    attestation.permissions.contents !== "write" ||
+    attestation.permissions.metadata !== "read" ||
+    JSON.stringify(attestation.repositories) !== JSON.stringify([repo])
+  ) {
+    throw new Error(
+      "Release tag publisher installation attestation does not match the dedicated selected-repository App contract.",
+    );
+  }
+  return {
+    ready: true,
+    installationId: attestation.installationId,
+    attestation,
+  };
+}
+
 export function verifyReleaseTagPublisherConfig(config) {
   if (
     config?.schemaVersion !== 1 ||
     config?.purpose !== "freed-release-tag-publisher-binding" ||
     config?.status !== "active" ||
-    config?.repo !== "freed-project/freed" ||
+    config?.repo !== RELEASE_REPO ||
     !Number.isSafeInteger(config?.appId) ||
     config.appId <= 0 ||
     typeof config?.appSlug !== "string" ||
@@ -91,6 +170,38 @@ export function verifyReleaseTagPublisherConfig(config) {
     throw new Error("Release tag publisher binding is missing or malformed.");
   }
   return config;
+}
+
+export function verifyReleaseTagPublisherInstallation(
+  binding,
+  { exec = execFileSync } = {},
+) {
+  const raw = exec(
+    binding.publisherPath,
+    [
+      "verify-installation",
+      "--repo",
+      binding.repo,
+      "--app-id",
+      String(binding.appId),
+      "--app-slug",
+      binding.appSlug,
+    ],
+    { encoding: "utf8", maxBuffer: 1024 * 1024 },
+  );
+  let attestation;
+  try {
+    attestation = JSON.parse(raw);
+  } catch {
+    throw new Error(
+      "Release tag publisher installation check did not return one JSON attestation.",
+    );
+  }
+  return verifyReleaseTagPublisherInstallationReadiness(attestation, {
+    repo: binding.repo,
+    releaseAppId: binding.appId,
+    releaseAppSlug: binding.appSlug,
+  });
 }
 
 export function verifyReleaseTagPublisherBinding(

--- a/scripts/lib/release-tag-publisher.test.mjs
+++ b/scripts/lib/release-tag-publisher.test.mjs
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { verifyReleaseTagPublisherBinding } from "./release-tag-publisher.mjs";
+import {
+  verifyReleaseTagPublisherBinding,
+  verifyReleaseTagPublisherInstallation,
+  verifyReleaseTagPublisherInstallationReadiness,
+} from "./release-tag-publisher.mjs";
 
 function fixture() {
   const digest = "a".repeat(64);
@@ -31,6 +35,28 @@ function fixture() {
   return { config, attestation, digest };
 }
 
+function installationAttestation() {
+  return {
+    schemaVersion: 1,
+    purpose: "freed-release-tag-publisher-installation-readiness",
+    repo: "freed-project/freed",
+    appId: 123456,
+    appSlug: "freed-release-publisher",
+    appName: "Freed Release Publisher",
+    appExternalUrl: "https://freed.wtf",
+    appOwnerLogin: "freed-project",
+    appOwnerType: "Organization",
+    appPermissions: { contents: "write", metadata: "read" },
+    appEvents: [],
+    installationId: 42,
+    accountLogin: "freed-project",
+    accountType: "Organization",
+    repositorySelection: "selected",
+    permissions: { contents: "write", metadata: "read" },
+    repositories: ["freed-project/freed"],
+  };
+}
+
 test("publisher binding pins the exact App, operation, and executable digest", () => {
   const { config, attestation, digest } = fixture();
   assert.deepEqual(
@@ -49,4 +75,63 @@ test("publisher binding pins the exact App, operation, and executable digest", (
       }),
     /does not match the pinned short-lived annotated-tag publisher/,
   );
+});
+
+test("installation readiness accepts only the exact dedicated App scope", () => {
+  const attestation = installationAttestation();
+  const expected = {
+    repo: "freed-project/freed",
+    releaseAppId: 123456,
+    releaseAppSlug: "freed-release-publisher",
+  };
+  assert.deepEqual(
+    verifyReleaseTagPublisherInstallationReadiness(attestation, expected),
+    { ready: true, installationId: 42, attestation },
+  );
+  for (const invalid of [
+    { ...attestation, repositories: ["freed-project/other"] },
+    {
+      ...attestation,
+      permissions: { contents: "write", metadata: "read", actions: "read" },
+    },
+    { ...attestation, repositorySelection: "all" },
+    { ...attestation, appEvents: ["push"] },
+    {
+      ...attestation,
+      appPermissions: { contents: "write", metadata: "read", actions: "read" },
+    },
+    { ...attestation, pem: "secret" },
+  ]) {
+    assert.throws(
+      () => verifyReleaseTagPublisherInstallationReadiness(invalid, expected),
+      /does not match the dedicated selected-repository App contract/,
+    );
+  }
+});
+
+test("native installation verification uses only the pinned App identity", () => {
+  const binding = {
+    repo: "freed-project/freed",
+    appId: 123456,
+    appSlug: "freed-release-publisher",
+    publisherPath: "/trusted/release-tag-publisher",
+  };
+  const calls = [];
+  const result = verifyReleaseTagPublisherInstallation(binding, {
+    exec(file, args, options) {
+      calls.push({ file, args, options });
+      return JSON.stringify(installationAttestation());
+    },
+  });
+  assert.equal(result.installationId, 42);
+  assert.deepEqual(calls[0].args, [
+    "verify-installation",
+    "--repo",
+    "freed-project/freed",
+    "--app-id",
+    "123456",
+    "--app-slug",
+    "freed-release-publisher",
+  ]);
+  assert.equal(calls[0].options.encoding, "utf8");
 });

--- a/scripts/release-tag-publisher-build.sh
+++ b/scripts/release-tag-publisher-build.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+
+set -euo pipefail
+set +x
+umask 077
+
+usage() {
+  echo "Usage: scripts/release-tag-publisher-build.sh --host-output <absolute-path> --provisioner-output <absolute-path>" >&2
+  exit 2
+}
+
+HOST_OUTPUT=""
+PROVISIONER_OUTPUT=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --host-output)
+      [[ $# -ge 2 ]] || usage
+      HOST_OUTPUT="$2"
+      shift 2
+      ;;
+    --provisioner-output)
+      [[ $# -ge 2 ]] || usage
+      PROVISIONER_OUTPUT="$2"
+      shift 2
+      ;;
+    *) usage ;;
+  esac
+done
+
+if [[
+  "${HOST_OUTPUT}" != /* ||
+  "${PROVISIONER_OUTPUT}" != /* ||
+  "${HOST_OUTPUT}" == "${PROVISIONER_OUTPUT}"
+]]; then
+  usage
+fi
+
+validate_parent() {
+  local output="$1"
+  local parent="${output%/*}"
+  local name="${output##*/}"
+  local canonical
+  local mode
+  [[ -n "${name}" && -d "${parent}" ]] || {
+    echo "Error: output parents must already exist." >&2
+    exit 1
+  }
+  canonical="$(cd -P -- "${parent}" && pwd)"
+  [[ "${canonical}" == "${parent}" ]] || {
+    echo "Error: output parents must use canonical paths." >&2
+    exit 1
+  }
+  [[ "$(/usr/bin/stat -f '%u' "${parent}")" == "$(/usr/bin/id -u)" ]] || {
+    echo "Error: output parents must be owned by the current user." >&2
+    exit 1
+  }
+  mode="$(/usr/bin/stat -f '%Lp' "${parent}")"
+  if (( ((8#${mode}) & 8#022) != 0 )); then
+    echo "Error: output parents must not be group or world writable." >&2
+    exit 1
+  fi
+}
+
+validate_parent "${HOST_OUTPUT}"
+validate_parent "${PROVISIONER_OUTPUT}"
+
+[[ "$(/usr/bin/uname -s)" == "Darwin" ]] || {
+  echo "Error: release tag publisher native tools require macOS." >&2
+  exit 1
+}
+DEVELOPER_DIR="$(/usr/bin/xcode-select -p)"
+export DEVELOPER_DIR
+SWIFTC="$(/usr/bin/xcrun --sdk macosx --find swiftc)"
+SDK_PATH="$(/usr/bin/xcrun --sdk macosx --show-sdk-path)"
+ARCHITECTURE="$(/usr/bin/uname -m)"
+if [[
+  "${SWIFTC}" != /* || ! -x "${SWIFTC}" ||
+  "${SDK_PATH}" != /* || ! -d "${SDK_PATH}" ||
+  ( "${ARCHITECTURE}" != "arm64" && "${ARCHITECTURE}" != "x86_64" )
+]]; then
+  echo "Error: the pinned macOS Swift toolchain is unavailable." >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd -P -- "${BASH_SOURCE[0]%/*}" && pwd)"
+HOST_SOURCE="${SCRIPT_DIR}/release-tag-publisher-host.swift"
+PROVISIONER_SOURCE="${SCRIPT_DIR}/release-tag-publisher-provision.swift"
+HOST_TEMP="$(/usr/bin/mktemp "${HOST_OUTPUT%/*}/.release-tag-publisher.XXXXXX")"
+PROVISIONER_TEMP="$(/usr/bin/mktemp "${PROVISIONER_OUTPUT%/*}/.release-tag-publisher-provision.XXXXXX")"
+cleanup() {
+  /bin/rm -f -- "${HOST_TEMP}" "${PROVISIONER_TEMP}"
+}
+trap cleanup EXIT
+
+COMMON=(
+  -O
+  -whole-module-optimization
+  -sdk "${SDK_PATH}"
+  -target "${ARCHITECTURE}-apple-macosx10.15"
+)
+"${SWIFTC}" "${COMMON[@]}" "${HOST_SOURCE}" -o "${HOST_TEMP}" \
+  -framework Foundation -framework Security -framework CryptoKit
+"${SWIFTC}" "${COMMON[@]}" "${PROVISIONER_SOURCE}" -o "${PROVISIONER_TEMP}" \
+  -framework Foundation -framework Security
+
+/usr/bin/codesign --force --sign - "${HOST_TEMP}"
+/usr/bin/codesign --force --sign - "${PROVISIONER_TEMP}"
+/usr/bin/codesign --verify --strict --verbose=0 "${HOST_TEMP}"
+/usr/bin/codesign --verify --strict --verbose=0 "${PROVISIONER_TEMP}"
+/bin/chmod 755 "${HOST_TEMP}" "${PROVISIONER_TEMP}"
+/bin/mv -f -- "${HOST_TEMP}" "${HOST_OUTPUT}"
+/bin/mv -f -- "${PROVISIONER_TEMP}" "${PROVISIONER_OUTPUT}"
+trap - EXIT
+
+echo "Built release tag publisher host at ${HOST_OUTPUT}"
+echo "Built release tag publisher provisioner at ${PROVISIONER_OUTPUT}"

--- a/scripts/release-tag-publisher-host.swift
+++ b/scripts/release-tag-publisher-host.swift
@@ -1,0 +1,952 @@
+import CryptoKit
+import Darwin
+import Foundation
+import Security
+
+private let productionConfigPath =
+  "/Library/Application Support/Freed/release-tag-publisher.json"
+private let keychainService = "freed-release-tag-publisher"
+private let keychainAccount = "github-app-private-key"
+private let productionAPIBase = "https://api.github.com"
+private let maximumConfigBytes = 32 * 1_024
+private let maximumKeyBytes = 32 * 1_024
+private let requestTimeout: TimeInterval = 30
+
+private struct HostFailure: Error, CustomStringConvertible {
+  let description: String
+  init(_ description: String) { self.description = description }
+}
+
+private struct PublisherBinding: Decodable {
+  let schemaVersion: Int
+  let purpose: String
+  let status: String
+  let repo: String
+  let appId: Int
+  let appSlug: String
+  let publisherPath: String
+  let publisherSha256: String
+}
+
+private struct ParsedCommand {
+  let name: String
+  let values: [String: String]
+  let configPath: String
+  let testKeyFile: String?
+  let apiBase: String
+}
+
+private struct InstallationReadiness: Codable {
+  let schemaVersion: Int
+  let purpose: String
+  let repo: String
+  let appId: Int
+  let appSlug: String
+  let appName: String
+  let appExternalUrl: String
+  let appOwnerLogin: String
+  let appOwnerType: String
+  let appPermissions: [String: String]
+  let appEvents: [String]
+  let installationId: Int
+  let accountLogin: String
+  let accountType: String
+  let repositorySelection: String
+  let permissions: [String: String]
+  let repositories: [String]
+}
+
+private struct InstallationContext {
+  let readiness: InstallationReadiness
+  var token: String
+}
+
+private struct HTTPResponse {
+  let status: Int
+  let data: Data
+}
+
+private func fail(_ message: String) throws -> Never {
+  throw HostFailure(message)
+}
+
+private func usage() -> String {
+  """
+  Usage:
+    release-tag-publisher attest --repo <owner/repo> --app-id <id> --app-slug <slug>
+    release-tag-publisher verify-installation --repo <owner/repo> --app-id <id> --app-slug <slug>
+    release-tag-publisher publish --repo <owner/repo> --worktree <path> --tag <tag> --channel <dev|production> --commit <sha> --branch <dev|main> --release-file <path> --release-file-sha256 <sha256>
+  """
+}
+
+private func parseCommand(_ arguments: [String]) throws -> ParsedCommand {
+  guard let name = arguments.first,
+    ["attest", "verify-installation", "publish"].contains(name)
+  else {
+    try fail(usage())
+  }
+  var values: [String: String] = [:]
+  var index = 1
+  while index < arguments.count {
+    let flag = arguments[index]
+    guard flag.hasPrefix("--"), index + 1 < arguments.count else {
+      try fail("Every publisher option must be a flag followed by one value.")
+    }
+    guard values[flag] == nil else {
+      try fail("Publisher option \(flag) may only be provided once.")
+    }
+    let value = arguments[index + 1]
+    guard !value.hasPrefix("--"), !value.isEmpty else {
+      try fail("Publisher option \(flag) requires a value.")
+    }
+    values[flag] = value
+    index += 2
+  }
+
+  var testingFlags: Set<String> = []
+  #if RELEASE_TAG_PUBLISHER_HOST_TESTING
+    testingFlags = ["--config", "--test-key-file", "--api-base"]
+  #endif
+  let identityFlags: Set<String> = ["--repo", "--app-id", "--app-slug"]
+  let publishFlags: Set<String> = [
+    "--repo", "--worktree", "--tag", "--channel", "--commit", "--branch",
+    "--release-file", "--release-file-sha256",
+  ]
+  let expected = (name == "publish" ? publishFlags : identityFlags).union(testingFlags)
+  let received = Set(values.keys)
+  guard received.subtracting(testingFlags) == expected.subtracting(testingFlags),
+    received.isSubset(of: expected)
+  else {
+    try fail("Publisher command \(name) received an incomplete or unsupported option set.")
+  }
+
+  #if RELEASE_TAG_PUBLISHER_HOST_TESTING
+    let configPath = values["--config"] ?? productionConfigPath
+    let keyFile = values["--test-key-file"]
+    let apiBase = values["--api-base"] ?? productionAPIBase
+    if apiBase != productionAPIBase {
+      guard let url = URL(string: apiBase),
+        url.scheme == "http",
+        ["127.0.0.1", "localhost"].contains(url.host ?? "")
+      else {
+        try fail("The testing API base must be an HTTP loopback URL.")
+      }
+    }
+  #else
+    let configPath = productionConfigPath
+    let keyFile: String? = nil
+    let apiBase = productionAPIBase
+  #endif
+  return ParsedCommand(
+    name: name,
+    values: values,
+    configPath: configPath,
+    testKeyFile: keyFile,
+    apiBase: apiBase
+  )
+}
+
+private func currentExecutablePath() throws -> String {
+  var size: UInt32 = 0
+  _ = _NSGetExecutablePath(nil, &size)
+  var buffer = [CChar](repeating: 0, count: Int(size))
+  guard _NSGetExecutablePath(&buffer, &size) == 0 else {
+    try fail("The publisher executable path is unavailable.")
+  }
+  return try canonicalExistingPath(String(cString: buffer), label: "publisher executable")
+}
+
+private func canonicalExistingPath(_ path: String, label: String) throws -> String {
+  guard path.hasPrefix("/"), !path.contains("\n"), !path.contains("\r") else {
+    try fail("The \(label) must be an absolute path without control characters.")
+  }
+  guard let resolved = realpath(path, nil) else {
+    try fail("The \(label) does not resolve to an existing path.")
+  }
+  defer { free(resolved) }
+  return String(cString: resolved)
+}
+
+private func fileMetadata(_ path: String, followSymlink: Bool = false) throws -> stat {
+  var metadata = stat()
+  let status = path.withCString { pointer in
+    fstatat(AT_FDCWD, pointer, &metadata, followSymlink ? 0 : AT_SYMLINK_NOFOLLOW)
+  }
+  guard status == 0 else {
+    try fail("The publisher cannot inspect \(path).")
+  }
+  return metadata
+}
+
+private func requireTrustedFile(
+  _ path: String,
+  executable: Bool,
+  testingOwnerAllowed: Bool = false
+) throws {
+  let canonical = try canonicalExistingPath(path, label: "trusted publisher file")
+  guard canonical == path else {
+    try fail("Trusted publisher files must use canonical non-symlink paths.")
+  }
+  let link = try fileMetadata(path)
+  let metadata = try fileMetadata(path, followSymlink: true)
+  guard (link.st_mode & S_IFMT) != S_IFLNK,
+    (metadata.st_mode & S_IFMT) == S_IFREG,
+    metadata.st_mode & 0o022 == 0,
+    !executable || metadata.st_mode & 0o111 != 0
+  else {
+    try fail("A trusted publisher file has unsafe type or permissions.")
+  }
+  #if RELEASE_TAG_PUBLISHER_HOST_TESTING
+    let allowedOwners: Set<uid_t> = testingOwnerAllowed ? [0, getuid()] : [0]
+  #else
+    let allowedOwners: Set<uid_t> = [0]
+  #endif
+  guard allowedOwners.contains(metadata.st_uid) else {
+    try fail("A trusted publisher file has an unapproved owner.")
+  }
+}
+
+private func requireTrustedParents(_ path: String, testingOwnerAllowed: Bool) throws {
+  var current = URL(fileURLWithPath: path).deletingLastPathComponent().path
+  while true {
+    let metadata = try fileMetadata(current, followSymlink: true)
+    guard (metadata.st_mode & S_IFMT) == S_IFDIR, metadata.st_mode & 0o022 == 0 else {
+      try fail("Publisher parent \(current) has unsafe ownership or permissions.")
+    }
+    #if RELEASE_TAG_PUBLISHER_HOST_TESTING
+      let allowedOwners: Set<uid_t> = testingOwnerAllowed ? [0, getuid()] : [0]
+    #else
+      let allowedOwners: Set<uid_t> = [0]
+    #endif
+    guard allowedOwners.contains(metadata.st_uid) else {
+      try fail("Publisher parent \(current) has an unapproved owner.")
+    }
+    let parent = URL(fileURLWithPath: current).deletingLastPathComponent().path
+    if parent == current { break }
+    current = parent
+  }
+}
+
+private func readBoundedFile(_ path: String, maximumBytes: Int) throws -> Data {
+  let handle = try FileHandle(forReadingFrom: URL(fileURLWithPath: path))
+  defer { handle.closeFile() }
+  let data = handle.readData(ofLength: maximumBytes + 1)
+  guard !data.isEmpty, data.count <= maximumBytes else {
+    try fail("A publisher file is empty or exceeds its size limit.")
+  }
+  return data
+}
+
+private func sha256(_ data: Data) -> String {
+  SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+}
+
+private func validateLowercaseHex(_ value: String, count: Int, label: String) throws {
+  guard value.count == count,
+    value.unicodeScalars.allSatisfy({
+      ($0.value >= 48 && $0.value <= 57) || ($0.value >= 97 && $0.value <= 102)
+    })
+  else {
+    try fail("The \(label) must be \(count) lowercase hexadecimal characters.")
+  }
+}
+
+private func loadBinding(_ path: String) throws -> PublisherBinding {
+  #if RELEASE_TAG_PUBLISHER_HOST_TESTING
+    let testing = path != productionConfigPath
+  #else
+    let testing = false
+  #endif
+  try requireTrustedFile(path, executable: false, testingOwnerAllowed: testing)
+  try requireTrustedParents(path, testingOwnerAllowed: testing)
+  let data = try readBoundedFile(path, maximumBytes: maximumConfigBytes)
+  let object = try JSONSerialization.jsonObject(with: data)
+  let expectedKeys: Set<String> = [
+    "schemaVersion", "purpose", "status", "repo", "appId", "appSlug",
+    "publisherPath", "publisherSha256",
+  ]
+  guard let dictionary = object as? [String: Any], Set(dictionary.keys) == expectedKeys else {
+    try fail("The publisher binding contains unsupported or missing fields.")
+  }
+  let binding: PublisherBinding
+  do {
+    binding = try JSONDecoder().decode(PublisherBinding.self, from: data)
+  } catch {
+    try fail("The publisher binding has invalid field types.")
+  }
+  guard binding.schemaVersion == 1,
+    binding.purpose == "freed-release-tag-publisher-binding",
+    binding.status == "active",
+    binding.repo == "freed-project/freed",
+    binding.appId > 0,
+    !binding.appSlug.isEmpty
+  else {
+    try fail("The publisher binding identity is invalid.")
+  }
+  try validateLowercaseHex(binding.publisherSha256, count: 64, label: "publisher digest")
+  return binding
+}
+
+private func validateBinding(
+  _ binding: PublisherBinding,
+  parsed: ParsedCommand
+) throws -> String {
+  let executable = try currentExecutablePath()
+  #if RELEASE_TAG_PUBLISHER_HOST_TESTING
+    let testing = parsed.configPath != productionConfigPath
+  #else
+    let testing = false
+  #endif
+  try requireTrustedFile(executable, executable: true, testingOwnerAllowed: testing)
+  try requireTrustedParents(executable, testingOwnerAllowed: testing)
+  let boundPublisher = try canonicalExistingPath(binding.publisherPath, label: "bound publisher")
+  guard executable == boundPublisher else {
+    try fail("The running publisher does not match the bound publisher path.")
+  }
+  let digest = sha256(try readBoundedFile(executable, maximumBytes: 64 * 1_024 * 1_024))
+  guard digest == binding.publisherSha256 else {
+    try fail("The running publisher does not match the bound publisher digest.")
+  }
+  guard parsed.values["--repo"] == binding.repo else {
+    try fail("Publisher arguments do not match the root-owned App binding.")
+  }
+  if parsed.name != "publish" {
+    guard Int(parsed.values["--app-id"] ?? "") == binding.appId,
+      parsed.values["--app-slug"]?.lowercased() == binding.appSlug.lowercased()
+    else {
+      try fail("Publisher arguments do not match the root-owned App binding.")
+    }
+  }
+  return digest
+}
+
+private func readKeychainSecret() throws -> Data {
+  let query: [CFString: Any] = [
+    kSecClass: kSecClassGenericPassword,
+    kSecAttrService: keychainService,
+    kSecAttrAccount: keychainAccount,
+    kSecReturnData: true,
+    kSecMatchLimit: kSecMatchLimitOne,
+    kSecUseAuthenticationUI: kSecUseAuthenticationUIFail,
+  ]
+  var result: CFTypeRef?
+  let status = SecItemCopyMatching(query as CFDictionary, &result)
+  guard status == errSecSuccess, let data = result as? Data else {
+    try fail("The release GitHub App private key is unavailable in Keychain.")
+  }
+  return data
+}
+
+private func readPrivateKey(_ parsed: ParsedCommand) throws -> Data {
+  #if RELEASE_TAG_PUBLISHER_HOST_TESTING
+    if let path = parsed.testKeyFile {
+      let canonical = try canonicalExistingPath(path, label: "testing private key")
+      guard canonical == path else { try fail("The testing private key path must be canonical.") }
+      let metadata = try fileMetadata(path, followSymlink: true)
+      guard (metadata.st_mode & S_IFMT) == S_IFREG,
+        metadata.st_uid == getuid(),
+        metadata.st_mode & 0o077 == 0
+      else {
+        try fail("The testing private key must be a private file owned by the current user.")
+      }
+      return try readBoundedFile(path, maximumBytes: maximumKeyBytes)
+    }
+  #endif
+  return try readKeychainSecret()
+}
+
+private func privateRSAKey(from pem: Data) throws -> SecKey {
+  guard let text = String(data: pem, encoding: .utf8) else {
+    try fail("The release App key is not UTF-8 PKCS1 PEM.")
+  }
+  let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+  let begin = "-----BEGIN RSA PRIVATE KEY-----"
+  let end = "-----END RSA PRIVATE KEY-----"
+  guard trimmed.hasPrefix(begin), trimmed.hasSuffix(end),
+    !trimmed.contains("BEGIN PRIVATE KEY")
+  else {
+    try fail("The release App key must use PKCS1 RSA PRIVATE KEY PEM.")
+  }
+  let bodyStart = trimmed.index(trimmed.startIndex, offsetBy: begin.count)
+  let bodyEnd = trimmed.index(trimmed.endIndex, offsetBy: -end.count)
+  let body = trimmed[bodyStart..<bodyEnd]
+    .filter { !$0.isWhitespace }
+  guard !body.isEmpty, let der = Data(base64Encoded: String(body)) else {
+    try fail("The release App PKCS1 key body is invalid base64.")
+  }
+  let attributes: [CFString: Any] = [
+    kSecAttrKeyType: kSecAttrKeyTypeRSA,
+    kSecAttrKeyClass: kSecAttrKeyClassPrivate,
+  ]
+  var error: Unmanaged<CFError>?
+  guard let key = SecKeyCreateWithData(der as CFData, attributes as CFDictionary, &error) else {
+    try fail("The release App PKCS1 key cannot be imported.")
+  }
+  guard let details = SecKeyCopyAttributes(key) as? [CFString: Any],
+    let bits = details[kSecAttrKeySizeInBits] as? Int,
+    bits >= 2048
+  else {
+    try fail("The release App RSA key must contain at least 2,048 bits.")
+  }
+  return key
+}
+
+private func base64URL(_ data: Data) -> String {
+  data.base64EncodedString()
+    .replacingOccurrences(of: "+", with: "-")
+    .replacingOccurrences(of: "/", with: "_")
+    .replacingOccurrences(of: "=", with: "")
+}
+
+private func canonicalJSON(_ object: Any) throws -> Data {
+  try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys, .withoutEscapingSlashes])
+}
+
+private func appJWT(appId: Int, privateKey: SecKey) throws -> String {
+  let now = Int(Date().timeIntervalSince1970)
+  let header = try canonicalJSON(["alg": "RS256", "typ": "JWT"])
+  let payload = try canonicalJSON(["exp": now + 540, "iat": now - 30, "iss": appId])
+  let signingInput = "\(base64URL(header)).\(base64URL(payload))"
+  var error: Unmanaged<CFError>?
+  guard let signature = SecKeyCreateSignature(
+    privateKey,
+    .rsaSignatureMessagePKCS1v15SHA256,
+    Data(signingInput.utf8) as CFData,
+    &error
+  ) as Data? else {
+    try fail("The release App JWT could not be signed.")
+  }
+  return "\(signingInput).\(base64URL(signature))"
+}
+
+private final class GitHubClient: @unchecked Sendable {
+  private let baseURL: URL
+  private let session: URLSession
+
+  init(base: String) throws {
+    guard let url = URL(string: base), url.host != nil else {
+      try fail("The GitHub API base is invalid.")
+    }
+    baseURL = url
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.timeoutIntervalForRequest = requestTimeout
+    configuration.timeoutIntervalForResource = requestTimeout
+    configuration.requestCachePolicy = .reloadIgnoringLocalAndRemoteCacheData
+    configuration.httpCookieStorage = nil
+    configuration.urlCache = nil
+    session = URLSession(configuration: configuration)
+  }
+
+  func request(
+    method: String,
+    path: String,
+    token: String,
+    body: Any? = nil,
+    accepted: Set<Int>
+  ) throws -> HTTPResponse {
+    guard var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false) else {
+      try fail("The GitHub API base cannot be resolved.")
+    }
+    let parts = path.split(separator: "?", maxSplits: 1, omittingEmptySubsequences: false)
+    components.path = baseURL.path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+      .isEmpty ? String(parts[0]) : baseURL.path + String(parts[0])
+    if parts.count == 2 { components.percentEncodedQuery = String(parts[1]) }
+    guard let url = components.url else { try fail("A GitHub API request URL is invalid.") }
+    var request = URLRequest(url: url)
+    request.httpMethod = method
+    request.timeoutInterval = requestTimeout
+    request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+    request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+    request.setValue("2022-11-28", forHTTPHeaderField: "X-GitHub-Api-Version")
+    request.setValue("Freed-Release-Tag-Publisher", forHTTPHeaderField: "User-Agent")
+    if let body {
+      request.httpBody = try canonicalJSON(body)
+      request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    }
+
+    let semaphore = DispatchSemaphore(value: 0)
+    let lock = NSLock()
+    var responseData: Data?
+    var responseValue: URLResponse?
+    var responseError: Error?
+    let task = session.dataTask(with: request) { data, response, error in
+      lock.lock()
+      responseData = data
+      responseValue = response
+      responseError = error
+      lock.unlock()
+      semaphore.signal()
+    }
+    task.resume()
+    guard semaphore.wait(timeout: .now() + requestTimeout + 2) == .success else {
+      task.cancel()
+      try fail("A GitHub API request timed out.")
+    }
+    lock.lock()
+    let data = responseData ?? Data()
+    let response = responseValue
+    let error = responseError
+    lock.unlock()
+    if error != nil { try fail("A GitHub API request failed before receiving a response.") }
+    guard let http = response as? HTTPURLResponse else {
+      try fail("A GitHub API request returned no HTTP response.")
+    }
+    guard accepted.contains(http.statusCode) else {
+      try fail("GitHub API request \(method) \(path.split(separator: "?")[0]) returned HTTP \(http.statusCode).")
+    }
+    return HTTPResponse(status: http.statusCode, data: data)
+  }
+}
+
+private func jsonObject(_ data: Data, label: String) throws -> [String: Any] {
+  guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+    try fail("The \(label) response is not a JSON object.")
+  }
+  return object
+}
+
+private func installationContext(
+  binding: PublisherBinding,
+  key: SecKey,
+  client: GitHubClient
+) throws -> InstallationContext {
+  let jwt = try appJWT(appId: binding.appId, privateKey: key)
+  let appResponse = try client.request(method: "GET", path: "/app", token: jwt, accepted: [200])
+  let app = try jsonObject(appResponse.data, label: "GitHub App")
+  let expectedAppPermissions = ["contents": "write", "metadata": "read"]
+  guard app["id"] as? Int == binding.appId,
+    (app["slug"] as? String)?.lowercased() == binding.appSlug.lowercased(),
+    app["name"] as? String == "Freed Release Publisher",
+    app["external_url"] as? String == "https://freed.wtf",
+    app["events"] as? [String] == [],
+    app["permissions"] as? [String: String] == expectedAppPermissions,
+    let owner = app["owner"] as? [String: Any],
+    owner["login"] as? String == "freed-project",
+    owner["type"] as? String == "Organization"
+  else {
+    try fail("The Keychain key does not authenticate the exact private Freed Release Publisher App.")
+  }
+
+  let installationResponse = try client.request(
+    method: "GET",
+    path: "/repos/\(binding.repo)/installation",
+    token: jwt,
+    accepted: [200]
+  )
+  let installation = try jsonObject(installationResponse.data, label: "GitHub App installation")
+  guard let installationId = installation["id"] as? Int, installationId > 0,
+    let account = installation["account"] as? [String: Any],
+    let accountLogin = account["login"] as? String,
+    let accountType = account["type"] as? String,
+    let selection = installation["repository_selection"] as? String,
+    selection == "selected",
+    let permissions = installation["permissions"] as? [String: String],
+    permissions == ["contents": "write", "metadata": "read"],
+    installation["suspended_at"] is NSNull || installation["suspended_at"] == nil
+  else {
+    try fail("The release App installation must be active, selected-repository only, and have exactly Contents write plus Metadata read.")
+  }
+
+  let repositoryName = binding.repo.split(separator: "/").last.map(String.init) ?? ""
+  let tokenResponse = try client.request(
+    method: "POST",
+    path: "/app/installations/\(installationId)/access_tokens",
+    token: jwt,
+    body: [
+      "repositories": [repositoryName],
+      "permissions": ["contents": "write"],
+    ],
+    accepted: [201]
+  )
+  let tokenObject = try jsonObject(tokenResponse.data, label: "installation token")
+  guard let token = tokenObject["token"] as? String, token.count >= 20 else {
+    try fail("GitHub did not return a usable short-lived installation token.")
+  }
+  do {
+    let repositoriesResponse = try client.request(
+      method: "GET",
+      path: "/installation/repositories?per_page=100",
+      token: token,
+      accepted: [200]
+    )
+    let repositoriesObject = try jsonObject(
+      repositoriesResponse.data,
+      label: "installation repositories"
+    )
+    let repositoryNames = (repositoriesObject["repositories"] as? [[String: Any]] ?? [])
+      .compactMap { $0["full_name"] as? String }
+      .sorted()
+    guard repositoriesObject["total_count"] as? Int == 1,
+      repositoryNames == [binding.repo]
+    else {
+      try fail("The scoped installation token does not expose exactly the bound repository.")
+    }
+    return InstallationContext(
+      readiness: InstallationReadiness(
+        schemaVersion: 1,
+        purpose: "freed-release-tag-publisher-installation-readiness",
+        repo: binding.repo,
+        appId: binding.appId,
+        appSlug: binding.appSlug,
+        appName: "Freed Release Publisher",
+        appExternalUrl: "https://freed.wtf",
+        appOwnerLogin: "freed-project",
+        appOwnerType: "Organization",
+        appPermissions: expectedAppPermissions,
+        appEvents: [],
+        installationId: installationId,
+        accountLogin: accountLogin,
+        accountType: accountType,
+        repositorySelection: selection,
+        permissions: permissions,
+        repositories: repositoryNames
+      ),
+      token: token
+    )
+  } catch {
+    _ = try? client.request(
+      method: "DELETE", path: "/installation/token", token: token, accepted: [204])
+    throw error
+  }
+}
+
+private func revokeToken(_ context: inout InstallationContext, client: GitHubClient) throws {
+  let token = context.token
+  _ = try client.request(
+    method: "DELETE", path: "/installation/token", token: token, accepted: [204])
+  context.token = ""
+}
+
+private func emitJSON<T: Encodable>(_ value: T) throws {
+  let encoder = JSONEncoder()
+  encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+  FileHandle.standardOutput.write(try encoder.encode(value) + Data([0x0a]))
+}
+
+private func runGit(_ arguments: [String], worktree: String, home: String) throws -> String {
+  let process = Process()
+  process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+  process.arguments = [
+    "-c", "core.fsmonitor=false", "-c", "core.hooksPath=/dev/null",
+    "-c", "credential.helper=", "-C", worktree,
+  ] + arguments
+  process.currentDirectoryURL = URL(fileURLWithPath: worktree)
+  process.environment = [
+    "HOME": home,
+    "PATH": "/usr/bin:/bin",
+    "GIT_CONFIG_NOSYSTEM": "1",
+    "GIT_CONFIG_GLOBAL": "/dev/null",
+  ]
+  let output = Pipe()
+  let errors = Pipe()
+  process.standardOutput = output
+  process.standardError = errors
+  do { try process.run() } catch { try fail("The trusted git command could not start.") }
+  process.waitUntilExit()
+  guard process.terminationStatus == 0 else {
+    try fail("A trusted git validation command failed.")
+  }
+  let data = output.fileHandleForReading.readDataToEndOfFile()
+  guard let text = String(data: data, encoding: .utf8) else {
+    try fail("A trusted git command returned invalid text.")
+  }
+  return text.trimmingCharacters(in: .whitespacesAndNewlines)
+}
+
+private func validReleaseTag(_ value: String) -> Bool {
+  let suffix = value.hasSuffix("-dev") ? "-dev" : ""
+  let numeric = String(value.dropFirst().dropLast(suffix.count))
+  guard value.hasPrefix("v"), numeric.split(separator: ".").count == 3 else { return false }
+  return numeric.split(separator: ".").allSatisfy { part in
+    !part.isEmpty &&
+      part.utf8.allSatisfy { $0 >= 48 && $0 <= 57 } &&
+      (part.count == 1 || part.first != "0")
+  }
+}
+
+private func validateReceipt(_ data: Data, tag: String, channel: String) throws {
+  let object = try jsonObject(data, label: "release receipt")
+  guard object["tag"] as? String == tag,
+    object["version"] as? String == String(tag.dropFirst()),
+    object["channel"] as? String == channel,
+    object["approved"] as? Bool == true,
+    let source = object["source"] as? [String: Any],
+    source["channel"] as? String == channel
+  else {
+    try fail("The release receipt does not approve the requested tag and channel.")
+  }
+}
+
+private func remoteBranchSHA(
+  binding: PublisherBinding,
+  branch: String,
+  token: String,
+  client: GitHubClient
+) throws -> String {
+  let response = try client.request(
+    method: "GET",
+    path: "/repos/\(binding.repo)/git/ref/heads/\(branch)",
+    token: token,
+    accepted: [200]
+  )
+  let object = try jsonObject(response.data, label: "protected branch ref")
+  guard let target = object["object"] as? [String: Any],
+    let sha = target["sha"] as? String
+  else {
+    try fail("The protected branch response did not contain a commit SHA.")
+  }
+  return sha
+}
+
+private func remoteReceipt(
+  binding: PublisherBinding,
+  path: String,
+  commit: String,
+  token: String,
+  client: GitHubClient
+) throws -> Data {
+  let encodedPath = path.split(separator: "/").map { part in
+    String(part).addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
+  }.joined(separator: "/")
+  let response = try client.request(
+    method: "GET",
+    path: "/repos/\(binding.repo)/contents/\(encodedPath)?ref=\(commit)",
+    token: token,
+    accepted: [200]
+  )
+  let object = try jsonObject(response.data, label: "remote release receipt")
+  guard object["encoding"] as? String == "base64",
+    let encoded = object["content"] as? String,
+    let data = Data(base64Encoded: encoded.filter { !$0.isWhitespace })
+  else {
+    try fail("The remote release receipt is not canonical base64 content.")
+  }
+  return data
+}
+
+private func publish(
+  binding: PublisherBinding,
+  parsed: ParsedCommand,
+  key: SecKey,
+  client: GitHubClient,
+  home: String
+) throws {
+  let values = parsed.values
+  guard let worktreeValue = values["--worktree"],
+    let tag = values["--tag"],
+    let channel = values["--channel"],
+    let commit = values["--commit"],
+    let branch = values["--branch"],
+    let releaseFile = values["--release-file"],
+    let releaseDigest = values["--release-file-sha256"]
+  else { try fail("The publish request is incomplete.") }
+  let worktree = try canonicalExistingPath(worktreeValue, label: "release worktree")
+  guard worktree == worktreeValue,
+    try canonicalExistingPath(FileManager.default.currentDirectoryPath, label: "caller directory") == worktree
+  else {
+    try fail("The release publisher must run from the exact canonical release worktree.")
+  }
+  try validateLowercaseHex(commit, count: 40, label: "release commit")
+  try validateLowercaseHex(releaseDigest, count: 64, label: "release receipt digest")
+  guard validReleaseTag(tag),
+    ["dev", "production"].contains(channel),
+    (channel == "dev" ? branch == "dev" && tag.hasSuffix("-dev") : branch == "main" && !tag.hasSuffix("-dev")),
+    releaseFile == "release-notes/releases/\(tag).json"
+  else {
+    try fail("The tag, channel, branch, or release receipt path is invalid.")
+  }
+  guard try runGit(["rev-parse", "--show-toplevel"], worktree: worktree, home: home) == worktree,
+    try runGit(["symbolic-ref", "--short", "HEAD"], worktree: worktree, home: home) == branch,
+    try runGit(["rev-parse", "HEAD"], worktree: worktree, home: home) == commit,
+    try runGit(["status", "--porcelain", "--untracked-files=all"], worktree: worktree, home: home).isEmpty
+  else {
+    try fail("The release worktree is not the clean requested protected branch commit.")
+  }
+  let origin = try runGit(["remote", "get-url", "origin"], worktree: worktree, home: home)
+  let approvedOrigins = [
+    "https://github.com/\(binding.repo)",
+    "https://github.com/\(binding.repo).git",
+    "git@github.com:\(binding.repo).git",
+  ]
+  guard approvedOrigins.contains(origin) else {
+    try fail("The release worktree origin does not match the bound GitHub repository.")
+  }
+  let localReceiptPath = worktree + "/" + releaseFile
+  let canonicalReceipt = try canonicalExistingPath(localReceiptPath, label: "release receipt")
+  let receiptLink = try fileMetadata(localReceiptPath)
+  let receiptMetadata = try fileMetadata(localReceiptPath, followSymlink: true)
+  guard canonicalReceipt == localReceiptPath,
+    (receiptLink.st_mode & S_IFMT) != S_IFLNK,
+    (receiptMetadata.st_mode & S_IFMT) == S_IFREG
+  else {
+    try fail("The release receipt must be a canonical regular non-symlink file.")
+  }
+  let localReceipt = try readBoundedFile(localReceiptPath, maximumBytes: 2 * 1_024 * 1_024)
+  guard sha256(localReceipt) == releaseDigest else {
+    try fail("The local release receipt digest does not match the approved digest.")
+  }
+  try validateReceipt(localReceipt, tag: tag, channel: channel)
+
+  var context = try installationContext(binding: binding, key: key, client: client)
+  do {
+    guard try remoteBranchSHA(
+      binding: binding, branch: branch, token: context.token, client: client) == commit
+    else { try fail("The protected remote branch does not point at the requested release commit.") }
+    let committedReceipt = try remoteReceipt(
+      binding: binding,
+      path: releaseFile,
+      commit: commit,
+      token: context.token,
+      client: client
+    )
+    guard sha256(committedReceipt) == releaseDigest else {
+      try fail("The committed remote release receipt digest does not match the approved digest.")
+    }
+    try validateReceipt(committedReceipt, tag: tag, channel: channel)
+
+    let absent = try client.request(
+      method: "GET",
+      path: "/repos/\(binding.repo)/git/ref/tags/\(tag)",
+      token: context.token,
+      accepted: [200, 404]
+    )
+    guard absent.status == 404 else {
+      try fail("The requested immutable release tag already exists.")
+    }
+    let tagResponse = try client.request(
+      method: "POST",
+      path: "/repos/\(binding.repo)/git/tags",
+      token: context.token,
+      body: [
+        "tag": tag,
+        "message": "Freed release \(tag)",
+        "object": commit,
+        "type": "commit",
+      ],
+      accepted: [201]
+    )
+    let tagObject = try jsonObject(tagResponse.data, label: "annotated tag")
+    guard let tagObjectSHA = tagObject["sha"] as? String else {
+      try fail("GitHub did not return the annotated tag object SHA.")
+    }
+    guard try remoteBranchSHA(
+      binding: binding, branch: branch, token: context.token, client: client) == commit
+    else { try fail("The protected remote branch changed before tag creation.") }
+    _ = try client.request(
+      method: "POST",
+      path: "/repos/\(binding.repo)/git/refs",
+      token: context.token,
+      body: ["ref": "refs/tags/\(tag)", "sha": tagObjectSHA],
+      accepted: [201]
+    )
+    let refResponse = try client.request(
+      method: "GET",
+      path: "/repos/\(binding.repo)/git/ref/tags/\(tag)",
+      token: context.token,
+      accepted: [200]
+    )
+    let refObject = try jsonObject(refResponse.data, label: "created release tag ref")
+    guard let target = refObject["object"] as? [String: Any],
+      target["type"] as? String == "tag",
+      target["sha"] as? String == tagObjectSHA
+    else { try fail("The created release tag ref does not point at the annotated tag object.") }
+    let verifyTagResponse = try client.request(
+      method: "GET",
+      path: "/repos/\(binding.repo)/git/tags/\(tagObjectSHA)",
+      token: context.token,
+      accepted: [200]
+    )
+    let verifiedTag = try jsonObject(verifyTagResponse.data, label: "verified annotated tag")
+    guard verifiedTag["tag"] as? String == tag,
+      let targetCommit = verifiedTag["object"] as? [String: Any],
+      targetCommit["type"] as? String == "commit",
+      targetCommit["sha"] as? String == commit
+    else { try fail("The annotated release tag does not identify the approved commit.") }
+    try revokeToken(&context, client: client)
+    try emitJSON([
+      "schemaVersion": AnyEncodable(1),
+      "purpose": AnyEncodable("freed-release-tag-publish-result"),
+      "repo": AnyEncodable(binding.repo),
+      "tag": AnyEncodable(tag),
+      "commit": AnyEncodable(commit),
+      "tagObjectSha": AnyEncodable(tagObjectSHA),
+    ])
+  } catch {
+    if !context.token.isEmpty { try? revokeToken(&context, client: client) }
+    throw error
+  }
+}
+
+private func disableCoreDumps() throws {
+  var limit = rlimit(rlim_cur: 0, rlim_max: 0)
+  guard setrlimit(RLIMIT_CORE, &limit) == 0 else {
+    try fail("The publisher could not disable core dumps.")
+  }
+}
+
+private func clearEnvironment() {
+  for name in ProcessInfo.processInfo.environment.keys { unsetenv(name) }
+}
+
+private func main() -> Int32 {
+  do {
+    let rawArguments = Array(CommandLine.arguments.dropFirst())
+    let home = NSHomeDirectory()
+    _ = umask(0o077)
+    try disableCoreDumps()
+    clearEnvironment()
+    let parsed = try parseCommand(rawArguments)
+    let binding = try loadBinding(parsed.configPath)
+    let digest = try validateBinding(binding, parsed: parsed)
+    var secret = try readPrivateKey(parsed)
+    defer { secret.resetBytes(in: 0..<secret.count) }
+    let key = try privateRSAKey(from: secret)
+    secret.resetBytes(in: 0..<secret.count)
+    let client = try GitHubClient(base: parsed.apiBase)
+
+    switch parsed.name {
+    case "attest":
+      try emitJSON([
+        "schemaVersion": AnyEncodable(1),
+        "purpose": AnyEncodable("freed-release-tag-publisher-readiness"),
+        "repo": AnyEncodable(binding.repo),
+        "appId": AnyEncodable(binding.appId),
+        "appSlug": AnyEncodable(binding.appSlug),
+        "credentialMode": AnyEncodable("short-lived-installation-token"),
+        "operations": AnyEncodable(["create-annotated-tag"]),
+        "allowsArbitraryRefs": AnyEncodable(false),
+        "allowsUpdates": AnyEncodable(false),
+        "allowsDeletions": AnyEncodable(false),
+        "digest": AnyEncodable(digest),
+      ])
+    case "verify-installation":
+      var context = try installationContext(binding: binding, key: key, client: client)
+      do {
+        try revokeToken(&context, client: client)
+        try emitJSON(context.readiness)
+      } catch {
+        if !context.token.isEmpty { try? revokeToken(&context, client: client) }
+        throw error
+      }
+    case "publish":
+      try publish(binding: binding, parsed: parsed, key: key, client: client, home: home)
+    default:
+      try fail("Unsupported publisher command.")
+    }
+    return 0
+  } catch let error as HostFailure {
+    fputs("release-tag-publisher: \(error.description)\n", stderr)
+    return 1
+  } catch {
+    fputs("release-tag-publisher: an unexpected validation error occurred\n", stderr)
+    return 1
+  }
+}
+
+private struct AnyEncodable: Encodable {
+  private let encodeValue: (Encoder) throws -> Void
+  init<T: Encodable>(_ value: T) { encodeValue = value.encode }
+  func encode(to encoder: Encoder) throws { try encodeValue(encoder) }
+}
+
+exit(main())

--- a/scripts/release-tag-publisher-install.mjs
+++ b/scripts/release-tag-publisher-install.mjs
@@ -1,0 +1,446 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  chmodSync,
+  closeSync,
+  lstatSync,
+  mkdtempSync,
+  openSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const REPO_ROOT = path.resolve(path.dirname(__filename), "..");
+
+export const RELEASE_TAG_PUBLISHER_DIRECTORY =
+  "/Library/Application Support/Freed";
+export const RELEASE_TAG_PUBLISHER_HOST = path.join(
+  RELEASE_TAG_PUBLISHER_DIRECTORY,
+  "release-tag-publisher",
+);
+export const RELEASE_TAG_PUBLISHER_PROVISIONER = path.join(
+  RELEASE_TAG_PUBLISHER_DIRECTORY,
+  "release-tag-publisher-provision",
+);
+export const RELEASE_TAG_PUBLISHER_CONFIG = path.join(
+  RELEASE_TAG_PUBLISHER_DIRECTORY,
+  "release-tag-publisher.json",
+);
+
+class InstallerError extends Error {}
+
+function fail(message) {
+  throw new InstallerError(message);
+}
+
+function defaultDependencies() {
+  return {
+    repoRoot: REPO_ROOT,
+    tempRoot: os.tmpdir(),
+    buildScript: path.join(
+      REPO_ROOT,
+      "scripts",
+      "release-tag-publisher-build.sh",
+    ),
+    hostPath: RELEASE_TAG_PUBLISHER_HOST,
+    provisionerPath: RELEASE_TAG_PUBLISHER_PROVISIONER,
+    configPath: RELEASE_TAG_PUBLISHER_CONFIG,
+    run: spawnSync,
+  };
+}
+
+function dependenciesWith(overrides = {}) {
+  return { ...defaultDependencies(), ...overrides };
+}
+
+function runChecked(dependencies, executable, args, options = {}) {
+  const result = dependencies.run(executable, args, {
+    cwd: options.cwd ?? dependencies.repoRoot,
+    encoding: options.encoding ?? "utf8",
+    stdio: options.stdio,
+    env: {
+      HOME: process.env.HOME ?? "",
+      PATH: "/usr/bin:/bin",
+    },
+  });
+  if (result.error || result.status !== 0) {
+    const detail = String(result.stderr ?? "").trim();
+    fail(
+      `${options.purpose ?? executable} failed${detail ? `: ${detail}` : "."}`,
+    );
+  }
+  return String(result.stdout ?? "").trim();
+}
+
+function sha256File(filePath) {
+  return createHash("sha256").update(readFileSync(filePath)).digest("hex");
+}
+
+function inspectInstalledHost(filePath) {
+  if (!path.isAbsolute(filePath) || realpathSync(filePath) !== filePath) {
+    fail("The installed publisher host must use a canonical absolute path.");
+  }
+  const link = lstatSync(filePath);
+  const metadata = statSync(filePath);
+  if (
+    link.isSymbolicLink() ||
+    !metadata.isFile() ||
+    metadata.uid !== 0 ||
+    (metadata.mode & 0o022) !== 0 ||
+    (metadata.mode & 0o111) === 0
+  ) {
+    fail(
+      "The installed publisher host is not a root-owned immutable executable.",
+    );
+  }
+  return filePath;
+}
+
+function withPrivateDirectory(dependencies, operation) {
+  const created = mkdtempSync(
+    path.join(dependencies.tempRoot, "freed-release-tag-publisher-"),
+  );
+  const directory = realpathSync(created);
+  chmodSync(directory, 0o700);
+  try {
+    return operation(directory);
+  } finally {
+    rmSync(directory, { force: true, recursive: true });
+  }
+}
+
+function sudoInstall(dependencies, args, purpose) {
+  runChecked(dependencies, "/usr/bin/sudo", ["/usr/bin/install", ...args], {
+    purpose,
+  });
+}
+
+export function prepareReleaseTagPublisher({ dependencies: overrides } = {}) {
+  const dependencies = dependenciesWith(overrides);
+  return withPrivateDirectory(dependencies, (directory) => {
+    const hostOutput = path.join(directory, "release-tag-publisher");
+    const provisionerOutput = path.join(
+      directory,
+      "release-tag-publisher-provision",
+    );
+    runChecked(
+      dependencies,
+      "/bin/bash",
+      [
+        dependencies.buildScript,
+        "--host-output",
+        hostOutput,
+        "--provisioner-output",
+        provisionerOutput,
+      ],
+      { purpose: "Release tag publisher native build" },
+    );
+    sudoInstall(
+      dependencies,
+      [
+        "-d",
+        "-o",
+        "root",
+        "-g",
+        "wheel",
+        "-m",
+        "0755",
+        path.dirname(dependencies.hostPath),
+      ],
+      "Release tag publisher directory installation",
+    );
+    sudoInstall(
+      dependencies,
+      [
+        "-o",
+        "root",
+        "-g",
+        "wheel",
+        "-m",
+        "0555",
+        hostOutput,
+        dependencies.hostPath,
+      ],
+      "Release tag publisher host installation",
+    );
+    sudoInstall(
+      dependencies,
+      [
+        "-o",
+        "root",
+        "-g",
+        "wheel",
+        "-m",
+        "0555",
+        provisionerOutput,
+        dependencies.provisionerPath,
+      ],
+      "Release tag publisher provisioner installation",
+    );
+    return {
+      action: "prepare",
+      hostPath: dependencies.hostPath,
+      provisionerPath: dependencies.provisionerPath,
+      publisherSha256: sha256File(dependencies.hostPath),
+    };
+  });
+}
+
+function validateAppIdentity(appId, appSlug) {
+  const numericId = Number(appId);
+  if (!Number.isSafeInteger(numericId) || numericId <= 0) {
+    fail("The release GitHub App ID must be a positive integer.");
+  }
+  if (
+    typeof appSlug !== "string" ||
+    !/^[a-z0-9](?:[a-z0-9-]{0,98}[a-z0-9])?$/.test(appSlug)
+  ) {
+    fail("The release GitHub App slug is invalid.");
+  }
+  return { appId: numericId, appSlug };
+}
+
+export function activateReleaseTagPublisher({
+  appId,
+  appSlug,
+  dependencies: overrides,
+}) {
+  const dependencies = dependenciesWith(overrides);
+  const identity = validateAppIdentity(appId, appSlug);
+  inspectInstalledHost(dependencies.hostPath);
+  inspectInstalledHost(dependencies.provisionerPath);
+  const publisherSha256 = sha256File(dependencies.hostPath);
+  const binding = {
+    schemaVersion: 1,
+    purpose: "freed-release-tag-publisher-binding",
+    status: "active",
+    repo: "freed-project/freed",
+    appId: identity.appId,
+    appSlug: identity.appSlug,
+    publisherPath: dependencies.hostPath,
+    publisherSha256,
+  };
+  withPrivateDirectory(dependencies, (directory) => {
+    const source = path.join(directory, "release-tag-publisher.json");
+    writeFileSync(source, `${JSON.stringify(binding, null, 2)}\n`, {
+      mode: 0o600,
+    });
+    sudoInstall(
+      dependencies,
+      [
+        "-o",
+        "root",
+        "-g",
+        "wheel",
+        "-m",
+        "0444",
+        source,
+        dependencies.configPath,
+      ],
+      "Release tag publisher binding installation",
+    );
+  });
+  const attestation = runChecked(
+    dependencies,
+    dependencies.hostPath,
+    [
+      "attest",
+      "--repo",
+      binding.repo,
+      "--app-id",
+      String(binding.appId),
+      "--app-slug",
+      binding.appSlug,
+    ],
+    { purpose: "Release tag publisher local attestation" },
+  );
+  return { action: "activate", binding, attestation: JSON.parse(attestation) };
+}
+
+function inspectPrivateKeyFile(filePath) {
+  if (!path.isAbsolute(filePath) || realpathSync(filePath) !== filePath) {
+    fail("The private key file must use a canonical absolute path.");
+  }
+  const link = lstatSync(filePath);
+  const metadata = statSync(filePath);
+  if (
+    link.isSymbolicLink() ||
+    !metadata.isFile() ||
+    metadata.uid !== process.getuid() ||
+    (metadata.mode & 0o077) !== 0
+  ) {
+    fail(
+      "The private key file must be a mode 0600 file owned by the current user.",
+    );
+  }
+  return filePath;
+}
+
+function invokeProvisioner(dependencies, action, privateKeyFile = null) {
+  const fd = privateKeyFile === null ? null : openSync(privateKeyFile, "r");
+  try {
+    runChecked(
+      dependencies,
+      dependencies.provisionerPath,
+      [action, "--host", dependencies.hostPath],
+      {
+        purpose: `Release tag publisher key ${action}`,
+        stdio: [fd ?? "ignore", "pipe", "pipe"],
+      },
+    );
+  } finally {
+    if (fd !== null) closeSync(fd);
+  }
+}
+
+export function provisionReleaseTagPublisher({
+  appId,
+  appSlug,
+  privateKeyFile,
+  dependencies: overrides,
+}) {
+  const dependencies = dependenciesWith(overrides);
+  const keyFile = inspectPrivateKeyFile(privateKeyFile);
+  const prepared = prepareReleaseTagPublisher({ dependencies });
+  try {
+    invokeProvisioner(dependencies, "provision", keyFile);
+    const activated = activateReleaseTagPublisher({
+      appId,
+      appSlug,
+      dependencies,
+    });
+    return { action: "provision", prepared, activated };
+  } catch (error) {
+    try {
+      invokeProvisioner(dependencies, "revoke");
+    } catch {}
+    throw error;
+  }
+}
+
+export function verifyReleaseTagPublisher({ dependencies: overrides } = {}) {
+  const dependencies = dependenciesWith(overrides);
+  const binding = JSON.parse(readFileSync(dependencies.configPath, "utf8"));
+  inspectInstalledHost(dependencies.hostPath);
+  invokeProvisioner(dependencies, "verify");
+  const readiness = runChecked(
+    dependencies,
+    dependencies.hostPath,
+    [
+      "verify-installation",
+      "--repo",
+      binding.repo,
+      "--app-id",
+      String(binding.appId),
+      "--app-slug",
+      binding.appSlug,
+    ],
+    { purpose: "Release tag publisher installation verification" },
+  );
+  return { action: "verify", readiness: JSON.parse(readiness) };
+}
+
+export function rotateReleaseTagPublisher({
+  privateKeyFile,
+  dependencies: overrides,
+}) {
+  const dependencies = dependenciesWith(overrides);
+  invokeProvisioner(
+    dependencies,
+    "rotate",
+    inspectPrivateKeyFile(privateKeyFile),
+  );
+  return { action: "rotate" };
+}
+
+export function revokeReleaseTagPublisher({ dependencies: overrides } = {}) {
+  const dependencies = dependenciesWith(overrides);
+  invokeProvisioner(dependencies, "revoke");
+  runChecked(
+    dependencies,
+    "/usr/bin/sudo",
+    ["/bin/rm", "-f", dependencies.configPath],
+    { purpose: "Release tag publisher binding revocation" },
+  );
+  return { action: "revoke" };
+}
+
+function parseOptions(argv) {
+  const options = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const flag = argv[index];
+    if (!["--app-id", "--app-slug", "--private-key-file"].includes(flag)) {
+      fail(`Unknown installer option: ${flag}`);
+    }
+    const value = argv[index + 1];
+    if (!value || value.startsWith("--") || options[flag] !== undefined) {
+      fail(`Installer option ${flag} requires one value and may appear once.`);
+    }
+    options[flag] = value;
+    index += 1;
+  }
+  return options;
+}
+
+function main(argv) {
+  const [command, ...rest] = argv;
+  const options = parseOptions(rest);
+  let result;
+  switch (command) {
+    case "prepare":
+      if (rest.length !== 0) fail("prepare accepts no options.");
+      result = prepareReleaseTagPublisher();
+      break;
+    case "activate":
+      result = activateReleaseTagPublisher({
+        appId: options["--app-id"],
+        appSlug: options["--app-slug"],
+      });
+      break;
+    case "provision":
+      result = provisionReleaseTagPublisher({
+        appId: options["--app-id"],
+        appSlug: options["--app-slug"],
+        privateKeyFile: options["--private-key-file"],
+      });
+      break;
+    case "verify":
+      if (rest.length !== 0) fail("verify accepts no options.");
+      result = verifyReleaseTagPublisher();
+      break;
+    case "rotate":
+      result = rotateReleaseTagPublisher({
+        privateKeyFile: options["--private-key-file"],
+      });
+      break;
+    case "revoke":
+      if (rest.length !== 0) fail("revoke accepts no options.");
+      result = revokeReleaseTagPublisher();
+      break;
+    default:
+      fail(
+        "Usage: node scripts/release-tag-publisher-install.mjs <prepare|activate|provision|verify|rotate|revoke> [options]",
+      );
+  }
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+if (process.argv[1] === __filename) {
+  try {
+    main(process.argv.slice(2));
+  } catch (error) {
+    process.stderr.write(
+      `${error instanceof Error ? error.message : String(error)}\n`,
+    );
+    process.exitCode = 1;
+  }
+}

--- a/scripts/release-tag-publisher-native.test.mjs
+++ b/scripts/release-tag-publisher-native.test.mjs
@@ -1,0 +1,473 @@
+import assert from "node:assert/strict";
+import { execFileSync, spawn } from "node:child_process";
+import { createHash, generateKeyPairSync } from "node:crypto";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import test, { after, before } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const enabled = process.platform === "darwin";
+const secretToken = "installation-secret-token-do-not-print";
+const tagObjectSha = "b".repeat(40);
+const tag = "v26.7.1302-dev";
+
+let fixtureRoot;
+let host;
+let configPath;
+let keyPath;
+let worktree;
+let commit;
+let receipt;
+let receiptDigest;
+let apiBase;
+let server;
+let tagCreated = false;
+let revokedTokens = 0;
+const requests = [];
+
+function sha256(filePath) {
+  return createHash("sha256").update(readFileSync(filePath)).digest("hex");
+}
+
+function git(args, cwd) {
+  return execFileSync("/usr/bin/git", args, {
+    cwd,
+    encoding: "utf8",
+    env: {
+      HOME: process.env.HOME,
+      PATH: "/usr/bin:/bin",
+      GIT_CONFIG_NOSYSTEM: "1",
+      GIT_CONFIG_GLOBAL: "/dev/null",
+    },
+  }).trim();
+}
+
+function json(response, status, value) {
+  response.writeHead(status, { "content-type": "application/json" });
+  response.end(JSON.stringify(value));
+}
+
+function readBody(request) {
+  return new Promise((resolve) => {
+    const chunks = [];
+    request.on("data", (chunk) => chunks.push(chunk));
+    request.on("end", () => {
+      const data = Buffer.concat(chunks);
+      resolve(data.length === 0 ? null : JSON.parse(data.toString("utf8")));
+    });
+  });
+}
+
+function runHost(args, cwd = fixtureRoot) {
+  return new Promise((resolve) => {
+    const child = spawn(host, args, {
+      cwd,
+      env: { PATH: "/usr/bin:/bin" },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString("utf8");
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString("utf8");
+    });
+    child.on("close", (status) => resolve({ status, stdout, stderr }));
+  });
+}
+
+function testingFlags() {
+  return [
+    "--config",
+    configPath,
+    "--test-key-file",
+    keyPath,
+    "--api-base",
+    apiBase,
+  ];
+}
+
+function identityArgs(repo = "freed-project/freed") {
+  return [
+    "--repo",
+    repo,
+    "--app-id",
+    "123456",
+    "--app-slug",
+    "freed-release-publisher",
+    ...testingFlags(),
+  ];
+}
+
+function publishArgs(overrides = {}) {
+  const values = {
+    repo: "freed-project/freed",
+    worktree,
+    tag,
+    channel: "dev",
+    commit,
+    branch: "dev",
+    releaseFile: `release-notes/releases/${tag}.json`,
+    releaseDigest: receiptDigest,
+    ...overrides,
+  };
+  return [
+    "publish",
+    "--repo",
+    values.repo,
+    "--worktree",
+    values.worktree,
+    "--tag",
+    values.tag,
+    "--channel",
+    values.channel,
+    "--commit",
+    values.commit,
+    "--branch",
+    values.branch,
+    "--release-file",
+    values.releaseFile,
+    "--release-file-sha256",
+    values.releaseDigest,
+    ...testingFlags(),
+  ];
+}
+
+before(async () => {
+  if (!enabled) return;
+  fixtureRoot = realpathSync(
+    mkdtempSync(path.join(os.tmpdir(), "freed-release-publisher-native-")),
+  );
+  chmodSync(fixtureRoot, 0o700);
+  const productionHost = path.join(fixtureRoot, "production-host");
+  const productionProvisioner = path.join(
+    fixtureRoot,
+    "production-provisioner",
+  );
+  execFileSync(
+    path.join(root, "scripts", "release-tag-publisher-build.sh"),
+    [
+      "--host-output",
+      productionHost,
+      "--provisioner-output",
+      productionProvisioner,
+    ],
+    { cwd: root, stdio: "pipe" },
+  );
+  assert.equal(readFileSync(productionHost).length > 0, true);
+  assert.equal(readFileSync(productionProvisioner).length > 0, true);
+
+  host = path.join(fixtureRoot, "release-tag-publisher-test");
+  execFileSync(
+    "/usr/bin/xcrun",
+    [
+      "--sdk",
+      "macosx",
+      "swiftc",
+      "-D",
+      "RELEASE_TAG_PUBLISHER_HOST_TESTING",
+      "-O",
+      path.join(root, "scripts", "release-tag-publisher-host.swift"),
+      "-o",
+      host,
+      "-framework",
+      "Foundation",
+      "-framework",
+      "Security",
+      "-framework",
+      "CryptoKit",
+    ],
+    { cwd: root, stdio: "pipe" },
+  );
+  chmodSync(host, 0o700);
+
+  const { privateKey } = generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+    privateKeyEncoding: { format: "pem", type: "pkcs1" },
+    publicKeyEncoding: { format: "pem", type: "spki" },
+  });
+  keyPath = path.join(fixtureRoot, "release-app.pem");
+  writeFileSync(keyPath, privateKey, { mode: 0o600 });
+  configPath = path.join(fixtureRoot, "release-tag-publisher.json");
+  writeFileSync(
+    configPath,
+    `${JSON.stringify(
+      {
+        schemaVersion: 1,
+        purpose: "freed-release-tag-publisher-binding",
+        status: "active",
+        repo: "freed-project/freed",
+        appId: 123456,
+        appSlug: "freed-release-publisher",
+        publisherPath: host,
+        publisherSha256: sha256(host),
+      },
+      null,
+      2,
+    )}\n`,
+    { mode: 0o600 },
+  );
+
+  worktree = path.join(fixtureRoot, "repo");
+  mkdirSync(path.join(worktree, "release-notes", "releases"), {
+    recursive: true,
+  });
+  receipt = Buffer.from(
+    `${JSON.stringify({
+      tag,
+      version: tag.slice(1),
+      channel: "dev",
+      approved: true,
+      source: { channel: "dev", productCommitSha: "a".repeat(40) },
+    })}\n`,
+  );
+  writeFileSync(
+    path.join(worktree, "release-notes", "releases", `${tag}.json`),
+    receipt,
+  );
+  git(["init", "-b", "dev"], worktree);
+  git(["config", "user.name", "Release Test"], worktree);
+  git(["config", "user.email", "release-test@example.invalid"], worktree);
+  git(["add", "."], worktree);
+  git(["commit", "-m", "test: release receipt"], worktree);
+  git(
+    ["remote", "add", "origin", "https://github.com/freed-project/freed.git"],
+    worktree,
+  );
+  commit = git(["rev-parse", "HEAD"], worktree);
+  receiptDigest = createHash("sha256").update(receipt).digest("hex");
+
+  server = http.createServer(async (request, response) => {
+    const body = await readBody(request);
+    requests.push({
+      method: request.method,
+      url: request.url,
+      authorization: request.headers.authorization,
+      body,
+    });
+    const url = new URL(request.url, "http://127.0.0.1");
+    if (request.method === "GET" && url.pathname === "/app") {
+      return json(response, 200, {
+        id: 123456,
+        slug: "freed-release-publisher",
+        name: "Freed Release Publisher",
+        external_url: "https://freed.wtf",
+        events: [],
+        permissions: { contents: "write", metadata: "read" },
+        owner: { login: "freed-project", type: "Organization" },
+      });
+    }
+    if (
+      request.method === "GET" &&
+      url.pathname === "/repos/freed-project/freed/installation"
+    ) {
+      return json(response, 200, {
+        id: 42,
+        account: { login: "freed-project", type: "Organization" },
+        repository_selection: "selected",
+        permissions: { contents: "write", metadata: "read" },
+        suspended_at: null,
+      });
+    }
+    if (
+      request.method === "POST" &&
+      url.pathname === "/app/installations/42/access_tokens"
+    ) {
+      assert.deepEqual(body, {
+        permissions: { contents: "write" },
+        repositories: ["freed"],
+      });
+      return json(response, 201, { token: secretToken });
+    }
+    if (
+      request.method === "GET" &&
+      url.pathname === "/installation/repositories"
+    ) {
+      return json(response, 200, {
+        total_count: 1,
+        repositories: [{ full_name: "freed-project/freed" }],
+      });
+    }
+    if (request.method === "DELETE" && url.pathname === "/installation/token") {
+      revokedTokens += 1;
+      response.writeHead(204);
+      return response.end();
+    }
+    if (
+      request.method === "GET" &&
+      url.pathname === "/repos/freed-project/freed/git/ref/heads/dev"
+    ) {
+      return json(response, 200, { object: { type: "commit", sha: commit } });
+    }
+    if (
+      request.method === "GET" &&
+      url.pathname ===
+        `/repos/freed-project/freed/contents/release-notes/releases/${tag}.json`
+    ) {
+      assert.equal(url.searchParams.get("ref"), commit);
+      return json(response, 200, {
+        encoding: "base64",
+        content: receipt.toString("base64"),
+      });
+    }
+    if (
+      request.method === "GET" &&
+      url.pathname === `/repos/freed-project/freed/git/ref/tags/${tag}`
+    ) {
+      return tagCreated
+        ? json(response, 200, { object: { type: "tag", sha: tagObjectSha } })
+        : json(response, 404, { message: "Not Found" });
+    }
+    if (
+      request.method === "POST" &&
+      url.pathname === "/repos/freed-project/freed/git/tags"
+    ) {
+      assert.deepEqual(body, {
+        message: `Freed release ${tag}`,
+        object: commit,
+        tag,
+        type: "commit",
+      });
+      return json(response, 201, { sha: tagObjectSha });
+    }
+    if (
+      request.method === "POST" &&
+      url.pathname === "/repos/freed-project/freed/git/refs"
+    ) {
+      assert.deepEqual(body, {
+        ref: `refs/tags/${tag}`,
+        sha: tagObjectSha,
+      });
+      tagCreated = true;
+      return json(response, 201, { ref: `refs/tags/${tag}` });
+    }
+    if (
+      request.method === "GET" &&
+      url.pathname === `/repos/freed-project/freed/git/tags/${tagObjectSha}`
+    ) {
+      return json(response, 200, {
+        tag,
+        object: { type: "commit", sha: commit },
+      });
+    }
+    return json(response, 500, {
+      message: `Unexpected ${request.method} ${request.url}`,
+    });
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  apiBase = `http://127.0.0.1:${server.address().port}`;
+});
+
+after(async () => {
+  if (server) await new Promise((resolve) => server.close(resolve));
+  if (fixtureRoot) rmSync(fixtureRoot, { force: true, recursive: true });
+});
+
+test("production native publisher tools compile", { skip: !enabled }, () => {
+  assert.ok(host);
+  const hostSource = readFileSync(
+    path.join(root, "scripts", "release-tag-publisher-host.swift"),
+    "utf8",
+  );
+  const provisionerSource = readFileSync(
+    path.join(root, "scripts", "release-tag-publisher-provision.swift"),
+    "utf8",
+  );
+  assert.match(hostSource, /kSecUseAuthenticationUIFail/);
+  assert.match(provisionerSource, /kSecUseAuthenticationUIFail/);
+});
+
+test(
+  "native installation verification proves exact App and repository scope",
+  { skip: !enabled },
+  async () => {
+    const result = await runHost(["verify-installation", ...identityArgs()]);
+    assert.equal(result.status, 0, result.stderr);
+    const value = JSON.parse(result.stdout);
+    assert.equal(
+      value.purpose,
+      "freed-release-tag-publisher-installation-readiness",
+    );
+    assert.equal(value.appName, "Freed Release Publisher");
+    assert.equal(value.appOwnerLogin, "freed-project");
+    assert.deepEqual(value.appPermissions, {
+      contents: "write",
+      metadata: "read",
+    });
+    assert.deepEqual(value.repositories, ["freed-project/freed"]);
+    assert.doesNotMatch(result.stdout + result.stderr, new RegExp(secretToken));
+  },
+);
+
+test(
+  "native publisher rejects wrong repository",
+  { skip: !enabled },
+  async () => {
+    const result = await runHost([
+      "verify-installation",
+      ...identityArgs("freed-project/not-freed"),
+    ]);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /do not match the root-owned App binding/);
+    assert.doesNotMatch(result.stderr, new RegExp(secretToken));
+  },
+);
+
+test(
+  "native publisher rejects wrong branch and receipt digest",
+  { skip: !enabled },
+  async () => {
+    const wrongBranch = await runHost(
+      publishArgs({ branch: "main" }),
+      worktree,
+    );
+    assert.equal(wrongBranch.status, 1);
+    assert.match(wrongBranch.stderr, /tag, channel, branch/);
+    const wrongDigest = await runHost(
+      publishArgs({ releaseDigest: "f".repeat(64) }),
+      worktree,
+    );
+    assert.equal(wrongDigest.status, 1);
+    assert.match(wrongDigest.stderr, /local release receipt digest/);
+    assert.doesNotMatch(
+      wrongBranch.stderr + wrongDigest.stderr,
+      new RegExp(secretToken),
+    );
+  },
+);
+
+test(
+  "native publisher creates and verifies one annotated tag then revokes its token",
+  { skip: !enabled },
+  async () => {
+    const revokedBefore = revokedTokens;
+    const result = await runHost(publishArgs(), worktree);
+    assert.equal(result.status, 0, result.stderr);
+    const value = JSON.parse(result.stdout);
+    assert.equal(value.schemaVersion, 1);
+    assert.equal(value.tag, tag);
+    assert.equal(value.commit, commit);
+    assert.equal(tagCreated, true);
+    assert.equal(revokedTokens, revokedBefore + 1);
+    const mutationOrder = requests
+      .filter((item) => item.method === "POST")
+      .map((item) => item.url);
+    assert.ok(
+      mutationOrder.indexOf("/repos/freed-project/freed/git/tags") <
+        mutationOrder.indexOf("/repos/freed-project/freed/git/refs"),
+    );
+    assert.doesNotMatch(result.stdout + result.stderr, new RegExp(secretToken));
+  },
+);

--- a/scripts/release-tag-publisher-provision.swift
+++ b/scripts/release-tag-publisher-provision.swift
@@ -1,0 +1,333 @@
+import Darwin
+import Foundation
+import Security
+
+private let keychainService = "freed-release-tag-publisher"
+private let keychainAccount = "github-app-private-key"
+private let maximumKeyBytes = 32 * 1_024
+
+private struct ProvisionFailure: Error, CustomStringConvertible {
+  let description: String
+  init(_ description: String) { self.description = description }
+}
+
+private enum StoreFailure: Error {
+  case missing
+  case duplicate
+}
+
+private func fail(_ message: String) throws -> Never {
+  throw ProvisionFailure(message)
+}
+
+private func canonicalExistingPath(_ path: String, label: String) throws -> String {
+  guard path.hasPrefix("/"), !path.contains("\n"), !path.contains("\r") else {
+    try fail("The \(label) must be an absolute path without control characters.")
+  }
+  guard let resolved = realpath(path, nil) else {
+    try fail("The \(label) does not resolve to an existing path.")
+  }
+  defer { free(resolved) }
+  return String(cString: resolved)
+}
+
+private func currentExecutablePath() throws -> String {
+  var size: UInt32 = 0
+  _ = _NSGetExecutablePath(nil, &size)
+  var buffer = [CChar](repeating: 0, count: Int(size))
+  guard _NSGetExecutablePath(&buffer, &size) == 0 else {
+    try fail("The publisher provisioner path is unavailable.")
+  }
+  return try canonicalExistingPath(String(cString: buffer), label: "publisher provisioner")
+}
+
+private func requireRootOwnedExecutable(_ path: String) throws {
+  let canonical = try canonicalExistingPath(path, label: "publisher executable")
+  guard canonical == path else { try fail("Publisher executables must use canonical paths.") }
+  var link = stat()
+  var metadata = stat()
+  let linkStatus = path.withCString {
+    fstatat(AT_FDCWD, $0, &link, AT_SYMLINK_NOFOLLOW)
+  }
+  let metadataStatus = path.withCString {
+    fstatat(AT_FDCWD, $0, &metadata, 0)
+  }
+  guard linkStatus == 0, metadataStatus == 0,
+    (link.st_mode & S_IFMT) != S_IFLNK,
+    (metadata.st_mode & S_IFMT) == S_IFREG,
+    metadata.st_uid == 0,
+    metadata.st_mode & 0o022 == 0,
+    metadata.st_mode & 0o111 != 0
+  else {
+    try fail("Publisher executables must be root owned, executable, and immutable to other users.")
+  }
+}
+
+private func validatePKCS1PEM(_ data: Data) throws {
+  guard !data.isEmpty, data.count <= maximumKeyBytes,
+    let text = String(data: data, encoding: .utf8)
+  else { try fail("The release App key is empty, oversized, or not UTF-8.") }
+  let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+  let begin = "-----BEGIN RSA PRIVATE KEY-----"
+  let end = "-----END RSA PRIVATE KEY-----"
+  guard trimmed.hasPrefix(begin), trimmed.hasSuffix(end) else {
+    try fail("The release App key must use PKCS1 RSA PRIVATE KEY PEM.")
+  }
+  let start = trimmed.index(trimmed.startIndex, offsetBy: begin.count)
+  let finish = trimmed.index(trimmed.endIndex, offsetBy: -end.count)
+  let body = trimmed[start..<finish].filter { !$0.isWhitespace }
+  guard !body.isEmpty, let der = Data(base64Encoded: String(body)) else {
+    try fail("The release App PKCS1 key body is invalid base64.")
+  }
+  let attributes: [CFString: Any] = [
+    kSecAttrKeyType: kSecAttrKeyTypeRSA,
+    kSecAttrKeyClass: kSecAttrKeyClassPrivate,
+  ]
+  var error: Unmanaged<CFError>?
+  guard let key = SecKeyCreateWithData(der as CFData, attributes as CFDictionary, &error),
+    let details = SecKeyCopyAttributes(key) as? [CFString: Any],
+    let bits = details[kSecAttrKeySizeInBits] as? Int,
+    bits >= 2048
+  else { try fail("The release App key must be a valid RSA key with at least 2,048 bits.") }
+}
+
+private func readSecretFromStandardInput() throws -> Data {
+  let data = FileHandle.standardInput.readData(ofLength: maximumKeyBytes + 1)
+  try validatePKCS1PEM(data)
+  return data
+}
+
+private final class KeychainStore {
+  private func query() -> [CFString: Any] {
+    [
+      kSecClass: kSecClassGenericPassword,
+      kSecAttrService: keychainService,
+      kSecAttrAccount: keychainAccount,
+    ]
+  }
+
+  private func trustedApplication(_ path: String) throws -> SecTrustedApplication {
+    var application: SecTrustedApplication?
+    let status = path.withCString { SecTrustedApplicationCreateFromPath($0, &application) }
+    guard status == errSecSuccess, let application else {
+      try fail("A publisher Keychain application identity could not be created.")
+    }
+    return application
+  }
+
+  private func applicationData(_ application: SecTrustedApplication) throws -> Data {
+    var data: CFData?
+    guard SecTrustedApplicationCopyData(application, &data) == errSecSuccess, let data else {
+      try fail("A publisher Keychain application identity is unreadable.")
+    }
+    return data as Data
+  }
+
+  private func access(host: String, provisioner: String) throws -> SecAccess {
+    let applications = [
+      try trustedApplication(host),
+      try trustedApplication(provisioner),
+    ] as CFArray
+    var access: SecAccess?
+    let status = SecAccessCreate(
+      "Freed release tag publisher private key" as CFString,
+      applications,
+      &access
+    )
+    guard status == errSecSuccess, let access else {
+      try fail("The publisher-only Keychain ACL could not be created.")
+    }
+    return access
+  }
+
+  private func itemReference() throws -> SecKeychainItem {
+    var itemQuery = query()
+    itemQuery[kSecReturnRef] = true
+    itemQuery[kSecMatchLimit] = kSecMatchLimitOne
+    itemQuery[kSecUseAuthenticationUI] = kSecUseAuthenticationUIFail
+    var result: CFTypeRef?
+    let status = SecItemCopyMatching(itemQuery as CFDictionary, &result)
+    if status == errSecItemNotFound { throw StoreFailure.missing }
+    guard status == errSecSuccess, let item = result as! SecKeychainItem? else {
+      try fail("The publisher Keychain item reference is unavailable.")
+    }
+    return item
+  }
+
+  private func aclMatches(host: String, provisioner: String) throws -> Bool {
+    let item = try itemReference()
+    var itemAccess: SecAccess?
+    guard SecKeychainItemCopyAccess(item, &itemAccess) == errSecSuccess, let itemAccess else {
+      try fail("The publisher Keychain ACL is unavailable.")
+    }
+    let expected = Set(try [host, provisioner].map {
+      try applicationData(trustedApplication($0)).base64EncodedString()
+    })
+    guard let aclList = SecAccessCopyMatchingACLList(
+      itemAccess,
+      kSecACLAuthorizationDecrypt
+    ) as? [SecACL], !aclList.isEmpty else { return false }
+    for acl in aclList {
+      var applications: CFArray?
+      var description: CFString?
+      var selector = SecKeychainPromptSelector()
+      guard SecACLCopyContents(acl, &applications, &description, &selector) == errSecSuccess,
+        let trusted = applications as? [SecTrustedApplication]
+      else { return false }
+      let actual = Set(try trusted.map {
+        try applicationData($0).base64EncodedString()
+      })
+      if actual != expected { return false }
+    }
+    return true
+  }
+
+  func read(host: String, provisioner: String) throws -> Data {
+    var dataQuery = query()
+    dataQuery[kSecReturnData] = true
+    dataQuery[kSecMatchLimit] = kSecMatchLimitOne
+    dataQuery[kSecUseAuthenticationUI] = kSecUseAuthenticationUIFail
+    var result: CFTypeRef?
+    let status = SecItemCopyMatching(dataQuery as CFDictionary, &result)
+    if status == errSecItemNotFound { throw StoreFailure.missing }
+    guard status == errSecSuccess, let data = result as? Data else {
+      try fail("The release App key could not be read from Keychain.")
+    }
+    guard try aclMatches(host: host, provisioner: provisioner) else {
+      try fail("The release App key is not restricted to the publisher host and provisioner.")
+    }
+    return data
+  }
+
+  func add(_ secret: Data, host: String, provisioner: String) throws {
+    var attributes = query()
+    attributes[kSecAttrLabel] = "Freed release tag publisher private key"
+    attributes[kSecValueData] = secret
+    attributes[kSecAttrAccess] = try access(host: host, provisioner: provisioner)
+    let status = SecItemAdd(attributes as CFDictionary, nil)
+    if status == errSecDuplicateItem { throw StoreFailure.duplicate }
+    guard status == errSecSuccess else {
+      try fail("The release App key could not be added to Keychain.")
+    }
+  }
+
+  func update(_ secret: Data, host: String, provisioner: String) throws {
+    let status = SecItemUpdate(
+      query() as CFDictionary,
+      [kSecValueData: secret] as CFDictionary
+    )
+    if status == errSecItemNotFound { throw StoreFailure.missing }
+    guard status == errSecSuccess else {
+      try fail("The release App key could not be rotated in Keychain.")
+    }
+    let item = try itemReference()
+    guard SecKeychainItemSetAccess(
+      item,
+      try access(host: host, provisioner: provisioner)
+    ) == errSecSuccess else {
+      try fail("The rotated release App key ACL could not be constrained.")
+    }
+  }
+
+  func delete() throws {
+    let status = SecItemDelete(query() as CFDictionary)
+    if status == errSecItemNotFound { throw StoreFailure.missing }
+    guard status == errSecSuccess else {
+      try fail("The release App key could not be revoked from Keychain.")
+    }
+  }
+}
+
+private func parse(_ arguments: [String]) throws -> (action: String, host: String) {
+  guard arguments.count == 3,
+    ["provision", "rotate", "verify", "revoke"].contains(arguments[0]),
+    arguments[1] == "--host"
+  else {
+    try fail("Usage: release-tag-publisher-provision <provision|rotate|verify|revoke> --host <absolute-path>")
+  }
+  return (arguments[0], arguments[2])
+}
+
+private func disableCoreDumps() throws {
+  var limit = rlimit(rlim_cur: 0, rlim_max: 0)
+  guard setrlimit(RLIMIT_CORE, &limit) == 0 else {
+    try fail("The publisher provisioner could not disable core dumps.")
+  }
+}
+
+private func main() -> Int32 {
+  do {
+    _ = umask(0o077)
+    try disableCoreDumps()
+    let parsed = try parse(Array(CommandLine.arguments.dropFirst()))
+    let host = try canonicalExistingPath(parsed.host, label: "publisher host")
+    let provisioner = try currentExecutablePath()
+    try requireRootOwnedExecutable(host)
+    try requireRootOwnedExecutable(provisioner)
+    let store = KeychainStore()
+    switch parsed.action {
+    case "provision":
+      var secret = try readSecretFromStandardInput()
+      defer { secret.resetBytes(in: 0..<secret.count) }
+      do {
+        try store.add(secret, host: host, provisioner: provisioner)
+        var verified = try store.read(host: host, provisioner: provisioner)
+        defer { verified.resetBytes(in: 0..<verified.count) }
+        try validatePKCS1PEM(verified)
+      } catch {
+        try? store.delete()
+        throw error
+      }
+    case "rotate":
+      var previous = try store.read(host: host, provisioner: provisioner)
+      defer { previous.resetBytes(in: 0..<previous.count) }
+      var replacement = try readSecretFromStandardInput()
+      defer { replacement.resetBytes(in: 0..<replacement.count) }
+      do {
+        try store.update(replacement, host: host, provisioner: provisioner)
+        var verified = try store.read(host: host, provisioner: provisioner)
+        defer { verified.resetBytes(in: 0..<verified.count) }
+        try validatePKCS1PEM(verified)
+      } catch {
+        try? store.update(previous, host: host, provisioner: provisioner)
+        throw error
+      }
+    case "verify":
+      var secret = try store.read(host: host, provisioner: provisioner)
+      defer { secret.resetBytes(in: 0..<secret.count) }
+      try validatePKCS1PEM(secret)
+    case "revoke":
+      try store.delete()
+    default:
+      try fail("Unsupported publisher provisioner action.")
+    }
+    let output: [String: Any] = [
+      "schemaVersion": 1,
+      "purpose": "freed-release-tag-publisher-keychain-result",
+      "action": parsed.action,
+      "service": keychainService,
+      "account": keychainAccount,
+      "host": host,
+    ]
+    let data = try JSONSerialization.data(
+      withJSONObject: output,
+      options: [.sortedKeys, .withoutEscapingSlashes]
+    )
+    FileHandle.standardOutput.write(data + Data([0x0a]))
+    return 0
+  } catch StoreFailure.missing {
+    fputs("release-tag-publisher-provision: the Keychain key is missing\n", stderr)
+    return 1
+  } catch StoreFailure.duplicate {
+    fputs("release-tag-publisher-provision: the Keychain key already exists\n", stderr)
+    return 1
+  } catch let error as ProvisionFailure {
+    fputs("release-tag-publisher-provision: \(error.description)\n", stderr)
+    return 1
+  } catch {
+    fputs("release-tag-publisher-provision: an unexpected validation error occurred\n", stderr)
+    return 1
+  }
+}
+
+exit(main())

--- a/scripts/release-tag-publisher.mjs
+++ b/scripts/release-tag-publisher.mjs
@@ -3,19 +3,24 @@
 import { execFileSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
-import { loadAndVerifyReleaseTagPublisher } from "./lib/release-tag-publisher.mjs";
+import {
+  loadAndVerifyReleaseTagPublisher,
+  verifyReleaseTagPublisherInstallation,
+} from "./lib/release-tag-publisher.mjs";
 
 function main() {
   const args = process.argv.slice(2);
   const command = args[0];
   if (!command || command === "--help" || command === "-h") {
     process.stdout.write(
-      "Usage: node scripts/release-tag-publisher.mjs <attest|publish> [publisher arguments]\n",
+      "Usage: node scripts/release-tag-publisher.mjs <attest|verify-installation|publish> [publisher arguments]\n",
     );
     return;
   }
-  if (!["attest", "publish"].includes(command)) {
-    throw new Error("Release tag publisher command must be attest or publish.");
+  if (!["attest", "verify-installation", "publish"].includes(command)) {
+    throw new Error(
+      "Release tag publisher command must be attest, verify-installation, or publish.",
+    );
   }
   const binding = loadAndVerifyReleaseTagPublisher();
   if (command === "attest") {
@@ -30,6 +35,11 @@ function main() {
         publisherSha256: binding.publisherSha256,
       })}\n`,
     );
+    return;
+  }
+  if (command === "verify-installation") {
+    const result = verifyReleaseTagPublisherInstallation(binding);
+    process.stdout.write(`${JSON.stringify(result.attestation)}\n`);
     return;
   }
   execFileSync(binding.publisherPath, args, { stdio: "inherit" });

--- a/scripts/sync-github-rulesets.mjs
+++ b/scripts/sync-github-rulesets.mjs
@@ -14,10 +14,15 @@ import { fileURLToPath } from "node:url";
 
 import {
   loadAndVerifyReleaseTagPublisher,
+  verifyReleaseTagPublisherInstallation,
+  verifyReleaseTagPublisherInstallationReadiness,
   verifyReleaseTagPublisherReadiness,
 } from "./lib/release-tag-publisher.mjs";
 
-export { verifyReleaseTagPublisherReadiness };
+export {
+  verifyReleaseTagPublisherInstallationReadiness,
+  verifyReleaseTagPublisherReadiness,
+};
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 export const DEFAULT_RULESET_DIR = path.resolve(
@@ -359,25 +364,22 @@ export function verifyLiveReleaseTagAuthority(rulesets, expectedReleaseAppId) {
 }
 
 export function verifyReleaseAppReadiness({
-  app,
   installations,
-  repositories,
+  installationReadiness,
   releaseAppId,
   releaseAppSlug,
   repo,
 }) {
   const actorId = Number(releaseAppId);
-  if (
-    Number(app?.id) !== actorId ||
-    String(app?.slug ?? "").toLowerCase() !==
-      String(releaseAppSlug ?? "").toLowerCase()
-  ) {
-    throw new Error(
-      `Release App ${releaseAppSlug} does not match GitHub App ID ${actorId.toLocaleString()}.`,
-    );
-  }
+  const native = verifyReleaseTagPublisherInstallationReadiness(
+    installationReadiness,
+    { repo, releaseAppId, releaseAppSlug },
+  );
   const installation = (installations ?? []).find(
-    (item) => Number(item?.app_id) === actorId,
+    (item) =>
+      Number.isSafeInteger(item?.app_id) &&
+      item.app_id === actorId &&
+      item.app_slug === releaseAppSlug,
   );
   if (!installation) {
     throw new Error(
@@ -387,20 +389,42 @@ export function verifyReleaseAppReadiness({
   if (installation.suspended_at || installation.suspended_by) {
     throw new Error(`Release App ${releaseAppSlug} installation is suspended.`);
   }
-  if (installation.permissions?.contents !== "write") {
+  if (!Number.isSafeInteger(installation.id) || installation.id <= 0) {
     throw new Error(
-      `Release App ${releaseAppSlug} installation requires exact Contents write permission.`,
+      `Release App ${releaseAppSlug} installation ID is invalid.`,
     );
   }
-  if (!(repositories ?? []).some((item) => item?.full_name === repo)) {
+  const permissionKeys = Object.keys(installation.permissions ?? {}).sort();
+  if (
+    JSON.stringify(permissionKeys) !==
+      JSON.stringify(["contents", "metadata"]) ||
+    installation.permissions.contents !== "write" ||
+    installation.permissions.metadata !== "read"
+  ) {
     throw new Error(
-      `Release App ${releaseAppSlug} installation cannot access ${repo}.`,
+      `Release App ${releaseAppSlug} installation requires exact Contents write and Metadata read permissions.`,
+    );
+  }
+  if (
+    installation.account?.login !== "freed-project" ||
+    installation.account?.type !== "Organization" ||
+    installation.target_type !== "Organization" ||
+    installation.repository_selection !== "selected" ||
+    JSON.stringify(installation.events ?? []) !== JSON.stringify([])
+  ) {
+    throw new Error(
+      `Release App ${releaseAppSlug} must be an event-free selected-repository installation owned by freed-project.`,
+    );
+  }
+  if (native.installationId !== installation.id) {
+    throw new Error(
+      `Release App ${releaseAppSlug} native installation proof does not match the organization installation.`,
     );
   }
   return {
     ready: true,
     appId: actorId,
-    installationId: Number(installation.id),
+    installationId: installation.id,
   };
 }
 
@@ -617,32 +641,23 @@ function findCodeownersReadinessEvidence(
   return verifyCodeownersReadiness(branch, apiFile, desiredText);
 }
 
-function findReleaseAppReadinessEvidence(
+export function findReleaseAppReadinessEvidence(
   repo,
   releaseAppId,
   releaseAppSlug,
+  installationReadiness,
   { exec = execFileSync } = {},
 ) {
-  const app = ghJson(["api", `apps/${releaseAppSlug}`], { exec });
+  const [owner, name, ...extra] = repo.split("/");
+  if (!owner || !name || extra.length > 0) {
+    throw new Error("Release repository must use the owner/name format.");
+  }
   const installations =
-    ghJson(["api", "user/installations?per_page=100"], { exec })
+    ghJson(["api", `orgs/${owner}/installations?per_page=100`], { exec })
       .installations ?? [];
-  const installation = installations.find(
-    (item) => Number(item?.app_id) === Number(releaseAppId),
-  );
-  const repositories = installation
-    ? (ghJson(
-        [
-          "api",
-          `user/installations/${installation.id}/repositories?per_page=100`,
-        ],
-        { exec },
-      ).repositories ?? [])
-    : [];
   return verifyReleaseAppReadiness({
-    app,
     installations,
-    repositories,
+    installationReadiness,
     releaseAppId,
     releaseAppSlug,
     repo,
@@ -664,7 +679,12 @@ function findReleaseTagPublisherReadinessEvidence(
       "Root-owned release tag publisher binding does not match the reviewed repository and App identity.",
     );
   }
-  return { ready: true, publisherDigest: binding.publisherSha256 };
+  const installation = verifyReleaseTagPublisherInstallation(binding);
+  return {
+    ready: true,
+    publisherDigest: binding.publisherSha256,
+    installationAttestation: installation.attestation,
+  };
 }
 
 export function parseArgs(argv) {
@@ -777,15 +797,16 @@ function main() {
   let releaseEvidence = null;
   if (args.apply && args.releaseTags) {
     verifyReleaseTagLockdown(current);
-    const app = findReleaseAppReadinessEvidence(
-      args.repo,
-      args.releaseAppId,
-      args.releaseAppSlug,
-    );
     const publisher = findReleaseTagPublisherReadinessEvidence(
       args.repo,
       args.releaseAppId,
       args.releaseAppSlug,
+    );
+    const app = findReleaseAppReadinessEvidence(
+      args.repo,
+      args.releaseAppId,
+      args.releaseAppSlug,
+      publisher.installationAttestation,
     );
     releaseEvidence = { app, publisher };
     process.stdout.write(

--- a/scripts/sync-github-rulesets.test.mjs
+++ b/scripts/sync-github-rulesets.test.mjs
@@ -14,6 +14,7 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 
 import {
+  findReleaseAppReadinessEvidence,
   loadRulesets,
   parseArgs,
   planRulesetSync,
@@ -329,17 +330,40 @@ test("release tag creation stays pending while immutability grants no bypass", (
 });
 
 test("release tag activation verifies the exact App installation and repository", () => {
+  const installationReadiness = {
+    schemaVersion: 1,
+    purpose: "freed-release-tag-publisher-installation-readiness",
+    repo: "freed-project/freed",
+    appId: 123456,
+    appSlug: "freed-release-publisher",
+    appName: "Freed Release Publisher",
+    appExternalUrl: "https://freed.wtf",
+    appOwnerLogin: "freed-project",
+    appOwnerType: "Organization",
+    appPermissions: { contents: "write", metadata: "read" },
+    appEvents: [],
+    installationId: 42,
+    accountLogin: "freed-project",
+    accountType: "Organization",
+    repositorySelection: "selected",
+    permissions: { contents: "write", metadata: "read" },
+    repositories: ["freed-project/freed"],
+  };
   const input = {
-    app: { id: 123456, slug: "freed-release-publisher" },
     installations: [
       {
         id: 42,
         app_id: 123456,
-        permissions: { contents: "write" },
+        app_slug: "freed-release-publisher",
+        account: { login: "freed-project", type: "Organization" },
+        target_type: "Organization",
+        repository_selection: "selected",
+        permissions: { contents: "write", metadata: "read" },
+        events: [],
         suspended_at: null,
       },
     ],
-    repositories: [{ full_name: "freed-project/freed" }],
+    installationReadiness,
     releaseAppId: 123456,
     releaseAppSlug: "freed-release-publisher",
     publisherDigest: "a".repeat(64),
@@ -352,15 +376,33 @@ test("release tag activation verifies the exact App installation and repository"
   });
   assert.throws(
     () => verifyReleaseAppReadiness({ ...input, releaseAppId: 999999 }),
-    /does not match GitHub App ID/,
+    /does not match the dedicated selected-repository App contract/,
+  );
+  assert.throws(
+    () =>
+      verifyReleaseAppReadiness({
+        ...input,
+        installationReadiness: {
+          ...installationReadiness,
+          appExternalUrl: "https://example.com",
+        },
+      }),
+    /does not match the dedicated selected-repository App contract/,
   );
   assert.throws(
     () => verifyReleaseAppReadiness({ ...input, installations: [] }),
     /is not installed/,
   );
   assert.throws(
-    () => verifyReleaseAppReadiness({ ...input, repositories: [] }),
-    /cannot access freed-project\/freed/,
+    () =>
+      verifyReleaseAppReadiness({
+        ...input,
+        installationReadiness: {
+          ...installationReadiness,
+          repositories: [],
+        },
+      }),
+    /does not match the dedicated selected-repository App contract/,
   );
   assert.throws(
     () =>
@@ -370,11 +412,16 @@ test("release tag activation verifies the exact App installation and repository"
           {
             id: 42,
             app_id: 123456,
-            permissions: { contents: "read" },
+            app_slug: "freed-release-publisher",
+            account: { login: "freed-project", type: "Organization" },
+            target_type: "Organization",
+            repository_selection: "selected",
+            permissions: { contents: "read", metadata: "read" },
+            events: [],
           },
         ],
       }),
-    /requires exact Contents write permission/,
+    /requires exact Contents write and Metadata read permissions/,
   );
   assert.throws(
     () =>
@@ -384,12 +431,87 @@ test("release tag activation verifies the exact App installation and repository"
           {
             id: 42,
             app_id: 123456,
-            permissions: { contents: "write" },
+            app_slug: "freed-release-publisher",
+            account: { login: "freed-project", type: "Organization" },
+            target_type: "Organization",
+            repository_selection: "selected",
+            permissions: { contents: "write", metadata: "read" },
+            events: [],
             suspended_at: "2026-07-12T00:00:00Z",
           },
         ],
       }),
     /installation is suspended/,
+  );
+});
+
+test("release activation uses organization installation evidence and never user installations", () => {
+  const calls = [];
+  const installationReadiness = {
+    schemaVersion: 1,
+    purpose: "freed-release-tag-publisher-installation-readiness",
+    repo: "freed-project/freed",
+    appId: 123456,
+    appSlug: "freed-release-publisher",
+    appName: "Freed Release Publisher",
+    appExternalUrl: "https://freed.wtf",
+    appOwnerLogin: "freed-project",
+    appOwnerType: "Organization",
+    appPermissions: { contents: "write", metadata: "read" },
+    appEvents: [],
+    installationId: 42,
+    accountLogin: "freed-project",
+    accountType: "Organization",
+    repositorySelection: "selected",
+    permissions: { contents: "write", metadata: "read" },
+    repositories: ["freed-project/freed"],
+  };
+  const result = findReleaseAppReadinessEvidence(
+    "freed-project/freed",
+    123456,
+    "freed-release-publisher",
+    installationReadiness,
+    {
+      exec(file, args) {
+        calls.push([file, ...args]);
+        if (args[1] === "orgs/freed-project/installations?per_page=100") {
+          return JSON.stringify({
+            installations: [
+              {
+                id: 42,
+                app_id: 123456,
+                app_slug: "freed-release-publisher",
+                account: {
+                  login: "freed-project",
+                  type: "Organization",
+                },
+                target_type: "Organization",
+                repository_selection: "selected",
+                permissions: { contents: "write", metadata: "read" },
+                events: [],
+                suspended_at: null,
+              },
+            ],
+          });
+        }
+        throw new Error(`Unexpected fake gh call: ${args.join(" ")}`);
+      },
+    },
+  );
+  assert.equal(result.installationId, 42);
+  assert.equal(
+    calls.some((call) => call.join(" ").includes("user/installations")),
+    false,
+  );
+  assert.equal(
+    calls.some((call) => call.join(" ").includes("apps/")),
+    false,
+  );
+  assert.equal(
+    calls.some((call) =>
+      call.join(" ").includes("orgs/freed-project/installations?per_page=100"),
+    ),
+    true,
   );
 });
 


### PR DESCRIPTION
(AI Generated).

## Summary
- Add a root-owned native publisher that creates one reviewed annotated release tag through a private repository-scoped GitHub App.
- Bootstrap the App through a loopback manifest flow that pipes its private key directly into Keychain and stores only nonsecret identity state.
- Verify exact App metadata, selected repository access, split tag rules, branch identity, receipt digest, and token revocation before publication.
- Document provisioning, activation, rotation, recovery, and revocation while completing Phase 10 release automation.

## Testing
- npm run validate:feature
- 21 focused release publisher and ruleset tests
- 5 native fake GitHub API end-to-end tests
- node scripts/validate-roadmap-status.mjs