### PR TITLE
fix: recover automation actors and production promotion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
         run: |
           node scripts/validate-main-pr.mjs \
             --base-ref="origin/${{ github.base_ref }}" \
-            --head-ref=HEAD \
+            --head-ref="${{ github.event.pull_request.head.sha }}" \
             --head-branch="${{ github.head_ref }}"
 
   feature:

--- a/scripts/automation-actor-host.swift
+++ b/scripts/automation-actor-host.swift
@@ -388,6 +388,7 @@ private struct ControlResult: Decodable {
   let acquired: Bool
   let takeover: Bool
   let credentialUpgrade: Bool
+  let recovered: Bool?
   let lease: ControlLease
 }
 
@@ -672,34 +673,38 @@ private struct ProcessControlInvoker: ControlInvoker {
         ? "2026-07-13T12:30:00.001Z"
         : "2026-07-13T12:30:00.000Z"
       let token = mode == "short-token" ? "short" : requestedToken
+      var result: [String: Any] = [
+        "acquired": true,
+        "takeover": false,
+        "credentialUpgrade": false,
+        "lease": [
+          "schemaVersion": 1,
+          "name": binding.leaseName,
+          "owner": binding.actor,
+          "token": token,
+          "observerAuthority": actorLeaseAuthorities[binding.actor]!.observer,
+          "providerAuthority": actorLeaseAuthorities[binding.actor]!.provider,
+          "credentialKind": "trusted-launcher-channel",
+          "launcherSha256": binding.launcherSha256,
+          "actorRuntimeDigest": runtimeDigest(binding),
+          "launcherChannelProtocol": channelProtocol,
+          "launcherAttestationSha256": TEST_LAUNCHER_ATTESTATION_SHA256,
+          "launcherSessionId": TEST_LAUNCHER_SESSION_ID,
+          "acquiredAt": acquiredAt,
+          "heartbeatAt": acquiredAt,
+          "expiresAt": expiresAt,
+          "ttlMs": leaseLifetimeMilliseconds,
+        ],
+      ]
+      if mode == "response-loss-once", acquireAttempts > 1 {
+        result["recovered"] = true
+      }
       let payload: [String: Any] = [
         "ok": true,
         "schemaVersion": 1,
         "action": "lease.acquire",
         "stateRoot": binding.stateRoot,
-        "result": [
-          "acquired": true,
-          "takeover": false,
-          "credentialUpgrade": false,
-          "lease": [
-            "schemaVersion": 1,
-            "name": binding.leaseName,
-            "owner": binding.actor,
-            "token": token,
-            "observerAuthority": actorLeaseAuthorities[binding.actor]!.observer,
-            "providerAuthority": actorLeaseAuthorities[binding.actor]!.provider,
-            "credentialKind": "trusted-launcher-channel",
-            "launcherSha256": binding.launcherSha256,
-            "actorRuntimeDigest": runtimeDigest(binding),
-            "launcherChannelProtocol": channelProtocol,
-            "launcherAttestationSha256": TEST_LAUNCHER_ATTESTATION_SHA256,
-            "launcherSessionId": TEST_LAUNCHER_SESSION_ID,
-            "acquiredAt": acquiredAt,
-            "heartbeatAt": acquiredAt,
-            "expiresAt": expiresAt,
-            "ttlMs": leaseLifetimeMilliseconds,
-          ],
-        ],
+        "result": result,
       ]
       return try JSONSerialization.data(withJSONObject: payload)
     }
