### PR TITLE
fix: defer archive pruning to cloud reconciliation instead of skipping it

### DIFF
--- a/packages/desktop/src/lib/cloud-reconcile-signal.test.ts
+++ b/packages/desktop/src/lib/cloud-reconcile-signal.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  isCloudReconciled,
+  markCloudReconciled,
+  onCloudReconciled,
+  resetCloudReconcileSignalForTests,
+} from "./cloud-reconcile-signal";
+
+// The contract this file protects: startup maintenance is DEFERRED until cloud
+// sync reconciles, never skipped. The previous implementation skipped it
+// outright whenever cloud credentials existed, so archive pruning never ran on
+// a machine with a cloud provider connected and the Automerge document grew
+// without bound.
+describe("cloud reconcile signal", () => {
+  beforeEach(() => {
+    resetCloudReconcileSignalForTests();
+  });
+
+  it("starts unreconciled so maintenance cannot run before a remote merge", () => {
+    expect(isCloudReconciled()).toBe(false);
+  });
+
+  it("releases waiters registered before reconciliation", () => {
+    const waiter = vi.fn();
+    onCloudReconciled(waiter);
+    expect(waiter).not.toHaveBeenCalled();
+
+    markCloudReconciled("gdrive");
+
+    expect(waiter).toHaveBeenCalledTimes(1);
+    expect(isCloudReconciled()).toBe(true);
+  });
+
+  it("runs a waiter immediately when reconciliation already happened", () => {
+    markCloudReconciled("gdrive");
+    const waiter = vi.fn();
+
+    onCloudReconciled(waiter);
+
+    expect(waiter).toHaveBeenCalledTimes(1);
+  });
+
+  it("releases waiters only once across multiple providers", () => {
+    const waiter = vi.fn();
+    onCloudReconciled(waiter);
+
+    markCloudReconciled("gdrive");
+    markCloudReconciled("dropbox");
+
+    // A second provider merges into an already-reconciled document, so
+    // re-running the full maintenance scan would repeat a full Automerge load
+    // for no new information.
+    expect(waiter).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels a waiter that is torn down before reconciliation", () => {
+    const waiter = vi.fn();
+    const cancel = onCloudReconciled(waiter);
+
+    cancel();
+    markCloudReconciled("gdrive");
+
+    expect(waiter).not.toHaveBeenCalled();
+  });
+
+  it("keeps releasing waiters when one of them throws", () => {
+    const failing = vi.fn(() => {
+      throw new Error("maintenance scheduling failed");
+    });
+    const following = vi.fn();
+    onCloudReconciled(failing);
+    onCloudReconciled(following);
+
+    expect(() => markCloudReconciled("gdrive")).not.toThrow();
+
+    expect(failing).toHaveBeenCalledTimes(1);
+    expect(following).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not re-run a waiter that already fired", () => {
+    const waiter = vi.fn();
+    onCloudReconciled(waiter);
+
+    markCloudReconciled("gdrive");
+    markCloudReconciled("gdrive");
+
+    expect(waiter).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/desktop/src/lib/cloud-reconcile-signal.ts
+++ b/packages/desktop/src/lib/cloud-reconcile-signal.ts
@@ -1,0 +1,63 @@
+/**
+ * One-shot signal for "cloud sync has reconciled the local document".
+ *
+ * Startup maintenance (archive pruning, feed-item dedupe, title healing) must
+ * not mutate the local document before cloud sync has merged the remote copy
+ * into it, or it would delete rows the remote is about to reintroduce and churn
+ * the merge. That constraint was previously expressed as "skip maintenance
+ * whenever cloud credentials exist", which made the deferral permanent: on a
+ * machine with Google Drive connected, archive pruning never ran at all.
+ *
+ * This module makes the deferral actually a deferral. Cloud sync marks the
+ * document reconciled once its initial download has merged, and anything
+ * waiting on that runs then.
+ *
+ * It lives in its own module so that store.ts and sync.ts can both use it
+ * without importing each other.
+ */
+
+const reconciledProviders = new Set<string>();
+let waiters: Array<() => void> = [];
+
+export function markCloudReconciled(provider: string): void {
+  const alreadyReconciled = reconciledProviders.size > 0;
+  reconciledProviders.add(provider);
+  if (alreadyReconciled) return;
+  // First provider to reconcile releases the waiters. Later providers merge
+  // into an already-reconciled document, so re-running maintenance for each one
+  // would just repeat the same scan.
+  const pending = waiters;
+  waiters = [];
+  for (const waiter of pending) {
+    try {
+      waiter();
+    } catch {
+      /* a failing waiter must not block the others */
+    }
+  }
+}
+
+export function isCloudReconciled(): boolean {
+  return reconciledProviders.size > 0;
+}
+
+/**
+ * Run `waiter` once the local document has been reconciled with a cloud copy.
+ * Runs immediately when reconciliation already happened. Returns a cancel
+ * function so a caller torn down before reconciliation does not leak.
+ */
+export function onCloudReconciled(waiter: () => void): () => void {
+  if (isCloudReconciled()) {
+    waiter();
+    return () => {};
+  }
+  waiters.push(waiter);
+  return () => {
+    waiters = waiters.filter((candidate) => candidate !== waiter);
+  };
+}
+
+export function resetCloudReconcileSignalForTests(): void {
+  reconciledProviders.clear();
+  waiters = [];
+}

--- a/packages/desktop/src/lib/store.ts
+++ b/packages/desktop/src/lib/store.ts
@@ -124,6 +124,7 @@ import { initSubstackAuth, type SubstackAuthState } from "./substack-auth";
 import { initMediumAuth, type MediumAuthState } from "./medium-auth";
 import { initYouTubeAuth, type YouTubeAuthState } from "./youtube-auth";
 import { recordDocumentHydrated } from "./memory-monitor";
+import { onCloudReconciled } from "./cloud-reconcile-signal";
 import { reconcileSocialAuthStateHints } from "./social-auth-cookie-state";
 import { getOrCreateDesktopClientRegistration } from "./desktop-client-registration";
 import {
@@ -133,6 +134,9 @@ import {
 
 let outboxTeardown: (() => void) | null = null;
 let startupMaintenanceTimer: ReturnType<typeof setTimeout> | null = null;
+// Unsubscribes the pending "run maintenance once cloud reconciles" waiter, so a
+// re-initialize does not stack duplicate waiters.
+let cancelPendingCloudReconcileMaintenance: (() => void) | null = null;
 let startupContentSignalTimer: ReturnType<typeof setTimeout> | null = null;
 let startupContentSignalBackfillRunning = false;
 let appInitializationPromise: Promise<void> | null = null;
@@ -792,11 +796,26 @@ export const useAppStore = create<AppState>((set, get) => ({
         );
 
         // Do not mutate the local doc before cloud sync has reconciled it.
-        if (!hasStoredCloudSyncCredentials()) {
-          // Run cleanup migrations later. On large local libraries, immediate
-          // maintenance can force another full Automerge load while the renderer is
-          // still recovering from initial hydration.
-          scheduleStartupMigrations(docState.preferences.display.archivePruneDays ?? 30);
+        //
+        // Run cleanup migrations later either way. On large local libraries,
+        // immediate maintenance can force another full Automerge load while the
+        // renderer is still recovering from initial hydration.
+        //
+        // With cloud credentials present this used to skip maintenance outright,
+        // which made the deferral permanent rather than deferred: archive
+        // pruning never ran on a machine with a cloud provider connected, and
+        // the document grew without bound. Wait for the reconciliation signal
+        // instead, so pruning still happens, just after the remote copy has been
+        // merged in.
+        const archivePruneDays = docState.preferences.display.archivePruneDays ?? 30;
+        if (hasStoredCloudSyncCredentials()) {
+          cancelPendingCloudReconcileMaintenance?.();
+          cancelPendingCloudReconcileMaintenance = onCloudReconciled(() => {
+            cancelPendingCloudReconcileMaintenance = null;
+            scheduleStartupMigrations(archivePruneDays);
+          });
+        } else {
+          scheduleStartupMigrations(archivePruneDays);
         }
       } catch (error) {
         recordRuntimeError({ source: "desktop:initialize", error, fatal: false });

--- a/packages/desktop/src/lib/sync.ts
+++ b/packages/desktop/src/lib/sync.ts
@@ -10,6 +10,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { workerCloudMerge } from "./cloud-merge";
 import { open as shellOpen } from "@tauri-apps/plugin-shell";
+import { markCloudReconciled } from "./cloud-reconcile-signal";
 import {
   gdriveUploadSafe,
   gdriveUploadReplace,
@@ -1504,6 +1505,14 @@ async function runStartupCloudReconciliation(
   generation: number,
 ): Promise<void> {
   const result = await runInitialCloudDownload(provider, signal, resolveToken, generation);
+
+  // The local document has now been merged with the remote copy, so deferred
+  // startup maintenance is safe to run. Signal before the startup-repair branch
+  // below: a document that needs no repair is still fully reconciled, and that
+  // is the common case. Missing it here is what previously left archive pruning
+  // permanently disabled on machines with a cloud provider connected.
+  if (result) markCloudReconciled(provider);
+
   if (
     !result?.needsStartupRepair
     || !isCloudGenerationCurrent(provider, generation, signal)


### PR DESCRIPTION
(AI Generated).

## Summary
- Startup maintenance was gated behind the absence of cloud credentials. The comment says the intent was to defer until cloud sync reconciled the document; the implementation made it permanent. With Google Drive connected, archive pruning, feed-item dedupe and title healing had never run.
- Measured on the owner's live v26.7.2300 client: 15,846 feedItems in one Automerge document, 11 MB of content materializing to about 800 MB in memory (77x), cloud merge peaking at 1,356 MB on the main thread, and WebAssembly.Memory having no shrink() so that peak becomes a permanent floor.
- Dropping all 12,067 changes of history saves only 17 percent, so history is not the driver. Document size is, and pruning is what bounds it.
- Adds cloud-reconcile-signal.ts, a one-shot signal raised once the initial cloud download has merged. Maintenance waits on it when credentials exist and runs immediately when they do not.
- Also a provider-reliability fix: the renderer reaching 7 to 10 GB is what makes scrape_memory_preflight block Facebook and destroy the renderer, so the memory defect and the scrape-reliability defect are the same loop.

## Testing
- 7/7 new cloud-reconcile-signal tests pass; 102 tests across 10 store, sync and cloud files pass; desktop tsc --noEmit clean.
- Root cause measured with vmmap and heap on renderer pids 94509 and 58233 plus 1,833 runtime-health events; clean fresh-process A/B on the real 15 MB snapshot.

## Provider Review
- Status: Draft publication is allowed. Ready and merge require provider authority.
- Review action: A provider CODEOWNER reacts with a GitHub thumbs-up on the generated provider review comment.
- Provider subdiff: `a15ab294915c5484fbf53a8530ef8fa5b81dea2a`
- Draft publication does not authorize new live provider traffic. Gate 1 behavior approval still applies.
- Gate 1 task: `prune-archive-after-cloud-reconcile`
- Gate 1 artifact: `e18da3807336a48097f17ac9fdb46d97988c0e3799156ab8bfc5f0e63490f830`
- Providers: facebook, instagram, linkedin, medium, other, substack, x, youtube
- Observable behavior: No change is observable to any social provider. Freed adds no request, navigation, cookie, header, retry, user agent, media preload, canvas or WebGL behavior, and does not change scrape cadence or timing. The only behavior change is that local document maintenance, which previously never ran, now runs once the initial cloud download has merged.
- Fingerprinting risk: None identified. No provider-visible surface is touched. The diff adds a one-shot local signal module, a waiter registration in the store initializer, and one call to that signal in the Google Drive and Dropbox reconciliation path. Second-order effect: a smaller Automerge document reduces renderer memory, which makes scrape_memory_preflight block Facebook scrapes less often. That restores previously intended scrape behavior rather than introducing new provider contact.
- Lowest profile alternative: Land an observation-only counter that reports how many items would be pruned without deleting any. The owner reviewed this alternative on 2026-07-24 and chose the full prune.

Files bound into this provider review:
- `packages/desktop/src/lib/store.ts`
- `packages/desktop/src/lib/sync.ts`