### PR TITLE
chore: prepare v26.7.1401-dev

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freed/desktop",
   "private": true,
-  "version": "26.7.1400",
+  "version": "26.7.1401",
   "type": "module",
   "scripts": {
     "dev": "node ../../node_modules/vite/bin/vite.js",

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -1420,7 +1420,7 @@ dependencies = [
 
 [[package]]
 name = "freed-desktop"
-version = "26.7.1400"
+version = "26.7.1401"
 dependencies = [
  "base64 0.22.1",
  "criterion",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freed-desktop"
-version = "26.7.1400"
+version = "26.7.1401"
 description = "Freed Desktop - Escape algorithmic manipulation"
 authors = ["Freed"]
 edition = "2021"

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Freed",
-  "version": "26.7.1400",
+  "version": "26.7.1401",
   "identifier": "wtf.freed.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freed/pwa",
   "private": true,
-  "version": "26.7.1400",
+  "version": "26.7.1401",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/release-notes/releases/v26.7.1401-dev.json
+++ b/release-notes/releases/v26.7.1401-dev.json
@@ -1,0 +1,91 @@
+{
+  "tag": "v26.7.1401-dev",
+  "version": "26.7.1401-dev",
+  "channel": "dev",
+  "dayKey": "26.7.14",
+  "approved": true,
+  "editorialNotes": [
+    "Reviewed 2026-07-14: retained the exact reviewed v26.7.1400-dev product copy because that immutable tag failed before any workflow job started. This replacement build changes only release metadata after the repository Actions allowlist was repaired."
+  ],
+  "generatedAt": "2026-07-14T22:51:22.000Z",
+  "model": "heuristic",
+  "source": {
+    "channel": "dev",
+    "previousPublishedTag": "v26.7.1200-dev",
+    "previousPublishedDayTag": "v26.7.1200-dev",
+    "compareRef": "HEAD",
+    "productCommitSha": "67af8b6a0c63bc5da9dd21a1cbb622be78d49d52",
+    "promotedDevCommitSha": null,
+    "isLatestOfDay": true,
+    "sameDayTagsIncluded": [
+      "v26.7.1401-dev"
+    ],
+    "relatedBuildTags": [
+      "v26.7.1401-dev"
+    ],
+    "prNumbers": [
+      642,
+      949,
+      953,
+      955,
+      957,
+      963,
+      964,
+      965,
+      966,
+      969,
+      970,
+      972,
+      973,
+      974,
+      975,
+      976,
+      977,
+      978,
+      979,
+      982,
+      983,
+      984
+    ],
+    "commitSubjects": [
+      "chore: prepare v26.7.1400-dev (#984)",
+      "fix: accept canonical tag ruleset responses (#983)",
+      "fix: allow exact current-task owner approvals (#982)",
+      "feat: build next-generation Friends Galaxy (#953)",
+      "fix: include publisher dependencies in main backports (#979)",
+      "chore: pin release publisher app bypass (#977)",
+      "fix: simplify provider approval workflow (#978)",
+      "feat: add authenticated essay capture (#642)",
+      "fix: stop automation actor keychain prompts (#976)",
+      "fix: stabilize automation actor handoff (#975)",
+      "fix: omit webhook from release app manifest (#974)",
+      "fix: accept canonical heartbeat thread targets (#973)",
+      "feat: add dedicated release tag publisher (#972)",
+      "fix: recognize historical promotion commits",
+      "chore: prepare v26.7.1301-dev (#970)",
+      "fix: complete YouTube capture lifecycle (#969)",
+      "fix: bootstrap automation actor leases (#965)",
+      "test: restore release channel build coverage (#967)",
+      "chore: reverse integrate main into dev (#966)",
+      "fix: bind release lockfile to version bump (#964)",
+      "chore: prepare v26.7.1300-dev (#963)",
+      "fix: harden the stability control plane (#949)",
+      "fix: enable YouTube terminal sync soaks (#955)",
+      "fix: resolve pinned Node when sourced by zsh (#957)"
+    ]
+  },
+  "release": {
+    "deck": "Friends is now a theme-aware personal galaxy with native touch and trackpad navigation, tight identity constellations, and cosmic provider nebulae",
+    "features": [
+      "Explore Friends as a hardware-accelerated 3D galaxy where relationship importance controls depth, identities form tight constellations, and every starfield follows the active Freed theme",
+      "Pan, zoom, and focus the galaxy with a mouse, trackpad, or midpoint-preserving iPhone pinch gestures while billboard labels stay visible and close to their stars",
+      "Use the new Medium and Substack beta sources in Freed Desktop to capture essays, visible relationships, subscriptions, and activity through your signed-in sessions"
+    ],
+    "fixes": [
+      "Provider regions now form spiral nebulae instead of flat ellipses, and identity links appear only for the hovered or selected constellation",
+      "YouTube followed-channel and subscription capture now reports bounded progress, cancels stale work, and closes hidden capture sessions when finished"
+    ],
+    "followUps": []
+  },
+  "releaseBody": "(AI Generated).\n\n## Freed v26.7.1401-dev\n\nFriends is now a theme-aware personal galaxy with native touch and trackpad navigation, tight identity constellations, and cosmic provider nebulae.\n\n### Features\n\n- Explore Friends as a hardware-accelerated 3D galaxy where relationship importance controls depth, identities form tight constellations, and every starfield follows the active Freed theme\n- Pan, zoom, and focus the galaxy with a mouse, trackpad, or midpoint-preserving iPhone pinch gestures while billboard labels stay visible and close to their stars\n- Use the new Medium and Substack beta sources in Freed Desktop to capture essays, visible relationships, subscriptions, and activity through your signed-in sessions\n\n### Fixes\n\n- Provider regions now form spiral nebulae instead of flat ellipses, and identity links appear only for the hovered or selected constellation\n- YouTube followed-channel and subscription capture now reports bounded progress, cancels stale work, and closes hidden capture sessions when finished\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+}

--- a/release-notes/releases/v26.7.1401-dev.json
+++ b/release-notes/releases/v26.7.1401-dev.json
@@ -5,16 +5,16 @@
   "dayKey": "26.7.14",
   "approved": true,
   "editorialNotes": [
-    "Reviewed 2026-07-14: retained the exact reviewed v26.7.1400-dev product copy because that immutable tag failed before any workflow job started. This replacement build changes only release metadata after the repository Actions allowlist was repaired."
+    "Reviewed 2026-07-14: retained the reviewed v26.7.1400-dev highlights because that immutable tag failed before any workflow job started. Rebound this replacement to the current dev product commit after private vulnerability reporting and release validation repairs merged, and after the repository Action policy was corrected."
   ],
-  "generatedAt": "2026-07-14T22:51:22.000Z",
+  "generatedAt": "2026-07-14T23:24:47.000Z",
   "model": "heuristic",
   "source": {
     "channel": "dev",
     "previousPublishedTag": "v26.7.1200-dev",
     "previousPublishedDayTag": "v26.7.1200-dev",
     "compareRef": "HEAD",
-    "productCommitSha": "67af8b6a0c63bc5da9dd21a1cbb622be78d49d52",
+    "productCommitSha": "41d35fd14a1d94122f4ed7b556d909b1cc2aea27",
     "promotedDevCommitSha": null,
     "isLatestOfDay": true,
     "sameDayTagsIncluded": [
@@ -24,6 +24,9 @@
       "v26.7.1401-dev"
     ],
     "prNumbers": [
+      1010,
+      1012,
+      968,
       642,
       949,
       953,
@@ -48,6 +51,9 @@
       984
     ],
     "commitSubjects": [
+      "fix: repair release validation contracts (#1010)",
+      "fix: align tooling fixtures with current policy (#1012)",
+      "feat: add private vulnerability reporting (#968)",
       "chore: prepare v26.7.1400-dev (#984)",
       "fix: accept canonical tag ruleset responses (#983)",
       "fix: allow exact current-task owner approvals (#982)",
@@ -83,9 +89,10 @@
     ],
     "fixes": [
       "Provider regions now form spiral nebulae instead of flat ellipses, and identity links appear only for the hovered or selected constellation",
-      "YouTube followed-channel and subscription capture now reports bounded progress, cancels stale work, and closes hidden capture sessions when finished"
+      "YouTube followed-channel and subscription capture now reports bounded progress, cancels stale work, and closes hidden capture sessions when finished",
+      "Security reports can now be submitted privately with redacted diagnostics and hardened fetched-content handling"
     ],
     "followUps": []
   },
-  "releaseBody": "(AI Generated).\n\n## Freed v26.7.1401-dev\n\nFriends is now a theme-aware personal galaxy with native touch and trackpad navigation, tight identity constellations, and cosmic provider nebulae.\n\n### Features\n\n- Explore Friends as a hardware-accelerated 3D galaxy where relationship importance controls depth, identities form tight constellations, and every starfield follows the active Freed theme\n- Pan, zoom, and focus the galaxy with a mouse, trackpad, or midpoint-preserving iPhone pinch gestures while billboard labels stay visible and close to their stars\n- Use the new Medium and Substack beta sources in Freed Desktop to capture essays, visible relationships, subscriptions, and activity through your signed-in sessions\n\n### Fixes\n\n- Provider regions now form spiral nebulae instead of flat ellipses, and identity links appear only for the hovered or selected constellation\n- YouTube followed-channel and subscription capture now reports bounded progress, cancels stale work, and closes hidden capture sessions when finished\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+  "releaseBody": "(AI Generated).\n\n## Freed v26.7.1401-dev\n\nFriends is now a theme-aware personal galaxy with native touch and trackpad navigation, tight identity constellations, and cosmic provider nebulae.\n\n### Features\n\n- Explore Friends as a hardware-accelerated 3D galaxy where relationship importance controls depth, identities form tight constellations, and every starfield follows the active Freed theme\n- Pan, zoom, and focus the galaxy with a mouse, trackpad, or midpoint-preserving iPhone pinch gestures while billboard labels stay visible and close to their stars\n- Use the new Medium and Substack beta sources in Freed Desktop to capture essays, visible relationships, subscriptions, and activity through your signed-in sessions\n\n### Fixes\n\n- Provider regions now form spiral nebulae instead of flat ellipses, and identity links appear only for the hovered or selected constellation\n- YouTube followed-channel and subscription capture now reports bounded progress, cancels stale work, and closes hidden capture sessions when finished\n- Security reports can now be submitted privately with redacted diagnostics and hardened fetched-content handling\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
 }

--- a/release-notes/releases/v26.7.1401-dev.md
+++ b/release-notes/releases/v26.7.1401-dev.md
@@ -14,6 +14,7 @@ Friends is now a theme-aware personal galaxy with native touch and trackpad navi
 
 - Provider regions now form spiral nebulae instead of flat ellipses, and identity links appear only for the hovered or selected constellation
 - YouTube followed-channel and subscription capture now reports bounded progress, cancels stale work, and closes hidden capture sessions when finished
+- Security reports can now be submitted privately with redacted diagnostics and hardened fetched-content handling
 
 ### Downloads
 

--- a/release-notes/releases/v26.7.1401-dev.md
+++ b/release-notes/releases/v26.7.1401-dev.md
@@ -1,0 +1,24 @@
+(AI Generated).
+
+## Freed v26.7.1401-dev
+
+Friends is now a theme-aware personal galaxy with native touch and trackpad navigation, tight identity constellations, and cosmic provider nebulae.
+
+### Features
+
+- Explore Friends as a hardware-accelerated 3D galaxy where relationship importance controls depth, identities form tight constellations, and every starfield follows the active Freed theme
+- Pan, zoom, and focus the galaxy with a mouse, trackpad, or midpoint-preserving iPhone pinch gestures while billboard labels stay visible and close to their stars
+- Use the new Medium and Substack beta sources in Freed Desktop to capture essays, visible relationships, subscriptions, and activity through your signed-in sessions
+
+### Fixes
+
+- Provider regions now form spiral nebulae instead of flat ellipses, and identity links appear only for the hovered or selected constellation
+- YouTube followed-channel and subscription capture now reports bounded progress, cancels stale work, and closes hidden capture sessions when finished
+
+### Downloads
+
+**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  
+**Windows:** `.exe` (NSIS installer)  
+**Linux:** `.AppImage`  
+
+> macOS downloads are signed and notarized for normal Gatekeeper installation.


### PR DESCRIPTION
(AI Generated).

## Summary
- Prepare the immutable replacement dev release v26.7.1401-dev after v26.7.1400-dev was rejected before any workflow job started.
- Advance Desktop, PWA, Tauri, Cargo package, and lockfile versions together while leaving the failed v26.7.1400-dev tag unchanged.
- Bind the release receipt to exact dev product commit 41d35fd14a1d94122f4ed7b556d909b1cc2aea27, including the merged release validation repairs.
- Use the corrected repository Actions allowlist with immutable SHAs for the Rust toolchain, Rust cache, and Tauri release actions.

## Testing
- node scripts/doctor.mjs --strict
- node scripts/validate-release-identity.mjs --tag=v26.7.1401-dev --head-ref=HEAD
- node scripts/validate-release-notes.mjs release-notes/releases/v26.7.1401-dev.json
- npm run test:unit -- src/lib/identity-graph-v2.test.ts, 16 passed
- Fresh exact-head GitHub validation required before merge