### PR TITLE
fix: remove registry test filesystem race

### DIFF
--- a/scripts/validate-host-automations.test.mjs
+++ b/scripts/validate-host-automations.test.mjs
@@ -2,7 +2,6 @@ import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
-  appendFileSync,
   chmodSync,
   closeSync,
   constants as fsConstants,
@@ -632,9 +631,18 @@ test("bounded project registry reads reject growth after the size snapshot", () 
   );
   try {
     const snapshotSize = fstatSync(descriptor).size;
-    appendFileSync(registryPath, " ");
+    const growthReader = (fd, buffer, offset, length, position) => {
+      if (position === snapshotSize) {
+        buffer[offset] = 0x20;
+        return 1;
+      }
+      return readSync(fd, buffer, offset, length, position);
+    };
     assert.throws(
-      () => readProjectRegistrySnapshot(descriptor, snapshotSize),
+      () =>
+        readProjectRegistrySnapshot(descriptor, snapshotSize, {
+          reader: growthReader,
+        }),
       /changed during its bounded read/,
     );
   } finally {
@@ -660,11 +668,17 @@ test("bounded project registry reads handle partial reads before probing growth"
       }),
       expected,
     );
-    appendFileSync(registryPath, " ");
+    const partialGrowthReader = (fd, buffer, offset, length, position) => {
+      if (position === snapshotSize) {
+        buffer[offset] = 0x20;
+        return 1;
+      }
+      return partialReader(fd, buffer, offset, length, position);
+    };
     assert.throws(
       () =>
         readProjectRegistrySnapshot(descriptor, snapshotSize, {
-          reader: partialReader,
+          reader: partialGrowthReader,
         }),
       /changed during its bounded read/,
     );


### PR DESCRIPTION
(AI Generated).

## Summary

- Replace both post-inspection registry file appends with injected one-byte growth readers.
- Preserve complete and partial-read coverage without mutating the inspected filesystem path.
- Keep the follow-up test-only and provider-neutral.

## Validation

- Two focused registry growth tests passed.
- The complete host automation test file passed 44 tests.
- The complete script suite passed 614 tests.
- Feature validation passed.
- The canonical provider-visible classifier returned no paths.