### PR TITLE
fix: stabilize map panels and markers

### DIFF
--- a/docs/PHASE-8-FRIENDS.md
+++ b/docs/PHASE-8-FRIENDS.md
@@ -393,6 +393,10 @@ Sample data batches now append friend-linked LinkedIn posts and bounded past, cu
 New sample data batches now carry an internal cleanup marker on generated feeds, items, people, and accounts, so the app can clear sample records without guessing from names or URLs.
 Friends and Map now use the same shared content header pattern as the rest of the app, instead of shipping bespoke top bars that wander off into their own little kingdoms.
 Map popovers now include the time of each location update and behave like a sane interface, with only one popup open at a time.
+Map now exposes the same `Fit all` canvas control as Friends Galaxy. It shares the sidebar's outer canvas gutter, closes an open location panel, and reframes every marker in the current time and identity filters without preserving a previously focused person.
+Map avatar markers now remain circular while zoomed and preserve the zoomed hover treatment while their location panel is open. Floating UI positions the open card around its marker, flips it when space is tight, keeps the marker outside the card, and holds the tooltip-style tail on the exact marker axis without intersecting the timeline or floating controls. When a control obscures the marker or the arrow would need clamping, the card omits the tail instead of pointing at false geography.
+Map theme changes now repaint the live MapLibre style and markers in place without losing the current markers or changing the camera, including transient theme hovers and a return to a previously cached theme.
+Map now paints exact coincident locations once, using the newest marker and a combined update count, so repeated city-level coordinates do not accumulate dozens of glows into concentric rings. A focused marker remains the representative for its location.
 Friends now behaves like a proper workspace: the graph settles once and freezes, supports pan and zoom, and uses a permanent resizable right sidebar for reconnect, search, filters, overview, and selected-friend detail.
 That Friends detail rail now uses the same floating shell-card treatment and gap-based resize grip as the main app sidebars, so it finally looks like it belongs in the same product.
 That same Friends rail can now be collapsed from a far-right toolbar toggle on larger screens, and narrow screens fold the detail surface into a third `Details` lens instead of stacking the graph and sidebar on top of each other like a punishment.
@@ -412,7 +416,7 @@ The Friends starfield now bleeds under the primary app sidebar like the map back
 Friend avatars now inherit a theme-authored tint across the Friends graph and map markers, so each theme stays coherent without a stray custom accent fighting the palette.
 The Friends graph now defaults to `All content`, keeps confirmed friends as larger center hubs, renders their linked channels as smaller radial satellites with straight connectors, and shows every other captured social account on the periphery inside provider-shaped metaball island regions.
 Unlinked accounts can now be promoted to friends or linked to an existing friend directly from the Friends sidebar workflow, while unlinked map markers route into that same account workflow instead of dead-ending.
-Map popovers now use a wider card layout and deliberately omit the old MapLibre tail, so place names and actions fit cleanly without the popup looking like a speech bubble from a cheaper app.
+Map popovers now use a wider card layout with a compact theme-aware tail attached to the open card, so place names and actions fit cleanly while the card still points back to its marker.
 Friends and Map now consume the same shared theme tokens, button treatments, shell backgrounds, surface recipes, and theme-native map palettes as the rest of Freed, so Starship, Dark Star, Neon, Midas, Ember, and Scriptorium land consistently across the graph, sidebars, popovers, mini-map cards, editor, contact-sync flows, and map basemap itself.
 The shared map now includes a device-local `Friends` / `All content` toggle. It restores the current device's last mode and defaults to `All content` when the library has geolocatable followed accounts but no friend-linked pins yet.
 That same `Friends` / `All content` lens now lives in the shared toolbar for feed surfaces too, so the operator can collapse Freed down to real-world people without leaving the main reading views.
@@ -611,6 +615,11 @@ The product Friends view now fixes decorative dust to the 100,000-star Raw WebGP
 | 8.169 | Keep graph-invalidating fields narrow, coalesce sustained source hydration through one resident latest-wins worker, and replace Raw WebGPU scenes without recreating the canvas, device, or compiled pipelines | High       | Done        |
 | 8.170 | Animate Fit All through simultaneous world-center pan and logarithmic zoom, preserve exact final framing and reduced-motion snapping, and interrupt the transition on direct camera input | Medium     | Done        |
 | 8.171 | Remove the temporary decorative-star comparison control and local-storage override from the product Friends view while retaining 100,000 Raw WebGPU vertex-generated dust stars and build timing diagnostics | Medium     | Done        |
+| 8.172 | Add the shared Friends Galaxy `Fit all` canvas control to Map with the standard sidebar gutter so it closes open location panels and reframes every marker admitted by the current filters | Low        | Done        |
+| 8.173 | Keep Map avatar bubbles circular while their hover treatment scales beyond the marker's resting bounds | Low        | Done        |
+| 8.174 | Position open Map cards from their marker with Floating UI, flip and constrain them around reserved controls, align honest card tails to the marker axis, omit tails for obscured or unalignable markers, and preserve the marker's zoomed hover treatment | High       | Done        |
+| 8.175 | Repaint the live MapLibre style and markers in place across theme changes, including transient hovers and cached-theme round trips, without losing markers or changing the camera | High       | Done        |
+| 8.176 | Coalesce exact coincident Map locations into one newest-marker representation with a combined update count while preserving a focused marker | Medium     | Done        |
 
 ---
 
@@ -651,6 +660,10 @@ The product Friends view now fixes decorative dust to the 100,000-star Raw WebGP
 - [x] Confirmed friend hubs render linked channel satellites with provider-shaped island backgrounds
 - [x] Friends and Map share header-level identity controls, and feed bulk actions stay feed-only
 - [x] Map exposes a lower-left draggable time range slider with all available time selected by default
+- [x] Map exposes the shared `Fit all` canvas control and reframes every marker admitted by the current time and identity filters
+- [x] Map avatar markers stay circular and zoomed while their Floating UI card remains outside the marker and controls, with a connected tail only when it can align honestly to an unobscured marker
+- [x] Map theme changes repaint in place through transient hovers and cached-theme round trips while preserving the exact marker set and camera
+- [x] Exact coincident Map locations paint once with the newest marker and a combined update count, while a focused marker remains the location representative
 - [x] Unlinked accounts can be promoted or linked from both the Friends workspace and Map popups
 - [x] Likely human social accounts can persist as provisional `connection` identities before they are confirmed as friends
 - [x] Substack and Medium follower, following, and visible subscription accounts

--- a/docs/roadmap-status.json
+++ b/docs/roadmap-status.json
@@ -24,7 +24,11 @@
       "status": "current",
       "source": "docs/PHASE-7-SOCIAL-CAPTURE.md"
     },
