### PR TITLE
feat: close the person and account written-leaf inventories

### DIFF
--- a/packages/shared/src/library-core/operation-registry.ts
+++ b/packages/shared/src/library-core/operation-registry.ts
@@ -12,6 +12,9 @@ import {
   FEED_ITEM_ARCHIVE_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS,
   FEED_ITEM_SAVED_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS,
   PREFERENCES_LEAF_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS,
+  ACCOUNT_UPSERT_TOUCHED_FIELD_REGISTRY_KEYS,
+  PERSON_REACH_OUT_APPEND_TOUCHED_FIELD_REGISTRY_KEYS,
+  PERSON_UPSERT_TOUCHED_FIELD_REGISTRY_KEYS,
   RSS_FEED_TITLE_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS,
   RSS_FEED_UPSERT_TOUCHED_FIELD_REGISTRY_KEYS,
 } from "./operation-touched-fields.js";
@@ -270,6 +273,7 @@ export const LIBRARY_CORE_OPERATION_REGISTRY = {
   }),
   account_upsert: localUserOperation({
     entityType: "Account",
+    touchedFieldRegistryKeys: ACCOUNT_UPSERT_TOUCHED_FIELD_REGISTRY_KEYS,
     candidateStoreSurfaces: [
       "addAccount",
       "addAccounts",
@@ -421,6 +425,8 @@ export const LIBRARY_CORE_OPERATION_REGISTRY = {
   }),
   person_reach_out_append: localUserOperation({
     entityType: "Person",
+    touchedFieldRegistryKeys:
+      PERSON_REACH_OUT_APPEND_TOUCHED_FIELD_REGISTRY_KEYS,
     candidateStoreSurfaces: ["logReachOut"],
     legacyWorkerRequests: ["LOG_REACH_OUT"],
   }),
@@ -442,6 +448,7 @@ export const LIBRARY_CORE_OPERATION_REGISTRY = {
   }),
   person_upsert: localUserOperation({
     entityType: "Person",
+    touchedFieldRegistryKeys: PERSON_UPSERT_TOUCHED_FIELD_REGISTRY_KEYS,
     candidateStoreSurfaces: [
       "addFriend",
       "addFriends",

--- a/packages/shared/src/library-core/operation-touched-fields.ts
+++ b/packages/shared/src/library-core/operation-touched-fields.ts
@@ -133,6 +133,48 @@ export const RSS_FEED_UPSERT_TOUCHED_FIELD_REGISTRY_KEYS =
   synchronizedLeavesUnder("library-core-v1:rssFeeds.");
 
 /**
+ * Traced from `addPerson` and `updatePerson`, plus the friend and connection
+ * surfaces that funnel into them.
+ *
+ * Both store a whole sanitized person, and `updatePerson` accepts an arbitrary
+ * partial through the same sanitizer, so between them any synchronized person
+ * leaf can be written. The four graph leaves are device-local and excluded.
+ *
+ * Checked against reality: all twenty-two `persons` registry leaves agree with
+ * what lands through the add and update paths, no exceptions.
+ */
+export const PERSON_UPSERT_TOUCHED_FIELD_REGISTRY_KEYS =
+  synchronizedLeavesUnder("library-core-v1:persons.");
+
+/**
+ * Traced from `addAccount` and `updateAccount`.
+ *
+ * Same shape as the person upsert, and checked the same way: all twenty-nine
+ * `accounts` registry leaves agree with what lands.
+ */
+export const ACCOUNT_UPSERT_TOUCHED_FIELD_REGISTRY_KEYS =
+  synchronizedLeavesUnder("library-core-v1:accounts.");
+
+/**
+ * Traced from `logReachOut`, which is far narrower than the person upsert.
+ *
+ * It appends one entry to `reachOutLog` and writes nothing else on the person.
+ * The entry is sanitized through `sanitizeReachOutLogWrite`, so exactly three
+ * leaves can be written. Verified directly: an entry carrying an unmodelled
+ * field stores `{loggedAt, channel, notes}` and drops the rest.
+ *
+ * Derived by filtering the registry rather than transcribed. A first draft
+ * spelled the key placeholder `{id}` when the registry uses `{personId}`, and
+ * hand-written keys invite exactly that. Filtering cannot misspell them.
+ */
+export const PERSON_REACH_OUT_APPEND_TOUCHED_FIELD_REGISTRY_KEYS =
+  Object.freeze(
+    PERSON_UPSERT_TOUCHED_FIELD_REGISTRY_KEYS.filter((key) =>
+      key.includes(".reachOutLog[]."),
+    ),
+  );
+
+/**
  * Why saved and archived still carry `field_algebra_unresolved`.
  *
  * `toggleSaved` and `toggleArchived` jointly maintain the invariant that an

--- a/packages/shared/src/library-core/registry.test.ts
+++ b/packages/shared/src/library-core/registry.test.ts
@@ -91,6 +91,9 @@ import {
   FEED_ITEM_SAVED_ARCHIVED_EXCLUSION_INVARIANT,
   FEED_ITEM_SAVED_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS,
   PREFERENCES_LEAF_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS,
+  ACCOUNT_UPSERT_TOUCHED_FIELD_REGISTRY_KEYS,
+  PERSON_REACH_OUT_APPEND_TOUCHED_FIELD_REGISTRY_KEYS,
+  PERSON_UPSERT_TOUCHED_FIELD_REGISTRY_KEYS,
   RSS_FEED_TITLE_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS,
   RSS_FEED_UPSERT_TOUCHED_FIELD_REGISTRY_KEYS,
   LIBRARY_CORE_RSS_FEED_TITLE_FIELD_REGISTRY_KEY,
@@ -183,6 +186,21 @@ const CLOSED_OPERATION_CONTRACTS: Partial<
   // Traced from `addRssFeed`, `updateRssFeed`, and the batch refresh path.
   rss_feed_upsert: {
     touchedFieldRegistryKeys: RSS_FEED_UPSERT_TOUCHED_FIELD_REGISTRY_KEYS,
+  },
+  // Traced from `addPerson` / `updatePerson` and the friend and connection
+  // surfaces that funnel into them.
+  person_upsert: {
+    touchedFieldRegistryKeys: PERSON_UPSERT_TOUCHED_FIELD_REGISTRY_KEYS,
+  },
+  // Traced from `addAccount` / `updateAccount`.
+  account_upsert: {
+    touchedFieldRegistryKeys: ACCOUNT_UPSERT_TOUCHED_FIELD_REGISTRY_KEYS,
+  },
+  // Traced from `logReachOut`, which appends one sanitized entry and writes
+  // nothing else on the person.
+  person_reach_out_append: {
+    touchedFieldRegistryKeys:
+      PERSON_REACH_OUT_APPEND_TOUCHED_FIELD_REGISTRY_KEYS,
   },
 };
 
@@ -326,6 +344,49 @@ describe("Library Core operation registry", () => {
       expect(nonSynchronized.has(excluded)).toBe(true);
       expect(keys).not.toContain(excluded);
     }
+  });
+
+  it("keeps the identity written sets faithful to their mutators", () => {
+    // The four graph leaves are device-local. They are one screen's layout, so
+    // replicating them would rearrange every other device's graph.
+    for (const root of ["persons", "accounts"] as const) {
+      for (const leaf of ["graphX", "graphY", "graphPinned", "graphUpdatedAt"]) {
+        const key = `library-core-v1:${root}.{${root === "persons" ? "personId" : "accountId"}}.${leaf}`;
+        expect(
+          LIBRARY_CORE_FIELD_REGISTRY.some((entry) => entry.registryKey === key),
+        ).toBe(true);
+        expect(PERSON_UPSERT_TOUCHED_FIELD_REGISTRY_KEYS).not.toContain(key);
+        expect(ACCOUNT_UPSERT_TOUCHED_FIELD_REGISTRY_KEYS).not.toContain(key);
+      }
+    }
+
+    // `logReachOut` appends one entry and touches nothing else, so its set must
+    // stay the three log leaves rather than widening to the person surface.
+    expect([...PERSON_REACH_OUT_APPEND_TOUCHED_FIELD_REGISTRY_KEYS])
+      .toStrictEqual([
+        "library-core-v1:persons.{personId}.reachOutLog[].channel",
+        "library-core-v1:persons.{personId}.reachOutLog[].loggedAt",
+        "library-core-v1:persons.{personId}.reachOutLog[].notes",
+      ]);
+    for (const key of PERSON_REACH_OUT_APPEND_TOUCHED_FIELD_REGISTRY_KEYS) {
+      expect(PERSON_UPSERT_TOUCHED_FIELD_REGISTRY_KEYS).toContain(key);
+    }
+    expect(
+      PERSON_UPSERT_TOUCHED_FIELD_REGISTRY_KEYS.length,
+    ).toBeGreaterThan(PERSON_REACH_OUT_APPEND_TOUCHED_FIELD_REGISTRY_KEYS.length);
+
+    // `person_restore` has no store surface and no worker request, so there is
+    // nothing to trace and its blocker stays. Asserted so a later declaration
+    // has to explain where it came from.
+    expect(
+      LIBRARY_CORE_OPERATION_REGISTRY.person_restore.candidateStoreSurfaces,
+    ).toStrictEqual([]);
+    expect(
+      LIBRARY_CORE_OPERATION_REGISTRY.person_restore.legacyWorkerRequests,
+    ).toStrictEqual([]);
+    expect(
+      LIBRARY_CORE_OPERATION_REGISTRY.person_restore.touchedFieldRegistryKeys,
+    ).toBeNull();
   });
 
   it("keeps the rss feed written sets faithful to their mutators", () => {


### PR DESCRIPTION
(AI Generated).

## Three more blockers drop

`person_upsert`, `account_upsert`, and `person_reach_out_append` lose `touched_fields_unresolved`, taking the closed count from five operations to eight.

## Widths differ, again on purpose

**`person_upsert` and `account_upsert` write whole records.** `addPerson` and `addAccount` store a whole sanitized entity, and the update paths accept arbitrary partials through the same sanitizers, so between them any synchronized leaf under each root can be written.

**`person_reach_out_append` writes three leaves.** `logReachOut` appends one entry to `reachOutLog` and touches nothing else on the person. The entry passes through `sanitizeReachOutLogWrite`, so exactly `loggedAt`, `channel`, and `notes` can land. Verified directly rather than inferred: an entry carrying an unmodelled field stores those three and drops the rest.

Both directions are mutation-tested. Widening the reach-out set to the whole person surface fails, and so does emptying it.

## The graph leaves stay out

Each root carries four device-local leaves: `graphX`, `graphY`, `graphPinned`, `graphUpdatedAt`. They are one screen's layout of the identity graph, so replicating them would rearrange every other device's view. The suite asserts each exists in the registry and appears in neither declared set, making the exclusion a checked fact rather than an absence.

## Checked before declared

All 22 `persons` and all 29 `accounts` registry leaves were probed through both the add and update paths into a real Automerge document, comparing what lands against what the registry claims. 22 of 22 and 29 of 29 agreed, no exceptions.

## `person_restore` keeps its blocker

It has no `candidateStoreSurfaces` and no `legacyWorkerRequests`. There is nothing to trace, so declaring anything would be invention. A test now asserts that emptiness alongside the null declaration, so a future contributor who wants to close it has to explain where the trace came from. A mutation that gives it the person upsert set fails.

## A mistake worth naming

My first draft of the reach-out keys hardcoded `library-core-v1:persons.{id}.reachOutLog[].channel`. The registry actually uses `{personId}`, and `{accountId}` for accounts. The keys are now derived by filtering the person set rather than transcribed, because hand-written registry keys invite exactly that error, and one of the mutations reproduces it.

A second, more embarrassing one: my edit script used a non-unique needle when adding imports and rewrote two usage sites as well. Vitest transpiled it happily; `tsc` caught it during `validate:feature`. Worth recording that the test suite alone would not have stopped it.

## Verification

Five mutations, all killed, each verified to have applied:

1. The person set admits the device-local graph leaves. This is the dishonest shortcut for this change.
2. The account set admits them.
3. Reach-out is widened to the whole person surface.
4. `person_restore` gains an untraceable declaration.
5. The reach-out filter matches nothing, leaving an empty declared set. This is the shape of my own placeholder mistake.

`npm run validate:feature` passes. `node scripts/validate-main-backflow.mjs` reports in sync. All three changed paths classify `isProviderVisiblePath: false` with no provider IDs.

## Boundaries

No runtime behavior changes. `legacy_friend_account_replacement_unresolved` stays on both upserts, along with payload, algebra, transaction member, materializer, and runtime authority. `activationAllowed` untouched.