### PR TITLE
fix: remove Friends dust test control

### DIFF
--- a/docs/PHASE-8-FRIENDS.md
+++ b/docs/PHASE-8-FRIENDS.md
@@ -432,6 +432,8 @@ Typed social profile search results now expose the same person workflow from the
 
 Reader author names now route directly into the matching Friends channel detail panel, using the existing captured-account workflow so a post can move from reading to identity review in one click.
 
+The product Friends view now fixes decorative dust to the 100,000-star Raw WebGPU vertex-generated path. The temporary buffered, procedural, and disabled comparison control and its local-storage override have been removed from the shipped interface. Build timing remains visible for diagnostics without exposing renderer experiments as product controls.
+
 ---
 
 ## Tasks
@@ -608,6 +610,7 @@ Reader author names now route directly into the matching Friends channel detail 
 | 8.168 | Add a persisted preview control that compares 100,000 worker-buffered decorative stars, 100,000 Raw WebGPU vertex-generated stars with no per-star source or instance buffer, and no decorative stars while reporting the last worker-to-renderer build time | Medium     | Done        |
 | 8.169 | Keep graph-invalidating fields narrow, coalesce sustained source hydration through one resident latest-wins worker, and replace Raw WebGPU scenes without recreating the canvas, device, or compiled pipelines | High       | Done        |
 | 8.170 | Animate Fit All through simultaneous world-center pan and logarithmic zoom, preserve exact final framing and reduced-motion snapping, and interrupt the transition on direct camera input | Medium     | Done        |
+| 8.171 | Remove the temporary decorative-star comparison control and local-storage override from the product Friends view while retaining 100,000 Raw WebGPU vertex-generated dust stars and build timing diagnostics | Medium     | Done        |
 
 ---
 
@@ -730,7 +733,7 @@ Reader author names now route directly into the matching Friends channel detail 
 - [x] Projected picking uses a worker-built transferable sparse world grid, preserves exact depth and prominence selection, tolerates distant pinned outliers, and projects only the locked-camera corridor candidates
 - [x] WebGPU rendering caps settled Retina density and lowers compact or wide motion density once per gesture without removing resident stars or labels
 - [x] Decorative background stars scale smoothly with camera zoom across Raw WebGPU, Three.js WebGPU, and WebGL2 without changing semantic star sizes or uploading resident buffers
-- [x] A preview-only Friends control can compare 100,000 worker-buffered decorative stars, 100,000 Raw WebGPU vertex-generated stars with no per-star source or instance buffer, and no decorative stars while persisting the choice and reporting comparable build timing
+- [x] The product Friends view uses 100,000 Raw WebGPU vertex-generated decorative stars without per-star source or instance buffers, a shipped preview selector, or a local-storage mode override, while retaining build timing diagnostics
 - [x] Friends Galaxy source churn ignores non-structural metadata, stays bounded during sustained hydration, reuses one worker, and replaces compatible Raw WebGPU scenes on one canvas and device without recompiling pipelines
 - [x] Compact initial framing opens on a legible semantic field while Fit galaxy remains the explicit complete-universe command
 - [x] Gesture diagnostics use fixed typed rings and defer panel DOM updates until camera settle

