### PR TITLE
chore: prepare v26.7.3001-dev

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freed/desktop",
   "private": true,
-  "version": "26.7.3000",
+  "version": "26.7.3001",
   "type": "module",
   "scripts": {
     "dev": "node ../../node_modules/vite/bin/vite.js",

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -1443,7 +1443,7 @@ dependencies = [
 
 [[package]]
 name = "freed-desktop"
-version = "26.7.3000"
+version = "26.7.3001"
 dependencies = [
  "base64 0.23.0",
  "criterion",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freed-desktop"
-version = "26.7.3000"
+version = "26.7.3001"
 description = "Freed Desktop - Escape algorithmic manipulation"
 authors = ["Freed"]
 edition = "2021"

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Freed",
-  "version": "26.7.3000",
+  "version": "26.7.3001",
   "identifier": "wtf.freed.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freed/pwa",
   "private": true,
-  "version": "26.7.3000",
+  "version": "26.7.3001",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/release-notes/daily/dev/26.7.30.json
+++ b/release-notes/daily/dev/26.7.30.json
@@ -14,5 +14,5 @@
     "State plainly that Automerge remains authoritative and is the immediate fallback.",
     "Keep dormant PWA foundations subordinate to the Desktop activation."
   ],
-  "updatedAt": "2026-07-30T18:35:41.933Z"
+  "updatedAt": "2026-07-30T21:36:13.644Z"
 }

--- a/release-notes/daily/dev/26.7.30.json
+++ b/release-notes/daily/dev/26.7.30.json
@@ -2,7 +2,7 @@
   "channel": "dev",
   "dayKey": "26.7.30",
   "date": "2026-07-30",
-  "preferredDeck": "Moves the ordinary Freed Desktop feed onto bounded SQLite pages while keeping Automerge authoritative and preserving an immediate local fallback",
+  "preferredDeck": "Cuts peak memory while building the SQLite-backed feed by reusing the renderer snapshot instead of traversing the full Automerge library twice",
   "editorialGuidance": [
     "Keep the tone concise, professional, and specific.",
     "Lead with user-facing outcomes, shipping milestones, trust wins, and installability improvements.",
@@ -10,9 +10,8 @@
   ],
   "pinnedHighlights": [],
   "editorialNotes": [
-    "Lead with the first active bounded SQLite read path.",
-    "State plainly that Automerge remains authoritative and is the immediate fallback.",
-    "Keep dormant PWA foundations subordinate to the Desktop activation."
+    "Keep v26.7.3001-dev focused on the memory correction layered over the SQLite reader shipped in v26.7.3000-dev.",
+    "State plainly that Automerge remains authoritative and is the immediate fallback."
   ],
   "updatedAt": "2026-07-30T21:36:13.644Z"
 }

