### PR TITLE
fix(ci): give the tooling smoke lane a budget its suites can actually fit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
           {
             echo "### Tooling smoke plan"
             echo ""
-            echo "- jobs: ${{ steps.plan.outputs.job-count }} (cap 8, was a fixed 32)"
+            echo "- jobs: ${{ steps.plan.outputs.job-count }} (cap 12, was a fixed 32)"
             echo "- reason: ${{ steps.plan.outputs.reason }}"
             echo "- native acceptance lane: ${{ steps.plan.outputs.native }}"
           } >> "$GITHUB_STEP_SUMMARY"
@@ -76,10 +76,15 @@ jobs:
     # 90 minutes, matching the pre-planner lane, NOT a shorter budget.
     #
     # Fewer shards means each one does more work. The old lane ran 32 shards at
-    # 90 minutes; capping at 8 quadruples the work per shard, so halving the
+    # 90 minutes; a cap of 12 still concentrates the work, so halving the
     # timeout was exactly backwards. A first attempt at 45 minutes killed
     # kernel-guard-cutover mid-run at 45:54 with every test passing, which reads
     # as a test failure and is not one.
+    #
+    # The cap was 8 until outcome-ledger-repair was re-measured. At 8 the
+    # allocator could not fit the measured suites under this timeout at all, so
+    # every PR touching package-lock.json was structurally red. See
+    # DEFAULT_MAX_JOBS in scripts/lib/tooling-smoke-plan.mjs.
     #
     # This is a ceiling for the full lane, not a target. Ordinary PRs select
     # zero or one suite and finish in minutes; only a scripts/ change or a push

--- a/scripts/lib/tooling-smoke-plan.mjs
+++ b/scripts/lib/tooling-smoke-plan.mjs
@@ -285,7 +285,30 @@ export function selectNativeAcceptance(
 }
 
 export const DURATIONS_FILE = "scripts/tooling-smoke-durations.json";
