### PR TITLE
chore: prepare v26.7.3100-dev

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freed/desktop",
   "private": true,
-  "version": "26.7.3001",
+  "version": "26.7.3100",
   "type": "module",
   "scripts": {
     "dev": "node ../../node_modules/vite/bin/vite.js",

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -1443,7 +1443,7 @@ dependencies = [
 
 [[package]]
 name = "freed-desktop"
-version = "26.7.3001"
+version = "26.7.3100"
 dependencies = [
  "base64 0.23.0",
  "criterion",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freed-desktop"
-version = "26.7.3001"
+version = "26.7.3100"
 description = "Freed Desktop - Escape algorithmic manipulation"
 authors = ["Freed"]
 edition = "2021"

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Freed",
-  "version": "26.7.3001",
+  "version": "26.7.3100",
   "identifier": "wtf.freed.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freed/pwa",
   "private": true,
-  "version": "26.7.3001",
+  "version": "26.7.3100",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/release-notes/daily/dev/26.7.31.json
+++ b/release-notes/daily/dev/26.7.31.json
@@ -1,0 +1,14 @@
+{
+  "channel": "dev",
+  "dayKey": "26.7.31",
+  "date": "2026-07-31",
+  "preferredDeck": null,
+  "editorialGuidance": [
+    "Keep the tone concise, professional, and specific.",
+    "Lead with user-facing outcomes, shipping milestones, trust wins, and installability improvements.",
+    "Demote internal cleanup unless it clearly changes the shipped product."
+  ],
+  "pinnedHighlights": [],
+  "editorialNotes": [],
+  "updatedAt": "2026-07-31T22:06:09.716Z"
+}

--- a/release-notes/releases/v26.7.3100-dev.json
+++ b/release-notes/releases/v26.7.3100-dev.json
@@ -1,0 +1,123 @@
+{
+  "tag": "v26.7.3100-dev",
+  "version": "26.7.3100-dev",
+  "channel": "dev",
+  "dayKey": "26.7.31",
+  "approved": false,
+  "editorialNotes": [],
+  "generatedAt": "2026-07-31T22:06:09.716Z",
+  "model": "heuristic",
+  "source": {
+    "channel": "dev",
+    "previousPublishedTag": "v26.7.3001-dev",
+    "previousPublishedDayTag": "v26.7.3001-dev",
+    "compareRef": "HEAD",
+    "productCommitSha": "cd644499e7abebd982b1434fcbba5bbb5b3fb331",
+    "promotedDevCommitSha": null,
+    "libraryCoreActivation": {
+      "schemaVersion": 1,
+      "range": {
+        "channel": "dev",
+        "previousPublishedTag": "v26.7.3001-dev",
+        "startMode": "previous_product_commit",
+        "fromExclusiveCommitSha": "bba5eaa18c1c00efd03c73a3bb912cdbc43e3144",
+        "toInclusiveProductCommitSha": "cd644499e7abebd982b1434fcbba5bbb5b3fb331"
+      },
+      "manifest": {
+        "path": "docs/library-core-activation-manifest.json",
+        "previousPresent": true,
+        "previousDigest": "sha256:74d4cd5c0e06468f79eeb2737c0c07a9ff83f0c238e6504cf31fe18cedb2d594",
+        "currentDigest": "sha256:f38e2c15dbdcbe7ef0b1e27a9967cf1a179c167b1acd6874a3ca857c6f3a5aa5"
+      },
+      "transitions": [
+        {
+          "activationId": "desktop-item-detail-sql-read-v1",
+          "gate": "D",
+          "kind": "sql_read_cutover",
+          "rollbackTrigger": "Set freed.libraryCore.itemDetailReaderV1.disabled to 1 on the affected device if a selected Desktop reader body diverges, fails to load, or increases memory relative to the Automerge fallback.",
+          "receiptExpectations": [
+            "read_cutover_parity",
+            "same_frontier_rollback_receipt"
+          ]
+        }
+      ],
+      "inspectionDigest": "sha256:405a8621c1e58ec0e3689860c9d81deaa5b236419e6c97ab63d4c2a9844e524f",
+      "decision": {
+        "state": "review_required",
+        "ownerApprovalReference": null,
+        "approvedInspectionDigest": null,
+        "approvedReleaseArtifactDigest": null
+      }
+    },
+    "isLatestOfDay": true,
+    "sameDayTagsIncluded": [
+      "v26.7.3100-dev"
+    ],
+    "relatedBuildTags": [
+      "v26.7.3100-dev"
+    ],
+    "prNumbers": [
+      1275,
+      1276,
+      1277,
+      1278,
+      1279,
+      1280,
+      1281,
+      1282,
+      1283,
+      1284,
+      1285,
+      1286,
+      1287,
+      1288,
+      1289,
+      1290,
+      1291,
+      1293
+    ],
+    "commitSubjects": [
+      "fix: stop blocked preflight renderer crash loop (#1293)",
+      "perf: read item details from Library Core SQLite (#1291)",
+      "feat: add durable PWA intent outbox (#1290)",
+      "feat: add PWA intent wire protocol (#1289)",
+      "feat: add authenticated portable feed reader (#1288)",
+      "feat: authenticate Library Core operation admission (#1287)",
+      "feat: add Library Core operation segments (#1286)",
+      "feat: add PWA portable checkpoint store (#1285)",
+      "feat: add portable Library Core checkpoints (#1284)",
+      "feat: publish exact Library Core checkpoints (#1283)",
+      "feat: import exact Library Core manifests (#1282)",
+      "fix: bind Library Core control to manifest ID (#1281)",
+      "feat: import Library Core checkpoint pages (#1280)",
+      "feat: add Library Core Google Drive adapter (#1279)",
+      "feat: define Library Core writer reassignment (#1278)",
+      "feat: define Library Core wire objects (#1277)",
+      "feat: coordinate immutable Library Core publication (#1276)",
+      "feat: define immutable Library Core transport (#1275)"
+    ]
+  },
+  "release": {
+    "deck": "Authenticated portable feed reader, durable PWA intent outbox, and PWA intent wire protocol",
+    "features": [
+      "Authenticated portable feed reader",
+      "Durable PWA intent outbox",
+      "PWA intent wire protocol"
+    ],
+    "fixes": [
+      "Stop blocked preflight renderer crash loop",
+      "Bind Library Core control to manifest ID"
+    ],
+    "followUps": [
+      "Read item details from Library Core SQLite",
+      "Authenticate Library Core operation admission",
+      "PWA portable checkpoint store",
+      "Portable Library Core checkpoints",
+      "Import exact Library Core manifests",
+      "Library Core Google Drive adapter",
+      "Define Library Core writer reassignment",
+      "Coordinate immutable Library Core publication"
+    ]
+  },
+  "releaseBody": "(AI Generated).\n\n## Freed v26.7.3100-dev\n\nAuthenticated portable feed reader, durable PWA intent outbox, and PWA intent wire protocol\n\n### Features\n\n- Authenticated portable feed reader\n- Durable PWA intent outbox\n- PWA intent wire protocol\n\n### Fixes\n\n- Stop blocked preflight renderer crash loop\n- Bind Library Core control to manifest ID\n\n### Follow-ups\n\n- Read item details from Library Core SQLite\n- Authenticate Library Core operation admission\n- PWA portable checkpoint store\n- Portable Library Core checkpoints\n- Import exact Library Core manifests\n- Library Core Google Drive adapter\n- Define Library Core writer reassignment\n- Coordinate immutable Library Core publication\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+}

--- a/release-notes/releases/v26.7.3100-dev.json
+++ b/release-notes/releases/v26.7.3100-dev.json
@@ -3,7 +3,7 @@
   "version": "26.7.3100-dev",
   "channel": "dev",
   "dayKey": "26.7.31",
-  "approved": false,
+  "approved": true,
   "editorialNotes": [],
   "generatedAt": "2026-07-31T22:06:09.716Z",
   "model": "heuristic",
@@ -98,18 +98,18 @@
     ]
   },
   "release": {
-    "deck": "Authenticated portable feed reader, durable PWA intent outbox, and PWA intent wire protocol",
+    "deck": "Stops recurring renderer restarts and adds portable feed reading with durable PWA intent delivery",
     "features": [
       "Authenticated portable feed reader",
       "Durable PWA intent outbox",
-      "PWA intent wire protocol"
+      "PWA intent wire protocol",
+      "Library Core SQLite item-detail reads"
     ],
     "fixes": [
       "Stop blocked preflight renderer crash loop",
       "Bind Library Core control to manifest ID"
     ],
     "followUps": [
-      "Read item details from Library Core SQLite",
       "Authenticate Library Core operation admission",
       "PWA portable checkpoint store",
       "Portable Library Core checkpoints",
@@ -119,5 +119,5 @@
       "Coordinate immutable Library Core publication"
     ]
   },
-  "releaseBody": "(AI Generated).\n\n## Freed v26.7.3100-dev\n\nAuthenticated portable feed reader, durable PWA intent outbox, and PWA intent wire protocol\n\n### Features\n\n- Authenticated portable feed reader\n- Durable PWA intent outbox\n- PWA intent wire protocol\n\n### Fixes\n\n- Stop blocked preflight renderer crash loop\n- Bind Library Core control to manifest ID\n\n### Follow-ups\n\n- Read item details from Library Core SQLite\n- Authenticate Library Core operation admission\n- PWA portable checkpoint store\n- Portable Library Core checkpoints\n- Import exact Library Core manifests\n- Library Core Google Drive adapter\n- Define Library Core writer reassignment\n- Coordinate immutable Library Core publication\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+  "releaseBody": "(AI Generated).\n\n## Freed v26.7.3100-dev\n\nStops recurring renderer restarts and adds portable feed reading with durable PWA intent delivery\n\n### Features\n\n- Authenticated portable feed reader\n- Durable PWA intent outbox\n- PWA intent wire protocol\n- Library Core SQLite item-detail reads\n\n### Fixes\n\n- Stop blocked preflight renderer crash loop\n- Bind Library Core control to manifest ID\n\n### Follow-ups\n\n- Authenticate Library Core operation admission\n- PWA portable checkpoint store\n- Portable Library Core checkpoints\n- Import exact Library Core manifests\n- Library Core Google Drive adapter\n- Define Library Core writer reassignment\n- Coordinate immutable Library Core publication\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
 }

--- a/release-notes/releases/v26.7.3100-dev.md
+++ b/release-notes/releases/v26.7.3100-dev.md
@@ -2,13 +2,14 @@
 
 ## Freed v26.7.3100-dev
 
-Authenticated portable feed reader, durable PWA intent outbox, and PWA intent wire protocol
+Stops recurring renderer restarts and adds portable feed reading with durable PWA intent delivery
 
 ### Features
 
 - Authenticated portable feed reader
 - Durable PWA intent outbox
 - PWA intent wire protocol
+- Library Core SQLite item-detail reads
 
 ### Fixes
 
@@ -17,7 +18,6 @@ Authenticated portable feed reader, durable PWA intent outbox, and PWA intent wi
 
 ### Follow-ups
 
-- Read item details from Library Core SQLite
 - Authenticate Library Core operation admission
 - PWA portable checkpoint store
 - Portable Library Core checkpoints

--- a/release-notes/releases/v26.7.3100-dev.md
+++ b/release-notes/releases/v26.7.3100-dev.md
@@ -1,0 +1,35 @@
+(AI Generated).
+
+## Freed v26.7.3100-dev
+
+Authenticated portable feed reader, durable PWA intent outbox, and PWA intent wire protocol
+
+### Features
+
+- Authenticated portable feed reader
+- Durable PWA intent outbox
+- PWA intent wire protocol
+
+### Fixes
+
+- Stop blocked preflight renderer crash loop
+- Bind Library Core control to manifest ID
+
+### Follow-ups
+
+- Read item details from Library Core SQLite
+- Authenticate Library Core operation admission
+- PWA portable checkpoint store
+- Portable Library Core checkpoints
+- Import exact Library Core manifests
+- Library Core Google Drive adapter
+- Define Library Core writer reassignment
+- Coordinate immutable Library Core publication
+
+### Downloads
+
+**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  
+**Windows:** `.exe` (NSIS installer)  
+**Linux:** `.AppImage`  
+
+> macOS downloads are signed and notarized for normal Gatekeeper installation.


### PR DESCRIPTION
(AI Generated).

## Summary
- Prepares the July 31 dev build from exact dev commit cd644499.
- Includes the renderer crash-loop hotfix and the governed Library Core Gate D activation already merged in PR #1291.

## Testing
- Release validation is pending authenticated Library Core owner approval.