### PR TITLE
chore: publish v26.8.1901 website release

### DIFF
--- a/release-notes/daily/production/26.8.19.json
+++ b/release-notes/daily/production/26.8.19.json
@@ -2,17 +2,17 @@
   "channel": "production",
   "dayKey": "26.8.19",
   "date": "2026-08-19",
-  "preferredDeck": "Freed now has editable Library followers, complete PWA Library views, and a safer SQLite authority boundary",
+  "preferredDeck": "Strong Google Drive revision fencing, a reusable native Library Core, and enforced actor capabilities",
   "editorialGuidance": [
     "Keep the tone concise, professional, and specific.",
     "Lead with user-facing outcomes, shipping milestones, trust wins, and installability improvements.",
     "Demote internal cleanup unless it clearly changes the shipped product."
   ],
   "pinnedHighlights": [
-    "Editable Freed Desktop followers with signed intents and exact results",
-    "Complete bounded PWA IndexedDB readers",
-    "In-place native SQLite authority repair and one-process fencing"
+    "Google Drive mutable revisions use bounded strong ETags and exact conditional updates",
+    "Reusable native Library Core with thin Freed Desktop adapters",
+    "Authority-signed actor capability certificates"
   ],
   "editorialNotes": [],
-  "updatedAt": "2026-08-20T00:06:38.000Z"
+  "updatedAt": "2026-08-20T06:38:30.868Z"
 }

