### PR TITLE
chore: correct v26.7.2600-dev version files

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freed/desktop",
   "private": true,
-  "version": "26.7.2600-dev",
+  "version": "26.7.2600",
   "type": "module",
   "scripts": {
     "dev": "node ../../node_modules/vite/bin/vite.js",

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -1419,7 +1419,7 @@ dependencies = [
 
 [[package]]
 name = "freed-desktop"
-version = "26.7.2600-dev"
+version = "26.7.2600"
 dependencies = [
  "base64 0.23.0",
  "criterion",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freed-desktop"
-version = "26.7.2600-dev"
+version = "26.7.2600"
 description = "Freed Desktop - Escape algorithmic manipulation"
 authors = ["Freed"]
 edition = "2021"

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Freed",
-  "version": "26.7.2600-dev",
+  "version": "26.7.2600",
   "identifier": "wtf.freed.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freed/pwa",
   "private": true,
-  "version": "26.7.2600-dev",
+  "version": "26.7.2600",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
(AI Generated).

Repairs the version files for v26.7.2600-dev so `release-publish.sh` will tag.

## What was wrong

I hand-rolled the version bump in #1177 instead of running `./scripts/release.sh --channel=dev`, and got the convention backwards. Package versions are plain CalVer; only the **tag** carries the `-dev` suffix. v26.7.1501-dev shipped with `26.7.1501` in `package.json`.

I wrote `26.7.2600-dev` into all five version files, so `validate-release-identity` rejected the publish:

```
- Desktop package version is 26.7.2600-dev, expected 26.7.2600.
- PWA package version is 26.7.2600-dev, expected 26.7.2600.
- Tauri bundle version is 26.7.2600-dev, expected 26.7.2600.
- Cargo package version is 26.7.2600-dev, expected 26.7.2600.
- Cargo.lock freed-desktop package version is 26.7.2600-dev, expected 26.7.2600.
```

It also rejected the publish because product files had changed after the release notes recorded their source commit, which is the second thing running the real script fixes.

## What this is

Output of `./scripts/release.sh --channel=dev`, unedited. It corrected all five version files and left the approved release notes alone on its own ("v26.7.2600-dev already has an approved release file. Leaving it untouched"), so the notes reviewed in #1180 are unchanged and still `approved: true`.

Diff is exactly the five version files. Nothing else.

## Lesson, recorded in the skill

The `freed-ship-build` skill already had all of this right, including the `release.sh` invocation and the final `release-publish.sh` step. I did not follow it and hand-assembled the release instead, which produced both this version error and the earlier round trip over the approval flag. A follow-up commit tightens the skill so the next run has no room to improvise.

## Provider surface

None.