### PR TITLE
fix: resolve GitHub CLI outside shell PATH

### DIFF
--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -37,6 +37,7 @@ import {
   conservativeLeaseCleanupArchiveReservation,
   inspectLeaseCleanupArchiveCapacity,
 } from "./lib/automation-control.mjs";
+import { resolveGitHubCli } from "./lib/github-tooling.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -286,7 +287,7 @@ export function evaluateGhCheck({
 }
 
 function checkGh(machineArch, platform) {
-  const ghPath = whichCommand("gh");
+  const ghPath = resolveGitHubCli({ required: false });
   const versionResult = ghPath
     ? tryExec(ghPath, ["--version"])
     : { ok: false, stdout: "", error: "gh is not installed" };
@@ -337,7 +338,7 @@ function checkGitCredentialHelpers() {
   ];
 
   if (broken.length > 0) {
-    const ghPath = whichCommand("gh");
+    const ghPath = resolveGitHubCli({ required: false });
     return check(
       "git-credential-helper",
       "git credential helper",

--- a/scripts/doctor.test.mjs
+++ b/scripts/doctor.test.mjs
@@ -1,3 +1,5 @@
+import "./test-helpers/lease-archive-python-runtime.mjs";
+
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
 import {

--- a/scripts/lib/github-tooling.mjs
+++ b/scripts/lib/github-tooling.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+
+import { accessSync, constants, statSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const DEFAULT_GITHUB_CLI_PATHS = Object.freeze([
+  "/opt/homebrew/bin/gh",
+  "/usr/local/bin/gh",
+]);
+
+function isExecutableFile(candidate) {
+  try {
+    accessSync(candidate, constants.X_OK);
+    return statSync(candidate).isFile();
+  } catch {
+    return false;
+  }
+}
+
+export function githubCliCandidates(environment = process.env) {
+  const configured = String(environment.GH_BIN ?? "").trim();
+  const pathEntries = String(environment.PATH ?? "")
+    .split(path.delimiter)
+    .filter(Boolean)
+    .map((directory) => path.join(directory, "gh"));
+
+  return [
+    ...(configured ? [configured] : []),
+    ...pathEntries,
+    ...DEFAULT_GITHUB_CLI_PATHS,
+  ];
+}
+
+export function resolveGitHubCli({
+  environment = process.env,
+  executable = isExecutableFile,
+  required = true,
+} = {}) {
+  const seen = new Set();
+  for (const candidate of githubCliCandidates(environment)) {
+    if (!path.isAbsolute(candidate) || seen.has(candidate)) continue;
+    seen.add(candidate);
+    if (executable(candidate)) return candidate;
+  }
+
+  if (!required) return "";
+  throw new Error(
+    "GitHub CLI is unavailable. Set GH_BIN to an absolute executable path, add gh to PATH, or install it in /opt/homebrew/bin or /usr/local/bin.",
+  );
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    process.stdout.write(`${resolveGitHubCli()}\n`);
+  } catch (error) {
+    process.stderr.write(
+      `${error instanceof Error ? error.message : String(error)}\n`,
+    );
+    process.exitCode = 1;
+  }
+}

--- a/scripts/lib/github-tooling.test.mjs
+++ b/scripts/lib/github-tooling.test.mjs
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  githubCliCandidates,
+  resolveGitHubCli,
+} from "./github-tooling.mjs";
+
+test("GitHub CLI resolution survives a PATH without Homebrew", () => {
+  const executablePaths = new Set(["/opt/homebrew/bin/gh"]);
+  assert.equal(
+    resolveGitHubCli({
+      environment: { PATH: "/usr/bin:/bin" },
+      executable: (candidate) => executablePaths.has(candidate),
+    }),
+    "/opt/homebrew/bin/gh",
+  );
+});
+
+test("GitHub CLI resolution prefers an explicit absolute binary", () => {
+  assert.equal(
+    resolveGitHubCli({
+      environment: {
+        GH_BIN: "/private/tools/gh",
+        PATH: "/usr/bin:/bin",
+      },
+      executable: (candidate) =>
+        candidate === "/private/tools/gh" ||
+        candidate === "/opt/homebrew/bin/gh",
+    }),
+    "/private/tools/gh",
+  );
+});
+
+test("GitHub CLI resolution uses PATH before installation fallbacks", () => {
+  assert.deepEqual(
+    githubCliCandidates({ PATH: "/custom/bin:/usr/bin" }).slice(0, 4),
+    [
+      "/custom/bin/gh",
+      "/usr/bin/gh",
+      "/opt/homebrew/bin/gh",
+      "/usr/local/bin/gh",
+    ],
+  );
+});
+
+test("GitHub CLI resolution fails with actionable remediation", () => {
+  assert.throws(
+    () =>
+      resolveGitHubCli({
+        environment: { PATH: "/usr/bin:/bin" },
+        executable: () => false,
+      }),
+    /Set GH_BIN.*add gh to PATH.*opt\/homebrew\/bin/s,
+  );
+  assert.equal(
+    resolveGitHubCli({
+      environment: { PATH: "/usr/bin:/bin" },
+      executable: () => false,
+      required: false,
+    }),
+    "",
+  );
+});

--- a/scripts/validate-release-tag-authority.mjs
+++ b/scripts/validate-release-tag-authority.mjs
@@ -9,6 +9,7 @@ import {
   RELEASE_TAG_IMMUTABILITY_RULESET_NAME,
   verifyLiveReleaseTagAuthority,
 } from "./sync-github-rulesets.mjs";
+import { resolveGitHubCli } from "./lib/github-tooling.mjs";
 
 export function parseArgs(argv) {
   let repo = "freed-project/freed";
@@ -25,16 +26,25 @@ export function parseArgs(argv) {
   return { help: false, repo };
 }
 
-function ghJson(args, { exec = execFileSync } = {}) {
+function ghJson(
+  args,
+  { exec = execFileSync, githubCli = resolveGitHubCli() } = {},
+) {
   return JSON.parse(
-    exec("gh", args, { encoding: "utf8", maxBuffer: 16 * 1024 * 1024 }),
+    exec(githubCli, args, {
+      encoding: "utf8",
+      maxBuffer: 16 * 1024 * 1024,
+    }),
   );
 }
 
-export function loadLiveReleaseTagRulesets(repo, { exec = execFileSync } = {}) {
+export function loadLiveReleaseTagRulesets(
+  repo,
+  { exec = execFileSync, githubCli = resolveGitHubCli() } = {},
+) {
   const summary = ghJson(
     ["api", `repos/${repo}/rulesets?targets=tag&per_page=100`],
-    { exec },
+    { exec, githubCli },
   );
   const names = [
     RELEASE_TAG_CREATION_RULESET_NAME,
@@ -49,7 +59,10 @@ export function loadLiveReleaseTagRulesets(repo, { exec = execFileSync } = {}) {
     );
   }
   return matches.map((match) =>
-    ghJson(["api", `repos/${repo}/rulesets/${match.id}`], { exec }),
+    ghJson(["api", `repos/${repo}/rulesets/${match.id}`], {
+      exec,
+      githubCli,
+    }),
   );
 }
 

--- a/scripts/validate-release-tag-authority.test.mjs
+++ b/scripts/validate-release-tag-authority.test.mjs
@@ -17,8 +17,8 @@ test("release tag authority arguments accept only owner and repository", () => {
 
 test("live release tag authority loader resolves the named ruleset", () => {
   const calls = [];
-  const exec = (_file, args) => {
-    calls.push(args);
+  const exec = (file, args) => {
+    calls.push({ file, args });
     if (args[1].includes("?targets=tag")) {
       return JSON.stringify([
         { id: 7, name: "Freed release tag creation" },
@@ -31,18 +31,31 @@ test("live release tag authority loader resolves the named ruleset", () => {
     });
   };
   assert.deepEqual(
-    loadLiveReleaseTagRulesets("freed-project/freed", { exec }).map(
-      (ruleset) => ruleset.id,
-    ),
+    loadLiveReleaseTagRulesets("freed-project/freed", {
+      exec,
+      githubCli: "/opt/homebrew/bin/gh",
+    }).map((ruleset) => ruleset.id),
     [7, 8],
   );
   assert.equal(calls.length, 3);
+  assert.deepEqual(
+    calls.map((call) => call.file),
+    [
+      "/opt/homebrew/bin/gh",
+      "/opt/homebrew/bin/gh",
+      "/opt/homebrew/bin/gh",
+    ],
+  );
 });
 
 test("live release tag authority loader fails when provisioning is absent", () => {
   const exec = () => JSON.stringify([]);
   assert.throws(
-    () => loadLiveReleaseTagRulesets("freed-project/freed", { exec }),
+    () =>
+      loadLiveReleaseTagRulesets("freed-project/freed", {
+        exec,
+        githubCli: "/fixture/gh",
+      }),
     /Release tags are blocked until a dedicated release GitHub App/,
   );
 });

--- a/scripts/worktree-publish.sh
+++ b/scripts/worktree-publish.sh
@@ -54,7 +54,7 @@ else
   source "${SCRIPT_DIR}/lib/node-tooling.sh"
   NODE_BIN="$(resolve_node_bin)"
   GIT_BIN="$(command -v git || true)"
-  GH_BIN="$(command -v gh || true)"
+  GH_BIN="$("${NODE_BIN}" "${SCRIPT_DIR}/lib/github-tooling.mjs")"
   PYTHON_BIN="$(command -v python3 || true)"
   PUBLISH_CONTROL_STATE_ROOT="${HOME}/.freed/automation"
   PUBLISH_SCOPE_JSON=""


### PR DESCRIPTION
(AI Generated).

## Summary
- Resolve the GitHub CLI through one shared helper that checks PATH and standard Homebrew locations.
- Use the resolved absolute binary in publication, release authority validation, and machine diagnostics.
- Initialize every CI authority suite with the isolated lease archive runtime fixture.

## Testing
- npm run validate:feature
- node --test scripts/doctor.test.mjs
- node --test scripts/worktree-publish.test.mjs