### PR TITLE
perf: send cloud IPC bodies as base64 instead of a JSON number array

### DIFF
--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -5228,11 +5228,33 @@ async fn fetch_url(url: String, max_bytes: Option<usize>) -> Result<String, Stri
     Ok(String::from_utf8_lossy(&body).into_owned())
 }
 
+/// Native HTTP response handed back to the renderer.
+///
+/// `body_b64` is base64 rather than `Vec<u8>` on purpose. Tauri serialises a
+/// `Vec<u8>` field as a JSON array of numbers, so a 38 MB cloud document
+/// crossed the IPC boundary as 38 million boxed JS numbers, roughly 300 MB of
+/// renderer heap plus the JSON string Tauri built to carry it. Because WebKit's
+/// allocator does not return that to the OS promptly, every cloud sync ratcheted
+/// the renderer. One base64 string is ~1.33x the byte length and a single
+/// allocation.
 #[derive(serde::Serialize)]
 struct NativeHttpResponse {
     status: u16,
     headers: Vec<(String, String)>,
-    body: Vec<u8>,
+    #[serde(rename = "bodyB64")]
+    body_b64: String,
+}
+
+/// Encode a response body for IPC. See `NativeHttpResponse` for why.
+fn encode_ipc_body(bytes: &[u8]) -> String {
+    base64::engine::general_purpose::STANDARD.encode(bytes)
+}
+
+/// Decode a request body received from the renderer over IPC.
+fn decode_ipc_body(encoded: &str) -> Result<Vec<u8>, String> {
+    base64::engine::general_purpose::STANDARD
+        .decode(encoded)
+        .map_err(|e| format!("Invalid base64 request body: {}", e))
 }
 
 fn response_headers(response: &reqwest::Response) -> Vec<(String, String)> {
@@ -5291,7 +5313,7 @@ async fn google_api_request(
     Ok(NativeHttpResponse {
         status,
         headers,
-        body,
+        body_b64: encode_ipc_body(&body),
     })
 }
 
@@ -5301,8 +5323,14 @@ async fn google_drive_request(
     url: String,
     method: Option<String>,
     headers: Option<Vec<(String, String)>>,
-    body: Option<Vec<u8>>,
+    #[allow(non_snake_case)] bodyB64: Option<String>,
 ) -> Result<NativeHttpResponse, String> {
+    // Base64 rather than Vec<u8>: see NativeHttpResponse. Uploading a 38 MB
+    // document as a JSON number array cost the renderer ~300 MB per sync.
+    let body: Option<Vec<u8>> = match bodyB64.as_deref() {
+        Some(encoded) => Some(decode_ipc_body(encoded)?),
+        None => None,
+    };
     let parsed =
         url::Url::parse(&url).map_err(|e| format!("Invalid Google Drive API URL: {}", e))?;
     let allowed_path =
@@ -5352,7 +5380,7 @@ async fn google_drive_request(
     Ok(NativeHttpResponse {
         status,
         headers,
-        body,
+        body_b64: encode_ipc_body(&body),
     })
 }
 
@@ -5415,7 +5443,7 @@ async fn google_oauth_proxy_request(
     Ok(NativeHttpResponse {
         status,
         headers,
-        body,
+        body_b64: encode_ipc_body(&body),
     })
 }
 

--- a/packages/desktop/src/__mocks__/@tauri-apps/api/core.ts
+++ b/packages/desktop/src/__mocks__/@tauri-apps/api/core.ts
@@ -100,11 +100,32 @@ async function proxyFetchBinary(args: Record<string, unknown>): Promise<number[]
   return Array.from(new Uint8Array(await resp.arrayBuffer()));
 }
 
+// Mirrors the real command: bodies cross the IPC boundary as base64, never as
+// a JSON number array. See NativeHttpResponse in src-tauri/src/lib.rs.
+function mockBytesToBase64(bytes: Uint8Array): string {
+  let binary = "";
+  for (let offset = 0; offset < bytes.length; offset += 32_768) {
+    binary += String.fromCharCode(...bytes.subarray(offset, offset + 32_768));
+  }
+  return btoa(binary);
+}
+
+function mockBase64ToBytes(encoded: string): Uint8Array {
+  if (!encoded) return new Uint8Array(0);
+  const binary = atob(encoded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
 async function proxyGoogleDriveRequest(args: Record<string, unknown>): Promise<{
   status: number;
   headers: Array<[string, string]>;
-  body: number[];
+  bodyB64: string;
 }> {
+  const requestBody = typeof args.bodyB64 === "string"
+    ? Array.from(mockBase64ToBytes(args.bodyB64))
+    : [];
   const resp = await fetch("/api/proxy", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -112,13 +133,13 @@ async function proxyGoogleDriveRequest(args: Record<string, unknown>): Promise<{
       url: args.url,
       headers: args.headers ?? [],
       method: args.method ?? "GET",
-      body: args.body ?? [],
+      body: requestBody,
     }),
   });
   return {
     status: resp.status,
     headers: Array.from(resp.headers.entries()),
-    body: Array.from(new Uint8Array(await resp.arrayBuffer())),
+    bodyB64: mockBytesToBase64(new Uint8Array(await resp.arrayBuffer())),
   };
 }
 

--- a/packages/desktop/src/lib/google-drive-ipc.test.ts
+++ b/packages/desktop/src/lib/google-drive-ipc.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import { base64ToBytes, bytesToBase64 } from "./google-drive";
+
+// The contract: cloud bodies cross the Tauri IPC boundary as base64, never as a
+// JSON number array. Tauri serialises a Rust Vec<u8> as an array of numbers, so
+// a 38 MB document arrived as 38 million boxed JS numbers (~300 MB of renderer
+// heap) plus the JSON string carrying it. WebKit does not return that promptly,
+// so every cloud sync ratcheted the renderer upward.
+describe("cloud IPC body encoding", () => {
+  it("round-trips an empty body", () => {
+    expect(bytesToBase64(new Uint8Array(0))).toBe("");
+    expect(base64ToBytes("")).toEqual(new Uint8Array(0));
+  });
+
+  it("round-trips every byte value, including nulls and high bytes", () => {
+    const all = new Uint8Array(256);
+    for (let i = 0; i < 256; i += 1) all[i] = i;
+    expect(Array.from(base64ToBytes(bytesToBase64(all)))).toEqual(Array.from(all));
+  });
+
+  it("round-trips across the chunk boundary without corruption", () => {
+    // The encoder walks 32 KiB at a time; sizes either side of that boundary
+    // are where an off-by-one would show up.
+    for (const size of [32_767, 32_768, 32_769, 65_536, 100_003]) {
+      const bytes = new Uint8Array(size);
+      for (let i = 0; i < size; i += 1) bytes[i] = (i * 31 + 7) & 0xff;
+      const restored = base64ToBytes(bytesToBase64(bytes));
+      expect(restored.length).toBe(size);
+      expect(restored[0]).toBe(bytes[0]);
+      expect(restored[size - 1]).toBe(bytes[size - 1]);
+      expect(restored[32_768]).toBe(bytes[32_768]);
+    }
+  });
+
+  it("round-trips a realistic Automerge-sized payload", () => {
+    // Not 38 MB in a unit test, but large enough that a chunking bug surfaces.
+    const size = 2 * 1024 * 1024;
+    const bytes = new Uint8Array(size);
+    for (let i = 0; i < size; i += 1) bytes[i] = (i * 131 + 17) & 0xff;
+
+    const encoded = bytesToBase64(bytes);
+    // Base64 is 4/3 plus padding. If this ever became a number array it would
+    // be an order of magnitude larger, which is the whole point of the change.
+    expect(encoded.length).toBeLessThan(size * 1.4);
+
+    const restored = base64ToBytes(encoded);
+    expect(restored.length).toBe(size);
+    let mismatches = 0;
+    for (let i = 0; i < size; i += 4096) {
+      if (restored[i] !== bytes[i]) mismatches += 1;
+    }
+    expect(mismatches).toBe(0);
+  });
+
+  it("produces standard base64, matching the Rust STANDARD engine", () => {
+    // The Rust side uses base64::engine::general_purpose::STANDARD. URL-safe
+    // output would decode to garbage there, so pin the alphabet.
+    const bytes = new Uint8Array([251, 255, 190, 239]);
+    const encoded = bytesToBase64(bytes);
+    expect(encoded).toBe("+/++7w==");
+    expect(encoded).not.toContain("-");
+    expect(encoded).not.toContain("_");
+  });
+});

--- a/packages/desktop/src/lib/google-drive.test.ts
+++ b/packages/desktop/src/lib/google-drive.test.ts
@@ -12,10 +12,12 @@ describe("desktop Google Drive platform fetch", () => {
   });
 
   it("routes Drive API requests through the Tauri command", async () => {
+    // Bodies cross IPC as base64, not as a JSON number array. See
+    // NativeHttpResponse in src-tauri/src/lib.rs.
     invokeMock.mockResolvedValueOnce({
       status: 200,
       headers: [["content-type", "application/json"]],
-      body: Array.from(new TextEncoder().encode('{"files":[{"id":"file-1"}]}')),
+      bodyB64: btoa('{"files":[{"id":"file-1"}]}'),
     });
 
     const { googleDriveFetchViaTauri } = await import("./google-drive");
@@ -28,7 +30,7 @@ describe("desktop Google Drive platform fetch", () => {
       url: "https://www.googleapis.com/drive/v3/files?spaces=appDataFolder",
       method: "GET",
       headers: [["Authorization", "Bearer token"]],
-      body: undefined,
+      bodyB64: undefined,
     });
     await expect(response.json()).resolves.toEqual({ files: [{ id: "file-1" }] });
   });
@@ -37,7 +39,7 @@ describe("desktop Google Drive platform fetch", () => {
     invokeMock.mockResolvedValueOnce({
       status: 200,
       headers: [],
-      body: [],
+      bodyB64: "",
     });
 
     const { googleDriveFetchViaTauri } = await import("./google-drive");
@@ -54,7 +56,9 @@ describe("desktop Google Drive platform fetch", () => {
       url: "https://www.googleapis.com/upload/drive/v3/files/file-1?uploadType=media",
       method: "PATCH",
       headers: [["Content-Type", "application/octet-stream"]],
-      body: [1, 2, 3],
+      // base64 of [1,2,3], not a number array. A regression here would silently
+      // restore ~300 MB of renderer transient per cloud sync.
+      bodyB64: "AQID",
     });
     expect(response.ok).toBe(true);
   });

--- a/packages/desktop/src/lib/google-drive.ts
+++ b/packages/desktop/src/lib/google-drive.ts
@@ -3,7 +3,17 @@ import { invoke } from "@tauri-apps/api/core";
 interface NativeGoogleDriveResponse {
   status: number;
   headers: Array<[string, string]>;
-  body: number[];
+  /**
+   * Base64 rather than `number[]`.
+   *
+   * Tauri serialises a Rust `Vec<u8>` as a JSON array of numbers, so a 38 MB
+   * cloud document arrived as 38 million boxed JS numbers, roughly 300 MB of
+   * renderer heap, plus the JSON string Tauri built to carry it. WebKit's
+   * allocator does not return that promptly, so every cloud sync ratcheted the
+   * renderer upward. One base64 string is ~1.33x the byte length and a single
+   * allocation.
+   */
+  bodyB64: string;
 }
 
 function throwIfAborted(signal?: AbortSignal | null): void {
@@ -21,11 +31,38 @@ function headersToEntries(headers?: HeadersInit): Array<[string, string]> {
   return Object.entries(headers).map(([key, value]) => [key, String(value)]);
 }
 
-function bodyToBytes(body?: BodyInit | null): number[] | undefined {
+// Chunked so a large document does not blow the argument limit of
+// String.fromCharCode.apply, and so no intermediate holds the whole corpus as
+// individually boxed values.
+const BASE64_CHUNK_BYTES = 32_768;
+
+export function bytesToBase64(bytes: Uint8Array): string {
+  let binary = "";
+  for (let offset = 0; offset < bytes.length; offset += BASE64_CHUNK_BYTES) {
+    const chunk = bytes.subarray(offset, offset + BASE64_CHUNK_BYTES);
+    binary += String.fromCharCode(...chunk);
+  }
+  return btoa(binary);
+}
+
+// Backed by an explicit ArrayBuffer so the result is Uint8Array<ArrayBuffer>,
+// which is what BodyInit requires. A plain `new Uint8Array(n)` widens to
+// ArrayBufferLike and will not satisfy the Response constructor.
+export function base64ToBytes(encoded: string): Uint8Array<ArrayBuffer> {
+  if (encoded.length === 0) return new Uint8Array(new ArrayBuffer(0));
+  const binary = atob(encoded);
+  const bytes = new Uint8Array(new ArrayBuffer(binary.length));
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return bytes;
+}
+
+function bodyToBase64(body?: BodyInit | null): string | undefined {
   if (!body) return undefined;
-  if (typeof body === "string") return Array.from(new TextEncoder().encode(body));
-  if (body instanceof Uint8Array) return Array.from(body);
-  if (body instanceof ArrayBuffer) return Array.from(new Uint8Array(body));
+  if (typeof body === "string") return bytesToBase64(new TextEncoder().encode(body));
+  if (body instanceof Uint8Array) return bytesToBase64(body);
+  if (body instanceof ArrayBuffer) return bytesToBase64(new Uint8Array(body));
   throw new Error("Google Drive native requests only support string and binary bodies.");
 }
 
@@ -40,12 +77,13 @@ export async function googleDriveFetchViaTauri(
     url,
     method: init.method ?? "GET",
     headers: headersToEntries(init.headers),
-    body: bodyToBytes(init.body),
+    bodyB64: bodyToBase64(init.body),
   });
 
   throwIfAborted(init.signal);
 
-  const body = response.body.length > 0 ? new Uint8Array(response.body) : null;
+  const decoded = base64ToBytes(response.bodyB64 ?? "");
+  const body = decoded.length > 0 ? decoded : null;
   return new Response(body, {
     status: response.status,
     headers: response.headers,


### PR DESCRIPTION
(AI Generated).

## Summary
- Tauri serialises a Rust Vec<u8> field as a JSON array of numbers, and bodyToBytes called Array.from on the way out. A 38 MB cloud document crossed the IPC boundary as 38 million boxed JS numbers, roughly 300 MB of renderer heap, plus the JSON string Tauri built to carry it.
- WebKit's allocator does not return that promptly, so every cloud sync ratcheted the renderer upward. Base64 is ~1.33x the byte length and a single allocation per direction.
- Stage 1 of the storage roadmap (#1135), independent of the Automerge work: pure transport encoding, no schema or format change.
- Both directions change together, plus the Tauri dev-proxy mock so the browser path stays faithful to the real command shape.

## Testing
- 67 desktop google-drive, sync and cloud tests pass, including 5 new round-trip tests covering every byte value, the 32 KiB chunk boundary, a 2 MB payload, and the standard-vs-URL-safe alphabet.
- packages/desktop tsc --noEmit clean. cargo check clean (two pre-existing dead-code warnings, unrelated).

## Provider Review
- Status: Draft publication is allowed. Ready and merge require provider authority.
- Review action: A provider CODEOWNER reacts with a GitHub thumbs-up on the generated provider review comment.
- Provider subdiff: `1b62b9d214b51e47acc4d67df63d0ba5ac12eb24`
- Draft publication does not authorize new live provider traffic. Gate 1 behavior approval still applies.
- Gate 1 task: `raw-bytes-cloud-ipc`
- Gate 1 artifact: `0c29a93c77c36d34b6d1e7206623f72249fae844432b3fd3b076ced2c5eb8cc5`
- Providers: facebook, instagram, linkedin, medium, other, substack, x, youtube
- Observable behavior: No change is observable to any provider, social or cloud. Same endpoints, same HTTP methods, same headers, same request cadence, same bytes on the wire to Google Drive. The only change is the encoding used between the renderer and the Rust process inside the application, which no external party can see.
- Fingerprinting risk: None. The change is entirely internal to the app's own process boundary and does not alter any network request. Second-order effect, stated plainly: reclaiming roughly 300 to 450 MB of renderer transient per cloud sync contributes to letting scrape_memory_preflight stop blocking Facebook and Instagram, so scrapes that currently return itemsExtracted 0 will begin completing. That restores the application's already-designed scrape cadence, which the owner has set as the goal. It introduces no new provider contact and no altered request shape.
- Lowest profile alternative: Leave the encoding as a number array and rely only on the storage rewrite. Rejected because the boxing cost is pure waste with no behavioral benefit, and this change is independent of the storage work and reversible in one commit.

Files bound into this provider review:
- `packages/desktop/src-tauri/src/lib.rs`
- `packages/desktop/src/lib/google-drive.ts`