### PR TITLE
docs: update the public Library Core roadmap

### DIFF
--- a/website/src/app/roadmap/RoadmapContent.tsx
+++ b/website/src/app/roadmap/RoadmapContent.tsx
@@ -731,7 +731,7 @@ const phases: Phase[] = [
     number: 4,
     title: "Sync Layer",
     description:
-      "Local relay, Google Drive, and Dropbox sync are working, with health checks, retries, debug charts, and desktop snapshots. iCloud is still open. Large offline media will use a separate future transport outside the synced Freed document.",
+      "Local relay and Google Drive sync are working, with health diagnostics, retries, manual sync, activity timelines, and desktop snapshots. Freed Desktop has begun the bounded-memory Library Core transition: its ordinary all-content feed can read source-bound, paged cards from a verified SQLite projection while Automerge remains authoritative and supplies the fallback. Dropbox remains gated while its provider work finishes. iCloud remains open. Large offline media will use a separate future transport outside the synced Freed document.",
     status: "current",
     planLink:
       "https://github.com/freed-project/freed/blob/dev/docs/PHASE-4-SYNC.md",


### PR DESCRIPTION
(AI Generated).

## Summary
- Sync the Phase 4 public roadmap description from merged product source 15b4422c764a375b825eb279d08203398be26f76.
- Record the first bounded SQLite feed reader while keeping Automerge authority and the remaining Dropbox and iCloud work explicit.
- Roadmap status manifest SHA-256: 27f96bec7290b31d3b327d4c9ec995e7c36c8a4f7289194c2a1c0f1a519daf8b.

## Testing
- cd website && PATH=../node_modules/.bin:/opt/homebrew/bin:/opt/homebrew/sbin:/opt/local/bin:/opt/local/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/usr/local/MacGPG2/bin:/Applications/VMware Fusion.app/Contents/Public:/usr/local/share/dotnet:~/.dotnet/tools:/usr/local/go/bin:/Library/Frameworks/Mono.framework/Versions/Current/Commands:/Users/aubreyfalconer/.nvm/versions/node/v26.4.0/bin:/Users/aubreyfalconer/.cargo/bin:/Users/aubreyfalconer/.codex/tmp/arg0/codex-arg0RdzE9Q:/Users/aubreyfalconer/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/override:/Users/aubreyfalconer/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/fallback:/Applications/ChatGPT.app/Contents/Resources:/usr/local/bin npm run build