### PR TITLE
perf: stream feed projection from SQLite

### DIFF
--- a/docs/LIBRARY-CORE-CONTRACT.md
+++ b/docs/LIBRARY-CORE-CONTRACT.md
@@ -2837,17 +2837,18 @@ receipted append or finalization after response loss, and cancels both sides
 on failure. It does not retain a corpus-sized ID or row array.
 
 The first Desktop product caller retains the same transport and native
-receipts, but no longer performs this second Automerge proxy traversal. The
-legacy renderer already owns one plain `DocState` snapshot. That snapshot now
-retains exact source-map enumeration IDs separately from its ranked visible
-items. Incremental patch responses identify source additions and removals so
-the tie-break sequence remains exact without a corpus rescan. The adapter
-freezes one state object and one durable source revision, computes rows from
-that plain state, and forwards only one replayable page capped at 128 rows.
-State or source movement fails closed before publication. This is an interim
-Gate D memory correction. Initial renderer hydration still scales with the
-legacy corpus, append-style Automerge change chunks still require the native
-external-memory decoder, and Automerge remains authoritative.
+receipts, but now sources the query-specific generation from the authenticated
+selected SQLite shadow rather than the renderer item array. It scans one
+generation once for the exact filtered row count and once for bounded
+projection output, retaining at most one native item page and one replayable
+128-row browse page. The renderer retains the source-map enumeration IDs needed
+for the exact Automerge tie-break plus compact ranking metadata. Incremental
+patch responses identify source additions and removals so that tie-break
+remains exact without a corpus rescan. State or source movement fails closed
+before publication. This is an interim Gate D memory correction. Initial
+renderer hydration still scales with the legacy corpus, append-style Automerge
+change chunks still require the native external-memory decoder, and Automerge
+remains authoritative.
 
 The cursor is versioned binary data encoded as canonical unpadded base64url. It
 binds the immutable generation digest, transition sequence, projection
@@ -2906,12 +2907,12 @@ renderer. The current recommendation order is also defined once and used by
 both active workers. The PWA now also persists exact filtered recommendation
 order in a separate query-specific IndexedDB generation while holding at most
 one 128-row output page, then serves it through the closed dormant browse
-protocol. The native generation writer transport and its bounded authenticated
-worker materializer are present, but generation selection, the native browse
-reader, renderer-cache eviction, and product caller proof remain absent.
-`adapter_proof_missing` therefore still blocks the query. Authenticated PWA
-materialization, runtime registration, shared semantic contracts, and dormant
-browse projection do not assign a product reader or activate Gate D.
+protocol. Desktop generation selection and the native browse reader now serve
+the default product feed through bounded pages. Renderer-cache eviction and the
+remaining product readers are still absent, so `adapter_proof_missing` still
+blocks the query and Gate D remains inactive. Authenticated PWA materialization,
+runtime registration, and shared semantic contracts likewise do not activate
+Gate D on their own.
 
 An interactive cursor does not pin an unbounded SQLite read transaction or WAL.
 If an adapter uses a pinned snapshot, the query registry declares its maximum

