### PR TITLE
fix: prevent theme preview hover strobing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,4 +39,6 @@ npm-debug.log*
 
 # Playwright MCP debug artifacts
 .playwright-mcp/
+test-results/
+playwright-report/
 .vercel

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,21 @@ Run `./scripts/release.sh` with no args to auto-compute the next version.
 
 **Never write `freed.wtf/app`** — the PWA lives at the subdomain `app.freed.wtf`.
 
+## Website Theme Selector
+
+- The footer theme selector previews fonts and layout, so it must render its
+  interactive preview in a fixed layer captured before the theme changes. Do
+  not replace that layer with an inline-only hover preview. Page reflow can move
+  the control out from under the pointer and create an infinite preview loop.
+- Keep exactly three themes per row in this order: Ember, Midas, Scriptorium,
+  then Starship, Dark Star, Neon.
+- The active swatch is taller than resting themes. Reserve fixed row height for
+  the maximum active state so switching themes never moves either row.
+- Any change to `ThemeSelector.tsx`, `desktop-themes.css`, or the compact theme
+  preview styles must run `npm run test:e2e` from `website/`. The regression test
+  must keep asserting a stable pointer target, fixed row centers, and a taller
+  active swatch.
+
 ## Git Workflow
 
 **Never work directly on `main`.** Always create a git worktree for feature work:

--- a/package-lock.json
+++ b/package-lock.json
@@ -15302,6 +15302,7 @@
         "react-icons": "^5.5.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.58.2",
         "@tailwindcss/postcss": "^4.1.18",
         "@types/node": "^24.10.1",
         "@types/react": "^19.2.5",

--- a/website/package.json
+++ b/website/package.json
@@ -12,7 +12,8 @@
     "generate-changelog": "npx tsx scripts/generate-changelog.ts",
     "start": "next start",
     "generate-feed": "npx tsx scripts/generate-feed.ts",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "test:e2e": "node ../node_modules/playwright/cli.js test -c playwright.config.ts"
   },
   "dependencies": {
     "@floating-ui/react": "^0.27.17",
@@ -27,6 +28,7 @@
     "react-icons": "^5.5.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.58.2",
     "@tailwindcss/postcss": "^4.1.18",
     "@types/node": "^24.10.1",
     "@types/react": "^19.2.5",

--- a/website/playwright.config.ts
+++ b/website/playwright.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig } from "@playwright/test";
+
+const port = Number(process.env.WEBSITE_E2E_PORT ?? 3101);
+const baseURL = `http://127.0.0.1:${port}`;
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  fullyParallel: true,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? "github" : "line",
+  timeout: 30_000,
+  use: {
+    baseURL,
+    trace: "retain-on-failure",
+  },
+  projects: [
+    {
+      name: "desktop-chromium",
+      use: { viewport: { width: 1_280, height: 720 } },
+    },
+    {
+      name: "mobile-chromium",
+      use: { viewport: { width: 390, height: 844 } },
+    },
+  ],
+  webServer: {
+    command: `npm run dev -- --hostname 127.0.0.1 --port ${port}`,
+    url: baseURL,
+    reuseExistingServer: false,
+    timeout: 120_000,
+  },
+});