--- a/release-notes/releases/v26.7.3001-dev.json
+++ b/release-notes/releases/v26.7.3001-dev.json
@@ -1,0 +1,146 @@
+{
+  "tag": "v26.7.3001-dev",
+  "version": "26.7.3001-dev",
+  "channel": "dev",
+  "dayKey": "26.7.30",
+  "approved": false,
+  "editorialNotes": [],
+  "generatedAt": "2026-07-30T21:36:13.642Z",
+  "model": "heuristic",
+  "source": {
+    "channel": "dev",
+    "previousPublishedTag": "v26.7.3000-dev",
+    "previousPublishedDayTag": "v26.7.2901-dev",
+    "compareRef": "HEAD",
+    "productCommitSha": "bba5eaa18c1c00efd03c73a3bb912cdbc43e3144",
+    "promotedDevCommitSha": null,
+    "libraryCoreActivation": {
+      "schemaVersion": 1,
+      "range": {
+        "channel": "dev",
+        "previousPublishedTag": "v26.7.3000-dev",
+        "startMode": "previous_product_commit",
+        "fromExclusiveCommitSha": "15b4422c764a375b825eb279d08203398be26f76",
+        "toInclusiveProductCommitSha": "bba5eaa18c1c00efd03c73a3bb912cdbc43e3144"
+      },
+      "manifest": {
+        "path": "docs/library-core-activation-manifest.json",
+        "previousPresent": true,
+        "previousDigest": "sha256:74d4cd5c0e06468f79eeb2737c0c07a9ff83f0c238e6504cf31fe18cedb2d594",
+        "currentDigest": "sha256:74d4cd5c0e06468f79eeb2737c0c07a9ff83f0c238e6504cf31fe18cedb2d594"
+      },
+      "transitions": [],
+      "inspectionDigest": "sha256:3d87f1a5c8fdb4621ac163c98f5187350494d072d158170d78c3bc076567891e",
+      "decision": {
+        "state": "no_activation_declared",
+        "ownerApprovalReference": null,
+        "approvedInspectionDigest": null,
+        "approvedReleaseArtifactDigest": null
+      }
+    },
+    "isLatestOfDay": true,
+    "sameDayTagsIncluded": [
+      "v26.7.3000-dev",
+      "v26.7.3001-dev"
+    ],
+    "relatedBuildTags": [
+      "v26.7.3000-dev",
+      "v26.7.3001-dev"
+    ],
+    "prNumbers": [
+      1237,
+      1242,
+      1243,
+      1245,
+      1246,
+      1247,
+      1248,
+      1249,
+      1250,
+      1251,
+      1252,
+      1253,
+      1254,
+      1255,
+      1256,
+      1257,
+      1258,
+      1259,
+      1260,
+      1261,
+      1262,
+      1263,
+      1264,
+      1265,
+      1266,
+      1267,
+      1268,
+      1269,
+      1272,
+      1273
+    ],
+    "commitSubjects": [
+      "fix: bound Library Core feed migration memory (#1273)",
+      "chore: prepare v26.7.3000-dev (#1272)",
+      "feat: read the Desktop feed from bounded SQLite pages (#1269)",
+      "feat: add bounded SQLite shadow migration bridge (#1268)",
+      "feat: pin native browse generation reads (#1267)",
+      "feat: register immutable browse generations (#1266)",
+      "feat: seal native browse generations (#1265)",
+      "fix: bind native browse source provenance (#1264)",
+      "feat: add desktop browse materializer (#1263)",
+      "feat: add native browse generation runtime (#1262)",
+      "feat: add native browse generation store (#1261)",
+      "feat: add dormant PWA browse page reader (#1260)",
+      "feat: materialize bounded PWA browse generations (#1259)",
+      "refactor: define Library Core recommendation order (#1258)",
+      "refactor: define Library Core feed filters (#1257)",
+      "feat: add authenticated PWA feed materialization (#1256)",
+      "feat: add dormant PWA Library Core feed reader (#1255)",
+      "feat: add dormant desktop SQLite feed reader (#1254)",
+      "feat: close bounded Library Core feed-page protocol (#1253)",
+      "feat: materialize bounded Automerge rows into SQLite (#1252)",
+      "feat: stage verified Automerge graphs in SQLite (#1251)",
+      "feat: reconstruct bounded Automerge migration rows (#1250)",
+      "feat: add bounded Automerge column and scalar decoders (#1249)",
+      "feat: add bounded Automerge framing decoder (#1248)",
+      "fix: use monochrome macOS menu bar icon (#1247)",
+      "feat: add bounded Automerge migration spool (#1246)",
+      "fix: remove card density menu divider (#1245)",
+      "feat: add runtime SQLite shadow generations (#1243)",
+      "feat: add immutable SQLite projection generations (#1237)",
+      "fix: shard nightly tooling tests independently (#1242)"
+    ]
+  },
+  "release": {
+    "deck": "Moves the ordinary Freed Desktop feed onto bounded SQLite pages while keeping Automerge authoritative and preserving an immediate local fallback",
+    "features": [
+      "Read the Desktop feed from bounded SQLite pages",
+      "Desktop browse materializer",
+      "Dormant PWA browse page reader"
+    ],
+    "fixes": [
+      "Bound Library Core feed migration memory",
+      "Bind native browse source provenance",
+      "Monochrome macOS menu bar icon now uses the correct path",
+      "Card density menu divider removed",
+      "Shard nightly tooling tests independently",
+      "SQLite browse generations are sealed, pinned, and tied to the exact Automerge source frontier before a page can be returned",
+      "A stale or divergent SQLite result falls back to the existing Automerge feed instead of replacing authoritative data"
+    ],
+    "followUps": [
+      "Reader, sidebar, and settings UX work",
+      "Stage verified Automerge graphs in SQLite",
+      "Bounded Automerge column and scalar decoders",
+      "Bounded Automerge framing decoder",
+      "Bounded Automerge migration spool",
+      "The ordinary All Content feed now reads exact, source-bound pages from the verified SQLite projection, capped at 128 rows per page and a 2 MiB native cache",
+      "Freed Desktop keeps at most 512 SQLite-backed feed cards in React and cancels stale page work when the source changes",
+      "The PWA and native browse-generation foundations now support the same bounded paging contract without activating a PWA cutover",
+      "Automerge remains the authority, full corpus, and fallback. SQLite does not accept user or provider writes in this build",
+      "If bounded-feed parity, responsiveness, or memory regresses, the local freed.libraryCore.feedBrowseReaderV1.disabled flag restores the Automerge reader",
+      "This activation changes only local storage reads. It adds no provider requests, navigation, cookies, headers, retries, or cadence"
+    ]
+  },
+  "releaseBody": "(AI Generated).\n\n## Freed v26.7.3001-dev\n\nMoves the ordinary Freed Desktop feed onto bounded SQLite pages while keeping Automerge authoritative and preserving an immediate local fallback\n\n### Features\n\n- Read the Desktop feed from bounded SQLite pages\n- Desktop browse materializer\n- Dormant PWA browse page reader\n\n### Fixes\n\n- Bound Library Core feed migration memory\n- Bind native browse source provenance\n- Monochrome macOS menu bar icon now uses the correct path\n- Card density menu divider removed\n- Shard nightly tooling tests independently\n- SQLite browse generations are sealed, pinned, and tied to the exact Automerge source frontier before a page can be returned\n- A stale or divergent SQLite result falls back to the existing Automerge feed instead of replacing authoritative data\n\n### Follow-ups\n\n- Reader, sidebar, and settings UX work\n- Stage verified Automerge graphs in SQLite\n- Bounded Automerge column and scalar decoders\n- Bounded Automerge framing decoder\n- Bounded Automerge migration spool\n- The ordinary All Content feed now reads exact, source-bound pages from the verified SQLite projection, capped at 128 rows per page and a 2 MiB native cache\n- Freed Desktop keeps at most 512 SQLite-backed feed cards in React and cancels stale page work when the source changes\n- The PWA and native browse-generation foundations now support the same bounded paging contract without activating a PWA cutover\n- Automerge remains the authority, full corpus, and fallback. SQLite does not accept user or provider writes in this build\n- If bounded-feed parity, responsiveness, or memory regresses, the local freed.libraryCore.feedBrowseReaderV1.disabled flag restores the Automerge reader\n- This activation changes only local storage reads. It adds no provider requests, navigation, cookies, headers, retries, or cadence\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+}

--- a/release-notes/releases/v26.7.3001-dev.json
+++ b/release-notes/releases/v26.7.3001-dev.json
@@ -116,17 +116,24 @@
   },
   "release": {
     "deck": "Cuts peak memory while building the SQLite-backed feed by reusing the renderer snapshot instead of traversing the full Automerge library twice",
-    "features": [],
+    "features": [
+      "The ordinary All Content feed now reads exact, source-bound pages from the verified SQLite projection, capped at 128 rows per page and a 2 MiB native cache",
+      "Freed Desktop keeps at most 512 SQLite-backed feed cards in React and cancels stale page work when the source changes",
+      "The PWA and native browse-generation foundations now support the same bounded paging contract without activating a PWA cutover"
+    ],
     "fixes": [
+      "SQLite browse generations are sealed, pinned, and tied to the exact Automerge source frontier before a page can be returned",
+      "A stale or divergent SQLite result falls back to the existing Automerge feed instead of replacing authoritative data",
+      "The macOS menu bar now uses the correct monochrome template icon, the card-density menu no longer shows a stray divider, and nightly tooling tests shard independently",
       "The SQLite feed materializer now reuses the plain library snapshot already produced at startup",
       "Incremental item patches preserve exact source order without another full Automerge traversal",
       "Migration still sends only bounded 128-row pages into SQLite and falls back safely if the source changes"
     ],
     "followUps": [
-      "Automerge remains the replication authority and immediate local fallback",
-      "The local freed.libraryCore.feedBrowseReaderV1.disabled switch restores the legacy reader if parity, responsiveness, or memory regresses",
-      "This build changes no provider requests, navigation, cookies, headers, retries, or cadence"
+      "Automerge remains the authority, full corpus, and fallback. SQLite does not accept user or provider writes in this build",
+      "If bounded-feed parity, responsiveness, or memory regresses, the local freed.libraryCore.feedBrowseReaderV1.disabled flag restores the Automerge reader",
+      "This activation changes only local storage reads. It adds no provider requests, navigation, cookies, headers, retries, or cadence"
     ]
   },
