### PR TITLE
fix: stabilize Friends selection atlas updates

### DIFF
--- a/packages/desktop/tests/e2e/smoke.spec.ts
+++ b/packages/desktop/tests/e2e/smoke.spec.ts
@@ -601,7 +601,7 @@ async function seedStressIdentityGraph(page: Page) {
     };
 
     const now = Date.now();
-    const personCount = 360;
+    const personCount = 1_200;
     const accountCount = 1_440;
     const feedCount = 80;
     const friendCutoff = Math.round(personCount * 0.82);
@@ -3941,6 +3941,123 @@ test("Friends detail rail resize caps at 400 pixels", async ({ app, page }) => {
   }, { timeout: 5_000 });
 });
 
+test("selection while the initial Friends atlas is pending retains the semantic scene", async ({ app, page }) => {
+  await page.addInitScript(() => {
+    const OriginalWorker = window.Worker;
+    const control: {
+      held: boolean;
+      released: boolean;
+      release: (() => void) | null;
+      outbound: unknown[];
+    } = {
+      held: false,
+      released: false,
+      release: null,
+      outbound: [],
+    };
+
+    class DelayedIdentityGalaxyWorker extends OriginalWorker {
+      private readonly identityGalaxyWorker: boolean;
+      private readonly heldMessages: unknown[] = [];
+
+      constructor(scriptURL: string | URL, options?: WorkerOptions) {
+        super(scriptURL, options);
+        this.identityGalaxyWorker = String(scriptURL).includes("identity-graph-atlas.worker");
+        if (!this.identityGalaxyWorker) return;
+        this.addEventListener("message", (event) => {
+          if (control.released) return;
+          event.stopImmediatePropagation();
+          this.heldMessages.push(event.data);
+          control.held = true;
+          control.release = () => {
+            if (control.released) return;
+            control.released = true;
+            for (const data of this.heldMessages.splice(0)) {
+              this.dispatchEvent(new MessageEvent("message", { data }));
+            }
+          };
+        });
+      }
+
+      override postMessage(
+        message: unknown,
+        transferOrOptions?: Transferable[] | StructuredSerializeOptions,
+      ): void {
+        if (this.identityGalaxyWorker) control.outbound.push(message);
+        if (transferOrOptions === undefined) {
+          OriginalWorker.prototype.postMessage.call(this, message);
+        } else {
+          OriginalWorker.prototype.postMessage.call(this, message, transferOrOptions);
+        }
+      }
+    }
+
+    Object.defineProperty(window, "Worker", {
+      configurable: true,
+      writable: true,
+      value: DelayedIdentityGalaxyWorker,
+    });
+    (window as typeof window & {
+      __FREED_GALAXY_WORKER_HOLD__?: typeof control;
+    }).__FREED_GALAXY_WORKER_HOLD__ = control;
+  });
+
+  await app.goto();
+  await app.waitForReady();
+  await app.seedFriendLocation();
+  await dismissCloudSyncNudgeIfPresent(page);
+  await page.evaluate(async () => {
+    const store = (window as Record<string, unknown>).__FREED_STORE__ as {
+      getState: () => {
+        updatePreferences: (patch: { display: { friendsMode: "friends"; friendsSidebarOpen: boolean } }) => Promise<void>;
+        setActiveView: (view: string) => void;
+        setSelectedPerson: (personId: string | null) => void;
+      };
+    };
+    await store.getState().updatePreferences({
+      display: {
+        friendsMode: "friends",
+        friendsSidebarOpen: false,
+      },
+    });
+    store.getState().setSelectedPerson(null);
+    store.getState().setActiveView("friends");
+  });
+
+  await expect(page.getByTestId("friend-graph-viewport")).toBeVisible({ timeout: 10_000 });
+  await page.waitForFunction(() => {
+    return (window as typeof window & {
+      __FREED_GALAXY_WORKER_HOLD__?: { held: boolean };
+    }).__FREED_GALAXY_WORKER_HOLD__?.held === true;
+  }, { timeout: 10_000 });
+  await page.evaluate(() => {
+    const store = (window as Record<string, unknown>).__FREED_STORE__ as {
+      getState: () => { setSelectedPerson: (personId: string | null) => void };
+    };
+    store.getState().setSelectedPerson("friend-ada");
+    const control = (window as typeof window & {
+      __FREED_GALAXY_WORKER_HOLD__?: { release: (() => void) | null };
+    }).__FREED_GALAXY_WORKER_HOLD__;
+    control?.release?.();
+  });
+
+  await expect(page.getByTestId("friends-collapsed-selection-card")).toContainText(
+    "Ada Lovelace",
+    { timeout: 10_000 },
+  );
+  await expect
+    .poll(async () => {
+      const debug = await readGraphDebug(page);
+      return debug?.nodes.some((node) => node.personId === "friend-ada") ?? false;
+    }, { timeout: 10_000 })
+    .toBe(true);
+  const drawError = await page.evaluate(() => {
+    return (window as typeof window & { __FREED_GRAPH_DRAW_ERROR__?: string })
+      .__FREED_GRAPH_DRAW_ERROR__ ?? null;
+  });
+  expect(drawError).toBeNull();
+});
+
 test("selected Friends graph person shows a compact detail card when the detail rail is closed", async ({ app, page }) => {
   await page.setViewportSize({ width: 1440, height: 900 });
   await app.goto();
@@ -3995,11 +4112,13 @@ test("selected Friends graph person shows a compact detail card when the detail 
   const compactCard = page.getByTestId("friends-collapsed-selection-card");
   await expect(compactCard).toBeVisible({ timeout: 5_000 });
   await expect(compactCard).toContainText("Ada Lovelace");
-  const afterSelection = await readGraphSummary(page);
+  await waitForGraphSceneSyncAfter(page, beforeSelection!.metrics.sceneSyncCount);
+  const afterSelection = await waitForGraphPerfToSettle(page);
   expect(afterSelection).not.toBeNull();
   expect(afterSelection!.transform.x).toBeCloseTo(beforeSelection!.transform.x, 1);
   expect(afterSelection!.transform.y).toBeCloseTo(beforeSelection!.transform.y, 1);
   expect(afterSelection!.transform.scale).toBeCloseTo(beforeSelection!.transform.scale, 3);
+  expect(afterSelection!.metrics.sceneSyncCount).toBe(beforeSelection!.metrics.sceneSyncCount + 1);
   expect(afterSelection!.metrics.edgeRebuildCount).toBeLessThanOrEqual(beforeSelection!.metrics.edgeRebuildCount + 2);
   expect(afterSelection!.metrics.nodeRestyleCount).toBeLessThanOrEqual(beforeSelection!.metrics.nodeRestyleCount + 2);
   await page.waitForFunction(() => {
@@ -5345,7 +5464,106 @@ test("stress Friends graph keeps labels resident and avoids scene rebuilds durin
   expect(initial!.metrics.layoutMs).toBeLessThan(1_000);
   expect(initial!.metrics.sceneSyncMs).toBeLessThan(250);
 
-  const benchmarkPoint = await graphNodeScreenPoint(page, { personId: "stress-person-0" });
+  const outOfSliceSelection = await page.evaluate(() => {
+    const debug = (window as typeof window & {
+      __FREED_GRAPH_DEBUG__?: {
+        nodes: Array<{ personId?: string; accountId?: string }>;
+      };
+    }).__FREED_GRAPH_DEBUG__;
+    const visiblePersonIds = new Set(
+      debug?.nodes.flatMap((node) => node.personId ? [node.personId] : []) ?? [],
+    );
+    const visibleAccountIds = new Set(
+      debug?.nodes.flatMap((node) => node.accountId ? [node.accountId] : []) ?? [],
+    );
+    let personId: string | null = null;
+    for (let index = 1_199; index >= 0; index -= 1) {
+      const candidate = `stress-person-${index}`;
+      if (!visiblePersonIds.has(candidate)) {
+        personId = candidate;
+        break;
+      }
+    }
+    let accountId: string | null = null;
+    for (let index = 1_439; index >= 0; index -= 1) {
+      const candidate = `stress-account-${index}`;
+      if (!visibleAccountIds.has(candidate)) {
+        accountId = candidate;
+        break;
+      }
+    }
+    return { personId, accountId };
+  });
+  if (!outOfSliceSelection.personId || !outOfSliceSelection.accountId) {
+    throw new Error("Dense Friends fixture did not produce out-of-slice identities");
+  }
+  const selectExternalIdentity = async (selection: {
+    personId: string | null;
+    accountId: string | null;
+  }) => {
+    const beforeSelection = await readGraphDebug(page);
+    expect(beforeSelection).not.toBeNull();
+    await page.evaluate((nextSelection) => {
+      const store = (window as Record<string, unknown>).__FREED_STORE__ as {
+        getState: () => {
+          setSelectedPerson: (selectedPersonId: string | null) => void;
+          setSelectedAccount: (selectedAccountId: string | null) => void;
+        };
+      };
+      if (nextSelection.personId) {
+        store.getState().setSelectedPerson(nextSelection.personId);
+      } else if (nextSelection.accountId) {
+        store.getState().setSelectedAccount(nextSelection.accountId);
+      } else {
+        store.getState().setSelectedPerson(null);
+      }
+    }, selection);
+    if (selection.personId || selection.accountId) {
+      await expect
+        .poll(async () => {
+          const debug = await readGraphDebug(page);
+          return debug?.nodes.some((node) =>
+            node.personId === selection.personId || node.accountId === selection.accountId
+          ) ?? false;
+        }, { timeout: 10_000 })
+        .toBe(true);
+    }
+    await waitForGraphSceneSyncAfter(page, beforeSelection!.metrics.sceneSyncCount);
+    const afterSelection = await waitForGraphPerfToSettle(page);
+    expect(afterSelection!.metrics.sceneSyncCount).toBe(
+      beforeSelection!.metrics.sceneSyncCount + 1,
+    );
+  };
+  await selectExternalIdentity({
+    personId: outOfSliceSelection.personId,
+    accountId: null,
+  });
+  await selectExternalIdentity({
+    personId: null,
+    accountId: outOfSliceSelection.accountId,
+  });
+  await selectExternalIdentity({ personId: null, accountId: null });
+  await page.waitForFunction(() => {
+    const store = (window as Record<string, unknown>).__FREED_STORE__ as {
+      getState: () => {
+        selectedPersonId: string | null;
+        selectedAccountId: string | null;
+      };
+    };
+    const state = store.getState();
+    return state.selectedPersonId === null && state.selectedAccountId === null;
+  });
+
+  const benchmarkPersonId = await page.evaluate(() => {
+    const debug = (window as typeof window & {
+      __FREED_GRAPH_DEBUG__?: {
+        nodes: Array<{ personId?: string }>;
+      };
+    }).__FREED_GRAPH_DEBUG__;
+    return debug?.nodes.find((node) => node.personId)?.personId ?? null;
+  });
+  expect(benchmarkPersonId).not.toBeNull();
+  const benchmarkPoint = await graphNodeScreenPoint(page, { personId: benchmarkPersonId! });
   expect(benchmarkPoint).not.toBeNull();
 
   await page.mouse.move(benchmarkPoint!.x, benchmarkPoint!.y);

--- a/packages/ui/src/components/friends/FriendGraph.tsx
+++ b/packages/ui/src/components/friends/FriendGraph.tsx
@@ -45,7 +45,13 @@ import {
 import { viewportPointToIdentityGalaxyPlane } from "../../lib/identity-galaxy-camera.js";
 import type {
   IdentityGalaxyWorkerResponse,
+  IdentityGalaxyWorkerSelection,
   IdentityGalaxyWorkerViewportInput,
+} from "../../lib/identity-galaxy-worker-protocol.js";
+import {
+  identityGalaxyWorkerResponseDisposition,
+  identityGalaxyWorkerSelectionsMatch,
+  shouldRequestIdentityGalaxyWorkerSelection,
 } from "../../lib/identity-galaxy-worker-protocol.js";
 import {
   FRIEND_GRAPH_DEFAULT_TRANSFORM,
@@ -194,6 +200,7 @@ interface GraphSurfacePerfSnapshot extends GraphPerfSnapshot {
 
 type ApplyIdentityGraphAtlas = (
   requestId: number,
+  sourceRevision: number,
   atlas: IdentityGraphAtlas,
   galaxyScene: IdentityGalaxyScene | undefined,
   edgeIndices: Uint32Array | undefined,
@@ -456,6 +463,8 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
   const engineRef = useRef<IdentityGalaxyEngine | null>(null);
   const workerRef = useRef<Worker | null>(null);
   const applyAtlasRef = useRef<ApplyIdentityGraphAtlas | null>(null);
+  const requestAtlasRef = useRef<((quality: IdentityGraphAtlasQuality) => void) | null>(null);
+  const requestSelectionByIdRef = useRef<Map<number, IdentityGalaxyWorkerSelection>>(new Map());
   const atlasRef = useRef<IdentityGraphAtlas | null>(null);
   const galaxySceneRef = useRef<IdentityGalaxyScene | null>(null);
   const hitBucketsRef = useRef<Map<string, string[]>>(new Map());
@@ -469,6 +478,12 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
   const activeTouchPointsRef = useRef<Map<number, TouchPoint>>(new Map());
   const ignoredTouchIdsRef = useRef<Set<number>>(new Set());
   const hoveredNodeIdRef = useRef<string | null>(null);
+  const selectedPersonIdRef = useRef(selectedPersonId);
+  const selectedAccountIdRef = useRef(selectedAccountId);
+  const previousSelectionRef = useRef<IdentityGalaxyWorkerSelection>({
+    selectedPersonId,
+    selectedAccountId,
+  });
   const latestRequestIdRef = useRef(0);
   const latestResolvedRequestIdRef = useRef(0);
   const nextSourceRevisionRef = useRef(0);
@@ -498,6 +513,10 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
   const [linkPickerAccountId, setLinkPickerAccountId] = useState<string | null>(null);
   const [linkPickerQuery, setLinkPickerQuery] = useState("");
   const [starfieldVariation, setStarfieldVariation] = useState<IdentityGalaxyVariation>("nebula");
+  const starfieldVariationRef = useRef(starfieldVariation);
+  selectedPersonIdRef.current = selectedPersonId;
+  selectedAccountIdRef.current = selectedAccountId;
+  starfieldVariationRef.current = starfieldVariation;
 
   const activitySummaries = useMemo(
     () => activitySummariesProp ?? buildIdentityGraphActivitySummaries(feedItems ?? {}),
@@ -705,8 +724,8 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
       if (shouldSyncInteraction) {
         updateIdentityGalaxySceneInteraction(galaxyScene, {
           quality: latestQualityRef.current,
-          selectedPersonId,
-          selectedAccountId,
+          selectedPersonId: selectedPersonIdRef.current,
+          selectedAccountId: selectedAccountIdRef.current,
           hoveredNodeId: hoveredNodeIdRef.current,
         });
       }
@@ -734,9 +753,9 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
           atlas,
           galaxyScene,
           {
-            selectedPersonId,
-            selectedAccountId,
-            variation: starfieldVariation,
+            selectedPersonId: selectedPersonIdRef.current,
+            selectedAccountId: selectedAccountIdRef.current,
+            variation: starfieldVariationRef.current,
             quality: latestQualityRef.current,
           },
         );
@@ -744,11 +763,19 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
         sceneSyncCountRef.current += 1;
         if (atlas.edges.length > 0) edgeRebuildCountRef.current += 1;
       } else if (shouldSyncInteraction) {
-        engine.updateInteraction(galaxyScene);
+        engine.updateInteraction(
+          galaxyScene,
+          selectedPersonIdRef.current,
+          selectedAccountIdRef.current,
+        );
+        if (galaxyScene.edgeIndices.length > 0) edgeRebuildCountRef.current += 1;
         const perf = (window as typeof window & {
           __FREED_GRAPH_PERF__?: GraphSurfacePerfSnapshot;
         }).__FREED_GRAPH_PERF__;
-        if (perf) perf.rendererEdgeCount = engine.edgeCount;
+        if (perf) {
+          perf.edgeRebuildCount = edgeRebuildCountRef.current;
+          perf.rendererEdgeCount = engine.edgeCount;
+        }
         if (containerRef.current) {
           containerRef.current.dataset.rendererEdgeCount = String(engine.edgeCount);
         }
@@ -773,9 +800,6 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
     canvasSize.height,
     canvasSize.width,
     exposeDiagnostics,
-    selectedAccountId,
-    selectedPersonId,
-    starfieldVariation,
     updateTransformDiagnostics,
   ]);
 
@@ -787,20 +811,61 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
     });
   }, [draw]);
 
+  const requestSelectionAwareAtlas = useCallback((quality: IdentityGraphAtlasQuality) => {
+    const currentSelection: IdentityGalaxyWorkerSelection = {
+      selectedPersonId: selectedPersonIdRef.current,
+      selectedAccountId: selectedAccountIdRef.current,
+    };
+    const latestRequestSelection = requestSelectionByIdRef.current.get(latestRequestIdRef.current);
+    if (!shouldRequestIdentityGalaxyWorkerSelection(latestRequestSelection, currentSelection)) return;
+    requestAtlasRef.current?.(quality);
+  }, []);
+
   const applyAtlas = useCallback((
     requestId: number,
+    sourceRevision: number,
     atlas: IdentityGraphAtlas,
     galaxyScene: IdentityGalaxyScene | undefined,
     edgeIndices: Uint32Array | undefined,
     durationMs: number,
   ) => {
-    if (requestId < latestResolvedRequestIdRef.current) return;
     const timeout = pendingWorkerTimeoutsRef.current.get(requestId);
     if (timeout !== undefined) {
       window.clearTimeout(timeout);
       pendingWorkerTimeoutsRef.current.delete(requestId);
     }
+    const requestSelection = requestSelectionByIdRef.current.get(requestId);
+    const currentSelection: IdentityGalaxyWorkerSelection = {
+      selectedPersonId: selectedPersonIdRef.current,
+      selectedAccountId: selectedAccountIdRef.current,
+    };
+    const disposition = identityGalaxyWorkerResponseDisposition(
+      requestId,
+      latestResolvedRequestIdRef.current,
+      requestSelection,
+      currentSelection,
+    );
+    if (disposition === "ignore") {
+      if (requestId < latestResolvedRequestIdRef.current) {
+        requestSelectionByIdRef.current.delete(requestId);
+      }
+      return;
+    }
+    if (disposition === "reconcile") {
+      latestResolvedRequestIdRef.current = requestId;
+      if (galaxyScene && sourceRevision === galaxySource.revision) {
+        galaxySceneRef.current = galaxyScene;
+      }
+      for (const resolvedRequestId of requestSelectionByIdRef.current.keys()) {
+        if (resolvedRequestId < requestId) requestSelectionByIdRef.current.delete(resolvedRequestId);
+      }
+      requestSelectionAwareAtlas("settled");
+      return;
+    }
     latestResolvedRequestIdRef.current = requestId;
+    for (const resolvedRequestId of requestSelectionByIdRef.current.keys()) {
+      if (resolvedRequestId < requestId) requestSelectionByIdRef.current.delete(resolvedRequestId);
+    }
     atlas.metrics.buildMs = durationMs;
     atlasRef.current = atlas;
     if (galaxyScene) {
@@ -828,11 +893,12 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
     setAtlasReady(true);
     draw();
     scheduleDraw();
-  }, [canvasSize.height, canvasSize.width, draw, scheduleDraw]);
+  }, [canvasSize.height, canvasSize.width, draw, galaxySource.revision, requestSelectionAwareAtlas, scheduleDraw]);
   applyAtlasRef.current = applyAtlas;
 
   const runAtlasOnMainThread = useCallback((
     requestId: number,
+    sourceRevision: number,
     source: BuildIdentityGraphAtlasModelInput,
     viewport: IdentityGalaxyWorkerViewportInput,
   ) => {
@@ -848,7 +914,7 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
         selectedPersonId: viewport.selectedPersonId,
         selectedAccountId: viewport.selectedAccountId,
       });
-      applyAtlas(requestId, atlas, galaxyScene, undefined, nowMs() - startedAt);
+      applyAtlas(requestId, sourceRevision, atlas, galaxyScene, undefined, nowMs() - startedAt);
     }, 0);
   }, [applyAtlas]);
 
