### PR TITLE
chore: prepare v26.8.1303-dev

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freed/desktop",
   "private": true,
-  "version": "26.8.1302",
+  "version": "26.8.1303",
   "type": "module",
   "scripts": {
     "dev": "node ../../node_modules/vite/bin/vite.js",

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -1360,7 +1360,7 @@ dependencies = [
 
 [[package]]
 name = "freed-desktop"
-version = "26.8.1302"
+version = "26.8.1303"
 dependencies = [
  "base64 0.23.0",
  "criterion",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freed-desktop"
-version = "26.8.1302"
+version = "26.8.1303"
 description = "Freed Desktop - Escape algorithmic manipulation"
 authors = ["Freed"]
 edition = "2021"

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Freed",
-  "version": "26.8.1302",
+  "version": "26.8.1303",
   "identifier": "wtf.freed.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freed/pwa",
   "private": true,
-  "version": "26.8.1302",
+  "version": "26.8.1303",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/release-notes/daily/dev/26.8.13.json
+++ b/release-notes/daily/dev/26.8.13.json
@@ -12,5 +12,5 @@
     "Bound map renderer memory on large libraries"
   ],
   "editorialNotes": [],
-  "updatedAt": "2026-08-13T23:23:59.394Z"
+  "updatedAt": "2026-08-14T00:51:55.996Z"
 }

--- a/release-notes/daily/dev/26.8.13.json
+++ b/release-notes/daily/dev/26.8.13.json
@@ -2,7 +2,7 @@
   "channel": "dev",
   "dayKey": "26.8.13",
   "date": "2026-08-13",
-  "preferredDeck": null,
+  "preferredDeck": "Run the Freed Library on SQLite and bounded IndexedDB without the legacy Automerge runtime, with substantially lower geographic Map memory",
   "editorialGuidance": [
     "Keep the tone concise, professional, and specific.",
     "Lead with user-facing outcomes, shipping milestones, trust wins, and installability improvements.",

--- a/release-notes/daily/dev/26.8.13.json
+++ b/release-notes/daily/dev/26.8.13.json
@@ -12,5 +12,5 @@
     "Bound map renderer memory on large libraries"
   ],
   "editorialNotes": [],
-  "updatedAt": "2026-08-14T00:51:55.996Z"
+  "updatedAt": "2026-08-14T01:14:52.458Z"
 }

--- a/release-notes/releases/v26.8.1303-dev.json
+++ b/release-notes/releases/v26.8.1303-dev.json
@@ -5,14 +5,14 @@
   "dayKey": "26.8.13",
   "approved": true,
   "editorialNotes": [],
-  "generatedAt": "2026-08-14T00:51:55.994Z",
+  "generatedAt": "2026-08-14T01:14:52.457Z",
   "model": "heuristic",
   "source": {
     "channel": "dev",
     "previousPublishedTag": "v26.8.1302-dev",
     "previousPublishedDayTag": "v26.8.1203-dev",
     "compareRef": "HEAD",
-    "productCommitSha": "6f336686a285ff0f587a8227b50a712e44917edf",
+    "productCommitSha": "cf65fb80cd41b8f9fdcf799402c6c7fa528a843e",
     "promotedDevCommitSha": null,
     "libraryCoreActivation": {
       "schemaVersion": 1,
@@ -21,7 +21,7 @@
         "previousPublishedTag": "v26.8.1302-dev",
         "startMode": "previous_product_commit",
         "fromExclusiveCommitSha": "461968ce8c37b93f1a64fad79e16d5e4420a4bac",
-        "toInclusiveProductCommitSha": "6f336686a285ff0f587a8227b50a712e44917edf"
+        "toInclusiveProductCommitSha": "cf65fb80cd41b8f9fdcf799402c6c7fa528a843e"
       },
       "manifest": {
         "path": "docs/library-core-activation-manifest.json",
@@ -30,7 +30,7 @@
         "currentDigest": "sha256:4a9e0286b40716aa67ec93c79cd6ed11f6b3da2e845e884c4e55f7e1e9139a94"
       },
       "transitions": [],
-      "inspectionDigest": "sha256:f738dfacb4d03469cac9ad7de6f689ec98529b4d62c62a10ab1ab37a6b139029",
+      "inspectionDigest": "sha256:e8dc57abc7b448b5c974190cd74d6fea42890bb1d8fe1cf4ce5e2cf2a3ed1784",
       "decision": {
         "state": "no_activation_declared",
         "ownerApprovalReference": null,
@@ -52,6 +52,7 @@
       "v26.8.1303-dev"
     ],
     "prNumbers": [
+      1408,
       1423,
       1424,
       1425,
@@ -75,9 +76,12 @@
       1444,
       1445,
       1454,
-      1457
+      1457,
+      1458
     ],
     "commitSubjects": [
+      "feat: designate primary automation host (#1408)",
+      "style: tighten map timeline controls (#1458)",
       "fix: recover stranded actor lease acquisitions (#1445)",
       "perf: bound map worker memory (#1457)",
       "release: v26.8.1302-dev (#1455)",
@@ -118,8 +122,8 @@
       "Make Library Core assignments idempotent",
       "Preserve release publication output",
       "Stop Freed Desktop from loading the retired Automerge engine after startup",
-      "Reclaim Freed Desktop WebKit memory after leaving the geographic map",
-      "Bound map renderer memory on large libraries"
+      "Bound map renderer memory on large libraries",
+      "Reclaim Freed Desktop WebKit memory after leaving the geographic map"
     ],
     "followUps": [
       "Exercise the SQLite-only Desktop and PWA clients against real libraries",
@@ -127,5 +131,5 @@
       "Measure SQLite and IndexedDB memory on older low-memory devices"
     ]
   },
