### PR TITLE
feat: resolve the feed page sort contract on an indexable key

### DIFF
--- a/packages/shared/src/library-core/feed-page-sort-contract.test.ts
+++ b/packages/shared/src/library-core/feed-page-sort-contract.test.ts
@@ -1,0 +1,193 @@
+import { DatabaseSync } from "node:sqlite";
+
+import { describe, expect, it } from "vitest";
+
+import { projectFeedItem } from "../projection.js";
+import {
+  SHADOW_INDEX_DDL,
+  SHADOW_TABLE_DDL,
+  SORT_AT_ABSENT,
+  createShadowSchema,
+  rowToParams,
+  upsertRows,
+} from "../shadow-store.js";
+import type { ShadowDatabase } from "../shadow-store.js";
+import type { FeedItem } from "../types.js";
+import { LIBRARY_CORE_QUERY_REGISTRY } from "./query-registry.js";
+
+/**
+ * The feed_page_v1 ordering, checked against the thing that has to implement it.
+ *
+ * A sort contract is only worth declaring if it stays true, and the two ways it
+ * silently stops being true are drift and fabrication. Drift: the registry says
+ * one order while the store indexes another, and pagination degrades or skips
+ * rows with nothing failing. Fabrication: someone makes the sort column NOT NULL
+ * by writing a sentinel into `publishedAt`, which is the irreversible data loss
+ * the projection exists to prevent. Both are checked here rather than described.
+ */
+
+const definition = LIBRARY_CORE_QUERY_REGISTRY.feed_page_v1;
+
+if (definition.status !== "planned_blocked") {
+  throw new Error("feed_page_v1 must be a planned Library Core query");
+}
+
+const timelineIndexDdl = SHADOW_INDEX_DDL.find((sql) =>
+  sql.includes("feed_items_timeline"),
+);
+
+function openStore(): ShadowDatabase {
+  const db = new DatabaseSync(":memory:") as unknown as ShadowDatabase;
+  createShadowSchema(db);
+  return db;
+}
+
+/**
+ * One in eight items has no `publishedAt` at all. That ratio is arbitrary; what
+ * matters is that undated items exist, stay null, and still paginate.
+ */
+function corpus(count: number): FeedItem[] {
+  const items: FeedItem[] = [];
+  for (let index = 0; index < count; index += 1) {
+    const undated = index % 8 === 3;
+    const item: Record<string, unknown> = {
+      globalId: `x:${String(index).padStart(6, "0")}`,
+      platform: "x",
+      contentType: "post",
+      capturedAt: 1_780_000_000_000,
+      author: { id: "a:1", handle: "someone", displayName: "Someone" },
+      sourceUrl: `https://example.test/${index}`,
+      content: { text: `item ${index}`, mediaUrls: [], mediaTypes: [] },
+      userState: { hidden: false, saved: false, archived: false, tags: [] },
+    };
+    if (!undated) {
+      // Heavy ties on purpose: a scrape assigns many items the same timestamp,
+      // which is exactly when a missing tie-break starts losing rows.
+      item.publishedAt = 1_780_000_000_000 - (index % 32) * 86_400_000;
+    }
+    items.push(item as unknown as FeedItem);
+  }
+  return items;
+}
+
+describe("feed_page_v1 sort contract", () => {
+  it("declares the ordering the shadow store actually indexes", () => {
+    expect(definition.stableSort).not.toBeNull();
+    expect(definition.blockers).not.toContain("sort_contract_unresolved");
+
+    const sort = definition.stableSort!;
+    expect(sort.columns.map((column) => column.column)).toStrictEqual([
+      "sortAt",
+      "globalId",
+    ]);
+    expect(definition.tieBreakKey).toBe("globalId");
+
+    // The index must carry every sort column, in order, in the same direction.
+    // Anything less and SQLite reorders with a temp B-tree, which is the cost
+    // this contract exists to avoid.
+    const expectedIndexColumns = sort.columns
+      .map((column) => `${column.column} ${column.direction.toUpperCase()}`)
+      .join(", ");
+    expect(timelineIndexDdl).toBeDefined();
+    expect(timelineIndexDdl!.replace(/\s+/g, " ")).toContain(
+      `ON feed_items (${expectedIndexColumns})`,
+    );
+  });
+
+  it("orders on a derived column so no timestamp is ever fabricated", () => {
+    // `nullOrdering` claims every sort column is NOT NULL. If that were achieved
+    // by constraining `publishedAt`, absence would have to be written as a
+    // sentinel and could never be reproduced. The declaration is only honest
+    // while the authoritative column stays nullable.
+    expect(definition.stableSort!.nullOrdering).toBe(
+      "all_sort_columns_not_null",
+    );
+    const ddl = SHADOW_TABLE_DDL.replace(/\s+/g, " ");
+    expect(ddl).toContain("sortAt INTEGER NOT NULL");
+    expect(ddl).toContain("publishedAt INTEGER,");
+    expect(ddl).not.toContain("publishedAt INTEGER NOT NULL");
+
+    const undated = projectFeedItem(corpus(4)[3]!);
+    expect(undated.publishedAt).toBeNull();
+    // The sentinel reaches the sort column and nothing else.
+    const params = rowToParams(undated);
+    expect(params[params.length - 1]).toBe(SORT_AT_ABSENT);
+  });
+
+  it("walks every row exactly once through a real keyset page", () => {
+    const db = openStore();
+    const items = corpus(2_000);
+    upsertRows(
+      db,
+      items.map((item) => projectFeedItem(item)),
+    );
+
+    const sql = `
+      SELECT globalId, publishedAt, sortAt FROM feed_items
+      WHERE archived IS NOT 1 AND hidden IS NOT 1
+        AND (sortAt < ? OR (sortAt = ? AND globalId > ?))
+      ORDER BY sortAt DESC, globalId ASC
+      LIMIT ?;
+    `;
+
+    const plan = db
+      .prepare(`EXPLAIN QUERY PLAN ${sql}`)
+      .all(Number.MAX_SAFE_INTEGER, Number.MAX_SAFE_INTEGER, "", 64)
+      .map((row) => (row as { detail: string }).detail)
+      .join(" ");
+    expect(plan).toContain("feed_items_timeline");
+    // The whole point. A temp B-tree here means each page sorts the remaining
+    // set, so the page is bounded but the work behind it is not.
+    expect(plan).not.toContain("TEMP B-TREE");
+
+    const statement = db.prepare(sql);
+    const seen = new Set<string>();
+    let sortAt = Number.MAX_SAFE_INTEGER;
+    let globalId = "";
+    let previous: { sortAt: number; globalId: string } | null = null;
+    let undatedSeen = 0;
+    let pages = 0;
+
+    for (;;) {
+      const rows = statement.all(sortAt, sortAt, globalId, 64) as {
+        globalId: string;
+        publishedAt: number | null;
+        sortAt: number;
+      }[];
+      if (rows.length === 0) break;
+      pages += 1;
+      expect(rows.length).toBeLessThanOrEqual(definition.maximumRows);
+      // A cursor that fails to advance would otherwise spin here forever.
+      expect(pages).toBeLessThanOrEqual(items.length);
+
+      for (const row of rows) {
+        // A repeat means the cursor compared differently from the database.
+        expect(seen.has(row.globalId)).toBe(false);
+        seen.add(row.globalId);
+        if (row.publishedAt === null) {
+          undatedSeen += 1;
+          expect(row.sortAt).toBe(SORT_AT_ABSENT);
+        } else {
+          expect(row.sortAt).toBe(row.publishedAt);
+        }
+        if (previous) {
+          const descends =
+            row.sortAt < previous.sortAt ||
+            (row.sortAt === previous.sortAt &&
+              row.globalId > previous.globalId);
+          expect(descends).toBe(true);
+        }
+        previous = { sortAt: row.sortAt, globalId: row.globalId };
+      }
+
+      const last = rows[rows.length - 1]!;
+      sortAt = last.sortAt;
+      globalId = last.globalId;
+    }
+
+    // No row dropped, no row served twice, and the undated ones survived as
+    // undated rather than being quietly dated to the epoch.
+    expect(seen.size).toBe(items.length);
+    expect(undatedSeen).toBe(250);
+  });
+});

