### PR TITLE
fix: wake provider scheduler after desktop resume

### DIFF
--- a/packages/desktop/src/App.tsx
+++ b/packages/desktop/src/App.tsx
@@ -40,6 +40,7 @@ import {
   startProviderSyncScheduler,
   stopProviderSyncScheduler,
   stopProviderSyncSchedulerAndDrain,
+  wakeProviderSyncScheduler,
 } from "./lib/provider-sync-scheduler";
 import { wasDesktopClientRegistrationCreatedThisLaunch } from "./lib/desktop-client-registration";
 import {
@@ -689,7 +690,7 @@ function App() {
   useEffect(() => {
     if (!legalAccepted) return;
     log.info("[app] desktop app started");
-    if (!isTauri()) return;
+    if (!tauriRuntimeAvailable) return;
 
     const cleanups: Array<() => void> = [];
 
@@ -699,6 +700,7 @@ function App() {
 
     listen("tauri://resume", () => {
       log.info("[app] system resume (wake)");
+      wakeProviderSyncScheduler();
     }).then((unlisten) => cleanups.push(unlisten));
 
     listen<RendererRecoveryStateEvent>("renderer-recovery-state", (event) => {
@@ -723,7 +725,7 @@ function App() {
     }).then((unlisten) => cleanups.push(unlisten));
 
     return () => cleanups.forEach((fn, index) => safeUnlisten(fn, `app-lifecycle:${index.toLocaleString()}`));
-  }, [legalAccepted]);
+  }, [legalAccepted, tauriRuntimeAvailable]);
 
   useEffect(() => {
     const hasTauriMock = "__TAURI_INTERNALS__" in window;

--- a/packages/desktop/src/lib/provider-sync-scheduler.test.ts
+++ b/packages/desktop/src/lib/provider-sync-scheduler.test.ts
@@ -237,6 +237,62 @@ describe("provider sync scheduler", () => {
     scheduler.stopProviderSyncScheduler();
   });
 
+  it("runs one due opportunity when the desktop resumes", async () => {
+    listDueProviderSchedules.mockReturnValueOnce([]).mockReturnValueOnce([
+      {
+        provider: "facebook",
+        dueAt: 1_000,
+        dueAgeMs: 9_000,
+        normalizedOverdue: 2,
+      },
+    ]);
+    const scheduler = await loadScheduler();
+    scheduler.startProviderSyncScheduler({
+      now: () => 10_000,
+      random: { uniform: () => 0.5, id: () => "attempt" },
+    });
+    await vi.runAllTicks();
+
+    expect(runScheduledProviderAdapter).not.toHaveBeenCalled();
+
+    scheduler.wakeProviderSyncScheduler();
+    await vi.runAllTicks();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(runScheduledProviderAdapter).toHaveBeenCalledOnce();
+    expect(recordProviderScheduleEvent).toHaveBeenCalledWith(
+      "provider_schedule_decision",
+      expect.objectContaining({
+        provider: "facebook",
+        trigger: "wake",
+        wakeContext: true,
+      }),
+    );
+    scheduler.stopProviderSyncScheduler();
+  });
+
+  it("keeps a due opportunity pending while the desktop session is hidden", async () => {
+    listDueProviderSchedules.mockReturnValue([]);
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      value: "hidden",
+    });
+    const scheduler = await loadScheduler();
+    scheduler.startProviderSyncScheduler({
+      now: () => 10_000,
+      random: { uniform: () => 0.5, id: () => "attempt" },
+    });
+    await vi.runAllTicks();
+
+    scheduler.wakeProviderSyncScheduler();
+    await vi.runAllTicks();
+
+    expect(listDueProviderSchedules).toHaveBeenCalledOnce();
+    expect(runScheduledProviderAdapter).not.toHaveBeenCalled();
+    scheduler.stopProviderSyncScheduler();
+  });
+
   it.each([
     { operation: "fb_scrape_feed", provider: "facebook" },
     { operation: "ig_scrape_feed", provider: "instagram" },

--- a/packages/desktop/src/lib/provider-sync-scheduler.ts
+++ b/packages/desktop/src/lib/provider-sync-scheduler.ts
@@ -353,7 +353,7 @@ function triggerTick(wakeContext = false): void {
   activeOperations.add(tracked);
 }
 
-function wake(): void {
+export function wakeProviderSyncScheduler(): void {
   if (document.visibilityState === "visible") triggerTick(true);
 }
 
@@ -367,9 +367,9 @@ export function startProviderSyncScheduler(
   reportedStorageBlocks.clear();
   initialize(nowSource(), activeRandom, options.existingInstall ?? false);
   timer = setInterval(() => triggerTick(false), options.tickMs ?? DEFAULT_TICK_MS);
-  document.addEventListener("visibilitychange", wake);
-  window.addEventListener("focus", wake);
-  window.addEventListener("online", wake);
+  document.addEventListener("visibilitychange", wakeProviderSyncScheduler);
+  window.addEventListener("focus", wakeProviderSyncScheduler);
+  window.addEventListener("online", wakeProviderSyncScheduler);
   triggerTick(false);
 }
 
@@ -378,9 +378,9 @@ export function stopProviderSyncScheduler(): void {
   wakePending = false;
   if (timer) clearInterval(timer);
   timer = null;
-  document.removeEventListener("visibilitychange", wake);
-  window.removeEventListener("focus", wake);
-  window.removeEventListener("online", wake);
+  document.removeEventListener("visibilitychange", wakeProviderSyncScheduler);
+  window.removeEventListener("focus", wakeProviderSyncScheduler);
+  window.removeEventListener("online", wakeProviderSyncScheduler);
 }
 
 export async function stopProviderSyncSchedulerAndDrain(): Promise<void> {

--- a/packages/desktop/tests/e2e/provider-sync-resume.spec.ts
+++ b/packages/desktop/tests/e2e/provider-sync-resume.spec.ts
@@ -1,0 +1,117 @@
+import { test, expect } from "./fixtures/app";
+
+test("desktop resume gives one due provider a wake opportunity", async ({
+  app,
+  page,
+  ipc,
+}) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem(
+      "__TAURI_MOCK_STORE__:legal.json",
+      JSON.stringify({
+        "legal.bundle.desktop": {
+          version: "2026-03-31.1",
+          acceptedAt: 1775146800000,
+          surface: "desktop-first-run",
+        },
+        "legal.provider.facebook": {
+          version: "2026-03-31-facebook",
+          acceptedAt: 1775146800000,
+          surface: "desktop-provider-facebook",
+        },
+      }),
+    );
+  });
+  await app.goto();
+  await app.waitForReady();
+
+  await expect
+    .poll(async () =>
+      (await ipc.invocations()).some(
+        (call) => call.cmd === "get_background_runtime_active_operation",
+      ),
+    )
+    .toBe(true);
+
+  await page.evaluate(() => {
+    const globalKey = "freed-device-provider-sync-global-v1";
+    window.localStorage.setItem(
+      globalKey,
+      JSON.stringify({ version: 1, config: { automaticEnabled: true } }),
+    );
+
+    const recordKey = "freed-device-provider-sync-state-v2:facebook";
+    const raw = window.localStorage.getItem(recordKey);
+    if (!raw) throw new Error("Facebook provider schedule was not initialized");
+    const value = JSON.parse(raw) as {
+      version: number;
+      record: Record<string, unknown>;
+    };
+    value.record = {
+      ...value.record,
+      phase: "waiting",
+      automaticPaused: false,
+      activationAt: Date.now() - 2_000,
+      nextDueAt: Date.now() - 1_000,
+    };
+    delete value.record.attempt;
+    delete value.record.localEligibilityRetryAt;
+    window.localStorage.setItem(recordKey, JSON.stringify(value));
+  });
+
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        const listeners = (window as unknown as Record<string, unknown>)
+          .__TAURI_EVENT_LISTENERS__ as
+          | Record<string, Array<(event: { payload: unknown }) => void>>
+          | undefined;
+        return listeners?.["tauri://resume"]?.length ?? 0;
+      }),
+    )
+    .toBeGreaterThan(0);
+
+  await page.evaluate(() => {
+    const testWindow = window as unknown as Record<string, unknown>;
+    const listeners = testWindow.__TAURI_EVENT_LISTENERS__ as Record<
+      string,
+      Array<(event: { payload: unknown }) => void>
+    >;
+    for (let opportunity = 0; opportunity < 2; opportunity += 1) {
+      for (const listener of listeners["tauri://resume"] ?? []) {
+        listener({ payload: null });
+      }
+    }
+  });
+
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        const raw = window.localStorage.getItem(
+          "freed-device-provider-sync-state-v2:facebook",
+        );
+        if (!raw) return null;
+        const value = JSON.parse(raw) as {
+          record: {
+            phase: string;
+            lastOutcome?: string;
+            lastAttemptStartedAt?: number;
+            nextDueAt: number;
+          };
+        };
+        return {
+          phase: value.record.phase,
+          lastOutcome: value.record.lastOutcome,
+          hasAttemptTimestamp:
+            typeof value.record.lastAttemptStartedAt === "number",
+          nextDueIsFuture: value.record.nextDueAt > Date.now(),
+        };
+      }),
+    )
+    .toEqual({
+      phase: "settled",
+      lastOutcome: "ignored",
+      hasAttemptTimestamp: true,
+      nextDueIsFuture: true,
+    });
+});


