### PR TITLE
chore: prepare v26.8.1300-dev

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freed/desktop",
   "private": true,
-  "version": "26.8.1203",
+  "version": "26.8.1300",
   "type": "module",
   "scripts": {
     "dev": "node ../../node_modules/vite/bin/vite.js",

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -1443,7 +1443,7 @@ dependencies = [
 
 [[package]]
 name = "freed-desktop"
-version = "26.8.1203"
+version = "26.8.1300"
 dependencies = [
  "base64 0.23.0",
  "criterion",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freed-desktop"
-version = "26.8.1203"
+version = "26.8.1300"
 description = "Freed Desktop - Escape algorithmic manipulation"
 authors = ["Freed"]
 edition = "2021"

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Freed",
-  "version": "26.8.1203",
+  "version": "26.8.1300",
   "identifier": "wtf.freed.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freed/pwa",
   "private": true,
-  "version": "26.8.1203",
+  "version": "26.8.1300",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/release-notes/daily/dev/26.8.13.json
+++ b/release-notes/daily/dev/26.8.13.json
@@ -1,0 +1,14 @@
+{
+  "channel": "dev",
+  "dayKey": "26.8.13",
+  "date": "2026-08-13",
+  "preferredDeck": null,
+  "editorialGuidance": [
+    "Keep the tone concise, professional, and specific.",
+    "Lead with user-facing outcomes, shipping milestones, trust wins, and installability improvements.",
+    "Demote internal cleanup unless it clearly changes the shipped product."
+  ],
+  "pinnedHighlights": [],
+  "editorialNotes": [],
+  "updatedAt": "2026-08-13T17:34:03.837Z"
+}

--- a/release-notes/releases/v26.8.1300-dev.json
+++ b/release-notes/releases/v26.8.1300-dev.json
@@ -1,0 +1,118 @@
+{
+  "tag": "v26.8.1300-dev",
+  "version": "26.8.1300-dev",
+  "channel": "dev",
+  "dayKey": "26.8.13",
+  "approved": false,
+  "editorialNotes": [],
+  "generatedAt": "2026-08-13T17:34:03.837Z",
+  "model": "heuristic",
+  "source": {
+    "channel": "dev",
+    "previousPublishedTag": "v26.8.1203-dev",
+    "previousPublishedDayTag": "v26.8.1203-dev",
+    "compareRef": "HEAD",
+    "productCommitSha": "35001083e2c0f85bdda80ffd179d60e5121a76f9",
+    "promotedDevCommitSha": null,
+    "libraryCoreActivation": {
+      "schemaVersion": 1,
+      "range": {
+        "channel": "dev",
+        "previousPublishedTag": "v26.8.1203-dev",
+        "startMode": "previous_product_commit",
+        "fromExclusiveCommitSha": "2199a5d825a380a551bdb8a306a7a42a7795404d",
+        "toInclusiveProductCommitSha": "35001083e2c0f85bdda80ffd179d60e5121a76f9"
+      },
+      "manifest": {
+        "path": "docs/library-core-activation-manifest.json",
+        "previousPresent": true,
+        "previousDigest": "sha256:163fb60ad9ff7c5e27b5b48c06475122235aee37237c2168a14504099bcfb07a",
+        "currentDigest": "sha256:4a9e0286b40716aa67ec93c79cd6ed11f6b3da2e845e884c4e55f7e1e9139a94"
+      },
+      "transitions": [
+        {
+          "activationId": "sqlite-desktop-legacy-engine-retirement-v1",
+          "gate": "H",
+          "kind": "legacy_engine_retirement",
+          "rollbackTrigger": "Restore the retained pre-cutover Automerge library with the last released Freed Desktop build if native SQLite integrity, item counts, bounded reads, mutations, backup, or immutable replication cannot preserve the verified cutover frontier without the retired Automerge runtime.",
+          "receiptExpectations": [
+            "retirement_receipt",
+            "roll_forward_recovery_receipt"
+          ]
+        },
+        {
+          "activationId": "sqlite-pwa-legacy-engine-retirement-v1",
+          "gate": "H",
+          "kind": "legacy_engine_retirement",
+          "rollbackTrigger": "Restore the previous PWA deployment if the IndexedDB Library Core cannot import the active immutable checkpoint, preserve bounded reads, publish signed intents, reconcile results, or complete factory reset without the retired Automerge runtime.",
+          "receiptExpectations": [
+            "retirement_receipt",
+            "roll_forward_recovery_receipt"
+          ]
+        }
+      ],
+      "inspectionDigest": "sha256:b898e7ed7c3ce5d1aa8370363d78de41d55291e7a5483496bf1fc726cfa98794",
+      "decision": {
+        "state": "review_required",
+        "ownerApprovalReference": null,
+        "approvedInspectionDigest": null,
+        "approvedReleaseArtifactDigest": null
+      }
+    },
+    "isLatestOfDay": true,
+    "sameDayTagsIncluded": [
+      "v26.8.1300-dev"
+    ],
+    "relatedBuildTags": [
+      "v26.8.1300-dev"
+    ],
+    "prNumbers": [
+      1423,
+      1424,
+      1425,
+      1426,
+      1427,
+      1428,
+      1429,
+      1430,
+      1431,
+      1432,
+      1433,
+      1434,
+      1435,
+      1436,
+      1437,
+      1438,
+      1440
+    ],
+    "commitSubjects": [
+      "perf: retire Desktop Automerge runtime (#1440)",
+      "feat: retire PWA Automerge runtime (#1438)",
+      "feat: move PWA Library maintenance to Library Core (#1437)",
+      "feat: move PWA FeedItem writes to Library Core (#1436)",
+      "feat: move PWA Accounts to Library Core (#1435)",
+      "feat: move PWA People lifecycle to Library Core (#1434)",
+      "feat: route PWA people through Library Core (#1433)",
+      "feat: route PWA preferences through Library Core (#1432)",
+      "feat: route PWA RSS configuration through Library Core (#1431)",
+      "feat: route PWA archive maintenance through Library Core (#1430)",
+      "feat: save PWA links through SQLite Library Core (#1429)",
+      "feat: route PWA item deletion through Library Core (#1428)",
+      "fix: make Library Core assignments idempotent (#1427)",
+      "feat: route PWA bulk actions through Library Core (#1426)",
+      "fix: start SQLite backups without Automerge (#1425)",
+      "fix: preserve release publication output (#1424)",
+      "perf: bound map renderer memory (#1423)"
+    ]
+  },
+  "release": {
+    "deck": "Retire PWA Automerge runtime, move PWA Library maintenance to Library Core, and preserve release publication output",
+    "features": [
+      "Retire PWA Automerge runtime",
+      "Move PWA Library maintenance to Library Core"
+    ],
+    "fixes": [],
+    "followUps": []
+  },
+  "releaseBody": "(AI Generated).\n\n## Freed v26.8.1300-dev\n\nRetire PWA Automerge runtime, move PWA Library maintenance to Library Core, and preserve release publication output\n\n### Features\n\n- Retire PWA Automerge runtime\n- Move PWA Library maintenance to Library Core\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+}

--- a/release-notes/releases/v26.8.1300-dev.json
+++ b/release-notes/releases/v26.8.1300-dev.json
@@ -3,7 +3,7 @@
   "version": "26.8.1300-dev",
   "channel": "dev",
   "dayKey": "26.8.13",
-  "approved": false,
+  "approved": true,
   "editorialNotes": [],
   "generatedAt": "2026-08-13T17:34:03.837Z",
   "model": "heuristic",
@@ -53,10 +53,10 @@
       ],
       "inspectionDigest": "sha256:b898e7ed7c3ce5d1aa8370363d78de41d55291e7a5483496bf1fc726cfa98794",
       "decision": {
-        "state": "review_required",
-        "ownerApprovalReference": null,
-        "approvedInspectionDigest": null,
-        "approvedReleaseArtifactDigest": null
+        "state": "owner_approved",
+        "ownerApprovalReference": "current-task:release-26-8-1300-dev#sha256:ac2911b4fc390bbb87e046368ed0c9b784e2942724b27d69f956560a4ab963a6",
+        "approvedInspectionDigest": "sha256:b898e7ed7c3ce5d1aa8370363d78de41d55291e7a5483496bf1fc726cfa98794",
+        "approvedReleaseArtifactDigest": "sha256:066b6c60bcdba6749b40db56348f1662960d0127f43bcead43a4138866d090cb"
       }
     },
     "isLatestOfDay": true,
@@ -106,13 +106,17 @@
     ]
   },
   "release": {
-    "deck": "Retire PWA Automerge runtime, move PWA Library maintenance to Library Core, and preserve release publication output",
+    "deck": "Run Freed's Library on SQLite across Freed Desktop and the PWA, with bounded map memory and no active Automerge runtime",
     "features": [
-      "Retire PWA Automerge runtime",
-      "Move PWA Library maintenance to Library Core"
+      "Move PWA Library reads, writes, accounts, people, preferences, RSS feeds, bulk actions, saves, deletions, and maintenance to Library Core",
+      "Remove the active Automerge runtime from Freed Desktop and the PWA",
+      "Start daily SQLite Library backups without loading the legacy document engine"
     ],
-    "fixes": [],
+    "fixes": [
+      "Bound geographic map renderer memory on large libraries",
+      "Make Library Core state assignments idempotent across retries"
+    ],
     "followUps": []
   },
