### PR TITLE
fix: route CI away from stalled Ubuntu mirrors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,7 +335,7 @@ jobs:
       - name: Install native Linux dependencies
         if: steps.feature-plan.outputs.needs_native == 'true'
         run: |
-          sudo rm -f /etc/apt/sources.list.d/azure-cli.list /etc/apt/sources.list.d/azure-cli.sources
+          bash scripts/ci-sanitize-apt-sources.sh
           sudo apt-get update
           sudo apt-get install -y \
             build-essential \
@@ -442,7 +442,7 @@ jobs:
 
       - name: Install native Linux dependencies
         run: |
-          sudo rm -f /etc/apt/sources.list.d/azure-cli.list /etc/apt/sources.list.d/azure-cli.sources
+          bash scripts/ci-sanitize-apt-sources.sh
           sudo apt-get update
           sudo apt-get install -y \
             build-essential \

--- a/.github/workflows/main-release-validation.yml
+++ b/.github/workflows/main-release-validation.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Install native Linux dependencies
         run: |
-          sudo rm -f /etc/apt/sources.list.d/azure-cli.list /etc/apt/sources.list.d/azure-cli.sources
+          bash scripts/ci-sanitize-apt-sources.sh
           sudo apt-get update
           sudo apt-get install -y \
             build-essential \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -196,7 +196,7 @@ jobs:
       - name: Install native Linux dependencies
         if: needs.notes.outputs.release_channel != 'dev'
         run: |
-          sudo rm -f /etc/apt/sources.list.d/azure-cli.list /etc/apt/sources.list.d/azure-cli.sources
+          bash scripts/ci-sanitize-apt-sources.sh
           sudo apt-get update
           sudo apt-get install -y \
             build-essential \
@@ -315,6 +315,7 @@ jobs:
       - name: Install Linux dependencies
         if: runner.os == 'Linux'
         run: |
+          bash scripts/ci-sanitize-apt-sources.sh
           sudo apt-get update
           sudo apt-get install -y \
             libwebkit2gtk-4.1-dev \

--- a/.github/workflows/tooling-nightly.yml
+++ b/.github/workflows/tooling-nightly.yml
@@ -136,8 +136,7 @@ jobs:
 
       - name: Install Playwright browsers
         run: |
-          sudo rm -f /etc/apt/sources.list.d/azure-cli.list \
-            /etc/apt/sources.list.d/azure-cli.sources
+          bash ../../scripts/ci-sanitize-apt-sources.sh
           npx playwright install --with-deps chromium
         working-directory: packages/desktop
 

--- a/scripts/ci-sanitize-apt-sources.sh
+++ b/scripts/ci-sanitize-apt-sources.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly ubuntu_archive="https://archive.ubuntu.com/ubuntu"
+
+# GitHub's Ubuntu images can retain optional Azure package sources and can
+# prefer the Azure Ubuntu mirror through apt-mirrors.txt. Either endpoint may
+# stall independently of the repositories needed by Freed. Keep CI package
+# installation on the canonical Ubuntu archive before the first apt update.
+sudo rm -f \
+  /etc/apt/sources.list.d/azure-cli.list \
+  /etc/apt/sources.list.d/azure-cli.sources
+
+for source_file in \
+  /etc/apt/apt-mirrors.txt \
+  /etc/apt/sources.list \
+  /etc/apt/sources.list.d/ubuntu.sources
+do
+  if sudo test -f "$source_file"; then
+    sudo sed -i \
+      -e "s|http://azure.archive.ubuntu.com/ubuntu|${ubuntu_archive}|g" \
+      -e "s|https://azure.archive.ubuntu.com/ubuntu|${ubuntu_archive}|g" \
+      "$source_file"
+  fi
+done

--- a/scripts/release-governance.test.mjs
+++ b/scripts/release-governance.test.mjs
@@ -201,8 +201,10 @@ test("native dependency setup sanitizes unstable runner sources before apt updat
     /\/etc\/apt\/sources\.list\.d\/azure-cli\.list/,
   );
   assert.match(aptSourceSanitizer, /\/etc\/apt\/apt-mirrors\.txt/);
