### PR TITLE
chore: prepare v26.7.1400-dev

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freed/desktop",
   "private": true,
-  "version": "26.7.1301",
+  "version": "26.7.1400",
   "type": "module",
   "scripts": {
     "dev": "node ../../node_modules/vite/bin/vite.js",

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -1420,7 +1420,7 @@ dependencies = [
 
 [[package]]
 name = "freed-desktop"
-version = "26.7.1301"
+version = "26.7.1400"
 dependencies = [
  "base64 0.22.1",
  "criterion",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freed-desktop"
-version = "26.7.1301"
+version = "26.7.1400"
 description = "Freed Desktop - Escape algorithmic manipulation"
 authors = ["Freed"]
 edition = "2021"

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Freed",
-  "version": "26.7.1301",
+  "version": "26.7.1400",
   "identifier": "wtf.freed.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freed/pwa",
   "private": true,
-  "version": "26.7.1301",
+  "version": "26.7.1400",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/release-notes/daily/dev/26.7.14.json
+++ b/release-notes/daily/dev/26.7.14.json
@@ -2,13 +2,19 @@
   "channel": "dev",
   "dayKey": "26.7.14",
   "date": "2026-07-14",
-  "preferredDeck": null,
+  "preferredDeck": "Friends is now a theme-aware personal galaxy with native touch and trackpad navigation, tight identity constellations, and cosmic provider nebulae",
   "editorialGuidance": [
     "Keep the tone concise, professional, and specific.",
     "Lead with user-facing outcomes, shipping milestones, trust wins, and installability improvements.",
     "Demote internal cleanup unless it clearly changes the shipped product."
   ],
-  "pinnedHighlights": [],
-  "editorialNotes": [],
+  "pinnedHighlights": [
+    "Friends Galaxy",
+    "Medium and Substack beta sources",
+    "Completed YouTube capture"
+  ],
+  "editorialNotes": [
+    "Lead with the user-facing Friends Galaxy. Keep release governance and superseded release-prep commits out of public copy."
+  ],
   "updatedAt": "2026-07-14T21:56:51.376Z"
 }

--- a/release-notes/daily/dev/26.7.14.json
+++ b/release-notes/daily/dev/26.7.14.json
@@ -1,0 +1,14 @@
+{
+  "channel": "dev",
+  "dayKey": "26.7.14",
+  "date": "2026-07-14",
+  "preferredDeck": null,
+  "editorialGuidance": [
+    "Keep the tone concise, professional, and specific.",
+    "Lead with user-facing outcomes, shipping milestones, trust wins, and installability improvements.",
+    "Demote internal cleanup unless it clearly changes the shipped product."
+  ],
+  "pinnedHighlights": [],
+  "editorialNotes": [],
+  "updatedAt": "2026-07-14T21:56:51.376Z"
+}

--- a/release-notes/releases/v26.7.1400-dev.json
+++ b/release-notes/releases/v26.7.1400-dev.json
@@ -3,8 +3,10 @@
   "version": "26.7.1400-dev",
   "channel": "dev",
   "dayKey": "26.7.14",
-  "approved": false,
-  "editorialNotes": [],
+  "approved": true,
+  "editorialNotes": [
+    "Reviewed 2026-07-14: led with the Friends Galaxy, described the new Medium and Substack beta sources and completed YouTube capture, and omitted internal release governance and abandoned release-prep commits from user-facing notes."
+  ],
   "generatedAt": "2026-07-14T21:56:51.374Z",
   "model": "heuristic",
   "source": {
@@ -71,34 +73,17 @@
     ]
   },
   "release": {
-    "deck": "Authenticated essay capture, build next-generation Friends Galaxy, and dedicated release tag publisher",
+    "deck": "Friends is now a theme-aware personal galaxy with native touch and trackpad navigation, tight identity constellations, and cosmic provider nebulae",
     "features": [
-      "Authenticated essay capture",
-      "Build next-generation Friends Galaxy",
-      "Dedicated release tag publisher"
+      "Explore Friends as a hardware-accelerated 3D galaxy where relationship importance controls depth, identities form tight constellations, and every starfield follows the active Freed theme",
+      "Pan, zoom, and focus the galaxy with a mouse, trackpad, or midpoint-preserving iPhone pinch gestures while billboard labels stay visible and close to their stars",
+      "Use the new Medium and Substack beta sources in Freed Desktop to capture essays, visible relationships, subscriptions, and activity through your signed-in sessions"
     ],
     "fixes": [
-      "Accept canonical tag ruleset responses",
-      "Allow exact current-task owner approvals",
-      "Include publisher dependencies in main backports",
-      "Simplify provider approval workflow",
-      "Stop automation actor keychain prompts",
-      "Automation actor handoff are now more stable",
-      "Omit webhook from release app manifest",
-      "Accept canonical heartbeat thread targets",
-      "Recognize historical promotion commits",
-      "Complete YouTube capture lifecycle",
-      "Bootstrap automation actor leases",
-      "Bind release lockfile to version bump",
-      "Harden the stability control plane",
-      "Enable YouTube terminal sync soaks",
-      "Pinned Node when sourced by zsh resolved"
+      "Provider regions now form spiral nebulae instead of flat ellipses, and identity links appear only for the hovered or selected constellation",
+      "YouTube followed-channel and subscription capture now reports bounded progress, cancels stale work, and closes hidden capture sessions when finished"
     ],
-    "followUps": [
-      "Pin release publisher app bypass",
-      "Prepare v26.7.1301-dev",
-      "Reverse integrate main into dev"
-    ]
+    "followUps": []
   },
-  "releaseBody": "(AI Generated).\n\n## Freed v26.7.1400-dev\n\nAuthenticated essay capture, build next-generation Friends Galaxy, and dedicated release tag publisher\n\n### Features\n\n- Authenticated essay capture\n- Build next-generation Friends Galaxy\n- Dedicated release tag publisher\n\n### Fixes\n\n- Accept canonical tag ruleset responses\n- Allow exact current-task owner approvals\n- Include publisher dependencies in main backports\n- Simplify provider approval workflow\n- Stop automation actor keychain prompts\n- Automation actor handoff are now more stable\n- Omit webhook from release app manifest\n- Accept canonical heartbeat thread targets\n- Recognize historical promotion commits\n- Complete YouTube capture lifecycle\n- Bootstrap automation actor leases\n- Bind release lockfile to version bump\n- Harden the stability control plane\n- Enable YouTube terminal sync soaks\n- Pinned Node when sourced by zsh resolved\n\n### Follow-ups\n\n- Pin release publisher app bypass\n- Prepare v26.7.1301-dev\n- Reverse integrate main into dev\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+  "releaseBody": "(AI Generated).\n\n## Freed v26.7.1400-dev\n\nFriends is now a theme-aware personal galaxy with native touch and trackpad navigation, tight identity constellations, and cosmic provider nebulae.\n\n### Features\n\n- Explore Friends as a hardware-accelerated 3D galaxy where relationship importance controls depth, identities form tight constellations, and every starfield follows the active Freed theme\n- Pan, zoom, and focus the galaxy with a mouse, trackpad, or midpoint-preserving iPhone pinch gestures while billboard labels stay visible and close to their stars\n- Use the new Medium and Substack beta sources in Freed Desktop to capture essays, visible relationships, subscriptions, and activity through your signed-in sessions\n\n### Fixes\n\n- Provider regions now form spiral nebulae instead of flat ellipses, and identity links appear only for the hovered or selected constellation\n- YouTube followed-channel and subscription capture now reports bounded progress, cancels stale work, and closes hidden capture sessions when finished\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
 }

