### PR TITLE
fix: verify release ancestry against GitHub graph

### DIFF
--- a/scripts/lib/github-release-publications.mjs
+++ b/scripts/lib/github-release-publications.mjs
@@ -5,6 +5,9 @@ import { existsSync } from "node:fs";
 export const GITHUB_RELEASE_PAGE_SIZE = 100;
 export const MAX_GITHUB_RELEASE_PAGES = 50;
 export const GITHUB_RELEASE_PAGE_MAX_BYTES = 16 * 1024 * 1024;
+export const GITHUB_COMPARE_MAX_BYTES = 16 * 1024 * 1024;
+
+const FULL_COMMIT_SHA_PATTERN = /^[0-9a-f]{40,64}$/;
 
 function githubBinary(environment) {
   const candidates = [
@@ -65,6 +68,85 @@ function requestFailure(result) {
     result.stderr?.trim() ||
     result.error?.message ||
     (result.signal ? `terminated by ${result.signal}` : "curl failed")
+  );
+}
+
+export function readGithubCommitAncestry({
+  repository = "freed-project/freed",
+  fromRef,
+  toRef,
+  environment = process.env,
+  execFile = execFileSync,
+  spawn = spawnSync,
+  curlBinary = "/usr/bin/curl",
+} = {}) {
+  const fromSha = String(fromRef ?? "").trim();
+  const toSha = String(toRef ?? "").trim();
+  if (
+    !FULL_COMMIT_SHA_PATTERN.test(fromSha) ||
+    !FULL_COMMIT_SHA_PATTERN.test(toSha)
+  ) {
+    throw new Error(
+      "Authenticated GitHub ancestry reads require two full commit SHAs.",
+    );
+  }
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repository)) {
+    throw new Error("Authenticated GitHub ancestry reads require owner/repo.");
+  }
+
+  const token = resolveGithubReadToken({ environment, execFile });
+  const result = spawn(
+    curlBinary,
+    [
+      "--disable",
+      "--fail",
+      "--silent",
+      "--show-error",
+      "--proto",
+      "=https",
+      "--tlsv1.2",
+      "--config",
+      "-",
+      "--connect-timeout",
+      "10",
+      "--max-time",
+      "30",
+      "--retry",
+      "2",
+      "--retry-all-errors",
+      "--header",
+      "Accept: application/vnd.github+json",
+      "--header",
+      "X-GitHub-Api-Version: 2022-11-28",
+      `https://api.github.com/repos/${repository}/compare/${fromSha}...${toSha}`,
+    ],
+    {
+      encoding: "utf8",
+      input: `header = "Authorization: Bearer ${token}"\n`,
+      timeout: 35_000,
+      maxBuffer: GITHUB_COMPARE_MAX_BYTES,
+    },
+  );
+  if (result.status !== 0) {
+    throw new Error(
+      `Could not read canonical GitHub commit ancestry: ${requestFailure(result)}.`,
+    );
+  }
+
+  let comparison;
+  try {
+    comparison = JSON.parse(result.stdout);
+  } catch {
+    throw new Error("Canonical GitHub commit comparison is invalid JSON.");
+  }
+
+  if (comparison?.status === "identical") {
+    return fromSha === toSha;
+  }
+  return (
+    comparison?.status === "ahead" &&
+    comparison?.behind_by === 0 &&
+    comparison?.merge_base_commit?.sha === fromSha
   );
 }
 

--- a/scripts/lib/github-release-publications.test.mjs
+++ b/scripts/lib/github-release-publications.test.mjs
@@ -3,10 +3,15 @@ import test from "node:test";
 
 import { canonicalPreviousPublishedRelease } from "../release-receipt.mjs";
 import {
+  GITHUB_COMPARE_MAX_BYTES,
   GITHUB_RELEASE_PAGE_MAX_BYTES,
+  readGithubCommitAncestry,
   readGithubReleasePublications,
   resolveGithubReadToken,
 } from "./github-release-publications.mjs";
+
+const FROM_SHA = "a".repeat(40);
+const TO_SHA = "b".repeat(40);
 
 function release(tag, overrides = {}) {
   return {
@@ -141,4 +146,56 @@ test("GitHub release reads fail closed without authenticated access", () => {
       }),
     /Authenticated GitHub release reads require .*not logged in/,
   );
+});
+
+test("GitHub commit ancestry accepts an exact ahead comparison", () => {
+  let request = null;
+  const isAncestor = readGithubCommitAncestry({
+    repository: "freed-project/freed",
+    fromRef: FROM_SHA,
+    toRef: TO_SHA,
+    environment: { GH_TOKEN: "fixture-token" },
+    spawn: (command, args, options) => {
+      request = { command, args, options };
+      return {
+        status: 0,
+        stdout: JSON.stringify({
+          status: "ahead",
+          ahead_by: 9,
+          behind_by: 0,
+          merge_base_commit: { sha: FROM_SHA },
+        }),
+        stderr: "",
+      };
+    },
+  });
+
+  assert.equal(isAncestor, true);
+  assert.equal(request.command, "/usr/bin/curl");
+  assert.equal(request.options.maxBuffer, GITHUB_COMPARE_MAX_BYTES);
+  assert.equal(request.args.includes("fixture-token"), false);
+  assert.equal(
+    request.options.input,
+    'header = "Authorization: Bearer fixture-token"\n',
+  );
+});
+
+test("GitHub commit ancestry rejects a diverged comparison", () => {
+  const isAncestor = readGithubCommitAncestry({
+    fromRef: FROM_SHA,
+    toRef: TO_SHA,
+    environment: { GH_TOKEN: "fixture-token" },
+    spawn: () => ({
+      status: 0,
+      stdout: JSON.stringify({
+        status: "diverged",
+        ahead_by: 4,
+        behind_by: 2,
+        merge_base_commit: { sha: "c".repeat(40) },
+      }),
+      stderr: "",
+    }),
+  });
+
+  assert.equal(isAncestor, false);
 });

