### PR TITLE
fix: show dev releases in changelog

### DIFF
--- a/.github/workflows/website-preview.yml
+++ b/.github/workflows/website-preview.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version-file: ".nvmrc"
           cache: "npm"

--- a/website/next.config.ts
+++ b/website/next.config.ts
@@ -9,9 +9,19 @@ const nextConfig: NextConfig = {
       process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY,
   },
 
-  // Configure redirects if needed
   async redirects() {
-    return [];
+    return [
+      {
+        source: "/changelog/all",
+        destination: "/changelog",
+        permanent: true,
+      },
+      {
+        source: "/changelog/all/:page",
+        destination: "/changelog/:page",
+        permanent: true,
+      },
+    ];
   },
 };
 

--- a/website/src/app/changelog/ChangelogContent.tsx
+++ b/website/src/app/changelog/ChangelogContent.tsx
@@ -61,7 +61,7 @@ function PaginationNav({
   smoothScrollOnNavigate?: boolean;
 }) {
   const router = useRouter();
-  const toggleHref = mode === "all" ? "/changelog" : "/changelog/all";
+  const toggleHref = mode === "all" ? "/changelog/prod" : "/changelog";
   const toggleLabel = mode === "all" ? "Hide dev releases" : "Show dev releases";
 
   return (

--- a/website/src/app/changelog/[page]/page.tsx
+++ b/website/src/app/changelog/[page]/page.tsx
@@ -15,17 +15,17 @@ interface Props {
 }
 
 export function generateStaticParams(): Array<{ page: string }> {
-  return getChangelogPaginationStaticParams("production");
+  return getChangelogPaginationStaticParams("all");
 }
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { page } = await params;
-  return buildChangelogMetadata(parseChangelogPage(page, "production"));
+  return buildChangelogMetadata(parseChangelogPage(page, "all"), "all");
 }
 
 export default async function ChangelogPaginationPage({ params }: Props) {
   const { page } = await params;
-  const mode = "production";
+  const mode = "all";
   const currentPage = parseChangelogPage(page, mode);
 
   return (

--- a/website/src/app/changelog/page.tsx
+++ b/website/src/app/changelog/page.tsx
@@ -12,7 +12,7 @@ export const metadata: Metadata = buildChangelogMetadata(1);
 
 export default function ChangelogPage() {
   const currentPage = 1;
-  const mode = "production";
+  const mode = "all";
 
   return (
     <ChangelogContent

--- a/website/src/app/changelog/pagination.ts
+++ b/website/src/app/changelog/pagination.ts
@@ -23,7 +23,7 @@ export function getLatestChangelogTagName(
 }
 
 export function getChangelogTotalPages(
-  mode: ChangelogMode = "production",
+  mode: ChangelogMode = "all",
 ): number {
   return Math.max(
     1,
@@ -33,16 +33,16 @@ export function getChangelogTotalPages(
 
 export function getChangelogPageHref(
   page: number,
-  mode: ChangelogMode = "production",
+  mode: ChangelogMode = "all",
 ): string {
-  const basePath = mode === "all" ? "/changelog/all" : "/changelog";
+  const basePath = mode === "all" ? "/changelog" : "/changelog/prod";
   const pathPage = page.toLocaleString("en-US", { useGrouping: false });
   return page <= 1 ? basePath : `${basePath}/${pathPage}`;
 }
 
 export function parseChangelogPage(
   value: string | number | undefined,
-  mode: ChangelogMode = "production",
+  mode: ChangelogMode = "all",
 ): number {
   const parsed =
     typeof value === "number" ? value : Number.parseInt(value ?? "1", 10);
@@ -61,12 +61,12 @@ export function parseChangelogPage(
 }
 
 export function getChangelogPageSlice(page: number): ParsedRelease[] {
-  return getChangelogPageSliceForMode(page, "production");
+  return getChangelogPageSliceForMode(page, "all");
 }
 
 export function getChangelogPageSliceForMode(
   page: number,
-  mode: ChangelogMode = "production",
+  mode: ChangelogMode = "all",
 ): ParsedRelease[] {
   const start = (page - 1) * CHANGELOG_PAGE_SIZE;
   return releasesForMode(mode).slice(start, start + CHANGELOG_PAGE_SIZE);
@@ -74,7 +74,7 @@ export function getChangelogPageSliceForMode(
 
 export function getChangelogPageRange(
   page: number,
-  mode: ChangelogMode = "production",
+  mode: ChangelogMode = "all",
 ): {
   start: number;
   end: number;
@@ -93,7 +93,7 @@ export function getChangelogPageRange(
 
 export function buildChangelogMetadata(
   page: number,
-  mode: ChangelogMode = "production",
+  mode: ChangelogMode = "all",
 ): Metadata {
   const pageSuffix = page > 1 ? `, page ${page.toLocaleString()}` : "";
   const title = "Changelog | Freed";
@@ -118,7 +118,7 @@ export function buildChangelogMetadata(
 }
 
 export function getChangelogPaginationStaticParams(
-  mode: ChangelogMode = "production",
+  mode: ChangelogMode = "all",
 ): Array<{ page: string }> {
   const totalPages = getChangelogTotalPages(mode);
 

--- a/website/src/app/changelog/prod/[page]/page.tsx
+++ b/website/src/app/changelog/prod/[page]/page.tsx
@@ -14,7 +14,7 @@ interface Props {
   params: Promise<{ page: string }>;
 }
 
-const mode = "all";
+const mode = "production";
 
 export function generateStaticParams(): Array<{ page: string }> {
   return getChangelogPaginationStaticParams(mode);
@@ -25,7 +25,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   return buildChangelogMetadata(parseChangelogPage(page, mode), mode);
 }
 
-export default async function AllChangelogPaginationPage({ params }: Props) {
+export default async function ProductionChangelogPaginationPage({
+  params,
+}: Props) {
   const { page } = await params;
   const currentPage = parseChangelogPage(page, mode);
 

--- a/website/src/app/changelog/prod/page.tsx
+++ b/website/src/app/changelog/prod/page.tsx
@@ -8,11 +8,11 @@ import {
   getChangelogTotalPages,
 } from "../pagination";
 
-const mode = "all";
+const mode = "production";
 
 export const metadata: Metadata = buildChangelogMetadata(1, mode);
 
-export default function AllChangelogPage() {
+export default function ProductionChangelogPage() {
   const currentPage = 1;
 
   return (

--- a/website/src/app/sitemap.ts
+++ b/website/src/app/sitemap.ts
@@ -1,6 +1,10 @@
 import type { MetadataRoute } from "next";
 import { posts } from "@/content";
-import { getChangelogTotalPages } from "./changelog/pagination";
+import {
+  getChangelogPageHref,
+  getChangelogTotalPages,
+  type ChangelogMode,
+} from "./changelog/pagination";
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const baseUrl = "https://freed.wtf";
@@ -32,6 +36,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.9,
     },
     {
+      url: `${baseUrl}/changelog/prod`,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 0.8,
+    },
+    {
       url: `${baseUrl}/updates`,
       lastModified: new Date(),
       changeFrequency: "weekly",
@@ -53,14 +63,18 @@ export default function sitemap(): MetadataRoute.Sitemap {
     priority: 0.7,
   }));
 
-  const changelogPages: MetadataRoute.Sitemap = Array.from(
-    { length: Math.max(0, getChangelogTotalPages() - 1) },
-    (_, index) => ({
-      url: `${baseUrl}/changelog/${(index + 2).toString()}`,
-      lastModified: new Date(),
-      changeFrequency: "weekly" as const,
-      priority: 0.7,
-    }),
+  const changelogPages: MetadataRoute.Sitemap = (
+    ["all", "production"] satisfies ChangelogMode[]
+  ).flatMap((mode) =>
+    Array.from(
+      { length: Math.max(0, getChangelogTotalPages(mode) - 1) },
+      (_, index) => ({
+        url: `${baseUrl}${getChangelogPageHref(index + 2, mode)}`,
+        lastModified: new Date(),
+        changeFrequency: "weekly" as const,
+        priority: 0.7,
+      }),
+    ),
   );
 
   return [...staticPages, ...blogPosts, ...changelogPages];

--- a/website/src/components/Navigation.tsx
+++ b/website/src/components/Navigation.tsx
@@ -43,7 +43,6 @@ const NAV_ITEMS = [
   { path: "/manifesto", label: "Manifesto" },
   { path: "/roadmap", label: "Roadmap" },
   { path: "/changelog", label: "Changelog" },
-  { path: "/updates", label: "Updates" },
 ];
 
 function isActive(itemPath: string, pathname: string): boolean {

--- a/website/src/content/changelog.generated.json
+++ b/website/src/content/changelog.generated.json
@@ -1,5 +1,161 @@
 [
   {
+    "version": "26.7.1501-dev",
+    "tagName": "v26.7.1501-dev",
+    "channel": "dev",
+    "date": "2026-07-15T10:55:05Z",
+    "deck": "Friends is now a theme-aware personal galaxy with native touch and trackpad navigation, tight identity constellations, and cosmic provider nebulae.",
+    "features": [
+      {
+        "text": "Explore Friends as a hardware-accelerated 3D galaxy where relationship importance controls depth, identities form tight constellations, and every starfield follows the active Freed theme"
+      },
+      {
+        "text": "Pan, zoom, and focus the galaxy with a mouse, trackpad, or midpoint-preserving iPhone pinch gestures while billboard labels stay visible and close to their stars"
+      },
+      {
+        "text": "Use the new Medium and Substack beta sources in Freed Desktop to capture essays, visible relationships, subscriptions, and activity through your signed-in sessions"
+      }
+    ],
+    "fixes": [
+      {
+        "text": "Friends selection now settles on the current person or account without stale atlas updates, while provider regions form spiral nebulae and identity links stay focused on the active constellation"
+      },
+      {
+        "text": "Facebook groups confirmed as left now stay removed from the source list"
+      },
+      {
+        "text": "Medium and Substack beta labels remain readable through 150% interface zoom, with their source menus still keyboard accessible"
+      },
+      {
+        "text": "YouTube followed-channel and subscription capture now reports bounded progress, cancels stale work, and closes hidden capture sessions when finished"
+      },
+      {
+        "text": "Security reports can now be submitted privately with redacted diagnostics and hardened fetched-content handling"
+      }
+    ],
+    "followUps": [],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.7.1501-dev",
+    "prNumbers": [],
+    "builds": [
+      "26.7.1501-dev"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.7.1501-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.7.1501-dev",
+        "channel": "dev"
+      }
+    ]
+  },
+  {
+    "version": "26.7.1200-dev",
+    "tagName": "v26.7.1200-dev",
+    "channel": "dev",
+    "date": "2026-07-12T22:27:00Z",
+    "deck": "YouTube now gets out of the way as soon as sign-in succeeds while your first subscription sync continues quietly.",
+    "features": [],
+    "fixes": [
+      {
+        "text": "The YouTube login window now hides as soon as authentication is confirmed while the first subscription sync continues in the background"
+      },
+      {
+        "text": "Later YouTube syncs and Freed Offline playlist actions reuse the authenticated session without showing the provider window"
+      }
+    ],
+    "followUps": [],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.7.1200-dev",
+    "prNumbers": [],
+    "builds": [
+      "26.7.1200-dev"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.7.1200-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.7.1200-dev",
+        "channel": "dev"
+      }
+    ]
+  },
+  {
+    "version": "26.7.1000-dev",
+    "tagName": "v26.7.1000-dev",
+    "channel": "dev",
+    "date": "2026-07-11T02:14:08Z",
+    "deck": "YouTube joins Freed with a focused study feed, exact-video playback, and a private playlist for YouTube Premium downloads. This build also refines display scaling and command search stability.",
+    "features": [
+      {
+        "text": "Connect YouTube in Freed Desktop through your signed-in website session to capture followed channels and recent long-form Subscriptions videos"
+      },
+      {
+        "text": "Keep Shorts and Reels out of the captured study feed, watch a selected video in Focus Mode, or open that same video directly in YouTube"
+      },
+      {
+        "text": "Create or reuse a private Freed Offline playlist from selected saved videos, then open it in YouTube so Premium subscribers can download it on their device"
+      }
+    ],
+    "fixes": [
+      {
+        "text": "Display scaling now uses a practical 75% to 200% range and keeps the sidebar, toolbar, and quick settings stable while the scale changes"
+      },
+      {
+        "text": "Command search clears delayed blur work when it is refocused or closed, preventing stale updates after navigation"
+      }
+    ],
+    "followUps": [
+      {
+        "text": "Large offline audio and video packages remain future work; this build hands offline downloads to YouTube Premium through the private playlist"
+      }
+    ],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.7.1000-dev",
+    "prNumbers": [],
+    "builds": [
+      "26.7.1000-dev"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.7.1000-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.7.1000-dev",
+        "channel": "dev"
+      }
+    ]
+  },
+  {
+    "version": "26.7.900-dev",
+    "tagName": "v26.7.900-dev",
+    "channel": "dev",
+    "date": "2026-07-09T17:13:45Z",
+    "deck": "The desktop cloud-sync upload loop is broken for good (stability P1-01): an idle machine with cloud sync connected no longer re-uploads the same unchanged document over and over. This build also lands the Wave-2 stability toolchain and interface zoom controls.",
+    "features": [
+      {
+        "text": "Desktop cloud sync no longer loops on idle: a mutation filter and document-heads guard stop the upload to merge-back to re-upload echo (stability P1-01)"
+      },
+      {
+        "text": "Interface zoom controls"
+      },
+      {
+        "text": "Stability observability toolchain: alarms, soak verdicts, canary regressions, and red CI fold into ranked task files (W2-02), backed by per-release canary summaries, an offline watchdog-decision replay, and a metric-driven release bisector (W2-03)"
+      }
+    ],
+    "fixes": [],
+    "followUps": [
+      {
+        "text": "P1-01 is the first cloud-loop damper; the PWA-side and GDrive self-write dampers follow, one per soak cycle"
+      }
+    ],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.7.900-dev",
+    "prNumbers": [],
+    "builds": [
+      "26.7.900-dev"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.7.900-dev",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.7.900-dev",
+        "channel": "dev"
+      }
+    ]
+  },
+  {
     "version": "26.7.800-dev",
     "tagName": "v26.7.800-dev",
     "channel": "dev",


### PR DESCRIPTION
(AI Generated).

## Summary
- Remove Updates from the top navigation while keeping the page available elsewhere.
- Show dev releases by default at `/changelog` and keep production releases at `/changelog/prod`.
- Redirect legacy `/changelog/all` URLs and refresh the current dev release snapshot.
- Pin the website workflow actions to the repository-approved commit SHAs so GitHub can start the required build.

## Testing
- `cd website && PATH=/Users/aubreyfalconer/.nvm/versions/node/v24.14.1/bin:$PATH npm run build`
- Verified the local preview navigation, default and production release visibility, toggle destinations, pagination routes, and legacy redirects.
- Confirmed the original GitHub Actions startup failure was caused by unpinned action refs, then applied the governed pins already used on `dev`.