### PR TITLE
chore: pin what the entity writers do with dangerous map keys

### DIFF
--- a/packages/shared/src/unsafe-key-guard.test.ts
+++ b/packages/shared/src/unsafe-key-guard.test.ts
@@ -1,0 +1,176 @@
+import * as A from "@automerge/automerge";
+import { describe, expect, it } from "vitest";
+
+import {
+  addAccount,
+  addFeedItem,
+  addPerson,
+  addRssFeed,
+} from "./schema.js";
+import type { FreedDoc } from "./schema.js";
+import type { Account, FeedItem, Person, RssFeed } from "./types.js";
+
+/**
+ * What the entity writers actually do with a dangerous map key.
+ *
+ * `__proto__`, `constructor`, and `prototype` are the keys that turn a plain
+ * object into someone else's prototype chain. Feed item identifiers and account
+ * identifiers come from provider capture, so these values are influenced from
+ * outside the app rather than chosen by it.
+ *
+ * The codebase agrees this matters and disagrees about how to say so. There is
+ * a canonical `UNSAFE_OBJECT_KEYS` set, six inline copies of the same literal
+ * array across the reconcilers, a `__proto__`-only check in Facebook group
+ * discovery, and two writers with no check at all. Nothing tested any of it.
+ *
+ * These tests state the behavior as it ships. They are deliberately not a fix:
+ * adding a guard to `addPerson` would start rejecting records it accepts today,
+ * which is a product decision. See
+ * https://github.com/freed-project/freed/issues/1337.
+ */
+
+const UNSAFE_KEYS = ["__proto__", "constructor", "prototype"] as const;
+
+const emptyDoc = (): FreedDoc =>
+  A.from({
+    feedItems: {},
+    persons: {},
+    accounts: {},
+    rssFeeds: {},
+    preferences: {},
+    meta: {},
+  } as never) as unknown as FreedDoc;
+
+const person = (id: string): Person =>
+  ({
+    id,
+    name: "Person",
+    relationshipStatus: "friend",
+    careLevel: 4,
+    createdAt: 1,
+    updatedAt: 1,
+  }) as Person;
+
+const account = (id: string): Account =>
+  ({
+    id,
+    personId: "person",
+    kind: "social",
+    provider: "rss",
+    externalId: "external",
+    firstSeenAt: 1,
+    lastSeenAt: 1,
+    discoveredFrom: "captured_item",
+    createdAt: 1,
+    updatedAt: 1,
+  }) as Account;
+
+const feed = (url: string): RssFeed =>
+  ({ url, title: "Example", enabled: true, trackUnread: false }) as RssFeed;
+
+const item = (globalId: string): FeedItem =>
+  ({
+    globalId,
+    platform: "rss",
+    sourceId: "source",
+    url: "https://example.com/1",
+    publishedAt: 1,
+    capturedAt: 1,
+    author: { id: "author", displayName: "Author" },
+    content: { text: "text", mediaUrls: [], mediaTypes: [] },
+    topics: [],
+    userState: { hidden: false, saved: false, archived: false, tags: [] },
+  }) as unknown as FeedItem;
+
+/** Each writer, its collection, and whether the source checks unsafe keys. */
+const WRITERS = [
+  {
+    name: "addFeedItem",
+    collection: "feedItems",
+    guarded: true,
+    write: (doc: FreedDoc, key: string) => addFeedItem(doc, item(key)),
+  },
+  {
+    name: "addAccount",
+    collection: "accounts",
+    guarded: true,
+    write: (doc: FreedDoc, key: string) => addAccount(doc, account(key)),
+  },
+  {
+    name: "addPerson",
+    collection: "persons",
+    guarded: false,
+    write: (doc: FreedDoc, key: string) => addPerson(doc, person(key)),
+  },
+  {
+    name: "addRssFeed",
+    collection: "rssFeeds",
+    guarded: false,
+    write: (doc: FreedDoc, key: string) => addRssFeed(doc, feed(key)),
+  },
+] as const;
+
+const storedKeys = (
+  writer: (typeof WRITERS)[number],
+  key: string,
+): string[] => {
+  const doc = A.change(emptyDoc() as never, (draft: never) => {
+    writer.write(draft as unknown as FreedDoc, key);
+  });
+  return Object.keys(
+    (doc as unknown as Record<string, Record<string, unknown>>)[
+      writer.collection
+    ],
+  );
+};
+
+describe("unsafe map keys in the entity writers", () => {
+  it("covers every writer and both guard states", () => {
+    // Guard the guard. If the table collapsed to one side, the contrast below
+    // would stop being a contrast.
+    expect(WRITERS.filter((writer) => writer.guarded)).toHaveLength(2);
+    expect(WRITERS.filter((writer) => !writer.guarded)).toHaveLength(2);
+    expect(UNSAFE_KEYS).toStrictEqual(["__proto__", "constructor", "prototype"]);
+  });
+
+  it("never writes a record under __proto__, guarded or not", () => {
+    // Assignment through `__proto__` does not create an own property, so the
+    // record is discarded by every writer. No error is raised, which means a
+    // caller cannot tell the write was dropped.
+    for (const writer of WRITERS) {
+      expect(storedKeys(writer, "__proto__")).toStrictEqual([]);
+    }
+  });
+
+  describe.each(WRITERS.filter((writer) => writer.guarded))(
+    "$name checks the key",
+    (writer) => {
+      it.each(["constructor", "prototype"])("refuses %s", (key) => {
+        expect(storedKeys(writer, key)).toStrictEqual([]);
+      });
+
+      it("still accepts an ordinary identifier", () => {
+        // The positive control. A writer that refused everything would satisfy
+        // the two assertions above without guarding anything.
+        expect(storedKeys(writer, "ordinary-id")).toStrictEqual(["ordinary-id"]);
+      });
+    },
+  );
+
+  describe.each(WRITERS.filter((writer) => !writer.guarded))(
+    "$name does not check the key",
+    (writer) => {
+      it.each(["constructor", "prototype"])("stores a record under %s", (key) => {
+        // Recorded as the shipping behavior, not endorsed. A record living at
+        // `constructor` shadows `Object.prototype.constructor` the moment the
+        // collection is materialized into a plain object, which the SQLite
+        // projection does.
+        expect(storedKeys(writer, key)).toStrictEqual([key]);
+      });
+
+      it("still accepts an ordinary identifier", () => {
+        expect(storedKeys(writer, "ordinary-id")).toStrictEqual(["ordinary-id"]);
+      });
+    },
+  );
+});


