### PR TITLE
fix: include publisher dependencies in main backports

### DIFF
--- a/docs/stability-tasks/W1-06-provider-visible-single-source.md
+++ b/docs/stability-tasks/W1-06-provider-visible-single-source.md
@@ -40,7 +40,9 @@ approval when unrelated files changed.
 10. A narrow `fix/main-governance-*` lane may backport these exact governance
     files to `main`. Every changed file must be on the control-plane allowlist
     and byte-for-byte equal to `origin/dev`. Product changes remain confined to
-    the normal release promotion lane.
+    the normal release promotion lane. The allowlist includes the publisher's
+    release-control dependencies and their focused tests so the backported
+    publisher is runnable rather than a decorative shell script.
 
 ## Human workflow
 

--- a/scripts/validate-main-pr.mjs
+++ b/scripts/validate-main-pr.mjs
@@ -19,6 +19,7 @@ const REPO_ROOT = path.resolve(__dirname, "..");
 const GOVERNANCE_BACKPORT_BRANCH_PATTERN =
   /^fix\/main-governance-[a-z0-9._-]+$/;
 const GOVERNANCE_BACKPORT_FILES = new Set([
+  ".github/CODEOWNERS",
   ".agents/skills/freed-build-feature/SKILL.md",
   ".agents/skills/freed-provider-risk-review/SKILL.md",
   "AGENTS.md",
@@ -26,8 +27,19 @@ const GOVERNANCE_BACKPORT_FILES = new Set([
   "docs/NIGHTLY-SELF-IMPROVE.md",
   "docs/STABILITY-PROGRAM.md",
   "docs/stability-tasks/W1-06-provider-visible-single-source.md",
+  "scripts/automation-control.mjs",
+  "scripts/automation-control.test.mjs",
+  "scripts/lib/automation-control.mjs",
+  "scripts/lib/cargo-lock-release.mjs",
+  "scripts/lib/node-tooling.sh",
+  "scripts/lib/provider-visible-paths.mjs",
+  "scripts/lib/provider-visible-paths.test.mjs",
   "scripts/release-promotion.test.mjs",
+  "scripts/release-promotion-shared.mjs",
+  "scripts/trusted-worktree-publish.sh",
+  "scripts/validate-main-backflow.mjs",
   "scripts/validate-main-pr.mjs",
+  "scripts/validate-release-promotion.mjs",
   "scripts/worktree-publish.sh",
   "scripts/worktree-publish.test.mjs",
 ]);


### PR DESCRIPTION
(AI Generated).

## Summary
- Allow exact dev copies of the provider publisher's release-control dependencies and focused tests in the governance backport lane

## Testing
- node --test --test-name-pattern='governance backport' scripts/release-promotion.test.mjs