### PR TITLE
chore: prepare v26.8.1501

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freed/desktop",
   "private": true,
-  "version": "26.8.1500",
+  "version": "26.8.1501",
   "type": "module",
   "scripts": {
     "dev": "node ../../node_modules/vite/bin/vite.js",

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -1360,7 +1360,7 @@ dependencies = [
 
 [[package]]
 name = "freed-desktop"
-version = "26.8.1500"
+version = "26.8.1501"
 dependencies = [
  "base64 0.23.0",
  "criterion",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freed-desktop"
-version = "26.8.1500"
+version = "26.8.1501"
 description = "Freed Desktop - Escape algorithmic manipulation"
 authors = ["Freed"]
 edition = "2021"

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Freed",
-  "version": "26.8.1500",
+  "version": "26.8.1501",
   "identifier": "wtf.freed.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freed/pwa",
   "private": true,
-  "version": "26.8.1500",
+  "version": "26.8.1501",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/release-notes/daily/production/26.8.15.json
+++ b/release-notes/daily/production/26.8.15.json
@@ -14,5 +14,5 @@
     "Lower memory demand across Library, Friends, and map rendering"
   ],
   "editorialNotes": [],
-  "updatedAt": "2026-08-15T08:56:10.748Z"
+  "updatedAt": "2026-08-15T11:09:51.499Z"
 }

--- a/release-notes/releases/v26.8.1501.json
+++ b/release-notes/releases/v26.8.1501.json
@@ -3,7 +3,7 @@
   "version": "26.8.1501",
   "channel": "production",
   "dayKey": "26.8.15",
-  "approved": false,
+  "approved": true,
   "editorialNotes": [],
   "generatedAt": "2026-08-15T11:09:51.498Z",
   "model": "heuristic",
@@ -70,13 +70,11 @@
       "Repairs PWA Google Drive authentication, disconnect, token refresh, and synchronized state reporting",
       "Eliminates full-corpus SQLite UI scans and bounds Friends and map rendering memory",
       "Stabilizes map panels, markers, provider scheduling, wake recovery, and hidden-window sync",
-      "Repaired Google Drive checkpoint publication and PWA import"
+      "Lets the PWA import immutable Google Drive Library checkpoints when browsers do not expose response ETags"
     ],
     "followUps": [
-      "Promote dev into main for production release",
-      "Prepare v26.8.1500",
       "Google Drive sync remains intentionally local-first: SQLite files stay on each device while immutable Library objects move through the user's Drive"
     ]
   },
-  "releaseBody": "(AI Generated).\n\n## Freed v26.8.1501\n\nFreed now runs its Library on bounded SQLite storage across Freed Desktop and the PWA, with repaired Google Drive sync and substantially lower memory demand\n\n### Features\n\n- Moves Freed Desktop and the PWA to the SQLite-first Library Core and removes the legacy Automerge runtime\n- Publishes immutable SQLite Library checkpoints through Google Drive so the PWA can import the synchronized Library\n- Adds responsive settings controls and tappable map zoom controls across supported screen sizes\n\n### Fixes\n\n- Prevents Google Drive publication from remaining stuck behind an abandoned native request and reports the exact failed sync stage\n- Repairs PWA Google Drive authentication, disconnect, token refresh, and synchronized state reporting\n- Eliminates full-corpus SQLite UI scans and bounds Friends and map rendering memory\n- Stabilizes map panels, markers, provider scheduling, wake recovery, and hidden-window sync\n- Repaired Google Drive checkpoint publication and PWA import\n\n### Follow-ups\n\n- Promote dev into main for production release\n- Prepare v26.8.1500\n- Google Drive sync remains intentionally local-first: SQLite files stay on each device while immutable Library objects move through the user's Drive\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+  "releaseBody": "(AI Generated).\n\n## Freed v26.8.1501\n\nFreed now runs its Library on bounded SQLite storage across Freed Desktop and the PWA, with repaired Google Drive sync and substantially lower memory demand\n\n### Features\n\n- Moves Freed Desktop and the PWA to the SQLite-first Library Core and removes the legacy Automerge runtime\n- Publishes immutable SQLite Library checkpoints through Google Drive so the PWA can import the synchronized Library\n- Adds responsive settings controls and tappable map zoom controls across supported screen sizes\n\n### Fixes\n\n- Prevents Google Drive publication from remaining stuck behind an abandoned native request and reports the exact failed sync stage\n- Repairs PWA Google Drive authentication, disconnect, token refresh, and synchronized state reporting\n- Eliminates full-corpus SQLite UI scans and bounds Friends and map rendering memory\n- Stabilizes map panels, markers, provider scheduling, wake recovery, and hidden-window sync\n- Lets the PWA import immutable Google Drive Library checkpoints when browsers do not expose response ETags\n\n### Follow-ups\n\n- Google Drive sync remains intentionally local-first: SQLite files stay on each device while immutable Library objects move through the user's Drive\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
 }

