### PR TITLE
feat: close written-leaf inventories for saved and archived operations

### DIFF
--- a/packages/shared/src/library-core/index.ts
+++ b/packages/shared/src/library-core/index.ts
@@ -18,6 +18,7 @@ export * from "./operation-envelope-contracts.js";
 export * from "./operation-envelope-finalization.js";
 export * from "./operation-envelope-verification.js";
 export * from "./operation-payload-contracts.js";
+export * from "./operation-touched-fields.js";
 export * from "./operation-transaction-contracts.js";
 export * from "./portable-checkpoint-contracts.js";
 export * from "./protocol-registry.js";

--- a/packages/shared/src/library-core/operation-registry.ts
+++ b/packages/shared/src/library-core/operation-registry.ts
@@ -9,6 +9,10 @@ import {
   type LibraryCoreOperationPayloadSchema,
 } from "./operation-payload-contracts.js";
 import {
+  FEED_ITEM_ARCHIVE_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS,
+  FEED_ITEM_SAVED_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS,
+} from "./operation-touched-fields.js";
+import {
   FEED_ITEM_READ_ASSIGNMENT_TRANSACTION_MEMBER_SCHEMA,
   type LibraryCoreTransactionMemberSchemaDescriptor,
 } from "./operation-envelope-contracts.js";
@@ -123,6 +127,11 @@ export interface LibraryCoreOperationDefinition {
   > | null;
   /** Exact entity-key syntax only. This does not prove the entity exists. */
   readonly entityIdCodec: LibraryCoreEntityIdCodec | null;
+  /**
+   * Every synchronized leaf this operation may write on any code path, sorted
+   * and unique. Leaves it only reads as a precondition are excluded. A closed
+   * inventory says what changes, not how concurrent changes converge.
+   */
   readonly touchedFieldRegistryKeys: readonly string[] | null;
   readonly fieldAlgebra:
     | LibraryCoreOperationFieldAlgebraContract<unknown>
@@ -276,6 +285,9 @@ export const LIBRARY_CORE_OPERATION_REGISTRY = {
   }),
   feed_item_archive_assignment: localUserOperation({
     entityType: "FeedItem",
+    entityIdCodec: LIBRARY_CORE_ENTITY_ID_CODEC_V1,
+    touchedFieldRegistryKeys:
+      FEED_ITEM_ARCHIVE_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS,
     candidateStoreSurfaces: ["toggleArchived"],
     legacyWorkerRequests: ["TOGGLE_ARCHIVED"],
   }),
@@ -332,6 +344,9 @@ export const LIBRARY_CORE_OPERATION_REGISTRY = {
   }),
   feed_item_saved_assignment: localUserOperation({
     entityType: "FeedItem",
+    entityIdCodec: LIBRARY_CORE_ENTITY_ID_CODEC_V1,
+    touchedFieldRegistryKeys:
+      FEED_ITEM_SAVED_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS,
     candidateStoreSurfaces: ["toggleSaved"],
     legacyWorkerRequests: ["TOGGLE_SAVED"],
   }),

