### PR TITLE
chore: prove the device-local preference boundary through the write path

### DIFF
--- a/packages/shared/src/preference-locality-boundary.test.ts
+++ b/packages/shared/src/preference-locality-boundary.test.ts
@@ -1,0 +1,215 @@
+import * as A from "@automerge/automerge";
+import { describe, expect, it } from "vitest";
+
+import { updatePreferences } from "./schema.js";
+import {
+  AI_PREFERENCES_WRITE_POLICY,
+  DISPLAY_PREFERENCES_WRITE_POLICY,
+  FACEBOOK_CAPTURE_PREFERENCES_WRITE_POLICY,
+  FRIEND_SUGGESTION_PREFERENCES_WRITE_POLICY,
+  READING_ENHANCEMENTS_WRITE_POLICY,
+  STORY_WALL_PREFERENCES_WRITE_POLICY,
+  STORY_WALL_PUBLISH_TARGET_WRITE_POLICY,
+  STORY_WALL_STYLE_WRITE_POLICY,
+  ULYSSES_PREFERENCES_WRITE_POLICY,
+  USER_PREFERENCES_WRITE_POLICY,
+  WEIGHT_PREFERENCES_WRITE_POLICY,
+  X_CAPTURE_PREFERENCES_WRITE_POLICY,
+} from "./sync-write-policy.js";
+
+/**
+ * The device-local boundary for preferences, proved through the real write
+ * path rather than through the sanitizer in isolation.
+ *
+ * `updatePreferences` is the only way preferences enter the synchronized
+ * document. It strips by policy, then hands what survives to `deepMergeInto`
+ * and, for `fbCapture`, to a dedicated writer. A leaf marked `device-local`
+ * that slipped through would propagate one machine's private setting to every
+ * other device: `ai.ollamaUrl` is a LAN address, `ai.provider` and `ai.model`
+ * describe local software, and the display leaves are one screen's layout.
+ *
+ * `locality-contract.test.ts` covers the feed item policy. Nothing covered
+ * this one, so the boundary held by construction alone.
+ *
+ * The cases are generated from the policy objects rather than listed by hand,
+ * so a leaf added tomorrow is covered without anyone remembering to add it.
+ */
+
+/** Sub-policies reachable through `USER_PREFERENCES_WRITE_POLICY`'s nested entries. */
+const NESTED_PREFERENCE_POLICIES = {
+  weights: WEIGHT_PREFERENCES_WRITE_POLICY,
+  ulysses: ULYSSES_PREFERENCES_WRITE_POLICY,
+  display: DISPLAY_PREFERENCES_WRITE_POLICY,
+  xCapture: X_CAPTURE_PREFERENCES_WRITE_POLICY,
+  fbCapture: FACEBOOK_CAPTURE_PREFERENCES_WRITE_POLICY,
+  friendSuggestions: FRIEND_SUGGESTION_PREFERENCES_WRITE_POLICY,
+  ai: AI_PREFERENCES_WRITE_POLICY,
+  storyWall: STORY_WALL_PREFERENCES_WRITE_POLICY,
+} as const;
+
+type Disposition = string;
+
+const dispositionOf = (entry: unknown): Disposition =>
+  typeof entry === "string"
+    ? entry
+    : String((entry as { disposition?: unknown })?.disposition);
+
+/** Writes `updates` through the only path preferences reach the document by. */
+const writtenPreferences = (updates: unknown): Record<string, unknown> => {
+  const doc = A.change(A.from({ preferences: {} } as never), (draft: never) => {
+    updatePreferences(draft as never, updates as never);
+  });
+  return (doc as never as { preferences: Record<string, unknown> }).preferences;
+};
+
+/**
+ * Two probe shapes. The sanitizer does not type check except for
+ * `positive-sync`, which requires a positive finite number, and the `fbCapture`
+ * writer expects records. Trying both keeps the positive control honest
+ * without weakening the negative one, which must hold for either shape.
+ */
+const PROBES = [1, { probeKey: true }] as const;
+
+/**
+ * Sub-objects one level deeper that carry their own policy.
+ *
+ * The first version of this file stopped at two levels and would have missed
+ * `display.reading.dualColumnMode`, `storyWall.publishTarget.lastError`, and
+ * `storyWall.publishTarget.status`, all device-local. The other `nested`
+ * entries are records and arrays whose values are sanitized as collections
+ * rather than against a named policy, so they have no leaves to enumerate.
+ */
+const DEEP_PREFERENCE_POLICIES = {
+  "display.reading": READING_ENHANCEMENTS_WRITE_POLICY,
+  "storyWall.style": STORY_WALL_STYLE_WRITE_POLICY,
+  "storyWall.publishTarget": STORY_WALL_PUBLISH_TARGET_WRITE_POLICY,
+} as const;
+
+/** Builds `{a: {b: {c: probe}}}` from a dotted path. */
+const nest = (path: readonly string[], probe: unknown): unknown =>
+  path.reduceRight<unknown>((inner, key) => ({ [key]: inner }), probe);
+
+const leafAfterWrite = (
+  group: string,
+  leaf: string,
+  probe: unknown,
+): unknown => {
+  const path = [...group.split("."), leaf];
+  let cursor: unknown = writtenPreferences(nest(path, probe));
+  for (const key of path) {
+    if (cursor === undefined || cursor === null) return undefined;
+    cursor = (cursor as Record<string, unknown>)[key];
+  }
+  return cursor;
+};
+
+describe("preference locality boundary", () => {
+  const cases = Object.entries({
+    ...NESTED_PREFERENCE_POLICIES,
+    ...DEEP_PREFERENCE_POLICIES,
+  }).flatMap(([group, policy]) =>
+    Object.entries(policy as Record<string, unknown>).map(([leaf, entry]) => ({
+      group,
+      leaf,
+      disposition: dispositionOf(entry),
+    })),
+  );
+
+  const local = cases.filter(
+    (entry) =>
+      entry.disposition === "device-local" ||
+      entry.disposition === "compatibility-only",
+  );
+  const synced = cases.filter(
+    (entry) =>
+      entry.disposition === "sync" || entry.disposition === "positive-sync",
+  );
+
+  const collections = cases.filter((entry) => entry.disposition === "nested");
+
+  it("generates cases from the policy and accounts for every leaf", () => {
+    // Guard the guard. If the policies stopped being enumerable, or every leaf
+    // landed in one bucket, the two suites below would pass vacuously.
+    expect(cases.length).toBeGreaterThan(30);
+    expect(local.length).toBeGreaterThan(10);
+    expect(synced.length).toBeGreaterThan(5);
+
+    // Every leaf is in exactly one bucket. `nested` here means a record or
+    // array sanitized as a collection, with no named policy to enumerate, so
+    // it is counted rather than silently dropped from the total.
+    expect(local.length + synced.length + collections.length).toBe(cases.length);
+
+    // The leaves whose leaking would be most visible to a user, including the
+    // three that only a third level of traversal reaches.
+    expect(local).toEqual(
+      expect.arrayContaining([
+        { group: "ai", leaf: "ollamaUrl", disposition: "device-local" },
+        { group: "display", leaf: "themeId", disposition: "device-local" },
+        { group: "fbCapture", leaf: "knownGroups", disposition: "device-local" },
+        {
+          group: "display.reading",
+          leaf: "dualColumnMode",
+          disposition: "device-local",
+        },
+        {
+          group: "storyWall.publishTarget",
+          leaf: "status",
+          disposition: "device-local",
+        },
+        {
+          group: "storyWall.publishTarget",
+          leaf: "lastError",
+          disposition: "device-local",
+        },
+      ]),
+    );
+  });
+
+  it.each(local)(
+    "$group.$leaf is $disposition and never reaches the document",
+    ({ group, leaf }) => {
+      for (const probe of PROBES) {
+        expect(leafAfterWrite(group, leaf, probe)).toBeUndefined();
+      }
+    },
+  );
+
+  it.each(synced)(
+    "$group.$leaf is $disposition and does reach the document",
+    ({ group, leaf }) => {
+      // The positive control. Without it, a sanitizer that dropped everything
+      // would satisfy every assertion above.
+      const landed = PROBES.some(
+        (probe) => leafAfterWrite(group, leaf, probe) !== undefined,
+      );
+      expect(landed).toBe(true);
+    },
+  );
+
+  it("drops the whole sync subtree, which is compatibility-only", () => {
+    expect(dispositionOf(USER_PREFERENCES_WRITE_POLICY.sync)).toBe(
+      "compatibility-only",
+    );
+    expect(
+      writtenPreferences({
+        sync: { cloudProvider: "gdrive", autoBackup: true, backupFrequency: "daily" },
+      }),
+    ).toStrictEqual({});
+  });
+
+  it("leaves the fbCapture knownGroups branch unreachable", () => {
+    // `applyFbCapturePreferenceUpdate` has a dedicated `if (updates.knownGroups)`
+    // branch, but `updatePreferences` strips device-local leaves before calling
+    // it and is that function's only caller. The branch cannot run from here.
+    // Asserted so the dead branch is not mistaken for a synchronized path.
+    const written = writtenPreferences({
+      fbCapture: {
+        knownGroups: { group1: "Group One" },
+        excludedGroupIds: { group2: true },
+      },
+    });
+    expect(written).toStrictEqual({
+      fbCapture: { excludedGroupIds: { group2: true } },
+    });
+  });
+});


