### PR TITLE
fix: allow exact current-task owner approvals

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,8 @@
 
 Before activating a saved Freed automation, run `npm run validate:host-automations`. It compares identity, prompt, schedule, authoritative callable model and supported reasoning effort, target, working directories, execution environment, credential record, root-owned launcher binding and digest, and non-secret Keychain item presence without editing host files. An ACTIVE actor fails closed unless its trusted launcher can exchange the persistent Keychain credential for only the actor's short-lived canonical lease. Missing actors remain PAUSED. Reconcile missing or drifted actors through the Codex host automation controls, and never repair drift by editing `automation.toml` directly.
 
+When the owner explicitly approves one exact lifecycle operation in the current task, a private current-task owner confirmation file is the supported cooperative fallback for that operation. It may acquire only a short `freed-owner` lease bound to the named task and canonical operation intent. Store the file outside the repository. The file does not authenticate the owner, does not grant provider traffic, and does not replace either provider-risk gate or CODEOWNER review. Each different operation requires its own exact intent and confirmation record.
+
 ## Versioning
 
 CalVer `YY.M.DDBUILD` — patch segment encodes the day and build number:
@@ -74,6 +76,7 @@ Run `./scripts/release.sh` with no args from a fresh release-prep worktree based
 Pass an explicit remote base like `origin/dev` or `origin/www` so feature work does not inherit a stale local branch by accident.
 For multi-thread or speculative worktree swarms, prefer `--swarm`. That maps to deferred bootstrap until the thread actually needs verification or a preview.
 Prefer the lightest useful local preview before opening a draft PR:
+
 - product work usually uses `PORT=$(node scripts/lib/find-free-port.mjs 1421) && ./scripts/worktree-preview.sh pwa --port "$PORT"`
 - website work uses `PORT=$(node scripts/lib/find-free-port.mjs 3000) && ./scripts/worktree-preview.sh website --port "$PORT"`
 - use `./scripts/worktree-preview.sh desktop --native` only when real Tauri behavior matters, and report the preview label when you do
@@ -263,7 +266,7 @@ test("invoke a command", async ({ app, ipc }) => {
   await ipc.setHandler("my_command", (_args) => ({ ok: true }));
 
   const result = await app.page.evaluate(async () =>
-    (window as any).__TAURI_MOCK_INVOKE__("my_command", {})
+    (window as any).__TAURI_MOCK_INVOKE__("my_command", {}),
   );
   expect(result).toEqual({ ok: true });
 });

--- a/docs/AUTOMATION-CONTROL-PLANE.md
+++ b/docs/AUTOMATION-CONTROL-PLANE.md
@@ -581,6 +581,69 @@ does not block normal publication. Provider work can use the signing-free
 GitHub reaction path described below. GitHub records the CODEOWNER account that
 made the human Gate 2 decision.
 
+### Current-task owner confirmation
+
+An owner may explicitly approve one exact control-plane operation in the
+current task without installing the optional broker. Record that decision in a
+private mode `0600` JSON file outside the repository:
+
+```json
+{
+  "schemaVersion": 1,
+  "kind": "owner-confirmation",
+  "confirmationId": "authenticated-essay-capture-create",
+  "approvedBy": "AubreyF",
+  "ownerApprovalReference": "Owner approved this exact lifecycle operation in the current task.",
+  "approvalSource": {
+    "kind": "current-task",
+    "reference": "authenticated-essay-capture-pr-642"
+  },
+  "taskId": "authenticated-essay-capture-pr-642",
+  "intent": {
+    "schemaVersion": 1,
+    "action": "task.create",
+    "taskId": "authenticated-essay-capture-pr-642",
+    "parameters": {
+      "state": "observed",
+      "observerAuthority": "merge-safe",
+      "providerAuthority": "approved",
+      "approvalReference": "<provider approval reference>",
+      "details": {
+        "behavioral": true,
+        "metricId": "renderer-recovery-count"
+      }
+    }
+  },
+  "intentDigest": "<canonical operation intent digest>",
+  "approvedAt": "<ISO-8601 timestamp>",
+  "expiresAt": "<ISO-8601 timestamp no more than seven days later>"
+}
+```
+
+Compute the intent with `owner intent-digest`, then acquire the short lease:
+
+```bash
+node scripts/automation-control.mjs lease acquire \
+  --name owner-governance \
+  --owner freed-owner \
+  --ttl-seconds 600 \
+  --owner-confirmation-file /absolute/path/to/confirmation.json \
+  --owner-task-id authenticated-essay-capture-pr-642 \
+  --owner-intent-digest <digest>
+```
+
+The command generates and returns only a short lease token. The lease is bound
+to the exact task and intent. A different action, parameter, revision, or task
+is rejected. The confirmation must identify `AubreyF`, cannot be future dated,
+must still be live, and cannot last more than seven days. Its canonical digest,
+task reference, and owner identity are copied into the lease and mutation audit
+events.
+
+This route is cooperative evidence. The JSON does not prove who wrote it, so
+the current task must contain the owner's explicit decision. It does not grant
+provider contact and cannot replace Gate 1, Gate 2, or exact-diff CODEOWNER
+review. The signed broker remains the stronger machine-verifiable option.
+
 ## Authority model
 
 Checked-in automation authority is one of:
@@ -595,11 +658,14 @@ Provider authority is separate. `forbidden` prohibits provider activity.
 provider-visible work ready without the owner's scoped Gate 1 decision and the
 Gate 2 CODEOWNER reaction. A task may move to provider authority
 `approved` only with an approval reference. Only the `freed-owner` lease may
-change task authority, and the optional signed owner capability is the stronger
-machine-verifiable route for that mutation. The direct human route is the
-CODEOWNER's GitHub thumbs-up on the generated provider review comment. It does
-not mutate task authority. Task authority never substitutes for the publish
-gate or CODEOWNER review. Creating a task
+change task authority. That lease can be bound to either the optional signed
+owner capability or one exact current-task owner confirmation. The
+confirmation file does not authenticate the owner. It records the owner's
+explicit current-task decision and the canonical operation intent. The direct
+provider Gate 2 route remains the CODEOWNER's GitHub thumbs-up on the generated
+provider review comment, and that reaction does not itself mutate task
+authority. Task authority never substitutes for the publish gate or CODEOWNER
+review. Creating a task
 directly with provider authority `approved` also requires an approval reference.
 The current manifest retains that reference, and every task event carries the
 same approval snapshot.

