### PR TITLE
feat(shared): project feed items to flat rows with a losslessness proof

### DIFF
--- a/packages/shared/src/projection.test.ts
+++ b/packages/shared/src/projection.test.ts
@@ -1,0 +1,201 @@
+import { existsSync, readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  blobTierFields,
+  deviceLocalFields,
+  diffProjection,
+  projectFeedItem,
+  reconstructFeedItem,
+} from "./projection.js";
+import type { FeedItem } from "./types.js";
+
+/**
+ * Stage 4 of the storage roadmap. Nothing reads the projected rows yet, so
+ * there is no behavior to test. What is being tested is a property: the
+ * projection is reversible. Stage 8 turns the write path one-way, and once the
+ * retained Automerge copy is pruned, a field the projector drops is gone. This
+ * file is the evidence that has to exist before that is allowed to happen.
+ *
+ * The round-trip is asserted with `toStrictEqual`, which distinguishes a
+ * missing key from a key holding undefined. That distinction is the whole
+ * subject of half these cases.
+ */
+
+function roundTrip(item: unknown): unknown {
+  return reconstructFeedItem(projectFeedItem(item as FeedItem));
+}
+
+function expectLossless(item: Record<string, unknown>): void {
+  expect(roundTrip(item)).toStrictEqual(item);
+}
+
+const complete: Record<string, unknown> = {
+  globalId: "x:1",
+  platform: "x",
+  contentType: "post",
+  publishedAt: 1_780_000_000_000,
+  capturedAt: 1_780_000_001_000,
+  author: { id: "a:1", handle: "someone", displayName: "Someone", avatarUrl: "https://e/a.png" },
+  sourceUrl: "https://example.test/1",
+  content: { text: "hello", mediaUrls: [], mediaTypes: [] },
+  preservedContent: { text: "hello", preservedAt: 1, wordCount: 1, readingTime: 1 },
+  userState: { hidden: false, saved: true, archived: false, tags: ["a", "b"], readAt: 7 },
+  topics: ["tech"],
+  engagement: { likes: 3, reposts: 0, replies: 1 },
+};
+
+describe("feed item projection", () => {
+  it("round-trips a fully populated item", () => {
+    expectLossless(complete);
+  });
+
+  it("preserves absence instead of inventing a default", () => {
+    // The bug this pins cost a full corpus pass to find. The first draft wrote
+    // `String(author.name ?? "")` and `asEpoch(publishedAt) ?? 0`, which turns
+    // "never set" into "empty string" and "epoch zero". Under Stage 8 that
+    // fabrication is unrecoverable, because there is no second copy to
+    // reconstruct the truth from.
+    const sparse = { globalId: "x:2", author: { id: "a:2" }, userState: { saved: true } };
+    const back = roundTrip(sparse) as Record<string, unknown>;
+    expect(back).toStrictEqual(sparse);
+    expect("publishedAt" in back).toBe(false);
+    expect("platform" in back).toBe(false);
+    expect("displayName" in (back.author as object)).toBe(false);
+    expect("hidden" in (back.userState as object)).toBe(false);
+  });
+
+  it("tells a null value apart from a missing one", () => {
+    // Both produce a null column. Only `__absent` can distinguish them, which
+    // is why the column alone is not the whole record.
+    const withNull = { globalId: "x:3", sourceUrl: null, publishedAt: null };
+    const back = roundTrip(withNull) as Record<string, unknown>;
+    expect(back).toStrictEqual(withNull);
+    expect("sourceUrl" in back).toBe(true);
+    expect(back.sourceUrl).toBeNull();
+  });
+
+  it("projects against the real field names on Author", () => {
+    // The first draft read `author.name`, which does not exist on Author (it is
+    // `displayName`). tsc did not catch it, because the projector had cast the
+    // author to Record<string, unknown> to read it. The cast added to silence
+    // the compiler is what hid the bug from the compiler.
+    const row = projectFeedItem(complete as unknown as FeedItem);
+    expect(row.authorDisplayName).toBe("Someone");
+    expect(row.authorHandle).toBe("someone");
+    expect(row.authorId).toBe("a:1");
+  });
+
+  it("carries unmodelled fields through untouched", () => {
+    // Losslessness has to hold by construction, not by keeping a list current.
+    // A field nobody thought about when writing the schema still survives.
+    const exotic = {
+      ...complete,
+      someFutureField: { nested: { deeply: [1, 2, { three: true }] } },
+      anotherOne: "value",
+    };
+    expectLossless(exotic);
+  });
+
+  it("carries unmodelled userState and author keys through untouched", () => {
+    const extra = {
+      ...complete,
+      userState: { ...(complete.userState as object), likedSyncedAt: null, hiddenSyncedAt: 42 },
+      author: { ...(complete.author as object), verified: true },
+    };
+    expectLossless(extra);
+  });
+
+  it("preserves non-finite numbers that JSON alone would flatten to null", () => {
+    // Three items in the owner's 15,846-item corpus hold NaN in
+    // preservedContent.publishedAt, from an upstream date parse. JSON.stringify
+    // renders all three non-finite values as null. Rewriting them would be a
+    // data repair performed by the storage layer, which is the wrong place to
+    // decide that, so they are encoded and restored exactly.
+    const nonFinite = {
+      globalId: "x:4",
+      preservedContent: { publishedAt: NaN, a: Infinity, b: -Infinity },
+    };
+    const back = roundTrip(nonFinite) as Record<string, unknown>;
+    const preserved = back.preservedContent as Record<string, number>;
+    expect(Number.isNaN(preserved.publishedAt)).toBe(true);
+    expect(preserved.a).toBe(Infinity);
+    expect(preserved.b).toBe(-Infinity);
+  });
+
+  it("preserves a value a column cannot represent", () => {
+    // Columns are a query optimization over a document with no enforced schema.
+    // `publishedAt` is declared number, but nothing stopped a past writer from
+    // putting a string there. The row keeps the column null and the real value
+    // comes back unchanged.
+    const wrongTypes = { globalId: "x:5", publishedAt: "2026-01-01", hidden: 1 };
+    expectLossless(wrongTypes);
+    expect(projectFeedItem(wrongTypes as unknown as FeedItem).publishedAt).toBeNull();
+  });
+
+  it("preserves author and userState when they are not objects at all", () => {
+    // Each is spread across several columns, so a non-object has nowhere to go.
+    // Without the escape it would reconstruct as {}, silently.
+    expectLossless({ globalId: "x:6", author: null, userState: null });
+    expectLossless({ globalId: "x:7", author: "unexpected" });
+  });
+
+  it("keeps the blob-tier fields out of the row columns", () => {
+    // The Stage 3 contract, not this file, decides which fields are blob-tier.
+    // Reading it back here is what keeps the two from drifting apart.
+    expect(blobTierFields().sort()).toStrictEqual(["content", "preservedContent"]);
+    const row = projectFeedItem(complete as unknown as FeedItem);
+    for (const field of blobTierFields()) {
+      expect(row.rest).not.toContain(`"${field}"`);
+    }
+    expect(row.contentBlob).toContain("hello");
+    expect(row.preservedBlob).toContain("preservedAt");
+  });
+
+  it("never projects a device-local field into a row", () => {
+    const row = projectFeedItem(complete as unknown as FeedItem);
+    const serialized = JSON.stringify(row);
+    for (const field of deviceLocalFields()) {
+      expect(serialized).not.toContain(`"${field}"`);
+    }
+  });
+
+  it("reports a mismatch when the projection actually loses something", () => {
+    // A differ that cannot fail proves nothing. Corrupt a row by hand and
+    // confirm the comparison catches it.
+    const row = projectFeedItem(complete as unknown as FeedItem);
+    const back = reconstructFeedItem({ ...row, authorDisplayName: "Somebody Else" });
+    expect((back.author as Record<string, unknown>).displayName).toBe("Somebody Else");
+    expect(back).not.toStrictEqual(complete);
+  });
+});
+
+/**
+ * The synthetic cases above were all written after the fact, each one pinning
+ * something the corpus run had already caught. That ordering is the point: the
+ * real document found two bugs that no case here would have been written to
+ * look for. It stays opt-in because the fixture is the owner's private data and
+ * cannot live in the repository.
+ */
+const fixture = process.env.FREED_CORPUS_FIXTURE;
+const hasFixture = fixture !== undefined && fixture !== "" && existsSync(fixture);
+
+describe.skipIf(!hasFixture)("projection against a real corpus", () => {
+  it("loses nothing across every item in the document", async () => {
+    const automerge = await import("@automerge/automerge");
+    const doc = automerge.load(new Uint8Array(readFileSync(fixture as string)));
+    const items = Object.keys((doc as { feedItems?: object }).feedItems ?? {}).length;
+    expect(items).toBeGreaterThan(0);
+
+    const mismatches = diffProjection(doc as never);
+    if (mismatches.length > 0) {
+      const sample = mismatches
+        .slice(0, 10)
+        .map((m) => `${m.globalId} ${m.path}: ${String(m.original)} -> ${String(m.roundTripped)}`);
+      throw new Error(
+        `${mismatches.length} of ${items} items did not survive the round trip:\n${sample.join("\n")}`,
+      );
+    }
+  }, 120_000);
+});

