### PR TITLE
feat: route PWA preferences through Library Core

### DIFF
--- a/docs/PHASE-4-SYNC.md
+++ b/docs/PHASE-4-SYNC.md
@@ -421,6 +421,7 @@ recovery, telemetry, milestones, and acceptance tests.
 | 4.134 | Signed PWA FeedItem removal intent with immediate IndexedDB and search eviction, native verification, atomic SQLite tombstone, acceptance receipt, and replication outbox | ✓ | High |
 | 4.135 | Signed PWA saved-link capture with immediate IndexedDB and search materialization, native whole-item verification, atomic SQLite upsert, acceptance receipt, and replication outbox | ✓ | High |
 | 4.136 | Signed PWA RSS add, rename, and removal intents with immediate IndexedDB shell materialization, native canonical verification, atomic SQLite shell update, optional item tombstones, acceptance receipt, and replication outbox | ✓ | High |
+| 4.137 | Signed PWA synchronized preference patches with device-local field rejection, immediate IndexedDB shell merge, authenticated replay, and atomic native SQLite shell, journal, acceptance receipt, and replication outbox commit | ✓ | High |
 
 ---
 
@@ -564,6 +565,7 @@ not mean those internal stages remain unreachable.
 - [x] PWA save-link capture now builds one complete saved FeedItem locally without foreground fetching, signs the canonical item into an epoch-scoped capture intent, and immediately exposes it from IndexedDB and local search. Freed Desktop verifies the whole canonical item and identity before atomically upserting SQLite, advancing the journal and actor tip, and recording both replication and Accepted-result outboxes. A prior explicit tombstone cannot be silently resurrected. This adds no social-provider request.
 - [x] PWA archive maintenance no longer wakes Automerge. Repairing saved-and-archived items scans the complete selected IndexedDB generation in bounded pages and emits explicit unarchive assignments. Deleting archived items emits signed removals only for unsaved archived rows, updates the selected IndexedDB materialization and local search, and refreshes the bounded renderer window after the operation completes. Both commands reuse the existing epoch-scoped intent journal and add no social-provider request.
 - [x] PWA RSS feed add, rename, and removal use canonical signed Library Core intents. IndexedDB updates the selected shell immediately, imported operation segments replay the same effect, and Freed Desktop commits the SQLite shell change, optional matching-item tombstones, acceptance receipt, and replication outbox in one transaction. Device-local RSS scheduler fields are rejected from synchronized payloads.
+- [x] PWA synchronized preference changes use one canonical signed patch operation. Device-local and compatibility fields are rejected, IndexedDB applies the recursive patch immediately and on authenticated replay, and Freed Desktop commits the same recursive merge with the journal, acceptance receipt, and replication outbox in one SQLite transaction.
 - [ ] iCloud sync integration
 - [ ] Large media packages transfer outside Automerge through an authenticated,
       resumable, integrity-checked path with explicit storage and deletion rules

--- a/packages/desktop/src-tauri/src/library_core_journal.rs
+++ b/packages/desktop/src-tauri/src/library_core_journal.rs
@@ -324,6 +324,7 @@ struct VerifiedOperation {
     operation_type: String,
     item_json: Option<String>,
     rss_feed_json: Option<String>,
+    preferences_patch_json: Option<String>,
     read_at_ms: Option<i64>,
     assigned: Option<bool>,
     assigned_at_ms: Option<i64>,
@@ -593,6 +594,7 @@ fn validate_transaction(transaction: &VerifiedOperationTransaction) -> JournalRe
                 if member.entity_type != "FeedItem"
                     || member.item_json.is_none()
                     || member.rss_feed_json.is_some()
+                    || member.preferences_patch_json.is_some()
                     || member.read_at_ms.is_some()
                     || member.assigned.is_some()
                     || member.assigned_at_ms.is_some()
@@ -605,6 +607,7 @@ fn validate_transaction(transaction: &VerifiedOperationTransaction) -> JournalRe
                 if member.entity_type != "FeedItem"
                     || member.item_json.is_some()
                     || member.rss_feed_json.is_some()
+                    || member.preferences_patch_json.is_some()
                     || member
                         .read_at_ms
                         .is_none_or(|value| !(0..=MAX_SAFE_INTEGER).contains(&value))
@@ -623,6 +626,7 @@ fn validate_transaction(transaction: &VerifiedOperationTransaction) -> JournalRe
                 if member.entity_type != "FeedItem"
                     || member.item_json.is_some()
                     || member.rss_feed_json.is_some()
+                    || member.preferences_patch_json.is_some()
                     || member.read_at_ms.is_some()
                     || member.assigned.is_none()
                     || member
@@ -639,6 +643,7 @@ fn validate_transaction(transaction: &VerifiedOperationTransaction) -> JournalRe
                 if member.entity_type != "FeedItem"
                     || member.item_json.is_some()
                     || member.rss_feed_json.is_some()
+                    || member.preferences_patch_json.is_some()
                     || member.read_at_ms.is_some()
                     || member.assigned.is_some()
                     || member.assigned_at_ms.is_some()
@@ -655,6 +660,7 @@ fn validate_transaction(transaction: &VerifiedOperationTransaction) -> JournalRe
                 if member.entity_type != "RssFeed"
                     || member.item_json.is_some()
                     || member.rss_feed_json.is_none()
+                    || member.preferences_patch_json.is_some()
                     || member.read_at_ms.is_some()
                     || member.assigned.is_some()
                     || member.assigned_at_ms.is_some()
@@ -669,6 +675,7 @@ fn validate_transaction(transaction: &VerifiedOperationTransaction) -> JournalRe
                 if member.entity_type != "RssFeed"
                     || member.item_json.is_some()
                     || member.rss_feed_json.is_some()
+                    || member.preferences_patch_json.is_some()
                     || member.read_at_ms.is_some()
                     || member.assigned.is_some()
                     || member.assigned_at_ms.is_some()
@@ -678,6 +685,22 @@ fn validate_transaction(transaction: &VerifiedOperationTransaction) -> JournalRe
                 {
                     return Err(JournalError::InvalidVerifiedInput {
                         field: "rss_feed_remove",
+                    });
+                }
+            }
+            "preferences_leaf_assignment" => {
+                if member.entity_type != "UserPreferences"
+                    || member.entity_id != "preferences"
+                    || member.item_json.is_some()
+                    || member.rss_feed_json.is_some()
+                    || member.preferences_patch_json.is_none()
+                    || member.read_at_ms.is_some()
+                    || member.assigned.is_some()
+                    || member.assigned_at_ms.is_some()
+                    || member.removed_at_ms.is_some()
+                {
+                    return Err(JournalError::InvalidVerifiedInput {
+                        field: "preferences_patch_json",
                     });
                 }
             }
