### PR TITLE
perf: scope dev tooling validation to changed paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [dev, main]
 
-# Superseded dev pushes cancel too. Only the latest dev tree carries the full
+# Superseded dev pushes cancel too. Only the latest dev tree carries the
 # integration proof that release admission inherits, so validating an
 # intermediate commit that a newer push already replaced is wasted runner time.
 concurrency:
@@ -43,13 +43,24 @@ jobs:
         with:
           node-version-file: ".nvmrc"
 
-      # A push to dev runs the full lane. That is the one full integration proof
-      # on the protected tree, and release admission inherits it by receipt.
+      # Dev keeps the full application integration job below. Tooling smoke is
+      # scoped to the merged delta because exhaustive tooling coverage belongs
+      # to the nightly lane. A missing push base fails closed to the full lane.
       - name: Resolve tooling smoke plan
         id: plan
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
         run: |
           if [ "${{ github.event_name }}" = "push" ]; then
-            node scripts/plan-tooling-smoke.mjs --all --github-output
+            if [ -n "$BEFORE_SHA" ] \
+              && ! [[ "$BEFORE_SHA" =~ ^0+$ ]] \
+              && git cat-file -e "${BEFORE_SHA}^{commit}"; then
+              node scripts/plan-tooling-smoke.mjs \
+                --base-ref "$BEFORE_SHA" \
+                --github-output
+            else
+              node scripts/plan-tooling-smoke.mjs --all --github-output
+            fi
           else
             git fetch --no-tags origin "${{ github.base_ref }}"
             node scripts/plan-tooling-smoke.mjs \
@@ -87,8 +98,9 @@ jobs:
     # DEFAULT_MAX_JOBS in scripts/lib/tooling-smoke-plan.mjs.
     #
     # This is a ceiling for the full lane, not a target. Ordinary PRs select
-    # zero or one suite and finish in minutes; only a scripts/ change or a push
-    # to dev pays the whole cost. Suite runtimes are tracked separately as debt.
+    # zero or one suite and finish in minutes. Only a change that invalidates
+    # the planner itself pays the whole cost. Suite runtimes are tracked
+    # separately as debt.
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.tooling-smoke-plan.outputs.matrix) }}

--- a/scripts/plan-tooling-smoke.mjs
+++ b/scripts/plan-tooling-smoke.mjs
@@ -2,9 +2,9 @@
 // Decide which tooling smoke suites a change can actually affect, and spread a
 // fixed job budget across them. Emits a GitHub Actions matrix.
 //
-// Ordinary pull requests get changed-path scoping. A push to dev gets the full
-// lane, because dev carries the one full integration proof that release
-// admission later inherits.
+// Pull requests and pushes to dev get changed-path scoping. The separate dev
+// integration job carries the full application proof that release admission
+// later inherits. Exhaustive tooling coverage runs nightly.
 
 import { spawnSync } from "node:child_process";
 import { appendFileSync } from "node:fs";

