### PR TITLE
docs: describe sync in the README by what it does, not what it is built from

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Capture your social/rss/newsletter feeds locally. Tune the ranking algo yourself
 - 🌊 **Unified feed** — X, RSS, YouTube, newsletters, podcasts in one timeline
 - ⚖️ **Your ranking** — Weight by recency, author, topic, custom semantics. Not engagement
 - 🔒 **Local-first** — All data on your device, we can't see it
-- 🔄 **Cross-device sync** — Automerge CRDT via local relay and cloud backup
+- 🔄 **Cross-device sync** — Your devices stay in step directly, with your own cloud storage as backup
 - 📌 **Save for later** — Capture any URL with reader view
 - ⚓ **Ulysses mode** — Block platform feeds, stay intentional
 - 📍 **Friend map** — See where your people are posting from
@@ -34,7 +34,7 @@ Capture your social/rss/newsletter feeds locally. Tune the ranking algo yourself
 ```
   Capture Layers              Sync                    Clients
  ─────────────────      ─────────────────      ─────────────────
-  X, RSS, Facebook,  →   Automerge CRDT   →    Desktop App
+  X, RSS, Facebook,  →   Sync + Storage   →    Desktop App
   Instagram, etc.        Local + Cloud          Phone PWA
                                                 Extension
 ```
@@ -62,7 +62,7 @@ Capture your social/rss/newsletter feeds locally. Tune the ranking algo yourself
 
 ### [Phase 1: Foundation](docs/PHASE-1-FOUNDATION.md) ✓
 
-Marketing site, monorepo, Automerge schema, CI/CD.
+Marketing site, monorepo, sync schema, CI/CD.
 
 ### [Phase 2: Capture Skills](docs/PHASE-2-CAPTURE-SKILLS.md) ✓
 
@@ -118,7 +118,7 @@ Compose and publish through your own site.
 
 1. **Desktop App as hub** — Capture + sync + UI in one installable package
 2. **Zero external infrastructure** — Local relay + user's cloud storage (GDrive, Dropbox, iCloud)
-3. **Automerge CRDT** — Conflict-free multi-device sync
+3. **Local-first sync** — Devices reconcile without a server; your cloud storage is backup, not the source of truth
 4. **Shared React codebase** — `packages/pwa/` embedded in Desktop AND deployed standalone
 5. **TypeScript capture via subprocess** — Capture packages run as TypeScript, not compiled into Tauri's Rust core. Easier to extend, easier to debug.
 6. **Ranking on core, display on edge** — Desktop/OpenClaw computes `priority`, PWA just displays
@@ -222,7 +222,7 @@ npm run typecheck  # Type-check all packages
 }
 ```
 
-**Subscriptions & preferences** sync via Automerge document.
+**Subscriptions & preferences** sync across your devices.
 
 ---
 


### PR DESCRIPTION
(AI Generated).

Copy-only, README only. **For manual review before merge**, as requested. Companion to #1158, which covers the marketing site and privacy policy on the `www` branch.

## Why

The README named the CRDT library in four places, including as a headline feature and as key decision 3. The storage work under way replaces it with a paged store, so every one of those lines is about to be false.

## The changes

| where | from | to |
| --- | --- | --- |
| Features list | Automerge CRDT via local relay and cloud backup | Your devices stay in step directly, with your own cloud storage as backup |
| Architecture diagram | `Automerge CRDT` | `Sync + Storage` |
| Key decision 3 | **Automerge CRDT** — Conflict-free multi-device sync | **Local-first sync** — Devices reconcile without a server; your cloud storage is backup, not the source of truth |
| Data model | sync via Automerge document | sync across your devices |
| Phase 1 record | Automerge schema | sync schema |

Each states the property a reader can rely on rather than the mechanism that happens to deliver it this quarter. Key decision 3 is the one that improves most: "conflict-free multi-device sync" described the library's category, while "cloud storage is backup, not the source of truth" is the decision that was actually made and the one that constrains everything downstream.

## Two details worth checking

**The ASCII diagram still aligns.** `Sync + Storage` and `Automerge CRDT` are both 14 characters, so the columns are unchanged. Worth a glance in the rendered diff anyway.

**Phase 1's line is a historical record**, not a claim about the present. Phase 1 genuinely did build the Automerge schema. Rather than erase that, it is restated at a durable level of abstraction — "sync schema" — which was equally true then and stays true after the migration. Say the word if you would rather completed-phase records keep their original vocabulary; that is a defensible position and easy to revert.

## Not touched

Engineering documentation and source. Naming the library there is accurate and load-bearing, and `docs/STORAGE-ARCHITECTURE-ROADMAP.md` has to name it in order to describe migrating off it.

## Provider surface

None.