### PR TITLE
chore: pin the destructive merge guard policy and its blind spots

### DIFF
--- a/packages/shared/src/destructive-merge-guard.test.ts
+++ b/packages/shared/src/destructive-merge-guard.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  assertNonDestructiveMerge,
+  evaluateDestructiveMergeGuard,
+} from "./schema.js";
+import type { FreedDoc } from "./schema.js";
+
+/**
+ * The exact policy of the destructive merge guard, including where it does not
+ * look.
+ *
+ * This guard is the last thing between a peer carrying stale delete history and
+ * a user's feed history. It has three live callers: the desktop worker, the PWA
+ * worker, and the cloud sync merge path. Two tests in
+ * `packages/pwa/src/lib/schema.test.ts` prove it fires on a catastrophic
+ * deletion. Nothing pinned the thresholds that decide when it fires, and
+ * nothing recorded what it cannot see.
+ *
+ * The thresholds are a deliberate policy, not an accident, so these tests state
+ * them rather than argue with them. The blind spots are recorded for the same
+ * reason: a guard whose limits are written down can be reasoned about, and one
+ * whose limits are folklore cannot.
+ */
+
+const docWith = (globalIds: readonly string[]): FreedDoc =>
+  ({
+    feedItems: Object.fromEntries(
+      globalIds.map((globalId) => [globalId, { globalId }]),
+    ),
+  }) as unknown as FreedDoc;
+
+const ids = (prefix: string, count: number): string[] =>
+  Array.from({ length: count }, (_, index) => `${prefix}-${index}`);
+
+/** Shrinks a document to its first `keep` items, the shape a delete-heavy merge produces. */
+const shrunk = (prefix: string, from: number, keep: number): FreedDoc =>
+  docWith(ids(prefix, from).slice(0, keep));
+
+describe("destructive merge guard thresholds", () => {
+  it("blocks at exactly the 25 percent boundary", () => {
+    // Inclusive. A comparison flipped to strictly-greater would let this pass.
+    const report = evaluateDestructiveMergeGuard(
+      docWith(ids("a", 1_000)),
+      docWith([]),
+      shrunk("a", 1_000, 750),
+    );
+    expect(report).toMatchObject({
+      blocked: true,
+      largestInputItemCount: 1_000,
+      deletedItemCount: 250,
+      deletedFraction: 0.25,
+    });
+  });
+
+  it("allows a loss just under the boundary", () => {
+    const report = evaluateDestructiveMergeGuard(
+      docWith(ids("a", 1_000)),
+      docWith([]),
+      shrunk("a", 1_000, 751),
+    );
+    expect(report.blocked).toBe(false);
+    expect(report.deletedItemCount).toBe(249);
+  });
+
+  it("needs at least 500 items on the larger side before it engages", () => {
+    // The floor. Below it the guard never fires, whatever the loss.
+    const justUnder = evaluateDestructiveMergeGuard(
+      docWith(ids("a", 499)),
+      docWith([]),
+      docWith([]),
+    );
+    expect(justUnder).toMatchObject({ blocked: false, deletedFraction: 1 });
+
+    const atFloor = evaluateDestructiveMergeGuard(
+      docWith(ids("a", 500)),
+      docWith([]),
+      docWith([]),
+    );
+    expect(atFloor.blocked).toBe(true);
+  });
+
+  it("cannot reach its own 100-item floor at the default thresholds", () => {
+    // Arithmetic, not opinion. To block, the larger input must be at least 500
+    // and the loss at least 25 percent, so the smallest blocking loss is
+    // 500 * 0.25 = 125. That is already above the 100-item floor, which means
+    // `minDeletedItems` can never be the deciding condition at defaults.
+    //
+    // Found because a mutation deleting that condition from the guard left the
+    // suite green. The first version of this test claimed to cover the floor
+    // and actually exercised the fraction.
+    const smallestBlockingLoss = 500 * 0.25;
+    expect(smallestBlockingLoss).toBeGreaterThan(100);
+
+    const atFloor = evaluateDestructiveMergeGuard(
+      docWith(ids("a", 500)),
+      docWith([]),
+      shrunk("a", 500, 375),
+    );
+    expect(atFloor).toMatchObject({ blocked: true, deletedItemCount: 125 });
+
+    // No shipping caller overrides the thresholds; the desktop worker, the PWA
+    // worker, and the cloud merge path all pass only `source`. So this floor is
+    // inert in production today.
+  });
+
+  it("honours the 100-item floor when a caller lowers the other thresholds", () => {
+    // The option is not dead code, only unreachable at defaults. Loosening the
+    // other two makes it bind, which is what keeps the condition load bearing.
+    const options = { minLargestInputItems: 10, maxDeletedFraction: 0.1 };
+
+    const underFloor = evaluateDestructiveMergeGuard(
+      docWith(ids("a", 500)),
+      docWith([]),
+      shrunk("a", 500, 440),
+      options,
+    );
+    expect(underFloor.deletedItemCount).toBe(60);
+    expect(underFloor.deletedFraction).toBeGreaterThan(0.1);
+    expect(underFloor.blocked).toBe(false);
+
+    const overFloor = evaluateDestructiveMergeGuard(
+      docWith(ids("a", 500)),
+      docWith([]),
+      shrunk("a", 500, 380),
+      options,
+    );
+    expect(overFloor.deletedItemCount).toBe(120);
+    expect(overFloor.blocked).toBe(true);
+  });
+
+  it("throws only when blocked, and returns the report otherwise", () => {
+    // The positive control for the assert wrapper. Without it, a wrapper that
+    // never threw would satisfy every allow-case above.
+    expect(() =>
+      assertNonDestructiveMerge(
+        docWith(ids("a", 1_000)),
+        docWith([]),
+        shrunk("a", 1_000, 750),
+      ),
+    ).toThrow(/Freed blocked a sync merge/);
+
+    expect(
+      assertNonDestructiveMerge(
+        docWith(ids("a", 1_000)),
+        docWith([]),
+        shrunk("a", 1_000, 751),
+      ).blocked,
+    ).toBe(false);
+  });
+
+  it("measures against the larger input, not the local one", () => {
+    // A small local document merging with a large peer must be judged against
+    // the peer, or a peer's history could be erased and called harmless.
+    const report = evaluateDestructiveMergeGuard(
+      docWith(ids("local", 10)),
+      docWith(ids("peer", 1_000)),
+      shrunk("peer", 1_000, 700),
+    );
+    expect(report.largestInputItemCount).toBe(1_000);
+    expect(report.blocked).toBe(true);
+  });
+});
+
+describe("destructive merge guard blind spots", () => {
+  it("counts items, so churn that nets to zero is invisible", () => {
+    // Every original item is gone and the guard reports no loss, because the
+    // replacements restore the count. A peer that pruned heavily while also
+    // capturing heavily produces exactly this shape.
+    // https://github.com/freed-project/freed/issues/1334
+    const report = evaluateDestructiveMergeGuard(
+      docWith(ids("original", 5_000)),
+      docWith(ids("replacement", 5_000)),
+      docWith(ids("replacement", 5_000)),
+    );
+
+    expect(report.blocked).toBe(false);
+    expect(report.deletedItemCount).toBe(0);
+    expect(report.deletedFraction).toBe(0);
+
+    // Stated explicitly: not one original identifier survived.
+    const survivors = Object.keys(
+      (docWith(ids("replacement", 5_000)) as unknown as {
+        feedItems: Record<string, unknown>;
+      }).feedItems,
+    ).filter((id) => id.startsWith("original-"));
+    expect(survivors).toHaveLength(0);
+  });
+
+  it("lets a quarter of a real-sized library go on a single merge", () => {
+    // The fraction is proportional, so the absolute loss it permits grows with
+    // the library. At the ~17,000 item corpus this program targets, that is
+    // over four thousand items in one merge, silently.
+    const report = evaluateDestructiveMergeGuard(
+      docWith(ids("a", 17_000)),
+      docWith([]),
+      shrunk("a", 17_000, 12_751),
+    );
+    expect(report.blocked).toBe(false);
+    expect(report.deletedItemCount).toBe(4_249);
+    expect(report.deletedFraction).toBeCloseTo(0.2499, 4);
+  });
+
+  it("reports a readable message only when it blocks", () => {
+    const blocked = evaluateDestructiveMergeGuard(
+      docWith(ids("a", 1_000)),
+      docWith([]),
+      shrunk("a", 1_000, 750),
+      { source: "cloud restore" },
+    );
+    expect(blocked.message).toContain("cloud restore");
+    expect(blocked.message).toContain("250");
+
+    const allowed = evaluateDestructiveMergeGuard(
+      docWith(ids("a", 1_000)),
+      docWith([]),
+      shrunk("a", 1_000, 751),
+    );
+    expect(allowed.message).toBe("Sync merge passed destructive merge guard.");
+  });
+});


