### PR TITLE
fix(desktop): move off the fully yanked rquest crate to wreq

### DIFF
--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -1515,8 +1515,6 @@ dependencies = [
  "objc2-web-kit",
  "rand 0.10.2",
  "reqwest",
- "rquest",
- "rquest-util",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -1538,6 +1536,8 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "window-vibrancy 0.8.0",
+ "wreq",
+ "wreq-util",
 ]
 
 [[package]]
@@ -4245,58 +4245,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "rquest"
-version = "5.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "821ab2b3866cc43b553364566edf7387aea98b28b87213d8a889fc2504b3b8b0"
-dependencies = [
- "antidote",
- "arc-swap",
- "async-compression",
- "base64 0.22.1",
- "boring2",
- "bytes",
- "encoding_rs",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "hyper2",
- "ipnet",
- "linked_hash_set",
- "log",
- "lru",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "socket2 0.5.10",
- "sync_wrapper",
- "system-configuration",
- "tokio",
- "tokio-boring2",
- "tokio-util",
- "tower",
- "tower-service",
- "typed-builder",
- "url",
- "webpki-root-certs 0.26.11",
- "windows-registry",
-]
-
-[[package]]
-name = "rquest-util"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e3762f6e3e0d1674a6e74ebcbcb3b8d56c895757fc2cc2aa0d5e62ccfcb21e"
-dependencies = [
- "rquest",
- "typed-builder",
 ]
 
 [[package]]
