### PR TITLE
chore: characterize the shipping user state merge algebra

### DIFF
--- a/packages/shared/src/library-core/index.ts
+++ b/packages/shared/src/library-core/index.ts
@@ -35,3 +35,4 @@ export * from "./facet-summary-contracts.js";
 export * from "./sha256.js";
 export * from "./store-surface-registry.js";
 export * from "./wire-frame.js";
+export * from "./user-state-merge-algebra.js";

--- a/packages/shared/src/library-core/user-state-merge-algebra.ts
+++ b/packages/shared/src/library-core/user-state-merge-algebra.ts
@@ -1,0 +1,85 @@
+/**
+ * The de facto merge algebra for feed item user state.
+ *
+ * `mergeUserState` in `packages/shared/src/schema.ts` is the single point where
+ * two copies of one item's user state converge. It runs today, on real data,
+ * reached from `deduplicateDocFeedItems` and from the three provider capture
+ * reconcilers (`reconcileProviderEssayItems`, `reconcileFollowRosterCapture`,
+ * `reconcileYouTubeCapture`).
+ *
+ * That makes it the authoritative statement of how each synchronized user-state
+ * leaf already converges, whatever the Library Core operation registry has or
+ * has not declared. This module records those rules so the replacement protocol
+ * has something traced to compare against instead of a blank field, and so the
+ * behavior cannot drift unobserved.
+ *
+ * Nothing here changes behavior. These are descriptions, and the accompanying
+ * test suite holds `mergeUserState` to them.
+ */
+
+export type LibraryCoreUserStateMergeRule =
+  /** `target || source`. Once true anywhere, true everywhere. */
+  | "boolean_or"
+  /** `boolean_or`, except a false result is stored as absent rather than false. */
+  | "boolean_or_absent_when_false"
+  /** Defined wins over absent; otherwise the smaller value. */
+  | "timestamp_min"
+  /**
+   * Defined wins over absent. If either side is positive, the larger positive
+   * wins and non-positive values lose. If both are non-positive, the smaller
+   * wins. Non-positive values encode a pending or failed sync, so a real
+   * receipt always beats one.
+   */
+  | "synced_timestamp"
+  /**
+   * Not independently mergeable. `likedAt` and `likedSyncedAt` converge as a
+   * pair in `mergeLikedIntentState`: when both sides carry a distinct finite
+   * `likedAt`, the later one wins and drags its own `likedSyncedAt` along, so
+   * the receipt can never outlive the like it belongs to. Otherwise the two
+   * leaves fall back to `timestamp_min` and `synced_timestamp` separately.
+   */
+  | "liked_intent_pair"
+  /** Set union, preserving the target's existing order and appending new values. */
+  | "string_set_union";
+
+/**
+ * One entry per synchronized `userState` leaf, traced from `mergeUserState`.
+ *
+ * `highlights` is deliberately absent. It merges through `mergeHighlights`,
+ * which is a record-level rule rather than a leaf rule, and folding it in here
+ * would misrepresent it as one.
+ */
+export const LIBRARY_CORE_USER_STATE_MERGE_ALGEBRA = Object.freeze({
+  hidden: "boolean_or",
+  saved: "boolean_or",
+  archived: "boolean_or",
+  liked: "boolean_or_absent_when_false",
+  readAt: "timestamp_min",
+  savedAt: "timestamp_min",
+  archivedAt: "timestamp_min",
+  likedAt: "liked_intent_pair",
+  likedSyncedAt: "liked_intent_pair",
+  seenSyncedAt: "synced_timestamp",
+  tags: "string_set_union",
+}) satisfies Readonly<Record<string, LibraryCoreUserStateMergeRule>>;
+
+/**
+ * `saved` and `archived` merge independently, so merging a saved copy with an
+ * archived copy yields an item that is both.
+ *
+ * This is not an accident and it is not a bug to be quietly fixed. The mutators
+ * enforce the exclusion one device at a time: `toggleSaved` clears archive
+ * state, and `toggleArchived` refuses to run on a saved item. Convergence does
+ * not, and the product answers that with repair rather than prevention. The
+ * shadow store counts the condition as `saved_archived_count`, the header
+ * surfaces an `Unarchive saved (N)` control when that count is positive, and
+ * `feed_items_unarchive_saved_frozen` is registered with
+ * `intendedAuthority: "system_repair"` to perform the bulk correction.
+ *
+ * So the exclusion is a per-device invariant with a cross-device repair, not a
+ * global invariant. Any replacement protocol has to decide deliberately whether
+ * to keep that shape or promote the exclusion to something merge itself
+ * guarantees. See https://github.com/freed-project/freed/issues/1327.
+ */
+export const LIBRARY_CORE_SAVED_ARCHIVED_EXCLUSION_IS_PER_DEVICE_ONLY =
+  true as const;

