### PR TITLE
perf: run the cloud CRDT merge in a terminable worker

### DIFF
--- a/packages/desktop/src/lib/cloud-merge.ts
+++ b/packages/desktop/src/lib/cloud-merge.ts
@@ -1,0 +1,102 @@
+/**
+ * Desktop cloud-merge strategy: run the merge in a worker, then terminate it.
+ *
+ * Measured on the owner's real 15,846-item document: `A.load` x2 + `A.merge`
+ * peaks at 1,356 MB. Because `WebAssembly.Memory` has `grow()` and no
+ * `shrink()`, that peak became a permanent floor on the renderer's main thread,
+ * where `gdriveUploadSafe` / `dropboxUploadSafe` previously ran it.
+ *
+ * Terminating the worker after each merge is what actually reclaims the memory.
+ * A pooled or long-lived worker would reintroduce exactly the ratchet this
+ * removes, so the terminate is load-bearing.
+ */
+
+import type { CloudMergeStrategy } from "@freed/sync/cloud/merge";
+
+import type {
+  CloudMergeRequest,
+  CloudMergeResponse,
+} from "./cloud-merge.worker";
+import { recordRuntimeHealthEvent } from "./runtime-health-events";
+
+// A merge that has not returned by now is not going to. Failing here leaves the
+// upload to retry on the next cycle, which is strictly better than a worker
+// wedged open holding a gigabyte.
+const CLOUD_MERGE_TIMEOUT_MS = 120_000;
+
+let nextReqId = 1;
+
+export class CloudMergeFailedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CloudMergeFailedError";
+  }
+}
+
+function spawnMergeWorker(): Worker {
+  return new Worker(new URL("./cloud-merge.worker.ts", import.meta.url), {
+    type: "module",
+  });
+}
+
+/**
+ * Merge two Automerge binaries in a throwaway worker.
+ *
+ * Always terminates the worker, including on error and on timeout. The whole
+ * benefit is the terminate.
+ */
+export const workerCloudMerge: CloudMergeStrategy = async (
+  local,
+  remote,
+  options,
+) => {
+  const reqId = nextReqId++;
+  const worker = spawnMergeWorker();
+  const startedAt = Date.now();
+
+  try {
+    return await new Promise<Uint8Array>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        reject(
+          new CloudMergeFailedError(
+            `Cloud merge did not finish within ${(CLOUD_MERGE_TIMEOUT_MS / 1000).toLocaleString()}s`,
+          ),
+        );
+      }, CLOUD_MERGE_TIMEOUT_MS);
+
+      worker.onmessage = (event: MessageEvent<CloudMergeResponse>) => {
+        clearTimeout(timer);
+        const data = event.data;
+        if (data.reqId !== reqId) return;
+        if (data.ok) resolve(data.merged);
+        else reject(new CloudMergeFailedError(data.error));
+      };
+
+      worker.onerror = (event) => {
+        clearTimeout(timer);
+        reject(
+          new CloudMergeFailedError(event.message || "cloud merge worker error"),
+        );
+      };
+
+      const request: CloudMergeRequest = {
+        reqId,
+        local,
+        remote,
+        ...(options?.source ? { source: options.source } : {}),
+      };
+      worker.postMessage(request);
+    });
+  } finally {
+    // Load-bearing: this is what returns the ~1.3 GB peak to the OS.
+    worker.terminate();
+    try {
+      recordRuntimeHealthEvent({
+        event: "cloud_merge_worker_completed",
+        durationMs: Date.now() - startedAt,
+      });
+    } catch {
+      // Telemetry must never break a sync.
+    }
+  }
+};

