### PR TITLE
fix: preserve release publication output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -530,7 +530,7 @@ jobs:
 
   # After all platform builds succeed, promote the draft to a published release
   publish:
-    needs: updater-manifest
+    needs: [updater-manifest, create-release]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/scripts/release-governance.test.mjs
+++ b/scripts/release-governance.test.mjs
@@ -211,6 +211,11 @@ test("draft release assets and publication use the exact release ID", () => {
     publishJob,
     /releases\/\$\{\{ needs\.create-release\.outputs\.release_id \}\}/,
   );
+  assert.match(
+    publishJob,
+    /needs:\s*\[updater-manifest, create-release\]/,
+    "publish must directly depend on create-release before reading its output",
+  );
   assert.doesNotMatch(publishJob, /gh release edit/);
 });
 


### PR DESCRIPTION
(AI Generated).

## Summary
- Make the publish job directly depend on create-release so GitHub exposes the exact release ID.
- Prevent a fully built release from remaining draft after artifact publication succeeds.

## Testing
- PATH=/Users/aubreyfalconer/.nvm/versions/node/v24.14.1/bin:/Users/aubreyfalconer/.local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/opt/local/bin:/opt/local/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/usr/local/MacGPG2/bin:/Applications/VMware Fusion.app/Contents/Public:/usr/local/share/dotnet:~/.dotnet/tools:/usr/local/go/bin:/Library/Frameworks/Mono.framework/Versions/Current/Commands:/Users/aubreyfalconer/.nvm/versions/node/v26.4.0/bin:/Users/aubreyfalconer/.codex/tmp/arg0/codex-arg0f8VfVh:/Users/aubreyfalconer/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/override:/Users/aubreyfalconer/.local/bin:/opt/homebrew/share/google-cloud-sdk/bin:/Users/aubreyfalconer/.rbenv/shims:/opt/homebrew/opt/mysql-client/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/opt/local/bin:/opt/local/sbin:/Users/aubreyfalconer/.cargo/bin:/Users/aubreyfalconer/go/bin:/Users/aubreyfalconer/.cache/lm-studio/bin:/Users/aubreyfalconer/.safe-chain/bin:/Users/aubreyfalconer/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/fallback:/Applications/ChatGPT.app/Contents/Resources:/usr/local/bin npm run validate:feature