### PR TITLE
fix: unblock dev release validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
           PLAN_LABELS="$(npm run --silent validate:feature -- --plan-labels)"
           echo "Feature validation plan:"
           printf '%s\n' "$PLAN_LABELS"
-          if printf '%s\n' "$PLAN_LABELS" | grep -q '^desktop e2e '; then
+          if printf '%s\n' "$PLAN_LABELS" | grep -q '^desktop .*e2e'; then
             echo "needs_playwright=true" >> "$GITHUB_OUTPUT"
           else
             echo "needs_playwright=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -620,6 +620,7 @@ jobs:
       - name: Open or update the automation-triage issue
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
         run: |
           title="Release pipeline failure: ${GITHUB_REF_NAME}"
           body="(AI Generated).

--- a/packages/pwa/api/fetch-url.ts
+++ b/packages/pwa/api/fetch-url.ts
@@ -11,6 +11,18 @@ interface ResolvedAddress {
   family: number;
 }
 
+interface ServerlessRequest {
+  method?: string;
+  headers?: Record<string, string | string[] | undefined>;
+  body?: unknown;
+}
+
+interface TextServerlessResponse {
+  setHeader(name: string, value: string): void;
+  status(code: number): TextServerlessResponse;
+  send(body: string): void;
+}
+
 type ResolveHost = (hostname: string) => Promise<ResolvedAddress[]>;
 
 function allowedOrigin(origin: string): boolean {
@@ -167,7 +179,10 @@ export async function fetchPublicHtml(
   throw new Error("Too many article redirects.");
 }
 
-export default async function handler(req: any, res: any): Promise<void> {
+export default async function handler(
+  req: ServerlessRequest,
+  res: TextServerlessResponse,
+): Promise<void> {
   if (req.method !== "POST") {
     res.status(405).send("Method Not Allowed");
     return;

--- a/packages/pwa/api/security-report.ts
+++ b/packages/pwa/api/security-report.ts
@@ -30,6 +30,19 @@ interface RateLimitEntry {
   resetAt: number;
 }
 
+interface ServerlessRequest {
+  method?: string;
+  headers?: Record<string, string | string[] | undefined>;
+  body?: unknown;
+}
+
+interface JsonServerlessResponse {
+  setHeader(name: string, value: string): void;
+  status(code: number): JsonServerlessResponse;
+  json(body: unknown): void;
+  end(): void;
+}
+
 let cachedInstallationToken: InstallationToken | null = null;
 const rateLimits = new Map<string, RateLimitEntry>();
 
@@ -289,7 +302,10 @@ function setResponseHeaders(
   }
 }
 
-export default async function handler(req: any, res: any) {
+export default async function handler(
+  req: ServerlessRequest,
+  res: JsonServerlessResponse,
+): Promise<void> {
   const origin = requestOrigin(req);
   setResponseHeaders(res, origin);
   if (req.method === "OPTIONS") {

--- a/scripts/release-governance.test.mjs
+++ b/scripts/release-governance.test.mjs
@@ -109,6 +109,18 @@ test("release publication delegates one exact tag to the trusted App publisher",
   );
 });
 
+test("release failure triage binds GitHub CLI to the triggering repository", () => {
+  const triageJobStart = releaseWorkflow.indexOf("\n  triage-on-failure:");
+  assert.ok(triageJobStart >= 0, "release workflow should define failure triage");
+  const triageJob = releaseWorkflow.slice(triageJobStart);
+
+  assert.match(triageJob, /GH_REPO:\s*\$\{\{ github\.repository \}\}/);
+  assert.match(triageJob, /gh issue list/);
+  assert.match(triageJob, /gh issue comment/);
+  assert.match(triageJob, /gh issue create/);
+  assert.doesNotMatch(triageJob, /uses:\s*actions\/checkout/);
+});
+
 test("release preparation validates canonical CalVer before mutating version files", () => {
   const validationIndex = releasePrep.indexOf("scripts/release-version.mjs");
   const firstMutationIndex = releasePrep.indexOf(

--- a/scripts/release-governance.test.mjs
+++ b/scripts/release-governance.test.mjs
@@ -30,6 +30,10 @@ const releaseWorkflow = readFileSync(
   path.join(scriptsDir, "..", ".github", "workflows", "release.yml"),
   "utf8",
 );
+const ciWorkflow = readFileSync(
+  path.join(scriptsDir, "..", ".github", "workflows", "ci.yml"),
+  "utf8",
+);
 
 test("release preparation uses the channel's protected branch as its exact base", () => {
   assert.match(releasePrep, /CHANNEL="production"/);
@@ -119,6 +123,11 @@ test("release failure triage binds GitHub CLI to the triggering repository", () 
   assert.match(triageJob, /gh issue comment/);
   assert.match(triageJob, /gh issue create/);
   assert.doesNotMatch(triageJob, /uses:\s*actions\/checkout/);
+});
+
+test("feature validation installs Playwright for every desktop e2e plan", () => {
+  assert.match(ciWorkflow, /grep -q '\^desktop \.\*e2e'/);
+  assert.doesNotMatch(ciWorkflow, /grep -q '\^desktop e2e '/);
 });
 
 test("release preparation validates canonical CalVer before mutating version files", () => {


### PR DESCRIPTION
(AI Generated).

## Summary
- Replace untyped PWA API handler arguments with narrow serverless request and response contracts.
- Bind release failure triage to the triggering repository.
- Install Chromium whenever any desktop e2e validation plan is selected.

## Testing
- 31 focused PWA API tests passed.
- 576 script tests passed.
- Local feature validation passed, including 22 browser workflows and 273 PWA unit tests.

## Provider Review
- Status: Draft publication is allowed. Ready and merge require provider authority.
- Review action: A provider CODEOWNER reacts with a GitHub thumbs-up on the generated provider review comment.
- Provider subdiff: `a7dba237c16a61e2368661f2341f468792197de9`
- Draft publication does not authorize new live provider traffic. Gate 1 behavior approval still applies.

Files bound into this provider review:
- `packages/pwa/api/fetch-url.ts`
- `packages/pwa/api/security-report.ts`