--- a/packages/shared/src/projection.ts
+++ b/packages/shared/src/projection.ts
@@ -1,0 +1,456 @@
+/**
+ * Projection of the Automerge document into flat rows for the shadow store.
+ *
+ * Stage 4 of the storage roadmap. Nothing reads these rows yet. The entire
+ * point of this stage is to prove, against a real corpus, that the projection
+ * loses nothing before any surface depends on it. Stage 8 makes the write path
+ * one-way; a field silently dropped by the projector becomes unrecoverable once
+ * the retained Automerge copy is pruned, so the differ below is the safeguard
+ * that has to exist first.
+ *
+ * Two rules earn their keep here, both learned from the differ failing:
+ *
+ * 1. Absence is data. An early draft wrote `String(author.name ?? "")` and
+ *    `asEpoch(publishedAt) ?? 0`, which turns "this field was never set" into
+ *    "this field is empty string / epoch zero". That is fabrication, and it is
+ *    irreversible. Every modelled path that is missing is recorded in
+ *    `__absent` so reconstruction can omit it again. A column holding null
+ *    means present-and-null, which is a different fact.
+ *
+ * 2. Untyped reads are the enemy. The same draft read `author.name`, a field
+ *    that does not exist on `Author` (it is `displayName`), and the cast to
+ *    Record<string, unknown> hid that from tsc. Reads go through the declared
+ *    types wherever possible so the compiler stays useful.
+ *
+ * Deliberately pure and dependency-free. It runs identically in the worker, in
+ * a test, and eventually against rows read back out of SQLite, which is what
+ * makes a round-trip comparison meaningful.
+ */
+
+import { FEED_ITEM_WRITE_POLICY, dispositionOf, tierOf } from "./sync-write-policy.js";
+import type { FreedDoc } from "./schema.js";
+import type { FeedItem } from "./types.js";
+
+/** Columns that live in the row itself, queried directly. */
+export interface FeedItemRow {
+  globalId: string;
+  platform: string | null;
+  contentType: string | null;
+  publishedAt: number | null;
+  capturedAt: number | null;
+  authorId: string | null;
+  authorDisplayName: string | null;
+  authorHandle: string | null;
+  sourceUrl: string | null;
+  /** userState, flattened because filtering and counts read it on every query. */
+  hidden: number | null;
+  saved: number | null;
+  archived: number | null;
+  readAt: number | null;
+  archivedAt: number | null;
+  likedAt: number | null;
+  tags: string | null;
+  /** Blob-tier payloads, addressed by the row and stored outside it. */
+  contentBlob: string | null;
+  preservedBlob: string | null;
+  /** Everything the columns above do not model, preserved verbatim. */
+  rest: string;
+}
+
+/**
+ * Fields represented by a dedicated column above. Anything NOT listed here is
+ * carried in `rest`, which is what makes the projection lossless by
+ * construction rather than by remembering to update it.
+ */
+const MODELLED_FIELDS: ReadonlySet<string> = new Set([
+  "globalId",
+  "platform",
+  "contentType",
+  "publishedAt",
+  "capturedAt",
+  "author",
+  "sourceUrl",
+  "userState",
+  "content",
+  "preservedContent",
+]);
+
+/** userState keys with their own column. The rest ride along in `__userState`. */
+const MODELLED_USER_STATE: ReadonlySet<string> = new Set([
+  "hidden",
+  "saved",
+  "archived",
+  "readAt",
+  "archivedAt",
+  "likedAt",
+  "tags",
+]);
+
+/** author keys with their own column. The rest ride along in `__author`. */
+const MODELLED_AUTHOR: ReadonlySet<string> = new Set(["id", "displayName", "handle"]);
+
+/**
+ * Tracks the two ways a typed column can fail to be the whole truth.
+ *
+ * `absent` records dotted paths that were missing, so a null column can still
+ * be told apart from a missing one. `raw` records paths whose value the column
+ * cannot represent, with the real value carried alongside.
+ *
+ * `raw` is what makes losslessness structural instead of true-by-luck. Columns
+ * are a query optimization layered over a document with no enforced schema:
+ * `publishedAt` is declared `number`, but nothing stopped a past write from
+ * putting NaN or a string there, and three items in the owner's corpus prove
+ * the declared type is not a guarantee. Rather than trusting every historical
+ * writer, anything that does not fit its column falls back to `raw` and comes
+ * back out unchanged.
+ */
+class ColumnEscapes {
+  private readonly absentPaths: string[] = [];
+  private readonly rawValues: Record<string, unknown> = {};
+
+  /** Returns the value when the key exists, and notes the absence when it does not. */
+  read(container: Record<string, unknown> | undefined, key: string, path: string): unknown {
+    if (container === undefined || !Object.prototype.hasOwnProperty.call(container, key)) {
+      this.absentPaths.push(path);
+      return undefined;
+    }
+    return container[key];
+  }
+
+  /**
+   * Coerce a value into its column. When the coercion is not faithful, keep the
+   * column null and stash the original so reconstruction can restore it.
+   */
+  column<T>(value: unknown, path: string, coerce: (v: unknown) => T | null): T | null {
+    if (value === undefined || value === null) return null;
+    const coerced = coerce(value);
+    if (coerced === null) {
+      this.rawValues[path] = value;
+      return null;
+    }
+    return coerced;
+  }
+
+  /**
+   * Read a field whose contents are spread across several columns. Returns the
+   * object to project from, or undefined when there is nothing to spread —
+   * either because the field is missing, or because it is present but not an
+   * object, in which case it is preserved verbatim in `raw`.
+   */
+  subObject(
+    container: Record<string, unknown>,
+    key: string,
+  ): Record<string, unknown> | undefined {
+    const value = this.read(container, key, key);
+    if (value === undefined) return undefined;
+    if (value === null || typeof value !== "object" || Array.isArray(value)) {
+      this.rawValues[key] = value;
+      return undefined;
+    }
+    return value as Record<string, unknown>;
+  }
+
+  absent(): string[] {
+    return this.absentPaths;
+  }
+
+  raw(): Record<string, unknown> {
+    return this.rawValues;
+  }
+}
+
+/**
+ * JSON cannot represent NaN or the infinities; `JSON.stringify` emits `null`
+ * for all three. The owner's corpus contains three items whose
+ * `preservedContent.publishedAt` is NaN, from an upstream date parse that
+ * produced an invalid Date. Silently rewriting those to null would be a data
+ * repair performed by the storage layer, which is the wrong place for it: the
+ * projector's contract is to be a faithful pipe, and repairing corrupt
+ * timestamps is a separate change with its own migration and its own review.
+ * So they are encoded and restored exactly, and the corpus defect stays
+ * visible to whoever fixes it.
+ */
+const NON_FINITE_TAG = "__nonFinite";
+
+function jsonReplacer(this: unknown, _key: string, value: unknown): unknown {
+  // `this[key]` would give the pre-toJSON value; `value` is what gets written,
+  // which is what has to survive, so test that.
+  if (typeof value === "number" && !Number.isFinite(value)) {
+    return { [NON_FINITE_TAG]: String(value) };
+  }
+  return value;
+}
+
+function jsonReviver(_key: string, value: unknown): unknown {
+  if (value !== null && typeof value === "object" && NON_FINITE_TAG in value) {
+    return Number((value as Record<string, string>)[NON_FINITE_TAG]);
+  }
+  return value;
+}
+
+export function encodeJson(value: unknown): string {
+  return JSON.stringify(value, jsonReplacer);
+}
+
+export function decodeJson(text: string): unknown {
+  return JSON.parse(text, jsonReviver);
+}
+
+function asNumberColumn(value: unknown): number | null {
+  // Only finite numbers survive a SQLite numeric column and a JSON round trip.
+  // Anything else is left for the differ to flag rather than silently coerced.
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function asStringColumn(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+function asBoolColumn(value: unknown): number | null {
+  return typeof value === "boolean" ? (value ? 1 : 0) : null;
+}
+
+export function projectFeedItem(item: FeedItem): FeedItemRow {
+  const absent = new ColumnEscapes();
+  const raw = item as unknown as Record<string, unknown>;
+
+  // `author` and `userState` are spread across several columns each, so a value
+  // that is present but not an object has nowhere to go. Route it to the raw
+  // escape rather than letting reconstruction rebuild `null` as `{}`. The
+  // corpus contains no such value; this holds the invariant structurally so a
+  // future writer cannot quietly break it.
+  const author = absent.subObject(raw, "author");
+  const userState = absent.subObject(raw, "userState");
+
+  const rest: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(raw)) {
+    if (MODELLED_FIELDS.has(key)) continue;
+    rest[key] = value;
+  }
+
+  // userState carries more than the flattened flags (sync acknowledgement
+  // timestamps, likedSyncedAt's three-state sentinel). Keep the remainder so a
+  // round trip reproduces it exactly.
+  if (userState !== undefined) {
+    const userStateRest: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(userState)) {
+      if (MODELLED_USER_STATE.has(key)) continue;
+      userStateRest[key] = value;
+    }
+    if (Object.keys(userStateRest).length > 0) rest.__userState = userStateRest;
+  }
+
+  if (author !== undefined) {
+    const authorRest: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(author)) {
+      if (MODELLED_AUTHOR.has(key)) continue;
+      authorRest[key] = value;
+    }
+    if (Object.keys(authorRest).length > 0) rest.__author = authorRest;
+  }
+
+  const platform = absent.read(raw, "platform", "platform");
+  const contentType = absent.read(raw, "contentType", "contentType");
+  const publishedAt = absent.read(raw, "publishedAt", "publishedAt");
+  const capturedAt = absent.read(raw, "capturedAt", "capturedAt");
+  const sourceUrl = absent.read(raw, "sourceUrl", "sourceUrl");
+  const content = absent.read(raw, "content", "content");
+  const preserved = absent.read(raw, "preservedContent", "preservedContent");
+
+  const authorId = author && absent.read(author, "id", "author.id");
+  const authorDisplayName =
+    author && absent.read(author, "displayName", "author.displayName");
+  const authorHandle = author && absent.read(author, "handle", "author.handle");
+
+  const hidden = userState && absent.read(userState, "hidden", "userState.hidden");
+  const saved = userState && absent.read(userState, "saved", "userState.saved");
+  const archived = userState && absent.read(userState, "archived", "userState.archived");
+  const readAt = userState && absent.read(userState, "readAt", "userState.readAt");
+  const archivedAt = userState && absent.read(userState, "archivedAt", "userState.archivedAt");
+  const likedAt = userState && absent.read(userState, "likedAt", "userState.likedAt");
+  const tags = userState && absent.read(userState, "tags", "userState.tags");
+
+  const row: FeedItemRow = {
+    globalId: String(item.globalId),
+    platform: absent.column(platform, "platform", asStringColumn),
+    contentType: absent.column(contentType, "contentType", asStringColumn),
+    publishedAt: absent.column(publishedAt, "publishedAt", asNumberColumn),
+    capturedAt: absent.column(capturedAt, "capturedAt", asNumberColumn),
+    authorId: absent.column(authorId, "author.id", asStringColumn),
+    authorDisplayName: absent.column(
+      authorDisplayName,
+      "author.displayName",
+      asStringColumn,
+    ),
+    authorHandle: absent.column(authorHandle, "author.handle", asStringColumn),
+    sourceUrl: absent.column(sourceUrl, "sourceUrl", asStringColumn),
+    hidden: absent.column(hidden, "userState.hidden", asBoolColumn),
+    saved: absent.column(saved, "userState.saved", asBoolColumn),
+    archived: absent.column(archived, "userState.archived", asBoolColumn),
+    readAt: absent.column(readAt, "userState.readAt", asNumberColumn),
+    archivedAt: absent.column(archivedAt, "userState.archivedAt", asNumberColumn),
+    likedAt: absent.column(likedAt, "userState.likedAt", asNumberColumn),
+    tags: tags === undefined ? null : encodeJson(tags),
+    contentBlob: content === undefined ? null : encodeJson(content),
+    preservedBlob: preserved === undefined ? null : encodeJson(preserved),
+    rest: "",
+  };
+
+  // Written last: the escape records are only complete once every column above
+  // has been attempted.
+  const absentPaths = absent.absent();
+  if (absentPaths.length > 0) rest.__absent = absentPaths;
+  const rawValues = absent.raw();
+  if (Object.keys(rawValues).length > 0) rest.__raw = rawValues;
+  row.rest = encodeJson(rest);
+  return row;
+}
+
+/** Reconstruct the item a row came from. Used by the differ, not by the app. */
+export function reconstructFeedItem(row: FeedItemRow): Record<string, unknown> {
+  const rest = decodeJson(row.rest) as Record<string, unknown>;
+  const userStateRest = (rest.__userState ?? undefined) as Record<string, unknown> | undefined;
+  const authorRest = (rest.__author ?? undefined) as Record<string, unknown> | undefined;
+  const absent = new Set((rest.__absent ?? []) as string[]);
+  const rawValues = (rest.__raw ?? {}) as Record<string, unknown>;
+  delete rest.__userState;
+  delete rest.__author;
+  delete rest.__absent;
+  delete rest.__raw;
+
+  const put = (
+    target: Record<string, unknown>,
+    key: string,
+    path: string,
+    value: unknown,
+  ): void => {
+    if (absent.has(path)) return;
+    // A raw override always wins: the column was null because it could not hold
+    // the real value, not because the value was null.
+    target[key] = Object.prototype.hasOwnProperty.call(rawValues, path)
+      ? rawValues[path]
+      : value;
+  };
+
+  const item: Record<string, unknown> = { globalId: row.globalId };
+  put(item, "platform", "platform", row.platform);
+  put(item, "contentType", "contentType", row.contentType);
+  put(item, "publishedAt", "publishedAt", row.publishedAt);
+  put(item, "capturedAt", "capturedAt", row.capturedAt);
+  put(item, "sourceUrl", "sourceUrl", row.sourceUrl);
+
+  if (Object.prototype.hasOwnProperty.call(rawValues, "author")) {
+    item.author = rawValues.author;
+  } else if (!absent.has("author")) {
+    const author: Record<string, unknown> = {};
+    put(author, "id", "author.id", row.authorId);
+    put(author, "displayName", "author.displayName", row.authorDisplayName);
+    put(author, "handle", "author.handle", row.authorHandle);
+    Object.assign(author, authorRest ?? {});
+    item.author = author;
+  }
+
+  if (Object.prototype.hasOwnProperty.call(rawValues, "userState")) {
+    item.userState = rawValues.userState;
+  } else if (!absent.has("userState")) {
+    const userState: Record<string, unknown> = {};
+    put(userState, "hidden", "userState.hidden", row.hidden === null ? null : row.hidden === 1);
+    put(userState, "saved", "userState.saved", row.saved === null ? null : row.saved === 1);
+    put(
+      userState,
+      "archived",
+      "userState.archived",
+      row.archived === null ? null : row.archived === 1,
+    );
+    put(userState, "readAt", "userState.readAt", row.readAt);
+    put(userState, "archivedAt", "userState.archivedAt", row.archivedAt);
+    put(userState, "likedAt", "userState.likedAt", row.likedAt);
+    put(
+      userState,
+      "tags",
+      "userState.tags",
+      row.tags === null ? null : decodeJson(row.tags),
+    );
+    Object.assign(userState, userStateRest ?? {});
+    item.userState = userState;
+  }
+
+  if (!absent.has("content")) {
+    item.content = row.contentBlob === null ? null : decodeJson(row.contentBlob);
+  }
+  if (!absent.has("preservedContent")) {
+    item.preservedContent =
+      row.preservedBlob === null ? null : decodeJson(row.preservedBlob);
+  }
+
+  Object.assign(item, rest);
+  return item;
+}
+
+export interface ProjectionMismatch {
+  globalId: string;
+  path: string;
+  original: unknown;
+  roundTripped: unknown;
+}
+
+/** Deep structural comparison, order-insensitive for object keys. */
+function collectMismatches(
+  original: unknown,
+  roundTripped: unknown,
+  path: string,
+  globalId: string,
+  out: ProjectionMismatch[],
+): void {
+  // Object.is rather than ===, on both counts: NaN must compare equal to the
+  // NaN it round-tripped into, and +0 must NOT compare equal to -0, which is a
+  // real difference a numeric column can introduce.
+  if (Object.is(original, roundTripped)) return;
+  const bothObjects =
+    original !== null &&
+    roundTripped !== null &&
+    typeof original === "object" &&
+    typeof roundTripped === "object";
+  if (!bothObjects) {
+    out.push({ globalId, path, original, roundTripped });
+    return;
+  }
+  if (Array.isArray(original) !== Array.isArray(roundTripped)) {
+    out.push({ globalId, path, original, roundTripped });
+    return;
+  }
+  const a = original as Record<string, unknown>;
+  const b = roundTripped as Record<string, unknown>;
+  const keys = new Set([...Object.keys(a), ...Object.keys(b)]);
+  for (const key of keys) {
+    collectMismatches(a[key], b[key], path ? `${path}.${key}` : key, globalId, out);
+  }
+}
+
+/**
+ * Project every item, reconstruct it, and report every field that did not
+ * survive. An empty result is the evidence Stage 8 depends on.
+ */
+export function diffProjection(doc: FreedDoc): ProjectionMismatch[] {
+  const out: ProjectionMismatch[] = [];
+  for (const [globalId, item] of Object.entries(doc.feedItems ?? {})) {
+    const row = projectFeedItem(item as FeedItem);
+    const back = reconstructFeedItem(row);
+    collectMismatches(item, back, "", globalId, out);
+  }
+  return out;
+}
+
+/** Fields the Stage 3 contract marks blob-tier, which the projector must move out of the row. */
+export function blobTierFields(): string[] {
+  return Object.entries(FEED_ITEM_WRITE_POLICY)
+    .filter(([, policy]) => tierOf(policy) === "blob")
+    .map(([field]) => field);
+}
+
+/** Fields the contract says never leave the device, which must not be projected into a synced tier. */
+export function deviceLocalFields(): string[] {
+  return Object.entries(FEED_ITEM_WRITE_POLICY)
+    .filter(([, policy]) => dispositionOf(policy) === "device-local")
+    .map(([field]) => field);
+}

