### PR TITLE
chore: prepare v26.8.1101-dev

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freed/desktop",
   "private": true,
-  "version": "26.8.1100",
+  "version": "26.8.1101",
   "type": "module",
   "scripts": {
     "dev": "node ../../node_modules/vite/bin/vite.js",

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -1443,7 +1443,7 @@ dependencies = [
 
 [[package]]
 name = "freed-desktop"
-version = "26.8.1100"
+version = "26.8.1101"
 dependencies = [
  "base64 0.23.0",
  "criterion",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freed-desktop"
-version = "26.8.1100"
+version = "26.8.1101"
 description = "Freed Desktop - Escape algorithmic manipulation"
 authors = ["Freed"]
 edition = "2021"

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Freed",
-  "version": "26.8.1100",
+  "version": "26.8.1101",
   "identifier": "wtf.freed.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freed/pwa",
   "private": true,
-  "version": "26.8.1100",
+  "version": "26.8.1101",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/release-notes/daily/dev/26.8.11.json
+++ b/release-notes/daily/dev/26.8.11.json
@@ -2,7 +2,7 @@
   "channel": "dev",
   "dayKey": "26.8.11",
   "date": "2026-08-11",
-  "preferredDeck": null,
+  "preferredDeck": "Search the whole Library without loading it into browser memory",
   "editorialGuidance": [
     "Keep the tone concise, professional, and specific.",
     "Lead with user-facing outcomes, shipping milestones, trust wins, and installability improvements.",
@@ -10,5 +10,5 @@
   ],
   "pinnedHighlights": [],
   "editorialNotes": [],
-  "updatedAt": "2026-08-11T20:46:12.825Z"
+  "updatedAt": "2026-08-11T23:22:06.437Z"
 }

--- a/release-notes/releases/v26.8.1101-dev.json
+++ b/release-notes/releases/v26.8.1101-dev.json
@@ -1,0 +1,75 @@
+{
+  "tag": "v26.8.1101-dev",
+  "version": "26.8.1101-dev",
+  "channel": "dev",
+  "dayKey": "26.8.11",
+  "approved": true,
+  "editorialNotes": [],
+  "generatedAt": "2026-08-11T23:22:06.436Z",
+  "model": "heuristic",
+  "source": {
+    "channel": "dev",
+    "previousPublishedTag": "v26.8.1100-dev",
+    "previousPublishedDayTag": "v26.8.1004-dev",
+    "compareRef": "HEAD",
+    "productCommitSha": "ddb7d90fb552532e8c0145e47ddeb09877b94c0e",
+    "promotedDevCommitSha": null,
+    "libraryCoreActivation": {
+      "schemaVersion": 1,
+      "range": {
+        "channel": "dev",
+        "previousPublishedTag": "v26.8.1100-dev",
+        "startMode": "previous_product_commit",
+        "fromExclusiveCommitSha": "d00f3e0b932e00cb72c9f739e602b072a461466d",
+        "toInclusiveProductCommitSha": "ddb7d90fb552532e8c0145e47ddeb09877b94c0e"
+      },
+      "manifest": {
+        "path": "docs/library-core-activation-manifest.json",
+        "previousPresent": true,
+        "previousDigest": "sha256:163fb60ad9ff7c5e27b5b48c06475122235aee37237c2168a14504099bcfb07a",
+        "currentDigest": "sha256:163fb60ad9ff7c5e27b5b48c06475122235aee37237c2168a14504099bcfb07a"
+      },
+      "transitions": [],
+      "inspectionDigest": "sha256:e04f4edcf127809e7bd0b7022fe439b473a45eb92cc8ee0314ffe514ba785f4a",
+      "decision": {
+        "state": "no_activation_declared",
+        "ownerApprovalReference": null,
+        "approvedInspectionDigest": null,
+        "approvedReleaseArtifactDigest": null
+      }
+    },
+    "isLatestOfDay": true,
+    "sameDayTagsIncluded": [
+      "v26.8.1100-dev",
+      "v26.8.1101-dev"
+    ],
+    "relatedBuildTags": [
+      "v26.8.1100-dev",
+      "v26.8.1101-dev"
+    ],
+    "prNumbers": [
+      1395,
+      1396,
+      1397,
+      1398
+    ],
+    "commitSubjects": [
+      "perf: move Desktop library search into SQLite (#1398)",
+      "perf: move PWA library search into IndexedDB (#1397)",
+      "chore: prepare v26.8.1100-dev (#1396)",
+      "fix: preserve Unicode during SQLite import (#1395)"
+    ]
+  },
+  "release": {
+    "deck": "Search the whole Library without loading it into browser memory",
+    "features": [
+      "Freed Desktop now searches the active SQLite Library in bounded native pages instead of rebuilding a full-library search heap in WebKit.",
+      "The PWA now keeps its disposable search index in IndexedDB and streams bounded result pages, so large synchronized libraries stay searchable without living in JavaScript memory."
+    ],
+    "fixes": [
+      "SQLite Library imports now preserve full Unicode text, including flag emoji, so large libraries can finish migrating instead of safely falling back to Automerge."
+    ],
+    "followUps": []
+  },
+  "releaseBody": "(AI Generated).\n\n## Freed v26.8.1101-dev\n\nSearch the whole Library without loading it into browser memory\n\n### Features\n\n- Freed Desktop now searches the active SQLite Library in bounded native pages instead of rebuilding a full-library search heap in WebKit.\n- The PWA now keeps its disposable search index in IndexedDB and streams bounded result pages, so large synchronized libraries stay searchable without living in JavaScript memory.\n\n### Fixes\n\n- SQLite Library imports now preserve full Unicode text, including flag emoji, so large libraries can finish migrating instead of safely falling back to Automerge.\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+}

--- a/release-notes/releases/v26.8.1101-dev.md
+++ b/release-notes/releases/v26.8.1101-dev.md
@@ -1,0 +1,22 @@
+(AI Generated).
+
+## Freed v26.8.1101-dev
+
+Search the whole Library without loading it into browser memory
+
+### Features
+
+- Freed Desktop now searches the active SQLite Library in bounded native pages instead of rebuilding a full-library search heap in WebKit.
+- The PWA now keeps its disposable search index in IndexedDB and streams bounded result pages, so large synchronized libraries stay searchable without living in JavaScript memory.
+
+### Fixes
+
+- SQLite Library imports now preserve full Unicode text, including flag emoji, so large libraries can finish migrating instead of safely falling back to Automerge.
+
+### Downloads
+
+**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  
+**Windows:** `.exe` (NSIS installer)  
+**Linux:** `.AppImage`  
+
+> macOS downloads are signed and notarized for normal Gatekeeper installation.


### PR DESCRIPTION
(AI Generated).

## Summary
- Bumps Freed Desktop and PWA to v26.8.1101-dev from exact dev ddb7d90fb552532e8c0145e47ddeb09877b94c0e.
- Publishes the SQLite and IndexedDB search improvements with the same-day Unicode migration fix carried forward.
- Declares no new Library Core activation transition.

## Testing
- Product validation passed through PWA, Desktop, 462 native tests, and release-note shared tests
- node scripts/validate-release-notes.mjs release-notes/releases/v26.8.1101-dev.json release-notes/releases/v26.8.1100-dev.json
- node scripts/validate-release-identity.mjs --tag=v26.8.1101-dev --head-ref=HEAD