### PR TITLE
fix: inherit cancelled release metadata receipts

### DIFF
--- a/scripts/validate-dev-integration-receipt.mjs
+++ b/scripts/validate-dev-integration-receipt.mjs
@@ -13,6 +13,11 @@ import { isReleaseOnlyFile } from "./release-promotion-shared.mjs";
 const DEFAULT_REPOSITORY = "freed-project/freed";
 const DEFAULT_BRANCH = "dev";
 const DEFAULT_WORKFLOW = "ci.yml";
+const BLOCKING_CONCLUSIONS = new Set([
+  "action_required",
+  "failure",
+  "timed_out",
+]);
 
 function fail(message) {
   throw new Error(message);
@@ -193,7 +198,9 @@ export function selectIntegrationReceipt(
       run.event === "push",
   );
   const exactFailure = exactRuns.find(
-    (run) => run.status === "completed" && run.conclusion !== "success",
+    (run) =>
+      run.status === "completed" &&
+      BLOCKING_CONCLUSIONS.has(run.conclusion),
   );
   if (exactFailure || !inheritedFromSha) {
     return selectExactIntegrationReceipt(payload, options);

--- a/scripts/validate-dev-integration-receipt.test.mjs
+++ b/scripts/validate-dev-integration-receipt.test.mjs
@@ -133,6 +133,25 @@ test("a failed exact run cannot be replaced by an inherited receipt", () => {
   );
 });
 
+test("a cancelled metadata-only run may inherit the successful parent receipt", () => {
+  const parentSha = "b".repeat(40);
+  const receipt = selectIntegrationReceipt(
+    {
+      workflow_runs: [
+        run({ conclusion: "cancelled" }),
+        run({ id: 41, head_sha: parentSha }),
+      ],
+    },
+    OPTIONS,
+    { inheritedFromSha: parentSha },
+  );
+
+  assert.equal(receipt.schemaVersion, 2);
+  assert.equal(receipt.headSha, OPTIONS.sha);
+  assert.equal(receipt.validationHeadSha, parentSha);
+  assert.equal(receipt.runId, 41);
+});
+
 function git(cwd, args) {
   return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
 }


### PR DESCRIPTION
(AI Generated).

## Summary
- 

## Testing
- Not run, no focused validation was recorded.