### PR TITLE
feat: close five persons graph contract fields

### DIFF
--- a/packages/shared/src/library-core/index.ts
+++ b/packages/shared/src/library-core/index.ts
@@ -26,6 +26,7 @@ export * from "./query-registry.js";
 export * from "./saved-feed-page-contracts.js";
 export * from "./saved-analytics-contracts.js";
 export * from "./person-timeline-contracts.js";
+export * from "./persons-graph-contracts.js";
 export * from "./sha256.js";
 export * from "./store-surface-registry.js";
 export * from "./wire-frame.js";

--- a/packages/shared/src/library-core/persons-graph-contracts.ts
+++ b/packages/shared/src/library-core/persons-graph-contracts.ts
@@ -1,0 +1,147 @@
+/**
+ * Closed contract for the Desktop persons-graph activity aggregate.
+ *
+ * Every bound is read from the live native reader rather than chosen here.
+ * `library_core_feed_reader_runtime.rs` fixes the query identity, the combined
+ * 5,000 source-key-plus-feed-URL ceiling, the recent-window rule, and the 8 MiB
+ * response ceiling. `shadow_store.rs` fixes the summary shapes and the ordering
+ * of each series.
+ */
+export const LIBRARY_CORE_PERSONS_GRAPH_QUERY_ID = "persons_graph_v1" as const;
+export const LIBRARY_CORE_PERSONS_GRAPH_SCHEMA_VERSION = 1 as const;
+/** Sources and RSS feed URLs share one ceiling; the native reader sums them. */
+export const LIBRARY_CORE_PERSONS_GRAPH_MAXIMUM_COMBINED_SOURCES = 5_000;
+export const LIBRARY_CORE_PERSONS_GRAPH_MAXIMUM_REQUEST_BYTES = 2 * 1_048_576;
+export const LIBRARY_CORE_PERSONS_GRAPH_MAXIMUM_RESPONSE_BYTES = 8 * 1_048_576;
+
+export const LIBRARY_CORE_PERSONS_GRAPH_REQUEST_SCHEMA = Object.freeze({
+  schemaId: "library_core_persons_graph_request_v1",
+  schemaVersion: LIBRARY_CORE_PERSONS_GRAPH_SCHEMA_VERSION,
+  queryId: LIBRARY_CORE_PERSONS_GRAPH_QUERY_ID,
+  canonicalKeys: Object.freeze([
+    "queryId",
+    "recentWindow",
+    "rssFeedUrls",
+    "schemaVersion",
+    "sources",
+  ]),
+  recentWindowKeys: Object.freeze(["endMs", "startMs"]),
+  sourceKeys: Object.freeze(["authorId", "platform"]),
+  /** `sources.length + rssFeedUrls.length` is checked against one ceiling. */
+  maximumCombinedSources:
+    LIBRARY_CORE_PERSONS_GRAPH_MAXIMUM_COMBINED_SOURCES,
+  /** Unlike the timeline, an empty source set is admitted. */
+  requiresNonEmptySources: false,
+  maximumRequestBytes: LIBRARY_CORE_PERSONS_GRAPH_MAXIMUM_REQUEST_BYTES,
+});
+
+export const LIBRARY_CORE_PERSONS_GRAPH_RESPONSE_SCHEMA = Object.freeze({
+  schemaId: "library_core_persons_graph_response_v1",
+  schemaVersion: LIBRARY_CORE_PERSONS_GRAPH_SCHEMA_VERSION,
+  queryId: LIBRARY_CORE_PERSONS_GRAPH_QUERY_ID,
+  canonicalKeys: Object.freeze([
+    "queryId",
+    "rss",
+    "schemaVersion",
+    "social",
+    "source",
+    "totalItemCount",
+  ]),
+  socialKeys: Object.freeze([
+    "authorId",
+    "avatarGlobalId",
+    "avatarPublishedAt",
+    "avatarUrl",
+    "hasLocation",
+    "itemCount",
+    "latestActivityAt",
+    "platform",
+  ]),
+  rssKeys: Object.freeze([
+    "avatarGlobalId",
+    "avatarPublishedAt",
+    "avatarUrl",
+    "feedUrl",
+    "hasLocation",
+    "itemCount",
+    "latestActivityAt",
+  ]),
+  maximumResponseBytes: LIBRARY_CORE_PERSONS_GRAPH_MAXIMUM_RESPONSE_BYTES,
+});
+
+export const LIBRARY_CORE_PERSONS_GRAPH_PROJECTION = Object.freeze({
+  projectionId: "library_core_persons_graph_activity_v1",
+  sourceTable: "feed_items",
+  fullContentAllowed: false,
+  /**
+   * Two independently keyed series rather than one row order. `social` is keyed
+   * by (platform, authorId) and `rss` by feedUrl.
+   */
+  orderedColumns: Object.freeze(["platform", "authorId", "feedUrl"]),
+});
+
+export const LIBRARY_CORE_PERSONS_GRAPH_SOURCE_IDENTITY = Object.freeze({
+  identityId: "library_core_projection_reader_source_v1",
+  generationId: "sha256_file_digest",
+  transitionSequence: "nonnegative_safe_integer",
+  projectionRevision: "nonnegative_safe_integer",
+  sessionPinned: true,
+});
+
+export const LIBRARY_CORE_PERSONS_GRAPH_NESTED_BOUNDS = Object.freeze({
+  social: Object.freeze({
+    maximumItems: LIBRARY_CORE_PERSONS_GRAPH_MAXIMUM_COMBINED_SOURCES,
+    maximumUnicodeScalarsPerItem: 4_096,
+    maximumUtf8BytesPerItem: 4_096,
+  }),
+  rss: Object.freeze({
+    maximumItems: LIBRARY_CORE_PERSONS_GRAPH_MAXIMUM_COMBINED_SOURCES,
+    maximumUnicodeScalarsPerItem: 4_096,
+    maximumUtf8BytesPerItem: 4_096,
+  }),
+});
+
+/**
+ * Why this query keeps `sort_contract_unresolved`.
+ *
+ * The response carries two independently ordered series: `social` comes from a
+ * `BTreeMap<FriendSourceKey, _>`, so it is ascending by platform then authorId,
+ * and `rss` comes from a `BTreeMap<String, _>` keyed by feed URL, so it is
+ * ascending by feedUrl. `ResolvedQuerySortContract` describes one column list
+ * with one final tie-break, which cannot express two key spaces at once.
+ *
+ * Declaring only the social order would be a plausible-looking placeholder that
+ * silently says nothing about half the response, so the blocker stays open
+ * until either the registry grows a per-series sort contract or this query is
+ * split. The orderings themselves are recorded here so that later work does not
+ * have to re-derive them.
+ */
+export const LIBRARY_CORE_PERSONS_GRAPH_SERIES_ORDER = Object.freeze({
+  social: Object.freeze({
+    columns: Object.freeze(["platform", "authorId"]),
+    direction: "asc",
+    textCollation: "binary",
+  }),
+  rss: Object.freeze({
+    columns: Object.freeze(["feedUrl"]),
+    direction: "asc",
+    textCollation: "binary",
+  }),
+  unresolvedReason: "multi_series_response_needs_per_series_sort_contract",
+});
+
+export interface LibraryCorePersonsGraphWindowV1 {
+  readonly startMs: number;
+  readonly endMs: number;
+}
+
+export interface LibraryCorePersonsGraphRequestV1 {
+  readonly queryId: typeof LIBRARY_CORE_PERSONS_GRAPH_QUERY_ID;
+  readonly recentWindow: LibraryCorePersonsGraphWindowV1;
+  readonly rssFeedUrls: readonly string[];
+  readonly schemaVersion: typeof LIBRARY_CORE_PERSONS_GRAPH_SCHEMA_VERSION;
+  readonly sources: readonly {
+    readonly platform: string;
+    readonly authorId: string;
+  }[];
+}

