### PR TITLE
fix: preserve malformed legacy text during SQLite migration

### DIFF
--- a/packages/desktop/src/lib/sqlite-library-import.test.ts
+++ b/packages/desktop/src/lib/sqlite-library-import.test.ts
@@ -139,4 +139,21 @@ describe("SQLite legacy import batching", () => {
       "Spain 🇪🇸 and Morocco 🇲🇦 with \\x text",
     );
   });
+
+  it("preserves a legacy item while repairing isolated surrogate halves", async () => {
+    const state = stateWithItems(1);
+    state.items[0]!.content.text = "before\ud800after\udc00 🇪🇸";
+
+    await importLegacyLibraryIntoSqlite(state, {
+      binary: new Uint8Array([1, 2, 3]),
+      heads: ["head-1"],
+      revision: { generation: 4, saveRevision: 9 },
+      itemCount: 1,
+      friendCount: 0,
+    });
+
+    expect(JSON.parse(mocks.appendCalls[0]![0]!).content.text).toBe(
+      "before�after� 🇪🇸",
+    );
+  });
 });

--- a/packages/desktop/src/lib/sqlite-library.ts
+++ b/packages/desktop/src/lib/sqlite-library.ts
@@ -158,6 +158,41 @@ interface EncodedImportItem {
   readonly utf8Bytes: number;
 }
 
+function replaceUnpairedSurrogates(value: string): string {
+  let normalized = "";
+  for (let index = 0; index < value.length; index += 1) {
+    const codeUnit = value.charCodeAt(index);
+    if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (next >= 0xdc00 && next <= 0xdfff) {
+        normalized += value[index] + value[index + 1];
+        index += 1;
+      } else {
+        normalized += "\ufffd";
+      }
+    } else if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff) {
+      normalized += "\ufffd";
+    } else {
+      normalized += value[index];
+    }
+  }
+  return normalized;
+}
+
+function normalizeLegacyUnicode(value: unknown): unknown {
+  if (typeof value === "string") return replaceUnpairedSurrogates(value);
+  if (Array.isArray(value)) return value.map(normalizeLegacyUnicode);
+  if (value !== null && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [
+        replaceUnpairedSurrogates(key),
+        normalizeLegacyUnicode(entry),
+      ]),
+    );
+  }
+  return value;
+}
+
 function encodeUtf8Base64(value: string): string {
   const bytes = new TextEncoder().encode(value);
   let binary = "";
@@ -177,7 +212,10 @@ function* legacyImportBatches(
   for (let sourceIndex = 0; sourceIndex < items.length; sourceIndex += 1) {
     const item = items[sourceIndex];
     if (!item) continue;
-    const json = encodeJson(item);
+    // Old provider captures can contain isolated UTF-16 surrogate halves.
+    // JavaScript permits them, but Rust strings and SQLite's UTF-8 boundary do
+    // not. Preserve the record and replace only those invalid scalar values.
+    const json = encodeJson(normalizeLegacyUnicode(item));
     const encoded: EncodedImportItem = {
       globalId: item.globalId,
       json,


### PR DESCRIPTION
(AI Generated).

## Summary
- normalize isolated UTF-16 surrogate halves only at the legacy SQLite migration boundary
- preserve valid Unicode pairs and every remaining field through canonical JSON
- prevent one malformed historical provider record from aborting the complete Library import

## Evidence
- exact installed v26.8.1102-dev failure: item x:2082825977353076848 at source index 625, `unexpected end of hex escape`
- focused migration regression passed
- `npm run validate:feature` passed: 962 Desktop unit tests and 9 Desktop smoke tests

Provider behavior is unchanged. This only repairs local legacy data normalization before native SQLite storage.