### PR TITLE
fix: recognize historical cloud promotions

### DIFF
--- a/scripts/release-promotion-shared.mjs
+++ b/scripts/release-promotion-shared.mjs
@@ -41,6 +41,10 @@ export const PROMOTION_COMMIT_SUBJECT_PATTERN =
 const HISTORICAL_MAIN_BACKPORT_SUBJECTS = new Set([
   "fix: backport simplified provider approval (#980)",
 ]);
+const HISTORICAL_MAIN_PROMOTION_SUBJECTS = new Set([
+  "chore: promote dev into main for cloud conflict recovery (#784)",
+  "chore: promote dev into main for PWA sync recovery (#798)",
+]);
 export const REVERSE_INTEGRATION_COMMIT_SUBJECT_PATTERN =
   /^(?:chore|fix): (?:merge main (?:back )?into dev(?: .*)?|reverse integrate (?:main|v\d+\.\d+\.\d+)(?: into dev| after v\d+\.\d+\.\d+| production release)?|backflow v\d+\.\d+\.\d+ main into dev|sync main(?: release artifacts)?(?: back)? into dev(?: .*)?)(?: \(#\d+\))?$/;
 
@@ -283,6 +287,7 @@ export function listMainBackflowDiffFiles({ devRef, mainRef, cwd }) {
         mainBlobId &&
         mainChange &&
         (PROMOTION_COMMIT_SUBJECT_PATTERN.test(mainChange.subject) ||
+          HISTORICAL_MAIN_PROMOTION_SUBJECTS.has(mainChange.subject) ||
           HISTORICAL_MAIN_BACKPORT_SUBJECTS.has(mainChange.subject)) &&
         blobExistsInHistory(devRef, filePath, mainBlobId, { cwd })
       ) {

--- a/scripts/release-promotion.test.mjs
+++ b/scripts/release-promotion.test.mjs
@@ -311,6 +311,30 @@ for (const subject of [
     assert.equal(result.status, 0);
     assert.match(result.stdout, /Main backflow is in sync/);
   });
+
+  test(`validate-main-backflow rejects novel content labeled as historical promotion ${subject}`, (t) => {
+    const cwd = makeTempRepo();
+    t.after(() => rmSync(cwd, { recursive: true, force: true }));
+
+    git(cwd, ["checkout", "main"]);
+    writeRepoFile(
+      cwd,
+      "packages/pwa/src/app.ts",
+      "export const value = 'main-only promotion content';\n",
+    );
+    commitAll(cwd, subject);
+    updateOriginRef(cwd, "main");
+
+    const result = runNode(VALIDATE_MAIN_BACKFLOW, [
+      `--cwd=${cwd}`,
+      "--dev-ref=origin/dev",
+      "--main-ref=origin/main",
+    ]);
+
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /Dev refresh needed/);
+    assert.match(result.stderr, /packages\/pwa\/src\/app\.ts/);
+  });
 }
 
 test("validate-main-backflow accepts a reviewed main backport already in dev history", (t) => {

--- a/scripts/release-promotion.test.mjs
+++ b/scripts/release-promotion.test.mjs
@@ -271,6 +271,48 @@ test("validate-main-backflow accepts the historical promote dev to main subject"
   assert.match(result.stdout, /Main backflow is in sync/);
 });
 
+for (const subject of [
+  "chore: promote dev into main for cloud conflict recovery (#784)",
+  "chore: promote dev into main for PWA sync recovery (#798)",
+]) {
+  test(`validate-main-backflow accepts reviewed historical promotion ${subject}`, (t) => {
+    const cwd = makeTempRepo();
+    t.after(() => rmSync(cwd, { recursive: true, force: true }));
+
+    git(cwd, ["checkout", "dev"]);
+    writeRepoFile(
+      cwd,
+      "packages/pwa/src/app.ts",
+      "export const value = 'promoted';\n",
+    );
+    commitAll(cwd, "dev feature");
+    updateOriginRef(cwd, "dev");
+
+    git(cwd, ["checkout", "main"]);
+    git(cwd, ["checkout", "dev", "--", "packages/pwa/src/app.ts"]);
+    commitAll(cwd, subject);
+    updateOriginRef(cwd, "main");
+
+    git(cwd, ["checkout", "dev"]);
+    writeRepoFile(
+      cwd,
+      "packages/pwa/src/app.ts",
+      "export const value = 'next dev change';\n",
+    );
+    commitAll(cwd, "next dev change");
+    updateOriginRef(cwd, "dev");
+
+    const result = runNode(VALIDATE_MAIN_BACKFLOW, [
+      `--cwd=${cwd}`,
+      "--dev-ref=origin/dev",
+      "--main-ref=origin/main",
+    ]);
+
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /Main backflow is in sync/);
+  });
+}
+
 test("validate-main-backflow accepts a reviewed main backport already in dev history", (t) => {
   const cwd = makeTempRepo();
   t.after(() => rmSync(cwd, { recursive: true, force: true }));


### PR DESCRIPTION
(AI Generated).

## Summary
- Treat the reviewed cloud-conflict promotion commits as known dev-origin history when checking main backflow.
- Keep rejecting main-only content unless its exact blob already exists in dev history.

## Testing
- node --test scripts/release-promotion.test.mjs
- npm run validate:feature
- node scripts/validate-main-backflow.mjs --dev-ref=HEAD --main-ref=origin/main