### PR TITLE
fix: recognize reviewed main backport history

### DIFF
--- a/scripts/release-promotion-shared.mjs
+++ b/scripts/release-promotion-shared.mjs
@@ -38,6 +38,9 @@ export const PROMOTION_BRANCH_PATTERN =
 export const RELEASE_PREP_BRANCH_PATTERN = /^chore\/release-[a-z0-9._-]+$/;
 export const PROMOTION_COMMIT_SUBJECT_PATTERN =
   /^chore: promote dev (?:into|to) main(?: for production release)?(?: \(#\d+\))?$/;
+const HISTORICAL_MAIN_BACKPORT_SUBJECTS = new Set([
+  "fix: backport simplified provider approval (#980)",
+]);
 export const REVERSE_INTEGRATION_COMMIT_SUBJECT_PATTERN =
   /^(?:chore|fix): (?:merge main (?:back )?into dev(?: .*)?|reverse integrate (?:main|v\d+\.\d+\.\d+)(?: into dev| after v\d+\.\d+\.\d+| production release)?|backflow v\d+\.\d+\.\d+ main into dev|sync main(?: release artifacts)?(?: back)? into dev(?: .*)?)(?: \(#\d+\))?$/;
 
@@ -279,7 +282,8 @@ export function listMainBackflowDiffFiles({ devRef, mainRef, cwd }) {
       if (
         mainBlobId &&
         mainChange &&
-        PROMOTION_COMMIT_SUBJECT_PATTERN.test(mainChange.subject) &&
+        (PROMOTION_COMMIT_SUBJECT_PATTERN.test(mainChange.subject) ||
+          HISTORICAL_MAIN_BACKPORT_SUBJECTS.has(mainChange.subject)) &&
         blobExistsInHistory(devRef, filePath, mainBlobId, { cwd })
       ) {
         return false;

--- a/scripts/release-promotion.test.mjs
+++ b/scripts/release-promotion.test.mjs
@@ -271,6 +271,103 @@ test("validate-main-backflow accepts the historical promote dev to main subject"
   assert.match(result.stdout, /Main backflow is in sync/);
 });
 
+test("validate-main-backflow accepts a reviewed main backport already in dev history", (t) => {
+  const cwd = makeTempRepo();
+  t.after(() => rmSync(cwd, { recursive: true, force: true }));
+
+  git(cwd, ["checkout", "dev"]);
+  writeRepoFile(
+    cwd,
+    "packages/pwa/src/app.ts",
+    "export const value = 'backported';\n",
+  );
+  commitAll(cwd, "fix: original dev repair");
+  updateOriginRef(cwd, "dev");
+
+  git(cwd, ["checkout", "main"]);
+  git(cwd, ["checkout", "dev", "--", "packages/pwa/src/app.ts"]);
+  commitAll(cwd, "fix: backport simplified provider approval (#980)");
+  updateOriginRef(cwd, "main");
+
+  git(cwd, ["checkout", "dev"]);
+  writeRepoFile(
+    cwd,
+    "packages/pwa/src/app.ts",
+    "export const value = 'next dev change';\n",
+  );
+  commitAll(cwd, "feat: advance dev state");
+  updateOriginRef(cwd, "dev");
+
+  const result = runNode(VALIDATE_MAIN_BACKFLOW, [
+    `--cwd=${cwd}`,
+    "--dev-ref=origin/dev",
+    "--main-ref=origin/main",
+  ]);
+
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /Main backflow is in sync/);
+});
+
+test("validate-main-backflow rejects a main backport absent from dev history", (t) => {
+  const cwd = makeTempRepo();
+  t.after(() => rmSync(cwd, { recursive: true, force: true }));
+
+  git(cwd, ["checkout", "main"]);
+  writeRepoFile(
+    cwd,
+    "packages/pwa/src/app.ts",
+    "export const value = 'main-only backport';\n",
+  );
+  commitAll(cwd, "fix: backport simplified provider approval (#980)");
+  updateOriginRef(cwd, "main");
+
+  const result = runNode(VALIDATE_MAIN_BACKFLOW, [
+    `--cwd=${cwd}`,
+    "--dev-ref=origin/dev",
+    "--main-ref=origin/main",
+  ]);
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Dev refresh needed/);
+  assert.match(result.stderr, /packages\/pwa\/src\/app\.ts/);
+});
+
+test("validate-main-backflow rejects an unapproved backport to an older dev blob", (t) => {
+  const cwd = makeTempRepo();
+  t.after(() => rmSync(cwd, { recursive: true, force: true }));
+
+  git(cwd, ["checkout", "dev"]);
+  writeRepoFile(
+    cwd,
+    "packages/pwa/src/app.ts",
+    "export const value = 'older dev state';\n",
+  );
+  commitAll(cwd, "feat: older dev state");
+  const olderDevCommit = git(cwd, ["rev-parse", "HEAD"]);
+  writeRepoFile(
+    cwd,
+    "packages/pwa/src/app.ts",
+    "export const value = 'current dev state';\n",
+  );
+  commitAll(cwd, "feat: current dev state");
+  updateOriginRef(cwd, "dev");
+
+  git(cwd, ["checkout", "main"]);
+  git(cwd, ["checkout", olderDevCommit, "--", "packages/pwa/src/app.ts"]);
+  commitAll(cwd, "fix: backport older app state (#981)");
+  updateOriginRef(cwd, "main");
+
+  const result = runNode(VALIDATE_MAIN_BACKFLOW, [
+    `--cwd=${cwd}`,
+    "--dev-ref=origin/dev",
+    "--main-ref=origin/main",
+  ]);
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Dev refresh needed/);
+  assert.match(result.stderr, /packages\/pwa\/src\/app\.ts/);
+});
+
 test("validate-main-backflow fails when main has product content absent from dev", (t) => {
   const cwd = makeTempRepo();
   t.after(() => rmSync(cwd, { recursive: true, force: true }));


### PR DESCRIPTION
(AI Generated).

## Summary
- Accept only the exact reviewed PR 980 backport when every main blob already exists in dev history.
- Keep newer dev state intact and preserve rollback rejection for any other backport subject.

## Testing
- node --test scripts/release-promotion.test.mjs (30 passed)
- npm run validate:feature
- node scripts/validate-main-backflow.mjs --dev-ref=origin/dev --main-ref=origin/main