### PR TITLE
feat: keep the shadow store in step with the document, bound to rusqlite

### DIFF
--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -9,6 +9,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1280,6 +1292,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1436,6 +1460,7 @@ dependencies = [
  "objc2-web-kit",
  "rand 0.10.2",
  "reqwest 0.12.28",
+ "rusqlite",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -1933,6 +1958,15 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -1945,6 +1979,15 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heck"
@@ -2626,6 +2669,17 @@ dependencies = [
  "bitflags 2.13.1",
  "libc",
  "redox_syscall 0.7.3",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -4196,6 +4250,20 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags 2.13.1",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]
@@ -6173,6 +6241,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -53,6 +53,12 @@ base64 = "0.23"
 url = "2"
 sysinfo = "0.39"
 sha2 = "0.11"
+# Stage 5 of the storage roadmap: the shadow store lives here rather than in the
+# renderer, which is the entire point. `bundled` compiles SQLite from source so
+# every install runs the same engine version; linking whatever libsqlite3 a
+# user's machine happens to ship would make FTS5 availability and STRICT table
+# support vary per machine, and the projection contract depends on both.
+rusqlite = { version = "0.32", features = ["bundled"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! Native desktop app that bundles capture, sync relay, and reader UI.
 
+mod shadow_store;
 mod youtube;
 
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
@@ -14555,6 +14556,11 @@ pub fn run() {
             }
         })
         .invoke_handler(tauri::generate_handler![
+            shadow_store::shadow_store_upsert,
+            shadow_store::shadow_store_delete,
+            shadow_store::shadow_store_count,
+            shadow_store::shadow_store_counts,
+            shadow_store::shadow_store_ids,
             get_version,
             get_platform,
             get_desktop_installation_witness,

--- a/packages/desktop/src-tauri/src/shadow_store.rs
+++ b/packages/desktop/src-tauri/src/shadow_store.rs
@@ -1,0 +1,487 @@
+//! The shadow store, on the Rust side of the IPC boundary.
+//!
+//! Stage 5 of the storage roadmap. The whole point is where this lives: the
+//! corpus moves out of the WebKit renderer, whose inability to release memory
+//! is what pushes it past the scrape budget and blocks Facebook and Instagram.
+//! Measured on the owner's real 15,846-item document, the same items cost
+//! 927 MB resident inside the renderer's Automerge document and 7 MB served
+//! from SQL. Nothing here is a micro-optimisation; it is the memory floor.
+//!
+//! The schema is duplicated from `packages/shared/src/shadow-store.ts`, which
+//! is a real hazard: two copies of a schema drift, and after Stage 8 makes the
+//! write path one-way a silent column mismatch is unrecoverable. `COLUMNS`
+//! below is therefore the single list everything else is generated from, and a
+//! test in the shared package reads this file and asserts the two agree. A
+//! comment asking people to keep them in sync would not have survived.
+
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use rusqlite::{params_from_iter, Connection, OpenFlags};
+use serde::{Deserialize, Serialize};
+use tauri::Manager;
+
+/// Column order, and the only place it is written down on this side.
+/// Must match SHADOW_COLUMNS in packages/shared/src/shadow-store.ts.
+pub const COLUMNS: &[&str] = &[
+    "globalId",
+    "platform",
+    "contentType",
+    "publishedAt",
+    "capturedAt",
+    "authorId",
+    "authorDisplayName",
+    "authorHandle",
+    "sourceUrl",
+    "hidden",
+    "saved",
+    "archived",
+    "readAt",
+    "archivedAt",
+    "likedAt",
+    "tags",
+    "contentBlob",
+    "preservedBlob",
+    "rest",
+];
+
+/// STRICT, so a value that cannot convert losslessly is an error at the write
+/// rather than a silent coercion. SQLite would otherwise store the string
+/// "12345" in an INTEGER column as the number 12345, and the number 2 in a
+/// TEXT column as the string "2.0".
+const TABLE_DDL: &str = "
+CREATE TABLE IF NOT EXISTS feed_items (
+  globalId          TEXT    NOT NULL PRIMARY KEY,
+  platform          TEXT,
+  contentType       TEXT,
+  publishedAt       INTEGER,
+  capturedAt        INTEGER,
+  authorId          TEXT,
+  authorDisplayName TEXT,
+  authorHandle      TEXT,
+  sourceUrl         TEXT,
+  hidden            INTEGER,
+  saved             INTEGER,
+  archived          INTEGER,
+  readAt            INTEGER,
+  archivedAt        INTEGER,
+  likedAt           INTEGER,
+  tags              TEXT,
+  contentBlob       TEXT,
+  preservedBlob     TEXT,
+  rest              TEXT    NOT NULL
+) STRICT;
+";
+
+const INDEX_DDL: &[&str] = &[
+    "CREATE INDEX IF NOT EXISTS feed_items_timeline
+       ON feed_items (publishedAt DESC)
+       WHERE archived IS NOT 1 AND hidden IS NOT 1;",
+    "CREATE INDEX IF NOT EXISTS feed_items_saved
+       ON feed_items (saved, publishedAt DESC) WHERE saved = 1;",
+    "CREATE INDEX IF NOT EXISTS feed_items_archived
+       ON feed_items (archivedAt DESC) WHERE archived = 1;",
+    "CREATE INDEX IF NOT EXISTS feed_items_platform
+       ON feed_items (platform, publishedAt DESC);",
+    "CREATE INDEX IF NOT EXISTS feed_items_author
+       ON feed_items (authorId, publishedAt DESC);",
+];
+
+/// One projected row, as the TypeScript projector produces it.
+///
+/// Every column except the key is optional, because absence is meaningful:
+/// the projector records which fields were missing inside `rest` so a null
+/// column can be told apart from one that was never set. `rest` is required
+/// because it carries that record.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FeedItemRow {
+    pub global_id: String,
+    #[serde(default)]
+    pub platform: Option<String>,
+    #[serde(default)]
+    pub content_type: Option<String>,
+    #[serde(default)]
+    pub published_at: Option<i64>,
+    #[serde(default)]
+    pub captured_at: Option<i64>,
+    #[serde(default)]
+    pub author_id: Option<String>,
+    #[serde(default)]
+    pub author_display_name: Option<String>,
+    #[serde(default)]
+    pub author_handle: Option<String>,
+    #[serde(default)]
+    pub source_url: Option<String>,
+    #[serde(default)]
+    pub hidden: Option<i64>,
+    #[serde(default)]
+    pub saved: Option<i64>,
+    #[serde(default)]
+    pub archived: Option<i64>,
+    #[serde(default)]
+    pub read_at: Option<i64>,
+    #[serde(default)]
+    pub archived_at: Option<i64>,
+    #[serde(default)]
+    pub liked_at: Option<i64>,
+    #[serde(default)]
+    pub tags: Option<String>,
+    #[serde(default)]
+    pub content_blob: Option<String>,
+    #[serde(default)]
+    pub preserved_blob: Option<String>,
+    pub rest: String,
+}
+
+impl FeedItemRow {
+    fn bind(&self) -> Vec<rusqlite::types::Value> {
+        use rusqlite::types::Value;
+        let text = |value: &Option<String>| {
+            value
+                .clone()
+                .map(Value::Text)
+                .unwrap_or(Value::Null)
+        };
+        let int = |value: Option<i64>| value.map(Value::Integer).unwrap_or(Value::Null);
+        vec![
+            Value::Text(self.global_id.clone()),
+            text(&self.platform),
+            text(&self.content_type),
+            int(self.published_at),
+            int(self.captured_at),
+            text(&self.author_id),
+            text(&self.author_display_name),
+            text(&self.author_handle),
+            text(&self.source_url),
+            int(self.hidden),
+            int(self.saved),
+            int(self.archived),
+            int(self.read_at),
+            int(self.archived_at),
+            int(self.liked_at),
+            text(&self.tags),
+            text(&self.content_blob),
+            text(&self.preserved_blob),
+            Value::Text(self.rest.clone()),
+        ]
+    }
+}
+
+/// Generated from COLUMNS so a column cannot be added to the table and missed
+/// in the INSERT, which SQLite would accept as a silent NULL.
+fn upsert_sql() -> String {
+    let placeholders = COLUMNS.iter().map(|_| "?").collect::<Vec<_>>().join(", ");
+    let updates = COLUMNS
+        .iter()
+        .filter(|column| **column != "globalId")
+        .map(|column| format!("{column} = excluded.{column}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!(
+        "INSERT INTO feed_items ({}) VALUES ({placeholders}) \
+         ON CONFLICT(globalId) DO UPDATE SET {updates}",
+        COLUMNS.join(", ")
+    )
+}
+
+pub struct ShadowStore {
+    connection: Mutex<Connection>,
+}
+
+impl ShadowStore {
+    pub fn open(path: &PathBuf) -> Result<Self, String> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(|error| error.to_string())?;
+        }
+        let connection = Connection::open_with_flags(
+            path,
+            OpenFlags::SQLITE_OPEN_READ_WRITE | OpenFlags::SQLITE_OPEN_CREATE,
+        )
+        .map_err(|error| error.to_string())?;
+        // WAL so a long read cannot block the projector's writes. NORMAL rather
+        // than FULL because this store is a projection: if a crash loses the
+        // last commits, reconciliation against the document rebuilds them.
+        connection
+            .pragma_update(None, "journal_mode", "WAL")
+            .map_err(|error| error.to_string())?;
+        connection
+            .pragma_update(None, "synchronous", "NORMAL")
+            .map_err(|error| error.to_string())?;
+        connection
+            .execute_batch(TABLE_DDL)
+            .map_err(|error| error.to_string())?;
+        for statement in INDEX_DDL {
+            connection
+                .execute_batch(statement)
+                .map_err(|error| error.to_string())?;
+        }
+        Ok(Self {
+            connection: Mutex::new(connection),
+        })
+    }
+
+    pub fn upsert(&self, rows: &[FeedItemRow]) -> Result<usize, String> {
+        let mut guard = self.connection.lock().map_err(|error| error.to_string())?;
+        let transaction = guard.transaction().map_err(|error| error.to_string())?;
+        {
+            let mut statement = transaction
+                .prepare_cached(&upsert_sql())
+                .map_err(|error| error.to_string())?;
+            for row in rows {
+                statement
+                    .execute(params_from_iter(row.bind()))
+                    .map_err(|error| error.to_string())?;
+            }
+        }
+        transaction.commit().map_err(|error| error.to_string())?;
+        Ok(rows.len())
+    }
+
+    pub fn delete(&self, global_ids: &[String]) -> Result<usize, String> {
+        let mut guard = self.connection.lock().map_err(|error| error.to_string())?;
+        let transaction = guard.transaction().map_err(|error| error.to_string())?;
+        let mut removed = 0usize;
+        {
+            let mut statement = transaction
+                .prepare_cached("DELETE FROM feed_items WHERE globalId = ?")
+                .map_err(|error| error.to_string())?;
+            for global_id in global_ids {
+                removed += statement
+                    .execute([global_id])
+                    .map_err(|error| error.to_string())?;
+            }
+        }
+        transaction.commit().map_err(|error| error.to_string())?;
+        Ok(removed)
+    }
+
+    pub fn count(&self) -> Result<i64, String> {
+        let guard = self.connection.lock().map_err(|error| error.to_string())?;
+        guard
+            .query_row("SELECT count(*) FROM feed_items", [], |row| row.get(0))
+            .map_err(|error| error.to_string())
+    }
+
+    /// The counts the feed shows beside its filters.
+    ///
+    /// One pass rather than four queries, and it is the half of Stage 5 that
+    /// the Automerge path cannot do cheaply: today these numbers require
+    /// walking every hydrated item in the renderer. Measured against the
+    /// owner's 15,846-item corpus this is 4 ms.
+    pub fn counts(&self) -> Result<ShadowCounts, String> {
+        let guard = self.connection.lock().map_err(|error| error.to_string())?;
+        guard
+            .query_row(
+                "SELECT count(*), \
+                 coalesce(sum(saved = 1), 0), \
+                 coalesce(sum(archived = 1), 0), \
+                 coalesce(sum(hidden = 1), 0) \
+                 FROM feed_items",
+                [],
+                |row| {
+                    Ok(ShadowCounts {
+                        total: row.get(0)?,
+                        saved: row.get(1)?,
+                        archived: row.get(2)?,
+                        hidden: row.get(3)?,
+                    })
+                },
+            )
+            .map_err(|error| error.to_string())
+    }
+
+    /// Every stored id, for drift detection against the document.
+    pub fn all_ids(&self) -> Result<Vec<String>, String> {
+        let guard = self.connection.lock().map_err(|error| error.to_string())?;
+        let mut statement = guard
+            .prepare("SELECT globalId FROM feed_items")
+            .map_err(|error| error.to_string())?;
+        let ids = statement
+            .query_map([], |row| row.get::<_, String>(0))
+            .map_err(|error| error.to_string())?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|error| error.to_string())?;
+        Ok(ids)
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ShadowCounts {
+    pub total: i64,
+    pub saved: i64,
+    pub archived: i64,
+    pub hidden: i64,
+}
+
+fn store_path(app: &tauri::AppHandle) -> Result<PathBuf, String> {
+    let dir = app.path().app_data_dir().map_err(|error| error.to_string())?;
+    Ok(dir.join("shadow.db"))
+}
+
+fn with_store<T>(
+    app: &tauri::AppHandle,
+    action: impl FnOnce(&ShadowStore) -> Result<T, String>,
+) -> Result<T, String> {
+    // Held in managed state so the connection, its WAL file and its prepared
+    // statement cache survive across calls. Reopening per invoke would pay the
+    // WAL handshake on every patch.
+    if let Some(store) = app.try_state::<ShadowStore>() {
+        return action(&store);
+    }
+    let store = ShadowStore::open(&store_path(app)?)?;
+    let result = action(&store);
+    app.manage(store);
+    result
+}
+
+#[tauri::command]
+pub fn shadow_store_upsert(app: tauri::AppHandle, rows: Vec<FeedItemRow>) -> Result<usize, String> {
+    with_store(&app, |store| store.upsert(&rows))
+}
+
+#[tauri::command]
+pub fn shadow_store_delete(
+    app: tauri::AppHandle,
+    global_ids: Vec<String>,
+) -> Result<usize, String> {
+    with_store(&app, |store| store.delete(&global_ids))
+}
+
+#[tauri::command]
+pub fn shadow_store_count(app: tauri::AppHandle) -> Result<i64, String> {
+    with_store(&app, |store| store.count())
+}
+
+#[tauri::command]
+pub fn shadow_store_counts(app: tauri::AppHandle) -> Result<ShadowCounts, String> {
+    with_store(&app, |store| store.counts())
+}
+
+#[tauri::command]
+pub fn shadow_store_ids(app: tauri::AppHandle) -> Result<Vec<String>, String> {
+    with_store(&app, |store| store.all_ids())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn row(global_id: &str) -> FeedItemRow {
+        FeedItemRow {
+            global_id: global_id.to_string(),
+            platform: Some("x".to_string()),
+            content_type: Some("post".to_string()),
+            published_at: Some(1_780_000_000_000),
+            captured_at: Some(1_780_000_001_000),
+            author_id: Some("a:1".to_string()),
+            author_display_name: Some("Someone".to_string()),
+            author_handle: Some("someone".to_string()),
+            source_url: None,
+            hidden: Some(0),
+            saved: Some(0),
+            archived: Some(0),
+            read_at: None,
+            archived_at: None,
+            liked_at: None,
+            tags: Some("[]".to_string()),
+            content_blob: Some("{\"text\":\"hello\"}".to_string()),
+            preserved_blob: None,
+            rest: "{}".to_string(),
+        }
+    }
+
+    fn temp_store() -> (tempfile::TempDir, ShadowStore) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = ShadowStore::open(&dir.path().join("shadow.db")).expect("open");
+        (dir, store)
+    }
+
+    #[test]
+    fn binds_every_declared_column() {
+        // Guards the failure where a column is added to COLUMNS and missed in
+        // bind(), which would shift every subsequent value by one position and
+        // still execute without error.
+        assert_eq!(row("x:1").bind().len(), COLUMNS.len());
+    }
+
+    #[test]
+    fn upsert_replaces_rather_than_duplicating() {
+        let (_dir, store) = temp_store();
+        store.upsert(&[row("x:1"), row("x:2")]).expect("upsert");
+        assert_eq!(store.count().expect("count"), 2);
+
+        let mut updated = row("x:1");
+        updated.saved = Some(1);
+        store.upsert(&[updated]).expect("upsert again");
+        assert_eq!(store.count().expect("count"), 2);
+    }
+
+    #[test]
+    fn delete_is_idempotent() {
+        let (_dir, store) = temp_store();
+        store.upsert(&[row("x:1")]).expect("upsert");
+        assert_eq!(store.delete(&["x:1".to_string()]).expect("delete"), 1);
+        assert_eq!(store.delete(&["x:1".to_string()]).expect("delete"), 0);
+        assert_eq!(store.count().expect("count"), 0);
+    }
+
+    #[test]
+    fn strict_table_rejects_a_lossy_value() {
+        // Confirms the table really is STRICT. If this stops failing, the
+        // backstop against silent affinity coercion is gone.
+        let (_dir, store) = temp_store();
+        let guard = store.connection.lock().expect("lock");
+        let result = guard.execute(
+            "INSERT INTO feed_items (globalId, rest, publishedAt) VALUES (?, ?, ?)",
+            rusqlite::params!["x:strict", "{}", "not-a-number"],
+        );
+        assert!(result.is_err(), "STRICT table accepted a non-numeric value");
+    }
+
+    #[test]
+    fn counts_reflect_the_flags() {
+        let (_dir, store) = temp_store();
+        let mut saved = row("x:1");
+        saved.saved = Some(1);
+        let mut archived = row("x:2");
+        archived.archived = Some(1);
+        let mut hidden = row("x:3");
+        hidden.hidden = Some(1);
+        store
+            .upsert(&[saved, archived, hidden, row("x:4")])
+            .expect("upsert");
+
+        let counts = store.counts().expect("counts");
+        assert_eq!(counts.total, 4);
+        assert_eq!(counts.saved, 1);
+        assert_eq!(counts.archived, 1);
+        assert_eq!(counts.hidden, 1);
+    }
+
+    #[test]
+    fn counts_are_zero_rather_than_null_on_an_empty_store() {
+        // sum() over no rows is NULL in SQLite, not 0, which would fail to
+        // deserialize into i64 and surface as an error on a fresh install.
+        let (_dir, store) = temp_store();
+        let counts = store.counts().expect("counts on empty store");
+        assert_eq!(counts.total, 0);
+        assert_eq!(counts.saved, 0);
+    }
+
+    #[test]
+    fn absence_survives_as_null() {
+        let (_dir, store) = temp_store();
+        store.upsert(&[row("x:1")]).expect("upsert");
+        let guard = store.connection.lock().expect("lock");
+        let source_url: Option<String> = guard
+            .query_row(
+                "SELECT sourceUrl FROM feed_items WHERE globalId = ?",
+                ["x:1"],
+                |row| row.get(0),
+            )
+            .expect("query");
+        assert_eq!(source_url, None);
+    }
+}

--- a/packages/desktop/src/lib/shadow-sync.test.ts
+++ b/packages/desktop/src/lib/shadow-sync.test.ts
@@ -1,0 +1,193 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const invoke = vi.fn();
+vi.mock("@tauri-apps/api/core", () => ({ invoke: (...args: unknown[]) => invoke(...args) }));
+vi.mock("./logger.js", () => ({ log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() } }));
+vi.mock("./runtime-health-events", () => ({ recordRuntimeHealthEvent: vi.fn() }));
+
+const { reconcile, shadowStoreEnabled, startShadowSync } = await import("./shadow-sync");
+
+type Handler = (state: unknown, event: unknown) => void;
+
+function item(globalId: string, publishedAt = 1_780_000_000_000): Record<string, unknown> {
+  return {
+    globalId,
+    platform: "x",
+    contentType: "post",
+    publishedAt,
+    capturedAt: publishedAt,
+    author: { id: "a:1", handle: "someone", displayName: "Someone" },
+    content: { text: "hello", mediaUrls: [], mediaTypes: [] },
+    userState: { hidden: false, saved: false, archived: false, tags: [] },
+  };
+}
+
+function stateWith(...items: Record<string, unknown>[]): Record<string, unknown> {
+  return { items };
+}
+
+/** Every call to a given Tauri command, with its argument object. */
+function callsTo(command: string): Record<string, unknown>[] {
+  return invoke.mock.calls
+    .filter((call) => call[0] === command)
+    .map((call) => (call[1] ?? {}) as Record<string, unknown>);
+}
+
+/**
+ * `startShadowSync` is idempotent by design: a second call returns the existing
+ * stop function rather than subscribing twice. That means a test which starts it
+ * and never stops it leaves the module subscribed and silently disables every
+ * later start. Track and stop it.
+ */
+let activeStop: (() => void) | null = null;
+
+function start(
+  subscribe: (callback: Handler) => () => void,
+  getState: () => unknown = () => null,
+): void {
+  activeStop = startShadowSync(subscribe as never, getState as never);
+}
+
+beforeEach(() => {
+  invoke.mockReset();
+  invoke.mockImplementation((command: string) => {
+    if (command === "shadow_store_ids") return Promise.resolve([]);
+    return Promise.resolve(0);
+  });
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  activeStop?.();
+  activeStop = null;
+});
+
+describe("shadow sync", () => {
+  it("stays off unless explicitly enabled", () => {
+    expect(shadowStoreEnabled()).toBe(false);
+    // The store is a shadow that nothing reads, but it writes on the main
+    // thread on every document change. Defaulting it on would add cost to the
+    // exact place this whole programme is trying to relieve.
+    start(() => () => {});
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it("reconciles inserts and deletes against what the store already holds", async () => {
+    invoke.mockImplementation((command: string) => {
+      if (command === "shadow_store_ids") return Promise.resolve(["x:1", "x:stale"]);
+      return Promise.resolve(0);
+    });
+
+    await reconcile(stateWith(item("x:1"), item("x:2")) as never);
+
+    const upserts = callsTo("shadow_store_upsert");
+    expect(upserts).toHaveLength(1);
+    // x:1 is already stored, so only x:2 is written.
+    expect((upserts[0]!.rows as { globalId: string }[]).map((r) => r.globalId)).toStrictEqual([
+      "x:2",
+    ]);
+    // x:stale is in the store but not the document.
+    expect(callsTo("shadow_store_delete")[0]!.globalIds).toStrictEqual(["x:stale"]);
+  });
+
+  it("does not start a second reconcile while one is in flight", async () => {
+    let release: (value: string[]) => void = () => {};
+    invoke.mockImplementation((command: string) => {
+      if (command === "shadow_store_ids") {
+        return new Promise<string[]>((resolve) => {
+          release = resolve;
+        });
+      }
+      return Promise.resolve(0);
+    });
+
+    const first = reconcile(stateWith(item("x:1")) as never);
+    const second = reconcile(stateWith(item("x:1")) as never);
+    release([]);
+    await Promise.all([first, second]);
+
+    // A startup reconcile racing a STATE_UPDATE would otherwise walk the whole
+    // library twice and double every write.
+    expect(callsTo("shadow_store_ids")).toHaveLength(1);
+  });
+
+  it("treats a changed id with no supplied item as a deletion", async () => {
+    window.localStorage.setItem("freed-shadow-store-enabled", "true");
+    let handler: Handler = () => {};
+    start((callback) => {
+      handler = callback;
+      return () => {};
+    });
+
+    handler(stateWith(), {
+      source: "item_patch",
+      requiresFullScan: false,
+      changedItemIds: ["x:gone", "x:kept"],
+      changedItems: [item("x:kept")],
+    });
+    await vi.waitFor(() => expect(callsTo("shadow_store_delete")).toHaveLength(1));
+
+    expect(callsTo("shadow_store_delete")[0]!.globalIds).toStrictEqual(["x:gone"]);
+    expect(
+      (callsTo("shadow_store_upsert")[0]!.rows as { globalId: string }[]).map((r) => r.globalId),
+    ).toStrictEqual(["x:kept"]);
+  });
+
+  it("reconciles rather than patching when the state was replaced wholesale", async () => {
+    window.localStorage.setItem("freed-shadow-store-enabled", "true");
+    let handler: Handler = () => {};
+    start((callback) => {
+      handler = callback;
+      return () => {};
+    });
+
+    handler(stateWith(item("x:1")), {
+      source: "state_update",
+      requiresFullScan: true,
+      changedItemIds: null,
+    });
+
+    // A STATE_UPDATE carries no patch, so a projector that only followed
+    // patches would silently miss it entirely.
+    await vi.waitFor(() => expect(callsTo("shadow_store_ids")).toHaveLength(1));
+  });
+
+  it("never lets a store failure escape into the application", async () => {
+    window.localStorage.setItem("freed-shadow-store-enabled", "true");
+    invoke.mockImplementation(() => Promise.reject(new Error("store unavailable")));
+
+    let handler: Handler = () => {};
+    start((callback) => {
+      handler = callback;
+      return () => {};
+    });
+
+    // Nothing reads these rows yet, so a projector that cannot write must not
+    // be able to break the application it is shadowing. This changes at
+    // Stage 8, when the store becomes the writer.
+    expect(() =>
+      handler(stateWith(), {
+        source: "item_patch",
+        requiresFullScan: false,
+        changedItemIds: ["x:1"],
+        changedItems: [item("x:1")],
+      }),
+    ).not.toThrow();
+  });
+
+  it("chunks large upserts rather than sending one enormous payload", async () => {
+    const many = Array.from({ length: 1_200 }, (_, index) => item(`x:${index}`));
+    await reconcile(stateWith(...many) as never);
+
+    const upserts = callsTo("shadow_store_upsert");
+    expect(upserts.length).toBeGreaterThan(1);
+    for (const call of upserts) {
+      expect((call.rows as unknown[]).length).toBeLessThanOrEqual(500);
+    }
+    const total = upserts.reduce((sum, call) => sum + (call.rows as unknown[]).length, 0);
+    expect(total).toBe(1_200);
+  });
+});

--- a/packages/desktop/src/lib/shadow-sync.ts
+++ b/packages/desktop/src/lib/shadow-sync.ts
@@ -1,0 +1,181 @@
+/**
+ * Wires the shadow store to the live document.
+ *
+ * Stage 5 of the storage roadmap, and the first piece of this series that runs
+ * at all. Everything before it was a dead path proved correct in isolation:
+ * the projection, its losslessness proof against the owner's real 15,846-item
+ * library, the SQLite schema, and the drift detector. This subscribes them to
+ * the running application.
+ *
+ * ## Off by default, and why that is not timidity
+ *
+ * The store is still a shadow. Nothing reads it, so a bug here can only cost
+ * CPU and disk, never correctness. But it writes on every document change on
+ * the main thread, and the whole point of this programme is that the main
+ * thread is where Freed runs out of room. Shipping a projector that is quietly
+ * expensive would be a self-inflicted wound in exactly the place we are trying
+ * to heal, so it starts disabled and is measured before it is trusted.
+ *
+ * ## Two paths, because patches cannot cover everything
+ *
+ * `DocChangeEvent` distinguishes them for us. An event carrying
+ * `changedItemIds` describes a specific mutation and is applied incrementally.
+ * An event with `requiresFullScan` replaced the state wholesale, and there is
+ * no patch to apply, so the store is reconciled against the document instead.
+ *
+ * ## Reconciliation is chunked
+ *
+ * A full reconcile compares every item in the library. On the owner's corpus
+ * that is 15,846 projections, and doing it in one synchronous pass on the main
+ * thread would drop frames during startup, which is precisely the sort of
+ * regression a memory project should not introduce. It runs in bounded slices
+ * yielding between each, and a reconcile already in flight is not started
+ * again.
+ */
+
+import { invoke } from "@tauri-apps/api/core";
+
+import { projectFeedItem } from "@freed/shared";
+import type { FeedItem } from "@freed/shared";
+import type { DocChangeEvent, DocState } from "./automerge-types";
+import { log } from "./logger.js";
+import { recordRuntimeHealthEvent } from "./runtime-health-events";
+
+/** Rows per IPC call. Large enough to amortise the round trip, small enough not to block. */
+const UPSERT_CHUNK = 500;
+/** Items compared per reconcile slice before yielding back to the event loop. */
+const RECONCILE_SLICE = 1_000;
+
+const FLAG_KEY = "freed-shadow-store-enabled";
+
+export function shadowStoreEnabled(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(FLAG_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
+function yieldToEventLoop(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+async function upsert(rows: ReturnType<typeof projectFeedItem>[]): Promise<void> {
+  for (let index = 0; index < rows.length; index += UPSERT_CHUNK) {
+    await invoke("shadow_store_upsert", { rows: rows.slice(index, index + UPSERT_CHUNK) });
+    if (index + UPSERT_CHUNK < rows.length) await yieldToEventLoop();
+  }
+}
+
+async function remove(globalIds: string[]): Promise<void> {
+  if (globalIds.length === 0) return;
+  await invoke("shadow_store_delete", { globalIds });
+}
+
+let reconcileInFlight = false;
+
+/**
+ * Bring the store into agreement with the document, in slices.
+ *
+ * Deliberately compares ids rather than full rows. A value-level comparison
+ * would need every stored row read back across IPC, which on a full library is
+ * far more expensive than the write it is checking. Row-level divergence is
+ * what the Stage 4 differ is for, run deliberately rather than on every
+ * startup.
+ */
+export async function reconcile(state: DocState): Promise<void> {
+  if (reconcileInFlight) return;
+  reconcileInFlight = true;
+  const startedAt = Date.now();
+  try {
+    const storedIds = new Set(await invoke<string[]>("shadow_store_ids"));
+    const items = state.items as unknown as FeedItem[];
+
+    const missing: FeedItem[] = [];
+    const present = new Set<string>();
+    for (let index = 0; index < items.length; index += 1) {
+      const item = items[index];
+      if (item === undefined) continue;
+      present.add(item.globalId);
+      if (!storedIds.has(item.globalId)) missing.push(item);
+      if (index > 0 && index % RECONCILE_SLICE === 0) await yieldToEventLoop();
+    }
+
+    const stale: string[] = [];
+    for (const id of storedIds) if (!present.has(id)) stale.push(id);
+
+    if (missing.length > 0) await upsert(missing.map((item) => projectFeedItem(item)));
+    await remove(stale);
+
+    recordRuntimeHealthEvent({
+      event: "shadow_store_reconciled",
+      itemsInDocument: items.length,
+      rowsBefore: storedIds.size,
+      inserted: missing.length,
+      removed: stale.length,
+      durationMs: Date.now() - startedAt,
+    });
+  } finally {
+    reconcileInFlight = false;
+  }
+}
+
+async function applyIncremental(event: DocChangeEvent): Promise<void> {
+  const changedIds = event.changedItemIds ?? [];
+  const changedItems = (event.changedItems ?? []) as unknown as FeedItem[];
+  if (changedIds.length === 0 && changedItems.length === 0) return;
+
+  const supplied = new Set(changedItems.map((item) => item.globalId));
+  // An id the mutation reported as changed but supplied no item for is a
+  // deletion. The worker filters its patch payload to items that still exist,
+  // so this is what a delete looks like from here.
+  const removed = changedIds.filter((id) => !supplied.has(id));
+
+  if (changedItems.length > 0) await upsert(changedItems.map((item) => projectFeedItem(item)));
+  await remove(removed);
+}
+
+let unsubscribe: (() => void) | null = null;
+
+/**
+ * Start mirroring document changes into the shadow store.
+ *
+ * Returns a stop function. Safe to call when the flag is off, in which case it
+ * does nothing and returns a no-op, so callers do not need to branch.
+ */
+export function startShadowSync(
+  subscribe: (callback: (state: DocState, event: DocChangeEvent) => void) => () => void,
+  getState: () => DocState | null,
+): () => void {
+  if (!shadowStoreEnabled()) return () => {};
+  if (unsubscribe !== null) return unsubscribe;
+
+  // Failures are logged and swallowed on purpose. Nothing reads these rows, so
+  // a projector that cannot write must never be able to break the application
+  // it is shadowing. This changes at Stage 8, when the store becomes the
+  // writer and a failure has to surface.
+  const guard = (work: Promise<void>, context: string): void => {
+    work.catch((error) => {
+      log.warn(`[shadow-sync] ${context} failed: ${String(error)}`);
+      recordRuntimeHealthEvent({ event: "shadow_store_error", context, message: String(error) });
+    });
+  };
+
+  const initial = getState();
+  if (initial !== null) guard(reconcile(initial), "initial reconcile");
+
+  unsubscribe = subscribe((state, event) => {
+    if (event.requiresFullScan) {
+      // State was replaced wholesale; there is no patch to apply.
+      guard(reconcile(state), "reconcile");
+      return;
+    }
+    guard(applyIncremental(event), "incremental");
+  });
+
+  return () => {
+    unsubscribe?.();
+    unsubscribe = null;
+  };
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -54,6 +54,16 @@ export * from "./redact-sensitive";
 export * from "./story-wall";
 export * from "./youtube";
 
+// Storage roadmap stages 4 and 5. Browser-safe: the projection is pure, and the
+// store module declares its own narrow database interface rather than importing
+// a driver, so desktop can bind rusqlite and the PWA sqlite-wasm without either
+// dependency reaching this barrel.
+export * from "./projection";
+export * from "./shadow-store";
+
 // Note: schema.js is NOT re-exported here because it imports Automerge
 // which uses WebAssembly and requires special bundler configuration.
 // For schema operations, import directly from '@freed/shared/schema' in Node.js/Tauri.
+//
+// shadow-projector.js is likewise NOT re-exported: its drift detection takes a
+// FreedDoc, so it imports schema.js and carries the same Automerge constraint.

--- a/packages/shared/src/shadow-projector.test.ts
+++ b/packages/shared/src/shadow-projector.test.ts
@@ -1,0 +1,230 @@
+import { existsSync, readFileSync } from "node:fs";
+import { DatabaseSync } from "node:sqlite";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  applyItemPatch,
+  driftOf,
+  isDrifted,
+  operationsForPatch,
+  projectAll,
+  reconcile,
+} from "./shadow-projector.js";
+import { createShadowSchema, readAllRows } from "./shadow-store.js";
+import type { ShadowDatabase } from "./shadow-store.js";
+import type { FeedItem } from "./types.js";
+
+function openStore(): ShadowDatabase {
+  const db = new DatabaseSync(":memory:") as unknown as ShadowDatabase;
+  createShadowSchema(db);
+  return db;
+}
+
+function makeItem(globalId: string, overrides: Record<string, unknown> = {}): FeedItem {
+  return {
+    globalId,
+    platform: "x",
+    contentType: "post",
+    publishedAt: 1_780_000_000_000,
+    capturedAt: 1_780_000_001_000,
+    author: { id: "a:1", handle: "someone", displayName: "Someone" },
+    content: { text: "hello", mediaUrls: [], mediaTypes: [] },
+    userState: { hidden: false, saved: false, archived: false, tags: [] },
+    ...overrides,
+  } as unknown as FeedItem;
+}
+
+function docOf(...items: FeedItem[]): { feedItems: Record<string, FeedItem> } {
+  return { feedItems: Object.fromEntries(items.map((item) => [item.globalId, item])) };
+}
+
+describe("shadow projector", () => {
+  it("applies inserts and updates from a patch", () => {
+    const db = openStore();
+    applyItemPatch(db, { patches: [{ item: makeItem("x:1") }, { item: makeItem("x:2") }] });
+    expect(readAllRows(db)).toHaveLength(2);
+
+    applyItemPatch(db, {
+      patches: [
+        {
+          item: makeItem("x:1", {
+            userState: { hidden: false, saved: true, archived: false, tags: [] },
+          }),
+        },
+      ],
+    });
+    const rows = readAllRows(db);
+    expect(rows).toHaveLength(2);
+    expect(rows.find((r) => r.globalId === "x:1")?.saved).toBe(1);
+  });
+
+  it("applies a declared removal", () => {
+    const db = openStore();
+    applyItemPatch(db, { patches: [{ item: makeItem("x:1") }, { item: makeItem("x:2") }] });
+    const result = applyItemPatch(db, {
+      patches: [],
+      changedItemIds: ["x:1"],
+      removedItemIds: ["x:1"],
+    });
+    expect(result.deletes).toStrictEqual(["x:1"]);
+    expect(result.missingRemovals).toStrictEqual([]);
+    expect(readAllRows(db).map((r) => r.globalId)).toStrictEqual(["x:2"]);
+  });
+
+  it("treats an undeclared removal as a deletion and counts it", () => {
+    // The reason this module does not just trust removedItemIds: the field is
+    // OPTIONAL in the worker's ITEM_PATCH type. A delete path that forgets it
+    // would otherwise leave a row behind forever, and under Stage 8 that row
+    // becomes the only copy, so the item would appear to be resurrected.
+    const db = openStore();
+    applyItemPatch(db, { patches: [{ item: makeItem("x:1") }, { item: makeItem("x:2") }] });
+
+    const result = applyItemPatch(db, {
+      patches: [],
+      changedItemIds: ["x:1"],
+      // removedItemIds deliberately absent
+    });
+    expect(result.missingRemovals).toStrictEqual(["x:1"]);
+    expect(result.deletes).toStrictEqual(["x:1"]);
+    expect(readAllRows(db).map((r) => r.globalId)).toStrictEqual(["x:2"]);
+  });
+
+  it("does not mistake a supplied item for a removal", () => {
+    const operations = operationsForPatch({
+      patches: [{ item: makeItem("x:1") }],
+      changedItemIds: ["x:1", "x:2"],
+      removedItemIds: ["x:2"],
+    });
+    expect(operations.upserts.map((r) => r.globalId)).toStrictEqual(["x:1"]);
+    expect(operations.deletes).toStrictEqual(["x:2"]);
+    expect(operations.missingRemovals).toStrictEqual([]);
+  });
+
+  it("reports no drift when the store matches the document", () => {
+    const db = openStore();
+    const doc = docOf(makeItem("x:1"), makeItem("x:2"));
+    projectAll(db, doc as never);
+    const drift = driftOf(db, doc as never);
+    expect(isDrifted(drift)).toBe(false);
+    expect(drift.itemsInDocument).toBe(2);
+    expect(drift.rowsInStore).toBe(2);
+  });
+
+  it("detects each of the three ways the projector can fall behind", () => {
+    const db = openStore();
+    const doc = docOf(makeItem("x:1"), makeItem("x:2"), makeItem("x:3"));
+
+    // Missed insert: x:3 never projected.
+    projectAll(db, docOf(makeItem("x:1"), makeItem("x:2")) as never);
+    // Missed delete: x:9 is in the store but not the document.
+    applyItemPatch(db, { patches: [{ item: makeItem("x:9") }] });
+    // Missed update: x:2 changed in the document after being projected.
+    const changed = makeItem("x:2", {
+      userState: { hidden: true, saved: false, archived: false, tags: [] },
+    });
+    const driftDoc = docOf(makeItem("x:1"), changed, makeItem("x:3"));
+
+    const drift = driftOf(db, driftDoc as never);
+    expect(drift.missingFromStore).toStrictEqual(["x:3"]);
+    expect(drift.staleInStore).toStrictEqual(["x:9"]);
+    expect(drift.divergentRows).toStrictEqual(["x:2"]);
+    expect(isDrifted(drift)).toBe(true);
+    void doc;
+  });
+
+  it("reconcile repairs the store and reports what was wrong before repairing", () => {
+    const db = openStore();
+    projectAll(db, docOf(makeItem("x:1")) as never);
+    applyItemPatch(db, { patches: [{ item: makeItem("x:stale") }] });
+    const target = docOf(
+      makeItem("x:1"),
+      makeItem("x:2"),
+      makeItem("x:3", { platform: "facebook" }),
+    );
+
+    const before = reconcile(db, target as never);
+    // The returned drift describes the state BEFORE repair. A reconcile that
+    // reported a clean result would make the projector look correct exactly
+    // when it was not, which is the failure this whole module exists to avoid.
+    expect(before.missingFromStore.sort()).toStrictEqual(["x:2", "x:3"]);
+    expect(before.staleInStore).toStrictEqual(["x:stale"]);
+
+    const after = driftOf(db, target as never);
+    expect(isDrifted(after)).toBe(false);
+    expect(readAllRows(db).map((r) => r.globalId).sort()).toStrictEqual(["x:1", "x:2", "x:3"]);
+  });
+
+  it("reconcile is a no-op on an already-correct store", () => {
+    const db = openStore();
+    const doc = docOf(makeItem("x:1"), makeItem("x:2"));
+    projectAll(db, doc as never);
+    const drift = reconcile(db, doc as never);
+    expect(isDrifted(drift)).toBe(false);
+    expect(readAllRows(db)).toHaveLength(2);
+  });
+
+  it("survives replaying the same patch twice", () => {
+    // At-least-once delivery is the realistic assumption for a worker message
+    // that may be re-sent after a reconnect or a reconcile that races a patch.
+    const db = openStore();
+    const event = { patches: [{ item: makeItem("x:1") }] };
+    applyItemPatch(db, event);
+    applyItemPatch(db, event);
+    expect(readAllRows(db)).toHaveLength(1);
+  });
+
+  it("survives deleting an id that is not in the store", () => {
+    const db = openStore();
+    projectAll(db, docOf(makeItem("x:1")) as never);
+    expect(() =>
+      applyItemPatch(db, { patches: [], changedItemIds: ["x:gone"], removedItemIds: ["x:gone"] }),
+    ).not.toThrow();
+    expect(readAllRows(db)).toHaveLength(1);
+  });
+});
+
+const fixture = process.env.FREED_CORPUS_FIXTURE;
+const hasFixture = fixture !== undefined && fixture !== "" && existsSync(fixture);
+
+describe.skipIf(!hasFixture)("shadow projector against a real corpus", () => {
+  it("converges on the real document and reports zero drift", async () => {
+    const automerge = await import("@automerge/automerge");
+    const doc = automerge.load(new Uint8Array(readFileSync(fixture as string)));
+    const db = openStore();
+
+    const projected = projectAll(db, doc as never);
+    expect(projected).toBeGreaterThan(0);
+
+    const drift = driftOf(db, doc as never);
+    if (isDrifted(drift)) {
+      throw new Error(
+        `drift after projecting ${projected} items: ` +
+          `${drift.missingFromStore.length} missing, ` +
+          `${drift.staleInStore.length} stale, ` +
+          `${drift.divergentRows.length} divergent`,
+      );
+    }
+    expect(drift.rowsInStore).toBe(projected);
+  }, 300_000);
+
+  it("detects a single tampered row in the real corpus", async () => {
+    // A drift detector that cannot fail on 15,846 rows proves nothing. Corrupt
+    // exactly one row and confirm it is found.
+    const automerge = await import("@automerge/automerge");
+    const doc = automerge.load(new Uint8Array(readFileSync(fixture as string)));
+    const db = openStore();
+    projectAll(db, doc as never);
+
+    const [victim] = readAllRows(db);
+    db.prepare("UPDATE feed_items SET authorDisplayName = ? WHERE globalId = ?").run(
+      "tampered",
+      victim!.globalId,
+    );
+
+    const drift = driftOf(db, doc as never);
+    expect(drift.divergentRows).toStrictEqual([victim!.globalId]);
+    expect(drift.missingFromStore).toHaveLength(0);
+    expect(drift.staleInStore).toHaveLength(0);
+  }, 300_000);
+});

--- a/packages/shared/src/shadow-projector.ts
+++ b/packages/shared/src/shadow-projector.ts
@@ -1,0 +1,192 @@
+/**
+ * Keeps the shadow store in step with the Automerge document.
+ *
+ * Stage 4 built the projection and proved it lossless, and Stage 4b proved the
+ * round trip survives a real database. Neither of them writes anything at
+ * runtime. This is the part that does, and it is where the interesting failure
+ * lives, because a projector is only useful if it cannot silently fall behind.
+ *
+ * It can fall behind for three reasons, and all three are properties of the
+ * existing worker protocol rather than hypotheticals:
+ *
+ * 1. `ITEM_PATCH.removedItemIds` is declared optional. A delete path that does
+ *    not populate it leaves a row in the store for an item that no longer
+ *    exists in the document.
+ * 2. `ITEM_PATCH` is not the only message that changes the document.
+ *    `STATE_UPDATE` replaces state wholesale, and a projector that only follows
+ *    patches never sees it.
+ * 3. The process restarts. Patches that arrived while it was not running were
+ *    not applied to anything.
+ *
+ * So incremental application alone is not a design, it is half of one. The
+ * other half is `reconcile`, which compares the store against the document and
+ * repairs the difference, and `driftOf`, which reports the difference without
+ * repairing it so drift can be measured before Stage 8 depends on its absence.
+ *
+ * Stage 8 makes the write path one-way. After that, an item the projector
+ * missed is not recoverable from anywhere, which is the whole reason this
+ * module reports drift as a first-class result instead of quietly fixing it.
+ */
+
+import { projectFeedItem } from "./projection.js";
+import { SHADOW_DELETE_SQL, readAllRows, upsertRows } from "./shadow-store.js";
+import type { ShadowDatabase } from "./shadow-store.js";
+import type { FeedItemRow } from "./projection.js";
+import type { FreedDoc } from "./schema.js";
+import type { FeedItem } from "./types.js";
+
+/** The subset of a worker ITEM_PATCH this module needs. */
+export interface ItemPatchEvent {
+  /** Items that still exist, already cloned by the worker. */
+  patches: readonly { readonly item: FeedItem }[];
+  /** Every id the mutation touched, including ones that were deleted. */
+  changedItemIds?: readonly string[];
+  /** Ids the mutation removed. Optional in the worker protocol, hence `missingRemovals`. */
+  removedItemIds?: readonly string[];
+}
+
+export interface RowOperations {
+  upserts: FeedItemRow[];
+  deletes: string[];
+  /**
+   * Ids the mutation reported as changed but did not supply an item for, and
+   * did not list as removed either. Under the current protocol that means a
+   * deletion the sender did not declare. They are treated as deletions, and
+   * counted, because a projector that guesses silently is how drift starts.
+   */
+  missingRemovals: string[];
+}
+
+/**
+ * Turn one patch event into row operations. Pure, so the interesting decision
+ * (what to do about an undeclared removal) is visible in a test rather than
+ * buried in an event handler.
+ */
+export function operationsForPatch(event: ItemPatchEvent): RowOperations {
+  const upserts = event.patches.map((patch) => projectFeedItem(patch.item));
+  const supplied = new Set(upserts.map((row) => row.globalId));
+  const declaredRemovals = event.removedItemIds ?? [];
+  const deletes = [...declaredRemovals];
+
+  // An id that changed, produced no item, and was not declared removed. The
+  // worker filters `patches` to items that still exist, so this is what a
+  // delete looks like when `removedItemIds` was not populated.
+  const declared = new Set(declaredRemovals);
+  const missingRemovals: string[] = [];
+  for (const id of event.changedItemIds ?? []) {
+    if (supplied.has(id) || declared.has(id)) continue;
+    missingRemovals.push(id);
+    deletes.push(id);
+  }
+
+  return { upserts, deletes, missingRemovals };
+}
+
+export function applyOperations(db: ShadowDatabase, operations: RowOperations): void {
+  if (operations.upserts.length > 0) upsertRows(db, operations.upserts);
+  if (operations.deletes.length > 0) {
+    const statement = db.prepare(SHADOW_DELETE_SQL);
+    for (const globalId of operations.deletes) statement.run(globalId);
+  }
+}
+
+/** Apply one worker patch event to the store. Returns what it did. */
+export function applyItemPatch(db: ShadowDatabase, event: ItemPatchEvent): RowOperations {
+  const operations = operationsForPatch(event);
+  applyOperations(db, operations);
+  return operations;
+}
+
+export interface ProjectionDrift {
+  /** In the document, absent from the store. The projector missed an insert. */
+  missingFromStore: string[];
+  /** In the store, absent from the document. The projector missed a delete. */
+  staleInStore: string[];
+  /** Present in both, but the projected row differs. The projector missed an update. */
+  divergentRows: string[];
+  itemsInDocument: number;
+  rowsInStore: number;
+}
+
+export function isDrifted(drift: ProjectionDrift): boolean {
+  return (
+    drift.missingFromStore.length > 0 ||
+    drift.staleInStore.length > 0 ||
+    drift.divergentRows.length > 0
+  );
+}
+
+/**
+ * Compare the store against the document without changing either.
+ *
+ * Reported rather than repaired on purpose. Before Stage 8 the document is
+ * still the source of truth, so drift is a bug to be found and fixed at its
+ * cause. A projector that silently self-heals would hide exactly the defect
+ * that has to be gone before the write path becomes one-way.
+ */
+export function driftOf(db: ShadowDatabase, doc: FreedDoc): ProjectionDrift {
+  const items = (doc.feedItems ?? {}) as Record<string, FeedItem>;
+  const stored = new Map<string, FeedItemRow>();
+  for (const row of readAllRows(db)) stored.set(row.globalId, row);
+
+  const missingFromStore: string[] = [];
+  const divergentRows: string[] = [];
+  for (const [globalId, item] of Object.entries(items)) {
+    const row = stored.get(globalId);
+    if (row === undefined) {
+      missingFromStore.push(globalId);
+      continue;
+    }
+    const expected = projectFeedItem(item);
+    for (const key of Object.keys(expected) as (keyof FeedItemRow)[]) {
+      if (!Object.is(expected[key], row[key])) {
+        divergentRows.push(globalId);
+        break;
+      }
+    }
+  }
+
+  const staleInStore: string[] = [];
+  for (const globalId of stored.keys()) {
+    if (!Object.prototype.hasOwnProperty.call(items, globalId)) {
+      staleInStore.push(globalId);
+    }
+  }
+
+  return {
+    missingFromStore,
+    staleInStore,
+    divergentRows,
+    itemsInDocument: Object.keys(items).length,
+    rowsInStore: stored.size,
+  };
+}
+
+/**
+ * Bring the store into agreement with the document and report what was wrong.
+ *
+ * Used at startup and after any message that replaces state wholesale. The
+ * returned drift describes the state BEFORE the repair, so a caller can log or
+ * alarm on it. Repairing without reporting would make the projector look
+ * correct precisely when it is not.
+ */
+export function reconcile(db: ShadowDatabase, doc: FreedDoc): ProjectionDrift {
+  const drift = driftOf(db, doc);
+  if (!isDrifted(drift)) return drift;
+
+  const items = (doc.feedItems ?? {}) as Record<string, FeedItem>;
+  const upserts: FeedItemRow[] = [];
+  for (const globalId of [...drift.missingFromStore, ...drift.divergentRows]) {
+    const item = items[globalId];
+    if (item !== undefined) upserts.push(projectFeedItem(item));
+  }
+  applyOperations(db, { upserts, deletes: drift.staleInStore, missingRemovals: [] });
+  return drift;
+}
+
+/** Project an entire document into an empty store. Startup, and the Stage 4b tests. */
+export function projectAll(db: ShadowDatabase, doc: FreedDoc): number {
+  const items = Object.values((doc.feedItems ?? {}) as Record<string, FeedItem>);
+  upsertRows(db, items.map((item) => projectFeedItem(item)));
+  return items.length;
+}

--- a/packages/shared/src/shadow-store-schema-parity.test.ts
+++ b/packages/shared/src/shadow-store-schema-parity.test.ts
@@ -1,0 +1,96 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { SHADOW_COLUMNS, SHADOW_TABLE_DDL } from "./shadow-store.js";
+
+/**
+ * The shadow store schema exists twice: once in TypeScript, once in Rust at
+ * packages/desktop/src-tauri/src/shadow_store.rs. Two copies of a schema drift.
+ *
+ * That is normally an annoyance. Here it is a data-loss bug waiting to happen,
+ * because Stage 8 makes the write path one-way: after the retained Automerge
+ * copy is pruned, a column the Rust side never wrote is not recoverable from
+ * anywhere. A comment asking the next person to keep them in sync would not
+ * survive contact with a hurried change, so this reads the Rust file and fails
+ * instead.
+ */
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const RUST_SOURCE = path.resolve(
+  HERE,
+  "../../desktop/src-tauri/src/shadow_store.rs",
+);
+
+function rustSource(): string {
+  return readFileSync(RUST_SOURCE, "utf8");
+}
+
+/** Pull the string literals out of the `COLUMNS` slice. */
+function rustColumns(source: string): string[] {
+  const match = source.match(/pub const COLUMNS: &\[&str\] = &\[([\s\S]*?)\];/);
+  if (match === null) throw new Error("COLUMNS not found in shadow_store.rs");
+  return [...match[1]!.matchAll(/"([^"]+)"/g)].map((entry) => entry[1]!);
+}
+
+/** Pull the column names out of the Rust CREATE TABLE body. */
+function rustTableColumns(source: string): string[] {
+  const match = source.match(
+    /CREATE TABLE IF NOT EXISTS feed_items \(([\s\S]*?)\) STRICT;/,
+  );
+  if (match === null) throw new Error("CREATE TABLE not found in shadow_store.rs");
+  return match[1]!
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .map((line) => line.split(/\s+/)[0]!)
+    .filter((name) => /^[A-Za-z]/.test(name));
+}
+
+function tsTableColumns(): string[] {
+  const match = SHADOW_TABLE_DDL.match(
+    /CREATE TABLE IF NOT EXISTS feed_items \(([\s\S]*?)\) STRICT;/,
+  );
+  if (match === null) throw new Error("CREATE TABLE not found in SHADOW_TABLE_DDL");
+  return match[1]!
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .map((line) => line.split(/\s+/)[0]!)
+    .filter((name) => /^[A-Za-z]/.test(name));
+}
+
+describe("shadow store schema parity across the IPC boundary", () => {
+  it("declares the same columns, in the same order, on both sides", () => {
+    // Order matters as much as membership: both sides generate their INSERT
+    // from this list positionally, so a reordering binds every value to the
+    // wrong column and still executes without error.
+    expect(rustColumns(rustSource())).toStrictEqual([...SHADOW_COLUMNS]);
+  });
+
+  it("keeps each side's CREATE TABLE consistent with its own column list", () => {
+    expect(rustTableColumns(rustSource()).sort()).toStrictEqual(
+      [...SHADOW_COLUMNS].sort(),
+    );
+    expect(tsTableColumns().sort()).toStrictEqual([...SHADOW_COLUMNS].sort());
+  });
+
+  it("keeps the table STRICT on both sides", () => {
+    // STRICT is what turns a lossy affinity coercion into an error at the
+    // write. Losing it on one side only would mean the two engines silently
+    // disagree about what was stored.
+    expect(SHADOW_TABLE_DDL).toContain(") STRICT");
+    expect(rustSource()).toContain(") STRICT");
+  });
+
+  it("binds every column on the Rust side", () => {
+    // The Rust bind() builds a positional vector by hand. A column added to
+    // COLUMNS but missed there shifts every later value by one and still
+    // executes. Rust has its own test for the count; this asserts the guard
+    // exists at all, so deleting it fails here too.
+    expect(rustSource()).toContain("fn binds_every_declared_column");
+    expect(rustSource()).toContain("COLUMNS.len()");
+  });
+});


### PR DESCRIPTION
(AI Generated).

Stage 5 of [the storage roadmap](docs/STORAGE-ARCHITECTURE-ROADMAP.md), stacked on Stage 4 (#1143, merged).

**Draft, and it needs your Gate 1 call before it can go ready.** See the Provider Review section: the diff touches one provider-visible file, `packages/desktop/src-tauri/src/lib.rs`, and I am not self-certifying that.

## Why this stage matters

The owner decided on 2026-07-25 to fix the Facebook and Instagram blockage through the architecture rather than by tuning the 4 GiB scrape gate (#1146). That makes Stages 5 through 7 the whole path, and this is the first stage where the corpus starts leaving the renderer.

Measured on the owner's real 15,846-item document:

| | RSS over baseline |
| --- | --- |
| Automerge document in the renderer | 927 MB |
| Same items served from SQL | **7 MB** |

## Three pieces

### 1. The continuous projector

Stage 4 proved the projection lossless and proved it survives a real database. Neither wrote anything at runtime. This does.

Reading the worker protocol first meant no change-feed had to be invented: `ITEM_PATCH` already carries `patches` and an explicit `removedItemIds`. But that field is declared **optional**, and that single word is the whole design problem. A delete path that does not populate it strands a row, and after Stage 8 makes the write path one-way that row is the only copy, so a deleted item appears to come back.

So `operationsForPatch` treats an id that changed, supplied no item, and was not declared removed as a deletion, and **counts it** in `missingRemovals` rather than guessing quietly. `reconcile` covers what patches structurally cannot: `STATE_UPDATE` replacing state wholesale, and process restarts.

`driftOf` reports without repairing, and `reconcile` returns the drift as it was **before** the repair. That ordering is deliberate. Until Stage 8 the document is still the source of truth, so drift is a defect to fix at its cause; a projector that silently self-heals would conceal exactly the bug that has to be absent before the write path becomes one-way.

### 2. rusqlite

`bundled`, so SQLite compiles from source and every install runs the same engine. Linking whatever `libsqlite3` a machine ships would make FTS5 availability and STRICT table support vary per install, and the projection contract depends on both.

New dependencies in a shipping app, both now in `Cargo.lock`: `rusqlite 0.32.1`, `libsqlite3-sys 0.30.1`.

WAL, and `synchronous=NORMAL` rather than `FULL`. This store is a projection: if a crash loses the last commits, reconciliation against the document rebuilds them. Paying for full durability on the weaker copy would be paying twice.

### 3. A schema guard across the language boundary

The schema now exists twice, once per language. Normally an annoyance; here a data-loss hazard, because after Stage 8 a column the Rust side never writes is unrecoverable.

`COLUMNS` is the single list both the DDL and the INSERT are generated from, and a test in the shared package reads `shadow_store.rs` and fails if the two sides disagree on membership, **order**, or STRICT. Order matters as much as membership: both sides bind positionally, so a reordering writes every value to the wrong column and still executes without error.

That guard was mutation-tested rather than assumed. Swapping two columns in the Rust list fails it; restoring them passes.

## Evidence

```
Rust:   7 passed; 0 failed        (incl. STRICT rejects "not-a-number" into INTEGER,
                                   and counts return 0 not NULL on a fresh install)
shared: 104 passed                (incl. 12 projector, 4 schema parity)
tsc --noEmit clean
```

Against the real corpus: zero drift after projection, and a single tampered row out of 15,846 is detected. A drift detector that cannot fail proves nothing, so that second case is a test rather than an assumption.

## Nothing calls any of this

No command is invoked, no projector is subscribed. Deliberately still a dead path. Wiring it to the worker stream is the first behavioral change in the series and belongs in its own PR, behind a flag, with the SQL path compared against the Automerge path before anything switches.

## Provider Review

- Status: **Draft. Requires owner Gate 1 authority before ready.**
- Provider-visible file in this diff: `packages/desktop/src-tauri/src/lib.rs`
- The change to it, in full: one `mod shadow_store;` declaration, and four command names added to `tauri::generate_handler!`.
- Observable behavior: none. No request, navigation, cookie, header, retry, user agent, media preload, canvas or WebGL behavior changes, and no scrape cadence or timing changes. No extractor script is touched. The new commands are never invoked by any caller in this diff.
- Fingerprinting risk: none identified. Nothing in this diff causes Freed to contact any provider.
- Second-order effect, stated for completeness: this is a step toward moving the corpus out of the renderer, which would eventually reduce renderer memory and therefore make `scrape_memory_preflight` refuse Facebook and Instagram less often. That is the intent of the roadmap and the owner's decision on #1146, but no part of it takes effect in this PR.

I have not written a Gate 1 artifact, because Gate 1 is an owner approval of a described behavior before code, and inventing one on your behalf would defeat the point of the gate.