-  "releaseBody": "(AI Generated).\n\n## Freed v26.8.1303-dev\n\nRun the Freed Library on SQLite and bounded IndexedDB without the legacy Automerge runtime, with substantially lower geographic Map memory\n\n### Features\n\n- Retire PWA Automerge runtime\n- Move PWA Library maintenance to Library Core\n- Write daily SQLite backups without loading the legacy document engine\n\n### Fixes\n\n- Recover stranded actor lease acquisitions\n- Make Library Core assignments idempotent\n- Preserve release publication output\n- Stop Freed Desktop from loading the retired Automerge engine after startup\n- Reclaim Freed Desktop WebKit memory after leaving the geographic map\n- Bound map renderer memory on large libraries\n\n### Follow-ups\n\n- Exercise the SQLite-only Desktop and PWA clients against real libraries\n- Verify restore behavior across the retained daily backup generations\n- Measure SQLite and IndexedDB memory on older low-memory devices\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+  "releaseBody": "(AI Generated).\n\n## Freed v26.8.1303-dev\n\nRun the Freed Library on SQLite and bounded IndexedDB without the legacy Automerge runtime, with substantially lower geographic Map memory\n\n### Features\n\n- Retire PWA Automerge runtime\n- Move PWA Library maintenance to Library Core\n- Write daily SQLite backups without loading the legacy document engine\n\n### Fixes\n\n- Recover stranded actor lease acquisitions\n- Make Library Core assignments idempotent\n- Preserve release publication output\n- Stop Freed Desktop from loading the retired Automerge engine after startup\n- Bound map renderer memory on large libraries\n- Reclaim Freed Desktop WebKit memory after leaving the geographic map\n\n### Follow-ups\n\n- Exercise the SQLite-only Desktop and PWA clients against real libraries\n- Verify restore behavior across the retained daily backup generations\n- Measure SQLite and IndexedDB memory on older low-memory devices\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
 }

