### PR TITLE
fix(desktop): declare the reqwest stream feature we already depend on

### DIFF
--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -27,7 +27,14 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 window-vibrancy = "0.8"
 # default-features = false drops native-tls (OpenSSL) which conflicts with wreq's BoringSSL on Linux.
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+#
+# "stream" is used directly: lib.rs calls Response::bytes_stream to download the
+# local AI model without buffering it whole. It was never declared here, and the
+# build only worked because tauri-plugin-updater 2.9.0 happened to turn it on
+# and cargo unifies features across the graph. That is a borrowed guarantee: the
+# updater bump to 2.10.1 drops it and the call site stops compiling. Declare what
+# we use so the build does not depend on another crate's feature choices.
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 # wreq is rquest renamed. The author renamed the crate and yanked every rquest
 # release, all 152 of them, so `rquest = "5"` no longer resolves at all and any
 # fresh dependency resolution fails outright. Version numbering carried straight


### PR DESCRIPTION
(AI Generated).

Unblocks #1168, and fixes a latent problem that bump merely exposed.

`lib.rs` calls `Response::bytes_stream()` to download the local AI model without buffering it whole. That method requires reqwest's `stream` feature, which **was never in our feature list**:

```toml
reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
```

It compiled anyway, because cargo unifies features across the graph and something else turned it on. `cargo tree -e features -i reqwest` names the benefactor exactly:

```
└── reqwest feature "stream"
    └── tauri-plugin-updater v2.9.0
```

One crate, one version. #1168 bumps `tauri-plugin-updater` 2.9.0 to 2.10.1, which no longer enables it, so the call site stops compiling:

```
error[E0599]: no method named `bytes_stream` found for struct `reqwest::Response` in the current scope
```

Nothing about that bump is wrong. The manifest was relying on another crate's feature choice for a method it calls directly, which is a guarantee nobody promised and Dependabot had no way to see.

### Why land this separately

Adding the feature is a **no-op today** — it is already on through unification, and `Cargo.lock` does not change. So this is safe to merge ahead of the bump, and it lets #1168 go green on its own rather than carrying an unrelated fix. It also means the next `tauri-plugin-updater` bump, whenever it comes, does not resurrect this.

I did not push it onto the Dependabot branch. Doing that earlier on #1126 took that PR out of Dependabot's hands for the rest of the day, and it was avoidable here.

After this: `freed-desktop` enables `reqwest/stream` directly rather than inheriting it.

`cargo check` clean, `cargo test --all-features` 159 passed 0 failed, `Cargo.lock` unchanged.