-    { "id": 8, "status": "current", "source": "docs/PHASE-8-FRIENDS.md" },
+    {
+      "id": 8,
+      "status": "current",
+      "source": "docs/PHASE-8-FRIENDS.md"
+    },
     {
       "id": 9,
       "status": "upcoming",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14431,6 +14431,7 @@
       "name": "@freed/ui",
       "version": "0.1.0",
       "dependencies": {
+        "@floating-ui/dom": "^1.8.0",
         "@freed/shared": "*",
         "@tanstack/react-virtual": "^3.14.8",
         "@types/d3-force": "^3.0.10",

--- a/packages/desktop/tests/e2e/smoke.spec.ts
+++ b/packages/desktop/tests/e2e/smoke.spec.ts
@@ -3402,6 +3402,7 @@ test("Friends keeps the source sidebar inset while its galaxy background stays f
 
 test("Map view popup exposes friend actions and supports post navigation", async ({ app }) => {
   test.setTimeout(60_000);
+  await app.page.setViewportSize({ width: 1_440, height: 900 });
   await app.goto();
   await app.waitForReady();
   await app.seedFriendLocation();
@@ -3417,6 +3418,72 @@ test("Map view popup exposes friend actions and supports post navigation", async
     store?.getState().setActiveView("map");
   });
   await expect(page.getByTestId("map-surface")).toBeVisible({ timeout: 10_000 });
+
+  await openVisibleMapMarker(page, "Ada Lovelace", "Open Friend");
+  const popup = page.locator("[data-map-floating-panel]");
+  const marker = page.locator('.freed-map-marker[aria-label="Ada Lovelace"]:visible').first();
+  const popupArrow = popup.locator("[data-map-popup-arrow]");
+  const popupBox = await popup.boundingBox();
+  const markerBox = await marker.boundingBox();
+  const popupArrowBox = await popupArrow.boundingBox();
+  const popupPlacement = await popup.getAttribute("data-placement");
+  const timelineBox = await page.getByTestId("map-time-range-slider").boundingBox();
+  const addControlBox = await page.getByTestId("map-add-floating-control").boundingBox();
+  const fitAllControlBox = await page.getByTestId("map-fit-all-control").boundingBox();
+  expect(popupBox).not.toBeNull();
+  expect(markerBox).not.toBeNull();
+  expect(popupArrowBox).not.toBeNull();
+  expect(popupPlacement).toMatch(/^(top|right|bottom|left)$/);
+  expect(timelineBox).not.toBeNull();
+  expect(addControlBox).not.toBeNull();
+  expect(fitAllControlBox).not.toBeNull();
+  expect(boxesOverlap(popupBox!, timelineBox!)).toBe(false);
+  expect(boxesOverlap(popupBox!, addControlBox!)).toBe(false);
+  expect(boxesOverlap(popupBox!, fitAllControlBox!)).toBe(false);
+  expect(boxesOverlap(popupBox!, markerBox!)).toBe(false);
+  expect(boxesOverlap(popupBox!, popupArrowBox!)).toBe(true);
+  const popupArrowCenter = {
+    x: popupArrowBox!.x + popupArrowBox!.width / 2,
+    y: popupArrowBox!.y + popupArrowBox!.height / 2,
+  };
+  const markerCenter = {
+    x: markerBox!.x + markerBox!.width / 2,
+    y: markerBox!.y + markerBox!.height / 2,
+  };
+  const arrowAlignmentError = popupPlacement === "top" || popupPlacement === "bottom"
+    ? Math.abs(popupArrowCenter.x - markerCenter.x)
+    : Math.abs(popupArrowCenter.y - markerCenter.y);
+  expect(arrowAlignmentError).toBeLessThanOrEqual(TOOLTIP_ARROW_ALIGNMENT_TOLERANCE_PX);
+  await page.getByRole("button", { name: "Fit all" }).click();
+  await expect(page.locator("[data-map-floating-panel]")).toHaveCount(0);
+
+  const occludedMarkerBox = await marker.boundingBox();
+  expect(occludedMarkerBox).not.toBeNull();
+  await page.evaluate((box) => {
+    const occluder = document.createElement("div");
+    occluder.dataset.mapFloatingControl = "marker-occluder";
+    occluder.dataset.testid = "map-marker-occluder";
+    occluder.style.cssText = [
+      "position:fixed",
+      `left:${box.x}px`,
+      `top:${box.y}px`,
+      `width:${box.width}px`,
+      `height:${box.height}px`,
+      "pointer-events:none",
+    ].join(";");
+    document.body.appendChild(occluder);
+  }, occludedMarkerBox!);
+  await openVisibleMapMarker(page, "Ada Lovelace", "Open Friend");
+  await expect(popup).toHaveAttribute("data-map-popup-tail", "hidden");
+  await expect(popupArrow).toBeHidden();
+  const occludedPopupBox = await popup.boundingBox();
+  const occluderBox = await page.getByTestId("map-marker-occluder").boundingBox();
+  expect(occludedPopupBox).not.toBeNull();
+  expect(occluderBox).not.toBeNull();
+  expect(boxesOverlap(occludedPopupBox!, occluderBox!)).toBe(false);
+  await page.getByTestId("map-marker-occluder").evaluate((element) => element.remove());
+  await page.getByRole("button", { name: "Fit all" }).click();
+  await expect(page.locator("[data-map-floating-panel]")).toHaveCount(0);
 
   await openVisibleMapMarker(page, "Ada Lovelace", "Open Friend");
   await clickMapPopupAction(page, "Open Friend");

--- a/packages/desktop/tests/e2e/theme-switching.spec.ts
+++ b/packages/desktop/tests/e2e/theme-switching.spec.ts
@@ -291,6 +291,12 @@ test("map view repaints across all themes without using the old canvas filter", 
   await app.seedFriendLocation();
   await dismissCloudSyncNudgeIfPresent(page);
 
+  await page.evaluate(async (themeModulePath) => {
+    const mod = await import(themeModulePath);
+    mod.applyThemeToDocument("scriptorium");
+    mod.setThemePreference("scriptorium");
+  }, THEME_MODULE_PATH);
+
   await page.getByRole("button", { name: /^Map/ }).click();
   await expect(page.getByTestId("map-surface")).toBeVisible({ timeout: 10_000 });
 
@@ -440,7 +446,15 @@ test("map view repaints across all themes without using the old canvas filter", 
     webkitMaskImage: "none",
   });
 
-  const themeIds = ["ember", "neon", "midas", "scriptorium"] as const;
+  const baselineMarkerCount = await page.locator(".freed-map-marker").count();
+  expect(baselineMarkerCount).toBeGreaterThan(0);
+
+  await expect(page.getByTestId("map-surface")).toHaveScreenshot("map-theme-scriptorium.png", {
+    animations: "disabled",
+    maxDiffPixelRatio: 0.02,
+  });
+
+  const themeIds = ["ember", "neon", "midas"] as const;
 
   for (const themeId of themeIds) {
     await page.evaluate(async ({ nextThemeId, themeModulePath }) => {
@@ -454,7 +468,9 @@ test("map view repaints across all themes without using the old canvas filter", 
     }).toBe(themeId);
 
     await expect(page.getByTestId("map-surface")).toHaveAttribute("data-map-theme", themeId);
-    await expect(page.locator(".freed-map-marker")).toBeVisible({ timeout: 20_000 });
+    await expect.poll(async () => page.locator(".freed-map-marker").count(), {
+      timeout: 20_000,
+    }).toBe(baselineMarkerCount);
 
     await expect.poll(async () => {
       return page.evaluate(() => {
@@ -477,6 +493,17 @@ test("map view repaints across all themes without using the old canvas filter", 
       maxDiffPixelRatio: 0.02,
     });
   }
+
+  await page.evaluate(async ({ nextThemeId, themeModulePath }) => {
+    const mod = await import(themeModulePath);
+    mod.applyThemeToDocument(nextThemeId);
+    mod.setThemePreference(nextThemeId);
+  }, { nextThemeId: "ember", themeModulePath: THEME_MODULE_PATH });
+
+  await expect(page.getByTestId("map-surface")).toHaveAttribute("data-map-theme", "ember");
+  await expect.poll(async () => page.locator(".freed-map-marker").count(), {
+    timeout: 20_000,
+  }).toBe(baselineMarkerCount);
 });
 
 test("top toolbar uses a single bottom border", async ({ app, page }) => {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -63,6 +63,7 @@
     "react-dom": "^19.2.8"
   },
   "dependencies": {
+    "@floating-ui/dom": "^1.8.0",
     "@freed/shared": "*",
     "@tanstack/react-virtual": "^3.14.8",
     "@types/d3-force": "^3.0.10",

--- a/packages/ui/src/components/LocalPreviewBadge.tsx
+++ b/packages/ui/src/components/LocalPreviewBadge.tsx
@@ -136,6 +136,8 @@ export function LocalPreviewBadge({ label }: LocalPreviewBadgeProps) {
     <div
       ref={badgeRef}
       className={`fixed z-[140] max-w-[min(32rem,calc(100vw-2rem))] touch-none select-none ${dragging ? "cursor-grabbing" : "cursor-grab"}`}
+      data-map-floating-control="preview-badge"
+      data-map-floating-control-edge={position ? undefined : "bottom"}
       style={
         position
           ? { left: `${position.x}px`, top: `${position.y}px` }
@@ -148,7 +150,7 @@ export function LocalPreviewBadge({ label }: LocalPreviewBadgeProps) {
       onLostPointerCapture={finishDrag}
     >
       <div className="theme-floating-panel flex items-center gap-0 rounded-2xl px-3 py-2 shadow-2xl shadow-black/30 sm:gap-3">
-        <div className="hidden rounded-full bg-[color:color-mix(in_srgb,var(--theme-accent-secondary)_20%,transparent)] px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-[var(--theme-accent-secondary)] sm:block">
+        <div className="hidden min-w-0 truncate whitespace-nowrap rounded-full bg-[color:color-mix(in_srgb,var(--theme-accent-secondary)_20%,transparent)] px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-[var(--theme-accent-secondary)] sm:block">
           Local preview
         </div>
         <p className="min-w-0 truncate font-mono text-xs text-[var(--theme-text-primary)]">

--- a/packages/ui/src/components/friends/FriendGraph.tsx
+++ b/packages/ui/src/components/friends/FriendGraph.tsx
@@ -70,6 +70,7 @@ import type {
   IdentityGraphAtlasNode,
 } from "../../lib/identity-graph-atlas.js";
 import { IdentityGalaxyNodeKindCode } from "../../lib/identity-galaxy-scene.js";
+import { CANVAS_CONTROL_BUTTON_CLASS } from "../layout/layoutConstants.js";
 
 export interface FriendGraphHandle {
   fitAll: () => void;
@@ -205,8 +206,6 @@ const BACKGROUND_STAR_COUNT = 100_000;
 type DecorativeStarMode = "buffered" | "procedural" | "off";
 const DECORATIVE_STAR_MODE: DecorativeStarMode = "procedural";
 const CONTROL_BASE = "btn-secondary rounded-lg px-3 py-1.5 text-xs shadow-sm";
-const CANVAS_CONTROL_BASE =
-  "btn-secondary theme-canvas-control rounded-[var(--card-radius)] px-3 py-1.5 text-xs shadow-sm";
 const MENU_WIDTH = 264;
 const MENU_ESTIMATED_HEIGHT = 376;
 
@@ -1449,7 +1448,7 @@ export const FriendGraph = forwardRef<FriendGraphHandle, FriendGraphProps>(funct
             : undefined
         }
       >
-        <button type="button" className={CANVAS_CONTROL_BASE} onClick={fitAll}>
+        <button type="button" className={CANVAS_CONTROL_BUTTON_CLASS} onClick={fitAll}>
           Fit all
         </button>
         <span

--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -2248,11 +2248,16 @@ export function Header({
         <div
           ref={dropdownRef}
           className="fixed bottom-5 right-5 z-[90] sm:bottom-6 sm:right-6"
+          data-testid="map-add-floating-control"
+          data-map-floating-control="add"
+          data-map-floating-control-edge="bottom"
           style={headerDragRegion ? noDrag : undefined}
         >
           {dropdownOpen && (
             <div
               className="theme-floating-panel theme-menu-shell absolute bottom-[calc(100%+0.875rem)] right-0 flex min-w-[12rem] flex-col py-1 shadow-2xl shadow-black/40"
+              data-map-floating-control="add-menu"
+              data-map-floating-control-edge="bottom"
               style={newMenuStyle}
             >
               {canAddRss && (

--- a/packages/ui/src/components/layout/layoutConstants.ts
+++ b/packages/ui/src/components/layout/layoutConstants.ts
@@ -9,6 +9,8 @@ export const FRIENDS_SIDEBAR_GAP_WIDTH_PX = 12;
 export const TOOLBAR_SIDEBAR_SLOT_PADDING_RIGHT_PX = 8;
 export const TOOLBAR_ICON_BUTTON_SIZE_PX = 40;
 export const TOOLBAR_BOUNDARY_BUTTON_GAP_PX = 8;
+export const CANVAS_CONTROL_BUTTON_CLASS =
+  "btn-secondary rounded-lg px-3 py-1.5 text-xs shadow-sm theme-canvas-control";
 
 export const COMPACT_PRIMARY_SIDEBAR_WIDTH_PX = 48;
 export const TOP_TOOLBAR_HEIGHT_PX =

--- a/packages/ui/src/components/map/MapSurface.test.ts
+++ b/packages/ui/src/components/map/MapSurface.test.ts
@@ -92,6 +92,47 @@ describe("areLocationMarkerListsRenderEquivalent", () => {
 });
 
 describe("dense map marker prioritization", () => {
+  it("paints coincident locations once with the newest marker and combined update count", () => {
+    const newest = marker({
+      key: "friend:newest",
+      groupCount: 2,
+      seenAt: NOW,
+    });
+    const older = marker({
+      key: "friend:older",
+      groupCount: 3,
+      seenAt: NOW - 60_000,
+    });
+
+    const renderedMarkers = getRenderedMapMarkers([older, newest]);
+
+    expect(renderedMarkers).toEqual([
+      expect.objectContaining({
+        key: "friend:newest",
+        groupCount: 5,
+      }),
+    ]);
+    expect(newest.groupCount).toBe(2);
+    expect(older.groupCount).toBe(3);
+  });
+
+  it("keeps a focused coincident marker as the location representative", () => {
+    const newest = marker({ key: "friend:newest", seenAt: NOW });
+    const focused = marker({ key: "friend:focused", seenAt: NOW - 60_000 });
+
+    const renderedMarkers = getRenderedMapMarkers(
+      [newest, focused],
+      focused.key,
+    );
+
+    expect(renderedMarkers).toEqual([
+      expect.objectContaining({
+        key: focused.key,
+        groupCount: 2,
+      }),
+    ]);
+  });
+
   it("limits paint-active markers while dense maps are moving", () => {
     expect(getMapMovingPriority(23, "friend:23", true, null)).toBe("primary");
     expect(getMapMovingPriority(24, "friend:24", true, null)).toBe("deferred");
@@ -103,6 +144,7 @@ describe("dense map marker prioritization", () => {
       marker({
         key: `friend:${index}`,
         authorKey: `author:instagram:${index}`,
+        lat: 48.8566 + index * 0.001,
         item: {
           ...marker().item,
           globalId: `instagram:${index}`,

--- a/packages/ui/src/components/map/MapSurface.tsx
+++ b/packages/ui/src/components/map/MapSurface.tsx
@@ -8,15 +8,23 @@ import {
   type WheelEvent,
 } from "react";
 import { formatDistanceToNow } from "date-fns";
+import {
+  arrow,
+  computePosition,
+  offset,
+  shift,
+  type Placement,
+} from "@floating-ui/dom";
 import type { LocationMarkerSummary } from "@freed/shared";
 import { DEFAULT_THEME_ID, getThemeDefinition, type ThemeId } from "@freed/shared/themes";
-import type { Map as MapLibreMap, Marker as MapLibreMarker, Popup as MapLibrePopup } from "maplibre-gl";
+import type { Map as MapLibreMap, Marker as MapLibreMarker } from "maplibre-gl";
 import mapLibreWorkerUrl from "maplibre-gl/dist/maplibre-gl-worker.mjs?worker&url";
 import { createMarkerElement } from "./MarkerElement.js";
 import { createFriendAvatarPalette } from "../../lib/friend-avatar-style.js";
 import { buildThemedMapStyle } from "../../lib/map-style.js";
+import { CANVAS_CONTROL_BUTTON_CLASS } from "../layout/layoutConstants.js";
 
-type PopupInstance = MapLibrePopup;
+type PopupInstance = HTMLElement;
 type MarkerInstance = MapLibreMarker;
 type MapInstance = MapLibreMap;
 type DisposableMapInstance = Pick<MapInstance, "getCanvas" | "remove" | "stop">;
@@ -41,6 +49,7 @@ interface MapSurfaceProps {
   onOpenPost?: (marker: LocationMarkerSummary) => void;
   emptyTitle?: string;
   emptyBody?: string;
+  showFitAllControl?: boolean;
 }
 
 type MapViewportInsets = {
@@ -64,6 +73,9 @@ const popupDateFormatter = new Intl.DateTimeFormat(undefined, {
 });
 const MAP_POPUP_MAX_WIDTH = 560;
 const MAP_POPUP_VIEWPORT_MARGIN = 40;
+const MAP_FLOATING_PANEL_GAP_PX = 12;
+const MAP_POPUP_ARROW_ALIGNMENT_TOLERANCE_PX = 1;
+const MAP_FLOATING_CONTROL_SELECTOR = "[data-map-floating-control]";
 const MAP_DOM_MARKER_LIMIT = 160;
 const MAP_MOVING_MARKER_PAINT_LIMIT = 24;
 const MAP_DENSE_MARKER_RESTORE_DELAY_MS = 420;
@@ -71,6 +83,318 @@ const MAP_CAMERA_PADDING_PX = 72;
 const MAP_CLUSTER_MAX_ZOOM = 7.5;
 const MAP_MAX_PIXEL_RATIO = 1.5;
 const MAP_MAX_TILE_CACHE_SIZE = 24;
+
+type FloatingLayoutRect = {
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+  width: number;
+  height: number;
+};
+
+function layoutRect(rect: DOMRect): FloatingLayoutRect {
+  return {
+    left: rect.left,
+    top: rect.top,
+    right: rect.right,
+    bottom: rect.bottom,
+    width: rect.width,
+    height: rect.height,
+  };
+}
+
+function floatingRectsIntersect(
+  panel: FloatingLayoutRect,
+  control: FloatingLayoutRect,
+  gap = 0,
+): boolean {
+  return (
+    panel.left < control.right + gap &&
+    panel.right > control.left - gap &&
+    panel.top < control.bottom + gap &&
+    panel.bottom > control.top - gap
+  );
+}
+
+function setupMapFloatingPanelLayout({
+  panel,
+  anchor,
+  shell,
+  map,
+  getViewportInsets,
+}: {
+  panel: HTMLElement;
+  anchor: HTMLElement;
+  shell: HTMLElement;
+  map?: MapInstance;
+  getViewportInsets: () => MapViewportInsets | undefined;
+}): () => void {
+  let frame = 0;
+  let updateGeneration = 0;
+  let disposed = false;
+  const resizeObserver = new ResizeObserver(() => schedule());
+
+  const update = async () => {
+    frame = 0;
+    const generation = updateGeneration + 1;
+    updateGeneration = generation;
+    const shellRect = shell.getBoundingClientRect();
+    const insets = getViewportInsets();
+    const controls = [...document.querySelectorAll<HTMLElement>(MAP_FLOATING_CONTROL_SELECTOR)]
+      .filter((control) => !panel.contains(control))
+      .map((control) => ({ element: control, rect: layoutRect(control.getBoundingClientRect()) }))
+      .filter(({ rect }) => rect.width > 0 && rect.height > 0);
+    for (const { element } of controls) resizeObserver.observe(element);
+
+    const baseBounds = {
+      left: shellRect.left + (insets?.left ?? 0) + MAP_FLOATING_PANEL_GAP_PX,
+      top: shellRect.top + (insets?.top ?? 0) + MAP_FLOATING_PANEL_GAP_PX,
+      right: shellRect.right - (insets?.right ?? 0) - MAP_FLOATING_PANEL_GAP_PX,
+      bottom: shellRect.bottom - (insets?.bottom ?? 0) - MAP_FLOATING_PANEL_GAP_PX,
+    };
+    const topControlBottom = controls
+      .filter(({ element, rect }) =>
+        element.dataset.mapFloatingControlEdge === "top" &&
+        rect.right > baseBounds.left &&
+        rect.left < baseBounds.right,
+      )
+      .reduce(
+        (bottom, { rect }) => Math.max(bottom, rect.bottom + MAP_FLOATING_PANEL_GAP_PX),
+        baseBounds.top,
+      );
+    const bottomControlTop = controls
+      .filter(({ element, rect }) =>
+        element.dataset.mapFloatingControlEdge === "bottom" &&
+        rect.right > baseBounds.left &&
+        rect.left < baseBounds.right,
+      )
+      .reduce((top, { rect }) => Math.min(top, rect.top - MAP_FLOATING_PANEL_GAP_PX), baseBounds.bottom);
+    const bounds = {
+      left: baseBounds.left,
+      top: Math.min(topControlBottom, bottomControlTop - 1),
+      right: baseBounds.right,
+      bottom: Math.max(topControlBottom + 1, bottomControlTop),
+      width: Math.max(1, baseBounds.right - baseBounds.left),
+      height: Math.max(1, bottomControlTop - topControlBottom),
+    };
+    const floatingBoundary = {
+      x: bounds.left,
+      y: bounds.top,
+      width: bounds.width,
+      height: bounds.height,
+    };
+
+    const content = panel.querySelector<HTMLElement>(".maplibregl-popup-content") ?? panel;
+    const popupArrow = panel.querySelector<HTMLElement>("[data-map-popup-arrow]");
+    if (popupArrow) popupArrow.style.display = "";
+    const maxPanelWidth = Math.max(1, Math.min(MAP_POPUP_MAX_WIDTH, bounds.width));
+    content.style.width = `${maxPanelWidth}px`;
+    content.style.minWidth = `${Math.min(420, maxPanelWidth)}px`;
+    content.style.maxWidth = `${maxPanelWidth}px`;
+    content.style.maxHeight = "none";
+    content.style.overflowY = "auto";
+    panel.style.maxWidth = `${maxPanelWidth}px`;
+    panel.style.position = "fixed";
+    panel.style.visibility = "hidden";
+
+    const anchorRect = anchor.getBoundingClientRect();
+    const naturalWidth = Math.min(maxPanelWidth, Math.max(1, content.scrollWidth));
+    const naturalHeight = Math.max(1, content.scrollHeight);
+    const placements: Placement[] = ["top", "bottom", "right", "left"];
+    const candidates: Array<{
+      placement: Placement;
+      x: number;
+      y: number;
+      width: number;
+      height: number;
+      maxWidth: number;
+      maxHeight: number;
+      score: number;
+    }> = [];
+
+    for (const [placementIndex, placement] of placements.entries()) {
+      const side = placement.split("-")[0];
+      const availableMain = side === "top"
+        ? anchorRect.top - MAP_FLOATING_PANEL_GAP_PX - bounds.top
+        : side === "bottom"
+          ? bounds.bottom - anchorRect.bottom - MAP_FLOATING_PANEL_GAP_PX
+          : side === "left"
+            ? anchorRect.left - MAP_FLOATING_PANEL_GAP_PX - bounds.left
+            : bounds.right - anchorRect.right - MAP_FLOATING_PANEL_GAP_PX;
+      const candidateMaxWidth = Math.max(
+        1,
+        Math.min(maxPanelWidth, side === "left" || side === "right" ? availableMain : bounds.width),
+      );
+      const candidateMaxHeight = Math.max(
+        1,
+        Math.min(bounds.height, side === "top" || side === "bottom" ? availableMain : bounds.height),
+      );
+      content.style.width = `${candidateMaxWidth}px`;
+      content.style.minWidth = `${Math.min(420, candidateMaxWidth)}px`;
+      content.style.maxWidth = `${candidateMaxWidth}px`;
+      content.style.maxHeight = `${candidateMaxHeight}px`;
+
+      const result = await computePosition(anchor, panel, {
+        strategy: "fixed",
+        placement,
+        middleware: [
+          offset(MAP_FLOATING_PANEL_GAP_PX),
+          shift({ boundary: floatingBoundary, crossAxis: false }),
+        ],
+      });
+      if (disposed || generation !== updateGeneration || !panel.isConnected) return;
+
+      const measuredRect = panel.getBoundingClientRect();
+      const candidateRect: FloatingLayoutRect = {
+        left: result.x,
+        top: result.y,
+        right: result.x + measuredRect.width,
+        bottom: result.y + measuredRect.height,
+        width: measuredRect.width,
+        height: measuredRect.height,
+      };
+      const overflow =
+        Math.max(0, bounds.left - candidateRect.left) +
+        Math.max(0, candidateRect.right - bounds.right) +
+        Math.max(0, bounds.top - candidateRect.top) +
+        Math.max(0, candidateRect.bottom - bounds.bottom);
+      const controlCollision = controls.some(({ rect }) =>
+        floatingRectsIntersect(candidateRect, rect, MAP_FLOATING_PANEL_GAP_PX),
+      );
+      const constraint =
+        Math.max(0, naturalWidth - measuredRect.width) +
+        Math.max(0, naturalHeight - measuredRect.height);
+      const anchorCenterX = anchorRect.left + anchorRect.width / 2;
+      const anchorCenterY = anchorRect.top + anchorRect.height / 2;
+      const arrowInset = 24;
+      const anchorAlignmentError = side === "top" || side === "bottom"
+        ? Math.max(
+            0,
+            candidateRect.left + arrowInset - anchorCenterX,
+            anchorCenterX - (candidateRect.right - arrowInset),
+          )
+        : Math.max(
+            0,
+            candidateRect.top + arrowInset - anchorCenterY,
+            anchorCenterY - (candidateRect.bottom - arrowInset),
+          );
+      candidates.push({
+        placement,
+        x: result.x,
+        y: result.y,
+        width: measuredRect.width,
+        height: measuredRect.height,
+        maxWidth: candidateMaxWidth,
+        maxHeight: candidateMaxHeight,
+        score:
+          overflow * 1_000_000 +
+          (controlCollision ? 100_000_000 : 0) +
+          anchorAlignmentError * 10_000 +
+          constraint * 100 +
+          placementIndex,
+      });
+    }
+
+    const selected = candidates.reduce(
+      (best, candidate) => !best || candidate.score < best.score ? candidate : best,
+      null as (typeof candidates)[number] | null,
+    );
+    if (!selected) return;
+
+    content.style.width = `${selected.maxWidth}px`;
+    content.style.minWidth = `${Math.min(420, selected.maxWidth)}px`;
+    content.style.maxWidth = `${selected.maxWidth}px`;
+    content.style.maxHeight = `${selected.maxHeight}px`;
+    const result = await computePosition(anchor, panel, {
+      strategy: "fixed",
+      placement: selected.placement,
+      middleware: [
+        offset(MAP_FLOATING_PANEL_GAP_PX),
+        shift({ boundary: floatingBoundary, crossAxis: false }),
+        popupArrow ? arrow({ element: popupArrow, padding: 24 }) : null,
+      ],
+    });
+    if (disposed || generation !== updateGeneration || !panel.isConnected) return;
+
+    panel.style.left = `${Math.round(result.x)}px`;
+    panel.style.top = `${Math.round(result.y)}px`;
+    panel.style.visibility = "visible";
+    panel.dataset.placement = result.placement.split("-")[0];
+
+    if (popupArrow) {
+      const arrowData = result.middlewareData.arrow;
+      const side = result.placement.split("-")[0] as "top" | "right" | "bottom" | "left";
+      const staticSide = {
+        top: "bottom",
+        right: "left",
+        bottom: "top",
+        left: "right",
+      }[side];
+      popupArrow.style.left = arrowData?.x == null ? "" : `${Math.round(arrowData.x)}px`;
+      popupArrow.style.top = arrowData?.y == null ? "" : `${Math.round(arrowData.y)}px`;
+      popupArrow.style.right = "";
+      popupArrow.style.bottom = "";
+      popupArrow.style.setProperty(staticSide, "-5px");
+
+      const finalAnchorRect = anchor.getBoundingClientRect();
+      const anchorOccluded = controls.some(({ rect }) =>
+        floatingRectsIntersect(layoutRect(finalAnchorRect), rect),
+      );
+      const anchorOutsideSafeBounds =
+        finalAnchorRect.left < bounds.left ||
+        finalAnchorRect.right > bounds.right ||
+        finalAnchorRect.top < bounds.top ||
+        finalAnchorRect.bottom > bounds.bottom;
+      const arrowCenterX = result.x + (arrowData?.x ?? 0) + popupArrow.offsetWidth / 2;
+      const arrowCenterY = result.y + (arrowData?.y ?? 0) + popupArrow.offsetHeight / 2;
+      const anchorCenterX = finalAnchorRect.left + finalAnchorRect.width / 2;
+      const anchorCenterY = finalAnchorRect.top + finalAnchorRect.height / 2;
+      const arrowAlignmentError = side === "top" || side === "bottom"
+        ? Math.abs(arrowCenterX - anchorCenterX)
+        : Math.abs(arrowCenterY - anchorCenterY);
+      const tailVisible =
+        arrowData != null &&
+        !anchorOccluded &&
+        !anchorOutsideSafeBounds &&
+        arrowAlignmentError <= MAP_POPUP_ARROW_ALIGNMENT_TOLERANCE_PX;
+      popupArrow.style.display = tailVisible ? "" : "none";
+      panel.dataset.mapPopupTail = tailVisible ? "visible" : "hidden";
+    }
+  };
+
+  function schedule() {
+    if (frame !== 0) return;
+    frame = window.requestAnimationFrame(() => {
+      void update();
+    });
+  }
+
+  const mutationObserver = new MutationObserver(schedule);
+  resizeObserver.observe(shell);
+  resizeObserver.observe(panel);
+  mutationObserver.observe(document.body, { childList: true, subtree: true });
+  window.addEventListener("resize", schedule);
+  window.addEventListener("scroll", schedule, true);
+  map?.on("move", schedule);
+  map?.on("resize", schedule);
+  schedule();
+
+  return () => {
+    disposed = true;
+    updateGeneration += 1;
+    if (frame !== 0) window.cancelAnimationFrame(frame);
+    resizeObserver.disconnect();
+    mutationObserver.disconnect();
+    window.removeEventListener("resize", schedule);
+    window.removeEventListener("scroll", schedule, true);
+    map?.off("move", schedule);
+    map?.off("resize", schedule);
+    panel.style.left = "";
+    panel.style.top = "";
+    panel.style.visibility = "";
+  };
+}
 
 /**
  * MapLibre removes its DOM and workers, but WebKit can retain the detached
@@ -387,7 +711,13 @@ function mapStyles(interactive: boolean) {
       display: none !important;
     }
 
-    .freed-map-shell .maplibregl-popup-content {
+    .freed-map-popup {
+      z-index: 70;
+      max-width: min(${MAP_POPUP_MAX_WIDTH}px, calc(100vw - ${MAP_POPUP_VIEWPORT_MARGIN}px));
+      pointer-events: none;
+    }
+
+    .freed-map-popup .maplibregl-popup-content {
       width: min(${MAP_POPUP_MAX_WIDTH}px, calc(100vw - ${MAP_POPUP_VIEWPORT_MARGIN}px));
       min-width: min(420px, calc(100vw - ${MAP_POPUP_VIEWPORT_MARGIN}px));
       max-width: none;
@@ -401,14 +731,39 @@ function mapStyles(interactive: boolean) {
         0 0 0 1px var(--theme-border-subtle);
       backdrop-filter: blur(18px);
       overflow: hidden;
+      pointer-events: auto;
     }
 
-    .freed-map-shell .maplibregl-popup {
-      max-width: min(${MAP_POPUP_MAX_WIDTH}px, calc(100vw - ${MAP_POPUP_VIEWPORT_MARGIN}px)) !important;
+    .freed-map-popup-arrow {
+      position: absolute;
+      z-index: 0;
+      width: 10px;
+      height: 10px;
+      box-sizing: border-box;
+      background: color-mix(in oklab, var(--theme-bg-elevated) 96%, transparent);
+      border: 1px solid var(--theme-border-strong);
+      transform: rotate(45deg);
+      pointer-events: none;
     }
 
-    .freed-map-shell .maplibregl-popup-tip {
-      display: none !important;
+    .freed-map-popup[data-placement="top"] .freed-map-popup-arrow {
+      border-top: 0;
+      border-left: 0;
+    }
+
+    .freed-map-popup[data-placement="bottom"] .freed-map-popup-arrow {
+      border-right: 0;
+      border-bottom: 0;
+    }
+
+    .freed-map-popup[data-placement="right"] .freed-map-popup-arrow {
+      border-top: 0;
+      border-right: 0;
+    }
+
+    .freed-map-popup[data-placement="left"] .freed-map-popup-arrow {
+      border-left: 0;
+      border-bottom: 0;
     }
 
     .freed-map-shell .freed-map-marker {
@@ -454,7 +809,13 @@ function mapStyles(interactive: boolean) {
       display: none;
     }
 
-    .freed-map-shell .freed-map-marker:hover .freed-map-marker-body {
+    .freed-map-shell .freed-map-marker:hover,
+    .freed-map-shell .freed-map-marker[data-map-marker-open="true"] {
+      z-index: 1;
+    }
+
+    .freed-map-shell .freed-map-marker:hover .freed-map-marker-body,
+    .freed-map-shell .freed-map-marker[data-map-marker-open="true"] .freed-map-marker-body {
       scale: 1.06;
       filter: brightness(1.06);
       box-shadow:
@@ -502,15 +863,63 @@ export function getRenderedMapMarkers(
   markers: LocationMarkerSummary[],
   focusedMarkerKey?: string | null,
 ): LocationMarkerSummary[] {
-  const baseRenderedMarkers = markers.length <= MAP_DOM_MARKER_LIMIT
-    ? markers
-    : markers.slice(0, MAP_DOM_MARKER_LIMIT);
-  if (markers.length <= MAP_DOM_MARKER_LIMIT) return baseRenderedMarkers;
+  const coincidentGroups = new Map<
+    string,
+    {
+      newest: LocationMarkerSummary;
+      focused: LocationMarkerSummary | null;
+      updateCount: number;
+      markerCount: number;
+    }
+  >();
+
+  for (const marker of markers) {
+    const coordinateKey = `${marker.lat}:${marker.lng}`;
+    const group = coincidentGroups.get(coordinateKey);
+
+    if (!group) {
+      coincidentGroups.set(coordinateKey, {
+        newest: marker,
+        focused: marker.key === focusedMarkerKey ? marker : null,
+        updateCount: marker.groupCount,
+        markerCount: 1,
+      });
+      continue;
+    }
+
+    if (marker.seenAt > group.newest.seenAt) {
+      group.newest = marker;
+    }
+    if (marker.key === focusedMarkerKey) {
+      group.focused = marker;
+    }
+    group.updateCount += marker.groupCount;
+    group.markerCount += 1;
+  }
+
+  const distinctLocationMarkers = Array.from(coincidentGroups.values(), (group) => {
+    const representative = group.focused ?? group.newest;
+    if (group.markerCount === 1) return representative;
+
+    // City-level geocoding often gives many people the same exact coordinate.
+    // Paint that location once instead of stacking dozens of translucent marker
+    // shadows into concentric rings. The badge remains truthful by reporting the
+    // total number of updates represented at this spot.
+    return {
+      ...representative,
+      groupCount: group.updateCount,
+    };
+  });
+
+  const baseRenderedMarkers = distinctLocationMarkers.length <= MAP_DOM_MARKER_LIMIT
+    ? distinctLocationMarkers
+    : distinctLocationMarkers.slice(0, MAP_DOM_MARKER_LIMIT);
+  if (distinctLocationMarkers.length <= MAP_DOM_MARKER_LIMIT) return baseRenderedMarkers;
   if (!focusedMarkerKey || baseRenderedMarkers.some((marker) => marker.key === focusedMarkerKey)) {
     return baseRenderedMarkers;
   }
 
-  const focusedMarker = markers.find((marker) => marker.key === focusedMarkerKey);
+  const focusedMarker = distinctLocationMarkers.find((marker) => marker.key === focusedMarkerKey);
   if (!focusedMarker) return baseRenderedMarkers;
   return [...baseRenderedMarkers.slice(0, MAP_DOM_MARKER_LIMIT - 1), focusedMarker];
 }
@@ -708,6 +1117,7 @@ export function MapSurface({
   onOpenPost,
   emptyTitle = "No geo-tagged posts yet.",
   emptyBody = "Posts with location data will show up here.",
+  showFitAllControl = false,
 }: MapSurfaceProps) {
   const resolvedThemeId = themeId ?? DEFAULT_THEME_ID;
   const containerRef = useRef<HTMLDivElement>(null);
@@ -718,14 +1128,24 @@ export function MapSurface({
   const fallbackMovingTimeoutRef = useRef<number | null>(null);
   const nativeMarkerRestoreTimeoutRef = useRef<number | null>(null);
   const mapLifecycleRef = useRef(0);
+  const mapStyleRequestRef = useRef(0);
+  const desiredMapThemeRef = useRef(resolvedThemeId);
+  const appliedMapThemeRef = useRef<ThemeId | null>(null);
   const useDenseMarkersRef = useRef(false);
   const [mapReady, setMapReady] = useState(false);
+  const [mapGeneration, setMapGeneration] = useState(0);
   const [loadFailed, setLoadFailed] = useState(false);
   const [fallbackMoving, setFallbackMoving] = useState(false);
   const [surfaceSize, setSurfaceSize] = useState<MapSurfaceSize>({ width: 900, height: 560 });
   const [selectedFallbackMarkerKey, setSelectedFallbackMarkerKey] = useState<string | null>(null);
   const activePopupRef = useRef<PopupInstance | null>(null);
   const activePopupKeyRef = useRef<string | null>(null);
+  const activePopupMarkerElementRef = useRef<HTMLElement | null>(null);
+  const activePopupLayoutCleanupRef = useRef<(() => void) | null>(null);
+  const fallbackPopupRef = useRef<HTMLDivElement | null>(null);
+  const viewportInsetsRef = useRef(viewportInsets);
+  viewportInsetsRef.current = viewportInsets;
+  desiredMapThemeRef.current = resolvedThemeId;
   const actionHandlersRef = useRef({
     onOpenFriend,
     onPromoteAccount,
@@ -764,10 +1184,31 @@ export function MapSurface({
     });
   }, [fallbackMoving, focusedMarkerKey, renderedMarkers, showFallback, useDenseMarkers]);
   const closeActivePopup = useCallback(() => {
+    activePopupLayoutCleanupRef.current?.();
+    activePopupLayoutCleanupRef.current = null;
     activePopupRef.current?.remove();
     activePopupRef.current = null;
     activePopupKeyRef.current = null;
+    activePopupMarkerElementRef.current?.removeAttribute("data-map-marker-open");
+    activePopupMarkerElementRef.current = null;
   }, []);
+
+  useEffect(() => {
+    const panel = fallbackPopupRef.current;
+    const shell = shellRef.current;
+    if (!panel || !shell || !selectedFallbackMarker) return;
+    const anchor = shell.querySelector<HTMLElement>(
+      `[data-map-marker-key="${CSS.escape(selectedFallbackMarker.key)}"]`,
+    );
+    if (!anchor) return;
+
+    return setupMapFloatingPanelLayout({
+      panel,
+      anchor,
+      shell,
+      getViewportInsets: () => viewportInsetsRef.current,
+    });
+  }, [selectedFallbackMarker, viewportInsets]);
   const clearFallbackMovingTimeout = useCallback(() => {
     if (fallbackMovingTimeoutRef.current === null || typeof window === "undefined") return;
     window.clearTimeout(fallbackMovingTimeoutRef.current);
@@ -801,6 +1242,38 @@ export function MapSurface({
       record.marker.remove();
       record.attached = false;
     }
+  }, []);
+  const applyMapThemeStyle = useCallback((nextThemeId: ThemeId) => {
+    const map = mapRef.current;
+    if (!map || appliedMapThemeRef.current === nextThemeId) return;
+
+    const requestId = mapStyleRequestRef.current + 1;
+    mapStyleRequestRef.current = requestId;
+    void buildThemedMapStyle(nextThemeId).then((mapStyle) => {
+      if (
+        mapStyleRequestRef.current !== requestId
+        || mapRef.current !== map
+        || desiredMapThemeRef.current !== nextThemeId
+      ) return;
+
+      try {
+        // Replacing the style preserves the live MapLibre camera and canvas.
+        // Recreating the map here made transient theme hovers reset and refit
+        // the camera, while also churning a WebGL context for a palette change.
+        map.setStyle(mapStyle);
+        appliedMapThemeRef.current = nextThemeId;
+      } catch (error) {
+        console.error("[MapSurface] Failed to apply the themed map style", error);
+      }
+    }).catch((error) => {
+      if (
+        mapStyleRequestRef.current === requestId
+        && mapRef.current === map
+        && desiredMapThemeRef.current === nextThemeId
+      ) {
+        console.error("[MapSurface] Failed to load the themed map style", error);
+      }
+    });
   }, []);
   const setShellMoving = useCallback((moving: boolean) => {
     const shell = shellRef.current;
@@ -902,9 +1375,10 @@ export function MapSurface({
       };
     }
 
+    const initialThemeId = desiredMapThemeRef.current;
     void Promise.all([
       loadMapLibre(),
-      buildThemedMapStyle(resolvedThemeId),
+      buildThemedMapStyle(initialThemeId),
     ]).then(([module, mapStyle]) => {
       if (cancelled || !containerRef.current) return;
 
@@ -927,6 +1401,7 @@ export function MapSurface({
           attributionControl: false,
         });
         mapRef.current = map;
+        appliedMapThemeRef.current = initialThemeId;
         const setMoving = () => {
           clearNativeMarkerRestoreTimeout();
           syncNativeMarkerMotionLayer(true);
@@ -944,8 +1419,12 @@ export function MapSurface({
         map.on("zoomstart", setMoving);
         map.on("moveend", clearMoving);
         map.on("zoomend", clearMoving);
+        setMapGeneration(lifecycleId);
         setMapReady(true);
         setTimeout(() => map.resize(), 0);
+        if (desiredMapThemeRef.current !== initialThemeId) {
+          applyMapThemeStyle(desiredMapThemeRef.current);
+        }
       } catch (error) {
         console.error("[MapSurface] Failed to initialize MapLibre", error);
         if (mapRef.current) disposeMapInstance(mapRef.current);
@@ -960,6 +1439,8 @@ export function MapSurface({
     return () => {
       cancelled = true;
       mapLifecycleRef.current += 1;
+      mapStyleRequestRef.current += 1;
+      appliedMapThemeRef.current = null;
       closeActivePopup();
       clearNativeMarkerRestoreTimeout();
       for (const { marker } of markersRef.current) marker.remove();
@@ -968,10 +1449,19 @@ export function MapSurface({
       mapRef.current = null;
       setShellMoving(false);
     };
-  }, [clearNativeMarkerRestoreTimeout, closeActivePopup, interactive, resolvedThemeId, setShellMoving, syncNativeMarkerMotionLayer]);
+  }, [applyMapThemeStyle, clearNativeMarkerRestoreTimeout, closeActivePopup, interactive, setShellMoving, syncNativeMarkerMotionLayer]);
 
   useEffect(() => {
-    if (!mapReady || !mapRef.current || !mapModuleRef.current) return;
+    applyMapThemeStyle(resolvedThemeId);
+  }, [applyMapThemeStyle, resolvedThemeId]);
+
+  useEffect(() => {
+    if (
+      !mapReady
+      || !mapRef.current
+      || !mapModuleRef.current
+      || mapGeneration !== mapLifecycleRef.current
+    ) return;
 
     closeActivePopup();
     clearNativeMarkerRestoreTimeout();
@@ -1014,32 +1504,42 @@ export function MapSurface({
           }
           closeActivePopup();
           const currentHandlers = actionHandlersRef.current;
-          const popup = new maplibre.Popup({
-            closeButton: false,
-            closeOnClick: false,
-            offset: 12,
-            maxWidth: `${MAP_POPUP_MAX_WIDTH}px`,
-            className: "freed-map-popup",
-          })
-            .setLngLat([markerData.lng, markerData.lat])
-            .setDOMContent(buildPopupContent(
-              markerData,
-              currentHandlers.onOpenFriend
-                ? (marker) => actionHandlersRef.current.onOpenFriend?.(marker)
-                : undefined,
-              currentHandlers.onPromoteAccount
-                ? (marker) => actionHandlersRef.current.onPromoteAccount?.(marker)
-                : undefined,
-              currentHandlers.onLinkAccount
-                ? (marker) => actionHandlersRef.current.onLinkAccount?.(marker)
-                : undefined,
-              currentHandlers.onOpenPost
-                ? (marker) => actionHandlersRef.current.onOpenPost?.(marker)
-                : undefined,
-            ));
-          popup.addTo(map);
-          activePopupRef.current = popup;
+          const popupElement = document.createElement("div");
+          popupElement.className = "freed-map-popup";
+          popupElement.dataset.mapFloatingPanel = "popup";
+          popupElement.setAttribute("data-testid", "map-floating-panel");
+          const popupContent = buildPopupContent(
+            markerData,
+            currentHandlers.onOpenFriend
+              ? (marker) => actionHandlersRef.current.onOpenFriend?.(marker)
+              : undefined,
+            currentHandlers.onPromoteAccount
+              ? (marker) => actionHandlersRef.current.onPromoteAccount?.(marker)
+              : undefined,
+            currentHandlers.onLinkAccount
+              ? (marker) => actionHandlersRef.current.onLinkAccount?.(marker)
+              : undefined,
+            currentHandlers.onOpenPost
+              ? (marker) => actionHandlersRef.current.onOpenPost?.(marker)
+              : undefined,
+          );
+          popupContent.classList.add("maplibregl-popup-content");
+          const popupArrow = document.createElement("span");
+          popupArrow.className = "freed-map-popup-arrow";
+          popupArrow.dataset.mapPopupArrow = "true";
+          popupElement.append(popupContent, popupArrow);
+          document.body.appendChild(popupElement);
+          activePopupLayoutCleanupRef.current = setupMapFloatingPanelLayout({
+            panel: popupElement,
+            anchor: element,
+            shell: shellRef.current ?? map.getContainer(),
+            map,
+            getViewportInsets: () => viewportInsetsRef.current,
+          });
+          activePopupRef.current = popupElement;
           activePopupKeyRef.current = markerData.key;
+          activePopupMarkerElementRef.current = element;
+          element.dataset.mapMarkerOpen = "true";
         });
       }
 
@@ -1072,6 +1572,7 @@ export function MapSurface({
     closeActivePopup,
     focusedMarkerKey,
     interactive,
+    mapGeneration,
     mapReady,
     renderedMarkers,
     setShellMoving,
@@ -1080,9 +1581,20 @@ export function MapSurface({
   ]);
 
   useEffect(() => {
-    if (!mapReady || !mapRef.current) return;
+    if (
+      !mapReady
+      || !mapRef.current
+      || mapGeneration !== mapLifecycleRef.current
+    ) return;
     fitMapToMarkers(mapRef.current, stableMarkers, focusedMarkerKey, viewportInsets);
-  }, [focusedMarkerKey, mapReady, stableMarkers, viewportInsets]);
+  }, [focusedMarkerKey, mapGeneration, mapReady, stableMarkers, viewportInsets]);
+
+  const handleFitAll = useCallback(() => {
+    closeActivePopup();
+    setSelectedFallbackMarkerKey(null);
+    if (!mapReady || loadFailed || !mapRef.current) return;
+    fitMapToMarkers(mapRef.current, stableMarkers, null, viewportInsets);
+  }, [closeActivePopup, loadFailed, mapReady, stableMarkers, viewportInsets]);
 
   return (
     <div
@@ -1100,6 +1612,27 @@ export function MapSurface({
       onPointerMove={showFallback ? handleFallbackPointerMove : undefined}
     >
       <style>{mapStyles(interactive)}</style>
+      {showFitAllControl && (
+        <div
+          data-testid="map-fit-all-control"
+          data-map-floating-control="fit-all"
+          data-map-floating-control-edge="top"
+          className="pointer-events-none absolute z-20"
+          style={{
+            top: "max(var(--freed-canvas-viewport-inset-top, 0px), var(--feed-card-gap, 8px))",
+            right: "max(var(--freed-canvas-viewport-inset-right, 0px), var(--feed-card-gap, 8px))",
+          }}
+        >
+          <button
+            type="button"
+            className={`${CANVAS_CONTROL_BUTTON_CLASS} pointer-events-auto`}
+            disabled={stableMarkers.length === 0}
+            onClick={handleFitAll}
+          >
+            Fit all
+          </button>
+        </div>
+      )}
       <div className="absolute inset-0 overflow-hidden">
         <div
           ref={containerRef}
@@ -1153,6 +1686,7 @@ export function MapSurface({
               <button
                 key={marker.key}
                 type="button"
+                data-map-marker-key={marker.key}
                 data-map-moving-priority={getMapMovingPriority(
                   renderedMarkerIndex,
                   marker.key,
@@ -1176,12 +1710,10 @@ export function MapSurface({
 
           {interactive && selectedFallbackMarker && (
             <div
+              ref={fallbackPopupRef}
               data-testid="map-fallback-popup"
-              className="theme-dialog-shell absolute bottom-4 p-5"
-              style={{
-                left: "calc(var(--freed-canvas-viewport-inset-left, 0px) + 1rem)",
-                width: "min(560px, calc(100% - var(--freed-canvas-viewport-inset-left, 0px) - var(--freed-canvas-viewport-inset-right, 0px) - 2rem))",
-              }}
+              data-map-floating-panel="popup"
+              className="freed-map-popup theme-dialog-shell fixed p-5"
             >
               <div className="flex items-start justify-between gap-3">
                 <div className="min-w-0">
@@ -1277,6 +1809,10 @@ export function MapSurface({
                   </button>
                 )}
               </div>
+              <span
+                className="freed-map-popup-arrow"
+                data-map-popup-arrow="true"
+              />
             </div>
           )}
           </div>

--- a/packages/ui/src/components/map/MapView.tsx
+++ b/packages/ui/src/components/map/MapView.tsx
@@ -321,6 +321,8 @@ export function MapView({ viewportInsets }: MapViewProps) {
         <div
           className="pointer-events-auto theme-floating-panel w-[min(32rem,100%)] px-2 py-2"
           data-testid="map-time-range-slider"
+          data-map-floating-control="timeline"
+          data-map-floating-control-edge="bottom"
         >
           <div className="flex items-center justify-end text-[10px] font-medium text-[color:var(--theme-text-muted)]">
             <div className="flex flex-wrap items-center justify-end gap-1 text-right">
@@ -402,6 +404,7 @@ export function MapView({ viewportInsets }: MapViewProps) {
         focusedMarkerKey={focusedMarker?.key ?? null}
         themeId={themeId}
         viewportInsets={viewportInsets}
+        showFitAllControl
         onOpenFriend={(marker) => {
           openFriendFromMap(marker, {
             setActiveView,

--- a/packages/ui/src/components/map/MarkerElement.test.ts
+++ b/packages/ui/src/components/map/MarkerElement.test.ts
@@ -102,16 +102,17 @@ describe("createMarkerElement", () => {
     expect(element.querySelector("[data-avatar-fallback]")?.textContent).toBe("L");
   });
 
-  it("labels decorative marker layers so map movement can suppress paint-heavy chrome", () => {
+  it("keeps hover-scaled marker paint unclipped while labeling decorative layers", () => {
     const element = createMarkerElement(marker({ groupCount: 1234 }), palette);
 
     expect(element.querySelector(".freed-map-marker-body")).toBeInstanceOf(HTMLDivElement);
-    expect(element.style.contain).toBe("layout paint style");
+    expect(element.style.contain).toBe("layout style");
     expect(element.querySelector(".freed-map-marker-glow")).toBeInstanceOf(HTMLDivElement);
     expect(element.querySelector(".freed-map-marker-image")).toBeInstanceOf(HTMLImageElement);
     expect(element.querySelector(".freed-map-marker-tint")).toBeInstanceOf(HTMLDivElement);
     expect(element.querySelector(".freed-map-marker-halo")).toBeInstanceOf(HTMLDivElement);
     expect(element.querySelector(".freed-map-marker-badge")).toBeInstanceOf(HTMLDivElement);
+    expect(element.querySelector(".freed-map-marker-badge")?.parentElement).toBe(element);
   });
 
   it("can simplify dense marker chrome", () => {

--- a/packages/ui/src/components/map/MarkerElement.ts
+++ b/packages/ui/src/components/map/MarkerElement.ts
@@ -73,7 +73,8 @@ export function createMarkerElement(
   }
   el.style.cssText = [
     "position:absolute",
-    "contain:layout paint style",
+    // Paint containment clips the body's hover scale to this wrapper's original square bounds.
+    "contain:layout style",
     "transform-origin:center center",
   ].join(";");
 
@@ -185,7 +186,9 @@ export function createMarkerElement(
       `border:1px solid ${avatarPalette.borderSoft}`,
       "box-shadow:var(--theme-marker-badge-shadow)",
     ].join(";");
-    body.appendChild(badge);
+    // Keep the count outside the circular image crop. Appending it to `body`
+    // makes the badge exist in the DOM while `overflow:hidden` erases it.
+    el.appendChild(badge);
   }
 
   return el;


### PR DESCRIPTION
(AI Generated).

## Summary
- Keep Map cards clear of floating controls with marker-anchored placement and honest tails.
- Add Fit all, preserve camera and markers across theme previews, and coalesce coincident locations.
- Keep the local preview identity capsule on one line with ellipsis truncation.

## Testing
- npm run validate:feature: typecheck, build, PWA unit and performance tests, Desktop unit tests, smoke tests, and map performance passed; one unrelated Settings sample missed by 3.3 ms, then its isolated rerun passed at 59.3 ms.
- Roadmap status validation, diff hygiene, and a rendered 1,372 by 420 local preview check passed.