### PR TITLE
chore: pin feed item merge idempotency and its one clock exception

### DIFF
--- a/packages/shared/src/feed-item-merge-idempotency.test.ts
+++ b/packages/shared/src/feed-item-merge-idempotency.test.ts
@@ -1,0 +1,249 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  FEED_ITEM_MERGE_NON_IDEMPOTENT_FIELD,
+  FEED_ITEM_MERGE_EMPTY_PASS_MEASUREMENT,
+} from "./library-core/feed-item-merge-idempotency.js";
+import { mergeFeedItemInto } from "./schema.js";
+import type { FeedItem } from "./types.js";
+
+/**
+ * `mergeFeedItemInto` runs from deduplication and from all three provider
+ * capture reconcilers, so the same source really is merged into the same target
+ * repeatedly. Nothing held it to idempotency until now.
+ */
+
+const clone = <T>(value: T): T => JSON.parse(JSON.stringify(value)) as T;
+
+const item = (globalId: string, over: Record<string, unknown> = {}): FeedItem =>
+  clone({
+    globalId,
+    platform: "rss",
+    sourceId: "source-1",
+    url: `https://example.com/${globalId}`,
+    publishedAt: 100,
+    capturedAt: 200,
+    author: {
+      id: "author-1",
+      displayName: "Author",
+      avatarUrl: "https://example.com/a.png",
+    },
+    content: {
+      text: "body text",
+      mediaUrls: ["https://example.com/m1"],
+      mediaTypes: ["image"],
+      linkPreview: { url: "https://example.com/story", title: "Title" },
+    },
+    topics: ["topic-a"],
+    engagement: { likes: 3, comments: 1 },
+    priority: 5,
+    priorityComputedAt: 900,
+    location: { name: "Location", url: "https://example.com/loc" },
+    preservedContent: {
+      text: "preserved",
+      preservedAt: 1,
+      wordCount: 2,
+      readingTime: 1,
+    },
+    userState: {
+      hidden: false,
+      saved: false,
+      archived: false,
+      tags: ["tag-a"],
+      highlights: [{ text: "h1", note: "n1", createdAt: 10 }],
+    },
+    ...over,
+  }) as unknown as FeedItem;
+
+/** A source that differs from the base item on every merge rule at once. */
+const contrastingSource = (): FeedItem =>
+  item("duplicate", {
+    publishedAt: 50,
+    capturedAt: 150,
+    author: {
+      id: "author-1",
+      displayName: "A Much Longer Author Name",
+      avatarUrl: "https://example.com/a-much-longer-avatar.png",
+    },
+    content: {
+      text: "a considerably longer body text than the target carries",
+      mediaUrls: ["https://example.com/m2"],
+      mediaTypes: ["video"],
+      linkPreview: { url: "https://example.com/story", title: "A Longer Title" },
+    },
+    topics: ["topic-b"],
+    engagement: { likes: 9, views: 4 },
+    priority: 7,
+    priorityComputedAt: 1_500,
+    location: { name: "Real Place", coordinates: { lat: 1, lng: 2 } },
+    userState: {
+      hidden: false,
+      saved: false,
+      archived: false,
+      tags: ["tag-b"],
+      highlights: [{ text: "h2", note: "n2", createdAt: 20 }],
+    },
+  });
+
+/**
+ * Every leaf path where two merge results differ.
+ *
+ * Deliberately a diff rather than an exclusion list. An earlier version of this
+ * file compared two copies with the known clock field deleted from both, and a
+ * mutation proved that approach worthless: widening the deletion to also drop
+ * `topics` hid a real `topics` regression and the suite still passed. With a
+ * diff there is nothing to widen. The assertion states the exact set of moving
+ * paths, so any new one has to be added here in a reviewable line.
+ */
+const differingPaths = (
+  left: unknown,
+  right: unknown,
+  prefix = "",
+): string[] => {
+  if (Object.is(left, right)) return [];
+  const bothObjects =
+    typeof left === "object" &&
+    left !== null &&
+    typeof right === "object" &&
+    right !== null &&
+    Array.isArray(left) === Array.isArray(right);
+  if (!bothObjects) return [prefix || "<root>"];
+
+  const keys = new Set([
+    ...Object.keys(left as Record<string, unknown>),
+    ...Object.keys(right as Record<string, unknown>),
+  ]);
+  const paths: string[] = [];
+  for (const key of [...keys].sort()) {
+    paths.push(
+      ...differingPaths(
+        (left as Record<string, unknown>)[key],
+        (right as Record<string, unknown>)[key],
+        prefix ? `${prefix}.${key}` : key,
+      ),
+    );
+  }
+  return paths;
+};
+
+describe("mergeFeedItemInto idempotency", () => {
+  // The merge stamps a wall clock, so real time makes these assertions depend
+  // on whether two calls straddle a millisecond. The first draft of this file
+  // did exactly that and failed intermittently. Controlling the clock turns a
+  // flaky observation into two exact ones.
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("is completely idempotent once the clock is held still", () => {
+    // The strongest form of the property. With time frozen there is no
+    // difference at all, which proves the single exception below is entirely
+    // clock driven rather than an accumulation hiding behind one.
+    const once = item("keeper");
+    mergeFeedItemInto(once, contrastingSource());
+
+    const many = item("keeper");
+    for (let pass = 0; pass < 10; pass += 1) {
+      mergeFeedItemInto(many, contrastingSource());
+    }
+
+    expect(differingPaths(many, once)).toStrictEqual([]);
+  });
+
+  it("differs in exactly one clock field once time advances", () => {
+    const once = item("keeper");
+    mergeFeedItemInto(once, contrastingSource());
+
+    const twice = item("keeper");
+    mergeFeedItemInto(twice, contrastingSource());
+    vi.advanceTimersByTime(1_000);
+    mergeFeedItemInto(twice, contrastingSource());
+
+    expect(differingPaths(twice, once)).toStrictEqual([
+      FEED_ITEM_MERGE_NON_IDEMPOTENT_FIELD,
+    ]);
+  });
+
+  it("merging an already-merged item into itself moves only that field", () => {
+    const merged = item("keeper");
+    mergeFeedItemInto(merged, contrastingSource());
+
+    const settled = clone(merged);
+    vi.advanceTimersByTime(1_000);
+    mergeFeedItemInto(merged, clone(settled));
+
+    expect(differingPaths(merged, settled)).toStrictEqual([
+      FEED_ITEM_MERGE_NON_IDEMPOTENT_FIELD,
+    ]);
+  });
+
+  it("guards the differ itself", () => {
+    // A differ that returns nothing would make every assertion above vacuous.
+    expect(differingPaths({ a: 1 }, { a: 1 })).toStrictEqual([]);
+    expect(differingPaths({ a: 1 }, { a: 2 })).toStrictEqual(["a"]);
+    expect(differingPaths({ a: { b: 1 } }, { a: { b: 2 } })).toStrictEqual(["a.b"]);
+    expect(differingPaths({ a: 1 }, {})).toStrictEqual(["a"]);
+    expect(differingPaths({ a: [1, 2] }, { a: [1, 3] })).toStrictEqual(["a.1"]);
+  });
+
+  it("pins the item-level rules, which idempotency alone does not", () => {
+    // Idempotency is necessary but not sufficient. Flipping `priority` from
+    // max to min stays perfectly idempotent and is still wrong, so the rules
+    // themselves need pinning.
+    const merged = item("keeper");
+    mergeFeedItemInto(merged, contrastingSource());
+    const view = merged as unknown as Record<string, never>;
+
+    // Timestamps take the earlier value; the item is as old as its oldest copy.
+    expect(view.publishedAt).toBe(50);
+    expect(view.capturedAt).toBe(150);
+
+    // Ranking takes the strongest claim and the most recent computation.
+    expect(view.priority).toBe(7);
+    expect(view.priorityComputedAt).toBe(1_500);
+
+    // Longest wins for free text, on the theory that a truncated copy is worse.
+    expect((view.content as Record<string, unknown>).text).toBe(
+      "a considerably longer body text than the target carries",
+    );
+    expect((view.author as Record<string, unknown>).displayName).toBe(
+      "A Much Longer Author Name",
+    );
+    expect((view.author as Record<string, unknown>).avatarUrl).toBe(
+      "https://example.com/a-much-longer-avatar.png",
+    );
+
+    // Collections union rather than replace.
+    expect(view.topics).toStrictEqual(["topic-a", "topic-b"]);
+    expect((view.content as Record<string, unknown>).mediaUrls).toStrictEqual([
+      "https://example.com/m1",
+      "https://example.com/m2",
+    ]);
+
+    // Counters take a max per counter, never a sum.
+    expect(view.engagement).toStrictEqual({ likes: 9, comments: 1, views: 4 });
+
+    // Location fills gaps but treats the literal placeholder "Location" as
+    // absent, so a real place name can replace it.
+    expect(view.location).toStrictEqual({
+      name: "Real Place",
+      url: "https://example.com/loc",
+      coordinates: { lat: 1, lng: 2 },
+    });
+
+    // Fill-if-absent leaves an existing value alone.
+    expect((view.preservedContent as Record<string, unknown>).text).toBe("preserved");
+  });
+
+  it("records the measured cost of a semantically empty pass", () => {
+    // A magnitude, so the tradeoff can be argued with a number attached.
+    expect(FEED_ITEM_MERGE_EMPTY_PASS_MEASUREMENT.items).toBe(200);
+    expect(
+      FEED_ITEM_MERGE_EMPTY_PASS_MEASUREMENT.changeBytesPerItemPerPass,
+    ).toBeGreaterThan(FEED_ITEM_MERGE_EMPTY_PASS_MEASUREMENT.savedBytesPerItemPerPass);
+  });
+});

