### PR TITLE
feat: close the rss feed written-leaf inventories

### DIFF
--- a/packages/shared/src/library-core/operation-registry.ts
+++ b/packages/shared/src/library-core/operation-registry.ts
@@ -12,6 +12,8 @@ import {
   FEED_ITEM_ARCHIVE_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS,
   FEED_ITEM_SAVED_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS,
   PREFERENCES_LEAF_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS,
+  RSS_FEED_TITLE_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS,
+  RSS_FEED_UPSERT_TOUCHED_FIELD_REGISTRY_KEYS,
 } from "./operation-touched-fields.js";
 import {
   FEED_ITEM_READ_ASSIGNMENT_TRANSACTION_MEMBER_SCHEMA,
@@ -513,11 +515,17 @@ export const LIBRARY_CORE_OPERATION_REGISTRY = {
   }),
   rss_feed_title_assignment: localUserOperation({
     entityType: "RssFeed",
+    // `entityIdCodec` stays null. RSS feeds are keyed by url, a different key
+    // space from the globalId one the existing codec declaration was justified
+    // against, so reusing it here would be a new claim rather than a reuse.
+    touchedFieldRegistryKeys:
+      RSS_FEED_TITLE_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS,
     candidateStoreSurfaces: ["renameFeed"],
     legacyWorkerRequests: ["UPDATE_RSS_FEED"],
   }),
   rss_feed_upsert: localUserOperation({
     entityType: "RssFeed",
+    touchedFieldRegistryKeys: RSS_FEED_UPSERT_TOUCHED_FIELD_REGISTRY_KEYS,
     candidateStoreSurfaces: ["addFeed"],
     legacyWorkerRequests: ["ADD_RSS_FEED", "BATCH_REFRESH_FEEDS", "UPDATE_RSS_FEED"],
   }),

--- a/packages/shared/src/library-core/operation-touched-fields.ts
+++ b/packages/shared/src/library-core/operation-touched-fields.ts
@@ -15,6 +15,25 @@ import { LIBRARY_CORE_FIELD_REGISTRY } from "./field-registry.js";
  * or write authority.
  */
 
+/**
+ * Every synchronized leaf beneath a registry prefix, sorted.
+ *
+ * Derived rather than transcribed so a leaf added to the registry later is
+ * included without anyone remembering. Only `legacy-synchronized` qualifies;
+ * `legacy-device-local` and `legacy-compatibility` leaves are excluded because
+ * the sanitizers strip them before any write reaches the document.
+ */
+const synchronizedLeavesUnder = (prefix: string): readonly string[] =>
+  Object.freeze(
+    LIBRARY_CORE_FIELD_REGISTRY.filter(
+      (entry) =>
+        entry.registryKey.startsWith(prefix) &&
+        entry.currentLocality === "legacy-synchronized",
+    )
+      .map((entry) => entry.registryKey)
+      .sort((left, right) => (left < right ? -1 : left > right ? 1 : 0)),
+  );
+
 export const LIBRARY_CORE_FEED_ITEM_ARCHIVED_FIELD_REGISTRY_KEY =
   "library-core-v1:feedItems.{globalId}.userState.archived";
 
@@ -80,15 +99,38 @@ export const FEED_ITEM_SAVED_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS =
  * omitting them would understate what the operation writes.
  */
 export const PREFERENCES_LEAF_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS =
