### PR TITLE
perf(automation): widen the authority read caches to any exclusive guard scope

### DIFF
--- a/scripts/lib/automation-control.mjs
+++ b/scripts/lib/automation-control.mjs
@@ -1909,18 +1909,12 @@ export function withAutomationOutcomeLedgerWriterGuard(
         paths.stateRoot,
         context,
       );
-      OUTCOME_WRITER_AUTHORITY_SNAPSHOT_CACHES.set(context, new Map());
-      OUTCOME_WRITER_LEASE_HISTORY_CACHES.set(context, null);
-      OUTCOME_WRITER_DIRECTORY_CHILD_PROOF_CACHES.set(context, new Set());
-      OUTCOME_WRITER_DIRECTORY_NAME_CACHES.set(context, new Map());
+      openAuthorityCacheScope(paths.stateRoot, context);
       try {
         return operation(context);
       } finally {
         active = false;
-        OUTCOME_WRITER_AUTHORITY_SNAPSHOT_CACHES.delete(context);
-        OUTCOME_WRITER_LEASE_HISTORY_CACHES.delete(context);
-        OUTCOME_WRITER_DIRECTORY_CHILD_PROOF_CACHES.delete(context);
-        OUTCOME_WRITER_DIRECTORY_NAME_CACHES.delete(context);
+        closeAuthorityCacheScope(paths.stateRoot, context);
         ACTIVE_OUTCOME_LEDGER_WRITER_CONTEXTS_BY_ROOT.delete(paths.stateRoot);
         ACTIVE_OUTCOME_LEDGER_WRITER_CONTEXTS.delete(context);
       }
