### PR TITLE
fix: satisfy PWA SQLite runtime lint

### DIFF
--- a/packages/pwa/src/lib/library-core-runtime.ts
+++ b/packages/pwa/src/lib/library-core-runtime.ts
@@ -532,10 +532,13 @@ export async function clearPwaLibraryCoreSampleData(): Promise<SampleDataClearSu
 
   const updatedAt = Date.now();
   await enqueuePwaLibraryCoreAccountUpserts(
-    realLinkedAccounts.map(({ personId: _personId, ...account }) => ({
-      ...account,
-      updatedAt,
-    })),
+    realLinkedAccounts.map(({ personId, ...account }) => {
+      void personId;
+      return {
+        ...account,
+        updatedAt,
+      };
+    }),
   );
   for (const accountId of sampleAccountIds) {
     await enqueuePwaLibraryCoreAccountRemove(accountId);

--- a/packages/pwa/src/lib/sync.ts
+++ b/packages/pwa/src/lib/sync.ts
@@ -58,32 +58,42 @@ function retiredLegacyCloudSyncError(): Error {
 }
 
 async function gdriveUploadSafe(
-  ..._args: unknown[]
+  ...args: unknown[]
 ): Promise<RetiredCloudUploadResult> {
+  void args;
   throw retiredLegacyCloudSyncError();
 }
-async function gdriveStartPollLoop(..._args: unknown[]): Promise<void> {
+async function gdriveStartPollLoop(...args: unknown[]): Promise<void> {
+  void args;
   throw retiredLegacyCloudSyncError();
 }
 async function gdriveDownloadLatest(
-  ..._args: unknown[]
+  ...args: unknown[]
 ): Promise<Uint8Array | null> {
+  void args;
   throw retiredLegacyCloudSyncError();
 }
-async function dropboxUploadSafe(..._args: unknown[]): Promise<void> {
+async function dropboxUploadSafe(...args: unknown[]): Promise<void> {
+  void args;
   throw retiredLegacyCloudSyncError();
 }
-async function dropboxStartLongpollLoop(..._args: unknown[]): Promise<void> {
+async function dropboxStartLongpollLoop(...args: unknown[]): Promise<void> {
+  void args;
   throw retiredLegacyCloudSyncError();
 }
 async function dropboxDownloadLatest(
-  ..._args: unknown[]
+  ...args: unknown[]
 ): Promise<Uint8Array | null> {
+  void args;
   throw retiredLegacyCloudSyncError();
 }
 
-async function gdriveDeleteFile(..._args: unknown[]): Promise<void> {}
-async function dropboxDeleteFile(..._args: unknown[]): Promise<void> {}
+async function gdriveDeleteFile(...args: unknown[]): Promise<void> {
+  void args;
+}
+async function dropboxDeleteFile(...args: unknown[]): Promise<void> {
+  void args;
+}
 
 // Connection state — WebSocket relay
 let ws: WebSocket | null = null;


### PR DESCRIPTION
(AI Generated).

## Summary
- Consume retired compatibility arguments explicitly so the merged SQLite PWA runtime passes the repository lint gate without changing behavior.

## Testing
- npm run lint
- npm run validate:feature

## Provider Review
- Status: Provider authority is validated for ready publication.
- Review action: none required. The provider-risk artifact records the behavior authority decision; this exact provider subdiff is the audit subject.
- Provider subdiff: `2bdf3284547e593d1527efd73eff04f8f251997b`
- Publication does not authorize new live provider traffic. Gate 1 behavior approval still applies when observable behavior changes.
- Provider review task: `pwa-sqlite-lint`
- Provider review decision: `diff_authorized`
- Provider review artifact: `a8b2dab33b1fb7c09ff5c9ef262551167d4f01c911a8630dde1c6e4e8e075dfa`
- Providers: other
- Observable behavior: Provider requests, navigation, timing, retries, cookies, headers, uploads, downloads, and background activity remain unchanged. The diff only marks existing compatibility parameters as intentionally consumed so ESLint accepts retired fail-closed functions.
- Fingerprinting risk: None introduced. The edited compatibility functions retain the same signatures and either throw the same local retirement error or perform the same local no-op without contacting any provider.
- Lowest profile alternative: Keep the provider contact path disabled exactly as it is and change only local lint-visible parameter consumption.

Files bound into this provider review:
- `packages/pwa/src/lib/sync.ts`