### PR TITLE
chore: prepare v26.8.1301-dev

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freed/desktop",
   "private": true,
-  "version": "26.8.1300",
+  "version": "26.8.1301",
   "type": "module",
   "scripts": {
     "dev": "node ../../node_modules/vite/bin/vite.js",

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -1443,7 +1443,7 @@ dependencies = [
 
 [[package]]
 name = "freed-desktop"
-version = "26.8.1300"
+version = "26.8.1301"
 dependencies = [
  "base64 0.23.0",
  "criterion",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freed-desktop"
-version = "26.8.1300"
+version = "26.8.1301"
 description = "Freed Desktop - Escape algorithmic manipulation"
 authors = ["Freed"]
 edition = "2021"

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Freed",
-  "version": "26.8.1300",
+  "version": "26.8.1301",
   "identifier": "wtf.freed.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freed/pwa",
   "private": true,
-  "version": "26.8.1300",
+  "version": "26.8.1301",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/release-notes/daily/dev/26.8.13.json
+++ b/release-notes/daily/dev/26.8.13.json
@@ -10,5 +10,5 @@
   ],
   "pinnedHighlights": [],
   "editorialNotes": [],
-  "updatedAt": "2026-08-13T18:13:44.943Z"
+  "updatedAt": "2026-08-13T21:03:03.618Z"
 }

--- a/release-notes/releases/v26.8.1301-dev.json
+++ b/release-notes/releases/v26.8.1301-dev.json
@@ -1,0 +1,114 @@
+{
+  "tag": "v26.8.1301-dev",
+  "version": "26.8.1301-dev",
+  "channel": "dev",
+  "dayKey": "26.8.13",
+  "approved": true,
+  "editorialNotes": [],
+  "generatedAt": "2026-08-13T21:03:03.618Z",
+  "model": "heuristic",
+  "source": {
+    "channel": "dev",
+    "previousPublishedTag": "v26.8.1300-dev",
+    "previousPublishedDayTag": "v26.8.1203-dev",
+    "compareRef": "HEAD",
+    "productCommitSha": "37832ccf6e14ec4083b3601e26a890a132cd4d2d",
+    "promotedDevCommitSha": null,
+    "libraryCoreActivation": {
+      "schemaVersion": 1,
+      "range": {
+        "channel": "dev",
+        "previousPublishedTag": "v26.8.1300-dev",
+        "startMode": "previous_product_commit",
+        "fromExclusiveCommitSha": "77b29fb1100f43b548628c2c7565223526c272aa",
+        "toInclusiveProductCommitSha": "37832ccf6e14ec4083b3601e26a890a132cd4d2d"
+      },
+      "manifest": {
+        "path": "docs/library-core-activation-manifest.json",
+        "previousPresent": true,
+        "previousDigest": "sha256:4a9e0286b40716aa67ec93c79cd6ed11f6b3da2e845e884c4e55f7e1e9139a94",
+        "currentDigest": "sha256:4a9e0286b40716aa67ec93c79cd6ed11f6b3da2e845e884c4e55f7e1e9139a94"
+      },
+      "transitions": [],
+      "inspectionDigest": "sha256:420bbc7f922942cdc81137c9f5036c80feeea163d9ccdfabd0732f31616eecb2",
+      "decision": {
+        "state": "no_activation_declared",
+        "ownerApprovalReference": null,
+        "approvedInspectionDigest": null,
+        "approvedReleaseArtifactDigest": null
+      }
+    },
+    "isLatestOfDay": true,
+    "sameDayTagsIncluded": [
+      "v26.8.1300-dev",
+      "v26.8.1301-dev"
+    ],
+    "relatedBuildTags": [
+      "v26.8.1300-dev",
+      "v26.8.1301-dev"
+    ],
+    "prNumbers": [
+      1423,
+      1424,
+      1425,
+      1426,
+      1427,
+      1428,
+      1429,
+      1430,
+      1431,
+      1432,
+      1433,
+      1434,
+      1435,
+      1436,
+      1437,
+      1438,
+      1440,
+      1441,
+      1442,
+      1443,
+      1444
+    ],
+    "commitSubjects": [
+      "perf: reclaim map renderer memory (#1444)",
+      "chore: refresh v26.8.1300-dev release (#1443)",
+      "fix: satisfy PWA SQLite runtime lint (#1442)",
+      "chore: prepare v26.8.1300-dev (#1441)",
+      "perf: retire Desktop Automerge runtime (#1440)",
+      "feat: retire PWA Automerge runtime (#1438)",
+      "feat: move PWA Library maintenance to Library Core (#1437)",
+      "feat: move PWA FeedItem writes to Library Core (#1436)",
+      "feat: move PWA Accounts to Library Core (#1435)",
+      "feat: move PWA People lifecycle to Library Core (#1434)",
+      "feat: route PWA people through Library Core (#1433)",
+      "feat: route PWA preferences through Library Core (#1432)",
+      "feat: route PWA RSS configuration through Library Core (#1431)",
+      "feat: route PWA archive maintenance through Library Core (#1430)",
+      "feat: save PWA links through SQLite Library Core (#1429)",
+      "feat: route PWA item deletion through Library Core (#1428)",
+      "fix: make Library Core assignments idempotent (#1427)",
+      "feat: route PWA bulk actions through Library Core (#1426)",
+      "fix: start SQLite backups without Automerge (#1425)",
+      "fix: preserve release publication output (#1424)",
+      "perf: bound map renderer memory (#1423)"
+    ]
+  },
+  "release": {
+    "deck": "The SQLite Library Core is ready for real-world testing",
+    "features": [
+      "Retire PWA Automerge runtime",
+      "Move PWA Library maintenance to Library Core",
+      "Write daily SQLite backups without loading the legacy document engine"
+    ],
+    "fixes": [
+      "Stop Freed Desktop from loading the retired Automerge engine after startup",
+      "Bound map renderer memory on large libraries",
+      "Reclaim Freed Desktop WebKit memory after leaving the geographic map",
+      "Make Library Core assignments idempotent",
+      "Preserve release publication output"
+    ],
+    "followUps": []
+  },
+  "releaseBody": "(AI Generated).\n\n## Freed v26.8.1301-dev\n\nThe SQLite Library Core is ready for real-world testing\n\n### Features\n\n- Retire PWA Automerge runtime\n- Move PWA Library maintenance to Library Core\n- Write daily SQLite backups without loading the legacy document engine\n\n### Fixes\n\n- Stop Freed Desktop from loading the retired Automerge engine after startup\n- Bound map renderer memory on large libraries\n- Reclaim Freed Desktop WebKit memory after leaving the geographic map\n- Make Library Core assignments idempotent\n- Preserve release publication output\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+}

--- a/release-notes/releases/v26.8.1301-dev.md
+++ b/release-notes/releases/v26.8.1301-dev.md
@@ -1,0 +1,27 @@
+(AI Generated).
+
+## Freed v26.8.1301-dev
+
+The SQLite Library Core is ready for real-world testing
+
+### Features
+
+- Retire PWA Automerge runtime
+- Move PWA Library maintenance to Library Core
+- Write daily SQLite backups without loading the legacy document engine
+
+### Fixes
+
+- Stop Freed Desktop from loading the retired Automerge engine after startup
+- Bound map renderer memory on large libraries
+- Reclaim Freed Desktop WebKit memory after leaving the geographic map
+- Make Library Core assignments idempotent
+- Preserve release publication output
+
+### Downloads
+
+**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  
+**Windows:** `.exe` (NSIS installer)  
+**Linux:** `.AppImage`  
+
+> macOS downloads are signed and notarized for normal Gatekeeper installation.


### PR DESCRIPTION
(AI Generated).

## Summary
- Prepare v26.8.1301-dev from exact dev commit 37832ccf6e14ec4083b3601e26a890a132cd4d2d.
- Carry the merged geographic-map renderer teardown and WebKit reclamation fix.
- Preserve the current SQLite Library Core activation manifest with no new activation transition.

## Testing
- npm run validate:feature with pinned Node 24.14.1
- PWA and Desktop production builds
- 43 PWA unit files, 142 Desktop unit files, and nine focused Desktop end-to-end checks
- Rust Clippy and 476 native tests