-  "releaseBody": "(AI Generated).\n\n## Freed v26.7.3001-dev\n\nCuts peak memory while building the SQLite-backed feed by reusing the renderer snapshot instead of traversing the full Automerge library twice.\n\n### Fixes\n\n- The SQLite feed materializer now reuses the plain library snapshot already produced at startup.\n- Incremental item patches preserve exact source order without another full Automerge traversal.\n- Migration still sends only bounded 128-row pages into SQLite and falls back safely if the source changes.\n\n### Follow-ups\n\n- Automerge remains the replication authority and immediate local fallback.\n- The local `freed.libraryCore.feedBrowseReaderV1.disabled` switch restores the legacy reader if parity, responsiveness, or memory regresses.\n- This build changes no provider requests, navigation, cookies, headers, retries, or cadence.\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+  "releaseBody": "(AI Generated).\n\n## Freed v26.7.3001-dev\n\nCuts peak memory while building the SQLite-backed feed by reusing the renderer snapshot instead of traversing the full Automerge library twice\n\n### Features\n\n- The ordinary All Content feed now reads exact, source-bound pages from the verified SQLite projection, capped at 128 rows per page and a 2 MiB native cache\n- Freed Desktop keeps at most 512 SQLite-backed feed cards in React and cancels stale page work when the source changes\n- The PWA and native browse-generation foundations now support the same bounded paging contract without activating a PWA cutover\n\n### Fixes\n\n- SQLite browse generations are sealed, pinned, and tied to the exact Automerge source frontier before a page can be returned\n- A stale or divergent SQLite result falls back to the existing Automerge feed instead of replacing authoritative data\n- The macOS menu bar now uses the correct monochrome template icon, the card-density menu no longer shows a stray divider, and nightly tooling tests shard independently\n- The SQLite feed materializer now reuses the plain library snapshot already produced at startup\n- Incremental item patches preserve exact source order without another full Automerge traversal\n- Migration still sends only bounded 128-row pages into SQLite and falls back safely if the source changes\n\n### Follow-ups\n\n- Automerge remains the authority, full corpus, and fallback. SQLite does not accept user or provider writes in this build\n- If bounded-feed parity, responsiveness, or memory regresses, the local freed.libraryCore.feedBrowseReaderV1.disabled flag restores the Automerge reader\n- This activation changes only local storage reads. It adds no provider requests, navigation, cookies, headers, retries, or cadence\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
 }

