### PR TITLE
fix: start SQLite backups without Automerge

### DIFF
--- a/packages/desktop/src/lib/snapshots.test.ts
+++ b/packages/desktop/src/lib/snapshots.test.ts
@@ -46,6 +46,7 @@ vi.mock("./automerge", () => ({
 
 import { exists, readDir, remove, writeFile } from "@tauri-apps/plugin-fs";
 import * as fs from "@tauri-apps/plugin-fs";
+import * as sqliteLibrary from "./sqlite-library";
 import {
   clearSnapshots,
   createSnapshot,
@@ -393,6 +394,38 @@ describe("snapshots", () => {
     const snapshots = await listSnapshots();
     expect(snapshots).toHaveLength(1);
     expect(snapshots[0]?.reason).toBe("auto");
+  });
+
+  it("creates the initial SQLite backup without an Automerge document", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-01T15:00:00Z"));
+    mockDocState.mockReturnValue(null);
+    const listBackups = vi
+      .spyOn(sqliteLibrary, "listSqliteLibraryBackups")
+      .mockResolvedValue([]);
+    const createBackup = vi
+      .spyOn(sqliteLibrary, "createSqliteLibraryBackup")
+      .mockResolvedValue({
+        backupId: "sqlite-initial",
+        byteLength: 4_096,
+        createdAtMs: Date.now(),
+        fileName: "sqlite-initial.sqlite",
+        itemCount: 19_278,
+        reason: "auto",
+        revision: 8,
+        sha256: "ab".repeat(32),
+      });
+    const active = vi
+      .spyOn(sqliteLibrary, "isSqliteLibraryActive")
+      .mockReturnValue(true);
+
+    await startSnapshotManager();
+
+    expect(createBackup).toHaveBeenCalledWith("auto");
+    expect(listBackups).toHaveBeenCalled();
+    active.mockRestore();
+    createBackup.mockRestore();
+    listBackups.mockRestore();
   });
 
   it("keeps one self-rearming daily backup chain while Freed remains open", async () => {

--- a/packages/desktop/src/lib/snapshots.ts
+++ b/packages/desktop/src/lib/snapshots.ts
@@ -291,7 +291,8 @@ async function createSnapshotInternal(
   reason: SnapshotReason = "manual",
 ): Promise<SnapshotSummary | null> {
   const state = getDocState();
-  if (!state) {
+  const sqliteActive = isSqliteLibraryActive();
+  if (!state && !sqliteActive) {
     return null;
   }
 
@@ -301,7 +302,7 @@ async function createSnapshotInternal(
   }
 
   const createdAt = Date.now();
-  if (isSqliteLibraryActive()) {
+  if (sqliteActive) {
     const backup = await createSqliteLibraryBackup(reason);
     const contactSyncState = readContactSyncState();
     const summary: SnapshotSummary = {
@@ -309,7 +310,7 @@ async function createSnapshotInternal(
       createdAt: backup.createdAtMs,
       byteSize: backup.byteLength,
       itemCount: backup.itemCount,
-      friendCount: Object.keys(state.friends ?? {}).length,
+      friendCount: Object.keys(state?.friends ?? {}).length,
       contactCount: contactSyncState.cachedContacts.length,
       pendingMatchCount: contactSyncState.pendingSuggestions.length,
       reason,
@@ -519,7 +520,7 @@ export async function startSnapshotManager(): Promise<void> {
   const existing = await listSnapshots();
   lastSnapshotAt = existing[0]?.createdAt ?? 0;
 
-  if (existing.length === 0 && getDocState()) {
+  if (existing.length === 0 && (isSqliteLibraryActive() || getDocState())) {
     await createSnapshot("auto");
   }
 


### PR DESCRIPTION
(AI Generated).

## Summary
- Create the first automatic SQLite backup even when no legacy Automerge document is resident.
- Keep legacy snapshot behavior unchanged when SQLite is inactive.

## Testing
- npm run validate:feature