### PR TITLE
fix: repair release validation contracts

### DIFF
--- a/scripts/nightly-self-improve.test.mjs
+++ b/scripts/nightly-self-improve.test.mjs
@@ -90,7 +90,7 @@ function outcomeAuthentication(stateRoot, actor, nowMs) {
       token,
       actorCredentialToken: actorCredential(stateRoot, actor),
       nowMs: nowMs - 1_000,
-      ttlMs: 60 * 60 * 1_000,
+      ttlMs: policy.maxLeaseLifetimeMs,
     });
     ACTOR_LEASES.set(key, token);
   }

--- a/scripts/record-outcome.test.mjs
+++ b/scripts/record-outcome.test.mjs
@@ -51,7 +51,7 @@ function acquireActorLease(stateRoot, actor) {
     owner: actor,
     token,
     actorCredentialToken,
-    ttlMs: 60 * 60 * 1_000,
+    ttlMs: policy.maxLeaseLifetimeMs,
   });
   return { actor, leaseName: policy.leaseName, leaseToken: token };
 }

--- a/scripts/release-promotion-shared.mjs
+++ b/scripts/release-promotion-shared.mjs
@@ -38,6 +38,8 @@ export const PROMOTION_BRANCH_PATTERN =
 export const RELEASE_PREP_BRANCH_PATTERN = /^chore\/release-[a-z0-9._-]+$/;
 export const PROMOTION_COMMIT_SUBJECT_PATTERN =
   /^chore: promote dev (?:into|to) main(?: for production release)?(?: \(#\d+\))?$/;
+const DEV_BACKPORT_COMMIT_SUBJECT_PATTERN =
+  /^(?:chore|fix): backport .+(?: \(#\d+\))?$/;
 export const REVERSE_INTEGRATION_COMMIT_SUBJECT_PATTERN =
   /^(?:chore|fix): (?:merge main (?:back )?into dev(?: .*)?|reverse integrate (?:main|v\d+\.\d+\.\d+)(?: into dev| after v\d+\.\d+\.\d+| production release)?|backflow v\d+\.\d+\.\d+ main into dev|sync main(?: release artifacts)?(?: back)? into dev(?: .*)?)(?: \(#\d+\))?$/;
 
@@ -279,7 +281,8 @@ export function listMainBackflowDiffFiles({ devRef, mainRef, cwd }) {
       if (
         mainBlobId &&
         mainChange &&
-        PROMOTION_COMMIT_SUBJECT_PATTERN.test(mainChange.subject) &&
+        (PROMOTION_COMMIT_SUBJECT_PATTERN.test(mainChange.subject) ||
+          DEV_BACKPORT_COMMIT_SUBJECT_PATTERN.test(mainChange.subject)) &&
         blobExistsInHistory(devRef, filePath, mainBlobId, { cwd })
       ) {
         return false;

--- a/scripts/release-promotion.test.mjs
+++ b/scripts/release-promotion.test.mjs
@@ -585,6 +585,67 @@ test("validate-main-backflow rejects a main rollback to an older dev blob", (t) 
   assert.match(result.stderr, /packages\/pwa\/src\/app\.ts/);
 });
 
+test("validate-main-backflow accepts a dev-origin backport after dev advances", (t) => {
+  const cwd = makeTempRepo();
+  t.after(() => rmSync(cwd, { recursive: true, force: true }));
+
+  git(cwd, ["checkout", "dev"]);
+  writeRepoFile(
+    cwd,
+    "packages/pwa/src/app.ts",
+    "export const value = 'backported';\n",
+  );
+  commitAll(cwd, "fix: simplify shared behavior");
+  updateOriginRef(cwd, "dev");
+
+  git(cwd, ["checkout", "main"]);
+  git(cwd, ["checkout", "dev", "--", "packages/pwa/src/app.ts"]);
+  commitAll(cwd, "fix: backport simplified shared behavior (#980)");
+  updateOriginRef(cwd, "main");
+
+  git(cwd, ["checkout", "dev"]);
+  writeRepoFile(
+    cwd,
+    "packages/pwa/src/app.ts",
+    "export const value = 'newer dev state';\n",
+  );
+  commitAll(cwd, "feat: advance shared behavior");
+  updateOriginRef(cwd, "dev");
+
+  const result = runNode(VALIDATE_MAIN_BACKFLOW, [
+    `--cwd=${cwd}`,
+    "--dev-ref=origin/dev",
+    "--main-ref=origin/main",
+  ]);
+
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /Main backflow is in sync/);
+});
+
+test("validate-main-backflow rejects a main-only change named as a backport", (t) => {
+  const cwd = makeTempRepo();
+  t.after(() => rmSync(cwd, { recursive: true, force: true }));
+
+  git(cwd, ["checkout", "main"]);
+  writeRepoFile(
+    cwd,
+    "packages/pwa/src/app.ts",
+    "export const value = 'main only';\n",
+  );
+  commitAll(cwd, "fix: backport unverified behavior (#981)");
+  updateOriginRef(cwd, "main");
+
+  const result = runNode(VALIDATE_MAIN_BACKFLOW, [
+    `--cwd=${cwd}`,
+    "--dev-ref=origin/dev",
+    "--main-ref=origin/main",
+  ]);
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Dev refresh needed/);
+  assert.match(result.stderr, /packages\/pwa\/src\/app\.ts/);
+});
+
 test("validate-main-backflow accepts a reverse-integrated main hotfix after dev advances", (t) => {
   const cwd = makeTempRepo();
   t.after(() => rmSync(cwd, { recursive: true, force: true }));

--- a/scripts/validate-worktree.test.mjs
+++ b/scripts/validate-worktree.test.mjs
@@ -430,7 +430,11 @@ test("feature plan for capture-only changes runs the touched workspace check", (
     buildValidationPlan("feature", ["packages/capture-rss/src/index.ts"]),
   );
 
-  assert.deepEqual(labels, ["root typecheck", "packages/capture-rss build"]);
+  assert.deepEqual(labels, [
+    "root typecheck",
+    "packages/capture-rss tests",
+    "packages/capture-rss build",
+  ]);
 });
 
 test("feature plan for release tooling changes runs script tests and artifact validation", () => {


### PR DESCRIPTION
(AI Generated).

## Summary
- Recognize main backports only when their exact blobs already exist in dev history.
- Align automation lease fixtures and capture RSS validation expectations with current policy.

## Testing
- node --test scripts/nightly-self-improve.test.mjs scripts/record-outcome.test.mjs scripts/validate-worktree.test.mjs scripts/release-promotion.test.mjs, 121 passed
- npm run test:scripts, 573 passed
- npm run validate:feature