### PR TITLE
feat: close the item detail query contract

### DIFF
--- a/packages/shared/src/library-core/index.ts
+++ b/packages/shared/src/library-core/index.ts
@@ -27,6 +27,7 @@ export * from "./saved-feed-page-contracts.js";
 export * from "./saved-analytics-contracts.js";
 export * from "./person-timeline-contracts.js";
 export * from "./persons-graph-contracts.js";
+export * from "./item-detail-contracts.js";
 export * from "./sha256.js";
 export * from "./store-surface-registry.js";
 export * from "./wire-frame.js";

--- a/packages/shared/src/library-core/item-detail-contracts.ts
+++ b/packages/shared/src/library-core/item-detail-contracts.ts
@@ -1,0 +1,113 @@
+/**
+ * Closed contract for the Desktop single-item detail lookup.
+ *
+ * Every bound is read from the live native reader rather than chosen here.
+ * `library_core_feed_reader_runtime.rs` fixes the query identity, the 4,096
+ * byte entity-ID ceiling, and the 8 MiB response ceiling. `shadow_store.rs`
+ * fixes the selected columns, which include the preserved reader body.
+ */
+export const LIBRARY_CORE_ITEM_DETAIL_QUERY_ID = "item_detail_v1" as const;
+export const LIBRARY_CORE_ITEM_DETAIL_SCHEMA_VERSION = 1 as const;
+export const LIBRARY_CORE_ITEM_DETAIL_MAXIMUM_ENTITY_ID_UTF8_BYTES = 4_096;
+export const LIBRARY_CORE_ITEM_DETAIL_MAXIMUM_RESPONSE_BYTES = 8 * 1_048_576;
+
+export const LIBRARY_CORE_ITEM_DETAIL_REQUEST_SCHEMA = Object.freeze({
+  schemaId: "library_core_item_detail_request_v1",
+  schemaVersion: LIBRARY_CORE_ITEM_DETAIL_SCHEMA_VERSION,
+  queryId: LIBRARY_CORE_ITEM_DETAIL_QUERY_ID,
+  canonicalKeys: Object.freeze(["globalId", "queryId", "schemaVersion"]),
+  /** The native reader rejects an empty or oversized identity before opening. */
+  requiresNonEmptyGlobalId: true,
+  maximumGlobalIdUtf8Bytes:
+    LIBRARY_CORE_ITEM_DETAIL_MAXIMUM_ENTITY_ID_UTF8_BYTES,
+});
+
+export const LIBRARY_CORE_ITEM_DETAIL_RESPONSE_SCHEMA = Object.freeze({
+  schemaId: "library_core_item_detail_response_v1",
+  schemaVersion: LIBRARY_CORE_ITEM_DETAIL_SCHEMA_VERSION,
+  queryId: LIBRARY_CORE_ITEM_DETAIL_QUERY_ID,
+  canonicalKeys: Object.freeze([
+    "item",
+    "queryId",
+    "schemaVersion",
+    "source",
+  ]),
+  itemKeys: Object.freeze([
+    "archived",
+    "archivedAt",
+    "authorDisplayName",
+    "authorHandle",
+    "authorId",
+    "capturedAt",
+    "contentBlob",
+    "contentType",
+    "globalId",
+    "hidden",
+    "likedAt",
+    "platform",
+    "preservedBlob",
+    "publishedAt",
+    "readAt",
+    "rest",
+    "saved",
+    "sourceUrl",
+    "tags",
+  ]),
+  /** A missing item is an absent row, not an error. */
+  nullableItem: true,
+  maximumRows: 1,
+  maximumResponseBytes: LIBRARY_CORE_ITEM_DETAIL_MAXIMUM_RESPONSE_BYTES,
+});
+
+/**
+ * Unlike the compact feed card, this lookup selects `contentBlob` and
+ * `preservedBlob`, so it does carry full reader content. That is why its
+ * response ceiling is 8 MiB rather than the ordinary 2 MiB.
+ */
+export const LIBRARY_CORE_ITEM_DETAIL_PROJECTION = Object.freeze({
+  projectionId: "library_core_item_detail_row_v1",
+  sourceTable: "feed_items",
+  fullContentAllowed: true,
+  orderedColumns: Object.freeze(["globalId"]),
+});
+
+export const LIBRARY_CORE_ITEM_DETAIL_SOURCE_IDENTITY = Object.freeze({
+  identityId: "library_core_projection_reader_source_v1",
+  generationId: "sha256_file_digest",
+  transitionSequence: "nonnegative_safe_integer",
+  projectionRevision: "nonnegative_safe_integer",
+  sessionPinned: true,
+});
+
+export const LIBRARY_CORE_ITEM_DETAIL_NESTED_BOUNDS = Object.freeze({
+  globalId: Object.freeze({
+    maximumItems: 1,
+    maximumUnicodeScalarsPerItem:
+      LIBRARY_CORE_ITEM_DETAIL_MAXIMUM_ENTITY_ID_UTF8_BYTES,
+    maximumUtf8BytesPerItem:
+      LIBRARY_CORE_ITEM_DETAIL_MAXIMUM_ENTITY_ID_UTF8_BYTES,
+  }),
+  /**
+   * Content and preserved bodies are bounded by the response ceiling rather
+   * than a per-field cap, because the reader streams one row and the whole
+   * response is measured against 8 MiB.
+   */
+  contentBlob: Object.freeze({
+    maximumItems: 1,
+    maximumUnicodeScalarsPerItem:
+      LIBRARY_CORE_ITEM_DETAIL_MAXIMUM_RESPONSE_BYTES,
+    maximumUtf8BytesPerItem: LIBRARY_CORE_ITEM_DETAIL_MAXIMUM_RESPONSE_BYTES,
+  }),
+  preservedBlob: Object.freeze({
+    maximumItems: 1,
+    maximumUnicodeScalarsPerItem:
+      LIBRARY_CORE_ITEM_DETAIL_MAXIMUM_RESPONSE_BYTES,
+    maximumUtf8BytesPerItem: LIBRARY_CORE_ITEM_DETAIL_MAXIMUM_RESPONSE_BYTES,
+  }),
+});
+
+export interface LibraryCoreItemDetailRequestV1 {
+  readonly globalId: string;
+  readonly queryId: typeof LIBRARY_CORE_ITEM_DETAIL_QUERY_ID;
+  readonly schemaVersion: typeof LIBRARY_CORE_ITEM_DETAIL_SCHEMA_VERSION;
+}