--- a/release-notes/releases/v26.7.3001-dev.json
+++ b/release-notes/releases/v26.7.3001-dev.json
@@ -3,8 +3,10 @@
   "version": "26.7.3001-dev",
   "channel": "dev",
   "dayKey": "26.7.30",
-  "approved": false,
-  "editorialNotes": [],
+  "approved": true,
+  "editorialNotes": [
+    "Keep this build focused on the post-v26.7.3000 memory correction."
+  ],
   "generatedAt": "2026-07-30T21:36:13.642Z",
   "model": "heuristic",
   "source": {
@@ -113,34 +115,18 @@
     ]
   },
   "release": {
-    "deck": "Moves the ordinary Freed Desktop feed onto bounded SQLite pages while keeping Automerge authoritative and preserving an immediate local fallback",
-    "features": [
-      "Read the Desktop feed from bounded SQLite pages",
-      "Desktop browse materializer",
-      "Dormant PWA browse page reader"
-    ],
+    "deck": "Cuts peak memory while building the SQLite-backed feed by reusing the renderer snapshot instead of traversing the full Automerge library twice",
+    "features": [],
     "fixes": [
-      "Bound Library Core feed migration memory",
-      "Bind native browse source provenance",
-      "Monochrome macOS menu bar icon now uses the correct path",
-      "Card density menu divider removed",
-      "Shard nightly tooling tests independently",
-      "SQLite browse generations are sealed, pinned, and tied to the exact Automerge source frontier before a page can be returned",
-      "A stale or divergent SQLite result falls back to the existing Automerge feed instead of replacing authoritative data"
+      "The SQLite feed materializer now reuses the plain library snapshot already produced at startup",
+      "Incremental item patches preserve exact source order without another full Automerge traversal",
+      "Migration still sends only bounded 128-row pages into SQLite and falls back safely if the source changes"
     ],
     "followUps": [
-      "Reader, sidebar, and settings UX work",
-      "Stage verified Automerge graphs in SQLite",
-      "Bounded Automerge column and scalar decoders",
-      "Bounded Automerge framing decoder",
-      "Bounded Automerge migration spool",
-      "The ordinary All Content feed now reads exact, source-bound pages from the verified SQLite projection, capped at 128 rows per page and a 2 MiB native cache",
-      "Freed Desktop keeps at most 512 SQLite-backed feed cards in React and cancels stale page work when the source changes",
-      "The PWA and native browse-generation foundations now support the same bounded paging contract without activating a PWA cutover",
-      "Automerge remains the authority, full corpus, and fallback. SQLite does not accept user or provider writes in this build",
-      "If bounded-feed parity, responsiveness, or memory regresses, the local freed.libraryCore.feedBrowseReaderV1.disabled flag restores the Automerge reader",
-      "This activation changes only local storage reads. It adds no provider requests, navigation, cookies, headers, retries, or cadence"
+      "Automerge remains the replication authority and immediate local fallback",
+      "The local freed.libraryCore.feedBrowseReaderV1.disabled switch restores the legacy reader if parity, responsiveness, or memory regresses",
+      "This build changes no provider requests, navigation, cookies, headers, retries, or cadence"
     ]
   },
