### PR TITLE
feat: add canonical Library Core protocol codecs

### DIFF
--- a/.agents/skills/freed-library-core/SKILL.md
+++ b/.agents/skills/freed-library-core/SKILL.md
@@ -182,6 +182,28 @@ may compile into Freed Desktop behind an explicit dark-module boundary. A
 command registration, startup open, backfill, read route, or writer route is an
 activation change and follows the corresponding gate.
 
+## Keep canonical operation bytes honest
+
+Use the shared cross-runtime vectors for every canonical construction change.
+Library Core v1 accepts only null, booleans, Unicode scalar strings, dense
+arrays, plain closed records, and safe integers. Reject negative zero,
+fractions, unsafe or nonfinite numbers, sparse or decorated arrays, accessors,
+symbol keys, non-enumerable fields, non-plain objects, invalid Unicode, cycles,
+more than 128 nesting levels, and a direct domain input above 4 MiB including
+its prefix. Reject more than 65,536 nodes even when their canonical bytes fit.
+
+Sort object names by UTF-16 code units and do not normalize Unicode. Domain
+prefixes include their terminal zero byte. A generic string label is not a
+registered digest domain. Desktop and PWA must match the same exact bytes and
+digest vectors before either path may construct authoritative operations.
+
+The construction encoder is not an inbound verifier. Never verify received
+bytes by calling `JSON.parse` and re-encoding the result because duplicate
+object names have already been erased. The inbound path needs a bounded
+duplicate-preserving parser, byte-for-byte canonical comparison, closed-schema
+validation, exact digest derivation, and strict signature verification before
+materialization.
+
 ## Preserve the invariants
 
 1. Keep exactly one active writer epoch. Advance it only with a signed immutable

--- a/.agents/skills/freed-library-core/SKILL.md
+++ b/.agents/skills/freed-library-core/SKILL.md
@@ -198,11 +198,12 @@ registered digest domain. Desktop and PWA must match the same exact bytes and
 digest vectors before either path may construct authoritative operations.
 
 The construction encoder is not an inbound verifier. Never verify received
-bytes by calling `JSON.parse` and re-encoding the result because duplicate
-object names have already been erased. The inbound path needs a bounded
-duplicate-preserving parser, byte-for-byte canonical comparison, closed-schema
-validation, exact digest derivation, and strict signature verification before
-materialization.
+bytes by calling `JSON.parse` or a duplicate-erasing native JSON parser because
+duplicate object names have already been erased. Use the shared bounded
+duplicate-preserving parser and byte-for-byte canonical comparison first. That
+parser establishes only canonical Library Core value bytes. The authoritative
+inbound path still needs closed-schema validation, exact digest derivation, and
+strict signature verification before materialization.
 
 ## Preserve the invariants
 

--- a/.agents/skills/freed-library-core/SKILL.md
+++ b/.agents/skills/freed-library-core/SKILL.md
@@ -205,6 +205,13 @@ parser establishes only canonical Library Core value bytes. The authoritative
 inbound path still needs closed-schema validation, exact digest derivation, and
 strict signature verification before materialization.
 
+Reuse the shared protocol scalar predicates for fixed lowercase hexadecimal
+values, operation-instance IDs, bounded Unicode-scalar entity IDs, and
+nonnegative safe integers. Do not create artifact-specific regex copies or
+allocate encoded copies merely to count a bounded entity ID. Scalar syntax does
+not prove randomness, cryptographic derivation, authority, or semantic
+ownership.
+
 ## Preserve the invariants
 
 1. Keep exactly one active writer epoch. Advance it only with a signed immutable

--- a/docs/LIBRARY-CORE-CONTRACT.md
+++ b/docs/LIBRARY-CORE-CONTRACT.md
@@ -48,6 +48,12 @@ protocol input. Binary values, digests, public keys, nonces, and signatures use
 fixed-length lowercase hexadecimal strings. SHA-256 digests, Ed25519 public
 keys, and 32-byte nonces are exactly 64 characters. Ed25519 signatures are
 exactly 128 characters. Private keys never enter a canonical value.
+Direct canonical values and domain-separated digest or signature inputs have a
+maximum nesting depth of 128. The 4 MiB direct-input ceiling includes the
+domain prefix, and one value may contain at most 65,536 nodes. A construction
+encoder rejects accessors, symbol keys,
+non-enumerable properties, non-plain objects, decorated arrays, and cycles
+rather than interpreting JavaScript object behavior as protocol data.
 
 Registered fields that contain fractional values do not use JSON numbers in
 canonical protocol objects. Their field contract stores a closed
@@ -74,6 +80,9 @@ An inbound canonical artifact is accepted only when its received bytes equal
 Unicode before constructing the parsed value. It does not drop unknown fields
 and then verify a reconstructed object. This prevents alternate JSON spellings
 from producing a second signed representation of the same apparent value.
+The construction encoder is not an inbound verifier. In particular, passing
+received bytes through `JSON.parse` before canonicalization is invalid because
+that parser has already erased duplicate object names.
 
 An otherwise valid v1 outer operation envelope with an unknown operation type
 or payload schema preserves the received canonical payload as opaque evidence,

--- a/docs/LIBRARY-CORE-CONTRACT.md
+++ b/docs/LIBRARY-CORE-CONTRACT.md
@@ -84,6 +84,15 @@ The construction encoder is not an inbound verifier. In particular, passing
 received bytes through `JSON.parse` before canonicalization is invalid because
 that parser has already erased duplicate object names.
 
+The dormant shared and native construction modules include matching bounded
+inbound canonical-value parsers. They preserve object-name occurrences until
+duplicate rejection, accept only valid UTF-8 and Unicode scalar strings,
+enforce the same 4 MiB, 128-level, 65,536-node, and safe-integer ceilings, and
+require an exact re-encoding match before returning an immutable value. These
+parsers deliberately stop before operation-schema, digest, signature, actor,
+and causal validation. They are a prerequisite for an authoritative verifier,
+not an activation path or an authority receipt.
+
 An otherwise valid v1 outer operation envelope with an unknown operation type
 or payload schema preserves the received canonical payload as opaque evidence,
 verifies the outer digests and signature, stops the apply cursor, and does not

--- a/docs/LIBRARY-CORE-CONTRACT.md
+++ b/docs/LIBRARY-CORE-CONTRACT.md
@@ -481,6 +481,17 @@ logical operation always uses a new ID. `transaction_id`,
 `*_operation_id` use this codec unless a closed schema explicitly fixes that
 field to another already registered opaque identifier.
 
+The dormant shared protocol-scalar module is the executable source for the
+64-character lowercase hexadecimal, operation-instance-ID, entity-ID, and
+nonnegative-safe-integer syntax checks. A v1 entity ID is a nonempty Unicode
+scalar string whose UTF-8 encoding is at most 4,096 bytes. It is not normalized.
+The validator counts bytes without allocating an encoded copy and rejects lone
+UTF-16 surrogates. The legacy epoch bootstrap validator consumes the shared
+fixed-width and numeric predicates instead of carrying a second regex or
+numeric interpretation. Passing a scalar predicate proves only the encoded
+shape. Randomness, digest derivation, signature validity, authority, and
+field-specific semantics remain separate checks.
+
 Canonical sets use their field-specific sort before `C`. `causal_frontier`
 sorts ascending by `(actor_id, sequence, operation_id, chain_digest)`,
 comparing numeric sequence numerically and the remaining ASCII identifiers

--- a/docs/PHASE-4-SYNC.md
+++ b/docs/PHASE-4-SYNC.md
@@ -307,6 +307,7 @@ recovery, telemetry, milestones, and acceptance tests.
 | 4.23 | Dormant native SQLite projection engine with one canonical schema, atomic revisioned batches, and bounded keyset pages | ✓ | Medium |
 | 4.24 | Crash-safe, idempotent derived SQLite projection batch receipts with exact response-loss recovery | ✓ | Medium |
 | 4.25 | Bounded cross-runtime canonical operation construction codec and domain-separated input vectors | ✓ | Medium |
+| 4.26 | Bounded duplicate-preserving shared and native canonical-value decoders with exact byte rejection vectors | ✓ | Medium |
 
 ---
 

--- a/docs/PHASE-4-SYNC.md
+++ b/docs/PHASE-4-SYNC.md
@@ -308,6 +308,7 @@ recovery, telemetry, milestones, and acceptance tests.
 | 4.24 | Crash-safe, idempotent derived SQLite projection batch receipts with exact response-loss recovery | ✓ | Medium |
 | 4.25 | Bounded cross-runtime canonical operation construction codec and domain-separated input vectors | ✓ | Medium |
 | 4.26 | Bounded duplicate-preserving shared and native canonical-value decoders with exact byte rejection vectors | ✓ | Medium |
+| 4.27 | Shared exact protocol scalar predicates, including bounded entity IDs, reused by legacy bootstrap and future closed-schema validators | ✓ | Low |
 
 ---
 

--- a/docs/PHASE-4-SYNC.md
+++ b/docs/PHASE-4-SYNC.md
@@ -306,6 +306,7 @@ recovery, telemetry, milestones, and acceptance tests.
 | 4.22 | Revision-fenced IndexedDB v2 storage and repeatable Automerge persistence primitive | ✓ | Medium |
 | 4.23 | Dormant native SQLite projection engine with one canonical schema, atomic revisioned batches, and bounded keyset pages | ✓ | Medium |
 | 4.24 | Crash-safe, idempotent derived SQLite projection batch receipts with exact response-loss recovery | ✓ | Medium |
+| 4.25 | Bounded cross-runtime canonical operation construction codec and domain-separated input vectors | ✓ | Medium |
 
 ---
 
@@ -340,6 +341,7 @@ recovery, telemetry, milestones, and acceptance tests.
 - [x] IndexedDB v2 preserves v1 Automerge bytes at revision zero, returns an exact generation and save revision with every load, rejects stale saves and clears through one atomic compare-and-swap, closes on version change, blocks unsafe upgrades, and exposes repeatable `saveSince` persistence that advances committed bytes and heads only after storage commit. Failed decodes retain the exact loaded revision, distinguish corruption from memory exhaustion, and cannot clear a newer concurrent save. Worker integration remains a separate activation step.
 - [x] The dormant native SQLite projection engine compiles bundled SQLite into Freed Desktop, consumes one versioned canonical schema shared with the TypeScript contract, applies row upserts and deletions with one projection revision in one transaction, reopens committed disk rows, rejects stale page cursors and out-of-contract page sizes, pins its smallest memory tier, and serves the default feed through an index-backed bounded keyset query without opening a production database or changing durable authority
 - [x] Every dormant native SQLite projection batch binds one stable batch ID, canonical input digest, expected prior revision, and ceilings of 1,000 items and 4 MiB of projected input to rows, deletions, the next revision, and a durable derived receipt in one transaction. Exact retry after response loss returns the original receipt after process restart. Changed replay tuples, oversized batches, conflicting migrations, and partial receipt failures fail closed without advancing rows or revision. These receipts do not replace signed Library Core operation receipts or grant mutation authority