--- a/docs/PHASE-5-DESKTOP.md
+++ b/docs/PHASE-5-DESKTOP.md
@@ -373,6 +373,7 @@ export async function captureDomFeed(
 - [x] Desktop native JSON persistence, encrypted secret store calls, cloud uploads, and outbox drains now run through typed side-effect queues with slow-task diagnostics, so common UI actions do not directly wait on native storage or broad outbox scans
 - [x] Desktop Automerge subscriptions now carry change metadata, so item-patch mutations let the outbox drain only changed items while startup and full document updates keep the full scan path
 - [x] Desktop outbox and article-fetch discovery now stream lossless, generation-pinned SQLite pages with stable keyset cursors instead of traversing the full renderer item corpus
+- [x] Desktop feed browse materialization now scans the selected SQLite generation in bounded pages instead of walking the renderer item corpus a second time
 - [x] Desktop item-patch updates now maintain a main-thread item index and adjust unread, total, and archivable aggregates incrementally instead of walking the visible item list after each patch
 - [x] Desktop RSS feed metadata writes now persist through Automerge and send feed patches to the UI without hydrating the full feed item projection
 - [x] Desktop reader hydration now uses native fetch and authenticated provider paths on open, caches successful reader content locally, pins saved items by default, hydrates X reply threads with media, hydrates visible Facebook and Instagram post comments, and explains private story replies when the user is online

--- a/packages/desktop/src/lib/automerge.ts
+++ b/packages/desktop/src/lib/automerge.ts
@@ -81,7 +81,7 @@ import {
   type MaterializeDesktopLibraryCoreFeedBrowseGenerationResult,
 } from "./library-core-feed-browse-materializer-runtime";
 import {
-  createHydratedLibraryCoreFeedBrowseProjectionClient,
+  createScannedLibraryCoreFeedBrowseProjectionClient,
 } from "./library-core-feed-browse-hydrated-client";
 import { recordRuntimeHealthEvent, recordWorkerInit } from "./runtime-health-events";
 export type { DocChangeEvent, DocState } from "./automerge-types";
@@ -1710,9 +1710,15 @@ const libraryCoreProjectionWorkerClient: LibraryCoreProjectionWorkerClient = {
 };
 
 const libraryCoreFeedBrowseProjectionClient =
-  createHydratedLibraryCoreFeedBrowseProjectionClient({
+  createScannedLibraryCoreFeedBrowseProjectionClient({
     getSource: getLibraryCoreProjectionSource,
     getState: getDocState,
+    openScan: async () => {
+      const { openLibraryCoreItemScanSession } = await import(
+        "./library-core-item-detail-runtime"
+      );
+      return openLibraryCoreItemScanSession(getLibraryCoreProjectionSource);
+    },
   });
 
 let libraryCoreFeedBrowseRun:

--- a/packages/desktop/src/lib/library-core-feed-browse-hydrated-client.test.ts
+++ b/packages/desktop/src/lib/library-core-feed-browse-hydrated-client.test.ts
@@ -1,7 +1,4 @@
-import {
-  createDefaultPreferences,
-  type FeedItem,
-} from "@freed/shared";
+import { createDefaultPreferences, type FeedItem } from "@freed/shared";
 import { describe, expect, it } from "vitest";
 
 import type {
@@ -10,7 +7,9 @@ import type {
 } from "./automerge-types";
 import {
   createHydratedLibraryCoreFeedBrowseProjectionClient,
+  createScannedLibraryCoreFeedBrowseProjectionClient,
 } from "./library-core-feed-browse-hydrated-client";
+import type { LibraryCoreItemScanSession } from "./library-core-item-detail-runtime";
 
 function item(globalId: string, text = globalId): FeedItem {
   return {
@@ -79,18 +78,22 @@ describe("hydrated Library Core browse projection client", () => {
 
     expect(started.binding.totalRows).toBe(2);
     expect(batch.done).toBe(true);
-    expect(batch.rows.map((row) => [row.globalId, row.sourceSequence])).toEqual([
-      ["saved:second", 1],
-      ["saved:first", 0],
-    ]);
+    expect(batch.rows.map((row) => [row.globalId, row.sourceSequence])).toEqual(
+      [
+        ["saved:second", 1],
+        ["saved:first", 0],
+      ],
+    );
   });
 
   it("caps every transfer at 128 rows", async () => {
     const items = Array.from({ length: 129 }, (_, index) =>
-      item(`saved:${index.toLocaleString("en-US", {
-        minimumIntegerDigits: 3,
-        useGrouping: false,
-      })}`),
+      item(
+        `saved:${index.toLocaleString("en-US", {
+          minimumIntegerDigits: 3,
+          useGrouping: false,
+        })}`,
+      ),
     );
     const captured = state(items);
     const client = createHydratedLibraryCoreFeedBrowseProjectionClient({
@@ -135,6 +138,85 @@ describe("hydrated Library Core browse projection client", () => {
 
     await expect(client.begin("session", {}, 1_000)).rejects.toThrow(
       "source changed",
+    );
+  });
+});
+
+describe("scanned Library Core browse projection client", () => {
+  it("counts and emits bounded SQLite pages without reading renderer items", async () => {
+    const scannedItems = Array.from({ length: 129 }, (_, index) =>
+      item(
+        `saved:${index.toLocaleString("en-US", {
+          minimumIntegerDigits: 3,
+          useGrouping: false,
+        })}`,
+      ),
+    );
+    const captured = state(
+      [],
+      scannedItems.map((entry) => entry.globalId),
+    );
+    const pages = [
+      scannedItems.slice(0, 64),
+      scannedItems.slice(64, 128),
+      scannedItems.slice(128),
+    ];
+    let openedScans = 0;
+    const openScan = async (): Promise<LibraryCoreItemScanSession> => {
+      openedScans += 1;
+      let pageIndex = 0;
+      return {
+        async nextPage() {
+          const items = pages[pageIndex] ?? [];
+          pageIndex += 1;
+          return { items, done: pageIndex >= pages.length };
+        },
+        async close() {},
+      };
+    };
+    const client = createScannedLibraryCoreFeedBrowseProjectionClient({
+      getSource: async () => source,
+      getState: () => captured,
+      openScan,
+    });
+
+    const started = await client.begin("session", {}, 1_000);
+    const first = await client.nextBatch("session", 0);
+    const second = await client.nextBatch("session", 1);
+
+    expect(started.binding.totalRows).toBe(129);
+    expect(openedScans).toBe(2);
+    expect(first.rows).toHaveLength(128);
+    expect(first.done).toBe(false);
+    expect(second.rows).toHaveLength(1);
+    expect(second.done).toBe(true);
+    expect(
+      [...first.rows, ...second.rows].map((entry) => entry.globalId),
+    ).toEqual(scannedItems.map((entry) => entry.globalId));
+  });
+
+  it("fails closed when scanned items are absent from the source order", async () => {
+    const captured = state([], ["saved:first"]);
+    const openScan = async (): Promise<LibraryCoreItemScanSession> => {
+      let done = false;
+      return {
+        async nextPage() {
+          if (done) return { items: [], done: true };
+          done = true;
+          return { items: [item("saved:unknown")], done: true };
+        },
+        async close() {},
+      };
+    };
+    const client = createScannedLibraryCoreFeedBrowseProjectionClient({
+      getSource: async () => source,
+      getState: () => captured,
+      openScan,
+    });
+    await client.begin("session", {}, 1_000);
+
+    await expect(client.nextBatch("session", 0)).rejects.toThrow(
+      "no source sequence",
     );
   });
 });

--- a/packages/desktop/src/lib/library-core-feed-browse-hydrated-client.ts
+++ b/packages/desktop/src/lib/library-core-feed-browse-hydrated-client.ts
@@ -23,6 +23,7 @@ import type {
   LibraryCoreFeedBrowseProjectionStartedV1,
   LibraryCoreFeedBrowseProjectionWorkerClient,
 } from "./library-core-feed-browse-materializer-runtime";
+import type { LibraryCoreItemScanSession } from "./library-core-item-detail-runtime";
 
 const MAXIMUM_ROWS = 250_000;
 const MAXIMUM_BATCH_ROWS = 128;
@@ -44,6 +45,21 @@ interface HydratedProjectionSession {
   complete: boolean;
 }
 
+interface ScannedProjectionSession {
+  readonly sessionId: string;
+  readonly state: DocState;
+  readonly source: LibraryCoreProjectionSourceV1;
+  readonly sourceSequenceById: ReadonlyMap<string, number>;
+  readonly weights: ReturnType<typeof mergeDefaultPreferences>["weights"];
+  readonly priorityContext: ReturnType<typeof buildPriorityContext>;
+  readonly started: LibraryCoreFeedBrowseProjectionStartedV1;
+  scan: LibraryCoreItemScanSession | null;
+  nextBatchIndex: number;
+  projectedRows: number;
+  lastBatch: LibraryCoreFeedBrowseProjectionBatchV1 | null;
+  complete: boolean;
+}
+
 function buildPriorityContext(state: DocState) {
   const personByAuthorKey = new Map<
     string,
@@ -53,7 +69,7 @@ function buildPriorityContext(state: DocState) {
     if (account.kind !== "social") continue;
     personByAuthorKey.set(
       `${account.provider}:${account.externalId}`,
-      account.personId ? state.persons[account.personId] ?? null : null,
+      account.personId ? (state.persons[account.personId] ?? null) : null,
     );
   }
   return {
@@ -67,7 +83,7 @@ async function sha256Hex(value: string): Promise<string> {
   const bytes = new TextEncoder().encode(value);
   const digest = await globalThis.crypto.subtle.digest("SHA-256", bytes);
   return Array.from(new Uint8Array(digest), (byte) =>
-    byte.toString(16).padStart(2, "0")
+    byte.toString(16).padStart(2, "0"),
   ).join("");
 }
 
@@ -85,9 +101,7 @@ function sameSource(
   );
 }
 
-function buildSourceSequence(
-  state: DocState,
-): ReadonlyMap<string, number> {
+function buildSourceSequence(state: DocState): ReadonlyMap<string, number> {
   const ids = state.feedSourceOrderIds;
   if (!ids || ids.length !== state.docItemCount) {
     throw new Error("Hydrated feed source order is unavailable");
@@ -104,6 +118,75 @@ function buildSourceSequence(
     sequenceById.set(globalId, index);
   });
   return sequenceById;
+}
+
+function projectRow(
+  item: FeedItem,
+  sourceSequenceById: ReadonlyMap<string, number>,
+  weights: ReturnType<typeof mergeDefaultPreferences>["weights"],
+  priorityContext: ReturnType<typeof buildPriorityContext>,
+  rankingClockMs: number,
+): LibraryCoreFeedBrowseProjectedRowV1 {
+  const parsedCard = parseLibraryCoreFeedCardV1(
+    projectLibraryCoreFeedCardV1(item),
+  );
+  if (!parsedCard.ok) throw new Error(parsedCard.error);
+  const sourceSequence = sourceSequenceById.get(item.globalId);
+  if (sourceSequence === undefined) {
+    throw new Error("Library Core feed item has no source sequence");
+  }
+  return {
+    priority: calculatePriority(item, weights, rankingClockMs, priorityContext),
+    publishedAt: parsedCard.value.publishedAt ?? 0,
+    sourceSequence,
+    globalId: item.globalId,
+    cardJson: JSON.stringify(parsedCard.value),
+  };
+}
+
+async function buildStartedProjection(
+  sessionId: string,
+  source: LibraryCoreProjectionSourceV1,
+  filter: ReturnType<typeof normalizeLibraryCoreFeedBrowseFilterV1>,
+  rankingClockMs: number,
+  totalRows: number,
+): Promise<LibraryCoreFeedBrowseProjectionStartedV1> {
+  const binding: LibraryCoreFeedBrowseGenerationBindingV1 = {
+    generationId: await sha256Hex(
+      JSON.stringify({
+        domain: GENERATION_DOMAIN,
+        documentId: source.documentId,
+        filter,
+        headCount: source.headCount,
+        headsDigest: source.headsDigest,
+        projectionRevision: source.storageRevision.saveRevision,
+        rankingClockMs,
+        recommendationOrderSchemaVersion:
+          LIBRARY_CORE_FEED_RECOMMENDATION_ORDER_SCHEMA_VERSION,
+        transitionSequence: source.storageRevision.generation,
+      }),
+    ),
+    sourceDocumentId: source.documentId,
+    sourceHeadsDigest: source.headsDigest,
+    sourceHeadCount: source.headCount,
+    transitionSequence: source.storageRevision.generation,
+    projectionRevision: source.storageRevision.saveRevision,
+    filterJson: JSON.stringify(filter),
+    rankingClockMs,
+    recommendationOrderSchemaVersion:
+      LIBRARY_CORE_FEED_RECOMMENDATION_ORDER_SCHEMA_VERSION,
+    totalRows,
+  };
+  return {
+    type: "LIBRARY_CORE_FEED_BROWSE_PROJECTION_STARTED",
+    reqId: 0,
+    sessionId,
+    binding,
+    filter,
+    nextBatchIndex: 0,
+    projectedRows: 0,
+    maximumBatchRows: MAXIMUM_BATCH_ROWS,
+  };
 }
 
 /**
@@ -153,40 +236,13 @@ export function createHydratedLibraryCoreFeedBrowseProjectionClient({
           );
         }
       }
-      const binding: LibraryCoreFeedBrowseGenerationBindingV1 = {
-        generationId: await sha256Hex(JSON.stringify({
-          domain: GENERATION_DOMAIN,
-          documentId: source.documentId,
-          filter,
-          headCount: source.headCount,
-          headsDigest: source.headsDigest,
-          projectionRevision: source.storageRevision.saveRevision,
-          rankingClockMs,
-          recommendationOrderSchemaVersion:
-            LIBRARY_CORE_FEED_RECOMMENDATION_ORDER_SCHEMA_VERSION,
-          transitionSequence: source.storageRevision.generation,
-        })),
-        sourceDocumentId: source.documentId,
-        sourceHeadsDigest: source.headsDigest,
-        sourceHeadCount: source.headCount,
-        transitionSequence: source.storageRevision.generation,
-        projectionRevision: source.storageRevision.saveRevision,
-        filterJson: JSON.stringify(filter),
-        rankingClockMs,
-        recommendationOrderSchemaVersion:
-          LIBRARY_CORE_FEED_RECOMMENDATION_ORDER_SCHEMA_VERSION,
-        totalRows,
-      };
-      const started: LibraryCoreFeedBrowseProjectionStartedV1 = {
-        type: "LIBRARY_CORE_FEED_BROWSE_PROJECTION_STARTED",
-        reqId: 0,
+      const started = await buildStartedProjection(
         sessionId,
-        binding,
+        source,
         filter,
-        nextBatchIndex: 0,
-        projectedRows: 0,
-        maximumBatchRows: MAXIMUM_BATCH_ROWS,
-      };
+        rankingClockMs,
+        totalRows,
+      );
       if (session && !session.complete) {
         if (session.sessionId !== sessionId) {
           throw new Error(
@@ -196,7 +252,7 @@ export function createHydratedLibraryCoreFeedBrowseProjectionClient({
         if (
           session.state !== state ||
           !sameSource(session.source, source) ||
-          session.started.binding.generationId !== binding.generationId
+          session.started.binding.generationId !== started.binding.generationId
         ) {
           session = null;
           throw new Error("Library Core browse projection source changed");
@@ -246,44 +302,30 @@ export function createHydratedLibraryCoreFeedBrowseProjectionClient({
         const item: FeedItem = active.state.items[active.nextItemIndex];
         active.nextItemIndex += 1;
         if (
-          !matchesLibraryCoreFeedBrowseFilterV1(
-            item,
-            active.started.filter,
-          )
+          !matchesLibraryCoreFeedBrowseFilterV1(item, active.started.filter)
         ) {
           continue;
         }
-        const parsedCard = parseLibraryCoreFeedCardV1(
-          projectLibraryCoreFeedCardV1(item),
-        );
-        if (!parsedCard.ok) {
+        try {
+          rows.push(
+            projectRow(
+              item,
+              active.sourceSequenceById,
+              active.weights,
+              active.priorityContext,
+              active.started.binding.rankingClockMs,
+            ),
+          );
+        } catch (error) {
           session = null;
-          throw new Error(parsedCard.error);
+          throw error;
         }
-        const sourceSequence = active.sourceSequenceById.get(item.globalId);
-        if (sourceSequence === undefined) {
-          session = null;
-          throw new Error("Hydrated feed item has no source sequence");
-        }
-        rows.push({
-          priority: calculatePriority(
-            item,
-            active.weights,
-            active.started.binding.rankingClockMs,
-            active.priorityContext,
-          ),
-          publishedAt: parsedCard.value.publishedAt ?? 0,
-          sourceSequence,
-          globalId: item.globalId,
-          cardJson: JSON.stringify(parsedCard.value),
-        });
       }
       const done = active.nextItemIndex === active.state.items.length;
       active.projectedRows += rows.length;
       if (
         active.projectedRows > active.started.binding.totalRows ||
-        (done &&
-          active.projectedRows !== active.started.binding.totalRows)
+        (done && active.projectedRows !== active.started.binding.totalRows)
       ) {
         session = null;
         throw new Error("Library Core browse projection row count changed");
@@ -304,6 +346,186 @@ export function createHydratedLibraryCoreFeedBrowseProjectionClient({
 
     async cancel(sessionId: string) {
       if (session?.sessionId === sessionId) session = null;
+    },
+  };
+}
+
+/**
+ * Project one authenticated SQLite shadow generation into the query-specific
+ * browse store without traversing or retaining the renderer's item corpus.
+ * The source is scanned once to count matching rows and once to emit bounded
+ * pages because the native generation protocol binds its exact row count at
+ * begin time.
+ */
+export function createScannedLibraryCoreFeedBrowseProjectionClient({
+  getSource,
+  getState,
+  openScan,
+}: {
+  getSource(): Promise<LibraryCoreProjectionSourceV1>;
+  getState(): DocState | null;
+  openScan(): Promise<LibraryCoreItemScanSession>;
+}): LibraryCoreFeedBrowseProjectionWorkerClient {
+  let session: ScannedProjectionSession | null = null;
+
+  const discard = async (): Promise<void> => {
+    const active = session;
+    session = null;
+    if (active?.scan) await active.scan.close().catch(() => undefined);
+  };
+
+  return {
+    async begin(sessionId, filterInput, rankingClockMs) {
+      if (!Number.isSafeInteger(rankingClockMs) || rankingClockMs < 0) {
+        throw new Error("Library Core browse ranking clock is invalid");
+      }
+      const state = getState();
+      if (!state) throw new Error("Hydrated feed metadata is unavailable");
+      const source = await getSource();
+      if (getState() !== state) {
+        throw new Error("Library Core browse projection source changed");
+      }
+      const filter = normalizeLibraryCoreFeedBrowseFilterV1(filterInput);
+      if (filter.showHidden) {
+        throw new Error("SQLite feed projection cannot include hidden items");
+      }
+      if (session && !session.complete) {
+        if (session.sessionId !== sessionId) {
+          throw new Error(
+            `Library Core browse projection session ${session.sessionId} is already active`,
+          );
+        }
+        if (
+          session.state !== state ||
+          !sameSource(session.source, source) ||
+          session.started.binding.filterJson !== JSON.stringify(filter) ||
+          session.started.binding.rankingClockMs !== rankingClockMs
+        ) {
+          await discard();
+          throw new Error("Library Core browse projection source changed");
+        }
+        return session.started;
+      }
+      const sourceSequenceById = buildSourceSequence(state);
+      let totalRows = 0;
+      const countScan = await openScan();
+      try {
+        while (true) {
+          const page = await countScan.nextPage();
+          for (const item of page.items) {
+            if (!matchesLibraryCoreFeedBrowseFilterV1(item, filter)) continue;
+            totalRows += 1;
+            if (totalRows > MAXIMUM_ROWS) {
+              throw new Error(
+                `Library Core browse projection exceeds ${MAXIMUM_ROWS.toLocaleString()} rows`,
+              );
+            }
+          }
+          if (page.done) break;
+        }
+      } finally {
+        await countScan.close().catch(() => undefined);
+      }
+      if (getState() !== state || !sameSource(await getSource(), source)) {
+        throw new Error("Library Core browse projection source changed");
+      }
+      const started = await buildStartedProjection(
+        sessionId,
+        source,
+        filter,
+        rankingClockMs,
+        totalRows,
+      );
+      session = {
+        sessionId,
+        state,
+        source,
+        sourceSequenceById,
+        weights: mergeDefaultPreferences(state.preferences).weights,
+        priorityContext: buildPriorityContext(state),
+        started,
+        scan: null,
+        nextBatchIndex: 0,
+        projectedRows: 0,
+        lastBatch: null,
+        complete: false,
+      };
+      return started;
+    },
+
+    async nextBatch(sessionId, batchIndex) {
+      const active = session;
+      if (!active || active.sessionId !== sessionId) {
+        throw new Error("Library Core browse projection session is not active");
+      }
+      if (active.lastBatch?.batchIndex === batchIndex) {
+        return active.lastBatch;
+      }
+      if (
+        active.complete ||
+        batchIndex !== active.nextBatchIndex ||
+        getState() !== active.state ||
+        !sameSource(await getSource(), active.source)
+      ) {
+        await discard();
+        throw new Error("Library Core browse projection source changed");
+      }
+      active.scan ??= await openScan();
+      const rows: LibraryCoreFeedBrowseProjectedRowV1[] = [];
+      let done = false;
+      try {
+        while (rows.length < MAXIMUM_BATCH_ROWS && !done) {
+          const page = await active.scan.nextPage();
+          done = page.done;
+          for (const item of page.items) {
+            if (
+              !matchesLibraryCoreFeedBrowseFilterV1(item, active.started.filter)
+            ) {
+              continue;
+            }
+            rows.push(
+              projectRow(
+                item,
+                active.sourceSequenceById,
+                active.weights,
+                active.priorityContext,
+                active.started.binding.rankingClockMs,
+              ),
+            );
+          }
+        }
+      } catch (error) {
+        await discard();
+        throw error;
+      }
+      active.projectedRows += rows.length;
+      if (
+        active.projectedRows > active.started.binding.totalRows ||
+        (done && active.projectedRows !== active.started.binding.totalRows)
+      ) {
+        await discard();
+        throw new Error("Library Core browse projection row count changed");
+      }
+      const batch: LibraryCoreFeedBrowseProjectionBatchV1 = {
+        sessionId,
+        binding: active.started.binding,
+        batchIndex,
+        rows,
+        projectedRows: active.projectedRows,
+        done,
+      };
+      active.nextBatchIndex += 1;
+      active.lastBatch = batch;
+      active.complete = done;
+      if (done) {
+        await active.scan.close().catch(() => undefined);
+        active.scan = null;
+      }
+      return batch;
+    },
+
+    async cancel(sessionId) {
+      if (session?.sessionId === sessionId) await discard();
     },
   };
 }

--- a/packages/desktop/src/lib/library-core-feed-browse-materializer-runtime.ts
+++ b/packages/desktop/src/lib/library-core-feed-browse-materializer-runtime.ts
@@ -186,10 +186,9 @@ async function recoverFinalizeResponse(
 
 /**
  * Copy one source-authenticated, normalized browse projection into the native
- * SQLite staging generation. The projection client retains only one position
- * and one replayable 128-row page beyond the product state it already owns.
- * Native receipts absorb exact page and finalization response loss without
- * widening product authority.
+ * SQLite staging generation. The projection client retains only one source
+ * page and one replayable 128-row page. Native receipts absorb exact page and
+ * finalization response loss without widening product authority.
  */
 export async function materializeDesktopLibraryCoreFeedBrowseGeneration(
   workerClient: LibraryCoreFeedBrowseProjectionWorkerClient,

--- a/packages/desktop/src/lib/library-core-item-detail-runtime.ts
+++ b/packages/desktop/src/lib/library-core-item-detail-runtime.ts
@@ -5,9 +5,7 @@ import {
   type FeedItemRow,
 } from "@freed/shared/projection";
 
-import {
-  getLibraryCoreProjectionSource,
-} from "./automerge";
+import { getLibraryCoreProjectionSource } from "./automerge";
 import type { LibraryCoreProjectionSourceV1 } from "./automerge-types";
 
 const ITEM_DETAIL_QUERY_ID = "item_detail_v1";
@@ -82,6 +80,16 @@ interface NativeItemScanResponseV1 {
   readonly rows: FeedItemRow[];
   readonly schemaVersion: typeof ITEM_DETAIL_SCHEMA_VERSION;
   readonly source: NativeItemDetailSourceV1;
+}
+
+export interface LibraryCoreItemScanPage {
+  readonly items: readonly FeedItem[];
+  readonly done: boolean;
+}
+
+export interface LibraryCoreItemScanSession {
+  nextPage(): Promise<LibraryCoreItemScanPage>;
+  close(): Promise<void>;
 }
 
 function closedRecord(
@@ -163,7 +171,8 @@ function parseItemScanResponse(value: unknown): NativeItemScanResponseV1 {
     response.queryId !== ITEM_SCAN_QUERY_ID ||
     response.schemaVersion !== ITEM_DETAIL_SCHEMA_VERSION ||
     !nullableString(response.nextCursor) ||
-    (typeof response.nextCursor === "string" && response.nextCursor.length === 0) ||
+    (typeof response.nextCursor === "string" &&
+      response.nextCursor.length === 0) ||
     !Array.isArray(response.rows) ||
     response.rows.length > ITEM_SCAN_PAGE_LIMIT ||
     typeof source.documentId !== "string" ||
@@ -201,7 +210,10 @@ function newReaderOperationId(prefix: string): string {
   return `${prefix}:${crypto.randomUUID()}`;
 }
 
-function parseResponse(value: unknown, requestedId: string): NativeItemDetailResponseV1 {
+function parseResponse(
+  value: unknown,
+  requestedId: string,
+): NativeItemDetailResponseV1 {
   const response = closedRecord(value, RESPONSE_KEYS);
   const source = closedRecord(response?.source, SOURCE_KEYS);
   if (
@@ -251,8 +263,7 @@ function sourceMatches(
  */
 export async function readLibraryCoreItemDetail(
   globalId: string,
-  getSource: () => Promise<LibraryCoreProjectionSourceV1> =
-    getLibraryCoreProjectionSource,
+  getSource: () => Promise<LibraryCoreProjectionSourceV1> = getLibraryCoreProjectionSource,
   readNative: (request: {
     globalId: string;
     queryId: typeof ITEM_DETAIL_QUERY_ID;
@@ -294,10 +305,8 @@ export async function readLibraryCoreItemDetail(
  * generation. At most one native page and one reconstructed page are retained
  * at a time, so background maintenance cost is independent of Library size.
  */
-async function scanLibraryCoreItemsExclusive(
-  visitPage: (items: readonly FeedItem[]) => void | Promise<void>,
-  getSource: () => Promise<LibraryCoreProjectionSourceV1> =
-    getLibraryCoreProjectionSource,
+export async function openLibraryCoreItemScanSession(
+  getSource: () => Promise<LibraryCoreProjectionSourceV1> = getLibraryCoreProjectionSource,
   readNative: (request: {
     cancellationId: string;
     cursor: string | null;
@@ -315,7 +324,7 @@ async function scanLibraryCoreItemsExclusive(
       readerSessionId,
       cancellationId,
     }),
-): Promise<void> {
+): Promise<LibraryCoreItemScanSession> {
   if (
     typeof localStorage !== "undefined" &&
     localStorage.getItem(LIBRARY_CORE_ITEM_DETAIL_READER_DISABLED_KEY) === "1"
@@ -329,65 +338,153 @@ async function scanLibraryCoreItemsExclusive(
   let previousGlobalId: string | null = null;
   let lastCompletedCancellationId: string | null = null;
   let exhausted = false;
-  try {
-    for (let pageNumber = 0; pageNumber < MAXIMUM_ITEM_SCAN_PAGES; pageNumber += 1) {
+  let closed = false;
+  let pageInFlight = false;
+  let pageNumber = 0;
+
+  const close = async (): Promise<void> => {
+    if (closed) return;
+    closed = true;
+    if (!exhausted && lastCompletedCancellationId !== null) {
+      await cancelNative(readerSessionId, lastCompletedCancellationId).catch(
+        () => undefined,
+      );
+    }
+  };
+
+  return {
+    async nextPage(): Promise<LibraryCoreItemScanPage> {
+      if (closed) {
+        throw new Error("Library Core item scan session is closed");
+      }
+      if (pageInFlight) {
+        throw new Error("Library Core item scan page is already running");
+      }
+      if (exhausted) return { items: [], done: true };
+      if (pageNumber >= MAXIMUM_ITEM_SCAN_PAGES) {
+        await close();
+        throw new Error("Library Core item scan exceeded its page bound");
+      }
+      pageNumber += 1;
+      pageInFlight = true;
       const cancellationId = newReaderOperationId("item-scan-page");
-      const rawResponse = await readNative({
-        cancellationId,
-        cursor,
-        limit: ITEM_SCAN_PAGE_LIMIT,
-        queryId: ITEM_SCAN_QUERY_ID,
-        readerSessionId,
-        schemaVersion: ITEM_DETAIL_SCHEMA_VERSION,
-      });
+      let rawResponse: unknown;
+      try {
+        rawResponse = await readNative({
+          cancellationId,
+          cursor,
+          limit: ITEM_SCAN_PAGE_LIMIT,
+          queryId: ITEM_SCAN_QUERY_ID,
+          readerSessionId,
+          schemaVersion: ITEM_DETAIL_SCHEMA_VERSION,
+        });
+      } catch (error) {
+        pageInFlight = false;
+        await close();
+        throw error;
+      }
       lastCompletedCancellationId = cancellationId;
-      const response = parseItemScanResponse(rawResponse);
+      let response: NativeItemScanResponseV1;
+      try {
+        response = parseItemScanResponse(rawResponse);
+      } catch (error) {
+        pageInFlight = false;
+        await close();
+        throw error;
+      }
       if (!sourceMatches(before, response.source)) {
+        pageInFlight = false;
+        await close();
         throw new Error("Library Core item scan source is stale");
       }
-      if (selectedSource && !sameSelectedSource(selectedSource, response.source)) {
+      if (
+        selectedSource &&
+        !sameSelectedSource(selectedSource, response.source)
+      ) {
+        pageInFlight = false;
+        await close();
         throw new Error("Library Core item scan generation changed");
       }
       selectedSource ??= response.source;
       for (const row of response.rows) {
         if (previousGlobalId !== null && row.globalId <= previousGlobalId) {
+          pageInFlight = false;
+          await close();
           throw new Error("Library Core item scan order is invalid");
         }
         previousGlobalId = row.globalId;
       }
       if (response.rows.length === 0 && response.nextCursor !== null) {
+        pageInFlight = false;
+        await close();
         throw new Error("Library Core item scan cursor made no progress");
       }
-      await visitPage(
-        response.rows.map(
+      let items: FeedItem[];
+      try {
+        items = response.rows.map(
           (row) => reconstructFeedItem(row) as unknown as FeedItem,
-        ),
-      );
+        );
+      } catch (error) {
+        pageInFlight = false;
+        await close();
+        throw error;
+      }
       if (response.nextCursor === null) {
-        const after = await getSource();
+        let after: LibraryCoreProjectionSourceV1;
+        try {
+          after = await getSource();
+        } catch (error) {
+          pageInFlight = false;
+          await close();
+          throw error;
+        }
         if (!sourceMatches(after, response.source)) {
+          pageInFlight = false;
+          await close();
           throw new Error("Library Core item scan source changed during read");
         }
         exhausted = true;
-        return;
+        pageInFlight = false;
+        return { items, done: true };
       }
       if (response.nextCursor === cursor) {
+        pageInFlight = false;
+        await close();
         throw new Error("Library Core item scan cursor repeated");
       }
       cursor = response.nextCursor;
+      pageInFlight = false;
+      return { items, done: false };
+    },
+    close,
+  };
+}
+
+async function scanLibraryCoreItemsExclusive(
+  visitPage: (items: readonly FeedItem[]) => void | Promise<void>,
+  getSource: () => Promise<LibraryCoreProjectionSourceV1> = getLibraryCoreProjectionSource,
+  readNative?: Parameters<typeof openLibraryCoreItemScanSession>[1],
+  cancelNative?: Parameters<typeof openLibraryCoreItemScanSession>[2],
+): Promise<void> {
+  const session = await openLibraryCoreItemScanSession(
+    getSource,
+    readNative,
+    cancelNative,
+  );
+  try {
+    while (true) {
+      const page = await session.nextPage();
+      await visitPage(page.items);
+      if (page.done) return;
     }
-    throw new Error("Library Core item scan exceeded its page bound");
   } finally {
-    if (!exhausted && lastCompletedCancellationId !== null) {
-      await cancelNative(readerSessionId, lastCompletedCancellationId).catch(() => undefined);
-    }
+    await session.close();
   }
 }
 
 export async function scanLibraryCoreItems(
   visitPage: (items: readonly FeedItem[]) => void | Promise<void>,
-  getSource: () => Promise<LibraryCoreProjectionSourceV1> =
-    getLibraryCoreProjectionSource,
+  getSource: () => Promise<LibraryCoreProjectionSourceV1> = getLibraryCoreProjectionSource,
   readNative?: Parameters<typeof scanLibraryCoreItemsExclusive>[2],
   cancelNative?: Parameters<typeof scanLibraryCoreItemsExclusive>[3],
 ): Promise<void> {


### PR DESCRIPTION
(AI Generated).

## Summary
- Builds the Desktop feed browse generation from the authenticated selected SQLite shadow instead of walking the renderer item corpus a second time.
- Preserves the exact Automerge source-order tie-break, source fencing, native replay receipts, and bounded 128-row output.

## Testing
- Focused Library Core projection and item-scan tests: 12 passed.
- Desktop TypeScript build passed.
- npm run validate:feature passed, including 903 Desktop unit tests and the changed-path browser, performance, and activation lanes.

## Provider Review
- Status: Provider authority is validated for ready publication.
- Review action: none required. The provider-risk artifact records the behavior authority decision; this exact provider subdiff is the audit subject.
- Provider subdiff: `4114d25133ce7bae551a82165554b88b5a7e9545`
- Publication does not authorize new live provider traffic. Gate 1 behavior approval still applies when observable behavior changes.
- Provider review task: `library-core-renderer-scan`
- Provider review decision: `diff_authorized`
- Provider review artifact: `83e3e3d5e32a9c587600366b75ea71f9acb25e66bc830d83ac6607a4a37c99f7`
- Providers: facebook, instagram, linkedin, medium, other, substack, x, youtube
- Observable behavior: No provider-observable behavior changes. The existing feed browse path keeps the same filters, ranking clock, source-order tie-break, and user-triggered mutations. Only local query-generation input moves from the renderer item array to bounded reads of the authenticated selected SQLite shadow.
- Fingerprinting risk: No provider request, navigation, retry, timing, cadence, cookie, header, scrolling, clicking, extraction, login, or media-load behavior changes.
- Lowest profile alternative: Keep all provider traffic disabled during development and continue using the existing Automerge authority plus local SQLite shadow generation.

Files bound into this provider review:
- `packages/desktop/src/lib/automerge.ts`