-  assert.match(aptSourceSanitizer, /http:\/\/azure\.archive\.ubuntu\.com\/ubuntu/);
-  assert.match(aptSourceSanitizer, /https:\/\/archive\.ubuntu\.com\/ubuntu/);
+  assert.ok(
+    aptSourceSanitizer.includes("http://azure.archive.ubuntu.com/ubuntu"),
+  );
+  assert.ok(aptSourceSanitizer.includes("https://archive.ubuntu.com/ubuntu"));
 
   for (const [name, workflow, expectedCount] of [
     ["CI", ciWorkflow, 2],

--- a/scripts/release-governance.test.mjs
+++ b/scripts/release-governance.test.mjs
@@ -44,6 +44,14 @@ const mainReleaseValidationWorkflow = readFileSync(
   ),
   "utf8",
 );
+const toolingNightlyWorkflow = readFileSync(
+  path.join(scriptsDir, "..", ".github", "workflows", "tooling-nightly.yml"),
+  "utf8",
+);
+const aptSourceSanitizer = readFileSync(
+  path.join(scriptsDir, "ci-sanitize-apt-sources.sh"),
+  "utf8",
+);
 
 test("release preparation uses the channel's protected branch as its exact base", () => {
   assert.match(releasePrep, /CHANNEL="production"/);
@@ -187,7 +195,15 @@ test("release identity lanes receive authenticated pull request read access", ()
   }
 });
 
-test("native dependency setup removes the unstable Azure package source before apt update", () => {
+test("native dependency setup sanitizes unstable runner sources before apt update", () => {
+  assert.match(
+    aptSourceSanitizer,
+    /\/etc\/apt\/sources\.list\.d\/azure-cli\.list/,
+  );
+  assert.match(aptSourceSanitizer, /\/etc\/apt\/apt-mirrors\.txt/);
+  assert.match(aptSourceSanitizer, /http:\/\/azure\.archive\.ubuntu\.com\/ubuntu/);
+  assert.match(aptSourceSanitizer, /https:\/\/archive\.ubuntu\.com\/ubuntu/);
+
   for (const [name, workflow, expectedCount] of [
     ["CI", ciWorkflow, 2],
     ["production validation", mainReleaseValidationWorkflow, 1],
@@ -198,17 +214,38 @@ test("native dependency setup removes the unstable Azure package source before a
     );
     assert.equal(blocks?.length, expectedCount, `${name} native setup count`);
     for (const block of blocks ?? []) {
-      const sourceRemoval = block.indexOf(
-        "sudo rm -f /etc/apt/sources.list.d/azure-cli.list",
+      const sourceSanitizer = block.indexOf(
+        "bash scripts/ci-sanitize-apt-sources.sh",
       );
       const aptUpdate = block.indexOf("sudo apt-get update");
-      assert.ok(sourceRemoval >= 0, `${name} removes the Azure package source`);
+      assert.ok(sourceSanitizer >= 0, `${name} sanitizes apt sources`);
       assert.ok(
-        sourceRemoval < aptUpdate,
-        `${name} removes the Azure package source before apt update`,
+        sourceSanitizer < aptUpdate,
+        `${name} sanitizes apt sources before apt update`,
       );
     }
   }
+
+  const releaseLinuxBlock = releaseWorkflow.match(
+    /- name: Install Linux dependencies[\s\S]*?(?=\n      - name:)/,
+  )?.[0];
+  assert.ok(releaseLinuxBlock, "release Linux setup exists");
+  assert.ok(
+    releaseLinuxBlock.indexOf("bash scripts/ci-sanitize-apt-sources.sh") <
+      releaseLinuxBlock.indexOf("sudo apt-get update"),
+    "release Linux packaging sanitizes apt sources before apt update",
+  );
+
+  const nightlyPlaywrightBlock = toolingNightlyWorkflow.match(
+    /- name: Install Playwright browsers[\s\S]*?(?=\n      - name:)/,
+  )?.[0];
+  assert.ok(nightlyPlaywrightBlock, "nightly Playwright setup exists");
+  assert.ok(
+    nightlyPlaywrightBlock.indexOf(
+      "bash ../../scripts/ci-sanitize-apt-sources.sh",
+    ) < nightlyPlaywrightBlock.indexOf("npx playwright install --with-deps"),
+    "nightly Playwright setup sanitizes apt sources before package resolution",
+  );
 });
 
 test("dev tag validation inherits the exact successful dev integration receipt", () => {

--- a/scripts/release-governance.test.mjs
+++ b/scripts/release-governance.test.mjs
@@ -201,10 +201,18 @@ test("native dependency setup sanitizes unstable runner sources before apt updat
     /\/etc\/apt\/sources\.list\.d\/azure-cli\.list/,
   );
   assert.match(aptSourceSanitizer, /\/etc\/apt\/apt-mirrors\.txt/);
-  assert.ok(
-    aptSourceSanitizer.includes("http://azure.archive.ubuntu.com/ubuntu"),
+  const archiveAssignment = aptSourceSanitizer
+    .split("\n")
+    .find((line) => line.startsWith("readonly ubuntu_archive="));
+  assert.equal(
+    archiveAssignment,
+    'readonly ubuntu_archive="https://archive.ubuntu.com/ubuntu"',
   );
-  assert.ok(aptSourceSanitizer.includes("https://archive.ubuntu.com/ubuntu"));
+  assert.equal(
+    aptSourceSanitizer.split("${ubuntu_archive}").length - 1,
+    2,
+    "both Azure mirror variants route through the canonical archive",
+  );
 
   for (const [name, workflow, expectedCount] of [
     ["CI", ciWorkflow, 2],

--- a/scripts/validate-worktree.mjs
+++ b/scripts/validate-worktree.mjs
@@ -80,6 +80,8 @@ const RELEASE_ADMISSION_PATHS = new Set([
   ".github/workflows/ci.yml",
   ".github/workflows/main-release-validation.yml",
   ".github/workflows/release.yml",
+  ".github/workflows/tooling-nightly.yml",
+  "scripts/ci-sanitize-apt-sources.sh",
   "scripts/post-perf-comment.mjs",
   "scripts/post-perf-comment.test.mjs",
   "scripts/release-governance.test.mjs",


### PR DESCRIPTION
(AI Generated).

## Summary
- Replace the GitHub runner Azure Ubuntu archive mirror with the canonical Ubuntu archive before package resolution.
- Use one sanitizer across feature validation, production validation, release packaging, and nightly Playwright setup.
- Keep optional Azure CLI sources out of the apt dependency graph.

## Testing
- npm run validate:feature
- The cancelled exact-head release runner log showed azure.archive.ubuntu.com stalling for more than nine minutes while archive.ubuntu.com responded.
- CodeQL URL-regex annotations were removed by using exact string assertions.