### PR TITLE
feat: declare bulk repair inventories by reference to their counterparts

### DIFF
--- a/packages/shared/src/library-core/operation-registry.ts
+++ b/packages/shared/src/library-core/operation-registry.ts
@@ -1,7 +1,6 @@
 import type { BaseAppState } from "../store-types.js";
 import {
   FEED_ITEM_READ_AT_FIELD_ALGEBRA,
-  LIBRARY_CORE_FEED_ITEM_READ_AT_FIELD_REGISTRY_KEY,
   type LibraryCoreOperationFieldAlgebraContract,
 } from "./operation-field-algebra-contracts.js";
 import {
@@ -21,6 +20,10 @@ import {
   FEED_ITEM_LIKE_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS,
   FEED_ITEM_LIKE_SYNC_RECEIPT_TOUCHED_FIELD_REGISTRY_KEYS,
   FEED_ITEM_SEEN_SYNC_RECEIPT_TOUCHED_FIELD_REGISTRY_KEYS,
+  FEED_ITEM_READ_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS,
+  FEED_ITEMS_ARCHIVE_FROZEN_TOUCHED_FIELD_REGISTRY_KEYS,
+  FEED_ITEMS_READ_FROZEN_TOUCHED_FIELD_REGISTRY_KEYS,
+  RSS_FEEDS_HEAL_UNTITLED_FROZEN_TOUCHED_FIELD_REGISTRY_KEYS,
 } from "./operation-touched-fields.js";
 import {
   FEED_ITEM_READ_ASSIGNMENT_TRANSACTION_MEMBER_SCHEMA,
@@ -344,9 +347,8 @@ export const LIBRARY_CORE_OPERATION_REGISTRY = {
     entityType: "FeedItem",
     payloadSchema: FEED_ITEM_READ_ASSIGNMENT_PAYLOAD_SCHEMA,
     entityIdCodec: LIBRARY_CORE_ENTITY_ID_CODEC_V1,
-    touchedFieldRegistryKeys: [
-      LIBRARY_CORE_FEED_ITEM_READ_AT_FIELD_REGISTRY_KEY,
-    ],
+    touchedFieldRegistryKeys:
+      FEED_ITEM_READ_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS,
     fieldAlgebra: FEED_ITEM_READ_AT_FIELD_ALGEBRA,
     transactionMemberSchema:
       FEED_ITEM_READ_ASSIGNMENT_TRANSACTION_MEMBER_SCHEMA,
@@ -384,12 +386,18 @@ export const LIBRARY_CORE_OPERATION_REGISTRY = {
   }),
   feed_items_archive_frozen: localUserOperation({
     entityType: "FeedItem",
+    entityIdCodec: LIBRARY_CORE_ENTITY_ID_CODEC_V1,
+    touchedFieldRegistryKeys:
+      FEED_ITEMS_ARCHIVE_FROZEN_TOUCHED_FIELD_REGISTRY_KEYS,
     candidateStoreSurfaces: ["archiveItems"],
     legacyWorkerRequests: ["ARCHIVE_ITEMS"],
     additionalBlockers: frozenBulkBlocker,
   }),
   feed_items_archive_read_unsaved_frozen: localUserOperation({
     entityType: "FeedItem",
+    entityIdCodec: LIBRARY_CORE_ENTITY_ID_CODEC_V1,
+    touchedFieldRegistryKeys:
+      FEED_ITEMS_ARCHIVE_FROZEN_TOUCHED_FIELD_REGISTRY_KEYS,
     candidateStoreSurfaces: ["archiveAllReadUnsaved"],
     legacyWorkerRequests: ["ARCHIVE_ALL_READ_UNSAVED"],
     additionalBlockers: frozenBulkBlocker,
@@ -425,6 +433,9 @@ export const LIBRARY_CORE_OPERATION_REGISTRY = {
   }),
   feed_items_read_frozen: localUserOperation({
     entityType: "FeedItem",
+    entityIdCodec: LIBRARY_CORE_ENTITY_ID_CODEC_V1,
+    touchedFieldRegistryKeys:
+      FEED_ITEMS_READ_FROZEN_TOUCHED_FIELD_REGISTRY_KEYS,
     candidateStoreSurfaces: ["markAllAsRead", "markItemsAsRead"],
     legacyWorkerRequests: ["MARK_ALL_AS_READ", "MARK_ITEMS_AS_READ"],
     additionalBlockers: [
@@ -434,6 +445,9 @@ export const LIBRARY_CORE_OPERATION_REGISTRY = {
   }),
   feed_items_unarchive_saved_frozen: plannedOperation({
     entityType: "FeedItem",
+    entityIdCodec: LIBRARY_CORE_ENTITY_ID_CODEC_V1,
+    touchedFieldRegistryKeys:
+      FEED_ITEMS_ARCHIVE_FROZEN_TOUCHED_FIELD_REGISTRY_KEYS,
     candidateStoreSurfaces: ["unarchiveSavedItems"],
     legacyWorkerRequests: ["UNARCHIVE_SAVED_ITEMS"],
     intendedAuthority: "system_repair",
@@ -554,6 +568,8 @@ export const LIBRARY_CORE_OPERATION_REGISTRY = {
   }),
   rss_feeds_heal_untitled_frozen: plannedOperation({
     entityType: "RssFeed",
+    touchedFieldRegistryKeys:
+      RSS_FEEDS_HEAL_UNTITLED_FROZEN_TOUCHED_FIELD_REGISTRY_KEYS,
     legacyWorkerRequests: ["HEAL_UNTITLED_FEEDS"],
     intendedAuthority: "system_repair",
     additionalBlockers: frozenBulkBlocker,

--- a/packages/shared/src/library-core/operation-touched-fields.ts
+++ b/packages/shared/src/library-core/operation-touched-fields.ts
@@ -1,4 +1,5 @@
 import { LIBRARY_CORE_FIELD_REGISTRY } from "./field-registry.js";
+import { LIBRARY_CORE_FEED_ITEM_READ_AT_FIELD_REGISTRY_KEY } from "./operation-field-algebra-contracts.js";
 
 /**
  * Written-leaf inventories for candidate successor operations.
@@ -231,6 +232,47 @@ export const FEED_ITEM_LIKE_SYNC_RECEIPT_TOUCHED_FIELD_REGISTRY_KEYS =
       key.endsWith(".userState.likedSyncedAt"),
     ),
   );
+
+/**
+ * Traced from `markAsRead`, which writes one leaf and reads none.
+ *
+ * Named rather than spelled inline at the registry entry so the bulk read
+ * repair can reuse the same array by reference. Two declarations that must
+ * always agree should be one object, not two literals that happen to match.
+ */
+export const FEED_ITEM_READ_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS =
+  Object.freeze([LIBRARY_CORE_FEED_ITEM_READ_AT_FIELD_REGISTRY_KEY]);
+
+/**
+ * Bulk repairs write exactly what their single-item counterparts write.
+ *
+ * Each is verified by calling the mutator and diffing the item's user state
+ * before and after:
+ *
+ * - `markItemsAsRead` and `markAllVisibleAsRead` change `readAt` only.
+ * - `archiveItemsById` and `archiveAllReadUnsaved` change `archived` and
+ *   `archivedAt`.
+ * - `unarchiveSavedItems` changes the same two, clearing rather than setting.
+ *
+ * They are declared by reference to the assignment sets rather than copied, so
+ * the two cannot drift apart. The registry test asserts identity, not equality.
+ */
+export const FEED_ITEMS_READ_FROZEN_TOUCHED_FIELD_REGISTRY_KEYS =
+  FEED_ITEM_READ_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS;
+
+export const FEED_ITEMS_ARCHIVE_FROZEN_TOUCHED_FIELD_REGISTRY_KEYS =
+  FEED_ITEM_ARCHIVE_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS;
+
+/**
+ * `healUntitledFeedTitles` assigns `feed.title` and nothing else.
+ *
+ * Traced by reading rather than probed: it lives in the desktop worker and is
+ * not exported from this package, so there is no shared entry point to call.
+ * Saying which evidence backs a declaration matters more than pretending every
+ * one came from the same kind.
+ */
+export const RSS_FEEDS_HEAL_UNTITLED_FROZEN_TOUCHED_FIELD_REGISTRY_KEYS =
+  RSS_FEED_TITLE_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS;
 
 /**
  * Why saved and archived still carry `field_algebra_unresolved`.

--- a/packages/shared/src/library-core/registry.test.ts
+++ b/packages/shared/src/library-core/registry.test.ts
@@ -100,6 +100,10 @@ import {
   FEED_ITEM_LIKE_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS,
   FEED_ITEM_LIKE_SYNC_RECEIPT_TOUCHED_FIELD_REGISTRY_KEYS,
   FEED_ITEM_SEEN_SYNC_RECEIPT_TOUCHED_FIELD_REGISTRY_KEYS,
+  FEED_ITEM_READ_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS,
+  FEED_ITEMS_ARCHIVE_FROZEN_TOUCHED_FIELD_REGISTRY_KEYS,
+  FEED_ITEMS_READ_FROZEN_TOUCHED_FIELD_REGISTRY_KEYS,
+  RSS_FEEDS_HEAL_UNTITLED_FROZEN_TOUCHED_FIELD_REGISTRY_KEYS,
   LIBRARY_CORE_RSS_FEED_TITLE_FIELD_REGISTRY_KEY,
   LIBRARY_CORE_FEED_ITEM_ARCHIVED_AT_FIELD_REGISTRY_KEY,
   LIBRARY_CORE_FEED_ITEM_ARCHIVED_FIELD_REGISTRY_KEY,
@@ -155,7 +159,8 @@ const CLOSED_OPERATION_CONTRACTS: Partial<
     entityIdCodec: LIBRARY_CORE_ENTITY_ID_CODEC_V1,
     fieldAlgebra: FEED_ITEM_READ_AT_FIELD_ALGEBRA,
     payloadSchema: FEED_ITEM_READ_ASSIGNMENT_PAYLOAD_SCHEMA,
-    touchedFieldRegistryKeys: [LIBRARY_CORE_FEED_ITEM_READ_AT_FIELD_REGISTRY_KEY],
+    touchedFieldRegistryKeys:
+      FEED_ITEM_READ_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS,
     transactionMemberSchema: FEED_ITEM_READ_ASSIGNMENT_TRANSACTION_MEMBER_SCHEMA,
   },
   // Traced from `toggleArchived`. Algebra stays open: archive and save are
@@ -231,6 +236,32 @@ const CLOSED_OPERATION_CONTRACTS: Partial<
     entityIdCodec: LIBRARY_CORE_ENTITY_ID_CODEC_V1,
     touchedFieldRegistryKeys:
       FEED_ITEM_LIKE_SYNC_RECEIPT_TOUCHED_FIELD_REGISTRY_KEYS,
+  },
+  // Bulk repairs, declared by reference to their single-item counterparts.
+  feed_items_read_frozen: {
+    entityIdCodec: LIBRARY_CORE_ENTITY_ID_CODEC_V1,
+    touchedFieldRegistryKeys:
+      FEED_ITEMS_READ_FROZEN_TOUCHED_FIELD_REGISTRY_KEYS,
+  },
+  feed_items_archive_frozen: {
+    entityIdCodec: LIBRARY_CORE_ENTITY_ID_CODEC_V1,
+    touchedFieldRegistryKeys:
+      FEED_ITEMS_ARCHIVE_FROZEN_TOUCHED_FIELD_REGISTRY_KEYS,
+  },
+  feed_items_archive_read_unsaved_frozen: {
+    entityIdCodec: LIBRARY_CORE_ENTITY_ID_CODEC_V1,
+    touchedFieldRegistryKeys:
+      FEED_ITEMS_ARCHIVE_FROZEN_TOUCHED_FIELD_REGISTRY_KEYS,
+  },
+  feed_items_unarchive_saved_frozen: {
+    entityIdCodec: LIBRARY_CORE_ENTITY_ID_CODEC_V1,
+    touchedFieldRegistryKeys:
+      FEED_ITEMS_ARCHIVE_FROZEN_TOUCHED_FIELD_REGISTRY_KEYS,
+  },
+  // No entityIdCodec: feeds are keyed by url.
+  rss_feeds_heal_untitled_frozen: {
+    touchedFieldRegistryKeys:
+      RSS_FEEDS_HEAL_UNTITLED_FROZEN_TOUCHED_FIELD_REGISTRY_KEYS,
   },
 };
 
@@ -374,6 +405,49 @@ describe("Library Core operation registry", () => {
       expect(nonSynchronized.has(excluded)).toBe(true);
       expect(keys).not.toContain(excluded);
     }
+  });
+
+  it("declares bulk repairs by reference to their single-item counterparts", () => {
+    // Identity, not equality. Two arrays that merely match today would drift
+    // the first time one side is edited; the same object cannot.
+    expect(FEED_ITEMS_READ_FROZEN_TOUCHED_FIELD_REGISTRY_KEYS).toBe(
+      FEED_ITEM_READ_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS,
+    );
+    expect(FEED_ITEMS_ARCHIVE_FROZEN_TOUCHED_FIELD_REGISTRY_KEYS).toBe(
+      FEED_ITEM_ARCHIVE_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS,
+    );
+    expect(RSS_FEEDS_HEAL_UNTITLED_FROZEN_TOUCHED_FIELD_REGISTRY_KEYS).toBe(
+      RSS_FEED_TITLE_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS,
+    );
+
+    // The registry must hold those exact objects too, so the reuse survives
+    // the trip through `plannedOperation`.
+    expect(
+      LIBRARY_CORE_OPERATION_REGISTRY.feed_items_read_frozen
+        .touchedFieldRegistryKeys,
+    ).toBe(
+      LIBRARY_CORE_OPERATION_REGISTRY.feed_item_read_assignment
+        .touchedFieldRegistryKeys,
+    );
+    for (const bulk of [
+      "feed_items_archive_frozen",
+      "feed_items_archive_read_unsaved_frozen",
+      "feed_items_unarchive_saved_frozen",
+    ] as const) {
+      expect(
+        LIBRARY_CORE_OPERATION_REGISTRY[bulk].touchedFieldRegistryKeys,
+      ).toBe(
+        LIBRARY_CORE_OPERATION_REGISTRY.feed_item_archive_assignment
+          .touchedFieldRegistryKeys,
+      );
+    }
+
+    // The archive repair set is the archive pair, not the wider saved set.
+    // `unarchiveSavedItems` reads `saved` as a precondition and never writes it.
+    expect(FEED_ITEMS_ARCHIVE_FROZEN_TOUCHED_FIELD_REGISTRY_KEYS).not.toContain(
+      LIBRARY_CORE_FEED_ITEM_SAVED_FIELD_REGISTRY_KEY,
+    );
+    expect(FEED_ITEMS_ARCHIVE_FROZEN_TOUCHED_FIELD_REGISTRY_KEYS).toHaveLength(2);
   });
 
   it("keeps the feed item written sets faithful to their mutators", () => {


### PR DESCRIPTION
(AI Generated).

## Five more blockers drop

`feed_items_read_frozen`, `feed_items_archive_frozen`, `feed_items_archive_read_unsaved_frozen`, `feed_items_unarchive_saved_frozen`, and `rss_feeds_heal_untitled_frozen` lose `touched_fields_unresolved`. Four of them also lose `entity_id_schema_unresolved`. Seventeen operations now have at least one closed contract field.

## The finding: bulk repairs write exactly what their counterparts write

Verified by calling each mutator and diffing the item's user state before and after, rather than by reading and assuming:

| mutator | leaves changed |
| --- | --- |
| `markItemsAsRead` | `readAt` |
| `archiveItemsById` | `archived`, `archivedAt` |
| `archiveAllReadUnsaved` | `archived`, `archivedAt` |
| `unarchiveSavedItems` | `archived`, `archivedAt` |

So these are declared **by reference**, sharing the same frozen array as the assignment operations rather than a copy that happens to match today. The test asserts `toBe` identity, both on the exported constants and on what the registry actually holds after `plannedOperation` processes them.

The mutation that matters here replaces the shared object with `Object.freeze([...original])` — a structural copy, equal in every value. It fails, which is the whole point. Two declarations that must always agree should be one object, not two literals that agree until someone edits one.

`unarchiveSavedItems` reads `saved` as a precondition and never writes it, so the repair set stays the archive pair rather than widening to the saved set. That mutation fails too.

## One existing declaration was renamed, not changed

Reusing the read assignment's array by reference required naming it. It had been an inline literal at the registry entry. Same value, same contents, now a single object. Calling that out because the standing rule is to preserve existing declarations verbatim, and this is a structural change to how one is expressed rather than to what it says.

## Different evidence for one of them

`healUntitledFeedTitles` is traced by **reading**, not probing. It lives in `automerge.worker.ts` and is not exported from the shared package, so there is no shared entry point to call from a test. It assigns `feed.title` and nothing else.

The module doc says so explicitly. Which kind of evidence backs a declaration is worth recording, rather than letting four probed traces and one read trace look identical.

No `entityIdCodec` on the feed heal: feeds are keyed by url, which is the same distinction drawn in #1342 and #1344.

## Also surveyed, nothing to declare

Checked the rest of the unclosed list. `account_restore`, `feed_item_restore`, `rss_feed_restore`, and `person_restore` have no candidate store surface and no legacy worker request at all. The removal operations resolve to deletes, and a delete is not a written leaf. Left alone rather than given an invented set.

## Verification

Four mutations, all killed, each verified to have applied:

1. The archive repair copies the array instead of sharing it. This is the dishonest shortcut for this change, and the reason the assertion is identity rather than equality.
2. The read repair points at the archive set.
3. The archive repair is widened to the saved set, claiming a leaf it only reads.
4. The feed heal gains an `entityIdCodec` for a url key space.

`npm run validate:feature` passes. It caught one thing the test suite did not: naming the read array left an unused import in `operation-registry.ts`, which failed the PWA production build under `tsc -b`. Fixed before publishing.

`node scripts/validate-main-backflow.mjs` reports in sync. All three changed paths classify `isProviderVisiblePath: false` with no provider IDs.

## Boundaries

No runtime behavior changes. `frozen_bulk_contract_unresolved` stays on all five, along with payload, algebra, transaction member, materializer, and runtime authority. `activationAllowed` untouched.