--- a/scripts/validate-release-identity.mjs
+++ b/scripts/validate-release-identity.mjs
@@ -15,7 +15,10 @@ import {
   validatePreviousLibraryCoreActivationContinuity,
 } from "./lib/library-core-release-activation.mjs";
 import { readGitPathAtRef } from "./lib/git-path-at-ref.mjs";
-import { readGithubReleasePublications } from "./lib/github-release-publications.mjs";
+import {
+  readGithubCommitAncestry,
+  readGithubReleasePublications,
+} from "./lib/github-release-publications.mjs";
 import {
   compareTags,
   renderReleaseBody,
@@ -149,6 +152,10 @@ export function gitIsAncestor(
   fromRef,
   toRef,
   spawn = spawnSync,
+  {
+    environment = process.env,
+    remoteIsAncestor = readGithubCommitAncestry,
+  } = {},
 ) {
   const direct = spawn(
     "git",
@@ -175,13 +182,43 @@ export function gitIsAncestor(
     },
   );
   const resolvedFromSha = String(resolvedFrom.stdout ?? "").trim();
-  return (
+  const reachable =
     reachableHistory.status === 0 &&
     resolvedFrom.status === 0 &&
     String(reachableHistory.stdout ?? "")
       .split(/\s+/)
-      .includes(resolvedFromSha)
-  );
+      .includes(resolvedFromSha);
+  if (reachable) {
+    return true;
+  }
+
+  if (
+    environment.GITHUB_ACTIONS !== "true" ||
+    !environment.GITHUB_REPOSITORY
+  ) {
+    return false;
+  }
+  const origin = spawn("git", ["remote", "get-url", "origin"], {
+    cwd,
+    encoding: "utf8",
+  });
+  const repository = environment.GITHUB_REPOSITORY;
+  const originUrl = String(origin.stdout ?? "").trim();
+  const expectedOrigins = new Set([
+    `https://github.com/${repository}`,
+    `https://github.com/${repository}.git`,
+    `git@github.com:${repository}`,
+    `git@github.com:${repository}.git`,
+  ]);
+  if (origin.status !== 0 || !expectedOrigins.has(originUrl)) {
+    return false;
+  }
+  return remoteIsAncestor({
+    repository,
+    fromRef: resolvedFromSha || fromRef,
+    toRef,
+    environment,
+  });
 }
 
 function expectedLibraryCoreActivationRange({

--- a/scripts/validate-release-identity.test.mjs
+++ b/scripts/validate-release-identity.test.mjs
@@ -43,6 +43,42 @@ test("git ancestry falls back to an exact history walk after a direct probe fail
   assert.equal(gitIsAncestor("/tmp", "abc123", "def456", spawn), true);
 });
 
+test("git ancestry uses the authenticated server graph after CI local probes fail", () => {
+  const fromRef = "a".repeat(40);
+  const toRef = "b".repeat(40);
+  let comparison = null;
+  const spawn = (_command, args) => {
+    if (args[0] === "rev-parse") {
+      return { status: 0, stdout: `${fromRef}\n`, stderr: "" };
+    }
+    if (args[0] === "remote") {
+      return {
+        status: 0,
+        stdout: "https://github.com/freed-project/freed.git\n",
+        stderr: "",
+      };
+    }
+    return { status: 1, stdout: "", stderr: "local graph unavailable" };
+  };
+
+  const isAncestor = gitIsAncestor("/tmp", fromRef, toRef, spawn, {
+    environment: {
+      GITHUB_ACTIONS: "true",
+      GITHUB_REPOSITORY: "freed-project/freed",
+      GH_TOKEN: "fixture-token",
+    },
+    remoteIsAncestor: (request) => {
+      comparison = request;
+      return true;
+    },
+  });
+
+  assert.equal(isAncestor, true);
+  assert.equal(comparison.repository, "freed-project/freed");
+  assert.equal(comparison.fromRef, fromRef);
+  assert.equal(comparison.toRef, toRef);
+});
+
 function git(cwd, args) {
   return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
 }


### PR DESCRIPTION
(AI Generated).

## Summary

- Keep local Git ancestry as the first release-continuity proof.
- When a GitHub Actions checkout reports a false negative, verify the two exact immutable commits against GitHub's authenticated comparison graph.
- Accept only an exact ahead or identical relationship with the expected merge base and zero commits behind.
- Keep local development offline-first and fail closed if either authenticated access or the comparison response is invalid.

## Testing

- `npm run validate:feature`
- Root typecheck
- 68 focused Library Core and release identity tests
- Live exact comparison from `57e62362600063000df18ed19aec50bd845f1035` to `b6df8a9e23f9b2ecb667210d0d2415704d54cfff`
