### PR TITLE
fix: scope production release identity checks

### DIFF
--- a/scripts/validate-worktree.mjs
+++ b/scripts/validate-worktree.mjs
@@ -925,8 +925,13 @@ export function buildValidationPlan(mode, changedFiles) {
         ),
       );
     }
-    const identityArtifacts =
-      collectChangedReleaseIdentityArtifacts(changedFiles);
+    // A dev-to-main promotion carries reviewed dev release notes into main,
+    // but it does not turn those historical dev artifacts into the current
+    // production build. Their identities were admitted in the dev lane. Only
+    // production artifacts belong to production identity validation here.
+    const identityArtifacts = collectChangedReleaseIdentityArtifacts(
+      changedFiles,
+    ).filter((filePath) => !filePath.endsWith("-dev.json"));
     if (identityArtifacts.length > 0) {
       plan.push(
         releaseIdentityValidationItem(

--- a/scripts/validate-worktree.test.mjs
+++ b/scripts/validate-worktree.test.mjs
@@ -1006,6 +1006,21 @@ test("feature and production plans validate changed release identity directly", 
   }
 });
 
+test("production validation ignores dev release identities copied during promotion", () => {
+  const identityItem = buildValidationPlan("production", [
+    "release-notes/releases/v26.8.1303-dev.json",
+    "release-notes/releases/v26.8.1303-dev.md",
+    "release-notes/releases/v26.8.1400.json",
+    "release-notes/releases/v26.8.1400.md",
+  ]).find((item) => item.label === "release identity validation");
+
+  assert.deepEqual(identityItem, {
+    kind: "release-identity-validation",
+    label: "release identity validation",
+    files: ["release-notes/releases/v26.8.1400.json"],
+  });
+});
+
 test("release identity execution separates modern releases, historical corrections, and backfills", () => {
   const filePath = "release-notes/releases/v26.7.2800-dev.json";
   const artifact = {


### PR DESCRIPTION
(AI Generated).

## Summary
- Keep dev release identities in the dev validation lane when historical dev release notes are copied into main during production promotion.
- Continue validating current production release identities in production validation.

## Testing
- node --test scripts/validate-worktree.test.mjs
- production plan simulation across origin/main..origin/dev selects no historical dev identity artifacts