@@ -861,12 +927,16 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
       width: canvasSize.width,
       height: canvasSize.height,
       quality,
-      selectedPersonId,
-      selectedAccountId,
+      selectedPersonId: selectedPersonIdRef.current,
+      selectedAccountId: selectedAccountIdRef.current,
     };
+    requestSelectionByIdRef.current.set(requestId, {
+      selectedPersonId: viewport.selectedPersonId,
+      selectedAccountId: viewport.selectedAccountId,
+    });
     const worker = workerRef.current;
     if (!worker) {
-      runAtlasOnMainThread(requestId, galaxySource.input, viewport);
+      runAtlasOnMainThread(requestId, galaxySource.revision, galaxySource.input, viewport);
       return;
     }
     const timeout = window.setTimeout(() => {
@@ -877,7 +947,7 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
         workerRef.current = null;
         postedSourceRevisionRef.current = -1;
       }
-      runAtlasOnMainThread(requestId, galaxySource.input, viewport);
+      runAtlasOnMainThread(requestId, galaxySource.revision, galaxySource.input, viewport);
     }, GRAPH_LAYOUT_WORKER_TIMEOUT_MS);
     pendingWorkerTimeoutsRef.current.set(requestId, timeout);
     if (postedSourceRevisionRef.current !== galaxySource.revision) {
@@ -902,9 +972,8 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
     canvasSize.width,
     galaxySource,
     runAtlasOnMainThread,
-    selectedAccountId,
-    selectedPersonId,
   ]);
