### PR TITLE
chore: prepare v26.7.2900-dev

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freed/desktop",
   "private": true,
-  "version": "26.7.2800",
+  "version": "26.7.2900",
   "type": "module",
   "scripts": {
     "dev": "node ../../node_modules/vite/bin/vite.js",

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -1443,7 +1443,7 @@ dependencies = [
 
 [[package]]
 name = "freed-desktop"
-version = "26.7.2800"
+version = "26.7.2900"
 dependencies = [
  "base64 0.23.0",
  "criterion",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freed-desktop"
-version = "26.7.2800"
+version = "26.7.2900"
 description = "Freed Desktop - Escape algorithmic manipulation"
 authors = ["Freed"]
 edition = "2021"

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Freed",
-  "version": "26.7.2800",
+  "version": "26.7.2900",
   "identifier": "wtf.freed.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freed/pwa",
   "private": true,
-  "version": "26.7.2800",
+  "version": "26.7.2900",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/release-notes/daily/dev/26.7.29.json
+++ b/release-notes/daily/dev/26.7.29.json
@@ -1,0 +1,14 @@
+{
+  "channel": "dev",
+  "dayKey": "26.7.29",
+  "date": "2026-07-29",
+  "preferredDeck": null,
+  "editorialGuidance": [
+    "Keep the tone concise, professional, and specific.",
+    "Lead with user-facing outcomes, shipping milestones, trust wins, and installability improvements.",
+    "Demote internal cleanup unless it clearly changes the shipped product."
+  ],
+  "pinnedHighlights": [],
+  "editorialNotes": [],
+  "updatedAt": "2026-07-29T20:13:23.037Z"
+}

--- a/release-notes/releases/v26.7.2900-dev.json
+++ b/release-notes/releases/v26.7.2900-dev.json
@@ -3,8 +3,11 @@
   "version": "26.7.2900-dev",
   "channel": "dev",
   "dayKey": "26.7.29",
-  "approved": false,
-  "editorialNotes": [],
+  "approved": true,
+  "editorialNotes": [
+    "Lead with the visible theme work.",
+    "Keep Library Core explicitly dormant."
+  ],
   "generatedAt": "2026-07-29T20:13:23.037Z",
   "model": "heuristic",
   "source": {
@@ -86,29 +89,23 @@
     ]
   },
   "release": {
-    "deck": "Dormant native Library Core journal, starship and Dark Star themes, and verify Library Core operation transactions",
+    "deck": "Adds the source-faithful Starship and Dark Star themes, polishes theme controls across Freed, and expands the dormant Library Core without activating a new storage writer",
     "features": [
-      "Dormant native Library Core journal",
-      "Starship and Dark Star themes",
-      "Verify Library Core operation transactions"
+      "Starship and Dark Star bring AubOS-inspired color, type, radius, shadow, and map treatments to every main Freed surface",
+      "Theme previews and shared Theme and Zoom controls now appear at the top of the expanded right-side menu in Unified Feed, Friends, and Map",
+      "The dormant Library Core now includes a native authoritative journal, actor enrollment, signed transaction verification, projection receipts, and bounded feed queries"
     ],
     "fixes": [
-      "GitHub CLI outside shell PATH resolved",
-      "Isolate lease archive runtime in CI tests",
-      "Make doctor archive tests hermetic",
-      "Align feed fade boundaries",
-      "Fence Automerge saves on an exact storage revision",
-      "Make Friends performance gate deterministic"
+      "Theme changes no longer bounce through the previous persisted setting before settling on the new theme",
+      "Settings blur, spacing, shadows, active tile borders, hover outlines, button fills, feed fades, and right-side panel placement now stay consistent across themes",
+      "Release and publication tools now find the GitHub CLI in non-interactive shells, with hermetic authority tests on GitHub's Linux runners",
+      "Automerge saves are fenced to an exact storage revision, and the Friends performance gate is deterministic",
+      "Feed pages now use an indexable sort key while the active Automerge writer stays unchanged"
     ],
     "followUps": [
-      "Enroll Library Core actors",
-      "Materialize Library Core read assignments",
-      "Canonical Library Core protocol codecs",
-      "Crash-safe SQLite projection receipts",
-      "Dormant native SQLite projection kernel",
-      "Resolve the feed page sort contract on an indexable key",
-      "Close legacy epoch bootstrap contract"
+      "Library Core remains dormant in this build. Automerge stays the active writer, and no migration or storage epoch activates",
+      "The new themes do not change provider requests, navigation, cookies, headers, retries, or cadence"
     ]
   },
-  "releaseBody": "(AI Generated).\n\n## Freed v26.7.2900-dev\n\nDormant native Library Core journal, starship and Dark Star themes, and verify Library Core operation transactions\n\n### Features\n\n- Dormant native Library Core journal\n- Starship and Dark Star themes\n- Verify Library Core operation transactions\n\n### Fixes\n\n- GitHub CLI outside shell PATH resolved\n- Isolate lease archive runtime in CI tests\n- Make doctor archive tests hermetic\n- Align feed fade boundaries\n- Fence Automerge saves on an exact storage revision\n- Make Friends performance gate deterministic\n\n### Follow-ups\n\n- Enroll Library Core actors\n- Materialize Library Core read assignments\n- Canonical Library Core protocol codecs\n- Crash-safe SQLite projection receipts\n- Dormant native SQLite projection kernel\n- Resolve the feed page sort contract on an indexable key\n- Close legacy epoch bootstrap contract\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+  "releaseBody": "(AI Generated).\n\n## Freed v26.7.2900-dev\n\nAdds the source-faithful Starship and Dark Star themes, polishes theme controls across Freed, and expands the dormant Library Core without activating a new storage writer\n\n### Features\n\n- Starship and Dark Star bring AubOS-inspired color, type, radius, shadow, and map treatments to every main Freed surface\n- Theme previews and shared Theme and Zoom controls now appear at the top of the expanded right-side menu in Unified Feed, Friends, and Map\n- The dormant Library Core now includes a native authoritative journal, actor enrollment, signed transaction verification, projection receipts, and bounded feed queries\n\n### Fixes\n\n- Theme changes no longer bounce through the previous persisted setting before settling on the new theme\n- Settings blur, spacing, shadows, active tile borders, hover outlines, button fills, feed fades, and right-side panel placement now stay consistent across themes\n- Release and publication tools now find the GitHub CLI in non-interactive shells, with hermetic authority tests on GitHub's Linux runners\n- Automerge saves are fenced to an exact storage revision, and the Friends performance gate is deterministic\n- Feed pages now use an indexable sort key while the active Automerge writer stays unchanged\n\n### Known limits\n\n- Library Core remains dormant in this build. Automerge stays the active writer, and no migration or storage epoch activates\n- The new themes do not change provider requests, navigation, cookies, headers, retries, or cadence\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
 }

--- a/release-notes/releases/v26.7.2900-dev.json
+++ b/release-notes/releases/v26.7.2900-dev.json
@@ -1,0 +1,114 @@
+{
+  "tag": "v26.7.2900-dev",
+  "version": "26.7.2900-dev",
+  "channel": "dev",
+  "dayKey": "26.7.29",
+  "approved": false,
+  "editorialNotes": [],
+  "generatedAt": "2026-07-29T20:13:23.037Z",
+  "model": "heuristic",
+  "source": {
+    "channel": "dev",
+    "previousPublishedTag": "v26.7.2800-dev",
+    "previousPublishedDayTag": "v26.7.2800-dev",
+    "compareRef": "HEAD",
+    "productCommitSha": "e8195cace3f9810f0f6dd2d2cc364f21b307503f",
+    "promotedDevCommitSha": null,
+    "libraryCoreActivation": {
+      "schemaVersion": 1,
+      "range": {
+        "channel": "dev",
+        "previousPublishedTag": "v26.7.2800-dev",
+        "startMode": "previous_product_commit",
+        "fromExclusiveCommitSha": "7a2dbe6df63762fe7c0b83fc903dafc94ef16c30",
+        "toInclusiveProductCommitSha": "e8195cace3f9810f0f6dd2d2cc364f21b307503f"
+      },
+      "manifest": {
+        "path": "docs/library-core-activation-manifest.json",
+        "previousPresent": true,
+        "previousDigest": "sha256:96a22914b0b629c540ede98c41fb586b9695f139324fe033faae374dc83b3ccb",
+        "currentDigest": "sha256:96a22914b0b629c540ede98c41fb586b9695f139324fe033faae374dc83b3ccb"
+      },
+      "transitions": [],
+      "inspectionDigest": "sha256:c0eb42a4fa70462b14c1af89ecdea41e3bed898547c5260985710d874728eb3c",
+      "decision": {
+        "state": "no_activation_declared",
+        "ownerApprovalReference": null,
+        "approvedInspectionDigest": null,
+        "approvedReleaseArtifactDigest": null
+      }
+    },
+    "isLatestOfDay": true,
+    "sameDayTagsIncluded": [
+      "v26.7.2900-dev"
+    ],
+    "relatedBuildTags": [
+      "v26.7.2900-dev"
+    ],
+    "prNumbers": [
+      1212,
+      1216,
+      1218,
+      1219,
+      1220,
+      1221,
+      1222,
+      1223,
+      1224,
+      1225,
+      1227,
+      1228,
+      1229,
+      1231,
+      1232,
+      1233,
+      1236
+    ],
+    "commitSubjects": [
+      "fix: resolve GitHub CLI outside shell PATH (#1236)",
+      "feat: add dormant native Library Core journal (#1229)",
+      "fix: isolate lease archive runtime in CI tests (#1233)",
+      "feat: add Starship and Dark Star themes",
+      "fix: make doctor archive tests hermetic (#1232)",
+      "fix: align preview fade with sidebar (#1231)",
+      "feat: enroll Library Core actors (#1228)",
+      "feat: verify Library Core operation transactions (#1227)",
+      "feat: close Library Core operation envelopes (#1225)",
+      "feat: materialize Library Core read assignments (#1224)",
+      "feat: add canonical Library Core protocol codecs (#1223)",
+      "feat: add crash-safe SQLite projection receipts (#1222)",
+      "feat(storage): add dormant native SQLite projection kernel (#1221)",
+      "fix(sync): fence Automerge saves on an exact storage revision (#1220)",
+      "feat: resolve the feed page sort contract on an indexable key (#1219)",
+      "feat: close legacy epoch bootstrap contract (#1218)",
+      "feat: add dormant Library Core boundary census (#1212)",
+      "fix: make Friends performance gate deterministic (#1216)"
+    ]
+  },
+  "release": {
+    "deck": "Dormant native Library Core journal, starship and Dark Star themes, and verify Library Core operation transactions",
+    "features": [
+      "Dormant native Library Core journal",
+      "Starship and Dark Star themes",
+      "Verify Library Core operation transactions"
+    ],
+    "fixes": [
+      "GitHub CLI outside shell PATH resolved",
+      "Isolate lease archive runtime in CI tests",
+      "Make doctor archive tests hermetic",
+      "Align feed fade boundaries",
+      "Fence Automerge saves on an exact storage revision",
+      "Make Friends performance gate deterministic"
+    ],
+    "followUps": [
+      "Enroll Library Core actors",
+      "Materialize Library Core read assignments",
+      "Canonical Library Core protocol codecs",
+      "Crash-safe SQLite projection receipts",
+      "Dormant native SQLite projection kernel",
+      "Resolve the feed page sort contract on an indexable key",
+      "Close legacy epoch bootstrap contract"
+    ]
+  },
+  "releaseBody": "(AI Generated).\n\n## Freed v26.7.2900-dev\n\nDormant native Library Core journal, starship and Dark Star themes, and verify Library Core operation transactions\n\n### Features\n\n- Dormant native Library Core journal\n- Starship and Dark Star themes\n- Verify Library Core operation transactions\n\n### Fixes\n\n- GitHub CLI outside shell PATH resolved\n- Isolate lease archive runtime in CI tests\n- Make doctor archive tests hermetic\n- Align feed fade boundaries\n- Fence Automerge saves on an exact storage revision\n- Make Friends performance gate deterministic\n\n### Follow-ups\n\n- Enroll Library Core actors\n- Materialize Library Core read assignments\n- Canonical Library Core protocol codecs\n- Crash-safe SQLite projection receipts\n- Dormant native SQLite projection kernel\n- Resolve the feed page sort contract on an indexable key\n- Close legacy epoch bootstrap contract\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+}

--- a/release-notes/releases/v26.7.2900-dev.md
+++ b/release-notes/releases/v26.7.2900-dev.md
@@ -2,32 +2,26 @@
 
 ## Freed v26.7.2900-dev
 
-Dormant native Library Core journal, starship and Dark Star themes, and verify Library Core operation transactions
+Adds the source-faithful Starship and Dark Star themes, polishes theme controls across Freed, and expands the dormant Library Core without activating a new storage writer
 
 ### Features
 
-- Dormant native Library Core journal
-- Starship and Dark Star themes
-- Verify Library Core operation transactions
+- Starship and Dark Star bring AubOS-inspired color, type, radius, shadow, and map treatments to every main Freed surface
+- Theme previews and shared Theme and Zoom controls now appear at the top of the expanded right-side menu in Unified Feed, Friends, and Map
+- The dormant Library Core now includes a native authoritative journal, actor enrollment, signed transaction verification, projection receipts, and bounded feed queries
 
 ### Fixes
 
-- GitHub CLI outside shell PATH resolved
-- Isolate lease archive runtime in CI tests
-- Make doctor archive tests hermetic
-- Align feed fade boundaries
-- Fence Automerge saves on an exact storage revision
-- Make Friends performance gate deterministic
+- Theme changes no longer bounce through the previous persisted setting before settling on the new theme
+- Settings blur, spacing, shadows, active tile borders, hover outlines, button fills, feed fades, and right-side panel placement now stay consistent across themes
+- Release and publication tools now find the GitHub CLI in non-interactive shells, with hermetic authority tests on GitHub's Linux runners
+- Automerge saves are fenced to an exact storage revision, and the Friends performance gate is deterministic
+- Feed pages now use an indexable sort key while the active Automerge writer stays unchanged
 
-### Follow-ups
+### Known limits
 
-- Enroll Library Core actors
-- Materialize Library Core read assignments
-- Canonical Library Core protocol codecs
-- Crash-safe SQLite projection receipts
-- Dormant native SQLite projection kernel
-- Resolve the feed page sort contract on an indexable key
-- Close legacy epoch bootstrap contract
+- Library Core remains dormant in this build. Automerge stays the active writer, and no migration or storage epoch activates
+- The new themes do not change provider requests, navigation, cookies, headers, retries, or cadence
 
 ### Downloads
 

--- a/release-notes/releases/v26.7.2900-dev.md
+++ b/release-notes/releases/v26.7.2900-dev.md
@@ -1,0 +1,38 @@
+(AI Generated).
+
+## Freed v26.7.2900-dev
+
+Dormant native Library Core journal, starship and Dark Star themes, and verify Library Core operation transactions
+
+### Features
+
+- Dormant native Library Core journal
+- Starship and Dark Star themes
+- Verify Library Core operation transactions
+
+### Fixes
+
+- GitHub CLI outside shell PATH resolved
+- Isolate lease archive runtime in CI tests
+- Make doctor archive tests hermetic
+- Align feed fade boundaries
+- Fence Automerge saves on an exact storage revision
+- Make Friends performance gate deterministic
+
+### Follow-ups
+
+- Enroll Library Core actors
+- Materialize Library Core read assignments
+- Canonical Library Core protocol codecs
+- Crash-safe SQLite projection receipts
+- Dormant native SQLite projection kernel
+- Resolve the feed page sort contract on an indexable key
+- Close legacy epoch bootstrap contract
+
+### Downloads
+
+**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  
+**Windows:** `.exe` (NSIS installer)  
+**Linux:** `.AppImage`  
+
+> macOS downloads are signed and notarized for normal Gatekeeper installation.


### PR DESCRIPTION
(AI Generated).

## Summary
- Bump Freed Desktop and PWA to v26.7.2900-dev.
- Publish reviewed notes for Starship, Dark Star, and the dormant Library Core foundations.
- Record that this release declares no Library Core activation and no provider-visible behavior change.

## Testing
- npm run validate:feature