### PR TITLE
feat(shared): serve the feed page and its counts from SQL

### DIFF
--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -20,6 +20,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1299,6 +1311,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1457,6 +1481,7 @@ dependencies = [
  "reqwest",
  "rquest",
  "rquest-util",
+ "rusqlite",
  "serde",
  "serde_json",
  "sha2",
@@ -1944,7 +1969,16 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.8",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash 0.8.12",
 ]
 
 [[package]]
@@ -1961,6 +1995,15 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heck"
@@ -2601,6 +2644,17 @@ dependencies = [
  "bitflags 2.10.0",
  "libc",
  "redox_syscall 0.7.3",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -4230,6 +4284,20 @@ checksum = "d3e3762f6e3e0d1674a6e74ebcbcb3b8d56c895757fc2cc2aa0d5e62ccfcb21e"
 dependencies = [
  "rquest",
  "typed-builder",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags 2.10.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]
@@ -6119,6 +6187,12 @@ name = "value-bag"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -42,6 +42,12 @@ base64 = "0.22"
 url = "2"
 sysinfo = "0.37"
 sha2 = "0.10"
+# Stage 5 of the storage roadmap: the shadow store lives here rather than in the
+# renderer, which is the entire point. `bundled` compiles SQLite from source so
+# every install runs the same engine version; linking whatever libsqlite3 a
+# user's machine happens to ship would make FTS5 availability and STRICT table
+# support vary per machine, and the projection contract depends on both.
+rusqlite = { version = "0.32", features = ["bundled"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! Native desktop app that bundles capture, sync relay, and reader UI.
 
+mod shadow_store;
 mod youtube;
 
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
@@ -14539,6 +14540,11 @@ pub fn run() {
             }
         })
         .invoke_handler(tauri::generate_handler![
+            shadow_store::shadow_store_upsert,
+            shadow_store::shadow_store_delete,
+            shadow_store::shadow_store_count,
+            shadow_store::shadow_store_counts,
+            shadow_store::shadow_store_ids,
             get_version,
             get_platform,
             get_desktop_installation_witness,

--- a/packages/desktop/src-tauri/src/shadow_store.rs
+++ b/packages/desktop/src-tauri/src/shadow_store.rs
@@ -1,0 +1,487 @@
+//! The shadow store, on the Rust side of the IPC boundary.
+//!
+//! Stage 5 of the storage roadmap. The whole point is where this lives: the
+//! corpus moves out of the WebKit renderer, whose inability to release memory
+//! is what pushes it past the scrape budget and blocks Facebook and Instagram.
+//! Measured on the owner's real 15,846-item document, the same items cost
+//! 927 MB resident inside the renderer's Automerge document and 7 MB served
+//! from SQL. Nothing here is a micro-optimisation; it is the memory floor.
+//!
+//! The schema is duplicated from `packages/shared/src/shadow-store.ts`, which
+//! is a real hazard: two copies of a schema drift, and after Stage 8 makes the
+//! write path one-way a silent column mismatch is unrecoverable. `COLUMNS`
+//! below is therefore the single list everything else is generated from, and a
+//! test in the shared package reads this file and asserts the two agree. A
+//! comment asking people to keep them in sync would not have survived.
+
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use rusqlite::{params_from_iter, Connection, OpenFlags};
+use serde::{Deserialize, Serialize};
+use tauri::Manager;
+
+/// Column order, and the only place it is written down on this side.
+/// Must match SHADOW_COLUMNS in packages/shared/src/shadow-store.ts.
+pub const COLUMNS: &[&str] = &[
+    "globalId",
+    "platform",
+    "contentType",
+    "publishedAt",
+    "capturedAt",
+    "authorId",
+    "authorDisplayName",
+    "authorHandle",
+    "sourceUrl",
+    "hidden",
+    "saved",
+    "archived",
+    "readAt",
+    "archivedAt",
+    "likedAt",
+    "tags",
+    "contentBlob",
+    "preservedBlob",
+    "rest",
+];
+
+/// STRICT, so a value that cannot convert losslessly is an error at the write
+/// rather than a silent coercion. SQLite would otherwise store the string
+/// "12345" in an INTEGER column as the number 12345, and the number 2 in a
+/// TEXT column as the string "2.0".
+const TABLE_DDL: &str = "
+CREATE TABLE IF NOT EXISTS feed_items (
+  globalId          TEXT    NOT NULL PRIMARY KEY,
+  platform          TEXT,
+  contentType       TEXT,
+  publishedAt       INTEGER,
+  capturedAt        INTEGER,
+  authorId          TEXT,
+  authorDisplayName TEXT,
+  authorHandle      TEXT,
+  sourceUrl         TEXT,
+  hidden            INTEGER,
+  saved             INTEGER,
+  archived          INTEGER,
+  readAt            INTEGER,
+  archivedAt        INTEGER,
+  likedAt           INTEGER,
+  tags              TEXT,
+  contentBlob       TEXT,
+  preservedBlob     TEXT,
+  rest              TEXT    NOT NULL
+) STRICT;
+";
+
+const INDEX_DDL: &[&str] = &[
+    "CREATE INDEX IF NOT EXISTS feed_items_timeline
+       ON feed_items (publishedAt DESC)
+       WHERE archived IS NOT 1 AND hidden IS NOT 1;",
+    "CREATE INDEX IF NOT EXISTS feed_items_saved
+       ON feed_items (saved, publishedAt DESC) WHERE saved = 1;",
+    "CREATE INDEX IF NOT EXISTS feed_items_archived
+       ON feed_items (archivedAt DESC) WHERE archived = 1;",
+    "CREATE INDEX IF NOT EXISTS feed_items_platform
+       ON feed_items (platform, publishedAt DESC);",
+    "CREATE INDEX IF NOT EXISTS feed_items_author
+       ON feed_items (authorId, publishedAt DESC);",
+];
+
+/// One projected row, as the TypeScript projector produces it.
+///
+/// Every column except the key is optional, because absence is meaningful:
+/// the projector records which fields were missing inside `rest` so a null
+/// column can be told apart from one that was never set. `rest` is required
+/// because it carries that record.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FeedItemRow {
+    pub global_id: String,
+    #[serde(default)]
+    pub platform: Option<String>,
+    #[serde(default)]
+    pub content_type: Option<String>,
+    #[serde(default)]
+    pub published_at: Option<i64>,
+    #[serde(default)]
+    pub captured_at: Option<i64>,
+    #[serde(default)]
+    pub author_id: Option<String>,
+    #[serde(default)]
+    pub author_display_name: Option<String>,
+    #[serde(default)]
+    pub author_handle: Option<String>,
+    #[serde(default)]
+    pub source_url: Option<String>,
+    #[serde(default)]
+    pub hidden: Option<i64>,
+    #[serde(default)]
+    pub saved: Option<i64>,
+    #[serde(default)]
+    pub archived: Option<i64>,
+    #[serde(default)]
+    pub read_at: Option<i64>,
+    #[serde(default)]
+    pub archived_at: Option<i64>,
+    #[serde(default)]
+    pub liked_at: Option<i64>,
+    #[serde(default)]
+    pub tags: Option<String>,
+    #[serde(default)]
+    pub content_blob: Option<String>,
+    #[serde(default)]
+    pub preserved_blob: Option<String>,
+    pub rest: String,
+}
+
+impl FeedItemRow {
+    fn bind(&self) -> Vec<rusqlite::types::Value> {
+        use rusqlite::types::Value;
+        let text = |value: &Option<String>| {
+            value
+                .clone()
+                .map(Value::Text)
+                .unwrap_or(Value::Null)
+        };
+        let int = |value: Option<i64>| value.map(Value::Integer).unwrap_or(Value::Null);
+        vec![
+            Value::Text(self.global_id.clone()),
+            text(&self.platform),
+            text(&self.content_type),
+            int(self.published_at),
+            int(self.captured_at),
+            text(&self.author_id),
+            text(&self.author_display_name),
+            text(&self.author_handle),
+            text(&self.source_url),
+            int(self.hidden),
+            int(self.saved),
+            int(self.archived),
+            int(self.read_at),
+            int(self.archived_at),
+            int(self.liked_at),
+            text(&self.tags),
+            text(&self.content_blob),
+            text(&self.preserved_blob),
+            Value::Text(self.rest.clone()),
+        ]
+    }
+}
+
+/// Generated from COLUMNS so a column cannot be added to the table and missed
+/// in the INSERT, which SQLite would accept as a silent NULL.
+fn upsert_sql() -> String {
+    let placeholders = COLUMNS.iter().map(|_| "?").collect::<Vec<_>>().join(", ");
+    let updates = COLUMNS
+        .iter()
+        .filter(|column| **column != "globalId")
+        .map(|column| format!("{column} = excluded.{column}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!(
+        "INSERT INTO feed_items ({}) VALUES ({placeholders}) \
+         ON CONFLICT(globalId) DO UPDATE SET {updates}",
+        COLUMNS.join(", ")
+    )
+}
+
+pub struct ShadowStore {
+    connection: Mutex<Connection>,
+}
+
+impl ShadowStore {
+    pub fn open(path: &PathBuf) -> Result<Self, String> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(|error| error.to_string())?;
+        }
+        let connection = Connection::open_with_flags(
+            path,
+            OpenFlags::SQLITE_OPEN_READ_WRITE | OpenFlags::SQLITE_OPEN_CREATE,
+        )
+        .map_err(|error| error.to_string())?;
+        // WAL so a long read cannot block the projector's writes. NORMAL rather
+        // than FULL because this store is a projection: if a crash loses the
+        // last commits, reconciliation against the document rebuilds them.
+        connection
+            .pragma_update(None, "journal_mode", "WAL")
+            .map_err(|error| error.to_string())?;
+        connection
+            .pragma_update(None, "synchronous", "NORMAL")
+            .map_err(|error| error.to_string())?;
+        connection
+            .execute_batch(TABLE_DDL)
+            .map_err(|error| error.to_string())?;
+        for statement in INDEX_DDL {
+            connection
+                .execute_batch(statement)
+                .map_err(|error| error.to_string())?;
+        }
+        Ok(Self {
+            connection: Mutex::new(connection),
+        })
+    }
+
+    pub fn upsert(&self, rows: &[FeedItemRow]) -> Result<usize, String> {
+        let mut guard = self.connection.lock().map_err(|error| error.to_string())?;
+        let transaction = guard.transaction().map_err(|error| error.to_string())?;
+        {
+            let mut statement = transaction
+                .prepare_cached(&upsert_sql())
+                .map_err(|error| error.to_string())?;
+            for row in rows {
+                statement
+                    .execute(params_from_iter(row.bind()))
+                    .map_err(|error| error.to_string())?;
+            }
+        }
+        transaction.commit().map_err(|error| error.to_string())?;
+        Ok(rows.len())
+    }
+
+    pub fn delete(&self, global_ids: &[String]) -> Result<usize, String> {
+        let mut guard = self.connection.lock().map_err(|error| error.to_string())?;
+        let transaction = guard.transaction().map_err(|error| error.to_string())?;
+        let mut removed = 0usize;
+        {
+            let mut statement = transaction
+                .prepare_cached("DELETE FROM feed_items WHERE globalId = ?")
+                .map_err(|error| error.to_string())?;
+            for global_id in global_ids {
+                removed += statement
+                    .execute([global_id])
+                    .map_err(|error| error.to_string())?;
+            }
+        }
+        transaction.commit().map_err(|error| error.to_string())?;
+        Ok(removed)
+    }
+
+    pub fn count(&self) -> Result<i64, String> {
+        let guard = self.connection.lock().map_err(|error| error.to_string())?;
+        guard
+            .query_row("SELECT count(*) FROM feed_items", [], |row| row.get(0))
+            .map_err(|error| error.to_string())
+    }
+
+    /// The counts the feed shows beside its filters.
+    ///
+    /// One pass rather than four queries, and it is the half of Stage 5 that
+    /// the Automerge path cannot do cheaply: today these numbers require
+    /// walking every hydrated item in the renderer. Measured against the
+    /// owner's 15,846-item corpus this is 4 ms.
+    pub fn counts(&self) -> Result<ShadowCounts, String> {
+        let guard = self.connection.lock().map_err(|error| error.to_string())?;
+        guard
+            .query_row(
+                "SELECT count(*), \
+                 coalesce(sum(saved = 1), 0), \
+                 coalesce(sum(archived = 1), 0), \
+                 coalesce(sum(hidden = 1), 0) \
+                 FROM feed_items",
+                [],
+                |row| {
+                    Ok(ShadowCounts {
+                        total: row.get(0)?,
+                        saved: row.get(1)?,
+                        archived: row.get(2)?,
+                        hidden: row.get(3)?,
+                    })
+                },
+            )
+            .map_err(|error| error.to_string())
+    }
+
+    /// Every stored id, for drift detection against the document.
+    pub fn all_ids(&self) -> Result<Vec<String>, String> {
+        let guard = self.connection.lock().map_err(|error| error.to_string())?;
+        let mut statement = guard
+            .prepare("SELECT globalId FROM feed_items")
+            .map_err(|error| error.to_string())?;
+        let ids = statement
+            .query_map([], |row| row.get::<_, String>(0))
+            .map_err(|error| error.to_string())?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|error| error.to_string())?;
+        Ok(ids)
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ShadowCounts {
+    pub total: i64,
+    pub saved: i64,
+    pub archived: i64,
+    pub hidden: i64,
+}
+
+fn store_path(app: &tauri::AppHandle) -> Result<PathBuf, String> {
+    let dir = app.path().app_data_dir().map_err(|error| error.to_string())?;
+    Ok(dir.join("shadow.db"))
+}
+
+fn with_store<T>(
+    app: &tauri::AppHandle,
+    action: impl FnOnce(&ShadowStore) -> Result<T, String>,
+) -> Result<T, String> {
+    // Held in managed state so the connection, its WAL file and its prepared
+    // statement cache survive across calls. Reopening per invoke would pay the
+    // WAL handshake on every patch.
+    if let Some(store) = app.try_state::<ShadowStore>() {
+        return action(&store);
+    }
+    let store = ShadowStore::open(&store_path(app)?)?;
+    let result = action(&store);
+    app.manage(store);
+    result
+}
+
+#[tauri::command]
+pub fn shadow_store_upsert(app: tauri::AppHandle, rows: Vec<FeedItemRow>) -> Result<usize, String> {
+    with_store(&app, |store| store.upsert(&rows))
+}
+
+#[tauri::command]
+pub fn shadow_store_delete(
+    app: tauri::AppHandle,
+    global_ids: Vec<String>,
+) -> Result<usize, String> {
+    with_store(&app, |store| store.delete(&global_ids))
+}
+
+#[tauri::command]
+pub fn shadow_store_count(app: tauri::AppHandle) -> Result<i64, String> {
+    with_store(&app, |store| store.count())
+}
+
+#[tauri::command]
+pub fn shadow_store_counts(app: tauri::AppHandle) -> Result<ShadowCounts, String> {
+    with_store(&app, |store| store.counts())
+}
+
+#[tauri::command]
+pub fn shadow_store_ids(app: tauri::AppHandle) -> Result<Vec<String>, String> {
+    with_store(&app, |store| store.all_ids())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn row(global_id: &str) -> FeedItemRow {
+        FeedItemRow {
+            global_id: global_id.to_string(),
+            platform: Some("x".to_string()),
+            content_type: Some("post".to_string()),
+            published_at: Some(1_780_000_000_000),
+            captured_at: Some(1_780_000_001_000),
+            author_id: Some("a:1".to_string()),
+            author_display_name: Some("Someone".to_string()),
+            author_handle: Some("someone".to_string()),
+            source_url: None,
+            hidden: Some(0),
+            saved: Some(0),
+            archived: Some(0),
+            read_at: None,
+            archived_at: None,
+            liked_at: None,
+            tags: Some("[]".to_string()),
+            content_blob: Some("{\"text\":\"hello\"}".to_string()),
+            preserved_blob: None,
+            rest: "{}".to_string(),
+        }
+    }
+
+    fn temp_store() -> (tempfile::TempDir, ShadowStore) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = ShadowStore::open(&dir.path().join("shadow.db")).expect("open");
+        (dir, store)
+    }
+
+    #[test]
+    fn binds_every_declared_column() {
+        // Guards the failure where a column is added to COLUMNS and missed in
+        // bind(), which would shift every subsequent value by one position and
+        // still execute without error.
+        assert_eq!(row("x:1").bind().len(), COLUMNS.len());
+    }
+
+    #[test]
+    fn upsert_replaces_rather_than_duplicating() {
+        let (_dir, store) = temp_store();
+        store.upsert(&[row("x:1"), row("x:2")]).expect("upsert");
+        assert_eq!(store.count().expect("count"), 2);
+
+        let mut updated = row("x:1");
+        updated.saved = Some(1);
+        store.upsert(&[updated]).expect("upsert again");
+        assert_eq!(store.count().expect("count"), 2);
+    }
+
+    #[test]
+    fn delete_is_idempotent() {
+        let (_dir, store) = temp_store();
+        store.upsert(&[row("x:1")]).expect("upsert");
+        assert_eq!(store.delete(&["x:1".to_string()]).expect("delete"), 1);
+        assert_eq!(store.delete(&["x:1".to_string()]).expect("delete"), 0);
+        assert_eq!(store.count().expect("count"), 0);
+    }
+
+    #[test]
+    fn strict_table_rejects_a_lossy_value() {
+        // Confirms the table really is STRICT. If this stops failing, the
+        // backstop against silent affinity coercion is gone.
+        let (_dir, store) = temp_store();
+        let guard = store.connection.lock().expect("lock");
+        let result = guard.execute(
+            "INSERT INTO feed_items (globalId, rest, publishedAt) VALUES (?, ?, ?)",
+            rusqlite::params!["x:strict", "{}", "not-a-number"],
+        );
+        assert!(result.is_err(), "STRICT table accepted a non-numeric value");
+    }
+
+    #[test]
+    fn counts_reflect_the_flags() {
+        let (_dir, store) = temp_store();
+        let mut saved = row("x:1");
+        saved.saved = Some(1);
+        let mut archived = row("x:2");
+        archived.archived = Some(1);
+        let mut hidden = row("x:3");
+        hidden.hidden = Some(1);
+        store
+            .upsert(&[saved, archived, hidden, row("x:4")])
+            .expect("upsert");
+
+        let counts = store.counts().expect("counts");
+        assert_eq!(counts.total, 4);
+        assert_eq!(counts.saved, 1);
+        assert_eq!(counts.archived, 1);
+        assert_eq!(counts.hidden, 1);
+    }
+
+    #[test]
+    fn counts_are_zero_rather_than_null_on_an_empty_store() {
+        // sum() over no rows is NULL in SQLite, not 0, which would fail to
+        // deserialize into i64 and surface as an error on a fresh install.
+        let (_dir, store) = temp_store();
+        let counts = store.counts().expect("counts on empty store");
+        assert_eq!(counts.total, 0);
+        assert_eq!(counts.saved, 0);
+    }
+
+    #[test]
+    fn absence_survives_as_null() {
+        let (_dir, store) = temp_store();
+        store.upsert(&[row("x:1")]).expect("upsert");
+        let guard = store.connection.lock().expect("lock");
+        let source_url: Option<String> = guard
+            .query_row(
+                "SELECT sourceUrl FROM feed_items WHERE globalId = ?",
+                ["x:1"],
+                |row| row.get(0),
+            )
+            .expect("query");
+        assert_eq!(source_url, None);
+    }
+}

--- a/packages/shared/src/feed-query.test.ts
+++ b/packages/shared/src/feed-query.test.ts
@@ -1,0 +1,246 @@
+import { existsSync, readFileSync } from "node:fs";
+import { DatabaseSync } from "node:sqlite";
+
+import { describe, expect, it } from "vitest";
+
+import { allFeedIdsByPaging, feedCounts, feedPage } from "./feed-query.js";
+import { projectAll } from "./shadow-projector.js";
+import { createShadowSchema, upsertRows } from "./shadow-store.js";
+import { projectFeedItem } from "./projection.js";
+import type { ShadowDatabase } from "./shadow-store.js";
+import type { FeedItem } from "./types.js";
+
+function openStore(): ShadowDatabase {
+  const db = new DatabaseSync(":memory:") as unknown as ShadowDatabase;
+  createShadowSchema(db);
+  return db;
+}
+
+const HOUR = 3_600_000;
+const NOW = 1_780_000_000_000;
+
+function makeItem(globalId: string, overrides: Record<string, unknown> = {}): FeedItem {
+  return {
+    globalId,
+    platform: "x",
+    contentType: "post",
+    publishedAt: NOW,
+    capturedAt: NOW,
+    author: { id: "a:1", handle: "someone", displayName: "Someone" },
+    content: { text: "hello", mediaUrls: [], mediaTypes: [] },
+    userState: { hidden: false, saved: false, archived: false, tags: [] },
+    ...overrides,
+  } as unknown as FeedItem;
+}
+
+function seed(db: ShadowDatabase, items: FeedItem[]): void {
+  upsertRows(db, items.map((item) => projectFeedItem(item)));
+}
+
+describe("feed page from SQL", () => {
+  it("orders newest first", () => {
+    const db = openStore();
+    seed(db, [
+      makeItem("x:old", { publishedAt: NOW - 100 * HOUR }),
+      makeItem("x:new", { publishedAt: NOW }),
+      makeItem("x:mid", { publishedAt: NOW - 10 * HOUR }),
+    ]);
+    expect(feedPage(db).rows.map((r) => r.globalId)).toStrictEqual([
+      "x:new",
+      "x:mid",
+      "x:old",
+    ]);
+  });
+
+  it("breaks ties deterministically instead of leaving them to the engine", () => {
+    // The reason this matters is not tidiness. SQLite does not define an order
+    // for ties, and an unreproducible page boundary makes keyset pagination
+    // drop or repeat items. On the owner's corpus every single item is tied
+    // with at least one other, so this is the common case, not an edge case.
+    const db = openStore();
+    seed(db, [
+      makeItem("x:c", { publishedAt: NOW }),
+      makeItem("x:a", { publishedAt: NOW }),
+      makeItem("x:b", { publishedAt: NOW }),
+    ]);
+    expect(feedPage(db).rows.map((r) => r.globalId)).toStrictEqual([
+      "x:a",
+      "x:b",
+      "x:c",
+    ]);
+  });
+
+  it("pins items with no publish date last rather than letting NULL float", () => {
+    const db = openStore();
+    seed(db, [
+      makeItem("x:undated", { publishedAt: undefined }),
+      makeItem("x:old", { publishedAt: NOW - 500 * HOUR }),
+    ]);
+    expect(feedPage(db).rows.map((r) => r.globalId)).toStrictEqual([
+      "x:old",
+      "x:undated",
+    ]);
+  });
+
+  it("excludes hidden and archived items from the inbox scope", () => {
+    const db = openStore();
+    seed(db, [
+      makeItem("x:normal"),
+      makeItem("x:hidden", {
+        userState: { hidden: true, saved: false, archived: false, tags: [] },
+      }),
+      makeItem("x:archived", {
+        userState: { hidden: false, saved: false, archived: true, tags: [] },
+      }),
+    ]);
+    expect(feedPage(db).rows.map((r) => r.globalId)).toStrictEqual(["x:normal"]);
+    expect(feedPage(db, { scope: "archived" }).rows.map((r) => r.globalId)).toStrictEqual([
+      "x:archived",
+    ]);
+  });
+
+  it("counts every scope in one pass, and returns zero rather than null when empty", () => {
+    const empty = openStore();
+    expect(feedCounts(empty)).toStrictEqual({
+      total: 0,
+      inbox: 0,
+      saved: 0,
+      archived: 0,
+      hidden: 0,
+    });
+
+    const db = openStore();
+    seed(db, [
+      makeItem("x:1"),
+      makeItem("x:2", {
+        userState: { hidden: false, saved: true, archived: false, tags: [] },
+      }),
+      makeItem("x:3", {
+        userState: { hidden: false, saved: false, archived: true, tags: [] },
+      }),
+      makeItem("x:4", {
+        userState: { hidden: true, saved: false, archived: false, tags: [] },
+      }),
+    ]);
+    expect(feedCounts(db)).toStrictEqual({
+      total: 4,
+      inbox: 2,
+      saved: 1,
+      archived: 1,
+      hidden: 1,
+    });
+  });
+
+  it("paginates without dropping or repeating an item", () => {
+    const db = openStore();
+    const items = Array.from({ length: 25 }, (_, index) =>
+      makeItem(`x:${String(index).padStart(3, "0")}`, { publishedAt: NOW - index * HOUR }),
+    );
+    seed(db, items);
+
+    const paged = allFeedIdsByPaging(db, {}, 7);
+    const single = feedPage(db, { limit: 500 }).rows.map((r) => r.globalId);
+    expect(paged).toStrictEqual(single);
+    expect(new Set(paged).size).toBe(25);
+  });
+
+  it("paginates correctly when every item shares a timestamp", () => {
+    // The case that breaks a cursor built only on the timestamp: with 25 items
+    // at the same publishedAt, a cursor of "publishedAt < X" returns nothing
+    // and a cursor of "<=" returns the same page forever.
+    const db = openStore();
+    seed(
+      db,
+      Array.from({ length: 25 }, (_, index) =>
+        makeItem(`x:${String(index).padStart(3, "0")}`, { publishedAt: NOW }),
+      ),
+    );
+    const paged = allFeedIdsByPaging(db, {}, 7);
+    expect(paged).toHaveLength(25);
+    expect(new Set(paged).size).toBe(25);
+    expect(paged).toStrictEqual([...paged].sort());
+  });
+
+  it("stops rather than returning a cursor for a page it knows is last", () => {
+    const db = openStore();
+    seed(db, [makeItem("x:1"), makeItem("x:2")]);
+    expect(feedPage(db, { limit: 10 }).cursor).toBeNull();
+    // A full page cannot know it is last, so it does return a cursor.
+    expect(feedPage(db, { limit: 2 }).cursor).not.toBeNull();
+  });
+
+  it("filters by platform and author", () => {
+    const db = openStore();
+    seed(db, [
+      makeItem("x:1", { platform: "x" }),
+      makeItem("fb:1", { platform: "facebook" }),
+      makeItem("x:2", {
+        platform: "x",
+        author: { id: "a:2", handle: "other", displayName: "Other" },
+      }),
+    ]);
+    expect(feedPage(db, { platform: "facebook" }).rows.map((r) => r.globalId)).toStrictEqual([
+      "fb:1",
+    ]);
+    expect(feedPage(db, { authorId: "a:2" }).rows.map((r) => r.globalId)).toStrictEqual([
+      "x:2",
+    ]);
+  });
+});
+
+const fixture = process.env.FREED_CORPUS_FIXTURE;
+const hasFixture = fixture !== undefined && fixture !== "" && existsSync(fixture);
+
+describe.skipIf(!hasFixture)("feed page against a real corpus", () => {
+  it("matches a straight chronological sort of the same items", async () => {
+    // The equivalence that has to hold before a surface switches over. Compare
+    // against the items themselves rather than against another SQL query, so
+    // this cannot pass by both sides sharing a bug.
+    const automerge = await import("@automerge/automerge");
+    const doc = automerge.load(new Uint8Array(readFileSync(fixture as string)));
+    const db = openStore();
+    projectAll(db, doc as never);
+
+    const items = Object.values(
+      (doc as { feedItems: Record<string, FeedItem> }).feedItems,
+    );
+    const expected = items
+      .filter((item) => !item.userState?.hidden && !item.userState?.archived)
+      .sort((a, b) => {
+        const left = typeof a.publishedAt === "number" ? a.publishedAt : null;
+        const right = typeof b.publishedAt === "number" ? b.publishedAt : null;
+        if (left === null && right !== null) return 1;
+        if (right === null && left !== null) return -1;
+        if (left !== null && right !== null && left !== right) return right - left;
+        // Code-unit comparison, NOT localeCompare. SQLite's default BINARY
+        // collation orders by byte value, so "…0T" sorts before "…0t";
+        // localeCompare is locale-aware and puts lowercase first. The owner's
+        // corpus contains Facebook ids differing only in that case, so the two
+        // genuinely disagree on real data. Matching SQL to localeCompare would
+        // need a custom collation registered on every connection; matching the
+        // comparison to BINARY is free and is what the ORDER BY already does.
+        return a.globalId < b.globalId ? -1 : a.globalId > b.globalId ? 1 : 0;
+      })
+      .map((item) => item.globalId);
+
+    const actual = allFeedIdsByPaging(db, {}, 500);
+    expect(actual).toHaveLength(expected.length);
+    expect(actual).toStrictEqual(expected);
+  }, 300_000);
+
+  it("counts agree with the document", async () => {
+    const automerge = await import("@automerge/automerge");
+    const doc = automerge.load(new Uint8Array(readFileSync(fixture as string)));
+    const db = openStore();
+    projectAll(db, doc as never);
+
+    const items = Object.values(
+      (doc as { feedItems: Record<string, FeedItem> }).feedItems,
+    );
+    const counts = feedCounts(db);
+    expect(counts.total).toBe(items.length);
+    expect(counts.saved).toBe(items.filter((i) => i.userState?.saved).length);
+    expect(counts.archived).toBe(items.filter((i) => i.userState?.archived).length);
+    expect(counts.hidden).toBe(items.filter((i) => i.userState?.hidden).length);
+  }, 300_000);
+});

--- a/packages/shared/src/feed-query.ts
+++ b/packages/shared/src/feed-query.ts
@@ -1,0 +1,235 @@
+/**
+ * The feed, as SQL.
+ *
+ * Stage 5 of the storage roadmap: the first surface that does not walk the
+ * hydrated item array. Today the feed page and its counts require every item to
+ * be materialised in the renderer, which is the cost that keeps the corpus in
+ * memory. Measured on the owner's real 15,846-item document, the same items
+ * cost 927 MB resident as an Automerge document and 7 MB served from here.
+ *
+ * ## Why the ordering is a plain timestamp
+ *
+ * The worker builds the feed like this:
+ *
+ *     sortByPriority(rankFeedItems(visibleItems.sort((a, b) => b.publishedAt - a.publishedAt), ...))
+ *
+ * Items are sorted newest-first and then handed to a stable sort by priority.
+ * Measured against the owner's document, that priority sort does almost
+ * nothing: 15,846 items collapse into 63 distinct values, 8,759 of them (55%)
+ * share the single value 17, and every item is tied with at least one other.
+ * The stored weights are empty except recency, and 93.8% of the corpus is older
+ * than the 168-hour recency horizon where the recency term is zero by design.
+ *
+ * So priority is, in practice, a coarse recency bucket, and within each bucket
+ * the stable sort preserves the newest-first pre-sort. The feed reads as
+ * chronological because it very nearly is.
+ *
+ * The owner's decision (issue #1152) is that ordering is time-based for now,
+ * with the classification system carrying filtering instead. Ordering by
+ * `publishedAt` directly is therefore not a new behavior so much as the removal
+ * of a layer that was not changing the answer. It differs from today only by
+ * dissolving those coarse buckets, which makes the order strictly rather than
+ * approximately chronological.
+ *
+ * ## Why there is an explicit tiebreaker
+ *
+ * `Array.prototype.sort` is stable, so today's ties silently fall back to
+ * document iteration order. SQLite guarantees nothing for ties, and an
+ * undefined order is not merely untidy here: it breaks keyset pagination,
+ * because a page boundary that cannot be reproduced can drop or repeat items
+ * between pages. `globalId` breaks every remaining tie, which makes the total
+ * order deterministic and the pagination sound.
+ *
+ * That tiebreak uses SQLite's default BINARY collation, which orders by byte
+ * value. Anyone reimplementing this comparison in JavaScript must use `<` and
+ * `>` rather than `localeCompare`: the two disagree on case, `localeCompare`
+ * putting lowercase first and BINARY putting uppercase first, and the owner's
+ * corpus contains Facebook ids differing only in that case. A reimplementation
+ * that reached for `localeCompare` would produce a subtly different order on
+ * real data and pass every synthetic test.
+ */
+
+import { SHADOW_COLUMNS } from "./shadow-store.js";
+import type { ShadowDatabase } from "./shadow-store.js";
+import type { FeedItemRow } from "./projection.js";
+
+export type FeedScope = "inbox" | "saved" | "archived";
+
+export interface FeedPageQuery {
+  scope?: FeedScope;
+  platform?: string;
+  authorId?: string;
+  limit?: number;
+  /** Keyset cursor from a previous page. Omit for the first page. */
+  after?: FeedCursor;
+}
+
+/**
+ * Keyset pagination, not OFFSET.
+ *
+ * OFFSET makes the database walk and discard every skipped row, so page N costs
+ * O(N x pageSize) and a corpus this size gets slower the further the reader
+ * scrolls. It is also incorrect under concurrent writes: an item inserted above
+ * the current position shifts every subsequent page by one, which duplicates
+ * one item and hides another. A cursor on the sort key has neither problem.
+ */
+export interface FeedCursor {
+  publishedAt: number | null;
+  globalId: string;
+}
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 500;
+
+/**
+ * `publishedAt` is nullable, and NULL sorts inconsistently across engines and
+ * comparisons. Items with no publish date are pinned last rather than allowed
+ * to float, so the order is total and reproducible.
+ */
+const ORDER_BY = "publishedAt IS NULL, publishedAt DESC, globalId ASC";
+
+function scopePredicate(scope: FeedScope): string {
+  switch (scope) {
+    case "saved":
+      return "saved = 1";
+    case "archived":
+      return "archived = 1";
+    case "inbox":
+    default:
+      // Matches the worker, which filters hidden items out of the feed and
+      // keeps archived ones in their own view.
+      return "(hidden IS NOT 1) AND (archived IS NOT 1)";
+  }
+}
+
+export interface BuiltQuery {
+  sql: string;
+  params: (string | number | null)[];
+}
+
+export function buildFeedPageQuery(query: FeedPageQuery = {}): BuiltQuery {
+  const limit = Math.min(Math.max(1, query.limit ?? DEFAULT_LIMIT), MAX_LIMIT);
+  const where: string[] = [scopePredicate(query.scope ?? "inbox")];
+  const params: (string | number | null)[] = [];
+
+  if (query.platform !== undefined) {
+    where.push("platform = ?");
+    params.push(query.platform);
+  }
+  if (query.authorId !== undefined) {
+    where.push("authorId = ?");
+    params.push(query.authorId);
+  }
+
+  if (query.after !== undefined) {
+    const { publishedAt, globalId } = query.after;
+    if (publishedAt === null) {
+      // Already inside the null-dated tail; only globalId can advance.
+      where.push("publishedAt IS NULL AND globalId > ?");
+      params.push(globalId);
+    } else {
+      // Strictly after the cursor in (publishedAt DESC, globalId ASC) order.
+      where.push(
+        "(publishedAt IS NULL OR publishedAt < ? OR (publishedAt = ? AND globalId > ?))",
+      );
+      params.push(publishedAt, publishedAt, globalId);
+    }
+  }
+
+  params.push(limit);
+  return {
+    sql:
+      `SELECT ${SHADOW_COLUMNS.join(", ")} FROM feed_items` +
+      ` WHERE ${where.join(" AND ")}` +
+      ` ORDER BY ${ORDER_BY}` +
+      ` LIMIT ?`,
+    params,
+  };
+}
+
+export interface FeedPage {
+  rows: FeedItemRow[];
+  /** Pass to the next call. Null when the page was not full, meaning the end. */
+  cursor: FeedCursor | null;
+}
+
+export function feedPage(db: ShadowDatabase, query: FeedPageQuery = {}): FeedPage {
+  const limit = Math.min(Math.max(1, query.limit ?? DEFAULT_LIMIT), MAX_LIMIT);
+  const built = buildFeedPageQuery(query);
+  const rows = db
+    .prepare(built.sql)
+    .all(...built.params)
+    .map((record) => record as unknown as FeedItemRow);
+
+  const last = rows[rows.length - 1];
+  return {
+    rows,
+    // A short page means there is nothing after it. Returning a cursor anyway
+    // would make a caller issue one guaranteed-empty query per scroll.
+    cursor:
+      rows.length === limit && last !== undefined
+        ? { publishedAt: last.publishedAt, globalId: last.globalId }
+        : null,
+  };
+}
+
+export interface FeedCounts {
+  total: number;
+  inbox: number;
+  saved: number;
+  archived: number;
+  hidden: number;
+}
+
+/**
+ * The numbers shown beside the feed's filters, in one pass.
+ *
+ * This is the half of Stage 5 the Automerge path cannot do cheaply: producing
+ * these today means walking every hydrated item in the renderer, which is
+ * exactly the work that keeps the corpus resident.
+ */
+export function feedCounts(db: ShadowDatabase): FeedCounts {
+  const [row] = db
+    .prepare(
+      "SELECT count(*) AS total," +
+        " coalesce(sum((hidden IS NOT 1) AND (archived IS NOT 1)), 0) AS inbox," +
+        " coalesce(sum(saved = 1), 0) AS saved," +
+        " coalesce(sum(archived = 1), 0) AS archived," +
+        " coalesce(sum(hidden = 1), 0) AS hidden" +
+        " FROM feed_items",
+    )
+    .all() as unknown as Partial<FeedCounts>[];
+  // Rebuilt rather than returned as-is, for two reasons. node:sqlite hands back
+  // rows created with a null prototype, so passing one out leaks the driver's
+  // object shape to every caller and fails any strict structural comparison.
+  // And the `coalesce` above only covers sum() over no rows returning NULL; the
+  // `?? 0` here covers a driver that omits the key entirely.
+  return {
+    total: row?.total ?? 0,
+    inbox: row?.inbox ?? 0,
+    saved: row?.saved ?? 0,
+    archived: row?.archived ?? 0,
+    hidden: row?.hidden ?? 0,
+  };
+}
+
+/**
+ * Walk every page and return the ids in order. Used to prove the paginated
+ * result equals the single-query result, which is the property keyset
+ * pagination is easy to get subtly wrong about.
+ */
+export function allFeedIdsByPaging(
+  db: ShadowDatabase,
+  query: FeedPageQuery = {},
+  pageSize = 100,
+): string[] {
+  const ids: string[] = [];
+  let cursor: FeedCursor | undefined;
+  for (;;) {
+    const page = feedPage(db, { ...query, limit: pageSize, after: cursor });
+    for (const row of page.rows) ids.push(row.globalId);
+    if (page.cursor === null) break;
+    cursor = page.cursor;
+  }
+  return ids;
+}

--- a/packages/shared/src/shadow-projector.test.ts
+++ b/packages/shared/src/shadow-projector.test.ts
@@ -1,0 +1,230 @@
+import { existsSync, readFileSync } from "node:fs";
+import { DatabaseSync } from "node:sqlite";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  applyItemPatch,
+  driftOf,
+  isDrifted,
+  operationsForPatch,
+  projectAll,
+  reconcile,
+} from "./shadow-projector.js";
+import { createShadowSchema, readAllRows } from "./shadow-store.js";
+import type { ShadowDatabase } from "./shadow-store.js";
+import type { FeedItem } from "./types.js";
+
+function openStore(): ShadowDatabase {
+  const db = new DatabaseSync(":memory:") as unknown as ShadowDatabase;
+  createShadowSchema(db);
+  return db;
+}
+
+function makeItem(globalId: string, overrides: Record<string, unknown> = {}): FeedItem {
+  return {
+    globalId,
+    platform: "x",
+    contentType: "post",
+    publishedAt: 1_780_000_000_000,
+    capturedAt: 1_780_000_001_000,
+    author: { id: "a:1", handle: "someone", displayName: "Someone" },
+    content: { text: "hello", mediaUrls: [], mediaTypes: [] },
+    userState: { hidden: false, saved: false, archived: false, tags: [] },
+    ...overrides,
+  } as unknown as FeedItem;
+}
+
+function docOf(...items: FeedItem[]): { feedItems: Record<string, FeedItem> } {
+  return { feedItems: Object.fromEntries(items.map((item) => [item.globalId, item])) };
+}
+
+describe("shadow projector", () => {
+  it("applies inserts and updates from a patch", () => {
+    const db = openStore();
+    applyItemPatch(db, { patches: [{ item: makeItem("x:1") }, { item: makeItem("x:2") }] });
+    expect(readAllRows(db)).toHaveLength(2);
+
+    applyItemPatch(db, {
+      patches: [
+        {
+          item: makeItem("x:1", {
+            userState: { hidden: false, saved: true, archived: false, tags: [] },
+          }),
+        },
+      ],
+    });
+    const rows = readAllRows(db);
+    expect(rows).toHaveLength(2);
+    expect(rows.find((r) => r.globalId === "x:1")?.saved).toBe(1);
+  });
+
+  it("applies a declared removal", () => {
+    const db = openStore();
+    applyItemPatch(db, { patches: [{ item: makeItem("x:1") }, { item: makeItem("x:2") }] });
+    const result = applyItemPatch(db, {
+      patches: [],
+      changedItemIds: ["x:1"],
+      removedItemIds: ["x:1"],
+    });
+    expect(result.deletes).toStrictEqual(["x:1"]);
+    expect(result.missingRemovals).toStrictEqual([]);
+    expect(readAllRows(db).map((r) => r.globalId)).toStrictEqual(["x:2"]);
+  });
+
+  it("treats an undeclared removal as a deletion and counts it", () => {
+    // The reason this module does not just trust removedItemIds: the field is
+    // OPTIONAL in the worker's ITEM_PATCH type. A delete path that forgets it
+    // would otherwise leave a row behind forever, and under Stage 8 that row
+    // becomes the only copy, so the item would appear to be resurrected.
+    const db = openStore();
+    applyItemPatch(db, { patches: [{ item: makeItem("x:1") }, { item: makeItem("x:2") }] });
+
+    const result = applyItemPatch(db, {
+      patches: [],
+      changedItemIds: ["x:1"],
+      // removedItemIds deliberately absent
+    });
+    expect(result.missingRemovals).toStrictEqual(["x:1"]);
+    expect(result.deletes).toStrictEqual(["x:1"]);
+    expect(readAllRows(db).map((r) => r.globalId)).toStrictEqual(["x:2"]);
+  });
+
+  it("does not mistake a supplied item for a removal", () => {
+    const operations = operationsForPatch({
+      patches: [{ item: makeItem("x:1") }],
+      changedItemIds: ["x:1", "x:2"],
+      removedItemIds: ["x:2"],
+    });
+    expect(operations.upserts.map((r) => r.globalId)).toStrictEqual(["x:1"]);
+    expect(operations.deletes).toStrictEqual(["x:2"]);
+    expect(operations.missingRemovals).toStrictEqual([]);
+  });
+
+  it("reports no drift when the store matches the document", () => {
+    const db = openStore();
+    const doc = docOf(makeItem("x:1"), makeItem("x:2"));
+    projectAll(db, doc as never);
+    const drift = driftOf(db, doc as never);
+    expect(isDrifted(drift)).toBe(false);
+    expect(drift.itemsInDocument).toBe(2);
+    expect(drift.rowsInStore).toBe(2);
+  });
+
+  it("detects each of the three ways the projector can fall behind", () => {
+    const db = openStore();
+    const doc = docOf(makeItem("x:1"), makeItem("x:2"), makeItem("x:3"));
+
+    // Missed insert: x:3 never projected.
+    projectAll(db, docOf(makeItem("x:1"), makeItem("x:2")) as never);
+    // Missed delete: x:9 is in the store but not the document.
+    applyItemPatch(db, { patches: [{ item: makeItem("x:9") }] });
+    // Missed update: x:2 changed in the document after being projected.
+    const changed = makeItem("x:2", {
+      userState: { hidden: true, saved: false, archived: false, tags: [] },
+    });
+    const driftDoc = docOf(makeItem("x:1"), changed, makeItem("x:3"));
+
+    const drift = driftOf(db, driftDoc as never);
+    expect(drift.missingFromStore).toStrictEqual(["x:3"]);
+    expect(drift.staleInStore).toStrictEqual(["x:9"]);
+    expect(drift.divergentRows).toStrictEqual(["x:2"]);
+    expect(isDrifted(drift)).toBe(true);
+    void doc;
+  });
+
+  it("reconcile repairs the store and reports what was wrong before repairing", () => {
+    const db = openStore();
+    projectAll(db, docOf(makeItem("x:1")) as never);
+    applyItemPatch(db, { patches: [{ item: makeItem("x:stale") }] });
+    const target = docOf(
+      makeItem("x:1"),
+      makeItem("x:2"),
+      makeItem("x:3", { platform: "facebook" }),
+    );
+
+    const before = reconcile(db, target as never);
+    // The returned drift describes the state BEFORE repair. A reconcile that
+    // reported a clean result would make the projector look correct exactly
+    // when it was not, which is the failure this whole module exists to avoid.
+    expect(before.missingFromStore.sort()).toStrictEqual(["x:2", "x:3"]);
+    expect(before.staleInStore).toStrictEqual(["x:stale"]);
+
+    const after = driftOf(db, target as never);
+    expect(isDrifted(after)).toBe(false);
+    expect(readAllRows(db).map((r) => r.globalId).sort()).toStrictEqual(["x:1", "x:2", "x:3"]);
+  });
+
+  it("reconcile is a no-op on an already-correct store", () => {
+    const db = openStore();
+    const doc = docOf(makeItem("x:1"), makeItem("x:2"));
+    projectAll(db, doc as never);
+    const drift = reconcile(db, doc as never);
+    expect(isDrifted(drift)).toBe(false);
+    expect(readAllRows(db)).toHaveLength(2);
+  });
+
+  it("survives replaying the same patch twice", () => {
+    // At-least-once delivery is the realistic assumption for a worker message
+    // that may be re-sent after a reconnect or a reconcile that races a patch.
+    const db = openStore();
+    const event = { patches: [{ item: makeItem("x:1") }] };
+    applyItemPatch(db, event);
+    applyItemPatch(db, event);
+    expect(readAllRows(db)).toHaveLength(1);
+  });
+
+  it("survives deleting an id that is not in the store", () => {
+    const db = openStore();
+    projectAll(db, docOf(makeItem("x:1")) as never);
+    expect(() =>
+      applyItemPatch(db, { patches: [], changedItemIds: ["x:gone"], removedItemIds: ["x:gone"] }),
+    ).not.toThrow();
+    expect(readAllRows(db)).toHaveLength(1);
+  });
+});
+
+const fixture = process.env.FREED_CORPUS_FIXTURE;
+const hasFixture = fixture !== undefined && fixture !== "" && existsSync(fixture);
+
+describe.skipIf(!hasFixture)("shadow projector against a real corpus", () => {
+  it("converges on the real document and reports zero drift", async () => {
+    const automerge = await import("@automerge/automerge");
+    const doc = automerge.load(new Uint8Array(readFileSync(fixture as string)));
+    const db = openStore();
+
+    const projected = projectAll(db, doc as never);
+    expect(projected).toBeGreaterThan(0);
+
+    const drift = driftOf(db, doc as never);
+    if (isDrifted(drift)) {
+      throw new Error(
+        `drift after projecting ${projected} items: ` +
+          `${drift.missingFromStore.length} missing, ` +
+          `${drift.staleInStore.length} stale, ` +
+          `${drift.divergentRows.length} divergent`,
+      );
+    }
+    expect(drift.rowsInStore).toBe(projected);
+  }, 300_000);
+
+  it("detects a single tampered row in the real corpus", async () => {
+    // A drift detector that cannot fail on 15,846 rows proves nothing. Corrupt
+    // exactly one row and confirm it is found.
+    const automerge = await import("@automerge/automerge");
+    const doc = automerge.load(new Uint8Array(readFileSync(fixture as string)));
+    const db = openStore();
+    projectAll(db, doc as never);
+
+    const [victim] = readAllRows(db);
+    db.prepare("UPDATE feed_items SET authorDisplayName = ? WHERE globalId = ?").run(
+      "tampered",
+      victim!.globalId,
+    );
+
+    const drift = driftOf(db, doc as never);
+    expect(drift.divergentRows).toStrictEqual([victim!.globalId]);
+    expect(drift.missingFromStore).toHaveLength(0);
+    expect(drift.staleInStore).toHaveLength(0);
+  }, 300_000);
+});

