### PR TITLE
fix: omit webhook from release app manifest

### DIFF
--- a/scripts/create-release-github-app.mjs
+++ b/scripts/create-release-github-app.mjs
@@ -164,13 +164,11 @@ export function verifyPreparedReleaseTagPublisher({
 
 export function buildReleaseGitHubAppManifest({ origin }) {
   const callbackUrl = new URL(CALLBACK_PATH, origin).toString();
-  const webhookUrl = new URL("/github-app/inactive-webhook", origin).toString();
   return {
     name: RELEASE_GITHUB_APP_NAME,
     url: "https://freed.wtf",
     description:
       "Creates one reviewed immutable release tag for freed-project/freed.",
-    hook_attributes: { url: webhookUrl, active: false },
     redirect_url: callbackUrl,
     public: false,
     default_permissions: { contents: "write" },

--- a/scripts/create-release-github-app.test.mjs
+++ b/scripts/create-release-github-app.test.mjs
@@ -45,15 +45,23 @@ test("release App manifest is private, event-free, and Contents-only", () => {
   const manifest = buildReleaseGitHubAppManifest({
     origin: "http://127.0.0.1:43123",
   });
+  assert.deepEqual(Object.keys(manifest).sort(), [
+    "default_events",
+    "default_permissions",
+    "description",
+    "name",
+    "public",
+    "redirect_url",
+    "request_oauth_on_install",
+    "setup_on_update",
+    "url",
+  ]);
+  assert.equal("hook_attributes" in manifest, false);
   assert.deepEqual(manifest, {
     name: "Freed Release Publisher",
     url: "https://freed.wtf",
     description:
       "Creates one reviewed immutable release tag for freed-project/freed.",
-    hook_attributes: {
-      url: "http://127.0.0.1:43123/github-app/inactive-webhook",
-      active: false,
-    },
     redirect_url: "http://127.0.0.1:43123/github-app/callback",
     public: false,
     default_permissions: { contents: "write" },
@@ -70,6 +78,7 @@ test("release App manifest is private, event-free, and Contents-only", () => {
     /organizations\/freed-project\/settings\/apps\/new\?state=/,
   );
   assert.match(html, /method="post"/);
+  assert.doesNotMatch(html, /hook_attributes|inactive-webhook/);
   assert.doesNotMatch(html, /client_secret|webhook_secret|BEGIN RSA/);
 });
 


### PR DESCRIPTION
(AI Generated).

## Summary
- Remove the unreachable loopback webhook from the GitHub App manifest.
- Lock the manifest to its intended exact key set, with no webhook configuration and no events.

## Testing
- node --test scripts/create-release-github-app.test.mjs
- npm run validate:feature