### PR TITLE
chore: promote dev into main for production release

### DIFF
--- a/docs/AUTOMATION-CONTROL-PLANE.md
+++ b/docs/AUTOMATION-CONTROL-PLANE.md
@@ -397,6 +397,47 @@ exact-generation retirement, after which later task mutation can proceed. A
 second stage, a mismatched namespace, or a canonical transaction beside its
 stage fails closed.
 
+### Stranded task-manifest witness repair
+
+A completed task transaction can leave its valid predecessor witness behind
+after the canonical manifest is later republished on a different physical
+inode. The generic reader correctly rejects that witness because its recorded
+successor digest no longer names the physical `current-tasks.json` generation,
+even when the bytes and task history still form one exact semantic successor.
+No reader removes or guesses through that condition.
+
+`node scripts/authority-witness-repair.mjs plan --task-id <id>` is the only
+read-only planner for this exceptional state. It requires one complete ready
+witness, one healthy exact task and event history, one unique retired task
+transaction lineage, no active owning transaction, the permanent local
+filesystem kernel guard, and a canonical manifest exactly one revision after
+the witness. The plan records the canonical and witness paths, devices, inodes,
+modes, link counts, timestamps, byte digests, exact witness bytes, event-history
+prefix, retired transaction, and one content-derived operation and owner-intent
+digest. Planning does not recover a transaction, acquire a lease, write an
+artifact, append an event, or change either generation.
+
+Applying the saved private plan requires a short `freed-owner` lease bound to
+the plan's exact task and intent digest:
+
+```bash
+FREED_AUTOMATION_LEASE_TOKEN=<one-use-token> \
+  node scripts/authority-witness-repair.mjs repair \
+  --task-id <id> \
+  --plan-file <private-plan.json>
+```
+
+Apply rechecks the unchanged canonical manifest, the exact witness generation,
+append-only healthy event history, retired semantic lineage, and absent active
+owner. It first appends one reserved
+`authority_witness_repair_authorized` event, then retires only the planned
+witness through `authority-retire`. It never rewrites `current-tasks.json` and
+never unlinks or overwrites a witness. If the process loses its response after
+the audit append or exact retirement, the same plan recovers the one existing
+event and retirement receipt without duplicating either. A changed manifest,
+witness, history prefix, lineage, plan, lease, or retirement generation fails
+closed.
+
 The generic authority publication path may call only
 `authority-stage-create`, `authority-stage-rewrite`, `authority-exchange`, and
 `authority-retire`. It must not call the helper's legacy `replace-durable` or

--- a/docs/PHASE-10-POLISH.md
+++ b/docs/PHASE-10-POLISH.md
@@ -155,6 +155,8 @@ Every general automation actor now requires lease acquisition through a trusted 
 
 An expired trusted-launcher acquisition stranded after its lease state commits can now be completed through one exact current-task owner confirmation. Recovery admits only the pending operation ID, actor, canonical lease, committed phase, retained token digest, and trusted-launcher provenance named by the confirmation. It rejects live leases and prepared or mismatched transactions, never returns the retained token, and preserves the original lease event and transaction receipt. This runtime-neutral control-plane repair adds no provider contact and does not change Phase 10's `upcoming` roadmap status.
 
+A stranded task-manifest predecessor witness now has one owner-governed repair path instead of a manual file-edit escape hatch. The read-only planner proves the exact canonical and witness generations, healthy task and event history, one unique retired transaction lineage, and no active owner. The task-bound apply command appends one reserved authorization event before exact-generation retirement, never rewrites `current-tasks.json`, and recovers without duplicate events or retirements after response loss. Changed, pending, ambiguous, or foreign generations fail closed. This runtime-neutral control-plane repair adds no provider contact and does not change Phase 10's `upcoming` roadmap status.
+
 Lease transaction cleanup now uses one pinned cross-platform helper and held file and directory descriptors for exclusive archive moves. Darwin uses `renameatx_np(RENAME_EXCL)` and Linux uses `renameat2(RENAME_NOREPLACE)`. Destination readback and the final exact archive-set rescan stay relative to the held directories, and destination durability is established before source removal durability. The general actor runtime copies and digests the helper. Strict preflight reports current and projected archive count, bytes, oldest age, local filesystem identity, and free-space headroom before new staging. The projection reserves three maximum-size transaction artifacts plus the largest stale receipt-pruning set that one canonical lease operation could retire. Count, byte, age, and headroom limits stop new transactions instead of compacting audit history without a separate owner-authorized lifecycle. This local control-plane hardening adds no provider contact and does not change Phase 10's `upcoming` roadmap status.
 
 Current-task owner confirmation is now a supported cooperative fallback for one exact lifecycle operation when the owner explicitly approves it in the active task. The private confirmation binds the owner name, current-task reference, task ID, canonical operation intent, approval time, and expiry to a short `freed-owner` lease. Every different operation needs a different intent record. The audit event preserves the confirmation digest and reference. This path does not authenticate the owner, contact a provider, or replace provider behavior approval or repository CODEOWNER requirements. Unknown metric IDs in stability artifacts now fail validation before a release handoff can depend on them.
@@ -429,17 +431,17 @@ Reward security researchers for responsible disclosure.
 
 ### UX Polish
 
-| Task  | Description                        | Complexity |
-| ----- | ---------------------------------- | ---------- |
-| 10.1  | Onboarding wizard                  | Medium     |
-| 10.2  | Statistics dashboard               | Medium     |
-| 10.3  | Export to JSON                     | Low        |
-| 10.4  | Export to CSV                      | Low        |
-| 10.5  | Keyboard shortcuts                 | Medium     | ✓ Complete (PWA reader keys, command palette, navigation history keys, and Freed Desktop Save Content shortcut) |
-| 10.6  | Screen reader support              | Medium     |
-| 10.7  | Reduced motion support             | Low        | ✓ Complete (Appearance animation intensity controls plus global app motion gating)                              |
-| 10.8  | Color contrast audit               | Low        |
-| 10.9  | Native Liquid Glass buttons        | High       |
+| Task  | Description                       | Complexity |
+| ----- | --------------------------------- | ---------- |
+| 10.1  | Onboarding wizard                 | Medium     |
+| 10.2  | Statistics dashboard              | Medium     |
+| 10.3  | Export to JSON                    | Low        |
+| 10.4  | Export to CSV                     | Low        |
+| 10.5  | Keyboard shortcuts                | Medium     | ✓ Complete (PWA reader keys, command palette, navigation history keys, and Freed Desktop Save Content shortcut) |
+| 10.6  | Screen reader support             | Medium     |
+| 10.7  | Reduced motion support            | Low        | ✓ Complete (Appearance animation intensity controls plus global app motion gating)                              |
+| 10.8  | Color contrast audit              | Low        |
+| 10.9  | Native Liquid Glass buttons       | High       |
 | 10.24 | Command bar: full action launcher | High       | ✓ Complete (Global `Cmd/Ctrl+K` palette with navigation, creation, current-item, sync, and danger actions)      |
 
 ### AI Features
@@ -474,6 +476,7 @@ Reward security researchers for responsible disclosure.
 | 10.22 | Documentation site                       | Medium     |
 | 10.28 | Primary automation host and task custody | Medium     | ✓ Complete (reviewed opaque host assignment, root-owned enrollment, nightly primary-host gate, one custodian heartbeat contract, and conservative external no-op archival)                                                              |
 | 10.29 | Task-scoped factory execution claims     | Medium     | ✓ Complete (single-manifest claims, exact retry receipts, conflict fencing, heartbeat custody, checkpoint-backed epoch transfer, exact release, and runtime-neutral draft-only pilot authority)                                         |
+| 10.30 | Stranded authority witness repair        | Medium     | ✓ Complete (read-only immutable planning, task-bound owner intent, reserved audit event, exact-generation retirement, response-loss recovery, and fail-closed drift checks)                                                             |
 
 ### Resilience
 
@@ -517,6 +520,7 @@ Reward security researchers for responsible disclosure.
 - [x] Stability status reduces the current read-only evidence surfaces into one deterministic model, rejects unsafe artifact shapes, reports foreign records without treating them as canonical evidence, and chooses one next action without network or state mutation.
 - [x] One reviewed primary host owns the single nightly executor, while one custodian heartbeat validates saved actors, enforces models from current callable capability data, and archives only confirmed no-op automation tasks.
 - [x] One trusted nightly coordinator can hold multiple task-scoped factory claims without giving workers permanent leases. Each claim remains inside the atomic task authority manifest, preserves exact custody across retries and crashes, and permits only runtime-neutral, provider-forbidden, draft-only pilot work.
+- [x] A stranded task-manifest predecessor witness can be planned without mutation and retired only through one exact task-bound owner intent, reserved audit event, and response-loss-safe native authority retirement.
 - [ ] Documentation site live
 
 ### Resilience

