### PR TITLE
feat: close the person timeline query contract

### DIFF
--- a/packages/shared/src/library-core/index.ts
+++ b/packages/shared/src/library-core/index.ts
@@ -25,6 +25,7 @@ export * from "./protocol-scalars.js";
 export * from "./query-registry.js";
 export * from "./saved-feed-page-contracts.js";
 export * from "./saved-analytics-contracts.js";
+export * from "./person-timeline-contracts.js";
 export * from "./sha256.js";
 export * from "./store-surface-registry.js";
 export * from "./wire-frame.js";

--- a/packages/shared/src/library-core/person-timeline-contracts.ts
+++ b/packages/shared/src/library-core/person-timeline-contracts.ts
@@ -1,0 +1,85 @@
+import {
+  LIBRARY_CORE_FEED_PAGE_NESTED_BOUNDS,
+  LIBRARY_CORE_FEED_PAGE_PROJECTION,
+  LIBRARY_CORE_FEED_PAGE_SOURCE_IDENTITY,
+} from "./feed-page-contracts.js";
+
+/**
+ * Closed contract for the Desktop person-timeline page.
+ *
+ * Every bound is read from the live native reader rather than chosen here.
+ * `library_core_feed_reader_runtime.rs` fixes the query identity, the default
+ * and maximum page limits, the 5,000 source-key ceiling, the cursor encoding,
+ * and the 2 MiB response ceiling. `shadow_store.rs` fixes the ordering.
+ */
+export const LIBRARY_CORE_PERSON_TIMELINE_QUERY_ID =
+  "person_timeline_v1" as const;
+export const LIBRARY_CORE_PERSON_TIMELINE_SCHEMA_VERSION = 1 as const;
+export const LIBRARY_CORE_PERSON_TIMELINE_DEFAULT_LIMIT = 50;
+export const LIBRARY_CORE_PERSON_TIMELINE_MAXIMUM_LIMIT = 100;
+export const LIBRARY_CORE_PERSON_TIMELINE_MAXIMUM_SOURCE_KEYS = 5_000;
+export const LIBRARY_CORE_PERSON_TIMELINE_MAXIMUM_CURSOR_BYTES = 5_600;
+export const LIBRARY_CORE_PERSON_TIMELINE_MAXIMUM_RESPONSE_BYTES =
+  2 * 1_048_576;
+
+export const LIBRARY_CORE_PERSON_TIMELINE_REQUEST_SCHEMA = Object.freeze({
+  schemaId: "library_core_person_timeline_request_v1",
+  schemaVersion: LIBRARY_CORE_PERSON_TIMELINE_SCHEMA_VERSION,
+  queryId: LIBRARY_CORE_PERSON_TIMELINE_QUERY_ID,
+  canonicalKeys: Object.freeze([
+    "cursor",
+    "limit",
+    "queryId",
+    "schemaVersion",
+    "sources",
+  ]),
+  sourceKeys: Object.freeze(["authorId", "platform"]),
+  /** The request selects by identity, so an empty source set is rejected. */
+  requiresNonEmptySources: true,
+  maximumSourceKeys: LIBRARY_CORE_PERSON_TIMELINE_MAXIMUM_SOURCE_KEYS,
+  defaultLimit: LIBRARY_CORE_PERSON_TIMELINE_DEFAULT_LIMIT,
+  maximumLimit: LIBRARY_CORE_PERSON_TIMELINE_MAXIMUM_LIMIT,
+  cursorCodec: "library_core_person_timeline_cursor_v1",
+  maximumCursorBytes: LIBRARY_CORE_PERSON_TIMELINE_MAXIMUM_CURSOR_BYTES,
+});
+
+export const LIBRARY_CORE_PERSON_TIMELINE_RESPONSE_SCHEMA = Object.freeze({
+  schemaId: "library_core_person_timeline_response_v1",
+  schemaVersion: LIBRARY_CORE_PERSON_TIMELINE_SCHEMA_VERSION,
+  queryId: LIBRARY_CORE_PERSON_TIMELINE_QUERY_ID,
+  canonicalKeys: Object.freeze([
+    "nextCursor",
+    "queryId",
+    "rows",
+    "schemaVersion",
+    "source",
+    "totalCount",
+  ]),
+  maximumRows: LIBRARY_CORE_PERSON_TIMELINE_MAXIMUM_LIMIT,
+  maximumResponseBytes: LIBRARY_CORE_PERSON_TIMELINE_MAXIMUM_RESPONSE_BYTES,
+});
+
+/**
+ * The timeline pages the same `feed_items` rows through the same compact card
+ * as the ordinary feed page, so it reuses that projection, source identity, and
+ * nested bounds rather than declaring a parallel copy that could drift.
+ */
+export const LIBRARY_CORE_PERSON_TIMELINE_PROJECTION =
+  LIBRARY_CORE_FEED_PAGE_PROJECTION;
+export const LIBRARY_CORE_PERSON_TIMELINE_SOURCE_IDENTITY =
+  LIBRARY_CORE_FEED_PAGE_SOURCE_IDENTITY;
+export const LIBRARY_CORE_PERSON_TIMELINE_NESTED_BOUNDS =
+  LIBRARY_CORE_FEED_PAGE_NESTED_BOUNDS;
+
+export interface LibraryCorePersonTimelineSourceKeyV1 {
+  readonly platform: string;
+  readonly authorId: string;
+}
+
+export interface LibraryCorePersonTimelineRequestV1 {
+  readonly cursor: string | null;
+  readonly limit: number;
+  readonly queryId: typeof LIBRARY_CORE_PERSON_TIMELINE_QUERY_ID;
+  readonly schemaVersion: typeof LIBRARY_CORE_PERSON_TIMELINE_SCHEMA_VERSION;
+  readonly sources: readonly LibraryCorePersonTimelineSourceKeyV1[];
+}

