### PR TITLE
fix: restore SQLite migration release build

### DIFF
--- a/packages/desktop/src/lib/automerge.ts
+++ b/packages/desktop/src/lib/automerge.ts
@@ -80,7 +80,6 @@ import {
   type LibraryCoreExternalExportChunkV1,
   type LibraryCoreExternalExportConfirmedV1,
   type LibraryCoreExternalExportStartedV1,
-  type LibraryCoreExternalExportWorkerClient,
 } from "./library-core-external-migration-runtime";
 import {
   materializeDesktopLibraryCoreFeedBrowseGeneration,
@@ -1444,71 +1443,6 @@ async function initializeWorkerDocumentWithDataRecovery(): Promise<DocState> {
     return initializeWorkerDocument();
   }
 }
-
-async function beginLibraryCoreExternalExport(
-  sessionId: string,
-): Promise<LibraryCoreExternalExportStartedV1> {
-  assertAutomergeRequestAccepted("BEGIN_LIBRARY_CORE_EXTERNAL_EXPORT");
-  await ensureWorkerReady();
-  return requestResultOnWorker(
-    getWorker(),
-    pendingLibraryCoreExternalExportStarted,
-    {
-      reqId: nextReqId++,
-      type: "BEGIN_LIBRARY_CORE_EXTERNAL_EXPORT",
-      sessionId,
-    } satisfies WorkerRequest,
-  );
-}
-
-async function readLibraryCoreExternalExport(
-  sessionId: string,
-  offset: number,
-): Promise<LibraryCoreExternalExportChunkV1> {
-  assertAutomergeRequestAccepted("READ_LIBRARY_CORE_EXTERNAL_EXPORT_CHUNK");
-  await ensureWorkerReady();
-  return requestResultOnWorker(
-    getWorker(),
-    pendingLibraryCoreExternalExportChunk,
-    {
-      reqId: nextReqId++,
-      type: "READ_LIBRARY_CORE_EXTERNAL_EXPORT_CHUNK",
-      sessionId,
-      offset,
-    } satisfies WorkerRequest,
-  );
-}
-
-async function confirmLibraryCoreExternalExport(
-  sessionId: string,
-): Promise<LibraryCoreExternalExportConfirmedV1> {
-  assertAutomergeRequestAccepted("CONFIRM_LIBRARY_CORE_EXTERNAL_EXPORT");
-  await ensureWorkerReady();
-  return requestResultOnWorker(
-    getWorker(),
-    pendingLibraryCoreExternalExportConfirmed,
-    {
-      reqId: nextReqId++,
-      type: "CONFIRM_LIBRARY_CORE_EXTERNAL_EXPORT",
-      sessionId,
-    } satisfies WorkerRequest,
-  );
-}
-
-function cancelLibraryCoreExternalExport(sessionId: string): Promise<void> {
-  return request({
-    reqId: nextReqId++,
-    type: "CANCEL_LIBRARY_CORE_EXTERNAL_EXPORT",
-    sessionId,
-  });
-}
-
-const libraryCoreExternalExportWorkerClient: LibraryCoreExternalExportWorkerClient = {
-  begin: beginLibraryCoreExternalExport,
-  read: readLibraryCoreExternalExport,
-  confirm: confirmLibraryCoreExternalExport,
-  cancel: cancelLibraryCoreExternalExport,
-};
 
 export const LIBRARY_CORE_RENDERER_ITEM_EVICTION_DISABLED_KEY =
   "freed.libraryCore.rendererItemEvictionV1.disabled";

--- a/packages/desktop/src/lib/sqlite-library-import.test.ts
+++ b/packages/desktop/src/lib/sqlite-library-import.test.ts
@@ -27,12 +27,18 @@ function stateWithItems(itemCount: number): DocState {
     capturedAt: index,
     author: { id: "author", displayName: "Author", handle: "author" },
     sourceUrl: `https://example.com/${index.toLocaleString("en-US", { useGrouping: false })}`,
-    text: "x".repeat(6_000),
+    content: {
+      text: "x".repeat(6_000),
+      mediaUrls: [],
+      mediaTypes: [],
+    },
+    topics: [],
     userState: {
       hidden: false,
       saved: false,
       archived: false,
       liked: false,
+      tags: [],
     },
   })) as FeedItem[];
   return {
@@ -91,7 +97,10 @@ describe("SQLite legacy import batching", () => {
     const state = stateWithItems(300);
     await importLegacyLibraryIntoSqlite(state, {
       binary: new Uint8Array([1, 2, 3]),
+      heads: ["head-1"],
       revision: { generation: 4, saveRevision: 9 },
+      itemCount: 300,
+      friendCount: 0,
     });
 
     expect(mocks.appendCalls.flat()).toHaveLength(300);


### PR DESCRIPTION
(AI Generated).

## Summary
- 

## Testing
- Not run, no focused validation was recorded.

## Provider Review
- Status: Provider authority is validated for ready publication.
- Review action: none required. The provider-risk artifact records the behavior authority decision; this exact provider subdiff is the audit subject.
- Provider subdiff: `97b91b0e9b191dc7dd2ee8e990029451d705fe3f`
- Publication does not authorize new live provider traffic. Gate 1 behavior approval still applies when observable behavior changes.
- Provider review task: `library-core-desktop-sqlite-migration-v1`
- Provider review decision: `diff_authorized`
- Provider review artifact: `44382b717e0994d6c903eedc95e7e0c20ba2464064e788ce66304fc37616483e`
- Providers: facebook, instagram, linkedin, medium, other, substack, x, youtube
- Observable behavior: Freed Desktop imports the existing local Library into native SQLite through bounded requests, activates SQLite after exact row-count and integrity checks, and stops the one-time Automerge worker. This changes no provider request, navigation, retry, cadence, cookie, header, scrolling, clicking, extraction, media preload, or provider action behavior.
- Fingerprinting risk: No new provider-visible behavior is introduced. The diff touches shared Desktop mutation routing that the classifier conservatively assigns to all providers, but it changes only local migration transport, local SQLite activation, and local worker shutdown.
- Lowest profile alternative: Retain the failed 500-record importer and Automerge fallback. That avoids the local migration change but leaves Freed memory-heavy and prevents the approved SQLite cutover.

Files bound into this provider review:
- `packages/desktop/src/lib/automerge.ts`