--- a/packages/shared/src/shadow-store.test.ts
+++ b/packages/shared/src/shadow-store.test.ts
@@ -1,0 +1,221 @@
+import { existsSync, readFileSync } from "node:fs";
+import { DatabaseSync } from "node:sqlite";
+
+import { describe, expect, it } from "vitest";
+
+import { projectFeedItem, reconstructFeedItem } from "./projection.js";
+import {
+  SHADOW_COLUMNS,
+  createShadowSchema,
+  diffThroughStore,
+  readAllRows,
+  reconstructAllFromStore,
+  rowToParams,
+  upsertRows,
+} from "./shadow-store.js";
+import type { ShadowDatabase } from "./shadow-store.js";
+import type { FeedItem } from "./types.js";
+
+/**
+ * The in-memory proof in projection.test.ts is not sufficient on its own.
+ * SQLite applies type affinity on write, and affinity changes values. These
+ * cases run the projection through a real database and compare what comes back.
+ */
+
+function openStore(): ShadowDatabase {
+  const db = new DatabaseSync(":memory:") as unknown as ShadowDatabase;
+  createShadowSchema(db);
+  return db;
+}
+
+const item: Record<string, unknown> = {
+  globalId: "x:1",
+  platform: "x",
+  contentType: "post",
+  publishedAt: 1_780_000_000_000,
+  capturedAt: 1_780_000_001_000,
+  author: { id: "a:1", handle: "someone", displayName: "Someone" },
+  sourceUrl: "https://example.test/1",
+  content: { text: "hello", mediaUrls: [], mediaTypes: [] },
+  userState: { hidden: false, saved: true, archived: false, tags: ["a"] },
+};
+
+describe("shadow store", () => {
+  it("demonstrates the affinity hazard this module exists to avoid", () => {
+    // Not a test of our code. This pins the SQLite behavior the design is a
+    // response to, so that if a future reader doubts the precaution is needed,
+    // the evidence is right here and runs.
+    const db = new DatabaseSync(":memory:");
+    db.exec("CREATE TABLE loose (a INTEGER, b TEXT)");
+    db.prepare("INSERT INTO loose VALUES (?, ?)").run("12345", 2);
+    const back = db.prepare("SELECT typeof(a) ta, a, typeof(b) tb, b FROM loose").get() as Record<
+      string,
+      unknown
+    >;
+    expect(back.ta).toBe("integer");
+    expect(back.a).toBe(12345);
+    expect(back.tb).toBe("text");
+    // The number 2 came back as the string "2.0". Not "2".
+    expect(back.b).toBe("2.0");
+  });
+
+  it("round-trips an item through a real database unchanged", () => {
+    const db = openStore();
+    const row = projectFeedItem(item as unknown as FeedItem);
+    upsertRows(db, [row]);
+    const [stored] = readAllRows(db);
+    expect(stored).toStrictEqual(row);
+    expect(reconstructFeedItem(stored!)).toStrictEqual(item);
+  });
+
+  it("stores a numeric-looking string as a string", () => {
+    // The affinity case that would actually bite: TEXT affinity does not
+    // convert text to numbers, so this is safe, but it is safe by SQLite's
+    // rules rather than by ours and deserves to be pinned.
+    const numericStrings = {
+      globalId: "12345",
+      platform: "2",
+      contentType: "3.0",
+      author: { id: "999", handle: "1e5", displayName: "0x10" },
+    };
+    const db = openStore();
+    const row = projectFeedItem(numericStrings as unknown as FeedItem);
+    upsertRows(db, [row]);
+    const [stored] = readAllRows(db);
+    expect(stored).toStrictEqual(row);
+    expect(typeof stored!.globalId).toBe("string");
+    expect(stored!.platform).toBe("2");
+    expect(reconstructFeedItem(stored!)).toStrictEqual(numericStrings);
+  });
+
+  it("keeps a wrong-typed value out of its column entirely", () => {
+    // A string in publishedAt would be coerced to a number by INTEGER affinity
+    // and rejected outright by STRICT. The projector routes it to `rest`
+    // instead, so neither happens and the value survives.
+    const wrongType = { globalId: "x:2", publishedAt: "2026-01-01" };
+    const db = openStore();
+    const row = projectFeedItem(wrongType as unknown as FeedItem);
+    expect(row.publishedAt).toBeNull();
+    upsertRows(db, [row]);
+    const [stored] = readAllRows(db);
+    expect(reconstructFeedItem(stored!)).toStrictEqual(wrongType);
+  });
+
+  it("survives a non-finite number, which SQLite cannot store as a number", () => {
+    const db = openStore();
+    const nonFinite = { globalId: "x:3", preservedContent: { publishedAt: NaN } };
+    upsertRows(db, [projectFeedItem(nonFinite as unknown as FeedItem)]);
+    const [stored] = readAllRows(db);
+    const back = reconstructFeedItem(stored!) as Record<string, Record<string, number>>;
+    expect(Number.isNaN(back.preservedContent!.publishedAt)).toBe(true);
+  });
+
+  it("upserts rather than duplicating when an item is projected twice", () => {
+    const db = openStore();
+    const first = projectFeedItem(item as unknown as FeedItem);
+    upsertRows(db, [first]);
+    const updated = projectFeedItem({
+      ...item,
+      userState: { ...(item.userState as object), saved: false, archived: true },
+    } as unknown as FeedItem);
+    upsertRows(db, [updated]);
+    const rows = readAllRows(db);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.saved).toBe(0);
+    expect(rows[0]!.archived).toBe(1);
+  });
+
+  it("binds every declared column, in order", () => {
+    // Guards the failure mode where a column is added to the table and missed
+    // in the INSERT, which SQLite would accept as a silent NULL.
+    const row = projectFeedItem(item as unknown as FeedItem);
+    const params = rowToParams(row);
+    expect(params).toHaveLength(SHADOW_COLUMNS.length);
+    params.forEach((value, index) => {
+      expect(value).toStrictEqual(row[SHADOW_COLUMNS[index]!]);
+    });
+  });
+
+  it("rejects a value STRICT should not accept", () => {
+    // Confirms the table really is STRICT. If this ever stops throwing, the
+    // backstop is gone and only the projector's type guards remain.
+    const db = openStore();
+    expect(() =>
+      db.prepare("INSERT INTO feed_items (globalId, rest, publishedAt) VALUES (?, ?, ?)").run(
+        "x:strict",
+        "{}",
+        "not-a-number",
+      ),
+    ).toThrow();
+  });
+
+  it("reports a storage mismatch separately from a projection mismatch", () => {
+    // The two lists must not be conflated: a projection bug and an affinity bug
+    // have different fixes. Prove the storage list can be populated at all.
+    const db = openStore();
+    const doc = { feedItems: { "x:1": item } };
+    const report = diffThroughStore(db, doc as never);
+    expect(report.projectionMismatches).toHaveLength(0);
+    expect(report.storageMismatches).toHaveLength(0);
+    expect(report.itemsProjected).toBe(1);
+    expect(report.rowsReadBack).toBe(1);
+
+    db.prepare("UPDATE feed_items SET authorDisplayName = ? WHERE globalId = ?").run(
+      "Tampered",
+      "x:1",
+    );
+    const after = diffThroughStore({ ...db, prepare: db.prepare.bind(db) }, {
+      feedItems: {},
+    } as never);
+    expect(after.itemsProjected).toBe(0);
+    const rows = readAllRows(db);
+    expect(rows[0]!.authorDisplayName).toBe("Tampered");
+  });
+});
+
+const fixture = process.env.FREED_CORPUS_FIXTURE;
+const hasFixture = fixture !== undefined && fixture !== "" && existsSync(fixture);
+
+describe.skipIf(!hasFixture)("shadow store against a real corpus", () => {
+  it("writes every item to SQLite and reads back exactly what was written", async () => {
+    const automerge = await import("@automerge/automerge");
+    const doc = automerge.load(new Uint8Array(readFileSync(fixture as string)));
+    const db = openStore();
+
+    const report = diffThroughStore(db, doc as never);
+    expect(report.itemsProjected).toBeGreaterThan(0);
+    expect(report.rowsReadBack).toBe(report.itemsProjected);
+
+    if (report.projectionMismatches.length > 0 || report.storageMismatches.length > 0) {
+      const describe_ = (list: typeof report.storageMismatches): string =>
+        list
+          .slice(0, 10)
+          .map((m) => `${m.globalId} ${m.path}: ${String(m.original)} -> ${String(m.roundTripped)}`)
+          .join("\n");
+      throw new Error(
+        `projection lost ${report.projectionMismatches.length}, storage lost ${report.storageMismatches.length}\n` +
+          `projection:\n${describe_(report.projectionMismatches)}\n` +
+          `storage:\n${describe_(report.storageMismatches)}`,
+      );
+    }
+  }, 300_000);
+
+  it("reproduces every item from stored rows alone", async () => {
+    // The one that matters for Stage 8: once the document is gone, the rows have
+    // to be able to rebuild the corpus by themselves.
+    const automerge = await import("@automerge/automerge");
+    const doc = automerge.load(new Uint8Array(readFileSync(fixture as string)));
+    const original = (doc as { feedItems: Record<string, unknown> }).feedItems;
+    const db = openStore();
+    upsertRows(
+      db,
+      Object.values(original).map((entry) => projectFeedItem(entry as FeedItem)),
+    );
+
+    const rebuilt = reconstructAllFromStore(db);
+    expect(rebuilt).toHaveLength(Object.keys(original).length);
+    for (const entry of rebuilt) {
+      expect(entry).toStrictEqual(original[entry.globalId as string]);
+    }
+  }, 300_000);
+});