--- a/scripts/run-tooling-smoke-shard.test.mjs
+++ b/scripts/run-tooling-smoke-shard.test.mjs
@@ -330,9 +330,22 @@ test("validation workflow preserves the complete tooling smoke gate", () => {
   assert.match(workflow, /--shard-count=\$\{\{ matrix\.shardCount \}\}/);
   assert.match(workflow, /tooling-smoke-results\/\*\.xml/);
 
-  // A push to dev must still run every suite. That run is the full integration
-  // proof, so scoping it by changed paths would break release admission.
+  // Dev retains the full application integration job, while tooling smoke
+  // scopes itself to the merged delta. Missing push history fails closed.
+  assert.match(workflow, /--base-ref "\$BEFORE_SHA"/);
+  assert.match(workflow, /git cat-file -e "\$\{BEFORE_SHA\}\^\{commit\}"/);
   assert.match(workflow, /plan-tooling-smoke\.mjs --all --github-output/);
+
+  const nightlyWorkflow = readFileSync(
+    path.join(
+      process.cwd(),
+      ".github",
+      "workflows",
+      "tooling-nightly.yml",
+    ),
+    "utf8",
+  );
+  assert.match(nightlyWorkflow, /node scripts\/measure-tooling-smoke\.mjs/);
 
   // The gate observes the planner, the shards, and the native lane together.
   assert.match(

--- a/scripts/validate-worktree.mjs
+++ b/scripts/validate-worktree.mjs
@@ -596,7 +596,7 @@ export function collectReleaseArtifactsToValidate(
   validateAll = false,
 ) {
   const artifacts = new Set();
-  let shouldValidateAll = validateAll;
+  const shouldValidateAll = validateAll;
 
   for (const filePath of changedFiles) {
     if (/^release-notes\/releases\/.+\.json$/.test(filePath)) {
@@ -611,12 +611,12 @@ export function collectReleaseArtifactsToValidate(
       }
       continue;
     }
-
-    if (/^release-notes\/daily\/.+\.json$/.test(filePath)) {
-      shouldValidateAll = true;
-    }
   }
 
+  // Daily artifacts contain editorial guidance, not release contracts. A
+  // release-prep change also carries its exact release JSON, which is added
+  // above. Replaying every historical release because the daily timestamp
+  // changed adds no distinct coverage.
   if (shouldValidateAll) {
     for (const artifactPath of listAllReleaseArtifacts()) {
       artifacts.add(artifactPath);

--- a/scripts/validate-worktree.test.mjs
+++ b/scripts/validate-worktree.test.mjs
@@ -674,3 +674,53 @@ test("collectReleaseArtifactsToValidate resolves markdown artifacts to their jso
 
   assert.deepEqual(artifacts, ["release-notes/releases/v26.4.1602.json"]);
 });
+
+test("daily release metadata does not replay the historical release archive", () => {
+  const dailyArtifact = [
+    "release-notes",
+    "daily",
+    "dev",
+    "26.7.27.json",
+  ].join("/");
+  const releaseArtifact = [
+    "release-notes",
+    "releases",
+    "v26.7.2701-dev",
+  ].join("/");
+
+  assert.deepEqual(
+    collectReleaseArtifactsToValidate([dailyArtifact]),
+    [],
+  );
+
+  assert.deepEqual(
+    collectReleaseArtifactsToValidate([
+      dailyArtifact,
+      `${releaseArtifact}.json`,
+      `${releaseArtifact}.md`,
+    ]),
+    [`${releaseArtifact}.json`],
+  );
+});
+
+test("feature release prep validates only the changed release artifact", () => {
+  const dailyArtifact = [
+    "release-notes",
+    "daily",
+    "dev",
+    "26.7.27.json",
+  ].join("/");
+  const releaseArtifact = [
+    "release-notes",
+    "releases",
+    "v26.7.2701-dev",
+  ].join("/");
+  const releaseValidation = buildValidationPlan("feature", [
+    dailyArtifact,
+    `${releaseArtifact}.json`,
+    `${releaseArtifact}.md`,
+  ]).find((item) => item.label === "release note artifact validation");
+
+  assert.ok(releaseValidation);
+  assert.deepEqual(releaseValidation.files, [`${releaseArtifact}.json`]);
+});


### PR DESCRIPTION
(AI Generated).

## Summary

- keep the full application integration proof on protected dev
- scope tooling smoke on dev pushes to the actual merged path set instead of forcing every suite
- fail closed to the full tooling lane when the prior dev commit cannot be resolved
- retain exhaustive tooling measurement in the nightly workflow
- validate only the changed release artifact instead of replaying the historical release archive when daily editorial metadata changes

## Testing

- npm run validate:feature
- 37 validation-runner contract tests
- 22 tooling-runner contract tests
- workflow YAML parse
- release metadata and focused receipt paths plan zero tooling jobs and no native macOS job

## Expected effect

Organizational and release-metadata merges keep the exact dev application proof but stop paying for unrelated outcome-ledger, automation-control, kernel-guard, general tooling, and native actor suites. Changes to the validation workflow itself still invalidate the full tooling lane, and missing push history still fails closed.