### PR TITLE
fix: stabilize PWA Google Drive sync

### DIFF
--- a/packages/pwa/src/components/OAuthCallback.tsx
+++ b/packages/pwa/src/components/OAuthCallback.tsx
@@ -195,7 +195,6 @@ export function OAuthCallback() {
 
       const exchange = provider === "gdrive" ? exchangeGDrive : exchangeDropbox;
       const lifecycle = captureCloudLifecycle();
-
       try {
         const result = await exchange(code, verifier);
         if (!result.ok) {
@@ -224,6 +223,7 @@ export function OAuthCallback() {
         startCloudSync(provider, result.token.accessToken).catch((err) => {
           console.error("[OAuthCallback] startCloudSync failed:", err);
         });
+        const redirectLifecycle = captureCloudLifecycle();
 
         if (cancelled) return;
 
@@ -234,7 +234,7 @@ export function OAuthCallback() {
           if (
             cancelled ||
             !runtimeLifecycle.isCurrent() ||
-            !lifecycle.isCurrent()
+            !redirectLifecycle.isCurrent()
           )
             return;
           window.location.replace("/");

--- a/packages/sync/src/cloud/library-core-google-drive-adapter.test.ts
+++ b/packages/sync/src/cloud/library-core-google-drive-adapter.test.ts
@@ -307,6 +307,25 @@ function adapter(fake: FakeGoogleDrive) {
 }
 
 describe("Google Drive Library Core immutable adapter", () => {
+  it("binds the browser fetch receiver when no fetch override is supplied", async () => {
+    const originalFetch = globalThis.fetch;
+    let receiver: unknown;
+    globalThis.fetch = function (this: unknown) {
+      receiver = this;
+      return Promise.resolve(Response.json({ files: [] }));
+    } as typeof fetch;
+
+    try {
+      await discoverGoogleDriveLibraryCoreControlV1({
+        accessToken: "test-token",
+        libraryId: "library-1",
+      });
+      expect(receiver).toBe(globalThis);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it("provisions one empty control and then reuses its exact file ID", async () => {
     const fake = new FakeGoogleDrive();
 

--- a/packages/sync/src/cloud/library-core-google-drive-adapter.ts
+++ b/packages/sync/src/cloud/library-core-google-drive-adapter.ts
@@ -49,6 +49,10 @@ const MAX_DRIVE_ERROR_BYTES = 4_096;
 
 export type GoogleDriveFetch = typeof fetch;
 
+function defaultGoogleDriveFetch(): GoogleDriveFetch {
+  return globalThis.fetch.bind(globalThis);
+}
+
 /**
  * Ordinary Library Core wire objects remain below 5 MB so Google Drive can
  * publish them in one multipart request. Large media uses a separate resumable
@@ -626,7 +630,7 @@ export async function discoverGoogleDriveLibraryCoreControlV1(input: {
     MAX_ACCESS_TOKEN_BYTES,
   );
   assertLibraryId(input.libraryId);
-  const googleFetch = input.googleFetch ?? fetch;
+  const googleFetch = input.googleFetch ?? defaultGoogleDriveFetch();
   const expectedProperties = controlAppProperties(
     await libraryIdentityDigest(input.libraryId),
   );
@@ -663,7 +667,7 @@ export async function discoverPublishedGoogleDriveLibraryCoreControlV1(input: {
     "Google Drive access token",
     MAX_ACCESS_TOKEN_BYTES,
   );
-  const googleFetch = input.googleFetch ?? fetch;
+  const googleFetch = input.googleFetch ?? defaultGoogleDriveFetch();
   const files = await listDriveFilesByProperties({
     accessToken: input.accessToken,
     properties: Object.freeze({
@@ -716,7 +720,7 @@ async function discoverGoogleDriveLibraryCoreActorObjectsV1(input: {
   if (!isLibraryCoreOperationInstanceId(input.epochId)) {
     throw new TypeError("epochId must be a bounded Library Core identifier");
   }
-  const googleFetch = input.googleFetch ?? fetch;
+  const googleFetch = input.googleFetch ?? defaultGoogleDriveFetch();
   const libraryDigest = await libraryIdentityDigest(input.libraryId);
   const files = await listDriveFilesByProperties({
     accessToken: input.accessToken,
@@ -826,7 +830,7 @@ export async function discoverGoogleDriveLibraryCoreIntentSegmentsV1(input: {
   assertLibraryId(input.libraryId);
   assertLibraryId(input.epochId);
   assertLibraryId(input.actorId);
-  const googleFetch = input.googleFetch ?? fetch;
+  const googleFetch = input.googleFetch ?? defaultGoogleDriveFetch();
   const libraryDigest = await libraryIdentityDigest(input.libraryId);
   const files = await listDriveFilesByProperties({
     accessToken: input.accessToken,
@@ -935,7 +939,7 @@ export async function discoverGoogleDriveLibraryCoreResultSegmentsV1(input: {
   assertLibraryId(input.libraryId);
   assertLibraryId(input.epochId);
   assertLibraryId(input.actorId);
-  const googleFetch = input.googleFetch ?? fetch;
+  const googleFetch = input.googleFetch ?? defaultGoogleDriveFetch();
   const libraryDigest = await libraryIdentityDigest(input.libraryId);
   const files = await listDriveFilesByProperties({
     accessToken: input.accessToken,
@@ -1025,7 +1029,7 @@ export async function provisionGoogleDriveLibraryCoreControlV1(input: {
     return Object.freeze({ ...existing, created: false });
   }
 
-  const googleFetch = input.googleFetch ?? fetch;
+  const googleFetch = input.googleFetch ?? defaultGoogleDriveFetch();
   const bytes = textEncoder.encode("{}");
   const boundary = `freed-control-${await libraryIdentityDigest(input.libraryId)}`;
   const response = await googleFetch(
@@ -1086,7 +1090,7 @@ export async function discoverGoogleDriveLibraryCoreIntentHeadV1(input: {
   assertLibraryId(input.libraryId);
   assertLibraryId(input.epochId);
   assertLibraryId(input.actorId);
-  const googleFetch = input.googleFetch ?? fetch;
+  const googleFetch = input.googleFetch ?? defaultGoogleDriveFetch();
   const expectedProperties = intentHeadAppProperties(
     await libraryIdentityDigest(input.libraryId),
     await libraryIdentityDigest(input.epochId),
@@ -1140,7 +1144,7 @@ export async function provisionGoogleDriveLibraryCoreIntentHeadV1(input: {
     return Object.freeze({ ...existing, created: false });
   }
 
-  const googleFetch = input.googleFetch ?? fetch;
+  const googleFetch = input.googleFetch ?? defaultGoogleDriveFetch();
   const bytes = encodeIntentHead(head);
   const actorDigest = await actorIdentityDigest(head.actor_id);
   const boundary = `freed-intent-head-${actorDigest.slice(0, 32)}`;
@@ -1206,7 +1210,7 @@ export function createGoogleDriveLibraryCoreIntentAdapterV1(
     "Google Drive intent-head file id",
     MAX_DRIVE_FILE_ID_BYTES,
   );
-  const googleFetch = options.googleFetch ?? fetch;
+  const googleFetch = options.googleFetch ?? defaultGoogleDriveFetch();
   const immutableAdapter = createGoogleDriveLibraryCoreAdapterV1(options);
   const expectedPropertiesPromise = Promise.all([
     libraryIdentityDigest(options.libraryId),
@@ -1332,7 +1336,7 @@ export async function discoverGoogleDriveLibraryCoreResultHeadV1(input: {
   const files = await listDriveFilesByProperties({
     accessToken: input.accessToken,
     properties: expectedProperties,
-    googleFetch: input.googleFetch ?? fetch,
+    googleFetch: input.googleFetch ?? defaultGoogleDriveFetch(),
     signal: input.signal,
     maxFiles: 1,
   });
@@ -1360,7 +1364,7 @@ export async function provisionGoogleDriveLibraryCoreResultHeadV1(input: {
   };
   const existing = await discoverGoogleDriveLibraryCoreResultHeadV1(discovery);
   if (existing) return Object.freeze({ ...existing, created: false });
-  const googleFetch = input.googleFetch ?? fetch;
+  const googleFetch = input.googleFetch ?? defaultGoogleDriveFetch();
   const actorDigest = await actorIdentityDigest(head.actor_id);
   const bytes = encodeResultHead(head);
   const boundary = `freed-result-head-${actorDigest.slice(0, 32)}`;
@@ -1399,7 +1403,7 @@ export function createGoogleDriveLibraryCoreResultAdapterV1(
   assertLibraryId(options.epochId);
   assertLibraryId(options.actorId);
   assertBoundedText(options.resultHeadFileId, "Google Drive result-head file id", MAX_DRIVE_FILE_ID_BYTES);
-  const googleFetch = options.googleFetch ?? fetch;
+  const googleFetch = options.googleFetch ?? defaultGoogleDriveFetch();
   const immutableAdapter = createGoogleDriveLibraryCoreAdapterV1(options);
   const expectedPropertiesPromise = Promise.all([
     libraryIdentityDigest(options.libraryId),
@@ -1488,7 +1492,7 @@ export function createGoogleDriveLibraryCoreAdapterV1(
     "Google Drive control file id",
     MAX_DRIVE_FILE_ID_BYTES,
   );
-  const googleFetch = options.googleFetch ?? fetch;
+  const googleFetch = options.googleFetch ?? defaultGoogleDriveFetch();
   const libraryDigestPromise = libraryIdentityDigest(options.libraryId);
 
   async function readDescriptorAtFile(


### PR DESCRIPTION
(AI Generated).

## Summary
- Bind browser fetch calls before Google Drive Library Core requests.
- Return from the OAuth callback after the sync lifecycle advances.

## Testing
- npm run validate:feature

## Provider Review
- Status: Provider authority is validated for ready publication.
- Review action: none required. The provider-risk artifact records the behavior authority decision; this exact provider subdiff is the audit subject.
- Provider subdiff: `16aa7ae1f24c711889b08b5622bb43e1ad249582`
- Publication does not authorize new live provider traffic. Gate 1 behavior approval still applies when observable behavior changes.
- Provider review task: `pwa-google-drive-sync-stabilization`
- Provider review decision: `behavior_approved`
- Provider review artifact: `429f7be740980d8ddcb7971ea16589e440736bdde3055915d9d3edae80873a5a`
- Providers: other
- Observable behavior: The authenticated Freed PWA performs its already designed Google Drive appDataFolder checkpoint discovery, import, enrollment, intent publication, and result import instead of crashing before the first request. The OAuth callback returns to the app after storing the approved Google token and starting the existing sync loop.
- Fingerprinting risk: Google can observe the existing Drive appDataFolder synchronization that the broken production client failed to send. Request URLs, methods, scopes, headers, object protocol, retry cadence, and polling cadence are unchanged. The repair only binds the browser fetch receiver and fixes local callback lifecycle bookkeeping.
- Lowest profile alternative: Leave the authenticated PWA unable to synchronize and require manual navigation after every OAuth connection. That avoids only the requests the approved sync feature is supposed to make and leaves the product broken.

Files bound into this provider review:
- `packages/pwa/src/components/OAuthCallback.tsx`
- `packages/sync/src/cloud/library-core-google-drive-adapter.test.ts`
- `packages/sync/src/cloud/library-core-google-drive-adapter.ts`