### PR TITLE
chore: prepare v26.7.1900-dev

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freed/desktop",
   "private": true,
-  "version": "26.7.1501",
+  "version": "26.7.1900",
   "type": "module",
   "scripts": {
     "dev": "node ../../node_modules/vite/bin/vite.js",

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -1420,7 +1420,7 @@ dependencies = [
 
 [[package]]
 name = "freed-desktop"
-version = "26.7.1501"
+version = "26.7.1900"
 dependencies = [
  "base64 0.22.1",
  "criterion",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freed-desktop"
-version = "26.7.1501"
+version = "26.7.1900"
 description = "Freed Desktop - Escape algorithmic manipulation"
 authors = ["Freed"]
 edition = "2021"

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Freed",
-  "version": "26.7.1501",
+  "version": "26.7.1900",
   "identifier": "wtf.freed.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freed/pwa",
   "private": true,
-  "version": "26.7.1501",
+  "version": "26.7.1900",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/release-notes/daily/dev/26.7.19.json
+++ b/release-notes/daily/dev/26.7.19.json
@@ -1,0 +1,14 @@
+{
+  "channel": "dev",
+  "dayKey": "26.7.19",
+  "date": "2026-07-19",
+  "preferredDeck": null,
+  "editorialGuidance": [
+    "Keep the tone concise, professional, and specific.",
+    "Lead with user-facing outcomes, shipping milestones, trust wins, and installability improvements.",
+    "Demote internal cleanup unless it clearly changes the shipped product."
+  ],
+  "pinnedHighlights": [],
+  "editorialNotes": [],
+  "updatedAt": "2026-07-19T11:12:09.841Z"
+}

--- a/release-notes/daily/dev/26.7.19.json
+++ b/release-notes/daily/dev/26.7.19.json
@@ -2,13 +2,17 @@
   "channel": "dev",
   "dayKey": "26.7.19",
   "date": "2026-07-19",
-  "preferredDeck": null,
+  "preferredDeck": "Explore a fluid, fully accelerated Friends Galaxy with theme-aware cosmic fields, intuitive touch and trackpad navigation, and stronger local reliability.",
   "editorialGuidance": [
     "Keep the tone concise, professional, and specific.",
     "Lead with user-facing outcomes, shipping milestones, trust wins, and installability improvements.",
     "Demote internal cleanup unless it clearly changes the shipped product."
   ],
-  "pinnedHighlights": [],
+  "pinnedHighlights": [
+    "Explore friends, identities, and accounts across a fully GPU-accelerated galactic plane.",
+    "Navigate with inertial touch, Safari, and Mac trackpad gestures while labels remain visible.",
+    "Pin identities and link accounts from searchable node context menus."
+  ],
   "editorialNotes": [],
   "updatedAt": "2026-07-19T11:12:09.841Z"
 }

--- a/release-notes/releases/v26.7.1900-dev.json
+++ b/release-notes/releases/v26.7.1900-dev.json
@@ -1,0 +1,57 @@
+{
+  "tag": "v26.7.1900-dev",
+  "version": "26.7.1900-dev",
+  "channel": "dev",
+  "dayKey": "26.7.19",
+  "approved": false,
+  "editorialNotes": [],
+  "generatedAt": "2026-07-19T11:12:09.841Z",
+  "model": "heuristic",
+  "source": {
+    "channel": "dev",
+    "previousPublishedTag": "v26.7.1501-dev",
+    "previousPublishedDayTag": "v26.7.1501-dev",
+    "compareRef": "HEAD",
+    "productCommitSha": "9813bd3d33d76e8887929cf811d6c9aa2b300000",
+    "promotedDevCommitSha": null,
+    "isLatestOfDay": true,
+    "sameDayTagsIncluded": [
+      "v26.7.1900-dev"
+    ],
+    "relatedBuildTags": [
+      "v26.7.1900-dev"
+    ],
+    "prNumbers": [
+      1030,
+      1031,
+      1032,
+      1033,
+      1036,
+      1037,
+      1039
+    ],
+    "commitSubjects": [
+      "feat: ship the next-generation Friends Galaxy (#1039)",
+      "fix: isolate local AI health notifications (#1037)",
+      "fix: serialize runtime health writes (#1036)",
+      "fix: count renderer recovery sequences",
+      "fix: enforce renderer recovery outcome guardrail",
+      "fix: remove registry test filesystem race (#1033)",
+      "fix: harden automation host validation (#1032)",
+      "fix: recognize historical cloud promotions (#1031)",
+      "fix: align Facebook group regression with local state (#1030)",
+      "fix: enforce device-local state boundaries"
+    ]
+  },
+  "release": {
+    "deck": "The next-generation Friends Galaxy, recognize historical cloud promotions, and enforce device-local state boundaries",
+    "features": [
+      "The next-generation Friends Galaxy"
+    ],
+    "fixes": [
+      "Align Facebook group regression with local state"
+    ],
+    "followUps": []
+  },
+  "releaseBody": "(AI Generated).\n\n## Freed v26.7.1900-dev\n\nThe next-generation Friends Galaxy, recognize historical cloud promotions, and enforce device-local state boundaries\n\n### Features\n\n- The next-generation Friends Galaxy\n\n### Fixes\n\n- Align Facebook group regression with local state\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+}

--- a/release-notes/releases/v26.7.1900-dev.json
+++ b/release-notes/releases/v26.7.1900-dev.json
@@ -3,7 +3,7 @@
   "version": "26.7.1900-dev",
   "channel": "dev",
   "dayKey": "26.7.19",
-  "approved": false,
+  "approved": true,
   "editorialNotes": [],
   "generatedAt": "2026-07-19T11:12:09.841Z",
   "model": "heuristic",
@@ -44,14 +44,18 @@
     ]
   },
   "release": {
-    "deck": "The next-generation Friends Galaxy, recognize historical cloud promotions, and enforce device-local state boundaries",
+    "deck": "Explore a fluid, fully accelerated Friends Galaxy with theme-aware cosmic fields, intuitive touch and trackpad navigation, and stronger local reliability.",
     "features": [
-      "The next-generation Friends Galaxy"
+      "Explore friends, identities, and accounts across a fully GPU-accelerated galactic plane, with relationship prominence mapped to depth, gentle parallax, themed nebula fields, and tightly organized provider constellations.",
+      "Pan, throw, and zoom with one-finger touch, multi-touch pinch, Safari gestures, or a Mac trackpad. Inertial movement, a directional zoom ceiling, and stable billboard labels keep navigation legible.",
+      "Use a node context menu to pin identities or link accounts through a searchable person picker, with accessible keyboard controls and a dedicated mobile Details view."
     ],
     "fixes": [
-      "Align Facebook group regression with local state"
+      "Keep Friends labels, stars, and identity details resident while the camera moves, including during live data updates and WebGL2 recovery.",
+      "Strengthen device-local state boundaries, runtime health persistence, renderer recovery reporting, and local AI health isolation.",
+      "Align Facebook group removal checks with the current device-local state model."
     ],
     "followUps": []
   },
-  "releaseBody": "(AI Generated).\n\n## Freed v26.7.1900-dev\n\nThe next-generation Friends Galaxy, recognize historical cloud promotions, and enforce device-local state boundaries\n\n### Features\n\n- The next-generation Friends Galaxy\n\n### Fixes\n\n- Align Facebook group regression with local state\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+  "releaseBody": "(AI Generated).\n\n## Freed v26.7.1900-dev\n\nExplore a fluid, fully accelerated Friends Galaxy with theme-aware cosmic fields, intuitive touch and trackpad navigation, and stronger local reliability.\n\n### Features\n\n- Explore friends, identities, and accounts across a fully GPU-accelerated galactic plane, with relationship prominence mapped to depth, gentle parallax, themed nebula fields, and tightly organized provider constellations.\n- Pan, throw, and zoom with one-finger touch, multi-touch pinch, Safari gestures, or a Mac trackpad. Inertial movement, a directional zoom ceiling, and stable billboard labels keep navigation legible.\n- Use a node context menu to pin identities or link accounts through a searchable person picker, with accessible keyboard controls and a dedicated mobile Details view.\n\n### Fixes\n\n- Keep Friends labels, stars, and identity details resident while the camera moves, including during live data updates and WebGL2 recovery.\n- Strengthen device-local state boundaries, runtime health persistence, renderer recovery reporting, and local AI health isolation.\n- Align Facebook group removal checks with the current device-local state model.\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
 }