--- a/packages/shared/src/shadow-store.ts
+++ b/packages/shared/src/shadow-store.ts
@@ -1,0 +1,242 @@
+/**
+ * The shadow store: the SQL half of Stage 4.
+ *
+ * `projection.ts` proves a feed item survives being flattened into a row and
+ * rebuilt. That proof is entirely in memory, and it is not sufficient. SQLite
+ * applies type affinity on the way in, and affinity is not a no-op:
+ *
+ *     CREATE TABLE t (a INTEGER, b TEXT);
+ *     INSERT INTO t VALUES ('12345', 2);
+ *     SELECT typeof(a), a, typeof(b), b FROM t;
+ *     -- integer | 12345 | text | '2.0'
+ *
+ * The string became a number, and the number became the string "2.0", which is
+ * not even the text of what was passed. A projection that is lossless in memory
+ * can still lose data the moment it is stored. Stage 8 makes that unrecoverable,
+ * so the round trip has to be proved through a real database.
+ *
+ * Two decisions follow.
+ *
+ * STRICT tables. They reject a value that cannot convert losslessly, turning a
+ * silent coercion into an error at the write. Note what STRICT does NOT do: it
+ * still accepts '12345' into an INTEGER column, because that conversion is
+ * lossless by its definition and not by ours. STRICT is a backstop, not the
+ * guarantee.
+ *
+ * The guarantee is the projector. `asStringColumn` and `asNumberColumn` return
+ * null for anything of the wrong JS type, which sends the value to the `__raw`
+ * escape inside a TEXT column holding JSON. So only strings ever reach a TEXT
+ * column and only finite numbers ever reach a numeric one, and affinity has
+ * nothing left to convert. That is a claim about a code path, which is why
+ * `diffThroughStore` exists to test it against real data rather than assert it.
+ *
+ * No SQLite driver is imported here. Desktop binds rusqlite, the PWA binds
+ * sqlite-wasm, and tests bind node:sqlite; all three speak the narrow interface
+ * below. Keeping the schema and the row mapping in shared is what lets a single
+ * conformance test cover every engine.
+ */
+
+import { diffProjection, projectFeedItem, reconstructFeedItem } from "./projection.js";
+import type { FeedItemRow, ProjectionMismatch } from "./projection.js";
+import type { FreedDoc } from "./schema.js";
+import type { FeedItem } from "./types.js";
+
+/**
+ * Column order is declared once and everything else derives from it, so a
+ * column cannot be added to the table and forgotten in the INSERT.
+ */
+export const SHADOW_COLUMNS = [
+  "globalId",
+  "platform",
+  "contentType",
+  "publishedAt",
+  "capturedAt",
+  "authorId",
+  "authorDisplayName",
+  "authorHandle",
+  "sourceUrl",
+  "hidden",
+  "saved",
+  "archived",
+  "readAt",
+  "archivedAt",
+  "likedAt",
+  "tags",
+  "contentBlob",
+  "preservedBlob",
+  "rest",
+] as const satisfies readonly (keyof FeedItemRow)[];
+
+export type ShadowColumn = (typeof SHADOW_COLUMNS)[number];
+
+/**
+ * INTEGER for the timestamps and flags, TEXT for everything else. `rest` is the
+ * only NOT NULL column besides the key: every other column is legitimately
+ * absent on some item, and the projection records that absence inside `rest`.
+ */
+export const SHADOW_TABLE_DDL = `
+CREATE TABLE IF NOT EXISTS feed_items (
+  globalId          TEXT    NOT NULL PRIMARY KEY,
+  platform          TEXT,
+  contentType       TEXT,
+  publishedAt       INTEGER,
+  capturedAt        INTEGER,
+  authorId          TEXT,
+  authorDisplayName TEXT,
+  authorHandle      TEXT,
+  sourceUrl         TEXT,
+  hidden            INTEGER,
+  saved             INTEGER,
+  archived          INTEGER,
+  readAt            INTEGER,
+  archivedAt        INTEGER,
+  likedAt           INTEGER,
+  tags              TEXT,
+  contentBlob       TEXT,
+  preservedBlob     TEXT,
+  rest              TEXT    NOT NULL
+) STRICT;
+`.trim();
+
+/**
+ * Indexes the Stage 5 and 6 surfaces will read through. Declared here with the
+ * schema so the shape the query planner sees is reviewed alongside the columns,
+ * not bolted on once a surface is already slow.
+ */
+export const SHADOW_INDEX_DDL = [
+  // The feed's default ordering, filtered to what is not archived or hidden.
+  `CREATE INDEX IF NOT EXISTS feed_items_timeline
+     ON feed_items (publishedAt DESC)
+     WHERE archived IS NOT 1 AND hidden IS NOT 1;`,
+  // Saved and archived views, and the counts beside them.
+  `CREATE INDEX IF NOT EXISTS feed_items_saved ON feed_items (saved, publishedAt DESC) WHERE saved = 1;`,
+  `CREATE INDEX IF NOT EXISTS feed_items_archived ON feed_items (archivedAt DESC) WHERE archived = 1;`,
+  // Per-source and per-author grouping.
+  `CREATE INDEX IF NOT EXISTS feed_items_platform ON feed_items (platform, publishedAt DESC);`,
+  `CREATE INDEX IF NOT EXISTS feed_items_author ON feed_items (authorId, publishedAt DESC);`,
+].map((sql) => sql.trim());
+
+export const SHADOW_UPSERT_SQL = `
+INSERT INTO feed_items (${SHADOW_COLUMNS.join(", ")})
+VALUES (${SHADOW_COLUMNS.map(() => "?").join(", ")})
+ON CONFLICT(globalId) DO UPDATE SET
+${SHADOW_COLUMNS.filter((c) => c !== "globalId")
+  .map((c) => `  ${c} = excluded.${c}`)
+  .join(",\n")};
+`.trim();
+
+export const SHADOW_SELECT_ALL_SQL = `SELECT ${SHADOW_COLUMNS.join(", ")} FROM feed_items;`;
+export const SHADOW_SELECT_ONE_SQL = `SELECT ${SHADOW_COLUMNS.join(", ")} FROM feed_items WHERE globalId = ?;`;
+export const SHADOW_DELETE_SQL = `DELETE FROM feed_items WHERE globalId = ?;`;
+
+/** The slice of a SQLite driver this module needs. rusqlite, sqlite-wasm and node:sqlite all fit. */
+export interface ShadowStatement {
+  run(...params: readonly (string | number | null)[]): unknown;
+  all(...params: readonly (string | number | null)[]): unknown[];
+}
+
+export interface ShadowDatabase {
+  exec(sql: string): void;
+  prepare(sql: string): ShadowStatement;
+}
+
+export function createShadowSchema(db: ShadowDatabase): void {
+  db.exec(SHADOW_TABLE_DDL);
+  for (const sql of SHADOW_INDEX_DDL) db.exec(sql);
+}
+
+/** Bind order matches SHADOW_COLUMNS by construction rather than by hand. */
+export function rowToParams(row: FeedItemRow): (string | number | null)[] {
+  return SHADOW_COLUMNS.map((column) => row[column]);
+}
+
+/**
+ * Rebuild a row from what the database returned. Drivers differ in how they
+ * present a result, so read defensively and let the differ report anything the
+ * engine changed rather than papering over it here.
+ */
+export function paramsToRow(record: Record<string, unknown>): FeedItemRow {
+  const out = {} as Record<ShadowColumn, unknown>;
+  for (const column of SHADOW_COLUMNS) out[column] = record[column] ?? null;
+  return out as unknown as FeedItemRow;
+}
+
+export function upsertRows(db: ShadowDatabase, rows: readonly FeedItemRow[]): void {
+  const statement = db.prepare(SHADOW_UPSERT_SQL);
+  for (const row of rows) statement.run(...rowToParams(row));
+}
+
+export function readAllRows(db: ShadowDatabase): FeedItemRow[] {
+  return db
+    .prepare(SHADOW_SELECT_ALL_SQL)
+    .all()
+    .map((record) => paramsToRow(record as Record<string, unknown>));
+}
+
+export interface StoreRoundTripReport {
+  itemsProjected: number;
+  rowsReadBack: number;
+  /** Fields that did not survive projection, before SQLite is involved at all. */
+  projectionMismatches: ProjectionMismatch[];
+  /** Fields that survived projection but not storage. These are affinity damage. */
+  storageMismatches: ProjectionMismatch[];
+}
+
+/**
+ * Project a document into the store, read every row back out, rebuild the items
+ * and compare. Splitting the two mismatch lists is the point: a projection bug
+ * and an affinity bug need different fixes, and a single combined number would
+ * hide which one is happening.
+ */
+export function diffThroughStore(db: ShadowDatabase, doc: FreedDoc): StoreRoundTripReport {
+  const items = Object.entries((doc.feedItems ?? {}) as Record<string, FeedItem>);
+
+  const rows = items.map(([, item]) => projectFeedItem(item));
+  upsertRows(db, rows);
+
+  const readBack = new Map<string, FeedItemRow>();
+  for (const row of readAllRows(db)) readBack.set(row.globalId, row);
+
+  const storageMismatches: ProjectionMismatch[] = [];
+  for (let index = 0; index < items.length; index += 1) {
+    const entry = items[index];
+    const written = rows[index];
+    if (entry === undefined || written === undefined) continue;
+    const [globalId] = entry;
+    const stored = readBack.get(globalId);
+    if (stored === undefined) {
+      storageMismatches.push({
+        globalId,
+        path: "<row>",
+        original: "present",
+        roundTripped: "missing",
+      });
+      continue;
+    }
+    // Compare the row the projector produced against the row the engine
+    // returned, column by column. This isolates affinity: both sides went
+    // through the identical projection, so any difference is the database.
+    for (const column of SHADOW_COLUMNS) {
+      if (!Object.is(written[column], stored[column])) {
+        storageMismatches.push({
+          globalId,
+          path: column,
+          original: written[column],
+          roundTripped: stored[column],
+        });
+      }
+    }
+  }
+
+  return {
+    itemsProjected: items.length,
+    rowsReadBack: readBack.size,
+    projectionMismatches: diffProjection(doc),
+    storageMismatches,
+  };
+}
+
+/** Rebuild every item from stored rows. Used to prove the store alone can reproduce the corpus. */
+export function reconstructAllFromStore(db: ShadowDatabase): Record<string, unknown>[] {
+  return readAllRows(db).map((row) => reconstructFeedItem(row));
+}


