### PR TITLE
feat: add dormant Library Core boundary census

### DIFF
--- a/.agents/skills/freed-library-core/SKILL.md
+++ b/.agents/skills/freed-library-core/SKILL.md
@@ -36,6 +36,35 @@ Gate A includes the one-time legacy epoch bootstrap. Record it through one
 durable initialization transaction, then read it back. Never guess an initial
 epoch or infer authority from file presence.
 
+## Keep the dormant census honest
+
+The checked-in Gate A census is a compiler-enforced inventory, not activation
+authority:
+
+- synchronized schema work updates
+  `packages/shared/src/library-core/field-registry.ts`;
+- shared store contract work updates
+  `packages/shared/src/library-core/store-surface-registry.ts`;
+- Desktop and PWA worker message changes update the platform-owned
+  `library-core-worker-surface-registry.ts` beside each worker type union;
+- planned operation or query vocabulary changes update the corresponding
+  shared registry;
+- localStorage, IndexedDB, Cache API, Tauri store, native file, Keychain, or
+  operating-system session ownership changes update
+  `local-authority-registry.ts`.
+
+Run the focused registry tests and the affected platform typechecks. A new
+schema leaf, store method, or worker message must fail typecheck until
+classified. Current authority and planned authority remain separate. An
+unresolved codec, algebra, projection, retention limit, platform locator, or
+migration rule stays typed as blocked instead of receiving a plausible
+placeholder.
+
+Never infer activation from registry presence. The combined census must keep
+`activationAllowed: false` until every blocker is closed and the exact
+transition is recorded through the activation manifest and its required
+receipt.
+
 ## Preserve the invariants
 
 1. Keep exactly one active writer epoch. Advance it only with a signed immutable

--- a/docs/PHASE-4-SYNC.md
+++ b/docs/PHASE-4-SYNC.md
@@ -301,6 +301,7 @@ recovery, telemetry, milestones, and acceptance tests.
 | 4.17 | Desktop cloud sync activity in the global background monitor | ✓ | Low |
 | 4.18 | Dedicated large-media transfer lane, LAN first with encrypted user-cloud fallback | ☐ | High |
 | 4.19 | Synced Freed Desktop registration and duplicate provider request warning | ✓ | Low |
+| 4.20 | Dormant Library Core schema, mutation, query, worker-message, and local-authority census | ✓ | Medium |
 
 ---
 
@@ -330,6 +331,7 @@ recovery, telemetry, milestones, and acceptance tests.
 - [x] Desktop no-cloud-sync launch banner self-dismisses after 15 seconds with a gentle countdown ring
 - [x] Desktop writes rotating local snapshots and can restore an older Automerge copy from Settings
 - [x] Each Freed Desktop installation keeps its opaque identity locally, registers durable topology metadata after document initialization and merges, and warns in Sync setup when another Freed Desktop could duplicate RSS or authenticated provider requests. PWA readers do not count toward the warning.
+- [x] The dormant Library Core census makes current synchronized fields, shared store surfaces, Desktop and PWA worker messages, planned operations and queries, and retained local authorities reviewable without changing the active Automerge writer or claiming Gate A activation
 - [ ] iCloud sync integration
 - [ ] Large media packages transfer outside Automerge through an authenticated,
       resumable, integrity-checked path with explicit storage and deletion rules

--- a/docs/STORAGE-ARCHITECTURE-ROADMAP.md
+++ b/docs/STORAGE-ARCHITECTURE-ROADMAP.md
@@ -6,6 +6,20 @@ The normative architecture lives in
 [LIBRARY-CORE-CONTRACT.md](LIBRARY-CORE-CONTRACT.md). This roadmap records why
 the work exists, what evidence is real, and the safest delivery order.
 
+## Current implementation boundary
+
+The first Gate A delivery is a dormant census. It makes the current synchronized
+schema, shared store surface, Desktop and PWA worker messages, planned operation
+and query vocabulary, and device-local authorities reviewable by the compiler.
+It does not activate Library Core, change a writer, migrate data, or claim that
+unresolved codecs, field algebra, query projections, retention limits, or the
+legacy epoch bootstrap are complete.
+
+Every planned successor remains `planned_blocked`. The combined census reports
+`activationAllowed: false` until the executable contracts and one durable
+legacy bootstrap transaction exist. Registry presence is not an activation
+receipt.
+
 ## What the evidence establishes
 
 On the owner's 15,846-item production document, the current Automerge and
@@ -84,7 +98,7 @@ user data yet.
 | step | delivery | activation condition |
 | --- | --- | --- |
 | 0 | Process-safe memory attribution and matched tier fixtures | Exact build and process-generation evidence, no startup stall |
-| 1 | Freeze the Library Core registries, authority, and legacy epoch bootstrap | Every synchronized field has algebra, locality, deletion, and storage policy; signed actor and global epoch-transition contracts are exhaustive; one durable control transaction records the initial epoch |
+| 1 | Freeze the Library Core registries, authority, and legacy epoch bootstrap | The dormant census is complete; every synchronized field then gains executable algebra, locality, deletion, storage, operation, and query contracts; signed actor and global epoch-transition contracts are exhaustive; one durable control transaction records the initial epoch |
 | 2 | Dormant Rust SQLite core and shared operation fixtures | Crash-safe complete transaction receipts, signature and fork rejection, and identical cross-platform materialization |
 | 3 | Authenticated elected Automerge migration authority plus bounded device-local source contributions | Candidate registration is the first claim-bound mutation, and registration races state-correct candidate-absent abandonment and cleanup in one serialization domain; cloud claims use authenticated store time and expiry; local claims use null timestamps and never self-expire; every claim-bound source, candidate-registry, and cutover mutation uses a closed noncircular payload-bound grant; cloud source commits require the original runtime-owned process generation and live monotonic attempt handle; migration and rollback split corpus-sized prepared proofs from a maximum 65-fence, 2 MiB activation sidecar committed in one atomic authority bundle; rollback uses its own signed reservation and activation schema; full-field private-corpus diff, composite source identity, resumable receipts, changed-head rejection, and adapter fixture parity pass |
 | 4 | Bounded Desktop query API | Stable cursors, explicit limits, cancellation, count and search parity |

--- a/package-lock.json
+++ b/package-lock.json
@@ -14562,7 +14562,8 @@
         "@automerge/automerge": "^2.2.0"
       },
       "devDependencies": {
-        "typescript": "^5.3.0"
+        "typescript": "^5.3.0",
+        "vitest": "^4.1.10"
       }
     },
     "packages/sync": {

--- a/packages/desktop/src/lib/library-core-worker-surface-registry.test.ts
+++ b/packages/desktop/src/lib/library-core-worker-surface-registry.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "vitest";
+import { LIBRARY_CORE_OPERATION_REGISTRY } from "@freed/shared/library-core";
+
+import {
+  DESKTOP_AUTOMERGE_REQUEST_EFFECT_REGISTRY,
+  DESKTOP_AUTOMERGE_WORKER_REQUEST_SURFACE_REGISTRY,
+  DESKTOP_AUTOMERGE_WORKER_RESPONSE_SURFACE_REGISTRY,
+} from "./library-core-worker-surface-registry";
+
+describe("Desktop Library Core worker surface census", () => {
+  it("keeps every current request and response classified but blocked", () => {
+    for (const definition of [
+      ...Object.values(DESKTOP_AUTOMERGE_WORKER_REQUEST_SURFACE_REGISTRY),
+      ...Object.values(DESKTOP_AUTOMERGE_WORKER_RESPONSE_SURFACE_REGISTRY),
+    ]) {
+      expect(definition.status).toBe("planned_blocked");
+      expect(definition.blockers.length).toBeGreaterThan(0);
+      expect(definition.blockers).toContain(
+        "library_core_runtime_inactive",
+      );
+    }
+  });
+
+  it("does not blur provider intent, corpus reads, or full-state transport into ordinary mutations", () => {
+    for (const kind of [
+      "MARK_AS_READ",
+      "MARK_ITEMS_AS_READ",
+      "MARK_ALL_AS_READ",
+      "TOGGLE_LIKED",
+    ] as const) {
+      expect(
+        DESKTOP_AUTOMERGE_WORKER_REQUEST_SURFACE_REGISTRY[kind].blockers,
+        kind,
+      ).toContain("provider_intent_separation_unresolved");
+      expect(
+        DESKTOP_AUTOMERGE_WORKER_REQUEST_SURFACE_REGISTRY[kind].blockers,
+        kind,
+      ).toContain("provider_intent_execution_receipt_unresolved");
+      expect(
+        DESKTOP_AUTOMERGE_REQUEST_EFFECT_REGISTRY[kind]
+          .successorOperationIds,
+        kind,
+      ).toContain("provider_intent");
+    }
+    expect(
+      DESKTOP_AUTOMERGE_WORKER_REQUEST_SURFACE_REGISTRY
+        .RECONCILE_YOUTUBE_CAPTURE.classification,
+    ).toBe("legacy_provider_capture_authority");
+    expect(
+      DESKTOP_AUTOMERGE_WORKER_REQUEST_SURFACE_REGISTRY.GET_DOC_BINARY
+        .classification,
+    ).toBe("legacy_unbounded_read");
+    expect(
+      DESKTOP_AUTOMERGE_WORKER_RESPONSE_SURFACE_REGISTRY.STATE_UPDATE
+        .classification,
+    ).toBe("legacy_full_state_transport");
+    expect(
+      DESKTOP_AUTOMERGE_WORKER_RESPONSE_SURFACE_REGISTRY.ITEM_PATCH
+        .classification,
+    ).toBe("legacy_patch_transport");
+  });
+
+  it("censuses every request effect independently of its classification", () => {
+    for (const [kind, effect] of Object.entries(
+      DESKTOP_AUTOMERGE_REQUEST_EFFECT_REGISTRY,
+    )) {
+      if (effect.legacyWriteEffects.length === 0) continue;
+      expect(
+        effect.successorOperationIds.length > 0 ||
+          effect.blockers.length > 0,
+        kind,
+      ).toBe(true);
+    }
+
+    expect(
+      DESKTOP_AUTOMERGE_REQUEST_EFFECT_REGISTRY.CONFIRM_LIKED_SYNCED
+        .successorOperationIds,
+    ).toStrictEqual(["feed_item_like_sync_receipt"]);
+    expect(
+      DESKTOP_AUTOMERGE_REQUEST_EFFECT_REGISTRY.CONFIRM_SEEN_SYNCED
+        .successorOperationIds,
+    ).toStrictEqual(["feed_item_seen_sync_receipt"]);
+    expect(
+      DESKTOP_AUTOMERGE_REQUEST_EFFECT_REGISTRY.HEAL_UNTITLED_FEEDS
+        .successorOperationIds,
+    ).toStrictEqual(["rss_feeds_heal_untitled_frozen"]);
+    expect(
+      DESKTOP_AUTOMERGE_REQUEST_EFFECT_REGISTRY.DEDUPLICATE_ITEMS
+        .successorOperationIds,
+    ).toStrictEqual(["feed_items_deduplicate_frozen"]);
+
+    for (const kind of ["INIT", "MERGE_DOC", "REPLACE_DOC"] as const) {
+      const effect = DESKTOP_AUTOMERGE_REQUEST_EFFECT_REGISTRY[kind];
+      expect(effect.legacyWriteEffects, kind).toContain(
+        "legacy_schema_migration",
+      );
+      expect(effect.blockers, kind).toContain(
+        "hidden_legacy_write_contract_unresolved",
+      );
+    }
+
+    for (const kind of ["ADD_FEED_ITEMS", "BATCH_REFRESH_FEEDS"] as const) {
+      const effect = DESKTOP_AUTOMERGE_REQUEST_EFFECT_REGISTRY[kind];
+      expect(effect.legacyWriteEffects, kind).toContain(
+        "legacy_duplicate_removal",
+      );
+      expect(effect.successorOperationIds, kind).toContain(
+        "feed_items_deduplicate_frozen",
+      );
+    }
+  });
+
+  it("marks arbitrary diagnostic and mutation payload bytes as unbounded", () => {
+    for (const kind of [
+      "ADD_FEED_ITEM",
+      "TOGGLE_LIKED",
+      "UPDATE_FEED_ITEM",
+      "UPDATE_PREFERENCES",
+    ] as const) {
+      expect(
+        DESKTOP_AUTOMERGE_WORKER_REQUEST_SURFACE_REGISTRY[kind].blockers,
+        kind,
+      ).toContain("unbounded_payload");
+    }
+    for (const kind of ["ACK", "DEBUG_EVENT", "DEBUG_SNAPSHOT"] as const) {
+      expect(
+        DESKTOP_AUTOMERGE_WORKER_RESPONSE_SURFACE_REGISTRY[kind].blockers,
+        kind,
+      ).toContain("unbounded_payload");
+    }
+  });
+
+  it("records non-document runtime writes instead of reporting a false zero", () => {
+    expect(
+      DESKTOP_AUTOMERGE_REQUEST_EFFECT_REGISTRY.QUIESCE,
+    ).toStrictEqual({
+      legacyWriteEffects: ["legacy_runtime_state_write"],
+      successorOperationIds: [],
+      blockers: ["lifecycle_contract_unresolved"],
+    });
+    expect(
+      DESKTOP_AUTOMERGE_REQUEST_EFFECT_REGISTRY.UPDATE_RELAY_CLIENT_COUNT,
+    ).toStrictEqual({
+      legacyWriteEffects: ["legacy_runtime_state_write"],
+      successorOperationIds: [],
+      blockers: ["lifecycle_contract_unresolved"],
+    });
+  });
+
+  it("keeps every successor operation linked back to its current request", () => {
+    for (const [kind, effect] of Object.entries(
+      DESKTOP_AUTOMERGE_REQUEST_EFFECT_REGISTRY,
+    )) {
+      for (const operationId of effect.successorOperationIds) {
+        expect(
+          LIBRARY_CORE_OPERATION_REGISTRY[operationId].legacyWorkerRequests,
+          `${kind} -> ${operationId}`,
+        ).toContain(kind);
+      }
+    }
+  });
+});

--- a/packages/desktop/src/lib/library-core-worker-surface-registry.ts
+++ b/packages/desktop/src/lib/library-core-worker-surface-registry.ts
@@ -1,0 +1,556 @@
+import type { WorkerRequest, WorkerResponse } from "./automerge-types";
+import type { LibraryCoreOperationId } from "@freed/shared/library-core";
+
+export type DesktopAutomergeWorkerRequestKind = WorkerRequest["type"];
+export type DesktopAutomergeWorkerResponseKind = WorkerResponse["type"];
+
+export type LibraryCoreWorkerSurfaceClassification =
+  | "diagnostic_transport"
+  | "legacy_bulk_or_repair_authority"
+  | "legacy_full_state_transport"
+  | "legacy_lifecycle_control"
+  | "legacy_mutation_authority"
+  | "legacy_patch_transport"
+  | "legacy_progress_transport"
+  | "legacy_provider_capture_authority"
+  | "legacy_provider_receipt_authority"
+  | "legacy_replication_authority"
+  | "legacy_unbounded_read"
+  | "legacy_unbounded_transport"
+  | "mutation_acknowledgement"
+  | "relay_control";
+
+export type LibraryCoreWorkerSurfaceBlocker =
+  | "hidden_legacy_write_contract_unresolved"
+  | "legacy_authority_active"
+  | "library_core_runtime_inactive"
+  | "lifecycle_contract_unresolved"
+  | "local_authority_reset_contract_unresolved"
+  | "provider_capture_contract_unresolved"
+  | "provider_intent_execution_receipt_unresolved"
+  | "provider_intent_separation_unresolved"
+  | "query_contract_unresolved"
+  | "replication_contract_unresolved"
+  | "response_transport_not_cut_over"
+  | "successor_contract_unresolved"
+  | "unbounded_payload";
+
+type NonEmptyWorkerSurfaceBlockers = readonly [
+  LibraryCoreWorkerSurfaceBlocker,
+  ...LibraryCoreWorkerSurfaceBlocker[],
+];
+
+export interface LibraryCoreWorkerSurfaceDefinition {
+  readonly status: "planned_blocked";
+  readonly classification: LibraryCoreWorkerSurfaceClassification;
+  readonly blockers: NonEmptyWorkerSurfaceBlockers;
+}
+
+function blockedSurface(
+  classification: LibraryCoreWorkerSurfaceClassification,
+  ...blockers: readonly LibraryCoreWorkerSurfaceBlocker[]
+): LibraryCoreWorkerSurfaceDefinition {
+  return {
+    status: "planned_blocked",
+    classification,
+    blockers: ["library_core_runtime_inactive", ...blockers],
+  };
+}
+
+const lifecycleRequest = () =>
+  blockedSurface("legacy_lifecycle_control", "lifecycle_contract_unresolved");
+const mutationRequest = () =>
+  blockedSurface(
+    "legacy_mutation_authority",
+    "legacy_authority_active",
+    "successor_contract_unresolved",
+    "unbounded_payload",
+  );
+const bulkOrRepairRequest = () =>
+  blockedSurface(
+    "legacy_bulk_or_repair_authority",
+    "legacy_authority_active",
+    "successor_contract_unresolved",
+    "unbounded_payload",
+  );
+const providerReceiptRequest = () =>
+  blockedSurface(
+    "legacy_provider_receipt_authority",
+    "legacy_authority_active",
+    "provider_intent_execution_receipt_unresolved",
+    "unbounded_payload",
+  );
+const providerSeenMutationRequest = (bulk: boolean) =>
+  blockedSurface(
+    bulk
+      ? "legacy_bulk_or_repair_authority"
+      : "legacy_mutation_authority",
+    "legacy_authority_active",
+    "successor_contract_unresolved",
+    "unbounded_payload",
+    "provider_intent_separation_unresolved",
+    "provider_intent_execution_receipt_unresolved",
+  );
+const providerCaptureRequest = () =>
+  blockedSurface(
+    "legacy_provider_capture_authority",
+    "legacy_authority_active",
+    "provider_capture_contract_unresolved",
+    "unbounded_payload",
+  );
+const unboundedReadRequest = () =>
+  blockedSurface(
+    "legacy_unbounded_read",
+    "query_contract_unresolved",
+    "unbounded_payload",
+  );
+
+/**
+ * Compile-time census of the current Desktop Automerge request boundary.
+ *
+ * This registry is deliberately dormant. `satisfies Record<...>` makes a new
+ * discriminant fail typecheck until it is classified, but no entry grants
+ * Library Core authority or changes worker dispatch.
+ */
+export const DESKTOP_AUTOMERGE_WORKER_REQUEST_SURFACE_REGISTRY = {
+  INIT: blockedSurface(
+    "legacy_lifecycle_control",
+    "lifecycle_contract_unresolved",
+    "hidden_legacy_write_contract_unresolved",
+    "unbounded_payload",
+  ),
+  QUIESCE: lifecycleRequest(),
+  CLEAR_LOCAL: blockedSurface(
+    "legacy_lifecycle_control",
+    "lifecycle_contract_unresolved",
+    "local_authority_reset_contract_unresolved",
+  ),
+  REPLACE_DOC: blockedSurface(
+    "legacy_replication_authority",
+    "legacy_authority_active",
+    "replication_contract_unresolved",
+    "hidden_legacy_write_contract_unresolved",
+    "unbounded_payload",
+  ),
+  MARK_AS_READ: providerSeenMutationRequest(false),
+  MARK_ITEMS_AS_READ: providerSeenMutationRequest(true),
+  MARK_ALL_AS_READ: providerSeenMutationRequest(true),
+  TOGGLE_SAVED: mutationRequest(),
+  TOGGLE_ARCHIVED: mutationRequest(),
+  ARCHIVE_ITEMS: bulkOrRepairRequest(),
+  TOGGLE_LIKED: blockedSurface(
+    "legacy_mutation_authority",
+    "legacy_authority_active",
+    "successor_contract_unresolved",
+    "provider_intent_separation_unresolved",
+    "provider_intent_execution_receipt_unresolved",
+    "unbounded_payload",
+  ),
+  CONFIRM_LIKED_SYNCED: providerReceiptRequest(),
+  CONFIRM_SEEN_SYNCED: providerReceiptRequest(),
+  ADD_FEED_ITEM: mutationRequest(),
+  ADD_FEED_ITEMS: blockedSurface(
+    "legacy_bulk_or_repair_authority",
+    "legacy_authority_active",
+    "successor_contract_unresolved",
+    "hidden_legacy_write_contract_unresolved",
+    "unbounded_payload",
+  ),
+  RECONCILE_YOUTUBE_CAPTURE: providerCaptureRequest(),
+  RECONCILE_FOLLOW_ROSTER_CAPTURE: providerCaptureRequest(),
+  ADD_SAMPLE_LIBRARY_DATA: bulkOrRepairRequest(),
+  REMOVE_FEED_ITEM: mutationRequest(),
+  CLEAR_SAMPLE_DATA: bulkOrRepairRequest(),
+  UPDATE_FEED_ITEM: mutationRequest(),
+  ARCHIVE_ALL_READ_UNSAVED: bulkOrRepairRequest(),
+  UNARCHIVE_SAVED_ITEMS: bulkOrRepairRequest(),
+  PRUNE_ARCHIVED_ITEMS: bulkOrRepairRequest(),
+  DELETE_ALL_ARCHIVED: bulkOrRepairRequest(),
+  ADD_RSS_FEED: mutationRequest(),
+  REMOVE_RSS_FEED: mutationRequest(),
+  UPDATE_RSS_FEED: mutationRequest(),
+  REMOVE_ALL_FEEDS: bulkOrRepairRequest(),
+  UPDATE_PREFERENCES: mutationRequest(),
+  ADD_PERSON: mutationRequest(),
+  ADD_PERSONS: bulkOrRepairRequest(),
+  UPDATE_PERSON: mutationRequest(),
+  UPSERT_CONNECTION_PERSONS: bulkOrRepairRequest(),
+  REMOVE_PERSON: mutationRequest(),
+  LOG_REACH_OUT: mutationRequest(),
+  ADD_ACCOUNT: mutationRequest(),
+  ADD_ACCOUNTS: bulkOrRepairRequest(),
+  UPDATE_ACCOUNT: mutationRequest(),
+  REMOVE_ACCOUNT: mutationRequest(),
+  MERGE_DOC: blockedSurface(
+    "legacy_replication_authority",
+    "legacy_authority_active",
+    "replication_contract_unresolved",
+    "hidden_legacy_write_contract_unresolved",
+    "unbounded_payload",
+  ),
+  BATCH_REFRESH_FEEDS: blockedSurface(
+    "legacy_bulk_or_repair_authority",
+    "legacy_authority_active",
+    "successor_contract_unresolved",
+    "hidden_legacy_write_contract_unresolved",
+    "unbounded_payload",
+  ),
+  BATCH_IMPORT_ITEMS: bulkOrRepairRequest(),
+  HEAL_UNTITLED_FEEDS: bulkOrRepairRequest(),
+  DEDUPLICATE_ITEMS: bulkOrRepairRequest(),
+  BACKFILL_CONTENT_SIGNALS: bulkOrRepairRequest(),
+  GET_ALL_ITEM_IDS: unboundedReadRequest(),
+  GET_DOC_BINARY: unboundedReadRequest(),
+  GET_HEADS: unboundedReadRequest(),
+  COMPARE_DOC: unboundedReadRequest(),
+  GET_SAVED_YOUTUBE_URLS: unboundedReadRequest(),
+  GET_ITEM_PRESERVED_TEXT: unboundedReadRequest(),
+  GET_ITEM_LEGACY_HTML: unboundedReadRequest(),
+  UPDATE_RELAY_CLIENT_COUNT: blockedSurface(
+    "relay_control",
+    "lifecycle_contract_unresolved",
+  ),
+} as const satisfies Readonly<
+  Record<
+    DesktopAutomergeWorkerRequestKind,
+    LibraryCoreWorkerSurfaceDefinition
+  >
+>;
+
+type NonEmptyOperationIds = readonly [
+  LibraryCoreOperationId,
+  ...LibraryCoreOperationId[],
+];
+
+export type DesktopLegacyWriteEffect =
+  | "legacy_document_broadcast"
+  | "legacy_document_compaction"
+  | "legacy_document_merge"
+  | "legacy_document_persistence"
+  | "legacy_document_replace"
+  | "legacy_duplicate_removal"
+  | "legacy_identity_migration"
+  | "legacy_local_authority_reset"
+  | "legacy_operation_write"
+  | "legacy_runtime_state_write"
+  | "legacy_schema_migration"
+  | "legacy_desktop_registration";
+
+interface DesktopRequestEffectDefinition {
+  readonly legacyWriteEffects: readonly DesktopLegacyWriteEffect[];
+  readonly successorOperationIds:
+    | readonly []
+    | NonEmptyOperationIds;
+  readonly blockers: readonly LibraryCoreWorkerSurfaceBlocker[];
+}
+
+const noWriteEffect = (): DesktopRequestEffectDefinition => ({
+  legacyWriteEffects: [],
+  successorOperationIds: [],
+  blockers: [],
+});
+
+const operationWrite = (
+  ...successorOperationIds: NonEmptyOperationIds
+): DesktopRequestEffectDefinition => ({
+  legacyWriteEffects: ["legacy_operation_write"],
+  successorOperationIds,
+  blockers: [],
+});
+
+const hiddenWrite = (
+  legacyWriteEffects: readonly DesktopLegacyWriteEffect[],
+  blockers: readonly LibraryCoreWorkerSurfaceBlocker[],
+): DesktopRequestEffectDefinition => ({
+  legacyWriteEffects,
+  successorOperationIds: [],
+  blockers,
+});
+
+/**
+ * Typed effect coverage for every current Desktop worker request.
+ *
+ * This registry is intentionally independent of the request classification
+ * above. A request labeled lifecycle or replication can still mutate the
+ * legacy document. Every discriminant must therefore declare its concrete
+ * write effects, dormant successors, or an explicit unresolved blocker.
+ */
+export const DESKTOP_AUTOMERGE_REQUEST_EFFECT_REGISTRY = {
+  INIT: hiddenWrite(
+    [
+      "legacy_schema_migration",
+      "legacy_identity_migration",
+      "legacy_document_compaction",
+      "legacy_desktop_registration",
+      "legacy_document_persistence",
+      "legacy_document_broadcast",
+    ],
+    ["hidden_legacy_write_contract_unresolved"],
+  ),
+  QUIESCE: hiddenWrite(
+    ["legacy_runtime_state_write"],
+    ["lifecycle_contract_unresolved"],
+  ),
+  CLEAR_LOCAL: hiddenWrite(
+    ["legacy_local_authority_reset"],
+    ["local_authority_reset_contract_unresolved"],
+  ),
+  REPLACE_DOC: hiddenWrite(
+    [
+      "legacy_document_replace",
+      "legacy_schema_migration",
+      "legacy_identity_migration",
+      "legacy_document_compaction",
+      "legacy_desktop_registration",
+      "legacy_document_persistence",
+      "legacy_document_broadcast",
+    ],
+    [
+      "hidden_legacy_write_contract_unresolved",
+      "replication_contract_unresolved",
+    ],
+  ),
+  MARK_AS_READ: operationWrite(
+    "feed_item_read_assignment",
+    "provider_intent",
+  ),
+  MARK_ITEMS_AS_READ: operationWrite(
+    "feed_items_read_frozen",
+    "provider_intent",
+  ),
+  MARK_ALL_AS_READ: operationWrite(
+    "feed_items_read_frozen",
+    "provider_intent",
+  ),
+  TOGGLE_SAVED: operationWrite("feed_item_saved_assignment"),
+  TOGGLE_ARCHIVED: operationWrite("feed_item_archive_assignment"),
+  ARCHIVE_ITEMS: operationWrite("feed_items_archive_frozen"),
+  TOGGLE_LIKED: operationWrite(
+    "feed_item_like_assignment",
+    "provider_intent",
+  ),
+  CONFIRM_LIKED_SYNCED: operationWrite("feed_item_like_sync_receipt"),
+  CONFIRM_SEEN_SYNCED: operationWrite("feed_item_seen_sync_receipt"),
+  ADD_FEED_ITEM: operationWrite("feed_item_capture_upsert"),
+  ADD_FEED_ITEMS: {
+    legacyWriteEffects: [
+      "legacy_operation_write",
+      "legacy_duplicate_removal",
+    ],
+    successorOperationIds: [
+      "feed_item_capture_upsert",
+      "feed_items_deduplicate_frozen",
+    ],
+    blockers: [],
+  },
+  RECONCILE_YOUTUBE_CAPTURE: operationWrite(
+    "provider_capture_snapshot_reconcile",
+  ),
+  RECONCILE_FOLLOW_ROSTER_CAPTURE: operationWrite(
+    "provider_capture_snapshot_reconcile",
+  ),
+  ADD_SAMPLE_LIBRARY_DATA: operationWrite("sample_library_import"),
+  REMOVE_FEED_ITEM: operationWrite("feed_item_remove"),
+  CLEAR_SAMPLE_DATA: operationWrite("sample_library_remove"),
+  UPDATE_FEED_ITEM: operationWrite("feed_item_capture_upsert"),
+  ARCHIVE_ALL_READ_UNSAVED: operationWrite(
+    "feed_items_archive_read_unsaved_frozen",
+  ),
+  UNARCHIVE_SAVED_ITEMS: operationWrite(
+    "feed_items_unarchive_saved_frozen",
+  ),
+  PRUNE_ARCHIVED_ITEMS: operationWrite(
+    "feed_items_prune_archived_frozen",
+  ),
+  DELETE_ALL_ARCHIVED: operationWrite(
+    "feed_items_delete_archived_frozen",
+  ),
+  ADD_RSS_FEED: operationWrite("rss_feed_upsert"),
+  REMOVE_RSS_FEED: operationWrite(
+    "rss_feed_remove_keep_items",
+    "rss_feed_remove_with_items",
+  ),
+  UPDATE_RSS_FEED: operationWrite(
+    "rss_feed_title_assignment",
+    "rss_feed_upsert",
+  ),
+  REMOVE_ALL_FEEDS: operationWrite(
+    "rss_feeds_remove_keep_items",
+    "rss_feeds_remove_with_items",
+  ),
+  UPDATE_PREFERENCES: operationWrite("preferences_leaf_assignment"),
+  ADD_PERSON: operationWrite("person_upsert"),
+  ADD_PERSONS: operationWrite("person_upsert"),
+  UPDATE_PERSON: operationWrite("person_upsert"),
+  UPSERT_CONNECTION_PERSONS: operationWrite(
+    "account_person_assignment",
+    "account_upsert",
+    "person_upsert",
+  ),
+  REMOVE_PERSON: operationWrite("person_remove_and_accounts"),
+  LOG_REACH_OUT: operationWrite("person_reach_out_append"),
+  ADD_ACCOUNT: operationWrite("account_upsert"),
+  ADD_ACCOUNTS: operationWrite("account_upsert"),
+  UPDATE_ACCOUNT: operationWrite(
+    "account_person_assignment",
+    "account_upsert",
+  ),
+  REMOVE_ACCOUNT: operationWrite("account_remove"),
+  MERGE_DOC: hiddenWrite(
+    [
+      "legacy_document_merge",
+      "legacy_schema_migration",
+      "legacy_identity_migration",
+      "legacy_document_compaction",
+      "legacy_desktop_registration",
+      "legacy_document_persistence",
+      "legacy_document_broadcast",
+    ],
+    [
+      "hidden_legacy_write_contract_unresolved",
+      "replication_contract_unresolved",
+    ],
+  ),
+  BATCH_REFRESH_FEEDS: {
+    legacyWriteEffects: [
+      "legacy_operation_write",
+      "legacy_duplicate_removal",
+    ],
+    successorOperationIds: [
+      "feed_item_capture_upsert",
+      "feed_items_deduplicate_frozen",
+      "rss_feed_upsert",
+    ],
+    blockers: [],
+  },
+  BATCH_IMPORT_ITEMS: operationWrite("feed_item_capture_upsert"),
+  HEAL_UNTITLED_FEEDS: operationWrite(
+    "rss_feeds_heal_untitled_frozen",
+  ),
+  DEDUPLICATE_ITEMS: operationWrite(
+    "feed_items_deduplicate_frozen",
+  ),
+  BACKFILL_CONTENT_SIGNALS: operationWrite(
+    "feed_items_content_signals_backfill_frozen",
+  ),
+  GET_ALL_ITEM_IDS: noWriteEffect(),
+  GET_DOC_BINARY: noWriteEffect(),
+  GET_HEADS: noWriteEffect(),
+  COMPARE_DOC: noWriteEffect(),
+  GET_SAVED_YOUTUBE_URLS: noWriteEffect(),
+  GET_ITEM_PRESERVED_TEXT: noWriteEffect(),
+  GET_ITEM_LEGACY_HTML: noWriteEffect(),
+  UPDATE_RELAY_CLIENT_COUNT: hiddenWrite(
+    ["legacy_runtime_state_write"],
+    ["lifecycle_contract_unresolved"],
+  ),
+} as const satisfies Readonly<
+  Record<DesktopAutomergeWorkerRequestKind, DesktopRequestEffectDefinition>
+>;
+
+/**
+ * Compile-time census of the current Desktop Automerge response boundary.
+ * These classifications describe legacy transports only.
+ */
+export const DESKTOP_AUTOMERGE_WORKER_RESPONSE_SURFACE_REGISTRY = {
+  ACK: blockedSurface(
+    "mutation_acknowledgement",
+    "response_transport_not_cut_over",
+    "unbounded_payload",
+  ),
+  STATE_UPDATE: blockedSurface(
+    "legacy_full_state_transport",
+    "response_transport_not_cut_over",
+    "unbounded_payload",
+  ),
+  PREFERENCES_PATCH: blockedSurface(
+    "legacy_patch_transport",
+    "response_transport_not_cut_over",
+    "unbounded_payload",
+  ),
+  ITEM_PATCH: blockedSurface(
+    "legacy_patch_transport",
+    "response_transport_not_cut_over",
+    "unbounded_payload",
+  ),
+  FEEDS_PATCH: blockedSurface(
+    "legacy_patch_transport",
+    "response_transport_not_cut_over",
+    "unbounded_payload",
+  ),
+  DEBUG_EVENT: blockedSurface(
+    "diagnostic_transport",
+    "response_transport_not_cut_over",
+    "unbounded_payload",
+  ),
+  DEBUG_SNAPSHOT: blockedSurface(
+    "diagnostic_transport",
+    "response_transport_not_cut_over",
+    "unbounded_payload",
+  ),
+  READY: blockedSurface(
+    "legacy_lifecycle_control",
+    "lifecycle_contract_unresolved",
+  ),
+  BROADCAST_REQUEST: blockedSurface(
+    "legacy_unbounded_transport",
+    "response_transport_not_cut_over",
+    "unbounded_payload",
+  ),
+  ALL_ITEM_IDS: blockedSurface(
+    "legacy_unbounded_transport",
+    "response_transport_not_cut_over",
+    "unbounded_payload",
+  ),
+  DOC_BINARY: blockedSurface(
+    "legacy_unbounded_transport",
+    "response_transport_not_cut_over",
+    "unbounded_payload",
+  ),
+  DOC_HEADS: blockedSurface(
+    "legacy_unbounded_transport",
+    "response_transport_not_cut_over",
+    "unbounded_payload",
+  ),
+  DOC_RELATIONSHIP: blockedSurface(
+    "legacy_unbounded_transport",
+    "response_transport_not_cut_over",
+    "unbounded_payload",
+  ),
+  SAVED_YOUTUBE_URLS: blockedSurface(
+    "legacy_unbounded_transport",
+    "response_transport_not_cut_over",
+    "unbounded_payload",
+  ),
+  INIT_STATS: blockedSurface(
+    "diagnostic_transport",
+    "response_transport_not_cut_over",
+  ),
+  ITEM_PRESERVED_TEXT: blockedSurface(
+    "legacy_unbounded_transport",
+    "response_transport_not_cut_over",
+    "unbounded_payload",
+  ),
+  ITEM_LEGACY_HTML: blockedSurface(
+    "legacy_unbounded_transport",
+    "response_transport_not_cut_over",
+    "unbounded_payload",
+  ),
+  CONTENT_SIGNAL_BACKFILL_RESULT: blockedSurface(
+    "legacy_progress_transport",
+    "response_transport_not_cut_over",
+  ),
+  SAMPLE_DATA_CLEAR_RESULT: blockedSurface(
+    "legacy_progress_transport",
+    "response_transport_not_cut_over",
+  ),
+  IMPORT_PROGRESS: blockedSurface(
+    "legacy_progress_transport",
+    "response_transport_not_cut_over",
+  ),
+} as const satisfies Readonly<
+  Record<
+    DesktopAutomergeWorkerResponseKind,
+    LibraryCoreWorkerSurfaceDefinition
+  >
+>;

--- a/packages/pwa/src/lib/library-core-worker-surface-registry.test.ts
+++ b/packages/pwa/src/lib/library-core-worker-surface-registry.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+import { LIBRARY_CORE_OPERATION_REGISTRY } from "@freed/shared/library-core";
+
+import {
+  PWA_AUTOMERGE_REQUEST_EFFECT_REGISTRY,
+  PWA_AUTOMERGE_WORKER_REQUEST_SURFACE_REGISTRY,
+  PWA_AUTOMERGE_WORKER_RESPONSE_SURFACE_REGISTRY,
+} from "./library-core-worker-surface-registry";
+
+describe("PWA Library Core worker surface census", () => {
+  it("keeps every current request and response classified but blocked", () => {
+    for (const definition of [
+      ...Object.values(PWA_AUTOMERGE_WORKER_REQUEST_SURFACE_REGISTRY),
+      ...Object.values(PWA_AUTOMERGE_WORKER_RESPONSE_SURFACE_REGISTRY),
+    ]) {
+      expect(definition.status).toBe("planned_blocked");
+      expect(definition.blockers.length).toBeGreaterThan(0);
+      expect(definition.blockers).toContain(
+        "library_core_runtime_inactive",
+      );
+    }
+  });
+
+  it("does not blur provider intent, corpus reads, or full-state transport into ordinary mutations", () => {
+    for (const kind of [
+      "MARK_AS_READ",
+      "MARK_ITEMS_AS_READ",
+      "MARK_ALL_AS_READ",
+      "TOGGLE_LIKED",
+    ] as const) {
+      expect(
+        PWA_AUTOMERGE_WORKER_REQUEST_SURFACE_REGISTRY[kind].blockers,
+        kind,
+      ).toContain("provider_intent_separation_unresolved");
+      expect(
+        PWA_AUTOMERGE_WORKER_REQUEST_SURFACE_REGISTRY[kind].blockers,
+        kind,
+      ).toContain("provider_intent_execution_receipt_unresolved");
+      expect(
+        PWA_AUTOMERGE_REQUEST_EFFECT_REGISTRY[kind]
+          .successorOperationIds,
+        kind,
+      ).toContain("provider_intent");
+    }
+    expect(
+      PWA_AUTOMERGE_WORKER_REQUEST_SURFACE_REGISTRY.GET_DOC_BINARY
+        .classification,
+    ).toBe("legacy_unbounded_read");
+    expect(
+      PWA_AUTOMERGE_WORKER_REQUEST_SURFACE_REGISTRY.MERGE_DOC.classification,
+    ).toBe("legacy_replication_authority");
+    expect(
+      PWA_AUTOMERGE_WORKER_RESPONSE_SURFACE_REGISTRY.STATE_UPDATE
+        .classification,
+    ).toBe("legacy_full_state_transport");
+  });
+
+  it("censuses every request effect independently of its classification", () => {
+    for (const [kind, effect] of Object.entries(
+      PWA_AUTOMERGE_REQUEST_EFFECT_REGISTRY,
+    )) {
+      if (effect.legacyWriteEffects.length === 0) continue;
+      expect(
+        effect.successorOperationIds.length > 0 ||
+          effect.blockers.length > 0,
+        kind,
+      ).toBe(true);
+    }
+
+    expect(
+      PWA_AUTOMERGE_REQUEST_EFFECT_REGISTRY.CONFIRM_LIKED_SYNCED
+        .successorOperationIds,
+    ).toStrictEqual(["feed_item_like_sync_receipt"]);
+    expect(
+      PWA_AUTOMERGE_REQUEST_EFFECT_REGISTRY.CONFIRM_SEEN_SYNCED
+        .successorOperationIds,
+    ).toStrictEqual(["feed_item_seen_sync_receipt"]);
+
+    for (const kind of ["INIT", "MERGE_DOC"] as const) {
+      const effect = PWA_AUTOMERGE_REQUEST_EFFECT_REGISTRY[kind];
+      expect(effect.legacyWriteEffects, kind).toContain(
+        "legacy_schema_migration",
+      );
+      expect(effect.legacyWriteEffects, kind).toContain(
+        "legacy_document_broadcast",
+      );
+      expect(effect.blockers, kind).toContain(
+        "hidden_legacy_write_contract_unresolved",
+      );
+    }
+  });
+
+  it("marks arbitrary diagnostic and mutation payload bytes as unbounded", () => {
+    for (const kind of [
+      "ADD_FEED_ITEM",
+      "ADD_STUB_ITEM",
+      "TOGGLE_LIKED",
+      "UPDATE_PREFERENCES",
+    ] as const) {
+      expect(
+        PWA_AUTOMERGE_WORKER_REQUEST_SURFACE_REGISTRY[kind].blockers,
+        kind,
+      ).toContain("unbounded_payload");
+    }
+    for (const kind of ["ACK", "DEBUG_EVENT", "DEBUG_SNAPSHOT"] as const) {
+      expect(
+        PWA_AUTOMERGE_WORKER_RESPONSE_SURFACE_REGISTRY[kind].blockers,
+        kind,
+      ).toContain("unbounded_payload");
+    }
+  });
+
+  it("records quiesce as an explicit runtime-state write", () => {
+    expect(PWA_AUTOMERGE_REQUEST_EFFECT_REGISTRY.QUIESCE).toStrictEqual({
+      legacyWriteEffects: ["legacy_runtime_state_write"],
+      successorOperationIds: [],
+      blockers: ["lifecycle_contract_unresolved"],
+    });
+  });
+
+  it("keeps every successor operation linked back to its current request", () => {
+    for (const [kind, effect] of Object.entries(
+      PWA_AUTOMERGE_REQUEST_EFFECT_REGISTRY,
+    )) {
+      for (const operationId of effect.successorOperationIds) {
+        expect(
+          LIBRARY_CORE_OPERATION_REGISTRY[operationId].legacyWorkerRequests,
+          `${kind} -> ${operationId}`,
+        ).toContain(kind);
+      }
+    }
+  });
+});

--- a/packages/pwa/src/lib/library-core-worker-surface-registry.ts
+++ b/packages/pwa/src/lib/library-core-worker-surface-registry.ts
@@ -1,0 +1,404 @@
+import type { WorkerRequest, WorkerResponse } from "./automerge-types";
+import type { LibraryCoreOperationId } from "@freed/shared/library-core";
+
+export type PwaAutomergeWorkerRequestKind = WorkerRequest["type"];
+export type PwaAutomergeWorkerResponseKind = WorkerResponse["type"];
+
+export type LibraryCoreWorkerSurfaceClassification =
+  | "diagnostic_transport"
+  | "legacy_bulk_or_repair_authority"
+  | "legacy_full_state_transport"
+  | "legacy_lifecycle_control"
+  | "legacy_mutation_authority"
+  | "legacy_progress_transport"
+  | "legacy_provider_receipt_authority"
+  | "legacy_replication_authority"
+  | "legacy_unbounded_read"
+  | "legacy_unbounded_transport"
+  | "mutation_acknowledgement";
+
+export type LibraryCoreWorkerSurfaceBlocker =
+  | "hidden_legacy_write_contract_unresolved"
+  | "legacy_authority_active"
+  | "library_core_runtime_inactive"
+  | "lifecycle_contract_unresolved"
+  | "local_authority_reset_contract_unresolved"
+  | "provider_intent_execution_receipt_unresolved"
+  | "provider_intent_separation_unresolved"
+  | "query_contract_unresolved"
+  | "replication_contract_unresolved"
+  | "response_transport_not_cut_over"
+  | "successor_contract_unresolved"
+  | "unbounded_payload";
+
+type NonEmptyWorkerSurfaceBlockers = readonly [
+  LibraryCoreWorkerSurfaceBlocker,
+  ...LibraryCoreWorkerSurfaceBlocker[],
+];
+
+export interface LibraryCoreWorkerSurfaceDefinition {
+  readonly status: "planned_blocked";
+  readonly classification: LibraryCoreWorkerSurfaceClassification;
+  readonly blockers: NonEmptyWorkerSurfaceBlockers;
+}
+
+function blockedSurface(
+  classification: LibraryCoreWorkerSurfaceClassification,
+  ...blockers: readonly LibraryCoreWorkerSurfaceBlocker[]
+): LibraryCoreWorkerSurfaceDefinition {
+  return {
+    status: "planned_blocked",
+    classification,
+    blockers: ["library_core_runtime_inactive", ...blockers],
+  };
+}
+
+const lifecycleRequest = () =>
+  blockedSurface("legacy_lifecycle_control", "lifecycle_contract_unresolved");
+const mutationRequest = () =>
+  blockedSurface(
+    "legacy_mutation_authority",
+    "legacy_authority_active",
+    "successor_contract_unresolved",
+    "unbounded_payload",
+  );
+const bulkOrRepairRequest = () =>
+  blockedSurface(
+    "legacy_bulk_or_repair_authority",
+    "legacy_authority_active",
+    "successor_contract_unresolved",
+    "unbounded_payload",
+  );
+const providerReceiptRequest = () =>
+  blockedSurface(
+    "legacy_provider_receipt_authority",
+    "legacy_authority_active",
+    "provider_intent_execution_receipt_unresolved",
+    "unbounded_payload",
+  );
+const providerSeenMutationRequest = (bulk: boolean) =>
+  blockedSurface(
+    bulk
+      ? "legacy_bulk_or_repair_authority"
+      : "legacy_mutation_authority",
+    "legacy_authority_active",
+    "successor_contract_unresolved",
+    "unbounded_payload",
+    "provider_intent_separation_unresolved",
+    "provider_intent_execution_receipt_unresolved",
+  );
+const unboundedReadRequest = () =>
+  blockedSurface(
+    "legacy_unbounded_read",
+    "query_contract_unresolved",
+    "unbounded_payload",
+  );
+
+/**
+ * Compile-time census of the current PWA Automerge request boundary.
+ *
+ * This registry is deliberately dormant. `satisfies Record<...>` makes a new
+ * discriminant fail typecheck until it is classified, but no entry grants
+ * Library Core authority or changes worker dispatch.
+ */
+export const PWA_AUTOMERGE_WORKER_REQUEST_SURFACE_REGISTRY = {
+  INIT: blockedSurface(
+    "legacy_lifecycle_control",
+    "lifecycle_contract_unresolved",
+    "hidden_legacy_write_contract_unresolved",
+  ),
+  QUIESCE: lifecycleRequest(),
+  MARK_AS_READ: providerSeenMutationRequest(false),
+  MARK_ITEMS_AS_READ: providerSeenMutationRequest(true),
+  MARK_ALL_AS_READ: providerSeenMutationRequest(true),
+  TOGGLE_SAVED: mutationRequest(),
+  TOGGLE_ARCHIVED: mutationRequest(),
+  ARCHIVE_ITEMS: bulkOrRepairRequest(),
+  TOGGLE_LIKED: blockedSurface(
+    "legacy_mutation_authority",
+    "legacy_authority_active",
+    "successor_contract_unresolved",
+    "provider_intent_separation_unresolved",
+    "provider_intent_execution_receipt_unresolved",
+    "unbounded_payload",
+  ),
+  CONFIRM_LIKED_SYNCED: providerReceiptRequest(),
+  CONFIRM_SEEN_SYNCED: providerReceiptRequest(),
+  ADD_FEED_ITEM: mutationRequest(),
+  ADD_FEED_ITEMS: bulkOrRepairRequest(),
+  ADD_SAMPLE_LIBRARY_DATA: bulkOrRepairRequest(),
+  REMOVE_FEED_ITEM: mutationRequest(),
+  CLEAR_SAMPLE_DATA: bulkOrRepairRequest(),
+  UPDATE_FEED_ITEM: mutationRequest(),
+  ARCHIVE_ALL_READ_UNSAVED: bulkOrRepairRequest(),
+  UNARCHIVE_SAVED_ITEMS: bulkOrRepairRequest(),
+  PRUNE_ARCHIVED_ITEMS: bulkOrRepairRequest(),
+  DELETE_ALL_ARCHIVED: bulkOrRepairRequest(),
+  ADD_RSS_FEED: mutationRequest(),
+  REMOVE_RSS_FEED: mutationRequest(),
+  UPDATE_RSS_FEED: mutationRequest(),
+  REMOVE_ALL_FEEDS: bulkOrRepairRequest(),
+  UPDATE_PREFERENCES: mutationRequest(),
+  ADD_PERSON: mutationRequest(),
+  ADD_PERSONS: bulkOrRepairRequest(),
+  UPDATE_PERSON: mutationRequest(),
+  UPSERT_CONNECTION_PERSONS: bulkOrRepairRequest(),
+  REMOVE_PERSON: mutationRequest(),
+  LOG_REACH_OUT: mutationRequest(),
+  ADD_ACCOUNT: mutationRequest(),
+  ADD_ACCOUNTS: bulkOrRepairRequest(),
+  UPDATE_ACCOUNT: mutationRequest(),
+  REMOVE_ACCOUNT: mutationRequest(),
+  ADD_STUB_ITEM: mutationRequest(),
+  BACKFILL_CONTENT_SIGNALS: bulkOrRepairRequest(),
+  MERGE_DOC: blockedSurface(
+    "legacy_replication_authority",
+    "legacy_authority_active",
+    "replication_contract_unresolved",
+    "hidden_legacy_write_contract_unresolved",
+    "unbounded_payload",
+  ),
+  GET_DOC_BINARY: unboundedReadRequest(),
+  GET_HEADS: unboundedReadRequest(),
+  COMPARE_DOC: unboundedReadRequest(),
+  GET_ITEM_LEGACY_HTML: unboundedReadRequest(),
+  CLEAR_LOCAL: blockedSurface(
+    "legacy_lifecycle_control",
+    "lifecycle_contract_unresolved",
+    "local_authority_reset_contract_unresolved",
+  ),
+} as const satisfies Readonly<
+  Record<PwaAutomergeWorkerRequestKind, LibraryCoreWorkerSurfaceDefinition>
+>;
+
+type NonEmptyOperationIds = readonly [
+  LibraryCoreOperationId,
+  ...LibraryCoreOperationId[],
+];
+
+export type PwaLegacyWriteEffect =
+  | "legacy_document_broadcast"
+  | "legacy_document_merge"
+  | "legacy_document_persistence"
+  | "legacy_identity_migration"
+  | "legacy_local_authority_reset"
+  | "legacy_operation_write"
+  | "legacy_runtime_state_write"
+  | "legacy_schema_migration";
+
+interface PwaRequestEffectDefinition {
+  readonly legacyWriteEffects: readonly PwaLegacyWriteEffect[];
+  readonly successorOperationIds:
+    | readonly []
+    | NonEmptyOperationIds;
+  readonly blockers: readonly LibraryCoreWorkerSurfaceBlocker[];
+}
+
+const noWriteEffect = (): PwaRequestEffectDefinition => ({
+  legacyWriteEffects: [],
+  successorOperationIds: [],
+  blockers: [],
+});
+
+const operationWrite = (
+  ...successorOperationIds: NonEmptyOperationIds
+): PwaRequestEffectDefinition => ({
+  legacyWriteEffects: ["legacy_operation_write"],
+  successorOperationIds,
+  blockers: [],
+});
+
+const hiddenWrite = (
+  legacyWriteEffects: readonly PwaLegacyWriteEffect[],
+  blockers: readonly LibraryCoreWorkerSurfaceBlocker[],
+): PwaRequestEffectDefinition => ({
+  legacyWriteEffects,
+  successorOperationIds: [],
+  blockers,
+});
+
+/**
+ * Typed effect coverage for every current PWA worker request.
+ *
+ * This registry is intentionally independent of request classification.
+ * Initialization and replication can still migrate and persist the legacy
+ * document, so every discriminant declares its concrete write effects,
+ * dormant successors, or an explicit unresolved blocker.
+ */
+export const PWA_AUTOMERGE_REQUEST_EFFECT_REGISTRY = {
+  INIT: hiddenWrite(
+    [
+      "legacy_schema_migration",
+      "legacy_identity_migration",
+      "legacy_document_persistence",
+      "legacy_document_broadcast",
+    ],
+    ["hidden_legacy_write_contract_unresolved"],
+  ),
+  QUIESCE: hiddenWrite(
+    ["legacy_runtime_state_write"],
+    ["lifecycle_contract_unresolved"],
+  ),
+  MARK_AS_READ: operationWrite(
+    "feed_item_read_assignment",
+    "provider_intent",
+  ),
+  MARK_ITEMS_AS_READ: operationWrite(
+    "feed_items_read_frozen",
+    "provider_intent",
+  ),
+  MARK_ALL_AS_READ: operationWrite(
+    "feed_items_read_frozen",
+    "provider_intent",
+  ),
+  TOGGLE_SAVED: operationWrite("feed_item_saved_assignment"),
+  TOGGLE_ARCHIVED: operationWrite("feed_item_archive_assignment"),
+  ARCHIVE_ITEMS: operationWrite("feed_items_archive_frozen"),
+  TOGGLE_LIKED: operationWrite(
+    "feed_item_like_assignment",
+    "provider_intent",
+  ),
+  CONFIRM_LIKED_SYNCED: operationWrite("feed_item_like_sync_receipt"),
+  CONFIRM_SEEN_SYNCED: operationWrite("feed_item_seen_sync_receipt"),
+  ADD_FEED_ITEM: operationWrite("feed_item_capture_upsert"),
+  ADD_FEED_ITEMS: operationWrite("feed_item_capture_upsert"),
+  ADD_SAMPLE_LIBRARY_DATA: operationWrite("sample_library_import"),
+  REMOVE_FEED_ITEM: operationWrite("feed_item_remove"),
+  CLEAR_SAMPLE_DATA: operationWrite("sample_library_remove"),
+  UPDATE_FEED_ITEM: operationWrite("feed_item_capture_upsert"),
+  ARCHIVE_ALL_READ_UNSAVED: operationWrite(
+    "feed_items_archive_read_unsaved_frozen",
+  ),
+  UNARCHIVE_SAVED_ITEMS: operationWrite(
+    "feed_items_unarchive_saved_frozen",
+  ),
+  PRUNE_ARCHIVED_ITEMS: operationWrite(
+    "feed_items_prune_archived_frozen",
+  ),
+  DELETE_ALL_ARCHIVED: operationWrite(
+    "feed_items_delete_archived_frozen",
+  ),
+  ADD_RSS_FEED: operationWrite("rss_feed_upsert"),
+  REMOVE_RSS_FEED: operationWrite(
+    "rss_feed_remove_keep_items",
+    "rss_feed_remove_with_items",
+  ),
+  UPDATE_RSS_FEED: operationWrite(
+    "rss_feed_title_assignment",
+    "rss_feed_upsert",
+  ),
+  REMOVE_ALL_FEEDS: operationWrite(
+    "rss_feeds_remove_keep_items",
+    "rss_feeds_remove_with_items",
+  ),
+  UPDATE_PREFERENCES: operationWrite("preferences_leaf_assignment"),
+  ADD_PERSON: operationWrite("person_upsert"),
+  ADD_PERSONS: operationWrite("person_upsert"),
+  UPDATE_PERSON: operationWrite("person_upsert"),
+  UPSERT_CONNECTION_PERSONS: operationWrite(
+    "account_person_assignment",
+    "account_upsert",
+    "person_upsert",
+  ),
+  REMOVE_PERSON: operationWrite("person_remove_and_accounts"),
+  LOG_REACH_OUT: operationWrite("person_reach_out_append"),
+  ADD_ACCOUNT: operationWrite("account_upsert"),
+  ADD_ACCOUNTS: operationWrite("account_upsert"),
+  UPDATE_ACCOUNT: operationWrite(
+    "account_person_assignment",
+    "account_upsert",
+  ),
+  REMOVE_ACCOUNT: operationWrite("account_remove"),
+  ADD_STUB_ITEM: operationWrite("feed_item_capture_upsert"),
+  BACKFILL_CONTENT_SIGNALS: operationWrite(
+    "feed_items_content_signals_backfill_frozen",
+  ),
+  MERGE_DOC: hiddenWrite(
+    [
+      "legacy_document_merge",
+      "legacy_schema_migration",
+      "legacy_identity_migration",
+      "legacy_document_persistence",
+      "legacy_document_broadcast",
+    ],
+    [
+      "hidden_legacy_write_contract_unresolved",
+      "replication_contract_unresolved",
+    ],
+  ),
+  GET_DOC_BINARY: noWriteEffect(),
+  GET_HEADS: noWriteEffect(),
+  COMPARE_DOC: noWriteEffect(),
+  GET_ITEM_LEGACY_HTML: noWriteEffect(),
+  CLEAR_LOCAL: hiddenWrite(
+    ["legacy_local_authority_reset"],
+    ["local_authority_reset_contract_unresolved"],
+  ),
+} as const satisfies Readonly<
+  Record<PwaAutomergeWorkerRequestKind, PwaRequestEffectDefinition>
+>;
+
+/**
+ * Compile-time census of the current PWA Automerge response boundary. These
+ * classifications describe legacy transports only.
+ */
+export const PWA_AUTOMERGE_WORKER_RESPONSE_SURFACE_REGISTRY = {
+  ACK: blockedSurface(
+    "mutation_acknowledgement",
+    "response_transport_not_cut_over",
+    "unbounded_payload",
+  ),
+  STATE_UPDATE: blockedSurface(
+    "legacy_full_state_transport",
+    "response_transport_not_cut_over",
+    "unbounded_payload",
+  ),
+  DOC_BINARY: blockedSurface(
+    "legacy_unbounded_transport",
+    "response_transport_not_cut_over",
+    "unbounded_payload",
+  ),
+  DOC_HEADS: blockedSurface(
+    "legacy_unbounded_transport",
+    "response_transport_not_cut_over",
+    "unbounded_payload",
+  ),
+  DOC_RELATIONSHIP: blockedSurface(
+    "legacy_unbounded_transport",
+    "response_transport_not_cut_over",
+    "unbounded_payload",
+  ),
+  ITEM_LEGACY_HTML: blockedSurface(
+    "legacy_unbounded_transport",
+    "response_transport_not_cut_over",
+    "unbounded_payload",
+  ),
+  INIT_STATS: blockedSurface(
+    "diagnostic_transport",
+    "response_transport_not_cut_over",
+  ),
+  DEBUG_EVENT: blockedSurface(
+    "diagnostic_transport",
+    "response_transport_not_cut_over",
+    "unbounded_payload",
+  ),
+  DEBUG_SNAPSHOT: blockedSurface(
+    "diagnostic_transport",
+    "response_transport_not_cut_over",
+    "unbounded_payload",
+  ),
+  CONTENT_SIGNAL_BACKFILL_RESULT: blockedSurface(
+    "legacy_progress_transport",
+    "response_transport_not_cut_over",
+  ),
+  SAMPLE_DATA_CLEAR_RESULT: blockedSurface(
+    "legacy_progress_transport",
+    "response_transport_not_cut_over",
+  ),
+  READY: blockedSurface(
+    "legacy_lifecycle_control",
+    "lifecycle_contract_unresolved",
+  ),
+} as const satisfies Readonly<
+  Record<PwaAutomergeWorkerResponseKind, LibraryCoreWorkerSurfaceDefinition>
+>;

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -15,17 +15,20 @@
     "./google-contacts": "./src/google-contacts.ts",
     "./google-contacts-automation": "./src/google-contacts-automation.ts",
     "./redact-sensitive": "./src/redact-sensitive.ts",
-    "./contact-matching": "./src/contact-matching.ts"
+    "./contact-matching": "./src/contact-matching.ts",
+    "./library-core": "./src/library-core/index.ts"
   },
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
+    "test": "node ../../node_modules/vitest/vitest.mjs run --maxWorkers=1",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@automerge/automerge": "^2.2.0"
   },
   "devDependencies": {
-    "typescript": "^5.3.0"
+    "typescript": "^5.3.0",
+    "vitest": "^4.1.10"
   }
 }

--- a/packages/shared/src/library-core/census.test.ts
+++ b/packages/shared/src/library-core/census.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  LIBRARY_CORE_CENSUS,
+  LIBRARY_CORE_CENSUS_BLOCKERS,
+} from "./census.js";
+
+describe("Library Core dormant census", () => {
+  it("cannot be mistaken for writer or activation authority", () => {
+    expect(LIBRARY_CORE_CENSUS).toMatchObject({
+      status: "dormant_incomplete",
+      activationAllowed: false,
+      runtimeBehaviorChanged: false,
+      activeEngine: "automerge_legacy",
+      replicationProtocol: "automerge_blob_v1",
+    });
+  });
+
+  it("keeps the typed blocker vocabulary stable, sorted, and nonempty", () => {
+    expect(LIBRARY_CORE_CENSUS_BLOCKERS.length).toBeGreaterThan(0);
+    expect([...LIBRARY_CORE_CENSUS_BLOCKERS]).toStrictEqual(
+      [...LIBRARY_CORE_CENSUS_BLOCKERS].sort(),
+    );
+    expect(new Set(LIBRARY_CORE_CENSUS_BLOCKERS).size).toBe(
+      LIBRARY_CORE_CENSUS_BLOCKERS.length,
+    );
+  });
+
+  it("names every census surface without claiming that its successor exists", () => {
+    expect(LIBRARY_CORE_CENSUS.registrySurfaces).toStrictEqual([
+      "field",
+      "root",
+      "operation",
+      "query",
+      "shared_store",
+      "desktop_worker_message",
+      "pwa_worker_message",
+      "local_authority",
+    ]);
+  });
+});

--- a/packages/shared/src/library-core/census.ts
+++ b/packages/shared/src/library-core/census.ts
@@ -1,0 +1,42 @@
+/**
+ * The checked-in Library Core inventory is deliberately dormant.
+ *
+ * These blockers describe missing executable contracts. They are not a
+ * roadmap status and they cannot be cleared by changing this array alone.
+ * Activation requires the corresponding implementations, proofs, transition
+ * entry, and durable receipts.
+ */
+export const LIBRARY_CORE_CENSUS_BLOCKERS = [
+  "actor_and_global_authority_contracts_unimplemented",
+  "legacy_epoch_bootstrap_transaction_unimplemented",
+  "local_authority_retention_and_migration_incomplete",
+  "materializers_and_storage_adapters_unimplemented",
+  "migration_source_and_frontier_unbound",
+  "operation_payload_and_field_algebra_incomplete",
+  "query_request_response_and_projection_contracts_incomplete",
+  "synchronized_field_semantics_incomplete",
+  "worker_surface_cutover_incomplete",
+] as const;
+
+export type LibraryCoreCensusBlocker =
+  (typeof LIBRARY_CORE_CENSUS_BLOCKERS)[number];
+
+export const LIBRARY_CORE_CENSUS = Object.freeze({
+  schemaVersion: 1,
+  status: "dormant_incomplete",
+  activationAllowed: false,
+  runtimeBehaviorChanged: false,
+  activeEngine: "automerge_legacy",
+  replicationProtocol: "automerge_blob_v1",
+  registrySurfaces: [
+    "field",
+    "root",
+    "operation",
+    "query",
+    "shared_store",
+    "desktop_worker_message",
+    "pwa_worker_message",
+    "local_authority",
+  ],
+  blockers: LIBRARY_CORE_CENSUS_BLOCKERS,
+} as const);

--- a/packages/shared/src/library-core/field-registry.test.ts
+++ b/packages/shared/src/library-core/field-registry.test.ts
@@ -1,0 +1,302 @@
+import { describe, expect, it } from "vitest";
+import type {
+  LibraryCoreActivationBlocker,
+  LibraryCoreFieldRegistryEntry,
+} from "./protocol-registry.js";
+import {
+  LIBRARY_CORE_FIELD_REGISTRY,
+  LIBRARY_CORE_ROOT_REGISTRY,
+} from "./field-registry.js";
+import { DESKTOP_CLIENT_KEY_PREFIX } from "../schema.js";
+
+const compareCodeUnits = (left: string, right: string): number =>
+  left < right ? -1 : left > right ? 1 : 0;
+
+const entryAt = (path: string): LibraryCoreFieldRegistryEntry => {
+  const entry = LIBRARY_CORE_FIELD_REGISTRY.find(
+    (candidate) => candidate.path.text === path,
+  );
+  expect(entry, `missing registry entry ${path}`).toBeDefined();
+  return entry!;
+};
+
+describe("Library Core legacy field census", () => {
+  it("has exact, unique, machine-ordered root coverage and blocks every cutover", () => {
+    const expectedRoots = [
+      "<unknown-root>",
+      "accounts",
+      "desktopClient:*",
+      "feedItems",
+      "friends",
+      "meta",
+      "persons",
+      "preferences",
+      "rssFeeds",
+    ].sort(compareCodeUnits);
+    const roots = LIBRARY_CORE_ROOT_REGISTRY.map((entry) => entry.root);
+    const keys = LIBRARY_CORE_ROOT_REGISTRY.map((entry) => entry.registryKey);
+
+    expect(roots).toEqual(expectedRoots);
+    expect(new Set(roots).size).toBe(roots.length);
+    expect(new Set(keys).size).toBe(keys.length);
+    expect(keys).toEqual([...keys].sort(compareCodeUnits));
+    expect(
+      LIBRARY_CORE_ROOT_REGISTRY.every(
+        (entry) =>
+          entry.cutover === "blocked" &&
+          entry.plannedLocality === null &&
+          entry.plannedAuthority === null &&
+          entry.blockers.includes("planned_locality_undecided") &&
+          entry.blockers.includes("planned_authority_undecided"),
+      ),
+    ).toBe(true);
+  });
+
+  it("has unique field keys in deterministic UTF-16 code-unit order", () => {
+    const keys = LIBRARY_CORE_FIELD_REGISTRY.map((entry) => entry.registryKey);
+
+    expect(new Set(keys).size).toBe(keys.length);
+    expect(keys).toEqual([...keys].sort(compareCodeUnits));
+  });
+
+  it("keeps current legacy authority separate from unresolved planned authority", () => {
+    const feedRoot = LIBRARY_CORE_ROOT_REGISTRY.find(
+      (entry) => entry.root === "feedItems",
+    );
+    const friendRoot = LIBRARY_CORE_ROOT_REGISTRY.find(
+      (entry) => entry.root === "friends",
+    );
+
+    expect(feedRoot).toMatchObject({
+      currentLocality: "legacy-synchronized",
+      currentAuthority: "legacy-automerge-document",
+      plannedLocality: null,
+      plannedAuthority: null,
+      cutover: "blocked",
+    });
+    expect(friendRoot).toMatchObject({
+      entity: "LegacyFriend",
+      kind: "legacy-root",
+      currentLocality: "legacy-compatibility",
+      currentAuthority: "legacy-automerge-read-only",
+      plannedLocality: null,
+      plannedAuthority: null,
+      cutover: "blocked",
+    });
+
+    expect(entryAt("feedItems.{globalId}.content.text")).toMatchObject({
+      currentLocality: "legacy-synchronized",
+      currentAuthority: "legacy-automerge-document",
+      plannedLocality: null,
+      plannedAuthority: null,
+      storageTier: null,
+      deleteBehavior: null,
+    });
+    expect(entryAt("feedItems.{globalId}.priority")).toMatchObject({
+      currentLocality: "legacy-derived",
+      currentAuthority: "derived-runtime",
+      plannedLocality: null,
+      plannedAuthority: null,
+    });
+  });
+
+  it("covers the retained LegacyFriend shape without current Person-only fields", () => {
+    expect(entryAt("friends.{friendId}.sources[].platform")).toMatchObject({
+      entity: "LegacyFriend",
+      currentLocality: "legacy-compatibility",
+      currentAuthority: "legacy-automerge-read-only",
+    });
+    expect(entryAt("friends.{friendId}.contact.email")).toMatchObject({
+      entity: "LegacyFriend",
+      localPresence: "optional",
+      ancestorOptional: true,
+    });
+    expect(
+      LIBRARY_CORE_FIELD_REGISTRY.some(
+        (entry) =>
+          entry.path.text === "friends.{friendId}.relationshipStatus" ||
+          entry.path.text === "friends.{friendId}.graphX" ||
+          entry.path.text === "friends.{friendId}.sampleDataFingerprint.marker",
+      ),
+    ).toBe(false);
+  });
+
+  it("keeps one recursive legacy-Automerge fallback per retained root", () => {
+    const fallbacks = LIBRARY_CORE_FIELD_REGISTRY.filter((entry) =>
+      entry.path.segments.some(
+        (segment) => segment.kind === "unregistered-descendant",
+      ),
+    );
+    expect(fallbacks).toHaveLength(8);
+    expect(
+      fallbacks.every((entry) =>
+        entry.path.segments.some(
+          (segment) =>
+            segment.kind === "unregistered-descendant" &&
+            segment.recursive === true,
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      fallbacks.every(
+        (entry) =>
+          entry.currentLocality === "legacy-compatibility" &&
+          entry.currentAuthority === "legacy-automerge-read-only" &&
+          entry.opaqueRetention === null &&
+          entry.activation.blockers.includes(
+            "opaque_retention_unimplemented",
+          ) &&
+          entry.activation.blockers.includes(
+            "unregistered_descendant_requires_classification",
+          ),
+      ),
+    ).toBe(true);
+  });
+
+  it("models arrays, maps, dynamic roots, and immediate presence without ancestor collapse", () => {
+    const pathSegmentKinds = new Set(
+      LIBRARY_CORE_FIELD_REGISTRY.flatMap((entry) =>
+        entry.path.segments.map((segment) => segment.kind),
+      ),
+    );
+    expect(pathSegmentKinds).toEqual(
+      new Set([
+        "array-element",
+        "dynamic-map-key",
+        "dynamic-root-key",
+        "entity-key",
+        "fixed-map-key",
+        "property",
+        "unknown-root",
+        "unregistered-descendant",
+      ]),
+    );
+
+    expect(
+      entryAt("feedItems.{globalId}.contentSignals.version"),
+    ).toMatchObject({
+      localPresence: "required",
+      ancestorOptional: true,
+    });
+    const scoreEntry = LIBRARY_CORE_FIELD_REGISTRY.find((entry) =>
+      entry.path.text.includes("contentSignals.scores"),
+    );
+    expect(scoreEntry).toMatchObject({
+      localPresence: "optional",
+      ancestorOptional: true,
+      path: {
+        segments: expect.arrayContaining([
+          expect.objectContaining({
+            kind: "fixed-map-key",
+            name: "contentSignal",
+          }),
+        ]),
+      },
+    });
+    expect(
+      entryAt("feedItems.{globalId}.userState.highlights[].text"),
+    ).toMatchObject({
+      localPresence: "required",
+      ancestorOptional: true,
+    });
+
+    const desktopRoot = LIBRARY_CORE_ROOT_REGISTRY.find(
+      (entry) => entry.root === "desktopClient:*",
+    );
+    expect(desktopRoot?.path.segments[0]).toEqual({
+      kind: "dynamic-root-key",
+      prefix: DESKTOP_CLIENT_KEY_PREFIX,
+      name: "installationId",
+    });
+  });
+
+  it("does not invent protocol codecs, ranges, or closed string values", () => {
+    const numberEntries = LIBRARY_CORE_FIELD_REGISTRY.filter(
+      (entry) => entry.legacyValueShape === "typescript-number",
+    );
+
+    expect(numberEntries.length).toBeGreaterThan(0);
+    expect(
+      numberEntries.every(
+        (entry) =>
+          entry.valueCodec === null &&
+          entry.numericRange === null &&
+          entry.activation.blockers.includes("protocol_codec_undecided") &&
+          entry.activation.blockers.includes("field_range_undecided"),
+      ),
+    ).toBe(true);
+    expect(
+      LIBRARY_CORE_FIELD_REGISTRY.some(
+        (entry) => (entry.valueCodec as string | null) === "finite-number",
+      ),
+    ).toBe(false);
+
+    const stringEntries = LIBRARY_CORE_FIELD_REGISTRY.filter(
+      (entry) => entry.legacyValueShape === "typescript-string",
+    );
+    expect(stringEntries.length).toBeGreaterThan(0);
+    expect(
+      stringEntries.every(
+        (entry) =>
+          entry.valueCodec === null &&
+          entry.allowedValues === null &&
+          entry.activation.blockers.includes("protocol_codec_undecided") &&
+          entry.activation.blockers.includes("allowed_values_undecided"),
+      ),
+    ).toBe(true);
+  });
+
+  it("pairs every null future decision with its specific blocker", () => {
+    const blockerByField = {
+      executableValidation: "executable_validation_undecided",
+      plannedLocality: "planned_locality_undecided",
+      plannedAuthority: "planned_authority_undecided",
+      storageTier: "storage_tier_undecided",
+      allowedOperationTypes: "allowed_operations_undecided",
+      mergeAlgebra: "merge_algebra_undecided",
+      omissionSemantics: "omission_semantics_undecided",
+      explicitClear: "explicit_clear_undecided",
+      deleteBehavior: "delete_behavior_undecided",
+      restoreSemantics: "restore_semantics_undecided",
+      relationshipCascade: "relationship_cascade_undecided",
+      migrationRule: "legacy_migration_rule_undecided",
+      backupBehavior: "backup_behavior_undecided",
+      exportBehavior: "export_behavior_undecided",
+      redactionBehavior: "redaction_behavior_undecided",
+      provenanceBehavior: "provenance_behavior_undecided",
+      materializedProjection: "materialized_projection_undecided",
+      queryEligible: "query_eligibility_undecided",
+    } as const satisfies Partial<
+      Record<keyof LibraryCoreFieldRegistryEntry, LibraryCoreActivationBlocker>
+    >;
+
+    for (const entry of LIBRARY_CORE_FIELD_REGISTRY) {
+      expect(entry.activation.status).toBe("blocked");
+      expect(entry.activation.blockers).toEqual(
+        [...entry.activation.blockers].sort(compareCodeUnits),
+      );
+      for (const [field, blocker] of Object.entries(blockerByField)) {
+        if (entry[field as keyof LibraryCoreFieldRegistryEntry] === null) {
+          expect(
+            entry.activation.blockers,
+            `${entry.registryKey} lacks ${blocker}`,
+          ).toContain(blocker);
+        }
+      }
+      if (entry.localPresence === null || entry.ancestorOptional === null) {
+        expect(entry.activation.blockers).toContain(
+          "presence_semantics_undecided",
+        );
+      }
+      if (entry.valueCodec === null) {
+        expect(entry.activation.blockers).toContain("protocol_codec_undecided");
+      }
+      if (entry.allowedValues === null) {
+        expect(entry.activation.blockers).toContain("allowed_values_undecided");
+      }
+      if (entry.numericRange === null) {
+        expect(entry.activation.blockers).toContain("field_range_undecided");
+      }
+    }
+  });
+});

--- a/packages/shared/src/library-core/field-registry.ts
+++ b/packages/shared/src/library-core/field-registry.ts
@@ -1,0 +1,1692 @@
+import type {
+  Account,
+  AIPreferences,
+  Author,
+  Content,
+  ContentSignal,
+  ContentSignals,
+  DesktopClientRegistration,
+  DisplayPreferences,
+  DocumentMeta,
+  Engagement,
+  EventCandidate,
+  FacebookCapturePreferences,
+  FbGroupInfo,
+  FeedItem,
+  FriendSuggestionPreferences,
+  Highlight,
+  LegacyDeviceContact,
+  LegacyFriendSource,
+  LinkPreview,
+  Location,
+  Person,
+  PreservedContent,
+  ReachOutLog,
+  ReadingEnhancements,
+  RssFeed,
+  RssSourceInfo,
+  SampleDataFingerprint,
+  StoryWallPreferences,
+  StoryWallPublishTarget,
+  StoryWallStylePreferences,
+  SyncPreferences,
+  TimeRange,
+  UlyssesPreferences,
+  UserPreferences,
+  UserState,
+  WeightPreferences,
+  XAccount,
+  XCapturePreferences,
+} from "../types.js";
+import type {
+  DesktopClientKeyPrefix,
+  FreedDoc,
+  LegacyFriend,
+} from "../schema.js";
+import type {
+  LibraryCoreActivationBlocker,
+  LibraryCoreCurrentAuthority,
+  LibraryCoreCurrentLocality,
+  LibraryCoreEntity,
+  LibraryCoreFieldRegistryEntry,
+  LibraryCoreLegacyDisposition,
+  LibraryCorePathPattern,
+  LibraryCorePathSegment,
+  LibraryCorePresence,
+  LibraryCoreRootRegistryEntry,
+} from "./protocol-registry.js";
+
+type Primitive = string | number | boolean;
+
+type LegacyValueShapeFor<T> = T extends string
+  ? "typescript-string"
+  : T extends number
+    ? "typescript-number"
+    : T extends boolean
+      ? "typescript-boolean"
+      : never;
+
+type CodecFor<T> = T extends number
+  ? null
+  : T extends string
+    ? null
+    : T extends boolean
+      ? "boolean"
+      : never;
+
+type AllowedValuesFor<T> = T extends string
+  ? null
+  : { readonly kind: "not-applicable" };
+
+type NumericRangeFor<T> = T extends number
+  ? null
+  : { readonly kind: "not-applicable" };
+
+interface LeafNode<T> {
+  readonly kind: "leaf";
+  readonly legacyValueShape: LegacyValueShapeFor<T>;
+  readonly codec: CodecFor<T>;
+  readonly allowedValues: AllowedValuesFor<T>;
+  readonly legacyDisposition: LibraryCoreLegacyDisposition;
+  readonly currentLocality: LibraryCoreCurrentLocality;
+  readonly currentAuthority: LibraryCoreCurrentAuthority;
+  readonly numericRange: NumericRangeFor<T>;
+}
+
+interface ArrayNode<T> {
+  readonly kind: "array";
+  readonly element: ValueNode<T>;
+}
+
+interface DynamicMapNode<T> {
+  readonly kind: "dynamic-map";
+  readonly keyName: string;
+  readonly value: ValueNode<T>;
+}
+
+interface FixedMapNode<T extends object> {
+  readonly kind: "fixed-map";
+  readonly keyName: string;
+  readonly keys: { readonly [K in keyof T]-?: true };
+  readonly keyPresence: undefined extends T[keyof T] ? "optional" : "required";
+  readonly value: ValueNode<NonNullable<T[keyof T]>>;
+}
+
+interface ExactKeyIdentity<Keys extends PropertyKey> {
+  readonly input: (key: Keys) => void;
+  readonly output: Keys;
+}
+
+const exactObjectKeysSymbol = Symbol("library-core-exact-object-keys");
+
+interface ObjectNode<T extends object> {
+  readonly kind: "object";
+  readonly [exactObjectKeysSymbol]: ExactKeyIdentity<keyof T>;
+  readonly fields: {
+    readonly [K in keyof T]-?: PropertyNode<T[K]>;
+  };
+}
+
+type Defined<T> = Exclude<T, undefined>;
+
+type ValueNode<T> = null extends T
+  ? never
+  : Defined<T> extends Primitive
+    ? LeafNode<Defined<T>>
+    : Defined<T> extends readonly (infer Element)[]
+      ? ArrayNode<Element>
+      : Defined<T> extends object
+        ? string extends keyof Defined<T>
+          ? DynamicMapNode<Defined<T>[string]>
+          : ObjectNode<Defined<T>> | FixedMapNode<Defined<T>>
+        : never;
+
+type PropertyNode<T> = undefined extends T
+  ? {
+      readonly presence: "optional";
+      readonly value: ValueNode<T>;
+    }
+  : {
+      readonly presence: "required";
+      readonly value: ValueNode<T>;
+    };
+
+type RuntimeValueNode =
+  | LeafNode<Primitive>
+  | {
+      readonly kind: "array";
+      readonly element: RuntimeValueNode;
+    }
+  | {
+      readonly kind: "dynamic-map";
+      readonly keyName: string;
+      readonly value: RuntimeValueNode;
+    }
+  | {
+      readonly kind: "fixed-map";
+      readonly keyName: string;
+      readonly keys: Readonly<Record<string, true>>;
+      readonly keyPresence: LibraryCorePresence;
+      readonly value: RuntimeValueNode;
+    }
+  | {
+      readonly kind: "object";
+      readonly [exactObjectKeysSymbol]: ExactKeyIdentity<PropertyKey>;
+      readonly fields: Readonly<
+        Record<
+          string,
+          {
+            readonly presence: LibraryCorePresence;
+            readonly value: RuntimeValueNode;
+          }
+        >
+      >;
+    };
+
+const unresolvedFutureSemantics = null;
+
+const authorityFor = (
+  locality: LibraryCoreCurrentLocality,
+): LibraryCoreCurrentAuthority => {
+  switch (locality) {
+    case "legacy-synchronized":
+      return "legacy-automerge-document";
+    case "legacy-device-local":
+      return "installation-local-store";
+    case "legacy-derived":
+      return "derived-runtime";
+    case "legacy-compatibility":
+      return "legacy-automerge-read-only";
+  }
+};
+
+const localityFor = (
+  disposition: LibraryCoreLegacyDisposition,
+): LibraryCoreCurrentLocality => {
+  switch (disposition) {
+    case "sync":
+    case "positive-sync":
+      return "legacy-synchronized";
+    case "device-local":
+      return "legacy-device-local";
+    case "compatibility-only":
+      return "legacy-compatibility";
+  }
+};
+
+const leaf = <
+  Token extends "typescript-string" | "typescript-number" | "boolean",
+  Disposition extends LibraryCoreLegacyDisposition,
+>(
+  token: Token,
+  legacyDisposition: Disposition,
+  _futureSemantics: null,
+  currentLocality: LibraryCoreCurrentLocality = localityFor(legacyDisposition),
+): {
+  readonly kind: "leaf";
+  readonly legacyValueShape: Token extends "typescript-number"
+    ? "typescript-number"
+    : Token extends "boolean"
+      ? "typescript-boolean"
+      : "typescript-string";
+  readonly codec: Token extends "boolean" ? "boolean" : null;
+  readonly allowedValues: Token extends "typescript-string"
+    ? null
+    : { readonly kind: "not-applicable" };
+  readonly legacyDisposition: Disposition;
+  readonly currentLocality: LibraryCoreCurrentLocality;
+  readonly currentAuthority: LibraryCoreCurrentAuthority;
+  readonly numericRange: Token extends "typescript-number"
+    ? null
+    : { readonly kind: "not-applicable" };
+} =>
+  ({
+    kind: "leaf",
+    legacyValueShape:
+      token === "typescript-number"
+        ? "typescript-number"
+        : token === "boolean"
+          ? "typescript-boolean"
+          : "typescript-string",
+    codec: token === "boolean" ? token : null,
+    allowedValues:
+      token === "typescript-string" ? null : { kind: "not-applicable" },
+    legacyDisposition,
+    currentLocality,
+    currentAuthority: authorityFor(currentLocality),
+    numericRange:
+      token === "typescript-number" ? null : { kind: "not-applicable" },
+  }) as never;
+
+const required = <Node>(value: Node) =>
+  ({ presence: "required", value }) as const;
+
+const optional = <Node>(value: Node) =>
+  ({ presence: "optional", value }) as const;
+
+const object = <Fields extends object>(fields: Fields) =>
+  ({
+    kind: "object",
+    [exactObjectKeysSymbol]: null as unknown as ExactKeyIdentity<keyof Fields>,
+    fields,
+  }) as const;
+
+const array = <Element>(element: Element) =>
+  ({ kind: "array", element }) as const;
+
+const dynamicMap = <Value>(keyName: string, value: Value) =>
+  ({ kind: "dynamic-map", keyName, value }) as const;
+
+const fixedMap = <Keys, Presence extends LibraryCorePresence, Value>(
+  keyName: string,
+  keys: Keys,
+  keyPresence: Presence,
+  value: Value,
+) => ({ kind: "fixed-map", keyName, keys, keyPresence, value }) as const;
+
+const exactKeyObject =
+  <Expected extends PropertyKey>() =>
+  <Actual extends Record<Expected, unknown>>(
+    value: Actual & Record<Exclude<keyof Actual, Expected>, never>,
+  ): Actual =>
+    value;
+
+const compareCodeUnits = (left: string, right: string): number =>
+  left < right ? -1 : left > right ? 1 : 0;
+
+const desktopClientKeyPrefix: DesktopClientKeyPrefix = "desktopClient:";
+
+const sortBlockers = (
+  blockers: readonly LibraryCoreActivationBlocker[],
+): readonly LibraryCoreActivationBlocker[] =>
+  [...blockers].sort(compareCodeUnits);
+
+const fingerprintSchema = object({
+  marker: required(
+    leaf("typescript-string", "sync", unresolvedFutureSemantics),
+  ),
+  batchId: required(
+    leaf("typescript-string", "sync", unresolvedFutureSemantics),
+  ),
+  generatedAt: required(
+    leaf("typescript-number", "sync", unresolvedFutureSemantics),
+  ),
+  generatorVersion: required(
+    leaf("typescript-number", "sync", unresolvedFutureSemantics),
+  ),
+}) satisfies ObjectNode<SampleDataFingerprint>;
+
+const authorSchema = object({
+  id: required(leaf("typescript-string", "sync", unresolvedFutureSemantics)),
+  handle: required(
+    leaf("typescript-string", "sync", unresolvedFutureSemantics),
+  ),
+  displayName: required(
+    leaf("typescript-string", "sync", unresolvedFutureSemantics),
+  ),
+  avatarUrl: optional(
+    leaf("typescript-string", "sync", unresolvedFutureSemantics),
+  ),
+}) satisfies ObjectNode<Author>;
+
+const linkPreviewSchema = object({
+  url: required(leaf("typescript-string", "sync", unresolvedFutureSemantics)),
+  title: optional(leaf("typescript-string", "sync", unresolvedFutureSemantics)),
+  description: optional(
+    leaf("typescript-string", "sync", unresolvedFutureSemantics),
+  ),
+}) satisfies ObjectNode<LinkPreview>;
+
+const contentSchema = object({
+  text: optional(leaf("typescript-string", "sync", unresolvedFutureSemantics)),
+  mediaUrls: required(
+    array(leaf("typescript-string", "sync", unresolvedFutureSemantics)),
+  ),
+  mediaTypes: required(
+    array(leaf("typescript-string", "sync", unresolvedFutureSemantics)),
+  ),
+  linkPreview: optional(linkPreviewSchema),
+}) satisfies ObjectNode<Content>;
+
+const engagementSchema = object({
+  likes: optional(leaf("typescript-number", "sync", unresolvedFutureSemantics)),
+  reposts: optional(
+    leaf("typescript-number", "sync", unresolvedFutureSemantics),
+  ),
+  comments: optional(
+    leaf("typescript-number", "sync", unresolvedFutureSemantics),
+  ),
+  views: optional(leaf("typescript-number", "sync", unresolvedFutureSemantics)),
+}) satisfies ObjectNode<Engagement>;
+
+const locationSchema = object({
+  name: required(leaf("typescript-string", "sync", unresolvedFutureSemantics)),
+  coordinates: optional(
+    object({
+      lat: required(
+        leaf("typescript-number", "sync", unresolvedFutureSemantics),
+      ),
+      lng: required(
+        leaf("typescript-number", "sync", unresolvedFutureSemantics),
+      ),
+    }),
+  ),
+  url: optional(leaf("typescript-string", "sync", unresolvedFutureSemantics)),
+  source: required(
+    leaf("typescript-string", "sync", unresolvedFutureSemantics),
+  ),
+}) satisfies ObjectNode<Location>;
+
+const timeRangeSchema = object({
+  startsAt: required(
+    leaf("typescript-number", "sync", unresolvedFutureSemantics),
+  ),
+  endsAt: optional(
+    leaf("typescript-number", "sync", unresolvedFutureSemantics),
+  ),
+  kind: required(leaf("typescript-string", "sync", unresolvedFutureSemantics)),
+}) satisfies ObjectNode<TimeRange>;
+
+const rssSourceSchema = object({
+  feedUrl: required(
+    leaf("typescript-string", "sync", unresolvedFutureSemantics),
+  ),
+  feedTitle: required(
+    leaf("typescript-string", "sync", unresolvedFutureSemantics),
+  ),
+  siteUrl: required(
+    leaf("typescript-string", "sync", unresolvedFutureSemantics),
+  ),
+}) satisfies ObjectNode<RssSourceInfo>;
+
+const fbGroupSchema = object({
+  id: required(leaf("typescript-string", "sync", unresolvedFutureSemantics)),
+  name: required(leaf("typescript-string", "sync", unresolvedFutureSemantics)),
+  url: required(leaf("typescript-string", "sync", unresolvedFutureSemantics)),
+}) satisfies ObjectNode<FbGroupInfo>;
+
+const preservedContentSchema = object({
+  html: optional(
+    leaf(
+      "typescript-string",
+      "compatibility-only",
+      unresolvedFutureSemantics,
+      "legacy-compatibility",
+    ),
+  ),
+  text: required(leaf("typescript-string", "sync", unresolvedFutureSemantics)),
+  author: optional(
+    leaf("typescript-string", "sync", unresolvedFutureSemantics),
+  ),
+  publishedAt: optional(
+    leaf("typescript-number", "sync", unresolvedFutureSemantics),
+  ),
+  wordCount: required(
+    leaf("typescript-number", "sync", unresolvedFutureSemantics),
+  ),
+  readingTime: required(
+    leaf("typescript-number", "sync", unresolvedFutureSemantics),
+  ),
+  preservedAt: required(
+    leaf("typescript-number", "sync", unresolvedFutureSemantics),
+  ),
+}) satisfies ObjectNode<PreservedContent>;
+
+const highlightSchema = object({
+  text: required(leaf("typescript-string", "sync", unresolvedFutureSemantics)),
+  note: optional(leaf("typescript-string", "sync", unresolvedFutureSemantics)),
+  createdAt: required(
+    leaf("typescript-number", "sync", unresolvedFutureSemantics),
+  ),
+}) satisfies ObjectNode<Highlight>;
+
+const userStateSchema = object({
+  hidden: required(leaf("boolean", "sync", unresolvedFutureSemantics)),
+  readAt: optional(
+    leaf("typescript-number", "sync", unresolvedFutureSemantics),
+  ),
+  saved: required(leaf("boolean", "sync", unresolvedFutureSemantics)),
+  savedAt: optional(
+    leaf("typescript-number", "sync", unresolvedFutureSemantics),
+  ),
+  archived: required(leaf("boolean", "sync", unresolvedFutureSemantics)),
+  archivedAt: optional(
+    leaf("typescript-number", "sync", unresolvedFutureSemantics),
+  ),
+  tags: required(
+    array(leaf("typescript-string", "sync", unresolvedFutureSemantics)),
+  ),
+  highlights: optional(array(highlightSchema)),
+  liked: optional(leaf("boolean", "sync", unresolvedFutureSemantics)),
+  likedAt: optional(
+    leaf("typescript-number", "sync", unresolvedFutureSemantics),
+  ),
+  likedSyncedAt: optional(
+    leaf("typescript-number", "positive-sync", unresolvedFutureSemantics),
+  ),
+  seenSyncedAt: optional(
+    leaf("typescript-number", "positive-sync", unresolvedFutureSemantics),
+  ),
+}) satisfies ObjectNode<UserState>;
+
+const contentSignalKeySet = exactKeyObject<ContentSignal>()({
+  event: true,
+  deadline: true,
+  opportunity: true,
+  how_to: true,
+  reference: true,
+  transaction: true,
+  product_update: true,
+  alert: true,
+  deal: true,
+  place: true,
+  media: true,
+  essay: true,
+  moment: true,
+  life_update: true,
+  announcement: true,
+  recommendation: true,
+  request: true,
+  discussion: true,
+  promotion: true,
+  news: true,
+} as const);
+
+const contentSignalsSchema = object({
+  version: required(
+    leaf("typescript-number", "sync", unresolvedFutureSemantics),
+  ),
+  method: required(
+    leaf("typescript-string", "sync", unresolvedFutureSemantics),
+  ),
+  inferredAt: required(
+    leaf("typescript-number", "sync", unresolvedFutureSemantics),
+  ),
+  scores: required(
+    fixedMap(
+      "contentSignal",
+      contentSignalKeySet,
+      "optional",
+      leaf("typescript-number", "sync", unresolvedFutureSemantics),
+    ),
+  ),
+  tags: required(
+    array(leaf("typescript-string", "sync", unresolvedFutureSemantics)),
+  ),
+}) satisfies ObjectNode<ContentSignals>;
+
+const eventCandidateSchema = object({
+  version: required(
+    leaf("typescript-number", "sync", unresolvedFutureSemantics),
+  ),
+  method: required(
+    leaf("typescript-string", "sync", unresolvedFutureSemantics),
+  ),
+  detectedAt: required(
+    leaf("typescript-number", "sync", unresolvedFutureSemantics),
+  ),
+  confidence: required(
+    leaf("typescript-number", "sync", unresolvedFutureSemantics),
+  ),
+  title: optional(leaf("typescript-string", "sync", unresolvedFutureSemantics)),
+  startsAt: optional(
+    leaf("typescript-number", "sync", unresolvedFutureSemantics),
+  ),
+  endsAt: optional(
+    leaf("typescript-number", "sync", unresolvedFutureSemantics),
+  ),
+  timezone: optional(
+    leaf("typescript-string", "sync", unresolvedFutureSemantics),
+  ),
+  locationName: optional(
+    leaf("typescript-string", "sync", unresolvedFutureSemantics),
+  ),
+  locationUrl: optional(
+    leaf("typescript-string", "sync", unresolvedFutureSemantics),
+  ),
+  evidence: optional(
+    leaf("typescript-string", "sync", unresolvedFutureSemantics),
+  ),
+}) satisfies ObjectNode<EventCandidate>;
+
+const feedItemSchema = object({
+  globalId: required(
+    leaf("typescript-string", "sync", unresolvedFutureSemantics),
+  ),
+  platform: required(
+    leaf("typescript-string", "sync", unresolvedFutureSemantics),
+  ),
+  contentType: required(
+    leaf("typescript-string", "sync", unresolvedFutureSemantics),
+  ),
+  capturedAt: required(
+    leaf("typescript-number", "sync", unresolvedFutureSemantics),
+  ),
+  publishedAt: required(
+    leaf("typescript-number", "sync", unresolvedFutureSemantics),
+  ),
+  author: required(authorSchema),
+  content: required(contentSchema),
+  engagement: optional(engagementSchema),
+  location: optional(locationSchema),
+  timeRange: optional(timeRangeSchema),
+  rssSource: optional(rssSourceSchema),
+  fbGroup: optional(fbGroupSchema),
+  preservedContent: optional(preservedContentSchema),
+  userState: required(userStateSchema),
+  topics: required(
+    array(leaf("typescript-string", "sync", unresolvedFutureSemantics)),
+  ),
+  contentSignals: optional(contentSignalsSchema),
+  eventCandidate: optional(eventCandidateSchema),
+  priority: optional(
+    leaf(
+      "typescript-number",
+      "device-local",
+      unresolvedFutureSemantics,
+      "legacy-derived",
+    ),
+  ),
+  priorityComputedAt: optional(
+    leaf(
+      "typescript-number",
+      "device-local",
+      unresolvedFutureSemantics,
+      "legacy-derived",
+    ),
+  ),
+  sourceUrl: optional(
+    leaf("typescript-string", "sync", unresolvedFutureSemantics),
+  ),
+  sampleDataFingerprint: optional(fingerprintSchema),
+}) satisfies ObjectNode<FeedItem>;
+
+const rssFeedSchema = object({
+  url: required(leaf("typescript-string", "sync", unresolvedFutureSemantics)),
+  title: required(leaf("typescript-string", "sync", unresolvedFutureSemantics)),
+  siteUrl: optional(
+    leaf("typescript-string", "sync", unresolvedFutureSemantics),
+  ),
+  lastFetched: optional(
+    leaf("typescript-number", "sync", unresolvedFutureSemantics),
+  ),
+  lastFetchAttemptedAt: optional(
+    leaf("typescript-number", "device-local", unresolvedFutureSemantics),
+  ),
+  nextFetchAfter: optional(
+    leaf("typescript-number", "device-local", unresolvedFutureSemantics),
+  ),
+  consecutiveFailures: optional(
+    leaf("typescript-number", "device-local", unresolvedFutureSemantics),
+  ),
+  lastFetchError: optional(
+    leaf("typescript-string", "device-local", unresolvedFutureSemantics),
+  ),
+  etag: optional(
+    leaf("typescript-string", "compatibility-only", unresolvedFutureSemantics),
+  ),
+  lastModified: optional(
+    leaf("typescript-string", "compatibility-only", unresolvedFutureSemantics),
+  ),
+  imageUrl: optional(
+    leaf("typescript-string", "sync", unresolvedFutureSemantics),
+  ),
+  enabled: required(leaf("boolean", "sync", unresolvedFutureSemantics)),
+  pollInterval: optional(
+    leaf("typescript-number", "sync", unresolvedFutureSemantics),
+  ),
+  trackUnread: required(leaf("boolean", "sync", unresolvedFutureSemantics)),
+  folder: optional(
+    leaf("typescript-string", "sync", unresolvedFutureSemantics),
+  ),
+  sampleDataFingerprint: optional(fingerprintSchema),
+}) satisfies ObjectNode<RssFeed>;
+
+const reachOutLogSchema = object({
+  loggedAt: required(
+    leaf("typescript-number", "sync", unresolvedFutureSemantics),
+  ),
+  channel: optional(
+    leaf("typescript-string", "sync", unresolvedFutureSemantics),
+  ),
+  notes: optional(leaf("typescript-string", "sync", unresolvedFutureSemantics)),
+}) satisfies ObjectNode<ReachOutLog>;
+
+const personSchema = object({
+  id: required(leaf("typescript-string", "sync", unresolvedFutureSemantics)),
+  name: required(leaf("typescript-string", "sync", unresolvedFutureSemantics)),
+  avatarUrl: optional(
+    leaf("typescript-string", "sync", unresolvedFutureSemantics),
+  ),
+  bio: optional(leaf("typescript-string", "sync", unresolvedFutureSemantics)),
+  relationshipStatus: required(
+    leaf("typescript-string", "sync", unresolvedFutureSemantics),
+  ),
+  careLevel: required(
+    leaf("typescript-number", "sync", unresolvedFutureSemantics),
+  ),
+  reachOutIntervalDays: optional(
+    leaf("typescript-number", "sync", unresolvedFutureSemantics),
+  ),
+  reachOutLog: optional(array(reachOutLogSchema)),
+  tags: optional(
+    array(leaf("typescript-string", "sync", unresolvedFutureSemantics)),
+  ),
+  notes: optional(leaf("typescript-string", "sync", unresolvedFutureSemantics)),
+  graphX: optional(
+    leaf("typescript-number", "device-local", unresolvedFutureSemantics),
+  ),
+  graphY: optional(
+    leaf("typescript-number", "device-local", unresolvedFutureSemantics),
+  ),
+  graphPinned: optional(
+    leaf("boolean", "device-local", unresolvedFutureSemantics),
+  ),
+  graphUpdatedAt: optional(
+    leaf("typescript-number", "device-local", unresolvedFutureSemantics),
+  ),
+  sampleDataFingerprint: optional(fingerprintSchema),
+  createdAt: required(
+    leaf("typescript-number", "sync", unresolvedFutureSemantics),
+  ),
+  updatedAt: required(
+    leaf("typescript-number", "sync", unresolvedFutureSemantics),
+  ),
+}) satisfies ObjectNode<Person>;
+
+const accountSchema = object({
+  id: required(leaf("typescript-string", "sync", unresolvedFutureSemantics)),
+  personId: optional(
+    leaf("typescript-string", "sync", unresolvedFutureSemantics),
+  ),
+  kind: required(leaf("typescript-string", "sync", unresolvedFutureSemantics)),
+  provider: required(
+    leaf("typescript-string", "sync", unresolvedFutureSemantics),
+  ),
+  externalId: required(
+    leaf("typescript-string", "sync", unresolvedFutureSemantics),
+  ),
+  handle: optional(
+    leaf("typescript-string", "sync", unresolvedFutureSemantics),
+  ),
+  displayName: optional(
+    leaf("typescript-string", "sync", unresolvedFutureSemantics),
+  ),
+  avatarUrl: optional(
+    leaf("typescript-string", "sync", unresolvedFutureSemantics),
+  ),
+  profileUrl: optional(
+    leaf("typescript-string", "sync", unresolvedFutureSemantics),
+  ),
+  email: optional(leaf("typescript-string", "sync", unresolvedFutureSemantics)),
+  phone: optional(leaf("typescript-string", "sync", unresolvedFutureSemantics)),
+  address: optional(
+    leaf("typescript-string", "sync", unresolvedFutureSemantics),
+  ),
+  importedAt: optional(
+    leaf("typescript-number", "sync", unresolvedFutureSemantics),
+  ),
+  firstSeenAt: required(
+    leaf("typescript-number", "sync", unresolvedFutureSemantics),
+  ),
+  lastSeenAt: required(
+    leaf("typescript-number", "sync", unresolvedFutureSemantics),
+  ),
+  discoveredFrom: required(
+    leaf("typescript-string", "sync", unresolvedFutureSemantics),
+  ),
+  followRosterActive: optional(
+    leaf("boolean", "sync", unresolvedFutureSemantics),
+  ),
+  followRosterSyncedAt: optional(
+    leaf("typescript-number", "sync", unresolvedFutureSemantics),
+  ),
+  followRosterRoles: optional(
+    array(leaf("typescript-string", "sync", unresolvedFutureSemantics)),
+  ),
+  graphX: optional(
+    leaf("typescript-number", "device-local", unresolvedFutureSemantics),
+  ),
+  graphY: optional(
+    leaf("typescript-number", "device-local", unresolvedFutureSemantics),
+  ),
+  graphPinned: optional(
+    leaf("boolean", "device-local", unresolvedFutureSemantics),
+  ),
+  graphUpdatedAt: optional(
+    leaf("typescript-number", "device-local", unresolvedFutureSemantics),
+  ),
+  sampleDataFingerprint: optional(fingerprintSchema),
+  createdAt: required(
+    leaf("typescript-number", "sync", unresolvedFutureSemantics),
+  ),
+  updatedAt: required(
+    leaf("typescript-number", "sync", unresolvedFutureSemantics),
+  ),
+}) satisfies ObjectNode<Account>;
+
+const legacyFriendSourceSchema = object({
+  platform: required(
+    leaf("typescript-string", "sync", unresolvedFutureSemantics),
+  ),
+  authorId: required(
+    leaf("typescript-string", "sync", unresolvedFutureSemantics),
+  ),
+  handle: optional(
+    leaf("typescript-string", "sync", unresolvedFutureSemantics),
+  ),
+  displayName: optional(
+    leaf("typescript-string", "sync", unresolvedFutureSemantics),
+  ),
+  avatarUrl: optional(
+    leaf("typescript-string", "sync", unresolvedFutureSemantics),
+  ),
+  profileUrl: optional(
+    leaf("typescript-string", "sync", unresolvedFutureSemantics),
+  ),
+}) satisfies ObjectNode<LegacyFriendSource>;
+
+const legacyDeviceContactSchema = object({
+  importedFrom: required(
+    leaf("typescript-string", "sync", unresolvedFutureSemantics),
+  ),
+  name: required(leaf("typescript-string", "sync", unresolvedFutureSemantics)),
+  phone: optional(leaf("typescript-string", "sync", unresolvedFutureSemantics)),
+  email: optional(leaf("typescript-string", "sync", unresolvedFutureSemantics)),
+  address: optional(
+    leaf("typescript-string", "sync", unresolvedFutureSemantics),
+  ),
+  nativeId: optional(
+    leaf("typescript-string", "sync", unresolvedFutureSemantics),
+  ),
+  importedAt: required(
+    leaf("typescript-number", "sync", unresolvedFutureSemantics),
+  ),
+}) satisfies ObjectNode<LegacyDeviceContact>;
+
+const friendSchema = object({
+  id: required(leaf("typescript-string", "sync", unresolvedFutureSemantics)),
+  name: required(leaf("typescript-string", "sync", unresolvedFutureSemantics)),
+  avatarUrl: optional(
+    leaf("typescript-string", "sync", unresolvedFutureSemantics),
+  ),
+  bio: optional(leaf("typescript-string", "sync", unresolvedFutureSemantics)),
+  sources: required(array(legacyFriendSourceSchema)),
+  contact: optional(legacyDeviceContactSchema),
+  careLevel: required(
+    leaf("typescript-number", "sync", unresolvedFutureSemantics),
+  ),
+  reachOutIntervalDays: optional(
+    leaf("typescript-number", "sync", unresolvedFutureSemantics),
+  ),
+  reachOutLog: optional(array(reachOutLogSchema)),
+  tags: optional(
+    array(leaf("typescript-string", "sync", unresolvedFutureSemantics)),
+  ),
+  notes: optional(leaf("typescript-string", "sync", unresolvedFutureSemantics)),
+  createdAt: required(
+    leaf("typescript-number", "sync", unresolvedFutureSemantics),
+  ),
+  updatedAt: required(
+    leaf("typescript-number", "sync", unresolvedFutureSemantics),
+  ),
+}) satisfies ObjectNode<LegacyFriend>;
+
+const weightPreferencesSchema = object({
+  recency: required(
+    leaf("typescript-number", "sync", unresolvedFutureSemantics),
+  ),
+  platforms: required(
+    dynamicMap(
+      "platform",
+      leaf("typescript-number", "sync", unresolvedFutureSemantics),
+    ),
+  ),
+  topics: required(
+    dynamicMap(
+      "topic",
+      leaf("typescript-number", "sync", unresolvedFutureSemantics),
+    ),
+  ),
+  authors: required(
+    dynamicMap(
+      "authorId",
+      leaf("typescript-number", "sync", unresolvedFutureSemantics),
+    ),
+  ),
+}) satisfies ObjectNode<WeightPreferences>;
+
+const ulyssesPreferencesSchema = object({
+  enabled: required(leaf("boolean", "sync", unresolvedFutureSemantics)),
+  blockedPlatforms: required(
+    array(leaf("typescript-string", "sync", unresolvedFutureSemantics)),
+  ),
+  allowedPaths: required(
+    dynamicMap(
+      "platform",
+      array(leaf("typescript-string", "sync", unresolvedFutureSemantics)),
+    ),
+  ),
+}) satisfies ObjectNode<UlyssesPreferences>;
+
+const syncPreferencesSchema = object({
+  cloudProvider: optional(
+    leaf("typescript-string", "compatibility-only", unresolvedFutureSemantics),
+  ),
+  autoBackup: required(
+    leaf("boolean", "compatibility-only", unresolvedFutureSemantics),
+  ),
+  backupFrequency: optional(
+    leaf("typescript-string", "compatibility-only", unresolvedFutureSemantics),
+  ),
+}) satisfies ObjectNode<SyncPreferences>;
+
+const readingEnhancementsSchema = object({
+  focusMode: required(leaf("boolean", "sync", unresolvedFutureSemantics)),
+  focusIntensity: required(
+    leaf("typescript-string", "sync", unresolvedFutureSemantics),
+  ),
+  markReadOnScroll: required(
+    leaf("boolean", "sync", unresolvedFutureSemantics),
+  ),
+  showReadInGrayscale: required(
+    leaf("boolean", "sync", unresolvedFutureSemantics),
+  ),
+  dualColumnMode: optional(
+    leaf("boolean", "device-local", unresolvedFutureSemantics),
+  ),
+}) satisfies ObjectNode<ReadingEnhancements>;
+
+const displayPreferencesSchema = object({
+  itemsPerPage: optional(
+    leaf("typescript-number", "compatibility-only", unresolvedFutureSemantics),
+  ),
+  compactMode: optional(
+    leaf("boolean", "compatibility-only", unresolvedFutureSemantics),
+  ),
+  themeId: required(
+    leaf("typescript-string", "sync", unresolvedFutureSemantics),
+  ),
+  showEngagementCounts: required(
+    leaf("boolean", "sync", unresolvedFutureSemantics),
+  ),
+  animationIntensity: required(
+    leaf("typescript-string", "sync", unresolvedFutureSemantics),
+  ),
+  reading: required(readingEnhancementsSchema),
+  sidebarWidth: optional(
+    leaf("typescript-number", "device-local", unresolvedFutureSemantics),
+  ),
+  sidebarMode: optional(
+    leaf("typescript-string", "device-local", unresolvedFutureSemantics),
+  ),
+  friendsSidebarWidth: optional(
+    leaf("typescript-number", "device-local", unresolvedFutureSemantics),
+  ),
+  friendsSidebarOpen: optional(
+    leaf("boolean", "device-local", unresolvedFutureSemantics),
+  ),
+  friendsMode: optional(
+    leaf("typescript-string", "device-local", unresolvedFutureSemantics),
+  ),
+  friendAvatarTint: optional(
+    leaf("typescript-string", "compatibility-only", unresolvedFutureSemantics),
+  ),
+  debugPanelWidth: optional(
+    leaf("typescript-number", "device-local", unresolvedFutureSemantics),
+  ),
+  mapMode: optional(
+    leaf("typescript-string", "device-local", unresolvedFutureSemantics),
+  ),
+  mapTimeMode: optional(
+    leaf("typescript-string", "device-local", unresolvedFutureSemantics),
+  ),
+  feedSignalMode: optional(
+    leaf("typescript-string", "device-local", unresolvedFutureSemantics),
+  ),
+  feedSignalModes: optional(
+    array(leaf("typescript-string", "device-local", unresolvedFutureSemantics)),
+  ),
+  savedContentSortMode: optional(
+    leaf("typescript-string", "device-local", unresolvedFutureSemantics),
+  ),
+  archivePruneDays: required(
+    leaf("typescript-number", "sync", unresolvedFutureSemantics),
+  ),
+}) satisfies ObjectNode<DisplayPreferences>;
+
+const xAccountSchema = object({
+  id: required(leaf("typescript-string", "sync", unresolvedFutureSemantics)),
+  handle: required(
+    leaf("typescript-string", "sync", unresolvedFutureSemantics),
+  ),
+  displayName: optional(
+    leaf("typescript-string", "sync", unresolvedFutureSemantics),
+  ),
+  avatarUrl: optional(
+    leaf("typescript-string", "sync", unresolvedFutureSemantics),
+  ),
+  addedAt: required(
+    leaf("typescript-number", "sync", unresolvedFutureSemantics),
+  ),
+  note: optional(leaf("typescript-string", "sync", unresolvedFutureSemantics)),
+}) satisfies ObjectNode<XAccount>;
+
+const xCapturePreferencesSchema = object({
+  mode: required(leaf("typescript-string", "sync", unresolvedFutureSemantics)),
+  whitelist: required(dynamicMap("accountId", xAccountSchema)),
+  blacklist: required(dynamicMap("accountId", xAccountSchema)),
+  includeRetweets: required(leaf("boolean", "sync", unresolvedFutureSemantics)),
+  includeReplies: required(leaf("boolean", "sync", unresolvedFutureSemantics)),
+}) satisfies ObjectNode<XCapturePreferences>;
+
+const facebookCapturePreferencesSchema = object({
+  knownGroups: optional(
+    dynamicMap(
+      "groupId",
+      object({
+        id: required(
+          leaf("typescript-string", "device-local", unresolvedFutureSemantics),
+        ),
+        name: required(
+          leaf("typescript-string", "device-local", unresolvedFutureSemantics),
+        ),
+        url: required(
+          leaf("typescript-string", "device-local", unresolvedFutureSemantics),
+        ),
+      }) satisfies ObjectNode<FbGroupInfo>,
+    ),
+  ),
+  excludedGroupIds: required(
+    dynamicMap("groupId", leaf("boolean", "sync", unresolvedFutureSemantics)),
+  ),
+}) satisfies ObjectNode<FacebookCapturePreferences>;
+
+const friendSuggestionPreferencesSchema = object({
+  dismissedSuggestionIds: required(
+    array(leaf("typescript-string", "sync", unresolvedFutureSemantics)),
+  ),
+}) satisfies ObjectNode<FriendSuggestionPreferences>;
+
+const aiPreferencesSchema = object({
+  provider: optional(
+    leaf("typescript-string", "device-local", unresolvedFutureSemantics),
+  ),
+  model: optional(
+    leaf("typescript-string", "device-local", unresolvedFutureSemantics),
+  ),
+  ollamaUrl: optional(
+    leaf("typescript-string", "device-local", unresolvedFutureSemantics),
+  ),
+  autoSummarize: required(leaf("boolean", "sync", unresolvedFutureSemantics)),
+  extractTopics: required(leaf("boolean", "sync", unresolvedFutureSemantics)),
+}) satisfies ObjectNode<AIPreferences>;
+
+const storyWallStyleSchema = object({
+  palette: required(
+    leaf("typescript-string", "sync", unresolvedFutureSemantics),
+  ),
+  typographyScale: required(
+    leaf("typescript-number", "sync", unresolvedFutureSemantics),
+  ),
+  mediaDensity: required(
+    leaf("typescript-number", "sync", unresolvedFutureSemantics),
+  ),
+  captionsEnabled: required(leaf("boolean", "sync", unresolvedFutureSemantics)),
+  locationGroupingEnabled: required(
+    leaf("boolean", "sync", unresolvedFutureSemantics),
+  ),
+  dateGroupingEnabled: required(
+    leaf("boolean", "sync", unresolvedFutureSemantics),
+  ),
+  motionLevel: required(
+    leaf("typescript-string", "sync", unresolvedFutureSemantics),
+  ),
+}) satisfies ObjectNode<StoryWallStylePreferences>;
+
+const storyWallPublishTargetSchema = object({
+  provider: required(
+    leaf("typescript-string", "sync", unresolvedFutureSemantics),
+  ),
+  repoName: required(
+    leaf("typescript-string", "sync", unresolvedFutureSemantics),
+  ),
+  branch: required(
+    leaf("typescript-string", "sync", unresolvedFutureSemantics),
+  ),
+  directory: required(
+    leaf("typescript-string", "sync", unresolvedFutureSemantics),
+  ),
+  pagesUrl: optional(
+    leaf("typescript-string", "sync", unresolvedFutureSemantics),
+  ),
+  lastPublishedAt: optional(
+    leaf("typescript-number", "sync", unresolvedFutureSemantics),
+  ),
+  lastError: optional(
+    leaf("typescript-string", "device-local", unresolvedFutureSemantics),
+  ),
+  status: optional(
+    leaf("typescript-string", "device-local", unresolvedFutureSemantics),
+  ),
+}) satisfies ObjectNode<StoryWallPublishTarget>;
+
+const storyWallPreferencesSchema = object({
+  enabled: required(leaf("boolean", "sync", unresolvedFutureSemantics)),
+  selectedYears: required(
+    array(leaf("typescript-number", "sync", unresolvedFutureSemantics)),
+  ),
+  includedPlatforms: required(
+    array(leaf("typescript-string", "sync", unresolvedFutureSemantics)),
+  ),
+  includedAccountIds: required(
+    array(leaf("typescript-string", "sync", unresolvedFutureSemantics)),
+  ),
+  visibilityDefault: required(
+    leaf("typescript-string", "sync", unresolvedFutureSemantics),
+  ),
+  layoutPreset: required(
+    leaf("typescript-string", "sync", unresolvedFutureSemantics),
+  ),
+  style: required(storyWallStyleSchema),
+  embedModeEnabled: required(
+    leaf("boolean", "sync", unresolvedFutureSemantics),
+  ),
+  publishTarget: required(storyWallPublishTargetSchema),
+  featuredItemIds: required(
+    array(leaf("typescript-string", "sync", unresolvedFutureSemantics)),
+  ),
+  hiddenItemIds: required(
+    array(leaf("typescript-string", "sync", unresolvedFutureSemantics)),
+  ),
+  lastReviewedAt: optional(
+    leaf("typescript-number", "sync", unresolvedFutureSemantics),
+  ),
+}) satisfies ObjectNode<StoryWallPreferences>;
+
+const userPreferencesSchema = object({
+  weights: required(weightPreferencesSchema),
+  ulysses: required(ulyssesPreferencesSchema),
+  sync: optional(syncPreferencesSchema),
+  display: required(displayPreferencesSchema),
+  xCapture: required(xCapturePreferencesSchema),
+  fbCapture: required(facebookCapturePreferencesSchema),
+  friendSuggestions: required(friendSuggestionPreferencesSchema),
+  ai: required(aiPreferencesSchema),
+  storyWall: required(storyWallPreferencesSchema),
+}) satisfies ObjectNode<UserPreferences>;
+
+const documentMetaSchema = object({
+  documentId: optional(
+    leaf("typescript-string", "sync", unresolvedFutureSemantics),
+  ),
+  deviceId: optional(
+    leaf("typescript-string", "compatibility-only", unresolvedFutureSemantics),
+  ),
+  lastSync: optional(
+    leaf("typescript-number", "compatibility-only", unresolvedFutureSemantics),
+  ),
+  version: required(
+    leaf("typescript-number", "sync", unresolvedFutureSemantics),
+  ),
+}) satisfies ObjectNode<DocumentMeta>;
+
+const desktopClientRegistrationSchema = object({
+  id: required(leaf("typescript-string", "sync", unresolvedFutureSemantics)),
+  registeredAt: required(
+    leaf("typescript-number", "sync", unresolvedFutureSemantics),
+  ),
+}) satisfies ObjectNode<DesktopClientRegistration>;
+
+/*
+ * These unreachable assignments make schema drift a compile failure. The
+ * exact-key identity rejects stale nested keys, and nullable additions require
+ * an explicit registry model instead of silently inheriting a leaf codec.
+ */
+if (false) {
+  const staleDesktopClientSchema = object({
+    id: required(leaf("typescript-string", "sync", unresolvedFutureSemantics)),
+    registeredAt: required(
+      leaf("typescript-number", "sync", unresolvedFutureSemantics),
+    ),
+    stale: required(
+      leaf("typescript-string", "sync", unresolvedFutureSemantics),
+    ),
+  });
+  // @ts-expect-error Extra nested keys must not satisfy a registered object.
+  const exactDesktopClientSchema: ObjectNode<DesktopClientRegistration> =
+    staleDesktopClientSchema;
+
+  interface NullableFieldFixture {
+    value: string | null;
+  }
+  const unmodeledNullableSchema = object({
+    value: required(
+      leaf("typescript-string", "sync", unresolvedFutureSemantics),
+    ),
+  });
+  // @ts-expect-error Nullable fields require an explicit registry node.
+  const exactNullableSchema: ObjectNode<NullableFieldFixture> =
+    unmodeledNullableSchema;
+
+  void exactDesktopClientSchema;
+  void exactNullableSchema;
+}
+
+interface RootSchema<T extends object = object> {
+  readonly root: Exclude<
+    LibraryCoreFieldRegistryEntry["root"],
+    "<unknown-root>"
+  >;
+  readonly entity: LibraryCoreEntity;
+  readonly baseSegments: readonly LibraryCorePathSegment[];
+  readonly schema: ObjectNode<T>;
+  readonly currentLocalityOverride?: LibraryCoreCurrentLocality;
+  readonly currentAuthorityOverride?: LibraryCoreCurrentAuthority;
+  readonly additionalBlockers?: readonly LibraryCoreActivationBlocker[];
+}
+
+type StaticRootSchemas = {
+  readonly feedItems: RootSchema<FeedItem>;
+  readonly rssFeeds: RootSchema<RssFeed>;
+  readonly persons: RootSchema<Person>;
+  readonly accounts: RootSchema<Account>;
+  readonly preferences: RootSchema<UserPreferences>;
+  readonly meta: RootSchema<DocumentMeta>;
+};
+
+const staticRootSchemas = exactKeyObject<keyof FreedDoc>()({
+  feedItems: {
+    root: "feedItems",
+    entity: "FeedItem",
+    baseSegments: [
+      { kind: "property", name: "feedItems" },
+      { kind: "entity-key", name: "globalId" },
+    ],
+    schema: feedItemSchema,
+  },
+  rssFeeds: {
+    root: "rssFeeds",
+    entity: "RssFeed",
+    baseSegments: [
+      { kind: "property", name: "rssFeeds" },
+      { kind: "entity-key", name: "url" },
+    ],
+    schema: rssFeedSchema,
+  },
+  persons: {
+    root: "persons",
+    entity: "Person",
+    baseSegments: [
+      { kind: "property", name: "persons" },
+      { kind: "entity-key", name: "personId" },
+    ],
+    schema: personSchema,
+  },
+  accounts: {
+    root: "accounts",
+    entity: "Account",
+    baseSegments: [
+      { kind: "property", name: "accounts" },
+      { kind: "entity-key", name: "accountId" },
+    ],
+    schema: accountSchema,
+  },
+  preferences: {
+    root: "preferences",
+    entity: "UserPreferences",
+    baseSegments: [{ kind: "property", name: "preferences" }],
+    schema: userPreferencesSchema,
+  },
+  meta: {
+    root: "meta",
+    entity: "DocumentMeta",
+    baseSegments: [{ kind: "property", name: "meta" }],
+    schema: documentMetaSchema,
+  },
+} as const satisfies StaticRootSchemas);
+
+const desktopClientRootSchema = {
+  root: "desktopClient:*",
+  entity: "DesktopClientRegistration",
+  baseSegments: [
+    {
+      kind: "dynamic-root-key",
+      prefix: desktopClientKeyPrefix,
+      name: "installationId",
+    },
+  ],
+  schema: desktopClientRegistrationSchema,
+} as const satisfies RootSchema<DesktopClientRegistration>;
+
+const friendRootSchema = {
+  root: "friends",
+  entity: "LegacyFriend",
+  baseSegments: [
+    { kind: "property", name: "friends" },
+    { kind: "entity-key", name: "friendId" },
+  ],
+  schema: friendSchema,
+  currentLocalityOverride: "legacy-compatibility",
+  currentAuthorityOverride: "legacy-automerge-read-only",
+  additionalBlockers: ["legacy_root_requires_migration"],
+} as const satisfies RootSchema<LegacyFriend>;
+
+const rootSchemas = [
+  ...Object.keys(staticRootSchemas)
+    .sort(compareCodeUnits)
+    .map(
+      (root) =>
+        staticRootSchemas[
+          root as keyof typeof staticRootSchemas
+        ] as unknown as RootSchema,
+    ),
+  desktopClientRootSchema as unknown as RootSchema,
+  friendRootSchema as unknown as RootSchema,
+];
+
+const pathText = (segments: readonly LibraryCorePathSegment[]): string =>
+  segments
+    .map((segment) => {
+      switch (segment.kind) {
+        case "property":
+          return segment.name;
+        case "entity-key":
+        case "dynamic-map-key":
+          return `{${segment.name}}`;
+        case "fixed-map-key":
+          return `{${segment.name}:${segment.allowedKeys.join("|")}}`;
+        case "array-element":
+          return "[]";
+        case "dynamic-root-key":
+          return `${segment.prefix}{${segment.name}}`;
+        case "unregistered-descendant":
+          return "<unregistered-descendant:**>";
+        case "unknown-root":
+          return "<unknown-root>";
+      }
+    })
+    .reduce(
+      (text, part) =>
+        part === "[]"
+          ? `${text}[]`
+          : text.length === 0
+            ? part
+            : `${text}.${part}`,
+      "",
+    );
+
+const pattern = (
+  segments: readonly LibraryCorePathSegment[],
+): LibraryCorePathPattern => ({
+  text: pathText(segments),
+  segments,
+});
+
+const unresolvedProtocolBlockers = [
+  "allowed_operations_undecided",
+  "backup_behavior_undecided",
+  "delete_behavior_undecided",
+  "executable_validation_undecided",
+  "explicit_clear_undecided",
+  "export_behavior_undecided",
+  "legacy_migration_rule_undecided",
+  "materialized_projection_undecided",
+  "merge_algebra_undecided",
+  "omission_semantics_undecided",
+  "planned_authority_undecided",
+  "planned_locality_undecided",
+  "provenance_behavior_undecided",
+  "query_eligibility_undecided",
+  "redaction_behavior_undecided",
+  "relationship_cascade_undecided",
+  "restore_semantics_undecided",
+  "storage_tier_undecided",
+] as const satisfies readonly LibraryCoreActivationBlocker[];
+
+const blockersFor = (
+  leafNode: LeafNode<Primitive>,
+): readonly LibraryCoreActivationBlocker[] => [
+  ...unresolvedProtocolBlockers,
+  ...(leafNode.allowedValues === null
+    ? (["allowed_values_undecided"] as const)
+    : []),
+  ...(leafNode.codec === null ? (["protocol_codec_undecided"] as const) : []),
+  ...(leafNode.numericRange === null
+    ? (["field_range_undecided"] as const)
+    : []),
+];
+
+const entryFor = (
+  root: Exclude<LibraryCoreFieldRegistryEntry["root"], "<unknown-root>">,
+  entity: LibraryCoreEntity,
+  pathSegments: readonly LibraryCorePathSegment[],
+  localPresence: LibraryCorePresence,
+  ancestorOptional: boolean,
+  leafNode: LeafNode<Primitive>,
+  currentLocalityOverride?: LibraryCoreCurrentLocality,
+  currentAuthorityOverride?: LibraryCoreCurrentAuthority,
+  additionalBlockers: readonly LibraryCoreActivationBlocker[] = [],
+): LibraryCoreFieldRegistryEntry => {
+  const fieldPath = pattern(pathSegments);
+  return {
+    registryKey: `library-core-v1:${fieldPath.text}`,
+    root,
+    entity,
+    path: fieldPath,
+    legacyValueShape: leafNode.legacyValueShape,
+    valueCodec: leafNode.codec,
+    allowedValues: leafNode.allowedValues,
+    localPresence,
+    ancestorOptional,
+    nullable: false,
+    currentValidation: {
+      kind: "typescript-shape-census",
+      schema: `${entity}:${fieldPath.text}`,
+    },
+    executableValidation: null,
+    currentLocality: currentLocalityOverride ?? leafNode.currentLocality,
+    currentAuthority: currentAuthorityOverride ?? leafNode.currentAuthority,
+    plannedLocality: null,
+    plannedAuthority: null,
+    legacyDisposition: leafNode.legacyDisposition,
+    numericRange: leafNode.numericRange,
+    storageTier: null,
+    allowedOperationTypes: null,
+    mergeAlgebra: null,
+    omissionSemantics: null,
+    explicitClear: null,
+    deleteBehavior: null,
+    restoreSemantics: null,
+    relationshipCascade: null,
+    legacySourcePaths: [fieldPath.text],
+    opaqueRetention: null,
+    migrationRule: null,
+    backupBehavior: null,
+    exportBehavior: null,
+    redactionBehavior: null,
+    provenanceBehavior: null,
+    materializedProjection: null,
+    queryEligible: null,
+    activation: {
+      status: "blocked",
+      blockers: sortBlockers([...blockersFor(leafNode), ...additionalBlockers]),
+    },
+  };
+};
+
+const flattenValue = (
+  output: LibraryCoreFieldRegistryEntry[],
+  root: Exclude<LibraryCoreFieldRegistryEntry["root"], "<unknown-root>">,
+  entity: LibraryCoreEntity,
+  pathSegments: readonly LibraryCorePathSegment[],
+  localPresence: LibraryCorePresence,
+  ancestorOptional: boolean,
+  node: RuntimeValueNode,
+  currentLocalityOverride?: LibraryCoreCurrentLocality,
+  currentAuthorityOverride?: LibraryCoreCurrentAuthority,
+  additionalBlockers: readonly LibraryCoreActivationBlocker[] = [],
+): void => {
+  switch (node.kind) {
+    case "leaf":
+      output.push(
+        entryFor(
+          root,
+          entity,
+          pathSegments,
+          localPresence,
+          ancestorOptional,
+          node as LeafNode<Primitive>,
+          currentLocalityOverride,
+          currentAuthorityOverride,
+          additionalBlockers,
+        ),
+      );
+      return;
+    case "array":
+      flattenValue(
+        output,
+        root,
+        entity,
+        [...pathSegments, { kind: "array-element" }],
+        "required",
+        ancestorOptional || localPresence === "optional",
+        node.element,
+        currentLocalityOverride,
+        currentAuthorityOverride,
+        additionalBlockers,
+      );
+      return;
+    case "dynamic-map":
+      flattenValue(
+        output,
+        root,
+        entity,
+        [...pathSegments, { kind: "dynamic-map-key", name: node.keyName }],
+        "required",
+        ancestorOptional || localPresence === "optional",
+        node.value,
+        currentLocalityOverride,
+        currentAuthorityOverride,
+        additionalBlockers,
+      );
+      return;
+    case "fixed-map": {
+      const allowedKeys = Object.keys(node.keys).sort(compareCodeUnits);
+      flattenValue(
+        output,
+        root,
+        entity,
+        [
+          ...pathSegments,
+          { kind: "fixed-map-key", name: node.keyName, allowedKeys },
+        ],
+        node.keyPresence,
+        ancestorOptional || localPresence === "optional",
+        node.value,
+        currentLocalityOverride,
+        currentAuthorityOverride,
+        additionalBlockers,
+      );
+      return;
+    }
+    case "object":
+      for (const name of Object.keys(node.fields).sort(compareCodeUnits)) {
+        const property = node.fields[name];
+        flattenValue(
+          output,
+          root,
+          entity,
+          [...pathSegments, { kind: "property", name }],
+          property.presence,
+          ancestorOptional || localPresence === "optional",
+          property.value,
+          currentLocalityOverride,
+          currentAuthorityOverride,
+          additionalBlockers,
+        );
+      }
+  }
+};
+
+const typedEntries: LibraryCoreFieldRegistryEntry[] = [];
+for (const rootSchema of rootSchemas) {
+  flattenValue(
+    typedEntries,
+    rootSchema.root,
+    rootSchema.entity,
+    rootSchema.baseSegments,
+    "required",
+    false,
+    rootSchema.schema as unknown as RuntimeValueNode,
+    rootSchema.currentLocalityOverride,
+    rootSchema.currentAuthorityOverride,
+    rootSchema.additionalBlockers,
+  );
+}
+
+const opaqueEntry = (
+  registryKey: string,
+  root: LibraryCoreFieldRegistryEntry["root"],
+  entity: LibraryCoreEntity,
+  segments: readonly LibraryCorePathSegment[],
+  blocker: Extract<
+    LibraryCoreActivationBlocker,
+    | "unknown_root_requires_classification"
+    | "unregistered_descendant_requires_classification"
+  >,
+): LibraryCoreFieldRegistryEntry => ({
+  registryKey,
+  root,
+  entity,
+  path: pattern(segments),
+  legacyValueShape: "unregistered-legacy-value",
+  valueCodec: null,
+  allowedValues: null,
+  localPresence: null,
+  ancestorOptional: null,
+  nullable: true,
+  currentValidation: {
+    kind: "unregistered-legacy-shape",
+    schema: "retained in the current legacy Automerge document",
+  },
+  executableValidation: null,
+  currentLocality: "legacy-compatibility",
+  currentAuthority: "legacy-automerge-read-only",
+  plannedLocality: null,
+  plannedAuthority: null,
+  legacyDisposition: null,
+  numericRange: null,
+  storageTier: null,
+  allowedOperationTypes: null,
+  mergeAlgebra: null,
+  omissionSemantics: null,
+  explicitClear: null,
+  deleteBehavior: null,
+  restoreSemantics: null,
+  relationshipCascade: null,
+  legacySourcePaths: [pattern(segments).text],
+  opaqueRetention: null,
+  migrationRule: null,
+  backupBehavior: null,
+  exportBehavior: null,
+  redactionBehavior: null,
+  provenanceBehavior: null,
+  materializedProjection: null,
+  queryEligible: null,
+  activation: {
+    status: "blocked",
+    blockers: sortBlockers([
+      ...unresolvedProtocolBlockers,
+      "allowed_values_undecided",
+      "field_range_undecided",
+      "opaque_retention_unimplemented",
+      "presence_semantics_undecided",
+      "protocol_codec_undecided",
+      blocker,
+    ]),
+  },
+});
+
+const unregisteredDescendantEntries = rootSchemas.map((rootSchema) =>
+  opaqueEntry(
+    `library-core-v1:${rootSchema.root}:<unregistered-descendant:**>`,
+    rootSchema.root,
+    "OpaqueRecoveryEvidence",
+    [
+      ...rootSchema.baseSegments,
+      { kind: "unregistered-descendant", recursive: true },
+    ],
+    "unregistered_descendant_requires_classification",
+  ),
+);
+
+const retainedEntries = [
+  opaqueEntry(
+    "library-core-v1:<unknown-root>",
+    "<unknown-root>",
+    "OpaqueRecoveryEvidence",
+    [{ kind: "unknown-root" }],
+    "unknown_root_requires_classification",
+  ),
+] as const;
+
+/**
+ * Deterministic, exhaustive census of every current synchronized schema leaf.
+ *
+ * Every undecided v1 semantic is encoded as null and paired with an explicit
+ * activation blocker. This registry cannot authorize persistence or cutover.
+ */
+export const LIBRARY_CORE_FIELD_REGISTRY = [
+  ...typedEntries,
+  ...unregisteredDescendantEntries,
+  ...retainedEntries,
+].sort((left, right) => compareCodeUnits(left.registryKey, right.registryKey));
+
+const staticRootKinds = exactKeyObject<keyof FreedDoc>()({
+  accounts: "entity-map",
+  feedItems: "entity-map",
+  meta: "singleton",
+  persons: "entity-map",
+  preferences: "singleton",
+  rssFeeds: "entity-map",
+} as const);
+
+const rootBlockers = [
+  "planned_authority_undecided",
+  "planned_locality_undecided",
+] as const satisfies readonly LibraryCoreActivationBlocker[];
+
+const rootEntry = (
+  rootSchema: RootSchema,
+  kind: LibraryCoreRootRegistryEntry["kind"],
+  additionalBlockers: readonly LibraryCoreActivationBlocker[] = [],
+): LibraryCoreRootRegistryEntry => ({
+  registryKey: `library-core-v1:root:${rootSchema.root}`,
+  root: rootSchema.root,
+  entity: rootSchema.entity,
+  kind,
+  path: pattern(rootSchema.baseSegments),
+  currentLocality: rootSchema.currentLocalityOverride ?? "legacy-synchronized",
+  currentAuthority:
+    rootSchema.currentAuthorityOverride ?? "legacy-automerge-document",
+  plannedLocality: null,
+  plannedAuthority: null,
+  cutover: "blocked",
+  blockers: sortBlockers([...rootBlockers, ...additionalBlockers]),
+});
+
+export const LIBRARY_CORE_ROOT_REGISTRY = [
+  ...Object.keys(staticRootSchemas)
+    .sort(compareCodeUnits)
+    .map((root) =>
+      rootEntry(
+        staticRootSchemas[
+          root as keyof typeof staticRootSchemas
+        ] as unknown as RootSchema,
+        staticRootKinds[root as keyof typeof staticRootKinds],
+      ),
+    ),
+  rootEntry(desktopClientRootSchema as unknown as RootSchema, "dynamic-root"),
+  rootEntry(friendRootSchema as unknown as RootSchema, "legacy-root", [
+    "legacy_root_requires_migration",
+  ]),
+  {
+    registryKey: "library-core-v1:root:<unknown-root>",
+    root: "<unknown-root>",
+    entity: "OpaqueRecoveryEvidence",
+    kind: "opaque-fallback",
+    path: pattern([{ kind: "unknown-root" }]),
+    currentLocality: "legacy-compatibility",
+    currentAuthority: "legacy-automerge-read-only",
+    plannedLocality: null,
+    plannedAuthority: null,
+    cutover: "blocked",
+    blockers: sortBlockers([
+      ...rootBlockers,
+      "unknown_root_requires_classification",
+    ]),
+  } satisfies LibraryCoreRootRegistryEntry,
+].sort((left, right) =>
+  compareCodeUnits(left.registryKey, right.registryKey),
+) satisfies readonly LibraryCoreRootRegistryEntry[];

--- a/packages/shared/src/library-core/index.ts
+++ b/packages/shared/src/library-core/index.ts
@@ -1,0 +1,7 @@
+export * from "./census.js";
+export * from "./field-registry.js";
+export * from "./local-authority-registry.js";
+export * from "./operation-registry.js";
+export * from "./protocol-registry.js";
+export * from "./query-registry.js";
+export * from "./store-surface-registry.js";

--- a/packages/shared/src/library-core/local-authority-registry.test.ts
+++ b/packages/shared/src/library-core/local-authority-registry.test.ts
@@ -1,0 +1,394 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  LIBRARY_CORE_LOCAL_AUTHORITY_NON_PRODUCT_EXCLUSIONS,
+  LIBRARY_CORE_LOCAL_AUTHORITY_REGISTRY,
+  LIBRARY_CORE_LOCAL_AUTHORITY_SOURCE_OWNERS,
+  type LibraryCoreLocalAuthorityRegistryEntry,
+} from "./local-authority-registry.js";
+
+const REPOSITORY_ROOT = fileURLToPath(new URL("../../../../", import.meta.url));
+
+function readRepositorySource(sourcePath: string): string {
+  return readFileSync(resolve(REPOSITORY_ROOT, sourcePath), "utf8");
+}
+
+function registryByKey(): Map<string, LibraryCoreLocalAuthorityRegistryEntry> {
+  return new Map(
+    LIBRARY_CORE_LOCAL_AUTHORITY_REGISTRY.map((entry) => [
+      entry.registryKey,
+      entry,
+    ]),
+  );
+}
+
+function rustByteArrayUuid(sourcePath: string, symbol: string): string {
+  const source = readRepositorySource(sourcePath);
+  const declaration = source.match(
+    new RegExp(
+      `const\\s+${symbol}:\\s*\\[u8;\\s*16\\]\\s*=\\s*\\[([\\s\\S]*?)\\];`,
+    ),
+  );
+  if (!declaration) {
+    throw new Error(`Missing ${symbol} in ${sourcePath}`);
+  }
+  const bytes = [...declaration[1].matchAll(/0x([0-9a-f]{2})/gi)]
+    .map((match) => match[1]);
+  if (bytes.length !== 16) {
+    throw new Error(`${symbol} must contain exactly 16 hexadecimal bytes`);
+  }
+  const hex = bytes.join("").toLowerCase();
+  return [
+    hex.slice(0, 8),
+    hex.slice(8, 12),
+    hex.slice(12, 16),
+    hex.slice(16, 20),
+    hex.slice(20),
+  ].join("-");
+}
+
+describe("Library Core local authority registry", () => {
+  it("is unique and sorted for deterministic serialization", () => {
+    const keys = LIBRARY_CORE_LOCAL_AUTHORITY_REGISTRY.map((entry) => entry.registryKey);
+    expect(keys).toEqual([...keys].sort());
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  it("includes the high-risk local-authority families required by Gate A", () => {
+    const required = [
+      "authenticated-essay-capture-cooldowns",
+      "automerge-cloud-dropbox",
+      "automerge-cloud-google-drive",
+      "automerge-local-document",
+      "cloud-oauth-credentials",
+      "cloud-runtime-state",
+      "contact-sync-state",
+      "desktop-client-warning-acknowledgement",
+      "desktop-reader-content",
+      "desktop-webkit-network-cache",
+      "dev-sync-trigger-control",
+      "device-ai-preferences",
+      "device-display-preferences",
+      "device-feed-card-density",
+      "device-graph-layout",
+      "device-interface-zoom",
+      "device-theme",
+      "facebook-group-discovery",
+      "factory-reset-cloud-cleanup-barrier",
+      "geocoding-cache",
+      "library-core-actor-private-key",
+      "library-core-authority-private-key",
+      "local-ai-model-files",
+      "local-ai-model-state",
+      "media-vault",
+      "provider-health",
+      "provider-user-agents",
+      "provider-webview-sessions-linux",
+      "provider-webview-sessions-macos",
+      "provider-webview-sessions-windows",
+      "pwa-automerge-worker-debug",
+      "pwa-install-notice",
+      "pwa-legal-consent",
+      "pwa-reader-content",
+      "pwa-relay-credential",
+      "pwa-release-channel",
+      "pwa-service-worker-build-caches",
+      "pwa-service-worker-network-cache",
+      "pwa-service-worker-sync-cache",
+      "reader-image-cache",
+      "release-log-files",
+      "rss-runtime-state",
+      "scraper-window-modes",
+      "secure-api-keys",
+      "snapshots",
+      "social-outbox-state",
+      "x-manual-cookies",
+      "youtube-offline-playlist",
+    ];
+    const keys = new Set<string>(
+      LIBRARY_CORE_LOCAL_AUTHORITY_REGISTRY.map((entry) => entry.registryKey),
+    );
+
+    for (const key of required) expect(keys.has(key)).toBe(true);
+  });
+
+  it("binds audited persisted-key families to checked-in source owners", () => {
+    const byKey = registryByKey();
+
+    for (const owner of LIBRARY_CORE_LOCAL_AUTHORITY_SOURCE_OWNERS) {
+      const entry = byKey.get(owner.registryKey);
+      expect(entry, owner.registryKey).toBeDefined();
+      expect(entry?.sourceReferences).toContain(owner.sourcePath);
+
+      const registeredKeys = new Set(
+        entry?.physicalStores.flatMap((store) => store.keys) ?? [],
+      );
+      for (const key of owner.registeredKeys) {
+        expect(registeredKeys.has(key), `${owner.registryKey}: ${key}`).toBe(true);
+      }
+
+      const source = readRepositorySource(owner.sourcePath);
+      for (const token of owner.sourceTokens) {
+        expect(source.includes(token), `${owner.sourcePath}: ${token}`).toBe(true);
+      }
+    }
+  });
+
+  it("has source-owner coverage for every registered persistent store", () => {
+    const persistentStoreKinds = new Set([
+      "cache-api",
+      "cloud-file",
+      "filesystem",
+      "indexeddb",
+      "local-storage",
+      "native-json",
+      "session-storage",
+      "webkit-data-store",
+      "webkitgtk-data-store",
+      "webview2-data-store",
+    ]);
+
+    for (const entry of LIBRARY_CORE_LOCAL_AUTHORITY_REGISTRY) {
+      if (
+        !entry.physicalStores.some((store) =>
+          persistentStoreKinds.has(store.kind),
+        )
+      ) {
+        continue;
+      }
+
+      const registeredKeys = new Set(
+        LIBRARY_CORE_LOCAL_AUTHORITY_SOURCE_OWNERS
+          .filter((owner) => owner.registryKey === entry.registryKey)
+          .flatMap((owner) => owner.registeredKeys),
+      );
+      const physicalKeys = new Set(
+        entry.physicalStores.flatMap((store) => store.keys),
+      );
+
+      expect(
+        [...registeredKeys].sort(),
+        entry.registryKey,
+      ).toEqual([...physicalKeys].sort());
+    }
+  });
+
+  it("keeps non-product persistence exclusions explicit and source-backed", () => {
+    for (const exclusion of LIBRARY_CORE_LOCAL_AUTHORITY_NON_PRODUCT_EXCLUSIONS) {
+      const source = readRepositorySource(exclusion.sourcePath);
+      expect(source.includes(exclusion.sourceToken)).toBe(true);
+      expect(exclusion.reason.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("never backs up, exports, or snapshots a secret", () => {
+    const secrets = LIBRARY_CORE_LOCAL_AUTHORITY_REGISTRY.filter(
+      (entry) => entry.locality === "secret",
+    );
+    expect(secrets.length).toBeGreaterThan(0);
+    for (const entry of secrets) {
+      expect(entry.backup).toBe("exclude-secret");
+      expect(entry.export).toBe("exclude");
+      expect(entry.redaction).toBe("drop-entire-value");
+      expect(entry.snapshot).toBe("excluded");
+    }
+    expect(
+      secrets.find((entry) =>
+        entry.registryKey === "library-core-authority-private-key"
+      ),
+    ).toMatchObject({
+      soleOwner: "unprovisioned Library Core native authority adapter",
+      resetSemantics: "Factory reset removes local protected authority material. Restore may install a newly rotated authority key only through an accepted recovery transition; private bytes are never exported or imported.",
+    });
+  });
+
+  it("blocks cutover on sole-copy, active legacy, unbounded, and unproven authorities", () => {
+    const blockers = LIBRARY_CORE_LOCAL_AUTHORITY_REGISTRY
+      .filter((entry) => entry.cutover.blocksCutover)
+      .map((entry) => entry.registryKey);
+
+    expect(blockers).toEqual([
+      "automerge-cloud-dropbox",
+      "automerge-cloud-google-drive",
+      "automerge-local-document",
+      "contact-sync-state",
+      "desktop-reader-content",
+      "device-graph-layout",
+      "factory-reset-cloud-cleanup-barrier",
+      "library-core-actor-private-key",
+      "library-core-authority-private-key",
+      "media-vault",
+      "provider-webview-sessions-linux",
+      "provider-webview-sessions-macos",
+      "provider-webview-sessions-windows",
+      "pwa-reader-content",
+      "pwa-service-worker-network-cache",
+      "pwa-service-worker-sync-cache",
+      "youtube-offline-playlist",
+    ]);
+  });
+
+  it("does not waive measured retention for contact, graph, or playlist state", () => {
+    const byKey = registryByKey();
+    for (const key of [
+      "contact-sync-state",
+      "device-graph-layout",
+      "youtube-offline-playlist",
+    ]) {
+      const entry = byKey.get(key);
+      expect(entry?.retention.kind).toBe("unbounded-current");
+      expect(entry?.cutover.blocksCutover).toBe(true);
+      expect(entry?.cutover.reason).toMatch(/measured|bounded/);
+    }
+  });
+
+  it("records the PWA reset envelope and acknowledgement key shapes exactly", () => {
+    const entry = registryByKey().get("pwa-factory-reset-coordination");
+    const localKeys = entry?.physicalStores.find(
+      (store) => store.kind === "local-storage",
+    )?.keys;
+    const sessionKeys = entry?.physicalStores.find(
+      (store) => store.kind === "session-storage",
+    )?.keys;
+
+    expect(localKeys).toContain(
+      "freed_pwa_factory_reset_ack_<resetId>_<runtimeId>",
+    );
+    expect(localKeys).toContain("freed_pwa_factory_reset_reload_envelope");
+    expect(sessionKeys).toEqual(["freed_pwa_factory_reset_reload"]);
+  });
+
+  it("separates provider session ownership by desktop platform and fails closed", () => {
+    const byKey = registryByKey();
+    const expected = [
+      {
+        key: "provider-webview-sessions-linux",
+        platform: "desktop-linux",
+        kind: "webkitgtk-data-store",
+      },
+      {
+        key: "provider-webview-sessions-macos",
+        platform: "desktop-macos",
+        kind: "webkit-data-store",
+      },
+      {
+        key: "provider-webview-sessions-windows",
+        platform: "desktop-windows",
+        kind: "webview2-data-store",
+      },
+    ] as const;
+
+    for (const { key, platform, kind } of expected) {
+      const entry = byKey.get(key);
+      expect(entry?.physicalStores).toHaveLength(1);
+      expect(entry?.physicalStores[0]?.platforms).toEqual([platform]);
+      expect(entry?.physicalStores[0]?.kind).toBe(kind);
+      expect(entry?.physicalStores[0]?.locator).toMatch(
+        platform === "desktop-macos" ? /Library\/WebKit/ : /unresolved:/,
+      );
+      expect(entry?.cutover.blocksCutover).toBe(true);
+      expect(entry?.backup).toBe("exclude-secret");
+      expect(entry?.export).toBe("exclude");
+      expect(entry?.snapshot).toBe("excluded");
+    }
+
+    expect(byKey.has("provider-webview-sessions")).toBe(false);
+    expect(byKey.get("provider-webview-sessions-macos")?.resetSemantics)
+      .toContain("conditionally");
+  });
+
+  it("binds provider session descriptors to the Rust data-store UUID bytes", () => {
+    const expectedDescriptors = [
+      ["packages/desktop/src-tauri/src/lib.rs", "FB_SCRAPER_DATA_STORE_IDENTIFIER", "facebook"],
+      ["packages/desktop/src-tauri/src/lib.rs", "IG_SCRAPER_DATA_STORE_IDENTIFIER", "instagram"],
+      ["packages/desktop/src-tauri/src/lib.rs", "LI_SCRAPER_DATA_STORE_IDENTIFIER", "linkedin"],
+      ["packages/desktop/src-tauri/src/lib.rs", "SUBSTACK_SCRAPER_DATA_STORE_IDENTIFIER", "substack"],
+      ["packages/desktop/src-tauri/src/lib.rs", "MEDIUM_SCRAPER_DATA_STORE_IDENTIFIER", "medium"],
+      ["packages/desktop/src-tauri/src/youtube.rs", "YOUTUBE_SESSION_DATA_STORE_IDENTIFIER", "youtube"],
+    ].map(([sourcePath, symbol, provider]) =>
+      `${rustByteArrayUuid(sourcePath, symbol)} (${provider})`
+    );
+
+    const byKey = registryByKey();
+    for (const key of [
+      "provider-webview-sessions-linux",
+      "provider-webview-sessions-macos",
+      "provider-webview-sessions-windows",
+    ]) {
+      const sessionDescriptors = byKey.get(key)?.physicalStores
+        .flatMap((store) => store.keys)
+        .filter((descriptor) => !descriptor.includes("sessionStorage"));
+      expect(sessionDescriptors, key).toEqual(expectedDescriptors);
+    }
+  });
+
+  it("closes Desktop legal-consent keys over the shared provider-risk union", () => {
+    const legalSource = readRepositorySource("packages/shared/src/legal.ts");
+    const providerUnion = legalSource.match(
+      /export type ProviderRiskId =([\s\S]*?);/,
+    );
+    if (!providerUnion) {
+      throw new Error("ProviderRiskId must remain a closed string union");
+    }
+    const providers = [...providerUnion[1].matchAll(/"([^"]+)"/g)]
+      .map((match) => match[1]);
+    const entry = registryByKey().get("desktop-legal-consent");
+    const nativeKeys = entry?.physicalStores
+      .find((store) => store.kind === "native-json")
+      ?.keys.filter((key) => key.startsWith("legal.provider."));
+    const fallbackKeys = entry?.physicalStores
+      .find((store) => store.kind === "local-storage")
+      ?.keys.filter((key) => key.startsWith("freed.legal.legal.provider."));
+
+    expect(nativeKeys).toEqual(providers.map((provider) => `legal.provider.${provider}`));
+    expect(fallbackKeys).toEqual(
+      providers.map((provider) => `freed.legal.legal.provider.${provider}`),
+    );
+  });
+
+  it("records the PWA stores that factory reset currently preserves", () => {
+    const appSource = readRepositorySource("packages/pwa/src/App.tsx");
+    const resetStart = appSource.indexOf("const handleFactoryReset");
+    const resetEnd = appSource.indexOf("const platform", resetStart);
+    const resetWiring = appSource.slice(
+      resetStart,
+      resetEnd > resetStart ? resetEnd : undefined,
+    );
+    expect(resetWiring).toContain("clearLocalData: []");
+
+    const byKey = registryByKey();
+    for (const key of [
+      "pwa-install-notice",
+      "pwa-legal-consent",
+      "pwa-reader-content",
+      "pwa-release-channel",
+      "pwa-service-worker-build-caches",
+      "pwa-service-worker-network-cache",
+      "pwa-service-worker-sync-cache",
+      "reader-image-cache",
+      "reader-offline-cache-mode",
+    ]) {
+      expect(byKey.get(key)?.resetSemantics, key)
+        .toMatch(/current PWA factory reset preserves|current PWA factory reset does not delete/);
+    }
+  });
+
+  it("distinguishes authoritative reader bodies from rebuildable images", () => {
+    const byKey = registryByKey();
+
+    for (const key of ["desktop-reader-content", "pwa-reader-content"]) {
+      const entry = byKey.get(key);
+      expect(entry?.authoritative).toBe(true);
+      expect(entry?.snapshot).toBe("authoritative-source-manifest-required");
+      expect(entry?.migration).toBe("migrate-to-library-core");
+    }
+
+    const images = byKey.get("reader-image-cache");
+    expect(images?.authoritative).toBe(false);
+    expect(images?.role).toBe("cache");
+    expect(images?.snapshot).toBe("rebuildable");
+    expect(images?.cutover.blocksCutover).toBe(false);
+  });
+});

--- a/packages/shared/src/library-core/local-authority-registry.ts
+++ b/packages/shared/src/library-core/local-authority-registry.ts
@@ -1,0 +1,2783 @@
+import type { LibraryCorePlannedLocality } from "./protocol-registry.js";
+
+/**
+ * Dormant Gate A census of storage that exists outside the synchronized field
+ * registry. This file describes current authorities. It does not open, mutate,
+ * migrate, reset, export, or activate any store.
+ */
+
+export type LibraryCoreLocalPlatform =
+  | "desktop"
+  | "desktop-linux"
+  | "desktop-macos"
+  | "desktop-windows"
+  | "pwa"
+  | "cloud"
+  | "node";
+
+export type LibraryCoreLocalStoreKind =
+  | "cache-api"
+  | "cloud-file"
+  | "filesystem"
+  | "indexeddb"
+  | "local-storage"
+  | "memory"
+  | "native-json"
+  | "session-storage"
+  | "unprovisioned"
+  | "webkit-data-store"
+  | "webkitgtk-data-store"
+  | "webview2-data-store";
+
+export interface LibraryCorePhysicalStore {
+  readonly kind: LibraryCoreLocalStoreKind;
+  readonly platforms: readonly LibraryCoreLocalPlatform[];
+  /**
+   * Exact current locator syntax. Runtime-resolved roots use appDataDir(),
+   * origin, bundle identifier, or HOME rather than one machine's absolute path.
+   */
+  readonly locator: string;
+  readonly keys: readonly string[];
+}
+
+export type LibraryCoreLocalRole =
+  | "active-authority"
+  | "authoritative-device-source"
+  | "backup"
+  | "cache"
+  | "control"
+  | "derived-runtime"
+  | "secret"
+  | "telemetry";
+
+export type LibraryCoreRetention =
+  | {
+      readonly kind: "bounded-count";
+      readonly limit: number;
+      readonly unit: string;
+    }
+  | {
+      readonly kind: "bounded-time";
+      readonly durationMs: number;
+    }
+  | {
+      readonly kind: "bounded-by-rule";
+      readonly rules: readonly {
+        readonly scope: string;
+        readonly limit: number;
+        readonly unit: string;
+      }[];
+    }
+  | {
+      readonly kind:
+        | "browser-managed"
+        | "process-lifetime"
+        | "until-disconnect"
+        | "until-explicit-delete"
+        | "until-reset";
+    }
+  | {
+      readonly kind: "unbounded-current";
+      readonly reason: string;
+    };
+
+export type LibraryCoreBackupDisposition =
+  | "exclude-derived"
+  | "exclude-device-local"
+  | "exclude-secret"
+  | "include-private"
+  | "legacy-recovery-only"
+  | "not-applicable";
+
+export type LibraryCoreExportDisposition =
+  | "exclude"
+  | "include-private"
+  | "include-redacted-metadata"
+  | "legacy-compatibility"
+  | "not-applicable";
+
+export type LibraryCoreRedactionDisposition =
+  | "drop-entire-value"
+  | "not-applicable"
+  | "redact-sensitive-fields"
+  | "retain-private-bytes";
+
+export type LibraryCoreSnapshotDisposition =
+  | "authoritative-source-manifest-required"
+  | "excluded"
+  | "legacy-recovery"
+  | "portable-snapshot-required"
+  | "rebuildable";
+
+export type LibraryCoreMigrationDisposition =
+  | "exclude-secret-and-retain-current-owner"
+  | "generate-after-gate-a"
+  | "migrate-to-library-core"
+  | "rebuild-after-cutover"
+  | "retain-current-device-owner"
+  | "retain-legacy-recovery"
+  | "retire-with-legacy-epoch";
+
+export interface LibraryCoreCutoverStatus {
+  readonly blocksCutover: boolean;
+  readonly reason: string;
+}
+
+export interface LibraryCoreLocalAuthorityRegistryEntry {
+  readonly registryKey: string;
+  readonly soleOwner: string;
+  readonly locality: LibraryCorePlannedLocality;
+  readonly role: LibraryCoreLocalRole;
+  readonly authoritative: boolean;
+  readonly physicalStores: readonly LibraryCorePhysicalStore[];
+  readonly retention: LibraryCoreRetention;
+  readonly backup: LibraryCoreBackupDisposition;
+  readonly export: LibraryCoreExportDisposition;
+  readonly redaction: LibraryCoreRedactionDisposition;
+  readonly resetSemantics: string;
+  readonly snapshot: LibraryCoreSnapshotDisposition;
+  readonly migration: LibraryCoreMigrationDisposition;
+  readonly cutover: LibraryCoreCutoverStatus;
+  readonly sourceReferences: readonly string[];
+}
+
+const APP_DATA = "appDataDir()";
+const VERSIONED_RECOVERY = "<key>.recovery.<capturedAtMs>.<sequence>";
+
+/**
+ * Registry keys are sorted so JSON serialization and registry digests do not
+ * depend on object enumeration or filesystem discovery order.
+ */
+export const LIBRARY_CORE_LOCAL_AUTHORITY_REGISTRY = [
+  {
+    registryKey: "authenticated-essay-capture-cooldowns",
+    soleOwner: "packages/desktop/src/lib/authenticated-essay-capture.ts",
+    locality: "device-local",
+    role: "control",
+    authoritative: true,
+    physicalStores: [{
+      kind: "local-storage",
+      platforms: ["desktop"],
+      locator: "origin:localStorage",
+      keys: [
+        "freed.capture-cooldown.substack",
+        "freed.capture-cooldown.medium",
+      ],
+    }],
+    retention: { kind: "until-explicit-delete" },
+    backup: "exclude-device-local",
+    export: "exclude",
+    redaction: "redact-sensitive-fields",
+    resetSemantics: "A deadline becomes semantically inert after at most 36 minutes and is removed on the next read. Without another read, the current factory-reset path does not explicitly remove the physical key.",
+    snapshot: "excluded",
+    migration: "retain-current-device-owner",
+    cutover: {
+      blocksCutover: false,
+      reason: "These bounded request-scheduling deadlines remain device-local and never enter Library Core operations or provider artifacts.",
+    },
+    sourceReferences: ["packages/desktop/src/lib/authenticated-essay-capture.ts"],
+  },
+  {
+    registryKey: "automerge-cloud-dropbox",
+    soleOwner: "packages/sync/src/cloud/dropbox.ts",
+    locality: "synchronized",
+    role: "active-authority",
+    authoritative: true,
+    physicalStores: [{
+      kind: "cloud-file",
+      platforms: ["cloud"],
+      locator: "Dropbox:/Apps/Freed/freed.automerge",
+      keys: ["/Apps/Freed/freed.automerge"],
+    }],
+    retention: { kind: "until-explicit-delete" },
+    backup: "legacy-recovery-only",
+    export: "legacy-compatibility",
+    redaction: "retain-private-bytes",
+    resetSemantics: "Disconnect preserves the remote file; explicit cloud-data deletion removes it.",
+    snapshot: "legacy-recovery",
+    migration: "retire-with-legacy-epoch",
+    cutover: {
+      blocksCutover: true,
+      reason: "The active legacy cloud replica must be reconciled, fenced, and retired by the signed epoch transition.",
+    },
+    sourceReferences: ["packages/sync/src/cloud/dropbox.ts"],
+  },
+  {
+    registryKey: "automerge-cloud-google-drive",
+    soleOwner: "packages/sync/src/cloud/gdrive.ts",
+    locality: "synchronized",
+    role: "active-authority",
+    authoritative: true,
+    physicalStores: [{
+      kind: "cloud-file",
+      platforms: ["cloud"],
+      locator: "GoogleDrive:spaces=appDataFolder;name=freed.automerge",
+      keys: ["freed.automerge"],
+    }],
+    retention: { kind: "until-explicit-delete" },
+    backup: "legacy-recovery-only",
+    export: "legacy-compatibility",
+    redaction: "retain-private-bytes",
+    resetSemantics: "Disconnect preserves the appDataFolder file; explicit cloud-data deletion removes it.",
+    snapshot: "legacy-recovery",
+    migration: "retire-with-legacy-epoch",
+    cutover: {
+      blocksCutover: true,
+      reason: "The active legacy cloud replica must be reconciled, fenced, and retired by the signed epoch transition.",
+    },
+    sourceReferences: ["packages/sync/src/cloud/gdrive.ts"],
+  },
+  {
+    registryKey: "automerge-local-document",
+    soleOwner: "packages/sync/src/storage/indexeddb.ts",
+    locality: "synchronized",
+    role: "active-authority",
+    authoritative: true,
+    physicalStores: [{
+      kind: "indexeddb",
+      platforms: ["desktop", "pwa"],
+      locator: "origin:indexedDB/freed@1/automerge",
+      keys: ["feed", "feed:installation-generation"],
+    }],
+    retention: { kind: "until-reset" },
+    backup: "include-private",
+    export: "legacy-compatibility",
+    redaction: "retain-private-bytes",
+    resetSemantics: "Factory reset atomically clears feed and advances feed:installation-generation.",
+    snapshot: "portable-snapshot-required",
+    migration: "migrate-to-library-core",
+    cutover: {
+      blocksCutover: true,
+      reason: "Cutover requires one immutable raw Automerge source binary and exact heads from the elected migration authority.",
+    },
+    sourceReferences: [
+      "packages/sync/src/storage/indexeddb.ts",
+      "packages/desktop/src/lib/automerge.worker.ts",
+      "packages/pwa/src/lib/automerge.worker.ts",
+    ],
+  },
+  {
+    registryKey: "clipboard-save-shortcut",
+    soleOwner: "packages/desktop/src/lib/clipboard-save-shortcut.ts",
+    locality: "device-local",
+    role: "control",
+    authoritative: true,
+    physicalStores: [{
+      kind: "native-json",
+      platforms: ["desktop"],
+      locator: `${APP_DATA}/clipboard-save-shortcut.json`,
+      keys: ["enabled", "shortcut"],
+    }],
+    retention: { kind: "until-reset" },
+    backup: "exclude-device-local",
+    export: "exclude",
+    redaction: "not-applicable",
+    resetSemantics: "Factory reset removes the file and restores the platform default shortcut.",
+    snapshot: "excluded",
+    migration: "retain-current-device-owner",
+    cutover: {
+      blocksCutover: false,
+      reason: "This is an explicitly retained Desktop control outside Library Core.",
+    },
+    sourceReferences: ["packages/desktop/src/lib/clipboard-save-shortcut.ts"],
+  },
+  {
+    registryKey: "cloud-oauth-credentials",
+    soleOwner: "cloud credential adapter for the current runtime origin",
+    locality: "secret",
+    role: "secret",
+    authoritative: true,
+    physicalStores: [{
+      kind: "local-storage",
+      platforms: ["desktop", "pwa"],
+      locator: "origin:localStorage",
+      keys: [
+        "freed_cloud_token_gdrive",
+        "freed_cloud_token_dropbox",
+        "freed_cloud_token_meta_gdrive",
+        "freed_cloud_token_meta_dropbox",
+        "freed_cloud_provider",
+      ],
+    }],
+    retention: { kind: "until-disconnect" },
+    backup: "exclude-secret",
+    export: "exclude",
+    redaction: "drop-entire-value",
+    resetSemantics: "Disconnect or factory reset removes access-token, refresh-token, expiry, and provider-selection records.",
+    snapshot: "excluded",
+    migration: "exclude-secret-and-retain-current-owner",
+    cutover: {
+      blocksCutover: false,
+      reason: "OAuth credentials remain outside operations, blobs, manifests, snapshots, and portable backups.",
+    },
+    sourceReferences: [
+      "packages/desktop/src/lib/sync.ts",
+      "packages/pwa/src/lib/sync.ts",
+    ],
+  },
+  {
+    registryKey: "cloud-runtime-state",
+    soleOwner: "cloud sync runtime coordinator for the current process",
+    locality: "derived",
+    role: "derived-runtime",
+    authoritative: false,
+    physicalStores: [{
+      kind: "memory",
+      platforms: ["desktop", "pwa"],
+      locator: "process:cloud sync lifecycle maps, timers, abort controllers, and last uploaded heads",
+      keys: [
+        "cloudGenerations",
+        "cloudCredentialRevisions",
+        "cloudTokenRefreshes",
+        "cloudInFlightOperations",
+        "lastSuccessfulUploadHeadsByProvider",
+      ],
+    }],
+    retention: { kind: "process-lifetime" },
+    backup: "exclude-derived",
+    export: "exclude",
+    redaction: "drop-entire-value",
+    resetSemantics: "Disconnect, factory reset, or process exit cancels and drops the current generation.",
+    snapshot: "rebuildable",
+    migration: "rebuild-after-cutover",
+    cutover: {
+      blocksCutover: false,
+      reason: "The runtime state is reconstructed from durable authority and must never be imported as truth.",
+    },
+    sourceReferences: [
+      "packages/desktop/src/lib/sync.ts",
+      "packages/pwa/src/lib/sync.ts",
+    ],
+  },
+  {
+    registryKey: "contact-sync-state",
+    soleOwner: "packages/desktop/src/lib/contact-sync-storage.ts",
+    locality: "device-local",
+    role: "active-authority",
+    authoritative: true,
+    physicalStores: [{
+      kind: "local-storage",
+      platforms: ["desktop"],
+      locator: "origin:localStorage",
+      keys: ["freed_contact_sync"],
+    }],
+    retention: {
+      kind: "unbounded-current",
+      reason: "The current schema places no entry or byte ceiling on cached contacts, pending suggestions, or dismissed IDs.",
+    },
+    backup: "exclude-device-local",
+    export: "include-redacted-metadata",
+    redaction: "redact-sensitive-fields",
+    resetSemantics: "Factory reset clears cached contacts, sync token, errors, suggestions, and match decisions.",
+    snapshot: "excluded",
+    migration: "retain-current-device-owner",
+    cutover: {
+      blocksCutover: true,
+      reason: "Cached contacts, pending suggestions, and dismissed IDs have no measured entry or byte limit. Gate A cannot retain this sole-copy authority without a bounded preservation policy.",
+    },
+    sourceReferences: [
+      "packages/shared/src/contact-sync-state.ts",
+      "packages/desktop/src/lib/contact-sync-storage.ts",
+    ],
+  },
+  {
+    registryKey: "desktop-client-registration",
+    soleOwner: "packages/desktop/src/lib/desktop-client-registration.ts",
+    locality: "device-local",
+    role: "control",
+    authoritative: true,
+    physicalStores: [
+      {
+        kind: "native-json",
+        platforms: ["desktop"],
+        locator: `${APP_DATA}/desktop-client.json`,
+        keys: ["registration"],
+      },
+      {
+        kind: "local-storage",
+        platforms: ["desktop"],
+        locator: "origin:localStorage",
+        keys: [
+          "freed-desktop-client-registration-v1",
+          "freed-desktop-client-registration-v1.recovery.<capturedAtMs>",
+        ],
+      },
+    ],
+    retention: { kind: "until-reset" },
+    backup: "exclude-device-local",
+    export: "include-redacted-metadata",
+    redaction: "redact-sensitive-fields",
+    resetSemantics: "Factory reset replaces the installation identity and invalidates fallback recovery copies.",
+    snapshot: "excluded",
+    migration: "retain-current-device-owner",
+    cutover: {
+      blocksCutover: false,
+      reason: "The installation identity remains the Desktop client's local authority outside the library corpus.",
+    },
+    sourceReferences: ["packages/desktop/src/lib/desktop-client-registration.ts"],
+  },
+  {
+    registryKey: "desktop-client-warning-acknowledgement",
+    soleOwner: "packages/desktop/src/lib/desktop-client-warning.ts",
+    locality: "device-local",
+    role: "control",
+    authoritative: true,
+    physicalStores: [{
+      kind: "local-storage",
+      platforms: ["desktop"],
+      locator: "origin:localStorage",
+      keys: ["freed-multiple-desktop-warning-ack-v1"],
+    }],
+    retention: { kind: "until-reset" },
+    backup: "exclude-device-local",
+    export: "exclude",
+    redaction: "not-applicable",
+    resetSemantics: "Factory reset removes the acknowledged client-set signature so setup can warn again.",
+    snapshot: "excluded",
+    migration: "retain-current-device-owner",
+    cutover: {
+      blocksCutover: false,
+      reason: "The acknowledgement is a local warning control and carries no library or provider authority.",
+    },
+    sourceReferences: ["packages/desktop/src/lib/desktop-client-warning.ts"],
+  },
+  {
+    registryKey: "desktop-legal-consent",
+    soleOwner: "packages/desktop/src/lib/legal-consent.ts",
+    locality: "device-local",
+    role: "control",
+    authoritative: true,
+    physicalStores: [
+      {
+        kind: "native-json",
+        platforms: ["desktop"],
+        locator: `${APP_DATA}/legal.json`,
+        keys: [
+          "legal.bundle.desktop",
+          "legal.provider.x",
+          "legal.provider.facebook",
+          "legal.provider.instagram",
+          "legal.provider.linkedin",
+          "legal.provider.substack",
+          "legal.provider.medium",
+          "legal.provider.youtube",
+        ],
+      },
+      {
+        kind: "local-storage",
+        platforms: ["desktop"],
+        locator: "origin:localStorage",
+        keys: [
+          "freed.legal.legal.bundle.desktop",
+          "freed.legal.legal.provider.x",
+          "freed.legal.legal.provider.facebook",
+          "freed.legal.legal.provider.instagram",
+          "freed.legal.legal.provider.linkedin",
+          "freed.legal.legal.provider.substack",
+          "freed.legal.legal.provider.medium",
+          "freed.legal.legal.provider.youtube",
+        ],
+      },
+    ],
+    retention: { kind: "until-reset" },
+    backup: "exclude-device-local",
+    export: "exclude",
+    redaction: "redact-sensitive-fields",
+    resetSemantics: "Factory reset removes acceptance and requires the current legal bundle to be accepted again.",
+    snapshot: "excluded",
+    migration: "retain-current-device-owner",
+    cutover: {
+      blocksCutover: false,
+      reason: "Legal acceptance is an installation control, not library content.",
+    },
+    sourceReferences: [
+      "packages/desktop/src/lib/legal-consent.ts",
+      "packages/shared/src/legal.ts",
+    ],
+  },
+  {
+    registryKey: "desktop-pairing-token",
+    soleOwner: "packages/desktop/src-tauri/src/lib.rs",
+    locality: "secret",
+    role: "secret",
+    authoritative: true,
+    physicalStores: [{
+      kind: "filesystem",
+      platforms: ["desktop"],
+      locator: `${APP_DATA}/pairing-token`,
+      keys: ["raw pairing token bytes"],
+    }],
+    retention: { kind: "until-reset" },
+    backup: "exclude-secret",
+    export: "exclude",
+    redaction: "drop-entire-value",
+    resetSemantics: "Factory reset rotates or removes the relay pairing token before a new runtime accepts clients.",
+    snapshot: "excluded",
+    migration: "exclude-secret-and-retain-current-owner",
+    cutover: {
+      blocksCutover: false,
+      reason: "Relay pairing material stays outside Library Core and every portable artifact.",
+    },
+    sourceReferences: ["packages/desktop/src-tauri/src/lib.rs"],
+  },
+  {
+    registryKey: "desktop-reader-content",
+    soleOwner: "packages/desktop/src/lib/content-cache.ts",
+    locality: "blob",
+    role: "authoritative-device-source",
+    authoritative: true,
+    physicalStores: [{
+      kind: "filesystem",
+      platforms: ["desktop"],
+      locator: `${APP_DATA}/content/<globalId with [<>:\"/\\\\|?* and controls] replaced by _>.html`,
+      keys: ["<sanitized-globalId>.html"],
+    }],
+    retention: {
+      kind: "unbounded-current",
+      reason: "Each HTML file is capped at 2 MiB, but the directory has no total byte or entry ceiling.",
+    },
+    backup: "include-private",
+    export: "include-private",
+    redaction: "retain-private-bytes",
+    resetSemantics: "Clear cache or factory reset deletes the content directory.",
+    snapshot: "authoritative-source-manifest-required",
+    migration: "migrate-to-library-core",
+    cutover: {
+      blocksCutover: true,
+      reason: "A file may be the only complete article body and sanitized filenames are not injective; every byte needs an identity-bound disposition.",
+    },
+    sourceReferences: ["packages/desktop/src/lib/content-cache.ts"],
+  },
+  {
+    registryKey: "desktop-release-channel",
+    soleOwner: "packages/desktop/src/lib/release-channel.ts",
+    locality: "device-local",
+    role: "control",
+    authoritative: true,
+    physicalStores: [
+      {
+        kind: "native-json",
+        platforms: ["desktop"],
+        locator: `${APP_DATA}/release-channel.json`,
+        keys: ["channel", "installedChannel"],
+      },
+      {
+        kind: "local-storage",
+        platforms: ["desktop"],
+        locator: "origin:localStorage",
+        keys: ["freed-release-channel", "freed-updated-to"],
+      },
+    ],
+    retention: { kind: "until-reset" },
+    backup: "exclude-device-local",
+    export: "exclude",
+    redaction: "not-applicable",
+    resetSemantics: "Factory reset or explicit channel selection replaces the local release controls.",
+    snapshot: "excluded",
+    migration: "retain-current-device-owner",
+    cutover: {
+      blocksCutover: false,
+      reason: "Release selection is an installation control and does not enter the library.",
+    },
+    sourceReferences: [
+      "packages/desktop/src/lib/release-channel.ts",
+      "packages/desktop/src/lib/desktop-updater.ts",
+      "packages/ui/src/lib/release-channel.ts",
+    ],
+  },
+  {
+    registryKey: "desktop-webkit-network-cache",
+    soleOwner: "packages/desktop/src-tauri/src/lib.rs",
+    locality: "derived",
+    role: "cache",
+    authoritative: false,
+    physicalStores: [{
+      kind: "filesystem",
+      platforms: ["desktop"],
+      locator: "appCacheDir()/WebKit/NetworkCache",
+      keys: ["<WebKit network-cache file>"],
+    }],
+    retention: {
+      kind: "unbounded-current",
+      reason: "A memory sample may start a best-effort trim after the entire WebKit cache exceeds 768 MiB and target 512 MiB by deleting NetworkCache files. Sampling can be absent, deletion can fail, and bytes outside NetworkCache cannot be reclaimed by this path, so neither threshold is a hard bound.",
+    },
+    backup: "exclude-derived",
+    export: "exclude",
+    redaction: "drop-entire-value",
+    resetSemantics: "The current factory-reset path does not delete appCacheDir(). WebKit eviction or the best-effort memory-pressure trim may delete individual NetworkCache files.",
+    snapshot: "rebuildable",
+    migration: "rebuild-after-cutover",
+    cutover: {
+      blocksCutover: false,
+      reason: "Network responses are derived, non-authoritative cache entries and must never seed Library Core state.",
+    },
+    sourceReferences: [
+      "packages/desktop/src-tauri/src/lib.rs",
+      "packages/desktop/src/lib/memory-monitor.ts",
+    ],
+  },
+  {
+    registryKey: "dev-sync-trigger-control",
+    soleOwner: "Freed Desktop terminal trigger bridge",
+    locality: "device-local",
+    role: "control",
+    authoritative: false,
+    physicalStores: [{
+      kind: "filesystem",
+      platforms: ["desktop"],
+      locator: APP_DATA,
+      keys: ["dev-sync-trigger.json", "dev-sync-trigger-result.json"],
+    }],
+    retention: { kind: "until-reset" },
+    backup: "exclude-device-local",
+    export: "exclude",
+    redaction: "redact-sensitive-fields",
+    resetSemantics: "Requests older than 10 minutes become ineligible, each new result replaces the prior result, and factory reset removes both files.",
+    snapshot: "excluded",
+    migration: "retain-current-device-owner",
+    cutover: {
+      blocksCutover: false,
+      reason: "These files are a dev-build terminal control and receipt, not library authority or a portable provider artifact.",
+    },
+    sourceReferences: [
+      "packages/desktop/src-tauri/src/lib.rs",
+      "packages/desktop/src/lib/dev-sync-triggers.ts",
+    ],
+  },
+  {
+    registryKey: "device-ai-preferences",
+    soleOwner: "packages/ui/src/lib/device-ai-preferences.ts",
+    locality: "device-local",
+    role: "active-authority",
+    authoritative: true,
+    physicalStores: [{
+      kind: "local-storage",
+      platforms: ["desktop", "pwa"],
+      locator: "origin:localStorage",
+      keys: ["freed-device-ai-preferences-v1", VERSIONED_RECOVERY],
+    }],
+    retention: { kind: "until-reset" },
+    backup: "exclude-device-local",
+    export: "exclude",
+    redaction: "redact-sensitive-fields",
+    resetSemantics: "Factory reset restores provider none, empty model, and the default Ollama URL.",
+    snapshot: "excluded",
+    migration: "retain-current-device-owner",
+    cutover: {
+      blocksCutover: false,
+      reason: "The current versioned store is explicitly retained as sole owner of device AI selection.",
+    },
+    sourceReferences: ["packages/ui/src/lib/device-ai-preferences.ts"],
+  },
+  {
+    registryKey: "device-display-preferences",
+    soleOwner: "packages/ui/src/lib/device-display-preferences.ts",
+    locality: "device-local",
+    role: "active-authority",
+    authoritative: true,
+    physicalStores: [{
+      kind: "local-storage",
+      platforms: ["desktop", "pwa"],
+      locator: "origin:localStorage",
+      keys: ["freed-device-display-preferences-v1", VERSIONED_RECOVERY],
+    }],
+    retention: { kind: "until-reset" },
+    backup: "exclude-device-local",
+    export: "exclude",
+    redaction: "not-applicable",
+    resetSemantics: "Factory reset replaces the record with default display values and purges recovery copies.",
+    snapshot: "excluded",
+    migration: "retain-current-device-owner",
+    cutover: {
+      blocksCutover: false,
+      reason: "The current versioned store is explicitly retained as sole owner of display state.",
+    },
+    sourceReferences: ["packages/ui/src/lib/device-display-preferences.ts"],
+  },
+  {
+    registryKey: "device-feed-card-density",
+    soleOwner: "packages/ui/src/lib/feed-card-density.ts",
+    locality: "device-local",
+    role: "control",
+    authoritative: true,
+    physicalStores: [{
+      kind: "local-storage",
+      platforms: ["desktop", "pwa"],
+      locator: "origin:localStorage",
+      keys: ["freed-feed-card-density"],
+    }],
+    retention: { kind: "until-reset" },
+    backup: "exclude-device-local",
+    export: "exclude",
+    redaction: "not-applicable",
+    resetSemantics: "Factory reset removes the key and restores comfortable cards.",
+    snapshot: "excluded",
+    migration: "retain-current-device-owner",
+    cutover: {
+      blocksCutover: false,
+      reason: "Feed-card density remains a presentation preference outside synchronized library state.",
+    },
+    sourceReferences: ["packages/ui/src/lib/feed-card-density.ts"],
+  },
+  {
+    registryKey: "device-graph-layout",
+    soleOwner: "packages/ui/src/lib/device-graph-layout.ts",
+    locality: "device-local",
+    role: "active-authority",
+    authoritative: true,
+    physicalStores: [{
+      kind: "local-storage",
+      platforms: ["desktop", "pwa"],
+      locator: "origin:localStorage",
+      keys: ["freed-device-graph-layout-v1", VERSIONED_RECOVERY],
+    }],
+    retention: {
+      kind: "unbounded-current",
+      reason: "Pinned person and account positions have no current entry or byte ceiling.",
+    },
+    backup: "exclude-device-local",
+    export: "exclude",
+    redaction: "redact-sensitive-fields",
+    resetSemantics: "Entity unpin removes its record; factory reset clears persons, accounts, and legacy migration state.",
+    snapshot: "excluded",
+    migration: "retain-current-device-owner",
+    cutover: {
+      blocksCutover: true,
+      reason: "Pinned graph positions have no measured entry or byte limit. Gate A cannot retain this authority until a bounded policy and preservation decision are registered.",
+    },
+    sourceReferences: ["packages/ui/src/lib/device-graph-layout.ts"],
+  },
+  {
+    registryKey: "device-interface-zoom",
+    soleOwner: "packages/ui/src/lib/interface-zoom.ts",
+    locality: "device-local",
+    role: "control",
+    authoritative: true,
+    physicalStores: [{
+      kind: "local-storage",
+      platforms: ["desktop", "pwa"],
+      locator: "origin:localStorage",
+      keys: ["freed-interface-zoom"],
+    }],
+    retention: { kind: "until-reset" },
+    backup: "exclude-device-local",
+    export: "exclude",
+    redaction: "not-applicable",
+    resetSemantics: "Factory reset removes the key and restores 100 percent zoom.",
+    snapshot: "excluded",
+    migration: "retain-current-device-owner",
+    cutover: {
+      blocksCutover: false,
+      reason: "Interface zoom remains a presentation preference outside synchronized library state.",
+    },
+    sourceReferences: ["packages/ui/src/lib/interface-zoom.ts"],
+  },
+  {
+    registryKey: "device-theme",
+    soleOwner: "packages/ui/src/lib/theme.ts",
+    locality: "device-local",
+    role: "control",
+    authoritative: true,
+    physicalStores: [{
+      kind: "local-storage",
+      platforms: ["desktop", "pwa"],
+      locator: "origin:localStorage",
+      keys: ["freed-theme"],
+    }],
+    retention: { kind: "until-reset" },
+    backup: "exclude-device-local",
+    export: "exclude",
+    redaction: "not-applicable",
+    resetSemantics: "Factory reset removes the key and restores the default theme.",
+    snapshot: "excluded",
+    migration: "retain-current-device-owner",
+    cutover: {
+      blocksCutover: false,
+      reason: "Theme selection remains a presentation preference outside synchronized library state.",
+    },
+    sourceReferences: ["packages/ui/src/lib/theme.ts"],
+  },
+  {
+    registryKey: "facebook-group-discovery",
+    soleOwner: "packages/desktop/src/lib/facebook-group-discovery.ts",
+    locality: "device-local",
+    role: "cache",
+    authoritative: false,
+    physicalStores: [{
+      kind: "local-storage",
+      platforms: ["desktop"],
+      locator: "origin:localStorage",
+      keys: ["freed-device-facebook-groups-v1", VERSIONED_RECOVERY],
+    }],
+    retention: { kind: "bounded-count", limit: 5_000, unit: "groups" },
+    backup: "exclude-derived",
+    export: "exclude",
+    redaction: "redact-sensitive-fields",
+    resetSemantics: "Factory reset clears discovered groups and legacy migration completion.",
+    snapshot: "rebuildable",
+    migration: "rebuild-after-cutover",
+    cutover: {
+      blocksCutover: false,
+      reason: "The discovery roster is rebuildable provider cache and cannot be treated as library authority.",
+    },
+    sourceReferences: ["packages/desktop/src/lib/facebook-group-discovery.ts"],
+  },
+  {
+    registryKey: "factory-reset-cloud-cleanup-barrier",
+    soleOwner: "packages/ui/src/lib/factory-reset.ts",
+    locality: "device-local",
+    role: "control",
+    authoritative: true,
+    physicalStores: [{
+      kind: "local-storage",
+      platforms: ["desktop", "pwa"],
+      locator: "origin:localStorage",
+      keys: ["freed_factory_reset_cloud_cleanup_pending"],
+    }],
+    retention: { kind: "until-explicit-delete" },
+    backup: "exclude-device-local",
+    export: "include-redacted-metadata",
+    redaction: "redact-sensitive-fields",
+    resetSemantics: "The barrier is written before destructive cloud cleanup and removed only after cleanup completes or an explicit reconnect.",
+    snapshot: "excluded",
+    migration: "retain-current-device-owner",
+    cutover: {
+      blocksCutover: true,
+      reason: "Cutover admission must prove that no durable cloud-cleanup barrier is pending. Treating a missing credential as completed deletion would violate authority.",
+    },
+    sourceReferences: [
+      "packages/ui/src/lib/factory-reset.ts",
+      "packages/desktop/src/lib/sync.ts",
+      "packages/pwa/src/lib/sync.ts",
+    ],
+  },
+  {
+    registryKey: "geocoding-cache",
+    soleOwner: "packages/ui/src/lib/geocoding-cache.ts",
+    locality: "derived",
+    role: "cache",
+    authoritative: false,
+    physicalStores: [{
+      kind: "indexeddb",
+      platforms: ["desktop", "pwa"],
+      locator: "origin:indexedDB/freed-geocache@1/locations",
+      keys: ["query"],
+    }],
+    retention: {
+      kind: "bounded-by-rule",
+      rules: [
+        { scope: "successful geocodes", limit: 30, unit: "days" },
+        { scope: "negative geocodes", limit: 7, unit: "days" },
+      ],
+    },
+    backup: "exclude-derived",
+    export: "exclude",
+    redaction: "drop-entire-value",
+    resetSemantics: "Factory reset clears the database; expired hits and misses become cache misses.",
+    snapshot: "rebuildable",
+    migration: "rebuild-after-cutover",
+    cutover: {
+      blocksCutover: false,
+      reason: "Geocodes are derived from queries; hits expire after 30 days and misses after 7 days.",
+    },
+    sourceReferences: ["packages/ui/src/lib/geocoding-cache.ts"],
+  },
+  {
+    registryKey: "library-core-actor-private-key",
+    soleOwner: "unprovisioned Library Core installation actor adapter",
+    locality: "secret",
+    role: "secret",
+    authoritative: false,
+    physicalStores: [{
+      kind: "unprovisioned",
+      platforms: ["desktop", "pwa"],
+      locator: "none:Gate A does not provision a Library Core actor private key",
+      keys: [],
+    }],
+    retention: { kind: "until-reset" },
+    backup: "exclude-secret",
+    export: "exclude",
+    redaction: "drop-entire-value",
+    resetSemantics: "A reset or restore creates a new installation actor key and incarnation; active private material is never imported.",
+    snapshot: "excluded",
+    migration: "generate-after-gate-a",
+    cutover: {
+      blocksCutover: true,
+      reason: "A writable installation cannot cut over until its platform-protected actor key is generated, enrolled, and proven.",
+    },
+    sourceReferences: ["docs/LIBRARY-CORE-CONTRACT.md"],
+  },
+  {
+    registryKey: "library-core-authority-private-key",
+    soleOwner: "unprovisioned Library Core native authority adapter",
+    locality: "secret",
+    role: "secret",
+    authoritative: false,
+    physicalStores: [{
+      kind: "unprovisioned",
+      platforms: ["desktop", "pwa"],
+      locator: "none:Gate A does not provision a Library Core authority private key",
+      keys: [],
+    }],
+    retention: { kind: "until-reset" },
+    backup: "exclude-secret",
+    export: "exclude",
+    redaction: "drop-entire-value",
+    resetSemantics: "Factory reset removes local protected authority material. Restore may install a newly rotated authority key only through an accepted recovery transition; private bytes are never exported or imported.",
+    snapshot: "excluded",
+    migration: "generate-after-gate-a",
+    cutover: {
+      blocksCutover: true,
+      reason: "An active Library Core epoch cannot exist until a platform secret store and authority-key lifecycle are implemented and proven.",
+    },
+    sourceReferences: ["docs/LIBRARY-CORE-CONTRACT.md"],
+  },
+  {
+    registryKey: "local-ai-model-files",
+    soleOwner: "packages/desktop/src/lib/local-ai-models.ts",
+    locality: "derived",
+    role: "cache",
+    authoritative: false,
+    physicalStores: [{
+      kind: "filesystem",
+      platforms: ["desktop"],
+      locator: `${APP_DATA}/local-ai-models/<modelId>/<manifestRevision>/<manifestPath>`,
+      keys: ["manifest file path", "<target>.partial"],
+    }],
+    retention: { kind: "until-explicit-delete" },
+    backup: "exclude-derived",
+    export: "exclude",
+    redaction: "not-applicable",
+    resetSemantics: "Model removal or factory reset deletes downloaded and partial files.",
+    snapshot: "rebuildable",
+    migration: "rebuild-after-cutover",
+    cutover: {
+      blocksCutover: false,
+      reason: "Every model file is verified against a pinned manifest and can be downloaded again.",
+    },
+    sourceReferences: ["packages/desktop/src/lib/local-ai-models.ts"],
+  },
+  {
+    registryKey: "local-ai-model-state",
+    soleOwner: "packages/desktop/src/lib/local-ai-models.ts",
+    locality: "device-local",
+    role: "derived-runtime",
+    authoritative: true,
+    physicalStores: [{
+      kind: "native-json",
+      platforms: ["desktop"],
+      locator: `${APP_DATA}/local-ai-models/state.json`,
+      keys: ["version", "selectedModelId", "models"],
+    }],
+    retention: { kind: "until-reset" },
+    backup: "exclude-device-local",
+    export: "include-redacted-metadata",
+    redaction: "redact-sensitive-fields",
+    resetSemantics: "Model removal or factory reset clears selection, install progress, and local health.",
+    snapshot: "excluded",
+    migration: "retain-current-device-owner",
+    cutover: {
+      blocksCutover: false,
+      reason: "Installed-model selection and health remain device-local; model bytes are separately rebuildable.",
+    },
+    sourceReferences: ["packages/desktop/src/lib/local-ai-models.ts"],
+  },
+  {
+    registryKey: "media-vault",
+    soleOwner: "packages/desktop/src/lib/media-vault.ts",
+    locality: "blob",
+    role: "authoritative-device-source",
+    authoritative: true,
+    physicalStores: [{
+      kind: "filesystem",
+      platforms: ["desktop"],
+      locator: `${APP_DATA}/media-vault`,
+      keys: [
+        "manifest.json",
+        "facebook/<safe-entry-id>.<extension>",
+        "instagram/<safe-entry-id>.<extension>",
+      ],
+    }],
+    retention: {
+      kind: "unbounded-current",
+      reason: "Permanent media, roster records, and failure records have no current total byte or entry ceiling.",
+    },
+    backup: "include-private",
+    export: "include-private",
+    redaction: "retain-private-bytes",
+    resetSemantics: "Only explicit vault removal or factory reset deletes permanent files and manifest state.",
+    snapshot: "authoritative-source-manifest-required",
+    migration: "migrate-to-library-core",
+    cutover: {
+      blocksCutover: true,
+      reason: "The manifest and every retained Meta export byte are authoritative device-local sources requiring a fenced portable snapshot.",
+    },
+    sourceReferences: [
+      "packages/desktop/src/lib/media-vault.ts",
+      "packages/desktop/src/lib/meta-export-import.ts",
+    ],
+  },
+  {
+    registryKey: "provider-auth-hints",
+    soleOwner: "Desktop provider authentication hint adapter",
+    locality: "device-local",
+    role: "control",
+    authoritative: false,
+    physicalStores: [{
+      kind: "local-storage",
+      platforms: ["desktop"],
+      locator: "origin:localStorage",
+      keys: [
+        "fb_auth_state",
+        "ig_auth_state",
+        "li_auth_state",
+        "substack_auth_state",
+        "medium_auth_state",
+        "youtube_auth_state",
+      ],
+    }],
+    retention: { kind: "until-disconnect" },
+    backup: "exclude-device-local",
+    export: "include-redacted-metadata",
+    redaction: "redact-sensitive-fields",
+    resetSemantics: "Disconnect or factory reset writes a disconnected hint; the WebView cookie store remains the authentication authority.",
+    snapshot: "excluded",
+    migration: "retain-current-device-owner",
+    cutover: {
+      blocksCutover: false,
+      reason: "These sanitized hints are not proof of provider authentication and remain outside Library Core.",
+    },
+    sourceReferences: [
+      "packages/desktop/src/lib/fb-auth.ts",
+      "packages/desktop/src/lib/instagram-auth.ts",
+      "packages/desktop/src/lib/li-auth.ts",
+      "packages/desktop/src/lib/substack-auth.ts",
+      "packages/desktop/src/lib/medium-auth.ts",
+      "packages/desktop/src/lib/youtube-auth.ts",
+    ],
+  },
+  {
+    registryKey: "provider-health",
+    soleOwner: "packages/desktop/src/lib/provider-health.ts",
+    locality: "device-local",
+    role: "active-authority",
+    authoritative: true,
+    physicalStores: [
+      {
+        kind: "native-json",
+        platforms: ["desktop"],
+        locator: `${APP_DATA}/sync-health.json`,
+        keys: ["provider-health"],
+      },
+      {
+        kind: "local-storage",
+        platforms: ["desktop"],
+        locator: "origin:localStorage",
+        keys: ["freed.provider-health", "__TAURI_MOCK_STORE__:sync-health.json"],
+      },
+    ],
+    retention: {
+      kind: "bounded-by-rule",
+      rules: [
+        { scope: "provider attempts", limit: 20, unit: "attempts per provider" },
+        { scope: "feed attempts", limit: 5, unit: "attempts per feed" },
+        { scope: "daily summaries", limit: 7, unit: "buckets" },
+        { scope: "hourly summaries", limit: 24, unit: "buckets" },
+      ],
+    },
+    backup: "exclude-device-local",
+    export: "include-redacted-metadata",
+    redaction: "redact-sensitive-fields",
+    resetSemantics: "Factory reset clears provider and feed histories, pause state, and repair artifacts.",
+    snapshot: "excluded",
+    migration: "retain-current-device-owner",
+    cutover: {
+      blocksCutover: false,
+      reason: "The native JSON file remains the sole request-history authority; feed attempts are separately capped at 5 per feed.",
+    },
+    sourceReferences: ["packages/desktop/src/lib/provider-health.ts"],
+  },
+  {
+    registryKey: "provider-user-agents",
+    soleOwner: "packages/desktop/src/lib/user-agent.ts",
+    locality: "secret",
+    role: "secret",
+    authoritative: true,
+    physicalStores: [{
+      kind: "local-storage",
+      platforms: ["desktop"],
+      locator: "origin:localStorage",
+      keys: [
+        "freed_ua_facebook",
+        "freed_ua_instagram",
+        "freed_ua_linkedin",
+        "freed_ua_substack",
+        "freed_ua_medium",
+        "freed_ua_x",
+      ],
+    }],
+    retention: { kind: "until-disconnect" },
+    backup: "exclude-secret",
+    export: "exclude",
+    redaction: "drop-entire-value",
+    resetSemantics: "Provider disconnect removes that provider's persisted user agent so reconnect chooses a new one.",
+    snapshot: "excluded",
+    migration: "exclude-secret-and-retain-current-owner",
+    cutover: {
+      blocksCutover: false,
+      reason: "Provider-facing identity material remains outside every Library Core operation, snapshot, export, backup, and diagnostic artifact.",
+    },
+    sourceReferences: ["packages/desktop/src/lib/user-agent.ts"],
+  },
+  {
+    registryKey: "provider-webview-sessions-linux",
+    soleOwner: "Tauri WebKitGTK provider WebView profile",
+    locality: "secret",
+    role: "secret",
+    authoritative: true,
+    physicalStores: [{
+      kind: "webkitgtk-data-store",
+      platforms: ["desktop-linux"],
+      locator: "unresolved:Tauri WebKitGTK profile root, identifier mapping, and physical cookie ownership are not proven by current source",
+      keys: [
+        "66726565-64fb-0001-9a7d-370102fb0001 (facebook)",
+        "66726565-641a-0002-9a7d-3701021a0002 (instagram)",
+        "66726565-641d-0003-9a7d-3701021d0003 (linkedin)",
+        "66726565-645b-0004-9a7d-3701025b0004 (substack)",
+        "66726565-646d-0005-9a7d-3701026d0005 (medium)",
+        "66726565-6479-7401-9a7d-370102797401 (youtube)",
+        "freed.essay.roster.v1 (substack sessionStorage)",
+        "freed.essay.roster.v1 (medium sessionStorage)",
+      ],
+    }],
+    retention: {
+      kind: "unbounded-current",
+      reason: "The current source does not prove WebKitGTK profile lifetime, eviction, or physical removal.",
+    },
+    backup: "exclude-secret",
+    export: "exclude",
+    redaction: "drop-entire-value",
+    resetSemantics: "Disconnect calls clear_all_browsing_data only through a live or temporary provider window. The current source does not prove identifier isolation or physical deletion on Linux.",
+    snapshot: "excluded",
+    migration: "exclude-secret-and-retain-current-owner",
+    cutover: {
+      blocksCutover: true,
+      reason: "Gate A must prove the Linux profile owner, provider isolation, and deletion semantics while continuing to exclude all session bytes from Library Core artifacts.",
+    },
+    sourceReferences: [
+      "packages/desktop/src-tauri/src/lib.rs",
+      "packages/desktop/src-tauri/src/medium-extract.js",
+      "packages/desktop/src-tauri/src/substack-extract.js",
+      "packages/desktop/src-tauri/src/youtube.rs",
+    ],
+  },
+  {
+    registryKey: "provider-webview-sessions-macos",
+    soleOwner: "Tauri WebKit provider WebsiteDataStore identifiers",
+    locality: "secret",
+    role: "secret",
+    authoritative: true,
+    physicalStores: [{
+      kind: "webkit-data-store",
+      platforms: ["desktop-macos"],
+      locator: "$HOME/Library/WebKit/<bundleId>/WebsiteDataStore/<identifier>",
+      keys: [
+        "66726565-64fb-0001-9a7d-370102fb0001 (facebook)",
+        "66726565-641a-0002-9a7d-3701021a0002 (instagram)",
+        "66726565-641d-0003-9a7d-3701021d0003 (linkedin)",
+        "66726565-645b-0004-9a7d-3701025b0004 (substack)",
+        "66726565-646d-0005-9a7d-3701026d0005 (medium)",
+        "66726565-6479-7401-9a7d-370102797401 (youtube)",
+        "freed.essay.roster.v1 (substack sessionStorage)",
+        "freed.essay.roster.v1 (medium sessionStorage)",
+      ],
+    }],
+    retention: {
+      kind: "unbounded-current",
+      reason: "YouTube explicitly removes its data store on Apple, but Facebook, Instagram, and LinkedIn clear only an existing window and essay-provider cleanup depends on a live or temporary window succeeding.",
+    },
+    backup: "exclude-secret",
+    export: "exclude",
+    redaction: "drop-entire-value",
+    resetSemantics: "YouTube disconnect fetches and removes its Apple data-store identifier. Other providers call clear_all_browsing_data conditionally and do not prove physical directory removal.",
+    snapshot: "excluded",
+    migration: "exclude-secret-and-retain-current-owner",
+    cutover: {
+      blocksCutover: true,
+      reason: "Gate A must close the conditional cleanup gap for every macOS provider data store while continuing to exclude all session bytes from Library Core artifacts.",
+    },
+    sourceReferences: [
+      "packages/desktop/src-tauri/src/lib.rs",
+      "packages/desktop/src-tauri/src/medium-extract.js",
+      "packages/desktop/src-tauri/src/substack-extract.js",
+      "packages/desktop/src-tauri/src/youtube.rs",
+    ],
+  },
+  {
+    registryKey: "provider-webview-sessions-windows",
+    soleOwner: "Tauri WebView2 provider profile",
+    locality: "secret",
+    role: "secret",
+    authoritative: true,
+    physicalStores: [{
+      kind: "webview2-data-store",
+      platforms: ["desktop-windows"],
+      locator: "unresolved:Tauri WebView2 user-data root, identifier mapping, and physical cookie ownership are not proven by current source",
+      keys: [
+        "66726565-64fb-0001-9a7d-370102fb0001 (facebook)",
+        "66726565-641a-0002-9a7d-3701021a0002 (instagram)",
+        "66726565-641d-0003-9a7d-3701021d0003 (linkedin)",
+        "66726565-645b-0004-9a7d-3701025b0004 (substack)",
+        "66726565-646d-0005-9a7d-3701026d0005 (medium)",
+        "66726565-6479-7401-9a7d-370102797401 (youtube)",
+        "freed.essay.roster.v1 (substack sessionStorage)",
+        "freed.essay.roster.v1 (medium sessionStorage)",
+      ],
+    }],
+    retention: {
+      kind: "unbounded-current",
+      reason: "The current source does not prove WebView2 profile lifetime, identifier isolation, eviction, or physical removal.",
+    },
+    backup: "exclude-secret",
+    export: "exclude",
+    redaction: "drop-entire-value",
+    resetSemantics: "Disconnect calls clear_all_browsing_data only through a live or temporary provider window. The Apple-only remove_data_store path does not run on Windows.",
+    snapshot: "excluded",
+    migration: "exclude-secret-and-retain-current-owner",
+    cutover: {
+      blocksCutover: true,
+      reason: "Gate A must prove the Windows profile owner, provider isolation, and deletion semantics while continuing to exclude all session bytes from Library Core artifacts.",
+    },
+    sourceReferences: [
+      "packages/desktop/src-tauri/src/lib.rs",
+      "packages/desktop/src-tauri/src/medium-extract.js",
+      "packages/desktop/src-tauri/src/substack-extract.js",
+      "packages/desktop/src-tauri/src/youtube.rs",
+    ],
+  },
+  {
+    registryKey: "pwa-automerge-worker-debug",
+    soleOwner: "packages/pwa/src/lib/automerge-worker-debug.ts",
+    locality: "derived",
+    role: "telemetry",
+    authoritative: false,
+    physicalStores: [{
+      kind: "local-storage",
+      platforms: ["pwa"],
+      locator: "origin:localStorage",
+      keys: ["freed:pwa:automerge-worker-debug:v1"],
+    }],
+    retention: { kind: "bounded-count", limit: 30, unit: "events" },
+    backup: "exclude-derived",
+    export: "include-redacted-metadata",
+    redaction: "redact-sensitive-fields",
+    resetSemantics: "Factory reset removes all persisted worker debug events.",
+    snapshot: "excluded",
+    migration: "rebuild-after-cutover",
+    cutover: {
+      blocksCutover: false,
+      reason: "Bounded worker diagnostics are non-authoritative and must never seed Library Core state.",
+    },
+    sourceReferences: ["packages/pwa/src/lib/automerge-worker-debug.ts"],
+  },
+  {
+    registryKey: "pwa-factory-reset-coordination",
+    soleOwner: "packages/pwa/src/lib/factory-reset-coordinator.ts",
+    locality: "device-local",
+    role: "control",
+    authoritative: true,
+    physicalStores: [
+      {
+        kind: "local-storage",
+        platforms: ["pwa"],
+        locator: "origin:localStorage",
+        keys: [
+          "freed_pwa_installation_generation",
+          "freed_pwa_factory_reset_tombstone",
+          "freed_pwa_factory_reset_message",
+          "freed_pwa_runtime_<runtimeId>",
+          "freed_pwa_factory_reset_ack_<resetId>_<runtimeId>",
+          "freed_pwa_factory_reset_claim_<claimId>",
+          "freed_pwa_factory_reset_reload_envelope",
+        ],
+      },
+      {
+        kind: "session-storage",
+        platforms: ["pwa"],
+        locator: "origin:sessionStorage",
+        keys: ["freed_pwa_factory_reset_reload"],
+      },
+    ],
+    retention: { kind: "until-reset" },
+    backup: "exclude-device-local",
+    export: "exclude",
+    redaction: "redact-sensitive-fields",
+    resetSemantics: "The winning reset transaction advances generation, tombstones stale runtimes, reloads peers, then prunes transient coordination records.",
+    snapshot: "excluded",
+    migration: "retain-current-device-owner",
+    cutover: {
+      blocksCutover: false,
+      reason: "Generation and reset barriers remain PWA installation controls outside library content.",
+    },
+    sourceReferences: ["packages/pwa/src/lib/factory-reset-coordinator.ts"],
+  },
+  {
+    registryKey: "pwa-install-notice",
+    soleOwner: "packages/pwa/src/lib/pwa-install.ts",
+    locality: "device-local",
+    role: "control",
+    authoritative: true,
+    physicalStores: [{
+      kind: "local-storage",
+      platforms: ["pwa"],
+      locator: "origin:localStorage",
+      keys: ["freed.pwa.install.dismissed"],
+    }],
+    retention: { kind: "until-explicit-delete" },
+    backup: "exclude-device-local",
+    export: "exclude",
+    redaction: "not-applicable",
+    resetSemantics: "The current PWA factory reset preserves the dismissal marker. A successful installation or direct clearInstallNoticeDismissal call removes it.",
+    snapshot: "excluded",
+    migration: "retain-current-device-owner",
+    cutover: {
+      blocksCutover: false,
+      reason: "The installation prompt dismissal is PWA chrome state, not library authority.",
+    },
+    sourceReferences: ["packages/pwa/src/lib/pwa-install.ts"],
+  },
+  {
+    registryKey: "pwa-legal-consent",
+    soleOwner: "packages/pwa/src/lib/legal-consent.ts",
+    locality: "device-local",
+    role: "control",
+    authoritative: true,
+    physicalStores: [{
+      kind: "local-storage",
+      platforms: ["pwa"],
+      locator: "origin:localStorage",
+      keys: ["freed.legal.pwa.bundle"],
+    }],
+    retention: { kind: "until-explicit-delete" },
+    backup: "exclude-device-local",
+    export: "exclude",
+    redaction: "redact-sensitive-fields",
+    resetSemantics: "The current PWA factory reset preserves legal acceptance. Clearing origin site data removes it; accepting a later legal bundle replaces it.",
+    snapshot: "excluded",
+    migration: "retain-current-device-owner",
+    cutover: {
+      blocksCutover: false,
+      reason: "PWA legal acceptance remains installation-local control state outside library content.",
+    },
+    sourceReferences: ["packages/pwa/src/lib/legal-consent.ts"],
+  },
+  {
+    registryKey: "pwa-oauth-pkce",
+    soleOwner: "PWA OAuth redirect transaction coordinator",
+    locality: "secret",
+    role: "secret",
+    authoritative: true,
+    physicalStores: [{
+      kind: "session-storage",
+      platforms: ["pwa"],
+      locator: "origin:sessionStorage",
+      keys: [
+        "freed_pkce_verifier",
+        "freed_pkce_provider",
+        "freed_pkce_google_redirect_uri",
+        "freed_pkce_installation_generation",
+      ],
+    }],
+    retention: { kind: "process-lifetime" },
+    backup: "exclude-secret",
+    export: "exclude",
+    redaction: "drop-entire-value",
+    resetSemantics: "OAuth callback consumes verifier and provider; factory reset invalidates the installation generation.",
+    snapshot: "excluded",
+    migration: "exclude-secret-and-retain-current-owner",
+    cutover: {
+      blocksCutover: false,
+      reason: "PKCE material is ephemeral authentication state and cannot enter a library artifact.",
+    },
+    sourceReferences: [
+      "packages/pwa/src/lib/cloud-oauth.ts",
+      "packages/pwa/src/lib/oauth-redirect.ts",
+      "packages/pwa/src/components/OAuthCallback.tsx",
+      "packages/pwa/src/components/SyncConnectDialog.tsx",
+    ],
+  },
+  {
+    registryKey: "pwa-reader-content",
+    soleOwner: "packages/ui/src/lib/article-cache.ts",
+    locality: "blob",
+    role: "authoritative-device-source",
+    authoritative: true,
+    physicalStores: [
+      {
+        kind: "cache-api",
+        platforms: ["pwa"],
+        locator: "origin:CacheStorage/freed-articles-v1",
+        keys: ["<articleUrl>", "/content/<globalId>"],
+      },
+      {
+        kind: "cache-api",
+        platforms: ["pwa"],
+        locator: "origin:CacheStorage/freed-articles-pinned-v1",
+        keys: ["<articleUrl>", "/content/<globalId>", "/pinned-content/<globalId>"],
+      },
+    ],
+    retention: {
+      kind: "unbounded-current",
+      reason: "Neither authoritative cache namespace has a current byte or entry ceiling and browser eviction is possible.",
+    },
+    backup: "include-private",
+    export: "include-private",
+    redaction: "retain-private-bytes",
+    resetSemantics: "The current PWA factory reset preserves both namespaces. Browser eviction or clearing origin CacheStorage deletes entries; there is no current app cache-wide deletion path.",
+    snapshot: "authoritative-source-manifest-required",
+    migration: "migrate-to-library-core",
+    cutover: {
+      blocksCutover: true,
+      reason: "Either namespace may hold the only complete article body; every request entry needs an immutable lookup plan and source disposition.",
+    },
+    sourceReferences: [
+      "packages/ui/src/lib/article-cache.ts",
+      "packages/pwa/src/lib/reader-cache.ts",
+    ],
+  },
+  {
+    registryKey: "pwa-relay-credential",
+    soleOwner: "packages/pwa/src/lib/sync.ts",
+    locality: "secret",
+    role: "secret",
+    authoritative: true,
+    physicalStores: [{
+      kind: "local-storage",
+      platforms: ["pwa"],
+      locator: "origin:localStorage",
+      keys: ["freed_relay_url"],
+    }],
+    retention: { kind: "until-explicit-delete" },
+    backup: "exclude-secret",
+    export: "exclude",
+    redaction: "drop-entire-value",
+    resetSemantics: "Explicit relay cleanup or factory reset removes the relay URL, including its pairing-token query value.",
+    snapshot: "excluded",
+    migration: "exclude-secret-and-retain-current-owner",
+    cutover: {
+      blocksCutover: false,
+      reason: "The relay URL is authentication material and remains outside every Library Core artifact.",
+    },
+    sourceReferences: ["packages/pwa/src/lib/sync.ts"],
+  },
+  {
+    registryKey: "pwa-release-channel",
+    soleOwner: "packages/ui/src/lib/release-channel.ts",
+    locality: "device-local",
+    role: "control",
+    authoritative: true,
+    physicalStores: [{
+      kind: "local-storage",
+      platforms: ["pwa"],
+      locator: "origin:localStorage",
+      keys: ["freed-release-channel"],
+    }],
+    retention: { kind: "until-explicit-delete" },
+    backup: "exclude-device-local",
+    export: "exclude",
+    redaction: "not-applicable",
+    resetSemantics: "The current PWA factory reset preserves the release channel. Explicit channel selection replaces it, and clearing origin site data removes it.",
+    snapshot: "excluded",
+    migration: "retain-current-device-owner",
+    cutover: {
+      blocksCutover: false,
+      reason: "Release selection is an installation control and does not enter the library.",
+    },
+    sourceReferences: ["packages/ui/src/lib/release-channel.ts"],
+  },
+  {
+    registryKey: "pwa-service-worker-build-caches",
+    soleOwner: "packages/pwa/vite.config.ts",
+    locality: "derived",
+    role: "cache",
+    authoritative: false,
+    physicalStores: [
+      {
+        kind: "cache-api",
+        platforms: ["pwa"],
+        locator: "origin:CacheStorage/freed-wasm",
+        keys: ["GET <http-or-https URL ending .wasm>"],
+      },
+      {
+        kind: "cache-api",
+        platforms: ["pwa"],
+        locator: "origin:CacheStorage/workbox-precache-v2-<scope>",
+        keys: ["build manifest:**/*.{js,css,html,ico,png,svg}"],
+      },
+    ],
+    retention: { kind: "browser-managed" },
+    backup: "exclude-derived",
+    export: "exclude",
+    redaction: "drop-entire-value",
+    resetSemantics: "The current PWA factory reset preserves both namespaces. Browser eviction, site-data clearing, or service-worker cache replacement may delete entries.",
+    snapshot: "rebuildable",
+    migration: "rebuild-after-cutover",
+    cutover: {
+      blocksCutover: false,
+      reason: "WASM and build assets are reproducible from an exact build and must never seed Library Core state.",
+    },
+    sourceReferences: ["packages/pwa/vite.config.ts"],
+  },
+  {
+    registryKey: "pwa-service-worker-network-cache",
+    soleOwner: "packages/pwa/vite.config.ts",
+    locality: "secret",
+    role: "cache",
+    authoritative: false,
+    physicalStores: [{
+      kind: "cache-api",
+      platforms: ["pwa"],
+      locator: "origin:CacheStorage/freed-network",
+      keys: ["GET <http-or-https URL matched by the catch-all rule>"],
+    }],
+    retention: {
+      kind: "bounded-by-rule",
+      rules: [
+        { scope: "Workbox expiration entries", limit: 200, unit: "requests" },
+        { scope: "Workbox expiration age", limit: 7, unit: "days" },
+      ],
+    },
+    backup: "exclude-secret",
+    export: "exclude",
+    redaction: "drop-entire-value",
+    resetSemantics: "The current PWA factory reset preserves this namespace. Browser eviction, Workbox expiration, or clearing origin CacheStorage deletes entries.",
+    snapshot: "excluded",
+    migration: "retire-with-legacy-epoch",
+    cutover: {
+      blocksCutover: true,
+      reason: "The catch-all rule has no public-only or unauthenticated-response filter, so the cache can retain external authenticated response bytes. Gate A must delete the namespace and replace it with classified cache rules.",
+    },
+    sourceReferences: ["packages/pwa/vite.config.ts"],
+  },
+  {
+    registryKey: "pwa-service-worker-sync-cache",
+    soleOwner: "packages/pwa/vite.config.ts",
+    locality: "synchronized",
+    role: "authoritative-device-source",
+    authoritative: true,
+    physicalStores: [{
+      kind: "cache-api",
+      platforms: ["pwa"],
+      locator: "origin:CacheStorage/freed-sync-v1",
+      keys: ["GET <origin>/sync[?<query>]"],
+    }],
+    retention: {
+      kind: "unbounded-current",
+      reason: "The NetworkFirst rule has no expiration policy and accepts distinct query URLs.",
+    },
+    backup: "legacy-recovery-only",
+    export: "legacy-compatibility",
+    redaction: "retain-private-bytes",
+    resetSemantics: "The current PWA factory reset preserves this namespace. Browser eviction or clearing origin CacheStorage deletes entries.",
+    snapshot: "legacy-recovery",
+    migration: "retire-with-legacy-epoch",
+    cutover: {
+      blocksCutover: true,
+      reason: "The service worker can return a cached legacy /sync response offline. Gate A must delete or epoch-fence the namespace before a Library Core reader can interpret the response.",
+    },
+    sourceReferences: ["packages/pwa/vite.config.ts"],
+  },
+  {
+    registryKey: "reader-image-cache",
+    soleOwner: "packages/ui/src/lib/article-cache.ts",
+    locality: "derived",
+    role: "cache",
+    authoritative: false,
+    physicalStores: [{
+      kind: "cache-api",
+      platforms: ["desktop", "pwa"],
+      locator: "origin:CacheStorage/freed-images",
+      keys: ["<resolved-http-or-https-image-url>"],
+    }],
+    retention: { kind: "browser-managed" },
+    backup: "exclude-derived",
+    export: "exclude",
+    redaction: "drop-entire-value",
+    resetSemantics: "The current PWA factory reset preserves the image cache. Browser eviction or clearing origin CacheStorage deletes images; the HTML/source URL can warm them again.",
+    snapshot: "rebuildable",
+    migration: "rebuild-after-cutover",
+    cutover: {
+      blocksCutover: false,
+      reason: "Image responses are rebuildable and are never the sole authoritative reader body.",
+    },
+    sourceReferences: ["packages/ui/src/lib/article-cache.ts"],
+  },
+  {
+    registryKey: "reader-offline-cache-mode",
+    soleOwner: "packages/ui/src/lib/reader-cache-settings.ts",
+    locality: "device-local",
+    role: "control",
+    authoritative: true,
+    physicalStores: [{
+      kind: "local-storage",
+      platforms: ["desktop", "pwa"],
+      locator: "origin:localStorage",
+      keys: ["freed.reader.offlineCacheMode"],
+    }],
+    retention: { kind: "until-explicit-delete" },
+    backup: "exclude-device-local",
+    export: "exclude",
+    redaction: "not-applicable",
+    resetSemantics: "The current PWA factory reset preserves this preference. A new selection replaces it, and clearing origin site data restores the saved_only default.",
+    snapshot: "excluded",
+    migration: "retain-current-device-owner",
+    cutover: {
+      blocksCutover: false,
+      reason: "The preference remains device-local; it does not determine whether already retained content is authoritative.",
+    },
+    sourceReferences: ["packages/ui/src/lib/reader-cache-settings.ts"],
+  },
+  {
+    registryKey: "release-log-files",
+    soleOwner: "packages/desktop/src-tauri/src/lib.rs",
+    locality: "derived",
+    role: "telemetry",
+    authoritative: false,
+    physicalStores: [{
+      kind: "filesystem",
+      platforms: ["desktop"],
+      locator: "appLogDir()",
+      keys: ["<tauri-plugin-log rotating file>"],
+    }],
+    retention: {
+      kind: "unbounded-current",
+      reason: "Release logs rotate at 10 MiB per file with RotationStrategy::KeepAll, so file count and total bytes have no current ceiling.",
+    },
+    backup: "exclude-derived",
+    export: "include-redacted-metadata",
+    redaction: "redact-sensitive-fields",
+    resetSemantics: "The current factory-reset path does not delete appLogDir(). A bug-report export reads and sanitizes recent lines, but it does not remove source log files.",
+    snapshot: "excluded",
+    migration: "rebuild-after-cutover",
+    cutover: {
+      blocksCutover: false,
+      reason: "Release logs are diagnostic derivatives and must never become library or migration authority.",
+    },
+    sourceReferences: [
+      "packages/desktop/src-tauri/src/lib.rs",
+      "packages/desktop/src/lib/bug-report.ts",
+    ],
+  },
+  {
+    registryKey: "rss-runtime-state",
+    soleOwner: "packages/desktop/src/lib/rss-runtime-state.ts",
+    locality: "device-local",
+    role: "active-authority",
+    authoritative: true,
+    physicalStores: [{
+      kind: "local-storage",
+      platforms: ["desktop"],
+      locator: "origin:localStorage",
+      keys: ["freed-device-rss-runtime-v1", VERSIONED_RECOVERY],
+    }],
+    retention: { kind: "bounded-count", limit: 10_000, unit: "feed URLs" },
+    backup: "exclude-device-local",
+    export: "include-redacted-metadata",
+    redaction: "redact-sensitive-fields",
+    resetSemantics: "Feed removal deletes its scheduler record; factory reset clears the ledger and retry barriers.",
+    snapshot: "excluded",
+    migration: "retain-current-device-owner",
+    cutover: {
+      blocksCutover: false,
+      reason: "The scheduler ledger is retained locally; legacy etag and lastModified fields remain compatibility-only and are not current local authority.",
+    },
+    sourceReferences: [
+      "packages/desktop/src/lib/rss-runtime-state.ts",
+      "packages/shared/src/sync-write-policy.ts",
+    ],
+  },
+  {
+    registryKey: "runtime-observability",
+    soleOwner: "packages/desktop/src-tauri/src/lib.rs",
+    locality: "derived",
+    role: "telemetry",
+    authoritative: false,
+    physicalStores: [{
+      kind: "filesystem",
+      platforms: ["desktop"],
+      locator: APP_DATA,
+      keys: [
+        "runtime-health.jsonl or runtime-health-<YYYY-MM-DD>.jsonl",
+        "runtime-diagnostics.jsonl",
+        "startup-recovery.json",
+        ".runtime-health.writer.lock",
+      ],
+    }],
+    retention: {
+      kind: "bounded-by-rule",
+      rules: [
+        { scope: "runtime-health dated files", limit: 14, unit: "days" },
+        { scope: "runtime-health current file on non-Unix", limit: 5_242_880, unit: "bytes" },
+        { scope: "runtime-diagnostics.jsonl", limit: 5_242_880, unit: "bytes" },
+      ],
+    },
+    backup: "exclude-derived",
+    export: "include-redacted-metadata",
+    redaction: "redact-sensitive-fields",
+    resetSemantics: "Factory reset removes runtime health, diagnostics, startup recovery state, and writer lock.",
+    snapshot: "excluded",
+    migration: "rebuild-after-cutover",
+    cutover: {
+      blocksCutover: false,
+      reason: "Diagnostics may prove migration behavior but are not library authority.",
+    },
+    sourceReferences: ["packages/desktop/src-tauri/src/lib.rs"],
+  },
+  {
+    registryKey: "scraper-window-modes",
+    soleOwner: "packages/desktop/src/lib/scraper-prefs.ts",
+    locality: "device-local",
+    role: "control",
+    authoritative: true,
+    physicalStores: [{
+      kind: "local-storage",
+      platforms: ["desktop"],
+      locator: "origin:localStorage",
+      keys: [
+        "fb_scraper_debug_window",
+        "ig_scraper_debug_window",
+        "li_scraper_debug_window",
+        "substack_scraper_debug_window",
+        "medium_scraper_debug_window",
+      ],
+    }],
+    retention: { kind: "until-reset" },
+    backup: "exclude-device-local",
+    export: "exclude",
+    redaction: "not-applicable",
+    resetSemantics: "Removing a key restores the hidden mode. The current factory-reset path relies on browser-origin clearing rather than calling this module directly.",
+    snapshot: "excluded",
+    migration: "retain-current-device-owner",
+    cutover: {
+      blocksCutover: false,
+      reason: "Window presentation mode remains a device-local provider control and never enters Library Core artifacts.",
+    },
+    sourceReferences: ["packages/desktop/src/lib/scraper-prefs.ts"],
+  },
+  {
+    registryKey: "secure-api-keys",
+    soleOwner: "packages/desktop/src/lib/secure-storage.ts",
+    locality: "secret",
+    role: "secret",
+    authoritative: true,
+    physicalStores: [{
+      kind: "native-json",
+      platforms: ["desktop"],
+      locator: `${APP_DATA}/secure.json`,
+      keys: [
+        "apiKey.openai",
+        "apiKey.anthropic",
+        "apiKey.gemini",
+        "apiKey.github_story_wall",
+      ],
+    }],
+    retention: { kind: "until-explicit-delete" },
+    backup: "exclude-secret",
+    export: "exclude",
+    redaction: "drop-entire-value",
+    resetSemantics: "Explicit key removal or factory reset deletes the provider key.",
+    snapshot: "excluded",
+    migration: "exclude-secret-and-retain-current-owner",
+    cutover: {
+      blocksCutover: false,
+      reason: "API keys remain in the current plugin-store JSON authority and are forbidden in every Library Core artifact; at-rest hardening is separate security debt.",
+    },
+    sourceReferences: ["packages/desktop/src/lib/secure-storage.ts"],
+  },
+  {
+    registryKey: "snapshots",
+    soleOwner: "packages/desktop/src/lib/snapshots.ts",
+    locality: "compatibility",
+    role: "backup",
+    authoritative: false,
+    physicalStores: [
+      {
+        kind: "filesystem",
+        platforms: ["desktop"],
+        locator: `${APP_DATA}/snapshots`,
+        keys: ["index.json", "<snapshotId>.automerge", "<snapshotId>.contacts.json"],
+      },
+      {
+        kind: "local-storage",
+        platforms: ["desktop"],
+        locator: "origin:localStorage",
+        keys: ["freed.snapshots"],
+      },
+    ],
+    retention: { kind: "bounded-count", limit: 24, unit: "snapshots" },
+    backup: "legacy-recovery-only",
+    export: "legacy-compatibility",
+    redaction: "retain-private-bytes",
+    resetSemantics: "Factory reset deletes native snapshots and browser fallback snapshots.",
+    snapshot: "legacy-recovery",
+    migration: "retain-legacy-recovery",
+    cutover: {
+      blocksCutover: false,
+      reason: "Legacy snapshots stay explicit recovery inputs and never override the elected immutable migration source.",
+    },
+    sourceReferences: ["packages/desktop/src/lib/snapshots.ts"],
+  },
+  {
+    registryKey: "social-outbox-state",
+    soleOwner: "packages/desktop/src/lib/social-outbox-state.ts",
+    locality: "device-local",
+    role: "active-authority",
+    authoritative: true,
+    physicalStores: [{
+      kind: "local-storage",
+      platforms: ["desktop"],
+      locator: "origin:localStorage",
+      keys: ["freed-device-social-outbox-v1", VERSIONED_RECOVERY],
+    }],
+    retention: {
+      kind: "bounded-by-rule",
+      rules: [
+        { scope: "provider intents", limit: 2_000, unit: "intents" },
+        { scope: "one provider intent", limit: 3, unit: "attempts" },
+      ],
+    },
+    backup: "exclude-device-local",
+    export: "include-redacted-metadata",
+    redaction: "redact-sensitive-fields",
+    resetSemantics: "Factory reset clears intent, retry, and provider-confirmation state; each intent permits at most 3 attempts.",
+    snapshot: "excluded",
+    migration: "retain-current-device-owner",
+    cutover: {
+      blocksCutover: false,
+      reason: "Execution receipts remain the Desktop outbox authority and are not synchronized library operations.",
+    },
+    sourceReferences: ["packages/desktop/src/lib/social-outbox-state.ts"],
+  },
+  {
+    registryKey: "x-manual-cookies",
+    soleOwner: "packages/desktop/src/lib/x-auth.ts",
+    locality: "secret",
+    role: "secret",
+    authoritative: true,
+    physicalStores: [{
+      kind: "local-storage",
+      platforms: ["desktop"],
+      locator: "origin:localStorage",
+      keys: ["x_auth_cookies"],
+    }],
+    retention: { kind: "until-disconnect" },
+    backup: "exclude-secret",
+    export: "exclude",
+    redaction: "drop-entire-value",
+    resetSemantics: "X disconnect or factory reset removes ct0 and authToken.",
+    snapshot: "excluded",
+    migration: "exclude-secret-and-retain-current-owner",
+    cutover: {
+      blocksCutover: false,
+      reason: "X cookies remain outside Library Core and every backup, manifest, segment, log, and telemetry event.",
+    },
+    sourceReferences: ["packages/desktop/src/lib/x-auth.ts"],
+  },
+  {
+    registryKey: "youtube-offline-playlist",
+    soleOwner: "packages/desktop/src/lib/youtube-playlist.ts",
+    locality: "device-local",
+    role: "active-authority",
+    authoritative: true,
+    physicalStores: [{
+      kind: "local-storage",
+      platforms: ["desktop"],
+      locator: "origin:localStorage",
+      keys: ["youtube_offline_playlist_state"],
+    }],
+    retention: {
+      kind: "unbounded-current",
+      reason: "The current playlist execution record has no explicit entry or byte ceiling.",
+    },
+    backup: "exclude-device-local",
+    export: "include-redacted-metadata",
+    redaction: "redact-sensitive-fields",
+    resetSemantics: "YouTube disconnect clears playlist progress; factory reset preserves only governed request receipts outside this store.",
+    snapshot: "excluded",
+    migration: "retain-current-device-owner",
+    cutover: {
+      blocksCutover: true,
+      reason: "The synced video-ID receipt set has no measured entry or byte limit. Gate A cannot retain this sole provider-action progress authority without a bounded policy.",
+    },
+    sourceReferences: ["packages/desktop/src/lib/youtube-playlist.ts"],
+  },
+] as const satisfies readonly LibraryCoreLocalAuthorityRegistryEntry[];
+
+export interface LibraryCoreLocalAuthoritySourceOwner {
+  readonly registryKey: string;
+  readonly sourcePath: string;
+  /**
+   * Stable source tokens that identify the current persistence owner. Tests
+   * read the checked-in source and require every token. This is deliberately
+   * not described as AST exhaustiveness.
+   */
+  readonly sourceTokens: readonly string[];
+  /** Exact registry key descriptors owned by that source. */
+  readonly registeredKeys: readonly string[];
+}
+
+/**
+ * Checked-in source-owner manifest for the persistence constants audited in
+ * this Gate A slice. A new product persistence family must add its source
+ * owner here and a registry entry above. Dynamic key builders use their stable
+ * prefix/function token plus the closed key expansion registered above.
+ */
+export const LIBRARY_CORE_LOCAL_AUTHORITY_SOURCE_OWNERS = [
+  {
+    registryKey: "authenticated-essay-capture-cooldowns",
+    sourcePath: "packages/desktop/src/lib/authenticated-essay-capture.ts",
+    sourceTokens: [
+      'const COOLDOWN_STORAGE_PREFIX = "freed.capture-cooldown"',
+      "function cooldownStorageKey",
+    ],
+    registeredKeys: [
+      "freed.capture-cooldown.substack",
+      "freed.capture-cooldown.medium",
+    ],
+  },
+  {
+    registryKey: "automerge-cloud-dropbox",
+    sourcePath: "packages/sync/src/cloud/dropbox.ts",
+    sourceTokens: [
+      'const FILE_NAME = "freed.automerge"',
+      "const DBX_PATH = `/Apps/Freed/${FILE_NAME}`",
+    ],
+    registeredKeys: ["/Apps/Freed/freed.automerge"],
+  },
+  {
+    registryKey: "automerge-cloud-google-drive",
+    sourcePath: "packages/sync/src/cloud/gdrive.ts",
+    sourceTokens: [
+      'const FILE_NAME = "freed.automerge"',
+      'parents: ["appDataFolder"]',
+    ],
+    registeredKeys: ["freed.automerge"],
+  },
+  {
+    registryKey: "automerge-local-document",
+    sourcePath: "packages/sync/src/storage/indexeddb.ts",
+    sourceTokens: [
+      'const DB_NAME = "freed"',
+      'const STORE_NAME = "automerge"',
+      'const DOC_KEY = "feed"',
+      'const DOCUMENT_GENERATION_KEY = "feed:installation-generation"',
+    ],
+    registeredKeys: ["feed", "feed:installation-generation"],
+  },
+  {
+    registryKey: "clipboard-save-shortcut",
+    sourcePath: "packages/desktop/src/lib/clipboard-save-shortcut.ts",
+    sourceTokens: ['const STORE_FILE = "clipboard-save-shortcut.json"'],
+    registeredKeys: ["enabled", "shortcut"],
+  },
+  {
+    registryKey: "cloud-oauth-credentials",
+    sourcePath: "packages/desktop/src/lib/sync.ts",
+    sourceTokens: [
+      "const CLOUD_TOKEN_KEY = (p: CloudProvider) => `freed_cloud_token_${p}`",
+      "const CLOUD_TOKEN_META_KEY = (p: CloudProvider) => `freed_cloud_token_meta_${p}`",
+    ],
+    registeredKeys: [
+      "freed_cloud_token_gdrive",
+      "freed_cloud_token_dropbox",
+      "freed_cloud_token_meta_gdrive",
+      "freed_cloud_token_meta_dropbox",
+    ],
+  },
+  {
+    registryKey: "cloud-oauth-credentials",
+    sourcePath: "packages/pwa/src/lib/sync.ts",
+    sourceTokens: [
+      "const CLOUD_TOKEN_KEY = (provider: CloudProvider) => `freed_cloud_token_${provider}`",
+      "const CLOUD_TOKEN_META_KEY = (provider: CloudProvider) => `freed_cloud_token_meta_${provider}`",
+      'const CLOUD_PROVIDER_KEY = "freed_cloud_provider"',
+    ],
+    registeredKeys: [
+      "freed_cloud_token_gdrive",
+      "freed_cloud_token_dropbox",
+      "freed_cloud_token_meta_gdrive",
+      "freed_cloud_token_meta_dropbox",
+      "freed_cloud_provider",
+    ],
+  },
+  {
+    registryKey: "contact-sync-state",
+    sourcePath: "packages/shared/src/contact-sync-state.ts",
+    sourceTokens: [
+      'export const CONTACT_SYNC_STORAGE_KEY = "freed_contact_sync"',
+    ],
+    registeredKeys: ["freed_contact_sync"],
+  },
+  {
+    registryKey: "desktop-client-registration",
+    sourcePath: "packages/desktop/src/lib/desktop-client-registration.ts",
+    sourceTokens: [
+      'const STORE_FILE = "desktop-client.json"',
+      'const STORE_KEY = "registration"',
+      'const FALLBACK_STORAGE_KEY = "freed-desktop-client-registration-v1"',
+    ],
+    registeredKeys: [
+      "registration",
+      "freed-desktop-client-registration-v1",
+      "freed-desktop-client-registration-v1.recovery.<capturedAtMs>",
+    ],
+  },
+  {
+    registryKey: "desktop-client-warning-acknowledgement",
+    sourcePath: "packages/desktop/src/lib/desktop-client-warning.ts",
+    sourceTokens: [
+      'const DESKTOP_WARNING_ACK_KEY = "freed-multiple-desktop-warning-ack-v1"',
+    ],
+    registeredKeys: ["freed-multiple-desktop-warning-ack-v1"],
+  },
+  {
+    registryKey: "desktop-legal-consent",
+    sourcePath: "packages/desktop/src/lib/legal-consent.ts",
+    sourceTokens: [
+      'const DESKTOP_BUNDLE_KEY = "legal.bundle.desktop"',
+      'const PROVIDER_PREFIX = "legal.provider"',
+      'const FALLBACK_STORAGE_PREFIX = "freed.legal."',
+      'const LEGAL_STORE_FILE = "legal.json"',
+    ],
+    registeredKeys: [
+      "legal.bundle.desktop",
+      "legal.provider.x",
+      "legal.provider.facebook",
+      "legal.provider.instagram",
+      "legal.provider.linkedin",
+      "legal.provider.substack",
+      "legal.provider.medium",
+      "legal.provider.youtube",
+      "freed.legal.legal.bundle.desktop",
+      "freed.legal.legal.provider.x",
+      "freed.legal.legal.provider.facebook",
+      "freed.legal.legal.provider.instagram",
+      "freed.legal.legal.provider.linkedin",
+      "freed.legal.legal.provider.substack",
+      "freed.legal.legal.provider.medium",
+      "freed.legal.legal.provider.youtube",
+    ],
+  },
+  {
+    registryKey: "desktop-legal-consent",
+    sourcePath: "packages/shared/src/legal.ts",
+    sourceTokens: ["export type ProviderRiskId ="],
+    registeredKeys: [
+      "legal.provider.x",
+      "legal.provider.facebook",
+      "legal.provider.instagram",
+      "legal.provider.linkedin",
+      "legal.provider.substack",
+      "legal.provider.medium",
+      "legal.provider.youtube",
+      "freed.legal.legal.provider.x",
+      "freed.legal.legal.provider.facebook",
+      "freed.legal.legal.provider.instagram",
+      "freed.legal.legal.provider.linkedin",
+      "freed.legal.legal.provider.substack",
+      "freed.legal.legal.provider.medium",
+      "freed.legal.legal.provider.youtube",
+    ],
+  },
+  {
+    registryKey: "desktop-pairing-token",
+    sourcePath: "packages/desktop/src-tauri/src/lib.rs",
+    sourceTokens: ['data_dir.join("pairing-token")'],
+    registeredKeys: ["raw pairing token bytes"],
+  },
+  {
+    registryKey: "desktop-reader-content",
+    sourcePath: "packages/desktop/src/lib/content-cache.ts",
+    sourceTokens: [
+      'const dir = `${dataDir}/content`',
+      "function idToFilename",
+    ],
+    registeredKeys: ["<sanitized-globalId>.html"],
+  },
+  {
+    registryKey: "desktop-release-channel",
+    sourcePath: "packages/desktop/src/lib/release-channel.ts",
+    sourceTokens: [
+      'const DESKTOP_RELEASE_CHANNEL_STORE_FILE = "release-channel.json"',
+      'const DESKTOP_RELEASE_CHANNEL_STORE_KEY = "channel"',
+      'const DESKTOP_INSTALLED_RELEASE_CHANNEL_STORE_KEY = "installedChannel"',
+    ],
+    registeredKeys: ["channel", "installedChannel"],
+  },
+  {
+    registryKey: "desktop-release-channel",
+    sourcePath: "packages/ui/src/lib/release-channel.ts",
+    sourceTokens: [
+      'export const RELEASE_CHANNEL_STORAGE_KEY = "freed-release-channel"',
+    ],
+    registeredKeys: ["freed-release-channel"],
+  },
+  {
+    registryKey: "desktop-release-channel",
+    sourcePath: "packages/desktop/src/lib/desktop-updater.ts",
+    sourceTokens: [
+      'export const JUST_UPDATED_KEY = "freed-updated-to"',
+    ],
+    registeredKeys: ["freed-updated-to"],
+  },
+  {
+    registryKey: "desktop-webkit-network-cache",
+    sourcePath: "packages/desktop/src-tauri/src/lib.rs",
+    sourceTokens: [
+      "const WEBKIT_CACHE_TRIM_AT_BYTES: u64 = 768 * 1024 * 1024",
+      "const WEBKIT_CACHE_TRIM_TARGET_BYTES: u64 = 512 * 1024 * 1024",
+      'let network_cache_root = webkit_root.join("NetworkCache")',
+    ],
+    registeredKeys: ["<WebKit network-cache file>"],
+  },
+  {
+    registryKey: "desktop-webkit-network-cache",
+    sourcePath: "packages/desktop/src/lib/memory-monitor.ts",
+    sourceTokens: [
+      "const WEBKIT_CACHE_TRIM_AT_BYTES = 768 * 1024 * 1024",
+      'invoke<WebkitCacheTrimResult>("trim_webkit_network_cache_now")',
+    ],
+    registeredKeys: ["<WebKit network-cache file>"],
+  },
+  {
+    registryKey: "dev-sync-trigger-control",
+    sourcePath: "packages/desktop/src-tauri/src/lib.rs",
+    sourceTokens: [
+      'const DEV_SYNC_TRIGGER_FILE: &str = "dev-sync-trigger.json"',
+      'const DEV_SYNC_TRIGGER_RESULT_FILE: &str = "dev-sync-trigger-result.json"',
+      "const DEV_SYNC_TRIGGER_REQUEST_MAX_AGE_MS: u64 = 10 * 60 * 1000",
+    ],
+    registeredKeys: ["dev-sync-trigger.json", "dev-sync-trigger-result.json"],
+  },
+  {
+    registryKey: "dev-sync-trigger-control",
+    sourcePath: "packages/desktop/src/lib/dev-sync-triggers.ts",
+    sourceTokens: [
+      'const DEV_SYNC_TRIGGER_FILE = "dev-sync-trigger.json"',
+      'const DEV_SYNC_TRIGGER_RESULT_FILE = "dev-sync-trigger-result.json"',
+      "const DEV_SYNC_TRIGGER_REQUEST_MAX_AGE_MS = 10 * 60 * 1000",
+    ],
+    registeredKeys: ["dev-sync-trigger.json", "dev-sync-trigger-result.json"],
+  },
+  {
+    registryKey: "device-ai-preferences",
+    sourcePath: "packages/ui/src/lib/device-ai-preferences.ts",
+    sourceTokens: [
+      'export const DEVICE_AI_PREFERENCES_STORAGE_KEY = "freed-device-ai-preferences-v1"',
+      "writeVersionedLocalStorage",
+    ],
+    registeredKeys: [
+      "freed-device-ai-preferences-v1",
+      "<key>.recovery.<capturedAtMs>.<sequence>",
+    ],
+  },
+  {
+    registryKey: "device-display-preferences",
+    sourcePath: "packages/ui/src/lib/device-display-preferences.ts",
+    sourceTokens: [
+      'export const DEVICE_DISPLAY_PREFERENCES_STORAGE_KEY = "freed-device-display-preferences-v1"',
+      "writeVersionedLocalStorage",
+    ],
+    registeredKeys: [
+      "freed-device-display-preferences-v1",
+      "<key>.recovery.<capturedAtMs>.<sequence>",
+    ],
+  },
+  {
+    registryKey: "device-feed-card-density",
+    sourcePath: "packages/ui/src/lib/feed-card-density.ts",
+    sourceTokens: ['const STORAGE_KEY = "freed-feed-card-density"'],
+    registeredKeys: ["freed-feed-card-density"],
+  },
+  {
+    registryKey: "device-graph-layout",
+    sourcePath: "packages/ui/src/lib/device-graph-layout.ts",
+    sourceTokens: [
+      'export const DEVICE_GRAPH_LAYOUT_STORAGE_KEY = "freed-device-graph-layout-v1"',
+      "writeVersionedLocalStorage",
+    ],
+    registeredKeys: [
+      "freed-device-graph-layout-v1",
+      "<key>.recovery.<capturedAtMs>.<sequence>",
+    ],
+  },
+  {
+    registryKey: "device-interface-zoom",
+    sourcePath: "packages/ui/src/lib/interface-zoom.ts",
+    sourceTokens: ['const STORAGE_KEY = "freed-interface-zoom"'],
+    registeredKeys: ["freed-interface-zoom"],
+  },
+  {
+    registryKey: "device-theme",
+    sourcePath: "packages/ui/src/lib/theme.ts",
+    sourceTokens: ['export const THEME_STORAGE_KEY = "freed-theme"'],
+    registeredKeys: ["freed-theme"],
+  },
+  {
+    registryKey: "facebook-group-discovery",
+    sourcePath: "packages/desktop/src/lib/facebook-group-discovery.ts",
+    sourceTokens: [
+      'export const FACEBOOK_GROUP_DISCOVERY_STORAGE_KEY = "freed-device-facebook-groups-v1"',
+      "writeVersionedLocalStorage",
+    ],
+    registeredKeys: [
+      "freed-device-facebook-groups-v1",
+      "<key>.recovery.<capturedAtMs>.<sequence>",
+    ],
+  },
+  {
+    registryKey: "factory-reset-cloud-cleanup-barrier",
+    sourcePath: "packages/ui/src/lib/factory-reset.ts",
+    sourceTokens: [
+      'const FACTORY_RESET_CLOUD_CLEANUP_BARRIER_KEY =',
+      '"freed_factory_reset_cloud_cleanup_pending"',
+    ],
+    registeredKeys: ["freed_factory_reset_cloud_cleanup_pending"],
+  },
+  {
+    registryKey: "geocoding-cache",
+    sourcePath: "packages/ui/src/lib/geocoding-cache.ts",
+    sourceTokens: [
+      'const DB_NAME = "freed-geocache"',
+      'const STORE_NAME = "locations"',
+    ],
+    registeredKeys: ["query"],
+  },
+  {
+    registryKey: "local-ai-model-files",
+    sourcePath: "packages/desktop/src/lib/local-ai-models.ts",
+    sourceTokens: [
+      'const MODEL_ROOT_DIR = "local-ai-models"',
+      "const partial = `${target}.partial`",
+    ],
+    registeredKeys: ["manifest file path", "<target>.partial"],
+  },
+  {
+    registryKey: "local-ai-model-state",
+    sourcePath: "packages/desktop/src/lib/local-ai-models.ts",
+    sourceTokens: ['const STATE_FILE = "state.json"'],
+    registeredKeys: ["version", "selectedModelId", "models"],
+  },
+  {
+    registryKey: "media-vault",
+    sourcePath: "packages/desktop/src/lib/media-vault.ts",
+    sourceTokens: [
+      'const MANIFEST_FILE = "manifest.json"',
+      'const PROVIDERS: MediaVaultProvider[] = ["facebook", "instagram"]',
+      "safeMediaVaultFilename",
+      "extensionFromCandidate",
+    ],
+    registeredKeys: [
+      "manifest.json",
+      "facebook/<safe-entry-id>.<extension>",
+      "instagram/<safe-entry-id>.<extension>",
+    ],
+  },
+  {
+    registryKey: "provider-auth-hints",
+    sourcePath: "packages/desktop/src/lib/fb-auth.ts",
+    sourceTokens: ['const FB_AUTH_KEY = "fb_auth_state"'],
+    registeredKeys: ["fb_auth_state"],
+  },
+  {
+    registryKey: "provider-auth-hints",
+    sourcePath: "packages/desktop/src/lib/instagram-auth.ts",
+    sourceTokens: ['const IG_AUTH_KEY = "ig_auth_state"'],
+    registeredKeys: ["ig_auth_state"],
+  },
+  {
+    registryKey: "provider-auth-hints",
+    sourcePath: "packages/desktop/src/lib/li-auth.ts",
+    sourceTokens: ['const LI_AUTH_KEY = "li_auth_state"'],
+    registeredKeys: ["li_auth_state"],
+  },
+  {
+    registryKey: "provider-auth-hints",
+    sourcePath: "packages/desktop/src/lib/medium-auth.ts",
+    sourceTokens: ['storageKey: "medium_auth_state"'],
+    registeredKeys: ["medium_auth_state"],
+  },
+  {
+    registryKey: "provider-auth-hints",
+    sourcePath: "packages/desktop/src/lib/substack-auth.ts",
+    sourceTokens: ['storageKey: "substack_auth_state"'],
+    registeredKeys: ["substack_auth_state"],
+  },
+  {
+    registryKey: "provider-auth-hints",
+    sourcePath: "packages/desktop/src/lib/youtube-auth.ts",
+    sourceTokens: ['const YOUTUBE_AUTH_KEY = "youtube_auth_state"'],
+    registeredKeys: ["youtube_auth_state"],
+  },
+  {
+    registryKey: "provider-health",
+    sourcePath: "packages/desktop/src/lib/provider-health.ts",
+    sourceTokens: [
+      'const HEALTH_STORE_FILE = "sync-health.json"',
+      'const HEALTH_STORE_KEY = "provider-health"',
+      'const FALLBACK_STORAGE_KEY = "freed.provider-health"',
+    ],
+    registeredKeys: [
+      "provider-health",
+      "freed.provider-health",
+      "__TAURI_MOCK_STORE__:sync-health.json",
+    ],
+  },
+  {
+    registryKey: "provider-user-agents",
+    sourcePath: "packages/desktop/src/lib/user-agent.ts",
+    sourceTokens: [
+      'export type Platform = "facebook" | "instagram" | "linkedin" | "substack" | "medium" | "x"',
+      "const storageKey = (platform: Platform) => `freed_ua_${platform}`",
+    ],
+    registeredKeys: [
+      "freed_ua_facebook",
+      "freed_ua_instagram",
+      "freed_ua_linkedin",
+      "freed_ua_substack",
+      "freed_ua_medium",
+      "freed_ua_x",
+    ],
+  },
+  {
+    registryKey: "provider-webview-sessions-linux",
+    sourcePath: "packages/desktop/src-tauri/src/lib.rs",
+    sourceTokens: [
+      "FB_SCRAPER_DATA_STORE_IDENTIFIER",
+      "IG_SCRAPER_DATA_STORE_IDENTIFIER",
+      "LI_SCRAPER_DATA_STORE_IDENTIFIER",
+      "SUBSTACK_SCRAPER_DATA_STORE_IDENTIFIER",
+      "MEDIUM_SCRAPER_DATA_STORE_IDENTIFIER",
+    ],
+    registeredKeys: [
+      "66726565-64fb-0001-9a7d-370102fb0001 (facebook)",
+      "66726565-641a-0002-9a7d-3701021a0002 (instagram)",
+      "66726565-641d-0003-9a7d-3701021d0003 (linkedin)",
+      "66726565-645b-0004-9a7d-3701025b0004 (substack)",
+      "66726565-646d-0005-9a7d-3701026d0005 (medium)",
+    ],
+  },
+  {
+    registryKey: "provider-webview-sessions-linux",
+    sourcePath: "packages/desktop/src-tauri/src/medium-extract.js",
+    sourceTokens: ['var ROSTER_STORAGE_KEY = "freed.essay.roster.v1"'],
+    registeredKeys: [
+      "freed.essay.roster.v1 (medium sessionStorage)",
+    ],
+  },
+  {
+    registryKey: "provider-webview-sessions-linux",
+    sourcePath: "packages/desktop/src-tauri/src/substack-extract.js",
+    sourceTokens: ['var ROSTER_STORAGE_KEY = "freed.essay.roster.v1"'],
+    registeredKeys: [
+      "freed.essay.roster.v1 (substack sessionStorage)",
+    ],
+  },
+  {
+    registryKey: "provider-webview-sessions-linux",
+    sourcePath: "packages/desktop/src-tauri/src/youtube.rs",
+    sourceTokens: ["YOUTUBE_SESSION_DATA_STORE_IDENTIFIER"],
+    registeredKeys: [
+      "66726565-6479-7401-9a7d-370102797401 (youtube)",
+    ],
+  },
+  {
+    registryKey: "provider-webview-sessions-macos",
+    sourcePath: "packages/desktop/src-tauri/src/lib.rs",
+    sourceTokens: [
+      "FB_SCRAPER_DATA_STORE_IDENTIFIER",
+      "IG_SCRAPER_DATA_STORE_IDENTIFIER",
+      "LI_SCRAPER_DATA_STORE_IDENTIFIER",
+      "SUBSTACK_SCRAPER_DATA_STORE_IDENTIFIER",
+      "MEDIUM_SCRAPER_DATA_STORE_IDENTIFIER",
+    ],
+    registeredKeys: [
+      "66726565-64fb-0001-9a7d-370102fb0001 (facebook)",
+      "66726565-641a-0002-9a7d-3701021a0002 (instagram)",
+      "66726565-641d-0003-9a7d-3701021d0003 (linkedin)",
+      "66726565-645b-0004-9a7d-3701025b0004 (substack)",
+      "66726565-646d-0005-9a7d-3701026d0005 (medium)",
+    ],
+  },
+  {
+    registryKey: "provider-webview-sessions-macos",
+    sourcePath: "packages/desktop/src-tauri/src/medium-extract.js",
+    sourceTokens: ['var ROSTER_STORAGE_KEY = "freed.essay.roster.v1"'],
+    registeredKeys: [
+      "freed.essay.roster.v1 (medium sessionStorage)",
+    ],
+  },
+  {
+    registryKey: "provider-webview-sessions-macos",
+    sourcePath: "packages/desktop/src-tauri/src/substack-extract.js",
+    sourceTokens: ['var ROSTER_STORAGE_KEY = "freed.essay.roster.v1"'],
+    registeredKeys: [
+      "freed.essay.roster.v1 (substack sessionStorage)",
+    ],
+  },
+  {
+    registryKey: "provider-webview-sessions-macos",
+    sourcePath: "packages/desktop/src-tauri/src/youtube.rs",
+    sourceTokens: [
+      "YOUTUBE_SESSION_DATA_STORE_IDENTIFIER",
+      "remove_data_store(YOUTUBE_SESSION_DATA_STORE_IDENTIFIER)",
+    ],
+    registeredKeys: [
+      "66726565-6479-7401-9a7d-370102797401 (youtube)",
+    ],
+  },
+  {
+    registryKey: "provider-webview-sessions-windows",
+    sourcePath: "packages/desktop/src-tauri/src/lib.rs",
+    sourceTokens: [
+      "FB_SCRAPER_DATA_STORE_IDENTIFIER",
+      "IG_SCRAPER_DATA_STORE_IDENTIFIER",
+      "LI_SCRAPER_DATA_STORE_IDENTIFIER",
+      "SUBSTACK_SCRAPER_DATA_STORE_IDENTIFIER",
+      "MEDIUM_SCRAPER_DATA_STORE_IDENTIFIER",
+    ],
+    registeredKeys: [
+      "66726565-64fb-0001-9a7d-370102fb0001 (facebook)",
+      "66726565-641a-0002-9a7d-3701021a0002 (instagram)",
+      "66726565-641d-0003-9a7d-3701021d0003 (linkedin)",
+      "66726565-645b-0004-9a7d-3701025b0004 (substack)",
+      "66726565-646d-0005-9a7d-3701026d0005 (medium)",
+    ],
+  },
+  {
+    registryKey: "provider-webview-sessions-windows",
+    sourcePath: "packages/desktop/src-tauri/src/medium-extract.js",
+    sourceTokens: ['var ROSTER_STORAGE_KEY = "freed.essay.roster.v1"'],
+    registeredKeys: [
+      "freed.essay.roster.v1 (medium sessionStorage)",
+    ],
+  },
+  {
+    registryKey: "provider-webview-sessions-windows",
+    sourcePath: "packages/desktop/src-tauri/src/substack-extract.js",
+    sourceTokens: ['var ROSTER_STORAGE_KEY = "freed.essay.roster.v1"'],
+    registeredKeys: [
+      "freed.essay.roster.v1 (substack sessionStorage)",
+    ],
+  },
+  {
+    registryKey: "provider-webview-sessions-windows",
+    sourcePath: "packages/desktop/src-tauri/src/youtube.rs",
+    sourceTokens: ["YOUTUBE_SESSION_DATA_STORE_IDENTIFIER"],
+    registeredKeys: [
+      "66726565-6479-7401-9a7d-370102797401 (youtube)",
+    ],
+  },
+  {
+    registryKey: "pwa-automerge-worker-debug",
+    sourcePath: "packages/pwa/src/lib/automerge-worker-debug.ts",
+    sourceTokens: [
+      'const WORKER_DEBUG_STORAGE_KEY = "freed:pwa:automerge-worker-debug:v1"',
+      "const MAX_PERSISTED_WORKER_DEBUG_EVENTS = 30",
+    ],
+    registeredKeys: ["freed:pwa:automerge-worker-debug:v1"],
+  },
+  {
+    registryKey: "pwa-factory-reset-coordination",
+    sourcePath: "packages/pwa/src/lib/factory-reset-coordinator.ts",
+    sourceTokens: [
+      'const GENERATION_KEY = "freed_pwa_installation_generation"',
+      'const TOMBSTONE_KEY = "freed_pwa_factory_reset_tombstone"',
+      'const MESSAGE_KEY = "freed_pwa_factory_reset_message"',
+      'const RUNTIME_KEY_PREFIX = "freed_pwa_runtime_"',
+      'const ACK_KEY_PREFIX = "freed_pwa_factory_reset_ack_"',
+      'const RESET_CLAIM_KEY_PREFIX = "freed_pwa_factory_reset_claim_"',
+      'const RELOAD_MARKER_KEY = "freed_pwa_factory_reset_reload"',
+      'const RELOAD_ENVELOPE_KEY = "freed_pwa_factory_reset_reload_envelope"',
+    ],
+    registeredKeys: [
+      "freed_pwa_installation_generation",
+      "freed_pwa_factory_reset_tombstone",
+      "freed_pwa_factory_reset_message",
+      "freed_pwa_runtime_<runtimeId>",
+      "freed_pwa_factory_reset_ack_<resetId>_<runtimeId>",
+      "freed_pwa_factory_reset_claim_<claimId>",
+      "freed_pwa_factory_reset_reload",
+      "freed_pwa_factory_reset_reload_envelope",
+    ],
+  },
+  {
+    registryKey: "pwa-install-notice",
+    sourcePath: "packages/pwa/src/lib/pwa-install.ts",
+    sourceTokens: [
+      'const INSTALL_PROMPT_DISMISS_KEY = "freed.pwa.install.dismissed"',
+    ],
+    registeredKeys: ["freed.pwa.install.dismissed"],
+  },
+  {
+    registryKey: "pwa-legal-consent",
+    sourcePath: "packages/pwa/src/lib/legal-consent.ts",
+    sourceTokens: ['const PWA_BUNDLE_KEY = "freed.legal.pwa.bundle"'],
+    registeredKeys: ["freed.legal.pwa.bundle"],
+  },
+  {
+    registryKey: "pwa-oauth-pkce",
+    sourcePath: "packages/pwa/src/lib/cloud-oauth.ts",
+    sourceTokens: [
+      'sessionStorage.setItem("freed_pkce_verifier", verifier)',
+      'sessionStorage.setItem("freed_pkce_provider", "gdrive")',
+    ],
+    registeredKeys: ["freed_pkce_verifier", "freed_pkce_provider"],
+  },
+  {
+    registryKey: "pwa-oauth-pkce",
+    sourcePath: "packages/pwa/src/components/SyncConnectDialog.tsx",
+    sourceTokens: [
+      'sessionStorage.setItem("freed_pkce_verifier", verifier)',
+      'sessionStorage.setItem("freed_pkce_provider", "dropbox")',
+    ],
+    registeredKeys: ["freed_pkce_verifier", "freed_pkce_provider"],
+  },
+  {
+    registryKey: "pwa-oauth-pkce",
+    sourcePath: "packages/pwa/src/components/OAuthCallback.tsx",
+    sourceTokens: [
+      'sessionStorage.getItem("freed_pkce_verifier")',
+      'sessionStorage.removeItem("freed_pkce_provider")',
+      'sessionStorage.removeItem("freed_pkce_verifier")',
+    ],
+    registeredKeys: ["freed_pkce_verifier", "freed_pkce_provider"],
+  },
+  {
+    registryKey: "pwa-oauth-pkce",
+    sourcePath: "packages/pwa/src/lib/oauth-redirect.ts",
+    sourceTokens: [
+      'const GOOGLE_REDIRECT_URI_STORAGE_KEY = "freed_pkce_google_redirect_uri"',
+      'const PKCE_GENERATION_STORAGE_KEY = "freed_pkce_installation_generation"',
+    ],
+    registeredKeys: [
+      "freed_pkce_google_redirect_uri",
+      "freed_pkce_installation_generation",
+    ],
+  },
+  {
+    registryKey: "pwa-reader-content",
+    sourcePath: "packages/ui/src/lib/article-cache.ts",
+    sourceTokens: [
+      'const ARTICLE_CONTENT_CACHE_NAME = "freed-articles-v1"',
+      'const PINNED_ARTICLE_CONTENT_CACHE_NAME = "freed-articles-pinned-v1"',
+    ],
+    registeredKeys: [
+      "<articleUrl>",
+      "/content/<globalId>",
+      "/pinned-content/<globalId>",
+    ],
+  },
+  {
+    registryKey: "pwa-relay-credential",
+    sourcePath: "packages/pwa/src/lib/sync.ts",
+    sourceTokens: ['"freed_relay_url"'],
+    registeredKeys: ["freed_relay_url"],
+  },
+  {
+    registryKey: "pwa-release-channel",
+    sourcePath: "packages/ui/src/lib/release-channel.ts",
+    sourceTokens: [
+      'export const RELEASE_CHANNEL_STORAGE_KEY = "freed-release-channel"',
+    ],
+    registeredKeys: ["freed-release-channel"],
+  },
+  {
+    registryKey: "pwa-service-worker-build-caches",
+    sourcePath: "packages/pwa/vite.config.ts",
+    sourceTokens: [
+      "cacheName: 'freed-wasm'",
+      "globPatterns: ['**/*.{js,css,html,ico,png,svg}']",
+    ],
+    registeredKeys: [
+      "GET <http-or-https URL ending .wasm>",
+      "build manifest:**/*.{js,css,html,ico,png,svg}",
+    ],
+  },
+  {
+    registryKey: "pwa-service-worker-network-cache",
+    sourcePath: "packages/pwa/vite.config.ts",
+    sourceTokens: [
+      "cacheName: 'freed-network'",
+      "maxEntries: 200",
+      "maxAgeSeconds: 60 * 60 * 24 * 7",
+    ],
+    registeredKeys: [
+      "GET <http-or-https URL matched by the catch-all rule>",
+    ],
+  },
+  {
+    registryKey: "pwa-service-worker-sync-cache",
+    sourcePath: "packages/pwa/vite.config.ts",
+    sourceTokens: [
+      "cacheName: 'freed-sync-v1'",
+      "networkTimeoutSeconds: 5",
+    ],
+    registeredKeys: ["GET <origin>/sync[?<query>]"],
+  },
+  {
+    registryKey: "reader-image-cache",
+    sourcePath: "packages/ui/src/lib/article-cache.ts",
+    sourceTokens: ['const ARTICLE_IMAGE_CACHE_NAME = "freed-images"'],
+    registeredKeys: ["<resolved-http-or-https-image-url>"],
+  },
+  {
+    registryKey: "reader-offline-cache-mode",
+    sourcePath: "packages/ui/src/lib/reader-cache-settings.ts",
+    sourceTokens: ['const STORAGE_KEY = "freed.reader.offlineCacheMode"'],
+    registeredKeys: ["freed.reader.offlineCacheMode"],
+  },
+  {
+    registryKey: "release-log-files",
+    sourcePath: "packages/desktop/src-tauri/src/lib.rs",
+    sourceTokens: [
+      ".max_file_size(10 * 1024 * 1024)",
+      ".rotation_strategy(tauri_plugin_log::RotationStrategy::KeepAll)",
+      "app.path().app_log_dir()",
+    ],
+    registeredKeys: ["<tauri-plugin-log rotating file>"],
+  },
+  {
+    registryKey: "release-log-files",
+    sourcePath: "packages/desktop/src/lib/bug-report.ts",
+    sourceTokens: [
+      'invoke<string[]>("get_recent_logs", { limit })',
+      'zip.file("logs/recent.log", logLines.join("\\n"))',
+    ],
+    registeredKeys: ["<tauri-plugin-log rotating file>"],
+  },
+  {
+    registryKey: "rss-runtime-state",
+    sourcePath: "packages/desktop/src/lib/rss-runtime-state.ts",
+    sourceTokens: [
+      'const STORAGE_KEY = "freed-device-rss-runtime-v1"',
+      "const MAX_TRACKED_FEEDS = 10_000",
+      "writeVersionedLocalStorage",
+    ],
+    registeredKeys: [
+      "freed-device-rss-runtime-v1",
+      "<key>.recovery.<capturedAtMs>.<sequence>",
+    ],
+  },
+  {
+    registryKey: "runtime-observability",
+    sourcePath: "packages/desktop/src-tauri/src/lib.rs",
+    sourceTokens: [
+      'const STARTUP_RECOVERY_STATE_FILE: &str = "startup-recovery.json"',
+      'const RUNTIME_HEALTH_FILE: &str = "runtime-health.jsonl"',
+      'const RUNTIME_DIAGNOSTICS_FILE: &str = "runtime-diagnostics.jsonl"',
+      'const RUNTIME_HEALTH_WRITER_LOCK_FILE: &str = ".runtime-health.writer.lock"',
+    ],
+    registeredKeys: [
+      "runtime-health.jsonl or runtime-health-<YYYY-MM-DD>.jsonl",
+      "runtime-diagnostics.jsonl",
+      "startup-recovery.json",
+      ".runtime-health.writer.lock",
+    ],
+  },
+  {
+    registryKey: "scraper-window-modes",
+    sourcePath: "packages/desktop/src/lib/scraper-prefs.ts",
+    sourceTokens: [
+      'const IG_KEY = "ig_scraper_debug_window"',
+      'const FB_KEY = "fb_scraper_debug_window"',
+      'const LI_KEY = "li_scraper_debug_window"',
+      'const SUBSTACK_KEY = "substack_scraper_debug_window"',
+      'const MEDIUM_KEY = "medium_scraper_debug_window"',
+    ],
+    registeredKeys: [
+      "fb_scraper_debug_window",
+      "ig_scraper_debug_window",
+      "li_scraper_debug_window",
+      "substack_scraper_debug_window",
+      "medium_scraper_debug_window",
+    ],
+  },
+  {
+    registryKey: "secure-api-keys",
+    sourcePath: "packages/desktop/src/lib/secure-storage.ts",
+    sourceTokens: [
+      'type ApiKeyProvider = "openai" | "anthropic" | "gemini" | "github_story_wall"',
+      'load("secure.json", { defaults: {}, autoSave: true })',
+      "`apiKey.${provider}`",
+    ],
+    registeredKeys: [
+      "apiKey.openai",
+      "apiKey.anthropic",
+      "apiKey.gemini",
+      "apiKey.github_story_wall",
+    ],
+  },
+  {
+    registryKey: "snapshots",
+    sourcePath: "packages/desktop/src/lib/snapshots.ts",
+    sourceTokens: [
+      'const SNAPSHOT_INDEX_FILE = "index.json"',
+      'const SNAPSHOT_FALLBACK_STORAGE_KEY = "freed.snapshots"',
+      "function snapshotBinaryPath",
+      "function snapshotContactsPath",
+    ],
+    registeredKeys: [
+      "index.json",
+      "<snapshotId>.automerge",
+      "<snapshotId>.contacts.json",
+      "freed.snapshots",
+    ],
+  },
+  {
+    registryKey: "social-outbox-state",
+    sourcePath: "packages/desktop/src/lib/social-outbox-state.ts",
+    sourceTokens: [
+      'const STORAGE_KEY = "freed-device-social-outbox-v1"',
+      "const MAX_RECORDS = 2_000",
+      "writeVersionedLocalStorage",
+    ],
+    registeredKeys: [
+      "freed-device-social-outbox-v1",
+      "<key>.recovery.<capturedAtMs>.<sequence>",
+    ],
+  },
+  {
+    registryKey: "x-manual-cookies",
+    sourcePath: "packages/desktop/src/lib/x-auth.ts",
+    sourceTokens: ['const X_COOKIES_KEY = "x_auth_cookies"'],
+    registeredKeys: ["x_auth_cookies"],
+  },
+  {
+    registryKey: "youtube-offline-playlist",
+    sourcePath: "packages/desktop/src/lib/youtube-playlist.ts",
+    sourceTokens: [
+      'const PLAYLIST_STATE_KEY = "youtube_offline_playlist_state"',
+      "const MAX_PLAYLIST_ACTIONS_PER_SYNC = 25",
+    ],
+    registeredKeys: ["youtube_offline_playlist_state"],
+  },
+] as const satisfies readonly LibraryCoreLocalAuthoritySourceOwner[];
+
+/**
+ * Persisted records intentionally excluded from the product authority census.
+ * Keeping the exclusions explicit prevents a test-only or preview-only key from
+ * being mistaken for a durable production family.
+ */
+export const LIBRARY_CORE_LOCAL_AUTHORITY_NON_PRODUCT_EXCLUSIONS = [
+  {
+    sourcePath: "packages/desktop/src/App.tsx",
+    sourceToken: 'const guardKey = "freed_dev_seeded"',
+    reason: "Development and feature-preview session guard only.",
+  },
+  {
+    sourcePath: "packages/desktop/src/__mocks__/@tauri-apps/plugin-store/index.ts",
+    sourceToken: '"__TAURI_MOCK_STORE_THROW__"',
+    reason: "Test-only mock failure switch.",
+  },
+] as const;

--- a/packages/shared/src/library-core/operation-registry.ts
+++ b/packages/shared/src/library-core/operation-registry.ts
@@ -1,0 +1,483 @@
+import type { BaseAppState } from "../store-types.js";
+import type { LibraryCoreEntity } from "./protocol-registry.js";
+
+export type BaseAppFunctionKey = {
+  [Key in keyof BaseAppState]-?: NonNullable<BaseAppState[Key]> extends (
+    ...args: never[]
+  ) => unknown
+    ? Key
+    : never;
+}[keyof BaseAppState];
+
+export const LIBRARY_CORE_MAX_TRANSACTION_MEMBERS = 1_000;
+export const LIBRARY_CORE_MAX_CANONICAL_TRANSACTION_BYTES = 4_194_304;
+
+export const LIBRARY_CORE_OPERATION_IDS = [
+  "account_person_assignment",
+  "account_remove",
+  "account_restore",
+  "account_upsert",
+  "feed_item_archive_assignment",
+  "feed_item_capture_upsert",
+  "feed_item_like_assignment",
+  "feed_item_like_sync_receipt",
+  "feed_item_read_assignment",
+  "feed_item_remove",
+  "feed_item_restore",
+  "feed_item_saved_assignment",
+  "feed_item_seen_sync_receipt",
+  "feed_items_archive_frozen",
+  "feed_items_archive_read_unsaved_frozen",
+  "feed_items_content_signals_backfill_frozen",
+  "feed_items_deduplicate_frozen",
+  "feed_items_delete_archived_frozen",
+  "feed_items_prune_archived_frozen",
+  "feed_items_read_frozen",
+  "feed_items_unarchive_saved_frozen",
+  "person_reach_out_append",
+  "person_remove_and_accounts",
+  "person_remove_detach_accounts",
+  "person_restore",
+  "person_upsert",
+  "preferences_leaf_assignment",
+  "provider_capture_snapshot_reconcile",
+  "provider_intent",
+  "rss_feed_remove_keep_items",
+  "rss_feed_remove_with_items",
+  "rss_feed_restore",
+  "rss_feed_title_assignment",
+  "rss_feed_upsert",
+  "rss_feeds_heal_untitled_frozen",
+  "rss_feeds_remove_keep_items",
+  "rss_feeds_remove_with_items",
+  "sample_library_import",
+  "sample_library_remove",
+] as const;
+
+export type LibraryCoreOperationId = (typeof LIBRARY_CORE_OPERATION_IDS)[number];
+
+export type LibraryCoreOperationEntity =
+  | LibraryCoreEntity
+  | "ProviderCaptureSnapshot"
+  | "ProviderIntent"
+  | "SampleLibrary";
+
+export type LibraryCoreRelationshipEffect =
+  | "delete_accounts_linked_to_person"
+  | "delete_all_feed_items"
+  | "delete_feed_items_for_feed"
+  | "detach_accounts_from_person"
+  | "remove_sample_accounts"
+  | "remove_sample_feed_items"
+  | "remove_sample_feeds"
+  | "remove_sample_persons";
+
+export type LibraryCoreOperationBlocker =
+  | "capture_source_authority_unresolved"
+  | "field_algebra_unresolved"
+  | "frozen_bulk_contract_unresolved"
+  | "legacy_friend_account_replacement_unresolved"
+  | "materializer_unimplemented"
+  | "payload_schema_unresolved"
+  | "provider_intent_execution_receipt_unresolved"
+  | "provider_action_lifecycle_contract_unresolved"
+  | "provider_intent_separation_unresolved"
+  | "runtime_authority_inactive"
+  | "touched_fields_unresolved";
+
+type NonEmptyBlockers = readonly [
+  LibraryCoreOperationBlocker,
+  ...LibraryCoreOperationBlocker[],
+];
+
+export interface LibraryCoreOperationDefinition {
+  readonly status: "planned_blocked";
+  readonly schemaVersion: 1;
+  readonly entityType: LibraryCoreOperationEntity;
+  /**
+   * Gate A has not closed payload schemas or their exact field algebra. Keeping
+   * these values null prevents a name from masquerading as an executable codec.
+   */
+  readonly payloadSchema: null;
+  readonly touchedFieldRegistryKeys: null;
+  readonly fieldAlgebra: null;
+  readonly materializer: null;
+  readonly frozenBulkContract: null;
+  readonly transactionLimits: {
+    readonly maximumMembers: 1_000;
+    readonly maximumCanonicalTransactionBytes: 4_194_304;
+  };
+  readonly relationshipEffects: readonly LibraryCoreRelationshipEffect[];
+  readonly candidateStoreSurfaces: readonly BaseAppFunctionKey[];
+  readonly legacyWorkerRequests: readonly string[];
+  readonly intendedAuthority:
+    | "capture_ingest"
+    | "local_user"
+    | "provider_action_executor_receipt"
+    | "provider_capture_reconciliation"
+    | "system_repair";
+  readonly blockers: NonEmptyBlockers;
+}
+
+interface PlannedOperationInput {
+  readonly entityType: LibraryCoreOperationEntity;
+  readonly relationshipEffects?: readonly LibraryCoreRelationshipEffect[];
+  readonly candidateStoreSurfaces?: readonly BaseAppFunctionKey[];
+  readonly legacyWorkerRequests?: readonly string[];
+  readonly intendedAuthority:
+    | "capture_ingest"
+    | "local_user"
+    | "provider_action_executor_receipt"
+    | "provider_capture_reconciliation"
+    | "system_repair";
+  readonly additionalBlockers?: readonly LibraryCoreOperationBlocker[];
+}
+
+const BASE_OPERATION_BLOCKERS = [
+  "payload_schema_unresolved",
+  "touched_fields_unresolved",
+  "field_algebra_unresolved",
+  "materializer_unimplemented",
+  "runtime_authority_inactive",
+] as const satisfies NonEmptyBlockers;
+
+function plannedOperation(
+  input: PlannedOperationInput,
+): LibraryCoreOperationDefinition {
+  return {
+    status: "planned_blocked",
+    schemaVersion: 1,
+    entityType: input.entityType,
+    payloadSchema: null,
+    touchedFieldRegistryKeys: null,
+    fieldAlgebra: null,
+    materializer: null,
+    frozenBulkContract: null,
+    transactionLimits: {
+      maximumMembers: LIBRARY_CORE_MAX_TRANSACTION_MEMBERS,
+      maximumCanonicalTransactionBytes:
+        LIBRARY_CORE_MAX_CANONICAL_TRANSACTION_BYTES,
+    },
+    relationshipEffects: input.relationshipEffects ?? [],
+    candidateStoreSurfaces: input.candidateStoreSurfaces ?? [],
+    legacyWorkerRequests: input.legacyWorkerRequests ?? [],
+    intendedAuthority: input.intendedAuthority,
+    blockers: [
+      ...BASE_OPERATION_BLOCKERS,
+      ...(input.additionalBlockers ?? []),
+    ],
+  };
+}
+
+const localUserOperation = (
+  input: Omit<PlannedOperationInput, "intendedAuthority">,
+): LibraryCoreOperationDefinition =>
+  plannedOperation({ ...input, intendedAuthority: "local_user" });
+
+const frozenBulkBlocker = [
+  "frozen_bulk_contract_unresolved",
+] as const satisfies readonly LibraryCoreOperationBlocker[];
+
+/**
+ * Dormant operation census only.
+ *
+ * These IDs name candidate successors for current legacy surfaces. Every entry
+ * is blocked because no payload schema, touched-field set, field algebra, or
+ * materializer exists yet. Nothing in this registry grants write authority.
+ */
+export const LIBRARY_CORE_OPERATION_REGISTRY = {
+  account_person_assignment: localUserOperation({
+    entityType: "Account",
+    candidateStoreSurfaces: [
+      "createConnectionPersonFromAccounts",
+      "createConnectionPersonsFromCandidates",
+      "linkAccountToPerson",
+      "updateAccount",
+    ],
+    legacyWorkerRequests: ["UPSERT_CONNECTION_PERSONS", "UPDATE_ACCOUNT"],
+  }),
+  account_remove: localUserOperation({
+    entityType: "Account",
+    candidateStoreSurfaces: ["removeAccount", "updateFriend"],
+    legacyWorkerRequests: ["REMOVE_ACCOUNT"],
+    additionalBlockers: ["legacy_friend_account_replacement_unresolved"],
+  }),
+  account_restore: localUserOperation({
+    entityType: "Account",
+  }),
+  account_upsert: localUserOperation({
+    entityType: "Account",
+    candidateStoreSurfaces: [
+      "addAccount",
+      "addAccounts",
+      "addFriend",
+      "addFriends",
+      "updateAccount",
+      "updateFriend",
+    ],
+    legacyWorkerRequests: [
+      "ADD_ACCOUNT",
+      "ADD_ACCOUNTS",
+      "UPDATE_ACCOUNT",
+      "UPSERT_CONNECTION_PERSONS",
+    ],
+    additionalBlockers: ["legacy_friend_account_replacement_unresolved"],
+  }),
+  feed_item_archive_assignment: localUserOperation({
+    entityType: "FeedItem",
+    candidateStoreSurfaces: ["toggleArchived"],
+    legacyWorkerRequests: ["TOGGLE_ARCHIVED"],
+  }),
+  feed_item_capture_upsert: plannedOperation({
+    entityType: "FeedItem",
+    candidateStoreSurfaces: ["addItems", "updateItem"],
+    legacyWorkerRequests: [
+      "ADD_FEED_ITEM",
+      "ADD_FEED_ITEMS",
+      "ADD_STUB_ITEM",
+      "BATCH_IMPORT_ITEMS",
+      "BATCH_REFRESH_FEEDS",
+      "UPDATE_FEED_ITEM",
+    ],
+    intendedAuthority: "capture_ingest",
+    additionalBlockers: ["capture_source_authority_unresolved"],
+  }),
+  feed_item_like_assignment: localUserOperation({
+    entityType: "FeedItem",
+    candidateStoreSurfaces: ["toggleLiked"],
+    legacyWorkerRequests: ["TOGGLE_LIKED"],
+    additionalBlockers: ["provider_intent_separation_unresolved"],
+  }),
+  feed_item_like_sync_receipt: plannedOperation({
+    entityType: "FeedItem",
+    legacyWorkerRequests: ["CONFIRM_LIKED_SYNCED"],
+    intendedAuthority: "provider_action_executor_receipt",
+    additionalBlockers: [
+      "provider_action_lifecycle_contract_unresolved",
+      "provider_intent_execution_receipt_unresolved",
+    ],
+  }),
+  feed_item_read_assignment: localUserOperation({
+    entityType: "FeedItem",
+    candidateStoreSurfaces: ["markAsRead"],
+    legacyWorkerRequests: ["MARK_AS_READ"],
+    additionalBlockers: ["provider_intent_separation_unresolved"],
+  }),
+  feed_item_remove: localUserOperation({
+    entityType: "FeedItem",
+    candidateStoreSurfaces: ["removeItem"],
+    legacyWorkerRequests: ["REMOVE_FEED_ITEM"],
+  }),
+  feed_item_restore: localUserOperation({
+    entityType: "FeedItem",
+  }),
+  feed_item_saved_assignment: localUserOperation({
+    entityType: "FeedItem",
+    candidateStoreSurfaces: ["toggleSaved"],
+    legacyWorkerRequests: ["TOGGLE_SAVED"],
+  }),
+  feed_item_seen_sync_receipt: plannedOperation({
+    entityType: "FeedItem",
+    legacyWorkerRequests: ["CONFIRM_SEEN_SYNCED"],
+    intendedAuthority: "provider_action_executor_receipt",
+    additionalBlockers: [
+      "provider_action_lifecycle_contract_unresolved",
+      "provider_intent_execution_receipt_unresolved",
+    ],
+  }),
+  feed_items_archive_frozen: localUserOperation({
+    entityType: "FeedItem",
+    candidateStoreSurfaces: ["archiveItems"],
+    legacyWorkerRequests: ["ARCHIVE_ITEMS"],
+    additionalBlockers: frozenBulkBlocker,
+  }),
+  feed_items_archive_read_unsaved_frozen: localUserOperation({
+    entityType: "FeedItem",
+    candidateStoreSurfaces: ["archiveAllReadUnsaved"],
+    legacyWorkerRequests: ["ARCHIVE_ALL_READ_UNSAVED"],
+    additionalBlockers: frozenBulkBlocker,
+  }),
+  feed_items_content_signals_backfill_frozen: plannedOperation({
+    entityType: "FeedItem",
+    legacyWorkerRequests: ["BACKFILL_CONTENT_SIGNALS"],
+    intendedAuthority: "system_repair",
+    additionalBlockers: frozenBulkBlocker,
+  }),
+  feed_items_deduplicate_frozen: plannedOperation({
+    entityType: "FeedItem",
+    candidateStoreSurfaces: ["addItems"],
+    legacyWorkerRequests: [
+      "ADD_FEED_ITEMS",
+      "BATCH_REFRESH_FEEDS",
+      "DEDUPLICATE_ITEMS",
+    ],
+    intendedAuthority: "system_repair",
+    additionalBlockers: frozenBulkBlocker,
+  }),
+  feed_items_delete_archived_frozen: localUserOperation({
+    entityType: "FeedItem",
+    candidateStoreSurfaces: ["deleteAllArchived"],
+    legacyWorkerRequests: ["DELETE_ALL_ARCHIVED"],
+    additionalBlockers: frozenBulkBlocker,
+  }),
+  feed_items_prune_archived_frozen: plannedOperation({
+    entityType: "FeedItem",
+    legacyWorkerRequests: ["PRUNE_ARCHIVED_ITEMS"],
+    intendedAuthority: "system_repair",
+    additionalBlockers: frozenBulkBlocker,
+  }),
+  feed_items_read_frozen: localUserOperation({
+    entityType: "FeedItem",
+    candidateStoreSurfaces: ["markAllAsRead", "markItemsAsRead"],
+    legacyWorkerRequests: ["MARK_ALL_AS_READ", "MARK_ITEMS_AS_READ"],
+    additionalBlockers: [
+      ...frozenBulkBlocker,
+      "provider_intent_separation_unresolved",
+    ],
+  }),
+  feed_items_unarchive_saved_frozen: plannedOperation({
+    entityType: "FeedItem",
+    candidateStoreSurfaces: ["unarchiveSavedItems"],
+    legacyWorkerRequests: ["UNARCHIVE_SAVED_ITEMS"],
+    intendedAuthority: "system_repair",
+    additionalBlockers: frozenBulkBlocker,
+  }),
+  person_reach_out_append: localUserOperation({
+    entityType: "Person",
+    candidateStoreSurfaces: ["logReachOut"],
+    legacyWorkerRequests: ["LOG_REACH_OUT"],
+  }),
+  person_remove_and_accounts: localUserOperation({
+    entityType: "Person",
+    relationshipEffects: ["delete_accounts_linked_to_person"],
+    candidateStoreSurfaces: ["removeFriend", "removePerson"],
+    legacyWorkerRequests: ["REMOVE_PERSON"],
+    additionalBlockers: frozenBulkBlocker,
+  }),
+  person_remove_detach_accounts: localUserOperation({
+    entityType: "Person",
+    relationshipEffects: ["detach_accounts_from_person"],
+    candidateStoreSurfaces: ["removeFriend", "removePerson"],
+    additionalBlockers: frozenBulkBlocker,
+  }),
+  person_restore: localUserOperation({
+    entityType: "Person",
+  }),
+  person_upsert: localUserOperation({
+    entityType: "Person",
+    candidateStoreSurfaces: [
+      "addFriend",
+      "addFriends",
+      "addPerson",
+      "addPersons",
+      "createConnectionPersonFromAccounts",
+      "createConnectionPersonsFromCandidates",
+      "updateFriend",
+      "updatePerson",
+    ],
+    legacyWorkerRequests: [
+      "ADD_PERSON",
+      "ADD_PERSONS",
+      "UPDATE_PERSON",
+      "UPSERT_CONNECTION_PERSONS",
+    ],
+    additionalBlockers: ["legacy_friend_account_replacement_unresolved"],
+  }),
+  preferences_leaf_assignment: localUserOperation({
+    entityType: "UserPreferences",
+    candidateStoreSurfaces: ["updatePreferences"],
+    legacyWorkerRequests: ["UPDATE_PREFERENCES"],
+  }),
+  provider_capture_snapshot_reconcile: plannedOperation({
+    entityType: "ProviderCaptureSnapshot",
+    legacyWorkerRequests: [
+      "RECONCILE_FOLLOW_ROSTER_CAPTURE",
+      "RECONCILE_YOUTUBE_CAPTURE",
+    ],
+    intendedAuthority: "provider_capture_reconciliation",
+    additionalBlockers: frozenBulkBlocker,
+  }),
+  provider_intent: localUserOperation({
+    entityType: "ProviderIntent",
+    candidateStoreSurfaces: [
+      "markAllAsRead",
+      "markAsRead",
+      "markItemsAsRead",
+      "toggleLiked",
+    ],
+    legacyWorkerRequests: [
+      "MARK_ALL_AS_READ",
+      "MARK_AS_READ",
+      "MARK_ITEMS_AS_READ",
+      "TOGGLE_LIKED",
+    ],
+    additionalBlockers: [
+      "provider_action_lifecycle_contract_unresolved",
+      "provider_intent_execution_receipt_unresolved",
+    ],
+  }),
+  rss_feed_remove_keep_items: localUserOperation({
+    entityType: "RssFeed",
+    candidateStoreSurfaces: ["removeFeed"],
+    legacyWorkerRequests: ["REMOVE_RSS_FEED"],
+  }),
+  rss_feed_remove_with_items: localUserOperation({
+    entityType: "RssFeed",
+    relationshipEffects: ["delete_feed_items_for_feed"],
+    candidateStoreSurfaces: ["removeFeed"],
+    legacyWorkerRequests: ["REMOVE_RSS_FEED"],
+    additionalBlockers: frozenBulkBlocker,
+  }),
+  rss_feed_restore: localUserOperation({
+    entityType: "RssFeed",
+  }),
+  rss_feed_title_assignment: localUserOperation({
+    entityType: "RssFeed",
+    candidateStoreSurfaces: ["renameFeed"],
+    legacyWorkerRequests: ["UPDATE_RSS_FEED"],
+  }),
+  rss_feed_upsert: localUserOperation({
+    entityType: "RssFeed",
+    candidateStoreSurfaces: ["addFeed"],
+    legacyWorkerRequests: ["ADD_RSS_FEED", "BATCH_REFRESH_FEEDS", "UPDATE_RSS_FEED"],
+  }),
+  rss_feeds_heal_untitled_frozen: plannedOperation({
+    entityType: "RssFeed",
+    legacyWorkerRequests: ["HEAL_UNTITLED_FEEDS"],
+    intendedAuthority: "system_repair",
+    additionalBlockers: frozenBulkBlocker,
+  }),
+  rss_feeds_remove_keep_items: localUserOperation({
+    entityType: "RssFeed",
+    candidateStoreSurfaces: ["removeAllFeeds"],
+    legacyWorkerRequests: ["REMOVE_ALL_FEEDS"],
+    additionalBlockers: frozenBulkBlocker,
+  }),
+  rss_feeds_remove_with_items: localUserOperation({
+    entityType: "RssFeed",
+    relationshipEffects: ["delete_all_feed_items"],
+    candidateStoreSurfaces: ["removeAllFeeds"],
+    legacyWorkerRequests: ["REMOVE_ALL_FEEDS"],
+    additionalBlockers: frozenBulkBlocker,
+  }),
+  sample_library_import: localUserOperation({
+    entityType: "SampleLibrary",
+    candidateStoreSurfaces: ["addSampleLibraryData"],
+    legacyWorkerRequests: ["ADD_SAMPLE_LIBRARY_DATA"],
+    additionalBlockers: frozenBulkBlocker,
+  }),
+  sample_library_remove: localUserOperation({
+    entityType: "SampleLibrary",
+    relationshipEffects: [
+      "remove_sample_accounts",
+      "remove_sample_feed_items",
+      "remove_sample_feeds",
+      "remove_sample_persons",
+    ],
+    candidateStoreSurfaces: ["clearSampleData"],
+    legacyWorkerRequests: ["CLEAR_SAMPLE_DATA"],
+    additionalBlockers: frozenBulkBlocker,
+  }),
+} as const satisfies Readonly<
+  Record<LibraryCoreOperationId, LibraryCoreOperationDefinition>
+>;

--- a/packages/shared/src/library-core/protocol-registry.ts
+++ b/packages/shared/src/library-core/protocol-registry.ts
@@ -1,0 +1,240 @@
+/**
+ * Runtime-neutral vocabulary for the dormant Library Core field census.
+ *
+ * These types describe the legacy state that exists today and leave future
+ * Library Core decisions null. Nothing here grants authority, selects an
+ * adapter, activates persistence, or changes provider behavior.
+ */
+
+export type LibraryCoreKnownRoot =
+  | "feedItems"
+  | "rssFeeds"
+  | "persons"
+  | "accounts"
+  | "preferences"
+  | "meta"
+  | "desktopClient:*";
+
+export type LibraryCoreRetainedRoot =
+  LibraryCoreKnownRoot | "friends" | "<unknown-root>";
+
+export type LibraryCoreEntity =
+  | "FeedItem"
+  | "RssFeed"
+  | "Person"
+  | "Account"
+  | "UserPreferences"
+  | "DocumentMeta"
+  | "DesktopClientRegistration"
+  | "LegacyFriend"
+  | "OpaqueRecoveryEvidence";
+
+export type LibraryCoreLegacyDisposition =
+  "sync" | "positive-sync" | "device-local" | "compatibility-only";
+
+export type LibraryCoreLegacyValueShape =
+  | "typescript-string"
+  | "typescript-number"
+  | "typescript-boolean"
+  | "unregistered-legacy-value";
+
+export type LibraryCoreCurrentLocality =
+  | "legacy-synchronized"
+  | "legacy-device-local"
+  | "legacy-derived"
+  | "legacy-compatibility";
+
+export type LibraryCoreCurrentAuthority =
+  | "legacy-automerge-document"
+  | "legacy-automerge-read-only"
+  | "installation-local-store"
+  | "derived-runtime";
+
+export type LibraryCorePlannedLocality =
+  | "synchronized"
+  | "device-local"
+  | "secret"
+  | "derived"
+  | "blob"
+  | "compatibility"
+  | "opaque";
+
+export type LibraryCorePlannedAuthority =
+  | "library-operation-log"
+  | "installation-local-store"
+  | "content-addressed-blob-store"
+  | "compatibility-store"
+  | "opaque-recovery-store";
+
+/**
+ * Closed future codecs already defined by the architecture contract.
+ *
+ * Legacy TypeScript `number` is intentionally absent. The current schema does
+ * not prove safe-integer or registered fractional semantics.
+ */
+export type LibraryCoreValueCodec =
+  "boolean" | "safe-integer" | "utf8-string" | "literal-string";
+
+export type LibraryCoreStorageTier =
+  "hot" | "warm" | "cold" | "blob" | "device";
+
+export type LibraryCoreDeleteBehavior =
+  "tombstone" | "cascade" | "orphan" | "never";
+
+export type LibraryCorePathSegment =
+  | {
+      readonly kind: "property";
+      readonly name: string;
+    }
+  | {
+      readonly kind: "entity-key";
+      readonly name: string;
+    }
+  | {
+      readonly kind: "array-element";
+    }
+  | {
+      readonly kind: "dynamic-map-key";
+      readonly name: string;
+    }
+  | {
+      readonly kind: "fixed-map-key";
+      readonly name: string;
+      readonly allowedKeys: readonly string[];
+    }
+  | {
+      readonly kind: "dynamic-root-key";
+      readonly prefix: "desktopClient:";
+      readonly name: "installationId";
+    }
+  | {
+      /**
+       * Recursively matches any unregistered descendant below this root.
+       * It is one fallback per root, not a claim about one object level.
+       */
+      readonly kind: "unregistered-descendant";
+      readonly recursive: true;
+    }
+  | {
+      readonly kind: "unknown-root";
+    };
+
+export interface LibraryCorePathPattern {
+  readonly text: string;
+  readonly segments: readonly LibraryCorePathSegment[];
+}
+
+export type LibraryCorePresence = "required" | "optional";
+
+export type LibraryCoreActivationBlocker =
+  | "allowed_operations_undecided"
+  | "allowed_values_undecided"
+  | "backup_behavior_undecided"
+  | "delete_behavior_undecided"
+  | "executable_validation_undecided"
+  | "explicit_clear_undecided"
+  | "export_behavior_undecided"
+  | "field_range_undecided"
+  | "legacy_root_requires_migration"
+  | "legacy_migration_rule_undecided"
+  | "materialized_projection_undecided"
+  | "merge_algebra_undecided"
+  | "omission_semantics_undecided"
+  | "opaque_retention_unimplemented"
+  | "planned_authority_undecided"
+  | "planned_locality_undecided"
+  | "presence_semantics_undecided"
+  | "protocol_codec_undecided"
+  | "provenance_behavior_undecided"
+  | "query_eligibility_undecided"
+  | "redaction_behavior_undecided"
+  | "relationship_cascade_undecided"
+  | "restore_semantics_undecided"
+  | "storage_tier_undecided"
+  | "unknown_root_requires_classification"
+  | "unregistered_descendant_requires_classification";
+
+export interface LibraryCoreFieldActivation {
+  readonly status: "blocked";
+  /** Sorted, nonempty, and derived from every unresolved field below. */
+  readonly blockers: readonly LibraryCoreActivationBlocker[];
+}
+
+export interface LibraryCoreOpaqueRetentionReference {
+  /**
+   * Planned cutover identity. Gate A does not implement or populate it.
+   * Current unknown descendants still live in the legacy Automerge document.
+   */
+  readonly kind: "immutable-legacy-source-reference";
+  readonly requiredIdentity: readonly [
+    "sourceOccurrenceId",
+    "sourcePath",
+    "sourceDigest",
+  ];
+}
+
+export interface LibraryCoreFieldRegistryEntry {
+  readonly registryKey: string;
+  readonly root: LibraryCoreRetainedRoot;
+  readonly entity: LibraryCoreEntity;
+  readonly path: LibraryCorePathPattern;
+  readonly legacyValueShape: LibraryCoreLegacyValueShape;
+  readonly valueCodec: LibraryCoreValueCodec | null;
+  readonly allowedValues:
+    readonly string[] | { readonly kind: "not-applicable" } | null;
+  /** Presence in the immediate object, array, or map only. */
+  readonly localPresence: LibraryCorePresence | null;
+  /** True when any containing object or collection may itself be absent. */
+  readonly ancestorOptional: boolean | null;
+  readonly nullable: boolean;
+  readonly currentValidation: {
+    readonly kind: "typescript-shape-census" | "unregistered-legacy-shape";
+    readonly schema: string;
+  };
+  readonly executableValidation: null;
+  readonly currentLocality: LibraryCoreCurrentLocality;
+  readonly currentAuthority: LibraryCoreCurrentAuthority;
+  readonly plannedLocality: LibraryCorePlannedLocality | null;
+  readonly plannedAuthority: LibraryCorePlannedAuthority | null;
+  readonly legacyDisposition: LibraryCoreLegacyDisposition | null;
+  readonly numericRange: { readonly kind: "not-applicable" } | null;
+  readonly storageTier: LibraryCoreStorageTier | null;
+  readonly allowedOperationTypes: readonly string[] | null;
+  readonly mergeAlgebra: string | null;
+  readonly omissionSemantics: string | null;
+  readonly explicitClear: string | null;
+  readonly deleteBehavior: LibraryCoreDeleteBehavior | null;
+  readonly restoreSemantics: string | null;
+  readonly relationshipCascade: string | null;
+  readonly legacySourcePaths: readonly string[];
+  readonly opaqueRetention: LibraryCoreOpaqueRetentionReference | null;
+  readonly migrationRule: string | null;
+  readonly backupBehavior: string | null;
+  readonly exportBehavior: string | null;
+  readonly redactionBehavior: string | null;
+  readonly provenanceBehavior: string | null;
+  readonly materializedProjection: boolean | null;
+  readonly queryEligible: boolean | null;
+  readonly activation: LibraryCoreFieldActivation;
+}
+
+export type LibraryCoreRootKind =
+  | "entity-map"
+  | "singleton"
+  | "dynamic-root"
+  | "legacy-root"
+  | "opaque-fallback";
+
+export interface LibraryCoreRootRegistryEntry {
+  readonly registryKey: string;
+  readonly root: LibraryCoreRetainedRoot;
+  readonly entity: LibraryCoreEntity;
+  readonly kind: LibraryCoreRootKind;
+  readonly path: LibraryCorePathPattern;
+  readonly currentLocality: LibraryCoreCurrentLocality;
+  readonly currentAuthority: LibraryCoreCurrentAuthority;
+  readonly plannedLocality: null;
+  readonly plannedAuthority: null;
+  readonly cutover: "blocked";
+  readonly blockers: readonly LibraryCoreActivationBlocker[];
+}

--- a/packages/shared/src/library-core/query-registry.ts
+++ b/packages/shared/src/library-core/query-registry.ts
@@ -1,0 +1,583 @@
+export const LIBRARY_CORE_QUERY_IDS = [
+  "account_detail_v1",
+  "change_feed_v1",
+  "content_fetch_claim_v1",
+  "export_enumeration_v1",
+  "feed_facets_v1",
+  "feed_page_v1",
+  "feed_subscription_page_v1",
+  "item_detail_v1",
+  "item_reader_body_v1",
+  "legacy_direct_document_diagnostics",
+  "legacy_direct_document_export",
+  "legacy_direct_document_hydration",
+  "legacy_worker_all_item_ids",
+  "legacy_worker_broadcast_binary",
+  "legacy_worker_compare_document",
+  "legacy_worker_document_binary",
+  "legacy_worker_document_heads",
+  "legacy_worker_feeds_patch",
+  "legacy_worker_item_html",
+  "legacy_worker_item_patch",
+  "legacy_worker_item_preserved_text",
+  "legacy_worker_preferences_patch",
+  "legacy_worker_saved_youtube_urls",
+  "legacy_worker_state_update",
+  "map_markers_v1",
+  "person_detail_v1",
+  "person_timeline_v1",
+  "persons_graph_v1",
+  "preferences_snapshot_v1",
+  "provider_action_claim_v1",
+  "provider_media_page_v1",
+  "repair_work_claim_v1",
+  "search_page_v1",
+  "semantic_classification_claim_v1",
+  "story_wall_candidates_v1",
+] as const;
+
+export type LibraryCoreQueryId = (typeof LIBRARY_CORE_QUERY_IDS)[number];
+
+export type LibraryCoreQueryAdapter =
+  | "desktop_sqlite"
+  | "pwa_indexeddb"
+  | "pwa_sqlite_opfs";
+
+export type LegacyQueryBoundary =
+  | "desktop_automerge_worker"
+  | "desktop_and_pwa_automerge_workers"
+  | "direct_automerge_document"
+  | "pwa_automerge_worker";
+
+export type LibraryCoreQueryBlocker =
+  | "adapter_proof_missing"
+  | "durable_checkpoint_contract_unresolved"
+  | "nested_bounds_unresolved"
+  | "projection_unresolved"
+  | "request_schema_unresolved"
+  | "response_schema_unresolved"
+  | "runtime_adapter_unimplemented"
+  | "sort_contract_unresolved"
+  | "source_identity_unresolved";
+
+type NonEmptyQueryBlockers = readonly [
+  LibraryCoreQueryBlocker,
+  ...LibraryCoreQueryBlocker[],
+];
+
+const MIB = 1_048_576;
+const ORDINARY_RESPONSE_MAX_BYTES = 2 * MIB;
+
+/**
+ * One renderer-wide pool. Individual queries receive no private reservation,
+ * so opening several views cannot add their nominal maxima together.
+ */
+export const LIBRARY_CORE_RENDERER_CACHE_POOL = {
+  id: "renderer_dto_shared_v1",
+  settledMaximumBytes: 48 * MIB,
+  burstMaximumBytes: 64 * MIB,
+  eviction: "cross_query_lru",
+  perQueryReservations: false,
+  retainedFeedPagesMaximum: 2,
+  retainedCompactSummariesMaximum: 512,
+  retainedReaderBodiesMaximum: 16,
+  retainedReaderBodyBytesMaximum: 16 * MIB,
+} as const;
+
+/**
+ * One pool for every interactive query snapshot. Export, backup, and migration
+ * are excluded because they require durable checkpoints.
+ */
+export const LIBRARY_CORE_INTERACTIVE_SNAPSHOT_POOL = {
+  id: "interactive_snapshot_shared_v1",
+  maximumAgeMs: 60_000,
+  maximumPinnedBytesAcrossQueries: 16 * MIB,
+  releaseOn: ["cancellation", "disconnect", "cursor_exhaustion", "expiry"],
+  expiryResult: "CURSOR_STALE",
+} as const;
+
+interface InteractiveCursorIntent {
+  readonly kind: "interactive";
+  readonly pagination: "keyset" | "single_page" | "stream_offset";
+  readonly version: 1;
+  readonly opaque: true;
+  readonly snapshotPool: typeof LIBRARY_CORE_INTERACTIVE_SNAPSHOT_POOL.id;
+}
+
+interface DurableCheckpointCursorIntent {
+  readonly kind: "durable_checkpoint";
+  readonly version: 1;
+  readonly opaque: true;
+  readonly checkpointSchema: null;
+}
+
+type QueryCursorIntent =
+  | InteractiveCursorIntent
+  | DurableCheckpointCursorIntent;
+
+interface QueryCancellationContract {
+  readonly required: true;
+  readonly identitySchema: null;
+  readonly releasesSnapshot: true;
+}
+
+interface QuerySourceInventory {
+  readonly boundary: "library_core" | LegacyQueryBoundary;
+  readonly currentKinds: readonly string[];
+}
+
+export interface PlannedBlockedLibraryCoreQueryDefinition {
+  readonly status: "planned_blocked";
+  readonly querySchemaVersion: 1;
+  readonly source: {
+    readonly boundary: "library_core";
+    readonly currentKinds: readonly [];
+  };
+  readonly requestSchema: null;
+  readonly responseSchema: null;
+  readonly projection: null;
+  readonly sourceIdentity: null;
+  readonly nestedBounds: null;
+  readonly stableSort: null;
+  readonly tieBreakKey: null;
+  readonly defaultLimit: number;
+  readonly maximumLimit: number;
+  readonly maximumRows: number;
+  readonly maximumResponseBytes: number;
+  readonly cursor: QueryCursorIntent;
+  readonly fullContentAllowed: boolean;
+  readonly cancellation: QueryCancellationContract;
+  readonly totalCountIntent: "exact" | "none" | "snapshot_exact";
+  readonly rendererCachePool:
+    | typeof LIBRARY_CORE_RENDERER_CACHE_POOL.id
+    | null;
+  readonly invalidationKeyIntent: readonly string[];
+  readonly intendedAdapters: readonly LibraryCoreQueryAdapter[];
+  readonly blockers: NonEmptyQueryBlockers;
+}
+
+export interface LegacyUnboundedQueryDefinition {
+  readonly status: "legacy_unbounded";
+  readonly querySchemaVersion: 0;
+  readonly source: QuerySourceInventory & {
+    readonly boundary: LegacyQueryBoundary;
+  };
+  readonly consumers: readonly string[];
+  readonly projection: "*";
+  readonly fullContentAllowed: boolean;
+  readonly activationBlocker:
+    | "decodes_full_document"
+    | "materializes_full_collection"
+    | "missing_hard_byte_bound"
+    | "missing_hard_row_bound"
+    | "missing_snapshot_bound";
+}
+
+export type LibraryCoreQueryDefinition =
+  | PlannedBlockedLibraryCoreQueryDefinition
+  | LegacyUnboundedQueryDefinition;
+
+const ALL_INTENDED_ADAPTERS = [
+  "desktop_sqlite",
+  "pwa_indexeddb",
+  "pwa_sqlite_opfs",
+] as const satisfies readonly LibraryCoreQueryAdapter[];
+
+const BASE_QUERY_BLOCKERS = [
+  "request_schema_unresolved",
+  "response_schema_unresolved",
+  "projection_unresolved",
+  "source_identity_unresolved",
+  "nested_bounds_unresolved",
+  "sort_contract_unresolved",
+  "adapter_proof_missing",
+  "runtime_adapter_unimplemented",
+] as const satisfies NonEmptyQueryBlockers;
+
+const requiredCancellation = {
+  required: true,
+  identitySchema: null,
+  releasesSnapshot: true,
+} as const;
+
+const interactiveCursor = (
+  pagination: InteractiveCursorIntent["pagination"],
+): InteractiveCursorIntent => ({
+  kind: "interactive",
+  pagination,
+  version: 1,
+  opaque: true,
+  snapshotPool: LIBRARY_CORE_INTERACTIVE_SNAPSHOT_POOL.id,
+});
+
+interface PlannedQueryInput {
+  readonly defaultLimit: number;
+  readonly maximumLimit: number;
+  readonly maximumRows: number;
+  readonly maximumResponseBytes?: number;
+  readonly cursor?: QueryCursorIntent;
+  readonly fullContentAllowed?: boolean;
+  readonly totalCountIntent: "exact" | "none" | "snapshot_exact";
+  readonly rendererCache: boolean;
+  readonly invalidationKeyIntent: readonly string[];
+  readonly intendedAdapters?: readonly LibraryCoreQueryAdapter[];
+  readonly additionalBlockers?: readonly LibraryCoreQueryBlocker[];
+}
+
+function plannedQuery(
+  input: PlannedQueryInput,
+): PlannedBlockedLibraryCoreQueryDefinition {
+  return {
+    status: "planned_blocked",
+    querySchemaVersion: 1,
+    source: {
+      boundary: "library_core",
+      currentKinds: [],
+    },
+    requestSchema: null,
+    responseSchema: null,
+    projection: null,
+    sourceIdentity: null,
+    nestedBounds: null,
+    stableSort: null,
+    tieBreakKey: null,
+    defaultLimit: input.defaultLimit,
+    maximumLimit: input.maximumLimit,
+    maximumRows: input.maximumRows,
+    maximumResponseBytes:
+      input.maximumResponseBytes ?? ORDINARY_RESPONSE_MAX_BYTES,
+    cursor: input.cursor ?? interactiveCursor("keyset"),
+    fullContentAllowed: input.fullContentAllowed ?? false,
+    cancellation: requiredCancellation,
+    totalCountIntent: input.totalCountIntent,
+    rendererCachePool: input.rendererCache
+      ? LIBRARY_CORE_RENDERER_CACHE_POOL.id
+      : null,
+    invalidationKeyIntent: input.invalidationKeyIntent,
+    intendedAdapters: input.intendedAdapters ?? ALL_INTENDED_ADAPTERS,
+    blockers: [
+      ...BASE_QUERY_BLOCKERS,
+      ...(input.additionalBlockers ?? []),
+    ],
+  };
+}
+
+function legacyUnboundedQuery(
+  boundary: LegacyQueryBoundary,
+  currentKinds: readonly string[],
+  consumers: readonly string[],
+  activationBlocker: LegacyUnboundedQueryDefinition["activationBlocker"],
+  fullContentAllowed: boolean,
+): LegacyUnboundedQueryDefinition {
+  return {
+    status: "legacy_unbounded",
+    querySchemaVersion: 0,
+    source: { boundary, currentKinds },
+    consumers,
+    projection: "*",
+    fullContentAllowed,
+    activationBlocker,
+  };
+}
+
+/**
+ * Dormant query census only.
+ *
+ * Top-level limits come from the approved architecture, but each replacement
+ * query remains blocked until its request, response, projection, source
+ * identity, nested bounds, and sort contract are executable and adapter proofs
+ * exist. The legacy entries name every known unbounded transport and consumer
+ * that must disappear before read cutover.
+ */
+export const LIBRARY_CORE_QUERY_REGISTRY = {
+  account_detail_v1: plannedQuery({
+    defaultLimit: 1,
+    maximumLimit: 1,
+    maximumRows: 1,
+    cursor: interactiveCursor("single_page"),
+    totalCountIntent: "none",
+    rendererCache: true,
+    invalidationKeyIntent: ["account:{account_id}", "person:{person_id}"],
+  }),
+  change_feed_v1: plannedQuery({
+    defaultLimit: 128,
+    maximumLimit: 512,
+    maximumRows: 512,
+    totalCountIntent: "none",
+    rendererCache: true,
+    invalidationKeyIntent: ["change-feed"],
+  }),
+  content_fetch_claim_v1: plannedQuery({
+    defaultLimit: 25,
+    maximumLimit: 50,
+    maximumRows: 50,
+    totalCountIntent: "none",
+    rendererCache: false,
+    invalidationKeyIntent: ["content-fetch-queue"],
+  }),
+  export_enumeration_v1: plannedQuery({
+    defaultLimit: 128,
+    maximumLimit: 512,
+    maximumRows: 512,
+    cursor: {
+      kind: "durable_checkpoint",
+      version: 1,
+      opaque: true,
+      checkpointSchema: null,
+    },
+    fullContentAllowed: true,
+    totalCountIntent: "snapshot_exact",
+    rendererCache: false,
+    invalidationKeyIntent: ["export-checkpoint:{checkpoint_id}"],
+    additionalBlockers: ["durable_checkpoint_contract_unresolved"],
+  }),
+  feed_facets_v1: plannedQuery({
+    defaultLimit: 128,
+    maximumLimit: 512,
+    maximumRows: 512,
+    cursor: interactiveCursor("single_page"),
+    totalCountIntent: "exact",
+    rendererCache: true,
+    invalidationKeyIntent: ["feed-facets"],
+  }),
+  feed_page_v1: plannedQuery({
+    defaultLimit: 64,
+    maximumLimit: 128,
+    maximumRows: 128,
+    totalCountIntent: "snapshot_exact",
+    rendererCache: true,
+    invalidationKeyIntent: ["feed:{normalized_filter_digest}", "feed-facets"],
+  }),
+  feed_subscription_page_v1: plannedQuery({
+    defaultLimit: 64,
+    maximumLimit: 128,
+    maximumRows: 128,
+    totalCountIntent: "snapshot_exact",
+    rendererCache: true,
+    invalidationKeyIntent: ["rss-feeds"],
+  }),
+  item_detail_v1: plannedQuery({
+    defaultLimit: 1,
+    maximumLimit: 1,
+    maximumRows: 1,
+    cursor: interactiveCursor("single_page"),
+    totalCountIntent: "none",
+    rendererCache: true,
+    invalidationKeyIntent: ["item:{global_id}"],
+  }),
+  item_reader_body_v1: plannedQuery({
+    defaultLimit: 1,
+    maximumLimit: 1,
+    maximumRows: 1,
+    maximumResponseBytes: 256 * 1_024,
+    cursor: interactiveCursor("stream_offset"),
+    fullContentAllowed: true,
+    totalCountIntent: "none",
+    rendererCache: true,
+    invalidationKeyIntent: ["item-body:{global_id}:{content_digest}"],
+  }),
+  legacy_direct_document_diagnostics: legacyUnboundedQuery(
+    "direct_automerge_document",
+    ["A.toJS", "A.view", "Object.values", "summarizeDocContentSignals"],
+    ["debug diagnostics", "runtime-health summaries", "support evidence"],
+    "decodes_full_document",
+    true,
+  ),
+  legacy_direct_document_export: legacyUnboundedQuery(
+    "direct_automerge_document",
+    ["A.save", "document export enumeration"],
+    ["import-export", "manual export", "snapshot backup"],
+    "missing_snapshot_bound",
+    true,
+  ),
+  legacy_direct_document_hydration: legacyUnboundedQuery(
+    "direct_automerge_document",
+    ["A.view", "Object.values(feedItems)", "rankFeedItems"],
+    ["Desktop Zustand hydration", "PWA Zustand hydration"],
+    "materializes_full_collection",
+    true,
+  ),
+  legacy_worker_all_item_ids: legacyUnboundedQuery(
+    "desktop_automerge_worker",
+    ["GET_ALL_ITEM_IDS", "ALL_ITEM_IDS"],
+    ["Desktop import deduplication"],
+    "missing_hard_row_bound",
+    false,
+  ),
+  legacy_worker_broadcast_binary: legacyUnboundedQuery(
+    "desktop_automerge_worker",
+    ["BROADCAST_REQUEST"],
+    ["Desktop relay broadcast"],
+    "missing_hard_byte_bound",
+    true,
+  ),
+  legacy_worker_compare_document: legacyUnboundedQuery(
+    "desktop_and_pwa_automerge_workers",
+    ["COMPARE_DOC", "DOC_RELATIONSHIP"],
+    ["cloud reconciliation", "relay reconciliation"],
+    "missing_hard_byte_bound",
+    true,
+  ),
+  legacy_worker_document_binary: legacyUnboundedQuery(
+    "desktop_and_pwa_automerge_workers",
+    ["GET_DOC_BINARY", "DOC_BINARY"],
+    ["cloud upload", "relay broadcast", "snapshot backup", "factory reset"],
+    "missing_hard_byte_bound",
+    true,
+  ),
+  legacy_worker_document_heads: legacyUnboundedQuery(
+    "desktop_and_pwa_automerge_workers",
+    ["GET_HEADS", "DOC_HEADS"],
+    ["cloud upload loop accounting", "relay reconciliation"],
+    "missing_hard_row_bound",
+    false,
+  ),
+  legacy_worker_feeds_patch: legacyUnboundedQuery(
+    "desktop_automerge_worker",
+    ["FEEDS_PATCH"],
+    ["Desktop Zustand feed map"],
+    "missing_hard_row_bound",
+    false,
+  ),
+  legacy_worker_item_html: legacyUnboundedQuery(
+    "desktop_and_pwa_automerge_workers",
+    ["GET_ITEM_LEGACY_HTML", "ITEM_LEGACY_HTML"],
+    ["Desktop reader", "PWA reader"],
+    "missing_hard_byte_bound",
+    true,
+  ),
+  legacy_worker_item_patch: legacyUnboundedQuery(
+    "desktop_automerge_worker",
+    ["ITEM_PATCH"],
+    ["Desktop Zustand item projection", "provider outbox change subscription"],
+    "missing_hard_row_bound",
+    true,
+  ),
+  legacy_worker_item_preserved_text: legacyUnboundedQuery(
+    "desktop_automerge_worker",
+    ["GET_ITEM_PRESERVED_TEXT", "ITEM_PRESERVED_TEXT"],
+    ["Desktop reader", "content fetch accounting"],
+    "missing_hard_byte_bound",
+    true,
+  ),
+  legacy_worker_preferences_patch: legacyUnboundedQuery(
+    "desktop_automerge_worker",
+    ["PREFERENCES_PATCH"],
+    ["Desktop Zustand preferences", "semantic-classifier scheduling"],
+    "missing_hard_row_bound",
+    false,
+  ),
+  legacy_worker_saved_youtube_urls: legacyUnboundedQuery(
+    "desktop_automerge_worker",
+    ["GET_SAVED_YOUTUBE_URLS", "SAVED_YOUTUBE_URLS"],
+    ["YouTube capture deduplication"],
+    "missing_hard_row_bound",
+    false,
+  ),
+  legacy_worker_state_update: legacyUnboundedQuery(
+    "desktop_and_pwa_automerge_workers",
+    ["STATE_UPDATE", "DocState"],
+    [
+      "Desktop Zustand hydration",
+      "PWA Zustand hydration",
+      "content-fetch full-list scan",
+      "provider-outbox full-list scan",
+      "semantic-classifier corpus scheduling",
+    ],
+    "materializes_full_collection",
+    true,
+  ),
+  map_markers_v1: plannedQuery({
+    defaultLimit: 500,
+    maximumLimit: 1_000,
+    maximumRows: 1_000,
+    totalCountIntent: "snapshot_exact",
+    rendererCache: true,
+    invalidationKeyIntent: ["map:{normalized_filter_digest}"],
+  }),
+  person_detail_v1: plannedQuery({
+    defaultLimit: 1,
+    maximumLimit: 1,
+    maximumRows: 1,
+    cursor: interactiveCursor("single_page"),
+    totalCountIntent: "none",
+    rendererCache: true,
+    invalidationKeyIntent: ["person:{person_id}"],
+  }),
+  person_timeline_v1: plannedQuery({
+    defaultLimit: 50,
+    maximumLimit: 100,
+    maximumRows: 100,
+    totalCountIntent: "snapshot_exact",
+    rendererCache: true,
+    invalidationKeyIntent: ["person-timeline:{person_id}"],
+  }),
+  persons_graph_v1: plannedQuery({
+    defaultLimit: 1_000,
+    maximumLimit: 5_000,
+    maximumRows: 5_000,
+    cursor: interactiveCursor("single_page"),
+    totalCountIntent: "snapshot_exact",
+    rendererCache: true,
+    invalidationKeyIntent: ["friends-graph:{normalized_filter_digest}"],
+  }),
+  preferences_snapshot_v1: plannedQuery({
+    defaultLimit: 1,
+    maximumLimit: 1,
+    maximumRows: 1,
+    cursor: interactiveCursor("single_page"),
+    totalCountIntent: "none",
+    rendererCache: true,
+    invalidationKeyIntent: ["preferences"],
+  }),
+  provider_action_claim_v1: plannedQuery({
+    defaultLimit: 10,
+    maximumLimit: 25,
+    maximumRows: 25,
+    totalCountIntent: "none",
+    rendererCache: false,
+    invalidationKeyIntent: ["provider-action-queue"],
+  }),
+  provider_media_page_v1: plannedQuery({
+    defaultLimit: 100,
+    maximumLimit: 250,
+    maximumRows: 250,
+    totalCountIntent: "snapshot_exact",
+    rendererCache: true,
+    invalidationKeyIntent: ["provider-media:{provider}:{account_id}"],
+  }),
+  repair_work_claim_v1: plannedQuery({
+    defaultLimit: 25,
+    maximumLimit: 50,
+    maximumRows: 50,
+    totalCountIntent: "none",
+    rendererCache: false,
+    invalidationKeyIntent: ["repair-work-queue"],
+  }),
+  search_page_v1: plannedQuery({
+    defaultLimit: 50,
+    maximumLimit: 100,
+    maximumRows: 100,
+    totalCountIntent: "snapshot_exact",
+    rendererCache: true,
+    invalidationKeyIntent: ["search:{normalized_query_digest}"],
+  }),
+  semantic_classification_claim_v1: plannedQuery({
+    defaultLimit: 50,
+    maximumLimit: 100,
+    maximumRows: 100,
+    totalCountIntent: "none",
+    rendererCache: false,
+    invalidationKeyIntent: ["semantic-classification-queue"],
+  }),
+  story_wall_candidates_v1: plannedQuery({
+    defaultLimit: 100,
+    maximumLimit: 250,
+    maximumRows: 250,
+    totalCountIntent: "snapshot_exact",
+    rendererCache: true,
+    invalidationKeyIntent: ["story-wall:{normalized_filter_digest}"],
+  }),
+} as const satisfies Readonly<
+  Record<LibraryCoreQueryId, LibraryCoreQueryDefinition>
+>;

--- a/packages/shared/src/library-core/registry.test.ts
+++ b/packages/shared/src/library-core/registry.test.ts
@@ -1,0 +1,397 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  LIBRARY_CORE_MAX_CANONICAL_TRANSACTION_BYTES,
+  LIBRARY_CORE_MAX_TRANSACTION_MEMBERS,
+  LIBRARY_CORE_OPERATION_IDS,
+  LIBRARY_CORE_OPERATION_REGISTRY,
+} from "./operation-registry.js";
+import {
+  LIBRARY_CORE_INTERACTIVE_SNAPSHOT_POOL,
+  LIBRARY_CORE_QUERY_IDS,
+  LIBRARY_CORE_QUERY_REGISTRY,
+  LIBRARY_CORE_RENDERER_CACHE_POOL,
+} from "./query-registry.js";
+import { BASE_APP_STORE_SURFACE_REGISTRY } from "./store-surface-registry.js";
+
+describe("Library Core operation registry", () => {
+  it("has one stable, sorted definition for every dormant operation ID", () => {
+    expect([...LIBRARY_CORE_OPERATION_IDS]).toStrictEqual(
+      [...LIBRARY_CORE_OPERATION_IDS].sort(),
+    );
+    expect(Object.keys(LIBRARY_CORE_OPERATION_REGISTRY)).toStrictEqual([
+      ...LIBRARY_CORE_OPERATION_IDS,
+    ]);
+    expect(new Set(LIBRARY_CORE_OPERATION_IDS).size).toBe(
+      LIBRARY_CORE_OPERATION_IDS.length,
+    );
+  });
+
+  it("does not claim executable schemas, algebra, materializers, or authority", () => {
+    for (const definition of Object.values(
+      LIBRARY_CORE_OPERATION_REGISTRY,
+    )) {
+      expect(definition.status).toBe("planned_blocked");
+      expect(definition.payloadSchema).toBeNull();
+      expect(definition.touchedFieldRegistryKeys).toBeNull();
+      expect(definition.fieldAlgebra).toBeNull();
+      expect(definition.materializer).toBeNull();
+      expect(definition.frozenBulkContract).toBeNull();
+      expect(definition.blockers.length).toBeGreaterThan(0);
+      expect(definition.blockers).toContain("runtime_authority_inactive");
+      expect(definition.transactionLimits).toStrictEqual({
+        maximumMembers: LIBRARY_CORE_MAX_TRANSACTION_MEMBERS,
+        maximumCanonicalTransactionBytes:
+          LIBRARY_CORE_MAX_CANONICAL_TRANSACTION_BYTES,
+      });
+      expect("mergeAlgebra" in definition).toBe(false);
+    }
+
+    expect(LIBRARY_CORE_MAX_TRANSACTION_MEMBERS).toBe(1_000);
+    expect(LIBRARY_CORE_MAX_CANONICAL_TRANSACTION_BYTES).toBe(4 * 1_048_576);
+  });
+
+  it("keeps frozen membership, provider intent, and execution receipts unresolved", () => {
+    for (const operationId of LIBRARY_CORE_OPERATION_IDS.filter((id) =>
+      id.includes("_frozen"),
+    )) {
+      expect(
+        LIBRARY_CORE_OPERATION_REGISTRY[operationId].blockers,
+      ).toContain("frozen_bulk_contract_unresolved");
+    }
+
+    expect(
+      LIBRARY_CORE_OPERATION_REGISTRY.feed_item_like_assignment.blockers,
+    ).toContain("provider_intent_separation_unresolved");
+    expect(
+      LIBRARY_CORE_OPERATION_REGISTRY.feed_item_read_assignment.blockers,
+    ).toContain("provider_intent_separation_unresolved");
+    expect(
+      LIBRARY_CORE_OPERATION_REGISTRY.feed_items_read_frozen.blockers,
+    ).toContain("provider_intent_separation_unresolved");
+    expect(LIBRARY_CORE_OPERATION_REGISTRY.provider_intent.blockers).toContain(
+      "provider_intent_execution_receipt_unresolved",
+    );
+    expect(
+      LIBRARY_CORE_OPERATION_REGISTRY.provider_intent.candidateStoreSurfaces,
+    ).toStrictEqual([
+      "markAllAsRead",
+      "markAsRead",
+      "markItemsAsRead",
+      "toggleLiked",
+    ]);
+
+    for (const operationId of [
+      "feed_item_like_sync_receipt",
+      "feed_item_seen_sync_receipt",
+    ] as const) {
+      const definition = LIBRARY_CORE_OPERATION_REGISTRY[operationId];
+      expect(definition.intendedAuthority).toBe(
+        "provider_action_executor_receipt",
+      );
+      expect(definition.blockers).toContain(
+        "provider_action_lifecycle_contract_unresolved",
+      );
+    }
+    expect(
+      LIBRARY_CORE_OPERATION_REGISTRY.feed_item_capture_upsert,
+    ).toMatchObject({
+      intendedAuthority: "capture_ingest",
+      blockers: expect.arrayContaining([
+        "capture_source_authority_unresolved",
+      ]),
+    });
+    expect(
+      LIBRARY_CORE_OPERATION_REGISTRY.feed_items_deduplicate_frozen,
+    ).toMatchObject({
+      candidateStoreSurfaces: ["addItems"],
+      legacyWorkerRequests: [
+        "ADD_FEED_ITEMS",
+        "BATCH_REFRESH_FEEDS",
+        "DEDUPLICATE_ITEMS",
+      ],
+    });
+
+    for (const operationId of [
+      "feed_items_deduplicate_frozen",
+      "rss_feeds_heal_untitled_frozen",
+    ] as const) {
+      expect(
+        LIBRARY_CORE_OPERATION_REGISTRY[operationId].blockers,
+      ).toContain("frozen_bulk_contract_unresolved");
+    }
+  });
+
+  it("names each destructive relationship cascade instead of hiding it behind a boolean", () => {
+    expect(
+      LIBRARY_CORE_OPERATION_REGISTRY.rss_feed_remove_keep_items
+        .relationshipEffects,
+    ).toStrictEqual([]);
+    expect(
+      LIBRARY_CORE_OPERATION_REGISTRY.rss_feed_remove_with_items
+        .relationshipEffects,
+    ).toStrictEqual(["delete_feed_items_for_feed"]);
+    expect(
+      LIBRARY_CORE_OPERATION_REGISTRY.rss_feeds_remove_keep_items
+        .relationshipEffects,
+    ).toStrictEqual([]);
+    expect(
+      LIBRARY_CORE_OPERATION_REGISTRY.rss_feeds_remove_with_items
+        .relationshipEffects,
+    ).toStrictEqual(["delete_all_feed_items"]);
+    expect(
+      LIBRARY_CORE_OPERATION_REGISTRY.person_remove_detach_accounts
+        .relationshipEffects,
+    ).toStrictEqual(["detach_accounts_from_person"]);
+    expect(
+      LIBRARY_CORE_OPERATION_REGISTRY.person_remove_detach_accounts.blockers,
+    ).toContain("frozen_bulk_contract_unresolved");
+    expect(
+      LIBRARY_CORE_OPERATION_REGISTRY.person_remove_and_accounts
+        .relationshipEffects,
+    ).toStrictEqual(["delete_accounts_linked_to_person"]);
+  });
+});
+
+describe("Library Core query registry", () => {
+  it("has one stable, sorted definition for every query census ID", () => {
+    expect([...LIBRARY_CORE_QUERY_IDS]).toStrictEqual(
+      [...LIBRARY_CORE_QUERY_IDS].sort(),
+    );
+    expect(Object.keys(LIBRARY_CORE_QUERY_REGISTRY)).toStrictEqual([
+      ...LIBRARY_CORE_QUERY_IDS,
+    ]);
+    expect(new Set(LIBRARY_CORE_QUERY_IDS).size).toBe(
+      LIBRARY_CORE_QUERY_IDS.length,
+    );
+  });
+
+  it("keeps every intended query blocked on its unresolved executable contract", () => {
+    for (const definition of Object.values(LIBRARY_CORE_QUERY_REGISTRY)) {
+      if (definition.status !== "planned_blocked") continue;
+
+      expect(definition.requestSchema).toBeNull();
+      expect(definition.responseSchema).toBeNull();
+      expect(definition.projection).toBeNull();
+      expect(definition.sourceIdentity).toBeNull();
+      expect(definition.nestedBounds).toBeNull();
+      expect(definition.stableSort).toBeNull();
+      expect(definition.tieBreakKey).toBeNull();
+      expect(definition.source.currentKinds).toStrictEqual([]);
+      expect(definition.intendedAdapters.length).toBeGreaterThan(0);
+      expect(definition.blockers.length).toBeGreaterThan(0);
+      expect(definition.blockers).toContain("runtime_adapter_unimplemented");
+      expect("supportedAdapters" in definition).toBe(false);
+
+      expect(definition.defaultLimit).toBeGreaterThan(0);
+      expect(definition.defaultLimit).toBeLessThanOrEqual(
+        definition.maximumLimit,
+      );
+      expect(definition.maximumLimit).toBeLessThanOrEqual(
+        definition.maximumRows,
+      );
+      expect(definition.maximumResponseBytes).toBeGreaterThan(0);
+      expect(definition.cancellation.required).toBe(true);
+      expect(definition.cancellation.identitySchema).toBeNull();
+    }
+  });
+
+  it("uses shared renderer and interactive snapshot pools instead of additive query reservations", () => {
+    expect(LIBRARY_CORE_RENDERER_CACHE_POOL).toMatchObject({
+      settledMaximumBytes: 48 * 1_048_576,
+      burstMaximumBytes: 64 * 1_048_576,
+      eviction: "cross_query_lru",
+      perQueryReservations: false,
+    });
+    expect(LIBRARY_CORE_INTERACTIVE_SNAPSHOT_POOL).toMatchObject({
+      maximumAgeMs: 60_000,
+      maximumPinnedBytesAcrossQueries: 16 * 1_048_576,
+      expiryResult: "CURSOR_STALE",
+    });
+
+    for (const definition of Object.values(LIBRARY_CORE_QUERY_REGISTRY)) {
+      if (definition.status !== "planned_blocked") continue;
+      if (definition.rendererCachePool !== null) {
+        expect(definition.rendererCachePool).toBe(
+          LIBRARY_CORE_RENDERER_CACHE_POOL.id,
+        );
+      }
+      expect("rendererCacheBytes" in definition).toBe(false);
+
+      if (definition.cursor.kind === "interactive") {
+        expect(definition.cursor.snapshotPool).toBe(
+          LIBRARY_CORE_INTERACTIVE_SNAPSHOT_POOL.id,
+        );
+      }
+    }
+  });
+
+  it("requires a durable checkpoint for export enumeration", () => {
+    const definition =
+      LIBRARY_CORE_QUERY_REGISTRY.export_enumeration_v1;
+    expect(definition.cursor).toStrictEqual({
+      kind: "durable_checkpoint",
+      version: 1,
+      opaque: true,
+      checkpointSchema: null,
+    });
+    expect(definition.blockers).toContain(
+      "durable_checkpoint_contract_unresolved",
+    );
+  });
+
+  it("keeps every current unbounded request, response, and direct-document read blocked", () => {
+    const currentKinds = new Set<string>();
+    for (const definition of Object.values(LIBRARY_CORE_QUERY_REGISTRY)) {
+      if (definition.status !== "legacy_unbounded") continue;
+      expect(definition.activationBlocker).toBeTruthy();
+      expect(definition.consumers.length).toBeGreaterThan(0);
+      definition.source.currentKinds.forEach((kind) => currentKinds.add(kind));
+    }
+
+    for (const kind of [
+      "ALL_ITEM_IDS",
+      "BROADCAST_REQUEST",
+      "COMPARE_DOC",
+      "DOC_BINARY",
+      "DOC_HEADS",
+      "DOC_RELATIONSHIP",
+      "FEEDS_PATCH",
+      "GET_ALL_ITEM_IDS",
+      "GET_DOC_BINARY",
+      "GET_HEADS",
+      "GET_ITEM_LEGACY_HTML",
+      "GET_ITEM_PRESERVED_TEXT",
+      "GET_SAVED_YOUTUBE_URLS",
+      "ITEM_LEGACY_HTML",
+      "ITEM_PATCH",
+      "ITEM_PRESERVED_TEXT",
+      "PREFERENCES_PATCH",
+      "SAVED_YOUTUBE_URLS",
+      "STATE_UPDATE",
+    ]) {
+      expect(currentKinds.has(kind), kind).toBe(true);
+    }
+  });
+});
+
+describe("BaseAppState surface registry", () => {
+  it("maps every deprecated Friend surface to its canonical Person successor", () => {
+    expect(BASE_APP_STORE_SURFACE_REGISTRY.friends.deprecatedAliasFor).toBe(
+      "persons",
+    );
+    expect(
+      BASE_APP_STORE_SURFACE_REGISTRY.selectedFriendId.deprecatedAliasFor,
+    ).toBe("selectedPersonId");
+    expect(BASE_APP_STORE_SURFACE_REGISTRY.addFriend.deprecatedAliasFor).toBe(
+      "addPerson",
+    );
+    expect(BASE_APP_STORE_SURFACE_REGISTRY.addFriends.deprecatedAliasFor).toBe(
+      "addPersons",
+    );
+    expect(
+      BASE_APP_STORE_SURFACE_REGISTRY.updateFriend.deprecatedAliasFor,
+    ).toBe("updatePerson");
+    expect(
+      BASE_APP_STORE_SURFACE_REGISTRY.removeFriend.deprecatedAliasFor,
+    ).toBe("removePerson");
+    expect(
+      BASE_APP_STORE_SURFACE_REGISTRY.setSelectedFriend.deprecatedAliasFor,
+    ).toBe("setSelectedPerson");
+  });
+
+  it("marks current full-corpus renderer state and generic authority methods as blockers", () => {
+    for (const key of [
+      "items",
+      "feeds",
+      "persons",
+      "accounts",
+      "preferences",
+      "friends",
+    ] as const) {
+      expect(BASE_APP_STORE_SURFACE_REGISTRY[key].classification).toBe(
+        "legacy_unbounded",
+      );
+      expect(BASE_APP_STORE_SURFACE_REGISTRY[key].activationBlocker).toBeTruthy();
+    }
+    expect(BASE_APP_STORE_SURFACE_REGISTRY.initialize).toMatchObject({
+      classification: "legacy_unbounded",
+      activationBlocker: expect.stringContaining("complete legacy document"),
+    });
+
+    for (const key of [
+      "toggleArchived",
+      "toggleLiked",
+      "toggleSaved",
+      "updateAccount",
+      "updateItem",
+      "updatePerson",
+      "updatePreferences",
+    ] as const) {
+      expect(BASE_APP_STORE_SURFACE_REGISTRY[key].classification).toBe(
+        "legacy_compatibility",
+      );
+      expect(BASE_APP_STORE_SURFACE_REGISTRY[key].activationBlocker).toBeTruthy();
+    }
+  });
+
+  it("never leaves a legacy classification without a concrete activation blocker", () => {
+    for (const definition of Object.values(
+      BASE_APP_STORE_SURFACE_REGISTRY,
+    )) {
+      if (
+        definition.classification === "legacy_compatibility" ||
+        definition.classification === "legacy_unbounded"
+      ) {
+        expect(definition.activationBlocker).toBeTruthy();
+      }
+    }
+  });
+
+  it("keeps store successors and operation candidate surfaces bidirectional", () => {
+    const storeRegistry: Record<
+      string,
+      { readonly successorOperationIds: readonly string[] }
+    > = BASE_APP_STORE_SURFACE_REGISTRY;
+    const operationRegistry: Record<
+      string,
+      { readonly candidateStoreSurfaces: readonly string[] }
+    > = LIBRARY_CORE_OPERATION_REGISTRY;
+
+    for (const [surfaceKey, definition] of Object.entries(storeRegistry)) {
+      for (const operationId of definition.successorOperationIds) {
+        expect(
+          operationRegistry[operationId]?.candidateStoreSurfaces,
+          `${surfaceKey} -> ${operationId}`,
+        ).toContain(surfaceKey);
+      }
+    }
+
+    for (const [operationId, definition] of Object.entries(
+      operationRegistry,
+    )) {
+      for (const surfaceKey of definition.candidateStoreSurfaces) {
+        expect(
+          storeRegistry[surfaceKey]?.successorOperationIds,
+          `${operationId} -> ${surfaceKey}`,
+        ).toContain(operationId);
+      }
+    }
+
+    expect(
+      BASE_APP_STORE_SURFACE_REGISTRY.toggleLiked.successorOperationIds,
+    ).toStrictEqual(["feed_item_like_assignment", "provider_intent"]);
+    expect(
+      BASE_APP_STORE_SURFACE_REGISTRY.addItems.successorOperationIds,
+    ).toStrictEqual([
+      "feed_item_capture_upsert",
+      "feed_items_deduplicate_frozen",
+    ]);
+    expect(
+      BASE_APP_STORE_SURFACE_REGISTRY.updateFriend.successorOperationIds,
+    ).toStrictEqual(["account_remove", "account_upsert", "person_upsert"]);
+    expect(
+      BASE_APP_STORE_SURFACE_REGISTRY.updateAccount.successorOperationIds,
+    ).toStrictEqual(["account_person_assignment", "account_upsert"]);
+  });
+});

--- a/packages/shared/src/library-core/store-surface-registry.ts
+++ b/packages/shared/src/library-core/store-surface-registry.ts
@@ -1,0 +1,344 @@
+import type { BaseAppState } from "../store-types.js";
+import type {
+  BaseAppFunctionKey,
+  LibraryCoreOperationId,
+} from "./operation-registry.js";
+import type { LibraryCoreQueryId } from "./query-registry.js";
+
+export type BaseAppValueKey = Exclude<keyof BaseAppState, BaseAppFunctionKey>;
+
+export type StoreSurfaceClassification =
+  | "derived"
+  | "legacy_compatibility"
+  | "legacy_unbounded"
+  | "lifecycle"
+  | "ui_local";
+
+interface StoreSurfaceDefinition {
+  readonly surfaceKind: "function" | "state";
+  readonly classification: StoreSurfaceClassification;
+  readonly successorOperationIds: readonly LibraryCoreOperationId[];
+  readonly successorQueryIds: readonly LibraryCoreQueryId[];
+  readonly activationBlocker: string | null;
+  readonly deprecatedAliasFor?: keyof BaseAppState;
+}
+
+type StoreSurfaceRegistry = {
+  readonly [Key in keyof BaseAppState]-?: NonNullable<BaseAppState[Key]> extends (
+    ...args: never[]
+  ) => unknown
+    ? StoreSurfaceDefinition & { readonly surfaceKind: "function" }
+    : StoreSurfaceDefinition & { readonly surfaceKind: "state" };
+};
+
+const functionSurface = (
+  classification: StoreSurfaceClassification,
+  options: Omit<
+    StoreSurfaceDefinition,
+    "classification" | "surfaceKind"
+  > = {
+    successorOperationIds: [],
+    successorQueryIds: [],
+    activationBlocker: null,
+  },
+): StoreSurfaceDefinition & { readonly surfaceKind: "function" } => ({
+  surfaceKind: "function",
+  classification,
+  ...options,
+});
+
+const stateSurface = (
+  classification: StoreSurfaceClassification,
+  options: Omit<
+    StoreSurfaceDefinition,
+    "classification" | "surfaceKind"
+  > = {
+    successorOperationIds: [],
+    successorQueryIds: [],
+    activationBlocker: null,
+  },
+): StoreSurfaceDefinition & { readonly surfaceKind: "state" } => ({
+  surfaceKind: "state",
+  classification,
+  ...options,
+});
+
+/**
+ * Exhaustive inventory of the current shared Zustand contract.
+ *
+ * `satisfies StoreSurfaceRegistry` makes a new BaseAppState key fail typecheck
+ * until it is classified. Every persisted mutation remains legacy until its
+ * blocked successor operation has a closed payload, field algebra, materializer,
+ * and activation receipt.
+ */
+export const BASE_APP_STORE_SURFACE_REGISTRY = {
+  accounts: stateSurface("legacy_unbounded", {
+    successorOperationIds: [],
+    successorQueryIds: ["account_detail_v1", "persons_graph_v1"],
+    activationBlocker: "complete account record is retained in renderer state",
+  }),
+  activeFilter: stateSurface("ui_local"),
+  activeView: stateSurface("ui_local"),
+  addAccount: functionSurface("legacy_compatibility", {
+    successorOperationIds: ["account_upsert"],
+    successorQueryIds: [],
+    activationBlocker: "current method writes legacy Automerge and its successor payload is unresolved",
+  }),
+  addAccounts: functionSurface("legacy_unbounded", {
+    successorOperationIds: ["account_upsert"],
+    successorQueryIds: [],
+    activationBlocker: "caller-supplied account array has no hard member bound",
+  }),
+  addFeed: functionSurface("legacy_compatibility", {
+    successorOperationIds: ["rss_feed_upsert"],
+    successorQueryIds: [],
+    activationBlocker: "current method writes legacy Automerge and its successor payload is unresolved",
+  }),
+  addFriend: functionSurface("legacy_compatibility", {
+    successorOperationIds: ["account_upsert", "person_upsert"],
+    successorQueryIds: [],
+    activationBlocker: "deprecated Friend write aliases Person without an explicit migration boundary",
+    deprecatedAliasFor: "addPerson",
+  }),
+  addFriends: functionSurface("legacy_compatibility", {
+    successorOperationIds: ["account_upsert", "person_upsert"],
+    successorQueryIds: [],
+    activationBlocker: "deprecated Friend batch is unbounded and aliases Person",
+    deprecatedAliasFor: "addPersons",
+  }),
+  addItems: functionSurface("legacy_unbounded", {
+    successorOperationIds: [
+      "feed_item_capture_upsert",
+      "feed_items_deduplicate_frozen",
+    ],
+    successorQueryIds: [],
+    activationBlocker: "caller-supplied capture array has no hard member or byte bound, provider, import, and user-capture authority are not separated, and the conditional legacy duplicate-removal contract is frozen",
+  }),
+  addPerson: functionSurface("legacy_compatibility", {
+    successorOperationIds: ["person_upsert"],
+    successorQueryIds: [],
+    activationBlocker: "current method writes legacy Automerge and its successor payload is unresolved",
+  }),
+  addPersons: functionSurface("legacy_unbounded", {
+    successorOperationIds: ["person_upsert"],
+    successorQueryIds: [],
+    activationBlocker: "caller-supplied person array has no hard member bound",
+  }),
+  addSampleLibraryData: functionSurface("legacy_unbounded", {
+    successorOperationIds: ["sample_library_import"],
+    successorQueryIds: [],
+    activationBlocker: "multi-root sample payload has no hard member or byte bound",
+  }),
+  archiveAllReadUnsaved: functionSurface("legacy_unbounded", {
+    successorOperationIds: ["feed_items_archive_read_unsaved_frozen"],
+    successorQueryIds: [],
+    activationBlocker: "current implementation scans a mutable full document instead of frozen membership",
+  }),
+  archiveItems: functionSurface("legacy_unbounded", {
+    successorOperationIds: ["feed_items_archive_frozen"],
+    successorQueryIds: [],
+    activationBlocker: "caller enumerates an unbounded item-id set",
+  }),
+  archivableCountByPlatform: stateSurface("derived"),
+  archivableFeedCounts: stateSurface("derived"),
+  clearSampleData: functionSurface("legacy_unbounded", {
+    successorOperationIds: ["sample_library_remove"],
+    successorQueryIds: [],
+    activationBlocker: "current implementation scans every synchronized root",
+  }),
+  createConnectionPersonFromAccounts: functionSurface("legacy_unbounded", {
+    successorOperationIds: ["account_person_assignment", "person_upsert"],
+    successorQueryIds: [],
+    activationBlocker: "caller-supplied account-id set has no hard member bound",
+  }),
+  createConnectionPersonsFromCandidates: functionSurface("legacy_unbounded", {
+    successorOperationIds: ["account_person_assignment", "person_upsert"],
+    successorQueryIds: [],
+    activationBlocker: "candidate and nested account-id arrays have no hard member bound",
+  }),
+  deleteAllArchived: functionSurface("legacy_unbounded", {
+    successorOperationIds: ["feed_items_delete_archived_frozen"],
+    successorQueryIds: [],
+    activationBlocker: "current implementation scans mutable corpus membership",
+  }),
+  error: stateSurface("lifecycle"),
+  feedTotalCounts: stateSurface("derived"),
+  feedUnreadCounts: stateSurface("derived"),
+  feeds: stateSurface("legacy_unbounded", {
+    successorOperationIds: [],
+    successorQueryIds: ["feed_subscription_page_v1"],
+    activationBlocker: "complete RSS subscription map is retained in renderer state",
+  }),
+  friends: stateSurface("legacy_unbounded", {
+    successorOperationIds: [],
+    successorQueryIds: ["persons_graph_v1"],
+    activationBlocker: "deprecated Friend projection duplicates the complete Person and Account corpora in renderer state",
+    deprecatedAliasFor: "persons",
+  }),
+  initialize: functionSurface("legacy_unbounded", {
+    successorOperationIds: [],
+    successorQueryIds: [],
+    activationBlocker: "initialization decodes and hydrates the complete legacy document before bounded Library Core queries exist",
+  }),
+  isInitialized: stateSurface("lifecycle"),
+  isLoading: stateSurface("lifecycle"),
+  isSyncing: stateSurface("lifecycle"),
+  itemCountByPlatform: stateSurface("derived"),
+  items: stateSurface("legacy_unbounded", {
+    successorOperationIds: [],
+    successorQueryIds: ["feed_page_v1", "item_detail_v1"],
+    activationBlocker: "ranked feed array retains a corpus-sized renderer projection",
+  }),
+  linkAccountToPerson: functionSurface("legacy_compatibility", {
+    successorOperationIds: ["account_person_assignment"],
+    successorQueryIds: [],
+    activationBlocker: "current method writes legacy Automerge and its successor payload is unresolved",
+  }),
+  logReachOut: functionSurface("legacy_compatibility", {
+    successorOperationIds: ["person_reach_out_append"],
+    successorQueryIds: [],
+    activationBlocker: "legacy ReachOutLog has no closed stable-element payload yet",
+  }),
+  mapAllContentLocationCount: stateSurface("derived"),
+  mapFriendLocationCount: stateSurface("derived"),
+  markAllAsRead: functionSurface("legacy_unbounded", {
+    successorOperationIds: ["feed_items_read_frozen", "provider_intent"],
+    successorQueryIds: [],
+    activationBlocker: "current implementation resolves mutable corpus membership and derives provider seen actions from ordinary read state",
+  }),
+  markAsRead: functionSurface("legacy_compatibility", {
+    successorOperationIds: ["feed_item_read_assignment", "provider_intent"],
+    successorQueryIds: [],
+    activationBlocker: "current method writes legacy Automerge and derives a provider seen action from ordinary read state",
+  }),
+  markItemsAsRead: functionSurface("legacy_unbounded", {
+    successorOperationIds: ["feed_items_read_frozen", "provider_intent"],
+    successorQueryIds: [],
+    activationBlocker: "caller enumerates an unbounded item-id set and derives provider seen actions from ordinary read state",
+  }),
+  openMapForPerson: functionSurface("ui_local"),
+  pendingMatchCount: stateSurface("derived"),
+  persons: stateSurface("legacy_unbounded", {
+    successorOperationIds: [],
+    successorQueryIds: ["person_detail_v1", "persons_graph_v1"],
+    activationBlocker: "complete Person map is retained in renderer state",
+  }),
+  preferences: stateSurface("legacy_unbounded", {
+    successorOperationIds: [],
+    successorQueryIds: ["preferences_snapshot_v1"],
+    activationBlocker: "complete preferences include dynamic maps without closed nested bounds",
+  }),
+  removeAccount: functionSurface("legacy_compatibility", {
+    successorOperationIds: ["account_remove"],
+    successorQueryIds: [],
+    activationBlocker: "current method physically deletes from legacy Automerge without a tombstone receipt",
+  }),
+  removeAllFeeds: functionSurface("legacy_unbounded", {
+    successorOperationIds: ["rss_feeds_remove_keep_items", "rss_feeds_remove_with_items"],
+    successorQueryIds: [],
+    activationBlocker: "boolean parameter conceals a corpus-wide cascade",
+  }),
+  removeFeed: functionSurface("legacy_compatibility", {
+    successorOperationIds: ["rss_feed_remove_keep_items", "rss_feed_remove_with_items"],
+    successorQueryIds: [],
+    activationBlocker: "includeItems boolean conceals a relationship cascade",
+  }),
+  removeFriend: functionSurface("legacy_compatibility", {
+    successorOperationIds: ["person_remove_and_accounts", "person_remove_detach_accounts"],
+    successorQueryIds: [],
+    activationBlocker: "deprecated alias inherits an implicit account-deletion cascade",
+    deprecatedAliasFor: "removePerson",
+  }),
+  removeItem: functionSurface("legacy_compatibility", {
+    successorOperationIds: ["feed_item_remove"],
+    successorQueryIds: [],
+    activationBlocker: "current method physically deletes from legacy Automerge without a tombstone receipt",
+  }),
+  removePerson: functionSurface("legacy_compatibility", {
+    successorOperationIds: ["person_remove_and_accounts", "person_remove_detach_accounts"],
+    successorQueryIds: [],
+    activationBlocker: "current removePerson always deletes linked accounts instead of naming the cascade",
+  }),
+  renameFeed: functionSurface("legacy_compatibility", {
+    successorOperationIds: ["rss_feed_title_assignment"],
+    successorQueryIds: [],
+    activationBlocker: "current method writes legacy Automerge and its successor payload is unresolved",
+  }),
+  searchCorpusVersion: stateSurface("derived"),
+  searchQuery: stateSurface("ui_local"),
+  selectedAccountId: stateSurface("ui_local"),
+  selectedFriendId: stateSurface("legacy_compatibility", {
+    successorOperationIds: [],
+    successorQueryIds: [],
+    activationBlocker: "deprecated selection alias duplicates selectedPersonId",
+    deprecatedAliasFor: "selectedPersonId",
+  }),
+  selectedItemId: stateSurface("ui_local"),
+  selectedPersonId: stateSurface("ui_local"),
+  setActiveView: functionSurface("ui_local"),
+  setError: functionSurface("lifecycle"),
+  setFilter: functionSurface("ui_local"),
+  setLoading: functionSurface("lifecycle"),
+  setPendingMatchCount: functionSurface("ui_local"),
+  setSearchQuery: functionSurface("ui_local"),
+  setSelectedAccount: functionSurface("ui_local"),
+  setSelectedFriend: functionSurface("legacy_compatibility", {
+    successorOperationIds: [],
+    successorQueryIds: [],
+    activationBlocker: "deprecated UI alias duplicates setSelectedPerson",
+    deprecatedAliasFor: "setSelectedPerson",
+  }),
+  setSelectedItem: functionSurface("ui_local"),
+  setSelectedPerson: functionSurface("ui_local"),
+  setSyncing: functionSurface("lifecycle"),
+  toggleArchived: functionSurface("legacy_compatibility", {
+    successorOperationIds: ["feed_item_archive_assignment"],
+    successorQueryIds: [],
+    activationBlocker: "toggle is not a replay-idempotent authority command",
+  }),
+  toggleLiked: functionSurface("legacy_compatibility", {
+    successorOperationIds: ["feed_item_like_assignment", "provider_intent"],
+    successorQueryIds: [],
+    activationBlocker: "toggle is not replay-idempotent and current item state directly feeds the provider outbox",
+  }),
+  toggleSaved: functionSurface("legacy_compatibility", {
+    successorOperationIds: ["feed_item_saved_assignment"],
+    successorQueryIds: [],
+    activationBlocker: "toggle is not a replay-idempotent authority command",
+  }),
+  totalArchivableCount: stateSurface("derived"),
+  totalItemCount: stateSurface("derived"),
+  totalUnreadCount: stateSurface("derived"),
+  unarchiveSavedItems: functionSurface("legacy_unbounded", {
+    successorOperationIds: ["feed_items_unarchive_saved_frozen"],
+    successorQueryIds: [],
+    activationBlocker: "current repair scans mutable corpus membership",
+  }),
+  unreadCountByPlatform: stateSurface("derived"),
+  updateAccount: functionSurface("legacy_compatibility", {
+    successorOperationIds: ["account_person_assignment", "account_upsert"],
+    successorQueryIds: [],
+    activationBlocker: "generic Partial<Account> merge has no closed authoritative payload",
+  }),
+  updateFriend: functionSurface("legacy_compatibility", {
+    successorOperationIds: ["account_remove", "account_upsert", "person_upsert"],
+    successorQueryIds: [],
+    activationBlocker: "deprecated Friend replacement deletes every linked Account, then re-adds caller-supplied Accounts without a closed bounded replacement transaction",
+    deprecatedAliasFor: "updatePerson",
+  }),
+  updateItem: functionSurface("legacy_compatibility", {
+    successorOperationIds: ["feed_item_capture_upsert"],
+    successorQueryIds: [],
+    activationBlocker: "generic Partial<FeedItem> merge has no closed authoritative payload or separated capture-source authority",
+  }),
+  updatePerson: functionSurface("legacy_compatibility", {
+    successorOperationIds: ["person_upsert"],
+    successorQueryIds: [],
+    activationBlocker: "generic Partial<Person> merge has no closed authoritative payload",
+  }),
+  updatePreferences: functionSurface("legacy_compatibility", {
+    successorOperationIds: ["preferences_leaf_assignment"],
+    successorQueryIds: [],
+    activationBlocker: "generic nested merge cannot distinguish omission from clear or deletion",
+  }),
+} as const satisfies StoreSurfaceRegistry;

--- a/packages/shared/src/locality-contract.test.ts
+++ b/packages/shared/src/locality-contract.test.ts
@@ -39,8 +39,8 @@ describe("locality and deletion contract", () => {
     // edited, so it gains nothing from merge semantics.
     expect(tierOf(FEED_ITEM_WRITE_POLICY.content)).toBe("blob");
     expect(tierOf(FEED_ITEM_WRITE_POLICY.preservedContent)).toBe("blob");
-    expect(deleteBehaviorOf(FEED_ITEM_WRITE_POLICY.content)).toBe("cascade");
-    expect(deleteBehaviorOf(FEED_ITEM_WRITE_POLICY.preservedContent)).toBe("cascade");
+    expect(deleteBehaviorOf(FEED_ITEM_WRITE_POLICY.content)).toBe("orphan");
+    expect(deleteBehaviorOf(FEED_ITEM_WRITE_POLICY.preservedContent)).toBe("orphan");
   });
 
   it("keeps userState hot, because filtering and counts read it on every query", () => {

--- a/packages/shared/src/schema.ts
+++ b/packages/shared/src/schema.ts
@@ -146,7 +146,8 @@ export function createDocFromTrustedCompatibilityData(
   ) as unknown as FreedDoc;
 }
 
-const DESKTOP_CLIENT_KEY_PREFIX = "desktopClient:";
+export const DESKTOP_CLIENT_KEY_PREFIX = "desktopClient:" as const;
+export type DesktopClientKeyPrefix = typeof DESKTOP_CLIENT_KEY_PREFIX;
 const LEGACY_MIGRATED_ROOT_KEYS = new Set(["friends"]);
 
 // Registrations use namespaced root keys at runtime so concurrent clients add
@@ -239,7 +240,7 @@ export function getRegisteredDesktopClientIds(doc: FreedDoc): string[] {
   return getRegisteredDesktopClients(doc).map((registration) => registration.id);
 }
 
-interface LegacyFriend {
+export interface LegacyFriend {
   id: string;
   name: string;
   avatarUrl?: string;

--- a/packages/shared/src/sync-write-policy.ts
+++ b/packages/shared/src/sync-write-policy.ts
@@ -481,19 +481,20 @@ export const FEED_ITEM_WRITE_POLICY = {
   publishedAt: "sync",
   author: "nested",
   // Measured: 52.1% of the serialized corpus. Immutable once captured and never
-  // concurrently edited, so it gains nothing from merge semantics. Cascades on
-  // delete because the bytes are addressed by the item and reachable from
-  // nothing else.
-  content: { disposition: "nested", tier: "blob", delete: "cascade" },
+  // concurrently edited, so it gains nothing from merge semantics. The future
+  // blob store is content-addressed, so equal bytes may be shared by more than
+  // one item. Deleting one row therefore leaves the blob orphaned until a
+  // verified reachability pass proves that physical collection is safe.
+  content: { disposition: "nested", tier: "blob", delete: "orphan" },
   engagement: "nested",
   location: "nested",
   timeRange: "nested",
   rssSource: "nested",
   fbGroup: "nested",
   // Measured: a further 22.9%, present on 6,778 of 15,846 items, and its text
-  // does not overlap content.text — these are two independent bodies of prose,
-  // not a duplicate. Same reasoning as content.
-  preservedContent: { disposition: "nested", tier: "blob", delete: "cascade" },
+  // does not overlap content.text. These are two independent bodies of prose,
+  // not a duplicate. Same reachability-verified collection rule as content.
+  preservedContent: { disposition: "nested", tier: "blob", delete: "orphan" },
   // Read, saved, archived, tags. Small, edited from any device, and read on
   // every feed query for filtering and counts, so it stays hot and resident
   // even after the prose moves out.

--- a/scripts/validate-worktree.mjs
+++ b/scripts/validate-worktree.mjs
@@ -817,6 +817,7 @@ export function buildValidationPlan(mode, changedFiles) {
       npmCommand("root typecheck", ["run", "typecheck"]),
       npmCommand("root lint", ["run", "lint"]),
       npmCommand("website tests", ["run", "test"], "website"),
+      npmCommand("shared unit tests", ["run", "test"], "packages/shared"),
       ...pwaTestCommands(),
       npmCommand(
         "desktop unit tests",
@@ -924,6 +925,9 @@ export function buildValidationPlan(mode, changedFiles) {
   }
 
   const plan = [npmCommand("root typecheck", ["run", "typecheck"])];
+  const sharedPackageChanged = changedFiles.some((filePath) =>
+    filePath.startsWith("packages/shared/"),
+  );
   const sharedSurfaceChanged = changedFiles.some(isSharedSurface);
   const desktopSurfaceChanged =
     sharedSurfaceChanged || changedFiles.some(isDesktopSurface);
@@ -1024,6 +1028,13 @@ export function buildValidationPlan(mode, changedFiles) {
       npmCommand("website production build", ["run", "build"], "website"),
     );
     addCommand(plan, npmCommand("website tests", ["run", "test"], "website"));
+  }
+
+  if (sharedPackageChanged) {
+    addCommand(
+      plan,
+      npmCommand("shared unit tests", ["run", "test"], "packages/shared"),
+    );
   }
 
   if (pwaSurfaceChanged) {

--- a/scripts/validate-worktree.test.mjs
+++ b/scripts/validate-worktree.test.mjs
@@ -64,6 +64,7 @@ test("feature plan for shared changes covers both desktop and pwa surfaces", () 
     "root typecheck",
     "desktop social provider unit tests",
     "desktop social provider e2e",
+    "shared unit tests",
     "pwa production build",
     "pwa typecheck",
     "pwa unit tests",
@@ -567,6 +568,7 @@ test("dev plan runs desktop smoke, regression, perf, and visual lanes", () => {
   assert.ok(labels.includes("desktop e2e perf"));
   assert.ok(labels.includes("desktop e2e visual"));
   assert.ok(labels.includes("pwa performance tests"));
+  assert.ok(labels.includes("shared unit tests"));
   assert.ok(labels.includes("native rust clippy"));
   assert.ok(labels.includes("native rust tests"));
   assert.ok(!labels.includes("desktop e2e full"));


### PR DESCRIPTION
(AI Generated).

## Summary
- Inventory 281 synchronized fields across nine roots with compiler-enforced drift detection.
- Map planned operations, bounded queries, Desktop and PWA worker effects, and retained local authority without activating a new writer.
- Keep every successor blocked, preserve Automerge authority, and classify hidden payload, broadcast, runtime-state, and deduplication effects explicitly.

## Testing
- npm run validate:feature
- Shared Library Core registry: 13 passed
- Desktop worker surface registry: 6 passed
- PWA worker surface registry: 6 passed
- node scripts/validate-main-backflow.mjs --dev-ref=origin/dev --main-ref=origin/main

## Provider Review
- Status: Provider authority is validated for ready publication.
- Review action: none required. The provider-risk artifact records the behavior authority decision; this exact provider subdiff is the audit subject.
- Provider subdiff: `246c74a9e5232e9beaa3fa71dab686a9c8f8b6dd`
- Publication does not authorize new live provider traffic. Gate 1 behavior approval still applies when observable behavior changes.
- Provider review task: `library-core-gate-a-census`
- Provider review decision: `diff_authorized`
- Provider review artifact: `cefdb16c0a4a9bc301c84222181375a22f6b09d1bc2e9a0bfaf3db29255502d1`
- Providers: facebook, instagram, linkedin, medium, other, substack, x, youtube
- Observable behavior: No provider-observable behavior changes. The classified diff exports existing schema metadata and corrects a dormant future blob-deletion declaration. It changes no provider requests, navigation, extraction, cookies, headers, timing, retries, media loads, login flow, or background cadence.
- Fingerprinting risk: None introduced. Providers receive the same requests and browser behavior as before.
- Lowest profile alternative: Keep provider traffic disabled while validating the dormant census offline.

Files bound into this provider review:
- `packages/shared/src/schema.ts`
- `packages/shared/src/sync-write-policy.ts`