--- a/release-notes/releases/v26.8.1303-dev.json
+++ b/release-notes/releases/v26.8.1303-dev.json
@@ -1,0 +1,131 @@
+{
+  "tag": "v26.8.1303-dev",
+  "version": "26.8.1303-dev",
+  "channel": "dev",
+  "dayKey": "26.8.13",
+  "approved": false,
+  "editorialNotes": [],
+  "generatedAt": "2026-08-14T00:51:55.994Z",
+  "model": "heuristic",
+  "source": {
+    "channel": "dev",
+    "previousPublishedTag": "v26.8.1302-dev",
+    "previousPublishedDayTag": "v26.8.1203-dev",
+    "compareRef": "HEAD",
+    "productCommitSha": "6f336686a285ff0f587a8227b50a712e44917edf",
+    "promotedDevCommitSha": null,
+    "libraryCoreActivation": {
+      "schemaVersion": 1,
+      "range": {
+        "channel": "dev",
+        "previousPublishedTag": "v26.8.1302-dev",
+        "startMode": "previous_product_commit",
+        "fromExclusiveCommitSha": "461968ce8c37b93f1a64fad79e16d5e4420a4bac",
+        "toInclusiveProductCommitSha": "6f336686a285ff0f587a8227b50a712e44917edf"
+      },
+      "manifest": {
+        "path": "docs/library-core-activation-manifest.json",
+        "previousPresent": true,
+        "previousDigest": "sha256:4a9e0286b40716aa67ec93c79cd6ed11f6b3da2e845e884c4e55f7e1e9139a94",
+        "currentDigest": "sha256:4a9e0286b40716aa67ec93c79cd6ed11f6b3da2e845e884c4e55f7e1e9139a94"
+      },
+      "transitions": [],
+      "inspectionDigest": "sha256:f738dfacb4d03469cac9ad7de6f689ec98529b4d62c62a10ab1ab37a6b139029",
+      "decision": {
+        "state": "no_activation_declared",
+        "ownerApprovalReference": null,
+        "approvedInspectionDigest": null,
+        "approvedReleaseArtifactDigest": null
+      }
+    },
+    "isLatestOfDay": true,
+    "sameDayTagsIncluded": [
+      "v26.8.1300-dev",
+      "v26.8.1301-dev",
+      "v26.8.1302-dev",
+      "v26.8.1303-dev"
+    ],
+    "relatedBuildTags": [
+      "v26.8.1300-dev",
+      "v26.8.1301-dev",
+      "v26.8.1302-dev",
+      "v26.8.1303-dev"
+    ],
+    "prNumbers": [
+      1423,
+      1424,
+      1425,
+      1426,
+      1427,
+      1428,
+      1429,
+      1430,
+      1431,
+      1432,
+      1433,
+      1434,
+      1435,
+      1436,
+      1437,
+      1438,
+      1440,
+      1441,
+      1442,
+      1443,
+      1444,
+      1445,
+      1454,
+      1457
+    ],
+    "commitSubjects": [
+      "fix: recover stranded actor lease acquisitions (#1445)",
+      "perf: bound map worker memory (#1457)",
+      "release: v26.8.1302-dev (#1455)",
+      "perf: retire Automerge runtime (#1454)",
+      "release: v26.8.1301-dev (#1450)",
+      "perf: reclaim map renderer memory (#1444)",
+      "chore: refresh v26.8.1300-dev release (#1443)",
+      "fix: satisfy PWA SQLite runtime lint (#1442)",
+      "chore: prepare v26.8.1300-dev (#1441)",
+      "perf: retire Desktop Automerge runtime (#1440)",
+      "feat: retire PWA Automerge runtime (#1438)",
+      "feat: move PWA Library maintenance to Library Core (#1437)",
+      "feat: move PWA FeedItem writes to Library Core (#1436)",
+      "feat: move PWA Accounts to Library Core (#1435)",
+      "feat: move PWA People lifecycle to Library Core (#1434)",
+      "feat: route PWA people through Library Core (#1433)",
+      "feat: route PWA preferences through Library Core (#1432)",
+      "feat: route PWA RSS configuration through Library Core (#1431)",
+      "feat: route PWA archive maintenance through Library Core (#1430)",
+      "feat: save PWA links through SQLite Library Core (#1429)",
+      "feat: route PWA item deletion through Library Core (#1428)",
+      "fix: make Library Core assignments idempotent (#1427)",
+      "feat: route PWA bulk actions through Library Core (#1426)",
+      "fix: start SQLite backups without Automerge (#1425)",
+      "fix: preserve release publication output (#1424)",
+      "perf: bound map renderer memory (#1423)"
+    ]
+  },
+  "release": {
+    "deck": "Retire PWA Automerge runtime, move PWA Library maintenance to Library Core, and refresh v26.8.1300-dev release",
+    "features": [
+      "Retire PWA Automerge runtime",
+      "Move PWA Library maintenance to Library Core",
+      "Write daily SQLite backups without loading the legacy document engine"
+    ],
+    "fixes": [
+      "Recover stranded actor lease acquisitions",
+      "Make Library Core assignments idempotent",
+      "Preserve release publication output",
+      "Stop Freed Desktop from loading the retired Automerge engine after startup",
+      "Reclaim Freed Desktop WebKit memory after leaving the geographic map",
+      "Bound map renderer memory on large libraries"
+    ],
+    "followUps": [
+      "Finish the bounded-memory Library Core cutover and repair large-Library map behavior",
+      "The SQLite Library Core is ready for real-world testing",
+      "Run Freed Desktop on native SQLite without an Automerge worker or WASM runtime"
+    ]
+  },
+  "releaseBody": "(AI Generated).\n\n## Freed v26.8.1303-dev\n\nRetire PWA Automerge runtime, move PWA Library maintenance to Library Core, and refresh v26.8.1300-dev release\n\n### Features\n\n- Retire PWA Automerge runtime\n- Move PWA Library maintenance to Library Core\n- Write daily SQLite backups without loading the legacy document engine\n\n### Fixes\n\n- Recover stranded actor lease acquisitions\n- Make Library Core assignments idempotent\n- Preserve release publication output\n- Stop Freed Desktop from loading the retired Automerge engine after startup\n- Reclaim Freed Desktop WebKit memory after leaving the geographic map\n- Bound map renderer memory on large libraries\n\n### Follow-ups\n\n- Finish the bounded-memory Library Core cutover and repair large-Library map behavior\n- The SQLite Library Core is ready for real-world testing\n- Run Freed Desktop on native SQLite without an Automerge worker or WASM runtime\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+}

--- a/release-notes/releases/v26.8.1303-dev.json
+++ b/release-notes/releases/v26.8.1303-dev.json
@@ -3,7 +3,7 @@
   "version": "26.8.1303-dev",
   "channel": "dev",
   "dayKey": "26.8.13",
-  "approved": false,
+  "approved": true,
   "editorialNotes": [],
   "generatedAt": "2026-08-14T00:51:55.994Z",
   "model": "heuristic",
@@ -107,7 +107,7 @@
     ]
   },
   "release": {
-    "deck": "Retire PWA Automerge runtime, move PWA Library maintenance to Library Core, and refresh v26.8.1300-dev release",
+    "deck": "Run the Freed Library on SQLite and bounded IndexedDB without the legacy Automerge runtime, with substantially lower geographic Map memory",
     "features": [
       "Retire PWA Automerge runtime",
       "Move PWA Library maintenance to Library Core",
@@ -122,10 +122,10 @@
       "Bound map renderer memory on large libraries"
     ],
     "followUps": [
-      "Finish the bounded-memory Library Core cutover and repair large-Library map behavior",
-      "The SQLite Library Core is ready for real-world testing",
-      "Run Freed Desktop on native SQLite without an Automerge worker or WASM runtime"
+      "Exercise the SQLite-only Desktop and PWA clients against real libraries",
+      "Verify restore behavior across the retained daily backup generations",
+      "Measure SQLite and IndexedDB memory on older low-memory devices"
     ]
   },
