### PR TITLE
feat: make the Automerge-to-SQLite read bridge survive its own success

### DIFF
--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -59,6 +59,8 @@ mod library_core_journal;
 mod library_core_journal_runtime;
 mod library_core_migration_claim;
 mod library_core_platform_key;
+mod library_core_read_bridge;
+mod library_core_read_transactions;
 mod library_core_saved_feed_runtime;
 mod library_core_shadow_runtime;
 #[cfg_attr(not(test), allow(dead_code))]

--- a/packages/desktop/src-tauri/src/library_core_journal.rs
+++ b/packages/desktop/src-tauri/src/library_core_journal.rs
@@ -23,11 +23,42 @@ mod enrollment_verifier;
 #[path = "library_core_journal_operation_verifier.rs"]
 mod operation_verifier;
 
-const AUTHORITATIVE_SCHEMA_VERSION: i64 = 1;
+const AUTHORITATIVE_SCHEMA_VERSION: i64 = 2;
 // ASCII "FREE" in SQLite's 32-bit application_id header field.
 const AUTHORITATIVE_APPLICATION_ID: i64 = 0x4652_4545;
 const AUTHORITATIVE_SCHEMA_V1_SQL: &str =
     include_str!("../../../shared/src/library-core/authoritative-schema-v1.sql");
+
+/// Every migration past the genesis schema, in order, paired with the version
+/// it produces.
+///
+/// A database is brought up to date by applying the genesis schema if it is
+/// empty and then every entry here above its current version. The reference
+/// catalogue used to verify a database is built the same way, so a migrated
+/// database and a freshly created one are required to be identical rather than
+/// merely similar.
+const AUTHORITATIVE_SCHEMA_MIGRATIONS: [(i64, &str); 1] = [(
+    2,
+    include_str!("../../../shared/src/library-core/authoritative-migration-002.sql"),
+)];
+
+/// Apply the genesis schema when needed, then every migration in `(prior,
+/// through]`.
+fn apply_schema_range(
+    transaction: &Transaction<'_>,
+    prior: i64,
+    through: i64,
+) -> JournalResult<()> {
+    if prior == 0 {
+        transaction.execute_batch(AUTHORITATIVE_SCHEMA_V1_SQL)?;
+    }
+    for (version, sql) in AUTHORITATIVE_SCHEMA_MIGRATIONS {
+        if version > prior && version <= through {
+            transaction.execute_batch(sql)?;
+        }
+    }
+    Ok(())
+}
 const BUSY_TIMEOUT: Duration = Duration::from_secs(5);
 const BASE_CACHE_KIB: i64 = -32 * 1024;
 const MAX_TRANSACTION_MEMBERS: usize = 1_000;
@@ -251,6 +282,28 @@ pub(crate) struct AcceptedAuthorityState {
     pub(crate) observed_frontier: Vec<VerifiedCausalTip>,
 }
 
+/// One durable bridge attempt: the exact bytes and the tip they were
+/// built against, plus whether the SQLite commit was confirmed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ReadBridgeAttempt {
+    pub(crate) attempt_id: String,
+    pub(crate) library_id: String,
+    pub(crate) epoch_id: String,
+    pub(crate) actor_id: String,
+    pub(crate) source_storage_generation: i64,
+    pub(crate) source_save_revision: i64,
+    pub(crate) source_heads_digest: String,
+    pub(crate) actor_sequence: i64,
+    pub(crate) previous_operation_id: Option<String>,
+    pub(crate) previous_chain_digest: String,
+    pub(crate) created_at_ms: i64,
+    pub(crate) transaction_id: String,
+    pub(crate) transaction_digest: String,
+    pub(crate) canonical_envelopes: Vec<Vec<u8>>,
+    pub(crate) committed: bool,
+    pub(crate) committed_ingest_sequence: Option<i64>,
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct VerifiedAuthorityEpoch {
     pub(crate) authority: AcceptedAuthorityState,
@@ -287,18 +340,20 @@ struct VerifiedReadTransaction {
     members: Vec<VerifiedReadAssignment>,
 }
 
+/// What a committed read transaction produced. Returned to the bridge so a
+/// retry can hand back the same completion instead of a second commit.
 #[derive(Debug, Clone, PartialEq)]
-struct TransactionReceipt {
-    transaction_id: String,
-    transaction_digest: String,
+pub(crate) struct TransactionReceipt {
+    pub(crate) transaction_id: String,
+    pub(crate) transaction_digest: String,
     actor_id: String,
-    member_count: usize,
-    first_sequence: i64,
+    pub(crate) member_count: usize,
+    pub(crate) first_sequence: i64,
     last_sequence: i64,
     committed_operation_id: String,
     committed_chain_digest: String,
     first_ingest_sequence: i64,
-    last_ingest_sequence: i64,
+    pub(crate) last_ingest_sequence: i64,
     previous_revision: i64,
     committed_revision: i64,
     committed_at_ms: i64,
@@ -702,7 +757,7 @@ impl LibraryCoreJournal {
                 Ok(())
             };
         }
-        Self::verify_schema_contract(connection)?;
+        Self::verify_schema_contract_at(connection, version)?;
         Ok(())
     }
 
@@ -803,9 +858,7 @@ impl LibraryCoreJournal {
         if prior == 0 && has_unversioned_tables {
             return Err(JournalError::UnversionedSchemaPresent);
         }
-        if prior == 0 {
-            transaction.execute_batch(AUTHORITATIVE_SCHEMA_V1_SQL)?;
-        }
+        apply_schema_range(&transaction, prior, AUTHORITATIVE_SCHEMA_VERSION)?;
         let actual =
             transaction.pragma_query_value(None, "user_version", |row| row.get::<_, i64>(0))?;
         let actual_application_id =
@@ -822,7 +875,7 @@ impl LibraryCoreJournal {
                 actual: actual_application_id,
             });
         }
-        Self::verify_schema_contract(&transaction)?;
+        Self::verify_schema_contract_at(&transaction, AUTHORITATIVE_SCHEMA_VERSION)?;
         transaction.commit()?;
         Ok(())
     }
@@ -887,9 +940,20 @@ impl LibraryCoreJournal {
         Ok(entries)
     }
 
