### PR TITLE
chore: publish v26.8.1800 changelog

### DIFF
--- a/release-notes/daily/production/26.8.18.json
+++ b/release-notes/daily/production/26.8.18.json
@@ -1,0 +1,14 @@
+{
+  "channel": "production",
+  "dayKey": "26.8.18",
+  "date": "2026-08-18",
+  "preferredDeck": null,
+  "editorialGuidance": [
+    "Keep the tone concise, professional, and specific.",
+    "Lead with user-facing outcomes, shipping milestones, trust wins, and installability improvements.",
+    "Demote internal cleanup unless it clearly changes the shipped product."
+  ],
+  "pinnedHighlights": [],
+  "editorialNotes": [],
+  "updatedAt": "2026-08-19T03:44:13.121Z"
+}

--- a/release-notes/releases/v26.8.1800.json
+++ b/release-notes/releases/v26.8.1800.json
@@ -1,0 +1,68 @@
+{
+  "tag": "v26.8.1800",
+  "version": "26.8.1800",
+  "channel": "production",
+  "dayKey": "26.8.18",
+  "approved": true,
+  "editorialNotes": [],
+  "generatedAt": "2026-08-19T03:44:13.121Z",
+  "model": "heuristic",
+  "source": {
+    "channel": "production",
+    "previousPublishedTag": "v26.8.1501",
+    "previousPublishedDayTag": "v26.8.1501",
+    "compareRef": "HEAD",
+    "productCommitSha": "1e33dc1588e952b9acdc4991aa8ac89af34792d9",
+    "promotedDevCommitSha": "92c08c070a1086e2a2e1e31b5116088a0a463ba0",
+    "libraryCoreActivation": {
+      "schemaVersion": 1,
+      "range": {
+        "channel": "production",
+        "previousPublishedTag": "v26.8.1501",
+        "startMode": "previous_product_commit",
+        "fromExclusiveCommitSha": "39bf2c851b191eb7f82fd50fbcdd01b2c797f164",
+        "toInclusiveProductCommitSha": "1e33dc1588e952b9acdc4991aa8ac89af34792d9"
+      },
+      "manifest": {
+        "path": "docs/library-core-activation-manifest.json",
+        "previousPresent": true,
+        "previousDigest": "sha256:4a9e0286b40716aa67ec93c79cd6ed11f6b3da2e845e884c4e55f7e1e9139a94",
+        "currentDigest": "sha256:4a9e0286b40716aa67ec93c79cd6ed11f6b3da2e845e884c4e55f7e1e9139a94"
+      },
+      "transitions": [],
+      "inspectionDigest": "sha256:2e972a4555186f4de080719dbb030e16fc79366c61f1f87a16922b0e110ed70e",
+      "decision": {
+        "state": "no_activation_declared",
+        "ownerApprovalReference": null,
+        "approvedInspectionDigest": null,
+        "approvedReleaseArtifactDigest": null
+      }
+    },
+    "isLatestOfDay": true,
+    "sameDayTagsIncluded": [
+      "v26.8.1800"
+    ],
+    "relatedBuildTags": [
+      "v26.8.1800"
+    ],
+    "prNumbers": [
+      1556
+    ],
+    "commitSubjects": [
+      "chore: promote dev into main for production release (#1556)"
+    ]
+  },
+  "release": {
+    "deck": "Google Drive Library setup now handles abandoned empty controls safely and reports precise Freed Desktop sync failures",
+    "features": [],
+    "fixes": [
+      "Lets the authenticated PWA ignore a bounded set of exact empty Google Drive control placeholders left by interrupted setup while still failing closed on conflicting published controls",
+      "Preserves the exact native Google Drive failure stage in Freed Desktop instead of replacing it with a generic connection failed error",
+      "Keeps Google Drive control discovery bounded and avoids downloading known empty provisioning placeholders"
+    ],
+    "followUps": [
+      "Freed moves immutable Library objects through Google Drive and never uploads SQLite, WAL, or SHM files"
+    ]
+  },
+  "releaseBody": "(AI Generated).\n\n## Freed v26.8.1800\n\nGoogle Drive Library setup now handles abandoned empty controls safely and reports precise Freed Desktop sync failures\n\n### Fixes\n\n- Lets the authenticated PWA ignore a bounded set of exact empty Google Drive control placeholders left by interrupted setup while still failing closed on conflicting published controls\n- Preserves the exact native Google Drive failure stage in Freed Desktop instead of replacing it with a generic connection failed error\n- Keeps Google Drive control discovery bounded and avoids downloading known empty provisioning placeholders\n\n### Follow-ups\n\n- Freed moves immutable Library objects through Google Drive and never uploads SQLite, WAL, or SHM files\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+}

--- a/release-notes/releases/v26.8.1800.md
+++ b/release-notes/releases/v26.8.1800.md
@@ -1,0 +1,23 @@
+(AI Generated).
+
+## Freed v26.8.1800
+
+Google Drive Library setup now handles abandoned empty controls safely and reports precise Freed Desktop sync failures
+
+### Fixes
+
+- Lets the authenticated PWA ignore a bounded set of exact empty Google Drive control placeholders left by interrupted setup while still failing closed on conflicting published controls
+- Preserves the exact native Google Drive failure stage in Freed Desktop instead of replacing it with a generic connection failed error
+- Keeps Google Drive control discovery bounded and avoids downloading known empty provisioning placeholders
+
+### Follow-ups
+
+- Freed moves immutable Library objects through Google Drive and never uploads SQLite, WAL, or SHM files
+
+### Downloads
+
+**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  
+**Windows:** `.exe` (NSIS installer)  
+**Linux:** `.AppImage`  
+
+> macOS downloads are signed and notarized for normal Gatekeeper installation.

--- a/website/public/atom.xml
+++ b/website/public/atom.xml
@@ -2,7 +2,7 @@
 <feed xmlns="http://www.w3.org/2005/Atom">
     <id>https://freed.wtf</id>
     <title>Freed Blog</title>
-    <updated>2026-08-15T04:26:01.197Z</updated>
+    <updated>2026-08-19T06:26:04.543Z</updated>
     <generator>https://github.com/jpmonette/feed</generator>
     <author>
         <name>The Freed Team</name>

--- a/website/public/feed.xml
+++ b/website/public/feed.xml
@@ -4,7 +4,7 @@
         <title>Freed Blog</title>
         <link>https://freed.wtf</link>
         <description>Progress reports, technical deep-dives, and philosophical rants about the attention economy. From the team building Freed.</description>
-        <lastBuildDate>Sat, 15 Aug 2026 04:26:01 GMT</lastBuildDate>
+        <lastBuildDate>Wed, 19 Aug 2026 06:26:04 GMT</lastBuildDate>
         <docs>https://validator.w3.org/feed/docs/rss2.html</docs>
         <generator>https://github.com/jpmonette/feed</generator>
         <language>en</language>

--- a/website/src/content/changelog.generated.json
+++ b/website/src/content/changelog.generated.json
@@ -1,5 +1,101 @@
 [
   {
+    "version": "26.8.1800",
+    "tagName": "v26.8.1800",
+    "channel": "production",
+    "date": "2026-08-19T06:22:34Z",
+    "deck": "Google Drive Library setup now handles abandoned empty controls safely and reports precise Freed Desktop sync failures",
+    "features": [],
+    "fixes": [
+      {
+        "text": "Lets the authenticated PWA ignore a bounded set of exact empty Google Drive control placeholders left by interrupted setup while still failing closed on conflicting published controls"
+      },
+      {
+        "text": "Preserves the exact native Google Drive failure stage in Freed Desktop instead of replacing it with a generic connection failed error"
+      },
+      {
+        "text": "Keeps Google Drive control discovery bounded and avoids downloading known empty provisioning placeholders"
+      }
+    ],
+    "followUps": [
+      {
+        "text": "Freed moves immutable Library objects through Google Drive and never uploads SQLite, WAL, or SHM files"
+      }
+    ],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.8.1800",
+    "prNumbers": [
+      1556
+    ],
+    "builds": [
+      "26.8.1800"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.8.1800",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.8.1800",
+        "channel": "production"
+      }
+    ]
+  },
+  {
+    "version": "26.8.1501",
+    "tagName": "v26.8.1501",
+    "channel": "production",
+    "date": "2026-08-15T12:32:27Z",
+    "deck": "Freed now runs its Library on bounded SQLite storage across Freed Desktop and the PWA, with repaired Google Drive sync and substantially lower memory demand",
+    "features": [
+      {
+        "text": "Moves Freed Desktop and the PWA to the SQLite-first Library Core and removes the legacy Automerge runtime"
+      },
+      {
+        "text": "Publishes immutable SQLite Library checkpoints through Google Drive so the PWA can import the synchronized Library"
+      },
+      {
+        "text": "Adds responsive settings controls and tappable map zoom controls across supported screen sizes"
+      }
+    ],
+    "fixes": [
+      {
+        "text": "Prevents Google Drive publication from remaining stuck behind an abandoned native request and reports the exact failed sync stage"
+      },
+      {
+        "text": "Repairs PWA Google Drive authentication, disconnect, token refresh, and synchronized state reporting"
+      },
+      {
+        "text": "Eliminates full-corpus SQLite UI scans and bounds Friends and map rendering memory"
+      },
+      {
+        "text": "Stabilizes map panels, markers, provider scheduling, wake recovery, and hidden-window sync"
+      },
+      {
+        "text": "Lets the PWA import immutable Google Drive Library checkpoints when browsers do not expose response ETags"
+      }
+    ],
+    "followUps": [
+      {
+        "text": "Google Drive sync remains intentionally local-first: SQLite files stay on each device while immutable Library objects move through the user's Drive"
+      }
+    ],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.8.1501",
+    "prNumbers": [],
+    "builds": [
+      "26.8.1500",
+      "26.8.1501"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.8.1500",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.8.1500",
+        "channel": "production"
+      },
+      {
+        "version": "26.8.1501",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.8.1501",
+        "channel": "production"
+      }
+    ]
+  },
+  {
     "version": "26.8.1407",
     "tagName": "v26.8.1407",
     "channel": "production",


### PR DESCRIPTION
(AI Generated).

## Summary
- Publish the approved v26.8.1800 production release note from main
- Refresh the public changelog and feeds with v26.8.1800 and the previously published v26.8.1501 entry

## Testing
- cd website && PATH=../node_modules/.bin:$PATH npm run build
- Local production changelog preview showed v26.8.1800 at http://localhost:3001/changelog/prod