-  "releaseBody": "(AI Generated).\n\n## Freed v26.8.1300-dev\n\nRetire PWA Automerge runtime, move PWA Library maintenance to Library Core, and preserve release publication output\n\n### Features\n\n- Retire PWA Automerge runtime\n- Move PWA Library maintenance to Library Core\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+  "releaseBody": "(AI Generated).\n\n## Freed v26.8.1300-dev\n\nRun Freed's Library on SQLite across Freed Desktop and the PWA, with bounded map memory and no active Automerge runtime.\n\n### Features\n\n- Move PWA Library reads, writes, accounts, people, preferences, RSS feeds, bulk actions, saves, deletions, and maintenance to Library Core\n- Remove the active Automerge runtime from Freed Desktop and the PWA\n- Start daily SQLite Library backups without loading the legacy document engine\n\n### Fixes\n\n- Bound geographic map renderer memory on large libraries\n- Make Library Core state assignments idempotent across retries\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
 }

--- a/release-notes/releases/v26.8.1300-dev.md
+++ b/release-notes/releases/v26.8.1300-dev.md
@@ -1,0 +1,18 @@
+(AI Generated).
+
+## Freed v26.8.1300-dev
+
+Retire PWA Automerge runtime, move PWA Library maintenance to Library Core, and preserve release publication output
+
+### Features
+
+- Retire PWA Automerge runtime
+- Move PWA Library maintenance to Library Core
+
+### Downloads
+
+**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  
+**Windows:** `.exe` (NSIS installer)  
+**Linux:** `.AppImage`  
+
+> macOS downloads are signed and notarized for normal Gatekeeper installation.

