### PR TITLE
chore(deps): take the cargo major upgrades and migrate the call sites

### DIFF
--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -44,6 +44,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "android_log-sys"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -198,6 +207,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
+
+[[package]]
 name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -206,7 +221,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools",
  "proc-macro2",
  "quote",
  "regex",
@@ -264,6 +279,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -549,6 +573,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -672,13 +707,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
 
 [[package]]
-name = "concurrent-queue"
-version = "2.5.0"
+name = "const-oid"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
-]
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "convert_case"
@@ -756,6 +788,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -766,25 +807,24 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.5.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
 dependencies = [
+ "alloca",
  "anes",
  "cast",
  "ciborium",
  "clap",
  "criterion-plot",
- "is-terminal",
- "itertools 0.10.5",
+ "itertools",
  "num-traits",
- "once_cell",
  "oorandom",
+ "page_size",
  "plotters",
  "rayon",
  "regex",
  "serde",
- "serde_derive",
  "serde_json",
  "tinytemplate",
  "walkdir",
@@ -792,12 +832,12 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.5.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
- "itertools 0.10.5",
+ "itertools",
 ]
 
 [[package]]
@@ -848,6 +888,15 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1073,8 +1122,19 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -1300,9 +1360,9 @@ checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fax"
@@ -1373,9 +1433,9 @@ dependencies = [
 
 [[package]]
 name = "flume"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1440,7 +1500,7 @@ dependencies = [
 name = "freed-desktop"
 version = "26.7.2300"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.0",
  "criterion",
  "fslock",
  "futures-util",
@@ -1453,13 +1513,13 @@ dependencies = [
  "objc2-app-kit",
  "objc2-foundation",
  "objc2-web-kit",
- "rand 0.8.5",
+ "rand 0.10.2",
  "reqwest",
  "rquest",
  "rquest-util",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "sysinfo",
  "tauri",
  "tauri-build",
@@ -1477,7 +1537,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
- "window-vibrancy",
+ "window-vibrancy 0.8.0",
 ]
 
 [[package]]
@@ -1742,10 +1802,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
- "wasip2",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasm-bindgen",
 ]
 
@@ -1975,12 +2047,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2075,6 +2141,15 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -2302,12 +2377,12 @@ dependencies = [
 
 [[package]]
 name = "if-addrs"
-version = "0.13.4"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69b2eeee38fef3aa9b4cc5f1beea8a2444fc00e7377cafae396de3f5c2065e24"
+checksum = "c0a05c691e1fae256cf7013d99dad472dc52d5543322761f83ec8d47eab40d2b"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2382,17 +2457,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "is-wsl"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2400,15 +2464,6 @@ checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
 dependencies = [
  "is-docker",
  "once_cell",
-]
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
 ]
 
 [[package]]
@@ -2730,15 +2785,17 @@ checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "mdns-sd"
-version = "0.11.5"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fe7c11a1eb3cfbfcf702d1601c1f5f4c102cdc8665b8a557783ef634741676e"
+checksum = "f18d8ec9d1869796fb2910d95f4d957072df0b6a22e247a1d760d8b4c805e17a"
 dependencies = [
+ "fastrand",
  "flume",
  "if-addrs",
  "log",
- "polling",
- "socket2 0.5.10",
+ "mio",
+ "socket-pktinfo",
+ "socket2 0.6.5",
 ]
 
 [[package]]
@@ -2791,6 +2848,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
@@ -3152,6 +3210,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-open-directory"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb82bed227edf5201dfedf072bba4015a33d3d4a98519837295a90f0a23f676d"
+dependencies = [
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-osa-kit"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3277,6 +3346,16 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -3609,22 +3688,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "polling"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
-dependencies = [
- "autocfg",
- "bitflags 1.3.2",
- "cfg-if",
- "concurrent-queue",
- "libc",
- "log",
- "pin-project-lite",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3819,14 +3882,15 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.10.2",
+ "rand_pcg 0.10.2",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3868,6 +3932,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3884,7 +3954,7 @@ dependencies = [
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc",
- "rand_pcg",
+ "rand_pcg 0.2.1",
 ]
 
 [[package]]
@@ -3900,12 +3970,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.5",
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3929,16 +4000,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.5",
-]
-
-[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3958,12 +4019,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.9.5"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.4",
-]
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_hc"
@@ -3981,6 +4039,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -4623,13 +4690,13 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4639,8 +4706,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4735,6 +4813,17 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket-pktinfo"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e8e43b4bdce7cff8a4d3f8025ee38fce5ca138fab868ebbf9529c81328fbf9d"
+dependencies = [
+ "libc",
+ "socket2 0.6.5",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "socket2"
@@ -4946,16 +5035,17 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.37.2"
+version = "0.39.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16607d5caffd1c07ce073528f9ed972d88db15dd44023fa57142963be3feb11f"
+checksum = "d2071df9448915b71c4fe6d25deaf1c22f12bd234f01540b77312bb8e41361e6"
 dependencies = [
  "libc",
  "memchr",
  "ntapi",
  "objc2-core-foundation",
  "objc2-io-kit",
- "windows",
+ "objc2-open-directory",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -5026,7 +5116,7 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
@@ -5114,8 +5204,8 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "window-vibrancy",
- "windows",
+ "window-vibrancy 0.6.0",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -5156,7 +5246,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "syn 2.0.114",
  "tauri-utils",
  "thiserror 2.0.18",
@@ -5372,7 +5462,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -5398,7 +5488,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "wry",
 ]
 
@@ -5460,7 +5550,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -5668,9 +5758,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.26.2"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
+checksum = "17a073bfed563fa236697a068031408a93cd9522e08abf9933ead3e73411bd71"
 dependencies = [
  "futures-util",
  "log",
@@ -5947,19 +6037,18 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.26.2"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+checksum = "e48ac77174b19c110a50ab2128b24215ac9cb40e0e12e093fb602d175c569d22"
 dependencies = [
  "bytes",
  "data-encoding",
  "http",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.10.2",
  "sha1",
  "thiserror 2.0.18",
- "utf-8",
 ]
 
 [[package]]
@@ -5990,9 +6079,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unic-char-property"
@@ -6445,7 +6534,7 @@ checksum = "7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-implement",
  "windows-interface",
@@ -6469,7 +6558,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.18",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
 ]
 
@@ -6526,16 +6615,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "window-vibrancy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe6461139557c2245c3b9b34de2092e7af39460bf97ef4723bc5feb0cf66f831"
+dependencies = [
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-quartz-core",
+ "raw-window-handle",
+ "windows-sys 0.60.2",
+ "windows-version",
+]
+
+[[package]]
 name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-collections",
+ "windows-collections 0.2.0",
  "windows-core 0.61.2",
- "windows-future",
+ "windows-future 0.2.1",
  "windows-link 0.1.3",
- "windows-numerics",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
 ]
 
 [[package]]
@@ -6545,6 +6662,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -6581,7 +6707,18 @@ checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
- "windows-threading",
+ "windows-threading 0.1.0",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -6626,6 +6763,16 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -6686,15 +6833,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -6746,21 +6884,6 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
@@ -6802,6 +6925,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "windows-version"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6815,12 +6947,6 @@ name = "windows_aarch64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -6842,12 +6968,6 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -6863,12 +6983,6 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6902,12 +7016,6 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -6923,12 +7031,6 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6950,12 +7052,6 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -6971,12 +7067,6 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -7079,7 +7169,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "raw-window-handle",
- "sha2",
+ "sha2 0.10.9",
  "soup3",
  "tao-macros",
  "thiserror 2.0.18",
@@ -7087,7 +7177,7 @@ dependencies = [
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -25,23 +25,23 @@ tauri-plugin-clipboard-manager = "=2.3.2"
 log = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-window-vibrancy = "0.6"
+window-vibrancy = "0.8"
 # default-features = false drops native-tls (OpenSSL) which conflicts with rquest's BoringSSL on Linux.
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 rquest = { version = "5", features = ["json"] }
 rquest-util = "2"
 tokio = { version = "1", features = ["full"] }
-tokio-tungstenite = "0.26"
+tokio-tungstenite = "0.30"
 futures-util = "0.3"
 fslock = "0.2.1"
 local-ip-address = "0.6"
-mdns-sd = "0.11"
+mdns-sd = "0.20"
 hostname = "0.4"
-rand = "0.8"
-base64 = "0.22"
+rand = "0.10"
+base64 = "0.23"
 url = "2"
-sysinfo = "0.37"
-sha2 = "0.10"
+sysinfo = "0.39"
+sha2 = "0.11"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
@@ -53,7 +53,7 @@ objc2-foundation = { version = "0.3", default-features = false, features = ["std
 objc2-web-kit = { version = "0.3", features = ["WKWebViewConfiguration"] }
 
 [dev-dependencies]
-criterion = { version = "0.5", features = ["html_reports"] }
+criterion = { version = "0.8", features = ["html_reports"] }
 tempfile = "3"
 
 [[bench]]

--- a/packages/desktop/src-tauri/benches/relay.rs
+++ b/packages/desktop/src-tauri/benches/relay.rs
@@ -171,7 +171,7 @@ fn bench_json_serialise(c: &mut Criterion) {
                     // Array.from(Uint8Array) and then Tauri serialises it.
                     let as_array: Vec<u8> = bin.to_vec();
                     let json = serde_json::to_vec(&as_array).expect("json");
-                    criterion::black_box(json);
+                    std::hint::black_box(json);
                 });
             },
         );

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -7,7 +7,7 @@ mod youtube;
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use futures_util::{SinkExt, StreamExt};
 use log::{error, info, warn};
-use rand::{Rng, RngCore};
+use rand::{Rng, RngExt};
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet, VecDeque};
 #[cfg(unix)]
@@ -1015,7 +1015,7 @@ async fn restore_scraper_feed(
 /// base64url without padding (43 ASCII characters).
 fn generate_token() -> String {
     let mut bytes = [0u8; 32];
-    rand::thread_rng().fill_bytes(&mut bytes);
+    rand::rng().fill_bytes(&mut bytes);
     URL_SAFE_NO_PAD.encode(bytes)
 }
 
@@ -5022,13 +5022,29 @@ fn get_platform() -> String {
     std::env::consts::OS.to_string()
 }
 
+// sha2 0.11 returns a hybrid-array `Array`, which dropped the `LowerHex` impl
+// that `format!("{:x}", ..)` relied on under 0.10. Encode by hand so the string
+// stays exactly what it was: lower case, zero padded, no separators. Both
+// callers compare against digests persisted by earlier builds, so a change in
+// encoding would read as a changed hash and invalidate them.
+fn hex_digest(bytes: impl AsRef<[u8]>) -> String {
+    use std::fmt::Write as _;
+
+    let bytes = bytes.as_ref();
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        let _ = write!(out, "{byte:02x}");
+    }
+    out
+}
+
 fn hash_desktop_installation_witness(machine_id: &str, user_id: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(b"freed-desktop-installation-witness-v1\0");
     hasher.update(machine_id.trim().as_bytes());
     hasher.update(b"\0");
     hasher.update(user_id.trim().as_bytes());
-    format!("{:x}", hasher.finalize())
+    hex_digest(hasher.finalize())
 }
 
 #[cfg(target_os = "macos")]
@@ -5734,7 +5750,7 @@ async fn sha256_file(app: tauri::AppHandle, path: String) -> Result<String, Stri
         hasher.update(&buffer[..read]);
     }
 