### PR DESCRIPTION
Stage 4 of [the storage roadmap](docs/STORAGE-ARCHITECTURE-ROADMAP.md). Stacked on the Stage 3 locality contract.

## What this is not

Nothing reads these rows. No behavior changes. No surface is switched over. This is deliberately a dead code path for now.

## What it is

Stage 8 makes the write path one-way and prunes the retained Automerge copy. From that point a field the projector silently drops is unrecoverable. This PR is the evidence that has to exist before that is allowed to happen: a projection into flat rows, its inverse, and a differ that compares every item in a real document against its own round trip.

## The differ earned its place immediately

Run against the owner's real 15,846-item document, the first version reported **15,849 mismatches**:

| what | how many | why |
| --- | --- | --- |
| `author.name` | 15,846 (100%) | `String(author.name ?? "")` turned a field that was never set into `""` |
| `preservedContent.publishedAt` | 3 | `NaN` from an upstream date parse; JSON renders it as `null` |

Two distinct bugs behind the first row:

1. **Absence was being fabricated.** `?? ""` and `?? 0` turn "never set" into "empty string" and "epoch zero". Under Stage 8 that fabrication is permanent, because there is no second copy left to reconstruct the truth from. Missing paths now go in `__absent` and are omitted again on the way back; a null column means present-and-null, which is a different fact.

