### PR TITLE
perf: skip unrelated tooling for release notes

### DIFF
--- a/scripts/lib/tooling-smoke-plan.mjs
+++ b/scripts/lib/tooling-smoke-plan.mjs
@@ -267,6 +267,10 @@ function isRepoSurface(changedFile) {
 function hasFocusedFeatureValidation(changedFile) {
   return (
     FOCUSED_FEATURE_VALIDATION_PATHS.has(changedFile) ||
+    /^release-notes\/daily\/(?:dev|production)\/[^/]+\.json$/.test(
+      changedFile,
+    ) ||
+    /^release-notes\/releases\/v[^/]+\.(?:json|md)$/.test(changedFile) ||
     /^\.agents\/skills\/[^/]+\/SKILL\.md$/.test(changedFile) ||
     /^\.agents\/skills\/[^/]+\/agents\/openai\.yaml$/.test(changedFile)
   );

--- a/scripts/tooling-smoke-plan.test.mjs
+++ b/scripts/tooling-smoke-plan.test.mjs
@@ -185,6 +185,20 @@ test("release admission and repository configuration changes use focused feature
   assert.match(selection.reason, /explicit focused feature-validation/);
 });
 
+test("generated release artifacts do not replay unrelated tooling suites", () => {
+  const selection = selectApplicableSuites([
+    "release-notes/daily/dev/26.7.28.json",
+    "release-notes/daily/production/26.7.28.json",
+    "release-notes/releases/v26.7.2800-dev.json",
+    "release-notes/releases/v26.7.2800-dev.md",
+    "release-notes/releases/v26.7.2800.json",
+    "release-notes/releases/v26.7.2800.md",
+  ]);
+
+  assert.deepEqual(selection.suites, []);
+  assert.match(selection.reason, /explicit focused feature-validation/);
+});
+
 test("Library Core and pull request publisher paths do not duplicate focused feature validation", () => {
   const selection = selectApplicableSuites([
     ".github/workflows/main-release-validation.yml",


### PR DESCRIPTION
(AI Generated).

## Summary
- Treat generated dev and production release-note artifacts as covered by their focused release validation.
- Keep workspace version files and generated Desktop metadata out of unrelated control-plane tooling suites.
- Reduce the observed v26.7.2800-dev tooling plan from 16 general shards to zero without weakening application, native, release-note, or release-identity checks.

## Testing
- npm run validate:feature
- 14 focused planner contract tests
- Exact v26.7.2800-dev release path set plans zero tooling jobs