### PR TITLE
feat: close the account assignment and signal backfill inventories

### DIFF
--- a/packages/shared/src/library-core/operation-registry.ts
+++ b/packages/shared/src/library-core/operation-registry.ts
@@ -24,6 +24,8 @@ import {
   FEED_ITEMS_ARCHIVE_FROZEN_TOUCHED_FIELD_REGISTRY_KEYS,
   FEED_ITEMS_READ_FROZEN_TOUCHED_FIELD_REGISTRY_KEYS,
   RSS_FEEDS_HEAL_UNTITLED_FROZEN_TOUCHED_FIELD_REGISTRY_KEYS,
+  ACCOUNT_PERSON_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS,
+  FEED_ITEMS_CONTENT_SIGNALS_BACKFILL_TOUCHED_FIELD_REGISTRY_KEYS,
 } from "./operation-touched-fields.js";
 import {
   FEED_ITEM_READ_ASSIGNMENT_TRANSACTION_MEMBER_SCHEMA,
@@ -261,6 +263,8 @@ const frozenBulkBlocker = [
 export const LIBRARY_CORE_OPERATION_REGISTRY = {
   account_person_assignment: localUserOperation({
     entityType: "Account",
+    touchedFieldRegistryKeys:
+      ACCOUNT_PERSON_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS,
     candidateStoreSurfaces: [
       "createConnectionPersonFromAccounts",
       "createConnectionPersonsFromCandidates",
@@ -404,6 +408,9 @@ export const LIBRARY_CORE_OPERATION_REGISTRY = {
   }),
   feed_items_content_signals_backfill_frozen: plannedOperation({
     entityType: "FeedItem",
+    entityIdCodec: LIBRARY_CORE_ENTITY_ID_CODEC_V1,
+    touchedFieldRegistryKeys:
+      FEED_ITEMS_CONTENT_SIGNALS_BACKFILL_TOUCHED_FIELD_REGISTRY_KEYS,
     legacyWorkerRequests: ["BACKFILL_CONTENT_SIGNALS"],
     intendedAuthority: "system_repair",
     additionalBlockers: frozenBulkBlocker,

--- a/packages/shared/src/library-core/operation-touched-fields.ts
+++ b/packages/shared/src/library-core/operation-touched-fields.ts
@@ -275,6 +275,49 @@ export const RSS_FEEDS_HEAL_UNTITLED_FROZEN_TOUCHED_FIELD_REGISTRY_KEYS =
   RSS_FEED_TITLE_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS;
 
 /**
+ * Traced from `linkAccountToPerson` and the `UPSERT_CONNECTION_PERSONS`
+ * handler, which write the same two leaves.
+ *
+ * Both set `personId` and stamp `updatedAt`, and nothing else on the account.
+ * Verified by diffing the stored account before and after.
+ *
+ * `updateAccount` also appears among this operation's candidate surfaces
+ * because it is the generic mechanism the assignment goes through, the same
+ * way `UPDATE_RSS_FEED` appears under the feed title assignment. The operation
+ * is an assignment, so it gets the assignment's leaves rather than the whole
+ * account surface.
+ */
+export const ACCOUNT_PERSON_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS =
+  Object.freeze(
+    ACCOUNT_UPSERT_TOUCHED_FIELD_REGISTRY_KEYS.filter((key) =>
+      /\.(personId|updatedAt)$/.test(key),
+    ),
+  );
+
+/**
+ * Traced from `backfillContentSignals`, which calls
+ * `applySemanticEnrichmentToItem` on items missing current signals.
+ *
+ * That call is `applyContentSignalsToItem` followed by
+ * `applyEventCandidateToItem`, so the written set is the union of both
+ * subtrees.
+ *
+ * Evidence differs between the two halves and that is worth stating. The
+ * `contentSignals` leaves were probed: running the backfill over an item with
+ * its signals stripped changes those and nothing else. The `eventCandidate`
+ * leaves are read-traced from the same enrichment call, because whether a
+ * given item yields an event candidate depends on heuristic inference that a
+ * fixture cannot reliably force.
+ */
+export const FEED_ITEMS_CONTENT_SIGNALS_BACKFILL_TOUCHED_FIELD_REGISTRY_KEYS =
+  Object.freeze(
+    FEED_ITEM_CAPTURE_UPSERT_TOUCHED_FIELD_REGISTRY_KEYS.filter(
+      (key) =>
+        key.includes(".contentSignals.") || key.includes(".eventCandidate."),
+    ),
+  );
+
+/**
  * Why saved and archived still carry `field_algebra_unresolved`.
  *
  * `toggleSaved` and `toggleArchived` jointly maintain the invariant that an

--- a/packages/shared/src/library-core/registry.test.ts
+++ b/packages/shared/src/library-core/registry.test.ts
@@ -104,6 +104,8 @@ import {
   FEED_ITEMS_ARCHIVE_FROZEN_TOUCHED_FIELD_REGISTRY_KEYS,
   FEED_ITEMS_READ_FROZEN_TOUCHED_FIELD_REGISTRY_KEYS,
   RSS_FEEDS_HEAL_UNTITLED_FROZEN_TOUCHED_FIELD_REGISTRY_KEYS,
+  ACCOUNT_PERSON_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS,
+  FEED_ITEMS_CONTENT_SIGNALS_BACKFILL_TOUCHED_FIELD_REGISTRY_KEYS,
   LIBRARY_CORE_RSS_FEED_TITLE_FIELD_REGISTRY_KEY,
   LIBRARY_CORE_FEED_ITEM_ARCHIVED_AT_FIELD_REGISTRY_KEY,
   LIBRARY_CORE_FEED_ITEM_ARCHIVED_FIELD_REGISTRY_KEY,
@@ -263,6 +265,19 @@ const CLOSED_OPERATION_CONTRACTS: Partial<
     touchedFieldRegistryKeys:
       RSS_FEEDS_HEAL_UNTITLED_FROZEN_TOUCHED_FIELD_REGISTRY_KEYS,
   },
+  // Traced from `linkAccountToPerson` and the connection-person handler, both
+  // of which set personId and stamp updatedAt. No codec: accounts are keyed by
+  // accountId, not the feed item globalId space.
+  account_person_assignment: {
+    touchedFieldRegistryKeys:
+      ACCOUNT_PERSON_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS,
+  },
+  // Traced from `backfillContentSignals`, which re-runs semantic enrichment.
+  feed_items_content_signals_backfill_frozen: {
+    entityIdCodec: LIBRARY_CORE_ENTITY_ID_CODEC_V1,
+    touchedFieldRegistryKeys:
+      FEED_ITEMS_CONTENT_SIGNALS_BACKFILL_TOUCHED_FIELD_REGISTRY_KEYS,
+  },
 };
 
 describe("Library Core operation registry", () => {
@@ -405,6 +420,41 @@ describe("Library Core operation registry", () => {
       expect(nonSynchronized.has(excluded)).toBe(true);
       expect(keys).not.toContain(excluded);
     }
+  });
+
+  it("keeps the narrow assignment and backfill sets narrow", () => {
+    // The account assignment sets personId and stamps updatedAt. Declaring the
+    // whole account surface would overstate it, exactly as it would for the
+    // feed title assignment.
+    expect([...ACCOUNT_PERSON_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS])
+      .toStrictEqual([
+        "library-core-v1:accounts.{accountId}.personId",
+        "library-core-v1:accounts.{accountId}.updatedAt",
+      ]);
+    expect(
+      ACCOUNT_UPSERT_TOUCHED_FIELD_REGISTRY_KEYS.length,
+    ).toBeGreaterThan(ACCOUNT_PERSON_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS.length);
+    for (const key of ACCOUNT_PERSON_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS) {
+      expect(ACCOUNT_UPSERT_TOUCHED_FIELD_REGISTRY_KEYS).toContain(key);
+    }
+
+    // The backfill re-runs semantic enrichment, so it writes both enrichment
+    // subtrees and nothing outside them.
+    const backfill = FEED_ITEMS_CONTENT_SIGNALS_BACKFILL_TOUCHED_FIELD_REGISTRY_KEYS;
+    expect(backfill.length).toBeGreaterThan(3);
+    for (const key of backfill) {
+      expect(
+        key.includes(".contentSignals.") || key.includes(".eventCandidate."),
+      ).toBe(true);
+      expect(FEED_ITEM_CAPTURE_UPSERT_TOUCHED_FIELD_REGISTRY_KEYS).toContain(key);
+    }
+    // Both halves are present. A filter that matched only one subtree would
+    // understate the enrichment call.
+    expect(backfill.some((key) => key.includes(".contentSignals."))).toBe(true);
+    expect(backfill.some((key) => key.includes(".eventCandidate."))).toBe(true);
+
+    // It must not claim the item body it never touches.
+    expect(backfill).not.toContain("library-core-v1:feedItems.{globalId}.content.text");
   });
 
   it("declares bulk repairs by reference to their single-item counterparts", () => {


### PR DESCRIPTION
(AI Generated).

## Two more blockers drop

`account_person_assignment` and `feed_items_content_signals_backfill_frozen` lose `touched_fields_unresolved`. Nineteen operations now have at least one closed contract field.

## `account_person_assignment` writes two leaves

`linkAccountToPerson` and the `UPSERT_CONNECTION_PERSONS` handler both set `personId` and stamp `updatedAt`, and touch nothing else on the account. Verified by diffing the stored record before and after.

`updateAccount` also appears among this operation's candidate surfaces, and it accepts an arbitrary partial. It is there because it is the generic mechanism the assignment goes through, exactly as `UPDATE_RSS_FEED` appears under the feed title assignment in #1342. The operation is an assignment, so it gets the assignment's leaves rather than the whole account surface. The suite asserts the narrow set is a strict subset of the upsert set, and widening it fails.

No `entityIdCodec`: accounts are keyed by `accountId`, not the feed item `globalId` space the codec was justified against. That mutation fails too.

## The backfill writes both enrichment subtrees

`backfillContentSignals` calls `applySemanticEnrichmentToItem`, which is `applyContentSignalsToItem` followed by `applyEventCandidateToItem`. Its set is the union of `contentSignals.*` and `eventCandidate.*`, and nothing outside them.

**The evidence differs between the two halves, and the module records which is which.** The `contentSignals` leaves were probed: running the backfill over an item with its signals stripped changes exactly those. The `eventCandidate` leaves are read-traced from the same enrichment call, because whether a given item yields an event candidate depends on heuristic inference that a fixture cannot reliably force.

I could have written a probe that only exercised `contentSignals` and declared the union anyway without mentioning it. Saying which half is probed and which is read is the difference between a traced declaration and a plausible one.

## Verification

Five mutations, all killed, each verified to have applied:

1. The account assignment is widened to the whole account surface. This is the dishonest shortcut for this change.
2. The account assignment drops the `updatedAt` stamp it really writes.
3. The backfill drops the `eventCandidate` subtree, which is the half backed by the weaker evidence and therefore the one most worth pinning.
4. The backfill is widened to the whole capture surface.
5. The account assignment gains an `entityIdCodec` for an `accountId` key space.

`npm run validate:feature` passes. `node scripts/validate-main-backflow.mjs` reports in sync. All three changed paths classify `isProviderVisiblePath: false` with no provider IDs.

## The census lane is nearly dry

What remains genuinely has nothing to declare, and I checked rather than assuming:

- `account_restore`, `feed_item_restore`, `rss_feed_restore`, `person_restore`: no candidate store surface, no legacy worker request.
- `feed_item_remove`, `account_remove`, `rss_feed_remove_*`, `rss_feeds_remove_*`, `person_remove_*`, `sample_library_remove`, `feed_items_delete_archived_frozen`, `feed_items_prune_archived_frozen`: these resolve to deletes, and a delete is not a written leaf.
- `feed_items_deduplicate_frozen` writes through `mergeFeedItemInto` and also deletes the losing item, so it is entangled with #1339 and #1334.
- `provider_capture_snapshot_reconcile` and `provider_intent` are broad and keep their provider blockers regardless.

Next iteration will likely move to the Rust fail-closed variants that still have zero test assertions.

## Boundaries

No runtime behavior changes. `legacy_friend_account_replacement_unresolved` stays on the account assignment, `frozen_bulk_contract_unresolved` on the backfill, and payload, algebra, transaction member, materializer, and runtime authority on both. `activationAllowed` untouched.