### PR TITLE
feat: attribute renderer memory against a pre-hydration shell baseline

### DIFF
--- a/packages/desktop/src/lib/memory-attribution.test.ts
+++ b/packages/desktop/src/lib/memory-attribution.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  getShellBaselineBytes,
+  recordDocumentHydrated,
+  resetMemoryAttributionForTests,
+} from "./memory-monitor";
+
+// The contract this protects: the shell baseline is only meaningful if it is
+// captured BEFORE the Automerge document is hydrated. Every floor estimate in
+// the storage roadmap is derived by subtracting from an observed total, and the
+// WebKit-plus-React shell is the largest term in that subtraction, estimated
+// across four independent passes at anywhere from 60 to 250 MB. A baseline
+// taken after hydration silently folds the document into the "shell" and makes
+// every derived number wrong in the flattering direction.
+describe("memory attribution", () => {
+  beforeEach(() => {
+    resetMemoryAttributionForTests();
+  });
+
+  it("starts with no baseline", () => {
+    expect(getShellBaselineBytes()).toBeUndefined();
+  });
+
+  it("treats hydration as a one-way door", () => {
+    recordDocumentHydrated();
+    recordDocumentHydrated();
+    // Idempotent: a second call must not reopen the window by resetting state.
+    expect(getShellBaselineBytes()).toBeUndefined();
+  });
+
+  it("clears state for tests so runs do not leak into each other", () => {
+    recordDocumentHydrated();
+    resetMemoryAttributionForTests();
+    expect(getShellBaselineBytes()).toBeUndefined();
+  });
+});

--- a/packages/desktop/src/lib/memory-monitor.ts
+++ b/packages/desktop/src/lib/memory-monitor.ts
@@ -87,10 +87,51 @@ interface BrowserMemoryStats {
   jsHeapSizeLimit: number;
 }
 