+- [x] Shared TypeScript and native Rust construction encoders produce identical bounded RFC 8785 bytes and operation domain inputs for safe integers, UTF-16 object-key ordering, Unicode, nested arrays and objects, and registered fractional wrappers. They reject unsupported JavaScript values, non-plain or behavior-bearing objects, negative zero, fractions, unsafe integers, excessive bytes, more than 65,536 nodes, and more than 128 nesting levels. The construction path remains dark and cannot verify inbound bytes until a duplicate-preserving decoder and closed envelope validator land
 - [ ] iCloud sync integration
 - [ ] Large media packages transfer outside Automerge through an authenticated,
       resumable, integrity-checked path with explicit storage and deletion rules

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -6,6 +6,8 @@
 // production entry point may open the store until the activation contract is
 // reviewed.
 #[cfg_attr(not(test), allow(dead_code))]
+mod library_core_canonical;
+#[cfg_attr(not(test), allow(dead_code))]
 mod shadow_store;
 mod youtube;
 

--- a/packages/desktop/src-tauri/src/library_core_canonical.rs
+++ b/packages/desktop/src-tauri/src/library_core_canonical.rs
@@ -1,4 +1,5 @@
 use serde_json::Value;
+use std::collections::HashSet;
 
 const MAX_DIRECT_CANONICAL_BYTES: usize = 4_194_304;
 const MAX_CANONICAL_NESTING_DEPTH: usize = 128;
