### PR TITLE
fix: align feed fade boundaries

### DIFF
--- a/packages/ui/src/components/feed/FeedView.tsx
+++ b/packages/ui/src/components/feed/FeedView.tsx
@@ -541,6 +541,10 @@ export function FeedView() {
   } satisfies React.CSSProperties;
   const railContentStyle = {
     width: `${panelWidth + COMPACT_PANEL_RESIZE_HANDLE_WIDTH}px`,
+    // Keep the rail inside both sidebar frame gaps while primary content spans
+    // the full height below the toolbar.
+    height: "calc(100% - var(--feed-card-gap, 8px) - var(--feed-card-gap, 8px))",
+    marginTop: "var(--feed-card-gap, 8px)",
   } satisfies React.CSSProperties;
 
   const handleRailTransitionEnd = useCallback(
@@ -593,7 +597,7 @@ export function FeedView() {
               style={railSlotStyle}
               onTransitionEnd={handleRailTransitionEnd}
             >
-              <div className="flex h-full" style={railContentStyle}>
+              <div className="flex" style={railContentStyle}>
                 <CompactFeedPanel
                   items={readerItems}
                   selectedId={selectedItem.globalId}
@@ -606,9 +610,6 @@ export function FeedView() {
                 />
                 <div
                   className="theme-resize-gap-handle w-4 shrink-0 self-stretch"
-                  style={{
-                    marginTop: "var(--feed-card-gap, 8px)",
-                  }}
                   onPointerDown={handleDragStart}
                   onPointerMove={handleDragMove}
                   onPointerUp={handleDragEnd}

--- a/packages/ui/src/components/layout/AppShell.tsx
+++ b/packages/ui/src/components/layout/AppShell.tsx
@@ -149,7 +149,7 @@ export function AppShell({ children }: AppShellProps) {
   const [mapViewportInsets, setMapViewportInsets] = useState<CanvasViewportInsets>(EMPTY_CANVAS_VIEWPORT_INSETS);
   const usesFullCanvasFrame = activeView === "friends";
   const contentFrameSpacingClass =
-    "px-[var(--feed-card-gap,8px)] pb-[var(--feed-card-gap,8px)]";
+    "px-[var(--feed-card-gap,8px)]";
   const [desktopSidebarDisplayMode, setDesktopSidebarDisplayMode] = useState<SidebarMode>(persistedDesktopSidebarMode);
   const dragging = useRef(false);
   const lastNonClosedDesktopSidebarModeRef = useRef<SidebarMode>(
@@ -573,7 +573,7 @@ export function AppShell({ children }: AppShellProps) {
 
           <div
             data-testid="debug-panel-drawer"
-            className="relative z-10 hidden sm:flex flex-none overflow-hidden"
+            className="relative z-10 hidden flex-none overflow-hidden pb-[var(--feed-card-gap,8px)] sm:flex"
             style={{
               width: debugVisible ? debugWidth + AUXILIARY_DRAWER_GAP_WIDTH_PX : 0,
               opacity: debugVisible ? 1 : 0,

--- a/packages/ui/src/components/layout/Sidebar.tsx
+++ b/packages/ui/src/components/layout/Sidebar.tsx
@@ -822,6 +822,7 @@ export function Sidebar({
   const desktopShellTopPadding = renderMode !== "closed" || closedPreviewActive
     ? "var(--feed-card-gap, 8px)"
     : 0;
+  const desktopShellBottomPadding = desktopShellTopPadding;
   const sidebarHandleCenterlinePx =
     renderMode === "closed" && !closedPreviewActive
       ? effectiveGapWidthPx / 2
@@ -1951,6 +1952,7 @@ export function Sidebar({
         style={{
           width: desktopShellWidth,
           paddingTop: desktopShellTopPadding,
+          paddingBottom: desktopShellBottomPadding,
           transition: desktopShellTransition,
         }}
       >


### PR DESCRIPTION
(AI Generated).

## Summary
- Align the compact social thumbnail rail fade with the sidebar top and bottom insets.
- Let primary feed content fade through the full available top and bottom edges while preserving sidebar and debug-panel spacing.

## Testing
- npm run validate:feature with pinned Node 24.14.1
- WebKit visual verification in Safari and geometry verification in Chromium