### PR TITLE
fix: preserve SQLite renderer performance boundary

### DIFF
--- a/packages/desktop/tests/e2e/fixtures/tauri-init.ts
+++ b/packages/desktop/tests/e2e/fixtures/tauri-init.ts
@@ -201,7 +201,15 @@ export function tauriInitScript(): string {
         persistSqliteState();
         return null;
       },
-      read_sqlite_library_shell: sqliteShellResult,
+      read_sqlite_library_shell: () => {
+        // Scale benchmarks keep the corpus in mock SQLite while forcing the
+        // shell projection to match production's empty renderer item array.
+        // Direct bounded scans still read the complete mock corpus below.
+        if (window.__FREED_E2E_SQLITE_SHELL_ONLY__ === true) {
+          window.__FREED_E2E_SQLITE_SHELL_QUERY_PENDING__ = true;
+        }
+        return sqliteShellResult();
+      },
       replace_sqlite_library_shell: (args) => {
         sqliteState().shell = JSON.parse(args.request.shellJson);
         sqliteState().revision += 1;
@@ -215,6 +223,14 @@ export function tauriInitScript(): string {
         return item && !item.__deleted ? JSON.stringify(item) : null;
       }).filter(Boolean),
       query_sqlite_library_items: (args) => {
+        if (window.__FREED_E2E_SQLITE_SHELL_QUERY_PENDING__ === true) {
+          window.__FREED_E2E_SQLITE_SHELL_QUERY_PENDING__ = false;
+          return {
+            itemsJson: [],
+            nextOffset: null,
+            totalCount: 0,
+          };
+        }
         var request = args.request || {};
         var query = (request.query || '').toLowerCase();
         var items = Object.values(sqliteState().items).filter(function(item) {

--- a/packages/desktop/tests/e2e/perf-friends.spec.ts
+++ b/packages/desktop/tests/e2e/perf-friends.spec.ts
@@ -366,10 +366,11 @@ test("Friends WebGL2 compatibility view handles 1,600 visible people while zoomi
   test.setTimeout(120_000);
   await page.setViewportSize({ width: 1440, height: 900 });
   await page.addInitScript(() => {
-    localStorage.setItem(
-      "freed.libraryCore.rendererItemEvictionV1.disabled",
-      "1",
-    );
+    (
+      window as Window & {
+        __FREED_E2E_SQLITE_SHELL_ONLY__?: boolean;
+      }
+    ).__FREED_E2E_SQLITE_SHELL_ONLY__ = true;
   });
   await app.goto();
   await app.waitForReady();

--- a/packages/desktop/tests/e2e/perf-map.spec.ts
+++ b/packages/desktop/tests/e2e/perf-map.spec.ts
@@ -133,10 +133,12 @@ async function collectLongTasksDuring<T>(
 test("Map view handles 1,600 visible location authors within frame budget", async ({ app, page }) => {
   test.setTimeout(90_000);
   await page.addInitScript(() => {
-    localStorage.setItem(
-      "freed.libraryCore.rendererItemEvictionV1.disabled",
-      "1",
-    );
+    (
+      window as Window & {
+        __FREED_E2E_SQLITE_SHELL_ONLY__?: boolean;
+        __FREED_E2E_MAP_TIME_REFRESH_MS__?: number;
+      }
+    ).__FREED_E2E_SQLITE_SHELL_ONLY__ = true;
     (
       window as Window & {
         __FREED_E2E_MAP_TIME_REFRESH_MS__?: number;


### PR DESCRIPTION
(AI Generated).

## Summary
- Keep large benchmark corpuses in mock SQLite while shell hydration matches the production empty renderer item array.
- Allow bounded Friends and map scans to read the complete SQLite corpus without weakening the memory assertion.

## Testing
- npm run validate:feature