### PR TITLE
fix: recover durable automation cleanup

### DIFF
--- a/scripts/automation-actor-host.swift
+++ b/scripts/automation-actor-host.swift
@@ -24,7 +24,7 @@ private let maximumBindingBytes = 32 * 1_024
 private let maximumControlOutputBytes = 64 * 1_024
 private let maximumAttestationBytes = 16 * 1_024
 private let maximumChannelFrameBytes = 8 * 1_024
-private let controlTimeoutMilliseconds: UInt64 = 30 * 1_000
+private let controlTimeoutMilliseconds: UInt64 = 60 * 1_000
 private let channelTimeoutMilliseconds: Int32 = 5 * 1_000
 #if AUTOMATION_ACTOR_HOST_TESTING
   private let testControlTimeoutMilliseconds: UInt64 = 250
@@ -35,11 +35,11 @@ private let channelTimeoutMilliseconds: Int32 = 5 * 1_000
   private let TEST_LAUNCHER_SESSION_ID = String(repeating: "d", count: 64)
 #else
   // Validation and channel verification share the acquisition window. Two
-  // durable acquire attempts receive 30 seconds each plus a five-second
-  // boundary margin. Once an acquire child may have run, the final 125 seconds
+  // durable acquire attempts receive 60 seconds each plus a five-second
+  // boundary margin. Once an acquire child may have run, the final 245 seconds
   // belong only to two exact-token release attempts and two absence inspections.
-  private let nativeAcquisitionWindowMilliseconds: UInt64 = 65 * 1_000
-  private let nativeCleanupReserveMilliseconds: UInt64 = 125 * 1_000
+  private let nativeAcquisitionWindowMilliseconds: UInt64 = 125 * 1_000
+  private let nativeCleanupReserveMilliseconds: UInt64 = 245 * 1_000
 #endif
 private let nativeLifecycleBudgetMilliseconds =
   nativeAcquisitionWindowMilliseconds + nativeCleanupReserveMilliseconds

--- a/scripts/automation-actor-native.test.mjs
+++ b/scripts/automation-actor-native.test.mjs
@@ -818,7 +818,7 @@ test("native actor lifecycle budget stays below the caller outer ceiling", async
       .replaceAll("_", ""),
   );
   assert.equal(callerBudget, (acquisition + cleanup) * 1_000);
-  assert.equal(control, 30);
+  assert.equal(control, 60);
   assert.ok(acquisition >= control * 2 + 5);
   assert.ok(cleanup >= control * 4 + 5);
 });

--- a/scripts/automation-actors.mjs
+++ b/scripts/automation-actors.mjs
@@ -45,14 +45,14 @@ const MAX_LEASE_LIFETIME_MS = 30 * 60 * 1_000;
 const LEASE_TTL_SECONDS = 30 * 60;
 const MAX_LAUNCHER_HANDOFF_BYTES = 16 * 1_024;
 const MAX_COMMAND_DIAGNOSTIC_BYTES = 4 * 1_024;
-// The native launcher bounds two 30-second acquire attempts, two exact-token
-// release attempts, and two absence inspections to a 190-second lifecycle.
+// The native launcher bounds two 60-second acquire attempts, two exact-token
+// release attempts, and two absence inspections to a 370-second lifecycle.
 // Keep the caller bound above that complete recovery budget so SIGKILL cannot
 // preempt an active bounded child or discard its retained lease token.
-const NATIVE_LAUNCHER_LIFECYCLE_BUDGET_MS = 190_000;
+const NATIVE_LAUNCHER_LIFECYCLE_BUDGET_MS = 370_000;
 const LAUNCHER_ACQUIRE_TIMEOUT_MS =
   NATIVE_LAUNCHER_LIFECYCLE_BUDGET_MS + 10_000;
-const CONTROL_LIFECYCLE_TIMEOUT_MS = 40_000;
+const CONTROL_LIFECYCLE_TIMEOUT_MS = 70_000;
 const PROVISIONER_ACTION_TIMEOUT_MS = 120_000;
 const LIFECYCLE_LOCK_STALE_MS = 30 * 1_000;
 const LIFECYCLE_LOCK_PROTOCOL = "freed-automation-actor-lifecycle-lock-v1";

--- a/scripts/automation-actors.test.mjs
+++ b/scripts/automation-actors.test.mjs
@@ -1907,7 +1907,7 @@ test("acquire validates the public binding and invokes its exact launcher", (t) 
     "--ttl-seconds",
     "1800",
   ]);
-  assert.equal(launcherCall.options.timeoutMs, 200_000);
+  assert.equal(launcherCall.options.timeoutMs, 380_000);
   assert.equal(launcherCall.options.killSignal, "SIGKILL");
   assert.equal(launcherCall.options.stdin, "ignore");
 });
@@ -1936,7 +1936,7 @@ test("acquire fails closed when the installed launcher exceeds its outer bound",
     (error) =>
       error instanceof AutomationActorsError &&
       error.code === "command_timeout" &&
-      error.message.includes("200,000"),
+      error.message.includes("380,000"),
   );
 });
 
@@ -2418,7 +2418,7 @@ test("accept-host proves every installed actor lifecycle without exposing lease 
   const controlCalls = value.calls.filter((call) => call.args[1] === "lease");
   assert.equal(controlCalls.length, AUTOMATION_ACTOR_IDS.length * 3);
   for (const call of controlCalls) {
-    assert.equal(call.options.timeoutMs, 40_000);
+    assert.equal(call.options.timeoutMs, 70_000);
     assert.equal(call.options.killSignal, "SIGKILL");
     assert.equal(call.options.stdin, "ignore");
     assert.equal(
@@ -2715,7 +2715,7 @@ test("accept-host reports a bounded lifecycle timeout after releasing in finally
     (error) =>
       error instanceof AutomationActorsError &&
       error.code === "command_timeout" &&
-      error.message.includes("40,000"),
+      error.message.includes("70,000"),
   );
   assert.equal(value.liveLeases.size, 0);
   assert.equal(

--- a/scripts/automation-control.test.mjs
+++ b/scripts/automation-control.test.mjs
@@ -4114,16 +4114,18 @@ test("actor policies enforce lifecycle ownership and fresh-evidence reopening", 
       nowMs: baseMs + 60 * 60_000,
     }),
   );
-  const reopened = transitionTask({
-    stateRoot,
-    taskId: "policy-reopen",
-    ...reopenController,
-    toState: "triaged",
-    details: {
-      evidenceWindowEnd: new Date(baseMs + 60 * 60_000).toISOString(),
-    },
-    nowMs: baseMs + 61 * 60_000,
-  });
+  const reopened = withTestDateNow(baseMs + 61 * 60_000, () =>
+    transitionTask({
+      stateRoot,
+      taskId: "policy-reopen",
+      ...reopenController,
+      toState: "triaged",
+      details: {
+        evidenceWindowEnd: new Date(baseMs + 60 * 60_000).toISOString(),
+      },
+      nowMs: baseMs + 61 * 60_000,
+    }),
+  );
   assert.equal(reopened.task.state, "triaged");
 });
 
@@ -12708,6 +12710,156 @@ test("completed lease receipt recovery binds the exact retained staged state", (
   );
 });
 
