### PR TITLE
fix: harden release ancestry validation

### DIFF
--- a/scripts/validate-release-identity.mjs
+++ b/scripts/validate-release-identity.mjs
@@ -144,12 +144,43 @@ function readTaggedJson(cwd, tag, relativePath, label, ref = tag) {
   }
 }
 
-function gitIsAncestor(cwd, fromRef, toRef) {
-  return (
-    spawnSync("git", ["merge-base", "--is-ancestor", fromRef, toRef], {
+export function gitIsAncestor(
+  cwd,
+  fromRef,
+  toRef,
+  spawn = spawnSync,
+) {
+  const direct = spawn(
+    "git",
+    ["merge-base", "--is-ancestor", fromRef, toRef],
+    {
       cwd,
       encoding: "utf8",
-    }).status === 0
+    },
+  );
+  if (direct.status === 0) {
+    return true;
+  }
+
+  const reachableHistory = spawn("git", ["rev-list", toRef], {
+    cwd,
+    encoding: "utf8",
+  });
+  const resolvedFrom = spawn(
+    "git",
+    ["rev-parse", `${fromRef}^{commit}`],
+    {
+      cwd,
+      encoding: "utf8",
+    },
+  );
+  const resolvedFromSha = String(resolvedFrom.stdout ?? "").trim();
+  return (
+    reachableHistory.status === 0 &&
+    resolvedFrom.status === 0 &&
+    String(reachableHistory.stdout ?? "")
+      .split(/\s+/)
+      .includes(resolvedFromSha)
   );
 }
 

--- a/scripts/validate-release-identity.test.mjs
+++ b/scripts/validate-release-identity.test.mjs
@@ -20,6 +20,7 @@ import {
   releaseInspectionRange,
 } from "./release-receipt.mjs";
 import {
+  gitIsAncestor,
   parseReleaseTag,
   validateHistoricalPublishedTagIdentity,
   validateHistoricalReleaseNoteCorrectionIdentity,
@@ -27,6 +28,20 @@ import {
   validateReleaseIdentity,
 } from "./validate-release-identity.mjs";
 import { renderReleaseBody } from "./release-notes-shared.mjs";
+
+test("git ancestry falls back to an exact history walk after a direct probe fails", () => {
+  const spawn = (_command, args) => {
+    if (args.includes("--is-ancestor")) {
+      return { status: 1, stdout: "", stderr: "" };
+    }
+    if (args[0] === "rev-list") {
+      return { status: 0, stdout: "def456\nabc123\n", stderr: "" };
+    }
+    return { status: 0, stdout: "abc123\n", stderr: "" };
+  };
+
+  assert.equal(gitIsAncestor("/tmp", "abc123", "def456", spawn), true);
+});
 
 function git(cwd, args) {
   return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();


### PR DESCRIPTION
(AI Generated).

## Summary

- Fall back to an exact reachable-history walk when Git's direct ancestor probe reports a false negative.
- Preserve the release validator's fail-closed behavior for genuinely unrelated commits.
- Add focused regression coverage for the fallback.

## Testing

- `npm run validate:feature`
- 64 Library Core and release-identity tests
- Root typecheck
- Release-note shared tests
- Library Core activation manifest validation
