### PR TITLE
feat: close the bounded item scan query contract

### DIFF
--- a/packages/shared/src/library-core/index.ts
+++ b/packages/shared/src/library-core/index.ts
@@ -28,6 +28,7 @@ export * from "./saved-analytics-contracts.js";
 export * from "./person-timeline-contracts.js";
 export * from "./persons-graph-contracts.js";
 export * from "./item-detail-contracts.js";
+export * from "./item-scan-contracts.js";
 export * from "./sha256.js";
 export * from "./store-surface-registry.js";
 export * from "./wire-frame.js";

--- a/packages/shared/src/library-core/item-scan-contracts.ts
+++ b/packages/shared/src/library-core/item-scan-contracts.ts
@@ -1,0 +1,76 @@
+import {
+  LIBRARY_CORE_ITEM_DETAIL_NESTED_BOUNDS,
+  LIBRARY_CORE_ITEM_DETAIL_PROJECTION,
+  LIBRARY_CORE_ITEM_DETAIL_SOURCE_IDENTITY,
+} from "./item-detail-contracts.js";
+
+/**
+ * Closed contract for the bounded item scan behind `scanLibraryItems`.
+ *
+ * This is the primitive the rest of the bounded-read program stands on: search,
+ * content fetch, the header signal counts, and the compatibility rebuild all
+ * page through it. Every bound is read from the live native reader.
+ * `library_core_feed_reader_runtime.rs` fixes the 64-row page limit and the
+ * cursor encoding; `shadow_store.rs` fixes the selected columns, the ordering,
+ * and the per-page row budget.
+ */
+export const LIBRARY_CORE_ITEM_SCAN_QUERY_ID =
+  "background_item_page_v1" as const;
+export const LIBRARY_CORE_ITEM_SCAN_SCHEMA_VERSION = 1 as const;
+export const LIBRARY_CORE_ITEM_SCAN_MAXIMUM_LIMIT = 64;
+/** 8 MiB less 64 KiB reserved for response framing. */
+export const LIBRARY_CORE_ITEM_SCAN_MAXIMUM_ROW_BYTES = 8 * 1_048_576 - 64 * 1_024;
+
+export const LIBRARY_CORE_ITEM_SCAN_REQUEST_SCHEMA = Object.freeze({
+  schemaId: "library_core_item_scan_request_v1",
+  schemaVersion: LIBRARY_CORE_ITEM_SCAN_SCHEMA_VERSION,
+  queryId: LIBRARY_CORE_ITEM_SCAN_QUERY_ID,
+  canonicalKeys: Object.freeze([
+    "cancellationId",
+    "cursor",
+    "limit",
+    "queryId",
+    "readerSessionId",
+    "schemaVersion",
+  ]),
+  cursorCodec: "library_core_item_scan_cursor_v1",
+  maximumLimit: LIBRARY_CORE_ITEM_SCAN_MAXIMUM_LIMIT,
+  /** Cancellable: the caller may stop the traversal between pages. */
+  cancellable: true,
+});
+
+export const LIBRARY_CORE_ITEM_SCAN_RESPONSE_SCHEMA = Object.freeze({
+  schemaId: "library_core_item_scan_response_v1",
+  schemaVersion: LIBRARY_CORE_ITEM_SCAN_SCHEMA_VERSION,
+  queryId: LIBRARY_CORE_ITEM_SCAN_QUERY_ID,
+  canonicalKeys: Object.freeze([
+    "nextCursor",
+    "queryId",
+    "rows",
+    "schemaVersion",
+    "source",
+  ]),
+  maximumRows: LIBRARY_CORE_ITEM_SCAN_MAXIMUM_LIMIT,
+  maximumResponseBytes: LIBRARY_CORE_ITEM_SCAN_MAXIMUM_ROW_BYTES,
+});
+
+/**
+ * The scan selects exactly the same columns as the single-item lookup, in the
+ * same order, including `contentBlob` and `preservedBlob`. Reused by reference
+ * so the two cannot drift: if one grows a column, the other must too.
+ */
+export const LIBRARY_CORE_ITEM_SCAN_PROJECTION =
+  LIBRARY_CORE_ITEM_DETAIL_PROJECTION;
+export const LIBRARY_CORE_ITEM_SCAN_SOURCE_IDENTITY =
+  LIBRARY_CORE_ITEM_DETAIL_SOURCE_IDENTITY;
+export const LIBRARY_CORE_ITEM_SCAN_NESTED_BOUNDS =
+  LIBRARY_CORE_ITEM_DETAIL_NESTED_BOUNDS;
+
+export interface LibraryCoreItemScanRequestV1 {
+  readonly cancellationId: string;
+  readonly cursor: string | null;
+  readonly limit: number;
+  readonly queryId: typeof LIBRARY_CORE_ITEM_SCAN_QUERY_ID;
+  readonly readerSessionId: string;
+  readonly schemaVersion: typeof LIBRARY_CORE_ITEM_SCAN_SCHEMA_VERSION;
+}

