### PR TITLE
fix: refresh v26.8.1004-dev release provenance

### DIFF
--- a/release-notes/daily/dev/26.8.10.json
+++ b/release-notes/daily/dev/26.8.10.json
@@ -14,5 +14,5 @@
   "editorialNotes": [
     "Lead with the working SQLite Desktop outcome and restored maps. Omit internal census and contract churn."
   ],
-  "updatedAt": "2026-08-10T22:28:39.277Z"
+  "updatedAt": "2026-08-10T23:07:54.908Z"
 }

--- a/release-notes/releases/v26.8.1004-dev.json
+++ b/release-notes/releases/v26.8.1004-dev.json
@@ -5,14 +5,14 @@
   "dayKey": "26.8.10",
   "approved": true,
   "editorialNotes": [],
-  "generatedAt": "2026-08-10T22:28:39.275Z",
+  "generatedAt": "2026-08-10T23:07:54.906Z",
   "model": "heuristic",
   "source": {
     "channel": "dev",
     "previousPublishedTag": "v26.8.1003-dev",
     "previousPublishedDayTag": "v26.7.3100-dev",
     "compareRef": "HEAD",
-    "productCommitSha": "4ec3565087ffb506482faa44571378234f4f7a9b",
+    "productCommitSha": "34becd54fb12bb0c9165e1d74ca07fab5c10bcd0",
     "promotedDevCommitSha": null,
     "libraryCoreActivation": {
       "schemaVersion": 1,
@@ -21,7 +21,7 @@
         "previousPublishedTag": "v26.8.1003-dev",
         "startMode": "previous_product_commit",
         "fromExclusiveCommitSha": "62c8ddeb327c18ba07c24419d8ff05b0b07a59c6",
-        "toInclusiveProductCommitSha": "4ec3565087ffb506482faa44571378234f4f7a9b"
+        "toInclusiveProductCommitSha": "34becd54fb12bb0c9165e1d74ca07fab5c10bcd0"
       },
       "manifest": {
         "path": "docs/library-core-activation-manifest.json",
@@ -30,7 +30,7 @@
         "currentDigest": "sha256:163fb60ad9ff7c5e27b5b48c06475122235aee37237c2168a14504099bcfb07a"
       },
       "transitions": [],
-      "inspectionDigest": "sha256:3fc00509583b4bd7e2fc5273f76c2753c8df9ef1ac09fe966ffaf4eab0333907",
+      "inspectionDigest": "sha256:23d5c483856764ff0b6b6fca411d098d665990dbf7a52bce2cf3565400f253d1",
       "decision": {
         "state": "no_activation_declared",
         "ownerApprovalReference": null,
@@ -126,9 +126,13 @@
       1388,
       1389,
       1390,
-      1391
+      1391,
+      1392,
+      1393
     ],
     "commitSubjects": [
+      "fix: retire obsolete migration registry key (#1393)",
+      "chore: prepare v26.8.1004-dev (#1392)",
       "fix: restore SQLite migration release build (#1391)",
       "fix: complete bounded SQLite library migration (#1390)",
       "feat: route PWA user state through Library Core (#1389)",
@@ -213,8 +217,8 @@
       "Keep the renderer corpus bounded and stop the legacy Automerge worker after SQLite takes over"
     ],
     "fixes": [
-      "Release build and type-safety cleanup",
       "Reader, feed, and header polish",
+      "Release build and type-safety cleanup",
       "Repair SQLite browser regression boundary",
       "Keep full-library PWA search and reader content off the legacy Automerge worker",
       "The user-visible 24-generation cloud backup mirror",
@@ -236,5 +240,5 @@
       "Give the PWA a complete IndexedDB Library reader and search path, signed read-state intents, and exact single-writer ownership transfer"
     ]
   },
