### PR TITLE
feat: materialize bounded PWA browse generations

### DIFF
--- a/docs/LIBRARY-CORE-CONTRACT.md
+++ b/docs/LIBRARY-CORE-CONTRACT.md
@@ -2581,20 +2581,24 @@ binary-sorts set-like tag and signal inputs, and pins hidden, archived,
 platform, RSS identity, author, feed URL, post/story, saved, tag, and signal
 semantics. The renderer normalizes once per browse pass and applies the same
 predicate without allocating one adapter object per item. This closes the
-semantic filter definition, not its storage execution. `feed_page_v1` remains
-the narrower default page. A later registered query must push every normalized
-predicate into SQLite and IndexedDB, bind that normalized filter to its cursor,
-store archived rows in a separately safe generation contract, and prove exact
-result parity before a product reader can use it. Recommendation ordering is
-also not silently approximated. Version 1 preserves the current two stable
-passes exactly: published time descending, then computed priority descending.
+semantic filter definition. `feed_page_v1` remains the narrower default page.
+The dormant PWA browse projector now applies every normalized predicate while
+building a query-specific IndexedDB generation, including archived and hidden
+variants without changing the default generation. A later registered query
+must still bind that normalized filter to its request and cursor, implement the
+same execution in SQLite, and prove exact result parity before a product reader
+can use it. Recommendation ordering is not silently approximated. Version 1
+preserves the current two stable passes exactly: published time descending,
+then computed priority descending.
 The complete order is therefore priority descending, published time
 descending, then source-map enumeration sequence ascending. Both current
 workers use one shared comparator contract. A bounded adapter must compute
 priority from one generation-bound clock, retain the source enumeration
 sequence, push the full order into its storage query, and bind the order
-version and clock identity to its cursor. Defining this order does not yet
-implement that storage query.
+version and clock identity to its cursor. The dormant PWA projector now freezes
+one safe ranking clock, retains source sequence, and writes the complete order
+tuple into its IndexedDB compound key. The bounded browse request and cursor
+that consume those rows remain unregistered.
 
 The cursor is versioned binary data encoded as canonical unpadded base64url. It
 binds the immutable generation digest, transition sequence, projection
@@ -2650,11 +2654,13 @@ Both platform runtimes are now implemented, so
 `runtime_adapter_unimplemented` is resolved for `feed_page_v1`.
 The product filter predicate is now defined once and used by the current
 renderer. The current recommendation order is also defined once and used by
-both active workers, but native and IndexedDB predicate and ordering execution,
+both active workers. The PWA now also persists exact filtered recommendation
+order in a separate query-specific IndexedDB generation while holding at most
+one 128-row output page. Native execution, a closed bounded browse transport,
 renderer-cache eviction, and product caller proof remain absent.
 `adapter_proof_missing` therefore still blocks the query. Authenticated PWA
-materialization, runtime registration, and shared semantic contracts do not
-assign a product reader or activate Gate D.
+materialization, runtime registration, shared semantic contracts, and dormant
+browse projection do not assign a product reader or activate Gate D.
 
 An interactive cursor does not pin an unbounded SQLite read transaction or WAL.
 If an adapter uses a pinned snapshot, the query registry declares its maximum

--- a/docs/PHASE-4-SYNC.md
+++ b/docs/PHASE-4-SYNC.md
@@ -371,6 +371,7 @@ recovery, telemetry, milestones, and acceptance tests.
 | 4.87 | Dormant authenticated PWA feed materializer with committed-head source identity, one-item projection, 128-row staging bounds, exact replay, visibility parity, and no product caller | ✓ | Medium |
 | 4.88 | Canonical normalized feed-filter contract shared by the current renderer and future bounded adapters, with exact archived, hidden, source, author, feed, post/story, saved, tag, and signal semantics | ✓ | Medium |
 | 4.89 | Canonical recommendation-order contract shared by both current workers, preserving priority, published-time, and source-enumeration tie semantics for future bounded adapters | ✓ | Medium |
+| 4.90 | Dormant query-specific PWA browse projection with normalized filter and ranking-clock source identity, exact recommendation-order index keys, 128-row staging bounds, IndexedDB v1 upgrade preservation, and no product caller | ✓ | Medium |
 
 ---
 

--- a/docs/STORAGE-ARCHITECTURE-ROADMAP.md
+++ b/docs/STORAGE-ARCHITECTURE-ROADMAP.md
@@ -56,10 +56,14 @@ authenticate and materialize its row generation without activating a reader.
 The current renderer and future bounded adapters also share one canonical
 normalized product-filter predicate. Both current workers also share one exact
 recommendation-order contract that preserves priority, published-time, and
-source-enumeration tie semantics. Filter and ordering pushdown,
-archived-generation coverage, renderer-cache eviction, and product caller
-proof remain explicit blockers. This is progress inside Gate B and step 4, not
-a claim that either gate is complete.
+source-enumeration tie semantics. The PWA can now materialize a separate
+query-specific browse generation whose authenticated identity binds the
+normalized filter, one ranking clock, and the order version. It streams at most
+128 projected rows at a time and lets IndexedDB enforce the exact priority,
+published-time, and source-sequence order. A bounded browse request, cursor,
+and response contract, native execution, renderer-cache eviction, and product
+caller proof remain explicit blockers. This is progress inside Gate B and step
+4, not a claim that either gate is complete.
 
 The Desktop derived-shadow path now also has a dormant bounded projection
 probe. It pins one exact durable Automerge frontier and storage revision, emits

--- a/packages/pwa/src/lib/automerge-types.ts
+++ b/packages/pwa/src/lib/automerge-types.ts
@@ -21,10 +21,12 @@ import type {
 } from "@freed/shared";
 import type { DocumentHistoryRelation } from "@freed/shared/schema";
 import type {
+  LibraryCoreFeedBrowseFilterInputV1,
   LibraryCoreFeedPageRequestV1,
   LibraryCoreFeedPageSourceV1,
 } from "@freed/shared/library-core";
 import type { StorageRevision } from "@freed/sync/types";
+import type { MaterializePwaLibraryCoreFeedBrowseGenerationResult } from "./library-core-feed-browse-materializer";
 import type { PwaLibraryCoreFeedReaderResult } from "./library-core-feed-reader-runtime";
 
 export type { DocumentHistoryRelation } from "@freed/shared/schema";
@@ -173,6 +175,12 @@ export type WorkerRequest =
   | { reqId: number; type: "MATERIALIZE_LIBRARY_CORE_FEED_GENERATION" }
   | {
       reqId: number;
+      type: "MATERIALIZE_LIBRARY_CORE_FEED_BROWSE_GENERATION";
+      filter?: LibraryCoreFeedBrowseFilterInputV1;
+      rankingClockMs: number;
+    }
+  | {
+      reqId: number;
       type: "READ_LIBRARY_CORE_FEED_PAGE";
       request: LibraryCoreFeedPageRequestV1;
     }
@@ -231,6 +239,11 @@ export type WorkerResponse =
       type: "LIBRARY_CORE_FEED_GENERATION_RESULT";
       source: LibraryCoreFeedPageSourceV1;
       totalCount: number;