--- a/packages/shared/src/user-state-merge-algebra.test.ts
+++ b/packages/shared/src/user-state-merge-algebra.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  LIBRARY_CORE_SAVED_ARCHIVED_EXCLUSION_IS_PER_DEVICE_ONLY,
+  LIBRARY_CORE_USER_STATE_MERGE_ALGEBRA,
+} from "./library-core/user-state-merge-algebra.js";
+import {
+  deduplicateDocFeedItems,
+  mergeFeedItemInto,
+  type FreedDoc,
+} from "./schema.js";
+import type { FeedItem, UserState } from "./types.js";
+
+/**
+ * `mergeUserState` is the de facto field algebra for every synchronized
+ * user-state leaf, and until now nothing held it to a stated rule. These are
+ * characterization tests: they pin what the shipping code already does so a
+ * change to convergence has to be deliberate and visible in a diff.
+ */
+
+const SHARED_STORY_URL = "https://example.com/story";
+
+const item = (globalId: string, userState: Partial<UserState>): FeedItem =>
+  ({
+    globalId,
+    platform: "rss",
+    sourceId: "source-1",
+    url: `https://example.com/${globalId}`,
+    publishedAt: 1,
+    author: { id: "author-1", displayName: "Author" },
+    content: {
+      text: "same story",
+      mediaUrls: [],
+      mediaTypes: [],
+      linkPreview: { url: SHARED_STORY_URL },
+    },
+    topics: [],
+    userState: {
+      hidden: false,
+      saved: false,
+      archived: false,
+      tags: [],
+      ...userState,
+    },
+  }) as unknown as FeedItem;
+
+/** Merge `right` into `left` through the shipping entry point. */
+const merged = (
+  left: Partial<UserState>,
+  right: Partial<UserState>,
+): UserState => {
+  const keeper = item("keeper", left);
+  mergeFeedItemInto(keeper, item("duplicate", right));
+  return keeper.userState;
+};
+
+describe("feed item user state merge algebra", () => {
+  it("declares a rule for every leaf mergeUserState actually touches", () => {
+    // Guard the guard. If a leaf is added to mergeUserState without a rule
+    // here, this list stops describing the function it claims to describe.
+    expect(Object.keys(LIBRARY_CORE_USER_STATE_MERGE_ALGEBRA).sort()).toStrictEqual([
+      "archived",
+      "archivedAt",
+      "hidden",
+      "liked",
+      "likedAt",
+      "likedSyncedAt",
+      "readAt",
+      "saved",
+      "savedAt",
+      "seenSyncedAt",
+      "tags",
+    ]);
+  });
+
+  describe("boolean_or", () => {
+    it.each([
+      ["hidden"],
+      ["saved"],
+      ["archived"],
+    ] as const)("%s is true when either side is true", (leaf) => {
+      expect(merged({ [leaf]: true }, { [leaf]: false })[leaf]).toBe(true);
+      expect(merged({ [leaf]: false }, { [leaf]: true })[leaf]).toBe(true);
+      expect(merged({ [leaf]: false }, { [leaf]: false })[leaf]).toBe(false);
+    });
+  });
+
+  it("liked collapses a false result to absent rather than false", () => {
+    expect(merged({ liked: true }, {}).liked).toBe(true);
+    expect(merged({}, { liked: true }).liked).toBe(true);
+    // The distinction that makes this rule its own case: `false` is not stored.
+    expect(merged({ liked: false }, { liked: false })).not.toHaveProperty("liked");
+  });
+
+  describe("timestamp_min", () => {
+    it.each([
+      ["readAt"],
+      ["savedAt"],
+      ["archivedAt"],
+    ] as const)("%s keeps the earlier time and prefers a defined value", (leaf) => {
+      expect(merged({ [leaf]: 500 }, { [leaf]: 100 })[leaf]).toBe(100);
+      expect(merged({ [leaf]: 100 }, { [leaf]: 500 })[leaf]).toBe(100);
+      expect(merged({ [leaf]: 500 }, {})[leaf]).toBe(500);
+      expect(merged({}, { [leaf]: 500 })[leaf]).toBe(500);
+    });
+  });
+
+  describe("synced_timestamp", () => {
+    it("keeps the later receipt when both are positive", () => {
+      expect(merged({ seenSyncedAt: 100 }, { seenSyncedAt: 500 }).seenSyncedAt).toBe(500);
+      expect(merged({ seenSyncedAt: 500 }, { seenSyncedAt: 100 }).seenSyncedAt).toBe(500);
+    });
+
+    it("lets a real receipt beat a non-positive pending marker", () => {
+      // This is the whole reason it is not plain `max`: a pending or failed
+      // marker must never mask a receipt that actually happened.
+      expect(merged({ seenSyncedAt: 0 }, { seenSyncedAt: 300 }).seenSyncedAt).toBe(300);
+      expect(merged({ seenSyncedAt: 300 }, { seenSyncedAt: -1 }).seenSyncedAt).toBe(300);
+    });
+
+    it("keeps the smaller marker when neither side has a receipt", () => {
+      expect(merged({ seenSyncedAt: 0 }, { seenSyncedAt: -5 }).seenSyncedAt).toBe(-5);
+    });
+  });
+
+  describe("liked_intent_pair", () => {
+    it("lets the later like carry its own receipt", () => {
+      // The pairing exists so a receipt cannot outlive the like it belongs to.
+      const result = merged(
+        { liked: true, likedAt: 100, likedSyncedAt: 150 },
+        { liked: true, likedAt: 900, likedSyncedAt: 950 },
+      );
+      expect(result.likedAt).toBe(900);
+      expect(result.likedSyncedAt).toBe(950);
+    });
+
+    it("does not take the later receipt when the earlier like wins", () => {
+      const result = merged(
+        { liked: true, likedAt: 900, likedSyncedAt: 950 },
+        { liked: true, likedAt: 100, likedSyncedAt: 150 },
+      );
+      expect(result.likedAt).toBe(900);
+      expect(result.likedSyncedAt).toBe(950);
+    });
+
+    it("falls back to per-leaf rules when the like times agree", () => {
+      const result = merged(
+        { liked: true, likedAt: 100, likedSyncedAt: 150 },
+        { liked: true, likedAt: 100, likedSyncedAt: 900 },
+      );
+      expect(result.likedAt).toBe(100);
+      expect(result.likedSyncedAt).toBe(900);
+    });
+  });
+
+  it("unions tags without reordering the ones already present", () => {
+    expect(merged({ tags: ["b", "a"] }, { tags: ["a", "c"] }).tags).toStrictEqual([
+      "b",
+      "a",
+      "c",
+    ]);
+  });
+});
+
+describe("saved and archived converge independently", () => {
+  it("produces an item that is both saved and archived", () => {
+    // Not a bug report. `toggleSaved` clears archive state and `toggleArchived`
+    // refuses to run on a saved item, so the exclusion holds on one device.
+    // Merge does not enforce it, and the product repairs the result instead.
+    expect(merged({ saved: true, savedAt: 100 }, { archived: true, archivedAt: 200 }))
+      .toMatchObject({ saved: true, archived: true });
+    expect(merged({ archived: true, archivedAt: 200 }, { saved: true, savedAt: 100 }))
+      .toMatchObject({ saved: true, archived: true });
+    expect(LIBRARY_CORE_SAVED_ARCHIVED_EXCLUSION_IS_PER_DEVICE_ONLY).toBe(true);
+  });
+
+  it("reaches that state through the shipping deduplication entry point", () => {
+    // Reachability matters more than the unit result: this is the path real
+    // documents take, not a direct call to an internal helper.
+    const doc = {
+      feedItems: {
+        keeper: item("keeper", { saved: true, savedAt: 100 }),
+        duplicate: item("duplicate", { archived: true, archivedAt: 200 }),
+      },
+    } as unknown as FreedDoc;
+
+    expect(deduplicateDocFeedItems(doc)).toBe(1);
+
+    const survivors = Object.values(doc.feedItems) as FeedItem[];
+    expect(survivors).toHaveLength(1);
+    expect(survivors[0]?.userState).toMatchObject({ saved: true, archived: true });
+  });
+});