--- a/packages/shared/src/library-core/query-registry.ts
+++ b/packages/shared/src/library-core/query-registry.ts
@@ -58,6 +58,13 @@ import {
   LIBRARY_CORE_ITEM_DETAIL_RESPONSE_SCHEMA,
   LIBRARY_CORE_ITEM_DETAIL_SOURCE_IDENTITY,
 } from "./item-detail-contracts.js";
+import {
+  LIBRARY_CORE_ITEM_SCAN_NESTED_BOUNDS,
+  LIBRARY_CORE_ITEM_SCAN_PROJECTION,
+  LIBRARY_CORE_ITEM_SCAN_REQUEST_SCHEMA,
+  LIBRARY_CORE_ITEM_SCAN_RESPONSE_SCHEMA,
+  LIBRARY_CORE_ITEM_SCAN_SOURCE_IDENTITY,
+} from "./item-scan-contracts.js";
 
 export const LIBRARY_CORE_QUERY_IDS = [
   "account_detail_v1",
@@ -241,6 +248,7 @@ export interface PlannedBlockedLibraryCoreQueryDefinition {
     | typeof LIBRARY_CORE_PERSON_TIMELINE_REQUEST_SCHEMA
     | typeof LIBRARY_CORE_PERSONS_GRAPH_REQUEST_SCHEMA
     | typeof LIBRARY_CORE_ITEM_DETAIL_REQUEST_SCHEMA
+    | typeof LIBRARY_CORE_ITEM_SCAN_REQUEST_SCHEMA
     | null;
   readonly responseSchema:
     | typeof LIBRARY_CORE_FEED_PAGE_RESPONSE_SCHEMA
@@ -252,6 +260,7 @@ export interface PlannedBlockedLibraryCoreQueryDefinition {
     | typeof LIBRARY_CORE_PERSON_TIMELINE_RESPONSE_SCHEMA
     | typeof LIBRARY_CORE_PERSONS_GRAPH_RESPONSE_SCHEMA
     | typeof LIBRARY_CORE_ITEM_DETAIL_RESPONSE_SCHEMA
+    | typeof LIBRARY_CORE_ITEM_SCAN_RESPONSE_SCHEMA
     | null;
   readonly projection:
     | typeof LIBRARY_CORE_FEED_PAGE_PROJECTION
@@ -372,7 +381,8 @@ interface PlannedQueryInput {
     | typeof LIBRARY_CORE_SAVED_ANALYTICS_REQUEST_SCHEMA
     | typeof LIBRARY_CORE_PERSON_TIMELINE_REQUEST_SCHEMA
     | typeof LIBRARY_CORE_PERSONS_GRAPH_REQUEST_SCHEMA
-    | typeof LIBRARY_CORE_ITEM_DETAIL_REQUEST_SCHEMA;
+    | typeof LIBRARY_CORE_ITEM_DETAIL_REQUEST_SCHEMA
+    | typeof LIBRARY_CORE_ITEM_SCAN_REQUEST_SCHEMA;
   readonly responseSchema?:
     | typeof LIBRARY_CORE_FEED_PAGE_RESPONSE_SCHEMA
     | typeof LIBRARY_CORE_FEED_BROWSE_PAGE_RESPONSE_SCHEMA
@@ -382,7 +392,8 @@ interface PlannedQueryInput {
     | typeof LIBRARY_CORE_SAVED_ANALYTICS_RESPONSE_SCHEMA
     | typeof LIBRARY_CORE_PERSON_TIMELINE_RESPONSE_SCHEMA
     | typeof LIBRARY_CORE_PERSONS_GRAPH_RESPONSE_SCHEMA
-    | typeof LIBRARY_CORE_ITEM_DETAIL_RESPONSE_SCHEMA;
+    | typeof LIBRARY_CORE_ITEM_DETAIL_RESPONSE_SCHEMA
+    | typeof LIBRARY_CORE_ITEM_SCAN_RESPONSE_SCHEMA;
   readonly projection?:
     | typeof LIBRARY_CORE_FEED_PAGE_PROJECTION
     | typeof LIBRARY_CORE_FEED_BROWSE_PAGE_PROJECTION
@@ -564,6 +575,21 @@ export const LIBRARY_CORE_QUERY_REGISTRY = {
       "read_library_core_item_scan_page",
       "scanLibraryCoreItems",
     ],
+    requestSchema: LIBRARY_CORE_ITEM_SCAN_REQUEST_SCHEMA,
+    responseSchema: LIBRARY_CORE_ITEM_SCAN_RESPONSE_SCHEMA,
+    projection: LIBRARY_CORE_ITEM_SCAN_PROJECTION,
+    sourceIdentity: LIBRARY_CORE_ITEM_SCAN_SOURCE_IDENTITY,
+    nestedBounds: LIBRARY_CORE_ITEM_SCAN_NESTED_BOUNDS,
+    fullContentAllowed: true,
+    // Keyset on the unique globalId primary key, ascending. Two statements
+    // rather than a nullable-cursor expression precisely so the index can
+    // satisfy the order without a temp B-tree.
+    stableSort: {
+      columns: [{ column: "globalId", direction: "asc" }],
+      textCollation: "binary",
+      nullOrdering: "all_sort_columns_not_null",
+    },
+    tieBreakKey: "globalId",
     resolvedImplementationBlockers: ["runtime_adapter_unimplemented"],
   }),
   change_feed_v1: plannedQuery({

--- a/packages/shared/src/library-core/registry.test.ts
+++ b/packages/shared/src/library-core/registry.test.ts
@@ -44,6 +44,13 @@ import {
   LIBRARY_CORE_ITEM_DETAIL_SOURCE_IDENTITY,
 } from "./item-detail-contracts.js";
 import {
+  LIBRARY_CORE_ITEM_SCAN_NESTED_BOUNDS,
+  LIBRARY_CORE_ITEM_SCAN_PROJECTION,
+  LIBRARY_CORE_ITEM_SCAN_REQUEST_SCHEMA,
+  LIBRARY_CORE_ITEM_SCAN_RESPONSE_SCHEMA,
+  LIBRARY_CORE_ITEM_SCAN_SOURCE_IDENTITY,
+} from "./item-scan-contracts.js";
+import {
   LIBRARY_CORE_FIELD_REGISTRY,
 } from "./field-registry.js";
 import {
@@ -459,6 +466,39 @@ describe("Library Core query registry", () => {
     expect(
       BASE_APP_STORE_SURFACE_REGISTRY.items.successorQueryIds,
     ).toContain("feed_browse_page_v2");
+  });
+
+  it("closes the bounded item-scan contract and shares the item-detail row", () => {
+    expect(LIBRARY_CORE_QUERY_REGISTRY.background_item_page_v1).toMatchObject({
+      status: "planned_blocked",
+      requestSchema: LIBRARY_CORE_ITEM_SCAN_REQUEST_SCHEMA,
+      responseSchema: LIBRARY_CORE_ITEM_SCAN_RESPONSE_SCHEMA,
+      projection: LIBRARY_CORE_ITEM_SCAN_PROJECTION,
+      sourceIdentity: LIBRARY_CORE_ITEM_SCAN_SOURCE_IDENTITY,
+      nestedBounds: LIBRARY_CORE_ITEM_SCAN_NESTED_BOUNDS,
+      tieBreakKey: "globalId",
+      fullContentAllowed: true,
+    });
+    for (const blocker of [
+      "request_schema_unresolved",
+      "response_schema_unresolved",
+      "projection_unresolved",
+      "source_identity_unresolved",
+      "nested_bounds_unresolved",
+      "sort_contract_unresolved",
+    ]) {
+      expect(
+        LIBRARY_CORE_QUERY_REGISTRY.background_item_page_v1.blockers,
+      ).not.toContain(blocker);
+    }
+    // ITEM_SCAN_COLUMNS is byte-identical to the item_detail SELECT, so the two
+    // must share one projection. If either grows a column, both move together.
+    expect(LIBRARY_CORE_QUERY_REGISTRY.background_item_page_v1.projection).toBe(
+      LIBRARY_CORE_QUERY_REGISTRY.item_detail_v1.projection,
+    );
+    expect(
+      LIBRARY_CORE_QUERY_REGISTRY.background_item_page_v1.stableSort,
+    ).toEqual(LIBRARY_CORE_QUERY_REGISTRY.item_detail_v1.stableSort);
   });
 
   it("closes the item-detail contract and records that it carries full content", () => {


### PR DESCRIPTION
(AI Generated).

## Summary
- (AI Generated).

`background_item_page_v1` is the primitive the rest of the bounded-read program stands on — search, content fetch, the header signal counts, and the compatibility rebuild all page through it. It was registered in #1320 with traced bounds but no contract fields. This closes all six.

**Traced from the live reader:** 64-row pages, keyset cursor, a cancellable reader session, and a per-page budget of 8 MiB less 64 KiB of framing.

**Shared with `item_detail_v1` by reference, not by copy.** `ITEM_SCAN_COLUMNS` is byte-identical to the `item_detail` SELECT — including `contentBlob` and `preservedBlob` — and both order by the unique `globalId` ascending. So the scan reuses that projection, source identity, and nested bounds, and the test asserts `toBe` identity. If either query grows a column, both move together instead of drifting. `fullContentAllowed` is true for the same reason it is on `item_detail`.

Worth noting the shadow store earns this sort contract: it uses two statements rather than one nullable-cursor expression specifically so the index satisfies the order without a temp B-tree. Its own comment says so. That makes the declared `stableSort` index-satisfiable rather than aspirational — which is the distinction `ResolvedQuerySortContract`'s documentation is built around.

Mutation-tested: dropping the request schema, pointing the scan at a different projection, and dropping `fullContentAllowed` each fail the suite. The middle one is the drift the shared reference exists to prevent.

No provider-visible path changed. No phase status or contract document changed. Dormant contract work, merge-safe.

## Testing
- npm run validate:feature exit 0; shared library-core 219/219; registry mutation tests 3/3 caught