### PR TITLE
feat: materialize Library Core read assignments

### DIFF
--- a/.agents/skills/freed-library-core/SKILL.md
+++ b/.agents/skills/freed-library-core/SKILL.md
@@ -212,6 +212,14 @@ allocate encoded copies merely to count a bounded entity ID. Scalar syntax does
 not prove randomness, cryptographic derivation, authority, or semantic
 ownership.
 
+Closing one operation payload or entity-ID schema does not close the operation.
+Keep entity existence, touched fields, field algebra, materialization, provider
+intent, and runtime authority independently blocked until each has an
+executable contract. Every operation without an exact entity-key binding keeps
+the typed `entity_id_schema_unresolved` blocker. The initial
+`feed_item_read_assignment` payload is local read-state syntax only. It never
+authorizes or schedules a provider-visible seen action.
+
 ## Preserve the invariants
 
 1. Keep exactly one active writer epoch. Advance it only with a signed immutable

--- a/.agents/skills/freed-library-core/SKILL.md
+++ b/.agents/skills/freed-library-core/SKILL.md
@@ -219,8 +219,10 @@ executable contract. Every operation without an exact entity-key binding keeps
 the typed `entity_id_schema_unresolved` blocker. Bind touched fields by their
 exact field-registry keys and keep `touched_fields_unresolved` until the full
 set is closed. The initial `feed_item_read_assignment` payload is local
-read-state syntax only. It never authorizes or schedules a provider-visible
-seen action.
+read-state syntax only. Its `readAt` algebra treats absence as unread and
+retains the earliest valid assignment under duplicate, reordered, or
+concurrent delivery. It never authorizes or schedules a provider-visible seen
+action.
 
 ## Preserve the invariants
 

--- a/.agents/skills/freed-library-core/SKILL.md
+++ b/.agents/skills/freed-library-core/SKILL.md
@@ -182,6 +182,14 @@ may compile into Freed Desktop behind an explicit dark-module boundary. A
 command registration, startup open, backfill, read route, or writer route is an
 activation change and follows the corresponding gate.
 
+When a closed field operation reaches the dark projection, update only its
+registered columns. Do not rebuild or overwrite the full row. Validate current
+projected state, apply the shared field algebra, advance the projection
+revision, and commit the derived receipt in one transaction. Missing entities,
+malformed current values, stale revisions, and receipt failures roll back
+without repair. This derived path does not satisfy the authoritative operation
+materializer blocker.
+
 ## Keep canonical operation bytes honest
 
 Use the shared cross-runtime vectors for every canonical construction change.

--- a/.agents/skills/freed-library-core/SKILL.md
+++ b/.agents/skills/freed-library-core/SKILL.md
@@ -216,9 +216,11 @@ Closing one operation payload or entity-ID schema does not close the operation.
 Keep entity existence, touched fields, field algebra, materialization, provider
 intent, and runtime authority independently blocked until each has an
 executable contract. Every operation without an exact entity-key binding keeps
-the typed `entity_id_schema_unresolved` blocker. The initial
-`feed_item_read_assignment` payload is local read-state syntax only. It never
-authorizes or schedules a provider-visible seen action.
+the typed `entity_id_schema_unresolved` blocker. Bind touched fields by their
+exact field-registry keys and keep `touched_fields_unresolved` until the full
+set is closed. The initial `feed_item_read_assignment` payload is local
+read-state syntax only. It never authorizes or schedules a provider-visible
+seen action.
 
 ## Preserve the invariants
 

--- a/docs/LIBRARY-CORE-CONTRACT.md
+++ b/docs/LIBRARY-CORE-CONTRACT.md
@@ -499,10 +499,12 @@ non-data fields are invalid. Validation returns an immutable snapshot rather
 than retaining the caller's object. The operation registry also binds this
 operation to the shared v1 entity-ID codec. Every other dormant operation
 retains a typed `entity_id_schema_unresolved` blocker until its exact key syntax
-is bound. These schemas close payload and entity-key syntax only. Entity
-existence, touched-field registry binding, field algebra, SQLite materializer,
-provider-intent separation, and runtime authority remain blocked. The payload
-does not itself schedule or authorize a provider-visible seen action.
+is bound. The read assignment also binds its sole touched field to
+`library-core-v1:feedItems.{globalId}.userState.readAt`. These contracts close
+payload syntax, entity-key syntax, and the touched-field set only. Entity
+existence, field algebra, SQLite materializer, provider-intent separation, and
+runtime authority remain blocked. The payload does not itself schedule or
+authorize a provider-visible seen action.
 
 Canonical sets use their field-specific sort before `C`. `causal_frontier`
 sorts ascending by `(actor_id, sequence, operation_id, chain_digest)`,

--- a/docs/LIBRARY-CORE-CONTRACT.md
+++ b/docs/LIBRARY-CORE-CONTRACT.md
@@ -502,9 +502,13 @@ retains a typed `entity_id_schema_unresolved` blocker until its exact key syntax
 is bound. The read assignment also binds its sole touched field to
 `library-core-v1:feedItems.{globalId}.userState.readAt`. These contracts close
 payload syntax, entity-key syntax, and the touched-field set only. Entity
-existence, field algebra, SQLite materializer, provider-intent separation, and
-runtime authority remain blocked. The payload does not itself schedule or
-authorize a provider-visible seen action.
+existence, SQLite materializer, provider-intent separation, and runtime
+authority remain blocked. `readAt` uses the executable
+`minimum_present_nonnegative_safe_integer_v1` algebra: absence means unread,
+the first assignment establishes the value, and duplicate, reordered, or
+concurrent assignments retain the earliest valid timestamp. Invalid current or
+incoming values fail closed. The payload does not itself schedule or authorize
+a provider-visible seen action.
 
 Canonical sets use their field-specific sort before `C`. `causal_frontier`
 sorts ascending by `(actor_id, sequence, operation_id, chain_digest)`,

--- a/docs/LIBRARY-CORE-CONTRACT.md
+++ b/docs/LIBRARY-CORE-CONTRACT.md
@@ -492,6 +492,18 @@ numeric interpretation. Passing a scalar predicate proves only the encoded
 shape. Randomness, digest derivation, signature validity, authority, and
 field-specific semantics remain separate checks.
 
+The v1 `feed_item_read_assignment` payload schema is the exact closed object
+`{ read_at_ms }`. `read_at_ms` is a nonnegative safe integer, including zero
+and excluding negative zero. Unknown, missing, accessor, symbol, inherited, or
+non-data fields are invalid. Validation returns an immutable snapshot rather
+than retaining the caller's object. The operation registry also binds this
+operation to the shared v1 entity-ID codec. Every other dormant operation
+retains a typed `entity_id_schema_unresolved` blocker until its exact key syntax
+is bound. These schemas close payload and entity-key syntax only. Entity
+existence, touched-field registry binding, field algebra, SQLite materializer,
+provider-intent separation, and runtime authority remain blocked. The payload
+does not itself schedule or authorize a provider-visible seen action.
+
 Canonical sets use their field-specific sort before `C`. `causal_frontier`
 sorts ascending by `(actor_id, sequence, operation_id, chain_digest)`,
 comparing numeric sequence numerically and the remaining ASCII identifiers

--- a/docs/LIBRARY-CORE-CONTRACT.md
+++ b/docs/LIBRARY-CORE-CONTRACT.md
@@ -510,6 +510,17 @@ concurrent assignments retain the earliest valid timestamp. Invalid current or
 incoming values fail closed. The payload does not itself schedule or authorize
 a provider-visible seen action.
 
+The dark native projection may apply a validated read assignment through one
+column-local SQLite update. It reads and validates the current projected
+`readAt`, applies the same minimum-present algebra, updates only `readAt`,
+advances the projection revision, and writes the existing derived projection
+batch receipt in one immediate transaction. A missing entity, malformed current
+value, stale revision, changed replay tuple, or receipt failure rolls back
+without widening the update to a full row. Exact response-loss retry returns
+the original projection receipt. This is still derived projection maintenance.
+It stores no authoritative operation, grants no write authority, and has no
+production caller.
+
 Canonical sets use their field-specific sort before `C`. `causal_frontier`
 sorts ascending by `(actor_id, sequence, operation_id, chain_digest)`,
 comparing numeric sequence numerically and the remaining ASCII identifiers

