### PR TITLE
chore: prepare v26.7.3000-dev

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freed/desktop",
   "private": true,
-  "version": "26.7.2901",
+  "version": "26.7.3000",
   "type": "module",
   "scripts": {
     "dev": "node ../../node_modules/vite/bin/vite.js",

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -1443,7 +1443,7 @@ dependencies = [
 
 [[package]]
 name = "freed-desktop"
-version = "26.7.2901"
+version = "26.7.3000"
 dependencies = [
  "base64 0.23.0",
  "criterion",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freed-desktop"
-version = "26.7.2901"
+version = "26.7.3000"
 description = "Freed Desktop - Escape algorithmic manipulation"
 authors = ["Freed"]
 edition = "2021"

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Freed",
-  "version": "26.7.2901",
+  "version": "26.7.3000",
   "identifier": "wtf.freed.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freed/pwa",
   "private": true,
-  "version": "26.7.2901",
+  "version": "26.7.3000",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/release-notes/daily/dev/26.7.30.json
+++ b/release-notes/daily/dev/26.7.30.json
@@ -1,0 +1,14 @@
+{
+  "channel": "dev",
+  "dayKey": "26.7.30",
+  "date": "2026-07-30",
+  "preferredDeck": null,
+  "editorialGuidance": [
+    "Keep the tone concise, professional, and specific.",
+    "Lead with user-facing outcomes, shipping milestones, trust wins, and installability improvements.",
+    "Demote internal cleanup unless it clearly changes the shipped product."
+  ],
+  "pinnedHighlights": [],
+  "editorialNotes": [],
+  "updatedAt": "2026-07-30T18:35:41.933Z"
+}

--- a/release-notes/daily/dev/26.7.30.json
+++ b/release-notes/daily/dev/26.7.30.json
@@ -2,13 +2,17 @@
   "channel": "dev",
   "dayKey": "26.7.30",
   "date": "2026-07-30",
-  "preferredDeck": null,
+  "preferredDeck": "Moves the ordinary Freed Desktop feed onto bounded SQLite pages while keeping Automerge authoritative and preserving an immediate local fallback",
   "editorialGuidance": [
     "Keep the tone concise, professional, and specific.",
     "Lead with user-facing outcomes, shipping milestones, trust wins, and installability improvements.",
     "Demote internal cleanup unless it clearly changes the shipped product."
   ],
   "pinnedHighlights": [],
-  "editorialNotes": [],
+  "editorialNotes": [
+    "Lead with the first active bounded SQLite read path.",
+    "State plainly that Automerge remains authoritative and is the immediate fallback.",
+    "Keep dormant PWA foundations subordinate to the Desktop activation."
+  ],
   "updatedAt": "2026-07-30T18:35:41.933Z"
 }

--- a/release-notes/releases/v26.7.3000-dev.json
+++ b/release-notes/releases/v26.7.3000-dev.json
@@ -1,0 +1,151 @@
+{
+  "tag": "v26.7.3000-dev",
+  "version": "26.7.3000-dev",
+  "channel": "dev",
+  "dayKey": "26.7.30",
+  "approved": false,
+  "editorialNotes": [],
+  "generatedAt": "2026-07-30T18:35:41.932Z",
+  "model": "heuristic",
+  "source": {
+    "channel": "dev",
+    "previousPublishedTag": "v26.7.2901-dev",
+    "previousPublishedDayTag": "v26.7.2901-dev",
+    "compareRef": "HEAD",
+    "productCommitSha": "15b4422c764a375b825eb279d08203398be26f76",
+    "promotedDevCommitSha": null,
+    "libraryCoreActivation": {
+      "schemaVersion": 1,
+      "range": {
+        "channel": "dev",
+        "previousPublishedTag": "v26.7.2901-dev",
+        "startMode": "previous_product_commit",
+        "fromExclusiveCommitSha": "792cc907cae274069746467a2b5b34390686d222",
+        "toInclusiveProductCommitSha": "15b4422c764a375b825eb279d08203398be26f76"
+      },
+      "manifest": {
+        "path": "docs/library-core-activation-manifest.json",
+        "previousPresent": true,
+        "previousDigest": "sha256:96a22914b0b629c540ede98c41fb586b9695f139324fe033faae374dc83b3ccb",
+        "currentDigest": "sha256:74d4cd5c0e06468f79eeb2737c0c07a9ff83f0c238e6504cf31fe18cedb2d594"
+      },
+      "transitions": [
+        {
+          "activationId": "desktop-feed-browse-sql-read-v1",
+          "gate": "D",
+          "kind": "sql_read_cutover",
+          "rollbackTrigger": "Set freed.libraryCore.feedBrowseReaderV1.disabled to 1 on the affected device if the bounded Desktop feed diverges, stalls, or increases memory relative to the Automerge fallback.",
+          "receiptExpectations": [
+            "read_cutover_parity",
+            "same_frontier_rollback_receipt"
+          ]
+        }
+      ],
+      "inspectionDigest": "sha256:c9b2ad54c4b1fb9bd4220964f49791efa63d14adaebb1785a96cd994529c84ba",
+      "decision": {
+        "state": "review_required",
+        "ownerApprovalReference": null,
+        "approvedInspectionDigest": null,
+        "approvedReleaseArtifactDigest": null
+      }
+    },
+    "isLatestOfDay": true,
+    "sameDayTagsIncluded": [
+      "v26.7.3000-dev"
+    ],
+    "relatedBuildTags": [
+      "v26.7.3000-dev"
+    ],
+    "prNumbers": [
+      1237,
+      1242,
+      1243,
+      1245,
+      1246,
+      1247,
+      1248,
+      1249,
+      1250,
+      1251,
+      1252,
+      1253,
+      1254,
+      1255,
+      1256,
+      1257,
+      1258,
+      1259,
+      1260,
+      1261,
+      1262,
+      1263,
+      1264,
+      1265,
+      1266,
+      1267,
+      1268,
+      1269
+    ],
+    "commitSubjects": [
+      "feat: read the Desktop feed from bounded SQLite pages (#1269)",
+      "feat: add bounded SQLite shadow migration bridge (#1268)",
+      "feat: pin native browse generation reads (#1267)",
+      "feat: register immutable browse generations (#1266)",
+      "feat: seal native browse generations (#1265)",
+      "fix: bind native browse source provenance (#1264)",
+      "feat: add desktop browse materializer (#1263)",
+      "feat: add native browse generation runtime (#1262)",
+      "feat: add native browse generation store (#1261)",
+      "feat: add dormant PWA browse page reader (#1260)",
+      "feat: materialize bounded PWA browse generations (#1259)",
+      "refactor: define Library Core recommendation order (#1258)",
+      "refactor: define Library Core feed filters (#1257)",
+      "feat: add authenticated PWA feed materialization (#1256)",
+      "feat: add dormant PWA Library Core feed reader (#1255)",
+      "feat: add dormant desktop SQLite feed reader (#1254)",
+      "feat: close bounded Library Core feed-page protocol (#1253)",
+      "feat: materialize bounded Automerge rows into SQLite (#1252)",
+      "feat: stage verified Automerge graphs in SQLite (#1251)",
+      "feat: reconstruct bounded Automerge migration rows (#1250)",
+      "feat: add bounded Automerge column and scalar decoders (#1249)",
+      "feat: add bounded Automerge framing decoder (#1248)",
+      "fix: use monochrome macOS menu bar icon (#1247)",
+      "feat: add bounded Automerge migration spool (#1246)",
+      "fix: remove card density menu divider (#1245)",
+      "feat: add runtime SQLite shadow generations (#1243)",
+      "feat: add immutable SQLite projection generations (#1237)",
+      "fix: shard nightly tooling tests independently (#1242)"
+    ]
+  },
+  "release": {
+    "deck": "Read the Desktop feed from bounded SQLite pages, dormant PWA browse page reader, and desktop browse materializer",
+    "features": [
+      "Read the Desktop feed from bounded SQLite pages",
+      "Desktop browse materializer",
+      "Dormant PWA browse page reader"
+    ],
+    "fixes": [
+      "Bind native browse source provenance",
+      "Monochrome macOS menu bar icon now uses the correct path",
+      "Card density menu divider removed",
+      "Shard nightly tooling tests independently"
+    ],
+    "followUps": [
+      "Bounded SQLite shadow migration bridge",
+      "Pin native browse generation reads",
+      "Register immutable browse generations",
+      "Seal native browse generations",
+      "Define Library Core recommendation order",
+      "Authenticated PWA feed materialization",
+      "Close bounded Library Core feed-page protocol",
+      "Materialize bounded Automerge rows into SQLite",
+      "Stage verified Automerge graphs in SQLite",
+      "Bounded Automerge column and scalar decoders",
+      "Bounded Automerge framing decoder",
+      "Bounded Automerge migration spool",
+      "Runtime SQLite shadow generations",
+      "Immutable SQLite projection generations"
+    ]
+  },
+  "releaseBody": "(AI Generated).\n\n## Freed v26.7.3000-dev\n\nRead the Desktop feed from bounded SQLite pages, dormant PWA browse page reader, and desktop browse materializer\n\n### Features\n\n- Read the Desktop feed from bounded SQLite pages\n- Desktop browse materializer\n- Dormant PWA browse page reader\n\n### Fixes\n\n- Bind native browse source provenance\n- Monochrome macOS menu bar icon now uses the correct path\n- Card density menu divider removed\n- Shard nightly tooling tests independently\n\n### Follow-ups\n\n- Bounded SQLite shadow migration bridge\n- Pin native browse generation reads\n- Register immutable browse generations\n- Seal native browse generations\n- Define Library Core recommendation order\n- Authenticated PWA feed materialization\n- Close bounded Library Core feed-page protocol\n- Materialize bounded Automerge rows into SQLite\n- Stage verified Automerge graphs in SQLite\n- Bounded Automerge column and scalar decoders\n- Bounded Automerge framing decoder\n- Bounded Automerge migration spool\n- Runtime SQLite shadow generations\n- Immutable SQLite projection generations\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+}

--- a/release-notes/releases/v26.7.3000-dev.json
+++ b/release-notes/releases/v26.7.3000-dev.json
@@ -3,8 +3,12 @@
   "version": "26.7.3000-dev",
   "channel": "dev",
   "dayKey": "26.7.30",
-  "approved": false,
-  "editorialNotes": [],
+  "approved": true,
+  "editorialNotes": [
+    "Lead with the first active bounded SQLite read path.",
+    "State plainly that Automerge remains authoritative and is the immediate fallback.",
+    "Keep dormant PWA foundations subordinate to the Desktop activation."
+  ],
   "generatedAt": "2026-07-30T18:35:41.932Z",
   "model": "heuristic",
   "source": {
@@ -118,34 +122,22 @@
     ]
   },
   "release": {
-    "deck": "Read the Desktop feed from bounded SQLite pages, dormant PWA browse page reader, and desktop browse materializer",
+    "deck": "Moves the ordinary Freed Desktop feed onto bounded SQLite pages while keeping Automerge authoritative and preserving an immediate local fallback",
     "features": [
-      "Read the Desktop feed from bounded SQLite pages",
-      "Desktop browse materializer",
-      "Dormant PWA browse page reader"
+      "The ordinary All Content feed now reads exact, source-bound pages from the verified SQLite projection, capped at 128 rows per page and a 2 MiB native cache",
+      "Freed Desktop keeps at most 512 SQLite-backed feed cards in React and cancels stale page work when the source changes",
+      "The PWA and native browse-generation foundations now support the same bounded paging contract without activating a PWA cutover"
     ],
     "fixes": [
-      "Bind native browse source provenance",
-      "Monochrome macOS menu bar icon now uses the correct path",
-      "Card density menu divider removed",
-      "Shard nightly tooling tests independently"
+      "SQLite browse generations are sealed, pinned, and tied to the exact Automerge source frontier before a page can be returned",
+      "A stale or divergent SQLite result falls back to the existing Automerge feed instead of replacing authoritative data",
+      "The macOS menu bar now uses the correct monochrome template icon, the card-density menu no longer shows a stray divider, and nightly tooling tests shard independently"
     ],
     "followUps": [
-      "Bounded SQLite shadow migration bridge",
-      "Pin native browse generation reads",
-      "Register immutable browse generations",
-      "Seal native browse generations",
-      "Define Library Core recommendation order",
-      "Authenticated PWA feed materialization",
-      "Close bounded Library Core feed-page protocol",
-      "Materialize bounded Automerge rows into SQLite",
-      "Stage verified Automerge graphs in SQLite",
-      "Bounded Automerge column and scalar decoders",
-      "Bounded Automerge framing decoder",
-      "Bounded Automerge migration spool",
-      "Runtime SQLite shadow generations",
-      "Immutable SQLite projection generations"
+      "Automerge remains the authority, full corpus, and fallback. SQLite does not accept user or provider writes in this build",
+      "If bounded-feed parity, responsiveness, or memory regresses, the local freed.libraryCore.feedBrowseReaderV1.disabled flag restores the Automerge reader",
+      "This activation changes only local storage reads. It adds no provider requests, navigation, cookies, headers, retries, or cadence"
     ]
   },
-  "releaseBody": "(AI Generated).\n\n## Freed v26.7.3000-dev\n\nRead the Desktop feed from bounded SQLite pages, dormant PWA browse page reader, and desktop browse materializer\n\n### Features\n\n- Read the Desktop feed from bounded SQLite pages\n- Desktop browse materializer\n- Dormant PWA browse page reader\n\n### Fixes\n\n- Bind native browse source provenance\n- Monochrome macOS menu bar icon now uses the correct path\n- Card density menu divider removed\n- Shard nightly tooling tests independently\n\n### Follow-ups\n\n- Bounded SQLite shadow migration bridge\n- Pin native browse generation reads\n- Register immutable browse generations\n- Seal native browse generations\n- Define Library Core recommendation order\n- Authenticated PWA feed materialization\n- Close bounded Library Core feed-page protocol\n- Materialize bounded Automerge rows into SQLite\n- Stage verified Automerge graphs in SQLite\n- Bounded Automerge column and scalar decoders\n- Bounded Automerge framing decoder\n- Bounded Automerge migration spool\n- Runtime SQLite shadow generations\n- Immutable SQLite projection generations\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+  "releaseBody": "(AI Generated).\n\n## Freed v26.7.3000-dev\n\nMoves the ordinary Freed Desktop feed onto bounded SQLite pages while keeping Automerge authoritative and preserving an immediate local fallback\n\n### Features\n\n- The ordinary All Content feed now reads exact, source-bound pages from the verified SQLite projection, capped at 128 rows per page and a 2 MiB native cache\n- Freed Desktop keeps at most 512 SQLite-backed feed cards in React and cancels stale page work when the source changes\n- The PWA and native browse-generation foundations now support the same bounded paging contract without activating a PWA cutover\n\n### Fixes\n\n- SQLite browse generations are sealed, pinned, and tied to the exact Automerge source frontier before a page can be returned\n- A stale or divergent SQLite result falls back to the existing Automerge feed instead of replacing authoritative data\n- The macOS menu bar now uses the correct monochrome template icon, the card-density menu no longer shows a stray divider, and nightly tooling tests shard independently\n\n### Follow-ups\n\n- Automerge remains the authority, full corpus, and fallback. SQLite does not accept user or provider writes in this build\n- If bounded-feed parity, responsiveness, or memory regresses, the local freed.libraryCore.feedBrowseReaderV1.disabled flag restores the Automerge reader\n- This activation changes only local storage reads. It adds no provider requests, navigation, cookies, headers, retries, or cadence\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
 }

--- a/release-notes/releases/v26.7.3000-dev.json
+++ b/release-notes/releases/v26.7.3000-dev.json
@@ -47,10 +47,10 @@
       ],
       "inspectionDigest": "sha256:c9b2ad54c4b1fb9bd4220964f49791efa63d14adaebb1785a96cd994529c84ba",
       "decision": {
-        "state": "review_required",
-        "ownerApprovalReference": null,
-        "approvedInspectionDigest": null,
-        "approvedReleaseArtifactDigest": null
+        "state": "owner_approved",
+        "ownerApprovalReference": "https://github.com/freed-project/freed/pull/1272#issuecomment-5135239996",
+        "approvedInspectionDigest": "sha256:c9b2ad54c4b1fb9bd4220964f49791efa63d14adaebb1785a96cd994529c84ba",
+        "approvedReleaseArtifactDigest": "sha256:84272dddd285f13c5e64d4fcf81b54cc68d3dd9c6838647781f7a86ef6b94272"
       }
     },
     "isLatestOfDay": true,