--- a/website/src/components/Footer.tsx
+++ b/website/src/components/Footer.tsx
@@ -31,7 +31,7 @@ export default function Footer() {
               </span>
             </Link>
             <div className="max-w-[18rem] sm:mt-6">
-              <ThemeSelector />
+              <ThemeSelector compact />
             </div>
           </div>
 

--- a/website/src/components/ThemeSelector.tsx
+++ b/website/src/components/ThemeSelector.tsx
@@ -1,13 +1,31 @@
 "use client";
 
-import type { FocusEvent } from "react";
+import {
+  useEffect,
+  useRef,
+  useState,
+  type FocusEvent as ReactFocusEvent,
+  type MouseEvent as ReactMouseEvent,
+} from "react";
+import { createPortal } from "react-dom";
+import type { ThemeId } from "@freed/shared/themes";
 import { ThemePreviewButton } from "@freed/ui/components/ThemePreviewButton";
 import { Tooltip } from "@freed/ui/components/Tooltip";
 import { THEME_DEFINITIONS, useTheme } from "@/context/ThemeContext";
 
-// Light themes on the first row, dark themes on the second. THEME_DEFINITIONS
-// is ordered for other consumers, so the grid carries its own order instead.
-const THEME_DISPLAY_ORDER: readonly string[] = [
+interface ThemeSelectorProps {
+  compact?: boolean;
+}
+
+interface FloatingRect {
+  left: number;
+  top: number;
+  width: number;
+}
+
+// Light themes occupy the first row and dark themes occupy the second.
+// THEME_DEFINITIONS serves other consumers, so this surface owns its order.
+const THEME_DISPLAY_ORDER: readonly ThemeId[] = [
   "ember",
   "midas",
   "scriptorium",
@@ -16,66 +34,230 @@ const THEME_DISPLAY_ORDER: readonly string[] = [
   "neon",
 ];
 
-// Fixed row slots. Hovering a swatch previews the theme and restyles the
-// button, so content-sized rows would let one swatch resize its own row and
-// shove the other row down. Reserving the slot and centring inside it makes
-// that shift impossible regardless of what any hover or active state does.
-const THEME_GRID_CLASS =
-  "grid w-fit grid-cols-[repeat(3,max-content)] [grid-auto-rows:1.5rem] items-center gap-2";
-
-function displayRank(id: string): number {
+function displayRank(id: ThemeId): number {
   const index = THEME_DISPLAY_ORDER.indexOf(id);
-  // A theme added later but not placed here sorts to the end rather than vanishing.
   return index === -1 ? THEME_DISPLAY_ORDER.length : index;
 }
 
-export default function ThemeSelector() {
+export default function ThemeSelector({ compact = false }: ThemeSelectorProps) {
   const { themeId, setThemeId, previewTheme, revertPreview } = useTheme();
   const orderedThemes = [...THEME_DEFINITIONS].sort(
     (a, b) => displayRank(a.id) - displayRank(b.id),
   );
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
+  const inlineGridRef = useRef<HTMLDivElement | null>(null);
+  const floatingGridRef = useRef<HTMLDivElement | null>(null);
+  const ignoreNextInlineMouseLeaveRef = useRef(false);
+  const [floatingRect, setFloatingRect] = useState<FloatingRect | null>(null);
+  const [stableHeight, setStableHeight] = useState<number | null>(null);
+  const isFloating = compact && floatingRect !== null;
 
-  function handleBlur(event: FocusEvent<HTMLDivElement>) {
+  useEffect(() => {
+    if (!isFloating) {
+      return;
+    }
+
+    function clearFloatingPreview() {
+      setFloatingRect(null);
+      revertPreview();
+    }
+
+    window.addEventListener("resize", clearFloatingPreview);
+    window.addEventListener("scroll", clearFloatingPreview, true);
+    return () => {
+      window.removeEventListener("resize", clearFloatingPreview);
+      window.removeEventListener("scroll", clearFloatingPreview, true);
+    };
+  }, [isFloating, revertPreview]);
+
+  useEffect(() => {
+    if (!wrapperRef.current || typeof ResizeObserver === "undefined") {
+      return;
+    }
+
+    const recordHeight = () => {
+      if (!wrapperRef.current) {
+        return;
+      }
+
+      const nextHeight = Math.ceil(wrapperRef.current.getBoundingClientRect().height);
+      setStableHeight((currentHeight) => {
+        if (currentHeight !== null && currentHeight >= nextHeight) {
+          return currentHeight;
+        }
+
+        return nextHeight;
+      });
+    };
+
+    recordHeight();
+    const observer = new ResizeObserver(recordHeight);
+    observer.observe(wrapperRef.current);
+    window.addEventListener("resize", recordHeight);
+
+    return () => {
+      observer.disconnect();
+      window.removeEventListener("resize", recordHeight);
+    };
+  }, []);
+
+  function activatePreview(nextThemeId: ThemeId) {
+    if (compact && floatingRect === null) {
+      const rect = wrapperRef.current?.getBoundingClientRect();
+      if (rect) {
+        // Theme previews can change page fonts and total document height. Keep
+        // the interactive copy fixed at its captured viewport coordinates so
+        // that global reflow cannot move the swatch out from under the pointer.
+        ignoreNextInlineMouseLeaveRef.current = true;
+        setFloatingRect({
+          left: rect.left,
+          top: rect.top,
+          width: rect.width,
+        });
+      }
+    }
+
+    previewTheme(nextThemeId);
+  }
+
+  function clearPreview() {
+    ignoreNextInlineMouseLeaveRef.current = false;
+    setFloatingRect(null);
+    revertPreview();
+  }
+
+  function commitTheme(nextThemeId: ThemeId) {
+    ignoreNextInlineMouseLeaveRef.current = false;
+    setFloatingRect(null);
+    setThemeId(nextThemeId);
+  }
+
+  function shouldKeepPreview(
+    event:
+      | ReactFocusEvent<HTMLDivElement>
+      | ReactMouseEvent<HTMLDivElement>,
+  ) {
+    const nextTarget = event.relatedTarget;
+    if (!(nextTarget instanceof Node)) {
+      return false;
+    }
+
+    if (event.currentTarget.contains(nextTarget)) {
+      return true;
+    }
+
+    return (
+      inlineGridRef.current?.contains(nextTarget)
+      || floatingGridRef.current?.contains(nextTarget)
+      || false
+    );
+  }
+
+  function handleMouseLeave(
+    layer: "inline" | "floating",
+    event: ReactMouseEvent<HTMLDivElement>,
+  ) {
+    if (layer === "inline" && ignoreNextInlineMouseLeaveRef.current) {
+      ignoreNextInlineMouseLeaveRef.current = false;
+      return;
+    }
+
+    if (!shouldKeepPreview(event)) {
+      clearPreview();
+    }
+  }
+
+  function handleBlurCapture(event: ReactFocusEvent<HTMLDivElement>) {
+    if (!shouldKeepPreview(event)) {
+      clearPreview();
+    }
+  }
+
+  function handleButtonMouseLeave(
+    layer: "inline" | "floating",
+    event: ReactMouseEvent<HTMLButtonElement>,
+  ) {
+    if (layer === "inline" && ignoreNextInlineMouseLeaveRef.current) {
+      ignoreNextInlineMouseLeaveRef.current = false;
+      return;
+    }
+
+    const nextTarget = event.relatedTarget;
     if (
-      event.relatedTarget
-      && event.currentTarget.contains(event.relatedTarget)
+      nextTarget instanceof Element
+      && nextTarget.closest(".theme-preview-button")
     ) {
       return;
     }
 
-    revertPreview();
+    clearPreview();
+  }
+
+  function renderSelectorContent(layer: "inline" | "floating") {
+    return (
+      <>
+        <h4 className="mb-4 font-semibold text-text-primary">Theme</h4>
+        <div
+          ref={layer === "inline" ? inlineGridRef : floatingGridRef}
+          role="group"
+          aria-label="Theme"
+          className="website-theme-grid"
+          data-theme-selector-layer={layer}
+          onMouseLeave={(event) => handleMouseLeave(layer, event)}
+          onBlurCapture={handleBlurCapture}
+        >
+          {orderedThemes.map((theme) => (
+            <Tooltip
+              key={theme.id}
+              side="top"
+              label={theme.name}
+              description={theme.description}
+              className="items-center justify-center"
+            >
+              <ThemePreviewButton
+                theme={theme}
+                active={themeId === theme.id}
+                variant="compact"
+                onMouseEnter={() => activatePreview(theme.id)}
+                onMouseLeave={(event) => handleButtonMouseLeave(layer, event)}
+                onFocus={() => previewTheme(theme.id)}
+                onClick={() => commitTheme(theme.id)}
+                className="website-theme-swatch"
+              />
+            </Tooltip>
+          ))}
+        </div>
+      </>
+    );
   }
 
   return (
-    <div>
-      <h4 className="mb-4 font-semibold text-text-primary">Theme</h4>
+    <div
+      ref={wrapperRef}
+      className="relative"
+      style={stableHeight ? { minHeight: `${stableHeight}px` } : undefined}
+    >
       <div
-        role="group"
-        aria-label="Theme"
-        className={THEME_GRID_CLASS}
-        onMouseLeave={revertPreview}
-        onBlurCapture={handleBlur}
+        aria-hidden={isFloating || undefined}
+        style={isFloating ? { visibility: "hidden" } : undefined}
       >
-        {orderedThemes.map((theme) => (
-          <Tooltip
-            key={theme.id}
-            side="top"
-            label={theme.name}
-            description={theme.description}
-            className="items-center"
-          >
-            <ThemePreviewButton
-              theme={theme}
-              active={themeId === theme.id}
-              variant="compact"
-              onMouseEnter={() => previewTheme(theme.id)}
-              onFocus={() => previewTheme(theme.id)}
-              onClick={() => setThemeId(theme.id)}
-              className="website-theme-swatch"
-            />
-          </Tooltip>
-        ))}
+        {renderSelectorContent("inline")}
       </div>
+      {isFloating && typeof document !== "undefined"
+        ? createPortal(
+          <div
+            className="fixed z-[80]"
+            style={{
+              left: `${floatingRect.left}px`,
+              top: `${floatingRect.top}px`,
+              width: `${floatingRect.width}px`,
+            }}
+          >
+            {renderSelectorContent("floating")}
+          </div>,
+          document.body,
+        )
+        : null}
     </div>
   );
 }

--- a/website/src/desktop-themes.css
+++ b/website/src/desktop-themes.css
@@ -324,27 +324,21 @@ html[data-theme="dark-star"]
   pointer-events: none;
 }
 
-/* Hovering a swatch previews the theme, which repaints the whole shell. The
-   swatch must not change size while that happens: the shared button grows its
-   surface from 1.1rem to 1.65rem on hover, and that reflow resizes the grid
-   row, slides the swatch out from under the pointer, and drops the hover. The
-   preview then reverts and the pointer lands on it again, so the row oscillates.
-   Pin every state to the resting size and drop the scale. Hover feedback stays,
-   via the compact variant's opacity and shadow, neither of which reflows. */
+/* The active swatch is deliberately taller than the other themes. Each row is
+   sized for that maximum state, so moving the active theme between rows cannot
+   move either row. The fixed preview layer in ThemeSelector separately protects
+   the pointer from page-wide font and document-height changes during preview. */
+.website-theme-grid {
+  display: grid;
+  width: max-content;
+  grid-template-columns: repeat(3, max-content);
+  grid-auto-rows: 2.75rem;
+  align-items: center;
+  column-gap: 0.5rem;
+  row-gap: 0.5rem;
+}
+
 .website-theme-swatch:hover,
 .website-theme-swatch:focus-visible {
   transform: none;
-}
-
-.website-theme-swatch .theme-preview-button-surface,
-.website-theme-swatch:hover .theme-preview-button-surface,
-.website-theme-swatch:focus-visible .theme-preview-button-surface,
-.website-theme-swatch.theme-preview-button-active .theme-preview-button-surface,
-.website-theme-swatch.theme-preview-button-active:hover
-  .theme-preview-button-surface,
-.website-theme-swatch.theme-preview-button-active:focus-visible
-  .theme-preview-button-surface {
-  width: 3rem;
-  height: 1.1rem;
-  flex: none;
 }

--- a/website/tests/e2e/README.md
+++ b/website/tests/e2e/README.md
@@ -1,0 +1,24 @@
+# Website browser tests
+
+Run these tests from `website/`:
+
+```bash
+npm run test:e2e
+```
+
+## Theme selector contract
+
+The footer selector previews themes on hover. A preview can change fonts, line
+metrics, and total page height. The interactive selector must therefore move to
+a fixed layer captured before the preview is applied. An inline-only selector
+can move out from under the pointer and enter a preview and revert loop.
+
+The visible grid has three columns in this order:
+
+1. Ember, Midas, Scriptorium
+2. Starship, Dark Star, Neon
+
+Both rows reserve enough height for the active theme. The active swatch remains
+taller than resting themes, but changing the active row cannot move either row.
+The browser test checks the real pointer target and geometry across animation
+frames because DOM presence or a static CSS assertion cannot detect this bug.

--- a/website/tests/e2e/theme-selector.spec.ts
+++ b/website/tests/e2e/theme-selector.spec.ts
@@ -1,0 +1,160 @@
+import { expect, test, type Locator } from "@playwright/test";
+
+interface ThemeButtonGeometry {
+  label: string;
+  pressed: boolean;
+  centerX: number;
+  centerY: number;
+  height: number;
+  surfaceHeight: number;
+}
+
+async function readThemeGeometry(grid: Locator): Promise<ThemeButtonGeometry[]> {
+  return grid.locator(".website-theme-swatch").evaluateAll((buttons) =>
+    buttons.map((button) => {
+      const buttonRect = button.getBoundingClientRect();
+      const surface = button.querySelector(".theme-preview-button-surface");
+      const surfaceRect = surface?.getBoundingClientRect();
+
+      return {
+        label: button.getAttribute("aria-label") ?? "",
+        pressed: button.getAttribute("aria-pressed") === "true",
+        centerX: buttonRect.left + buttonRect.width / 2,
+        centerY: buttonRect.top + buttonRect.height / 2,
+        height: buttonRect.height,
+        surfaceHeight: surfaceRect?.height ?? 0,
+      };
+    }),
+  );
+}
+
+function span(values: number[]): number {
+  return Math.max(...values) - Math.min(...values);
+}
+
+function assertFixedRows(buttons: ThemeButtonGeometry[]) {
+  expect(buttons).toHaveLength(6);
+  expect(span(buttons.slice(0, 3).map((button) => button.centerY))).toBeLessThanOrEqual(0.5);
+  expect(span(buttons.slice(3).map((button) => button.centerY))).toBeLessThanOrEqual(0.5);
+
+  const rowDistance = buttons[3].centerY - buttons[0].centerY;
+  expect(rowDistance).toBeGreaterThan(Math.max(...buttons.map((button) => button.height)));
+  return rowDistance;
+}
+
+test("theme preview stays under the pointer while the active swatch remains taller", async ({
+  page,
+}) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("freed-theme", "ember");
+  });
+  await page.goto("/");
+  await page.locator("footer").scrollIntoViewIfNeeded();
+
+  const inlineGrid = page.locator('[data-theme-selector-layer="inline"]');
+  await expect(inlineGrid).toBeVisible();
+
+  const initialGeometry = await readThemeGeometry(inlineGrid);
+  const initialRowDistance = assertFixedRows(initialGeometry);
+  const activeTheme = initialGeometry.find((button) => button.pressed);
+  const inactiveTheme = initialGeometry.find((button) => !button.pressed);
+  expect(activeTheme).toBeDefined();
+  expect(inactiveTheme).toBeDefined();
+  expect(activeTheme!.surfaceHeight - inactiveTheme!.surfaceHeight).toBeGreaterThan(8);
+
+  const midasButton = inlineGrid.getByRole("button", { name: /^Midas\./ });
+  const midasBox = await midasButton.boundingBox();
+  expect(midasBox).not.toBeNull();
+  const pointer = {
+    x: midasBox!.x + midasBox!.width / 2,
+    y: midasBox!.y + midasBox!.height / 2,
+  };
+  await page.mouse.move(pointer.x, pointer.y);
+
+  const floatingGrid = page.locator('[data-theme-selector-layer="floating"]');
+  await expect(floatingGrid).toBeVisible();
+  await expect(page.locator("html")).toHaveAttribute("data-theme", "midas");
+
+  const samples = await page.evaluate(async (point) => {
+    const results: Array<{
+      theme: string | undefined;
+      labelAtPointer: string | null;
+      gridX: number;
+      gridY: number;
+      buttonCenterX: number;
+      buttonCenterY: number;
+    }> = [];
+
+    for (let frame = 0; frame < 16; frame += 1) {
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+      const grid = document.querySelector<HTMLElement>(
+        '[data-theme-selector-layer="floating"]',
+      );
+      const button = [...(grid?.querySelectorAll<HTMLElement>(".website-theme-swatch") ?? [])]
+        .find((candidate) => candidate.getAttribute("aria-label")?.startsWith("Midas."));
+      const gridRect = grid?.getBoundingClientRect();
+      const buttonRect = button?.getBoundingClientRect();
+      const hit = document.elementFromPoint(point.x, point.y)?.closest("button");
+
+      results.push({
+        theme: document.documentElement.dataset.theme,
+        labelAtPointer: hit?.getAttribute("aria-label") ?? null,
+        gridX: gridRect?.x ?? Number.NaN,
+        gridY: gridRect?.y ?? Number.NaN,
+        buttonCenterX: buttonRect
+          ? buttonRect.left + buttonRect.width / 2
+          : Number.NaN,
+        buttonCenterY: buttonRect
+          ? buttonRect.top + buttonRect.height / 2
+          : Number.NaN,
+      });
+    }
+
+    return results;
+  }, pointer);
+
+  expect(new Set(samples.map((sample) => sample.theme))).toEqual(new Set(["midas"]));
+  expect(samples.every((sample) => sample.labelAtPointer?.startsWith("Midas."))).toBe(true);
+  expect(span(samples.map((sample) => sample.gridX))).toBeLessThanOrEqual(0.5);
+  expect(span(samples.map((sample) => sample.gridY))).toBeLessThanOrEqual(0.5);
+  expect(span(samples.map((sample) => sample.buttonCenterX))).toBeLessThanOrEqual(0.5);
+  expect(span(samples.map((sample) => sample.buttonCenterY))).toBeLessThanOrEqual(0.5);
+
+  await page.mouse.move(0, 0);
+  await expect(floatingGrid).toHaveCount(0);
+  const neonButton = inlineGrid.getByRole("button", { name: /^Neon\./ });
+  const neonBox = await neonButton.boundingBox();
+  expect(neonBox).not.toBeNull();
+  const neonPointer = {
+    x: neonBox!.x + neonBox!.width / 2,
+    y: neonBox!.y + neonBox!.height / 2,
+  };
+  await page.mouse.move(neonPointer.x, neonPointer.y);
+  await expect(floatingGrid).toBeVisible();
+  const floatingNeonButton = floatingGrid.getByRole("button", { name: /^Neon\./ });
+  const floatingNeonBox = await floatingNeonButton.boundingBox();
+  expect(floatingNeonBox).not.toBeNull();
+  await page.mouse.click(
+    floatingNeonBox!.x + floatingNeonBox!.width / 2,
+    floatingNeonBox!.y + floatingNeonBox!.height / 2,
+  );
+  await expect(floatingGrid.locator(".website-theme-swatch").nth(5)).toHaveAttribute(
+    "aria-pressed",
+    "true",
+  );
+  await page.mouse.move(0, 0);
+  await expect(floatingGrid).toHaveCount(0);
+  await expect(inlineGrid.locator(".website-theme-swatch").nth(5)).toHaveAttribute(
+    "aria-pressed",
+    "true",
+  );
+  await page.locator("footer").scrollIntoViewIfNeeded();
+
+  const committedGeometry = await readThemeGeometry(inlineGrid);
+  const committedRowDistance = assertFixedRows(committedGeometry);
+  expect(Math.abs(committedRowDistance - initialRowDistance)).toBeLessThanOrEqual(0.5);
+  const committedActive = committedGeometry.find((button) => button.pressed);
+  const committedInactive = committedGeometry.find((button) => !button.pressed);
+  expect(committedActive?.label).toMatch(/^Neon\./);
+  expect(committedActive!.surfaceHeight - committedInactive!.surfaceHeight).toBeGreaterThan(8);
+});


### PR DESCRIPTION
(AI Generated).

## Summary
- Keep the footer theme selector fixed under the pointer while preview themes reflow the page.
- Reserve row height for the taller active swatch and document the invariant for future agents.
- Add real browser regression coverage at desktop and mobile widths.

## Testing
- cd website && PATH=../node_modules/.bin:$PATH npm run lint
- cd website && PATH=../node_modules/.bin:$PATH npm run test:e2e
- cd website && PATH=../node_modules/.bin:$PATH npm run build