--- a/release-notes/releases/v26.8.1901.json
+++ b/release-notes/releases/v26.8.1901.json
@@ -1,0 +1,88 @@
+{
+  "tag": "v26.8.1901",
+  "version": "26.8.1901",
+  "channel": "production",
+  "dayKey": "26.8.19",
+  "approved": true,
+  "editorialNotes": [],
+  "generatedAt": "2026-08-20T06:38:30.866Z",
+  "model": "heuristic",
+  "source": {
+    "channel": "production",
+    "previousPublishedTag": "v26.8.1900",
+    "previousPublishedDayTag": "v26.8.1800",
+    "compareRef": "HEAD",
+    "productCommitSha": "86d3f98d69ba6977f8e1f5f02d1258c146de6015",
+    "promotedDevCommitSha": "16a4bd7de6cd280cc6dc3b2f03560222adfbc26f",
+    "libraryCoreActivation": {
+      "schemaVersion": 1,
+      "range": {
+        "channel": "production",
+        "previousPublishedTag": "v26.8.1900",
+        "startMode": "previous_product_commit",
+        "fromExclusiveCommitSha": "2ca993f1f6adb65d262ca8a31d5ce219b372d289",
+        "toInclusiveProductCommitSha": "86d3f98d69ba6977f8e1f5f02d1258c146de6015"
+      },
+      "manifest": {
+        "path": "docs/library-core-activation-manifest.json",
+        "previousPresent": true,
+        "previousDigest": "sha256:4a9e0286b40716aa67ec93c79cd6ed11f6b3da2e845e884c4e55f7e1e9139a94",
+        "currentDigest": "sha256:4a9e0286b40716aa67ec93c79cd6ed11f6b3da2e845e884c4e55f7e1e9139a94"
+      },
+      "transitions": [],
+      "inspectionDigest": "sha256:11696cb3f12092b99509c238484bea043a1d8fb8431fde2c09c9f7578fb9de40",
+      "decision": {
+        "state": "no_activation_declared",
+        "ownerApprovalReference": null,
+        "approvedInspectionDigest": null,
+        "approvedReleaseArtifactDigest": null
+      }
+    },
+    "isLatestOfDay": true,
+    "sameDayTagsIncluded": [
+      "v26.8.1900",
+      "v26.8.1901"
+    ],
+    "relatedBuildTags": [
+      "v26.8.1900",
+      "v26.8.1901"
+    ],
+    "prNumbers": [
+      1564,
+      1575,
+      1577,
+      1583
+    ],
+    "commitSubjects": [
+      "chore: promote dev into main for production release (#1583)",
+      "chore: prepare v26.8.1900 (#1577)",
+      "chore: promote dev into main for production release (#1575)",
+      "chore: promote dev into main for production release (#1564)"
+    ]
+  },
+  "release": {
+    "deck": "Strong Google Drive revision fencing, a reusable native Library Core, and enforced actor capabilities",
+    "features": [
+      "Editable Freed Desktop followers with signed intents and exact results",
+      "Complete bounded PWA IndexedDB readers",
+      "In-place native SQLite authority repair and one-process fencing"
+    ],
+    "fixes": [
+      "Repairs the Google Drive connection failure caused by Drive v3 omitting ETag metadata by reading bounded strong JSON ETags through Drive v2 and using each exact token in If-Match conditional updates for mutable control, intent-head, and result-head files",
+      "Keeps immutable Drive discovery, creation, upload, and bounded media reads on Drive v3 at the existing request count and cadence",
+      "Extracts the signed SQLite journal, authority epochs, actor enrollment, deterministic product projection, and process lease into a reusable native Library Core with thin Freed Desktop adapters",
+      "Enforces authority-signed actor capability certificates and exact operation authority before an editable follower operation can replay or materialize",
+      "Repairs legacy SQLite authority in place with signed lineage checks instead of creating a second Library head",
+      "Recovers a successful Google Drive control update after a lost response by verifying the exact committed control pointer",
+      "Keeps SQLite, WAL, SHM, rollback journal, and closed SQLite backup files off Google Drive so only logical immutable protocol objects are eligible",
+      "Removes retired Automerge runtime entry points and fails production builds if legacy worker or WASM assets reappear",
+      "Refreshes rejected PWA Drive tokens and retries authenticated checkpoint discovery after a 401 response"
+    ],
+    "followUps": [
+      "Installed Drive acceptance remains open until one Primary receipt and the authenticated PWA receipt name the same manifest and exact revision",
+      "The content-addressed media adapter remains dormant until local vault, retention, restore, and live Drive acceptance are complete",
+      "Provider-neutral headless Primary supervision and capability-bounded scraper actors are still being built; this release adds no new social provider traffic"
+    ]
+  },
+  "releaseBody": "(AI Generated).\n\n## Freed v26.8.1901\n\nStrong Google Drive revision fencing, a reusable native Library Core, and enforced actor capabilities\n\n### Features\n\n- Editable Freed Desktop followers with signed intents and exact results\n- Complete bounded PWA IndexedDB readers\n- In-place native SQLite authority repair and one-process fencing\n\n### Fixes\n\n- Repairs the Google Drive connection failure caused by Drive v3 omitting ETag metadata by reading bounded strong JSON ETags through Drive v2 and using each exact token in If-Match conditional updates for mutable control, intent-head, and result-head files\n- Keeps immutable Drive discovery, creation, upload, and bounded media reads on Drive v3 at the existing request count and cadence\n- Extracts the signed SQLite journal, authority epochs, actor enrollment, deterministic product projection, and process lease into a reusable native Library Core with thin Freed Desktop adapters\n- Enforces authority-signed actor capability certificates and exact operation authority before an editable follower operation can replay or materialize\n- Repairs legacy SQLite authority in place with signed lineage checks instead of creating a second Library head\n- Recovers a successful Google Drive control update after a lost response by verifying the exact committed control pointer\n- Keeps SQLite, WAL, SHM, rollback journal, and closed SQLite backup files off Google Drive so only logical immutable protocol objects are eligible\n- Removes retired Automerge runtime entry points and fails production builds if legacy worker or WASM assets reappear\n- Refreshes rejected PWA Drive tokens and retries authenticated checkpoint discovery after a 401 response\n\n### Follow-ups\n\n- Installed Drive acceptance remains open until one Primary receipt and the authenticated PWA receipt name the same manifest and exact revision\n- The content-addressed media adapter remains dormant until local vault, retention, restore, and live Drive acceptance are complete\n- Provider-neutral headless Primary supervision and capability-bounded scraper actors are still being built; this release adds no new social provider traffic\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+}

--- a/release-notes/releases/v26.8.1901.md
+++ b/release-notes/releases/v26.8.1901.md
@@ -1,0 +1,37 @@
+(AI Generated).
+
+## Freed v26.8.1901
+
+Strong Google Drive revision fencing, a reusable native Library Core, and enforced actor capabilities
+
+### Features
+
+- Editable Freed Desktop followers with signed intents and exact results
+- Complete bounded PWA IndexedDB readers
+- In-place native SQLite authority repair and one-process fencing
+
+### Fixes
+
+- Repairs the Google Drive connection failure caused by Drive v3 omitting ETag metadata by reading bounded strong JSON ETags through Drive v2 and using each exact token in If-Match conditional updates for mutable control, intent-head, and result-head files
+- Keeps immutable Drive discovery, creation, upload, and bounded media reads on Drive v3 at the existing request count and cadence
+- Extracts the signed SQLite journal, authority epochs, actor enrollment, deterministic product projection, and process lease into a reusable native Library Core with thin Freed Desktop adapters
+- Enforces authority-signed actor capability certificates and exact operation authority before an editable follower operation can replay or materialize
+- Repairs legacy SQLite authority in place with signed lineage checks instead of creating a second Library head
+- Recovers a successful Google Drive control update after a lost response by verifying the exact committed control pointer
+- Keeps SQLite, WAL, SHM, rollback journal, and closed SQLite backup files off Google Drive so only logical immutable protocol objects are eligible
+- Removes retired Automerge runtime entry points and fails production builds if legacy worker or WASM assets reappear
+- Refreshes rejected PWA Drive tokens and retries authenticated checkpoint discovery after a 401 response
+
+### Follow-ups
+
+- Installed Drive acceptance remains open until one Primary receipt and the authenticated PWA receipt name the same manifest and exact revision
+- The content-addressed media adapter remains dormant until local vault, retention, restore, and live Drive acceptance are complete
+- Provider-neutral headless Primary supervision and capability-bounded scraper actors are still being built; this release adds no new social provider traffic
+
+### Downloads
+
+**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  
+**Windows:** `.exe` (NSIS installer)  
+**Linux:** `.AppImage`  
+
+> macOS downloads are signed and notarized for normal Gatekeeper installation.

--- a/website/src/content/changelog.generated.json
+++ b/website/src/content/changelog.generated.json
@@ -1,5 +1,86 @@
 [
   {
+    "version": "26.8.1901",
+    "tagName": "v26.8.1901",
+    "channel": "production",
+    "date": "2026-08-20T08:21:51Z",
+    "deck": "Strong Google Drive revision fencing, a reusable native Library Core, and enforced actor capabilities",
+    "features": [
+      {
+        "text": "Editable Freed Desktop followers with signed intents and exact results"
+      },
+      {
+        "text": "Complete bounded PWA IndexedDB readers"
+      },
+      {
+        "text": "In-place native SQLite authority repair and one-process fencing"
+      }
+    ],
+    "fixes": [
+      {
+        "text": "Repairs the Google Drive connection failure caused by Drive v3 omitting ETag metadata by reading bounded strong JSON ETags through Drive v2 and using each exact token in If-Match conditional updates for mutable control, intent-head, and result-head files"
+      },
+      {
+        "text": "Keeps immutable Drive discovery, creation, upload, and bounded media reads on Drive v3 at the existing request count and cadence"
+      },
+      {
+        "text": "Extracts the signed SQLite journal, authority epochs, actor enrollment, deterministic product projection, and process lease into a reusable native Library Core with thin Freed Desktop adapters"
+      },
+      {
+        "text": "Enforces authority-signed actor capability certificates and exact operation authority before an editable follower operation can replay or materialize"
+      },
+      {
+        "text": "Repairs legacy SQLite authority in place with signed lineage checks instead of creating a second Library head"
+      },
+      {
+        "text": "Recovers a successful Google Drive control update after a lost response by verifying the exact committed control pointer"
+      },
+      {
+        "text": "Keeps SQLite, WAL, SHM, rollback journal, and closed SQLite backup files off Google Drive so only logical immutable protocol objects are eligible"
+      },
+      {
+        "text": "Removes retired Automerge runtime entry points and fails production builds if legacy worker or WASM assets reappear"
+      },
+      {
+        "text": "Refreshes rejected PWA Drive tokens and retries authenticated checkpoint discovery after a 401 response"
+      }
+    ],
+    "followUps": [
+      {
+        "text": "Installed Drive acceptance remains open until one Primary receipt and the authenticated PWA receipt name the same manifest and exact revision"
+      },
+      {
+        "text": "The content-addressed media adapter remains dormant until local vault, retention, restore, and live Drive acceptance are complete"
+      },
+      {
+        "text": "Provider-neutral headless Primary supervision and capability-bounded scraper actors are still being built; this release adds no new social provider traffic"
+      }
+    ],
+    "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.8.1901",
+    "prNumbers": [
+      1564,
+      1575,
+      1577,
+      1583
+    ],
+    "builds": [
+      "26.8.1900",
+      "26.8.1901"
+    ],
+    "buildLinks": [
+      {
+        "version": "26.8.1900",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.8.1900",
+        "channel": "production"
+      },
+      {
+        "version": "26.8.1901",
+        "htmlUrl": "https://github.com/freed-project/freed/releases/tag/v26.8.1901",
+        "channel": "production"
+      }
+    ]
+  },
+  {
     "version": "26.8.1800",
     "tagName": "v26.8.1800",
     "channel": "production",


### PR DESCRIPTION
(AI Generated).

## Summary
- Sync the approved v26.8.1901 production release artifacts from exact main 62327ca2d45400a0c190c3efbe9bc56b3c8ac104.
- Refresh the checked-in public changelog snapshot with the published release and both same-day build links.

## Testing
- node scripts/validate-release-notes.mjs release-notes/releases/v26.8.1901.json
- cd website && PATH=../node_modules/.bin:$PATH npm run build