### PR TITLE
fix: stop automation actor keychain prompts

### DIFF
--- a/docs/AUTOMATION-CONTROL-PLANE.md
+++ b/docs/AUTOMATION-CONTROL-PLANE.md
@@ -127,6 +127,13 @@ private automation state directory. The orchestration script, shell, and agent
 never receive the credential. It never appears in arguments, standard output,
 logs, task state, or agent state.
 
+The launcher-only decrypt ACL uses an empty prompt selector. The trusted
+application list already limits access to the exact root-owned launcher.
+Setting the unsigned or invalid application prompt flags would require a
+passphrase for the deterministic ad hoc signature and would turn unattended
+acquisition into a password dialog. A missing or mismatched launcher trust
+entry must fail closed while Keychain interaction is disabled.
+
 The installed launcher clears inherited environment state, verifies its own
 root-owned binding and every pinned runtime digest, disables Keychain user
 interaction for the credential read, restores the prior interaction policy,

--- a/scripts/automation-actor-native.test.mjs
+++ b/scripts/automation-actor-native.test.mjs
@@ -916,24 +916,19 @@ test(
 );
 
 test(
-  "native provisioner pins exact launcher trust while suppressing unsigned prompt defaults",
+  "native provisioner lets the exact trusted ad hoc launcher read without a passphrase prompt",
   { skip: !darwinOnly },
   async () => {
     const source = await readFile(provisionerSource, "utf8");
     assert.match(
       source,
-      /SecKeychainPromptSelector\.unsignedAct\.union\(\.invalidAct\)/,
+      /launcherPromptSelector\s*=\s*SecKeychainPromptSelector\(\)/,
     );
     assert.match(source, /selector == launcherPromptSelector/);
     assert.match(source, /trustedApplications\.count == 1/);
-    assert.doesNotMatch(
-      source,
-      /launcherPromptSelector\s*=\s*SecKeychainPromptSelector\.unsigned\b/,
-    );
-    assert.doesNotMatch(
-      source,
-      /launcherPromptSelector\s*=.*SecKeychainPromptSelector\.invalid\b/,
-    );
+    assert.doesNotMatch(source, /SecKeychainPromptSelector\.unsignedAct/);
+    assert.doesNotMatch(source, /SecKeychainPromptSelector\.invalidAct/);
+    assert.doesNotMatch(source, /SecKeychainPromptSelector\.requirePassphase/);
     assert.doesNotMatch(source, /func verify\s*\(/);
   },
 );

--- a/scripts/automation-actor-provision.swift
+++ b/scripts/automation-actor-provision.swift
@@ -18,8 +18,10 @@ private let leaseLifetimeMilliseconds = 30 * 60 * 1_000
 private let maximumBindingBytes = 32 * 1_024
 private let maximumCredentialBytes = 4 * 1_024
 private let randomCredentialBytes = 32
-private let launcherPromptSelector =
-  SecKeychainPromptSelector.unsignedAct.union(.invalidAct)
+// The trusted application list already limits decryption to the exact
+// root-owned launcher. Requiring a passphrase for unsigned or invalid callers
+// would force a dialog for our deterministic ad hoc signed launcher.
+private let launcherPromptSelector = SecKeychainPromptSelector()
 #if AUTOMATION_ACTOR_PROVISION_TESTING
   private let fakeExistingCredential =
     Data("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".utf8)


### PR DESCRIPTION
(AI Generated).

## Summary
- Remove passphrase selectors from exact-launcher Keychain ACLs
- Keep mismatched launcher access fail closed with Keychain UI disabled

## Testing
- node --test scripts/automation-actor-native.test.mjs
- node --test scripts/automation-actors.test.mjs scripts/validate-host-automations.test.mjs
- npm run validate:feature