--- a/packages/shared/src/library-core/feed-item-merge-idempotency.ts
+++ b/packages/shared/src/library-core/feed-item-merge-idempotency.ts
@@ -1,0 +1,55 @@
+/**
+ * Idempotency of `mergeFeedItemInto`.
+ *
+ * `mergeFeedItemInto` is reached from `deduplicateDocFeedItems` and from all
+ * three provider capture reconcilers, so the same source can be merged into the
+ * same target many times over a library's life. That makes idempotency a real
+ * operational property rather than a theoretical nicety: a rule that grows a
+ * value on every pass would inflate without bound.
+ *
+ * Measured, every semantic field is idempotent. Counters take a max, timestamps
+ * take a min or a max, collections union by identity, and fill-if-absent rules
+ * stop filling once present. Merging one source twice produces exactly what
+ * merging it once produces.
+ *
+ * One field is not, and it is the reason this module exists.
+ */
+
+/**
+ * The single field that changes on a semantically empty merge.
+ *
+ * `mergeFeedItemInto` ends by calling `applySemanticEnrichmentToItem`, which
+ * calls `applyContentSignalsToItem` with freshly inferred signals and assigns
+ * `target.inferredAt = clean.inferredAt` unconditionally. That value comes from
+ * the wall clock, so it differs on every call even when the inferred signals
+ * are identical to the ones already stored.
+ *
+ * Automerge records a put for every assignment rather than diffing, so each
+ * pass appends operations to the change history for work that changed nothing.
+ */
+export const FEED_ITEM_MERGE_NON_IDEMPOTENT_FIELD =
+  "contentSignals.inferredAt" as const;
+
+/**
+ * Measured cost of one semantically empty reconcile pass.
+ *
+ * Two hundred items were built into an Automerge document, enrichment was
+ * settled so the first pass could not be doing real work, and each item was
+ * then merged with an identical copy of itself five times. Every pass appended
+ * a change of the same size, which is the signature of a fixed per-item write
+ * rather than a converging one.
+ *
+ * These numbers describe one measurement on synthetic items, not a guarantee.
+ * They are recorded so the tradeoff can be discussed with a magnitude attached
+ * instead of an adjective. See
+ * https://github.com/freed-project/freed/issues/1331.
+ */
+export const FEED_ITEM_MERGE_EMPTY_PASS_MEASUREMENT = Object.freeze({
+  items: 200,
+  /** Bytes of one appended change per pass, uncompressed. */
+  changeBytesPerPass: 1_732,
+  /** `changeBytesPerPass / items`, rounded. */
+  changeBytesPerItemPerPass: 8.7,
+  /** Growth of the compressed saved document, which dedupes far better. */
+  savedBytesPerItemPerPass: 1.4,
+});

