### PR TITLE
feat: close five facet summary contract fields and pin the tag collation

### DIFF
--- a/packages/shared/src/library-core/facet-summary-contracts.ts
+++ b/packages/shared/src/library-core/facet-summary-contracts.ts
@@ -1,0 +1,99 @@
+/**
+ * Closed contract for the whole-corpus facet summary.
+ *
+ * Every bound is read from the live native reader. `shadow_store.rs` fixes the
+ * 4,096 tag ceiling, the 1,024 byte tag ceiling, and the tag ordering;
+ * `library_core_feed_reader_runtime.rs` fixes the query identity.
+ */
+export const LIBRARY_CORE_FACET_SUMMARY_QUERY_ID =
+  "library_facet_summary_v1" as const;
+export const LIBRARY_CORE_FACET_SUMMARY_SCHEMA_VERSION = 1 as const;
+export const LIBRARY_CORE_FACET_SUMMARY_MAXIMUM_TAGS = 4_096;
+export const LIBRARY_CORE_FACET_SUMMARY_MAXIMUM_TAG_UTF8_BYTES = 1_024;
+
+export const LIBRARY_CORE_FACET_SUMMARY_REQUEST_SCHEMA = Object.freeze({
+  schemaId: "library_core_facet_summary_request_v1",
+  schemaVersion: LIBRARY_CORE_FACET_SUMMARY_SCHEMA_VERSION,
+  queryId: LIBRARY_CORE_FACET_SUMMARY_QUERY_ID,
+  /** No filter, no cursor, no limit: the aggregate covers the whole corpus. */
+  canonicalKeys: Object.freeze(["queryId", "schemaVersion"]),
+});
+
+export const LIBRARY_CORE_FACET_SUMMARY_RESPONSE_SCHEMA = Object.freeze({
+  schemaId: "library_core_facet_summary_response_v1",
+  schemaVersion: LIBRARY_CORE_FACET_SUMMARY_SCHEMA_VERSION,
+  queryId: LIBRARY_CORE_FACET_SUMMARY_QUERY_ID,
+  canonicalKeys: Object.freeze([
+    "queryId",
+    "schemaVersion",
+    "source",
+    "summary",
+  ]),
+  summaryKeys: Object.freeze([
+    "archivedCount",
+    "sampleItemCount",
+    "savedArchivedCount",
+    "savedCount",
+    "savedPlatformCount",
+    "tags",
+    "totalCount",
+  ]),
+  maximumTags: LIBRARY_CORE_FACET_SUMMARY_MAXIMUM_TAGS,
+});
+
+/**
+ * Counts, not rows. The aggregate is computed inside SQLite and the renderer
+ * never receives item rows, so no item projection applies.
+ */
+export const LIBRARY_CORE_FACET_SUMMARY_PROJECTION = Object.freeze({
+  projectionId: "library_core_facet_summary_v1",
+  sourceTable: "feed_items",
+  fullContentAllowed: false,
+  orderedColumns: Object.freeze(["tag"]),
+});
+
+export const LIBRARY_CORE_FACET_SUMMARY_SOURCE_IDENTITY = Object.freeze({
+  identityId: "library_core_projection_reader_source_v1",
+  generationId: "sha256_file_digest",
+  transitionSequence: "nonnegative_safe_integer",
+  projectionRevision: "nonnegative_safe_integer",
+  sessionPinned: true,
+});
+
+export const LIBRARY_CORE_FACET_SUMMARY_NESTED_BOUNDS = Object.freeze({
+  tags: Object.freeze({
+    maximumItems: LIBRARY_CORE_FACET_SUMMARY_MAXIMUM_TAGS,
+    maximumUnicodeScalarsPerItem:
+      LIBRARY_CORE_FACET_SUMMARY_MAXIMUM_TAG_UTF8_BYTES,
+    maximumUtf8BytesPerItem:
+      LIBRARY_CORE_FACET_SUMMARY_MAXIMUM_TAG_UTF8_BYTES,
+  }),
+});
+
+/**
+ * Why this query keeps `sort_contract_unresolved`.
+ *
+ * The tag list is sorted by **UTF-16 code units**, deliberately, so that Unicode
+ * tags keep parity with JavaScript's `Array.sort()`. The Rust comment at the
+ * sort site says exactly that. `ResolvedQuerySortContract.textCollation` admits
+ * only `"binary"`, meaning UTF-8 byte order, and the two orders disagree for
+ * characters outside the Basic Multilingual Plane: UTF-16 compares surrogate
+ * pairs in the U+E000..U+FFFF range as greater than astral characters, while
+ * UTF-8 byte order does not.
+ *
+ * Declaring `"binary"` here would misdescribe the order for any library holding
+ * an emoji or CJK-extension tag. The blocker stays open until the sort contract
+ * can express a UTF-16 collation. The real ordering is recorded below.
+ */
+export const LIBRARY_CORE_FACET_SUMMARY_TAG_ORDER = Object.freeze({
+  columns: Object.freeze(["tag"]),
+  direction: "asc",
+  textCollation: "utf16_code_unit",
+  reason: "product parity with JavaScript Array.sort()",
+  unresolvedReason: "sort_contract_admits_only_binary_collation",
+});
+
+export interface LibraryCoreFacetSummaryRequestV1 {
+  readonly queryId: typeof LIBRARY_CORE_FACET_SUMMARY_QUERY_ID;
+  readonly schemaVersion: typeof LIBRARY_CORE_FACET_SUMMARY_SCHEMA_VERSION;
+}