--- a/packages/shared/src/library-core/query-registry.ts
+++ b/packages/shared/src/library-core/query-registry.ts
@@ -126,6 +126,35 @@ interface QuerySourceInventory {
   readonly currentKinds: readonly string[];
 }
 
+export interface ResolvedQuerySortColumn {
+  readonly column: string;
+  readonly direction: "asc" | "desc";
+}
+
+/**
+ * A resolved ordering, stated so an adapter can satisfy it with an index rather
+ * than a sort.
+ *
+ * Every field here exists because getting it wrong is silent. Columns are
+ * columns and never expressions, because a leading expression such as
+ * `publishedAt IS NULL` is not index-satisfiable and quietly turns each keyset
+ * page into a sort of the whole remaining set: the page stays bounded while the
+ * work behind it grows with the corpus. Text comparison is pinned to BINARY
+ * because a cursor that compares differently from the database skips or repeats
+ * rows at the page boundary, and JavaScript's `localeCompare` treats ids that
+ * differ only in case as equal where SQLite does not. The null ordering is
+ * declared rather than assumed so that a later nullable sort column cannot be
+ * added without confronting the first rule.
+ */
+export interface ResolvedQuerySortContract {
+  readonly columns: readonly [
+    ResolvedQuerySortColumn,
+    ...ResolvedQuerySortColumn[],
+  ];
+  readonly textCollation: "binary";
+  readonly nullOrdering: "all_sort_columns_not_null";
+}
+
 export interface PlannedBlockedLibraryCoreQueryDefinition {
   readonly status: "planned_blocked";
   readonly querySchemaVersion: 1;
@@ -138,8 +167,8 @@ export interface PlannedBlockedLibraryCoreQueryDefinition {
   readonly projection: null;
   readonly sourceIdentity: null;
   readonly nestedBounds: null;
-  readonly stableSort: null;
-  readonly tieBreakKey: null;
+  readonly stableSort: ResolvedQuerySortContract | null;
+  readonly tieBreakKey: string | null;
   readonly defaultLimit: number;
   readonly maximumLimit: number;
   readonly maximumRows: number;
@@ -222,11 +251,49 @@ interface PlannedQueryInput {
   readonly invalidationKeyIntent: readonly string[];
   readonly intendedAdapters?: readonly LibraryCoreQueryAdapter[];
   readonly additionalBlockers?: readonly LibraryCoreQueryBlocker[];
+  /**
+   * Supplying both clears `sort_contract_unresolved` for this query. They move
+   * together on purpose: an ordering without a tie-break is not stable, and a
+   * keyset cursor built on an unstable order drops and repeats rows.
+   */
+  readonly stableSort?: ResolvedQuerySortContract;
+  readonly tieBreakKey?: string;
+}
+
+function nonEmptyBlockers(
+  blockers: readonly LibraryCoreQueryBlocker[],
+): NonEmptyQueryBlockers {
+  const [first, ...rest] = blockers;
+  if (!first) {
+    throw new Error("a planned query must declare at least one blocker");
+  }
+  return [first, ...rest];
 }
 
 function plannedQuery(
   input: PlannedQueryInput,
 ): PlannedBlockedLibraryCoreQueryDefinition {
+  const stableSort = input.stableSort ?? null;
+  const tieBreakKey = input.tieBreakKey ?? null;
+
+  if ((stableSort === null) !== (tieBreakKey === null)) {
+    throw new Error(
+      "a resolved sort contract requires both stableSort and tieBreakKey",
+    );
+  }
+  if (stableSort && tieBreakKey) {
+    // The tie-break has to be the final ordering term, not merely present
+    // somewhere in it. If an earlier column followed it, rows sharing every
+    // preceding value would still have no defined order between them and the
+    // cursor would have nothing unique to resume from.
+    const last = stableSort.columns[stableSort.columns.length - 1];
+    if (last?.column !== tieBreakKey) {
+      throw new Error(
+        `tie-break ${tieBreakKey} must be the last sort column, found ${last?.column}`,
+      );
+    }
+  }
+
   return {
     status: "planned_blocked",
     querySchemaVersion: 1,
@@ -239,8 +306,8 @@ function plannedQuery(
     projection: null,
     sourceIdentity: null,
     nestedBounds: null,
-    stableSort: null,
-    tieBreakKey: null,
+    stableSort,
+    tieBreakKey,
     defaultLimit: input.defaultLimit,
     maximumLimit: input.maximumLimit,
     maximumRows: input.maximumRows,
@@ -255,10 +322,13 @@ function plannedQuery(
       : null,
     invalidationKeyIntent: input.invalidationKeyIntent,
     intendedAdapters: input.intendedAdapters ?? ALL_INTENDED_ADAPTERS,
-    blockers: [
-      ...BASE_QUERY_BLOCKERS,
+    blockers: nonEmptyBlockers([
+      ...BASE_QUERY_BLOCKERS.filter(
+        (blocker) =>
+          stableSort === null || blocker !== "sort_contract_unresolved",
+      ),
       ...(input.additionalBlockers ?? []),
-    ],
+    ]),
   };
 }
 
@@ -347,6 +417,20 @@ export const LIBRARY_CORE_QUERY_REGISTRY = {
     totalCountIntent: "snapshot_exact",
     rendererCache: true,
     invalidationKeyIntent: ["feed:{normalized_filter_digest}", "feed-facets"],
+    // Newest first, then by id so the order is total. `sortAt` is the shadow
+    // store's derived sort key rather than `publishedAt`: the authoritative
+    // column stays nullable because absence is data the projection must be able
+    // to reproduce, and ordering by it would need a null-handling expression
+    // that no index can satisfy. See SORT_AT_ABSENT in shadow-store.ts.
+    stableSort: {
+      columns: [
+        { column: "sortAt", direction: "desc" },
+        { column: "globalId", direction: "asc" },
+      ],
+      textCollation: "binary",
+      nullOrdering: "all_sort_columns_not_null",
+    },
+    tieBreakKey: "globalId",
   }),
   feed_subscription_page_v1: plannedQuery({
     defaultLimit: 64,

--- a/packages/shared/src/library-core/registry.test.ts
+++ b/packages/shared/src/library-core/registry.test.ts
@@ -175,8 +175,16 @@ describe("Library Core query registry", () => {
       expect(definition.projection).toBeNull();
       expect(definition.sourceIdentity).toBeNull();
       expect(definition.nestedBounds).toBeNull();
-      expect(definition.stableSort).toBeNull();
-      expect(definition.tieBreakKey).toBeNull();
+      // A contract field and its blocker move together. Asserting the sort is
+      // always null would have forbidden ever resolving one; asserting the
+      // relation catches the failure that actually matters, which is a query
+      // claiming a resolved ordering while still advertising it as unresolved,
+      // or clearing the blocker without stating an ordering at all.
+      const sortBlocked = definition.blockers.includes(
+        "sort_contract_unresolved",
+      );
+      expect(definition.stableSort === null).toBe(sortBlocked);
+      expect(definition.tieBreakKey === null).toBe(sortBlocked);
       expect(definition.source.currentKinds).toStrictEqual([]);
       expect(definition.intendedAdapters.length).toBeGreaterThan(0);
       expect(definition.blockers.length).toBeGreaterThan(0);

--- a/packages/shared/src/shadow-store.test.ts
+++ b/packages/shared/src/shadow-store.test.ts
@@ -6,7 +6,10 @@ import { describe, expect, it } from "vitest";
 import { projectFeedItem, reconstructFeedItem } from "./projection.js";
 import {
   SHADOW_COLUMNS,
+  SHADOW_DERIVED_COLUMNS,
+  SHADOW_TABLE_DDL,
   createShadowSchema,
+  sortKeyOf,
   diffThroughStore,
   readAllRows,
   reconstructAllFromStore,
@@ -127,13 +130,32 @@ describe("shadow store", () => {
 
   it("binds every declared column, in order", () => {
     // Guards the failure mode where a column is added to the table and missed
-    // in the INSERT, which SQLite would accept as a silent NULL.
+    // in the INSERT, which SQLite would accept as a silent NULL. Read the
+    // column list out of the DDL rather than trusting the same constant the
+    // INSERT is built from, so the check is against the table as declared.
+    const declared = SHADOW_TABLE_DDL.slice(
+      SHADOW_TABLE_DDL.indexOf("(") + 1,
+      SHADOW_TABLE_DDL.lastIndexOf(")"),
+    )
+      .split(",")
+      .map((line) => line.trim().split(/\s+/)[0])
+      .filter((name): name is string => Boolean(name));
+    expect(declared).toStrictEqual([
+      ...SHADOW_COLUMNS,
+      ...SHADOW_DERIVED_COLUMNS,
+    ]);
+
     const row = projectFeedItem(item as unknown as FeedItem);
     const params = rowToParams(row);
-    expect(params).toHaveLength(SHADOW_COLUMNS.length);
-    params.forEach((value, index) => {
-      expect(value).toStrictEqual(row[SHADOW_COLUMNS[index]!]);
+    expect(params).toHaveLength(declared.length);
+    // Authoritative columns bind by position; the derived tail is computed and
+    // has no counterpart on the row.
+    SHADOW_COLUMNS.forEach((column, index) => {
+      expect(params[index]).toStrictEqual(row[column]);
     });
+    expect(params.slice(SHADOW_COLUMNS.length)).toStrictEqual([
+      sortKeyOf(row),
+    ]);
   });
 
   it("rejects a value STRICT should not accept", () => {

--- a/packages/shared/src/shadow-store.ts
+++ b/packages/shared/src/shadow-store.ts
@@ -70,9 +70,50 @@ export const SHADOW_COLUMNS = [
 export type ShadowColumn = (typeof SHADOW_COLUMNS)[number];
 
 /**
- * INTEGER for the timestamps and flags, TEXT for everything else. `rest` is the
- * only NOT NULL column besides the key: every other column is legitimately
- * absent on some item, and the projection records that absence inside `rest`.
+ * Derived columns exist only so the query planner can order without sorting.
+ * They are written, never read back, and never reconstructed, which is why they
+ * are deliberately absent from `SHADOW_COLUMNS` and from `FeedItemRow`: the
+ * round-trip differ compares authoritative data, and a derived value has
+ * nothing to say about whether the projection lost anything.
+ */
+export const SHADOW_DERIVED_COLUMNS = ["sortAt"] as const;
+
+/**
+ * Sort position for an item whose `publishedAt` is absent, null, or a value the
+ * column cannot hold. Ordering is `sortAt DESC`, so this places undated items
+ * at the far end of the timeline.
+ *
+ * This is not a timestamp and is never presented as one. `publishedAt` stays
+ * nullable and authoritative, and `__absent` still records that the field was
+ * missing, so nothing here fabricates a date. That distinction is the whole
+ * reason for a separate column rather than `COALESCE(publishedAt, 0)` in the
+ * schema: writing the sentinel into `publishedAt` itself would be exactly the
+ * irreversible fabrication the projection was built to prevent.
+ *
+ * An item genuinely published at epoch zero shares this sort position. The two
+ * remain distinguishable in `publishedAt`, and the `globalId` tie-break keeps
+ * the total order strict either way.
+ */
+export const SORT_AT_ABSENT = 0;
+
+/**
+ * The sort key is defensive because it must satisfy NOT NULL for every row the
+ * table will accept. A non-integer `publishedAt` cannot reach a STRICT INTEGER
+ * column at all, so the fallback is unreachable in practice; it exists so the
+ * invariant is guaranteed by construction rather than by that argument holding
+ * forever.
+ */
+export function sortKeyOf(row: FeedItemRow): number {
+  return Number.isSafeInteger(row.publishedAt)
+    ? (row.publishedAt as number)
+    : SORT_AT_ABSENT;
+}
+
+/**
+ * INTEGER for the timestamps and flags, TEXT for everything else. `rest` and
+ * the derived `sortAt` are the only NOT NULL columns besides the key: every
+ * other column is legitimately absent on some item, and the projection records
+ * that absence inside `rest`.
  */
 export const SHADOW_TABLE_DDL = `
 CREATE TABLE IF NOT EXISTS feed_items (
@@ -94,7 +135,8 @@ CREATE TABLE IF NOT EXISTS feed_items (
   tags              TEXT,
   contentBlob       TEXT,
   preservedBlob     TEXT,
-  rest              TEXT    NOT NULL
+  rest              TEXT    NOT NULL,
+  sortAt            INTEGER NOT NULL
 ) STRICT;
 `.trim();
 
@@ -105,10 +147,24 @@ CREATE TABLE IF NOT EXISTS feed_items (
  */
 export const SHADOW_INDEX_DDL = [
   // The feed's default ordering, filtered to what is not archived or hidden.
+  //
+  // Both columns of the feed_page_v1 sort contract are in the index, and in its
+  // exact direction, so a keyset page is an index range scan. Ordering by the
+  // nullable `publishedAt` instead would force `ORDER BY publishedAt IS NULL,
+  // ...` to keep undated items at the end, and that leading expression is not
+  // index-satisfiable: SQLite falls back to USE TEMP B-TREE FOR ORDER BY and
+  // sorts the whole remaining set on every page. Measured first-page cost with
+  // that shape was 0.24ms at 4k rows, 4.22ms at 64k and 15.82ms at 256k, rising
+  // with the corpus; against this index it is flat at ~0.03ms across the same
+  // range. A bounded result with unbounded work is the failure Library Core
+  // exists to remove, so the sort key is a column rather than an expression.
   `CREATE INDEX IF NOT EXISTS feed_items_timeline
-     ON feed_items (publishedAt DESC)
+     ON feed_items (sortAt DESC, globalId ASC)
      WHERE archived IS NOT 1 AND hidden IS NOT 1;`,
-  // Saved and archived views, and the counts beside them.
+  // Saved and archived views, and the counts beside them. These still order by
+  // the authoritative column: their queries' sort contracts are unresolved, and
+  // switching them would presuppose decisions this slice has not measured. Each
+  // needs the same treatment when its contract is resolved.
   `CREATE INDEX IF NOT EXISTS feed_items_saved ON feed_items (saved, publishedAt DESC) WHERE saved = 1;`,
   `CREATE INDEX IF NOT EXISTS feed_items_archived ON feed_items (archivedAt DESC) WHERE archived = 1;`,
   // Per-source and per-author grouping.
@@ -116,11 +172,21 @@ export const SHADOW_INDEX_DDL = [
   `CREATE INDEX IF NOT EXISTS feed_items_author ON feed_items (authorId, publishedAt DESC);`,
 ].map((sql) => sql.trim());
 
+/**
+ * Written columns are the authoritative ones plus the derived ones. Reads stay
+ * on `SHADOW_COLUMNS` alone, so a derived value can never re-enter the document
+ * it was computed from.
+ */
+const SHADOW_WRITE_COLUMNS = [
+  ...SHADOW_COLUMNS,
+  ...SHADOW_DERIVED_COLUMNS,
+] as const;
+
 export const SHADOW_UPSERT_SQL = `
-INSERT INTO feed_items (${SHADOW_COLUMNS.join(", ")})
-VALUES (${SHADOW_COLUMNS.map(() => "?").join(", ")})
+INSERT INTO feed_items (${SHADOW_WRITE_COLUMNS.join(", ")})
+VALUES (${SHADOW_WRITE_COLUMNS.map(() => "?").join(", ")})
 ON CONFLICT(globalId) DO UPDATE SET
-${SHADOW_COLUMNS.filter((c) => c !== "globalId")
+${SHADOW_WRITE_COLUMNS.filter((c) => c !== "globalId")
   .map((c) => `  ${c} = excluded.${c}`)
   .join(",\n")};
 `.trim();
@@ -145,9 +211,9 @@ export function createShadowSchema(db: ShadowDatabase): void {
   for (const sql of SHADOW_INDEX_DDL) db.exec(sql);
 }
 
-/** Bind order matches SHADOW_COLUMNS by construction rather than by hand. */
+/** Bind order matches SHADOW_WRITE_COLUMNS by construction rather than by hand. */
 export function rowToParams(row: FeedItemRow): (string | number | null)[] {
-  return SHADOW_COLUMNS.map((column) => row[column]);
+  return [...SHADOW_COLUMNS.map((column) => row[column]), sortKeyOf(row)];
 }
 
 /**


### PR DESCRIPTION
(AI Generated).

Resolves the `sort_contract_unresolved` blocker on `feed_page_v1`, and gives the shadow store the column that makes the resolved ordering achievable with an index instead of a sort.

Local-only. Nothing imports `shadow-store.ts` yet, and no query executes, so this changes no runtime behavior. The classifier reports zero provider-visible paths.

## What the measurement found

`feed_page_v1` already declared a keyset cursor, but the timeline index ordered on the nullable `publishedAt`. Ordering by a nullable column means the query needs a null-handling term to keep undated items at the end of the feed, and `ORDER BY publishedAt IS NULL, ...` leads with an expression no index can satisfy. SQLite falls back to `USE TEMP B-TREE FOR ORDER BY` and sorts the whole remaining set on every page.

First-page cost, median of 21 runs, page size 64:

```
rows      null-term ORDER BY    resolved contract
4,000               0.24 ms             0.014 ms
16,000              0.97 ms             0.013 ms
64,000              4.22 ms             0.013 ms
256,000            15.82 ms             0.013 ms
```

The left column tracks corpus size. The right column is flat. That gap is the point: a bounded page over unbounded work is still unbounded, and it degrades exactly as a library grows, which is the failure Library Core exists to remove.

I first assumed the cause was the missing tie-break column in the index. That was wrong, and the query planner said so: adding `globalId` changed nothing while the null term was present. The null term was masking it. Both facts turned out to be real, and both are now in the contract, because removing the null term makes the tie-break column start to matter.

## Why not simply make publishedAt NOT NULL

Because that is the one thing the projection was built to prevent. `projection.ts` records absence in `__absent` so a missing field can be reconstructed as missing, and calls the alternative what it is: writing a sentinel into the authoritative column turns "never set" into "epoch zero", which is fabrication and irreversible.

So the sort key is a separate derived column. `sortAt` is NOT NULL and equals `publishedAt` whenever there is one, with `SORT_AT_ABSENT` as the sort position otherwise. `publishedAt` stays nullable and authoritative. `sortAt` is written, never read back, and never reconstructed, which is why it is absent from `SHADOW_COLUMNS` and from `FeedItemRow`: the round-trip differ compares authoritative data, and a derived value has nothing to say about whether the projection lost anything.

An item genuinely published at epoch zero shares the sentinel's sort position. The two stay distinguishable in `publishedAt`, and the `globalId` tie-break keeps the total order strict either way.

## The registry change

`stableSort` and `tieBreakKey` were typed as literal `null`, so the registry could describe an unresolved ordering but not a resolved one. They now accept a resolved contract, and supplying one clears `sort_contract_unresolved` for that query.

`plannedQuery` refuses a half-resolved contract: an ordering without a tie-break is not stable, and it also refuses a tie-break that is not the final ordering term, since rows sharing every preceding value would otherwise have no defined order and the cursor nothing unique to resume from.

The registry invariant moved from "every planned query has a null sort" to "a contract field is null exactly while its blocker is present". The old assertion would have forbidden ever resolving one. The new one catches what actually matters: a query claiming an ordering it has not declared, or clearing the blocker without stating one.

## Evidence

Three permanent tests, each protecting a contract that fails silently otherwise. They were verified by mutation rather than by passing:

- timeline index reverted to `(publishedAt DESC)`: 2 tests fail, on drift and on the temp B-tree
- `globalId` dropped from the index: 2 tests fail, same two
- `publishedAt` constrained NOT NULL: 2 tests fail, on fabrication and on the walk

The third test paginates 2,000 projected items through real SQLite and asserts every row is served exactly once, that no undated item was quietly dated, that the order is strictly descending across page boundaries, and that the plan uses the index with no temp B-tree.

Text comparison is pinned to BINARY in the contract because a cursor that compares differently from the database skips or repeats rows at the page boundary, and JavaScript's `localeCompare` treats ids differing only in case as equal where SQLite does not.

```
shared            16 files, 139 passed, 3 skipped
desktop unit     129 files, 864 passed
desktop e2e        9 passed
typecheck         shared, sync, desktop, pwa all clean
validate:feature  exit 0
```

Pinned Node v24.14.1 throughout.

## Scope left alone

The `saved`, `archived`, `platform` and `author` indexes still order on `publishedAt`. Their queries' sort contracts are unresolved, and switching them would presuppose decisions this slice has not measured. Each needs the same treatment when its contract is resolved, and the schema comment says so.