### PR TITLE
docs: describe sync by what it does, not what it is built from (marketing site + privacy policy)

### DIFF
--- a/website/src/app/privacy/PrivacyContent.tsx
+++ b/website/src/app/privacy/PrivacyContent.tsx
@@ -95,8 +95,8 @@ export default function PrivacyContent() {
                     Your feed data stays on your device.
                   </strong>
                   Posts captured from X, RSS, YouTube, or any other source are
-                  written to local storage: IndexedDB in the browser, the
-                  filesystem in the desktop app. None of this ever touches our
+                  written to storage on your own device, in the browser or in
+                  the desktop app itself. None of this ever touches our
                   infrastructure, because we have no infrastructure to touch.
                 </li>
                 <li>
@@ -158,7 +158,8 @@ export default function PrivacyContent() {
               <p>
                 Desktop provider warnings for X, Facebook, Instagram, and
                 LinkedIn are also stored locally on that device. These records
-                are not synced through Automerge and are not transmitted to us.
+                stay on that device, are not synced to your other devices, and
+                are not transmitted to us.
               </p>
             </section>
 

--- a/website/src/components/Features.tsx
+++ b/website/src/components/Features.tsx
@@ -204,7 +204,7 @@ const features = [
     icon: <SyncIcon />,
     title: "Cross-Device Sync",
     description:
-      "CRDT-powered sync across all your devices. No cloud required. Peer-to-peer when you want it.",
+      "Every device stays in step, automatically. No account, no server, no cloud required.",
   },
   {
     icon: <OpenSourceIcon />,


### PR DESCRIPTION
(AI Generated).

Copy-only. **For manual review before merge**, as requested. No behavior, no logic, no dependencies.

## Why now

Public copy named the sync library. That is arcane for the audience, and more practically it is about to be false: the storage work under way replaces the CRDT with a paged store. Left alone, the marketing site and the privacy policy would assert something the product no longer does.

## The changes, in full

**`website/src/components/Features.tsx`** — the Cross-Device Sync card

> ~~CRDT-powered sync across all your devices. No cloud required. Peer-to-peer when you want it.~~
> **Every device stays in step, automatically. No account, no server, no cloud required.**

Same promise, stated as an outcome. "No account, no server" is a stronger and more concrete claim to a reader than "CRDT-powered" ever was.

**`website/src/app/privacy/PrivacyContent.tsx`** — two edits

> ~~These records are not synced through Automerge and are not transmitted to us.~~
> **These records stay on that device, are not synced to your other devices, and are not transmitted to us.**

> ~~written to local storage: IndexedDB in the browser, the filesystem in the desktop app~~
> **written to storage on your own device, in the browser or in the desktop app itself**

Naming an implementation inside a privacy policy is the worse of the two problems. A reader wants to know whether their data leaves the device, not which library moves it — and a policy phrased around a library becomes inaccurate the moment the library changes. Both edits now state the property directly, which is what those sentences were always trying to say.

Please read these two with a legal eye rather than an engineering one. I believe they are strictly clearer and strictly more durable, but they are the privacy policy.

## Deliberately not touched

**`changelog.generated.json`**, which mentions the library **77 times.** It is generated by `website/scripts/generate-changelog.ts` from release notes, and it is a historical record of what actually shipped. Editing it would be overwritten on the next regeneration, and rewriting past entries to match present vocabulary would falsify the record. If you want the vocabulary to change going forward, the place to do that is the release-note source, not the generated artifact.

**Engineering documentation and source.** Naming the library there is accurate and load-bearing — `docs/STORAGE-ARCHITECTURE-ROADMAP.md` in particular has to name it in order to describe migrating off it.

## Detail

The apostrophe is left raw rather than escaped, matching the six already in that file; my first draft used `&rsquo;` and broke the file's own convention.

Typecheck clean. The regenerated `tsconfig.tsbuildinfo` was kept out of the commit.

## Companion PR

The README on `dev` had the same problem in four places, including as a headline feature. That is a separate base branch so it is a separate PR: **#1159**.