### PR TITLE
feat: open the materializer gate and bind the first one to its native code

### DIFF
--- a/packages/desktop/src-tauri/src/library_core_journal.rs
+++ b/packages/desktop/src-tauri/src/library_core_journal.rs
@@ -2127,6 +2127,107 @@ mod tests {
         }
     }
 
+    /// The read-state upsert carries two rules, not one.
+    ///
+    /// `minimum_present_nonnegative_safe_integer_v1` decides which read time
+    /// wins. It says nothing about which of two *equal* read times wins, and
+    /// that second question decides the provenance columns. The SQL answers it
+    /// by preferring the lower source operation id.
+    ///
+    /// This is executed rather than string-matched. The locator test in
+    /// `native-materializer-binding.test.ts` can see that the column is
+    /// consulted; only running the SQL can show which way the comparison goes.
+    #[test]
+    fn equal_read_times_are_broken_by_the_lower_source_operation_id() {
+        let mut journal = LibraryCoreJournal::open_in_memory().expect("open journal");
+        install_actor_authority(&mut journal);
+        let enrollment = actor();
+        journal.enroll_actor(&enrollment).expect("enroll actor");
+
+        let entity = "rss:item:1";
+        let read_at = 900;
+
+        let provenance = |journal: &LibraryCoreJournal| -> (i64, String) {
+            journal
+                .connection
+                .query_row(
+                    "SELECT readAtMs, sourceOperationId
+                     FROM library_core_feed_item_read_state WHERE entityId = ?1;",
+                    params![entity],
+                    |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?)),
+                )
+                .expect("read state row")
+        };
+
+        let first = transaction(
+            "tx:mmm",
+            1,
+            None,
+            &enrollment.actor_chain_genesis,
+            &[(entity, read_at)],
+        );
+        journal
+            .commit_read_transaction(&first, 1_000)
+            .expect("commit first");
+        assert_eq!(
+            provenance(&journal),
+            (read_at, "tx:mmm:member:0".to_string())
+        );
+
+        // Equal read time, HIGHER operation id. The value is already correct,
+        // so provenance must not move.
+        let higher = transaction(
+            "tx:zzz",
+            2,
+            Some("tx:mmm:member:0"),
+            &format!("{:064x}", 101),
+            &[(entity, read_at)],
+        );
+        journal
+            .commit_read_transaction(&higher, 2_000)
+            .expect("commit higher");
+        assert_eq!(
+            provenance(&journal),
+            (read_at, "tx:mmm:member:0".to_string()),
+            "a higher operation id must not claim provenance at equal read time"
+        );
+
+        // Equal read time, LOWER operation id. Provenance moves, value does not.
+        let lower = transaction(
+            "tx:aaa",
+            3,
+            Some("tx:zzz:member:0"),
+            &format!("{:064x}", 102),
+            &[(entity, read_at)],
+        );
+        journal
+            .commit_read_transaction(&lower, 3_000)
+            .expect("commit lower");
+        assert_eq!(
+            provenance(&journal),
+            (read_at, "tx:aaa:member:0".to_string()),
+            "a lower operation id must take provenance at equal read time"
+        );
+
+        // Positive control for the algebra itself, kept separate on purpose: a
+        // strictly earlier read time wins regardless of operation id ordering.
+        let earlier = transaction(
+            "tx:zzy",
+            4,
+            Some("tx:aaa:member:0"),
+            &format!("{:064x}", 103),
+            &[(entity, read_at - 1)],
+        );
+        journal
+            .commit_read_transaction(&earlier, 4_000)
+            .expect("commit earlier");
+        assert_eq!(
+            provenance(&journal),
+            (read_at - 1, "tx:zzy:member:0".to_string()),
+            "the minimum rule decides the value independently of the tie-break"
+        );
+    }
+
     #[test]
     fn enrollment_and_response_loss_retry_are_idempotent() {
         let mut journal = LibraryCoreJournal::open_in_memory().expect("open journal");

--- a/packages/shared/src/library-core/index.ts
+++ b/packages/shared/src/library-core/index.ts
@@ -37,3 +37,4 @@ export * from "./store-surface-registry.js";
 export * from "./wire-frame.js";
 export * from "./user-state-merge-algebra.js";
 export * from "./feed-item-merge-idempotency.js";
+export * from "./operation-materializer-contracts.js";

--- a/packages/shared/src/library-core/index.ts
+++ b/packages/shared/src/library-core/index.ts
@@ -37,4 +37,3 @@ export * from "./store-surface-registry.js";
 export * from "./wire-frame.js";
 export * from "./user-state-merge-algebra.js";
 export * from "./feed-item-merge-idempotency.js";
-export * from "./operation-materializer-contracts.js";

--- a/packages/shared/src/library-core/native-materializer-binding.test.ts
+++ b/packages/shared/src/library-core/native-materializer-binding.test.ts
@@ -1,0 +1,100 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { LIBRARY_CORE_FIELD_REGISTRY } from "./field-registry.js";
+import { FEED_ITEM_READ_ASSIGNMENT_MATERIALIZER } from "./operation-materializer-contracts.js";
+import { LIBRARY_CORE_OPERATION_REGISTRY } from "./operation-registry.js";
+
+/**
+ * Holds each declared materializer to the native code that implements it.
+ *
+ * A materializer contract is a description. The implementation is Rust, inside
+ * the journal commit, and TypeScript exhaustiveness cannot cross that boundary.
+ * Without this test the registry could claim an operation is materialized while
+ * the table it names does not exist, or exists and is written by nobody.
+ *
+ * Same shape as the query census binding: read the source, assert the claim,
+ * and guard the extraction so a broken read fails loudly rather than passing
+ * vacuously.
+ */
+
+const repositoryRoot = join(import.meta.dirname, "..", "..", "..", "..");
+
+const readNativeModule = (relativePath: string): string => {
+  const source = readFileSync(join(repositoryRoot, relativePath), "utf8");
+  // Guard the guard. A path that resolved to something tiny or missing would
+  // make every `toContain` below trivially suspicious.
+  expect(source.length).toBeGreaterThan(10_000);
+  return source;
+};
+
+const DECLARED_MATERIALIZERS = Object.values(LIBRARY_CORE_OPERATION_REGISTRY)
+  .map((definition) => definition.materializer)
+  .filter((materializer) => materializer !== null);
+
+describe("declared materializers are bound to native implementations", () => {
+  it("has at least one materializer to check", () => {
+    // Otherwise every assertion below is vacuous.
+    expect(DECLARED_MATERIALIZERS.length).toBeGreaterThan(0);
+  });
+
+  it.each(DECLARED_MATERIALIZERS)(
+    "$materializerId writes $targetTable in its named module",
+    (materializer) => {
+      const source = readNativeModule(materializer.nativeModulePath);
+
+      // The table it claims to write must be written there.
+      expect(source).toContain(`INSERT INTO ${materializer.targetTable}`);
+      // Upserting on the declared column is what makes the operation
+      // idempotent under replay, so the conflict target is part of the claim.
+      expect(source).toContain(`ON CONFLICT(${materializer.conflictColumn})`);
+      // And the operation type must be the one the native commit records.
+      expect(source).toContain(materializer.operationType);
+    },
+  );
+
+  it.each(DECLARED_MATERIALIZERS)(
+    "$materializerId names a merge algebra that the field registry knows",
+    (materializer) => {
+      // The upsert and the field algebra must be the same rule. If a
+      // materializer named an algebra nothing declares, the two could diverge
+      // and a replayed operation would converge differently from a merged one.
+      const known = LIBRARY_CORE_FIELD_REGISTRY.some(
+        (entry) => entry.mergeAlgebra === materializer.mergeAlgebraId,
+      );
+      expect({ algebra: materializer.mergeAlgebraId, known }).toStrictEqual({
+        algebra: materializer.mergeAlgebraId,
+        known: true,
+      });
+    },
+  );
+
+  it("declares the target table in the authoritative schema", () => {
+    // A materializer writing a table the schema never creates would fail only
+    // at runtime, on the machine that ran the migration.
+    const schema = readFileSync(
+      join(repositoryRoot, "packages/shared/src/library-core/authoritative-schema-v1.sql"),
+      "utf8",
+    );
+    expect(schema.length).toBeGreaterThan(1_000);
+    for (const materializer of DECLARED_MATERIALIZERS) {
+      expect(schema).toContain(`CREATE TABLE ${materializer.targetTable}`);
+    }
+  });
+
+  it("keeps the read assignment materializer pinned to its traced values", () => {
+    // The first materializer, spelled out so a silent retarget is visible in a
+    // diff rather than only in a failing string match.
+    expect(FEED_ITEM_READ_ASSIGNMENT_MATERIALIZER).toStrictEqual({
+      materializerId: "feed_item_read_state_v1",
+      schemaVersion: 1,
+      operationType: "feed_item_read_assignment",
+      targetTable: "library_core_feed_item_read_state",
+      conflictColumn: "entityId",
+      mergeAlgebraId: "minimum_present_nonnegative_safe_integer_v1",
+      nativeModulePath:
+        "packages/desktop/src-tauri/src/library_core_journal.rs",
+    });
+  });
+});

--- a/packages/shared/src/library-core/native-materializer-binding.test.ts
+++ b/packages/shared/src/library-core/native-materializer-binding.test.ts
@@ -7,16 +7,19 @@ import { FEED_ITEM_READ_ASSIGNMENT_MATERIALIZER } from "./operation-materializer
 import { LIBRARY_CORE_OPERATION_REGISTRY } from "./operation-registry.js";
 
 /**
- * Holds each declared materializer to the native code that implements it.
+ * A LOCATOR smoke test, not a semantic binding. Read this before trusting it.
  *
- * A materializer contract is a description. The implementation is Rust, inside
- * the journal commit, and TypeScript exhaustiveness cannot cross that boundary.
- * Without this test the registry could claim an operation is materialized while
- * the table it names does not exist, or exists and is written by nobody.
+ * It searches the named Rust module for the table, the conflict target, and
+ * the operation type. That catches a declaration pointing at a table nobody
+ * writes, a renamed module, or a retargeted upsert.
  *
- * Same shape as the query census binding: read the source, assert the claim,
- * and guard the extraction so a broken read fails loudly rather than passing
- * vacuously.
+ * It does NOT prove the SQL implements the declared algebra. A string search
+ * cannot see a flipped comparison, a dropped tie-break, or an inverted WHERE
+ * clause. Those need executable tests against the native code, and the ones
+ * that exist live beside the implementation in `library_core_journal.rs`.
+ *
+ * Calling this a cross-language binding would overstate it, and an overstated
+ * guard is worse than none because it stops people looking for the real one.
  */
 
 const repositoryRoot = join(import.meta.dirname, "..", "..", "..", "..");
@@ -33,7 +36,7 @@ const DECLARED_MATERIALIZERS = Object.values(LIBRARY_CORE_OPERATION_REGISTRY)
   .map((definition) => definition.materializer)
   .filter((materializer) => materializer !== null);
 
-describe("declared materializers are bound to native implementations", () => {
+describe("declared materializers locate their native implementations", () => {
   it("has at least one materializer to check", () => {
     // Otherwise every assertion below is vacuous.
     expect(DECLARED_MATERIALIZERS.length).toBeGreaterThan(0);
@@ -51,6 +54,9 @@ describe("declared materializers are bound to native implementations", () => {
       expect(source).toContain(`ON CONFLICT(${materializer.conflictColumn})`);
       // And the operation type must be the one the native commit records.
       expect(source).toContain(materializer.operationType);
+      // The tie-break column must at least appear in the ordering. Still a
+      // locator: it proves the column is consulted, not how.
+      expect(source).toContain("sourceOperationId");
     },
   );
 
@@ -93,6 +99,7 @@ describe("declared materializers are bound to native implementations", () => {
       targetTable: "library_core_feed_item_read_state",
       conflictColumn: "entityId",
       mergeAlgebraId: "minimum_present_nonnegative_safe_integer_v1",
+      equalValueTieBreak: "lower_source_operation_id_v1",
       nativeModulePath:
         "packages/desktop/src-tauri/src/library_core_journal.rs",
     });

--- a/packages/shared/src/library-core/operation-materializer-contracts.ts
+++ b/packages/shared/src/library-core/operation-materializer-contracts.ts
@@ -1,0 +1,65 @@
+/**
+ * What an operation does to the authoritative SQLite tables.
+ *
+ * A materializer is the step that turns a verified, committed operation into
+ * rows. It is the piece that makes SQLite the store rather than a projection
+ * of something else, so until one exists for an operation that operation
+ * cannot be the source of truth for anything.
+ *
+ * The implementations are native, inside the journal commit, because a
+ * materializer must land in the same SQLite transaction as the operation row
+ * it comes from. A materializer that could commit separately would let the
+ * journal and the tables disagree after a crash.
+ *
+ * These contracts therefore describe rather than implement. They exist so the
+ * registry can say which operations are materialized and against what, and so
+ * a test can hold the description to the native code. TypeScript exhaustiveness
+ * cannot cross into Rust, so that binding is a source-reading test rather than
+ * a type.
+ */
+
+export interface LibraryCoreOperationMaterializerContract {
+  readonly materializerId: string;
+  readonly schemaVersion: 1;
+  readonly operationType: string;
+  /** The authoritative table the operation writes. */
+  readonly targetTable: string;
+  /** The column the upsert conflicts on. */
+  readonly conflictColumn: string;
+  /**
+   * The field algebra this upsert implements.
+   *
+   * The materializer and the algebra must agree or a replayed operation would
+   * converge differently from a merged one. Naming the algebra here lets a
+   * test assert they are the same rule rather than two rules that happen to
+   * match today.
+   */
+  readonly mergeAlgebraId: string;
+  /**
+   * The module that owns the implementation, relative to the repository root.
+   *
+   * Recorded so the binding test knows where to look, and so a reader can find
+   * the real code from the declaration.
+   */
+  readonly nativeModulePath: string;
+}
+
+/**
+ * Traced from `commit_read_transaction` in the desktop journal.
+ *
+ * The upsert keeps the earliest read time, breaking ties on the lower source
+ * operation id, which is the same rule
+ * `minimum_present_nonnegative_safe_integer_v1` states for the `readAt` leaf.
+ * It runs inside the same transaction as the operation row, the causal tip and
+ * the replication outbox entry, so a crash cannot leave the journal ahead of
+ * the table.
+ */
+export const FEED_ITEM_READ_ASSIGNMENT_MATERIALIZER = Object.freeze({
+  materializerId: "feed_item_read_state_v1",
+  schemaVersion: 1,
+  operationType: "feed_item_read_assignment",
+  targetTable: "library_core_feed_item_read_state",
+  conflictColumn: "entityId",
+  mergeAlgebraId: "minimum_present_nonnegative_safe_integer_v1",
+  nativeModulePath: "packages/desktop/src-tauri/src/library_core_journal.rs",
+}) satisfies LibraryCoreOperationMaterializerContract;

--- a/packages/shared/src/library-core/operation-materializer-contracts.ts
+++ b/packages/shared/src/library-core/operation-materializer-contracts.ts
@@ -27,14 +27,22 @@ export interface LibraryCoreOperationMaterializerContract {
   /** The column the upsert conflicts on. */
   readonly conflictColumn: string;
   /**
-   * The field algebra this upsert implements.
+   * The field algebra this upsert implements for the value itself.
    *
    * The materializer and the algebra must agree or a replayed operation would
-   * converge differently from a merged one. Naming the algebra here lets a
-   * test assert they are the same rule rather than two rules that happen to
-   * match today.
+   * converge differently from a merged one.
    */
   readonly mergeAlgebraId: string;
+  /**
+   * How the upsert breaks a tie when the algebra leaves two writes equal.
+   *
+   * This is a second rule, not part of the algebra. `minimum_present_...`
+   * says which value wins; it says nothing about which of two equal values
+   * wins, and the answer decides provenance columns. Conflating them was the
+   * original error here: the declaration named only the algebra while the SQL
+   * also ordered on the source operation id.
+   */
+  readonly equalValueTieBreak: string;
   /**
    * The module that owns the implementation, relative to the repository root.
    *
@@ -47,9 +55,11 @@ export interface LibraryCoreOperationMaterializerContract {
 /**
  * Traced from `commit_read_transaction` in the desktop journal.
  *
- * The upsert keeps the earliest read time, breaking ties on the lower source
- * operation id, which is the same rule
- * `minimum_present_nonnegative_safe_integer_v1` states for the `readAt` leaf.
+ * The upsert keeps the earliest read time, which is
+ * `minimum_present_nonnegative_safe_integer_v1` for the `readAt` leaf. At equal
+ * read times it prefers the lower source operation id, which the algebra does
+ * not describe and which decides the provenance columns, so it is declared
+ * separately and has its own native test.
  * It runs inside the same transaction as the operation row, the causal tip and
  * the replication outbox entry, so a crash cannot leave the journal ahead of
  * the table.
@@ -61,5 +71,6 @@ export const FEED_ITEM_READ_ASSIGNMENT_MATERIALIZER = Object.freeze({
   targetTable: "library_core_feed_item_read_state",
   conflictColumn: "entityId",
   mergeAlgebraId: "minimum_present_nonnegative_safe_integer_v1",
+  equalValueTieBreak: "lower_source_operation_id_v1",
   nativeModulePath: "packages/desktop/src-tauri/src/library_core_journal.rs",
 }) satisfies LibraryCoreOperationMaterializerContract;

--- a/packages/shared/src/library-core/operation-registry.ts
+++ b/packages/shared/src/library-core/operation-registry.ts
@@ -4,6 +4,10 @@ import {
   type LibraryCoreOperationFieldAlgebraContract,
 } from "./operation-field-algebra-contracts.js";
 import {
+  FEED_ITEM_READ_ASSIGNMENT_MATERIALIZER,
+  type LibraryCoreOperationMaterializerContract,
+} from "./operation-materializer-contracts.js";
+import {
   FEED_ITEM_READ_ASSIGNMENT_PAYLOAD_SCHEMA,
   type LibraryCoreOperationPayloadSchema,
 } from "./operation-payload-contracts.js";
@@ -154,7 +158,13 @@ export interface LibraryCoreOperationDefinition {
   readonly transactionMemberSchema:
     | LibraryCoreTransactionMemberSchemaDescriptor
     | null;
-  readonly materializer: null;
+  /**
+   * How this operation lands in the authoritative tables.
+   *
+   * Null means the operation cannot yet be the source of truth for anything,
+   * whatever else about it is closed.
+   */
+  readonly materializer: LibraryCoreOperationMaterializerContract | null;
   readonly frozenBulkContract: null;
   readonly transactionLimits: {
     readonly maximumMembers: 1_000;
@@ -189,18 +199,20 @@ interface PlannedOperationInput {
   readonly touchedFieldRegistryKeys?: readonly string[];
   readonly fieldAlgebra?: LibraryCoreOperationFieldAlgebraContract<unknown>;
   readonly transactionMemberSchema?: LibraryCoreTransactionMemberSchemaDescriptor;
+  readonly materializer?: LibraryCoreOperationMaterializerContract;
 }
-
-const BASE_OPERATION_BLOCKERS = [
-  "materializer_unimplemented",
-  "runtime_authority_inactive",
-] as const satisfies NonEmptyBlockers;
 
 function plannedOperation(
   input: PlannedOperationInput,
 ): LibraryCoreOperationDefinition {
+  // `runtime_authority_inactive` leads because it is the one blocker no
+  // declaration can drop. Nothing in this registry grants write authority, so
+  // every entry keeps it and the list is provably non-empty.
   const blockers: NonEmptyBlockers = [
-    "materializer_unimplemented",
+    "runtime_authority_inactive",
+    ...(input.materializer === undefined
+      ? (["materializer_unimplemented"] as const)
+      : []),
     ...(input.fieldAlgebra === undefined
       ? (["field_algebra_unresolved"] as const)
       : []),
@@ -216,7 +228,6 @@ function plannedOperation(
     ...(input.transactionMemberSchema === undefined
       ? (["transaction_member_schema_unresolved"] as const)
       : []),
-    ...BASE_OPERATION_BLOCKERS.slice(1),
     ...(input.additionalBlockers ?? []),
   ];
 
@@ -229,7 +240,7 @@ function plannedOperation(
     touchedFieldRegistryKeys: input.touchedFieldRegistryKeys ?? null,
     fieldAlgebra: input.fieldAlgebra ?? null,
     transactionMemberSchema: input.transactionMemberSchema ?? null,
-    materializer: null,
+    materializer: input.materializer ?? null,
     frozenBulkContract: null,
     transactionLimits: {
       maximumMembers: LIBRARY_CORE_MAX_TRANSACTION_MEMBERS,
@@ -349,6 +360,7 @@ export const LIBRARY_CORE_OPERATION_REGISTRY = {
   }),
   feed_item_read_assignment: localUserOperation({
     entityType: "FeedItem",
+    materializer: FEED_ITEM_READ_ASSIGNMENT_MATERIALIZER,
     payloadSchema: FEED_ITEM_READ_ASSIGNMENT_PAYLOAD_SCHEMA,
     entityIdCodec: LIBRARY_CORE_ENTITY_ID_CODEC_V1,
     touchedFieldRegistryKeys:

--- a/packages/shared/src/library-core/registry.test.ts
+++ b/packages/shared/src/library-core/registry.test.ts
@@ -73,6 +73,7 @@ import {
   FEED_ITEM_READ_ASSIGNMENT_TRANSACTION_MEMBER_SCHEMA,
 } from "./operation-envelope-contracts.js";
 import { FEED_ITEM_READ_ASSIGNMENT_PAYLOAD_SCHEMA } from "./operation-payload-contracts.js";
+import { FEED_ITEM_READ_ASSIGNMENT_MATERIALIZER } from "./operation-materializer-contracts.js";
 import {
   FEED_ITEM_READ_AT_FIELD_ALGEBRA,
   LIBRARY_CORE_FEED_ITEM_READ_AT_FIELD_REGISTRY_KEY,
@@ -129,6 +130,7 @@ type ClosedOperationContract = Partial<
     LibraryCoreOperationDefinition,
     | "entityIdCodec"
     | "fieldAlgebra"
+    | "materializer"
     | "payloadSchema"
     | "touchedFieldRegistryKeys"
     | "transactionMemberSchema"
@@ -137,6 +139,7 @@ type ClosedOperationContract = Partial<
 
 const OPERATION_CONTRACT_BLOCKERS = [
   ["entityIdCodec", "entity_id_schema_unresolved"],
+  ["materializer", "materializer_unimplemented"],
   ["fieldAlgebra", "field_algebra_unresolved"],
   ["payloadSchema", "payload_schema_unresolved"],
   ["touchedFieldRegistryKeys", "touched_fields_unresolved"],
@@ -159,6 +162,7 @@ const CLOSED_OPERATION_CONTRACTS: Partial<
   // Traced from `markAsRead`, which writes exactly one leaf and reads none.
   feed_item_read_assignment: {
     entityIdCodec: LIBRARY_CORE_ENTITY_ID_CODEC_V1,
+    materializer: FEED_ITEM_READ_ASSIGNMENT_MATERIALIZER,
     fieldAlgebra: FEED_ITEM_READ_AT_FIELD_ALGEBRA,
     payloadSchema: FEED_ITEM_READ_ASSIGNMENT_PAYLOAD_SCHEMA,
     touchedFieldRegistryKeys:
@@ -319,7 +323,6 @@ describe("Library Core operation registry", () => {
         }
       }
 
-      expect(definition.materializer).toBeNull();
       expect(definition.frozenBulkContract).toBeNull();
       expect(definition.blockers.length).toBeGreaterThan(0);
       expect(definition.blockers).toContain("runtime_authority_inactive");


### PR DESCRIPTION
## The gate was self-imposed and stale

`LibraryCoreOperationDefinition.materializer` was typed `null`. Not "no materializer declared yet" — the type made declaring one impossible. Every operation therefore carried `materializer_unimplemented` regardless of what else was closed.

It was also wrong. **A materializer already ships.** `commit_read_transaction` in `library_core_journal.rs` upserts `library_core_feed_item_read_state` inside the same SQLite transaction as the operation row, the causal tip, and the replication outbox entry. It keeps the earliest read time and breaks ties on the lower source operation id, which is exactly what `minimum_present_nonnegative_safe_integer_v1` states for the `readAt` leaf.

So the census understated the system. This corrects it.

## What changed

`materializer` is now a real contract type. `feed_item_read_assignment` declares the one that exists, and `materializer_unimplemented` drops through the same derivation every other blocker uses, so the declaration is the only way to clear it.

`runtime_authority_inactive` now leads the blocker list. It is the one blocker no declaration can drop, which makes the list provably non-empty now that the materializer blocker is conditional.

## The contract describes, it does not implement

Materializers have to be native and inside the journal commit, because a materializer must land in the same transaction as the operation it comes from. One that could commit separately would let the journal and the tables disagree after a crash.

So the TypeScript contract records what the native code does, and a test holds it there. TypeScript exhaustiveness cannot cross into Rust, so the binding is a source-reading test, same shape as the query census binding in #1320.

Each declared materializer must:

- write the table it names, `INSERT INTO <targetTable>`
- upsert on the column it names, `ON CONFLICT(<conflictColumn>)`, which is what makes replay idempotent
- appear in the module it names
- name a merge algebra the field registry knows, so the upsert and the algebra cannot be two rules that merely agree today
- target a table the authoritative schema actually creates

The extraction guards itself: a native path that resolved to something under 10,000 characters fails rather than letting every `toContain` pass vacuously.

## Verification

Five mutations, all killed, each verified applied and with its run count checked:

1. The materializer is retargeted to a table it does not write.
2. It names an algebra nothing declares.
3. It points at the wrong native module.
4. The declaration is dropped, so the blocker must return.
5. The upsert conflict column no longer matches the native code, which would break replay idempotence.

Mutation 3 first reported "no tests ran" because the run-count extraction picked the wrong line with two test files. Rerun against the single file, it killed. Same class of harness error as #1347, caught the same way.

`npm run validate:feature` passes. `node scripts/validate-main-backflow.mjs` reports in sync.

## Boundaries

Nothing is wired to runtime. The journal still has no call sites outside its own module and its tests. `activationAllowed`, `activeEngine`, and `runtimeBehaviorChanged` are untouched. This opens the gate; it does not walk through it.

---

## Review corrections applied (second commit)

External review found three overstatements in the first commit. All three were correct.

**The contract was exported from a public subpath.** `./library-core` is a package export with 56 production importers, and nothing consumes the materializer API. Export removed.

**The source-scanning test was called a cross-language binding. It is a locator.** String searches catch a declaration pointing at a table nobody writes, a renamed module, or a retargeted upsert. They cannot see a flipped comparison or a dropped clause. The file now states what it does and does not prove, because an overstated guard is worse than none: it stops people looking for the real one.

**The declaration named one rule where the SQL implements two.** The upsert keeps the earliest read time, which is `minimum_present_nonnegative_safe_integer_v1`. At *equal* read times it prefers the lower source operation id, which that algebra does not describe and which decides the provenance columns. `equalValueTieBreak` is now declared separately.

That last one is the error class I have been finding in other people's code, made here in my own.

Adds the executable test the locator cannot provide, in `library_core_journal.rs`: equal read time with a higher operation id must not claim provenance, with a lower one must, and a strictly earlier read time wins regardless of operation id ordering. Three mutations kill it — tie-break direction flipped, tie-break clause removed, and the minimum rule flipped to maximum.

`cargo test --lib` is 424 passing. `cargo fmt --check` clean.
