### PR TITLE
feat: enroll this desktop installation's own Library Core actor

### DIFF
--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -37,6 +37,7 @@ mod automerge_external_token_run;
 mod automerge_external_value;
 #[cfg_attr(not(test), allow(dead_code))]
 mod automerge_external_value_run;
+mod library_core_actor_enrollment;
 mod library_core_authority_genesis;
 #[cfg_attr(not(test), allow(dead_code))]
 mod library_core_canonical;

--- a/packages/desktop/src-tauri/src/library_core_actor_enrollment.rs
+++ b/packages/desktop/src-tauri/src/library_core_actor_enrollment.rs
@@ -1,0 +1,627 @@
+//! This desktop installation's own actor, enrolled under its own authority.
+//!
+//! With a genesis epoch installed, the journal will accept an actor, but only
+//! against a canonical enrollment certificate that binds an actor key to that
+//! exact authority state. Nothing produced one, so `verify_and_enroll_actor`
+//! had no caller and no operation could be signed or committed.
+//!
+//! This mints the certificate. The actor key signs a proof of possession over
+//! the enrollment body; the authority key countersigns the certificate. Both
+//! live in the platform credential vault under separate accounts, because the
+//! authority admits actors and the actor writes operations, and one key doing
+//! both would make an actor able to admit itself.
+//!
+//! Automerge stays authoritative. Enrolling an actor writes no operation,
+//! changes no active engine, and emits no provider traffic.
+//!
+//! Like the genesis epoch, the certificate is a pure function of the library,
+//! the two keys, and the authority state, apart from `created_at_ms`. That one
+//! wall-clock field is inside the signed body, so a rebuilt certificate would
+//! not match a stored one and would be refused as a conflict rather than
+//! recognized as a replay. An already-enrolled actor is therefore returned
+//! from storage without rebuilding anything.
+
+use crate::automerge_external_common::lower_hex;
+use crate::library_core_canonical::{
+    encode_canonical_value, encode_operation_digest_input, encode_signature_input,
+};
+use crate::library_core_journal::{ActorState, LibraryCoreJournal};
+use crate::library_core_platform_key::{load_platform_key, store_platform_key, PlatformKeyVault};
+use ring::rand::SystemRandom;
+use ring::signature::{Ed25519KeyPair, KeyPair};
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+
+const SIGNATURE_ALGORITHM: &str = "ed25519";
+const OPERATION_TYPE: &str = "actor_enrolled";
+const SCHEMA_VERSION: i64 = 1;
+const MAX_CERTIFICATE_BYTES: usize = 64 * 1_024;
+
+/// The actor signing key is its own vault account. The authority key admits
+/// actors; this key writes operations. One key doing both would let an actor
+/// admit itself.
+const ACTOR_VAULT: PlatformKeyVault = PlatformKeyVault {
+    account: "actor-current",
+    envelope_format: "freed_library_core_actor_key_v1",
+    description: "actor signing",
+};
+
+/// The authority state an enrollment must bind to, exactly as the journal
+/// holds it. The verifier compares every field, including the frontier.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct EnrollmentAuthority {
+    pub(crate) library_id: String,
+    pub(crate) epoch: i64,
+    pub(crate) epoch_id: String,
+    pub(crate) authority_key_id: String,
+}
+
+fn digest_value(domain: &str, value: &Value) -> Result<String, String> {
+    let input = encode_operation_digest_input(domain, value, MAX_CERTIFICATE_BYTES)
+        .map_err(|_| format!("Library Core {domain} digest input is invalid"))?;
+    Ok(lower_hex(&Sha256::digest(input)))
+}
+
+/// Which installation of this library the actor belongs to.
+///
+/// Derived from the authority key, which every installation mints for itself,
+/// so the value is stable across restarts and differs between installations
+/// without anything having to be stored for it.
+fn installation_incarnation(authority: &EnrollmentAuthority) -> Result<String, String> {
+    digest_value(
+        "installation-incarnation",
+        &json!({
+            "library_id": authority.library_id,
+            "authority_key_id": authority.authority_key_id,
+            "signature_algorithm": SIGNATURE_ALGORITHM,
+        }),
+    )
+}
+
+/// Which incarnation of the actor this is.
+///
+/// Derived rather than random on purpose. One installation holds one actor key
+/// at a time, so a random value would add no distinguishing power, and
+/// deriving keeps the enrollment body a pure function of the stored keys. A
+/// future rotation that needs two incarnations under one key would store an
+/// explicit nonce instead.
+fn actor_incarnation_nonce(
+    installation_incarnation: &str,
+    actor_public_key: &str,
+) -> Result<String, String> {
+    digest_value(
+        "actor-incarnation-nonce",
+        &json!({
+            "installation_incarnation": installation_incarnation,
+            "actor_public_key": actor_public_key,
+            "signature_algorithm": SIGNATURE_ALGORITHM,
+        }),
+    )
+}
+
+fn actor_public_key_fingerprint(actor_public_key: &str) -> Result<String, String> {
+    digest_value(
+        "actor-public-key",
+        &json!({
+            "signature_algorithm": SIGNATURE_ALGORITHM,
+            "actor_public_key": actor_public_key,
+        }),
+    )
+}
+
+fn actor_id(
+    library_id: &str,
+    installation_incarnation: &str,
+    actor_public_key: &str,
+    actor_incarnation_nonce: &str,
+) -> Result<String, String> {
+    digest_value(
+        "actor-id",
+        &json!({
+            "library_id": library_id,
+            "installation_incarnation": installation_incarnation,
+            "signature_algorithm": SIGNATURE_ALGORITHM,
+            "actor_public_key": actor_public_key,
+            "actor_incarnation_nonce": actor_incarnation_nonce,
+        }),
+    )
+}
+
+/// Everything about the actor that does not depend on the clock.
+///
+/// Computed before deciding whether to enroll, because the actor id is what
+/// tells us whether this actor already exists.
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct ActorIdentity {
+    actor_id: String,
+    actor_public_key: String,
+    actor_public_key_fingerprint: String,
+    installation_incarnation: String,
+    actor_incarnation_nonce: String,
+}
+
+fn actor_identity(
+    authority: &EnrollmentAuthority,
+    key_pair: &Ed25519KeyPair,
+) -> Result<ActorIdentity, String> {
+    let actor_public_key = lower_hex(key_pair.public_key().as_ref());
+    let installation_incarnation = installation_incarnation(authority)?;
+    let actor_incarnation_nonce =
+        actor_incarnation_nonce(&installation_incarnation, &actor_public_key)?;
+    Ok(ActorIdentity {
+        actor_id: actor_id(
+            &authority.library_id,
+            &installation_incarnation,
+            &actor_public_key,
+            &actor_incarnation_nonce,
+        )?,
+        actor_public_key_fingerprint: actor_public_key_fingerprint(&actor_public_key)?,
+        actor_public_key,
+        installation_incarnation,
+        actor_incarnation_nonce,
+    })
+}
+
+/// Build the canonical certificate the journal's verifier expects.
+///
+/// The shape is fixed by `library_core_journal_enrollment_verifier`, which
+/// rejects any object with an unexpected or missing key, so this is written to
+/// match it exactly rather than to be convenient.
+fn build_certificate(
+    authority: &EnrollmentAuthority,
+    identity: &ActorIdentity,
+    actor_key_pair: &Ed25519KeyPair,
+    authority_key_pair: &Ed25519KeyPair,
+    created_at_ms: i64,
+) -> Result<Vec<u8>, String> {
+    if created_at_ms < 0 {
+        return Err("Library Core enrollment time is invalid".to_string());
+    }
+    let enrollment_body = json!({
+        "operation_id": format!("actor-enrolled:{}", identity.actor_id),
+        "operation_type": OPERATION_TYPE,
+        "library_id": authority.library_id,
+        "epoch": authority.epoch,
+        "epoch_id": authority.epoch_id,
+        "schema_version": SCHEMA_VERSION,
+        "authority_key_id": authority.authority_key_id,
+        "installation_incarnation": identity.installation_incarnation,
+        "actor_incarnation_nonce": identity.actor_incarnation_nonce,
+        "actor_id": identity.actor_id,
+        "actor_public_key": identity.actor_public_key,
+        "actor_public_key_fingerprint": identity.actor_public_key_fingerprint,
+        // The genesis epoch observes nothing, and the verifier requires this
+        // to equal the authority's frontier exactly.
+        "observed_frontier": [],
+        "created_at_ms": created_at_ms,
+        "signature_algorithm": SIGNATURE_ALGORITHM,
+    });
+
+    let enrollment_body_digest = digest_value("actor-enrollment-body", &enrollment_body)?;
+    let actor_proof_input = encode_signature_input(
+        "actor-enrollment-proof",
+        &json!({ "enrollment_body_digest": enrollment_body_digest }),
+        MAX_CERTIFICATE_BYTES,
+    )
+    .map_err(|_| "Library Core actor proof input is invalid".to_string())?;
+
+    let certificate_body = json!({
+        "actor_enrollment_body": enrollment_body,
+        "enrollment_body_digest": enrollment_body_digest,
+        "actor_proof": lower_hex(actor_key_pair.sign(&actor_proof_input).as_ref()),
+    });
+
+    let certificate_digest = digest_value("actor-enrollment-certificate", &certificate_body)?;
+    let authority_signature_input = encode_signature_input(
+        "actor-enrollment-authority",
+        &json!({ "certificate_digest": certificate_digest }),
+        MAX_CERTIFICATE_BYTES,
+    )
+    .map_err(|_| "Library Core enrollment authority signature input is invalid".to_string())?;
+
+    let certificate = json!({
+        "certificate_body": certificate_body,
+        "certificate_digest": certificate_digest,
+        "authority_signature": lower_hex(
+            authority_key_pair.sign(&authority_signature_input).as_ref(),
+        ),
+    });
+
+    encode_canonical_value(&certificate, MAX_CERTIFICATE_BYTES)
+        .map_err(|_| "Library Core enrollment certificate is not canonically encodable".to_string())
+}
+
+/// Where the actor signing key is kept. Production is the platform vault;
+/// tests substitute memory so they never touch the real credential store.
+pub(crate) trait ActorKeyStore {
+    fn load(&self, library_id: &str) -> Result<Option<Vec<u8>>, String>;
+    fn store(&self, library_id: &str, bytes: &[u8]) -> Result<(), String>;
+}
+
+pub(crate) struct PlatformActorKeyStore;
+
+impl ActorKeyStore for PlatformActorKeyStore {
+    fn load(&self, library_id: &str) -> Result<Option<Vec<u8>>, String> {
+        load_platform_key(&ACTOR_VAULT, library_id)
+    }
+
+    fn store(&self, library_id: &str, bytes: &[u8]) -> Result<(), String> {
+        store_platform_key(&ACTOR_VAULT, library_id, bytes)
+    }
+}
+
+fn load_or_create_actor_key_pair(
+    store: &dyn ActorKeyStore,
+    library_id: &str,
+) -> Result<Ed25519KeyPair, String> {
+    if let Some(bytes) = store.load(library_id)? {
+        return Ed25519KeyPair::from_pkcs8(&bytes)
+            .map_err(|_| "Library Core actor signing key is corrupt".to_string());
+    }
+
+    let generated = Ed25519KeyPair::generate_pkcs8(&SystemRandom::new())
+        .map_err(|_| "Library Core could not generate an actor signing key".to_string())?;
+    store.store(library_id, generated.as_ref())?;
+    // Read back before signing. A store that accepted the write but kept
+    // something else would enroll an actor whose key nobody can reproduce
+    // after the next restart, stranding its whole operation chain.
+    let readback = store
+        .load(library_id)?
+        .ok_or_else(|| "Library Core actor signing key readback is missing".to_string())?;
+    if readback.as_slice() != generated.as_ref() {
+        return Err("Library Core actor signing key readback changed".to_string());
+    }
+    Ed25519KeyPair::from_pkcs8(&readback)
+        .map_err(|_| "Library Core actor signing key readback is corrupt".to_string())
+}
+
+fn enroll_with_key_pairs(
+    journal: &mut LibraryCoreJournal,
+    authority: &EnrollmentAuthority,
+    actor_key_pair: &Ed25519KeyPair,
+    authority_key_pair: &Ed25519KeyPair,
+    created_at_ms: i64,
+) -> Result<ActorState, String> {
+    let identity = actor_identity(authority, actor_key_pair)?;
+
+    // Check before minting. `created_at_ms` is inside the signed body, so a
+    // rebuilt certificate for an already-enrolled actor would carry a
+    // different digest and be refused as a conflict.
+    if let Some(existing) = journal
+        .actor_state(
+            &authority.library_id,
+            &authority.epoch_id,
+            &identity.actor_id,
+        )
+        .map_err(|error| format!("Library Core could not read actor state: {error}"))?
+    {
+        return Ok(existing);
+    }
+
+    let certificate = build_certificate(
+        authority,
+        &identity,
+        actor_key_pair,
+        authority_key_pair,
+        created_at_ms,
+    )?;
+    journal
+        .verify_and_enroll_actor(&certificate, &authority.library_id)
+        .map_err(|error| format!("Library Core could not enroll its actor: {error}"))
+}
+
+/// Enroll this installation's actor under its active authority epoch.
+pub(crate) fn enroll_desktop_actor(
+    journal: &mut LibraryCoreJournal,
+    authority: &EnrollmentAuthority,
+    actor_store: &dyn ActorKeyStore,
+    authority_key_pair: &Ed25519KeyPair,
+    created_at_ms: i64,
+) -> Result<ActorState, String> {
+    let actor_key_pair = load_or_create_actor_key_pair(actor_store, &authority.library_id)?;
+    enroll_with_key_pairs(
+        journal,
+        authority,
+        &actor_key_pair,
+        authority_key_pair,
+        created_at_ms,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::library_core_authority_genesis::{
+        establish_with_key_pair_for_test, LegacySourceRevision,
+    };
+    use tempfile::tempdir;
+
+    #[derive(Default)]
+    struct MemoryActorKeyStore {
+        stored: std::cell::RefCell<Option<Vec<u8>>>,
+        substitute_on_readback: Option<Vec<u8>>,
+    }
+
+    impl ActorKeyStore for MemoryActorKeyStore {
+        fn load(&self, _library_id: &str) -> Result<Option<Vec<u8>>, String> {
+            if let Some(substitute) = self.substitute_on_readback.as_ref() {
+                if self.stored.borrow().is_some() {
+                    return Ok(Some(substitute.clone()));
+                }
+            }
+            Ok(self.stored.borrow().clone())
+        }
+
+        fn store(&self, _library_id: &str, bytes: &[u8]) -> Result<(), String> {
+            *self.stored.borrow_mut() = Some(bytes.to_vec());
+            Ok(())
+        }
+    }
+
+    fn authority_key_pair() -> Ed25519KeyPair {
+        Ed25519KeyPair::from_seed_unchecked(&[7_u8; 32]).unwrap()
+    }
+
+    fn actor_key_pair() -> Ed25519KeyPair {
+        Ed25519KeyPair::from_seed_unchecked(&[11_u8; 32]).unwrap()
+    }
+
+    fn other_actor_key_pair() -> Ed25519KeyPair {
+        Ed25519KeyPair::from_seed_unchecked(&[13_u8; 32]).unwrap()
+    }
+
+    fn revision() -> LegacySourceRevision {
+        LegacySourceRevision {
+            document_id: "freed-library-document-1".to_string(),
+            heads_digest: "a".repeat(64),
+            head_count: 2,
+            storage_generation: 7,
+            storage_save_revision: 11,
+        }
+    }
+
+    /// A journal with a real genesis epoch installed, and the authority state
+    /// as the enrollment verifier will see it.
+    fn journal_with_authority() -> (tempfile::TempDir, LibraryCoreJournal, EnrollmentAuthority) {
+        let directory = tempdir().unwrap();
+        let mut journal =
+            LibraryCoreJournal::open(&directory.path().join("library-core.sqlite")).unwrap();
+        let accepted = establish_with_key_pair_for_test(
+            &mut journal,
+            &revision(),
+            &authority_key_pair(),
+            1_700,
+        )
+        .unwrap();
+        let authority = EnrollmentAuthority {
+            library_id: accepted.library_id,
+            epoch: accepted.epoch,
+            epoch_id: accepted.epoch_id,
+            authority_key_id: accepted.authority_key_id,
+        };
+        (directory, journal, authority)
+    }
+
+    #[test]
+    fn enrolls_one_actor_under_the_installed_genesis_epoch() {
+        let (_directory, mut journal, authority) = journal_with_authority();
+
+        let actor = enroll_with_key_pairs(
+            &mut journal,
+            &authority,
+            &actor_key_pair(),
+            &authority_key_pair(),
+            2_000,
+        )
+        .unwrap();
+
+        assert_eq!(actor.library_id, authority.library_id);
+        assert_eq!(actor.epoch, 1);
+        assert_eq!(actor.epoch_id, authority.epoch_id);
+        assert_eq!(actor.next_sequence, 1, "a fresh actor has written nothing");
+        assert_eq!(actor.previous_operation_id, None);
+        assert_eq!(
+            actor.actor_public_key,
+            lower_hex(actor_key_pair().public_key().as_ref())
+        );
+    }
+
+    /// The wall clock moves between runs. Enrollment must still converge, or
+    /// every restart would collide with its own previous certificate.
+    #[test]
+    fn re_enrolling_at_a_later_time_returns_the_stored_actor() {
+        let (_directory, mut journal, authority) = journal_with_authority();
+
+        let first = enroll_with_key_pairs(
+            &mut journal,
+            &authority,
+            &actor_key_pair(),
+            &authority_key_pair(),
+            2_000,
+        )
+        .unwrap();
+        let second = enroll_with_key_pairs(
+            &mut journal,
+            &authority,
+            &actor_key_pair(),
+            &authority_key_pair(),
+            9_999,
+        )
+        .unwrap();
+
+        assert_eq!(first, second);
+        let actors: i64 = journal
+            .connection_for_test()
+            .query_row("SELECT COUNT(*) FROM library_core_actors;", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(actors, 1, "replay must not enroll a second actor");
+    }
+
+    #[test]
+    fn a_different_actor_key_is_a_different_actor() {
+        let (_directory, mut journal, authority) = journal_with_authority();
+
+        let first = enroll_with_key_pairs(
+            &mut journal,
+            &authority,
+            &actor_key_pair(),
+            &authority_key_pair(),
+            2_000,
+        )
+        .unwrap();
+        let second = enroll_with_key_pairs(
+            &mut journal,
+            &authority,
+            &other_actor_key_pair(),
+            &authority_key_pair(),
+            2_000,
+        )
+        .unwrap();
+
+        assert_ne!(first.actor_id, second.actor_id);
+    }
+
+    /// The authority admits actors. An actor that countersigned its own
+    /// enrollment would be admitting itself.
+    #[test]
+    fn an_enrollment_the_authority_did_not_countersign_is_refused() {
+        let (_directory, mut journal, authority) = journal_with_authority();
+
+        let error = enroll_with_key_pairs(
+            &mut journal,
+            &authority,
+            &actor_key_pair(),
+            // The actor key standing in for the authority key.
+            &actor_key_pair(),
+            2_000,
+        )
+        .unwrap_err();
+
+        assert!(error.contains("could not enroll its actor"), "{error}");
+        let actors: i64 = journal
+            .connection_for_test()
+            .query_row("SELECT COUNT(*) FROM library_core_actors;", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(actors, 0, "a refused enrollment must write nothing");
+    }
+
+    #[test]
+    fn an_enrollment_bound_to_the_wrong_authority_state_is_refused() {
+        let (_directory, mut journal, authority) = journal_with_authority();
+
+        for wrong in [
+            EnrollmentAuthority {
+                epoch: 2,
+                ..authority.clone()
+            },
+            EnrollmentAuthority {
+                epoch_id: "f".repeat(64),
+                ..authority.clone()
+            },
+            EnrollmentAuthority {
+                authority_key_id: "e".repeat(64),
+                ..authority.clone()
+            },
+        ] {
+            let error = enroll_with_key_pairs(
+                &mut journal,
+                &wrong,
+                &actor_key_pair(),
+                &authority_key_pair(),
+                2_000,
+            )
+            .unwrap_err();
+            assert!(error.contains("could not enroll its actor"), "{error}");
+        }
+    }
+
+    #[test]
+    fn an_actor_key_is_minted_once_and_reused_afterwards() {
+        let store = MemoryActorKeyStore::default();
+
+        let first = load_or_create_actor_key_pair(&store, "library-a").unwrap();
+        let minted = store.stored.borrow().clone();
+        let second = load_or_create_actor_key_pair(&store, "library-a").unwrap();
+
+        assert_eq!(
+            lower_hex(first.public_key().as_ref()),
+            lower_hex(second.public_key().as_ref())
+        );
+        assert_eq!(*store.stored.borrow(), minted);
+    }
+
+    #[test]
+    fn an_actor_key_that_does_not_read_back_is_refused_before_it_signs_anything() {
+        let store = MemoryActorKeyStore {
+            substitute_on_readback: Some(vec![3_u8; 32]),
+            ..MemoryActorKeyStore::default()
+        };
+
+        let error = load_or_create_actor_key_pair(&store, "library-a").unwrap_err();
+
+        assert!(error.contains("readback changed"), "{error}");
+    }
+
+    #[test]
+    fn the_whole_path_enrolls_through_the_key_store() {
+        let (_directory, mut journal, authority) = journal_with_authority();
+        let store = MemoryActorKeyStore::default();
+
+        let actor = enroll_desktop_actor(
+            &mut journal,
+            &authority,
+            &store,
+            &authority_key_pair(),
+            2_000,
+        )
+        .unwrap();
+
+        assert!(store.stored.borrow().is_some(), "the key must be persisted");
+        // A second call reloads the same key, so it lands on the same actor.
+        let again = enroll_desktop_actor(
+            &mut journal,
+            &authority,
+            &store,
+            &authority_key_pair(),
+            5_000,
+        )
+        .unwrap();
+        assert_eq!(actor, again);
+    }
+
+    #[test]
+    fn the_derived_identity_is_stable_and_separates_installations() {
+        let (_directory, _journal, authority) = journal_with_authority();
+        let identity = actor_identity(&authority, &actor_key_pair()).unwrap();
+
+        assert_eq!(
+            identity,
+            actor_identity(&authority, &actor_key_pair()).unwrap()
+        );
+        assert_eq!(
+            identity.actor_public_key_fingerprint,
+            actor_public_key_fingerprint(&identity.actor_public_key).unwrap()
+        );
+
+        // A different authority key means a different installation, so the
+        // same actor key must not resolve to the same actor.
+        let other_installation = EnrollmentAuthority {
+            authority_key_id: "e".repeat(64),
+            ..authority.clone()
+        };
+        let other = actor_identity(&other_installation, &actor_key_pair()).unwrap();
+        assert_ne!(
+            identity.installation_incarnation,
+            other.installation_incarnation
+        );
+        assert_ne!(
+            identity.actor_incarnation_nonce,
+            other.actor_incarnation_nonce
+        );
+        assert_ne!(identity.actor_id, other.actor_id);
+    }
+}

--- a/packages/desktop/src-tauri/src/library_core_authority_genesis.rs
+++ b/packages/desktop/src-tauri/src/library_core_authority_genesis.rs
@@ -312,6 +312,35 @@ fn load_or_create_authority_key_pair(
         .map_err(|_| "Library Core authority signing key readback is corrupt".to_string())
 }
 
+/// Establish a genesis epoch with a caller-supplied key.
+///
+/// Test-only entry point for sibling modules that need a real installed epoch
+/// without touching the platform credential vault.
+#[cfg(test)]
+pub(crate) fn establish_with_key_pair_for_test(
+    journal: &mut LibraryCoreJournal,
+    revision: &LegacySourceRevision,
+    key_pair: &Ed25519KeyPair,
+    accepted_at_ms: i64,
+) -> Result<AcceptedAuthorityState, String> {
+    establish_with_key_pair(journal, revision, key_pair, accepted_at_ms)
+}
+
+/// Load the authority key this installation already minted.
+///
+/// Deliberately never mints one. An authority key that did not sign the active
+/// epoch cannot countersign anything the journal will accept, so a caller that
+/// needs the key for enrollment must fail rather than quietly create a second
+/// identity.
+pub(crate) fn load_established_authority_key_pair(
+    library_id: &str,
+) -> Result<Ed25519KeyPair, String> {
+    let bytes = load_platform_key(&AUTHORITY_VAULT, library_id)?
+        .ok_or_else(|| "Library Core has no established authority signing key".to_string())?;
+    Ed25519KeyPair::from_pkcs8(&bytes)
+        .map_err(|_| "Library Core authority signing key is corrupt".to_string())
+}
+
 fn establish_with_key_pair(
     journal: &mut LibraryCoreJournal,
     revision: &LegacySourceRevision,

--- a/packages/desktop/src-tauri/src/library_core_journal.rs
+++ b/packages/desktop/src-tauri/src/library_core_journal.rs
@@ -204,19 +204,19 @@ impl std::error::Error for JournalError {}
 type JournalResult<T> = std::result::Result<T, JournalError>;
 
 #[derive(Debug, Clone, PartialEq)]
-struct ActorState {
-    library_id: String,
-    epoch: i64,
-    epoch_id: String,
-    actor_id: String,
-    actor_public_key: String,
-    enrollment_operation_id: String,
-    enrollment_certificate_digest: String,
-    canonical_enrollment_certificate_json: String,
-    actor_chain_genesis: String,
-    next_sequence: i64,
-    previous_operation_id: Option<String>,
-    previous_chain_digest: String,
+pub(crate) struct ActorState {
+    pub(crate) library_id: String,
+    pub(crate) epoch: i64,
+    pub(crate) epoch_id: String,
+    pub(crate) actor_id: String,
+    pub(crate) actor_public_key: String,
+    pub(crate) enrollment_operation_id: String,
+    pub(crate) enrollment_certificate_digest: String,
+    pub(crate) canonical_enrollment_certificate_json: String,
+    pub(crate) actor_chain_genesis: String,
+    pub(crate) next_sequence: i64,
+    pub(crate) previous_operation_id: Option<String>,
+    pub(crate) previous_chain_digest: String,
 }
 
 #[derive(Debug, Clone)]
@@ -933,7 +933,14 @@ impl LibraryCoreJournal {
             .optional()
     }
 
-    fn actor_state(
+    /// The stored actor, if this library, epoch and actor are already
+    /// enrolled.
+    ///
+    /// A caller that mints enrollment certificates must check this first. The
+    /// signed enrollment body carries `created_at_ms`, so rebuilding one for
+    /// an actor that is already enrolled would produce a different certificate
+    /// digest and be refused as a conflict rather than seen as a replay.
+    pub(crate) fn actor_state(
         &self,
         library_id: &str,
         epoch_id: &str,
@@ -1118,7 +1125,12 @@ impl LibraryCoreJournal {
         enrollment_verifier::verify_actor_enrollment(canonical_certificate, authority)
     }
 
-    fn verify_and_enroll_actor(
+    /// Verify a canonical enrollment certificate against the active authority
+    /// and enroll the actor it names.
+    ///
+    /// Replaying the exact same certificate returns the stored actor; a
+    /// different certificate for the same actor is a conflict, not an update.
+    pub(crate) fn verify_and_enroll_actor(
         &mut self,
         canonical_certificate: &[u8],
         library_id: &str,

--- a/packages/desktop/src-tauri/src/library_core_journal_runtime.rs
+++ b/packages/desktop/src-tauri/src/library_core_journal_runtime.rs
@@ -17,7 +17,12 @@ use std::sync::Mutex;
 
 use tauri::Manager;
 
-use super::library_core_authority_genesis::{establish_genesis_epoch, LegacySourceRevision};
+use super::library_core_actor_enrollment::{
+    enroll_desktop_actor, EnrollmentAuthority, PlatformActorKeyStore,
+};
+use super::library_core_authority_genesis::{
+    establish_genesis_epoch, load_established_authority_key_pair, LegacySourceRevision,
+};
 use super::library_core_journal::{JournalRuntimeStatus, LibraryCoreJournal};
 
 /// Directory holding the authoritative database, under the app data root.
@@ -162,7 +167,7 @@ pub(super) struct GenesisSourceRequest {
 }
 
 /// What was established, for the caller to log. No key material, and no
-/// certificate: the certificate stays in the journal.
+/// certificates: those stay in the journal.
 #[derive(Debug, Eq, PartialEq, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(super) struct GenesisAuthorityStatus {
@@ -170,13 +175,23 @@ pub(super) struct GenesisAuthorityStatus {
     pub(super) epoch: i64,
     pub(super) epoch_id: String,
     pub(super) authority_key_id: String,
+    pub(super) actor_id: String,
+    /// The sequence this actor's next operation would take. 1 means it has
+    /// written nothing, which is the only value this path can produce.
+    pub(super) next_sequence: i64,
 }
 
-/// Establishes the genesis authority epoch against the held journal.
+/// Establishes this installation's Library Core identity against the held
+/// journal: the genesis authority epoch, then its own enrolled actor.
+///
+/// One step, because an epoch with no actor can write nothing and an actor
+/// cannot exist without an epoch. Both halves are idempotent, so a call that
+/// fails after the epoch lands completes the actor on the next attempt.
 ///
 /// Requires the journal to be open already, so a caller cannot establish
 /// authority against a database that was never validated on open. Replaying
-/// the same revision returns the same epoch rather than writing again.
+/// the same revision returns the same epoch and the same actor rather than
+/// writing again.
 pub(super) fn establish_genesis_at(
     state: &LibraryCoreJournalRuntimeState,
     request: &GenesisSourceRequest,
@@ -203,11 +218,33 @@ pub(super) fn establish_genesis_at(
     )
     .map_err(JournalRuntimeError::Journal)?;
 
+    let enrollment_authority = EnrollmentAuthority {
+        library_id: authority.library_id.clone(),
+        epoch: authority.epoch,
+        epoch_id: authority.epoch_id.clone(),
+        authority_key_id: authority.authority_key_id.clone(),
+    };
+    // Loaded, never minted: the epoch above was signed by this exact key, and
+    // a second authority identity could not countersign an enrollment the
+    // journal would accept.
+    let authority_key_pair = load_established_authority_key_pair(&authority.library_id)
+        .map_err(JournalRuntimeError::Journal)?;
+    let actor = enroll_desktop_actor(
+        journal,
+        &enrollment_authority,
+        &PlatformActorKeyStore,
+        &authority_key_pair,
+        accepted_at_ms,
+    )
+    .map_err(JournalRuntimeError::Journal)?;
+
     Ok(GenesisAuthorityStatus {
         library_id: authority.library_id,
         epoch: authority.epoch,
         epoch_id: authority.epoch_id,
         authority_key_id: authority.authority_key_id,
+        actor_id: actor.actor_id,
+        next_sequence: actor.next_sequence,
     })
 }
 

--- a/packages/desktop/src/lib/library-core-journal-runtime.test.ts
+++ b/packages/desktop/src/lib/library-core-journal-runtime.test.ts
@@ -33,6 +33,8 @@ const AUTHORITY = {
   epoch: 1,
   epochId: "c".repeat(64),
   authorityKeyId: "d".repeat(64),
+  actorId: "e".repeat(64),
+  nextSequence: 1,
 } as const;
 
 describe("Library Core journal runtime client", () => {

--- a/packages/desktop/src/lib/library-core-journal-runtime.ts
+++ b/packages/desktop/src/lib/library-core-journal-runtime.ts
@@ -45,17 +45,28 @@ export function libraryCoreJournalStatus(): Promise<LibraryCoreJournalStatusV1 |
   );
 }
 
-/** What this installation established as its own authority origin. */
+/** What this installation established as its own Library Core identity. */
 export interface LibraryCoreGenesisAuthorityV1 {
   readonly libraryId: string;
   readonly epoch: number;
   readonly epochId: string;
   readonly authorityKeyId: string;
+  readonly actorId: string;
+  /**
+   * The sequence this actor's next operation would take. 1 means it has
+   * written nothing, which is the only value this path can produce.
+   */
+  readonly nextSequence: number;
 }
 
 /**
- * Establishes the genesis authority epoch for one exact durable Automerge
- * revision, minting this installation's authority key if it has none.
+ * Establishes this installation's Library Core identity: the genesis authority
+ * epoch for one exact durable Automerge revision, then its own enrolled actor.
+ * Mints the authority and actor signing keys if it has none.
+ *
+ * One call, because an epoch with no actor can write nothing and an actor
+ * cannot exist without an epoch. Both halves are idempotent, so a call that
+ * fails after the epoch lands completes the actor on the next attempt.
  *
  * Requires the journal to be open. Everything the epoch is derived from is a
  * pure function of the library, the key and the revision, so replaying the same
@@ -88,12 +99,13 @@ export function establishLibraryCoreGenesisAuthority(
  * is surfaced to the console as evidence rather than raised, because the only
  * consumer of that evidence today is us.
  *
- * Once the journal is open, the installation establishes its own genesis
- * authority epoch against the document's current durable revision. Until that
- * exists there is no active epoch, and Library Core fences every actor
- * enrollment and every operation commit against one, so nothing can be written
- * at all. This is dormant either way: no operations are written here, Automerge
- * stays authoritative, and no provider traffic is emitted.
+ * Once the journal is open, the installation establishes its own identity
+ * against the document's current durable revision: a genesis authority epoch
+ * and an actor enrolled under it. Until both exist nothing can be written at
+ * all, because Library Core fences every operation commit against an active
+ * epoch and an enrolled actor. This is dormant either way: no operations are
+ * written here, Automerge stays authoritative, and no provider traffic is
+ * emitted.
  *
  * The document may not be readable yet at startup, which is why establishment
  * is attempted and not required. The next start tries again against whatever
@@ -115,11 +127,11 @@ export async function openLibraryCoreJournalForStartup(): Promise<LibraryCoreJou
     const source = await getLibraryCoreProjectionSource();
     const authority = await establishLibraryCoreGenesisAuthority(source);
     console.info(
-      `[library-core] authority epoch ${authority.epoch} for library ${authority.libraryId}`,
+      `[library-core] authority epoch ${authority.epoch} for library ${authority.libraryId}, actor ${authority.actorId} at sequence ${authority.nextSequence}`,
     );
   } catch (error) {
     console.warn(
-      "[library-core] genesis authority not established; retrying next start",
+      "[library-core] identity not established; retrying next start",
       error,
     );
   }

--- a/packages/shared/src/library-core/canonical-codec.ts
+++ b/packages/shared/src/library-core/canonical-codec.ts
@@ -53,6 +53,8 @@ export const LIBRARY_CORE_DIGEST_DOMAINS = [
   "legacy-epoch-bootstrap-prepared",
   "legacy-epoch-bootstrap-receipt",
   "legacy-library-identity",
+  "installation-incarnation",
+  "actor-incarnation-nonce",
 ] as const;
 
 export type LibraryCoreDigestDomain =

--- a/packages/shared/src/library-core/canonical-domains-v1.json
+++ b/packages/shared/src/library-core/canonical-domains-v1.json
@@ -24,7 +24,9 @@
     "legacy-library-control",
     "legacy-epoch-bootstrap-prepared",
     "legacy-epoch-bootstrap-receipt",
-    "legacy-library-identity"
+    "legacy-library-identity",
+    "installation-incarnation",
+    "actor-incarnation-nonce"
   ],
   "signature": [
     "operation-envelope",

--- a/packages/shared/src/library-core/local-authority-registry.ts
+++ b/packages/shared/src/library-core/local-authority-registry.ts
@@ -893,15 +893,15 @@ export const LIBRARY_CORE_LOCAL_AUTHORITY_REGISTRY = [
   },
   {
     registryKey: "library-core-actor-private-key",
-    soleOwner: "unprovisioned Library Core installation actor adapter",
+    soleOwner: "packages/desktop/src-tauri/src/library_core_actor_enrollment.rs",
     locality: "secret",
     role: "secret",
     authoritative: false,
     physicalStores: [{
-      kind: "unprovisioned",
-      platforms: ["desktop", "pwa"],
-      locator: "none:Gate A does not provision a Library Core actor private key",
-      keys: [],
+      kind: "platform-credential",
+      platforms: ["desktop-macos", "desktop-windows"],
+      locator: "platform-credential:wtf.freed.library-core/actor-current",
+      keys: ["actor-current"],
     }],
     retention: { kind: "until-reset" },
     backup: "exclude-secret",
@@ -909,12 +909,16 @@ export const LIBRARY_CORE_LOCAL_AUTHORITY_REGISTRY = [
     redaction: "drop-entire-value",
     resetSemantics: "A reset or restore creates a new installation actor key and incarnation; active private material is never imported.",
     snapshot: "excluded",
-    migration: "generate-after-gate-a",
+    migration: "retire-with-legacy-epoch",
     cutover: {
       blocksCutover: true,
-      reason: "A writable installation cannot cut over until its platform-protected actor key is generated, enrolled, and proven.",
+      reason: "Desktop macOS and Windows now generate this key in the platform vault and enroll it under the genesis epoch, so a writable installation exists there. Cutover stays blocked because the enrolled actor has still written no operation, and neither Linux nor the PWA has a proven noninteractive vault to hold this key at all.",
     },
-    sourceReferences: ["docs/LIBRARY-CORE-CONTRACT.md"],
+    sourceReferences: [
+      "docs/LIBRARY-CORE-CONTRACT.md",
+      "packages/desktop/src-tauri/src/library_core_actor_enrollment.rs",
+      "packages/desktop/src-tauri/src/library_core_platform_key.rs",
+    ],
   },
   {
     registryKey: "library-core-authority-private-key",
@@ -2555,6 +2559,15 @@ export const LIBRARY_CORE_LOCAL_AUTHORITY_SOURCE_OWNERS = [
       'envelope_format: "freed_library_core_migration_key_v1"',
     ],
     registeredKeys: ["migration-source-current"],
+  },
+  {
+    registryKey: "library-core-actor-private-key",
+    sourcePath: "packages/desktop/src-tauri/src/library_core_actor_enrollment.rs",
+    sourceTokens: [
+      'account: "actor-current"',
+      'envelope_format: "freed_library_core_actor_key_v1"',
+    ],
+    registeredKeys: ["actor-current"],
   },
   {
     registryKey: "library-core-authority-private-key",


### PR DESCRIPTION
(AI Generated).

## What was still missing

[#1354](https://github.com/freed-project/freed/pull/1354) gave a fresh installation an active authority epoch. The journal would then accept an actor — but only against a canonical enrollment certificate binding an actor key to that exact authority state, and nothing produced one. `verify_and_enroll_actor` had no caller, so no operation could be signed or committed by anyone.

This mints the certificate, and the first actor is now enrolled through the production path.

## Two keys, on purpose

The actor key signs a proof of possession over the enrollment body; the authority key countersigns the certificate. They are separate vault accounts (`actor-current`, `authority-current`) because the authority *admits* actors and the actor *writes* operations. One key doing both would let an actor admit itself.

`an_enrollment_the_authority_did_not_countersign_is_refused` passes the actor key where the authority key belongs and asserts the journal refuses it and writes nothing.

## Derived identity, and the one field that cannot be

The actor identity is derived rather than stored beyond the key itself:

- `installation_incarnation` from the authority key, which every installation mints for itself
- `actor_incarnation_nonce` from that plus the actor public key
- `actor_id` from the library, incarnation, key and nonce — the shape `library_core_journal_enrollment_verifier` recomputes and checks

One installation holds one actor key at a time, so a random nonce would add no distinguishing power, and deriving keeps the identity a pure function of the stored keys.

`created_at_ms` is the exception. It sits inside the signed body, so a rebuilt certificate for an already-enrolled actor carries a different digest and is refused as `ActorEnrollmentConflict` — not recognized as a replay. Enrollment therefore reads the stored actor first and returns it without rebuilding. **Without that the app would collide with its own previous certificate on the second launch.** `re_enrolling_at_a_later_time_returns_the_stored_actor` enrolls at 2,000 ms then 9,999 ms and asserts one identical actor and exactly one row.

## One runtime step

Establishing the epoch and enrolling the actor are now a single call. An epoch with no actor can write nothing, an actor cannot exist without an epoch, and both halves are idempotent — so a call that fails after the epoch lands completes the actor on the next attempt. The authority key is *loaded, never minted*, on that path: an authority key that did not sign the active epoch could not countersign anything the journal would accept.

## Evidence

Five mutations, applied one at a time with application asserted and the run count printed:

| Mutation | Result |
| --- | --- |
| Never short-circuit on an already-enrolled actor | caught by `re_enrolling_at_a_later_time_returns_the_stored_actor`, `the_whole_path_enrolls_through_the_key_store` |
| Installation incarnation ignores the authority key | caught by `the_derived_identity_is_stable_and_separates_installations` |
| Authority signature made by the actor key | caught by 4 tests |
| Actor id ignores the actor public key | caught by 4 tests |
| Actor key readback comparison dropped | caught by `an_actor_key_that_does_not_read_back_is_refused_before_it_signs_anything` |

A sixth attempt did not compile and a seventh had a stale needle after `cargo fmt`; both were reported by the harness as not-applied rather than counted as survivals, and were redone.

Gates: `cargo test --lib` 455 passed, `cargo fmt --check` clean, `npm run validate:feature` exit 0, `validate-main-backflow.mjs` in sync.

## Census

`library-core-actor-private-key` was recorded as `unprovisioned`. It now names its real owner and locator, and **still blocks cutover** for the accurate reasons: the enrolled actor has written no operation yet, and neither Linux nor the PWA has a vault that can hold this key at all.

## Provider surface

The entire provider-visible diff is one added line in `lib.rs` declaring a module. Recorded as `diff_authorized` under task `library-core-actor-enrollment-v1`.

Automerge remains authoritative. No operation is written, no active engine changes, no provider traffic is emitted, and no private key material is exported or synchronized.

## Provider Review
- Status: Provider authority is validated for ready publication.
- Review action: none required. The provider-risk artifact records the behavior authority decision; this exact provider subdiff is the audit subject.
- Provider subdiff: `ab3072823c442b2b869bea7f09e8d44c1dbd7ac5`
- Publication does not authorize new live provider traffic. Gate 1 behavior approval still applies when observable behavior changes.
- Provider review task: `library-core-actor-enrollment-v1`
- Provider review decision: `diff_authorized`
- Provider review artifact: `9a76bb12f27dee4b9b7bdf9115c1b5b8fc9bffef1a20b01dce9fea4ccfae9335`
- Providers: facebook, instagram, linkedin, medium, other, substack, x, youtube
- Observable behavior: Provider requests, navigation, retries, cadence, cookies, headers, extraction scripts, scrolling, clicking, media loading, and authentication behavior are unchanged. The entire provider-visible diff is one added line in lib.rs declaring a module. The module enrolls this installation's own actor in the local Library Core SQLite journal, signing with keys held in the platform credential vault. It performs no network activity, touches no WebView, and reads nothing a provider can observe.
- Fingerprinting risk: None introduced. Providers receive the same requests with the same timing and content, because nothing in this change contacts a provider or alters any code path that does. Declaring a module adds no provider-reachable behavior.
- Lowest profile alternative: Already taken: enrollment is local, offline, derived from state the installation already holds, with no additional provider contact and no new background activity.

Files bound into this provider review:
- `packages/desktop/src-tauri/src/lib.rs`