--- a/docs/PHASE-4-SYNC.md
+++ b/docs/PHASE-4-SYNC.md
@@ -311,6 +311,7 @@ recovery, telemetry, milestones, and acceptance tests.
 | 4.27 | Shared exact protocol scalar predicates, including bounded entity IDs, reused by legacy bootstrap and future closed-schema validators | ✓ | Low |
 | 4.28 | Closed immutable `feed_item_read_assignment` payload syntax without materializer, provider action, or runtime activation | ✓ | Low |
 | 4.29 | Typed entity-ID blocker for every dormant operation and exact v1 entity-key binding for `feed_item_read_assignment` | ✓ | Low |
+| 4.30 | Exact `feed_item_read_assignment` touched-field binding without claiming merge algebra or write authority | ✓ | Low |
 
 ---
 

--- a/docs/PHASE-4-SYNC.md
+++ b/docs/PHASE-4-SYNC.md
@@ -312,6 +312,7 @@ recovery, telemetry, milestones, and acceptance tests.
 | 4.28 | Closed immutable `feed_item_read_assignment` payload syntax without materializer, provider action, or runtime activation | ✓ | Low |
 | 4.29 | Typed entity-ID blocker for every dormant operation and exact v1 entity-key binding for `feed_item_read_assignment` | ✓ | Low |
 | 4.30 | Exact `feed_item_read_assignment` touched-field binding without claiming merge algebra or write authority | ✓ | Low |
+| 4.31 | Executable minimum-present `readAt` merge algebra shared by the operation and field registries | ✓ | Low |
 
 ---
 

--- a/docs/PHASE-4-SYNC.md
+++ b/docs/PHASE-4-SYNC.md
@@ -309,6 +309,8 @@ recovery, telemetry, milestones, and acceptance tests.
 | 4.25 | Bounded cross-runtime canonical operation construction codec and domain-separated input vectors | ✓ | Medium |
 | 4.26 | Bounded duplicate-preserving shared and native canonical-value decoders with exact byte rejection vectors | ✓ | Medium |
 | 4.27 | Shared exact protocol scalar predicates, including bounded entity IDs, reused by legacy bootstrap and future closed-schema validators | ✓ | Low |
+| 4.28 | Closed immutable `feed_item_read_assignment` payload syntax without materializer, provider action, or runtime activation | ✓ | Low |
+| 4.29 | Typed entity-ID blocker for every dormant operation and exact v1 entity-key binding for `feed_item_read_assignment` | ✓ | Low |
 
 ---
 

--- a/docs/PHASE-4-SYNC.md
+++ b/docs/PHASE-4-SYNC.md
@@ -313,6 +313,7 @@ recovery, telemetry, milestones, and acceptance tests.
 | 4.29 | Typed entity-ID blocker for every dormant operation and exact v1 entity-key binding for `feed_item_read_assignment` | ✓ | Low |
 | 4.30 | Exact `feed_item_read_assignment` touched-field binding without claiming merge algebra or write authority | ✓ | Low |
 | 4.31 | Executable minimum-present `readAt` merge algebra shared by the operation and field registries | ✓ | Low |
+| 4.32 | Crash-safe column-local SQLite read-assignment projection with exact derived receipt retry and no runtime caller | ✓ | Medium |
 
 ---
 

--- a/packages/desktop/src-tauri/src/shadow_store.rs
+++ b/packages/desktop/src-tauri/src/shadow_store.rs
@@ -35,6 +35,8 @@ const MAX_FEED_PAGE_LIMIT: u32 = 128;
 const MAX_PROJECTION_BATCH_ID_BYTES: usize = 128;
 const MAX_PROJECTION_BATCH_ITEMS: usize = 1_000;
 const MAX_PROJECTION_BATCH_BYTES: usize = 4 * 1024 * 1024;
+const MAX_ENTITY_ID_UTF8_BYTES: usize = 4_096;
+const MAX_JAVASCRIPT_SAFE_INTEGER: i64 = 9_007_199_254_740_991;
 const BUSY_TIMEOUT: Duration = Duration::from_secs(5);
 const BASE_CACHE_KIB: i64 = -32 * 1024;
 