-  Object.freeze(
-    LIBRARY_CORE_FIELD_REGISTRY.filter(
-      (entry) =>
-        entry.registryKey.startsWith("library-core-v1:preferences.") &&
-        entry.currentLocality === "legacy-synchronized",
-    )
-      .map((entry) => entry.registryKey)
-      .sort((left, right) => (left < right ? -1 : left > right ? 1 : 0)),
-  );
+  synchronizedLeavesUnder("library-core-v1:preferences.");
+
+export const LIBRARY_CORE_RSS_FEED_TITLE_FIELD_REGISTRY_KEY =
+  "library-core-v1:rssFeeds.{url}.title";
+
+/**
+ * Traced from `renameFeed`, which is narrower than the worker request it uses.
+ *
+ * `renameFeed(url, title)` sends `{ title }` and nothing else, so this
+ * operation writes one leaf. `UPDATE_RSS_FEED` can carry an arbitrary partial,
+ * but the operation is a title assignment and the store surface it succeeds
+ * only ever sets the title. Declaring the whole feed surface here would
+ * overstate it.
+ */
+export const RSS_FEED_TITLE_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS =
+  Object.freeze([LIBRARY_CORE_RSS_FEED_TITLE_FIELD_REGISTRY_KEY]);
+
+/**
+ * Traced from `addRssFeed`, `updateRssFeed`, and the batch refresh path.
+ *
+ * `addRssFeed` stores a whole sanitized feed, and `UPDATE_RSS_FEED` carries an
+ * arbitrary partial through the same sanitizer, so between them any
+ * synchronized feed leaf can be written. `BATCH_REFRESH_FEEDS` is narrower
+ * still, writing only `lastFetched`, `title`, and `siteUrl`, all of which are
+ * already in this union.
+ *
+ * Derived from the field registry rather than transcribed. Checked against
+ * reality: all nineteen `rssFeeds` registry leaves agree with what actually
+ * lands through the add and update paths, with no exceptions.
+ */
+export const RSS_FEED_UPSERT_TOUCHED_FIELD_REGISTRY_KEYS =
+  synchronizedLeavesUnder("library-core-v1:rssFeeds.");
 
 /**
  * Why saved and archived still carry `field_algebra_unresolved`.

--- a/packages/shared/src/library-core/registry.test.ts
+++ b/packages/shared/src/library-core/registry.test.ts
@@ -91,6 +91,9 @@ import {
   FEED_ITEM_SAVED_ARCHIVED_EXCLUSION_INVARIANT,
   FEED_ITEM_SAVED_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS,
   PREFERENCES_LEAF_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS,
+  RSS_FEED_TITLE_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS,
+  RSS_FEED_UPSERT_TOUCHED_FIELD_REGISTRY_KEYS,
+  LIBRARY_CORE_RSS_FEED_TITLE_FIELD_REGISTRY_KEY,
   LIBRARY_CORE_FEED_ITEM_ARCHIVED_AT_FIELD_REGISTRY_KEY,
   LIBRARY_CORE_FEED_ITEM_ARCHIVED_FIELD_REGISTRY_KEY,
   LIBRARY_CORE_FEED_ITEM_SAVED_AT_FIELD_REGISTRY_KEY,
@@ -169,6 +172,17 @@ const CLOSED_OPERATION_CONTRACTS: Partial<
   preferences_leaf_assignment: {
     touchedFieldRegistryKeys:
       PREFERENCES_LEAF_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS,
+  },
+  // Traced from `renameFeed`, which sends only `{ title }`. No entityIdCodec:
+  // feeds are keyed by url, not by the globalId space the codec was justified
+  // against.
+  rss_feed_title_assignment: {
+    touchedFieldRegistryKeys:
+      RSS_FEED_TITLE_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS,
+  },
+  // Traced from `addRssFeed`, `updateRssFeed`, and the batch refresh path.
+  rss_feed_upsert: {
+    touchedFieldRegistryKeys: RSS_FEED_UPSERT_TOUCHED_FIELD_REGISTRY_KEYS,
   },
 };
 
@@ -311,6 +325,44 @@ describe("Library Core operation registry", () => {
     ]) {
       expect(nonSynchronized.has(excluded)).toBe(true);
       expect(keys).not.toContain(excluded);
+    }
+  });
+
+  it("keeps the rss feed written sets faithful to their mutators", () => {
+    // `renameFeed` sends only `{ title }`. The operation is a title
+    // assignment, so declaring the whole feed surface would overstate it.
+    expect([...RSS_FEED_TITLE_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS])
+      .toStrictEqual([LIBRARY_CORE_RSS_FEED_TITLE_FIELD_REGISTRY_KEY]);
+
+    // The upsert union is broader and must contain the title, since
+    // `updateRssFeed` and the batch refresh both write it.
+    expect(RSS_FEED_UPSERT_TOUCHED_FIELD_REGISTRY_KEYS).toContain(
+      LIBRARY_CORE_RSS_FEED_TITLE_FIELD_REGISTRY_KEY,
+    );
+    expect(RSS_FEED_UPSERT_TOUCHED_FIELD_REGISTRY_KEYS.length).toBeGreaterThan(
+      RSS_FEED_TITLE_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS.length,
+    );
+
+    // Neither set may contain a device-local or compatibility feed leaf. These
+    // four are a feed's local fetch state; replicating them would turn one
+    // machine's network trouble into every device's.
+    for (const excluded of [
+      "library-core-v1:rssFeeds.{url}.consecutiveFailures",
+      "library-core-v1:rssFeeds.{url}.lastFetchError",
+      "library-core-v1:rssFeeds.{url}.lastFetchAttemptedAt",
+      "library-core-v1:rssFeeds.{url}.nextFetchAfter",
+      "library-core-v1:rssFeeds.{url}.etag",
+      "library-core-v1:rssFeeds.{url}.lastModified",
+    ]) {
+      expect(
+        LIBRARY_CORE_FIELD_REGISTRY.some(
+          (entry) => entry.registryKey === excluded,
+        ),
+      ).toBe(true);
+      expect(RSS_FEED_UPSERT_TOUCHED_FIELD_REGISTRY_KEYS).not.toContain(excluded);
+      expect(RSS_FEED_TITLE_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS).not.toContain(
+        excluded,
+      );
     }
   });
 


### PR DESCRIPTION
(AI Generated).

## Two more blockers drop

`rss_feed_title_assignment` and `rss_feed_upsert` both lose `touched_fields_unresolved`, taking the closed count from three operations to five.

## The two are deliberately different sizes

**`rss_feed_title_assignment` writes exactly one leaf.** `renameFeed(url, title)` sends `{ title }` and nothing else. Its legacy worker request is `UPDATE_RSS_FEED`, which can carry an arbitrary partial, so it would have been easy to declare the whole feed surface here. That would overstate it. The operation is a title assignment and the store surface it succeeds only ever sets the title.

**`rss_feed_upsert` writes the union of its three legacy requests.** `addRssFeed` stores a whole sanitized feed, `UPDATE_RSS_FEED` carries an arbitrary partial through the same sanitizer, and `BATCH_REFRESH_FEEDS` writes only `lastFetched`, `title`, and `siteUrl`, all already inside that union. The union is every synchronized feed leaf.

Both directions are mutation-tested: the suite fails if the narrow one is widened and if the broad one is narrowed.

## Checked before declared

All nineteen `rssFeeds` registry leaves were probed through both the add and update paths into a real Automerge document, comparing what lands against what the registry claims. Nineteen of nineteen agreed, with no exceptions.

That matters because the excluded six are a feed's local fetch state: `consecutiveFailures`, `lastFetchError`, `lastFetchAttemptedAt`, `nextFetchAfter`, `etag`, `lastModified`. Replicating those would turn one machine's network trouble into every device's. The suite asserts each of them exists in the registry and appears in neither declared set, so the exclusion is a checked fact rather than an absence.

I also checked `BATCH_REFRESH_FEEDS` specifically for the #1339 shape, a path that writes device-local fields directly while bypassing the sanitizer. It does not. Its input type is `Pick<RssFeed, "url"> & Partial<Pick<RssFeed, "lastFetched" | "title" | "siteUrl">>`, which bounds it at compile time to three synchronized leaves.

## What stays open

`entityIdCodec` stays null for both. RSS feeds are keyed by url, which is a different key space from the globalId one the existing codec declaration was justified against in #1328. Reusing it here would be a new claim rather than a reuse, and the field registry itself distinguishes them: `library-core-v1:rssFeeds.{url}.title` against `library-core-v1:feedItems.{globalId}...`. A mutation that adds the codec fails.

Payload, algebra, transaction member, materializer, and runtime authority all remain unresolved for both.

## Also refactored

The derivation helper is now shared with the preferences set from #1341 rather than duplicated. One place decides what "every synchronized leaf under this root" means.

## Verification

Four mutations, all killed, each verified to have applied:

1. The derivation admits device-local fetch state. This is the dishonest shortcut for this change.
2. The title assignment is overstated to the whole feed surface.
3. The upsert is understated to the title only.
4. `rss_feed_upsert` gains an `entityIdCodec` for a url key space.

`npm run validate:feature` passes. `node scripts/validate-main-backflow.mjs` reports in sync. All three changed paths classify `isProviderVisiblePath: false` with no provider IDs.

## Boundaries

No runtime behavior changes. No operation gains write authority. `activationAllowed` untouched, and the census blocker `operation_payload_and_field_algebra_incomplete` remains.