--- a/packages/shared/src/library-core/query-registry.ts
+++ b/packages/shared/src/library-core/query-registry.ts
@@ -36,6 +36,13 @@ import {
   LIBRARY_CORE_SAVED_ANALYTICS_RESPONSE_SCHEMA,
   LIBRARY_CORE_SAVED_ANALYTICS_SOURCE_IDENTITY,
 } from "./saved-analytics-contracts.js";
+import {
+  LIBRARY_CORE_PERSON_TIMELINE_NESTED_BOUNDS,
+  LIBRARY_CORE_PERSON_TIMELINE_PROJECTION,
+  LIBRARY_CORE_PERSON_TIMELINE_REQUEST_SCHEMA,
+  LIBRARY_CORE_PERSON_TIMELINE_RESPONSE_SCHEMA,
+  LIBRARY_CORE_PERSON_TIMELINE_SOURCE_IDENTITY,
+} from "./person-timeline-contracts.js";
 
 export const LIBRARY_CORE_QUERY_IDS = [
   "account_detail_v1",
@@ -213,6 +220,7 @@ export interface PlannedBlockedLibraryCoreQueryDefinition {
     | typeof LIBRARY_CORE_FEED_BROWSE_PAGE_V3_REQUEST_SCHEMA
     | typeof LIBRARY_CORE_SAVED_FEED_PAGE_REQUEST_SCHEMA
     | typeof LIBRARY_CORE_SAVED_ANALYTICS_REQUEST_SCHEMA
+    | typeof LIBRARY_CORE_PERSON_TIMELINE_REQUEST_SCHEMA
     | null;
   readonly responseSchema:
     | typeof LIBRARY_CORE_FEED_PAGE_RESPONSE_SCHEMA
@@ -221,6 +229,7 @@ export interface PlannedBlockedLibraryCoreQueryDefinition {
     | typeof LIBRARY_CORE_FEED_BROWSE_PAGE_V3_RESPONSE_SCHEMA
     | typeof LIBRARY_CORE_SAVED_FEED_PAGE_RESPONSE_SCHEMA
     | typeof LIBRARY_CORE_SAVED_ANALYTICS_RESPONSE_SCHEMA
+    | typeof LIBRARY_CORE_PERSON_TIMELINE_RESPONSE_SCHEMA
     | null;
   readonly projection:
     | typeof LIBRARY_CORE_FEED_PAGE_PROJECTION
@@ -332,14 +341,16 @@ interface PlannedQueryInput {
     | typeof LIBRARY_CORE_FEED_BROWSE_PAGE_V2_REQUEST_SCHEMA
     | typeof LIBRARY_CORE_FEED_BROWSE_PAGE_V3_REQUEST_SCHEMA
     | typeof LIBRARY_CORE_SAVED_FEED_PAGE_REQUEST_SCHEMA
-    | typeof LIBRARY_CORE_SAVED_ANALYTICS_REQUEST_SCHEMA;
+    | typeof LIBRARY_CORE_SAVED_ANALYTICS_REQUEST_SCHEMA
+    | typeof LIBRARY_CORE_PERSON_TIMELINE_REQUEST_SCHEMA;
   readonly responseSchema?:
     | typeof LIBRARY_CORE_FEED_PAGE_RESPONSE_SCHEMA
     | typeof LIBRARY_CORE_FEED_BROWSE_PAGE_RESPONSE_SCHEMA
     | typeof LIBRARY_CORE_FEED_BROWSE_PAGE_V2_RESPONSE_SCHEMA
     | typeof LIBRARY_CORE_FEED_BROWSE_PAGE_V3_RESPONSE_SCHEMA
     | typeof LIBRARY_CORE_SAVED_FEED_PAGE_RESPONSE_SCHEMA
-    | typeof LIBRARY_CORE_SAVED_ANALYTICS_RESPONSE_SCHEMA;
+    | typeof LIBRARY_CORE_SAVED_ANALYTICS_RESPONSE_SCHEMA
+    | typeof LIBRARY_CORE_PERSON_TIMELINE_RESPONSE_SCHEMA;
   readonly projection?:
     | typeof LIBRARY_CORE_FEED_PAGE_PROJECTION
     | typeof LIBRARY_CORE_FEED_BROWSE_PAGE_PROJECTION
@@ -834,6 +845,23 @@ export const LIBRARY_CORE_QUERY_REGISTRY = {
       "ProjectionReadSession::person_timeline",
       "read_library_core_person_timeline",
     ],
+    requestSchema: LIBRARY_CORE_PERSON_TIMELINE_REQUEST_SCHEMA,
+    responseSchema: LIBRARY_CORE_PERSON_TIMELINE_RESPONSE_SCHEMA,
+    projection: LIBRARY_CORE_PERSON_TIMELINE_PROJECTION,
+    sourceIdentity: LIBRARY_CORE_PERSON_TIMELINE_SOURCE_IDENTITY,
+    nestedBounds: LIBRARY_CORE_PERSON_TIMELINE_NESTED_BOUNDS,
+    // Identical to feed_page_v1: the timeline pages the same shadow rows with
+    // `ORDER BY sortAt DESC, globalId ASC`. `sortAt` rather than `publishedAt`
+    // for the same reason given there.
+    stableSort: {
+      columns: [
+        { column: "sortAt", direction: "desc" },
+        { column: "globalId", direction: "asc" },
+      ],
+      textCollation: "binary",
+      nullOrdering: "all_sort_columns_not_null",
+    },
+    tieBreakKey: "globalId",
     resolvedImplementationBlockers: ["runtime_adapter_unimplemented"],
   }),
   persons_graph_v1: plannedQuery({

--- a/packages/shared/src/library-core/registry.test.ts
+++ b/packages/shared/src/library-core/registry.test.ts
@@ -22,6 +22,13 @@ import {
   LIBRARY_CORE_SAVED_ANALYTICS_SOURCE_IDENTITY,
 } from "./saved-analytics-contracts.js";
 import {
+  LIBRARY_CORE_PERSON_TIMELINE_NESTED_BOUNDS,
+  LIBRARY_CORE_PERSON_TIMELINE_PROJECTION,
+  LIBRARY_CORE_PERSON_TIMELINE_REQUEST_SCHEMA,
+  LIBRARY_CORE_PERSON_TIMELINE_RESPONSE_SCHEMA,
+  LIBRARY_CORE_PERSON_TIMELINE_SOURCE_IDENTITY,
+} from "./person-timeline-contracts.js";
+import {
   LIBRARY_CORE_FIELD_REGISTRY,
 } from "./field-registry.js";
 import {
@@ -433,6 +440,38 @@ describe("Library Core query registry", () => {
     expect(
       BASE_APP_STORE_SURFACE_REGISTRY.items.successorQueryIds,
     ).toContain("feed_browse_page_v2");
+  });
+
+  it("closes the person-timeline page contract", () => {
+    expect(LIBRARY_CORE_QUERY_REGISTRY.person_timeline_v1).toMatchObject({
+      status: "planned_blocked",
+      requestSchema: LIBRARY_CORE_PERSON_TIMELINE_REQUEST_SCHEMA,
+      responseSchema: LIBRARY_CORE_PERSON_TIMELINE_RESPONSE_SCHEMA,
+      projection: LIBRARY_CORE_PERSON_TIMELINE_PROJECTION,
+      sourceIdentity: LIBRARY_CORE_PERSON_TIMELINE_SOURCE_IDENTITY,
+      nestedBounds: LIBRARY_CORE_PERSON_TIMELINE_NESTED_BOUNDS,
+      tieBreakKey: "globalId",
+    });
+    // The timeline pages the same shadow rows as the ordinary feed page, so its
+    // order must be identical rather than a parallel copy that could drift.
+    expect(
+      LIBRARY_CORE_QUERY_REGISTRY.person_timeline_v1.stableSort,
+    ).toEqual(LIBRARY_CORE_QUERY_REGISTRY.feed_page_v1.stableSort);
+    expect(LIBRARY_CORE_QUERY_REGISTRY.person_timeline_v1.projection).toBe(
+      LIBRARY_CORE_QUERY_REGISTRY.feed_page_v1.projection,
+    );
+    for (const blocker of [
+      "request_schema_unresolved",
+      "response_schema_unresolved",
+      "projection_unresolved",
+      "source_identity_unresolved",
+      "nested_bounds_unresolved",
+      "sort_contract_unresolved",
+    ]) {
+      expect(
+        LIBRARY_CORE_QUERY_REGISTRY.person_timeline_v1.blockers,
+      ).not.toContain(blocker);
+    }
   });
 
   it("closes the Saved-analytics aggregate contract", () => {


### PR DESCRIPTION
(AI Generated).

## Summary
- (AI Generated).

`person_timeline_v1` was registered with no `requestSchema`, `responseSchema`, `projection`, `sourceIdentity`, `nestedBounds`, or `stableSort`/`tieBreakKey` — six typed blockers open on a query whose runtime adapter already exists. Second query closed against the `query_request_response_and_projection_contracts_incomplete` census blocker, after #1316.

**Traced, not chosen.** `library_core_feed_reader_runtime.rs` fixes the query identity, default limit 50, maximum 100, the 5,000 source-key ceiling (`MAXIMUM_FRIEND_SOURCE_KEYS`), the cursor encoding, and the 2 MiB response ceiling. `shadow_store.rs` fixes the ordering. As a cross-check, the limits already declared in the registry independently matched what I read from the native side.

**Reuse instead of parallel copies.** The timeline pages the same `feed_items` rows through the same compact card as the ordinary feed page, and reads them with the same `ORDER BY sortAt DESC, globalId ASC`. So it reuses `feed_page_v1`'s projection, source identity, and nested bounds *by reference*, and the test asserts `toBe`/`toEqual` identity with `feed_page_v1` rather than restating the values — two declarations that must agree are better expressed as one.

**No behavior change.** Previously declared limits, response ceiling, `totalCountIntent`, `invalidationKeyIntent`, and `currentKinds` are untouched.

The three registry assertions were mutation-tested: dropping the request schema, dropping the source identity, and altering the sort order each make the suite fail.

No provider-visible path changed, so no provider-risk artifact applies. No phase status or contract document changed. Dormant contract work, merge-safe.

## Testing
- npm run validate:feature exit 0; shared library-core 214/214; registry mutation tests 3/3 caught