--- a/packages/shared/src/shadow-projector.ts
+++ b/packages/shared/src/shadow-projector.ts
@@ -1,0 +1,192 @@
+/**
+ * Keeps the shadow store in step with the Automerge document.
+ *
+ * Stage 4 built the projection and proved it lossless, and Stage 4b proved the
+ * round trip survives a real database. Neither of them writes anything at
+ * runtime. This is the part that does, and it is where the interesting failure
+ * lives, because a projector is only useful if it cannot silently fall behind.
+ *
+ * It can fall behind for three reasons, and all three are properties of the
+ * existing worker protocol rather than hypotheticals:
+ *
+ * 1. `ITEM_PATCH.removedItemIds` is declared optional. A delete path that does
+ *    not populate it leaves a row in the store for an item that no longer
+ *    exists in the document.
+ * 2. `ITEM_PATCH` is not the only message that changes the document.
+ *    `STATE_UPDATE` replaces state wholesale, and a projector that only follows
+ *    patches never sees it.
+ * 3. The process restarts. Patches that arrived while it was not running were
+ *    not applied to anything.
+ *
+ * So incremental application alone is not a design, it is half of one. The
+ * other half is `reconcile`, which compares the store against the document and
+ * repairs the difference, and `driftOf`, which reports the difference without
+ * repairing it so drift can be measured before Stage 8 depends on its absence.
+ *
+ * Stage 8 makes the write path one-way. After that, an item the projector
+ * missed is not recoverable from anywhere, which is the whole reason this
+ * module reports drift as a first-class result instead of quietly fixing it.
+ */
+
+import { projectFeedItem } from "./projection.js";
+import { SHADOW_DELETE_SQL, readAllRows, upsertRows } from "./shadow-store.js";
+import type { ShadowDatabase } from "./shadow-store.js";
+import type { FeedItemRow } from "./projection.js";
+import type { FreedDoc } from "./schema.js";
+import type { FeedItem } from "./types.js";
+
+/** The subset of a worker ITEM_PATCH this module needs. */
+export interface ItemPatchEvent {
+  /** Items that still exist, already cloned by the worker. */
+  patches: readonly { readonly item: FeedItem }[];
+  /** Every id the mutation touched, including ones that were deleted. */
+  changedItemIds?: readonly string[];
+  /** Ids the mutation removed. Optional in the worker protocol, hence `missingRemovals`. */
+  removedItemIds?: readonly string[];
+}
+
+export interface RowOperations {
+  upserts: FeedItemRow[];
+  deletes: string[];
+  /**
+   * Ids the mutation reported as changed but did not supply an item for, and
+   * did not list as removed either. Under the current protocol that means a
+   * deletion the sender did not declare. They are treated as deletions, and
+   * counted, because a projector that guesses silently is how drift starts.
+   */
+  missingRemovals: string[];
+}
+
+/**
+ * Turn one patch event into row operations. Pure, so the interesting decision
+ * (what to do about an undeclared removal) is visible in a test rather than
+ * buried in an event handler.
+ */
+export function operationsForPatch(event: ItemPatchEvent): RowOperations {
+  const upserts = event.patches.map((patch) => projectFeedItem(patch.item));
+  const supplied = new Set(upserts.map((row) => row.globalId));
+  const declaredRemovals = event.removedItemIds ?? [];
+  const deletes = [...declaredRemovals];
+
+  // An id that changed, produced no item, and was not declared removed. The
+  // worker filters `patches` to items that still exist, so this is what a
+  // delete looks like when `removedItemIds` was not populated.
+  const declared = new Set(declaredRemovals);
+  const missingRemovals: string[] = [];
+  for (const id of event.changedItemIds ?? []) {
+    if (supplied.has(id) || declared.has(id)) continue;
+    missingRemovals.push(id);
+    deletes.push(id);
+  }
+
+  return { upserts, deletes, missingRemovals };
+}
+
+export function applyOperations(db: ShadowDatabase, operations: RowOperations): void {
+  if (operations.upserts.length > 0) upsertRows(db, operations.upserts);
+  if (operations.deletes.length > 0) {
+    const statement = db.prepare(SHADOW_DELETE_SQL);
+    for (const globalId of operations.deletes) statement.run(globalId);
+  }
+}
+
+/** Apply one worker patch event to the store. Returns what it did. */
+export function applyItemPatch(db: ShadowDatabase, event: ItemPatchEvent): RowOperations {
+  const operations = operationsForPatch(event);
+  applyOperations(db, operations);
+  return operations;
+}
+
+export interface ProjectionDrift {
+  /** In the document, absent from the store. The projector missed an insert. */
+  missingFromStore: string[];
+  /** In the store, absent from the document. The projector missed a delete. */
+  staleInStore: string[];
+  /** Present in both, but the projected row differs. The projector missed an update. */
+  divergentRows: string[];
+  itemsInDocument: number;
+  rowsInStore: number;
+}
+
+export function isDrifted(drift: ProjectionDrift): boolean {
+  return (
+    drift.missingFromStore.length > 0 ||
+    drift.staleInStore.length > 0 ||
+    drift.divergentRows.length > 0
+  );
+}
+
+/**
+ * Compare the store against the document without changing either.
+ *
+ * Reported rather than repaired on purpose. Before Stage 8 the document is
+ * still the source of truth, so drift is a bug to be found and fixed at its
+ * cause. A projector that silently self-heals would hide exactly the defect
+ * that has to be gone before the write path becomes one-way.
+ */
+export function driftOf(db: ShadowDatabase, doc: FreedDoc): ProjectionDrift {
+  const items = (doc.feedItems ?? {}) as Record<string, FeedItem>;
+  const stored = new Map<string, FeedItemRow>();
+  for (const row of readAllRows(db)) stored.set(row.globalId, row);
+
+  const missingFromStore: string[] = [];
+  const divergentRows: string[] = [];
+  for (const [globalId, item] of Object.entries(items)) {
+    const row = stored.get(globalId);
+    if (row === undefined) {
+      missingFromStore.push(globalId);
+      continue;
+    }
+    const expected = projectFeedItem(item);
+    for (const key of Object.keys(expected) as (keyof FeedItemRow)[]) {
+      if (!Object.is(expected[key], row[key])) {
+        divergentRows.push(globalId);
+        break;
+      }
+    }
+  }
+
+  const staleInStore: string[] = [];
+  for (const globalId of stored.keys()) {
+    if (!Object.prototype.hasOwnProperty.call(items, globalId)) {
+      staleInStore.push(globalId);
+    }
+  }
+
+  return {
+    missingFromStore,
+    staleInStore,
+    divergentRows,
+    itemsInDocument: Object.keys(items).length,
+    rowsInStore: stored.size,
+  };
+}
+
+/**
+ * Bring the store into agreement with the document and report what was wrong.
+ *
+ * Used at startup and after any message that replaces state wholesale. The
+ * returned drift describes the state BEFORE the repair, so a caller can log or
+ * alarm on it. Repairing without reporting would make the projector look
+ * correct precisely when it is not.
+ */
+export function reconcile(db: ShadowDatabase, doc: FreedDoc): ProjectionDrift {
+  const drift = driftOf(db, doc);
+  if (!isDrifted(drift)) return drift;
+
+  const items = (doc.feedItems ?? {}) as Record<string, FeedItem>;
+  const upserts: FeedItemRow[] = [];
+  for (const globalId of [...drift.missingFromStore, ...drift.divergentRows]) {
+    const item = items[globalId];
+    if (item !== undefined) upserts.push(projectFeedItem(item));
+  }
+  applyOperations(db, { upserts, deletes: drift.staleInStore, missingRemovals: [] });
+  return drift;
+}
+
+/** Project an entire document into an empty store. Startup, and the Stage 4b tests. */
+export function projectAll(db: ShadowDatabase, doc: FreedDoc): number {
+  const items = Object.values((doc.feedItems ?? {}) as Record<string, FeedItem>);
+  upsertRows(db, items.map((item) => projectFeedItem(item)));
+  return items.length;
+}

