### PR TITLE
fix: use product receipt as release range boundary

### DIFF
--- a/scripts/release-receipt.mjs
+++ b/scripts/release-receipt.mjs
@@ -417,15 +417,10 @@ export function releaseInspectionRange({
       `Previous release product commit ${fromExclusiveCommitSha} is not an ancestor of its published tag commit ${resolvedTagCommitSha}.`,
     );
   }
-  for (const ancestorStart of new Set([
-    resolvedTagCommitSha,
-    fromExclusiveCommitSha,
-  ])) {
-    if (!isAncestor(ancestorStart, toInclusiveProductCommitSha)) {
-      throw new Error(
-        `Previous release range boundary ${ancestorStart} is not an ancestor of current product commit ${toInclusiveProductCommitSha}.`,
-      );
-    }
+  if (!isAncestor(fromExclusiveCommitSha, toInclusiveProductCommitSha)) {
+    throw new Error(
+      `Previous release range boundary ${fromExclusiveCommitSha} is not an ancestor of current product commit ${toInclusiveProductCommitSha}.`,
+    );
   }
 
   return {

--- a/scripts/release-receipt.test.mjs
+++ b/scripts/release-receipt.test.mjs
@@ -175,7 +175,6 @@ test("release inspection ranges select the exact modern, historical, or complete
   );
   assert.deepEqual(ancestryChecks, [
     [PRODUCT_SHA, TAG_SHA],
-    [TAG_SHA, CURRENT_PRODUCT_SHA],
     [PRODUCT_SHA, CURRENT_PRODUCT_SHA],
   ]);
 
@@ -327,6 +326,37 @@ test("modern release ranges reject a product commit from a fork outside the publ
       }),
     /product commit .* is not an ancestor of its published tag commit/,
   );
+});
+
+test("modern release continuity follows the recorded product boundary, not its metadata tag", () => {
+  const ancestryChecks = [];
+  const range = releaseInspectionRange({
+    channel: "dev",
+    previousPublishedTag: "v26.7.2701-dev",
+    previousSource: {
+      channel: "dev",
+      productCommitSha: PRODUCT_SHA,
+      promotedDevCommitSha: null,
+    },
+    previousTagCommitSha: TAG_SHA,
+    productCommitSha: CURRENT_PRODUCT_SHA,
+    isAncestor(from, to) {
+      ancestryChecks.push([from, to]);
+      return (
+        (from === PRODUCT_SHA && to === TAG_SHA) ||
+        (from === PRODUCT_SHA && to === CURRENT_PRODUCT_SHA)
+      );
+    },
+  });
+
+  assert.equal(
+    range.fromExclusiveCommitSha,
+    PRODUCT_SHA,
+  );
+  assert.deepEqual(ancestryChecks, [
+    [PRODUCT_SHA, TAG_SHA],
+    [PRODUCT_SHA, CURRENT_PRODUCT_SHA],
+  ]);
 });
 
 test("release inspection ranges fail closed on unsupported or unproven boundaries", () => {


### PR DESCRIPTION
(AI Generated).

## Summary

- Use the recorded previous product commit as the modern release inspection boundary.
- Continue proving that the previous product commit belongs to its published tag.
- Keep historical receipts on the tag boundary because they do not record a separate product commit.
- Cover the case where release metadata history diverges from the product history without breaking the valid product range.

## Testing

- `npm run validate:feature`
- Root typecheck
- 65 focused Library Core and release identity tests
