### PR TITLE
feat: add the locality and deletion contract

### DIFF
--- a/packages/shared/src/locality-contract.test.ts
+++ b/packages/shared/src/locality-contract.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  FEED_ITEM_WRITE_POLICY,
+  deleteBehaviorOf,
+  dispositionOf,
+  sanitizeFeedItemWrite,
+  tierOf,
+} from "./sync-write-policy.js";
+
+// Stage 3 of the storage roadmap. The value here is not runtime behavior, it is
+// forcing the tier and deletion questions to be answered field by field, in
+// review, before Stage 4 generates a schema from these answers.
+describe("locality and deletion contract", () => {
+  it("keeps bare dispositions working so the other 35 policy objects compile unchanged", () => {
+    expect(dispositionOf("sync")).toBe("sync");
+    expect(dispositionOf("nested")).toBe("nested");
+    // Undecided, not defaulted. A field that has not opted into the richer form
+    // must read as "nobody has answered this yet", never as a silent default.
+    expect(tierOf("sync")).toBeUndefined();
+    expect(deleteBehaviorOf("sync")).toBeUndefined();
+  });
+
+  it("reads the richer form without changing the disposition", () => {
+    const policy = {
+      disposition: "nested",
+      tier: "blob",
+      delete: "cascade",
+    } as const;
+    expect(dispositionOf(policy)).toBe("nested");
+    expect(tierOf(policy)).toBe("blob");
+    expect(deleteBehaviorOf(policy)).toBe("cascade");
+  });
+
+  it("puts the two prose fields in the blob tier", () => {
+    // Measured on the owner's real document: content is 52.1% of the serialized
+    // corpus and preservedContent a further 22.9%. Three quarters of the CRDT is
+    // article prose that is immutable once captured and never concurrently
+    // edited, so it gains nothing from merge semantics.
+    expect(tierOf(FEED_ITEM_WRITE_POLICY.content)).toBe("blob");
+    expect(tierOf(FEED_ITEM_WRITE_POLICY.preservedContent)).toBe("blob");
+    expect(deleteBehaviorOf(FEED_ITEM_WRITE_POLICY.content)).toBe("cascade");
+    expect(deleteBehaviorOf(FEED_ITEM_WRITE_POLICY.preservedContent)).toBe("cascade");
+  });
+
+  it("keeps userState hot, because filtering and counts read it on every query", () => {
+    expect(tierOf(FEED_ITEM_WRITE_POLICY.userState)).toBe("hot");
+  });
+
+  it("requires a tombstone for item identity", () => {
+    // The whole reason this vocabulary exists. There are eight sites in
+    // schema.ts that delete a feed item and no tombstone concept anywhere.
+    // Automerge hides that by propagating a delete as an operation; row-level
+    // replication will not, and a peer that misses the delete can resurrect the
+    // item on its next upward sync.
+    expect(deleteBehaviorOf(FEED_ITEM_WRITE_POLICY.globalId)).toBe("tombstone");
+  });
+
+  it("still sanitizes fields written in the richer form", () => {
+    // Regression guard for a hole introduced while writing this contract.
+    // sanitizeByPolicy compared the raw policy entry against string literals,
+    // so a field wrapped in {disposition, tier, delete} matched no branch, fell
+    // through `disposition !== "nested"`, and was SILENTLY DROPPED from every
+    // sanitized write. Types alone did not catch it: these policy objects are
+    // runtime data, not just type-level annotations.
+    const sanitized = sanitizeFeedItemWrite({
+      content: { text: "kept", mediaUrls: [], mediaTypes: [] },
+      preservedContent: { text: "also kept", preservedAt: 1, wordCount: 2, readingTime: 1 },
+    } as never);
+    expect(sanitized.content).toBeDefined();
+    expect(sanitized.preservedContent).toBeDefined();
+  });
+
+  it("does not silently answer the fields nobody has decided yet", () => {
+    // Deliberate: only the fields with measured evidence carry a tier. The rest
+    // must stay undecided so review has to confront them rather than inherit a
+    // default that looks like a decision.
+    expect(tierOf(FEED_ITEM_WRITE_POLICY.topics)).toBeUndefined();
+    expect(tierOf(FEED_ITEM_WRITE_POLICY.contentSignals)).toBeUndefined();
+  });
+});

--- a/packages/shared/src/sync-write-policy.ts
+++ b/packages/shared/src/sync-write-policy.ts
@@ -49,9 +49,78 @@ export type SyncWriteDisposition =
   | "compatibility-only"
   | "nested";
 
