### PR TITLE
fix: sanitize runner sources before apt update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,6 +335,7 @@ jobs:
       - name: Install native Linux dependencies
         if: steps.feature-plan.outputs.needs_native == 'true'
         run: |
+          sudo rm -f /etc/apt/sources.list.d/azure-cli.list /etc/apt/sources.list.d/azure-cli.sources
           sudo apt-get update
           sudo apt-get install -y \
             build-essential \
@@ -350,7 +351,6 @@ jobs:
       - name: Install Playwright browsers
         if: steps.feature-plan.outputs.needs_playwright == 'true'
         run: |
-          sudo rm -f /etc/apt/sources.list.d/azure-cli.list /etc/apt/sources.list.d/azure-cli.sources
           npx playwright install --with-deps chromium
         working-directory: packages/desktop
 
@@ -442,6 +442,7 @@ jobs:
 
       - name: Install native Linux dependencies
         run: |
+          sudo rm -f /etc/apt/sources.list.d/azure-cli.list /etc/apt/sources.list.d/azure-cli.sources
           sudo apt-get update
           sudo apt-get install -y \
             build-essential \
@@ -456,7 +457,6 @@ jobs:
 
       - name: Install Playwright browsers
         run: |
-          sudo rm -f /etc/apt/sources.list.d/azure-cli.list /etc/apt/sources.list.d/azure-cli.sources
           npx playwright install --with-deps chromium
         working-directory: packages/desktop
 

--- a/.github/workflows/main-release-validation.yml
+++ b/.github/workflows/main-release-validation.yml
@@ -50,6 +50,7 @@ jobs:
 
       - name: Install native Linux dependencies
         run: |
+          sudo rm -f /etc/apt/sources.list.d/azure-cli.list /etc/apt/sources.list.d/azure-cli.sources
           sudo apt-get update
           sudo apt-get install -y \
             build-essential \
@@ -64,7 +65,6 @@ jobs:
 
       - name: Install Playwright browsers
         run: |
-          sudo rm -f /etc/apt/sources.list.d/azure-cli.list /etc/apt/sources.list.d/azure-cli.sources
           npx playwright install --with-deps chromium
         working-directory: packages/desktop
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -196,6 +196,7 @@ jobs:
       - name: Install native Linux dependencies
         if: needs.notes.outputs.release_channel != 'dev'
         run: |
+          sudo rm -f /etc/apt/sources.list.d/azure-cli.list /etc/apt/sources.list.d/azure-cli.sources
           sudo apt-get update
           sudo apt-get install -y \
             build-essential \
@@ -211,7 +212,6 @@ jobs:
       - name: Install Playwright browsers
         if: needs.notes.outputs.release_channel != 'dev'
         run: |
-          sudo rm -f /etc/apt/sources.list.d/azure-cli.list /etc/apt/sources.list.d/azure-cli.sources
           npx playwright install --with-deps chromium
         working-directory: packages/desktop
 

--- a/scripts/release-governance.test.mjs
+++ b/scripts/release-governance.test.mjs
@@ -187,6 +187,30 @@ test("release identity lanes receive authenticated pull request read access", ()
   }
 });
 
+test("native dependency setup removes the unstable Azure package source before apt update", () => {
+  for (const [name, workflow, expectedCount] of [
+    ["CI", ciWorkflow, 2],
+    ["production validation", mainReleaseValidationWorkflow, 1],
+    ["release", releaseWorkflow, 1],
+  ]) {
+    const blocks = workflow.match(
+      /- name: Install native Linux dependencies[\s\S]*?(?=\n      - name:)/g,
+    );
+    assert.equal(blocks?.length, expectedCount, `${name} native setup count`);
+    for (const block of blocks ?? []) {
+      const sourceRemoval = block.indexOf(
+        "sudo rm -f /etc/apt/sources.list.d/azure-cli.list",
+      );
+      const aptUpdate = block.indexOf("sudo apt-get update");
+      assert.ok(sourceRemoval >= 0, `${name} removes the Azure package source`);
+      assert.ok(
+        sourceRemoval < aptUpdate,
+        `${name} removes the Azure package source before apt update`,
+      );
+    }
+  }
+});
+
 test("dev tag validation inherits the exact successful dev integration receipt", () => {
   const validationJob = releaseWorkflow.slice(
     releaseWorkflow.indexOf("\n  validation:"),


### PR DESCRIPTION
(AI Generated).

## Summary
- Remove the unstable Azure CLI package source before the first apt update in feature, dev, production, and release validation jobs.
- Keep Playwright setup on the same sanitized runner state instead of deleting the source only after native dependency installation.

## Testing
- Exact-head Feature Validation, CodeQL, native acceptance, and the complete tooling smoke matrix passed at 5b18e2eddb3e5dfc67d484b7c81aa586c3e91eba.
- Release governance tests passed, 12 tests total, including an ordering regression check for every native dependency job.