### PR TITLE
perf: bound map worker memory

### DIFF
--- a/packages/ui/src/components/map/MapSurface.tsx
+++ b/packages/ui/src/components/map/MapSurface.tsx
@@ -156,6 +156,12 @@ function loadMapLibre(): Promise<MapLibreModule> {
     import("maplibre-gl/dist/maplibre-gl.css"),
   ]).then(([module]) => {
     module.setWorkerUrl(mapLibreWorkerUrl);
+    // Safari otherwise creates as many as three MapLibre workers. WebKit gives
+    // each worker a large process allocation, which pushed the geographic map
+    // above 2 GB on the 20,000-item Library even though tile caching and marker
+    // counts were already bounded. One worker keeps the same map data and
+    // rendering behavior without multiplying that fixed memory cost.
+    module.setWorkerCount(1);
     return module;
   }).catch((error) => {
     mapLibreLoader = null;


### PR DESCRIPTION
(AI Generated).

## Summary

- Cap MapLibre to one worker so the geographic Map does not multiply WebKit process memory.
- Preserve the existing map source, tiles, rendering behavior, marker cap, and provider behavior.

## Testing

- Local native Map on the 20,004-record Library: one WebKit process and 655.70 MB after settling, down from about 2,309 MB.
- `npx vitest run packages/ui/src/components/map/MapSurface.test.ts`
- `npm run validate:feature`