--- a/packages/shared/src/library-core/index.ts
+++ b/packages/shared/src/library-core/index.ts
@@ -30,6 +30,7 @@ export * from "./persons-graph-contracts.js";
 export * from "./item-detail-contracts.js";
 export * from "./item-scan-contracts.js";
 export * from "./surface-items-contracts.js";
+export * from "./facet-summary-contracts.js";
 export * from "./sha256.js";
 export * from "./store-surface-registry.js";
 export * from "./wire-frame.js";

--- a/packages/shared/src/library-core/query-registry.ts
+++ b/packages/shared/src/library-core/query-registry.ts
@@ -72,6 +72,13 @@ import {
   LIBRARY_CORE_SURFACE_ITEMS_RESPONSE_SCHEMA,
   LIBRARY_CORE_SURFACE_ITEMS_SOURCE_IDENTITY,
 } from "./surface-items-contracts.js";
+import {
+  LIBRARY_CORE_FACET_SUMMARY_NESTED_BOUNDS,
+  LIBRARY_CORE_FACET_SUMMARY_PROJECTION,
+  LIBRARY_CORE_FACET_SUMMARY_REQUEST_SCHEMA,
+  LIBRARY_CORE_FACET_SUMMARY_RESPONSE_SCHEMA,
+  LIBRARY_CORE_FACET_SUMMARY_SOURCE_IDENTITY,
+} from "./facet-summary-contracts.js";
 
 export const LIBRARY_CORE_QUERY_IDS = [
   "account_detail_v1",
@@ -257,6 +264,7 @@ export interface PlannedBlockedLibraryCoreQueryDefinition {
     | typeof LIBRARY_CORE_ITEM_DETAIL_REQUEST_SCHEMA
     | typeof LIBRARY_CORE_ITEM_SCAN_REQUEST_SCHEMA
     | typeof LIBRARY_CORE_SURFACE_ITEMS_REQUEST_SCHEMA
+    | typeof LIBRARY_CORE_FACET_SUMMARY_REQUEST_SCHEMA
     | null;
   readonly responseSchema:
     | typeof LIBRARY_CORE_FEED_PAGE_RESPONSE_SCHEMA
@@ -270,6 +278,7 @@ export interface PlannedBlockedLibraryCoreQueryDefinition {
     | typeof LIBRARY_CORE_ITEM_DETAIL_RESPONSE_SCHEMA
     | typeof LIBRARY_CORE_ITEM_SCAN_RESPONSE_SCHEMA
     | typeof LIBRARY_CORE_SURFACE_ITEMS_RESPONSE_SCHEMA
+    | typeof LIBRARY_CORE_FACET_SUMMARY_RESPONSE_SCHEMA
     | null;
   readonly projection:
     | typeof LIBRARY_CORE_FEED_PAGE_PROJECTION
@@ -277,18 +286,21 @@ export interface PlannedBlockedLibraryCoreQueryDefinition {
     | typeof LIBRARY_CORE_FEED_BROWSE_PAGE_V2_PROJECTION
     | typeof LIBRARY_CORE_SAVED_FEED_PAGE_PROJECTION
     | typeof LIBRARY_CORE_SAVED_ANALYTICS_PROJECTION
+    | typeof LIBRARY_CORE_FACET_SUMMARY_PROJECTION
     | typeof LIBRARY_CORE_PERSONS_GRAPH_PROJECTION
     | typeof LIBRARY_CORE_ITEM_DETAIL_PROJECTION
     | null;
   readonly sourceIdentity:
     | typeof LIBRARY_CORE_FEED_PAGE_SOURCE_IDENTITY
     | typeof LIBRARY_CORE_SAVED_ANALYTICS_SOURCE_IDENTITY
+    | typeof LIBRARY_CORE_FACET_SUMMARY_SOURCE_IDENTITY
     | typeof LIBRARY_CORE_PERSONS_GRAPH_SOURCE_IDENTITY
     | typeof LIBRARY_CORE_ITEM_DETAIL_SOURCE_IDENTITY
     | null;
   readonly nestedBounds:
     | typeof LIBRARY_CORE_FEED_PAGE_NESTED_BOUNDS
     | typeof LIBRARY_CORE_SAVED_ANALYTICS_NESTED_BOUNDS
+    | typeof LIBRARY_CORE_FACET_SUMMARY_NESTED_BOUNDS
     | typeof LIBRARY_CORE_PERSONS_GRAPH_NESTED_BOUNDS
     | typeof LIBRARY_CORE_ITEM_DETAIL_NESTED_BOUNDS
     | null;
@@ -392,7 +404,8 @@ interface PlannedQueryInput {
     | typeof LIBRARY_CORE_PERSONS_GRAPH_REQUEST_SCHEMA
     | typeof LIBRARY_CORE_ITEM_DETAIL_REQUEST_SCHEMA
     | typeof LIBRARY_CORE_ITEM_SCAN_REQUEST_SCHEMA
-    | typeof LIBRARY_CORE_SURFACE_ITEMS_REQUEST_SCHEMA;
+    | typeof LIBRARY_CORE_SURFACE_ITEMS_REQUEST_SCHEMA
+    | typeof LIBRARY_CORE_FACET_SUMMARY_REQUEST_SCHEMA;
   readonly responseSchema?:
     | typeof LIBRARY_CORE_FEED_PAGE_RESPONSE_SCHEMA
     | typeof LIBRARY_CORE_FEED_BROWSE_PAGE_RESPONSE_SCHEMA
@@ -404,7 +417,8 @@ interface PlannedQueryInput {
     | typeof LIBRARY_CORE_PERSONS_GRAPH_RESPONSE_SCHEMA
     | typeof LIBRARY_CORE_ITEM_DETAIL_RESPONSE_SCHEMA
     | typeof LIBRARY_CORE_ITEM_SCAN_RESPONSE_SCHEMA
-    | typeof LIBRARY_CORE_SURFACE_ITEMS_RESPONSE_SCHEMA;
+    | typeof LIBRARY_CORE_SURFACE_ITEMS_RESPONSE_SCHEMA
+    | typeof LIBRARY_CORE_FACET_SUMMARY_RESPONSE_SCHEMA;
   readonly projection?:
     | typeof LIBRARY_CORE_FEED_PAGE_PROJECTION
     | typeof LIBRARY_CORE_FEED_BROWSE_PAGE_PROJECTION
@@ -412,17 +426,20 @@ interface PlannedQueryInput {
     | typeof LIBRARY_CORE_SAVED_FEED_PAGE_PROJECTION
     | typeof LIBRARY_CORE_SAVED_ANALYTICS_PROJECTION
     | typeof LIBRARY_CORE_PERSONS_GRAPH_PROJECTION
-    | typeof LIBRARY_CORE_ITEM_DETAIL_PROJECTION;
+    | typeof LIBRARY_CORE_ITEM_DETAIL_PROJECTION
+    | typeof LIBRARY_CORE_FACET_SUMMARY_PROJECTION;
   readonly sourceIdentity?:
     | typeof LIBRARY_CORE_FEED_PAGE_SOURCE_IDENTITY
     | typeof LIBRARY_CORE_SAVED_ANALYTICS_SOURCE_IDENTITY
     | typeof LIBRARY_CORE_PERSONS_GRAPH_SOURCE_IDENTITY
-    | typeof LIBRARY_CORE_ITEM_DETAIL_SOURCE_IDENTITY;
+    | typeof LIBRARY_CORE_ITEM_DETAIL_SOURCE_IDENTITY
+    | typeof LIBRARY_CORE_FACET_SUMMARY_SOURCE_IDENTITY;
   readonly nestedBounds?:
     | typeof LIBRARY_CORE_FEED_PAGE_NESTED_BOUNDS
     | typeof LIBRARY_CORE_SAVED_ANALYTICS_NESTED_BOUNDS
     | typeof LIBRARY_CORE_PERSONS_GRAPH_NESTED_BOUNDS
-    | typeof LIBRARY_CORE_ITEM_DETAIL_NESTED_BOUNDS;
+    | typeof LIBRARY_CORE_ITEM_DETAIL_NESTED_BOUNDS
+    | typeof LIBRARY_CORE_FACET_SUMMARY_NESTED_BOUNDS;
   /**
    * Supplying both clears `sort_contract_unresolved` for this query. They move
    * together on purpose: an ordering without a tie-break is not stable, and a
@@ -948,6 +965,17 @@ export const LIBRARY_CORE_QUERY_REGISTRY = {
       "read_library_core_facet_summary",
       "readLibraryFacetSummary",
     ],
+    requestSchema: LIBRARY_CORE_FACET_SUMMARY_REQUEST_SCHEMA,
+    responseSchema: LIBRARY_CORE_FACET_SUMMARY_RESPONSE_SCHEMA,
+    projection: LIBRARY_CORE_FACET_SUMMARY_PROJECTION,
+    sourceIdentity: LIBRARY_CORE_FACET_SUMMARY_SOURCE_IDENTITY,
+    nestedBounds: LIBRARY_CORE_FACET_SUMMARY_NESTED_BOUNDS,
+    // stableSort and tieBreakKey stay null on purpose. Tags are sorted by
+    // UTF-16 code units for parity with JavaScript Array.sort(), and
+    // ResolvedQuerySortContract admits only binary UTF-8 collation. The two
+    // disagree outside the Basic Multilingual Plane, so declaring "binary"
+    // would misdescribe any library holding an emoji or CJK-extension tag.
+    // The real ordering is in LIBRARY_CORE_FACET_SUMMARY_TAG_ORDER.
     resolvedImplementationBlockers: ["runtime_adapter_unimplemented"],
   }),
   library_surface_items_v1: plannedQuery({

--- a/packages/shared/src/library-core/registry.test.ts
+++ b/packages/shared/src/library-core/registry.test.ts
@@ -59,6 +59,14 @@ import {
   LIBRARY_CORE_SURFACE_ITEMS_SOURCE_IDENTITY,
 } from "./surface-items-contracts.js";
 import {
+  LIBRARY_CORE_FACET_SUMMARY_NESTED_BOUNDS,
+  LIBRARY_CORE_FACET_SUMMARY_PROJECTION,
+  LIBRARY_CORE_FACET_SUMMARY_REQUEST_SCHEMA,
+  LIBRARY_CORE_FACET_SUMMARY_RESPONSE_SCHEMA,
+  LIBRARY_CORE_FACET_SUMMARY_SOURCE_IDENTITY,
+  LIBRARY_CORE_FACET_SUMMARY_TAG_ORDER,
+} from "./facet-summary-contracts.js";
+import {
   LIBRARY_CORE_FIELD_REGISTRY,
 } from "./field-registry.js";
 import {
@@ -474,6 +482,40 @@ describe("Library Core query registry", () => {
     expect(
       BASE_APP_STORE_SURFACE_REGISTRY.items.successorQueryIds,
     ).toContain("feed_browse_page_v2");
+  });
+
+  it("closes five facet-summary fields and blocks the sort on UTF-16 collation", () => {
+    expect(LIBRARY_CORE_QUERY_REGISTRY.library_facet_summary_v1).toMatchObject({
+      status: "planned_blocked",
+      requestSchema: LIBRARY_CORE_FACET_SUMMARY_REQUEST_SCHEMA,
+      responseSchema: LIBRARY_CORE_FACET_SUMMARY_RESPONSE_SCHEMA,
+      projection: LIBRARY_CORE_FACET_SUMMARY_PROJECTION,
+      sourceIdentity: LIBRARY_CORE_FACET_SUMMARY_SOURCE_IDENTITY,
+      nestedBounds: LIBRARY_CORE_FACET_SUMMARY_NESTED_BOUNDS,
+    });
+    for (const blocker of [
+      "request_schema_unresolved",
+      "response_schema_unresolved",
+      "projection_unresolved",
+      "source_identity_unresolved",
+      "nested_bounds_unresolved",
+    ]) {
+      expect(
+        LIBRARY_CORE_QUERY_REGISTRY.library_facet_summary_v1.blockers,
+      ).not.toContain(blocker);
+    }
+    // Tags sort by UTF-16 code units for JavaScript parity. The contract type
+    // admits only binary UTF-8 collation, and the two disagree outside the BMP,
+    // so declaring one would misdescribe the order rather than record it.
+    expect(
+      LIBRARY_CORE_QUERY_REGISTRY.library_facet_summary_v1.stableSort,
+    ).toBeNull();
+    expect(
+      LIBRARY_CORE_QUERY_REGISTRY.library_facet_summary_v1.blockers,
+    ).toContain("sort_contract_unresolved");
+    expect(LIBRARY_CORE_FACET_SUMMARY_TAG_ORDER.textCollation).toBe(
+      "utf16_code_unit",
+    );
   });
 
   it("closes five surface-items fields and blocks the sort on the Map defect", () => {


### PR DESCRIPTION
(AI Generated).

## Summary
- (AI Generated).

Closes five of six fields on `library_facet_summary_v1`. The sixth stays open for a reason distinct from the two before it.

**Traced bounds:** a whole-corpus aggregate with no filter, cursor, or limit; at most 4,096 tags of 1,024 bytes each; counts computed inside SQLite so the renderer never receives item rows.

**Why the sort stays blocked.** Tags are sorted by **UTF-16 code units**, deliberately — the Rust comment at the sort site says it is to keep Unicode tags at parity with JavaScript's `Array.sort()`. `ResolvedQuerySortContract.textCollation` admits only `"binary"`, meaning UTF-8 byte order. Those two disagree outside the Basic Multilingual Plane: UTF-16 compares surrogate pairs such that U+E000..U+FFFF sort above astral characters, and UTF-8 byte order does not. Declaring `"binary"` would misdescribe the order for any library holding an emoji or CJK-extension tag, so the blocker stays and the real collation is recorded in `LIBRARY_CORE_FACET_SUMMARY_TAG_ORDER`.

**This is the third query the sort type cannot honestly describe, each for a different reason:**

| Query | Why the type cannot express it |
|---|---|
| `persons_graph_v1` | two independently keyed series in one response |
| `library_surface_items_v1` | order is not index-satisfiable for the Map surface (#1323) |
| `library_facet_summary_v1` | collation is UTF-16 code units, not binary UTF-8 |

Three distinct failure modes in one type is a signal the type wants revisiting rather than each query needing an exception. That is a schema decision, so it is surfaced here rather than made.

Mutation-tested: dropping the request schema fails, and **declaring binary collation the store does not use** fails.

No provider-visible path changed. Dormant contract work, merge-safe.

## Testing
- npm run validate:feature exit 0; shared library-core 221/221; registry mutation tests 2/2 caught