### PR TITLE
fix: recover legacy lease history takeover

### DIFF
--- a/scripts/automation-control.test.mjs
+++ b/scripts/automation-control.test.mjs
@@ -1258,6 +1258,34 @@ function pinnedLegacyRuntimeObserverTakeover() {
   };
 }
 
+function exactMissingStateScaffoldingAcquisition() {
+  return {
+    schemaVersion: 1,
+    eventId: "lease:edacbfa4-8c08-4f1c-9a52-56ee8583e62d",
+    type: "lease_acquired",
+    ts: "2026-07-23T06:17:55.750Z",
+    actor: "freed-scaffolding-maintainer",
+    leaseName: "scaffolding-writer",
+    data: {
+      expiresAt: "2026-07-23T06:47:55.750Z",
+      observerAuthority: "pr-only",
+      providerAuthority: "forbidden",
+      requestDigest:
+        "02c27dee741004a401d12cb568b33174abfec6e928bca7d21fa0305d16fb9e08",
+      credentialKind: "trusted-launcher-channel",
+      launcherSha256:
+        "a413388c90beddf5a38a9a7c2bdeef41d0434e0695c756be45f9bde934761c20",
+      actorRuntimeDigest:
+        "d5c4600bc7ddedc51c984324350f16b80c36641bbce01d9435f66d8e17c9625e",
+      launcherChannelProtocol: "freed-actor-launcher-channel-v1",
+      launcherAttestationSha256:
+        "20cf3710f077b771879c730b86ca604bbaf7e4f7f05d5d07f13ebdde56139302",
+      launcherSessionId:
+        "da285fb9f7a41c813ce59c4e5b36605fc831eaf212f34816db0531983bd9c871",
+    },
+  };
+}
+
 function leaseHistoryCorruptionEvent(sourceEvent, variant, label) {
   if (variant === "duplicate") return structuredClone(sourceEvent);
   if (variant === "conflicting") {
@@ -5239,6 +5267,264 @@ test("exact lifecycle history admits only the pinned legacy lease acquisition br
   ]);
   assert.equal(unboundCurrent.healthy, false);
   assert.match(unboundCurrent.issues.join("\n"), /lifecycle creation/);
+});
+
+test("exact history admits only the installed missing-state acquisition bridge", () => {
+  const legacyEvents = readFileSync(
+    path.join(__dirname, "fixtures", "legacy-control-event-history.jsonl"),
+    "utf8",
+  )
+    .trimEnd()
+    .split("\n")
+    .map((line) => JSON.parse(line));
+  const acquisition = exactMissingStateScaffoldingAcquisition();
+  assert.equal(
+    createHash("sha256")
+      .update(JSON.stringify(canonicalTestValue(acquisition)))
+      .digest("hex"),
+    "67a8dd0129b10ff167dd1707682d930eb199eb194e484e8b66402dbfe69126e0",
+  );
+  const installed = [
+    structuredClone(legacyEvents[0]),
+    structuredClone(legacyEvents[1]),
+    acquisition,
+  ];
+  const exact = inspectExactTaskLifecycleHistory(installed);
+  assert.equal(exact.healthy, true, exact.issues.join("\n"));
+
+  const release = {
+    schemaVersion: 1,
+    eventId: `lease:${"e".repeat(64)}`,
+    type: "lease_released",
+    ts: "2026-07-23T06:48:55.750Z",
+    actor: "freed-scaffolding-maintainer",
+    leaseName: "scaffolding-writer",
+    data: {
+      expired: true,
+      requestDigest: "f".repeat(64),
+    },
+  };
+  const released = inspectExactTaskLifecycleHistory([...installed, release]);
+  assert.equal(released.healthy, true, released.issues.join("\n"));
+
+  const driftCases = [
+    {
+      label: "predecessor acquisition",
+      mutate(events) {
+        events[0].data.expiresAt = "2026-07-10T22:29:02.587Z";
+      },
+    },
+    {
+      label: "predecessor heartbeat",
+      mutate(events) {
+        events[1].data.expiresAt = "2026-07-10T22:32:14.169Z";
+      },
+    },
+    {
+      label: "successor",
+      mutate(events) {
+        events[2].data.requestDigest = "1".repeat(64);
+      },
+    },
+  ];
+  for (const driftCase of driftCases) {
+    const drifted = structuredClone(installed);
+    driftCase.mutate(drifted);
+    const inspection = inspectExactTaskLifecycleHistory(drifted);
+    assert.equal(inspection.healthy, false, driftCase.label);
+  }
+
+  const omittedHeartbeat = inspectExactTaskLifecycleHistory([
+    structuredClone(installed[0]),
+    structuredClone(installed[2]),
+  ]);
+  assert.equal(omittedHeartbeat.healthy, false);
+
+  const secondAcquisition = structuredClone(acquisition);
+  secondAcquisition.eventId = `lease:${"d".repeat(64)}`;
+  secondAcquisition.ts = "2026-07-23T06:48:55.750Z";
+  secondAcquisition.data.expiresAt = "2026-07-23T07:18:55.750Z";
+  const invented = inspectExactTaskLifecycleHistory([
+    ...installed,
+    secondAcquisition,
+  ]);
+  assert.equal(invented.healthy, false);
+});
+
+test("missing legacy lease state acquires through an audited credential upgrade", () => {
+  const stateRoot = temporaryStateRoot();
+  const paths = automationControlPaths(stateRoot);
+  const fixtureBytes = readFileSync(
+    path.join(__dirname, "fixtures", "legacy-control-event-history.jsonl"),
+  );
+  mkdirSync(paths.controlRoot, { recursive: true, mode: 0o700 });
+  writeFileSync(paths.events, fixtureBytes, { mode: 0o600 });
+
+  const actor = "freed-scaffolding-maintainer";
+  const name = AUTOMATION_ACTOR_POLICIES[actor].leaseName;
+  const token = `missing-legacy-state-upgrade-${"x".repeat(40)}`;
+  const acquiredAtMs = Date.parse("2026-07-23T06:17:55.750Z");
+  const acquireOptions = {
+    stateRoot,
+    name,
+    owner: actor,
+    operationId: nextLeaseOperationId("missing-legacy-state-upgrade"),
+    ttlMs: 60_000,
+    nowMs: acquiredAtMs,
+    token,
+  };
+  assert.throws(
+    () =>
+      acquireLeaseMutation({
+        ...acquireOptions,
+        checkpoint: throwAtLeaseCheckpoint("lease-state-committed"),
+      }),
+    /lease checkpoint lease-state-committed/,
+  );
+  const result = acquireLeaseMutation(acquireOptions);
+  assert.equal(result.takeover, true);
+  assert.equal(result.credentialUpgrade, true);
+  assert.deepEqual(result.previous, {
+    owner: actor,
+    expiredAt: "2026-07-10T22:32:14.168Z",
+    heartbeatAt: "2026-07-10T22:02:14.168Z",
+    legacyUncredentialed: true,
+  });
+  assert.equal(readEvents(stateRoot).at(-1).type, "lease_credential_upgraded");
+  const acquired = inspectExactTaskLifecycleHistory(readEvents(stateRoot));
+  assert.equal(acquired.healthy, true, acquired.issues.join("\n"));
+
+  releaseLease({
+    stateRoot,
+    name,
+    operationId: nextLeaseOperationId("missing-legacy-state-release"),
+    token,
+    nowMs: acquiredAtMs + 1_000,
+  });
+  const released = inspectExactTaskLifecycleHistory(readEvents(stateRoot));
+  assert.equal(released.healthy, true, released.issues.join("\n"));
+});
+
+test("missing live legacy lease state fails before lease authority mutation", () => {
+  const stateRoot = temporaryStateRoot();
+  const paths = automationControlPaths(stateRoot);
+  const fixtureEvents = readFileSync(
+    path.join(__dirname, "fixtures", "legacy-control-event-history.jsonl"),
+    "utf8",
+  )
+    .trimEnd()
+    .split("\n")
+    .slice(0, 2);
+  mkdirSync(paths.controlRoot, { recursive: true, mode: 0o700 });
+  writeFileSync(paths.events, `${fixtureEvents.join("\n")}\n`, {
+    mode: 0o600,
+  });
+  const before = snapshotLeaseAuthorityState(stateRoot);
+  const actor = "freed-scaffolding-maintainer";
+  assert.throws(
+    () =>
+      acquireLeaseMutation({
+        stateRoot,
+        name: AUTOMATION_ACTOR_POLICIES[actor].leaseName,
+        owner: actor,
+        operationId: nextLeaseOperationId("missing-live-legacy-state"),
+        ttlMs: 60_000,
+        nowMs: Date.parse("2026-07-10T22:10:00.000Z"),
+        token: `missing-live-legacy-state-${"x".repeat(40)}`,
+      }),
+    (error) => isAutomationControlError(error) && error.code === "lease_busy",
+  );
+  assert.deepEqual(snapshotLeaseAuthorityState(stateRoot), before);
+});
+
+test("missing current lease state requires explicit repair before reacquisition", () => {
+  const stateRoot = temporaryStateRoot();
+  const actor = "freed-release-verifier";
+  const name = AUTOMATION_ACTOR_POLICIES[actor].leaseName;
+  const acquiredAtMs = Date.parse("2026-07-23T07:00:00.000Z");
+  acquireLeaseMutation({
+    stateRoot,
+    name,
+    owner: actor,
+    operationId: nextLeaseOperationId("missing-current-state-initial"),
+    ttlMs: 1_000,
+    nowMs: acquiredAtMs,
+    token: `missing-current-state-initial-${"x".repeat(40)}`,
+  });
+  rmSync(path.join(automationControlPaths(stateRoot).leases, `${name}.lease`), {
+    recursive: true,
+  });
+  const before = snapshotLeaseAuthorityState(stateRoot);
+  assert.throws(
+    () =>
+      acquireLeaseMutation({
+        stateRoot,
+        name,
+        owner: actor,
+        operationId: nextLeaseOperationId("missing-current-state-reacquire"),
+        ttlMs: 60_000,
+        nowMs: acquiredAtMs + 2_000,
+        token: `missing-current-state-reacquire-${"y".repeat(40)}`,
+      }),
+    (error) =>
+      isAutomationControlError(error) && error.code === "lease_repair_required",
+  );
+  assert.deepEqual(snapshotLeaseAuthorityState(stateRoot), before);
+});
+
+test("missing-state takeover recovery binds its predecessor before mutation", () => {
+  const stateRoot = temporaryStateRoot();
+  const actor = "freed-release-verifier";
+  const name = AUTOMATION_ACTOR_POLICIES[actor].leaseName;
+  const operationId = nextLeaseOperationId("invented-missing-state-takeover");
+  const nowMs = Date.parse("2026-07-23T07:30:00.000Z");
+  const options = {
+    stateRoot,
+    name,
+    owner: actor,
+    operationId,
+    ttlMs: 60_000,
+    nowMs,
+    token: `invented-missing-state-takeover-${"x".repeat(40)}`,
+  };
+  assert.throws(
+    () =>
+      acquireLeaseMutation({
+        ...options,
+        checkpoint: throwAtLeaseCheckpoint("lease-state-committed"),
+      }),
+    /lease checkpoint lease-state-committed/,
+  );
+  const files = leaseTransactionPaths(stateRoot, name, "acquire", operationId);
+  const transaction = JSON.parse(readFileSync(files.active, "utf8"));
+  const previous = {
+    owner: actor,
+    expiredAt: new Date(
+      Date.parse(transaction.preparedAt) - 60_000,
+    ).toISOString(),
+    heartbeatAt: new Date(
+      Date.parse(transaction.preparedAt) - 120_000,
+    ).toISOString(),
+    legacyUncredentialed: true,
+  };
+  transaction.takeover = previous;
+  transaction.resultReceipt.takeover = true;
+  transaction.resultReceipt.credentialUpgrade = true;
+  transaction.resultReceipt.previous = previous;
+  transaction.event.type = "lease_credential_upgraded";
+  transaction.event.data.credentialUpgrade = true;
+  transaction.event.data.previous = previous;
+  writeFileSync(files.active, `${JSON.stringify(transaction, null, 2)}\n`, {
+    mode: 0o600,
+  });
+  const before = snapshotLeaseAuthorityState(stateRoot);
+  assert.throws(
+    () => acquireLeaseMutation(options),
+    (error) =>
+      isAutomationControlError(error) &&
+      error.code === "lease_transaction_conflict",
+  );
+  assert.deepEqual(snapshotLeaseAuthorityState(stateRoot), before);
 });
 
 test("the complete installed legacy control history is byte pinned and drift sensitive", () => {

--- a/scripts/lib/automation-control.mjs
+++ b/scripts/lib/automation-control.mjs
@@ -7324,6 +7324,18 @@ const PINNED_LEGACY_LEASE_EVENT_DIGESTS = new Set([
   "fb110936e1ee51c202e5982110a852d57e9d5a75c4656d4602aea10ce7862af2",
   "f648bb3c2d352f3679a4a96d72aa3ab490f3d4c6bf409401226e642eb078badf",
 ]);
+const PINNED_MISSING_STATE_ACQUISITION_BRIDGE = Object.freeze({
+  actor: "freed-scaffolding-maintainer",
+  leaseName: "scaffolding-writer",
+  predecessorAcquisitionDigest:
+    "22e1ef7e106bb242f7829ace4aecd772696877ab736e5c1bd75737105e9aae90",
+  predecessorLastEventDigest:
+    "e879ed4128c7f45f66e3bddfa6d7cce64957b41106768f1d3ccfc5f0fcbd0607",
+  predecessorHeartbeatAt: "2026-07-10T22:02:14.168Z",
+  predecessorExpiresAt: "2026-07-10T22:32:14.168Z",
+  successorDigest:
+    "67a8dd0129b10ff167dd1707682d930eb199eb194e484e8b66402dbfe69126e0",
+});
 const TASK_MANIFEST_EVENT_TYPES = new Set([
   "outcome_reservation_created",
   "outcome_reservation_finalized",
@@ -7367,6 +7379,22 @@ function pinnedLegacyLeaseControlEvent(event) {
     isCanonicalUuidV4(event?.eventId) &&
     LEASE_CONTROL_EVENT_TYPES.has(event?.type) &&
     pinnedControlEventDigest(event, PINNED_LEGACY_LEASE_EVENT_DIGESTS)
+  );
+}
+
+function pinnedMissingStateAcquisitionBridge(event, active) {
+  const bridge = PINNED_MISSING_STATE_ACQUISITION_BRIDGE;
+  return (
+    event?.type === "lease_acquired" &&
+    canonicalControlEventDigest(event) === bridge.successorDigest &&
+    event.actor === bridge.actor &&
+    event.leaseName === bridge.leaseName &&
+    active?.actor === bridge.actor &&
+    active?.legacyUncredentialed === true &&
+    active?.acquisitionEventDigest === bridge.predecessorAcquisitionDigest &&
+    active?.lastEventDigest === bridge.predecessorLastEventDigest &&
+    active?.heartbeatAt === bridge.predecessorHeartbeatAt &&
+    active?.expiresAt === bridge.predecessorExpiresAt
   );
 }
 
@@ -7960,10 +7988,14 @@ function inspectExactLeaseEventHistory(records, eventIdCounts) {
       const pinnedLegacy = pinnedLegacyLeaseControlEvent(event);
       const active = activeByLeaseName.get(event.leaseName);
       const previous = event.data.previous;
+      const missingStateAcquisitionBridge =
+        active !== undefined &&
+        pinnedMissingStateAcquisitionBridge(event, active);
       const beginsAfterExplicitAbsence =
         active === undefined && observedLeaseNames.has(event.leaseName);
       const auditedPredecessorMatches =
         active === undefined ||
+        missingStateAcquisitionBridge ||
         ((event.type === "lease_credential_upgraded") ===
           active.legacyUncredentialed &&
           ["lease_credential_upgraded", "lease_taken_over"].includes(
@@ -7988,6 +8020,7 @@ function inspectExactLeaseEventHistory(records, eventIdCounts) {
       }
       activeByLeaseName.set(event.leaseName, {
         acquisitionEvent: structuredClone(event),
+        acquisitionEventDigest: canonicalControlEventDigest(event),
         acquisitionIndex: record.index,
         actor: event.actor,
         acquiredAtMs: eventAtMs,
@@ -8004,6 +8037,7 @@ function inspectExactLeaseEventHistory(records, eventIdCounts) {
         heartbeatAtMs: eventAtMs,
         heartbeatAt: event.ts,
         lastEventAtMs: eventAtMs,
+        lastEventDigest: canonicalControlEventDigest(event),
         legacyUncredentialed: event.data.credentialKind === undefined,
         scope:
           event.actor === "freed-pr-publisher"
@@ -8049,6 +8083,7 @@ function inspectExactLeaseEventHistory(records, eventIdCounts) {
       active.heartbeatAtMs = eventAtMs;
       active.heartbeatAt = event.ts;
       active.lastEventAtMs = eventAtMs;
+      active.lastEventDigest = canonicalControlEventDigest(event);
       canonicalEventsByIndex.set(
         record.index,
         Object.freeze({
@@ -8095,6 +8130,7 @@ function inspectExactLeaseEventHistory(records, eventIdCounts) {
       }
       active.scope = structuredClone(nextScope);
       active.lastEventAtMs = eventAtMs;
+      active.lastEventDigest = canonicalControlEventDigest(event);
       canonicalEventsByIndex.set(
         record.index,
         Object.freeze({
@@ -18576,7 +18612,7 @@ function validateLeaseStaging(paths, transaction) {
     }
     records[side] = parseLeaseRecordBytes(bytes, transaction.name);
   }
-  validateLeaseTransactionStagedSemantics(transaction, records);
+  validateLeaseTransactionStagedSemantics(paths, transaction, records);
   return records;
 }
 
@@ -18586,7 +18622,54 @@ function leaseRecordWithoutFields(record, fields) {
   return clone;
 }
 
-function validateLeaseTransactionStagedSemantics(transaction, records) {
+function requireExactMissingStateLeaseTakeover(paths, transaction) {
+  const snapshot = readControlEventHistorySnapshot(paths.events);
+  const inspection = requireExactLeaseEventHistory(snapshot.events);
+  const exactEventMatches = snapshot.events.filter(
+    (event) => event?.eventId === transaction.event?.eventId,
+  );
+  if (exactEventMatches.length === 1) {
+    if (!canonicalValuesEqual(exactEventMatches[0], transaction.event)) {
+      throw new AutomationControlError(
+        "lease_transaction_conflict",
+        `Lease acquisition transaction for ${transaction.name} does not match its exact audited event.`,
+      );
+    }
+    return structuredClone(transaction.event.data.previous);
+  }
+  if (exactEventMatches.length !== 0) {
+    throw new AutomationControlError(
+      "lease_transaction_conflict",
+      `Lease acquisition transaction for ${transaction.name} has duplicate audited events.`,
+    );
+  }
+  const active = inspection.activeByLeaseName.get(transaction.name);
+  const expected =
+    active === undefined
+      ? null
+      : {
+          owner: active.actor,
+          expiredAt: active.expiresAt,
+          heartbeatAt: active.heartbeatAt,
+          legacyUncredentialed: true,
+        };
+  if (
+    active === undefined ||
+    active.actor !== transaction.request.owner ||
+    active.legacyUncredentialed !== true ||
+    !pinnedLegacyLeaseControlEvent(active.acquisitionEvent) ||
+    active.expiresAtMs > Date.parse(transaction.preparedAt) ||
+    !canonicalValuesEqual(transaction.event?.data?.previous, expected)
+  ) {
+    throw new AutomationControlError(
+      "lease_transaction_conflict",
+      `Lease acquisition transaction for ${transaction.name} does not match its exact historical predecessor.`,
+    );
+  }
+  return expected;
+}
+
+function validateLeaseTransactionStagedSemantics(paths, transaction, records) {
   const { before: beforeRecord, after: afterRecord } = records;
   const request = transaction.request;
   const tokenRecords =
@@ -18654,6 +18737,19 @@ function validateLeaseTransactionStagedSemantics(transaction, records) {
           );
         }
       }
+    } else if (
+      transaction.event?.type === "lease_credential_upgraded" &&
+      canonicalLeaseTakeoverSummary(transaction.event.data?.previous) &&
+      transaction.event.data.previous.legacyUncredentialed === true &&
+      transaction.event.data.previous.owner === request.owner &&
+      Date.parse(transaction.event.data.previous.expiredAt) <=
+        Date.parse(transaction.preparedAt)
+    ) {
+      expectedTakeover = requireExactMissingStateLeaseTakeover(
+        paths,
+        transaction,
+      );
+      expectedCredentialUpgrade = true;
     }
     if (
       afterRecord === null ||
@@ -18672,7 +18768,8 @@ function validateLeaseTransactionStagedSemantics(transaction, records) {
             transaction.resultReceipt.previous,
             expectedTakeover,
           )) ||
-      (expectedCredentialUpgrade && beforeRecord.owner !== afterRecord.owner)
+      (expectedCredentialUpgrade &&
+        expectedTakeover.owner !== afterRecord.owner)
     ) {
       throw new AutomationControlError(
         "lease_transaction_conflict",
@@ -29077,11 +29174,12 @@ function validateCompletedLeaseReceiptStaging(
     validateLeaseStagingSnapshot(transaction, side, snapshot);
     records[side] = parseLeaseRecordBytes(snapshot.bytes, transaction.name);
   }
-  validateLeaseTransactionStagedSemantics(transaction, records);
+  validateLeaseTransactionStagedSemantics(paths, transaction, records);
   return cleanupPlan;
 }
 
 function validateParsedCompletedLeaseReceiptHealthEvidence(
+  paths,
   transaction,
   admittedParsedCleanupEvidence,
   receiptContentDigest,
@@ -29210,7 +29308,7 @@ function validateParsedCompletedLeaseReceiptHealthEvidence(
     atomicEvidence,
     stagingBytesBySide,
   );
-  validateLeaseTransactionStagedSemantics(transaction, records);
+  validateLeaseTransactionStagedSemantics(paths, transaction, records);
   return Object.freeze({
     operationId: transaction.operationId,
     activeWal: currentWal[0],
@@ -29226,6 +29324,7 @@ function validateCompletedLeaseReceiptHealthEvidence(
 ) {
   if (admission?.admittedParsedCleanupEvidence instanceof Map) {
     return validateParsedCompletedLeaseReceiptHealthEvidence(
+      paths,
       transaction,
       admission.admittedParsedCleanupEvidence,
       admission.receiptContentDigest,
@@ -30210,7 +30309,6 @@ function acquireLeaseAuthorized({
         secretDigest(token),
         eventsGuard,
       );
-      ensurePrivateDirectory(paths.leases);
       recoverLeaseTransactionUnlocked(paths, name, Date.now(), eventsGuard);
       const completed = replayCompletedLeaseReceipt({
         paths,
@@ -30235,6 +30333,9 @@ function acquireLeaseAuthorized({
         normalizePublisherScope(publisherScope);
       }
       const operationNowMs = Date.now();
+      const exactLeaseHistory = requireExactLeaseEventHistory(
+        readControlEventHistorySnapshot(paths.events).events,
+      );
       const beforeState = readLeaseStateSnapshot(paths, name);
       if (
         beforeState.descriptor.directoryExists &&
@@ -30246,6 +30347,51 @@ function acquireLeaseAuthorized({
           { name },
         );
       }
+      let previous = null;
+      let takeover = false;
+      let credentialUpgrade = false;
+      const historicalActive = beforeState.descriptor.directoryExists
+        ? undefined
+        : exactLeaseHistory.activeByLeaseName.get(name);
+      if (historicalActive !== undefined) {
+        if (historicalActive.actor !== owner) {
+          throw new AutomationControlError(
+            "legacy_lease_owner_mismatch",
+            `Historical lease ${name} belongs to ${historicalActive.actor}, not ${owner}.`,
+            { name, owner: historicalActive.actor, actor: owner },
+          );
+        }
+        if (
+          historicalActive.legacyUncredentialed !== true ||
+          !pinnedLegacyLeaseControlEvent(historicalActive.acquisitionEvent)
+        ) {
+          throw new AutomationControlError(
+            "lease_repair_required",
+            `Lease ${name} has current audited authority without canonical state and requires explicit owner-governed repair.`,
+            { name, owner: historicalActive.actor },
+          );
+        }
+        if (historicalActive.expiresAtMs > operationNowMs) {
+          throw new AutomationControlError(
+            "lease_busy",
+            `Historical lease ${name} remains live and requires expiry or an owner-governed migration before credential upgrade.`,
+            {
+              name,
+              owner: historicalActive.actor,
+              expiresAt: historicalActive.expiresAt,
+            },
+          );
+        }
+        previous = {
+          owner: historicalActive.actor,
+          expiredAt: historicalActive.expiresAt,
+          heartbeatAt: historicalActive.heartbeatAt,
+          legacyUncredentialed: true,
+        };
+        takeover = true;
+        credentialUpgrade = true;
+      }
+      ensurePrivateDirectory(paths.leases);
       const ownerCapability =
         owner === "freed-owner" && ownerCapabilityFile !== undefined
           ? readAndValidateOwnerCapability({
@@ -30291,10 +30437,6 @@ function acquireLeaseAuthorized({
           `Actor ${owner} cannot use a publisher capability.`,
         );
       }
-      let previous = null;
-      let takeover = false;
-      let credentialUpgrade = false;
-
       if (beforeState.descriptor.directoryExists) {
         const existing = beforeState.record;
         const isLegacyUncredentialed =


### PR DESCRIPTION
(AI Generated).

## Summary
- Admit only the exact installed missing-state acquisition sequence.
- Derive future legacy credential upgrades from validated event history before mutation.
- Reject forged recovery predecessors before authority state changes.

## Testing
- Focused lease-history regressions: 5 passed.
- Strict live machine preflight: 9 passed, 1 optional publisher warning.
- Feature validation and root typecheck passed.