--- a/packages/shared/src/library-core/operation-touched-fields.ts
+++ b/packages/shared/src/library-core/operation-touched-fields.ts
@@ -1,0 +1,78 @@
+/**
+ * Written-leaf inventories for candidate successor operations.
+ *
+ * A `touchedFieldRegistryKeys` entry lists every synchronized leaf the
+ * operation may **write** on any code path, as a sorted unique set. Leaves the
+ * operation only reads as a precondition are documented here in prose but are
+ * deliberately excluded from the written set, because a precondition read and a
+ * write have different replication consequences and collapsing them would hide
+ * that difference.
+ *
+ * Every key below is traced from the legacy mutator the operation is a
+ * candidate successor for. Nothing here declares merge algebra, payload syntax,
+ * or write authority.
+ */
+
+export const LIBRARY_CORE_FEED_ITEM_ARCHIVED_FIELD_REGISTRY_KEY =
+  "library-core-v1:feedItems.{globalId}.userState.archived";
+
+export const LIBRARY_CORE_FEED_ITEM_ARCHIVED_AT_FIELD_REGISTRY_KEY =
+  "library-core-v1:feedItems.{globalId}.userState.archivedAt";
+
+export const LIBRARY_CORE_FEED_ITEM_SAVED_FIELD_REGISTRY_KEY =
+  "library-core-v1:feedItems.{globalId}.userState.saved";
+
+export const LIBRARY_CORE_FEED_ITEM_SAVED_AT_FIELD_REGISTRY_KEY =
+  "library-core-v1:feedItems.{globalId}.userState.savedAt";
+
+/**
+ * Traced from `toggleArchived` in `packages/shared/src/schema.ts`.
+ *
+ * Archiving writes `archived` on every unguarded path and either sets or
+ * deletes `archivedAt` alongside it. It additionally **reads** `saved` as a
+ * precondition and returns without writing anything when the item is saved, so
+ * the archive path observes saved state without owning it.
+ */
+export const FEED_ITEM_ARCHIVE_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS =
+  Object.freeze([
+    LIBRARY_CORE_FEED_ITEM_ARCHIVED_FIELD_REGISTRY_KEY,
+    LIBRARY_CORE_FEED_ITEM_ARCHIVED_AT_FIELD_REGISTRY_KEY,
+  ]);
+
+/**
+ * Traced from `toggleSaved` in `packages/shared/src/schema.ts`.
+ *
+ * Saving writes `saved` on every path and sets or deletes `savedAt` alongside
+ * it. On the save path it also clears archive state, writing `archived` and
+ * deleting `archivedAt`, so a saved item can never also be archived. The
+ * archive leaves belong in this written set because this operation really does
+ * write them rather than merely observe them.
+ */
+export const FEED_ITEM_SAVED_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS =
+  Object.freeze([
+    LIBRARY_CORE_FEED_ITEM_ARCHIVED_FIELD_REGISTRY_KEY,
+    LIBRARY_CORE_FEED_ITEM_ARCHIVED_AT_FIELD_REGISTRY_KEY,
+    LIBRARY_CORE_FEED_ITEM_SAVED_FIELD_REGISTRY_KEY,
+    LIBRARY_CORE_FEED_ITEM_SAVED_AT_FIELD_REGISTRY_KEY,
+  ]);
+
+/**
+ * Why saved and archived still carry `field_algebra_unresolved`.
+ *
+ * `toggleSaved` and `toggleArchived` jointly maintain the invariant that an
+ * item is never both saved and archived: saving clears archive state, and
+ * archiving refuses to run on a saved item. Independent per-leaf merge algebras
+ * cannot preserve that. Two actors converging a save against an archive under
+ * any per-leaf rule can land on `saved && archived`, the exact state both
+ * mutators exist to prevent.
+ *
+ * `LibraryCoreOperationDefinition.fieldAlgebra` holds a single
+ * `LibraryCoreOperationFieldAlgebraContract`, which merges one leaf against one
+ * leaf. It cannot express a rule spanning two leaves, so declaring anything for
+ * these operations would claim convergence the type cannot deliver. Both stay
+ * null and both keep the blocker until the coupled rule is designed.
+ *
+ * See https://github.com/freed-project/freed/issues/1327.
+ */
+export const FEED_ITEM_SAVED_ARCHIVED_EXCLUSION_INVARIANT =
+  "an item is never simultaneously saved and archived" as const;