-  "releaseBody": "(AI Generated).\n\n## Freed v26.7.3001-dev\n\nMoves the ordinary Freed Desktop feed onto bounded SQLite pages while keeping Automerge authoritative and preserving an immediate local fallback\n\n### Features\n\n- Read the Desktop feed from bounded SQLite pages\n- Desktop browse materializer\n- Dormant PWA browse page reader\n\n### Fixes\n\n- Bound Library Core feed migration memory\n- Bind native browse source provenance\n- Monochrome macOS menu bar icon now uses the correct path\n- Card density menu divider removed\n- Shard nightly tooling tests independently\n- SQLite browse generations are sealed, pinned, and tied to the exact Automerge source frontier before a page can be returned\n- A stale or divergent SQLite result falls back to the existing Automerge feed instead of replacing authoritative data\n\n### Follow-ups\n\n- Reader, sidebar, and settings UX work\n- Stage verified Automerge graphs in SQLite\n- Bounded Automerge column and scalar decoders\n- Bounded Automerge framing decoder\n- Bounded Automerge migration spool\n- The ordinary All Content feed now reads exact, source-bound pages from the verified SQLite projection, capped at 128 rows per page and a 2 MiB native cache\n- Freed Desktop keeps at most 512 SQLite-backed feed cards in React and cancels stale page work when the source changes\n- The PWA and native browse-generation foundations now support the same bounded paging contract without activating a PWA cutover\n- Automerge remains the authority, full corpus, and fallback. SQLite does not accept user or provider writes in this build\n- If bounded-feed parity, responsiveness, or memory regresses, the local freed.libraryCore.feedBrowseReaderV1.disabled flag restores the Automerge reader\n- This activation changes only local storage reads. It adds no provider requests, navigation, cookies, headers, retries, or cadence\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+  "releaseBody": "(AI Generated).\n\n## Freed v26.7.3001-dev\n\nCuts peak memory while building the SQLite-backed feed by reusing the renderer snapshot instead of traversing the full Automerge library twice.\n\n### Fixes\n\n- The SQLite feed materializer now reuses the plain library snapshot already produced at startup.\n- Incremental item patches preserve exact source order without another full Automerge traversal.\n- Migration still sends only bounded 128-row pages into SQLite and falls back safely if the source changes.\n\n### Follow-ups\n\n- Automerge remains the replication authority and immediate local fallback.\n- The local `freed.libraryCore.feedBrowseReaderV1.disabled` switch restores the legacy reader if parity, responsiveness, or memory regresses.\n- This build changes no provider requests, navigation, cookies, headers, retries, or cadence.\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
 }

