### PR TITLE
fix: isolate production validation from website

### DIFF
--- a/scripts/validate-worktree.mjs
+++ b/scripts/validate-worktree.mjs
@@ -873,7 +873,13 @@ export function buildValidationPlan(mode, changedFiles) {
   if (normalizedMode === "production") {
     const plan = [
       ...buildValidationPlan("dev", changedFiles).filter(
-        (item) => item.label !== "root build" && item.label !== "website tests",
+        (item) =>
+          ![
+            "root build",
+            "root typecheck",
+            "root lint",
+            "website tests",
+          ].includes(item.label),
       ),
       nodeCommand("release notes shared tests", [
         "--test",
@@ -882,8 +888,8 @@ export function buildValidationPlan(mode, changedFiles) {
       // The website is a separate lane. It ships from `www` through the
       // publish-website job against the reviewed marketing branch, so building
       // it here proved nothing about the Desktop release and coupled two lanes
-      // that AGENTS.md keeps apart. The root build fanout also includes the
-      // website, so production validation inherits the already-green dev
+      // that AGENTS.md keeps apart. The root build, typecheck, and lint fanouts
+      // also include the website, so production validation inherits the green dev
       // product build and reruns only the release-critical product checks.
       //
       // The desktop production build is also gone: the release matrix runs the

--- a/scripts/validate-worktree.test.mjs
+++ b/scripts/validate-worktree.test.mjs
@@ -373,15 +373,6 @@ test("PWA-only provider-visible changes stay in the PWA validation lane", () => 
   );
 
   assert.ok(labels.includes("pwa production build"));
-
-  assert.ok(
-    !labels.includes("root build"),
-    "the production promotion must not fan out into the separate website lane",
-  );
-  assert.ok(
-    !labels.includes("website tests"),
-    "the production promotion must not test the separate website lane",
-  );
   assert.ok(labels.includes("pwa unit tests"));
   assert.ok(!labels.includes("desktop social provider unit tests"));
   assert.ok(!labels.includes("desktop social provider e2e"));
@@ -612,6 +603,23 @@ test("production plan includes dev desktop gates without duplicating shipped bui
 
   // The PWA is not otherwise built by the release workflow, so it stays.
   assert.ok(labels.includes("pwa production build"));
+
+  assert.ok(
+    !labels.includes("root build"),
+    "the production promotion must not build the separate website lane",
+  );
+  assert.ok(
+    !labels.includes("root typecheck"),
+    "the production promotion must not typecheck the separate website lane",
+  );
+  assert.ok(
+    !labels.includes("root lint"),
+    "the production promotion must not lint the separate website lane",
+  );
+  assert.ok(
+    !labels.includes("website tests"),
+    "the production promotion must not test the separate website lane",
+  );
 
   // The release matrix runs the real signed desktop build on all four
   // platforms. Building the frontend once more here made it five builds to


### PR DESCRIPTION
(AI Generated).

## Summary
- Exclude root build, typecheck, lint, and website tests from product production validation.
- Keep the exact green dev product receipt and rerun release-critical Desktop, PWA, native, and release checks.

## Testing
- PATH=/Users/aubreyfalconer/.nvm/versions/node/v24.14.1/bin:$PATH node --test scripts/validate-worktree.test.mjs
- git diff --check