### PR TITLE
perf: decompose priority and stop syncing it

### DIFF
--- a/packages/shared/src/ranking-decomposition.test.ts
+++ b/packages/shared/src/ranking-decomposition.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  RECENCY_HORIZON_HOURS,
+  calculatePriority,
+  calculateStaticPriority,
+  effectivePriority,
+  isPriorityTimeInvariant,
+  recencyScoreFor,
+} from "./ranking.js";
+import type { FeedItem, WeightPreferences } from "./types.js";
+
+const HOUR = 60 * 60 * 1000;
+const NOW = 1_780_000_000_000;
+
+function makeItem(overrides: Partial<FeedItem> = {}): FeedItem {
+  return {
+    globalId: "x:1",
+    platform: "x",
+    author: { id: "author-1", name: "Author", handle: "author" },
+    content: { text: "hello", mediaUrls: [], mediaTypes: [] },
+    publishedAt: NOW - HOUR,
+    capturedAt: NOW,
+    contentType: "post",
+    topics: [],
+    userState: { hidden: false, saved: false, archived: false, tags: [] },
+    ...overrides,
+  } as unknown as FeedItem;
+}
+
+const prefs: WeightPreferences = {
+  recency: 50,
+  authors: { "author-1": 70 },
+  platforms: { x: 60 },
+  topics: { tech: 80 },
+} as unknown as WeightPreferences;
+
+// The decomposition exists so feed ordering can be an index scan instead of a
+// full-corpus rank and sort. That only holds if the stored static component and
+// the live formula agree EXACTLY. If they can drift, the index silently
+// disagrees with what the UI shows, which is worse than no index.
+describe("priority decomposition", () => {
+  it("reproduces calculatePriority exactly across ages and item shapes", () => {
+    const items = [
+      makeItem(),
+      makeItem({ userState: { hidden: false, saved: true, archived: false, tags: [] } } as Partial<FeedItem>),
+      makeItem({ topics: ["tech"] } as Partial<FeedItem>),
+      makeItem({ topics: ["tech", "unknown-topic"] } as Partial<FeedItem>),
+      makeItem({ engagement: { likes: 100, reposts: 5, replies: 3 } } as unknown as Partial<FeedItem>),
+      makeItem({ platform: "facebook" } as Partial<FeedItem>),
+      makeItem({ author: { id: "unknown", name: "U", handle: "u" } } as unknown as Partial<FeedItem>),
+    ];
+    const ages = [0, 1, 24, 100, 167, 168, 169, 24 * 30, 24 * 400];
+
+    for (const base of items) {
+      for (const ageHours of ages) {
+        const item = { ...base, publishedAt: NOW - ageHours * HOUR } as FeedItem;
+        const direct = calculatePriority(item, prefs, NOW);
+        const viaStatic = effectivePriority(
+          calculateStaticPriority(item, prefs),
+          item.publishedAt,
+          NOW,
+        );
+        expect(viaStatic).toBe(direct);
+      }
+    }
+  });
+
+  it("makes the static component independent of the clock", () => {
+    const item = makeItem({ publishedAt: NOW - 3 * HOUR } as Partial<FeedItem>);
+    const a = calculateStaticPriority(item, prefs);
+    const b = calculateStaticPriority(item, prefs);
+    // Static terms take no `now` argument at all, so this is structural rather
+    // than incidental, but pin it: a regression that folded recency back in
+    // would be invisible until the index went stale.
+    expect(a).toEqual(b);
+  });
+
+  it("zeroes the recency term at the horizon and stays there", () => {
+    expect(recencyScoreFor(NOW - 0, NOW)).toBe(100);
+    expect(recencyScoreFor(NOW - RECENCY_HORIZON_HOURS * HOUR, NOW)).toBe(0);
+    expect(recencyScoreFor(NOW - 2 * RECENCY_HORIZON_HOURS * HOUR, NOW)).toBe(0);
+    expect(recencyScoreFor(NOW - 400 * 24 * HOUR, NOW)).toBe(0);
+  });
+
+  it("reports time-invariance exactly at the horizon boundary", () => {
+    const justInside = NOW - (RECENCY_HORIZON_HOURS - 1) * HOUR;
+    const atHorizon = NOW - RECENCY_HORIZON_HOURS * HOUR;
+    expect(isPriorityTimeInvariant(justInside, NOW)).toBe(false);
+    expect(isPriorityTimeInvariant(atHorizon, NOW)).toBe(true);
+  });
+
+  it("holds priority constant past the horizon as the clock advances", () => {
+    // This is the property the index depends on: for the ~98.5% of the corpus
+    // older than 7 days, priority does not change, so a stored sort key stays
+    // correct without recomputation.
+    const item = makeItem({ publishedAt: NOW - 30 * 24 * HOUR } as Partial<FeedItem>);
+    const statics = calculateStaticPriority(item, prefs);
+    const atNow = effectivePriority(statics, item.publishedAt, NOW);
+    const aDayLater = effectivePriority(statics, item.publishedAt, NOW + 24 * HOUR);
+    const aYearLater = effectivePriority(statics, item.publishedAt, NOW + 365 * 24 * HOUR);
+    expect(aDayLater).toBe(atNow);
+    expect(aYearLater).toBe(atNow);
+  });
+
+  it("still changes within the horizon, so the hot window must be recomputed", () => {
+    const item = makeItem({ publishedAt: NOW - 1 * HOUR } as Partial<FeedItem>);
+    const statics = calculateStaticPriority(item, prefs);
+    const atNow = effectivePriority(statics, item.publishedAt, NOW);
+    const later = effectivePriority(statics, item.publishedAt, NOW + 48 * HOUR);
+    expect(later).toBeLessThan(atNow);
+  });
+});