### PR DESCRIPTION
(AI Generated).

## What this found

`mergeUserState` in `packages/shared/src/schema.ts` is the single point where two copies of one feed item's user state converge. It is reached from `deduplicateDocFeedItems` and from all three provider capture reconcilers (`reconcileProviderEssayItems`, `reconcileFollowRosterCapture`, `reconcileYouTubeCapture`), so it runs today on real data.

That makes it the de facto field algebra for every synchronized user-state leaf. Until now nothing held it to a stated rule. Its only test contact was incidental, through `follow-roster-capture.test.ts`.

## What this adds

`LIBRARY_CORE_USER_STATE_MERGE_ALGEBRA` records the traced rule for each of the eleven leaves, and a characterization suite pins them against the shipping entry point rather than against internal helpers.

| rule | leaves |
| --- | --- |
| `boolean_or` | `hidden`, `saved`, `archived` |
| `boolean_or_absent_when_false` | `liked` |
| `timestamp_min` | `readAt`, `savedAt`, `archivedAt` |
| `synced_timestamp` | `seenSyncedAt` |
| `liked_intent_pair` | `likedAt`, `likedSyncedAt` |
| `string_set_union` | `tags` |

`highlights` is deliberately excluded. It merges through a record-level rule, and listing it as a leaf rule would misrepresent it.

