### PR TITLE
chore: prepare v26.8.1102-dev

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freed/desktop",
   "private": true,
-  "version": "26.8.1101",
+  "version": "26.8.1102",
   "type": "module",
   "scripts": {
     "dev": "node ../../node_modules/vite/bin/vite.js",

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -1443,7 +1443,7 @@ dependencies = [
 
 [[package]]
 name = "freed-desktop"
-version = "26.8.1101"
+version = "26.8.1102"
 dependencies = [
  "base64 0.23.0",
  "criterion",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freed-desktop"
-version = "26.8.1101"
+version = "26.8.1102"
 description = "Freed Desktop - Escape algorithmic manipulation"
 authors = ["Freed"]
 edition = "2021"

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Freed",
-  "version": "26.8.1101",
+  "version": "26.8.1102",
   "identifier": "wtf.freed.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freed/pwa",
   "private": true,
-  "version": "26.8.1101",
+  "version": "26.8.1102",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/release-notes/daily/dev/26.8.11.json
+++ b/release-notes/daily/dev/26.8.11.json
@@ -10,5 +10,5 @@
   ],
   "pinnedHighlights": [],
   "editorialNotes": [],
-  "updatedAt": "2026-08-11T23:22:06.437Z"
+  "updatedAt": "2026-08-12T02:08:54.862Z"
 }

--- a/release-notes/releases/v26.8.1102-dev.json
+++ b/release-notes/releases/v26.8.1102-dev.json
@@ -1,0 +1,88 @@
+{
+  "tag": "v26.8.1102-dev",
+  "version": "26.8.1102-dev",
+  "channel": "dev",
+  "dayKey": "26.8.11",
+  "approved": true,
+  "editorialNotes": [],
+  "generatedAt": "2026-08-12T02:08:54.861Z",
+  "model": "heuristic",
+  "source": {
+    "channel": "dev",
+    "previousPublishedTag": "v26.8.1101-dev",
+    "previousPublishedDayTag": "v26.8.1004-dev",
+    "compareRef": "HEAD",
+    "productCommitSha": "7b56fa09a19ed7c1f46917433a42cfa43ac3e8ce",
+    "promotedDevCommitSha": null,
+    "libraryCoreActivation": {
+      "schemaVersion": 1,
+      "range": {
+        "channel": "dev",
+        "previousPublishedTag": "v26.8.1101-dev",
+        "startMode": "previous_product_commit",
+        "fromExclusiveCommitSha": "ddb7d90fb552532e8c0145e47ddeb09877b94c0e",
+        "toInclusiveProductCommitSha": "7b56fa09a19ed7c1f46917433a42cfa43ac3e8ce"
+      },
+      "manifest": {
+        "path": "docs/library-core-activation-manifest.json",
+        "previousPresent": true,
+        "previousDigest": "sha256:163fb60ad9ff7c5e27b5b48c06475122235aee37237c2168a14504099bcfb07a",
+        "currentDigest": "sha256:163fb60ad9ff7c5e27b5b48c06475122235aee37237c2168a14504099bcfb07a"
+      },
+      "transitions": [],
+      "inspectionDigest": "sha256:5e33b8d0d9ad3994415126d566e30b4111703007356682c7b76f36759bc7a5a9",
+      "decision": {
+        "state": "no_activation_declared",
+        "ownerApprovalReference": null,
+        "approvedInspectionDigest": null,
+        "approvedReleaseArtifactDigest": null
+      }
+    },
+    "isLatestOfDay": true,
+    "sameDayTagsIncluded": [
+      "v26.8.1100-dev",
+      "v26.8.1101-dev",
+      "v26.8.1102-dev"
+    ],
+    "relatedBuildTags": [
+      "v26.8.1100-dev",
+      "v26.8.1101-dev",
+      "v26.8.1102-dev"
+    ],
+    "prNumbers": [
+      1395,
+      1396,
+      1397,
+      1398,
+      1400,
+      1401,
+      1402,
+      1403
+    ],
+    "commitSubjects": [
+      "fix: restore Desktop cloud merge type import (#1403)",
+      "perf: keep Automerge dormant in the PWA (#1402)",
+      "fix: reject unsafe entity map keys (#1401)",
+      "perf: index map location candidates (#1400)",
+      "release: v26.8.1101-dev (#1399)",
+      "perf: move Desktop library search into SQLite (#1398)",
+      "perf: move PWA library search into IndexedDB (#1397)",
+      "chore: prepare v26.8.1100-dev (#1396)",
+      "fix: preserve Unicode during SQLite import (#1395)"
+    ]
+  },
+  "release": {
+    "deck": "SQLite keeps the full Library out of browser memory",
+    "features": [
+      "Freed Desktop now searches the active SQLite Library in bounded native pages instead of rebuilding a full-library search heap in WebKit",
+      "The PWA now keeps its disposable search index in IndexedDB and streams bounded result pages, so large synchronized libraries stay searchable without living in JavaScript memory",
+      "The normal PWA startup no longer loads the legacy Automerge worker or its WebAssembly runtime"
+    ],
+    "fixes": [
+      "Reject unsafe entity map keys",
+      "Preserve Unicode during SQLite import"
+    ],
+    "followUps": []
+  },
+  "releaseBody": "(AI Generated).\n\n## Freed v26.8.1102-dev\n\nSQLite keeps the full Library out of browser memory\n\n### Features\n\n- Freed Desktop now searches the active SQLite Library in bounded native pages instead of rebuilding a full-library search heap in WebKit\n- The PWA now keeps its disposable search index in IndexedDB and streams bounded result pages, so large synchronized libraries stay searchable without living in JavaScript memory\n- The normal PWA startup no longer loads the legacy Automerge worker or its WebAssembly runtime\n\n### Fixes\n\n- Reject unsafe entity map keys\n- Preserve Unicode during SQLite import\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+}

--- a/release-notes/releases/v26.8.1102-dev.md
+++ b/release-notes/releases/v26.8.1102-dev.md
@@ -1,0 +1,24 @@
+(AI Generated).
+
+## Freed v26.8.1102-dev
+
+SQLite keeps the full Library out of browser memory
+
+### Features
+
+- Freed Desktop now searches the active SQLite Library in bounded native pages instead of rebuilding a full-library search heap in WebKit
+- The PWA now keeps its disposable search index in IndexedDB and streams bounded result pages, so large synchronized libraries stay searchable without living in JavaScript memory
+- The normal PWA startup no longer loads the legacy Automerge worker or its WebAssembly runtime
+
+### Fixes
+
+- Reject unsafe entity map keys
+- Preserve Unicode during SQLite import
+
+### Downloads
+
+**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  
+**Windows:** `.exe` (NSIS installer)  
+**Linux:** `.AppImage`  
+
+> macOS downloads are signed and notarized for normal Gatekeeper installation.


### PR DESCRIPTION
(AI Generated).

## Summary
- prepare the v26.8.1102-dev Desktop and PWA release from exact dev 7b56fa09
- publish native SQLite and IndexedDB search, map indexing, Unicode migration recovery, unsafe-key hardening, and dormant PWA Automerge startup
- preserve the existing Library Core activation and rollback boundaries

## Testing
- inherited exact-head Validation and CodeQL from PRs #1397, #1398, #1400, #1401, #1402, and #1403
- release PR exact-head Validation and CodeQL required before merge