### PR DESCRIPTION
(AI Generated).

## What this guard does, and what was known about it

`evaluateDestructiveMergeGuard` blocks a sync merge that would remove too much feed history. It has three live callers: the desktop worker, the PWA worker, and `packages/sync/src/cloud/merge.ts`. It is the last thing standing between a peer carrying stale delete history and a user's library.

The only coverage was two tests in `packages/pwa/src/lib/schema.test.ts`, both proving it fires on a catastrophic deletion (600 items down to 20). Nothing pinned the thresholds that decide when it fires. Nothing recorded what it cannot see.

## The policy, now pinned

| rule | value |
| --- | --- |
| fraction that blocks | 25 percent, inclusive |
| minimum size of the larger input | 500 items |
| minimum absolute loss | 100 items |
| measured against | the larger of local and incoming, not local |

The inclusive boundary matters: flipping `>=` to `>` would let an exact 25 percent loss through, and that mutation is now caught.

## Two blind spots, both measured

**It counts items, it does not identify them.** With 5,000 local items and 5,000 different incoming items merging to those 5,000 replacements, the guard reports `deletedItemCount: 0` and allows the merge. Not one original identifier survives.

This is reachable. The guard exists for a peer with stale delete history, and that same peer can have captured new items while away. A device that pruned heavily and then ran captures produces exactly this shape. Partial masking is likelier still: losing 4,000 originals while gaining 3,000 new items nets to 1,000, which on a 17,000 item library is under the fraction and passes.