--- a/packages/shared/src/library-core/query-registry.ts
+++ b/packages/shared/src/library-core/query-registry.ts
@@ -43,6 +43,13 @@ import {
   LIBRARY_CORE_PERSON_TIMELINE_RESPONSE_SCHEMA,
   LIBRARY_CORE_PERSON_TIMELINE_SOURCE_IDENTITY,
 } from "./person-timeline-contracts.js";
+import {
+  LIBRARY_CORE_PERSONS_GRAPH_NESTED_BOUNDS,
+  LIBRARY_CORE_PERSONS_GRAPH_PROJECTION,
+  LIBRARY_CORE_PERSONS_GRAPH_REQUEST_SCHEMA,
+  LIBRARY_CORE_PERSONS_GRAPH_RESPONSE_SCHEMA,
+  LIBRARY_CORE_PERSONS_GRAPH_SOURCE_IDENTITY,
+} from "./persons-graph-contracts.js";
 
 export const LIBRARY_CORE_QUERY_IDS = [
   "account_detail_v1",
@@ -221,6 +228,7 @@ export interface PlannedBlockedLibraryCoreQueryDefinition {
     | typeof LIBRARY_CORE_SAVED_FEED_PAGE_REQUEST_SCHEMA
     | typeof LIBRARY_CORE_SAVED_ANALYTICS_REQUEST_SCHEMA
     | typeof LIBRARY_CORE_PERSON_TIMELINE_REQUEST_SCHEMA
+    | typeof LIBRARY_CORE_PERSONS_GRAPH_REQUEST_SCHEMA
     | null;
   readonly responseSchema:
     | typeof LIBRARY_CORE_FEED_PAGE_RESPONSE_SCHEMA
@@ -230,6 +238,7 @@ export interface PlannedBlockedLibraryCoreQueryDefinition {
     | typeof LIBRARY_CORE_SAVED_FEED_PAGE_RESPONSE_SCHEMA
     | typeof LIBRARY_CORE_SAVED_ANALYTICS_RESPONSE_SCHEMA
     | typeof LIBRARY_CORE_PERSON_TIMELINE_RESPONSE_SCHEMA
+    | typeof LIBRARY_CORE_PERSONS_GRAPH_RESPONSE_SCHEMA
     | null;
   readonly projection:
     | typeof LIBRARY_CORE_FEED_PAGE_PROJECTION
@@ -237,14 +246,17 @@ export interface PlannedBlockedLibraryCoreQueryDefinition {
     | typeof LIBRARY_CORE_FEED_BROWSE_PAGE_V2_PROJECTION
     | typeof LIBRARY_CORE_SAVED_FEED_PAGE_PROJECTION
     | typeof LIBRARY_CORE_SAVED_ANALYTICS_PROJECTION
+    | typeof LIBRARY_CORE_PERSONS_GRAPH_PROJECTION
     | null;
   readonly sourceIdentity:
     | typeof LIBRARY_CORE_FEED_PAGE_SOURCE_IDENTITY
     | typeof LIBRARY_CORE_SAVED_ANALYTICS_SOURCE_IDENTITY
+    | typeof LIBRARY_CORE_PERSONS_GRAPH_SOURCE_IDENTITY
     | null;
   readonly nestedBounds:
     | typeof LIBRARY_CORE_FEED_PAGE_NESTED_BOUNDS
     | typeof LIBRARY_CORE_SAVED_ANALYTICS_NESTED_BOUNDS
+    | typeof LIBRARY_CORE_PERSONS_GRAPH_NESTED_BOUNDS
     | null;
   readonly stableSort: ResolvedQuerySortContract | null;
   readonly tieBreakKey: string | null;
@@ -342,7 +354,8 @@ interface PlannedQueryInput {
     | typeof LIBRARY_CORE_FEED_BROWSE_PAGE_V3_REQUEST_SCHEMA
     | typeof LIBRARY_CORE_SAVED_FEED_PAGE_REQUEST_SCHEMA
     | typeof LIBRARY_CORE_SAVED_ANALYTICS_REQUEST_SCHEMA
-    | typeof LIBRARY_CORE_PERSON_TIMELINE_REQUEST_SCHEMA;
+    | typeof LIBRARY_CORE_PERSON_TIMELINE_REQUEST_SCHEMA
+    | typeof LIBRARY_CORE_PERSONS_GRAPH_REQUEST_SCHEMA;
   readonly responseSchema?:
     | typeof LIBRARY_CORE_FEED_PAGE_RESPONSE_SCHEMA
     | typeof LIBRARY_CORE_FEED_BROWSE_PAGE_RESPONSE_SCHEMA
@@ -350,19 +363,23 @@ interface PlannedQueryInput {
     | typeof LIBRARY_CORE_FEED_BROWSE_PAGE_V3_RESPONSE_SCHEMA
     | typeof LIBRARY_CORE_SAVED_FEED_PAGE_RESPONSE_SCHEMA
     | typeof LIBRARY_CORE_SAVED_ANALYTICS_RESPONSE_SCHEMA
-    | typeof LIBRARY_CORE_PERSON_TIMELINE_RESPONSE_SCHEMA;
+    | typeof LIBRARY_CORE_PERSON_TIMELINE_RESPONSE_SCHEMA
+    | typeof LIBRARY_CORE_PERSONS_GRAPH_RESPONSE_SCHEMA;
   readonly projection?:
     | typeof LIBRARY_CORE_FEED_PAGE_PROJECTION
     | typeof LIBRARY_CORE_FEED_BROWSE_PAGE_PROJECTION
     | typeof LIBRARY_CORE_FEED_BROWSE_PAGE_V2_PROJECTION
     | typeof LIBRARY_CORE_SAVED_FEED_PAGE_PROJECTION
-    | typeof LIBRARY_CORE_SAVED_ANALYTICS_PROJECTION;
+    | typeof LIBRARY_CORE_SAVED_ANALYTICS_PROJECTION
+    | typeof LIBRARY_CORE_PERSONS_GRAPH_PROJECTION;
   readonly sourceIdentity?:
     | typeof LIBRARY_CORE_FEED_PAGE_SOURCE_IDENTITY
-    | typeof LIBRARY_CORE_SAVED_ANALYTICS_SOURCE_IDENTITY;
+    | typeof LIBRARY_CORE_SAVED_ANALYTICS_SOURCE_IDENTITY
+    | typeof LIBRARY_CORE_PERSONS_GRAPH_SOURCE_IDENTITY;
   readonly nestedBounds?:
     | typeof LIBRARY_CORE_FEED_PAGE_NESTED_BOUNDS
-    | typeof LIBRARY_CORE_SAVED_ANALYTICS_NESTED_BOUNDS;
+    | typeof LIBRARY_CORE_SAVED_ANALYTICS_NESTED_BOUNDS
+    | typeof LIBRARY_CORE_PERSONS_GRAPH_NESTED_BOUNDS;
   /**
    * Supplying both clears `sort_contract_unresolved` for this query. They move
    * together on purpose: an ordering without a tie-break is not stable, and a
@@ -877,6 +894,17 @@ export const LIBRARY_CORE_QUERY_REGISTRY = {
       "ProjectionReadSession::friends_graph_activity",
       "read_library_core_persons_graph",
     ],
+    requestSchema: LIBRARY_CORE_PERSONS_GRAPH_REQUEST_SCHEMA,
+    responseSchema: LIBRARY_CORE_PERSONS_GRAPH_RESPONSE_SCHEMA,
+    projection: LIBRARY_CORE_PERSONS_GRAPH_PROJECTION,
+    sourceIdentity: LIBRARY_CORE_PERSONS_GRAPH_SOURCE_IDENTITY,
+    nestedBounds: LIBRARY_CORE_PERSONS_GRAPH_NESTED_BOUNDS,
+    // stableSort and tieBreakKey stay null on purpose. The response carries two
+    // independently keyed series (social by platform+authorId, rss by feedUrl)
+    // and ResolvedQuerySortContract expresses one column list with one final
+    // tie-break. Declaring only one series would say nothing about the other,
+    // so sort_contract_unresolved stays open. The real orderings are recorded
+    // in LIBRARY_CORE_PERSONS_GRAPH_SERIES_ORDER.
     resolvedImplementationBlockers: ["runtime_adapter_unimplemented"],
   }),
   preferences_snapshot_v1: plannedQuery({

--- a/packages/shared/src/library-core/registry.test.ts
+++ b/packages/shared/src/library-core/registry.test.ts
@@ -29,6 +29,14 @@ import {
   LIBRARY_CORE_PERSON_TIMELINE_SOURCE_IDENTITY,
 } from "./person-timeline-contracts.js";
 import {
+  LIBRARY_CORE_PERSONS_GRAPH_NESTED_BOUNDS,
+  LIBRARY_CORE_PERSONS_GRAPH_PROJECTION,
+  LIBRARY_CORE_PERSONS_GRAPH_REQUEST_SCHEMA,
+  LIBRARY_CORE_PERSONS_GRAPH_RESPONSE_SCHEMA,
+  LIBRARY_CORE_PERSONS_GRAPH_SERIES_ORDER,
+  LIBRARY_CORE_PERSONS_GRAPH_SOURCE_IDENTITY,
+} from "./persons-graph-contracts.js";
+import {
   LIBRARY_CORE_FIELD_REGISTRY,
 } from "./field-registry.js";
 import {
@@ -440,6 +448,44 @@ describe("Library Core query registry", () => {
     expect(
       BASE_APP_STORE_SURFACE_REGISTRY.items.successorQueryIds,
     ).toContain("feed_browse_page_v2");
+  });
+
+  it("closes five persons-graph contract fields and keeps the sort blocked", () => {
+    expect(LIBRARY_CORE_QUERY_REGISTRY.persons_graph_v1).toMatchObject({
+      status: "planned_blocked",
+      requestSchema: LIBRARY_CORE_PERSONS_GRAPH_REQUEST_SCHEMA,
+      responseSchema: LIBRARY_CORE_PERSONS_GRAPH_RESPONSE_SCHEMA,
+      projection: LIBRARY_CORE_PERSONS_GRAPH_PROJECTION,
+      sourceIdentity: LIBRARY_CORE_PERSONS_GRAPH_SOURCE_IDENTITY,
+      nestedBounds: LIBRARY_CORE_PERSONS_GRAPH_NESTED_BOUNDS,
+    });
+    for (const blocker of [
+      "request_schema_unresolved",
+      "response_schema_unresolved",
+      "projection_unresolved",
+      "source_identity_unresolved",
+      "nested_bounds_unresolved",
+    ]) {
+      expect(
+        LIBRARY_CORE_QUERY_REGISTRY.persons_graph_v1.blockers,
+      ).not.toContain(blocker);
+    }
+    // The response carries two independently keyed series, which the single
+    // column list of ResolvedQuerySortContract cannot express. Leaving a
+    // half-true sort here would be worse than leaving the blocker open.
+    expect(LIBRARY_CORE_QUERY_REGISTRY.persons_graph_v1.stableSort).toBeNull();
+    expect(LIBRARY_CORE_QUERY_REGISTRY.persons_graph_v1.tieBreakKey).toBeNull();
+    expect(LIBRARY_CORE_QUERY_REGISTRY.persons_graph_v1.blockers).toContain(
+      "sort_contract_unresolved",
+    );
+    // The real orderings are still recorded so later work need not re-derive.
+    expect(LIBRARY_CORE_PERSONS_GRAPH_SERIES_ORDER.social.columns).toEqual([
+      "platform",
+      "authorId",
+    ]);
+    expect(LIBRARY_CORE_PERSONS_GRAPH_SERIES_ORDER.rss.columns).toEqual([
+      "feedUrl",
+    ]);
   });
 
   it("closes the person-timeline page contract", () => {


### PR DESCRIPTION
(AI Generated).

## Summary
- (AI Generated).

Third query against the `query_request_response_and_projection_contracts_incomplete` census blocker, after #1316 and #1317. This one closes **five of six** fields, and the sixth staying open is the point.

**Traced, not chosen.** The native reader fixes the query identity, the combined 5,000 source-key-plus-feed-URL ceiling (`sources.length + rssFeedUrls.length` is checked against one limit), the recent-window rule, and the 8 MiB response ceiling. The shadow store fixes the summary shapes and each series ordering. Cross-check: the `maximumRows: 5_000` already declared in the registry independently matches the traced `MAXIMUM_FRIEND_SOURCE_KEYS`.

**Why the sort contract stays blocked.** The response carries two independently keyed series — `social` from a `BTreeMap<FriendSourceKey, _>` (ascending platform, then authorId) and `rss` from a `BTreeMap<String, _>` (ascending feedUrl). `ResolvedQuerySortContract` describes one column list with one final tie-break, which cannot express two key spaces. Declaring only the social order would look complete while saying nothing about half the response, so `sort_contract_unresolved` stays open per the skill's rule that an unresolved rule stays typed as blocked rather than taking a plausible placeholder.

The orderings are still recorded in `LIBRARY_CORE_PERSONS_GRAPH_SERIES_ORDER` so whoever adds a per-series sort contract does not have to re-derive them. That is the real follow-up this surfaces: the registry's sort type assumes single-series responses, and at least one query is not.

Mutation-tested: dropping the request schema, dropping the nested bounds, and — most importantly — **adding a half-true single-series sort** each fail the suite.

No provider-visible path changed. No phase status or contract document changed. Dormant contract work, merge-safe.

## Testing
- npm run validate:feature exit 0; shared library-core 215/215; registry mutation tests 3/3 caught incl. the half-true-sort case