### PR TITLE
feat: close five surface items contract fields and pin the Map sort defect

### DIFF
--- a/packages/desktop/src-tauri/src/shadow_store.rs
+++ b/packages/desktop/src-tauri/src/shadow_store.rs
@@ -1924,6 +1924,47 @@ const FRIENDS_GRAPH_RSS_SQL: &str = "WITH requested AS (
        ON json_extract(f.rest, '$.rssSource.feedUrl') = r.feedUrl
      WHERE f.platform = 'rss' AND f.hidden IS NOT 1;";
 
+/// The surface predicate and page order, factored out so the query-plan test
+/// can explain exactly the SQL the reader runs.
+///
+/// The predicate uses json_type, json_extract, and GLOB, none of which an index
+/// can satisfy. The ORDER BY must still be answered by the timeline index or
+/// each open sorts the whole filtered corpus.
+fn surface_items_sql(surface: LibrarySurface) -> String {
+    let predicate = match surface {
+        LibrarySurface::Map => {
+            "json_type(rest, '$.location') = 'object'
+                   OR json_extract(contentBlob, '$.text') GLOB '*📍*'
+                   OR json_extract(contentBlob, '$.text') GLOB '*🌍*'
+                   OR json_extract(contentBlob, '$.text') GLOB '*🌎*'
+                   OR json_extract(contentBlob, '$.text') GLOB '*🌏*'
+                   OR json_extract(contentBlob, '$.text') GLOB 'in [A-Z]*'
+                   OR json_extract(contentBlob, '$.text') GLOB 'at [A-Z]*'
+                   OR json_extract(contentBlob, '$.text') GLOB 'from [A-Z]*'
+                   OR json_extract(contentBlob, '$.text') GLOB '* in [A-Z]*'
+                   OR json_extract(contentBlob, '$.text') GLOB '* at [A-Z]*'
+                   OR json_extract(contentBlob, '$.text') GLOB '* from [A-Z]*'
+            "
+        }
+        LibrarySurface::StoryWall => {
+            "hidden IS NOT 1
+                   AND archived IS NOT 1
+                   AND CASE
+                     WHEN json_valid(contentBlob)
+                     THEN json_type(contentBlob, '$.mediaUrls') = 'array'
+                      AND json_array_length(contentBlob, '$.mediaUrls') > 0
+                     ELSE 0
+                   END
+            "
+        }
+    };
+    format!(
+        "SELECT {ITEM_SCAN_COLUMNS} FROM feed_items
+         WHERE {predicate}
+         ORDER BY sortAt DESC, globalId ASC LIMIT ?1;"
+    )
+}
+
 fn person_timeline_page_sql(after: bool, use_friends_timeline_index: bool) -> StoreResult<String> {
     let base = if after {
         PAGE_AFTER_SQL
@@ -2976,38 +3017,7 @@ impl ShadowStore {
                 maximum,
             });
         }
-        let predicate = match surface {
-            LibrarySurface::Map => {
-                "json_type(rest, '$.location') = 'object'
-                   OR json_extract(contentBlob, '$.text') GLOB '*📍*'
-                   OR json_extract(contentBlob, '$.text') GLOB '*🌍*'
-                   OR json_extract(contentBlob, '$.text') GLOB '*🌎*'
-                   OR json_extract(contentBlob, '$.text') GLOB '*🌏*'
-                   OR json_extract(contentBlob, '$.text') GLOB 'in [A-Z]*'
-                   OR json_extract(contentBlob, '$.text') GLOB 'at [A-Z]*'
-                   OR json_extract(contentBlob, '$.text') GLOB 'from [A-Z]*'
-                   OR json_extract(contentBlob, '$.text') GLOB '* in [A-Z]*'
-                   OR json_extract(contentBlob, '$.text') GLOB '* at [A-Z]*'
-                   OR json_extract(contentBlob, '$.text') GLOB '* from [A-Z]*'
-                "
-            }
-            LibrarySurface::StoryWall => {
-                "hidden IS NOT 1
-                   AND archived IS NOT 1
-                   AND CASE
-                     WHEN json_valid(contentBlob)
-                     THEN json_type(contentBlob, '$.mediaUrls') = 'array'
-                      AND json_array_length(contentBlob, '$.mediaUrls') > 0
-                     ELSE 0
-                   END
-                "
-            }
-        };
-        let query = format!(
-            "SELECT {ITEM_SCAN_COLUMNS} FROM feed_items
-             WHERE {predicate}
-             ORDER BY sortAt DESC, globalId ASC LIMIT ?1;"
-        );
+        let query = surface_items_sql(surface);
         let tx = self.conn.unchecked_transaction()?;
         Self::require_readable_projection_in(&tx)?;
         let rows = {
@@ -5227,6 +5237,55 @@ mod tests {
                 "page must not sort, got: {plan}"
             );
         }