+/**
+ * `performance.memory` is a Chrome extension to the Performance interface and
+ * does not exist in WebKit, which is what Tauri uses on macOS. So on the actual
+ * product this has always returned null, and every rendererHeap* field in the
+ * telemetry has been silently absent.
+ *
+ * That absence read as zero in analysis and invited the conclusion that the JS
+ * heap was negligible. It is not measured, which is a different claim. The
+ * `rendererHeapAvailable` flag below makes the difference explicit so nobody
+ * else draws a conclusion from a missing number.
+ */
 function getRendererMemoryStats(): BrowserMemoryStats | null {
   if (typeof performance === "undefined") return null;
   const perf = performance as Performance & { memory?: BrowserMemoryStats };
   return perf.memory ?? null;
+}
+
+/**
+ * WebKit resident bytes captured before the Automerge document is loaded.
+ *
+ * This is the single largest unmeasured term in the storage roadmap's floor
+ * estimates: the WebKit shell plus React baseline, which four independent
+ * design passes estimated anywhere from 60 to 250 MB. Everything else in the
+ * renderer budget is derived by subtracting from the observed total, so a 4x
+ * uncertainty here makes every ratio in that document soft.
+ *
+ * Recorded once per app launch, at the first sample taken before hydration.
+ */
+let shellBaselineWebkitResidentBytes: number | undefined;
+let shellBaselineCapturedAtMs: number | undefined;
+let documentHydratedAtMs: number | undefined;
+
+export function recordDocumentHydrated(): void {
+  documentHydratedAtMs ??= Date.now();
+}
+
+export function getShellBaselineBytes(): number | undefined {
+  return shellBaselineWebkitResidentBytes;
+}
+
+/** Test seam: clears the once-per-launch baseline. */
+export function resetMemoryAttributionForTests(): void {
+  shellBaselineWebkitResidentBytes = undefined;
+  shellBaselineCapturedAtMs = undefined;
+  documentHydratedAtMs = undefined;
 }
 
 function getDomNodeCount(): number | undefined {
@@ -287,6 +328,22 @@ async function sampleRuntimeMemory(
     ? await invoke<NativeRuntimeMemoryStats>("get_runtime_memory_stats", nativeOptions)
     : emptyNativeRuntimeMemoryStats();
   const nativeSampleDurationMs = Math.round(performance.now() - nativeStartedAt);
+
+  // Capture the shell baseline exactly once, and only from a sample taken
+  // before the document is hydrated. Taking it later would fold the Automerge
+  // document into the "baseline" and make the delta meaningless, which is the
+  // specific way this measurement is easy to get wrong.
+  const baselineCandidateBytes = native.webkitTotalResidentBytes;
+  if (
+    shellBaselineWebkitResidentBytes === undefined &&
+    documentHydratedAtMs === undefined &&
+    native.webkitTelemetryAvailable &&
+    baselineCandidateBytes !== undefined &&
+    baselineCandidateBytes > 0
+  ) {
+    shellBaselineWebkitResidentBytes = baselineCandidateBytes;
+    shellBaselineCapturedAtMs = Date.now();
+  }
   const limits = {
     highBytes:
       native.memoryHighBytes ??
@@ -355,6 +412,27 @@ async function sampleRuntimeMemory(
     rendererHeapUsedBytes: renderer?.usedJSHeapSize,
     rendererHeapTotalBytes: renderer?.totalJSHeapSize,
     rendererHeapLimitBytes: renderer?.jsHeapSizeLimit,
+    // Absent is not zero. WebKit has no performance.memory, so on the shipping
+    // desktop app the three fields above are always undefined; without this
+    // flag that reads as "the JS heap is negligible" rather than "unmeasured".
+    rendererHeapAvailable: renderer !== null,
+    // Attribution terms. shellBaseline is captured once per launch before the
+    // document is hydrated; the delta against it is the measured cost of
+    // everything Freed loads on top of an empty renderer.
+    shellBaselineWebkitResidentBytes,
+    webkitResidentOverShellBaselineBytes:
+      shellBaselineWebkitResidentBytes === undefined ||
+      native.webkitTotalResidentBytes === undefined
+        ? undefined
+        : Math.max(
+            0,
+            native.webkitTotalResidentBytes - shellBaselineWebkitResidentBytes,
+          ),
+    shellBaselineAgeMs:
+      shellBaselineCapturedAtMs === undefined
+        ? undefined
+        : Date.now() - shellBaselineCapturedAtMs,
+    documentHydrated: documentHydratedAtMs !== undefined,
     domNodeCount,
     sampleTs: Date.now(),
   };

--- a/packages/desktop/src/lib/store.ts
+++ b/packages/desktop/src/lib/store.ts
@@ -123,6 +123,7 @@ import { initLiAuth, storeLiAuthState, type LiAuthState } from "./li-auth";
 import { initSubstackAuth, type SubstackAuthState } from "./substack-auth";
 import { initMediumAuth, type MediumAuthState } from "./medium-auth";
 import { initYouTubeAuth, type YouTubeAuthState } from "./youtube-auth";
+import { recordDocumentHydrated } from "./memory-monitor";
 import { reconcileSocialAuthStateHints } from "./social-auth-cookie-state";
 import { getOrCreateDesktopClientRegistration } from "./desktop-client-registration";
 import {
@@ -694,6 +695,9 @@ export const useAppStore = create<AppState>((set, get) => ({
         const desktopClientRegistration = await getOrCreateDesktopClientRegistration();
         assertDesktopStoreWritable();
         const docState = await initDoc(desktopClientRegistration);
+        // Closes the shell-baseline window. Any memory sample after this point
+        // includes the Automerge document, so it cannot serve as a baseline.
+        recordDocumentHydrated();
         assertDesktopStoreWritable();
         migrateLegacyDeviceDisplayPreferences(docState.preferences.display);
         migrateLegacyDeviceAIPreferences(docState.preferences.ai);

--- a/packages/ui/src/lib/debug-store.ts
+++ b/packages/ui/src/lib/debug-store.ts
@@ -106,6 +106,26 @@ export interface RuntimeMemorySnapshot {
   rendererHeapUsedBytes?: number;
   rendererHeapTotalBytes?: number;
   rendererHeapLimitBytes?: number;
+  /**
+   * False on the shipping desktop app: `performance.memory` is a Chrome
+   * extension and WebKit does not implement it, so the three fields above are
+   * always undefined there. Without this flag their absence reads as zero and
+   * invites the conclusion that the JS heap is negligible, which is a claim
+   * nobody has measured.
+   */
+  rendererHeapAvailable?: boolean;
+  /**
+   * WebKit resident bytes sampled before the Automerge document was hydrated,
+   * captured once per launch. This is the WebKit shell plus React baseline, the
+   * largest single unmeasured term in the storage roadmap's floor estimates
+   * (independent passes put it anywhere from 60 to 250 MB).
+   */
+  shellBaselineWebkitResidentBytes?: number;
+  /** Current WebKit resident minus the shell baseline: the measured cost of everything Freed loads on top of an empty renderer. */
+  webkitResidentOverShellBaselineBytes?: number;
+  shellBaselineAgeMs?: number;
+  /** Whether the document had been hydrated when this sample was taken. A baseline is only valid from a pre-hydration sample. */
+  documentHydrated?: boolean;
   domNodeCount?: number;
   sampleTs: number;
 }


### PR DESCRIPTION
(AI Generated).

## Summary
- Stage 0 of the storage roadmap (#1135). Zero behavior change, telemetry only.
- Every floor estimate in the roadmap is derived by subtracting from an observed total, and the largest term is the WebKit shell plus React baseline, estimated across four independent design passes at anywhere from 60 to 250 MB. Measure the dominant term before building against it.
- Captures webkitTotalResidentBytes once per launch from a sample taken BEFORE the document is hydrated, and reports the delta thereafter. recordDocumentHydrated closes that window at the initDoc boundary, because a baseline taken after hydration folds the document into the shell and biases every derived number favourably.
- Also fixes a silent measurement bug: rendererHeapUsedBytes reads performance.memory, a Chrome extension WebKit does not implement, so on the shipping desktop app it has always been absent. That absence read as zero and invited the conclusion that the JS heap is negligible. rendererHeapAvailable now states whether the number exists.

## Testing
- 12 desktop memory tests pass. packages/desktop tsc clean. packages/ui reports 32 errors on this branch and 32 on origin/dev, so none are introduced here.

## Provider Review
- Status: Draft publication is allowed. Ready and merge require provider authority.
- Review action: A provider CODEOWNER reacts with a GitHub thumbs-up on the generated provider review comment.
- Provider subdiff: `8445b34ff129d708051bba2566dbf77f5e52e639`
- Draft publication does not authorize new live provider traffic. Gate 1 behavior approval still applies.
- Gate 1 task: `memory-attribution-harness`
- Gate 1 artifact: `b0714b2f39d603a66e0860ac9d73c25156f9fa38b62d5ea869abb027b4385f20`
- Providers: facebook, instagram, linkedin, medium, other, substack, x, youtube
- Observable behavior: No change observable to any provider. This is measurement only: it records one extra number per sample and one boolean marking whether the document had been hydrated. No request, navigation, cookie, header, timing, or scrape behavior changes. Nothing is gated on the new fields.
- Fingerprinting risk: None. Zero behavior change of any kind; the diff adds telemetry fields and a single call that records a timestamp. No provider can observe anything different.
- Lowest profile alternative: Estimate the shell baseline instead of measuring it. Rejected because the estimate spread is 60 to 250 MB and every subsequent floor claim is derived from it.

Files bound into this provider review:
- `packages/desktop/src/lib/memory-monitor.ts`
- `packages/desktop/src/lib/store.ts`