### PR TITLE
fix: align tooling fixtures with current policy

### DIFF
--- a/scripts/nightly-self-improve.test.mjs
+++ b/scripts/nightly-self-improve.test.mjs
@@ -90,7 +90,7 @@ function outcomeAuthentication(stateRoot, actor, nowMs) {
       token,
       actorCredentialToken: actorCredential(stateRoot, actor),
       nowMs: nowMs - 1_000,
-      ttlMs: 60 * 60 * 1_000,
+      ttlMs: policy.maxLeaseLifetimeMs,
     });
     ACTOR_LEASES.set(key, token);
   }

--- a/scripts/record-outcome.test.mjs
+++ b/scripts/record-outcome.test.mjs
@@ -51,7 +51,7 @@ function acquireActorLease(stateRoot, actor) {
     owner: actor,
     token,
     actorCredentialToken,
-    ttlMs: 60 * 60 * 1_000,
+    ttlMs: policy.maxLeaseLifetimeMs,
   });
   return { actor, leaseName: policy.leaseName, leaseToken: token };
 }

--- a/scripts/validate-worktree.test.mjs
+++ b/scripts/validate-worktree.test.mjs
@@ -425,12 +425,16 @@ test("release mode remains a compatibility alias for production", () => {
   );
 });
 
-test("feature plan for capture-only changes runs the touched workspace check", () => {
+test("feature plan for capture-only changes runs the touched workspace checks", () => {
   const labels = describePlan(
     buildValidationPlan("feature", ["packages/capture-rss/src/index.ts"]),
   );
 
-  assert.deepEqual(labels, ["root typecheck", "packages/capture-rss build"]);
+  assert.deepEqual(labels, [
+    "root typecheck",
+    "packages/capture-rss tests",
+    "packages/capture-rss build",
+  ]);
 });
 
 test("feature plan for release tooling changes runs script tests and artifact validation", () => {


### PR DESCRIPTION
(AI Generated).

## Summary
- Use the actor policy lease cap in nightly and outcome test helpers without changing production policy.
- Expect capture-rss tests before its build now that the workspace exposes a test script.

## Testing
- node --test scripts/nightly-self-improve.test.mjs scripts/record-outcome.test.mjs scripts/validate-worktree.test.mjs (92 passed)
- node scripts/validate-worktree.mjs --mode feature --plan-labels --changed-files packages/capture-rss/src/index.ts
- npm run test:scripts (571 passed)
- npm run validate:feature