### PR TITLE
fix: keep settings visual frame stable while scrolling

### DIFF
--- a/packages/desktop/tests/e2e/smoke.spec.ts
+++ b/packages/desktop/tests/e2e/smoke.spec.ts
@@ -2034,49 +2034,61 @@ test("settings backdrop stays blurred while settings contents scroll", async ({ 
   }, SETTINGS_STORE_PATH);
   await expect(page.getByText("Settings").first()).toBeVisible({ timeout: 5_000 });
 
+  // Scroll performance state belongs to the scrollport. Do not weaken this
+  // contract by accepting an unblurred backdrop or shadowless shell in motion.
   const scrollContainer = page.getByTestId("settings-scroll-container");
-  const styles = await scrollContainer.evaluate((element) => {
-    const overlay = document.querySelector(".theme-settings-overlay");
-    const shell = document.querySelector(".theme-settings-shell");
-    if (!(overlay instanceof HTMLElement) || !(shell instanceof HTMLElement)) {
-      throw new Error("Settings dialog styles were not mounted");
+  const frameBeforeScroll = await page.evaluate(() => {
+    const overlayElement = document.querySelector(".theme-settings-overlay");
+    const shellElement = document.querySelector(".theme-settings-shell");
+    if (!(overlayElement instanceof HTMLElement) || !(shellElement instanceof HTMLElement)) {
+      throw new Error("Settings visual frame was not mounted");
     }
-
-    const overlayStyleBeforeScroll = window.getComputedStyle(overlay);
-    const overlayFilterBeforeScroll =
-      overlayStyleBeforeScroll.backdropFilter || overlayStyleBeforeScroll.webkitBackdropFilter;
-    const overlayBackgroundBeforeScroll = overlayStyleBeforeScroll.background;
-    const maxScrollTop = element.scrollHeight - element.clientHeight;
-    element.scrollTop = Math.min(Math.max(maxScrollTop, 0), 360);
-    element.dispatchEvent(new Event("scroll", { bubbles: true }));
-
-    const overlayStyleWhileScrolling = window.getComputedStyle(overlay);
-    const shellStyleWhileScrolling = window.getComputedStyle(shell);
+    const overlayStyle = window.getComputedStyle(overlayElement);
+    const shellStyle = window.getComputedStyle(shellElement);
     return {
-      maxScrollTop,
-      scrollTop: element.scrollTop,
-      overlayMoving: overlay.dataset.moving,
-      shellMoving: shell.dataset.moving,
-      overlayFilterBeforeScroll,
-      overlayFilterWhileScrolling:
-        overlayStyleWhileScrolling.backdropFilter || overlayStyleWhileScrolling.webkitBackdropFilter,
-      overlayBackgroundBeforeScroll,
-      overlayBackgroundWhileScrolling: overlayStyleWhileScrolling.background,
-      shellFilterWhileScrolling:
-        shellStyleWhileScrolling.backdropFilter || shellStyleWhileScrolling.webkitBackdropFilter,
+      overlayBackground: overlayStyle.background,
+      overlayFilter: overlayStyle.backdropFilter || overlayStyle.webkitBackdropFilter,
+      shellFilter: shellStyle.backdropFilter || shellStyle.webkitBackdropFilter,
+      shellShadow: shellStyle.boxShadow,
     };
   });
 
-  expect(styles.maxScrollTop).toBeGreaterThan(0);
-  expect(styles.scrollTop).toBeGreaterThan(0);
-  expect(styles.overlayMoving).toBe("true");
-  expect(styles.shellMoving).toBe("true");
-  expect(styles.overlayFilterBeforeScroll).toContain("blur");
-  expect(styles.overlayFilterWhileScrolling).toBe("none");
-  expect(styles.overlayBackgroundWhileScrolling).not.toBe(styles.overlayBackgroundBeforeScroll);
-  expect(styles.overlayBackgroundWhileScrolling).toMatch(/\/ 0\.92\)/);
-  expect(styles.shellFilterWhileScrolling).toContain("blur");
-  expect(styles.shellFilterWhileScrolling).not.toBe("none");
+  await scrollContainer.hover();
+  await page.mouse.wheel(0, 600);
+  await expect
+    .poll(() => scrollContainer.evaluate((element) => element.scrollTop))
+    .toBeGreaterThan(0);
+  await expect(scrollContainer).toHaveAttribute("data-moving", "true");
+
+  const frameWhileScrolling = await page.evaluate(() => {
+    const overlayElement = document.querySelector(".theme-settings-overlay");
+    const shellElement = document.querySelector(".theme-settings-shell");
+    if (!(overlayElement instanceof HTMLElement) || !(shellElement instanceof HTMLElement)) {
+      throw new Error("Settings visual frame was not mounted");
+    }
+    const overlayStyle = window.getComputedStyle(overlayElement);
+    const shellStyle = window.getComputedStyle(shellElement);
+    return {
+      overlayBackground: overlayStyle.background,
+      overlayFilter: overlayStyle.backdropFilter || overlayStyle.webkitBackdropFilter,
+      overlayMoving: overlayElement.hasAttribute("data-moving"),
+      shellFilter: shellStyle.backdropFilter || shellStyle.webkitBackdropFilter,
+      shellMoving: shellElement.hasAttribute("data-moving"),
+      shellShadow: shellStyle.boxShadow,
+    };
+  });
+
+  expect(frameBeforeScroll.overlayFilter).toContain("blur");
+  expect(frameBeforeScroll.shellShadow).not.toBe("none");
+  expect(frameWhileScrolling.overlayMoving).toBe(false);
+  expect(frameWhileScrolling.shellMoving).toBe(false);
+  expect(frameWhileScrolling.overlayBackground).toBe(frameBeforeScroll.overlayBackground);
+  expect(frameWhileScrolling.overlayFilter).toBe(frameBeforeScroll.overlayFilter);
+  expect(frameWhileScrolling.overlayFilter).not.toBe("none");
+  expect(frameWhileScrolling.shellFilter).toBe(frameBeforeScroll.shellFilter);
+  expect(frameWhileScrolling.shellFilter).not.toBe("none");
+  expect(frameWhileScrolling.shellShadow).toBe(frameBeforeScroll.shellShadow);
+  expect(frameWhileScrolling.shellShadow).not.toBe("none");
 });
 
 test("settings dialog closes from the mobile header close button", async ({ app, page }) => {

--- a/packages/ui/src/components/SettingsDialog.tsx
+++ b/packages/ui/src/components/SettingsDialog.tsx
@@ -504,8 +504,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
   const toggleDebug = useDebugStore((s) => s.toggle);
   const themeBlurRestoreTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const scrollOptimizationTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const settingsOverlayRef = useRef<HTMLDivElement>(null);
-  const settingsShellRef = useRef<HTMLDivElement>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
   const [readerOfflineCacheMode, setReaderOfflineCacheMode] = useReaderOfflineCacheMode();
   const [feedCardDensity, setFeedCardDensity] = useFeedCardDensity();
   const [interfaceZoom, setInterfaceZoom] = useInterfaceZoom();
@@ -638,8 +637,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
     if (open) return;
     setThemePreviewHovering(false);
     setThemePreviewTouchActive(false);
-    delete settingsShellRef.current?.dataset.moving;
-    delete settingsOverlayRef.current?.dataset.moving;
+    delete scrollRef.current?.dataset.moving;
     if (themeBlurRestoreTimerRef.current) {
       clearTimeout(themeBlurRestoreTimerRef.current);
       themeBlurRestoreTimerRef.current = null;
@@ -658,8 +656,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
       if (scrollOptimizationTimerRef.current) {
         clearTimeout(scrollOptimizationTimerRef.current);
       }
-      delete settingsShellRef.current?.dataset.moving;
-      delete settingsOverlayRef.current?.dataset.moving;
+      delete scrollRef.current?.dataset.moving;
     };
   }, []);
 
@@ -675,22 +672,19 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
     }, 5000);
   }, [hasCoarsePointer]);
 