### PR DESCRIPTION
(AI Generated).

## What was dark

`updatePreferences` is the only path preferences take into the synchronized document. Eighteen preference leaves are marked `device-local` or `compatibility-only` precisely so they never arrive there, and nothing tested that.

The leaks would be visible ones. `ai.ollamaUrl` is a LAN address. `ai.provider` and `ai.model` name software installed on one machine. The display leaves are one screen's layout, including sidebar widths and theme.

`locality-contract.test.ts` covers the feed item write policy. It has no preference coverage at all.

## The boundary holds

Verified end to end rather than by reading the sanitizer: each leaf is written through `updatePreferences` into a real Automerge document, and what lands is asserted. Every device-local and compatibility-only leaf is stripped. Every sync leaf arrives.

That is the point of the exercise. The defense was already correct; what was missing was anything that would notice if it stopped being correct.

## Generated, not listed

Cases come from the policy objects themselves, so a leaf added tomorrow is covered without anyone remembering to add it. 57 tests from 51 policy entries.

Traversal goes three levels deep. The two-level version I wrote first would have missed three device-local leaves that only appear deeper:

- `display.reading.dualColumnMode`
- `storyWall.publishTarget.lastError`
- `storyWall.publishTarget.status`

Every leaf is placed in exactly one bucket and the buckets are asserted to sum to the total, so `nested` collection entries are counted rather than quietly dropped from the accounting.