@@ -7130,6 +7078,58 @@ dependencies = [
  "wayland-client",
  "wayland-protocols",
  "wayland-protocols-wlr",
+]
+
+[[package]]
+name = "wreq"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "137ed11c4c418fb3dc41db7323ebc49aa9b6fe6a24ce152e6b2de9d6fadd9c8f"
+dependencies = [
+ "antidote",
+ "arc-swap",
+ "async-compression",
+ "base64 0.22.1",
+ "boring2",
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper2",
+ "ipnet",
+ "linked_hash_set",
+ "log",
+ "lru",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "socket2 0.5.10",
+ "sync_wrapper",
+ "system-configuration",
+ "tokio",
+ "tokio-boring2",
+ "tokio-util",
+ "tower",
+ "tower-service",
+ "typed-builder",
+ "url",
+ "webpki-root-certs 0.26.11",
+ "windows-registry",
+]
+
+[[package]]
+name = "wreq-util"
+version = "2.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b28b3585973a8923c32c2f916e60b7b0d1cb4dd53e8cb2d7422c0ac001ef2487"
+dependencies = [
+ "typed-builder",
+ "wreq",
 ]
 
 [[package]]

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -26,10 +26,14 @@ log = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 window-vibrancy = "0.8"
-# default-features = false drops native-tls (OpenSSL) which conflicts with rquest's BoringSSL on Linux.
+# default-features = false drops native-tls (OpenSSL) which conflicts with wreq's BoringSSL on Linux.
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
-rquest = { version = "5", features = ["json"] }
-rquest-util = "2"
+# wreq is rquest renamed. The author renamed the crate and yanked every rquest
+# release, all 152 of them, so `rquest = "5"` no longer resolves at all and any
+# fresh dependency resolution fails outright. Version numbering carried straight
+# over: rquest 5.1.0 is wreq 5.1.0, and 5.3.0 continues that line.
+wreq = { version = "5.3", features = ["json"] }
+wreq-util = "2.2"
 tokio = { version = "1", features = ["full"] }
 tokio-tungstenite = "0.30"
 futures-util = "0.3"

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -3365,7 +3365,7 @@ impl BackgroundRuntimeCoordinator {
 // ---------------------------------------------------------------------------
 
 /// Per-session user agent strings set by TypeScript at platform connect time,
-/// plus a shared rquest HTTP client with persistent connection pooling.
+/// plus a shared wreq HTTP client with persistent connection pooling.
 struct CaptureState {
     fb_user_agent: std::sync::Mutex<String>,
     ig_user_agent: std::sync::Mutex<String>,
@@ -3374,18 +3374,18 @@ struct CaptureState {
     medium_user_agent: std::sync::Mutex<String>,
     scraper_session: Arc<tokio::sync::Mutex<()>>,
     background_runtime: Arc<BackgroundRuntimeCoordinator>,
-    x_client: rquest::Client,
+    x_client: wreq::Client,
 }
 
 impl CaptureState {
     fn new() -> Self {
-        // rquest 5.x uses rquest_util::Emulation for Chrome TLS fingerprinting.
-        let x_client = rquest::Client::builder()
-            .emulation(rquest_util::Emulation::Chrome131)
+        // wreq 5.x uses wreq_util::Emulation for Chrome TLS fingerprinting.
+        let x_client = wreq::Client::builder()
+            .emulation(wreq_util::Emulation::Chrome131)
             .no_proxy()
             .timeout(std::time::Duration::from_secs(30))
             .build()
-            .expect("Failed to build rquest client");
+            .expect("Failed to build wreq client");
 
         Self {
             fb_user_agent: std::sync::Mutex::new(String::new()),
@@ -5503,7 +5503,7 @@ async fn x_api_request(
     headers: Vec<(String, String)>,
     method: Option<String>,
 ) -> Result<String, String> {
-    // Use the shared rquest client (Chrome TLS fingerprint, persistent connection pool).
+    // Use the shared wreq client (Chrome TLS fingerprint, persistent connection pool).
     let client = &capture.x_client;
 
     let req_builder = if method.as_deref() == Some("GET") {


### PR DESCRIPTION
(AI Generated).

Stacked on #1153 because both touch `Cargo.toml` and `Cargo.lock`. GitHub will retarget this to `dev` automatically when that merges. Review only the top commit.

### The problem

**Every published version of `rquest` is yanked from crates.io. All 152, including the 5.1.0 this repo pins.**

The desktop app still builds, because `Cargo.lock` pins the version and cargo will happily fetch a locked yanked crate. That is what hid this. What it did not hide is that the manifest became immovable: any command that re-resolves dependencies fails outright.

```
error: failed to select a version for the requirement `rquest = "^5"`
  version 5.0.0 is yanked
  version 5.1.0 is yanked
  version 5.2.0 is yanked
```

That is why `cargo update` could not be run at all, and why the cargo work earlier today had to route around full resolution.

### It is a rename, not an abandonment

Worth saying plainly, because "your HTTP client was withdrawn from the registry" reads worse than it is:

- `github.com/0x676e67/rquest` **redirects to** `0x676e67/wreq`. Same repository, renamed, not archived, 943 stars, last pushed 2026-07-20.
- The version line carried straight over. rquest ended at 5.2.0; wreq publishes 5.1.0, 5.2.0, 5.3.0.
- `rquest-util` continues as `wreq-util` from the same 2.2.1.

The author renamed and yanked the old name to force migration. Blunt, but not sinister.

### What this takes

`wreq` **5.3.0** and `wreq-util` **2.2.6**, the newest stable of each, rather than the `6.0.0-rc` line the README advertises. This is the TLS-fingerprinting client in the X capture path on a shipping desktop app, so a release candidate is the wrong default.

The API is unchanged: `Client::builder().emulation(wreq_util::Emulation::Chrome131)`. Confirmed `Emulation::Chrome131` exists in wreq-util 2.2.6 and the `json` feature exists in wreq 5.3.0 (it lives in the index's `features2` because of the `dep:` syntax, which is why a first look appeared to show it missing). `wreq-util` 2.2.6 declares `wreq >=3.0.5, <6`, so 5.3.0 is in range. BoringSSL is still in the graph, so the `default-features = false` note on `reqwest` still applies.

Source change is 7 references in one file.

### Verification

Ran a full `cargo update`, which **now completes** where it previously failed outright. That is the direct proof the resolution deadlock is gone. Then restored the lockfile so this commit carries only the crate swap: the lock diff is exactly two crates out, two in, no other version movement.

`cargo test --all-features`: 159 passed, 0 failed. `cargo clippy --all-targets`: 0 errors, no new warnings.

### Worth knowing

Dependabot never told you about this. A yanked-but-locked crate raises no advisory and no update PR, so the only signal was a resolution failure nobody hit while the lock stayed untouched. Being pinned to a name that no longer exists in the registry is a real supply chain position: no publisher, no security backstop, and a lockfile that cannot be regenerated from scratch.