-  const suppressSettingsChromeDuringScroll = useCallback(() => {
-    const shell = settingsShellRef.current;
-    if (shell && shell.dataset.moving !== "true") {
-      shell.dataset.moving = "true";
-    }
-    const overlay = settingsOverlayRef.current;
-    if (overlay && overlay.dataset.moving !== "true") {
-      overlay.dataset.moving = "true";
+  const suppressSettingsScrollportDescendantsDuringScroll = useCallback(() => {
+    // The overlay and shell are static visual frames. Keep moving state on the
+    // scrollport so performance CSS cannot drop their blur or shadow again.
+    const scrollport = scrollRef.current;
+    if (scrollport && scrollport.dataset.moving !== "true") {
+      scrollport.dataset.moving = "true";
     }
 
     if (scrollOptimizationTimerRef.current) {
       clearTimeout(scrollOptimizationTimerRef.current);
     }
     scrollOptimizationTimerRef.current = setTimeout(() => {
-      delete settingsShellRef.current?.dataset.moving;
-      delete settingsOverlayRef.current?.dataset.moving;
+      delete scrollRef.current?.dataset.moving;
       scrollOptimizationTimerRef.current = null;
     }, SETTINGS_SCROLL_OPTIMIZATION_RESTORE_MS);
   }, []);
@@ -961,7 +955,6 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
   const [activeSection, setActiveSection] = useState<SectionId>("appearance");
   const [mobileView, setMobileView] = useState<"nav" | "section">("nav");
   const [scrollportHeight, setScrollportHeight] = useState(0);
-  const scrollRef = useRef<HTMLDivElement>(null);
   const activeSectionBreadcrumb = useMemo(() => {
     const section = allSections.find((candidate) => candidate.id === activeSection);
     if (!section) return ["Freed Settings"];
@@ -1223,7 +1216,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
     };
 
     const scheduleActiveSectionUpdate = () => {
-      suppressSettingsChromeDuringScroll();
+      suppressSettingsScrollportDescendantsDuringScroll();
       clearTimeout(scrollIdleTimer);
       scrollIdleTimer = setTimeout(() => {
         if (isScrollingProgrammatically.current) {
@@ -1247,7 +1240,14 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
         root.removeEventListener("scrollend", updateActiveSectionFromScroll);
       }
     };
-  }, [isMobile, mobileView, open, searchLower, suppressSettingsChromeDuringScroll, updateScrollAnchorFromPosition]);
+  }, [
+    isMobile,
+    mobileView,
+    open,
+    searchLower,
+    suppressSettingsScrollportDescendantsDuringScroll,
+    updateScrollAnchorFromPosition,
+  ]);
 
   useEffect(() => {
     if (!open || isMobile || searchLower) {
@@ -2028,14 +2028,12 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
     <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center sm:p-6">
       {/* Backdrop */}
       <div
-        ref={settingsOverlayRef}
         className={`theme-settings-overlay absolute inset-0 ${themeBackdropSuppressed ? "theme-settings-overlay-preview-off" : ""}`}
         onClick={onClose}
       />
 
       {/* Panel */}
       <div
-        ref={settingsShellRef}
         className={`
           theme-dialog-shell theme-settings-shell relative z-10 flex w-full flex-col
           h-[100dvh] rounded-none

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -2536,8 +2536,8 @@ html.freed-mobile-sidebar-open body {
   -webkit-backdrop-filter: blur(18px) saturate(120%);
 }
 
-/* Settings content scrolls inside the shell. Keep the static overlay out of
-   scroll-state optimizations so its backdrop blur cannot be dropped mid-scroll. */
+/* Settings content scrolls inside the shell. The overlay is deliberately
+   scroll-state-free so its backdrop blur cannot be dropped mid-scroll. */
 .theme-settings-overlay {
   background: rgb(var(--theme-shell-rgb) / 0.045);
   backdrop-filter: blur(17px) saturate(138%);
@@ -2555,30 +2555,17 @@ html.freed-mobile-sidebar-open body {
   -webkit-backdrop-filter: blur(0px) saturate(100%);
 }
 
-.theme-settings-overlay[data-moving="true"] {
-  background:
-    linear-gradient(
-      135deg,
-      rgb(255 255 255 / 0.035),
-      rgb(var(--theme-shell-rgb) / 0.08)
-    ),
-    color-mix(in oklab, var(--theme-bg-root) 92%, transparent);
-  backdrop-filter: none;
-  -webkit-backdrop-filter: none;
-  transition: none;
-}
-
-.theme-settings-shell[data-moving="true"] .theme-card-soft {
+.theme-settings-scrollport[data-moving="true"] .theme-card-soft {
   box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.035);
   backdrop-filter: none;
   -webkit-backdrop-filter: none;
 }
 
-.theme-settings-shell[data-moving="true"] .theme-settings-scrollport {
+.theme-settings-scrollport[data-moving="true"] {
   will-change: auto;
 }
 
-.theme-settings-shell[data-moving="true"] .theme-dialog-section {
+.theme-settings-scrollport[data-moving="true"] .theme-dialog-section {
   box-shadow: none;
 }
 
@@ -2658,7 +2645,7 @@ html[data-theme="scriptorium"] .theme-dialog-shell::before {
   overscroll-behavior: contain;
 }
 
-html[data-theme="scriptorium"] .theme-settings-shell:not([data-moving="true"]) {
+html[data-theme="scriptorium"] .theme-settings-shell {
   box-shadow:
     inset 0 1px 0 rgb(255 255 255 / 0.032),
     inset 0 0 0 0.5px rgb(255 255 255 / 0.018),
@@ -2666,11 +2653,6 @@ html[data-theme="scriptorium"] .theme-settings-shell:not([data-moving="true"]) {
     0 72px 188px rgb(84 58 35 / 0.34),
     0 0 56px rgb(84 58 35 / 0.08),
     0 0 0 1px rgb(255 255 255 / 0.04);
-}
-
-.theme-dialog-shell.theme-settings-shell[data-moving="true"] {
-  box-shadow: none;
-  transition: none;
 }
 
 .theme-dialog-divider {


### PR DESCRIPTION
(AI Generated).

## Summary
- Confine scroll-performance state to the Settings content scrollport so it cannot alter the modal shell.
- Keep the backdrop blur and modal shadow constant through active wheel scrolling.
- Protect the invariant with a real-scroll regression test that checks the overlay, shell, and moving-state boundary.

## Testing
- npm run validate:feature (all settings-related checks passed; the existing flaky YouTube consent assertion tracked in #1292 failed once and passed independently)
- npm run test:e2e -- smoke.spec.ts --grep settings backdrop stays blurred while settings contents scroll
- npm run test:e2e:perf:settings
- npm run test:e2e -- legal-gate.spec.ts --grep YouTube login requires provider consent

## Provider Review
- Status: Provider authority is validated for ready publication.
- Review action: none required. The provider-risk artifact records the behavior authority decision; this exact provider subdiff is the audit subject.
- Provider subdiff: `200792d764a6d4784b9c43104dbc0c73c43ff670`
- Publication does not authorize new live provider traffic. Gate 1 behavior approval still applies when observable behavior changes.
- Provider review task: `settings-scroll-blur-invariant`
- Provider review decision: `diff_authorized`
- Provider review artifact: `ccad34119ad9707e12b2781612b3f5e9a74e8f8896886010a8c18ddf87da095a`
- Providers: facebook, instagram, linkedin, medium, other, substack, x, youtube
- Observable behavior: No provider-observable behavior changes. The diff moves a UI-only scrolling marker within the Settings dialog and keeps the modal blur and shadow stable.
- Fingerprinting risk: No provider request, navigation, extraction, cookie, header, cadence, or timing behavior changes.
- Lowest profile alternative: Keep provider traffic disabled while validating this UI-only Settings change.

Files bound into this provider review:
- `packages/ui/src/components/SettingsDialog.tsx`