--- a/packages/desktop/src/App.tsx
+++ b/packages/desktop/src/App.tsx
@@ -40,6 +40,7 @@ import {
   startProviderSyncScheduler,
   stopProviderSyncScheduler,
   stopProviderSyncSchedulerAndDrain,
+  wakeProviderSyncScheduler,
 } from "./lib/provider-sync-scheduler";
 import { wasDesktopClientRegistrationCreatedThisLaunch } from "./lib/desktop-client-registration";
 import {
@@ -689,7 +690,7 @@ function App() {
   useEffect(() => {
     if (!legalAccepted) return;
     log.info("[app] desktop app started");
-    if (!isTauri()) return;
+    if (!tauriRuntimeAvailable) return;
 
     const cleanups: Array<() => void> = [];
 
@@ -699,6 +700,7 @@ function App() {
 
     listen("tauri://resume", () => {
       log.info("[app] system resume (wake)");
+      wakeProviderSyncScheduler();
     }).then((unlisten) => cleanups.push(unlisten));
 
     listen<RendererRecoveryStateEvent>("renderer-recovery-state", (event) => {
@@ -723,7 +725,7 @@ function App() {
     }).then((unlisten) => cleanups.push(unlisten));
 
     return () => cleanups.forEach((fn, index) => safeUnlisten(fn, `app-lifecycle:${index.toLocaleString()}`));
-  }, [legalAccepted]);
+  }, [legalAccepted, tauriRuntimeAvailable]);
 
   useEffect(() => {
     const hasTauriMock = "__TAURI_INTERNALS__" in window;

--- a/packages/desktop/src/lib/google-drive.test.ts
+++ b/packages/desktop/src/lib/google-drive.test.ts
@@ -63,6 +63,38 @@ describe("desktop Google Drive platform fetch", () => {
     expect(response.ok).toBe(true);
   });
 
+  it("serializes multipart Blob uploads before invoking the native request", async () => {
+    invokeMock.mockResolvedValueOnce({
+      status: 200,
+      headers: [],
+      bodyB64: "",
+    });
+
+    const { googleDriveFetchViaTauri } = await import("./google-drive");
+    const multipartBody = new Blob(["metadata\r\n", new Uint8Array([1, 2, 3])], {
+      type: "multipart/related; boundary=freed-test",
+    });
+    const expectedBodyB64 = btoa(
+      String.fromCharCode(...new Uint8Array(await multipartBody.arrayBuffer())),
+    );
+
+    await googleDriveFetchViaTauri(
+      "https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart",
+      {
+        method: "POST",
+        headers: { "Content-Type": multipartBody.type },
+        body: multipartBody,
+      },
+    );
+
+    expect(invokeMock).toHaveBeenCalledWith("google_drive_request", {
+      url: "https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart",
+      method: "POST",
+      headers: [["Content-Type", "multipart/related; boundary=freed-test"]],
+      bodyB64: expectedBodyB64,
+    });
+  });
+
   it("supports empty 204 Drive responses", async () => {
     invokeMock.mockResolvedValueOnce({
       status: 204,

--- a/packages/desktop/src/lib/google-drive.ts
+++ b/packages/desktop/src/lib/google-drive.ts
@@ -58,9 +58,19 @@ export function base64ToBytes(encoded: string): Uint8Array<ArrayBuffer> {
   return bytes;
 }
 
-function bodyToBase64(body?: BodyInit | null): string | undefined {
+async function bodyToBase64(body?: BodyInit | null): Promise<string | undefined> {
   if (!body) return undefined;
+  // Yield before encoding. Drive publication is fire-and-forget from parts of
+  // the UI, and even an async caller would otherwise run the conversion
+  // synchronously until its first await.
+  await Promise.resolve();
   if (typeof body === "string") return bytesToBase64(new TextEncoder().encode(body));
+  if (body instanceof URLSearchParams) {
+    return bytesToBase64(new TextEncoder().encode(body.toString()));
+  }
+  if (body instanceof Blob) {
+    return bytesToBase64(new Uint8Array(await body.arrayBuffer()));
+  }
   if (body instanceof Uint8Array) return bytesToBase64(body);
   if (body instanceof ArrayBuffer) return bytesToBase64(new Uint8Array(body));
   throw new Error("Google Drive native requests only support string and binary bodies.");
@@ -77,7 +87,7 @@ export async function googleDriveFetchViaTauri(
     url,
     method: init.method ?? "GET",
     headers: headersToEntries(init.headers),
-    bodyB64: bodyToBase64(init.body),
+    bodyB64: await bodyToBase64(init.body),
   });
 
   throwIfAborted(init.signal);

--- a/packages/desktop/src/lib/provider-sync-scheduler.test.ts
+++ b/packages/desktop/src/lib/provider-sync-scheduler.test.ts
@@ -237,6 +237,62 @@ describe("provider sync scheduler", () => {
     scheduler.stopProviderSyncScheduler();
   });
 
+  it("runs one due opportunity when the desktop resumes", async () => {
+    listDueProviderSchedules.mockReturnValueOnce([]).mockReturnValueOnce([
+      {
+        provider: "facebook",
+        dueAt: 1_000,
+        dueAgeMs: 9_000,
+        normalizedOverdue: 2,
+      },
+    ]);
+    const scheduler = await loadScheduler();
+    scheduler.startProviderSyncScheduler({
+      now: () => 10_000,
+      random: { uniform: () => 0.5, id: () => "attempt" },
+    });
+    await vi.runAllTicks();
+
+    expect(runScheduledProviderAdapter).not.toHaveBeenCalled();
+
+    scheduler.wakeProviderSyncScheduler();
+    await vi.runAllTicks();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(runScheduledProviderAdapter).toHaveBeenCalledOnce();
+    expect(recordProviderScheduleEvent).toHaveBeenCalledWith(
+      "provider_schedule_decision",
+      expect.objectContaining({
+        provider: "facebook",
+        trigger: "wake",
+        wakeContext: true,
+      }),
+    );
+    scheduler.stopProviderSyncScheduler();
+  });
+
+  it("keeps a due opportunity pending while the desktop session is hidden", async () => {
+    listDueProviderSchedules.mockReturnValue([]);
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      value: "hidden",
+    });
+    const scheduler = await loadScheduler();
+    scheduler.startProviderSyncScheduler({
+      now: () => 10_000,
+      random: { uniform: () => 0.5, id: () => "attempt" },
+    });
+    await vi.runAllTicks();
+
+    scheduler.wakeProviderSyncScheduler();
+    await vi.runAllTicks();
+
+    expect(listDueProviderSchedules).toHaveBeenCalledOnce();
+    expect(runScheduledProviderAdapter).not.toHaveBeenCalled();
+    scheduler.stopProviderSyncScheduler();
+  });
+
   it.each([
     { operation: "fb_scrape_feed", provider: "facebook" },
     { operation: "ig_scrape_feed", provider: "instagram" },

--- a/packages/desktop/src/lib/provider-sync-scheduler.ts
+++ b/packages/desktop/src/lib/provider-sync-scheduler.ts
@@ -353,7 +353,7 @@ function triggerTick(wakeContext = false): void {
   activeOperations.add(tracked);
 }
 
-function wake(): void {
+export function wakeProviderSyncScheduler(): void {
   if (document.visibilityState === "visible") triggerTick(true);
 }
 
@@ -367,9 +367,9 @@ export function startProviderSyncScheduler(
   reportedStorageBlocks.clear();
   initialize(nowSource(), activeRandom, options.existingInstall ?? false);
   timer = setInterval(() => triggerTick(false), options.tickMs ?? DEFAULT_TICK_MS);
-  document.addEventListener("visibilitychange", wake);
-  window.addEventListener("focus", wake);
-  window.addEventListener("online", wake);
+  document.addEventListener("visibilitychange", wakeProviderSyncScheduler);
+  window.addEventListener("focus", wakeProviderSyncScheduler);
+  window.addEventListener("online", wakeProviderSyncScheduler);
   triggerTick(false);
 }
 
@@ -378,9 +378,9 @@ export function stopProviderSyncScheduler(): void {
   wakePending = false;
   if (timer) clearInterval(timer);
   timer = null;
-  document.removeEventListener("visibilitychange", wake);
-  window.removeEventListener("focus", wake);
-  window.removeEventListener("online", wake);
+  document.removeEventListener("visibilitychange", wakeProviderSyncScheduler);
+  window.removeEventListener("focus", wakeProviderSyncScheduler);
+  window.removeEventListener("online", wakeProviderSyncScheduler);
 }
 
 export async function stopProviderSyncSchedulerAndDrain(): Promise<void> {

--- a/packages/desktop/tests/e2e/provider-sync-resume.spec.ts
+++ b/packages/desktop/tests/e2e/provider-sync-resume.spec.ts
@@ -1,0 +1,117 @@
+import { test, expect } from "./fixtures/app";
+
+test("desktop resume gives one due provider a wake opportunity", async ({
+  app,
+  page,
+  ipc,
+}) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem(
+      "__TAURI_MOCK_STORE__:legal.json",
+      JSON.stringify({
+        "legal.bundle.desktop": {
+          version: "2026-03-31.1",
+          acceptedAt: 1775146800000,
+          surface: "desktop-first-run",
+        },
+        "legal.provider.facebook": {
+          version: "2026-03-31-facebook",
+          acceptedAt: 1775146800000,
+          surface: "desktop-provider-facebook",
+        },
+      }),
+    );
+  });
+  await app.goto();
+  await app.waitForReady();
+
+  await expect
+    .poll(async () =>
+      (await ipc.invocations()).some(
+        (call) => call.cmd === "get_background_runtime_active_operation",
+      ),
+    )
+    .toBe(true);
+
+  await page.evaluate(() => {
+    const globalKey = "freed-device-provider-sync-global-v1";
+    window.localStorage.setItem(
+      globalKey,
+      JSON.stringify({ version: 1, config: { automaticEnabled: true } }),
+    );
+
+    const recordKey = "freed-device-provider-sync-state-v2:facebook";
+    const raw = window.localStorage.getItem(recordKey);
+    if (!raw) throw new Error("Facebook provider schedule was not initialized");
+    const value = JSON.parse(raw) as {
+      version: number;
+      record: Record<string, unknown>;
+    };
+    value.record = {
+      ...value.record,
+      phase: "waiting",
+      automaticPaused: false,
+      activationAt: Date.now() - 2_000,
+      nextDueAt: Date.now() - 1_000,
+    };
+    delete value.record.attempt;
+    delete value.record.localEligibilityRetryAt;
+    window.localStorage.setItem(recordKey, JSON.stringify(value));
+  });
+
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        const listeners = (window as unknown as Record<string, unknown>)
+          .__TAURI_EVENT_LISTENERS__ as
+          | Record<string, Array<(event: { payload: unknown }) => void>>
+          | undefined;
+        return listeners?.["tauri://resume"]?.length ?? 0;
+      }),
+    )
+    .toBeGreaterThan(0);
+
+  await page.evaluate(() => {
+    const testWindow = window as unknown as Record<string, unknown>;
+    const listeners = testWindow.__TAURI_EVENT_LISTENERS__ as Record<
+      string,
+      Array<(event: { payload: unknown }) => void>
+    >;
+    for (let opportunity = 0; opportunity < 2; opportunity += 1) {
+      for (const listener of listeners["tauri://resume"] ?? []) {
+        listener({ payload: null });
+      }
+    }
+  });
+
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        const raw = window.localStorage.getItem(
+          "freed-device-provider-sync-state-v2:facebook",
+        );
+        if (!raw) return null;
+        const value = JSON.parse(raw) as {
+          record: {
+            phase: string;
+            lastOutcome?: string;
+            lastAttemptStartedAt?: number;
+            nextDueAt: number;
+          };
+        };
+        return {
+          phase: value.record.phase,
+          lastOutcome: value.record.lastOutcome,
+          hasAttemptTimestamp:
+            typeof value.record.lastAttemptStartedAt === "number",
+          nextDueIsFuture: value.record.nextDueAt > Date.now(),
+        };
+      }),
+    )
+    .toEqual({
+      phase: "settled",
+      lastOutcome: "ignored",
+      hasAttemptTimestamp: true,
+      nextDueIsFuture: true,
+    });
+});

--- a/scripts/authority-witness-repair.mjs
+++ b/scripts/authority-witness-repair.mjs
@@ -1,0 +1,227 @@
+#!/usr/bin/env node
+
+import {
+  lstatSync,
+  openSync,
+  closeSync,
+  constants,
+  fstatSync,
+  readFileSync,
+  realpathSync,
+} from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  AUTHORITY_WITNESS_REPAIR_ACTION,
+  AutomationControlError,
+  planTaskManifestAuthorityWitnessRepair,
+  repairTaskManifestAuthorityWitness,
+  resolveAutomationStateRoot,
+} from "./lib/automation-control.mjs";
+
+const __filename = fileURLToPath(import.meta.url);
+const MAX_PLAN_BYTES = 2 * 1024 * 1024;
+
+function usage() {
+  return `Usage:
+  node scripts/authority-witness-repair.mjs plan --task-id <id> [--state-root <path>]
+  node scripts/authority-witness-repair.mjs repair --task-id <id> --plan-file <path> [--state-root <path>]
+
+The plan command is read-only. Save its JSON output to a private physical file.
+The repair command requires an exact live freed-owner lease for owner-governance
+in FREED_AUTOMATION_LEASE_TOKEN.
+`;
+}
+
+function takeOptions(argv) {
+  const options = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const flag = argv[index];
+    if (flag === "--help" || flag === "-h") {
+      options.help = true;
+      continue;
+    }
+    if (!flag.startsWith("--")) {
+      throw new AutomationControlError(
+        "invalid_argument",
+        `Unexpected argument: ${flag}`,
+      );
+    }
+    const value = argv[index + 1];
+    if (value === undefined || value.startsWith("--")) {
+      throw new AutomationControlError(
+        "invalid_argument",
+        `${flag} requires a value.`,
+      );
+    }
+    const key = flag
+      .slice(2)
+      .replace(/-([a-z])/g, (_match, letter) => letter.toUpperCase());
+    if (Object.hasOwn(options, key)) {
+      throw new AutomationControlError(
+        "invalid_argument",
+        `${flag} may only be provided once.`,
+      );
+    }
+    options[key] = value;
+    index += 1;
+  }
+  return options;
+}
+
+function required(options, key, flag) {
+  const value = options[key];
+  if (typeof value !== "string" || value.length === 0) {
+    throw new AutomationControlError(
+      "invalid_argument",
+      `${flag} is required.`,
+    );
+  }
+  return value;
+}
+
+function assertExactOptions(options, expected) {
+  const unexpected = Object.keys(options).filter(
+    (key) => key !== "help" && !expected.includes(key),
+  );
+  if (unexpected.length > 0) {
+    throw new AutomationControlError(
+      "invalid_argument",
+      `Unexpected option: ${unexpected[0]}`,
+    );
+  }
+}
+
+function readPrivatePlan(filePath) {
+  const resolved = path.resolve(filePath);
+  let descriptor;
+  try {
+    descriptor = openSync(
+      resolved,
+      constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK,
+    );
+    const held = fstatSync(descriptor, { bigint: true });
+    if (
+      !held.isFile() ||
+      held.uid !== BigInt(process.getuid()) ||
+      held.nlink !== 1n ||
+      held.size <= 0n ||
+      held.size > BigInt(MAX_PLAN_BYTES) ||
+      ![0o600, 0o640].includes(Number(held.mode & 0o7777n))
+    ) {
+      throw new Error("file is not one private physical bounded generation");
+    }
+    const named = lstatSync(resolved, { bigint: true });
+    if (
+      named.isSymbolicLink() ||
+      held.dev !== named.dev ||
+      held.ino !== named.ino ||
+      held.mode !== named.mode ||
+      held.size !== named.size ||
+      realpathSync(resolved) !== resolved
+    ) {
+      throw new Error("file changed while it was admitted");
+    }
+    const parsed = JSON.parse(readFileSync(descriptor, "utf8"));
+    const after = fstatSync(descriptor, { bigint: true });
+    if (
+      after.dev !== held.dev ||
+      after.ino !== held.ino ||
+      after.mode !== held.mode ||
+      after.size !== held.size
+    ) {
+      throw new Error("file changed while it was read");
+    }
+    return parsed?.result ?? parsed;
+  } catch (error) {
+    throw new AutomationControlError(
+      "invalid_argument",
+      "Authority witness repair plan file could not be admitted safely.",
+      { cause: error instanceof Error ? error.message : String(error) },
+    );
+  } finally {
+    if (descriptor !== undefined) closeSync(descriptor);
+  }
+}
+
+export function execute(argv, env = process.env) {
+  const [action, ...rest] = argv;
+  const options = takeOptions(rest);
+  if (
+    options.help ||
+    action === undefined ||
+    action === "--help" ||
+    action === "-h"
+  ) {
+    return { help: true };
+  }
+  const stateRoot = resolveAutomationStateRoot(options.stateRoot);
+  const taskId = required(options, "taskId", "--task-id");
+  if (action === "plan") {
+    assertExactOptions(options, ["stateRoot", "taskId"]);
+    return {
+      action: "authority-witness.plan",
+      stateRoot,
+      result: planTaskManifestAuthorityWitnessRepair({ stateRoot, taskId }),
+    };
+  }
+  if (action === "repair") {
+    assertExactOptions(options, ["planFile", "stateRoot", "taskId"]);
+    const leaseToken = env.FREED_AUTOMATION_LEASE_TOKEN;
+    if (typeof leaseToken !== "string" || leaseToken.length === 0) {
+      throw new AutomationControlError(
+        "invalid_argument",
+        "FREED_AUTOMATION_LEASE_TOKEN is required.",
+      );
+    }
+    return {
+      action: AUTHORITY_WITNESS_REPAIR_ACTION,
+      stateRoot,
+      result: repairTaskManifestAuthorityWitness({
+        stateRoot,
+        taskId,
+        plan: readPrivatePlan(required(options, "planFile", "--plan-file")),
+        actor: "freed-owner",
+        leaseName: "owner-governance",
+        leaseToken,
+      }),
+    };
+  }
+  throw new AutomationControlError(
+    "invalid_command",
+    `Unknown authority witness repair command: ${action}`,
+  );
+}
+
+function main() {
+  const execution = execute(process.argv.slice(2));
+  if (execution.help) {
+    process.stdout.write(usage());
+    return;
+  }
+  process.stdout.write(
+    `${JSON.stringify({ ok: true, schemaVersion: 1, ...execution })}\n`,
+  );
+}
+
+if (process.argv[1] === __filename) {
+  try {
+    main();
+  } catch (error) {
+    process.stderr.write(
+      `${JSON.stringify({
+        ok: false,
+        schemaVersion: 1,
+        error: {
+          code:
+            error instanceof AutomationControlError
+              ? error.code
+              : "internal_error",
+          message: error instanceof Error ? error.message : String(error),
+        },
+      })}\n`,
+    );
+    process.exitCode = 1;
+  }
+}

