### PR TITLE
fix: preserve removed Facebook group preferences

### DIFF
--- a/packages/desktop/src/lib/automerge-state-patches.test.ts
+++ b/packages/desktop/src/lib/automerge-state-patches.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { createDefaultPreferences, type FeedItem } from "@freed/shared";
 import type { DocState } from "./automerge-types";
-import { applyItemPatchesToState, createItemIndex } from "./automerge-state-patches";
+import {
+  applyItemPatchesToState,
+  applyPreferencePatchToState,
+  createItemIndex,
+} from "./automerge-state-patches";
 
 const FEED_URL = "https://example.com/feed.xml";
 
@@ -64,6 +68,51 @@ function makeState(items: FeedItem[]): DocState {
 }
 
 describe("Automerge item patch state updates", () => {
+  it("replaces Facebook capture maps so removed groups stay removed", () => {
+    const state = makeState([]);
+    state.preferences.fbCapture = {
+      knownGroups: {
+        one: { id: "one", name: "One", url: "https://facebook.com/groups/one" },
+        two: { id: "two", name: "Two", url: "https://facebook.com/groups/two" },
+      },
+      excludedGroupIds: { one: true },
+    };
+
+    const result = applyPreferencePatchToState(state, {
+      fbCapture: {
+        knownGroups: {
+          two: { id: "two", name: "Two", url: "https://facebook.com/groups/two" },
+        },
+        excludedGroupIds: {},
+      },
+    });
+
+    expect(result.preferences.fbCapture.knownGroups).toEqual({
+      two: { id: "two", name: "Two", url: "https://facebook.com/groups/two" },
+    });
+    expect(result.preferences.fbCapture.excludedGroupIds).toEqual({});
+    expect(result.preferences.display).toEqual(state.preferences.display);
+  });
+
+  it("preserves the omitted Facebook capture map in a partial patch", () => {
+    const state = makeState([]);
+    state.preferences.fbCapture = {
+      knownGroups: {
+        one: { id: "one", name: "One", url: "https://facebook.com/groups/one" },
+      },
+      excludedGroupIds: { one: true },
+    };
+
+    const result = applyPreferencePatchToState(state, {
+      fbCapture: { excludedGroupIds: {} },
+    });
+
+    expect(result.preferences.fbCapture.knownGroups).toEqual(
+      state.preferences.fbCapture.knownGroups,
+    );
+    expect(result.preferences.fbCapture.excludedGroupIds).toEqual({});
+  });
+
   it("updates read and archivable counts without rebuilding every count from items", () => {
     const unread = makeItem("rss:unread");
     const read = makeItem("rss:read", { readAt: 10 });

--- a/packages/desktop/src/lib/automerge-state-patches.ts
+++ b/packages/desktop/src/lib/automerge-state-patches.ts
@@ -1,7 +1,11 @@
-import type { FeedItem } from "@freed/shared";
+import type { FeedItem, UserPreferences } from "@freed/shared";
 import type { DocState, FeedItemPatch } from "./automerge-types";
 
 export type ItemIndex = Map<string, number>;
+
+type PreferencePatch = Omit<Partial<UserPreferences>, "fbCapture"> & {
+  fbCapture?: Partial<UserPreferences["fbCapture"]>;
+};
 
 interface CountState {
   feedUnreadCounts: Record<string, number>;
@@ -17,6 +21,45 @@ interface CountState {
 
 export function createItemIndex(items: FeedItem[]): ItemIndex {
   return new Map(items.map((item, index) => [item.globalId, index]));
+}
+
+function isMergeablePreferenceObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function mergePreferencePatch<T extends object>(current: T, update: Partial<T>): T {
+  const next = { ...current };
+
+  for (const key of Object.keys(update) as Array<keyof T>) {
+    const currentValue = current[key];
+    const updateValue = update[key];
+    next[key] = (
+      isMergeablePreferenceObject(currentValue) && isMergeablePreferenceObject(updateValue)
+        ? mergePreferencePatch<Record<string, unknown>>(currentValue, updateValue)
+        : updateValue
+    ) as T[typeof key];
+  }
+
+  return next;
+}
+
+export function applyPreferencePatchToState(
+  state: DocState,
+  updates: PreferencePatch,
+): DocState {
+  const preferences = mergePreferencePatch(state.preferences, updates);
+  if (updates.fbCapture !== undefined) {
+    preferences.fbCapture = {
+      knownGroups: updates.fbCapture.knownGroups !== undefined
+        ? { ...updates.fbCapture.knownGroups }
+        : { ...state.preferences.fbCapture.knownGroups },
+      excludedGroupIds: updates.fbCapture.excludedGroupIds !== undefined
+        ? { ...updates.fbCapture.excludedGroupIds }
+        : { ...state.preferences.fbCapture.excludedGroupIds },
+    };
+  }
+
+  return { ...state, preferences };
 }
 
 function cloneCountState(state: DocState): CountState {

--- a/packages/desktop/src/lib/automerge.ts
+++ b/packages/desktop/src/lib/automerge.ts
@@ -32,7 +32,12 @@ import type {
   UserPreferences,
 } from "@freed/shared";
 import type { DocChangeEvent, DocState, DocStats, WorkerRequest, WorkerResponse } from "./automerge-types";
-import { applyItemPatchesToState, createItemIndex, type ItemIndex } from "./automerge-state-patches";
+import {
+  applyItemPatchesToState,
+  applyPreferencePatchToState,
+  createItemIndex,
+  type ItemIndex,
+} from "./automerge-state-patches";
 import { log } from "./logger.js";
 import { recordRuntimeHealthEvent, recordWorkerInit } from "./runtime-health-events";
 export type { DocChangeEvent, DocState } from "./automerge-types";
@@ -351,29 +356,6 @@ export function subscribe(callback: Subscriber): () => void {
   return () => subscribers.delete(callback);
 }
 
-function isMergeablePreferenceObject(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
-}
-
-function mergePreferencePatch<T extends object>(
-  current: T,
-  update: Partial<T>,
-): T {
-  const next = { ...current };
-
-  for (const key of Object.keys(update) as Array<keyof T>) {
-    const currentValue = current[key];
-    const updateValue = update[key];
-    next[key] = (
-      isMergeablePreferenceObject(currentValue) && isMergeablePreferenceObject(updateValue)
-        ? mergePreferencePatch<Record<string, unknown>>(currentValue, updateValue)
-        : updateValue
-    ) as T[typeof key];
-  }
-
-  return next;
-}
-
 function publishState(state: DocState, event: DocChangeEvent): void {
   lastDocState = state;
   if (event.requiresFullScan) {
@@ -421,9 +403,8 @@ function handleWorkerMessage(event: MessageEvent<WorkerResponse>) {
 
   if (msg.type === "PREFERENCES_PATCH") {
     if (!lastDocState) return;
-    const preferences = mergePreferencePatch(lastDocState.preferences, msg.updates);
     publishState(
-      { ...lastDocState, preferences },
+      applyPreferencePatchToState(lastDocState, msg.updates),
       {
         source: "preferences_patch",
         mutation: msg.mutation,

--- a/packages/desktop/tests/e2e/provider-health.spec.ts
+++ b/packages/desktop/tests/e2e/provider-health.spec.ts
@@ -854,12 +854,32 @@ test("facebook groups settings separate last-active text, show active counts, an
   await page.getByTestId("facebook-group-one-leave").click();
   await expect.poll(async () => (await ipc.openedUrls()).at(-1)).toBe("https://facebook.com/groups/one");
   await page.evaluate(() => window.dispatchEvent(new Event("focus")));
-  await expect(page.getByTestId("facebook-group-one-label")).toHaveCount(0);
-  await expect(page.getByText("1 active of 2 total")).toBeVisible();
   await expect.poll(async () => {
     const calls = await ipc.invocations();
-    return calls.some((call) => call.cmd === "fb_check_group_membership");
+    return calls.some(
+      (call) =>
+        call.cmd === "fb_check_group_membership" &&
+        (call.args as { groupId?: string } | undefined)?.groupId === "one",
+    );
   }).toBe(true);
+  await page.waitForFunction(() => {
+    const store = (window as Window & {
+      __FREED_STORE__?: {
+        getState: () => {
+          preferences: {
+            fbCapture?: {
+              knownGroups?: Record<string, unknown>;
+            };
+          };
+        };
+      };
+    }).__FREED_STORE__;
+    const knownGroups = store?.getState().preferences.fbCapture?.knownGroups;
+    if (!knownGroups) return false;
+    return !("one" in knownGroups) && Object.keys(knownGroups).length === 2;
+  });
+  await expect(page.getByText("1 active of 2 total")).toBeVisible();
+  await expect(page.getByTestId("facebook-group-one-label")).toHaveCount(0);
 
   await page.getByTestId("facebook-groups-filter").fill("North Idaho");
   await expect(page.getByRole("button", { name: "Activate shown", exact: true })).toBeVisible();


### PR DESCRIPTION
(AI Generated).

## Summary
- Replace Facebook capture record maps when worker preference patches arrive so deleted group IDs stay deleted.
- Preserve an omitted sibling map when a partial Facebook capture preference patch arrives.

## Testing
- Pinned Node 24.14.1 focused unit regression, 12 tests passed.
- Pinned Node 24.14.1 leave-flow acceptance, 10 consecutive runs passed.
- Pinned Node 24.14.1 Desktop regression, 154 tests passed.
- npm run validate:feature, including 599 Desktop unit tests plus 1 todo, 9 smoke checks, and the complete performance lane.