+  requestAtlasRef.current = requestAtlas;
 
   const markInteractive = useCallback(() => {
     latestQualityRef.current = "interactive";
@@ -1026,6 +1095,7 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
     worker.onmessage = (event: MessageEvent<IdentityGalaxyWorkerResponse>) => {
       applyAtlasRef.current?.(
         event.data.requestId,
+        event.data.sourceRevision,
         event.data.atlas,
         event.data.scene,
         event.data.edgeIndices,
@@ -1043,6 +1113,7 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
         window.clearTimeout(timeout);
       }
       pendingWorkerTimeoutsRef.current.clear();
+      requestSelectionByIdRef.current.clear();
       worker.terminate();
       if (workerRef.current === worker) {
         workerRef.current = null;
@@ -1117,7 +1188,23 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
   useEffect(() => {
     sceneDirtyRef.current = true;
     scheduleDraw();
-  }, [scheduleDraw, selectedAccountId, selectedPersonId, starfieldVariation]);
+  }, [scheduleDraw, starfieldVariation]);
+
+  useEffect(() => {
+    const currentSelection: IdentityGalaxyWorkerSelection = {
+      selectedPersonId,
+      selectedAccountId,
+    };
+    if (identityGalaxyWorkerSelectionsMatch(previousSelectionRef.current, currentSelection)) {
+      return;
+    }
+    previousSelectionRef.current = currentSelection;
+    interactionDirtyRef.current = true;
+    scheduleDraw();
+    if (atlasReady) {
+      requestSelectionAwareAtlas("settled");
+    }
+  }, [atlasReady, requestSelectionAwareAtlas, scheduleDraw, selectedAccountId, selectedPersonId]);
 
   useEffect(() => {
     if (typeof PerformanceObserver === "undefined") return;

--- a/packages/ui/src/lib/identity-galaxy-engine.ts
+++ b/packages/ui/src/lib/identity-galaxy-engine.ts
@@ -1534,8 +1534,14 @@ export class IdentityGalaxyEngine {
     this.renderer?.syncScene(atlas, scene, palette, options.variation, options.quality);
   }
 
-  updateInteraction(scene: IdentityGalaxyScene): void {
+  updateInteraction(
+    scene: IdentityGalaxyScene,
+    selectedPersonId: string | null | undefined,
+    selectedAccountId: string | null | undefined,
+  ): void {
     this.scene = scene;
+    this.selectedPersonId = selectedPersonId;
+    this.selectedAccountId = selectedAccountId;
     if (this.renderer && this.palette) {
       this.renderer.updateInteraction(scene, this.palette);
     }

--- a/packages/ui/src/lib/identity-galaxy-worker-protocol.test.ts
+++ b/packages/ui/src/lib/identity-galaxy-worker-protocol.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import {
+  identityGalaxyWorkerResponseDisposition,
+  identityGalaxyWorkerSelectionsMatch,
+  shouldReconcileIdentityGalaxyWorkerSelection,
+  shouldRequestIdentityGalaxyWorkerSelection,
+} from "./identity-galaxy-worker-protocol.js";
+
+describe("identity galaxy worker selection", () => {
+  it("rejects an older pending response after the selected identity changes", () => {
+    expect(shouldReconcileIdentityGalaxyWorkerSelection(
+      { selectedPersonId: null, selectedAccountId: null },
+      { selectedPersonId: "person-399", selectedAccountId: null },
+    )).toBe(true);
+    expect(shouldReconcileIdentityGalaxyWorkerSelection(
+      { selectedPersonId: "person-399", selectedAccountId: null },
+      { selectedPersonId: null, selectedAccountId: "account-999" },
+    )).toBe(true);
+  });
+
+  it("accepts the response for the current selection tuple", () => {
+    expect(identityGalaxyWorkerSelectionsMatch(
+      { selectedPersonId: undefined, selectedAccountId: undefined },
+      { selectedPersonId: null, selectedAccountId: null },
+    )).toBe(true);
+    expect(shouldReconcileIdentityGalaxyWorkerSelection(
+      { selectedPersonId: null, selectedAccountId: "account-999" },
+      { selectedPersonId: null, selectedAccountId: "account-999" },
+    )).toBe(false);
+  });
+
+  it("deduplicates the passive selection effect after stale-response recovery queues the same tuple", () => {
+    const currentSelection = {
+      selectedPersonId: "person-399",
+      selectedAccountId: null,
+    };
+    expect(shouldRequestIdentityGalaxyWorkerSelection(
+      { selectedPersonId: null, selectedAccountId: null },
+      currentSelection,
+    )).toBe(true);
+    expect(shouldRequestIdentityGalaxyWorkerSelection(
+      currentSelection,
+      currentSelection,
+    )).toBe(false);
+  });
+
+  it("reconciles a pending older response and ignores it after the current response wins", () => {
+    const oldSelection = { selectedPersonId: null, selectedAccountId: null };
+    const currentSelection = {
+      selectedPersonId: "person-399",
+      selectedAccountId: null,
+    };
+    expect(identityGalaxyWorkerResponseDisposition(
+      1,
+      0,
+      oldSelection,
+      currentSelection,
+    )).toBe("reconcile");
+    expect(identityGalaxyWorkerResponseDisposition(
+      2,
+      1,
+      currentSelection,
+      currentSelection,
+    )).toBe("apply");
+    expect(identityGalaxyWorkerResponseDisposition(
+      1,
+      2,
+      oldSelection,
+      currentSelection,
+    )).toBe("ignore");
+  });
+});

--- a/packages/ui/src/lib/identity-galaxy-worker-protocol.ts
+++ b/packages/ui/src/lib/identity-galaxy-worker-protocol.ts
@@ -10,6 +10,52 @@ export type IdentityGalaxyWorkerViewportInput = Pick<
   "transform" | "width" | "height" | "quality" | "selectedPersonId" | "selectedAccountId"
 >;
 
+export type IdentityGalaxyWorkerSelection = Pick<
+  IdentityGalaxyWorkerViewportInput,
+  "selectedPersonId" | "selectedAccountId"
+>;
+
+export function identityGalaxyWorkerSelectionsMatch(
+  left: IdentityGalaxyWorkerSelection,
+  right: IdentityGalaxyWorkerSelection,
+): boolean {
+  return (left.selectedPersonId ?? null) === (right.selectedPersonId ?? null) &&
+    (left.selectedAccountId ?? null) === (right.selectedAccountId ?? null);
+}
+
+export function shouldReconcileIdentityGalaxyWorkerSelection(
+  requestSelection: IdentityGalaxyWorkerSelection,
+  currentSelection: IdentityGalaxyWorkerSelection,
+): boolean {
+  return !identityGalaxyWorkerSelectionsMatch(requestSelection, currentSelection);
+}
+
+export function shouldRequestIdentityGalaxyWorkerSelection(
+  latestRequestSelection: IdentityGalaxyWorkerSelection | undefined,
+  currentSelection: IdentityGalaxyWorkerSelection,
+): boolean {
+  return !latestRequestSelection ||
+    !identityGalaxyWorkerSelectionsMatch(latestRequestSelection, currentSelection);
+}
+
+export type IdentityGalaxyWorkerResponseDisposition = "apply" | "ignore" | "reconcile";
+
+export function identityGalaxyWorkerResponseDisposition(
+  requestId: number,
+  latestResolvedRequestId: number,
+  requestSelection: IdentityGalaxyWorkerSelection | undefined,
+  currentSelection: IdentityGalaxyWorkerSelection,
+): IdentityGalaxyWorkerResponseDisposition {
+  if (requestId <= latestResolvedRequestId) return "ignore";
+  if (
+    requestSelection &&
+    shouldReconcileIdentityGalaxyWorkerSelection(requestSelection, currentSelection)
+  ) {
+    return "reconcile";
+  }
+  return "apply";
+}
+
 interface IdentityGalaxyWorkerRequestBase {
   requestId: number;
   sourceRevision: number;

--- a/packages/ui/src/lib/identity-graph-atlas.test.ts
+++ b/packages/ui/src/lib/identity-graph-atlas.test.ts
@@ -153,10 +153,10 @@ describe("buildIdentityGraphAtlas", () => {
     expect(atlas.metrics.lod).toBe("overview");
   });
 
-  it("keeps selected nodes visible even when the atlas is capped", () => {
-    const persons = Array.from({ length: 400 }, (_, index) => person(index));
+  it("keeps selected people, accounts, and labels visible when the atlas is capped", () => {
+    const persons = Array.from({ length: 800 }, (_, index) => person(index));
     const accounts = Object.fromEntries(
-      Array.from({ length: 1_000 }, (_, index) => {
+      Array.from({ length: 1_400 }, (_, index) => {
         const entry = account(index);
         return [entry.id, entry];
       }),
@@ -168,7 +168,7 @@ describe("buildIdentityGraphAtlas", () => {
       itemCount: 0,
     };
 
-    const atlas = buildIdentityGraphAtlas({
+    const input = {
       persons,
       accounts,
       feeds: {},
@@ -178,10 +178,46 @@ describe("buildIdentityGraphAtlas", () => {
       width: 390,
       height: 760,
       quality: "settled",
-      selectedPersonId: "person-399",
+    } as const;
+    const unselectedAtlas = buildIdentityGraphAtlas(input);
+    const visiblePersonIds = new Set(unselectedAtlas.nodes.flatMap((node) =>
+      node.personId ? [node.personId] : []
+    ));
+    const visibleAccountIds = new Set(unselectedAtlas.nodes.flatMap((node) =>
+      node.accountId ? [node.accountId] : []
+    ));
+    const selectedPersonId = persons.find((entry) => !visiblePersonIds.has(entry.id))?.id;
+    const selectedAccountId = Object.values(accounts).find((entry) =>
+      !visibleAccountIds.has(entry.id)
+    )?.id;
+    expect(selectedPersonId).toBeTruthy();
+    expect(selectedAccountId).toBeTruthy();
+
+    const selectedPersonAtlas = buildIdentityGraphAtlas({
+      ...input,
+      selectedPersonId,
+    });
+    const selectedAccountAtlas = buildIdentityGraphAtlas({
+      ...input,
+      selectedAccountId,
     });
 
-    expect(atlas.nodes.some((node) => node.personId === "person-399")).toBe(true);
+    expect(selectedPersonAtlas.nodes.some((node) => node.personId === selectedPersonId)).toBe(true);
+    expect(selectedPersonAtlas.labels.some((label) => label.nodeId === `person:${selectedPersonId}`)).toBe(true);
+    expect(selectedAccountAtlas.nodes.some((node) => node.accountId === selectedAccountId)).toBe(true);
+    expect(selectedAccountAtlas.labels.some((label) => label.nodeId === `account:${selectedAccountId}`)).toBe(true);
+
+    const unlabeledVisibleNode = unselectedAtlas.nodes.find((node) =>
+      !unselectedAtlas.labels.some((label) => label.nodeId === node.id) &&
+      (!!node.personId || !!node.accountId)
+    );
+    expect(unlabeledVisibleNode).toBeTruthy();
+    const selectedVisibleAtlas = buildIdentityGraphAtlas({
+      ...input,
+      selectedPersonId: unlabeledVisibleNode?.personId,
+      selectedAccountId: unlabeledVisibleNode?.accountId,
+    });
+    expect(selectedVisibleAtlas.labels.some((label) => label.nodeId === unlabeledVisibleNode?.id)).toBe(true);
   });
 
   it("packs linked accounts into tight fields around their person", () => {

--- a/packages/ui/src/lib/identity-graph-atlas.ts
+++ b/packages/ui/src/lib/identity-graph-atlas.ts
@@ -720,7 +720,7 @@ export function sliceIdentityGraphAtlas({
         text: node.label,
         x: node.x,
         y: node.y,
-        priority: node.priority,
+        priority: node.priority + (selectedNodeIds.has(node.id) ? 10_000 : 0),
         kind: node.kind,
       }));
   const labels = [...regionLabels, ...nodeLabels]


### PR DESCRIPTION
(AI Generated).

## Summary
- Keep Friends graph draw and atlas request callbacks stable across selection changes.
- Run exactly one selection-aware atlas reslice for each real person or account selection tuple change, while deduplicating stale worker responses.
- Preserve revision-matched semantic scenes during initial-load races and keep fallback canvas selection plus rebuild telemetry accurate.

## Testing
- Exact rebased head passes four focused browser checks covering the delayed initial Worker response, compact selection, empty-space clear, and dense capped-atlas settlement.
- Exact rebased head passes root typecheck and 22 identity atlas, scene, camera, and worker protocol unit tests.
- Pre-rebase feature validation passed 273 PWA tests, 597 Desktop tests plus 1 todo, 9 smoke checks, and the Friends, feed, map, and sidebar performance lanes.
- Settings performance passed three consecutive focused reruns after one unrelated 84.9 ms timing outlier in the full feature run.