### PR TITLE
feat: close the preferences written-leaf inventory

### DIFF
--- a/packages/shared/src/library-core/operation-registry.ts
+++ b/packages/shared/src/library-core/operation-registry.ts
@@ -11,6 +11,7 @@ import {
 import {
   FEED_ITEM_ARCHIVE_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS,
   FEED_ITEM_SAVED_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS,
+  PREFERENCES_LEAF_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS,
 } from "./operation-touched-fields.js";
 import {
   FEED_ITEM_READ_ASSIGNMENT_TRANSACTION_MEMBER_SCHEMA,
@@ -459,6 +460,11 @@ export const LIBRARY_CORE_OPERATION_REGISTRY = {
   }),
   preferences_leaf_assignment: localUserOperation({
     entityType: "UserPreferences",
+    // `entityIdCodec` stays null on purpose. Preferences are a singleton root,
+    // not an entity map, so there is no per-entity key for a codec to validate.
+    // Declaring one would claim a key space this operation does not have.
+    touchedFieldRegistryKeys:
+      PREFERENCES_LEAF_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS,
     candidateStoreSurfaces: ["updatePreferences"],
     legacyWorkerRequests: ["UPDATE_PREFERENCES"],
   }),

--- a/packages/shared/src/library-core/operation-touched-fields.ts
+++ b/packages/shared/src/library-core/operation-touched-fields.ts
@@ -1,3 +1,5 @@
+import { LIBRARY_CORE_FIELD_REGISTRY } from "./field-registry.js";
+
 /**
  * Written-leaf inventories for candidate successor operations.
  *
@@ -55,6 +57,38 @@ export const FEED_ITEM_SAVED_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS =
     LIBRARY_CORE_FEED_ITEM_SAVED_FIELD_REGISTRY_KEY,
     LIBRARY_CORE_FEED_ITEM_SAVED_AT_FIELD_REGISTRY_KEY,
   ]);
+
+/**
+ * Traced from `updatePreferences` in `packages/shared/src/schema.ts`.
+ *
+ * That function accepts an arbitrary `Partial<UserPreferences>`, strips it
+ * through `sanitizeUserPreferenceWrite`, and deep-merges whatever survives. It
+ * therefore may write any synchronized preference leaf and no others, so the
+ * written set is exactly the synchronized preference leaves rather than a
+ * shorter list of the ones some caller happens to use today.
+ *
+ * Derived from the field registry rather than transcribed, so a leaf added
+ * later is included without anyone remembering. The derivation was checked
+ * against reality: every addressable leaf the registry marks
+ * `legacy-synchronized` does land in the document through `updatePreferences`,
+ * and every leaf it marks `legacy-device-local` or `legacy-compatibility` does
+ * not. `packages/shared/src/preference-locality-boundary.test.ts` holds the
+ * second half of that statement.
+ *
+ * Array-element and record patterns such as `...[]` and `...{groupId}` are
+ * included. They are real registry keys naming real synchronized leaves, and
+ * omitting them would understate what the operation writes.
+ */
+export const PREFERENCES_LEAF_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS =
+  Object.freeze(
+    LIBRARY_CORE_FIELD_REGISTRY.filter(
+      (entry) =>
+        entry.registryKey.startsWith("library-core-v1:preferences.") &&
+        entry.currentLocality === "legacy-synchronized",
+    )
+      .map((entry) => entry.registryKey)
+      .sort((left, right) => (left < right ? -1 : left > right ? 1 : 0)),
+  );
 
 /**
  * Why saved and archived still carry `field_algebra_unresolved`.

--- a/packages/shared/src/library-core/registry.test.ts
+++ b/packages/shared/src/library-core/registry.test.ts
@@ -90,6 +90,7 @@ import {
   FEED_ITEM_ARCHIVE_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS,
   FEED_ITEM_SAVED_ARCHIVED_EXCLUSION_INVARIANT,
   FEED_ITEM_SAVED_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS,
+  PREFERENCES_LEAF_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS,
   LIBRARY_CORE_FEED_ITEM_ARCHIVED_AT_FIELD_REGISTRY_KEY,
   LIBRARY_CORE_FEED_ITEM_ARCHIVED_FIELD_REGISTRY_KEY,
   LIBRARY_CORE_FEED_ITEM_SAVED_AT_FIELD_REGISTRY_KEY,
@@ -161,6 +162,13 @@ const CLOSED_OPERATION_CONTRACTS: Partial<
     entityIdCodec: LIBRARY_CORE_ENTITY_ID_CODEC_V1,
     touchedFieldRegistryKeys:
       FEED_ITEM_SAVED_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS,
+  },
+  // Traced from `updatePreferences`, which deep-merges an arbitrary partial
+  // and so may write any synchronized preference leaf. No entityIdCodec:
+  // preferences are a singleton root with no per-entity key.
+  preferences_leaf_assignment: {
+    touchedFieldRegistryKeys:
+      PREFERENCES_LEAF_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS,
   },
 };
 
@@ -262,6 +270,48 @@ describe("Library Core operation registry", () => {
         (contract) => contract.touchedFieldRegistryKeys !== undefined,
       ).length,
     );
+  });
+
+  it("derives the preference written set from the registry, not by hand", () => {
+    const keys = PREFERENCES_LEAF_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS;
+
+    // `updatePreferences` deep-merges an arbitrary partial, so the written set
+    // is every synchronized preference leaf. Both halves are asserted: nothing
+    // synchronized is missing, and nothing device-local sneaks in.
+    const synchronized = LIBRARY_CORE_FIELD_REGISTRY.filter(
+      (entry) =>
+        entry.registryKey.startsWith("library-core-v1:preferences.") &&
+        entry.currentLocality === "legacy-synchronized",
+    ).map((entry) => entry.registryKey);
+    expect([...keys].sort(compareCodeUnits)).toStrictEqual(
+      synchronized.sort(compareCodeUnits),
+    );
+
+    // Guard the guard. A filter that matched nothing would satisfy the equality
+    // above against an equally empty expectation.
+    expect(keys.length).toBeGreaterThan(30);
+
+    const nonSynchronized = new Set(
+      LIBRARY_CORE_FIELD_REGISTRY.filter(
+        (entry) =>
+          entry.registryKey.startsWith("library-core-v1:preferences.") &&
+          entry.currentLocality !== "legacy-synchronized",
+      ).map((entry) => entry.registryKey),
+    );
+    expect(nonSynchronized.size).toBeGreaterThan(10);
+    for (const key of keys) {
+      expect(nonSynchronized.has(key)).toBe(false);
+    }
+
+    // The device-local leaves whose leaking would be most visible, named so the
+    // exclusion is not merely a count.
+    for (const excluded of [
+      "library-core-v1:preferences.ai.ollamaUrl",
+      "library-core-v1:preferences.display.themeId",
+    ]) {
+      expect(nonSynchronized.has(excluded)).toBe(true);
+      expect(keys).not.toContain(excluded);
+    }
   });
 
   it("keeps saved and archived written-leaf sets faithful to the legacy mutators", () => {


### PR DESCRIPTION
(AI Generated).

## A census blocker actually drops

`preferences_leaf_assignment` loses `touched_fields_unresolved`. That is the third operation to close a contract field, and the first outside the feed item family.

The blocker is derived, not edited: `plannedOperation()` computes it from whether the field was supplied, so supplying a traced value is the only way to drop it.

## What was traced

`updatePreferences` accepts an arbitrary `Partial<UserPreferences>`, strips it through `sanitizeUserPreferenceWrite`, and deep-merges whatever survives. It can therefore write **any** synchronized preference leaf and no others. The honest written set is the whole synchronized surface, not the subset some caller happens to use today.

Derived from the field registry rather than transcribed, so a leaf added tomorrow is included without anyone remembering.

## The derivation was checked against reality first

Before declaring anything I probed every one of the 84 preference registry leaves through `updatePreferences` into a real Automerge document and compared what landed against what the registry claims:

- Every addressable leaf marked `legacy-synchronized` lands.
- Every leaf marked `legacy-device-local` or `legacy-compatibility` does not.

Agreement was exact on every leaf the probe could address. The only apparent mismatches were the eight array-element patterns such as `storyWall.featuredItemIds[]`, and those were a limitation of the probe rather than a disagreement: a path ending in `[]` names elements of an array, which a nested-object write cannot express. Worth stating plainly, because the first run reported them as disagreements and they are not.

`preference-locality-boundary.test.ts` from #1333 already holds the second half of that statement permanently.

## What stays open, and why

`entityIdCodec` stays null. Preferences are a singleton root, not an entity map, so there is no per-entity key for a codec to validate. Declaring `LIBRARY_CORE_ENTITY_ID_CODEC_V1` here would claim a key space this operation does not have. A mutation that adds one fails the suite.

`payload_schema_unresolved`, `field_algebra_unresolved`, `transaction_member_schema_unresolved`, `materializer_unimplemented`, and `runtime_authority_inactive` all remain.

Array-element and record patterns like `...[]` and `...{groupId}` are included in the set. They are real registry keys naming real synchronized leaves, and omitting them would understate what the operation writes.

## Verification

Four mutations, all killed, each verified to have applied:

1. The derivation admits device-local leaves. This is the dishonest shortcut for this change, and the one that would leak `ai.ollamaUrl` into a declared write set.
2. The derivation narrows to the `ai` subtree only.
3. `preferences_leaf_assignment` gains an `entityIdCodec` it has no key space for.
4. The declaration is removed entirely.

The new test asserts both directions: nothing synchronized is missing, and nothing non-synchronized is present. It also guards its own filters, since a filter matching nothing would satisfy an equality against an equally empty expectation.

Worth noting that the existing #1328 enforcement did its job here. Adding the declaration failed the registry suite until the closed-contracts table was updated in the same diff, which is exactly what that table is for.

`npm run validate:feature` passes. `node scripts/validate-main-backflow.mjs` reports in sync. All three changed paths classify `isProviderVisiblePath: false` with no provider IDs.

## Boundaries

No runtime behavior changes. No operation gains write authority. `activationAllowed` untouched, and the census blocker `operation_payload_and_field_algebra_incomplete` remains.