### PR TITLE
fix: compile partial Facebook preference patches

### DIFF
--- a/packages/desktop/src/lib/automerge-state-patches.ts
+++ b/packages/desktop/src/lib/automerge-state-patches.ts
@@ -47,14 +47,15 @@ export function applyPreferencePatchToState(
   state: DocState,
   updates: PreferencePatch,
 ): DocState {
-  const preferences = mergePreferencePatch(state.preferences, updates);
-  if (updates.fbCapture !== undefined) {
+  const { fbCapture, ...remainingUpdates } = updates;
+  const preferences = mergePreferencePatch(state.preferences, remainingUpdates);
+  if (fbCapture !== undefined) {
     preferences.fbCapture = {
-      knownGroups: updates.fbCapture.knownGroups !== undefined
-        ? { ...updates.fbCapture.knownGroups }
+      knownGroups: fbCapture.knownGroups !== undefined
+        ? { ...fbCapture.knownGroups }
         : { ...state.preferences.fbCapture.knownGroups },
-      excludedGroupIds: updates.fbCapture.excludedGroupIds !== undefined
-        ? { ...updates.fbCapture.excludedGroupIds }
+      excludedGroupIds: fbCapture.excludedGroupIds !== undefined
+        ? { ...fbCapture.excludedGroupIds }
         : { ...state.preferences.fbCapture.excludedGroupIds },
     };
   }


### PR DESCRIPTION
(AI Generated).

## Summary
- Keep Facebook capture records out of the generic preference merger so production TypeScript builds accept nested partial updates.
- Continue replacing supplied group maps while preserving omitted sibling maps.

## Testing
- Focused state patch unit tests, 12 passed.
- Freed Desktop production build passed.
- Feature validation passed with 599 unit tests plus 1 todo and 9 smoke checks.
- Mocked Facebook group removal regression passed 3 consecutive runs.