--- a/release-notes/releases/v26.7.3001-dev.md
+++ b/release-notes/releases/v26.7.3001-dev.md
@@ -1,0 +1,43 @@
+(AI Generated).
+
+## Freed v26.7.3001-dev
+
+Moves the ordinary Freed Desktop feed onto bounded SQLite pages while keeping Automerge authoritative and preserving an immediate local fallback
+
+### Features
+
+- Read the Desktop feed from bounded SQLite pages
+- Desktop browse materializer
+- Dormant PWA browse page reader
+
+### Fixes
+
+- Bound Library Core feed migration memory
+- Bind native browse source provenance
+- Monochrome macOS menu bar icon now uses the correct path
+- Card density menu divider removed
+- Shard nightly tooling tests independently
+- SQLite browse generations are sealed, pinned, and tied to the exact Automerge source frontier before a page can be returned
+- A stale or divergent SQLite result falls back to the existing Automerge feed instead of replacing authoritative data
+
+### Follow-ups
+
+- Reader, sidebar, and settings UX work
+- Stage verified Automerge graphs in SQLite
+- Bounded Automerge column and scalar decoders
+- Bounded Automerge framing decoder
+- Bounded Automerge migration spool
+- The ordinary All Content feed now reads exact, source-bound pages from the verified SQLite projection, capped at 128 rows per page and a 2 MiB native cache
+- Freed Desktop keeps at most 512 SQLite-backed feed cards in React and cancels stale page work when the source changes
+- The PWA and native browse-generation foundations now support the same bounded paging contract without activating a PWA cutover
+- Automerge remains the authority, full corpus, and fallback. SQLite does not accept user or provider writes in this build
+- If bounded-feed parity, responsiveness, or memory regresses, the local freed.libraryCore.feedBrowseReaderV1.disabled flag restores the Automerge reader
+- This activation changes only local storage reads. It adds no provider requests, navigation, cookies, headers, retries, or cadence
+
+### Downloads
+
+**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  
+**Windows:** `.exe` (NSIS installer)  
+**Linux:** `.AppImage`  
+
+> macOS downloads are signed and notarized for normal Gatekeeper installation.