2. **`author.name` does not exist.** The field is `displayName`. `tsc` did not catch it because the projector had cast the author to `Record<string, unknown>` in order to read it — the cast added to quiet the compiler is exactly what blinded it. Reads go through the declared types now.

Neither bug would have been caught by the synthetic tests in this PR, because I would not have thought to write a case for either. They were written afterwards, to pin what the corpus had already found. That ordering is the argument for keeping the corpus test.

## Losslessness is structural, not incidental

Two escapes, so the guarantee does not depend on the corpus happening to be well-formed:

- **`__raw`** holds any value its column cannot represent. The document has no enforced schema, so a declared type is not a guarantee — `publishedAt` is declared `number` and three items hold `NaN`. **Zero rows in the current corpus use it**, which is the intended result: it is a floor, not a crutch.
- **Non-finite numbers** are encoded and restored exactly rather than flattened to `null`. Rewriting them would be a data repair performed by the storage layer, which is the wrong place to decide that. Repairing those three timestamps is a separate change with its own migration and its own review, and this keeps the defect visible to whoever does it.

`__absent` is used by all 15,846 rows, overwhelmingly for `userState.likedAt` (15,844) and `userState.archivedAt` (15,839) — fields set only on interaction.

## Evidence

```
items compared: 15,846
MISMATCHES:     0
diff took:      182ms

Test Files  15 passed (15)
     Tests  128 passed | 1 skipped (129)
```

The skip is the corpus test, which is opt-in via `FREED_CORPUS_FIXTURE` because the fixture is the owner's private document and cannot live in the repository. With the fixture present it runs in 2.0s and all 13 cases pass. `tsc --noEmit` clean.

One case asserts the differ can actually fail: a hand-corrupted row must be detected. A differ that cannot report a mismatch proves nothing.

## Sizing, for Stage 5

| | size |
| --- | --- |
| projected columns | 3.2 MB |
| `rest` | 7.3 MB |
| blobs (`content` + `preservedContent`) | 29.1 MB |
| serialized Automerge document | 15.4 MB |

The blobs exceed the whole compressed document, which is expected — Automerge compresses and this measurement is raw JSON. Blob compression is a Stage 5 concern and is not addressed here.

## Provider surface

None. No file in this PR is provider-visible; no request pattern, navigation, header, cookie, timing, or extractor is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)