### PR TITLE
chore: stop grouping major dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,18 @@
 # Every dependabot PR launches the full Validation matrix, so ungrouped bumps are
 # the single largest consumer of runner time in this repo. Group by risk class
-# instead of by package: routine minor and patch bumps batch into one PR, major
-# bumps batch separately so a risky upgrade is never buried in a safe batch, and
+# instead of by package: routine minor and patch bumps batch into one PR, and
 # security fixes get their own group so a broken routine bump can never block them.
 #
 # open-pull-requests-limit does not apply to security updates, so grouping is the
 # only lever that bounds their PR count.
+#
+# Majors are deliberately NOT grouped. Batching them looks like it saves runner
+# time and does the opposite, because a group can only merge when every member
+# can. One batch here carried automerge 3, typescript 7, tailwind 4 and vite 8 at
+# once: four unrelated migrations, no reviewer, and a weekly rebase that burned
+# the full matrix every time without ever merging. Ungrouped, each major is one
+# reviewable PR that either lands or gets closed on its own merits, and
+# open-pull-requests-limit still bounds how many are open at a time.
 version: 2
 updates:
   - package-ecosystem: npm
@@ -32,12 +39,6 @@ updates:
           - patch
         patterns:
           - "*"
-      major-updates:
-        applies-to: version-updates
-        update-types:
-          - major
-        patterns:
-          - "*"
       security-updates:
         applies-to: security-updates
         patterns:
@@ -56,12 +57,6 @@ updates:
         update-types:
           - minor
           - patch
-        patterns:
-          - "*"
-      cargo-major-updates:
-        applies-to: version-updates
-        update-types:
-          - major
         patterns:
           - "*"
       cargo-security-updates:


### PR DESCRIPTION
(AI Generated).

Grouping majors was meant to keep a risky upgrade from being buried in a safe batch. It achieved the opposite: it buried every risky upgrade in a batch with all the other risky upgrades.

A grouped PR can only merge when every member can. The npm majors group has been sitting open carrying **automerge 3, typescript 7, tailwind 4 and vite 8** simultaneously. Four unrelated migrations, no way to review them as a unit, no way to land any one of them, and a weekly rebase that re-runs the full Validation matrix each time. That is exactly the runner cost the grouping was written to avoid, except paid forever and buying nothing. I closed that group twice today and Dependabot immediately rebuilt it, which is correct behaviour and the reason this needs a config change rather than another close.

Ungrouped, each major shows up as one PR that can be judged on its own and either landed or closed with a reason. `open-pull-requests-limit: 5` still bounds how many are open at once.

Minor, patch and security grouping is untouched. That is where batching genuinely pays, and it worked: the routine groups merged today without incident.

Applied to both the npm and cargo ecosystems. Config re-parsed to confirm it is still valid YAML and the remaining groups are intact.