--- a/release-notes/releases/v26.7.3001-dev.md
+++ b/release-notes/releases/v26.7.3001-dev.md
@@ -2,37 +2,19 @@
 
 ## Freed v26.7.3001-dev
 
-Moves the ordinary Freed Desktop feed onto bounded SQLite pages while keeping Automerge authoritative and preserving an immediate local fallback
-
-### Features
-
-- Read the Desktop feed from bounded SQLite pages
-- Desktop browse materializer
-- Dormant PWA browse page reader
+Cuts peak memory while building the SQLite-backed feed by reusing the renderer snapshot instead of traversing the full Automerge library twice.
 
 ### Fixes
 
-- Bound Library Core feed migration memory
-- Bind native browse source provenance
-- Monochrome macOS menu bar icon now uses the correct path
-- Card density menu divider removed
-- Shard nightly tooling tests independently
-- SQLite browse generations are sealed, pinned, and tied to the exact Automerge source frontier before a page can be returned
-- A stale or divergent SQLite result falls back to the existing Automerge feed instead of replacing authoritative data
+- The SQLite feed materializer now reuses the plain library snapshot already produced at startup.
+- Incremental item patches preserve exact source order without another full Automerge traversal.
+- Migration still sends only bounded 128-row pages into SQLite and falls back safely if the source changes.
 
 ### Follow-ups
 
-- Reader, sidebar, and settings UX work
-- Stage verified Automerge graphs in SQLite
-- Bounded Automerge column and scalar decoders
-- Bounded Automerge framing decoder
-- Bounded Automerge migration spool
-- The ordinary All Content feed now reads exact, source-bound pages from the verified SQLite projection, capped at 128 rows per page and a 2 MiB native cache
-- Freed Desktop keeps at most 512 SQLite-backed feed cards in React and cancels stale page work when the source changes
-- The PWA and native browse-generation foundations now support the same bounded paging contract without activating a PWA cutover
-- Automerge remains the authority, full corpus, and fallback. SQLite does not accept user or provider writes in this build
-- If bounded-feed parity, responsiveness, or memory regresses, the local freed.libraryCore.feedBrowseReaderV1.disabled flag restores the Automerge reader
-- This activation changes only local storage reads. It adds no provider requests, navigation, cookies, headers, retries, or cadence
+- Automerge remains the replication authority and immediate local fallback.
+- The local `freed.libraryCore.feedBrowseReaderV1.disabled` switch restores the legacy reader if parity, responsiveness, or memory regresses.
+- This build changes no provider requests, navigation, cookies, headers, retries, or cadence.
 
 ### Downloads
 


### PR DESCRIPTION
(AI Generated).

## Summary
- Prepare v26.7.3001-dev from exact product commit bba5eaa18c1c00efd03c73a3bb912cdbc43e3144.
- Carry forward the complete same-day v26.7.3000-dev SQLite feed release notes.
- Document the v26.7.3001-dev memory correction: reuse the startup renderer snapshot, preserve exact source order for incremental patches, and keep SQLite migration writes bounded to 128-row pages.
- Keep Automerge authoritative for replication and preserve the immediate local fallback. This release changes no provider requests, navigation, cookies, headers, retries, or cadence.

## Testing
- npm run validate:feature
- Root typecheck passed.
- PWA production build and typecheck passed.
- PWA unit tests: 411 passed, 1 skipped.
- PWA performance tests: 16 passed.
- Desktop unit tests: 893 passed.
- Desktop smoke checks: 9 passed.
- Desktop production build passed.
- Rust clippy passed.
- Rust tests: 363 passed.
- Release-note shared tests: 22 passed.
- Release-note artifact and release identity validation passed at c64522e458c8cc6ebfb7b8a38bc8b20297c29bf9.