### PR TITLE
fix: show honest Drive sync activity

### DIFF
--- a/packages/desktop/src/components/MobileSyncTab.test.tsx
+++ b/packages/desktop/src/components/MobileSyncTab.test.tsx
@@ -131,6 +131,30 @@ describe("MobileSyncTab cloud diagnostics", () => {
     expect(mocks.syncCloudProviderNow).toHaveBeenCalledWith("gdrive");
   });
 
+  it("shows honest activity feedback while Drive publication is running", async () => {
+    useDebugStore.setState({
+      cloudProviders: {
+        dropbox: { status: "idle" },
+        gdrive: {
+          status: "connecting",
+          stage: "upload",
+          statusMessage: "Publishing the SQLite Library checkpoint.",
+          pendingReason: "Publishing immutable Library objects now.",
+        },
+      },
+    });
+
+    await act(async () => {
+      root.render(<MobileSyncTab />);
+    });
+
+    const status = container.querySelector("[data-testid='cloud-sync-status-message']");
+    expect(status?.getAttribute("aria-busy")).toBe("true");
+    expect(status?.getAttribute("role")).toBe("status");
+    expect(status?.textContent).toContain("Publishing the SQLite Library checkpoint.");
+    expect(container.querySelector("[data-testid='cloud-sync-activity-spinner']")).not.toBeNull();
+  });
+
   it("warns when the synced library has multiple Freed Desktop clients", async () => {
     useAppStore.setState({
       desktopClientIds: ["desktop-current", "desktop-other"],

--- a/packages/desktop/src/components/MobileSyncTab.tsx
+++ b/packages/desktop/src/components/MobileSyncTab.tsx
@@ -87,6 +87,7 @@ export function MobileSyncTab() {
       : { status: driveState.status };
   const connected = driveCardState.status === "connected";
   const diagnosticError = driveState?.error ?? manualError;
+  const publishing = driveState?.stage === "upload" || syncing;
 
   useEffect(() => {
     setWarningDismissed(isDesktopClientWarningAcknowledged(warningSignature));
@@ -225,9 +226,19 @@ export function MobileSyncTab() {
 
             <div
               data-testid="cloud-sync-status-message"
+              aria-busy={publishing}
+              aria-live="polite"
+              role="status"
               className="mb-3 rounded-lg bg-[var(--theme-bg-muted)] px-3 py-2 text-xs text-[var(--theme-text-secondary)]"
             >
-              <p className="font-medium text-[var(--theme-text-primary)]">
+              <p className="flex items-center gap-2 font-medium text-[var(--theme-text-primary)]">
+                {publishing && (
+                  <span
+                    aria-hidden="true"
+                    data-testid="cloud-sync-activity-spinner"
+                    className="h-3 w-3 shrink-0 animate-spin rounded-full border border-[var(--theme-accent-secondary)] border-t-transparent"
+                  />
+                )}
                 {driveState?.statusMessage ?? "No cloud sync activity yet."}
               </p>
               <p className="mt-1 text-[var(--theme-text-muted)]">

--- a/packages/ui/src/components/CloudProviderCard.tsx
+++ b/packages/ui/src/components/CloudProviderCard.tsx
@@ -148,6 +148,12 @@ export function CloudProviderCard({
                 : "theme-accent-tag"
           }`}
         >
+          {isConnecting && (
+            <span
+              aria-hidden="true"
+              className="mr-1.5 inline-block h-3 w-3 align-[-0.125rem] animate-spin rounded-full border border-current border-t-transparent"
+            />
+          )}
           {isComingSoon
             ? "Coming soon"
             : isConnecting


### PR DESCRIPTION
(AI Generated).

## Summary
- Show a spinner and accessible busy status only while Google Drive connection or SQLite Library publication work is active.
- Preserve the existing five-minute publication timeout so a stalled operation settles as an error instead of appearing active forever.

## Testing
- npm run validate:feature

## Provider Review
- Status: Provider authority is validated for ready publication.
- Review action: none required. The provider-risk artifact records the behavior authority decision; this exact provider subdiff is the audit subject.
- Provider subdiff: `190c866c2b4692e7cad8f0d19bde91361034f18c`
- Publication does not authorize new live provider traffic. Gate 1 behavior approval still applies when observable behavior changes.
- Provider review task: `drive-sync-lifecycle-20260815`
- Provider review decision: `behavior_approved`
- Provider review artifact: `e28ef4c0278f453f3e90fee0a9e01c558050f5249dbcb103e9b3e750f0e83df7`
- Providers: other
- Observable behavior: Google Drive sync may make the already configured publication attempt after a canceled or timed-out local native command instead of remaining permanently blocked. Existing polling, publication cadence, OAuth scopes, headers, cookies, object format, and user-triggered Sync now behavior remain unchanged.
- Fingerprinting risk: Google Drive may observe a later retry that the broken client previously prevented. The repair adds no new scheduled contact and does not increase the configured cadence.
- Lowest profile alternative: Leave Google Drive sync wedged after an abandoned native command and require the user to restart or reconnect manually.

Files bound into this provider review:
- `packages/desktop/src/components/MobileSyncTab.tsx`