### PR TITLE
fix: retry release tag readback

### DIFF
--- a/scripts/release-governance.test.mjs
+++ b/scripts/release-governance.test.mjs
@@ -72,9 +72,32 @@ test("release publication delegates one exact tag to the trusted App publisher",
     /release-tag-publisher\.mjs publish[\s\S]*--tag "\$\{TAG\}"[\s\S]*--commit "\$\{LOCAL_RELEASE_SHA\}"[\s\S]*--branch "\$\{EXPECTED_BRANCH\}"[\s\S]*--release-file-sha256 "\$\{RELEASE_FILE_SHA256\}"/,
   );
   assert.match(releasePublish, /git ls-remote --tags origin/);
+  assert.match(releasePublish, /TAG_ALREADY_PUBLISHED=false/);
+  assert.match(
+    releasePublish,
+    /\$\{LOCAL_TAG_EXISTS\}" != "\$\{REMOTE_TAG_EXISTS\}"[\s\S]*local and remote state disagree for immutable tag/,
+  );
+  assert.match(
+    releasePublish,
+    /Recovered exact existing immutable tag \$\{TAG\}; publication was already committed/,
+  );
+  assert.match(
+    releasePublish,
+    /if \[\[ "\$\{TAG_ALREADY_PUBLISHED\}" != true \]\]; then[\s\S]*release-tag-publisher\.mjs publish/,
+  );
   assert.match(
     releasePublish,
     /git fetch origin "refs\/tags\/\$\{TAG\}:refs\/tags\/\$\{TAG\}"/,
+  );
+  assert.match(releasePublish, /TAG_FETCH_MAX_ATTEMPTS=8/);
+  assert.match(
+    releasePublish,
+    /for \(\(TAG_FETCH_ATTEMPT = 1; TAG_FETCH_ATTEMPT <= TAG_FETCH_MAX_ATTEMPTS; TAG_FETCH_ATTEMPT \+= 1\)\)/,
+  );
+  assert.match(releasePublish, /Waiting for GitHub to expose newly published tag/);
+  assert.match(
+    releasePublish,
+    /published tag \$\{TAG\} did not become readable after \$\{TAG_FETCH_MAX_ATTEMPTS\} attempts/,
   );
   assert.match(releasePublish, /git cat-file -t "refs\/tags\/\$\{TAG\}"/);
   assert.match(releasePublish, /git rev-list -n 1 "refs\/tags\/\$\{TAG\}"/);

--- a/scripts/release-publish.sh
+++ b/scripts/release-publish.sh
@@ -99,14 +99,31 @@ if [[ "$CHANNEL" == "dev" ]]; then
     --workflow=ci.yml
 fi
 
+TAG_ALREADY_PUBLISHED=false
+LOCAL_TAG_EXISTS=false
+REMOTE_TAG_EXISTS=false
 if git rev-parse --verify --quiet "refs/tags/${TAG}" >/dev/null; then
-  echo "Error: tag ${TAG} already exists. Release tags are immutable." >&2
-  exit 1
+  LOCAL_TAG_EXISTS=true
+fi
+if [[ -n "$(git ls-remote --tags origin "refs/tags/${TAG}")" ]]; then
+  REMOTE_TAG_EXISTS=true
 fi
 
-if [[ -n "$(git ls-remote --tags origin "refs/tags/${TAG}")" ]]; then
-  echo "Error: remote tag ${TAG} already exists. Release tags are immutable." >&2
+if [[ "${LOCAL_TAG_EXISTS}" != "${REMOTE_TAG_EXISTS}" ]]; then
+  echo "Error: local and remote state disagree for immutable tag ${TAG}." >&2
   exit 1
