### PR TITLE
fix: reject unsafe entity map keys

### DIFF
--- a/docs/PHASE-1-FOUNDATION.md
+++ b/docs/PHASE-1-FOUNDATION.md
@@ -274,7 +274,7 @@ Production release closeout now also requires a dedicated `main` back into `dev`
 | ---- | -------------------------------------------- | ------ |
 | 1.1  | Initialize monorepo with npm workspaces      | ✓      |
 | 1.2  | Create `@freed/shared` with core types       | ✓      |
-| 1.3  | Implement Automerge document schema          | ✓ (bugfixes: toggleSaved delete, updatePreferences deepMerge) |
+| 1.3  | Implement Automerge document schema          | ✓ (bugfixes: toggleSaved delete, updatePreferences deepMerge, canonical safe object-key admission across entity writers and reconcilers) |
 | 1.4  | Build marketing site (landing, manifesto)    | ✓      |
 | 1.5  | Set up GitHub Actions CI/CD                  | ✓      |
 | 1.6  | Configure custom domain (freed.wtf)          | ✓      |

--- a/packages/shared/src/schema.ts
+++ b/packages/shared/src/schema.ts
@@ -506,6 +506,17 @@ export function migrateLegacyIdentityGraph(doc: FreedDoc): boolean {
  */
 const UNSAFE_OBJECT_KEYS = new Set(["__proto__", "constructor", "prototype"]);
 
+/**
+ * Return whether a dynamic key can be stored safely in a plain object map.
+ *
+ * Freed still materializes several entity collections as ordinary JavaScript
+ * objects. These three property names can mutate or shadow the prototype chain
+ * instead of creating an ordinary entity entry.
+ */
+export function isSafeObjectKey(key: string): boolean {
+  return !UNSAFE_OBJECT_KEYS.has(key);
+}
+
 export function stripUndefined<T>(value: T): T {
   if (Array.isArray(value)) {
     return value.map(stripUndefined) as unknown as T;
@@ -513,7 +524,7 @@ export function stripUndefined<T>(value: T): T {
   if (value !== null && typeof value === "object") {
     const entries: Array<[string, unknown]> = [];
     for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
-      if (v === undefined || UNSAFE_OBJECT_KEYS.has(k)) continue;
+      if (v === undefined || !isSafeObjectKey(k)) continue;
       entries.push([k, stripUndefined(v)]);
     }
     return Object.fromEntries(entries) as T;
@@ -1365,13 +1376,14 @@ export function clearSampleData(doc: FreedDoc): SampleDataClearSummary {
  * @param doc - The Automerge document (mutable within A.change)
  * @param item - The feed item to add
  */
-export function addFeedItem(doc: FreedDoc, item: FeedItem): void {
-  if (UNSAFE_OBJECT_KEYS.has(item.globalId)) return;
+export function addFeedItem(doc: FreedDoc, item: FeedItem): boolean {
+  if (!isSafeObjectKey(item.globalId)) return false;
   const next = stripUndefined(sanitizeFeedItemWrite(item)) as FeedItem;
   if (!hasCurrentContentSignals(next)) {
     applySemanticEnrichmentToItem(next);
   }
   doc.feedItems[item.globalId] = stripUndefined(next);
+  return true;
 }
 
 /**
@@ -1846,8 +1858,10 @@ export function confirmSeenSynced(
  * @param doc - The Automerge document (mutable within A.change)
  * @param feed - The RSS feed to add
  */
-export function addRssFeed(doc: FreedDoc, feed: RssFeed): void {
+export function addRssFeed(doc: FreedDoc, feed: RssFeed): boolean {
+  if (!isSafeObjectKey(feed.url)) return false;
   doc.rssFeeds[feed.url] = stripUndefined(stripDeviceLocalRssFeedState(feed));
+  return true;
 }
 
 /**
@@ -1939,9 +1953,11 @@ export function removeAllFeeds(doc: FreedDoc, includeItems: boolean): void {
  * @param doc - The Automerge document (mutable within A.change)
  * @param friend - The friend to add
  */
-export function addPerson(doc: FreedDoc, person: Person): void {
+export function addPerson(doc: FreedDoc, person: Person): boolean {
+  if (!isSafeObjectKey(person.id)) return false;
   ensureIdentityGraphRoots(doc);
   doc.persons[person.id] = normalizePerson(person);
+  return true;
 }
 
 /**
@@ -2060,10 +2076,11 @@ export function logReachOut(
 // Account Operations
 // =============================================================================
 
-export function addAccount(doc: FreedDoc, account: Account): void {
+export function addAccount(doc: FreedDoc, account: Account): boolean {
+  if (!isSafeObjectKey(account.id)) return false;
   ensureIdentityGraphRoots(doc);
-  if (UNSAFE_OBJECT_KEYS.has(account.id)) return;
   doc.accounts[account.id] = stripUndefined(sanitizeAccountWrite(account)) as Account;
+  return true;
 }
 
 export function addAccounts(doc: FreedDoc, accounts: Account[]): void {
@@ -2249,7 +2266,7 @@ export function reconcileProviderEssayItems(
   }
 
   for (const incoming of items) {
-    if (["__proto__", "constructor", "prototype"].includes(incoming.globalId)) continue;
+    if (!isSafeObjectKey(incoming.globalId)) continue;
     if (incoming.platform !== provider || incoming.contentType !== "article") continue;
     const url = canonicalEssayItemUrl(incoming);
     const exact = doc.feedItems[incoming.globalId] as FeedItem | undefined;
@@ -2314,11 +2331,11 @@ export function reconcileFollowRosterCapture(
   const providerItems = items.filter(
     (item) =>
       item.platform === options.provider &&
-      !["__proto__", "constructor", "prototype"].includes(item.globalId),
+      isSafeObjectKey(item.globalId),
   );
 
   for (const account of accounts) {
-    if (["__proto__", "constructor", "prototype"].includes(account.id)) continue;
+    if (!isSafeObjectKey(account.id)) continue;
     if (account.provider !== options.provider) continue;
     const existing = doc.accounts[account.id];
     if (!existing) {
@@ -2367,7 +2384,7 @@ export function reconcileFollowRosterCapture(
 
   for (const item of providerItems) {
     if (item.contentType === "article") continue;
-    if (["__proto__", "constructor", "prototype"].includes(item.globalId)) continue;
+    if (!isSafeObjectKey(item.globalId)) continue;
     const existing = doc.feedItems[item.globalId];
     if (existing) {
       mergeFeedItemInto(existing, item);
@@ -2403,7 +2420,7 @@ export function reconcileYouTubeCapture(
   const incomingAccountIds = new Set(accounts.map((account) => account.id));
 
   for (const account of accounts) {
-    if (["__proto__", "constructor", "prototype"].includes(account.id)) continue;
+    if (!isSafeObjectKey(account.id)) continue;
     const existing = doc.accounts[account.id];
     if (!existing) {
       addAccount(doc, {
@@ -2441,7 +2458,7 @@ export function reconcileYouTubeCapture(
   }
 
   for (const item of items) {
-    if (["__proto__", "constructor", "prototype"].includes(item.globalId)) continue;
+    if (!isSafeObjectKey(item.globalId)) continue;
     const existing = doc.feedItems[item.globalId];
     if (existing) {
       mergeFeedItemInto(

--- a/packages/shared/src/unsafe-key-guard.test.ts
+++ b/packages/shared/src/unsafe-key-guard.test.ts
@@ -6,6 +6,7 @@ import {
   addFeedItem,
   addPerson,
   addRssFeed,
+  isSafeObjectKey,
 } from "./schema.js";
 import type { FreedDoc } from "./schema.js";
 import type { Account, FeedItem, Person, RssFeed } from "./types.js";
@@ -18,15 +19,9 @@ import type { Account, FeedItem, Person, RssFeed } from "./types.js";
  * identifiers come from provider capture, so these values are influenced from
  * outside the app rather than chosen by it.
  *
- * The codebase agrees this matters and disagrees about how to say so. There is
- * a canonical `UNSAFE_OBJECT_KEYS` set, six inline copies of the same literal
- * array across the reconcilers, a `__proto__`-only check in Facebook group
- * discovery, and two writers with no check at all. Nothing tested any of it.
- *
- * These tests state the behavior as it ships. They are deliberately not a fix:
- * adding a guard to `addPerson` would start rejecting records it accepts today,
- * which is a product decision. See
- * https://github.com/freed-project/freed/issues/1337.
+ * One exported predicate now owns the rule. Every direct entity writer rejects
+ * the same keys and returns whether it accepted the write, so callers can
+ * observe a refused record instead of mistaking a silent drop for success.
  */
 
 const UNSAFE_KEYS = ["__proto__", "constructor", "prototype"] as const;
@@ -82,30 +77,26 @@ const item = (globalId: string): FeedItem =>
     userState: { hidden: false, saved: false, archived: false, tags: [] },
   }) as unknown as FeedItem;
 
-/** Each writer, its collection, and whether the source checks unsafe keys. */
+/** Each writer and its collection. */
 const WRITERS = [
   {
     name: "addFeedItem",
     collection: "feedItems",
-    guarded: true,
     write: (doc: FreedDoc, key: string) => addFeedItem(doc, item(key)),
   },
   {
     name: "addAccount",
     collection: "accounts",
-    guarded: true,
     write: (doc: FreedDoc, key: string) => addAccount(doc, account(key)),
   },
   {
     name: "addPerson",
     collection: "persons",
-    guarded: false,
     write: (doc: FreedDoc, key: string) => addPerson(doc, person(key)),
   },
   {
     name: "addRssFeed",
     collection: "rssFeeds",
-    guarded: false,
     write: (doc: FreedDoc, key: string) => addRssFeed(doc, feed(key)),
   },
 ] as const;
@@ -125,50 +116,41 @@ const storedKeys = (
 };
 
 describe("unsafe map keys in the entity writers", () => {
-  it("covers every writer and both guard states", () => {
-    // Guard the guard. If the table collapsed to one side, the contrast below
-    // would stop being a contrast.
-    expect(WRITERS.filter((writer) => writer.guarded)).toHaveLength(2);
-    expect(WRITERS.filter((writer) => !writer.guarded)).toHaveLength(2);
+  it("owns one canonical key rule", () => {
     expect(UNSAFE_KEYS).toStrictEqual(["__proto__", "constructor", "prototype"]);
+    expect(UNSAFE_KEYS.every((key) => !isSafeObjectKey(key))).toBe(true);
+    expect(isSafeObjectKey("ordinary-id")).toBe(true);
   });
 
   it("never writes a record under __proto__, guarded or not", () => {
-    // Assignment through `__proto__` does not create an own property, so the
-    // record is discarded by every writer. No error is raised, which means a
-    // caller cannot tell the write was dropped.
     for (const writer of WRITERS) {
       expect(storedKeys(writer, "__proto__")).toStrictEqual([]);
     }
   });
 
-  describe.each(WRITERS.filter((writer) => writer.guarded))(
-    "$name checks the key",
+  describe.each(WRITERS)(
+    "$name",
     (writer) => {
-      it.each(["constructor", "prototype"])("refuses %s", (key) => {
+      it.each(UNSAFE_KEYS)("refuses %s observably", (key) => {
+        let accepted = true;
+        const doc = A.change(emptyDoc() as never, (draft: never) => {
+          accepted = writer.write(draft as unknown as FreedDoc, key);
+        });
+        expect(accepted).toBe(false);
         expect(storedKeys(writer, key)).toStrictEqual([]);
+        expect(
+          Object.keys(
+            (doc as unknown as Record<string, Record<string, unknown>>)[writer.collection],
+          ),
+        ).toStrictEqual([]);
       });
 
-      it("still accepts an ordinary identifier", () => {
-        // The positive control. A writer that refused everything would satisfy
-        // the two assertions above without guarding anything.
-        expect(storedKeys(writer, "ordinary-id")).toStrictEqual(["ordinary-id"]);
-      });
-    },
-  );
-
-  describe.each(WRITERS.filter((writer) => !writer.guarded))(
-    "$name does not check the key",
-    (writer) => {
-      it.each(["constructor", "prototype"])("stores a record under %s", (key) => {
-        // Recorded as the shipping behavior, not endorsed. A record living at
-        // `constructor` shadows `Object.prototype.constructor` the moment the
-        // collection is materialized into a plain object, which the SQLite
-        // projection does.
-        expect(storedKeys(writer, key)).toStrictEqual([key]);
-      });
-
-      it("still accepts an ordinary identifier", () => {
+      it("accepts an ordinary identifier observably", () => {
+        let accepted = false;
+        A.change(emptyDoc() as never, (draft: never) => {
+          accepted = writer.write(draft as unknown as FreedDoc, "ordinary-id");
+        });
+        expect(accepted).toBe(true);
         expect(storedKeys(writer, "ordinary-id")).toStrictEqual(["ordinary-id"]);
       });
     },


### PR DESCRIPTION
(AI Generated).

## Summary
- Use one canonical predicate for reserved JavaScript object keys across every shared entity writer and reconciler.
- Return explicit acceptance from direct entity writes so malformed provider-controlled identifiers cannot disappear silently.
- Closes #1337.

## Testing
- npm run validate:feature

## Provider Review
- Status: Provider authority is validated for ready publication.
- Review action: none required. The provider-risk artifact records the behavior authority decision; this exact provider subdiff is the audit subject.
- Provider subdiff: `1a7cd8db37b16a0dd304b9af2d85e53a1f415d01`
- Publication does not authorize new live provider traffic. Gate 1 behavior approval still applies when observable behavior changes.
- Provider review task: `github-issue-1337`
- Provider review decision: `diff_authorized`
- Provider review artifact: `606e578c31bb27bf99d0e84d156c17f79d1b04fe79ff7202ab211f3518751e0e`
- Providers: facebook, instagram, linkedin, medium, other, substack, x, youtube
- Observable behavior: No provider-observable behavior changes. The diff only rejects three reserved JavaScript object keys when captured records are written to local entity maps.
- Fingerprinting risk: None. The diff changes no provider requests, navigation, extraction, timing, cookies, headers, scrolling, clicking, or traffic cadence.
- Lowest profile alternative: Keep provider traffic disabled during validation and inspect only deterministic local fixtures.

Files bound into this provider review:
- `packages/shared/src/schema.ts`