--- a/packages/shared/src/library-core/query-registry.ts
+++ b/packages/shared/src/library-core/query-registry.ts
@@ -50,6 +50,14 @@ import {
   LIBRARY_CORE_PERSONS_GRAPH_RESPONSE_SCHEMA,
   LIBRARY_CORE_PERSONS_GRAPH_SOURCE_IDENTITY,
 } from "./persons-graph-contracts.js";
+import {
+  LIBRARY_CORE_ITEM_DETAIL_MAXIMUM_RESPONSE_BYTES,
+  LIBRARY_CORE_ITEM_DETAIL_NESTED_BOUNDS,
+  LIBRARY_CORE_ITEM_DETAIL_PROJECTION,
+  LIBRARY_CORE_ITEM_DETAIL_REQUEST_SCHEMA,
+  LIBRARY_CORE_ITEM_DETAIL_RESPONSE_SCHEMA,
+  LIBRARY_CORE_ITEM_DETAIL_SOURCE_IDENTITY,
+} from "./item-detail-contracts.js";
 
 export const LIBRARY_CORE_QUERY_IDS = [
   "account_detail_v1",
@@ -229,6 +237,7 @@ export interface PlannedBlockedLibraryCoreQueryDefinition {
     | typeof LIBRARY_CORE_SAVED_ANALYTICS_REQUEST_SCHEMA
     | typeof LIBRARY_CORE_PERSON_TIMELINE_REQUEST_SCHEMA
     | typeof LIBRARY_CORE_PERSONS_GRAPH_REQUEST_SCHEMA
+    | typeof LIBRARY_CORE_ITEM_DETAIL_REQUEST_SCHEMA
     | null;
   readonly responseSchema:
     | typeof LIBRARY_CORE_FEED_PAGE_RESPONSE_SCHEMA
@@ -239,6 +248,7 @@ export interface PlannedBlockedLibraryCoreQueryDefinition {
     | typeof LIBRARY_CORE_SAVED_ANALYTICS_RESPONSE_SCHEMA
     | typeof LIBRARY_CORE_PERSON_TIMELINE_RESPONSE_SCHEMA
     | typeof LIBRARY_CORE_PERSONS_GRAPH_RESPONSE_SCHEMA
+    | typeof LIBRARY_CORE_ITEM_DETAIL_RESPONSE_SCHEMA
     | null;
   readonly projection:
     | typeof LIBRARY_CORE_FEED_PAGE_PROJECTION
@@ -247,16 +257,19 @@ export interface PlannedBlockedLibraryCoreQueryDefinition {
     | typeof LIBRARY_CORE_SAVED_FEED_PAGE_PROJECTION
     | typeof LIBRARY_CORE_SAVED_ANALYTICS_PROJECTION
     | typeof LIBRARY_CORE_PERSONS_GRAPH_PROJECTION
+    | typeof LIBRARY_CORE_ITEM_DETAIL_PROJECTION
     | null;
   readonly sourceIdentity:
     | typeof LIBRARY_CORE_FEED_PAGE_SOURCE_IDENTITY
     | typeof LIBRARY_CORE_SAVED_ANALYTICS_SOURCE_IDENTITY
     | typeof LIBRARY_CORE_PERSONS_GRAPH_SOURCE_IDENTITY
+    | typeof LIBRARY_CORE_ITEM_DETAIL_SOURCE_IDENTITY
     | null;
   readonly nestedBounds:
     | typeof LIBRARY_CORE_FEED_PAGE_NESTED_BOUNDS
     | typeof LIBRARY_CORE_SAVED_ANALYTICS_NESTED_BOUNDS
     | typeof LIBRARY_CORE_PERSONS_GRAPH_NESTED_BOUNDS
+    | typeof LIBRARY_CORE_ITEM_DETAIL_NESTED_BOUNDS
     | null;
   readonly stableSort: ResolvedQuerySortContract | null;
   readonly tieBreakKey: string | null;
@@ -355,7 +368,8 @@ interface PlannedQueryInput {
     | typeof LIBRARY_CORE_SAVED_FEED_PAGE_REQUEST_SCHEMA
     | typeof LIBRARY_CORE_SAVED_ANALYTICS_REQUEST_SCHEMA
     | typeof LIBRARY_CORE_PERSON_TIMELINE_REQUEST_SCHEMA
-    | typeof LIBRARY_CORE_PERSONS_GRAPH_REQUEST_SCHEMA;
+    | typeof LIBRARY_CORE_PERSONS_GRAPH_REQUEST_SCHEMA
+    | typeof LIBRARY_CORE_ITEM_DETAIL_REQUEST_SCHEMA;
   readonly responseSchema?:
     | typeof LIBRARY_CORE_FEED_PAGE_RESPONSE_SCHEMA
     | typeof LIBRARY_CORE_FEED_BROWSE_PAGE_RESPONSE_SCHEMA
@@ -364,22 +378,26 @@ interface PlannedQueryInput {
     | typeof LIBRARY_CORE_SAVED_FEED_PAGE_RESPONSE_SCHEMA
     | typeof LIBRARY_CORE_SAVED_ANALYTICS_RESPONSE_SCHEMA
     | typeof LIBRARY_CORE_PERSON_TIMELINE_RESPONSE_SCHEMA
-    | typeof LIBRARY_CORE_PERSONS_GRAPH_RESPONSE_SCHEMA;
+    | typeof LIBRARY_CORE_PERSONS_GRAPH_RESPONSE_SCHEMA
+    | typeof LIBRARY_CORE_ITEM_DETAIL_RESPONSE_SCHEMA;
   readonly projection?:
     | typeof LIBRARY_CORE_FEED_PAGE_PROJECTION
     | typeof LIBRARY_CORE_FEED_BROWSE_PAGE_PROJECTION
     | typeof LIBRARY_CORE_FEED_BROWSE_PAGE_V2_PROJECTION
     | typeof LIBRARY_CORE_SAVED_FEED_PAGE_PROJECTION
     | typeof LIBRARY_CORE_SAVED_ANALYTICS_PROJECTION
-    | typeof LIBRARY_CORE_PERSONS_GRAPH_PROJECTION;
+    | typeof LIBRARY_CORE_PERSONS_GRAPH_PROJECTION
+    | typeof LIBRARY_CORE_ITEM_DETAIL_PROJECTION;
   readonly sourceIdentity?:
     | typeof LIBRARY_CORE_FEED_PAGE_SOURCE_IDENTITY
     | typeof LIBRARY_CORE_SAVED_ANALYTICS_SOURCE_IDENTITY
-    | typeof LIBRARY_CORE_PERSONS_GRAPH_SOURCE_IDENTITY;
+    | typeof LIBRARY_CORE_PERSONS_GRAPH_SOURCE_IDENTITY
+    | typeof LIBRARY_CORE_ITEM_DETAIL_SOURCE_IDENTITY;
   readonly nestedBounds?:
     | typeof LIBRARY_CORE_FEED_PAGE_NESTED_BOUNDS
     | typeof LIBRARY_CORE_SAVED_ANALYTICS_NESTED_BOUNDS
-    | typeof LIBRARY_CORE_PERSONS_GRAPH_NESTED_BOUNDS;
+    | typeof LIBRARY_CORE_PERSONS_GRAPH_NESTED_BOUNDS
+    | typeof LIBRARY_CORE_ITEM_DETAIL_NESTED_BOUNDS;
   /**
    * Supplying both clears `sort_contract_unresolved` for this query. They move
    * together on purpose: an ordering without a tie-break is not stable, and a
@@ -706,10 +724,34 @@ export const LIBRARY_CORE_QUERY_REGISTRY = {
     defaultLimit: 1,
     maximumLimit: 1,
     maximumRows: 1,
+    // Traced from the native reader. This lookup selects contentBlob and
+    // preservedBlob, so it carries full reader content and its real ceiling is
+    // 8 MiB, not the 2 MiB default this entry previously fell back to.
+    maximumResponseBytes: LIBRARY_CORE_ITEM_DETAIL_MAXIMUM_RESPONSE_BYTES,
+    fullContentAllowed: true,
     cursor: interactiveCursor("single_page"),
     totalCountIntent: "none",
     rendererCache: true,
     invalidationKeyIntent: ["item:{global_id}"],
+    currentKinds: [
+      "ProjectionReadSession::item_detail",
+      "read_library_core_item_detail",
+    ],
+    requestSchema: LIBRARY_CORE_ITEM_DETAIL_REQUEST_SCHEMA,
+    responseSchema: LIBRARY_CORE_ITEM_DETAIL_RESPONSE_SCHEMA,
+    projection: LIBRARY_CORE_ITEM_DETAIL_PROJECTION,
+    sourceIdentity: LIBRARY_CORE_ITEM_DETAIL_SOURCE_IDENTITY,
+    nestedBounds: LIBRARY_CORE_ITEM_DETAIL_NESTED_BOUNDS,
+    // A point lookup on the unique globalId primary key. The result is at most
+    // one row, so this order is total and globalId is genuinely the tie-break
+    // rather than a placeholder.
+    stableSort: {
+      columns: [{ column: "globalId", direction: "asc" }],
+      textCollation: "binary",
+      nullOrdering: "all_sort_columns_not_null",
+    },
+    tieBreakKey: "globalId",
+    resolvedImplementationBlockers: ["runtime_adapter_unimplemented"],
   }),
   item_reader_body_v1: plannedQuery({
     defaultLimit: 1,

--- a/packages/shared/src/library-core/registry.test.ts
+++ b/packages/shared/src/library-core/registry.test.ts
@@ -37,6 +37,13 @@ import {
   LIBRARY_CORE_PERSONS_GRAPH_SOURCE_IDENTITY,
 } from "./persons-graph-contracts.js";
 import {
+  LIBRARY_CORE_ITEM_DETAIL_NESTED_BOUNDS,
+  LIBRARY_CORE_ITEM_DETAIL_PROJECTION,
+  LIBRARY_CORE_ITEM_DETAIL_REQUEST_SCHEMA,
+  LIBRARY_CORE_ITEM_DETAIL_RESPONSE_SCHEMA,
+  LIBRARY_CORE_ITEM_DETAIL_SOURCE_IDENTITY,
+} from "./item-detail-contracts.js";
+import {
   LIBRARY_CORE_FIELD_REGISTRY,
 } from "./field-registry.js";
 import {
@@ -288,6 +295,7 @@ describe("Library Core query registry", () => {
       expect(definition.blockers.length).toBeGreaterThan(0);
       if (
         definition === LIBRARY_CORE_QUERY_REGISTRY.feed_page_v1 ||
+        definition === LIBRARY_CORE_QUERY_REGISTRY.item_detail_v1 ||
         definition === LIBRARY_CORE_QUERY_REGISTRY.feed_browse_page_v2 ||
         definition === LIBRARY_CORE_QUERY_REGISTRY.feed_browse_page_v3 ||
         definition === LIBRARY_CORE_QUERY_REGISTRY.person_timeline_v1 ||
@@ -448,6 +456,41 @@ describe("Library Core query registry", () => {
     expect(
       BASE_APP_STORE_SURFACE_REGISTRY.items.successorQueryIds,
     ).toContain("feed_browse_page_v2");
+  });
+
+  it("closes the item-detail contract and records that it carries full content", () => {
+    expect(LIBRARY_CORE_QUERY_REGISTRY.item_detail_v1).toMatchObject({
+      status: "planned_blocked",
+      requestSchema: LIBRARY_CORE_ITEM_DETAIL_REQUEST_SCHEMA,
+      responseSchema: LIBRARY_CORE_ITEM_DETAIL_RESPONSE_SCHEMA,
+      projection: LIBRARY_CORE_ITEM_DETAIL_PROJECTION,
+      sourceIdentity: LIBRARY_CORE_ITEM_DETAIL_SOURCE_IDENTITY,
+      nestedBounds: LIBRARY_CORE_ITEM_DETAIL_NESTED_BOUNDS,
+      tieBreakKey: "globalId",
+    });
+    for (const blocker of [
+      "request_schema_unresolved",
+      "response_schema_unresolved",
+      "projection_unresolved",
+      "source_identity_unresolved",
+      "nested_bounds_unresolved",
+      "sort_contract_unresolved",
+    ]) {
+      expect(
+        LIBRARY_CORE_QUERY_REGISTRY.item_detail_v1.blockers,
+      ).not.toContain(blocker);
+    }
+    // The lookup selects contentBlob and preservedBlob, so it really does carry
+    // full reader content and its ceiling is 8 MiB rather than the ordinary
+    // 2 MiB this entry previously defaulted to.
+    expect(LIBRARY_CORE_ITEM_DETAIL_PROJECTION.fullContentAllowed).toBe(true);
+    // Assert the registry entry itself, not just the contract constant.
+    expect(LIBRARY_CORE_QUERY_REGISTRY.item_detail_v1.fullContentAllowed).toBe(
+      true,
+    );
+    expect(LIBRARY_CORE_QUERY_REGISTRY.item_detail_v1.maximumResponseBytes).toBe(
+      8 * 1_048_576,
+    );
   });
 
   it("closes five persons-graph contract fields and keeps the sort blocked", () => {


### PR DESCRIPTION
(AI Generated).

## Summary
- (AI Generated).

Fourth query against `query_request_response_and_projection_contracts_incomplete`, after #1316, #1317, #1318. All six fields closed.

**Tracing found two understatements in the existing entry.** `item_detail_v1` selects `contentBlob` and `preservedBlob` from `feed_items`, so it carries the full preserved reader body — and the native reader enforces an 8 MiB ceiling. The registry entry declared neither `fullContentAllowed` nor `maximumResponseBytes`, so it was silently falling back to the ordinary **2 MiB** default while the real limit is **8 MiB**, and nothing recorded that full content crosses this boundary. Both are now declared from the traced values. This is the kind of drift the exercise is meant to catch: the declaration and the implementation disagreed by 4x.

**The sort contract is honest, not a placeholder.** This is a point lookup on the unique `globalId` primary key returning at most one row, so ordering by `globalId` is total and `globalId` really is the tie-break. Contrast #1318, where the response had two independently keyed series and I left the blocker open rather than invent one.

**Clearing `runtime_adapter_unimplemented` is a claim, so I verified it** at all three layers before making it: `App.tsx` provides `readLibraryCoreItemDetail`, `store.ts` calls it, and `lib.rs` registers `read_library_core_item_detail`.

Mutation-tested: dropping the request schema, dropping `fullContentAllowed`, and reverting to the understated 2 MiB default each fail the suite. The first attempt at the `fullContentAllowed` assertion checked the contract constant rather than the registry entry and did not fail — tightened so it asserts the entry.

No provider-visible path changed. No phase status or contract document changed. Dormant contract work, merge-safe.

## Testing
- npm run validate:feature exit 0; shared library-core 216/216; registry mutation tests 3/3 caught after tightening