### PR TITLE
fix: clarify empty provider states

### DIFF
--- a/packages/desktop/src/components/FacebookFeedEmptyState.tsx
+++ b/packages/desktop/src/components/FacebookFeedEmptyState.tsx
@@ -13,7 +13,7 @@ import { captureFbFeed } from "../lib/fb-capture";
 import { useSettingsStore } from "@freed/ui/lib/settings-store";
 import { resetProviderPauseState } from "../lib/provider-health";
 import { SampleDataTestingSection } from "@freed/ui/components/SampleDataTestingSection";
-import { socialProviderCopy } from "../lib/social-provider-copy";
+import { EMPTY_PROVIDER_FEED_COPY, socialProviderCopy } from "../lib/social-provider-copy";
 
 const FbIcon = () => (
   <svg className="h-7 w-7 text-[var(--theme-media-facebook)]" viewBox="0 0 24 24" fill="currentColor">
@@ -69,7 +69,7 @@ export function FacebookFeedEmptyState() {
         <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full border border-[var(--theme-border-subtle)] bg-[radial-gradient(circle_at_top,var(--theme-bg-card-hover),transparent_72%),linear-gradient(135deg,color-mix(in_srgb,var(--theme-media-facebook)_18%,transparent),rgb(var(--theme-accent-secondary-rgb)/0.12))]">
           <FbIcon />
         </div>
-        <p className="text-lg font-medium mb-2">All caught up!</p>
+        <p className="text-lg font-medium mb-2">{EMPTY_PROVIDER_FEED_COPY.title}</p>
         <p className="mb-6 text-sm text-[var(--theme-text-muted)]">{copy.connectedEmptyState}</p>
         <div className="flex gap-3">
           <button

--- a/packages/desktop/src/components/InstagramFeedEmptyState.tsx
+++ b/packages/desktop/src/components/InstagramFeedEmptyState.tsx
@@ -13,7 +13,7 @@ import { captureIgFeed } from "../lib/instagram-capture";
 import { useSettingsStore } from "@freed/ui/lib/settings-store";
 import { resetProviderPauseState } from "../lib/provider-health";
 import { SampleDataTestingSection } from "@freed/ui/components/SampleDataTestingSection";
-import { socialProviderCopy } from "../lib/social-provider-copy";
+import { EMPTY_PROVIDER_FEED_COPY, socialProviderCopy } from "../lib/social-provider-copy";
 
 const IgIcon = () => (
   <svg className="h-7 w-7 text-[var(--theme-media-instagram)]" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
@@ -71,7 +71,7 @@ export function InstagramFeedEmptyState() {
         <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full border border-[var(--theme-border-subtle)] bg-[radial-gradient(circle_at_top,var(--theme-bg-card-hover),transparent_72%),linear-gradient(135deg,color-mix(in_srgb,var(--theme-media-instagram)_18%,transparent),rgb(var(--theme-accent-secondary-rgb)/0.12))]">
           <IgIcon />
         </div>
-        <p className="text-lg font-medium mb-2">All caught up!</p>
+        <p className="text-lg font-medium mb-2">{EMPTY_PROVIDER_FEED_COPY.title}</p>
         <p className="mb-6 text-sm text-[var(--theme-text-muted)]">{copy.connectedEmptyState}</p>
         <div className="flex gap-3">
           <button

--- a/packages/desktop/src/components/XFeedEmptyState.tsx
+++ b/packages/desktop/src/components/XFeedEmptyState.tsx
@@ -16,7 +16,7 @@ import { captureXTimeline } from "../lib/x-capture";
 import { useSettingsStore } from "@freed/ui/lib/settings-store";
 import { resetProviderPauseState } from "../lib/provider-health";
 import { SampleDataTestingSection } from "@freed/ui/components/SampleDataTestingSection";
-import { socialProviderCopy } from "../lib/social-provider-copy";
+import { EMPTY_PROVIDER_FEED_COPY, socialProviderCopy } from "../lib/social-provider-copy";
 
 const XIcon = () => (
   <svg className="h-7 w-7 text-[var(--theme-media-x)]" viewBox="0 0 24 24" fill="currentColor">
@@ -69,8 +69,8 @@ export function XFeedEmptyState() {
         <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-[color:rgb(var(--theme-accent-secondary-rgb)/0.14)]">
           <span className="text-2xl">📡</span>
         </div>
-        <p className="text-lg font-medium mb-2">All caught up!</p>
-        <p className="text-sm text-[var(--theme-text-muted)]">No new items to show.</p>
+        <p className="text-lg font-medium mb-2">{EMPTY_PROVIDER_FEED_COPY.title}</p>
+        <p className="text-sm text-[var(--theme-text-muted)]">{EMPTY_PROVIDER_FEED_COPY.detail}</p>
         <SampleDataTestingSection />
       </>
     );
@@ -83,7 +83,7 @@ export function XFeedEmptyState() {
         <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-[color:rgb(var(--theme-accent-secondary-rgb)/0.14)]">
           <XIcon />
         </div>
-        <p className="text-lg font-medium mb-2">All caught up!</p>
+        <p className="text-lg font-medium mb-2">{EMPTY_PROVIDER_FEED_COPY.title}</p>
         <p className="mb-6 text-sm text-[var(--theme-text-muted)]">{copy.connectedEmptyState}</p>
         <div className="flex gap-3">
           <button

--- a/packages/desktop/src/lib/social-provider-copy.test.ts
+++ b/packages/desktop/src/lib/social-provider-copy.test.ts
@@ -1,9 +1,26 @@
 import { describe, expect, it } from "vitest";
-import { SOCIAL_PROVIDER_COPY, type SocialProviderId } from "./social-provider-copy";
+import {
+  EMPTY_PROVIDER_FEED_COPY,
+  SOCIAL_PROVIDER_COPY,
+  type SocialProviderId,
+} from "./social-provider-copy";
 
 const allCopyText = (provider: SocialProviderId) => Object.values(SOCIAL_PROVIDER_COPY[provider]).join(" ");
 
 describe("social provider copy", () => {
+  it("uses the welcome state when a provider has no items", () => {
+    expect(EMPTY_PROVIDER_FEED_COPY).toEqual({
+      title: "Welcome!",
+      detail: "No items to show.",
+    });
+
+    for (const provider of Object.keys(SOCIAL_PROVIDER_COPY) as SocialProviderId[]) {
+      expect(SOCIAL_PROVIDER_COPY[provider].connectedEmptyState).toBe(
+        EMPTY_PROVIDER_FEED_COPY.detail,
+      );
+    }
+  });
+
   it("keeps provider labels, domains, and feed terms scoped to the right provider", () => {
     const forbidden: Record<SocialProviderId, string[]> = {
       x: ["Facebook", "Instagram", "LinkedIn", "Substack", "Medium", "facebook.com", "instagram.com", "linkedin.com"],

--- a/packages/desktop/src/lib/social-provider-copy.ts
+++ b/packages/desktop/src/lib/social-provider-copy.ts
@@ -12,11 +12,16 @@ export interface SocialProviderCopy {
   memoryPressure: string;
 }
 
+export const EMPTY_PROVIDER_FEED_COPY = {
+  title: "Welcome!",
+  detail: "No items to show.",
+} as const;
+
 export const SOCIAL_PROVIDER_COPY = {
   x: {
     label: "X",
     settingsTitle: "X",
-    connectedEmptyState: "Your X timeline is up to date.",
+    connectedEmptyState: EMPTY_PROVIDER_FEED_COPY.detail,
     disconnectedSettings:
       "Pull your home timeline into Freed. Sign in with your X account to start syncing.",
     disconnectedEmptyState:
@@ -32,7 +37,7 @@ export const SOCIAL_PROVIDER_COPY = {
   facebook: {
     label: "Facebook",
     settingsTitle: "Facebook",
-    connectedEmptyState: "Your Facebook feed is up to date.",
+    connectedEmptyState: EMPTY_PROVIDER_FEED_COPY.detail,
     disconnectedSettings:
       "Pull your Facebook feed into Freed. Log in through a native browser window. Freed reads your feed the same way you would.",
     disconnectedEmptyState:
@@ -49,7 +54,7 @@ export const SOCIAL_PROVIDER_COPY = {
   instagram: {
     label: "Instagram",
     settingsTitle: "Instagram",
-    connectedEmptyState: "Your Instagram feed is up to date.",
+    connectedEmptyState: EMPTY_PROVIDER_FEED_COPY.detail,
     disconnectedSettings:
       "Pull your Instagram feed into Freed. Log in through a native browser window. Freed reads your feed the same way you would.",
     disconnectedEmptyState:
@@ -66,7 +71,7 @@ export const SOCIAL_PROVIDER_COPY = {
   linkedin: {
     label: "LinkedIn",
     settingsTitle: "LinkedIn",
-    connectedEmptyState: "Your LinkedIn feed is up to date.",
+    connectedEmptyState: EMPTY_PROVIDER_FEED_COPY.detail,
     disconnectedSettings:
       "Pull your LinkedIn feed into Freed. Log in through a native browser window. Freed reads your feed the same way you would.",
     disconnectedEmptyState:
@@ -83,7 +88,7 @@ export const SOCIAL_PROVIDER_COPY = {
   substack: {
     label: "Substack",
     settingsTitle: "Substack",
-    connectedEmptyState: "Your Substack essays and notes are up to date.",
+    connectedEmptyState: EMPTY_PROVIDER_FEED_COPY.detail,
     disconnectedSettings:
       "Pull Substack essays, notes, public follows, and visible subscriptions into Freed. Log in through a native browser window.",
     disconnectedEmptyState:
@@ -100,7 +105,7 @@ export const SOCIAL_PROVIDER_COPY = {
   medium: {
     label: "Medium",
     settingsTitle: "Medium",
-    connectedEmptyState: "Your Medium stories and responses are up to date.",
+    connectedEmptyState: EMPTY_PROVIDER_FEED_COPY.detail,
     disconnectedSettings:
       "Pull Medium stories, responses, public follows, and visible activity into Freed. Log in through a native browser window.",
     disconnectedEmptyState:

--- a/packages/desktop/src/lib/source-status.test.ts
+++ b/packages/desktop/src/lib/source-status.test.ts
@@ -75,6 +75,47 @@ describe("desktop source status", () => {
     expect(status).toBeNull();
   });
 
+  it("omits the status indicator for a provider that has never been configured", () => {
+    const status = getDesktopSourceStatus(
+      "substack",
+      sourceState({
+        substackAuth: { isAuthenticated: false },
+        itemCountByPlatform: { substack: 0 },
+      }),
+      null,
+    );
+
+    expect(status).toBeNull();
+  });
+
+  it("keeps a configured provider neutral until it has synced an item", () => {
+    const status = getDesktopSourceStatus(
+      "substack",
+      sourceState({
+        substackAuth: { isAuthenticated: true },
+        itemCountByPlatform: { substack: 0 },
+      }),
+      health(),
+    );
+
+    expect(status?.tone).toBe("idle");
+    expect(status?.label).toBe("No items yet");
+  });
+
+  it("marks a configured provider healthy after it has synced an item", () => {
+    const status = getDesktopSourceStatus(
+      "substack",
+      sourceState({
+        substackAuth: { isAuthenticated: true },
+        itemCountByPlatform: { substack: 1 },
+      }),
+      health(),
+    );
+
+    expect(status?.tone).toBe("healthy");
+    expect(status?.label).toBe("Connected");
+  });
+
   it("still surfaces reconnect-required social source errors without a live connection", () => {
     const status = getDesktopSourceStatus(
       "facebook",
@@ -104,6 +145,7 @@ describe("desktop source status", () => {
       sourceState({
         ytAuth: { isAuthenticated: true },
         providerSyncCounts: { youtube: 1 },
+        itemCountByPlatform: { youtube: 1 },
       }),
       health({
         youtube: providerSnapshot("youtube", {
@@ -124,6 +166,7 @@ describe("desktop source status", () => {
       sourceState({
         substackAuth: { isAuthenticated: true },
         providerSyncCounts: { substack: 1 },
+        itemCountByPlatform: { substack: 1 },
       }),
       health({
         substack: providerSnapshot("substack", {

--- a/packages/desktop/src/lib/source-status.ts
+++ b/packages/desktop/src/lib/source-status.ts
@@ -119,28 +119,43 @@ export function getDesktopSourceStatus(
   const authError =
     typeof authState?.lastCaptureError === "string" ? authState.lastCaptureError : undefined;
   const isConnected = authState?.isAuthenticated === true;
-  const tone = getProviderStatusTone({
+  const providerItemCount = isSocialProviderSourceId(sourceId)
+    ? (desktopState.itemCountByPlatform[sourceId] ?? 0)
+    : 0;
+  const healthTone = getProviderStatusTone({
     isConnected,
     authError,
     snapshot,
   });
 
-  if (tone === "idle") {
+  if (!isConnected && healthTone === "idle") {
     return null;
   }
 
+  // A configured provider is not healthy merely because it has credentials.
+  // Keep its status neutral until it has supplied at least one library item,
+  // while preserving actionable warning and critical states.
+  const tone = isConnected && providerItemCount === 0 && healthTone === "healthy"
+    ? "idle"
+    : healthTone;
+  const hasConfiguredEmptyLibrary = isConnected && providerItemCount === 0 && tone === "idle";
+
   return {
     tone,
-    label: getProviderStatusLabel({
-      isConnected,
-      authError,
-      snapshot,
-    }),
-    detail: getProviderStatusDetail({
-      isConnected,
-      authError,
-      snapshot,
-    }),
+    label: hasConfiguredEmptyLibrary
+      ? "No items yet"
+      : getProviderStatusLabel({
+          isConnected,
+          authError,
+          snapshot,
+        }),
+    detail: hasConfiguredEmptyLibrary
+      ? "Connected. No items have synced yet."
+      : getProviderStatusDetail({
+          isConnected,
+          authError,
+          snapshot,
+        }),
     paused: snapshot?.status === "paused",
     syncing: isSocialProviderSourceId(sourceId)
       ? (desktopState.providerSyncCounts[sourceId] ?? 0) > 0

--- a/packages/desktop/tests/e2e/provider-health.spec.ts
+++ b/packages/desktop/tests/e2e/provider-health.spec.ts
@@ -1683,11 +1683,11 @@ test("settings sources nav shows provider status dots", async ({ app, page }) =>
   await expect(page.getByTestId("settings-provider-status-linkedin")).toHaveClass(/bg-amber-500/);
   const sidebar = getDesktopSidebar(page);
   await expect(sidebar.getByTestId("source-indicator-x")).toHaveAttribute("title", "Reconnect required");
-  await expect(sidebar.getByTestId("source-indicator-facebook")).toHaveAttribute("title", "Connected");
+  await expect(sidebar.getByTestId("source-indicator-facebook")).toHaveAttribute("title", "No items yet");
   await expect(sidebar.getByTestId("source-indicator-linkedin")).toHaveAttribute("title", "Sync issue");
   await expect(sidebar.getByTestId("source-indicator-instagram")).toHaveCount(0);
   await expect(sidebar.getByTestId("source-indicator-x")).toHaveClass(/bg-red-500/);
-  await expect(sidebar.getByTestId("source-indicator-facebook")).toHaveClass(/bg-emerald-500/);
+  await expect(sidebar.getByTestId("source-indicator-facebook")).toHaveClass(/theme-text-soft/);
   await expect(sidebar.getByTestId("source-indicator-linkedin")).toHaveClass(/bg-amber-500/);
 
   const facebookSourceIndicatorLayout = await page.evaluate(() => {

--- a/packages/ui/src/components/ProviderStatusIndicator.tsx
+++ b/packages/ui/src/components/ProviderStatusIndicator.tsx
@@ -31,7 +31,9 @@ export function ProviderStatusIndicator({
       ? "border-red-400"
       : tone === "warning"
         ? "border-amber-400"
-        : "border-emerald-400";
+        : tone === "healthy"
+          ? "border-emerald-400"
+          : "border-[var(--theme-text-soft)]";
   const activeLabel = syncing && tone === "healthy" ? "Syncing" : label;
   const emojiClass =
     size === "xxs"

--- a/packages/ui/src/lib/provider-status.ts
+++ b/packages/ui/src/lib/provider-status.ts
@@ -3,11 +3,16 @@ import type { ProviderHealthSnapshot } from "./debug-store.js";
 export type ProviderStatusTone = "idle" | "healthy" | "warning" | "critical";
 
 export function getProviderStatusToneClass(tone: ProviderStatusTone): string {
-  return tone === "critical"
-    ? "bg-red-500"
-    : tone === "warning"
-      ? "bg-amber-500"
-      : "bg-emerald-500";
+  switch (tone) {
+    case "critical":
+      return "bg-red-500";
+    case "warning":
+      return "bg-amber-500";
+    case "healthy":
+      return "bg-emerald-500";
+    case "idle":
+      return "bg-[var(--theme-text-soft)]";
+  }
 }
 
 export function getHealthStatusLabel(snapshot?: ProviderHealthSnapshot | null): string {


### PR DESCRIPTION
(AI Generated).

## Summary
- Hide status dots for unconfigured providers, use a neutral status until a configured provider has synced items, and show the requested welcome copy for provider feeds with zero items.

## Testing
- npm run validate:feature

## Provider Review
- Status: Provider authority is validated for ready publication.
- Review action: none required. The provider-risk artifact records the behavior authority decision; this exact provider subdiff is the audit subject.
- Provider subdiff: `53d047680185cd27ea18d35838c172b88e8c2d49`
- Publication does not authorize new live provider traffic. Gate 1 behavior approval still applies when observable behavior changes.
- Provider review task: `provider-empty-states-20260814`
- Provider review decision: `diff_authorized`
- Provider review artifact: `b500d03a116657c8c0e2b80ad47f219b8b6e7b1e12ddb71b364c488a32391c1b`
- Providers: facebook, instagram, linkedin, medium, substack, x
- Observable behavior: Provider-facing network behavior is semantically unchanged. This diff only changes local sidebar status dots and local empty-feed copy.
- Fingerprinting risk: None introduced. The diff does not change provider loads, navigation, requests, retries, cadence, cookies, headers, scrolling, clicks, extraction, media, login, or background activity.
- Lowest profile alternative: Keep all provider traffic disabled and validate only through local state, offline fixtures, and the local Chromium preview.

Files bound into this provider review:
- `packages/desktop/src/components/FacebookFeedEmptyState.tsx`
- `packages/desktop/src/components/InstagramFeedEmptyState.tsx`
- `packages/desktop/src/components/XFeedEmptyState.tsx`
- `packages/desktop/src/lib/social-provider-copy.ts`