### PR TITLE
fix: standardize sidebar search and nav menus

### DIFF
--- a/packages/desktop/tests/e2e/theme-switching.spec.ts
+++ b/packages/desktop/tests/e2e/theme-switching.spec.ts
@@ -547,7 +547,7 @@ test("map view removes the left frame when the desktop sidebar is closed", async
   });
 });
 
-test("friends graph controls align to the graph lane between sidebars", async ({ app, page }) => {
+test("friends graph controls align and its sidebar menu follows shared nav behavior", async ({ app, page }) => {
   await page.setViewportSize({ width: 1440, height: 900 });
   await app.goto();
   await app.waitForReady();
@@ -559,7 +559,14 @@ test("friends graph controls align to the graph lane between sidebars", async ({
     const store = w.__FREED_STORE__ as
       | {
           getState: () => {
-            updatePreferences: (patch: { display: { friendsMode: "friends"; friendsSidebarOpen: boolean } }) => Promise<void>;
+            updatePreferences: (patch: {
+              display: {
+                friendsMode: "friends";
+                friendsSidebarOpen: boolean;
+                sidebarMode: "expanded";
+                sidebarWidth: number;
+              };
+            }) => Promise<void>;
             setActiveView: (view: string) => void;
           };
         }
@@ -568,12 +575,51 @@ test("friends graph controls align to the graph lane between sidebars", async ({
       display: {
         friendsMode: "friends",
         friendsSidebarOpen: true,
+        sidebarMode: "expanded",
+        sidebarWidth: 256,
       },
     });
-    store?.getState().setActiveView("friends");
+  });
+
+  const navigationSidebar = page.getByTestId("app-sidebar");
+  const friendsNavigationRow = navigationSidebar.getByTestId("source-row-friends");
+  const friendsMenuTrigger = navigationSidebar.getByTestId("source-menu-trigger-friends");
+
+  await friendsNavigationRow.hover();
+  await expect(friendsMenuTrigger).toHaveClass(/opacity-100/);
+  await friendsMenuTrigger.click();
+  await expect(page.getByTestId("friends-context-menu")).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(page.getByTestId("friends-context-menu")).toHaveCount(0);
+
+  await page.evaluate(() => {
+    const store = (window as Record<string, unknown>).__FREED_STORE__ as {
+      getState: () => { setActiveView: (view: string) => void };
+    };
+    store.getState().setActiveView("friends");
   });
 
   await expect(page.getByTestId("friend-graph-viewport")).toBeVisible({ timeout: 10_000 });
+  const graphViewport = page.getByTestId("friend-graph-viewport");
+
+  await friendsNavigationRow.hover();
+  const triggerInsets = await friendsMenuTrigger.evaluate((trigger) => {
+    const row = trigger.closest('[data-sidebar-row="true"]');
+    if (!(row instanceof HTMLElement)) return null;
+    const rowRect = row.getBoundingClientRect();
+    const triggerRect = trigger.getBoundingClientRect();
+    return {
+      top: Math.round(triggerRect.top - rowRect.top),
+      right: Math.round(rowRect.right - triggerRect.right),
+    };
+  });
+  expect(triggerInsets).not.toBeNull();
+  expect(Math.abs(triggerInsets!.top - triggerInsets!.right)).toBeLessThanOrEqual(1);
+
+  await friendsMenuTrigger.click();
+  await expect(page.getByTestId("friends-context-menu")).toBeVisible();
+  await graphViewport.click({ position: { x: 24, y: 48 } });
+  await expect(page.getByTestId("friends-context-menu")).toHaveCount(0);
 
   await expect.poll(async () => {
     return page.evaluate(() => {
@@ -683,7 +729,6 @@ test("friends graph controls align to the graph lane between sidebars", async ({
 
   await page.getByRole("button", { name: "Fit all" }).click();
   const fittedCamera = await copyCameraDiagnostics();
-  const graphViewport = page.getByTestId("friend-graph-viewport");
   await graphViewport.hover();
   for (let index = 0; index < 24; index += 1) await page.mouse.wheel(0, -120);
   const zoomedInCamera = await copyCameraDiagnostics();

--- a/packages/ui/src/components/layout/SearchJumpField.tsx
+++ b/packages/ui/src/components/layout/SearchJumpField.tsx
@@ -1091,7 +1091,7 @@ export function SearchJumpField({
           ref={triggerPaletteRef}
           data-testid={usesFloatingTrigger ? "compact-sidebar-search-palette" : "sidebar-search-command-palette"}
           className="theme-dialog-shell theme-menu-shell fixed z-[320] w-[min(20rem,calc(100vw-1.5rem))] rounded-[var(--card-radius)] border border-[var(--theme-border-subtle)] bg-[var(--theme-bg-elevated)] p-2 shadow-2xl shadow-black/50"
-          style={palettePosition}
+          style={{ ...palettePosition, scrollbarGutter: "auto" }}
         >
           {renderActionSurface(usesFloatingTrigger)}
         </div>,

--- a/packages/ui/src/components/layout/Sidebar.tsx
+++ b/packages/ui/src/components/layout/Sidebar.tsx
@@ -70,6 +70,48 @@ function MoreIcon() {
   );
 }
 
+interface SidebarNavMenuButtonProps {
+  countsVisible: boolean;
+  label: string;
+  menuOpen: boolean;
+  onToggle: (element: HTMLButtonElement) => void;
+  testId?: string;
+}
+
+function SidebarNavMenuButton({
+  countsVisible,
+  label,
+  menuOpen,
+  onToggle,
+  testId,
+}: SidebarNavMenuButtonProps) {
+  const positionClass = countsVisible
+    ? "absolute right-[-6px] top-1/2 flex h-6 w-6 -translate-y-1/2 items-center justify-center"
+    : "absolute bottom-[-1px] right-0 top-[-1px] flex items-center justify-center px-1";
+
+  return (
+    <button
+      type="button"
+      aria-label={`Options for ${label}`}
+      data-testid={testId}
+      onMouseDown={(event) => {
+        event.stopPropagation();
+      }}
+      onClick={(event) => {
+        event.stopPropagation();
+        onToggle(event.currentTarget);
+      }}
+      className={`${positionClass} rounded-md transition-all duration-200 ease-in-out hover:bg-[color:var(--theme-bg-muted)] hover:text-[color:var(--theme-text-primary)] ${
+        menuOpen
+          ? "translate-x-0 bg-[color:var(--theme-bg-muted)] text-[color:var(--theme-text-primary)] opacity-100"
+          : "pointer-events-none translate-x-[-4px] text-[color:var(--theme-text-muted)] opacity-0 group-hover/sidebar-row:pointer-events-auto group-hover/sidebar-row:translate-x-0 group-hover/sidebar-row:opacity-100"
+      }`}
+    >
+      <MoreIcon />
+    </button>
+  );
+}
+
 interface SidebarNavRowProps {
   active: boolean;
   actionSlotClass?: string;
@@ -335,7 +377,7 @@ function SidebarContextMenuShell({
   const menuRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    const handleDown = (e: MouseEvent) => {
+    const handleDown = (e: PointerEvent) => {
       if (ignoreElement && ignoreElement.contains(e.target as Node)) {
         return;
       }
@@ -346,10 +388,10 @@ function SidebarContextMenuShell({
     const handleKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") onClose();
     };
-    document.addEventListener("mousedown", handleDown);
+    document.addEventListener("pointerdown", handleDown, true);
     document.addEventListener("keydown", handleKey);
     return () => {
-      document.removeEventListener("mousedown", handleDown);
+      document.removeEventListener("pointerdown", handleDown, true);
       document.removeEventListener("keydown", handleKey);
     };
   }, [ignoreElement, onClose]);
@@ -1202,9 +1244,6 @@ export function Sidebar({
     (source.id === "substack" && Boolean(SubstackSettingsContent)) ||
     (source.id === "medium" && Boolean(MediumSettingsContent)) ||
     (source.id === "youtube" && Boolean(YouTubeSettingsContent));
-  const sourceMenuTriggerBaseClass = rowCountsVisible
-    ? "absolute right-0 top-1/2 flex h-6 w-6 -translate-y-1/2 items-center justify-center rounded-md transition-all duration-200 ease-in-out hover:text-[color:var(--theme-text-primary)] hover:bg-[color:var(--theme-bg-muted)]"
-    : "absolute top-[-1px] bottom-[-1px] right-0 flex items-center justify-center rounded-md px-1 transition-all duration-200 ease-in-out hover:text-[color:var(--theme-text-primary)] hover:bg-[color:var(--theme-bg-muted)]";
   const rowActionSlotClass = (menuAvailable: boolean, hasCount: boolean, key: string) => {
     if (rowCountsVisible) {
       if (hasCount) return SOURCE_ACTION_SLOT_WITH_COUNTS_CLASS;
@@ -1416,14 +1455,12 @@ export function Sidebar({
     if (!sourceMenusVisible || !menuAvailable) return null;
 
     return (
-      <button
-        aria-label={`Options for ${label}`}
-        data-testid={`source-menu-trigger-${key}`}
-        onMouseDown={(e) => {
-          e.stopPropagation();
-        }}
-        onClick={(e) => {
-          e.stopPropagation();
+      <SidebarNavMenuButton
+        countsVisible={rowCountsVisible}
+        label={label}
+        menuOpen={openMenuSourceKey === key}
+        testId={`source-menu-trigger-${key}`}
+        onToggle={(element) => {
           if (openMenuSourceKey === key) {
             setOpenMenuSourceKey(null);
             setSourceMenuAnchorRect(null);
@@ -1433,30 +1470,22 @@ export function Sidebar({
             setMenuAnchorRect(null);
             setMenuAnchorElement(null);
             setOpenMenuSourceKey(key);
-            setSourceMenuAnchorRect(e.currentTarget.getBoundingClientRect());
-            setSourceMenuAnchorElement(e.currentTarget);
+            setSourceMenuAnchorRect(element.getBoundingClientRect());
+            setSourceMenuAnchorElement(element);
           }
         }}
-        className={`${sourceMenuTriggerBaseClass} ${
-          openMenuSourceKey === key
-            ? "translate-x-0 bg-[color:var(--theme-bg-muted)] text-[color:var(--theme-text-primary)] opacity-100"
-            : "pointer-events-none translate-x-[-4px] text-[color:var(--theme-text-muted)] opacity-0 group-hover/sidebar-row:pointer-events-auto group-hover/sidebar-row:translate-x-0 group-hover/sidebar-row:opacity-100"
-        }`}
-      >
-        <MoreIcon />
-      </button>
+      />
     );
   };
   const renderSourceMenu = (source: SourceNavigationItem) =>
     renderRowMenu(sourceKey(source), source.label, canShowSourceMenu(source));
   const renderFeedMenu = (feed: RssFeed, menuOpen: boolean) => (
-    <button
-      aria-label={`Options for ${feed.title}`}
-      onMouseDown={(e) => {
-        e.stopPropagation();
-      }}
-      onClick={(e) => {
-        e.stopPropagation();
+    <SidebarNavMenuButton
+      countsVisible={rowCountsVisible}
+      label={feed.title}
+      menuOpen={menuOpen}
+      testId={`feed-menu-trigger-${feed.url}`}
+      onToggle={(element) => {
         if (menuOpen) {
           setOpenMenuFeedUrl(null);
           setMenuAnchorRect(null);
@@ -1466,20 +1495,11 @@ export function Sidebar({
           setSourceMenuAnchorRect(null);
           setSourceMenuAnchorElement(null);
           setOpenMenuFeedUrl(feed.url);
-          setMenuAnchorRect(e.currentTarget.getBoundingClientRect());
-          setMenuAnchorElement(e.currentTarget);
+          setMenuAnchorRect(element.getBoundingClientRect());
+          setMenuAnchorElement(element);
         }
       }}
-      className={`absolute right-0 top-1/2 flex h-6 w-6 -translate-y-1/2 items-center justify-center rounded-md transition-all duration-200 ease-in-out hover:bg-[color:var(--theme-bg-muted)] hover:text-[color:var(--theme-text-primary)] ${
-        menuOpen
-          ? "translate-x-0 bg-[color:var(--theme-bg-muted)] text-[color:var(--theme-text-primary)] opacity-100"
-          : sourceMenusVisible
-            ? "pointer-events-none translate-x-[-4px] text-[color:var(--theme-text-muted)] opacity-0 group-hover/sidebar-row:pointer-events-auto group-hover/sidebar-row:translate-x-0 group-hover/sidebar-row:opacity-100"
-            : "pointer-events-none opacity-0"
-      }`}
-    >
-      <MoreIcon />
-    </button>
+    />
   );
 
   const sidebarBody = (
@@ -1611,7 +1631,7 @@ export function Sidebar({
                 <SidebarNavRow
                   active={activeView === "friends"}
                   actionSlotClass={rowActionSlotClass(
-                    activeView === "friends",
+                    true,
                     pendingMatchCount > 0 || friendCount > 0,
                     "friends",
                   )}
@@ -1629,7 +1649,7 @@ export function Sidebar({
                   icon={renderSidebarRowIcon(<UsersIcon />, pendingFriendsBadge)}
                   label="Friends"
                   labelClass={sidebarLabelClass}
-                  menu={renderRowMenu("friends", "Friends", activeView === "friends")}
+                  menu={renderRowMenu("friends", "Friends", true)}
                   menuOpen={openMenuSourceKey === "friends"}
                   onClick={() => {
                     setActiveView("friends");
@@ -2116,7 +2136,7 @@ export function Sidebar({
         />
       )}
 
-      {openMenuSourceKey === "friends" && sourceMenuAnchorRect && activeView === "friends" ? (
+      {openMenuSourceKey === "friends" && sourceMenuAnchorRect ? (
         <FriendsContextMenu
           anchorRect={sourceMenuAnchorRect}
           anchorElement={sourceMenuAnchorElement}


### PR DESCRIPTION
(AI Generated).

## Summary
- Balance search panel content insets by removing its unused scrollbar gutter.
- Use one shared nav-menu trigger for Friends, provider, and feed rows with equal top and right spacing.
- Keep the Friends menu available while inactive and dismiss all sidebar menus on captured pointer input.

## Testing
- Focused Friends and source-menu e2e: 3 passed.
- Full workspace typecheck passed.
- Feature build, unit, smoke, and performance lanes passed; Settings performance passed on isolated rerun after one 3.4 ms p95 timing miss.