**The permitted absolute loss scales with the library.** At the ~17,000 item corpus this program targets, 25 percent is 4,249 items in a single merge. That is a policy choice rather than a defect, but the magnitude deserves to be written down.

Filed as #1334 with three options. Not changed here: both fixes alter when sync is blocked, which is user-visible.

## A dead threshold, and how I found it

`minDeletedItems: 100` can never be the deciding condition at the defaults. To block, the larger input must be at least 500 and the loss at least 25 percent, so the smallest blocking loss is 125, already above 100. No shipping caller overrides the thresholds; all three pass only `source`.

I found this because a mutation that deleted the condition from the guard left my suite green. My first version of that test claimed to cover the floor and actually exercised the fraction: 600 items losing 99 is 16.5 percent, so the fraction rejected it before the count ever mattered. The test now states the arithmetic, and a second test proves the option still binds when a caller lowers the other two thresholds, which keeps the condition load bearing.

## Verification

Eight mutations, all killed, each verified to have applied:

1. The boundary becomes strictly-greater, so an exact 25 percent loss passes.
2. The fraction threshold loosened to 50 percent.
3. The floor raised to 5,000, leaving most libraries unprotected.
4. The guard measures the local document instead of the larger input.
5. `assertNonDestructiveMerge` never throws.
6. The 100-item condition dropped from the guard. This is the one that initially survived.
7. `docWith` builds empty documents, so every count becomes zero. This is the dishonest shortcut for this suite.
8. The blocked message stops naming its source.

`npm run validate:feature` passes. `node scripts/validate-main-backflow.mjs` reports in sync. The one changed path classifies `isProviderVisiblePath: false` with no provider IDs.

## Boundaries

Tests only. No threshold changed, no guard logic changed, no behavior changed.