+    }
+
+    #[test]
+    fn surface_queries_order_through_the_index_except_the_known_map_defect() {
+        // Both surfaces filter with json_type, json_extract, and GLOB, none of
+        // which an index can satisfy. What matters is whether the ORDER BY is
+        // still answered by an index: if SQLite sorts instead, every open of
+        // that surface sorts the whole filtered corpus, and the page is bounded
+        // while the work behind it is not.
+        let store = seeded(500);
+
+        // Story Wall leads with `hidden IS NOT 1 AND archived IS NOT 1`, which
+        // matches the friends-timeline index prefix, so it walks that index in
+        // order and never sorts. This is the invariant.
+        let story_wall = explain_surface(&store, LibrarySurface::StoryWall);
+        assert!(
+            story_wall.contains("feed_items_friends_timeline"),
+            "Story Wall should read through the friends timeline index, got: {story_wall}"
+        );
+        assert!(
+            !story_wall.to_uppercase().contains("TEMP B-TREE"),
+            "Story Wall must not sort, got: {story_wall}"
+        );
+
+        // Map has no indexable leading term, so it scans and sorts. This
+        // characterizes a KNOWN DEFECT tracked in issue #1323, it does not
+        // bless it. Fixing that issue makes this assertion fail, which is the
+        // signal to replace it with the same no-sort assertion above.
+        let map = explain_surface(&store, LibrarySurface::Map);
+        assert!(
+            map.to_uppercase().contains("TEMP B-TREE"),
+            "Map is expected to still sort until issue #1323 lands. If this \
+             failed, the defect is fixed: assert the absence of TEMP B-TREE \
+             here instead. Got: {map}"
+        );
+    }
+
+    fn explain_surface(store: &ShadowStore, surface: LibrarySurface) -> String {
+        let explained = format!("EXPLAIN QUERY PLAN {}", surface_items_sql(surface));
+        let mut statement = store
+            .conn
+            .prepare(&explained)
+            .expect("prepare surface plan");
+        statement
+            .query_map(params![64u32], |row| row.get::<_, String>(3))
+            .expect("surface plan")
+            .collect::<SqlResult<Vec<_>>>()
+            .expect("surface plan rows")
+            .join(" | ")
     }
 
     #[test]

--- a/packages/shared/src/library-core/index.ts
+++ b/packages/shared/src/library-core/index.ts
@@ -29,6 +29,7 @@ export * from "./person-timeline-contracts.js";
 export * from "./persons-graph-contracts.js";
 export * from "./item-detail-contracts.js";
 export * from "./item-scan-contracts.js";
+export * from "./surface-items-contracts.js";
 export * from "./sha256.js";
 export * from "./store-surface-registry.js";
 export * from "./wire-frame.js";

--- a/packages/shared/src/library-core/query-registry.ts
+++ b/packages/shared/src/library-core/query-registry.ts
@@ -65,6 +65,13 @@ import {
   LIBRARY_CORE_ITEM_SCAN_RESPONSE_SCHEMA,
   LIBRARY_CORE_ITEM_SCAN_SOURCE_IDENTITY,
 } from "./item-scan-contracts.js";