### PR DESCRIPTION
(AI Generated).

## Summary
- Connect the existing macOS resume event to the durable provider scheduler wake path.
- Coalesce repeated resume signals into one due-provider opportunity while retaining hidden-session deferral.
- Add focused scheduler and Desktop workflow regression coverage without generating provider traffic.

## Testing
- npm run validate:feature
- npx playwright test tests/e2e/provider-sync-resume.spec.ts

## Provider Review
- Status: Provider authority is validated for ready publication.
- Review action: none required. The provider-risk artifact records the behavior authority decision; this exact provider subdiff is the audit subject.
- Provider subdiff: `b6d8c3d205093569af4fc3103bd29a1bfeed54fd`
- Publication does not authorize new live provider traffic. Gate 1 behavior approval still applies when observable behavior changes.
- Provider review task: `provider-sync-cadence-v2`
- Provider review decision: `behavior_approved`
- Provider review artifact: `2b731340a42180bba616111e0e025feaa07950c1698d2fb6d9b7b24ca6b0e294`
- Providers: facebook, instagram, linkedin, medium, other, substack, x, youtube
- Observable behavior: Existing automatic X, Facebook, Instagram, LinkedIn, YouTube, Substack, Medium, and RSS contact opportunities move from coupled legacy timers to independent device-local durable schedules. One automatic social provider may run at a time. Manual and post-login settlement resample the next automatic deadline. RSS remains separate. Existing provider request, navigation, extraction, and logical capture behavior is unchanged.
- Fingerprinting risk: Providers can observe changed contact timing and cadence even though the implementation adds no requests, pages, navigation, scrolling, clicks, cookies, headers, media loads, or extraction behavior. Independent randomized schedules reduce synchronized patterns but do not make automated traffic unobservable or human-indistinguishable.
- Lowest profile alternative: Disable global automatic provider sync and use manual Sync Now only. Passive local evidence collection remains available without provider traffic.

Files bound into this provider review:
- `packages/desktop/src/App.tsx`
- `packages/desktop/src/lib/provider-sync-scheduler.ts`