+    }
+  | {
+      reqId: number;
+      type: "LIBRARY_CORE_FEED_BROWSE_GENERATION_RESULT";
+      result: MaterializePwaLibraryCoreFeedBrowseGenerationResult;
     }
   | {
       reqId: number;

--- a/packages/pwa/src/lib/automerge.ts
+++ b/packages/pwa/src/lib/automerge.ts
@@ -21,7 +21,10 @@ import type {
   SampleDataClearSummary,
   UserPreferences,
 } from "@freed/shared";
-import type { LibraryCoreFeedPageRequestV1 } from "@freed/shared/library-core";
+import type {
+  LibraryCoreFeedBrowseFilterInputV1,
+  LibraryCoreFeedPageRequestV1,
+} from "@freed/shared/library-core";
 import type {
   CommittedAutomergeDoc,
   DocState,
@@ -32,6 +35,7 @@ import type {
 } from "./automerge-types";
 import { IndexedDBStorage } from "@freed/sync/storage/indexeddb";
 import { persistWorkerDebugEvent } from "./automerge-worker-debug";
+import type { MaterializePwaLibraryCoreFeedBrowseGenerationResult } from "./library-core-feed-browse-materializer";
 import type { MaterializePwaLibraryCoreFeedGenerationResult } from "./library-core-feed-materializer";
 import type { PwaLibraryCoreFeedReaderResult } from "./library-core-feed-reader-runtime";
 import {
@@ -132,6 +136,10 @@ const pendingLibraryCoreFeedGeneration = new Map<
   number,
   GenerationOwnedRequest<MaterializePwaLibraryCoreFeedGenerationResult>
 >();
+const pendingLibraryCoreFeedBrowseGeneration = new Map<
+  number,
+  GenerationOwnedRequest<MaterializePwaLibraryCoreFeedBrowseGenerationResult>
+>();
 const pendingLibraryCoreFeedPage = new Map<
   number,
   GenerationOwnedRequest<PwaLibraryCoreFeedReaderResult>
@@ -151,6 +159,10 @@ const pendingMaps: Array<Map<number, GenerationOwnedRequest<unknown>>> = [
   pendingDocRelationship as Map<number, GenerationOwnedRequest<unknown>>,
   pendingLegacyHtml as Map<number, GenerationOwnedRequest<unknown>>,
   pendingLibraryCoreFeedGeneration as Map<
+    number,
+    GenerationOwnedRequest<unknown>
+  >,
+  pendingLibraryCoreFeedBrowseGeneration as Map<
     number,
     GenerationOwnedRequest<unknown>
   >,
@@ -563,6 +575,18 @@ function handleWorkerMessage(
     return;
   }
 
+  if (msg.type === "LIBRARY_CORE_FEED_BROWSE_GENERATION_RESULT") {
+    const pendingGeneration = getOwnedRequest(
+      pendingLibraryCoreFeedBrowseGeneration,
+      msg.reqId,
+      generation.id,
+    );
+    if (!pendingGeneration) return;
+    pendingLibraryCoreFeedBrowseGeneration.delete(msg.reqId);
+    pendingGeneration.resolve(msg.result);
+    return;
+  }
+
   if (msg.type === "LIBRARY_CORE_FEED_PAGE_RESULT") {
     const pendingPage = getOwnedRequest(
       pendingLibraryCoreFeedPage,
@@ -703,6 +727,17 @@ function handleWorkerMessage(
   if (pendingFeedGeneration && msg.error) {
     pendingLibraryCoreFeedGeneration.delete(msg.reqId);
     pendingFeedGeneration.reject(new Error(msg.error));
+    return;
+  }
+
+  const pendingFeedBrowseGeneration = getOwnedRequest(
+    pendingLibraryCoreFeedBrowseGeneration,
+    msg.reqId,
+    generation.id,
+  );
+  if (pendingFeedBrowseGeneration && msg.error) {
+    pendingLibraryCoreFeedBrowseGeneration.delete(msg.reqId);
+    pendingFeedBrowseGeneration.reject(new Error(msg.error));
     return;
   }
 
@@ -941,6 +976,26 @@ export async function materializeLibraryCoreFeedGeneration(): Promise<Materializ
     {
       reqId,
       type: "MATERIALIZE_LIBRARY_CORE_FEED_GENERATION",
+    } satisfies WorkerRequest,
+  );
+}
+
+/**
+ * Build one dormant, query-specific PWA row generation from the committed
+ * worker document. No product surface calls this before governed cutover.
+ */
+export async function materializeLibraryCoreFeedBrowseGeneration(
+  filter: LibraryCoreFeedBrowseFilterInputV1,
+  rankingClockMs: number,
+): Promise<MaterializePwaLibraryCoreFeedBrowseGenerationResult> {
+  const reqId = nextReqId++;
+  return requestResult(
+    pendingLibraryCoreFeedBrowseGeneration,
+    {
+      reqId,
+      type: "MATERIALIZE_LIBRARY_CORE_FEED_BROWSE_GENERATION",
+      filter,
+      rankingClockMs,
     } satisfies WorkerRequest,
   );
 }

--- a/packages/pwa/src/lib/automerge.worker.ts
+++ b/packages/pwa/src/lib/automerge.worker.ts
@@ -82,6 +82,7 @@ import type {
   WorkerResponse,
 } from "./automerge-types";
 import { materializePwaLibraryCoreFeedGeneration } from "./library-core-feed-materializer";
+import { materializePwaLibraryCoreFeedBrowseGeneration } from "./library-core-feed-browse-materializer";
 import { createPwaLibraryCoreFeedReaderRuntime } from "./library-core-feed-reader-runtime";
 
 // ---------------------------------------------------------------------------
@@ -1077,6 +1078,23 @@ async function handleRequest(req: WorkerRequest): Promise<void> {
           type: "LIBRARY_CORE_FEED_GENERATION_RESULT",
           source: result.source,
           totalCount: result.totalCount,
+        });
+        break;
+      }
+
+      case "MATERIALIZE_LIBRARY_CORE_FEED_BROWSE_GENERATION": {
+        if (!currentDoc) throw new Error("Document not initialized");
+        send({
+          reqId: req.reqId,
+          type: "LIBRARY_CORE_FEED_BROWSE_GENERATION_RESULT",
+          result: await materializePwaLibraryCoreFeedBrowseGeneration({
+            committed: persistence.current(),
+            document: currentDoc,
+            filter: req.filter,
+            rankingClockMs: req.rankingClockMs,
+            subtle: crypto.subtle,
+            writer: getLibraryCoreFeedReader(),
+          }),
         });
         break;
       }

--- a/packages/pwa/src/lib/library-core-feed-browse-materializer.test.ts
+++ b/packages/pwa/src/lib/library-core-feed-browse-materializer.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "vitest";
+import {
+  filterFeedItems,
+  rankFeedItemsInRecommendedOrder,
+  type FeedItem,
+} from "@freed/shared";
+import { createEmptyDoc } from "@freed/shared/schema";
+
+import { materializePwaLibraryCoreFeedBrowseGeneration } from "./library-core-feed-browse-materializer";
+import type {
+  AppendPwaLibraryCoreBrowseGenerationPageInput,
+  PwaLibraryCoreBrowseProjectedRowV1,
+} from "./library-core-feed-reader-runtime";
+
+const NOW = 1_780_000_000_000;
+
+function item(
+  globalId: string,
+  publishedAt: number,
+  overrides: Partial<FeedItem> = {},
+): FeedItem {
+  return {
+    author: {
+      displayName: globalId,
+      handle: globalId,
+      id: `author:${globalId}`,
+    },
+    capturedAt: NOW,
+    content: { mediaTypes: [], mediaUrls: [], text: globalId },
+    contentType: "post",
+    globalId,
+    platform: "x",
+    publishedAt,
+    topics: [],
+    userState: {
+      archived: false,
+      hidden: false,
+      saved: false,
+      tags: [],
+    },
+    ...overrides,
+  } as FeedItem;
+}
+
+describe("PWA Library Core browse materializer", () => {
+  it("streams filtered recommendation tuples in bounded pages with exact order metadata", async () => {
+    const document = createEmptyDoc();
+    const sourceItems = Array.from({ length: 385 }, (_, index) => {
+      const globalId = `x:${index.toString().padStart(3, "0")}`;
+      return item(globalId, NOW - (index % 11) * 60_000, {
+        topics: index % 5 === 0 ? ["essay"] : [],
+        userState: {
+          archived: false,
+          hidden: index === 384,
+          saved: index % 2 === 0,
+          tags: index % 3 === 0 ? ["work"] : [],
+        },
+      });
+    });
+    document.feedItems = Object.fromEntries(
+      sourceItems.map((value) => [value.globalId, value]),
+    );
+    document.preferences.weights.authors["author:x:006"] = 100;
+
+    const pages: PwaLibraryCoreBrowseProjectedRowV1[][] = [];
+    const result = await materializePwaLibraryCoreFeedBrowseGeneration({
+      committed: {
+        heads: ["a".repeat(64)],
+        revision: { generation: 4, saveRevision: 9 },
+      },
+      document,
+      filter: { savedOnly: true },
+      rankingClockMs: NOW,
+      subtle: crypto.subtle,
+      writer: {
+        async appendBrowseGenerationPage(
+          input: AppendPwaLibraryCoreBrowseGenerationPageInput,
+        ) {
+          pages.push([...input.rows]);
+        },
+        async beginBrowseGeneration(input) {
+          expect(input.totalCount).toBe(192);
+          return "staging";
+        },
+        async finalizeBrowseGeneration() {},
+      },
+    });
+
+    expect(pages.map((page) => page.length)).toStrictEqual([128, 64]);
+    const projected = pages.flat();
+    expect(projected.map(({ sourceSequence }) => sourceSequence)).toStrictEqual(
+      Array.from({ length: 192 }, (_, index) => index * 2),
+    );
+    const materializedOrder = [...projected]
+      .sort(
+        (left, right) =>
+          right.priority - left.priority ||
+          (right.row.publishedAt ?? 0) - (left.row.publishedAt ?? 0) ||
+          left.sourceSequence - right.sourceSequence,
+      )
+      .map(({ row }) => row.globalId);
+    const expectedOrder = rankFeedItemsInRecommendedOrder(
+      filterFeedItems(sourceItems, { savedOnly: true }),
+      document.preferences.weights,
+      { accounts: document.accounts, persons: document.persons },
+      NOW,
+    ).map(({ globalId }) => globalId);
+
+    expect(materializedOrder).toStrictEqual(expectedOrder);
+    expect(result).toMatchObject({
+      filter: {
+        savedOnly: true,
+        schemaVersion: 1,
+      },
+      rankingClockMs: NOW,
+      totalCount: 192,
+    });
+  });
+
+  it("binds normalized filter and ranking clock into generation identity", async () => {
+    const document = createEmptyDoc();
+    const identities: string[] = [];
+    const run = async (
+      tags: string[],
+      rankingClockMs: number,
+    ): Promise<void> => {
+      const result = await materializePwaLibraryCoreFeedBrowseGeneration({
+        committed: {
+          heads: ["b".repeat(64)],
+          revision: { generation: 5, saveRevision: 10 },
+        },
+        document,
+        filter: { tags },
+        rankingClockMs,
+        subtle: crypto.subtle,
+        writer: {
+          async appendBrowseGenerationPage() {},
+          async beginBrowseGeneration() {
+            return "staging";
+          },
+          async finalizeBrowseGeneration() {},
+        },
+      });
+      identities.push(result.source.generationId);
+    };
+
+    await run(["work", "favorite", "work"], NOW);
+    await run(["favorite", "work"], NOW);
+    await run(["favorite", "work"], NOW + 1);
+
+    expect(identities[0]).toBe(identities[1]);
+    expect(identities[2]).not.toBe(identities[1]);
+  });
+});

--- a/packages/pwa/src/lib/library-core-feed-browse-materializer.ts
+++ b/packages/pwa/src/lib/library-core-feed-browse-materializer.ts
@@ -1,0 +1,221 @@
+import {
+  calculatePriority,
+  mergeDefaultPreferences,
+  type FeedItem,
+} from "@freed/shared";
+import type { FreedDoc } from "@freed/shared/schema";
+import {
+  LIBRARY_CORE_FEED_RECOMMENDATION_ORDER_SCHEMA_VERSION,
+  matchesLibraryCoreFeedBrowseFilterV1,
+  normalizeLibraryCoreFeedBrowseFilterV1,
+  projectLibraryCoreFeedCardV1,
+  type LibraryCoreFeedBrowseFilterInputV1,
+  type LibraryCoreFeedBrowseFilterV1,
+  type LibraryCoreFeedPageSourceV1,
+} from "@freed/shared/library-core";
+
+import {
+  derivePwaLibraryCoreFeedGenerationSource,
+  type CommittedAutomergeFeedSource,
+} from "./library-core-feed-materializer";
+import type {
+  AppendPwaLibraryCoreBrowseGenerationPageInput,
+  BeginPwaLibraryCoreBrowseGenerationInput,
+  PwaLibraryCoreBrowseProjectedRowV1,
+  PwaLibraryCoreFeedGenerationState,
+} from "./library-core-feed-reader-runtime";
+
+const MATERIALIZATION_PAGE_ROWS = 128;
+const SOURCE_DOMAIN = "freed-pwa-library-core-feed-browse-generation-v1";
+
+interface PwaLibraryCoreBrowseGenerationWriter {
+  beginBrowseGeneration(
+    input: BeginPwaLibraryCoreBrowseGenerationInput,
+  ): Promise<PwaLibraryCoreFeedGenerationState>;
+  appendBrowseGenerationPage(
+    input: AppendPwaLibraryCoreBrowseGenerationPageInput,
+  ): Promise<void>;
+  finalizeBrowseGeneration(source: LibraryCoreFeedPageSourceV1): Promise<void>;
+}
+
+export interface MaterializePwaLibraryCoreFeedBrowseGenerationInput {
+  readonly committed: CommittedAutomergeFeedSource;
+  readonly document: FreedDoc;
+  readonly filter?: LibraryCoreFeedBrowseFilterInputV1;
+  readonly rankingClockMs: number;
+  readonly subtle: SubtleCrypto;
+  readonly writer: PwaLibraryCoreBrowseGenerationWriter;
+}
+
+export interface MaterializePwaLibraryCoreFeedBrowseGenerationResult {
+  readonly filter: LibraryCoreFeedBrowseFilterV1;
+  readonly rankingClockMs: number;
+  readonly source: LibraryCoreFeedPageSourceV1;
+  readonly totalCount: number;
+}
+
+function feedItemsOf(document: FreedDoc): Record<string, FeedItem> {
+  const feedItems = document.feedItems;
+  if (
+    typeof feedItems !== "object" ||
+    feedItems === null ||
+    Array.isArray(feedItems)
+  ) {
+    throw new TypeError("committed Automerge feedItems must be one map");
+  }
+  return feedItems as Record<string, FeedItem>;
+}
+
+function checkedFeedItem(
+  feedItems: Record<string, FeedItem>,
+  globalId: string,
+): FeedItem {
+  const item = feedItems[globalId];
+  if (
+    typeof item !== "object" ||
+    item === null ||
+    Array.isArray(item) ||
+    item.globalId !== globalId
+  ) {
+    throw new TypeError(
+      "committed Automerge feed item identity does not match its map key",
+    );
+  }
+  return item;
+}
+
+/**
+ * Materialize one query-specific browser generation from the exact committed
+ * Automerge frontier.
+ *
+ * The shared filter runs before projection. Priority is frozen at one safe
+ * clock, while IndexedDB receives the exact priority, published-time, source
+ * sequence tuple needed to reproduce the current recommendation order without
+ * a corpus-sized array or sort in application memory.
+ */
+export async function materializePwaLibraryCoreFeedBrowseGeneration(
+  input: MaterializePwaLibraryCoreFeedBrowseGenerationInput,
+): Promise<MaterializePwaLibraryCoreFeedBrowseGenerationResult> {
+  if (
+    !Number.isSafeInteger(input.rankingClockMs) ||
+    input.rankingClockMs < 0
+  ) {
+    throw new TypeError("browse ranking clock must be nonnegative and safe");
+  }
+  const filter = normalizeLibraryCoreFeedBrowseFilterV1(input.filter);
+  const source = await derivePwaLibraryCoreFeedGenerationSource(
+    input.committed,
+    input.subtle,
+    SOURCE_DOMAIN,
+    {
+      filter,
+      rankingClockMs: input.rankingClockMs,
+      recommendationOrderSchemaVersion:
+        LIBRARY_CORE_FEED_RECOMMENDATION_ORDER_SCHEMA_VERSION,
+    },
+  );
+  const feedItems = feedItemsOf(input.document);
+  let totalCount = 0;
+  for (const globalId in feedItems) {
+    if (!Object.prototype.hasOwnProperty.call(feedItems, globalId)) continue;
+    if (!matchesLibraryCoreFeedBrowseFilterV1(
+      checkedFeedItem(feedItems, globalId),
+      filter,
+    )) {
+      continue;
+    }
+    totalCount += 1;
+    if (!Number.isSafeInteger(totalCount)) {
+      throw new RangeError("browse feed item count exceeds safe integer range");
+    }
+  }
+
+  const state = await input.writer.beginBrowseGeneration({
+    source,
+    totalCount,
+  });
+  if (state === "complete") {
+    await input.writer.finalizeBrowseGeneration(source);
+    return Object.freeze({
+      filter,
+      rankingClockMs: input.rankingClockMs,
+      source,
+      totalCount,
+    });
+  }
+
+  const preferences = mergeDefaultPreferences(input.document.preferences);
+  const personByAuthorKey = new Map<
+    string,
+    (typeof input.document.persons)[string] | null
+  >();
+  for (const accountId in input.document.accounts) {
+    if (
+      !Object.prototype.hasOwnProperty.call(
+        input.document.accounts,
+        accountId,
+      )
+    ) {
+      continue;
+    }
+    const account = input.document.accounts[accountId];
+    if (account.kind !== "social") continue;
+    personByAuthorKey.set(
+      `${account.provider}:${account.externalId}`,
+      account.personId
+        ? input.document.persons[account.personId] ?? null
+        : null,
+    );
+  }
+  const context = {
+    accounts: input.document.accounts,
+    personByAuthorKey,
+    persons: input.document.persons,
+  };
+  let batchIndex = 0;
+  let sourceSequence = 0;
+  let rows: PwaLibraryCoreBrowseProjectedRowV1[] = [];
+  const flush = async (): Promise<void> => {
+    if (rows.length === 0) return;
+    const page = Object.freeze(rows);
+    rows = [];
+    await input.writer.appendBrowseGenerationPage({
+      batchIndex,
+      rows: page,
+      source,
+    });
+    batchIndex += 1;
+  };
+
+  for (const globalId in feedItems) {
+    if (!Object.prototype.hasOwnProperty.call(feedItems, globalId)) continue;
+    const item = checkedFeedItem(feedItems, globalId);
+    const itemSourceSequence = sourceSequence;
+    sourceSequence += 1;
+    if (!Number.isSafeInteger(sourceSequence)) {
+      throw new RangeError(
+        "browse feed source sequence exceeds safe integer range",
+      );
+    }
+    if (!matchesLibraryCoreFeedBrowseFilterV1(item, filter)) continue;
+    rows.push(Object.freeze({
+      priority: calculatePriority(
+        item,
+        preferences.weights,
+        input.rankingClockMs,
+        context,
+      ),
+      row: projectLibraryCoreFeedCardV1(item),
+      sourceSequence: itemSourceSequence,
+    }));
+    if (rows.length === MATERIALIZATION_PAGE_ROWS) await flush();
+  }
+  await flush();
+  await input.writer.finalizeBrowseGeneration(source);
+  return Object.freeze({
+    filter,
+    rankingClockMs: input.rankingClockMs,
+    source,
+    totalCount,
+  });
+}

--- a/packages/pwa/src/lib/library-core-feed-materializer.ts
+++ b/packages/pwa/src/lib/library-core-feed-materializer.ts
@@ -19,7 +19,7 @@ const SOURCE_DOMAIN = "freed-pwa-library-core-feed-generation-v1";
 const TEXT_ENCODER = new TextEncoder();
 const LOWER_HEX_64 = /^[0-9a-f]{64}$/;
 
-interface CommittedAutomergeFeedSource {
+export interface CommittedAutomergeFeedSource {
   readonly heads: readonly string[];
   readonly revision: Readonly<{
     readonly generation: number;
@@ -123,18 +123,30 @@ function lowerHex(bytes: ArrayBuffer): string {
   return output;
 }
 
-async function sourceIdentity(
+export async function derivePwaLibraryCoreFeedGenerationSource(
   committed: CommittedAutomergeFeedSource,
   subtle: SubtleCrypto,
+  domain = SOURCE_DOMAIN,
+  contract?: Readonly<Record<string, unknown>>,
 ): Promise<LibraryCoreFeedPageSourceV1> {
   const snapshot = snapshotCommittedSource(committed);
   const digestInput = TEXT_ENCODER.encode(
-    JSON.stringify({
-      domain: SOURCE_DOMAIN,
-      generation: snapshot.generation,
-      heads: snapshot.heads,
-      saveRevision: snapshot.saveRevision,
-    }),
+    JSON.stringify(
+      contract
+        ? {
+            contract,
+            domain,
+            generation: snapshot.generation,
+            heads: snapshot.heads,
+            saveRevision: snapshot.saveRevision,
+          }
+        : {
+            domain,
+            generation: snapshot.generation,
+            heads: snapshot.heads,
+            saveRevision: snapshot.saveRevision,
+          },
+    ),
   );
   return Object.freeze({
     generationId: lowerHex(
@@ -153,7 +165,10 @@ async function sourceIdentity(
 export async function materializePwaLibraryCoreFeedGeneration(
   input: MaterializePwaLibraryCoreFeedGenerationInput,
 ): Promise<MaterializePwaLibraryCoreFeedGenerationResult> {
-  const source = await sourceIdentity(input.committed, input.subtle);
+  const source = await derivePwaLibraryCoreFeedGenerationSource(
+    input.committed,
+    input.subtle,
+  );
   const feedItems = feedItemsOf(input.document);
   let totalCount = 0;
   forEachOwnFeedItem(feedItems, (_globalId, item) => {

--- a/packages/pwa/src/lib/library-core-feed-reader-runtime.ts
+++ b/packages/pwa/src/lib/library-core-feed-reader-runtime.ts
@@ -12,12 +12,17 @@ import {
   type LibraryCoreFeedPageSourceV1,
 } from "@freed/shared/library-core";
 
-const DATABASE_VERSION = 1;
+const DATABASE_VERSION = 2;
 const GENERATIONS_STORE = "generations";
 const ROWS_STORE = "feed_rows";
 const BATCHES_STORE = "generation_batches";
 const CONTROL_STORE = "control";
+const BROWSE_GENERATIONS_STORE = "browse_generations";
+const BROWSE_ROWS_STORE = "browse_rows";
+const BROWSE_BATCHES_STORE = "browse_generation_batches";
+const BROWSE_CONTROL_STORE = "browse_control";
 const SELECTED_GENERATION_KEY = "selected_generation";
+const SELECTED_BROWSE_GENERATION_KEY = "selected_browse_generation";
 const SESSION_MAXIMUM_AGE_MS = 60_000;
 const MAXIMUM_READER_SESSIONS = 2;
 const MAXIMUM_STAGING_PAGE_ROWS = 128;
@@ -26,6 +31,32 @@ const MAXIMUM_SAFE_SORT_KEY = Number.MAX_SAFE_INTEGER;
 const TEXT_ENCODER = new TextEncoder();
 
 type GenerationStatus = "staging" | "complete";
+
+interface GenerationStoreNames {
+  readonly batches: string;
+  readonly control: string;
+  readonly generations: string;
+  readonly rows: string;
+  readonly selectedKey:
+    | typeof SELECTED_GENERATION_KEY
+    | typeof SELECTED_BROWSE_GENERATION_KEY;
+}
+
+const DEFAULT_GENERATION_STORES: GenerationStoreNames = Object.freeze({
+  batches: BATCHES_STORE,
+  control: CONTROL_STORE,
+  generations: GENERATIONS_STORE,
+  rows: ROWS_STORE,
+  selectedKey: SELECTED_GENERATION_KEY,
+});
+
+const BROWSE_GENERATION_STORES: GenerationStoreNames = Object.freeze({
+  batches: BROWSE_BATCHES_STORE,
+  control: BROWSE_CONTROL_STORE,
+  generations: BROWSE_GENERATIONS_STORE,
+  rows: BROWSE_ROWS_STORE,
+  selectedKey: SELECTED_BROWSE_GENERATION_KEY,
+});
 
 interface GenerationRecord extends LibraryCoreFeedPageSourceV1 {
   readonly generationId: LibraryCoreFeedPageSourceV1["generationId"];
@@ -44,6 +75,16 @@ interface FeedRowRecord {
   readonly row: LibraryCoreFeedCardV1;
 }
 
+interface BrowseFeedRowRecord {
+  readonly generationId: string;
+  readonly orderKey: string;
+  readonly globalId: string;
+  readonly priority: number;
+  readonly publishedAt: number;
+  readonly sourceSequence: number;
+  readonly row: LibraryCoreFeedCardV1;
+}
+
 interface GenerationBatchRecord {
   readonly generationId: string;
   readonly batchIndex: number;
@@ -53,7 +94,9 @@ interface GenerationBatchRecord {
 }
 
 interface SelectedGenerationRecord {
-  readonly key: typeof SELECTED_GENERATION_KEY;
+  readonly key:
+    | typeof SELECTED_GENERATION_KEY
+    | typeof SELECTED_BROWSE_GENERATION_KEY;
   readonly generationId: string;
   readonly selectionSequence: number;
 }
@@ -68,6 +111,16 @@ interface ReaderRequestIdentity {
   readonly cancellationId: string;
   readonly cursor: string | null;
   readonly limit: number;
+}
+
+interface AppendStoredGenerationPageInput {
+  readonly batchIndex: number;
+  readonly label: string;
+  readonly rowCount: number;
+  readonly rowsDigest: string;
+  readonly source: LibraryCoreFeedPageSourceV1;
+  readonly stores: GenerationStoreNames;
+  readonly writeRows: (store: IDBObjectStore) => void;
 }
 
 type SessionAdmission =
@@ -116,6 +169,23 @@ export interface AppendPwaLibraryCoreFeedGenerationPageInput {
   readonly source: LibraryCoreFeedPageSourceV1;
   readonly batchIndex: number;
   readonly rows: readonly LibraryCoreFeedCardV1[];
+}
+
+export interface PwaLibraryCoreBrowseProjectedRowV1 {
+  readonly priority: number;
+  readonly row: LibraryCoreFeedCardV1;
+  readonly sourceSequence: number;
+}
+
+export interface BeginPwaLibraryCoreBrowseGenerationInput {
+  readonly source: LibraryCoreFeedPageSourceV1;
+  readonly totalCount: number;
+}
+
+export interface AppendPwaLibraryCoreBrowseGenerationPageInput {
+  readonly source: LibraryCoreFeedPageSourceV1;
+  readonly batchIndex: number;
+  readonly rows: readonly PwaLibraryCoreBrowseProjectedRowV1[];
 }
 
 export type PwaLibraryCoreFeedGenerationState = "complete" | "staging";
@@ -173,6 +243,20 @@ function feedRowOrderKey(row: LibraryCoreFeedCardV1): string {
   const sortAt = row.publishedAt ?? 0;
   return `${reverseSortKey(sortAt)}\u0000${lowerHex(
     TEXT_ENCODER.encode(row.globalId).buffer,
+  )}`;
+}
+
+function forwardSortKey(value: number): string {
+  return value.toString(16).padStart(14, "0");
+}
+
+function browseFeedRowOrderKey(
+  value: PwaLibraryCoreBrowseProjectedRowV1,
+): string {
+  return `${(100 - value.priority).toString(16).padStart(2, "0")}\u0000${
+    reverseSortKey(value.row.publishedAt ?? 0)
+  }\u0000${forwardSortKey(value.sourceSequence)}\u0000${lowerHex(
+    TEXT_ENCODER.encode(value.row.globalId).buffer,
   )}`;
 }
 
@@ -256,6 +340,59 @@ function snapshotRows(
   return Object.freeze(rows);
 }
 
+function snapshotBrowseRows(
+  value: readonly PwaLibraryCoreBrowseProjectedRowV1[],
+): readonly PwaLibraryCoreBrowseProjectedRowV1[] {
+  if (
+    !Array.isArray(value) ||
+    value.length === 0 ||
+    value.length > MAXIMUM_STAGING_PAGE_ROWS
+  ) {
+    throw new TypeError(
+      "a PWA Library Core browse generation page must contain 1 through 128 rows",
+    );
+  }
+
+  const rows: PwaLibraryCoreBrowseProjectedRowV1[] = [];
+  const orderKeys = new Set<string>();
+  for (let index = 0; index < value.length; index += 1) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, String(index));
+    if (!descriptor || !descriptor.enumerable || !("value" in descriptor)) {
+      throw new TypeError("browse generation rows must be one dense data array");
+    }
+    const candidate = descriptor.value as Partial<PwaLibraryCoreBrowseProjectedRowV1>;
+    const parsed = parseLibraryCoreFeedCardV1(candidate?.row);
+    if (!parsed.ok) throw new TypeError(parsed.error);
+    if (
+      !Number.isSafeInteger(candidate.priority) ||
+      (candidate.priority ?? -1) < 0 ||
+      (candidate.priority ?? 101) > 100
+    ) {
+      throw new TypeError("browse generation row priority must be 0 through 100");
+    }
+    if (
+      !Number.isSafeInteger(candidate.sourceSequence) ||
+      (candidate.sourceSequence ?? -1) < 0
+    ) {
+      throw new TypeError(
+        "browse generation row sourceSequence must be nonnegative and safe",
+      );
+    }
+    const row = Object.freeze({
+      priority: candidate.priority,
+      row: parsed.value,
+      sourceSequence: candidate.sourceSequence,
+    }) as PwaLibraryCoreBrowseProjectedRowV1;
+    const orderKey = browseFeedRowOrderKey(row);
+    if (orderKeys.has(orderKey)) {
+      throw new TypeError("browse generation page repeats one ordered row");
+    }
+    orderKeys.add(orderKey);
+    rows.push(row);
+  }
+  return Object.freeze(rows);
+}
+
 /**
  * Dormant row-oriented browser implementation of `feed_page_v1`.
  *
@@ -287,50 +424,21 @@ class PwaLibraryCoreFeedReaderRuntime {
   async beginGeneration(
     input: BeginPwaLibraryCoreFeedGenerationInput,
   ): Promise<PwaLibraryCoreFeedGenerationState> {
-    this.#requireAvailable();
-    const source = snapshotSource(input.source);
-    if (!Number.isSafeInteger(input.totalCount) || input.totalCount < 0) {
-      throw new TypeError("generation totalCount must be nonnegative and safe");
-    }
-
-    const database = await this.#database();
-    const transaction = database.transaction(
-      [GENERATIONS_STORE],
-      "readwrite",
+    return this.#beginStoredGeneration(
+      input,
+      DEFAULT_GENERATION_STORES,
+      "generation",
     );
-    const store = transaction.objectStore(GENERATIONS_STORE);
-    const existing = (await requestResult(
-      store.get(source.generationId),
-    )) as GenerationRecord | undefined;
-    if (existing) {
-      if (
-        sourceMatches(existing, source) &&
-        existing.totalCount === input.totalCount
-      ) {
-        await transactionDone(transaction);
-        return existing.status;
-      }
-      transaction.abort();
-      throw new Error("generation identity already exists with different state");
-    }
-    const generations = (await requestResult(
-      store.getAll(),
-    )) as GenerationRecord[];
-    if (generations.some((generation) => generation.status === "staging")) {
-      transaction.abort();
-      throw new Error("another PWA Library Core generation is still staging");
-    }
+  }
 
-    store.add({
-      ...source,
-      status: "staging",
-      totalCount: input.totalCount,
-      writtenCount: 0,
-      nextBatchIndex: 0,
-      selectedSequence: null,
-    } satisfies GenerationRecord);
-    await transactionDone(transaction);
-    return "staging";
+  async beginBrowseGeneration(
+    input: BeginPwaLibraryCoreBrowseGenerationInput,
+  ): Promise<PwaLibraryCoreFeedGenerationState> {
+    return this.#beginStoredGeneration(
+      input,
+      BROWSE_GENERATION_STORES,
+      "browse generation",
+    );
   }
 
   async appendGenerationPage(
@@ -342,166 +450,89 @@ class PwaLibraryCoreFeedReaderRuntime {
       throw new TypeError("generation batchIndex must be nonnegative and safe");
     }
     const rows = snapshotRows(input.rows);
-    const encodedRows = TEXT_ENCODER.encode(JSON.stringify(rows));
-    const rowsDigest = lowerHex(
-      await this.#subtle.digest("SHA-256", encodedRows),
-    );
-    const database = await this.#database();
-    const transaction = database.transaction(
-      [GENERATIONS_STORE, ROWS_STORE, BATCHES_STORE],
-      "readwrite",
-    );
-    const generations = transaction.objectStore(GENERATIONS_STORE);
-    const feedRows = transaction.objectStore(ROWS_STORE);
-    const batches = transaction.objectStore(BATCHES_STORE);
-    const generation = (await requestResult(
-      generations.get(source.generationId),
-    )) as GenerationRecord | undefined;
-    if (
-      !generation ||
-      generation.status !== "staging" ||
-      !sourceMatches(generation, source)
-    ) {
-      transaction.abort();
-      throw new Error("generation is absent, complete, or source-mismatched");
-    }
-
-    const existingBatch = (await requestResult(
-      batches.get([source.generationId, input.batchIndex]),
-    )) as GenerationBatchRecord | undefined;
-    if (existingBatch) {
-      if (
-        existingBatch.rowsDigest === rowsDigest &&
-        existingBatch.rowCount === rows.length &&
-        existingBatch.writtenCountAfter <= generation.writtenCount &&
-        generation.nextBatchIndex > input.batchIndex
-      ) {
-        await transactionDone(transaction);
-        return;
-      }
-      transaction.abort();
-      throw new Error("generation batch replay changed its exact rows");
-    }
-    if (
-      generation.nextBatchIndex !== input.batchIndex ||
-      generation.writtenCount + rows.length > generation.totalCount
-    ) {
-      transaction.abort();
-      throw new Error("generation page is skipped, reordered, or oversized");
-    }
-
-    for (const row of rows) {
-      const sortAt = row.publishedAt ?? 0;
-      feedRows.add({
-        generationId: source.generationId,
-        orderKey: feedRowOrderKey(row),
-        globalId: row.globalId,
-        sortAt,
-        row,
-      } satisfies FeedRowRecord);
-    }
-    batches.add({
-      generationId: source.generationId,
+    await this.#appendStoredGenerationPage({
       batchIndex: input.batchIndex,
+      label: "generation",
       rowCount: rows.length,
-      rowsDigest,
-      writtenCountAfter: generation.writtenCount + rows.length,
-    } satisfies GenerationBatchRecord);
-    generations.put({
-      ...generation,
-      writtenCount: generation.writtenCount + rows.length,
-      nextBatchIndex: generation.nextBatchIndex + 1,
-    } satisfies GenerationRecord);
-    await transactionDone(transaction);
+      rowsDigest: await this.#rowsDigest(rows),
+      source,
+      stores: DEFAULT_GENERATION_STORES,
+      writeRows(feedRows) {
+        for (const row of rows) {
+          const sortAt = row.publishedAt ?? 0;
+          feedRows.add({
+            generationId: source.generationId,
+            orderKey: feedRowOrderKey(row),
+            globalId: row.globalId,
+            sortAt,
+            row,
+          } satisfies FeedRowRecord);
+        }
+      },
+    });
+  }
+
+  async appendBrowseGenerationPage(
+    input: AppendPwaLibraryCoreBrowseGenerationPageInput,
+  ): Promise<void> {
+    this.#requireAvailable();
+    const source = snapshotSource(input.source);
+    if (!Number.isSafeInteger(input.batchIndex) || input.batchIndex < 0) {
+      throw new TypeError(
+        "browse generation batchIndex must be nonnegative and safe",
+      );
+    }
+    const rows = snapshotBrowseRows(input.rows);
+    await this.#appendStoredGenerationPage({
+      batchIndex: input.batchIndex,
+      label: "browse generation",
+      rowCount: rows.length,
+      rowsDigest: await this.#rowsDigest(rows),
+      source,
+      stores: BROWSE_GENERATION_STORES,
+      writeRows(feedRows) {
+        for (const projected of rows) {
+          feedRows.add({
+            generationId: source.generationId,
+            orderKey: browseFeedRowOrderKey(projected),
+            globalId: projected.row.globalId,
+            priority: projected.priority,
+            publishedAt: projected.row.publishedAt ?? 0,
+            sourceSequence: projected.sourceSequence,
+            row: projected.row,
+          } satisfies BrowseFeedRowRecord);
+        }
+      },
+    });
   }
 
   async finalizeGeneration(
     sourceValue: LibraryCoreFeedPageSourceV1,
   ): Promise<void> {
-    this.#requireAvailable();
-    const source = snapshotSource(sourceValue);
-    const database = await this.#database();
-    const transaction = database.transaction(
-      [GENERATIONS_STORE, ROWS_STORE, CONTROL_STORE],
-      "readwrite",
+    const source = await this.#finalizeStoredGeneration(
+      sourceValue,
+      DEFAULT_GENERATION_STORES,
+      "generation",
     );
-    const generations = transaction.objectStore(GENERATIONS_STORE);
-    const rows = transaction.objectStore(ROWS_STORE);
-    const control = transaction.objectStore(CONTROL_STORE);
-    const generation = (await requestResult(
-      generations.get(source.generationId),
-    )) as GenerationRecord | undefined;
-    const selected = (await requestResult(
-      control.get(SELECTED_GENERATION_KEY),
-    )) as SelectedGenerationRecord | undefined;
-    if (generation?.status === "complete" && sourceMatches(generation, source)) {
-      if (
-        selected?.generationId === source.generationId &&
-        generation.selectedSequence !== selected.selectionSequence
-      ) {
-        transaction.abort();
-        throw new Error(
-          "completed generation selection sequence is inconsistent",
-        );
-      }
-      if (selected?.generationId !== source.generationId) {
-        const selectionSequence = (selected?.selectionSequence ?? 0) + 1;
-        if (!Number.isSafeInteger(selectionSequence)) {
-          transaction.abort();
-          throw new Error("generation selection sequence exhausted");
-        }
-        generations.put({
-          ...generation,
-          selectedSequence: selectionSequence,
-        } satisfies GenerationRecord);
-        control.put({
-          key: SELECTED_GENERATION_KEY,
-          generationId: source.generationId,
-          selectionSequence,
-        } satisfies SelectedGenerationRecord);
-      }
-      await transactionDone(transaction);
-      this.#sessions.clear();
-      await this.#pruneOldGenerations(source.generationId);
-      return;
-    }
-    if (
-      !generation ||
-      generation.status !== "staging" ||
-      !sourceMatches(generation, source)
-    ) {
-      transaction.abort();
-      throw new Error("generation is absent, complete, or source-mismatched");
-    }
-    const actualCount = await requestResult(
-      rows.count(generationRange(this.#keyRange, source.generationId)),
-    );
-    if (
-      generation.writtenCount !== generation.totalCount ||
-      actualCount !== generation.totalCount
-    ) {
-      transaction.abort();
-      throw new Error("generation cannot publish before every row is durable");
-    }
-
-    const selectionSequence = (selected?.selectionSequence ?? 0) + 1;
-    if (!Number.isSafeInteger(selectionSequence)) {
-      transaction.abort();
-      throw new Error("generation selection sequence exhausted");
-    }
-    generations.put({
-      ...generation,
-      status: "complete",
-      selectedSequence: selectionSequence,
-    } satisfies GenerationRecord);
-    control.put({
-      key: SELECTED_GENERATION_KEY,
-      generationId: source.generationId,
-      selectionSequence,
-    } satisfies SelectedGenerationRecord);
-    await transactionDone(transaction);
     this.#sessions.clear();
-    await this.#pruneOldGenerations(source.generationId);
+    await this.#pruneStoredGenerations(
+      source.generationId,
+      DEFAULT_GENERATION_STORES,
+    );
+  }
+
+  async finalizeBrowseGeneration(
+    sourceValue: LibraryCoreFeedPageSourceV1,
+  ): Promise<void> {
+    const source = await this.#finalizeStoredGeneration(
+      sourceValue,
+      BROWSE_GENERATION_STORES,
+      "browse generation",
+    );
+    await this.#pruneStoredGenerations(
+      source.generationId,
+      BROWSE_GENERATION_STORES,
+    );
   }
 
   async readFeedPage(
@@ -749,6 +780,229 @@ class PwaLibraryCoreFeedReaderRuntime {
     }
   }
 
+  async #beginStoredGeneration(
+    input: BeginPwaLibraryCoreFeedGenerationInput,
+    stores: GenerationStoreNames,
+    label: string,
+  ): Promise<PwaLibraryCoreFeedGenerationState> {
+    this.#requireAvailable();
+    const source = snapshotSource(input.source);
+    if (!Number.isSafeInteger(input.totalCount) || input.totalCount < 0) {
+      throw new TypeError(
+        `${label} totalCount must be nonnegative and safe`,
+      );
+    }
+
+    const database = await this.#database();
+    const transaction = database.transaction(
+      [stores.generations],
+      "readwrite",
+    );
+    const store = transaction.objectStore(stores.generations);
+    const existing = (await requestResult(
+      store.get(source.generationId),
+    )) as GenerationRecord | undefined;
+    if (existing) {
+      if (
+        sourceMatches(existing, source) &&
+        existing.totalCount === input.totalCount
+      ) {
+        await transactionDone(transaction);
+        return existing.status;
+      }
+      transaction.abort();
+      throw new Error(
+        `${label} identity already exists with different state`,
+      );
+    }
+    const generations = (await requestResult(
+      store.getAll(),
+    )) as GenerationRecord[];
+    if (generations.some((generation) => generation.status === "staging")) {
+      transaction.abort();
+      throw new Error(
+        `another PWA Library Core ${label} is still staging`,
+      );
+    }
+
+    store.add({
+      ...source,
+      status: "staging",
+      totalCount: input.totalCount,
+      writtenCount: 0,
+      nextBatchIndex: 0,
+      selectedSequence: null,
+    } satisfies GenerationRecord);
+    await transactionDone(transaction);
+    return "staging";
+  }
+
+  async #rowsDigest(value: unknown): Promise<string> {
+    return lowerHex(
+      await this.#subtle.digest(
+        "SHA-256",
+        TEXT_ENCODER.encode(JSON.stringify(value)),
+      ),
+    );
+  }
+
+  async #appendStoredGenerationPage(
+    input: AppendStoredGenerationPageInput,
+  ): Promise<void> {
+    const database = await this.#database();
+    const transaction = database.transaction(
+      [input.stores.generations, input.stores.rows, input.stores.batches],
+      "readwrite",
+    );
+    const generations = transaction.objectStore(input.stores.generations);
+    const rows = transaction.objectStore(input.stores.rows);
+    const batches = transaction.objectStore(input.stores.batches);
+    const generation = (await requestResult(
+      generations.get(input.source.generationId),
+    )) as GenerationRecord | undefined;
+    if (
+      !generation ||
+      generation.status !== "staging" ||
+      !sourceMatches(generation, input.source)
+    ) {
+      transaction.abort();
+      throw new Error(
+        `${input.label} is absent, complete, or source-mismatched`,
+      );
+    }
+
+    const existingBatch = (await requestResult(
+      batches.get([input.source.generationId, input.batchIndex]),
+    )) as GenerationBatchRecord | undefined;
+    if (existingBatch) {
+      if (
+        existingBatch.rowsDigest === input.rowsDigest &&
+        existingBatch.rowCount === input.rowCount &&
+        existingBatch.writtenCountAfter <= generation.writtenCount &&
+        generation.nextBatchIndex > input.batchIndex
+      ) {
+        await transactionDone(transaction);
+        return;
+      }
+      transaction.abort();
+      throw new Error(`${input.label} batch replay changed its exact rows`);
+    }
+    if (
+      generation.nextBatchIndex !== input.batchIndex ||
+      generation.writtenCount + input.rowCount > generation.totalCount
+    ) {
+      transaction.abort();
+      throw new Error(
+        `${input.label} page is skipped, reordered, or oversized`,
+      );
+    }
+
+    input.writeRows(rows);
+    batches.add({
+      generationId: input.source.generationId,
+      batchIndex: input.batchIndex,
+      rowCount: input.rowCount,
+      rowsDigest: input.rowsDigest,
+      writtenCountAfter: generation.writtenCount + input.rowCount,
+    } satisfies GenerationBatchRecord);
+    generations.put({
+      ...generation,
+      writtenCount: generation.writtenCount + input.rowCount,
+      nextBatchIndex: generation.nextBatchIndex + 1,
+    } satisfies GenerationRecord);
+    await transactionDone(transaction);
+  }
+
+  async #finalizeStoredGeneration(
+    sourceValue: LibraryCoreFeedPageSourceV1,
+    stores: GenerationStoreNames,
+    label: string,
+  ): Promise<LibraryCoreFeedPageSourceV1> {
+    this.#requireAvailable();
+    const source = snapshotSource(sourceValue);
+    const database = await this.#database();
+    const transaction = database.transaction(
+      [stores.generations, stores.rows, stores.control],
+      "readwrite",
+    );
+    const generations = transaction.objectStore(stores.generations);
+    const rows = transaction.objectStore(stores.rows);
+    const control = transaction.objectStore(stores.control);
+    const generation = (await requestResult(
+      generations.get(source.generationId),
+    )) as GenerationRecord | undefined;
+    const selected = (await requestResult(
+      control.get(stores.selectedKey),
+    )) as SelectedGenerationRecord | undefined;
+    if (generation?.status === "complete" && sourceMatches(generation, source)) {
+      if (
+        selected?.generationId === source.generationId &&
+        generation.selectedSequence !== selected.selectionSequence
+      ) {
+        transaction.abort();
+        throw new Error(
+          `completed ${label} selection sequence is inconsistent`,
+        );
+      }
+      if (selected?.generationId !== source.generationId) {
+        const selectionSequence = (selected?.selectionSequence ?? 0) + 1;
+        if (!Number.isSafeInteger(selectionSequence)) {
+          transaction.abort();
+          throw new Error(`${label} selection sequence exhausted`);
+        }
+        generations.put({
+          ...generation,
+          selectedSequence: selectionSequence,
+        } satisfies GenerationRecord);
+        control.put({
+          key: stores.selectedKey,
+          generationId: source.generationId,
+          selectionSequence,
+        } satisfies SelectedGenerationRecord);
+      }
+      await transactionDone(transaction);
+      return source;
+    }
+    if (
+      !generation ||
+      generation.status !== "staging" ||
+      !sourceMatches(generation, source)
+    ) {
+      transaction.abort();
+      throw new Error(`${label} is absent, complete, or source-mismatched`);
+    }
+    const actualCount = await requestResult(
+      rows.count(generationRange(this.#keyRange, source.generationId)),
+    );
+    if (
+      generation.writtenCount !== generation.totalCount ||
+      actualCount !== generation.totalCount
+    ) {
+      transaction.abort();
+      throw new Error(
+        `${label} cannot publish before every row is durable`,
+      );
+    }
+
+    const selectionSequence = (selected?.selectionSequence ?? 0) + 1;
+    if (!Number.isSafeInteger(selectionSequence)) {
+      transaction.abort();
+      throw new Error(`${label} selection sequence exhausted`);
+    }
+    generations.put({
+      ...generation,
+      status: "complete",
+      selectedSequence: selectionSequence,
+    } satisfies GenerationRecord);
+    control.put({
+      key: stores.selectedKey,
+      generationId: source.generationId,
+      selectionSequence,
+    } satisfies SelectedGenerationRecord);
+    await transactionDone(transaction);
+    return source;
+  }
+
   #database(): Promise<IDBDatabase> {
     this.#requireAvailable();
     if (!this.#databasePromise) {
@@ -782,6 +1036,36 @@ class PwaLibraryCoreFeedReaderRuntime {
           if (!database.objectStoreNames.contains(CONTROL_STORE)) {
             database.createObjectStore(CONTROL_STORE, { keyPath: "key" });
           }
+          if (!database.objectStoreNames.contains(BROWSE_GENERATIONS_STORE)) {
+            database.createObjectStore(BROWSE_GENERATIONS_STORE, {
+              keyPath: "generationId",
+            });
+          }
+          if (!database.objectStoreNames.contains(BROWSE_ROWS_STORE)) {
+            const browseRows = database.createObjectStore(BROWSE_ROWS_STORE, {
+              keyPath: ["generationId", "orderKey"],
+            });
+            browseRows.createIndex(
+              "browse_generation_global_id",
+              ["generationId", "globalId"],
+              { unique: true },
+            );
+            browseRows.createIndex(
+              "browse_generation_source_sequence",
+              ["generationId", "sourceSequence"],
+              { unique: true },
+            );
+          }
+          if (!database.objectStoreNames.contains(BROWSE_BATCHES_STORE)) {
+            database.createObjectStore(BROWSE_BATCHES_STORE, {
+              keyPath: ["generationId", "batchIndex"],
+            });
+          }
+          if (!database.objectStoreNames.contains(BROWSE_CONTROL_STORE)) {
+            database.createObjectStore(BROWSE_CONTROL_STORE, {
+              keyPath: "key",
+            });
+          }
         });
         request.addEventListener(
           "success",
@@ -813,14 +1097,17 @@ class PwaLibraryCoreFeedReaderRuntime {
     return this.#databasePromise;
   }
 
-  async #pruneOldGenerations(selectedGenerationId: string): Promise<void> {
+  async #pruneStoredGenerations(
+    selectedGenerationId: string,
+    stores: GenerationStoreNames,
+  ): Promise<void> {
     const database = await this.#database();
     const transaction = database.transaction(
-      [GENERATIONS_STORE],
+      [stores.generations],
       "readonly",
     );
     const generations = (await requestResult(
-      transaction.objectStore(GENERATIONS_STORE).getAll(),
+      transaction.objectStore(stores.generations).getAll(),
     )) as GenerationRecord[];
     await transactionDone(transaction);
     const retained = generations
@@ -835,25 +1122,28 @@ class PwaLibraryCoreFeedReaderRuntime {
       );
     const obsolete = retained.slice(MAXIMUM_RETAINED_GENERATIONS - 1);
     for (const generation of obsolete) {
-      await this.#deleteGeneration(generation.generationId);
+      await this.#deleteStoredGeneration(generation.generationId, stores);
     }
   }
 
-  async #deleteGeneration(generationId: string): Promise<void> {
+  async #deleteStoredGeneration(
+    generationId: string,
+    stores: GenerationStoreNames,
+  ): Promise<void> {
     const database = await this.#database();
     const transaction = database.transaction(
-      [GENERATIONS_STORE, ROWS_STORE, BATCHES_STORE],
+      [stores.generations, stores.rows, stores.batches],
       "readwrite",
     );
     const range = generationRange(this.#keyRange, generationId);
-    transaction.objectStore(ROWS_STORE).delete(range);
-    transaction.objectStore(BATCHES_STORE).delete(
+    transaction.objectStore(stores.rows).delete(range);
+    transaction.objectStore(stores.batches).delete(
       this.#keyRange.bound(
         [generationId, 0],
         [generationId, Number.MAX_SAFE_INTEGER],
       ),
     );
-    transaction.objectStore(GENERATIONS_STORE).delete(generationId);
+    transaction.objectStore(stores.generations).delete(generationId);
     await transactionDone(transaction);
   }
 }

--- a/packages/pwa/src/lib/library-core-worker-surface-registry.test.ts
+++ b/packages/pwa/src/lib/library-core-worker-surface-registry.test.ts
@@ -157,6 +157,28 @@ describe("PWA Library Core worker surface census", () => {
     });
     expect(
       PWA_AUTOMERGE_WORKER_REQUEST_SURFACE_REGISTRY
+        .MATERIALIZE_LIBRARY_CORE_FEED_BROWSE_GENERATION,
+    ).toStrictEqual({
+      status: "planned_blocked",
+      classification: "library_core_local_projection",
+      blockers: [
+        "library_core_runtime_inactive",
+        "response_transport_not_cut_over",
+      ],
+    });
+    expect(
+      PWA_AUTOMERGE_REQUEST_EFFECT_REGISTRY
+        .MATERIALIZE_LIBRARY_CORE_FEED_BROWSE_GENERATION,
+    ).toStrictEqual({
+      legacyWriteEffects: [],
+      libraryCoreWriteEffects: [
+        "library_core_projection_generation_write",
+      ],
+      successorOperationIds: [],
+      blockers: ["response_transport_not_cut_over"],
+    });
+    expect(
+      PWA_AUTOMERGE_WORKER_REQUEST_SURFACE_REGISTRY
         .READ_LIBRARY_CORE_FEED_PAGE,
     ).toStrictEqual({
       status: "planned_blocked",
@@ -186,6 +208,10 @@ describe("PWA Library Core worker surface census", () => {
     expect(
       PWA_AUTOMERGE_WORKER_RESPONSE_SURFACE_REGISTRY
         .LIBRARY_CORE_FEED_GENERATION_RESULT.classification,
+    ).toBe("library_core_bounded_transport");
+    expect(
+      PWA_AUTOMERGE_WORKER_RESPONSE_SURFACE_REGISTRY
+        .LIBRARY_CORE_FEED_BROWSE_GENERATION_RESULT.classification,
     ).toBe("library_core_bounded_transport");
   });
 

--- a/packages/pwa/src/lib/library-core-worker-surface-registry.ts
+++ b/packages/pwa/src/lib/library-core-worker-surface-registry.ts
@@ -171,6 +171,10 @@ export const PWA_AUTOMERGE_WORKER_REQUEST_SURFACE_REGISTRY = {
     "library_core_local_projection",
     "response_transport_not_cut_over",
   ),
+  MATERIALIZE_LIBRARY_CORE_FEED_BROWSE_GENERATION: blockedSurface(
+    "library_core_local_projection",
+    "response_transport_not_cut_over",
+  ),
   READ_LIBRARY_CORE_FEED_PAGE: blockedSurface(
     "library_core_bounded_read",
     "response_transport_not_cut_over",
@@ -362,6 +366,8 @@ export const PWA_AUTOMERGE_REQUEST_EFFECT_REGISTRY = {
   COMPARE_DOC: noWriteEffect(),
   GET_ITEM_LEGACY_HTML: noWriteEffect(),
   MATERIALIZE_LIBRARY_CORE_FEED_GENERATION: libraryCoreProjectionWrite(),
+  MATERIALIZE_LIBRARY_CORE_FEED_BROWSE_GENERATION:
+    libraryCoreProjectionWrite(),
   READ_LIBRARY_CORE_FEED_PAGE: noWriteEffect(),
   CANCEL_LIBRARY_CORE_FEED_READER: noWriteEffect(),
   CLEAR_LOCAL: hiddenWrite(
@@ -413,6 +419,10 @@ export const PWA_AUTOMERGE_WORKER_RESPONSE_SURFACE_REGISTRY = {
     "unbounded_payload",
   ),
   LIBRARY_CORE_FEED_GENERATION_RESULT: blockedSurface(
+    "library_core_bounded_transport",
+    "response_transport_not_cut_over",
+  ),
+  LIBRARY_CORE_FEED_BROWSE_GENERATION_RESULT: blockedSurface(
     "library_core_bounded_transport",
     "response_transport_not_cut_over",
   ),

--- a/packages/pwa/tests/library-core-feed-reader.spec.ts
+++ b/packages/pwa/tests/library-core-feed-reader.spec.ts
@@ -356,6 +356,141 @@ test("dormant IndexedDB feed reader preserves bounded session and generation sem
   expect(result.workerBridgeCancellation).toBe(false);
 });
 
+test("dormant browse projection upgrades v1 and persists exact recommendation order", async ({
+  page,
+}) => {
+  await page.goto("/favicon.svg");
+
+  const result = await page.evaluate(async () => {
+    const databaseName = `freed-library-core-browse-${crypto.randomUUID()}`;
+    const legacyDatabase = await new Promise<IDBDatabase>((resolve, reject) => {
+      const request = indexedDB.open(databaseName, 1);
+      request.onupgradeneeded = () => {
+        const database = request.result;
+        database.createObjectStore("generations", {
+          keyPath: "generationId",
+        });
+        database.createObjectStore("feed_rows", {
+          keyPath: ["generationId", "orderKey"],
+        });
+        database.createObjectStore("generation_batches", {
+          keyPath: ["generationId", "batchIndex"],
+        });
+        database.createObjectStore("control", { keyPath: "key" });
+      };
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error);
+    });
+    legacyDatabase.close();
+
+    const modulePath = "/src/lib/library-core-feed-reader-runtime.ts";
+    const { createPwaLibraryCoreFeedReaderRuntime } = await import(modulePath);
+    const runtime = createPwaLibraryCoreFeedReaderRuntime({
+      databaseName,
+      indexedDb: indexedDB,
+      keyRange: IDBKeyRange,
+      subtle: crypto.subtle,
+    });
+    const source = {
+      generationId: "c".repeat(64),
+      projectionRevision: 11,
+      transitionSequence: 6,
+    };
+    const row = (globalId: string, publishedAt: number) => ({
+      archived: false,
+      authorAvatarUrl: null,
+      authorDisplayName: null,
+      authorHandle: null,
+      authorId: null,
+      capturedAt: publishedAt,
+      contentSignalTags: [],
+      contentText: globalId,
+      contentType: "post",
+      engagementComments: null,
+      engagementLikes: null,
+      eventConfidenceBasisPoints: null,
+      eventStartsAt: null,
+      globalId,
+      liked: false,
+      likedAt: null,
+      likedSyncedAt: null,
+      linkPreviewTitle: null,
+      locationName: null,
+      mediaTypes: [],
+      mediaUrls: [],
+      platform: "x",
+      publishedAt,
+      readAt: null,
+      readingTimeMinutes: null,
+      saved: false,
+      sourceUrl: null,
+      tags: [],
+    });
+
+    await runtime.beginBrowseGeneration({ source, totalCount: 4 });
+    await runtime.appendBrowseGenerationPage({
+      source,
+      batchIndex: 0,
+      rows: [
+        { priority: 40, row: row("source-first", 100), sourceSequence: 0 },
+        { priority: 80, row: row("newer-high", 300), sourceSequence: 1 },
+        { priority: 80, row: row("source-second", 200), sourceSequence: 3 },
+        { priority: 80, row: row("source-earlier", 200), sourceSequence: 2 },
+      ],
+    });
+    await runtime.finalizeBrowseGeneration(source);
+    await runtime.quiesce();
+
+    const orderedRows = await new Promise<
+      Array<{ globalId: string; orderKey: string }>
+    >((resolve, reject) => {
+      const request = indexedDB.open(databaseName, 2);
+      request.onsuccess = () => {
+        const database = request.result;
+        const transaction = database.transaction("browse_rows", "readonly");
+        const rows: Array<{ globalId: string; orderKey: string }> = [];
+        const cursorRequest = transaction.objectStore("browse_rows").openCursor();
+        cursorRequest.onsuccess = () => {
+          const cursor = cursorRequest.result;
+          if (!cursor) return;
+          rows.push(cursor.value);
+          cursor.continue();
+        };
+        transaction.oncomplete = () => {
+          database.close();
+          resolve(rows);
+        };
+        transaction.onerror = () => reject(transaction.error);
+      };
+      request.onerror = () => reject(request.error);
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      const deletion = indexedDB.deleteDatabase(databaseName);
+      deletion.onsuccess = () => resolve();
+      deletion.onerror = () => reject(deletion.error);
+      deletion.onblocked = () =>
+        reject(new Error("browse test database deletion was blocked"));
+    });
+    return {
+      orderedIds: orderedRows.map(({ globalId }) => globalId),
+      uniqueOrderKeys: new Set(
+        orderedRows.map(({ orderKey }) => orderKey),
+      ).size,
+    };
+  });
+
+  expect(result).toStrictEqual({
+    orderedIds: [
+      "newer-high",
+      "source-earlier",
+      "source-second",
+      "source-first",
+    ],
+    uniqueOrderKeys: 4,
+  });
+});
+
 test("committed Automerge heads materialize one resumable bounded feed generation", async ({
   page,
 }) => {
@@ -405,11 +540,15 @@ test("committed Automerge heads materialize one resumable bounded feed generatio
     await client.docAddFeedItems([
       item("x:older", 100),
       item("x:hidden", 400, { hidden: true }),
-      item("x:newer", 300),
+      item("x:newer", 300, { saved: true }),
       item("x:archived", 500, { archived: true }),
     ]);
     const first = await client.materializeLibraryCoreFeedGeneration();
     const replay = await client.materializeLibraryCoreFeedGeneration();
+    const browse = await client.materializeLibraryCoreFeedBrowseGeneration(
+      { savedOnly: true },
+      1_000,
+    );
     const pageResult = await client.readLibraryCoreFeedPage({
       cancellationId: "materializer-cancellation",
       cursor: null,
@@ -429,10 +568,18 @@ test("committed Automerge heads materialize one resumable bounded feed generatio
       deletion.onblocked = () =>
         reject(new Error("test database deletion was blocked"));
     });
-    return { first, pageResult, replay };
+    return { browse, first, pageResult, replay };
   });
 
   expect(result.first).toStrictEqual(result.replay);
+  expect(result.browse).toMatchObject({
+    filter: { savedOnly: true, schemaVersion: 1 },
+    rankingClockMs: 1_000,
+    totalCount: 1,
+  });
+  expect(result.browse.source.generationId).not.toBe(
+    result.first.source.generationId,
+  );
   expect(result.first).toMatchObject({ totalCount: 2 });
   expect(result.first.source.generationId).toMatch(/^[0-9a-f]{64}$/);
   expect(result.first.source.projectionRevision).toBeGreaterThan(0);


### PR DESCRIPTION
(AI Generated).

## Summary
- Materialize normalized feed filters and exact recommendation-order tuples into a separate dormant IndexedDB generation.
- Bind each generation to committed Automerge heads, the normalized filter, one ranking clock, and the recommendation-order schema.
- Preserve the existing chronological feed reader and keep Library Core unassigned until governed cutover.

## Testing
- Pinned npm run validate:feature
- PWA lint
- Focused Library Core unit and Chromium IndexedDB worker-bridge tests

## Provider Review
- Status: Provider authority is validated for ready publication.
- Review action: none required. The provider-risk artifact records the behavior authority decision; this exact provider subdiff is the audit subject.
- Provider subdiff: `9184533f26eaa564bde15b7346cbffbfd8af7aa8`
- Publication does not authorize new live provider traffic. Gate 1 behavior approval still applies when observable behavior changes.
- Provider review task: `library-core-pwa-browse-query-v1`
- Provider review decision: `diff_authorized`
- Provider review artifact: `228d0441b3a52180d94cb6c1e2c85d1729943a6f4e675a6b89b1a002b50a0798`
- Providers: other
- Observable behavior: No provider-observable behavior changes. The PWA gains an explicit dormant worker request that filters and writes a committed local Automerge snapshot into a separate query-specific IndexedDB generation. No product caller invokes it.
- Fingerprinting risk: No new fingerprinting risk is introduced because requests, navigation, timing, retries, cookies, headers, extraction, WebView lifecycle, provider cadence, and live provider contact remain unchanged.
- Lowest profile alternative: Keep live provider traffic disabled and prove the local projection with deterministic unit tests, a mocked worker bridge, and an isolated IndexedDB browser test.

Files bound into this provider review:
- `packages/pwa/src/lib/automerge-types.ts`
- `packages/pwa/src/lib/automerge.ts`
- `packages/pwa/src/lib/automerge.worker.ts`