+test("a new exact-token release finishes completed acquisition cleanup after response loss", () => {
+  const stateRoot = temporaryStateRoot();
+  const actor = "freed-release-verifier";
+  const name = AUTOMATION_ACTOR_POLICIES[actor].leaseName;
+  const actorCredentialToken = writeActorCredential(stateRoot, actor);
+  const token = `completed-acquire-cleanup-${"x".repeat(40)}`;
+  const acquireOperationId = nextLeaseOperationId(
+    "completed-acquire-cleanup-acquire",
+  );
+  const nowMs = Date.now();
+
+  assert.throws(
+    () =>
+      acquireLeaseMutation({
+        stateRoot,
+        name,
+        owner: actor,
+        operationId: acquireOperationId,
+        ttlMs: 60_000,
+        nowMs,
+        token,
+        actorCredentialToken,
+        checkpoint: throwAtLeaseCheckpoint("lease-receipt-written"),
+      }),
+    /lease checkpoint lease-receipt-written/,
+  );
+  const acquirePaths = leaseTransactionPaths(
+    stateRoot,
+    name,
+    "acquire",
+    acquireOperationId,
+  );
+  assert.equal(existsSync(acquirePaths.active), true);
+  assert.equal(existsSync(acquirePaths.receipt), true);
+
+  const releaseOperationId = nextLeaseOperationId(
+    "completed-acquire-cleanup-release",
+  );
+  assert.throws(
+    () =>
+      releaseLeaseMutation({
+        stateRoot,
+        name,
+        operationId: releaseOperationId,
+        token: `${token}-wrong`,
+        nowMs: nowMs + 1_000,
+      }),
+    (error) =>
+      isAutomationControlError(error) &&
+      error.code === "lease_transaction_pending",
+  );
+  assert.equal(existsSync(acquirePaths.active), true);
+  assert.equal(existsSync(acquirePaths.receipt), true);
+
+  const released = releaseLeaseMutation({
+    stateRoot,
+    name,
+    operationId: releaseOperationId,
+    token,
+    nowMs: nowMs + 1_000,
+  });
+
+  assert.equal(released.released, true);
+  assert.equal(released.lease.token, undefined);
+  assert.equal(inspectLease({ stateRoot, name }), null);
+  assert.equal(existsSync(acquirePaths.active), false);
+  assert.equal(existsSync(acquirePaths.receipt), true);
+  assert.equal(
+    readControlEvents(stateRoot).filter(
+      (event) => event.eventId === `lease:${acquireOperationId}`,
+    ).length,
+    1,
+  );
+  assert.equal(
+    readControlEvents(stateRoot).filter(
+      (event) => event.eventId === `lease:${releaseOperationId}`,
+    ).length,
+    1,
+  );
+});
+
+test("a different owner operation cannot clean a completed governance transaction", () => {
+  const stateRoot = temporaryStateRoot();
+  const nowMs = Date.now();
+  const taskId = "completed-owner-recovery-fence";
+  const intent = {
+    schemaVersion: 1,
+    action: "task.create",
+    taskId,
+    parameters: {
+      state: "observed",
+      observerAuthority: "merge-safe",
+      providerAuthority: "none",
+      approvalReference: null,
+      details: { behavioral: false },
+    },
+  };
+  const confirmation = writeOwnerConfirmation(stateRoot, taskId, intent, {
+    nowMs,
+  });
+  const token = `completed-owner-recovery-fence-${"x".repeat(40)}`;
+  const acquireOperationId = nextLeaseOperationId(
+    "completed-owner-recovery-fence-acquire",
+  );
+
+  assert.throws(
+    () =>
+      acquireLeaseMutation({
+        stateRoot,
+        name: "owner-governance",
+        owner: "freed-owner",
+        operationId: acquireOperationId,
+        ttlMs: 60_000,
+        nowMs: nowMs + 1,
+        token,
+        ownerConfirmationFile: confirmation.confirmationPath,
+        ownerCapabilityTaskId: taskId,
+        ownerCapabilityIntentDigest: confirmation.intentDigest,
+        checkpoint: throwAtLeaseCheckpoint("lease-receipt-written"),
+      }),
+    /lease checkpoint lease-receipt-written/,
+  );
+  const transactionPaths = leaseTransactionPaths(
+    stateRoot,
+    "owner-governance",
+    "acquire",
+    acquireOperationId,
+  );
+  const before = snapshotLeaseAuthorityState(stateRoot);
+
+  assert.throws(
+    () =>
+      releaseLeaseMutation({
+        stateRoot,
+        name: "owner-governance",
+        operationId: nextLeaseOperationId(
+          "completed-owner-recovery-fence-release",
+        ),
+        token,
+        nowMs: nowMs + 2,
+      }),
+    (error) =>
+      isAutomationControlError(error) &&
+      error.code === "lease_transaction_pending",
+  );
+  assert.deepEqual(snapshotLeaseAuthorityState(stateRoot), before);
+  assert.equal(existsSync(transactionPaths.active), true);
+  assert.equal(existsSync(transactionPaths.receipt), true);
+});
+
 test("complete lease WAL recovery validates retained state before cleanup", () => {
   const stateRoot = temporaryStateRoot();
   const actor = "freed-release-verifier";
@@ -13269,7 +13421,7 @@ test("lease cleanup pins source and destination directory generations across the
               if (
                 swap !== null ||
                 phase !== "lease-cleanup-admitted" ||
-                details.kind !== "staging-before"
+                details.kind !== "staging-after"
               ) {
                 return;
               }
@@ -13279,7 +13431,15 @@ test("lease cleanup pins source and destination directory generations across the
                 const displaced = `${directory}.displaced`;
                 renameSync(directory, displaced);
                 mkdirSync(directory, { mode: 0o700 });
-                swap = { sourceBytes, sourcePath: details.filePath, displaced };
+                swap = {
+                  sourceBytes,
+                  sourcePath: details.filePath,
+                  displaced,
+                  targetArchivePath: path.join(
+                    displaced,
+                    path.basename(details.archivePath),
+                  ),
+                };
               } else {
                 const directory = path.dirname(details.filePath);
                 const displaced = `${directory}.displaced`;
@@ -13295,6 +13455,10 @@ test("lease cleanup pins source and destination directory generations across the
                     path.basename(details.filePath),
                   ),
                   displaced,
+                  targetArchivePath: path.join(
+                    displaced,
+                    path.relative(directory, details.archivePath),
+                  ),
                 };
               }
             },
@@ -13306,12 +13470,7 @@ test("lease cleanup pins source and destination directory generations across the
       );
       assert.ok(swap);
       assert.deepEqual(readFileSync(swap.sourcePath), swap.sourceBytes);
-      assert.equal(
-        readdirSync(swap.displaced, { recursive: true }).some((entry) =>
-          String(entry).startsWith(`${operationId}.`),
-        ),
-        false,
-      );
+      assert.equal(existsSync(swap.targetArchivePath), false);
     });
   }
 });
@@ -19055,7 +19214,7 @@ test("a foreign pending event stage cannot publish an exact current-operation pr
         checkpoint: (phase) => checkpoints.push(phase),
       }),
     (error) =>
-      error instanceof AutomationControlError &&
+      isAutomationControlError(error) &&
       error.code === "authority_generation_conflict",
   );
   assert.deepEqual(checkpoints, []);

--- a/scripts/automation-control.test.mjs
+++ b/scripts/automation-control.test.mjs
@@ -9319,6 +9319,8 @@ test("legacy backfill finalization rejects a tampered reservation event ID", () 
       );
     },
   );
+  retireReadyAuthorityWitnessForLegacyFixture(fixture.paths.taskManifest);
+  retireReadyAuthorityWitnessForLegacyFixture(fixture.paths.events);
 
   const tamperedEventId = `task-outcome-reserved:${"d".repeat(64)}`;
   const events = readEvents(stateRoot);
@@ -9333,7 +9335,6 @@ test("legacy backfill finalization rejects a tampered reservation event ID", () 
     `${events.map((event) => JSON.stringify(event)).join("\n")}\n`,
     { mode: 0o600 },
   );
-  retireReadyAuthorityWitnessForLegacyFixture(fixture.paths.events);
   const ledgerEntries = readFileSync(fixture.paths.outcomes, "utf8")
     .trim()
     .split("\n")

