### PR TITLE
fix: read immutable Drive objects without browser ETags

### DIFF
--- a/packages/sync/src/cloud/library-core-google-drive-adapter.test.ts
+++ b/packages/sync/src/cloud/library-core-google-drive-adapter.test.ts
@@ -95,6 +95,7 @@ class FakeGoogleDrive {
   nextId = 1;
   uploadFixture: ReturnType<typeof operationObject> | null = null;
   intentHeadFixture: ReturnType<typeof emptyIntentHead> | null = null;
+  exposeMediaEtag = true;
 
   addControl(
     id = "control-1",
@@ -276,7 +277,7 @@ class FakeGoogleDrive {
       if (parsed.searchParams.get("alt") === "media") {
         return new Response(file.bytes.slice(), {
           headers: {
-            ETag: file.etag,
+            ...(this.exposeMediaEtag ? { ETag: file.etag } : {}),
             "Content-Length": String(file.bytes.byteLength),
           },
         });
@@ -367,6 +368,7 @@ describe("Google Drive Library Core immutable adapter", () => {
 
   it("discovers a fresh PWA library identity from the sole published control", async () => {
     const fake = new FakeGoogleDrive();
+    fake.exposeMediaEtag = false;
     const manifestDigest = "22".repeat(32);
     fake.addControl(
       "control-1",
@@ -406,7 +408,6 @@ describe("Google Drive Library Core immutable adapter", () => {
     expect(discovered).toMatchObject({
       controlFileId: "control-1",
       libraryId: "library-1",
-      control: { revision: '"control-revision-1"' },
     });
     expect(discovered?.control.bytes.byteLength).toBeGreaterThan(0);
     const query = new URL(fake.requests[0]?.url ?? "").searchParams.get("q");
@@ -441,6 +442,7 @@ describe("Google Drive Library Core immutable adapter", () => {
 
   it("uploads one bounded immutable object and verifies exact stored bytes", async () => {
     const fake = new FakeGoogleDrive();
+    fake.exposeMediaEtag = false;
     fake.addControl();
     const fixture = operationObject();
     fake.uploadFixture = fixture;

--- a/packages/sync/src/cloud/library-core-google-drive-adapter.ts
+++ b/packages/sync/src/cloud/library-core-google-drive-adapter.ts
@@ -87,7 +87,6 @@ export interface PublishedGoogleDriveLibraryCoreControlV1
   extends GoogleDriveLibraryCoreControlLocatorV1 {
   readonly control: {
     readonly bytes: Uint8Array;
-    readonly revision: string;
   };
   readonly libraryId: string;
 }
@@ -538,7 +537,7 @@ async function listDriveFilesByProperties(input: {
   );
 }
 
-async function readDriveFile(input: {
+async function readDriveFileWithRevision(input: {
   readonly accessToken: string;
   readonly fileId: string;
   readonly googleFetch: GoogleDriveFetch;
@@ -564,6 +563,25 @@ async function readDriveFile(input: {
       input.label,
     ),
   };
+}
+
+async function readDriveFileBytes(input: {
+  readonly accessToken: string;
+  readonly fileId: string;
+  readonly googleFetch: GoogleDriveFetch;
+  readonly signal?: AbortSignal;
+  readonly maxBytes: number;
+  readonly label: string;
+}): Promise<Uint8Array> {
+  const response = await input.googleFetch(
+    `${DRIVE_FILES_URL}/${encodeURIComponent(input.fileId)}?alt=media`,
+    {
+      headers: authorizationHeaders(input.accessToken),
+      signal: input.signal,
+    },
+  );
+  if (!response.ok) throw await responseError(input.label, response);
+  return readBoundedResponseBytes(response, input.maxBytes, input.label);
 }
 
 async function readDriveFileMetadata(input: {
@@ -680,7 +698,7 @@ export async function discoverPublishedGoogleDriveLibraryCoreControlV1(input: {
   });
   const file = files[0];
   if (file === undefined) return null;
-  const control = await readDriveFile({
+  const controlBytes = await readDriveFileBytes({
     accessToken: input.accessToken,
     fileId: file.id,
     googleFetch,
@@ -689,12 +707,12 @@ export async function discoverPublishedGoogleDriveLibraryCoreControlV1(input: {
     label: "Library Core Drive control discovery",
   });
   const decoded = JSON.parse(
-    new TextDecoder("utf-8", { fatal: true }).decode(control.bytes),
+    new TextDecoder("utf-8", { fatal: true }).decode(controlBytes),
   );
   const pointer = parseLibraryCoreControlPointerV1(decoded);
   return Object.freeze({
     controlFileId: file.id,
-    control: Object.freeze(control),
+    control: Object.freeze({ bytes: controlBytes }),
     libraryId: pointer.libraryId,
   });
 }
@@ -760,7 +778,7 @@ async function discoverGoogleDriveLibraryCoreActorObjectsV1(input: {
       expectedProperties,
       `actor ${kind} ${descriptor.objectKey}`,
     );
-    const stored = await readDriveFile({
+    const storedBytes = await readDriveFileBytes({
       accessToken: input.accessToken,
       fileId: file.id,
       googleFetch,
@@ -769,14 +787,14 @@ async function discoverGoogleDriveLibraryCoreActorObjectsV1(input: {
       label: `actor ${kind} ${descriptor.objectKey}`,
     });
     if (
-      stored.bytes.byteLength !== descriptor.byteLength ||
-      (await sha256Hex(stored.bytes)) !== descriptor.contentDigest
+      storedBytes.byteLength !== descriptor.byteLength ||
+      (await sha256Hex(storedBytes)) !== descriptor.contentDigest
     ) {
       throw new Error(`actor ${kind} bytes are corrupt`);
     }
     discovered.push(
       Object.freeze({
-        bytes: stored.bytes,
+        bytes: storedBytes,
         reference: Object.freeze({
           descriptor,
           transportObjectId: file.id,
@@ -1232,7 +1250,7 @@ export function createGoogleDriveLibraryCoreIntentAdapterV1(
       await expectedPropertiesPromise,
       "Library Core Drive intent head",
     );
-    const stored = await readDriveFile({
+    const stored = await readDriveFileWithRevision({
       accessToken: options.accessToken,
       fileId: options.intentHeadFileId,
       googleFetch,
@@ -1417,7 +1435,7 @@ export function createGoogleDriveLibraryCoreResultAdapterV1(
       googleFetch, signal: options.signal,
     });
     assertExpectedProperties(metadata.appProperties, await expectedPropertiesPromise, "Library Core Drive result head");
-    const stored = await readDriveFile({
+    const stored = await readDriveFileWithRevision({
       accessToken: options.accessToken, fileId: options.resultHeadFileId,
       googleFetch, signal: options.signal, maxBytes: MAX_RESULT_HEAD_BYTES,
       label: "Library Core Drive result-head read failed",
@@ -1536,7 +1554,7 @@ export function createGoogleDriveLibraryCoreAdapterV1(
       expectedProperties,
       `immutable Drive object ${descriptor.objectKey}`,
     );
-    const stored = await readDriveFile({
+    const storedBytes = await readDriveFileBytes({
       accessToken: options.accessToken,
       fileId,
       googleFetch,
@@ -1544,19 +1562,19 @@ export function createGoogleDriveLibraryCoreAdapterV1(
       maxBytes: descriptor.byteLength,
       label: `immutable Drive object ${descriptor.objectKey}`,
     });
-    if (stored.bytes.byteLength !== descriptor.byteLength) {
+    if (storedBytes.byteLength !== descriptor.byteLength) {
       throw new Error(
         `immutable Drive byte length mismatch for ${descriptor.objectKey}`,
       );
     }
-    const storedDigest = await sha256Hex(stored.bytes);
+    const storedDigest = await sha256Hex(storedBytes);
     if (storedDigest !== descriptor.contentDigest) {
       throw new Error(
         `immutable Drive digest mismatch for ${descriptor.objectKey}`,
       );
     }
     return Object.freeze({
-      bytes: stored.bytes,
+      bytes: storedBytes,
       descriptor,
     });
   }
@@ -1569,7 +1587,7 @@ export function createGoogleDriveLibraryCoreAdapterV1(
   }
 
   const readControl = async (): Promise<LibraryCoreControlReadV1> => {
-    const stored = await readDriveFile({
+    const stored = await readDriveFileWithRevision({
       accessToken: options.accessToken,
       fileId: options.controlFileId,
       googleFetch,


### PR DESCRIPTION
(AI Generated).

## Summary
- Lets the PWA discover and import immutable Google Drive Library objects when CORS does not expose response ETags.
- Keeps exact ETag requirements for mutable control, intent-head, and result-head compare-and-swap reads.

## Testing
- Pinned Node v24.14.1: @freed/sync Google Drive adapter tests, 19 passed
- Pinned Node v24.14.1: @freed/sync typecheck
- npm run validate:feature before the exact release reverse-integration rebase

## Provider Review
- Status: Provider authority is validated for ready publication.
- Review action: none required. The provider-risk artifact records the behavior authority decision; this exact provider subdiff is the audit subject.
- Provider subdiff: `f068d4935d1cf746921c81e5165e56cd1f262fd0`
- Publication does not authorize new live provider traffic. Gate 1 behavior approval still applies when observable behavior changes.
- Provider review task: `drive-sync-lifecycle-20260815`
- Provider review decision: `behavior_approved`
- Provider review artifact: `e28ef4c0278f453f3e90fee0a9e01c558050f5249dbcb103e9b3e750f0e83df7`
- Providers: other
- Observable behavior: Google Drive sync may make the already configured publication attempt after a canceled or timed-out local native command instead of remaining permanently blocked. Existing polling, publication cadence, OAuth scopes, headers, cookies, object format, and user-triggered Sync now behavior remain unchanged.
- Fingerprinting risk: Google Drive may observe a later retry that the broken client previously prevented. The repair adds no new scheduled contact and does not increase the configured cadence.
- Lowest profile alternative: Leave Google Drive sync wedged after an abandoned native command and require the user to restart or reconnect manually.

Files bound into this provider review:
- `packages/sync/src/cloud/library-core-google-drive-adapter.test.ts`
- `packages/sync/src/cloud/library-core-google-drive-adapter.ts`