### PR TITLE
chore: make the tooling lane path-aware and codify a testing standard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,12 @@ on:
   pull_request:
     branches: [dev, main]
 
+# Superseded dev pushes cancel too. Only the latest dev tree carries the full
+# integration proof that release admission inherits, so validating an
+# intermediate commit that a newer push already replaced is wasted runner time.
 concurrency:
   group: validation-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -17,19 +20,73 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
+  # Cheap by design: the planner imports only Node builtins, so this job needs
+  # no dependency install and settles in well under a minute.
+  tooling-smoke-plan:
+    name: Tooling smoke plan
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      matrix: ${{ steps.plan.outputs.matrix }}
+      applicable: ${{ steps.plan.outputs.applicable }}
+      job-count: ${{ steps.plan.outputs.job-count }}
+      native: ${{ steps.plan.outputs.native }}
+      reason: ${{ steps.plan.outputs.reason }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version-file: ".nvmrc"
+
+      # A push to dev runs the full lane. That is the one full integration proof
+      # on the protected tree, and release admission inherits it by receipt.
+      - name: Resolve tooling smoke plan
+        id: plan
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            node scripts/plan-tooling-smoke.mjs --all --github-output
+          else
+            git fetch --no-tags origin "${{ github.base_ref }}"
+            node scripts/plan-tooling-smoke.mjs \
+              --base-ref "origin/${{ github.base_ref }}" \
+              --github-output
+          fi
+
+      - name: Summarize the plan
+        run: |
+          {
+            echo "### Tooling smoke plan"
+            echo ""
+            echo "- jobs: ${{ steps.plan.outputs.job-count }} (cap 8, was a fixed 32)"
+            echo "- reason: ${{ steps.plan.outputs.reason }}"
+            echo "- native acceptance lane: ${{ steps.plan.outputs.native }}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
   tooling-smoke-shards:
-    name: Tooling smoke shard (${{ matrix.suite }} ${{ matrix.shard }}/8)
+    name: Tooling smoke shard (${{ matrix.name }})
+    needs: tooling-smoke-plan
+    if: needs.tooling-smoke-plan.outputs.applicable == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 90
+    # 90 minutes, matching the pre-planner lane, NOT a shorter budget.
+    #
+    # Fewer shards means each one does more work. The old lane ran 32 shards at
+    # 90 minutes; capping at 8 quadruples the work per shard, so halving the
+    # timeout was exactly backwards. A first attempt at 45 minutes killed
+    # kernel-guard-cutover mid-run at 45:54 with every test passing, which reads
+    # as a test failure and is not one.
+    #
+    # This is a ceiling for the full lane, not a target. Ordinary PRs select
+    # zero or one suite and finish in minutes; only a scripts/ change or a push
+    # to dev pays the whole cost. Suite runtimes are tracked separately as debt.
     strategy:
       fail-fast: false
-      matrix:
-        suite:
-          - general
-          - automation-control
-          - kernel-guard-cutover
-          - outcome-ledger-repair
-        shard: [1, 2, 3, 4, 5, 6, 7, 8]
+      matrix: ${{ fromJSON(needs.tooling-smoke-plan.outputs.matrix) }}
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -44,22 +101,102 @@ jobs:
         run: npm ci
 
       - name: Run tooling smoke shard
-        run: >-
-          node scripts/run-tooling-smoke-shard.mjs
-          --suite=${{ matrix.suite }}
-          --shard-index=${{ matrix.shard }}
-          --shard-count=8
+        run: |
+          started=$(date +%s)
+          node scripts/run-tooling-smoke-shard.mjs \
+            --suite=${{ matrix.suite }} \
+            --shard-index=${{ matrix.shard }} \
+            --shard-count=${{ matrix.shardCount }}
+          echo "shard ${{ matrix.name }} took $(( $(date +%s) - started ))s" \
+            >> "$GITHUB_STEP_SUMMARY"
 
+  # The gate is the branch-visible contract. It fails when the planner fails,
+  # when a scheduled shard fails, and when shards are missing while the planner
+  # said they were required. A not-applicable plan is the only path to a green
+  # gate without shard execution.
   tooling-smoke:
     name: Tooling smoke
     if: ${{ always() }}
-    needs: tooling-smoke-shards
+    needs: [tooling-smoke-plan, tooling-smoke-shards, native-acceptance]
     runs-on: ubuntu-latest
     steps:
-      - name: Require every tooling smoke shard
+      - name: Require the planned tooling smoke result
         env:
-          TOOLING_SMOKE_RESULT: ${{ needs.tooling-smoke-shards.result }}
-        run: test "$TOOLING_SMOKE_RESULT" = "success"
+          PLAN_RESULT: ${{ needs.tooling-smoke-plan.result }}
+          SHARD_RESULT: ${{ needs.tooling-smoke-shards.result }}
+          NATIVE_RESULT: ${{ needs.native-acceptance.result }}
+          APPLICABLE: ${{ needs.tooling-smoke-plan.outputs.applicable }}
+          NATIVE_REQUIRED: ${{ needs.tooling-smoke-plan.outputs.native }}
+          JOB_COUNT: ${{ needs.tooling-smoke-plan.outputs.job-count }}
+        run: |
+          if [ "$PLAN_RESULT" != "success" ]; then
+            echo "Tooling smoke planner did not succeed: $PLAN_RESULT"
+            exit 1
+          fi
+
+          if [ "$APPLICABLE" = "true" ]; then
+            if [ "$SHARD_RESULT" != "success" ]; then
+              echo "Planner scheduled $JOB_COUNT shard(s); result was $SHARD_RESULT"
+              exit 1
+            fi
+            echo "All $JOB_COUNT planned tooling smoke shard(s) passed."
+          else
+            if [ "$SHARD_RESULT" != "skipped" ]; then
+              echo "Plan was not applicable but shards reported $SHARD_RESULT"
+              exit 1
+            fi
+            echo "No changed path reaches the tooling smoke lane."
+          fi
+
+          # Observe-only for now, deliberately.
+          #
+          # These three files gate every test behind a module-level darwin
+          # check, so on Ubuntu they have always skipped and asserted nothing.
+          # This lane is the first time they execute at all, and the first run
+          # hung for the full job timeout. Blocking on a known-hanging test
+          # would stop every provider-visible change while proving nothing, and
+          # non-blocking is still strictly more coverage than the zero we had.
+          #
+          # This becomes blocking once the hang is diagnosed. Tracked as debt.
+          if [ "$NATIVE_REQUIRED" = "true" ]; then
+            if [ "$NATIVE_RESULT" = "success" ]; then
+              echo "Native acceptance passed on macOS."
+            else
+              echo "::warning::Native acceptance reported $NATIVE_RESULT (observe-only, not gating yet)"
+            fi
+          elif [ "$NATIVE_RESULT" != "skipped" ]; then
+            echo "Native acceptance was not required but reported $NATIVE_RESULT"
+            exit 1
+          fi
+
+  # These assertions no-op on Linux. Running them on a real macOS runner is the
+  # only way the launchd, Keychain, and signed-broker paths are actually proven.
+  native-acceptance:
+    name: Native actor acceptance (macOS)
+    needs: tooling-smoke-plan
+    if: needs.tooling-smoke-plan.outputs.native == 'true'
+    runs-on: macos-latest
+    # 60, not 30. Measured on a hosted macOS runner the publish tests take
+    # 175-250s each, and this lane currently re-runs all 35 of them even though
+    # only 7 are darwin-gated. Issue #1133 tracks narrowing the lane to the
+    # darwin-only subset, which is the real fix; this is the honest budget until
+    # then. The lane is observe-only, so a slow run costs time, not a red gate.
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run native acceptance tests
+        run: node scripts/run-native-acceptance.mjs
 
   main-pr-guard:
     name: Main PR guard

--- a/.github/workflows/tooling-nightly.yml
+++ b/.github/workflows/tooling-nightly.yml
@@ -1,0 +1,155 @@
+name: Nightly exhaustive
+
+# The blocking lanes are deliberately narrow. This is where the expensive work
+# lives: every suite unsharded, repeated runs to surface flake, and the native
+# acceptance tests on a real macOS runner.
+#
+# Nothing here gates a pull request. When it finds something it files debt the
+# same way the dev lane files incidents, so a slow suite or a flaky test becomes
+# a tracked issue instead of a surprise in someone's PR.
+
+on:
+  schedule:
+    # 07:00 UTC, comfortably after the usual working day in the owner's timezone.
+    - cron: "0 7 * * *"
+  workflow_dispatch:
+    inputs:
+      repeat:
+        description: "Runs per suite for flake discovery"
+        required: false
+        default: "2"
+
+concurrency:
+  group: tooling-nightly
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  exhaustive-tooling:
+    name: Exhaustive tooling suites
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Measure every suite and look for flake
+        id: measure
+        run: |
+          node scripts/measure-tooling-smoke.mjs \
+            --repeat="${{ github.event.inputs.repeat || '2' }}" \
+            > tooling-smoke-measured.json 2> tooling-smoke-measured.log
+          cat tooling-smoke-measured.log
+
+      - name: Report timings and drift
+        if: always()
+        run: node scripts/report-tooling-smoke-drift.mjs tooling-smoke-measured.json
+
+      - name: Upload measurements
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: tooling-smoke-measurements
+          path: |
+            tooling-smoke-measured.json
+            tooling-smoke-measured.log
+          retention-days: 30
+          if-no-files-found: warn
+
+      # Flake and drift are debt, not incidents. One issue, deduplicated, so the
+      # backlog stays the single source per the repo debt contract.
+      - name: File or update the tooling debt issue
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          title="Nightly exhaustive tooling lane needs attention"
+          body="(AI Generated).
+
+          Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
+          Commit: ${GITHUB_SHA}
+
+          The nightly exhaustive lane failed, went flaky, or drifted far enough
+          from scripts/tooling-smoke-durations.json that shard balance is stale.
+          Refresh durations with: node scripts/measure-tooling-smoke.mjs --write"
+          existing=$(gh issue list --label debt --state open \
+            --search "in:title \"$title\"" --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$body"
+          else
+            gh issue create --title "$title" --label debt --body "$body"
+          fi
+
+  native-acceptance:
+    name: Native actor acceptance (macOS)
+    runs-on: macos-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run native acceptance tests
+        run: node scripts/run-native-acceptance.mjs
+
+  desktop-e2e:
+    name: Desktop e2e (full)
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/azure-cli.list \
+            /etc/apt/sources.list.d/azure-cli.sources
+          npx playwright install --with-deps chromium
+        working-directory: packages/desktop
+
+      - name: Run the full desktop e2e suite
+        run: npm run test:e2e
+        working-directory: packages/desktop
+
+      - name: Upload reports on failure
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: nightly-playwright-report
+          path: packages/desktop/playwright-report/
+          retention-days: 14
+          if-no-files-found: ignore

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,6 +181,19 @@ Treat `dev`, `main`, and `www` as separate lanes with explicit promotion points.
 - `npm run validate:release` is the heaviest lane for release-prep work on `main`.
 - Do not default feature threads to the full integration suite when the touched surface is narrow.
 
+### Test Economy
+
+The binding standard is [docs/TESTING-STANDARD.md](docs/TESTING-STANDARD.md). Read it before adding, moving, or deleting a permanent test.
+
+- **Admission.** A new permanent test must protect a distinct user, data-integrity, security, authority, provider, release, migration, or operational contract. Search for existing same-layer coverage first and prefer extending it. State the unique failure it detects, use the cheapest deterministic layer, assign a tier, and measure its runtime. Individual test additions do not need owner approval, they need judgment.
+- **Tiers.** Changed-path suites for ordinary PRs, one full integration proof on the latest `dev` tree, release-delta checks at tag and promotion, exhaustive coverage nightly. A test can be release-critical through an exact inherited receipt without rerunning in the release workflow.
+- **Local coverage is not automatically a release gate.** A test earns a blocking lane by protecting a contract in the universal release gate list, not by having caught something once.
+- **No real sleeps or production-duration timeouts in blocking lanes.** Use injected clocks. Tooling shards run with a 5 minute per-test timeout; anything slower in a blocking lane is a defect.
+- **Delete temporary probes before publishing.** Exact pixel offsets, one-off geometry checks, and fixture self-tests already covered by real workflows do not survive to `main`.
+- **Platform honesty.** A test that skips itself wholesale on the runner it executes on is not coverage. Route it to the lane where it actually asserts something.
+- **The tooling smoke matrix is computed, never hardcoded.** `scripts/plan-tooling-smoke.mjs` derives applicable suites from changed paths and caps the lane at 8 jobs. Do not reintroduce a literal suite or shard list in `ci.yml`.
+- **Prune continuously.** Move expensive-but-useful tests to nightly, merge duplicate assertions, and quarantine flaky noncritical tests behind one debt issue with an owner. Never quarantine data integrity, authority, provider safety, signing, release identity, or updater protection without an equivalent deterministic blocker.
+
 **Never use `git log main..branch` to check whether a branch has been merged.** Squash merge creates a new commit hash on `main`, so the original branch commits are never reachable from `main`'s history. The branch always looks "ahead" even when its content is fully shipped. Use these instead:
 
 ```bash

--- a/docs/TESTING-STANDARD.md
+++ b/docs/TESTING-STANDARD.md
@@ -1,0 +1,124 @@
+# Testing Standard
+
+Status: **Active.**
+
+This document governs which tests exist, where they run, and when they are removed. It is the companion to [STABILITY-PROGRAM.md](STABILITY-PROGRAM.md), which governs product behavior changes.
+
+## Why this exists
+
+The suite reached about 2,700 declared tests across 342 files and roughly 152,000 lines, of which about 107,000 lines were added since July 1. Five control-plane files alone hold about 47,000 lines. Every pull request launched 32 tooling jobs regardless of what changed.
+
+The cost was not theoretical. Friends PR #1111 finished its relevant feature validation in 9 minutes while unrelated tooling consumed 604 runner-minutes and held the pull request for about 88 minutes. Of the last 100 Validation runs, 58 cancelled, burning roughly 60 wall-clock hours. The July 23 production release repeated broad validation five times for about 149 minutes, while packaging all four platforms took under 28 minutes.
+
+The organization runs on the GitHub Free plan: **20 concurrent jobs, 5 concurrent macOS jobs**. A 32-job lane meant one pull request demanded 160 percent of total capacity, so pull requests could not overlap and serialized into the queue. That is the mechanism behind the numbers above.
+
+## Admission
+
+A new permanent test must protect a distinct user, data-integrity, security, authority, provider, release, migration, or operational contract.
+
+Before adding one:
+
+1. Search for existing same-layer coverage.
+2. Prefer extending or strengthening an existing test.
+3. State the unique failure it detects.
+4. Use the cheapest deterministic layer that can detect it.
+5. Identify the inputs that invalidate its result.
+6. Assign it to an execution tier.
+7. Measure its runtime.
+8. Avoid real sleeps and production-duration timeouts in blocking lanes.
+9. Delete temporary diagnostic probes before publication.
+
+Use engineering judgment. Individual test additions do not need owner approval.
+
+Local regression coverage does not automatically become a permanent universal release gate. A test earns a blocking lane by protecting a contract in the universal gate list below, not by having caught something once.
+
+## Execution tiers
+
+| Tier | Runs on | Contains |
+| --- | --- | --- |
+| 1. Changed-path | Every pull request | Only suites the changed paths can affect |
+| 2. Full integration | Every push to `dev` | Every suite, unscoped. This is the proof release admission inherits |
+| 3. Release delta | Tag and promotion | Version, notes, identity, build, packaging, artifacts |
+| 4. Exhaustive | Nightly and dispatch | Stress, fault injection, full visual and performance matrices, long control-plane simulations, flake discovery |
+
+A test may be release-critical through an exact inherited receipt without rerunning inside the release workflow.
+
+## How tier 1 is computed
+
+`scripts/plan-tooling-smoke.mjs` derives the applicable suites from the changed path set and emits a GitHub Actions matrix. It never exceeds **8 jobs**, against the previous fixed 32.
+
+Attribution uses two signals, because neither alone is correct:
+
+- **Transitive relative imports** from each suite's test files.
+- **Repo-path string literals** named anywhere in that closure. Several validators assert facts about content they never import, such as the provider-visible path list and the roadmap status file. An import graph alone would miss them.
+
+A path literal counts as a dependency edge only when it is concrete. Bare roots such as `packages/` and package roots such as `packages/desktop/` appear in sources as `startsWith` guards rather than references. Treating those as edges attached every UI change to the control-plane suites, which is the exact waste this planner removes.
+
+The planner fails closed. Any change under `scripts/` or `automation/` that cannot be attributed selects every suite, as does any change to a global input such as `package.json`, `.nvmrc`, or the workflow itself. An empty plan is reported as a quick not-applicable success, and the gate then requires that the shard job was genuinely skipped rather than failed.
+
+Shard budget is distributed across the selected suites by highest averages, weighted by measured runtime from `scripts/tooling-smoke-durations.json` when available and source size otherwise. Source size is a poor predictor, which is why the nightly lane measures and reports drift.
+
+## Platform routing
+
+Three files gate every test behind a single module-level `process.platform === "darwin"` check. Running them on Ubuntu spent time and asserted nothing, and one of them was observed blocking indefinitely at 0 percent CPU. They run on the macOS lane only:
+
+- `scripts/automation-actor-native.test.mjs`
+- `scripts/release-tag-publisher-native.test.mjs`
+- `scripts/trusted-publisher-host.test.mjs`
+
+`scripts/worktree-publish.test.mjs` deliberately stays in the Linux lane. It gates 7 of its 35 tests per-test, so the other 28 are real coverage. It also runs on the macOS lane, where its darwin cases execute for the first time.
+
+`run-tooling-smoke-shard.test.mjs` asserts that the sharded suites, the general suite, and the macOS lane together claim every repository test file. Nothing can fall out of the lane silently.
+
+## Timeouts
+
+Shards run with a per-test timeout of 5 minutes. `node --test` defaults to no timeout, which let one blocked test pin a shard until the job-level timeout with no useful signal. Any tooling test slower than this in a blocking lane is a defect, not a long test.
+
+## Universal release gate
+
+Keep this list small. These are the only checks that gate every release:
+
+- Protected source and tree identity
+- Exact green integration receipt
+- Provider approval receipt when applicable
+- Promotion and backflow validity
+- Version consistency
+- Approved release notes and release receipt
+- Publisher and tag authority
+- Four-platform compilation and packaging
+- Signing and notarization
+- Updater manifest and artifact hashes
+- Concise packaged startup, migration, updater, and data-open smoke
+
+Do not rerun unrelated unit, e2e, visual, performance, automation, outcome-ledger, Website, Rust, or provider suites when their inputs are unchanged.
+
+The Website is a separate lane. It ships from `www` through its own job against the reviewed marketing branch, so it is not built or tested inside the Desktop release lane.
+
+## Continuous maintenance
+
+Collect per-suite runtime, flake rate, runner cost, skipped-platform coverage, and unique defect catches. The nightly lane writes timings and opens one deduplicated debt issue when a suite goes flaky or drifts by more than 2x.
+
+Continuously:
+
+- Remove obsolete fixtures
+- Merge duplicate same-layer assertions
+- Move useful but expensive tests to nightly
+- Quarantine inconsistent noncritical tests with one debt issue and owner
+- Rewrite real-time waits using injected clocks
+- Restore quarantined tests after sustained clean evidence
+
+Never quarantine data integrity, authority, provider safety, signing, release identity, or updater protection without an equivalent deterministic blocker.
+
+No test stays in a blocking lane merely because it has always been there.
+
+## Targets
+
+| Lane | Target |
+| --- | --- |
+| Ordinary pull request | Under about 10 minutes |
+| Complex pull request | Under 20 minutes at the 95th percentile |
+| Latest `dev` integration | Under 25 minutes |
+| Release-delta admission | Under 10 minutes |
+| Tag to published artifacts | Under about 40 minutes |
+
+No UI-only pull request runs control-plane suites.

--- a/scripts/lib/tooling-smoke-plan.mjs
+++ b/scripts/lib/tooling-smoke-plan.mjs
@@ -288,6 +288,12 @@ export const DURATIONS_FILE = "scripts/tooling-smoke-durations.json";
 export const DEFAULT_MAX_JOBS = 8;
 
 /**
+ * The `timeout-minutes` on a tooling smoke shard job, in seconds. Kept here so
+ * the planner can predict an overrun rather than discover one.
+ */
+export const DEFAULT_SHARD_TIMEOUT_SECONDS = 90 * 60;
+
+/**
  * Measured suite seconds when the nightly lane has recorded them, falling back
  * to source size. Size is a poor predictor of runtime, which is why the nightly
  * lane writes real timings back into the durations file.
@@ -306,18 +312,63 @@ export function suiteWeights({ repoRoot = REPO_ROOT, durations = null } = {}) {
     })();
   const weights = new Map();
   for (const suite of SUITE_NAMES) {
-    const measured = Number(recorded?.suites?.[suite]?.seconds);
+    const entry = recorded?.suites?.[suite];
+    const measured = Number(entry?.seconds);
     if (Number.isFinite(measured) && measured > 0) {
-      weights.set(suite, { weight: measured, measured: true });
+      // A run that was killed by the job timeout did not measure anything. It
+      // established a floor. Recording it as a measurement is what made this
+      // lane unable to correct itself: the truncated number is smaller than the
+      // truth, so the planner under-shards, so the shards are killed again, so
+      // the number never grows. `capped` breaks that loop by keeping the
+      // distinction the durations file previously only stated in prose.
+      weights.set(suite, {
+        weight: measured,
+        measured: entry?.capped !== true,
+        capped: entry?.capped === true,
+      });
       continue;
     }
     let size = 0;
     for (const testFile of suiteTestFiles(suite, repoRoot)) {
       size += readIfPresent(repoRoot, testFile)?.length ?? 0;
     }
-    weights.set(suite, { weight: Math.max(1, size), measured: false });
+    weights.set(suite, { weight: Math.max(1, size), measured: false, capped: false });
   }
   return weights;
+}
+
+/**
+ * Per-shard seconds the plan implies, and whether that fits the job timeout.
+ *
+ * The lane used to schedule work it could have predicted would not fit, wait
+ * ninety minutes, and then report the cancellation as a test failure. Predicting
+ * it costs one division. A capped weight is a floor rather than a measurement,
+ * so `atLeast` says the real figure is higher by an unknown amount.
+ */
+export function projectShardRuntime(allocation, weights, timeoutSeconds) {
+  return allocation.map(({ suite, shardCount }) => {
+    const entry = weights.get(suite);
+    const weight = entry?.weight ?? 0;
+    const capped = entry?.capped === true;
+    // The size fallback weighs source bytes, not seconds. Dividing bytes by
+    // shards and comparing the result to a timeout would be a unit error that
+    // happens to typecheck, so that case predicts nothing and blocks nothing.
+    const isSeconds = entry?.measured === true || capped;
+    const perShardSeconds = shardCount > 0 ? weight / shardCount : weight;
+    return {
+      suite,
+      shardCount,
+      perShardSeconds: isSeconds ? perShardSeconds : null,
+      atLeast: capped,
+      // Only a real measurement can clear the check. A capped weight already
+      // exceeded a timeout once, so treating "the floor fits" as "it fits"
+      // would reproduce the bug this function exists to catch.
+      fits: capped
+        ? false
+        : !isSeconds || !Number.isFinite(timeoutSeconds) || perShardSeconds <= timeoutSeconds,
+      predictedFrom: capped ? "capped" : entry?.measured === true ? "measured" : "size",
+    };
+  });
 }
 
 /**
@@ -361,10 +412,12 @@ export function buildToolingSmokeMatrix({
   maxJobs = DEFAULT_MAX_JOBS,
   repoRoot = REPO_ROOT,
   durations = null,
+  shardTimeoutSeconds = DEFAULT_SHARD_TIMEOUT_SECONDS,
 } = {}) {
   const selection = selectApplicableSuites(changedFiles, { repoRoot });
   const weights = suiteWeights({ repoRoot, durations });
   const allocation = allocateShardBudget(selection.suites, maxJobs, weights);
+  const projection = projectShardRuntime(allocation, weights, shardTimeoutSeconds);
   const include = allocation.flatMap(({ suite, shardCount }) =>
     Array.from({ length: shardCount }, (_, index) => ({
       suite,
@@ -384,5 +437,11 @@ export function buildToolingSmokeMatrix({
     weightsAreMeasured:
       selection.suites.length > 0 &&
       selection.suites.every((suite) => weights.get(suite)?.measured === true),
+    projection,
+    shardTimeoutSeconds,
+    // Suites this plan predicts will not finish inside the job timeout. The
+    // caller decides what to do about it; the point is that it is known before
+    // the jobs run rather than ninety minutes later.
+    overrunSuites: projection.filter((entry) => !entry.fits).map((entry) => entry.suite),
   });
 }

--- a/scripts/lib/tooling-smoke-plan.mjs
+++ b/scripts/lib/tooling-smoke-plan.mjs
@@ -1,0 +1,388 @@
+import { readFileSync, statSync } from "node:fs";
+import path from "node:path";
+
+import {
+  GENERAL_SUITE,
+  NATIVE_ACCEPTANCE_TEST_FILES,
+  REPO_ROOT,
+  SUITE_NAMES,
+  suiteTestFiles,
+} from "./tooling-smoke-suites.mjs";
+
+// A change to any of these invalidates every suite, so the planner stops trying
+// to attribute it and runs the full lane.
+export const GLOBAL_INVALIDATION_PATHS = Object.freeze(
+  new Set([
+    ".github/workflows/ci.yml",
+    ".github/workflows/tooling-nightly.yml",
+    ".nvmrc",
+    "package-lock.json",
+    "package.json",
+    "scripts/lib/tooling-smoke-plan.mjs",
+    "scripts/lib/tooling-smoke-suites.mjs",
+    "scripts/run-tooling-smoke-shard.mjs",
+    "tsconfig.base.json",
+    "tsconfig.json",
+  ]),
+);
+
+// Changes under these roots can reach the tooling lane through a spawned shell
+// script or a fixture that no static edge records, so an unattributed change
+// here fails closed to the full lane instead of being silently dropped.
+const FAIL_CLOSED_ROOTS = Object.freeze(["scripts/", "automation/"]);
+
+const REPO_PATH_LITERAL =
+  /(?<=["'`])(?:scripts|packages|website|docs|automation|release-notes|skills|\.github)\/[A-Za-z0-9._*/-]*/g;
+
+const TOP_LEVEL_ROOTS = Object.freeze([
+  ".github/",
+  "automation/",
+  "docs/",
+  "packages/",
+  "release-notes/",
+  "scripts/",
+  "skills/",
+  "website/",
+]);
+
+function toPosix(filePath) {
+  return filePath.replace(/\\/g, "/").replace(/^\.\//, "");
+}
+
+// Attempt the read rather than checking first. An existsSync/statSync guard
+// ahead of readFileSync is a time-of-check to time-of-use race: the path can
+// change between the check and the read. Reading a directory or a missing path
+// throws, which is the same answer the guard was trying to produce.
+function readIfPresent(repoRoot, relativePath) {
+  try {
+    return readFileSync(path.join(repoRoot, relativePath), "utf8");
+  } catch {
+    return null;
+  }
+}
+
+function statOrNull(absolutePath) {
+  try {
+    return statSync(absolutePath);
+  } catch {
+    return null;
+  }
+}
+
+function importSpecifiers(source) {
+  const specifiers = [];
+  const patterns = [
+    /\bfrom\s*["']([^"']+)["']/g,
+    /\bimport\s*\(\s*["']([^"']+)["']\s*\)/g,
+    /\bimport\s+["']([^"']+)["']/g,
+  ];
+  for (const pattern of patterns) {
+    for (const match of source.matchAll(pattern)) specifiers.push(match[1]);
+  }
+  return specifiers;
+}
+
+function resolveRelative(fromFile, specifier) {
+  if (!specifier.startsWith(".")) return null;
+  return toPosix(path.posix.join(path.posix.dirname(fromFile), specifier));
+}
+
+/**
+ * Tooling sources mention repo paths for two different reasons: to name a
+ * specific file they depend on, and to guard a path prefix such as
+ * `startsWith("packages/")`. Only the first is a dependency edge. Treating a
+ * bare top-level root as an edge would attach every UI and website change to
+ * the control-plane suites, which is the exact waste this planner removes.
+ */
+function isDependencyEdge(literal, repoRoot) {
+  const trimmed = literal.replace(/\/+$/, "");
+  const segments = trimmed.split("/").filter(Boolean);
+  // A lone root such as "packages/" is a guard prefix, never an edge.
+  if (segments.length < 2) return false;
+  if (literal.includes("*")) return true;
+  // One stat, not an exists-then-stat pair, so there is no window for the path
+  // to change between the two calls.
+  const stats = statOrNull(path.join(repoRoot, trimmed));
+  if (stats !== null) {
+    // A package root such as "packages/desktop/" is as broad as a top-level
+    // root, so it reads as a guard rather than a reference. Only a directory
+    // narrower than a package counts as an edge. The provider gate does not
+    // depend on this: validate:feature classifies provider surfaces on every
+    // PR regardless of which tooling suites the planner selects.
+    if (stats.isDirectory()) return segments.length >= 3;
+    return true;
+  }
+  // Unresolved literals count only when they read as a deliberate filename
+  // prefix, such as "docs/PHASE-" or "packages/capture-".
+  return segments.length >= 3 || /[-_.]/.test(segments.at(-1) ?? "");
+}
+
+/**
+ * Transitive closure of relative imports reachable from `entryFiles`, plus the
+ * repo-path string literals those modules name. Literals matter because several
+ * tooling validators assert facts about repo content they never import, such as
+ * the provider-visible path list and the roadmap status file.
+ */
+export function moduleClosure(entryFiles, { repoRoot = REPO_ROOT } = {}) {
+  const modules = new Set();
+  const literals = new Set();
+  const queue = [...entryFiles.map(toPosix)];
+  while (queue.length > 0) {
+    const current = queue.pop();
+    if (modules.has(current)) continue;
+    const source = readIfPresent(repoRoot, current);
+    if (source === null) continue;
+    modules.add(current);
+    for (const specifier of importSpecifiers(source)) {
+      const resolved = resolveRelative(current, specifier);
+      if (resolved !== null && !modules.has(resolved)) queue.push(resolved);
+    }
+    for (const match of source.matchAll(REPO_PATH_LITERAL)) {
+      const literal = toPosix(match[0]);
+      if (!modules.has(literal) && isDependencyEdge(literal, repoRoot)) {
+        literals.add(literal);
+      }
+    }
+  }
+  return { modules, literals };
+}
+
+function literalMatches(literal, changedFile) {
+  if (literal === changedFile) return true;
+  // A literal naming a directory, or a prefix such as "docs/PHASE-", covers
+  // every file beneath or beginning with it. Bare roots never reach here:
+  // isDependencyEdge rejects them before they become edges.
+  if (literal.endsWith("/")) return changedFile.startsWith(literal);
+  const glob = literal.indexOf("*");
+  if (glob >= 0) return changedFile.startsWith(literal.slice(0, glob));
+  if (path.posix.basename(literal).includes(".")) return false;
+  return (
+    changedFile.startsWith(`${literal}/`) || changedFile.startsWith(literal)
+  );
+}
+
+export function suiteDependencies({ repoRoot = REPO_ROOT } = {}) {
+  const dependencies = new Map();
+  for (const suite of SUITE_NAMES) {
+    const entryFiles = suiteTestFiles(suite, repoRoot);
+    const { modules, literals } = moduleClosure(entryFiles, { repoRoot });
+    // A suite always owns its own test files and their subject modules.
+    for (const testFile of entryFiles) {
+      const subject = testFile.replace(/\.test\.mjs$/, ".mjs");
+      if (readIfPresent(repoRoot, subject) !== null) modules.add(subject);
+    }
+    dependencies.set(suite, { modules, literals });
+  }
+  return dependencies;
+}
+
+function isUnderFailClosedRoot(changedFile) {
+  return FAIL_CLOSED_ROOTS.some((root) => changedFile.startsWith(root));
+}
+
+function isRepoSurface(changedFile) {
+  return TOP_LEVEL_ROOTS.some((root) => changedFile.startsWith(root));
+}
+
+/**
+ * Decide which suites a changed path set can actually affect.
+ *
+ * Returns every suite when the change is global or when a change under a
+ * fail-closed root cannot be attributed. Returns an empty list only when no
+ * changed file reaches the tooling lane at all, which is the quick
+ * not-applicable success path.
+ */
+export function selectApplicableSuites(
+  changedFiles,
+  { repoRoot = REPO_ROOT, dependencies = null } = {},
+) {
+  const files = [...new Set(changedFiles.map(toPosix))].filter(Boolean).sort();
+  if (files.length === 0) {
+    return Object.freeze({
+      suites: Object.freeze([...SUITE_NAMES]),
+      reason: "no changed files were supplied, so the full lane runs",
+      unattributed: Object.freeze([]),
+    });
+  }
+
+  const globalHits = files.filter((file) => GLOBAL_INVALIDATION_PATHS.has(file));
+  if (globalHits.length > 0) {
+    return Object.freeze({
+      suites: Object.freeze([...SUITE_NAMES]),
+      reason: `global tooling input changed: ${globalHits.join(", ")}`,
+      unattributed: Object.freeze([]),
+    });
+  }
+
+  const graph = dependencies ?? suiteDependencies({ repoRoot });
+  const selected = new Set();
+  const attributed = new Set();
+  for (const [suite, { modules, literals }] of graph) {
+    for (const file of files) {
+      const hit =
+        modules.has(file) ||
+        [...literals].some((literal) => literalMatches(literal, file));
+      if (hit) {
+        selected.add(suite);
+        attributed.add(file);
+      }
+    }
+  }
+
+  const unattributed = files.filter(
+    (file) => !attributed.has(file) && isUnderFailClosedRoot(file),
+  );
+  if (unattributed.length > 0) {
+    return Object.freeze({
+      suites: Object.freeze([...SUITE_NAMES]),
+      reason: `unattributed tooling change fails closed to the full lane: ${unattributed.join(", ")}`,
+      unattributed: Object.freeze(unattributed),
+    });
+  }
+
+  const suites = SUITE_NAMES.filter((suite) => selected.has(suite));
+  if (suites.length === 0) {
+    const offRepo = files.filter((file) => !isRepoSurface(file));
+    return Object.freeze({
+      suites: Object.freeze([]),
+      reason:
+        offRepo.length === files.length
+          ? "no changed file touches a tracked repo surface"
+          : "no changed file reaches the tooling smoke lane",
+      unattributed: Object.freeze([]),
+    });
+  }
+  return Object.freeze({
+    suites: Object.freeze(suites),
+    reason: `changed paths reach ${suites.length.toLocaleString()} of ${SUITE_NAMES.length.toLocaleString()} tooling suites`,
+    unattributed: Object.freeze([]),
+  });
+}
+
+/**
+ * Whether a change reaches the native acceptance tests. These skip themselves
+ * on Linux, so selecting them means scheduling the macOS lane where their
+ * assertions actually run.
+ */
+export function selectNativeAcceptance(
+  changedFiles,
+  { repoRoot = REPO_ROOT } = {},
+) {
+  const files = [...new Set(changedFiles.map(toPosix))].filter(Boolean);
+  if (files.length === 0) return Object.freeze({ required: true, files: [] });
+  if (files.some((file) => GLOBAL_INVALIDATION_PATHS.has(file))) {
+    return Object.freeze({ required: true, files: [] });
+  }
+  const { modules, literals } = moduleClosure(NATIVE_ACCEPTANCE_TEST_FILES, {
+    repoRoot,
+  });
+  const reached = files.filter(
+    (file) =>
+      modules.has(file) ||
+      [...literals].some((literal) => literalMatches(literal, file)),
+  );
+  return Object.freeze({ required: reached.length > 0, files: reached });
+}
+
+export const DURATIONS_FILE = "scripts/tooling-smoke-durations.json";
+export const DEFAULT_MAX_JOBS = 8;
+
+/**
+ * Measured suite seconds when the nightly lane has recorded them, falling back
+ * to source size. Size is a poor predictor of runtime, which is why the nightly
+ * lane writes real timings back into the durations file.
+ */
+export function suiteWeights({ repoRoot = REPO_ROOT, durations = null } = {}) {
+  const recorded =
+    durations ??
+    (() => {
+      const raw = readIfPresent(repoRoot, DURATIONS_FILE);
+      if (raw === null) return null;
+      try {
+        return JSON.parse(raw);
+      } catch {
+        return null;
+      }
+    })();
+  const weights = new Map();
+  for (const suite of SUITE_NAMES) {
+    const measured = Number(recorded?.suites?.[suite]?.seconds);
+    if (Number.isFinite(measured) && measured > 0) {
+      weights.set(suite, { weight: measured, measured: true });
+      continue;
+    }
+    let size = 0;
+    for (const testFile of suiteTestFiles(suite, repoRoot)) {
+      size += readIfPresent(repoRoot, testFile)?.length ?? 0;
+    }
+    weights.set(suite, { weight: Math.max(1, size), measured: false });
+  }
+  return weights;
+}
+
+/**
+ * Spread a fixed job budget across the selected suites using highest averages,
+ * so the slowest suite gets the most shards and total jobs never exceed the cap.
+ */
+export function allocateShardBudget(suites, maxJobs, weights) {
+  if (suites.length === 0) return [];
+  if (!Number.isSafeInteger(maxJobs) || maxJobs <= 0) {
+    throw new Error("Tooling smoke job budget must be a positive integer.");
+  }
+  const ordered = [...suites];
+  const counts = new Map(ordered.map((suite) => [suite, 1]));
+  // With more suites than jobs, every suite still runs once. Correctness beats
+  // the cap: dropping a suite would silently lose coverage.
+  let remaining = Math.max(0, maxJobs - ordered.length);
+  while (remaining > 0) {
+    let best = null;
+    let bestValue = -Infinity;
+    for (const suite of ordered) {
+      const weight = weights.get(suite)?.weight ?? 1;
+      const value = weight / (counts.get(suite) + 1);
+      if (value > bestValue) {
+        bestValue = value;
+        best = suite;
+      }
+    }
+    counts.set(best, counts.get(best) + 1);
+    remaining -= 1;
+  }
+  return ordered.map((suite) => ({ suite, shardCount: counts.get(suite) }));
+}
+
+/**
+ * The full GitHub Actions matrix for a changed path set. An empty `include`
+ * means no tooling suite is reachable, which the workflow reports as a quick
+ * not-applicable success instead of running anything.
+ */
+export function buildToolingSmokeMatrix({
+  changedFiles,
+  maxJobs = DEFAULT_MAX_JOBS,
+  repoRoot = REPO_ROOT,
+  durations = null,
+} = {}) {
+  const selection = selectApplicableSuites(changedFiles, { repoRoot });
+  const weights = suiteWeights({ repoRoot, durations });
+  const allocation = allocateShardBudget(selection.suites, maxJobs, weights);
+  const include = allocation.flatMap(({ suite, shardCount }) =>
+    Array.from({ length: shardCount }, (_, index) => ({
+      suite,
+      shard: index + 1,
+      shardCount,
+      name: `${suite} ${(index + 1).toLocaleString()}/${shardCount.toLocaleString()}`,
+    })),
+  );
+  return Object.freeze({
+    schemaVersion: 1,
+    applicable: include.length > 0,
+    include,
+    jobCount: include.length,
+    maxJobs,
+    reason: selection.reason,
+    suites: selection.suites,
+    weightsAreMeasured:
+      selection.suites.length > 0 &&
+      selection.suites.every((suite) => weights.get(suite)?.measured === true),
+  });
+}

--- a/scripts/lib/tooling-smoke-suites.mjs
+++ b/scripts/lib/tooling-smoke-suites.mjs
@@ -1,0 +1,97 @@
+import { readdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const LIB_DIRECTORY = path.dirname(fileURLToPath(import.meta.url));
+export const REPO_ROOT = path.resolve(LIB_DIRECTORY, "..", "..");
+
+// The three control-plane suites are large enough to shard by test name rather
+// than by file. Everything else in scripts/ shards by file under "general".
+export const SHARDED_TEST_FILES = Object.freeze({
+  "automation-control": "scripts/automation-control.test.mjs",
+  "kernel-guard-cutover": "scripts/automation-kernel-guard-cutover.test.mjs",
+  "outcome-ledger-repair": "scripts/outcome-ledger-repair.test.mjs",
+});
+
+export const GENERAL_SUITE = "general";
+
+// These assert real launchd, Keychain, and signed-broker behavior. They skip
+// themselves on Linux, so running them only on ubuntu means the assertions
+// never execute. The macOS lane is where they actually prove anything.
+export const NATIVE_ACCEPTANCE_TEST_FILES = Object.freeze([
+  "scripts/automation-actor-native.test.mjs",
+  "scripts/release-tag-publisher-native.test.mjs",
+  "scripts/trusted-publisher-host.test.mjs",
+  "scripts/worktree-publish.test.mjs",
+]);
+
+// A narrower set: these three gate every test behind one module-level
+// `process.platform === "darwin"` check, so on Linux they contribute nothing but
+// runtime. release-tag-publisher-native has been observed blocking indefinitely
+// at 0% CPU, which is worse than useless in a blocking lane. They run on macOS
+// only.
+//
+// worktree-publish.test.mjs is deliberately NOT here. It gates 7 of its 35 tests
+// per-test, so the other 28 are real Linux coverage. It stays in the general
+// suite and also runs on the macOS lane, where its darwin cases execute.
+export const DARWIN_ONLY_TEST_FILES = Object.freeze([
+  "scripts/automation-actor-native.test.mjs",
+  "scripts/release-tag-publisher-native.test.mjs",
+  "scripts/trusted-publisher-host.test.mjs",
+]);
+
+export const SUITE_NAMES = Object.freeze([
+  GENERAL_SUITE,
+  ...Object.keys(SHARDED_TEST_FILES),
+]);
+
+export function isKnownSuite(suite) {
+  return suite === GENERAL_SUITE || Object.hasOwn(SHARDED_TEST_FILES, suite);
+}
+
+export function generalTestFiles(repoRoot = REPO_ROOT) {
+  const specialFiles = new Set([
+    ...Object.values(SHARDED_TEST_FILES),
+    ...DARWIN_ONLY_TEST_FILES,
+  ]);
+  const visit = (relativeDirectory) =>
+    readdirSync(path.join(repoRoot, relativeDirectory), {
+      withFileTypes: true,
+    }).flatMap((entry) => {
+      const relativePath = path.posix.join(relativeDirectory, entry.name);
+      if (entry.isDirectory()) return visit(relativePath);
+      if (
+        !entry.isFile() ||
+        !entry.name.endsWith(".test.mjs") ||
+        specialFiles.has(relativePath)
+      ) {
+        return [];
+      }
+      return [relativePath];
+    });
+  return visit("scripts").sort();
+}
+
+export function shellFiles(repoRoot = REPO_ROOT) {
+  return ["scripts", path.join("scripts", "lib")]
+    .flatMap((relativeDirectory) =>
+      readdirSync(path.join(repoRoot, relativeDirectory), {
+        withFileTypes: true,
+      })
+        .filter((entry) => entry.isFile() && entry.name.endsWith(".sh"))
+        .map((entry) =>
+          path.posix.join(
+            relativeDirectory.split(path.sep).join("/"),
+            entry.name,
+          ),
+        ),
+    )
+    .sort();
+}
+
+export function suiteTestFiles(suite, repoRoot = REPO_ROOT) {
+  if (suite === GENERAL_SUITE) return generalTestFiles(repoRoot);
+  const testFile = SHARDED_TEST_FILES[suite];
+  if (!testFile) throw new Error(`Unknown tooling smoke suite: ${suite}`);
+  return [testFile];
+}

--- a/scripts/measure-tooling-smoke.mjs
+++ b/scripts/measure-tooling-smoke.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+// Record how long each tooling smoke suite actually takes, and how often it
+// fails on a rerun. The planner shards by these numbers, so a suite that gets
+// slower automatically gets more shards without anyone editing a workflow.
+//
+// The nightly exhaustive lane runs this and commits the result. Source size is
+// only a fallback for a suite that has never been measured.
+
+import { spawnSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+import { DURATIONS_FILE } from "./lib/tooling-smoke-plan.mjs";
+import {
+  REPO_ROOT,
+  SUITE_NAMES,
+  suiteTestFiles,
+} from "./lib/tooling-smoke-suites.mjs";
+
+function parseArgs(argv) {
+  const parsed = { repeat: 1, suites: [...SUITE_NAMES], write: false };
+  for (const argument of argv) {
+    if (argument === "--write") parsed.write = true;
+    else if (argument.startsWith("--repeat=")) {
+      parsed.repeat = Number(argument.slice("--repeat=".length));
+    } else if (argument.startsWith("--suites=")) {
+      parsed.suites = argument
+        .slice("--suites=".length)
+        .split(",")
+        .map((value) => value.trim())
+        .filter(Boolean);
+    } else {
+      throw new Error(`Unknown measure-tooling-smoke argument: ${argument}`);
+    }
+  }
+  if (!Number.isSafeInteger(parsed.repeat) || parsed.repeat <= 0) {
+    throw new Error("--repeat must be a positive integer.");
+  }
+  for (const suite of parsed.suites) {
+    if (!SUITE_NAMES.includes(suite)) {
+      throw new Error(`Unknown tooling smoke suite: ${suite}`);
+    }
+  }
+  return parsed;
+}
+
+function runSuiteOnce(suite) {
+  const files = suiteTestFiles(suite, REPO_ROOT);
+  const startedAt = process.hrtime.bigint();
+  const result = spawnSync(process.execPath, ["--test", ...files], {
+    cwd: REPO_ROOT,
+    env: process.env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const seconds = Number(process.hrtime.bigint() - startedAt) / 1e9;
+  return { seconds, ok: result.status === 0 };
+}
+
+export function measureSuites(suites, repeat) {
+  const measured = {};
+  for (const suite of suites) {
+    const runs = [];
+    for (let attempt = 0; attempt < repeat; attempt += 1) {
+      const run = runSuiteOnce(suite);
+      runs.push(run);
+      process.stderr.write(
+        `  ${suite} run ${(attempt + 1).toLocaleString()}/${repeat.toLocaleString()}: ${run.seconds.toFixed(1)}s ${run.ok ? "pass" : "FAIL"}\n`,
+      );
+    }
+    const failures = runs.filter(({ ok }) => !ok).length;
+    measured[suite] = {
+      seconds: Number(
+        (runs.reduce((total, { seconds }) => total + seconds, 0) / runs.length).toFixed(1),
+      ),
+      runs: runs.length,
+      failures,
+      // A suite that passes sometimes and fails sometimes across identical runs
+      // is flaky by definition, and the report says so rather than hiding it.
+      flaky: failures > 0 && failures < runs.length,
+    };
+  }
+  return measured;
+}
+
+function main(argv) {
+  const { repeat, suites, write } = parseArgs(argv);
+  process.stderr.write(
+    `Measuring ${suites.length.toLocaleString()} tooling smoke suites, ${repeat.toLocaleString()} run(s) each.\n`,
+  );
+  const measured = measureSuites(suites, repeat);
+
+  const absolute = path.join(REPO_ROOT, DURATIONS_FILE);
+  let existing = { schemaVersion: 1, suites: {} };
+  try {
+    existing = JSON.parse(readFileSync(absolute, "utf8"));
+  } catch {
+    // First run writes the file.
+  }
+  const merged = {
+    schemaVersion: 1,
+    suites: { ...existing.suites, ...measured },
+  };
+  const serialized = `${JSON.stringify(merged, null, 2)}\n`;
+  if (write) {
+    writeFileSync(absolute, serialized);
+    process.stderr.write(`Wrote ${DURATIONS_FILE}.\n`);
+  } else {
+    process.stdout.write(serialized);
+  }
+
+  const flaky = Object.entries(merged.suites).filter(([, v]) => v.flaky);
+  if (flaky.length > 0) {
+    process.stderr.write(
+      `Flaky suites: ${flaky.map(([name]) => name).join(", ")}\n`,
+    );
+  }
+}
+
+if (path.resolve(process.argv[1]) === path.resolve(new URL(import.meta.url).pathname)) {
+  try {
+    main(process.argv.slice(2));
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/plan-tooling-smoke.mjs
+++ b/scripts/plan-tooling-smoke.mjs
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+// Decide which tooling smoke suites a change can actually affect, and spread a
+// fixed job budget across them. Emits a GitHub Actions matrix.
+//
+// Ordinary pull requests get changed-path scoping. A push to dev gets the full
+// lane, because dev carries the one full integration proof that release
+// admission later inherits.
+
+import { spawnSync } from "node:child_process";
+import { appendFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  DEFAULT_MAX_JOBS,
+  buildToolingSmokeMatrix,
+  selectNativeAcceptance,
+} from "./lib/tooling-smoke-plan.mjs";
+import { REPO_ROOT, SUITE_NAMES } from "./lib/tooling-smoke-suites.mjs";
+
+function usage() {
+  return `Usage:
+  node scripts/plan-tooling-smoke.mjs [--base-ref <ref>] [--changed-files <file>...]
+                                      [--all] [--max-jobs <n>] [--github-output]
+
+  --base-ref       Diff against this ref to derive the changed path set.
+  --changed-files  Use this explicit path set instead of git.
+  --all            Force every suite, used for pushes to dev.
+  --max-jobs       Total job budget for the lane (default ${DEFAULT_MAX_JOBS}).
+  --github-output  Append matrix and applicable outputs to $GITHUB_OUTPUT.`;
+}
+
+export function parseArgs(argv) {
+  let baseRef = "";
+  let changedFiles = [];
+  let all = false;
+  let maxJobs = DEFAULT_MAX_JOBS;
+  let githubOutput = false;
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--all") all = true;
+    else if (argument === "--github-output") githubOutput = true;
+    else if (argument === "--base-ref") baseRef = argv[++index] ?? "";
+    else if (argument === "--max-jobs") maxJobs = Number(argv[++index]);
+    else if (argument === "--changed-files") {
+      changedFiles = argv.slice(index + 1);
+      index = argv.length;
+    } else if (argument === "--help" || argument === "-h") {
+      process.stdout.write(`${usage()}\n`);
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${argument}\n\n${usage()}`);
+    }
+  }
+  if (!Number.isSafeInteger(maxJobs) || maxJobs <= 0) {
+    throw new Error("--max-jobs must be a positive integer.");
+  }
+  return { all, baseRef, changedFiles, githubOutput, maxJobs };
+}
+
+function gitChangedFiles(baseRef) {
+  const result = spawnSync(
+    "git",
+    ["diff", "--name-only", "--diff-filter=ACDMRTUXB", `${baseRef}...HEAD`],
+    { cwd: REPO_ROOT, encoding: "utf8" },
+  );
+  if (result.status !== 0) {
+    throw new Error(
+      `Could not diff against ${baseRef}: ${(result.stderr || "").trim()}`,
+    );
+  }
+  return result.stdout.split("\n").map((line) => line.trim()).filter(Boolean);
+}
+
+export function resolvePlan({ all, baseRef, changedFiles, maxJobs }) {
+  // An empty changed set means "everything is in play" to the planner.
+  const files = all
+    ? []
+    : changedFiles.length > 0
+      ? changedFiles
+      : baseRef
+        ? gitChangedFiles(baseRef)
+        : [];
+  return {
+    ...buildToolingSmokeMatrix({ changedFiles: files, maxJobs }),
+    files,
+    native: selectNativeAcceptance(files),
+  };
+}
+
+function main(argv) {
+  const options = parseArgs(argv);
+  const plan = resolvePlan(options);
+
+  process.stderr.write(
+    `Tooling smoke plan: ${plan.jobCount.toLocaleString()} job(s) across ${plan.suites.length.toLocaleString()} of ${SUITE_NAMES.length.toLocaleString()} suites.\n`,
+  );
+  process.stderr.write(`  reason: ${plan.reason}\n`);
+  process.stderr.write(
+    `  shard weights: ${plan.weightsAreMeasured ? "measured runtimes" : "source size fallback"}\n`,
+  );
+  for (const suite of plan.suites) {
+    const shards = plan.include.filter((entry) => entry.suite === suite).length;
+    process.stderr.write(`  ${suite}: ${shards.toLocaleString()} shard(s)\n`);
+  }
+  if (!plan.applicable) {
+    process.stderr.write(
+      "  no suite is reachable, the lane reports not applicable\n",
+    );
+  }
+  process.stderr.write(
+    `  native acceptance (macOS): ${plan.native.required ? "required" : "not applicable"}\n`,
+  );
+
+  const matrix = JSON.stringify({ include: plan.include });
+  if (options.githubOutput && process.env.GITHUB_OUTPUT) {
+    appendFileSync(
+      process.env.GITHUB_OUTPUT,
+      `matrix=${matrix}\napplicable=${plan.applicable}\njob-count=${plan.jobCount}\nnative=${plan.native.required}\nreason=${plan.reason}\n`,
+    );
+  }
+  process.stdout.write(`${matrix}\n`);
+}
+
+if (
+  typeof process.argv[1] === "string" &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  try {
+    main(process.argv.slice(2));
+  } catch (error) {
+    process.stderr.write(
+      `${error instanceof Error ? error.message : String(error)}\n`,
+    );
+    process.exitCode = 1;
+  }
+}

--- a/scripts/plan-tooling-smoke.mjs
+++ b/scripts/plan-tooling-smoke.mjs
@@ -97,11 +97,34 @@ function main(argv) {
   );
   process.stderr.write(`  reason: ${plan.reason}\n`);
   process.stderr.write(
-    `  shard weights: ${plan.weightsAreMeasured ? "measured runtimes" : "source size fallback"}\n`,
+    // Three cases, not two. Saying "source size fallback" when the weights are
+    // real recorded runtimes with one capped entry describes the wrong problem.
+    `  shard weights: ${
+      plan.weightsAreMeasured
+        ? "measured runtimes"
+        : plan.projection.some((entry) => entry.predictedFrom === "capped")
+          ? "recorded runtimes, at least one a timeout floor rather than a measurement"
+          : "source size fallback"
+    }\n`,
   );
-  for (const suite of plan.suites) {
-    const shards = plan.include.filter((entry) => entry.suite === suite).length;
-    process.stderr.write(`  ${suite}: ${shards.toLocaleString()} shard(s)\n`);
+  for (const entry of plan.projection) {
+    const predicted =
+      entry.perShardSeconds === null
+        ? "runtime unknown, weighted by source size"
+        : `${entry.atLeast ? "at least " : ""}${Math.round(entry.perShardSeconds / 60).toLocaleString()} min per shard`;
+    process.stderr.write(
+      `  ${entry.suite}: ${entry.shardCount.toLocaleString()} shard(s), ${predicted}\n`,
+    );
+  }
+  if (plan.overrunSuites.length > 0) {
+    // Say this before the jobs start. The failure it describes previously took
+    // ninety minutes to surface and then reported as a test failure rather than
+    // as a scheduling problem.
+    process.stderr.write(
+      `\n  WARNING: ${plan.overrunSuites.join(", ")} is not expected to finish inside the ${Math.round(plan.shardTimeoutSeconds / 60).toLocaleString()} minute shard timeout.\n` +
+        "  A shard killed by the timeout reports as cancelled, which the lane surfaces as a failure.\n" +
+        "  Tracked as issue #1147. Raising the timeout is not the fix.\n",
+    );
   }
   if (!plan.applicable) {
     process.stderr.write(

--- a/scripts/report-tooling-smoke-drift.mjs
+++ b/scripts/report-tooling-smoke-drift.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+// Compare a fresh measurement against the committed durations and fail when the
+// shard balance has gone stale or a suite proved flaky.
+//
+// The planner shards by committed durations. When real runtimes drift far from
+// them, shards stop being balanced and the slowest shard silently sets the lane
+// duration. This turns that into a visible, tracked failure.
+
+import { readFileSync, appendFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { DURATIONS_FILE } from "./lib/tooling-smoke-plan.mjs";
+import { REPO_ROOT } from "./lib/tooling-smoke-suites.mjs";
+
+// A suite has to be meaningfully wrong before it counts as drift. Runner noise
+// alone should never open a debt issue.
+export const DRIFT_RATIO = 2;
+export const DRIFT_FLOOR_SECONDS = 20;
+
+export function compareDurations(committed, measured) {
+  const rows = [];
+  for (const [suite, value] of Object.entries(measured.suites ?? {})) {
+    const before = Number(committed.suites?.[suite]?.seconds);
+    const after = Number(value.seconds);
+    const known = Number.isFinite(before) && before > 0;
+    const ratio = known && after > 0 ? after / before : null;
+    const drifted =
+      known &&
+      Math.abs(after - before) >= DRIFT_FLOOR_SECONDS &&
+      (ratio >= DRIFT_RATIO || ratio <= 1 / DRIFT_RATIO);
+    rows.push({
+      suite,
+      before: known ? before : null,
+      after,
+      ratio,
+      drifted,
+      flaky: value.flaky === true,
+      failures: value.failures ?? 0,
+      runs: value.runs ?? 0,
+    });
+  }
+  return rows.sort((left, right) => right.after - left.after);
+}
+
+function formatRow(row) {
+  const before = row.before === null ? "unmeasured" : `${row.before.toFixed(1)}s`;
+  const ratio = row.ratio === null ? "n/a" : `${row.ratio.toFixed(2)}x`;
+  const flags = [row.drifted ? "DRIFT" : "", row.flaky ? "FLAKY" : ""]
+    .filter(Boolean)
+    .join(" ");
+  return `| ${row.suite} | ${before} | ${row.after.toFixed(1)}s | ${ratio} | ${row.failures}/${row.runs} | ${flags || "ok"} |`;
+}
+
+function main(argv) {
+  const measuredPath = argv[0];
+  if (!measuredPath) throw new Error("Usage: report-tooling-smoke-drift.mjs <measured.json>");
+  const measured = JSON.parse(readFileSync(measuredPath, "utf8"));
+  let committed = { schemaVersion: 1, suites: {} };
+  try {
+    committed = JSON.parse(
+      readFileSync(path.join(REPO_ROOT, DURATIONS_FILE), "utf8"),
+    );
+  } catch {
+    process.stderr.write(`${DURATIONS_FILE} is missing, treating every suite as unmeasured.\n`);
+  }
+
+  const rows = compareDurations(committed, measured);
+  const lines = [
+    "### Tooling smoke timings",
+    "",
+    "| suite | committed | measured | ratio | failures | status |",
+    "| --- | --- | --- | --- | --- | --- |",
+    ...rows.map(formatRow),
+    "",
+    `Refresh with \`node scripts/measure-tooling-smoke.mjs --write\` when drift is real.`,
+  ];
+  const report = `${lines.join("\n")}\n`;
+  process.stdout.write(report);
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    appendFileSync(process.env.GITHUB_STEP_SUMMARY, report);
+  }
+
+  const drifted = rows.filter(({ drifted: d }) => d);
+  const flaky = rows.filter(({ flaky: f }) => f);
+  if (flaky.length > 0) {
+    process.stderr.write(`Flaky suites: ${flaky.map((r) => r.suite).join(", ")}\n`);
+  }
+  if (drifted.length > 0) {
+    process.stderr.write(`Drifted suites: ${drifted.map((r) => r.suite).join(", ")}\n`);
+  }
+  if (flaky.length > 0 || drifted.length > 0) process.exitCode = 1;
+}
+
+if (
+  typeof process.argv[1] === "string" &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  try {
+    main(process.argv.slice(2));
+  } catch (error) {
+    process.stderr.write(
+      `${error instanceof Error ? error.message : String(error)}\n`,
+    );
+    process.exitCode = 1;
+  }
+}

--- a/scripts/run-native-acceptance.mjs
+++ b/scripts/run-native-acceptance.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+// Run the native acceptance tests and refuse to report success on a platform
+// where they cannot actually assert anything.
+//
+// These files guard launchd actors, Keychain-backed publisher trust, and the
+// signed broker handoff. On Linux they skip themselves, so a green Ubuntu run
+// proves nothing about them. This runner makes that explicit instead of letting
+// a vacuous pass look like coverage.
+
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  NATIVE_ACCEPTANCE_TEST_FILES,
+  REPO_ROOT,
+} from "./lib/tooling-smoke-suites.mjs";
+
+// Native acceptance touches launchd, Keychain and the signed broker, all of
+// which can block on a machine that is not provisioned for them. Cap each test
+// so a block fails with a name instead of eating the job.
+//
+// Sized from measurement, not preference. The publish tests spawn real git and
+// gh subprocesses: roughly 65s each locally, and 175-250s on a hosted macOS
+// runner. An earlier 120s cap killed healthy tests and buried the one genuine
+// macOS failure underneath a wall of false timeouts. That those tests are this
+// slow at all is separate debt, tracked on the native acceptance issue.
+export const NATIVE_TEST_TIMEOUT_MS = 420_000;
+
+export function nativeAcceptanceIsMeaningful(platform = process.platform) {
+  return platform === "darwin";
+}
+
+function main(argv) {
+  const allowNonDarwin = argv.includes("--allow-non-darwin");
+  if (!nativeAcceptanceIsMeaningful() && !allowNonDarwin) {
+    process.stderr.write(
+      `Native acceptance requires macOS. This runner is ${process.platform}, where every assertion skips itself.\n` +
+        "Run this lane on a macOS runner, or pass --allow-non-darwin to acknowledge a vacuous run.\n",
+    );
+    process.exitCode = 1;
+    return;
+  }
+  process.stderr.write(
+    `Running ${NATIVE_ACCEPTANCE_TEST_FILES.length.toLocaleString()} native acceptance files on ${process.platform}.\n`,
+  );
+  // Without this the run has no per-test timeout, so one stuck test consumes the
+  // whole job budget and reports only "cancelled" with nothing to act on. These
+  // files had never executed on a real macOS runner before this lane existed;
+  // the first run hung for the full 30 minute job timeout. A named timeout
+  // failure is the difference between a diagnosable defect and a mystery.
+  const result = spawnSync(
+    process.execPath,
+    [
+      "--test",
+      `--test-timeout=${NATIVE_TEST_TIMEOUT_MS}`,
+      ...NATIVE_ACCEPTANCE_TEST_FILES,
+    ],
+    { cwd: REPO_ROOT, env: process.env, stdio: "inherit" },
+  );
+  if (result.error) throw result.error;
+  if (result.signal !== null) {
+    throw new Error(`Native acceptance stopped on signal ${result.signal}.`);
+  }
+  process.exitCode = result.status ?? 1;
+}
+
+if (
+  typeof process.argv[1] === "string" &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  try {
+    main(process.argv.slice(2));
+  } catch (error) {
+    process.stderr.write(
+      `${error instanceof Error ? error.message : String(error)}\n`,
+    );
+    process.exitCode = 1;
+  }
+}

--- a/scripts/run-tooling-smoke-shard.mjs
+++ b/scripts/run-tooling-smoke-shard.mjs
@@ -2,18 +2,17 @@
 
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { readFileSync, readdirSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import ts from "typescript";
 
-const SCRIPT_DIRECTORY = path.dirname(fileURLToPath(import.meta.url));
-const REPO_ROOT = path.dirname(SCRIPT_DIRECTORY);
-const SHARDED_TEST_FILES = Object.freeze({
-  "automation-control": "scripts/automation-control.test.mjs",
-  "kernel-guard-cutover": "scripts/automation-kernel-guard-cutover.test.mjs",
-  "outcome-ledger-repair": "scripts/outcome-ledger-repair.test.mjs",
-});
+import {
+  REPO_ROOT,
+  SHARDED_TEST_FILES,
+  generalTestFiles,
+  shellFiles,
+} from "./lib/tooling-smoke-suites.mjs";
 
 function fail(message) {
   throw new Error(message);
@@ -330,43 +329,6 @@ export function partitionWeightedTestUnits(units, shardCount) {
   return shards.map(({ units: assignedUnits }) => Object.freeze(assignedUnits));
 }
 
-function generalTestFiles(repoRoot) {
-  const specialFiles = new Set(Object.values(SHARDED_TEST_FILES));
-  const visit = (relativeDirectory) =>
-    readdirSync(path.join(repoRoot, relativeDirectory), {
-      withFileTypes: true,
-    }).flatMap((entry) => {
-      const relativePath = path.posix.join(relativeDirectory, entry.name);
-      if (entry.isDirectory()) return visit(relativePath);
-      if (
-        !entry.isFile() ||
-        !entry.name.endsWith(".test.mjs") ||
-        specialFiles.has(relativePath)
-      ) {
-        return [];
-      }
-      return [relativePath];
-    });
-  return visit("scripts").sort();
-}
-
-function shellFiles(repoRoot) {
-  return ["scripts", path.join("scripts", "lib")]
-    .flatMap((relativeDirectory) =>
-      readdirSync(path.join(repoRoot, relativeDirectory), {
-        withFileTypes: true,
-      })
-        .filter((entry) => entry.isFile() && entry.name.endsWith(".sh"))
-        .map((entry) =>
-          path.posix.join(
-            relativeDirectory.split(path.sep).join("/"),
-            entry.name,
-          ),
-        ),
-    )
-    .sort();
-}
-
 export function buildToolingSmokeShardPlan(
   { suite, shardIndex, shardCount },
   { repoRoot = REPO_ROOT } = {},
@@ -427,11 +389,16 @@ function runChecked(command, args, repoRoot) {
   if (result.status !== 0) process.exit(result.status ?? 1);
 }
 
+// node --test defaults to no per-test timeout, so one blocked test pins a shard
+// until the job-level timeout kills the whole run with no useful signal. Any
+// tooling test slower than this in a blocking lane is a defect, not a long test.
+export const SHARD_TEST_TIMEOUT_MS = 300_000;
+
 export function runToolingSmokeShard(plan, { repoRoot = REPO_ROOT } = {}) {
   if (plan.shellFiles.length > 0) {
     runChecked("bash", ["-n", ...plan.shellFiles], repoRoot);
   }
-  const args = ["--test"];
+  const args = ["--test", `--test-timeout=${SHARD_TEST_TIMEOUT_MS}`];
   if (plan.testNamePattern !== null) {
     args.push(`--test-name-pattern=${plan.testNamePattern}`);
   }

--- a/scripts/run-tooling-smoke-shard.test.mjs
+++ b/scripts/run-tooling-smoke-shard.test.mjs
@@ -12,6 +12,10 @@ import path from "node:path";
 import test from "node:test";
 
 import {
+  DARWIN_ONLY_TEST_FILES,
+  NATIVE_ACCEPTANCE_TEST_FILES,
+} from "./lib/tooling-smoke-suites.mjs";
+import {
   buildToolingSmokeShardPlan,
   exactTestNamePattern,
   exactTestUnitPattern,
@@ -178,10 +182,40 @@ test("repository plans are nonempty and cover each named suite", () => {
         "scripts/automation-kernel-guard-cutover.test.mjs",
         "scripts/outcome-ledger-repair.test.mjs",
       ]);
+      // The darwin-only files moved to the macOS lane. They gate every test
+      // behind one module-level platform check, so running them on Linux only
+      // ever skipped them.
+      const routedElsewhere = new Set([
+        ...specialFiles,
+        ...DARWIN_ONLY_TEST_FILES,
+      ]);
       assert.deepEqual(
         files,
-        repositoryTestFiles().filter((filePath) => !specialFiles.has(filePath)),
+        repositoryTestFiles().filter(
+          (filePath) => !routedElsewhere.has(filePath),
+        ),
       );
+
+      // Nothing may silently fall out of the lane. Every repository test file
+      // must be claimed by a sharded suite, the general suite, or the macOS
+      // native lane.
+      const covered = new Set([
+        ...files,
+        ...specialFiles,
+        ...NATIVE_ACCEPTANCE_TEST_FILES,
+      ]);
+      const orphaned = repositoryTestFiles().filter(
+        (filePath) => !covered.has(filePath),
+      );
+      assert.deepEqual(orphaned, [], "every test file must run somewhere");
+
+      // Each darwin-only file must actually be claimed by the native lane.
+      for (const darwinOnly of DARWIN_ONLY_TEST_FILES) {
+        assert.ok(
+          NATIVE_ACCEPTANCE_TEST_FILES.includes(darwinOnly),
+          `${darwinOnly} left the general suite and must run on the macOS lane`,
+        );
+      }
     } else {
       const names = plans.flatMap((plan) => plan.testNames);
       assert.equal(names.length, new Set(names).size);
@@ -200,19 +234,39 @@ test("validation workflow preserves the complete tooling smoke gate", () => {
     path.join(process.cwd(), ".github", "workflows", "ci.yml"),
     "utf8",
   );
-  for (const suite of [
-    "general",
-    "automation-control",
-    "kernel-guard-cutover",
-    "outcome-ledger-repair",
-  ]) {
-    assert.match(workflow, new RegExp(`^          - ${suite}$`, "m"));
-  }
-  assert.match(workflow, /^        shard: \[1, 2, 3, 4, 5, 6, 7, 8\]$/m);
+  // The matrix is computed, never hardcoded. A literal suite list here would
+  // silently reintroduce the fixed 32 job lane this planner replaced.
   assert.match(
     workflow,
-    /^          node scripts\/run-tooling-smoke-shard\.mjs$/m,
+    /matrix: \$\{\{ fromJSON\(needs\.tooling-smoke-plan\.outputs\.matrix\) \}\}/,
+  );
+  assert.match(workflow, /node scripts\/plan-tooling-smoke\.mjs/);
+  assert.match(workflow, /--shard-count=\$\{\{ matrix\.shardCount \}\}/);
+
+  // A push to dev must still run every suite. That run is the full integration
+  // proof, so scoping it by changed paths would break release admission.
+  assert.match(workflow, /plan-tooling-smoke\.mjs --all --github-output/);
+
+  // The gate observes the planner, the shards, and the native lane together.
+  assert.match(
+    workflow,
+    /needs: \[tooling-smoke-plan, tooling-smoke-shards, native-acceptance\]/,
   );
   assert.match(workflow, /^  tooling-smoke:\n    name: Tooling smoke$/m);
-  assert.match(workflow, /^    needs: tooling-smoke-shards$/m);
+
+  // Fail-closed wiring: a skipped shard job is acceptable only when the planner
+  // said the lane was not applicable, and a failed planner always fails.
+  assert.match(workflow, /if \[ "\$PLAN_RESULT" != "success" \]/);
+  assert.match(workflow, /if \[ "\$SHARD_RESULT" != "skipped" \]/);
+  // The macOS lane is observe-only until the first-run hang is diagnosed, so it
+  // must warn rather than exit. It must still be wired up and still fail closed
+  // when it runs unexpectedly, which the next assertion covers.
+  assert.match(workflow, /observe-only, not gating yet/);
+  assert.match(
+    workflow,
+    /Native acceptance was not required but reported \$NATIVE_RESULT/,
+  );
+
+  // Superseded dev runs cancel.
+  assert.match(workflow, /^  cancel-in-progress: true$/m);
 });

--- a/scripts/tooling-smoke-durations.json
+++ b/scripts/tooling-smoke-durations.json
@@ -28,7 +28,8 @@
       "runs": 1,
       "failures": 0,
       "flaky": false,
-      "source": "ci-shard hit the 90m job cap at 5415s, so this is a LOWER BOUND"
+      "capped": true,
+      "source": "ci-shard killed by the 90m job cap at 5415s; a floor, not a measurement (issue #1147)"
     }
   }
 }

--- a/scripts/tooling-smoke-durations.json
+++ b/scripts/tooling-smoke-durations.json
@@ -1,0 +1,34 @@
+{
+  "schemaVersion": 1,
+  "note": "Measured on ubuntu-latest CI, run 30140909175 / 30143xxxxx (2026-07-25). Seconds are per-suite totals summed across that run's shards. Source size is a poor runtime proxy: within the general suite the byte-weighted split produced shards of 41s and 4,909s, a 120x spread. Refresh with: node scripts/measure-tooling-smoke.mjs --write, or from CI shard durations.",
+  "suites": {
+    "general": {
+      "seconds": 6679,
+      "runs": 1,
+      "failures": 0,
+      "flaky": false,
+      "source": "ci-shards 41+406+1323+4909"
+    },
+    "automation-control": {
+      "seconds": 8689,
+      "runs": 1,
+      "failures": 0,
+      "flaky": false,
+      "source": "ci-shards 3985+4704"
+    },
+    "kernel-guard-cutover": {
+      "seconds": 3648,
+      "runs": 1,
+      "failures": 0,
+      "flaky": false,
+      "source": "ci-shard 3648 (single shard, completed)"
+    },
+    "outcome-ledger-repair": {
+      "seconds": 5415,
+      "runs": 1,
+      "failures": 0,
+      "flaky": false,
+      "source": "ci-shard hit the 90m job cap at 5415s, so this is a LOWER BOUND"
+    }
+  }
+}

--- a/scripts/tooling-smoke-plan.test.mjs
+++ b/scripts/tooling-smoke-plan.test.mjs
@@ -1,0 +1,144 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  DEFAULT_SHARD_TIMEOUT_SECONDS,
+  buildToolingSmokeMatrix,
+  projectShardRuntime,
+  suiteWeights,
+} from "./lib/tooling-smoke-plan.mjs";
+
+// The planner decides how every tooling smoke job is allocated and had no
+// coverage at all. What follows pins the specific failure that motivated it:
+// a shard killed by the job timeout was recorded as if it were a measurement,
+// so the planner under-sharded, so the shards were killed again, so the
+// recorded number could never grow. See issue #1147.
+
+const CAPPED = {
+  suites: {
+    "outcome-ledger-repair": {
+      seconds: 5415,
+      runs: 1,
+      capped: true,
+      source: "killed by the 90m cap",
+    },
+  },
+};
+
+const COMPLETED = {
+  suites: {
+    "outcome-ledger-repair": { seconds: 5415, runs: 1, source: "completed" },
+  },
+};
+
+test("a capped duration is not treated as a measurement", () => {
+  const capped = suiteWeights({ durations: CAPPED }).get("outcome-ledger-repair");
+  assert.equal(capped.capped, true);
+  assert.equal(capped.measured, false);
+
+  // Same seconds, no cap flag: this one really was measured.
+  const completed = suiteWeights({ durations: COMPLETED }).get(
+    "outcome-ledger-repair",
+  );
+  assert.equal(completed.capped, false);
+  assert.equal(completed.measured, true);
+
+  // The weight itself is unchanged. A floor is still the best number available
+  // for relative ordering; what changes is the confidence attached to it.
+  assert.equal(capped.weight, completed.weight);
+});
+
+test("a capped suite never reports that it fits, even when the floor divides small", () => {
+  // The trap this guards: 5415 / 2 is 45 minutes, comfortably inside a 90
+  // minute timeout, so arithmetic on the floor says the plan is fine. It is
+  // not fine, because the real duration is unknown and already exceeded a
+  // timeout once. Both shards of this suite went on to burn the full 90.
+  const weights = suiteWeights({ durations: CAPPED });
+  const [projected] = projectShardRuntime(
+    [{ suite: "outcome-ledger-repair", shardCount: 2 }],
+    weights,
+    DEFAULT_SHARD_TIMEOUT_SECONDS,
+  );
+  assert.equal(projected.perShardSeconds, 5415 / 2);
+  assert.ok(projected.perShardSeconds < DEFAULT_SHARD_TIMEOUT_SECONDS);
+  assert.equal(projected.atLeast, true);
+  assert.equal(projected.fits, false);
+  assert.equal(projected.predictedFrom, "capped");
+});
+
+test("a measured suite that genuinely overruns is reported too", () => {
+  const weights = suiteWeights({
+    durations: { suites: { "outcome-ledger-repair": { seconds: 20_000 } } },
+  });
+  const [projected] = projectShardRuntime(
+    [{ suite: "outcome-ledger-repair", shardCount: 2 }],
+    weights,
+    DEFAULT_SHARD_TIMEOUT_SECONDS,
+  );
+  assert.equal(projected.fits, false);
+  assert.equal(projected.predictedFrom, "measured");
+  assert.equal(projected.atLeast, false);
+});
+
+test("a measured suite that fits is left alone", () => {
+  const weights = suiteWeights({
+    durations: { suites: { "outcome-ledger-repair": { seconds: 600 } } },
+  });
+  const [projected] = projectShardRuntime(
+    [{ suite: "outcome-ledger-repair", shardCount: 2 }],
+    weights,
+    DEFAULT_SHARD_TIMEOUT_SECONDS,
+  );
+  assert.equal(projected.fits, true);
+  assert.equal(projected.perShardSeconds, 300);
+});
+
+test("the source-size fallback predicts nothing rather than comparing bytes to seconds", () => {
+  // suiteWeights falls back to counting source bytes when no duration exists.
+  // Dividing bytes by shards and comparing the result to a timeout is a unit
+  // error that would still typecheck, and would either block every plan or
+  // clear every plan depending on file sizes. It must abstain instead.
+  const weights = suiteWeights({ durations: { suites: {} } });
+  const entry = weights.get("outcome-ledger-repair");
+  assert.equal(entry.measured, false);
+  assert.equal(entry.capped, false);
+
+  const [projected] = projectShardRuntime(
+    [{ suite: "outcome-ledger-repair", shardCount: 2 }],
+    weights,
+    DEFAULT_SHARD_TIMEOUT_SECONDS,
+  );
+  assert.equal(projected.perShardSeconds, null);
+  assert.equal(projected.fits, true);
+  assert.equal(projected.predictedFrom, "size");
+});
+
+test("the real plan reports the overrun this repository currently has", () => {
+  // Reads the checked-in durations file rather than a fixture, so if the
+  // outcome-ledger-repair cost is ever genuinely fixed and re-measured, this
+  // test fails and someone has to decide whether the guard is still needed.
+  const plan = buildToolingSmokeMatrix({ changedFiles: [] });
+  assert.ok(plan.projection.length > 0);
+  assert.deepEqual(plan.overrunSuites, ["outcome-ledger-repair"]);
+  assert.equal(plan.shardTimeoutSeconds, DEFAULT_SHARD_TIMEOUT_SECONDS);
+
+  // Every other suite has a real measurement and is expected to fit.
+  for (const entry of plan.projection) {
+    if (entry.suite === "outcome-ledger-repair") continue;
+    assert.equal(entry.fits, true, `${entry.suite} was expected to fit`);
+    assert.equal(entry.predictedFrom, "measured");
+  }
+});
+
+test("the plan still schedules work when a suite is predicted to overrun", () => {
+  // Deliberate. Refusing to schedule would turn one slow suite into a total
+  // lane outage, and the shards do produce real signal before they are killed.
+  // The guard exists to make the overrun visible and attributable, not to stop
+  // the lane. Changing this to a hard failure is a policy decision.
+  const plan = buildToolingSmokeMatrix({ changedFiles: [] });
+  assert.ok(plan.overrunSuites.includes("outcome-ledger-repair"));
+  assert.equal(plan.applicable, true);
+  assert.ok(
+    plan.include.some((entry) => entry.suite === "outcome-ledger-repair"),
+  );
+});

--- a/scripts/validate-worktree.mjs
+++ b/scripts/validate-worktree.mjs
@@ -637,13 +637,16 @@ export function buildValidationPlan(mode, changedFiles) {
         "--test",
         path.join("scripts", "release-notes-shared.test.mjs"),
       ]),
-      npmCommand("website production build", ["run", "build"], "website"),
+      // The website is a separate lane. It ships from `www` through the
+      // publish-website job against the reviewed marketing branch, so building
+      // it here proved nothing about the Desktop release and coupled two lanes
+      // that AGENTS.md keeps apart.
+      //
+      // The desktop production build is also gone: the release matrix runs the
+      // real signed build on all four platforms, so building the frontend once
+      // more on ubuntu made it five builds to gate four artifacts. A frontend
+      // break still fails, just in the build that actually ships.
       npmCommand("pwa production build", ["run", "build"], "packages/pwa"),
-      npmCommand(
-        "desktop production build",
-        ["run", "build"],
-        "packages/desktop",
-      ),
     ];
 
     const releaseArtifacts = collectReleaseArtifactsToValidate(

--- a/scripts/validate-worktree.test.mjs
+++ b/scripts/validate-worktree.test.mjs
@@ -438,7 +438,7 @@ test("dev plan runs desktop smoke, regression, perf, and visual lanes", () => {
   assert.ok(!labels.includes("desktop e2e full"));
 });
 
-test("production plan includes dev desktop gates and production builds", () => {
+test("production plan includes dev desktop gates without duplicating shipped builds", () => {
   const labels = describePlan(buildValidationPlan("production", []));
 
   assert.ok(labels.includes("desktop e2e smoke"));
@@ -446,7 +446,25 @@ test("production plan includes dev desktop gates and production builds", () => {
   assert.ok(labels.includes("desktop e2e perf"));
   assert.ok(labels.includes("desktop e2e visual"));
   assert.ok(!labels.includes("desktop e2e full"));
-  assert.ok(labels.includes("desktop production build"));
+
+  // The PWA is not otherwise built by the release workflow, so it stays.
+  assert.ok(labels.includes("pwa production build"));
+
+  // The release matrix runs the real signed desktop build on all four
+  // platforms. Building the frontend once more here made it five builds to
+  // gate four artifacts, and a frontend break still fails the build that ships.
+  assert.ok(
+    !labels.includes("desktop production build"),
+    "the desktop build must not be duplicated ahead of the release matrix",
+  );
+
+  // The website ships from `www` through publish-website against the reviewed
+  // marketing branch. Building it in the Desktop release lane couples two
+  // branch lanes that AGENTS.md keeps apart.
+  assert.ok(
+    !labels.includes("website production build"),
+    "the Desktop release lane must not build the website",
+  );
 });
 
 test("release mode remains a compatibility alias for production", () => {


### PR DESCRIPTION
(AI Generated).

## Summary
- Replace the fixed 4x8 tooling matrix with a computed matrix capped at 8 jobs, covering only the suites a change can reach. A dependabot config edit or UI-only change now schedules zero tooling jobs, against 32 before.
- Attribution uses transitive imports plus concrete repo-path literals, since several validators assert facts about content they never import. Bare roots and package roots are excluded because they appear as startsWith guards, not references.
- Fails closed: unattributable scripts/ or automation/ changes and global inputs select every suite, and a push to dev always runs the full lane.
- Three darwin-only files move to a real macOS lane where their assertions actually execute; one had been observed blocking indefinitely at 0 percent CPU on Ubuntu. Shards gain a 5 minute per-test timeout.
- Desktop release lane no longer builds the website (ships from www) or the desktop frontend (built for real on four platforms by the release matrix). Adds a nightly exhaustive lane with runtime and flake reporting.
- New docs/TESTING-STANDARD.md plus an AGENTS.md Test Economy section codify admission rules, execution tiers, and the universal release gate.

## Testing
- validate-worktree.test.mjs 29/29 pass, run-tooling-smoke-shard.test.mjs 6/6 pass, workspace typecheck clean.
- Planner verified against real change sets: dependabot.yml 0 jobs, UI-only 0 jobs, website-only 1 suite, kernel-guard lib 1 suite, unattributable new script 4 suites, global input 4 suites.