### PR TITLE
chore: prepare v26.7.1500-dev

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freed/desktop",
   "private": true,
-  "version": "26.7.1402",
+  "version": "26.7.1500",
   "type": "module",
   "scripts": {
     "dev": "node ../../node_modules/vite/bin/vite.js",

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -1420,7 +1420,7 @@ dependencies = [
 
 [[package]]
 name = "freed-desktop"
-version = "26.7.1402"
+version = "26.7.1500"
 dependencies = [
  "base64 0.22.1",
  "criterion",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freed-desktop"
-version = "26.7.1402"
+version = "26.7.1500"
 description = "Freed Desktop - Escape algorithmic manipulation"
 authors = ["Freed"]
 edition = "2021"

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Freed",
-  "version": "26.7.1402",
+  "version": "26.7.1500",
   "identifier": "wtf.freed.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freed/pwa",
   "private": true,
-  "version": "26.7.1402",
+  "version": "26.7.1500",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/release-notes/daily/dev/26.7.15.json
+++ b/release-notes/daily/dev/26.7.15.json
@@ -2,13 +2,19 @@
   "channel": "dev",
   "dayKey": "26.7.15",
   "date": "2026-07-15",
-  "preferredDeck": null,
+  "preferredDeck": "Friends is now a theme-aware personal galaxy with native touch and trackpad navigation, tight identity constellations, and cosmic provider nebulae",
   "editorialGuidance": [
     "Keep the tone concise, professional, and specific.",
     "Lead with user-facing outcomes, shipping milestones, trust wins, and installability improvements.",
     "Demote internal cleanup unless it clearly changes the shipped product."
   ],
-  "pinnedHighlights": [],
-  "editorialNotes": [],
-  "updatedAt": "2026-07-15T07:09:45.076Z"
+  "pinnedHighlights": [
+    "Friends Galaxy",
+    "Medium and Substack beta sources",
+    "Completed YouTube capture"
+  ],
+  "editorialNotes": [
+    "Lead with the user-facing Friends Galaxy. Keep release governance and superseded release-prep commits out of public copy."
+  ],
+  "updatedAt": "2026-07-15T07:10:39.000Z"
 }

--- a/release-notes/daily/dev/26.7.15.json
+++ b/release-notes/daily/dev/26.7.15.json
@@ -1,0 +1,14 @@
+{
+  "channel": "dev",
+  "dayKey": "26.7.15",
+  "date": "2026-07-15",
+  "preferredDeck": null,
+  "editorialGuidance": [
+    "Keep the tone concise, professional, and specific.",
+    "Lead with user-facing outcomes, shipping milestones, trust wins, and installability improvements.",
+    "Demote internal cleanup unless it clearly changes the shipped product."
+  ],
+  "pinnedHighlights": [],
+  "editorialNotes": [],
+  "updatedAt": "2026-07-15T07:09:45.076Z"
+}

--- a/release-notes/releases/v26.7.1500-dev.json
+++ b/release-notes/releases/v26.7.1500-dev.json
@@ -3,8 +3,10 @@
   "version": "26.7.1500-dev",
   "channel": "dev",
   "dayKey": "26.7.15",
-  "approved": false,
-  "editorialNotes": [],
+  "approved": true,
+  "editorialNotes": [
+    "Reviewed 2026-07-15: retained the reviewed Friends Galaxy highlights because the immutable v26.7.1400-dev and v26.7.1402-dev tags published no installer. Rebound this replacement to the exact current dev product commit after the PWA handler type repair, release workflow validation fix, and release notes deduplication repair merged."
+  ],
   "generatedAt": "2026-07-15T07:09:45.075Z",
   "model": "heuristic",
   "source": {
@@ -12,7 +14,7 @@
     "previousPublishedTag": "v26.7.1200-dev",
     "previousPublishedDayTag": "v26.7.1200-dev",
     "compareRef": "HEAD",
-    "productCommitSha": "b3afab526f889b68071af04ae684ff27e3c4fa60",
+    "productCommitSha": "bb7443162ef9d53cc96cb19e7d7ffb63f00537fc",
     "promotedDevCommitSha": null,
     "isLatestOfDay": true,
     "sameDayTagsIncluded": [
@@ -49,9 +51,11 @@
       1012,
       1013,
       1015,
-      1016
+      1016,
+      1021
     ],
     "commitSubjects": [
+      "fix: avoid duplicate pinned release highlights (#1021)",
       "fix: unblock dev release validation (#1016)",
       "chore: prepare v26.7.1402-dev (#1015)",
       "fix: recognize reviewed main backport history (#1013)",
@@ -85,25 +89,18 @@
     ]
   },
   "release": {
-    "deck": "Authenticated essay capture, private vulnerability reporting, and build next-generation Friends Galaxy",
+    "deck": "Friends is now a theme-aware personal galaxy with native touch and trackpad navigation, tight identity constellations, and cosmic provider nebulae",
     "features": [
-      "Authenticated essay capture",
-      "Private vulnerability reporting",
-      "Build next-generation Friends Galaxy"
+      "Explore Friends as a hardware-accelerated 3D galaxy where relationship importance controls depth, identities form tight constellations, and every starfield follows the active Freed theme",
+      "Pan, zoom, and focus the galaxy with a mouse, trackpad, or midpoint-preserving iPhone pinch gestures while billboard labels stay visible and close to their stars",
+      "Use the new Medium and Substack beta sources in Freed Desktop to capture essays, visible relationships, subscriptions, and activity through your signed-in sessions"
     ],
     "fixes": [
-      "Release build and type-safety cleanup",
-      "Reader, feed, and header polish",
-      "Align tooling fixtures with current policy",
-      "Complete YouTube capture lifecycle",
-      "Enable YouTube terminal sync soaks"
+      "Provider regions now form spiral nebulae instead of flat ellipses, and identity links appear only for the hovered or selected constellation",
+      "YouTube followed-channel and subscription capture now reports bounded progress, cancels stale work, and closes hidden capture sessions when finished",
+      "Security reports can now be submitted privately with redacted diagnostics and hardened fetched-content handling"
     ],
-    "followUps": [
-      "Prepare v26.7.1402-dev",
-      "Pin release publisher app bypass",
-      "Dedicated release tag publisher",
-      "Reverse integrate main into dev"
-    ]
+    "followUps": []
   },
-  "releaseBody": "(AI Generated).\n\n## Freed v26.7.1500-dev\n\nAuthenticated essay capture, private vulnerability reporting, and build next-generation Friends Galaxy\n\n### Features\n\n- Authenticated essay capture\n- Private vulnerability reporting\n- Build next-generation Friends Galaxy\n\n### Fixes\n\n- Release build and type-safety cleanup\n- Reader, feed, and header polish\n- Align tooling fixtures with current policy\n- Complete YouTube capture lifecycle\n- Enable YouTube terminal sync soaks\n\n### Follow-ups\n\n- Prepare v26.7.1402-dev\n- Pin release publisher app bypass\n- Dedicated release tag publisher\n- Reverse integrate main into dev\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+  "releaseBody": "(AI Generated).\n\n## Freed v26.7.1500-dev\n\nFriends is now a theme-aware personal galaxy with native touch and trackpad navigation, tight identity constellations, and cosmic provider nebulae.\n\n### Features\n\n- Explore Friends as a hardware-accelerated 3D galaxy where relationship importance controls depth, identities form tight constellations, and every starfield follows the active Freed theme\n- Pan, zoom, and focus the galaxy with a mouse, trackpad, or midpoint-preserving iPhone pinch gestures while billboard labels stay visible and close to their stars\n- Use the new Medium and Substack beta sources in Freed Desktop to capture essays, visible relationships, subscriptions, and activity through your signed-in sessions\n\n### Fixes\n\n- Provider regions now form spiral nebulae instead of flat ellipses, and identity links appear only for the hovered or selected constellation\n- YouTube followed-channel and subscription capture now reports bounded progress, cancels stale work, and closes hidden capture sessions when finished\n- Security reports can now be submitted privately with redacted diagnostics and hardened fetched-content handling\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
 }

--- a/release-notes/releases/v26.7.1500-dev.json
+++ b/release-notes/releases/v26.7.1500-dev.json
@@ -1,0 +1,109 @@
+{
+  "tag": "v26.7.1500-dev",
+  "version": "26.7.1500-dev",
+  "channel": "dev",
+  "dayKey": "26.7.15",
+  "approved": false,
+  "editorialNotes": [],
+  "generatedAt": "2026-07-15T07:09:45.075Z",
+  "model": "heuristic",
+  "source": {
+    "channel": "dev",
+    "previousPublishedTag": "v26.7.1200-dev",
+    "previousPublishedDayTag": "v26.7.1200-dev",
+    "compareRef": "HEAD",
+    "productCommitSha": "b3afab526f889b68071af04ae684ff27e3c4fa60",
+    "promotedDevCommitSha": null,
+    "isLatestOfDay": true,
+    "sameDayTagsIncluded": [
+      "v26.7.1500-dev"
+    ],
+    "relatedBuildTags": [
+      "v26.7.1500-dev"
+    ],
+    "prNumbers": [
+      642,
+      949,
+      953,
+      955,
+      957,
+      963,
+      964,
+      965,
+      966,
+      968,
+      969,
+      970,
+      972,
+      973,
+      974,
+      975,
+      976,
+      977,
+      978,
+      979,
+      982,
+      983,
+      984,
+      1010,
+      1012,
+      1013,
+      1015,
+      1016
+    ],
+    "commitSubjects": [
+      "fix: unblock dev release validation (#1016)",
+      "chore: prepare v26.7.1402-dev (#1015)",
+      "fix: recognize reviewed main backport history (#1013)",
+      "fix: repair release validation contracts (#1010)",
+      "fix: align tooling fixtures with current policy (#1012)",
+      "feat: add private vulnerability reporting (#968)",
+      "chore: prepare v26.7.1400-dev (#984)",
+      "fix: accept canonical tag ruleset responses (#983)",
+      "fix: allow exact current-task owner approvals (#982)",
+      "feat: build next-generation Friends Galaxy (#953)",
+      "fix: include publisher dependencies in main backports (#979)",
+      "chore: pin release publisher app bypass (#977)",
+      "fix: simplify provider approval workflow (#978)",
+      "feat: add authenticated essay capture (#642)",
+      "fix: stop automation actor keychain prompts (#976)",
+      "fix: stabilize automation actor handoff (#975)",
+      "fix: omit webhook from release app manifest (#974)",
+      "fix: accept canonical heartbeat thread targets (#973)",
+      "feat: add dedicated release tag publisher (#972)",
+      "fix: recognize historical promotion commits",
+      "chore: prepare v26.7.1301-dev (#970)",
+      "fix: complete YouTube capture lifecycle (#969)",
+      "fix: bootstrap automation actor leases (#965)",
+      "test: restore release channel build coverage (#967)",
+      "chore: reverse integrate main into dev (#966)",
+      "fix: bind release lockfile to version bump (#964)",
+      "chore: prepare v26.7.1300-dev (#963)",
+      "fix: harden the stability control plane (#949)",
+      "fix: enable YouTube terminal sync soaks (#955)",
+      "fix: resolve pinned Node when sourced by zsh (#957)"
+    ]
+  },
+  "release": {
+    "deck": "Authenticated essay capture, private vulnerability reporting, and build next-generation Friends Galaxy",
+    "features": [
+      "Authenticated essay capture",
+      "Private vulnerability reporting",
+      "Build next-generation Friends Galaxy"
+    ],
+    "fixes": [
+      "Release build and type-safety cleanup",
+      "Reader, feed, and header polish",
+      "Align tooling fixtures with current policy",
+      "Complete YouTube capture lifecycle",
+      "Enable YouTube terminal sync soaks"
+    ],
+    "followUps": [
+      "Prepare v26.7.1402-dev",
+      "Pin release publisher app bypass",
+      "Dedicated release tag publisher",
+      "Reverse integrate main into dev"
+    ]
+  },
+  "releaseBody": "(AI Generated).\n\n## Freed v26.7.1500-dev\n\nAuthenticated essay capture, private vulnerability reporting, and build next-generation Friends Galaxy\n\n### Features\n\n- Authenticated essay capture\n- Private vulnerability reporting\n- Build next-generation Friends Galaxy\n\n### Fixes\n\n- Release build and type-safety cleanup\n- Reader, feed, and header polish\n- Align tooling fixtures with current policy\n- Complete YouTube capture lifecycle\n- Enable YouTube terminal sync soaks\n\n### Follow-ups\n\n- Prepare v26.7.1402-dev\n- Pin release publisher app bypass\n- Dedicated release tag publisher\n- Reverse integrate main into dev\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+}

--- a/release-notes/releases/v26.7.1500-dev.md
+++ b/release-notes/releases/v26.7.1500-dev.md
@@ -2,28 +2,19 @@
 
 ## Freed v26.7.1500-dev
 
-Authenticated essay capture, private vulnerability reporting, and build next-generation Friends Galaxy
+Friends is now a theme-aware personal galaxy with native touch and trackpad navigation, tight identity constellations, and cosmic provider nebulae.
 
 ### Features
 
-- Authenticated essay capture
-- Private vulnerability reporting
-- Build next-generation Friends Galaxy
+- Explore Friends as a hardware-accelerated 3D galaxy where relationship importance controls depth, identities form tight constellations, and every starfield follows the active Freed theme
+- Pan, zoom, and focus the galaxy with a mouse, trackpad, or midpoint-preserving iPhone pinch gestures while billboard labels stay visible and close to their stars
+- Use the new Medium and Substack beta sources in Freed Desktop to capture essays, visible relationships, subscriptions, and activity through your signed-in sessions
 
 ### Fixes
 
-- Release build and type-safety cleanup
-- Reader, feed, and header polish
-- Align tooling fixtures with current policy
-- Complete YouTube capture lifecycle
-- Enable YouTube terminal sync soaks
-
-### Follow-ups
-
-- Prepare v26.7.1402-dev
-- Pin release publisher app bypass
-- Dedicated release tag publisher
-- Reverse integrate main into dev
+- Provider regions now form spiral nebulae instead of flat ellipses, and identity links appear only for the hovered or selected constellation
+- YouTube followed-channel and subscription capture now reports bounded progress, cancels stale work, and closes hidden capture sessions when finished
+- Security reports can now be submitted privately with redacted diagnostics and hardened fetched-content handling
 
 ### Downloads
 

--- a/release-notes/releases/v26.7.1500-dev.md
+++ b/release-notes/releases/v26.7.1500-dev.md
@@ -1,0 +1,34 @@
+(AI Generated).
+
+## Freed v26.7.1500-dev
+
+Authenticated essay capture, private vulnerability reporting, and build next-generation Friends Galaxy
+
+### Features
+
+- Authenticated essay capture
+- Private vulnerability reporting
+- Build next-generation Friends Galaxy
+
+### Fixes
+
+- Release build and type-safety cleanup
+- Reader, feed, and header polish
+- Align tooling fixtures with current policy
+- Complete YouTube capture lifecycle
+- Enable YouTube terminal sync soaks
+
+### Follow-ups
+
+- Prepare v26.7.1402-dev
+- Pin release publisher app bypass
+- Dedicated release tag publisher
+- Reverse integrate main into dev
+
+### Downloads
+
+**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  
+**Windows:** `.exe` (NSIS installer)  
+**Linux:** `.AppImage`  
+
+> macOS downloads are signed and notarized for normal Gatekeeper installation.


### PR DESCRIPTION
(AI Generated).

## Summary
- Prepare the July 15 dev build from the exact current dev product commit.
- Carry the reviewed Friends Galaxy release narrative forward from the immutable failed tags.

## Testing
- npm run lint
- npm run validate:feature