--- a/packages/shared/src/shadow-store-schema-parity.test.ts
+++ b/packages/shared/src/shadow-store-schema-parity.test.ts
@@ -1,0 +1,96 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { SHADOW_COLUMNS, SHADOW_TABLE_DDL } from "./shadow-store.js";
+
+/**
+ * The shadow store schema exists twice: once in TypeScript, once in Rust at
+ * packages/desktop/src-tauri/src/shadow_store.rs. Two copies of a schema drift.
+ *
+ * That is normally an annoyance. Here it is a data-loss bug waiting to happen,
+ * because Stage 8 makes the write path one-way: after the retained Automerge
+ * copy is pruned, a column the Rust side never wrote is not recoverable from
+ * anywhere. A comment asking the next person to keep them in sync would not
+ * survive contact with a hurried change, so this reads the Rust file and fails
+ * instead.
+ */
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const RUST_SOURCE = path.resolve(
+  HERE,
+  "../../desktop/src-tauri/src/shadow_store.rs",
+);
+
+function rustSource(): string {
+  return readFileSync(RUST_SOURCE, "utf8");
+}
+
+/** Pull the string literals out of the `COLUMNS` slice. */
+function rustColumns(source: string): string[] {
+  const match = source.match(/pub const COLUMNS: &\[&str\] = &\[([\s\S]*?)\];/);
+  if (match === null) throw new Error("COLUMNS not found in shadow_store.rs");
+  return [...match[1]!.matchAll(/"([^"]+)"/g)].map((entry) => entry[1]!);
+}
+
+/** Pull the column names out of the Rust CREATE TABLE body. */
+function rustTableColumns(source: string): string[] {
+  const match = source.match(
+    /CREATE TABLE IF NOT EXISTS feed_items \(([\s\S]*?)\) STRICT;/,
+  );
+  if (match === null) throw new Error("CREATE TABLE not found in shadow_store.rs");
+  return match[1]!
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .map((line) => line.split(/\s+/)[0]!)
+    .filter((name) => /^[A-Za-z]/.test(name));
+}
+
+function tsTableColumns(): string[] {
+  const match = SHADOW_TABLE_DDL.match(
+    /CREATE TABLE IF NOT EXISTS feed_items \(([\s\S]*?)\) STRICT;/,
+  );
+  if (match === null) throw new Error("CREATE TABLE not found in SHADOW_TABLE_DDL");
+  return match[1]!
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .map((line) => line.split(/\s+/)[0]!)
+    .filter((name) => /^[A-Za-z]/.test(name));
+}
+
+describe("shadow store schema parity across the IPC boundary", () => {
+  it("declares the same columns, in the same order, on both sides", () => {
+    // Order matters as much as membership: both sides generate their INSERT
+    // from this list positionally, so a reordering binds every value to the
+    // wrong column and still executes without error.
+    expect(rustColumns(rustSource())).toStrictEqual([...SHADOW_COLUMNS]);
+  });
+
+  it("keeps each side's CREATE TABLE consistent with its own column list", () => {
+    expect(rustTableColumns(rustSource()).sort()).toStrictEqual(
+      [...SHADOW_COLUMNS].sort(),
+    );
+    expect(tsTableColumns().sort()).toStrictEqual([...SHADOW_COLUMNS].sort());
+  });
+
+  it("keeps the table STRICT on both sides", () => {
+    // STRICT is what turns a lossy affinity coercion into an error at the
+    // write. Losing it on one side only would mean the two engines silently
+    // disagree about what was stored.
+    expect(SHADOW_TABLE_DDL).toContain(") STRICT");
+    expect(rustSource()).toContain(") STRICT");
+  });
+
+  it("binds every column on the Rust side", () => {
+    // The Rust bind() builds a positional vector by hand. A column added to
+    // COLUMNS but missed there shifts every later value by one and still
+    // executes. Rust has its own test for the count; this asserts the guard
+    // exists at all, so deleting it fails here too.
+    expect(rustSource()).toContain("fn binds_every_declared_column");
+    expect(rustSource()).toContain("COLUMNS.len()");
+  });
+});


