### PR TITLE
feat: give the Library Core journal a production owner

### DIFF
--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -54,6 +54,7 @@ mod library_core_feed_browse_store;
 mod library_core_feed_reader_runtime;
 #[cfg_attr(not(test), allow(dead_code))]
 mod library_core_journal;
+mod library_core_journal_runtime;
 mod library_core_migration_claim;
 mod library_core_saved_feed_runtime;
 mod library_core_shadow_runtime;
@@ -13595,6 +13596,7 @@ pub fn run() {
         .manage(LocalAIModelDownloadState::default())
         .manage(CaptureState::new())
         .manage(library_core_feed_browse_runtime::LibraryCoreFeedBrowseRuntimeState::default())
+        .manage(library_core_journal_runtime::LibraryCoreJournalRuntimeState::default())
         .manage(
             library_core_feed_browse_reader_runtime::LibraryCoreFeedBrowseReaderRuntimeState::default(),
         )
@@ -14801,6 +14803,8 @@ pub fn run() {
             get_desktop_session_state,
             get_social_provider_cookie_state,
             prepare_social_scrape_memory,
+            library_core_journal_runtime::open_library_core_journal,
+            library_core_journal_runtime::library_core_journal_status,
             library_core_feed_browse_runtime::begin_library_core_feed_browse_generation,
             library_core_feed_browse_runtime::append_library_core_feed_browse_generation_page,
             library_core_feed_browse_runtime::finalize_library_core_feed_browse_generation,

--- a/packages/desktop/src-tauri/src/library_core_journal.rs
+++ b/packages/desktop/src-tauri/src/library_core_journal.rs
@@ -85,7 +85,7 @@ const ENROLLMENT_OUTBOX_PAGE_SQL: &str = "
     LIMIT ?3;";
 
 #[derive(Debug)]
-enum JournalError {
+pub(super) enum JournalError {
     Io(std::io::Error),
     Sql(rusqlite::Error),
     UnsupportedSchemaVersion { expected: i64, actual: i64 },
@@ -102,6 +102,19 @@ enum JournalError {
     UnknownCausalTip { operation_id: String },
     OperationVerification { index: usize, field: &'static str },
     EnrollmentVerification { field: &'static str },
+}
+
+/// What the runtime can say about an opened journal.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct JournalRuntimeStatus {
+    pub(super) schema_version: i64,
+    /// How far materialization has consumed the operation log.
+    pub(super) materializer_ingest_sequence: i64,
+    pub(super) actors: i64,
+    pub(super) operations: i64,
+    pub(super) read_state: i64,
+    pub(super) unacknowledged_outbox: i64,
 }
 
 impl From<rusqlite::Error> for JournalError {
@@ -347,7 +360,7 @@ struct SchemaCatalogEntry {
     sql: String,
 }
 
-struct LibraryCoreJournal {
+pub(super) struct LibraryCoreJournal {
     connection: Connection,
 }
 
@@ -546,7 +559,7 @@ fn validate_transaction(transaction: &VerifiedReadTransaction) -> JournalResult<
 }
 
 impl LibraryCoreJournal {
-    fn open(path: &Path) -> JournalResult<Self> {
+    pub(super) fn open(path: &Path) -> JournalResult<Self> {
         let file_name = path.file_name().ok_or(JournalError::InvalidVerifiedInput {
             field: "database_path",
         })?;
@@ -560,6 +573,51 @@ impl LibraryCoreJournal {
         let resolved_path = parent.canonicalize()?.join(file_name);
         let existing_file = Self::preflight_existing_file(&resolved_path)?;
         Self::open_after_preflight(&resolved_path, existing_file)
+    }
+
+    /// Counts the runtime can report after opening.
+    ///
+    /// Deliberately cheap and read-only. This is the first observable evidence
+    /// that a production call reached the journal, so it must not mutate.
+    pub(super) fn runtime_status(&self) -> JournalResult<JournalRuntimeStatus> {
+        let schema_version: i64 =
+            self.connection
+                .pragma_query_value(None, "user_version", |row| row.get(0))?;
+        let materializer_ingest_sequence: i64 = self.connection.query_row(
+            "SELECT integerValue FROM library_core_meta
+             WHERE key = 'materializerIngestSequence';",
+            [],
+            |row| row.get(0),
+        )?;
+        let actors: i64 =
+            self.connection
+                .query_row("SELECT COUNT(*) FROM library_core_actors;", [], |row| {
+                    row.get(0)
+                })?;
+        let operations: i64 = self.connection.query_row(
+            "SELECT COUNT(*) FROM library_core_operations;",
+            [],
+            |row| row.get(0),
+        )?;
+        let read_state: i64 = self.connection.query_row(
+            "SELECT COUNT(*) FROM library_core_feed_item_read_state;",
+            [],
+            |row| row.get(0),
+        )?;
+        let unacknowledged_outbox: i64 = self.connection.query_row(
+            "SELECT COUNT(*) FROM library_core_replication_outbox
+             WHERE acknowledgedAtMs IS NULL;",
+            [],
+            |row| row.get(0),
+        )?;
+        Ok(JournalRuntimeStatus {
+            schema_version,
+            materializer_ingest_sequence,
+            actors,
+            operations,
+            read_state,
+            unacknowledged_outbox,
+        })
     }
 
     fn open_after_preflight(resolved_path: &Path, existing_file: bool) -> JournalResult<Self> {

--- a/packages/desktop/src-tauri/src/library_core_journal_runtime.rs
+++ b/packages/desktop/src-tauri/src/library_core_journal_runtime.rs
@@ -1,0 +1,228 @@
+//! Runtime ownership of the Library Core journal.
+//!
+//! The journal, its verifiers and its one materializer have been merged and
+//! tested for some time, but nothing outside their own modules referenced
+//! them. Every `LibraryCoreJournal::open` call site sat inside `#[cfg(test)]`,
+//! so no installation has ever held a journal database.
+//!
+//! This module is the first production owner. It resolves the database path,
+//! opens the journal into Tauri managed state, and reports what it found.
+//!
+//! Automerge remains authoritative. Opening a database and counting rows
+//! changes no user-visible behaviour and grants no write authority; it is the
+//! call path the shadow slice needs before any operation can be written.
+
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use tauri::Manager;
+
+use super::library_core_journal::{JournalRuntimeStatus, LibraryCoreJournal};
+
+/// Directory holding the authoritative database, under the app data root.
+const JOURNAL_DIRECTORY: &str = "library-core";
+
+/// The database file itself.
+const JOURNAL_FILE: &str = "library-core.sqlite";
+
+#[derive(Debug)]
+pub(super) enum JournalRuntimeError {
+    /// The app data root could not be resolved or created.
+    Storage(std::io::Error),
+    /// The journal refused to open. Reported verbatim rather than flattened,
+    /// because a schema or integrity refusal is the interesting case.
+    Journal(String),
+    /// Managed state was poisoned by a panic on another thread.
+    StatePoisoned,
+}
+
+impl std::fmt::Display for JournalRuntimeError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Storage(error) => write!(formatter, "journal storage unavailable: {error}"),
+            Self::Journal(detail) => write!(formatter, "journal refused to open: {detail}"),
+            Self::StatePoisoned => write!(formatter, "journal state was poisoned by a panic"),
+        }
+    }
+}
+
+impl From<std::io::Error> for JournalRuntimeError {
+    fn from(error: std::io::Error) -> Self {
+        Self::Storage(error)
+    }
+}
+
+type RuntimeResult<T> = Result<T, JournalRuntimeError>;
+
+/// The opened journal, or nothing if it has not been opened yet.
+#[derive(Default)]
+pub(super) struct LibraryCoreJournalRuntimeState(Mutex<Option<LibraryCoreJournal>>);
+
+/// Where the journal lives beneath an app data root.
+pub(super) fn journal_path(base: &Path) -> PathBuf {
+    base.join(JOURNAL_DIRECTORY).join(JOURNAL_FILE)
+}
+
+#[cfg(unix)]
+fn create_private_directory(path: &Path) -> std::io::Result<()> {
+    use std::os::unix::fs::DirBuilderExt;
+
+    if path.exists() {
+        return Ok(());
+    }
+    std::fs::DirBuilder::new()
+        .recursive(true)
+        .mode(0o700)
+        .create(path)
+}
+
+#[cfg(not(unix))]
+fn create_private_directory(path: &Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(path)
+}
+
+/// Opens the journal beneath `base`, replacing any previously held handle.
+///
+/// Idempotent by construction: a second call reopens the same file and reports
+/// the same counts. It never creates actors, operations or authority, so a
+/// repeated open cannot advance state.
+pub(super) fn open_at_root(
+    state: &LibraryCoreJournalRuntimeState,
+    base: &Path,
+) -> RuntimeResult<JournalRuntimeStatus> {
+    let directory = base.join(JOURNAL_DIRECTORY);
+    create_private_directory(&directory)?;
+
+    let path = journal_path(base);
+    let journal = LibraryCoreJournal::open(&path)
+        .map_err(|error| JournalRuntimeError::Journal(error.to_string()))?;
+    let status = journal
+        .runtime_status()
+        .map_err(|error| JournalRuntimeError::Journal(error.to_string()))?;
+
+    let mut held = state
+        .0
+        .lock()
+        .map_err(|_| JournalRuntimeError::StatePoisoned)?;
+    *held = Some(journal);
+    Ok(status)
+}
+
+/// Reports the currently held journal, or `None` if it has not been opened.
+pub(super) fn status_of(
+    state: &LibraryCoreJournalRuntimeState,
+) -> RuntimeResult<Option<JournalRuntimeStatus>> {
+    let held = state
+        .0
+        .lock()
+        .map_err(|_| JournalRuntimeError::StatePoisoned)?;
+    match held.as_ref() {
+        None => Ok(None),
+        Some(journal) => journal
+            .runtime_status()
+            .map(Some)
+            .map_err(|error| JournalRuntimeError::Journal(error.to_string())),
+    }
+}
+
+#[tauri::command]
+pub(super) fn open_library_core_journal(
+    app: tauri::AppHandle,
+    state: tauri::State<'_, LibraryCoreJournalRuntimeState>,
+) -> Result<JournalRuntimeStatus, String> {
+    let base = app
+        .path()
+        .app_data_dir()
+        .map_err(|error| error.to_string())?;
+    open_at_root(&state, &base).map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+pub(super) fn library_core_journal_status(
+    state: tauri::State<'_, LibraryCoreJournalRuntimeState>,
+) -> Result<Option<JournalRuntimeStatus>, String> {
+    status_of(&state).map_err(|error| error.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn base() -> TempDir {
+        TempDir::new().expect("create app data root")
+    }
+
+    #[test]
+    fn opening_creates_the_database_under_a_private_directory() {
+        let root = base();
+        let state = LibraryCoreJournalRuntimeState::default();
+
+        assert!(status_of(&state).expect("status before open").is_none());
+
+        let status = open_at_root(&state, root.path()).expect("open journal");
+        assert_eq!(status.schema_version, 1);
+        assert_eq!(status.materializer_ingest_sequence, 0);
+        assert_eq!(status.actors, 0);
+        assert_eq!(status.operations, 0);
+        assert_eq!(status.read_state, 0);
+        assert_eq!(status.unacknowledged_outbox, 0);
+
+        let path = journal_path(root.path());
+        assert!(path.exists(), "journal database must exist after opening");
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(path.parent().expect("journal directory"))
+                .expect("directory metadata")
+                .permissions()
+                .mode()
+                & 0o777;
+            assert_eq!(mode, 0o700, "journal directory must not be world readable");
+        }
+    }
+
+    #[test]
+    fn opening_twice_is_idempotent_and_reports_the_same_state() {
+        let root = base();
+        let state = LibraryCoreJournalRuntimeState::default();
+
+        let first = open_at_root(&state, root.path()).expect("first open");
+        let second = open_at_root(&state, root.path()).expect("second open");
+        assert_eq!(first, second);
+
+        // Reopening must not have advanced anything. An open that enrolled an
+        // actor or wrote an operation would show here.
+        assert_eq!(second.actors, 0);
+        assert_eq!(second.operations, 0);
+    }
+
+    #[test]
+    fn status_reflects_the_open_journal_without_reopening_it() {
+        let root = base();
+        let state = LibraryCoreJournalRuntimeState::default();
+
+        let opened = open_at_root(&state, root.path()).expect("open journal");
+        let reported = status_of(&state)
+            .expect("status after open")
+            .expect("journal is held");
+        assert_eq!(opened, reported);
+    }
+
+    #[test]
+    fn a_fresh_root_starts_empty_so_no_installation_inherits_a_journal() {
+        // The reason schema v1 is free to change: nothing has ever created one
+        // of these outside a test. A fresh root must therefore always start at
+        // zero, and this asserts that rather than leaving it as an argument.
+        let root = base();
+        let state = LibraryCoreJournalRuntimeState::default();
+        assert!(!journal_path(root.path()).exists());
+
+        let status = open_at_root(&state, root.path()).expect("open journal");
+        assert_eq!(
+            (status.actors, status.operations, status.read_state),
+            (0, 0, 0)
+        );
+    }
+}

--- a/packages/desktop/src-tauri/src/shadow_store.rs
+++ b/packages/desktop/src-tauri/src/shadow_store.rs
@@ -6434,7 +6434,6 @@ mod tests {
         std::fs::remove_dir(directory).expect("remove publication directory");
     }
 
-    #[test]
     /// A rebuild may only begin on an empty projection.
     ///
     /// The guard reads three things, and a test that only emptied one would

--- a/packages/desktop/src/App.tsx
+++ b/packages/desktop/src/App.tsx
@@ -179,6 +179,7 @@ import {
   forgetRssFeedHealth,
   initProviderHealth,
 } from "./lib/provider-health";
+import { openLibraryCoreJournalForStartup } from "./lib/library-core-journal-runtime";
 import { getDesktopSourceStatus } from "./lib/source-status";
 import { setContactSyncError } from "./lib/contact-sync-storage";
 import { clearSnapshots, startSnapshotManager, stopSnapshotManager } from "./lib/snapshots";
@@ -589,6 +590,9 @@ function App() {
         noteMemoryPressure(snapshot);
       },
     });
+    // Shadow only. Nothing reads the journal yet, and a machine that cannot
+    // open it starts normally on Automerge alone.
+    void openLibraryCoreJournalForStartup();
     void initProviderHealth();
     startRssPoller();
     startAuthenticatedEssayPoller();

--- a/packages/desktop/src/lib/library-core-journal-runtime.ts
+++ b/packages/desktop/src/lib/library-core-journal-runtime.ts
@@ -1,0 +1,63 @@
+import { invoke } from "@tauri-apps/api/core";
+
+/**
+ * Desktop client for the Library Core journal.
+ *
+ * The journal, its verifiers and its one materializer have been merged and
+ * tested for a while, but nothing outside their own Rust modules referenced
+ * them: every `LibraryCoreJournal::open` call site sat inside a test module.
+ * This is the first production caller.
+ *
+ * Automerge remains authoritative. Opening the database and reading counts
+ * changes no user-visible behaviour and grants no write authority. It exists so
+ * the shadow slice has a call path, and so we can see whether a real
+ * installation can open the journal at all before anything depends on it.
+ */
+
+export interface LibraryCoreJournalStatusV1 {
+  /** SQLite `user_version`. 1 is the only schema that has ever existed. */
+  readonly schemaVersion: number;
+  /** How far materialization has consumed the operation log. */
+  readonly materializerIngestSequence: number;
+  readonly actors: number;
+  readonly operations: number;
+  readonly readState: number;
+  readonly unacknowledgedOutbox: number;
+}
+
+/**
+ * Opens the journal, creating the database and its private directory.
+ *
+ * Idempotent. A second call reopens the same file and reports the same counts;
+ * it never enrolls an actor or writes an operation, so it cannot advance state.
+ */
+export function openLibraryCoreJournal(): Promise<LibraryCoreJournalStatusV1> {
+  return invoke<LibraryCoreJournalStatusV1>("open_library_core_journal");
+}
+
+/** Reports the held journal, or null when it has not been opened. */
+export function libraryCoreJournalStatus(): Promise<LibraryCoreJournalStatusV1 | null> {
+  return invoke<LibraryCoreJournalStatusV1 | null>(
+    "library_core_journal_status",
+  );
+}
+
+/**
+ * Opens the journal during startup without letting a failure reach the user.
+ *
+ * The journal is a shadow. Nothing reads from it yet, so a machine that cannot
+ * open it must still start normally and behave exactly as before. The failure
+ * is surfaced to the console as evidence rather than raised, because the only
+ * consumer of that evidence today is us.
+ */
+export async function openLibraryCoreJournalForStartup(): Promise<LibraryCoreJournalStatusV1 | null> {
+  try {
+    return await openLibraryCoreJournal();
+  } catch (error) {
+    console.warn(
+      "[library-core] journal unavailable; continuing on Automerge only",
+      error,
+    );
+    return null;
+  }
+}


### PR DESCRIPTION
(AI Generated).

## The journal had no owner

`library_core_journal.rs`, its verifiers, and its one materializer have been merged and tested for a while. Nothing outside their own modules referenced them. Every `LibraryCoreJournal::open` call site sat inside `#[cfg(test)]`, and `lib.rs` carried exactly one line: `mod library_core_journal;`.

This is the first production owner. It resolves the database path under the app data root, creates a 0700 directory, opens the journal into Tauri managed state, and reports what it found.

## That absence settles the schema question

Because nothing has ever opened a journal outside a test, **no installation can hold a journal database.** Schema v1 has zero deployed instances.

So there is no v1-to-v2 migration to write, and the exact-catalog validation in `verify_schema_contract` only ever has to satisfy databases this code creates from here on. The schema stays free to change until first activation. A test asserts the emptiness rather than leaving it as an argument in a commit message.

That removes an entire workstream that would otherwise have sat in front of every subsequent materializer.

## What it reports

Schema version from `user_version`, plus `materializerIngestSequence`, actor, operation, read-state, and unacknowledged-outbox counts. The materializer sequence matters most later: it is how far materialization has consumed the operation log.

I guessed the schema version lived in `library_core_meta` and the tests caught it. It is `PRAGMA user_version`; the meta table holds `projectionRevision`, `nextIngestSequence`, and `materializerIngestSequence`.

## Safety properties, asserted not assumed

**Opening is idempotent.** A second open reopens the same file and reports identical counts. It never enrolls an actor or writes an operation, so a repeated open cannot advance state. Both are asserted.

**Startup failure is swallowed.** Nothing reads the journal yet, so a machine that cannot open it must start normally on Automerge alone. The error is logged as evidence rather than raised.

**The directory is 0700**, asserted on unix.

## Also fixed

A stray duplicate `#[test]` attribute I left in `shadow_store.rs` in #1347. Warning only, and mine.

## Provider classification

`App.tsx` and `lib.rs` classify provider-visible, so this publishes with a `diff_authorized` artifact under the skill's "classified path with no behavior change" rule.

The diff performs no network activity and touches no WebView, navigation, request, retry, cadence, cookie, header, extraction, media, login, or background provider work. The two classified files are touched only for module registration, command registration, managed-state registration, one import, and one fire-and-forget call inside an effect that already runs. Digests bind to the provider-only subdiff.

## Verification

`cargo test --lib` passes 427, up from 423. Four new runtime tests: private directory creation, idempotent reopen, status without reopening, and the fresh-root emptiness that backs the schema claim.

The command-parity test from #1321 confirms both new `invoke` names have registered handlers, which is the check that would have caught a registration I forgot.

`cargo fmt --check` clean. `npm run validate:feature` passes. `node scripts/validate-main-backflow.mjs` reports in sync.

## Boundaries

Automerge remains authoritative. No operation is written. Nothing reads from the journal. `activationAllowed`, `activeEngine`, and `runtimeBehaviorChanged` are untouched.

## Provider Review
- Status: Provider authority is validated for ready publication.
- Review action: none required. The provider-risk artifact records the behavior authority decision; this exact provider subdiff is the audit subject.
- Provider subdiff: `dc75e5d1fd7c46ab84c90f68801f65f7ad4936d8`
- Publication does not authorize new live provider traffic. Gate 1 behavior approval still applies when observable behavior changes.
- Provider review task: `library-core-journal-runtime-owner-v1`
- Provider review decision: `diff_authorized`
- Provider review artifact: `93ca1c3bdbbe4abe314288d6d62d0f3f66210d20eaf0e4bd6cb304773de9ffd7`
- Providers: facebook, instagram, linkedin, medium, other, substack, x, youtube
- Observable behavior: No provider-observable behavior changes. The diff adds a local SQLite journal opener owned by Tauri managed state, two commands that open the database and report row counts, and one fire-and-forget startup call inside an effect that already runs. It performs no network activity and touches no WebView, navigation, request, retry, cadence, cookie, header, extraction, media, login, or background provider work. The two classified files are touched only for module registration, command registration, managed-state registration, one import and one call line.
- Fingerprinting risk: None introduced. No provider is contacted, and no provider-facing timing, ordering, or content changes.
- Lowest profile alternative: Keep provider traffic disabled and exercise the journal against local temporary directories, which is what the tests do.

Files bound into this provider review:
- `packages/desktop/src-tauri/src/lib.rs`
- `packages/desktop/src/App.tsx`