### PR TITLE
chore: refresh changelog for v26.7.2300

### DIFF
--- a/website/public/atom.xml
+++ b/website/public/atom.xml
@@ -2,7 +2,7 @@
 <feed xmlns="http://www.w3.org/2005/Atom">
     <id>https://freed.wtf</id>
     <title>Freed Blog</title>
-    <updated>2026-07-08T17:45:24.124Z</updated>
+    <updated>2026-07-23T18:38:11.552Z</updated>
     <generator>https://github.com/jpmonette/feed</generator>
     <author>
         <name>The Freed Team</name>

--- a/website/public/feed.xml
+++ b/website/public/feed.xml
@@ -4,7 +4,7 @@
         <title>Freed Blog</title>
         <link>https://freed.wtf</link>
         <description>Progress reports, technical deep-dives, and philosophical rants about the attention economy. From the team building Freed.</description>
-        <lastBuildDate>Wed, 08 Jul 2026 17:45:24 GMT</lastBuildDate>
+        <lastBuildDate>Thu, 23 Jul 2026 18:38:11 GMT</lastBuildDate>
         <docs>https://validator.w3.org/feed/docs/rss2.html</docs>
         <generator>https://github.com/jpmonette/feed</generator>
         <language>en</language>

--- a/website/src/content/changelog.generated.json
+++ b/website/src/content/changelog.generated.json
@@ -1,5 +1,135 @@
 [
   {
+    "version": "26.7.2300",
+    "tagName": "v26.7.2300",
+    "channel": "production",
+    "date": "2026-07-23T18:27:53Z",
+    "deck": "Friends Galaxy, a focused YouTube study feed, and calmer reading from Medium and Substack",
+    "features": [
+      {
+        "text": "Explore Friends as a theme-aware, GPU-accelerated galaxy with provider constellations, stable labels, and mouse, trackpad, touch, and keyboard navigation."
+      },
+      {
+        "text": "Connect YouTube through your signed-in session to capture followed channels and recent long-form subscriptions, keep Shorts out of the study feed, watch in Focus Mode, or hand selected videos to a private YouTube playlist for Premium downloads."
+      },
+      {
+        "text": "Add Medium and Substack as beta sources for signed-in essays, subscriptions, visible relationships, and activity."
+      }
+    ],
+    "fixes": [
+      {
+        "text": "Sidebar controls are vertically centered with full-height hit areas, and expand or collapse no longer rebounds as synchronized state arrives."
+      },
+      {
+        "text": "Zoom, density, sidebar state and width, Friends layout, feed views, sorting, filters, and reader layout now stay local to each device instead of syncing through Automerge."
+      },
+      {
+        "text": "Factory reset fences active capture work, removes selected local sessions and sync state, and stops safely when cleanup fails."
+      },
+      {
+        "text": "Freed Desktop warns when a second desktop client may duplicate RSS and authenticated provider requests."
+      },
+      {
+        "text": "YouTube sign-in, capture, progress, cancellation, and hidden session cleanup are bounded and recover safely."
+      },
+      {
+        "text": "Automerge worker startup retries once after a clean reset, and unchanged cloud documents no longer echo through idle reuploads."
+      },
+      {
+        "text": "Facebook groups you have left stay removed, and Medium and Substack beta labels remain readable through 150% zoom."
+      },
+      {
+        "text": "Private security reports redact diagnostics and harden fetched content before submission."
+      }
+    ],
+    "followUps": [
+      {
+        "text": "Medium and Substack remain beta while capture coverage broadens."
+      },
+      {
+        "text": "RSS subscriptions and successful refresh timestamps sync. Retry state and reader cache stay local, and the PWA does not poll feeds."
+      },
+      {
+        "text": "Multiple desktop clients are warned about duplicate request surface, but requests are not centrally deduplicated yet."
+      },
+      {
+        "text": "Factory reset preserves safety ledgers, media files, AI models, legal acceptance, and install identity."
+      },
+      {
+        "text": "Freed does not download or cache YouTube video or audio. Offline downloads remain in YouTube Premium through the private playlist."
+      }
+    ],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.7.2300",
+    "prNumbers": [
+      642,
+      917,
+      920,
+      922,
+      924,
+      927,
+      929,
+      932,
+      934,
+      935,
+      936,
+      937,
+      939,
+      940,
+      942,
+      944,
+      946,
+      947,
+      949,
+      950,
+      953,
+      954,
+      955,
+      957,
+      963,
+      964,
+      965,
+      966,
+      968,
+      969,
+      970,
+      972,
+      973,
+      974,
+      975,
+      976,
+      977,
+      978,
+      979,
+      980,
+      982,
+      983,
+      984,
+      1010,
+      1012,
+      1013,
+      1015,
+      1016,
+      1021,
+      1022,
+      1023,
+      1025,
+      1026,
+      1027,
+      1028,
+      1060
+    ],
+    "builds": [
+      "26.7.2300"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.7.2300",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.7.2300",
+        "channel": "production"
+      }
+    ]
+  },
+  {
     "version": "26.7.1501-dev",
     "tagName": "v26.7.1501-dev",
     "channel": "dev",


### PR DESCRIPTION
(AI Generated).

## Summary
- Regenerate the public changelog snapshot after the v26.7.2300 GitHub release became available.
- Refresh the RSS and Atom build timestamps from the same published release state.

## Testing
- cd website && PATH=../node_modules/.bin:$PATH npm run build