### PR TITLE
fix: import actor-bearing SQLite checkpoints

### DIFF
--- a/packages/desktop/src/lib/library-core-cloud-sync.test.ts
+++ b/packages/desktop/src/lib/library-core-cloud-sync.test.ts
@@ -171,7 +171,7 @@ vi.mock("@freed/sync/cloud", async (importOriginal) => {
             field_clocks: 0,
             relationships: 0,
             tombstones: 0,
-            actor_states: 0,
+            actor_states: 1,
             receipt_records: 0,
             blob_roots: 0,
             excluded_registry_keys: 0,
@@ -211,8 +211,22 @@ vi.mock("@freed/sync/cloud", async (importOriginal) => {
             },
           },
         ]);
-        await writer.finalizeImport({ header, manifest: { totalRecordCount: 4 } });
-        return { status: "imported", importedPageCount: 1, importedRecordCount: 4 };
+        await writer.appendPage(1, [{
+          kind: "logical_checkpoint_entry",
+          collection: "actor_states",
+          ordinal: 0,
+          value: {
+            accepted_chain_digest: "45".repeat(32),
+            accepted_operation_id: null,
+            accepted_sequence: 0,
+            actor_id: "12".repeat(32),
+            enrollment_certificate_digest: "44".repeat(32),
+            retired: false,
+            retirement_certificate_digest: null,
+          },
+        }]);
+        await writer.finalizeImport({ header, manifest: { totalRecordCount: 5 } });
+        return { status: "imported", importedPageCount: 1, importedRecordCount: 5 };
       },
     ),
     reassignLibraryCorePortableCheckpointV1: mocks.reassign.mockImplementation(

--- a/packages/desktop/src/lib/library-core-cloud-sync.ts
+++ b/packages/desktop/src/lib/library-core-cloud-sync.ts
@@ -780,6 +780,13 @@ function materializedRow(record: LibraryCorePortableCheckpointRecordV1): {
   readonly row: unknown;
 } | null {
   if (record.kind === "logical_checkpoint_header") return null;
+  // Actor state authenticates the checkpoint and its operation frontier, but
+  // it belongs to the retiring writer epoch. A restored Desktop creates a
+  // fresh epoch and actor after importing the materialized Library, so these
+  // rows must be verified by the portable checkpoint reader and then omitted
+  // from the new local authority instead of making ownership transfer
+  // impossible for every real checkpoint.
+  if (record.collection === "actor_states") return null;
   if (record.collection !== "materialized_rows") {
     throw new Error(
       `SQLite cloud import does not support ${record.collection} checkpoint rows yet`,
@@ -828,7 +835,9 @@ async function bootstrapCloudCheckpointIntoSqlite(input: {
             const header = records[0];
             const unsupportedCount = Object.entries(header.collection_counts)
               .some(([collection, count]) =>
-                collection !== "materialized_rows" && count !== 0,
+                collection !== "materialized_rows"
+                && collection !== "actor_states"
+                && count !== 0,
               );
             if (unsupportedCount) {
               throw new Error("SQLite cloud import contains unsupported Library collections");
@@ -855,6 +864,12 @@ async function bootstrapCloudCheckpointIntoSqlite(input: {
             }
           } else {
             for (const record of records) {
+              if (
+                record.kind === "logical_checkpoint_entry"
+                && record.collection === "actor_states"
+              ) {
+                continue;
+              }
               const row = materializedRow(record);
               if (row === null) {
                 throw new Error("SQLite cloud import repeats its logical header");


### PR DESCRIPTION
(AI Generated).

## Summary
- Allow verified actor-state rows from a retiring writer epoch to pass portable checkpoint import without installing those retired actors into the new local SQLite epoch.

## Testing
- Desktop Library Core cloud sync tests: 5 passed
- npm run validate:feature passed before docs-only dev rebase