### PR TITLE
fix: refresh crash fixture capability clocks

### DIFF
--- a/scripts/automation-control.test.mjs
+++ b/scripts/automation-control.test.mjs
@@ -15413,7 +15413,6 @@ test("active WAL recovery preflights every sibling before cleanup", () => {
 });
 
 test("one-use credential and release intermediates recover real process loss", () => {
-  const nowMs = Date.now();
   for (const phase of [
     "lease-credential-directory-created",
     "lease-credential-directory-parent-synced",
@@ -15436,7 +15435,6 @@ test("one-use credential and release intermediates recover real process loss", (
       .digest("hex");
     const token = `process-loss-publisher-${phase}-${"x".repeat(32)}`;
     const capability = writePublisherCapability(publisherRoot, scope, {
-      nowMs,
       leaseOperationId: operationId,
       token,
     });


### PR DESCRIPTION
(AI Generated).

## Summary
- Create each one-use publisher capability at the start of its own crash-recovery case so slow CI cannot expire later fixtures before their checkpoints.
- Keep the production one-minute capability lifetime and validation unchanged.

## Testing
- node --test --test-name-pattern="one-use credential and release intermediates recover real process loss" scripts/automation-control.test.mjs
- npm run validate:feature