+import {
+  LIBRARY_CORE_SURFACE_ITEMS_NESTED_BOUNDS,
+  LIBRARY_CORE_SURFACE_ITEMS_PROJECTION,
+  LIBRARY_CORE_SURFACE_ITEMS_REQUEST_SCHEMA,
+  LIBRARY_CORE_SURFACE_ITEMS_RESPONSE_SCHEMA,
+  LIBRARY_CORE_SURFACE_ITEMS_SOURCE_IDENTITY,
+} from "./surface-items-contracts.js";
 
 export const LIBRARY_CORE_QUERY_IDS = [
   "account_detail_v1",
@@ -249,6 +256,7 @@ export interface PlannedBlockedLibraryCoreQueryDefinition {
     | typeof LIBRARY_CORE_PERSONS_GRAPH_REQUEST_SCHEMA
     | typeof LIBRARY_CORE_ITEM_DETAIL_REQUEST_SCHEMA
     | typeof LIBRARY_CORE_ITEM_SCAN_REQUEST_SCHEMA
+    | typeof LIBRARY_CORE_SURFACE_ITEMS_REQUEST_SCHEMA
     | null;
   readonly responseSchema:
     | typeof LIBRARY_CORE_FEED_PAGE_RESPONSE_SCHEMA
@@ -261,6 +269,7 @@ export interface PlannedBlockedLibraryCoreQueryDefinition {
     | typeof LIBRARY_CORE_PERSONS_GRAPH_RESPONSE_SCHEMA
     | typeof LIBRARY_CORE_ITEM_DETAIL_RESPONSE_SCHEMA
     | typeof LIBRARY_CORE_ITEM_SCAN_RESPONSE_SCHEMA
+    | typeof LIBRARY_CORE_SURFACE_ITEMS_RESPONSE_SCHEMA
     | null;
   readonly projection:
     | typeof LIBRARY_CORE_FEED_PAGE_PROJECTION
@@ -382,7 +391,8 @@ interface PlannedQueryInput {
     | typeof LIBRARY_CORE_PERSON_TIMELINE_REQUEST_SCHEMA
     | typeof LIBRARY_CORE_PERSONS_GRAPH_REQUEST_SCHEMA
     | typeof LIBRARY_CORE_ITEM_DETAIL_REQUEST_SCHEMA
-    | typeof LIBRARY_CORE_ITEM_SCAN_REQUEST_SCHEMA;
+    | typeof LIBRARY_CORE_ITEM_SCAN_REQUEST_SCHEMA
+    | typeof LIBRARY_CORE_SURFACE_ITEMS_REQUEST_SCHEMA;
   readonly responseSchema?:
     | typeof LIBRARY_CORE_FEED_PAGE_RESPONSE_SCHEMA
     | typeof LIBRARY_CORE_FEED_BROWSE_PAGE_RESPONSE_SCHEMA
@@ -393,7 +403,8 @@ interface PlannedQueryInput {
     | typeof LIBRARY_CORE_PERSON_TIMELINE_RESPONSE_SCHEMA
     | typeof LIBRARY_CORE_PERSONS_GRAPH_RESPONSE_SCHEMA
     | typeof LIBRARY_CORE_ITEM_DETAIL_RESPONSE_SCHEMA
-    | typeof LIBRARY_CORE_ITEM_SCAN_RESPONSE_SCHEMA;
+    | typeof LIBRARY_CORE_ITEM_SCAN_RESPONSE_SCHEMA
+    | typeof LIBRARY_CORE_SURFACE_ITEMS_RESPONSE_SCHEMA;
   readonly projection?:
     | typeof LIBRARY_CORE_FEED_PAGE_PROJECTION
     | typeof LIBRARY_CORE_FEED_BROWSE_PAGE_PROJECTION
@@ -953,6 +964,18 @@ export const LIBRARY_CORE_QUERY_REGISTRY = {
       "read_library_core_surface_items",
       "readLibrarySurfaceItems",
     ],
+    requestSchema: LIBRARY_CORE_SURFACE_ITEMS_REQUEST_SCHEMA,
+    responseSchema: LIBRARY_CORE_SURFACE_ITEMS_RESPONSE_SCHEMA,
+    projection: LIBRARY_CORE_SURFACE_ITEMS_PROJECTION,
+    sourceIdentity: LIBRARY_CORE_SURFACE_ITEMS_SOURCE_IDENTITY,
+    nestedBounds: LIBRARY_CORE_SURFACE_ITEMS_NESTED_BOUNDS,
+    fullContentAllowed: true,
+    // stableSort and tieBreakKey stay null on purpose. Both surfaces read
+    // ORDER BY sortAt DESC, globalId ASC, but declaring a sort contract asserts
+    // the order is index-satisfiable and for the Map surface it is not:
+    // EXPLAIN QUERY PLAN answers it with USE TEMP B-TREE FOR ORDER BY. Tracked
+    // in issue #1323; the intended order is recorded in
+    // LIBRARY_CORE_SURFACE_ITEMS_INTENDED_ORDER.
     resolvedImplementationBlockers: ["runtime_adapter_unimplemented"],
   }),
   map_markers_v1: plannedQuery({

--- a/packages/shared/src/library-core/registry.test.ts
+++ b/packages/shared/src/library-core/registry.test.ts
@@ -51,6 +51,14 @@ import {
   LIBRARY_CORE_ITEM_SCAN_SOURCE_IDENTITY,
 } from "./item-scan-contracts.js";
 import {
+  LIBRARY_CORE_SURFACE_ITEMS_INTENDED_ORDER,
+  LIBRARY_CORE_SURFACE_ITEMS_NESTED_BOUNDS,
+  LIBRARY_CORE_SURFACE_ITEMS_PROJECTION,
+  LIBRARY_CORE_SURFACE_ITEMS_REQUEST_SCHEMA,
+  LIBRARY_CORE_SURFACE_ITEMS_RESPONSE_SCHEMA,
+  LIBRARY_CORE_SURFACE_ITEMS_SOURCE_IDENTITY,
+} from "./surface-items-contracts.js";
+import {
   LIBRARY_CORE_FIELD_REGISTRY,
 } from "./field-registry.js";
 import {
@@ -466,6 +474,44 @@ describe("Library Core query registry", () => {
     expect(
       BASE_APP_STORE_SURFACE_REGISTRY.items.successorQueryIds,
     ).toContain("feed_browse_page_v2");
+  });
+
+  it("closes five surface-items fields and blocks the sort on the Map defect", () => {
+    expect(LIBRARY_CORE_QUERY_REGISTRY.library_surface_items_v1).toMatchObject({
+      status: "planned_blocked",
+      requestSchema: LIBRARY_CORE_SURFACE_ITEMS_REQUEST_SCHEMA,
+      responseSchema: LIBRARY_CORE_SURFACE_ITEMS_RESPONSE_SCHEMA,
+      projection: LIBRARY_CORE_SURFACE_ITEMS_PROJECTION,
+      sourceIdentity: LIBRARY_CORE_SURFACE_ITEMS_SOURCE_IDENTITY,
+      nestedBounds: LIBRARY_CORE_SURFACE_ITEMS_NESTED_BOUNDS,
+      fullContentAllowed: true,
+    });
+    for (const blocker of [
+      "request_schema_unresolved",
+      "response_schema_unresolved",
+      "projection_unresolved",
+      "source_identity_unresolved",
+      "nested_bounds_unresolved",
+    ]) {
+      expect(
+        LIBRARY_CORE_QUERY_REGISTRY.library_surface_items_v1.blockers,
+      ).not.toContain(blocker);
+    }
+    // Same row as the item lookup and the bounded scan, shared by reference.
+    expect(
+      LIBRARY_CORE_QUERY_REGISTRY.library_surface_items_v1.projection,
+    ).toBe(LIBRARY_CORE_QUERY_REGISTRY.item_detail_v1.projection);
+    // A declared sort asserts index-satisfiability. The Map surface needs a
+    // temp B-tree, so the blocker stays open until issue #1323 lands.
+    expect(
+      LIBRARY_CORE_QUERY_REGISTRY.library_surface_items_v1.stableSort,
+    ).toBeNull();
+    expect(
+      LIBRARY_CORE_QUERY_REGISTRY.library_surface_items_v1.blockers,
+    ).toContain("sort_contract_unresolved");
+    expect(
+      LIBRARY_CORE_SURFACE_ITEMS_INTENDED_ORDER.indexSatisfiedBySurface,
+    ).toEqual({ map: false, story_wall: true });
   });
 
   it("closes the bounded item-scan contract and shares the item-detail row", () => {

--- a/packages/shared/src/library-core/surface-items-contracts.ts
+++ b/packages/shared/src/library-core/surface-items-contracts.ts
@@ -1,0 +1,108 @@
+import {
+  LIBRARY_CORE_ITEM_DETAIL_NESTED_BOUNDS,
+  LIBRARY_CORE_ITEM_DETAIL_PROJECTION,
+  LIBRARY_CORE_ITEM_DETAIL_SOURCE_IDENTITY,
+} from "./item-detail-contracts.js";
+
+/**
+ * Closed contract for the Map and Story Wall candidate reader.
+ *
+ * Every bound is read from the live native reader. `shadow_store.rs` fixes the
+ * per-surface ceilings and the selected columns; the surface predicate is
+ * evaluated inside SQLite so the renderer never receives non-candidates.
+ */
+export const LIBRARY_CORE_SURFACE_ITEMS_QUERY_ID =
+  "library_surface_items_v1" as const;
+export const LIBRARY_CORE_SURFACE_ITEMS_SCHEMA_VERSION = 1 as const;
+export const LIBRARY_CORE_SURFACE_ITEMS_MAXIMUM_MAP_ITEMS = 1_000;
+export const LIBRARY_CORE_SURFACE_ITEMS_MAXIMUM_STORY_WALL_ITEMS = 250;
+
+const LIBRARY_CORE_SURFACE_KINDS = Object.freeze([
+  "map",
+  "story_wall",
+] as const);
+
+export type LibraryCoreSurfaceKindV1 =
+  (typeof LIBRARY_CORE_SURFACE_KINDS)[number];
+
+export const LIBRARY_CORE_SURFACE_ITEMS_REQUEST_SCHEMA = Object.freeze({
+  schemaId: "library_core_surface_items_request_v1",
+  schemaVersion: LIBRARY_CORE_SURFACE_ITEMS_SCHEMA_VERSION,
+  queryId: LIBRARY_CORE_SURFACE_ITEMS_QUERY_ID,
+  canonicalKeys: Object.freeze([
+    "limit",
+    "queryId",
+    "schemaVersion",
+    "surface",
+  ]),
+  surfaceKinds: LIBRARY_CORE_SURFACE_KINDS,
+  /** The ceiling depends on which surface is asked for. */
+  maximumItemsBySurface: Object.freeze({
+    map: LIBRARY_CORE_SURFACE_ITEMS_MAXIMUM_MAP_ITEMS,
+    story_wall: LIBRARY_CORE_SURFACE_ITEMS_MAXIMUM_STORY_WALL_ITEMS,
+  }),
+});
+
+export const LIBRARY_CORE_SURFACE_ITEMS_RESPONSE_SCHEMA = Object.freeze({
+  schemaId: "library_core_surface_items_response_v1",
+  schemaVersion: LIBRARY_CORE_SURFACE_ITEMS_SCHEMA_VERSION,
+  queryId: LIBRARY_CORE_SURFACE_ITEMS_QUERY_ID,
+  canonicalKeys: Object.freeze([
+    "queryId",
+    "rows",
+    "schemaVersion",
+    "source",
+    "surface",
+  ]),
+  maximumRows: LIBRARY_CORE_SURFACE_ITEMS_MAXIMUM_MAP_ITEMS,
+});
+
+/**
+ * The surface reader selects the same columns as the single-item lookup and the
+ * bounded scan, including the content and preserved bodies. Reused by reference
+ * so the three cannot drift apart.
+ */
+export const LIBRARY_CORE_SURFACE_ITEMS_PROJECTION =
+  LIBRARY_CORE_ITEM_DETAIL_PROJECTION;
+export const LIBRARY_CORE_SURFACE_ITEMS_SOURCE_IDENTITY =
+  LIBRARY_CORE_ITEM_DETAIL_SOURCE_IDENTITY;
+export const LIBRARY_CORE_SURFACE_ITEMS_NESTED_BOUNDS =
+  LIBRARY_CORE_ITEM_DETAIL_NESTED_BOUNDS;
+
+/**
+ * Why this query keeps `sort_contract_unresolved`.
+ *
+ * Both surfaces read `ORDER BY sortAt DESC, globalId ASC`, but a declared sort
+ * contract asserts the order is index-satisfiable, and for one surface it is
+ * not. Verified with `EXPLAIN QUERY PLAN` against the real SQL:
+ *
+ *   Story Wall  SCAN feed_items USING INDEX feed_items_friends_timeline
+ *   Map         SCAN feed_items | USE TEMP B-TREE FOR ORDER BY
+ *
+ * Story Wall leads with `hidden IS NOT 1 AND archived IS NOT 1`, matching the
+ * index prefix, so it walks the index in order. Map's predicate is a pure OR
+ * chain of `json_type`, `json_extract`, and `GLOB` with no indexable leading
+ * term, so SQLite scans every row and sorts the matches.
+ *
+ * Declaring the order here would claim an index-satisfiable sort the store does
+ * not achieve for Map. The blocker stays open until issue #1323 lands a derived
+ * `hasLocation` column and a `(hasLocation, sortAt DESC, globalId ASC)` index.
+ * The intended order is recorded below so that work does not re-derive it.
+ */
+export const LIBRARY_CORE_SURFACE_ITEMS_INTENDED_ORDER = Object.freeze({
+  columns: Object.freeze([
+    Object.freeze({ column: "sortAt", direction: "desc" }),
+    Object.freeze({ column: "globalId", direction: "asc" }),
+  ]),
+  textCollation: "binary",
+  tieBreakKey: "globalId",
+  indexSatisfiedBySurface: Object.freeze({ map: false, story_wall: true }),
+  unresolvedReason: "map_surface_requires_temp_b_tree_see_issue_1323",
+});
+
+export interface LibraryCoreSurfaceItemsRequestV1 {
+  readonly limit: number;
+  readonly queryId: typeof LIBRARY_CORE_SURFACE_ITEMS_QUERY_ID;
+  readonly schemaVersion: typeof LIBRARY_CORE_SURFACE_ITEMS_SCHEMA_VERSION;
+  readonly surface: LibraryCoreSurfaceKindV1;
+}


### PR DESCRIPTION
(AI Generated).

## Summary
- (AI Generated).

Closes five of six fields on `library_surface_items_v1`. The sixth stays open, and finding out why turned up a live performance defect.

**Traced bounds:** 1,000 Map items, 250 Story Wall items, and the same selected columns as `item_detail_v1` and `background_item_page_v1` — so projection, source identity, and nested bounds are reused by reference, and the test asserts `toBe` identity.

**Why the sort stays blocked.** A declared `stableSort` asserts the order is index-satisfiable. Verified with `EXPLAIN QUERY PLAN` against the real SQL:

```
Story Wall  SCAN feed_items USING INDEX feed_items_friends_timeline
Map         SCAN feed_items | USE TEMP B-TREE FOR ORDER BY
```

Story Wall leads with `hidden IS NOT 1 AND archived IS NOT 1`, matching the index prefix, so it walks the index in order. Map's predicate is a pure `OR` chain of `json_type`, `json_extract`, and `GLOB` with no indexable leading term, so SQLite scans every row and sorts the matches — the page is bounded and the work behind it is not, on every open of the Map view. Filed as issue #1323; the fix is a derived `hasLocation` column plus a `(hasLocation, sortAt DESC, globalId ASC)` index, which is a schema decision and not made here.

**The Rust change is what made this checkable.** The query SQL was built inline, so no test could explain it. It is now extracted into `surface_items_sql`, mirroring the existing `person_timeline_page_sql`. The new test asserts Story Wall's no-sort invariant properly, and *characterizes* the Map plan with an explicit `#1323` reference — so landing the fix makes that assertion fail, which is the signal to replace it with the same no-sort assertion. It documents the defect rather than blessing it.

Mutation-tested: dropping the request schema fails, and **declaring the sort the Map surface cannot serve** fails — which is the shortcut this contract exists to prevent.

No provider-visible path changed. `cargo fmt` clean, native tests pass.

## Testing
- npm run validate:feature exit 0; shared library-core 220/220; cargo shadow_store surface plan test passes; registry mutation tests 2/2 caught