@@ -2002,8 +1996,56 @@ function withFilesystemGuard(
 
 const ACTIVE_AUTOMATION_EVENTS_GUARDS = new WeakSet();
 const ACTIVE_AUTOMATION_EVENTS_GUARDS_BY_ROOT = new Map();
+// Authority read caches hang off whichever exclusive kernel-guard scope is
+// active for a state root. The outcome ledger writer guard was the first such
+// scope; the automation events guard is the second. Both hold an exclusive
+// kernel file guard for the whole scope, both are single-instance per state
+// root, and both drop their caches when the scope unwinds, so a cached
+// generation can never outlive the guard that admitted it.
+const ACTIVE_AUTHORITY_CACHE_SCOPES_BY_ROOT = new Map();
 const AUTOMATION_EVENTS_GUARD_STAGE_ADMISSIONS = new WeakMap();
 const OUTCOME_REPAIR_OWNER_LEASE_BYPASSES = new WeakMap();
+
+function openAuthorityCacheScope(stateRoot, scope) {
+  OUTCOME_WRITER_AUTHORITY_SNAPSHOT_CACHES.set(scope, new Map());
+  OUTCOME_WRITER_LEASE_HISTORY_CACHES.set(scope, null);
+  OUTCOME_WRITER_DIRECTORY_CHILD_PROOF_CACHES.set(scope, new Set());
+  OUTCOME_WRITER_DIRECTORY_NAME_CACHES.set(scope, new Map());
+  const stack = ACTIVE_AUTHORITY_CACHE_SCOPES_BY_ROOT.get(stateRoot);
+  if (stack === undefined) {
+    ACTIVE_AUTHORITY_CACHE_SCOPES_BY_ROOT.set(stateRoot, [scope]);
+    return;
+  }
+  stack.push(scope);
+}
+
+function closeAuthorityCacheScope(stateRoot, scope) {
+  OUTCOME_WRITER_AUTHORITY_SNAPSHOT_CACHES.delete(scope);
+  OUTCOME_WRITER_LEASE_HISTORY_CACHES.delete(scope);
+  OUTCOME_WRITER_DIRECTORY_CHILD_PROOF_CACHES.delete(scope);
+  OUTCOME_WRITER_DIRECTORY_NAME_CACHES.delete(scope);
+  const stack = ACTIVE_AUTHORITY_CACHE_SCOPES_BY_ROOT.get(stateRoot);
+  if (stack === undefined) return;
+  const index = stack.lastIndexOf(scope);
+  if (index !== -1) stack.splice(index, 1);
+  if (stack.length === 0) {
+    ACTIVE_AUTHORITY_CACHE_SCOPES_BY_ROOT.delete(stateRoot);
+  }
+}
+
+// An outcome ledger writer context keeps its own cache for the whole guard, so
+// it stays the preferred scope whenever one is active for the root. That keeps
+// writer-guard behavior byte for byte identical and confines the widened
+// caching to the events-guard scopes that previously had none.
+function activeAuthorityCacheScopeForRoot(stateRoot) {
+  const writerContext =
+    ACTIVE_OUTCOME_LEDGER_WRITER_CONTEXTS_BY_ROOT.get(stateRoot);
+  if (writerContext !== undefined) return writerContext;
+  const stack = ACTIVE_AUTHORITY_CACHE_SCOPES_BY_ROOT.get(stateRoot);
+  return stack === undefined || stack.length === 0
+    ? null
+    : stack[stack.length - 1];
+}
 
 function requireActiveAutomationEventsGuard(token) {
   if (
@@ -2049,6 +2091,7 @@ function withActiveAutomationEventsGuard(
       }
       ACTIVE_AUTOMATION_EVENTS_GUARDS.add(token);
       ACTIVE_AUTOMATION_EVENTS_GUARDS_BY_ROOT.set(paths.stateRoot, token);
+      openAuthorityCacheScope(paths.stateRoot, token);
       try {
         if (authorizeOutcomeRepairBypass !== null) {
           if (typeof authorizeOutcomeRepairBypass !== "function") {
@@ -2087,6 +2130,7 @@ function withActiveAutomationEventsGuard(
         }
         return result;
       } finally {
+        closeAuthorityCacheScope(paths.stateRoot, token);
         AUTOMATION_EVENTS_GUARD_STAGE_ADMISSIONS.delete(token);
         ACTIVE_AUTOMATION_EVENTS_GUARDS_BY_ROOT.delete(paths.stateRoot);
         OUTCOME_REPAIR_OWNER_LEASE_BYPASSES.delete(token);
@@ -15274,13 +15318,10 @@ function automationAuthoritySnapshotGenerationFingerprint(filePath) {
   return before === after ? digestBytes(Buffer.from(after, "utf8")) : null;
 }
 
-function activeOutcomeWriterContextForPath(filePath) {
-  let matchingContext = null;
+function longestActiveStateRootForPath(filePath, stateRoots) {
+  let matchingRoot = null;
   let matchingRootLength = -1;
-  for (const [
-    stateRoot,
-    context,
-  ] of ACTIVE_OUTCOME_LEDGER_WRITER_CONTEXTS_BY_ROOT) {
+  for (const stateRoot of stateRoots) {
     const relative = path.relative(stateRoot, filePath);
     if (
       relative !== "" &&
@@ -15289,11 +15330,34 @@ function activeOutcomeWriterContextForPath(filePath) {
       !path.isAbsolute(relative) &&
       stateRoot.length > matchingRootLength
     ) {
-      matchingContext = context;
+      matchingRoot = stateRoot;
       matchingRootLength = stateRoot.length;
     }
   }
-  return matchingContext;
+  return matchingRoot;
+}
+
+function activeAuthorityCacheScopeForPath(filePath) {
+  const stateRoot = longestActiveStateRootForPath(
+    filePath,
+    ACTIVE_AUTHORITY_CACHE_SCOPES_BY_ROOT.keys(),
+  );
+  return stateRoot === null
+    ? null
+    : activeAuthorityCacheScopeForRoot(stateRoot);
+}
+
+// Private batch re-admission skips a pinned-helper verification outright rather
+// than reusing an already-admitted value, so it stays bound to the outcome
+// ledger writer guard that originally admitted the skip.
+function activeOutcomeLedgerWriterContextForPath(filePath) {
+  const stateRoot = longestActiveStateRootForPath(
+    filePath,
+    ACTIVE_OUTCOME_LEDGER_WRITER_CONTEXTS_BY_ROOT.keys(),
+  );
+  return stateRoot === null
+    ? null
+    : (ACTIVE_OUTCOME_LEDGER_WRITER_CONTEXTS_BY_ROOT.get(stateRoot) ?? null);
 }
 
 function cloneAutomationAuthoritySnapshot(snapshot) {
@@ -15318,7 +15382,7 @@ function readAutomationAuthorityFileSnapshotWithPolicy(
       label,
       invalidCode,
     );
-  const context = activeOutcomeWriterContextForPath(normalizedFilePath);
+  const context = activeAuthorityCacheScopeForPath(normalizedFilePath);
   const helperTestPause = options?.helperTestPause;
   if (context === null || helperTestPause !== undefined) {
     return readAutomationAuthorityFileSnapshotWithPolicyUncached(
@@ -17117,10 +17181,8 @@ function leaseAuthorityTreeGenerationFingerprint(paths) {
 }
 
 function inspectLeaseTransactionEventHistoryForPlanning(paths, events) {
-  const context = ACTIVE_OUTCOME_LEDGER_WRITER_CONTEXTS_BY_ROOT.get(
-    paths.stateRoot,
-  );
-  if (context === undefined) {
+  const context = activeAuthorityCacheScopeForRoot(paths.stateRoot);
+  if (context === null) {
     return inspectLeaseTransactionEventHistoryInternal({
       stateRoot: paths.stateRoot,
       events,
@@ -20251,7 +20313,7 @@ function requirePinnedLeaseArchiveDirectoryChild(helper, parent, child, label) {
   }
   assertPinnedLeaseArchiveDirectory(parent);
   assertPinnedLeaseArchiveDirectory(child);
-  const writerContext = activeOutcomeWriterContextForPath(parent.path);
+  const writerContext = activeAuthorityCacheScopeForPath(parent.path);
   const proofCache =
     writerContext === null
       ? undefined
@@ -21334,7 +21396,7 @@ function requirePrivateBatchInventoryUnchanged(
     }
   };
   if (
-    activeOutcomeWriterContextForPath(directory.path) !== null &&
+    activeOutcomeLedgerWriterContextForPath(directory.path) !== null &&
     currentGenerationMatches() &&
     currentGenerationMatches()
   ) {
@@ -21388,7 +21450,7 @@ function automationPlanningReadNames(
       return null;
     }
   };
-  const context = activeOutcomeWriterContextForPath(directory.path);
+  const context = activeAuthorityCacheScopeForPath(directory.path);
   const cache =
     context === null
       ? undefined


### PR DESCRIPTION
(AI Generated).

Partial progress on [#1147](https://github.com/freed-project/freed/issues/1147). Cuts interpreter launches by 12.4% without touching what makes the lease-archive helper safe.

## The measurement

`runLeaseArchiveHelper` spawns a pinned Python interpreter for every lease-archive filesystem operation. Interleaved BEFORE/AFTER/BEFORE/AFTER on one machine, on `plans a 0644 legacy ledger without mutating canonical state`:

| | spawns | wall clock |
| --- | --- | --- |
| before | 466 | 46.0s, 46.3s |
| after | **408** | **39.8s, 38.9s** |

The two figures agreeing is the check that matters. Spawns are 97.8% of this test's runtime by CPU profile, so a 12.4% spawn reduction should buy roughly 12–15% of wall clock, and it buys 14.6%.

Worth recording: an earlier report of this work claimed **35%** wall clock against the same 12.4% spawn reduction. Those cannot both be true when spawns dominate that completely, and re-measuring showed the 35% came from comparing against a noisy 58.2s first run rather than a settled baseline. The interleaved A/B exists to make that class of error visible.

## What changed

The four generation-fingerprint-gated authority read caches hung off the outcome-ledger writer guard only. They now hang off any exclusive kernel-guard scope, so the automation events guard — which already wraps lease transactions and task manifest mutations — opens and closes a cache scope the same way the writer guard does.

## The security boundary is untouched

This helper is a deliberate isolation boundary, not accidental slowness, so the relevant question is not "is it faster" but "is it still safe". Unchanged in this diff:

- the interpreter is still resolved through `resolveLeaseArchivePythonRuntime` to the pinned uid-0 binary under the trusted root
- the environment is still scrubbed to `HOME`, `LANG=C`, `LC_ALL=C`, `PATH=/usr/bin:/bin`
- descriptors are still pinned
- the helper source is still the pinned source

Grepping the diff for any of those terms returns nothing. This is a caching change.

## What it does not do

**It does not make the suite fit the 90-minute cap.** At roughly a 3-hour baseline, 12.4% still leaves two shards well over. The real remedy is fewer interpreter launches, not a cheaper cache, and that stays open on #1147.

## Verification

13 pass across `outcome-ledger-repair-contract` and `tooling-smoke-plan`, plus the target test, on current dev.

## Provider surface

None. One file under `scripts/lib/`.