### PR TITLE
fix: shard nightly tooling tests independently

### DIFF
--- a/scripts/lib/tooling-smoke-suites.mjs
+++ b/scripts/lib/tooling-smoke-suites.mjs
@@ -10,6 +10,7 @@ export const REPO_ROOT = path.resolve(LIB_DIRECTORY, "..", "..");
 export const SHARDED_TEST_FILES = Object.freeze({
   "automation-control": "scripts/automation-control.test.mjs",
   "kernel-guard-cutover": "scripts/automation-kernel-guard-cutover.test.mjs",
+  "nightly-self-improve": "scripts/nightly-self-improve.test.mjs",
   "outcome-ledger-repair": "scripts/outcome-ledger-repair.test.mjs",
 });
 

--- a/scripts/nightly-self-improve.test.mjs
+++ b/scripts/nightly-self-improve.test.mjs
@@ -5819,7 +5819,7 @@ for (const [state, requiredControlEvents] of Object.entries({
   implemented: 4,
   validated: 3,
 })) {
-  test(`${state} target requires ${requiredControlEvents.toLocaleString()} control event slots and one outcome slot`, () => {
+  test(`target state ${state} requires ${requiredControlEvents.toLocaleString()} control event slots and one outcome slot`, () => {
     const candidate = {
       id: `capacity-${state}`,
       taskId: `capacity-${state}`,
@@ -6743,7 +6743,7 @@ test("appendOutcomeLedger crash recovery reserves merged and installed outcomes 
 });
 
 for (const route of ["fresh", "legacy-backfill"]) {
-  test(`${route} installed identity drift blocks finalization and continuous trust`, () => {
+  test(`installed identity route ${route} drift blocks finalization and continuous trust`, () => {
     const stateRoot = temporaryOutcomeStateRoot(
       `freed-installed-${route}-finalization-`,
     );

--- a/scripts/run-tooling-smoke-shard.mjs
+++ b/scripts/run-tooling-smoke-shard.mjs
@@ -184,7 +184,45 @@ function patternsCanOverlap(left, right) {
   return prefixesCompatible && suffixesCompatible;
 }
 
-export function extractTopLevelTestUnits(source, label = "test source") {
+function transparentLocalTestWrapper(node) {
+  if (
+    !ts.isFunctionDeclaration(node) ||
+    node.name?.text !== "test" ||
+    node.parent === undefined ||
+    !ts.isSourceFile(node.parent) ||
+    node.parameters.length === 0 ||
+    !ts.isIdentifier(node.parameters[0].name) ||
+    node.body === undefined
+  ) {
+    return false;
+  }
+  const nameParameter = node.parameters[0].name.text;
+  const delegatedReturns = [];
+  const inspect = (child) => {
+    if (
+      ts.isReturnStatement(child) &&
+      child.expression !== undefined &&
+      ts.isCallExpression(child.expression) &&
+      ts.isIdentifier(child.expression.expression) &&
+      child.expression.expression.text === "nodeTest"
+    ) {
+      delegatedReturns.push(child.expression);
+    }
+    ts.forEachChild(child, inspect);
+  };
+  inspect(node.body);
+  return (
+    delegatedReturns.length === 1 &&
+    ts.isIdentifier(delegatedReturns[0].arguments[0]) &&
+    delegatedReturns[0].arguments[0].text === nameParameter
+  );
+}
+
+export function extractTopLevelTestUnits(
+  source,
+  label = "test source",
+  { allowTransparentLocalWrapper = false } = {},
+) {
   const sourceFile = ts.createSourceFile(
     label,
     source,
@@ -238,7 +276,11 @@ export function extractTopLevelTestUnits(source, label = "test source") {
         (ts.isImportClause(node.parent) && node.parent.name === node) ||
         (ts.isCallExpression(node.parent) && node.parent.expression === node) ||
         (ts.isPropertyAccessExpression(node.parent) &&
-          node.parent.name === node)
+          node.parent.name === node) ||
+        (allowTransparentLocalWrapper &&
+          ts.isFunctionDeclaration(node.parent) &&
+          node.parent.name === node &&
+          transparentLocalTestWrapper(node.parent))
       )
     ) {
       fail(`${label} aliases or passes the top-level test registrar.`);
@@ -391,7 +433,9 @@ export function buildToolingSmokeShardPlan(
   }
   const testFile = SHARDED_TEST_FILES[suite];
   const source = readFileSync(path.join(repoRoot, testFile), "utf8");
-  const extractedUnits = extractTopLevelTestUnits(source, testFile);
+  const extractedUnits = extractTopLevelTestUnits(source, testFile, {
+    allowTransparentLocalWrapper: suite === "nightly-self-improve",
+  });
   const measuredWeights = completeMeasuredUnitWeights(
     recorded,
     suite,

--- a/scripts/run-tooling-smoke-shard.test.mjs
+++ b/scripts/run-tooling-smoke-shard.test.mjs
@@ -90,6 +90,33 @@ for (const variant of ["one", "two"]) {
   assert.equal(pattern.test("not registered"), false);
 });
 
+test("top-level extraction admits only a name-transparent local test wrapper", () => {
+  const transparent = `
+    import nodeTest from "node:test";
+    function test(name, callback) {
+      return nodeTest(name, async (context) => callback(context));
+    }
+    test("first", () => {});
+  `;
+  assert.deepEqual(
+    extractTopLevelTestUnits(transparent, "wrapped.test.mjs", {
+      allowTransparentLocalWrapper: true,
+    }).map(({ name }) => name),
+    ["first"],
+  );
+  const renamed = transparent.replace(
+    "return nodeTest(name,",
+    "return nodeTest(`wrapped: ${name}`,",
+  );
+  assert.throws(
+    () =>
+      extractTopLevelTestUnits(renamed, "renamed.test.mjs", {
+        allowTransparentLocalWrapper: true,
+      }),
+    /aliases or passes/,
+  );
+});
+
 test("shard assignment covers every item exactly once", () => {
   const items = Array.from({ length: 64 }, (_, index) => `test ${index}`);
   const assignments = Array.from({ length: 8 }, (_, index) =>
@@ -247,6 +274,7 @@ test("repository plans are nonempty and cover each named suite", () => {
     "general",
     "automation-control",
     "kernel-guard-cutover",
+    "nightly-self-improve",
     "outcome-ledger-repair",
   ]) {
     const plans = Array.from({ length: 8 }, (_, index) =>
@@ -266,6 +294,7 @@ test("repository plans are nonempty and cover each named suite", () => {
       const specialFiles = new Set([
         "scripts/automation-control.test.mjs",
         "scripts/automation-kernel-guard-cutover.test.mjs",
+        "scripts/nightly-self-improve.test.mjs",
         "scripts/outcome-ledger-repair.test.mjs",
       ]);
       // The darwin-only files moved to the macOS lane. They gate every test
@@ -309,7 +338,9 @@ test("repository plans are nonempty and cover each named suite", () => {
       const source = readFileSync(path.join(process.cwd(), testFile), "utf8");
       assert.equal(
         names.length,
-        extractTopLevelTestUnits(source, testFile).length,
+        extractTopLevelTestUnits(source, testFile, {
+          allowTransparentLocalWrapper: suite === "nightly-self-improve",
+        }).length,
       );
     }
   }

--- a/scripts/tooling-smoke-durations.json
+++ b/scripts/tooling-smoke-durations.json
@@ -1,13 +1,13 @@
 {
   "schemaVersion": 1,
-  "note": "Measured on ubuntu-latest CI, run 30140909175 / 30143xxxxx (2026-07-25), with outcome-ledger-repair re-measured from run 30166138958 where all 8 of its shards completed. Seconds are per-suite totals summed across that run's shards, so they include per-shard job overhead and read slightly high at low shard counts, which is the safe direction. Source size is a poor runtime proxy: within the general suite the byte-weighted split produced shards of 41s and 4,909s, a 120x spread. Refresh with: node scripts/measure-tooling-smoke.mjs --write, or from CI shard durations.",
+  "note": "Measured on ubuntu-latest CI, run 30140909175 / 30143xxxxx (2026-07-25), with outcome-ledger-repair re-measured from run 30166138958 where all 8 of its shards completed. Seconds are per-suite totals summed across that run's shards, so they include per-shard job overhead and read slightly high at low shard counts, which is the safe direction. The former general suite had shards of 41s, 406s, 1,323s, and 4,909s. The 4,909s shard contained only nightly-self-improve.test.mjs, so its observed duration is now assigned to that independently sharded suite and the remaining three shard durations stay with general. Refresh with: node scripts/measure-tooling-smoke.mjs --write, or from CI shard durations.",
   "suites": {
     "general": {
-      "seconds": 6679,
+      "seconds": 1770,
       "runs": 1,
       "failures": 0,
       "flaky": false,
-      "source": "ci-shards 41+406+1323+4909"
+      "source": "ci-shards 41+406+1323 after nightly-self-improve extraction"
     },
     "automation-control": {
       "seconds": 8689,
@@ -22,6 +22,13 @@
       "failures": 0,
       "flaky": false,
       "source": "ci-shard 4800 (single shard, 80 min, observed 2026-07-25). Replaces 3648s, which was a third low and left this suite one shard away from the 90 minute cap."
+    },
+    "nightly-self-improve": {
+      "seconds": 4909,
+      "runs": 1,
+      "failures": 0,
+      "flaky": false,
+      "source": "former general shard 4/4, which contained only scripts/nightly-self-improve.test.mjs"
     },
     "outcome-ledger-repair": {
       "seconds": 17266,

--- a/scripts/tooling-smoke-plan.test.mjs
+++ b/scripts/tooling-smoke-plan.test.mjs
@@ -120,7 +120,7 @@ test("the real plan fits every suite inside the shard timeout", () => {
   // and invited whoever fixed it to decide whether the guard was still needed.
   // outcome-ledger-repair has since been re-measured from a run where all
   // eight of its shards completed, 17,266s against the 5,415s floor a killed
-  // shard had left behind, and the job budget was raised to 12 so the
+  // shard had left behind, and the job budget was raised to 16 so the
   // allocator can actually spread it.
   //
   // Kept pointing at the checked-in durations file rather than a fixture, and
@@ -135,6 +135,11 @@ test("the real plan fits every suite inside the shard timeout", () => {
     assert.equal(entry.fits, true, `${entry.suite} was expected to fit`);
     assert.equal(entry.predictedFrom, "measured");
   }
+  assert.ok(
+    plan.include.filter((entry) => entry.suite === "nightly-self-improve")
+      .length >= 2,
+    "the observed 82-minute nightly file must not collapse back into one shard",
+  );
 });
 
 test("the plan still schedules work when a suite is predicted to overrun", () => {


### PR DESCRIPTION
(AI Generated).

## Summary
- Extract the 82-minute nightly self-improvement suite from ordinary general tooling validation.
- Shard the suite by stable top-level test names while preserving its bounded fixture wrapper.
- Use recorded CI duration evidence so ordinary Library Core PRs no longer inherit the nightly corpus.

## Testing
- npm run validate:feature
- focused nightly name-selection run: 6 passed
- main backflow, diff check, and provider classifier