### PR TITLE
fix: decouple production website validation

### DIFF
--- a/scripts/validate-worktree.mjs
+++ b/scripts/validate-worktree.mjs
@@ -872,7 +872,9 @@ export function buildValidationPlan(mode, changedFiles) {
 
   if (normalizedMode === "production") {
     const plan = [
-      ...buildValidationPlan("dev", changedFiles),
+      ...buildValidationPlan("dev", changedFiles).filter(
+        (item) => item.label !== "root build" && item.label !== "website tests",
+      ),
       nodeCommand("release notes shared tests", [
         "--test",
         path.join("scripts", "release-notes-shared.test.mjs"),
@@ -880,7 +882,9 @@ export function buildValidationPlan(mode, changedFiles) {
       // The website is a separate lane. It ships from `www` through the
       // publish-website job against the reviewed marketing branch, so building
       // it here proved nothing about the Desktop release and coupled two lanes
-      // that AGENTS.md keeps apart.
+      // that AGENTS.md keeps apart. The root build fanout also includes the
+      // website, so production validation inherits the already-green dev
+      // product build and reruns only the release-critical product checks.
       //
       // The desktop production build is also gone: the release matrix runs the
       // real signed build on all four platforms, so building the frontend once

--- a/scripts/validate-worktree.test.mjs
+++ b/scripts/validate-worktree.test.mjs
@@ -373,6 +373,15 @@ test("PWA-only provider-visible changes stay in the PWA validation lane", () => 
   );
 
   assert.ok(labels.includes("pwa production build"));
+
+  assert.ok(
+    !labels.includes("root build"),
+    "the production promotion must not fan out into the separate website lane",
+  );
+  assert.ok(
+    !labels.includes("website tests"),
+    "the production promotion must not test the separate website lane",
+  );
   assert.ok(labels.includes("pwa unit tests"));
   assert.ok(!labels.includes("desktop social provider unit tests"));
   assert.ok(!labels.includes("desktop social provider e2e"));


### PR DESCRIPTION
(AI Generated).

## Summary
- Keep production product validation out of the separate website branch lane.
- Avoid the root build fanout because it includes the stale `main` website copy even though `www` is the marketing authority.
- Preserve the exact green dev product build and rerun only release-critical product checks.

## Testing
- `PATH=/Users/aubreyfalconer/.nvm/versions/node/v24.14.1/bin:$PATH node --test scripts/validate-worktree.test.mjs`
- `git diff --check`