-    fn verify_schema_contract(connection: &Connection) -> JournalResult<()> {
-        let reference = Connection::open_in_memory()?;
-        reference.execute_batch(AUTHORITATIVE_SCHEMA_V1_SQL)?;
+    /// Hold a database to the exact catalogue of the schema version it claims.
+    ///
+    /// Not the newest version. A database written by an older release is
+    /// legitimately missing later tables, and checking it against the current
+    /// reference would reject it before it could ever be migrated. Checking it
+    /// against its own version still rejects a tampered or foreign file, which
+    /// is the point of the check.
+    fn verify_schema_contract_at(connection: &Connection, version: i64) -> JournalResult<()> {
+        let mut reference = Connection::open_in_memory()?;
+        {
+            let transaction = reference.transaction()?;
+            apply_schema_range(&transaction, 0, version)?;
+            transaction.commit()?;
+        }
         let expected = Self::schema_catalog(&reference)?;
         let actual = Self::schema_catalog(connection)?;
         if actual != expected {
@@ -931,6 +995,138 @@ impl LibraryCoreJournal {
                 },
             )
             .optional()
+    }
+
+    /// The durable attempt for this mutation, if one was ever prepared.
+    pub(crate) fn read_bridge_attempt(
+        &self,
+        attempt_id: &str,
+    ) -> JournalResult<Option<ReadBridgeAttempt>> {
+        let row = self
+            .connection
+            .query_row(
+                "SELECT attemptId, libraryId, epochId, actorId,
+                        sourceStorageGeneration, sourceSaveRevision, sourceHeadsDigest,
+                        actorSequence, previousOperationId, previousChainDigest,
+                        createdAtMs, transactionId, transactionDigest,
+                        canonicalEnvelopesJson, state, committedIngestSequence
+                 FROM library_core_read_bridge_attempts WHERE attemptId = ?1;",
+                [attempt_id],
+                |row| {
+                    Ok((
+                        ReadBridgeAttempt {
+                            attempt_id: row.get(0)?,
+                            library_id: row.get(1)?,
+                            epoch_id: row.get(2)?,
+                            actor_id: row.get(3)?,
+                            source_storage_generation: row.get(4)?,
+                            source_save_revision: row.get(5)?,
+                            source_heads_digest: row.get(6)?,
+                            actor_sequence: row.get(7)?,
+                            previous_operation_id: row.get(8)?,
+                            previous_chain_digest: row.get(9)?,
+                            created_at_ms: row.get(10)?,
+                            transaction_id: row.get(11)?,
+                            transaction_digest: row.get(12)?,
+                            canonical_envelopes: Vec::new(),
+                            committed: row.get::<_, String>(14)? == "committed",
+                            committed_ingest_sequence: row.get(15)?,
+                        },
+                        row.get::<_, String>(13)?,
+                    ))
+                },
+            )
+            .optional()?;
+        let Some((mut attempt, envelopes_json)) = row else {
+            return Ok(None);
+        };
+        let encoded: Vec<String> = serde_json::from_str(&envelopes_json).map_err(|_| {
+            JournalError::InvalidVerifiedInput {
+                field: "canonical_envelopes",
+            }
+        })?;
+        attempt.canonical_envelopes = encoded
+            .into_iter()
+            .map(|member| member.into_bytes())
+            .collect();
+        Ok(Some(attempt))
+    }
+
+    /// Record one attempt durably before its SQLite commit is tried.
+    ///
+    /// Refuses to overwrite an existing attempt. A caller retrying a mutation
+    /// must replay the stored bytes, and a caller reusing an attempt id for
+    /// different work is naming two different facts the same thing.
+    pub(crate) fn prepare_read_bridge_attempt(
+        &mut self,
+        attempt: &ReadBridgeAttempt,
+        prepared_at_ms: i64,
+    ) -> JournalResult<()> {
+        let encoded: Vec<String> = attempt
+            .canonical_envelopes
+            .iter()
+            .map(|member| {
+                String::from_utf8(member.clone()).map_err(|_| JournalError::InvalidVerifiedInput {
+                    field: "canonical_envelopes",
+                })
+            })
+            .collect::<JournalResult<Vec<String>>>()?;
+        let envelopes_json =
+            serde_json::to_string(&encoded).map_err(|_| JournalError::InvalidVerifiedInput {
+                field: "canonical_envelopes",
+            })?;
+        self.connection.execute(
+            "INSERT INTO library_core_read_bridge_attempts (
+               attemptId, libraryId, epochId, actorId,
+               sourceStorageGeneration, sourceSaveRevision, sourceHeadsDigest,
+               actorSequence, previousOperationId, previousChainDigest,
+               createdAtMs, transactionId, transactionDigest,
+               canonicalEnvelopesJson, memberCount, state, preparedAtMs
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15,
+                       'prepared', ?16);",
+            params![
+                attempt.attempt_id,
+                attempt.library_id,
+                attempt.epoch_id,
+                attempt.actor_id,
+                attempt.source_storage_generation,
+                attempt.source_save_revision,
+                attempt.source_heads_digest,
+                attempt.actor_sequence,
+                attempt.previous_operation_id,
+                attempt.previous_chain_digest,
+                attempt.created_at_ms,
+                attempt.transaction_id,
+                attempt.transaction_digest,
+                envelopes_json,
+                attempt.canonical_envelopes.len() as i64,
+                prepared_at_ms,
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Mark an attempt complete, only after its receipt was read back.
+    pub(crate) fn complete_read_bridge_attempt(
+        &mut self,
+        attempt_id: &str,
+        committed_ingest_sequence: i64,
+        committed_at_ms: i64,
+    ) -> JournalResult<()> {
+        let updated = self.connection.execute(
+            "UPDATE library_core_read_bridge_attempts
+             SET state = 'committed',
+                 committedAtMs = ?2,
+                 committedIngestSequence = ?3
+             WHERE attemptId = ?1 AND state = 'prepared';",
+            params![attempt_id, committed_at_ms, committed_ingest_sequence],
+        )?;
+        if updated != 1 {
+            return Err(JournalError::InvalidVerifiedInput {
+                field: "read_bridge_attempt_state",
+            });
+        }
+        Ok(())
     }
 
     /// The stored actor, if this library, epoch and actor are already
@@ -988,7 +1184,7 @@ impl LibraryCoreJournal {
         })
     }
 
-    fn verify_and_commit_read_transaction(
+    pub(crate) fn verify_and_commit_read_transaction(
         &mut self,
         canonical_envelopes: &[Vec<u8>],
         committed_at_ms: i64,
@@ -1935,6 +2131,58 @@ mod tests {
             canonical_envelope_bytes,
             members,
         }
+    }
+
+    /// A database created before the bridge existed must reach exactly the
+    /// same schema as a fresh one, not merely a working one.
+    ///
+    /// `verify_schema_contract` compares the whole catalogue, so a migration
+    /// that produced a subtly different table would fail every later open.
+    /// Installations already hold schema 1 databases, created by the startup
+    /// opener, so this path is real rather than hypothetical.
+    #[test]
+    fn a_schema_one_database_migrates_to_exactly_a_fresh_schema_two() {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let path = directory.path().join("library-core.sqlite");
+
+        // Build a database the way the previous release did: genesis schema
+        // only, no migrations.
+        {
+            let legacy = Connection::open(&path).expect("create legacy database");
+            legacy
+                .execute_batch(AUTHORITATIVE_SCHEMA_V1_SQL)
+                .expect("apply schema 1");
+            let version: i64 = legacy
+                .pragma_query_value(None, "user_version", |row| row.get(0))
+                .expect("legacy version");
+            assert_eq!(version, 1, "the fixture must really be schema 1");
+        }
+
+        let migrated = LibraryCoreJournal::open(&path).expect("migrate and open");
+        let version: i64 = migrated
+            .connection
+            .pragma_query_value(None, "user_version", |row| row.get(0))
+            .expect("migrated version");
+        assert_eq!(version, 2);
+
+        let fresh_directory = tempfile::tempdir().expect("temporary directory");
+        let fresh = LibraryCoreJournal::open(&fresh_directory.path().join("library-core.sqlite"))
+            .expect("open fresh journal");
+
+        assert_eq!(
+            LibraryCoreJournal::schema_catalog(&migrated.connection).expect("migrated catalog"),
+            LibraryCoreJournal::schema_catalog(&fresh.connection).expect("fresh catalog"),
+        );
+
+        // Reopening a migrated database must be a no-op, not a second attempt
+        // to apply the migration.
+        drop(migrated);
+        let reopened = LibraryCoreJournal::open(&path).expect("reopen migrated database");
+        let version: i64 = reopened
+            .connection
+            .pragma_query_value(None, "user_version", |row| row.get(0))
+            .expect("reopened version");
+        assert_eq!(version, 2);
     }
 
     #[test]

--- a/packages/desktop/src-tauri/src/library_core_journal_runtime.rs
+++ b/packages/desktop/src-tauri/src/library_core_journal_runtime.rs
@@ -167,7 +167,7 @@ mod tests {
         assert!(status_of(&state).expect("status before open").is_none());
 
         let status = open_at_root(&state, root.path()).expect("open journal");
-        assert_eq!(status.schema_version, 1);
+        assert_eq!(status.schema_version, 2);
         assert_eq!(status.materializer_ingest_sequence, 0);
         assert_eq!(status.actors, 0);
         assert_eq!(status.operations, 0);

--- a/packages/desktop/src-tauri/src/library_core_read_bridge.rs
+++ b/packages/desktop/src-tauri/src/library_core_read_bridge.rs
@@ -1,0 +1,650 @@
+//! The durable bridge from one exact Automerge commit to the SQLite shadow.
+//!
+//! Automerge commits, then SQLite commits. Nothing makes those two writes
+//! atomic, so the gap between them has to be survivable rather than wished
+//! away. Every crash, restart and lost response has to land on exactly one
+//! outcome, and the same one it would have reached without the interruption.
+//!
+//! ## Why storing the bytes is the whole mechanism
+//!
+//! An earlier attempt rebuilt the transaction on retry. That cannot work.
+//! Envelope identity includes the actor's chain tip, and a successful commit
+//! advances the tip, so a retry after a lost response rebuilds a *different*
+//! transaction against the new tip. The journal then sees unfamiliar work
+//! rather than a replay: it would either commit the same reads twice under new
+//! operation IDs, or refuse on a stale tip, depending on timing. Taking a
+//! fresh `created_at_ms` breaks it a second way, because that field is inside
+//! the signed body.
+//!
+//! So the attempt is recorded durably, with its exact canonical envelope
+//! bytes, *before* the SQLite commit is tried, keyed by a mutation identity
+//! the caller keeps stable across retries. Retry replays those bytes verbatim.
+//! The operation identity survives its own success.
+//!
+//! ## The four gaps, and what happens in each
+//!
+//! 1. Crash before the attempt is recorded: neither side has the read
+//!    assignment beyond Automerge's own commit, and the next attempt builds
+//!    fresh against the current tip. Nothing is lost, because Automerge is
+//!    still authoritative and the shadow simply has not caught up.
+//! 2. Crash after recording, before the SQLite commit: the stored bytes are
+//!    replayed and commit exactly once.
+//! 3. Crash after the SQLite commit, before the attempt is marked complete:
+//!    the journal's own transaction replay returns the committed receipt, and
+//!    the attempt is marked complete from it.
+//! 4. Crash after marking complete: the stored completion is returned.
+//!
+//! ## What this is not
+//!
+//! Not authority. Automerge remains the writer; a disagreement here is
+//! evidence, never an override. Native code loads authority and actor state
+//! itself and verifies the original canonical bytes; a caller cannot hand in a
+//! pre-verified object. No provider request belongs anywhere in this path.
+
+use crate::library_core_journal::{
+    ActorState, LibraryCoreJournal, ReadBridgeAttempt, TransactionReceipt,
+};
+use crate::library_core_read_transactions::{build_read_transaction, ReadAssignmentIntent};
+use ring::signature::Ed25519KeyPair;
+
+/// The exact durable Automerge revision a mutation committed at.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct SourceRevision {
+    pub(crate) storage_generation: i64,
+    pub(crate) save_revision: i64,
+    pub(crate) heads_digest: String,
+}
+
+/// What the caller is asking to shadow, named by a stable mutation identity.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ReadBridgeRequest {
+    /// Stable across retries of the same mutation. This is what makes an exact
+    /// retry possible at all, so a caller that regenerates it per attempt has
+    /// defeated the mechanism.
+    pub(crate) attempt_id: String,
+    pub(crate) source: SourceRevision,
+    pub(crate) intents: Vec<ReadAssignmentIntent>,
+    /// Inside the signed envelopes. Stored on the first attempt and reused,
+    /// never re-read from the clock on retry.
+    pub(crate) created_at_ms: i64,
+}
+
+fn invalid(what: &str) -> String {
+    format!("Library Core read bridge {what} is invalid")
+}
+
+fn validate_request(request: &ReadBridgeRequest) -> Result<(), String> {
+    if request.attempt_id.is_empty() || request.attempt_id.len() > 128 {
+        return Err(invalid("attempt ID"));
+    }
+    if request.source.heads_digest.len() != 64
+        || !request
+            .source
+            .heads_digest
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return Err(invalid("source heads digest"));
+    }
+    if request.source.storage_generation < 0 || request.source.save_revision < 0 {
+        return Err(invalid("source revision"));
+    }
+    if request.created_at_ms < 0 {
+        return Err(invalid("creation time"));
+    }
+    Ok(())
+}
+
+/// A stored attempt must describe the same fact the caller is now asking for.
+///
+/// Reusing one mutation identity for a different revision or a different actor
+/// is two facts sharing a name, and replaying the stored bytes would silently
+/// answer the wrong question.
+fn require_same_fact(
+    stored: &ReadBridgeAttempt,
+    request: &ReadBridgeRequest,
+    actor: &ActorState,
+) -> Result<(), String> {
+    if stored.source_storage_generation != request.source.storage_generation
+        || stored.source_save_revision != request.source.save_revision
+        || stored.source_heads_digest != request.source.heads_digest
+    {
+        return Err(format!(
+            "Library Core read bridge attempt {} was recorded against a different Automerge revision",
+            stored.attempt_id
+        ));
+    }
+    if stored.library_id != actor.library_id
+        || stored.epoch_id != actor.epoch_id
+        || stored.actor_id != actor.actor_id
+    {
+        return Err(format!(
+            "Library Core read bridge attempt {} was recorded by a different actor",
+            stored.attempt_id
+        ));
+    }
+    Ok(())
+}
+
+/// Resolve one mutation to exactly one committed SQLite transaction.
+///
+/// Safe to call again with the same request after any interruption.
+pub(crate) fn bridge_read_assignments(
+    journal: &mut LibraryCoreJournal,
+    request: &ReadBridgeRequest,
+    library_id: &str,
+    epoch_id: &str,
+    actor_id: &str,
+    actor_key_pair: &Ed25519KeyPair,
+    now_ms: i64,
+) -> Result<TransactionReceipt, String> {
+    validate_request(request)?;
+
+    // Authority and actor state are loaded here, natively. A caller cannot
+    // hand in an actor it decided was enrolled.
+    let actor = journal
+        .actor_state(library_id, epoch_id, actor_id)
+        .map_err(|error| format!("Library Core could not read actor state: {error}"))?
+        .ok_or_else(|| "Library Core has no enrolled actor for this library".to_string())?;
+
+    let stored = journal
+        .read_bridge_attempt(&request.attempt_id)
+        .map_err(|error| format!("Library Core could not read the bridge attempt: {error}"))?;
+
+    let attempt = match stored {
+        Some(stored) => {
+            require_same_fact(&stored, request, &actor)?;
+            stored
+        }
+        None => {
+            // Gap 1 ends here: from the moment this insert commits, the exact
+            // bytes are recoverable and no later rebuild can change them.
+            let envelopes = build_read_transaction(
+                &actor,
+                &request.intents,
+                actor_key_pair,
+                request.created_at_ms,
+            )?;
+            let (transaction_id, transaction_digest) = transaction_identity(&envelopes)?;
+            let attempt = ReadBridgeAttempt {
+                attempt_id: request.attempt_id.clone(),
+                library_id: actor.library_id.clone(),
+                epoch_id: actor.epoch_id.clone(),
+                actor_id: actor.actor_id.clone(),
+                source_storage_generation: request.source.storage_generation,
+                source_save_revision: request.source.save_revision,
+                source_heads_digest: request.source.heads_digest.clone(),
+                actor_sequence: actor.next_sequence,
+                previous_operation_id: actor.previous_operation_id.clone(),
+                previous_chain_digest: actor.previous_chain_digest.clone(),
+                created_at_ms: request.created_at_ms,
+                transaction_id,
+                transaction_digest,
+                canonical_envelopes: envelopes,
+                committed: false,
+                committed_ingest_sequence: None,
+            };
+            journal
+                .prepare_read_bridge_attempt(&attempt, now_ms)
+                .map_err(|error| {
+                    format!("Library Core could not record the bridge attempt: {error}")
+                })?;
+            attempt
+        }
+    };
+
+    // Replay the stored bytes, never a rebuild. The journal answers a repeat
+    // of an already-committed transaction with its stored receipt, so gaps 3
+    // and 4 both land here and both return the same completion.
+    let receipt = journal
+        .verify_and_commit_read_transaction(&attempt.canonical_envelopes, now_ms)
+        .map_err(|error| format!("Library Core could not commit read assignments: {error}"))?;
+
+    if !attempt.committed {
+        journal
+            .complete_read_bridge_attempt(&attempt.attempt_id, receipt.last_ingest_sequence, now_ms)
+            .map_err(|error| {
+                format!("Library Core could not complete the bridge attempt: {error}")
+            })?;
+    }
+
+    Ok(receipt)
+}
+
+/// Read the transaction identity back out of the envelopes that carry it.
+///
+/// Taken from the bytes rather than recomputed, so the stored row can never
+/// name a transaction the stored bytes do not contain.
+fn transaction_identity(envelopes: &[Vec<u8>]) -> Result<(String, String), String> {
+    let first = envelopes.first().ok_or_else(|| invalid("envelope set"))?;
+    let value: serde_json::Value =
+        serde_json::from_slice(first).map_err(|_| invalid("canonical envelope"))?;
+    let object = value
+        .as_object()
+        .ok_or_else(|| invalid("canonical envelope"))?;
+    let transaction_id = object
+        .get("transaction_id")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| invalid("transaction ID"))?;
+    let transaction_digest = object
+        .get("transaction_digest")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| invalid("transaction digest"))?;
+    Ok((transaction_id.to_owned(), transaction_digest.to_owned()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::library_core_actor_enrollment::{
+        enroll_desktop_actor, ActorKeyStore, EnrollmentAuthority,
+    };
+    use crate::library_core_authority_genesis::{
+        establish_with_key_pair_for_test, LegacySourceRevision,
+    };
+    use tempfile::tempdir;
+
+    struct FixedActorKeyStore(Vec<u8>);
+
+    impl ActorKeyStore for FixedActorKeyStore {
+        fn load(&self, _library_id: &str) -> Result<Option<Vec<u8>>, String> {
+            Ok(Some(self.0.clone()))
+        }
+
+        fn store(&self, _library_id: &str, _bytes: &[u8]) -> Result<(), String> {
+            Ok(())
+        }
+    }
+
+    fn authority_key_pair() -> Ed25519KeyPair {
+        Ed25519KeyPair::from_seed_unchecked(&[7_u8; 32]).unwrap()
+    }
+
+    struct Fixture {
+        directory: tempfile::TempDir,
+        journal: LibraryCoreJournal,
+        actor: ActorState,
+        actor_key_pair: Ed25519KeyPair,
+        pkcs8: Vec<u8>,
+    }
+
+    impl Fixture {
+        /// Reopen the same database, standing in for a process restart.
+        fn restart(self) -> Self {
+            let path = self.directory.path().join("library-core.sqlite");
+            drop(self.journal);
+            let journal = LibraryCoreJournal::open(&path).expect("reopen journal");
+            Self {
+                directory: self.directory,
+                journal,
+                actor: self.actor,
+                actor_key_pair: Ed25519KeyPair::from_pkcs8(&self.pkcs8).unwrap(),
+                pkcs8: self.pkcs8,
+            }
+        }
+    }
+
+    fn fixture() -> Fixture {
+        let directory = tempdir().unwrap();
+        let mut journal =
+            LibraryCoreJournal::open(&directory.path().join("library-core.sqlite")).unwrap();
+        let accepted = establish_with_key_pair_for_test(
+            &mut journal,
+            &LegacySourceRevision {
+                document_id: "freed-library-document-1".to_string(),
+                heads_digest: "a".repeat(64),
+                head_count: 2,
+                storage_generation: 7,
+                storage_save_revision: 11,
+            },
+            &authority_key_pair(),
+            1_700,
+        )
+        .unwrap();
+        let pkcs8 =
+            ring::signature::Ed25519KeyPair::generate_pkcs8(&ring::rand::SystemRandom::new())
+                .unwrap()
+                .as_ref()
+                .to_vec();
+        let actor = enroll_desktop_actor(
+            &mut journal,
+            &EnrollmentAuthority {
+                library_id: accepted.library_id.clone(),
+                epoch: accepted.epoch,
+                epoch_id: accepted.epoch_id.clone(),
+                authority_key_id: accepted.authority_key_id.clone(),
+                installation_witness: "c".repeat(64),
+            },
+            &FixedActorKeyStore(pkcs8.clone()),
+            &authority_key_pair(),
+            2_000,
+        )
+        .unwrap();
+        Fixture {
+            directory,
+            journal,
+            actor,
+            actor_key_pair: Ed25519KeyPair::from_pkcs8(&pkcs8).unwrap(),
+            pkcs8,
+        }
+    }
+
+    fn request(attempt_id: &str) -> ReadBridgeRequest {
+        ReadBridgeRequest {
+            attempt_id: attempt_id.to_string(),
+            source: SourceRevision {
+                storage_generation: 7,
+                save_revision: 11,
+                heads_digest: "a".repeat(64),
+            },
+            intents: vec![
+                ReadAssignmentIntent {
+                    entity_id: "feed-item-a".to_string(),
+                    read_at_ms: 5_000,
+                },
+                ReadAssignmentIntent {
+                    entity_id: "feed-item-b".to_string(),
+                    read_at_ms: 5_000,
+                },
+            ],
+            created_at_ms: 6_000,
+        }
+    }
+
+    fn bridge(
+        f: &mut Fixture,
+        request: &ReadBridgeRequest,
+        now_ms: i64,
+    ) -> Result<TransactionReceipt, String> {
+        let (library_id, epoch_id, actor_id) = (
+            f.actor.library_id.clone(),
+            f.actor.epoch_id.clone(),
+            f.actor.actor_id.clone(),
+        );
+        bridge_read_assignments(
+            &mut f.journal,
+            request,
+            &library_id,
+            &epoch_id,
+            &actor_id,
+            &f.actor_key_pair,
+            now_ms,
+        )
+    }
+
+    fn count(f: &Fixture, sql: &str) -> i64 {
+        f.journal
+            .connection_for_test()
+            .query_row(sql, [], |row| row.get(0))
+            .unwrap()
+    }
+
+    fn read_state(f: &Fixture, entity_id: &str) -> Option<i64> {
+        f.journal
+            .connection_for_test()
+            .query_row(
+                "SELECT readAtMs FROM library_core_feed_item_read_state WHERE entityId = ?1;",
+                [entity_id],
+                |row| row.get(0),
+            )
+            .ok()
+    }
+
+    #[test]
+    fn a_single_mutation_reaches_sqlite_and_materializes() {
+        let mut f = fixture();
+
+        let receipt = bridge(&mut f, &request("mutation-1"), 6_500).unwrap();
+
+        assert_eq!(receipt.member_count, 2);
+        assert_eq!(read_state(&f, "feed-item-a"), Some(5_000));
+        assert_eq!(read_state(&f, "feed-item-b"), Some(5_000));
+        assert_eq!(
+            count(
+                &f,
+                "SELECT COUNT(*) FROM library_core_read_bridge_attempts WHERE state = 'committed';"
+            ),
+            1
+        );
+    }
+
+    /// Gap 4, and the case the previous design could not express: the commit
+    /// succeeded, the response was lost, the caller retries. It must get the
+    /// committed receipt, not a second transaction.
+    #[test]
+    fn a_lost_response_retry_returns_the_committed_receipt() {
+        let mut f = fixture();
+
+        let first = bridge(&mut f, &request("mutation-1"), 6_500).unwrap();
+        // A later wall clock, exactly as a real retry would have.
+        let second = bridge(&mut f, &request("mutation-1"), 90_000).unwrap();
+
+        assert_eq!(first, second);
+        assert_eq!(
+            count(&f, "SELECT COUNT(*) FROM library_core_operations;"),
+            2
+        );
+        assert_eq!(
+            count(&f, "SELECT COUNT(*) FROM library_core_replication_outbox;"),
+            2
+        );
+    }
+
+    /// Gap 2: the attempt is durable but the SQLite commit never happened.
+    /// A restart must replay the stored bytes and commit exactly once.
+    #[test]
+    fn a_restart_resumes_a_prepared_attempt_exactly_once() {
+        let mut f = fixture();
+        let envelopes = build_read_transaction(
+            &f.actor,
+            &request("mutation-1").intents,
+            &f.actor_key_pair,
+            6_000,
+        )
+        .unwrap();
+        let (transaction_id, transaction_digest) = transaction_identity(&envelopes).unwrap();
+        f.journal
+            .prepare_read_bridge_attempt(
+                &ReadBridgeAttempt {
+                    attempt_id: "mutation-1".to_string(),
+                    library_id: f.actor.library_id.clone(),
+                    epoch_id: f.actor.epoch_id.clone(),
+                    actor_id: f.actor.actor_id.clone(),
+                    source_storage_generation: 7,
+                    source_save_revision: 11,
+                    source_heads_digest: "a".repeat(64),
+                    actor_sequence: f.actor.next_sequence,
+                    previous_operation_id: f.actor.previous_operation_id.clone(),
+                    previous_chain_digest: f.actor.previous_chain_digest.clone(),
+                    created_at_ms: 6_000,
+                    transaction_id,
+                    transaction_digest,
+                    canonical_envelopes: envelopes,
+                    committed: false,
+                    committed_ingest_sequence: None,
+                },
+                6_100,
+            )
+            .unwrap();
+        assert_eq!(
+            count(&f, "SELECT COUNT(*) FROM library_core_operations;"),
+            0
+        );
+
+        let mut f = f.restart();
+        let receipt = bridge(&mut f, &request("mutation-1"), 7_000).unwrap();
+
+        assert_eq!(receipt.member_count, 2);
+        assert_eq!(
+            count(&f, "SELECT COUNT(*) FROM library_core_operations;"),
+            2
+        );
+        assert_eq!(read_state(&f, "feed-item-a"), Some(5_000));
+
+        // And retrying after the resume is still the same answer.
+        let again = bridge(&mut f, &request("mutation-1"), 8_000).unwrap();
+        assert_eq!(receipt, again);
+        assert_eq!(
+            count(&f, "SELECT COUNT(*) FROM library_core_operations;"),
+            2
+        );
+    }
+
+    /// Gap 1: nothing was recorded, so nothing is owed. The next attempt is
+    /// ordinary new work.
+    #[test]
+    fn a_crash_before_recording_leaves_neither_side_written() {
+        let f = fixture();
+
+        assert_eq!(
+            count(
+                &f,
+                "SELECT COUNT(*) FROM library_core_read_bridge_attempts;"
+            ),
+            0
+        );
+        assert_eq!(
+            count(&f, "SELECT COUNT(*) FROM library_core_operations;"),
+            0
+        );
+
+        let mut f = f.restart();
+        bridge(&mut f, &request("mutation-1"), 6_500).unwrap();
+        assert_eq!(
+            count(&f, "SELECT COUNT(*) FROM library_core_operations;"),
+            2
+        );
+    }
+
+    /// Gap 3: SQLite committed but the attempt was never marked complete.
+    /// The journal's own replay supplies the receipt and the attempt closes.
+    #[test]
+    fn a_committed_transaction_with_an_unfinished_attempt_completes_on_retry() {
+        let mut f = fixture();
+        bridge(&mut f, &request("mutation-1"), 6_500).unwrap();
+
+        // Reopen the gap: the transaction is committed, the attempt is not.
+        f.journal
+            .connection_for_test()
+            .execute(
+                "UPDATE library_core_read_bridge_attempts
+                 SET state = 'prepared', committedAtMs = NULL, committedIngestSequence = NULL;",
+                [],
+            )
+            .unwrap();
+
+        let mut f = f.restart();
+        let receipt = bridge(&mut f, &request("mutation-1"), 9_000).unwrap();
+
+        assert_eq!(receipt.member_count, 2);
+        assert_eq!(
+            count(&f, "SELECT COUNT(*) FROM library_core_operations;"),
+            2
+        );
+        assert_eq!(
+            count(
+                &f,
+                "SELECT COUNT(*) FROM library_core_read_bridge_attempts WHERE state = 'committed';"
+            ),
+            1
+        );
+    }
+
+    /// Two different mutations are two transactions, and the chain continues.
+    #[test]
+    fn separate_mutations_commit_separately_and_extend_the_chain() {
+        let mut f = fixture();
+        let first = bridge(&mut f, &request("mutation-1"), 6_500).unwrap();
+
+        let mut second_request = request("mutation-2");
+        second_request.intents = vec![ReadAssignmentIntent {
+            entity_id: "feed-item-c".to_string(),
+            read_at_ms: 5_500,
+        }];
+        second_request.created_at_ms = 7_000;
+        let second = bridge(&mut f, &second_request, 7_100).unwrap();
+
+        assert_ne!(first.transaction_id, second.transaction_id);
+        assert_eq!(second.first_sequence, 3, "the chain continues, not forks");
+        assert_eq!(
+            count(&f, "SELECT COUNT(*) FROM library_core_operations;"),
+            3
+        );
+    }
+
+    /// One mutation identity naming two different Automerge revisions is two
+    /// facts sharing a name. Replaying the stored bytes would answer the wrong
+    /// question, so it fails closed instead.
+    #[test]
+    fn reusing_an_attempt_id_for_a_different_revision_fails_closed() {
+        let mut f = fixture();
+        bridge(&mut f, &request("mutation-1"), 6_500).unwrap();
+
+        let mut moved = request("mutation-1");
+        moved.source.save_revision = 12;
+        let error = bridge(&mut f, &moved, 7_000).unwrap_err();
+
+        assert!(error.contains("different Automerge revision"), "{error}");
+        assert_eq!(
+            count(&f, "SELECT COUNT(*) FROM library_core_operations;"),
+            2
+        );
+    }
+
+    #[test]
+    fn a_malformed_request_is_refused_before_anything_is_recorded() {
+        let mut f = fixture();
+
+        for broken in [
+            ReadBridgeRequest {
+                attempt_id: String::new(),
+                ..request("x")
+            },
+            ReadBridgeRequest {
+                source: SourceRevision {
+                    heads_digest: "not a digest".to_string(),
+                    ..request("x").source
+                },
+                ..request("x")
+            },
+            ReadBridgeRequest {
+                created_at_ms: -1,
+                ..request("x")
+            },
+        ] {
+            assert!(bridge(&mut f, &broken, 6_500).is_err());
+        }
+
+        assert_eq!(
+            count(
+                &f,
+                "SELECT COUNT(*) FROM library_core_read_bridge_attempts;"
+            ),
+            0
+        );
+        assert_eq!(
+            count(&f, "SELECT COUNT(*) FROM library_core_operations;"),
+            0
+        );
+    }
+
+    /// The stored row must name the transaction the stored bytes contain, or a
+    /// resume could commit one transaction while recording another.
+    #[test]
+    fn the_recorded_identity_matches_the_recorded_bytes() {
+        let mut f = fixture();
+        bridge(&mut f, &request("mutation-1"), 6_500).unwrap();
+
+        let stored = f
+            .journal
+            .read_bridge_attempt("mutation-1")
+            .unwrap()
+            .unwrap();
+        let (transaction_id, transaction_digest) =
+            transaction_identity(&stored.canonical_envelopes).unwrap();
+
+        assert_eq!(stored.transaction_id, transaction_id);
+        assert_eq!(stored.transaction_digest, transaction_digest);
+        assert!(stored.committed);
+    }
+}

--- a/packages/desktop/src-tauri/src/library_core_read_transactions.rs
+++ b/packages/desktop/src-tauri/src/library_core_read_transactions.rs
@@ -1,0 +1,385 @@
+//! Signed read-assignment transactions, produced by this installation's actor.
+//!
+//! The journal has verified and committed read assignments for a while, but
+//! only from envelopes tests hand-built. `verify_and_commit_read_transaction`
+//! had no production caller because nothing could produce a canonical envelope:
+//! it needs an enrolled actor's key, that actor's exact chain tip, per-member
+//! digests, a transaction digest over all of them, and a signature over each
+//! signing body. This produces them.
+//!
+//! Automerge stays authoritative. A committed read assignment here is shadow
+//! state whose disagreement with the document is evidence, not truth. Nothing
+//! reads it, no active engine changes, and no provider traffic is emitted.
+//!
+//! ## Why the envelopes are a pure function of the intent and the tip
+//!
+//! Every field is derived from the items being marked, the actor, and the
+//! actor's current chain tip. Ed25519 is deterministic, so the same intent
+//! against the same tip produces byte-identical envelopes and the same
+//! transaction id. That is what makes retry safe in both directions:
+//!
+//! - A retry after a lost response replays the same transaction id, and the
+//!   journal returns the stored receipt instead of writing again.
+//! - A retry after a crash before the commit rebuilds the same bytes.
+//! - A retry against a tip that has since moved produces a different
+//!   transaction id and commits as new work, rather than colliding with the
+//!   committed one or being silently dropped.
+
+use crate::automerge_external_common::lower_hex;
+use crate::library_core_canonical::{
+    encode_canonical_value, encode_operation_digest_input, encode_operation_signature_input,
+};
+use crate::library_core_journal::ActorState;
+use ring::signature::Ed25519KeyPair;
+use serde_json::{json, Map, Value};
+use sha2::{Digest, Sha256};
+
+const OPERATION_TYPE: &str = "feed_item_read_assignment";
+// The verifier requires exactly this spelling, not the snake_case the
+// operation type uses.
+const ENTITY_TYPE: &str = "FeedItem";
+const SIGNATURE_ALGORITHM: &str = "ed25519";
+const SCHEMA_VERSION: i64 = 1;
+
+/// The journal refuses a transaction with more members than this, and refuses
+/// an empty one.
+const MAX_TRANSACTION_MEMBERS: usize = 1_000;
+const MAX_ENTITY_ID_BYTES: usize = 4_096;
+const MAX_TRANSACTION_BYTES: usize = 4_194_304;
+const MAX_SAFE_INTEGER: i64 = 9_007_199_254_740_991;
+
+/// One item to mark read, and when it was read.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ReadAssignmentIntent {
+    pub(crate) entity_id: String,
+    pub(crate) read_at_ms: i64,
+}
+
+fn invalid(what: &str) -> String {
+    format!("Library Core read transaction {what} is invalid")
+}
+
+fn digest_value(domain: &str, value: &Value) -> Result<String, String> {
+    let input = encode_operation_digest_input(domain, value, MAX_TRANSACTION_BYTES)
+        .map_err(|_| invalid(domain))?;
+    Ok(lower_hex(&Sha256::digest(input)))
+}
+
+fn validate_intents(intents: &[ReadAssignmentIntent]) -> Result<(), String> {
+    if intents.is_empty() || intents.len() > MAX_TRANSACTION_MEMBERS {
+        return Err(invalid("member count"));
+    }
+    for intent in intents {
+        if intent.entity_id.is_empty() || intent.entity_id.len() > MAX_ENTITY_ID_BYTES {
+            return Err(invalid("entity ID"));
+        }
+        if !(0..=MAX_SAFE_INTEGER).contains(&intent.read_at_ms) {
+            return Err(invalid("read time"));
+        }
+    }
+    Ok(())
+}
+
+/// Names the transaction from everything that makes it this transaction.
+///
+/// The actor's tip is part of it, so the same items marked read again after
+/// the actor has written something else are new work with a new id, while a
+/// retry against an unchanged tip replays the committed one.
+fn transaction_id(actor: &ActorState, intents: &[ReadAssignmentIntent]) -> Result<String, String> {
+    let members: Vec<Value> = intents
+        .iter()
+        .map(|intent| {
+            json!({
+                "entity_id": intent.entity_id,
+                "read_at_ms": intent.read_at_ms,
+            })
+        })
+        .collect();
+    let digest = digest_value(
+        "transaction",
+        &json!({
+            "operation_type": OPERATION_TYPE,
+            "library_id": actor.library_id,
+            "epoch_id": actor.epoch_id,
+            "actor_id": actor.actor_id,
+            "actor_sequence": actor.next_sequence,
+            "previous_actor_chain_digest": actor.previous_chain_digest,
+            "members": members,
+        }),
+    )?;
+    Ok(format!("read:{digest}"))
+}
+
+/// The member body, which is every envelope field except the four that depend
+/// on the chain and the signature.
+///
+/// `library_core_journal_operation_verifier` recomputes the member digest by
+/// removing exactly those four keys, so this builds what remains and lets the
+/// caller add them back.
+#[allow(clippy::too_many_arguments)]
+fn member_body(
+    actor: &ActorState,
+    transaction_id: &str,
+    operation_id: &str,
+    previous_actor_operation_id: Option<&str>,
+    index: usize,
+    member_count: usize,
+    intent: &ReadAssignmentIntent,
+    created_at_ms: i64,
+) -> Result<Map<String, Value>, String> {
+    let payload = json!({ "read_at_ms": intent.read_at_ms });
+    let payload_digest = digest_value(
+        "operation-payload",
+        &json!({
+            "schema_version": SCHEMA_VERSION,
+            "operation_type": OPERATION_TYPE,
+            "payload": payload,
+        }),
+    )?;
+    let actor_sequence = actor
+        .next_sequence
+        .checked_add(index as i64)
+        .filter(|value| *value <= MAX_SAFE_INTEGER)
+        .ok_or_else(|| invalid("actor sequence"))?;
+
+    let body = json!({
+        "operation_id": operation_id,
+        "library_id": actor.library_id,
+        "epoch": actor.epoch,
+        "epoch_id": actor.epoch_id,
+        "schema_version": SCHEMA_VERSION,
+        "actor_id": actor.actor_id,
+        "actor_sequence": actor_sequence,
+        "previous_actor_operation_id": previous_actor_operation_id,
+        // This actor is the only writer of its own chain and observes no other
+        // actor yet, so it depends on nothing outside its own sequence. The
+        // journal refuses a tip it has not stored, so claiming one here would
+        // fail closed rather than fabricate history.
+        "causal_frontier": [],
+        // Derived from the intent rather than read from a clock, so a rebuilt
+        // envelope is byte-identical. The journal does not order operations by
+        // this today; when it does, this needs persisted per-actor HLC state.
+        "hlc_wall_ms": intent.read_at_ms,
+        "hlc_counter": index as i64,
+        "transaction_id": transaction_id,
+        "transaction_member_index": index as i64,
+        "transaction_member_count": member_count as i64,
+        "operation_type": OPERATION_TYPE,
+        "entity_type": ENTITY_TYPE,
+        "entity_id": intent.entity_id,
+        "payload": payload,
+        "payload_digest": payload_digest,
+        "blob_references": [],
+        "created_at_ms": created_at_ms,
+        "signature_algorithm": SIGNATURE_ALGORITHM,
+    });
+    body.as_object()
+        .cloned()
+        .ok_or_else(|| invalid("member body"))
+}
+
+/// Build the canonical envelopes for one read-assignment transaction.
+///
+/// Ordered the way the verifier recomputes: member digests first, then the
+/// transaction digest over all of them, then the chain digests in sequence,
+/// then the signature over each completed body.
+pub(crate) fn build_read_transaction(
+    actor: &ActorState,
+    intents: &[ReadAssignmentIntent],
+    actor_key_pair: &Ed25519KeyPair,
+    created_at_ms: i64,
+) -> Result<Vec<Vec<u8>>, String> {
+    validate_intents(intents)?;
+    if !(0..=MAX_SAFE_INTEGER).contains(&created_at_ms) {
+        return Err(invalid("creation time"));
+    }
+
+    let transaction_id = transaction_id(actor, intents)?;
+    let operation_ids: Vec<String> = (0..intents.len())
+        .map(|index| format!("{transaction_id}:{index}"))
+        .collect();
+
+    let mut bodies = Vec::with_capacity(intents.len());
+    let mut member_digests = Vec::with_capacity(intents.len());
+    for (index, intent) in intents.iter().enumerate() {
+        let previous_actor_operation_id = if index == 0 {
+            actor.previous_operation_id.as_deref()
+        } else {
+            Some(operation_ids[index - 1].as_str())
+        };
+        let body = member_body(
+            actor,
+            &transaction_id,
+            &operation_ids[index],
+            previous_actor_operation_id,
+            index,
+            intents.len(),
+            intent,
+            created_at_ms,
+        )?;
+        member_digests.push(Value::String(digest_value(
+            "transaction-member",
+            &Value::Object(body.clone()),
+        )?));
+        bodies.push(body);
+    }
+
+    let transaction_digest = digest_value(
+        "transaction",
+        &json!({
+            "transaction_id": transaction_id,
+            "transaction_member_count": intents.len() as i64,
+            "actor_id": actor.actor_id,
+            "initial_previous_actor_operation_id": actor.previous_operation_id,
+            "initial_previous_actor_chain_digest": actor.previous_chain_digest,
+            "transaction_member_digests": member_digests,
+        }),
+    )?;
+
+    let mut previous_chain_digest = actor.previous_chain_digest.clone();
+    let mut envelopes = Vec::with_capacity(bodies.len());
+    for (index, mut body) in bodies.into_iter().enumerate() {
+        let member_digest = member_digests[index]
+            .as_str()
+            .ok_or_else(|| invalid("member digest"))?;
+        let actor_chain_digest = digest_value(
+            "actor-chain",
+            &json!({
+                "previous_actor_chain_digest": previous_chain_digest,
+                "transaction_member_digest": member_digest,
+                "transaction_digest": transaction_digest,
+            }),
+        )?;
+
+        body.insert(
+            "previous_actor_chain_digest".to_string(),
+            Value::String(previous_chain_digest.clone()),
+        );
+        body.insert(
+            "actor_chain_digest".to_string(),
+            Value::String(actor_chain_digest.clone()),
+        );
+        body.insert(
+            "transaction_digest".to_string(),
+            Value::String(transaction_digest.clone()),
+        );
+
+        let signing_body = Value::Object(body.clone());
+        let signing_body_digest = digest_value("operation-signing-body", &signing_body)?;
+        let signature_input = encode_operation_signature_input(
+            &json!({ "operation_signing_body_digest": signing_body_digest }),
+            MAX_TRANSACTION_BYTES,
+        )
+        .map_err(|_| invalid("signature input"))?;
+        body.insert(
+            "signature".to_string(),
+            Value::String(lower_hex(actor_key_pair.sign(&signature_input).as_ref())),
+        );
+
+        envelopes.push(
+            encode_canonical_value(&Value::Object(body), MAX_TRANSACTION_BYTES)
+                .map_err(|_| invalid("canonical envelope"))?,
+        );
+        previous_chain_digest = actor_chain_digest;
+    }
+
+    Ok(envelopes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ring::signature::KeyPair;
+
+    fn actor() -> ActorState {
+        ActorState {
+            library_id: "a".repeat(64),
+            epoch: 1,
+            epoch_id: "b".repeat(64),
+            actor_id: "c".repeat(64),
+            actor_public_key: lower_hex(actor_key_pair().public_key().as_ref()),
+            enrollment_operation_id: "actor-enrolled:1".to_string(),
+            enrollment_certificate_digest: "d".repeat(64),
+            canonical_enrollment_certificate_json: "{}".to_string(),
+            actor_chain_genesis: "e".repeat(64),
+            next_sequence: 1,
+            previous_operation_id: None,
+            previous_chain_digest: "e".repeat(64),
+        }
+    }
+
+    fn actor_key_pair() -> Ed25519KeyPair {
+        Ed25519KeyPair::from_seed_unchecked(&[11_u8; 32]).unwrap()
+    }
+
+    fn intents() -> Vec<ReadAssignmentIntent> {
+        vec![
+            ReadAssignmentIntent {
+                entity_id: "feed-item-a".to_string(),
+                read_at_ms: 5_000,
+            },
+            ReadAssignmentIntent {
+                entity_id: "feed-item-b".to_string(),
+                read_at_ms: 5_000,
+            },
+        ]
+    }
+
+    /// Nothing in an envelope comes from a live clock or a random source, so
+    /// the same inputs rebuild the same bytes. The bridge stores the bytes
+    /// rather than relying on this, but a builder that was not deterministic
+    /// would make the stored bytes unverifiable against their own inputs.
+    #[test]
+    fn the_same_inputs_build_byte_identical_envelopes() {
+        let first = build_read_transaction(&actor(), &intents(), &actor_key_pair(), 6_000).unwrap();
+        let second =
+            build_read_transaction(&actor(), &intents(), &actor_key_pair(), 6_000).unwrap();
+
+        assert_eq!(first, second);
+        assert_eq!(first.len(), 2);
+    }
+
+    /// Envelope identity includes the actor tip. This is exactly why a retry
+    /// must replay stored bytes: once a commit advances the tip, rebuilding
+    /// produces a different transaction.
+    #[test]
+    fn a_moved_actor_tip_builds_a_different_transaction() {
+        let before =
+            build_read_transaction(&actor(), &intents(), &actor_key_pair(), 6_000).unwrap();
+
+        let advanced = ActorState {
+            next_sequence: 3,
+            previous_operation_id: Some("read:earlier:1".to_string()),
+            previous_chain_digest: "f".repeat(64),
+            ..actor()
+        };
+        let after =
+            build_read_transaction(&advanced, &intents(), &actor_key_pair(), 6_000).unwrap();
+
+        assert_ne!(before, after);
+    }
+
+    /// A different creation time changes signed bytes, which is the other
+    /// reason a rebuilt retry cannot be an exact retry.
+    #[test]
+    fn a_different_creation_time_builds_different_envelopes() {
+        let first = build_read_transaction(&actor(), &intents(), &actor_key_pair(), 6_000).unwrap();
+        let second =
+            build_read_transaction(&actor(), &intents(), &actor_key_pair(), 6_001).unwrap();
+
+        assert_ne!(first, second);
+    }
+
+    #[test]
+    fn an_empty_or_oversized_transaction_is_refused_before_signing() {
+        assert!(build_read_transaction(&actor(), &[], &actor_key_pair(), 6_000).is_err());
+
+        let too_many: Vec<ReadAssignmentIntent> = (0..=MAX_TRANSACTION_MEMBERS)
+            .map(|index| ReadAssignmentIntent {
+                entity_id: format!("feed-item-{index}"),
+                read_at_ms: 5_000,
+            })
+            .collect();
+        assert!(build_read_transaction(&actor(), &too_many, &actor_key_pair(), 6_000).is_err());
+    }
+}

--- a/packages/shared/src/library-core/authoritative-migration-002.sql
+++ b/packages/shared/src/library-core/authoritative-migration-002.sql
@@ -1,0 +1,122 @@
+-- Schema 2: the durable bridge from one exact Automerge commit to SQLite.
+--
+-- Automerge commits, then SQLite commits. Those are two writes and nothing
+-- makes them atomic, so the gap has to be survivable rather than avoided. This
+-- table holds one durable attempt per mutation, recorded before the SQLite
+-- commit is tried, carrying the exact canonical envelope bytes.
+--
+-- Retry replays the stored bytes rather than rebuilding them. Rebuilding is
+-- what makes exact retry impossible: envelope identity includes the actor's
+-- chain tip, a successful commit advances that tip, and a rebuild after the
+-- lost response would therefore produce a different transaction. Storing the
+-- bytes is what makes the operation identity survive its own success.
+--
+-- This is the first migration. Databases created before it hold schema 1 and
+-- reach schema 2 by applying exactly this file, so the reference catalogue is
+-- always the genesis schema plus every migration in order.
+
+CREATE TABLE library_core_read_bridge_attempts (
+  -- The mutation identity the caller is retrying. Supplied by the caller and
+  -- stable across retries; that stability is the whole mechanism.
+  attemptId                 TEXT    NOT NULL PRIMARY KEY CHECK (
+    length(attemptId) BETWEEN 1 AND 128
+  ),
+  libraryId                 TEXT    NOT NULL CHECK (
+    length(libraryId) = 64 AND libraryId NOT GLOB '*[^0-9a-f]*'
+  ),
+  epochId                   TEXT    NOT NULL CHECK (
+    length(epochId) = 64 AND epochId NOT GLOB '*[^0-9a-f]*'
+  ),
+  actorId                   TEXT    NOT NULL CHECK (
+    length(actorId) = 64 AND actorId NOT GLOB '*[^0-9a-f]*'
+  ),
+
+  -- The exact durable Automerge revision this attempt followed. A later
+  -- attempt that names the same mutation against a different revision is a
+  -- different fact and must not silently reuse this one.
+  sourceStorageGeneration   INTEGER NOT NULL CHECK (
+    sourceStorageGeneration BETWEEN 0 AND 9007199254740991
+  ),
+  sourceSaveRevision        INTEGER NOT NULL CHECK (
+    sourceSaveRevision BETWEEN 0 AND 9007199254740991
+  ),
+  sourceHeadsDigest         TEXT    NOT NULL CHECK (
+    length(sourceHeadsDigest) = 64
+    AND sourceHeadsDigest NOT GLOB '*[^0-9a-f]*'
+  ),
+
+  -- The actor tip the stored envelopes were built against. Kept so a resumed
+  -- attempt can be recognised as stale instead of being replayed into a fork.
+  actorSequence             INTEGER NOT NULL CHECK (
+    actorSequence BETWEEN 1 AND 9007199254740991
+  ),
+  previousOperationId       TEXT CHECK (
+    previousOperationId IS NULL
+    OR length(previousOperationId) BETWEEN 1 AND 128
+  ),
+  previousChainDigest       TEXT    NOT NULL CHECK (
+    length(previousChainDigest) = 64
+    AND previousChainDigest NOT GLOB '*[^0-9a-f]*'
+  ),
+
+  -- Inside the signed envelopes, so it is stored rather than re-read from a
+  -- clock. A retry that took a fresh timestamp would change the bytes.
+  createdAtMs               INTEGER NOT NULL CHECK (
+    createdAtMs BETWEEN 0 AND 9007199254740991
+  ),
+
+  transactionId             TEXT    NOT NULL UNIQUE CHECK (
+    length(transactionId) BETWEEN 1 AND 128
+  ),
+  transactionDigest         TEXT    NOT NULL CHECK (
+    length(transactionDigest) = 64
+    AND transactionDigest NOT GLOB '*[^0-9a-f]*'
+  ),
+
+  -- The exact canonical envelope bytes, as a JSON array of strings. Replayed
+  -- verbatim; never regenerated.
+  canonicalEnvelopesJson    TEXT    NOT NULL CHECK (
+    length(canonicalEnvelopesJson) BETWEEN 2 AND 4194304
+    AND json_valid(canonicalEnvelopesJson)
+    AND json_type(canonicalEnvelopesJson) = 'array'
+    AND json_array_length(canonicalEnvelopesJson) BETWEEN 1 AND 1000
+  ),
+  memberCount               INTEGER NOT NULL CHECK (
+    memberCount BETWEEN 1 AND 1000
+  ),
+
+  -- 'prepared' means the bytes are durable and the SQLite commit has not been
+  -- confirmed. 'committed' means the receipt below was read back.
+  state                     TEXT    NOT NULL CHECK (
+    state IN ('prepared', 'committed')
+  ),
+  preparedAtMs              INTEGER NOT NULL CHECK (
+    preparedAtMs BETWEEN 0 AND 9007199254740991
+  ),
+  committedAtMs             INTEGER CHECK (
+    committedAtMs IS NULL
+    OR committedAtMs BETWEEN preparedAtMs AND 9007199254740991
+  ),
+  committedIngestSequence   INTEGER CHECK (
+    committedIngestSequence IS NULL
+    OR committedIngestSequence BETWEEN 1 AND 9007199254740991
+  ),
+
+  -- A committed attempt carries its completion; a prepared one carries none.
+  -- Anything else is a state the resume path would have to guess about.
+  CHECK (
+    (state = 'prepared'
+      AND committedAtMs IS NULL
+      AND committedIngestSequence IS NULL)
+    OR (state = 'committed'
+      AND committedAtMs IS NOT NULL
+      AND committedIngestSequence IS NOT NULL)
+  ),
+  CHECK (json_array_length(canonicalEnvelopesJson) = memberCount)
+) STRICT;
+
+-- Resume scans want the unfinished attempts, oldest first.
+CREATE INDEX library_core_read_bridge_attempts_resume
+  ON library_core_read_bridge_attempts (state, preparedAtMs);
+
+PRAGMA user_version = 2;


### PR DESCRIPTION
(AI Generated).

## The retry design was wrong, and this is why

The parked read-transaction candidate rebuilt the transaction on retry. That cannot work, and the reason is worth stating precisely because it looks fine until you trace it:

Envelope identity includes the actor's chain tip. A successful commit **advances** that tip. So a retry after a lost response rebuilds a *different* transaction against the *new* tip. The journal then sees unfamiliar work rather than a replay — and depending on timing it either commits the same reads twice under new operation IDs, or refuses on a stale tip. Taking a fresh `created_at_ms` breaks it a second way, since that field sits inside the signed body.

The fix is not a relaxed test. The attempt is recorded durably, **with its exact canonical envelope bytes**, *before* the SQLite commit is tried, keyed by a mutation identity the caller keeps stable across retries. Retry replays those bytes verbatim. The operation identity survives its own success.

## The four gaps

| Interruption | Outcome | Test |
| --- | --- | --- |
| Before the attempt is recorded | neither side written; next attempt is ordinary new work | `a_crash_before_recording_leaves_neither_side_written` |
| After recording, before the SQLite commit | stored bytes replayed, commits exactly once | `a_restart_resumes_a_prepared_attempt_exactly_once` |
| After the SQLite commit, before completion | receipt taken from the journal's own transaction replay, attempt closed | `a_committed_transaction_with_an_unfinished_attempt_completes_on_retry` |
| After completion | stored completion returned | `a_lost_response_retry_returns_the_committed_receipt` |

Restart cases genuinely reopen the database rather than reusing the handle.

Reusing one mutation identity for a different Automerge revision or a different actor fails closed — two facts sharing a name would have the stored bytes answer the wrong question.

## A latent defect that would have blocked every future migration

This needed schema 2. Adding it surfaced a real bug: `verify_schema_contract` held an existing database to the **newest** catalogue, so any database written by an older release was rejected before `migrate` could run. Schema 1 databases already exist in the wild from the startup opener, so this was not hypothetical — the first migration ever attempted would have bricked opening.

Verification now holds a database to the catalogue of **the version it claims**, which still rejects a tampered or foreign file. A migrated schema 1 database is required to match a fresh schema 2 database *exactly*, not merely to work. Migrations are now a list rather than a special case, so the next one is one file and one tuple entry.

## Evidence

Mutations, each applied with the application asserted and the run count printed:

| Mutation | Result |
| --- | --- |
| Rebuild on retry instead of replaying stored bytes | caught by 3 crash-gap tests — *this is the previous design* |
| Record the attempt after committing instead of before | caught by 7 tests |
| Stop checking that a reused attempt id names the same revision | caught by `reusing_an_attempt_id_for_a_different_revision_fails_closed` |
| Verify an old database against the newest schema | caught by the migration test — *this is the bug fixed above* |
| Migration never applies | caught by 5 tests |

`cargo test --lib` 468 passed · `cargo fmt --check` clean · `npm run validate:feature` exit 0 · backflow in sync.

## What this does NOT do

**There is no production caller. Operations actually shadow-writing remains zero.** Wiring the worker mark-read path is the next slice, and I am not claiming this reaches it. The handoff asked that the builder not ship alone; it ships here inside the durable bridge that makes its retry semantics correct, with all four crash boundaries proven, which is the real seam. Everything above the seam — the worker call site, single and batched mark-read, corpus parity, memory measurement — is still owed.

Automerge remains authoritative and a SQLite disagreement is evidence, never an override. Native code loads authority and actor state itself and verifies the original canonical bytes; no caller can hand in a pre-verified object. No provider request exists anywhere in this path.

## Provider surface

Two added lines in `lib.rs` declaring modules. Recorded as `diff_authorized` under `library-core-read-bridge-v1`.

## Provider Review
- Status: Provider authority is validated for ready publication.
- Review action: none required. The provider-risk artifact records the behavior authority decision; this exact provider subdiff is the audit subject.
- Provider subdiff: `7b9a96e42566e25574252316101d2eff06e76345`
- Publication does not authorize new live provider traffic. Gate 1 behavior approval still applies when observable behavior changes.
- Provider review task: `library-core-read-bridge-v1`
- Provider review decision: `diff_authorized`
- Provider review artifact: `8a3a03c22d75a812e1a8a0cd300f3315b36d27e0fe68a280115a8b9078a90a87`
- Providers: facebook, instagram, linkedin, medium, other, substack, x, youtube
- Observable behavior: Provider requests, navigation, retries, cadence, cookies, headers, extraction scripts, scrolling, clicking, media loading, and authentication behavior are unchanged. The entire provider-visible diff is two added lines in lib.rs declaring modules. Those modules build signed read-assignment transactions and commit them to the local Library Core SQLite journal. They perform no network activity, touch no WebView, and have no production caller at all in this change.
- Fingerprinting risk: None introduced. Providers receive the same requests with the same timing and content, because nothing in this change contacts a provider or alters any code path that does. Declaring two modules adds no provider-reachable behavior.
- Lowest profile alternative: Already taken: the bridge operates entirely on locally durable state and emits nothing. No provider contact is involved in any variant of this work.

Files bound into this provider review:
- `packages/desktop/src-tauri/src/lib.rs`