--- a/docs/PHASE-10-POLISH.md
+++ b/docs/PHASE-10-POLISH.md
@@ -132,6 +132,8 @@ The stability automation now has a checked-in control plane instead of relying o
 
 Every general automation actor now requires lease acquisition through a trusted host launcher and a private machine-local credential record. The owner-run bootstrap helper builds deterministic native binaries with linker-generated ad hoc signatures and requires no developer signing identity. It installs an actor-specific root-owned launcher plus a content-addressed root-owned copy of the pinned Node and control runtime, generates the persistent credential inside a native Swift provisioner, limits its Keychain ACL to the exact launcher, and leaves the orchestration layer, shell, logs, and agent state with only the short-lived lease result. Verification validates the public binding and private digest, then asks that exact installed launcher for a nonmutating readiness attestation instead of reading the secret through a disposable helper. Verify, acquire, and owner-run host acceptance disable Keychain user interaction, bound child runtime and output, and fail closed instead of displaying a password dialog. Host acceptance proves acquire, heartbeat, and release for every actor before activation. Rotation remains an explicit owner-interactive recovery action with one-time Keychain approval only. The pinned control child is the only JavaScript process that receives the persistent credential, and receives it only long enough to acquire the canonical lease. General actor leases have a 30 minute absolute lifetime. Saved actor reconciliation validates the schedule, current callable model and supported reasoning effort, canonical Freed target, exact working-directory scope, execution environment, credential record, launcher and runtime digests, and Keychain-to-lease handoff metadata. Missing actors remain paused. Active actors fail closed until real-host verification and lifecycle acceptance prove the complete handoff. The ad hoc signed launchers pin the selected role and protect its persistent credential, but they cannot authenticate which process under the same macOS user invoked that role. Cross-role isolation remains cooperative. Stored task authority, provider approvals, the global behavior slot, owner governance, publisher isolation, and GitHub review remain enforced. This bootstrap excludes the owner and PR publisher identities and grants no provider authority. Normal pull request publication remains available through the governed helper and the caller's existing GitHub authentication. Hosts that need stronger unattended publication hardening may optionally install the separate native signed broker. It clears inherited process state, validates its root-owned trust configuration and pinned tools, and uses an Ed25519 Keychain key to issue one short-lived target-scoped capability and publisher lease. The repository does not install that host profile. Missing broker provisioning does not block normal publication, and a partial broker handoff fails closed. This optional profile is cooperative hardening, not an operating-system sandbox against arbitrary same-user code. The owner governance identity remains protected by its separate expiring one-time bootstrap.
 
+Current-task owner confirmation is now a supported cooperative fallback for one exact lifecycle operation when the owner explicitly approves it in the active task. The private confirmation binds the owner name, current-task reference, task ID, canonical operation intent, approval time, and expiry to a short `freed-owner` lease. Every different operation needs a different intent record. The audit event preserves the confirmation digest and reference. This path does not authenticate the owner, contact a provider, or replace provider-risk approval and CODEOWNER review. Unknown metric IDs in stability artifacts now fail validation before a release handoff can depend on them.
+
 ### Keyboard Shortcuts
 
 Freed Desktop now includes a device-local OS-wide shortcut for Save Content. It opens the existing Save Content dialog, reads the clipboard only when the shortcut fires, pre-fills the URL field when the clipboard contains an HTTP or HTTPS link, and opens the saved item in reader mode after persistence. Users can change, disable, or reset the shortcut from Settings > Shortcuts.
@@ -398,17 +400,17 @@ Reward security researchers for responsible disclosure.
 
 ### UX Polish
 
-| Task  | Description                        | Complexity |
-| ----- | ---------------------------------- | ---------- |
-| 10.1  | Onboarding wizard                  | Medium     |
-| 10.2  | Statistics dashboard               | Medium     |
-| 10.3  | Export to JSON                     | Low        |
-| 10.4  | Export to CSV                      | Low        |
-| 10.5  | Keyboard shortcuts                 | Medium     | ✓ Complete (PWA reader keys, command palette, navigation history keys, and Freed Desktop Save Content shortcut) |
-| 10.6  | Screen reader support              | Medium     |
-| 10.7  | Reduced motion support             | Low        | ✓ Complete (Appearance animation intensity controls plus global app motion gating)                              |
-| 10.8  | Color contrast audit               | Low        |
-| 10.9  | Native Liquid Glass buttons        | High       |
+| Task  | Description                       | Complexity |
+| ----- | --------------------------------- | ---------- |
+| 10.1  | Onboarding wizard                 | Medium     |
+| 10.2  | Statistics dashboard              | Medium     |
+| 10.3  | Export to JSON                    | Low        |
+| 10.4  | Export to CSV                     | Low        |
+| 10.5  | Keyboard shortcuts                | Medium     | ✓ Complete (PWA reader keys, command palette, navigation history keys, and Freed Desktop Save Content shortcut) |
+| 10.6  | Screen reader support             | Medium     |
+| 10.7  | Reduced motion support            | Low        | ✓ Complete (Appearance animation intensity controls plus global app motion gating)                              |
+| 10.8  | Color contrast audit              | Low        |
+| 10.9  | Native Liquid Glass buttons       | High       |
 | 10.24 | Command bar: full action launcher | High       | ✓ Complete (Global `Cmd/Ctrl+K` palette with navigation, creation, current-item, sync, and danger actions)      |
 
 ### AI Features

--- a/scripts/automation-control.mjs
+++ b/scripts/automation-control.mjs
@@ -71,16 +71,18 @@ Lease options:
   --scope-json <json>               Required target scope for pr-publisher acquisition or head binding.
   --capability-file <path>          One-use signed broker capability for pr-publisher acquisition.
   --owner-capability-file <path>    One-use signed broker capability for freed-owner acquisition.
-  --owner-task-id <task-id>         Exact task bound to the owner capability.
-  --owner-intent-digest <sha256>    Exact canonical governance intent bound to the capability.
+  --owner-confirmation-file <path> Current-task owner confirmation for one exact freed-owner operation.
+  --owner-task-id <task-id>         Exact task bound to the owner authorization.
+  --owner-intent-digest <sha256>    Exact canonical governance intent bound to the owner authorization.
   --head-sha <sha>                  Exact commit bound once to the publisher lease.
   Lease authority is derived from the checked-in actor policy. It cannot be supplied by the caller.
   Non-owner acquisition except freed-pr-publisher requires the matching
   persistent credential in FREED_AUTOMATION_ACTOR_TOKEN.
   freed-pr-publisher requires a broker-signed one-use capability file and does
   not accept a reusable actor credential.