Two of these are subtler than they look and now have tests explaining why. `synced_timestamp` is not plain `max`: non-positive values encode a pending or failed sync, so a real receipt has to beat one regardless of ordering. `liked_intent_pair` couples `likedAt` and `likedSyncedAt` so a receipt can never outlive the like it belongs to.

`readAt` merging as `min` independently confirms the already-closed `FEED_ITEM_READ_AT_FIELD_ALGEBRA`, which declares the same rule. Two statements that must always agree now fail together if either moves.

## This corrects #1327

I filed #1327 saying the type could not express reality for saved and archived. That was wrong in an important way and I am correcting it rather than leaving it to stand.

Per-leaf rules for both leaves do exist and do ship: each is boolean OR. Merging a saved copy with an archived copy really does produce an item that is both saved and archived, in either order, and through the real dedup path, not just a direct helper call.

That is a designed condition, not an oversight:

- `shadow_store.rs` counts it as `saved_archived_count` via `SUM(saved = 1 AND archived = 1)`.
- `Header.tsx` surfaces an `Unarchive saved (N)` control whenever that count is positive.
- `feed_items_unarchive_saved_frozen` is registered with `intendedAuthority: "system_repair"` and a real store surface for the bulk correction.

So the exclusion the mutators enforce is a per-device invariant with a cross-device repair, not a global invariant. What actually remains unexpressible is narrower and still true: `LibraryCoreOperationDefinition.fieldAlgebra` is a single slot, and `feed_item_saved_assignment` writes four leaves. That part of #1327 stands. I have updated the issue.

## Why no behavior change

Making merge enforce the exclusion would delete a designed affordance and silently change what users see in Saved and Archive after a dedup or a capture. That is a product decision, not a cleanup, so this PR characterizes the behavior and leaves it alone. The suite asserts the tolerated joint state on purpose, which means a future silent promotion of the exclusion to a merge guarantee fails loudly instead of passing quietly.

## Verification

Seven mutations, all killed:

1. `saved` merges with AND instead of OR.
2. `readAt` flips to `max`, which would contradict the already-closed read contract.
3. `synced_timestamp` degrades to plain `max`, letting a pending marker mask a real receipt.
4. The later like stops carrying its own receipt.
5. Tag union prepends instead of appending.
6. The algebra table claims a leaf `mergeUserState` does not treat as one.
7. Merge silently starts enforcing the saved/archived exclusion.

Number seven is the one this PR exists for. Number six guards the table against describing a function it no longer matches.

`npm run validate:feature` passes. `node scripts/validate-main-backflow.mjs` reports in sync. All three changed paths classify `isProviderVisiblePath: false` with no provider IDs.

## Boundaries

No runtime behavior changes. No operation gains write authority. No census blocker cleared. No provider traffic.