### PR TITLE
fix: sync the roadmap layout ref after commit instead of during render

### DIFF
--- a/website/src/app/roadmap/RoadmapContent.tsx
+++ b/website/src/app/roadmap/RoadmapContent.tsx
@@ -289,8 +289,15 @@ function useDataFlow(layout: (typeof LAYOUT)["desktop"]) {
   );
   const nextId = useRef(0);
   const frameRef = useRef<number>(0);
+  // spawnParticle runs from an interval rather than from render, so it reads the
+  // layout through a ref to stay stable instead of tearing down the frame loop
+  // every time the breakpoint changes. Sync the ref after commit: assigning it
+  // during render is what react-hooks flags, and the interval cannot observe the
+  // value until after commit anyway.
   const layoutRef = useRef(layout);
-  layoutRef.current = layout;
+  useEffect(() => {
+    layoutRef.current = layout;
+  }, [layout]);
 
   const pulseCapture = useCallback((index: number) => {
     setCapturePulseKeys((prev) => {


### PR DESCRIPTION
(AI Generated).

Unblocks #1124. That group bumps `eslint-plugin-react-hooks` 7.0.1 to 7.1.1, which added the rule that fails the website build with:

```
./src/app/roadmap/RoadmapContent.tsx
293:3  Error: Error: Cannot access refs during render
```

`useDataFlow` mirrored the `layout` prop into a ref by assigning during render, the usual latest-ref trick, so `spawnParticle` could stay referentially stable and not tear down the frame loop on every breakpoint change. The new rule flags the assignment.

Moved it into an effect keyed on `layout`. `spawnParticle` is only ever invoked from the `setInterval` inside the frame loop effect and never during render, so it cannot observe the ref before commit. Timing is unchanged.

Landing this separately from the dependency bump because it touches no lockfile, so it can merge in parallel rather than joining the queue behind the other npm PRs. Once it is on `dev`, #1124 needs only a rebase.

Verified with `next lint` (clean) and a full `next build` (succeeds, `/roadmap` prerenders).