### PR TITLE
fix: stop choosing a Library Core creator at desktop startup

### DIFF
--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -14808,7 +14808,6 @@ pub fn run() {
             prepare_social_scrape_memory,
             library_core_journal_runtime::open_library_core_journal,
             library_core_journal_runtime::library_core_journal_status,
-            library_core_journal_runtime::establish_library_core_genesis_authority,
             library_core_feed_browse_runtime::begin_library_core_feed_browse_generation,
             library_core_feed_browse_runtime::append_library_core_feed_browse_generation_page,
             library_core_feed_browse_runtime::finalize_library_core_feed_browse_generation,

--- a/packages/desktop/src-tauri/src/library_core_actor_enrollment.rs
+++ b/packages/desktop/src-tauri/src/library_core_actor_enrollment.rs
@@ -21,7 +21,7 @@
 //! recognized as a replay. An already-enrolled actor is therefore returned
 //! from storage without rebuilding anything.
 
-use crate::automerge_external_common::lower_hex;
+use crate::automerge_external_common::{is_lower_sha256, lower_hex};
 use crate::library_core_canonical::{
     encode_canonical_value, encode_operation_digest_input, encode_signature_input,
 };
@@ -54,6 +54,16 @@ pub(crate) struct EnrollmentAuthority {
     pub(crate) epoch: i64,
     pub(crate) epoch_id: String,
     pub(crate) authority_key_id: String,
+    /// The Desktop installation witness: a digest of the machine identifier
+    /// and the user, produced by `get_desktop_installation_witness`.
+    ///
+    /// Installation identity is bound to this rather than to the local epoch
+    /// key. Two Desktops holding the same Automerge Library mint different
+    /// local keys, so deriving identity from the key would make one machine
+    /// look like several installations and would survive nothing, while the
+    /// witness is stable for the machine and does not depend on anything the
+    /// app minted for itself.
+    pub(crate) installation_witness: String,
 }
 
 fn digest_value(domain: &str, value: &Value) -> Result<String, String> {
@@ -64,15 +74,19 @@ fn digest_value(domain: &str, value: &Value) -> Result<String, String> {
 
 /// Which installation of this library the actor belongs to.
 ///
-/// Derived from the authority key, which every installation mints for itself,
-/// so the value is stable across restarts and differs between installations
-/// without anything having to be stored for it.
+/// Bound to the Desktop installation witness, not to any key this process
+/// minted. A witness is derived from the machine and the user, so it survives
+/// a discarded local epoch and it distinguishes two real Desktops holding the
+/// same Library, which is what installation identity has to mean.
 fn installation_incarnation(authority: &EnrollmentAuthority) -> Result<String, String> {
+    if !is_lower_sha256(&authority.installation_witness) {
+        return Err("Library Core installation witness is invalid".to_string());
+    }
     digest_value(
         "installation-incarnation",
         &json!({
             "library_id": authority.library_id,
-            "authority_key_id": authority.authority_key_id,
+            "installation_witness": authority.installation_witness,
             "signature_algorithm": SIGNATURE_ALGORITHM,
         }),
     )
@@ -398,6 +412,7 @@ mod tests {
             epoch: accepted.epoch,
             epoch_id: accepted.epoch_id,
             authority_key_id: accepted.authority_key_id,
+            installation_witness: "c".repeat(64),
         };
         (directory, journal, authority)
     }
@@ -607,12 +622,26 @@ mod tests {
             actor_public_key_fingerprint(&identity.actor_public_key).unwrap()
         );
 
-        // A different authority key means a different installation, so the
-        // same actor key must not resolve to the same actor.
+        // A different machine means a different installation, so the same
+        // actor key must not resolve to the same actor.
         let other_installation = EnrollmentAuthority {
+            installation_witness: "d".repeat(64),
+            ..authority.clone()
+        };
+
+        // A different local epoch key on the SAME machine must NOT change
+        // installation identity. That was the defect: the local key is
+        // disposable, so identity derived from it could not survive one.
+        let same_machine_new_key = EnrollmentAuthority {
             authority_key_id: "e".repeat(64),
             ..authority.clone()
         };
+        assert_eq!(
+            identity.installation_incarnation,
+            actor_identity(&same_machine_new_key, &actor_key_pair())
+                .unwrap()
+                .installation_incarnation
+        );
         let other = actor_identity(&other_installation, &actor_key_pair()).unwrap();
         assert_ne!(
             identity.installation_incarnation,

--- a/packages/desktop/src-tauri/src/library_core_authority_genesis.rs
+++ b/packages/desktop/src-tauri/src/library_core_authority_genesis.rs
@@ -1,21 +1,29 @@
-//! The one authority epoch a fresh installation can mint for itself.
+//! A disposable local epoch so the shadow journal will accept shadow writes.
 //!
-//! Library Core operations are fenced against an active authority epoch, and
-//! until now nothing outside tests could install one, so nothing outside tests
-//! could enroll an actor or commit an operation. This mints the genesis epoch
-//! for a library whose only existing authority is the legacy Automerge
-//! document, under trust on first use.
+//! NOT canonical authority, and it can never become canonical authority. The
+//! contract is explicit: the legacy bootstrap record deliberately carries no
+//! authority key, signature, or proof of owner consent, because a key created
+//! and signed by the same app process proves only that the app possesses the
+//! key it just created. It authenticates neither the owner nor another
+//! installation. The real Library Core authority key stays unprovisioned until
+//! a user-present or authenticated authority-holder protocol exists.
 //!
-//! Automerge stays authoritative. The epoch installed here grants no cloud
-//! authority, retires nothing, changes no active engine, and emits no provider
-//! traffic. It is local evidence that this installation considers itself the
-//! origin of a Library Core authority chain for one exact legacy revision.
+//! What this is for: `library_core_authority_epochs` requires an epoch row
+//! before the journal will accept an actor or an operation, and the shadow
+//! slice needs to write shadow operations. This fills that slot with a local,
+//! never-replicated value that is thrown away at the real bootstrap.
 //!
-//! Everything the certificate contains is a pure function of the library, the
-//! authority public key, and that revision, and Ed25519 signatures are
-//! deterministic, so minting is a pure function too. A caller that crashes
-//! anywhere in `establish_genesis_epoch` and retries produces byte-identical
-//! output and converges on the stored epoch instead of forking a second one.
+//! Three rules follow, and each is load-bearing:
+//!
+//! 1. Nothing may call this from startup. Startup absence never chooses a
+//!    creator. An earlier revision did exactly that and had to be reverted.
+//! 2. Nothing may treat the key or the epoch id as cloud authority, as a
+//!    writer epoch, or as input to a future authenticated transition.
+//! 3. Installation identity never comes from this key. It comes from the
+//!    Desktop installation witness, which is derived from the machine and the
+//!    user rather than from something the app just minted.
+//!
+//! Automerge stays authoritative throughout.
 
 use crate::automerge_external_common::{is_lower_sha256, lower_hex};
 use crate::library_core_canonical::{
@@ -332,6 +340,7 @@ pub(crate) fn establish_with_key_pair_for_test(
 /// epoch cannot countersign anything the journal will accept, so a caller that
 /// needs the key for enrollment must fail rather than quietly create a second
 /// identity.
+#[cfg_attr(not(test), allow(dead_code))]
 pub(crate) fn load_established_authority_key_pair(
     library_id: &str,
 ) -> Result<Ed25519KeyPair, String> {
@@ -381,8 +390,12 @@ fn establish_with_key_pair(
         .map_err(|error| format!("Library Core could not install the genesis epoch: {error}"))
 }
 
-/// Establish this installation's genesis authority epoch for one exact legacy
-/// Automerge revision, minting and storing the authority key if needed.
+/// Establish the disposable local epoch for one exact legacy Automerge
+/// revision, minting and storing the local key if needed.
+///
+/// Has no production caller and must not acquire one from startup. The real
+/// creator choice is an explicit owner action in the legacy epoch bootstrap.
+#[cfg_attr(not(test), allow(dead_code))]
 pub(crate) fn establish_genesis_epoch(
     journal: &mut LibraryCoreJournal,
     revision: &LegacySourceRevision,

--- a/packages/desktop/src-tauri/src/library_core_journal_runtime.rs
+++ b/packages/desktop/src-tauri/src/library_core_journal_runtime.rs
@@ -9,20 +9,20 @@
 //! opens the journal into Tauri managed state, and reports what it found.
 //!
 //! Automerge remains authoritative. Opening a database and counting rows
-//! changes no user-visible behaviour and grants no write authority; it is the
-//! call path the shadow slice needs before any operation can be written.
+//! grants no write authority.
+//!
+//! This module deliberately establishes nothing. An earlier revision minted a
+//! local authority key and enrolled an actor here at startup, which the
+//! contract forbids: startup absence never chooses a creator, and a key the
+//! app creates and signs proves only that the app possesses the key it just
+//! created. Choosing a creator is an explicit owner action, and it belongs to
+//! the legacy epoch bootstrap, not to opening a file.
 
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
 use tauri::Manager;
 
-use super::library_core_actor_enrollment::{
-    enroll_desktop_actor, EnrollmentAuthority, PlatformActorKeyStore,
-};
-use super::library_core_authority_genesis::{
-    establish_genesis_epoch, load_established_authority_key_pair, LegacySourceRevision,
-};
 use super::library_core_journal::{JournalRuntimeStatus, LibraryCoreJournal};
 
 /// Directory holding the authoritative database, under the app data root.
@@ -150,119 +150,6 @@ pub(super) fn library_core_journal_status(
     status_of(&state).map_err(|error| error.to_string())
 }
 
-/// What the caller reports about the exact durable Automerge revision the
-/// genesis epoch should be bound to.
-///
-/// These are the fields of the renderer's `LibraryCoreProjectionSourceV1`,
-/// which the Automerge worker only produces when the in-memory document's
-/// heads equal the durable snapshot's heads.
-#[derive(Debug, serde::Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub(super) struct GenesisSourceRequest {
-    document_id: String,
-    heads_digest: String,
-    head_count: u64,
-    storage_generation: u64,
-    storage_save_revision: u64,
-}
-
-/// What was established, for the caller to log. No key material, and no
-/// certificates: those stay in the journal.
-#[derive(Debug, Eq, PartialEq, serde::Serialize)]
-#[serde(rename_all = "camelCase")]
-pub(super) struct GenesisAuthorityStatus {
-    pub(super) library_id: String,
-    pub(super) epoch: i64,
-    pub(super) epoch_id: String,
-    pub(super) authority_key_id: String,
-    pub(super) actor_id: String,
-    /// The sequence this actor's next operation would take. 1 means it has
-    /// written nothing, which is the only value this path can produce.
-    pub(super) next_sequence: i64,
-}
-
-/// Establishes this installation's Library Core identity against the held
-/// journal: the genesis authority epoch, then its own enrolled actor.
-///
-/// One step, because an epoch with no actor can write nothing and an actor
-/// cannot exist without an epoch. Both halves are idempotent, so a call that
-/// fails after the epoch lands completes the actor on the next attempt.
-///
-/// Requires the journal to be open already, so a caller cannot establish
-/// authority against a database that was never validated on open. Replaying
-/// the same revision returns the same epoch and the same actor rather than
-/// writing again.
-pub(super) fn establish_genesis_at(
-    state: &LibraryCoreJournalRuntimeState,
-    request: &GenesisSourceRequest,
-    accepted_at_ms: i64,
-) -> RuntimeResult<GenesisAuthorityStatus> {
-    let mut held = state
-        .0
-        .lock()
-        .map_err(|_| JournalRuntimeError::StatePoisoned)?;
-    let journal = held
-        .as_mut()
-        .ok_or_else(|| JournalRuntimeError::Journal("journal is not open".to_string()))?;
-
-    let authority = establish_genesis_epoch(
-        journal,
-        &LegacySourceRevision {
-            document_id: request.document_id.clone(),
-            heads_digest: request.heads_digest.clone(),
-            head_count: request.head_count,
-            storage_generation: request.storage_generation,
-            storage_save_revision: request.storage_save_revision,
-        },
-        accepted_at_ms,
-    )
-    .map_err(JournalRuntimeError::Journal)?;
-
-    let enrollment_authority = EnrollmentAuthority {
-        library_id: authority.library_id.clone(),
-        epoch: authority.epoch,
-        epoch_id: authority.epoch_id.clone(),
-        authority_key_id: authority.authority_key_id.clone(),
-    };
-    // Loaded, never minted: the epoch above was signed by this exact key, and
-    // a second authority identity could not countersign an enrollment the
-    // journal would accept.
-    let authority_key_pair = load_established_authority_key_pair(&authority.library_id)
-        .map_err(JournalRuntimeError::Journal)?;
-    let actor = enroll_desktop_actor(
-        journal,
-        &enrollment_authority,
-        &PlatformActorKeyStore,
-        &authority_key_pair,
-        accepted_at_ms,
-    )
-    .map_err(JournalRuntimeError::Journal)?;
-
-    Ok(GenesisAuthorityStatus {
-        library_id: authority.library_id,
-        epoch: authority.epoch,
-        epoch_id: authority.epoch_id,
-        authority_key_id: authority.authority_key_id,
-        actor_id: actor.actor_id,
-        next_sequence: actor.next_sequence,
-    })
-}
-
-#[tauri::command]
-pub(super) fn establish_library_core_genesis_authority(
-    state: tauri::State<'_, LibraryCoreJournalRuntimeState>,
-    source: GenesisSourceRequest,
-) -> Result<GenesisAuthorityStatus, String> {
-    let accepted_at_ms = i64::try_from(
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map_err(|_| "system clock is before the Unix epoch".to_string())?
-            .as_millis(),
-    )
-    .map_err(|_| "system clock exceeds the supported range".to_string())?;
-    establish_genesis_at(&state, &source, accepted_at_ms).map_err(|error| error.to_string())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -300,25 +187,6 @@ mod tests {
                 & 0o777;
             assert_eq!(mode, 0o700, "journal directory must not be world readable");
         }
-    }
-
-    /// Establishing authority against a database that never validated on open
-    /// would be writing an authority chain into an unknown store.
-    #[test]
-    fn genesis_authority_is_refused_before_the_journal_is_open() {
-        let state = LibraryCoreJournalRuntimeState::default();
-        let request = GenesisSourceRequest {
-            document_id: "freed-library-document-1".to_string(),
-            heads_digest: "a".repeat(64),
-            head_count: 2,
-            storage_generation: 7,
-            storage_save_revision: 11,
-        };
-
-        let error = establish_genesis_at(&state, &request, 1_700)
-            .expect_err("authority must require an open journal");
-
-        assert!(error.to_string().contains("journal is not open"), "{error}");
     }
 
     #[test]

--- a/packages/desktop/src/lib/library-core-journal-runtime.test.ts
+++ b/packages/desktop/src/lib/library-core-journal-runtime.test.ts
@@ -6,18 +6,9 @@ const getLibraryCoreProjectionSource = vi.fn();
 vi.mock("@tauri-apps/api/core", () => ({ invoke }));
 vi.mock("./automerge", () => ({ getLibraryCoreProjectionSource }));
 
-const {
-  establishLibraryCoreGenesisAuthority,
-  openLibraryCoreJournalForStartup,
-} = await import("./library-core-journal-runtime.js");
-
-const SOURCE = {
-  schemaVersion: 1,
-  documentId: "freed-library-document-1",
-  headsDigest: "a".repeat(64),
-  headCount: 2,
-  storageRevision: { generation: 7, saveRevision: 11 },
-} as const;
+const { openLibraryCoreJournalForStartup } = await import(
+  "./library-core-journal-runtime.js"
+);
 
 const STATUS = {
   schemaVersion: 1,
@@ -28,93 +19,34 @@ const STATUS = {
   unacknowledgedOutbox: 0,
 } as const;
 
-const AUTHORITY = {
-  libraryId: "b".repeat(64),
-  epoch: 1,
-  epochId: "c".repeat(64),
-  authorityKeyId: "d".repeat(64),
-  actorId: "e".repeat(64),
-  nextSequence: 1,
-} as const;
-
 describe("Library Core journal runtime client", () => {
   beforeEach(() => {
     invoke.mockReset();
     getLibraryCoreProjectionSource.mockReset();
     vi.spyOn(console, "warn").mockImplementation(() => {});
-    vi.spyOn(console, "info").mockImplementation(() => {});
   });
 
-  it("sends the exact durable revision the worker reported", async () => {
-    invoke.mockResolvedValue(AUTHORITY);
-
-    await expect(establishLibraryCoreGenesisAuthority(SOURCE)).resolves.toEqual(
-      AUTHORITY,
-    );
-    expect(invoke).toHaveBeenCalledWith(
-      "establish_library_core_genesis_authority",
-      {
-        source: {
-          documentId: "freed-library-document-1",
-          headsDigest: "a".repeat(64),
-          headCount: 2,
-          storageGeneration: 7,
-          storageSaveRevision: 11,
-        },
-      },
-    );
-  });
-
-  it("opens the journal and then establishes authority against that revision", async () => {
-    invoke.mockImplementation((command: string) =>
-      command === "open_library_core_journal"
-        ? Promise.resolve(STATUS)
-        : Promise.resolve(AUTHORITY),
-    );
-    getLibraryCoreProjectionSource.mockResolvedValue(SOURCE);
+  /// Startup opens a database and stops. It must not choose a creator, mint a
+  /// key, create an epoch, or enroll an actor as a side effect of launching.
+  it("opens the journal and establishes nothing else", async () => {
+    invoke.mockResolvedValue(STATUS);
 
     await expect(openLibraryCoreJournalForStartup()).resolves.toEqual(STATUS);
 
     expect(invoke.mock.calls.map(([command]) => command)).toEqual([
       "open_library_core_journal",
-      "establish_library_core_genesis_authority",
     ]);
-  });
-
-  it("does not try to establish authority when the journal will not open", async () => {
-    invoke.mockRejectedValue(new Error("journal refused to open"));
-
-    await expect(openLibraryCoreJournalForStartup()).resolves.toBeNull();
-
-    // Establishing against a database that never validated on open would be
-    // writing authority into an unknown store.
-    expect(invoke.mock.calls.map(([command]) => command)).toEqual([
-      "open_library_core_journal",
-    ]);
+    // Reading the durable Automerge revision at startup only made sense as
+    // input to choosing a creator, which startup must never do.
     expect(getLibraryCoreProjectionSource).not.toHaveBeenCalled();
   });
 
-  it("still starts when the document has no durable revision yet", async () => {
-    invoke.mockResolvedValue(STATUS);
-    getLibraryCoreProjectionSource.mockRejectedValue(
-      new Error("Document not initialized"),
-    );
+  it("still starts when the journal will not open", async () => {
+    invoke.mockRejectedValue(new Error("journal refused to open"));
 
-    // Startup must survive it: the next start tries again.
-    await expect(openLibraryCoreJournalForStartup()).resolves.toEqual(STATUS);
+    await expect(openLibraryCoreJournalForStartup()).resolves.toBeNull();
     expect(invoke.mock.calls.map(([command]) => command)).toEqual([
       "open_library_core_journal",
     ]);
-  });
-
-  it("still starts when establishing authority is refused", async () => {
-    invoke.mockImplementation((command: string) =>
-      command === "open_library_core_journal"
-        ? Promise.resolve(STATUS)
-        : Promise.reject(new Error("stale authority")),
-    );
-    getLibraryCoreProjectionSource.mockResolvedValue(SOURCE);
-
-    await expect(openLibraryCoreJournalForStartup()).resolves.toEqual(STATUS);
   });
 });

--- a/packages/desktop/src/lib/library-core-journal-runtime.ts
+++ b/packages/desktop/src/lib/library-core-journal-runtime.ts
@@ -1,8 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
 
-import { getLibraryCoreProjectionSource } from "./automerge";
-import type { LibraryCoreProjectionSourceV1 } from "./automerge-types";
-
 /**
  * Desktop client for the Library Core journal.
  *
@@ -45,52 +42,6 @@ export function libraryCoreJournalStatus(): Promise<LibraryCoreJournalStatusV1 |
   );
 }
 
-/** What this installation established as its own Library Core identity. */
-export interface LibraryCoreGenesisAuthorityV1 {
-  readonly libraryId: string;
-  readonly epoch: number;
-  readonly epochId: string;
-  readonly authorityKeyId: string;
-  readonly actorId: string;
-  /**
-   * The sequence this actor's next operation would take. 1 means it has
-   * written nothing, which is the only value this path can produce.
-   */
-  readonly nextSequence: number;
-}
-
-/**
- * Establishes this installation's Library Core identity: the genesis authority
- * epoch for one exact durable Automerge revision, then its own enrolled actor.
- * Mints the authority and actor signing keys if it has none.
- *
- * One call, because an epoch with no actor can write nothing and an actor
- * cannot exist without an epoch. Both halves are idempotent, so a call that
- * fails after the epoch lands completes the actor on the next attempt.
- *
- * Requires the journal to be open. Everything the epoch is derived from is a
- * pure function of the library, the key and the revision, so replaying the same
- * revision returns the same epoch instead of writing a second one. A revision
- * that differs from the one already established is refused rather than
- * silently re-pointing the library.
- */
-export function establishLibraryCoreGenesisAuthority(
-  source: LibraryCoreProjectionSourceV1,
-): Promise<LibraryCoreGenesisAuthorityV1> {
-  return invoke<LibraryCoreGenesisAuthorityV1>(
-    "establish_library_core_genesis_authority",
-    {
-      source: {
-        documentId: source.documentId,
-        headsDigest: source.headsDigest,
-        headCount: source.headCount,
-        storageGeneration: source.storageRevision.generation,
-        storageSaveRevision: source.storageRevision.saveRevision,
-      },
-    },
-  );
-}
-
 /**
  * Opens the journal during startup without letting a failure reach the user.
  *
@@ -99,22 +50,18 @@ export function establishLibraryCoreGenesisAuthority(
  * is surfaced to the console as evidence rather than raised, because the only
  * consumer of that evidence today is us.
  *
- * Once the journal is open, the installation establishes its own identity
- * against the document's current durable revision: a genesis authority epoch
- * and an actor enrolled under it. Until both exist nothing can be written at
- * all, because Library Core fences every operation commit against an active
- * epoch and an enrolled actor. This is dormant either way: no operations are
- * written here, Automerge stays authoritative, and no provider traffic is
- * emitted.
- *
- * The document may not be readable yet at startup, which is why establishment
- * is attempted and not required. The next start tries again against whatever
- * revision is durable then, and the first one to succeed pins the library.
+ * Opening is all that happens here. An earlier revision also minted a local
+ * authority key, created an epoch, minted an actor key and enrolled an actor,
+ * all as a side effect of launching the app. The contract forbids it: startup
+ * absence never chooses a creator, and a key the app creates and signs proves
+ * only that the app possesses the key it just created, authenticating neither
+ * the owner nor another installation. Two Desktops holding the same Library
+ * would each have silently declared themselves its origin. Choosing a creator
+ * is an explicit owner action and belongs to the legacy epoch bootstrap.
  */
 export async function openLibraryCoreJournalForStartup(): Promise<LibraryCoreJournalStatusV1 | null> {
-  let status: LibraryCoreJournalStatusV1;
   try {
-    status = await openLibraryCoreJournal();
+    return await openLibraryCoreJournal();
   } catch (error) {
     console.warn(
       "[library-core] journal unavailable; continuing on Automerge only",
@@ -122,19 +69,4 @@ export async function openLibraryCoreJournalForStartup(): Promise<LibraryCoreJou
     );
     return null;
   }
-
-  try {
-    const source = await getLibraryCoreProjectionSource();
-    const authority = await establishLibraryCoreGenesisAuthority(source);
-    console.info(
-      `[library-core] authority epoch ${authority.epoch} for library ${authority.libraryId}, actor ${authority.actorId} at sequence ${authority.nextSequence}`,
-    );
-  } catch (error) {
-    console.warn(
-      "[library-core] identity not established; retrying next start",
-      error,
-    );
-  }
-
-  return status;
 }

--- a/packages/shared/src/library-core/census.test.ts
+++ b/packages/shared/src/library-core/census.test.ts
@@ -7,7 +7,10 @@ describe("Library Core dormant census", () => {
     expect(LIBRARY_CORE_CENSUS).toMatchObject({
       status: "dormant_incomplete",
       activationAllowed: false,
-      runtimeBehaviorChanged: false,
+      // Desktop startup opens a local shadow database. It still establishes
+      // no authority, so this cannot be read as writer or activation power.
+      runtimeBehaviorChanged: true,
+      runtimeBehaviorChange: "desktop_startup_opens_local_shadow_journal_database",
       activeEngine: "automerge_legacy",
       replicationProtocol: "automerge_blob_v1",
       legacyEpochBootstrapContract: "closed_dormant_v1",

--- a/packages/shared/src/library-core/census.ts
+++ b/packages/shared/src/library-core/census.ts
@@ -26,7 +26,18 @@ export const LIBRARY_CORE_CENSUS = Object.freeze({
   schemaVersion: 1,
   status: "dormant_incomplete",
   activationAllowed: false,
-  runtimeBehaviorChanged: false,
+  /**
+   * True since the journal gained a production owner: Desktop startup creates
+   * and opens `library-core/library-core.sqlite`. That is a real side effect
+   * and this flag said `false` through two releases of it, so it is recorded
+   * here rather than left to the reader to discover.
+   *
+   * It grants no authority. Startup establishes no epoch, mints no key,
+   * enrolls no actor, and writes no operation. A revision that did all four
+   * was reverted: startup absence never chooses a creator.
+   */
+  runtimeBehaviorChanged: true,
+  runtimeBehaviorChange: "desktop_startup_opens_local_shadow_journal_database",
   activeEngine: "automerge_legacy",
   replicationProtocol: "automerge_blob_v1",
   legacyEpochBootstrapContract: "closed_dormant_v1",

--- a/packages/shared/src/library-core/local-authority-registry.ts
+++ b/packages/shared/src/library-core/local-authority-registry.ts
@@ -912,7 +912,7 @@ export const LIBRARY_CORE_LOCAL_AUTHORITY_REGISTRY = [
     migration: "retire-with-legacy-epoch",
     cutover: {
       blocksCutover: true,
-      reason: "Desktop macOS and Windows now generate this key in the platform vault and enroll it under the genesis epoch, so a writable installation exists there. Cutover stays blocked because the enrolled actor has still written no operation, and neither Linux nor the PWA has a proven noninteractive vault to hold this key at all.",
+      reason: "The code to generate and enroll this key exists on desktop macOS and Windows but has no production caller, because the epoch it would enroll under is disposable local shadow state rather than authority. The enrolled actor has written no operation, and neither Linux nor the PWA has a proven noninteractive vault to hold this key at all.",
     },
     sourceReferences: [
       "docs/LIBRARY-CORE-CONTRACT.md",
@@ -941,7 +941,7 @@ export const LIBRARY_CORE_LOCAL_AUTHORITY_REGISTRY = [
     migration: "retire-with-legacy-epoch",
     cutover: {
       blocksCutover: true,
-      reason: "Desktop macOS and Windows now mint this key in the platform vault and sign one genesis epoch bound to one exact legacy Automerge revision, so an active Library Core epoch can exist there. Cutover stays blocked because Library Core cannot be authoritative on a platform that cannot hold this key, and neither Linux nor the PWA has a proven noninteractive vault.",
+      reason: "The code to mint this key exists on desktop macOS and Windows but has no production caller: startup was minting it automatically, which the contract forbids because a key the app creates and signs proves only that the app possesses the key it just created. Any key or epoch produced by that path is disposable local shadow state and can never be canonical authority. The real authority key stays unprovisioned until a user-present or authenticated authority-holder protocol exists.",
     },
     sourceReferences: [
       "docs/LIBRARY-CORE-CONTRACT.md",


### PR DESCRIPTION
(AI Generated).

## The defect

PRs #1354 and #1355 gave desktop startup a side effect the contract forbids. On launch, Freed Desktop was:

1. minting a local authority key,
2. creating an epoch-1 authority,
3. minting an actor key,
4. enrolling an actor,
5. writing epoch, actor, enrollment and outbox rows.

All of it because the app started. No owner was involved.

`docs/LIBRARY-CORE-CONTRACT.md:862` is explicit:

> The record deliberately has no authority key, signature, or proof of owner consent. A key created and signed by the same app process would prove only that the app possesses the key it just created.

and at line 814:

> Startup absence never chooses a creator.

Two Desktops holding the same Automerge Library would each have silently declared themselves its origin and derived different epoch-1 authorities. This could not corrupt a Library today — Automerge still owns every user write and the journal is not replicated — but it was invalid groundwork for canonical authority. It is in `dev` and not in any released build, so it is removed before it reaches one.

I wrote both of those PRs. This reverses the part that was wrong.

## What changes

**Startup opens the journal and stops.** The `establish_library_core_genesis_authority` command is unregistered and the runtime module establishes nothing.

**The local epoch machinery is kept and reclassified, not deleted.** `library_core_authority_epochs` needs an epoch row before the journal will accept an actor or an operation, so the shadow slice still needs a local value. It is now documented as disposable local shadow state that can never become canonical authority, has no production caller, and must not acquire one from startup.

**Installation identity binds to the Desktop installation witness.** Previously it was derived from the disposable local key — so a discarded epoch would have changed the installation's identity, and two real machines were indistinguishable in principle. The witness is a digest of the machine identifier and the user (`hash_desktop_installation_witness`), which is what installation identity has to mean. `the_derived_identity_is_stable_and_separates_installations` now asserts both halves: a different machine is a different installation, **and a new local key on the same machine is not**.

## Corrections to stale statements

- `census.ts` said `runtimeBehaviorChanged: false` through two releases in which desktop startup created and opened a real database. Now `true`, naming the exact change (`desktop_startup_opens_local_shadow_journal_database`) alongside the fact that it grants no authority.
- The `library-core-authority-private-key` and `library-core-actor-private-key` registry entries no longer claim to be provisioned. Their code has no production caller again, and the reasons now say so plainly.
- `legacyEpochBootstrapTransactionImplemented: false` stays. It is accurate: the real owner-confirmed bootstrap is still unbuilt, and that is the next slice.

**No activation-manifest entry is added.** Its transition kinds are a closed vocabulary (`sql_read_cutover`, `legacy_worker_eviction`, `renderer_corpus_eviction` for Gate D) and none of them describes opening a local shadow store, which grants nothing and activates nothing. Bending that vocabulary to record a file being created would make the manifest less trustworthy, not more. The census records it instead.

## Evidence

`cargo test --lib` 454 passed · `cargo fmt --check` clean · `npm run validate:feature` exit 0 · `validate-main-backflow.mjs` in sync · activation manifest validates with 0 new transitions.

One environment note: this worktree's Playwright browser binary was missing (`chromium_headless_shell-1234`), which failed 23 e2e tests before any code was examined. `npx playwright install chromium` fixed it; the failures were not related to this change.

## Provider surface

The entire provider-visible diff is **one deleted line** in `lib.rs` unregistering a Tauri command. The removed command wrote local SQLite rows and minted vault keys; it performed no network activity and touched no WebView. This strictly reduces what the app does at startup. Recorded as `diff_authorized` under `library-core-stop-startup-authority-v1`.

## Not in this PR

The read-transaction builder is deliberately held back. Its retry design is wrong: `commit_read_assignments` rereads the actor's mutable chain tip and folds it into the transaction identity, so a successful commit advances the tip and a response-loss retry cannot reconstruct the original transaction ID. Exact retry identity is a durable contract and the fix is the durable bridge, not a relaxed test. That is the next slice.

## Provider Review
- Status: Provider authority is validated for ready publication.
- Review action: none required. The provider-risk artifact records the behavior authority decision; this exact provider subdiff is the audit subject.
- Provider subdiff: `e1523abe39c10c43bc5b0ef5ddd7b910e2e85e17`
- Publication does not authorize new live provider traffic. Gate 1 behavior approval still applies when observable behavior changes.
- Provider review task: `library-core-stop-startup-authority-v1`
- Provider review decision: `diff_authorized`
- Provider review artifact: `905509819303a4d51331d84a1ce113725a7e3a4e40f634a9f5128294b633e63c`
- Providers: facebook, instagram, linkedin, medium, other, substack, x, youtube
- Observable behavior: Provider requests, navigation, retries, cadence, cookies, headers, extraction scripts, scrolling, clicking, media loading, and authentication behavior are unchanged. The entire provider-visible diff is one deleted line in lib.rs that unregisters a Tauri command. The removed command wrote local SQLite rows and minted keys in the platform credential vault; it performed no network activity and touched no WebView. Removing it strictly reduces what the app does at startup.
- Fingerprinting risk: None introduced, and none removed. Providers receive the same requests with the same timing and content, because neither the removed command nor anything around it contacts a provider. Unregistering a command adds no provider-reachable behavior.
- Lowest profile alternative: This is itself the lower-profile direction: it deletes an automatic local side effect rather than adding one. No provider contact is involved either way.

Files bound into this provider review:
- `packages/desktop/src-tauri/src/lib.rs`