-export const DEFAULT_MAX_JOBS = 8;
+
+/**
+ * Total shard jobs the lane may schedule.
+ *
+ * 12, not 8. At 8 the allocator could not fit the measured suites inside the
+ * 90 minute shard timeout no matter how it spread them: outcome-ledger-repair
+ * needs at least 4 shards and general at least 2, and the arithmetic only
+ * closes from 10 upward. Every npm dependency PR selects all four suites,
+ * because package-lock.json is a global tooling input, so an unfittable budget
+ * meant the gate was structurally red for the entire class.
+ *
+ * This raises parallelism, not the clock. Issue #1147 rules out a longer
+ * `timeout-minutes` because that hides the cost and finds out later; splitting
+ * further keeps total runner seconds flat, adds only per-job setup, and lets
+ * the suite actually finish, which is also the only way its duration entry can
+ * ever be a measurement instead of a timeout floor.
+ *
+ * It is a mitigation and not the fix. outcome-ledger-repair is ~4.8 hours of
+ * work because it spawns a pinned Python interpreter per lease-archive
+ * operation, roughly 466 of them per test. Cutting that is #1147 and it
+ * touches a deliberate security boundary. Once it lands this should come back
+ * down.
+ */
+export const DEFAULT_MAX_JOBS = 12;
 
 /**
  * The `timeout-minutes` on a tooling smoke shard job, in seconds. Kept here so

--- a/scripts/tooling-smoke-durations.json
+++ b/scripts/tooling-smoke-durations.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "note": "Measured on ubuntu-latest CI, run 30140909175 / 30143xxxxx (2026-07-25). Seconds are per-suite totals summed across that run's shards. Source size is a poor runtime proxy: within the general suite the byte-weighted split produced shards of 41s and 4,909s, a 120x spread. Refresh with: node scripts/measure-tooling-smoke.mjs --write, or from CI shard durations.",
+  "note": "Measured on ubuntu-latest CI, run 30140909175 / 30143xxxxx (2026-07-25), with outcome-ledger-repair re-measured from run 30166138958 where all 8 of its shards completed. Seconds are per-suite totals summed across that run's shards, so they include per-shard job overhead and read slightly high at low shard counts, which is the safe direction. Source size is a poor runtime proxy: within the general suite the byte-weighted split produced shards of 41s and 4,909s, a 120x spread. Refresh with: node scripts/measure-tooling-smoke.mjs --write, or from CI shard durations.",
   "suites": {
     "general": {
       "seconds": 6679,
@@ -24,12 +24,11 @@
       "source": "ci-shard 3648 (single shard, completed)"
     },
     "outcome-ledger-repair": {
-      "seconds": 5415,
+      "seconds": 17266,
       "runs": 1,
       "failures": 0,
       "flaky": false,
-      "capped": true,
-      "source": "ci-shard killed by the 90m job cap at 5415s; a floor, not a measurement (issue #1147)"
+      "source": "ci-shards 1957+1732+3115+1752+2637+1427+2341+2305 (run 30166138958, all 8 completed). Replaces the 5415s floor from a killed shard, which understated the suite by 3.2x and kept the planner under-sharding it. The suite is still ~4.8 hours of work; that cost is issue #1147, not this number."
     }
   }
 }

--- a/scripts/tooling-smoke-plan.test.mjs
+++ b/scripts/tooling-smoke-plan.test.mjs
@@ -113,18 +113,23 @@ test("the source-size fallback predicts nothing rather than comparing bytes to s
   assert.equal(projected.predictedFrom, "size");
 });
 
-test("the real plan reports the overrun this repository currently has", () => {
-  // Reads the checked-in durations file rather than a fixture, so if the
-  // outcome-ledger-repair cost is ever genuinely fixed and re-measured, this
-  // test fails and someone has to decide whether the guard is still needed.
+test("the real plan fits every suite inside the shard timeout", () => {
+  // This used to assert the opposite, that the repository had a live overrun,
+  // and invited whoever fixed it to decide whether the guard was still needed.
+  // outcome-ledger-repair has since been re-measured from a run where all
+  // eight of its shards completed, 17,266s against the 5,415s floor a killed
+  // shard had left behind, and the job budget was raised to 12 so the
+  // allocator can actually spread it.
+  //
+  // Kept pointing at the checked-in durations file rather than a fixture, and
+  // simply flipped. Under-shard any suite again, by understating a duration or
+  // by lowering the budget, and this fails.
   const plan = buildToolingSmokeMatrix({ changedFiles: [] });
   assert.ok(plan.projection.length > 0);
-  assert.deepEqual(plan.overrunSuites, ["outcome-ledger-repair"]);
+  assert.deepEqual(plan.overrunSuites, []);
   assert.equal(plan.shardTimeoutSeconds, DEFAULT_SHARD_TIMEOUT_SECONDS);
 
-  // Every other suite has a real measurement and is expected to fit.
   for (const entry of plan.projection) {
-    if (entry.suite === "outcome-ledger-repair") continue;
     assert.equal(entry.fits, true, `${entry.suite} was expected to fit`);
     assert.equal(entry.predictedFrom, "measured");
   }
@@ -135,7 +140,19 @@ test("the plan still schedules work when a suite is predicted to overrun", () =>
   // lane outage, and the shards do produce real signal before they are killed.
   // The guard exists to make the overrun visible and attributable, not to stop
   // the lane. Changing this to a hard failure is a policy decision.
-  const plan = buildToolingSmokeMatrix({ changedFiles: [] });
+  //
+  // Driven from a fixture now that the real durations file no longer overruns.
+  // The behaviour still needs covering: it is what the lane does the next time
+  // a suite outgrows its budget.
+  const plan = buildToolingSmokeMatrix({
+    changedFiles: [],
+    maxJobs: 2,
+    durations: {
+      suites: {
+        "outcome-ledger-repair": { seconds: 100_000, runs: 1 },
+      },
+    },
+  });
   assert.ok(plan.overrunSuites.includes("outcome-ledger-repair"));
   assert.equal(plan.applicable, true);
   assert.ok(


### PR DESCRIPTION
(AI Generated).

This is why the dependency backlog was red, and it is not about dependencies at all.

`package-lock.json` is a global tooling input, so **every npm dependency PR selects all four suites**. One of those suites could never finish inside the shard timeout. So the `Tooling smoke` gate was structurally red for the entire class of change, permanently, regardless of the diff.

### The evidence

Across 40 recent runs, `outcome-ledger-repair`:

| Shards allocated | Outcome |
|---|---|
| 2 | killed at exactly 90 min, **11 runs out of 11** |
| 8 | **passed every time**, 23 to 51 min per shard |

It has never once failed an assertion. Every failure was the clock.

### Cause one: the recorded duration was a floor, not a measurement

`scripts/tooling-smoke-durations.json` carried `5415s` with `capped: true`, left behind by a shard the timeout killed. Run 30166138958 completed all eight of its shards; they sum to **17,266s**. The recorded figure understated the suite by **3.2x**.

The `capped` flag already existed and already stopped that number being trusted by the `fits` check, which is why the planner printed an accurate warning. It did not stop the same number being trusted by `allocateShardBudget`. So the planner correctly predicted the overrun and then allocated from the bad figure anyway, guaranteeing it.

### Cause two: the budget could not fit the work at any allocation

At 8 jobs across 4 suites there is no spread that fits the measured runtimes under 90 minutes. `outcome-ledger-repair` needs at least 4 shards, `general` at least 2, and the arithmetic only closes from **10** upward. Verified by running the repo's own `allocateShardBudget` and `projectShardRuntime` against the measured weights:

```
cap  8: worst shard 111 min   OVERRUN general
cap 10: worst shard  72 min   all fit
cap 12: worst shard  61 min   all fit
```

Raised to **12**, leaving the worst shard at 61 minutes against a 90 minute timeout.

### This is not the thing #1147 rules out

#1147 says raising `timeout-minutes` is not a fix, and it is right: that hides the cost and finds out later. This raises **parallelism**, not the clock. Total runner seconds stay flat, only per-job setup is added, and the suite actually finishes, which is also the only way its duration entry can ever become a real measurement instead of another floor.

### It is a mitigation, and should be reverted

`outcome-ledger-repair` is ~4.8 hours of work because it spawns a pinned Python interpreter per lease-archive operation, roughly **466 per test**. Cutting that is #1147's real fix and it touches a deliberate security boundary, so I have not gone near it. **The cap should come back down once that lands.**

Worth knowing separately: a single npm dependency PR now costs roughly 10 runner-hours of test work. That is the honest price of the lockfile selecting all four suites, and it was being paid in full before this change too, just without a green check at the end.

### Tests

The test asserting this repository has a live overrun is **inverted rather than deleted**, and still reads the checked-in durations file. It now fails if any suite is ever under-sharded again, which is the regression that caused this. Its own comment invited exactly this: *"if the outcome-ledger-repair cost is ever genuinely fixed and re-measured, this test fails and someone has to decide whether the guard is still needed."*

The companion test covering "schedule anyway when an overrun is predicted" moves to a fixture, since that behaviour still needs coverage once the real file no longer overruns.

`tooling-smoke-plan` 7 pass, `run-tooling-smoke-shard` 6 pass, `validate-worktree` 30 pass, 0 failures.