### PR TITLE
fix: enforce renderer recovery outcome guardrail

### DIFF
--- a/scripts/build-outcome-verdict.test.mjs
+++ b/scripts/build-outcome-verdict.test.mjs
@@ -88,6 +88,8 @@ function writeStoredSoak(
     workerInitCount = 0,
     workerIdleTerminationReasons = [],
     workerInitRecoveryCount = 0,
+    novelItemsNotPersistedCount = 0,
+    rendererRecoveryCount = 0,
     comparisonContext = {},
   },
 ) {
@@ -142,6 +144,19 @@ function writeStoredSoak(
       ...identity,
       event: "worker_init_recovery",
       tsMs: start + (index + 1) * 3_000,
+    })),
+    ...Array.from({ length: rendererRecoveryCount }, (_, index) => ({
+      ...identity,
+      event: "renderer_recovery_restart_requested",
+      tsMs: start + (index + 1) * 4_000,
+    })),
+    ...Array.from({ length: novelItemsNotPersistedCount }, (_, index) => ({
+      ...identity,
+      event: "scrape_outcome",
+      tsMs: end - 10_000 - index,
+      itemsExtracted: 5,
+      itemsNovel: 5,
+      itemsPersisted: 0,
     })),
     {
       ...identity,
@@ -810,6 +825,50 @@ test("worker init outcomes enforce the automatic memory-pressure guardrail", () 
       }),
     /lacks the registered app-memory-pressure-p95 measurement contract/,
   );
+});
+
+test("novel item persistence outcomes enforce the renderer recovery guardrail", () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "freed-scrape-guardrail-"));
+  const baseline = writeStoredSoak(root, {
+    name: "baseline",
+    start: Date.parse("2026-07-09T00:00:00.000Z"),
+    commitSha: "a".repeat(40),
+    version: "26.7.900-dev",
+    slopeMbPerHour: 4,
+    novelItemsNotPersistedCount: 2,
+  });
+  const current = writeStoredSoak(root, {
+    name: "current",
+    start: Date.parse("2026-07-10T00:00:00.000Z"),
+    commitSha: "b".repeat(40),
+    version: "26.7.1000-dev",
+    slopeMbPerHour: 4,
+    rendererRecoveryCount: 1,
+  });
+
+  const verdict = buildOutcomeVerdictFromArtifacts({
+    sourcePath: current.verdictPath,
+    sourceKind: "soak",
+    taskId: "youtube-capture-completion-timeout",
+    outcome: "regressed",
+    metric: "novel-items-not-persisted",
+    baselineReference: baseline.verdictPath,
+  });
+  assert.equal(verdict.effect.metric, "renderer-recovery-count");
+  assert.equal(verdict.effectAssessment.primaryAssessment, "effective");
+  assert.deepEqual(verdict.effectAssessment.guardrails, [
+    {
+      metric: "renderer-recovery-count",
+      before: 0,
+      after: 4,
+      delta: 4,
+      unit: "events/app-alive-day",
+      direction: "lower",
+      tolerance: 0.01,
+      assessment: "regressed",
+    },
+  ]);
+  assert.equal(verdict.status, "fail");
 });
 
 test("artifact identity survives the soak, canary, and outcome chain", () => {

--- a/scripts/lib/stability-metrics.mjs
+++ b/scripts/lib/stability-metrics.mjs
@@ -6,7 +6,7 @@
  * surfaces cannot quietly invent different definitions for the same symptom.
  */
 
-export const STABILITY_METRIC_REGISTRY_VERSION = 5;
+export const STABILITY_METRIC_REGISTRY_VERSION = 6;
 export const MIN_LIFECYCLE_CREDITED_APP_ALIVE_HOURS = 6;
 export const MIN_COMPARABLE_WINDOW_DURATION_RATIO = 0.8;
 export const MAX_COMPARABLE_WINDOW_DURATION_RATIO = 1.25;
@@ -317,6 +317,7 @@ export const STABILITY_METRICS = Object.freeze([
     }),
     target: Object.freeze({ kind: "max_count", value: 0 }),
     triageBucketId: "scrape-zero-persist",
+    outcomeGuardrailMetricIds: Object.freeze(["renderer-recovery-count"]),
     alarmNames: Object.freeze(["scrape_zero_persist"]),
     canaryMetrics: Object.freeze([]),
   }),

