### PR TITLE
fix: restore SQLite Google Drive sync

### DIFF
--- a/packages/desktop/src/App.tsx
+++ b/packages/desktop/src/App.tsx
@@ -45,6 +45,7 @@ import { open as shellOpen } from "@tauri-apps/plugin-shell";
 import {
   stopSync,
   restartCloudSync,
+  startAllCloudSyncs,
   stopAllCloudSyncs,
   getActiveProviders,
   getValidCloudToken,
@@ -585,6 +586,16 @@ function App() {
     if (!legalAccepted || lockedStartupState !== "ready") return;
     initialize();
   }, [initialize, legalAccepted, lockedStartupState]);
+
+  useEffect(() => {
+    if (!legalAccepted || !isInitialized || !tauriRuntimeAvailable) return;
+    void startAllCloudSyncs().catch((error) => {
+      log.warn(
+        `[cloud] Failed to resume configured sync: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    });
+    return () => stopAllCloudSyncs();
+  }, [isInitialized, legalAccepted, tauriRuntimeAvailable]);
 
   useEffect(() => {
     if (!legalAccepted || !isInitialized) return;

--- a/packages/desktop/src/components/MobileSyncTab.tsx
+++ b/packages/desktop/src/components/MobileSyncTab.tsx
@@ -80,7 +80,12 @@ export function MobileSyncTab() {
   const [transferringWriter, setTransferringWriter] = useState(false);
   const [manualError, setManualError] = useState<string | null>(null);
   const driveState = cloudProviders?.gdrive ?? null;
-  const connected = providers.gdrive.status === "connected";
+  const driveCardState = driveState === null
+    ? providers.gdrive
+    : driveState.status === "error"
+      ? { status: "error" as const, error: driveState.error ?? "Cloud sync failed." }
+      : { status: driveState.status };
+  const connected = driveCardState.status === "connected";
   const diagnosticError = driveState?.error ?? manualError;
 
   useEffect(() => {
@@ -154,7 +159,7 @@ export function MobileSyncTab() {
 
           <CloudProviderCard
             provider="gdrive"
-            state={providers.gdrive}
+            state={driveCardState}
             onConnect={connect}
             onCancelConnect={setCancelProvider}
             onDisconnect={disconnect}

--- a/packages/desktop/src/hooks/useCloudProviders.test.tsx
+++ b/packages/desktop/src/hooks/useCloudProviders.test.tsx
@@ -106,7 +106,7 @@ describe("useCloudProviders", () => {
     expect(mocks.startCloudSync).not.toHaveBeenCalled();
   });
 
-  it("does not clear existing cloud sync errors when a provider is connected", async () => {
+  it("does not call a stored token connected before startup reconciliation", async () => {
     mocks.getCloudToken.mockImplementation((provider: string) =>
       provider === "gdrive" ? "test-access-token" : null,
     );
@@ -115,13 +115,8 @@ describe("useCloudProviders", () => {
       root.render(<Harness />);
     });
 
-    expect(container.querySelector("[data-testid='gdrive-status']")?.textContent).toBe("connected");
-    expect(mocks.updateCloudProvider).toHaveBeenCalledWith("gdrive", { status: "connected" });
-    const gdriveCall = mocks.updateCloudProvider.mock.calls.find(
-      ([provider]) => provider === "gdrive",
-    );
-    expect(gdriveCall?.[1]).toEqual({ status: "connected" });
-    expect(Object.hasOwn(gdriveCall?.[1] ?? {}, "error")).toBe(false);
+    expect(container.querySelector("[data-testid='gdrive-status']")?.textContent).toBe("connecting");
+    expect(mocks.updateCloudProvider).not.toHaveBeenCalled();
   });
 
   it("stays connecting until the initial cloud reconciliation completes", async () => {

--- a/packages/desktop/src/hooks/useCloudProviders.ts
+++ b/packages/desktop/src/hooks/useCloudProviders.ts
@@ -28,8 +28,8 @@ export type { ProviderState, CloudProviderStatus };
 
 function initialStatus(): CloudProviderStatus {
   return {
-    gdrive: { status: getCloudToken("gdrive") ? "connected" : "idle" },
-    dropbox: { status: getCloudToken("dropbox") ? "connected" : "idle" },
+    gdrive: { status: getCloudToken("gdrive") ? "connecting" : "idle" },
+    dropbox: { status: getCloudToken("dropbox") ? "connecting" : "idle" },
   };
 }
 
@@ -40,6 +40,9 @@ export function useCloudProviders() {
   const setProvider = useCallback(
     (provider: CloudProvider, state: ProviderState) => {
       setProviders((prev) => ({ ...prev, [provider]: state }));
+      updateCloudProvider(provider, state.status === "error"
+        ? { status: state.status, error: state.error }
+        : { status: state.status });
     },
     [],
   );
@@ -126,16 +129,6 @@ export function useCloudProviders() {
       connectAbortControllers.current = {};
     };
   }, []);
-
-  // Keep the debug panel's cloud sync section in sync with live provider state.
-  useEffect(() => {
-    (["gdrive", "dropbox"] as const).forEach((provider) => {
-      const providerState = providers[provider];
-      updateCloudProvider(provider, providerState.status === "error"
-        ? { status: providerState.status, error: providerState.error }
-        : { status: providerState.status });
-    });
-  }, [providers]);
 
   const anyConnected =
     providers.gdrive.status === "connected" ||

--- a/packages/desktop/src/lib/cloud-oauth.test.ts
+++ b/packages/desktop/src/lib/cloud-oauth.test.ts
@@ -5,6 +5,10 @@ const shellOpenMock = vi.fn();
 let oauthListener: ((event: { payload: { code: string; state: string } }) => void) | null = null;
 let unlistenMock = vi.fn();
 
+function nativeBody(value: string): string {
+  return btoa(value);
+}
+
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: invokeMock,
 }));
@@ -79,11 +83,11 @@ describe("desktop Google OAuth", () => {
         return {
           status: 200,
           headers: [["content-type", "application/json"]],
-          body: Array.from(new TextEncoder().encode(JSON.stringify({
+          bodyB64: nativeBody(JSON.stringify({
             access_token: "access-token",
             refresh_token: "refresh-token",
             expires_in: 3600,
-          }))),
+          })),
         };
       }
       return null;
@@ -264,10 +268,10 @@ describe("desktop Google OAuth", () => {
         return {
           status: 200,
           headers: [["content-type", "application/json"]],
-          body: Array.from(new TextEncoder().encode(JSON.stringify({
+          bodyB64: nativeBody(JSON.stringify({
             access_token: "refreshed-access-token",
             expires_in: 3600,
-          }))),
+          })),
         };
       }
       return null;
@@ -303,10 +307,10 @@ describe("desktop Google OAuth", () => {
         return {
           status: 200,
           headers: [["content-type", "application/json"]],
-          body: Array.from(new TextEncoder().encode(JSON.stringify({
+          bodyB64: nativeBody(JSON.stringify({
             access_token: "shared-refreshed-access-token",
             expires_in: 3600,
-          }))),
+          })),
         };
       }
       return null;
@@ -343,10 +347,10 @@ describe("desktop Google OAuth", () => {
         return {
           status: 200,
           headers: [["content-type", "application/json"]],
-          body: Array.from(new TextEncoder().encode(JSON.stringify({
+          bodyB64: nativeBody(JSON.stringify({
             access_token: "forced-refreshed-access-token",
             expires_in: 3600,
-          }))),
+          })),
         };
       }
       return null;
@@ -431,9 +435,9 @@ describe("desktop Google OAuth", () => {
         return {
           status: 200,
           headers: [["content-type", "application/json"]],
-          body: Array.from(new TextEncoder().encode(JSON.stringify({
+          bodyB64: nativeBody(JSON.stringify({
             access_token: "fallback-expiring-access-token",
-          }))),
+          })),
         };
       }
       return null;
@@ -485,11 +489,11 @@ describe("desktop Google OAuth", () => {
         return {
           status: 400,
           headers: [["content-type", "application/json"]],
-          body: Array.from(new TextEncoder().encode(JSON.stringify({
+          bodyB64: nativeBody(JSON.stringify({
             error: "invalid_scope",
             error_description:
               "Contacts API failed for access_token=oauth-secret user@example.com refresh_token=refresh-secret.",
-          }))),
+          })),
         };
       }
       return null;
@@ -521,9 +525,9 @@ describe("desktop Google OAuth", () => {
         return {
           status: 502,
           headers: [["content-type", "text/html"]],
-          body: Array.from(new TextEncoder().encode(
+          bodyB64: nativeBody(
             "<html>bad gateway access_token=oauth-secret user@example.com</html>",
-          )),
+          ),
         };
       }
       return null;
@@ -584,10 +588,10 @@ describe("desktop Google OAuth", () => {
         return {
           status,
           headers: [["content-type", "application/json"]],
-          body: Array.from(new TextEncoder().encode(JSON.stringify({
+          bodyB64: nativeBody(JSON.stringify({
             error: errorCode,
             error_description: "access_token=category-secret user@example.com",
-          }))),
+          })),
         };
       }
       return null;
@@ -616,10 +620,10 @@ describe("desktop Google OAuth", () => {
         return {
           status: 400,
           headers: [["content-type", "application/json"]],
-          body: Array.from(new TextEncoder().encode(JSON.stringify({
+          bodyB64: nativeBody(JSON.stringify({
             error: "invalid_request",
             error_description: "client_secret is missing.",
-          }))),
+          })),
         };
       }
       return null;

--- a/packages/desktop/src/lib/google-contacts-platform.test.ts
+++ b/packages/desktop/src/lib/google-contacts-platform.test.ts
@@ -15,13 +15,13 @@ describe("desktop Google Contacts platform fetch", () => {
     invokeMock.mockResolvedValueOnce({
       status: 200,
       headers: [["content-type", "application/json"]],
-      body: Array.from(new TextEncoder().encode(JSON.stringify({
+      bodyB64: btoa(JSON.stringify({
       connections: [{
         resourceName: "people/1",
         names: [{ displayName: "Test Contact" }],
       }],
       nextSyncToken: "sync-token",
-      }))),
+      })),
     });
 
     const { fetchGoogleContactsViaTauri } = await import("./google-contacts");
@@ -40,12 +40,12 @@ describe("desktop Google Contacts platform fetch", () => {
     invokeMock.mockResolvedValueOnce({
       status: 403,
       headers: [["content-type", "application/json"]],
-      body: Array.from(new TextEncoder().encode(JSON.stringify({
+      bodyB64: btoa(JSON.stringify({
         error: {
           message: "Request had insufficient authentication scopes.",
           errors: [{ reason: "ACCESS_TOKEN_SCOPE_INSUFFICIENT" }],
         },
-      }))),
+      })),
     });
 
     const { fetchGoogleContactsViaTauri } = await import("./google-contacts");

--- a/packages/desktop/src/lib/google-contacts.ts
+++ b/packages/desktop/src/lib/google-contacts.ts
@@ -4,17 +4,18 @@ import {
   type GoogleContactsConnectionsResponse,
   type GoogleContactsResult,
 } from "@freed/shared/google-contacts";
+import { base64ToBytes } from "./google-drive";
 
 const GOOGLE_CONTACTS_CONNECTIONS_URL = "https://people.googleapis.com/v1/people/me/connections";
 
 interface NativeGoogleApiResponse {
   status: number;
   headers: Array<[string, string]>;
-  body: number[];
+  bodyB64: string;
 }
 
-function decodeBody(body: number[]): string {
-  return new TextDecoder().decode(new Uint8Array(body));
+function decodeBody(bodyB64: string): string {
+  return new TextDecoder().decode(base64ToBytes(bodyB64));
 }
 
 function googleErrorMessage(prefix: string, status: number, body: string): string {
@@ -54,7 +55,7 @@ export async function fetchGoogleContactsViaTauri(
     const url = `${GOOGLE_CONTACTS_CONNECTIONS_URL}?${params.toString()}`;
     try {
       const response = await invoke<NativeGoogleApiResponse>("google_api_request", { url, accessToken: token });
-      const raw = decodeBody(response.body);
+      const raw = decodeBody(response.bodyB64);
       if (response.status < 200 || response.status >= 300) {
         throw Object.assign(
           new Error(googleErrorMessage("Google Contacts API failed", response.status, raw)),

--- a/packages/desktop/src/lib/sync.ts
+++ b/packages/desktop/src/lib/sync.ts
@@ -24,6 +24,7 @@ import {
   stopSqliteLibraryCloudSync,
 } from "./library-core-cloud-sync";
 import { reloadSqliteLibraryState } from "./library-client";
+import { base64ToBytes } from "./google-drive";
 import { safeUnlisten } from "./safe-unlisten";
 
 export type { CloudProvider };
@@ -76,7 +77,7 @@ interface TokenExchangeResponse {
 interface NativeGoogleOAuthResponse {
   readonly status: number;
   readonly headers: Array<[string, string]>;
-  readonly body: number[];
+  readonly bodyB64: string;
 }
 
 export type CloudConflictWinner = "local" | "cloud";
@@ -173,8 +174,8 @@ function tokenBundleFromResponse(
   };
 }
 
-function decodeNativeBody(body: number[]): string {
-  return new TextDecoder().decode(new Uint8Array(body));
+function decodeNativeBody(bodyB64: string): string {
+  return new TextDecoder().decode(base64ToBytes(bodyB64));
 }
 
 async function postGoogleTokenProxy(
@@ -188,7 +189,7 @@ async function postGoogleTokenProxy(
       contentType: "application/json",
     },
   );
-  const body = decodeNativeBody(response.body);
+  const body = decodeNativeBody(response.bodyB64);
   if (response.status < 200 || response.status >= 300) {
     let errorCode = "";
     let description = "";

--- a/packages/pwa/src/App.tsx
+++ b/packages/pwa/src/App.tsx
@@ -76,7 +76,7 @@ import {
 import { resetThemePreference } from "@freed/ui/lib/theme";
 import { hydrateReaderItemInPwa, pinReaderItemInPwa } from "./lib/reader-cache";
 import {
-  ensurePwaLibraryCoreFeaturePreviewState,
+  ensurePwaLibraryCoreLocalSampleState,
   openPwaLibraryCoreFeedReader,
   readPwaLibraryCoreItemDetail,
   scanPwaLibraryCoreItems,
@@ -232,7 +232,7 @@ function App() {
     if (sampleSummary.total > 0 && hasTimeWindowMapSamples) return;
 
     void (async () => {
-      await ensurePwaLibraryCoreFeaturePreviewState();
+      await ensurePwaLibraryCoreLocalSampleState();
       if (sampleSummary.total > 0 && !hasTimeWindowMapSamples) {
         await state.clearSampleData();
       }

--- a/packages/pwa/src/components/PwaSyncSettings.test.ts
+++ b/packages/pwa/src/components/PwaSyncSettings.test.ts
@@ -134,6 +134,38 @@ describe("PwaSyncSettings cloud diagnostics", () => {
     });
   });
 
+  it("shows a linked Google account with a failed Library sync as needing attention", () => {
+    useAppStore.setState({ syncConnected: false });
+    useDebugStore.setState({
+      cloudProviders: {
+        dropbox: { status: "idle" },
+        gdrive: {
+          status: "error",
+          stage: "download",
+          error: "No published SQLite Library was found in Google Drive",
+          statusMessage: "SQLite Library sync failed.",
+          pendingReason: "Fix the error, then use Sync now to retry.",
+          events: [],
+        },
+      },
+    });
+
+    const { container, root } = renderWithPlatform(createElement(PwaSyncSettings));
+    const text = container.textContent ?? "";
+
+    expect(text).toContain("Google Drive");
+    expect(text).toContain("Needs attention");
+    expect(text).toContain("No published SQLite Library was found in Google Drive");
+    expect(text).not.toContain("Choose a sync method below to get started.");
+    expect(
+      container.querySelector("[data-testid='pwa-cloud-sync-now-button']"),
+    ).toBeInstanceOf(HTMLButtonElement);
+
+    act(() => {
+      root.unmount();
+    });
+  });
+
   it("summarizes blocked merge errors in the provider card and shows details only in diagnostics", () => {
     const blockedMessage =
       "Freed blocked a sync merge because it would remove too much feed history. Source: PWA sync. Largest input: 11,238 items. Merged result: 0 items. Potential loss: 11,238 items (100%). Restore from a trusted snapshot or reconnect sync after confirming which copy should win.";

--- a/packages/pwa/src/components/PwaSyncSettings.tsx
+++ b/packages/pwa/src/components/PwaSyncSettings.tsx
@@ -27,14 +27,17 @@ import { useCloudSyncActivity } from "./cloudSyncActivity";
 
 type Provider = "gdrive" | "dropbox" | "local";
 
-function getProviderInfo(syncConnected: boolean): {
+function getProviderInfo(
+  syncConnected: boolean,
+  configuredProvider: ReturnType<typeof getCloudProvider>,
+): {
   label: string;
   provider: Provider | null;
 } {
-  if (!syncConnected) return { label: "Not connected", provider: null };
-  const provider = getCloudProvider();
+  const provider = configuredProvider;
   if (provider === "gdrive") return { label: "Google Drive", provider: "gdrive" };
   if (provider === "dropbox") return { label: "Dropbox", provider: "dropbox" };
+  if (!syncConnected) return { label: "Not connected", provider: null };
   return { label: "Local Desktop", provider: "local" };
 }
 
@@ -134,7 +137,11 @@ export function PwaSyncSettings() {
     return times.length > 0 ? Math.max(...times) : null;
   }, [feeds]);
 
-  const { label, provider } = getProviderInfo(syncConnected);
+  const configuredCloudProvider = getCloudProvider();
+  const { label, provider } = getProviderInfo(
+    syncConnected,
+    configuredCloudProvider,
+  );
   const cloudProviderState = provider === "gdrive" || provider === "dropbox"
     ? cloudProviders?.[provider]
     : null;
@@ -169,7 +176,7 @@ export function PwaSyncSettings() {
   }, [activeCloudProvider]);
 
   // Disconnected, show connect UI inline with no intermediate "Connect" button.
-  if (!syncConnected) {
+  if (!syncConnected && configuredCloudProvider === null) {
     return (
       <div className="flex flex-col flex-1">
         <div className="mb-8 overflow-hidden rounded-xl border border-[var(--theme-border-subtle)] bg-[var(--theme-bg-card)]">
@@ -221,11 +228,14 @@ export function PwaSyncSettings() {
   const statusText = providerError
     ? isMergeBlocked(providerError) ? "Merge blocked" : "Needs attention"
     : cloudActivity ? `${cloudActivity.shortLabel} ${cloudActivity.elapsedLabel}`
-    : isSyncing ? "Syncing now" : "Connected";
+    : isSyncing ? "Syncing now"
+    : syncConnected ? "Connected" : "Not synchronized";
   const dotColor = providerError
     ? "bg-[rgb(var(--theme-feedback-danger-rgb))]"
-    : isSyncing
+    : isSyncing || cloudActivity
       ? "bg-[var(--theme-accent-secondary)] animate-pulse"
+      : !syncConnected
+        ? "bg-[var(--theme-text-soft)]"
       : "bg-[rgb(var(--theme-feedback-success-rgb))]";
 
   return (
@@ -246,6 +256,11 @@ export function PwaSyncSettings() {
           {providerError && (
             <p className="theme-feedback-text-danger mt-2 break-words text-xs">
               {describeProviderError(providerError)}
+            </p>
+          )}
+          {!syncConnected && !providerError && (
+            <p className="mt-2 text-xs text-[var(--theme-text-muted)]">
+              Google Drive is linked, but this device has not completed a Library sync.
             </p>
           )}
         </div>

--- a/packages/pwa/src/lib/library-core-runtime.ts
+++ b/packages/pwa/src/lib/library-core-runtime.ts
@@ -230,8 +230,8 @@ export async function initializePwaLibraryCoreState(): Promise<LibraryState> {
   return state;
 }
 
-/** Establish the isolated signed Library used only by local feature previews. */
-export async function ensurePwaLibraryCoreFeaturePreviewState(): Promise<void> {
+/** Establish the isolated signed Library used by local sample-data previews. */
+export async function ensurePwaLibraryCoreLocalSampleState(): Promise<void> {
   await getPortableStore().bootstrapFeaturePreviewAuthority();
   const state = await readSelectedState();
   if (state) publishState(state);

--- a/packages/pwa/src/lib/pwa-updater.ts
+++ b/packages/pwa/src/lib/pwa-updater.ts
@@ -1,11 +1,10 @@
 /**
  * PWA update detection & application.
  *
- * vite-plugin-pwa's `prompt` mode parks new service workers in the `waiting`
- * state and fires `onNeedRefresh` so the user can choose when to reload.
- * This module bridges that signal to React components via pub/sub,
- * provides an imperative `checkForPwaUpdate()` for the Settings button,
- * and runs a background interval so long-running sessions are not skipped.
+ * Production workers activate immediately so a stale shell cannot keep
+ * requesting deleted hashed assets before React can show an update prompt.
+ * This module retains the manual check and status hooks for diagnostics and
+ * runs a background interval so long-running sessions still check promptly.
  */
 
 import { registerSW } from "virtual:pwa-register";

--- a/packages/pwa/src/lib/store.ts
+++ b/packages/pwa/src/lib/store.ts
@@ -92,7 +92,7 @@ import {
   enqueuePwaLibraryCoreReadAssignments,
   enqueuePwaLibraryCoreUnarchiveSavedItems,
   enqueuePwaLibraryCoreUserStateToggle,
-  ensurePwaLibraryCoreFeaturePreviewState,
+  ensurePwaLibraryCoreLocalSampleState,
   initializePwaLibraryCoreState,
   subscribePwaLibraryCoreState,
 } from "./library-core-runtime";
@@ -551,9 +551,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   },
 
   addSampleLibraryData: async (data: SampleLibraryData) => {
-    if (import.meta.env.DEV) {
-      await ensurePwaLibraryCoreFeaturePreviewState();
-    }
+    await ensurePwaLibraryCoreLocalSampleState();
     const persons = data.friends.map((friend) =>
       personFromLegacyFriend(friend as Friend),
     );

--- a/packages/pwa/src/lib/sync.test.ts
+++ b/packages/pwa/src/lib/sync.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  recordCloudProviderEvent: vi.fn(),
+  syncLibraryCore: vi.fn(),
+  updateCloudProvider: vi.fn(),
+}));
+
+vi.mock("@freed/ui/lib/debug-store", () => ({
+  recordCloudProviderEvent: mocks.recordCloudProviderEvent,
+  updateCloudProvider: mocks.updateCloudProvider,
+}));
+
+vi.mock("./library-core-runtime", () => ({
+  syncPwaLibraryCoreFromGoogleDrive: mocks.syncLibraryCore,
+}));
+
+import {
+  onStatusChange,
+  startCloudSync,
+  stopCloudSync,
+  syncCloudProviderNow,
+} from "./sync";
+
+describe("PWA Library Core sync lifecycle", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    localStorage.clear();
+    stopCloudSync();
+  });
+
+  afterEach(() => {
+    stopCloudSync();
+    vi.useRealTimers();
+  });
+
+  it("surfaces an initial failure and lets Sync now restore the live session", async () => {
+    const statuses: boolean[] = [];
+    const unsubscribe = onStatusChange((connected) => statuses.push(connected));
+    mocks.syncLibraryCore.mockRejectedValueOnce(
+      new Error("No published SQLite Library was found in Google Drive"),
+    );
+
+    await expect(startCloudSync("gdrive", "stored-token")).rejects.toThrow(
+      "No published SQLite Library was found in Google Drive",
+    );
+    expect(statuses.at(-1)).toBe(false);
+    expect(mocks.updateCloudProvider).toHaveBeenCalledWith(
+      "gdrive",
+      expect.objectContaining({
+        status: "error",
+        error: "No published SQLite Library was found in Google Drive",
+      }),
+    );
+
+    mocks.syncLibraryCore.mockResolvedValueOnce({});
+    await syncCloudProviderNow("gdrive");
+
+    expect(statuses.at(-1)).toBe(true);
+    expect(mocks.syncLibraryCore).toHaveBeenCalledTimes(2);
+    unsubscribe();
+  });
+});

--- a/packages/pwa/src/lib/sync.ts
+++ b/packages/pwa/src/lib/sync.ts
@@ -145,7 +145,26 @@ async function syncGoogleDriveOnce(
     statusMessage: "Refreshing the SQLite Library checkpoint.",
     error: undefined,
   });
-  await syncPwaLibraryCoreFromGoogleDrive({ accessToken, signal });
+  try {
+    await syncPwaLibraryCoreFromGoogleDrive({ accessToken, signal });
+  } catch (error) {
+    if (generation !== cloudGeneration || signal.aborted) throw error;
+    const message = error instanceof Error ? error.message : String(error);
+    updateCloudProvider("gdrive", {
+      status: "error",
+      stage: "download",
+      error: message,
+      lastErrorAt: Date.now(),
+      statusMessage: "SQLite Library sync failed.",
+      pendingReason: "Fix the error, then use Sync now to retry.",
+    });
+    recordCloudProviderEvent("gdrive", {
+      kind: "error",
+      stage: "download",
+      message,
+    });
+    throw error;
+  }
   if (generation !== cloudGeneration || signal.aborted) return;
   const now = Date.now();
   updateCloudProvider("gdrive", {
@@ -281,9 +300,11 @@ export async function startCloudSync(
   const generation = cloudGeneration;
   const controller = new AbortController();
   cloudAbort = controller;
-  setCloudConnected(true);
+  setCloudConnected(false);
   try {
     await syncGoogleDriveOnce(generation, controller.signal);
+    if (generation !== cloudGeneration || controller.signal.aborted) return;
+    setCloudConnected(true);
     scheduleRefresh(generation, controller.signal);
   } catch (error) {
     if (generation === cloudGeneration && !controller.signal.aborted) {
@@ -308,9 +329,15 @@ export async function syncCloudProviderNow(
   if (provider !== "gdrive") {
     throw new Error("The SQLite Library PWA currently requires Google Drive");
   }
-  const generation = cloudGeneration;
-  const controller = cloudAbort ?? new AbortController();
-  await syncGoogleDriveOnce(generation, controller.signal);
+  if (!cloudConnected || !cloudAbort || cloudAbort.signal.aborted) {
+    const token = await getValidCloudToken(provider);
+    if (!token) {
+      throw new Error("Reconnect Google Drive before retrying sync");
+    }
+    await startCloudSync(provider, token);
+    return;
+  }
+  await syncGoogleDriveOnce(cloudGeneration, cloudAbort.signal);
 }
 
 export function scheduleCloudUpload(

--- a/packages/pwa/src/main.tsx
+++ b/packages/pwa/src/main.tsx
@@ -21,7 +21,7 @@ if (import.meta.env.DEV) {
     const w = window as unknown as Record<string, unknown>
     w.__FREED_STORE__ = store.useAppStore
     const run = async (action: () => Promise<void>) => {
-      await libraryCore.ensurePwaLibraryCoreFeaturePreviewState()
+      await libraryCore.ensurePwaLibraryCoreLocalSampleState()
       await action()
     }
     w.__FREED_LIBRARY_CORE__ = {

--- a/packages/pwa/vite.config.ts
+++ b/packages/pwa/vite.config.ts
@@ -79,11 +79,10 @@ export default defineConfig({
     topLevelAwait(),
     react(),
     VitePWA({
-      // prompt: new service workers park in `waiting` and fire onNeedRefresh
-      // so the user sees a toast and chooses when to reload. The app checks
-      // periodically in the background (see pwa-updater.ts) so long-running
-      // sessions are not skipped.
-      registerType: "prompt",
+      // A stale app shell can reference hashed assets that no longer exist.
+      // Activate new workers immediately so an obsolete shell cannot strand
+      // the app before React is able to render an update prompt.
+      registerType: "autoUpdate",
       includeAssets: ["favicon.svg", "icons/*.png"],
       manifest: false,
       workbox: {
@@ -145,20 +144,6 @@ export default defineConfig({
             },
           },
           {
-            // Automerge WASM: cache-first, loaded once at startup.
-            // Not precached because automerge emits a duplicate web/ WASM
-            // via low_level.js that's never actually fetched at runtime.
-            urlPattern: /\.wasm$/i,
-            handler: "CacheFirst",
-            options: {
-              cacheName: "freed-wasm",
-              expiration: {
-                maxEntries: 5,
-                maxAgeSeconds: 60 * 60 * 24 * 365,
-              },
-            },
-          },
-          {
             // Catch-all for external resources (CDN, external APIs).
             // Same-origin fetches not matched above bypass the SW natively.
             urlPattern: /^https?:\/\/(?!freed-pwa)/,
@@ -175,6 +160,8 @@ export default defineConfig({
         ],
         globPatterns: ["**/*.{js,css,html,ico,png,svg}"],
         clientsClaim: true,
+        skipWaiting: true,
+        cleanupOutdatedCaches: true,
       },
       devOptions: {
         enabled: false,


### PR DESCRIPTION
(AI Generated).

## Summary
- Decode native Google OAuth and Contacts responses from the bounded bodyB64 contract.
- Resume configured Desktop Drive sync at startup and make Desktop and PWA connection status reflect live reconciliation.
- Make local PWA sample data work without cloud enrollment and activate new service workers before stale hashed assets can strand startup.

## Testing
- npm run validate:feature
- Production-mode PWA build populated 1,686 IndexedDB sample items without an enrolled cloud actor.
- Generated service worker calls skipWaiting, claims clients, cleans obsolete precaches, and contains no Automerge WASM cache route.

## Provider Review
- Status: Provider authority is validated for ready publication.
- Review action: none required. The provider-risk artifact records the behavior authority decision; this exact provider subdiff is the audit subject.
- Provider subdiff: `3e5ced6091f2d250c3824681d1ba6879a658e8aa`
- Publication does not authorize new live provider traffic. Gate 1 behavior approval still applies when observable behavior changes.
- Provider review task: `sqlite-google-drive-sync-recovery`
- Provider review decision: `behavior_approved`
- Provider review artifact: `48b646a324af229949c57cd7fbef80252ddfc7cfb34eef858e6ee9cc726f793e`
- Providers: facebook, instagram, linkedin, medium, other, substack, x, youtube
- Observable behavior: Freed Desktop resumes the existing Google Drive appDataFolder Library Core sync after startup when a stored Google connection exists. The repaired OAuth decoder accepts the successful native bodyB64 response. The PWA retries the same authorized Google Drive sync when the owner selects Sync now and resumes its existing refresh loop after success.
- Fingerprinting risk: Google can observe the existing OAuth exchange and Drive appDataFolder reconciliation that previously failed locally. Startup can now produce one reconciliation and immutable checkpoint publication where the broken build produced none. Request URLs, methods, scopes, headers, cookies, and sync cadence are unchanged. The shared Desktop startup shell is mechanically classified for Facebook, Instagram, LinkedIn, Medium, Substack, X, and YouTube, but this change neither starts nor alters any traffic to those providers.
- Lowest profile alternative: Require the owner to reconnect and manually retry sync after every launch. This keeps startup quieter only by leaving the approved sync feature broken and is not an acceptable product behavior.

Files bound into this provider review:
- `packages/desktop/src/App.tsx`
- `packages/desktop/src/components/MobileSyncTab.tsx`
- `packages/desktop/src/hooks/useCloudProviders.ts`
- `packages/desktop/src/lib/google-contacts.ts`
- `packages/desktop/src/lib/sync.ts`
- `packages/pwa/src/App.tsx`
- `packages/pwa/src/components/PwaSyncSettings.tsx`
- `packages/pwa/src/lib/store.ts`
- `packages/pwa/src/lib/sync.ts`