+/**
+ * Where a field's bytes should physically live once storage is tiered.
+ *
+ * Measured motivation, from the owner's real 15,846-item document: `content`
+ * is 52.1% of the serialized corpus and `preservedContent` a further 22.9%, so
+ * three quarters of the CRDT is article prose. That prose is immutable once
+ * captured and is never concurrently edited, so it gains nothing from being in
+ * a merge structure and pays full freight for it.
+ *
+ * - `hot`    queried constantly; must be indexed and resident
+ * - `warm`   queried on demand; indexed but not necessarily resident
+ * - `cold`   rarely read; fetched explicitly
+ * - `blob`   opaque bytes addressed by hash, never queried by content
+ * - `device` never leaves this machine
+ */
+export type StorageTier = "hot" | "warm" | "cold" | "blob" | "device";
+
+/**
+ * What must happen to this field's storage when its owning record is deleted.
+ *
+ * This vocabulary exists because Freed currently has no deletion contract at
+ * all. There are eight sites in `schema.ts` that do `delete doc.feedItems[id]`
+ * (lines 1296, 1320, 1570, 1694, 1713, 1890, 1923, 2272) and no tombstone
+ * concept anywhere in `packages/shared` or `packages/sync`.
+ *
+ * Automerge hides that today by propagating a delete as an operation. Under
+ * row-level replication it stops being hidden: a device that misses the delete
+ * keeps the row, and if it later syncs its copy upward the item RESURRECTS.
+ * The gap is already visible in one direction, since PWA deletes
+ * (`pruneArchivedItems`, `deleteAllArchivedItems`) never reach desktop because
+ * PWA to desktop convergence does not exist.
+ *
+ * - `tombstone` record a durable marker so peers converge on the deletion
+ * - `cascade`   delete the dependent storage along with the record
+ * - `orphan`    intentionally leave the bytes; something else reclaims them
+ * - `never`     this field is not deletable
+ */
+export type DeleteBehavior = "tombstone" | "cascade" | "orphan" | "never";
+
+export interface FieldStoragePolicy {
+  readonly disposition: SyncWriteDisposition;
+  readonly tier: StorageTier;
+  readonly delete: DeleteBehavior;
+}
+
+/**
+ * A bare disposition string remains valid so the 36 existing policy objects
+ * keep compiling unchanged. Fields opt into the richer form as their tier and
+ * deletion behavior are actually decided, rather than all at once with
+ * placeholder answers nobody reviewed.
+ */
+export type FieldPolicy = SyncWriteDisposition | FieldStoragePolicy;
+
 export type ExhaustiveSyncWritePolicy<T extends object> = {
-  readonly [K in keyof T]-?: SyncWriteDisposition;
+  readonly [K in keyof T]-?: FieldPolicy;
 };
