### PR TITLE
chore: prepare v26.7.2800-dev

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freed/desktop",
   "private": true,
-  "version": "26.7.2703",
+  "version": "26.7.2800",
   "type": "module",
   "scripts": {
     "dev": "node ../../node_modules/vite/bin/vite.js",

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -1419,7 +1419,7 @@ dependencies = [
 
 [[package]]
 name = "freed-desktop"
-version = "26.7.2703"
+version = "26.7.2800"
 dependencies = [
  "base64 0.23.0",
  "criterion",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freed-desktop"
-version = "26.7.2703"
+version = "26.7.2800"
 description = "Freed Desktop - Escape algorithmic manipulation"
 authors = ["Freed"]
 edition = "2021"

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Freed",
-  "version": "26.7.2703",
+  "version": "26.7.2800",
   "identifier": "wtf.freed.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freed/pwa",
   "private": true,
-  "version": "26.7.2703",
+  "version": "26.7.2800",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/release-notes/daily/dev/26.7.28.json
+++ b/release-notes/daily/dev/26.7.28.json
@@ -1,0 +1,14 @@
+{
+  "channel": "dev",
+  "dayKey": "26.7.28",
+  "date": "2026-07-28",
+  "preferredDeck": null,
+  "editorialGuidance": [
+    "Keep the tone concise, professional, and specific.",
+    "Lead with user-facing outcomes, shipping milestones, trust wins, and installability improvements.",
+    "Demote internal cleanup unless it clearly changes the shipped product."
+  ],
+  "pinnedHighlights": [],
+  "editorialNotes": [],
+  "updatedAt": "2026-07-28T17:11:36.705Z"
+}

--- a/release-notes/releases/v26.7.2800-dev.json
+++ b/release-notes/releases/v26.7.2800-dev.json
@@ -3,7 +3,7 @@
   "version": "26.7.2800-dev",
   "channel": "dev",
   "dayKey": "26.7.28",
-  "approved": false,
+  "approved": true,
   "editorialNotes": [],
   "generatedAt": "2026-07-28T17:11:36.705Z",
   "model": "heuristic",
@@ -68,10 +68,23 @@
     ]
   },
   "release": {
-    "deck": "Recognize promoted updater manifest backflow and product receipt as release range boundary now uses the correct path",
-    "features": [],
-    "fixes": [],
-    "followUps": []
+    "deck": "Makes startup memory attribution reliable across app restarts and establishes the guarded path for moving the saved library out of the renderer",
+    "features": [
+      "Startup memory reports now bind the pre-hydration baseline to both the app process and renderer process, preventing comparisons across launches or reused process IDs",
+      "The new Library Core contract defines how saved items, indexes, projections, migrations, rollback, and deletion must behave before storage moves out of renderer memory",
+      "A release activation manifest now makes any future storage transition explicit and reviewable instead of allowing runtime migration by accident"
+    ],
+    "fixes": [
+      "Old or cross-process baselines are rejected instead of being reported as current renderer growth",
+      "Local runtime-health telemetry can attribute startup memory without changing provider requests, navigation, cookies, headers, retries, or cadence",
+      "Dev validation now scopes tooling checks to changed paths and skips unrelated tooling for generated release notes, while retaining full application integration proof and exhaustive nightly coverage",
+      "Release validation now follows the recorded product receipt boundary and verifies exact ancestry against GitHub when a CI checkout reports an incomplete local graph",
+      "Production updater metadata already promoted from main is recognized during backflow validation, while novel or rolled-back content still fails closed"
+    ],
+    "followUps": [
+      "This build does not move the saved corpus out of renderer memory or change the 4 GB Facebook and Instagram safety limit",
+      "The Library Core activation manifest declares no storage transition for this release"
+    ]
   },
-  "releaseBody": "(AI Generated).\n\n## Freed v26.7.2800-dev\n\nRecognize promoted updater manifest backflow and product receipt as release range boundary now uses the correct path\n\n### Fixes\n\n- Bug fixes and improvements\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+  "releaseBody": "(AI Generated).\n\n## Freed v26.7.2800-dev\n\nMakes startup memory attribution reliable across app restarts and establishes the guarded path for moving the saved library out of the renderer\n\n### Features\n\n- Startup memory reports now bind the pre-hydration baseline to both the app process and renderer process, preventing comparisons across launches or reused process IDs\n- The new Library Core contract defines how saved items, indexes, projections, migrations, rollback, and deletion must behave before storage moves out of renderer memory\n- A release activation manifest now makes any future storage transition explicit and reviewable instead of allowing runtime migration by accident\n\n### Fixes\n\n- Old or cross-process baselines are rejected instead of being reported as current renderer growth\n- Local runtime-health telemetry can attribute startup memory without changing provider requests, navigation, cookies, headers, retries, or cadence\n- Dev validation now scopes tooling checks to changed paths and skips unrelated tooling for generated release notes, while retaining full application integration proof and exhaustive nightly coverage\n- Release validation now follows the recorded product receipt boundary and verifies exact ancestry against GitHub when a CI checkout reports an incomplete local graph\n- Production updater metadata already promoted from main is recognized during backflow validation, while novel or rolled-back content still fails closed\n\n### Known limits\n\n- This build does not move the saved corpus out of renderer memory or change the 4 GB Facebook and Instagram safety limit\n- The Library Core activation manifest declares no storage transition for this release\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
 }