--- a/release-notes/releases/v26.7.3000-dev.md
+++ b/release-notes/releases/v26.7.3000-dev.md
@@ -1,0 +1,43 @@
+(AI Generated).
+
+## Freed v26.7.3000-dev
+
+Read the Desktop feed from bounded SQLite pages, dormant PWA browse page reader, and desktop browse materializer
+
+### Features
+
+- Read the Desktop feed from bounded SQLite pages
+- Desktop browse materializer
+- Dormant PWA browse page reader
+
+### Fixes
+
+- Bind native browse source provenance
+- Monochrome macOS menu bar icon now uses the correct path
+- Card density menu divider removed
+- Shard nightly tooling tests independently
+
+### Follow-ups
+
+- Bounded SQLite shadow migration bridge
+- Pin native browse generation reads
+- Register immutable browse generations
+- Seal native browse generations
+- Define Library Core recommendation order
+- Authenticated PWA feed materialization
+- Close bounded Library Core feed-page protocol
+- Materialize bounded Automerge rows into SQLite
+- Stage verified Automerge graphs in SQLite
+- Bounded Automerge column and scalar decoders
+- Bounded Automerge framing decoder
+- Bounded Automerge migration spool
+- Runtime SQLite shadow generations
+- Immutable SQLite projection generations
+
+### Downloads
+
+**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  
+**Windows:** `.exe` (NSIS installer)  
+**Linux:** `.AppImage`  
+
+> macOS downloads are signed and notarized for normal Gatekeeper installation.

