### PR TITLE
fix: accept canonical tag ruleset responses

### DIFF
--- a/.github/rulesets/release-tag-immutability.json
+++ b/.github/rulesets/release-tag-immutability.json
@@ -10,10 +10,7 @@
     }
   },
   "rules": [
-    {
-      "type": "update",
-      "parameters": { "update_allows_fetch_and_merge": false }
-    },
+    { "type": "update" },
     { "type": "deletion" }
   ]
 }

--- a/.github/rulesets/release-tag-lockdown.json
+++ b/.github/rulesets/release-tag-lockdown.json
@@ -11,10 +11,7 @@
   },
   "rules": [
     { "type": "creation" },
-    {
-      "type": "update",
-      "parameters": { "update_allows_fetch_and_merge": false }
-    },
+    { "type": "update" },
     { "type": "deletion" }
   ]
 }

--- a/docs/RELEASE-SECRETS.md
+++ b/docs/RELEASE-SECRETS.md
@@ -213,6 +213,11 @@ digest, Keychain-backed App proof, and native publisher attestation. It applies
 from GitHub before removing the bootstrap lockdown. A partial activation leaves
 the lockdown in place.
 
+GitHub returns tag update rules without the branch-only fetch and merge
+parameter. The checked-in tag policies use that canonical parameter-free form.
+The verifier accepts an older explicit `false` value but rejects `true` or any
+unexpected update parameters.
+
 ### Verify, publish, rotate, or revoke
 
 Verify the installed publisher and its live App installation at any time:

--- a/scripts/sync-github-rulesets.mjs
+++ b/scripts/sync-github-rulesets.mjs
@@ -53,6 +53,16 @@ function hasExactRuleTypes(ruleset, expectedTypes) {
   );
 }
 
+function hasSafeTagUpdateRule(ruleset) {
+  const update = ruleset.rules?.find((rule) => rule.type === "update");
+  if (!update) return false;
+  if (update.parameters == null) return true;
+  return (
+    Object.keys(update.parameters).length === 1 &&
+    update.parameters.update_allows_fetch_and_merge === false
+  );
+}
+
 function hasExactReleaseTagTarget(ruleset) {
   return (
     JSON.stringify(ruleset?.conditions?.ref_name?.include) ===
@@ -121,12 +131,9 @@ export function validateRuleset(ruleset, fileName = "ruleset") {
           `${fileName}: release tag lockdown must be active, have no bypass, and contain only creation, update, and deletion rules.`,
         );
       }
-      const update = ruleset.rules.find(
-        (rule) => rule.type === "update",
-      )?.parameters;
-      if (update?.update_allows_fetch_and_merge !== false) {
+      if (!hasSafeTagUpdateRule(ruleset)) {
         throw new Error(
-          `${fileName}: release tag lockdown must reject fetch and merge updates.`,
+          `${fileName}: release tag lockdown has an unsafe update rule.`,
         );
       }
       return ruleset;
@@ -145,12 +152,9 @@ export function validateRuleset(ruleset, fileName = "ruleset") {
         `${fileName}: release tag immutability must be active, have no bypass, and contain only update and deletion rules.`,
       );
     }
-    const update = ruleset.rules.find(
-      (rule) => rule.type === "update",
-    )?.parameters;
-    if (update?.update_allows_fetch_and_merge !== false) {
+    if (!hasSafeTagUpdateRule(ruleset)) {
       throw new Error(
-        `${fileName}: release tag updates must not allow fetch and merge.`,
+        `${fileName}: release tag immutability has an unsafe update rule.`,
       );
     }
     return ruleset;
@@ -305,8 +309,7 @@ export function verifyReleaseTagLockdown(rulesets) {
     lockdown.bypass_actors?.length !== 0 ||
     !hasExactReleaseTagTarget(lockdown) ||
     !hasExactRuleTypes(lockdown, TAG_LOCKDOWN_RULE_TYPES) ||
-    lockdown.rules.find((rule) => rule.type === "update")?.parameters
-      ?.update_allows_fetch_and_merge !== false
+    !hasSafeTagUpdateRule(lockdown)
   ) {
     throw new Error(
       "Release tag lockdown must actively restrict creation, update, and deletion with no bypass.",
@@ -352,12 +355,9 @@ export function verifyLiveReleaseTagAuthority(rulesets, expectedReleaseAppId) {
       "Live release tag immutability must be active, target every refs/tags/v* tag, contain only update and deletion rules, and grant no bypass.",
     );
   }
-  const update = immutability.rules.find(
-    (rule) => rule.type === "update",
-  )?.parameters;
-  if (update?.update_allows_fetch_and_merge !== false) {
+  if (!hasSafeTagUpdateRule(immutability)) {
     throw new Error(
-      "The live release tag authority must reject fetch and merge updates.",
+      "The live release tag authority has an unsafe update rule.",
     );
   }
   return { ready: true, releaseAppId: expectedAppId };

--- a/scripts/sync-github-rulesets.test.mjs
+++ b/scripts/sync-github-rulesets.test.mjs
@@ -227,6 +227,13 @@ test("release tag creation grants only the dedicated App while immutability gran
   assert.equal(immutability.enforcement, "active");
   assert.deepEqual(immutability.bypass_actors, []);
   assert.equal(verifyReleaseTagLockdown(tagRulesets).lockdown, lockdown);
+  assert.deepEqual(
+    planRulesetSync(
+      tagRulesets,
+      tagRulesets.map((ruleset, index) => ({ ...ruleset, id: index + 1 })),
+    ).map((item) => item.action),
+    ["unchanged", "unchanged", "unchanged"],
+  );
   assert.throws(
     () =>
       verifyReleaseTagLockdown([


### PR DESCRIPTION
(AI Generated).

## Summary
- Use GitHub's canonical parameter-free update rule for protected release tags.
- Keep validation fail-closed for explicit unsafe or unexpected update parameters.

## Testing
- node --test scripts/sync-github-rulesets.test.mjs scripts/validate-release-tag-authority.test.mjs
- npm run validate:feature