### PR TITLE
fix: recover task transactions in canonical order

### DIFF
--- a/scripts/automation-control.test.mjs
+++ b/scripts/automation-control.test.mjs
@@ -3184,6 +3184,111 @@ test("a pending task transaction recovers once and rejects stale resurrection", 
   assert.equal(existsSync(transactionPath), true);
 });
 
+test("an event-first task transaction recovers against its settled manifest witness", () => {
+  const stateRoot = temporaryStateRoot();
+  const nowMs = Date.now();
+  const controller = actorLease(stateRoot, "freed-stability-controller", {
+    nowMs,
+  });
+  const created = createTask({
+    stateRoot,
+    taskId: "event-first-recoverable-task",
+    ...controller,
+    observerAuthority: "plan-only",
+    providerAuthority: "forbidden",
+    details: { behavioral: false },
+    nowMs: nowMs + 1,
+  });
+
+  const paths = automationControlPaths(stateRoot);
+  const current = readTaskManifest({ stateRoot });
+  const targetManifest = structuredClone(current);
+  const targetTask = targetManifest.tasks[0];
+  const transitionAt = new Date(nowMs + 2).toISOString();
+  targetTask.state = "triaged";
+  targetTask.revision += 1;
+  targetTask.updatedAt = transitionAt;
+  targetManifest.revision += 1;
+  targetManifest.updatedAt = transitionAt;
+  const event = {
+    schemaVersion: 1,
+    eventId: "e9b3b385-5434-4ca5-8cff-0c10e3aa0b19",
+    type: "task_transitioned",
+    ts: transitionAt,
+    actor: "freed-stability-controller",
+    taskId: targetTask.taskId,
+    taskRevision: targetTask.revision,
+    manifestRevision: targetManifest.revision,
+    observerAuthority: targetTask.observerAuthority,
+    providerAuthority: targetTask.providerAuthority,
+    data: {
+      fromState: "observed",
+      toState: "triaged",
+      authorizationProvenance: structuredClone(
+        created.event.data.authorizationProvenance,
+      ),
+    },
+  };
+  const transaction = {
+    schemaVersion: 1,
+    transactionId: "1f2496f9-6a8f-41ab-a01a-990e2bf53a9d",
+    preparedAt: transitionAt,
+    previousManifestRevision: current.revision,
+    targetManifest,
+    event,
+  };
+  mkdirSync(paths.taskTransactions, { recursive: true, mode: 0o700 });
+  const transactionPath = path.join(
+    paths.taskTransactions,
+    `${String(targetManifest.revision).padStart(12, "0")}-${transaction.transactionId}.json`,
+  );
+  writeFileSync(transactionPath, `${JSON.stringify(transaction, null, 2)}\n`, {
+    mode: 0o600,
+  });
+
+  const eventSnapshot = readAutomationAuthorityFileSnapshot(paths.events, {
+    privateRoot: paths.controlRoot,
+    maxBytes: CONTROL_EVENT_HISTORY_MAX_BYTES,
+    allowedModes: [0o600],
+    label: "Event-first task recovery fixture history",
+  });
+  const separator =
+    eventSnapshot.bytes.length > 0 && eventSnapshot.bytes.at(-1) !== 0x0a
+      ? Buffer.from("\n")
+      : Buffer.alloc(0);
+  writeAutomationAuthorityFile({
+    filePath: paths.events,
+    bytes: Buffer.concat([
+      eventSnapshot.bytes,
+      separator,
+      Buffer.from(`${JSON.stringify(event)}\n`),
+    ]),
+    previousSnapshot: eventSnapshot,
+    operationId: `control-event:${event.eventId}`,
+    privateRoot: paths.controlRoot,
+    maxBytes: CONTROL_EVENT_HISTORY_MAX_BYTES,
+    allowedModes: [0o600],
+    label: "Event-first task recovery fixture history",
+  });
+  heartbeatLease({
+    stateRoot,
+    name: controller.leaseName,
+    token: controller.leaseToken,
+    ttlMs: 30 * 60_000,
+    nowMs: nowMs + 3,
+  });
+  assert.equal(readEvents(stateRoot).at(-1)?.type, "lease_heartbeat");
+
+  const recovered = readTaskManifest({ stateRoot });
+  assert.deepEqual(recovered, targetManifest);
+  assert.equal(
+    readEvents(stateRoot).filter((candidate) => candidate.eventId === event.eventId)
+      .length,
+    1,
+  );
+  assert.equal(existsSync(transactionPath), false);
+});
+
 test("task transaction recovery rejects conflicting and duplicate audit events before mutation", async (t) => {
   const prepareFixture = (variant) => {
     const stateRoot = temporaryStateRoot();

--- a/scripts/lib/automation-control.mjs
+++ b/scripts/lib/automation-control.mjs
@@ -2722,7 +2722,6 @@ function recoverTaskTransactionsUnlocked(
         };
 
         if (current.revision === transaction.previousManifestRevision) {
-          requireExactEvent();
           guardMutation();
           readmitAuthorityStages();
           writeJsonAtomic(paths.taskManifest, target, {
@@ -2731,7 +2730,9 @@ function recoverTaskTransactionsUnlocked(
             privateRoot: paths.controlRoot,
             label: "Current task manifest",
             validateStageSuccessor: (before, after) =>
-              requireTaskManifestSemanticSuccessor(paths, before, after),
+              requireTaskManifestSemanticSuccessor(paths, before, after, {
+                expectedPendingTransactions: [transaction],
+              }),
             buildStagePendingPlans: () => [
               Object.freeze({
                 operationId: `task-manifest:${transaction.transactionId}`,
@@ -2739,6 +2740,9 @@ function recoverTaskTransactionsUnlocked(
               }),
             ],
           });
+          guardMutation();
+          readmitAuthorityStages();
+          requireExactEvent();
         } else if (current.revision === target.revision) {
           if (JSON.stringify(current) !== JSON.stringify(target)) {
             throw new AutomationControlError(
@@ -10180,7 +10184,9 @@ function mutateTaskManifestUnderGuards(
     privateRoot: paths.controlRoot,
     label: "Current task manifest",
     validateStageSuccessor: (before, after) =>
-      requireTaskManifestSemanticSuccessor(paths, before, after),
+      requireTaskManifestSemanticSuccessor(paths, before, after, {
+        expectedPendingTransactions: [transaction],
+      }),
     buildStagePendingPlans: () => [
       Object.freeze({
         operationId: `task-manifest:${transactionId}`,
@@ -24957,7 +24963,45 @@ function readTaskManifestLineageTransactions(
   return candidates;
 }
 
-function requireTaskManifestSemanticSuccessor(paths, before, after) {
+function exactPendingTaskTransactionTailMatches({
+  events,
+  manifest,
+  expectedPendingTransactions,
+}) {
+  if (expectedPendingTransactions.length !== 1 || events.length === 0) {
+    return false;
+  }
+  const transaction = expectedPendingTransactions[0];
+  const transactionEventIndex = events.findIndex((event) =>
+    canonicalValuesEqual(event, transaction.event),
+  );
+  if (
+    transaction.previousManifestRevision !== manifest.revision ||
+    transaction.targetManifest?.revision !== manifest.revision + 1 ||
+    transactionEventIndex === -1 ||
+    events.filter((event) => event?.eventId === transaction.event.eventId)
+      .length !== 1
+  ) {
+    return false;
+  }
+  return (
+    inspectExactTaskManifestHistoryParity(
+      events.slice(0, transactionEventIndex),
+      manifest,
+    ).healthy &&
+    inspectExactTaskManifestHistoryParity(
+      events,
+      transaction.targetManifest,
+    ).healthy
+  );
+}
+
+function requireTaskManifestSemanticSuccessor(
+  paths,
+  before,
+  after,
+  { expectedPendingTransactions = [] } = {},
+) {
   const beforeManifest = parseTaskManifestAuthoritySnapshot(
     before,
     "Current task manifest predecessor",
@@ -25013,11 +25057,19 @@ function requireTaskManifestSemanticSuccessor(paths, before, after) {
     ) {
       return false;
     }
-    if (
-      eventIndexes.length === 1 &&
-      !inspectExactTaskManifestHistoryParity(events, afterManifest).healthy
-    ) {
-      return false;
+    if (eventIndexes.length === 1) {
+      const currentHistoryHealthy =
+        inspectExactTaskManifestHistoryParity(events, afterManifest).healthy;
+      if (
+        !currentHistoryHealthy &&
+        !exactPendingTaskTransactionTailMatches({
+          events,
+          manifest: afterManifest,
+          expectedPendingTransactions,
+        })
+      ) {
+        return false;
+      }
     }
     if (
       eventIndexes.length === 0 &&
@@ -25061,7 +25113,9 @@ function admitTaskManifestAuthorityStage(
         }),
       ),
     validateSuccessor: (before, after) =>
-      requireTaskManifestSemanticSuccessor(paths, before, after),
+      requireTaskManifestSemanticSuccessor(paths, before, after, {
+        expectedPendingTransactions,
+      }),
     label: "Current task manifest",
   });
 }

--- a/scripts/nightly-self-improve.test.mjs
+++ b/scripts/nightly-self-improve.test.mjs
@@ -553,6 +553,20 @@ function readFixtureControlEvents(stateRoot) {
   return text === "" ? [] : text.split("\n").map(JSON.parse);
 }
 
+function retireReadyAuthorityWitnessForFixtureRewrite(filePath) {
+  const directory = path.dirname(filePath);
+  const prefix = `.${path.basename(filePath)}.authority.`;
+  const entries = readdirSync(directory).filter((entry) =>
+    entry.startsWith(prefix),
+  );
+  assert.equal(entries.length, 1, JSON.stringify(entries));
+  assert.match(
+    entries[0].slice(prefix.length),
+    /^[0-9a-f]{64}\.[0-9a-f]{64}\.tmp$/,
+  );
+  rmSync(path.join(directory, entries[0]));
+}
+
 function acquireFixtureActorLeases(stateRoot, actors, acquiredAtMs) {
   for (const [index, actor] of actors.entries()) {
     outcomeAuthentication(stateRoot, actor, acquiredAtMs + index);
@@ -881,6 +895,7 @@ function prepareTaskAtState(
       details: { behavioral },
       nowMs: clockNowMs,
     });
+    if (targetState === "observed") return;
     const sequence = [
       ["triaged", controller],
       ["approved_for_pr", controller],
@@ -905,6 +920,14 @@ function prepareTaskAtState(
           channel,
         };
         if (legacyOutcomeTransitions) {
+          if (state === "merged") {
+            retireReadyAuthorityWitnessForFixtureRewrite(
+              automationControlPaths(stateRoot).taskManifest,
+            );
+            retireReadyAuthorityWitnessForFixtureRewrite(
+              automationControlPaths(stateRoot).events,
+            );
+          }
           writeLegacyOutcomeTransitionFixture({
             stateRoot,
             taskId,
@@ -3883,6 +3906,7 @@ test("nightly planning fails closed while a missing outcome ledger has a pending
         operationId: repairPlan.operationId,
         taskId,
         phase: "prepared",
+        recoverablePreparationResidue: false,
       },
     ],
   );
@@ -4824,11 +4848,34 @@ test("post-admission task WAL recovery blocks the requested outcome", (t) => {
   const nowMs = Date.now();
   prepareTaskAtState(stateRoot, taskId, "validated", nowMs);
   prepareTaskAtState(stateRoot, auxiliaryTaskId, "observed", nowMs + 1_000);
+  const auxiliaryAuthentication = outcomeAuthentication(
+    stateRoot,
+    "freed-stability-controller",
+    nowMs + 1_500,
+  );
   const authentication = outcomeAuthentication(
     stateRoot,
     "freed-nightly-runner",
     nowMs + 2_000,
   );
+  const auxiliaryLease = inspectLease({
+    stateRoot,
+    name: auxiliaryAuthentication.authentication.leaseName,
+    nowMs: nowMs + 2_000,
+  });
+  assert.ok(auxiliaryLease);
+  const auxiliaryLeaseEvent = readFixtureControlEvents(stateRoot)
+    .filter(
+      (event) =>
+        ["lease_acquired", "lease_taken_over"].includes(event.type) &&
+        event.actor === auxiliaryAuthentication.authentication.actor &&
+        event.leaseName === auxiliaryAuthentication.authentication.leaseName &&
+        event.ts === auxiliaryLease.acquiredAt,
+    )
+    .at(-1);
+  assert.ok(auxiliaryLeaseEvent);
+  const auxiliaryAuthorizationProvenance =
+    leaseEventProvenance(auxiliaryLeaseEvent);
   const transactionId = "10000000-2000-4000-8000-000000000099";
   const recoveredEventId = "20000000-3000-4000-8000-000000000099";
   let transactionPath;
@@ -4880,7 +4927,11 @@ test("post-admission task WAL recovery blocks the requested outcome", (t) => {
               manifestRevision: targetManifest.revision,
               observerAuthority: targetTask.observerAuthority,
               providerAuthority: targetTask.providerAuthority,
-              data: { fromState: "observed", toState: "triaged" },
+              data: {
+                fromState: "observed",
+                toState: "triaged",
+                authorizationProvenance: auxiliaryAuthorizationProvenance,
+              },
             };
             const transaction = {
               schemaVersion: 1,
@@ -4912,7 +4963,10 @@ test("post-admission task WAL recovery blocks the requested outcome", (t) => {
   assert.ok(transactionPath);
   assert.equal(existsSync(transactionPath), false);
   assert.equal(readTask({ stateRoot, taskId }).state, "validated");
-  assert.equal(readTask({ stateRoot, auxiliaryTaskId }).state, "triaged");
+  assert.equal(
+    readTask({ stateRoot, taskId: auxiliaryTaskId }).state,
+    "triaged",
+  );
   assert.equal(existsSync(paths.outcomes), false);
   const events = readFileSync(paths.events, "utf8")
     .trim()
@@ -5152,9 +5206,11 @@ test("outcome ledger publication rejects a parent generation swap without writin
         },
       ),
     (error) =>
-      ["authority_generation_conflict", "lease_transaction_conflict"].includes(
-        error?.code,
-      ),
+      [
+        "authority_generation_conflict",
+        "lease_not_found",
+        "lease_transaction_conflict",
+      ].includes(error?.code),
   );
   assert.equal(swapped, true);
   assert.deepEqual(readFileSync(paths.outcomes), replacementBytes);
@@ -5836,6 +5892,7 @@ test("a tampered pending outcome digest blocks retry before mutation", () => {
       }),
     /simulated pending digest crash/,
   );
+  retireReadyAuthorityWitnessForFixtureRewrite(paths.taskManifest);
   const manifest = JSON.parse(readFileSync(paths.taskManifest, "utf8"));
   const task = manifest.tasks.find((candidate) => candidate.taskId === taskId);
   task.pendingOutcome.outcomeDigest = "3".repeat(64);
@@ -5993,7 +6050,7 @@ test("installed backfill rejects unpinned legacy event identity without mutation
           now: new Date(nowMs + 2_000),
         },
       ),
-    /unsafe or pending outcome ledger repair state/,
+    /fully authenticated, healthy outcome ledger/,
   );
   assert.deepEqual(readFileSync(paths.taskManifest), before.manifest);
   assert.deepEqual(readFileSync(paths.events), before.events);
@@ -6399,7 +6456,7 @@ for (const route of ["fresh", "legacy-backfill"]) {
             ...authentication,
             now: recordTime,
           }),
-        /unsafe or pending outcome ledger repair state/,
+        /fully authenticated, healthy outcome ledger/,
       );
       assert.deepEqual(readFileSync(paths.taskManifest), before.manifest);
       assert.deepEqual(readFileSync(paths.events), before.events);
@@ -6458,6 +6515,8 @@ for (const route of ["fresh", "legacy-backfill"]) {
       ...transition.data.installedIdentity,
       commitSha: "f".repeat(40),
     };
+    retireReadyAuthorityWitnessForFixtureRewrite(paths.taskManifest);
+    retireReadyAuthorityWitnessForFixtureRewrite(paths.events);
     writeFileSync(
       paths.events,
       `${events.map((event) => JSON.stringify(event)).join("\n")}\n`,


### PR DESCRIPTION
(AI Generated).

## Summary
- Commit a recovered task manifest before appending its exact audit event so semantic authority remains valid through crashes.
- Recover the one exact event-first state produced by older code, including later canonical non-task events such as lease heartbeats.
- Keep adversarial nightly fixtures aligned with authority-witness and lease-provenance invariants.

## Testing
- Focused task transaction recovery tests: 3 passed.
- Post-admission nightly WAL regression: 1 passed.
- npm run validate:feature