### PR DESCRIPTION
(AI Generated).

## Coverage survey first

Following the rule that a lane is not dark until it is measured, I counted test call sites before picking anything:

| candidate | calls in tests |
| --- | --- |
| `compareDocumentHistories` | 5 |
| `reconcileFollowRosterCapture` | 9 |
| `reconcileYouTubeCapture` | 8, across 3 files |
| `reconcileProviderEssayItems` | 1 |
| `reconcileAuthenticatedItemAuthors` | 0 |
| `ensureIdentityGraphRoots` | 0 |
| `UNSAFE_OBJECT_KEYS` | 0 |

The reconcilers and `compareDocumentHistories` are covered, so they are not this PR. The unsafe-key guard had nothing.

## One rule, eight expressions

| where | form |
| --- | --- |
| `schema.ts:507` | the canonical `UNSAFE_OBJECT_KEYS` set |
| `schema.ts:516` | `UNSAFE_OBJECT_KEYS.has(k)` in `stripUndefined` |
| `schema.ts:1369` | the set, in `addFeedItem` |
| `schema.ts:2065` | the set, in `addAccount` |
| `schema.ts:2252, 2317, 2321, 2370, 2406, 2444` | six inline copies of the literal array |
| `facebook-group-discovery.ts:59` | `__proto__` only |
| `addPerson` | no check |
| `addRssFeed` | no check |

The six inline copies cannot track the canonical set. The Facebook check is already out of step, covering one key of three.

## Measured behavior

Against real Automerge documents, one writer per row:

| writer | `__proto__` | `constructor` | `prototype` |
| --- | --- | --- | --- |
| `addFeedItem` | dropped | refused | refused |
| `addAccount` | dropped | refused | refused |
| `addPerson` | dropped | **stored** | **stored** |
| `addRssFeed` | dropped | **stored** | **stored** |

Two separate facts, worth not conflating.

`__proto__` is dropped everywhere, but no guard does it. Assignment through `__proto__` never creates an own property, so the record silently vanishes and no writer reports it. That is silent loss on all four paths including the guarded ones, and it is the one case no guard currently covers.

`constructor` and `prototype` really are stored by the two unguarded writers. A record living at `constructor` shadows `Object.prototype.constructor` once the collection is materialized into a plain object, which the SQLite projection does.

Account and feed item identifiers come from provider capture. The inline guards in the reconcilers are themselves the evidence that this was understood.

## Not fixed, and why

Adding a guard to `addPerson` starts rejecting records it accepts today, on a path that carries captured data. Consolidating the six copies changes what each reconciler rejects the moment the set and the literal diverge. Both want a decision. Filed as #1337 with three options.

The suite records the behavior as it ships. A mutation that adds the missing guard **fails** it, which is the point: a consolidation cannot land silently, it has to update the recorded table in the same diff.

## Verification

Five mutations, all killed, each verified to have applied:

1. `addFeedItem` loses its guard.
2. `addAccount` loses its guard.
3. `UNSAFE_OBJECT_KEYS` shrinks to `__proto__` only.
4. `addPerson` silently gains a guard. This is the future-fix case, and catching it is the reason the file exists.
5. `storedKeys` stops writing, so every collection is empty. This is the dishonest shortcut for this suite.

Each guarded and unguarded writer also has a positive control proving it still accepts an ordinary identifier, so a writer that refused everything would not pass.

`npm run validate:feature` passes. `node scripts/validate-main-backflow.mjs` reports in sync. The one changed path classifies `isProviderVisiblePath: false` with no provider IDs.

## Boundaries

Tests only. No guard added, removed, or consolidated. No behavior changed.