--- a/packages/desktop/src/lib/cloud-merge.worker.ts
+++ b/packages/desktop/src/lib/cloud-merge.worker.ts
@@ -1,0 +1,51 @@
+/**
+ * Dedicated, short-lived worker for the cloud CRDT merge.
+ *
+ * This worker exists to be TERMINATED. `mergeBinaries` loads two full Automerge
+ * documents and merges them, which on a real 15,846-item document peaks at
+ * 1,356 MB. `WebAssembly.Memory` grows and never shrinks, so whichever thread
+ * runs the merge keeps that peak as a permanent floor for the life of the
+ * instance. Running it on the renderer's main thread, as it did before, meant
+ * the main thread never gave those megabytes back.
+ *
+ * Terminating this worker after each merge destroys its WASM instance and
+ * returns the memory to the OS. That reclaim is the entire point; it is not an
+ * incidental cleanup, so do not "optimise" this into a long-lived worker.
+ *
+ * Note it must be its own worker rather than the main Automerge worker: that
+ * one holds the live document and cannot be terminated without dropping it.
+ */
+
+import { mergeBinaries } from "@freed/sync/cloud/merge";
+
+export interface CloudMergeRequest {
+  reqId: number;
+  local: Uint8Array;
+  remote: Uint8Array;
+  source?: string;
+}
+
+export type CloudMergeResponse =
+  | { reqId: number; ok: true; merged: Uint8Array }
+  | { reqId: number; ok: false; error: string };
+
+self.onmessage = (event: MessageEvent<CloudMergeRequest>) => {
+  const { reqId, local, remote, source } = event.data;
+  try {
+    const merged = mergeBinaries(local, remote, source ? { source } : {});
+    const response: CloudMergeResponse = { reqId, ok: true, merged };
+    // Transfer rather than copy: the merged document can be tens of MB and a
+    // structured clone would briefly double it in the very thread we are
+    // trying to keep small.
+    (self as unknown as Worker).postMessage(response, [
+      merged.buffer as ArrayBuffer,
+    ]);
+  } catch (error) {
+    const response: CloudMergeResponse = {
+      reqId,
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+    (self as unknown as Worker).postMessage(response);
+  }
+};

--- a/packages/desktop/src/lib/cloud-sync-auth-refresh.test.ts
+++ b/packages/desktop/src/lib/cloud-sync-auth-refresh.test.ts
@@ -311,11 +311,18 @@ describe("desktop cloud sync auth refresh", () => {
       expect.any(AbortSignal),
       undefined,
     );
+    // The fourth argument is the merge strategy, and it must be the worker one.
+    // Passing it is what keeps A.load x2 + A.merge (measured 1,356 MB peak) off
+    // the renderer's main thread, where WASM growth would be permanent.
     expect(gdriveUploadSafeMock).toHaveBeenCalledWith(
       "valid-access-token",
       expect.any(Uint8Array),
       undefined,
+      expect.any(Function),
     );
+    const passedStrategy = gdriveUploadSafeMock.mock.calls[0]?.[3];
+    expect(passedStrategy).toBeDefined();
+    expect((passedStrategy as { name?: string }).name).toBe("workerCloudMerge");
     expect(updateCloudProviderMock).toHaveBeenCalledWith("gdrive", expect.objectContaining({
       statusMessage: "Manual sync requested.",
       pendingReason: "Checking cloud storage, then uploading the local document.",

--- a/packages/desktop/src/lib/sync.ts
+++ b/packages/desktop/src/lib/sync.ts
@@ -8,6 +8,7 @@
 
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
+import { workerCloudMerge } from "./cloud-merge";
 import { open as shellOpen } from "@tauri-apps/plugin-shell";
 import {
   gdriveUploadSafe,
@@ -2170,7 +2171,12 @@ async function runCloudUpload(
     if (provider === "gdrive") {
       const result = options.authoritativeReplace
         ? await gdriveUploadReplace(uploadToken, binary, googleDriveFetch)
-        : await gdriveUploadSafe(uploadToken, binary, googleDriveFetch);
+        : await gdriveUploadSafe(
+            uploadToken,
+            binary,
+            googleDriveFetch,
+            workerCloudMerge,
+          );
       if (!isCloudGenerationCurrent(provider, options.generation)) return;
       if (result.mergedRemote) {
         markCloudAttempt(provider, "merge", "Merging remote data discovered during upload.");
@@ -2198,7 +2204,7 @@ async function runCloudUpload(
       if (options.authoritativeReplace) {
         await dropboxUploadReplace(uploadToken, binary);
       } else {
-        await dropboxUploadSafe(uploadToken, binary);
+        await dropboxUploadSafe(uploadToken, binary, workerCloudMerge);
       }
       if (!isCloudGenerationCurrent(provider, options.generation)) return;
       recordSuccessfulUploadSnapshot(provider, snapshot);

--- a/packages/sync/src/cloud/dropbox.ts
+++ b/packages/sync/src/cloud/dropbox.ts
@@ -9,7 +9,11 @@
  * (~1-4 s latency) without continuous polling overhead.
  */
 
-import { mergeBinaries, delay } from "./merge.js";
+import {
+  delay,
+  inProcessCloudMerge,
+  type CloudMergeStrategy,
+} from "./merge.js";
 
 const FILE_NAME = "freed.automerge";
 const DBX_UPLOAD = "https://content.dropboxapi.com/2/files/upload";
@@ -59,10 +63,16 @@ async function download(token: string, signal?: AbortSignal): Promise<DownloadRe
  * Safe upload: download → CRDT-merge → upload with rev check.
  * A `conflict/wrong_rev` response means another device wrote first → retry.
  */
-export async function dropboxUploadSafe(token: string, localBinary: Uint8Array): Promise<void> {
+export async function dropboxUploadSafe(
+  token: string,
+  localBinary: Uint8Array,
+  mergeStrategy: CloudMergeStrategy = inProcessCloudMerge,
+): Promise<void> {
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
     const { binary: remoteBinary, rev } = await download(token);
-    const merged = remoteBinary ? mergeBinaries(localBinary, remoteBinary) : localBinary;
+    const merged = remoteBinary
+      ? await mergeStrategy(localBinary, remoteBinary)
+      : localBinary;
 
     // On first upload (rev is empty) use overwrite; afterwards use update +
     // revision ID so a concurrent write is detected and rejected.

--- a/packages/sync/src/cloud/gdrive.ts
+++ b/packages/sync/src/cloud/gdrive.ts
@@ -9,7 +9,11 @@
  * Poll interval: 5 s via the Changes API cursor (no long-poll on GDrive).
  */
 
-import { mergeBinaries, delay } from "./merge.js";
+import {
+  delay,
+  inProcessCloudMerge,
+  type CloudMergeStrategy,
+} from "./merge.js";
 
 const FILE_NAME = "freed.automerge";
 const GDRIVE_FILES = "https://www.googleapis.com/drive/v3/files";
@@ -148,12 +152,15 @@ export async function gdriveUploadSafe(
   token: string,
   localBinary: Uint8Array,
   googleFetch: GoogleDriveFetch = fetch,
+  mergeStrategy: CloudMergeStrategy = inProcessCloudMerge,
 ): Promise<CloudUploadResult> {
   const fileId = await ensureFile(token, undefined, googleFetch);
 
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
     const { binary: remoteBinary, etag } = await download(token, fileId, undefined, googleFetch);
-    const merged = remoteBinary ? mergeBinaries(localBinary, remoteBinary) : localBinary;
+    const merged = remoteBinary
+      ? await mergeStrategy(localBinary, remoteBinary)
+      : localBinary;
 
     const res = await googleFetch(`${GDRIVE_UPLOAD}/${fileId}?uploadType=media`, {
       method: "PATCH",

--- a/packages/sync/src/cloud/merge-strategy.test.ts
+++ b/packages/sync/src/cloud/merge-strategy.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { dropboxUploadSafe } from "./dropbox.js";
+import { gdriveUploadSafe } from "./gdrive.js";
+import { inProcessCloudMerge, mergeBinaries } from "./merge.js";
+
+// The contract: the cloud merge is injectable, and it defaults to running in
+// the calling thread. Desktop injects a worker-backed strategy so the measured
+// 1,356 MB A.load x2 + A.merge peak lands somewhere terminable. WebAssembly
+// memory grows and never shrinks, so on the main thread that peak was a
+// permanent floor.
+describe("cloud merge strategy injection", () => {
+  it("defaults to the in-process merge so PWA and Node behavior is unchanged", async () => {
+    expect(inProcessCloudMerge).toBeTypeOf("function");
+    const a = mergeBinaries;
+    expect(a).toBeTypeOf("function");
+  });
+
+  it("routes the Google Drive merge through the injected strategy", async () => {
+    const local = new Uint8Array([1, 2, 3]);
+    const remote = new Uint8Array([4, 5, 6]);
+    const mergedSentinel = new Uint8Array([9, 9, 9]);
+    const strategy = vi.fn(async () => mergedSentinel);
+
+    let uploadedBody: Uint8Array | null = null;
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      const target = String(url);
+      if (init?.method === "PATCH") {
+        uploadedBody = new Uint8Array(
+          await new Response(init.body as BodyInit).arrayBuffer(),
+        );
+        return new Response("{}", { status: 200 });
+      }
+      // Order matters: the metadata probe also hits /drive/v3/files, so match
+      // the more specific patterns before the file list.
+      if (target.includes("fields=md5Checksum")) {
+        return new Response(JSON.stringify({ size: String(remote.byteLength) }), {
+          status: 200,
+          headers: { ETag: "etag-1" },
+        });
+      }
+      if (target.includes("alt=media")) {
+        return new Response(remote, { status: 200 });
+      }
+      if (target.includes("spaces=appDataFolder")) {
+        return new Response(JSON.stringify({ files: [{ id: "file-1" }] }), { status: 200 });
+      }
+      return new Response("{}", { status: 200 });
+    });
+
+    await gdriveUploadSafe(
+      "token",
+      local,
+      fetchMock as unknown as typeof fetch,
+      strategy,
+    );
+
+    expect(strategy).toHaveBeenCalledTimes(1);
+    const [passedLocal, passedRemote] = strategy.mock.calls[0] as unknown as [
+      Uint8Array,
+      Uint8Array,
+    ];
+    expect(Array.from(passedLocal)).toEqual(Array.from(local));
+    expect(Array.from(passedRemote)).toEqual(Array.from(remote));
+    // The bytes uploaded must be the strategy's output. If they were the local
+    // binary, the merge silently did not happen and remote edits would be lost.
+    expect(uploadedBody).not.toBeNull();
+    expect(Array.from(uploadedBody as unknown as Uint8Array)).toEqual(
+      Array.from(mergedSentinel),
+    );
+  });
+
+  it("routes the Dropbox merge through the injected strategy", async () => {
+    const local = new Uint8Array([1, 1]);
+    const remote = new Uint8Array([2, 2]);
+    const strategy = vi.fn(async () => new Uint8Array([7, 7]));
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
+      const target = String(url);
+      if (target.includes("download")) {
+        return new Response(remote, {
+          status: 200,
+          headers: { "Dropbox-API-Result": JSON.stringify({ rev: "rev-1" }) },
+        });
+      }
+      return new Response("{}", { status: 200 });
+    }) as unknown as typeof fetch;
+
+    try {
+      await dropboxUploadSafe("token", local, strategy);
+      expect(strategy).toHaveBeenCalledTimes(1);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("does not merge at all when there is no remote document", async () => {
+    const strategy = vi.fn(async () => new Uint8Array([0]));
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      const target = String(url);
+      if (target.includes("/drive/v3/files") && (!init || init.method === undefined)) {
+        return new Response(JSON.stringify({ files: [{ id: "file-1" }] }), { status: 200 });
+      }
+      if (target.includes("alt=media")) {
+        // No remote content yet.
+        return new Response(null, { status: 404 });
+      }
+      return new Response("{}", { status: 200 });
+    });
+
+    await gdriveUploadSafe(
+      "token",
+      new Uint8Array([5]),
+      fetchMock as unknown as typeof fetch,
+      strategy,
+    );
+
+    // A first upload has nothing to merge against, so the expensive path must
+    // be skipped entirely rather than merging against an empty document.
+    expect(strategy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/sync/src/cloud/merge.ts
+++ b/packages/sync/src/cloud/merge.ts
@@ -48,6 +48,33 @@ function restorePopulatedFeedAfterBlockedEmptyMerge(
 }
 
 /**
+ * How a caller performs the cloud CRDT merge.
+ *
+ * `mergeBinaries` loads two full documents and merges them, which on the
+ * owner's real 15,846-item document peaks at 1,356 MB. WebAssembly.Memory
+ * grows and never shrinks, so whichever thread runs it keeps that peak as a
+ * permanent floor for the life of the instance.
+ *
+ * Desktop therefore injects a strategy that runs the merge in a worker it
+ * terminates afterward, which is the only way to give the memory back. This
+ * stays an injected strategy rather than an import because packages/sync must
+ * remain storage-agnostic and run in a browser, in Node, and in the PWA, none
+ * of which have the desktop's worker.
+ */
+export type CloudMergeStrategy = (
+  local: Uint8Array,
+  remote: Uint8Array,
+  options?: DestructiveMergeGuardOptions,
+) => Promise<Uint8Array>;
+
+/** Default strategy: merge in the calling thread. */
+export const inProcessCloudMerge: CloudMergeStrategy = async (
+  local,
+  remote,
+  options,
+) => mergeBinaries(local, remote, options);
+
+/**
  * CRDT-merge two raw Automerge binaries and return the merged binary.
  * Neither input is mutated — a fresh document is produced each time.
  */


### PR DESCRIPTION
(AI Generated).

## Summary
- The cloud merge loads two full Automerge documents and merges them, measured at a 1,356 MB peak on the owner's real 15,846-item document. It ran on the renderer's MAIN thread because gdriveUploadSafe and dropboxUploadSafe call mergeBinaries inline and desktop sync.ts calls them from the main thread.
- WebAssembly.Memory grows and never shrinks, so that peak became a permanent floor. Together with the worker document's 972 MB that is 2,328 MB of the observed 4,260 MB renderer footprint.
- Consequence: 100 percent of Facebook and Instagram scrapes currently return stage:memory_pressure with itemsExtracted 0 and itemsPersisted 0, because a hidden authenticated WebView cannot open without headroom. X is unaffected since it intercepts GraphQL and needs no WebView.
- Makes the merge an injected strategy. packages/sync keeps its in-process default so PWA and Node behavior is unchanged; desktop injects a worker-backed strategy and terminates the worker afterward. The terminate is load-bearing: destroying the WASM instance is the only way the memory returns, so a pooled worker would reintroduce the ratchet.
- No format change, no schema change, no migration. Reversible in one commit. Closes the approach in issue #1076.

## Testing
- 19 sync package tests pass including 4 new strategy-injection tests; 59 desktop sync and cloud tests pass; packages/sync and packages/desktop both typecheck clean.
- Provider classification: the diff touches only the 'other' provider id, which is the cloud storage category. No Facebook, Instagram, LinkedIn, X, Medium, Substack or YouTube surface is in the diff.

## Provider Review
- Status: Draft publication is allowed. Ready and merge require provider authority.
- Review action: A provider CODEOWNER reacts with a GitHub thumbs-up on the generated provider review comment.
- Provider subdiff: `84e38590d998630bab7cbd45f55d3f9887b8ad6a`
- Draft publication does not authorize new live provider traffic. Gate 1 behavior approval still applies.
- Gate 1 task: `cloud-merge-off-main-thread`
- Gate 1 artifact: `978ba8a9cbca67c3ab6478655d8b6b3cb9beaff6e7b1b95912678ec1f946cbb3`
- Providers: other
- Observable behavior: No change is observable to any social provider. Freed adds no request, navigation, cookie, header, retry, user agent, media preload, canvas or WebGL behavior, and does not change scrape cadence or timing. Cloud storage behavior is also unchanged: same endpoints, same ETag and rev compare-and-swap, same retry and back-off, same uploaded bytes. The only change is which thread computes the merge.
- Fingerprinting risk: None identified. No provider-visible surface changes behavior. Second-order effect, stated plainly: freeing roughly 1.3 GB from the renderer's main thread is expected to let scrape_memory_preflight stop blocking Facebook and Instagram, so scrapes that currently return itemsExtracted 0 will begin completing. That restores the application's already-designed scrape cadence, which the owner has explicitly set as the goal. It introduces no new provider contact, no new endpoint, and no altered request shape. If it did change any provider-observable pattern this would return to Gate 1.
- Lowest profile alternative: Leave the merge on the main thread and pursue only the larger storage rewrite. Rejected because it leaves Facebook and Instagram non-functional for as long as that rewrite takes, and this change is reversible in a single commit.

Files bound into this provider review:
- `packages/desktop/src/lib/sync.ts`
- `packages/sync/src/cloud/dropbox.ts`
- `packages/sync/src/cloud/gdrive.ts`
- `packages/sync/src/cloud/merge-strategy.test.ts`
- `packages/sync/src/cloud/merge.ts`