@@ -24,6 +25,10 @@ pub(crate) enum CanonicalEncodingError {
     UnsupportedNumber,
     UnregisteredDomain,
     JsonStringEncoding,
+    InvalidUtf8,
+    InvalidJson,
+    DuplicateObjectName,
+    NonCanonicalBytes,
 }
 
 struct BoundedWriter {
@@ -173,6 +178,299 @@ pub(crate) fn encode_operation_signature_input(
     Ok(result)
 }
 
+struct CanonicalJsonParser<'a> {
+    source: &'a str,
+    bytes: &'a [u8],
+    index: usize,
+    node_count: usize,
+}
+
+impl<'a> CanonicalJsonParser<'a> {
+    fn new(source: &'a str) -> Self {
+        Self {
+            source,
+            bytes: source.as_bytes(),
+            index: 0,
+            node_count: 0,
+        }
+    }
+
+    fn parse(mut self) -> Result<Value, CanonicalEncodingError> {
+        let value = self.parse_value(0)?;
+        if self.index != self.bytes.len() {
+            return Err(CanonicalEncodingError::InvalidJson);
+        }
+        Ok(value)
+    }
+
+    fn count_node(&mut self, depth: usize) -> Result<(), CanonicalEncodingError> {
+        self.node_count = self
+            .node_count
+            .checked_add(1)
+            .ok_or(CanonicalEncodingError::MaximumNodesExceeded)?;
+        if self.node_count > MAX_CANONICAL_NODES {
+            return Err(CanonicalEncodingError::MaximumNodesExceeded);
+        }
+        if depth > MAX_CANONICAL_NESTING_DEPTH {
+            return Err(CanonicalEncodingError::MaximumDepthExceeded);
+        }
+        Ok(())
+    }
+
+    fn parse_value(&mut self, depth: usize) -> Result<Value, CanonicalEncodingError> {
+        self.count_node(depth)?;
+        match self.bytes.get(self.index).copied() {
+            Some(b'"') => self.parse_string().map(Value::String),
+            Some(b'[') => self.parse_array(depth),
+            Some(b'{') => self.parse_object(depth),
+            Some(b't') => {
+                self.parse_keyword(b"true")?;
+                Ok(Value::Bool(true))
+            }
+            Some(b'f') => {
+                self.parse_keyword(b"false")?;
+                Ok(Value::Bool(false))
+            }
+            Some(b'n') => {
+                self.parse_keyword(b"null")?;
+                Ok(Value::Null)
+            }
+            Some(b'-' | b'0'..=b'9') => self.parse_integer(),
+            _ => Err(CanonicalEncodingError::InvalidJson),
+        }
+    }
+
+    fn parse_keyword(&mut self, keyword: &[u8]) -> Result<(), CanonicalEncodingError> {
+        if self
+            .bytes
+            .get(self.index..self.index.saturating_add(keyword.len()))
+            != Some(keyword)
+        {
+            return Err(CanonicalEncodingError::InvalidJson);
+        }
+        self.index += keyword.len();
+        Ok(())
+    }
+
+    fn parse_integer(&mut self) -> Result<Value, CanonicalEncodingError> {
+        let start = self.index;
+        if self.bytes.get(self.index) == Some(&b'-') {
+            self.index += 1;
+        }
+        match self.bytes.get(self.index).copied() {
+            Some(b'0') => {
+                self.index += 1;
+                if matches!(self.bytes.get(self.index), Some(b'0'..=b'9')) {
+                    return Err(CanonicalEncodingError::InvalidJson);
+                }
+            }
+            Some(b'1'..=b'9') => {
+                self.index += 1;
+                while matches!(self.bytes.get(self.index), Some(b'0'..=b'9')) {
+                    self.index += 1;
+                }
+            }
+            _ => return Err(CanonicalEncodingError::InvalidJson),
+        }
+        if matches!(self.bytes.get(self.index), Some(b'.' | b'e' | b'E')) {
+            return Err(CanonicalEncodingError::UnsupportedNumber);
+        }
+        let lexeme = &self.source[start..self.index];
+        if lexeme == "-0" {
+            return Err(CanonicalEncodingError::UnsupportedNumber);
+        }
+        let integer = lexeme
+            .parse::<i64>()
+            .map_err(|_| CanonicalEncodingError::UnsupportedNumber)?;
+        if integer.unsigned_abs() > SAFE_INTEGER_MAX {
+            return Err(CanonicalEncodingError::UnsupportedNumber);
+        }
+        Ok(Value::Number(integer.into()))
+    }
+
+    fn parse_string(&mut self) -> Result<String, CanonicalEncodingError> {
+        if self.bytes.get(self.index) != Some(&b'"') {
+            return Err(CanonicalEncodingError::InvalidJson);
+        }
+        self.index += 1;
+        let mut result = String::new();
+        while let Some(byte) = self.bytes.get(self.index).copied() {
+            match byte {
+                b'"' => {
+                    self.index += 1;
+                    return Ok(result);
+                }
+                b'\\' => {
+                    self.index += 1;
+                    result.push_str(&self.parse_escape()?);
+                }
+                0x00..=0x1f => return Err(CanonicalEncodingError::InvalidJson),
+                0x20..=0x7f => {
+                    result.push(char::from(byte));
+                    self.index += 1;
+                }
+                _ => {
+                    let character = self.source[self.index..]
+                        .chars()
+                        .next()
+                        .ok_or(CanonicalEncodingError::InvalidJson)?;
+                    result.push(character);
+                    self.index += character.len_utf8();
+                }
+            }
+        }
+        Err(CanonicalEncodingError::InvalidJson)
+    }
+
+    fn parse_escape(&mut self) -> Result<String, CanonicalEncodingError> {
+        let escaped = self
+            .bytes
+            .get(self.index)
+            .copied()
+            .ok_or(CanonicalEncodingError::InvalidJson)?;
+        self.index += 1;
+        match escaped {
+            b'"' => Ok("\"".to_owned()),
+            b'\\' => Ok("\\".to_owned()),
+            b'/' => Ok("/".to_owned()),
+            b'b' => Ok("\u{0008}".to_owned()),
+            b'f' => Ok("\u{000c}".to_owned()),
+            b'n' => Ok("\n".to_owned()),
+            b'r' => Ok("\r".to_owned()),
+            b't' => Ok("\t".to_owned()),
+            b'u' => self.parse_unicode_escape(),
+            _ => Err(CanonicalEncodingError::InvalidJson),
+        }
+    }
+
+    fn parse_unicode_escape(&mut self) -> Result<String, CanonicalEncodingError> {
+        let high = self.parse_hex_code_unit()?;
+        let scalar = if (0xd800..=0xdbff).contains(&high) {
+            if self.bytes.get(self.index..self.index.saturating_add(2)) != Some(b"\\u") {
+                return Err(CanonicalEncodingError::InvalidJson);
+            }
+            self.index += 2;
+            let low = self.parse_hex_code_unit()?;
+            if !(0xdc00..=0xdfff).contains(&low) {
+                return Err(CanonicalEncodingError::InvalidJson);
+            }
+            0x10000 + ((u32::from(high) - 0xd800) << 10) + (u32::from(low) - 0xdc00)
+        } else if (0xdc00..=0xdfff).contains(&high) {
+            return Err(CanonicalEncodingError::InvalidJson);
+        } else {
+            u32::from(high)
+        };
+        char::from_u32(scalar)
+            .map(|value| value.to_string())
+            .ok_or(CanonicalEncodingError::InvalidJson)
+    }
+
+    fn parse_hex_code_unit(&mut self) -> Result<u16, CanonicalEncodingError> {
+        let bytes = self
+            .bytes
+            .get(self.index..self.index.saturating_add(4))
+            .ok_or(CanonicalEncodingError::InvalidJson)?;
+        let mut value = 0_u16;
+        for byte in bytes {
+            let digit = match byte {
+                b'0'..=b'9' => u16::from(*byte - b'0'),
+                b'a'..=b'f' => u16::from(*byte - b'a' + 10),
+                b'A'..=b'F' => u16::from(*byte - b'A' + 10),
+                _ => return Err(CanonicalEncodingError::InvalidJson),
+            };
+            value = (value << 4) | digit;
+        }
+        self.index += 4;
+        Ok(value)
+    }
+
+    fn parse_array(&mut self, depth: usize) -> Result<Value, CanonicalEncodingError> {
+        self.index += 1;
+        let mut values = Vec::new();
+        if self.bytes.get(self.index) == Some(&b']') {
+            self.index += 1;
+            return Ok(Value::Array(values));
+        }
+        loop {
+            values.push(self.parse_value(depth + 1)?);
+            match self.bytes.get(self.index).copied() {
+                Some(b']') => {
+                    self.index += 1;
+                    return Ok(Value::Array(values));
+                }
+                Some(b',') => self.index += 1,
+                _ => return Err(CanonicalEncodingError::InvalidJson),
+            }
+        }
+    }
+
+    fn parse_object(&mut self, depth: usize) -> Result<Value, CanonicalEncodingError> {
+        self.index += 1;
+        let mut values = serde_json::Map::new();
+        let mut names = HashSet::new();
+        if self.bytes.get(self.index) == Some(&b'}') {
+            self.index += 1;
+            return Ok(Value::Object(values));
+        }
+        loop {
+            let name = self.parse_string()?;
+            if !names.insert(name.clone()) {
+                return Err(CanonicalEncodingError::DuplicateObjectName);
+            }
+            if self.bytes.get(self.index) != Some(&b':') {
+                return Err(CanonicalEncodingError::InvalidJson);
+            }
+            self.index += 1;
+            values.insert(name, self.parse_value(depth + 1)?);
+            match self.bytes.get(self.index).copied() {
+                Some(b'}') => {
+                    self.index += 1;
+                    return Ok(Value::Object(values));
+                }
+                Some(b',') => self.index += 1,
+                _ => return Err(CanonicalEncodingError::InvalidJson),
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DecodedCanonicalValue {
+    value: Value,
+    canonical_bytes: Vec<u8>,
+}
+
+impl DecodedCanonicalValue {
+    pub(crate) fn value(&self) -> &Value {
+        &self.value
+    }
+
+    pub(crate) fn canonical_bytes(&self) -> &[u8] {
+        &self.canonical_bytes
+    }
+}
+
+pub(crate) fn decode_canonical_value(
+    bytes: &[u8],
+    maximum_bytes: usize,
+) -> Result<DecodedCanonicalValue, CanonicalEncodingError> {
+    if maximum_bytes == 0 || maximum_bytes > MAX_DIRECT_CANONICAL_BYTES {
+        return Err(CanonicalEncodingError::InvalidMaximumBytes);
+    }
+    if bytes.len() > maximum_bytes {
+        return Err(CanonicalEncodingError::MaximumBytesExceeded);
+    }
+    let source = std::str::from_utf8(bytes).map_err(|_| CanonicalEncodingError::InvalidUtf8)?;
+    let value = CanonicalJsonParser::new(source).parse()?;
+    if encode_canonical_value(&value, maximum_bytes)? != bytes {
+        return Err(CanonicalEncodingError::NonCanonicalBytes);
+    }
+    Ok(DecodedCanonicalValue {
+        value,
+        canonical_bytes: bytes.to_vec(),
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -186,11 +484,25 @@ mod tests {
         canonical: String,
     }
 
+    #[derive(Deserialize)]
+    struct DecoderVector {
+        name: String,
+        input: String,
+        accepted: bool,
+    }
+
     fn vectors() -> Vec<CanonicalVector> {
         serde_json::from_str(include_str!(
             "../../../shared/src/library-core/canonical-codec-vectors.json"
         ))
         .expect("cross-runtime canonical vectors must parse")
+    }
+
+    fn decoder_vectors() -> Vec<DecoderVector> {
+        serde_json::from_str(include_str!(
+            "../../../shared/src/library-core/canonical-decoder-vectors.json"
+        ))
+        .expect("cross-runtime canonical decoder vectors must parse")
     }
 
     #[test]
@@ -286,6 +598,61 @@ mod tests {
         assert_eq!(
             encode_canonical_value(&value, MAX_DIRECT_CANONICAL_BYTES),
             Err(CanonicalEncodingError::MaximumNodesExceeded)
+        );
+    }
+
+    #[test]
+    fn matches_cross_runtime_duplicate_preserving_decoder_vectors() {
+        for vector in decoder_vectors() {
+            let decoded =
+                decode_canonical_value(vector.input.as_bytes(), MAX_DIRECT_CANONICAL_BYTES);
+            assert_eq!(
+                decoded.is_ok(),
+                vector.accepted,
+                "{} returned {decoded:?}",
+                vector.name
+            );
+            if let Ok(decoded) = decoded {
+                assert_eq!(decoded.canonical_bytes(), vector.input.as_bytes());
+                assert_eq!(
+                    encode_canonical_value(decoded.value(), MAX_DIRECT_CANONICAL_BYTES)
+                        .expect("decoded value re-encodes"),
+                    vector.input.as_bytes()
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn decoder_rejects_invalid_utf8_and_inbound_limits() {
+        assert_eq!(
+            decode_canonical_value(&[0xc3, 0x28], MAX_DIRECT_CANONICAL_BYTES),
+            Err(CanonicalEncodingError::InvalidUtf8)
+        );
+        assert_eq!(
+            decode_canonical_value(br#""12345""#, 6),
+            Err(CanonicalEncodingError::MaximumBytesExceeded)
+        );
+
+        let excessive_nodes = format!(
+            "[{}]",
+            std::iter::repeat_n("null", MAX_CANONICAL_NODES)
+                .collect::<Vec<_>>()
+                .join(",")
+        );
+        assert_eq!(
+            decode_canonical_value(excessive_nodes.as_bytes(), MAX_DIRECT_CANONICAL_BYTES),
+            Err(CanonicalEncodingError::MaximumNodesExceeded)
+        );
+
+        let excessive_depth = format!(
+            "{}null{}",
+            "[".repeat(MAX_CANONICAL_NESTING_DEPTH + 1),
+            "]".repeat(MAX_CANONICAL_NESTING_DEPTH + 1)
+        );
+        assert_eq!(
+            decode_canonical_value(excessive_depth.as_bytes(), MAX_DIRECT_CANONICAL_BYTES),
+            Err(CanonicalEncodingError::MaximumDepthExceeded)
         );
     }
 }

--- a/packages/desktop/src-tauri/src/library_core_canonical.rs
+++ b/packages/desktop/src-tauri/src/library_core_canonical.rs
@@ -1,0 +1,291 @@
+use serde_json::Value;
+
+const MAX_DIRECT_CANONICAL_BYTES: usize = 4_194_304;
+const MAX_CANONICAL_NESTING_DEPTH: usize = 128;
+const MAX_CANONICAL_NODES: usize = 65_536;
+const OPERATION_DIGEST_DOMAINS: [&str; 8] = [
+    "operation-payload",
+    "operation-signing-body",
+    "transaction-member",
+    "transaction",
+    "actor-chain-genesis",
+    "actor-chain",
+    "operation-envelope",
+    "causal-frontier",
+];
+const SAFE_INTEGER_MAX: u64 = 9_007_199_254_740_991;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum CanonicalEncodingError {
+    InvalidMaximumBytes,
+    MaximumBytesExceeded,
+    MaximumDepthExceeded,
+    MaximumNodesExceeded,
+    UnsupportedNumber,
+    UnregisteredDomain,
+    JsonStringEncoding,
+}
+
+struct BoundedWriter {
+    bytes: Vec<u8>,
+    maximum_bytes: usize,
+}
+
+impl BoundedWriter {
+    fn new(maximum_bytes: usize) -> Result<Self, CanonicalEncodingError> {
+        if maximum_bytes == 0 || maximum_bytes > MAX_DIRECT_CANONICAL_BYTES {
+            return Err(CanonicalEncodingError::InvalidMaximumBytes);
+        }
+        Ok(Self {
+            bytes: Vec::with_capacity(maximum_bytes.min(1_024)),
+            maximum_bytes,
+        })
+    }
+
+    fn write(&mut self, value: &[u8]) -> Result<(), CanonicalEncodingError> {
+        let next_length = self
+            .bytes
+            .len()
+            .checked_add(value.len())
+            .ok_or(CanonicalEncodingError::MaximumBytesExceeded)?;
+        if next_length > self.maximum_bytes {
+            return Err(CanonicalEncodingError::MaximumBytesExceeded);
+        }
+        self.bytes.extend_from_slice(value);
+        Ok(())
+    }
+}
+
+fn compare_utf16(left: &str, right: &str) -> std::cmp::Ordering {
+    left.encode_utf16().cmp(right.encode_utf16())
+}
+
+fn write_string(writer: &mut BoundedWriter, value: &str) -> Result<(), CanonicalEncodingError> {
+    let encoded =
+        serde_json::to_string(value).map_err(|_| CanonicalEncodingError::JsonStringEncoding)?;
+    writer.write(encoded.as_bytes())
+}
+
+fn write_value(
+    writer: &mut BoundedWriter,
+    value: &Value,
+    depth: usize,
+    node_count: &mut usize,
+) -> Result<(), CanonicalEncodingError> {
+    *node_count = node_count
+        .checked_add(1)
+        .ok_or(CanonicalEncodingError::MaximumNodesExceeded)?;
+    if *node_count > MAX_CANONICAL_NODES {
+        return Err(CanonicalEncodingError::MaximumNodesExceeded);
+    }
+    if depth > MAX_CANONICAL_NESTING_DEPTH {
+        return Err(CanonicalEncodingError::MaximumDepthExceeded);
+    }
+    match value {
+        Value::Null => writer.write(b"null"),
+        Value::Bool(value) => writer.write(if *value { b"true" } else { b"false" }),
+        Value::String(value) => write_string(writer, value),
+        Value::Number(value) => {
+            if let Some(integer) = value.as_i64() {
+                if integer.unsigned_abs() > SAFE_INTEGER_MAX {
+                    return Err(CanonicalEncodingError::UnsupportedNumber);
+                }
+                writer.write(integer.to_string().as_bytes())
+            } else if let Some(integer) = value.as_u64() {
+                if integer > SAFE_INTEGER_MAX {
+                    return Err(CanonicalEncodingError::UnsupportedNumber);
+                }
+                writer.write(integer.to_string().as_bytes())
+            } else {
+                Err(CanonicalEncodingError::UnsupportedNumber)
+            }
+        }
+        Value::Array(values) => {
+            writer.write(b"[")?;
+            for (index, value) in values.iter().enumerate() {
+                if index > 0 {
+                    writer.write(b",")?;
+                }
+                write_value(writer, value, depth + 1, node_count)?;
+            }
+            writer.write(b"]")
+        }
+        Value::Object(values) => {
+            let mut keys: Vec<&str> = values.keys().map(String::as_str).collect();
+            keys.sort_unstable_by(|left, right| compare_utf16(left, right));
+            writer.write(b"{")?;
+            for (index, key) in keys.into_iter().enumerate() {
+                if index > 0 {
+                    writer.write(b",")?;
+                }
+                write_string(writer, key)?;
+                writer.write(b":")?;
+                write_value(writer, &values[key], depth + 1, node_count)?;
+            }
+            writer.write(b"}")
+        }
+    }
+}
+
+pub(crate) fn encode_canonical_value(
+    value: &Value,
+    maximum_bytes: usize,
+) -> Result<Vec<u8>, CanonicalEncodingError> {
+    let mut writer = BoundedWriter::new(maximum_bytes)?;
+    let mut node_count = 0;
+    write_value(&mut writer, value, 0, &mut node_count)?;
+    Ok(writer.bytes)
+}
+
+pub(crate) fn encode_operation_digest_input(
+    domain: &str,
+    value: &Value,
+    maximum_bytes: usize,
+) -> Result<Vec<u8>, CanonicalEncodingError> {
+    if !OPERATION_DIGEST_DOMAINS.contains(&domain) {
+        return Err(CanonicalEncodingError::UnregisteredDomain);
+    }
+    let prefix = format!("freed.library-core.v1/digest/{domain}\0");
+    let canonical_budget = maximum_bytes
+        .checked_sub(prefix.len())
+        .filter(|budget| *budget > 0)
+        .ok_or(CanonicalEncodingError::InvalidMaximumBytes)?;
+    let canonical = encode_canonical_value(value, canonical_budget)?;
+    let mut result = Vec::with_capacity(prefix.len() + canonical.len());
+    result.extend_from_slice(prefix.as_bytes());
+    result.extend_from_slice(&canonical);
+    Ok(result)
+}
+
+pub(crate) fn encode_operation_signature_input(
+    value: &Value,
+    maximum_bytes: usize,
+) -> Result<Vec<u8>, CanonicalEncodingError> {
+    let prefix = b"freed.library-core.v1/signature/operation-envelope\0";
+    let canonical_budget = maximum_bytes
+        .checked_sub(prefix.len())
+        .filter(|budget| *budget > 0)
+        .ok_or(CanonicalEncodingError::InvalidMaximumBytes)?;
+    let canonical = encode_canonical_value(value, canonical_budget)?;
+    let mut result = Vec::with_capacity(prefix.len() + canonical.len());
+    result.extend_from_slice(prefix);
+    result.extend_from_slice(&canonical);
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Deserialize;
+    use sha2::{Digest, Sha256};
+
+    #[derive(Deserialize)]
+    struct CanonicalVector {
+        name: String,
+        value: Value,
+        canonical: String,
+    }
+
+    fn vectors() -> Vec<CanonicalVector> {
+        serde_json::from_str(include_str!(
+            "../../../shared/src/library-core/canonical-codec-vectors.json"
+        ))
+        .expect("cross-runtime canonical vectors must parse")
+    }
+
+    #[test]
+    fn matches_cross_runtime_canonical_vectors() {
+        for vector in vectors() {
+            let encoded = encode_canonical_value(&vector.value, MAX_DIRECT_CANONICAL_BYTES)
+                .unwrap_or_else(|error| panic!("{} failed: {error:?}", vector.name));
+            assert_eq!(encoded, vector.canonical.as_bytes(), "{}", vector.name);
+        }
+    }
+
+    #[test]
+    fn builds_exact_domain_separated_inputs() {
+        let value = serde_json::json!({
+            "schema_version": 1,
+            "operation_type": "person_upsert"
+        });
+        let digest_input =
+            encode_operation_digest_input("operation-payload", &value, MAX_DIRECT_CANONICAL_BYTES)
+                .expect("digest input");
+        assert_eq!(
+            digest_input,
+            b"freed.library-core.v1/digest/operation-payload\0{\"operation_type\":\"person_upsert\",\"schema_version\":1}"
+        );
+        let digest_hex = Sha256::digest(&digest_input)
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect::<String>();
+        assert_eq!(
+            digest_hex,
+            "5192eab75edf78a8181905197adec6ae800e93ce7d568aaf4f1b6f2e98d28285"
+        );
+
+        let signature_input = encode_operation_signature_input(
+            &serde_json::json!({
+                "operation_signing_body_digest":
+                    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+            }),
+            MAX_DIRECT_CANONICAL_BYTES,
+        )
+        .expect("signature input");
+        assert_eq!(
+            signature_input,
+            b"freed.library-core.v1/signature/operation-envelope\0{\"operation_signing_body_digest\":\"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\"}"
+        );
+    }
+
+    #[test]
+    fn rejects_unsupported_numbers_limits_and_domains() {
+        for value in [
+            serde_json::json!(0.5),
+            serde_json::json!(-0.0),
+            serde_json::json!(9_007_199_254_740_992_u64),
+        ] {
+            assert_eq!(
+                encode_canonical_value(&value, MAX_DIRECT_CANONICAL_BYTES),
+                Err(CanonicalEncodingError::UnsupportedNumber)
+            );
+        }
+        assert_eq!(
+            encode_canonical_value(&serde_json::json!("12345"), 4),
+            Err(CanonicalEncodingError::MaximumBytesExceeded)
+        );
+        assert_eq!(
+            encode_operation_digest_input(
+                "made-up-domain",
+                &Value::Null,
+                MAX_DIRECT_CANONICAL_BYTES
+            ),
+            Err(CanonicalEncodingError::UnregisteredDomain)
+        );
+        assert_eq!(
+            encode_operation_signature_input(&Value::Null, 20),
+            Err(CanonicalEncodingError::InvalidMaximumBytes)
+        );
+    }
+
+    #[test]
+    fn rejects_excessive_nesting() {
+        let mut nested = Value::Null;
+        for _ in 0..=MAX_CANONICAL_NESTING_DEPTH {
+            nested = Value::Array(vec![nested]);
+        }
+        assert_eq!(
+            encode_canonical_value(&nested, MAX_DIRECT_CANONICAL_BYTES),
+            Err(CanonicalEncodingError::MaximumDepthExceeded)
+        );
+    }
+
+    #[test]
+    fn rejects_excessive_node_count() {
+        let value = Value::Array(vec![Value::Null; MAX_CANONICAL_NODES]);
+        assert_eq!(
+            encode_canonical_value(&value, MAX_DIRECT_CANONICAL_BYTES),
+            Err(CanonicalEncodingError::MaximumNodesExceeded)
+        );
+    }
+}

--- a/packages/shared/src/library-core/canonical-codec-vectors.json
+++ b/packages/shared/src/library-core/canonical-codec-vectors.json
@@ -1,0 +1,58 @@
+[
+  {
+    "name": "null",
+    "value": null,
+    "canonical": "null"
+  },
+  {
+    "name": "booleans and safe integer boundaries",
+    "value": {
+      "maximum": 9007199254740991,
+      "minimum": -9007199254740991,
+      "truth": true,
+      "falsehood": false
+    },
+    "canonical": "{\"falsehood\":false,\"maximum\":9007199254740991,\"minimum\":-9007199254740991,\"truth\":true}"
+  },
+  {
+    "name": "nested objects and arrays",
+    "value": {
+      "z": [
+        3,
+        {
+          "b": "second",
+          "a": "first"
+        }
+      ],
+      "a": {
+        "y": null,
+        "x": []
+      }
+    },
+    "canonical": "{\"a\":{\"x\":[],\"y\":null},\"z\":[3,{\"a\":\"first\",\"b\":\"second\"}]}"
+  },
+  {
+    "name": "utf16 property order",
+    "value": {
+      "€": "euro",
+      "\r": "carriage-return",
+      "דּ": "hebrew-ligature",
+      "1": "digit",
+      "😀": "emoji",
+      "": "control",
+      "ö": "latin"
+    },
+    "canonical": "{\"\\r\":\"carriage-return\",\"1\":\"digit\",\"\":\"control\",\"ö\":\"latin\",\"€\":\"euro\",\"😀\":\"emoji\",\"דּ\":\"hebrew-ligature\"}"
+  },
+  {
+    "name": "string escaping and registered fractional wrapper",
+    "value": {
+      "bits": {
+        "codec": "ieee754_binary64_hex_v1",
+        "bits": "3fd5555555555555"
+      },
+      "text": "quote=\" slash=/ backslash=\\ line=\n control=\u000f snowman=☃"
+    },
+    "canonical": "{\"bits\":{\"bits\":\"3fd5555555555555\",\"codec\":\"ieee754_binary64_hex_v1\"},\"text\":\"quote=\\\" slash=/ backslash=\\\\ line=\\n control=\\u000f snowman=☃\"}"
+  }
+]

--- a/packages/shared/src/library-core/canonical-codec.test.ts
+++ b/packages/shared/src/library-core/canonical-codec.test.ts
@@ -1,0 +1,130 @@
+import { createHash } from "node:crypto";
+
+import { describe, expect, it } from "vitest";
+
+import vectors from "./canonical-codec-vectors.json";
+import {
+  encodeLibraryCoreCanonicalValue,
+  encodeLibraryCoreDigestInput,
+  encodeLibraryCoreOperationSignatureInput,
+  LIBRARY_CORE_MAX_CANONICAL_NODES,
+  LIBRARY_CORE_MAX_CANONICAL_NESTING_DEPTH,
+} from "./canonical-codec.js";
+
+const decoder = new TextDecoder();
+
+describe("Library Core canonical codec", () => {
+  it.each(vectors)("$name matches the cross-runtime canonical vector", (test) => {
+    expect(
+      decoder.decode(encodeLibraryCoreCanonicalValue(test.value as never)),
+    ).toBe(test.canonical);
+  });
+
+  it("builds exact domain-separated digest and signature inputs", () => {
+    const value = { schema_version: 1, operation_type: "person_upsert" };
+    const digestInput = encodeLibraryCoreDigestInput(
+      "operation-payload",
+      value,
+    );
+    const signatureInput = encodeLibraryCoreOperationSignatureInput({
+      operation_signing_body_digest:
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    });
+
+    expect(decoder.decode(digestInput)).toBe(
+      'freed.library-core.v1/digest/operation-payload\u0000{"operation_type":"person_upsert","schema_version":1}',
+    );
+    expect(createHash("sha256").update(digestInput).digest("hex")).toBe(
+      "5192eab75edf78a8181905197adec6ae800e93ce7d568aaf4f1b6f2e98d28285",
+    );
+    expect(decoder.decode(signatureInput)).toBe(
+      'freed.library-core.v1/signature/operation-envelope\u0000{"operation_signing_body_digest":"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"}',
+    );
+    expect(() =>
+      encodeLibraryCoreOperationSignatureInput(null, { maximumBytes: 20 }),
+    ).toThrow(/prefix/);
+    expect(() =>
+      encodeLibraryCoreDigestInput("made-up-domain" as never, null),
+    ).toThrow(/unregistered/);
+  });
+
+  it.each([
+    ["negative zero", -0],
+    ["fraction", 0.5],
+    ["unsafe integer", Number.MAX_SAFE_INTEGER + 1],
+    ["NaN", Number.NaN],
+    ["positive infinity", Number.POSITIVE_INFINITY],
+    ["undefined", undefined],
+    ["byte array", new Uint8Array([1, 2, 3])],
+    ["date", new Date(0)],
+    ["unpaired high surrogate", "\ud800"],
+    ["unpaired low surrogate", "\udc00"],
+  ])("rejects %s", (_name, value) => {
+    expect(() =>
+      encodeLibraryCoreCanonicalValue(value as never),
+    ).toThrowError();
+  });
+
+  it("rejects sparse arrays, extra array properties, symbols, accessors, and cycles", () => {
+    const sparse = new Array(2);
+    sparse[1] = "present";
+    const decorated: unknown[] & { extra?: string } = [];
+    decorated.extra = "hidden protocol input";
+    const symbolRecord = { valid: true } as Record<
+      string | symbol,
+      unknown
+    >;
+    symbolRecord[Symbol("hidden")] = true;
+    const accessor = Object.defineProperty({}, "value", {
+      enumerable: true,
+      get: () => "surprise",
+    });
+    const accessorArray: unknown[] = [];
+    Object.defineProperty(accessorArray, "0", {
+      enumerable: true,
+      get: () => "surprise",
+    });
+    const cyclic: { self?: unknown } = {};
+    cyclic.self = cyclic;
+
+    for (const value of [
+      sparse,
+      decorated,
+      symbolRecord,
+      accessor,
+      accessorArray,
+      cyclic,
+    ]) {
+      expect(() =>
+        encodeLibraryCoreCanonicalValue(value as never),
+      ).toThrowError();
+    }
+  });
+
+  it("enforces byte and nesting ceilings before returning canonical bytes", () => {
+    expect(() =>
+      encodeLibraryCoreCanonicalValue("12345", { maximumBytes: 4 }),
+    ).toThrow(/exceeds/);
+
+    let nested: unknown = null;
+    for (
+      let depth = 0;
+      depth <= LIBRARY_CORE_MAX_CANONICAL_NESTING_DEPTH;
+      depth += 1
+    ) {
+      nested = [nested];
+    }
+    expect(() =>
+      encodeLibraryCoreCanonicalValue(nested as never),
+    ).toThrow(/nesting/);
+
+    expect(() =>
+      encodeLibraryCoreCanonicalValue(
+        Array.from(
+          { length: LIBRARY_CORE_MAX_CANONICAL_NODES },
+          () => null,
+        ),
+      ),
+    ).toThrow(/nodes/);
+  });
+});

--- a/packages/shared/src/library-core/canonical-codec.test.ts
+++ b/packages/shared/src/library-core/canonical-codec.test.ts
@@ -3,7 +3,9 @@ import { createHash } from "node:crypto";
 import { describe, expect, it } from "vitest";
 
 import vectors from "./canonical-codec-vectors.json";
+import decoderVectors from "./canonical-decoder-vectors.json";
 import {
+  decodeLibraryCoreCanonicalValue,
   encodeLibraryCoreCanonicalValue,
   encodeLibraryCoreDigestInput,
   encodeLibraryCoreOperationSignatureInput,
@@ -12,13 +14,17 @@ import {
 } from "./canonical-codec.js";
 
 const decoder = new TextDecoder();
+const encoder = new TextEncoder();
 
 describe("Library Core canonical codec", () => {
-  it.each(vectors)("$name matches the cross-runtime canonical vector", (test) => {
-    expect(
-      decoder.decode(encodeLibraryCoreCanonicalValue(test.value as never)),
-    ).toBe(test.canonical);
-  });
+  it.each(vectors)(
+    "$name matches the cross-runtime canonical vector",
+    (test) => {
+      expect(
+        decoder.decode(encodeLibraryCoreCanonicalValue(test.value as never)),
+      ).toBe(test.canonical);
+    },
+  );
 
   it("builds exact domain-separated digest and signature inputs", () => {
     const value = { schema_version: 1, operation_type: "person_upsert" };
@@ -70,10 +76,7 @@ describe("Library Core canonical codec", () => {
     sparse[1] = "present";
     const decorated: unknown[] & { extra?: string } = [];
     decorated.extra = "hidden protocol input";
-    const symbolRecord = { valid: true } as Record<
-      string | symbol,
-      unknown
-    >;
+    const symbolRecord = { valid: true } as Record<string | symbol, unknown>;
     symbolRecord[Symbol("hidden")] = true;
     const accessor = Object.defineProperty({}, "value", {
       enumerable: true,
@@ -114,17 +117,69 @@ describe("Library Core canonical codec", () => {
     ) {
       nested = [nested];
     }
-    expect(() =>
-      encodeLibraryCoreCanonicalValue(nested as never),
-    ).toThrow(/nesting/);
+    expect(() => encodeLibraryCoreCanonicalValue(nested as never)).toThrow(
+      /nesting/,
+    );
 
     expect(() =>
       encodeLibraryCoreCanonicalValue(
-        Array.from(
-          { length: LIBRARY_CORE_MAX_CANONICAL_NODES },
-          () => null,
-        ),
+        Array.from({ length: LIBRARY_CORE_MAX_CANONICAL_NODES }, () => null),
       ),
     ).toThrow(/nodes/);
+  });
+
+  it.each(decoderVectors)(
+    "$name has the same duplicate-preserving decoder verdict",
+    (test) => {
+      const decode = () =>
+        decodeLibraryCoreCanonicalValue(encoder.encode(test.input));
+      if (test.accepted) {
+        expect(decode()).toEqual(JSON.parse(test.input));
+      } else {
+        expect(decode).toThrowError();
+      }
+    },
+  );
+
+  it("rejects invalid UTF-8 and enforces inbound byte, node, and depth ceilings", () => {
+    expect(() =>
+      decodeLibraryCoreCanonicalValue(new Uint8Array([0xc3, 0x28])),
+    ).toThrow(/UTF-8/);
+    expect(() =>
+      decodeLibraryCoreCanonicalValue(encoder.encode('"12345"'), {
+        maximumBytes: 6,
+      }),
+    ).toThrow(/exceeds/);
+
+    const excessiveNodes = `[${Array.from(
+      { length: LIBRARY_CORE_MAX_CANONICAL_NODES },
+      () => "null",
+    ).join(",")}]`;
+    expect(() =>
+      decodeLibraryCoreCanonicalValue(encoder.encode(excessiveNodes)),
+    ).toThrow(/nodes/);
+
+    const excessiveDepth =
+      "[".repeat(LIBRARY_CORE_MAX_CANONICAL_NESTING_DEPTH + 1) +
+      "null" +
+      "]".repeat(LIBRARY_CORE_MAX_CANONICAL_NESTING_DEPTH + 1);
+    expect(() =>
+      decodeLibraryCoreCanonicalValue(encoder.encode(excessiveDepth)),
+    ).toThrow(/nesting/);
+  });
+
+  it("returns immutable arrays and null-prototype immutable records", () => {
+    const value = decodeLibraryCoreCanonicalValue(
+      encoder.encode('{"array":[1],"record":{"safe":true}}'),
+    ) as {
+      readonly array: readonly number[];
+      readonly record: Readonly<Record<string, boolean>>;
+    };
+
+    expect(Object.isFrozen(value)).toBe(true);
+    expect(Object.getPrototypeOf(value)).toBeNull();
+    expect(Object.isFrozen(value.array)).toBe(true);
+    expect(Object.isFrozen(value.record)).toBe(true);
+    expect(Object.getPrototypeOf(value.record)).toBeNull();
   });
 });

--- a/packages/shared/src/library-core/canonical-codec.ts
+++ b/packages/shared/src/library-core/canonical-codec.ts
@@ -1,0 +1,300 @@
+/**
+ * Bounded canonical encoder for Library Core v1 protocol values.
+ *
+ * This is the construction side of the RFC 8785 contract. Received bytes need
+ * a separate duplicate-preserving parser before they can be verified. Passing
+ * a value through JSON.parse first would erase duplicate object names and is
+ * therefore not a valid verification path.
+ */
+
+export const LIBRARY_CORE_MAX_DIRECT_CANONICAL_BYTES = 4_194_304;
+export const LIBRARY_CORE_MAX_CANONICAL_NESTING_DEPTH = 128;
+export const LIBRARY_CORE_MAX_CANONICAL_NODES = 65_536;
+
+export const LIBRARY_CORE_OPERATION_DIGEST_DOMAINS = [
+  "operation-payload",
+  "operation-signing-body",
+  "transaction-member",
+  "transaction",
+  "actor-chain-genesis",
+  "actor-chain",
+  "operation-envelope",
+  "causal-frontier",
+] as const;
+
+export type LibraryCoreOperationDigestDomain =
+  (typeof LIBRARY_CORE_OPERATION_DIGEST_DOMAINS)[number];
+
+export type LibraryCoreCanonicalValue =
+  | null
+  | boolean
+  | string
+  | number
+  | readonly LibraryCoreCanonicalValue[]
+  | { readonly [key: string]: LibraryCoreCanonicalValue };
+
+export interface LibraryCoreCanonicalEncodingOptions {
+  readonly maximumBytes?: number;
+}
+
+const textEncoder = new TextEncoder();
+
+function assertUnicodeScalarString(value: string, label: string): void {
+  for (let index = 0; index < value.length; index += 1) {
+    const codeUnit = value.charCodeAt(index);
+    if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) {
+        throw new TypeError(`${label} contains an unpaired high surrogate`);
+      }
+      index += 1;
+      continue;
+    }
+    if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff) {
+      throw new TypeError(`${label} contains an unpaired low surrogate`);
+    }
+  }
+}
+
+function compareUtf16CodeUnits(left: string, right: string): number {
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
+}
+
+function normalizedMaximumBytes(
+  options: LibraryCoreCanonicalEncodingOptions,
+): number {
+  const maximumBytes =
+    options.maximumBytes ?? LIBRARY_CORE_MAX_DIRECT_CANONICAL_BYTES;
+  if (
+    !Number.isSafeInteger(maximumBytes) ||
+    maximumBytes <= 0 ||
+    maximumBytes > LIBRARY_CORE_MAX_DIRECT_CANONICAL_BYTES
+  ) {
+    throw new RangeError(
+      `maximumBytes must be a positive safe integer no greater than ${LIBRARY_CORE_MAX_DIRECT_CANONICAL_BYTES.toLocaleString()}`,
+    );
+  }
+  return maximumBytes;
+}
+
+class BoundedUtf8Writer {
+  private bytes: Uint8Array;
+  private length = 0;
+  private readonly maximumBytes: number;
+
+  constructor(maximumBytes: number) {
+    this.maximumBytes = maximumBytes;
+    this.bytes = new Uint8Array(Math.min(maximumBytes, 1_024));
+  }
+
+  write(value: string): void {
+    const encoded = textEncoder.encode(value);
+    const nextLength = this.length + encoded.byteLength;
+    if (nextLength > this.maximumBytes) {
+      throw new RangeError(
+        `canonical value exceeds ${this.maximumBytes.toLocaleString()} UTF-8 bytes`,
+      );
+    }
+    if (nextLength > this.bytes.byteLength) {
+      let capacity = this.bytes.byteLength;
+      while (capacity < nextLength) {
+        capacity = Math.min(
+          this.maximumBytes,
+          Math.max(capacity * 2, nextLength),
+        );
+      }
+      const grown = new Uint8Array(capacity);
+      grown.set(this.bytes.subarray(0, this.length));
+      this.bytes = grown;
+    }
+    this.bytes.set(encoded, this.length);
+    this.length = nextLength;
+  }
+
+  finish(): Uint8Array {
+    return this.bytes.slice(0, this.length);
+  }
+}
+
+function writeCanonicalValue(
+  writer: BoundedUtf8Writer,
+  value: unknown,
+  depth: number,
+  ancestors: Set<object>,
+  nodeBudget: { count: number },
+): void {
+  nodeBudget.count += 1;
+  if (nodeBudget.count > LIBRARY_CORE_MAX_CANONICAL_NODES) {
+    throw new RangeError(
+      `canonical value exceeds ${LIBRARY_CORE_MAX_CANONICAL_NODES.toLocaleString()} nodes`,
+    );
+  }
+  if (depth > LIBRARY_CORE_MAX_CANONICAL_NESTING_DEPTH) {
+    throw new RangeError(
+      `canonical value exceeds ${LIBRARY_CORE_MAX_CANONICAL_NESTING_DEPTH.toLocaleString()} nesting levels`,
+    );
+  }
+
+  if (value === null) {
+    writer.write("null");
+    return;
+  }
+  if (typeof value === "boolean") {
+    writer.write(value ? "true" : "false");
+    return;
+  }
+  if (typeof value === "string") {
+    assertUnicodeScalarString(value, "canonical string");
+    writer.write(JSON.stringify(value));
+    return;
+  }
+  if (typeof value === "number") {
+    if (!Number.isSafeInteger(value) || Object.is(value, -0)) {
+      throw new TypeError(
+        "canonical numbers must be safe integers and may not be negative zero",
+      );
+    }
+    writer.write(String(value));
+    return;
+  }
+  if (typeof value !== "object") {
+    throw new TypeError(`unsupported canonical value type: ${typeof value}`);
+  }
+
+  if (ancestors.has(value)) {
+    throw new TypeError("canonical values may not contain cycles");
+  }
+  ancestors.add(value);
+  try {
+    if (Array.isArray(value)) {
+      const ownNames = Object.getOwnPropertyNames(value);
+      if (
+        ownNames.length !== value.length + 1 ||
+        ownNames[ownNames.length - 1] !== "length" ||
+        Object.getOwnPropertySymbols(value).length !== 0
+      ) {
+        throw new TypeError(
+          "canonical arrays must be dense and may not carry extra properties",
+        );
+      }
+      writer.write("[");
+      for (let index = 0; index < value.length; index += 1) {
+        const descriptor = Object.getOwnPropertyDescriptor(
+          value,
+          String(index),
+        );
+        if (
+          descriptor === undefined ||
+          !descriptor.enumerable ||
+          !("value" in descriptor)
+        ) {
+          throw new TypeError(
+            "canonical arrays require dense enumerable data elements",
+          );
+        }
+        if (index > 0) writer.write(",");
+        writeCanonicalValue(
+          writer,
+          descriptor.value,
+          depth + 1,
+          ancestors,
+          nodeBudget,
+        );
+      }
+      writer.write("]");
+      return;
+    }
+
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) {
+      throw new TypeError("canonical objects must be plain records");
+    }
+    if (Object.getOwnPropertySymbols(value).length !== 0) {
+      throw new TypeError("canonical objects may not contain symbol keys");
+    }
+
+    const keys = Object.getOwnPropertyNames(value).sort(compareUtf16CodeUnits);
+    writer.write("{");
+    keys.forEach((key, index) => {
+      assertUnicodeScalarString(key, "canonical object key");
+      const descriptor = Object.getOwnPropertyDescriptor(value, key);
+      if (
+        descriptor === undefined ||
+        !descriptor.enumerable ||
+        !("value" in descriptor)
+      ) {
+        throw new TypeError(
+          "canonical objects require enumerable data properties",
+        );
+      }
+      if (index > 0) writer.write(",");
+      writer.write(JSON.stringify(key));
+      writer.write(":");
+      writeCanonicalValue(
+        writer,
+        descriptor.value,
+        depth + 1,
+        ancestors,
+        nodeBudget,
+      );
+    });
+    writer.write("}");
+  } finally {
+    ancestors.delete(value);
+  }
+}
+
+export function encodeLibraryCoreCanonicalValue(
+  value: LibraryCoreCanonicalValue,
+  options: LibraryCoreCanonicalEncodingOptions = {},
+): Uint8Array {
+  const writer = new BoundedUtf8Writer(normalizedMaximumBytes(options));
+  writeCanonicalValue(writer, value, 0, new Set(), { count: 0 });
+  return writer.finish();
+}
+
+export function encodeLibraryCoreDigestInput(
+  domain: LibraryCoreOperationDigestDomain,
+  value: LibraryCoreCanonicalValue,
+  options: LibraryCoreCanonicalEncodingOptions = {},
+): Uint8Array {
+  if (!LIBRARY_CORE_OPERATION_DIGEST_DOMAINS.includes(domain)) {
+    throw new TypeError(`unregistered Library Core operation domain: ${domain}`);
+  }
+  const prefix = textEncoder.encode(
+    `freed.library-core.v1/digest/${domain}\u0000`,
+  );
+  const maximumBytes = normalizedMaximumBytes(options);
+  if (prefix.byteLength >= maximumBytes) {
+    throw new RangeError("maximumBytes cannot fit the digest domain prefix");
+  }
+  const canonical = encodeLibraryCoreCanonicalValue(value, {
+    maximumBytes: maximumBytes - prefix.byteLength,
+  });
+  const input = new Uint8Array(prefix.byteLength + canonical.byteLength);
+  input.set(prefix);
+  input.set(canonical, prefix.byteLength);
+  return input;
+}
+
+export function encodeLibraryCoreOperationSignatureInput(
+  value: LibraryCoreCanonicalValue,
+  options: LibraryCoreCanonicalEncodingOptions = {},
+): Uint8Array {
+  const prefix = textEncoder.encode(
+    "freed.library-core.v1/signature/operation-envelope\u0000",
+  );
+  const maximumBytes = normalizedMaximumBytes(options);
+  if (prefix.byteLength >= maximumBytes) {
+    throw new RangeError("maximumBytes cannot fit the signature domain prefix");
+  }
+  const canonical = encodeLibraryCoreCanonicalValue(value, {
+    maximumBytes: maximumBytes - prefix.byteLength,
+  });
+  const input = new Uint8Array(prefix.byteLength + canonical.byteLength);
+  input.set(prefix);
+  input.set(canonical, prefix.byteLength);
+  return input;
+}

--- a/packages/shared/src/library-core/canonical-codec.ts
+++ b/packages/shared/src/library-core/canonical-codec.ts
@@ -38,6 +38,7 @@ export interface LibraryCoreCanonicalEncodingOptions {
 }
 
 const textEncoder = new TextEncoder();
+const fatalTextDecoder = new TextDecoder("utf-8", { fatal: true });
 
 function assertUnicodeScalarString(value: string, label: string): void {
   for (let index = 0; index < value.length; index += 1) {
@@ -261,7 +262,9 @@ export function encodeLibraryCoreDigestInput(
   options: LibraryCoreCanonicalEncodingOptions = {},
 ): Uint8Array {
   if (!LIBRARY_CORE_OPERATION_DIGEST_DOMAINS.includes(domain)) {
-    throw new TypeError(`unregistered Library Core operation domain: ${domain}`);
+    throw new TypeError(
+      `unregistered Library Core operation domain: ${domain}`,
+    );
   }
   const prefix = textEncoder.encode(
     `freed.library-core.v1/digest/${domain}\u0000`,
@@ -297,4 +300,293 @@ export function encodeLibraryCoreOperationSignatureInput(
   input.set(prefix);
   input.set(canonical, prefix.byteLength);
   return input;
+}
+
+class CanonicalJsonParser {
+  private index = 0;
+  private nodeCount = 0;
+  private readonly source: string;
+
+  constructor(source: string) {
+    this.source = source;
+  }
+
+  parse(): LibraryCoreCanonicalValue {
+    const value = this.parseValue(0);
+    if (this.index !== this.source.length) {
+      throw new TypeError("canonical JSON contains trailing input");
+    }
+    return value;
+  }
+
+  private countNode(depth: number): void {
+    this.nodeCount += 1;
+    if (this.nodeCount > LIBRARY_CORE_MAX_CANONICAL_NODES) {
+      throw new RangeError(
+        `canonical JSON exceeds ${LIBRARY_CORE_MAX_CANONICAL_NODES.toLocaleString()} nodes`,
+      );
+    }
+    if (depth > LIBRARY_CORE_MAX_CANONICAL_NESTING_DEPTH) {
+      throw new RangeError(
+        `canonical JSON exceeds ${LIBRARY_CORE_MAX_CANONICAL_NESTING_DEPTH.toLocaleString()} nesting levels`,
+      );
+    }
+  }
+
+  private parseValue(depth: number): LibraryCoreCanonicalValue {
+    this.countNode(depth);
+    const token = this.source[this.index];
+    if (token === '"') return this.parseString();
+    if (token === "[") return this.parseArray(depth);
+    if (token === "{") return this.parseObject(depth);
+    if (token === "t") return this.parseKeyword("true", true);
+    if (token === "f") return this.parseKeyword("false", false);
+    if (token === "n") return this.parseKeyword("null", null);
+    if (token === "-" || (token >= "0" && token <= "9")) {
+      return this.parseInteger();
+    }
+    throw new TypeError("canonical JSON contains an invalid value");
+  }
+
+  private parseKeyword<T extends null | boolean>(keyword: string, value: T): T {
+    if (
+      this.source.slice(this.index, this.index + keyword.length) !== keyword
+    ) {
+      throw new TypeError(
+        `canonical JSON contains an invalid ${keyword} token`,
+      );
+    }
+    this.index += keyword.length;
+    return value;
+  }
+
+  private parseInteger(): number {
+    const start = this.index;
+    if (this.source[this.index] === "-") {
+      this.index += 1;
+    }
+    const firstDigit = this.source[this.index];
+    if (firstDigit === "0") {
+      this.index += 1;
+      if (this.isDigit(this.source[this.index])) {
+        throw new TypeError("canonical integers may not contain leading zeros");
+      }
+    } else if (firstDigit >= "1" && firstDigit <= "9") {
+      this.index += 1;
+      while (this.isDigit(this.source[this.index])) this.index += 1;
+    } else {
+      throw new TypeError("canonical JSON contains an invalid integer");
+    }
+    const next = this.source[this.index];
+    if (next === "." || next === "e" || next === "E") {
+      throw new TypeError(
+        "canonical JSON numbers must use the safe-integer codec",
+      );
+    }
+    const lexeme = this.source.slice(start, this.index);
+    if (lexeme === "-0") {
+      throw new TypeError("canonical integers may not be negative zero");
+    }
+    let integer: bigint;
+    try {
+      integer = BigInt(lexeme);
+    } catch {
+      throw new TypeError("canonical JSON contains an invalid integer");
+    }
+    if (
+      integer < BigInt(Number.MIN_SAFE_INTEGER) ||
+      integer > BigInt(Number.MAX_SAFE_INTEGER)
+    ) {
+      throw new TypeError("canonical integer is outside the safe range");
+    }
+    return Number(integer);
+  }
+
+  private isDigit(value: string | undefined): boolean {
+    return value !== undefined && value >= "0" && value <= "9";
+  }
+
+  private parseString(): string {
+    this.index += 1;
+    let result = "";
+    while (this.index < this.source.length) {
+      const codeUnit = this.source.charCodeAt(this.index);
+      if (codeUnit === 0x22) {
+        this.index += 1;
+        return result;
+      }
+      if (codeUnit === 0x5c) {
+        result += this.parseEscape();
+        continue;
+      }
+      if (codeUnit < 0x20) {
+        throw new TypeError(
+          "canonical JSON strings may not contain raw control characters",
+        );
+      }
+      if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
+        const next = this.source.charCodeAt(this.index + 1);
+        if (!(next >= 0xdc00 && next <= 0xdfff)) {
+          throw new TypeError("canonical JSON contains invalid Unicode");
+        }
+        result += this.source.slice(this.index, this.index + 2);
+        this.index += 2;
+        continue;
+      }
+      if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff) {
+        throw new TypeError("canonical JSON contains invalid Unicode");
+      }
+      result += this.source[this.index];
+      this.index += 1;
+    }
+    throw new TypeError("canonical JSON contains an unterminated string");
+  }
+
+  private parseEscape(): string {
+    this.index += 1;
+    const escaped = this.source[this.index];
+    this.index += 1;
+    switch (escaped) {
+      case '"':
+      case "\\":
+      case "/":
+        return escaped;
+      case "b":
+        return "\b";
+      case "f":
+        return "\f";
+      case "n":
+        return "\n";
+      case "r":
+        return "\r";
+      case "t":
+        return "\t";
+      case "u":
+        return this.parseUnicodeEscape();
+      default:
+        throw new TypeError("canonical JSON contains an invalid escape");
+    }
+  }
+
+  private parseUnicodeEscape(): string {
+    const high = this.parseHexCodeUnit();
+    if (high >= 0xd800 && high <= 0xdbff) {
+      if (
+        this.source[this.index] !== "\\" ||
+        this.source[this.index + 1] !== "u"
+      ) {
+        throw new TypeError("canonical JSON contains an unpaired surrogate");
+      }
+      this.index += 2;
+      const low = this.parseHexCodeUnit();
+      if (!(low >= 0xdc00 && low <= 0xdfff)) {
+        throw new TypeError("canonical JSON contains an unpaired surrogate");
+      }
+      return String.fromCodePoint(
+        0x10000 + ((high - 0xd800) << 10) + (low - 0xdc00),
+      );
+    }
+    if (high >= 0xdc00 && high <= 0xdfff) {
+      throw new TypeError("canonical JSON contains an unpaired surrogate");
+    }
+    return String.fromCharCode(high);
+  }
+
+  private parseHexCodeUnit(): number {
+    const hex = this.source.slice(this.index, this.index + 4);
+    if (!/^[0-9a-fA-F]{4}$/.test(hex)) {
+      throw new TypeError("canonical JSON contains an invalid Unicode escape");
+    }
+    this.index += 4;
+    return Number.parseInt(hex, 16);
+  }
+
+  private parseArray(depth: number): readonly LibraryCoreCanonicalValue[] {
+    this.index += 1;
+    const result: LibraryCoreCanonicalValue[] = [];
+    if (this.source[this.index] === "]") {
+      this.index += 1;
+      return Object.freeze(result);
+    }
+    while (true) {
+      result.push(this.parseValue(depth + 1));
+      const separator = this.source[this.index];
+      this.index += 1;
+      if (separator === "]") return Object.freeze(result);
+      if (separator !== ",") {
+        throw new TypeError("canonical JSON array has an invalid separator");
+      }
+    }
+  }
+
+  private parseObject(
+    depth: number,
+  ): Readonly<Record<string, LibraryCoreCanonicalValue>> {
+    this.index += 1;
+    const result: Record<string, LibraryCoreCanonicalValue> =
+      Object.create(null);
+    const keys = new Set<string>();
+    if (this.source[this.index] === "}") {
+      this.index += 1;
+      return Object.freeze(result);
+    }
+    while (true) {
+      if (this.source[this.index] !== '"') {
+        throw new TypeError("canonical JSON object key must be a string");
+      }
+      const key = this.parseString();
+      if (keys.has(key)) {
+        throw new TypeError("canonical JSON contains a duplicate object name");
+      }
+      keys.add(key);
+      if (this.source[this.index] !== ":") {
+        throw new TypeError("canonical JSON object key is missing a colon");
+      }
+      this.index += 1;
+      result[key] = this.parseValue(depth + 1);
+      const separator = this.source[this.index];
+      this.index += 1;
+      if (separator === "}") return Object.freeze(result);
+      if (separator !== ",") {
+        throw new TypeError("canonical JSON object has an invalid separator");
+      }
+    }
+  }
+}
+
+function bytesEqual(left: Uint8Array, right: Uint8Array): boolean {
+  if (left.byteLength !== right.byteLength) return false;
+  for (let index = 0; index < left.byteLength; index += 1) {
+    if (left[index] !== right[index]) return false;
+  }
+  return true;
+}
+
+export function decodeLibraryCoreCanonicalValue(
+  bytes: Uint8Array,
+  options: LibraryCoreCanonicalEncodingOptions = {},
+): LibraryCoreCanonicalValue {
+  if (!(bytes instanceof Uint8Array)) {
+    throw new TypeError("canonical input must be a Uint8Array");
+  }
+  const maximumBytes = normalizedMaximumBytes(options);
+  if (bytes.byteLength > maximumBytes) {
+    throw new RangeError(
+      `canonical input exceeds ${maximumBytes.toLocaleString()} UTF-8 bytes`,
+    );
+  }
+  const snapshot = new Uint8Array(bytes.byteLength);
+  snapshot.set(bytes);
+  let source: string;
+  try {
+    source = fatalTextDecoder.decode(snapshot);
+  } catch {
+    throw new TypeError("canonical input is not valid UTF-8");
+  }
+  const value = new CanonicalJsonParser(source).parse();
+  const canonical = encodeLibraryCoreCanonicalValue(value, { maximumBytes });
+  if (!bytesEqual(snapshot, canonical)) {
+    throw new TypeError("canonical input bytes are not RFC 8785 canonical");
+  }
+  return value;
 }

--- a/packages/shared/src/library-core/canonical-decoder-vectors.json
+++ b/packages/shared/src/library-core/canonical-decoder-vectors.json
@@ -1,0 +1,127 @@
+[
+  {
+    "name": "null",
+    "input": "null",
+    "accepted": true
+  },
+  {
+    "name": "safe integer boundaries",
+    "input": "[-9007199254740991,0,9007199254740991]",
+    "accepted": true
+  },
+  {
+    "name": "sorted object and canonical escapes",
+    "input": "{\"a\":\"line\\nfeed\",\"emoji\":\"😀\",\"z\":true}",
+    "accepted": true
+  },
+  {
+    "name": "empty containers",
+    "input": "[{},[]]",
+    "accepted": true
+  },
+  {
+    "name": "leading whitespace",
+    "input": " null",
+    "accepted": false
+  },
+  {
+    "name": "trailing whitespace",
+    "input": "null\n",
+    "accepted": false
+  },
+  {
+    "name": "noncanonical object order",
+    "input": "{\"z\":1,\"a\":2}",
+    "accepted": false
+  },
+  {
+    "name": "duplicate literal object name",
+    "input": "{\"a\":1,\"a\":2}",
+    "accepted": false
+  },
+  {
+    "name": "duplicate escaped object name",
+    "input": "{\"a\":1,\"\\u0061\":2}",
+    "accepted": false
+  },
+  {
+    "name": "unnecessary slash escape",
+    "input": "\"\\/\"",
+    "accepted": false
+  },
+  {
+    "name": "unnecessary unicode escape",
+    "input": "\"\\u0061\"",
+    "accepted": false
+  },
+  {
+    "name": "noncanonical control escape",
+    "input": "\"\\u000A\"",
+    "accepted": false
+  },
+  {
+    "name": "negative zero",
+    "input": "-0",
+    "accepted": false
+  },
+  {
+    "name": "leading zero",
+    "input": "01",
+    "accepted": false
+  },
+  {
+    "name": "fraction",
+    "input": "0.5",
+    "accepted": false
+  },
+  {
+    "name": "exponent",
+    "input": "1e3",
+    "accepted": false
+  },
+  {
+    "name": "positive unsafe integer",
+    "input": "9007199254740992",
+    "accepted": false
+  },
+  {
+    "name": "negative unsafe integer",
+    "input": "-9007199254740992",
+    "accepted": false
+  },
+  {
+    "name": "invalid escape",
+    "input": "\"\\x20\"",
+    "accepted": false
+  },
+  {
+    "name": "lone high surrogate",
+    "input": "\"\\ud800\"",
+    "accepted": false
+  },
+  {
+    "name": "lone low surrogate",
+    "input": "\"\\udc00\"",
+    "accepted": false
+  },
+  {
+    "name": "raw control character",
+    "input": "\"\u0001\"",
+    "accepted": false
+  },
+  {
+    "name": "trailing comma",
+    "input": "[null,]",
+    "accepted": false
+  },
+  {
+    "name": "missing comma",
+    "input": "[null true]",
+    "accepted": false
+  },
+  {
+    "name": "trailing value",
+    "input": "nulltrue",
+    "accepted": false
+  }
+]

--- a/packages/shared/src/library-core/index.ts
+++ b/packages/shared/src/library-core/index.ts
@@ -3,5 +3,6 @@ export * from "./field-registry.js";
 export * from "./local-authority-registry.js";
 export * from "./operation-registry.js";
 export * from "./protocol-registry.js";
+export * from "./protocol-scalars.js";
 export * from "./query-registry.js";
 export * from "./store-surface-registry.js";

--- a/packages/shared/src/library-core/legacy-epoch-bootstrap-contract.ts
+++ b/packages/shared/src/library-core/legacy-epoch-bootstrap-contract.ts
@@ -11,16 +11,17 @@
  * write storage, activate Library Core, or perform platform cryptography.
  */
 
-declare const lowercaseHex64Brand: unique symbol;
-declare const operationIdBrand: unique symbol;
+import {
+  isLibraryCoreLowercaseHex64 as isLowercaseHex64,
+  isLibraryCoreNonnegativeSafeInteger as isNonnegativeSafeInteger,
+  isLibraryCoreOperationInstanceId as isOperationId,
+  type LibraryCoreLowercaseHex64,
+  type LibraryCoreOperationInstanceId,
+} from "./protocol-scalars.js";
 
-export type LibraryCoreLowercaseHex64 = string & {
-  readonly [lowercaseHex64Brand]: true;
-};
+export type { LibraryCoreLowercaseHex64 } from "./protocol-scalars.js";
 
-export type LegacyEpochBootstrapOperationId = string & {
-  readonly [operationIdBrand]: true;
-};
+export type LegacyEpochBootstrapOperationId = LibraryCoreOperationInstanceId;
 
 export const LEGACY_EPOCH_BOOTSTRAP_MAX_HEADS = 65;
 export const LEGACY_EPOCH_BOOTSTRAP_MAX_RECORD_OCCURRENCES = 65;
@@ -210,9 +211,6 @@ export interface LegacyEpochBootstrapStateInput {
   readonly library_control: unknown | null;
 }
 
-const HEX_64 = /^[0-9a-f]{64}$/;
-const OPERATION_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
-
 const HEADS_KEYS = ["heads"] as const;
 const RECORD_BODY_KEYS = [
   "format",
@@ -398,16 +396,6 @@ function snapshotArray(
   return success(Object.freeze(snapshot));
 }
 
-function isLowercaseHex64(value: unknown): value is LibraryCoreLowercaseHex64 {
-  return typeof value === "string" && HEX_64.test(value);
-}
-
-function isOperationId(
-  value: unknown,
-): value is LegacyEpochBootstrapOperationId {
-  return typeof value === "string" && OPERATION_ID.test(value);
-}
-
 function isBootstrapRecordRootKey(value: unknown): value is string {
   return (
     typeof value === "string" &&
@@ -415,15 +403,6 @@ function isBootstrapRecordRootKey(value: unknown): value is string {
     isLowercaseHex64(
       value.slice(LEGACY_EPOCH_BOOTSTRAP_RECORD_ROOT_PREFIX.length),
     )
-  );
-}
-
-function isNonnegativeSafeInteger(value: unknown): value is number {
-  return (
-    typeof value === "number" &&
-    Number.isSafeInteger(value) &&
-    value >= 0 &&
-    !Object.is(value, -0)
   );
 }
 

--- a/packages/shared/src/library-core/protocol-scalars.test.ts
+++ b/packages/shared/src/library-core/protocol-scalars.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  LIBRARY_CORE_ENTITY_ID_CODEC_V1,
+  LIBRARY_CORE_MAX_ENTITY_ID_UTF8_BYTES,
+  isLibraryCoreLowercaseHex64,
+  isLibraryCoreNonnegativeSafeInteger,
+  isLibraryCoreOperationInstanceId,
+} from "./protocol-scalars.js";
+
+describe("Library Core protocol scalar codecs", () => {
+  it("accepts only exact lowercase fixed-width hexadecimal strings", () => {
+    const hex64 = "ab".repeat(32);
+
+    expect(isLibraryCoreLowercaseHex64(hex64)).toBe(true);
+    for (const invalid of [
+      "",
+      "a".repeat(63),
+      "a".repeat(65),
+      "A".repeat(64),
+      "g".repeat(64),
+      `${hex64} `,
+      new Uint8Array(64),
+    ]) {
+      expect(isLibraryCoreLowercaseHex64(invalid)).toBe(false);
+    }
+  });
+
+  it("enforces the bounded ASCII operation-instance ID codec", () => {
+    expect(isLibraryCoreOperationInstanceId("a")).toBe(true);
+    expect(isLibraryCoreOperationInstanceId(`a${"b".repeat(127)}`)).toBe(true);
+
+    for (const invalid of [
+      "",
+      ".starts-with-punctuation",
+      "a".repeat(129),
+      "contains space",
+      "contains/slash",
+      "unicode-😀",
+      42,
+    ]) {
+      expect(isLibraryCoreOperationInstanceId(invalid)).toBe(false);
+    }
+  });
+
+  it("accepts only nonempty Unicode-scalar entity IDs within 4,096 UTF-8 bytes", () => {
+    expect(LIBRARY_CORE_MAX_ENTITY_ID_UTF8_BYTES).toBe(4_096);
+    expect(LIBRARY_CORE_ENTITY_ID_CODEC_V1).toMatchObject({
+      codecId: "library_core_entity_id_v1",
+      codecVersion: 1,
+      maximumUtf8Bytes: 4_096,
+    });
+    expect(Object.isFrozen(LIBRARY_CORE_ENTITY_ID_CODEC_V1)).toBe(true);
+    for (const accepted of [
+      "x:1",
+      "rss:https://example.com/你好",
+      "😀".repeat(1_024),
+      "a".repeat(4_096),
+    ]) {
+      expect(LIBRARY_CORE_ENTITY_ID_CODEC_V1.validate(accepted)).toBe(true);
+    }
+
+    for (const invalid of [
+      "",
+      "a".repeat(4_097),
+      `${"😀".repeat(1_024)}a`,
+      "\ud800",
+      "\udc00",
+      `valid\ud800invalid`,
+      42,
+      new Uint8Array([1]),
+    ]) {
+      expect(LIBRARY_CORE_ENTITY_ID_CODEC_V1.validate(invalid)).toBe(false);
+    }
+  });
+
+  it("accepts only nonnegative safe integers and rejects negative zero", () => {
+    for (const accepted of [0, 1, Number.MAX_SAFE_INTEGER]) {
+      expect(isLibraryCoreNonnegativeSafeInteger(accepted)).toBe(true);
+    }
+    for (const invalid of [
+      -0,
+      -1,
+      0.5,
+      Number.MAX_SAFE_INTEGER + 1,
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      "1",
+      1n,
+    ]) {
+      expect(isLibraryCoreNonnegativeSafeInteger(invalid)).toBe(false);
+    }
+  });
+});

--- a/packages/shared/src/library-core/protocol-scalars.ts
+++ b/packages/shared/src/library-core/protocol-scalars.ts
@@ -1,0 +1,99 @@
+/**
+ * Exact scalar codecs shared by dormant Library Core protocol validators.
+ *
+ * These predicates establish syntax and numeric bounds only. They do not prove
+ * randomness, cryptographic derivation, authority, or semantic ownership.
+ */
+
+declare const lowercaseHex64Brand: unique symbol;
+declare const entityIdBrand: unique symbol;
+declare const operationInstanceIdBrand: unique symbol;
+
+export type LibraryCoreLowercaseHex64 = string & {
+  readonly [lowercaseHex64Brand]: true;
+};
+
+export type LibraryCoreEntityId = string & {
+  readonly [entityIdBrand]: true;
+};
+
+export type LibraryCoreOperationInstanceId = string & {
+  readonly [operationInstanceIdBrand]: true;
+};
+
+export const LIBRARY_CORE_MAX_ENTITY_ID_UTF8_BYTES = 4_096;
+
+export interface LibraryCoreEntityIdCodec {
+  readonly codecId: "library_core_entity_id_v1";
+  readonly codecVersion: 1;
+  readonly maximumUtf8Bytes: 4_096;
+  readonly validate: (value: unknown) => value is LibraryCoreEntityId;
+}
+
+const LOWERCASE_HEX_64 = /^[0-9a-f]{64}$/;
+const OPERATION_INSTANCE_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+
+export function isLibraryCoreLowercaseHex64(
+  value: unknown,
+): value is LibraryCoreLowercaseHex64 {
+  return typeof value === "string" && LOWERCASE_HEX_64.test(value);
+}
+
+/**
+ * Accept the exact bounded entity-key string used by dormant operation
+ * schemas. The manual UTF-8 count avoids allocating a second encoded copy and
+ * rejects lone UTF-16 surrogates instead of silently replacing them.
+ */
+export function isLibraryCoreEntityId(
+  value: unknown,
+): value is LibraryCoreEntityId {
+  if (typeof value !== "string" || value.length === 0) return false;
+
+  let utf8Bytes = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    const codeUnit = value.charCodeAt(index);
+    if (codeUnit <= 0x7f) {
+      utf8Bytes += 1;
+    } else if (codeUnit <= 0x7ff) {
+      utf8Bytes += 2;
+    } else if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
+      if (index + 1 >= value.length) return false;
+      const trailing = value.charCodeAt(index + 1);
+      if (trailing < 0xdc00 || trailing > 0xdfff) return false;
+      utf8Bytes += 4;
+      index += 1;
+    } else if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff) {
+      return false;
+    } else {
+      utf8Bytes += 3;
+    }
+
+    if (utf8Bytes > LIBRARY_CORE_MAX_ENTITY_ID_UTF8_BYTES) return false;
+  }
+
+  return true;
+}
+
+export const LIBRARY_CORE_ENTITY_ID_CODEC_V1 = Object.freeze({
+  codecId: "library_core_entity_id_v1",
+  codecVersion: 1,
+  maximumUtf8Bytes: LIBRARY_CORE_MAX_ENTITY_ID_UTF8_BYTES,
+  validate: isLibraryCoreEntityId,
+}) satisfies LibraryCoreEntityIdCodec;
+
+export function isLibraryCoreOperationInstanceId(
+  value: unknown,
+): value is LibraryCoreOperationInstanceId {
+  return typeof value === "string" && OPERATION_INSTANCE_ID.test(value);
+}
+
+export function isLibraryCoreNonnegativeSafeInteger(
+  value: unknown,
+): value is number {
+  return (
+    typeof value === "number" &&
+    Number.isSafeInteger(value) &&
+    value >= 0 &&
+    !Object.is(value, -0)
+  );
+}


### PR DESCRIPTION
(AI Generated).

## Summary
- Add bounded cross-runtime canonical construction encoding and duplicate-preserving inbound decoding
- Centralize exact Library Core protocol scalar and entity-ID predicates
- Keep the codec dormant with no runtime caller, persistence authority, or provider behavior

## Testing
- npm run validate:feature

## Provider Review
- Status: Provider authority is validated for ready publication.
- Review action: none required. The provider-risk artifact records the behavior authority decision; this exact provider subdiff is the audit subject.
- Provider subdiff: `bd54e7172f35c7d396018cce02bf371b50c16731`
- Publication does not authorize new live provider traffic. Gate 1 behavior approval still applies when observable behavior changes.
- Provider review task: `library-core-canonical-codec`
- Provider review decision: `diff_authorized`
- Provider review artifact: `f971fe6b1e9c96366221741bcb139c8652f8e136cd91e91c87e7a50f927d5d71`
- Providers: facebook, instagram, linkedin, medium, other, substack, x, youtube
- Observable behavior: No provider-observable behavior changes. The native monolith only registers a dormant canonical codec module with no command, runtime caller, request, navigation, extraction, cookie, header, retry, or cadence change.
- Fingerprinting risk: None from this change because the codec remains dark and cannot contact a provider.
- Lowest profile alternative: Keep the codec dormant until the later Library Core activation gate, which is the implemented state.

Files bound into this provider review:
- `packages/desktop/src-tauri/src/lib.rs`