### PR TITLE
fix: recognize promoted updater manifest backflow

### DIFF
--- a/scripts/release-promotion-shared.mjs
+++ b/scripts/release-promotion-shared.mjs
@@ -45,6 +45,7 @@ const HISTORICAL_MAIN_BACKPORT_SUBJECTS = new Set([
 const HISTORICAL_MAIN_PROMOTION_SUBJECTS = new Set([
   "chore: promote dev into main for cloud conflict recovery (#784)",
   "chore: promote dev into main for PWA sync recovery (#798)",
+  "chore: promote updater asset url fix to main (#313)",
 ]);
 export const REVERSE_INTEGRATION_COMMIT_SUBJECT_PATTERN =
   /^(?:chore|fix): (?:merge main (?:back )?into dev(?: .*)?|reverse integrate (?:main|v\d+\.\d+\.\d+)(?: into dev| after v\d+\.\d+\.\d+| production release)?|backflow v\d+\.\d+\.\d+ main into dev|sync main(?: release artifacts)?(?: back)? into dev(?: .*)?)(?: \(#\d+\))?$/;

--- a/scripts/release-promotion.test.mjs
+++ b/scripts/release-promotion.test.mjs
@@ -434,6 +434,7 @@ test("validate-main-backflow accepts the historical promote dev to main subject"
 for (const subject of [
   "chore: promote dev into main for cloud conflict recovery (#784)",
   "chore: promote dev into main for PWA sync recovery (#798)",
+  "chore: promote updater asset url fix to main (#313)",
 ]) {
   test(`validate-main-backflow accepts reviewed historical promotion ${subject}`, (t) => {
     const cwd = makeTempRepo();


### PR DESCRIPTION
(AI Generated).

## Summary
- Recognize the exact historical updater URL promotion only when its reviewed blob already exists in dev history.
- Keep novel-content and rollback detection fail-closed.

## Testing
- node --test scripts/release-promotion.test.mjs (38 passed)
- node scripts/validate-main-backflow.mjs --dev-ref=HEAD --main-ref=origin/main
- npm run validate:feature