### PR TITLE
perf: reclaim map renderer memory

### DIFF
--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -85,7 +85,10 @@ use std::mem::MaybeUninit;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::sync::{Arc, Mutex as StdMutex, RwLock as StdRwLock};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc, Mutex as StdMutex, RwLock as StdRwLock,
+};
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use sysinfo::{Disks, Pid, ProcessRefreshKind, ProcessesToUpdate, System};
 use tauri::menu::{Menu, MenuItem};
@@ -731,10 +734,12 @@ enum WindowDestroyedReason {
     LoginFlow,
     JobComplete,
     StartupRecovery,
+    MapRendererRelease,
 }
 
 static WINDOW_CREATED_AT: std::sync::LazyLock<StdMutex<HashMap<String, Instant>>> =
     std::sync::LazyLock::new(|| StdMutex::new(HashMap::new()));
+static MAP_RENDERER_RELEASE_PENDING: AtomicBool = AtomicBool::new(false);
 
 /// Record when a tracked webview window was (re)created so kill records can
 /// report the victim's age. Insert-if-absent: ensure-window paths call this
@@ -13311,6 +13316,43 @@ fn recover_main_window(
     )
 }
 
+#[tauri::command]
+fn release_main_renderer_memory(app: tauri::AppHandle) -> Result<(), String> {
+    if MAP_RENDERER_RELEASE_PENDING.swap(true, Ordering::AcqRel) {
+        return Ok(());
+    }
+
+    append_runtime_health(
+        &app,
+        serde_json::json!({
+            "event": "map_renderer_memory_release_requested",
+        }),
+    );
+
+    tauri::async_runtime::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let outcome = recover_main_window(
+            &app,
+            WindowDestroyedReason::MapRendererRelease,
+            "geographic map renderer memory release",
+        );
+        MAP_RENDERER_RELEASE_PENDING.store(false, Ordering::Release);
+
+        if let Err(error) = outcome {
+            warn!("[map] failed to release native renderer memory: {}", error);
+            append_runtime_health(
+                &app,
+                serde_json::json!({
+                    "event": "map_renderer_memory_release_failed",
+                    "error": error,
+                }),
+            );
+        }
+    });
+
+    Ok(())
+}
+
 fn recover_main_window_hidden(
     app: &tauri::AppHandle,
     reason_enum: WindowDestroyedReason,
@@ -14790,6 +14832,7 @@ pub fn run() {
             cancel_local_ai_model_download,
             get_sync_client_count,
             get_runtime_memory_stats,
+            release_main_renderer_memory,
             trim_webkit_network_cache_now,
             get_recent_runtime_health,
             get_runtime_health_history,

--- a/packages/desktop/src/App.tsx
+++ b/packages/desktop/src/App.tsx
@@ -1315,6 +1315,10 @@ function App() {
         import.meta.env.VITE_TEST_TAURI === "1" || isTauri()
           ? () => getCurrentWindow().startDragging()
           : undefined,
+      releaseMapRendererMemory:
+        import.meta.env.VITE_TEST_TAURI === "1" || isTauri()
+          ? () => invoke("release_main_renderer_memory")
+          : undefined,
       SourceIndicator: XSourceIndicator,
       HeaderSyncIndicator: null,
       SettingsExtraSections: MobileSyncTab,

--- a/packages/ui/src/components/layout/AppShell.tsx
+++ b/packages/ui/src/components/layout/AppShell.tsx
@@ -107,7 +107,8 @@ export function AppShell({ children }: AppShellProps) {
   const setActiveView = useAppStore((s) => s.setActiveView);
   const items = useAppStore((s) => s.items);
   const searchCorpusVersion = useAppStore((s) => s.searchCorpusVersion);
-  const { scanLibraryItems } = usePlatform();
+  const { releaseMapRendererMemory, scanLibraryItems } = usePlatform();
+  const previousActiveViewRef = useRef(activeView);
   const accounts = useAppStore((s) => s.accounts);
   const persons = useAppStore((s) => s.persons);
   const addPerson = useAppStore((s) => s.addPerson);
@@ -132,6 +133,23 @@ export function AppShell({ children }: AppShellProps) {
   const libraryDialogOpen = useCommandSurfaceStore((s) => s.libraryDialogOpen);
   const libraryDialogTab = useCommandSurfaceStore((s) => s.libraryDialogTab);
   const closeLibraryDialog = useCommandSurfaceStore((s) => s.closeLibraryDialog);
+
+  useEffect(() => {
+    const previousActiveView = previousActiveViewRef.current;
+    previousActiveViewRef.current = activeView;
+    if (previousActiveView !== "map" || activeView === "map" || !releaseMapRendererMemory) {
+      return;
+    }
+
+    void releaseMapRendererMemory().catch((error) => {
+      addDebugEvent(
+        "error",
+        `[map] native renderer memory release failed: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    });
+  }, [activeView, releaseMapRendererMemory]);
 
   // Mount the contact sync hook here (not in FriendsView) so the 15-minute
   // interval and focus listener run regardless of which view is active.

--- a/packages/ui/src/components/map/MapSurface.test.ts
+++ b/packages/ui/src/components/map/MapSurface.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { LocationMarkerSummary } from "@freed/shared";
 import {
   areLocationMarkerListsRenderEquivalent,
+  disposeMapInstance,
   fitMapToMarkers,
   getMapMovingPriority,
   getRenderedMapMarkers,
@@ -152,5 +153,33 @@ describe("map camera framing", () => {
       ],
       expect.objectContaining({ maxZoom: 7.5 }),
     );
+  });
+});
+
+describe("map renderer disposal", () => {
+  it("releases the detached WebGL context and canvas backing store", () => {
+    const calls: string[] = [];
+    const loseContext = vi.fn(() => calls.push("lose"));
+    const canvas = {
+      width: 1_920,
+      height: 1_152,
+      getContext: vi.fn((kind: string) => {
+        calls.push(`context:${kind}`);
+        return kind === "webgl2"
+          ? { getExtension: () => ({ loseContext }) }
+          : null;
+      }),
+    } as unknown as HTMLCanvasElement;
+    const map = {
+      stop: vi.fn(() => calls.push("stop")),
+      getCanvas: vi.fn(() => canvas),
+      remove: vi.fn(() => calls.push("remove")),
+    };
+
+    disposeMapInstance(map as unknown as Parameters<typeof disposeMapInstance>[0]);
+
+    expect(calls).toEqual(["stop", "context:webgl2", "remove", "lose"]);
+    expect(canvas.width).toBe(1);
+    expect(canvas.height).toBe(1);
   });
 });

--- a/packages/ui/src/components/map/MapSurface.tsx
+++ b/packages/ui/src/components/map/MapSurface.tsx
@@ -19,6 +19,7 @@ import { buildThemedMapStyle } from "../../lib/map-style.js";
 type PopupInstance = MapLibrePopup;
 type MarkerInstance = MapLibreMarker;
 type MapInstance = MapLibreMap;
+type DisposableMapInstance = Pick<MapInstance, "getCanvas" | "remove" | "stop">;
 type MapMarkerMovingPriority = "primary" | "deferred";
 interface MapMarkerRecord {
   marker: MarkerInstance;
@@ -70,6 +71,34 @@ const MAP_CAMERA_PADDING_PX = 72;
 const MAP_CLUSTER_MAX_ZOOM = 7.5;
 const MAP_MAX_PIXEL_RATIO = 1.5;
 const MAP_MAX_TILE_CACHE_SIZE = 24;
+
+/**
+ * MapLibre removes its DOM and workers, but WebKit can retain the detached
+ * canvas backing store and GPU context for the rest of the renderer process.
+ * Release that context after MapLibre has stopped using it so leaving Map
+ * returns the browsing surface's memory to the system.
+ */
+export function disposeMapInstance(map: DisposableMapInstance): void {
+  let canvas: HTMLCanvasElement | null = null;
+  let loseContext: WEBGL_lose_context | null = null;
+
+  try {
+    try {
+      map.stop();
+      canvas = map.getCanvas();
+      const context = canvas.getContext("webgl2") ?? canvas.getContext("webgl");
+      loseContext = context?.getExtension("WEBGL_lose_context") ?? null;
+    } finally {
+      map.remove();
+    }
+  } finally {
+    loseContext?.loseContext();
+    if (canvas) {
+      canvas.width = 1;
+      canvas.height = 1;
+    }
+  }
+}
 
 function shouldForceMapFallback() {
   if (typeof window === "undefined") return false;
@@ -862,7 +891,7 @@ export function MapSurface({
         clearNativeMarkerRestoreTimeout();
         for (const { marker } of markersRef.current) marker.remove();
         markersRef.current = [];
-        mapRef.current?.remove();
+        if (mapRef.current) disposeMapInstance(mapRef.current);
         mapRef.current = null;
       };
     }
@@ -913,7 +942,7 @@ export function MapSurface({
         setTimeout(() => map.resize(), 0);
       } catch (error) {
         console.error("[MapSurface] Failed to initialize MapLibre", error);
-        mapRef.current?.remove();
+        if (mapRef.current) disposeMapInstance(mapRef.current);
         mapRef.current = null;
         setLoadFailed(true);
       }
@@ -929,7 +958,7 @@ export function MapSurface({
       clearNativeMarkerRestoreTimeout();
       for (const { marker } of markersRef.current) marker.remove();
       markersRef.current = [];
-      mapRef.current?.remove();
+      if (mapRef.current) disposeMapInstance(mapRef.current);
       mapRef.current = null;
       setShellMoving(false);
     };

--- a/packages/ui/src/context/PlatformContext.tsx
+++ b/packages/ui/src/context/PlatformContext.tsx
@@ -460,6 +460,12 @@ export interface PlatformConfig {
    */
   startWindowDrag?: () => Promise<void>;
 
+  /**
+   * Rebuild the native main WebView after leaving the geographic map so WebKit
+   * releases MapLibre's high-water GPU and tile allocations. Desktop only.
+   */
+  releaseMapRendererMemory?: () => Promise<void>;
+
   // -- Layout slot components (null = not rendered) --
 
   /** Rendered inline per source button for status indicators (e.g. X auth dot) */


### PR DESCRIPTION
(AI Generated).

## New agent continuity prompt

Copy everything in this section into the replacement task, or simply instruct the agent to read PR #1444 and assume custody.

```text
You are taking custody of Freed's long-term SQLite Library Core delivery. Read this entire PR description before acting.

OWNER INTENT

Continue decisively without waiting for routine implementation approvals. Finish active work, validate proportionately, publish guarded dev PRs, merge exact green heads, clean merged worktrees, and continue toward the complete Freed Desktop and PWA Library Core.

Do not confuse checkpoints, registries, bridges, speculative contracts, or test expansion with product progress. Prefer the shortest complete path to a working system. GitHub is the integration gate, not the local development loop.

ACTIVE GOAL

1. Finish and merge this geographic Map renderer memory repair.
2. Ship and install a manually testable Freed Desktop build containing it.
3. Prove the full 19,883-record library remains bounded after entering and leaving Map.
4. Implement Google Drive immutable-object synchronization with one non-expiring Desktop writer epoch and compare-and-swap ownership transfer.
5. Implement the PWA IndexedDB Library reader, bounded search, intent queue, acceptance receipts, and provider-result receipts.
6. Preserve 24 immutable daily backup generations, restore, rollback, and reachable media closure.
7. Keep media outside SQLite and IndexedDB row bodies.
8. Preserve current provider behavior.
9. Retire remaining Automerge product paths only after replacement paths are functional and verified.

Never synchronize a live SQLite database, WAL, SHM, rollback journal, or mutable database replacement.

CURRENT SOURCE AUTHORITY

Repository: https://github.com/freed-project/freed
PR: https://github.com/freed-project/freed/pull/1444
Branch: perf/map-memory-teardown
Exact head: ea352cd39c1e26eed105e78f5c94d8a3a89c952f
Exact tree: ad46a6fe69c6b90ab70ed004f22a9adc6a50ecae
Exact base: de948e88a0f5da2a8fd7e180283c76ab038f6fa9
Base tree: a31d0bfe941856f5db6f3c6b157eb800606d96dd
Validation run: 31738425096
CodeQL run: 31738423242

The branch was clean and matched the remote when custody transferred. The old task is stopped and must not compete for Git or GitHub ownership.

NEW MACHINE SETUP

Use the repository-pinned Node toolchain from .nvmrc. Run the strict machine doctor before diagnosing repository failures.

From a clean clone:

git fetch origin dev perf/map-memory-teardown
./scripts/worktree-add.sh ../freed-map-memory-teardown -b perf/map-memory-teardown origin/perf/map-memory-teardown --target desktop

Read these files before changing the candidate:

1. AGENTS.md
2. .agents/skills/freed-library-core/SKILL.md
3. .agents/skills/freed-build-feature/SKILL.md
4. docs/LIBRARY-CORE-CONTRACT.md
5. docs/STORAGE-ARCHITECTURE-ROADMAP.md
6. docs/library-core-activation-manifest.json
7. docs/TESTING-STANDARD.md

Do not copy a live SQLite file, WAL, SHM, machine installation witness, Keychain entry, provider session, or device key from the old machine. GitHub carries the source candidate. Use supported backup, import, enrollment, and ownership flows for product data and machine identity.

PR #1444 PURPOSE

The installed v26.8.1300-dev build proved that Freed Desktop and PWA geographic basemaps render. The remaining Map defect is memory retention.

On the full 19,883-record installed library, opening Map raised total app memory from roughly 277 MB to roughly 865 MB. Leaving Map did not release most of it.

This candidate:

- explicitly stops MapLibre;
- releases its WebGL context;
- shrinks the detached canvas backing store;
- invokes a Freed Desktop-only native command after leaving Map;
- recycles the main WebView through the existing production renderer-recovery path;
- preserves PWA behavior;
- changes no provider requests, navigation, timing, retries, cookies, headers, scrolling, clicks, extraction, login, or background activity.

EXACT LOCAL PROOF

The isolated native preview used 1,451 records.

Before renderer recycle:
- app resident bytes: 623,968,256
- WebKit resident bytes: 464,371,712
- WebKit footprint bytes: 441,583,008
- WebKit PID: 30279

After renderer recycle:
- app resident bytes: 430,260,224
- WebKit resident bytes: 252,231,680
- WebKit footprint bytes: 215,090,352
- new WebKit PID: 41010
- old WebKit process exited
- reclaimed WebKit resident bytes: 212,140,032
- recovery reported shouldRestartApp=false

The UI returned to Unified Feed with the preview library intact.

Local validation passed:

- npm run validate:feature
- 142 Freed Desktop unit files and 966 tests
- Freed Desktop smoke and performance suites
- PWA build, typecheck, unit, and performance suites
- provider offline fixtures
- 476 native Rust tests
- cargo fmt
- cargo check
- git diff check

The local Tauri app bundle built successfully. The surrounding build command later exited because that machine lacked the private updater signing key. Do not misclassify that as a compile failure.

Provider-neutral audit artifact digest:
da93c62b0c41e0d3ae97a71beccd64a7055691dcd8721748476ebcbfd010712f

Audit comment:
https://github.com/freed-project/freed/pull/1444#issuecomment-5285711313

IMMEDIATE ACTIONS

1. Confirm this PR still points exactly at ea352cd39c1e26eed105e78f5c94d8a3a89c952f.
2. Inspect Validation 31738425096 and CodeQL 31738423242.
3. If a check fails, repair only a genuine exact-head defect.
4. When exact-head checks are green, mark this PR ready.
5. Squash merge under exact-head protection.
6. Record the reviewed head, reviewed tree, merged dev SHA, merged tree, and check identities.
7. Remove only the merged map-memory worktree and branch.
8. Ship the next dev build through freed-ship-build.
9. Install it and repeat the Map open and leave measurement against the real 19,883-record library.
10. Require renderer PID retirement, successful recovery verification, bounded post-recovery memory, intact navigation, and intact record counts.
11. Resume replacement synchronization and PWA implementation immediately after that installed proof.

CURRENT INSTALLED PRODUCT STATE

Installed release: v26.8.1300-dev
Release: https://github.com/freed-project/freed/releases/tag/v26.8.1300-dev
Installed commit: de948e88a0f5da2a8fd7e180283c76ab038f6fa9

Installed database evidence:
- SQLite integrity: ok
- user_version: 6
- feed items: 19,883
- Automerge binary bytes retained: 0

The local Freed Desktop runtime is SQLite-backed. Remaining long-term work includes replacement cloud transport, PWA Library Core, backup and restore completion, media transport, and removal of obsolete Automerge-era product paths.

BINDING ARCHITECTURE

- Freed Desktop canonical local storage is native SQLite.
- SQLite files are never synchronized between devices.
- Google Drive transports immutable logical objects plus one small CAS control record.
- One Freed Desktop writer epoch owns canonical writes.
- The writer epoch does not expire and has no heartbeat or automatic failover.
- A new Freed Desktop claims ownership with one explicit confirmation and one exact control-record CAS.
- A retired offline writer preserves later changes for review but never silently publishes them.
- PWA uses IndexedDB for MVP.
- PWA is an intent-producing reader, not a canonical writer.
- PWA success states require separate canonical acceptance and actual provider-result receipts.
- Search uses bounded, adapter-neutral base shards and delta packs.
- Media is content-addressed and stored outside row databases.
- Daily backups retain 24 immutable generations.
- Backups contain a portable logical checkpoint and a fresh scrubbed, closed SQLite checkpoint.
- Existing provider request behavior and cadence must not change without a new scoped provider-risk decision.
- YouTube audiovisual bytes must remain inside YouTube unless YouTube explicitly authorizes another path.

TEST ECONOMY

Do not add tests merely because code was touched. Every permanent test must protect a distinct data-integrity, authority, migration, provider, security, release, or user workflow contract. Extend existing coverage where possible. Prefer focused changed-path validation locally.

Do not publish every local experiment. Build and test locally until a complete slice is real.

CUSTODY

The replacement task owns PR #1444 completion and the subsequent Library Core implementation lane. Do not mutate unrelated dirty worktrees, provider state, installed app data, Keychain, device identity, release tags, or automation control state without the corresponding operation.

Create the long-term goal in the replacement task. Goal state does not migrate automatically between machines.
```

## Candidate summary

- Releases MapLibre WebGL resources when the map unmounts.
- Recycles the Freed Desktop main WebView after leaving Map so WebKit returns retained map allocations.
- Keeps PWA and provider behavior unchanged.

## Verification

- `npm run validate:feature`
- Native isolated preview with 1,451 records retired the old WebKit renderer and recovered without an app restart.
- WebKit resident memory fell from 464,371,712 bytes to 252,231,680 bytes after renderer recycle.

## Provider review

- Provider subdiff: `b43b049bf5f028c0036cc16522a8317ae513073d`
- Decision: `diff_authorized`
- Artifact: `da93c62b0c41e0d3ae97a71beccd64a7055691dcd8721748476ebcbfd010712f`
- Provider behavior remains unchanged. Publication authorizes no live provider traffic.
