### PR TITLE
chore: cover the cursor guard that the merge algebra makes load bearing

### DIFF
--- a/packages/desktop/src-tauri/src/shadow_store.rs
+++ b/packages/desktop/src-tauri/src/shadow_store.rs
@@ -5420,6 +5420,81 @@ mod tests {
         assert_eq!(undated, total / 8, "undated items survived as undated");
     }
 
+    /// `sortAt` is `COALESCE(publishedAt, 0)` and the order is `sortAt DESC`,
+    /// so a row that loses `publishedAt` moves toward the tail. `publishedAt`
+    /// merges as `min` in `mergeFeedItemInto`, which deduplication and all
+    /// three provider capture reconcilers reach, so that move happens on real
+    /// data. A forward pager holding a cursor above the old position would
+    /// then serve the row a second time.
+    ///
+    /// The revision check is what prevents it. Nothing tested that until now,
+    /// which left a load-bearing guard free to regress silently.
+    #[test]
+    fn a_cursor_is_rejected_once_a_merge_lowers_a_sort_key() {
+        let mut store = seeded(64);
+
+        let first = store.feed_page(None, 16).expect("first page");
+        let cursor = first.next_cursor.expect("a second page exists");
+        let served = first.rows[0].global_id.clone();
+        let served_sort = first.rows[0].sort_key();
+
+        // Re-project one already-served row with an earlier `publishedAt`,
+        // exactly as a min-merge against a duplicate would.
+        let lowered = served
+            .strip_prefix("x:")
+            .and_then(|value| value.parse::<usize>().ok())
+            .expect("seeded ids are x:NNNNNN");
+        let mut demoted = row(lowered, Some(1_000_000_000_000));
+        demoted.global_id = served.clone();
+        assert!(
+            demoted.published_at.expect("dated") < served_sort,
+            "the re-projection must actually move the row"
+        );
+        store
+            .apply_projection_batch("merge-lowered-sort", &digest(999), 1, &[demoted], &[])
+            .expect("reproject");
+
+        match store.feed_page(Some(&cursor), 16) {
+            Err(ShadowStoreError::StaleRevision { expected, actual }) => {
+                assert_eq!(expected, cursor.revision);
+                assert_ne!(actual, cursor.revision, "the revision must have moved");
+            }
+            other => panic!("a cursor older than the merge must be refused, got {other:?}"),
+        }
+    }
+
+    /// The recovery path has to be correct too. Refusing the stale cursor is
+    /// only safe if restarting the walk still covers the corpus exactly once.
+    #[test]
+    fn restarting_after_a_lowered_sort_key_still_serves_every_row_once() {
+        let total = 64usize;
+        let mut store = seeded(total);
+
+        let mut demoted = row(0, Some(1_000_000_000_000));
+        demoted.global_id = "x:000000".to_string();
+        store
+            .apply_projection_batch("merge-lowered-sort", &digest(999), 1, &[demoted], &[])
+            .expect("reproject");
+
+        let mut seen: HashSet<String> = HashSet::new();
+        let mut cursor: Option<PageCursor> = None;
+        loop {
+            let page = store.feed_page(cursor.as_ref(), 16).expect("page");
+            if page.rows.is_empty() {
+                break;
+            }
+            for item in &page.rows {
+                assert!(seen.insert(item.global_id.clone()), "row served twice");
+            }
+            match page.next_cursor {
+                Some(next) => cursor = Some(next),
+                None => break,
+            }
+        }
+
+        assert_eq!(seen.len(), total, "every row exactly once after the merge");
+    }
+
     #[test]
     fn feed_pages_expose_only_bounded_card_fields() {
         let mut store = ShadowStore::open_in_memory().expect("open");


### PR DESCRIPTION
(AI Generated).

## The chain this closes

I went looking for merge rules that contradict a declared contract. The one that matters connects two things previously reasoned about separately.

1. `sortAt` is pinned by DDL: `CHECK (sortAt = COALESCE(publishedAt, 0))`.
2. Feed paging orders by `sortAt DESC, globalId ASC` with the keyset predicate `sortAt < ?1 OR (sortAt = ?1 AND globalId > ?2)`.
3. `publishedAt` merges as `min` in `mergeFeedItemInto`.
4. That merge is reached from `deduplicateDocFeedItems` and from `reconcileProviderEssayItems`, `reconcileFollowRosterCapture`, and `reconcileYouTubeCapture`.

So a row's sort position moves downward on real data, during normal use. In a `DESC` walk that carries it toward the tail, past a cursor the reader already advanced beyond, and a forward pager would serve it again.

`priority` merges as `max` and leads the browse ordering, which moves rows the other way, toward already-read pages.

## Why this is not a bug report

The readers already defend against it, three different ways, and I verified each rather than assuming:

| reader | defense |
| --- | --- |
| `feed_page` | refuses a cursor whose `revision` no longer matches the projection, returning `StaleRevision` |
| feed browse (`library_core_feed_browse_store`) | binds cursors to a generation and rejects on `transition_sequence` or `projection_revision` mismatch |
| `item_scan_page` | orders by `globalId ASC`, which merge never changes |

That is a good design. The problem was that one leg of it had no test.

## The gap

`StaleRevision` had **zero** test references. Its only occurrences were the enum variant and its `Display` arm. A guard standing between the merge algebra and duplicate page delivery could have been deleted or inverted without a single failure.

This adds two tests:

- A cursor taken before a merge is refused once that merge lowers a sort key. The test re-projects an already-served row with an earlier `publishedAt`, exactly as a min-merge against a duplicate does, and asserts the refusal names the moved revision.
- Restarting the walk after that change still serves every row exactly once. Refusing the cursor is only safe if the recovery path is correct, so that is asserted rather than assumed.

## Verification

Two mutations against `feed_page`, both killed:

1. Guard inverted so it only fires when the revisions match.
2. Guard neutered to a no-op that still compiles.

An earlier attempt to mutate by deleting the block was discarded: it unbalanced the braces, so it was a compile failure rather than a surviving mutant. Worth saying, because a compile error can read as a passing mutation if the check only greps for test failures.

`cargo test --lib` passes 419 tests, up from 417. `cargo fmt --check` is clean. `npm run validate:feature` passes. `node scripts/validate-main-backflow.mjs` reports in sync. `shadow_store.rs` classifies `isProviderVisiblePath: false` with no provider IDs.

Clippy under `-D warnings` still reports five pre-existing findings, none in this change. That is #1244, untouched here.

## Boundaries

No behavior changes. No SQL, no schema, no guard logic modified. Tests only.