-    Ok(format!("{:x}", hasher.finalize()))
+    Ok(hex_digest(hasher.finalize()))
 }
 
 fn validate_local_ai_download_url(raw: &str) -> Result<(), String> {
@@ -8141,10 +8157,10 @@ async fn close_x_login_window(app: tauri::AppHandle) -> Result<(), String> {
 /// Uses the Box-Muller transform to convert two uniform samples to a normal
 /// variate, which is fast and requires no external crate.
 fn gaussian_ms(mean: f64, std_dev: f64) -> u64 {
-    use rand::Rng;
-    let mut rng = rand::thread_rng();
-    let u1: f64 = rng.gen_range(f64::EPSILON..1.0);
-    let u2: f64 = rng.gen_range(0.0..1.0);
+    use rand::RngExt;
+    let mut rng = rand::rng();
+    let u1: f64 = rng.random_range(f64::EPSILON..1.0);
+    let u2: f64 = rng.random_range(0.0..1.0);
     let z = (-2.0 * u1.ln()).sqrt() * (2.0 * std::f64::consts::PI * u2).cos();
     (mean + z * std_dev).max(400.0) as u64
 }
@@ -8546,12 +8562,12 @@ async fn fb_show_login(
     .title("Connect Facebook — Freed")
     .inner_size(
         460.0 + {
-            use rand::Rng;
-            rand::thread_rng().gen_range(-8.0f64..8.0)
+            use rand::RngExt;
+            rand::rng().random_range(-8.0f64..8.0)
         },
         700.0 + {
-            use rand::Rng;
-            rand::thread_rng().gen_range(-10.0f64..10.0)
+            use rand::RngExt;
+            rand::rng().random_range(-10.0f64..10.0)
         },
     )
     .center()
@@ -8682,7 +8698,7 @@ async fn fb_check_auth(
 /// Bails early if the story viewer closes (overlay no longer present) or
 /// if `max_frames` have been viewed.
 async fn scrape_fb_stories(wv: &tauri::WebviewWindow, max_frames: usize) {
-    use rand::Rng;
+    use rand::RngExt;
 
     let _ = set_background_scraper_media_guard(wv, true);
     info!("[FB] story scrape start, max_frames={}", max_frames);
@@ -8737,7 +8753,7 @@ async fn scrape_fb_stories(wv: &tauri::WebviewWindow, max_frames: usize) {
         }
 
         // Pause to let the user "view" this story frame (2-4s normally, ~8% chance of 6-8s)
-        let view_pause = if rand::thread_rng().gen_bool(0.08) {
+        let view_pause = if rand::rng().random_bool(0.08) {
             gaussian_ms(7000.0, 1000.0)
         } else {
             gaussian_ms(3000.0, 700.0)
@@ -8794,7 +8810,7 @@ async fn scrape_fb_stories(wv: &tauri::WebviewWindow, max_frames: usize) {
 /// row of circular avatars at the top of the Following feed), then advances
 /// through frames using the right-side click area.
 async fn scrape_ig_stories(wv: &tauri::WebviewWindow, max_frames: usize) {
-    use rand::Rng;
+    use rand::RngExt;
 
     let _ = set_background_scraper_media_guard(wv, true);
     info!("[IG] story scrape start, max_frames={}", max_frames);
@@ -8844,7 +8860,7 @@ async fn scrape_ig_stories(wv: &tauri::WebviewWindow, max_frames: usize) {
         }
 
         // "View" pause: 2-4s normally, ~8% chance of 6-8s (lingering on a story)
-        let view_pause = if rand::thread_rng().gen_bool(0.08) {
+        let view_pause = if rand::rng().random_bool(0.08) {
             gaussian_ms(7000.0, 1000.0)
         } else {
             gaussian_ms(3000.0, 600.0)
@@ -9098,16 +9114,16 @@ async fn fb_scrape_feed(
     let skip_stories = scrape_plan.skip_stories
         || !optional_story_scrape_may_continue(&app, "Facebook", "feed scrape")
         || {
-            use rand::Rng;
-            rand::thread_rng().gen_bool(0.15)
+            use rand::RngExt;
+            rand::rng().random_bool(0.15)
         };
     let stories_first = !skip_stories && {
-        use rand::Rng;
-        rand::thread_rng().gen_bool(0.50)
+        use rand::RngExt;
+        rand::rng().random_bool(0.50)
     };
     let story_frame_cap = {
-        use rand::Rng;
-        rand::thread_rng().gen_range(2usize..=4)
+        use rand::RngExt;
+        rand::rng().random_range(2usize..=4)
     };
 
     if stories_first {
@@ -9124,15 +9140,15 @@ async fn fb_scrape_feed(
     // they're near the viewport, and are unmounted when scrolled away.
     // We must scroll incrementally, extracting at each position.
     let num_passes = {
-        use rand::Rng;
-        rand::thread_rng().gen_range(scrape_plan.min_passes.max(1)..=scrape_plan.max_passes.max(1))
+        use rand::RngExt;
+        rand::rng().random_range(scrape_plan.min_passes.max(1)..=scrape_plan.max_passes.max(1))
     };
     // If doing feed-first, split the passes: 2-4 passes before stories, rest after.
     let early_passes = if !stories_first && !skip_stories {
-        use rand::Rng;
+        use rand::RngExt;
         let upper = 4usize.min(num_passes.saturating_sub(1).max(1));
         let lower = 2usize.min(upper);
-        rand::thread_rng().gen_range(lower..=upper)
+        rand::rng().random_range(lower..=upper)
     } else {
         num_passes // all passes in one go
     };
@@ -9152,8 +9168,8 @@ async fn fb_scrape_feed(
         }
 
         let scroll_amount = {
-            use rand::Rng;
-            rand::thread_rng().gen_range(280u64..520)
+            use rand::RngExt;
+            rand::rng().random_range(280u64..520)
         };
         let scroll_js = social_feed_scroll_script(scroll_amount as i64);
         wv.eval(&scroll_js).map_err(|e| e.to_string())?;
@@ -9161,12 +9177,12 @@ async fn fb_scrape_feed(
 
         // Occasional micro-backscroll (~12% probability) simulates re-reading.
         if {
-            use rand::Rng;
-            rand::thread_rng().gen_bool(0.12)
+            use rand::RngExt;
+            rand::rng().random_bool(0.12)
         } {
             let back = {
-                use rand::Rng;
-                rand::thread_rng().gen_range(80u64..250)
+                use rand::RngExt;
+                rand::rng().random_range(80u64..250)
             };
             let back_js = social_feed_scroll_script(-(back as i64));
             let _ = wv.eval(&back_js);
@@ -9175,8 +9191,8 @@ async fn fb_scrape_feed(
 
         // Gaussian pause between scroll passes; ~25% chance of a longer "reading" pause.
         let pause = if {
-            use rand::Rng;
-            rand::thread_rng().gen_bool(0.25)
+            use rand::RngExt;
+            rand::rng().random_bool(0.25)
         } {
             gaussian_ms(6000.0, 1500.0)
         } else {
@@ -9675,12 +9691,12 @@ async fn ig_show_login(
     .title("Connect Instagram — Freed")
     .inner_size(
         460.0 + {
-            use rand::Rng;
-            rand::thread_rng().gen_range(-8.0f64..8.0)
+            use rand::RngExt;
+            rand::rng().random_range(-8.0f64..8.0)
         },
         700.0 + {
-            use rand::Rng;
-            rand::thread_rng().gen_range(-10.0f64..10.0)
+            use rand::RngExt;
+            rand::rng().random_range(-10.0f64..10.0)
         },
     )
     .center()
@@ -9959,16 +9975,16 @@ async fn ig_scrape_feed(
     let skip_stories = scrape_plan.skip_stories
         || !optional_story_scrape_may_continue(&app, "Instagram", "feed scrape")
         || (!placeholder_feed && {
-            use rand::Rng;
-            rand::thread_rng().gen_bool(0.15)
+            use rand::RngExt;
+            rand::rng().random_bool(0.15)
         });
     let stories_first = !skip_stories && {
-        use rand::Rng;
-        placeholder_feed || rand::thread_rng().gen_bool(0.50)
+        use rand::RngExt;
+        placeholder_feed || rand::rng().random_bool(0.50)
     };
     let story_frame_cap = {
-        use rand::Rng;
-        rand::thread_rng().gen_range(2usize..=4)
+        use rand::RngExt;
+        rand::rng().random_range(2usize..=4)
     };
 
     if stories_first {
@@ -9988,15 +10004,15 @@ async fn ig_scrape_feed(
     // Instagram virtualizes its feed similarly to Facebook. Scroll
     // incrementally, extracting at each position.
     let num_passes = {
-        use rand::Rng;
-        rand::thread_rng().gen_range(scrape_plan.min_passes.max(1)..=scrape_plan.max_passes.max(1))
+        use rand::RngExt;
+        rand::rng().random_range(scrape_plan.min_passes.max(1)..=scrape_plan.max_passes.max(1))
     };
     // Feed-first: scrape stories after the first 2-4 passes
     let early_passes = if !stories_first && !skip_stories {
-        use rand::Rng;
+        use rand::RngExt;
         let upper = 4usize.min(num_passes.saturating_sub(1).max(1));
         let lower = 2usize.min(upper);
-        rand::thread_rng().gen_range(lower..=upper)
+        rand::rng().random_range(lower..=upper)
     } else {
         num_passes
     };
@@ -10026,8 +10042,8 @@ async fn ig_scrape_feed(
         }
 
         let scroll_amount = {
-            use rand::Rng;
-            rand::thread_rng().gen_range(380u64..720)
+            use rand::RngExt;
+            rand::rng().random_range(380u64..720)
         };
         let scroll_js = social_feed_scroll_script(scroll_amount as i64);
         wv.eval(&scroll_js).map_err(|e| e.to_string())?;
@@ -10035,12 +10051,12 @@ async fn ig_scrape_feed(
 
         // Micro-backscroll ~12% of the time.
         if {
-            use rand::Rng;
-            rand::thread_rng().gen_bool(0.12)
+            use rand::RngExt;
+            rand::rng().random_bool(0.12)
         } {
             let back = {
-                use rand::Rng;
-                rand::thread_rng().gen_range(80u64..250)
+                use rand::RngExt;
+                rand::rng().random_range(80u64..250)
             };
             let back_js = social_feed_scroll_script(-(back as i64));
             let _ = wv.eval(&back_js);
@@ -10049,8 +10065,8 @@ async fn ig_scrape_feed(
 
         // Gaussian pause; ~25% chance of longer "reading" pause.
         let pause = if {
-            use rand::Rng;
-            rand::thread_rng().gen_bool(0.25)
+            use rand::RngExt;
+            rand::rng().random_bool(0.25)
         } {
             gaussian_ms(5500.0, 1500.0)
         } else {
@@ -10401,12 +10417,12 @@ async fn li_show_login(
     .title("Connect LinkedIn with Freed")
     .inner_size(
         460.0 + {
-            use rand::Rng;
-            rand::thread_rng().gen_range(-8.0f64..8.0)
+            use rand::RngExt;
+            rand::rng().random_range(-8.0f64..8.0)
         },
         700.0 + {
-            use rand::Rng;
-            rand::thread_rng().gen_range(-10.0f64..10.0)
+            use rand::RngExt;
+            rand::rng().random_range(-10.0f64..10.0)
         },
     )
     .center()
@@ -10641,8 +10657,8 @@ async fn li_scrape_feed(
     // LinkedIn virtualizes its feed: scroll incrementally, extracting at each
     // position. Fewer passes than FB (LinkedIn loads fewer posts per scroll).
     let num_passes = {
-        use rand::Rng;
-        rand::thread_rng().gen_range(4usize..=8)
+        use rand::RngExt;
+        rand::rng().random_range(4usize..=8)
     };
 
     // Inject the extract script as a const so we can append done=true on last pass.
@@ -10690,8 +10706,8 @@ async fn li_scrape_feed(
         }
 
         let scroll_amount = {
-            use rand::Rng;
-            rand::thread_rng().gen_range(350u64..650)
+            use rand::RngExt;
+            rand::rng().random_range(350u64..650)
         };
         let scroll_js = social_feed_scroll_script(scroll_amount as i64);
         wv.eval(&scroll_js).map_err(|e| e.to_string())?;
@@ -10699,12 +10715,12 @@ async fn li_scrape_feed(
 
         // Occasional micro-backscroll (~12% probability).
         if {
-            use rand::Rng;
-            rand::thread_rng().gen_bool(0.12)
+            use rand::RngExt;
+            rand::rng().random_bool(0.12)
         } {
             let back = {
-                use rand::Rng;
-                rand::thread_rng().gen_range(80u64..200)
+                use rand::RngExt;
+                rand::rng().random_range(80u64..200)
             };
             let back_js = social_feed_scroll_script(-(back as i64));
             let _ = wv.eval(&back_js);
@@ -10713,8 +10729,8 @@ async fn li_scrape_feed(
 
         // Gaussian pause; longer pauses more common than FB (LinkedIn users scroll slower).
         let pause = if {
-            use rand::Rng;
-            rand::thread_rng().gen_bool(0.30)
+            use rand::RngExt;
+            rand::rng().random_bool(0.30)
         } {
             gaussian_ms(7000.0, 2000.0)
         } else {
@@ -11247,7 +11263,7 @@ async fn scroll_essay_roster_surface(
         }
     });
 
-    let scroll_ratio = rand::thread_rng().gen_range(0.72f64..1.28f64);
+    let scroll_ratio = rand::rng().random_range(0.72f64..1.28f64);
     let event_name =
         serde_json::to_string(ESSAY_ROSTER_SCROLL_EVENT).map_err(|error| error.to_string())?;
     let script = format!(
@@ -11350,8 +11366,8 @@ async fn show_essay_provider_login(
     .initialization_script(include_str!("webkit-mask.js"))
     .title(provider.login_title)
     .inner_size(
-        500.0 + rand::thread_rng().gen_range(-8.0f64..8.0),
-        720.0 + rand::thread_rng().gen_range(-10.0f64..10.0),
+        500.0 + rand::rng().random_range(-8.0f64..8.0),
+        720.0 + rand::rng().random_range(-10.0f64..10.0),
     )
     .center()
     .visible(true)
@@ -14658,6 +14674,20 @@ mod tests {
         assert_ne!(
             first,
             hash_desktop_installation_witness("machine-a", "user-b")
+        );
+    }
+
+    // Pins the digest itself, not just its length. Witnesses are persisted by
+    // earlier builds and compared on later launches, so the hex encoding is
+    // part of the format. The sha2 0.11 upgrade had to replace the `{:x}`
+    // formatting this once relied on, and a silent shift to upper case or a
+    // separator would still have satisfied the length and scoping assertions
+    // above while invalidating every stored witness.
+    #[test]
+    fn desktop_installation_witness_encoding_is_stable() {
+        assert_eq!(
+            hash_desktop_installation_witness("machine-a", "user-a"),
+            "220d7bdd4df1bf6ce110652b6b5ca6f1425c4429f55fb1096be194dd26ac32bb"
         );
     }
 


### PR DESCRIPTION
(AI Generated).

Replaces #1131, which could not merge as-is: `rand` 0.8 to 0.10 does not compile without source changes. Also folds in #1119, whose quinn-proto advisory fix was stuck behind the same `Cargo.lock`.

| Crate | From | To |
|---|---|---|
| window-vibrancy | 0.6 | 0.8 |
| tokio-tungstenite | 0.26 | 0.30 |
| mdns-sd | 0.11 | 0.20 |
| rand | 0.8 | 0.10 |
| base64 | 0.22 | 0.23 |
| sysinfo | 0.37 | 0.39 |
| sha2 | 0.10 | 0.11 |
| criterion | 0.5 | 0.8 |
| quinn-proto | 0.11.13 | 0.11.16 |

### rand

0.9 and 0.10 renamed most of the surface this repo touches: `thread_rng` to `rng`, `gen_range` to `random_range`, `gen_bool` to `random_bool`, and the `Rng` extension trait to `RngExt` now that `rand_core::RngCore` has taken the `Rng` name. Sixty call sites in `lib.rs` follow the renames. Spelling only, no behaviour change.

### sha2

0.11 returns a `hybrid-array` `Array`, which dropped the `LowerHex` impl that `format!("{:x}", ..)` depended on, so both digest sites stopped compiling.

This one deserved care rather than a mechanical fix. Both digests are **persisted and compared across launches**: one is the desktop installation witness, the other verifies local AI model downloads. A silent shift to upper case or a separator would invalidate every stored value. Replaced the formatting with a `hex_digest` helper that emits identical lower case unseparated hex, and pinned it with a test against a digest computed independently outside Rust. The existing test only asserted `len() == 64` plus scoping, so it would have passed an upper case regression.

### Verification

`cargo test --all-features` gives **159 passed, 0 failed** (158 before, plus the new encoding test). `cargo clippy --all-targets` reports no new warnings beyond the two pre-existing dead code ones, and `criterion::black_box` was switched to `std::hint::black_box` to clear the deprecation the criterion bump introduced.

### Unrelated finding worth knowing

`cargo update` cannot run in this repo at all. Every one of the 152 published versions of `rquest` is yanked from crates.io, including the pinned 5.1.0, so any full re-resolution fails on `failed to select a version for the requirement rquest = "^5"`. Builds only keep working because `Cargo.lock` pins it and cargo will still fetch a locked yanked crate. That is a standing supply chain risk on a crate in the request path, and it is worth a decision separate from this PR. Targeted resolution still works, which is how this branch was built.