### PR TITLE
chore: stage v26.8.1900 website release

### DIFF
--- a/release-notes/daily/production/26.8.19.json
+++ b/release-notes/daily/production/26.8.19.json
@@ -1,0 +1,18 @@
+{
+  "channel": "production",
+  "dayKey": "26.8.19",
+  "date": "2026-08-19",
+  "preferredDeck": "Freed now has editable Library followers, complete PWA Library views, and a safer SQLite authority boundary",
+  "editorialGuidance": [
+    "Keep the tone concise, professional, and specific.",
+    "Lead with user-facing outcomes, shipping milestones, trust wins, and installability improvements.",
+    "Demote internal cleanup unless it clearly changes the shipped product."
+  ],
+  "pinnedHighlights": [
+    "Editable Freed Desktop followers with signed intents and exact results",
+    "Complete bounded PWA IndexedDB readers",
+    "In-place native SQLite authority repair and one-process fencing"
+  ],
+  "editorialNotes": [],
+  "updatedAt": "2026-08-20T00:06:38.000Z"
+}

--- a/release-notes/releases/v26.8.1900.json
+++ b/release-notes/releases/v26.8.1900.json
@@ -1,0 +1,78 @@
+{
+  "tag": "v26.8.1900",
+  "version": "26.8.1900",
+  "channel": "production",
+  "dayKey": "26.8.19",
+  "approved": true,
+  "editorialNotes": [],
+  "generatedAt": "2026-08-20T00:05:54.258Z",
+  "model": "heuristic",
+  "source": {
+    "channel": "production",
+    "previousPublishedTag": "v26.8.1800",
+    "previousPublishedDayTag": "v26.8.1800",
+    "compareRef": "HEAD",
+    "productCommitSha": "2ca993f1f6adb65d262ca8a31d5ce219b372d289",
+    "promotedDevCommitSha": "f2a294edadd1f96da81b9002a9925e4ce73de312",
+    "libraryCoreActivation": {
+      "schemaVersion": 1,
+      "range": {
+        "channel": "production",
+        "previousPublishedTag": "v26.8.1800",
+        "startMode": "previous_product_commit",
+        "fromExclusiveCommitSha": "1e33dc1588e952b9acdc4991aa8ac89af34792d9",
+        "toInclusiveProductCommitSha": "2ca993f1f6adb65d262ca8a31d5ce219b372d289"
+      },
+      "manifest": {
+        "path": "docs/library-core-activation-manifest.json",
+        "previousPresent": true,
+        "previousDigest": "sha256:4a9e0286b40716aa67ec93c79cd6ed11f6b3da2e845e884c4e55f7e1e9139a94",
+        "currentDigest": "sha256:4a9e0286b40716aa67ec93c79cd6ed11f6b3da2e845e884c4e55f7e1e9139a94"
+      },
+      "transitions": [],
+      "inspectionDigest": "sha256:10d577c805718af76982cf0a2d173c1de372127e9a6b392a40703f0ea8b6a3d8",
+      "decision": {
+        "state": "no_activation_declared",
+        "ownerApprovalReference": null,
+        "approvedInspectionDigest": null,
+        "approvedReleaseArtifactDigest": null
+      }
+    },
+    "isLatestOfDay": true,
+    "sameDayTagsIncluded": [
+      "v26.8.1900"
+    ],
+    "relatedBuildTags": [
+      "v26.8.1900"
+    ],
+    "prNumbers": [
+      1564,
+      1575
+    ],
+    "commitSubjects": [
+      "chore: promote dev into main for production release (#1575)",
+      "chore: promote dev into main for production release (#1564)"
+    ]
+  },
+  "release": {
+    "deck": "Freed now has editable Library followers, complete PWA Library views, and a safer SQLite authority boundary",
+    "features": [
+      "Adds an editable Freed Desktop follower that applies local edits immediately, exchanges signed intents and canonical results every 60 seconds, and exposes exact Primary and PWA checkpoint receipts",
+      "Completes bounded PWA IndexedDB readers for ordinary feeds, Saved, Friends, facets, analytics, Map, Story Wall, timelines, and item detail",
+      "Allows only one Freed Desktop process to open a Library data root at a time and records attributable refusal details"
+    ],
+    "fixes": [
+      "Repairs legacy SQLite authority in place with signed lineage checks instead of creating a second Library head",
+      "Recovers a successful Google Drive control update after a lost response by verifying the exact committed control pointer",
+      "Keeps SQLite, WAL, SHM, rollback journal, and closed SQLite backup files off Google Drive so only logical immutable protocol objects are eligible",
+      "Removes retired Automerge runtime entry points and fails production builds if legacy worker or WASM assets reappear",
+      "Refreshes rejected PWA Drive tokens and retries authenticated checkpoint discovery after a 401 response"
+    ],
+    "followUps": [
+      "Installed Drive acceptance remains open until one Primary receipt and the authenticated PWA receipt name the same manifest and exact revision",
+      "The content-addressed media adapter remains dormant until local vault, retention, restore, and live Drive acceptance are complete",
+      "Headless Primary hosting and capability-bounded scraper actors remain future work; this release adds no new social provider traffic"
+    ]
+  },
+  "releaseBody": "(AI Generated).\n\n## Freed v26.8.1900\n\nFreed now has editable Library followers, complete PWA Library views, and a safer SQLite authority boundary\n\n### Features\n\n- Adds an editable Freed Desktop follower that applies local edits immediately, exchanges signed intents and canonical results every 60 seconds, and exposes exact Primary and PWA checkpoint receipts\n- Completes bounded PWA IndexedDB readers for ordinary feeds, Saved, Friends, facets, analytics, Map, Story Wall, timelines, and item detail\n- Allows only one Freed Desktop process to open a Library data root at a time and records attributable refusal details\n\n### Fixes\n\n- Repairs legacy SQLite authority in place with signed lineage checks instead of creating a second Library head\n- Recovers a successful Google Drive control update after a lost response by verifying the exact committed control pointer\n- Keeps SQLite, WAL, SHM, rollback journal, and closed SQLite backup files off Google Drive so only logical immutable protocol objects are eligible\n- Removes retired Automerge runtime entry points and fails production builds if legacy worker or WASM assets reappear\n- Refreshes rejected PWA Drive tokens and retries authenticated checkpoint discovery after a 401 response\n\n### Follow-ups\n\n- Installed Drive acceptance remains open until one Primary receipt and the authenticated PWA receipt name the same manifest and exact revision\n- The content-addressed media adapter remains dormant until local vault, retention, restore, and live Drive acceptance are complete\n- Headless Primary hosting and capability-bounded scraper actors remain future work; this release adds no new social provider traffic\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)\n\n**Windows:** `.exe` (NSIS installer)\n\n**Linux:** `.AppImage`\n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+}

--- a/release-notes/releases/v26.8.1900.md
+++ b/release-notes/releases/v26.8.1900.md
@@ -1,0 +1,35 @@
+(AI Generated).
+
+## Freed v26.8.1900
+
+Freed now has editable Library followers, complete PWA Library views, and a safer SQLite authority boundary
+
+### Features
+
+- Adds an editable Freed Desktop follower that applies local edits immediately, exchanges signed intents and canonical results every 60 seconds, and exposes exact Primary and PWA checkpoint receipts
+- Completes bounded PWA IndexedDB readers for ordinary feeds, Saved, Friends, facets, analytics, Map, Story Wall, timelines, and item detail
+- Allows only one Freed Desktop process to open a Library data root at a time and records attributable refusal details
+
+### Fixes
+
+- Repairs legacy SQLite authority in place with signed lineage checks instead of creating a second Library head
+- Recovers a successful Google Drive control update after a lost response by verifying the exact committed control pointer
+- Keeps SQLite, WAL, SHM, rollback journal, and closed SQLite backup files off Google Drive so only logical immutable protocol objects are eligible
+- Removes retired Automerge runtime entry points and fails production builds if legacy worker or WASM assets reappear
+- Refreshes rejected PWA Drive tokens and retries authenticated checkpoint discovery after a 401 response
+
+### Follow-ups
+
+- Installed Drive acceptance remains open until one Primary receipt and the authenticated PWA receipt name the same manifest and exact revision
+- The content-addressed media adapter remains dormant until local vault, retention, restore, and live Drive acceptance are complete
+- Headless Primary hosting and capability-bounded scraper actors remain future work; this release adds no new social provider traffic
+
+### Downloads
+
+**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)
+
+**Windows:** `.exe` (NSIS installer)
+
+**Linux:** `.AppImage`
+
+> macOS downloads are signed and notarized for normal Gatekeeper installation.


### PR DESCRIPTION
(AI Generated).

## Summary
- Stage the exact approved v26.8.1900 release artifact, Markdown body, and daily editorial record on the reviewed www branch before the production tag is published.
- Satisfy the release workflow precondition without prepublishing a changelog entry. The checked-in changelog snapshot remains unchanged until GitHub publishes the release.

## Testing
- Release JSON, Markdown, and daily record match the approved main release artifacts byte for byte.
- Release-note validation passed.
- Website production build passed and generated all 45 static pages. Generated feed timestamps were restored and are not part of the diff.