--- a/scripts/lib/automation-control.mjs
+++ b/scripts/lib/automation-control.mjs
@@ -26030,6 +26030,206 @@ export function writeAutomationAuthorityFile({
   }
 }
 
+export function retireOutcomeLedgerAuthorityStageForRepair({
+  stateRoot,
+  operationId,
+  replacementBytes,
+  beforeRemove = () => {},
+}) {
+  const paths = automationControlPaths(stateRoot);
+  if (
+    !SHA256_PATTERN.test(String(operationId ?? "")) ||
+    !Buffer.isBuffer(replacementBytes) ||
+    replacementBytes.length > OUTCOME_LEDGER_REPAIR_MAX_BYTES ||
+    typeof beforeRemove !== "function"
+  ) {
+    throw new AutomationControlError(
+      "invalid_argument",
+      "Outcome ledger repair authority retirement requires one exact bounded repair plan.",
+    );
+  }
+  const current = readAutomationAuthorityFileSnapshot(paths.outcomes, {
+    allowEmpty: true,
+    privateRoot: paths.stateRoot,
+    maxBytes: OUTCOME_LEDGER_REPAIR_MAX_BYTES,
+    allowedModes: [0o600, 0o640, 0o644],
+    label: "Outcome ledger repair canonical source",
+    invalidCode: "authority_generation_conflict",
+  });
+  if (
+    current.missing ||
+    !current.bytes.equals(replacementBytes)
+  ) {
+    throw new AutomationControlError(
+      "authority_generation_conflict",
+      "Outcome ledger repair canonical source changed before authority retirement.",
+    );
+  }
+
+  const directory = openPinnedLeaseArchiveDirectory(
+    path.dirname(paths.outcomes),
+    "Outcome ledger repair authority parent directory",
+  );
+  try {
+    requireAutomationAuthorityDirectoryGeneration(
+      directory,
+      current.directoryIdentity,
+      "Outcome ledger repair authority parent directory",
+    );
+    const helper = openPinnedLeaseArchiveHelper();
+    const stages = listAutomationAuthorityStages(
+      paths.outcomes,
+      helper,
+      directory,
+    );
+    if (stages.length === 0) {
+      return Object.freeze({ retired: false });
+    }
+    if (stages.length !== 1 || stages[0].kind !== "ready") {
+      throw new AutomationControlError(
+        "authority_generation_conflict",
+        "Outcome ledger repair requires at most one complete predecessor authority witness.",
+      );
+    }
+    const stagePath = path.join(path.dirname(paths.outcomes), stages[0].entry);
+    const stage = readAutomationAuthorityStage(stagePath, {
+      privateRoot: paths.stateRoot,
+      maxBytes: OUTCOME_LEDGER_REPAIR_MAX_BYTES,
+      allowedModes: [0o600],
+      label: "Outcome ledger repair predecessor authority witness",
+    });
+    requireAutomationAuthoritySnapshotDirectory(
+      stage,
+      directory,
+      "Outcome ledger repair predecessor authority witness",
+    );
+    if (
+      stage.missing ||
+      stage.bytes.length > replacementBytes.length ||
+      !replacementBytes.subarray(0, stage.bytes.length).equals(stage.bytes)
+    ) {
+      throw new AutomationControlError(
+        "authority_generation_conflict",
+        "Outcome ledger repair predecessor authority witness is outside the authenticated replacement prefix.",
+      );
+    }
+    removeAutomationAuthorityFile({
+      filePath: stagePath,
+      snapshot: stage,
+      operationId: `outcome-ledger-repair:${operationId}`,
+      privateRoot: paths.stateRoot,
+      maxBytes: OUTCOME_LEDGER_REPAIR_MAX_BYTES,
+      allowedModes: [0o600],
+      label: "Outcome ledger repair predecessor authority witness",
+      beforeRemove,
+      retirementBasename: path.basename(paths.outcomes),
+      rawSource: true,
+    });
+    if (
+      listAutomationAuthorityStages(paths.outcomes, helper, directory).length !==
+      0
+    ) {
+      throw new AutomationControlError(
+        "authority_generation_conflict",
+        "Outcome ledger repair authority witness survived exact retirement.",
+      );
+    }
+    return Object.freeze({ retired: true });
+  } finally {
+    closeSync(directory.descriptor);
+  }
+}
+
+export function preflightOutcomeLedgerAuthorityStageForRepair({
+  stateRoot,
+  sourceBytes,
+  replacementBytes,
+}) {
+  const paths = automationControlPaths(stateRoot);
+  if (
+    !Buffer.isBuffer(sourceBytes) ||
+    !Buffer.isBuffer(replacementBytes) ||
+    sourceBytes.length > OUTCOME_LEDGER_REPAIR_MAX_BYTES ||
+    replacementBytes.length > OUTCOME_LEDGER_REPAIR_MAX_BYTES
+  ) {
+    throw new AutomationControlError(
+      "invalid_argument",
+      "Outcome ledger repair authority preflight requires exact bounded source and replacement bytes.",
+    );
+  }
+  const current = readAutomationAuthorityFileSnapshot(paths.outcomes, {
+    allowEmpty: true,
+    privateRoot: paths.stateRoot,
+    maxBytes: OUTCOME_LEDGER_REPAIR_MAX_BYTES,
+    allowedModes: [0o600, 0o640, 0o644],
+    label: "Outcome ledger repair canonical source",
+    invalidCode: "authority_generation_conflict",
+  });
+  if (
+    current.missing ||
+    ![sourceBytes, replacementBytes].some((bytes) =>
+      current.bytes.equals(bytes),
+    )
+  ) {
+    throw new AutomationControlError(
+      "authority_generation_conflict",
+      "Outcome ledger repair canonical source changed before authority preflight.",
+    );
+  }
+  const directory = openPinnedLeaseArchiveDirectory(
+    path.dirname(paths.outcomes),
+    "Outcome ledger repair authority parent directory",
+  );
+  try {
+    requireAutomationAuthorityDirectoryGeneration(
+      directory,
+      current.directoryIdentity,
+      "Outcome ledger repair authority parent directory",
+    );
+    const stages = listAutomationAuthorityStages(
+      paths.outcomes,
+      openPinnedLeaseArchiveHelper(),
+      directory,
+    );
+    if (stages.length === 0) {
+      return Object.freeze({ present: false });
+    }
+    if (stages.length !== 1 || stages[0].kind !== "ready") {
+      throw new AutomationControlError(
+        "authority_generation_conflict",
+        "Outcome ledger repair requires at most one complete predecessor authority witness.",
+      );
+    }
+    const stage = readAutomationAuthorityStage(
+      path.join(path.dirname(paths.outcomes), stages[0].entry),
+      {
+        privateRoot: paths.stateRoot,
+        maxBytes: OUTCOME_LEDGER_REPAIR_MAX_BYTES,
+        allowedModes: [0o600],
+        label: "Outcome ledger repair predecessor authority witness",
+      },
+    );
+    requireAutomationAuthoritySnapshotDirectory(
+      stage,
+      directory,
+      "Outcome ledger repair predecessor authority witness",
+    );
+    if (
+      stage.missing ||
+      stage.bytes.length > replacementBytes.length ||
+      !replacementBytes.subarray(0, stage.bytes.length).equals(stage.bytes)
+    ) {
+      throw new AutomationControlError(
+        "authority_generation_conflict",
+        "Outcome ledger repair predecessor authority witness is outside the authenticated replacement prefix.",
+      );
+    }
+    return Object.freeze({ present: true });
+  } finally {
+    closeSync(directory.descriptor);
+  }
+}
+
 function readPinnedLeaseArchivePath(context, directory, fileBinding, name) {
   assertPinnedLeaseArchiveDirectory(directory);
   assertPinnedLeaseArchiveFile(fileBinding);
@@ -28607,6 +28807,16 @@ function requireCurrentLeaseOperationRecoveryMatch(
       transaction.operation !== operation ||
       transaction.operationId !== operationId
     ) {
+      // A retained general-actor token may finish durable cleanup after the
+      // original response is lost. Owner governance remains exact-plan fenced.
+      if (
+        transaction.phase === "complete" &&
+        transaction.resultReceipt.lease.owner !== "freed-owner" &&
+        transaction.tokenDigest === tokenDigest
+      ) {
+        recoverLeaseTransactionUnlocked(paths, name, Date.now(), eventsGuard);
+        return;
+      }
       throw new AutomationControlError(
         "lease_transaction_pending",
         `Lease ${name} has a pending transaction that only its exact caller plan may recover.`,

--- a/scripts/lib/automation-control.mjs
+++ b/scripts/lib/automation-control.mjs
@@ -26144,20 +26144,24 @@ export function preflightOutcomeLedgerAuthorityStageForRepair({
   stateRoot,
   sourceBytes,
   replacementBytes,
+  canonicalState = "present",
 }) {
   const paths = automationControlPaths(stateRoot);
   if (
     !Buffer.isBuffer(sourceBytes) ||
     !Buffer.isBuffer(replacementBytes) ||
     sourceBytes.length > OUTCOME_LEDGER_REPAIR_MAX_BYTES ||
-    replacementBytes.length > OUTCOME_LEDGER_REPAIR_MAX_BYTES
+    replacementBytes.length > OUTCOME_LEDGER_REPAIR_MAX_BYTES ||
+    !["present", "recoverable-missing", "completed"].includes(canonicalState)
   ) {
     throw new AutomationControlError(
       "invalid_argument",
       "Outcome ledger repair authority preflight requires exact bounded source and replacement bytes.",
     );
   }
+  const canonicalMustBeMissing = canonicalState === "recoverable-missing";
   const current = readAutomationAuthorityFileSnapshot(paths.outcomes, {
+    allowMissing: canonicalMustBeMissing,
     allowEmpty: true,
     privateRoot: paths.stateRoot,
     maxBytes: OUTCOME_LEDGER_REPAIR_MAX_BYTES,
@@ -26165,11 +26169,20 @@ export function preflightOutcomeLedgerAuthorityStageForRepair({
     label: "Outcome ledger repair canonical source",
     invalidCode: "authority_generation_conflict",
   });
+  const canonicalMatchesPlan =
+    canonicalState === "completed"
+      ? !current.missing &&
+        current.bytes.length >= replacementBytes.length &&
+        current.bytes
+          .subarray(0, replacementBytes.length)
+          .equals(replacementBytes)
+      : !current.missing &&
+        [sourceBytes, replacementBytes].some((bytes) =>
+          current.bytes.equals(bytes),
+        );
   if (
-    current.missing ||
-    ![sourceBytes, replacementBytes].some((bytes) =>
-      current.bytes.equals(bytes),
-    )
+    current.missing !== canonicalMustBeMissing ||
+    (!current.missing && !canonicalMatchesPlan)
   ) {
     throw new AutomationControlError(
       "authority_generation_conflict",
@@ -26191,8 +26204,11 @@ export function preflightOutcomeLedgerAuthorityStageForRepair({
       openPinnedLeaseArchiveHelper(),
       directory,
     );
+    const canonicalHasLaterEntries =
+      canonicalState === "completed" &&
+      current.bytes.length > replacementBytes.length;
     if (stages.length === 0) {
-      return Object.freeze({ present: false });
+      return Object.freeze({ present: false, retireable: false });
     }
     if (stages.length !== 1 || stages[0].kind !== "ready") {
       throw new AutomationControlError(
@@ -26216,15 +26232,23 @@ export function preflightOutcomeLedgerAuthorityStageForRepair({
     );
     if (
       stage.missing ||
-      stage.bytes.length > replacementBytes.length ||
-      !replacementBytes.subarray(0, stage.bytes.length).equals(stage.bytes)
+      stage.bytes.length >
+        (canonicalHasLaterEntries
+          ? current.bytes.length
+          : replacementBytes.length) ||
+      !(canonicalHasLaterEntries ? current.bytes : replacementBytes)
+        .subarray(0, stage.bytes.length)
+        .equals(stage.bytes)
     ) {
       throw new AutomationControlError(
         "authority_generation_conflict",
         "Outcome ledger repair predecessor authority witness is outside the authenticated replacement prefix.",
       );
     }
-    return Object.freeze({ present: true });
+    return Object.freeze({
+      present: true,
+      retireable: !canonicalHasLaterEntries,
+    });
   } finally {
     closeSync(directory.descriptor);
   }

--- a/scripts/lib/outcome-ledger-repair.mjs
+++ b/scripts/lib/outcome-ledger-repair.mjs
@@ -25,11 +25,13 @@ import {
   CONTROL_EVENT_HISTORY_MAX_BYTES,
   framePinnedLeaseArchiveHelperInvocation,
   ownerGovernanceIntentDigest,
+  preflightOutcomeLedgerAuthorityStageForRepair,
   preauthorizeOutcomeLedgerRepair,
   preflightOutcomeLedgerRepairEvent,
   readAutomationPlanningAdmission,
   readPinnedLeaseArchiveHelperSource,
   reauthorizeOutcomeLedgerRepairLease,
+  retireOutcomeLedgerAuthorityStageForRepair,
   validateOutcomeLedgerRepairEvent,
   withAutomationPlanningReadBundle,
   withMutationLeaseAuthority,
@@ -4791,6 +4793,11 @@ export function repairOutcomeLedger(
       }
       plan = recoveredPlan;
       transaction = recoveredPlan.transaction;
+      preflightOutcomeLedgerAuthorityStageForRepair({
+        stateRoot: root,
+        sourceBytes: plan.material.sourceBytes,
+        replacementBytes: plan.material.trustedBytes,
+      });
       if (transaction.phase === "fenced") {
         preflightRepairTemporaryFiles(plan, { fencedRecovery: true });
         writePreparedArtifacts(
@@ -4826,6 +4833,11 @@ export function repairOutcomeLedger(
         throw new Error("Outcome ledger classification drifted before repair.");
       }
       plan = lockedPlan;
+      preflightOutcomeLedgerAuthorityStageForRepair({
+        stateRoot: root,
+        sourceBytes: plan.material.sourceBytes,
+        replacementBytes: plan.material.trustedBytes,
+      });
       preflightRepairTemporaryFiles(plan, { beforeFirstFence: true });
       preflightOutcomeLedgerRepairEvent({
         stateRoot: root,
@@ -4867,12 +4879,31 @@ export function repairOutcomeLedger(
       transaction = recoveredPlan.transaction;
     }
 
+    const retireLedgerAuthorityStage = (beforeRemove) => {
+      const authorityRetirement =
+        retireOutcomeLedgerAuthorityStageForRepair({
+          stateRoot: root,
+          operationId: plan.operationId,
+          replacementBytes: plan.material.trustedBytes,
+          beforeRemove: () => {
+            guardedCheckpoint(
+              "outcome-ledger-authority-stage-before-retirement",
+            );
+            beforeRemove();
+          },
+        });
+      if (authorityRetirement.retired) {
+        guardedCheckpoint("outcome-ledger-authority-stage-retired");
+      }
+    };
+
     reauthorizeCurrentRepair();
     if (
       transaction?.phase === "complete" &&
       !existsAsPath(plan.artifacts.transaction) &&
       existsAsPath(plan.artifacts.completedTransaction)
     ) {
+      retireLedgerAuthorityStage(reauthorizeCurrentRepair);
       if (hasActionableRepairReplacementTemporary(plan)) {
         verifyCompletedRepair(plan, {
           requireComplete: false,
@@ -4923,6 +4954,7 @@ export function repairOutcomeLedger(
             beforeMutation,
           });
         if (transaction.phase === "complete") {
+          retireLedgerAuthorityStage(beforeMutation);
           cleanupRepairTemporaryFiles(
             plan,
             guardedCheckpoint,
@@ -5109,6 +5141,16 @@ export function repairOutcomeLedger(
               });
               guardedCheckpoint("transaction-replaced");
             }
+            if (
+              !["replaced", "audited", "complete"].includes(
+                transaction.phase,
+              )
+            ) {
+              throw new Error(
+                "Outcome ledger repair cannot retire authority before replacement publication.",
+              );
+            }
+            retireLedgerAuthorityStage(beforeMutation);
             if (!["audited", "complete"].includes(transaction.phase)) {
               appendRepairEvent();
               captureRepairTopology(plan);

--- a/scripts/lib/outcome-ledger-repair.mjs
+++ b/scripts/lib/outcome-ledger-repair.mjs
@@ -2749,10 +2749,7 @@ function openPublicationIdentity(filePath, record, expectedBytes, label) {
   return pinned;
 }
 
-function recoverLedgerReplacementPublication(
-  plan,
-  { checkpoint = () => {}, beforeMutation = () => {} } = {},
-) {
+function admitLedgerReplacementPublicationRecovery(plan) {
   const publication = readLedgerReplacementPublicationIntent(plan);
   if (publication === null) return null;
   requirePrivateDescendantDirectories(
@@ -2813,12 +2810,76 @@ function recoverLedgerReplacementPublication(
         "Outcome ledger repair publication canonical contains a foreign generation.",
       );
     }
+    let state;
     if (canonicalIsReplacement && archive !== null && replacement === null) {
+      state = "published";
+    } else if (
+      canonicalIsPredecessor &&
+      archive === null &&
+      replacement !== null
+    ) {
+      state = "predecessor-canonical";
+    } else if (
+      canonical === null &&
+      archive !== null &&
+      replacement !== null
+    ) {
+      state = "canonical-missing";
+    } else {
+      throw new Error(
+        "Outcome ledger repair publication intent has an invalid recovery state.",
+      );
+    }
+    return {
+      publication,
+      canonical,
+      archive,
+      replacement,
+      state,
+    };
+  } catch (error) {
+    closeLedgerReplacementPublicationRecovery({
+      canonical,
+      archive,
+      replacement,
+    });
+    throw error;
+  }
+}
+
+function closeLedgerReplacementPublicationRecovery(recovery) {
+  const descriptors = new Set(
+    [recovery.canonical, recovery.archive, recovery.replacement]
+      .filter((value) => value !== null)
+      .map((value) => value.descriptor),
+  );
+  for (const descriptor of descriptors) closeSync(descriptor);
+}
+
+function inspectLedgerReplacementPublicationRecovery(plan) {
+  const recovery = admitLedgerReplacementPublicationRecovery(plan);
+  if (recovery === null) return null;
+  try {
+    return Object.freeze({ state: recovery.state });
+  } finally {
+    closeLedgerReplacementPublicationRecovery(recovery);
+  }
+}
+
+function recoverLedgerReplacementPublication(
+  plan,
+  { checkpoint = () => {}, beforeMutation = () => {} } = {},
+) {
+  const recovery = admitLedgerReplacementPublicationRecovery(plan);
+  if (recovery === null) return null;
+  const { publication, canonical, archive, replacement, state } = recovery;
+  try {
+    if (state === "published") {
       checkpoint("replacement-publication-recovered");
       return publication.replacement;
     }
     let predecessorAtArchive = archive;
-    if (canonicalIsPredecessor && archive === null && replacement !== null) {
+    if (state === "predecessor-canonical") {
       beforeMutation();
       runDurableRepairMove(
         plan.artifacts.outcomes,
@@ -2828,14 +2889,6 @@ function recoverLedgerReplacementPublication(
       );
       predecessorAtArchive = canonical;
       checkpoint("replacement-predecessor-archive-recovered");
-    } else if (
-      canonical !== null ||
-      archive === null ||
-      replacement === null
-    ) {
-      throw new Error(
-        "Outcome ledger repair publication intent has an invalid recovery state.",
-      );
     }
     requirePinnedRepairFile(
       publication.archivePath,
@@ -2866,12 +2919,7 @@ function recoverLedgerReplacementPublication(
     );
     return publication.replacement;
   } finally {
-    const descriptors = new Set(
-      [canonical, archive, replacement]
-        .filter((value) => value !== null)
-        .map((value) => value.descriptor),
-    );
-    for (const descriptor of descriptors) closeSync(descriptor);
+    closeLedgerReplacementPublicationRecovery(recovery);
   }
 }
 
@@ -4766,6 +4814,8 @@ export function repairOutcomeLedger(
       sourceDigest,
     );
     let transaction = lockedTransaction?.record ?? null;
+    let ledgerPublicationRecovery = null;
+    let ledgerAuthorityPreflight = null;
     const reauthorizeCurrentRepair = () =>
       invokeReadOnlyRepairCallback(plan, () =>
         reauthorizeOutcomeLedgerRepairLease({
@@ -4793,11 +4843,26 @@ export function repairOutcomeLedger(
       }
       plan = recoveredPlan;
       transaction = recoveredPlan.transaction;
-      preflightOutcomeLedgerAuthorityStageForRepair({
-        stateRoot: root,
-        sourceBytes: plan.material.sourceBytes,
-        replacementBytes: plan.material.trustedBytes,
-      });
+      const completedTransactionRetired =
+        transaction.phase === "complete" &&
+        !existsAsPath(plan.artifacts.transaction) &&
+        existsAsPath(plan.artifacts.completedTransaction);
+      ledgerPublicationRecovery =
+        completedTransactionRetired
+          ? null
+          : inspectLedgerReplacementPublicationRecovery(plan);
+      ledgerAuthorityPreflight =
+        preflightOutcomeLedgerAuthorityStageForRepair({
+          stateRoot: root,
+          sourceBytes: plan.material.sourceBytes,
+          replacementBytes: plan.material.trustedBytes,
+          canonicalState:
+            ledgerPublicationRecovery?.state === "canonical-missing"
+              ? "recoverable-missing"
+              : completedTransactionRetired
+                ? "completed"
+                : "present",
+        });
       if (transaction.phase === "fenced") {
         preflightRepairTemporaryFiles(plan, { fencedRecovery: true });
         writePreparedArtifacts(
@@ -4833,11 +4898,12 @@ export function repairOutcomeLedger(
         throw new Error("Outcome ledger classification drifted before repair.");
       }
       plan = lockedPlan;
-      preflightOutcomeLedgerAuthorityStageForRepair({
-        stateRoot: root,
-        sourceBytes: plan.material.sourceBytes,
-        replacementBytes: plan.material.trustedBytes,
-      });
+      ledgerAuthorityPreflight =
+        preflightOutcomeLedgerAuthorityStageForRepair({
+          stateRoot: root,
+          sourceBytes: plan.material.sourceBytes,
+          replacementBytes: plan.material.trustedBytes,
+        });
       preflightRepairTemporaryFiles(plan, { beforeFirstFence: true });
       preflightOutcomeLedgerRepairEvent({
         stateRoot: root,
@@ -4900,10 +4966,13 @@ export function repairOutcomeLedger(
     reauthorizeCurrentRepair();
     if (
       transaction?.phase === "complete" &&
+      ledgerPublicationRecovery?.state !== "canonical-missing" &&
       !existsAsPath(plan.artifacts.transaction) &&
       existsAsPath(plan.artifacts.completedTransaction)
     ) {
-      retireLedgerAuthorityStage(reauthorizeCurrentRepair);
+      if (ledgerAuthorityPreflight?.retireable) {
+        retireLedgerAuthorityStage(reauthorizeCurrentRepair);
+      }
       if (hasActionableRepairReplacementTemporary(plan)) {
         verifyCompletedRepair(plan, {
           requireComplete: false,
@@ -4944,17 +5013,36 @@ export function repairOutcomeLedger(
         };
         const committedPlan = committedRepairEventPlan();
         if (committedPlan !== null) plan.eventPlan = committedPlan;
-        transaction = recoverTransactionPublications(plan, {
-          checkpoint: guardedCheckpoint,
-          beforeMutation,
-        });
-        recoveredLedgerReplacementPublication =
-          recoverLedgerReplacementPublication(plan, {
+        const recoverLedgerPublication = () => {
+          recoveredLedgerReplacementPublication =
+            recoverLedgerReplacementPublication(plan, {
+              checkpoint: guardedCheckpoint,
+              beforeMutation,
+            });
+          ledgerAuthorityPreflight =
+            preflightOutcomeLedgerAuthorityStageForRepair({
+              stateRoot: root,
+              sourceBytes: plan.material.sourceBytes,
+              replacementBytes: plan.material.trustedBytes,
+            });
+        };
+        if (ledgerPublicationRecovery?.state === "canonical-missing") {
+          recoverLedgerPublication();
+          transaction = recoverTransactionPublications(plan, {
             checkpoint: guardedCheckpoint,
             beforeMutation,
           });
+        } else {
+          transaction = recoverTransactionPublications(plan, {
+            checkpoint: guardedCheckpoint,
+            beforeMutation,
+          });
+          recoverLedgerPublication();
+        }
         if (transaction.phase === "complete") {
-          retireLedgerAuthorityStage(beforeMutation);
+          if (ledgerAuthorityPreflight?.retireable) {
+            retireLedgerAuthorityStage(beforeMutation);
+          }
           cleanupRepairTemporaryFiles(
             plan,
             guardedCheckpoint,

--- a/scripts/outcome-ledger-repair.test.mjs
+++ b/scripts/outcome-ledger-repair.test.mjs
@@ -32,6 +32,7 @@ import { pathToFileURL } from "node:url";
 
 import {
   AUTOMATION_ACTOR_POLICIES,
+  CONTROL_EVENT_HISTORY_MAX_RECORDS,
   acquireLease,
   automationControlPaths,
   consumeLeaseArchiveHelperInvocationCountForTest,
@@ -1420,6 +1421,39 @@ function appendJsonPaddingToSize(filePath, targetSize, type) {
   }
   appendFileSync(filePath, Buffer.concat(chunks, totalPadding));
   assert.equal(statSync(filePath).size, targetSize);
+}
+
+function appendControlEventPaddingToRecordCount(paths, targetRecordCount) {
+  removeControlEventAuthorityStages(paths);
+  const existing = readFileSync(paths.events, "utf8");
+  const existingRecordCount = existing
+    .split(/\r?\n/)
+    .filter((line) => line !== "").length;
+  assert.ok(targetRecordCount > existingRecordCount);
+  const lines = [];
+  for (
+    let index = existingRecordCount;
+    index < targetRecordCount;
+    index += 1
+  ) {
+    lines.push(
+      JSON.stringify({
+        schemaVersion: 1,
+        eventId: `00000000-0000-4000-8000-${index
+          .toString(16)
+          .padStart(12, "0")}`,
+        type: "test_capacity_padding",
+        ts: "2026-07-22T00:00:00.000Z",
+        actor: "freed-stability-controller",
+        data: { index },
+      }),
+    );
+  }
+  appendFileSync(paths.events, `${lines.join("\n")}\n`);
+  const finalRecordCount = readFileSync(paths.events, "utf8")
+    .split(/\r?\n/)
+    .filter((line) => line !== "").length;
+  assert.equal(finalRecordCount, targetRecordCount);
 }
 
 function outcomeMutationSnapshot(stateRoot, paths) {
@@ -3160,8 +3194,23 @@ test("a prepared repair rejects a live legacy receipt temporary", (t) => {
       .ledgerHealthy,
     false,
   );
-  rmSync(receiptTemporaryPath);
-  assert.equal(executeRepair({ stateRoot, sourceDigest }).changed, true);
+  assert.equal(existsSync(receiptTemporaryPath), false);
+  const retiredReceiptTemps = readdirSync(
+    path.join(session.plan.artifacts.artifactDirectory, "retired"),
+  ).filter(
+    (entry) =>
+      entry.startsWith("temporary-v2.receipt.424215.") &&
+      entry.endsWith(".archive"),
+  );
+  assert.equal(retiredReceiptTemps.length, 1);
+  const retiredLedger = readFileSync(paths.outcomes);
+  const retiredEvents = readFileSync(paths.events);
+  assert.throws(
+    () => executeRepair({ stateRoot, sourceDigest }),
+    /retired receipt temporary exists before audit/,
+  );
+  assert.deepEqual(readFileSync(paths.outcomes), retiredLedger);
+  assert.deepEqual(readFileSync(paths.events), retiredEvents);
 });
 
 test("a post-fence foreign sibling blocks preparation without mutation", (t) => {
@@ -4096,15 +4145,6 @@ for (const variant of [
         .phase,
       variant.phase,
     );
-    releaseLease({
-      stateRoot,
-      name: session.owner.leaseName,
-      operationId: leaseMutationId(`release:pending-audit-${variant.name}`),
-      token: session.owner.leaseToken,
-    });
-    const replacementOwner = ownerRepairLease(stateRoot, session.plan, {
-      nowMs: Date.now() + 1_000,
-    });
     const beforeEvents = readFileSync(paths.events);
     const beforeLedger = readFileSync(paths.outcomes);
     const beforeTransaction = readFileSync(session.plan.artifacts.transaction);
@@ -4115,8 +4155,19 @@ for (const variant of [
     assert.equal(summary.sourceHealth.outcomeLedgerTransactionsHealthy, false);
     assert.throws(
       () =>
-        executeRepair({ stateRoot, sourceDigest }, { owner: replacementOwner }),
-      /requires healthy ledger, control event, and repair transaction sources/,
+        releaseLease({
+          stateRoot,
+          name: session.owner.leaseName,
+          operationId: leaseMutationId(
+            `release:pending-audit-${variant.name}`,
+          ),
+          token: session.owner.leaseToken,
+        }),
+      (error) => error?.code === "outcome_ledger_repair_transaction_invalid",
+    );
+    assert.throws(
+      () => executeRepair({ stateRoot, sourceDigest }),
+      (error) => error?.code === "outcome_ledger_repair_transaction_invalid",
     );
     assert.equal(readFileSync(paths.events).equals(beforeEvents), true);
     assert.equal(readFileSync(paths.outcomes).equals(beforeLedger), true);
@@ -5163,23 +5214,28 @@ test("repair audit capacity is preflighted before ledger transaction or event mu
   const { stateRoot, paths } = temporaryStateRoot(t);
   const source = legacyLine("repair-audit-capacity-preflight");
   const sourceDigest = writeLedger(paths, source);
+  appendControlEventPaddingToRecordCount(
+    paths,
+    CONTROL_EVENT_HISTORY_MAX_RECORDS - 1,
+  );
   const plan = planOutcomeLedgerRepair({
     stateRoot,
     taskId: TASK_ID,
     expectedSourceDigest: sourceDigest,
   });
   const owner = ownerRepairLease(stateRoot, plan);
-  const eventCap = 128 * 1024 * 1024;
-  const targetSize = eventCap - 128;
-  appendJsonPaddingToSize(
-    paths.events,
-    targetSize,
-    "repair_audit_capacity_padding",
-  );
 
   const manifestBefore = readFileSync(paths.taskManifest);
   const taskBefore = readTask({ stateRoot, taskId: TASK_ID });
-  const eventDigestBefore = sha256(readFileSync(paths.events));
+  const eventsBefore = readFileSync(paths.events);
+  const eventDigestBefore = sha256(eventsBefore);
+  assert.equal(
+    eventsBefore.reduce(
+      (count, byte) => count + (byte === 0x0a ? 1 : 0),
+      0,
+    ),
+    CONTROL_EVENT_HISTORY_MAX_RECORDS,
+  );
   const repairTransactionsBefore = flatDirectorySnapshot(
     plan.artifacts.transactionDirectory,
   );
@@ -5196,7 +5252,7 @@ test("repair audit capacity is preflighted before ledger transaction or event mu
   );
 
   assert.equal(readFileSync(paths.outcomes).equals(source), true);
-  assert.equal(statSync(paths.events).size, targetSize);
+  assert.equal(statSync(paths.events).size, eventsBefore.length);
   assert.equal(sha256(readFileSync(paths.events)), eventDigestBefore);
   assert.equal(readFileSync(paths.taskManifest).equals(manifestBefore), true);
   assert.deepEqual(readTask({ stateRoot, taskId: TASK_ID }), taskBefore);
@@ -5539,6 +5595,25 @@ for (const checkpointName of [
       ...owner,
     });
     assert.equal(recovered.changed, true);
+    assert.equal(
+      readdirSync(stateRoot).some((entry) =>
+        entry.startsWith(`.${path.basename(paths.outcomes)}.authority.`),
+      ),
+      false,
+    );
+    const authorityRetirements = path.join(
+      stateRoot,
+      ".authority-retirements",
+    );
+    assert.equal(existsSync(authorityRetirements), true);
+    assert.equal(
+      readdirSync(authorityRetirements).some(
+        (entry) =>
+          entry.startsWith(`${path.basename(paths.outcomes)}.`) &&
+          entry.endsWith(".retired"),
+      ),
+      true,
+    );
     const installed = appendOutcomeLedger(
       paths.outcomes,
       installedEntry,
@@ -5563,6 +5638,29 @@ for (const checkpointName of [
     );
   });
 }
+
+test("repair rejects a foreign outcome authority witness before ledger mutation", (t) => {
+  const { stateRoot, paths } = temporaryStateRoot(t);
+  const source = legacyLine("foreign-outcome-authority-witness");
+  const sourceDigest = writeLedger(paths, source);
+  const session = repairSession(stateRoot, sourceDigest);
+  const witnessPath = path.join(
+    stateRoot,
+    `.${path.basename(paths.outcomes)}.authority.${"a".repeat(64)}.${"b".repeat(64)}.tmp`,
+  );
+  const witnessBytes = Buffer.from("foreign predecessor witness\n", "utf8");
+  writeFileSync(witnessPath, witnessBytes, { mode: 0o600 });
+  const beforeLedger = readFileSync(paths.outcomes);
+
+  assert.throws(
+    () => executeRepair({ stateRoot, sourceDigest }),
+    /predecessor authority witness is outside the authenticated replacement prefix/,
+  );
+  assert.equal(readFileSync(paths.outcomes).equals(beforeLedger), true);
+  assert.equal(readFileSync(witnessPath).equals(witnessBytes), true);
+  assert.equal(existsSync(session.plan.artifacts.transaction), false);
+  assert.equal(existsSync(session.plan.artifacts.artifactDirectory), false);
+});
 
 for (const checkpointName of [
   "outcome-transition-resolved",

--- a/scripts/outcome-ledger-repair.test.mjs
+++ b/scripts/outcome-ledger-repair.test.mjs
@@ -2306,12 +2306,38 @@ test("repair retains authenticated lines byte for byte and later appends survive
       .ledgerHealthy,
     true,
   );
+  const authorityStageEntries = readdirSync(stateRoot)
+    .filter((entry) =>
+      entry.startsWith(`.${path.basename(paths.outcomes)}.authority.`),
+    )
+    .sort();
+  assert.equal(authorityStageEntries.length, 1);
+  const authorityStagePath = path.join(stateRoot, authorityStageEntries[0]);
+  const authorityStageBeforeRetry =
+    pinnedRegularFileSnapshot(authorityStagePath);
 
   const retry = executeRepair({ stateRoot, sourceDigest });
   assert.equal(retry.changed, false);
   assert.equal(
     readFileSync(paths.outcomes).equals(afterAuthenticatedAppend),
     true,
+  );
+  assert.deepEqual(
+    readdirSync(stateRoot)
+      .filter((entry) =>
+        entry.startsWith(`.${path.basename(paths.outcomes)}.authority.`),
+      )
+      .sort(),
+    authorityStageEntries,
+  );
+  const authorityStageAfterRetry = pinnedRegularFileSnapshot(authorityStagePath);
+  assert.deepEqual(
+    authorityStageAfterRetry.bytes,
+    authorityStageBeforeRetry.bytes,
+  );
+  assert.equal(
+    authorityStageAfterRetry.identity.ino,
+    authorityStageBeforeRetry.identity.ino,
   );
 });
 
@@ -6760,6 +6786,201 @@ for (const move of [
     });
   }
 }
+
+test("missing canonical recovery rejects a foreign authority witness before mutation", async (t) => {
+  const fixture = temporaryStateRoot(t);
+  const source = legacyLine("missing-canonical-foreign-authority-witness");
+  const sourceDigest = writeLedger(fixture.paths, source);
+  const plan = planOutcomeLedgerRepair({
+    stateRoot: fixture.stateRoot,
+    taskId: TASK_ID,
+    expectedSourceDigest: sourceDigest,
+  });
+  const owner = ownerRepairLease(fixture.stateRoot, plan);
+  const child = spawnNativePausedRepairChild(t, {
+    stateRoot: fixture.stateRoot,
+    sourceDigest,
+    owner,
+    pause: "after-postcheck",
+    operation: "rename-durable",
+    source: path.basename(fixture.paths.outcomes),
+    destination: "",
+  });
+
+  await waitForNativeHelperPause(child, "after-postcheck");
+  killPausedNativeHelper(child);
+  const childExit = await waitForChildExit(child);
+  assert.equal(childExit.code, 1);
+  assert.equal(childExit.signal, null);
+
+  assert.equal(existsSync(fixture.paths.outcomes), false);
+  const transactionBytes = transactionBytesForPlan(plan, "prepared");
+  assert.deepEqual(readFileSync(plan.artifacts.transaction), transactionBytes);
+  assert.equal(existsSync(plan.artifacts.completedTransaction), false);
+  assert.equal(existsSync(plan.artifacts.receiptArtifact), false);
+  assert.equal(repairAuditEvents(fixture.paths, plan.eventId).length, 0);
+
+  const publicationIntentPath = path.join(
+    plan.artifacts.artifactDirectory,
+    "publication-intents",
+    "ledger-replacement.json",
+  );
+  const publicationIntentBytes = readFileSync(publicationIntentPath);
+  const publicationIntent = JSON.parse(publicationIntentBytes.toString("utf8"));
+  assert.equal(publicationIntent.operationId, plan.operationId);
+  assert.equal(publicationIntent.targetPath, fixture.paths.outcomes);
+  assert.equal(publicationIntent.predecessor.digest, sourceDigest);
+  assert.equal(publicationIntent.predecessor.size, source.length);
+  assert.equal(
+    publicationIntent.replacement.digest,
+    plan.parameters.replacementDigest,
+  );
+  assert.equal(
+    publicationIntent.replacement.size,
+    plan.parameters.replacementSize,
+  );
+
+  const predecessorBefore = pinnedRegularFileSnapshot(
+    publicationIntent.predecessor.archivePath,
+  );
+  const replacementBefore = pinnedRegularFileSnapshot(
+    publicationIntent.replacement.path,
+  );
+  assert.deepEqual(predecessorBefore.bytes, source);
+  assert.equal(sha256(predecessorBefore.bytes), sourceDigest);
+  assert.equal(Number(predecessorBefore.identity.mode & 0o7777n), 0o600);
+  assert.equal(predecessorBefore.identity.nlink, 1n);
+  assert.equal(
+    sha256(replacementBefore.bytes),
+    plan.parameters.replacementDigest,
+  );
+  assert.equal(
+    replacementBefore.bytes.length,
+    plan.parameters.replacementSize,
+  );
+  assert.equal(Number(replacementBefore.identity.mode & 0o7777n), 0o600);
+  assert.equal(replacementBefore.identity.nlink, 1n);
+
+  const witnessPath = path.join(
+    fixture.stateRoot,
+    `.${path.basename(fixture.paths.outcomes)}.authority.${"a".repeat(64)}.${"b".repeat(64)}.tmp`,
+  );
+  const witnessBytes = Buffer.from("foreign predecessor witness\n", "utf8");
+  writeFileSync(witnessPath, witnessBytes, { mode: 0o600 });
+  chmodSync(witnessPath, 0o600);
+
+  const before = {
+    tree: snapshotTestTree(fixture.stateRoot),
+    transaction: readFileSync(plan.artifacts.transaction),
+    publicationIntent: readFileSync(publicationIntentPath),
+    predecessor: pinnedRegularFileSnapshot(
+      publicationIntent.predecessor.archivePath,
+    ),
+    replacement: pinnedRegularFileSnapshot(publicationIntent.replacement.path),
+    events: readFileSync(fixture.paths.events),
+    witness: readFileSync(witnessPath),
+    retired: readdirSync(
+      path.join(plan.artifacts.artifactDirectory, "retired"),
+    ).sort(),
+  };
+
+  assert.throws(
+    () =>
+      repairOutcomeLedger({
+        stateRoot: fixture.stateRoot,
+        taskId: TASK_ID,
+        expectedSourceDigest: sourceDigest,
+        ...owner,
+      }),
+    /predecessor authority witness is outside the authenticated replacement prefix/,
+  );
+
+  assert.deepEqual(snapshotTestTree(fixture.stateRoot), before.tree);
+  assert.equal(existsSync(fixture.paths.outcomes), false);
+  assert.deepEqual(readFileSync(plan.artifacts.transaction), before.transaction);
+  assert.equal(existsSync(plan.artifacts.completedTransaction), false);
+  assert.deepEqual(readFileSync(publicationIntentPath), before.publicationIntent);
+  const predecessorAfter = pinnedRegularFileSnapshot(
+    publicationIntent.predecessor.archivePath,
+  );
+  const replacementAfter = pinnedRegularFileSnapshot(
+    publicationIntent.replacement.path,
+  );
+  assert.deepEqual(predecessorAfter.bytes, before.predecessor.bytes);
+  assert.equal(predecessorAfter.identity.ino, before.predecessor.identity.ino);
+  assert.equal(predecessorAfter.identity.dev, before.predecessor.identity.dev);
+  assert.deepEqual(replacementAfter.bytes, before.replacement.bytes);
+  assert.equal(replacementAfter.identity.ino, before.replacement.identity.ino);
+  assert.equal(replacementAfter.identity.dev, before.replacement.identity.dev);
+  assert.deepEqual(readFileSync(fixture.paths.events), before.events);
+  assert.equal(repairAuditEvents(fixture.paths, plan.eventId).length, 0);
+  assert.equal(existsSync(plan.artifacts.receiptArtifact), false);
+  assert.deepEqual(readFileSync(witnessPath), before.witness);
+  assert.deepEqual(
+    readdirSync(path.join(plan.artifacts.artifactDirectory, "retired")).sort(),
+    before.retired,
+  );
+});
+
+test("missing canonical recovery retires an exact authority witness once", async (t) => {
+  const fixture = temporaryStateRoot(t);
+  const source = legacyLine("missing-canonical-exact-authority-witness");
+  const sourceDigest = writeLedger(fixture.paths, source);
+  const plan = planOutcomeLedgerRepair({
+    stateRoot: fixture.stateRoot,
+    taskId: TASK_ID,
+    expectedSourceDigest: sourceDigest,
+  });
+  const owner = ownerRepairLease(fixture.stateRoot, plan);
+  const child = spawnNativePausedRepairChild(t, {
+    stateRoot: fixture.stateRoot,
+    sourceDigest,
+    owner,
+    pause: "after-postcheck",
+    operation: "rename-durable",
+    source: path.basename(fixture.paths.outcomes),
+    destination: "",
+  });
+
+  await waitForNativeHelperPause(child, "after-postcheck");
+  killPausedNativeHelper(child);
+  const childExit = await waitForChildExit(child);
+  assert.equal(childExit.code, 1);
+  assert.equal(childExit.signal, null);
+  assert.equal(existsSync(fixture.paths.outcomes), false);
+  assert.equal(plan.parameters.replacementSize, 0);
+
+  const witnessPath = path.join(
+    fixture.stateRoot,
+    `.${path.basename(fixture.paths.outcomes)}.authority.${"c".repeat(64)}.${"d".repeat(64)}.tmp`,
+  );
+  writeFileSync(witnessPath, Buffer.alloc(0), { mode: 0o600 });
+  chmodSync(witnessPath, 0o600);
+
+  const recovered = repairOutcomeLedger({
+    stateRoot: fixture.stateRoot,
+    taskId: TASK_ID,
+    expectedSourceDigest: sourceDigest,
+    ...owner,
+  });
+  assert.equal(recovered.changed, true);
+  assert.equal(readFileSync(fixture.paths.outcomes).length, 0);
+  assert.equal(existsSync(witnessPath), false);
+  assert.equal(repairAuditEvents(fixture.paths, plan.eventId).length, 1);
+  assert.equal(
+    JSON.parse(readFileSync(plan.artifacts.completedTransaction, "utf8")).phase,
+    "complete",
+  );
+
+  const repeated = repairOutcomeLedger({
+    stateRoot: fixture.stateRoot,
+    taskId: TASK_ID,
+    expectedSourceDigest: sourceDigest,
+    ...owner,
+  });
+  assert.equal(repeated.changed, false);
+  assert.equal(repairAuditEvents(fixture.paths, plan.eventId).length, 1);
+});
 
 for (const pause of [
   "before-exchange-syscall",


### PR DESCRIPTION
(AI Generated).\n\n## Summary\n- Recover a completed general-actor lease transaction only when the next operation presents the same retained lease token.\n- Keep owner governance exact-plan fenced and reject mismatched cleanup tokens.\n- Extend the bounded native actor lifecycle window so durable cleanup can finish instead of being killed mid-archive.\n- Preflight any retained outcome-ledger authority witness before repair mutation.\n- Retire one exact authenticated predecessor witness only after the replacement ledger is durably installed.\n- Preserve permanent fail-closed evidence when an unaudited receipt temporary is quarantined.\n- Correct stale fixtures so they exercise the intended capacity, lifecycle, and quarantine boundaries without corrupting their own authority state.\n\n## Root cause\nThe native launcher could outlive its caller while cleaning retained transaction generations. A completed acquisition then remained recoverable, but a different logical operation was blocked before it could finish exact-token cleanup. Separately, outcome repair replaced the ledger inode while leaving the prior authenticated append witness live, so the next ordinary append correctly rejected the stale generation.\n\n## Validation\n- Exact-token cleanup recovery and wrong-token rejection passed.\n- Owner-governance cross-operation cleanup rejection passed.\n- Both ordinary append crash boundaries recovered and accepted one idempotent follow-up append.\n- The 100,000-record audit ceiling failed before transaction or event mutation.\n- Pending conflicting, duplicate, and missing audit histories remained byte stable and fail-closed.\n- Foreign authority witness and quarantined receipt evidence tests passed.\n- JavaScript syntax and staged diff checks passed.\n- Exact-head GitHub validation is running.