### PR TITLE
feat: close the saved analytics query contract

### DIFF
--- a/packages/desktop/src/lib/library-core-item-detail-runtime.ts
+++ b/packages/desktop/src/lib/library-core-item-detail-runtime.ts
@@ -10,6 +10,9 @@ import {
   isLibraryCoreEntityId,
   parseLibraryCoreFeedCardV1,
   type LibraryCoreFeedCardV1,
+  LIBRARY_CORE_SAVED_ANALYTICS_DAILY_WINDOW_COUNT,
+  LIBRARY_CORE_SAVED_ANALYTICS_HOURLY_WINDOW_COUNT,
+  LIBRARY_CORE_SAVED_ANALYTICS_REQUEST_SCHEMA,
 } from "@freed/shared/library-core";
 import {
   reconstructFeedItem,
@@ -1782,8 +1785,15 @@ export async function readLibraryCoreSavedAnalytics(
   ) {
     throw new Error("Library Core Saved analytics reader is disabled");
   }
-  const dailyWindows = parseAnalyticsWindows(request.dailyWindows, 7);
-  const hourlyWindows = parseAnalyticsWindows(request.hourlyWindows, 24, true);
+  const dailyWindows = parseAnalyticsWindows(
+    request.dailyWindows,
+    LIBRARY_CORE_SAVED_ANALYTICS_DAILY_WINDOW_COUNT,
+  );
+  const hourlyWindows = parseAnalyticsWindows(
+    request.hourlyWindows,
+    LIBRARY_CORE_SAVED_ANALYTICS_HOURLY_WINDOW_COUNT,
+    LIBRARY_CORE_SAVED_ANALYTICS_REQUEST_SCHEMA.repeatedWindowAllowance.hourly > 0,
+  );
   if (!dailyWindows || !hourlyWindows) {
     throw new Error("Library Core saved analytics windows are invalid");
   }

--- a/packages/shared/src/library-core/index.ts
+++ b/packages/shared/src/library-core/index.ts
@@ -24,6 +24,7 @@ export * from "./protocol-registry.js";
 export * from "./protocol-scalars.js";
 export * from "./query-registry.js";
 export * from "./saved-feed-page-contracts.js";
+export * from "./saved-analytics-contracts.js";
 export * from "./sha256.js";
 export * from "./store-surface-registry.js";
 export * from "./wire-frame.js";

--- a/packages/shared/src/library-core/query-registry.ts
+++ b/packages/shared/src/library-core/query-registry.ts
@@ -29,6 +29,13 @@ import {
   LIBRARY_CORE_SAVED_FEED_PAGE_RESPONSE_SCHEMA,
   LIBRARY_CORE_SAVED_FEED_PAGE_SOURCE_IDENTITY,
 } from "./saved-feed-page-contracts.js";
+import {
+  LIBRARY_CORE_SAVED_ANALYTICS_NESTED_BOUNDS,
+  LIBRARY_CORE_SAVED_ANALYTICS_PROJECTION,
+  LIBRARY_CORE_SAVED_ANALYTICS_REQUEST_SCHEMA,
+  LIBRARY_CORE_SAVED_ANALYTICS_RESPONSE_SCHEMA,
+  LIBRARY_CORE_SAVED_ANALYTICS_SOURCE_IDENTITY,
+} from "./saved-analytics-contracts.js";
 
 export const LIBRARY_CORE_QUERY_IDS = [
   "account_detail_v1",
@@ -205,6 +212,7 @@ export interface PlannedBlockedLibraryCoreQueryDefinition {
     | typeof LIBRARY_CORE_FEED_BROWSE_PAGE_V2_REQUEST_SCHEMA
     | typeof LIBRARY_CORE_FEED_BROWSE_PAGE_V3_REQUEST_SCHEMA
     | typeof LIBRARY_CORE_SAVED_FEED_PAGE_REQUEST_SCHEMA
+    | typeof LIBRARY_CORE_SAVED_ANALYTICS_REQUEST_SCHEMA
     | null;
   readonly responseSchema:
     | typeof LIBRARY_CORE_FEED_PAGE_RESPONSE_SCHEMA
@@ -212,18 +220,22 @@ export interface PlannedBlockedLibraryCoreQueryDefinition {
     | typeof LIBRARY_CORE_FEED_BROWSE_PAGE_V2_RESPONSE_SCHEMA
     | typeof LIBRARY_CORE_FEED_BROWSE_PAGE_V3_RESPONSE_SCHEMA
     | typeof LIBRARY_CORE_SAVED_FEED_PAGE_RESPONSE_SCHEMA
+    | typeof LIBRARY_CORE_SAVED_ANALYTICS_RESPONSE_SCHEMA
     | null;
   readonly projection:
     | typeof LIBRARY_CORE_FEED_PAGE_PROJECTION
     | typeof LIBRARY_CORE_FEED_BROWSE_PAGE_PROJECTION
     | typeof LIBRARY_CORE_FEED_BROWSE_PAGE_V2_PROJECTION
     | typeof LIBRARY_CORE_SAVED_FEED_PAGE_PROJECTION
+    | typeof LIBRARY_CORE_SAVED_ANALYTICS_PROJECTION
     | null;
   readonly sourceIdentity:
     | typeof LIBRARY_CORE_FEED_PAGE_SOURCE_IDENTITY
+    | typeof LIBRARY_CORE_SAVED_ANALYTICS_SOURCE_IDENTITY
     | null;
   readonly nestedBounds:
     | typeof LIBRARY_CORE_FEED_PAGE_NESTED_BOUNDS
+    | typeof LIBRARY_CORE_SAVED_ANALYTICS_NESTED_BOUNDS
     | null;
   readonly stableSort: ResolvedQuerySortContract | null;
   readonly tieBreakKey: string | null;
@@ -319,20 +331,27 @@ interface PlannedQueryInput {
     | typeof LIBRARY_CORE_FEED_BROWSE_PAGE_REQUEST_SCHEMA
     | typeof LIBRARY_CORE_FEED_BROWSE_PAGE_V2_REQUEST_SCHEMA
     | typeof LIBRARY_CORE_FEED_BROWSE_PAGE_V3_REQUEST_SCHEMA
-    | typeof LIBRARY_CORE_SAVED_FEED_PAGE_REQUEST_SCHEMA;
+    | typeof LIBRARY_CORE_SAVED_FEED_PAGE_REQUEST_SCHEMA
+    | typeof LIBRARY_CORE_SAVED_ANALYTICS_REQUEST_SCHEMA;
   readonly responseSchema?:
     | typeof LIBRARY_CORE_FEED_PAGE_RESPONSE_SCHEMA
     | typeof LIBRARY_CORE_FEED_BROWSE_PAGE_RESPONSE_SCHEMA
     | typeof LIBRARY_CORE_FEED_BROWSE_PAGE_V2_RESPONSE_SCHEMA
     | typeof LIBRARY_CORE_FEED_BROWSE_PAGE_V3_RESPONSE_SCHEMA
-    | typeof LIBRARY_CORE_SAVED_FEED_PAGE_RESPONSE_SCHEMA;
+    | typeof LIBRARY_CORE_SAVED_FEED_PAGE_RESPONSE_SCHEMA
+    | typeof LIBRARY_CORE_SAVED_ANALYTICS_RESPONSE_SCHEMA;
   readonly projection?:
     | typeof LIBRARY_CORE_FEED_PAGE_PROJECTION
     | typeof LIBRARY_CORE_FEED_BROWSE_PAGE_PROJECTION
     | typeof LIBRARY_CORE_FEED_BROWSE_PAGE_V2_PROJECTION
-    | typeof LIBRARY_CORE_SAVED_FEED_PAGE_PROJECTION;
-  readonly sourceIdentity?: typeof LIBRARY_CORE_FEED_PAGE_SOURCE_IDENTITY;
-  readonly nestedBounds?: typeof LIBRARY_CORE_FEED_PAGE_NESTED_BOUNDS;
+    | typeof LIBRARY_CORE_SAVED_FEED_PAGE_PROJECTION
+    | typeof LIBRARY_CORE_SAVED_ANALYTICS_PROJECTION;
+  readonly sourceIdentity?:
+    | typeof LIBRARY_CORE_FEED_PAGE_SOURCE_IDENTITY
+    | typeof LIBRARY_CORE_SAVED_ANALYTICS_SOURCE_IDENTITY;
+  readonly nestedBounds?:
+    | typeof LIBRARY_CORE_FEED_PAGE_NESTED_BOUNDS
+    | typeof LIBRARY_CORE_SAVED_ANALYTICS_NESTED_BOUNDS;
   /**
    * Supplying both clears `sort_contract_unresolved` for this query. They move
    * together on purpose: an ordering without a tie-break is not stable, and a
@@ -878,6 +897,20 @@ export const LIBRARY_CORE_QUERY_REGISTRY = {
       "ProjectionReadSession::saved_analytics",
       "read_library_core_saved_analytics",
     ],
+    requestSchema: LIBRARY_CORE_SAVED_ANALYTICS_REQUEST_SCHEMA,
+    responseSchema: LIBRARY_CORE_SAVED_ANALYTICS_RESPONSE_SCHEMA,
+    projection: LIBRARY_CORE_SAVED_ANALYTICS_PROJECTION,
+    sourceIdentity: LIBRARY_CORE_SAVED_ANALYTICS_SOURCE_IDENTITY,
+    nestedBounds: LIBRARY_CORE_SAVED_ANALYTICS_NESTED_BOUNDS,
+    // Both count series come from a BTreeMap keyed by label, so they arrive in
+    // ascending binary label order. Labels are map keys and therefore unique,
+    // which makes label a valid final tie-break.
+    stableSort: {
+      columns: [{ column: "label", direction: "asc" }],
+      textCollation: "binary",
+      nullOrdering: "all_sort_columns_not_null",
+    },
+    tieBreakKey: "label",
     resolvedImplementationBlockers: ["runtime_adapter_unimplemented"],
   }),
   saved_feed_page_v1: plannedQuery({

--- a/packages/shared/src/library-core/registry.test.ts
+++ b/packages/shared/src/library-core/registry.test.ts
@@ -15,6 +15,13 @@ import {
   LIBRARY_CORE_FEED_BROWSE_PAGE_V3_RESPONSE_SCHEMA,
 } from "./feed-browse-page-contracts.js";
 import {
+  LIBRARY_CORE_SAVED_ANALYTICS_NESTED_BOUNDS,
+  LIBRARY_CORE_SAVED_ANALYTICS_PROJECTION,
+  LIBRARY_CORE_SAVED_ANALYTICS_REQUEST_SCHEMA,
+  LIBRARY_CORE_SAVED_ANALYTICS_RESPONSE_SCHEMA,
+  LIBRARY_CORE_SAVED_ANALYTICS_SOURCE_IDENTITY,
+} from "./saved-analytics-contracts.js";
+import {
   LIBRARY_CORE_FIELD_REGISTRY,
 } from "./field-registry.js";
 import {
@@ -426,6 +433,40 @@ describe("Library Core query registry", () => {
     expect(
       BASE_APP_STORE_SURFACE_REGISTRY.items.successorQueryIds,
     ).toContain("feed_browse_page_v2");
+  });
+
+  it("closes the Saved-analytics aggregate contract", () => {
+    expect(LIBRARY_CORE_QUERY_REGISTRY.saved_analytics_v1).toMatchObject({
+      status: "planned_blocked",
+      requestSchema: LIBRARY_CORE_SAVED_ANALYTICS_REQUEST_SCHEMA,
+      responseSchema: LIBRARY_CORE_SAVED_ANALYTICS_RESPONSE_SCHEMA,
+      projection: LIBRARY_CORE_SAVED_ANALYTICS_PROJECTION,
+      sourceIdentity: LIBRARY_CORE_SAVED_ANALYTICS_SOURCE_IDENTITY,
+      nestedBounds: LIBRARY_CORE_SAVED_ANALYTICS_NESTED_BOUNDS,
+      tieBreakKey: "label",
+    });
+    // Both count series are built from a label-keyed BTreeMap, so the only
+    // ordering term is the label itself and it is also the tie-break.
+    expect(
+      LIBRARY_CORE_QUERY_REGISTRY.saved_analytics_v1.stableSort,
+    ).toEqual({
+      columns: [{ column: "label", direction: "asc" }],
+      textCollation: "binary",
+      nullOrdering: "all_sort_columns_not_null",
+    });
+    // Closing the six contract fields must clear their paired blockers.
+    for (const blocker of [
+      "request_schema_unresolved",
+      "response_schema_unresolved",
+      "projection_unresolved",
+      "source_identity_unresolved",
+      "nested_bounds_unresolved",
+      "sort_contract_unresolved",
+    ]) {
+      expect(
+        LIBRARY_CORE_QUERY_REGISTRY.saved_analytics_v1.blockers,
+      ).not.toContain(blocker);
+    }
   });
 
   it("registers the bidirectional bounded Desktop all-content feed", () => {

--- a/packages/shared/src/library-core/saved-analytics-contracts.ts
+++ b/packages/shared/src/library-core/saved-analytics-contracts.ts
@@ -1,0 +1,145 @@
+import type { LibraryCoreLowercaseHex64 } from "./protocol-scalars.js";
+
+/**
+ * Closed contract for the Desktop Saved-analytics aggregate.
+ *
+ * Every bound here is read from the live native reader, not chosen here:
+ * `library_core_feed_reader_runtime.rs` fixes the window counts and the 8 MiB
+ * response ceiling, and `shadow_store.rs` fixes the label caps and the label
+ * ordering. Changing a value in this file without changing those does not make
+ * it true.
+ */
+export const LIBRARY_CORE_SAVED_ANALYTICS_QUERY_ID =
+  "saved_analytics_v1" as const;
+export const LIBRARY_CORE_SAVED_ANALYTICS_SCHEMA_VERSION = 1 as const;
+
+/** Seven contiguous day windows, oldest first. */
+export const LIBRARY_CORE_SAVED_ANALYTICS_DAILY_WINDOW_COUNT = 7;
+/** Twenty-four hour windows, oldest first. */
+export const LIBRARY_CORE_SAVED_ANALYTICS_HOURLY_WINDOW_COUNT = 24;
+export const LIBRARY_CORE_SAVED_ANALYTICS_MAXIMUM_SOURCE_LABELS = 4_096;
+export const LIBRARY_CORE_SAVED_ANALYTICS_MAXIMUM_CONTENT_TYPES = 64;
+export const LIBRARY_CORE_SAVED_ANALYTICS_MAXIMUM_LABEL_UTF8_BYTES = 2_048;
+export const LIBRARY_CORE_SAVED_ANALYTICS_MAXIMUM_RESPONSE_BYTES = 8 * 1_048_576;
+
+export const LIBRARY_CORE_SAVED_ANALYTICS_REQUEST_SCHEMA = Object.freeze({
+  schemaId: "library_core_saved_analytics_request_v1",
+  schemaVersion: LIBRARY_CORE_SAVED_ANALYTICS_SCHEMA_VERSION,
+  queryId: LIBRARY_CORE_SAVED_ANALYTICS_QUERY_ID,
+  canonicalKeys: Object.freeze([
+    "dailyWindows",
+    "hourlyWindows",
+    "queryId",
+    "schemaVersion",
+  ]),
+  windowKeys: Object.freeze(["endMs", "startMs"]),
+  dailyWindowCount: LIBRARY_CORE_SAVED_ANALYTICS_DAILY_WINDOW_COUNT,
+  hourlyWindowCount: LIBRARY_CORE_SAVED_ANALYTICS_HOURLY_WINDOW_COUNT,
+  /**
+   * Windows are contiguous: each window's start equals the previous window's
+   * end. The hourly series admits exactly one repeated window because a
+   * daylight-saving fall-back repeats a wall-clock hour; the daily series
+   * admits none.
+   */
+  contiguousWindows: true,
+  repeatedWindowAllowance: Object.freeze({ daily: 0, hourly: 1 }),
+});
+
+export const LIBRARY_CORE_SAVED_ANALYTICS_RESPONSE_SCHEMA = Object.freeze({
+  schemaId: "library_core_saved_analytics_response_v1",
+  schemaVersion: LIBRARY_CORE_SAVED_ANALYTICS_SCHEMA_VERSION,
+  queryId: LIBRARY_CORE_SAVED_ANALYTICS_QUERY_ID,
+  canonicalKeys: Object.freeze([
+    "contentMix",
+    "dailyCounts",
+    "hourlyCounts",
+    "latestSavedAt",
+    "queryId",
+    "schemaVersion",
+    "source",
+    "sourceCounts",
+    "totalCount",
+  ]),
+  countKeys: Object.freeze(["count", "label"]),
+  dailyCountsLength: LIBRARY_CORE_SAVED_ANALYTICS_DAILY_WINDOW_COUNT,
+  hourlyCountsLength: LIBRARY_CORE_SAVED_ANALYTICS_HOURLY_WINDOW_COUNT,
+  maximumSourceCounts: LIBRARY_CORE_SAVED_ANALYTICS_MAXIMUM_SOURCE_LABELS,
+  maximumContentMix: LIBRARY_CORE_SAVED_ANALYTICS_MAXIMUM_CONTENT_TYPES,
+  maximumResponseBytes: LIBRARY_CORE_SAVED_ANALYTICS_MAXIMUM_RESPONSE_BYTES,
+});
+
+/**
+ * This query returns aggregates, not entity rows, so it has no row projection
+ * over `feed_items`. It projects two label-keyed count series.
+ */
+export const LIBRARY_CORE_SAVED_ANALYTICS_PROJECTION = Object.freeze({
+  projectionId: "library_core_saved_analytics_v1",
+  sourceTable: "feed_items",
+  fullContentAllowed: false,
+  orderedColumns: Object.freeze(["label"]),
+});
+
+export const LIBRARY_CORE_SAVED_ANALYTICS_SOURCE_IDENTITY = Object.freeze({
+  identityId: "library_core_projection_reader_source_v1",
+  generationId: "sha256_file_digest",
+  transitionSequence: "nonnegative_safe_integer",
+  projectionRevision: "nonnegative_safe_integer",
+  sessionPinned: true,
+});
+
+export const LIBRARY_CORE_SAVED_ANALYTICS_NESTED_BOUNDS = Object.freeze({
+  sourceCounts: Object.freeze({
+    maximumItems: LIBRARY_CORE_SAVED_ANALYTICS_MAXIMUM_SOURCE_LABELS,
+    maximumUnicodeScalarsPerItem:
+      LIBRARY_CORE_SAVED_ANALYTICS_MAXIMUM_LABEL_UTF8_BYTES,
+    maximumUtf8BytesPerItem:
+      LIBRARY_CORE_SAVED_ANALYTICS_MAXIMUM_LABEL_UTF8_BYTES,
+  }),
+  contentMix: Object.freeze({
+    maximumItems: LIBRARY_CORE_SAVED_ANALYTICS_MAXIMUM_CONTENT_TYPES,
+    maximumUnicodeScalarsPerItem:
+      LIBRARY_CORE_SAVED_ANALYTICS_MAXIMUM_LABEL_UTF8_BYTES,
+    maximumUtf8BytesPerItem:
+      LIBRARY_CORE_SAVED_ANALYTICS_MAXIMUM_LABEL_UTF8_BYTES,
+  }),
+});
+
+export interface LibraryCoreSavedAnalyticsWindowV1 {
+  readonly startMs: number;
+  readonly endMs: number;
+}
+
+export interface LibraryCoreSavedAnalyticsCountV1 {
+  readonly label: string;
+  readonly count: number;
+}
+
+export interface LibraryCoreSavedAnalyticsRequestV1 {
+  readonly dailyWindows: readonly LibraryCoreSavedAnalyticsWindowV1[];
+  readonly hourlyWindows: readonly LibraryCoreSavedAnalyticsWindowV1[];
+  readonly queryId: typeof LIBRARY_CORE_SAVED_ANALYTICS_QUERY_ID;
+  readonly schemaVersion: typeof LIBRARY_CORE_SAVED_ANALYTICS_SCHEMA_VERSION;
+}
+
+export interface LibraryCoreSavedAnalyticsSourceV1 {
+  readonly documentId: string;
+  readonly generationId: LibraryCoreLowercaseHex64;
+  readonly headCount: number;
+  readonly headsDigest: LibraryCoreLowercaseHex64;
+  readonly projectionRevision: number;
+  readonly storageGeneration: number;
+  readonly storageSaveRevision: number;
+  readonly transitionSequence: number;
+}
+
+export interface LibraryCoreSavedAnalyticsResponseV1 {
+  readonly contentMix: readonly LibraryCoreSavedAnalyticsCountV1[];
+  readonly dailyCounts: readonly number[];
+  readonly hourlyCounts: readonly number[];
+  readonly latestSavedAt: number | null;
+  readonly queryId: typeof LIBRARY_CORE_SAVED_ANALYTICS_QUERY_ID;
+  readonly schemaVersion: typeof LIBRARY_CORE_SAVED_ANALYTICS_SCHEMA_VERSION;
+  readonly source: LibraryCoreSavedAnalyticsSourceV1;
+  readonly sourceCounts: readonly LibraryCoreSavedAnalyticsCountV1[];
+  readonly totalCount: number;
+}


### PR DESCRIPTION
(AI Generated).

## Summary
- (AI Generated).

`saved_analytics_v1` was registered with no `requestSchema`, `responseSchema`, `projection`, `sourceIdentity`, `nestedBounds`, or `stableSort`/`tieBreakKey` — six typed blockers left open on a query whose runtime adapter already exists. This closes them, moving the `query_request_response_and_projection_contracts_incomplete` census blocker forward by one query.

**Every value is traced from the live implementation, not chosen.** `library_core_feed_reader_runtime.rs` fixes the 7 daily and 24 hourly windows, the contiguity rule, the single repeated hour the hourly series admits for a daylight-saving fall-back, and the 8 MiB response ceiling. `shadow_store.rs` fixes the 4,096 source labels, 64 content types, and 2,048 label bytes — and it builds both count series from a `BTreeMap<String, i64>`, which is precisely why the sort contract is ascending binary label order with `label` as the tie-break (map keys are unique, so it is a valid final term).

**The declaration is load-bearing, not decorative.** The desktop reader already validated these windows via `parseAnalyticsWindows` with hardcoded `7`, `24`, and a repeat flag. It now reads those from the shared contract, so the two cannot drift apart. I deliberately did *not* add a second TypeScript validator: the desktop one already exists and works, and duplicating it would have been redundancy rather than contract closure.

**No behavior change.** The previously declared `cursor`, `totalCountIntent`, `invalidationKeyIntent`, and `currentKinds` are untouched — an earlier draft of mine overwrote them with plausible-looking substitutes and I reverted that.

No provider-visible path changed, so no provider-risk artifact applies. No phase status or contract document changed. Dormant contract work, merge-safe per `freed-library-core`.

## Testing
- npm run validate:feature exit 0; shared library-core 213/213 incl. registry invariants; desktop item-detail-runtime 23/23; shared+desktop+pwa typecheck 0 errors