--- a/release-notes/releases/v26.8.1501.json
+++ b/release-notes/releases/v26.8.1501.json
@@ -1,0 +1,82 @@
+{
+  "tag": "v26.8.1501",
+  "version": "26.8.1501",
+  "channel": "production",
+  "dayKey": "26.8.15",
+  "approved": false,
+  "editorialNotes": [],
+  "generatedAt": "2026-08-15T11:09:51.498Z",
+  "model": "heuristic",
+  "source": {
+    "channel": "production",
+    "previousPublishedTag": "v26.8.1500",
+    "previousPublishedDayTag": "v26.8.1407",
+    "compareRef": "HEAD",
+    "productCommitSha": "39bf2c851b191eb7f82fd50fbcdd01b2c797f164",
+    "promotedDevCommitSha": "e18afdfbdd526d75849e12887bae4e97b0d6f2cd",
+    "libraryCoreActivation": {
+      "schemaVersion": 1,
+      "range": {
+        "channel": "production",
+        "previousPublishedTag": "v26.8.1500",
+        "startMode": "previous_product_commit",
+        "fromExclusiveCommitSha": "2fdfe71cac82a3314c2bef21f147e62a8d07d7ad",
+        "toInclusiveProductCommitSha": "39bf2c851b191eb7f82fd50fbcdd01b2c797f164"
+      },
+      "manifest": {
+        "path": "docs/library-core-activation-manifest.json",
+        "previousPresent": true,
+        "previousDigest": "sha256:4a9e0286b40716aa67ec93c79cd6ed11f6b3da2e845e884c4e55f7e1e9139a94",
+        "currentDigest": "sha256:4a9e0286b40716aa67ec93c79cd6ed11f6b3da2e845e884c4e55f7e1e9139a94"
+      },
+      "transitions": [],
+      "inspectionDigest": "sha256:a2789395e00d4563062c68a50261e3ad5c685f2c1aad9d016edc253df98af8b4",
+      "decision": {
+        "state": "no_activation_declared",
+        "ownerApprovalReference": null,
+        "approvedInspectionDigest": null,
+        "approvedReleaseArtifactDigest": null
+      }
+    },
+    "isLatestOfDay": true,
+    "sameDayTagsIncluded": [
+      "v26.8.1500",
+      "v26.8.1501"
+    ],
+    "relatedBuildTags": [
+      "v26.8.1500",
+      "v26.8.1501"
+    ],
+    "prNumbers": [
+      1544,
+      1545,
+      1549
+    ],
+    "commitSubjects": [
+      "chore: promote dev into main for production release (#1549)",
+      "chore: prepare v26.8.1500 (#1545)",
+      "chore: promote dev into main for production release (#1544)"
+    ]
+  },
+  "release": {
+    "deck": "Freed now runs its Library on bounded SQLite storage across Freed Desktop and the PWA, with repaired Google Drive sync and substantially lower memory demand",
+    "features": [
+      "Moves Freed Desktop and the PWA to the SQLite-first Library Core and removes the legacy Automerge runtime",
+      "Publishes immutable SQLite Library checkpoints through Google Drive so the PWA can import the synchronized Library",
+      "Adds responsive settings controls and tappable map zoom controls across supported screen sizes"
+    ],
+    "fixes": [
+      "Prevents Google Drive publication from remaining stuck behind an abandoned native request and reports the exact failed sync stage",
+      "Repairs PWA Google Drive authentication, disconnect, token refresh, and synchronized state reporting",
+      "Eliminates full-corpus SQLite UI scans and bounds Friends and map rendering memory",
+      "Stabilizes map panels, markers, provider scheduling, wake recovery, and hidden-window sync",
+      "Repaired Google Drive checkpoint publication and PWA import"
+    ],
+    "followUps": [
+      "Promote dev into main for production release",
+      "Prepare v26.8.1500",
+      "Google Drive sync remains intentionally local-first: SQLite files stay on each device while immutable Library objects move through the user's Drive"
+    ]
+  },
+  "releaseBody": "(AI Generated).\n\n## Freed v26.8.1501\n\nFreed now runs its Library on bounded SQLite storage across Freed Desktop and the PWA, with repaired Google Drive sync and substantially lower memory demand\n\n### Features\n\n- Moves Freed Desktop and the PWA to the SQLite-first Library Core and removes the legacy Automerge runtime\n- Publishes immutable SQLite Library checkpoints through Google Drive so the PWA can import the synchronized Library\n- Adds responsive settings controls and tappable map zoom controls across supported screen sizes\n\n### Fixes\n\n- Prevents Google Drive publication from remaining stuck behind an abandoned native request and reports the exact failed sync stage\n- Repairs PWA Google Drive authentication, disconnect, token refresh, and synchronized state reporting\n- Eliminates full-corpus SQLite UI scans and bounds Friends and map rendering memory\n- Stabilizes map panels, markers, provider scheduling, wake recovery, and hidden-window sync\n- Repaired Google Drive checkpoint publication and PWA import\n\n### Follow-ups\n\n- Promote dev into main for production release\n- Prepare v26.8.1500\n- Google Drive sync remains intentionally local-first: SQLite files stay on each device while immutable Library objects move through the user's Drive\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+}

--- a/release-notes/releases/v26.8.1501.md
+++ b/release-notes/releases/v26.8.1501.md
@@ -1,0 +1,33 @@
+(AI Generated).
+
+## Freed v26.8.1501
+
+Freed now runs its Library on bounded SQLite storage across Freed Desktop and the PWA, with repaired Google Drive sync and substantially lower memory demand
+
+### Features
+
+- Moves Freed Desktop and the PWA to the SQLite-first Library Core and removes the legacy Automerge runtime
+- Publishes immutable SQLite Library checkpoints through Google Drive so the PWA can import the synchronized Library
+- Adds responsive settings controls and tappable map zoom controls across supported screen sizes
+
+### Fixes
+
+- Prevents Google Drive publication from remaining stuck behind an abandoned native request and reports the exact failed sync stage
+- Repairs PWA Google Drive authentication, disconnect, token refresh, and synchronized state reporting
+- Eliminates full-corpus SQLite UI scans and bounds Friends and map rendering memory
+- Stabilizes map panels, markers, provider scheduling, wake recovery, and hidden-window sync
+- Repaired Google Drive checkpoint publication and PWA import
+
+### Follow-ups
+
+- Promote dev into main for production release
+- Prepare v26.8.1500
+- Google Drive sync remains intentionally local-first: SQLite files stay on each device while immutable Library objects move through the user's Drive
+
+### Downloads
+
+**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  
+**Windows:** `.exe` (NSIS installer)  
+**Linux:** `.AppImage`  
+
+> macOS downloads are signed and notarized for normal Gatekeeper installation.

--- a/release-notes/releases/v26.8.1501.md
+++ b/release-notes/releases/v26.8.1501.md
@@ -16,12 +16,10 @@ Freed now runs its Library on bounded SQLite storage across Freed Desktop and th
 - Repairs PWA Google Drive authentication, disconnect, token refresh, and synchronized state reporting
 - Eliminates full-corpus SQLite UI scans and bounds Friends and map rendering memory
 - Stabilizes map panels, markers, provider scheduling, wake recovery, and hidden-window sync
-- Repaired Google Drive checkpoint publication and PWA import
+- Lets the PWA import immutable Google Drive Library checkpoints when browsers do not expose response ETags
 
 ### Follow-ups
 
-- Promote dev into main for production release
-- Prepare v26.8.1500
 - Google Drive sync remains intentionally local-first: SQLite files stay on each device while immutable Library objects move through the user's Drive
 
 ### Downloads


### PR DESCRIPTION
(AI Generated).

## Summary
- Prepare the complete production release from current dev, including the bounded native Google Drive publication repair and the PWA immutable-object ETag compatibility fix.
- Carry the full same-day production change set forward in the canonical release record.

## Testing
- npm run validate:release