### PR TITLE
fix: register the shipping queries the census was missing

### DIFF
--- a/packages/shared/src/library-core/native-query-census.test.ts
+++ b/packages/shared/src/library-core/native-query-census.test.ts
@@ -1,0 +1,64 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import { LIBRARY_CORE_QUERY_IDS } from "./query-registry.js";
+
+/**
+ * The Gate A census claims to be an exhaustive inventory of Library Core
+ * queries, and activation is gated on it. Nothing enforced that claim against
+ * the native reader, so three shipping queries were absent from it at once:
+ * `background_item_page_v1` (the bounded scan behind every corpus reader),
+ * `library_facet_summary_v1`, and `library_surface_items_v1`.
+ *
+ * This asserts the census against the Rust sources by string literal rather
+ * than by import, the same way the provider-visible path list and the roadmap
+ * status file are validated. A native query the census does not know about is
+ * a census defect, not a missing feature.
+ */
+const NATIVE_SOURCE_DIRECTORY = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "..",
+  "desktop",
+  "src-tauri",
+  "src",
+);
+
+const QUERY_ID_CONSTANT =
+  /const\s+[A-Z0-9_]*QUERY_ID\s*:\s*&str\s*=\s*"([a-z0-9_]+)"/g;
+
+function nativeQueryIds(): string[] {
+  const found = new Set<string>();
+  for (const entry of readdirSync(NATIVE_SOURCE_DIRECTORY)) {
+    if (!entry.endsWith(".rs")) continue;
+    const source = readFileSync(join(NATIVE_SOURCE_DIRECTORY, entry), "utf8");
+    for (const match of source.matchAll(QUERY_ID_CONSTANT)) {
+      found.add(match[1]!);
+    }
+  }
+  return [...found].sort();
+}
+
+describe("Library Core native query census", () => {
+  it("finds the native query identity constants it is meant to police", () => {
+    // Guards the regex itself. If this drops to zero the suite would pass
+    // vacuously while enforcing nothing.
+    const ids = nativeQueryIds();
+    expect(ids.length).toBeGreaterThanOrEqual(8);
+    expect(ids).toContain("feed_page_v1");
+  });
+
+  it("registers every query identity the native reader ships", () => {
+    const registered = new Set<string>(LIBRARY_CORE_QUERY_IDS);
+    const unregistered = nativeQueryIds().filter((id) => !registered.has(id));
+    expect(
+      unregistered,
+      `Native reader ships query identities the Gate A census does not list: ${unregistered.join(", ")}. ` +
+        "Register them in LIBRARY_CORE_QUERY_IDS with their traced bounds. " +
+        "The census gates activation, so an unlisted live query makes it untrue.",
+    ).toEqual([]);
+  });
+});