### PR DESCRIPTION
(AI Generated).

Stage 5 of [the storage roadmap](docs/STORAGE-ARCHITECTURE-ROADMAP.md). **Stacked on #1151** — based against `feat/shadow-projector`, so this diff shows only the feed query. Retargets to `dev` once #1151 merges.

Draft until then.

## Ordering is a plain timestamp, and that is close to a no-op

The owner's decision (#1152) is that ranking is time-based for now, with the classification system carrying filtering. That turns out to be barely a change. The worker builds the feed as:

```js
sortByPriority(rankFeedItems(visibleItems.sort((a, b) => b.publishedAt - a.publishedAt), ...))
```

Items are sorted newest-first and then handed to a **stable** sort by priority. Measured on the real corpus, that priority sort does almost nothing: 15,846 items collapse into 63 distinct values, 8,759 of them share the single value 17, and every item is tied with at least one other. The stored weights are empty except recency, and 93.8% of the corpus is past the 168-hour horizon where recency is zero by design.

So priority is a coarse recency bucket, and the stable sort preserves the newest-first pre-sort inside each one. Ordering by `publishedAt` directly only dissolves those buckets, making the order strictly rather than approximately chronological.

## Keyset pagination, not OFFSET

`OFFSET` makes the engine walk and discard every skipped row, so page N costs O(N × pageSize) and gets slower the further the reader scrolls. It is also wrong under concurrent writes: an item inserted above the current position shifts every later page by one, duplicating one item and hiding another.

