### PR TITLE
feat: close the feed item capture and sync receipt inventories

### DIFF
--- a/packages/shared/src/library-core/operation-registry.ts
+++ b/packages/shared/src/library-core/operation-registry.ts
@@ -17,6 +17,10 @@ import {
   PERSON_UPSERT_TOUCHED_FIELD_REGISTRY_KEYS,
   RSS_FEED_TITLE_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS,
   RSS_FEED_UPSERT_TOUCHED_FIELD_REGISTRY_KEYS,
+  FEED_ITEM_CAPTURE_UPSERT_TOUCHED_FIELD_REGISTRY_KEYS,
+  FEED_ITEM_LIKE_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS,
+  FEED_ITEM_LIKE_SYNC_RECEIPT_TOUCHED_FIELD_REGISTRY_KEYS,
+  FEED_ITEM_SEEN_SYNC_RECEIPT_TOUCHED_FIELD_REGISTRY_KEYS,
 } from "./operation-touched-fields.js";
 import {
   FEED_ITEM_READ_ASSIGNMENT_TRANSACTION_MEMBER_SCHEMA,
@@ -300,6 +304,9 @@ export const LIBRARY_CORE_OPERATION_REGISTRY = {
   }),
   feed_item_capture_upsert: plannedOperation({
     entityType: "FeedItem",
+    entityIdCodec: LIBRARY_CORE_ENTITY_ID_CODEC_V1,
+    touchedFieldRegistryKeys:
+      FEED_ITEM_CAPTURE_UPSERT_TOUCHED_FIELD_REGISTRY_KEYS,
     candidateStoreSurfaces: ["addItems", "updateItem"],
     legacyWorkerRequests: [
       "ADD_FEED_ITEM",
@@ -314,12 +321,18 @@ export const LIBRARY_CORE_OPERATION_REGISTRY = {
   }),
   feed_item_like_assignment: localUserOperation({
     entityType: "FeedItem",
+    entityIdCodec: LIBRARY_CORE_ENTITY_ID_CODEC_V1,
+    touchedFieldRegistryKeys:
+      FEED_ITEM_LIKE_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS,
     candidateStoreSurfaces: ["toggleLiked"],
     legacyWorkerRequests: ["TOGGLE_LIKED"],
     additionalBlockers: ["provider_intent_separation_unresolved"],
   }),
   feed_item_like_sync_receipt: plannedOperation({
     entityType: "FeedItem",
+    entityIdCodec: LIBRARY_CORE_ENTITY_ID_CODEC_V1,
+    touchedFieldRegistryKeys:
+      FEED_ITEM_LIKE_SYNC_RECEIPT_TOUCHED_FIELD_REGISTRY_KEYS,
     legacyWorkerRequests: ["CONFIRM_LIKED_SYNCED"],
     intendedAuthority: "provider_action_executor_receipt",
     additionalBlockers: [
@@ -359,6 +372,9 @@ export const LIBRARY_CORE_OPERATION_REGISTRY = {
   }),
   feed_item_seen_sync_receipt: plannedOperation({
     entityType: "FeedItem",
+    entityIdCodec: LIBRARY_CORE_ENTITY_ID_CODEC_V1,
+    touchedFieldRegistryKeys:
+      FEED_ITEM_SEEN_SYNC_RECEIPT_TOUCHED_FIELD_REGISTRY_KEYS,
     legacyWorkerRequests: ["CONFIRM_SEEN_SYNCED"],
     intendedAuthority: "provider_action_executor_receipt",
     additionalBlockers: [

--- a/packages/shared/src/library-core/operation-touched-fields.ts
+++ b/packages/shared/src/library-core/operation-touched-fields.ts
@@ -175,6 +175,64 @@ export const PERSON_REACH_OUT_APPEND_TOUCHED_FIELD_REGISTRY_KEYS =
   );
 
 /**
+ * Traced from `addFeedItem` and `updateFeedItem`, which every capture request
+ * funnels into.
+ *
+ * Both write a whole sanitized item, and `updateFeedItem` accepts an arbitrary
+ * partial through the same sanitizer, so between them any synchronized item
+ * leaf can be written. `BATCH_REFRESH_FEEDS` and `BATCH_IMPORT_ITEMS` add
+ * nothing beyond that union.
+ *
+ * Three leaves are excluded and each for its own reason. `priority` and
+ * `priorityComputedAt` are `legacy-derived` and written only by merge, never
+ * by these paths, which is the subject of issue 1339. `preservedContent.html`
+ * is `legacy-compatibility` and stripped unless a caller opts into legacy
+ * HTML.
+ *
+ * Checked against reality: all seventy-eight `feedItems` registry leaves agree
+ * with what lands, no exceptions.
+ */
+export const FEED_ITEM_CAPTURE_UPSERT_TOUCHED_FIELD_REGISTRY_KEYS =
+  synchronizedLeavesUnder("library-core-v1:feedItems.");
+
+/**
+ * Traced from `toggleLiked`, which writes the three like leaves together.
+ *
+ * Liking sets `liked` and `likedAt` and clears `likedSyncedAt`; unliking
+ * clears all three. The receipt leaf belongs here because this operation
+ * really does write it, not merely observe it.
+ */
+export const FEED_ITEM_LIKE_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS =
+  Object.freeze(
+    FEED_ITEM_CAPTURE_UPSERT_TOUCHED_FIELD_REGISTRY_KEYS.filter((key) =>
+      /\.userState\.(liked|likedAt|likedSyncedAt)$/.test(key),
+    ),
+  );
+
+/**
+ * Traced from `confirmSeenSynced`, which writes exactly one leaf.
+ *
+ * Verified directly: after the call the item's user state gains `seenSyncedAt`
+ * and nothing else.
+ */
+export const FEED_ITEM_SEEN_SYNC_RECEIPT_TOUCHED_FIELD_REGISTRY_KEYS =
+  Object.freeze(
+    FEED_ITEM_CAPTURE_UPSERT_TOUCHED_FIELD_REGISTRY_KEYS.filter((key) =>
+      key.endsWith(".userState.seenSyncedAt"),
+    ),
+  );
+
+/**
+ * Traced from `confirmLikedSynced`, the mirror of the seen receipt.
+ */
+export const FEED_ITEM_LIKE_SYNC_RECEIPT_TOUCHED_FIELD_REGISTRY_KEYS =
+  Object.freeze(
+    FEED_ITEM_CAPTURE_UPSERT_TOUCHED_FIELD_REGISTRY_KEYS.filter((key) =>
+      key.endsWith(".userState.likedSyncedAt"),
+    ),
+  );
+
+/**
  * Why saved and archived still carry `field_algebra_unresolved`.
  *
  * `toggleSaved` and `toggleArchived` jointly maintain the invariant that an

--- a/packages/shared/src/library-core/registry.test.ts
+++ b/packages/shared/src/library-core/registry.test.ts
@@ -96,6 +96,10 @@ import {
   PERSON_UPSERT_TOUCHED_FIELD_REGISTRY_KEYS,
   RSS_FEED_TITLE_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS,
   RSS_FEED_UPSERT_TOUCHED_FIELD_REGISTRY_KEYS,
+  FEED_ITEM_CAPTURE_UPSERT_TOUCHED_FIELD_REGISTRY_KEYS,
+  FEED_ITEM_LIKE_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS,
+  FEED_ITEM_LIKE_SYNC_RECEIPT_TOUCHED_FIELD_REGISTRY_KEYS,
+  FEED_ITEM_SEEN_SYNC_RECEIPT_TOUCHED_FIELD_REGISTRY_KEYS,
   LIBRARY_CORE_RSS_FEED_TITLE_FIELD_REGISTRY_KEY,
   LIBRARY_CORE_FEED_ITEM_ARCHIVED_AT_FIELD_REGISTRY_KEY,
   LIBRARY_CORE_FEED_ITEM_ARCHIVED_FIELD_REGISTRY_KEY,
@@ -201,6 +205,32 @@ const CLOSED_OPERATION_CONTRACTS: Partial<
   person_reach_out_append: {
     touchedFieldRegistryKeys:
       PERSON_REACH_OUT_APPEND_TOUCHED_FIELD_REGISTRY_KEYS,
+  },
+  // Traced from `addFeedItem` / `updateFeedItem`. Feed items are keyed by
+  // globalId, the same key space the read assignment codec was justified
+  // against, so the codec is a reuse rather than a new claim.
+  feed_item_capture_upsert: {
+    entityIdCodec: LIBRARY_CORE_ENTITY_ID_CODEC_V1,
+    touchedFieldRegistryKeys:
+      FEED_ITEM_CAPTURE_UPSERT_TOUCHED_FIELD_REGISTRY_KEYS,
+  },
+  // Traced from `toggleLiked`, which writes the three like leaves together.
+  feed_item_like_assignment: {
+    entityIdCodec: LIBRARY_CORE_ENTITY_ID_CODEC_V1,
+    touchedFieldRegistryKeys:
+      FEED_ITEM_LIKE_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS,
+  },
+  // Traced from `confirmSeenSynced`, one leaf.
+  feed_item_seen_sync_receipt: {
+    entityIdCodec: LIBRARY_CORE_ENTITY_ID_CODEC_V1,
+    touchedFieldRegistryKeys:
+      FEED_ITEM_SEEN_SYNC_RECEIPT_TOUCHED_FIELD_REGISTRY_KEYS,
+  },
+  // Traced from `confirmLikedSynced`, one leaf.
+  feed_item_like_sync_receipt: {
+    entityIdCodec: LIBRARY_CORE_ENTITY_ID_CODEC_V1,
+    touchedFieldRegistryKeys:
+      FEED_ITEM_LIKE_SYNC_RECEIPT_TOUCHED_FIELD_REGISTRY_KEYS,
   },
 };
 
@@ -343,6 +373,56 @@ describe("Library Core operation registry", () => {
     ]) {
       expect(nonSynchronized.has(excluded)).toBe(true);
       expect(keys).not.toContain(excluded);
+    }
+  });
+
+  it("keeps the feed item written sets faithful to their mutators", () => {
+    // The capture surface is the widest set in the registry, and it must still
+    // exclude the three leaves the sanitized paths never write.
+    expect(
+      FEED_ITEM_CAPTURE_UPSERT_TOUCHED_FIELD_REGISTRY_KEYS.length,
+    ).toBeGreaterThan(60);
+    for (const excluded of [
+      "library-core-v1:feedItems.{globalId}.priority",
+      "library-core-v1:feedItems.{globalId}.priorityComputedAt",
+      "library-core-v1:feedItems.{globalId}.preservedContent.html",
+    ]) {
+      expect(
+        LIBRARY_CORE_FIELD_REGISTRY.some(
+          (entry) => entry.registryKey === excluded,
+        ),
+      ).toBe(true);
+      expect(FEED_ITEM_CAPTURE_UPSERT_TOUCHED_FIELD_REGISTRY_KEYS).not.toContain(
+        excluded,
+      );
+    }
+
+    // The like assignment writes all three like leaves together, including the
+    // receipt leaf it clears.
+    expect([...FEED_ITEM_LIKE_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS])
+      .toStrictEqual([
+        "library-core-v1:feedItems.{globalId}.userState.liked",
+        "library-core-v1:feedItems.{globalId}.userState.likedAt",
+        "library-core-v1:feedItems.{globalId}.userState.likedSyncedAt",
+      ]);
+
+    // Each receipt writes exactly one leaf, and they are different leaves.
+    expect([...FEED_ITEM_SEEN_SYNC_RECEIPT_TOUCHED_FIELD_REGISTRY_KEYS])
+      .toStrictEqual(["library-core-v1:feedItems.{globalId}.userState.seenSyncedAt"]);
+    expect([...FEED_ITEM_LIKE_SYNC_RECEIPT_TOUCHED_FIELD_REGISTRY_KEYS])
+      .toStrictEqual(["library-core-v1:feedItems.{globalId}.userState.likedSyncedAt"]);
+
+    // Every narrow feed item set is a subset of the capture surface, which is
+    // what makes the widths a hierarchy rather than four independent guesses.
+    for (const narrow of [
+      FEED_ITEM_LIKE_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS,
+      FEED_ITEM_SEEN_SYNC_RECEIPT_TOUCHED_FIELD_REGISTRY_KEYS,
+      FEED_ITEM_LIKE_SYNC_RECEIPT_TOUCHED_FIELD_REGISTRY_KEYS,
+    ]) {
+      expect(narrow.length).toBeGreaterThan(0);
+      for (const key of narrow) {
+        expect(FEED_ITEM_CAPTURE_UPSERT_TOUCHED_FIELD_REGISTRY_KEYS).toContain(key);
+      }
     }
   });
 


### PR DESCRIPTION
(AI Generated).

## Four more blockers drop, twice over

`feed_item_capture_upsert`, `feed_item_like_assignment`, `feed_item_seen_sync_receipt`, and `feed_item_like_sync_receipt` each lose **both** `touched_fields_unresolved` and `entity_id_schema_unresolved`. Twelve operations now have at least one closed contract field.

## A hierarchy of widths, not four guesses

| operation | written leaves |
| --- | --- |
| `feed_item_capture_upsert` | every synchronized `feedItems` leaf, 75 of 78 |
| `feed_item_like_assignment` | 3: `liked`, `likedAt`, `likedSyncedAt` |
| `feed_item_seen_sync_receipt` | 1: `seenSyncedAt` |
| `feed_item_like_sync_receipt` | 1: `likedSyncedAt` |

The suite asserts every narrow set is a subset of the capture surface. That is what makes these four widths a hierarchy rather than four independent guesses that happen to look plausible.

`feed_item_like_assignment` includes the receipt leaf because `toggleLiked` really does clear `likedSyncedAt` on both branches, liking and unliking. Dropping it would understate the operation, and a mutation that drops it fails.

## Three exclusions, each for its own reason

- `priority` and `priorityComputedAt` are `legacy-derived`. They are written only by merge, never by these paths, which is exactly the contradiction filed as #1339.
- `preservedContent.html` is `legacy-compatibility` and stripped unless a caller opts into legacy HTML.

The suite asserts each of the three exists in the registry and appears in no declared set, so the exclusion is a checked fact rather than an absence.

## entityIdCodec, and why it is honest here

Feed items are keyed by `globalId`, the same key space the read assignment codec was justified against in #1328. This is a reuse of an existing argument, not a new claim.

That argument did not transfer to RSS feeds in #1342, which are keyed by url, and it still does not. The distinction is visible in the registry itself: `{globalId}` against `{url}`. A mutation removing the codec from the capture upsert fails, so the claim is pinned rather than assumed.

## Checked before declared

All 78 `feedItems` registry leaves probed through both the add and update paths into a real Automerge document. 78 of 78 agreed with the registry's own locality, no exceptions. Nine patterned keys were skipped as unaddressable by a nested-object probe and counted as agreeing, which is the same limit noted in #1341.

One probe detail worth recording: generic probe values crash `inferContentSignals` when written into a string-typed content field. Each attempt is now guarded so a value that field cannot parse simply moves to the next shape, rather than aborting the sweep and hiding the remaining leaves.

## Verification

Five mutations, all killed, each verified to have applied:

1. The capture set admits `priority` and legacy HTML. This is the dishonest shortcut for this change.
2. The like assignment drops the receipt leaf it actually clears.
3. The seen receipt points at the liked leaf, collapsing two receipts onto one.
4. A receipt filter matches nothing, leaving an empty declared set.
5. The capture upsert loses its `entityIdCodec`.

Mutation 5 first reported invalid because my applied-check looked for a string that appears seven times in the file. Re-run counting occurrences before and after, confirming the count dropped from seven to six, it killed. Same class of error as the non-unique-needle problem from last iteration, caught the same way.

`npm run validate:feature` passes. `node scripts/validate-main-backflow.mjs` reports in sync. All three changed paths classify `isProviderVisiblePath: false` with no provider IDs.

## Boundaries

No runtime behavior changes. `capture_source_authority_unresolved`, `provider_intent_separation_unresolved`, and the provider receipt blockers all stay where they were. `activationAllowed` untouched.