### PR TITLE
fix: make startup memory attribution process-safe

### DIFF
--- a/docs/PHASE-7-SOCIAL-CAPTURE.md
+++ b/docs/PHASE-7-SOCIAL-CAPTURE.md
@@ -116,6 +116,8 @@ Background scrape and auth-check sessions now force provider media elements sile
 
 Social memory preflight now has shared backoff across Facebook, Instagram, and LinkedIn. When one provider cannot start because Freed Desktop memory is high after cleanup, the next providers reuse that deferred result instead of immediately opening more WebKit work. High-memory Freed Desktop installs now get larger adaptive scrape budgets, and low-priority semantic enrichment waits through launch so Facebook and Instagram scraping does not lose the first background window to Automerge maintenance.
 
+Startup memory attribution now primes a nonblocking native sample before document hydration and records one rooted main-renderer process identity. Later deltas require the same PID and native microsecond process start time. Renderer replacement, rapid relaunch, PID reuse, ambiguous WebKit candidates, and late samples are recorded as incomparable instead of being mislabeled as document or provider memory.
+
 Provider health now treats memory-pressure preflight blocks as transient deferrals instead of durable provider failures. The attempts stay in local diagnostics for review, but after the recovery window they stop driving sidebar warnings or stale source-menu copy.
 
 Facebook and Instagram feed scrapes now build a memory-aware pass plan after the WebView has loaded. When memory is healthy they keep the normal randomized session. When Freed Desktop is close to the scrape budget, they skip story collection and reduce scroll passes instead of opening a full story-plus-feed session that is likely to pause or trigger memory recovery. Each plan is written to runtime health diagnostics with the provider, pass range, story decision, margin, and memory budgets.
