### PR TITLE
fix: avoid duplicate pinned release highlights

### DIFF
--- a/scripts/release-notes-shared.mjs
+++ b/scripts/release-notes-shared.mjs
@@ -201,6 +201,7 @@ export function applyPinnedHighlightsToRelease(rawRelease = {}, pinnedHighlights
       ...release.followUps,
     ].filter(Boolean);
     if (
+      areNearDuplicates(release.deck, pinnedText) ||
       visibleItems.some(
         (item) =>
           normalizeReleaseText(item).toLowerCase() ===

--- a/scripts/release-notes-shared.test.mjs
+++ b/scripts/release-notes-shared.test.mjs
@@ -350,6 +350,25 @@ test("applyPinnedHighlightsToRelease keeps missing pinned items visible", () => 
   );
 });
 
+test("applyPinnedHighlightsToRelease treats a matching deck theme as visible", () => {
+  const release = applyPinnedHighlightsToRelease(
+    {
+      deck: "Friends is now a theme-aware personal galaxy with native touch and trackpad navigation, tight identity constellations, and cosmic provider nebulae",
+      features: [
+        "Explore Friends as a hardware-accelerated 3D galaxy where relationship importance controls depth",
+      ],
+      fixes: ["Release validation now installs every required browser"],
+      followUps: [],
+    },
+    ["Friends Galaxy"],
+  );
+
+  assert.deepEqual(release.fixes, [
+    "Release validation now installs every required browser",
+  ]);
+  assert.deepEqual(validateReleaseShape(release).errors, []);
+});
+
 test("validateReleaseShape allows previous-day theme overlap in the deck", () => {
   const result = validateReleaseShape(
     {


### PR DESCRIPTION
(AI Generated).

## Summary
- Treat a pinned highlight as visible when the release deck already covers it as a near duplicate.
- Prevent release preparation from inserting a deck theme into fixes and rejecting its own generated notes.

## Testing
- 22 release-note shared tests passed
- npm run validate:feature