-  freed-owner requires a root-pinned broker signature, an exact task and intent
-  digest, and the capability-bound lease token in FREED_OWNER_LEASE_TOKEN.
+  freed-owner accepts either a root-pinned broker signature or an explicit
+  current-task owner confirmation, both bound to one exact task and intent.
+  The signed capability also requires FREED_OWNER_LEASE_TOKEN.
 
 All successful commands print one JSON object to stdout. Errors print one JSON object to stderr.
 `;
@@ -426,6 +428,7 @@ export function executeCommand(command, { env = process.env } = {}) {
       "scopeJson",
       "capabilityFile",
       "ownerCapabilityFile",
+      "ownerConfirmationFile",
       "ownerTaskId",
       "ownerIntentDigest",
     ]);
@@ -442,7 +445,8 @@ export function executeCommand(command, { env = process.env } = {}) {
             required(options, "ttlSeconds", "--ttl-seconds"),
             "--ttl-seconds",
           ) * 1_000,
-        ...(owner === "freed-owner"
+        ...(owner === "freed-owner" &&
+        options.ownerConfirmationFile === undefined
           ? {
               token: requiredOptionOrEnv(
                 {},
@@ -454,6 +458,7 @@ export function executeCommand(command, { env = process.env } = {}) {
             }
           : {}),
         ownerCapabilityFile: options.ownerCapabilityFile,
+        ownerConfirmationFile: options.ownerConfirmationFile,
         ownerCapabilityTaskId: options.ownerTaskId,
         ownerCapabilityIntentDigest: options.ownerIntentDigest,
         actorCredentialToken: env.FREED_AUTOMATION_ACTOR_TOKEN,

--- a/scripts/automation-control.test.mjs
+++ b/scripts/automation-control.test.mjs
@@ -122,6 +122,44 @@ function signedOwnerCapability(
   };
 }
 
+function writeOwnerConfirmation(
+  stateRoot,
+  taskId,
+  intent,
+  {
+    nowMs = Date.parse("2026-07-10T09:00:00Z"),
+    confirmationId = `owner-confirmation-${nowMs}`,
+    approvedBy = "AubreyF",
+    approvedAtMs = nowMs,
+    expiresAtMs = nowMs + 24 * 60 * 60_000,
+    mode = 0o600,
+  } = {},
+) {
+  const intentDigest = ownerGovernanceIntentDigest(intent);
+  const confirmation = {
+    schemaVersion: 1,
+    kind: "owner-confirmation",
+    confirmationId,
+    approvedBy,
+    ownerApprovalReference:
+      "Owner explicitly approved this exact lifecycle operation in the current task.",
+    approvalSource: {
+      kind: "current-task",
+      reference: taskId,
+    },
+    taskId,
+    intent,
+    intentDigest,
+    approvedAt: new Date(approvedAtMs).toISOString(),
+    expiresAt: new Date(expiresAtMs).toISOString(),
+  };
+  const confirmationPath = path.join(stateRoot, `${confirmationId}.json`);
+  writeFileSync(confirmationPath, `${JSON.stringify(confirmation)}\n`, {
+    mode,
+  });
+  return { confirmation, confirmationPath, intentDigest };
+}
+
 function writeActorCredential(
   stateRoot,
   actor,
@@ -1623,6 +1661,186 @@ test("owner capability signature is bound to task, intent, state root, and lease
   );
 });
 
+test("current-task owner confirmation acquires one exact audited governance lease", () => {
+  const stateRoot = temporaryStateRoot();
+  const nowMs = Date.parse("2026-07-10T14:00:00Z");
+  const taskId = "current-task-owner-confirmation";
+  const details = {
+    behavioral: true,
+    metricId: "renderer-recovery-count",
+  };
+  const intent = {
+    schemaVersion: 1,
+    action: "task.create",
+    taskId,
+    parameters: {
+      state: "observed",
+      observerAuthority: "merge-safe",
+      providerAuthority: "approved",
+      approvalReference: "sha256:approved-provider-diff",
+      details,
+    },
+  };
+  const intentDigest = ownerGovernanceIntentDigest(intent);
+  const { confirmation, confirmationPath } = writeOwnerConfirmation(
+    stateRoot,
+    taskId,
+    intent,
+    { nowMs },
+  );
+  const acquired = acquireLease({
+    stateRoot,
+    name: "owner-governance",
+    owner: "freed-owner",
+    ttlMs: 60_000,
+    nowMs: nowMs + 1_000,
+    ownerConfirmationFile: confirmationPath,
+    ownerCapabilityTaskId: taskId,
+    ownerCapabilityIntentDigest: intentDigest,
+  });
+  assert.equal(acquired.lease.credentialKind, "owner-confirmation");
+  assert.equal(acquired.lease.ownerConfirmationTaskId, taskId);
+  assert.equal(acquired.lease.ownerConfirmationIntentDigest, intentDigest);
+  assert.match(acquired.lease.ownerConfirmationDigest, /^[0-9a-f]{64}$/);
+  assert.equal(acquired.lease.ownerConfirmationReference, taskId);
+  assert.equal(acquired.lease.ownerConfirmationApprovedBy, "AubreyF");
+  assert.equal(
+    acquired.lease.ownerConfirmationApprovalReference,
+    confirmation.ownerApprovalReference,
+  );
+  assert.equal(
+    acquired.lease.ownerConfirmationApprovedAt,
+    confirmation.approvedAt,
+  );
+  assert.equal(
+    acquired.lease.ownerConfirmationExpiresAt,
+    confirmation.expiresAt,
+  );
+
+  const created = createTask({
+    stateRoot,
+    taskId,
+    actor: "freed-owner",
+    leaseName: "owner-governance",
+    leaseToken: acquired.lease.token,
+    observerAuthority: "merge-safe",
+    providerAuthority: "approved",
+    approvalReference: "sha256:approved-provider-diff",
+    details,
+    nowMs: nowMs + 2_000,
+  });
+  assert.equal(created.task.state, "observed");
+  assert.equal(
+    created.event.data.authorizationProvenance.credentialKind,
+    "owner-confirmation",
+  );
+  assert.equal(
+    created.event.data.authorizationProvenance.ownerConfirmationDigest,
+    acquired.lease.ownerConfirmationDigest,
+  );
+  assert.throws(
+    () =>
+      createTask({
+        stateRoot,
+        taskId: "different-current-task",
+        actor: "freed-owner",
+        leaseName: "owner-governance",
+        leaseToken: acquired.lease.token,
+        observerAuthority: "merge-safe",
+        providerAuthority: "forbidden",
+        details: { behavioral: false },
+        nowMs: nowMs + 3_000,
+      }),
+    (error) =>
+      error instanceof AutomationControlError &&
+      error.code === "owner_capability_intent_mismatch",
+  );
+});
+
+test("current-task owner confirmation rejects stale, forged, and permissive records", () => {
+  const stateRoot = temporaryStateRoot();
+  const nowMs = Date.parse("2026-07-10T14:00:00Z");
+  const taskId = "invalid-owner-confirmation";
+  const intent = {
+    schemaVersion: 1,
+    action: "task.create",
+    taskId,
+    parameters: {
+      state: "observed",
+      observerAuthority: "merge-safe",
+      providerAuthority: "forbidden",
+      approvalReference: null,
+      details: { behavioral: false },
+    },
+  };
+  const intentDigest = ownerGovernanceIntentDigest(intent);
+  const acquire = (confirmationPath) =>
+    acquireLease({
+      stateRoot,
+      name: "owner-governance",
+      owner: "freed-owner",
+      ttlMs: 60_000,
+      nowMs,
+      ownerConfirmationFile: confirmationPath,
+      ownerCapabilityTaskId: taskId,
+      ownerCapabilityIntentDigest: intentDigest,
+    });
+
+  const expired = writeOwnerConfirmation(stateRoot, taskId, intent, {
+    nowMs,
+    confirmationId: "expired-owner-confirmation",
+    approvedAtMs: nowMs - 120_000,
+    expiresAtMs: nowMs - 60_000,
+  });
+  assert.throws(
+    () => acquire(expired.confirmationPath),
+    (error) =>
+      error instanceof AutomationControlError &&
+      error.code === "owner_confirmation_invalid",
+  );
+
+  const forged = writeOwnerConfirmation(stateRoot, taskId, intent, {
+    nowMs,
+    confirmationId: "forged-owner-confirmation",
+    approvedBy: "SomeoneElse",
+  });
+  assert.throws(
+    () => acquire(forged.confirmationPath),
+    (error) =>
+      error instanceof AutomationControlError &&
+      error.code === "owner_confirmation_invalid",
+  );
+
+  const tampered = writeOwnerConfirmation(stateRoot, taskId, intent, {
+    nowMs,
+    confirmationId: "tampered-owner-confirmation",
+  });
+  tampered.confirmation.intent.parameters.details.behavioral = true;
+  writeFileSync(
+    tampered.confirmationPath,
+    `${JSON.stringify(tampered.confirmation)}\n`,
+    { mode: 0o600 },
+  );
+  assert.throws(
+    () => acquire(tampered.confirmationPath),
+    (error) =>
+      error instanceof AutomationControlError &&
+      error.code === "owner_confirmation_invalid",
+  );
+
+  const permissive = writeOwnerConfirmation(stateRoot, taskId, intent, {
+    nowMs,
+    confirmationId: "permissive-owner-confirmation",
+    mode: 0o644,
+  });
+  assert.throws(
+    () => acquire(permissive.confirmationPath),
+    (error) =>
+      error instanceof AutomationControlError &&
+      error.code === "owner_confirmation_permissions_invalid",
+  );
+});
+
 test("same-UID owner bootstrap files cannot authenticate governance", () => {
   const stateRoot = temporaryStateRoot();
   const nowMs = Date.parse("2026-07-10T14:00:00Z");
@@ -2642,7 +2860,77 @@ test("CLI computes the canonical owner governance intent digest", () => {
   assert.equal(result.result.intentDigest, ownerGovernanceIntentDigest(intent));
 });
 
-test("CLI cannot mint freed-owner without a signed owner capability", async () => {
+test("CLI accepts a current-task owner confirmation without a broker token", () => {
+  const stateRoot = temporaryStateRoot();
+  const taskId = "cli-current-task-owner";
+  const details = {
+    behavioral: false,
+    metricId: "renderer-recovery-count",
+  };
+  const intent = {
+    schemaVersion: 1,
+    action: "task.create",
+    taskId,
+    parameters: {
+      state: "observed",
+      observerAuthority: "merge-safe",
+      providerAuthority: "forbidden",
+      approvalReference: null,
+      details,
+    },
+  };
+  const intentDigest = ownerGovernanceIntentDigest(intent);
+  const { confirmationPath } = writeOwnerConfirmation(
+    stateRoot,
+    taskId,
+    intent,
+    { nowMs: Date.now(), confirmationId: "cli-owner-confirmation" },
+  );
+  const lease = runCli([
+    "lease",
+    "acquire",
+    "--state-root",
+    stateRoot,
+    "--name",
+    "owner-governance",
+    "--owner",
+    "freed-owner",
+    "--ttl-seconds",
+    "60",
+    "--owner-confirmation-file",
+    confirmationPath,
+    "--owner-task-id",
+    taskId,
+    "--owner-intent-digest",
+    intentDigest,
+  ]);
+  assert.equal(lease.result.lease.credentialKind, "owner-confirmation");
+  assert.ok(lease.result.lease.token);
+
+  const created = runCli([
+    "task",
+    "create",
+    "--state-root",
+    stateRoot,
+    "--id",
+    taskId,
+    "--actor",
+    "freed-owner",
+    "--lease-name",
+    "owner-governance",
+    "--lease-token",
+    lease.result.lease.token,
+    "--observer-authority",
+    "merge-safe",
+    "--provider-authority",
+    "forbidden",
+    "--details-json",
+    JSON.stringify(details),
+  ]);
+  assert.equal(created.result.task.taskId, taskId);
+});
+
+test("CLI cannot mint freed-owner without an approved owner source", async () => {
   const stateRoot = temporaryStateRoot();
   const args = [
     "lease",

--- a/scripts/lib/automation-control.mjs
+++ b/scripts/lib/automation-control.mjs
@@ -30,6 +30,7 @@ export const AUTOMATION_CONTROL_SCHEMA_VERSION = 1;
 export const PUBLISH_SCOPE_SCHEMA_VERSION = 2;
 export const PUBLISHER_CAPABILITY_SCHEMA_VERSION = 1;
 export const OWNER_CAPABILITY_SCHEMA_VERSION = 1;
+const OWNER_CONFIRMATION_SCHEMA_VERSION = 1;
 const OUTCOME_LEDGER_SCHEMA_VERSION = 3;
 export const DEFAULT_AUTOMATION_STATE_ROOT = path.join(
   os.homedir(),
@@ -269,6 +270,8 @@ const ORPHAN_LEASE_GRACE_MS = 5 * 60 * 1_000;
 const OWNER_LEASE_MAX_LIFETIME_MS = 15 * 60 * 1_000;
 const OWNER_CAPABILITY_LIFETIME_MS = 60 * 1_000;
 const OWNER_CAPABILITY_CLOCK_SKEW_MS = 30 * 1_000;
+const OWNER_CONFIRMATION_MAX_LIFETIME_MS = 7 * 24 * 60 * 60 * 1_000;
+const OWNER_CONFIRMATION_CLOCK_SKEW_MS = 30 * 1_000;
 const OWNER_CAPABILITY_PURPOSE = "owner-governance-capability";
 const OWNER_CAPABILITY_ISSUER = "trusted-publisher-host";
 const OWNER_TRUST_CONFIG_PATH =
@@ -1173,6 +1176,20 @@ function leaseAuthorizationProvenance(lease) {
           ownerCapabilityTaskId: lease.ownerCapabilityTaskId,
           ownerCapabilityIntentDigest: lease.ownerCapabilityIntentDigest,
         }),
+    ...(lease.ownerConfirmationId === undefined
+      ? {}
+      : {
+          ownerConfirmationId: lease.ownerConfirmationId,
+          ownerConfirmationTaskId: lease.ownerConfirmationTaskId,
+          ownerConfirmationIntentDigest: lease.ownerConfirmationIntentDigest,
+          ownerConfirmationDigest: lease.ownerConfirmationDigest,
+          ownerConfirmationReference: lease.ownerConfirmationReference,
+          ownerConfirmationApprovedBy: lease.ownerConfirmationApprovedBy,
+          ownerConfirmationApprovalReference:
+            lease.ownerConfirmationApprovalReference,
+          ownerConfirmationApprovedAt: lease.ownerConfirmationApprovedAt,
+          ownerConfirmationExpiresAt: lease.ownerConfirmationExpiresAt,
+        }),
     ...(lease.publisherCapabilityId === undefined
       ? {}
       : { publisherCapabilityId: lease.publisherCapabilityId }),
@@ -1442,7 +1459,7 @@ export function transitionTask({
   }
   const normalizedDetails =
     details === undefined ? undefined : requirePlainObject(details, "details");
-  const { policy } = requireMutationLease({
+  const { policy, lease } = requireMutationLease({
     stateRoot,
     actor,
     leaseName,
@@ -1694,6 +1711,7 @@ export function transitionTask({
       eventData: {
         fromState,
         toState,
+        authorizationProvenance: leaseAuthorizationProvenance(lease),
         ...(VERIFICATION_TASK_STATES.has(toState)
           ? { outcomeRequired: true }
           : {}),
@@ -2264,7 +2282,58 @@ function validateLeaseRecord(record, name) {
   const acquiredAtMs = Date.parse(String(record?.acquiredAt ?? ""));
   const heartbeatAtMs = Date.parse(String(record?.heartbeatAt ?? ""));
   const expiresAtMs = Date.parse(String(record?.expiresAt ?? ""));
+  const ownerConfirmationApprovedAtMs = Date.parse(
+    String(record?.ownerConfirmationApprovedAt ?? ""),
+  );
+  const ownerConfirmationExpiresAtMs = Date.parse(
+    String(record?.ownerConfirmationExpiresAt ?? ""),
+  );
   const maxLifetimeMs = actorLeaseMaxLifetimeMs(record?.owner);
+  const hasNoOwnerConfirmationFields =
+    record?.ownerConfirmationId === undefined &&
+    record?.ownerConfirmationTaskId === undefined &&
+    record?.ownerConfirmationIntentDigest === undefined &&
+    record?.ownerConfirmationDigest === undefined &&
+    record?.ownerConfirmationReference === undefined &&
+    record?.ownerConfirmationApprovedBy === undefined &&
+    record?.ownerConfirmationApprovalReference === undefined &&
+    record?.ownerConfirmationApprovedAt === undefined &&
+    record?.ownerConfirmationExpiresAt === undefined;
+  const validOwnerSignedCapability =
+    record?.credentialKind === "owner-signed-capability" &&
+    typeof record?.ownerCapabilityId === "string" &&
+    IDENTIFIER_PATTERN.test(record.ownerCapabilityId) &&
+    typeof record?.ownerCapabilityTaskId === "string" &&
+    IDENTIFIER_PATTERN.test(record.ownerCapabilityTaskId) &&
+    typeof record?.ownerCapabilityIntentDigest === "string" &&
+    /^[0-9a-f]{64}$/.test(record.ownerCapabilityIntentDigest) &&
+    hasNoOwnerConfirmationFields;
+  const validOwnerConfirmation =
+    record?.credentialKind === "owner-confirmation" &&
+    record?.ownerCapabilityId === undefined &&
+    record?.ownerCapabilityTaskId === undefined &&
+    record?.ownerCapabilityIntentDigest === undefined &&
+    typeof record?.ownerConfirmationId === "string" &&
+    IDENTIFIER_PATTERN.test(record.ownerConfirmationId) &&
+    typeof record?.ownerConfirmationTaskId === "string" &&
+    IDENTIFIER_PATTERN.test(record.ownerConfirmationTaskId) &&
+    typeof record?.ownerConfirmationIntentDigest === "string" &&
+    /^[0-9a-f]{64}$/.test(record.ownerConfirmationIntentDigest) &&
+    typeof record?.ownerConfirmationDigest === "string" &&
+    /^[0-9a-f]{64}$/.test(record.ownerConfirmationDigest) &&
+    typeof record?.ownerConfirmationReference === "string" &&
+    record.ownerConfirmationReference.trim() !== "" &&
+    record?.ownerConfirmationApprovedBy === "AubreyF" &&
+    typeof record?.ownerConfirmationApprovalReference === "string" &&
+    record.ownerConfirmationApprovalReference.trim() !== "" &&
+    Number.isFinite(ownerConfirmationApprovedAtMs) &&
+    Number.isFinite(ownerConfirmationExpiresAtMs) &&
+    ownerConfirmationExpiresAtMs > ownerConfirmationApprovedAtMs &&
+    ownerConfirmationExpiresAtMs - ownerConfirmationApprovedAtMs <=
+      OWNER_CONFIRMATION_MAX_LIFETIME_MS &&
+    ownerConfirmationApprovedAtMs <=
+      acquiredAtMs + OWNER_CONFIRMATION_CLOCK_SKEW_MS &&
+    ownerConfirmationExpiresAtMs >= expiresAtMs;
   if (
     record?.schemaVersion !== AUTOMATION_CONTROL_SCHEMA_VERSION ||
     record?.name !== name ||
@@ -2288,29 +2357,26 @@ function validateLeaseRecord(record, name) {
     policy.providerAuthority !== record?.providerAuthority ||
     ![
       "persistent-actor",
+      "owner-confirmation",
       "owner-signed-capability",
       "signed-capability",
     ].includes(record?.credentialKind) ||
     (record?.owner === "freed-owner"
-      ? record.credentialKind !== "owner-signed-capability" ||
-        typeof record?.ownerCapabilityId !== "string" ||
-        !IDENTIFIER_PATTERN.test(record.ownerCapabilityId) ||
-        typeof record?.ownerCapabilityTaskId !== "string" ||
-        !IDENTIFIER_PATTERN.test(record.ownerCapabilityTaskId) ||
-        typeof record?.ownerCapabilityIntentDigest !== "string" ||
-        !/^[0-9a-f]{64}$/.test(record.ownerCapabilityIntentDigest) ||
+      ? (!validOwnerSignedCapability && !validOwnerConfirmation) ||
         record?.publisherCapabilityId !== undefined
       : record?.owner === "freed-pr-publisher"
         ? record.credentialKind !== "signed-capability" ||
           record?.ownerCapabilityId !== undefined ||
           record?.ownerCapabilityTaskId !== undefined ||
           record?.ownerCapabilityIntentDigest !== undefined ||
+          !hasNoOwnerConfirmationFields ||
           typeof record?.publisherCapabilityId !== "string" ||
           !IDENTIFIER_PATTERN.test(record.publisherCapabilityId)
         : record.credentialKind !== "persistent-actor" ||
           record?.ownerCapabilityId !== undefined ||
           record?.ownerCapabilityTaskId !== undefined ||
           record?.ownerCapabilityIntentDigest !== undefined ||
+          !hasNoOwnerConfirmationFields ||
           record?.publisherCapabilityId !== undefined)
   ) {
     throw new AutomationControlError(
@@ -2410,6 +2476,15 @@ function canonicalIntentValue(value) {
 export function ownerGovernanceIntentDigest(intent) {
   const canonical = canonicalIntentValue(
     requirePlainObject(intent, "owner governance intent"),
+  );
+  return createHash("sha256")
+    .update(JSON.stringify(canonical), "utf8")
+    .digest("hex");
+}
+
+function ownerConfirmationDigest(confirmation) {
+  const canonical = canonicalIntentValue(
+    requirePlainObject(confirmation, "owner confirmation"),
   );
   return createHash("sha256")
     .update(JSON.stringify(canonical), "utf8")
@@ -3031,6 +3106,129 @@ function readAndValidateOwnerCapability({
   return { capabilityFile: expectedPath, consumedPath, payload };
 }
 
+function readAndValidateOwnerConfirmation({
+  confirmationFile,
+  taskId,
+  intentDigest,
+  ttlMs,
+  nowMs,
+}) {
+  if (
+    typeof confirmationFile !== "string" ||
+    !path.isAbsolute(confirmationFile)
+  ) {
+    throw new AutomationControlError(
+      "owner_confirmation_required",
+      "freed-owner requires an absolute current-task owner confirmation file when no signed capability is supplied.",
+    );
+  }
+  requirePrivateRegularFile(confirmationFile, {
+    missingCode: "owner_confirmation_required",
+    missingMessage: "The current-task owner confirmation file is unavailable.",
+    invalidCode: "owner_confirmation_permissions_invalid",
+    invalidMessage:
+      "The current-task owner confirmation must be a private regular file owned by the current user.",
+  });
+  let physicalConfirmationFile = "";
+  try {
+    physicalConfirmationFile = realpathSync(confirmationFile);
+  } catch {
+    // The private-file check above supplies the useful missing-file error.
+  }
+  if (physicalConfirmationFile !== confirmationFile) {
+    throw new AutomationControlError(
+      "owner_confirmation_invalid",
+      "The current-task owner confirmation path must be canonical.",
+    );
+  }
+
+  const confirmation = readJsonFile(confirmationFile);
+  const requiredKeys = [
+    "approvalSource",
+    "approvedAt",
+    "approvedBy",
+    "confirmationId",
+    "expiresAt",
+    "intent",
+    "intentDigest",
+    "kind",
+    "ownerApprovalReference",
+    "schemaVersion",
+    "taskId",
+  ].sort();
+  const sourceKeys = ["kind", "reference"];
+  const approvedAtMs = Date.parse(String(confirmation?.approvedAt ?? ""));
+  const expiresAtMs = Date.parse(String(confirmation?.expiresAt ?? ""));
+  const normalizedIntentDigest = String(intentDigest ?? "")
+    .trim()
+    .toLowerCase();
+  const confirmationIntentDigest = String(confirmation?.intentDigest ?? "")
+    .trim()
+    .toLowerCase();
+  let embeddedIntentDigest = "";
+  try {
+    embeddedIntentDigest = ownerGovernanceIntentDigest(confirmation?.intent);
+  } catch {
+    // The aggregate validation error below keeps approval failures uniform.
+  }
+  const source = confirmation?.approvalSource;
+  if (
+    confirmation?.schemaVersion !== OWNER_CONFIRMATION_SCHEMA_VERSION ||
+    Object.keys(confirmation ?? {})
+      .sort()
+      .join("\n") !== requiredKeys.join("\n") ||
+    confirmation?.kind !== "owner-confirmation" ||
+    typeof confirmation?.confirmationId !== "string" ||
+    !IDENTIFIER_PATTERN.test(confirmation.confirmationId) ||
+    confirmation?.approvedBy !== "AubreyF" ||
+    typeof confirmation?.ownerApprovalReference !== "string" ||
+    confirmation.ownerApprovalReference.trim() === "" ||
+    !source ||
+    typeof source !== "object" ||
+    Array.isArray(source) ||
+    Object.keys(source).sort().join("\n") !== sourceKeys.join("\n") ||
+    source.kind !== "current-task" ||
+    typeof source.reference !== "string" ||
+    source.reference.trim() === "" ||
+    confirmation?.taskId !== taskId ||
+    !IDENTIFIER_PATTERN.test(String(confirmation?.taskId ?? "")) ||
+    confirmation?.intent?.schemaVersion !== OWNER_CAPABILITY_SCHEMA_VERSION ||
+    confirmation?.intent?.taskId !== taskId ||
+    typeof confirmation?.intent?.action !== "string" ||
+    confirmation.intent.action.trim() === "" ||
+    !/^[0-9a-f]{64}$/.test(normalizedIntentDigest) ||
+    confirmationIntentDigest !== normalizedIntentDigest ||
+    embeddedIntentDigest !== confirmationIntentDigest ||
+    !Number.isFinite(approvedAtMs) ||
+    !Number.isFinite(expiresAtMs) ||
+    approvedAtMs > nowMs + OWNER_CONFIRMATION_CLOCK_SKEW_MS ||
+    expiresAtMs <= nowMs ||
+    expiresAtMs <= approvedAtMs ||
+    expiresAtMs - approvedAtMs > OWNER_CONFIRMATION_MAX_LIFETIME_MS ||
+    nowMs + ttlMs > expiresAtMs
+  ) {
+    throw new AutomationControlError(
+      "owner_confirmation_invalid",
+      "The current-task owner confirmation does not match this exact governance lease request or is outside its validity window.",
+    );
+  }
+  return {
+    confirmationFile,
+    confirmation: {
+      ...confirmation,
+      ownerApprovalReference: confirmation.ownerApprovalReference.trim(),
+      approvalSource: {
+        kind: source.kind,
+        reference: source.reference.trim(),
+      },
+      intentDigest: confirmationIntentDigest,
+      approvedAt: new Date(approvedAtMs).toISOString(),
+      expiresAt: new Date(expiresAtMs).toISOString(),
+    },
+    digest: ownerConfirmationDigest(confirmation),
+  };
+}
+
 function consumeOwnerCapability(capability) {
   ensurePrivateDirectory(path.dirname(capability.consumedPath));
   renameSync(capability.capabilityFile, capability.consumedPath);
@@ -3103,18 +3301,23 @@ function requireMutationLease({
   if (
     actor === "freed-owner" &&
     (typeof taskId !== "string" ||
-      record.ownerCapabilityTaskId !== taskId ||
+      (record.ownerCapabilityTaskId ?? record.ownerConfirmationTaskId) !==
+        taskId ||
       typeof ownerIntentDigest !== "string" ||
-      record.ownerCapabilityIntentDigest !== ownerIntentDigest)
+      (record.ownerCapabilityIntentDigest ??
+        record.ownerConfirmationIntentDigest) !== ownerIntentDigest)
   ) {
     throw new AutomationControlError(
       "owner_capability_intent_mismatch",
       "The owner governance lease is not authorized for this exact task and intent digest.",
       {
         taskId,
-        authorizedTaskId: record.ownerCapabilityTaskId,
+        authorizedTaskId:
+          record.ownerCapabilityTaskId ?? record.ownerConfirmationTaskId,
         ownerIntentDigest,
-        authorizedIntentDigest: record.ownerCapabilityIntentDigest,
+        authorizedIntentDigest:
+          record.ownerCapabilityIntentDigest ??
+          record.ownerConfirmationIntentDigest,
       },
     );
   }
@@ -3202,6 +3405,7 @@ export function acquireLease({
   token = randomUUID(),
   orphanGraceMs = ORPHAN_LEASE_GRACE_MS,
   ownerCapabilityFile = undefined,
+  ownerConfirmationFile = undefined,
   ownerCapabilityTaskId = undefined,
   ownerCapabilityIntentDigest = undefined,
   actorCredentialToken = undefined,
@@ -3238,7 +3442,9 @@ export function acquireLease({
   requirePositiveInteger(orphanGraceMs, "orphanGraceMs");
   if (
     owner === "freed-pr-publisher" &&
-    (actorCredentialToken !== undefined || ownerCapabilityFile !== undefined)
+    (actorCredentialToken !== undefined ||
+      ownerCapabilityFile !== undefined ||
+      ownerConfirmationFile !== undefined)
   ) {
     throw new AutomationControlError(
       "publisher_reusable_credential_forbidden",
@@ -3254,6 +3460,7 @@ export function acquireLease({
   if (
     owner !== "freed-owner" &&
     (ownerCapabilityFile !== undefined ||
+      ownerConfirmationFile !== undefined ||
       ownerCapabilityTaskId !== undefined ||
       ownerCapabilityIntentDigest !== undefined)
   ) {
@@ -3280,6 +3487,23 @@ export function acquireLease({
       `${owner} leases cannot exceed ${maxLeaseLifetimeMs.toLocaleString()} ms.`,
     );
   }
+  if (owner === "freed-owner") {
+    const authorizationCount =
+      Number(ownerCapabilityFile !== undefined) +
+      Number(ownerConfirmationFile !== undefined);
+    if (authorizationCount === 0) {
+      throw new AutomationControlError(
+        "owner_capability_required",
+        "freed-owner requires a signed owner capability or current-task owner confirmation.",
+      );
+    }
+    if (authorizationCount > 1) {
+      throw new AutomationControlError(
+        "owner_authorization_conflict",
+        "freed-owner accepts only one signed capability or current-task confirmation per lease.",
+      );
+    }
+  }
   const publisherScope =
     owner === "freed-pr-publisher" ? normalizePublisherScope(scope) : undefined;
   if (owner !== "freed-pr-publisher" && scope !== undefined) {
@@ -3296,13 +3520,23 @@ export function acquireLease({
       ensurePrivateDirectory(paths.leases);
       const leasePath = leasePathFor(paths, name);
       const ownerCapability =
-        owner === "freed-owner"
+        owner === "freed-owner" && ownerCapabilityFile !== undefined
           ? readAndValidateOwnerCapability({
               paths,
               capabilityFile: ownerCapabilityFile,
               taskId: ownerCapabilityTaskId,
               intentDigest: ownerCapabilityIntentDigest,
               leaseToken: token,
+              ttlMs,
+              nowMs,
+            })
+          : null;
+      const ownerConfirmation =
+        owner === "freed-owner" && ownerConfirmationFile !== undefined
+          ? readAndValidateOwnerConfirmation({
+              confirmationFile: ownerConfirmationFile,
+              taskId: ownerCapabilityTaskId,
+              intentDigest: ownerCapabilityIntentDigest,
               ttlMs,
               nowMs,
             })
@@ -3418,15 +3652,37 @@ export function acquireLease({
         credentialKind:
           ownerCapability !== null
             ? "owner-signed-capability"
-            : publisherCapability !== null
-              ? "signed-capability"
-              : "persistent-actor",
+            : ownerConfirmation !== null
+              ? "owner-confirmation"
+              : publisherCapability !== null
+                ? "signed-capability"
+                : "persistent-actor",
         ...(ownerCapability === null
           ? {}
           : {
               ownerCapabilityId: ownerCapability.payload.capabilityId,
               ownerCapabilityTaskId: ownerCapability.payload.taskId,
               ownerCapabilityIntentDigest: ownerCapability.payload.intentDigest,
+            }),
+        ...(ownerConfirmation === null
+          ? {}
+          : {
+              ownerConfirmationId:
+                ownerConfirmation.confirmation.confirmationId,
+              ownerConfirmationTaskId: ownerConfirmation.confirmation.taskId,
+              ownerConfirmationIntentDigest:
+                ownerConfirmation.confirmation.intentDigest,
+              ownerConfirmationDigest: ownerConfirmation.digest,
+              ownerConfirmationReference:
+                ownerConfirmation.confirmation.approvalSource.reference,
+              ownerConfirmationApprovedBy:
+                ownerConfirmation.confirmation.approvedBy,
+              ownerConfirmationApprovalReference:
+                ownerConfirmation.confirmation.ownerApprovalReference,
+              ownerConfirmationApprovedAt:
+                ownerConfirmation.confirmation.approvedAt,
+              ownerConfirmationExpiresAt:
+                ownerConfirmation.confirmation.expiresAt,
             }),
         ...(publisherCapability === null
           ? {}
@@ -3494,6 +3750,26 @@ export function acquireLease({
                 ownerCapabilityTaskId: ownerCapability.payload.taskId,
                 ownerCapabilityIntentDigest:
                   ownerCapability.payload.intentDigest,
+              }),
+          ...(ownerConfirmation === null
+            ? {}
+            : {
+                ownerConfirmationId:
+                  ownerConfirmation.confirmation.confirmationId,
+                ownerConfirmationTaskId: ownerConfirmation.confirmation.taskId,
+                ownerConfirmationIntentDigest:
+                  ownerConfirmation.confirmation.intentDigest,
+                ownerConfirmationDigest: ownerConfirmation.digest,
+                ownerConfirmationReference:
+                  ownerConfirmation.confirmation.approvalSource.reference,
+                ownerConfirmationApprovedBy:
+                  ownerConfirmation.confirmation.approvedBy,
+                ownerConfirmationApprovalReference:
+                  ownerConfirmation.confirmation.ownerApprovalReference,
+                ownerConfirmationApprovedAt:
+                  ownerConfirmation.confirmation.approvedAt,
+                ownerConfirmationExpiresAt:
+                  ownerConfirmation.confirmation.expiresAt,
               }),
           ...(credentialUpgrade ? { credentialUpgrade: true } : {}),
           ...(previous === null ? {} : { previous }),

--- a/scripts/lib/stability-artifacts.mjs
+++ b/scripts/lib/stability-artifacts.mjs
@@ -9,6 +9,8 @@ import {
 import os from "node:os";
 import path from "node:path";
 
+import { stabilityMetricById } from "./stability-metrics.mjs";
+
 export const STABILITY_ARTIFACT_SCHEMA_VERSION = 1;
 export const DEFAULT_STABILITY_ARTIFACT_ROOT = path.join(
   os.homedir(),
@@ -147,6 +149,19 @@ function requireStringArray(value, field, errors, options = {}) {
 }
 
 function validatePayload(kind, status, payload, errors) {
+  if (Object.hasOwn(payload, "metricId")) {
+    const metricId = requireString(
+      payload.metricId,
+      "payload.metricId",
+      errors,
+    );
+    if (metricId && !stabilityMetricById(metricId)) {
+      errors.push(
+        `payload.metricId must name a registered stability metric: ${metricId}`,
+      );
+    }
+  }
+
   if (kind === "evidence-capture") {
     const processSegments = requireArray(
       payload.processSegments,
@@ -175,7 +190,6 @@ function validatePayload(kind, status, payload, errors) {
   if (kind === "memory-profile") {
     requireString(payload.scenario, "payload.scenario", errors);
     requireString(payload.comparisonCohort, "payload.comparisonCohort", errors);
-    requireString(payload.metricId, "payload.metricId", errors);
     const budget = requireObject(payload.budget, "payload.budget", errors);
     if (!Number.isFinite(budget.value))
       errors.push("payload.budget.value must be a finite number");

--- a/scripts/stability-artifact.test.mjs
+++ b/scripts/stability-artifact.test.mjs
@@ -61,7 +61,7 @@ function memoryArtifact(overrides = {}) {
     payload: {
       scenario: "large-document-idle",
       comparisonCohort: "apple-silicon-32gb-large",
-      metricId: "main_footprint_slope",
+      metricId: "main-footprint-slope",
       budget: { value: 5, unit: "MiB/hour" },
       contributors: [],
       measuredScope: ["Freed Desktop native and attributed WebKit RSS"],
@@ -153,6 +153,33 @@ test("provider review artifacts require named providers and human-readable risk 
   assert.throws(
     () => validateStabilityArtifact(artifact),
     /payload.providers must be an array[\s\S]*payload.observableBehavior must be a non-empty string/,
+  );
+});
+
+test("stability artifacts reject unknown optional metric ids", () => {
+  const valid = controllerArtifact({
+    kind: "provider-risk-review",
+    status: "diff_authorized",
+    payload: {
+      providers: ["other"],
+      observableBehavior: "Observe the reviewed provider behavior.",
+      fingerprintingRisk: "The provider can observe authenticated requests.",
+      lowestProfileAlternative: "Keep provider contact disabled.",
+      allowedBehavior: "Only the exact reviewed provider behavior.",
+      metricId: "renderer-recovery-count",
+    },
+  });
+  assert.doesNotThrow(() => validateStabilityArtifact(valid));
+  assert.throws(
+    () =>
+      validateStabilityArtifact({
+        ...valid,
+        payload: {
+          ...valid.payload,
+          metricId: "unregistered-provider-wish",
+        },
+      }),
+    /payload.metricId must name a registered stability metric/,
   );
 });
 


### PR DESCRIPTION
(AI Generated).

## Summary
- Allow an explicit current-task owner confirmation to authorize one exact lifecycle operation when the optional signed broker is unavailable.
- Reject unregistered metric IDs in stability artifacts and preserve authorization provenance in lifecycle audit events.

## Testing
- npm run validate:feature
- node --test scripts/automation-control.test.mjs scripts/stability-artifact.test.mjs scripts/stability-metrics.test.mjs
- npm run validate:automations
- npm run validate:roadmap