--- a/release-notes/releases/v26.7.1900-dev.md
+++ b/release-notes/releases/v26.7.1900-dev.md
@@ -1,0 +1,21 @@
+(AI Generated).
+
+## Freed v26.7.1900-dev
+
+The next-generation Friends Galaxy, recognize historical cloud promotions, and enforce device-local state boundaries
+
+### Features
+
+- The next-generation Friends Galaxy
+
+### Fixes
+
+- Align Facebook group regression with local state
+
+### Downloads
+
+**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  
+**Windows:** `.exe` (NSIS installer)  
+**Linux:** `.AppImage`  
+
+> macOS downloads are signed and notarized for normal Gatekeeper installation.

--- a/release-notes/releases/v26.7.1900-dev.md
+++ b/release-notes/releases/v26.7.1900-dev.md
@@ -2,15 +2,19 @@
 
 ## Freed v26.7.1900-dev
 
-The next-generation Friends Galaxy, recognize historical cloud promotions, and enforce device-local state boundaries
+Explore a fluid, fully accelerated Friends Galaxy with theme-aware cosmic fields, intuitive touch and trackpad navigation, and stronger local reliability.
 
 ### Features
 
-- The next-generation Friends Galaxy
+- Explore friends, identities, and accounts across a fully GPU-accelerated galactic plane, with relationship prominence mapped to depth, gentle parallax, themed nebula fields, and tightly organized provider constellations.
+- Pan, throw, and zoom with one-finger touch, multi-touch pinch, Safari gestures, or a Mac trackpad. Inertial movement, a directional zoom ceiling, and stable billboard labels keep navigation legible.
+- Use a node context menu to pin identities or link accounts through a searchable person picker, with accessible keyboard controls and a dedicated mobile Details view.
 
 ### Fixes
 
-- Align Facebook group regression with local state
+- Keep Friends labels, stars, and identity details resident while the camera moves, including during live data updates and WebGL2 recovery.
+- Strengthen device-local state boundaries, runtime health persistence, renderer recovery reporting, and local AI health isolation.
+- Align Facebook group removal checks with the current device-local state model.
 
 ### Downloads
 


### PR DESCRIPTION
(AI Generated).

## Summary
- Prepare the v26.7.1900-dev release from exact product commit 9813bd3d33d76e8887929cf811d6c9aa2b300000.
- Publish the next-generation Friends Galaxy with fluid touch and trackpad navigation, themed cosmic fields, context linking, and local reliability fixes.
- Approve release notes and bind all versioned artifacts to the reviewed dev source receipt.

## Testing
- Pinned Node 24.14.1 npm run validate:feature
- PWA and Freed Desktop production builds
- 396 PWA tests, 16 PWA performance tests, 834 Desktop tests, and 9 smoke workflows
- Native Rust lint and 158 native tests
- Release receipt and release-note artifact validation