@@ -2242,6 +2247,10 @@ private func validateLeaseResponse(
       [
         Set(["acquired", "credentialUpgrade", "lease", "takeover"]),
         Set(["acquired", "credentialUpgrade", "lease", "previous", "takeover"]),
+        Set(["acquired", "credentialUpgrade", "lease", "recovered", "takeover"]),
+        Set([
+          "acquired", "credentialUpgrade", "lease", "previous", "recovered", "takeover",
+        ]),
       ].contains(Set(result.keys)),
       let lease = result["lease"] as? [String: Any],
       Set(lease.keys) == [
@@ -2269,12 +2278,15 @@ private func validateLeaseResponse(
   }
   let lease = response.result.lease
   let hasPrevious = rawResult["previous"] != nil
+  let hasRecovered = rawResult["recovered"] != nil
   guard response.ok,
     rawEnvelope["ok"] as? Bool == true,
     rawResult["acquired"] as? Bool == true,
     rawResult["takeover"] as? Bool == response.result.takeover,
     rawResult["credentialUpgrade"] as? Bool == response.result.credentialUpgrade,
     hasPrevious == response.result.takeover,
+    (!hasRecovered && response.result.recovered == nil) ||
+      (rawResult["recovered"] as? Bool == true && response.result.recovered == true),
     rawLease["schemaVersion"] as? Int == 1,
     response.schemaVersion == 1,
     response.action == "lease.acquire",

--- a/scripts/automation-control.test.mjs
+++ b/scripts/automation-control.test.mjs
@@ -104,56 +104,19 @@ import {
   providerApprovalAuthorizationDigest,
   validateProviderRiskApproval,
 } from "./lib/provider-visible-paths.mjs";
+import {
+  ACTOR_LAUNCHER_CHANNEL_PROTOCOL,
+  TEST_ACTOR_RUNTIME_DIGEST,
+  TEST_LAUNCHER_ATTESTATION_SHA256,
+  TEST_LAUNCHER_SESSION_ID,
+  TEST_LAUNCHER_SHA256,
+  TRUSTED_ACTOR_CONTROL_MODULE_URL,
+  acquireGeneralActorLeaseForTest,
+} from "./test-helpers/trusted-actor-lease.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CLI_PATH = path.join(__dirname, "automation-control.mjs");
 const ACTOR_CONTROL_PATH = path.join(__dirname, "automation-actor-control.mjs");
-const ACTOR_LAUNCHER_CHANNEL_PROTOCOL = "freed-actor-launcher-channel-v1";
-const TEST_LAUNCHER_SHA256 = "a".repeat(64);
-const TEST_ACTOR_RUNTIME_DIGEST = "b".repeat(64);
-const TEST_LAUNCHER_ATTESTATION_SHA256 = "c".repeat(64);
-const TEST_LAUNCHER_SESSION_ID = "d".repeat(64);
-
-const internalControlRoot = mkdtempSync(
-  path.join(os.tmpdir(), "freed-automation-control-internal-"),
-);
-cpSync(path.join(__dirname, "lib"), internalControlRoot, { recursive: true });
-const internalControlPath = path.join(
-  internalControlRoot,
-  "automation-control.mjs",
-);
-appendFileSync(
-  internalControlPath,
-  `
-export function acquireGeneralActorLeaseForTest(options) {
-  const {
-    actorCredentialToken: _retiredCredential,
-    launcherAttestationSha256 = "c".repeat(64),
-    launcherSessionId = "d".repeat(64),
-    ...leaseOptions
-  } = options;
-  return acquireLeaseAuthorized({
-    ...leaseOptions,
-    trustedLauncherAuthorization: {
-      marker: TRUSTED_LAUNCHER_AUTHORIZATION,
-      launcherSha256: "a".repeat(64),
-      actorRuntimeDigest: "b".repeat(64),
-      launcherChannelProtocol: ACTOR_LAUNCHER_CHANNEL_PROTOCOL,
-      launcherAttestationSha256,
-      launcherSessionId,
-      leaseOperationId: leaseOptions.operationId,
-      leaseTokenSha256: secretDigest(leaseOptions.token),
-    },
-  });
-}
-`,
-);
-const { acquireGeneralActorLeaseForTest } = await import(
-  pathToFileURL(internalControlPath).href
-);
-process.once("exit", () => {
-  rmSync(internalControlRoot, { recursive: true, force: true });
-});
 
 function acquireLeaseLive(options) {
   const policy = AUTOMATION_ACTOR_POLICIES[options.owner];
@@ -2906,7 +2869,7 @@ test("release and replacement wait until the authorized mutation scope commits",
   const replacementToken = `replacement-${"y".repeat(32)}`;
   const releaseOperationId = "91".repeat(32);
   const acquireOperationId = "92".repeat(32);
-  const moduleUrl = pathToFileURL(internalControlPath).href;
+  const moduleUrl = TRUSTED_ACTOR_CONTROL_MODULE_URL;
   const maxLeaseLifetimeMs =
     AUTOMATION_ACTOR_POLICIES[actor].maxLeaseLifetimeMs;
   let contender;
@@ -8300,6 +8263,23 @@ test("shared outcome history enforces exact records, evidence, ledger identity, 
     events.push(finalized);
     return { events, heartbeat, finalized };
   };
+  const canonicalLeaseRelease = (timestamp) => ({
+    schemaVersion: 1,
+    eventId: `lease:${createHash("sha256")
+      .update(`release-event:${timestamp}`)
+      .digest("hex")}`,
+    type: "lease_released",
+    ts: timestamp,
+    actor: "freed-scaffolding-maintainer",
+    leaseName:
+      AUTOMATION_ACTOR_POLICIES["freed-scaffolding-maintainer"].leaseName,
+    data: {
+      expired: false,
+      requestDigest: createHash("sha256")
+        .update(`release-request:${timestamp}`)
+        .digest("hex"),
+    },
+  });
 
   await t.test(
     "reconstructs one canonical heartbeat for outcome recording and finalization",
@@ -8322,6 +8302,8 @@ test("shared outcome history enforces exact records, evidence, ledger identity, 
     "noncanonical heartbeat",
     "heartbeat at prior expiry",
     "heartbeat beyond absolute lifetime",
+    "outcome after release without reacquire",
+    "finalization after release without reacquire",
   ]) {
     await t.test(`rejects ${variant} in continuous outcome history`, () => {
       const fixture = heartbeatExtendedHistory();
@@ -8348,13 +8330,51 @@ test("shared outcome history enforces exact records, evidence, ledger identity, 
         fixture.heartbeat.ts = fixture.heartbeat.ts.replace(/Z$/, "+00:00");
       } else if (variant === "heartbeat at prior expiry") {
         fixture.heartbeat.ts = "2026-07-19T12:00:02.500Z";
-      } else {
+      } else if (variant === "heartbeat beyond absolute lifetime") {
         fixture.heartbeat.data.expiresAt = "2026-07-19T12:30:00.001Z";
+      } else if (variant === "outcome after release without reacquire") {
+        const outcomeIndex = fixture.events.indexOf(outcome);
+        assert.notEqual(outcomeIndex, -1);
+        fixture.events.splice(
+          outcomeIndex,
+          0,
+          canonicalLeaseRelease("2026-07-19T12:00:02.750Z"),
+        );
+        fixture.events.splice(fixture.events.indexOf(fixture.finalized), 1);
+      } else {
+        const finalizedIndex = fixture.events.indexOf(fixture.finalized);
+        assert.notEqual(finalizedIndex, -1);
+        fixture.events.splice(
+          finalizedIndex,
+          0,
+          canonicalLeaseRelease("2026-07-19T12:00:03.250Z"),
+        );
       }
       const inspection = inspectExactOutcomeControlHistory(fixture.events, {
         ledgerPath,
       });
       assert.equal(inspection.healthy, false);
+      if (variant === "outcome after release without reacquire") {
+        assert.equal(
+          inspection.leaseHistoryHealthy,
+          true,
+          inspection.leaseHistoryIssues.join("\n"),
+        );
+        assert.match(
+          inspection.issues.join("\n"),
+          /has no exact preceding canonical outcome transition/,
+        );
+      } else if (variant === "finalization after release without reacquire") {
+        assert.equal(
+          inspection.leaseHistoryHealthy,
+          true,
+          inspection.leaseHistoryIssues.join("\n"),
+        );
+        assert.match(
+          inspection.issues.join("\n"),
+          /is not the exact completion of its task outcome reservation/,
+        );
+      }
     });
   }
 

--- a/scripts/automation-kernel-guard-cutover.test.mjs
+++ b/scripts/automation-kernel-guard-cutover.test.mjs
@@ -42,7 +42,10 @@ import {
   writeAutomationKernelGuardCutoverPlan,
   writeAutomationKernelGuardCutoverSupersedePlan,
 } from "./lib/automation-kernel-guard-cutover.mjs";
-import { withKernelFileGuard } from "./lib/automation-control.mjs";
+import {
+  inspectLeaseCleanupArchiveCapacity,
+  withKernelFileGuard,
+} from "./lib/automation-control.mjs";
 
 const TASK_ID = "authenticated-essay-capture-pr-642";
 const CLI_PATH = path.join(
@@ -220,6 +223,32 @@ function planFixture(fixture) {
   writeAutomationKernelGuardCutoverPlan(fixture.planFile, plan);
   writeConfirmation(fixture, plan);
   return plan;
+}
+
+function expectedLeaseRuntimeDirectories(stateRoot) {
+  const leases = path.join(stateRoot, "control", "leases");
+  const transactions = path.join(leases, ".transactions");
+  const receipts = path.join(leases, ".transaction-receipts");
+  return [
+    transactions,
+    receipts,
+    path.join(leases, ".lease-state-quarantine"),
+    path.join(transactions, ".lease-cleanup-quarantine"),
+    path.join(receipts, ".lease-cleanup-quarantine"),
+  ];
+}
+
+function assertLeaseRuntimeReady(stateRoot) {
+  for (const directoryPath of expectedLeaseRuntimeDirectories(stateRoot)) {
+    const stats = lstatSync(directoryPath);
+    assert.equal(stats.isDirectory(), true, directoryPath);
+    assert.equal(stats.isSymbolicLink(), false, directoryPath);
+    assert.equal(stats.mode & 0o7777, 0o700, directoryPath);
+  }
+  const capacity = inspectLeaseCleanupArchiveCapacity(stateRoot, {
+    reservation: { entries: 8, bytes: 8 * 1024 * 1024 },
+  });
+  assert.equal(capacity.ready, true, capacity.problems.join("\n"));
 }
 
 function supersedePlanFixture(fixture, plan) {
@@ -2335,7 +2364,6 @@ test("receipt-prepared recovery no longer depends on the source confirmation", (
 
   assert.equal(result.changed, true);
   assert.equal(transaction.authorizations.length, 2);
-  assert.equal(transaction.authorizations.length, 2);
   assert.equal(
     transaction.authorizations.at(-1).confirmationId,
     "kernel-cutover-test",
@@ -2346,6 +2374,59 @@ test("receipt-prepared recovery no longer depends on the source confirmation", (
     transaction.authorizations.at(-1).validatedAt,
   );
   assert.equal(inspection.ready, true, inspection.problems.join("\n"));
+  assertLeaseRuntimeReady(fixture.stateRoot);
+});
+
+test("receipt-prepared recovery completes a partially durable lease runtime scaffold without the source confirmation", (t) => {
+  const fixture = createFixture(t);
+  const plan = planFixture(fixture);
+  const paths = automationKernelGuardCutoverPaths(fixture.stateRoot);
+  const stopPath = path.join(
+    fixture.controlRoot,
+    "leases",
+    ".transaction-receipts",
+  );
+  assert.throws(
+    () =>
+      applyAutomationKernelGuardCutover({
+        plan,
+        ownerConfirmationFile: fixture.confirmationFile,
+        checkpoint(name, details) {
+          if (
+            name === "lease-runtime-directory-durable" &&
+            details?.directoryPath === stopPath
+          ) {
+            throw new Error("stop during lease runtime initialization");
+          }
+        },
+      }),
+    /stop during lease runtime initialization/,
+  );
+  assert.equal(existsSync(paths.globalReceipt), false);
+  assert.equal(existsSync(stopPath), true);
+  assert.equal(
+    existsSync(
+      path.join(
+        fixture.controlRoot,
+        "leases",
+        ".lease-state-quarantine",
+      ),
+    ),
+    false,
+  );
+  unlinkSync(fixture.confirmationFile);
+
+  const result = applyAutomationKernelGuardCutover({
+    plan,
+    ownerConfirmationFile: fixture.confirmationFile,
+  });
+
+  assert.equal(result.changed, true);
+  assertLeaseRuntimeReady(fixture.stateRoot);
+  assert.equal(
+    inspectAutomationKernelGuardCutover(fixture.stateRoot).ready,
+    true,
+  );
 });
 
 test("receipt-prepared activation rejects exact protected-state drift and residue", async (t) => {
@@ -2397,6 +2478,16 @@ test("receipt-prepared activation rejects exact protected-state drift and residu
       name: "terminal quarantine residue",
       mutate({ artifactDirectory }) {
         privateDirectory(path.join(artifactDirectory, ".recovery-quarantine"));
+      },
+    },
+    {
+      name: "foreign lease runtime entry",
+      mutate({ fixture }) {
+        writeFileSync(
+          path.join(fixture.controlRoot, "leases", "foreign.json"),
+          "{}\n",
+          { mode: 0o600 },
+        );
       },
     },
   ];

--- a/scripts/lib/automation-control.mjs
+++ b/scripts/lib/automation-control.mjs
@@ -3558,35 +3558,11 @@ function appendOutcomeLedgerRepairEventUnlocked(
 }
 
 function outcomeLedgerRepairAuthorizationFromOwnerAcquisition(event) {
-  const common = {
-    leaseName: event.leaseName,
-    leaseAcquiredAt: event.ts,
-    credentialKind: event.data?.credentialKind,
-  };
-  if (event.data?.credentialKind === "owner-signed-capability") {
-    return {
-      ...common,
-      ownerCapabilityId: event.data.ownerCapabilityId,
-      ownerCapabilityTaskId: event.data.ownerCapabilityTaskId,
-      ownerCapabilityIntentDigest: event.data.ownerCapabilityIntentDigest,
-    };
-  }
-  if (event.data?.credentialKind === "owner-confirmation") {
-    return {
-      ...common,
-      ownerConfirmationId: event.data.ownerConfirmationId,
-      ownerConfirmationTaskId: event.data.ownerConfirmationTaskId,
-      ownerConfirmationIntentDigest: event.data.ownerConfirmationIntentDigest,
-      ownerConfirmationDigest: event.data.ownerConfirmationDigest,
-      ownerConfirmationReference: event.data.ownerConfirmationReference,
-      ownerConfirmationApprovedBy: event.data.ownerConfirmationApprovedBy,
-      ownerConfirmationApprovalReference:
-        event.data.ownerConfirmationApprovalReference,
-      ownerConfirmationApprovedAt: event.data.ownerConfirmationApprovedAt,
-      ownerConfirmationExpiresAt: event.data.ownerConfirmationExpiresAt,
-    };
-  }
-  return null;
+  return ["owner-signed-capability", "owner-confirmation"].includes(
+    event?.data?.credentialKind,
+  )
+    ? taskAuthorizationProvenanceFromLeaseAcquisition(event)
+    : null;
 }
 
 function ownerAcquisitionMatchesOutcomeLedgerRepair(event, authorization) {
@@ -8410,6 +8386,80 @@ function canonicalTaskAuthorizationProvenance(
   });
 }
 
+function taskAuthorizationProvenanceFromLeaseAcquisition(event) {
+  const common = {
+    leaseName: event?.leaseName,
+    leaseAcquiredAt: event?.ts,
+    credentialKind: event?.data?.credentialKind,
+  };
+  if (event?.data?.credentialKind === "owner-signed-capability") {
+    return {
+      ...common,
+      ownerCapabilityId: event.data.ownerCapabilityId,
+      ownerCapabilityTaskId: event.data.ownerCapabilityTaskId,
+      ownerCapabilityIntentDigest: event.data.ownerCapabilityIntentDigest,
+    };
+  }
+  if (event?.data?.credentialKind === "owner-confirmation") {
+    return {
+      ...common,
+      ownerConfirmationId: event.data.ownerConfirmationId,
+      ownerConfirmationTaskId: event.data.ownerConfirmationTaskId,
+      ownerConfirmationIntentDigest: event.data.ownerConfirmationIntentDigest,
+      ownerConfirmationDigest: event.data.ownerConfirmationDigest,
+      ownerConfirmationReference: event.data.ownerConfirmationReference,
+      ownerConfirmationApprovedBy: event.data.ownerConfirmationApprovedBy,
+      ownerConfirmationApprovalReference:
+        event.data.ownerConfirmationApprovalReference,
+      ownerConfirmationApprovedAt: event.data.ownerConfirmationApprovedAt,
+      ownerConfirmationExpiresAt: event.data.ownerConfirmationExpiresAt,
+    };
+  }
+  if (event?.data?.credentialKind === "signed-capability") {
+    return {
+      ...common,
+      publisherCapabilityId: event.data.publisherCapabilityId,
+    };
+  }
+  if (event?.data?.credentialKind === "trusted-launcher-channel") {
+    return {
+      ...common,
+      launcherSha256: event.data.launcherSha256,
+      actorRuntimeDigest: event.data.actorRuntimeDigest,
+      launcherChannelProtocol: event.data.launcherChannelProtocol,
+      launcherAttestationSha256: event.data.launcherAttestationSha256,
+      launcherSessionId: event.data.launcherSessionId,
+    };
+  }
+  if (event?.data?.credentialKind === "persistent-actor") return common;
+  return null;
+}
+
+function indexActiveCanonicalLeaseAcquisitionByRecord(
+  records,
+  canonicalLeaseEventsByIndex,
+) {
+  const activeByLeaseName = new Map();
+  const acquisitionByRecordIndex = new Map();
+  for (const record of records) {
+    const descriptor = canonicalLeaseEventsByIndex.get(record.index);
+    if (descriptor?.kind === "acquisition") {
+      activeByLeaseName.set(
+        record.entry.leaseName,
+        descriptor.acquisitionIndex,
+      );
+    } else if (descriptor?.kind === "release") {
+      activeByLeaseName.delete(record.entry.leaseName);
+    }
+    const policy = AUTOMATION_ACTOR_POLICIES[record.entry?.actor];
+    const acquisitionIndex = activeByLeaseName.get(policy?.leaseName);
+    if (acquisitionIndex !== undefined) {
+      acquisitionByRecordIndex.set(record.index, acquisitionIndex);
+    }
+  }
+  return acquisitionByRecordIndex;
+}
+
 function canonicalTaskEventPolicyAuthority(event, toState) {
   const policy = AUTOMATION_ACTOR_POLICIES[event?.actor];
   return (
@@ -8842,6 +8892,11 @@ export function inspectExactTaskLifecycleHistory(events) {
   );
   const leaseHistory = inspectExactLeaseEventHistory(records, eventIdCounts);
   issues.push(...leaseHistory.issues);
+  const activeCanonicalLeaseAcquisitionByRecordIndex =
+    indexActiveCanonicalLeaseAcquisitionByRecord(
+      records,
+      leaseHistory.canonicalEventsByIndex,
+    );
   const lifecycleByRecordIndex = new Map();
   const canonicalTaskEventIndexes = new Set();
   const currentByTask = new Map();
@@ -9104,6 +9159,12 @@ export function inspectExactTaskLifecycleHistory(events) {
       };
     } else {
       const pending = before.pendingOutcome;
+      const activeAcquisitionIndex =
+        activeCanonicalLeaseAcquisitionByRecordIndex.get(record.index);
+      const activeAcquisition =
+        activeAcquisitionIndex === undefined
+          ? undefined
+          : records[activeAcquisitionIndex]?.entry;
       if (
         !canonicalOutcomeFinalizedEvent(
           event,
@@ -9112,7 +9173,7 @@ export function inspectExactTaskLifecycleHistory(events) {
           recordsByEventId,
           acquisitionRecordsByKey,
           leaseTimelinesByAcquisitionIndex,
-          pending?.authorizationProvenance,
+          taskAuthorizationProvenanceFromLeaseAcquisition(activeAcquisition),
         ) ||
         event.taskRevision !== before.taskRevision ||
         pending === null ||
@@ -9146,6 +9207,7 @@ export function inspectExactTaskLifecycleHistory(events) {
     recordsByEventId,
     acquisitionRecordsByKey,
     leaseTimelinesByAcquisitionIndex,
+    activeCanonicalLeaseAcquisitionByRecordIndex,
     canonicalLeaseEventsByIndex: leaseHistory.canonicalEventsByIndex,
     leaseHistoryIssues: leaseHistory.issues,
     leaseHistoryHealthy: leaseHistory.healthy,
@@ -9389,6 +9451,16 @@ export function inspectExactOutcomeControlHistory(
     const pinnedLegacyTransition =
       transition !== undefined &&
       pinnedLegacyActorOutcomeTransition(transition);
+    const activeAcquisitionIndex =
+      lifecycle.activeCanonicalLeaseAcquisitionByRecordIndex.get(record.index);
+    const activeAcquisition =
+      activeAcquisitionIndex === undefined
+        ? undefined
+        : lifecycle.records[activeAcquisitionIndex]?.entry;
+    const activeLeaseProvenance =
+      activeAcquisition === undefined
+        ? undefined
+        : taskAuthorizationProvenanceFromLeaseAcquisition(activeAcquisition);
     const deterministicRequired =
       transition?.type === "outcome_reservation_created" ||
       transition?.data?.outcomeRequired === true ||
@@ -9419,7 +9491,7 @@ export function inspectExactOutcomeControlHistory(
       (pinnedLegacyTransition
         ? !canonicalPinnedLegacyActorOutcomeEvent(event, transition)
         : !canonicalTaskAuthorizationProvenance(
-            transition.data?.authorizationProvenance,
+            activeLeaseProvenance,
             {
               actor: event.actor,
               taskId: event.taskId,

--- a/scripts/lib/automation-kernel-guard-cutover.mjs
+++ b/scripts/lib/automation-kernel-guard-cutover.mjs
@@ -73,6 +73,10 @@ const CUTOVER_SNAPSHOT_MAX_AGGREGATE_BYTES =
 const CUTOVER_NATIVE_MOVE_HELPER_SHA256 =
   "d23a65379acad43c7fb601d65fc150c29f1d214796121362f2a44c7e6c305a3e";
 const CUTOVER_NATIVE_MOVE_PYTHON = "/usr/bin/python3";
+const LEASE_TRANSACTION_DIRECTORY = ".transactions";
+const LEASE_TRANSACTION_RECEIPT_DIRECTORY = ".transaction-receipts";
+const LEASE_STATE_QUARANTINE_DIRECTORY = ".lease-state-quarantine";
+const LEASE_CLEANUP_QUARANTINE_DIRECTORY = ".lease-cleanup-quarantine";
 const CUTOVER_PRIVATE_FILE_CREATE_HELPER_SOURCE = String.raw`
 import hashlib
 import json
@@ -4329,13 +4333,39 @@ function validateUnmigratedSource(plan) {
   }
 }
 
-function validateStaticSource(plan) {
+function validateStaticSource(
+  plan,
+  {
+    allowLeaseRuntimeStorage = false,
+    requireCompleteLeaseRuntimeStorage = false,
+  } = {},
+) {
   const paths = automationKernelGuardCutoverPaths(plan.parameters.stateRoot);
+  const leasesRoot = path.join(paths.controlRoot, "leases");
   for (const expected of plan.sourceSnapshot.entries) {
     if (
       expected.path === paths.writerLock ||
       expected.path === paths.guardsRoot
     ) {
+      continue;
+    }
+    if (allowLeaseRuntimeStorage && expected.path === leasesRoot) {
+      if (
+        !(
+          expected.kind === "missing" ||
+          (expected.kind === "directory" &&
+            expected.mode === 0o700 &&
+            expected.entries.length === 0)
+        )
+      ) {
+        fail(
+          "cutover_source_drift",
+          "The planned lease root was not empty before terminal runtime initialization.",
+        );
+      }
+      requireTerminalLeaseRuntimeStorage(plan.parameters.stateRoot, {
+        requireComplete: requireCompleteLeaseRuntimeStorage,
+      });
       continue;
     }
     requireSnapshotMatch(
@@ -4352,7 +4382,270 @@ function validateStaticSource(plan) {
   }
 }
 
-function requireNoLeases(stateRoot) {
+function leaseRuntimeStorageLayout(stateRoot) {
+  const leases = path.join(stateRoot, "control", "leases");
+  const transactions = path.join(leases, LEASE_TRANSACTION_DIRECTORY);
+  const receipts = path.join(
+    leases,
+    LEASE_TRANSACTION_RECEIPT_DIRECTORY,
+  );
+  const transactionArchive = path.join(
+    transactions,
+    LEASE_CLEANUP_QUARANTINE_DIRECTORY,
+  );
+  const receiptArchive = path.join(
+    receipts,
+    LEASE_CLEANUP_QUARANTINE_DIRECTORY,
+  );
+  const stateArchive = path.join(leases, LEASE_STATE_QUARANTINE_DIRECTORY);
+  return {
+    leases,
+    transactions,
+    receipts,
+    transactionArchive,
+    receiptArchive,
+    stateArchive,
+    requiredDirectories: [
+      leases,
+      transactions,
+      receipts,
+      stateArchive,
+      transactionArchive,
+      receiptArchive,
+    ],
+  };
+}
+
+function listPinnedPrivateDirectoryEntries(
+  directoryPath,
+  pinned,
+  { maxEntries, maxEncodedBytes, label },
+) {
+  let bytes;
+  try {
+    bytes = runCutoverNativeHelperBytes(
+      "list-bounded",
+      [
+        String(maxEntries),
+        String(maxEncodedBytes),
+        String(pinned.identity.dev),
+        String(pinned.identity.ino),
+      ],
+      [pinned.descriptor],
+      { maxBuffer: maxEncodedBytes + 1 },
+    );
+  } catch (error) {
+    if (
+      /listing exceeds the (?:entry|encoded byte) boundary/.test(
+        error?.message ?? "",
+      )
+    ) {
+      fail(
+        "cutover_lease_live",
+        `${label} contains entries outside the terminal lease runtime scaffold.`,
+      );
+    }
+    throw error;
+  }
+  requirePinnedPrivateDirectoryPath(directoryPath, pinned, label);
+  if (bytes.length === 0) return [];
+  let entries;
+  try {
+    entries = fatalDecoder.decode(bytes).split("\0");
+  } catch {
+    fail(
+      "cutover_lease_live",
+      `${label} has an invalid terminal lease runtime inventory.`,
+    );
+  }
+  if (
+    entries.length > maxEntries ||
+    entries.some(
+      (entry) =>
+        entry.length === 0 ||
+        entry === "." ||
+        entry === ".." ||
+        entry.includes(path.sep) ||
+        entry.includes("\0"),
+    )
+  ) {
+    fail(
+      "cutover_lease_live",
+      `${label} has an invalid terminal lease runtime inventory.`,
+    );
+  }
+  return entries;
+}
+
+function requireTerminalLeaseRuntimeStorage(
+  stateRoot,
+  { requireComplete = false } = {},
+) {
+  const layout = leaseRuntimeStorageLayout(stateRoot);
+  if (!existsSync(layout.leases)) {
+    if (requireComplete) {
+      fail(
+        "cutover_state_invalid",
+        "The terminal lease runtime directory scaffold is incomplete.",
+      );
+    }
+    return;
+  }
+  const leases = openPinnedPrivateDirectoryPath(
+    layout.leases,
+    "Automation lease root",
+  );
+  try {
+    const allowedTopLevel = new Set([
+      LEASE_TRANSACTION_DIRECTORY,
+      LEASE_TRANSACTION_RECEIPT_DIRECTORY,
+      LEASE_STATE_QUARANTINE_DIRECTORY,
+    ]);
+    const entries = listPinnedPrivateDirectoryEntries(layout.leases, leases, {
+      maxEntries: allowedTopLevel.size,
+      maxEncodedBytes: 128,
+      label: "Automation lease root",
+    });
+    if (entries.some((entry) => !allowedTopLevel.has(entry))) {
+      fail(
+        "cutover_lease_live",
+        "Every canonical lease must be absent before cutover activation.",
+      );
+    }
+  } finally {
+    closeSync(leases.descriptor);
+  }
+
+  for (const [directoryPath, allowedEntries] of [
+    [layout.transactions, new Set([LEASE_CLEANUP_QUARANTINE_DIRECTORY])],
+    [layout.receipts, new Set([LEASE_CLEANUP_QUARANTINE_DIRECTORY])],
+    [layout.stateArchive, new Set()],
+  ]) {
+    if (!existsSync(directoryPath)) {
+      if (requireComplete) {
+        fail(
+          "cutover_state_invalid",
+          "The terminal lease runtime directory scaffold is incomplete.",
+        );
+      }
+      continue;
+    }
+    const pinned = openPinnedPrivateDirectoryPath(
+      directoryPath,
+      `Lease runtime directory ${directoryPath}`,
+    );
+    try {
+      const entries = listPinnedPrivateDirectoryEntries(
+        directoryPath,
+        pinned,
+        {
+          maxEntries: Math.max(1, allowedEntries.size),
+          maxEncodedBytes: 64,
+          label: `Lease runtime directory ${directoryPath}`,
+        },
+      );
+      if (entries.some((entry) => !allowedEntries.has(entry))) {
+        fail(
+          "cutover_lease_live",
+          "Every canonical lease and lease transaction must be absent before cutover activation.",
+        );
+      }
+    } finally {
+      closeSync(pinned.descriptor);
+    }
+  }
+
+  for (const directoryPath of [
+    layout.transactionArchive,
+    layout.receiptArchive,
+  ]) {
+    if (!existsSync(directoryPath)) {
+      if (requireComplete) {
+        fail(
+          "cutover_state_invalid",
+          "The terminal lease runtime directory scaffold is incomplete.",
+        );
+      }
+      continue;
+    }
+    const pinned = openPinnedPrivateDirectoryPath(
+      directoryPath,
+      `Lease runtime archive ${directoryPath}`,
+    );
+    try {
+      const entries = listPinnedPrivateDirectoryEntries(
+        directoryPath,
+        pinned,
+        {
+          maxEntries: 1,
+          maxEncodedBytes: 255,
+          label: `Lease runtime archive ${directoryPath}`,
+        },
+      );
+      if (entries.length !== 0) {
+        fail(
+          "cutover_lease_live",
+          "Lease cleanup archives must be empty before cutover activation.",
+        );
+      }
+    } finally {
+      closeSync(pinned.descriptor);
+    }
+  }
+
+  if (requireComplete) {
+    for (const directoryPath of layout.requiredDirectories) {
+      requirePrivateDirectory(
+        directoryPath,
+        `Lease runtime directory ${directoryPath}`,
+      );
+    }
+  }
+}
+
+function requireLeaseRuntimeDirectoryScaffold(stateRoot) {
+  const layout = leaseRuntimeStorageLayout(stateRoot);
+  for (const directoryPath of layout.requiredDirectories) {
+    requirePrivateDirectory(
+      directoryPath,
+      `Lease runtime directory ${directoryPath}`,
+    );
+  }
+}
+
+function leaseRuntimeDirectoryScaffoldReady(stateRoot) {
+  try {
+    requireLeaseRuntimeDirectoryScaffold(stateRoot);
+    return true;
+  } catch (error) {
+    if (error?.code === "cutover_state_invalid") return false;
+    throw error;
+  }
+}
+
+function ensureLeaseRuntimeDirectoryScaffold(
+  plan,
+  checkpoint = () => undefined,
+) {
+  const layout = leaseRuntimeStorageLayout(plan.parameters.stateRoot);
+  for (const directoryPath of layout.requiredDirectories) {
+    const existed = existsSync(directoryPath);
+    ensurePrivateDirectory(directoryPath);
+    checkpoint("lease-runtime-directory-durable", {
+      directoryPath,
+      created: !existed,
+    });
+  }
+}
+
+function requireNoLeases(
+  stateRoot,
+  { allowLeaseRuntimeStorage = false } = {},
+) {
+  if (allowLeaseRuntimeStorage) {
+    requireTerminalLeaseRuntimeStorage(stateRoot);
+    return;
+  }
   const leases = path.join(stateRoot, "control", "leases");
   if (!existsSync(leases)) return;
   const pinned = openPinnedPrivateDirectoryPath(
@@ -4494,9 +4787,12 @@ function requireNoOpenStateDescriptor(stateRoot) {
   }
 }
 
-function requireQuiescence(plan) {
+function requireQuiescence(
+  plan,
+  { allowLeaseRuntimeStorage = false } = {},
+) {
   requirePausedActors(plan.parameters.codexHome);
-  requireNoLeases(plan.parameters.stateRoot);
+  requireNoLeases(plan.parameters.stateRoot, { allowLeaseRuntimeStorage });
   requireNoOldControlProcess();
   requireNoOpenStateDescriptor(plan.parameters.stateRoot);
 }
@@ -8004,11 +8300,19 @@ function prepareBootstrapLock(plan, beforeMutation = () => undefined) {
 function validateReceiptPreparedActivation(
   plan,
   transaction,
-  { requireReceipt },
+  { requireReceipt, requireCompleteLeaseRuntimeStorage = false },
 ) {
-  requireQuiescence(plan);
-  validateStaticSource(plan);
-  requireLocalFilesystem(plan.parameters.stateRoot, { plan, transaction });
+  requireQuiescence(plan, { allowLeaseRuntimeStorage: true });
+  validateStaticSource(plan, {
+    allowLeaseRuntimeStorage: true,
+    requireCompleteLeaseRuntimeStorage,
+  });
+  requireLocalFilesystem(plan.parameters.stateRoot, {
+    plan,
+    transaction,
+    extraPaths: leaseRuntimeStorageLayout(plan.parameters.stateRoot)
+      .requiredDirectories,
+  });
   if (readWriteAheadRecord(plan) !== null) {
     fail(
       "cutover_write_ahead_invalid",
@@ -8039,6 +8343,11 @@ function finishReceiptPreparedCutover(
   validateReceiptPreparedActivation(plan, transaction, {
     requireReceipt: false,
   });
+  ensureLeaseRuntimeDirectoryScaffold(plan, checkpoint);
+  validateReceiptPreparedActivation(plan, transaction, {
+    requireReceipt: false,
+    requireCompleteLeaseRuntimeStorage: true,
+  });
   const receipt = buildReceipt(plan, transaction);
   const paths = automationKernelGuardCutoverPaths(plan.parameters.stateRoot);
   requireCutoverImmutableTargetPreflight(
@@ -8057,6 +8366,7 @@ function finishReceiptPreparedCutover(
     beforeFinalize() {
       validateReceiptPreparedActivation(plan, transaction, {
         requireReceipt: false,
+        requireCompleteLeaseRuntimeStorage: true,
       });
     },
   });
@@ -8065,6 +8375,7 @@ function finishReceiptPreparedCutover(
   });
   validateReceiptPreparedActivation(plan, transaction, {
     requireReceipt: true,
+    requireCompleteLeaseRuntimeStorage: true,
   });
   writeCutoverImmutable(plan, paths.globalReceipt, prettyJsonBytes(receipt.global), {
     checkpoint,
@@ -8072,6 +8383,7 @@ function finishReceiptPreparedCutover(
     beforeFinalize() {
       validateReceiptPreparedActivation(plan, transaction, {
         requireReceipt: true,
+        requireCompleteLeaseRuntimeStorage: true,
       });
     },
   });
@@ -8080,6 +8392,7 @@ function finishReceiptPreparedCutover(
   });
   validateReceiptPreparedActivation(plan, transaction, {
     requireReceipt: true,
+    requireCompleteLeaseRuntimeStorage: true,
   });
   const inspection = inspectAutomationKernelGuardCutover(
     plan.parameters.stateRoot,
@@ -8853,7 +9166,10 @@ export function applyAutomationKernelGuardCutover({
   const initialInspection = inspectAutomationKernelGuardCutover(
     plan.parameters.stateRoot,
   );
-  if (initialInspection.ready) {
+  if (
+    initialInspection.ready &&
+    leaseRuntimeDirectoryScaffoldReady(plan.parameters.stateRoot)
+  ) {
     if (preexistingTransaction?.phase !== "receipt-prepared") {
       fail(
         "cutover_transaction_invalid",
@@ -8879,7 +9195,7 @@ export function applyAutomationKernelGuardCutover({
     return withKernelFileGuard(
       paths.bootstrapLock,
       () => {
-        requireQuiescence(plan);
+        requireQuiescence(plan, { allowLeaseRuntimeStorage: true });
         const transaction = readTransaction(plan, checkpoint);
         if (transaction?.phase !== "receipt-prepared") {
           fail(

--- a/scripts/nightly-self-improve.test.mjs
+++ b/scripts/nightly-self-improve.test.mjs
@@ -89,6 +89,10 @@ import {
   planOutcomeLedgerRepair,
   repairOutcomeLedger,
 } from "./lib/outcome-ledger-repair.mjs";
+import {
+  TEST_TRUSTED_LAUNCHER_PROVENANCE,
+  acquireGeneralActorLeaseForTest,
+} from "./test-helpers/trusted-actor-lease.mjs";
 
 const GIB = 1024 * 1024 * 1024;
 const NIGHTLY_MODULE_URL = new URL(
@@ -132,11 +136,7 @@ function deterministicOutcomeRecordedEventId({
     .digest("hex")}`;
 }
 
-function persistentActorProvenance(
-  actor,
-  taskId,
-  eventTimestamp,
-) {
+function trustedActorProvenance(actor, taskId, eventTimestamp) {
   const offset = Number.parseInt(
     createHash("sha256").update(`${actor}:${taskId}`).digest("hex").slice(0, 8),
     16,
@@ -146,7 +146,8 @@ function persistentActorProvenance(
   return {
     leaseName: AUTOMATION_ACTOR_POLICIES[actor].leaseName,
     leaseAcquiredAt: new Date(eventTimestampMs - 2_000 - offset).toISOString(),
-    credentialKind: "persistent-actor",
+    credentialKind: "trusted-launcher-channel",
+    ...TEST_TRUSTED_LAUNCHER_PROVENANCE,
   };
 }
 
@@ -239,7 +240,7 @@ function canonicalMergedTransition({
     data: {
       fromState: "validated",
       toState: "merged",
-      authorizationProvenance: persistentActorProvenance(actor, taskId, ts),
+      authorizationProvenance: trustedActorProvenance(actor, taskId, ts),
       ...(outcomeDigest === undefined
         ? {}
         : { outcomeRequired: true, outcomeDigest }),
@@ -277,7 +278,7 @@ function canonicalTaskCreationFor(
     data: {
       state: "observed",
       behavioral: false,
-      authorizationProvenance: persistentActorProvenance(
+      authorizationProvenance: trustedActorProvenance(
         actor,
         event.taskId,
         createdAt,
@@ -321,7 +322,7 @@ function canonicalTaskStateTransition({
     data: {
       fromState,
       toState,
-      authorizationProvenance: persistentActorProvenance(actor, taskId, ts),
+      authorizationProvenance: trustedActorProvenance(actor, taskId, ts),
     },
   };
 }
@@ -442,7 +443,7 @@ function canonicalMergedReservation(identity, legacyTransition) {
       outcomeBackfill: true,
       outcomeDigest: identity.outcomeDigest,
       legacyTransitionEventId: identity.legacyTransitionEventId,
-      authorizationProvenance: persistentActorProvenance(
+      authorizationProvenance: trustedActorProvenance(
         actor,
         identity.taskId,
         "2026-07-19T12:00:01.000Z",
@@ -504,53 +505,42 @@ function jsonPaddingPhysicalLine(byteLength) {
   return `${prefix}${"x".repeat(paddingLength)}${suffix}`;
 }
 
-function actorCredential(stateRoot, actor) {
-  const token = `credential:${actor}:${"x".repeat(64)}`;
-  const credentialDir = path.join(stateRoot, "control", "actor-credentials");
-  mkdirSync(credentialDir, { recursive: true, mode: 0o700 });
-  chmodSync(credentialDir, 0o700);
-  writeFileSync(
-    path.join(credentialDir, `${actor}.json`),
-    `${JSON.stringify({
-      schemaVersion: 1,
-      actor,
-      purpose: "automation-actor-lease",
-      tokenSha256: createHash("sha256").update(token).digest("hex"),
-    })}\n`,
-    { mode: 0o600 },
-  );
-  return token;
-}
-
 function leaseEventProvenance(event) {
   const common = {
     leaseName: event.leaseName,
     leaseAcquiredAt: event.ts,
     credentialKind: event.data.credentialKind,
   };
-  if (event.data.credentialKind === "persistent-actor") return common;
   const fields =
-    event.data.credentialKind === "owner-confirmation"
+    event.data.credentialKind === "trusted-launcher-channel"
       ? [
-          "ownerConfirmationApprovalReference",
-          "ownerConfirmationApprovedAt",
-          "ownerConfirmationApprovedBy",
-          "ownerConfirmationDigest",
-          "ownerConfirmationExpiresAt",
-          "ownerConfirmationId",
-          "ownerConfirmationIntentDigest",
-          "ownerConfirmationReference",
-          "ownerConfirmationTaskId",
+          "launcherSha256",
+          "actorRuntimeDigest",
+          "launcherChannelProtocol",
+          "launcherAttestationSha256",
+          "launcherSessionId",
         ]
-      : event.data.credentialKind === "owner-signed-capability"
+      : event.data.credentialKind === "owner-confirmation"
         ? [
-            "ownerCapabilityId",
-            "ownerCapabilityIntentDigest",
-            "ownerCapabilityTaskId",
+            "ownerConfirmationApprovalReference",
+            "ownerConfirmationApprovedAt",
+            "ownerConfirmationApprovedBy",
+            "ownerConfirmationDigest",
+            "ownerConfirmationExpiresAt",
+            "ownerConfirmationId",
+            "ownerConfirmationIntentDigest",
+            "ownerConfirmationReference",
+            "ownerConfirmationTaskId",
           ]
-        : event.data.credentialKind === "signed-capability"
-          ? ["publisherCapabilityId"]
-          : [];
+        : event.data.credentialKind === "owner-signed-capability"
+          ? [
+              "ownerCapabilityId",
+              "ownerCapabilityIntentDigest",
+              "ownerCapabilityTaskId",
+            ]
+          : event.data.credentialKind === "signed-capability"
+            ? ["publisherCapabilityId"]
+            : [];
   return {
     ...common,
     ...Object.fromEntries(fields.map((field) => [field, event.data[field]])),
@@ -592,7 +582,9 @@ function bindFixtureLeaseProvenance(events, fixture) {
     const replacement = fixture.provenanceByActor.get(event?.actor);
     const replaceGeneralActor =
       event.actor !== "freed-owner" &&
-      provenance?.credentialKind === "persistent-actor";
+      ["persistent-actor", "trusted-launcher-channel"].includes(
+        provenance?.credentialKind,
+      );
     const replaceSyntheticOwner =
       event.actor === "freed-owner" &&
       provenance?.credentialKind === "owner-signed-capability";
@@ -635,13 +627,12 @@ function outcomeAuthentication(stateRoot, actor, nowMs) {
       };
     }
     const token = `${actor}-${nowMs}`;
-    acquireLease({
+    acquireGeneralActorLeaseForTest({
       stateRoot,
       name: policy.leaseName,
       owner: actor,
       operationId: leaseMutationId(`acquire:${actor}`),
       token,
-      actorCredentialToken: actorCredential(stateRoot, actor),
       ttlMs: policy.maxLeaseLifetimeMs,
     });
     ACTOR_LEASES.set(key, token);
@@ -681,18 +672,24 @@ function ownerOutcomeAuthentication(stateRoot, plan, nowMs = Date.now()) {
     })}\n`,
     { mode: 0o600 },
   );
-  const acquired = acquireLease({
-    stateRoot,
-    name: "owner-governance",
-    owner: "freed-owner",
-    operationId: leaseMutationId("acquire:freed-owner"),
-    token: `owner-outcome-token-${"x".repeat(64)}`,
-    ttlMs: 10 * 60_000,
-    nowMs: nowMs + 1,
-    ownerConfirmationFile: confirmationPath,
-    ownerCapabilityTaskId: plan.taskId,
-    ownerCapabilityIntentDigest: plan.intentDigest,
-  });
+  const liveDateNow = Date.now;
+  let acquired;
+  Date.now = () => nowMs + 1;
+  try {
+    acquired = acquireLease({
+      stateRoot,
+      name: "owner-governance",
+      owner: "freed-owner",
+      operationId: leaseMutationId("acquire:freed-owner"),
+      token: `owner-outcome-token-${"x".repeat(64)}`,
+      ttlMs: 10 * 60_000,
+      ownerConfirmationFile: confirmationPath,
+      ownerCapabilityTaskId: plan.taskId,
+      ownerCapabilityIntentDigest: plan.intentDigest,
+    });
+  } finally {
+    Date.now = liveDateNow;
+  }
   return {
     stateRoot,
     authentication: {
@@ -2220,14 +2217,13 @@ test("outcome source health requires retained lease receipts to match exact even
   let heartbeatOperationId;
   try {
     Date.now = () => acquiredAtMs;
-    acquireLease({
+    acquireGeneralActorLeaseForTest({
       stateRoot,
       name: policy.leaseName,
       owner: actor,
       operationId: leaseMutationId("retained-source-health-acquire"),
       ttlMs: 60_000,
       token,
-      actorCredentialToken: actorCredential(stateRoot, actor),
     });
     heartbeatOperationId = leaseMutationId(
       "retained-source-health-heartbeat",

--- a/scripts/outcome-ledger-repair.test.mjs
+++ b/scripts/outcome-ledger-repair.test.mjs
@@ -7,6 +7,7 @@ import {
   closeSync,
   constants,
   existsSync,
+  fstatSync,
   linkSync,
   lstatSync,
   mkdirSync,
@@ -63,6 +64,7 @@ import {
 } from "./nightly-self-improve.mjs";
 import { writeMeasuredOutcomeVerdict } from "./test-helpers/outcome-evidence.mjs";
 import { installAutomationKernelGuardCutoverFixture } from "./test-helpers/automation-kernel-guard.mjs";
+import { acquireGeneralActorLeaseForTest } from "./test-helpers/trusted-actor-lease.mjs";
 
 const TASK_ID = "authenticated-essay-capture-pr-642";
 const CLI_PATH = path.join(import.meta.dirname, "outcome-ledger-repair.mjs");
@@ -727,12 +729,56 @@ function privateDirectoryFixture(t, label) {
   return root;
 }
 
+const DIRECTORY_RETIREMENT_MAX_FILE_BYTES = 1024 * 1024;
+const DIRECTORY_RETIREMENT_MAX_ENTRIES = 4;
+const DIRECTORY_RETIREMENT_MAX_DEPTH = 1;
+const DIRECTORY_RETIREMENT_MAX_AGGREGATE_BYTES = 1024 * 1024;
+
+function snapshotRetirementDirectoryTree(sourceParentPath, sourceName) {
+  const descriptor = openSync(
+    sourceParentPath,
+    constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW,
+  );
+  const sourceParent = fstatSync(descriptor);
+  let result;
+  try {
+    result = runNativeMoveHelper(
+      "snapshot-tree",
+      [
+        sourceName,
+        0,
+        DIRECTORY_RETIREMENT_MAX_FILE_BYTES,
+        DIRECTORY_RETIREMENT_MAX_ENTRIES,
+        DIRECTORY_RETIREMENT_MAX_DEPTH,
+        DIRECTORY_RETIREMENT_MAX_AGGREGATE_BYTES,
+        2 * DIRECTORY_RETIREMENT_MAX_FILE_BYTES,
+        sourceParent.dev,
+        sourceParent.ino,
+        sourceParent.mode & 0o7777,
+      ],
+      [descriptor],
+    );
+  } finally {
+    closeSync(descriptor);
+  }
+  assert.equal(result.status, 0, result.stderr.toString("utf8"));
+  const receipt = JSON.parse(result.stdout.toString("utf8"));
+  assert.equal(receipt.protocol, "freed-lease-archive-move-v1");
+  assert.equal(receipt.operation, "snapshot-tree");
+  assert.equal(receipt.parentDevice, String(sourceParent.dev));
+  assert.equal(receipt.parentInode, String(sourceParent.ino));
+  assert.equal(receipt.parentMode, String(sourceParent.mode & 0o7777));
+  assert.match(receipt.treeDigest, /^[0-9a-f]{64}$/);
+  return receipt.treeDigest;
+}
+
 function retireDirectoryArguments({
   sourceName,
   destinationName,
   source,
   sourceParent,
   destinationParent,
+  treeDigest,
 }) {
   return [
     sourceName,
@@ -745,6 +791,11 @@ function retireDirectoryArguments({
     sourceParent.ino,
     destinationParent.dev,
     destinationParent.ino,
+    treeDigest,
+    DIRECTORY_RETIREMENT_MAX_FILE_BYTES,
+    DIRECTORY_RETIREMENT_MAX_ENTRIES,
+    DIRECTORY_RETIREMENT_MAX_DEPTH,
+    DIRECTORY_RETIREMENT_MAX_AGGREGATE_BYTES,
   ];
 }
 
@@ -966,19 +1017,16 @@ test("replaced repair accepts its exact same-intent owner heartbeat before audit
   );
 });
 
-test("replaced repair rejects an unrelated canonical lease event before audit", (t) => {
+test("replaced repair fences an unrelated actor lease before mutation or audit", (t) => {
   const fixture = leaveRepairReplaced(t, "unrelated-lease-before-audit");
-  actorLease(fixture.stateRoot, "freed-release-verifier", Date.now());
+  const eventsBefore = readFileSync(fixture.paths.events);
+  const leaseEntriesBefore = readdirSync(fixture.paths.leases).sort();
   assert.throws(
-    () =>
-      repairOutcomeLedger({
-        stateRoot: fixture.stateRoot,
-        taskId: TASK_ID,
-        expectedSourceDigest: fixture.sourceDigest,
-        ...fixture.owner,
-      }),
-    /plan-bound owner lease lifecycle/i,
+    () => actorLease(fixture.stateRoot, "freed-release-verifier", Date.now()),
+    (error) => error?.code === "outcome_ledger_repair_pending",
   );
+  assert.deepEqual(readFileSync(fixture.paths.events), eventsBefore);
+  assert.deepEqual(readdirSync(fixture.paths.leases).sort(), leaseEntriesBefore);
   assert.equal(repairAuditEvents(fixture.paths, fixture.plan.eventId).length, 0);
 });
 
@@ -1019,38 +1067,17 @@ test("audited repair recovers under a new same-intent owner lease without duplic
   assert.equal(existsSync(fixture.plan.artifacts.transaction), false);
 });
 
-function writeActorCredential(stateRoot, actor) {
-  const token = `credential:${actor}:${"x".repeat(64)}`;
-  const credentialPath = path.join(
-    automationControlPaths(stateRoot).actorCredentials,
-    `${actor}.json`,
-  );
-  mkdirSync(path.dirname(credentialPath), { recursive: true, mode: 0o700 });
-  writeFileSync(
-    credentialPath,
-    `${JSON.stringify({
-      schemaVersion: 1,
-      actor,
-      purpose: "automation-actor-lease",
-      tokenSha256: sha256(token),
-    })}\n`,
-    { mode: 0o600 },
-  );
-  return token;
-}
-
 function actorLease(stateRoot, actor, nowMs) {
   const policy = AUTOMATION_ACTOR_POLICIES[actor];
   const token = `${actor}:${nowMs}`;
   const currentTimeMs = Date.now();
   const leaseNowMs = nowMs >= currentTimeMs - 1_000 ? nowMs : currentTimeMs;
-  acquireLease({
+  acquireGeneralActorLeaseForTest({
     stateRoot,
     name: policy.leaseName,
     owner: actor,
     operationId: leaseMutationId(`acquire:${actor}`),
     token,
-    actorCredentialToken: writeActorCredential(stateRoot, actor),
     nowMs: leaseNowMs,
     ttlMs: policy.maxLeaseLifetimeMs,
   });
@@ -5807,6 +5834,10 @@ test("native durable directory retirement is exclusive and generation bound", as
     const source = statSync(sourcePath);
     const sourceParent = statSync(sourceParentPath);
     const destinationParent = statSync(destinationParentPath);
+    const treeDigest = snapshotRetirementDirectoryTree(
+      sourceParentPath,
+      sourceName,
+    );
     const descriptors = [sourceParentPath, destinationParentPath, sourcePath].map(
       (value) =>
         openSync(
@@ -5824,6 +5855,7 @@ test("native durable directory retirement is exclusive and generation bound", as
           source,
           sourceParent,
           destinationParent,
+          treeDigest,
         }),
         descriptors,
       );
@@ -5842,6 +5874,7 @@ test("native durable directory retirement is exclusive and generation bound", as
       inode: String(source.ino),
       mode: String(source.mode & 0o7777),
       protocol: "freed-lease-archive-move-v1",
+      treeDigest,
       uid: String(source.uid),
     });
   });
@@ -5866,6 +5899,10 @@ test("native durable directory retirement is exclusive and generation bound", as
     const destination = statSync(destinationPath);
     const sourceParent = statSync(sourceParentPath);
     const destinationParent = statSync(destinationParentPath);
+    const treeDigest = snapshotRetirementDirectoryTree(
+      sourceParentPath,
+      sourceName,
+    );
     const descriptors = [sourceParentPath, destinationParentPath, sourcePath].map(
       (value) =>
         openSync(
@@ -5883,6 +5920,7 @@ test("native durable directory retirement is exclusive and generation bound", as
           source,
           sourceParent,
           destinationParent,
+          treeDigest,
         }),
         descriptors,
       );
@@ -5914,6 +5952,10 @@ test("native durable directory retirement is exclusive and generation bound", as
     const source = statSync(sourcePath);
     const sourceParent = statSync(sourceParentPath);
     const destinationParent = statSync(destinationParentPath);
+    const treeDigest = snapshotRetirementDirectoryTree(
+      sourceParentPath,
+      sourceName,
+    );
     const descriptors = [sourceParentPath, destinationParentPath, sourcePath].map(
       (value) =>
         openSync(
@@ -5929,6 +5971,7 @@ test("native durable directory retirement is exclusive and generation bound", as
         source,
         sourceParent,
         destinationParent,
+        treeDigest,
       }),
       descriptors,
       pause: "before-retire-directory-syscall",
@@ -5961,6 +6004,10 @@ test("native durable directory retirement is exclusive and generation bound", as
     const source = statSync(sourcePath);
     const sourceParent = statSync(sourceParentPath);
     const destinationParent = statSync(destinationParentPath);
+    const treeDigest = snapshotRetirementDirectoryTree(
+      sourceParentPath,
+      sourceName,
+    );
     const descriptors = [sourceParentPath, destinationParentPath, sourcePath].map(
       (value) =>
         openSync(
@@ -5976,6 +6023,7 @@ test("native durable directory retirement is exclusive and generation bound", as
         source,
         sourceParent,
         destinationParent,
+        treeDigest,
       }),
       descriptors,
       pause: "after-retire-directory-before-destination-sync",

--- a/scripts/prepare-release-promotion.mjs
+++ b/scripts/prepare-release-promotion.mjs
@@ -1,0 +1,215 @@
+#!/usr/bin/env node
+
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  ensureRefExists,
+  formatFileList,
+  listPromotionBranchDiffFiles,
+  listPromotionBranchPatchFiles,
+} from "./release-promotion-shared.mjs";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const REPO_ROOT = path.resolve(__dirname, "..");
+const MAX_PATCH_BYTES = 512 * 1024 * 1024;
+
+function die(message) {
+  console.error(message);
+  process.exit(1);
+}
+
+function runGit(args, { cwd, encoding = "utf8", env = process.env } = {}) {
+  return execFileSync("git", args, {
+    cwd,
+    encoding,
+    env,
+    maxBuffer: MAX_PATCH_BYTES,
+  });
+}
+
+function parseArgs(argv) {
+  const options = {
+    cwd: REPO_ROOT,
+    fromRef: "origin/dev",
+    baseRef: "origin/main",
+  };
+
+  for (const arg of argv) {
+    if (arg === "--help" || arg === "-h") {
+      options.help = true;
+      continue;
+    }
+    if (arg.startsWith("--cwd=")) {
+      options.cwd = path.resolve(arg.slice("--cwd=".length));
+      continue;
+    }
+    if (arg.startsWith("--from-ref=")) {
+      options.fromRef = arg.slice("--from-ref=".length);
+      continue;
+    }
+    if (arg.startsWith("--base-ref=")) {
+      options.baseRef = arg.slice("--base-ref=".length);
+      continue;
+    }
+    die(`Unsupported argument: ${arg}`);
+  }
+
+  return options;
+}
+
+function usage() {
+  console.error(
+    "Usage: node scripts/prepare-release-promotion.mjs [--cwd=<path>] [--from-ref=<ref>] [--base-ref=<ref>]",
+  );
+}
+
+function ensureCleanBase({ cwd, baseRef }) {
+  const status = runGit(["status", "--porcelain=v1", "--untracked-files=normal"], {
+    cwd,
+  }).trim();
+  if (status) {
+    die("Promotion preparation requires a clean worktree and index.");
+  }
+
+  const headSha = runGit(["rev-parse", "HEAD"], { cwd }).trim();
+  const baseSha = runGit(["rev-parse", baseRef], { cwd }).trim();
+  if (headSha !== baseSha) {
+    die(
+      `Promotion preparation requires HEAD ${headSha} to equal ${baseRef} ${baseSha}.`,
+    );
+  }
+}
+
+function promotionPatch({ cwd, fromRef, baseRef, files }) {
+  return runGit(
+    [
+      "diff",
+      "--binary",
+      "--full-index",
+      "--no-ext-diff",
+      "--no-textconv",
+      "--no-renames",
+      baseRef,
+      fromRef,
+      "--",
+      ...files,
+    ],
+    { cwd, encoding: null },
+  );
+}
+
+function applyPromotionPatch({ cwd, patch, indexFile = null }) {
+  const temporaryIndex = indexFile !== null;
+  const env = temporaryIndex
+    ? { ...process.env, GIT_INDEX_FILE: indexFile }
+    : process.env;
+
+  if (patch.length === 0) {
+    die("Promotion preparation found changed paths but produced no patch.");
+  }
+
+  const applied = spawnSync(
+    "git",
+    [
+      "apply",
+      temporaryIndex ? "--cached" : "--index",
+      "--binary",
+      "--whitespace=nowarn",
+    ],
+    {
+      cwd,
+      env,
+      input: patch,
+      encoding: "utf8",
+      maxBuffer: MAX_PATCH_BYTES,
+    },
+  );
+  if (applied.status !== 0) {
+    const detail = (applied.stderr || applied.stdout || "unknown error").trim();
+    die(`Promotion snapshot could not be applied: ${detail}`);
+  }
+}
+
+function verifyPreparedSnapshot({ cwd, fromRef, expectedFiles, indexFile }) {
+  const env = { ...process.env, GIT_INDEX_FILE: indexFile };
+  const stagedFiles = runGit(["diff", "--cached", "--name-only", "--no-renames"], {
+    cwd,
+    env,
+  })
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .sort((left, right) => left.localeCompare(right));
+  if (JSON.stringify(stagedFiles) !== JSON.stringify(expectedFiles)) {
+    die(
+      `Promotion preparation staged an unexpected path set:\n${formatFileList(stagedFiles)}`,
+    );
+  }
+
+  const preparedTree = runGit(["write-tree"], { cwd, env }).trim();
+  const remaining = listPromotionBranchDiffFiles({
+    fromRef,
+    toRef: preparedTree,
+    cwd,
+  });
+  if (remaining.length > 0) {
+    die(
+      `Promotion preparation did not reproduce the source product snapshot:\n${formatFileList(remaining)}`,
+    );
+  }
+
+  return preparedTree;
+}
+
+function prepareInTemporaryIndex({ cwd, fromRef, baseRef, files, patch }) {
+  const directory = mkdtempSync(path.join(tmpdir(), "freed-promotion-index-"));
+  const indexFile = path.join(directory, "index");
+  try {
+    const env = { ...process.env, GIT_INDEX_FILE: indexFile };
+    runGit(["read-tree", baseRef], { cwd, env });
+    applyPromotionPatch({ cwd, patch, indexFile });
+    return verifyPreparedSnapshot({
+      cwd,
+      fromRef,
+      expectedFiles: files,
+      indexFile,
+    });
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    usage();
+    process.exit(0);
+  }
+
+  ensureRefExists(options.fromRef, { cwd: options.cwd });
+  ensureRefExists(options.baseRef, { cwd: options.cwd });
+  ensureCleanBase(options);
+
+  const files = listPromotionBranchPatchFiles({
+    fromRef: options.fromRef,
+    toRef: options.baseRef,
+    cwd: options.cwd,
+  });
+  if (files.length === 0) {
+    console.log("The production product snapshot already matches the development source.");
+    return;
+  }
+
+  const patch = promotionPatch({ ...options, files });
+  prepareInTemporaryIndex({ ...options, files, patch });
+  ensureCleanBase(options);
+  applyPromotionPatch({ cwd: options.cwd, patch });
+  console.log(`Prepared ${files.length.toLocaleString()} product paths for promotion.`);
+}
+
+main();

--- a/scripts/promote-dev-to-main.sh
+++ b/scripts/promote-dev-to-main.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 if [[ $# -lt 1 ]]; then
-  echo "Usage: ./scripts/promote-dev-to-main.sh <worktree-path> [<branch-name>] [--provider-risk-approval-file <path>]" >&2
+  echo "Usage: ./scripts/promote-dev-to-main.sh <worktree-path> [<branch-name>] [--provider-risk-review-artifact <path> | --provider-risk-approval-file <path>]" >&2
   exit 1
 fi
 
@@ -11,6 +11,7 @@ WORKTREE_PATH="$1"
 shift
 BRANCH_NAME=""
 PROVIDER_RISK_APPROVAL_FILE=""
+PROVIDER_RISK_REVIEW_ARTIFACT=""
 if [[ $# -gt 0 && "$1" != --* ]]; then
   BRANCH_NAME="$1"
   shift
@@ -18,6 +19,11 @@ fi
 BRANCH_NAME="${BRANCH_NAME:-chore/promote-dev-to-main-$(date +%Y%m%d-%H%M%S)}"
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    --provider-risk-review-artifact)
+      [[ $# -ge 2 && -n "$2" ]] || { echo "Error: --provider-risk-review-artifact requires a path." >&2; exit 1; }
+      PROVIDER_RISK_REVIEW_ARTIFACT="$2"
+      shift 2
+      ;;
     --provider-risk-approval-file)
       [[ $# -ge 2 && -n "$2" ]] || { echo "Error: --provider-risk-approval-file requires a path." >&2; exit 1; }
       PROVIDER_RISK_APPROVAL_FILE="$2"
@@ -29,6 +35,10 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+if [[ -n "${PROVIDER_RISK_REVIEW_ARTIFACT}" && -n "${PROVIDER_RISK_APPROVAL_FILE}" ]]; then
+  echo "Error: --provider-risk-review-artifact and --provider-risk-approval-file are mutually exclusive." >&2
+  exit 1
+fi
 TITLE="chore: promote dev into main for production release"
 SCRIPT_DIR="$(cd -P -- "${BASH_SOURCE[0]%/*}" && pwd)"
 REPO_ROOT="$(cd -P -- "${SCRIPT_DIR}/.." && pwd)"
@@ -42,6 +52,9 @@ if [[ "${WORKTREE_PATH}" != /* ]]; then
 fi
 if [[ -n "${PROVIDER_RISK_APPROVAL_FILE}" && "${PROVIDER_RISK_APPROVAL_FILE}" != /* ]]; then
   PROVIDER_RISK_APPROVAL_FILE="${ORIGINAL_CWD}/${PROVIDER_RISK_APPROVAL_FILE}"
+fi
+if [[ -n "${PROVIDER_RISK_REVIEW_ARTIFACT}" && "${PROVIDER_RISK_REVIEW_ARTIFACT}" != /* ]]; then
+  PROVIDER_RISK_REVIEW_ARTIFACT="${ORIGINAL_CWD}/${PROVIDER_RISK_REVIEW_ARTIFACT}"
 fi
 
 cd "${REPO_ROOT}"
@@ -83,7 +96,10 @@ else
   (
     cd "${WORKTREE_PATH}"
     /usr/bin/git fetch origin dev main
-    /usr/bin/git merge --squash --no-commit origin/dev
+    "${NODE_BIN}" "${SCRIPT_DIR}/prepare-release-promotion.mjs" \
+      --cwd="${WORKTREE_PATH}" \
+      --from-ref=origin/dev \
+      --base-ref=origin/main
 
     if /usr/bin/git diff --cached --quiet; then
       echo "Error: no staged changes were produced while promoting origin/dev into main." >&2
@@ -97,6 +113,16 @@ fi
 (
   cd "${WORKTREE_PATH}"
   /usr/bin/git fetch origin dev main
+  MAIN_SHA="$(/usr/bin/git rev-parse origin/main)"
+  HEAD_PARENT="$(/usr/bin/git rev-parse HEAD^)"
+  if [[ "${HEAD_PARENT}" != "${MAIN_SHA}" ]]; then
+    echo "Error: promotion commit parent ${HEAD_PARENT} does not equal current origin/main ${MAIN_SHA}. Recreate the promotion from the current base." >&2
+    exit 1
+  fi
+  if [[ "$(/usr/bin/git rev-list --count origin/main..HEAD)" != "1" ]]; then
+    echo "Error: promotion branch must contain exactly one commit above current origin/main." >&2
+    exit 1
+  fi
   "${NODE_BIN}" scripts/validate-main-pr.mjs \
     --base-ref=origin/main \
     --head-ref=HEAD \
@@ -105,9 +131,10 @@ fi
   BODY_FILE="$(mktemp)"
   trap 'rm -f "${BODY_FILE}"' EXIT
   DEV_SHA="$(/usr/bin/git rev-parse origin/dev)"
-  MAIN_SHA="$(/usr/bin/git rev-parse origin/main)"
 
   cat > "${BODY_FILE}" <<EOF
+(AI Generated).
+
 ## Summary
 - Promote the current \`origin/dev\` product snapshot into \`main\` before a production release.
 - Base main SHA: \`${MAIN_SHA}\`
@@ -125,6 +152,9 @@ EOF
   )
   if [[ -n "${PROVIDER_RISK_APPROVAL_FILE}" ]]; then
     PUBLISH_ARGS+=(--provider-risk-approval-file "${PROVIDER_RISK_APPROVAL_FILE}")
+  fi
+  if [[ -n "${PROVIDER_RISK_REVIEW_ARTIFACT}" ]]; then
+    PUBLISH_ARGS+=(--provider-risk-review-artifact "${PROVIDER_RISK_REVIEW_ARTIFACT}")
   fi
   "${PUBLISH_COMMAND[@]}" "${PUBLISH_ARGS[@]}"
 )

--- a/scripts/promote-dev-to-main.test.mjs
+++ b/scripts/promote-dev-to-main.test.mjs
@@ -37,6 +37,93 @@ function mustRun(command, args, options = {}) {
   return result;
 }
 
+async function existingPromotionFixture(t) {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "freed-promote-existing-"));
+  t.after(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+  const repo = path.join(root, "repo");
+  const origin = path.join(root, "origin.git");
+  const caller = path.join(root, "caller");
+  const worktree = path.join(caller, "promotion-worktree");
+  const branch = "chore/promote-dev-to-main-test";
+  const publisherLog = path.join(root, "publisher-args.json");
+  const validationLog = path.join(root, "validation-args.json");
+  const reviewArtifact = path.join(caller, "provider-review.json");
+
+  await fs.mkdir(path.join(repo, "scripts/lib"), { recursive: true });
+  await fs.mkdir(path.join(repo, "packages/pwa/src"), { recursive: true });
+  await fs.mkdir(caller, { recursive: true });
+  await fs.copyFile(
+    path.join(sourceRoot, "scripts/promote-dev-to-main.sh"),
+    path.join(repo, "scripts/promote-dev-to-main.sh"),
+  );
+  await fs.copyFile(
+    path.join(sourceRoot, "scripts/lib/node-tooling.sh"),
+    path.join(repo, "scripts/lib/node-tooling.sh"),
+  );
+  await fs.copyFile(path.join(sourceRoot, ".nvmrc"), path.join(repo, ".nvmrc"));
+  await fs.writeFile(
+    path.join(repo, "scripts/validate-release-promotion.mjs"),
+    "process.exit(1);\n",
+  );
+  await fs.writeFile(
+    path.join(repo, "scripts/validate-main-pr.mjs"),
+    `import fs from "node:fs";\nfs.writeFileSync(${JSON.stringify(validationLog)}, JSON.stringify(process.argv.slice(2)));\n`,
+  );
+  await fs.writeFile(
+    path.join(repo, "scripts/worktree-publish.sh"),
+    `#!${process.execPath}\nconst fs = require("node:fs");\nfs.writeFileSync(${JSON.stringify(publisherLog)}, JSON.stringify(process.argv.slice(2)));\n`,
+    { mode: 0o755 },
+  );
+  await fs.writeFile(reviewArtifact, "{}\n");
+  await fs.writeFile(
+    path.join(repo, "packages/pwa/src/app.ts"),
+    "export const value = 'main';\n",
+  );
+
+  mustRun("git", ["init", "--bare", origin]);
+  mustRun("git", ["init"], { cwd: repo });
+  mustRun("git", ["config", "user.name", "Freed Tests"], { cwd: repo });
+  mustRun("git", ["config", "user.email", "tests@freed.invalid"], {
+    cwd: repo,
+  });
+  mustRun("git", ["add", "-A"], { cwd: repo });
+  mustRun("git", ["commit", "-m", "chore: seed main"], { cwd: repo });
+  mustRun("git", ["branch", "-M", "main"], { cwd: repo });
+  mustRun("git", ["remote", "add", "origin", origin], { cwd: repo });
+  mustRun("git", ["push", "-u", "origin", "main"], { cwd: repo });
+  mustRun("git", ["checkout", "-b", "dev"], { cwd: repo });
+  await fs.writeFile(
+    path.join(repo, "packages/pwa/src/app.ts"),
+    "export const value = 'dev';\n",
+  );
+  mustRun("git", ["add", "packages/pwa/src/app.ts"], { cwd: repo });
+  mustRun("git", ["commit", "-m", "feat: dev change"], { cwd: repo });
+  mustRun("git", ["push", "-u", "origin", "dev"], { cwd: repo });
+  mustRun("git", ["worktree", "add", worktree, "-b", branch, "origin/main"], {
+    cwd: repo,
+  });
+  await fs.writeFile(
+    path.join(worktree, "packages/pwa/src/app.ts"),
+    "export const value = 'dev';\n",
+  );
+  mustRun("git", ["add", "packages/pwa/src/app.ts"], { cwd: worktree });
+  mustRun("git", ["commit", "-m", "chore: promote dev into main"], {
+    cwd: worktree,
+  });
+  return {
+    branch,
+    caller,
+    origin,
+    publisherLog,
+    repo,
+    reviewArtifact,
+    validationLog,
+    worktree,
+  };
+}
+
 test("promotion fails closed when a configured publisher broker is not provisioned", async (t) => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "freed-promote-main-"));
   t.after(async () => {
@@ -134,4 +221,84 @@ test("promotion fails closed when a configured publisher broker is not provision
   await assert.rejects(fs.access(publisherLog));
   await assert.rejects(fs.access(validationLog));
   await assert.rejects(fs.access(worktree));
+});
+
+test("promotion forwards one provider review artifact to draft publication", async (t) => {
+  const fixture = await existingPromotionFixture(t);
+  const result = run(
+    "bash",
+    [
+      path.join(fixture.repo, "scripts/promote-dev-to-main.sh"),
+      fixture.worktree,
+      fixture.branch,
+      "--provider-risk-review-artifact",
+      path.relative(fixture.caller, fixture.reviewArtifact),
+    ],
+    {
+      cwd: fixture.caller,
+      env: { ...process.env, NODE_BIN: process.execPath },
+    },
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  const publisherArgs = JSON.parse(await fs.readFile(fixture.publisherLog));
+  const canonicalReviewArtifact = await fs.realpath(fixture.reviewArtifact);
+  assert.deepEqual(
+    publisherArgs.slice(-2),
+    ["--provider-risk-review-artifact", canonicalReviewArtifact],
+  );
+  assert.equal(publisherArgs.includes("--provider-risk-approval-file"), false);
+  assert.deepEqual(
+    JSON.parse(await fs.readFile(fixture.validationLog)),
+    [
+      "--base-ref=origin/main",
+      "--head-ref=HEAD",
+      `--head-branch=${fixture.branch}`,
+    ],
+  );
+});
+
+test("promotion rejects a stale existing branch before validation or publication", async (t) => {
+  const fixture = await existingPromotionFixture(t);
+  mustRun("git", ["checkout", "main"], { cwd: fixture.repo });
+  await fs.writeFile(path.join(fixture.repo, "MAIN-ONLY.txt"), "advanced\n");
+  mustRun("git", ["add", "MAIN-ONLY.txt"], { cwd: fixture.repo });
+  mustRun("git", ["commit", "-m", "fix: advance main"], {
+    cwd: fixture.repo,
+  });
+  mustRun("git", ["push", "origin", "main"], { cwd: fixture.repo });
+
+  const result = run(
+    "bash",
+    [
+      path.join(fixture.repo, "scripts/promote-dev-to-main.sh"),
+      fixture.worktree,
+      fixture.branch,
+      "--provider-risk-review-artifact",
+      fixture.reviewArtifact,
+    ],
+    {
+      cwd: fixture.caller,
+      env: { ...process.env, NODE_BIN: process.execPath },
+    },
+  );
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /does not equal current origin\/main/);
+  await assert.rejects(fs.access(fixture.validationLog));
+  await assert.rejects(fs.access(fixture.publisherLog));
+});
+
+test("promotion rejects competing provider authority inputs before repository access", () => {
+  const result = run("bash", [
+    path.join(sourceRoot, "scripts/promote-dev-to-main.sh"),
+    "/tmp/not-used",
+    "chore/promote-dev-to-main-test",
+    "--provider-risk-review-artifact",
+    "/tmp/review.json",
+    "--provider-risk-approval-file",
+    "/tmp/approval.json",
+  ]);
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /mutually exclusive/);
 });

--- a/scripts/record-outcome.test.mjs
+++ b/scripts/record-outcome.test.mjs
@@ -31,6 +31,7 @@ import {
 } from "./nightly-self-improve.mjs";
 import { writeMeasuredOutcomeVerdict } from "./test-helpers/outcome-evidence.mjs";
 import { installAutomationKernelGuardCutoverFixture } from "./test-helpers/automation-kernel-guard.mjs";
+import { acquireGeneralActorLeaseForTest } from "./test-helpers/trusted-actor-lease.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CLI_PATH = path.join(__dirname, "record-outcome.mjs");
@@ -48,32 +49,15 @@ function acquireActorLease(stateRoot, actor) {
   installAutomationKernelGuardCutoverFixture(stateRoot);
   const policy = AUTOMATION_ACTOR_POLICIES[actor];
   const token = `${actor}-lease-token`;
-  const actorCredentialToken = `credential:${actor}:${"x".repeat(64)}`;
   const controlRoot = path.join(stateRoot, "control");
   mkdirSync(controlRoot, { recursive: true, mode: 0o700 });
   chmodSync(controlRoot, 0o700);
-  const credentialDir = path.join(stateRoot, "control", "actor-credentials");
-  mkdirSync(credentialDir, { recursive: true, mode: 0o700 });
-  chmodSync(credentialDir, 0o700);
-  writeFileSync(
-    path.join(credentialDir, `${actor}.json`),
-    `${JSON.stringify({
-      schemaVersion: 1,
-      actor,
-      purpose: "automation-actor-lease",
-      tokenSha256: createHash("sha256")
-        .update(actorCredentialToken)
-        .digest("hex"),
-    })}\n`,
-    { mode: 0o600 },
-  );
-  acquireLease({
+  acquireGeneralActorLeaseForTest({
     stateRoot,
     name: policy.leaseName,
     owner: actor,
     operationId: leaseMutationId(`acquire:${actor}`),
     token,
-    actorCredentialToken,
     ttlMs: policy.maxLeaseLifetimeMs,
   });
   return { actor, leaseName: policy.leaseName, leaseToken: token };

--- a/scripts/release-governance.test.mjs
+++ b/scripts/release-governance.test.mjs
@@ -130,6 +130,14 @@ test("feature validation installs Playwright for every desktop e2e plan", () => 
   assert.doesNotMatch(ciWorkflow, /grep -q '\^desktop e2e '/);
 });
 
+test("main PR validation inspects the actual PR head instead of the synthetic merge", () => {
+  assert.match(
+    ciWorkflow,
+    /--head-ref="\$\{\{ github\.event\.pull_request\.head\.sha \}\}"/,
+  );
+  assert.doesNotMatch(ciWorkflow, /validate-main-pr\.mjs[\s\S]*--head-ref=HEAD/);
+});
+
 test("release preparation validates canonical CalVer before mutating version files", () => {
   const validationIndex = releasePrep.indexOf("scripts/release-version.mjs");
   const firstMutationIndex = releasePrep.indexOf(

--- a/scripts/release-promotion-shared.mjs
+++ b/scripts/release-promotion-shared.mjs
@@ -100,8 +100,17 @@ export function isPromotionScopeFile(filePath) {
   );
 }
 
-export function listChangedFiles({ fromRef, toRef, cwd, pathspec = [] }) {
+export function listChangedFiles({
+  fromRef,
+  toRef,
+  cwd,
+  pathspec = [],
+  detectRenames = true,
+}) {
   const args = ["diff", "--name-only", toRef, fromRef];
+  if (!detectRenames) {
+    args.push("--no-renames");
+  }
   if (pathspec.length > 0) {
     args.push("--", ...pathspec);
   }
@@ -149,6 +158,36 @@ export function listPromotionBranchDiffFiles({ fromRef, toRef, cwd }) {
     toRef,
     cwd,
     pathspec: RELEASE_ONLY_PREFIXES,
+  });
+
+  return uniqueSorted([
+    ...promotionScopeFiles,
+    ...websiteConfigFiles,
+    ...releaseNoteFiles,
+  ]);
+}
+
+export function listPromotionBranchPatchFiles({ fromRef, toRef, cwd }) {
+  const promotionScopeFiles = listChangedFiles({
+    fromRef,
+    toRef,
+    cwd,
+    pathspec: PROMOTION_SCOPE_PATHS,
+    detectRenames: false,
+  });
+  const websiteConfigFiles = listChangedFiles({
+    fromRef,
+    toRef,
+    cwd,
+    pathspec: PROMOTION_WEBSITE_CONFIG_FILES,
+    detectRenames: false,
+  });
+  const releaseNoteFiles = listChangedFiles({
+    fromRef,
+    toRef,
+    cwd,
+    pathspec: RELEASE_ONLY_PREFIXES,
+    detectRenames: false,
   });
 
   return uniqueSorted([

--- a/scripts/release-promotion.test.mjs
+++ b/scripts/release-promotion.test.mjs
@@ -5,6 +5,7 @@ import {
   chmodSync,
   mkdtempSync,
   mkdirSync,
+  renameSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
@@ -22,6 +23,10 @@ const __dirname = path.dirname(__filename);
 const VALIDATE_RELEASE_PROMOTION = path.join(
   __dirname,
   "validate-release-promotion.mjs",
+);
+const PREPARE_RELEASE_PROMOTION = path.join(
+  __dirname,
+  "prepare-release-promotion.mjs",
 );
 const VALIDATE_MAIN_PR = path.join(__dirname, "validate-main-pr.mjs");
 const VALIDATE_MAIN_BACKFLOW = path.join(
@@ -195,6 +200,147 @@ test("validate-release-promotion fails when main is stale on product files", (t)
   assert.equal(result.status, 1);
   assert.match(result.stderr, /Production release blocked/);
   assert.match(result.stderr, /packages\/pwa\/src\/app\.ts/);
+});
+
+test("prepare-release-promotion copies the dev product snapshot across squashed history", (t) => {
+  const cwd = makeTempRepo();
+  t.after(() => rmSync(cwd, { recursive: true, force: true }));
+
+  git(cwd, ["checkout", "dev"]);
+  writeRepoFile(
+    cwd,
+    "packages/pwa/src/app.ts",
+    "export const value = 'shared snapshot';\n",
+  );
+  writeRepoFile(
+    cwd,
+    "packages/pwa/src/icon.bin",
+    Buffer.from([0, 1, 2, 3]),
+  );
+  writeRepoFile(cwd, "packages/pwa/src/legacy.ts", "export const old = true;\n");
+  commitAll(cwd, "dev shared snapshot");
+
+  git(cwd, ["checkout", "main"]);
+  writeRepoFile(
+    cwd,
+    "packages/pwa/src/app.ts",
+    "export const value = 'shared snapshot';\n",
+  );
+  writeRepoFile(
+    cwd,
+    "packages/pwa/src/icon.bin",
+    Buffer.from([0, 1, 2, 3]),
+  );
+  writeRepoFile(cwd, "packages/pwa/src/legacy.ts", "export const old = true;\n");
+  commitAll(cwd, "chore: promote dev into main");
+  writeRepoFile(
+    cwd,
+    "packages/pwa/package.json",
+    '{\n  "name": "@freed/pwa",\n  "version": "26.7.700"\n}\n',
+  );
+  commitAll(cwd, "release: preserve main version");
+  updateOriginRef(cwd, "main");
+
+  git(cwd, ["checkout", "dev"]);
+  writeRepoFile(
+    cwd,
+    "packages/pwa/src/app.ts",
+    "export const value = 'next dev snapshot';\n",
+  );
+  writeRepoFile(
+    cwd,
+    "packages/pwa/src/icon.bin",
+    Buffer.from([0, 255, 2, 3]),
+  );
+  renameSync(
+    path.join(cwd, "packages/pwa/src/legacy.ts"),
+    path.join(cwd, "packages/pwa/src/current.ts"),
+  );
+  writeRepoFile(cwd, "docs/NEXT.md", "# Next\n");
+  rmSync(path.join(cwd, "docs/PHASE-1-FOUNDATION.md"));
+  chmodSync(path.join(cwd, "scripts/release.sh"), 0o755);
+  writeRepoFile(
+    cwd,
+    "packages/pwa/package.json",
+    '{\n  "name": "@freed/pwa",\n  "version": "26.7.2200-dev"\n}\n',
+  );
+  writeRepoFile(
+    cwd,
+    "release-notes/releases/v26.7.2200-dev.json",
+    '{\n  "approved": true\n}\n',
+  );
+  commitAll(cwd, "dev advances after promotion");
+  updateOriginRef(cwd, "dev");
+
+  git(cwd, [
+    "checkout",
+    "-b",
+    "chore/promote-dev-to-main-20260722",
+    "origin/main",
+  ]);
+  const naiveMerge = spawnSync(
+    "git",
+    ["merge", "--squash", "--no-commit", "origin/dev"],
+    { cwd, encoding: "utf8" },
+  );
+  assert.notEqual(naiveMerge.status, 0);
+  assert.notEqual(git(cwd, ["diff", "--name-only", "--diff-filter=U"]), "");
+  git(cwd, ["reset", "--hard", "origin/main"]);
+
+  const prepared = runNode(PREPARE_RELEASE_PROMOTION, [
+    `--cwd=${cwd}`,
+    "--from-ref=origin/dev",
+    "--base-ref=origin/main",
+  ]);
+
+  assert.equal(prepared.status, 0, prepared.stderr);
+  assert.match(prepared.stdout, /Prepared 9 product paths for promotion/);
+  assert.equal(
+    git(cwd, ["show", ":packages/pwa/src/app.ts"]),
+    "export const value = 'next dev snapshot';",
+  );
+  assert.equal(git(cwd, ["show", ":docs/NEXT.md"]), "# Next");
+  assert.equal(
+    git(cwd, ["rev-parse", ":packages/pwa/src/icon.bin"]),
+    git(cwd, ["rev-parse", "origin/dev:packages/pwa/src/icon.bin"]),
+  );
+  assert.match(git(cwd, ["ls-files", "-s", "scripts/release.sh"]), /^100755 /);
+  assert.equal(
+    git(cwd, ["show", ":packages/pwa/src/current.ts"]),
+    "export const old = true;",
+  );
+  assert.equal(
+    spawnSync("git", ["cat-file", "-e", ":packages/pwa/src/legacy.ts"], {
+      cwd,
+      encoding: "utf8",
+    }).status,
+    128,
+  );
+  assert.equal(
+    spawnSync(
+      "git",
+      ["cat-file", "-e", ":docs/PHASE-1-FOUNDATION.md"],
+      { cwd, encoding: "utf8" },
+    ).status,
+    128,
+  );
+  assert.match(
+    git(cwd, ["show", ":packages/pwa/package.json"]),
+    /26\.7\.2200-dev/,
+  );
+  assert.equal(
+    git(cwd, ["show", ":release-notes/releases/v26.7.2200-dev.json"]),
+    '{\n  "approved": true\n}',
+  );
+
+  commitAll(cwd, "chore: promote dev into main for production release");
+  const validated = runNode(VALIDATE_MAIN_PR, [
+    `--cwd=${cwd}`,
+    "--base-ref=origin/main",
+    "--head-ref=HEAD",
+    "--head-branch=chore/promote-dev-to-main-20260722",
+  ]);
+  assert.equal(validated.status, 0, validated.stderr);
 });
 
 test("validate-main-backflow ignores squashed promotion content already in dev history", (t) => {
@@ -877,16 +1023,61 @@ test("validate-main-pr passes for a fresh promotion branch", (t) => {
     "-m",
     "chore: promote dev into main for production release",
   ]);
+  const promotionHead = git(cwd, ["rev-parse", "HEAD"]);
+  git(cwd, ["checkout", "main"]);
+  git(cwd, ["merge", "--no-ff", "--no-edit", promotionHead]);
+  assert.equal(
+    git(cwd, ["rev-list", "--parents", "--max-count=1", "HEAD"])
+      .split(/\s+/)
+      .length,
+    3,
+  );
 
   const result = runNode(VALIDATE_MAIN_PR, [
     `--cwd=${cwd}`,
     "--base-ref=origin/main",
-    "--head-ref=HEAD",
+    `--head-ref=${promotionHead}`,
     "--head-branch=chore/promote-dev-to-main-20260421",
   ]);
 
   assert.equal(result.status, 0);
   assert.match(result.stdout, /Promotion branch matches origin\/dev/);
+});
+
+test("validate-main-pr rejects a promotion whose parent is no longer current main", (t) => {
+  const cwd = makeTempRepo();
+  t.after(() => rmSync(cwd, { recursive: true, force: true }));
+
+  git(cwd, ["checkout", "dev"]);
+  writeRepoFile(
+    cwd,
+    "packages/pwa/src/app.ts",
+    "export const value = 'dev';\n",
+  );
+  commitAll(cwd, "dev change");
+  updateOriginRef(cwd, "dev");
+
+  const promotionBranch = "chore/promote-dev-to-main-20260421";
+  git(cwd, ["checkout", "-b", promotionBranch, "main"]);
+  git(cwd, ["merge", "--squash", "--no-commit", "dev"]);
+  commitAll(cwd, "chore: promote dev into main for production release");
+
+  git(cwd, ["checkout", "main"]);
+  writeRepoFile(cwd, "release-notes/releases/v0.0.1.json", "{\n}\n");
+  commitAll(cwd, "release: advance main");
+  updateOriginRef(cwd, "main");
+  git(cwd, ["checkout", promotionBranch]);
+
+  const result = runNode(VALIDATE_MAIN_PR, [
+    `--cwd=${cwd}`,
+    "--base-ref=origin/main",
+    "--head-ref=HEAD",
+    `--head-branch=${promotionBranch}`,
+  ]);
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Promotion PR is stale/);
+  assert.match(result.stderr, /parent is the current origin\/main commit/);
 });
 
 test("validate-main-pr rejects third-content release metadata on a promotion branch", (t) => {

--- a/scripts/test-helpers/trusted-actor-lease.mjs
+++ b/scripts/test-helpers/trusted-actor-lease.mjs
@@ -1,0 +1,68 @@
+import { appendFileSync, cpSync, mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+export const ACTOR_LAUNCHER_CHANNEL_PROTOCOL =
+  "freed-actor-launcher-channel-v1";
+export const TEST_LAUNCHER_SHA256 = "a".repeat(64);
+export const TEST_ACTOR_RUNTIME_DIGEST = "b".repeat(64);
+export const TEST_LAUNCHER_ATTESTATION_SHA256 = "c".repeat(64);
+export const TEST_LAUNCHER_SESSION_ID = "d".repeat(64);
+
+export const TEST_TRUSTED_LAUNCHER_PROVENANCE = Object.freeze({
+  launcherSha256: TEST_LAUNCHER_SHA256,
+  actorRuntimeDigest: TEST_ACTOR_RUNTIME_DIGEST,
+  launcherChannelProtocol: ACTOR_LAUNCHER_CHANNEL_PROTOCOL,
+  launcherAttestationSha256: TEST_LAUNCHER_ATTESTATION_SHA256,
+  launcherSessionId: TEST_LAUNCHER_SESSION_ID,
+});
+
+const scriptsDirectory = path.resolve(import.meta.dirname, "..");
+const internalControlRoot = mkdtempSync(
+  path.join(os.tmpdir(), "freed-trusted-actor-lease-test-"),
+);
+cpSync(path.join(scriptsDirectory, "lib"), internalControlRoot, {
+  recursive: true,
+});
+const internalControlPath = path.join(
+  internalControlRoot,
+  "automation-control.mjs",
+);
+appendFileSync(
+  internalControlPath,
+  `
+export function acquireGeneralActorLeaseForTest(options) {
+  const {
+    actorCredentialToken: _retiredCredential,
+    launcherAttestationSha256 = "c".repeat(64),
+    launcherSessionId = "d".repeat(64),
+    ...leaseOptions
+  } = options;
+  return acquireLeaseAuthorized({
+    ...leaseOptions,
+    trustedLauncherAuthorization: {
+      marker: TRUSTED_LAUNCHER_AUTHORIZATION,
+      launcherSha256: "a".repeat(64),
+      actorRuntimeDigest: "b".repeat(64),
+      launcherChannelProtocol: ACTOR_LAUNCHER_CHANNEL_PROTOCOL,
+      launcherAttestationSha256,
+      launcherSessionId,
+      leaseOperationId: leaseOptions.operationId,
+      leaseTokenSha256: secretDigest(leaseOptions.token),
+    },
+  });
+}
+`,
+);
+
+const internalControl = await import(pathToFileURL(internalControlPath).href);
+
+export const TRUSTED_ACTOR_CONTROL_MODULE_URL =
+  pathToFileURL(internalControlPath).href;
+export const acquireGeneralActorLeaseForTest =
+  internalControl.acquireGeneralActorLeaseForTest;
+
+process.once("exit", () => {
+  rmSync(internalControlRoot, { recursive: true, force: true });
+});

--- a/scripts/validate-main-pr.mjs
+++ b/scripts/validate-main-pr.mjs
@@ -70,6 +70,38 @@ function filesThatDifferFromDev(files, { cwd, headRef }) {
   });
 }
 
+function requirePromotionHeadOnCurrentBase({ cwd, baseRef, headRef }) {
+  const headResult = spawnSync(
+    "git",
+    ["rev-list", "--parents", "--max-count=1", headRef],
+    { cwd, encoding: "utf8" },
+  );
+  if (headResult.status !== 0) {
+    die(
+      `Unable to inspect promotion head ${headRef}: ${headResult.stderr || headResult.error?.message || "git rev-list failed"}`,
+    );
+  }
+
+  const baseResult = spawnSync(
+    "git",
+    ["rev-parse", "--verify", `${baseRef}^{commit}`],
+    { cwd, encoding: "utf8" },
+  );
+  if (baseResult.status !== 0) {
+    die(
+      `Unable to resolve promotion base ${baseRef}: ${baseResult.stderr || baseResult.error?.message || "git rev-parse failed"}`,
+    );
+  }
+
+  const headParts = headResult.stdout.trim().split(/\s+/);
+  const baseSha = baseResult.stdout.trim();
+  if (headParts.length !== 2 || headParts[1] !== baseSha) {
+    die(
+      `Promotion PR is stale. ${headRef} must be one commit whose parent is the current ${baseRef} commit ${baseSha}. Recreate the promotion from the current base.`,
+    );
+  }
+}
+
 function parseArgs(argv) {
   const options = {
     cwd: REPO_ROOT,
@@ -200,6 +232,12 @@ function main() {
       `Promotion PR is stale. ${options.headRef} does not match origin/dev on product-owned paths:\n${formatFileList(driftFiles)}`,
     );
   }
+
+  requirePromotionHeadOnCurrentBase({
+    cwd: options.cwd,
+    baseRef: options.baseRef,
+    headRef: options.headRef,
+  });
 
   console.log("Main PR guard passed. Promotion branch matches origin/dev.");
 }

--- a/scripts/worktree-publish.test.mjs
+++ b/scripts/worktree-publish.test.mjs
@@ -24,6 +24,7 @@ import {
 import { providerApprovalAuthorizationDigest } from "./lib/provider-visible-paths.mjs";
 import { stabilityArtifactDigest } from "./lib/stability-artifacts.mjs";
 import { installAutomationKernelGuardCutoverFixture } from "./test-helpers/automation-kernel-guard.mjs";
+import { acquireGeneralActorLeaseForTest } from "./test-helpers/trusted-actor-lease.mjs";
 
 const scriptsDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptsDir, "..");
@@ -529,28 +530,9 @@ async function authorizeProviderApproval(fixture, approval) {
     const seedPaths = automationControlPaths(seedStateRoot);
     const controller = "freed-stability-controller";
     const controllerPolicy = AUTOMATION_ACTOR_POLICIES[controller];
-    const controllerCredentialToken =
-      `credential:${controller}:${"x".repeat(64)}`;
     const controllerLeaseToken =
       `provider-approval-controller:${"x".repeat(64)}`;
-    await fs.mkdir(seedPaths.actorCredentials, {
-      recursive: true,
-      mode: 0o700,
-    });
-    await fs.chmod(seedPaths.actorCredentials, 0o700);
-    await fs.writeFile(
-      path.join(seedPaths.actorCredentials, `${controller}.json`),
-      `${JSON.stringify({
-        schemaVersion: 1,
-        actor: controller,
-        purpose: "automation-actor-lease",
-        tokenSha256: createHash("sha256")
-          .update(controllerCredentialToken)
-          .digest("hex"),
-      })}\n`,
-      { mode: 0o600 },
-    );
-    const acquiredController = acquireLease({
+    const acquiredController = acquireGeneralActorLeaseForTest({
       stateRoot: seedStateRoot,
       name: controllerPolicy.leaseName,
       owner: controller,
@@ -558,7 +540,6 @@ async function authorizeProviderApproval(fixture, approval) {
         .update(`provider-approval-controller:${approval.approvalId}`)
         .digest("hex"),
       token: controllerLeaseToken,
-      actorCredentialToken: controllerCredentialToken,
       ttlMs: controllerPolicy.maxLeaseLifetimeMs,
     });
     const controllerAcquiredAtMs = Date.parse(


### PR DESCRIPTION
(AI Generated).

## Summary
- Accept exact recovered lease receipts in the native actor launcher without weakening response validation.
- Repair outcome history authority across lease reacquisition and durably initialize the kernel lease runtime scaffold.
- Promote an exact dev snapshot across squashed history and reject stale publication after the publisher refreshes main.

## Testing
- npm run validate:feature
- node --test scripts/release-promotion.test.mjs scripts/release-governance.test.mjs
- node --test --test-name-pattern='native durable directory retirement is exclusive and generation bound' scripts/outcome-ledger-repair.test.mjs