### PR TITLE
fix: remove card density menu divider

### DIFF
--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -2059,7 +2059,7 @@ export function Header({
         >
           <div
             data-testid="view-menu-appearance-section"
-            className={`${showFilterMenuContextControls ? "border-b border-[var(--theme-border-subtle)]" : ""} px-3 pb-3 pt-1`}
+            className={`${showFilterMenuContextControls && !showFilterMenuFeedCardDensityControl ? "border-b border-[var(--theme-border-subtle)]" : ""} px-3 pb-3 pt-1`}
           >
             <div data-testid="feed-filter-theme-section">
               <p className="mb-2 px-1 text-[0.68rem] font-semibold uppercase tracking-[0.18em] text-[var(--theme-text-muted)]">


### PR DESCRIPTION
(AI Generated).

## Summary
- Remove the horizontal divider between the shared Theme and Zoom controls and feed-specific Card density control while preserving the dividers around later menu sections.

## Testing
- npm run validate:feature
- Desktop E2E: filter menu theme row and narrow toolbar card density