The tiebreak is load-bearing rather than cosmetic. Today's ties fall through to JS stable-sort order; SQLite defines nothing for ties, and an unreproducible page boundary is exactly what makes keyset pagination drop or repeat rows. Since every item in this corpus is tied, that is the common case, not an edge case.

## Two bugs the corpus test caught that synthetic cases did not

**Collation.** The tiebreak uses SQLite's BINARY collation, which orders by byte value. My test compared with `localeCompare`, which is locale-aware and puts lowercase first where BINARY puts uppercase first — and the corpus contains Facebook ids differing *only* in that case. The test was wrong, not the query: making SQL match `localeCompare` would need a custom collation registered on every connection. Both the module and the test now say so, because a future reimplementation in JS would reach for `localeCompare` and pass every synthetic test while producing a different order on real data.

**Null prototype.** `feedCounts` returned the driver's row object directly, and `node:sqlite` builds rows with `Object.create(null)`. That leaks the driver's shape to every caller and fails any strict structural comparison. Rebuilt explicitly.

## Evidence

Measured on the owner's real 15,846-item document:

| | |
| --- | --- |
| first page (50 rows) | **7 ms** |
| next 20 pages (1,000 rows) | 168 ms |
| counts over the full corpus | **7 ms** |

```
11 feed-query tests, 115 passed in packages/shared, tsc --noEmit clean
```

The corpus tests compare against a straight chronological sort of **the items themselves**, not against another SQL query, so it cannot pass by both sides sharing a bug. Pagination is checked by walking every page and asserting it equals the single-query result, including the case where every item shares a timestamp — which is what breaks a cursor built on the timestamp alone.

## Nothing reads this yet

No surface is switched over. Wiring it up is the first behavioral change in this series and belongs in its own PR, behind a flag.

## Provider surface

None. `packages/shared` only; no file in this diff is provider-visible.