### PR TITLE
chore: prove the projection rebuild guards fire

### DIFF
--- a/packages/desktop/src-tauri/src/shadow_store.rs
+++ b/packages/desktop/src-tauri/src/shadow_store.rs
@@ -6435,6 +6435,167 @@ mod tests {
     }
 
     #[test]
+    /// A rebuild may only begin on an empty projection.
+    ///
+    /// The guard reads three things, and a test that only emptied one would
+    /// pass while the other two rotted, so all three are exercised.
+    #[test]
+    fn a_rebuild_refuses_to_begin_over_an_existing_projection() {
+        let mut store = seeded(4);
+        let source = projection_source(201);
+
+        assert!(matches!(
+            store
+                .begin_projection_rebuild("rebuild-201", &source, 4)
+                .expect_err("a populated projection must refuse a rebuild"),
+            ShadowStoreError::ProjectionRebuildNotEmpty
+        ));
+
+        // Positive control. On a fresh store the same call succeeds, so the
+        // refusal above is the guard and not a broken argument list.
+        let mut empty = ShadowStore::open_in_memory().expect("open");
+        let started = empty
+            .begin_projection_rebuild("rebuild-201", &source, 4)
+            .expect("an empty projection accepts a rebuild");
+        assert_eq!(started.projected_rows, 0);
+        assert_eq!(started.projection_revision, 0);
+        assert!(!started.complete);
+    }
+
+    /// Each batch must account for exactly the rows it carries.
+    #[test]
+    fn a_batch_that_miscounts_its_rows_is_refused() {
+        let mut store = ShadowStore::open_in_memory().expect("open");
+        let source = projection_source(202);
+        let rows = corpus(4);
+        store
+            .begin_projection_rebuild("rebuild-202", &source, rows.len())
+            .expect("begin rebuild");
+
+        // Claims three cumulative rows while carrying two.
+        assert!(matches!(
+            store
+                .apply_projection_rebuild_batch(
+                    "rebuild-202",
+                    &source,
+                    rows.len(),
+                    0,
+                    "rebuild-202-batch-0",
+                    &digest(203),
+                    3,
+                    false,
+                    &rows[..2],
+                )
+                .expect_err("an overstated batch must fail"),
+            ShadowStoreError::ProjectionRebuildRowCountMismatch {
+                expected: 2,
+                actual: 3
+            }
+        ));
+
+        // Claims more than the rebuild promised in total.
+        assert!(matches!(
+            store
+                .apply_projection_rebuild_batch(
+                    "rebuild-202",
+                    &source,
+                    rows.len(),
+                    0,
+                    "rebuild-202-batch-0",
+                    &digest(203),
+                    5,
+                    false,
+                    &rows[..5.min(rows.len())],
+                )
+                .expect_err("a batch beyond the promised total must fail"),
+            ShadowStoreError::ProjectionRebuildRowCountMismatch { .. }
+        ));
+
+        // Positive control: the honest count is accepted.
+        store
+            .apply_projection_rebuild_batch(
+                "rebuild-202",
+                &source,
+                rows.len(),
+                0,
+                "rebuild-202-batch-0",
+                &digest(203),
+                2,
+                false,
+                &rows[..2],
+            )
+            .expect("an accurate batch commits");
+    }
+
+    /// The completion flag must agree with the arithmetic.
+    #[test]
+    fn a_batch_cannot_claim_completion_early() {
+        let mut store = ShadowStore::open_in_memory().expect("open");
+        let source = projection_source(204);
+        let rows = corpus(4);
+        store
+            .begin_projection_rebuild("rebuild-204", &source, rows.len())
+            .expect("begin rebuild");
+
+        assert!(matches!(
+            store
+                .apply_projection_rebuild_batch(
+                    "rebuild-204",
+                    &source,
+                    rows.len(),
+                    0,
+                    "rebuild-204-batch-0",
+                    &digest(205),
+                    2,
+                    true,
+                    &rows[..2],
+                )
+                .expect_err("completion with rows outstanding must fail"),
+            ShadowStoreError::InvalidProjectionRebuild { field: "complete" }
+        ));
+    }
+
+    /// The last line of defence: a rebuild that claims completion while the
+    /// projection actually holds fewer rows than promised.
+    ///
+    /// Reached with duplicate identifiers, which is the realistic shape. The
+    /// batch honestly reports the number of rows it carried, and every count
+    /// along the way agrees, but the upsert collapses the duplicates so the
+    /// stored total falls short. Without this check the generation would be
+    /// published as complete while silently missing rows.
+    #[test]
+    fn completion_is_refused_when_stored_rows_fall_short() {
+        let mut store = ShadowStore::open_in_memory().expect("open");
+        let source = projection_source(206);
+
+        let mut rows = corpus(3);
+        rows[2] = rows[1].clone();
+
+        store
+            .begin_projection_rebuild("rebuild-206", &source, rows.len())
+            .expect("begin rebuild");
+
+        assert!(matches!(
+            store
+                .apply_projection_rebuild_batch(
+                    "rebuild-206",
+                    &source,
+                    rows.len(),
+                    0,
+                    "rebuild-206-batch-0",
+                    &digest(207),
+                    rows.len(),
+                    true,
+                    &rows,
+                )
+                .expect_err("a short projection must not complete"),
+            ShadowStoreError::ProjectionRebuildRowCountMismatch {
+                expected: 3,
+                actual: 2
+            }
+        ));
+    }
+
     fn incomplete_rebuild_cannot_publish_and_remains_resumable() {
         let nonce = SystemTime::now()
             .duration_since(UNIX_EPOCH)


### PR DESCRIPTION
(AI Generated).

## Four fail-closed paths, none of them asserted

The rebuild protocol is how a SQLite projection gets built from scratch. These guards are what stop a corrupted or short rebuild from being accepted as authoritative, and no test asserted any of them fires.

`StaleRevision` was in exactly this state before #1330, and it turned out to be load-bearing.

| guard | what it refuses |
| --- | --- |
| `ProjectionRebuildNotEmpty` | beginning over a projection that already has a revision, rows, or receipts |
| `ProjectionRebuildRowCountMismatch`, per batch | a claimed cumulative count that does not match the rows carried, or exceeds the promised total |
| `InvalidProjectionRebuild { field: "complete" }` | a completion flag that disagrees with the arithmetic |
| `ProjectionRebuildRowCountMismatch`, on completion | a rebuild that claims to be finished while the projection is actually short |

## The last one is the interesting case

It re-counts stored rows at completion, which looks redundant against the per-batch accounting until you ask how they could ever disagree.

The test reaches it with duplicate identifiers. Every count along the way is honest: the batch reports exactly the number of rows it carried, and the running total matches. But the upsert collapses the duplicates, so the stored total falls short of what was promised. Without this check that generation would publish as complete while silently missing rows.

That is the shape worth having a test for, because it is the one a reviewer would most plausibly delete as redundant.

## The empty precondition reads three things

`projection_revision`, row count, and receipt count. A test that emptied only one would pass while the other two rotted, so the assertion goes through `seeded()`, which populates all three. There is also a positive control: on a fresh store the same call succeeds, so the refusal is the guard rather than a broken argument list.

## My verification harness was wrong three times here

Worth reporting, because the first result I got was four false survivals.

1. The batch runner passed four test filters through an unquoted variable that collapsed into a single argument matching nothing. Every mutation reported SURVIVED while `running 0 tests`.
2. Rerunning one filter at a time, three reported INVALID because my "did it run" extraction required `running N tests` and libtest prints `running 1 test`, singular.
3. Only after fixing both did all four report KILLED, each confirmed to have run exactly the test it names.

The lesson I had already written down was to suspect the test before the subject when a mutation survives. The sharper version is to suspect the *harness*, and to make it print how many tests actually ran rather than inferring it from the absence of a failure. All four run counts are now printed and checked.

## Verification

Four mutations, all killed, each confirmed to have applied and to have run its test:

1. The empty-projection precondition never fires.
2. Per-batch row accounting removed.
3. The completion flag no longer has to match the arithmetic.
4. Completion stops re-counting stored rows, which is the silent-short-projection case.

`cargo test --lib` passes 423 tests, up from 419. `cargo fmt --check` clean after formatting the new block. `npm run validate:feature` passes. `node scripts/validate-main-backflow.mjs` reports in sync. `shadow_store.rs` classifies `isProviderVisiblePath: false` with no provider IDs.

Clippy under `-D warnings` still reports the five pre-existing findings tracked in #1244, none in this change.

## Boundaries

Tests only. No guard logic touched, no SQL changed, no behavior changed.