-  "releaseBody": "(AI Generated).\n\n## Freed v26.8.1303-dev\n\nRetire PWA Automerge runtime, move PWA Library maintenance to Library Core, and refresh v26.8.1300-dev release\n\n### Features\n\n- Retire PWA Automerge runtime\n- Move PWA Library maintenance to Library Core\n- Write daily SQLite backups without loading the legacy document engine\n\n### Fixes\n\n- Recover stranded actor lease acquisitions\n- Make Library Core assignments idempotent\n- Preserve release publication output\n- Stop Freed Desktop from loading the retired Automerge engine after startup\n- Reclaim Freed Desktop WebKit memory after leaving the geographic map\n- Bound map renderer memory on large libraries\n\n### Follow-ups\n\n- Finish the bounded-memory Library Core cutover and repair large-Library map behavior\n- The SQLite Library Core is ready for real-world testing\n- Run Freed Desktop on native SQLite without an Automerge worker or WASM runtime\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+  "releaseBody": "(AI Generated).\n\n## Freed v26.8.1303-dev\n\nRun the Freed Library on SQLite and bounded IndexedDB without the legacy Automerge runtime, with substantially lower geographic Map memory\n\n### Features\n\n- Retire PWA Automerge runtime\n- Move PWA Library maintenance to Library Core\n- Write daily SQLite backups without loading the legacy document engine\n\n### Fixes\n\n- Recover stranded actor lease acquisitions\n- Make Library Core assignments idempotent\n- Preserve release publication output\n- Stop Freed Desktop from loading the retired Automerge engine after startup\n- Reclaim Freed Desktop WebKit memory after leaving the geographic map\n- Bound map renderer memory on large libraries\n\n### Follow-ups\n\n- Exercise the SQLite-only Desktop and PWA clients against real libraries\n- Verify restore behavior across the retained daily backup generations\n- Measure SQLite and IndexedDB memory on older low-memory devices\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
 }

