### PR TITLE
fix: align Friends graph controls

### DIFF
--- a/packages/desktop/tests/e2e/theme-switching.spec.ts
+++ b/packages/desktop/tests/e2e/theme-switching.spec.ts
@@ -597,7 +597,6 @@ test("friends graph controls align to the graph lane between sidebars", async ({
       if (!(header instanceof HTMLElement)) return null;
 
       const graphRect = graph.getBoundingClientRect();
-      const fitAllRect = fitAll.getBoundingClientRect();
       const controlsRect = controls.getBoundingClientRect();
       const sidebarRect = sidebar.getBoundingClientRect();
       const navigationHandleRect = navigationHandle.getBoundingClientRect();
@@ -615,8 +614,9 @@ test("friends graph controls align to the graph lane between sidebars", async ({
         graphToRightRailPx: Math.round(friendsHandleCenter - graphRect.right),
         rightRailToSidebarPx: Math.round(friendsSidebarRect.left - friendsHandleCenter),
         bottomGapPx: Math.round(window.innerHeight - graphRect.bottom),
-        fitAllTopGapPx: Math.round(fitAllRect.top - graphRect.top),
-        controlsRightGapPx: Math.round(graphRect.right - controlsRect.right),
+        controlsTopDeltaPx: Math.round(controlsRect.top - friendsSidebarRect.top),
+        controlsToFriendsSidebarGapPx: Math.round(friendsSidebarRect.left - controlsRect.right),
+        friendsSidebarOuterGapPx: Math.round(window.innerWidth - friendsSidebarRect.right),
         friendsSidebarTopGapPx: Math.round(friendsSidebarRect.top - headerRect.bottom),
         sidebarTopDeltaPx: Math.round(friendsSidebarRect.top - sidebarRect.top),
         navigationHandleTopDeltaPx: Math.round(navigationHandleRect.top - handleRect.top),
@@ -634,8 +634,9 @@ test("friends graph controls align to the graph lane between sidebars", async ({
     // The graph is the primary full-height canvas. Each floating sidebar owns
     // its panel inset, so the graph itself reaches the window edge.
     bottomGapPx: 0,
-    fitAllTopGapPx: 16,
-    controlsRightGapPx: 16,
+    controlsTopDeltaPx: 0,
+    controlsToFriendsSidebarGapPx: 8,
+    friendsSidebarOuterGapPx: 8,
     friendsSidebarTopGapPx: 8,
     sidebarTopDeltaPx: 0,
     navigationHandleTopDeltaPx: 0,

--- a/packages/ui/src/components/friends/FriendGraph.tsx
+++ b/packages/ui/src/components/friends/FriendGraph.tsx
@@ -94,6 +94,7 @@ interface FriendGraphProps {
   friendSuggestionStrengthByAccount?: Map<string, FriendCandidateConfidence>;
   themeId?: ThemeId;
   presentationVisible?: boolean;
+  controlsAdjacentToSidebar?: boolean;
 }
 
 interface GraphContextMenuState {
@@ -447,6 +448,7 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
     friendSuggestionStrengthByAccount,
     themeId,
     presentationVisible = true,
+    controlsAdjacentToSidebar = false,
   },
   ref,
 ) {
@@ -1365,7 +1367,18 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
       <div
         data-testid="friend-graph-controls"
         data-graph-gesture-ignore="true"
-        className="absolute right-3 top-3 z-20 flex items-center gap-2 sm:right-4 sm:top-4"
+        className={`absolute z-20 flex items-center gap-2 ${
+          controlsAdjacentToSidebar
+            ? "top-[var(--feed-card-gap,8px)]"
+            : "right-3 top-3 sm:right-4 sm:top-4"
+        }`}
+        style={
+          controlsAdjacentToSidebar
+            // The control crosses 4px into the 12px resize gutter so the
+            // remaining 8px matches the detail panel's outer window inset.
+            ? { right: "calc(var(--feed-card-gap, 8px) - 0.75rem)" }
+            : undefined
+        }
       >
         <button type="button" className={CANVAS_CONTROL_BASE} onClick={fitAll}>
           Fit all

--- a/packages/ui/src/components/friends/FriendsView.tsx
+++ b/packages/ui/src/components/friends/FriendsView.tsx
@@ -2204,6 +2204,7 @@ export function FriendsView({
                 }
                 themeId={themeId}
                 presentationVisible={showGraphSurface}
+                controlsAdjacentToSidebar={showDesktopSidebar}
               />
               {friendsRows.graphLoading ? renderGraphLoadingState(true) : null}
             </>


### PR DESCRIPTION
(AI Generated).

## Summary
- Align the Friends graph control cluster with the detail panel top edge and reuse the panel's 8px outer spacing across the resize gutter.

## Testing
- Focused Friends layout e2e passed. Feature validation passed through all product checks; one unrelated feed perf startup timeout passed on immediate focused rerun, and all remaining perf lanes passed.