--- a/scripts/soak.test.mjs
+++ b/scripts/soak.test.mjs
@@ -2452,7 +2452,7 @@ test("buildVerdict produces a machine-readable verdict with real numbers", () =>
   assert.equal(verdict.schemaVersion, 1);
   assert.equal(verdict.windowStart, new Date(measurementStartMs).toISOString());
   assert.equal(verdict.windowEnd, new Date(measurementEndMs).toISOString());
-  assert.equal(verdict.metricRegistryVersion, 5);
+  assert.equal(verdict.metricRegistryVersion, 6);
   assert.equal(verdict.pass, true);
   assert.equal(verdict.status, "pass");
   assert.equal(verdict.failures, 0);

--- a/scripts/stability-metrics.test.mjs
+++ b/scripts/stability-metrics.test.mjs
@@ -14,7 +14,7 @@ import {
 } from "./lib/stability-metrics.mjs";
 
 test("the stability metric registry has unique ids and a version", () => {
-  assert.equal(STABILITY_METRIC_REGISTRY_VERSION, 5);
+  assert.equal(STABILITY_METRIC_REGISTRY_VERSION, 6);
   assert.equal(
     new Set(STABILITY_METRICS.map((metric) => metric.id)).size,
     STABILITY_METRICS.length,
@@ -147,6 +147,14 @@ test("worker soak, triage, and canary surfaces share one rate contract", () => {
     allowance: 128 * 1024 * 1024,
     direction: "lower",
   });
+});
+
+test("lost novel item outcomes guard against renderer recovery regression", () => {
+  const contract = metricContractForAssertion("scrape_zero_persist");
+
+  assert.deepEqual(contract.outcomeGuardrailMetricIds, [
+    "renderer-recovery-count",
+  ]);
 });
 
 test("provider-neutral lifecycle metrics route to their existing program buckets", () => {

--- a/scripts/stability-ops.test.mjs
+++ b/scripts/stability-ops.test.mjs
@@ -627,7 +627,7 @@ test("computeCanarySummary folds counters into per-release metrics", () => {
     bounds,
   );
   assert.equal(summary.version, "26.7.800");
-  assert.equal(summary.metricRegistryVersion, 5);
+  assert.equal(summary.metricRegistryVersion, 6);
   assert.equal(summary.spanHours, 6);
   assert.equal(summary.metrics.uploadsUnchangedPerHour, 2);
   assert.equal(summary.metrics.startupRepairUploadsPerHour, 0.17);

--- a/scripts/triage.test.mjs
+++ b/scripts/triage.test.mjs
@@ -58,7 +58,7 @@ function attributableAlarm(count, lastTsMs, evidence = []) {
 function validVerdict(assertions, windowEnd = NOW) {
   return {
     schemaVersion: 1,
-    metricRegistryVersion: 5,
+    metricRegistryVersion: 6,
     sourceHealth: { healthy: true },
     runtimeIdentity: {
       attributable: true,
@@ -179,7 +179,7 @@ function validCanaryRecord({
   });
   return {
     schemaVersion: 3,
-    metricRegistryVersion: 5,
+    metricRegistryVersion: 6,
     version,
     buildIdentity,
     runtimeIdentity,


### PR DESCRIPTION
(AI Generated).

## Summary

- bind `renderer-recovery-count` as an outcome guardrail for `novel-items-not-persisted`
- advance the stability metric registry from version 5 to version 6
- prove an outcome regresses when novel item persistence improves but renderer recoveries worsen
- use the existing stable lifecycle task `youtube-capture-completion-timeout` in the regression fixture

## Validation

- Node 24.14.1
- focused metric and outcome tests: 20 of 20 passed
- expanded affected suite: 132 of 132 passed
- script suite: 616 of 616 passed
- `npm run validate:feature`: passed
- main backflow validation: passed
- diff check: clean
- canonical provider classifier: no provider-visible paths

Remote tree `837fe64d081651b168a3b6541887c19f4e1ecaab` exactly matches the reviewed local candidate.