--- a/packages/shared/src/library-core/index.ts
+++ b/packages/shared/src/library-core/index.ts
@@ -36,3 +36,4 @@ export * from "./sha256.js";
 export * from "./store-surface-registry.js";
 export * from "./wire-frame.js";
 export * from "./user-state-merge-algebra.js";
+export * from "./feed-item-merge-idempotency.js";


### PR DESCRIPTION
(AI Generated).

## The property

`mergeFeedItemInto` runs from `deduplicateDocFeedItems` and from all three provider capture reconcilers, so the same source really is merged into the same target repeatedly over a library's life. That makes idempotency an operational property, not a theoretical one. Nothing held it to that.

Measured, every semantic rule is idempotent:

| rule | fields |
| --- | --- |
| min | `capturedAt`, `publishedAt` |
| max | `priority` (collapsing 0 to absent), `priorityComputedAt` |
| max per counter, never a sum | `engagement.likes`, `.reposts`, `.comments`, `.views` |
| longest wins | `content.text`, `author.displayName`, `author.avatarUrl` |
| set union | `topics`, `content.mediaUrls`, `userState.tags`, `userState.highlights` |
| fill if absent | `timeRange`, `rssSource`, `fbGroup`, `sourceUrl`, `preservedContent`, and `location` sub-fields |

