### PR TITLE
fix(ci): raise the smoke budget to 16, because 12 left the lane flapping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
           {
             echo "### Tooling smoke plan"
             echo ""
-            echo "- jobs: ${{ steps.plan.outputs.job-count }} (cap 12, was a fixed 32)"
+            echo "- jobs: ${{ steps.plan.outputs.job-count }} (cap 16, was a fixed 32)"
             echo "- reason: ${{ steps.plan.outputs.reason }}"
             echo "- native acceptance lane: ${{ steps.plan.outputs.native }}"
           } >> "$GITHUB_STEP_SUMMARY"
@@ -81,7 +81,7 @@ jobs:
     # kernel-guard-cutover mid-run at 45:54 with every test passing, which reads
     # as a test failure and is not one.
     #
-    # The cap was 8 until outcome-ledger-repair was re-measured. At 8 the
+    # The cap was 8, then 12. At 8 the
     # allocator could not fit the measured suites under this timeout at all, so
     # every PR touching package-lock.json was structurally red. See
     # DEFAULT_MAX_JOBS in scripts/lib/tooling-smoke-plan.mjs.

--- a/scripts/lib/tooling-smoke-plan.mjs
+++ b/scripts/lib/tooling-smoke-plan.mjs
@@ -289,12 +289,24 @@ export const DURATIONS_FILE = "scripts/tooling-smoke-durations.json";
 /**
  * Total shard jobs the lane may schedule.
  *
- * 12, not 8. At 8 the allocator could not fit the measured suites inside the
- * 90 minute shard timeout no matter how it spread them: outcome-ledger-repair
- * needs at least 4 shards and general at least 2, and the arithmetic only
- * closes from 10 upward. Every npm dependency PR selects all four suites,
- * because package-lock.json is a global tooling input, so an unfittable budget
- * meant the gate was structurally red for the entire class.
+ * 16, not 8. At 8 the allocator could not fit the measured suites inside the
+ * 90 minute shard timeout no matter how it spread them. Every npm dependency
+ * PR selects all four suites, because package-lock.json is a global tooling
+ * input, so an unfittable budget meant the gate was structurally red for the
+ * entire class.
+ *
+ * 12 was the first attempt and was not enough. The projection here divides a
+ * suite total by its shard count, which assumes the shards are even, and they
+ * are not: sharding is per test file, so one heavy file dominates. Measured
+ * gap between projection and the actual worst shard is about 1.5x. At 12 that
+ * left `general` on two shards running 82 to 90 minutes against a 90 minute
+ * cap across eight consecutive runs. It passed at 89 minutes once and was
+ * killed at 90 the next time, which is a coin flip, not a gate.
+ *
+ * 16 gives general a third shard, which isolates its heavy file at about 66
+ * minutes, and gives kernel-guard-cutover a second. That is the practical
+ * floor: the largest single test file in `general` is ~66 minutes on its own
+ * and no shard count splits it further.
  *
  * This raises parallelism, not the clock. Issue #1147 rules out a longer
  * `timeout-minutes` because that hides the cost and finds out later; splitting
@@ -308,7 +320,7 @@ export const DURATIONS_FILE = "scripts/tooling-smoke-durations.json";
  * touches a deliberate security boundary. Once it lands this should come back
  * down.
  */
-export const DEFAULT_MAX_JOBS = 12;
+export const DEFAULT_MAX_JOBS = 16;
 
 /**
  * The `timeout-minutes` on a tooling smoke shard job, in seconds. Kept here so

--- a/scripts/tooling-smoke-durations.json
+++ b/scripts/tooling-smoke-durations.json
@@ -17,11 +17,11 @@
       "source": "ci-shards 3985+4704"
     },
     "kernel-guard-cutover": {
-      "seconds": 3648,
+      "seconds": 4800,
       "runs": 1,
       "failures": 0,
       "flaky": false,
-      "source": "ci-shard 3648 (single shard, completed)"
+      "source": "ci-shard 4800 (single shard, 80 min, observed 2026-07-25). Replaces 3648s, which was a third low and left this suite one shard away from the 90 minute cap."
     },
     "outcome-ledger-repair": {
       "seconds": 17266,


### PR DESCRIPTION
(AI Generated).

Correcting my own under-shoot in #1173.

That PR took the budget from 8 to 12, which was right in direction and insufficient in size. It fixed `outcome-ledger-repair` and stopped the gate being permanently red, but it left three suites *near* the cap rather than clear of it.

### The projection is systematically optimistic

`projectShardRuntime` divides a suite total by its shard count, which assumes the shards are even. They are not: sharding is per test file, so one heavy file dominates its shard. Measured gap:

| Suite | Shards | Projected | Actual worst |
|---|---|---|---|
| general | 2 | 56 min | **82–90 min** |
| automation-control | 3 | 49 min | 67 min |
| outcome-ledger-repair | 6 | 48 min | 78 min |

About 1.5x across the board.

### general was a coin flip

`general 1/2` across eight consecutive runs: 68, 82, 82, 84, 85, 86, **89**, **90**. Against a 90 minute cap.

It passed at 89 minutes on #1163 and was killed at 90 on #1174. Same code, same shard, opposite verdicts. That is exactly the class of noise the cancelled-is-not-failed work was meant to remove, and I reintroduced it by picking a budget that was merely better rather than sufficient.

### What 16 buys

`general` gets a third shard, isolating its heavy file at about 66 minutes. `kernel-guard-cutover` gets a second, which it needed independently: it was observed at **80 minutes on a single shard** against a recorded 3648s (61 min), a third low, leaving it one slow runner from the cap on its own. Corrected to 4800s here.

Resulting allocation for an npm dependency PR: general 3, automation-control 4, kernel-guard-cutover 2, outcome-ledger-repair 7.

### This is the floor, and further budget raises will not help

The largest single test file in `general` is ~66 minutes on its own, and no shard count splits a file. So 66 minutes is the best worst-case available until either:

- #1147 lands, cutting the ~466 interpreter spawns per test, or
- that one heavy `general` file is split.

I want to be plain that this is the second time I have raised this constant today, and that raising it a third time would buy nothing. The honest read is that ~10 runner-hours of test work per lockfile PR is the actual problem, and sharding is only rearranging it.

`tooling-smoke-plan` 7 pass, `run-tooling-smoke-shard` 6 pass, `validate-worktree` 30 pass, 0 failures.