### PR TITLE
fix(build): make the automerge export patch fail loudly when it no longer applies

### DIFF
--- a/scripts/patch-automerge.mjs
+++ b/scripts/patch-automerge.mjs
@@ -24,30 +24,74 @@ const pkgPath = resolve(
   "../node_modules/@automerge/automerge/package.json",
 );
 
+function fail(lines) {
+  console.error(`[patch-automerge] ${lines[0]}`);
+  for (const line of lines.slice(1)) console.error(`[patch-automerge] ${line}`);
+  process.exit(1);
+}
+
 try {
   const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
-  let patched = 0;
+  const version = pkg.version ?? "unknown";
+
+  // Classify every browser.import entry before touching any of them. The old
+  // version only counted the ones it rewrote, so "nothing to rewrite" and "this
+  // package no longer looks the way I expect" produced the same cheerful line
+  // and the same exit 0. That is the wrong way round for a patch whose whole
+  // job is keeping a multi-megabyte base64 blob out of the bundle: if the
+  // upstream layout moves, the build stays green and silently ships the heavy
+  // entry point. Better to stop the install than to lose the saving quietly.
+  const alreadyBundler = [];
+  const needsPatch = [];
+  // Entrypoints that mention neither name are simply not this patch's business.
+  // ./slim is the real example: it ships no WASM of its own, so it never had a
+  // fullfat variant. Recorded only so the failure message below can show what
+  // the package did look like.
+  const unrelated = [];
 
   for (const [key, entry] of Object.entries(pkg.exports ?? {})) {
-    if (typeof entry !== "object" || !entry.browser) continue;
+    if (typeof entry !== "object" || entry === null) continue;
     const browser = entry.browser;
-    if (typeof browser === "object" && typeof browser.import === "string") {
-      if (browser.import.includes("fullfat_base64")) {
-        const before = browser.import;
-        browser.import = before.replace("fullfat_base64", "fullfat_bundler");
-        patched++;
-        console.log(
-          `[patch-automerge] ${key}.browser.import: ${before} → ${browser.import}`,
-        );
-      }
-    }
+    if (typeof browser !== "object" || browser === null) continue;
+    if (typeof browser.import !== "string") continue;
+
+    if (browser.import.includes("fullfat_bundler")) alreadyBundler.push(key);
+    else if (browser.import.includes("fullfat_base64")) needsPatch.push(key);
+    else unrelated.push(`${key} -> ${browser.import}`);
   }
 
-  if (patched > 0) {
-    writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
-    console.log(`[patch-automerge] Patched ${patched} export(s)`);
+  if (alreadyBundler.length + needsPatch.length === 0) {
+    fail([
+      `Found no fullfat_base64 or fullfat_bundler browser export in @automerge/automerge ${version}.`,
+      "This patch redirects the browser entry away from the base64 build, which",
+      "inlines the WASM binary into JS and costs roughly 65% of the bundle.",
+      "Finding neither name means the upstream export layout changed and this",
+      "patch is now a no-op, so the build would quietly ship the heavy entry.",
+      unrelated.length
+        ? `browser.import entries present: ${unrelated.join(", ")}`
+        : "No browser.import entries were present at all.",
+      "Re-target this script at the new layout, or drop it if upstream fixed the",
+      "default. Do not silence it without checking the bundle size first.",
+    ]);
+  }
+
+  if (needsPatch.length === 0) {
+    console.log(
+      `[patch-automerge] Already correct: ${alreadyBundler.length} browser export(s) on fullfat_bundler (v${version})`,
+    );
   } else {
-    console.log("[patch-automerge] No patching needed (already correct)");
+    for (const key of needsPatch) {
+      const browser = pkg.exports[key].browser;
+      const before = browser.import;
+      browser.import = before.replace("fullfat_base64", "fullfat_bundler");
+      console.log(
+        `[patch-automerge] ${key}.browser.import: ${before} → ${browser.import}`,
+      );
+    }
+    writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
+    console.log(
+      `[patch-automerge] Patched ${needsPatch.length} export(s) (v${version})`,
+    );
   }
 } catch (err) {
   if (err.code === "ENOENT") {


### PR DESCRIPTION
(AI Generated).

`scripts/patch-automerge.mjs` counted only the exports it rewrote. So "nothing needed rewriting" and "this package no longer looks the way I expect" both printed the same line and both exited 0:

```
[patch-automerge] No patching needed (already correct)
```

Only one of those is actually correct.

### Why it matters

The patch exists to keep the browser entry off `fullfat_base64`, which inlines the WASM binary into JS instead of shipping a streamable `.wasm` asset. The header puts that at roughly **65% of the bundle**.

Automerge 3 restructured its packaging. If those filenames moved, `postinstall` would report success, CI would stay green, and the renderer would quietly start shipping the heavy entry point. On a renderer already sitting at its memory ceiling, discovering that from a bundle-size regression weeks later is the expensive path.

This is a fail-open guard on the one thing it was written to guarantee.

### The fix

Classify every `browser.import` before touching any of them, and exit 1 with an explanation when neither fullfat name is found anywhere, printing what the exports actually contained so the next person can re-target it:

```
[patch-automerge] Found no fullfat_base64 or fullfat_bundler browser export in @automerge/automerge 3.3.2.
[patch-automerge] This patch redirects the browser entry away from the base64 build, which
[patch-automerge] inlines the WASM binary into JS and costs roughly 65% of the bundle.
[patch-automerge] browser.import entries present: . -> ./dist/mjs/index.js, ./slim -> ./dist/mjs/entrypoints/slim.js
[patch-automerge] Re-target this script at the new layout, or drop it if upstream fixed the
[patch-automerge] default. Do not silence it without checking the bundle size first.
```

Entrypoints mentioning neither name are ignored rather than treated as suspicious. `./slim` is exactly that case: it ships no WASM of its own and never had a fullfat variant. My first draft was stricter and failed on the real installed package for that reason, which is why the distinction is now commented in the source.

### Verification

Against the installed 2.2.9 tree and four synthetic layouts:

| Case | Expected | Result |
|---|---|---|
| Real installed 2.2.9 | already correct, exit 0 | pass |
| Unpatched base64 package | patches 1 export, exit 0 | pass |
| Re-run on that result | idempotent, exit 0 | pass |
| Automerge 3 shape, no fullfat | **fail, exit 1** | pass |
| No browser exports at all | **fail, exit 1** | pass |

The fourth row is the one that mattered: that layout previously printed "No patching needed" and exited 0.

Worth noting this makes an automerge 3 upgrade *louder*, not easier. It will now stop the install rather than silently regress the bundle, which is the point. Retargeting the script is part of that upgrade's work.