--- a/packages/shared/src/library-core/query-registry.ts
+++ b/packages/shared/src/library-core/query-registry.ts
@@ -61,6 +61,7 @@ import {
 
 export const LIBRARY_CORE_QUERY_IDS = [
   "account_detail_v1",
+  "background_item_page_v1",
   "change_feed_v1",
   "content_fetch_claim_v1",
   "export_enumeration_v1",
@@ -87,6 +88,8 @@ export const LIBRARY_CORE_QUERY_IDS = [
   "legacy_worker_preferences_patch",
   "legacy_worker_saved_youtube_urls",
   "legacy_worker_state_update",
+  "library_facet_summary_v1",
+  "library_surface_items_v1",
   "map_markers_v1",
   "person_detail_v1",
   "person_timeline_v1",
@@ -544,6 +547,25 @@ export const LIBRARY_CORE_QUERY_REGISTRY = {
     rendererCache: true,
     invalidationKeyIntent: ["account:{account_id}", "person:{person_id}"],
   }),
+  background_item_page_v1: plannedQuery({
+    // The bounded item scan behind scanLibraryItems. Traced from the native
+    // reader: 64 rows per page, keyset cursor, and a per-page row budget of
+    // 8 MiB less 64 KiB of framing.
+    defaultLimit: 64,
+    maximumLimit: 64,
+    maximumRows: 64,
+    maximumResponseBytes: 8 * MIB - 64 * 1_024,
+    cursor: interactiveCursor("keyset"),
+    totalCountIntent: "none",
+    rendererCache: false,
+    invalidationKeyIntent: ["library:item-scan"],
+    currentKinds: [
+      "ProjectionReadSession::item_scan",
+      "read_library_core_item_scan_page",
+      "scanLibraryCoreItems",
+    ],
+    resolvedImplementationBlockers: ["runtime_adapter_unimplemented"],
+  }),
   change_feed_v1: plannedQuery({
     defaultLimit: 128,
     maximumLimit: 512,
@@ -875,6 +897,38 @@ export const LIBRARY_CORE_QUERY_REGISTRY = {
     "materializes_full_collection",
     true,
   ),
+  library_facet_summary_v1: plannedQuery({
+    // Whole-corpus aggregate, no paging. Traced from the native reader and the
+    // shadow store: exact counts plus at most 4,096 tags of 1,024 bytes.
+    defaultLimit: 1,
+    maximumLimit: 1,
+    maximumRows: 1,
+    totalCountIntent: "exact",
+    rendererCache: true,
+    invalidationKeyIntent: ["feed-facets"],
+    currentKinds: [
+      "ProjectionReadSession::facet_summary",
+      "read_library_core_facet_summary",
+      "readLibraryFacetSummary",
+    ],
+    resolvedImplementationBlockers: ["runtime_adapter_unimplemented"],
+  }),
+  library_surface_items_v1: plannedQuery({
+    // Map and Story Wall candidate rows. Traced ceilings: 1,000 map items and
+    // 250 Story Wall items, selected by surface kind.
+    defaultLimit: 250,
+    maximumLimit: 1_000,
+    maximumRows: 1_000,
+    totalCountIntent: "none",
+    rendererCache: true,
+    invalidationKeyIntent: ["library-surface:{surface}"],
+    currentKinds: [
+      "ProjectionReadSession::surface_items",
+      "read_library_core_surface_items",
+      "readLibrarySurfaceItems",
+    ],
+    resolvedImplementationBlockers: ["runtime_adapter_unimplemented"],
+  }),
   map_markers_v1: plannedQuery({
     defaultLimit: 500,
     maximumLimit: 1_000,

--- a/packages/shared/src/library-core/registry.test.ts
+++ b/packages/shared/src/library-core/registry.test.ts
@@ -294,6 +294,9 @@ describe("Library Core query registry", () => {
       expect(definition.intendedAdapters.length).toBeGreaterThan(0);
       expect(definition.blockers.length).toBeGreaterThan(0);
       if (
+        definition === LIBRARY_CORE_QUERY_REGISTRY.background_item_page_v1 ||
+        definition === LIBRARY_CORE_QUERY_REGISTRY.library_facet_summary_v1 ||
+        definition === LIBRARY_CORE_QUERY_REGISTRY.library_surface_items_v1 ||
         definition === LIBRARY_CORE_QUERY_REGISTRY.feed_page_v1 ||
         definition === LIBRARY_CORE_QUERY_REGISTRY.item_detail_v1 ||
         definition === LIBRARY_CORE_QUERY_REGISTRY.feed_browse_page_v2 ||


### PR DESCRIPTION
(AI Generated).

## Summary
- (AI Generated).

I set out to close `feed_facets_v1`'s contract and found something worth more: **the Gate A census is missing three queries the native reader actually ships.**

| Query | What it is |
|---|---|
| `background_item_page_v1` | the bounded item scan behind `scanLibraryItems` |
| `library_facet_summary_v1` | whole-corpus facet aggregate |
| `library_surface_items_v1` | Map and Story Wall candidate rows |

All three are registered Tauri commands, wired through `App.tsx`, and called in production. The first one matters most: it is the scan primitive that search, content fetch, the Header signal counts, and the whole renderer-eviction story depend on. The census that gates activation did not know it existed.

**The deeper defect is that nothing enforced the census against the native reader**, which is why this went unnoticed. So this adds that check. `native-query-census.test.ts` extracts every `QUERY_ID` constant from the Rust sources by string literal — the same technique `docs/TESTING-STANDARD.md` describes for the provider-visible path list and the roadmap status file — and fails when one is not registered, naming the offenders. It also guards its own extraction: if the pattern ever stops matching, the suite fails rather than passing vacuously while enforcing nothing.

Each new entry carries bounds traced from the native reader (64-row scan pages under an 8 MiB-less-framing budget; 1,000 map and 250 Story Wall items; the facet aggregate's exact counts), and each clears `runtime_adapter_unimplemented` because the adapter demonstrably exists. Their six contract fields stay open for later slices — this PR fixes the inventory, not the contracts.

**One question for you, which I did not decide.** The registry still has planned `feed_facets_v1`, `map_markers_v1`, and `story_wall_candidates_v1` entries with different IDs and different shapes (paged, cursored) than the aggregates that actually shipped. They look like the planned designs these three superseded, but merging or retiring a query identity is a vocabulary decision, so I left them untouched.

Mutation-tested: unregistering each of the three fails the suite, and breaking the extraction regex fails it too.

No provider-visible path changed. Dormant registry work, merge-safe.

## Testing
- npm run validate:feature exit 0; shared library-core 218/218; census invariant mutation-tested 4/4 incl. vacuous-pass guard