--- a/release-notes/releases/v26.7.1400-dev.json
+++ b/release-notes/releases/v26.7.1400-dev.json
@@ -1,0 +1,104 @@
+{
+  "tag": "v26.7.1400-dev",
+  "version": "26.7.1400-dev",
+  "channel": "dev",
+  "dayKey": "26.7.14",
+  "approved": false,
+  "editorialNotes": [],
+  "generatedAt": "2026-07-14T21:56:51.374Z",
+  "model": "heuristic",
+  "source": {
+    "channel": "dev",
+    "previousPublishedTag": "v26.7.1200-dev",
+    "previousPublishedDayTag": "v26.7.1200-dev",
+    "compareRef": "HEAD",
+    "productCommitSha": "91e9e04071fa56db969e03b18d5f69d296e0ecab",
+    "promotedDevCommitSha": null,
+    "isLatestOfDay": true,
+    "sameDayTagsIncluded": [
+      "v26.7.1400-dev"
+    ],
+    "relatedBuildTags": [
+      "v26.7.1400-dev"
+    ],
+    "prNumbers": [
+      642,
+      949,
+      953,
+      955,
+      957,
+      963,
+      964,
+      965,
+      966,
+      969,
+      970,
+      972,
+      973,
+      974,
+      975,
+      976,
+      977,
+      978,
+      979,
+      982,
+      983
+    ],
+    "commitSubjects": [
+      "fix: accept canonical tag ruleset responses (#983)",
+      "fix: allow exact current-task owner approvals (#982)",
+      "feat: build next-generation Friends Galaxy (#953)",
+      "fix: include publisher dependencies in main backports (#979)",
+      "chore: pin release publisher app bypass (#977)",
+      "fix: simplify provider approval workflow (#978)",
+      "feat: add authenticated essay capture (#642)",
+      "fix: stop automation actor keychain prompts (#976)",
+      "fix: stabilize automation actor handoff (#975)",
+      "fix: omit webhook from release app manifest (#974)",
+      "fix: accept canonical heartbeat thread targets (#973)",
+      "feat: add dedicated release tag publisher (#972)",
+      "fix: recognize historical promotion commits",
+      "chore: prepare v26.7.1301-dev (#970)",
+      "fix: complete YouTube capture lifecycle (#969)",
+      "fix: bootstrap automation actor leases (#965)",
+      "test: restore release channel build coverage (#967)",
+      "chore: reverse integrate main into dev (#966)",
+      "fix: bind release lockfile to version bump (#964)",
+      "chore: prepare v26.7.1300-dev (#963)",
+      "fix: harden the stability control plane (#949)",
+      "fix: enable YouTube terminal sync soaks (#955)",
+      "fix: resolve pinned Node when sourced by zsh (#957)"
+    ]
+  },
+  "release": {
+    "deck": "Authenticated essay capture, build next-generation Friends Galaxy, and dedicated release tag publisher",
+    "features": [
+      "Authenticated essay capture",
+      "Build next-generation Friends Galaxy",
+      "Dedicated release tag publisher"
+    ],
+    "fixes": [
+      "Accept canonical tag ruleset responses",
+      "Allow exact current-task owner approvals",
+      "Include publisher dependencies in main backports",
+      "Simplify provider approval workflow",
+      "Stop automation actor keychain prompts",
+      "Automation actor handoff are now more stable",
+      "Omit webhook from release app manifest",
+      "Accept canonical heartbeat thread targets",
+      "Recognize historical promotion commits",
+      "Complete YouTube capture lifecycle",
+      "Bootstrap automation actor leases",
+      "Bind release lockfile to version bump",
+      "Harden the stability control plane",
+      "Enable YouTube terminal sync soaks",
+      "Pinned Node when sourced by zsh resolved"
+    ],
+    "followUps": [
+      "Pin release publisher app bypass",
+      "Prepare v26.7.1301-dev",
+      "Reverse integrate main into dev"
+    ]
+  },
+  "releaseBody": "(AI Generated).\n\n## Freed v26.7.1400-dev\n\nAuthenticated essay capture, build next-generation Friends Galaxy, and dedicated release tag publisher\n\n### Features\n\n- Authenticated essay capture\n- Build next-generation Friends Galaxy\n- Dedicated release tag publisher\n\n### Fixes\n\n- Accept canonical tag ruleset responses\n- Allow exact current-task owner approvals\n- Include publisher dependencies in main backports\n- Simplify provider approval workflow\n- Stop automation actor keychain prompts\n- Automation actor handoff are now more stable\n- Omit webhook from release app manifest\n- Accept canonical heartbeat thread targets\n- Recognize historical promotion commits\n- Complete YouTube capture lifecycle\n- Bootstrap automation actor leases\n- Bind release lockfile to version bump\n- Harden the stability control plane\n- Enable YouTube terminal sync soaks\n- Pinned Node when sourced by zsh resolved\n\n### Follow-ups\n\n- Pin release publisher app bypass\n- Prepare v26.7.1301-dev\n- Reverse integrate main into dev\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+}

--- a/release-notes/releases/v26.7.1400-dev.md
+++ b/release-notes/releases/v26.7.1400-dev.md
@@ -2,37 +2,18 @@
 
 ## Freed v26.7.1400-dev
 
-Authenticated essay capture, build next-generation Friends Galaxy, and dedicated release tag publisher
+Friends is now a theme-aware personal galaxy with native touch and trackpad navigation, tight identity constellations, and cosmic provider nebulae.
 
 ### Features
 
-- Authenticated essay capture
-- Build next-generation Friends Galaxy
-- Dedicated release tag publisher
+- Explore Friends as a hardware-accelerated 3D galaxy where relationship importance controls depth, identities form tight constellations, and every starfield follows the active Freed theme
+- Pan, zoom, and focus the galaxy with a mouse, trackpad, or midpoint-preserving iPhone pinch gestures while billboard labels stay visible and close to their stars
+- Use the new Medium and Substack beta sources in Freed Desktop to capture essays, visible relationships, subscriptions, and activity through your signed-in sessions
 
 ### Fixes
 
-- Accept canonical tag ruleset responses
-- Allow exact current-task owner approvals
-- Include publisher dependencies in main backports
-- Simplify provider approval workflow
-- Stop automation actor keychain prompts
-- Automation actor handoff are now more stable
-- Omit webhook from release app manifest
-- Accept canonical heartbeat thread targets
-- Recognize historical promotion commits
-- Complete YouTube capture lifecycle
-- Bootstrap automation actor leases
-- Bind release lockfile to version bump
-- Harden the stability control plane
-- Enable YouTube terminal sync soaks
-- Pinned Node when sourced by zsh resolved
-
-### Follow-ups
-
-- Pin release publisher app bypass
-- Prepare v26.7.1301-dev
-- Reverse integrate main into dev
+- Provider regions now form spiral nebulae instead of flat ellipses, and identity links appear only for the hovered or selected constellation
+- YouTube followed-channel and subscription capture now reports bounded progress, cancels stale work, and closes hidden capture sessions when finished
 
 ### Downloads
 

--- a/release-notes/releases/v26.7.1400-dev.md
+++ b/release-notes/releases/v26.7.1400-dev.md
@@ -1,0 +1,43 @@
+(AI Generated).
+
+## Freed v26.7.1400-dev
+
+Authenticated essay capture, build next-generation Friends Galaxy, and dedicated release tag publisher
+
+### Features
+
+- Authenticated essay capture
+- Build next-generation Friends Galaxy
+- Dedicated release tag publisher
+
+### Fixes
+
+- Accept canonical tag ruleset responses
+- Allow exact current-task owner approvals
+- Include publisher dependencies in main backports
+- Simplify provider approval workflow
+- Stop automation actor keychain prompts
+- Automation actor handoff are now more stable
+- Omit webhook from release app manifest
+- Accept canonical heartbeat thread targets
+- Recognize historical promotion commits
+- Complete YouTube capture lifecycle
+- Bootstrap automation actor leases
+- Bind release lockfile to version bump
+- Harden the stability control plane
+- Enable YouTube terminal sync soaks
+- Pinned Node when sourced by zsh resolved
+
+### Follow-ups
+
+- Pin release publisher app bypass
+- Prepare v26.7.1301-dev
+- Reverse integrate main into dev
+
+### Downloads
+
+**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  
+**Windows:** `.exe` (NSIS installer)  
+**Linux:** `.AppImage`  
+
+> macOS downloads are signed and notarized for normal Gatekeeper installation.


### PR DESCRIPTION
(AI Generated).

## Summary
- Prepare the reviewed v26.7.1400-dev release from product commit 91e9e04071fa56db969e03b18d5f69d296e0ecab.
- Publish curated notes for the Friends Galaxy, Medium and Substack beta capture, and completed YouTube capture lifecycle.
- Bump Freed Desktop and PWA bundle versions to 26.7.1400.

## Testing
- npm run validate:feature
- 241 PWA tests passed
- 597 Freed Desktop tests passed with 1 todo
- 9 Freed Desktop smoke checks passed
- 148 Rust tests passed; cargo clippy passed with warnings only
- 21 release-note tests and release artifact validators passed