### PR TITLE
fix: count feed signal chips from bounded pages

### DIFF
--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -13,7 +13,6 @@ import { flushSync } from "react-dom";
 import {
   applyFeedSignalModesToFilter,
   FEED_SIGNAL_FILTER_PRESETS,
-  filterFeedItems,
   type FeedSignalMode,
   type MapMode,
   type SavedContentSortMode,
@@ -38,6 +37,7 @@ import {
   SortIcon,
 } from "../icons.js";
 import { useSearchResults } from "../../hooks/useSearchResults.js";
+import { useFeedSignalCounts } from "../../hooks/useFeedSignalCounts.js";
 import { useLibraryFacetSummary } from "../../hooks/useLibraryFacetSummary.js";
 import { useIsMobile } from "../../hooks/useIsMobile.js";
 import { useIsMobileDevice } from "../../hooks/useIsMobileDevice.js";
@@ -363,6 +363,7 @@ export function Header({
   const activeFilter = useAppStore((s) => s.activeFilter);
   const searchQuery = useAppStore((s) => s.searchQuery);
   const searchCorpusVersion = useAppStore((s) => s.searchCorpusVersion);
+  const isLibraryInitialized = useAppStore((s) => s.isInitialized);
   const libraryItemVersion = useAppStore(
     (state) => state.libraryItemVersion ?? state.searchCorpusVersion,
   );
@@ -705,23 +706,15 @@ export function Header({
     delete nextFilter.signals;
     return nextFilter;
   }, [activeFilter]);
-  const feedSignalCounts = useMemo(() => {
-    const counts: Record<FeedSignalMode, number> = {
-      all: filterFeedItems(items, feedSignalCountBaseFilter).length,
-      inspiring: 0,
-      events: 0,
-      personal: 0,
-      conversation: 0,
-      news: 0,
-    };
-    for (const preset of selectableFeedSignalPresets) {
-      counts[preset.mode] = filterFeedItems(items, {
-        ...feedSignalCountBaseFilter,
-        signals: [...preset.signals],
-      }).length;
-    }
-    return counts;
-  }, [feedSignalCountBaseFilter, items, selectableFeedSignalPresets]);
+  // Counted through bounded pages. The renderer evicts the full item
+  // projection on the healthy Desktop path, so counting the store array here
+  // reported zero for every chip.
+  const feedSignalCounts = useFeedSignalCounts(
+    items,
+    feedSignalCountBaseFilter,
+    searchCorpusVersion,
+    isLibraryInitialized,
+  );
 
   const handleFeedSignalModeChange = useCallback((mode: FeedSignalMode) => {
     const nextModes = (() => {

--- a/packages/ui/src/hooks/useFeedSignalCounts.test.tsx
+++ b/packages/ui/src/hooks/useFeedSignalCounts.test.tsx
@@ -1,0 +1,186 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import type { ContentSignal, FeedItem } from "@freed/shared";
+import {
+  PlatformProvider,
+  type PlatformConfig,
+} from "../context/PlatformContext.js";
+import {
+  useFeedSignalCounts,
+  type FeedSignalCounts,
+} from "./useFeedSignalCounts.js";
+
+function item(globalId: string, tags: readonly ContentSignal[]): FeedItem {
+  return {
+    globalId,
+    platform: "rss",
+    contentType: "post",
+    capturedAt: 1,
+    publishedAt: 1,
+    author: { id: "author", handle: "author", displayName: "Author" },
+    content: { text: globalId, mediaUrls: [], mediaTypes: [] },
+    userState: { hidden: false, saved: false, archived: false, tags: [] },
+    topics: [],
+    contentSignals: {
+      version: 1,
+      method: "rules",
+      inferredAt: 1,
+      scores: {},
+      tags: [...tags],
+    },
+  };
+}
+
+const CORPUS: FeedItem[] = [
+  item("essay-1", ["essay"]),
+  item("essay-2", ["how_to"]),
+  item("event-1", ["event"]),
+  item("news-1", ["news"]),
+  item("news-2", ["alert"]),
+  item("news-3", ["product_update"]),
+];
+
+function Harness({
+  fallbackItems,
+  enabled = true,
+  onReady,
+}: {
+  fallbackItems: FeedItem[];
+  enabled?: boolean;
+  onReady: (counts: FeedSignalCounts) => void;
+}) {
+  onReady(useFeedSignalCounts(fallbackItems, {}, 1, enabled));
+  return null;
+}
+
+describe("useFeedSignalCounts", () => {
+  let container: HTMLDivElement | null = null;
+  let root: Root | null = null;
+
+  beforeAll(() => {
+    (
+      globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+  afterAll(() => {
+    (
+      globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = false;
+  });
+  afterEach(async () => {
+    await act(async () => {
+      root?.unmount();
+    });
+    container?.remove();
+    container = null;
+    root = null;
+    vi.restoreAllMocks();
+  });
+
+  function mount() {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  }
+
+  async function render(
+    config: Partial<PlatformConfig>,
+    fallbackItems: FeedItem[],
+    enabled = true,
+  ) {
+    mount();
+    let current: FeedSignalCounts | null = null;
+    await act(async () => {
+      root!.render(
+        <PlatformProvider value={config as PlatformConfig}>
+          <Harness
+            fallbackItems={fallbackItems}
+            enabled={enabled}
+            onReady={(counts) => {
+              current = counts;
+            }}
+          />
+        </PlatformProvider>,
+      );
+    });
+    return () => current;
+  }
+
+  it("counts every preset from bounded pages while the renderer corpus is evicted", async () => {
+    // Two pages, mirroring the bounded native scan contract.
+    const scanLibraryItems = vi.fn(async (visit) => {
+      await visit(CORPUS.slice(0, 3));
+      await visit(CORPUS.slice(3));
+    });
+    // The store array is empty because renderer eviction is active. Counting
+    // from it is exactly the regression this hook exists to prevent.
+    const read = await render({ scanLibraryItems }, []);
+
+    await vi.waitFor(() => {
+      expect(read()?.all).toBe(6);
+    });
+    const counts = read()!;
+    expect(counts.inspiring).toBe(2);
+    expect(counts.events).toBe(1);
+    expect(counts.news).toBe(3);
+    expect(counts.personal).toBe(0);
+    expect(counts.conversation).toBe(0);
+    expect(scanLibraryItems).toHaveBeenCalledOnce();
+  });
+
+  it("reads nothing before the library reports initialized", async () => {
+    // The bounded scanner pins the projection source. Asking for it during
+    // startup made the Automerge worker log a fatal-looking console error.
+    const scanLibraryItems = vi.fn(async () => undefined);
+    const acquireLegacyLibraryItems = vi.fn(async () => () => undefined);
+    const read = await render(
+      { scanLibraryItems, acquireLegacyLibraryItems },
+      CORPUS,
+      false,
+    );
+
+    expect(read()!.all).toBe(0);
+    expect(scanLibraryItems).not.toHaveBeenCalled();
+    expect(acquireLegacyLibraryItems).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the leased projection when no bounded scanner exists", async () => {
+    const acquireLegacyLibraryItems = vi.fn(async () => () => undefined);
+    const read = await render({ acquireLegacyLibraryItems }, CORPUS);
+
+    await vi.waitFor(() => {
+      expect(read()?.all).toBe(6);
+    });
+    expect(read()!.news).toBe(3);
+    expect(acquireLegacyLibraryItems).toHaveBeenCalled();
+  });
+
+  it("falls back when the bounded scan fails instead of reporting zero", async () => {
+    const scanLibraryItems = vi.fn(async () => {
+      throw new Error("stale source");
+    });
+    const acquireLegacyLibraryItems = vi.fn(async () => () => undefined);
+    const read = await render(
+      { scanLibraryItems, acquireLegacyLibraryItems },
+      CORPUS,
+    );
+
+    await vi.waitFor(() => {
+      expect(read()?.all).toBe(6);
+    });
+    expect(read()!.inspiring).toBe(2);
+    expect(acquireLegacyLibraryItems).toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/hooks/useFeedSignalCounts.ts
+++ b/packages/ui/src/hooks/useFeedSignalCounts.ts
@@ -1,0 +1,196 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  FEED_SIGNAL_FILTER_PRESETS,
+  filterFeedItems,
+  type FeedItem,
+  type FeedSignalMode,
+  type LibraryCoreFeedBrowseFilterInputV1,
+} from "@freed/shared";
+import { usePlatform, type ScanLibraryItems } from "../context/PlatformContext.js";
+import { useLegacyLibraryItems } from "./useLegacyLibraryItems.js";
+
+export type FeedSignalCounts = Readonly<Record<FeedSignalMode, number>>;
+
+const EMPTY_FEED_SIGNAL_COUNTS: FeedSignalCounts = Object.freeze({
+  all: 0,
+  inspiring: 0,
+  events: 0,
+  personal: 0,
+  conversation: 0,
+  news: 0,
+});
+
+const SELECTABLE_PRESETS = FEED_SIGNAL_FILTER_PRESETS.filter(
+  (preset) => preset.mode !== "all",
+);
+
+interface CachedSignalCounts {
+  scanner: ScanLibraryItems;
+  requestKey: string;
+  promise: Promise<FeedSignalCounts>;
+  result: FeedSignalCounts | null;
+}
+
+interface VersionedSignalCounts {
+  requestKey: string;
+  counts: FeedSignalCounts;
+}
+
+let signalCountCache: CachedSignalCounts | null = null;
+
+/**
+ * Count every signal preset in one bounded pass.
+ *
+ * Each page is filtered and discarded, so the corpus is never resident. Doing
+ * all presets in a single traversal keeps this to one scan per source revision
+ * instead of one scan per chip.
+ */
+async function countBySignalPreset(
+  scanner: ScanLibraryItems,
+  baseFilter: LibraryCoreFeedBrowseFilterInputV1,
+): Promise<FeedSignalCounts> {
+  const counts: Record<FeedSignalMode, number> = {
+    all: 0,
+    inspiring: 0,
+    events: 0,
+    personal: 0,
+    conversation: 0,
+    news: 0,
+  };
+  await scanner((page) => {
+    const pageItems = [...page];
+    counts.all += filterFeedItems(pageItems, baseFilter).length;
+    for (const preset of SELECTABLE_PRESETS) {
+      counts[preset.mode] += filterFeedItems(pageItems, {
+        ...baseFilter,
+        signals: [...preset.signals],
+      }).length;
+    }
+    return "continue";
+  });
+  return Object.freeze(counts);
+}
+
+function prepareSignalCounts(
+  scanner: ScanLibraryItems,
+  requestKey: string,
+  baseFilter: LibraryCoreFeedBrowseFilterInputV1,
+): CachedSignalCounts {
+  if (
+    signalCountCache?.scanner === scanner &&
+    signalCountCache.requestKey === requestKey
+  ) {
+    return signalCountCache;
+  }
+  const entry: CachedSignalCounts = {
+    scanner,
+    requestKey,
+    result: null,
+    promise: Promise.resolve(EMPTY_FEED_SIGNAL_COUNTS),
+  };
+  entry.promise = countBySignalPreset(scanner, baseFilter).then((counts) => {
+    entry.result = counts;
+    return counts;
+  });
+  signalCountCache = entry;
+  return entry;
+}
+
+/**
+ * Feed-signal chip counts for the current filter, without holding the corpus.
+ *
+ * The renderer evicts the full item projection on the healthy Desktop path, so
+ * counting from the store array silently reports zero for every chip. This
+ * streams bounded pages instead, and leases the compatibility projection only
+ * when no bounded scanner exists or the scan actually fails.
+ */
+export function useFeedSignalCounts(
+  fallbackItems: FeedItem[],
+  baseFilter: LibraryCoreFeedBrowseFilterInputV1,
+  sourceVersion: number,
+  /**
+   * Hold every read until the library has loaded. The bounded scanner pins the
+   * projection source, and asking for it before Automerge persistence is ready
+   * makes the worker log a startup error.
+   */
+  enabled: boolean,
+): FeedSignalCounts {
+  const { scanLibraryItems } = usePlatform();
+  const requestKey = useMemo(
+    () => JSON.stringify([sourceVersion, baseFilter]),
+    [baseFilter, sourceVersion],
+  );
+  const [versioned, setVersioned] = useState<VersionedSignalCounts | null>(
+    () => {
+      if (!scanLibraryItems) return null;
+      const cached =
+        signalCountCache?.scanner === scanLibraryItems &&
+        signalCountCache.requestKey === requestKey
+          ? signalCountCache.result
+          : null;
+      return cached ? { requestKey, counts: cached } : null;
+    },
+  );
+  const [failedKey, setFailedKey] = useState<string | null>(null);
+  const shouldFallback =
+    enabled && (!scanLibraryItems || failedKey === requestKey);
+  useLegacyLibraryItems(shouldFallback);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!enabled || !scanLibraryItems) {
+      setVersioned(null);
+      setFailedKey(null);
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    setFailedKey(null);
+    const prepared = prepareSignalCounts(
+      scanLibraryItems,
+      requestKey,
+      baseFilter,
+    );
+    if (prepared.result) setVersioned({ requestKey, counts: prepared.result });
+    prepared.promise
+      .then((counts) => {
+        if (!cancelled) setVersioned({ requestKey, counts });
+      })
+      .catch(() => {
+        if (!cancelled) setFailedKey(requestKey);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+    // baseFilter is already folded into requestKey; depending on the object
+    // identity would rescan on every render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled, requestKey, scanLibraryItems]);
+
+  const fallbackCounts = useMemo(() => {
+    if (!shouldFallback) return null;
+    const counts: Record<FeedSignalMode, number> = {
+      all: filterFeedItems(fallbackItems, baseFilter).length,
+      inspiring: 0,
+      events: 0,
+      personal: 0,
+      conversation: 0,
+      news: 0,
+    };
+    for (const preset of SELECTABLE_PRESETS) {
+      counts[preset.mode] = filterFeedItems(fallbackItems, {
+        ...baseFilter,
+        signals: [...preset.signals],
+      }).length;
+    }
+    return Object.freeze(counts);
+  }, [baseFilter, fallbackItems, shouldFallback]);
+
+  if (!enabled) return EMPTY_FEED_SIGNAL_COUNTS;
+  if (fallbackCounts) return fallbackCounts;
+  return versioned?.requestKey === requestKey
+    ? versioned.counts
+    : (versioned?.counts ?? EMPTY_FEED_SIGNAL_COUNTS);
+}


### PR DESCRIPTION
(AI Generated).

## Summary
- (AI Generated).

The header's feed-signal filter chips counted straight from the store item array (`useAppStore((s) => s.items)`), with no lease, no bounded reader, and no fallback closure. Renderer eviction empties that array on the healthy Desktop path, so every chip rendered **0** — Everything, Inspiring, Events, Personal, Conversation, News.

**Fix.** Count through bounded pages via `scanLibraryItems`. A single pass accumulates all six presets, so this costs one scan per source revision rather than one per chip, and no page is retained. The compatibility projection is leased only when no bounded scanner exists or the scan actually fails, matching the surface-reader pattern already used by Story Wall and Map.

**Startup gate.** Reads are held until the library reports initialized. The scanner pins the projection source, and requesting it during startup made the Automerge worker log `Automerge persistence must load before use`. I caught this because the change failed the existing `no console errors on startup` smoke test; I verified the test passes on clean `origin/dev` and fails with the ungated version, so the causation is confirmed rather than assumed.

**Audit.** I traced every other unleased reader of the store array — `AppShell`, `SettingsDialog`, `SavedSection` (both sites), `SearchJumpField`, `FriendsView`, `MapView`. All of them feed a bounded hook as its fallback closure and are correct. The header was the only defect.

The regression test was mutation-tested: reintroducing the defect makes it fail with `expected +0 to be 6`.

No provider-visible path changed, so no provider-risk artifact applies. No phase status or query contract changed, so no docs or activation-manifest entry applies.

## Testing
- npm run validate:feature exit 0; useFeedSignalCounts 4/4; ui hooks+layout 45/45; desktop e2e 'no console errors on startup' verified failing before the gate and passing after