### PR TITLE
docs: record the Turso evaluation, with its reproduction

### DIFF
--- a/docs/STORAGE-ARCHITECTURE-ROADMAP.md
+++ b/docs/STORAGE-ARCHITECTURE-ROADMAP.md
@@ -53,13 +53,19 @@ These are latent only because PWA to desktop convergence does not exist. Fixing 
 | MVCC | Experimental; all statements on a connection share one transaction |
 | in-place `VACUUM` / `incremental_vacuum` | Experimental / No |
 
-The fatal one is FTS. The entire justification for accepting a pre-1.0 dependency was that SQLite file-format compatibility makes the swap reversible. **A Tantivy index is not SQLite B-tree pages**, and the `CREATE INDEX` statement is not parseable by stock SQLite. The escape hatch preserves the data but not the search index, on the one subsystem that is load-bearing rather than an optimisation.
+> **This section's original reasoning has been retracted and replaced by measurement.** It argued the fatal flaw was that "a Tantivy index is not SQLite B-tree pages", so the escape hatch preserves data but not the search index. That objection is weak and the owner correctly rejected it: indexes are derived data, you rebuild them. Do not use it.
+>
+> Turso was then benchmarked properly against the real corpus. **The verdict is unchanged but the reasons are different and much stronger.** See [TURSO-EVALUATION.md](TURSO-EVALUATION.md) for the full record, the reproduction scripts, and the adoption gate. In brief:
+>
+> - **Incremental FTS ingest scales with index size**: 313 ms/row into a 95,076-row index versus SQLite's flat 0.20 ms/row, about 1,570x. Plain writes are fine, so "Turso writes get slower as the database grows" is the wrong summary and will send you after the wrong thing.
+> - **Silent, total index corruption.** Any virtual-table module Turso does not implement causes it to open a connection with no indexes at all and skip index maintenance on every write, while reporting success. Measured: 650 writes, zero reflected in any index, stale pre-update values left indexed. Traced to a swallowed error at `core/lib.rs:1514-1519`. Unfixed on `main` and unreported upstream.
+> - **Turso costs 48x more peak RSS to build an index** (+153.5 MB vs SQLite's +3.2 MB) and carries ~474 MB more resident on the same corpus. For a project whose blocker is renderer memory, that alone decides it.
 
 **The PWA unlock is not Turso-specific.** Official SQLite WASM over OPFS delivers identical page-cache physics, at 1.0, with FTS5 and `STORED` generated columns. The physics win is *a paged store instead of a CRDT*. It was never Turso.
 
-Decision: **rusqlite on desktop, official sqlite-wasm on the phone, Turso as a read-only CI conformance track** from Stage 4 — open every fixture with both engines and diff. Cheap, keeps the option genuinely alive, generates real readiness signal.
+Decision: **rusqlite on desktop, official sqlite-wasm on the phone.** The originally planned "Turso as a read-only CI conformance track from Stage 4" is dropped: stock SQLite cannot open a Turso-FTS file at all, so the diff it was meant to generate is not possible, and a conformance track against an engine that silently drops index writes would manufacture false confidence rather than readiness signal.
 
-Adoption gate, written down so it is checkable: revisit when generated columns are `STORED` and stable without an experimental flag, `changes()` supports triggers, and either FTS5 is supported or the FTS index is fully external to the database file.
+Adoption gate: see [TURSO-EVALUATION.md](TURSO-EVALUATION.md). The trigger is specific probes passing, not a version number.
 
 ## The floor
 

--- a/docs/TURSO-EVALUATION.md
+++ b/docs/TURSO-EVALUATION.md
@@ -1,0 +1,233 @@
+# Turso evaluation
+
+**Decision: use stock SQLite. Do not adopt Turso.** rusqlite on desktop, official sqlite-wasm over OPFS on the PWA.
+
+Decided 2026-07-24, re-verified 2026-07-25 against Turso 0.7.1. This document exists because Turso is genuinely appealing and the question will come back. It records what was measured, so the next conversation starts from evidence instead of from the appeal.
+
+Reproduction scripts and raw results are in [`docs/turso-evaluation/`](turso-evaluation/).
+
+---
+
+## Read this first if you are here to relitigate
+
+Two arguments are **not** the reason, and should not be used:
+
+- **"A Tantivy index is not SQLite pages, so file-format reversibility breaks."** Retracted. Indexes are derived data; you rebuild them. This objection was raised in a first analysis and was correctly called weak.
+- **"It is pre-1.0."** Not an argument here. Freed is pre-1.0 too, and the project deliberately adopts bleeding-edge technology.
+
+The real reasons are below, and neither is about portability or version numbers.
+
+---
+
+## Test conditions
+
+| | |
+| --- | --- |
+| corpus | 110,922 rows, 160 MB of body text, 222.8 MB database |
+| note on scale | this is **7 copies** of the owner's real corpus; real scale is 15,846 items |
+| platform | darwin-arm64 |
+| Turso | 0.7.1 via `@tursodatabase/database` |
+| SQLite | 3.51.2 via `node:sqlite` |
+
+0.7.1 **is** the current release as of 2026-07-25 (published 2026-07-22). `v0.8.0-pre.1` is an earlier branch cut from 2026-07-20, not a newer version.
+
+---
+
+## Disqualifier 1: incremental FTS ingest scales with index size
+
+Plain writes are fine. Base row insert and build were comparable: **SQLite 1,063 ms vs Turso 1,115 ms**. If someone tells you "Turso writes get slower as the database grows", that is not what was measured and it will send you after the wrong thing.
+
+What degrades is full-text index maintenance. A 500-row batch into a 95,076-row index:
+
+| | total | per row |
+| --- | --- | --- |
+| SQLite FTS5 (including the AFTER INSERT/UPDATE/DELETE triggers external-content FTS5 needs) | 79 ms | **0.20 ms** |
+| Turso | 156,600 ms | **313 ms** |
+
+Roughly 1,570x. Two independent runs, so not warm-up.
+
+The cost scales with total index size, consistent with rewriting the index on each commit:
+
+| base rows | Turso ms/row | SQLite ms/row |
+| --- | --- | --- |
+| 500 | 2.02 | 0.02–0.13 (flat) |
+| 2,000 | 4.2 | |
+| 8,000 | 29.6 | |
+| 95,076 | 313 | |
+
+**Turso's FTS is build-once, not maintainable.** Freed ingests continuously, so a single new feed item would cost roughly 300 ms to index.
+
+Reproduce: [`inc-scaling.mjs`](turso-evaluation/inc-scaling.mjs), [`incremental.mjs`](turso-evaluation/incremental.mjs). Results: [`results/inc-turso.json`](turso-evaluation/results/inc-turso.json), [`results/inc-sqlite.json`](turso-evaluation/results/inc-sqlite.json).
+
+---
+
+## Disqualifier 2: silent, total index corruption
+
+This is the serious one, and it is much broader than the first measurement suggested.
+
+### What happens
+
+Turso writing into a database that contains **any virtual table module Turso does not implement** silently stops maintaining **every index in that database**. Writes report success. Table scans return the new rows. The indexes do not know any of it happened.
+
+Measured: seed 100 rows with SQLite, then perform 500 inserts, 100 updates and 50 deletes through Turso.
+
+- Table scan afterwards: **550 rows**, and stock SQLite agrees.
+- `idx_tag` and `idx_n`: still exactly the original **100** entries.
+- **Zero of 650 writes reached any index.**
+- The 100 updated rows keep their **stale pre-update values indexed**, so index-driven reads return rows that no longer match the query.
+- `PRAGMA integrity_check` on stock SQLite lists rows missing from indexes. Turso's own `integrity_check` reports "Page 3: never used" through "Page 9: never used" — it does not believe the index pages exist.
+
+### What triggers it
+
+Not what you would guess:
+
+- **Not FTS5-specific.** fts4 and rtree do it too. Any module Turso lacks.
+- **Not about the virtual table's own data.** A vtab on a completely unrelated table still corrupts writes to other tables.
+- **Not a standalone-vs-external-content distinction.** A plain `CREATE VIRTUAL TABLE docs USING fts5(body)` is enough.
+- **Not the implicit primary-key autoindex.** Ordinary `CREATE INDEX` indexes are lost as well.
+- Read-only access with a vtab present is safe. Only writes corrupt.
+
+### Root cause, read in the source (v0.7.1)
+
+1. `core/vtab.rs:353` returns `LimboError::ExtensionError("Virtual table module not found: fts5")`.
+2. `core/schema.rs:2098-2109` propagates it out of `handle_schema_row`, called with `?` at `core/schema.rs:1636-1647`, which aborts the schema scan.
+3. `populate_indices(...)` at `core/schema.rs:1674` therefore **never runs**. Indexes are accumulated as `UnparsedFromSqlIndex` and only attached in that post-loop pass.
+4. `core/lib.rs:1514-1519` catches the error and **swallows it**:
+
+   ```rust
+   Err(LimboError::ExtensionError(e)) => {
+       // this means that a vtab exists and we no longer have the module loaded.
+       // we print a warning to the user to load the module
+       state.schema_guard = None;
+       tracing::warn!("open warning, failed to load extension: {e}");
+   }
+   ```
+
+The connection opens with tables and **no indexes at all**, and every subsequent write skips index maintenance.
+
+### Status
+
+**Unfixed on `main`** (331 commits ahead of v0.7.1 as of 2026-07-25). Commit `727efd8c` rewrote the classification but `core/schema.rs:2115-2127` still calls `VirtualTable::table(...)?` for an unknown module, and `core/lib.rs:1621-1626` contains the identical swallow verbatim.
+
+**There is no upstream issue for this.** It appears to be unreported.
+
+Reproduce: [`blast2.mjs`](turso-evaluation/blast2.mjs), [`write-safety.mjs`](turso-evaluation/write-safety.mjs).
+
+---
+
+## Memory, which is the one that matters most for Freed
+
+Freed's central problem is renderer memory. Turso is worse on it, in both directions.
+
+| index build over the same 110,922 rows | build ms | peak RSS delta | resident before build | index size |
+| --- | --- | --- | --- | --- |
+| SQLite FTS5 porter | 3,108 | **+3.2 MB** | 300.4 MB | 68.3 MB (43% of text) |
+| SQLite FTS5 unicode61 | 3,127 | **+3.2 MB** | 300.2 MB | 71.7 MB (45%) |
+| Turso `USING fts` | 7,706 | **+153.5 MB** | **774.1 MB** | 167 MB (104%) |
+| Turso ngram | 28,785 | +481.2 MB | — | 326.5 MB |
+
+Turso is **48x worse on peak build RSS** and carries roughly **474 MB more resident** on the same corpus before the index build even begins.
+
+> **Note for anyone quoting these numbers:** every "A vs B" pair in this document is **SQLite first, Turso second**. This pair has been transposed at least once in conversation, which inverted the entire argument. SQLite is the 3.2 MB one.
+
+Steady-state resident on 110,922 rows was fine for both: 48.7 MB vs 62.9 MB. File size was identical at 222.8 MB.
+
+Raw: [`results/sqlite-porter-7.json`](turso-evaluation/results/sqlite-porter-7.json), [`results/turso-default-7.json`](turso-evaluation/results/turso-default-7.json). Measurement window is `fts.mjs:101-126`, which wraps only the index-build statement, identically for both engines.
+
+---
+
+## Search quality: the "Tantivy beats FTS5" premise is false as shipped
+
+| capability | Turso 0.7.1 | SQLite FTS5 |
+| --- | --- | --- |
+| prefix `democr*` | **0 hits** across 7 syntaxes, literal and bound | 1,372 hits |
+| stemming (`run` vs `running`) | **0 hits**; no stemmer exists (tokenizers are default/raw/simple/whitespace/ngram) | porter stems correctly |
+| fuzzy `climat~1` | **0 hits, no error** | trigram gives substring and partial typo tolerance |
+| `fts_score(body, ?)` with a bound parameter | silently returns **0**; needs literal constants, i.e. concatenating user input into SQL | n/a |
+| multi-term default | OR (`climate change` → 6,277) | AND (315) |
+| ngram | works, but 477–794 ms per query, unusable interactively | — |
+
+Open upstream: #7636, #7637, #7532 (`fts_score` returns 0), #7530 (FK cascades bypass FTS maintenance), #4973 (FTS index not updated after `UPDATE OR REPLACE`, open since February), #5027 (index does not roll back on failed insert), #7611 (valid inserts make `integrity_check` report FTS directory mismatch), #7800 (custom index modules unsupported under MVCC, so FTS is unavailable on any Cloud database), #6533 (incremental maintenance, open since 2026-04-22, one comment, no owner).
+
+**Prefix search and stemming have no issue filed at all**, so they are not tracked as gaps.
+
+Reproduce: [`gate.mjs`](turso-evaluation/gate.mjs), [`quality.mjs`](turso-evaluation/quality.mjs).
+
+---
+
+## What Turso genuinely wins
+
+Worth stating plainly, because a fair record is more useful than a one-sided one.
+
+**Very high frequency terms.** `that` (54,320 hits), top-10: SQLite 28.38 ms vs Turso **2.25 ms**, 12.6x faster. FTS5's `ORDER BY rank` scores every match; Tantivy does top-K pruning.
+
+**Predictable latency.** Turso is flat at 1.6–2.5 ms across every query shape. SQLite ranges 0.02–28 ms.
+
+But that flatness is a floor, not a ceiling: Turso is faster on **2 of 11** query shapes. SQLite wins the other 9, often by 5x to 80x (`climate` 0.32 vs 1.92 ms; `tantivy` 0.02 vs 1.63 ms).
+
+Per-call binding overhead is identical between the two, so Turso's latency is real index work rather than napi cost.
+
+---
+
+## Can the ingest cost be architected around?
+
+Yes. It is not worth it.
+
+Disqualifier 2 rules out an FTS5 table anywhere in a file Turso writes, so the only viable shapes are a separate search file or an external index. Rebuild-and-swap was costed at full scale ([`mitigations.mjs`](turso-evaluation/mitigations.mjs), [`results/mitigations.json`](turso-evaluation/results/mitigations.json)):
+
+- Full rebuild of 110,922 rows in Turso: 7,746 ms, +109.6 MB peak, 371.3 MB sidecar.
+- Search stayed online against the previous sidecar throughout: 17 queries, 0 failures, max latency 1.78 ms.
+- Atomic rename swap: 247 ms.
+
+It works. The problem is the comparison. Freed's real corpus is **15,846 items**, not 110,922. At real scale, **stock SQLite rebuilds its entire search index from scratch in roughly 0.44 seconds for 3.2 MB of peak RSS.** The machinery built to avoid the cost is more expensive than the cost.
+
+The other options and what they cost:
+
+- **Turso rows + SQLite FTS5 in a separate file.** Two files with no cross-file transaction, so you inherit dual-write reconciliation and orphan cleanup. And you must guarantee nothing ever creates an fts5 table in the Turso file, because if anything does, index maintenance silently stops. A landmine with no compile-time guard.
+- **External index (Tantivy directly).** A real option, but it makes Turso irrelevant to the decision.
+
+---
+
+## Reversibility, stated correctly
+
+Stock SQLite **cannot open a Turso-FTS database at all**:
+
+```
+malformed database schema (__turso_internal_fts_dir_items_fts_key) - near "USING": syntax error
+```
+
+Turso writes `CREATE INDEX ... USING ...` into `sqlite_master`. SQLite validates all of `sqlite_master` on open, so the whole schema load fails and **no table in the file is readable** — not just the indexed one. You also lose `integrity_check`, the `sqlite3` CLI, and every other diagnostic and repair tool on that file.
+
+Mitigation, measured ([`drop-mitigation.mjs`](turso-evaluation/drop-mitigation.mjs)): `DROP INDEX items_fts` from Turso fully cleans `sqlite_master`, after which stock SQLite opens the file normally. So recovery exists, **but only through Turso, and only while Turso can still open the file.**
+
+Turso's FTS lives inside the single `.db` file; there is no Tantivy sidecar directory.
+
+Reproduce: [`crossread.mjs`](turso-evaluation/crossread.mjs), [`blast3.mjs`](turso-evaluation/blast3.mjs).
+
+---
+
+## Adoption gate
+
+**The trigger to revisit is not a new version number.** It is these probes passing:
+
+1. [`blast2.mjs`](turso-evaluation/blast2.mjs) returns `sqlite_viaIdxTagCount == sqlite_tableScanCount` and `integrity == ["ok"]`.
+2. [`gate.mjs`](turso-evaluation/gate.mjs) returns a non-empty `prefix_star` and a non-zero `score_bound_param`.
+3. Incremental FTS maintenance that does not scale with total index size (re-run [`inc-scaling.mjs`](turso-evaluation/inc-scaling.mjs) and require a flat ms/row curve).
+4. Peak RSS during index build within the same order of magnitude as SQLite's, given Freed's memory constraints.
+
+**As of 2026-07-25 on 0.7.1, zero of these hold.**
+
+---
+
+## Running the scripts
+
+They expect Turso and a corpus that are not checked in:
+
+```bash
+npm i @tursodatabase/database
+node docs/turso-evaluation/gate.mjs
+```
+
+Node must be the repo's pinned version (see `.nvmrc`); `node:sqlite` is used for the SQLite side. The scripts build their own fixtures. The 110,922-row corpus was generated by replicating the owner's real document seven times; at real scale, divide the row-count-dependent figures accordingly.
+
+Result JSON in [`results/`](turso-evaluation/results/) is the output of the original runs, kept as the evidence behind the tables above.

--- a/docs/turso-evaluation/blast2.mjs
+++ b/docs/turso-evaluation/blast2.mjs
@@ -1,0 +1,59 @@
+// Follow-up: is index maintenance *entirely* disabled when an fts5 vtab is in the
+// file, or is it an edge case? And does the damage spread into the fts5 shadow btrees?
+import fs from 'node:fs';
+const SCRATCH = process.env.SCRATCH;
+const { connect } = await import('@tursodatabase/database');
+const { DatabaseSync } = await import('node:sqlite');
+const out = {};
+
+const p = `${SCRATCH}/blast2.db`;
+for (const s of ['', '-wal', '-shm']) fs.rmSync(p + s, { force: true });
+const s = new DatabaseSync(p);
+s.exec(`PRAGMA journal_mode=WAL;
+  CREATE TABLE items(id INTEGER PRIMARY KEY, tag TEXT, n INTEGER);
+  CREATE INDEX idx_tag ON items(tag);
+  CREATE INDEX idx_n ON items(n);
+  CREATE VIRTUAL TABLE docs USING fts5(body);
+  INSERT INTO docs(body) VALUES('unrelated corpus about climate policy');`);
+for (let i = 1; i <= 100; i++) s.prepare('INSERT INTO items VALUES(?,?,?)').run(i, `t${i}`, i);
+s.exec('PRAGMA wal_checkpoint(TRUNCATE)');
+out.sqliteSeeded = s.prepare('SELECT COUNT(*) c FROM items').all()[0].c;
+out.seedIntegrity = s.prepare('PRAGMA integrity_check').all().map(x => x.integrity_check).slice(0, 3);
+s.close();
+
+// Turso: 500 inserts, 100 updates, 50 deletes
+const t = await connect(p, { experimental: ['index_method'] });
+const ins = t.prepare('INSERT INTO items VALUES(?,?,?)');
+await t.exec('BEGIN');
+for (let i = 101; i <= 600; i++) await ins.run([i, `t${i}`, i]);
+await t.exec('COMMIT');
+const upd = t.prepare('UPDATE items SET tag=? WHERE id=?');
+await t.exec('BEGIN');
+for (let i = 1; i <= 100; i++) await upd.run([`u${i}`, i]);
+await t.exec('COMMIT');
+const del = t.prepare('DELETE FROM items WHERE id=?');
+await t.exec('BEGIN');
+for (let i = 201; i <= 250; i++) await del.run([i]);
+await t.exec('COMMIT');
+out.tursoCount = (await t.prepare('SELECT COUNT(*) c FROM items').all([]))[0].c;
+try { out.tursoIntegrity = JSON.stringify((await t.prepare('PRAGMA integrity_check').all([])).slice(0, 3)); }
+catch (e) { out.tursoIntegrity = 'ERR ' + e.message.slice(0, 80); }
+await t.exec('PRAGMA wal_checkpoint(TRUNCATE)');
+t.close?.();
+
+const s2 = new DatabaseSync(p);
+const one = sql => { try { return s2.prepare(sql).all(); } catch (e) { return 'ERR ' + e.message.slice(0, 90); } };
+out.sqlite_tableScanCount = one('SELECT COUNT(*) c FROM (SELECT id FROM items NOT INDEXED)');
+out.sqlite_viaIdxTagCount = one("SELECT COUNT(*) c FROM items INDEXED BY idx_tag WHERE tag > ''");
+out.sqlite_viaIdxNCount = one('SELECT COUNT(*) c FROM items INDEXED BY idx_n WHERE n > 0');
+out.sqlite_updatedRowVisibleViaIndex = one("SELECT COUNT(*) c FROM items INDEXED BY idx_tag WHERE tag LIKE 'u%'");
+out.sqlite_staleTagStillIndexed = one("SELECT COUNT(*) c FROM items INDEXED BY idx_tag WHERE tag LIKE 't%' AND id<=100");
+out.integrity = one('PRAGMA integrity_check');
+if (Array.isArray(out.integrity)) out.integrity = out.integrity.map(x => x.integrity_check).slice(0, 8);
+// did Turso scribble into the fts5 shadow btrees?
+out.fts5_query = one("SELECT rowid FROM docs WHERE docs MATCH 'climate'");
+try { s2.prepare("INSERT INTO docs(docs) VALUES('integrity-check')").all(); out.fts5_integrity = 'PASSED'; }
+catch (e) { out.fts5_integrity = 'FAILED: ' + e.message.slice(0, 90); }
+s2.close();
+
+console.log(JSON.stringify(out, null, 1));

--- a/docs/turso-evaluation/blast3.mjs
+++ b/docs/turso-evaluation/blast3.mjs
@@ -1,0 +1,77 @@
+// Where exactly is the boundary?
+//  (a) Turso's OWN fts index on table B + a plain secondary index on table A:
+//      does Turso maintain A's index? (this is the "Turso-only hybrid" shape)
+//  (b) is it fts5 specifically, or ANY virtual table Turso can't model? (rtree/fts4)
+//  (c) does creation order of the vtab matter?
+import fs from 'node:fs';
+const SCRATCH = process.env.SCRATCH;
+const { connect } = await import('@tursodatabase/database');
+const { DatabaseSync } = await import('node:sqlite');
+const out = {};
+
+// ---------- (a) Turso-only file: fts index on B, secondary index on A ----------
+{
+  const p = `${SCRATCH}/b3-tursoonly.db`;
+  for (const s of ['', '-wal', '-shm']) fs.rmSync(p + s, { force: true });
+  const t = await connect(p, { experimental: ['index_method'] });
+  await t.exec('PRAGMA journal_mode=WAL');
+  await t.exec('CREATE TABLE a(id INTEGER PRIMARY KEY, tag TEXT)');
+  await t.exec('CREATE INDEX idx_a_tag ON a(tag)');
+  await t.exec('CREATE TABLE b(id INTEGER PRIMARY KEY, body TEXT)');
+  await t.exec('CREATE INDEX b_fts ON b USING fts (body)');
+  const ia = t.prepare('INSERT INTO a VALUES(?,?)');
+  const ib = t.prepare('INSERT INTO b VALUES(?,?)');
+  await t.exec('BEGIN');
+  for (let i = 1; i <= 300; i++) { await ia.run([i, `tag${i}`]); await ib.run([i, `doc ${i} climate policy`]); }
+  await t.exec('COMMIT');
+  await t.exec('PRAGMA wal_checkpoint(TRUNCATE)');
+  const cnt = (await t.prepare('SELECT COUNT(*) c FROM a').all([]))[0].c;
+  const viaIdx = (await t.prepare("SELECT COUNT(*) c FROM a WHERE tag='tag7'").all([]))[0].c;
+  t.close?.();
+  const s = new DatabaseSync(p, { readOnly: true });
+  const r = { tursoCount: cnt, tursoPkTagProbe: viaIdx };
+  try { r.sqliteScan = s.prepare('SELECT COUNT(*) c FROM a NOT INDEXED').all()[0].c; } catch (e) { r.sqliteScan = 'ERR ' + e.message.slice(0, 80); }
+  try { r.sqliteViaIdx = s.prepare("SELECT COUNT(*) c FROM a INDEXED BY idx_a_tag WHERE tag > ''").all()[0].c; } catch (e) { r.sqliteViaIdx = 'ERR ' + e.message.slice(0, 80); }
+  try { r.sqliteIntegrity = s.prepare('PRAGMA integrity_check').all().map(x => x.integrity_check).slice(0, 5); } catch (e) { r.sqliteIntegrity = 'ERR ' + e.message.slice(0, 80); }
+  try { r.sqliteSeesB = s.prepare("SELECT COUNT(*) c FROM b NOT INDEXED").all()[0].c; } catch (e) { r.sqliteSeesB = 'ERR ' + e.message.slice(0, 80); }
+  s.close();
+  out.tursoOnly_ftsOnOtherTable = r;
+}
+
+// ---------- (b) which vtab modules trip it, and (c) ordering ----------
+async function vtabScenario(name, vtabSql, orderFirst) {
+  const p = `${SCRATCH}/b3-${name}.db`;
+  for (const s of ['', '-wal', '-shm']) fs.rmSync(p + s, { force: true });
+  const r = { scenario: name };
+  const s = new DatabaseSync(p);
+  try {
+    s.exec('PRAGMA journal_mode=WAL');
+    if (orderFirst) s.exec(vtabSql);
+    s.exec(`CREATE TABLE items(id INTEGER PRIMARY KEY, tag TEXT);
+            CREATE INDEX idx_tag ON items(tag);
+            INSERT INTO items VALUES(1,'x'),(2,'y');`);
+    if (!orderFirst) s.exec(vtabSql);
+    s.exec('PRAGMA wal_checkpoint(TRUNCATE)');
+  } catch (e) { s.close(); return { scenario: name, setup: 'UNAVAILABLE: ' + e.message.slice(0, 70) }; }
+  s.close();
+  const t = await connect(p, { experimental: ['index_method'] });
+  try { await t.exec("INSERT INTO items VALUES(3,'z')"); r.tursoInsert = 'SUCCESS'; }
+  catch (e) { r.tursoInsert = 'threw: ' + e.message.slice(0, 70); }
+  await t.exec('PRAGMA wal_checkpoint(TRUNCATE)');
+  t.close?.();
+  const s2 = new DatabaseSync(p);
+  r.viaIndex = JSON.stringify(s2.prepare("SELECT id FROM items INDEXED BY idx_tag WHERE tag='z'").all());
+  r.integrity = s2.prepare('PRAGMA integrity_check').all().map(x => x.integrity_check).slice(0, 2);
+  s2.close();
+  return r;
+}
+
+const vt = [];
+vt.push(await vtabScenario('none', 'SELECT 1', false));
+vt.push(await vtabScenario('fts5-after', "CREATE VIRTUAL TABLE d USING fts5(body); INSERT INTO d(body) VALUES('t');", false));
+vt.push(await vtabScenario('fts5-before', "CREATE VIRTUAL TABLE d USING fts5(body); INSERT INTO d(body) VALUES('t');", true));
+vt.push(await vtabScenario('fts4-after', "CREATE VIRTUAL TABLE d USING fts4(body);", false));
+vt.push(await vtabScenario('rtree-after', "CREATE VIRTUAL TABLE d USING rtree(id, minx, maxx);", false));
+out.vtabMatrix = vt;
+
+console.log(JSON.stringify(out, null, 1));

--- a/docs/turso-evaluation/crossread.mjs
+++ b/docs/turso-evaluation/crossread.mjs
@@ -1,0 +1,64 @@
+// Can stock SQLite still open and read a database that Turso wrote an FTS
+// index into? And can Turso read a database containing an FTS5 virtual table?
+import fs from 'node:fs';
+const SCRATCH = process.env.SCRATCH;
+const tursoDb = `${SCRATCH}/ftsdb-turso-default-7/db.db`;
+const sqliteDb = `${SCRATCH}/ftsdb-sqlite-unicode61-7/db.db`;
+const out = {};
+
+// ---- stock SQLite reading Turso's file -------------------------------------
+{
+  const copy = `${SCRATCH}/crossread-turso-copy.db`;
+  fs.copyFileSync(tursoDb, copy);
+  const o = { file: tursoDb, sizeMB: +(fs.statSync(tursoDb).size / 1048576).toFixed(1) };
+  try {
+    const { DatabaseSync } = await import('node:sqlite');
+    const db = new DatabaseSync(copy, { readOnly: true });
+    o.opened = true;
+    o.schema = db.prepare("SELECT type, name FROM sqlite_master ORDER BY type, name").all()
+      .map(r => `${r.type}:${r.name}`);
+    o.rowCount = Number(db.prepare('SELECT COUNT(*) c FROM items').all()[0].c);
+    o.sampleRow = db.prepare('SELECT id, publishedAt, length(body) len FROM items ORDER BY publishedAt DESC LIMIT 1').all()[0];
+    o.integrityCheck = db.prepare('PRAGMA integrity_check').all().slice(0, 3);
+    try {
+      o.ftsQueryFromSqlite = db.prepare("SELECT COUNT(*) c FROM items WHERE fts_match(body,'climate')").all();
+    } catch (e) { o.ftsQueryFromSqlite = `ERR: ${e.message}`; }
+    try {
+      o.indexedRangeScan = Number(db.prepare("SELECT COUNT(*) c FROM items WHERE body LIKE '%climate%'").all()[0].c);
+    } catch (e) { o.indexedRangeScan = `ERR: ${e.message}`; }
+    db.close();
+  } catch (e) {
+    o.opened = false;
+    o.error = `${e.constructor?.name}: ${e.message}`;
+  }
+  out.stockSqlite_reading_tursoFile = o;
+  fs.rmSync(copy, { force: true });
+}
+
+// ---- Turso reading a stock SQLite FTS5 file --------------------------------
+{
+  const copy = `${SCRATCH}/crossread-sqlite-copy.db`;
+  fs.copyFileSync(sqliteDb, copy);
+  const o = { file: sqliteDb, sizeMB: +(fs.statSync(sqliteDb).size / 1048576).toFixed(1) };
+  try {
+    const { connect } = await import('@tursodatabase/database');
+    const db = await connect(copy, { experimental: ['index_method'] });
+    o.opened = true;
+    o.rowCount = Number((await db.prepare('SELECT COUNT(*) c FROM items').all([]))[0].c);
+    o.sampleRow = (await db.prepare('SELECT id, publishedAt, length(body) len FROM items ORDER BY publishedAt DESC LIMIT 1').all([]))[0];
+    try {
+      o.fts5QueryFromTurso = await db.prepare("SELECT COUNT(*) c FROM items_fts WHERE items_fts MATCH 'climate'").all([]);
+    } catch (e) { o.fts5QueryFromTurso = `ERR: ${e.message}`; }
+    try {
+      o.canReadFts5Shadow = Number((await db.prepare('SELECT COUNT(*) c FROM items_fts_data').all([]))[0].c);
+    } catch (e) { o.canReadFts5Shadow = `ERR: ${e.message}`; }
+    db.close?.();
+  } catch (e) {
+    o.opened = false;
+    o.error = `${e.constructor?.name}: ${e.message}`;
+  }
+  out.turso_reading_sqliteFts5File = o;
+  fs.rmSync(copy, { force: true });
+}
+
+console.log(JSON.stringify(out, null, 1));

--- a/docs/turso-evaluation/drop-mitigation.mjs
+++ b/docs/turso-evaluation/drop-mitigation.mjs
@@ -1,0 +1,33 @@
+// The case's #1 "decisive" argument is that a Turso-FTS file is unopenable by stock
+// SQLite. The probe measured a mitigation (DROP INDEX) that the case never mentions.
+// Verify the mitigation is real, and time it.
+import { connect } from '@tursodatabase/database';
+import fs from 'node:fs';
+import { execFileSync } from 'node:child_process';
+const p = process.env.SCRATCH + '/dropmit.db';
+for (const s of ['', '-wal', '-shm']) { try { fs.unlinkSync(p + s); } catch {} }
+const rows = JSON.parse(fs.readFileSync(process.env.SCRATCH + '/rows.json', 'utf8'));
+const db = await connect(p, { experimental: ['index_method'] });
+await db.exec('PRAGMA journal_mode=WAL');
+await db.exec('CREATE TABLE items(id TEXT PRIMARY KEY, body TEXT)');
+const ins = db.prepare('INSERT INTO items VALUES(?,?)');
+await db.exec('BEGIN');
+for (const r of rows) await ins.run([r[0], r[7]]);
+await db.exec('COMMIT');
+await db.exec('CREATE INDEX items_fts ON items USING fts (body)');
+await db.exec('PRAGMA wal_checkpoint(TRUNCATE)');
+db.close?.();
+const probe = () => { try { return execFileSync('/usr/bin/sqlite3', [p, 'SELECT COUNT(*) FROM items;'], { encoding: 'utf8' }).trim(); }
+                      catch (e) { return 'FAILED: ' + String(e.stderr || e.message).trim().slice(0, 120); } };
+console.log('rows indexed        =', rows.length);
+console.log('stock sqlite3 BEFORE=', probe());
+const db2 = await connect(p, { experimental: ['index_method'] });
+const t = Date.now();
+await db2.exec('DROP INDEX items_fts');
+await db2.exec('PRAGMA wal_checkpoint(TRUNCATE)');
+const dropMs = Date.now() - t;
+db2.close?.();
+console.log('DROP INDEX ms       =', dropMs);
+console.log('stock sqlite3 AFTER =', probe());
+console.log('body bytes AFTER    =', (() => { try { return execFileSync('/usr/bin/sqlite3', [p, 'SELECT SUM(length(body)) FROM items;'], {encoding:'utf8'}).trim(); } catch(e){ return 'FAILED'; } })());
+console.log('integrity AFTER     =', (() => { try { return execFileSync('/usr/bin/sqlite3', [p, 'PRAGMA integrity_check;'], {encoding:'utf8'}).trim(); } catch(e){ return 'FAILED'; } })());

--- a/docs/turso-evaluation/fts.mjs
+++ b/docs/turso-evaluation/fts.mjs
@@ -1,0 +1,256 @@
+// Head-to-head full-text search benchmark: SQLite FTS5 vs Turso FTS (Tantivy).
+// usage: node fts.mjs <sqlite|turso> <scale> [variant]
+//   sqlite variants: unicode61 | porter | trigram
+//   turso  variants: default
+import fs from 'node:fs';
+import path from 'node:path';
+
+const SCRATCH = process.env.SCRATCH;
+const ENGINE = process.argv[2];
+const SCALE = Number(process.argv[3] || 1);
+const VARIANT = process.argv[4] || (ENGINE === 'sqlite' ? 'unicode61' : 'default');
+const mb = b => +(b / 1048576).toFixed(1);
+const now = () => Number(process.hrtime.bigint()) / 1e6; // ms float
+
+const dir = `${SCRATCH}/ftsdb-${ENGINE}-${VARIANT}-${SCALE}`;
+fs.rmSync(dir, { recursive: true, force: true });
+fs.mkdirSync(dir, { recursive: true });
+const dbPath = `${dir}/db.db`;
+
+function footprint() {
+  let total = 0;
+  const walk = p => {
+    for (const e of fs.readdirSync(p, { withFileTypes: true })) {
+      const f = path.join(p, e.name);
+      if (e.isDirectory()) walk(f);
+      else total += fs.statSync(f).size;
+    }
+  };
+  walk(dir);
+  return total;
+}
+function listing() {
+  const out = [];
+  const walk = (p, rel) => {
+    for (const e of fs.readdirSync(p, { withFileTypes: true })) {
+      const f = path.join(p, e.name);
+      const r = rel ? `${rel}/${e.name}` : e.name;
+      if (e.isDirectory()) walk(f, r);
+      else out.push([r, fs.statSync(f).size]);
+    }
+  };
+  walk(dir, '');
+  return out.sort((a, b) => b[1] - a[1]);
+}
+
+// ---- engine adapter --------------------------------------------------------
+let db, exec, all, run, close;
+if (ENGINE === 'sqlite') {
+  const { DatabaseSync } = await import('node:sqlite');
+  db = new DatabaseSync(dbPath);
+  exec = async s => db.exec(s);
+  all = async (sql, args = []) => db.prepare(sql).all(...args);
+  run = sql => { const st = db.prepare(sql); return async args => st.run(...args); };
+  close = () => db.close();
+} else {
+  const { connect } = await import('@tursodatabase/database');
+  db = await connect(dbPath, { experimental: ['index_method'] });
+  exec = async s => { await db.exec(s); };
+  all = async (sql, args = []) => await db.prepare(sql).all(args);
+  run = sql => { const st = db.prepare(sql); return async args => await st.run(args); };
+  close = () => db.close?.();
+}
+
+const result = { engine: ENGINE, variant: VARIANT, scale: SCALE };
+
+await exec('PRAGMA journal_mode=WAL');
+await exec('CREATE TABLE items(id TEXT PRIMARY KEY, publishedAt INTEGER, platform TEXT, author TEXT, archived INTEGER, saved INTEGER, readAt INTEGER, body TEXT)');
+
+// ---- load corpus -----------------------------------------------------------
+const rows = JSON.parse(fs.readFileSync(`${SCRATCH}/rows.json`, 'utf8'));
+let bodyChars = 0;
+const tIns = now();
+const ins = run('INSERT INTO items VALUES(?,?,?,?,?,?,?,?)');
+await exec('BEGIN');
+let n = 0;
+for (let copy = 0; copy < SCALE; copy++) {
+  for (const r of rows) {
+    const id = copy === 0 ? r[0] : `c${copy}:${r[0]}`;
+    await ins([id, r[1], r[2], r[3], r[4], r[5], r[6], r[7]]);
+    if (copy === 0) bodyChars += (r[7] || '').length;
+    n++;
+  }
+}
+await exec('COMMIT');
+result.rows = n;
+result.insertMs = Math.round(now() - tIns);
+result.corpusTextMB = mb(bodyChars * SCALE);
+
+await exec('PRAGMA wal_checkpoint(TRUNCATE)');
+const baseBytes = footprint();
+result.baseFootprintMB = mb(baseBytes);
+
+// ---- build the FTS index ---------------------------------------------------
+// RSS sampling from a worker thread: the main thread blocks inside native
+// code during index build, so an in-thread setInterval never fires.
+const { Worker } = await import('node:worker_threads');
+const sab = new SharedArrayBuffer(3 * 8);
+const shared = new Float64Array(sab);
+const rssWorker = new Worker(new URL('./rss-sampler.mjs', import.meta.url), { workerData: { sab } });
+await new Promise(r => rssWorker.once('message', r));
+const rssBefore = process.memoryUsage().rss;
+shared[0] = rssBefore;
+
+const tIdx = now();
+let indexError = null;
+try {
+  if (ENGINE === 'sqlite') {
+    const tok = VARIANT === 'porter' ? ", tokenize='porter unicode61'"
+      : VARIANT === 'trigram' ? ", tokenize='trigram'"
+        : '';
+    // external-content FTS5: index only, body stays in `items`
+    await exec(`CREATE VIRTUAL TABLE items_fts USING fts5(body, content='items', content_rowid='rowid'${tok})`);
+    await exec(`INSERT INTO items_fts(items_fts) VALUES('rebuild')`);
+  } else {
+    const tk = (VARIANT === 'default' || VARIANT === 'unicode61') ? '' : ` WITH (tokenizer='${VARIANT}')`;
+    await exec(`CREATE INDEX items_fts ON items USING fts (body)${tk}`);
+  }
+} catch (e) {
+  indexError = `${e.constructor?.name}: ${e.message}`;
+}
+result.indexBuildMs = Math.round(now() - tIdx);
+shared[2] = 1;
+await rssWorker.terminate();
+result.indexBuildRssBeforeMB = mb(rssBefore);
+result.indexBuildPeakRssMB = mb(shared[0]);
+result.indexBuildRssDeltaMB = mb(shared[0] - rssBefore);
+result.rssSamples = shared[1];
+if (indexError) {
+  result.indexError = indexError;
+  console.log(JSON.stringify(result, null, 2));
+  close();
+  process.exit(0);
+}
+
+await exec('PRAGMA wal_checkpoint(TRUNCATE)');
+const afterBytes = footprint();
+result.afterFootprintMB = mb(afterBytes);
+result.indexSizeMB = mb(afterBytes - baseBytes);
+result.indexOverheadPctOfText = +((afterBytes - baseBytes) / (bodyChars * SCALE) * 100).toFixed(1);
+result.files = listing().slice(0, 12).map(([f, s]) => `${f} ${mb(s)}MB`);
+
+// ---- query battery ---------------------------------------------------------
+// Each entry: label, sqlite MATCH expression, turso fts_match query string.
+const QUERIES = [
+  ['single-veryhigh-freq', 'that', 'that'],           // ~246k postings at scale 7
+  ['single-common', 'climate', 'climate'],
+  ['single-rare', 'tantivy', 'tantivy'],
+  ['multi-term-default', 'climate change', 'climate change'],
+  ['multi-term-AND', 'climate AND change', 'climate AND change'],
+  ['phrase', '"climate change"', '"climate change"'],
+  ['prefix', 'democr*', 'democr*'],
+  ['typo-missing-letter', 'climat', 'climat'],
+  ['typo-transposed', 'cimate', 'cimate'],
+  ['stem-run', 'run', 'run'],
+  ['three-term', 'climate change policy', 'climate change policy'],
+];
+
+const REPS = Number(process.env.REPS || 11);
+const p = (arr, q) => { const s = [...arr].sort((a, b) => a - b); return +s[Math.floor(s.length * q)].toFixed(2); };
+
+function sqliteSql(kind) {
+  if (kind === 'count') return `SELECT COUNT(*) c FROM items_fts WHERE items_fts MATCH ?`;
+  return `SELECT i.id, bm25(items_fts) AS score FROM items_fts JOIN items i ON i.rowid = items_fts.rowid WHERE items_fts MATCH ? ORDER BY rank LIMIT 10`;
+}
+function tursoSql(kind) {
+  if (kind === 'count') return `SELECT COUNT(*) c FROM items WHERE fts_match(body, ?)`;
+  // NOTE: fts_score() with a BOUND PARAMETER returns 0 (measured bug), so an
+  // explicit ORDER BY fts_score(body, ?) is a no-op sort. The realistic app
+  // path is to rely on fts_match's own relevance order + LIMIT.
+  return `SELECT id FROM items WHERE fts_match(body, ?) LIMIT 10`;
+}
+// Same query with the score inlined as a literal, which is the only way to get
+// a non-zero score out of Turso today.
+function tursoSqlLiteralScore(q) {
+  const lit = q.replace(/'/g, "''");
+  return `SELECT id, fts_score(body, '${lit}') AS score FROM items WHERE fts_match(body, '${lit}') ORDER BY score DESC LIMIT 10`;
+}
+
+result.queries = [];
+for (const [label, sq, tq] of QUERIES) {
+  const q = ENGINE === 'sqlite' ? sq : tq;
+  const entry = { label, query: q };
+
+  // count
+  try {
+    const times = [];
+    let c = null;
+    for (let i = 0; i < REPS; i++) {
+      const t = now();
+      const r = await all(ENGINE === 'sqlite' ? sqliteSql('count') : tursoSql('count'), [q]);
+      times.push(now() - t);
+      c = r[0]?.c ?? r[0]?.['COUNT(*)'] ?? null;
+    }
+    entry.hits = Number(c);
+    entry.countP50ms = p(times, 0.5);
+    entry.countMinMs = +Math.min(...times).toFixed(2);
+    entry.countMaxMs = +Math.max(...times).toFixed(2);
+  } catch (e) {
+    entry.countError = e.message;
+  }
+
+  // top-10 ranked (the realistic search-UI path for each engine)
+  try {
+    const times = [];
+    let top = null;
+    for (let i = 0; i < REPS; i++) {
+      const t = now();
+      const r = ENGINE === 'sqlite'
+        ? await all(sqliteSql('top'), [q])
+        : await all(tursoSql('top'), [q]);
+      times.push(now() - t);
+      top = r;
+    }
+    entry.topP50ms = p(times, 0.5);
+    entry.topMinMs = +Math.min(...times).toFixed(2);
+    entry.topIds = top.slice(0, 5).map(r => `${r.id}|${typeof r.score === 'number' ? r.score.toFixed(3) : ''}`);
+  } catch (e) {
+    entry.topError = e.message;
+  }
+
+  // Turso only: explicit BM25 sort with a literal query string
+  if (ENGINE === 'turso') {
+    try {
+      const times = [];
+      let top = null;
+      for (let i = 0; i < REPS; i++) {
+        const t = now();
+        top = await all(tursoSqlLiteralScore(q));
+        times.push(now() - t);
+      }
+      entry.topLiteralScoreP50ms = p(times, 0.5);
+      entry.topLiteralScoreIds = top.slice(0, 5).map(r => `${r.id}|${r.score?.toFixed?.(3)}`);
+    } catch (e) {
+      entry.topLiteralScoreError = e.message;
+    }
+  }
+
+  result.queries.push(entry);
+}
+
+// baseline: what a LIKE scan costs for the same single term
+try {
+  const times = [];
+  let c = 0;
+  for (let i = 0; i < 3; i++) {
+    const t = now();
+    const r = await all(`SELECT COUNT(*) c FROM items WHERE body LIKE '%climate%'`);
+    times.push(now() - t);
+    c = r[0].c;
+  }
+  result.likeScanP50ms = p(times, 0.5);
+  result.likeScanHits = Number(c);
+} catch (e) { result.likeScanError = e.message; }
+
+console.log(JSON.stringify(result, null, 2));
+close();

--- a/docs/turso-evaluation/gate.mjs
+++ b/docs/turso-evaluation/gate.mjs
@@ -1,0 +1,27 @@
+// Re-verify the two remaining adoption-gate items first-hand on the installed build:
+// working prefix search, and fts_score() with a BOUND parameter.
+import fs from 'node:fs';
+const SCRATCH = process.env.SCRATCH;
+const { connect } = await import('@tursodatabase/database');
+const p = `${SCRATCH}/gate.db`;
+for (const s of ['', '-wal', '-shm']) fs.rmSync(p + s, { force: true });
+const db = await connect(p, { experimental: ['index_method'] });
+await db.exec('CREATE TABLE d(id INTEGER PRIMARY KEY, body TEXT)');
+await db.exec(`INSERT INTO d VALUES
+  (1,'democracy is fragile'),(2,'democratic norms erode'),(3,'running and runner'),(4,'climate policy update')`);
+await db.exec('CREATE INDEX d_fts ON d USING fts (body)');
+const out = {};
+const q = async (label, sql, args = []) => {
+  try { out[label] = JSON.stringify(await db.prepare(sql).all(args)); }
+  catch (e) { out[label] = 'THREW: ' + e.message.slice(0, 110); }
+};
+await q('sanity_exact', "SELECT id FROM d WHERE fts_match(body,'democracy')");
+await q('prefix_star', "SELECT id FROM d WHERE fts_match(body,'democr*')");
+await q('prefix_bound', 'SELECT id FROM d WHERE fts_match(body,?)', ['democr*']);
+await q('stem_run', "SELECT id FROM d WHERE fts_match(body,'run')");
+await q('fuzzy_tilde', "SELECT id FROM d WHERE fts_match(body,'climat~1')");
+await q('score_literal', "SELECT id, fts_score(body,'climate') s FROM d WHERE fts_match(body,'climate')");
+await q('score_bound_param', 'SELECT id, fts_score(body,?) s FROM d WHERE fts_match(body,?)', ['climate', 'climate']);
+await q('score_bound_match_literal', "SELECT id, fts_score(body,?) s FROM d WHERE fts_match(body,'climate')", ['climate']);
+console.log(JSON.stringify(out, null, 1));
+db.close?.();

--- a/docs/turso-evaluation/inc-scaling.mjs
+++ b/docs/turso-evaluation/inc-scaling.mjs
@@ -1,0 +1,76 @@
+// Does incremental FTS write cost scale with the size of the existing index?
+// Build an index over N base rows, then time appending 50 rows in one commit,
+// and 5 rows in one commit, for several N.
+// usage: node inc-scaling.mjs <sqlite|turso>
+import fs from 'node:fs';
+const SCRATCH = process.env.SCRATCH;
+const ENGINE = process.argv[2];
+const now = () => Number(process.hrtime.bigint()) / 1e6;
+const rows = JSON.parse(fs.readFileSync(`${SCRATCH}/rows.json`, 'utf8'));
+
+const BASES = (process.env.BASES || '500,2000,8000,15846').split(',').map(Number);
+const out = [];
+
+for (const N of BASES) {
+  const p = `${SCRATCH}/incs-${ENGINE}-${N}.db`;
+  for (const s of ['', '-wal', '-shm']) fs.rmSync(p + s, { force: true });
+
+  let exec, run, close;
+  if (ENGINE === 'sqlite') {
+    const { DatabaseSync } = await import('node:sqlite');
+    const db = new DatabaseSync(p);
+    exec = async s => db.exec(s);
+    run = sql => { const st = db.prepare(sql); return async a => st.run(...a); };
+    close = () => db.close();
+  } else {
+    const { connect } = await import('@tursodatabase/database');
+    const db = await connect(p, { experimental: ['index_method'] });
+    exec = async s => { await db.exec(s); };
+    run = sql => { const st = db.prepare(sql); return async a => await st.run(a); };
+    close = () => db.close?.();
+  }
+
+  await exec('PRAGMA journal_mode=WAL');
+  await exec('CREATE TABLE items(id TEXT PRIMARY KEY, body TEXT)');
+  const ins = run('INSERT INTO items VALUES(?,?)');
+  await exec('BEGIN');
+  for (let i = 0; i < N; i++) await ins([rows[i][0], rows[i][7]]);
+  await exec('COMMIT');
+
+  const tB = now();
+  if (ENGINE === 'sqlite') {
+    await exec(`CREATE VIRTUAL TABLE items_fts USING fts5(body, content='items', content_rowid='rowid')`);
+    await exec(`INSERT INTO items_fts(items_fts) VALUES('rebuild')`);
+    await exec(`CREATE TRIGGER items_ai AFTER INSERT ON items BEGIN
+      INSERT INTO items_fts(rowid, body) VALUES (new.rowid, new.body); END;`);
+  } else {
+    await exec('CREATE INDEX items_fts ON items USING fts (body)');
+  }
+  const buildMs = Math.round(now() - tB);
+
+  const append = async (label, count, tag) => {
+    const t = now();
+    await exec('BEGIN');
+    for (let i = 0; i < count; i++) {
+      const r = rows[(i + 100) % rows.length];
+      await ins([`${tag}:${i}:${r[0]}`, r[7]]);
+    }
+    await exec('COMMIT');
+    return +(now() - t).toFixed(1);
+  };
+
+  const add50 = await append('add50', 50, `x${N}a`);
+  const add50b = await append('add50b', 50, `x${N}b`);
+  const add5 = await append('add5', 5, `x${N}c`);
+  const add1 = await append('add1', 1, `x${N}d`);
+
+  out.push({
+    engine: ENGINE, baseRows: N, buildMs,
+    append50Ms: add50, append50Ms_2nd: add50b, append5Ms: add5, append1Ms: add1,
+    msPerRow_at50: +(add50b / 50).toFixed(2),
+    dbMB: +(fs.statSync(p).size / 1048576).toFixed(1),
+  });
+  console.log(JSON.stringify(out[out.length - 1]));
+  close();
+  for (const s of ['', '-wal', '-shm']) fs.rmSync(p + s, { force: true });
+}

--- a/docs/turso-evaluation/incremental.mjs
+++ b/docs/turso-evaluation/incremental.mjs
@@ -1,0 +1,138 @@
+// Incremental FTS maintenance: build an index over 6 copies of the corpus, then
+// ingest the 7th copy in batches (as a scraper would) and time each batch.
+// SQLite external-content FTS5 needs triggers to stay in sync; Turso's index
+// method claims to maintain itself. Both paths are exercised here.
+// usage: node incremental.mjs <sqlite|turso>
+import fs from 'node:fs';
+import path from 'node:path';
+
+const SCRATCH = process.env.SCRATCH;
+const ENGINE = process.argv[2];
+const BASE_COPIES = 6;
+const BATCH = 500;
+const mb = b => +(b / 1048576).toFixed(1);
+const now = () => Number(process.hrtime.bigint()) / 1e6;
+
+const dir = `${SCRATCH}/inc-${ENGINE}`;
+fs.rmSync(dir, { recursive: true, force: true });
+fs.mkdirSync(dir, { recursive: true });
+const dbPath = `${dir}/db.db`;
+const footprint = () => {
+  let t = 0;
+  const walk = p => { for (const e of fs.readdirSync(p, { withFileTypes: true })) { const f = path.join(p, e.name); if (e.isDirectory()) walk(f); else t += fs.statSync(f).size; } };
+  walk(dir); return t;
+};
+
+let exec, all, run, close;
+if (ENGINE === 'sqlite') {
+  const { DatabaseSync } = await import('node:sqlite');
+  const db = new DatabaseSync(dbPath);
+  exec = async s => db.exec(s);
+  all = async (sql, a = []) => db.prepare(sql).all(...a);
+  run = sql => { const st = db.prepare(sql); return async a => st.run(...a); };
+  close = () => db.close();
+} else {
+  const { connect } = await import('@tursodatabase/database');
+  const db = await connect(dbPath, { experimental: ['index_method'] });
+  exec = async s => { await db.exec(s); };
+  all = async (sql, a = []) => await db.prepare(sql).all(a);
+  run = sql => { const st = db.prepare(sql); return async a => await st.run(a); };
+  close = () => db.close?.();
+}
+
+const out = { engine: ENGINE, baseCopies: BASE_COPIES, batchSize: BATCH };
+await exec('PRAGMA journal_mode=WAL');
+await exec('CREATE TABLE items(id TEXT PRIMARY KEY, publishedAt INTEGER, platform TEXT, author TEXT, archived INTEGER, saved INTEGER, readAt INTEGER, body TEXT)');
+
+const rows = JSON.parse(fs.readFileSync(`${SCRATCH}/rows.json`, 'utf8'));
+const ins = run('INSERT INTO items VALUES(?,?,?,?,?,?,?,?)');
+
+// ---- base corpus -----------------------------------------------------------
+await exec('BEGIN');
+for (let c = 0; c < BASE_COPIES; c++) {
+  for (const r of rows) await ins([c === 0 ? r[0] : `c${c}:${r[0]}`, r[1], r[2], r[3], r[4], r[5], r[6], r[7]]);
+}
+await exec('COMMIT');
+out.baseRows = BASE_COPIES * rows.length;
+
+// ---- index + auto-maintenance ---------------------------------------------
+const tI = now();
+if (ENGINE === 'sqlite') {
+  await exec(`CREATE VIRTUAL TABLE items_fts USING fts5(body, content='items', content_rowid='rowid')`);
+  await exec(`INSERT INTO items_fts(items_fts) VALUES('rebuild')`);
+  // external-content FTS5 does NOT self-maintain; triggers are the documented pattern
+  await exec(`CREATE TRIGGER items_ai AFTER INSERT ON items BEGIN
+      INSERT INTO items_fts(rowid, body) VALUES (new.rowid, new.body); END;`);
+  await exec(`CREATE TRIGGER items_ad AFTER DELETE ON items BEGIN
+      INSERT INTO items_fts(items_fts, rowid, body) VALUES('delete', old.rowid, old.body); END;`);
+  await exec(`CREATE TRIGGER items_au AFTER UPDATE ON items BEGIN
+      INSERT INTO items_fts(items_fts, rowid, body) VALUES('delete', old.rowid, old.body);
+      INSERT INTO items_fts(rowid, body) VALUES (new.rowid, new.body); END;`);
+} else {
+  await exec('CREATE INDEX items_fts ON items USING fts (body)');
+}
+out.baseIndexBuildMs = Math.round(now() - tI);
+await exec('PRAGMA wal_checkpoint(TRUNCATE)');
+out.footprintAfterBaseMB = mb(footprint());
+
+const searchTop = async q => {
+  const t = now();
+  const r = ENGINE === 'sqlite'
+    ? await all(`SELECT i.id FROM items_fts JOIN items i ON i.rowid=items_fts.rowid WHERE items_fts MATCH ? ORDER BY rank LIMIT 10`, [q])
+    : await all(`SELECT id FROM items WHERE fts_match(body, ?) LIMIT 10`, [q]);
+  return [now() - t, r.length];
+};
+const med = a => { const s = [...a].sort((x, y) => x - y); return +s[s.length >> 1].toFixed(2); };
+const probe = async () => {
+  const ts = [];
+  for (let i = 0; i < 9; i++) ts.push((await searchTop('climate change'))[0]);
+  return med(ts);
+};
+out.queryP50BeforeIngestMs = await probe();
+out.hitsBefore = Number((await all(ENGINE === 'sqlite'
+  ? `SELECT COUNT(*) c FROM items_fts WHERE items_fts MATCH 'climate'`
+  : `SELECT COUNT(*) c FROM items WHERE fts_match(body,'climate')`))[0].c);
+
+// ---- incremental ingest of copy #6 in batches ------------------------------
+const batches = [];
+const copy = BASE_COPIES;
+const MAX_BATCHES = Number(process.env.MAX_BATCHES || 1e9);
+for (let start = 0; start < rows.length && batches.length < MAX_BATCHES; start += BATCH) {
+  const slice = rows.slice(start, start + BATCH);
+  const t = now();
+  await exec('BEGIN');
+  for (const r of slice) await ins([`c${copy}:${r[0]}`, r[1], r[2], r[3], r[4], r[5], r[6], r[7]]);
+  await exec('COMMIT');
+  const dt = now() - t;
+  batches.push(dt);
+  process.stderr.write(`batch ${batches.length} rows=${slice.length} ${dt.toFixed(0)}ms (${(dt / slice.length).toFixed(2)} ms/row)\n`);
+}
+out.batchCount = batches.length;
+out.ingestTotalMs = Math.round(batches.reduce((a, b) => a + b, 0));
+out.ingestPerRowMs = +(out.ingestTotalMs / (batches.length * BATCH)).toFixed(3);
+out.batchP50Ms = med(batches);
+out.batchMinMs = +Math.min(...batches).toFixed(1);
+out.batchMaxMs = +Math.max(...batches).toFixed(1);
+out.batchFirst3Ms = batches.slice(0, 3).map(x => +x.toFixed(1));
+out.batchLast3Ms = batches.slice(-3).map(x => +x.toFixed(1));
+
+await exec('PRAGMA wal_checkpoint(TRUNCATE)');
+out.footprintAfterIngestMB = mb(footprint());
+out.queryP50AfterIngestMs = await probe();
+out.hitsAfter = Number((await all(ENGINE === 'sqlite'
+  ? `SELECT COUNT(*) c FROM items_fts WHERE items_fts MATCH 'climate'`
+  : `SELECT COUNT(*) c FROM items WHERE fts_match(body,'climate')`))[0].c);
+out.indexStayedInSync = out.hitsAfter > out.hitsBefore;
+
+// ---- deletion ---------------------------------------------------------------
+const tD = now();
+await exec(`DELETE FROM items WHERE id LIKE 'c${copy}:%'`);
+out.deleteMs = Math.round(now() - tD);
+out.hitsAfterDelete = Number((await all(ENGINE === 'sqlite'
+  ? `SELECT COUNT(*) c FROM items_fts WHERE items_fts MATCH 'climate'`
+  : `SELECT COUNT(*) c FROM items WHERE fts_match(body,'climate')`))[0].c);
+await exec('PRAGMA wal_checkpoint(TRUNCATE)');
+out.footprintAfterDeleteMB = mb(footprint());
+
+console.log(JSON.stringify(out, null, 1));
+close();

--- a/docs/turso-evaluation/mitigations.mjs
+++ b/docs/turso-evaluation/mitigations.mjs
@@ -1,0 +1,171 @@
+// Measure the two mitigations the pro-Turso case depends on:
+//  (1) FTS sidecar rebuild-and-swap at real scale — does it bound the 313 ms/row incremental cost,
+//      and can search stay online during a rebuild?
+//  (2) Is a Turso-ONLY database (never touched by fts5) safe under heavy mixed DML?
+import fs from 'node:fs';
+import { Worker } from 'node:worker_threads';
+const SCRATCH = process.env.SCRATCH;
+const { connect } = await import('@tursodatabase/database');
+const { DatabaseSync } = await import('node:sqlite');
+const rm = p => { for (const s of ['', '-wal', '-shm']) { try { fs.unlinkSync(p + s); } catch {} } };
+const MB = b => +(b / 1048576).toFixed(1);
+const out = {};
+
+// ---- peak-RSS sampler (worker thread; main thread blocks inside native code) ----
+async function withPeak(fn) {
+  const sab = new SharedArrayBuffer(24);
+  const buf = new Float64Array(sab);
+  buf[0] = process.memoryUsage.rss();
+  const w = new Worker(new URL('./rss-sampler.mjs', import.meta.url), { workerData: { sab } });
+  await new Promise(r => w.once('message', r));
+  const before = process.memoryUsage.rss();
+  const t = Date.now();
+  const val = await fn();
+  const ms = Date.now() - t;
+  buf[2] = 1; await new Promise(r => w.once('exit', r));
+  return { val, ms, beforeMB: MB(before), peakMB: MB(buf[0]), deltaMB: MB(buf[0] - before), samples: buf[1] };
+}
+
+const rows = JSON.parse(fs.readFileSync(`${SCRATCH}/rows.json`, 'utf8'));
+const SCALE = 7;
+const bodyRows = [];
+for (let c = 0; c < SCALE; c++) for (const r of rows) bodyRows.push([c === 0 ? r[0] : `c${c}:${r[0]}`, r[7]]);
+out.corpusRows = bodyRows.length;
+out.corpusTextMB = MB(bodyRows.reduce((a, r) => a + (r[1]?.length || 0), 0));
+
+// ---------- (1a) Sidecar FTS rebuild from scratch at full scale ----------
+const sideA = `${SCRATCH}/mit-side-a.db`;
+rm(sideA);
+out.sidecarBuild = await withPeak(async () => {
+  const db = await connect(sideA, { experimental: ['index_method'] });
+  await db.exec('PRAGMA journal_mode=WAL');
+  await db.exec('CREATE TABLE fts_src(id TEXT PRIMARY KEY, body TEXT)');
+  const ins = db.prepare('INSERT INTO fts_src VALUES(?,?)');
+  const tCopy = Date.now();
+  await db.exec('BEGIN');
+  for (const r of bodyRows) await ins.run(r);
+  await db.exec('COMMIT');
+  const copyMs = Date.now() - tCopy;
+  const tIdx = Date.now();
+  await db.exec('CREATE INDEX fts_idx ON fts_src USING fts (body)');
+  const indexMs = Date.now() - tIdx;
+  await db.exec('PRAGMA wal_checkpoint(TRUNCATE)');
+  const hits = await db.prepare("SELECT COUNT(*) c FROM fts_src WHERE fts_match(body,'climate')").all([]);
+  db.close?.();
+  return { copyMs, indexMs, climateHits: hits[0].c, sidecarMB: MB(fs.statSync(sideA).size) };
+});
+
+// ---------- (1b) Query latency on the finished sidecar ----------
+{
+  const db = await connect(sideA, { experimental: ['index_method'] });
+  const pct = (a, p) => a.slice().sort((x, y) => x - y)[Math.floor(a.length * p)];
+  const q = async (term) => {
+    const st = db.prepare(`SELECT id FROM fts_src WHERE fts_match(body,'${term}') LIMIT 10`);
+    for (let i = 0; i < 5; i++) await st.all([]);
+    const s = [];
+    for (let i = 0; i < 40; i++) { const t = process.hrtime.bigint(); await st.all([]); s.push(Number(process.hrtime.bigint() - t) / 1e6); }
+    return { p50: +pct(s, 0.5).toFixed(2), p95: +pct(s, 0.95).toFixed(2) };
+  };
+  out.sidecarQuery = { climate: await q('climate'), that: await q('that'), zzznotfound: await q('zzznotfound') };
+  db.close?.();
+}
+
+// ---------- (1c) Rebuild-and-swap: can search stay online during a rebuild? ----------
+{
+  const live = `${SCRATCH}/mit-live.db`, next = `${SCRATCH}/mit-next.db`;
+  rm(live); rm(next);
+  fs.copyFileSync(sideA, live);
+  const liveDb = await connect(live, { experimental: ['index_method'] });
+  const probe = liveDb.prepare("SELECT id FROM fts_src WHERE fts_match(body,'climate') LIMIT 10");
+  await probe.all([]);
+
+  let served = 0, failed = 0, maxLatency = 0, stop = false;
+  const reader = (async () => {
+    while (!stop) {
+      const t = process.hrtime.bigint();
+      try { await probe.all([]); served++; } catch { failed++; }
+      const ms = Number(process.hrtime.bigint() - t) / 1e6;
+      if (ms > maxLatency) maxLatency = ms;
+      await new Promise(r => setImmediate(r));
+    }
+  })();
+
+  const rebuild = await withPeak(async () => {
+    const db = await connect(next, { experimental: ['index_method'] });
+    await db.exec('PRAGMA journal_mode=WAL');
+    await db.exec('CREATE TABLE fts_src(id TEXT PRIMARY KEY, body TEXT)');
+    const ins = db.prepare('INSERT INTO fts_src VALUES(?,?)');
+    await db.exec('BEGIN');
+    for (const r of bodyRows) await ins.run(r);
+    // simulate a scrape burst: 500 new items appended before the index is built
+    for (let i = 0; i < 500; i++) await ins.run([`new${i}`, `fresh capture ${i} climate policy update from the burst`]);
+    await db.exec('COMMIT');
+    await db.exec('CREATE INDEX fts_idx ON fts_src USING fts (body)');
+    await db.exec('PRAGMA wal_checkpoint(TRUNCATE)');
+    db.close?.();
+    return 'built';
+  });
+  stop = true; await reader;
+
+  // atomic swap
+  const tSwap = Date.now();
+  liveDb.close?.();
+  fs.renameSync(next, live);
+  const swapped = await connect(live, { experimental: ['index_method'] });
+  const after = await swapped.prepare("SELECT COUNT(*) c FROM fts_src WHERE fts_match(body,'climate')").all([]);
+  const burst = await swapped.prepare("SELECT COUNT(*) c FROM fts_src WHERE fts_match(body,'burst')").all([]);
+  const swapMs = Date.now() - tSwap;
+  swapped.close?.();
+
+  out.rebuildAndSwap = {
+    rebuildMs: rebuild.ms, rebuildPeakDeltaMB: rebuild.deltaMB,
+    queriesServedDuringRebuild: served, queriesFailedDuringRebuild: failed,
+    maxQueryLatencyDuringRebuildMs: +maxLatency.toFixed(2),
+    swapMs, climateHitsAfterSwap: after[0].c, burstHitsAfterSwap: burst[0].c,
+  };
+}
+
+// ---------- (2) Pure-Turso database under heavy mixed DML ----------
+{
+  const p = `${SCRATCH}/mit-pure.db`; rm(p);
+  const db = await connect(p);
+  await db.exec('PRAGMA journal_mode=WAL');
+  await db.exec('CREATE TABLE items(id TEXT PRIMARY KEY, publishedAt INTEGER, platform TEXT, readAt INTEGER, body TEXT)');
+  await db.exec('CREATE INDEX idx_pub ON items(publishedAt DESC)');
+  await db.exec('CREATE INDEX idx_plat ON items(platform, publishedAt DESC)');
+  const ins = db.prepare('INSERT INTO items VALUES(?,?,?,?,?)');
+  const upd = db.prepare('UPDATE items SET readAt=?, body=? WHERE id=?');
+  const del = db.prepare('DELETE FROM items WHERE id=?');
+  const t = Date.now();
+  await db.exec('BEGIN');
+  for (let i = 0; i < 40000; i++) await ins.run([`k${i}`, 1700000000 + i, ['rss', 'x', 'facebook', 'instagram'][i % 4], 0, `body ${i} ` + 'text '.repeat(20)]);
+  await db.exec('COMMIT');
+  await db.exec('BEGIN');
+  for (let i = 0; i < 15000; i++) await upd.run([Date.now(), `updated body ${i} ` + 'text '.repeat(25), `k${i * 2 % 40000}`]);
+  await db.exec('COMMIT');
+  await db.exec('BEGIN');
+  for (let i = 0; i < 8000; i++) await del.run([`k${i * 5 % 40000}`]);
+  await db.exec('COMMIT');
+  const dmlMs = Date.now() - t;
+  const cnt = await db.prepare('SELECT COUNT(*) c FROM items').all([]);
+  const ic = await db.prepare('PRAGMA integrity_check').all([]);
+  await db.exec('PRAGMA wal_checkpoint(TRUNCATE)');
+  db.close?.();
+
+  const s = new DatabaseSync(p, { readOnly: true });
+  const sCnt = s.prepare('SELECT COUNT(*) c FROM items').all()[0].c;
+  const sScan = s.prepare('SELECT COUNT(*) c FROM (SELECT id FROM items)').all()[0].c;
+  const sPk = s.prepare("SELECT COUNT(*) c FROM items WHERE id='k1'").all()[0].c;
+  const sIdx = s.prepare('SELECT COUNT(*) c FROM items WHERE publishedAt > 0').all()[0].c;
+  const sIc = s.prepare('PRAGMA integrity_check').all();
+  s.close();
+
+  out.pureTursoDML = {
+    dmlMs, tursoCount: cnt[0].c, tursoIntegrity: JSON.stringify(ic[0]),
+    sqliteCount: sCnt, sqliteFullScanCount: sScan, sqliteIndexScanCount: sIdx, sqlitePkProbe: sPk,
+    sqliteIntegrity: JSON.stringify(sIc.slice(0, 3)),
+    AGREE: cnt[0].c === sCnt && sCnt === sScan && sScan === sIdx,
+  };
+}
+
+console.log(JSON.stringify(out, null, 1));

--- a/docs/turso-evaluation/quality.mjs
+++ b/docs/turso-evaluation/quality.mjs
@@ -1,0 +1,99 @@
+// Controlled-corpus FTS quality comparison. Each doc contains exactly one
+// surface form so stemming/prefix/fuzzy claims can be tested unambiguously.
+// usage: node quality.mjs <sqlite|turso> [variant]
+const ENGINE = process.argv[2];
+const VARIANT = process.argv[3] || (ENGINE === 'sqlite' ? 'unicode61' : 'default');
+
+const DOCS = [
+  [1, 'the athletes were running quickly through the park'],       // only "running"
+  [2, 'she organizes community meetings every week'],              // only "organizes"
+  [3, 'a report on democracy in modern nations'],                  // only "democracy"
+  [4, 'global climate policy needs urgent attention'],             // only "climate"
+  [5, 'the connection between weather and farming'],               // only "connection"
+  [6, 'nationalization of the railways was debated'],              // only "nationalization"
+  [7, 'climate change is the defining issue of our era'],          // climate + change
+  [8, 'a change of scenery does everyone good'],                   // change only
+  [9, 'climate climate climate climate climate climate'],          // term-frequency outlier
+  [10, 'pottery and ceramics have a long history'],                // control, no keywords
+];
+
+let exec, all, close;
+if (ENGINE === 'sqlite') {
+  const { DatabaseSync } = await import('node:sqlite');
+  const db = new DatabaseSync(':memory:');
+  exec = s => db.exec(s);
+  all = (sql, args = []) => db.prepare(sql).all(...args);
+  close = () => db.close();
+} else {
+  const { connect } = await import('@tursodatabase/database');
+  const db = await connect(':memory:', { experimental: ['index_method'] });
+  exec = async s => { await db.exec(s); };
+  all = async (sql, args = []) => await db.prepare(sql).all(args);
+  close = () => db.close?.();
+}
+
+await exec('CREATE TABLE d(id INTEGER PRIMARY KEY, body TEXT)');
+for (const [id, body] of DOCS) await exec(`INSERT INTO d VALUES(${id}, '${body}')`);
+
+if (ENGINE === 'sqlite') {
+  const tok = VARIANT === 'porter' ? ", tokenize='porter unicode61'"
+    : VARIANT === 'trigram' ? ", tokenize='trigram'" : '';
+  await exec(`CREATE VIRTUAL TABLE d_fts USING fts5(body, content='d', content_rowid='rowid'${tok})`);
+  await exec(`INSERT INTO d_fts(d_fts) VALUES('rebuild')`);
+} else {
+  const tk = VARIANT === 'default' ? '' : ` WITH (tokenizer='${VARIANT}')`;
+  await exec(`CREATE INDEX d_fts ON d USING fts (body)${tk}`);
+}
+
+const search = async q => {
+  try {
+    const rows = ENGINE === 'sqlite'
+      ? await all('SELECT rowid AS id FROM d_fts WHERE d_fts MATCH ? ORDER BY rank', [q])
+      : await all('SELECT id FROM d WHERE fts_match(body, ?)', [q]);
+    return rows.map(r => Number(r.id));
+  } catch (e) {
+    return `ERR: ${e.message.slice(0, 90)}`;
+  }
+};
+
+const CASES = [
+  ['exact term', 'climate', 'baseline: docs 4,7,9'],
+  ['stem: run -> running', 'run', 'doc 1 only if stemming'],
+  ['stem: organize -> organizes', 'organize', 'doc 2 only if stemming'],
+  ['stem: national -> nationalization', 'national', 'doc 6 only if aggressive stemming'],
+  ['prefix: democr*', 'democr*', 'doc 3 if prefix supported'],
+  ['prefix: conn*', 'conn*', 'doc 5 if prefix supported'],
+  ['typo: climat (drop e)', 'climat', 'docs 4,7,9 if fuzzy'],
+  ['typo: cimate (transpose)', 'cimate', 'docs 4,7,9 if fuzzy'],
+  ['typo w/ ~1', 'climat~1', 'Tantivy fuzzy syntax'],
+  ['multi-term default', 'climate change', 'AND=>7 ; OR=>4,7,8,9'],
+  ['explicit AND', 'climate AND change', 'doc 7'],
+  ['phrase', '"climate change"', 'doc 7'],
+  ['negation', 'climate NOT change', 'docs 4,9'],
+  ['negation dash', 'climate -change', 'docs 4,9'],
+  ['substring: limat', 'limat', 'only trigram/ngram can do this'],
+];
+
+const out = { engine: ENGINE, variant: VARIANT, cases: [] };
+for (const [label, q, expect] of CASES) {
+  out.cases.push({ case: label, query: q, expect, got: await search(q) });
+}
+
+// ---- ranking check: is the result order actually relevance-ordered? --------
+// doc 9 has "climate" x6 and is short => must rank first under BM25.
+if (ENGINE === 'sqlite') {
+  out.ranking = {
+    withOrderByRank: (await all("SELECT rowid AS id, bm25(d_fts) s FROM d_fts WHERE d_fts MATCH 'climate' ORDER BY rank")).map(r => `${r.id}:${r.s.toFixed(3)}`),
+    noOrderBy: (await all("SELECT rowid AS id FROM d_fts WHERE d_fts MATCH 'climate'")).map(r => Number(r.id)),
+  };
+} else {
+  out.ranking = {
+    scoreLiteral: (await all("SELECT id, fts_score(body,'climate') s FROM d WHERE fts_match(body,'climate')")).map(r => `${r.id}:${r.s.toFixed(3)}`),
+    scoreBoundParam: (await all('SELECT id, fts_score(body,?) s FROM d WHERE fts_match(body,?)', ['climate', 'climate'])).map(r => `${r.id}:${r.s.toFixed(3)}`),
+    noOrderBy: (await all("SELECT id FROM d WHERE fts_match(body,'climate')")).map(r => Number(r.id)),
+    orderByScoreLiteral: (await all("SELECT id FROM d WHERE fts_match(body,'climate') ORDER BY fts_score(body,'climate') DESC")).map(r => Number(r.id)),
+  };
+}
+
+console.log(JSON.stringify(out, null, 1));
+close();

--- a/docs/turso-evaluation/results/inc-sqlite.json
+++ b/docs/turso-evaluation/results/inc-sqlite.json
@@ -1,0 +1,33 @@
+{
+ "engine": "sqlite",
+ "baseCopies": 6,
+ "batchSize": 500,
+ "baseRows": 95076,
+ "baseIndexBuildMs": 3005,
+ "footprintAfterBaseMB": 251.8,
+ "queryP50BeforeIngestMs": 0.25,
+ "hitsBefore": 552,
+ "batchCount": 32,
+ "ingestTotalMs": 3198,
+ "ingestPerRowMs": 0.2,
+ "batchP50Ms": 79.11,
+ "batchMinMs": 17.1,
+ "batchMaxMs": 241.5,
+ "batchFirst3Ms": [
+  86.6,
+  215.7,
+  207.2
+ ],
+ "batchLast3Ms": [
+  35,
+  30.6,
+  17.1
+ ],
+ "footprintAfterIngestMB": 290.6,
+ "queryP50AfterIngestMs": 0.48,
+ "hitsAfter": 644,
+ "indexStayedInSync": true,
+ "deleteMs": 549,
+ "hitsAfterDelete": 552,
+ "footprintAfterDeleteMB": 290.6
+}

--- a/docs/turso-evaluation/results/mitigations.json
+++ b/docs/turso-evaluation/results/mitigations.json
@@ -1,0 +1,52 @@
+{
+ "corpusRows": 110922,
+ "corpusTextMB": 160,
+ "sidecarBuild": {
+  "val": {
+   "copyMs": 959,
+   "indexMs": 6284,
+   "climateHits": 644,
+   "sidecarMB": 371.3
+  },
+  "ms": 7460,
+  "beforeMB": 253.1,
+  "peakMB": 965.4,
+  "deltaMB": 712.3,
+  "samples": 632
+ },
+ "sidecarQuery": {
+  "climate": {
+   "p50": 1.19,
+   "p95": 1.26
+  },
+  "that": {
+   "p50": 1.38,
+   "p95": 1.53
+  },
+  "zzznotfound": {
+   "p50": 1.09,
+   "p95": 1.17
+  }
+ },
+ "rebuildAndSwap": {
+  "rebuildMs": 7746,
+  "rebuildPeakDeltaMB": 109.6,
+  "queriesServedDuringRebuild": 17,
+  "queriesFailedDuringRebuild": 0,
+  "maxQueryLatencyDuringRebuildMs": 1.78,
+  "swapMs": 247,
+  "climateHitsAfterSwap": 1144,
+  "burstHitsAfterSwap": 780
+ },
+ "pureTursoDML": {
+  "dmlMs": 361,
+  "tursoCount": 32000,
+  "tursoIntegrity": "{\"integrity_check\":\"ok\"}",
+  "sqliteCount": 32000,
+  "sqliteFullScanCount": 32000,
+  "sqliteIndexScanCount": 32000,
+  "sqlitePkProbe": 1,
+  "sqliteIntegrity": "[{\"integrity_check\":\"ok\"}]",
+  "AGREE": true
+ }
+}

--- a/docs/turso-evaluation/results/sqlite-porter-7.json
+++ b/docs/turso-evaluation/results/sqlite-porter-7.json
@@ -1,0 +1,201 @@
+{
+  "engine": "sqlite",
+  "variant": "porter",
+  "scale": 7,
+  "rows": 110922,
+  "insertMs": 1046,
+  "corpusTextMB": 160,
+  "baseFootprintMB": 223.2,
+  "indexBuildMs": 3108,
+  "indexBuildRssBeforeMB": 300.4,
+  "indexBuildPeakRssMB": 303.6,
+  "indexBuildRssDeltaMB": 3.2,
+  "rssSamples": 271,
+  "afterFootprintMB": 291.5,
+  "indexSizeMB": 68.3,
+  "indexOverheadPctOfText": 42.7,
+  "files": [
+    "db.db 291.1MB",
+    "db.db-shm 0.4MB",
+    "db.db-wal 0MB"
+  ],
+  "queries": [
+    {
+      "label": "single-veryhigh-freq",
+      "query": "that",
+      "hits": 54327,
+      "countP50ms": 0.76,
+      "countMinMs": 0.75,
+      "countMaxMs": 1.3,
+      "topP50ms": 29.48,
+      "topMinMs": 28.8,
+      "topIds": [
+        "x:2048825454262710515|-0.084",
+        "c1:x:2048825454262710515|-0.084",
+        "c2:x:2048825454262710515|-0.084",
+        "c3:x:2048825454262710515|-0.084",
+        "c4:x:2048825454262710515|-0.084"
+      ]
+    },
+    {
+      "label": "single-common",
+      "query": "climate",
+      "hits": 644,
+      "countP50ms": 0.02,
+      "countMinMs": 0.02,
+      "countMaxMs": 0.1,
+      "topP50ms": 0.32,
+      "topMinMs": 0.3,
+      "topIds": [
+        "rss:https://thedailybell.com/?p=42437|-9.600",
+        "c1:rss:https://thedailybell.com/?p=42437|-9.600",
+        "c2:rss:https://thedailybell.com/?p=42437|-9.600",
+        "c3:rss:https://thedailybell.com/?p=42437|-9.600",
+        "c4:rss:https://thedailybell.com/?p=42437|-9.600"
+      ]
+    },
+    {
+      "label": "single-rare",
+      "query": "tantivy",
+      "hits": 0,
+      "countP50ms": 0.01,
+      "countMinMs": 0.01,
+      "countMaxMs": 0.05,
+      "topP50ms": 0.02,
+      "topMinMs": 0.01,
+      "topIds": []
+    },
+    {
+      "label": "multi-term-default",
+      "query": "climate change",
+      "hits": 343,
+      "countP50ms": 0.08,
+      "countMinMs": 0.08,
+      "countMaxMs": 0.12,
+      "topP50ms": 0.56,
+      "topMinMs": 0.51,
+      "topIds": [
+        "x:2059327973224845418|-12.707",
+        "c1:x:2059327973224845418|-12.707",
+        "c2:x:2059327973224845418|-12.707",
+        "c3:x:2059327973224845418|-12.707",
+        "c4:x:2059327973224845418|-12.707"
+      ]
+    },
+    {
+      "label": "multi-term-AND",
+      "query": "climate AND change",
+      "hits": 343,
+      "countP50ms": 0.08,
+      "countMinMs": 0.08,
+      "countMaxMs": 0.11,
+      "topP50ms": 0.51,
+      "topMinMs": 0.49,
+      "topIds": [
+        "x:2059327973224845418|-12.707",
+        "c1:x:2059327973224845418|-12.707",
+        "c2:x:2059327973224845418|-12.707",
+        "c3:x:2059327973224845418|-12.707",
+        "c4:x:2059327973224845418|-12.707"
+      ]
+    },
+    {
+      "label": "phrase",
+      "query": "\"climate change\"",
+      "hits": 273,
+      "countP50ms": 0.1,
+      "countMinMs": 0.08,
+      "countMaxMs": 0.24,
+      "topP50ms": 0.36,
+      "topMinMs": 0.34,
+      "topIds": [
+        "x:2059327973224845418|-10.022",
+        "c1:x:2059327973224845418|-10.022",
+        "c2:x:2059327973224845418|-10.022",
+        "c3:x:2059327973224845418|-10.022",
+        "c4:x:2059327973224845418|-10.022"
+      ]
+    },
+    {
+      "label": "prefix",
+      "query": "democr*",
+      "hits": 1372,
+      "countP50ms": 0.08,
+      "countMinMs": 0.06,
+      "countMaxMs": 0.11,
+      "topP50ms": 0.77,
+      "topMinMs": 0.72,
+      "topIds": [
+        "rss:https://blog.ted.com/?p=118819|-8.589",
+        "c1:rss:https://blog.ted.com/?p=118819|-8.589",
+        "c2:rss:https://blog.ted.com/?p=118819|-8.589",
+        "c3:rss:https://blog.ted.com/?p=118819|-8.589",
+        "c4:rss:https://blog.ted.com/?p=118819|-8.589"
+      ]
+    },
+    {
+      "label": "typo-missing-letter",
+      "query": "climat",
+      "hits": 644,
+      "countP50ms": 0.02,
+      "countMinMs": 0.02,
+      "countMaxMs": 0.05,
+      "topP50ms": 0.33,
+      "topMinMs": 0.3,
+      "topIds": [
+        "rss:https://thedailybell.com/?p=42437|-9.600",
+        "c1:rss:https://thedailybell.com/?p=42437|-9.600",
+        "c2:rss:https://thedailybell.com/?p=42437|-9.600",
+        "c3:rss:https://thedailybell.com/?p=42437|-9.600",
+        "c4:rss:https://thedailybell.com/?p=42437|-9.600"
+      ]
+    },
+    {
+      "label": "typo-transposed",
+      "query": "cimate",
+      "hits": 0,
+      "countP50ms": 0.01,
+      "countMinMs": 0.01,
+      "countMaxMs": 0.04,
+      "topP50ms": 0.02,
+      "topMinMs": 0.02,
+      "topIds": []
+    },
+    {
+      "label": "stem-run",
+      "query": "run",
+      "hits": 12670,
+      "countP50ms": 0.27,
+      "countMinMs": 0.2,
+      "countMaxMs": 0.42,
+      "topP50ms": 6.18,
+      "topMinMs": 5.67,
+      "topIds": [
+        "rss:tag:www.producthunt.com,2005:Post/1124825|-4.071",
+        "c1:rss:tag:www.producthunt.com,2005:Post/1124825|-4.071",
+        "c2:rss:tag:www.producthunt.com,2005:Post/1124825|-4.071",
+        "c3:rss:tag:www.producthunt.com,2005:Post/1124825|-4.071",
+        "c4:rss:tag:www.producthunt.com,2005:Post/1124825|-4.071"
+      ]
+    },
+    {
+      "label": "three-term",
+      "query": "climate change policy",
+      "hits": 49,
+      "countP50ms": 0.15,
+      "countMinMs": 0.11,
+      "countMaxMs": 0.34,
+      "topP50ms": 0.51,
+      "topMinMs": 0.49,
+      "topIds": [
+        "rss:https://www.schiffsovereign.com/?p=155189|-13.714",
+        "c1:rss:https://www.schiffsovereign.com/?p=155189|-13.714",
+        "c2:rss:https://www.schiffsovereign.com/?p=155189|-13.714",
+        "c3:rss:https://www.schiffsovereign.com/?p=155189|-13.714",
+        "c4:rss:https://www.schiffsovereign.com/?p=155189|-13.714"
+      ]
+    }
+  ],
+  "likeScanP50ms": 137.05,
+  "likeScanHits": 672
+}

--- a/docs/turso-evaluation/results/sqlite-trigram-7.json
+++ b/docs/turso-evaluation/results/sqlite-trigram-7.json
@@ -1,0 +1,207 @@
+{
+  "engine": "sqlite",
+  "variant": "trigram",
+  "scale": 7,
+  "rows": 110922,
+  "insertMs": 1070,
+  "corpusTextMB": 160,
+  "baseFootprintMB": 223.2,
+  "indexBuildMs": 17036,
+  "indexBuildRssBeforeMB": 300.2,
+  "indexBuildPeakRssMB": 305.2,
+  "indexBuildRssDeltaMB": 5,
+  "rssSamples": 1480,
+  "afterFootprintMB": 645.1,
+  "indexSizeMB": 421.9,
+  "indexOverheadPctOfText": 263.8,
+  "files": [
+    "db.db 644.3MB",
+    "db.db-shm 0.8MB",
+    "db.db-wal 0MB"
+  ],
+  "queries": [
+    {
+      "label": "single-veryhigh-freq",
+      "query": "that",
+      "hits": 54334,
+      "countP50ms": 5.3,
+      "countMinMs": 4.86,
+      "countMaxMs": 6.17,
+      "topP50ms": 44.65,
+      "topMinMs": 42.97,
+      "topIds": [
+        "x:2048825454262710515|-0.083",
+        "c1:x:2048825454262710515|-0.083",
+        "c2:x:2048825454262710515|-0.083",
+        "c3:x:2048825454262710515|-0.083",
+        "c4:x:2048825454262710515|-0.083"
+      ]
+    },
+    {
+      "label": "single-common",
+      "query": "climate",
+      "hits": 672,
+      "countP50ms": 1.28,
+      "countMinMs": 1.19,
+      "countMaxMs": 1.69,
+      "topP50ms": 4.92,
+      "topMinMs": 4.59,
+      "topIds": [
+        "rss:https://thedailybell.com/?p=42437|-9.252",
+        "c1:rss:https://thedailybell.com/?p=42437|-9.252",
+        "c2:rss:https://thedailybell.com/?p=42437|-9.252",
+        "c3:rss:https://thedailybell.com/?p=42437|-9.252",
+        "c4:rss:https://thedailybell.com/?p=42437|-9.252"
+      ]
+    },
+    {
+      "label": "single-rare",
+      "query": "tantivy",
+      "hits": 0,
+      "countP50ms": 0.52,
+      "countMinMs": 0.5,
+      "countMaxMs": 1.29,
+      "topP50ms": 0.55,
+      "topMinMs": 0.53,
+      "topIds": []
+    },
+    {
+      "label": "multi-term-default",
+      "query": "climate change",
+      "hits": 371,
+      "countP50ms": 2.84,
+      "countMinMs": 2.54,
+      "countMaxMs": 3.23,
+      "topP50ms": 11.92,
+      "topMinMs": 11.36,
+      "topIds": [
+        "x:2059327973224845418|-12.327",
+        "c1:x:2059327973224845418|-12.327",
+        "c2:x:2059327973224845418|-12.327",
+        "c3:x:2059327973224845418|-12.327",
+        "c4:x:2059327973224845418|-12.327"
+      ]
+    },
+    {
+      "label": "multi-term-AND",
+      "query": "climate AND change",
+      "hits": 371,
+      "countP50ms": 3.03,
+      "countMinMs": 2.73,
+      "countMaxMs": 3.3,
+      "topP50ms": 12.17,
+      "topMinMs": 11.4,
+      "topIds": [
+        "x:2059327973224845418|-12.327",
+        "c1:x:2059327973224845418|-12.327",
+        "c2:x:2059327973224845418|-12.327",
+        "c3:x:2059327973224845418|-12.327",
+        "c4:x:2059327973224845418|-12.327"
+      ]
+    },
+    {
+      "label": "phrase",
+      "query": "\"climate change\"",
+      "hits": 273,
+      "countP50ms": 4.25,
+      "countMinMs": 3.82,
+      "countMaxMs": 4.87,
+      "topP50ms": 12.33,
+      "topMinMs": 11.53,
+      "topIds": [
+        "x:2059327973224845418|-10.029",
+        "c1:x:2059327973224845418|-10.029",
+        "c2:x:2059327973224845418|-10.029",
+        "c3:x:2059327973224845418|-10.029",
+        "c4:x:2059327973224845418|-10.029"
+      ]
+    },
+    {
+      "label": "prefix",
+      "query": "democr*",
+      "hits": 1379,
+      "countP50ms": 0.41,
+      "countMinMs": 0.39,
+      "countMaxMs": 0.73,
+      "topP50ms": 2.06,
+      "topMinMs": 1.85,
+      "topIds": [
+        "rss:https://blog.ted.com/?p=118819|-8.612",
+        "c1:rss:https://blog.ted.com/?p=118819|-8.612",
+        "c2:rss:https://blog.ted.com/?p=118819|-8.612",
+        "c3:rss:https://blog.ted.com/?p=118819|-8.612",
+        "c4:rss:https://blog.ted.com/?p=118819|-8.612"
+      ]
+    },
+    {
+      "label": "typo-missing-letter",
+      "query": "climat",
+      "hits": 714,
+      "countP50ms": 0.77,
+      "countMinMs": 0.72,
+      "countMaxMs": 1.06,
+      "topP50ms": 3.03,
+      "topMinMs": 2.71,
+      "topIds": [
+        "rss:https://thedailybell.com/?p=42437|-9.141",
+        "c1:rss:https://thedailybell.com/?p=42437|-9.141",
+        "c2:rss:https://thedailybell.com/?p=42437|-9.141",
+        "c3:rss:https://thedailybell.com/?p=42437|-9.141",
+        "c4:rss:https://thedailybell.com/?p=42437|-9.141"
+      ]
+    },
+    {
+      "label": "typo-transposed",
+      "query": "cimate",
+      "hits": 21,
+      "countP50ms": 0.48,
+      "countMinMs": 0.46,
+      "countMaxMs": 0.79,
+      "topP50ms": 1.5,
+      "topMinMs": 1.45,
+      "topIds": [
+        "x:2051342246981595566|-12.540",
+        "c1:x:2051342246981595566|-12.540",
+        "c2:x:2051342246981595566|-12.540",
+        "c3:x:2051342246981595566|-12.540",
+        "c4:x:2051342246981595566|-12.540"
+      ]
+    },
+    {
+      "label": "stem-run",
+      "query": "run",
+      "hits": 15281,
+      "countP50ms": 0.23,
+      "countMinMs": 0.22,
+      "countMaxMs": 0.32,
+      "topP50ms": 7.51,
+      "topMinMs": 6.73,
+      "topIds": [
+        "rss:tag:www.producthunt.com,2005:Post/1150115|-3.738",
+        "c1:rss:tag:www.producthunt.com,2005:Post/1150115|-3.738",
+        "c2:rss:tag:www.producthunt.com,2005:Post/1150115|-3.738",
+        "c3:rss:tag:www.producthunt.com,2005:Post/1150115|-3.738",
+        "c4:rss:tag:www.producthunt.com,2005:Post/1150115|-3.738"
+      ]
+    },
+    {
+      "label": "three-term",
+      "query": "climate change policy",
+      "hits": 42,
+      "countP50ms": 2.96,
+      "countMinMs": 2.72,
+      "countMaxMs": 3.9,
+      "topP50ms": 13.5,
+      "topMinMs": 12.87,
+      "topIds": [
+        "rss:https://www.schiffsovereign.com/?p=155189|-13.766",
+        "c1:rss:https://www.schiffsovereign.com/?p=155189|-13.766",
+        "c2:rss:https://www.schiffsovereign.com/?p=155189|-13.766",
+        "c3:rss:https://www.schiffsovereign.com/?p=155189|-13.766",
+        "c4:rss:https://www.schiffsovereign.com/?p=155189|-13.766"
+      ]
+    }
+  ],
+  "likeScanP50ms": 140.94,
+  "likeScanHits": 672
+}

--- a/docs/turso-evaluation/results/sqlite-unicode61-7.json
+++ b/docs/turso-evaluation/results/sqlite-unicode61-7.json
@@ -1,0 +1,195 @@
+{
+  "engine": "sqlite",
+  "variant": "unicode61",
+  "scale": 7,
+  "rows": 110922,
+  "insertMs": 1139,
+  "corpusTextMB": 160,
+  "baseFootprintMB": 223.2,
+  "indexBuildMs": 3127,
+  "indexBuildRssBeforeMB": 300.2,
+  "indexBuildPeakRssMB": 303.4,
+  "indexBuildRssDeltaMB": 3.2,
+  "rssSamples": 269,
+  "afterFootprintMB": 294.9,
+  "indexSizeMB": 71.7,
+  "indexOverheadPctOfText": 44.8,
+  "files": [
+    "db.db 294.5MB",
+    "db.db-shm 0.4MB",
+    "db.db-wal 0MB"
+  ],
+  "queries": [
+    {
+      "label": "single-veryhigh-freq",
+      "query": "that",
+      "hits": 54320,
+      "countP50ms": 0.78,
+      "countMinMs": 0.74,
+      "countMaxMs": 0.98,
+      "topP50ms": 28.38,
+      "topMinMs": 27.65,
+      "topIds": [
+        "x:2048825454262710515|-0.084",
+        "c1:x:2048825454262710515|-0.084",
+        "c2:x:2048825454262710515|-0.084",
+        "c3:x:2048825454262710515|-0.084",
+        "c4:x:2048825454262710515|-0.084"
+      ]
+    },
+    {
+      "label": "single-common",
+      "query": "climate",
+      "hits": 644,
+      "countP50ms": 0.02,
+      "countMinMs": 0.02,
+      "countMaxMs": 0.11,
+      "topP50ms": 0.3,
+      "topMinMs": 0.29,
+      "topIds": [
+        "rss:https://thedailybell.com/?p=42437|-9.600",
+        "c1:rss:https://thedailybell.com/?p=42437|-9.600",
+        "c2:rss:https://thedailybell.com/?p=42437|-9.600",
+        "c3:rss:https://thedailybell.com/?p=42437|-9.600",
+        "c4:rss:https://thedailybell.com/?p=42437|-9.600"
+      ]
+    },
+    {
+      "label": "single-rare",
+      "query": "tantivy",
+      "hits": 0,
+      "countP50ms": 0.01,
+      "countMinMs": 0.01,
+      "countMaxMs": 0.05,
+      "topP50ms": 0.02,
+      "topMinMs": 0.01,
+      "topIds": []
+    },
+    {
+      "label": "multi-term-default",
+      "query": "climate change",
+      "hits": 315,
+      "countP50ms": 0.07,
+      "countMinMs": 0.07,
+      "countMaxMs": 0.11,
+      "topP50ms": 0.42,
+      "topMinMs": 0.38,
+      "topIds": [
+        "x:2059327973224845418|-13.815",
+        "c1:x:2059327973224845418|-13.815",
+        "c2:x:2059327973224845418|-13.815",
+        "c3:x:2059327973224845418|-13.815",
+        "c4:x:2059327973224845418|-13.815"
+      ]
+    },
+    {
+      "label": "multi-term-AND",
+      "query": "climate AND change",
+      "hits": 315,
+      "countP50ms": 0.07,
+      "countMinMs": 0.07,
+      "countMaxMs": 0.09,
+      "topP50ms": 0.39,
+      "topMinMs": 0.37,
+      "topIds": [
+        "x:2059327973224845418|-13.815",
+        "c1:x:2059327973224845418|-13.815",
+        "c2:x:2059327973224845418|-13.815",
+        "c3:x:2059327973224845418|-13.815",
+        "c4:x:2059327973224845418|-13.815"
+      ]
+    },
+    {
+      "label": "phrase",
+      "query": "\"climate change\"",
+      "hits": 273,
+      "countP50ms": 0.08,
+      "countMinMs": 0.07,
+      "countMaxMs": 0.1,
+      "topP50ms": 0.33,
+      "topMinMs": 0.32,
+      "topIds": [
+        "x:2059327973224845418|-10.022",
+        "c1:x:2059327973224845418|-10.022",
+        "c2:x:2059327973224845418|-10.022",
+        "c3:x:2059327973224845418|-10.022",
+        "c4:x:2059327973224845418|-10.022"
+      ]
+    },
+    {
+      "label": "prefix",
+      "query": "democr*",
+      "hits": 1372,
+      "countP50ms": 0.07,
+      "countMinMs": 0.07,
+      "countMaxMs": 0.13,
+      "topP50ms": 0.78,
+      "topMinMs": 0.73,
+      "topIds": [
+        "rss:https://blog.ted.com/?p=118819|-8.589",
+        "c1:rss:https://blog.ted.com/?p=118819|-8.589",
+        "c2:rss:https://blog.ted.com/?p=118819|-8.589",
+        "c3:rss:https://blog.ted.com/?p=118819|-8.589",
+        "c4:rss:https://blog.ted.com/?p=118819|-8.589"
+      ]
+    },
+    {
+      "label": "typo-missing-letter",
+      "query": "climat",
+      "hits": 0,
+      "countP50ms": 0.01,
+      "countMinMs": 0.01,
+      "countMaxMs": 0.04,
+      "topP50ms": 0.02,
+      "topMinMs": 0.01,
+      "topIds": []
+    },
+    {
+      "label": "typo-transposed",
+      "query": "cimate",
+      "hits": 0,
+      "countP50ms": 0.01,
+      "countMinMs": 0.01,
+      "countMaxMs": 0.03,
+      "topP50ms": 0.02,
+      "topMinMs": 0.01,
+      "topIds": []
+    },
+    {
+      "label": "stem-run",
+      "query": "run",
+      "hits": 7014,
+      "countP50ms": 0.11,
+      "countMinMs": 0.11,
+      "countMaxMs": 0.16,
+      "topP50ms": 3.11,
+      "topMinMs": 3.02,
+      "topIds": [
+        "rss:https://dave.cheney.net/?p=4373|-5.182",
+        "c1:rss:https://dave.cheney.net/?p=4373|-5.182",
+        "c2:rss:https://dave.cheney.net/?p=4373|-5.182",
+        "c3:rss:https://dave.cheney.net/?p=4373|-5.182",
+        "c4:rss:https://dave.cheney.net/?p=4373|-5.182"
+      ]
+    },
+    {
+      "label": "three-term",
+      "query": "climate change policy",
+      "hits": 35,
+      "countP50ms": 0.1,
+      "countMinMs": 0.1,
+      "countMaxMs": 0.19,
+      "topP50ms": 0.38,
+      "topMinMs": 0.37,
+      "topIds": [
+        "rss:https://www.schiffsovereign.com/?p=155189|-14.704",
+        "c1:rss:https://www.schiffsovereign.com/?p=155189|-14.704",
+        "c2:rss:https://www.schiffsovereign.com/?p=155189|-14.704",
+        "c3:rss:https://www.schiffsovereign.com/?p=155189|-14.704",
+        "c4:rss:https://www.schiffsovereign.com/?p=155189|-14.704"
+      ]
+    }
+  ],
+  "likeScanP50ms": 139.19,
+  "likeScanHits": 672
+}

--- a/docs/turso-evaluation/results/turso-default-7.json
+++ b/docs/turso-evaluation/results/turso-default-7.json
@@ -1,0 +1,252 @@
+{
+  "engine": "turso",
+  "variant": "default",
+  "scale": 7,
+  "rows": 110922,
+  "insertMs": 1121,
+  "corpusTextMB": 160,
+  "baseFootprintMB": 222.8,
+  "indexBuildMs": 7706,
+  "indexBuildRssBeforeMB": 774.1,
+  "indexBuildPeakRssMB": 927.6,
+  "indexBuildRssDeltaMB": 153.5,
+  "rssSamples": 664,
+  "afterFootprintMB": 389.8,
+  "indexSizeMB": 167,
+  "indexOverheadPctOfText": 104.4,
+  "files": [
+    "db.db 389.8MB",
+    "db.db-wal 0MB"
+  ],
+  "queries": [
+    {
+      "label": "single-veryhigh-freq",
+      "query": "that",
+      "hits": 54374,
+      "countP50ms": 7.91,
+      "countMinMs": 7.62,
+      "countMaxMs": 287.6,
+      "topP50ms": 2.25,
+      "topMinMs": 1.83,
+      "topIds": [
+        "x:2048825454262710515|",
+        "c3:x:2048825454262710515|",
+        "c4:x:2048825454262710515|",
+        "c2:x:2048825454262710515|",
+        "c6:x:2048825454262710515|"
+      ],
+      "topLiteralScoreP50ms": 2.1,
+      "topLiteralScoreIds": [
+        "x:2048825454262710515|1.463",
+        "c3:x:2048825454262710515|1.463",
+        "c4:x:2048825454262710515|1.463",
+        "c2:x:2048825454262710515|1.463",
+        "c6:x:2048825454262710515|1.463"
+      ]
+    },
+    {
+      "label": "single-common",
+      "query": "climate",
+      "hits": 645,
+      "countP50ms": 2.03,
+      "countMinMs": 1.78,
+      "countMaxMs": 2.39,
+      "topP50ms": 1.92,
+      "topMinMs": 1.67,
+      "topIds": [
+        "c3:rss:https://thedailybell.com/?p=42437|",
+        "c1:rss:https://thedailybell.com/?p=42437|",
+        "c2:rss:https://thedailybell.com/?p=42437|",
+        "c6:rss:https://thedailybell.com/?p=42437|",
+        "rss:https://thedailybell.com/?p=42437|"
+      ],
+      "topLiteralScoreP50ms": 1.94,
+      "topLiteralScoreIds": [
+        "c3:rss:https://thedailybell.com/?p=42437|9.628",
+        "c1:rss:https://thedailybell.com/?p=42437|9.628",
+        "c2:rss:https://thedailybell.com/?p=42437|9.628",
+        "c6:rss:https://thedailybell.com/?p=42437|9.628",
+        "rss:https://thedailybell.com/?p=42437|9.628"
+      ]
+    },
+    {
+      "label": "single-rare",
+      "query": "tantivy",
+      "hits": 0,
+      "countP50ms": 1.81,
+      "countMinMs": 1.52,
+      "countMaxMs": 2.23,
+      "topP50ms": 1.63,
+      "topMinMs": 1.51,
+      "topIds": [],
+      "topLiteralScoreP50ms": 1.71,
+      "topLiteralScoreIds": []
+    },
+    {
+      "label": "multi-term-default",
+      "query": "climate change",
+      "hits": 6277,
+      "countP50ms": 2.79,
+      "countMinMs": 2.62,
+      "countMaxMs": 3.24,
+      "topP50ms": 2.21,
+      "topMinMs": 1.86,
+      "topIds": [
+        "c1:x:2059327973224845418|",
+        "c6:x:2059327973224845418|",
+        "c5:x:2059327973224845418|",
+        "c2:x:2059327973224845418|",
+        "c3:x:2059327973224845418|"
+      ],
+      "topLiteralScoreP50ms": 2.16,
+      "topLiteralScoreIds": [
+        "c1:x:2059327973224845418|13.991",
+        "c6:x:2059327973224845418|13.991",
+        "c5:x:2059327973224845418|13.991",
+        "c2:x:2059327973224845418|13.991",
+        "c3:x:2059327973224845418|13.991"
+      ]
+    },
+    {
+      "label": "multi-term-AND",
+      "query": "climate AND change",
+      "hits": 316,
+      "countP50ms": 2.26,
+      "countMinMs": 1.84,
+      "countMaxMs": 3.2,
+      "topP50ms": 2.01,
+      "topMinMs": 1.74,
+      "topIds": [
+        "c1:x:2059327973224845418|",
+        "c6:x:2059327973224845418|",
+        "c5:x:2059327973224845418|",
+        "c2:x:2059327973224845418|",
+        "c3:x:2059327973224845418|"
+      ],
+      "topLiteralScoreP50ms": 1.98,
+      "topLiteralScoreIds": [
+        "c1:x:2059327973224845418|13.991",
+        "c6:x:2059327973224845418|13.991",
+        "c5:x:2059327973224845418|13.991",
+        "c2:x:2059327973224845418|13.991",
+        "c3:x:2059327973224845418|13.991"
+      ]
+    },
+    {
+      "label": "phrase",
+      "query": "\"climate change\"",
+      "hits": 273,
+      "countP50ms": 2,
+      "countMinMs": 1.76,
+      "countMaxMs": 37.17,
+      "topP50ms": 2.07,
+      "topMinMs": 1.75,
+      "topIds": [
+        "c1:x:2059327973224845418|",
+        "c6:x:2059327973224845418|",
+        "c5:x:2059327973224845418|",
+        "c2:x:2059327973224845418|",
+        "c3:x:2059327973224845418|"
+      ],
+      "topLiteralScoreP50ms": 2.35,
+      "topLiteralScoreIds": [
+        "c1:x:2059327973224845418|13.562",
+        "c6:x:2059327973224845418|13.562",
+        "c5:x:2059327973224845418|13.562",
+        "c2:x:2059327973224845418|13.562",
+        "c3:x:2059327973224845418|13.562"
+      ]
+    },
+    {
+      "label": "prefix",
+      "query": "democr*",
+      "hits": 0,
+      "countP50ms": 1.85,
+      "countMinMs": 1.55,
+      "countMaxMs": 2.32,
+      "topP50ms": 1.9,
+      "topMinMs": 1.54,
+      "topIds": [],
+      "topLiteralScoreP50ms": 1.81,
+      "topLiteralScoreIds": []
+    },
+    {
+      "label": "typo-missing-letter",
+      "query": "climat",
+      "hits": 0,
+      "countP50ms": 1.77,
+      "countMinMs": 1.53,
+      "countMaxMs": 2.21,
+      "topP50ms": 1.7,
+      "topMinMs": 1.52,
+      "topIds": [],
+      "topLiteralScoreP50ms": 1.61,
+      "topLiteralScoreIds": []
+    },
+    {
+      "label": "typo-transposed",
+      "query": "cimate",
+      "hits": 0,
+      "countP50ms": 1.67,
+      "countMinMs": 1.52,
+      "countMaxMs": 2.1,
+      "topP50ms": 1.73,
+      "topMinMs": 1.47,
+      "topIds": [],
+      "topLiteralScoreP50ms": 1.64,
+      "topLiteralScoreIds": []
+    },
+    {
+      "label": "stem-run",
+      "query": "run",
+      "hits": 7023,
+      "countP50ms": 2.64,
+      "countMinMs": 2.35,
+      "countMaxMs": 3.03,
+      "topP50ms": 1.98,
+      "topMinMs": 1.68,
+      "topIds": [
+        "c1:rss:https://dave.cheney.net/?p=4373|",
+        "c4:rss:https://dave.cheney.net/?p=4373|",
+        "c3:rss:https://dave.cheney.net/?p=4373|",
+        "c6:rss:https://dave.cheney.net/?p=4373|",
+        "rss:https://dave.cheney.net/?p=4373|"
+      ],
+      "topLiteralScoreP50ms": 1.95,
+      "topLiteralScoreIds": [
+        "c1:rss:https://dave.cheney.net/?p=4373|5.306",
+        "c4:rss:https://dave.cheney.net/?p=4373|5.306",
+        "c3:rss:https://dave.cheney.net/?p=4373|5.306",
+        "c6:rss:https://dave.cheney.net/?p=4373|5.306",
+        "rss:https://dave.cheney.net/?p=4373|5.306"
+      ]
+    },
+    {
+      "label": "three-term",
+      "query": "climate change policy",
+      "hits": 8830,
+      "countP50ms": 3.69,
+      "countMinMs": 3.21,
+      "countMaxMs": 4.08,
+      "topP50ms": 2.52,
+      "topMinMs": 2.05,
+      "topIds": [
+        "c3:rss:https://thedailybell.com/?p=42437|",
+        "c1:rss:https://thedailybell.com/?p=42437|",
+        "c2:rss:https://thedailybell.com/?p=42437|",
+        "c6:rss:https://thedailybell.com/?p=42437|",
+        "rss:https://thedailybell.com/?p=42437|"
+      ],
+      "topLiteralScoreP50ms": 2.52,
+      "topLiteralScoreIds": [
+        "c3:rss:https://thedailybell.com/?p=42437|15.877",
+        "c1:rss:https://thedailybell.com/?p=42437|15.877",
+        "c2:rss:https://thedailybell.com/?p=42437|15.877",
+        "c6:rss:https://thedailybell.com/?p=42437|15.877",
+        "rss:https://thedailybell.com/?p=42437|15.877"
+      ]
+    }
+  ],
+  "likeScanP50ms": 424.74,
+  "likeScanHits": 672
+}

--- a/docs/turso-evaluation/results/turso-ngram-7.json
+++ b/docs/turso-evaluation/results/turso-ngram-7.json
@@ -1,0 +1,288 @@
+{
+  "engine": "turso",
+  "variant": "ngram",
+  "scale": 7,
+  "rows": 110922,
+  "insertMs": 1087,
+  "corpusTextMB": 160,
+  "baseFootprintMB": 222.8,
+  "indexBuildMs": 28785,
+  "indexBuildRssBeforeMB": 773.9,
+  "indexBuildPeakRssMB": 1255.1,
+  "indexBuildRssDeltaMB": 481.2,
+  "rssSamples": 2490,
+  "afterFootprintMB": 549.3,
+  "indexSizeMB": 326.5,
+  "indexOverheadPctOfText": 204.1,
+  "files": [
+    "db.db 549.3MB",
+    "db.db-wal 0MB"
+  ],
+  "queries": [
+    {
+      "label": "single-veryhigh-freq",
+      "query": "that",
+      "hits": 54144,
+      "countP50ms": 513.71,
+      "countMinMs": 475.65,
+      "countMaxMs": 949.08,
+      "topP50ms": 499.73,
+      "topMinMs": 484.51,
+      "topIds": [
+        "x:2048825454262710515|",
+        "c4:x:2048825454262710515|",
+        "c6:x:2048825454262710515|",
+        "c2:x:2048825454262710515|",
+        "c5:x:2048825454262710515|"
+      ],
+      "topLiteralScoreP50ms": 501.83,
+      "topLiteralScoreIds": [
+        "x:2048825454262710515|3.991",
+        "c4:x:2048825454262710515|3.991",
+        "c6:x:2048825454262710515|3.991",
+        "c2:x:2048825454262710515|3.991",
+        "c5:x:2048825454262710515|3.991"
+      ]
+    },
+    {
+      "label": "single-common",
+      "query": "climate",
+      "hits": 1330,
+      "countP50ms": 491.37,
+      "countMinMs": 460.06,
+      "countMaxMs": 535.51,
+      "topP50ms": 477.34,
+      "topMinMs": 452.49,
+      "topIds": [
+        "c5:x:2052092991884685564|",
+        "c2:x:2052092991884685564|",
+        "x:2052092991884685564|",
+        "c4:x:2052092991884685564|",
+        "c6:x:2052092991884685564|"
+      ],
+      "topLiteralScoreP50ms": 472.67,
+      "topLiteralScoreIds": [
+        "c5:x:2052092991884685564|19.524",
+        "c2:x:2052092991884685564|19.524",
+        "x:2052092991884685564|19.524",
+        "c4:x:2052092991884685564|19.524",
+        "c6:x:2052092991884685564|19.524"
+      ]
+    },
+    {
+      "label": "single-rare",
+      "query": "tantivy",
+      "hits": 7,
+      "countP50ms": 479.78,
+      "countMinMs": 471.01,
+      "countMaxMs": 509.71,
+      "topP50ms": 500.83,
+      "topMinMs": 481.09,
+      "topIds": [
+        "c5:x:2049705418436600244|",
+        "x:2049705418436600244|",
+        "c3:x:2049705418436600244|",
+        "c6:x:2049705418436600244|",
+        "c2:x:2049705418436600244|"
+      ],
+      "topLiteralScoreP50ms": 530.1,
+      "topLiteralScoreIds": [
+        "c5:x:2049705418436600244|9.137",
+        "x:2049705418436600244|9.137",
+        "c3:x:2049705418436600244|9.137",
+        "c6:x:2049705418436600244|9.137",
+        "c2:x:2049705418436600244|9.137"
+      ]
+    },
+    {
+      "label": "multi-term-default",
+      "query": "climate change",
+      "hits": 15270,
+      "countP50ms": 498.3,
+      "countMinMs": 484.5,
+      "countMaxMs": 557.97,
+      "topP50ms": 502.11,
+      "topMinMs": 480.44,
+      "topIds": [
+        "c3:x:2059327973224845418|",
+        "c6:x:2059327973224845418|",
+        "x:2059327973224845418|",
+        "c2:x:2059327973224845418|",
+        "c1:x:2059327973224845418|"
+      ],
+      "topLiteralScoreP50ms": 516.31,
+      "topLiteralScoreIds": [
+        "c3:x:2059327973224845418|30.824",
+        "c6:x:2059327973224845418|30.824",
+        "x:2059327973224845418|30.824",
+        "c2:x:2059327973224845418|30.824",
+        "c1:x:2059327973224845418|30.824"
+      ]
+    },
+    {
+      "label": "multi-term-AND",
+      "query": "climate AND change",
+      "hits": 574,
+      "countP50ms": 486.09,
+      "countMinMs": 474.12,
+      "countMaxMs": 571.24,
+      "topP50ms": 490.17,
+      "topMinMs": 477.57,
+      "topIds": [
+        "c3:x:2059327973224845418|",
+        "c6:x:2059327973224845418|",
+        "x:2059327973224845418|",
+        "c2:x:2059327973224845418|",
+        "c1:x:2059327973224845418|"
+      ],
+      "topLiteralScoreP50ms": 514.07,
+      "topLiteralScoreIds": [
+        "c3:x:2059327973224845418|30.824",
+        "c6:x:2059327973224845418|30.824",
+        "x:2059327973224845418|30.824",
+        "c2:x:2059327973224845418|30.824",
+        "c1:x:2059327973224845418|30.824"
+      ]
+    },
+    {
+      "label": "phrase",
+      "query": "\"climate change\"",
+      "hits": 518,
+      "countP50ms": 531.23,
+      "countMinMs": 503.44,
+      "countMaxMs": 575.19,
+      "topP50ms": 550.8,
+      "topMinMs": 516.15,
+      "topIds": [
+        "c3:x:2059327973224845418|",
+        "c6:x:2059327973224845418|",
+        "x:2059327973224845418|",
+        "c2:x:2059327973224845418|",
+        "c1:x:2059327973224845418|"
+      ],
+      "topLiteralScoreP50ms": 618.37,
+      "topLiteralScoreIds": [
+        "c3:x:2059327973224845418|34.589",
+        "c6:x:2059327973224845418|34.589",
+        "x:2059327973224845418|34.589",
+        "c2:x:2059327973224845418|34.589",
+        "c1:x:2059327973224845418|34.589"
+      ]
+    },
+    {
+      "label": "prefix",
+      "query": "democr*",
+      "hits": 0,
+      "countP50ms": 595.34,
+      "countMinMs": 510.35,
+      "countMaxMs": 696.22,
+      "topP50ms": 501.7,
+      "topMinMs": 439.13,
+      "topIds": [],
+      "topLiteralScoreP50ms": 456.49,
+      "topLiteralScoreIds": []
+    },
+    {
+      "label": "typo-missing-letter",
+      "query": "climat",
+      "hits": 1358,
+      "countP50ms": 432.93,
+      "countMinMs": 416.97,
+      "countMaxMs": 451.93,
+      "topP50ms": 725.53,
+      "topMinMs": 420.89,
+      "topIds": [
+        "c5:x:2052092991884685564|",
+        "c2:x:2052092991884685564|",
+        "x:2052092991884685564|",
+        "c4:x:2052092991884685564|",
+        "c6:x:2052092991884685564|"
+      ],
+      "topLiteralScoreP50ms": 766.01,
+      "topLiteralScoreIds": [
+        "c5:x:2052092991884685564|17.967",
+        "c2:x:2052092991884685564|17.967",
+        "x:2052092991884685564|17.967",
+        "c4:x:2052092991884685564|17.967",
+        "c6:x:2052092991884685564|17.967"
+      ]
+    },
+    {
+      "label": "typo-transposed",
+      "query": "cimate",
+      "hits": 105,
+      "countP50ms": 630.56,
+      "countMinMs": 528.11,
+      "countMaxMs": 1339.71,
+      "topP50ms": 539.43,
+      "topMinMs": 513.63,
+      "topIds": [
+        "c4:x:2051342246981595566|",
+        "c5:x:2051342246981595566|",
+        "c2:x:2051342246981595566|",
+        "c6:x:2051342246981595566|",
+        "c3:x:2051342246981595566|"
+      ],
+      "topLiteralScoreP50ms": 561.63,
+      "topLiteralScoreIds": [
+        "c4:x:2051342246981595566|17.632",
+        "c5:x:2051342246981595566|17.632",
+        "c2:x:2051342246981595566|17.632",
+        "c6:x:2051342246981595566|17.632",
+        "c3:x:2051342246981595566|17.632"
+      ]
+    },
+    {
+      "label": "stem-run",
+      "query": "run",
+      "hits": 14406,
+      "countP50ms": 520.01,
+      "countMinMs": 481.14,
+      "countMaxMs": 847.01,
+      "topP50ms": 793.8,
+      "topMinMs": 765.56,
+      "topIds": [
+        "c3:rss:tag:www.producthunt.com,2005:Post/1150115|",
+        "c4:rss:tag:www.producthunt.com,2005:Post/1150115|",
+        "rss:tag:www.producthunt.com,2005:Post/1150115|",
+        "c6:rss:tag:www.producthunt.com,2005:Post/1150115|",
+        "c2:rss:tag:www.producthunt.com,2005:Post/1150115|"
+      ],
+      "topLiteralScoreP50ms": 877.65,
+      "topLiteralScoreIds": [
+        "c3:rss:tag:www.producthunt.com,2005:Post/1150115|7.130",
+        "c4:rss:tag:www.producthunt.com,2005:Post/1150115|7.130",
+        "rss:tag:www.producthunt.com,2005:Post/1150115|7.130",
+        "c6:rss:tag:www.producthunt.com,2005:Post/1150115|7.130",
+        "c2:rss:tag:www.producthunt.com,2005:Post/1150115|7.130"
+      ]
+    },
+    {
+      "label": "three-term",
+      "query": "climate change policy",
+      "hits": 17289,
+      "countP50ms": 599,
+      "countMinMs": 555.24,
+      "countMaxMs": 1346.12,
+      "topP50ms": 575.58,
+      "topMinMs": 521.68,
+      "topIds": [
+        "c1:rss:https://thedailybell.com/?p=42437|",
+        "rss:https://thedailybell.com/?p=42437|",
+        "c3:rss:https://thedailybell.com/?p=42437|",
+        "c6:rss:https://thedailybell.com/?p=42437|",
+        "c4:rss:https://thedailybell.com/?p=42437|"
+      ],
+      "topLiteralScoreP50ms": 539.9,
+      "topLiteralScoreIds": [
+        "c1:rss:https://thedailybell.com/?p=42437|40.532",
+        "rss:https://thedailybell.com/?p=42437|40.532",
+        "c3:rss:https://thedailybell.com/?p=42437|40.532",
+        "c6:rss:https://thedailybell.com/?p=42437|40.532",
+        "c4:rss:https://thedailybell.com/?p=42437|40.532"
+      ]
+    }
+  ],
+  "likeScanP50ms": 489.41,
+  "likeScanHits": 672
+}

--- a/docs/turso-evaluation/write-safety.mjs
+++ b/docs/turso-evaluation/write-safety.mjs
@@ -1,0 +1,70 @@
+// Careful verification: what happens when Turso writes to a base table that
+// carries FTS5 triggers (the "roll back to a previous SQLite schema" case)?
+import fs from 'node:fs';
+const SCRATCH = process.env.SCRATCH;
+const { connect } = await import('@tursodatabase/database');
+const { DatabaseSync } = await import('node:sqlite');
+const out = {};
+
+const p = `${SCRATCH}/ws.db`;
+for (const s of ['', '-wal', '-shm']) fs.rmSync(p + s, { force: true });
+
+// Build with stock SQLite: base table + external-content FTS5 + sync triggers
+const s = new DatabaseSync(p);
+s.exec(`PRAGMA journal_mode=WAL;
+  CREATE TABLE items(id TEXT PRIMARY KEY, body TEXT);
+  INSERT INTO items VALUES('a','climate change is real');
+  INSERT INTO items VALUES('b','pottery and ceramics');
+  CREATE VIRTUAL TABLE items_fts USING fts5(body, content='items', content_rowid='rowid');
+  INSERT INTO items_fts(items_fts) VALUES('rebuild');
+  CREATE TRIGGER items_ai AFTER INSERT ON items BEGIN
+    INSERT INTO items_fts(rowid, body) VALUES (new.rowid, new.body); END;`);
+s.exec('PRAGMA wal_checkpoint(TRUNCATE)');
+out.before_baseRows = s.prepare('SELECT id FROM items ORDER BY id').all().map(r => r.id);
+s.close();
+
+// Now write through Turso
+const t = await connect(p, { experimental: ['index_method'] });
+try {
+  await t.exec("INSERT INTO items VALUES('c','a new climate document')");
+  out.turso_insert = 'reported SUCCESS (no exception)';
+} catch (e) { out.turso_insert = `threw: ${e.message}`; }
+
+// read back FROM TURSO, in the same connection, before any checkpoint
+out.turso_readback_sameConn = (await t.prepare('SELECT id FROM items ORDER BY id').all([])).map(r => r.id);
+await t.exec('PRAGMA wal_checkpoint(TRUNCATE)');
+out.turso_readback_afterCheckpoint = (await t.prepare('SELECT id FROM items ORDER BY id').all([])).map(r => r.id);
+t.close?.();
+
+// reopen in Turso fresh
+const t2 = await connect(p, { experimental: ['index_method'] });
+out.turso_readback_freshConn = (await t2.prepare('SELECT id FROM items ORDER BY id').all([])).map(r => r.id);
+t2.close?.();
+
+// reopen in stock SQLite
+const s2 = new DatabaseSync(p);
+out.sqlite_readback = s2.prepare('SELECT id FROM items ORDER BY id').all().map(r => r.id);
+out.sqlite_ftsHits = s2.prepare("SELECT rowid FROM items_fts WHERE items_fts MATCH 'climate'").all().map(r => Number(r.rowid));
+try {
+  s2.prepare("INSERT INTO items_fts(items_fts) VALUES('integrity-check')").all();
+  out.sqlite_fts5_integrityCheck = 'PASSED';
+} catch (e) { out.sqlite_fts5_integrityCheck = `FAILED: ${e.message}`; }
+out.sqlite_integrity = s2.prepare('PRAGMA integrity_check').all().slice(0, 2);
+s2.close();
+
+// ---- control: same insert with NO fts5 triggers present --------------------
+const p2 = `${SCRATCH}/ws2.db`;
+for (const x of ['', '-wal', '-shm']) fs.rmSync(p2 + x, { force: true });
+const s3 = new DatabaseSync(p2);
+s3.exec(`PRAGMA journal_mode=WAL; CREATE TABLE items(id TEXT PRIMARY KEY, body TEXT);
+  INSERT INTO items VALUES('a','x'); INSERT INTO items VALUES('b','y');`);
+s3.exec('PRAGMA wal_checkpoint(TRUNCATE)'); s3.close();
+const t3 = await connect(p2, { experimental: ['index_method'] });
+try { await t3.exec("INSERT INTO items VALUES('c','z')"); out.control_turso_insert = 'SUCCESS'; }
+catch (e) { out.control_turso_insert = `threw: ${e.message}`; }
+await t3.exec('PRAGMA wal_checkpoint(TRUNCATE)'); t3.close?.();
+const s4 = new DatabaseSync(p2);
+out.control_sqlite_readback = s4.prepare('SELECT id FROM items ORDER BY id').all().map(r => r.id);
+s4.close();
+
+console.log(JSON.stringify(out, null, 1));


### PR DESCRIPTION
(AI Generated).

Turso keeps coming back, and it should. It is genuinely elegant and this project deliberately adopts bleeding-edge technology. This exists so the next conversation about it starts from evidence rather than from the appeal.

## Two reasons this is a document and not a decision-log line

**The roadmap documented the wrong reason.** `STORAGE-ARCHITECTURE-ROADMAP.md` argued the fatal flaw was that a Tantivy index is not SQLite B-tree pages, so the escape hatch preserves the data but not the search index. That objection is weak, and the owner correctly rejected it: indexes are derived data, you rebuild them. It is retracted here and replaced. The verdict is unchanged; the reasons are different and much stronger. Leaving it as written meant the next reader would relitigate on a basis nobody actually believes.

**The evidence lived in an ephemeral scratchpad.** Research that cannot be re-run is a claim, not a finding. The probes that make up the adoption gate, and the result JSON behind every table in the document, are checked in beside it. 120 KB, scripts and results only, no generated databases.

## What the measurement says

| | |
| --- | --- |
| Incremental FTS ingest | **313 ms/row** into a 95,076-row index vs SQLite's flat **0.20 ms/row**, ~1,570x, and it scales with index size |
| Plain writes | **fine** — 1,063 ms vs 1,115 ms |
| Peak RSS, index build | SQLite **+3.2 MB** vs Turso **+153.5 MB** (48x), and Turso carries ~474 MB more resident on the same corpus |
| Silent index corruption | 650 writes, **zero** reflected in any index |

"Turso writes get slower as the database grows" is the wrong summary, and it will send the next investigator after the wrong thing. Plain writes were never the problem; FTS index maintenance is.

The corruption is the serious one, and it is broader than first measured. **Any** virtual-table module Turso does not implement — fts5, fts4, rtree, on any table including an unrelated one — makes Turso open the connection with no indexes at all and skip index maintenance on every write while reporting success. Updated rows keep their stale pre-update values indexed, so index-driven reads return rows that no longer match. Traced to a swallowed error at `core/lib.rs:1514-1519`; still present on `main` 331 commits later; no upstream issue exists for it.

## A note on the numbers

The RSS pair was transposed once in conversation, which inverted the entire argument in Turso's favour. The document now states its ordering convention explicitly and says outright which engine is the 3.2 MB one.

Turso's genuine wins are recorded too, because a one-sided record is less useful than a fair one: 12.6x faster on very high frequency terms, and flat 1.6–2.5 ms latency across every query shape. It still loses 9 of 11 shapes, often by 5x to 80x.

## Roadmap change

Drops the planned "Turso as a read-only CI conformance track from Stage 4". Stock SQLite cannot open a Turso-FTS file at all, so the fixture diff that track was meant to produce is not possible, and conformance-testing against an engine that silently drops index writes would manufacture false confidence rather than readiness signal.

## Adoption gate

No longer a version number. Specific probes passing: `blast2.mjs` returning matching index counts with `integrity == ["ok"]`, and `gate.mjs` returning a non-empty `prefix_star` and non-zero `score_bound_param`. As of 2026-07-25 on 0.7.1, which is the current release, zero of four gate conditions hold.

## Provider surface

None. Documentation and benchmark scripts only; no file in this PR is provider-visible.