### PR TITLE
fix: wrap settings theme selector evenly

### DIFF
--- a/packages/ui/src/components/SettingsDialog.tsx
+++ b/packages/ui/src/components/SettingsDialog.tsx
@@ -1458,7 +1458,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
               >
                 <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                   <p className="theme-settings-theme-card__label text-sm font-semibold text-text-primary">Theme</p>
-                  <div className="flex flex-wrap items-center gap-2 sm:flex-nowrap">
+                  <div className="theme-settings-theme-options">
                     {THEME_DEFINITIONS.map((theme) => {
                       const isActive = themeId === theme.id;
                       return (

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -2715,7 +2715,36 @@ html[data-theme="dark-star"]
 }
 
 .theme-settings-theme-card {
+  container-type: inline-size;
   cursor: pointer;
+}
+
+.theme-settings-theme-options {
+  display: grid;
+  min-width: 0;
+  grid-template-columns: repeat(6, max-content);
+  align-items: center;
+  justify-content: start;
+  gap: 0.5rem;
+}
+
+@media (min-width: 640px) {
+  .theme-settings-theme-options {
+    flex: 1 1 0%;
+    justify-content: end;
+  }
+}
+
+@container (max-width: 32rem) {
+  .theme-settings-theme-options {
+    grid-template-columns: repeat(3, max-content);
+  }
+}
+
+@container (max-width: 15rem) {
+  .theme-settings-theme-options {
+    grid-template-columns: repeat(2, max-content);
+  }
 }
 
 .theme-settings-theme-card__label {


### PR DESCRIPTION
(AI Generated).

## Summary
- Use a container-responsive grid so theme choices render as six, three plus three, or two plus two plus two without orphaned rows.

## Testing
- npm run validate:feature

## Provider Review
- Status: Provider authority is validated for ready publication.
- Review action: none required. The provider-risk artifact records the behavior authority decision; this exact provider subdiff is the audit subject.
- Provider subdiff: `424a9fcf20cc92176c31b87494da2a2011a91a0f`
- Publication does not authorize new live provider traffic. Gate 1 behavior approval still applies when observable behavior changes.
- Provider review task: `settings-theme-selector-balanced-grid`
- Provider review decision: `diff_authorized`
- Provider review artifact: `c9f00c5f3ebc2e1bae9a38b22533fe197932a523dbe7ad4ecf9e226fe3103ff8`
- Providers: facebook, instagram, linkedin, medium, other, substack, x, youtube
- Observable behavior: No provider-observable behavior changes. The settings theme selector uses equal-count CSS grid rows while theme selection events and provider settings logic remain unchanged.
- Fingerprinting risk: No request, navigation, extraction, cookie, header, login, retry, cadence, timing, or provider activity changes.
- Lowest profile alternative: Keep provider traffic disabled and validate the settings layout in the local mocked Freed Desktop preview.

Files bound into this provider review:
- `packages/ui/src/components/SettingsDialog.tsx`