@@ -46,6 +48,8 @@ enum ShadowStoreError {
     InvalidProjectionBatchIdentity { field: &'static str },
     InvalidProjectionBatchSize { requested: usize, maximum: usize },
     InvalidProjectionBatchBytes { requested: usize, maximum: usize },
+    InvalidReadAssignment { field: &'static str },
+    ProjectionEntityNotFound { entity_id: String },
     ProjectionBatchReplayConflict { batch_id: String },
     UnsupportedSchemaVersion { expected: i64, actual: i64 },
     UnversionedSchemaPresent,
@@ -66,6 +70,8 @@ const SHADOW_SCHEMA_V1_SQL: &str =
     include_str!("../../../shared/src/library-core/shadow-schema-v1.sql");
 const SHADOW_SCHEMA_V2_SQL: &str =
     include_str!("../../../shared/src/library-core/shadow-schema-v2.sql");
+const READ_ASSIGNMENT_PROJECTION_V1_SQL: &str =
+    include_str!("../../../shared/src/library-core/read-assignment-projection-v1.sql");
 
 /// Sort position for an item whose `publishedAt` is absent or unusable.
 ///
@@ -369,6 +375,64 @@ impl ShadowStore {
             .optional()
     }
 
+    fn begin_projection_batch_in(
+        transaction: &Transaction<'_>,
+        batch_id: &str,
+        input_digest: &str,
+        expected_revision: i64,
+    ) -> StoreResult<Option<ProjectionCommit>> {
+        if let Some(receipt) = Self::projection_receipt_in(transaction, batch_id)? {
+            if receipt.input_digest == input_digest
+                && receipt.previous_revision == expected_revision
+            {
+                return Ok(Some(receipt));
+            }
+            return Err(ShadowStoreError::ProjectionBatchReplayConflict {
+                batch_id: batch_id.to_string(),
+            });
+        }
+        let actual_revision = Self::revision_in(transaction)?;
+        if actual_revision != expected_revision {
+            return Err(ShadowStoreError::StaleRevision {
+                expected: expected_revision,
+                actual: actual_revision,
+            });
+        }
+        Ok(None)
+    }
+
+    fn finish_projection_batch_in(
+        transaction: &Transaction<'_>,
+        batch_id: &str,
+        input_digest: &str,
+        expected_revision: i64,
+        upserted: usize,
+        deleted: usize,
+    ) -> StoreResult<ProjectionCommit> {
+        transaction.execute(ADVANCE_REVISION_SQL, [])?;
+        let revision = Self::revision_in(transaction)?;
+        transaction.execute(
+            "INSERT INTO projection_batches (batchId, inputDigest, previousRevision, \
+             committedRevision, upserted, deleted) VALUES (?1, ?2, ?3, ?4, ?5, ?6);",
+            params![
+                batch_id,
+                input_digest,
+                expected_revision,
+                revision,
+                upserted as i64,
+                deleted as i64,
+            ],
+        )?;
+        Ok(ProjectionCommit {
+            batch_id: batch_id.to_string(),
+            input_digest: input_digest.to_string(),
+            previous_revision: expected_revision,
+            revision,
+            upserted,
+            deleted,
+        })
+    }
+
     /// Applies one projection delta, advances its revision, and records its
     /// durable retry receipt in the same transaction.
     ///
@@ -412,23 +476,11 @@ impl ShadowStore {
         let tx: Transaction<'_> = self
             .conn
             .transaction_with_behavior(TransactionBehavior::Immediate)?;
-        if let Some(receipt) = Self::projection_receipt_in(&tx, batch_id)? {
-            if receipt.input_digest == input_digest
-                && receipt.previous_revision == expected_revision
-            {
-                tx.commit()?;
-                return Ok(receipt);
-            }
-            return Err(ShadowStoreError::ProjectionBatchReplayConflict {
-                batch_id: batch_id.to_string(),
-            });
-        }
-        let actual_revision = Self::revision_in(&tx)?;
-        if actual_revision != expected_revision {
-            return Err(ShadowStoreError::StaleRevision {
-                expected: expected_revision,
-                actual: actual_revision,
-            });
+        if let Some(receipt) =
+            Self::begin_projection_batch_in(&tx, batch_id, input_digest, expected_revision)?
+        {
+            tx.commit()?;
+            return Ok(receipt);
         }
         {
             let mut statement = tx.prepare_cached(UPSERT_SQL)?;
@@ -464,29 +516,85 @@ impl ShadowStore {
                 deleted += statement.execute(params![global_id])?;
             }
         }
-        tx.execute(ADVANCE_REVISION_SQL, [])?;
-        let revision = Self::revision_in(&tx)?;
-        tx.execute(
-            "INSERT INTO projection_batches (batchId, inputDigest, previousRevision, \
-             committedRevision, upserted, deleted) VALUES (?1, ?2, ?3, ?4, ?5, ?6);",
-            params![
-                batch_id,
-                input_digest,
-                expected_revision,
-                revision,
-                rows.len() as i64,
-                deleted as i64,
-            ],
+        let commit = Self::finish_projection_batch_in(
+            &tx,
+            batch_id,
+            input_digest,
+            expected_revision,
+            rows.len(),
+            deleted,
         )?;
         tx.commit()?;
-        Ok(ProjectionCommit {
-            batch_id: batch_id.to_string(),
-            input_digest: input_digest.to_string(),
-            previous_revision: expected_revision,
-            revision,
-            upserted: rows.len(),
-            deleted,
-        })
+        Ok(commit)
+    }
+
+    /// Applies one already validated local read assignment to the dark derived
+    /// projection without reconstructing or rewriting the rest of the item.
+    ///
+    /// This reuses projection-batch receipts for exact response-loss retry. It
+    /// remains derived-store bookkeeping, not an authoritative operation
+    /// receipt, and has no production caller.
+    fn apply_read_assignment_projection_batch(
+        &mut self,
+        batch_id: &str,
+        input_digest: &str,
+        expected_revision: i64,
+        entity_id: &str,
+        incoming_read_at: i64,
+    ) -> StoreResult<ProjectionCommit> {
+        Self::validate_projection_batch_identity(batch_id, input_digest)?;
+        if entity_id.is_empty() || entity_id.len() > MAX_ENTITY_ID_UTF8_BYTES {
+            return Err(ShadowStoreError::InvalidReadAssignment { field: "entity_id" });
+        }
+        if !(0..=MAX_JAVASCRIPT_SAFE_INTEGER).contains(&incoming_read_at) {
+            return Err(ShadowStoreError::InvalidReadAssignment {
+                field: "read_at_ms",
+            });
+        }
+
+        let tx = self
+            .conn
+            .transaction_with_behavior(TransactionBehavior::Immediate)?;
+        if let Some(receipt) =
+            Self::begin_projection_batch_in(&tx, batch_id, input_digest, expected_revision)?
+        {
+            tx.commit()?;
+            return Ok(receipt);
+        }
+
+        let current_read_at = tx
+            .query_row(
+                "SELECT readAt FROM feed_items WHERE globalId = ?1;",
+                params![entity_id],
+                |row| row.get::<_, Option<i64>>(0),
+            )
+            .optional()?
+            .ok_or_else(|| ShadowStoreError::ProjectionEntityNotFound {
+                entity_id: entity_id.to_string(),
+            })?;
+        if current_read_at.is_some_and(|value| !(0..=MAX_JAVASCRIPT_SAFE_INTEGER).contains(&value))
+        {
+            return Err(ShadowStoreError::InvalidReadAssignment {
+                field: "current_read_at",
+            });
+        }
+        let next_read_at = current_read_at
+            .map(|current| current.min(incoming_read_at))
+            .unwrap_or(incoming_read_at);
+        let updated = tx.execute(
+            READ_ASSIGNMENT_PROJECTION_V1_SQL,
+            params![entity_id, next_read_at],
+        )?;
+        if updated != 1 {
+            return Err(ShadowStoreError::ProjectionEntityNotFound {
+                entity_id: entity_id.to_string(),
+            });
+        }
+
+        let commit =
+            Self::finish_projection_batch_in(&tx, batch_id, input_digest, expected_revision, 1, 0)?;
+        tx.commit()?;
+        Ok(commit)
     }
 
     /// Reads one bounded page of the timeline.
@@ -1093,10 +1201,290 @@ mod tests {
             rows.len() as i64
         );
 
+        let read_entity_id = rows[0].global_id.clone();
+        let original_read = reopened
+            .apply_read_assignment_projection_batch(
+                "stable-read",
+                &digest(44),
+                1,
+                &read_entity_id,
+                25,
+            )
+            .expect("commit read before response loss");
+        drop(reopened);
+        let mut reopened = ShadowStore::open(&path).expect("reopen read receipt");
+        let retried_read = reopened
+            .apply_read_assignment_projection_batch(
+                "stable-read",
+                &digest(44),
+                1,
+                &read_entity_id,
+                25,
+            )
+            .expect("read durable read receipt");
+        assert_eq!(retried_read, original_read);
+        assert_eq!(
+            reopened
+                .feed_page(None, 128)
+                .expect("read projected page")
+                .rows
+                .into_iter()
+                .find(|row| row.global_id == read_entity_id)
+                .expect("read entity")
+                .read_at,
+            Some(25)
+        );
+        for (input_digest, expected_revision) in [(digest(45), 1), (digest(44), 2)] {
+            assert!(matches!(
+                reopened
+                    .apply_read_assignment_projection_batch(
+                        "stable-read",
+                        &input_digest,
+                        expected_revision,
+                        &read_entity_id,
+                        25,
+                    )
+                    .expect_err("changed read replay tuple must fail"),
+                ShadowStoreError::ProjectionBatchReplayConflict { .. }
+            ));
+        }
         drop(reopened);
         for suffix in ["", "-wal", "-shm"] {
             let _ = std::fs::remove_file(format!("{}{suffix}", path.display()));
         }
+    }
+
+    #[test]
+    fn read_assignment_updates_only_read_at_and_retries_exactly() {
+        let mut store = seeded(1);
+        let before = store
+            .feed_page(None, 1)
+            .expect("read before assignment")
+            .rows
+            .into_iter()
+            .next()
+            .expect("seeded row");
+
+        let first = store
+            .apply_read_assignment_projection_batch(
+                "read-first",
+                &digest(50),
+                1,
+                &before.global_id,
+                30,
+            )
+            .expect("first read assignment");
+        assert_eq!(
+            first,
+            ProjectionCommit {
+                batch_id: "read-first".to_string(),
+                input_digest: digest(50),
+                previous_revision: 1,
+                revision: 2,
+                upserted: 1,
+                deleted: 0,
+            }
+        );
+        let after_first = store
+            .feed_page(None, 1)
+            .expect("read after assignment")
+            .rows
+            .into_iter()
+            .next()
+            .expect("materialized row");
+        let mut expected = before.clone();
+        expected.read_at = Some(30);
+        assert_eq!(after_first, expected, "no other column may be rewritten");
+
+        let retried = store
+            .apply_read_assignment_projection_batch(
+                "read-first",
+                &digest(50),
+                1,
+                &before.global_id,
+                30,
+            )
+            .expect("response-loss retry");
+        assert_eq!(retried, first);
+
+        let later = store
+            .apply_read_assignment_projection_batch(
+                "read-later",
+                &digest(51),
+                2,
+                &before.global_id,
+                40,
+            )
+            .expect("later assignment");
+        assert_eq!(later.revision, 3);
+        assert_eq!(
+            store
+                .feed_page(None, 1)
+                .expect("read after later assignment")
+                .rows[0]
+                .read_at,
+            Some(30),
+            "the earliest assignment must survive"
+        );
+
+        let earlier = store
+            .apply_read_assignment_projection_batch(
+                "read-earlier",
+                &digest(52),
+                3,
+                &before.global_id,
+                20,
+            )
+            .expect("earlier assignment");
+        assert_eq!(earlier.revision, 4);
+        assert_eq!(
+            store
+                .feed_page(None, 1)
+                .expect("read after earlier assignment")
+                .rows[0]
+                .read_at,
+            Some(20)
+        );
+    }
+
+    #[test]
+    fn read_assignment_rejects_invalid_or_missing_projection_state() {
+        let mut store = seeded(1);
+        let entity_id = store.feed_page(None, 1).expect("seed page").rows[0]
+            .global_id
+            .clone();
+        let oversized_entity_id = "a".repeat(MAX_ENTITY_ID_UTF8_BYTES + 1);
+
+        for (batch_id, candidate_entity_id, read_at, field) in [
+            ("empty-entity", "", 1, "entity_id"),
+            (
+                "oversized-entity",
+                oversized_entity_id.as_str(),
+                1,
+                "entity_id",
+            ),
+            ("negative-read", entity_id.as_str(), -1, "read_at_ms"),
+            (
+                "unsafe-read",
+                entity_id.as_str(),
+                MAX_JAVASCRIPT_SAFE_INTEGER + 1,
+                "read_at_ms",
+            ),
+        ] {
+            match store
+                .apply_read_assignment_projection_batch(
+                    batch_id,
+                    &digest(60),
+                    1,
+                    candidate_entity_id,
+                    read_at,
+                )
+                .expect_err("invalid assignment must fail")
+            {
+                ShadowStoreError::InvalidReadAssignment { field: actual } => {
+                    assert_eq!(actual, field);
+                }
+                error => panic!("unexpected assignment error: {error:?}"),
+            }
+        }
+
+        match store
+            .apply_read_assignment_projection_batch(
+                "missing-entity",
+                &digest(61),
+                1,
+                "x:missing",
+                1,
+            )
+            .expect_err("missing row must fail")
+        {
+            ShadowStoreError::ProjectionEntityNotFound { entity_id } => {
+                assert_eq!(entity_id, "x:missing");
+            }
+            error => panic!("unexpected missing-row error: {error:?}"),
+        }
+
+        store
+            .conn
+            .execute(
+                "UPDATE feed_items SET readAt = -1 WHERE globalId = ?1;",
+                params![entity_id],
+            )
+            .expect("inject invalid current projection");
+        match store
+            .apply_read_assignment_projection_batch(
+                "invalid-current",
+                &digest(62),
+                1,
+                &entity_id,
+                1,
+            )
+            .expect_err("invalid current projection must fail")
+        {
+            ShadowStoreError::InvalidReadAssignment { field } => {
+                assert_eq!(field, "current_read_at");
+            }
+            error => panic!("unexpected current-state error: {error:?}"),
+        }
+
+        assert_eq!(
+            store.visible_count(Some(1)).expect("unchanged revision"),
+            RevisionedCount {
+                revision: 1,
+                count: 1,
+            }
+        );
+        let receipts: i64 = store
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM projection_batches WHERE batchId LIKE 'read-%' \
+                 OR batchId IN ('missing-entity', 'invalid-current');",
+                [],
+                |row| row.get(0),
+            )
+            .expect("receipt count");
+        assert_eq!(receipts, 0);
+    }
+
+    #[test]
+    fn read_assignment_receipt_failure_rolls_back_the_field_and_revision() {
+        let mut store = seeded(1);
+        let entity_id = store.feed_page(None, 1).expect("seed page").rows[0]
+            .global_id
+            .clone();
+        store
+            .conn
+            .execute_batch(
+                "CREATE TEMP TRIGGER reject_read_assignment_receipt \
+                 BEFORE INSERT ON projection_batches \
+                 WHEN NEW.batchId = 'read-must-rollback' \
+                 BEGIN SELECT RAISE(ABORT, 'injected receipt failure'); END;",
+            )
+            .expect("install failure injection");
+
+        let error = store
+            .apply_read_assignment_projection_batch(
+                "read-must-rollback",
+                &digest(70),
+                1,
+                &entity_id,
+                10,
+            )
+            .expect_err("receipt failure must roll back");
+        assert!(matches!(error, ShadowStoreError::Sql(_)));
+        assert_eq!(
+            store.feed_page(None, 1).expect("row after rollback").rows[0].read_at,
+            None
+        );
+        assert_eq!(
+            store
+                .visible_count(Some(1))
+                .expect("revision after rollback"),
+            RevisionedCount {
+                revision: 1,
+                count: 1,
+            }
+        );
     }
 
     #[test]

--- a/packages/shared/src/library-core/field-registry.ts
+++ b/packages/shared/src/library-core/field-registry.ts
@@ -1623,6 +1623,9 @@ export const LIBRARY_CORE_FIELD_REGISTRY = [
   ...retainedEntries,
 ].sort((left, right) => compareCodeUnits(left.registryKey, right.registryKey));
 
+export const LIBRARY_CORE_FEED_ITEM_READ_AT_FIELD_REGISTRY_KEY =
+  "library-core-v1:feedItems.{globalId}.userState.readAt";
+
 const staticRootKinds = exactKeyObject<keyof FreedDoc>()({
   accounts: "entity-map",
   feedItems: "entity-map",

--- a/packages/shared/src/library-core/field-registry.ts
+++ b/packages/shared/src/library-core/field-registry.ts
@@ -55,6 +55,10 @@ import type {
   LibraryCorePresence,
   LibraryCoreRootRegistryEntry,
 } from "./protocol-registry.js";
+import {
+  FEED_ITEM_READ_AT_FIELD_ALGEBRA,
+  LIBRARY_CORE_FEED_ITEM_READ_AT_FIELD_REGISTRY_KEY,
+} from "./operation-field-algebra-contracts.js";
 
 type Primitive = string | number | boolean;
 
@@ -1621,10 +1625,26 @@ export const LIBRARY_CORE_FIELD_REGISTRY = [
   ...typedEntries,
   ...unregisteredDescendantEntries,
   ...retainedEntries,
-].sort((left, right) => compareCodeUnits(left.registryKey, right.registryKey));
-
-export const LIBRARY_CORE_FEED_ITEM_READ_AT_FIELD_REGISTRY_KEY =
-  "library-core-v1:feedItems.{globalId}.userState.readAt";
+]
+  .map((entry) => {
+    if (
+      entry.registryKey !==
+      LIBRARY_CORE_FEED_ITEM_READ_AT_FIELD_REGISTRY_KEY
+    ) {
+      return entry;
+    }
+    return {
+      ...entry,
+      mergeAlgebra: FEED_ITEM_READ_AT_FIELD_ALGEBRA.algebraId,
+      activation: {
+        status: "blocked" as const,
+        blockers: entry.activation.blockers.filter(
+          (blocker) => blocker !== "merge_algebra_undecided",
+        ),
+      },
+    };
+  })
+  .sort((left, right) => compareCodeUnits(left.registryKey, right.registryKey));
 
 const staticRootKinds = exactKeyObject<keyof FreedDoc>()({
   accounts: "entity-map",

--- a/packages/shared/src/library-core/index.ts
+++ b/packages/shared/src/library-core/index.ts
@@ -2,6 +2,7 @@ export * from "./census.js";
 export * from "./field-registry.js";
 export * from "./local-authority-registry.js";
 export * from "./operation-registry.js";
+export * from "./operation-payload-contracts.js";
 export * from "./protocol-registry.js";
 export * from "./protocol-scalars.js";
 export * from "./query-registry.js";

--- a/packages/shared/src/library-core/index.ts
+++ b/packages/shared/src/library-core/index.ts
@@ -2,6 +2,7 @@ export * from "./census.js";
 export * from "./field-registry.js";
 export * from "./local-authority-registry.js";
 export * from "./operation-registry.js";
+export * from "./operation-field-algebra-contracts.js";
 export * from "./operation-payload-contracts.js";
 export * from "./protocol-registry.js";
 export * from "./protocol-scalars.js";

--- a/packages/shared/src/library-core/operation-field-algebra-contracts.test.ts
+++ b/packages/shared/src/library-core/operation-field-algebra-contracts.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import { FEED_ITEM_READ_AT_FIELD_ALGEBRA } from "./operation-field-algebra-contracts.js";
+
+const merge = (current: unknown, incoming: unknown): number => {
+  const result = FEED_ITEM_READ_AT_FIELD_ALGEBRA.merge(current, incoming);
+  if (!result.ok) throw new Error(result.reason);
+  return result.value;
+};
+
+describe("Library Core operation field algebra contracts", () => {
+  it("uses absence as identity and keeps the earliest read assignment", () => {
+    expect(merge(undefined, 20)).toBe(20);
+    expect(merge(20, 30)).toBe(20);
+    expect(merge(30, 20)).toBe(20);
+    expect(merge(20, 20)).toBe(20);
+    expect(FEED_ITEM_READ_AT_FIELD_ALGEBRA).toMatchObject({
+      algebraId: "minimum_present_nonnegative_safe_integer_v1",
+      fieldRegistryKey:
+        "library-core-v1:feedItems.{globalId}.userState.readAt",
+    });
+    expect(Object.isFrozen(FEED_ITEM_READ_AT_FIELD_ALGEBRA)).toBe(true);
+  });
+
+  it("is associative across replay and reordering", () => {
+    const left = merge(merge(undefined, 30), merge(20, 40));
+    const right = merge(merge(30, 20), 40);
+
+    expect(left).toBe(20);
+    expect(right).toBe(20);
+  });
+
+  it("fails closed on malformed current or incoming state", () => {
+    for (const [current, incoming] of [
+      [-1, 1],
+      [0.5, 1],
+      ["1", 1],
+      [undefined, -0],
+      [undefined, -1],
+      [undefined, Number.MAX_SAFE_INTEGER + 1],
+      [undefined, Number.NaN],
+    ]) {
+      expect(
+        FEED_ITEM_READ_AT_FIELD_ALGEBRA.merge(current, incoming),
+      ).toMatchObject({ ok: false, code: "invalid" });
+    }
+  });
+});

--- a/packages/shared/src/library-core/operation-field-algebra-contracts.ts
+++ b/packages/shared/src/library-core/operation-field-algebra-contracts.ts
@@ -1,0 +1,62 @@
+import { isLibraryCoreNonnegativeSafeInteger } from "./protocol-scalars.js";
+
+export const LIBRARY_CORE_FEED_ITEM_READ_AT_FIELD_REGISTRY_KEY =
+  "library-core-v1:feedItems.{globalId}.userState.readAt";
+
+export type LibraryCoreFieldAlgebraResult<T> =
+  | {
+      readonly ok: true;
+      readonly value: T;
+    }
+  | {
+      readonly ok: false;
+      readonly code: "invalid";
+      readonly reason: string;
+    };
+
+export interface LibraryCoreOperationFieldAlgebraContract<T> {
+  readonly algebraId: string;
+  readonly fieldRegistryKey: string;
+  readonly merge: (
+    current: unknown,
+    incoming: unknown,
+  ) => LibraryCoreFieldAlgebraResult<T>;
+}
+
+function mergeReadAt(
+  current: unknown,
+  incoming: unknown,
+): LibraryCoreFieldAlgebraResult<number> {
+  if (
+    current !== undefined &&
+    !isLibraryCoreNonnegativeSafeInteger(current)
+  ) {
+    return {
+      ok: false,
+      code: "invalid",
+      reason: "current readAt must be absent or a nonnegative safe integer",
+    };
+  }
+  if (!isLibraryCoreNonnegativeSafeInteger(incoming)) {
+    return {
+      ok: false,
+      code: "invalid",
+      reason: "incoming readAt must be a nonnegative safe integer",
+    };
+  }
+
+  return {
+    ok: true,
+    value: current === undefined ? incoming : Math.min(current, incoming),
+  };
+}
+
+/**
+ * Reading is monotone. Absence means unread, and the earliest valid read time
+ * survives duplicate, reordered, or concurrent assignment delivery.
+ */
+export const FEED_ITEM_READ_AT_FIELD_ALGEBRA = Object.freeze({
+  algebraId: "minimum_present_nonnegative_safe_integer_v1",
+  fieldRegistryKey: LIBRARY_CORE_FEED_ITEM_READ_AT_FIELD_REGISTRY_KEY,
+  merge: mergeReadAt,
+}) satisfies LibraryCoreOperationFieldAlgebraContract<number>;

--- a/packages/shared/src/library-core/operation-payload-contracts.test.ts
+++ b/packages/shared/src/library-core/operation-payload-contracts.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { FEED_ITEM_READ_ASSIGNMENT_PAYLOAD_SCHEMA } from "./operation-payload-contracts.js";
+
+describe("Library Core operation payload contracts", () => {
+  it("snapshots the exact feed-item read assignment payload", () => {
+    const input = { read_at_ms: 1_783_000_000_000 };
+    const result = FEED_ITEM_READ_ASSIGNMENT_PAYLOAD_SCHEMA.validate(input);
+
+    expect(result).toStrictEqual({
+      ok: true,
+      value: { read_at_ms: 1_783_000_000_000 },
+    });
+    if (!result.ok) throw new Error(result.reason);
+    expect(Object.isFrozen(result.value)).toBe(true);
+    expect(result.value).not.toBe(input);
+
+    input.read_at_ms = 1;
+    expect(result.value.read_at_ms).toBe(1_783_000_000_000);
+  });
+
+  it("rejects noncanonical shapes and unsafe read timestamps", () => {
+    const accessor = Object.defineProperty({}, "read_at_ms", {
+      enumerable: true,
+      get: () => 1,
+    });
+    const symbol = { read_at_ms: 1 };
+    Object.defineProperty(symbol, Symbol("extra"), { value: true });
+
+    for (const invalid of [
+      null,
+      [],
+      new Date(),
+      {},
+      { read_at_ms: 1, extra: true },
+      { read_at_ms: -0 },
+      { read_at_ms: -1 },
+      { read_at_ms: 1.5 },
+      { read_at_ms: Number.MAX_SAFE_INTEGER + 1 },
+      { read_at_ms: "1" },
+      accessor,
+      symbol,
+    ]) {
+      expect(
+        FEED_ITEM_READ_ASSIGNMENT_PAYLOAD_SCHEMA.validate(invalid),
+      ).toMatchObject({ ok: false, code: "invalid" });
+    }
+  });
+});

--- a/packages/shared/src/library-core/operation-payload-contracts.ts
+++ b/packages/shared/src/library-core/operation-payload-contracts.ts
@@ -1,0 +1,88 @@
+import { isLibraryCoreNonnegativeSafeInteger } from "./protocol-scalars.js";
+
+export interface FeedItemReadAssignmentPayloadV1 {
+  readonly read_at_ms: number;
+}
+
+export type LibraryCorePayloadValidationResult<T> =
+  | {
+      readonly ok: true;
+      readonly value: T;
+    }
+  | {
+      readonly ok: false;
+      readonly code: "invalid";
+      readonly reason: string;
+    };
+
+export interface LibraryCoreOperationPayloadSchema<
+  OperationType extends string,
+  Payload,
+> {
+  readonly schemaId: string;
+  readonly schemaVersion: 1;
+  readonly operationType: OperationType;
+  readonly canonicalKeys: readonly string[];
+  readonly validate: (
+    value: unknown,
+  ) => LibraryCorePayloadValidationResult<Payload>;
+}
+
+const READ_ASSIGNMENT_KEYS = ["read_at_ms"] as const;
+
+function invalid<T>(reason: string): LibraryCorePayloadValidationResult<T> {
+  return { ok: false, code: "invalid", reason };
+}
+
+function validateFeedItemReadAssignmentPayload(
+  value: unknown,
+): LibraryCorePayloadValidationResult<FeedItemReadAssignmentPayloadV1> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return invalid("payload must be a plain object");
+  }
+
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) {
+    return invalid("payload must be a plain object");
+  }
+  if (Object.getOwnPropertySymbols(value).length !== 0) {
+    return invalid("payload may not contain symbol keys");
+  }
+
+  const keys = Object.getOwnPropertyNames(value);
+  if (keys.length !== 1 || keys[0] !== READ_ASSIGNMENT_KEYS[0]) {
+    return invalid("payload must contain only read_at_ms");
+  }
+
+  const descriptor = Object.getOwnPropertyDescriptor(value, "read_at_ms");
+  if (
+    descriptor === undefined ||
+    !descriptor.enumerable ||
+    !("value" in descriptor)
+  ) {
+    return invalid("read_at_ms must be an enumerable data property");
+  }
+  if (!isLibraryCoreNonnegativeSafeInteger(descriptor.value)) {
+    return invalid("read_at_ms must be a nonnegative safe integer");
+  }
+
+  return {
+    ok: true,
+    value: Object.freeze({ read_at_ms: descriptor.value }),
+  };
+}
+
+/**
+ * Closed payload syntax only. This schema does not grant write authority,
+ * materialize state, or schedule a provider-visible action.
+ */
+export const FEED_ITEM_READ_ASSIGNMENT_PAYLOAD_SCHEMA = Object.freeze({
+  schemaId: "feed_item_read_assignment_payload_v1",
+  schemaVersion: 1,
+  operationType: "feed_item_read_assignment",
+  canonicalKeys: READ_ASSIGNMENT_KEYS,
+  validate: validateFeedItemReadAssignmentPayload,
+}) satisfies LibraryCoreOperationPayloadSchema<
+  "feed_item_read_assignment",
+  FeedItemReadAssignmentPayloadV1
+>;

--- a/packages/shared/src/library-core/operation-registry.ts
+++ b/packages/shared/src/library-core/operation-registry.ts
@@ -1,5 +1,13 @@
 import type { BaseAppState } from "../store-types.js";
+import {
+  FEED_ITEM_READ_ASSIGNMENT_PAYLOAD_SCHEMA,
+  type LibraryCoreOperationPayloadSchema,
+} from "./operation-payload-contracts.js";
 import type { LibraryCoreEntity } from "./protocol-registry.js";
+import {
+  LIBRARY_CORE_ENTITY_ID_CODEC_V1,
+  type LibraryCoreEntityIdCodec,
+} from "./protocol-scalars.js";
 
 export type BaseAppFunctionKey = {
   [Key in keyof BaseAppState]-?: NonNullable<BaseAppState[Key]> extends (
@@ -74,6 +82,7 @@ export type LibraryCoreRelationshipEffect =
 
 export type LibraryCoreOperationBlocker =
   | "capture_source_authority_unresolved"
+  | "entity_id_schema_unresolved"
   | "field_algebra_unresolved"
   | "frozen_bulk_contract_unresolved"
   | "legacy_friend_account_replacement_unresolved"
@@ -95,10 +104,15 @@ export interface LibraryCoreOperationDefinition {
   readonly schemaVersion: 1;
   readonly entityType: LibraryCoreOperationEntity;
   /**
-   * Gate A has not closed payload schemas or their exact field algebra. Keeping
-   * these values null prevents a name from masquerading as an executable codec.
+   * A non-null schema closes only payload syntax for that operation. It does
+   * not close touched fields, algebra, materialization, or runtime authority.
    */
-  readonly payloadSchema: null;
+  readonly payloadSchema: LibraryCoreOperationPayloadSchema<
+    string,
+    unknown
+  > | null;
+  /** Exact entity-key syntax only. This does not prove the entity exists. */
+  readonly entityIdCodec: LibraryCoreEntityIdCodec | null;
   readonly touchedFieldRegistryKeys: null;
   readonly fieldAlgebra: null;
   readonly materializer: null;
@@ -131,10 +145,11 @@ interface PlannedOperationInput {
     | "provider_capture_reconciliation"
     | "system_repair";
   readonly additionalBlockers?: readonly LibraryCoreOperationBlocker[];
+  readonly payloadSchema?: LibraryCoreOperationPayloadSchema<string, unknown>;
+  readonly entityIdCodec?: LibraryCoreEntityIdCodec;
 }
 
 const BASE_OPERATION_BLOCKERS = [
-  "payload_schema_unresolved",
   "touched_fields_unresolved",
   "field_algebra_unresolved",
   "materializer_unimplemented",
@@ -144,11 +159,24 @@ const BASE_OPERATION_BLOCKERS = [
 function plannedOperation(
   input: PlannedOperationInput,
 ): LibraryCoreOperationDefinition {
+  const blockers: NonEmptyBlockers = [
+    "touched_fields_unresolved",
+    ...(input.entityIdCodec === undefined
+      ? (["entity_id_schema_unresolved"] as const)
+      : []),
+    ...(input.payloadSchema === undefined
+      ? (["payload_schema_unresolved"] as const)
+      : []),
+    ...BASE_OPERATION_BLOCKERS.slice(1),
+    ...(input.additionalBlockers ?? []),
+  ];
+
   return {
     status: "planned_blocked",
     schemaVersion: 1,
     entityType: input.entityType,
-    payloadSchema: null,
+    payloadSchema: input.payloadSchema ?? null,
+    entityIdCodec: input.entityIdCodec ?? null,
     touchedFieldRegistryKeys: null,
     fieldAlgebra: null,
     materializer: null,
@@ -162,10 +190,7 @@ function plannedOperation(
     candidateStoreSurfaces: input.candidateStoreSurfaces ?? [],
     legacyWorkerRequests: input.legacyWorkerRequests ?? [],
     intendedAuthority: input.intendedAuthority,
-    blockers: [
-      ...BASE_OPERATION_BLOCKERS,
-      ...(input.additionalBlockers ?? []),
-    ],
+    blockers,
   };
 }
 
@@ -259,6 +284,8 @@ export const LIBRARY_CORE_OPERATION_REGISTRY = {
   }),
   feed_item_read_assignment: localUserOperation({
     entityType: "FeedItem",
+    payloadSchema: FEED_ITEM_READ_ASSIGNMENT_PAYLOAD_SCHEMA,
+    entityIdCodec: LIBRARY_CORE_ENTITY_ID_CODEC_V1,
     candidateStoreSurfaces: ["markAsRead"],
     legacyWorkerRequests: ["MARK_AS_READ"],
     additionalBlockers: ["provider_intent_separation_unresolved"],

--- a/packages/shared/src/library-core/operation-registry.ts
+++ b/packages/shared/src/library-core/operation-registry.ts
@@ -1,4 +1,5 @@
 import type { BaseAppState } from "../store-types.js";
+import { LIBRARY_CORE_FEED_ITEM_READ_AT_FIELD_REGISTRY_KEY } from "./field-registry.js";
 import {
   FEED_ITEM_READ_ASSIGNMENT_PAYLOAD_SCHEMA,
   type LibraryCoreOperationPayloadSchema,
@@ -113,7 +114,7 @@ export interface LibraryCoreOperationDefinition {
   > | null;
   /** Exact entity-key syntax only. This does not prove the entity exists. */
   readonly entityIdCodec: LibraryCoreEntityIdCodec | null;
-  readonly touchedFieldRegistryKeys: null;
+  readonly touchedFieldRegistryKeys: readonly string[] | null;
   readonly fieldAlgebra: null;
   readonly materializer: null;
   readonly frozenBulkContract: null;
@@ -147,10 +148,10 @@ interface PlannedOperationInput {
   readonly additionalBlockers?: readonly LibraryCoreOperationBlocker[];
   readonly payloadSchema?: LibraryCoreOperationPayloadSchema<string, unknown>;
   readonly entityIdCodec?: LibraryCoreEntityIdCodec;
+  readonly touchedFieldRegistryKeys?: readonly string[];
 }
 
 const BASE_OPERATION_BLOCKERS = [
-  "touched_fields_unresolved",
   "field_algebra_unresolved",
   "materializer_unimplemented",
   "runtime_authority_inactive",
@@ -160,7 +161,10 @@ function plannedOperation(
   input: PlannedOperationInput,
 ): LibraryCoreOperationDefinition {
   const blockers: NonEmptyBlockers = [
-    "touched_fields_unresolved",
+    "field_algebra_unresolved",
+    ...(input.touchedFieldRegistryKeys === undefined
+      ? (["touched_fields_unresolved"] as const)
+      : []),
     ...(input.entityIdCodec === undefined
       ? (["entity_id_schema_unresolved"] as const)
       : []),
@@ -177,7 +181,7 @@ function plannedOperation(
     entityType: input.entityType,
     payloadSchema: input.payloadSchema ?? null,
     entityIdCodec: input.entityIdCodec ?? null,
-    touchedFieldRegistryKeys: null,
+    touchedFieldRegistryKeys: input.touchedFieldRegistryKeys ?? null,
     fieldAlgebra: null,
     materializer: null,
     frozenBulkContract: null,
@@ -286,6 +290,9 @@ export const LIBRARY_CORE_OPERATION_REGISTRY = {
     entityType: "FeedItem",
     payloadSchema: FEED_ITEM_READ_ASSIGNMENT_PAYLOAD_SCHEMA,
     entityIdCodec: LIBRARY_CORE_ENTITY_ID_CODEC_V1,
+    touchedFieldRegistryKeys: [
+      LIBRARY_CORE_FEED_ITEM_READ_AT_FIELD_REGISTRY_KEY,
+    ],
     candidateStoreSurfaces: ["markAsRead"],
     legacyWorkerRequests: ["MARK_AS_READ"],
     additionalBlockers: ["provider_intent_separation_unresolved"],

--- a/packages/shared/src/library-core/operation-registry.ts
+++ b/packages/shared/src/library-core/operation-registry.ts
@@ -1,5 +1,9 @@
 import type { BaseAppState } from "../store-types.js";
-import { LIBRARY_CORE_FEED_ITEM_READ_AT_FIELD_REGISTRY_KEY } from "./field-registry.js";
+import {
+  FEED_ITEM_READ_AT_FIELD_ALGEBRA,
+  LIBRARY_CORE_FEED_ITEM_READ_AT_FIELD_REGISTRY_KEY,
+  type LibraryCoreOperationFieldAlgebraContract,
+} from "./operation-field-algebra-contracts.js";
 import {
   FEED_ITEM_READ_ASSIGNMENT_PAYLOAD_SCHEMA,
   type LibraryCoreOperationPayloadSchema,
@@ -115,7 +119,9 @@ export interface LibraryCoreOperationDefinition {
   /** Exact entity-key syntax only. This does not prove the entity exists. */
   readonly entityIdCodec: LibraryCoreEntityIdCodec | null;
   readonly touchedFieldRegistryKeys: readonly string[] | null;
-  readonly fieldAlgebra: null;
+  readonly fieldAlgebra:
+    | LibraryCoreOperationFieldAlgebraContract<unknown>
+    | null;
   readonly materializer: null;
   readonly frozenBulkContract: null;
   readonly transactionLimits: {
@@ -149,10 +155,10 @@ interface PlannedOperationInput {
   readonly payloadSchema?: LibraryCoreOperationPayloadSchema<string, unknown>;
   readonly entityIdCodec?: LibraryCoreEntityIdCodec;
   readonly touchedFieldRegistryKeys?: readonly string[];
+  readonly fieldAlgebra?: LibraryCoreOperationFieldAlgebraContract<unknown>;
 }
 
 const BASE_OPERATION_BLOCKERS = [
-  "field_algebra_unresolved",
   "materializer_unimplemented",
   "runtime_authority_inactive",
 ] as const satisfies NonEmptyBlockers;
@@ -161,7 +167,10 @@ function plannedOperation(
   input: PlannedOperationInput,
 ): LibraryCoreOperationDefinition {
   const blockers: NonEmptyBlockers = [
-    "field_algebra_unresolved",
+    "materializer_unimplemented",
+    ...(input.fieldAlgebra === undefined
+      ? (["field_algebra_unresolved"] as const)
+      : []),
     ...(input.touchedFieldRegistryKeys === undefined
       ? (["touched_fields_unresolved"] as const)
       : []),
@@ -182,7 +191,7 @@ function plannedOperation(
     payloadSchema: input.payloadSchema ?? null,
     entityIdCodec: input.entityIdCodec ?? null,
     touchedFieldRegistryKeys: input.touchedFieldRegistryKeys ?? null,
-    fieldAlgebra: null,
+    fieldAlgebra: input.fieldAlgebra ?? null,
     materializer: null,
     frozenBulkContract: null,
     transactionLimits: {
@@ -293,6 +302,7 @@ export const LIBRARY_CORE_OPERATION_REGISTRY = {
     touchedFieldRegistryKeys: [
       LIBRARY_CORE_FEED_ITEM_READ_AT_FIELD_REGISTRY_KEY,
     ],
+    fieldAlgebra: FEED_ITEM_READ_AT_FIELD_ALGEBRA,
     candidateStoreSurfaces: ["markAsRead"],
     legacyWorkerRequests: ["MARK_AS_READ"],
     additionalBlockers: ["provider_intent_separation_unresolved"],

--- a/packages/shared/src/library-core/read-assignment-projection-v1.sql
+++ b/packages/shared/src/library-core/read-assignment-projection-v1.sql
@@ -1,0 +1,3 @@
+UPDATE feed_items
+SET readAt = ?2
+WHERE globalId = ?1;

--- a/packages/shared/src/library-core/registry.test.ts
+++ b/packages/shared/src/library-core/registry.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  LIBRARY_CORE_FEED_ITEM_READ_AT_FIELD_REGISTRY_KEY,
+  LIBRARY_CORE_FIELD_REGISTRY,
+} from "./field-registry.js";
+import {
   LIBRARY_CORE_MAX_CANONICAL_TRANSACTION_BYTES,
   LIBRARY_CORE_MAX_TRANSACTION_MEMBERS,
   LIBRARY_CORE_OPERATION_IDS,
@@ -47,6 +51,10 @@ describe("Library Core operation registry", () => {
         expect(definition.blockers).not.toContain(
           "entity_id_schema_unresolved",
         );
+        expect(definition.touchedFieldRegistryKeys).toStrictEqual([
+          LIBRARY_CORE_FEED_ITEM_READ_AT_FIELD_REGISTRY_KEY,
+        ]);
+        expect(definition.blockers).not.toContain("touched_fields_unresolved");
       } else {
         expect(definition.payloadSchema).toBeNull();
         expect(definition.blockers).toContain("payload_schema_unresolved");
@@ -54,8 +62,9 @@ describe("Library Core operation registry", () => {
         expect(definition.blockers).toContain(
           "entity_id_schema_unresolved",
         );
+        expect(definition.touchedFieldRegistryKeys).toBeNull();
+        expect(definition.blockers).toContain("touched_fields_unresolved");
       }
-      expect(definition.touchedFieldRegistryKeys).toBeNull();
       expect(definition.fieldAlgebra).toBeNull();
       expect(definition.materializer).toBeNull();
       expect(definition.frozenBulkContract).toBeNull();
@@ -71,6 +80,13 @@ describe("Library Core operation registry", () => {
 
     expect(LIBRARY_CORE_MAX_TRANSACTION_MEMBERS).toBe(1_000);
     expect(LIBRARY_CORE_MAX_CANONICAL_TRANSACTION_BYTES).toBe(4 * 1_048_576);
+    expect(
+      LIBRARY_CORE_FIELD_REGISTRY.some(
+        (entry) =>
+          entry.registryKey ===
+          LIBRARY_CORE_FEED_ITEM_READ_AT_FIELD_REGISTRY_KEY,
+      ),
+    ).toBe(true);
   });
 
   it("keeps frozen membership, provider intent, and execution receipts unresolved", () => {

--- a/packages/shared/src/library-core/registry.test.ts
+++ b/packages/shared/src/library-core/registry.test.ts
@@ -6,6 +6,7 @@ import {
   LIBRARY_CORE_OPERATION_IDS,
   LIBRARY_CORE_OPERATION_REGISTRY,
 } from "./operation-registry.js";
+import { LIBRARY_CORE_ENTITY_ID_CODEC_V1 } from "./protocol-scalars.js";
 import {
   LIBRARY_CORE_INTERACTIVE_SNAPSHOT_POOL,
   LIBRARY_CORE_QUERY_IDS,
@@ -27,12 +28,33 @@ describe("Library Core operation registry", () => {
     );
   });
 
-  it("does not claim executable schemas, algebra, materializers, or authority", () => {
-    for (const definition of Object.values(
+  it("does not claim unresolved algebra, materializers, or authority", () => {
+    for (const [operationId, definition] of Object.entries(
       LIBRARY_CORE_OPERATION_REGISTRY,
     )) {
       expect(definition.status).toBe("planned_blocked");
-      expect(definition.payloadSchema).toBeNull();
+      if (operationId === "feed_item_read_assignment") {
+        expect(definition.payloadSchema).toMatchObject({
+          schemaId: "feed_item_read_assignment_payload_v1",
+          schemaVersion: 1,
+          operationType: "feed_item_read_assignment",
+          canonicalKeys: ["read_at_ms"],
+        });
+        expect(definition.blockers).not.toContain("payload_schema_unresolved");
+        expect(definition.entityIdCodec).toBe(
+          LIBRARY_CORE_ENTITY_ID_CODEC_V1,
+        );
+        expect(definition.blockers).not.toContain(
+          "entity_id_schema_unresolved",
+        );
+      } else {
+        expect(definition.payloadSchema).toBeNull();
+        expect(definition.blockers).toContain("payload_schema_unresolved");
+        expect(definition.entityIdCodec).toBeNull();
+        expect(definition.blockers).toContain(
+          "entity_id_schema_unresolved",
+        );
+      }
       expect(definition.touchedFieldRegistryKeys).toBeNull();
       expect(definition.fieldAlgebra).toBeNull();
       expect(definition.materializer).toBeNull();

--- a/packages/shared/src/library-core/registry.test.ts
+++ b/packages/shared/src/library-core/registry.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  LIBRARY_CORE_FEED_ITEM_READ_AT_FIELD_REGISTRY_KEY,
   LIBRARY_CORE_FIELD_REGISTRY,
 } from "./field-registry.js";
+import {
+  FEED_ITEM_READ_AT_FIELD_ALGEBRA,
+  LIBRARY_CORE_FEED_ITEM_READ_AT_FIELD_REGISTRY_KEY,
+} from "./operation-field-algebra-contracts.js";
 import {
   LIBRARY_CORE_MAX_CANONICAL_TRANSACTION_BYTES,
   LIBRARY_CORE_MAX_TRANSACTION_MEMBERS,
@@ -55,6 +58,10 @@ describe("Library Core operation registry", () => {
           LIBRARY_CORE_FEED_ITEM_READ_AT_FIELD_REGISTRY_KEY,
         ]);
         expect(definition.blockers).not.toContain("touched_fields_unresolved");
+        expect(definition.fieldAlgebra).toBe(
+          FEED_ITEM_READ_AT_FIELD_ALGEBRA,
+        );
+        expect(definition.blockers).not.toContain("field_algebra_unresolved");
       } else {
         expect(definition.payloadSchema).toBeNull();
         expect(definition.blockers).toContain("payload_schema_unresolved");
@@ -64,8 +71,9 @@ describe("Library Core operation registry", () => {
         );
         expect(definition.touchedFieldRegistryKeys).toBeNull();
         expect(definition.blockers).toContain("touched_fields_unresolved");
+        expect(definition.fieldAlgebra).toBeNull();
+        expect(definition.blockers).toContain("field_algebra_unresolved");
       }
-      expect(definition.fieldAlgebra).toBeNull();
       expect(definition.materializer).toBeNull();
       expect(definition.frozenBulkContract).toBeNull();
       expect(definition.blockers.length).toBeGreaterThan(0);
@@ -81,12 +89,17 @@ describe("Library Core operation registry", () => {
     expect(LIBRARY_CORE_MAX_TRANSACTION_MEMBERS).toBe(1_000);
     expect(LIBRARY_CORE_MAX_CANONICAL_TRANSACTION_BYTES).toBe(4 * 1_048_576);
     expect(
-      LIBRARY_CORE_FIELD_REGISTRY.some(
+      LIBRARY_CORE_FIELD_REGISTRY.find(
         (entry) =>
           entry.registryKey ===
           LIBRARY_CORE_FEED_ITEM_READ_AT_FIELD_REGISTRY_KEY,
       ),
-    ).toBe(true);
+    ).toMatchObject({
+      mergeAlgebra: "minimum_present_nonnegative_safe_integer_v1",
+      activation: {
+        blockers: expect.not.arrayContaining(["merge_algebra_undecided"]),
+      },
+    });
   });
 
   it("keeps frozen membership, provider intent, and execution receipts unresolved", () => {

--- a/packages/shared/src/shadow-store.test.ts
+++ b/packages/shared/src/shadow-store.test.ts
@@ -10,6 +10,7 @@ import {
   SHADOW_BATCH_RECEIPT_DDL,
   SHADOW_INDEX_DDL,
   SHADOW_META_DDL,
+  SHADOW_READ_AT_ASSIGNMENT_SQL,
   SHADOW_SCHEMA_VERSION_DDL,
   SHADOW_TABLE_DDL,
   SHADOW_V1_SCHEMA_VERSION_DDL,
@@ -74,6 +75,16 @@ describe("shadow store", () => {
     );
     expect(normalizeSql(canonicalV2)).toBe(
       normalizeSql([SHADOW_BATCH_RECEIPT_DDL, SHADOW_SCHEMA_VERSION_DDL].join("\n")),
+    );
+    const readAssignmentSql = readFileSync(
+      new URL(
+        "./library-core/read-assignment-projection-v1.sql",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+    expect(normalizeSql(readAssignmentSql)).toBe(
+      normalizeSql(SHADOW_READ_AT_ASSIGNMENT_SQL),
     );
   });
 

--- a/packages/shared/src/shadow-store.ts
+++ b/packages/shared/src/shadow-store.ts
@@ -229,6 +229,11 @@ ${SHADOW_WRITE_COLUMNS.filter((c) => c !== "globalId")
 export const SHADOW_SELECT_ALL_SQL = `SELECT ${SHADOW_COLUMNS.join(", ")} FROM feed_items;`;
 export const SHADOW_SELECT_ONE_SQL = `SELECT ${SHADOW_COLUMNS.join(", ")} FROM feed_items WHERE globalId = ?;`;
 export const SHADOW_DELETE_SQL = `DELETE FROM feed_items WHERE globalId = ?;`;
+export const SHADOW_READ_AT_ASSIGNMENT_SQL = `
+UPDATE feed_items
+SET readAt = ?2
+WHERE globalId = ?1;
+`.trim();
 
 /** The slice of a SQLite driver this module needs. rusqlite, sqlite-wasm and node:sqlite all fit. */
 export interface ShadowStatement {


### PR DESCRIPTION
(AI Generated).

## Summary
- Close the exact read-assignment payload, entity-key, touched-field, and minimum-timestamp merge contracts.
- Apply validated read assignments through one column-local native SQLite update with revision fencing and crash-safe retry receipts.
- Keep the materializer dark with no runtime opener, IPC entry point, provider request, or write-authority activation.

## Testing
- npm run validate:feature
- Focused shared read-contract suite: 52 passed, 2 skipped
- Focused native read-assignment transactions: 3 passed
- npm run validate:roadmap && npm run validate:skills