### PR TITLE
fix: align Friends graph layout contract

### DIFF
--- a/packages/desktop/tests/e2e/theme-switching.spec.ts
+++ b/packages/desktop/tests/e2e/theme-switching.spec.ts
@@ -616,11 +616,9 @@ test("friends graph controls align to the graph lane between sidebars", async ({
     leftGapPx: 0,
     topGapPx: 0,
     rightGapPx: 0,
-    // The content frame keeps its --feed-card-gap bottom padding in the friends
-    // view, so the graph lane sits one gap above the window edge. Horizontal
-    // gaps stay 0 because they are measured against the sidebar and the handle,
-    // which the same padding shifts.
-    bottomGapPx: 8,
+    // The graph is the primary full-height canvas. Each floating sidebar owns
+    // its panel inset, so the graph itself reaches the window edge.
+    bottomGapPx: 0,
     fitAllTopGapPx: 16,
     controlsRightGapPx: 16,
     friendsSidebarTopGapPx: 8,


### PR DESCRIPTION
(AI Generated).

## Summary
- Keep the Friends graph as the full-height primary canvas while each floating sidebar owns its panel inset.
- Correct the regression assertion that still expected the removed global bottom padding.

## Testing
- npm run validate:feature
- theme-switching.spec.ts, 9 tests