### PR TITLE
fix: refresh PWA Drive disconnect state

### DIFF
--- a/packages/pwa/src/components/PwaSyncSettings.test.ts
+++ b/packages/pwa/src/components/PwaSyncSettings.test.ts
@@ -10,7 +10,7 @@ const mocks = vi.hoisted(() => ({
   clearCloudSync: vi.fn(),
   clearStoredRelayUrl: vi.fn(),
   disconnect: vi.fn(),
-  getCloudProvider: vi.fn(() => "gdrive" as const),
+  getCloudProvider: vi.fn<() => "gdrive" | null>(() => "gdrive"),
   stopCloudSync: vi.fn(),
   syncCloudProviderNow: vi.fn(async () => {}),
 }));
@@ -59,6 +59,7 @@ describe("PwaSyncSettings cloud diagnostics", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-06-09T12:00:30Z"));
     vi.clearAllMocks();
+    mocks.getCloudProvider.mockReturnValue("gdrive");
     useAppStore.setState({
       syncConnected: true,
       isSyncing: false,
@@ -134,7 +135,11 @@ describe("PwaSyncSettings cloud diagnostics", () => {
     });
   });
 
-  it("clears the configured cloud provider before disconnecting the app store", () => {
+  it("clears the configured cloud provider and immediately shows the reconnect UI", async () => {
+    useAppStore.setState({ syncConnected: false });
+    mocks.clearCloudSync.mockImplementationOnce(() => {
+      mocks.getCloudProvider.mockReturnValue(null);
+    });
     const { container, root } = renderWithPlatform(createElement(PwaSyncSettings));
     const disconnectButton = Array.from(container.querySelectorAll("button")).find(
       (button) => button.textContent?.trim() === "Disconnect",
@@ -142,14 +147,15 @@ describe("PwaSyncSettings cloud diagnostics", () => {
 
     expect(disconnectButton).toBeInstanceOf(HTMLButtonElement);
 
-    act(() => {
+    await act(async () => {
       disconnectButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
     });
 
     expect(mocks.clearCloudSync).toHaveBeenCalledWith("gdrive");
-    expect(mocks.getCloudProvider.mock.invocationCallOrder.at(-1)).toBeLessThan(
-      mocks.disconnect.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
-    );
+    expect(container.textContent).toContain("Not connected");
+    expect(container.textContent).toContain("Connect");
+    expect(container.textContent).not.toContain("Disconnect");
 
     act(() => {
       root.unmount();

--- a/packages/pwa/src/components/PwaSyncSettings.tsx
+++ b/packages/pwa/src/components/PwaSyncSettings.tsx
@@ -128,6 +128,7 @@ export function PwaSyncSettings() {
   const cloudProviders = useDebugStore((s) => s.cloudProviders);
   const [manualSyncingProvider, setManualSyncingProvider] = useState<"gdrive" | "dropbox" | null>(null);
   const [manualSyncError, setManualSyncError] = useState<string | null>(null);
+  const [configuredCloudProvider, setConfiguredCloudProvider] = useState(() => getCloudProvider());
   const websiteGetUrl = `https://${getWebsiteHostForChannel(releaseChannel ?? "production")}/get`;
 
   const lastSyncTime = useMemo(() => {
@@ -137,7 +138,6 @@ export function PwaSyncSettings() {
     return times.length > 0 ? Math.max(...times) : null;
   }, [feeds]);
 
-  const configuredCloudProvider = getCloudProvider();
   const { label, provider } = getProviderInfo(
     syncConnected,
     configuredCloudProvider,
@@ -162,6 +162,7 @@ export function PwaSyncSettings() {
     if (cloudProvider) {
       clearCloudSync(cloudProvider);
       stopCloudSync();
+      setConfiguredCloudProvider(null);
     }
   };
 


### PR DESCRIPTION
(AI Generated).

## Summary
- Track the configured cloud provider in React state so Disconnect switches immediately to the Google Drive connect flow after credentials are cleared.
- Strengthen the existing regression to assert the visible reconnect state.

## Testing
- Authenticated production PWA reproduction confirmed credentials cleared only after closing and reopening Settings.
- npm run validate:feature: root and PWA typechecks, production build, 292 unit tests with 1 intentional skip, and 16 performance tests passed.

## Provider Review
- Status: Provider authority is validated for ready publication.
- Review action: none required. The provider-risk artifact records the behavior authority decision; this exact provider subdiff is the audit subject.
- Provider subdiff: `f4d19cfd50bb0c08e0f3ff6fece41cc1e60ef32c`
- Publication does not authorize new live provider traffic. Gate 1 behavior approval still applies when observable behavior changes.
- Provider review task: `pwa-google-drive-sync-stabilization`
- Provider review decision: `behavior_approved`
- Provider review artifact: `429f7be740980d8ddcb7971ea16589e440736bdde3055915d9d3edae80873a5a`
- Providers: other
- Observable behavior: The authenticated Freed PWA performs its already designed Google Drive appDataFolder checkpoint discovery, import, enrollment, intent publication, and result import instead of crashing before the first request. The OAuth callback returns to the app after storing the approved Google token and starting the existing sync loop.
- Fingerprinting risk: Google can observe the existing Drive appDataFolder synchronization that the broken production client failed to send. Request URLs, methods, scopes, headers, object protocol, retry cadence, and polling cadence are unchanged. The repair only binds the browser fetch receiver and fixes local callback lifecycle bookkeeping.
- Lowest profile alternative: Leave the authenticated PWA unable to synchronize and require manual navigation after every OAuth connection. That avoids only the requests the approved sync feature is supposed to make and leaves the product broken.

Files bound into this provider review:
- `packages/pwa/src/components/PwaSyncSettings.tsx`