--- a/scripts/automation-control.test.mjs
+++ b/scripts/automation-control.test.mjs
@@ -36,6 +36,7 @@ import test from "node:test";
 
 import {
   AutomationControlError,
+  AUTHORITY_WITNESS_REPAIR_ACTION,
   AUTOMATION_ACTOR_POLICIES,
   CONTROL_EVENT_HISTORY_MAX_BYTES,
   CONTROL_EVENT_HISTORY_MAX_RECORDS,
@@ -66,6 +67,7 @@ import {
   normalizeInstalledBuildIdentity,
   outcomeRecordedEventId,
   ownerGovernanceIntentDigest,
+  planTaskManifestAuthorityWitnessRepair,
   partitionPrivateBatchSelectionForTest,
   preauthorizeOutcomeLedgerRepair,
   preflightOutcomeLedgerRepairEvent,
@@ -75,6 +77,7 @@ import {
   readTask,
   readFactoryExecutionClaim,
   readTaskManifest,
+  repairTaskManifestAuthorityWitness,
   recoverExpiredGeneralActorLeaseAcquire,
   releaseLease as releaseLeaseMutation,
   releaseFactoryExecutionClaim,
@@ -10400,6 +10403,7 @@ test("behavioral classification and the installed soak slot are immutable contro
   );
 
   for (const type of [
+    "authority_witness_repair_authorized",
     "lease_acquired",
     "lease_credential_upgraded",
     "lease_heartbeat",
@@ -10430,6 +10434,7 @@ test("behavioral classification and the installed soak slot are immutable contro
     );
   }
   for (const eventId of [
+    `authority-witness-repaired:${"e".repeat(64)}`,
     `lease:${"a".repeat(64)}`,
     `outcome-history-repaired:${"b".repeat(64)}`,
     `outcome-recorded:${"c".repeat(64)}`,
@@ -21445,6 +21450,276 @@ test("production task WAL cleanup preserves a swapped canonical generation", () 
       (candidate) => candidate.eventId === event.eventId,
     ).length,
     1,
+  );
+});
+
+function driftTaskManifestAuthorityGeneration(fixture) {
+  const displacedPath = path.join(
+    fixture.stateRoot,
+    `${fixture.taskId}-manifest-pre-drift.json`,
+  );
+  renameSync(fixture.paths.taskManifest, displacedPath);
+  writeFileSync(fixture.paths.taskManifest, fixture.canonicalBytes, {
+    mode: 0o600,
+  });
+  rmSync(displacedPath);
+  return fixture;
+}
+
+function strandedTaskManifestAuthorityWitnessFixture(
+  label,
+  { drift = true } = {},
+) {
+  const stateRoot = temporaryStateRoot();
+  const nowMs = Date.now();
+  const controller = actorLease(stateRoot, "freed-stability-controller", {
+    nowMs,
+  });
+  const taskId = `stranded-witness-${label}`;
+  createTask({
+    stateRoot,
+    taskId,
+    ...controller,
+    observerAuthority: "plan-only",
+    providerAuthority: "forbidden",
+    details: { behavioral: false },
+    nowMs: nowMs + 1,
+  });
+  transitionTask({
+    stateRoot,
+    taskId,
+    ...controller,
+    toState: "triaged",
+    expectedRevision: 1,
+    nowMs: nowMs + 2,
+  });
+  const paths = automationControlPaths(stateRoot);
+  const prefix = `.${path.basename(paths.taskManifest)}.authority.`;
+  const witnesses = readdirSync(paths.controlRoot).filter((entry) =>
+    entry.startsWith(prefix),
+  );
+  assert.equal(witnesses.length, 1, JSON.stringify(witnesses));
+  const witnessPath = path.join(paths.controlRoot, witnesses[0]);
+  const canonicalBytes = readFileSync(paths.taskManifest);
+  const fixture = {
+    stateRoot,
+    paths,
+    taskId,
+    witnessPath,
+    canonicalBytes,
+  };
+  return drift ? driftTaskManifestAuthorityGeneration(fixture) : fixture;
+}
+
+function acquireAuthorityWitnessRepairOwner(fixture, plan) {
+  ownerIntentsByDigest.set(plan.intentDigest, plan.intent);
+  return actorLease(fixture.stateRoot, "freed-owner", {
+    ownerTaskId: plan.taskId,
+    ownerIntentDigest: plan.intentDigest,
+  });
+}
+
+test("stranded task manifest witness planning is read-only and exact repair is audited", () => {
+  const fixture = strandedTaskManifestAuthorityWitnessFixture("success");
+  const beforePlan = {
+    control: snapshotTaskMutationState(fixture.stateRoot),
+    witness: snapshotFilesystemEntry(fixture.witnessPath),
+  };
+  const plan = planTaskManifestAuthorityWitnessRepair({
+    stateRoot: fixture.stateRoot,
+    taskId: "github-issue-1469",
+  });
+  assert.deepEqual(
+    {
+      control: snapshotTaskMutationState(fixture.stateRoot),
+      witness: snapshotFilesystemEntry(fixture.witnessPath),
+    },
+    beforePlan,
+  );
+  assert.equal(plan.action, AUTHORITY_WITNESS_REPAIR_ACTION);
+  assert.equal(plan.parameters.canonical.revision, 2);
+  assert.equal(plan.parameters.witness.predecessorRevision, 1);
+  assert.equal(plan.parameters.lineage.retired, true);
+  assert.equal(plan.parameters.witness.snapshot.filePath, fixture.witnessPath);
+  assert.deepEqual(
+    Buffer.from(plan.parameters.witness.snapshot.bytesBase64, "base64"),
+    readFileSync(fixture.witnessPath),
+  );
+  const redirectedPlan = structuredClone(plan);
+  redirectedPlan.parameters.witness.entry = path.join(
+    "..",
+    path.basename(plan.parameters.witness.entry),
+  );
+  assert.throws(
+    () =>
+      repairTaskManifestAuthorityWitness({
+        stateRoot: fixture.stateRoot,
+        taskId: plan.taskId,
+        plan: redirectedPlan,
+      }),
+    (error) =>
+      error instanceof AutomationControlError &&
+      error.code === "invalid_argument",
+  );
+
+  const owner = acquireAuthorityWitnessRepairOwner(fixture, plan);
+  assert.throws(
+    () =>
+      repairTaskManifestAuthorityWitness(
+        {
+          stateRoot: fixture.stateRoot,
+          taskId: plan.taskId,
+          plan,
+          ...owner,
+        },
+        {
+          checkpoint: (phase) => {
+            if (phase === "before-audit-event") {
+              throw new Error("audit unavailable");
+            }
+          },
+        },
+      ),
+    /audit unavailable/,
+  );
+  assert.equal(existsSync(fixture.witnessPath), true);
+  assert.equal(
+    readEvents(fixture.stateRoot).filter(
+      (event) => event.eventId === plan.parameters.eventId,
+    ).length,
+    0,
+  );
+  assert.throws(
+    () =>
+      repairTaskManifestAuthorityWitness(
+        {
+          stateRoot: fixture.stateRoot,
+          taskId: plan.taskId,
+          plan,
+          ...owner,
+        },
+        {
+          checkpoint: (phase) => {
+            if (phase === "witness-retired") throw new Error("response lost");
+          },
+        },
+      ),
+    /response lost/,
+  );
+  assert.equal(existsSync(fixture.witnessPath), false);
+  const result = repairTaskManifestAuthorityWitness({
+    stateRoot: fixture.stateRoot,
+    taskId: plan.taskId,
+    plan,
+    ...owner,
+  });
+  assert.equal(result.retired, true);
+  assert.equal(result.recovered, true);
+  assert.equal(existsSync(fixture.witnessPath), false);
+  assert.deepEqual(
+    readFileSync(fixture.paths.taskManifest),
+    fixture.canonicalBytes,
+  );
+  assert.equal(readTaskManifest({ stateRoot: fixture.stateRoot }).revision, 2);
+  const repairEvents = readEvents(fixture.stateRoot).filter(
+    (event) => event.eventId === plan.parameters.eventId,
+  );
+  assert.equal(repairEvents.length, 1);
+  assert.equal(repairEvents[0].type, "authority_witness_repair_authorized");
+  assert.equal(repairEvents[0].data.ownerIntentDigest, plan.intentDigest);
+  assert.equal(
+    readdirSync(
+      path.join(fixture.paths.controlRoot, ".authority-retirements"),
+    ).filter((entry) => entry.startsWith("current-tasks.json.")).length,
+    1,
+  );
+});
+
+test("stranded task manifest witness repair fails closed on changed generations", async (t) => {
+  for (const variant of ["canonical", "witness"]) {
+    await t.test(variant, () => {
+      const fixture = strandedTaskManifestAuthorityWitnessFixture(variant);
+      const plan = planTaskManifestAuthorityWitnessRepair({
+        stateRoot: fixture.stateRoot,
+        taskId: "github-issue-1469",
+      });
+      const owner = acquireAuthorityWitnessRepairOwner(fixture, plan);
+      if (variant === "canonical") {
+        writeFileSync(
+          fixture.paths.taskManifest,
+          Buffer.concat([fixture.canonicalBytes, Buffer.from("\n")]),
+          { mode: 0o600 },
+        );
+      } else if (variant === "witness") {
+        writeFileSync(
+          fixture.witnessPath,
+          Buffer.concat([readFileSync(fixture.witnessPath), Buffer.from("\n")]),
+          { mode: 0o600 },
+        );
+      }
+      assert.throws(
+        () =>
+          repairTaskManifestAuthorityWitness({
+            stateRoot: fixture.stateRoot,
+            taskId: plan.taskId,
+            plan,
+            ...owner,
+          }),
+        (error) =>
+          error instanceof AutomationControlError &&
+          error.code === "authority_generation_conflict",
+      );
+      assert.equal(existsSync(fixture.witnessPath), true);
+      assert.equal(
+        readEvents(fixture.stateRoot).filter(
+          (event) => event.eventId === plan.parameters.eventId,
+        ).length,
+        0,
+      );
+    });
+  }
+});
+
+test("stranded task manifest witness planning rejects a still-owned or nondrifted witness", () => {
+  const fixture = strandedTaskManifestAuthorityWitnessFixture("owned", {
+    drift: false,
+  });
+  assert.throws(
+    () =>
+      planTaskManifestAuthorityWitnessRepair({
+        stateRoot: fixture.stateRoot,
+        taskId: "github-issue-1469",
+      }),
+    (error) =>
+      error instanceof AutomationControlError &&
+      error.code === "authority_generation_conflict",
+  );
+  driftTaskManifestAuthorityGeneration(fixture);
+  const retirementDirectory = path.join(
+    fixture.paths.taskTransactions,
+    ".authority-retirements",
+  );
+  const retiredEntry = readdirSync(retirementDirectory).find((entry) =>
+    entry.startsWith("000000000002-"),
+  );
+  assert.ok(retiredEntry);
+  const marker = retiredEntry.indexOf(".json.");
+  assert.notEqual(marker, -1);
+  const activeName = retiredEntry.slice(0, marker + ".json".length);
+  writeFileSync(
+    path.join(fixture.paths.taskTransactions, activeName),
+    readFileSync(path.join(retirementDirectory, retiredEntry)),
+    { mode: 0o600 },
+  );
+  assert.throws(
+    () =>
+      planTaskManifestAuthorityWitnessRepair({
+        stateRoot: fixture.stateRoot,
+        taskId: "github-issue-1469",
+      }),
+    (error) =>
+      error instanceof AutomationControlError &&
+      error.code === "authority_generation_conflict",
   );
 });
 

--- a/scripts/lib/automation-control.mjs
+++ b/scripts/lib/automation-control.mjs
@@ -159,6 +159,11 @@ const ACTIVE_BEHAVIOR_TASK_STATES = new Set([
 ]);
 const OUTCOME_RECORD_ACTION = "outcome.record";
 const OUTCOME_RECORD_POLICY = "freed-outcome-record-v1";
+export const AUTHORITY_WITNESS_REPAIR_ACTION = "authority-witness.repair";
+export const AUTHORITY_WITNESS_REPAIR_POLICY =
+  "freed-stranded-authority-witness-repair-v1";
+const AUTHORITY_WITNESS_REPAIR_EVENT_TYPE =
+  "authority_witness_repair_authorized";
 const LEASE_TRANSACTION_SCHEMA_VERSION = 2;
 const LEASE_TRANSACTION_KIND = "lease-transaction";
 const LEASE_TRANSACTION_MAX_BYTES = 1024 * 1024;
@@ -291,6 +296,7 @@ const OUTCOME_RECORD_PARAMETER_KEYS = Object.freeze(
   ].sort(),
 );
 const RESERVED_CONTROL_EVENT_TYPES = new Set([
+  AUTHORITY_WITNESS_REPAIR_EVENT_TYPE,
   OUTCOME_LEDGER_REPAIR_EVENT_TYPE,
   "lease_acquired",
   "lease_credential_upgraded",
@@ -311,6 +317,7 @@ const RESERVED_CONTROL_EVENT_TYPES = new Set([
   "task_transitioned",
 ]);
 const RESERVED_CONTROL_EVENT_ID_PREFIXES = Object.freeze([
+  "authority-witness-repaired:",
   "lease:",
   "outcome-history-repaired:",
   "outcome-recorded:",
@@ -21388,8 +21395,7 @@ function openPinnedLeaseArchiveHelper() {
         ? {
             entryPath:
               process.env.FREED_TEST_LEASE_ARCHIVE_PYTHON_RUNTIME ?? "",
-            trustedRoot:
-              process.env.FREED_TEST_LEASE_ARCHIVE_PYTHON_ROOT ?? "",
+            trustedRoot: process.env.FREED_TEST_LEASE_ARCHIVE_PYTHON_ROOT ?? "",
             requiredUid: Number(
               process.env.FREED_TEST_LEASE_ARCHIVE_PYTHON_UID ?? Number.NaN,
             ),
@@ -21488,9 +21494,9 @@ function runLeaseArchiveHelper(
           ? LEASE_PRIVATE_BATCH_MAX_BUFFER
           : operation === "list-bounded-batch"
             ? LEASE_ARCHIVE_LIST_BATCH_MAX_BUFFER
-          : operation === "list" || operation === "list-bounded"
-            ? LEASE_ARCHIVE_LIST_MAX_BUFFER
-            : 2 * LEASE_TRANSACTION_MAX_BYTES,
+            : operation === "list" || operation === "list-bounded"
+              ? LEASE_ARCHIVE_LIST_MAX_BUFFER
+              : 2 * LEASE_TRANSACTION_MAX_BYTES,
     stdio: [
       "pipe",
       "pipe",
@@ -25831,6 +25837,59 @@ function requireCanonicalStagedControlEvent(event) {
   return event;
 }
 
+function requireCanonicalAuthorityWitnessRepairEvent(paths, event) {
+  const operationId = String(event?.data?.operationId ?? "");
+  if (
+    event?.type !== AUTHORITY_WITNESS_REPAIR_EVENT_TYPE ||
+    event?.eventId !== `authority-witness-repaired:${operationId}` ||
+    event?.actor !== "freed-owner" ||
+    event?.leaseName !== "owner-governance" ||
+    !IDENTIFIER_PATTERN.test(String(event?.taskId ?? "")) ||
+    !exactObjectKeys(event, [
+      "actor",
+      "data",
+      "eventId",
+      "leaseName",
+      "schemaVersion",
+      "taskId",
+      "ts",
+      "type",
+    ]) ||
+    !exactObjectKeys(event.data, [
+      "canonicalDigest",
+      "canonicalPath",
+      "canonicalRevision",
+      "lineageTransactionId",
+      "operationId",
+      "ownerIntentDigest",
+      "policy",
+      "witnessDigest",
+      "witnessInode",
+      "witnessPath",
+    ]) ||
+    event.data.policy !== AUTHORITY_WITNESS_REPAIR_POLICY ||
+    !SHA256_PATTERN.test(operationId) ||
+    !SHA256_PATTERN.test(String(event.data.ownerIntentDigest ?? "")) ||
+    !SHA256_PATTERN.test(String(event.data.canonicalDigest ?? "")) ||
+    !SHA256_PATTERN.test(String(event.data.witnessDigest ?? "")) ||
+    event.data.canonicalPath !== paths.taskManifest ||
+    path.dirname(String(event.data.witnessPath ?? "")) !== paths.controlRoot ||
+    !path
+      .basename(String(event.data.witnessPath ?? ""))
+      .startsWith(`.${path.basename(paths.taskManifest)}.authority.`) ||
+    !Number.isSafeInteger(event.data.canonicalRevision) ||
+    event.data.canonicalRevision < 1 ||
+    !/^\d+$/.test(String(event.data.witnessInode ?? "")) ||
+    !IDENTIFIER_PATTERN.test(String(event.data.lineageTransactionId ?? ""))
+  ) {
+    throw new AutomationControlError(
+      "authority_generation_conflict",
+      "Control event staging does not end in one exact authority witness repair authorization.",
+    );
+  }
+  return event;
+}
+
 function requireControlEventSemanticSuccessor(paths, before, after) {
   const admittedBefore = parseControlEventHistorySnapshot(before);
   const admittedAfter = parseControlEventHistorySnapshot(after);
@@ -25882,14 +25941,18 @@ function requireControlEventSemanticSuccessor(paths, before, after) {
   const outcomeReserved =
     event.type === "outcome_recorded" ||
     event.eventId.startsWith("outcome-recorded:");
-  const repairReserved =
+  const outcomeRepairReserved =
     event.type === OUTCOME_LEDGER_REPAIR_EVENT_TYPE ||
     event.eventId.startsWith("outcome-history-repaired:");
+  const authorityWitnessRepairReserved =
+    event.type === AUTHORITY_WITNESS_REPAIR_EVENT_TYPE ||
+    event.eventId.startsWith("authority-witness-repaired:");
   if (
     !leaseReserved &&
     !taskReserved &&
     !outcomeReserved &&
-    !repairReserved &&
+    !outcomeRepairReserved &&
+    !authorityWitnessRepairReserved &&
     (AUTOMATION_ACTOR_POLICIES[event.actor]?.canAppendEvent !== true ||
       !exactObjectKeys(event, [
         "actor",
@@ -25927,7 +25990,7 @@ function requireControlEventSemanticSuccessor(paths, before, after) {
       );
     }
   }
-  if (outcomeReserved || repairReserved) {
+  if (outcomeReserved || outcomeRepairReserved) {
     const outcomeHistory = inspectExactOutcomeControlHistory(
       admittedAfter.events,
       { ledgerPath: paths.outcomes, stateRoot: paths.stateRoot },
@@ -25941,6 +26004,9 @@ function requireControlEventSemanticSuccessor(paths, before, after) {
         "Control event staging does not end in one exact outcome event.",
       );
     }
+  }
+  if (authorityWitnessRepairReserved) {
+    requireCanonicalAuthorityWitnessRepairEvent(paths, event);
   }
   return Object.freeze({
     operationId: `control-event:${event.eventId}`,
@@ -26355,10 +26421,8 @@ function exactPendingTaskTransactionTailMatches({
       events.slice(0, transactionEventIndex),
       manifest,
     ).healthy &&
-    inspectExactTaskManifestHistoryParity(
-      events,
-      transaction.targetManifest,
-    ).healthy
+    inspectExactTaskManifestHistoryParity(events, transaction.targetManifest)
+      .healthy
   );
 }
 
@@ -26424,8 +26488,10 @@ function requireTaskManifestSemanticSuccessor(
       return false;
     }
     if (eventIndexes.length === 1) {
-      const currentHistoryHealthy =
-        inspectExactTaskManifestHistoryParity(events, afterManifest).healthy;
+      const currentHistoryHealthy = inspectExactTaskManifestHistoryParity(
+        events,
+        afterManifest,
+      ).healthy;
       if (
         !currentHistoryHealthy &&
         !exactPendingTaskTransactionTailMatches({
@@ -26484,6 +26550,718 @@ function admitTaskManifestAuthorityStage(
       }),
     label: "Current task manifest",
   });
+}
+
+function authorityWitnessRepairSnapshotDescriptor(
+  snapshot,
+  { includeBytes = false } = {},
+) {
+  if (snapshot?.missing !== false || snapshot.identity === null) {
+    throw new AutomationControlError(
+      "authority_generation_conflict",
+      "Authority witness repair requires one present exact file generation.",
+    );
+  }
+  const descriptor = {
+    filePath: snapshot.filePath,
+    privateRoot: snapshot.privateRoot,
+    digest: digestBytes(snapshot.bytes),
+    size: snapshot.bytes.length,
+    identity: structuredClone(snapshot.identity),
+    directoryIdentity: structuredClone(snapshot.directoryIdentity),
+  };
+  if (includeBytes) descriptor.bytesBase64 = snapshot.bytes.toString("base64");
+  return Object.freeze(descriptor);
+}
+
+function requireAuthorityWitnessRepairSnapshotDescriptor(
+  value,
+  label,
+  { includeBytes = false } = {},
+) {
+  const expectedKeys = [
+    "digest",
+    "directoryIdentity",
+    "filePath",
+    "identity",
+    "privateRoot",
+    "size",
+    ...(includeBytes ? ["bytesBase64"] : []),
+  ];
+  if (
+    !exactObjectKeys(value, expectedKeys) ||
+    typeof value.filePath !== "string" ||
+    path.resolve(value.filePath) !== value.filePath ||
+    typeof value.privateRoot !== "string" ||
+    path.resolve(value.privateRoot) !== value.privateRoot ||
+    !SHA256_PATTERN.test(String(value.digest ?? "")) ||
+    !Number.isSafeInteger(value.size) ||
+    value.size < 0 ||
+    value.size > TASK_CONTROL_FILE_MAX_BYTES ||
+    !exactObjectKeys(value.identity, [
+      "ctimeMs",
+      "ctimeNs",
+      "dev",
+      "gid",
+      "ino",
+      "mode",
+      "mtimeMs",
+      "mtimeNs",
+      "nlink",
+      "size",
+      "uid",
+    ]) ||
+    !exactObjectKeys(value.directoryIdentity, ["dev", "ino", "mode", "uid"]) ||
+    !/^\d+$/.test(String(value.identity.dev ?? "")) ||
+    !/^\d+$/.test(String(value.identity.ino ?? "")) ||
+    !/^\d+$/.test(String(value.identity.mtimeNs ?? "")) ||
+    !/^\d+$/.test(String(value.identity.ctimeNs ?? "")) ||
+    Number(value.identity.mode) !== 0o100600 ||
+    Number(value.identity.nlink) !== 1 ||
+    Number(value.identity.size) !== value.size ||
+    !/^\d+$/.test(String(value.directoryIdentity.dev ?? "")) ||
+    !/^\d+$/.test(String(value.directoryIdentity.ino ?? "")) ||
+    Number(value.directoryIdentity.mode) !== 0o40700
+  ) {
+    throw new AutomationControlError(
+      "invalid_argument",
+      `${label} is not one exact private authority generation.`,
+    );
+  }
+  if (includeBytes) {
+    if (typeof value.bytesBase64 !== "string") {
+      throw new AutomationControlError(
+        "invalid_argument",
+        `${label} is missing its exact bytes.`,
+      );
+    }
+    const bytes = Buffer.from(value.bytesBase64, "base64");
+    if (
+      bytes.toString("base64") !== value.bytesBase64 ||
+      bytes.length !== value.size ||
+      digestBytes(bytes) !== value.digest
+    ) {
+      throw new AutomationControlError(
+        "invalid_argument",
+        `${label} bytes do not match its immutable descriptor.`,
+      );
+    }
+  }
+  return value;
+}
+
+function authorityWitnessRepairSnapshotMatches(snapshot, descriptor) {
+  return (
+    snapshot?.missing === false &&
+    snapshot.filePath === descriptor.filePath &&
+    snapshot.privateRoot === descriptor.privateRoot &&
+    snapshot.bytes.length === descriptor.size &&
+    digestBytes(snapshot.bytes) === descriptor.digest &&
+    privateFileIdentityMatches(snapshot.identity, descriptor.identity) &&
+    automationAuthorityDirectoryIdentityMatches(
+      snapshot.directoryIdentity,
+      descriptor.directoryIdentity,
+    )
+  );
+}
+
+function authorityWitnessRepairOperationSeed(taskId, parameters) {
+  const {
+    eventId: _eventId,
+    operationId: _operationId,
+    ...stable
+  } = parameters;
+  return {
+    purpose: AUTHORITY_WITNESS_REPAIR_POLICY,
+    taskId,
+    parameters: stable,
+  };
+}
+
+function readStrandedTaskManifestAuthorityWitness(paths) {
+  const current = readAutomationAuthorityFileSnapshot(paths.taskManifest, {
+    allowEmpty: false,
+    privateRoot: paths.controlRoot,
+    maxBytes: TASK_CONTROL_FILE_MAX_BYTES,
+    allowedModes: [0o600],
+    label: "Current task manifest repair canonical generation",
+    invalidCode: "authority_generation_conflict",
+  });
+  const currentManifest = parseTaskManifestAuthoritySnapshot(
+    current,
+    "Current task manifest repair canonical generation",
+  );
+  if (currentManifest === null) {
+    throw new AutomationControlError(
+      "authority_generation_conflict",
+      "Current task manifest repair requires one canonical manifest.",
+    );
+  }
+
+  const directory = openPinnedLeaseArchiveDirectory(
+    paths.controlRoot,
+    "Current task manifest repair authority parent directory",
+  );
+  let stageEntry;
+  let stage;
+  try {
+    const entries = listAutomationAuthorityStages(
+      paths.taskManifest,
+      openPinnedLeaseArchiveHelper(),
+      directory,
+    );
+    if (entries.length !== 1 || entries[0].kind !== "ready") {
+      throw new AutomationControlError(
+        "authority_generation_conflict",
+        "Current task manifest repair requires one complete stranded ready witness.",
+        { witnesses: entries.length },
+      );
+    }
+    [stageEntry] = entries;
+    stage = readAutomationAuthorityStage(
+      path.join(paths.controlRoot, stageEntry.entry),
+      {
+        privateRoot: paths.controlRoot,
+        maxBytes: TASK_CONTROL_FILE_MAX_BYTES,
+        allowedModes: [0o600],
+        label: "Current task manifest stranded authority witness",
+      },
+    );
+    requireAutomationAuthoritySnapshotDirectory(
+      stage,
+      directory,
+      "Current task manifest stranded authority witness",
+    );
+    if (stage.missing) {
+      throw new AutomationControlError(
+        "authority_generation_conflict",
+        "Current task manifest stranded authority witness disappeared during planning.",
+      );
+    }
+  } finally {
+    closeSync(directory.descriptor);
+  }
+
+  const predecessorManifest = parseTaskManifestAuthoritySnapshot(
+    stage,
+    "Current task manifest stranded authority witness",
+  );
+  if (
+    predecessorManifest === null ||
+    predecessorManifest.revision + 1 !== currentManifest.revision
+  ) {
+    throw new AutomationControlError(
+      "authority_generation_conflict",
+      "Current task manifest witness is not the exact prior semantic revision.",
+    );
+  }
+  const semantic = requireTaskManifestSemanticSuccessor(paths, stage, current);
+  const currentStableDigest =
+    automationAuthorityStableGenerationDigest(current);
+  if (stageEntry.successorStableDigest === currentStableDigest) {
+    throw new AutomationControlError(
+      "authority_generation_conflict",
+      "Current task manifest witness is not an exact stranded successor-digest drift.",
+    );
+  }
+  const activeOwners = readTaskManifestLineageTransactions(
+    paths,
+    currentManifest.revision,
+    { includeRetired: false },
+  ).filter(
+    ({ transaction }) =>
+      transaction.transactionId === semantic.transaction.transactionId,
+  );
+  if (activeOwners.length !== 0) {
+    throw new AutomationControlError(
+      "authority_generation_conflict",
+      "Current task manifest witness still has an active owning transaction.",
+      { activeOwners: activeOwners.length },
+    );
+  }
+  return Object.freeze({
+    current,
+    currentManifest,
+    predecessorManifest,
+    semantic,
+    stage,
+    stageEntry,
+  });
+}
+
+export function planTaskManifestAuthorityWitnessRepair({ stateRoot, taskId }) {
+  requireIdentifier(taskId, "taskId");
+  const paths = automationControlPaths(stateRoot);
+  const cutover = requireAutomationKernelGuardCutover(paths);
+  admitControlEventAuthorityStage(paths);
+  const eventHistory = readControlEventHistorySnapshot(paths.events);
+  const candidate = readStrandedTaskManifestAuthorityWitness(paths);
+  const parity = inspectExactTaskManifestHistoryParity(
+    eventHistory.events,
+    candidate.currentManifest,
+  );
+  if (!parity.healthy) {
+    throw new AutomationControlError(
+      "authority_generation_conflict",
+      "Current task manifest repair requires healthy exact event-history parity.",
+      { issues: parity.issues },
+    );
+  }
+  const parametersWithoutOperation = {
+    schemaVersion: 1,
+    policy: AUTHORITY_WITNESS_REPAIR_POLICY,
+    stateRoot: paths.stateRoot,
+    filesystemType: cutover.receipt?.filesystemType ?? null,
+    canonical: {
+      revision: candidate.currentManifest.revision,
+      snapshot: authorityWitnessRepairSnapshotDescriptor(candidate.current),
+    },
+    witness: {
+      entry: candidate.stageEntry.entry,
+      namespaceDigest: candidate.stageEntry.namespaceDigest,
+      successorStableDigest: candidate.stageEntry.successorStableDigest,
+      predecessorRevision: candidate.predecessorManifest.revision,
+      snapshot: authorityWitnessRepairSnapshotDescriptor(candidate.stage, {
+        includeBytes: true,
+      }),
+    },
+    eventHistory: {
+      digest: digestBytes(eventHistory.bytes),
+      size: eventHistory.bytes.length,
+      recordCount: eventHistory.recordCount,
+      snapshot: authorityWitnessRepairSnapshotDescriptor(eventHistory),
+    },
+    lineage: {
+      transactionId: candidate.semantic.transaction.transactionId,
+      operationId: candidate.semantic.operationId,
+      eventId: candidate.semantic.transaction.event.eventId,
+      taskId: candidate.semantic.transaction.event.taskId,
+      targetRevision: candidate.semantic.transaction.targetManifest.revision,
+      retired: true,
+    },
+  };
+  const operationId = canonicalLeaseRequestDigest(
+    authorityWitnessRepairOperationSeed(taskId, parametersWithoutOperation),
+  );
+  const parameters = Object.freeze({
+    ...parametersWithoutOperation,
+    operationId,
+    eventId: `authority-witness-repaired:${operationId}`,
+  });
+  const intent = Object.freeze({
+    schemaVersion: OWNER_CAPABILITY_SCHEMA_VERSION,
+    action: AUTHORITY_WITNESS_REPAIR_ACTION,
+    taskId,
+    parameters,
+  });
+  const intentDigest = ownerGovernanceIntentDigest(intent);
+
+  const currentAfter = readAutomationAuthorityFileSnapshot(paths.taskManifest, {
+    allowEmpty: false,
+    privateRoot: paths.controlRoot,
+    maxBytes: TASK_CONTROL_FILE_MAX_BYTES,
+    allowedModes: [0o600],
+    label: "Current task manifest repair canonical generation",
+    invalidCode: "authority_generation_conflict",
+  });
+  const stageAfter = readAutomationAuthorityStage(
+    path.join(paths.controlRoot, candidate.stageEntry.entry),
+    {
+      privateRoot: paths.controlRoot,
+      maxBytes: TASK_CONTROL_FILE_MAX_BYTES,
+      allowedModes: [0o600],
+      label: "Current task manifest stranded authority witness",
+    },
+  );
+  const eventsAfter = readControlEventHistorySnapshot(paths.events);
+  if (
+    !automationAuthoritySnapshotMatches(currentAfter, candidate.current) ||
+    !automationAuthoritySnapshotMatches(stageAfter, candidate.stage) ||
+    !automationAuthoritySnapshotMatches(eventsAfter, eventHistory)
+  ) {
+    throw new AutomationControlError(
+      "authority_generation_conflict",
+      "Authority witness repair inputs changed during read-only planning.",
+    );
+  }
+  return Object.freeze({
+    schemaVersion: 1,
+    action: AUTHORITY_WITNESS_REPAIR_ACTION,
+    taskId,
+    parameters,
+    intent,
+    intentDigest,
+  });
+}
+
+function requireTaskManifestAuthorityWitnessRepairPlan(plan, taskId, paths) {
+  if (
+    !exactObjectKeys(plan, [
+      "action",
+      "intent",
+      "intentDigest",
+      "parameters",
+      "schemaVersion",
+      "taskId",
+    ]) ||
+    plan.schemaVersion !== 1 ||
+    plan.action !== AUTHORITY_WITNESS_REPAIR_ACTION ||
+    plan.taskId !== taskId ||
+    !SHA256_PATTERN.test(String(plan.intentDigest ?? ""))
+  ) {
+    throw new AutomationControlError(
+      "invalid_argument",
+      "Authority witness repair plan has an invalid canonical envelope.",
+    );
+  }
+  const parameters = plan.parameters;
+  if (
+    !exactObjectKeys(parameters, [
+      "canonical",
+      "eventHistory",
+      "eventId",
+      "filesystemType",
+      "lineage",
+      "operationId",
+      "policy",
+      "schemaVersion",
+      "stateRoot",
+      "witness",
+    ]) ||
+    parameters.schemaVersion !== 1 ||
+    parameters.policy !== AUTHORITY_WITNESS_REPAIR_POLICY ||
+    parameters.stateRoot !== paths.stateRoot ||
+    !(
+      parameters.filesystemType === null ||
+      (typeof parameters.filesystemType === "string" &&
+        parameters.filesystemType.length > 0)
+    ) ||
+    !SHA256_PATTERN.test(String(parameters.operationId ?? "")) ||
+    parameters.eventId !==
+      `authority-witness-repaired:${parameters.operationId}` ||
+    !Number.isSafeInteger(parameters.canonical?.revision) ||
+    !Number.isSafeInteger(parameters.witness?.predecessorRevision) ||
+    parameters.witness.predecessorRevision + 1 !==
+      parameters.canonical.revision ||
+    !exactObjectKeys(parameters.canonical, ["revision", "snapshot"]) ||
+    !exactObjectKeys(parameters.witness, [
+      "entry",
+      "namespaceDigest",
+      "predecessorRevision",
+      "snapshot",
+      "successorStableDigest",
+    ]) ||
+    !exactObjectKeys(parameters.eventHistory, [
+      "digest",
+      "recordCount",
+      "size",
+      "snapshot",
+    ]) ||
+    !exactObjectKeys(parameters.lineage, [
+      "eventId",
+      "operationId",
+      "retired",
+      "targetRevision",
+      "taskId",
+      "transactionId",
+    ]) ||
+    parameters.lineage.retired !== true ||
+    parameters.lineage.targetRevision !== parameters.canonical.revision ||
+    !IDENTIFIER_PATTERN.test(String(parameters.lineage.transactionId ?? "")) ||
+    !IDENTIFIER_PATTERN.test(String(parameters.lineage.eventId ?? "")) ||
+    !IDENTIFIER_PATTERN.test(String(parameters.lineage.taskId ?? "")) ||
+    parameters.lineage.operationId !==
+      `task-manifest:${parameters.lineage.transactionId}` ||
+    !SHA256_PATTERN.test(String(parameters.eventHistory.digest ?? "")) ||
+    parameters.eventHistory.size !== parameters.eventHistory.snapshot?.size ||
+    parameters.eventHistory.digest !==
+      parameters.eventHistory.snapshot?.digest ||
+    !Number.isSafeInteger(parameters.eventHistory.recordCount) ||
+    parameters.eventHistory.recordCount < 0 ||
+    parameters.eventHistory.recordCount > CONTROL_EVENT_HISTORY_MAX_RECORDS ||
+    !SHA256_PATTERN.test(String(parameters.witness.namespaceDigest ?? "")) ||
+    !SHA256_PATTERN.test(
+      String(parameters.witness.successorStableDigest ?? ""),
+    ) ||
+    parameters.witness.entry !==
+      `.${path.basename(paths.taskManifest)}.authority.${parameters.witness.namespaceDigest}.${parameters.witness.successorStableDigest}.tmp` ||
+    path.join(paths.controlRoot, parameters.witness.entry) !==
+      parameters.witness.snapshot?.filePath ||
+    parameters.canonical.snapshot?.filePath !== paths.taskManifest ||
+    parameters.eventHistory.snapshot?.filePath !== paths.events
+  ) {
+    throw new AutomationControlError(
+      "invalid_argument",
+      "Authority witness repair plan parameters are not canonical.",
+    );
+  }
+  requireAuthorityWitnessRepairSnapshotDescriptor(
+    parameters.canonical.snapshot,
+    "Authority witness repair canonical snapshot",
+  );
+  requireAuthorityWitnessRepairSnapshotDescriptor(
+    parameters.witness.snapshot,
+    "Authority witness repair witness snapshot",
+    { includeBytes: true },
+  );
+  requireAuthorityWitnessRepairSnapshotDescriptor(
+    parameters.eventHistory.snapshot,
+    "Authority witness repair event-history snapshot",
+  );
+  const expectedOperationId = canonicalLeaseRequestDigest(
+    authorityWitnessRepairOperationSeed(taskId, parameters),
+  );
+  const expectedIntent = {
+    schemaVersion: OWNER_CAPABILITY_SCHEMA_VERSION,
+    action: AUTHORITY_WITNESS_REPAIR_ACTION,
+    taskId,
+    parameters,
+  };
+  if (
+    parameters.operationId !== expectedOperationId ||
+    !canonicalValuesEqual(plan.intent, expectedIntent) ||
+    plan.intentDigest !== ownerGovernanceIntentDigest(expectedIntent)
+  ) {
+    throw new AutomationControlError(
+      "owner_intent_mismatch",
+      "Authority witness repair plan does not match its exact owner intent.",
+    );
+  }
+  return parameters;
+}
+
+function plannedAuthorityWitnessSnapshot(parameters) {
+  const descriptor = parameters.witness.snapshot;
+  return Object.freeze({
+    filePath: descriptor.filePath,
+    privateRoot: descriptor.privateRoot,
+    missing: false,
+    bytes: Buffer.from(descriptor.bytesBase64, "base64"),
+    identity: Object.freeze(structuredClone(descriptor.identity)),
+    directoryIdentity: Object.freeze(
+      structuredClone(descriptor.directoryIdentity),
+    ),
+  });
+}
+
+export function repairTaskManifestAuthorityWitness(
+  { stateRoot, taskId, plan, actor, leaseName, leaseToken },
+  { checkpoint = () => {} } = {},
+) {
+  requireIdentifier(taskId, "taskId");
+  if (typeof checkpoint !== "function") {
+    throw new AutomationControlError(
+      "invalid_argument",
+      "Authority witness repair checkpoint must be a function.",
+    );
+  }
+  const paths = automationControlPaths(stateRoot);
+  requireAutomationKernelGuardCutover(paths);
+  const parameters = requireTaskManifestAuthorityWitnessRepairPlan(
+    plan,
+    taskId,
+    paths,
+  );
+  const authority = {
+    stateRoot: paths.stateRoot,
+    actor,
+    leaseName,
+    leaseToken,
+    taskId,
+    ownerIntentDigest: plan.intentDigest,
+  };
+  return withMutationLeaseAuthority(authority, (authorityContext) =>
+    withFilesystemGuard(paths, "tasks", () => {
+      const authorize = () => authorityContext.reauthorize();
+      authorize();
+      const current = readAutomationAuthorityFileSnapshot(paths.taskManifest, {
+        allowEmpty: false,
+        privateRoot: paths.controlRoot,
+        maxBytes: TASK_CONTROL_FILE_MAX_BYTES,
+        allowedModes: [0o600],
+        label: "Current task manifest repair canonical generation",
+        invalidCode: "authority_generation_conflict",
+      });
+      if (
+        !authorityWitnessRepairSnapshotMatches(
+          current,
+          parameters.canonical.snapshot,
+        )
+      ) {
+        throw new AutomationControlError(
+          "authority_generation_conflict",
+          "Current task manifest changed after authority witness planning.",
+        );
+      }
+      const currentManifest = parseTaskManifestAuthoritySnapshot(
+        current,
+        "Current task manifest repair canonical generation",
+      );
+      const events = readControlEventHistorySnapshot(paths.events);
+      if (
+        events.bytes.length < parameters.eventHistory.size ||
+        digestBytes(events.bytes.subarray(0, parameters.eventHistory.size)) !==
+          parameters.eventHistory.digest ||
+        !inspectExactTaskManifestHistoryParity(events.events, currentManifest)
+          .healthy
+      ) {
+        throw new AutomationControlError(
+          "authority_generation_conflict",
+          "Authority witness repair event history changed outside append-only healthy parity.",
+        );
+      }
+
+      const helper = openPinnedLeaseArchiveHelper();
+      const directory = openPinnedLeaseArchiveDirectory(
+        paths.controlRoot,
+        "Current task manifest repair authority parent directory",
+      );
+      let stagePresent = false;
+      try {
+        const entries = listAutomationAuthorityStages(
+          paths.taskManifest,
+          helper,
+          directory,
+        );
+        if (
+          entries.length > 1 ||
+          (entries.length === 1 &&
+            entries[0].entry !== parameters.witness.entry)
+        ) {
+          throw new AutomationControlError(
+            "authority_generation_conflict",
+            "Current task manifest authority witnesses changed after planning.",
+          );
+        }
+        if (entries.length === 1) {
+          const stage = readAutomationAuthorityStage(
+            path.join(paths.controlRoot, entries[0].entry),
+            {
+              privateRoot: paths.controlRoot,
+              maxBytes: TASK_CONTROL_FILE_MAX_BYTES,
+              allowedModes: [0o600],
+              label: "Current task manifest stranded authority witness",
+            },
+          );
+          requireAutomationAuthoritySnapshotDirectory(
+            stage,
+            directory,
+            "Current task manifest stranded authority witness",
+          );
+          if (
+            !authorityWitnessRepairSnapshotMatches(
+              stage,
+              parameters.witness.snapshot,
+            )
+          ) {
+            throw new AutomationControlError(
+              "authority_generation_conflict",
+              "Current task manifest authority witness changed after planning.",
+            );
+          }
+          const semantic = requireTaskManifestSemanticSuccessor(
+            paths,
+            stage,
+            current,
+          );
+          if (semantic.operationId !== parameters.lineage.operationId) {
+            throw new AutomationControlError(
+              "authority_generation_conflict",
+              "Current task manifest authority witness changed semantic lineage.",
+            );
+          }
+          const activeOwners = readTaskManifestLineageTransactions(
+            paths,
+            currentManifest.revision,
+            { includeRetired: false },
+          ).filter(
+            ({ transaction }) =>
+              transaction.transactionId === parameters.lineage.transactionId,
+          );
+          if (activeOwners.length !== 0) {
+            throw new AutomationControlError(
+              "authority_generation_conflict",
+              "Current task manifest authority witness regained an active owner.",
+            );
+          }
+          stagePresent = true;
+        }
+      } finally {
+        closeSync(directory.descriptor);
+      }
+
+      const buildAuditEvent = (timestamp) => ({
+        schemaVersion: AUTOMATION_CONTROL_SCHEMA_VERSION,
+        eventId: parameters.eventId,
+        type: AUTHORITY_WITNESS_REPAIR_EVENT_TYPE,
+        ts: timestamp,
+        actor,
+        taskId,
+        leaseName,
+        data: {
+          policy: AUTHORITY_WITNESS_REPAIR_POLICY,
+          operationId: parameters.operationId,
+          ownerIntentDigest: plan.intentDigest,
+          canonicalPath: parameters.canonical.snapshot.filePath,
+          canonicalDigest: parameters.canonical.snapshot.digest,
+          canonicalRevision: parameters.canonical.revision,
+          witnessPath: parameters.witness.snapshot.filePath,
+          witnessDigest: parameters.witness.snapshot.digest,
+          witnessInode: parameters.witness.snapshot.identity.ino,
+          lineageTransactionId: parameters.lineage.transactionId,
+        },
+      });
+      authorize();
+      checkpoint("before-audit-event");
+      appendDeterministicEventLine(paths, parameters.eventId, buildAuditEvent, {
+        beforeAccess: authorize,
+      });
+      checkpoint("audit-event-appended");
+      authorize();
+      const retirement = removeAutomationAuthorityFile({
+        filePath: parameters.witness.snapshot.filePath,
+        snapshot: plannedAuthorityWitnessSnapshot(parameters),
+        operationId: `authority-witness-repair:${parameters.operationId}`,
+        privateRoot: paths.controlRoot,
+        maxBytes: TASK_CONTROL_FILE_MAX_BYTES,
+        allowedModes: [0o600],
+        label: "Current task manifest stranded authority witness",
+        beforeRemove: () => {
+          authorize();
+          checkpoint("before-witness-retirement");
+        },
+        retirementBasename: path.basename(paths.taskManifest),
+        rawSource: true,
+      });
+      checkpoint("witness-retired");
+      const afterDirectory = openPinnedLeaseArchiveDirectory(
+        paths.controlRoot,
+        "Current task manifest repair authority parent directory",
+      );
+      try {
+        if (
+          listAutomationAuthorityStages(
+            paths.taskManifest,
+            openPinnedLeaseArchiveHelper(),
+            afterDirectory,
+          ).length !== 0
+        ) {
+          throw new AutomationControlError(
+            "authority_generation_conflict",
+            "Current task manifest authority witness survived repair.",
+          );
+        }
+      } finally {
+        closeSync(afterDirectory.descriptor);
+      }
+      return Object.freeze({
+        operationId: parameters.operationId,
+        eventId: parameters.eventId,
+        retired: retirement.removed === true,
+        recovered: retirement.recovered === true || !stagePresent,
+      });
+    }),
+  );
 }
 
 function readAutomationAuthorityRetirementInventory(helper, directory, label) {
@@ -27573,10 +28351,7 @@ export function retireOutcomeLedgerAuthorityStageForRepair({
     label: "Outcome ledger repair canonical source",
     invalidCode: "authority_generation_conflict",
   });
-  if (
-    current.missing ||
-    !current.bytes.equals(replacementBytes)
-  ) {
+  if (current.missing || !current.bytes.equals(replacementBytes)) {
     throw new AutomationControlError(
       "authority_generation_conflict",
       "Outcome ledger repair canonical source changed before authority retirement.",
@@ -27643,8 +28418,8 @@ export function retireOutcomeLedgerAuthorityStageForRepair({
       rawSource: true,
     });
     if (
-      listAutomationAuthorityStages(paths.outcomes, helper, directory).length !==
-      0
+      listAutomationAuthorityStages(paths.outcomes, helper, directory)
+        .length !== 0
     ) {
       throw new AutomationControlError(
         "authority_generation_conflict",
@@ -28434,7 +29209,9 @@ export function inspectLeaseCleanupArchiveCapacity(
       (candidate) => candidate.path === stateArchiveDirectory,
     );
     const stateArchiveNamePattern = /^[0-9a-f]{64}\.[0-9a-f]{64}\.lease$/;
-    const stateEntriesBefore = beforeEntriesByPath.get(stateArchiveBinding.path);
+    const stateEntriesBefore = beforeEntriesByPath.get(
+      stateArchiveBinding.path,
+    );
     for (const entry of stateEntriesBefore) {
       if (!stateArchiveNamePattern.test(entry)) {
         throw new AutomationControlError(
@@ -28460,7 +29237,9 @@ export function inspectLeaseCleanupArchiveCapacity(
       capacityBindings,
     );
     for (const [index, binding] of capacityBindings.entries()) {
-      if (beforeListings[index].join("\0") !== afterListings[index].join("\0")) {
+      if (
+        beforeListings[index].join("\0") !== afterListings[index].join("\0")
+      ) {
         throw new AutomationControlError(
           "lease_archive_capacity_invalid",
           `${binding.label} changed during capacity accounting.`,


### PR DESCRIPTION
(AI Generated).

## Summary
- Promote all three product changes merged after the v26.8.1405 reverse integration: authority witness recovery, provider resume scheduling, and native Drive multipart serialization.
- Keep website-owned changes on the separate www lane.

## Testing
- Exact-head validation and CodeQL passed for each source PR; production release validation will run on the promoted tree.

## Provider Review
- Status: Provider authority is validated for ready publication.
- Review action: none required. The provider-risk artifact records the behavior authority decision; this exact provider subdiff is the audit subject.
- Provider subdiff: `fb8911613b543a955eaeec9baed7c8c9e89909f4`
- Publication does not authorize new live provider traffic. Gate 1 behavior approval still applies when observable behavior changes.
- Provider review task: `provider-sync-cadence-v2`
- Provider review decision: `behavior_approved`
- Provider review artifact: `2b731340a42180bba616111e0e025feaa07950c1698d2fb6d9b7b24ca6b0e294`
- Providers: facebook, instagram, linkedin, medium, other, substack, x, youtube
- Observable behavior: Existing automatic X, Facebook, Instagram, LinkedIn, YouTube, Substack, Medium, and RSS contact opportunities move from coupled legacy timers to independent device-local durable schedules. One automatic social provider may run at a time. Manual and post-login settlement resample the next automatic deadline. RSS remains separate. Existing provider request, navigation, extraction, and logical capture behavior is unchanged.
- Fingerprinting risk: Providers can observe changed contact timing and cadence even though the implementation adds no requests, pages, navigation, scrolling, clicks, cookies, headers, media loads, or extraction behavior. Independent randomized schedules reduce synchronized patterns but do not make automated traffic unobservable or human-indistinguishable.
- Lowest profile alternative: Disable global automatic provider sync and use manual Sync Now only. Passive local evidence collection remains available without provider traffic.

Files bound into this provider review:
- `packages/desktop/src/App.tsx`
- `packages/desktop/src/lib/google-drive.ts`
- `packages/desktop/src/lib/provider-sync-scheduler.ts`