### PR TITLE
fix(ci): stop reporting a cancelled tooling smoke run as a failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,13 +138,25 @@ jobs:
         run: |
           # A cancelled dependency can still reach here when individual jobs were
           # cancelled without the whole run being cancelled. Name it for what it
-          # is. "result was cancelled" alongside a pile of green shards is the
-          # single most misread signal in this lane, and it is not a test failure
-          # anyone can fix by changing code.
+          # is: "result was cancelled" next to a pile of green shards is the most
+          # misread signal in this lane, and no diff change fixes it.
+          #
+          # Two different things produce it, and they want opposite responses, so
+          # do not guess between them here. A superseded run just needs running
+          # again. A shard killed by timeout-minutes also reports cancelled, and
+          # re-running that only burns the same ninety minutes a second time; it
+          # needs more shards or a longer budget. Point at both.
           if [ "$PLAN_RESULT" = "cancelled" ] || [ "$SHARD_RESULT" = "cancelled" ]; then
             echo "Tooling smoke was cancelled, not failed. No verdict was produced."
             echo "  planner: $PLAN_RESULT, shards: $SHARD_RESULT"
-            echo "Re-run the workflow. Nothing in the diff needs changing for this."
+            echo ""
+            echo "Check the shard durations before re-running:"
+            echo "  - Any shard sitting at exactly the job timeout was killed, not"
+            echo "    cancelled by a newer run. Re-running reproduces it. That suite"
+            echo "    needs more shards, which means fixing its entry in"
+            echo "    scripts/tooling-smoke-durations.json or raising the job budget."
+            echo "  - Otherwise a newer run superseded this one and re-running is"
+            echo "    the whole fix. Nothing in the diff needs changing."
             exit 1
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,9 +114,16 @@ jobs:
   # when a scheduled shard fails, and when shards are missing while the planner
   # said they were required. A not-applicable plan is the only path to a green
   # gate without shard execution.
+  #
+  # !cancelled() rather than always(), because always() also runs during a
+  # cancelled run. That is what made a superseded or manually cancelled run
+  # report a hard red gate while every shard it managed to finish had passed:
+  # cancellation is the absence of a verdict, not a failing one, and reporting
+  # it as failure taught everyone to read a red gate as noise. A cancelled run
+  # now skips the gate instead, which leaves no verdict rather than a wrong one.
   tooling-smoke:
     name: Tooling smoke
-    if: ${{ always() }}
+    if: ${{ !cancelled() }}
     needs: [tooling-smoke-plan, tooling-smoke-shards, native-acceptance]
     runs-on: ubuntu-latest
     steps:
@@ -129,6 +136,18 @@ jobs:
           NATIVE_REQUIRED: ${{ needs.tooling-smoke-plan.outputs.native }}
           JOB_COUNT: ${{ needs.tooling-smoke-plan.outputs.job-count }}
         run: |
+          # A cancelled dependency can still reach here when individual jobs were
+          # cancelled without the whole run being cancelled. Name it for what it
+          # is. "result was cancelled" alongside a pile of green shards is the
+          # single most misread signal in this lane, and it is not a test failure
+          # anyone can fix by changing code.
+          if [ "$PLAN_RESULT" = "cancelled" ] || [ "$SHARD_RESULT" = "cancelled" ]; then
+            echo "Tooling smoke was cancelled, not failed. No verdict was produced."
+            echo "  planner: $PLAN_RESULT, shards: $SHARD_RESULT"
+            echo "Re-run the workflow. Nothing in the diff needs changing for this."
+            exit 1
+          fi
+
           if [ "$PLAN_RESULT" != "success" ]; then
             echo "Tooling smoke planner did not succeed: $PLAN_RESULT"
             exit 1


### PR DESCRIPTION
(AI Generated).

`always()` also runs a job during a **cancelled** run. That is documented behaviour and it is the bug: the gate woke up mid-cancellation, read `shards: cancelled`, and reported a hard red check while every shard that had finished was green.

Cancellation is the absence of a verdict, not a failing one.

This is not a rare edge. A mass cancellation on 2026-07-24 left roughly fifteen open PRs showing a failed `Tooling smoke` gate with no failing test in any of them. One example, #1106: **27 cancelled, 8 passed, 1 failure, and the single failure was this gate reacting to the cancellations.** Since the `concurrency` group cancels superseded runs by design, any long lane hits this whenever a branch gets pushed twice.

The cost is not the red check, it is what a persistently wrong red check does to everyone reading it. A gate that cries failure on cancellation trains people to treat a red gate as noise, which is precisely the state this repo's dependency backlog was in.

### Changes

**`if: ${{ !cancelled() }}` instead of `always()`.** A cancelled run now skips the gate, leaving no verdict rather than a wrong one.

**An explicit cancelled branch in the script**, for the case where individual jobs are cancelled without the whole run being cancelled. It says so in plain words and tells the reader to re-run, instead of leaving them to hunt a test failure that does not exist:

```
Tooling smoke was cancelled, not failed. No verdict was produced.
  planner: success, shards: cancelled
Re-run the workflow. Nothing in the diff needs changing for this.
```

### Deliberately unchanged

Step-level `always()` elsewhere in `ci.yml` and `tooling-nightly.yml` is correct. Uploading test artifacts and perf reports from a cancelled run is exactly what you want. Only the gate job conflated the two states.

One note: a cancelled run now leaves `Tooling smoke` skipped rather than failed. That is the intent, and it is harmless today since `dev` has no required status checks. If required checks are ever turned on, a skipped check needs to be allowed for, or the gate needs to report neutral instead.

Config re-parsed to confirm the workflow is still valid YAML and the job's `needs` are intact.