@@ -1762,6 +1785,8 @@ impl LibraryCoreJournal {
             )?;
             product_rows_updated += if member.entity_type == "RssFeed" {
                 Self::materialize_rss_feed(&transaction, member, committed_at_ms)?
+            } else if member.entity_type == "UserPreferences" {
+                Self::materialize_preferences(&transaction, member)?
             } else if let Some(item_json) = member.item_json.as_deref() {
                 let deleted_at = transaction
                     .query_row(
@@ -2028,6 +2053,74 @@ impl LibraryCoreJournal {
             0
         };
         Ok(usize::from(shell_changed) + removed_items)
+    }
+
+    fn materialize_preferences(
+        transaction: &Transaction<'_>,
+        member: &VerifiedOperation,
+    ) -> JournalResult<usize> {
+        fn merge(target: &mut Value, patch: &Value) {
+            match (target, patch) {
+                (Value::Object(target), Value::Object(patch)) => {
+                    for (key, value) in patch {
+                        match target.get_mut(key) {
+                            Some(current) => merge(current, value),
+                            None => {
+                                target.insert(key.clone(), value.clone());
+                            }
+                        }
+                    }
+                }
+                (target, patch) => *target = patch.clone(),
+            }
+        }
+
+        let shell_json = transaction
+            .query_row(
+                "SELECT shellJson FROM library_core_desktop_state
+                 WHERE singletonId = 1 AND active = 1;",
+                [],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?
+            .ok_or(JournalError::InvalidVerifiedInput {
+                field: "desktop_library_state",
+            })?;
+        let mut shell: Value =
+            serde_json::from_str(&shell_json).map_err(|_| JournalError::InvalidVerifiedInput {
+                field: "desktop_library_shell",
+            })?;
+        let patch: Value = serde_json::from_str(
+            member
+                .preferences_patch_json
+                .as_deref()
+                .expect("validated preferences patch"),
+        )
+        .map_err(|_| JournalError::InvalidVerifiedInput {
+            field: "preferences_patch_json",
+        })?;
+        let preferences = shell
+            .as_object_mut()
+            .ok_or(JournalError::InvalidVerifiedInput {
+                field: "desktop_library_shell",
+            })?
+            .entry("preferences")
+            .or_insert_with(|| Value::Object(Default::default()));
+        let previous = preferences.clone();
+        merge(preferences, &patch);
+        if *preferences == previous {
+            return Ok(0);
+        }
+        let updated_shell =
+            serde_json::to_string(&shell).map_err(|_| JournalError::InvalidVerifiedInput {
+                field: "desktop_library_shell",
+            })?;
+        transaction.execute(
+            "UPDATE library_core_desktop_state SET shellJson = ?1
+             WHERE singletonId = 1 AND active = 1;",
+            params![updated_shell],
+        )?;
+        Ok(1)
     }
 
     fn intent_results_for_transaction(
@@ -2514,6 +2607,7 @@ mod tests {
                 operation_type: "feed_item_read_assignment".to_string(),
                 item_json: None,
                 rss_feed_json: None,
+                preferences_patch_json: None,
                 read_at_ms: Some(*read_at_ms),
                 assigned: None,
                 assigned_at_ms: None,

--- a/packages/desktop/src-tauri/src/library_core_journal_operation_verifier.rs
+++ b/packages/desktop/src-tauri/src/library_core_journal_operation_verifier.rs
@@ -54,6 +54,7 @@ const CAPTURE_PAYLOAD_KEYS: [&str; 1] = ["item"];
 const ASSIGNMENT_PAYLOAD_KEYS: [&str; 2] = ["assigned", "assigned_at_ms"];
 const REMOVE_PAYLOAD_KEYS: [&str; 1] = ["removed_at_ms"];
 const RSS_FEED_UPSERT_PAYLOAD_KEYS: [&str; 1] = ["feed"];
+const PREFERENCES_PAYLOAD_KEYS: [&str; 1] = ["updates"];
 const RSS_FEED_KEYS: [&str; 10] = [
     "enabled",
     "folder",
@@ -68,6 +69,7 @@ const RSS_FEED_KEYS: [&str; 10] = [
 ];
 const MAX_CAPTURE_ITEM_BYTES: usize = 1_048_576;
 const MAX_RSS_FEED_BYTES: usize = 65_536;
+const MAX_PREFERENCES_PATCH_BYTES: usize = 262_144;
 
 #[derive(Debug, Clone)]
 pub(super) struct OperationIdentity {
@@ -95,6 +97,7 @@ struct ParsedEnvelope {
     operation_type: String,
     item_json: Option<String>,
     rss_feed_json: Option<String>,
+    preferences_patch_json: Option<String>,
     read_at_ms: Option<i64>,
     assigned: Option<bool>,
     assigned_at_ms: Option<i64>,
@@ -155,6 +158,75 @@ fn validate_rss_feed(
         {
             return Err(invalid(index, "feed"));
         }
+    }
+    Ok(())
+}
+
+fn validate_preferences_patch(updates: &Map<String, Value>, index: usize) -> JournalResult<()> {
+    const TOP_LEVEL: [&str; 8] = [
+        "weights",
+        "ulysses",
+        "display",
+        "xCapture",
+        "fbCapture",
+        "friendSuggestions",
+        "ai",
+        "storyWall",
+    ];
+    if updates.is_empty() || updates.keys().any(|key| !TOP_LEVEL.contains(&key.as_str())) {
+        return Err(invalid(index, "preferences_updates"));
+    }
+    let rejects = [
+        (
+            "display",
+            [
+                "itemsPerPage",
+                "compactMode",
+                "themeId",
+                "sidebarWidth",
+                "sidebarMode",
+                "friendsSidebarWidth",
+                "friendsSidebarOpen",
+                "friendsMode",
+                "friendAvatarTint",
+                "debugPanelWidth",
+                "mapMode",
+                "mapTimeMode",
+                "feedSignalMode",
+                "feedSignalModes",
+                "savedContentSortMode",
+            ]
+            .as_slice(),
+        ),
+        ("ai", ["provider", "model", "ollamaUrl"].as_slice()),
+        ("fbCapture", ["knownGroups"].as_slice()),
+    ];
+    for (parent, forbidden) in rejects {
+        if updates
+            .get(parent)
+            .and_then(Value::as_object)
+            .is_some_and(|object| object.keys().any(|key| forbidden.contains(&key.as_str())))
+        {
+            return Err(invalid(index, "preferences_device_local"));
+        }
+    }
+    if updates
+        .get("display")
+        .and_then(Value::as_object)
+        .and_then(|display| display.get("reading"))
+        .and_then(Value::as_object)
+        .is_some_and(|reading| reading.contains_key("dualColumnMode"))
+    {
+        return Err(invalid(index, "preferences_device_local"));
+    }
+    if updates
+        .get("storyWall")
+        .and_then(Value::as_object)
+        .and_then(|story| story.get("publishTarget"))
+        .and_then(Value::as_object)
+        .is_some_and(|target| target.contains_key("lastError") || target.contains_key("status"))
+    {
+        return Err(invalid(index, "preferences_device_local"));
     }
     Ok(())
 }
@@ -328,11 +400,14 @@ fn parse_envelope(bytes: &[u8], index: usize) -> JournalResult<ParsedEnvelope> {
             | "rss_feed_upsert"
             | "rss_feed_remove_keep_items"
             | "rss_feed_remove_with_items"
+            | "preferences_leaf_assignment"
     ) {
         return Err(invalid(index, "operation_type"));
     }
     let entity_type = if operation_type.starts_with("rss_feed_") {
         "RssFeed"
+    } else if operation_type == "preferences_leaf_assignment" {
+        "UserPreferences"
     } else {
         "FeedItem"
     };
@@ -387,106 +462,143 @@ fn parse_envelope(bytes: &[u8], index: usize) -> JournalResult<ParsedEnvelope> {
     let payload = object
         .get("payload")
         .ok_or_else(|| invalid(index, "payload"))?;
-    let (item_json, rss_feed_json, read_at_ms, assigned, assigned_at_ms, removed_at_ms) =
-        match operation_type.as_str() {
-            "feed_item_capture_upsert" => {
-                let payload_object =
-                    exact_object(payload, &CAPTURE_PAYLOAD_KEYS, index, "payload")?;
-                let item = payload_object
-                    .get("item")
-                    .and_then(Value::as_object)
-                    .ok_or_else(|| invalid(index, "item"))?;
-                if item.get("globalId").and_then(Value::as_str) != Some(entity_id.as_str()) {
-                    return Err(invalid(index, "item_identity"));
-                }
-                let canonical_item =
-                    encode_canonical_value(&Value::Object(item.clone()), MAX_CAPTURE_ITEM_BYTES)
-                        .map_err(|_| invalid(index, "item"))?;
-                (
-                    Some(
-                        String::from_utf8(canonical_item)
-                            .expect("canonical encoder always emits UTF-8"),
-                    ),
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                )
+    let (
+        item_json,
+        rss_feed_json,
+        preferences_patch_json,
+        read_at_ms,
+        assigned,
+        assigned_at_ms,
+        removed_at_ms,
+    ) = match operation_type.as_str() {
+        "feed_item_capture_upsert" => {
+            let payload_object = exact_object(payload, &CAPTURE_PAYLOAD_KEYS, index, "payload")?;
+            let item = payload_object
+                .get("item")
+                .and_then(Value::as_object)
+                .ok_or_else(|| invalid(index, "item"))?;
+            if item.get("globalId").and_then(Value::as_str) != Some(entity_id.as_str()) {
+                return Err(invalid(index, "item_identity"));
             }
-            "feed_item_read_assignment" => {
-                let payload_object = exact_object(payload, &READ_PAYLOAD_KEYS, index, "payload")?;
-                (
-                    None,
-                    None,
-                    Some(safe_integer(payload_object, "read_at_ms", index)?),
-                    None,
-                    None,
-                    None,
-                )
+            let canonical_item =
+                encode_canonical_value(&Value::Object(item.clone()), MAX_CAPTURE_ITEM_BYTES)
+                    .map_err(|_| invalid(index, "item"))?;
+            (
+                Some(
+                    String::from_utf8(canonical_item)
+                        .expect("canonical encoder always emits UTF-8"),
+                ),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+        }
+        "feed_item_read_assignment" => {
+            let payload_object = exact_object(payload, &READ_PAYLOAD_KEYS, index, "payload")?;
+            (
+                None,
+                None,
+                None,
+                Some(safe_integer(payload_object, "read_at_ms", index)?),
+                None,
+                None,
+                None,
+            )
+        }
+        "feed_item_saved_assignment"
+        | "feed_item_archive_assignment"
+        | "feed_item_like_assignment" => {
+            let payload_object = exact_object(payload, &ASSIGNMENT_PAYLOAD_KEYS, index, "payload")?;
+            let assigned = payload_object
+                .get("assigned")
+                .and_then(Value::as_bool)
+                .ok_or_else(|| invalid(index, "assigned"))?;
+            (
+                None,
+                None,
+                None,
+                None,
+                Some(assigned),
+                Some(safe_integer(payload_object, "assigned_at_ms", index)?),
+                None,
+            )
+        }
+        "feed_item_remove" => {
+            let payload_object = exact_object(payload, &REMOVE_PAYLOAD_KEYS, index, "payload")?;
+            (
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                Some(safe_integer(payload_object, "removed_at_ms", index)?),
+            )
+        }
+        "rss_feed_upsert" => {
+            let payload_object =
+                exact_object(payload, &RSS_FEED_UPSERT_PAYLOAD_KEYS, index, "payload")?;
+            let feed = payload_object
+                .get("feed")
+                .and_then(Value::as_object)
+                .ok_or_else(|| invalid(index, "feed"))?;
+            validate_rss_feed(feed, &entity_id, index)?;
+            let canonical_feed =
+                encode_canonical_value(&Value::Object(feed.clone()), MAX_RSS_FEED_BYTES)
+                    .map_err(|_| invalid(index, "feed"))?;
+            (
+                None,
+                Some(String::from_utf8(canonical_feed).expect("canonical encoder emits UTF-8")),
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+        }
+        "preferences_leaf_assignment" => {
+            if entity_id != "preferences" {
+                return Err(invalid(index, "preferences_identity"));
             }
-            "feed_item_saved_assignment"
-            | "feed_item_archive_assignment"
-            | "feed_item_like_assignment" => {
-                let payload_object =
-                    exact_object(payload, &ASSIGNMENT_PAYLOAD_KEYS, index, "payload")?;
-                let assigned = payload_object
-                    .get("assigned")
-                    .and_then(Value::as_bool)
-                    .ok_or_else(|| invalid(index, "assigned"))?;
-                (
-                    None,
-                    None,
-                    None,
-                    Some(assigned),
-                    Some(safe_integer(payload_object, "assigned_at_ms", index)?),
-                    None,
-                )
-            }
-            "feed_item_remove" => {
-                let payload_object = exact_object(payload, &REMOVE_PAYLOAD_KEYS, index, "payload")?;
-                (
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    Some(safe_integer(payload_object, "removed_at_ms", index)?),
-                )
-            }
-            "rss_feed_upsert" => {
-                let payload_object =
-                    exact_object(payload, &RSS_FEED_UPSERT_PAYLOAD_KEYS, index, "payload")?;
-                let feed = payload_object
-                    .get("feed")
-                    .and_then(Value::as_object)
-                    .ok_or_else(|| invalid(index, "feed"))?;
-                validate_rss_feed(feed, &entity_id, index)?;
-                let canonical_feed =
-                    encode_canonical_value(&Value::Object(feed.clone()), MAX_RSS_FEED_BYTES)
-                        .map_err(|_| invalid(index, "feed"))?;
-                (
-                    None,
-                    Some(String::from_utf8(canonical_feed).expect("canonical encoder emits UTF-8")),
-                    None,
-                    None,
-                    None,
-                    None,
-                )
-            }
-            "rss_feed_remove_keep_items" | "rss_feed_remove_with_items" => {
-                let payload_object = exact_object(payload, &REMOVE_PAYLOAD_KEYS, index, "payload")?;
-                (
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    Some(safe_integer(payload_object, "removed_at_ms", index)?),
-                )
-            }
-            _ => unreachable!("validated operation type"),
-        };
+            let payload_object =
+                exact_object(payload, &PREFERENCES_PAYLOAD_KEYS, index, "payload")?;
+            let updates = payload_object
+                .get("updates")
+                .and_then(Value::as_object)
+                .ok_or_else(|| invalid(index, "preferences_updates"))?;
+            validate_preferences_patch(updates, index)?;
+            let canonical = encode_canonical_value(
+                &Value::Object(updates.clone()),
+                MAX_PREFERENCES_PATCH_BYTES,
+            )
+            .map_err(|_| invalid(index, "preferences_updates"))?;
+            (
+                None,
+                None,
+                Some(String::from_utf8(canonical).expect("canonical encoder emits UTF-8")),
+                None,
+                None,
+                None,
+                None,
+            )
+        }
+        "rss_feed_remove_keep_items" | "rss_feed_remove_with_items" => {
+            let payload_object = exact_object(payload, &REMOVE_PAYLOAD_KEYS, index, "payload")?;
+            (
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                Some(safe_integer(payload_object, "removed_at_ms", index)?),
+            )
+        }
+        _ => unreachable!("validated operation type"),
+    };
     let payload_digest = required_string(object, "payload_digest", index)?;
     let expected_payload_digest = digest_hex(
         "operation-payload",
@@ -553,6 +665,7 @@ fn parse_envelope(bytes: &[u8], index: usize) -> JournalResult<ParsedEnvelope> {
         operation_type,
         item_json,
         rss_feed_json,
+        preferences_patch_json,
         read_at_ms,
         assigned,
         assigned_at_ms,
@@ -708,6 +821,7 @@ where
             operation_type: member.operation_type.clone(),
             item_json: member.item_json.clone(),
             rss_feed_json: member.rss_feed_json.clone(),
+            preferences_patch_json: member.preferences_patch_json.clone(),
             read_at_ms: member.read_at_ms,
             assigned: member.assigned,
             assigned_at_ms: member.assigned_at_ms,
@@ -798,10 +912,18 @@ mod tests {
                 "rss_feed_remove_keep_items" | "rss_feed_remove_with_items" => {
                     json!({ "removed_at_ms": timestamp_ms })
                 }
+                "preferences_leaf_assignment" => json!({
+                    "updates": {
+                        "display": { "archivePruneDays": 14 },
+                        "ai": { "autoSummarize": true }
+                    }
+                }),
                 _ => panic!("unsupported fixture operation type"),
             };
             let entity_type = if operation_type.starts_with("rss_feed_") {
                 "RssFeed"
+            } else if operation_type == "preferences_leaf_assignment" {
+                "UserPreferences"
             } else {
                 "FeedItem"
             };
@@ -1214,6 +1336,64 @@ mod tests {
             )
             .expect("read removed state");
         assert_eq!(state, (0, 1));
+    }
+
+    #[test]
+    fn verifies_and_materializes_signed_preferences_patch() {
+        let key_pair = Ed25519KeyPair::from_seed_unchecked(&[14_u8; 32]).expect("key pair");
+        let enrollment = enrollment(&key_pair);
+        let envelopes = signed_envelopes_from_tip(
+            &key_pair,
+            &enrollment,
+            "tx:preferences:native-verified",
+            1,
+            None,
+            &enrollment.actor_chain_genesis,
+            &[("preferences", 1_234)],
+            "preferences_leaf_assignment",
+        );
+        let mut journal = LibraryCoreJournal::open_in_memory().expect("open journal");
+        journal
+            .install_fixture_authority(
+                &enrollment.library_id,
+                enrollment.epoch,
+                &enrollment.epoch_id,
+            )
+            .expect("install authority");
+        journal.enroll_actor(&enrollment).expect("enroll actor");
+        journal
+            .connection
+            .execute_batch(&format!(
+                r#"INSERT INTO library_core_desktop_state (
+                   singletonId, active, revision, sourceGeneration,
+                   sourceRevision, sourceDigest, expectedItemCount,
+                   importedItemCount, shellJson, startedAtMs, activatedAtMs
+                 ) VALUES (1, 1, 0, 1, 1, '{}', 0, 0,
+                   '{{"preferences":{{"display":{{"archivePruneDays":30,"showEngagementCounts":false}},"ai":{{"autoSummarize":false,"extractTopics":true}}}}}}',
+                   1, 1);"#,
+                "b".repeat(64)
+            ))
+            .expect("install desktop state");
+
+        journal
+            .verify_and_commit_read_transaction(&envelopes, 1_500)
+            .expect("commit preferences patch");
+        let shell: String = journal
+            .connection
+            .query_row(
+                "SELECT shellJson FROM library_core_desktop_state WHERE singletonId = 1;",
+                [],
+                |row| row.get(0),
+            )
+            .expect("read shell");
+        let shell: Value = serde_json::from_str(&shell).expect("parse shell");
+        assert_eq!(shell["preferences"]["display"]["archivePruneDays"], 14);
+        assert_eq!(
+            shell["preferences"]["display"]["showEngagementCounts"],
+            false
+        );
+        assert_eq!(shell["preferences"]["ai"]["autoSummarize"], true);
+        assert_eq!(shell["preferences"]["ai"]["extractTopics"], true);
     }
 
     #[test]

--- a/packages/pwa/src/lib/library-core-portable-checkpoint-store.ts
+++ b/packages/pwa/src/lib/library-core-portable-checkpoint-store.ts
@@ -19,6 +19,7 @@ import {
   RSS_FEED_REMOVE_KEEP_ITEMS_TRANSACTION_MEMBER_SCHEMA,
   RSS_FEED_REMOVE_WITH_ITEMS_TRANSACTION_MEMBER_SCHEMA,
   RSS_FEED_UPSERT_TRANSACTION_MEMBER_SCHEMA,
+  PREFERENCES_LEAF_ASSIGNMENT_TRANSACTION_MEMBER_SCHEMA,
   finalizeLibraryCoreTransactionV1,
   intentSegmentBodyFromRecordsV1,
   isLibraryCoreFinalizedTransactionV1,
@@ -65,6 +66,7 @@ import {
   type FeedItemUserStateAssignmentTransactionMemberInputV1,
   type RssFeedRemoveTransactionMemberInputV1,
   type RssFeedUpsertTransactionMemberInputV1,
+  type PreferencesLeafAssignmentTransactionMemberInputV1,
   type LibraryCoreImmutableObjectReferenceV1,
   type LibraryCoreIntentHeadV1,
   type LibraryCoreIntentSegmentBodyV1,
@@ -81,7 +83,7 @@ import {
   type LibraryCorePortableCheckpointRecordV1,
   type LibraryCoreResultSegmentHeaderV1,
 } from "@freed/shared/library-core";
-import type { FeedItem, RssFeed } from "@freed/shared";
+import type { FeedItem, RssFeed, UserPreferences } from "@freed/shared";
 import type {
   LibraryCoreOperationSegmentImportReceiptV1,
   LibraryCoreOperationSegmentImportWriterV1,
@@ -185,6 +187,22 @@ function canonicalObject(
     return null;
   }
   return value as Readonly<Record<string, LibraryCoreCanonicalValue>>;
+}
+
+function mergeCanonicalPatch(
+  target: Readonly<Record<string, LibraryCoreCanonicalValue>>,
+  patch: Readonly<Record<string, LibraryCoreCanonicalValue>>,
+): Readonly<Record<string, LibraryCoreCanonicalValue>> {
+  const next: Record<string, LibraryCoreCanonicalValue> = { ...target };
+  for (const [key, value] of Object.entries(patch)) {
+    const nestedPatch = canonicalObject(value);
+    const nestedTarget = canonicalObject(next[key]);
+    next[key] =
+      nestedPatch && nestedTarget
+        ? mergeCanonicalPatch(nestedTarget, nestedPatch)
+        : value;
+  }
+  return next;
 }
 
 interface PortableActorTipRecord {
@@ -2611,6 +2629,34 @@ class PwaLibraryCorePortableCheckpointStore
             }
           }
         } else if (
+          member.envelope.operation_type === "preferences_leaf_assignment"
+        ) {
+          const shellKey = [
+            generation.generationId,
+            "00_library_shell",
+            canonicalStringKey("shell"),
+          ];
+          const shell = (await requestResult(
+            materializedRows.get(shellKey),
+          )) as PortableMaterializedRowRecord | undefined;
+          if (!shell) {
+            transaction.abort();
+            throw new Error(
+              "authenticated preferences patch has no materialized Library shell",
+            );
+          }
+          const preferences = canonicalObject(shell.row.preferences) ?? {};
+          materializedRows.put({
+            ...shell,
+            row: {
+              ...shell.row,
+              preferences: mergeCanonicalPatch(
+                preferences,
+                member.envelope.payload.updates,
+              ),
+            },
+          } satisfies PortableMaterializedRowRecord);
+        } else if (
           storedRow &&
           (member.envelope.operation_type === "feed_item_saved_assignment" ||
             member.envelope.operation_type === "feed_item_archive_assignment" ||
@@ -3036,6 +3082,111 @@ class PwaLibraryCorePortableCheckpointStore
     const receipt = await this.enqueueIntentTransaction(finalized);
     await this.#applySelectedRssFeedRemove(input.url, input.includeItems);
     return receipt;
+  }
+
+  async enqueuePreferencesLeafAssignment(
+    updates: Partial<UserPreferences>,
+  ): Promise<PwaLibraryCoreIntentEnqueueReceiptV1> {
+    const context = await this.#activeIntentContext();
+    const actorSequence =
+      context.intentActor?.nextIntentSequence ??
+      context.actorTip.acceptedSequence + 1;
+    const previousOperationId =
+      context.intentActor?.latestOperationId ??
+      context.actorTip.acceptedOperationId;
+    const previousChainDigest =
+      context.intentActor?.latestActorChainDigest ??
+      context.actorTip.acceptedChainDigest;
+    const createdAtMs = this.#now();
+    const transactionId =
+      `pwa-preferences:${crypto.randomUUID()}` as LibraryCoreOperationInstanceId;
+    const member = PREFERENCES_LEAF_ASSIGNMENT_TRANSACTION_MEMBER_SCHEMA.construct(
+      {
+        operation_id: `${transactionId}:0`,
+        library_id: context.authority.library_id,
+        epoch: context.authority.epoch,
+        epoch_id: context.authority.epoch_id,
+        actor_id: context.identity.actorId,
+        actor_sequence: actorSequence,
+        previous_actor_operation_id: previousOperationId,
+        causal_frontier: context.authority.observed_frontier,
+        hlc_wall_ms: createdAtMs,
+        hlc_counter: 0,
+        transaction_id: transactionId,
+        transaction_member_index: 0,
+        transaction_member_count: 1,
+        entity_id: "preferences",
+        payload: {
+          updates: updates as unknown as Record<
+            string,
+            LibraryCoreCanonicalValue
+          >,
+        },
+        created_at_ms: createdAtMs,
+      } satisfies PreferencesLeafAssignmentTransactionMemberInputV1,
+      { digest: libraryCoreDigest },
+    );
+    const finalized = await finalizeLibraryCoreTransactionV1(
+      assembleLibraryCoreTransactionV1([member], previousChainDigest, {
+        digest: libraryCoreDigest,
+      }),
+      {
+        digest: libraryCoreDigest,
+        signOperation: async (message) =>
+          lowerHex(
+            await this.#subtle.sign(
+              { name: "Ed25519" },
+              context.identity.actorPrivateKey,
+              exactArrayBuffer(message),
+            ),
+          ) as LibraryCoreEd25519SignatureHex,
+      },
+    );
+    const receipt = await this.enqueueIntentTransaction(finalized);
+    await this.#applySelectedPreferencesPatch(
+      updates as unknown as Readonly<
+        Record<string, LibraryCoreCanonicalValue>
+      >,
+    );
+    return receipt;
+  }
+
+  async #applySelectedPreferencesPatch(
+    updates: Readonly<Record<string, LibraryCoreCanonicalValue>>,
+  ): Promise<void> {
+    const database = await this.#database();
+    const transaction = database.transaction(
+      [CONTROL_STORE, MATERIALIZED_ROWS_STORE],
+      "readwrite",
+    );
+    const selected = (await requestResult(
+      transaction.objectStore(CONTROL_STORE).get(SELECTED_GENERATION_KEY),
+    )) as SelectedPortableGenerationRecord | undefined;
+    if (!selected) {
+      transaction.abort();
+      throw new Error("PWA preferences intent has no selected Library generation");
+    }
+    const rows = transaction.objectStore(MATERIALIZED_ROWS_STORE);
+    const key = [
+      selected.generationId,
+      "00_library_shell",
+      canonicalStringKey("shell"),
+    ];
+    const stored = (await requestResult(rows.get(key))) as
+      PortableMaterializedRowRecord | undefined;
+    if (!stored) {
+      transaction.abort();
+      throw new Error("PWA preferences intent has no materialized Library shell");
+    }
+    const preferences = canonicalObject(stored.row.preferences) ?? {};
+    rows.put({
+      ...stored,
+      row: {
+        ...stored.row,
+        preferences: mergeCanonicalPatch(preferences, updates),
+      },
+    } satisfies PortableMaterializedRowRecord);
+    await transactionDone(transaction);
   }
 
   async #applySelectedRssFeedUpsert(feed: RssFeed): Promise<void> {

--- a/packages/pwa/src/lib/library-core-runtime.test.ts
+++ b/packages/pwa/src/lib/library-core-runtime.test.ts
@@ -1,10 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createDefaultPreferences } from "@freed/shared";
 
 const mocks = vi.hoisted(() => ({
   enqueueReadAssignments: vi.fn(),
   enqueueFeedItemRemove: vi.fn(),
   enqueueRssFeedRemove: vi.fn(),
   enqueueRssFeedUpsert: vi.fn(),
+  enqueuePreferencesLeafAssignment: vi.fn(),
   enqueueUserStateAssignments: vi.fn(),
   readSelectedCollectionPage: vi.fn(),
   readSelectedMaterializedRow: vi.fn(),
@@ -16,6 +18,7 @@ vi.mock("./library-core-portable-checkpoint-store", () => ({
     enqueueFeedItemRemove: mocks.enqueueFeedItemRemove,
     enqueueRssFeedRemove: mocks.enqueueRssFeedRemove,
     enqueueRssFeedUpsert: mocks.enqueueRssFeedUpsert,
+    enqueuePreferencesLeafAssignment: mocks.enqueuePreferencesLeafAssignment,
     enqueueUserStateAssignments: mocks.enqueueUserStateAssignments,
     readSelectedCollectionPage: mocks.readSelectedCollectionPage,
     readSelectedMaterializedRow: mocks.readSelectedMaterializedRow,
@@ -37,6 +40,7 @@ import {
   enqueuePwaLibraryCoreFeedItemRemove,
   enqueuePwaLibraryCoreRssFeedRemove,
   enqueuePwaLibraryCoreRssFeedUpsert,
+  enqueuePwaLibraryCorePreferencesPatch,
   enqueuePwaLibraryCoreUnarchiveSavedItems,
   readPwaLibraryCoreItemDetail,
   scanPwaLibraryCoreItems,
@@ -61,6 +65,7 @@ describe("PWA Library Core bounded scanner", () => {
     mocks.enqueueFeedItemRemove.mockReset();
     mocks.enqueueRssFeedRemove.mockReset();
     mocks.enqueueRssFeedUpsert.mockReset();
+    mocks.enqueuePreferencesLeafAssignment.mockReset();
   });
 
   it("uses IndexedDB Library Core by default with an explicit local rollback", () => {
@@ -329,5 +334,22 @@ describe("PWA Library Core bounded scanner", () => {
       removedAtMs: expect.any(Number),
       url: feed.url,
     });
+  });
+
+  it("routes synchronized preferences through a signed Library Core patch", async () => {
+    mocks.enqueuePreferencesLeafAssignment.mockResolvedValue({
+      operationId: "op:preferences",
+    });
+    mocks.readSelectedMaterializedRow.mockResolvedValue(null);
+    const update = {
+      display: {
+        ...createDefaultPreferences().display,
+        archivePruneDays: 14,
+      },
+    };
+
+    await enqueuePwaLibraryCorePreferencesPatch(update);
+
+    expect(mocks.enqueuePreferencesLeafAssignment).toHaveBeenCalledWith(update);
   });
 });

--- a/packages/pwa/src/lib/library-core-runtime.ts
+++ b/packages/pwa/src/lib/library-core-runtime.ts
@@ -6,6 +6,7 @@ import {
   type FeedItem,
   type Person,
   type RssFeed,
+  type UserPreferences,
 } from "@freed/shared";
 import {
   LIBRARY_CORE_FEED_PAGE_DEFAULT_LIMIT,
@@ -430,6 +431,15 @@ export async function enqueuePwaLibraryCoreRssFeedRemove(
     removedAtMs: Date.now(),
     url,
   });
+  const state = await readSelectedState();
+  if (state) publishState(state);
+}
+
+/** Queue one synchronized preference patch and update the selected shell. */
+export async function enqueuePwaLibraryCorePreferencesPatch(
+  updates: Partial<UserPreferences>,
+): Promise<void> {
+  await getPortableStore().enqueuePreferencesLeafAssignment(updates);
   const state = await readSelectedState();
   if (state) publishState(state);
 }

--- a/packages/pwa/src/lib/store.ts
+++ b/packages/pwa/src/lib/store.ts
@@ -116,6 +116,7 @@ import {
   enqueuePwaLibraryCoreFeedItemRemove,
   enqueuePwaLibraryCoreRssFeedRemove,
   enqueuePwaLibraryCoreRssFeedUpsert,
+  enqueuePwaLibraryCorePreferencesPatch,
   enqueuePwaLibraryCoreMarkAllAsRead,
   enqueuePwaLibraryCoreReadAssignments,
   enqueuePwaLibraryCoreUnarchiveSavedItems,
@@ -1009,6 +1010,17 @@ export const useAppStore = create<AppState>((set, get) => ({
     }
     const syncedUpdate = stripDeviceLocalPreferenceUpdates(update);
     if (Object.keys(syncedUpdate).length === 0) return;
+    if (isPwaLibraryCoreEnabled()) {
+      await runOptimisticMutation(
+        get,
+        set,
+        "pwa:updatePreferences",
+        (state) => projectUpdatePreferences(state, syncedUpdate),
+        () => enqueuePwaLibraryCorePreferencesPatch(syncedUpdate),
+        { allowLibraryCoreIntent: true },
+      );
+      return;
+    }
     await runOptimisticMutation(
       get,
       set,

--- a/packages/shared/src/library-core/operation-envelope-contracts.ts
+++ b/packages/shared/src/library-core/operation-envelope-contracts.ts
@@ -8,9 +8,11 @@ import {
   RSS_FEED_REMOVE_KEEP_ITEMS_PAYLOAD_SCHEMA,
   RSS_FEED_REMOVE_WITH_ITEMS_PAYLOAD_SCHEMA,
   RSS_FEED_UPSERT_PAYLOAD_SCHEMA,
+  PREFERENCES_LEAF_ASSIGNMENT_PAYLOAD_SCHEMA,
   type FeedItemCaptureUpsertPayloadV1,
   type FeedItemUserStateAssignmentOperationTypeV1,
   type RssFeedUpsertPayloadV1,
+  type PreferencesLeafAssignmentPayloadV1,
 } from "./operation-payload-contracts.js";
 import {
   isLibraryCoreEntityId,
@@ -59,6 +61,8 @@ export type FeedItemRemoveTransactionMemberInputV1 =
 export type RssFeedUpsertTransactionMemberInputV1 =
   FeedItemReadAssignmentTransactionMemberInputV1;
 export type RssFeedRemoveTransactionMemberInputV1 =
+  FeedItemReadAssignmentTransactionMemberInputV1;
+export type PreferencesLeafAssignmentTransactionMemberInputV1 =
   FeedItemReadAssignmentTransactionMemberInputV1;
 
 export interface FeedItemReadAssignmentTransactionMemberBodyV1 {
@@ -215,13 +219,39 @@ export interface RssFeedRemoveTransactionMemberBodyV1 {
   readonly signature_algorithm: "ed25519";
 }
 
+export interface PreferencesLeafAssignmentTransactionMemberBodyV1 {
+  readonly operation_id: LibraryCoreOperationInstanceId;
+  readonly library_id: LibraryCoreLowercaseHex64;
+  readonly epoch: number;
+  readonly epoch_id: LibraryCoreLowercaseHex64;
+  readonly schema_version: 1;
+  readonly actor_id: LibraryCoreLowercaseHex64;
+  readonly actor_sequence: number;
+  readonly previous_actor_operation_id: LibraryCoreOperationInstanceId | null;
+  readonly causal_frontier: readonly LibraryCoreCausalTipV1[];
+  readonly hlc_wall_ms: number;
+  readonly hlc_counter: number;
+  readonly transaction_id: LibraryCoreOperationInstanceId;
+  readonly transaction_member_index: number;
+  readonly transaction_member_count: number;
+  readonly operation_type: "preferences_leaf_assignment";
+  readonly entity_type: "UserPreferences";
+  readonly entity_id: LibraryCoreEntityId;
+  readonly payload: PreferencesLeafAssignmentPayloadV1;
+  readonly payload_digest: LibraryCoreLowercaseHex64;
+  readonly blob_references: readonly [];
+  readonly created_at_ms: number;
+  readonly signature_algorithm: "ed25519";
+}
+
 export type LibraryCoreTransactionMemberBodyV1 =
   | FeedItemCaptureUpsertTransactionMemberBodyV1
   | FeedItemReadAssignmentTransactionMemberBodyV1
   | FeedItemUserStateAssignmentTransactionMemberBodyV1
   | FeedItemRemoveTransactionMemberBodyV1
   | RssFeedUpsertTransactionMemberBodyV1
-  | RssFeedRemoveTransactionMemberBodyV1;
+  | RssFeedRemoveTransactionMemberBodyV1
+  | PreferencesLeafAssignmentTransactionMemberBodyV1;
 
 export interface LibraryCoreTransactionMemberConstruction<
   Body = LibraryCoreTransactionMemberBodyV1,
@@ -540,6 +570,11 @@ function constructEntityTransactionMember(
           "rss_feed_remove_keep_items" | "rss_feed_remove_with_items";
         readonly validatePayload: typeof RSS_FEED_REMOVE_KEEP_ITEMS_PAYLOAD_SCHEMA.validate;
         readonly entityType: "RssFeed";
+      }
+    | {
+        readonly operationType: "preferences_leaf_assignment";
+        readonly validatePayload: typeof PREFERENCES_LEAF_ASSIGNMENT_PAYLOAD_SCHEMA.validate;
+        readonly entityType: "UserPreferences";
       },
 ): LibraryCoreTransactionMemberConstruction {
   const digestValue = dependencies.digest;
@@ -775,6 +810,17 @@ function constructRssFeedRemoveTransactionMember(
   }) as LibraryCoreTransactionMemberConstruction<RssFeedRemoveTransactionMemberBodyV1>;
 }
 
+function constructPreferencesLeafAssignmentTransactionMember(
+  input: PreferencesLeafAssignmentTransactionMemberInputV1,
+  dependencies: LibraryCoreOperationDigestDependencies,
+): LibraryCoreTransactionMemberConstruction<PreferencesLeafAssignmentTransactionMemberBodyV1> {
+  return constructEntityTransactionMember(input, dependencies, {
+    operationType: "preferences_leaf_assignment",
+    validatePayload: PREFERENCES_LEAF_ASSIGNMENT_PAYLOAD_SCHEMA.validate,
+    entityType: "UserPreferences",
+  }) as LibraryCoreTransactionMemberConstruction<PreferencesLeafAssignmentTransactionMemberBodyV1>;
+}
+
 /**
  * Closed construction schema for the first dormant Library Core operation.
  *
@@ -886,3 +932,16 @@ export const RSS_FEED_REMOVE_KEEP_ITEMS_TRANSACTION_MEMBER_SCHEMA =
   rssFeedRemoveTransactionMemberSchema("rss_feed_remove_keep_items");
 export const RSS_FEED_REMOVE_WITH_ITEMS_TRANSACTION_MEMBER_SCHEMA =
   rssFeedRemoveTransactionMemberSchema("rss_feed_remove_with_items");
+
+export const PREFERENCES_LEAF_ASSIGNMENT_TRANSACTION_MEMBER_SCHEMA =
+  Object.freeze({
+    schemaId: "preferences_leaf_assignment_transaction_member_v1",
+    schemaVersion: 1,
+    operationType: "preferences_leaf_assignment",
+    entityType: "UserPreferences",
+    maximumCausalFrontierTips: LIBRARY_CORE_MAX_CAUSAL_FRONTIER_TIPS,
+    construct: constructPreferencesLeafAssignmentTransactionMember,
+  }) satisfies LibraryCoreTransactionMemberSchema<
+    PreferencesLeafAssignmentTransactionMemberInputV1,
+    PreferencesLeafAssignmentTransactionMemberBodyV1
+  >;

--- a/packages/shared/src/library-core/operation-envelope-finalization.ts
+++ b/packages/shared/src/library-core/operation-envelope-finalization.ts
@@ -17,6 +17,7 @@ import {
   type FeedItemUserStateAssignmentSigningBodyV1,
   type RssFeedRemoveSigningBodyV1,
   type RssFeedUpsertSigningBodyV1,
+  type PreferencesLeafAssignmentSigningBodyV1,
   type LibraryCoreOperationSigningBodyV1,
   type LibraryCoreAssembledTransactionV1,
   type LibraryCoreTransactionBodyV1,
@@ -51,13 +52,18 @@ export interface RssFeedRemoveEnvelopeV1 extends RssFeedRemoveSigningBodyV1 {
   readonly signature: LibraryCoreEd25519SignatureHex;
 }
 
+export interface PreferencesLeafAssignmentEnvelopeV1 extends PreferencesLeafAssignmentSigningBodyV1 {
+  readonly signature: LibraryCoreEd25519SignatureHex;
+}
+
 export type LibraryCoreOperationEnvelopeV1 =
   | FeedItemCaptureUpsertEnvelopeV1
   | FeedItemReadAssignmentEnvelopeV1
   | FeedItemUserStateAssignmentEnvelopeV1
   | FeedItemRemoveEnvelopeV1
   | RssFeedUpsertEnvelopeV1
-  | RssFeedRemoveEnvelopeV1;
+  | RssFeedRemoveEnvelopeV1
+  | PreferencesLeafAssignmentEnvelopeV1;
 
 export interface LibraryCoreFinalizedEnvelopeV1 {
   readonly envelope: LibraryCoreOperationEnvelopeV1;

--- a/packages/shared/src/library-core/operation-envelope-verification.ts
+++ b/packages/shared/src/library-core/operation-envelope-verification.ts
@@ -14,6 +14,7 @@ import {
   RSS_FEED_REMOVE_KEEP_ITEMS_TRANSACTION_MEMBER_SCHEMA,
   RSS_FEED_REMOVE_WITH_ITEMS_TRANSACTION_MEMBER_SCHEMA,
   RSS_FEED_UPSERT_TRANSACTION_MEMBER_SCHEMA,
+  PREFERENCES_LEAF_ASSIGNMENT_TRANSACTION_MEMBER_SCHEMA,
   type FeedItemReadAssignmentTransactionMemberInputV1,
   type LibraryCoreConstructionDigestDomain,
 } from "./operation-envelope-contracts.js";
@@ -426,6 +427,9 @@ export async function verifyLibraryCoreOperationTransactionV1(
                       ? RSS_FEED_REMOVE_KEEP_ITEMS_TRANSACTION_MEMBER_SCHEMA
                       : envelope.operation_type === "rss_feed_remove_with_items"
                         ? RSS_FEED_REMOVE_WITH_ITEMS_TRANSACTION_MEMBER_SCHEMA
+                        : envelope.operation_type ===
+                            "preferences_leaf_assignment"
+                          ? PREFERENCES_LEAF_ASSIGNMENT_TRANSACTION_MEMBER_SCHEMA
                         : null;
     if (schema === null) {
       throw new TypeError(

--- a/packages/shared/src/library-core/operation-payload-contracts.test.ts
+++ b/packages/shared/src/library-core/operation-payload-contracts.test.ts
@@ -5,6 +5,7 @@ import {
   FEED_ITEM_READ_ASSIGNMENT_PAYLOAD_SCHEMA,
   RSS_FEED_REMOVE_WITH_ITEMS_PAYLOAD_SCHEMA,
   RSS_FEED_UPSERT_PAYLOAD_SCHEMA,
+  PREFERENCES_LEAF_ASSIGNMENT_PAYLOAD_SCHEMA,
 } from "./operation-payload-contracts.js";
 
 describe("Library Core operation payload contracts", () => {
@@ -128,5 +129,28 @@ describe("Library Core operation payload contracts", () => {
         include_items: true,
       }),
     ).toMatchObject({ ok: false, code: "invalid" });
+  });
+
+  it("accepts synchronized preference patches and rejects device-local leaves", () => {
+    const accepted = PREFERENCES_LEAF_ASSIGNMENT_PAYLOAD_SCHEMA.validate({
+        updates: {
+          display: { archivePruneDays: 14 },
+          ai: { autoSummarize: true },
+        },
+      });
+    expect(accepted, accepted.ok ? undefined : accepted.reason).toMatchObject({ ok: true });
+    for (const updates of [
+      {},
+      { sync: { autoBackup: true } },
+      { display: { themeId: "dark-star" } },
+      { display: { reading: { dualColumnMode: true } } },
+      { ai: { ollamaUrl: "http://localhost:11434" } },
+      { fbCapture: { knownGroups: {} } },
+      { storyWall: { publishTarget: { lastError: "nope" } } },
+    ]) {
+      expect(
+        PREFERENCES_LEAF_ASSIGNMENT_PAYLOAD_SCHEMA.validate({ updates }),
+      ).toMatchObject({ ok: false, code: "invalid" });
+    }
   });
 });

--- a/packages/shared/src/library-core/operation-payload-contracts.ts
+++ b/packages/shared/src/library-core/operation-payload-contracts.ts
@@ -4,9 +4,12 @@ import {
   type LibraryCoreCanonicalValue,
 } from "./canonical-codec.js";
 import { isLibraryCoreNonnegativeSafeInteger } from "./protocol-scalars.js";
+import { stripDeviceLocalPreferenceUpdates } from "../preferences.js";
+import type { UserPreferences } from "../types.js";
 
 const FEED_ITEM_CAPTURE_MAXIMUM_BYTES = 1_048_576;
 const RSS_FEED_UPSERT_MAXIMUM_BYTES = 65_536;
+const PREFERENCES_PATCH_MAXIMUM_BYTES = 262_144;
 
 export interface FeedItemCaptureUpsertPayloadV1 {
   readonly item: Readonly<Record<string, LibraryCoreCanonicalValue>>;
@@ -26,6 +29,10 @@ export interface RssFeedUpsertPayloadV1 {
 
 export interface RssFeedRemovePayloadV1 {
   readonly removed_at_ms: number;
+}
+
+export interface PreferencesLeafAssignmentPayloadV1 {
+  readonly updates: Readonly<Record<string, LibraryCoreCanonicalValue>>;
 }
 
 export const FEED_ITEM_USER_STATE_ASSIGNMENT_FIELDS = Object.freeze([
@@ -76,6 +83,7 @@ const FEED_ITEM_CAPTURE_UPSERT_KEYS = ["item"] as const;
 const FEED_ITEM_REMOVE_KEYS = ["removed_at_ms"] as const;
 const RSS_FEED_UPSERT_KEYS = ["feed"] as const;
 const RSS_FEED_REMOVE_KEYS = ["removed_at_ms"] as const;
+const PREFERENCES_LEAF_ASSIGNMENT_KEYS = ["updates"] as const;
 const USER_STATE_ASSIGNMENT_KEYS = ["assigned", "assigned_at_ms"] as const;
 
 const RSS_FEED_KEYS = Object.freeze([
@@ -346,6 +354,78 @@ function validateRssFeedRemovePayload(
   return { ok: true, value: Object.freeze({ removed_at_ms: removedAt.value }) };
 }
 
+function validatePreferencesLeafAssignmentPayload(
+  value: unknown,
+): LibraryCorePayloadValidationResult<PreferencesLeafAssignmentPayloadV1> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return invalid("payload must be a plain object");
+  }
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) {
+    return invalid("payload must be a plain object");
+  }
+  if (Object.getOwnPropertySymbols(value).length !== 0) {
+    return invalid("payload may not contain symbol keys");
+  }
+  const keys = Object.getOwnPropertyNames(value);
+  if (
+    keys.length !== 1 ||
+    keys[0] !== PREFERENCES_LEAF_ASSIGNMENT_KEYS[0]
+  ) {
+    return invalid("payload must contain only updates");
+  }
+  const descriptor = Object.getOwnPropertyDescriptor(value, "updates");
+  if (
+    descriptor === undefined ||
+    !descriptor.enumerable ||
+    !("value" in descriptor) ||
+    typeof descriptor.value !== "object" ||
+    descriptor.value === null ||
+    Array.isArray(descriptor.value)
+  ) {
+    return invalid("updates must be a plain canonical object");
+  }
+  try {
+    const encoded = encodeLibraryCoreCanonicalValue(
+      descriptor.value as LibraryCoreCanonicalValue,
+      { maximumBytes: PREFERENCES_PATCH_MAXIMUM_BYTES },
+    );
+    const updates = decodeLibraryCoreCanonicalValue(encoded, {
+      maximumBytes: PREFERENCES_PATCH_MAXIMUM_BYTES,
+    });
+    if (typeof updates !== "object" || updates === null || Array.isArray(updates)) {
+      return invalid("updates must be a plain canonical object");
+    }
+    if (Object.keys(updates).length === 0) {
+      return invalid("updates must not be empty");
+    }
+    const synchronized = stripDeviceLocalPreferenceUpdates(
+      updates as Partial<UserPreferences>,
+    ) as unknown as LibraryCoreCanonicalValue;
+    const synchronizedBytes = encodeLibraryCoreCanonicalValue(synchronized, {
+      maximumBytes: PREFERENCES_PATCH_MAXIMUM_BYTES,
+    });
+    if (
+      synchronizedBytes.byteLength !== encoded.byteLength ||
+      synchronizedBytes.some((byte, index) => byte !== encoded[index])
+    ) {
+      return invalid("updates contain device-local or compatibility fields");
+    }
+    return {
+      ok: true,
+      value: Object.freeze({
+        updates: updates as Readonly<
+          Record<string, LibraryCoreCanonicalValue>
+        >,
+      }),
+    };
+  } catch (error) {
+    return invalid(
+      error instanceof Error ? error.message : "updates are not canonical",
+    );
+  }
+}
+
 function validateFeedItemUserStateAssignmentPayload(
   value: unknown,
 ): LibraryCorePayloadValidationResult<FeedItemUserStateAssignmentPayloadV1> {
@@ -457,6 +537,17 @@ export const RSS_FEED_REMOVE_KEEP_ITEMS_PAYLOAD_SCHEMA =
   rssFeedRemovePayloadSchema("rss_feed_remove_keep_items");
 export const RSS_FEED_REMOVE_WITH_ITEMS_PAYLOAD_SCHEMA =
   rssFeedRemovePayloadSchema("rss_feed_remove_with_items");
+
+export const PREFERENCES_LEAF_ASSIGNMENT_PAYLOAD_SCHEMA = Object.freeze({
+  schemaId: "preferences_leaf_assignment_payload_v1",
+  schemaVersion: 1,
+  operationType: "preferences_leaf_assignment",
+  canonicalKeys: PREFERENCES_LEAF_ASSIGNMENT_KEYS,
+  validate: validatePreferencesLeafAssignmentPayload,
+}) satisfies LibraryCoreOperationPayloadSchema<
+  "preferences_leaf_assignment",
+  PreferencesLeafAssignmentPayloadV1
+>;
 
 /** Closed payload for idempotent local PWA user-state assignments. */
 function userStateAssignmentPayloadSchema(

--- a/packages/shared/src/library-core/operation-registry.ts
+++ b/packages/shared/src/library-core/operation-registry.ts
@@ -14,6 +14,7 @@ import {
   RSS_FEED_REMOVE_KEEP_ITEMS_PAYLOAD_SCHEMA,
   RSS_FEED_REMOVE_WITH_ITEMS_PAYLOAD_SCHEMA,
   RSS_FEED_UPSERT_PAYLOAD_SCHEMA,
+  PREFERENCES_LEAF_ASSIGNMENT_PAYLOAD_SCHEMA,
   type LibraryCoreOperationPayloadSchema,
 } from "./operation-payload-contracts.js";
 import {
@@ -43,6 +44,7 @@ import {
   RSS_FEED_REMOVE_KEEP_ITEMS_TRANSACTION_MEMBER_SCHEMA,
   RSS_FEED_REMOVE_WITH_ITEMS_TRANSACTION_MEMBER_SCHEMA,
   RSS_FEED_UPSERT_TRANSACTION_MEMBER_SCHEMA,
+  PREFERENCES_LEAF_ASSIGNMENT_TRANSACTION_MEMBER_SCHEMA,
   type LibraryCoreTransactionMemberSchemaDescriptor,
 } from "./operation-envelope-contracts.js";
 import type { LibraryCoreEntity } from "./protocol-registry.js";
@@ -535,6 +537,9 @@ export const LIBRARY_CORE_OPERATION_REGISTRY = {
     // Declaring one would claim a key space this operation does not have.
     touchedFieldRegistryKeys:
       PREFERENCES_LEAF_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS,
+    payloadSchema: PREFERENCES_LEAF_ASSIGNMENT_PAYLOAD_SCHEMA,
+    transactionMemberSchema:
+      PREFERENCES_LEAF_ASSIGNMENT_TRANSACTION_MEMBER_SCHEMA,
     candidateStoreSurfaces: ["updatePreferences"],
     legacyWorkerRequests: ["UPDATE_PREFERENCES"],
   }),

--- a/packages/shared/src/library-core/operation-transaction-contracts.ts
+++ b/packages/shared/src/library-core/operation-transaction-contracts.ts
@@ -14,6 +14,7 @@ import type {
   FeedItemUserStateAssignmentTransactionMemberBodyV1,
   RssFeedRemoveTransactionMemberBodyV1,
   RssFeedUpsertTransactionMemberBodyV1,
+  PreferencesLeafAssignmentTransactionMemberBodyV1,
   LibraryCoreOperationDigestDependencies,
   LibraryCoreTransactionMemberConstruction,
 } from "./operation-envelope-contracts.js";
@@ -66,13 +67,20 @@ export interface RssFeedRemoveSigningBodyV1 extends RssFeedRemoveTransactionMemb
   readonly transaction_digest: LibraryCoreLowercaseHex64;
 }
 
+export interface PreferencesLeafAssignmentSigningBodyV1 extends PreferencesLeafAssignmentTransactionMemberBodyV1 {
+  readonly previous_actor_chain_digest: LibraryCoreLowercaseHex64;
+  readonly actor_chain_digest: LibraryCoreLowercaseHex64;
+  readonly transaction_digest: LibraryCoreLowercaseHex64;
+}
+
 export type LibraryCoreOperationSigningBodyV1 =
   | FeedItemCaptureUpsertSigningBodyV1
   | FeedItemReadAssignmentSigningBodyV1
   | FeedItemUserStateAssignmentSigningBodyV1
   | FeedItemRemoveSigningBodyV1
   | RssFeedUpsertSigningBodyV1
-  | RssFeedRemoveSigningBodyV1;
+  | RssFeedRemoveSigningBodyV1
+  | PreferencesLeafAssignmentSigningBodyV1;
 
 export interface LibraryCoreSigningMemberV1 {
   readonly member_digest: LibraryCoreLowercaseHex64;

--- a/packages/shared/src/library-core/registry.test.ts
+++ b/packages/shared/src/library-core/registry.test.ts
@@ -76,6 +76,7 @@ import {
   RSS_FEED_REMOVE_KEEP_ITEMS_TRANSACTION_MEMBER_SCHEMA,
   RSS_FEED_REMOVE_WITH_ITEMS_TRANSACTION_MEMBER_SCHEMA,
   RSS_FEED_UPSERT_TRANSACTION_MEMBER_SCHEMA,
+  PREFERENCES_LEAF_ASSIGNMENT_TRANSACTION_MEMBER_SCHEMA,
 } from "./operation-envelope-contracts.js";
 import {
   FEED_ITEM_CAPTURE_UPSERT_PAYLOAD_SCHEMA,
@@ -84,6 +85,7 @@ import {
   RSS_FEED_REMOVE_KEEP_ITEMS_PAYLOAD_SCHEMA,
   RSS_FEED_REMOVE_WITH_ITEMS_PAYLOAD_SCHEMA,
   RSS_FEED_UPSERT_PAYLOAD_SCHEMA,
+  PREFERENCES_LEAF_ASSIGNMENT_PAYLOAD_SCHEMA,
 } from "./operation-payload-contracts.js";
 import { FEED_ITEM_READ_ASSIGNMENT_MATERIALIZER } from "./operation-materializer-contracts.js";
 import {
@@ -200,8 +202,11 @@ const CLOSED_OPERATION_CONTRACTS: Partial<
   // and so may write any synchronized preference leaf. No entityIdCodec:
   // preferences are a singleton root with no per-entity key.
   preferences_leaf_assignment: {
+    payloadSchema: PREFERENCES_LEAF_ASSIGNMENT_PAYLOAD_SCHEMA,
     touchedFieldRegistryKeys:
       PREFERENCES_LEAF_ASSIGNMENT_TOUCHED_FIELD_REGISTRY_KEYS,
+    transactionMemberSchema:
+      PREFERENCES_LEAF_ASSIGNMENT_TRANSACTION_MEMBER_SCHEMA,
   },
   // Traced from `renameFeed`, which sends only `{ title }`. No entityIdCodec:
   // feeds are keyed by url, not by the globalId space the codec was justified


### PR DESCRIPTION
(AI Generated).

## Summary
- Sign synchronized PWA preference patches and apply them immediately to the selected IndexedDB Library shell.
- Verify and materialize the same authenticated patch atomically with the native SQLite journal, acceptance receipt, and replication outbox.
- Reject device-local and compatibility preference leaves from synchronized operations.

## Testing
- npm run validate:feature

## Provider Review
- Status: Provider authority is validated for ready publication.
- Review action: none required. The provider-risk artifact records the behavior authority decision; this exact provider subdiff is the audit subject.
- Provider subdiff: `85defa27b3ba059056c7bcb95ff0597656afafa1`
- Publication does not authorize new live provider traffic. Gate 1 behavior approval still applies when observable behavior changes.
- Provider review task: `pwa-library-preferences`
- Provider review decision: `diff_authorized`
- Provider review artifact: `c8acf990528d279a1379dcfc7538ce7652c0c56e1e86d21272b0696254796c7f`
- Providers: other
- Observable behavior: Provider requests, navigation, timing, retries, cookies, headers, extraction, login, and background activity remain unchanged. The classified PWA store path only routes synchronized preference state through signed Library Core intent and local materialization paths.
- Fingerprinting risk: None added. No provider receives any new or changed contact from this diff.
- Lowest profile alternative: Keep all provider contact disabled while validating the local intent, IndexedDB, and SQLite paths.

Files bound into this provider review:
- `packages/pwa/src/lib/store.ts`