--- a/release-notes/releases/v26.8.1300-dev.md
+++ b/release-notes/releases/v26.8.1300-dev.md
@@ -2,12 +2,18 @@
 
 ## Freed v26.8.1300-dev
 
-Retire PWA Automerge runtime, move PWA Library maintenance to Library Core, and preserve release publication output
+Run Freed's Library on SQLite across Freed Desktop and the PWA, with bounded map memory and no active Automerge runtime.
 
 ### Features
 
-- Retire PWA Automerge runtime
-- Move PWA Library maintenance to Library Core
+- Move PWA Library reads, writes, accounts, people, preferences, RSS feeds, bulk actions, saves, deletions, and maintenance to Library Core
+- Remove the active Automerge runtime from Freed Desktop and the PWA
+- Start daily SQLite Library backups without loading the legacy document engine
+
+### Fixes
+
+- Bound geographic map renderer memory on large libraries
+- Make Library Core state assignments idempotent across retries
 
 ### Downloads
 


### PR DESCRIPTION
(AI Generated).

## Summary

- Prepare the reviewed `v26.8.1300-dev` release from exact product commit `35001083e2c0f85bdda80ffd179d60e5121a76f9`.
- Record the owner-approved Gate H retirement of the active Automerge runtime in Freed Desktop and the PWA.
- Publish release notes for the SQLite Library Core cutover, SQLite daily backups, bounded map memory, and idempotent Library state retries.

## Testing

- `npm run validate:feature`
- PWA: production build, 378 unit tests passed with 1 intentional skip, 16 performance tests passed
- Freed Desktop: 966 unit tests passed, 9 smoke tests passed, production build passed
- Native: clippy passed and 476 tests passed
- Release notes and exact release identity validation passed
