### PR TITLE
fix: prevent Drive sync lifecycle stalls

### DIFF
--- a/packages/desktop/src/lib/library-core-cloud-sync.test.ts
+++ b/packages/desktop/src/lib/library-core-cloud-sync.test.ts
@@ -56,7 +56,8 @@ const mocks = vi.hoisted(() => ({
       actor_id: "12".repeat(32),
       actor_public_key: "23".repeat(32),
       enrollment_operation_id: "actor-enrolled:fixture",
-      enrollment_certificate_digest: "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+      enrollment_certificate_digest:
+        "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
       canonical_enrollment_certificate_json: "{}",
       actor_chain_genesis: "45".repeat(32),
     },
@@ -86,17 +87,19 @@ vi.mock("./sqlite-library", () => ({
   clearSqliteLibrary: mocks.clearSqliteLibrary,
   createSqliteLibraryBackup: mocks.createBackup,
   finalizePortableSqliteLibraryImport: mocks.finalizePortableImport,
-  listSqliteLibraryActorEnrollments: vi.fn(async () => [{
-    actor_id: mocks.bootstrapAuthority.actor.actor_id,
-    accepted_sequence: 0,
-    accepted_operation_id: null,
-    accepted_chain_digest: mocks.bootstrapAuthority.actor.actor_chain_genesis,
-    enrollment_certificate_digest:
-      mocks.bootstrapAuthority.actor.enrollment_certificate_digest,
-    retired: false,
-    retirement_certificate_digest: null,
-    canonical_enrollment_certificate_json: "{}",
-  }]),
+  listSqliteLibraryActorEnrollments: vi.fn(async () => [
+    {
+      actor_id: mocks.bootstrapAuthority.actor.actor_id,
+      accepted_sequence: 0,
+      accepted_operation_id: null,
+      accepted_chain_digest: mocks.bootstrapAuthority.actor.actor_chain_genesis,
+      enrollment_certificate_digest:
+        mocks.bootstrapAuthority.actor.enrollment_certificate_digest,
+      retired: false,
+      retirement_certificate_digest: null,
+      canonical_enrollment_certificate_json: "{}",
+    },
+  ]),
   readSqliteLibrarySyncDescriptor: mocks.readDescriptor,
   readSqliteLibrarySyncPage: mocks.readPage,
   readPwaIntentResultOutbox: mocks.readIntentResults,
@@ -107,10 +110,13 @@ vi.mock("./sqlite-library", () => ({
 }));
 
 vi.mock("@freed/sync/cloud/library-core", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@freed/sync/cloud/library-core")>();
+  const actual =
+    await importOriginal<typeof import("@freed/sync/cloud/library-core")>();
   return {
     ...actual,
-    discoverGoogleDriveLibraryCoreActorEnrollmentRequestsV1: vi.fn(async () => []),
+    discoverGoogleDriveLibraryCoreActorEnrollmentRequestsV1: vi.fn(
+      async () => [],
+    ),
     provisionGoogleDriveLibraryCoreControlV1: vi.fn(async () => ({
       controlFileId: "control-1",
       created: true,
@@ -118,8 +124,8 @@ vi.mock("@freed/sync/cloud/library-core", async (importOriginal) => {
     createGoogleDriveLibraryCoreAdapterV1: vi.fn(() => ({
       readControl: vi.fn(async () => mocks.controlRead),
       putImmutable: vi.fn(async () => ({ transportObjectId: "immutable-1" })),
-      verifyImmutable: vi.fn(async (reference: { descriptor: unknown }) =>
-        reference.descriptor
+      verifyImmutable: vi.fn(
+        async (reference: { descriptor: unknown }) => reference.descriptor,
       ),
     })),
     publishLibraryCorePortableCheckpointV1: mocks.publish.mockImplementation(
@@ -139,98 +145,111 @@ vi.mock("@freed/sync/cloud/library-core", async (importOriginal) => {
         };
       },
     ),
-    importLibraryCorePortableCheckpointV1: mocks.importCheckpoint.mockImplementation(
-      async (request: Record<string, unknown>) => {
-        const writer = request.writer as {
-          beginImport(input: unknown): Promise<unknown>;
-          appendPage(pageIndex: number, records: readonly unknown[]): Promise<void>;
-          finalizeImport(input: unknown): Promise<unknown>;
-        };
-        const header = {
-          kind: "logical_checkpoint_header",
-          format: "freed_logical_checkpoint_v1",
-          library_id: String(request.libraryId),
-          epoch: 2,
-          epoch_id: String(request.storageEpoch),
-          schema_version: 2,
-          field_registry_version: 1,
-          canonical_codec_version: 1,
-          anchor_kind: "accepted_authority",
-          accepted_authority: null,
-          source_transition_digest: null,
-          source_manifest_digest: null,
-          transition_candidate_anchor: null,
-          promoted_receipt_digests: [],
-          materializer_position: {
-            frontier_digest: "ef".repeat(32),
-            ingest_sequence: 9,
-            materialized_digest: "34".repeat(32),
-          },
-          collection_counts: {
-            accepted_frontier: 0,
-            quarantined_frontier: 0,
-            materialized_rows: 3,
-            field_clocks: 0,
-            relationships: 0,
-            tombstones: 0,
-            actor_states: 1,
-            receipt_records: 0,
-            blob_roots: 0,
-            excluded_registry_keys: 0,
-          },
-        };
-        await writer.beginImport({ manifest: {}, manifestReference: {} });
-        await writer.appendPage(0, [
-          header,
-          {
-            kind: "logical_checkpoint_entry",
-            collection: "materialized_rows",
-            ordinal: 0,
-            value: {
-              primary_key: "shell",
-              registry_key: "00_library_shell",
-              row: { accounts: {}, feeds: {}, persons: {} },
+    importLibraryCorePortableCheckpointV1:
+      mocks.importCheckpoint.mockImplementation(
+        async (request: Record<string, unknown>) => {
+          const writer = request.writer as {
+            beginImport(input: unknown): Promise<unknown>;
+            appendPage(
+              pageIndex: number,
+              records: readonly unknown[],
+            ): Promise<void>;
+            finalizeImport(input: unknown): Promise<unknown>;
+          };
+          const header = {
+            kind: "logical_checkpoint_header",
+            format: "freed_logical_checkpoint_v1",
+            library_id: String(request.libraryId),
+            epoch: 2,
+            epoch_id: String(request.storageEpoch),
+            schema_version: 2,
+            field_registry_version: 1,
+            canonical_codec_version: 1,
+            anchor_kind: "accepted_authority",
+            accepted_authority: null,
+            source_transition_digest: null,
+            source_manifest_digest: null,
+            transition_candidate_anchor: null,
+            promoted_receipt_digests: [],
+            materializer_position: {
+              frontier_digest: "ef".repeat(32),
+              ingest_sequence: 9,
+              materialized_digest: "34".repeat(32),
             },
-          },
-          {
-            kind: "logical_checkpoint_entry",
-            collection: "materialized_rows",
-            ordinal: 1,
-            value: {
-              primary_key: "item-1",
-              registry_key: "10_feed_items",
-              row: { globalId: "item-1", platform: "rss" },
+            collection_counts: {
+              accepted_frontier: 0,
+              quarantined_frontier: 0,
+              materialized_rows: 3,
+              field_clocks: 0,
+              relationships: 0,
+              tombstones: 0,
+              actor_states: 1,
+              receipt_records: 0,
+              blob_roots: 0,
+              excluded_registry_keys: 0,
             },
-          },
-          {
-            kind: "logical_checkpoint_entry",
-            collection: "materialized_rows",
-            ordinal: 2,
-            value: {
-              primary_key: "item-2",
-              registry_key: "10_feed_items",
-              row: { globalId: "item-2", platform: "youtube" },
+          };
+          await writer.beginImport({ manifest: {}, manifestReference: {} });
+          await writer.appendPage(0, [
+            header,
+            {
+              kind: "logical_checkpoint_entry",
+              collection: "materialized_rows",
+              ordinal: 0,
+              value: {
+                primary_key: "shell",
+                registry_key: "00_library_shell",
+                row: { accounts: {}, feeds: {}, persons: {} },
+              },
             },
-          },
-        ]);
-        await writer.appendPage(1, [{
-          kind: "logical_checkpoint_entry",
-          collection: "actor_states",
-          ordinal: 0,
-          value: {
-            accepted_chain_digest: "45".repeat(32),
-            accepted_operation_id: null,
-            accepted_sequence: 0,
-            actor_id: "12".repeat(32),
-            enrollment_certificate_digest: "44".repeat(32),
-            retired: false,
-            retirement_certificate_digest: null,
-          },
-        }]);
-        await writer.finalizeImport({ header, manifest: { totalRecordCount: 5 } });
-        return { status: "imported", importedPageCount: 1, importedRecordCount: 5 };
-      },
-    ),
+            {
+              kind: "logical_checkpoint_entry",
+              collection: "materialized_rows",
+              ordinal: 1,
+              value: {
+                primary_key: "item-1",
+                registry_key: "10_feed_items",
+                row: { globalId: "item-1", platform: "rss" },
+              },
+            },
+            {
+              kind: "logical_checkpoint_entry",
+              collection: "materialized_rows",
+              ordinal: 2,
+              value: {
+                primary_key: "item-2",
+                registry_key: "10_feed_items",
+                row: { globalId: "item-2", platform: "youtube" },
+              },
+            },
+          ]);
+          await writer.appendPage(1, [
+            {
+              kind: "logical_checkpoint_entry",
+              collection: "actor_states",
+              ordinal: 0,
+              value: {
+                accepted_chain_digest: "45".repeat(32),
+                accepted_operation_id: null,
+                accepted_sequence: 0,
+                actor_id: "12".repeat(32),
+                enrollment_certificate_digest: "44".repeat(32),
+                retired: false,
+                retirement_certificate_digest: null,
+              },
+            },
+          ]);
+          await writer.finalizeImport({
+            header,
+            manifest: { totalRecordCount: 5 },
+          });
+          return {
+            status: "imported",
+            importedPageCount: 1,
+            importedRecordCount: 5,
+          };
+        },
+      ),
     reassignLibraryCorePortableCheckpointV1: mocks.reassign.mockImplementation(
       async (request: Record<string, unknown>) => {
         mocks.reassignRequest = request;
@@ -332,6 +351,32 @@ describe("SQLite Library Google Drive production wiring", () => {
     });
   });
 
+  it("does not queue a fresh publication behind an abandoned native command", async () => {
+    const controller = new AbortController();
+    mocks.readDescriptor
+      .mockReset()
+      .mockImplementationOnce(() => new Promise(() => {}));
+    const abandoned = publishCurrentSqliteLibraryToGoogleDrive({
+      accessToken: "token",
+      signal: controller.signal,
+    });
+    await Promise.resolve();
+
+    mocks.readDescriptor.mockResolvedValue({
+      revision: 7,
+      itemCount: 2,
+      sourceDigest: "ab".repeat(32),
+      shellJson: '{"accounts":{},"feeds":{},"persons":{}}',
+      materializedDigest: "cd".repeat(32),
+    });
+    await expect(
+      publishCurrentSqliteLibraryToGoogleDrive({ accessToken: "token" }),
+    ).resolves.toEqual({ status: "published", revision: 7 });
+
+    controller.abort();
+    await expect(abandoned).rejects.toMatchObject({ name: "AbortError" });
+  });
+
   it("refuses cloud publication when restored state belongs to another Desktop installation", async () => {
     mocks.nativeState = {
       version: 1,
@@ -352,10 +397,12 @@ describe("SQLite Library Google Drive production wiring", () => {
 
     expect(mocks.publish).not.toHaveBeenCalled();
     expect(mocks.writeNative).not.toHaveBeenCalled();
-    expect(mocks.setWriterAdmission).toHaveBeenCalledWith(expect.objectContaining({
-      activeWriterId: "desktop-original-installation",
-      localWriterId: mocks.bootstrapAuthority.actor.actor_id,
-    }));
+    expect(mocks.setWriterAdmission).toHaveBeenCalledWith(
+      expect.objectContaining({
+        activeWriterId: "desktop-original-installation",
+        localWriterId: mocks.bootstrapAuthority.actor.actor_id,
+      }),
+    );
   });
 
   it("moves a current restored SQLite copy to a fresh writer epoch with one control CAS", async () => {
@@ -371,30 +418,32 @@ describe("SQLite Library Google Drive production wiring", () => {
     };
     mocks.controlRead = {
       revision: '"etag-current"',
-      bytes: new Uint8Array(encodeLibraryCoreCanonicalValue({
-        activeTransport: "google_drive_app_data_v1",
-        causalFrontierDigest: "ef".repeat(32),
-        generation: 4,
-        libraryId,
-        manifest: {
-          descriptor: {
-            byteLength: 123,
-            contentDigest: "12".repeat(32),
-            objectKey: createLibraryCoreImmutableObjectKey({
-              digest: "12".repeat(32) as LibraryCoreLowercaseHex64,
-              epochId: "epoch-original",
-              generation: 4,
-              kind: "checkpoint_manifest",
-              libraryId,
-            }),
+      bytes: new Uint8Array(
+        encodeLibraryCoreCanonicalValue({
+          activeTransport: "google_drive_app_data_v1",
+          causalFrontierDigest: "ef".repeat(32),
+          generation: 4,
+          libraryId,
+          manifest: {
+            descriptor: {
+              byteLength: 123,
+              contentDigest: "12".repeat(32),
+              objectKey: createLibraryCoreImmutableObjectKey({
+                digest: "12".repeat(32) as LibraryCoreLowercaseHex64,
+                epochId: "epoch-original",
+                generation: 4,
+                kind: "checkpoint_manifest",
+                libraryId,
+              }),
+            },
+            transportObjectId: "manifest-4",
           },
-          transportObjectId: "manifest-4",
-        },
-        protocolVersion: 1,
-        schemaVersion: 1,
-        storageEpoch: "epoch-original",
-        writerId: "desktop-original-installation",
-      })),
+          protocolVersion: 1,
+          schemaVersion: 1,
+          storageEpoch: "epoch-original",
+          writerId: "desktop-original-installation",
+        }),
+      ),
     };
 
     await expect(
@@ -402,10 +451,12 @@ describe("SQLite Library Google Drive production wiring", () => {
     ).resolves.toEqual({ status: "writer_transferred", revision: 7 });
 
     expect(mocks.reassign).toHaveBeenCalledTimes(1);
-    expect(mocks.reassignNative).toHaveBeenCalledWith(expect.objectContaining({
-      libraryId,
-      targetWriterId: mocks.bootstrapAuthority.actor.actor_id,
-    }));
+    expect(mocks.reassignNative).toHaveBeenCalledWith(
+      expect.objectContaining({
+        libraryId,
+        targetWriterId: mocks.bootstrapAuthority.actor.actor_id,
+      }),
+    );
     expect(mocks.reassignRequest).toMatchObject({
       expectedControl: { revision: '"etag-current"' },
       generation: 0,
@@ -420,11 +471,13 @@ describe("SQLite Library Google Drive production wiring", () => {
       lastPublishedRevision: 7,
       writerId: mocks.bootstrapAuthority.actor.actor_id,
     });
-    expect(mocks.setWriterAdmission).toHaveBeenLastCalledWith(expect.objectContaining({
-      activeWriterId: mocks.bootstrapAuthority.actor.actor_id,
-      localWriterId: mocks.bootstrapAuthority.actor.actor_id,
-      controlRevision: '"etag-2"',
-    }));
+    expect(mocks.setWriterAdmission).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        activeWriterId: mocks.bootstrapAuthority.actor.actor_id,
+        localWriterId: mocks.bootstrapAuthority.actor.actor_id,
+        controlRevision: '"etag-2"',
+      }),
+    );
   });
 
   it("backs up and imports the active cloud checkpoint before taking over from a newer epoch", async () => {
@@ -438,7 +491,8 @@ describe("SQLite Library Google Drive production wiring", () => {
       controlFileId: "control-1",
       lastPublishedRevision: 7,
     };
-    mocks.readDescriptor.mockReset()
+    mocks.readDescriptor
+      .mockReset()
       .mockResolvedValueOnce({
         revision: 8,
         itemCount: 2,
@@ -455,30 +509,32 @@ describe("SQLite Library Google Drive production wiring", () => {
       });
     mocks.controlRead = {
       revision: '"etag-current"',
-      bytes: new Uint8Array(encodeLibraryCoreCanonicalValue({
-        activeTransport: "google_drive_app_data_v1",
-        causalFrontierDigest: "ef".repeat(32),
-        generation: 9,
-        libraryId,
-        manifest: {
-          descriptor: {
-            byteLength: 123,
-            contentDigest: "56".repeat(32),
-            objectKey: createLibraryCoreImmutableObjectKey({
-              digest: "56".repeat(32) as LibraryCoreLowercaseHex64,
-              epochId: "epoch-cloud-newer",
-              generation: 9,
-              kind: "checkpoint_manifest",
-              libraryId,
-            }),
+      bytes: new Uint8Array(
+        encodeLibraryCoreCanonicalValue({
+          activeTransport: "google_drive_app_data_v1",
+          causalFrontierDigest: "ef".repeat(32),
+          generation: 9,
+          libraryId,
+          manifest: {
+            descriptor: {
+              byteLength: 123,
+              contentDigest: "56".repeat(32),
+              objectKey: createLibraryCoreImmutableObjectKey({
+                digest: "56".repeat(32) as LibraryCoreLowercaseHex64,
+                epochId: "epoch-cloud-newer",
+                generation: 9,
+                kind: "checkpoint_manifest",
+                libraryId,
+              }),
+            },
+            transportObjectId: "manifest-9",
           },
-          transportObjectId: "manifest-9",
-        },
-        protocolVersion: 1,
-        schemaVersion: 1,
-        storageEpoch: "epoch-cloud-newer",
-        writerId: "desktop-cloud-writer",
-      })),
+          protocolVersion: 1,
+          schemaVersion: 1,
+          storageEpoch: "epoch-cloud-newer",
+          writerId: "desktop-cloud-writer",
+        }),
+      ),
     };
 
     await expect(
@@ -487,11 +543,13 @@ describe("SQLite Library Google Drive production wiring", () => {
 
     expect(mocks.createBackup).toHaveBeenCalledWith("manual");
     expect(mocks.importCheckpoint).toHaveBeenCalledTimes(1);
-    expect(mocks.beginPortableImport).toHaveBeenCalledWith(expect.objectContaining({
-      expectedItemCount: 2,
-      sourceDigest: "ab".repeat(32),
-      sourceRevision: 9,
-    }));
+    expect(mocks.beginPortableImport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        expectedItemCount: 2,
+        sourceDigest: "ab".repeat(32),
+        sourceRevision: 9,
+      }),
+    );
     expect(mocks.appendPortableItems).toHaveBeenCalledWith([
       { globalId: "item-1", platform: "rss" },
       { globalId: "item-2", platform: "youtube" },

--- a/packages/desktop/src/lib/library-core-cloud-sync.ts
+++ b/packages/desktop/src/lib/library-core-cloud-sync.ts
@@ -36,6 +36,8 @@ import {
 import type { GoogleDriveFetch } from "@freed/sync/cloud/library-core";
 import { decodeJson } from "@freed/shared/projection";
 import type { FeedItem } from "@freed/shared";
+import { recordCloudProviderEvent } from "@freed/ui/lib/debug-store";
+import { log } from "./logger";
 import {
   appendPortableSqliteLibraryItems,
   acknowledgePwaIntentResultOutbox,
@@ -68,6 +70,7 @@ const STATE_FILE = "library-core-cloud.json";
 const STATE_KEY = "state";
 const LOCAL_REVISION_POLL_MS = 15_000;
 const INBOUND_ACTOR_POLL_MS = 60_000;
+const PUBLICATION_TIMEOUT_MS = 5 * 60_000;
 const ACTIVATION_KEY = "freed.libraryCore.immutableGoogleDriveV1.enabled";
 
 interface LocalLibraryCoreCloudStateV1 {
@@ -116,19 +119,22 @@ export function isSqliteLibraryGoogleDriveSyncEnabled(): boolean {
 function isCloudState(value: unknown): value is LocalLibraryCoreCloudStateV1 {
   if (!value || typeof value !== "object" || Array.isArray(value)) return false;
   const candidate = value as Partial<LocalLibraryCoreCloudStateV1>;
-  return candidate.version === 1
-    && typeof candidate.libraryId === "string"
-    && typeof candidate.sourceDigest === "string"
-    && typeof candidate.storageEpoch === "string"
-    && typeof candidate.writerId === "string"
-    && (candidate.controlFileId === null || typeof candidate.controlFileId === "string")
-    && (candidate.lastPublishedRevision === null
-      || (typeof candidate.lastPublishedRevision === "number"
-        && Number.isSafeInteger(candidate.lastPublishedRevision)
-        && candidate.lastPublishedRevision >= 0))
-    && (candidate.lastPublishedActorDigest === undefined
-      || candidate.lastPublishedActorDigest === null
-      || /^[a-f0-9]{64}$/.test(candidate.lastPublishedActorDigest));
+  return (
+    candidate.version === 1 &&
+    typeof candidate.libraryId === "string" &&
+    typeof candidate.sourceDigest === "string" &&
+    typeof candidate.storageEpoch === "string" &&
+    typeof candidate.writerId === "string" &&
+    (candidate.controlFileId === null ||
+      typeof candidate.controlFileId === "string") &&
+    (candidate.lastPublishedRevision === null ||
+      (typeof candidate.lastPublishedRevision === "number" &&
+        Number.isSafeInteger(candidate.lastPublishedRevision) &&
+        candidate.lastPublishedRevision >= 0)) &&
+    (candidate.lastPublishedActorDigest === undefined ||
+      candidate.lastPublishedActorDigest === null ||
+      /^[a-f0-9]{64}$/.test(candidate.lastPublishedActorDigest))
+  );
 }
 
 async function loadOrCreateCloudState(
@@ -143,7 +149,9 @@ async function loadOrCreateCloudState(
   const stored = await readNativeJsonValue(STATE_FILE, STATE_KEY);
   if (isCloudState(stored)) {
     if (stored.sourceDigest !== descriptor.sourceDigest) {
-      throw new Error("The saved Library Core cloud identity belongs to another Library");
+      throw new Error(
+        "The saved Library Core cloud identity belongs to another Library",
+      );
     }
     return {
       state: Object.freeze({
@@ -168,7 +176,9 @@ async function loadOrCreateCloudState(
   return { state, currentWriterId, bootstrap };
 }
 
-async function persistCloudState(state: LocalLibraryCoreCloudStateV1): Promise<void> {
+async function persistCloudState(
+  state: LocalLibraryCoreCloudStateV1,
+): Promise<void> {
   await writeNativeJsonValue(
     STATE_FILE,
     STATE_KEY,
@@ -208,16 +218,18 @@ function exactBytes(bytes: Uint8Array): Uint8Array {
   return copy;
 }
 
-function parseControl(read: LibraryCoreControlReadV1): LibraryCoreControlPointerV1 | null {
+function parseControl(
+  read: LibraryCoreControlReadV1,
+): LibraryCoreControlPointerV1 | null {
   if (read.bytes === null) {
     throw new Error("Library Core control file has no bytes");
   }
   const value = decodeLibraryCoreCanonicalValue(exactBytes(read.bytes));
   if (
-    value !== null
-    && typeof value === "object"
-    && !Array.isArray(value)
-    && Object.keys(value).length === 0
+    value !== null &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    Object.keys(value).length === 0
   ) {
     return null;
   }
@@ -256,6 +268,43 @@ async function sha256Bytes(bytes: Uint8Array): Promise<string> {
 
 function canonicalValue(value: unknown): LibraryCoreCanonicalValue {
   return value as LibraryCoreCanonicalValue;
+}
+
+async function tracedPublicationStage<T>(
+  label: string,
+  work: () => Promise<T>,
+): Promise<T> {
+  const startedAt = performance.now();
+  log.info(`[library-core-cloud] ${label} started`);
+  recordCloudProviderEvent("gdrive", {
+    kind: "started",
+    stage: "upload",
+    message: `${label} started.`,
+  });
+  try {
+    const result = await work();
+    const elapsedMs = Math.round(performance.now() - startedAt);
+    log.info(
+      `[library-core-cloud] ${label} completed in ${elapsedMs.toLocaleString()} ms`,
+    );
+    recordCloudProviderEvent("gdrive", {
+      kind: "success",
+      stage: "upload",
+      message: `${label} completed in ${elapsedMs.toLocaleString()} ms.`,
+    });
+    return result;
+  } catch (error) {
+    const elapsedMs = Math.round(performance.now() - startedAt);
+    log.warn(
+      `[library-core-cloud] ${label} failed after ${elapsedMs.toLocaleString()} ms: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    recordCloudProviderEvent("gdrive", {
+      kind: "error",
+      stage: "upload",
+      message: `${label} failed after ${elapsedMs.toLocaleString()} ms.`,
+    });
+    throw error;
+  }
 }
 
 async function* checkpointEntries(
@@ -327,18 +376,24 @@ async function checkpointHeader(
   actorCount: number,
   preservedFrontierDigest?: string,
 ): Promise<LibraryCorePortableCheckpointHeaderV1> {
-  const frontierDigest = preservedFrontierDigest ?? await sha256Text([
-      state.libraryId,
-      state.storageEpoch,
-      String(descriptor.revision),
-      descriptor.materializedDigest,
-    ].join("\n"));
+  const frontierDigest =
+    preservedFrontierDigest ??
+    (await sha256Text(
+      [
+        state.libraryId,
+        state.storageEpoch,
+        String(descriptor.revision),
+        descriptor.materializedDigest,
+      ].join("\n"),
+    ));
   return {
     kind: "logical_checkpoint_header",
     format: "freed_logical_checkpoint_v1",
-    library_id: state.libraryId as LibraryCorePortableCheckpointHeaderV1["library_id"],
+    library_id:
+      state.libraryId as LibraryCorePortableCheckpointHeaderV1["library_id"],
     epoch: bootstrap.authority.epoch,
-    epoch_id: state.storageEpoch as LibraryCorePortableCheckpointHeaderV1["epoch_id"],
+    epoch_id:
+      state.storageEpoch as LibraryCorePortableCheckpointHeaderV1["epoch_id"],
     schema_version: 2,
     field_registry_version: 1,
     canonical_codec_version: 1,
@@ -349,9 +404,11 @@ async function checkpointHeader(
     transition_candidate_anchor: null,
     promoted_receipt_digests: [],
     materializer_position: {
-      frontier_digest: frontierDigest as LibraryCorePortableCheckpointHeaderV1["materializer_position"]["frontier_digest"],
+      frontier_digest:
+        frontierDigest as LibraryCorePortableCheckpointHeaderV1["materializer_position"]["frontier_digest"],
       ingest_sequence: descriptor.revision,
-      materialized_digest: descriptor.materializedDigest as LibraryCorePortableCheckpointHeaderV1["materializer_position"]["materialized_digest"],
+      materialized_digest:
+        descriptor.materializedDigest as LibraryCorePortableCheckpointHeaderV1["materializer_position"]["materialized_digest"],
     },
     collection_counts: {
       accepted_frontier: 0,
@@ -452,7 +509,9 @@ async function acceptPendingPwaActorEnrollments(input: {
 
 function canonicalIntentTransactions(
   entries: readonly Readonly<{
-    readonly canonical_envelope: Readonly<Record<string, LibraryCoreCanonicalValue>>;
+    readonly canonical_envelope: Readonly<
+      Record<string, LibraryCoreCanonicalValue>
+    >;
   }>[],
 ): readonly (readonly string[])[] {
   const transactions: string[][] = [];
@@ -461,12 +520,12 @@ function canonicalIntentTransactions(
     const transactionId = first.transaction_id;
     const memberCount = first.transaction_member_count;
     if (
-      typeof transactionId !== "string"
-      || !Number.isSafeInteger(memberCount)
-      || typeof memberCount !== "number"
-      || memberCount < 1
-      || index + memberCount > entries.length
-      || first.transaction_member_index !== 0
+      typeof transactionId !== "string" ||
+      !Number.isSafeInteger(memberCount) ||
+      typeof memberCount !== "number" ||
+      memberCount < 1 ||
+      index + memberCount > entries.length ||
+      first.transaction_member_index !== 0
     ) {
       throw new Error("PWA intent segment splits a canonical transaction");
     }
@@ -474,23 +533,27 @@ function canonicalIntentTransactions(
     for (let memberIndex = 0; memberIndex < members.length; memberIndex += 1) {
       const envelope = members[memberIndex]!.canonical_envelope;
       if (
-        envelope.transaction_id !== transactionId
-        || envelope.transaction_member_count !== memberCount
-        || envelope.transaction_member_index !== memberIndex
+        envelope.transaction_id !== transactionId ||
+        envelope.transaction_member_count !== memberCount ||
+        envelope.transaction_member_index !== memberIndex
       ) {
         throw new Error("PWA intent transaction members are reordered");
       }
     }
-    transactions.push(members.map((member) =>
-      new TextDecoder("utf-8", { fatal: true }).decode(
-        encodeLibraryCoreCanonicalValue(
-          member.canonical_envelope as LibraryCoreCanonicalValue,
+    transactions.push(
+      members.map((member) =>
+        new TextDecoder("utf-8", { fatal: true }).decode(
+          encodeLibraryCoreCanonicalValue(
+            member.canonical_envelope as LibraryCoreCanonicalValue,
+          ),
         ),
-      )
-    ));
+      ),
+    );
     index += memberCount;
   }
-  return Object.freeze(transactions.map((transaction) => Object.freeze(transaction)));
+  return Object.freeze(
+    transactions.map((transaction) => Object.freeze(transaction)),
+  );
 }
 
 async function acceptPendingPwaReadIntents(input: {
@@ -545,20 +608,21 @@ async function acceptPendingPwaReadIntents(input: {
       const segment = segments[index]!;
       const previous = segments[index - 1];
       if (
-        segment.firstIntentSequence !== (previous?.lastIntentSequence ?? 0) + 1
-        || segment.lastIntentSequence >= head.head.next_intent_sequence
+        segment.firstIntentSequence !==
+          (previous?.lastIntentSequence ?? 0) + 1 ||
+        segment.lastIntentSequence >= head.head.next_intent_sequence
       ) {
         throw new Error("PWA intent segment chain has a gap or overlap");
       }
     }
     const latest = segments.at(-1)!;
     if (
-      latest.lastIntentSequence !== publishedThrough
-      || latest.reference.descriptor.contentDigest !==
-        head.head.latest_segment.descriptor.contentDigest
-      || latest.reference.descriptor.objectKey !==
-        head.head.latest_segment.descriptor.objectKey
-      || latest.reference.transportObjectId !==
+      latest.lastIntentSequence !== publishedThrough ||
+      latest.reference.descriptor.contentDigest !==
+        head.head.latest_segment.descriptor.contentDigest ||
+      latest.reference.descriptor.objectKey !==
+        head.head.latest_segment.descriptor.objectKey ||
+      latest.reference.transportObjectId !==
         head.head.latest_segment.transportObjectId
     ) {
       throw new Error("PWA intent segments do not match the actor head");
@@ -611,19 +675,23 @@ function resultEntryMatches(
     status: "accepted" | "provider_completed" | "provider_failed";
   }>,
 ): boolean {
-  return local.actorId === remote.actor_id
-    && local.intentOperationId === remote.intent_operation_id
-    && local.intentSequence === remote.intent_sequence
-    && local.providerReceiptDigest === remote.provider_receipt_digest
-    && local.resultOperationId === remote.result_operation_id
-    && local.resultSequence === remote.result_sequence
-    && local.status === remote.status;
+  return (
+    local.actorId === remote.actor_id &&
+    local.intentOperationId === remote.intent_operation_id &&
+    local.intentSequence === remote.intent_sequence &&
+    local.providerReceiptDigest === remote.provider_receipt_digest &&
+    local.resultOperationId === remote.result_operation_id &&
+    local.resultSequence === remote.result_sequence &&
+    local.status === remote.status
+  );
 }
 
 async function verifyPublishedResultPrefix(input: {
   readonly accessToken: string;
   readonly actorId: string;
-  readonly adapter: ReturnType<typeof createGoogleDriveLibraryCoreResultAdapterV1>;
+  readonly adapter: ReturnType<
+    typeof createGoogleDriveLibraryCoreResultAdapterV1
+  >;
   readonly epochId: string;
   readonly googleFetch?: GoogleDriveFetch;
   readonly head: LibraryCoreResultHeadV1;
@@ -664,7 +732,9 @@ async function verifyPublishedResultPrefix(input: {
           for (const remote of entries) {
             const local = pendingBySequence.get(remote.result_sequence);
             if (local && !resultEntryMatches(local, remote)) {
-              throw new Error("published PWA result differs from the durable SQLite receipt");
+              throw new Error(
+                "published PWA result differs from the durable SQLite receipt",
+              );
             }
             if (local) confirmed.add(local.resultOperationId);
           }
@@ -676,17 +746,19 @@ async function verifyPublishedResultPrefix(input: {
     if (nextSequence >= input.head.next_result_sequence) break;
   }
   if (
-    nextSequence !== input.head.next_result_sequence
-    || previousDigest !== input.head.latest_segment_digest
+    nextSequence !== input.head.next_result_sequence ||
+    previousDigest !== input.head.latest_segment_digest
   ) {
     throw new Error("PWA result objects do not match the actor result head");
   }
   for (const local of input.pending) {
     if (
-      local.resultSequence < input.head.next_result_sequence
-      && !confirmed.has(local.resultOperationId)
+      local.resultSequence < input.head.next_result_sequence &&
+      !confirmed.has(local.resultOperationId)
     ) {
-      throw new Error("published PWA result head omits a durable SQLite receipt");
+      throw new Error(
+        "published PWA result head omits a durable SQLite receipt",
+      );
     }
   }
   return Object.freeze([...confirmed]);
@@ -701,10 +773,13 @@ async function flushPwaIntentResultOutbox(input: {
   readonly signal?: AbortSignal;
 }): Promise<void> {
   for (let page = 0; page < 100; page += 1) {
-    const pending = await readPwaIntentResultOutbox({
-      epochId: input.epochId,
-      libraryId: input.libraryId,
-    }, 256);
+    const pending = await readPwaIntentResultOutbox(
+      {
+        epochId: input.epochId,
+        libraryId: input.libraryId,
+      },
+      256,
+    );
     if (pending.length === 0) return;
     const actorIds = [...new Set(pending.map((entry) => entry.actorId))].sort();
     for (const actorId of actorIds) {
@@ -770,7 +845,9 @@ async function flushPwaIntentResultOutbox(input: {
       );
       if (unpublished.length === 0) continue;
       if (unpublished[0]!.resultSequence !== head.next_result_sequence) {
-        throw new Error("durable PWA result outbox does not extend the cloud result head");
+        throw new Error(
+          "durable PWA result outbox does not extend the cloud result head",
+        );
       }
       await publishLibraryCoreResultEntriesV1({
         adapter,
@@ -781,8 +858,13 @@ async function flushPwaIntentResultOutbox(input: {
         unpublished.map((entry) => entry.resultOperationId),
       );
       head = (await adapter.readResultHead()).head;
-      if (head.next_result_sequence !== unpublished.at(-1)!.resultSequence + 1) {
-        throw new Error("PWA result head did not advance through published receipts");
+      if (
+        head.next_result_sequence !==
+        unpublished.at(-1)!.resultSequence + 1
+      ) {
+        throw new Error(
+          "PWA result head did not advance through published receipts",
+        );
       }
     }
   }
@@ -823,9 +905,10 @@ async function bootstrapCloudCheckpointIntoSqlite(input: {
   readonly sourceDigest: string;
 }): Promise<SqliteLibrarySyncDescriptor> {
   const previousStatus = await sqliteLibraryStatus();
-  const backup = previousStatus?.active === true
-    ? await createSqliteLibraryBackup("manual")
-    : null;
+  const backup =
+    previousStatus?.active === true
+      ? await createSqliteLibraryBackup("manual")
+      : null;
   let nativeImportStarted = false;
   let importedHeader: LibraryCorePortableCheckpointHeaderV1 | null = null;
   try {
@@ -843,23 +926,39 @@ async function bootstrapCloudCheckpointIntoSqlite(input: {
         async appendPage(pageIndex, records) {
           const feedItems: unknown[] = [];
           if (!nativeImportStarted) {
-            if (pageIndex !== 0 || records[0]?.kind !== "logical_checkpoint_header") {
-              throw new Error("SQLite cloud import did not begin with its logical header");
+            if (
+              pageIndex !== 0 ||
+              records[0]?.kind !== "logical_checkpoint_header"
+            ) {
+              throw new Error(
+                "SQLite cloud import did not begin with its logical header",
+              );
             }
             const header = records[0];
-            const unsupportedCount = Object.entries(header.collection_counts)
-              .some(([collection, count]) =>
-                collection !== "materialized_rows"
-                && collection !== "actor_states"
-                && count !== 0,
-              );
+            const unsupportedCount = Object.entries(
+              header.collection_counts,
+            ).some(
+              ([collection, count]) =>
+                collection !== "materialized_rows" &&
+                collection !== "actor_states" &&
+                count !== 0,
+            );
             if (unsupportedCount) {
-              throw new Error("SQLite cloud import contains unsupported Library collections");
+              throw new Error(
+                "SQLite cloud import contains unsupported Library collections",
+              );
             }
-            const rows = records.slice(1).map(materializedRow).filter((row) => row !== null);
-            const shell = rows.find((row) => row.registryKey === "00_library_shell");
+            const rows = records
+              .slice(1)
+              .map(materializedRow)
+              .filter((row) => row !== null);
+            const shell = rows.find(
+              (row) => row.registryKey === "00_library_shell",
+            );
             if (shell === undefined) {
-              throw new Error("SQLite cloud import is missing the Library shell");
+              throw new Error(
+                "SQLite cloud import is missing the Library shell",
+              );
             }
             await beginPortableSqliteLibraryImport({
               expectedItemCount: header.collection_counts.materialized_rows - 1,
@@ -873,23 +972,29 @@ async function bootstrapCloudCheckpointIntoSqlite(input: {
             for (const row of rows) {
               if (row.registryKey === "10_feed_items") feedItems.push(row.row);
               else if (row.registryKey !== "00_library_shell") {
-                throw new Error(`SQLite cloud import does not support ${row.registryKey}`);
+                throw new Error(
+                  `SQLite cloud import does not support ${row.registryKey}`,
+                );
               }
             }
           } else {
             for (const record of records) {
               if (
-                record.kind === "logical_checkpoint_entry"
-                && record.collection === "actor_states"
+                record.kind === "logical_checkpoint_entry" &&
+                record.collection === "actor_states"
               ) {
                 continue;
               }
               const row = materializedRow(record);
               if (row === null) {
-                throw new Error("SQLite cloud import repeats its logical header");
+                throw new Error(
+                  "SQLite cloud import repeats its logical header",
+                );
               }
               if (row.registryKey !== "10_feed_items") {
-                throw new Error(`SQLite cloud import does not support ${row.registryKey}`);
+                throw new Error(
+                  `SQLite cloud import does not support ${row.registryKey}`,
+                );
               }
               feedItems.push(row.row);
             }
@@ -898,7 +1003,9 @@ async function bootstrapCloudCheckpointIntoSqlite(input: {
         },
         async finalizeImport({ header, manifest }) {
           if (!nativeImportStarted || importedHeader === null) {
-            throw new Error("SQLite cloud import never initialized native staging");
+            throw new Error(
+              "SQLite cloud import never initialized native staging",
+            );
           }
           await finalizePortableSqliteLibraryImport();
           const descriptor = await readSqliteLibrarySyncDescriptor();
@@ -906,7 +1013,8 @@ async function bootstrapCloudCheckpointIntoSqlite(input: {
             frontierDigest: header.materializer_position.frontier_digest,
             ingestSequence: header.materializer_position.ingest_sequence,
             libraryId: header.library_id,
-            materializedDigest: descriptor.materializedDigest as LibraryCorePortableCheckpointHeaderV1["materializer_position"]["materialized_digest"],
+            materializedDigest:
+              descriptor.materializedDigest as LibraryCorePortableCheckpointHeaderV1["materializer_position"]["materialized_digest"],
             recordCount: manifest.totalRecordCount,
             storageEpoch: header.epoch_id,
           };
@@ -942,7 +1050,10 @@ export async function makeThisSqliteLibraryDesktopWriter(input: {
     signal: input.signal,
   });
   if (state.controlFileId !== provisioned.controlFileId) {
-    state = Object.freeze({ ...state, controlFileId: provisioned.controlFileId });
+    state = Object.freeze({
+      ...state,
+      controlFileId: provisioned.controlFileId,
+    });
     await persistCloudState(state);
   }
   const adapter = createGoogleDriveLibraryCoreAdapterV1({
@@ -964,9 +1075,9 @@ export async function makeThisSqliteLibraryDesktopWriter(input: {
       revision: controlRead.revision,
     });
     if (
-      state.writerId !== pointer.writerId
-      || state.storageEpoch !== pointer.storageEpoch
-      || state.lastPublishedRevision !== descriptor.revision
+      state.writerId !== pointer.writerId ||
+      state.storageEpoch !== pointer.storageEpoch ||
+      state.lastPublishedRevision !== descriptor.revision
     ) {
       state = Object.freeze({
         ...state,
@@ -979,9 +1090,9 @@ export async function makeThisSqliteLibraryDesktopWriter(input: {
     return { status: "current", revision: descriptor.revision };
   }
   if (
-    state.lastPublishedRevision !== descriptor.revision
-    || pointer.storageEpoch !== state.storageEpoch
-    || pointer.writerId !== state.writerId
+    state.lastPublishedRevision !== descriptor.revision ||
+    pointer.storageEpoch !== state.storageEpoch ||
+    pointer.writerId !== state.writerId
   ) {
     descriptor = await bootstrapCloudCheckpointIntoSqlite({
       adapter,
@@ -997,8 +1108,12 @@ export async function makeThisSqliteLibraryDesktopWriter(input: {
     await persistCloudState(state);
   }
 
-  const canonicalSourceControlJson = new TextDecoder("utf-8", { fatal: true }).decode(
-    encodeLibraryCoreCanonicalValue(pointer as unknown as LibraryCoreCanonicalValue),
+  const canonicalSourceControlJson = new TextDecoder("utf-8", {
+    fatal: true,
+  }).decode(
+    encodeLibraryCoreCanonicalValue(
+      pointer as unknown as LibraryCoreCanonicalValue,
+    ),
   );
   const reassigned = await reassignSqliteLibraryWriterEpoch({
     canonicalSourceControlJson,
@@ -1050,11 +1165,13 @@ export async function makeThisSqliteLibraryDesktopWriter(input: {
       localWriterId: loaded.currentWriterId,
     };
   }
-  await persistCloudState(Object.freeze({
-    ...targetState,
-    lastPublishedActorDigest: await actorStateDigest(actors),
-    lastPublishedRevision: descriptor.revision,
-  }));
+  await persistCloudState(
+    Object.freeze({
+      ...targetState,
+      lastPublishedActorDigest: await actorStateDigest(actors),
+      lastPublishedRevision: descriptor.revision,
+    }),
+  );
   await setSqliteLibraryCloudWriterAdmission({
     localWriterId: loaded.currentWriterId,
     activeWriterId: loaded.currentWriterId,
@@ -1069,8 +1186,14 @@ async function publishCurrentSqliteLibraryToGoogleDriveInternal(input: {
   readonly googleFetch?: GoogleDriveFetch;
   readonly signal?: AbortSignal;
 }): Promise<LibraryCoreCloudPublishResult> {
-  const descriptor = await readSqliteLibrarySyncDescriptor();
-  const loaded = await loadOrCreateCloudState(descriptor);
+  const descriptor = await tracedPublicationStage(
+    "read local SQLite revision",
+    readSqliteLibrarySyncDescriptor,
+  );
+  const loaded = await tracedPublicationStage(
+    "load local writer authority",
+    () => loadOrCreateCloudState(descriptor),
+  );
   let state = loaded.state;
   if (state.writerId !== loaded.currentWriterId) {
     await setSqliteLibraryCloudWriterAdmission({
@@ -1085,14 +1208,21 @@ async function publishCurrentSqliteLibraryToGoogleDriveInternal(input: {
       localWriterId: loaded.currentWriterId,
     };
   }
-  const provisioned = await provisionGoogleDriveLibraryCoreControlV1({
-    accessToken: input.accessToken,
-    libraryId: state.libraryId,
-    googleFetch: input.googleFetch,
-    signal: input.signal,
-  });
+  const provisioned = await tracedPublicationStage(
+    "discover Drive control",
+    () =>
+      provisionGoogleDriveLibraryCoreControlV1({
+        accessToken: input.accessToken,
+        libraryId: state.libraryId,
+        googleFetch: input.googleFetch,
+        signal: input.signal,
+      }),
+  );
   if (state.controlFileId !== provisioned.controlFileId) {
-    state = Object.freeze({ ...state, controlFileId: provisioned.controlFileId });
+    state = Object.freeze({
+      ...state,
+      controlFileId: provisioned.controlFileId,
+    });
     await persistCloudState(state);
   }
   const adapter = createGoogleDriveLibraryCoreAdapterV1({
@@ -1102,7 +1232,9 @@ async function publishCurrentSqliteLibraryToGoogleDriveInternal(input: {
     googleFetch: input.googleFetch,
     signal: input.signal,
   });
-  const controlRead = await adapter.readControl();
+  const controlRead = await tracedPublicationStage("read Drive control", () =>
+    adapter.readControl(),
+  );
   const pointer = parseControl(controlRead);
   if (pointer !== null && pointer.writerId !== state.writerId) {
     if (controlRead.revision === null) {
@@ -1219,21 +1351,75 @@ async function publishCurrentSqliteLibraryToGoogleDriveInternal(input: {
   return { status: "published", revision: updatedDescriptor.revision };
 }
 
-let publicationChain: Promise<void> = Promise.resolve();
+function publicationAbortError(message: string): Error {
+  const error = new Error(message);
+  error.name = "AbortError";
+  return error;
+}
+
+/**
+ * Bound one publication attempt to its owning UI lifecycle.
+ *
+ * Native SQLite and Keychain commands cannot be interrupted after Tauri has
+ * accepted them. Their result is still safe to ignore because every cloud
+ * mutation below rechecks the supplied signal before the request and Drive
+ * publication ends in an exact control CAS. A canceled native invoke must not
+ * remain the head of a module-wide queue and wedge every later sync attempt.
+ */
+async function runBoundedPublication(input: {
+  readonly accessToken: string;
+  readonly googleFetch?: GoogleDriveFetch;
+  readonly signal?: AbortSignal;
+}): Promise<LibraryCoreCloudPublishResult> {
+  if (input.signal?.aborted) {
+    throw publicationAbortError("SQLite Library publication was canceled.");
+  }
+  const timeoutController = new AbortController();
+  const combinedController = new AbortController();
+  const abortCombined = () => combinedController.abort();
+  input.signal?.addEventListener("abort", abortCombined, { once: true });
+  timeoutController.signal.addEventListener("abort", abortCombined, {
+    once: true,
+  });
+  const timer = window.setTimeout(
+    () => timeoutController.abort(),
+    PUBLICATION_TIMEOUT_MS,
+  );
+  const canceled = new Promise<never>((_resolve, reject) => {
+    combinedController.signal.addEventListener(
+      "abort",
+      () => {
+        reject(
+          publicationAbortError(
+            timeoutController.signal.aborted
+              ? "SQLite Library publication timed out. Try Sync now again."
+              : "SQLite Library publication was canceled.",
+          ),
+        );
+      },
+      { once: true },
+    );
+  });
+  try {
+    return await Promise.race([
+      publishCurrentSqliteLibraryToGoogleDriveInternal({
+        ...input,
+        signal: combinedController.signal,
+      }),
+      canceled,
+    ]);
+  } finally {
+    window.clearTimeout(timer);
+    input.signal?.removeEventListener("abort", abortCombined);
+  }
+}
 
 export function publishCurrentSqliteLibraryToGoogleDrive(input: {
   readonly accessToken: string;
   readonly googleFetch?: GoogleDriveFetch;
   readonly signal?: AbortSignal;
 }): Promise<LibraryCoreCloudPublishResult> {
-  const result = publicationChain.then(() =>
-    publishCurrentSqliteLibraryToGoogleDriveInternal(input),
-  );
-  publicationChain = result.then(
-    () => undefined,
-    () => undefined,
-  );
-  return result;
+  return runBoundedPublication(input);
 }
 
 export async function startSqliteLibraryGoogleDriveSync(input: {
@@ -1245,7 +1431,9 @@ export async function startSqliteLibraryGoogleDriveSync(input: {
   resetSqliteLibraryDriveBackupMirror();
   const abortController = new AbortController();
   running = { abortController, timer: null };
-  const publish = async (accessToken: string): Promise<LibraryCoreCloudPublishResult> =>
+  const publish = async (
+    accessToken: string,
+  ): Promise<LibraryCoreCloudPublishResult> =>
     publishCurrentSqliteLibraryToGoogleDrive({
       accessToken,
       googleFetch: input.googleFetch,
@@ -1259,16 +1447,20 @@ export async function startSqliteLibraryGoogleDriveSync(input: {
   let lastInboundActorPollAt = Date.now();
 
   const poll = async (): Promise<void> => {
-    if (running?.abortController !== abortController || abortController.signal.aborted) return;
+    if (
+      running?.abortController !== abortController ||
+      abortController.signal.aborted
+    )
+      return;
     try {
       const status = await sqliteLibraryStatus();
       const state = await readNativeJsonValue(STATE_FILE, STATE_KEY);
       const now = Date.now();
       if (
-        status?.active === true
-        && isCloudState(state)
-        && (state.lastPublishedRevision !== status.revision
-          || now - lastInboundActorPollAt >= INBOUND_ACTOR_POLL_MS)
+        status?.active === true &&
+        isCloudState(state) &&
+        (state.lastPublishedRevision !== status.revision ||
+          now - lastInboundActorPollAt >= INBOUND_ACTOR_POLL_MS)
       ) {
         lastInboundActorPollAt = now;
         const result = await publish(await input.resolveAccessToken());
@@ -1278,12 +1470,21 @@ export async function startSqliteLibraryGoogleDriveSync(input: {
         }
       }
     } finally {
-      if (running?.abortController === abortController && !abortController.signal.aborted) {
-        running.timer = setTimeout(() => void poll().catch(console.error), LOCAL_REVISION_POLL_MS);
+      if (
+        running?.abortController === abortController &&
+        !abortController.signal.aborted
+      ) {
+        running.timer = setTimeout(
+          () => void poll().catch(console.error),
+          LOCAL_REVISION_POLL_MS,
+        );
       }
     }
   };
-  running.timer = setTimeout(() => void poll().catch(console.error), LOCAL_REVISION_POLL_MS);
+  running.timer = setTimeout(
+    () => void poll().catch(console.error),
+    LOCAL_REVISION_POLL_MS,
+  );
   return initial;
 }
 

--- a/packages/desktop/src/lib/sync.ts
+++ b/packages/desktop/src/lib/sync.ts
@@ -37,14 +37,12 @@ const TOKEN_REFRESH_SKEW_MS = 60_000;
 const GOOGLE_TOKEN_REFRESH_FALLBACK_TTL_MS = 55 * 60 * 1_000;
 const DEFAULT_GDRIVE_DESKTOP_CLIENT_ID =
   "304530272769-fkbpan1l071vdvum1j6kufvo8rbq6sm1.apps.googleusercontent.com";
-const DEFAULT_GDRIVE_TOKEN_PROXY_URL =
-  "https://app.freed.wtf/api/oauth/google";
+const DEFAULT_GDRIVE_TOKEN_PROXY_URL = "https://app.freed.wtf/api/oauth/google";
 const GDRIVE_CLIENT_ID =
   import.meta.env.VITE_GDRIVE_DESKTOP_CLIENT_ID ||
   DEFAULT_GDRIVE_DESKTOP_CLIENT_ID;
 const GDRIVE_TOKEN_PROXY_URL =
-  import.meta.env.VITE_GDRIVE_TOKEN_PROXY_URL ||
-  DEFAULT_GDRIVE_TOKEN_PROXY_URL;
+  import.meta.env.VITE_GDRIVE_TOKEN_PROXY_URL || DEFAULT_GDRIVE_TOKEN_PROXY_URL;
 
 let googleDriveFetch: GoogleDriveFetch | undefined;
 let acceptingDesktopOAuth = true;
@@ -82,7 +80,9 @@ interface NativeGoogleOAuthResponse {
 
 export type CloudConflictWinner = "local" | "cloud";
 
-export function setGoogleDriveFetch(fetcher: GoogleDriveFetch | undefined): void {
+export function setGoogleDriveFetch(
+  fetcher: GoogleDriveFetch | undefined,
+): void {
   googleDriveFetch = fetcher;
 }
 
@@ -96,7 +96,9 @@ function advanceGeneration(provider: CloudProvider): number {
   return next;
 }
 
-export function captureCloudLifecycle(provider: CloudProvider): CloudLifecycleGuard {
+export function captureCloudLifecycle(
+  provider: CloudProvider,
+): CloudLifecycleGuard {
   const generation = currentGeneration(provider);
   return { isCurrent: () => generation === currentGeneration(provider) };
 }
@@ -125,7 +127,9 @@ function decodeTokenMetadata(raw: string): CloudTokenBundle | null {
   }
 }
 
-function readCloudTokenBundle(provider: CloudProvider): CloudTokenBundle | null {
+function readCloudTokenBundle(
+  provider: CloudProvider,
+): CloudTokenBundle | null {
   const metadata = localStorage.getItem(CLOUD_TOKEN_META_KEY(provider));
   if (metadata !== null) return decodeTokenMetadata(metadata);
   const accessToken = localStorage.getItem(CLOUD_TOKEN_KEY(provider));
@@ -267,7 +271,9 @@ export async function forceRefreshCloudToken(
 ): Promise<string | null> {
   const bundle = readCloudTokenBundle(provider);
   if (!bundle) return null;
-  return provider === "gdrive" ? refreshGoogleToken(bundle) : bundle.accessToken;
+  return provider === "gdrive"
+    ? refreshGoogleToken(bundle)
+    : bundle.accessToken;
 }
 
 export function getActiveProviders(): CloudProvider[] {
@@ -343,7 +349,9 @@ export function initiateDesktopOAuth(
   return operation;
 }
 
-async function initiateGoogleOAuth(signal: AbortSignal): Promise<CloudTokenBundle> {
+async function initiateGoogleOAuth(
+  signal: AbortSignal,
+): Promise<CloudTokenBundle> {
   throwIfOAuthCanceled(signal);
   const verifier = generateCodeVerifier();
   const challenge = await generateCodeChallenge(verifier);
@@ -387,7 +395,9 @@ async function initiateGoogleOAuth(signal: AbortSignal): Promise<CloudTokenBundl
       (event) => {
         finish();
         if (event.payload.state !== state) {
-          reject(new Error("OAuth state mismatch. Please try connecting again."));
+          reject(
+            new Error("OAuth state mismatch. Please try connecting again."),
+          );
         } else if (!event.payload.code) {
           reject(new Error("OAuth callback did not include a code."));
         } else {
@@ -450,7 +460,9 @@ export async function startCloudSync(
     throw new Error("The SQLite Library currently requires Google Drive.");
   }
   if (!isSqliteLibraryGoogleDriveSyncEnabled()) {
-    throw new Error("SQLite Library cloud sync is disabled on this Freed Desktop.");
+    throw new Error(
+      "SQLite Library cloud sync is disabled on this Freed Desktop.",
+    );
   }
   if (hasFactoryResetCloudCleanupBarrier()) return;
   stopCloudSync(provider);
@@ -464,29 +476,59 @@ export async function startCloudSync(
     statusMessage: "Publishing the SQLite Library checkpoint.",
     pendingReason: "Building bounded immutable checkpoint pages.",
   });
-  const result = await startSqliteLibraryGoogleDriveSync({
-    accessToken: token,
-    googleFetch: googleDriveFetch,
-    resolveAccessToken: async () => {
-      if (
-        controller.signal.aborted ||
-        generation !== currentGeneration(provider)
-      ) {
-        throw new Error("SQLite Library sync stopped.");
-      }
-      const accessToken = await getValidCloudToken(provider);
-      if (!accessToken) throw new Error("Reconnect Google Drive to resume sync.");
-      return accessToken;
-    },
-  });
-  if (controller.signal.aborted || generation !== currentGeneration(provider)) return;
+  let result: Awaited<ReturnType<typeof startSqliteLibraryGoogleDriveSync>>;
+  try {
+    result = await startSqliteLibraryGoogleDriveSync({
+      accessToken: token,
+      googleFetch: googleDriveFetch,
+      resolveAccessToken: async () => {
+        if (
+          controller.signal.aborted ||
+          generation !== currentGeneration(provider)
+        ) {
+          throw new Error("SQLite Library sync stopped.");
+        }
+        const accessToken = await getValidCloudToken(provider);
+        if (!accessToken)
+          throw new Error("Reconnect Google Drive to resume sync.");
+        return accessToken;
+      },
+    });
+  } catch (error) {
+    if (
+      controller.signal.aborted ||
+      generation !== currentGeneration(provider)
+    ) {
+      return;
+    }
+    const message =
+      error instanceof Error ? error.message : "SQLite Library sync failed.";
+    updateCloudProvider(provider, {
+      status: "error",
+      stage: "idle",
+      error: message,
+      statusMessage: "SQLite Library sync needs attention.",
+      pendingReason:
+        "Try Sync now again. Reconnect Google Drive if the problem continues.",
+    });
+    recordCloudProviderEvent(provider, {
+      kind: "error",
+      stage: "idle",
+      message,
+    });
+    throw error;
+  }
+  if (controller.signal.aborted || generation !== currentGeneration(provider))
+    return;
   if (result.status === "ownership_required") {
     updateCloudProvider(provider, {
       status: "error",
       stage: "idle",
       error: "Another Freed Desktop currently owns writes for this Library.",
-      statusMessage: "This Freed Desktop is read-only until ownership is transferred.",
-      pendingReason: "Use Make This Freed Desktop the Writer to transfer ownership.",
+      statusMessage:
+        "This Freed Desktop is read-only until ownership is transferred.",
+      pendingReason:
+        "Use Make This Freed Desktop the Writer to transfer ownership.",
     });
     return;
   }
@@ -532,24 +574,31 @@ export async function syncCloudProviderNow(
     signal: cloudAborts.get(provider)?.signal,
   });
   if (result.status === "ownership_required") {
-    throw new Error("Another Freed Desktop currently owns writes for this Library.");
+    throw new Error(
+      "Another Freed Desktop currently owns writes for this Library.",
+    );
   }
   markConnected(result.status === "published");
 }
 
 export async function transferSqliteLibraryWriterToThisDesktop(): Promise<void> {
   const accessToken = await getValidCloudToken("gdrive");
-  if (!accessToken) throw new Error("Reconnect Google Drive to transfer ownership.");
+  if (!accessToken)
+    throw new Error("Reconnect Google Drive to transfer ownership.");
   const result = await makeThisSqliteLibraryDesktopWriter({
     accessToken,
     googleFetch: googleDriveFetch,
     signal: cloudAborts.get("gdrive")?.signal,
   });
   if (result.status === "bootstrap_required") {
-    throw new Error("Download the current cloud Library before taking ownership.");
+    throw new Error(
+      "Download the current cloud Library before taking ownership.",
+    );
   }
   if (result.status === "ownership_required") {
-    throw new Error("Library ownership changed. Review the current owner and try again.");
+    throw new Error(
+      "Library ownership changed. Review the current owner and try again.",
+    );
   }
   await reloadSqliteLibraryState();
   await startCloudSync("gdrive", accessToken);
@@ -570,7 +619,9 @@ export async function deleteCloudFile(
   _provider: CloudProvider,
   _token: string,
 ): Promise<void> {
-  throw new Error("Factory reset cannot delete the active SQLite Library authority.");
+  throw new Error(
+    "Factory reset cannot delete the active SQLite Library authority.",
+  );
 }
 
 export async function clearStoredCloudDataForFactoryReset(


### PR DESCRIPTION
(AI Generated).

## Summary
- Release canceled or timed-out native publication attempts so later sync retries can proceed.
- Record native publication stages and surface failures in Sync diagnostics instead of leaving Google Drive stuck on Connecting.

## Testing
- npm run validate:feature
- Desktop unit test: library-core-cloud-sync.test.ts (6 passed)

## Provider Review
- Status: Provider authority is validated for ready publication.
- Review action: none required. The provider-risk artifact records the behavior authority decision; this exact provider subdiff is the audit subject.
- Provider subdiff: `0e243e55e06147e83a5eb7c62513758d1e1510aa`
- Publication does not authorize new live provider traffic. Gate 1 behavior approval still applies when observable behavior changes.
- Provider review task: `drive-sync-lifecycle-20260815`
- Provider review decision: `behavior_approved`
- Provider review artifact: `e28ef4c0278f453f3e90fee0a9e01c558050f5249dbcb103e9b3e750f0e83df7`
- Providers: other
- Observable behavior: Google Drive sync may make the already configured publication attempt after a canceled or timed-out local native command instead of remaining permanently blocked. Existing polling, publication cadence, OAuth scopes, headers, cookies, object format, and user-triggered Sync now behavior remain unchanged.
- Fingerprinting risk: Google Drive may observe a later retry that the broken client previously prevented. The repair adds no new scheduled contact and does not increase the configured cadence.
- Lowest profile alternative: Leave Google Drive sync wedged after an abandoned native command and require the user to restart or reconnect manually.

Files bound into this provider review:
- `packages/desktop/src/lib/sync.ts`