-  "releaseBody": "(AI Generated).\n\n## Freed v26.8.1004-dev\n\nFreed now runs its Library on SQLite in Freed Desktop and IndexedDB in the PWA, with immutable Drive sync and signed mobile actions\n\n### Features\n\n- Keep the renderer corpus bounded and stop the legacy Automerge worker after SQLite takes over\n\n### Fixes\n\n- Release build and type-safety cleanup\n- Reader, feed, and header polish\n- Repair SQLite browser regression boundary\n- Keep full-library PWA search and reader content off the legacy Automerge worker\n- The user-visible 24-generation cloud backup mirror\n- Geographic map backgrounds in Freed Desktop and PWA restored\n- SQLite-backed Desktop previews and durable Friends state across reloads restored\n- Refresh the authenticated immutable checkpoint after accepting PWA intents\n- Scope PWA intents and result heads to the active writer epoch so ownership transfer can safely restart actor sequences\n- Publish explicit PWA acceptance and provider-result receipts\n- Keep twenty-four scrubbed local SQLite backups on a self-rearming daily schedule\n- Enable immutable SQLite Library sync by default with an immediate PWA refresh and one bounded refresh per connected minute\n- Move Freed Desktop Library startup, reads, writes, resets, and daily backups to native SQLite after a verified one-time import\n\n### Follow-ups\n\n- Reader, sidebar, and settings UX work\n- Close the feed item capture and sync receipt inventories\n- Pin the destructive merge guard policy and its blind spots\n- Finish the reviewed replacement-sync activation and retire Automerge\n- Expand PWA intent support beyond read state\n- Give the PWA a complete IndexedDB Library reader and search path, signed read-state intents, and exact single-writer ownership transfer\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+  "releaseBody": "(AI Generated).\n\n## Freed v26.8.1004-dev\n\nFreed now runs its Library on SQLite in Freed Desktop and IndexedDB in the PWA, with immutable Drive sync and signed mobile actions\n\n### Features\n\n- Keep the renderer corpus bounded and stop the legacy Automerge worker after SQLite takes over\n\n### Fixes\n\n- Reader, feed, and header polish\n- Release build and type-safety cleanup\n- Repair SQLite browser regression boundary\n- Keep full-library PWA search and reader content off the legacy Automerge worker\n- The user-visible 24-generation cloud backup mirror\n- Geographic map backgrounds in Freed Desktop and PWA restored\n- SQLite-backed Desktop previews and durable Friends state across reloads restored\n- Refresh the authenticated immutable checkpoint after accepting PWA intents\n- Scope PWA intents and result heads to the active writer epoch so ownership transfer can safely restart actor sequences\n- Publish explicit PWA acceptance and provider-result receipts\n- Keep twenty-four scrubbed local SQLite backups on a self-rearming daily schedule\n- Enable immutable SQLite Library sync by default with an immediate PWA refresh and one bounded refresh per connected minute\n- Move Freed Desktop Library startup, reads, writes, resets, and daily backups to native SQLite after a verified one-time import\n\n### Follow-ups\n\n- Reader, sidebar, and settings UX work\n- Close the feed item capture and sync receipt inventories\n- Pin the destructive merge guard policy and its blind spots\n- Finish the reviewed replacement-sync activation and retire Automerge\n- Expand PWA intent support beyond read state\n- Give the PWA a complete IndexedDB Library reader and search path, signed read-state intents, and exact single-writer ownership transfer\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
 }

--- a/release-notes/releases/v26.8.1004-dev.md
+++ b/release-notes/releases/v26.8.1004-dev.md
@@ -10,8 +10,8 @@ Freed now runs its Library on SQLite in Freed Desktop and IndexedDB in the PWA, 
 
 ### Fixes
 
-- Release build and type-safety cleanup
 - Reader, feed, and header polish
+- Release build and type-safety cleanup
 - Repair SQLite browser regression boundary
 - Keep full-library PWA search and reader content off the legacy Automerge worker
 - The user-visible 24-generation cloud backup mirror


### PR DESCRIPTION
(AI Generated).

## Summary
- 

## Testing
- Not run, no focused validation was recorded.