`location.name` has a special case worth naming: the literal string `"Location"` is treated as absent, so a real place name can replace the placeholder.

With the clock held still, ten merges of one source produce exactly what one merge produces. No accumulation anywhere.

## The one exception, measured

`contentSignals.inferredAt` is re-stamped from the wall clock on every call. `applyContentSignalsToItem` assigns `target.inferredAt = clean.inferredAt` unconditionally, and Automerge records a put per assignment rather than diffing, so a reconcile that changes nothing still appends operations.

Two hundred synthetic items, enrichment settled first, then each merged with an identical copy of itself five times:

- 1,732 bytes of appended change per pass, uncompressed, for 200 items
- roughly 8.7 bytes per item per pass
- roughly 1.4 bytes per item per pass in the compressed saved document

Every pass appended the same size, which is the signature of a fixed per-item write rather than a converging one. On the ~17,000 item corpus that is about 148 KB of change history per empty pass.

Filed as #1331 rather than fixed. Skipping the write changes what `inferredAt` means, from "when signals were last computed" to "when signals last changed", which is a product decision. Two honest caveats are in the issue: these are synthetic items so this is the floor rather than the typical cost, and at this magnitude it is a contributor to document growth rather than the dominant driver.

## Two mistakes in my own test, both caught by mutation

**An exclusion list is not a comparison.** The first draft compared two merge results with the known clock field deleted from both. A mutation that widened the deletion to also drop `topics`, while regressing `topics` to a non-idempotent append, passed. The suite would have gone blind exactly when it mattered. It now diffs every leaf path and asserts the exact set of differing ones, so there is no list to widen.

**Real time made the assertions flaky.** Comparing two merges depends on whether they straddle a millisecond. The ten-pass case failed on first run for that reason alone. The suite now uses fake timers, which turns one flaky observation into two exact ones: frozen clock gives an empty diff, advanced clock gives exactly one path.

**Idempotency alone is too weak.** Flipping `priority` from max to min stays perfectly idempotent and is still wrong, and that mutation survived until the rules themselves were pinned.

## Verification

Eight mutations, all killed, each verified to have applied at the intended site before its result was trusted:

1. `priority` merges min instead of max.
2. `capturedAt` takes max instead of min.
3. Engagement sums instead of maxing.
4. The `"Location"` placeholder special case is dropped.
5. Highlight dedup disabled.
6. `differingPaths` always reports no difference. This is the dishonest shortcut for this suite.
7. `contentSignals.method` also becomes clock stamped, so the exception spreads.
8. `topics` accumulate only on later passes, which a single extra merge would miss.

Suite run three times to confirm the timer fix removed the flake. `npm run validate:feature` passes. `node scripts/validate-main-backflow.mjs` reports in sync. All three changed paths classify `isProviderVisiblePath: false` with no provider IDs.

## Boundaries

No behavior changes. No merge rule modified. No census blocker cleared.