### PR TITLE
feat: let a desktop installation establish its own authority epoch

### DIFF
--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -37,6 +37,7 @@ mod automerge_external_token_run;
 mod automerge_external_value;
 #[cfg_attr(not(test), allow(dead_code))]
 mod automerge_external_value_run;
+mod library_core_authority_genesis;
 #[cfg_attr(not(test), allow(dead_code))]
 mod library_core_canonical;
 #[cfg_attr(not(test), allow(dead_code))]
@@ -56,6 +57,7 @@ mod library_core_feed_reader_runtime;
 mod library_core_journal;
 mod library_core_journal_runtime;
 mod library_core_migration_claim;
+mod library_core_platform_key;
 mod library_core_saved_feed_runtime;
 mod library_core_shadow_runtime;
 #[cfg_attr(not(test), allow(dead_code))]
@@ -14805,6 +14807,7 @@ pub fn run() {
             prepare_social_scrape_memory,
             library_core_journal_runtime::open_library_core_journal,
             library_core_journal_runtime::library_core_journal_status,
+            library_core_journal_runtime::establish_library_core_genesis_authority,
             library_core_feed_browse_runtime::begin_library_core_feed_browse_generation,
             library_core_feed_browse_runtime::append_library_core_feed_browse_generation_page,
             library_core_feed_browse_runtime::finalize_library_core_feed_browse_generation,

--- a/packages/desktop/src-tauri/src/library_core_authority_genesis.rs
+++ b/packages/desktop/src-tauri/src/library_core_authority_genesis.rs
@@ -1,0 +1,725 @@
+//! The one authority epoch a fresh installation can mint for itself.
+//!
+//! Library Core operations are fenced against an active authority epoch, and
+//! until now nothing outside tests could install one, so nothing outside tests
+//! could enroll an actor or commit an operation. This mints the genesis epoch
+//! for a library whose only existing authority is the legacy Automerge
+//! document, under trust on first use.
+//!
+//! Automerge stays authoritative. The epoch installed here grants no cloud
+//! authority, retires nothing, changes no active engine, and emits no provider
+//! traffic. It is local evidence that this installation considers itself the
+//! origin of a Library Core authority chain for one exact legacy revision.
+//!
+//! Everything the certificate contains is a pure function of the library, the
+//! authority public key, and that revision, and Ed25519 signatures are
+//! deterministic, so minting is a pure function too. A caller that crashes
+//! anywhere in `establish_genesis_epoch` and retries produces byte-identical
+//! output and converges on the stored epoch instead of forking a second one.
+
+use crate::automerge_external_common::{is_lower_sha256, lower_hex};
+use crate::library_core_canonical::{
+    encode_canonical_value, encode_operation_digest_input, encode_signature_input,
+};
+use crate::library_core_ed25519::verify_library_core_ed25519;
+use crate::library_core_journal::{
+    AcceptedAuthorityState, LibraryCoreJournal, VerifiedAuthorityEpoch,
+};
+use crate::library_core_platform_key::{load_platform_key, store_platform_key, PlatformKeyVault};
+use ring::rand::SystemRandom;
+use ring::signature::{Ed25519KeyPair, KeyPair};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+
+const CERTIFICATE_FORMAT: &str = "freed_library_core_genesis_epoch_certificate_v1";
+const SIGNATURE_ALGORITHM: &str = "ed25519";
+const SOURCE_KIND: &str = "automerge_legacy";
+const REPLICATION_PROTOCOL: &str = "automerge_blob_v1";
+const TRUST_MODEL: &str = "tofu_read_only_until_authenticated_pairing";
+const GENESIS_EPOCH: i64 = 1;
+const MAX_CERTIFICATE_BYTES: usize = 16 * 1_024;
+const MAX_DOCUMENT_ID_BYTES: usize = 4_096;
+
+/// The authority signing key is a separate vault account from the migration
+/// signing key. One compromised or cleared key must not stand in for the other.
+const AUTHORITY_VAULT: PlatformKeyVault = PlatformKeyVault {
+    account: "authority-current",
+    envelope_format: "freed_library_core_authority_key_v1",
+    description: "authority signing",
+};
+
+/// One exact durable Automerge revision, as the worker already reports it.
+///
+/// The worker refuses to produce this unless the in-memory document's heads
+/// equal the durable snapshot's heads, so a revision that reaches here is one
+/// the document was actually saved at, not one that only existed in memory.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct LegacySourceRevision {
+    pub(crate) document_id: String,
+    pub(crate) heads_digest: String,
+    pub(crate) head_count: u64,
+    pub(crate) storage_generation: u64,
+    pub(crate) storage_save_revision: u64,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+struct GenesisEpochCertificateBodyV1 {
+    format: String,
+    library_id: String,
+    epoch: i64,
+    active_engine: String,
+    replication_protocol: String,
+    trust_model: String,
+    signature_algorithm: String,
+    authority_public_key: String,
+    authority_key_id: String,
+    source_document_id: String,
+    source_heads_digest: String,
+    source_head_count: u64,
+    source_storage_generation: u64,
+    source_save_revision: u64,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+struct GenesisEpochCertificateV1 {
+    certificate_body: GenesisEpochCertificateBodyV1,
+    /// The body digest. It names the epoch, so an epoch identifier and the
+    /// content it was minted from cannot disagree.
+    epoch_id: String,
+    epoch_signature: String,
+    authority_key_possession_signature: String,
+}
+
+fn digest_value(domain: &str, value: &Value) -> Result<String, String> {
+    let input = encode_operation_digest_input(domain, value, MAX_CERTIFICATE_BYTES)
+        .map_err(|_| format!("Library Core {domain} digest input is invalid"))?;
+    Ok(lower_hex(&Sha256::digest(input)))
+}
+
+/// The library identity for a legacy Automerge document.
+///
+/// Derived from the document identity rather than minted at random, so two
+/// installations that adopt the same legacy document agree on which library
+/// they are talking about, and re-deriving it after a crash gives the same
+/// answer.
+fn legacy_library_id(document_id: &str) -> Result<String, String> {
+    if document_id.is_empty() || document_id.len() > MAX_DOCUMENT_ID_BYTES {
+        return Err("Library Core legacy document ID is invalid".to_string());
+    }
+    digest_value(
+        "legacy-library-identity",
+        &json!({
+            "source_document_id": document_id,
+            "source_kind": SOURCE_KIND,
+        }),
+    )
+}
+
+fn authority_key_id(authority_public_key: &str) -> Result<String, String> {
+    digest_value(
+        "authority-key",
+        &json!({
+            "authority_public_key": authority_public_key,
+            "signature_algorithm": SIGNATURE_ALGORITHM,
+        }),
+    )
+}
+
+fn epoch_signature_input(epoch_id: &str) -> Result<Vec<u8>, String> {
+    encode_signature_input(
+        "epoch-transition-certificate",
+        &json!({ "certificate_digest": epoch_id }),
+        MAX_CERTIFICATE_BYTES,
+    )
+    .map_err(|_| "Library Core epoch signature input is invalid".to_string())
+}
+
+fn possession_signature_input(epoch_id: &str, key_id: &str) -> Result<Vec<u8>, String> {
+    encode_signature_input(
+        "authority-key-possession",
+        &json!({
+            "certificate_digest": epoch_id,
+            "target_authority_key_id": key_id,
+        }),
+        MAX_CERTIFICATE_BYTES,
+    )
+    .map_err(|_| "Library Core authority possession signature input is invalid".to_string())
+}
+
+fn validate_revision(revision: &LegacySourceRevision) -> Result<(), String> {
+    if revision.document_id.is_empty() || revision.document_id.len() > MAX_DOCUMENT_ID_BYTES {
+        return Err("Library Core legacy document ID is invalid".to_string());
+    }
+    if !is_lower_sha256(&revision.heads_digest) {
+        return Err("Library Core legacy heads digest is invalid".to_string());
+    }
+    // A revision with no heads is an uninitialized document, not a library
+    // this installation can claim to be the origin of.
+    if revision.head_count == 0 {
+        return Err("Library Core legacy revision has no heads".to_string());
+    }
+    Ok(())
+}
+
+fn build_certificate(
+    library_id: &str,
+    revision: &LegacySourceRevision,
+    key_pair: &Ed25519KeyPair,
+) -> Result<GenesisEpochCertificateV1, String> {
+    validate_revision(revision)?;
+    let authority_public_key = lower_hex(key_pair.public_key().as_ref());
+    let key_id = authority_key_id(&authority_public_key)?;
+    let certificate_body = GenesisEpochCertificateBodyV1 {
+        format: CERTIFICATE_FORMAT.to_string(),
+        library_id: library_id.to_string(),
+        epoch: GENESIS_EPOCH,
+        active_engine: SOURCE_KIND.to_string(),
+        replication_protocol: REPLICATION_PROTOCOL.to_string(),
+        trust_model: TRUST_MODEL.to_string(),
+        signature_algorithm: SIGNATURE_ALGORITHM.to_string(),
+        authority_public_key,
+        authority_key_id: key_id.clone(),
+        source_document_id: revision.document_id.clone(),
+        source_heads_digest: revision.heads_digest.clone(),
+        source_head_count: revision.head_count,
+        source_storage_generation: revision.storage_generation,
+        source_save_revision: revision.storage_save_revision,
+    };
+    let body_value = serde_json::to_value(&certificate_body)
+        .map_err(|_| "Library Core genesis certificate body is invalid".to_string())?;
+    let epoch_id = digest_value("epoch-transition-certificate", &body_value)?;
+    Ok(GenesisEpochCertificateV1 {
+        epoch_signature: lower_hex(key_pair.sign(&epoch_signature_input(&epoch_id)?).as_ref()),
+        authority_key_possession_signature: lower_hex(
+            key_pair
+                .sign(&possession_signature_input(&epoch_id, &key_id)?)
+                .as_ref(),
+        ),
+        certificate_body,
+        epoch_id,
+    })
+}
+
+/// Verify a genesis certificate against nothing but itself and the closed
+/// constants above.
+///
+/// Called on this installation's own freshly minted certificate before it is
+/// installed, so a mistake in minting fails closed instead of being written
+/// into the authority chain, and so the verification path is exercised on
+/// every establishment rather than only by tests.
+fn verify_certificate(certificate: &GenesisEpochCertificateV1) -> Result<(), String> {
+    let body = &certificate.certificate_body;
+    if body.format != CERTIFICATE_FORMAT
+        || body.epoch != GENESIS_EPOCH
+        || body.active_engine != SOURCE_KIND
+        || body.replication_protocol != REPLICATION_PROTOCOL
+        || body.trust_model != TRUST_MODEL
+        || body.signature_algorithm != SIGNATURE_ALGORITHM
+    {
+        return Err("Library Core genesis certificate is not a genesis certificate".to_string());
+    }
+    validate_revision(&LegacySourceRevision {
+        document_id: body.source_document_id.clone(),
+        heads_digest: body.source_heads_digest.clone(),
+        head_count: body.source_head_count,
+        storage_generation: body.source_storage_generation,
+        storage_save_revision: body.source_save_revision,
+    })?;
+    if body.library_id != legacy_library_id(&body.source_document_id)? {
+        return Err(
+            "Library Core genesis certificate library does not match its source".to_string(),
+        );
+    }
+    if !is_lower_sha256(&body.authority_public_key)
+        || body.authority_key_id != authority_key_id(&body.authority_public_key)?
+    {
+        return Err("Library Core genesis certificate authority key is invalid".to_string());
+    }
+    let body_value = serde_json::to_value(body)
+        .map_err(|_| "Library Core genesis certificate body is invalid".to_string())?;
+    if certificate.epoch_id != digest_value("epoch-transition-certificate", &body_value)? {
+        return Err("Library Core genesis certificate epoch does not match its body".to_string());
+    }
+    for (input, signature, what) in [
+        (
+            epoch_signature_input(&certificate.epoch_id)?,
+            &certificate.epoch_signature,
+            "epoch",
+        ),
+        (
+            possession_signature_input(&certificate.epoch_id, &body.authority_key_id)?,
+            &certificate.authority_key_possession_signature,
+            "authority key possession",
+        ),
+    ] {
+        let verified = verify_library_core_ed25519(&body.authority_public_key, signature, &input)
+            .map_err(|_| {
+            format!("Library Core genesis certificate {what} signature is malformed")
+        })?;
+        if !verified {
+            return Err(format!(
+                "Library Core genesis certificate {what} signature is invalid"
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Where the authority signing key is kept. Production is the platform vault;
+/// tests substitute memory so they never touch the real credential store.
+trait AuthorityKeyStore {
+    fn load(&self, library_id: &str) -> Result<Option<Vec<u8>>, String>;
+    fn store(&self, library_id: &str, bytes: &[u8]) -> Result<(), String>;
+}
+
+struct PlatformAuthorityKeyStore;
+
+impl AuthorityKeyStore for PlatformAuthorityKeyStore {
+    fn load(&self, library_id: &str) -> Result<Option<Vec<u8>>, String> {
+        load_platform_key(&AUTHORITY_VAULT, library_id)
+    }
+
+    fn store(&self, library_id: &str, bytes: &[u8]) -> Result<(), String> {
+        store_platform_key(&AUTHORITY_VAULT, library_id, bytes)
+    }
+}
+
+fn load_or_create_authority_key_pair(
+    store: &dyn AuthorityKeyStore,
+    library_id: &str,
+) -> Result<Ed25519KeyPair, String> {
+    if let Some(bytes) = store.load(library_id)? {
+        return Ed25519KeyPair::from_pkcs8(&bytes)
+            .map_err(|_| "Library Core authority signing key is corrupt".to_string());
+    }
+
+    let generated = Ed25519KeyPair::generate_pkcs8(&SystemRandom::new())
+        .map_err(|_| "Library Core could not generate an authority signing key".to_string())?;
+    store.store(library_id, generated.as_ref())?;
+    // Read the key back through the store before signing anything with it. A
+    // store that accepted the write but kept something else would otherwise
+    // produce an authority chain nobody can continue after the next restart.
+    let readback = store
+        .load(library_id)?
+        .ok_or_else(|| "Library Core authority signing key readback is missing".to_string())?;
+    if readback.as_slice() != generated.as_ref() {
+        return Err("Library Core authority signing key readback changed".to_string());
+    }
+    Ed25519KeyPair::from_pkcs8(&readback)
+        .map_err(|_| "Library Core authority signing key readback is corrupt".to_string())
+}
+
+fn establish_with_key_pair(
+    journal: &mut LibraryCoreJournal,
+    revision: &LegacySourceRevision,
+    key_pair: &Ed25519KeyPair,
+    accepted_at_ms: i64,
+) -> Result<AcceptedAuthorityState, String> {
+    validate_revision(revision)?;
+    if accepted_at_ms < 0 {
+        return Err("Library Core genesis acceptance time is invalid".to_string());
+    }
+    let library_id = legacy_library_id(&revision.document_id)?;
+    let certificate = build_certificate(&library_id, revision, key_pair)?;
+    verify_certificate(&certificate)?;
+
+    let certificate_value = serde_json::to_value(&certificate)
+        .map_err(|_| "Library Core genesis certificate is invalid".to_string())?;
+    let canonical = encode_canonical_value(&certificate_value, MAX_CERTIFICATE_BYTES)
+        .map_err(|_| "Library Core genesis certificate is not canonically encodable".to_string())?;
+    let canonical_transition_certificate_json = String::from_utf8(canonical)
+        .map_err(|_| "Library Core genesis certificate is not valid UTF-8".to_string())?;
+    let transition_certificate_digest =
+        digest_value("epoch-transition-certificate", &certificate_value)?;
+
+    journal
+        .install_authority_epoch(&VerifiedAuthorityEpoch {
+            authority: AcceptedAuthorityState {
+                library_id,
+                epoch: GENESIS_EPOCH,
+                epoch_id: certificate.epoch_id.clone(),
+                authority_key_id: certificate.certificate_body.authority_key_id.clone(),
+                authority_public_key: certificate.certificate_body.authority_public_key.clone(),
+                observed_frontier: Vec::new(),
+            },
+            transition_certificate_digest,
+            canonical_transition_certificate_json,
+            accepted_at_ms,
+        })
+        .map_err(|error| format!("Library Core could not install the genesis epoch: {error}"))
+}
+
+/// Establish this installation's genesis authority epoch for one exact legacy
+/// Automerge revision, minting and storing the authority key if needed.
+pub(crate) fn establish_genesis_epoch(
+    journal: &mut LibraryCoreJournal,
+    revision: &LegacySourceRevision,
+    accepted_at_ms: i64,
+) -> Result<AcceptedAuthorityState, String> {
+    validate_revision(revision)?;
+    let library_id = legacy_library_id(&revision.document_id)?;
+    let key_pair = load_or_create_authority_key_pair(&PlatformAuthorityKeyStore, &library_id)?;
+    establish_with_key_pair(journal, revision, &key_pair, accepted_at_ms)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn revision() -> LegacySourceRevision {
+        LegacySourceRevision {
+            document_id: "freed-library-document-1".to_string(),
+            heads_digest: "a".repeat(64),
+            head_count: 2,
+            storage_generation: 7,
+            storage_save_revision: 11,
+        }
+    }
+
+    fn key_pair() -> Ed25519KeyPair {
+        // A fixed seed keeps the tests deterministic. Production mints its key
+        // in the platform vault and never sees a seed.
+        Ed25519KeyPair::from_seed_unchecked(&[7_u8; 32]).unwrap()
+    }
+
+    fn other_key_pair() -> Ed25519KeyPair {
+        Ed25519KeyPair::from_seed_unchecked(&[9_u8; 32]).unwrap()
+    }
+
+    fn open_journal() -> (tempfile::TempDir, LibraryCoreJournal) {
+        let directory = tempdir().unwrap();
+        let path = directory.path().join("library-core.sqlite");
+        let journal = LibraryCoreJournal::open(&path).unwrap();
+        (directory, journal)
+    }
+
+    #[test]
+    fn establishes_a_genesis_epoch_bound_to_one_exact_revision() {
+        let (_directory, mut journal) = open_journal();
+
+        let authority =
+            establish_with_key_pair(&mut journal, &revision(), &key_pair(), 1_700).unwrap();
+
+        assert_eq!(authority.epoch, 1);
+        assert_eq!(
+            authority.library_id,
+            legacy_library_id(&revision().document_id).unwrap()
+        );
+        assert!(authority.observed_frontier.is_empty());
+        assert_eq!(
+            authority.authority_key_id,
+            authority_key_id(&authority.authority_public_key).unwrap()
+        );
+    }
+
+    /// Minting is a pure function of the library, the key, and the revision,
+    /// so a caller that crashes after committing and retries converges.
+    #[test]
+    fn replaying_the_same_revision_returns_the_same_epoch_without_forking() {
+        let (_directory, mut journal) = open_journal();
+
+        let first = establish_with_key_pair(&mut journal, &revision(), &key_pair(), 1_700).unwrap();
+        // A later acceptance time must not produce a different epoch: the
+        // clock is not part of what the epoch identifies.
+        let second =
+            establish_with_key_pair(&mut journal, &revision(), &key_pair(), 9_900).unwrap();
+
+        assert_eq!(first, second);
+        let stored: i64 = journal
+            .connection_for_test()
+            .query_row(
+                "SELECT COUNT(*) FROM library_core_authority_epochs;",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(stored, 1, "replay must not write a second epoch");
+    }
+
+    /// The point of binding the certificate to a revision: a second attempt
+    /// against a different revision is a different epoch, and the journal
+    /// refuses it rather than silently re-pointing the library.
+    #[test]
+    fn a_different_revision_is_refused_once_a_genesis_epoch_exists() {
+        let (_directory, mut journal) = open_journal();
+        establish_with_key_pair(&mut journal, &revision(), &key_pair(), 1_700).unwrap();
+
+        let moved = LegacySourceRevision {
+            heads_digest: "b".repeat(64),
+            storage_save_revision: 12,
+            ..revision()
+        };
+        let error = establish_with_key_pair(&mut journal, &moved, &key_pair(), 1_800).unwrap_err();
+
+        assert!(
+            error.contains("could not install the genesis epoch"),
+            "{error}"
+        );
+    }
+
+    /// Same library, different authority key, is also a different epoch. It
+    /// must not quietly replace the authority the library already accepted.
+    #[test]
+    fn a_different_authority_key_is_refused_once_a_genesis_epoch_exists() {
+        let (_directory, mut journal) = open_journal();
+        establish_with_key_pair(&mut journal, &revision(), &key_pair(), 1_700).unwrap();
+
+        let error = establish_with_key_pair(&mut journal, &revision(), &other_key_pair(), 1_800)
+            .unwrap_err();
+
+        assert!(
+            error.contains("could not install the genesis epoch"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn a_different_document_is_a_different_library() {
+        let (_directory, mut journal) = open_journal();
+        let first = establish_with_key_pair(&mut journal, &revision(), &key_pair(), 1_700).unwrap();
+
+        let other_document = LegacySourceRevision {
+            document_id: "freed-library-document-2".to_string(),
+            ..revision()
+        };
+        let second =
+            establish_with_key_pair(&mut journal, &other_document, &key_pair(), 1_700).unwrap();
+
+        assert_ne!(first.library_id, second.library_id);
+        assert_eq!(second.epoch, 1);
+    }
+
+    #[test]
+    fn a_tampered_certificate_fails_verification_on_every_signed_field() {
+        let library_id = legacy_library_id(&revision().document_id).unwrap();
+        let valid = build_certificate(&library_id, &revision(), &key_pair()).unwrap();
+        verify_certificate(&valid).expect("the freshly minted certificate must verify");
+
+        let mut swapped_heads = valid.clone();
+        swapped_heads.certificate_body.source_heads_digest = "b".repeat(64);
+        assert!(verify_certificate(&swapped_heads).is_err());
+
+        let mut swapped_revision = valid.clone();
+        swapped_revision.certificate_body.source_save_revision = 12;
+        assert!(verify_certificate(&swapped_revision).is_err());
+
+        let mut swapped_library = valid.clone();
+        swapped_library.certificate_body.library_id = "c".repeat(64);
+        assert!(verify_certificate(&swapped_library).is_err());
+
+        let mut swapped_trust = valid.clone();
+        swapped_trust.certificate_body.trust_model = "fully_authenticated".to_string();
+        assert!(verify_certificate(&swapped_trust).is_err());
+
+        let mut swapped_epoch = valid.clone();
+        swapped_epoch.certificate_body.epoch = 2;
+        assert!(verify_certificate(&swapped_epoch).is_err());
+
+        // Recomputing the epoch id after tampering does not help: the
+        // signatures are over that id.
+        let mut resealed = valid.clone();
+        resealed.certificate_body.source_head_count = 3;
+        let body_value = serde_json::to_value(&resealed.certificate_body).unwrap();
+        resealed.epoch_id = digest_value("epoch-transition-certificate", &body_value).unwrap();
+        assert!(verify_certificate(&resealed).is_err());
+
+        // A signature from a key that is not the one named in the body.
+        let mut foreign = valid.clone();
+        foreign.epoch_signature = lower_hex(
+            other_key_pair()
+                .sign(&epoch_signature_input(&valid.epoch_id).unwrap())
+                .as_ref(),
+        );
+        assert!(verify_certificate(&foreign).is_err());
+
+        let mut foreign_possession = valid.clone();
+        foreign_possession.authority_key_possession_signature = lower_hex(
+            other_key_pair()
+                .sign(
+                    &possession_signature_input(
+                        &valid.epoch_id,
+                        &valid.certificate_body.authority_key_id,
+                    )
+                    .unwrap(),
+                )
+                .as_ref(),
+        );
+        assert!(verify_certificate(&foreign_possession).is_err());
+
+        // The valid certificate still verifies, so the assertions above are
+        // rejecting the tampering rather than a broken fixture.
+        verify_certificate(&valid).unwrap();
+    }
+
+    /// Two separate rules, easy to conflate.
+    ///
+    /// The body's key id must be derived from the body's public key, and the
+    /// possession signature must be over that same key id. The first alone
+    /// would let a certificate signed for one key id be replayed under
+    /// another, so the second is tested with a body that already satisfies
+    /// the first.
+    #[test]
+    fn the_possession_signature_binds_the_named_authority_key() {
+        let library_id = legacy_library_id(&revision().document_id).unwrap();
+        let valid = build_certificate(&library_id, &revision(), &key_pair()).unwrap();
+
+        // Rule one: a key id that does not derive from the public key.
+        let mut relabelled = valid.clone();
+        relabelled.certificate_body.authority_key_id =
+            authority_key_id(&lower_hex(other_key_pair().public_key().as_ref())).unwrap();
+        let error = verify_certificate(&relabelled).unwrap_err();
+        assert!(error.contains("authority key is invalid"), "{error}");
+
+        // Rule two: the right key, the right key id in the body, but the
+        // possession signature computed over a different key id. If the
+        // possession input did not carry the key id, this signature would be
+        // byte-identical to the correct one and would verify.
+        let mut mis_signed = valid.clone();
+        mis_signed.authority_key_possession_signature = lower_hex(
+            key_pair()
+                .sign(&possession_signature_input(&valid.epoch_id, &"0".repeat(64)).unwrap())
+                .as_ref(),
+        );
+        let error = verify_certificate(&mis_signed).unwrap_err();
+        assert!(
+            error.contains("authority key possession signature is invalid"),
+            "{error}"
+        );
+
+        verify_certificate(&valid).unwrap();
+    }
+
+    #[test]
+    fn a_revision_that_was_never_saved_is_refused() {
+        let (_directory, mut journal) = open_journal();
+
+        for broken in [
+            LegacySourceRevision {
+                head_count: 0,
+                ..revision()
+            },
+            LegacySourceRevision {
+                heads_digest: "not a digest".to_string(),
+                ..revision()
+            },
+            LegacySourceRevision {
+                document_id: String::new(),
+                ..revision()
+            },
+        ] {
+            assert!(
+                establish_with_key_pair(&mut journal, &broken, &key_pair(), 1_700).is_err(),
+                "{broken:?} must be refused"
+            );
+        }
+
+        let stored: i64 = journal
+            .connection_for_test()
+            .query_row(
+                "SELECT COUNT(*) FROM library_core_authority_epochs;",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(stored, 0, "a refused revision must write nothing");
+    }
+
+    #[derive(Default)]
+    struct MemoryKeyStore {
+        stored: std::cell::RefCell<Option<Vec<u8>>>,
+        /// Returns this instead of what was written, standing in for a store
+        /// that accepts a write and keeps something else.
+        substitute_on_readback: Option<Vec<u8>>,
+    }
+
+    impl AuthorityKeyStore for MemoryKeyStore {
+        fn load(&self, _library_id: &str) -> Result<Option<Vec<u8>>, String> {
+            if let Some(substitute) = self.substitute_on_readback.as_ref() {
+                if self.stored.borrow().is_some() {
+                    return Ok(Some(substitute.clone()));
+                }
+            }
+            Ok(self.stored.borrow().clone())
+        }
+
+        fn store(&self, _library_id: &str, bytes: &[u8]) -> Result<(), String> {
+            *self.stored.borrow_mut() = Some(bytes.to_vec());
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn an_authority_key_is_minted_once_and_reused_afterwards() {
+        let store = MemoryKeyStore::default();
+
+        let first = load_or_create_authority_key_pair(&store, "library-a").unwrap();
+        let minted = store.stored.borrow().clone();
+        let second = load_or_create_authority_key_pair(&store, "library-a").unwrap();
+
+        assert_eq!(
+            lower_hex(first.public_key().as_ref()),
+            lower_hex(second.public_key().as_ref()),
+            "a second call must reuse the stored key, not mint a new one"
+        );
+        assert_eq!(
+            *store.stored.borrow(),
+            minted,
+            "a second call must not overwrite the stored key"
+        );
+    }
+
+    /// A store that keeps something other than what was written would produce
+    /// an authority chain that no later restart could continue.
+    #[test]
+    fn a_key_that_does_not_read_back_is_refused_before_it_signs_anything() {
+        let store = MemoryKeyStore {
+            substitute_on_readback: Some(vec![9_u8; 32]),
+            ..MemoryKeyStore::default()
+        };
+
+        let error = load_or_create_authority_key_pair(&store, "library-a").unwrap_err();
+
+        assert!(error.contains("readback changed"), "{error}");
+    }
+
+    #[test]
+    fn a_corrupt_stored_key_is_refused_rather_than_replaced() {
+        let store = MemoryKeyStore::default();
+        store.store("library-a", b"not a pkcs8 key").unwrap();
+
+        let error = load_or_create_authority_key_pair(&store, "library-a").unwrap_err();
+
+        assert!(error.contains("key is corrupt"), "{error}");
+        // Refusing must not silently mint a replacement over the top of a key
+        // that some other epoch may already have been signed with.
+        assert_eq!(*store.stored.borrow(), Some(b"not a pkcs8 key".to_vec()));
+    }
+
+    #[test]
+    fn the_stored_certificate_is_the_canonical_encoding_of_what_was_verified() {
+        let (_directory, mut journal) = open_journal();
+        establish_with_key_pair(&mut journal, &revision(), &key_pair(), 1_700).unwrap();
+
+        let stored: String = journal
+            .connection_for_test()
+            .query_row(
+                "SELECT canonicalTransitionCertificateJson
+                 FROM library_core_authority_epochs;",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+
+        let parsed: GenesisEpochCertificateV1 = serde_json::from_str(&stored).unwrap();
+        verify_certificate(&parsed).expect("the stored certificate must still verify");
+        let library_id = legacy_library_id(&revision().document_id).unwrap();
+        assert_eq!(
+            parsed,
+            build_certificate(&library_id, &revision(), &key_pair()).unwrap()
+        );
+    }
+}

--- a/packages/desktop/src-tauri/src/library_core_journal.rs
+++ b/packages/desktop/src-tauri/src/library_core_journal.rs
@@ -234,7 +234,7 @@ struct VerifiedActorEnrollment {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct VerifiedCausalTip {
+pub(crate) struct VerifiedCausalTip {
     actor_id: String,
     sequence: i64,
     operation_id: String,
@@ -242,21 +242,21 @@ struct VerifiedCausalTip {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct AcceptedAuthorityState {
-    library_id: String,
-    epoch: i64,
-    epoch_id: String,
-    authority_key_id: String,
-    authority_public_key: String,
-    observed_frontier: Vec<VerifiedCausalTip>,
+pub(crate) struct AcceptedAuthorityState {
+    pub(crate) library_id: String,
+    pub(crate) epoch: i64,
+    pub(crate) epoch_id: String,
+    pub(crate) authority_key_id: String,
+    pub(crate) authority_public_key: String,
+    pub(crate) observed_frontier: Vec<VerifiedCausalTip>,
 }
 
 #[derive(Debug, Clone)]
-struct VerifiedAuthorityEpoch {
-    authority: AcceptedAuthorityState,
-    transition_certificate_digest: String,
-    canonical_transition_certificate_json: String,
-    accepted_at_ms: i64,
+pub(crate) struct VerifiedAuthorityEpoch {
+    pub(crate) authority: AcceptedAuthorityState,
+    pub(crate) transition_certificate_digest: String,
+    pub(crate) canonical_transition_certificate_json: String,
+    pub(crate) accepted_at_ms: i64,
 }
 
 #[derive(Debug, Clone)]
@@ -559,7 +559,14 @@ fn validate_transaction(transaction: &VerifiedReadTransaction) -> JournalResult<
 }
 
 impl LibraryCoreJournal {
-    pub(super) fn open(path: &Path) -> JournalResult<Self> {
+    /// Read access for tests in sibling modules that assert what a
+    /// production write actually put in the authoritative tables.
+    #[cfg(test)]
+    pub(crate) fn connection_for_test(&self) -> &Connection {
+        &self.connection
+    }
+
+    pub(crate) fn open(path: &Path) -> JournalResult<Self> {
         let file_name = path.file_name().ok_or(JournalError::InvalidVerifiedInput {
             field: "database_path",
         })?;

--- a/packages/desktop/src-tauri/src/library_core_journal_authority.rs
+++ b/packages/desktop/src-tauri/src/library_core_journal_authority.rs
@@ -1,16 +1,16 @@
 //! Stored authority-epoch state for the dormant authoritative journal.
 //!
-//! Authority transition verification is intentionally not implemented here.
-//! Tests may install a sealed verified epoch so enrollment and operation
-//! commits can prove their same-transaction active-epoch fences.
+//! Transition certificates are verified by the caller, not here. This module
+//! stores an already-verified decision and answers what the active epoch is,
+//! so enrollment and operation commits can prove their same-transaction
+//! active-epoch fences. `library_core_authority_genesis` builds and verifies
+//! the one certificate a fresh installation can mint for itself.
 
 use super::{
     is_lower_hex, is_operation_id, AcceptedAuthorityState, JournalError, JournalResult,
     VerifiedCausalTip, MAX_CAUSAL_TIPS_PER_OPERATION, MAX_SAFE_INTEGER,
 };
-#[cfg(test)]
 use super::{LibraryCoreJournal, VerifiedAuthorityEpoch, MAX_TRANSACTION_ENVELOPE_BYTES};
-#[cfg(test)]
 use rusqlite::TransactionBehavior;
 use rusqlite::{params, Connection, OptionalExtension};
 
@@ -66,7 +66,6 @@ fn validate_authority_state(authority: &AcceptedAuthorityState) -> JournalResult
     Ok(())
 }
 
-#[cfg(test)]
 fn validate_verified_epoch(epoch: &VerifiedAuthorityEpoch) -> JournalResult<()> {
     validate_authority_state(&epoch.authority)?;
     if !is_lower_hex(&epoch.transition_certificate_digest, 32) {
@@ -203,9 +202,15 @@ pub(super) fn require_active_epoch(
     Ok(())
 }
 
-#[cfg(test)]
 impl LibraryCoreJournal {
-    pub(super) fn install_authority_epoch(
+    /// Install one verified authority epoch and make it active.
+    ///
+    /// The caller is responsible for verifying the transition certificate;
+    /// this stores an already-verified decision. Replaying the exact same
+    /// epoch returns the stored authority without writing again, so a caller
+    /// that crashes after committing and retries converges instead of
+    /// forking. Any other epoch must be exactly one past the current one.
+    pub(crate) fn install_authority_epoch(
         &mut self,
         epoch: &VerifiedAuthorityEpoch,
     ) -> JournalResult<AcceptedAuthorityState> {

--- a/packages/desktop/src-tauri/src/library_core_journal_runtime.rs
+++ b/packages/desktop/src-tauri/src/library_core_journal_runtime.rs
@@ -17,6 +17,7 @@ use std::sync::Mutex;
 
 use tauri::Manager;
 
+use super::library_core_authority_genesis::{establish_genesis_epoch, LegacySourceRevision};
 use super::library_core_journal::{JournalRuntimeStatus, LibraryCoreJournal};
 
 /// Directory holding the authoritative database, under the app data root.
@@ -144,6 +145,87 @@ pub(super) fn library_core_journal_status(
     status_of(&state).map_err(|error| error.to_string())
 }
 
+/// What the caller reports about the exact durable Automerge revision the
+/// genesis epoch should be bound to.
+///
+/// These are the fields of the renderer's `LibraryCoreProjectionSourceV1`,
+/// which the Automerge worker only produces when the in-memory document's
+/// heads equal the durable snapshot's heads.
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(super) struct GenesisSourceRequest {
+    document_id: String,
+    heads_digest: String,
+    head_count: u64,
+    storage_generation: u64,
+    storage_save_revision: u64,
+}
+
+/// What was established, for the caller to log. No key material, and no
+/// certificate: the certificate stays in the journal.
+#[derive(Debug, Eq, PartialEq, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct GenesisAuthorityStatus {
+    pub(super) library_id: String,
+    pub(super) epoch: i64,
+    pub(super) epoch_id: String,
+    pub(super) authority_key_id: String,
+}
+
+/// Establishes the genesis authority epoch against the held journal.
+///
+/// Requires the journal to be open already, so a caller cannot establish
+/// authority against a database that was never validated on open. Replaying
+/// the same revision returns the same epoch rather than writing again.
+pub(super) fn establish_genesis_at(
+    state: &LibraryCoreJournalRuntimeState,
+    request: &GenesisSourceRequest,
+    accepted_at_ms: i64,
+) -> RuntimeResult<GenesisAuthorityStatus> {
+    let mut held = state
+        .0
+        .lock()
+        .map_err(|_| JournalRuntimeError::StatePoisoned)?;
+    let journal = held
+        .as_mut()
+        .ok_or_else(|| JournalRuntimeError::Journal("journal is not open".to_string()))?;
+
+    let authority = establish_genesis_epoch(
+        journal,
+        &LegacySourceRevision {
+            document_id: request.document_id.clone(),
+            heads_digest: request.heads_digest.clone(),
+            head_count: request.head_count,
+            storage_generation: request.storage_generation,
+            storage_save_revision: request.storage_save_revision,
+        },
+        accepted_at_ms,
+    )
+    .map_err(JournalRuntimeError::Journal)?;
+
+    Ok(GenesisAuthorityStatus {
+        library_id: authority.library_id,
+        epoch: authority.epoch,
+        epoch_id: authority.epoch_id,
+        authority_key_id: authority.authority_key_id,
+    })
+}
+
+#[tauri::command]
+pub(super) fn establish_library_core_genesis_authority(
+    state: tauri::State<'_, LibraryCoreJournalRuntimeState>,
+    source: GenesisSourceRequest,
+) -> Result<GenesisAuthorityStatus, String> {
+    let accepted_at_ms = i64::try_from(
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_err(|_| "system clock is before the Unix epoch".to_string())?
+            .as_millis(),
+    )
+    .map_err(|_| "system clock exceeds the supported range".to_string())?;
+    establish_genesis_at(&state, &source, accepted_at_ms).map_err(|error| error.to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -181,6 +263,25 @@ mod tests {
                 & 0o777;
             assert_eq!(mode, 0o700, "journal directory must not be world readable");
         }
+    }
+
+    /// Establishing authority against a database that never validated on open
+    /// would be writing an authority chain into an unknown store.
+    #[test]
+    fn genesis_authority_is_refused_before_the_journal_is_open() {
+        let state = LibraryCoreJournalRuntimeState::default();
+        let request = GenesisSourceRequest {
+            document_id: "freed-library-document-1".to_string(),
+            heads_digest: "a".repeat(64),
+            head_count: 2,
+            storage_generation: 7,
+            storage_save_revision: 11,
+        };
+
+        let error = establish_genesis_at(&state, &request, 1_700)
+            .expect_err("authority must require an open journal");
+
+        assert!(error.to_string().contains("journal is not open"), "{error}");
     }
 
     #[test]

--- a/packages/desktop/src-tauri/src/library_core_migration_claim.rs
+++ b/packages/desktop/src-tauri/src/library_core_migration_claim.rs
@@ -10,9 +10,9 @@ use crate::library_core_canonical::{
     encode_signature_input,
 };
 use crate::library_core_ed25519::verify_library_core_ed25519;
-use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine};
-#[cfg(any(target_os = "macos", target_os = "windows"))]
-use keyring::Entry;
+use crate::library_core_platform_key::{
+    clear_platform_key, load_platform_key, store_platform_key, PlatformKeyVault,
+};
 use ring::rand::{SecureRandom, SystemRandom};
 use ring::signature::{Ed25519KeyPair, KeyPair};
 use serde::{Deserialize, Serialize};
@@ -21,16 +21,12 @@ use sha2::{Digest, Sha256};
 use std::fs::{File, OpenOptions};
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
-#[cfg(target_os = "macos")]
-use std::sync::{LazyLock, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 const CLAIM_FORMAT: &str = "freed_local_automerge_migration_claim_v1";
 const CLAIM_MODE: &str = "local";
 const SOURCE_KIND: &str = "automerge_indexeddb_v3";
 const SIGNATURE_ALGORITHM: &str = "ed25519";
-const KEYRING_SERVICE: &str = "wtf.freed.library-core";
-const KEYRING_ACCOUNT: &str = "migration-source-current";
 const CLAIM_DIRECTORY: &str = "claims";
 const MAXIMUM_CLAIM_BYTES: usize = 16 * 1_024;
 const MAXIMUM_INSTALLATION_ID_BYTES: usize = 128;
@@ -61,14 +57,6 @@ pub(super) struct LocalMigrationClaimV1 {
     source_key_signature: String,
 }
 
-#[derive(Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-struct PlatformMigrationKeyEnvelopeV1 {
-    format: String,
-    installation_id: String,
-    pkcs8_base64: String,
-}
-
 pub(super) trait MigrationClaimKeyStore {
     fn load(&self, installation_id: &str) -> Result<Option<Vec<u8>>, String>;
     fn store(&self, installation_id: &str, bytes: &[u8]) -> Result<(), String>;
@@ -76,139 +64,32 @@ pub(super) trait MigrationClaimKeyStore {
 
 pub(super) struct PlatformMigrationClaimKeyStore;
 
-#[cfg(any(target_os = "macos", target_os = "windows"))]
-fn keyring_entry() -> Result<Entry, String> {
-    Entry::new(KEYRING_SERVICE, KEYRING_ACCOUNT)
-        .map_err(|_| "Library Core could not open the platform credential vault".to_string())
-}
-
-#[cfg(target_os = "macos")]
-static KEYRING_INTERACTION_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
-
-#[cfg(any(test, target_os = "macos"))]
-fn with_user_interaction_policy<T, Guard>(
-    interaction_allowed: impl FnOnce() -> Result<bool, String>,
-    disable_interaction: impl FnOnce() -> Result<Guard, String>,
-    operation: impl FnOnce() -> Result<T, String>,
-) -> Result<T, String> {
-    let interaction_was_allowed = interaction_allowed()?;
-    let _interaction_guard = if interaction_was_allowed {
-        Some(disable_interaction()?)
-    } else {
-        None
-    };
-    operation()
-}
-
-#[cfg(target_os = "macos")]
-fn with_keyring_user_interaction_disabled<T>(
-    operation: impl FnOnce() -> Result<T, String>,
-) -> Result<T, String> {
-    use security_framework::os::macos::keychain::SecKeychain;
-
-    let _operation_guard = KEYRING_INTERACTION_LOCK
-        .lock()
-        .map_err(|_| "Library Core credential-vault access is unavailable".to_string())?;
-    with_user_interaction_policy(
-        || {
-            SecKeychain::user_interaction_allowed().map_err(|_| {
-                "Library Core could not inspect Keychain interaction policy".to_string()
-            })
-        },
-        || {
-            SecKeychain::disable_user_interaction()
-                .map_err(|_| "Library Core could not disable Keychain user interaction".to_string())
-        },
-        operation,
-    )
-}
-
-#[cfg(target_os = "windows")]
-fn with_keyring_user_interaction_disabled<T>(
-    operation: impl FnOnce() -> Result<T, String>,
-) -> Result<T, String> {
-    operation()
-}
-
-fn encode_platform_key_envelope(installation_id: &str, bytes: &[u8]) -> Result<Vec<u8>, String> {
-    validate_installation_id(installation_id)?;
-    let envelope = PlatformMigrationKeyEnvelopeV1 {
-        format: "freed_library_core_migration_key_v1".to_string(),
-        installation_id: installation_id.to_string(),
-        pkcs8_base64: BASE64_STANDARD.encode(bytes),
-    };
-    serde_json::to_vec(&envelope)
-        .map_err(|_| "Library Core migration signing key envelope is invalid".to_string())
-}
-
-fn decode_platform_key_envelope(
-    installation_id: &str,
-    bytes: &[u8],
-) -> Result<Option<Vec<u8>>, String> {
-    validate_installation_id(installation_id)?;
-    let envelope: PlatformMigrationKeyEnvelopeV1 = serde_json::from_slice(bytes)
-        .map_err(|_| "Library Core migration signing key envelope is corrupt".to_string())?;
-    if envelope.format != "freed_library_core_migration_key_v1" {
-        return Err("Library Core migration signing key format is unsupported".to_string());
-    }
-    validate_installation_id(&envelope.installation_id)?;
-    if envelope.installation_id != installation_id {
-        return Ok(None);
-    }
-    BASE64_STANDARD
-        .decode(envelope.pkcs8_base64)
-        .map(Some)
-        .map_err(|_| "Library Core migration signing key is corrupt".to_string())
-}
+/// The vault account holding this installation's migration signing key.
+///
+/// The account and envelope format are the same strings this module used
+/// before the vault plumbing moved to `library_core_platform_key`, so an
+/// already-stored key still reads back.
+const MIGRATION_CLAIM_VAULT: PlatformKeyVault = PlatformKeyVault {
+    account: "migration-source-current",
+    envelope_format: "freed_library_core_migration_key_v1",
+    description: "migration signing",
+};
 
 impl MigrationClaimKeyStore for PlatformMigrationClaimKeyStore {
     fn load(&self, installation_id: &str) -> Result<Option<Vec<u8>>, String> {
-        #[cfg(any(target_os = "macos", target_os = "windows"))]
-        {
-            with_keyring_user_interaction_disabled(|| match keyring_entry()?.get_secret() {
-                Ok(bytes) => decode_platform_key_envelope(installation_id, &bytes),
-                Err(keyring::Error::NoEntry) => Ok(None),
-                Err(_) => Err("Library Core could not read its migration signing key".to_string()),
-            })
-        }
-        #[cfg(not(any(target_os = "macos", target_os = "windows")))]
-        {
-            let _ = installation_id;
-            Err("Library Core has no noninteractive platform credential vault on this operating system".to_string())
-        }
+        validate_installation_id(installation_id)?;
+        load_platform_key(&MIGRATION_CLAIM_VAULT, installation_id)
     }
 
     fn store(&self, installation_id: &str, bytes: &[u8]) -> Result<(), String> {
-        #[cfg(any(target_os = "macos", target_os = "windows"))]
-        {
-            let encoded = encode_platform_key_envelope(installation_id, bytes)?;
-            with_keyring_user_interaction_disabled(|| {
-                keyring_entry()?.set_secret(&encoded).map_err(|_| {
-                    "Library Core could not protect its migration signing key".to_string()
-                })
-            })
-        }
-        #[cfg(not(any(target_os = "macos", target_os = "windows")))]
-        {
-            let _ = (installation_id, bytes);
-            Err("Library Core has no noninteractive platform credential vault on this operating system".to_string())
-        }
+        validate_installation_id(installation_id)?;
+        store_platform_key(&MIGRATION_CLAIM_VAULT, installation_id, bytes)
     }
 }
 
 #[cfg_attr(test, allow(dead_code))]
 pub(super) fn clear_platform_migration_claim_key() -> Result<(), String> {
-    #[cfg(any(target_os = "macos", target_os = "windows"))]
-    {
-        with_keyring_user_interaction_disabled(|| match keyring_entry()?.delete_credential() {
-            Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
-            Err(_) => Err("Library Core could not remove its migration signing key".to_string()),
-        })
-    }
-    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
-    {
-        Ok(())
-    }
+    clear_platform_key(&MIGRATION_CLAIM_VAULT)
 }
 
 fn validate_installation_id(value: &str) -> Result<(), String> {
@@ -524,7 +405,6 @@ pub(super) fn authenticate_migration_source_with_store(
 mod tests {
     use super::*;
     use std::cell::RefCell;
-    use std::rc::Rc;
     use tempfile::tempdir;
 
     #[derive(Default)]
@@ -549,57 +429,6 @@ mod tests {
             byte_length: 1_024,
             source_installation_id: "desktop-installation-1".to_string(),
         }
-    }
-
-    #[test]
-    fn platform_envelope_is_bound_to_one_installation() {
-        let encoded = encode_platform_key_envelope("desktop-installation-1", b"private-key")
-            .expect("encode envelope");
-        assert_eq!(
-            decode_platform_key_envelope("desktop-installation-1", &encoded).unwrap(),
-            Some(b"private-key".to_vec())
-        );
-        assert_eq!(
-            decode_platform_key_envelope("desktop-installation-2", &encoded).unwrap(),
-            None
-        );
-        assert!(decode_platform_key_envelope("desktop-installation-1", b"{}").is_err());
-    }
-
-    #[test]
-    fn credential_operation_runs_only_while_interaction_is_disabled() {
-        struct FakeInteractionGuard(Rc<RefCell<Vec<&'static str>>>);
-
-        impl Drop for FakeInteractionGuard {
-            fn drop(&mut self) {
-                self.0.borrow_mut().push("restore");
-            }
-        }
-
-        let events = Rc::new(RefCell::new(Vec::new()));
-        let inspect_events = events.clone();
-        let disable_events = events.clone();
-        let operation_events = events.clone();
-        with_user_interaction_policy(
-            move || {
-                inspect_events.borrow_mut().push("inspect");
-                Ok(true)
-            },
-            move || {
-                disable_events.borrow_mut().push("disable");
-                Ok(FakeInteractionGuard(disable_events.clone()))
-            },
-            move || {
-                operation_events.borrow_mut().push("credential-operation");
-                Ok(())
-            },
-        )
-        .unwrap();
-
-        assert_eq!(
-            *events.borrow(),
-            ["inspect", "disable", "credential-operation", "restore"]
-        );
     }
 
     #[test]

--- a/packages/desktop/src-tauri/src/library_core_platform_key.rs
+++ b/packages/desktop/src-tauri/src/library_core_platform_key.rs
@@ -1,0 +1,365 @@
+//! One process-wide accessor for private keys held in the platform vault.
+//!
+//! Every Library Core private key lives in the operating system credential
+//! vault under its own account, wrapped in a versioned envelope that names the
+//! subject it belongs to. Reading a key must never raise an interactive
+//! prompt, so on macOS the read runs with Keychain user interaction disabled.
+//!
+//! That policy is process-global state, not per-entry state, which is why this
+//! module exists at all. A second copy of the keyring plumbing would carry its
+//! own mutex, and two mutexes guarding one global would serialize neither: one
+//! caller could restore interaction while another was still relying on it
+//! being off. Every vault account goes through the lock below.
+//!
+//! Keys are never synchronized, exported, or written outside the vault.
+
+use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine};
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+use keyring::Entry;
+use serde::{Deserialize, Serialize};
+#[cfg(target_os = "macos")]
+use std::sync::{LazyLock, Mutex};
+
+pub(crate) const KEYRING_SERVICE: &str = "wtf.freed.library-core";
+const MAXIMUM_SUBJECT_BYTES: usize = 128;
+
+/// One named private key: which vault account holds it, and how its envelope
+/// is tagged. Both are stable identifiers, so changing either orphans the key
+/// already stored under the old pair rather than reading it as something else.
+pub(crate) struct PlatformKeyVault {
+    pub(crate) account: &'static str,
+    pub(crate) envelope_format: &'static str,
+    /// Names the key in operator-facing errors, lowercase, e.g. "migration
+    /// signing". Errors never include the subject or any key material.
+    pub(crate) description: &'static str,
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct PlatformKeyEnvelopeV1 {
+    format: String,
+    subject: String,
+    pkcs8_base64: String,
+}
+
+/// The identity a stored key is bound to, so a key minted for one subject is
+/// never handed back for another.
+pub(crate) fn validate_subject(value: &str) -> Result<(), String> {
+    if value.is_empty()
+        || value.len() > MAXIMUM_SUBJECT_BYTES
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b':' | b'-'))
+    {
+        return Err("invalid Library Core key subject".to_string());
+    }
+    Ok(())
+}
+
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+fn keyring_entry(vault: &PlatformKeyVault) -> Result<Entry, String> {
+    Entry::new(KEYRING_SERVICE, vault.account)
+        .map_err(|_| "Library Core could not open the platform credential vault".to_string())
+}
+
+#[cfg(target_os = "macos")]
+static KEYRING_INTERACTION_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+#[cfg(any(test, target_os = "macos"))]
+fn with_user_interaction_policy<T, Guard>(
+    interaction_allowed: impl FnOnce() -> Result<bool, String>,
+    disable_interaction: impl FnOnce() -> Result<Guard, String>,
+    operation: impl FnOnce() -> Result<T, String>,
+) -> Result<T, String> {
+    let interaction_was_allowed = interaction_allowed()?;
+    let _interaction_guard = if interaction_was_allowed {
+        Some(disable_interaction()?)
+    } else {
+        None
+    };
+    operation()
+}
+
+#[cfg(target_os = "macos")]
+fn with_keyring_user_interaction_disabled<T>(
+    operation: impl FnOnce() -> Result<T, String>,
+) -> Result<T, String> {
+    use security_framework::os::macos::keychain::SecKeychain;
+
+    let _operation_guard = KEYRING_INTERACTION_LOCK
+        .lock()
+        .map_err(|_| "Library Core credential-vault access is unavailable".to_string())?;
+    with_user_interaction_policy(
+        || {
+            SecKeychain::user_interaction_allowed().map_err(|_| {
+                "Library Core could not inspect Keychain interaction policy".to_string()
+            })
+        },
+        || {
+            SecKeychain::disable_user_interaction()
+                .map_err(|_| "Library Core could not disable Keychain user interaction".to_string())
+        },
+        operation,
+    )
+}
+
+#[cfg(target_os = "windows")]
+fn with_keyring_user_interaction_disabled<T>(
+    operation: impl FnOnce() -> Result<T, String>,
+) -> Result<T, String> {
+    operation()
+}
+
+fn encode_envelope(
+    vault: &PlatformKeyVault,
+    subject: &str,
+    bytes: &[u8],
+) -> Result<Vec<u8>, String> {
+    validate_subject(subject)?;
+    let envelope = PlatformKeyEnvelopeV1 {
+        format: vault.envelope_format.to_string(),
+        subject: subject.to_string(),
+        pkcs8_base64: BASE64_STANDARD.encode(bytes),
+    };
+    serde_json::to_vec(&envelope)
+        .map_err(|_| format!("Library Core {} key envelope is invalid", vault.description))
+}
+
+fn decode_envelope(
+    vault: &PlatformKeyVault,
+    subject: &str,
+    bytes: &[u8],
+) -> Result<Option<Vec<u8>>, String> {
+    validate_subject(subject)?;
+    let envelope: PlatformKeyEnvelopeV1 = serde_json::from_slice(bytes)
+        .map_err(|_| format!("Library Core {} key envelope is corrupt", vault.description))?;
+    if envelope.format != vault.envelope_format {
+        return Err(format!(
+            "Library Core {} key format is unsupported",
+            vault.description
+        ));
+    }
+    validate_subject(&envelope.subject)?;
+    // A key stored for a different subject is absent, not corrupt: the caller
+    // mints a fresh one rather than signing with someone else's key.
+    if envelope.subject != subject {
+        return Ok(None);
+    }
+    BASE64_STANDARD
+        .decode(envelope.pkcs8_base64)
+        .map(Some)
+        .map_err(|_| format!("Library Core {} key is corrupt", vault.description))
+}
+
+pub(crate) fn load_platform_key(
+    vault: &PlatformKeyVault,
+    subject: &str,
+) -> Result<Option<Vec<u8>>, String> {
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    {
+        with_keyring_user_interaction_disabled(|| match keyring_entry(vault)?.get_secret() {
+            Ok(bytes) => decode_envelope(vault, subject, &bytes),
+            Err(keyring::Error::NoEntry) => Ok(None),
+            Err(_) => Err(format!(
+                "Library Core could not read its {} key",
+                vault.description
+            )),
+        })
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    {
+        let _ = (vault, subject);
+        Err(unsupported_vault())
+    }
+}
+
+pub(crate) fn store_platform_key(
+    vault: &PlatformKeyVault,
+    subject: &str,
+    bytes: &[u8],
+) -> Result<(), String> {
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    {
+        let encoded = encode_envelope(vault, subject, bytes)?;
+        with_keyring_user_interaction_disabled(|| {
+            keyring_entry(vault)?.set_secret(&encoded).map_err(|_| {
+                format!(
+                    "Library Core could not protect its {} key",
+                    vault.description
+                )
+            })
+        })
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    {
+        let _ = (vault, subject, bytes);
+        Err(unsupported_vault())
+    }
+}
+
+pub(crate) fn clear_platform_key(vault: &PlatformKeyVault) -> Result<(), String> {
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    {
+        with_keyring_user_interaction_disabled(|| match keyring_entry(vault)?.delete_credential() {
+            Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
+            Err(_) => Err(format!(
+                "Library Core could not remove its {} key",
+                vault.description
+            )),
+        })
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    {
+        let _ = vault;
+        Ok(())
+    }
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+fn unsupported_vault() -> String {
+    "Library Core has no noninteractive platform credential vault on this operating system"
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const VAULT: PlatformKeyVault = PlatformKeyVault {
+        account: "test-account",
+        envelope_format: "freed_library_core_test_key_v1",
+        description: "test",
+    };
+
+    #[test]
+    fn an_envelope_round_trips_only_for_its_own_subject() {
+        let encoded = encode_envelope(&VAULT, "subject-a", &[1, 2, 3]).unwrap();
+
+        assert_eq!(
+            decode_envelope(&VAULT, "subject-a", &encoded).unwrap(),
+            Some(vec![1, 2, 3])
+        );
+        // A key minted for another subject reads as absent, never as this
+        // subject's key.
+        assert_eq!(
+            decode_envelope(&VAULT, "subject-b", &encoded).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn a_foreign_envelope_format_is_refused_rather_than_reinterpreted() {
+        const OTHER: PlatformKeyVault = PlatformKeyVault {
+            account: "test-account",
+            envelope_format: "freed_library_core_other_key_v1",
+            description: "other",
+        };
+        let encoded = encode_envelope(&OTHER, "subject-a", &[1, 2, 3]).unwrap();
+
+        let error = decode_envelope(&VAULT, "subject-a", &encoded).unwrap_err();
+
+        assert!(error.contains("format is unsupported"), "{error}");
+    }
+
+    #[test]
+    fn subjects_outside_the_closed_alphabet_are_refused() {
+        for subject in ["", "has space", "has/slash", "has\u{0}nul"] {
+            assert!(validate_subject(subject).is_err(), "{subject:?}");
+        }
+        assert!(validate_subject(&"a".repeat(MAXIMUM_SUBJECT_BYTES)).is_ok());
+        assert!(validate_subject(&"a".repeat(MAXIMUM_SUBJECT_BYTES + 1)).is_err());
+        assert!(validate_subject("desktop-installation-1.0_a:b-c").is_ok());
+    }
+
+    #[test]
+    fn a_corrupt_envelope_is_an_error_rather_than_an_absent_key() {
+        let error = decode_envelope(&VAULT, "subject-a", b"not json").unwrap_err();
+
+        assert!(error.contains("envelope is corrupt"), "{error}");
+    }
+
+    /// Moved here with the plumbing it covers. The operation must run only
+    /// while interaction is disabled, and the policy must be restored after.
+    #[test]
+    fn a_credential_operation_runs_only_while_interaction_is_disabled() {
+        use std::cell::RefCell;
+        use std::rc::Rc;
+
+        struct FakeInteractionGuard(Rc<RefCell<Vec<&'static str>>>);
+
+        impl Drop for FakeInteractionGuard {
+            fn drop(&mut self) {
+                self.0.borrow_mut().push("restore");
+            }
+        }
+
+        let events = Rc::new(RefCell::new(Vec::new()));
+        let inspect_events = events.clone();
+        let disable_events = events.clone();
+        let operation_events = events.clone();
+        with_user_interaction_policy(
+            move || {
+                inspect_events.borrow_mut().push("inspect");
+                Ok(true)
+            },
+            move || {
+                disable_events.borrow_mut().push("disable");
+                Ok(FakeInteractionGuard(disable_events.clone()))
+            },
+            move || {
+                operation_events.borrow_mut().push("credential-operation");
+                Ok(())
+            },
+        )
+        .unwrap();
+
+        assert_eq!(
+            *events.borrow(),
+            ["inspect", "disable", "credential-operation", "restore"]
+        );
+    }
+
+    /// The interaction policy this module serializes is process-global, so the
+    /// guard has to restore the previous policy even when the operation fails.
+    #[test]
+    fn the_interaction_guard_restores_the_previous_policy_after_a_failure() {
+        struct RestoreOnDrop<'a>(&'a std::cell::Cell<bool>);
+        impl Drop for RestoreOnDrop<'_> {
+            fn drop(&mut self) {
+                self.0.set(true);
+            }
+        }
+
+        let allowed = std::cell::Cell::new(true);
+        let restored = std::cell::Cell::new(false);
+
+        let result: Result<(), String> = with_user_interaction_policy(
+            || Ok(allowed.get()),
+            || Ok(RestoreOnDrop(&restored)),
+            || Err("operation failed".to_string()),
+        );
+
+        assert_eq!(result.unwrap_err(), "operation failed");
+        assert!(
+            restored.get(),
+            "the policy guard must run on the error path"
+        );
+    }
+
+    #[test]
+    fn no_guard_is_taken_when_interaction_was_already_disabled() {
+        let disable_calls = std::cell::Cell::new(0_u32);
+
+        let result: Result<u32, String> = with_user_interaction_policy(
+            || Ok(false),
+            || {
+                disable_calls.set(disable_calls.get() + 1);
+                Ok(())
+            },
+            || Ok(7),
+        );
+
+        assert_eq!(result.unwrap(), 7);
+        assert_eq!(disable_calls.get(), 0);
+    }
+}

--- a/packages/desktop/src/lib/library-core-journal-runtime.test.ts
+++ b/packages/desktop/src/lib/library-core-journal-runtime.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const invoke = vi.fn();
+const getLibraryCoreProjectionSource = vi.fn();
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke }));
+vi.mock("./automerge", () => ({ getLibraryCoreProjectionSource }));
+
+const {
+  establishLibraryCoreGenesisAuthority,
+  openLibraryCoreJournalForStartup,
+} = await import("./library-core-journal-runtime.js");
+
+const SOURCE = {
+  schemaVersion: 1,
+  documentId: "freed-library-document-1",
+  headsDigest: "a".repeat(64),
+  headCount: 2,
+  storageRevision: { generation: 7, saveRevision: 11 },
+} as const;
+
+const STATUS = {
+  schemaVersion: 1,
+  materializerIngestSequence: 0,
+  actors: 0,
+  operations: 0,
+  readState: 0,
+  unacknowledgedOutbox: 0,
+} as const;
+
+const AUTHORITY = {
+  libraryId: "b".repeat(64),
+  epoch: 1,
+  epochId: "c".repeat(64),
+  authorityKeyId: "d".repeat(64),
+} as const;
+
+describe("Library Core journal runtime client", () => {
+  beforeEach(() => {
+    invoke.mockReset();
+    getLibraryCoreProjectionSource.mockReset();
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "info").mockImplementation(() => {});
+  });
+
+  it("sends the exact durable revision the worker reported", async () => {
+    invoke.mockResolvedValue(AUTHORITY);
+
+    await expect(establishLibraryCoreGenesisAuthority(SOURCE)).resolves.toEqual(
+      AUTHORITY,
+    );
+    expect(invoke).toHaveBeenCalledWith(
+      "establish_library_core_genesis_authority",
+      {
+        source: {
+          documentId: "freed-library-document-1",
+          headsDigest: "a".repeat(64),
+          headCount: 2,
+          storageGeneration: 7,
+          storageSaveRevision: 11,
+        },
+      },
+    );
+  });
+
+  it("opens the journal and then establishes authority against that revision", async () => {
+    invoke.mockImplementation((command: string) =>
+      command === "open_library_core_journal"
+        ? Promise.resolve(STATUS)
+        : Promise.resolve(AUTHORITY),
+    );
+    getLibraryCoreProjectionSource.mockResolvedValue(SOURCE);
+
+    await expect(openLibraryCoreJournalForStartup()).resolves.toEqual(STATUS);
+
+    expect(invoke.mock.calls.map(([command]) => command)).toEqual([
+      "open_library_core_journal",
+      "establish_library_core_genesis_authority",
+    ]);
+  });
+
+  it("does not try to establish authority when the journal will not open", async () => {
+    invoke.mockRejectedValue(new Error("journal refused to open"));
+
+    await expect(openLibraryCoreJournalForStartup()).resolves.toBeNull();
+
+    // Establishing against a database that never validated on open would be
+    // writing authority into an unknown store.
+    expect(invoke.mock.calls.map(([command]) => command)).toEqual([
+      "open_library_core_journal",
+    ]);
+    expect(getLibraryCoreProjectionSource).not.toHaveBeenCalled();
+  });
+
+  it("still starts when the document has no durable revision yet", async () => {
+    invoke.mockResolvedValue(STATUS);
+    getLibraryCoreProjectionSource.mockRejectedValue(
+      new Error("Document not initialized"),
+    );
+
+    // Startup must survive it: the next start tries again.
+    await expect(openLibraryCoreJournalForStartup()).resolves.toEqual(STATUS);
+    expect(invoke.mock.calls.map(([command]) => command)).toEqual([
+      "open_library_core_journal",
+    ]);
+  });
+
+  it("still starts when establishing authority is refused", async () => {
+    invoke.mockImplementation((command: string) =>
+      command === "open_library_core_journal"
+        ? Promise.resolve(STATUS)
+        : Promise.reject(new Error("stale authority")),
+    );
+    getLibraryCoreProjectionSource.mockResolvedValue(SOURCE);
+
+    await expect(openLibraryCoreJournalForStartup()).resolves.toEqual(STATUS);
+  });
+});

--- a/packages/desktop/src/lib/library-core-journal-runtime.ts
+++ b/packages/desktop/src/lib/library-core-journal-runtime.ts
@@ -1,5 +1,8 @@
 import { invoke } from "@tauri-apps/api/core";
 
+import { getLibraryCoreProjectionSource } from "./automerge";
+import type { LibraryCoreProjectionSourceV1 } from "./automerge-types";
+
 /**
  * Desktop client for the Library Core journal.
  *
@@ -42,6 +45,41 @@ export function libraryCoreJournalStatus(): Promise<LibraryCoreJournalStatusV1 |
   );
 }
 
+/** What this installation established as its own authority origin. */
+export interface LibraryCoreGenesisAuthorityV1 {
+  readonly libraryId: string;
+  readonly epoch: number;
+  readonly epochId: string;
+  readonly authorityKeyId: string;
+}
+
+/**
+ * Establishes the genesis authority epoch for one exact durable Automerge
+ * revision, minting this installation's authority key if it has none.
+ *
+ * Requires the journal to be open. Everything the epoch is derived from is a
+ * pure function of the library, the key and the revision, so replaying the same
+ * revision returns the same epoch instead of writing a second one. A revision
+ * that differs from the one already established is refused rather than
+ * silently re-pointing the library.
+ */
+export function establishLibraryCoreGenesisAuthority(
+  source: LibraryCoreProjectionSourceV1,
+): Promise<LibraryCoreGenesisAuthorityV1> {
+  return invoke<LibraryCoreGenesisAuthorityV1>(
+    "establish_library_core_genesis_authority",
+    {
+      source: {
+        documentId: source.documentId,
+        headsDigest: source.headsDigest,
+        headCount: source.headCount,
+        storageGeneration: source.storageRevision.generation,
+        storageSaveRevision: source.storageRevision.saveRevision,
+      },
+    },
+  );
+}
+
 /**
  * Opens the journal during startup without letting a failure reach the user.
  *
@@ -49,10 +87,22 @@ export function libraryCoreJournalStatus(): Promise<LibraryCoreJournalStatusV1 |
  * open it must still start normally and behave exactly as before. The failure
  * is surfaced to the console as evidence rather than raised, because the only
  * consumer of that evidence today is us.
+ *
+ * Once the journal is open, the installation establishes its own genesis
+ * authority epoch against the document's current durable revision. Until that
+ * exists there is no active epoch, and Library Core fences every actor
+ * enrollment and every operation commit against one, so nothing can be written
+ * at all. This is dormant either way: no operations are written here, Automerge
+ * stays authoritative, and no provider traffic is emitted.
+ *
+ * The document may not be readable yet at startup, which is why establishment
+ * is attempted and not required. The next start tries again against whatever
+ * revision is durable then, and the first one to succeed pins the library.
  */
 export async function openLibraryCoreJournalForStartup(): Promise<LibraryCoreJournalStatusV1 | null> {
+  let status: LibraryCoreJournalStatusV1;
   try {
-    return await openLibraryCoreJournal();
+    status = await openLibraryCoreJournal();
   } catch (error) {
     console.warn(
       "[library-core] journal unavailable; continuing on Automerge only",
@@ -60,4 +110,19 @@ export async function openLibraryCoreJournalForStartup(): Promise<LibraryCoreJou
     );
     return null;
   }
+
+  try {
+    const source = await getLibraryCoreProjectionSource();
+    const authority = await establishLibraryCoreGenesisAuthority(source);
+    console.info(
+      `[library-core] authority epoch ${authority.epoch} for library ${authority.libraryId}`,
+    );
+  } catch (error) {
+    console.warn(
+      "[library-core] genesis authority not established; retrying next start",
+      error,
+    );
+  }
+
+  return status;
 }

--- a/packages/shared/src/library-core/canonical-codec.ts
+++ b/packages/shared/src/library-core/canonical-codec.ts
@@ -52,6 +52,7 @@ export const LIBRARY_CORE_DIGEST_DOMAINS = [
   "legacy-library-control",
   "legacy-epoch-bootstrap-prepared",
   "legacy-epoch-bootstrap-receipt",
+  "legacy-library-identity",
 ] as const;
 
 export type LibraryCoreDigestDomain =

--- a/packages/shared/src/library-core/canonical-domains-v1.json
+++ b/packages/shared/src/library-core/canonical-domains-v1.json
@@ -23,7 +23,8 @@
     "legacy-epoch-bootstrap-record",
     "legacy-library-control",
     "legacy-epoch-bootstrap-prepared",
-    "legacy-epoch-bootstrap-receipt"
+    "legacy-epoch-bootstrap-receipt",
+    "legacy-library-identity"
   ],
   "signature": [
     "operation-envelope",

--- a/packages/shared/src/library-core/local-authority-registry.test.ts
+++ b/packages/shared/src/library-core/local-authority-registry.test.ts
@@ -270,7 +270,10 @@ describe("Library Core local authority registry", () => {
         entry.registryKey === "library-core-authority-private-key"
       ),
     ).toMatchObject({
-      soleOwner: "unprovisioned Library Core native authority adapter",
+      // Provisioned on desktop macOS and Windows now that the genesis epoch
+      // mints and signs with it. It stays a secret with the same disposition:
+      // never backed up, exported, snapshotted, or synchronized.
+      soleOwner: "packages/desktop/src-tauri/src/library_core_authority_genesis.rs",
       resetSemantics: "Factory reset removes local protected authority material. Restore may install a newly rotated authority key only through an accepted recovery transition; private bytes are never exported or imported.",
     });
   });

--- a/packages/shared/src/library-core/local-authority-registry.ts
+++ b/packages/shared/src/library-core/local-authority-registry.ts
@@ -918,15 +918,15 @@ export const LIBRARY_CORE_LOCAL_AUTHORITY_REGISTRY = [
   },
   {
     registryKey: "library-core-authority-private-key",
-    soleOwner: "unprovisioned Library Core native authority adapter",
+    soleOwner: "packages/desktop/src-tauri/src/library_core_authority_genesis.rs",
     locality: "secret",
     role: "secret",
     authoritative: false,
     physicalStores: [{
-      kind: "unprovisioned",
-      platforms: ["desktop", "pwa"],
-      locator: "none:Gate A does not provision a Library Core authority private key",
-      keys: [],
+      kind: "platform-credential",
+      platforms: ["desktop-macos", "desktop-windows"],
+      locator: "platform-credential:wtf.freed.library-core/authority-current",
+      keys: ["authority-current"],
     }],
     retention: { kind: "until-reset" },
     backup: "exclude-secret",
@@ -934,12 +934,16 @@ export const LIBRARY_CORE_LOCAL_AUTHORITY_REGISTRY = [
     redaction: "drop-entire-value",
     resetSemantics: "Factory reset removes local protected authority material. Restore may install a newly rotated authority key only through an accepted recovery transition; private bytes are never exported or imported.",
     snapshot: "excluded",
-    migration: "generate-after-gate-a",
+    migration: "retire-with-legacy-epoch",
     cutover: {
       blocksCutover: true,
-      reason: "An active Library Core epoch cannot exist until a platform secret store and authority-key lifecycle are implemented and proven.",
+      reason: "Desktop macOS and Windows now mint this key in the platform vault and sign one genesis epoch bound to one exact legacy Automerge revision, so an active Library Core epoch can exist there. Cutover stays blocked because Library Core cannot be authoritative on a platform that cannot hold this key, and neither Linux nor the PWA has a proven noninteractive vault.",
     },
-    sourceReferences: ["docs/LIBRARY-CORE-CONTRACT.md"],
+    sourceReferences: [
+      "docs/LIBRARY-CORE-CONTRACT.md",
+      "packages/desktop/src-tauri/src/library_core_authority_genesis.rs",
+      "packages/desktop/src-tauri/src/library_core_platform_key.rs",
+    ],
   },
   {
     registryKey: "library-core-bootstrap-operation-journal",
@@ -1179,6 +1183,7 @@ export const LIBRARY_CORE_LOCAL_AUTHORITY_REGISTRY = [
     },
     sourceReferences: [
       "packages/desktop/src-tauri/src/library_core_migration_claim.rs",
+      "packages/desktop/src-tauri/src/library_core_platform_key.rs",
     ],
   },
   {
@@ -2546,10 +2551,19 @@ export const LIBRARY_CORE_LOCAL_AUTHORITY_SOURCE_OWNERS = [
     registryKey: "library-core-legacy-source-admission-key",
     sourcePath: "packages/desktop/src-tauri/src/library_core_migration_claim.rs",
     sourceTokens: [
-      'const KEYRING_SERVICE: &str = "wtf.freed.library-core"',
-      'const KEYRING_ACCOUNT: &str = "migration-source-current"',
+      'account: "migration-source-current"',
+      'envelope_format: "freed_library_core_migration_key_v1"',
     ],
     registeredKeys: ["migration-source-current"],
+  },
+  {
+    registryKey: "library-core-authority-private-key",
+    sourcePath: "packages/desktop/src-tauri/src/library_core_authority_genesis.rs",
+    sourceTokens: [
+      'account: "authority-current"',
+      'envelope_format: "freed_library_core_authority_key_v1"',
+    ],
+    registeredKeys: ["authority-current"],
   },
   {
     registryKey: "library-core-derived-runtime",


### PR DESCRIPTION
(AI Generated).

## Why nothing could be written to the journal

Library Core fences every actor enrollment and every operation commit against an active authority epoch. The only writer, `install_authority_epoch`, sat inside `#[cfg(test)]`; the only production authority functions in `library_core_journal_authority.rs` were readers (`active_authority`, `require_active_authority`, `require_active_epoch`). There was no production path to establish authority at all, so there was no production path to write anything.

This adds the one epoch a fresh installation can legitimately claim: genesis, epoch 1, for a library whose only existing authority is the legacy Automerge document, under trust on first use.

## What the epoch is bound to

The certificate is bound to one exact durable revision, taken from `getLibraryCoreProjectionSource()` — which the Automerge worker refuses to produce unless the in-memory document's heads equal the durable snapshot's heads. So a revision that reaches the certificate is one the document was actually saved at.

Everything in the certificate is a pure function of the library, the authority public key and that revision. Ed25519 signatures are deterministic, so minting is a pure function too:

- **Replay converges.** A caller that crashes anywhere and retries produces byte-identical output and lands on the stored epoch. Proven by asserting a second call with a *different* acceptance time returns the identical authority and leaves exactly one row in `library_core_authority_epochs`.
- **A moved revision is refused**, not silently re-pointed: it is a different epoch, and the journal requires exactly current+1.
- **A different authority key is refused** for the same reason.
- **A different document is a different library.** The library id is derived from the legacy document identity rather than minted at random, so two installations adopting the same document agree on which library they mean.

The freshly minted certificate is verified before it is installed, so a mistake in minting fails closed rather than entering the authority chain, and the verification path runs on every establishment.

## The key vault extraction is not tidying

The authority signing key lives in the platform credential vault under its own account (`authority-current`, separate from the migration claim's `migration-source-current`). Getting there required pulling the keyring plumbing out of `library_core_migration_claim.rs` into `library_core_platform_key.rs`.

That was not for neatness. The macOS Keychain user-interaction policy the code manipulates is **process-global**, and it is serialized by a `static KEYRING_INTERACTION_LOCK`. A copy-pasted second module would have carried its own mutex, and two mutexes guarding one global serialize neither — one caller could restore interaction while another was still relying on it being off. Both keys now go through one lock.

The migration claim keeps its exact account and envelope format strings, so an already-stored key still reads back.

## Census

The Gate A entry `library-core-authority-private-key` recorded this family as `unprovisioned`, blocking cutover because "a platform secret store and authority-key lifecycle" did not exist. Both now exist on desktop macOS and Windows, so the entry names its real owner and its real locator. It **still blocks cutover**, for the accurate reason: Library Core cannot be authoritative on a platform that cannot hold this key, and neither Linux nor the PWA has a proven noninteractive vault.

The census guard caught the relocation on its own, which is what it is for.

## Evidence

Seven mutations, each applied one at a time with the application asserted and the run count printed:

| Mutation | Result |
| --- | --- |
| Library id ignores the document | caught by `a_different_document_is_a_different_library` |
| Verification skips both signatures | caught by `a_tampered_certificate_fails_verification_on_every_signed_field` |
| Verification skips the epoch-id recomputation | caught by the same test |
| A revision with no heads is accepted | caught by `a_revision_that_was_never_saved_is_refused` |
| Possession input drops the key id | **survived at first** — see below |
| Key readback comparison dropped | caught by `a_key_that_does_not_read_back_is_refused_before_it_signs_anything` |
| Idempotent replay branch removed | caught by `replaying_the_same_revision_returns_the_same_epoch_without_forking` |

The possession-signature mutation surviving was a real defect in the test, not the code. The original assertion changed `authority_key_id` in the body, which is rejected by an *earlier* check that the key id derives from the public key — so it passed for the wrong reason and proved nothing about the signature. It now signs the possession input over a *different* key id with the *correct* key, leaving the earlier check satisfied, and asserts the specific `authority key possession signature is invalid` message. The mutation is caught.

Gates: `cargo test --lib` 446 passed, `cargo fmt --check` clean, `npm run validate:feature` exit 0, `validate-main-backflow.mjs` in sync.

## Provider surface

The entire provider-visible diff is three added lines in `lib.rs`: two `mod` declarations and one command registration. No requests, navigation, timing, cookies, headers, extraction, or WebView behavior changes. Recorded as `diff_authorized` under task `library-core-genesis-authority-v1`.

Automerge remains authoritative. No operations are written, no active engine changes, no provider traffic is emitted, and no private key material is ever exported or synchronized.

## Provider Review
- Status: Provider authority is validated for ready publication.
- Review action: none required. The provider-risk artifact records the behavior authority decision; this exact provider subdiff is the audit subject.
- Provider subdiff: `324c4c26e3b79224e4ad1e1c6201d5c2a0700410`
- Publication does not authorize new live provider traffic. Gate 1 behavior approval still applies when observable behavior changes.
- Provider review task: `library-core-genesis-authority-v1`
- Provider review decision: `diff_authorized`
- Provider review artifact: `40ac76dc319d5fbb0b532ec5102a2c1a25f7746f562b53ac5bc165d6a25cece2`
- Providers: facebook, instagram, linkedin, medium, other, substack, x, youtube
- Observable behavior: Provider requests, navigation, retries, cadence, cookies, headers, extraction scripts, scrolling, clicking, media loading, and authentication behavior are unchanged. The whole provider-visible diff is three added lines in lib.rs: two module declarations and one Tauri command registration. The registered command writes a local authority epoch into the local Library Core SQLite journal and mints a signing key in the platform credential vault. It performs no network activity of any kind, touches no WebView, and reads nothing a provider can observe.
- Fingerprinting risk: None introduced. Providers receive the same requests with the same timing and content, because nothing in this change contacts a provider or alters any code path that does. Declaring a module and registering a command adds no provider-reachable behavior.
- Lowest profile alternative: Already taken: the epoch is established from an already durable local Automerge revision, offline, with no additional provider contact and no new background activity.

Files bound into this provider review:
- `packages/desktop/src-tauri/src/lib.rs`