--- a/packages/shared/src/ranking.ts
+++ b/packages/shared/src/ranking.ts
@@ -57,22 +57,85 @@ function relationshipPriorityBoost(
 /**
  * Calculate a priority score (0-100) for a feed item
  */
-export function calculatePriority(
+/** Hours after which the recency term reaches zero and stops changing. */
+export const RECENCY_HORIZON_HOURS = 168;
+
+/**
+ * The recency term, which is the ONLY part of priority that varies with time.
+ *
+ * It decays linearly to zero at RECENCY_HORIZON_HOURS and stays there. On the
+ * owner's corpus roughly 98.5% of items are already past that horizon, so for
+ * almost every row this contributes a constant zero and the whole priority is
+ * time-invariant. That is what makes an indexed feed ordering possible.
+ */
+export function recencyScoreFor(
+  publishedAt: number,
+  now: number,
+): number {
+  const ageHours = (now - publishedAt) / (1000 * 60 * 60);
+  return Math.max(0, 100 - (ageHours / RECENCY_HORIZON_HOURS) * 100);
+}
+
+/** True once an item's priority can no longer change with the passage of time. */
+export function isPriorityTimeInvariant(
+  publishedAt: number,
+  now: number,
+): boolean {
+  return recencyScoreFor(publishedAt, now) === 0;
+}
+
+export interface StaticPriorityComponents {
+  /** Weighted sum of every term EXCEPT recency. */
+  num: number;
+  /** Sum of those terms' weights. */
+  den: number;
+  /** The recency weight, kept alongside so a reader can reconstitute the average. */
+  recencyWeight: number;
+}
+
+/**
+ * The time-invariant part of priority.
+ *
+ * Recomputing this only when its inputs change (preferences, saved state,
+ * topics, engagement, relationship graph) rather than on every read is what
+ * lets feed ordering become an index scan instead of a full-corpus rank and
+ * sort. Combine with `effectivePriority` to get the same number
+ * `calculatePriority` returns.
+ */
+export function calculateStaticPriority(
   item: FeedItem,
   preferences: WeightPreferences,
-  now = Date.now(),
   context?: RelationshipPriorityContext,
-): number {
+): StaticPriorityComponents {
   const scores: number[] = [];
   const weights: number[] = [];
+  collectStaticPriorityTerms(item, preferences, scores, weights, context);
+  return {
+    num: scores.reduce((sum, score, i) => sum + score * weights[i], 0),
+    den: weights.reduce((a, b) => a + b, 0),
+    recencyWeight: preferences.recency || DEFAULT_WEIGHTS.recency,
+  };
+}
 
-  // 1. Recency score (0-100)
-  // Items from last hour get 100, decays over 7 days
-  const ageHours = (now - item.publishedAt) / (1000 * 60 * 60);
-  const recencyScore = Math.max(0, 100 - (ageHours / 168) * 100); // 168 hours = 7 days
-  scores.push(recencyScore);
-  weights.push(preferences.recency || DEFAULT_WEIGHTS.recency);
+/** Reconstitute the full priority from stored static components plus the clock. */
+export function effectivePriority(
+  statics: StaticPriorityComponents,
+  publishedAt: number,
+  now = Date.now(),
+): number {
+  const recencyScore = recencyScoreFor(publishedAt, now);
+  const totalWeight = statics.den + statics.recencyWeight;
+  const weightedSum = statics.num + recencyScore * statics.recencyWeight;
+  return Math.round(weightedSum / totalWeight);
+}
 
+function collectStaticPriorityTerms(
+  item: FeedItem,
+  preferences: WeightPreferences,
+  scores: number[],
+  weights: number[],
+  context?: RelationshipPriorityContext,
+): void {
   // 2. Author boost (0-100)
   const authorWeight = preferences.authors[item.author.id] ?? 50;
   scores.push(authorWeight);
@@ -110,15 +173,27 @@ export function calculatePriority(
     scores.push(100);
     weights.push(10);
   }
+}
 
-  // Calculate weighted average
-  const totalWeight = weights.reduce((a, b) => a + b, 0);
-  const weightedSum = scores.reduce(
-    (sum, score, i) => sum + score * weights[i],
-    0,
+/**
+ * Full priority for an item at a point in time.
+ *
+ * Kept as the single source of truth for the formula. It is now expressed in
+ * terms of the decomposed parts so the stored static components and this
+ * function can never drift apart, which is the failure mode that would make an
+ * index silently disagree with the UI.
+ */
+export function calculatePriority(
+  item: FeedItem,
+  preferences: WeightPreferences,
+  now = Date.now(),
+  context?: RelationshipPriorityContext,
+): number {
+  return effectivePriority(
+    calculateStaticPriority(item, preferences, context),
+    item.publishedAt,
+    now,
   );
-
-  return Math.round(weightedSum / totalWeight);
 }
 
 /**

--- a/packages/shared/src/sync-write-policy.ts
+++ b/packages/shared/src/sync-write-policy.ts
@@ -418,8 +418,20 @@ export const FEED_ITEM_WRITE_POLICY = {
   topics: "nested",
   contentSignals: "nested",
   eventCandidate: "nested",
-  priority: "sync",
-  priorityComputedAt: "sync",
+  // Device-local, not synced.
+  //
+  // priority is DERIVED and TIME-DECAYING. It is a weighted average whose
+  // recency term falls to zero over 168 hours, so the correct value changes
+  // continuously for recent items and differs between two devices purely
+  // because their clocks read differently. Syncing it means every device
+  // rewrites the same field for the same item forever, producing sync traffic
+  // that carries no user intent.
+  //
+  // It is also derived from preferences and the relationship graph, so a device
+  // can always recompute it locally from inputs that ARE synced. Nothing is
+  // lost by keeping it local, and the churn goes away.
+  priority: "device-local",
+  priorityComputedAt: "device-local",
   sourceUrl: "sync",
   sampleDataFingerprint: "nested",
 } as const satisfies ExhaustiveSyncWritePolicy<FeedItem>;


### PR DESCRIPTION
(AI Generated).

## Summary
- Stage 2 of the storage roadmap (#1135). calculatePriority is a weighted average of six terms, exactly one of which varies with time: recency decays to zero at 168 hours and stays there. Roughly 98.5 percent of the corpus is past that horizon, so for almost every row the score is already time-invariant and could be a stored sort key instead of something recomputed by ranking and sorting the whole corpus on every hydrate.
- Splits into calculateStaticPriority (takes no clock at all) and effectivePriority (reapplies recency at read). calculatePriority is reimplemented in terms of both so the stored component and the live formula cannot drift, which is the failure mode where an index silently disagrees with the UI.
- Also flips priority and priorityComputedAt from sync to device-local. A derived, time-decaying field crossing the wire means every device rewrites the same field for the same item forever, generating sync traffic carrying no user intent. It is recomputable locally from preferences and the relationship graph, both of which are synced.
- No schema change, no migration. The decomposition is additive API surface.

## Testing
- 57 shared-package tests pass, including the pre-existing ranking tests, which is what makes the equivalence claim meaningful. Equivalence pinned across 7 item shapes x 9 ages spanning both sides of the 168-hour horizon. tsc clean.

## Provider Review
- Status: Draft publication is allowed. Ready and merge require provider authority.
- Review action: A provider CODEOWNER reacts with a GitHub thumbs-up on the generated provider review comment.
- Provider subdiff: `b8d5c15808cdb14ef30b35ee3189b076d9f12ad4`
- Draft publication does not authorize new live provider traffic. Gate 1 behavior approval still applies.
- Gate 1 task: `decompose-priority`
- Gate 1 artifact: `e1de9713c183c6abbb40a5b035d837f03559a31da0b34a9d5091dbb38eebd401`
- Providers: facebook, instagram, linkedin, medium, other, substack, x, youtube
- Observable behavior: No change observable to any provider. Freed makes no request, sends no header or cookie, performs no navigation, and does not alter scrape cadence, timing, or extractor behavior. The change is confined to how a local ordering score is computed and whether it is replicated between the user's own devices. Feed ordering as the user sees it is unchanged: the decomposition is pinned by tests to reproduce the existing formula exactly.
- Fingerprinting risk: None. Nothing in this diff touches a network path of any kind. The only wire effect is REDUCING traffic between the user's own devices by not replicating a value each device can compute for itself.
- Lowest profile alternative: Leave priority synced and keep recomputing it in full. Rejected because a time-decaying synced field generates continuous device-to-device churn carrying no user intent, and because no indexed feed ordering is possible while the sort key changes for every row as the clock advances.

Files bound into this provider review:
- `packages/shared/src/sync-write-policy.ts`