@@ -188,6 +190,7 @@ const RATE_LIMITS = {
 | 7.22 | Story Wall grouped settings section and GitHub Pages publisher | 🚧 In Progress |
 | 7.23 | Local social scrape optimization loop       | ✓ Complete  |
 | 7.24 | Shared safety runtime for authenticated Substack and Medium beta capture | ✓ Complete |
+| 7.25 | Process-matched startup memory attribution  | ✓ Complete  |
 
 ---
 
@@ -221,6 +224,7 @@ const RATE_LIMITS = {
 - [x] Memory-pressure preflight deferrals stay in diagnostics but age out of the current sidebar and source-menu warning state
 - [x] Facebook and Instagram feed scrapes now register with the shared background runtime so cloud sync, content fetches, RSS polls, snapshots, outbox drains, and semantic classifiers do not compete with active WebKit scraping
 - [x] Social scrape memory preflight uses adaptive high-memory budgets, native hidden-window runtime samples, and launch-delayed semantic enrichment so provider WebKit sessions get priority during long background runs
+- [x] Startup memory attribution never blocks initialization and rejects cross-process, recycled-PID, ambiguous, or post-hydration comparisons
 - [x] Local social scrape optimization loop ranks runtime-log evidence into safe local next actions and explicit provider-visible risk decisions
 - [x] Authenticated Substack and Medium beta capture serializes behind the same
       native social session lock, runs memory preflight before provider loads,

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -2956,6 +2956,8 @@ struct RuntimeMemoryStats {
 #[serde(rename_all = "camelCase")]
 struct WebkitProcessRuntimeStats {
     process_id: u32,
+    started_at_unix_seconds: u64,
+    started_at_unix_micros: Option<u64>,
     resident_bytes: u64,
     footprint_bytes: Option<u64>,
     virtual_bytes: u64,
@@ -6338,8 +6340,48 @@ fn macos_process_has_open_file_under_roots(pid: u32, roots: &[PathBuf]) -> bool 
         .any(|path| path_is_under_any_root(Path::new(path), roots))
 }
 
-fn webkit_process_started_after_app_start(webkit_age_seconds: u64, app_age_seconds: u64) -> bool {
-    webkit_age_seconds <= app_age_seconds.saturating_add(WEBKIT_PROCESS_START_GRACE_SECONDS)
+fn unix_micros_from_process_start(seconds: u64, microseconds: u64) -> Option<u64> {
+    if seconds == 0 || microseconds >= 1_000_000 {
+        return None;
+    }
+    seconds
+        .checked_mul(1_000_000)
+        .and_then(|value| value.checked_add(microseconds))
+}
+
+#[cfg(target_os = "macos")]
+fn macos_process_started_at_unix_micros(pid: u32) -> Option<u64> {
+    let mut info = MaybeUninit::<libc::proc_bsdinfo>::uninit();
+    let expected_size = std::mem::size_of::<libc::proc_bsdinfo>();
+    let result = unsafe {
+        libc::proc_pidinfo(
+            pid as libc::c_int,
+            libc::PROC_PIDTBSDINFO,
+            0,
+            info.as_mut_ptr().cast(),
+            expected_size as libc::c_int,
+        )
+    };
+    if result != expected_size as libc::c_int {
+        return None;
+    }
+    let info = unsafe { info.assume_init() };
+    unix_micros_from_process_start(info.pbi_start_tvsec, info.pbi_start_tvusec)
+}
+
+#[cfg(not(target_os = "macos"))]
+fn macos_process_started_at_unix_micros(_pid: u32) -> Option<u64> {
+    None
+}
+
+fn webkit_process_started_at_or_after_app(
+    webkit_started_at_unix_micros: Option<u64>,
+    app_started_at_unix_micros: Option<u64>,
+) -> bool {
+    matches!(
+        (webkit_started_at_unix_micros, app_started_at_unix_micros),
+        (Some(webkit), Some(app)) if app > 0 && webkit >= app
+    )
 }
 
 fn webkit_process_started_with_app(webkit_age_seconds: u64, app_age_seconds: u64) -> bool {
@@ -6362,15 +6404,19 @@ fn webkit_process_matches_renderer_uptime(
 
 fn freed_webkit_process_role(
     has_open_file_under_roots: bool,
+    webkit_started_at_unix_micros: Option<u64>,
+    app_started_at_unix_micros: Option<u64>,
     webkit_age_seconds: u64,
     app_age_seconds: u64,
 ) -> Option<&'static str> {
+    if !webkit_process_started_at_or_after_app(
+        webkit_started_at_unix_micros,
+        app_started_at_unix_micros,
+    ) {
+        return None;
+    }
     if has_open_file_under_roots {
-        if webkit_process_started_after_app_start(webkit_age_seconds, app_age_seconds) {
-            Some("freed-webcontent")
-        } else {
-            None
-        }
+        Some("freed-webcontent")
     } else if webkit_process_started_with_app(webkit_age_seconds, app_age_seconds) {
         Some("freed-webcontent-age-matched")
     } else {
@@ -6402,6 +6448,7 @@ fn macos_process_physical_footprint_bytes(_pid: u32) -> Option<u64> {
 fn freed_webkit_memory_stats(
     system: &System,
     roots: &[PathBuf],
+    app_started_at_unix_micros: Option<u64>,
     app_age_seconds: u64,
     precise_attribution: bool,
 ) -> WebkitMemoryStats {
@@ -6421,11 +6468,28 @@ fn freed_webkit_memory_stats(
             }
             let pid_u32 = pid.as_u32();
             let age_seconds = process.run_time();
+            let started_at_unix_seconds = process.start_time();
+            let started_at_unix_micros = macos_process_started_at_unix_micros(pid_u32);
+            // A WebKit process older than Freed cannot belong to this app.
+            // Skip it before lsof so precise startup attribution does not scan
+            // every Safari or unrelated WebKit process on the machine.
+            if precise_attribution
+                && !webkit_process_started_at_or_after_app(
+                    started_at_unix_micros,
+                    app_started_at_unix_micros,
+                )
+            {
+                continue;
+            }
             let has_open_file_under_roots =
                 precise_attribution && macos_process_has_open_file_under_roots(pid_u32, roots);
-            let Some(role) =
-                freed_webkit_process_role(has_open_file_under_roots, age_seconds, app_age_seconds)
-            else {
+            let Some(role) = freed_webkit_process_role(
+                has_open_file_under_roots,
+                started_at_unix_micros,
+                app_started_at_unix_micros,
+                age_seconds,
+                app_age_seconds,
+            ) else {
                 continue;
             };
             let resident = process.memory();
@@ -6439,6 +6503,8 @@ fn freed_webkit_memory_stats(
             process_count += 1;
             let stats = WebkitProcessRuntimeStats {
                 process_id: pid_u32,
+                started_at_unix_seconds,
+                started_at_unix_micros,
                 resident_bytes: resident,
                 footprint_bytes: footprint,
                 virtual_bytes,
@@ -6513,6 +6579,7 @@ fn collect_runtime_memory_stats_with_options(
             )
         })
         .unwrap_or((0, 0, 0));
+    let process_started_at_unix_micros = macos_process_started_at_unix_micros(std::process::id());
     let process_footprint_bytes = macos_process_physical_footprint_bytes(std::process::id());
     system.refresh_processes_specifics(
         ProcessesToUpdate::All,
@@ -6523,6 +6590,7 @@ fn collect_runtime_memory_stats_with_options(
     let webkit = freed_webkit_memory_stats(
         &system,
         &app_storage_roots(app),
+        process_started_at_unix_micros,
         process_age_seconds,
         options.precise_webkit_attribution,
     );
@@ -16563,16 +16631,24 @@ mod tests {
 
     #[test]
     fn webkit_process_filter_excludes_prior_launches() {
+        let app_started_at = 1_783_000_000_500_000;
         let app_age = 60;
 
-        assert!(webkit_process_started_after_app_start(0, app_age));
-        assert!(webkit_process_started_after_app_start(
-            app_age + WEBKIT_PROCESS_START_GRACE_SECONDS,
-            app_age
+        assert!(webkit_process_started_at_or_after_app(
+            Some(app_started_at),
+            Some(app_started_at)
         ));
-        assert!(!webkit_process_started_after_app_start(
-            app_age + WEBKIT_PROCESS_START_GRACE_SECONDS + 1,
-            app_age
+        assert!(webkit_process_started_at_or_after_app(
+            Some(app_started_at + 1),
+            Some(app_started_at)
+        ));
+        assert!(!webkit_process_started_at_or_after_app(
+            Some(app_started_at - 1),
+            Some(app_started_at)
+        ));
+        assert!(!webkit_process_started_at_or_after_app(
+            Some(app_started_at),
+            None
         ));
 
         assert!(webkit_process_started_with_app(app_age, app_age));
@@ -16585,20 +16661,35 @@ mod tests {
 
     #[test]
     fn webkit_process_role_counts_rooted_current_launches() {
+        let app_started_at = 1_783_000_000_500_000;
         let app_age = 60;
 
         assert_eq!(
-            freed_webkit_process_role(true, app_age, app_age),
-            Some("freed-webcontent")
-        );
-        assert_eq!(
-            freed_webkit_process_role(true, 0, app_age),
+            freed_webkit_process_role(
+                true,
+                Some(app_started_at),
+                Some(app_started_at),
+                app_age,
+                app_age
+            ),
             Some("freed-webcontent")
         );
         assert_eq!(
             freed_webkit_process_role(
                 true,
-                app_age + WEBKIT_PROCESS_START_GRACE_SECONDS + 1,
+                Some(app_started_at + 1),
+                Some(app_started_at),
+                0,
+                app_age
+            ),
+            Some("freed-webcontent")
+        );
+        assert_eq!(
+            freed_webkit_process_role(
+                true,
+                Some(app_started_at - 1),
+                Some(app_started_at),
+                app_age + 1,
                 app_age
             ),
             None
@@ -16607,24 +16698,44 @@ mod tests {
 
     #[test]
     fn webkit_process_role_keeps_only_app_start_rootless_processes() {
+        let app_started_at = 1_783_000_000_500_000;
         let app_age = 60;
 
         assert_eq!(
-            freed_webkit_process_role(false, app_age, app_age),
+            freed_webkit_process_role(
+                false,
+                Some(app_started_at),
+                Some(app_started_at),
+                app_age,
+                app_age
+            ),
             Some("freed-webcontent-age-matched")
         );
         assert_eq!(
             freed_webkit_process_role(
                 false,
+                Some(app_started_at + 1),
+                Some(app_started_at),
                 app_age.saturating_sub(WEBKIT_PROCESS_START_GRACE_SECONDS),
                 app_age
             ),
             Some("freed-webcontent-age-matched")
         );
-        assert_eq!(freed_webkit_process_role(false, 0, app_age), None);
         assert_eq!(
             freed_webkit_process_role(
                 false,
+                Some(app_started_at + 1),
+                Some(app_started_at),
+                0,
+                app_age
+            ),
+            None
+        );
+        assert_eq!(
+            freed_webkit_process_role(
+                false,
+                Some(app_started_at - 1),
+                Some(app_started_at),
                 app_age + WEBKIT_PROCESS_START_GRACE_SECONDS + 1,
                 app_age
             ),
@@ -16635,6 +16746,8 @@ mod tests {
     fn webkit_process_stats(process_id: u32, resident_bytes: u64) -> WebkitProcessRuntimeStats {
         WebkitProcessRuntimeStats {
             process_id,
+            started_at_unix_seconds: 1_783_000_000,
+            started_at_unix_micros: Some(1_783_000_000_500_000),
             resident_bytes,
             footprint_bytes: Some(resident_bytes),
             virtual_bytes: resident_bytes.saturating_mul(2),

--- a/packages/desktop/src/App.tsx
+++ b/packages/desktop/src/App.tsx
@@ -171,7 +171,11 @@ import { importMetaExportFiles } from "./lib/meta-export-import";
 import { summarizeMediaVault } from "./lib/media-vault";
 import { publishStoryWallToGitHubPages } from "./lib/story-wall-publisher";
 import { clearFatalRuntimeError, useFatalRuntimeError } from "@freed/ui/lib/bug-report";
-import { startMemoryMonitor, stopMemoryMonitor } from "./lib/memory-monitor";
+import {
+  captureShellMemoryBaseline,
+  startMemoryMonitor,
+  stopMemoryMonitor,
+} from "./lib/memory-monitor";
 import {
   getBackgroundRuntimeStatus,
   noteMemoryPressure,
@@ -376,6 +380,13 @@ function App() {
   const fatalError = useFatalRuntimeError();
 
   useDesktopNavigationHistory(legalAccepted);
+
+  useEffect(() => {
+    if (!tauriRuntimeAvailable) return;
+    // Give the nonblocking shell probe the legal and lock checks as headroom.
+    // Document initialization closes the window and discards a late result.
+    void captureShellMemoryBaseline();
+  }, [tauriRuntimeAvailable]);
 
   useEffect(() => {
     if (

--- a/packages/desktop/src/lib/memory-attribution.test.ts
+++ b/packages/desktop/src/lib/memory-attribution.test.ts
@@ -1,10 +1,98 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  invoke: vi.fn(),
+  recordRuntimeHealthEvent: vi.fn(),
+  setRuntimeMemory: vi.fn(),
+  warn: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: mocks.invoke,
+  isTauri: () => true,
+}));
+
+vi.mock("./logger", () => ({
+  log: {
+    info: vi.fn(),
+    warn: mocks.warn,
+  },
+}));
+
+vi.mock("./runtime-health-events", () => ({
+  recordRuntimeHealthEvent: mocks.recordRuntimeHealthEvent,
+}));
+
+vi.mock("@freed/ui/lib/debug-store", () => ({
+  setRuntimeMemory: mocks.setRuntimeMemory,
+}));
+
+vi.mock("./content-fetcher", () => ({
+  getStatus: () => ({
+    pending: 0,
+    completed: 0,
+    failedCount: 0,
+    active: false,
+    backoffLevel: 0,
+  }),
+}));
 
 import {
+  captureShellMemoryBaseline,
   getShellBaselineBytes,
   recordDocumentHydrated,
+  recordDocumentHydrationStarted,
   resetMemoryAttributionForTests,
+  startMemoryMonitor,
+  stopMemoryMonitor,
 } from "./memory-monitor";
+
+const MIB = 1024 * 1024;
+
+function nativeSample(
+  processId: number,
+  residentBytes: number,
+  startedAtUnixSeconds = 1_783_000_000,
+  startedAtUnixMicros = startedAtUnixSeconds * 1_000_000 + 500_000,
+) {
+  return {
+    totalPhysicalMemoryBytes: 8 * 1024 * MIB,
+    processResidentBytes: 64 * MIB,
+    processVirtualBytes: 256 * MIB,
+    appResidentBytes: 64 * MIB + residentBytes,
+    webkitResidentBytes: residentBytes,
+    webkitProcessId: processId,
+    webkitTotalResidentBytes: residentBytes,
+    webkitProcessCount: 1,
+    webkitLargestResidentBytes: residentBytes,
+    webkitLargestProcessId: processId,
+    webkitLargestRole: "freed-webcontent-age-matched",
+    webkitProcesses: [
+      {
+        processId,
+        startedAtUnixSeconds,
+        startedAtUnixMicros,
+        residentBytes,
+        virtualBytes: 512 * MIB,
+        cpuUsage: 0,
+        ageSeconds: 1,
+        role: "freed-webcontent",
+      },
+    ],
+    webkitTelemetryAvailable: true,
+    webkitAttributionPrecise: true,
+    memoryHighBytes: 2 * 1024 * MIB,
+    memoryCriticalBytes: 3 * 1024 * MIB,
+    relayDocBytes: 0,
+    relayClientCount: 0,
+  };
+}
+
+async function flushPromises(count = 4): Promise<void> {
+  for (let index = 0; index < count; index += 1) {
+    await Promise.resolve();
+  }
+}
 
 // The contract this protects: the shell baseline is only meaningful if it is
 // captured BEFORE the Automerge document is hydrated. Every floor estimate in
@@ -15,6 +103,12 @@ import {
 // every derived number wrong in the flattering direction.
 describe("memory attribution", () => {
   beforeEach(() => {
+    vi.useRealTimers();
+    mocks.invoke.mockReset();
+    mocks.recordRuntimeHealthEvent.mockReset();
+    mocks.setRuntimeMemory.mockReset();
+    mocks.warn.mockReset();
+    stopMemoryMonitor();
     resetMemoryAttributionForTests();
   });
 
@@ -27,6 +121,158 @@ describe("memory attribution", () => {
     recordDocumentHydrated();
     // Idempotent: a second call must not reopen the window by resetting state.
     expect(getShellBaselineBytes()).toBeUndefined();
+    expect(mocks.recordRuntimeHealthEvent).toHaveBeenCalledTimes(1);
+    expect(mocks.recordRuntimeHealthEvent).toHaveBeenCalledWith({
+      event: "memory_document_hydrated",
+      shellBaselineMainRendererResidentBytes: undefined,
+      shellBaselineMainRendererProcessId: undefined,
+      shellBaselineMainRendererStartedAtUnixSeconds: undefined,
+      shellBaselineMainRendererStartedAtUnixMicros: undefined,
+      shellBaselineCaptured: false,
+    });
+  });
+
+  it("captures one rooted main-renderer shell sample before hydration", async () => {
+    mocks.invoke.mockResolvedValue(nativeSample(41, 192 * MIB));
+
+    await expect(captureShellMemoryBaseline()).resolves.toBe(true);
+
+    expect(mocks.invoke).toHaveBeenCalledWith("get_runtime_memory_stats", {
+      includeStorageSizes: false,
+      preciseWebkitAttribution: true,
+    });
+    expect(getShellBaselineBytes()).toBe(192 * MIB);
+    expect(mocks.recordRuntimeHealthEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: "memory_shell_baseline",
+        mainRendererProcessId: 41,
+        mainRendererStartedAtUnixSeconds: 1_783_000_000,
+        mainRendererStartedAtUnixMicros: 1_783_000_000_500_000,
+        mainRendererResidentBytes: 192 * MIB,
+      }),
+    );
+  });
+
+  it("rejects a sample that completes after hydration starts", async () => {
+    let resolveSample:
+      | ((value: ReturnType<typeof nativeSample>) => void)
+      | undefined;
+    mocks.invoke.mockReturnValue(
+      new Promise((resolve) => {
+        resolveSample = resolve;
+      }),
+    );
+
+    const capture = captureShellMemoryBaseline();
+    recordDocumentHydrationStarted();
+    resolveSample?.(nativeSample(41, 192 * MIB));
+
+    await expect(capture).resolves.toBe(false);
+    expect(getShellBaselineBytes()).toBeUndefined();
+  });
+
+  it("does not compare a replacement renderer with the launch baseline", async () => {
+    mocks.invoke.mockResolvedValueOnce(nativeSample(41, 100 * MIB));
+    await captureShellMemoryBaseline();
+    recordDocumentHydrationStarted();
+    recordDocumentHydrated();
+    mocks.invoke.mockResolvedValue(nativeSample(42, 180 * MIB));
+
+    startMemoryMonitor();
+    await flushPromises();
+
+    expect(mocks.setRuntimeMemory).toHaveBeenCalledWith(
+      expect.objectContaining({
+        shellBaselineMainRendererProcessId: 41,
+        shellBaselineMainRendererStartedAtUnixSeconds: 1_783_000_000,
+        shellBaselineMainRendererStartedAtUnixMicros: 1_783_000_000_500_000,
+        shellBaselineMainRendererResidentBytes: 100 * MIB,
+        mainRendererResidentOverShellBaselineBytes: undefined,
+        shellBaselineComparisonStatus: "process_unavailable",
+      }),
+    );
+    stopMemoryMonitor();
+  });
+
+  it("does not compare a recycled PID with the launch baseline", async () => {
+    mocks.invoke.mockResolvedValueOnce(nativeSample(41, 100 * MIB));
+    await captureShellMemoryBaseline();
+    recordDocumentHydrationStarted();
+    recordDocumentHydrated();
+    mocks.invoke.mockResolvedValue(
+      nativeSample(
+        41,
+        180 * MIB,
+        1_783_000_100,
+        1_783_000_100_500_000,
+      ),
+    );
+
+    startMemoryMonitor();
+    await flushPromises();
+
+    expect(mocks.setRuntimeMemory).toHaveBeenCalledWith(
+      expect.objectContaining({
+        shellBaselineMainRendererProcessId: 41,
+        mainRendererResidentOverShellBaselineBytes: undefined,
+        shellBaselineComparisonStatus: "process_unavailable",
+      }),
+    );
+    stopMemoryMonitor();
+  });
+
+  it("measures growth only for the same renderer PID and start time", async () => {
+    mocks.invoke.mockResolvedValueOnce(nativeSample(41, 100 * MIB));
+    await captureShellMemoryBaseline();
+    recordDocumentHydrationStarted();
+    recordDocumentHydrated();
+    mocks.invoke.mockResolvedValue(nativeSample(41, 180 * MIB));
+
+    startMemoryMonitor();
+    await flushPromises();
+
+    expect(mocks.setRuntimeMemory).toHaveBeenCalledWith(
+      expect.objectContaining({
+        shellBaselineMainRendererProcessId: 41,
+        shellBaselineMainRendererStartedAtUnixSeconds: 1_783_000_000,
+        shellBaselineMainRendererStartedAtUnixMicros: 1_783_000_000_500_000,
+        mainRendererResidentOverShellBaselineBytes: 80 * MIB,
+        shellBaselineComparisonStatus: "same_process",
+      }),
+    );
+    stopMemoryMonitor();
+  });
+
+  it("rejects ambiguous or age-matched-only baseline candidates", async () => {
+    const first = nativeSample(41, 100 * MIB);
+    mocks.invoke.mockResolvedValueOnce({
+      ...first,
+      webkitAttributionPrecise: false,
+      webkitProcesses: [
+        {
+          ...first.webkitProcesses[0],
+          role: "freed-webcontent-age-matched",
+        },
+        {
+          ...first.webkitProcesses[0],
+          processId: 42,
+          role: "freed-webcontent-age-matched",
+        },
+      ],
+    });
+    await expect(captureShellMemoryBaseline()).resolves.toBe(false);
+
+    mocks.invoke.mockResolvedValueOnce({
+      ...first,
+      webkitProcesses: [
+        first.webkitProcesses[0],
+        { ...first.webkitProcesses[0], processId: 42 },
+      ],
+    });
+    await expect(captureShellMemoryBaseline()).resolves.toBe(false);
+
+    expect(getShellBaselineBytes()).toBeUndefined();
+    expect(mocks.recordRuntimeHealthEvent).not.toHaveBeenCalled();
   });
 
   it("clears state for tests so runs do not leak into each other", () => {

--- a/packages/desktop/src/lib/memory-monitor-social-preflight.test.ts
+++ b/packages/desktop/src/lib/memory-monitor-social-preflight.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   invoke: vi.fn(),
+  recordRuntimeHealthEvent: vi.fn(),
 }));
 
 vi.mock("@tauri-apps/api/core", () => ({
@@ -30,6 +31,10 @@ vi.mock("./logger", () => ({
     info: vi.fn(),
     warn: vi.fn(),
   },
+}));
+
+vi.mock("./runtime-health-events", () => ({
+  recordRuntimeHealthEvent: mocks.recordRuntimeHealthEvent,
 }));
 
 async function loadMonitor() {
@@ -64,7 +69,19 @@ function blockedPreparation() {
     webkitLargestCpuUsage: 0,
     webkitLargestAgeSeconds: 10,
     webkitLargestRole: "freed-webcontent",
-    webkitProcesses: [],
+    webkitProcesses: [
+      {
+        processId: 12345,
+        startedAtUnixSeconds: 1_783_000_000,
+        startedAtUnixMicros: 1_783_000_000_500_000,
+        residentBytes: 96 * 1024 * 1024,
+        footprintBytes: 96 * 1024 * 1024,
+        virtualBytes: 512 * 1024 * 1024,
+        cpuUsage: 0,
+        ageSeconds: 10,
+        role: "freed-webcontent",
+      },
+    ],
     webkitTelemetryAvailable: true,
     webkitAttributionPrecise: true,
     indexedDbBytes: 0,
@@ -89,6 +106,7 @@ describe("social scrape memory preflight scheduling", () => {
   beforeEach(() => {
     vi.useRealTimers();
     mocks.invoke.mockReset();
+    mocks.recordRuntimeHealthEvent.mockReset();
   });
 
   it("reuses the failed preflight result instead of stampeding other providers", async () => {
@@ -163,6 +181,22 @@ describe("social scrape memory preflight scheduling", () => {
       includeStorageSizes: true,
       preciseWebkitAttribution: true,
     });
+    expect(mocks.recordRuntimeHealthEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: "renderer_memory_attribution",
+        reason: "startup",
+        shellBaselineMainRendererResidentBytes:
+          after.webkitProcesses[0].residentBytes,
+        shellBaselineMainRendererProcessId: after.webkitProcesses[0].processId,
+        shellBaselineMainRendererStartedAtUnixSeconds:
+          after.webkitProcesses[0].startedAtUnixSeconds,
+        shellBaselineMainRendererStartedAtUnixMicros:
+          after.webkitProcesses[0].startedAtUnixMicros,
+        mainRendererResidentOverShellBaselineBytes: 0,
+        shellBaselineComparisonStatus: "same_process",
+        webkitTotalResidentBytes: after.webkitTotalResidentBytes,
+      }),
+    );
 
     await vi.advanceTimersByTimeAsync(30_000);
     await flushPromises();

--- a/packages/desktop/src/lib/memory-monitor.ts
+++ b/packages/desktop/src/lib/memory-monitor.ts
@@ -2,6 +2,7 @@ import { invoke, isTauri } from "@tauri-apps/api/core";
 import { setRuntimeMemory, type RuntimeMemorySnapshot } from "@freed/ui/lib/debug-store";
 import { getStatus as getContentFetcherStatus } from "./content-fetcher";
 import { log } from "./logger";
+import { recordRuntimeHealthEvent } from "./runtime-health-events";
 
 const MEMORY_SAMPLE_INTERVAL_MS = 60_000;
 const MEMORY_LOG_INTERVAL = 4;
@@ -35,6 +36,8 @@ interface NativeRuntimeMemoryStats {
   webkitLargestRole?: string;
   webkitProcesses?: Array<{
     processId: number;
+    startedAtUnixSeconds?: number;
+    startedAtUnixMicros?: number;
     residentBytes: number;
     footprintBytes?: number;
     virtualBytes: number;
@@ -115,22 +118,152 @@ function getRendererMemoryStats(): BrowserMemoryStats | null {
  *
  * Recorded once per app launch, at the first sample taken before hydration.
  */
-let shellBaselineWebkitResidentBytes: number | undefined;
+let shellBaselineMainRendererResidentBytes: number | undefined;
+let shellBaselineMainRendererProcessId: number | undefined;
+let shellBaselineMainRendererStartedAtUnixSeconds: number | undefined;
+let shellBaselineMainRendererStartedAtUnixMicros: number | undefined;
 let shellBaselineCapturedAtMs: number | undefined;
+let shellBaselineCapturePromise: Promise<boolean> | undefined;
+let documentHydrationStartedAtMs: number | undefined;
 let documentHydratedAtMs: number | undefined;
 
+export function recordDocumentHydrationStarted(): void {
+  documentHydrationStartedAtMs ??= Date.now();
+}
+
 export function recordDocumentHydrated(): void {
-  documentHydratedAtMs ??= Date.now();
+  if (documentHydratedAtMs !== undefined) return;
+  recordDocumentHydrationStarted();
+  documentHydratedAtMs = Date.now();
+  recordRuntimeHealthEvent({
+    event: "memory_document_hydrated",
+    shellBaselineMainRendererResidentBytes,
+    shellBaselineMainRendererProcessId,
+    shellBaselineMainRendererStartedAtUnixSeconds,
+    shellBaselineMainRendererStartedAtUnixMicros,
+    shellBaselineCaptured: shellBaselineMainRendererResidentBytes !== undefined,
+  });
 }
 
 export function getShellBaselineBytes(): number | undefined {
-  return shellBaselineWebkitResidentBytes;
+  return shellBaselineMainRendererResidentBytes;
+}
+
+function findMainRendererProcess(
+  native: Pick<
+    NativeRuntimeMemoryStats,
+    "webkitAttributionPrecise" | "webkitProcesses"
+  >,
+): NonNullable<NativeRuntimeMemoryStats["webkitProcesses"]>[number] | undefined {
+  if (!native.webkitAttributionPrecise) return undefined;
+  const rootedCandidates =
+    native.webkitProcesses?.filter(
+      (process) =>
+        process.role === "freed-webcontent" &&
+        process.startedAtUnixSeconds !== undefined &&
+        process.startedAtUnixSeconds > 0 &&
+        process.startedAtUnixMicros !== undefined &&
+        Number.isSafeInteger(process.startedAtUnixMicros) &&
+        process.startedAtUnixMicros > 0,
+    ) ?? [];
+  return rootedCandidates.length === 1 ? rootedCandidates[0] : undefined;
+}
+
+function captureShellBaselineFromNative(
+  native: Pick<
+    NativeRuntimeMemoryStats,
+    "webkitAttributionPrecise" | "webkitTelemetryAvailable" | "webkitProcesses"
+  >,
+): boolean {
+  const mainRenderer = findMainRendererProcess(native);
+  if (
+    shellBaselineMainRendererResidentBytes !== undefined ||
+    documentHydrationStartedAtMs !== undefined ||
+    !native.webkitTelemetryAvailable ||
+    !mainRenderer ||
+    mainRenderer.residentBytes <= 0
+  ) {
+    return false;
+  }
+  shellBaselineMainRendererResidentBytes = mainRenderer.residentBytes;
+  shellBaselineMainRendererProcessId = mainRenderer.processId;
+  shellBaselineMainRendererStartedAtUnixSeconds =
+    mainRenderer.startedAtUnixSeconds;
+  shellBaselineMainRendererStartedAtUnixMicros =
+    mainRenderer.startedAtUnixMicros;
+  shellBaselineCapturedAtMs = Date.now();
+  return true;
+}
+
+/**
+ * Capture the WebKit shell before the Automerge document starts loading.
+ *
+ * `startMemoryMonitor()` runs only after the store reports initialized. Calling
+ * it there is correct for pressure handling but too late for attribution. App
+ * startup primes this probe before legal and document initialization. The store
+ * also primes it as a fallback, then closes the baseline window before
+ * `initDoc()` begins.
+ *
+ * Measurement is never a startup dependency. Callers deliberately do not await
+ * this promise. The sample disables storage scans but requires rooted WebKit
+ * attribution and a process start time. If it does not finish before hydration
+ * starts, or cannot prove one exact main renderer, it is discarded.
+ */
+export async function captureShellMemoryBaseline(): Promise<boolean> {
+  if (
+    shellBaselineMainRendererResidentBytes !== undefined ||
+    documentHydrationStartedAtMs !== undefined ||
+    !canSampleNativeMemoryStats()
+  ) {
+    return false;
+  }
+  if (shellBaselineCapturePromise) return shellBaselineCapturePromise;
+
+  const capture = (async () => {
+    try {
+      const native = await invoke<NativeRuntimeMemoryStats>("get_runtime_memory_stats", {
+        includeStorageSizes: false,
+        preciseWebkitAttribution: true,
+      });
+      const captured = captureShellBaselineFromNative(native);
+      if (captured) {
+        recordRuntimeHealthEvent({
+          event: "memory_shell_baseline",
+          mainRendererProcessId: shellBaselineMainRendererProcessId,
+          mainRendererStartedAtUnixSeconds:
+            shellBaselineMainRendererStartedAtUnixSeconds,
+          mainRendererStartedAtUnixMicros:
+            shellBaselineMainRendererStartedAtUnixMicros,
+          mainRendererResidentBytes: shellBaselineMainRendererResidentBytes,
+          webkitProcessCount: native.webkitProcessCount,
+          webkitAttributionPrecise: native.webkitAttributionPrecise,
+        });
+      }
+      return captured;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      log.warn(`[memory] shell baseline unavailable: ${message}`);
+      return false;
+    }
+  })();
+  shellBaselineCapturePromise = capture;
+  void capture.then(() => {
+    if (shellBaselineCapturePromise === capture) {
+      shellBaselineCapturePromise = undefined;
+    }
+  });
+  return capture;
 }
 
 /** Test seam: clears the once-per-launch baseline. */
 export function resetMemoryAttributionForTests(): void {
-  shellBaselineWebkitResidentBytes = undefined;
+  shellBaselineMainRendererResidentBytes = undefined;
+  shellBaselineMainRendererProcessId = undefined;
+  shellBaselineMainRendererStartedAtUnixSeconds = undefined;
+  shellBaselineMainRendererStartedAtUnixMicros = undefined;
   shellBaselineCapturedAtMs = undefined;
+  shellBaselineCapturePromise = undefined;
+  documentHydrationStartedAtMs = undefined;
   documentHydratedAtMs = undefined;
 }
 
@@ -333,17 +466,7 @@ async function sampleRuntimeMemory(
   // before the document is hydrated. Taking it later would fold the Automerge
   // document into the "baseline" and make the delta meaningless, which is the
   // specific way this measurement is easy to get wrong.
-  const baselineCandidateBytes = native.webkitTotalResidentBytes;
-  if (
-    shellBaselineWebkitResidentBytes === undefined &&
-    documentHydratedAtMs === undefined &&
-    native.webkitTelemetryAvailable &&
-    baselineCandidateBytes !== undefined &&
-    baselineCandidateBytes > 0
-  ) {
-    shellBaselineWebkitResidentBytes = baselineCandidateBytes;
-    shellBaselineCapturedAtMs = Date.now();
-  }
+  captureShellBaselineFromNative(native);
   const limits = {
     highBytes:
       native.memoryHighBytes ??
@@ -366,6 +489,22 @@ async function sampleRuntimeMemory(
     native.webkitTotalResidentBytes ?? native.webkitResidentBytes ?? 0,
   );
   peakRelayDocBytes = Math.max(peakRelayDocBytes, native.relayDocBytes);
+  const baselineMainRenderer =
+    shellBaselineMainRendererProcessId === undefined ||
+    shellBaselineMainRendererStartedAtUnixMicros === undefined
+      ? undefined
+      : native.webkitProcesses?.find(
+          (process) =>
+            process.processId === shellBaselineMainRendererProcessId &&
+            process.startedAtUnixMicros ===
+              shellBaselineMainRendererStartedAtUnixMicros,
+        );
+  const shellBaselineComparisonStatus =
+    shellBaselineMainRendererResidentBytes === undefined
+      ? "not_captured"
+      : baselineMainRenderer
+        ? "same_process"
+        : "process_unavailable";
 
   const snapshot: RuntimeMemorySnapshot = {
     totalPhysicalMemoryBytes: native.totalPhysicalMemoryBytes,
@@ -416,18 +555,24 @@ async function sampleRuntimeMemory(
     // desktop app the three fields above are always undefined; without this
     // flag that reads as "the JS heap is negligible" rather than "unmeasured".
     rendererHeapAvailable: renderer !== null,
-    // Attribution terms. shellBaseline is captured once per launch before the
-    // document is hydrated; the delta against it is the measured cost of
-    // everything Freed loads on top of an empty renderer.
-    shellBaselineWebkitResidentBytes,
-    webkitResidentOverShellBaselineBytes:
-      shellBaselineWebkitResidentBytes === undefined ||
-      native.webkitTotalResidentBytes === undefined
+    // Attribution terms. The baseline is one main renderer process captured
+    // before document hydration. A delta is valid only while that exact PID is
+    // still present. Provider WebViews and renderer replacements must never be
+    // folded into a number that looks like corpus cost.
+    shellBaselineMainRendererResidentBytes,
+    shellBaselineMainRendererProcessId,
+    shellBaselineMainRendererStartedAtUnixSeconds,
+    shellBaselineMainRendererStartedAtUnixMicros,
+    mainRendererResidentOverShellBaselineBytes:
+      shellBaselineMainRendererResidentBytes === undefined ||
+      baselineMainRenderer === undefined
         ? undefined
         : Math.max(
             0,
-            native.webkitTotalResidentBytes - shellBaselineWebkitResidentBytes,
+            baselineMainRenderer.residentBytes -
+              shellBaselineMainRendererResidentBytes,
           ),
+    shellBaselineComparisonStatus,
     shellBaselineAgeMs:
       shellBaselineCapturedAtMs === undefined
         ? undefined
@@ -448,6 +593,34 @@ async function sampleRuntimeMemory(
     native.relayDocBytes >= HIGH_RELAY_DOC_BYTES;
 
   if (!shouldLog) return;
+
+  recordRuntimeHealthEvent({
+    event: "renderer_memory_attribution",
+    reason,
+    documentHydrated: snapshot.documentHydrated,
+    shellBaselineMainRendererResidentBytes:
+      snapshot.shellBaselineMainRendererResidentBytes,
+    shellBaselineMainRendererProcessId:
+      snapshot.shellBaselineMainRendererProcessId,
+    shellBaselineMainRendererStartedAtUnixSeconds:
+      snapshot.shellBaselineMainRendererStartedAtUnixSeconds,
+    shellBaselineMainRendererStartedAtUnixMicros:
+      snapshot.shellBaselineMainRendererStartedAtUnixMicros,
+    mainRendererResidentOverShellBaselineBytes:
+      snapshot.mainRendererResidentOverShellBaselineBytes,
+    shellBaselineComparisonStatus: snapshot.shellBaselineComparisonStatus,
+    appResidentBytes: snapshot.appResidentBytes,
+    appMemoryPressureBytes: snapshot.appMemoryPressureBytes,
+    webkitTotalResidentBytes: snapshot.webkitTotalResidentBytes,
+    webkitLargestProcessId: snapshot.webkitLargestProcessId,
+    webkitLargestResidentBytes: snapshot.webkitLargestResidentBytes,
+    webkitProcessCount: snapshot.webkitProcessCount,
+    automergeBinaryBytes: snapshot.automergeBinaryBytes,
+    automergeItemCount: snapshot.automergeItemCount,
+    indexedDbBytes: snapshot.indexedDbBytes,
+    webkitCacheBytes: snapshot.webkitCacheBytes,
+    rendererHeapAvailable: snapshot.rendererHeapAvailable,
+  });
 
   const level =
     pressureLevel !== "normal" ||

--- a/packages/desktop/src/lib/store-startup-migrations.test.ts
+++ b/packages/desktop/src/lib/store-startup-migrations.test.ts
@@ -14,7 +14,10 @@ const {
   mockDocDeduplicateFeedItems,
   mockDocHealUntitledFeedTitles,
   mockDocPruneArchivedItems,
+  mockCaptureShellMemoryBaseline,
   mockInitDoc,
+  mockRecordDocumentHydrated,
+  mockRecordDocumentHydrationStarted,
   mockRunBackgroundJob,
   mockStartOutboxProcessor,
   mockSubscribe,
@@ -24,7 +27,10 @@ const {
   mockDocDeduplicateFeedItems: vi.fn(),
   mockDocHealUntitledFeedTitles: vi.fn(),
   mockDocPruneArchivedItems: vi.fn(),
+  mockCaptureShellMemoryBaseline: vi.fn(),
   mockInitDoc: vi.fn(),
+  mockRecordDocumentHydrated: vi.fn(),
+  mockRecordDocumentHydrationStarted: vi.fn(),
   mockRunBackgroundJob: vi.fn(),
   mockStartOutboxProcessor: vi.fn(),
   mockSubscribe: vi.fn(),
@@ -84,6 +90,12 @@ vi.mock("./platform-actions", () => ({
 
 vi.mock("./outbox", () => ({
   startOutboxProcessor: mockStartOutboxProcessor,
+}));
+
+vi.mock("./memory-monitor", () => ({
+  captureShellMemoryBaseline: mockCaptureShellMemoryBaseline,
+  recordDocumentHydrated: mockRecordDocumentHydrated,
+  recordDocumentHydrationStarted: mockRecordDocumentHydrationStarted,
 }));
 
 vi.mock("./desktop-client-registration", () => ({
@@ -154,6 +166,8 @@ describe("store startup migrations", () => {
     mockDocHealUntitledFeedTitles.mockResolvedValue(undefined);
     mockDocPruneArchivedItems.mockReset();
     mockDocPruneArchivedItems.mockResolvedValue(undefined);
+    mockCaptureShellMemoryBaseline.mockReset();
+    mockCaptureShellMemoryBaseline.mockResolvedValue(true);
     mockInitDoc.mockReset();
     mockInitDoc.mockResolvedValue(createDocState());
     mockRunBackgroundJob.mockReset();
@@ -163,6 +177,8 @@ describe("store startup migrations", () => {
     mockSubscribe.mockReset();
     mockSubscribe.mockReturnValue(mockUnsubscribe);
     mockUnsubscribe.mockReset();
+    mockRecordDocumentHydrated.mockReset();
+    mockRecordDocumentHydrationStarted.mockReset();
     localStorage.clear();
     resetDeviceDisplayPreferencesForTests();
     resetFacebookGroupDiscoveryForTests();
@@ -171,6 +187,49 @@ describe("store startup migrations", () => {
   afterEach(() => {
     vi.useRealTimers();
     localStorage.clear();
+  });
+
+  it("primes the shell baseline and closes its window before loading the document", async () => {
+    const order: string[] = [];
+    mockCaptureShellMemoryBaseline.mockImplementation(async () => {
+      order.push("baseline");
+      return true;
+    });
+    mockRecordDocumentHydrationStarted.mockImplementation(() => {
+      order.push("hydration-started");
+    });
+    mockInitDoc.mockImplementation(async () => {
+      order.push("document");
+      return createDocState();
+    });
+    mockRecordDocumentHydrated.mockImplementation(() => {
+      order.push("hydrated");
+    });
+    const { useAppStore } = await import("./store");
+
+    await useAppStore.getState().initialize();
+
+    expect(order.slice(0, 4)).toEqual([
+      "baseline",
+      "hydration-started",
+      "document",
+      "hydrated",
+    ]);
+  });
+
+  it("does not await a stalled shell measurement", async () => {
+    mockCaptureShellMemoryBaseline.mockReturnValue(new Promise(() => {}));
+    const { useAppStore } = await import("./store");
+
+    await expect(useAppStore.getState().initialize()).resolves.toBeUndefined();
+
+    expect(mockInitDoc).toHaveBeenCalledTimes(1);
+    expect(mockRecordDocumentHydrationStarted.mock.invocationCallOrder[0]).toBeLessThan(
+      mockInitDoc.mock.invocationCallOrder[0],
+    );
+    expect(mockRecordDocumentHydrated.mock.invocationCallOrder[0]).toBeGreaterThan(
+      mockInitDoc.mock.invocationCallOrder[0],
+    );
   });
 
   it("defers startup maintenance instead of running it during launch", async () => {

--- a/packages/desktop/src/lib/store.ts
+++ b/packages/desktop/src/lib/store.ts
@@ -123,7 +123,11 @@ import { initLiAuth, storeLiAuthState, type LiAuthState } from "./li-auth";
 import { initSubstackAuth, type SubstackAuthState } from "./substack-auth";
 import { initMediumAuth, type MediumAuthState } from "./medium-auth";
 import { initYouTubeAuth, type YouTubeAuthState } from "./youtube-auth";
-import { recordDocumentHydrated } from "./memory-monitor";
+import {
+  captureShellMemoryBaseline,
+  recordDocumentHydrated,
+  recordDocumentHydrationStarted,
+} from "./memory-monitor";
 import { onCloudReconciled } from "./cloud-reconcile-signal";
 import { reconcileSocialAuthStateHints } from "./social-auth-cookie-state";
 import { getOrCreateDesktopClientRegistration } from "./desktop-client-registration";
@@ -695,8 +699,14 @@ export const useAppStore = create<AppState>((set, get) => ({
       try {
         set({ isLoading: true });
 
-        // initDoc() now returns DocState (pre-hydrated, WASM ran in worker).
+        // Prime the empty-shell probe before initDoc materializes the corpus.
+        // This is intentionally fire-and-forget: telemetry must never delay
+        // startup. The hydration-start marker below rejects a late result.
+        void captureShellMemoryBaseline();
         const desktopClientRegistration = await getOrCreateDesktopClientRegistration();
+
+        // initDoc() now returns DocState (pre-hydrated, WASM ran in worker).
+        recordDocumentHydrationStarted();
         assertDesktopStoreWritable();
         const docState = await initDoc(desktopClientRegistration);
         // Closes the shell-baseline window. Any memory sample after this point

--- a/packages/ui/src/lib/debug-store.ts
+++ b/packages/ui/src/lib/debug-store.ts
@@ -75,6 +75,7 @@ export interface RuntimeMemorySnapshot {
   webkitLargestRole?: string;
   webkitProcesses?: Array<{
     processId: number;
+    startedAtUnixSeconds?: number;
     residentBytes: number;
     footprintBytes?: number;
     virtualBytes: number;
@@ -114,15 +115,18 @@ export interface RuntimeMemorySnapshot {
    * nobody has measured.
    */
   rendererHeapAvailable?: boolean;
-  /**
-   * WebKit resident bytes sampled before the Automerge document was hydrated,
-   * captured once per launch. This is the WebKit shell plus React baseline, the
-   * largest single unmeasured term in the storage roadmap's floor estimates
-   * (independent passes put it anywhere from 60 to 250 MB).
-   */
-  shellBaselineWebkitResidentBytes?: number;
-  /** Current WebKit resident minus the shell baseline: the measured cost of everything Freed loads on top of an empty renderer. */
-  webkitResidentOverShellBaselineBytes?: number;
+  /** Main renderer RSS sampled before Automerge hydration, captured once per launch. */
+  shellBaselineMainRendererResidentBytes?: number;
+  /** PID that owns the shell baseline. Later samples are comparable only while this process survives. */
+  shellBaselineMainRendererProcessId?: number;
+  /** Native process start time paired with the PID so PID reuse cannot resurrect an old baseline. */
+  shellBaselineMainRendererStartedAtUnixSeconds?: number;
+  /** Native microsecond process start identity used for exact same-process comparisons. */
+  shellBaselineMainRendererStartedAtUnixMicros?: number;
+  /** Same-process main renderer growth since the shell baseline. This is undefined after renderer replacement. */
+  mainRendererResidentOverShellBaselineBytes?: number;
+  /** Why a same-process comparison is or is not available for this sample. */
+  shellBaselineComparisonStatus?: "not_captured" | "same_process" | "process_unavailable";
   shellBaselineAgeMs?: number;
   /** Whether the document had been hydrated when this sample was taken. A baseline is only valid from a pre-hydration sample. */
   documentHydrated?: boolean;


### PR DESCRIPTION
(AI Generated).

## Summary
- Capture the main-renderer baseline before document hydration without delaying startup.
- Bind attribution to native app and renderer process identities at microsecond precision, rejecting prior launches and PID reuse.
- Persist attributable local runtime-health telemetry without changing provider requests, navigation, retries, cookies, headers, extraction, or cadence.

## Testing
- 21 focused Desktop memory and startup tests plus 3 native WebKit process-generation tests passed.
- Scoped validation passed root, PWA, Desktop unit, provider E2E, feed, graph, map, sidebar, settings, production build, Clippy, and 159 native tests.
- The Friends performance benchmark reported 13 long tasks against a budget of 2; exact untouched dev reproduced the same 13 against 2, and #1196 tracks the inherited nondeterminism.
- Roadmap status, main backflow, provider artifact, provider classifier, and diff checks passed.

## Provider Review
- Status: Provider authority is validated for ready publication.
- Review action: none required. The provider-risk artifact records the behavior authority decision; this exact provider subdiff is the audit subject.
- Provider subdiff: `741bb3bf71f55392798b8c4c7c84116d618147d6`
- Publication does not authorize new live provider traffic. Gate 1 behavior approval still applies when observable behavior changes.
- Provider review task: `memory-attribution-startup`
- Provider review decision: `diff_authorized`
- Provider review artifact: `99c0add8d1d966339dcf568b3136d0bba6dbd470cc70c20b29ca2782e160e128`
- Providers: facebook, instagram, linkedin, medium, other, substack, x, youtube
- Observable behavior: No provider-observable behavior changes. The diff records a nonblocking main-renderer memory baseline before document hydration, rejects cross-process comparisons, and emits local runtime-health telemetry.
- Fingerprinting risk: None introduced. The change adds no provider request, navigation, WebView load, retry, cookie, header, extraction, scrolling, clicking, or cadence change.
- Lowest profile alternative: Keep provider traffic disabled during validation and measure only local process identity, memory, and offline fixtures.

Files bound into this provider review:
- `packages/desktop/src-tauri/src/lib.rs`
- `packages/desktop/src/App.tsx`
- `packages/desktop/src/lib/memory-monitor.ts`
- `packages/desktop/src/lib/store.ts`