--- a/packages/desktop/tests/e2e/smoke.spec.ts
+++ b/packages/desktop/tests/e2e/smoke.spec.ts
@@ -4670,6 +4670,8 @@ test("Friends graph renders confirmed friends, provisional people, and channels 
 
   const viewport = page.getByTestId("friend-graph-viewport");
   await expect(viewport).toBeVisible({ timeout: 10_000 });
+  await expect(page.getByTestId("friend-graph-decorative-stars-toggle")).toHaveCount(0);
+  await expect(viewport).toHaveAttribute("data-graph-decorative-star-mode", "procedural");
   await expect.poll(async () => {
     return viewport.evaluate((element) => ({
       nodes: Number((element as HTMLElement).dataset.graphNodeCount ?? "0"),

--- a/packages/ui/src/components/friends/FriendGraph.tsx
+++ b/packages/ui/src/components/friends/FriendGraph.tsx
@@ -202,9 +202,8 @@ interface ScheduledFriendsGalaxySource {
 }
 
 const BACKGROUND_STAR_COUNT = 100_000;
-const DECORATIVE_STARS_PREVIEW_STORAGE_KEY =
-  "freed.preview.friends.decorative-stars-v1";
 type DecorativeStarMode = "buffered" | "procedural" | "off";
+const DECORATIVE_STAR_MODE: DecorativeStarMode = "procedural";
 const CONTROL_BASE = "btn-secondary rounded-lg px-3 py-1.5 text-xs shadow-sm";
 const CANVAS_CONTROL_BASE =
   "btn-secondary theme-canvas-control rounded-[var(--card-radius)] px-3 py-1.5 text-xs shadow-sm";
@@ -215,17 +214,6 @@ function nowMs(): number {
   return typeof performance !== "undefined" && typeof performance.now === "function"
     ? performance.now()
     : Date.now();
-}
-
-function initialDecorativeStarMode(): DecorativeStarMode {
-  if (typeof window === "undefined") return "buffered";
-  try {
-    const stored = window.localStorage.getItem(DECORATIVE_STARS_PREVIEW_STORAGE_KEY);
-    if (stored === "off" || stored === "procedural") return stored;
-    return "buffered";
-  } catch {
-    return "buffered";
-  }
 }
 
 function shouldExposeGraphDebug(): boolean {
@@ -532,9 +520,7 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
   const [graphReady, setGraphReady] = useState(false);
   const [graphStatus, setGraphStatus] = useState("Building galaxy...");
   const [graphError, setGraphError] = useState<string | null>(null);
-  const [decorativeStarMode, setDecorativeStarMode] = useState<DecorativeStarMode>(
-    initialDecorativeStarMode,
-  );
+  const decorativeStarMode = DECORATIVE_STAR_MODE;
   const [sourceBuildInFlight, setSourceBuildInFlight] = useState(true);
   const [lastBuildMs, setLastBuildMs] = useState<number | null>(null);
   const [sourceRetry, setSourceRetry] = useState(0);
@@ -550,12 +536,8 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
   const graphDescriptionId = useId();
   const graphAnnouncementId = useId();
 
-  const backgroundStarCount = decorativeStarMode === "buffered"
-    ? BACKGROUND_STAR_COUNT
-    : 0;
-  const proceduralBackgroundStarCount = decorativeStarMode === "procedural"
-    ? BACKGROUND_STAR_COUNT
-    : 0;
+  const backgroundStarCount = 0;
+  const proceduralBackgroundStarCount = BACKGROUND_STAR_COUNT;
 
   latestActivityRef.current = activitySummaries;
 
@@ -1144,22 +1126,6 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
         : null;
     setAnnouncement(friendsGalaxySelectionAnnouncement(label, "focus"));
   }, [accounts, feeds, personsById]);
-  const cycleDecorativeStarMode = useCallback(() => {
-    setDecorativeStarMode((mode) => {
-      const next: DecorativeStarMode = mode === "buffered"
-        ? "procedural"
-        : mode === "procedural" ? "off" : "buffered";
-      try {
-        window.localStorage.setItem(
-          DECORATIVE_STARS_PREVIEW_STORAGE_KEY,
-          next,
-        );
-      } catch {
-        // The preview remains usable when storage is unavailable.
-      }
-      return next;
-    });
-  }, []);
   useImperativeHandle(ref, () => ({
     fitAll,
     focusNode,
@@ -1485,22 +1451,6 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
       >
         <button type="button" className={CANVAS_CONTROL_BASE} onClick={fitAll}>
           Fit all
-        </button>
-        <button
-          type="button"
-          className={CANVAS_CONTROL_BASE}
-          aria-busy={sourceBuildInFlight}
-          aria-label="Cycle decorative star rendering mode"
-          data-decorative-star-mode={decorativeStarMode}
-          data-testid="friend-graph-decorative-stars-toggle"
-          onClick={cycleDecorativeStarMode}
-          title="Cycle buffered, GPU-procedural, and disabled decorative stars"
-        >
-          {decorativeStarMode === "buffered"
-            ? `Dust buffer ${BACKGROUND_STAR_COUNT.toLocaleString()}`
-            : decorativeStarMode === "procedural"
-              ? `Dust vertex ${BACKGROUND_STAR_COUNT.toLocaleString()}`
-              : "Dust off"}
         </button>
         <span
           className="theme-canvas-control rounded-lg px-2.5 py-1.5 text-xs tabular-nums text-[color:var(--theme-text-muted)]"


### PR DESCRIPTION
(AI Generated).

## Summary
- Remove the temporary decorative-star mode selector and its local-storage override from the Friends product view while retaining 100,000 procedural GPU dust stars and build timing diagnostics.

## Testing
- npm run validate:feature
- Rendered PWA preview confirms only Fit all remains and data-graph-decorative-star-mode is procedural
- Focused Friends graph e2e and star-instance unit tests