--- a/release-notes/releases/v26.8.1303-dev.md
+++ b/release-notes/releases/v26.8.1303-dev.md
@@ -1,0 +1,34 @@
+(AI Generated).
+
+## Freed v26.8.1303-dev
+
+Retire PWA Automerge runtime, move PWA Library maintenance to Library Core, and refresh v26.8.1300-dev release
+
+### Features
+
+- Retire PWA Automerge runtime
+- Move PWA Library maintenance to Library Core
+- Write daily SQLite backups without loading the legacy document engine
+
+### Fixes
+
+- Recover stranded actor lease acquisitions
+- Make Library Core assignments idempotent
+- Preserve release publication output
+- Stop Freed Desktop from loading the retired Automerge engine after startup
+- Reclaim Freed Desktop WebKit memory after leaving the geographic map
+- Bound map renderer memory on large libraries
+
+### Follow-ups
+
+- Finish the bounded-memory Library Core cutover and repair large-Library map behavior
+- The SQLite Library Core is ready for real-world testing
+- Run Freed Desktop on native SQLite without an Automerge worker or WASM runtime
+
+### Downloads
+
+**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  
+**Windows:** `.exe` (NSIS installer)  
+**Linux:** `.AppImage`  
+
+> macOS downloads are signed and notarized for normal Gatekeeper installation.

--- a/release-notes/releases/v26.8.1303-dev.md
+++ b/release-notes/releases/v26.8.1303-dev.md
@@ -2,7 +2,7 @@
 
 ## Freed v26.8.1303-dev
 
-Retire PWA Automerge runtime, move PWA Library maintenance to Library Core, and refresh v26.8.1300-dev release
+Run the Freed Library on SQLite and bounded IndexedDB without the legacy Automerge runtime, with substantially lower geographic Map memory
 
 ### Features
 
@@ -21,9 +21,9 @@ Retire PWA Automerge runtime, move PWA Library maintenance to Library Core, and 
 
 ### Follow-ups
 
-- Finish the bounded-memory Library Core cutover and repair large-Library map behavior
-- The SQLite Library Core is ready for real-world testing
-- Run Freed Desktop on native SQLite without an Automerge worker or WASM runtime
+- Exercise the SQLite-only Desktop and PWA clients against real libraries
+- Verify restore behavior across the retained daily backup generations
+- Measure SQLite and IndexedDB memory on older low-memory devices
 
 ### Downloads
 

--- a/release-notes/releases/v26.8.1303-dev.md
+++ b/release-notes/releases/v26.8.1303-dev.md
@@ -16,8 +16,8 @@ Run the Freed Library on SQLite and bounded IndexedDB without the legacy Automer
 - Make Library Core assignments idempotent
 - Preserve release publication output
 - Stop Freed Desktop from loading the retired Automerge engine after startup
-- Reclaim Freed Desktop WebKit memory after leaving the geographic map
 - Bound map renderer memory on large libraries
+- Reclaim Freed Desktop WebKit memory after leaving the geographic map
 
 ### Follow-ups
 


### PR DESCRIPTION
(AI Generated).

## Summary
- Prepare the signed dev release containing the SQLite-only Library runtime and bounded MapLibre worker fix.
- Approve corrected release notes for the complete same-day SQLite cutover.

## Testing
- All product checks in `npm run validate:feature` passed locally.
- `node scripts/validate-release-notes.mjs release-notes/releases/v26.8.1303-dev.json release-notes/releases/v26.8.1300-dev.json release-notes/releases/v26.8.1301-dev.json release-notes/releases/v26.8.1302-dev.json`