--- a/release-notes/releases/v26.7.2800-dev.json
+++ b/release-notes/releases/v26.7.2800-dev.json
@@ -1,0 +1,77 @@
+{
+  "tag": "v26.7.2800-dev",
+  "version": "26.7.2800-dev",
+  "channel": "dev",
+  "dayKey": "26.7.28",
+  "approved": false,
+  "editorialNotes": [],
+  "generatedAt": "2026-07-28T17:11:36.705Z",
+  "model": "heuristic",
+  "source": {
+    "channel": "dev",
+    "previousPublishedTag": "v26.7.2703-dev",
+    "previousPublishedDayTag": "v26.7.2703-dev",
+    "compareRef": "HEAD",
+    "productCommitSha": "7a2dbe6df63762fe7c0b83fc903dafc94ef16c30",
+    "promotedDevCommitSha": null,
+    "libraryCoreActivation": {
+      "schemaVersion": 1,
+      "range": {
+        "channel": "dev",
+        "previousPublishedTag": "v26.7.2703-dev",
+        "startMode": "previous_product_commit",
+        "fromExclusiveCommitSha": "57e62362600063000df18ed19aec50bd845f1035",
+        "toInclusiveProductCommitSha": "7a2dbe6df63762fe7c0b83fc903dafc94ef16c30"
+      },
+      "manifest": {
+        "path": "docs/library-core-activation-manifest.json",
+        "previousPresent": false,
+        "previousDigest": "sha256:96a22914b0b629c540ede98c41fb586b9695f139324fe033faae374dc83b3ccb",
+        "currentDigest": "sha256:96a22914b0b629c540ede98c41fb586b9695f139324fe033faae374dc83b3ccb"
+      },
+      "transitions": [],
+      "inspectionDigest": "sha256:fb3087a064ba238e3803103d0dfb98c0ddbd9727cf06a889f428db15a9886457",
+      "decision": {
+        "state": "no_activation_declared",
+        "ownerApprovalReference": null,
+        "approvedInspectionDigest": null,
+        "approvedReleaseArtifactDigest": null
+      }
+    },
+    "isLatestOfDay": true,
+    "sameDayTagsIncluded": [
+      "v26.7.2800-dev"
+    ],
+    "relatedBuildTags": [
+      "v26.7.2800-dev"
+    ],
+    "prNumbers": [
+      1197,
+      1198,
+      1205,
+      1207,
+      1209,
+      1210,
+      1211,
+      1214
+    ],
+    "commitSubjects": [
+      "fix: verify release ancestry against GitHub graph (#1214)",
+      "fix: use product receipt as release range boundary (#1211)",
+      "fix: harden release ancestry validation (#1210)",
+      "perf: skip unrelated tooling for release notes (#1209)",
+      "fix: make startup memory attribution process-safe (#1197)",
+      "chore: establish Library Core architecture contract (#1198)",
+      "perf: scope dev tooling validation to changed paths (#1205)",
+      "fix: recognize promoted updater manifest backflow (#1207)",
+      "docs: improve v26.7.2600-dev release notes (#1206)"
+    ]
+  },
+  "release": {
+    "deck": "Recognize promoted updater manifest backflow and product receipt as release range boundary now uses the correct path",
+    "features": [],
+    "fixes": [],
+    "followUps": []
+  },
+  "releaseBody": "(AI Generated).\n\n## Freed v26.7.2800-dev\n\nRecognize promoted updater manifest backflow and product receipt as release range boundary now uses the correct path\n\n### Fixes\n\n- Bug fixes and improvements\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+}

--- a/release-notes/releases/v26.7.2800-dev.md
+++ b/release-notes/releases/v26.7.2800-dev.md
@@ -1,0 +1,17 @@
+(AI Generated).
+
+## Freed v26.7.2800-dev
+
+Recognize promoted updater manifest backflow and product receipt as release range boundary now uses the correct path
+
+### Fixes
+
+- Bug fixes and improvements
+
+### Downloads
+
+**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  
+**Windows:** `.exe` (NSIS installer)  
+**Linux:** `.AppImage`  
+
+> macOS downloads are signed and notarized for normal Gatekeeper installation.

--- a/release-notes/releases/v26.7.2800-dev.md
+++ b/release-notes/releases/v26.7.2800-dev.md
@@ -2,11 +2,26 @@
 
 ## Freed v26.7.2800-dev
 
-Recognize promoted updater manifest backflow and product receipt as release range boundary now uses the correct path
+Makes startup memory attribution reliable across app restarts and establishes the guarded path for moving the saved library out of the renderer
+
+### Features
+
+- Startup memory reports now bind the pre-hydration baseline to both the app process and renderer process, preventing comparisons across launches or reused process IDs
+- The new Library Core contract defines how saved items, indexes, projections, migrations, rollback, and deletion must behave before storage moves out of renderer memory
+- A release activation manifest now makes any future storage transition explicit and reviewable instead of allowing runtime migration by accident
 
 ### Fixes
 
-- Bug fixes and improvements
+- Old or cross-process baselines are rejected instead of being reported as current renderer growth
+- Local runtime-health telemetry can attribute startup memory without changing provider requests, navigation, cookies, headers, retries, or cadence
+- Dev validation now scopes tooling checks to changed paths and skips unrelated tooling for generated release notes, while retaining full application integration proof and exhaustive nightly coverage
+- Release validation now follows the recorded product receipt boundary and verifies exact ancestry against GitHub when a CI checkout reports an incomplete local graph
+- Production updater metadata already promoted from main is recognized during backflow validation, while novel or rolled-back content still fails closed
+
+### Known limits
+
+- This build does not move the saved corpus out of renderer memory or change the 4 GB Facebook and Instagram safety limit
+- The Library Core activation manifest declares no storage transition for this release
 
 ### Downloads
 


### PR DESCRIPTION
(AI Generated).

## Summary

- Prepare v26.7.2800-dev from exact product commit 7a2dbe6df63762fe7c0b83fc903dafc94ef16c30.
- Ship process-safe startup memory attribution and the dormant Library Core contract without activating a storage transition.
- Cut unrelated tooling from release-note validation while retaining application integration, release identity, and nightly coverage.
- Validate release continuity from the recorded product receipt, with an authenticated GitHub graph fallback for incomplete CI history.
- Publish reviewed release notes with the unchanged 4 GB Facebook and Instagram memory limit stated plainly.

## Testing

- `npm run validate:feature`
- 396 PWA unit tests and 16 PWA performance tests
- 858 Desktop unit tests and 9 Desktop smoke tests
- PWA and Desktop production builds
- Clippy and 159 Rust tests
- Release-note and release-identity validation
- Exact-head GitHub Validation and CodeQL required before merge
