### PR TITLE
chore: pin release publisher app bypass

### DIFF
--- a/.github/rulesets/release-tags.json
+++ b/.github/rulesets/release-tags.json
@@ -2,7 +2,13 @@
   "name": "Freed release tag creation",
   "target": "tag",
   "enforcement": "active",
-  "bypass_actors": [],
+  "bypass_actors": [
+    {
+      "actor_id": 4296969,
+      "actor_type": "Integration",
+      "bypass_mode": "always"
+    }
+  ],
   "conditions": {
     "ref_name": {
       "include": ["refs/tags/v*"],

--- a/scripts/sync-github-rulesets.test.mjs
+++ b/scripts/sync-github-rulesets.test.mjs
@@ -203,7 +203,7 @@ fi
   );
 });
 
-test("release tag creation stays pending while immutability grants no bypass", () => {
+test("release tag creation grants only the dedicated App while immutability grants no bypass", () => {
   const tagRulesets = loadRulesets().filter(
     (ruleset) => ruleset.target === "tag",
   );
@@ -217,7 +217,13 @@ test("release tag creation stays pending while immutability grants no bypass", (
     (ruleset) => ruleset.name === "Freed release tag lockdown",
   );
   assert.equal(creation.enforcement, "active");
-  assert.deepEqual(creation.bypass_actors, []);
+  assert.deepEqual(creation.bypass_actors, [
+    {
+      actor_id: 4296969,
+      actor_type: "Integration",
+      bypass_mode: "always",
+    },
+  ]);
   assert.equal(immutability.enforcement, "active");
   assert.deepEqual(immutability.bypass_actors, []);
   assert.equal(verifyReleaseTagLockdown(tagRulesets).lockdown, lockdown);
@@ -257,9 +263,9 @@ test("release tag creation stays pending while immutability grants no bypass", (
     () => parseArgs(["--apply", "--release-tags"]),
     /requires --release-app-id and --release-app-slug/,
   );
-  assert.throws(
-    () => verifyReleaseTagActivation(tagRulesets, 123456),
-    /Release tag creation is locked with no bypass/,
+  assert.equal(
+    verifyReleaseTagActivation(tagRulesets, 4296969).releaseAppId,
+    4296969,
   );
 
   const activeCreation = {


### PR DESCRIPTION
(AI Generated).

## Summary
- Pin GitHub App ID 4,296,969 as the sole Integration bypass for release tag creation.
- Keep release tag immutability and lockdown rules bypass-free.

## Testing
- node --test scripts/sync-github-rulesets.test.mjs scripts/validate-release-tag-authority.test.mjs
- npm run validate:feature
- node scripts/sync-github-rulesets.mjs --release-tags --release-app-id 4296969 --release-app-slug freed-release-publisher