### PR TITLE
fix: preview live theme tokens everywhere

### DIFF
--- a/packages/ui/src/components/friends/FriendAvatar.tsx
+++ b/packages/ui/src/components/friends/FriendAvatar.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { personInitialsForName } from "../../lib/friend-avatar.js";
 import { createFriendAvatarPalette } from "../../lib/friend-avatar-style.js";
-import { useThemePreference } from "../../lib/theme.js";
+import { useAppliedThemeId } from "../../lib/theme.js";
 
 interface FriendAvatarProps {
   name: string;
@@ -16,7 +16,7 @@ export function FriendAvatar({
   size,
   className = "",
 }: FriendAvatarProps) {
-  const [themeId] = useThemePreference();
+  const themeId = useAppliedThemeId();
   const palette = createFriendAvatarPalette(themeId);
   const initials = personInitialsForName(name);
   const [failedUrl, setFailedUrl] = useState<string | null>(null);

--- a/packages/ui/src/components/friends/FriendsView.tsx
+++ b/packages/ui/src/components/friends/FriendsView.tsx
@@ -82,7 +82,7 @@ import {
   setDevicePersonGraphPosition,
   useDeviceGraphLayout,
 } from "../../lib/device-graph-layout.js";
-import { useThemePreference } from "../../lib/theme.js";
+import { useAppliedThemeId } from "../../lib/theme.js";
 
 const DEFAULT_SIDEBAR_WIDTH = 360;
 const MIN_SIDEBAR_WIDTH = 280;
@@ -630,7 +630,7 @@ export function FriendsView({
   const pendingMatchCount = useAppStore((s) => s.pendingMatchCount);
   const [deviceDisplay, setDeviceDisplay] = useDeviceDisplayPreferences();
   const deviceGraphLayout = useDeviceGraphLayout();
-  const [themeId] = useThemePreference();
+  const themeId = useAppliedThemeId();
   const friendSuggestionPreferences = useAppStore(
     (s) => s.preferences.friendSuggestions,
   );

--- a/packages/ui/src/components/layout/BackgroundAtmosphere.tsx
+++ b/packages/ui/src/components/layout/BackgroundAtmosphere.tsx
@@ -2,13 +2,11 @@
 
 import { useEffect, useMemo, useState } from "react";
 import {
-  DEFAULT_THEME_ID,
   getThemeDefinition,
-  resolveThemeId,
-  type ThemeId,
   type ThemeBackgroundRecipe,
   type ThemeBackgroundTextureLayer,
 } from "@freed/shared/themes";
+import { useAppliedThemeId } from "../../lib/theme.js";
 
 const channels = {
   secondary: { rgbVar: "--theme-accent-secondary-rgb", intensity: 1.0 },
@@ -223,7 +221,7 @@ export function BackgroundAtmosphere() {
   const [viewportWidth, setViewportWidth] = useState(DESKTOP_BASELINE_WIDTH);
   const [viewportHeight, setViewportHeight] = useState(MIN_BACKGROUND_HEIGHT);
   const [documentVisible, setDocumentVisible] = useState(getDocumentVisible);
-  const [themeId, setThemeId] = useState<ThemeId>(DEFAULT_THEME_ID);
+  const themeId = useAppliedThemeId();
   const themeRecipe = useMemo(
     () => getThemeDefinition(themeId).background,
     [themeId],
@@ -236,23 +234,8 @@ export function BackgroundAtmosphere() {
   const isLegacyRenderer = rendererMode === "legacy";
 
   useEffect(() => {
-    const initialThemeId = resolveThemeId(
-      document.documentElement.dataset.theme || DEFAULT_THEME_ID,
-    );
     setViewportWidth(window.innerWidth);
     setViewportHeight(window.innerHeight);
-    setThemeId(initialThemeId);
-
-    const observer = new MutationObserver(() => {
-      const nextThemeId = resolveThemeId(
-        document.documentElement.dataset.theme || DEFAULT_THEME_ID,
-      );
-      setThemeId(nextThemeId);
-    });
-    observer.observe(document.documentElement, {
-      attributes: true,
-      attributeFilter: ["data-theme"],
-    });
 
     let rafId = 0;
     const onResize = () => {
@@ -272,7 +255,6 @@ export function BackgroundAtmosphere() {
       window.removeEventListener("resize", onResize);
       document.removeEventListener("visibilitychange", onVisibilityChange);
       cancelAnimationFrame(rafId);
-      observer.disconnect();
     };
   }, []);
 


### PR DESCRIPTION
(AI Generated).

## Summary
- Make Friends Galaxy palettes and generated friend avatars subscribe to the applied preview theme.
- Route the shared background atmosphere through the same applied-theme subscription and remove its duplicate DOM observer.

## Testing
- npm run validate:feature
- npm run test:e2e -- theme-switching.spec.ts background-atmosphere.spec.ts