--- a/release-notes/releases/v26.7.3000-dev.md
+++ b/release-notes/releases/v26.7.3000-dev.md
@@ -2,37 +2,25 @@
 
 ## Freed v26.7.3000-dev
 
-Read the Desktop feed from bounded SQLite pages, dormant PWA browse page reader, and desktop browse materializer
+Moves the ordinary Freed Desktop feed onto bounded SQLite pages while keeping Automerge authoritative and preserving an immediate local fallback
 
 ### Features
 
-- Read the Desktop feed from bounded SQLite pages
-- Desktop browse materializer
-- Dormant PWA browse page reader
+- The ordinary All Content feed now reads exact, source-bound pages from the verified SQLite projection, capped at 128 rows per page and a 2 MiB native cache
+- Freed Desktop keeps at most 512 SQLite-backed feed cards in React and cancels stale page work when the source changes
+- The PWA and native browse-generation foundations now support the same bounded paging contract without activating a PWA cutover
 
 ### Fixes
 
-- Bind native browse source provenance
-- Monochrome macOS menu bar icon now uses the correct path
-- Card density menu divider removed
-- Shard nightly tooling tests independently
+- SQLite browse generations are sealed, pinned, and tied to the exact Automerge source frontier before a page can be returned
+- A stale or divergent SQLite result falls back to the existing Automerge feed instead of replacing authoritative data
+- The macOS menu bar now uses the correct monochrome template icon, the card-density menu no longer shows a stray divider, and nightly tooling tests shard independently
 
 ### Follow-ups
 