There is a positive control. Without asserting that sync leaves do land, a sanitizer that dropped everything would satisfy every other assertion in the file.

## One dead branch, now recorded

`applyFbCapturePreferenceUpdate` has a dedicated `if (updates.knownGroups)` branch. `knownGroups` is device-local, `updatePreferences` strips before calling it, and it is that function's only caller. The branch cannot execute from this path. Pinned by assertion so a future reader does not mistake it for evidence that `knownGroups` synchronizes.

## Also checked, and empty

There are no merge functions for persons, accounts, or RSS feeds. Only feed items have one. Those entities converge through Automerge's own per-key behavior, so there is no de facto algebra to characterize there. Saying so explicitly since it was an open question, and the honest answer is that the lane is empty rather than unexamined.

## Verification

Seven mutations, all killed, each verified to have applied at the intended site:

1. `ai.ollamaUrl` reclassified as sync, so a LAN address would replicate.
2. `display.reading.dualColumnMode` reclassified as sync, which only the three-level traversal catches.
3. The sanitizer passes device-local values through instead of dropping them.
4. `leafAfterWrite` stops writing its probe, which would make every absence trivially true. This is the dishonest shortcut for this suite.
5. The deep policies are dropped from case generation, restoring the coverage hole.
6. The sanitizer drops sync leaves too, which only the positive control catches.
7. `fbCapture.knownGroups` becomes syncable, reviving the dead branch.

Mutation 5 first reported as invalid because the applied-check counted occurrences and a deletion drives that count to zero. Rerun with the check inverted, confirmed to apply, and killed. Worth naming: a deletion mutation needs the opposite guard from a substitution.

`npm run validate:feature` passes. `node scripts/validate-main-backflow.mjs` reports in sync. The one changed path classifies `isProviderVisiblePath: false` with no provider IDs.

## Boundaries

Tests only. No policy edited, no sanitizer edited, no behavior changed.