+fi
+if [[ "${LOCAL_TAG_EXISTS}" == true ]]; then
+  if [[ "$(git cat-file -t "refs/tags/${TAG}")" != "tag" ]]; then
+    echo "Error: existing release tag ${TAG} is not annotated." >&2
+    exit 1
+  fi
+  if [[ "$(git rev-list -n 1 "refs/tags/${TAG}")" != "${LOCAL_RELEASE_SHA}" ]]; then
+    echo "Error: existing release tag ${TAG} identifies the wrong commit." >&2
+    exit 1
+  fi
+  TAG_ALREADY_PUBLISHED=true
+  echo "==> Recovered exact existing immutable tag ${TAG}; publication was already committed."
 fi
 
 RELEASE_FILE_SHA256=$("${NODE_BIN}" -e "
@@ -115,17 +132,34 @@ RELEASE_FILE_SHA256=$("${NODE_BIN}" -e "
   process.stdout.write(crypto.createHash('sha256').update(fs.readFileSync(process.argv[1])).digest('hex'));
 " "$RELEASE_FILE")
 
-"${NODE_BIN}" scripts/release-tag-publisher.mjs publish \
-  --repo freed-project/freed \
-  --worktree "$(pwd -P)" \
-  --tag "${TAG}" \
-  --channel "${CHANNEL}" \
-  --commit "${LOCAL_RELEASE_SHA}" \
-  --branch "${EXPECTED_BRANCH}" \
-  --release-file "${RELEASE_FILE}" \
-  --release-file-sha256 "${RELEASE_FILE_SHA256}"
+if [[ "${TAG_ALREADY_PUBLISHED}" != true ]]; then
+  "${NODE_BIN}" scripts/release-tag-publisher.mjs publish \
+    --repo freed-project/freed \
+    --worktree "$(pwd -P)" \
+    --tag "${TAG}" \
+    --channel "${CHANNEL}" \
+    --commit "${LOCAL_RELEASE_SHA}" \
+    --branch "${EXPECTED_BRANCH}" \
+    --release-file "${RELEASE_FILE}" \
+    --release-file-sha256 "${RELEASE_FILE_SHA256}"
 
-git fetch origin "refs/tags/${TAG}:refs/tags/${TAG}"
+  TAG_FETCH_MAX_ATTEMPTS=8
+  TAG_FETCHED=false
+  for ((TAG_FETCH_ATTEMPT = 1; TAG_FETCH_ATTEMPT <= TAG_FETCH_MAX_ATTEMPTS; TAG_FETCH_ATTEMPT += 1)); do
+    if git fetch origin "refs/tags/${TAG}:refs/tags/${TAG}"; then
+      TAG_FETCHED=true
+      break
+    fi
+    if (( TAG_FETCH_ATTEMPT < TAG_FETCH_MAX_ATTEMPTS )); then
+      echo "Waiting for GitHub to expose newly published tag ${TAG} (${TAG_FETCH_ATTEMPT}/${TAG_FETCH_MAX_ATTEMPTS})..." >&2
+      sleep 2
+    fi
+  done
+  if [[ "${TAG_FETCHED}" != true ]]; then
+    echo "Error: published tag ${TAG} did not become readable after ${TAG_FETCH_MAX_ATTEMPTS} attempts." >&2
+    exit 1
+  fi
+fi
 if [[ "$(git cat-file -t "refs/tags/${TAG}")" != "tag" ]]; then
   echo "Error: release publisher created a non-annotated tag ${TAG}." >&2
   exit 1


### PR DESCRIPTION
(AI Generated).

Fixes the release publisher failure observed while publishing v26.8.1400.

GitHub accepted the trusted App tag mutation, then briefly returned the new tag as unreadable. The local wrapper reported failure even though the immutable tag existed, and every rerun refused to continue because the tag was already present.

This change:

* retries the exact post-publication tag fetch for a bounded 16 seconds
* treats an existing local and remote annotated tag at the exact reviewed commit as a successful recovered publication
* fails closed when local and remote state disagree, the tag is lightweight, or the tag identifies another commit

Validation:

* `bash -n scripts/release-publish.sh`
* `node --test scripts/release-governance.test.mjs` with 11 passing tests