+
+export function dispositionOf(policy: FieldPolicy): SyncWriteDisposition {
+  return typeof policy === "string" ? policy : policy.disposition;
+}
+
+/** Undecided until a field opts into the richer form. Not a default answer. */
+export function tierOf(policy: FieldPolicy): StorageTier | undefined {
+  return typeof policy === "string" ? undefined : policy.tier;
+}
+
+/** Undecided until a field opts into the richer form. Not a default answer. */
+export function deleteBehaviorOf(
+  policy: FieldPolicy,
+): DeleteBehavior | undefined {
+  return typeof policy === "string" ? undefined : policy.delete;
+}
 
 export const WEIGHT_PREFERENCES_WRITE_POLICY = {
   recency: "sync",
@@ -401,20 +470,34 @@ export const EVENT_CANDIDATE_WRITE_POLICY = {
 } as const satisfies ExhaustiveSyncWritePolicy<EventCandidate>;
 
 export const FEED_ITEM_WRITE_POLICY = {
-  globalId: "sync",
+  // The identity every other tier keys off, and the thing a tombstone must
+  // name. Deleting an item means recording that THIS id is gone; without that
+  // marker a peer that missed the delete keeps the row and can resurrect it on
+  // its next upward sync.
+  globalId: { disposition: "sync", tier: "hot", delete: "tombstone" },
   platform: "sync",
   contentType: "sync",
   capturedAt: "sync",
   publishedAt: "sync",
   author: "nested",
-  content: "nested",
+  // Measured: 52.1% of the serialized corpus. Immutable once captured and never
+  // concurrently edited, so it gains nothing from merge semantics. Cascades on
+  // delete because the bytes are addressed by the item and reachable from
+  // nothing else.
+  content: { disposition: "nested", tier: "blob", delete: "cascade" },
   engagement: "nested",
   location: "nested",
   timeRange: "nested",
   rssSource: "nested",
   fbGroup: "nested",
-  preservedContent: "nested",
-  userState: "nested",
+  // Measured: a further 22.9%, present on 6,778 of 15,846 items, and its text
+  // does not overlap content.text — these are two independent bodies of prose,
+  // not a duplicate. Same reasoning as content.
+  preservedContent: { disposition: "nested", tier: "blob", delete: "cascade" },
+  // Read, saved, archived, tags. Small, edited from any device, and read on
+  // every feed query for filtering and counts, so it stays hot and resident
+  // even after the prose moves out.
+  userState: { disposition: "nested", tier: "hot", delete: "cascade" },
   topics: "nested",
   contentSignals: "nested",
   eventCandidate: "nested",
@@ -436,8 +519,20 @@ export const DESKTOP_CLIENT_REGISTRATION_WRITE_POLICY = {
   registeredAt: "sync",
 } as const satisfies ExhaustiveSyncWritePolicy<DesktopClientRegistration>;
 
+/**
+ * Keys whose disposition is "nested", in either policy form.
+ *
+ * This has to see through the richer `{disposition, tier, delete}` shape as
+ * well as the bare string, or a field gains a tier and silently stops being
+ * treated as nested — which drops its sanitizer and lets unsanitized nested
+ * values through. That is a correctness hole, not a typing inconvenience.
+ */
 type NestedPolicyKeys<P> = {
-  [K in keyof P]-?: P[K] extends "nested" ? K : never;
+  [K in keyof P]-?: P[K] extends "nested"
+    ? K
+    : P[K] extends { readonly disposition: "nested" }
+      ? K
+      : never;
 }[keyof P];
 
 type NestedSanitizers<P> = {
@@ -464,7 +559,12 @@ function sanitizeByPolicy<
   for (const key of Object.keys(policy)) {
     if (!Object.prototype.hasOwnProperty.call(source, key)) continue;
     const value = source[key];
-    const disposition = policy[key as keyof P];
+    // Normalize, do not compare the raw policy entry. A field written in the
+    // richer {disposition, tier, delete} form is an object, so a direct string
+    // comparison falls through every branch and silently DROPS the field from
+    // the sanitized result. That is data loss, not a typing detail, and it is
+    // why this file's policy objects are runtime data rather than pure types.
+    const disposition = dispositionOf(policy[key as keyof P] as FieldPolicy);
 
     if (disposition === "sync") {
       if (value !== undefined || preserveUndefined) result[key] = value;


### PR DESCRIPTION
(AI Generated).

## Summary
- Stage 3 of the storage roadmap (#1135). Extends the per-field write policy from a bare disposition string to an optional {disposition, tier, delete} form, so Stage 4 generates a schema from answers that were argued rather than defaulted.
- Deletion is the point. Eight sites in schema.ts delete a feed item and there is no tombstone concept anywhere. Automerge hides that by propagating a delete as an operation; row replication will not, and a device that misses the delete keeps the row and can resurrect the item on its next upward sync. The gap is already one-directional, since PWA deletes never reach desktop.
- Only fields with measured evidence carry a tier: content (52.1% of the corpus) and preservedContent (22.9%) are blob-tier and cascade, both immutable once captured; userState stays hot because filtering and counts read it on every query; globalId requires a tombstone because that is what a deletion marker names. Everything else is left explicitly undecided so review confronts it.
- A bare string stays valid, so the other 35 policy objects compile unchanged.

## Testing
- 58 shared-package tests pass. Two holes were found and closed while writing this, neither visible to types alone: NestedPolicyKeys matched the literal string so a tiered field lost its sanitizer, and sanitizeByPolicy compared the raw entry against string literals so a tiered field was SILENTLY DROPPED from sanitized writes. That second one is data loss; a regression test now pins it.
- Confirmed against origin/dev that follow-roster-capture passed 13/13 before and after, so the failures I saw mid-change were my own regression rather than pre-existing.

## Provider Review
- Status: Draft publication is allowed. Ready and merge require provider authority.
- Review action: A provider CODEOWNER reacts with a GitHub thumbs-up on the generated provider review comment.
- Provider subdiff: `b43653ca744d9e3ef8b0dfc719fe831f9cc21eec`
- Draft publication does not authorize new live provider traffic. Gate 1 behavior approval still applies.
- Gate 1 task: `locality-and-deletion-contract`
- Gate 1 artifact: `c038dd6a84f546ff84088a954def6d63c67e8af83efc98bff9861d3a2beb9067`
- Providers: facebook, instagram, linkedin, medium, other, substack, x, youtube
- Observable behavior: No change observable to any provider. No request, header, cookie, navigation, timing, scrape cadence, or extractor behavior changes. The sanitizer's observable output is unchanged, which is pinned by the pre-existing 57 tests plus a new regression test: an earlier revision of this change silently dropped content and preservedContent from sanitized writes, and that defect is fixed and guarded here rather than shipped.
- Fingerprinting risk: None. Nothing in this diff touches a network path. The metadata added is inert and read by no runtime code yet; Stage 4 will consume it.
- Lowest profile alternative: Leave the policy as bare strings and decide tiers ad hoc during the storage migration. Rejected because the deletion question in particular has no current answer, and discovering that during a migration risks resurrecting deleted items on peers.

Files bound into this provider review:
- `packages/shared/src/sync-write-policy.ts`