--- a/packages/shared/src/library-core/registry.test.ts
+++ b/packages/shared/src/library-core/registry.test.ts
@@ -72,6 +72,7 @@ import {
 import {
   FEED_ITEM_READ_ASSIGNMENT_TRANSACTION_MEMBER_SCHEMA,
 } from "./operation-envelope-contracts.js";
+import { FEED_ITEM_READ_ASSIGNMENT_PAYLOAD_SCHEMA } from "./operation-payload-contracts.js";
 import {
   FEED_ITEM_READ_AT_FIELD_ALGEBRA,
   LIBRARY_CORE_FEED_ITEM_READ_AT_FIELD_REGISTRY_KEY,
@@ -81,7 +82,19 @@ import {
   LIBRARY_CORE_MAX_TRANSACTION_MEMBERS,
   LIBRARY_CORE_OPERATION_IDS,
   LIBRARY_CORE_OPERATION_REGISTRY,
+  type LibraryCoreOperationBlocker,
+  type LibraryCoreOperationDefinition,
+  type LibraryCoreOperationId,
 } from "./operation-registry.js";
+import {
+  FEED_ITEM_ARCHIVE_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS,
+  FEED_ITEM_SAVED_ARCHIVED_EXCLUSION_INVARIANT,
+  FEED_ITEM_SAVED_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS,
+  LIBRARY_CORE_FEED_ITEM_ARCHIVED_AT_FIELD_REGISTRY_KEY,
+  LIBRARY_CORE_FEED_ITEM_ARCHIVED_FIELD_REGISTRY_KEY,
+  LIBRARY_CORE_FEED_ITEM_SAVED_AT_FIELD_REGISTRY_KEY,
+  LIBRARY_CORE_FEED_ITEM_SAVED_FIELD_REGISTRY_KEY,
+} from "./operation-touched-fields.js";
 import { LIBRARY_CORE_ENTITY_ID_CODEC_V1 } from "./protocol-scalars.js";
 import {
   LIBRARY_CORE_INTERACTIVE_SNAPSHOT_POOL,
@@ -90,6 +103,66 @@ import {
   LIBRARY_CORE_RENDERER_CACHE_POOL,
 } from "./query-registry.js";
 import { BASE_APP_STORE_SURFACE_REGISTRY } from "./store-surface-registry.js";
+
+const compareCodeUnits = (left: string, right: string): number =>
+  left < right ? -1 : left > right ? 1 : 0;
+
+type ClosedOperationContract = Partial<
+  Pick<
+    LibraryCoreOperationDefinition,
+    | "entityIdCodec"
+    | "fieldAlgebra"
+    | "payloadSchema"
+    | "touchedFieldRegistryKeys"
+    | "transactionMemberSchema"
+  >
+>;
+
+const OPERATION_CONTRACT_BLOCKERS = [
+  ["entityIdCodec", "entity_id_schema_unresolved"],
+  ["fieldAlgebra", "field_algebra_unresolved"],
+  ["payloadSchema", "payload_schema_unresolved"],
+  ["touchedFieldRegistryKeys", "touched_fields_unresolved"],
+  ["transactionMemberSchema", "transaction_member_schema_unresolved"],
+] as const satisfies readonly (readonly [
+  keyof ClosedOperationContract,
+  LibraryCoreOperationBlocker,
+])[];
+
+/**
+ * The only contract fields any operation is allowed to have closed.
+ *
+ * Anything absent here must be null in the registry and must still carry its
+ * blocker. Adding an entry is a claim that the value was traced from a real
+ * implementation, so each one names where it came from.
+ */
+const CLOSED_OPERATION_CONTRACTS: Partial<
+  Record<LibraryCoreOperationId, ClosedOperationContract>
+> = {
+  // Traced from `markAsRead`, which writes exactly one leaf and reads none.
+  feed_item_read_assignment: {
+    entityIdCodec: LIBRARY_CORE_ENTITY_ID_CODEC_V1,
+    fieldAlgebra: FEED_ITEM_READ_AT_FIELD_ALGEBRA,
+    payloadSchema: FEED_ITEM_READ_ASSIGNMENT_PAYLOAD_SCHEMA,
+    touchedFieldRegistryKeys: [LIBRARY_CORE_FEED_ITEM_READ_AT_FIELD_REGISTRY_KEY],
+    transactionMemberSchema: FEED_ITEM_READ_ASSIGNMENT_TRANSACTION_MEMBER_SCHEMA,
+  },
+  // Traced from `toggleArchived`. Algebra stays open: archive and save are
+  // coupled by an exclusion invariant no single-leaf contract can express.
+  // https://github.com/freed-project/freed/issues/1327
+  feed_item_archive_assignment: {
+    entityIdCodec: LIBRARY_CORE_ENTITY_ID_CODEC_V1,
+    touchedFieldRegistryKeys:
+      FEED_ITEM_ARCHIVE_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS,
+  },
+  // Traced from `toggleSaved`, which also writes both archive leaves.
+  // https://github.com/freed-project/freed/issues/1327
+  feed_item_saved_assignment: {
+    entityIdCodec: LIBRARY_CORE_ENTITY_ID_CODEC_V1,
+    touchedFieldRegistryKeys:
+      FEED_ITEM_SAVED_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS,
+  },
+};
 
 describe("Library Core operation registry", () => {
   it("has one stable, sorted definition for every dormant operation ID", () => {
@@ -105,54 +178,31 @@ describe("Library Core operation registry", () => {
   });
 
   it("does not claim unresolved algebra, materializers, or authority", () => {
-    for (const [operationId, definition] of Object.entries(
-      LIBRARY_CORE_OPERATION_REGISTRY,
-    )) {
+    for (const operationId of LIBRARY_CORE_OPERATION_IDS) {
+      const definition = LIBRARY_CORE_OPERATION_REGISTRY[operationId];
       expect(definition.status).toBe("planned_blocked");
-      if (operationId === "feed_item_read_assignment") {
-        expect(definition.payloadSchema).toMatchObject({
-          schemaId: "feed_item_read_assignment_payload_v1",
-          schemaVersion: 1,
-          operationType: "feed_item_read_assignment",
-          canonicalKeys: ["read_at_ms"],
-        });
-        expect(definition.blockers).not.toContain("payload_schema_unresolved");
-        expect(definition.entityIdCodec).toBe(
-          LIBRARY_CORE_ENTITY_ID_CODEC_V1,
-        );
-        expect(definition.blockers).not.toContain(
-          "entity_id_schema_unresolved",
-        );
-        expect(definition.touchedFieldRegistryKeys).toStrictEqual([
-          LIBRARY_CORE_FEED_ITEM_READ_AT_FIELD_REGISTRY_KEY,
-        ]);
-        expect(definition.blockers).not.toContain("touched_fields_unresolved");
-        expect(definition.fieldAlgebra).toBe(
-          FEED_ITEM_READ_AT_FIELD_ALGEBRA,
-        );
-        expect(definition.blockers).not.toContain("field_algebra_unresolved");
-        expect(definition.transactionMemberSchema).toBe(
-          FEED_ITEM_READ_ASSIGNMENT_TRANSACTION_MEMBER_SCHEMA,
-        );
-        expect(definition.blockers).not.toContain(
-          "transaction_member_schema_unresolved",
-        );
-      } else {
-        expect(definition.payloadSchema).toBeNull();
-        expect(definition.blockers).toContain("payload_schema_unresolved");
-        expect(definition.entityIdCodec).toBeNull();
-        expect(definition.blockers).toContain(
-          "entity_id_schema_unresolved",
-        );
-        expect(definition.touchedFieldRegistryKeys).toBeNull();
-        expect(definition.blockers).toContain("touched_fields_unresolved");
-        expect(definition.fieldAlgebra).toBeNull();
-        expect(definition.blockers).toContain("field_algebra_unresolved");
-        expect(definition.transactionMemberSchema).toBeNull();
-        expect(definition.blockers).toContain(
-          "transaction_member_schema_unresolved",
-        );
+
+      // Every contract field carries its own blocker, and the blocker is
+      // present exactly when the field is null. Deriving both sides from the
+      // same table means a declaration cannot be added without dropping its
+      // blocker, and a blocker cannot be dropped without a declaration.
+      const closed = CLOSED_OPERATION_CONTRACTS[operationId] ?? {};
+      for (const [field, blocker] of OPERATION_CONTRACT_BLOCKERS) {
+        const declared = closed[field];
+        if (declared === undefined) {
+          expect(definition[field]).toBeNull();
+          expect(definition.blockers).toContain(blocker);
+        } else if (Array.isArray(declared)) {
+          expect(definition[field]).toStrictEqual(declared);
+          expect(definition.blockers).not.toContain(blocker);
+        } else {
+          // Shared contract objects are asserted by reference so a copy
+          // cannot silently drift away from the one the protocol uses.
+          expect(definition[field]).toBe(declared);
+          expect(definition.blockers).not.toContain(blocker);
+        }
       }
+
       expect(definition.materializer).toBeNull();
       expect(definition.frozenBulkContract).toBeNull();
       expect(definition.blockers.length).toBeGreaterThan(0);
@@ -179,6 +229,79 @@ describe("Library Core operation registry", () => {
         blockers: expect.not.arrayContaining(["merge_algebra_undecided"]),
       },
     });
+  });
+
+  it("binds every declared touched field to a real synchronized leaf", () => {
+    const knownLeaves = new Set(
+      LIBRARY_CORE_FIELD_REGISTRY.map((entry) => entry.registryKey),
+    );
+    // Guard the guard: an empty or tiny registry would make this vacuous.
+    expect(knownLeaves.size).toBeGreaterThan(100);
+
+    let declaredOperations = 0;
+    for (const operationId of LIBRARY_CORE_OPERATION_IDS) {
+      const keys =
+        LIBRARY_CORE_OPERATION_REGISTRY[operationId].touchedFieldRegistryKeys;
+      if (keys === null) continue;
+      declaredOperations += 1;
+
+      // A touched-field list is an inventory of real leaves. Without this a
+      // typo, a renamed field, or an invented path would pass silently and
+      // read as closed coverage it does not have.
+      expect(keys.length).toBeGreaterThan(0);
+      for (const key of keys) {
+        expect({ operationId, key, isKnownLeaf: knownLeaves.has(key) })
+          .toStrictEqual({ operationId, key, isKnownLeaf: true });
+      }
+      expect([...keys]).toStrictEqual([...keys].sort(compareCodeUnits));
+      expect(new Set(keys).size).toBe(keys.length);
+    }
+
+    expect(declaredOperations).toBe(
+      Object.values(CLOSED_OPERATION_CONTRACTS).filter(
+        (contract) => contract.touchedFieldRegistryKeys !== undefined,
+      ).length,
+    );
+  });
+
+  it("keeps saved and archived written-leaf sets faithful to the legacy mutators", () => {
+    // `toggleArchived` writes only archive state; it reads `saved` as a
+    // precondition and must not claim to write it.
+    expect([...FEED_ITEM_ARCHIVE_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS])
+      .toStrictEqual([
+        LIBRARY_CORE_FEED_ITEM_ARCHIVED_FIELD_REGISTRY_KEY,
+        LIBRARY_CORE_FEED_ITEM_ARCHIVED_AT_FIELD_REGISTRY_KEY,
+      ]);
+    expect(FEED_ITEM_ARCHIVE_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS).not.toContain(
+      LIBRARY_CORE_FEED_ITEM_SAVED_FIELD_REGISTRY_KEY,
+    );
+
+    // `toggleSaved` clears archive state on the save path, so it genuinely
+    // writes all four leaves. Omitting the archive pair would hide the
+    // coupling that keeps the algebra unresolved.
+    expect([...FEED_ITEM_SAVED_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS])
+      .toStrictEqual([
+        LIBRARY_CORE_FEED_ITEM_ARCHIVED_FIELD_REGISTRY_KEY,
+        LIBRARY_CORE_FEED_ITEM_ARCHIVED_AT_FIELD_REGISTRY_KEY,
+        LIBRARY_CORE_FEED_ITEM_SAVED_FIELD_REGISTRY_KEY,
+        LIBRARY_CORE_FEED_ITEM_SAVED_AT_FIELD_REGISTRY_KEY,
+      ]);
+
+    // The coupling is the whole reason both stay blocked. If either ever
+    // declares an algebra, that claim must be reviewed, not inherited.
+    for (const operationId of [
+      "feed_item_archive_assignment",
+      "feed_item_saved_assignment",
+    ] as const) {
+      const definition = LIBRARY_CORE_OPERATION_REGISTRY[operationId];
+      expect(definition.fieldAlgebra).toBeNull();
+      expect(definition.blockers).toContain("field_algebra_unresolved");
+      expect(definition.payloadSchema).toBeNull();
+      expect(definition.transactionMemberSchema).toBeNull();
+    }
+    expect(FEED_ITEM_SAVED_ARCHIVED_EXCLUSION_INVARIANT).toBe(
+      "an item is never simultaneously saved and archived",
+    );
   });
 
   it("keeps frozen membership, provider intent, and execution receipts unresolved", () => {


### PR DESCRIPTION
(AI Generated).

## What this closes

Two of the 39 dormant operations lose two blockers each, traced rather than chosen.

| operation | blockers dropped | blockers kept |
| --- | --- | --- |
| `feed_item_saved_assignment` | `touched_fields_unresolved`, `entity_id_schema_unresolved` | payload, algebra, transaction member, materializer, runtime authority |
| `feed_item_archive_assignment` | `touched_fields_unresolved`, `entity_id_schema_unresolved` | payload, algebra, transaction member, materializer, runtime authority |

The census blocker `operation_payload_and_field_algebra_incomplete` stays. Thirty seven operations remain fully open and `activationAllowed` is untouched.

## What was traced

`packages/shared/src/schema.ts`:

- `toggleSaved` writes `userState.saved` on every path, sets or deletes `savedAt`, and on the save path also writes `archived` and deletes `archivedAt`. Four leaves.
- `toggleArchived` writes `archived` and sets or deletes `archivedAt`. Two leaves. It reads `saved` as a precondition and returns without writing when the item is saved.
- Both index `doc.feedItems[globalId]`, the same entity key space `markAsRead` uses, so `LIBRARY_CORE_ENTITY_ID_CODEC_V1` applies by reference rather than by resemblance.

All four registry keys were confirmed to exist in `LIBRARY_CORE_FIELD_REGISTRY` before being declared.

## What stays open, and why

Both operations keep `field_algebra_unresolved`, `payload_schema_unresolved`, and `transaction_member_schema_unresolved`.

`toggleSaved` and `toggleArchived` jointly maintain one invariant: an item is never both saved and archived. `LibraryCoreOperationFieldAlgebraContract` merges one leaf against one leaf, so it cannot express a rule spanning two. Any per-leaf rule lets a concurrent save and archive converge to `saved && archived`, the exact state both mutators exist to prevent. Declaring an algebra here would claim convergence the type cannot deliver, so both fields stay null.

Filed as #1327 with the trace, the counterexample, and three candidate shapes. Not chosen here: it is a protocol decision.

## A definitional choice worth a look

`touchedFieldRegistryKeys` had no documented meaning. The one closed exemplar, `feed_item_read_assignment`, reads nothing, so it did not distinguish reads from writes. This pins it to written leaves only, documented on the interface, with precondition reads recorded in prose next to the inventory they belong to. Folding reads in would have hidden the asymmetry that makes #1327 real.

## Enforcement added

The registry test previously hardcoded `if (operationId === "feed_item_read_assignment")`, which would have quietly stopped covering anything the moment a second operation closed a field. Replaced with a table keyed on the closed contracts, asserting for every operation and every contract field that the blocker is present exactly when the field is null. A declaration cannot be added without dropping its blocker, and a blocker cannot be dropped without a declaration.

Two gaps that were previously unguarded:

- A declared touched-field key was never checked against `LIBRARY_CORE_FIELD_REGISTRY`. A typo, a rename, or an invented path would have passed and read as closed coverage. Now every key must name a real leaf, and the check guards its own source so an empty registry cannot make it vacuous.
- Touched-field lists were not required to be sorted or unique.

Shared contract objects are asserted by reference so a structural copy cannot drift from the one the protocol uses.

## Verification

Nine mutations, all killed:

1. `feed_item_saved_assignment` loses its `entityIdCodec` while the table still declares it.
2. `savedAt` key typo names a leaf that does not exist.
3. Archive falsely claims it writes the `saved` leaf, hiding the read-only precondition.
4. Saved hides the archive leaves it clears. This is the dishonest shortcut the inventory exists to prevent, and the one that would have erased the evidence for #1327.
5. Saved keys out of sort order.
6. Duplicate key in the archive set.
7. Saved borrows the `readAt` algebra it is not entitled to.
8. The read algebra replaced by a structural clone.
9. The field registry source emptied, to prove the guard is not vacuous.

`npm run validate:feature` passes. `node scripts/validate-main-backflow.mjs` reports in sync. All four changed paths classify `isProviderVisiblePath: false` with no provider IDs, so no provider risk review artifact applies.

## Boundaries

No runtime behavior changes. No operation gains write authority. No provider traffic. No Automerge retirement. The legacy mutators are untouched; this is inventory about them.