-- Bounded SQLite shadow migration bridge
-- Pin native browse generation reads
-- Register immutable browse generations
-- Seal native browse generations
-- Define Library Core recommendation order
-- Authenticated PWA feed materialization
-- Close bounded Library Core feed-page protocol
-- Materialize bounded Automerge rows into SQLite
-- Stage verified Automerge graphs in SQLite
-- Bounded Automerge column and scalar decoders
-- Bounded Automerge framing decoder
-- Bounded Automerge migration spool
-- Runtime SQLite shadow generations
-- Immutable SQLite projection generations
+- Automerge remains the authority, full corpus, and fallback. SQLite does not accept user or provider writes in this build
+- If bounded-feed parity, responsiveness, or memory regresses, the local freed.libraryCore.feedBrowseReaderV1.disabled flag restores the Automerge reader
+- This activation changes only local storage reads. It adds no provider requests, navigation, cookies, headers, retries, or cadence
 
 ### Downloads
 


### PR DESCRIPTION
(AI Generated).

## Summary
- Prepare the exact dev release from merged product commit 15b4422c764a375b825eb279d08203398be26f76.
- Activate bounded SQLite feed reads while keeping Automerge authoritative and locally reversible.

## Testing
- npm run validate:feature
- 411 PWA unit tests, 16 PWA performance tests, 888 Desktop unit tests, 9 Desktop smoke checks, and 363 native tests passed
- Release notes and exact release identity validation passed