### PR TITLE
feat: add fail-closed Library service supervisor

### DIFF
--- a/docs/PHASE-11-OPENCLAW.md
+++ b/docs/PHASE-11-OPENCLAW.md
@@ -1,6 +1,6 @@
 # Phase 11: Headless Library Authority and Agent Integrations
 
-> **Status:** 🚧 In Progress (the shared Primary coordinator, reusable native SQLite authority, local process lease, and actor capability enforcement have landed; the service host, production v2 issuance and retirement, and capture workers remain open)
+> **Status:** 🚧 In Progress (the shared Primary coordinator, reusable native SQLite authority, local process lease, actor capability enforcement, and fail-closed service supervisor have landed; the native sidecar, production v2 issuance and retirement, and capture workers remain open)
 > **Dependencies:** Phase 2 (Capture layers), Phase 4 (Sync)
 
 ---
@@ -84,11 +84,17 @@ The current product already provides the protocol foundation:
   signature.
 - Freed Desktop preserves its existing command DTOs and behavior through thin
   data-root and platform-vault adapters around that reusable native package.
+- `@freed/library-service` validates one explicit Primary role, private roots,
+  admission and credential descriptors, an exact sidecar digest, descriptor
+  bound authority inputs, a private lifetime watchdog, and whole process group
+  settlement before it starts one sidecar. Its local status and doctor
+  commands never open SQLite or start social provider work.
 
-These pieces do not yet create a headless executable. Drive credentials remain
-owned by the Freed Desktop renderer, and the production native command host
-remains inside the Tauri crate. The next work adds the service host and its
-credential boundary without changing the wire protocol.
+These pieces do not yet create a complete headless authority. Drive credentials
+remain owned by the Freed Desktop renderer, and no production native sidecar
+yet consumes the reusable core through descriptor-bound authority and lease
+entry points. The next work adds that sidecar and credential boundary without
+changing the wire protocol.
 
 ---
 
@@ -351,7 +357,7 @@ review before implementation.
 | 11.1 | Complete | Share the provider-neutral Primary coordinator from `@freed/sync` and consume it from Freed Desktop |
 | 11.2 | Complete | Enforce one operating system backed Library data-root lease before SQLite opens |
 | 11.3 | Complete | Extract the reusable native SQLite authority package without changing Tauri behavior |
-| 11.4 | Open | Add the headless service supervisor, explicit role config, and fail-closed startup |
+| 11.4 | Complete | Add the headless service supervisor, explicit role config, and fail-closed startup |
 | 11.5 | Open | Add Drive PKCE setup and platform-safe secret stores |
 | 11.6 | Open | Add exact checkpoint import, status, doctor, backup, and structured receipts |
 | 11.7 | Open | Add exact writer promotion and 60-second Primary actor processing |

--- a/package-lock.json
+++ b/package-lock.json
@@ -2625,6 +2625,10 @@
       "resolved": "packages/desktop",
       "link": true
     },
+    "node_modules/@freed/library-service": {
+      "resolved": "packages/library-service",
+      "link": true
+    },
     "node_modules/@freed/pwa": {
       "resolved": "packages/pwa",
       "link": true
@@ -14282,6 +14286,38 @@
         "vite-plugin-wasm": "^3.6.0",
         "vitest": "^4.1.10"
       }
+    },
+    "packages/library-service": {
+      "name": "@freed/library-service",
+      "version": "0.1.0",
+      "bin": {
+        "freed-library": "dist/bin.js"
+      },
+      "devDependencies": {
+        "@types/node": "^24.10.1",
+        "typescript": "^5.3.0",
+        "vitest": "^4.1.10"
+      },
+      "engines": {
+        "node": "24.x"
+      }
+    },
+    "packages/library-service/node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "packages/library-service/node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
     },
     "packages/pwa": {
       "name": "@freed/pwa",

--- a/packages/library-service/README.md
+++ b/packages/library-service/README.md
@@ -1,0 +1,101 @@
+# Freed Library service supervisor
+
+`@freed/library-service` is the fail-closed Node 24 host foundation for one
+headless Library Primary. It supervises one explicitly pinned native authority
+sidecar. Node never opens the Library SQLite database or acquires its data-root
+lease.
+
+The compiled `freed-library` CLI currently provides three commands:
+
+```text
+freed-library doctor --config /physical/path/service.json
+freed-library status --config /physical/path/service.json
+freed-library serve --config /physical/path/service.json
+```
+
+`doctor` validates only local prerequisites. `status` reads one private local
+status record. Neither command starts the sidecar. `serve` revalidates every
+prerequisite immediately before it starts one sidecar. The service exposes no
+network listener.
+
+## Configuration schema version 1
+
+The configuration is exact-shape JSON. Its physical file must be owned by the
+service user with mode `0600`. Data and state roots must be separate physical
+directories owned by that user with mode `0700`.
+
+```json
+{
+  "schemaVersion": 1,
+  "role": "primary",
+  "dataRoot": "/srv/freed/library-data",
+  "stateRoot": "/srv/freed/library-state",
+  "admissionFile": "/srv/freed/library-state/admission.json",
+  "credentialDescriptorFile": "/srv/freed/library-state/credentials.json",
+  "sidecar": {
+    "executable": "/opt/freed/bin/library-authority-sidecar",
+    "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+    "startupTimeoutMs": 10000,
+    "shutdownTimeoutMs": 5000
+  }
+}
+```
+
+Only the `primary` role is accepted in this slice. The executable must be a
+root-owned physical regular file with one link in a root-owned physical path
+hierarchy. Neither the file nor its hierarchy may be writable by a group or
+other users. Its bytes must match the configured lowercase SHA-256. Linux
+executes the already verified descriptor. macOS repeats the descriptor digest,
+path identity, and canonical path checks immediately before launching the
+protected path. No sidecar arguments or environment values are inherited.
+
+This slice provides the production ACL proof on macOS. Linux descriptor
+execution and process-group containment are covered, but `doctor` and `serve`
+return `acl_probe_unavailable` until a bounded Linux ACL proof backend lands.
+Every platform without the complete descriptor, containment, and ACL contract
+fails closed.
+
+The credential descriptor is also exact-shape private JSON. It contains a
+record identifier, never credential bytes:
+
+```json
+{
+  "schemaVersion": 1,
+  "backend": "os-vault",
+  "recordId": "freed-library-primary"
+}
+```
+
+`backend` may be `os-vault` or `mounted-credential`. The descriptor identifies
+a record but cannot contain credential bytes. The sidecar must prove that both
+admission and credentials are usable in its bounded ready record. Missing or
+changed prerequisites stop startup with no surviving child process group.
+
+Before `doctor` or `serve`, create
+`library-service-status.json` inside the state root as an empty file owned by
+the service user with mode `0600` and one link. The supervisor opens this file
+without following a symlink and holds that descriptor for the service
+lifetime. Runtime status reads and writes never reopen the path. `status`
+remains read-only and reports a null status when the file is absent.
+
+The supervisor passes only fixed inherited descriptors. File descriptor 3 is
+the verified executable, 4 is the data root, 5 is the state root, 6 is the
+admission record, 7 is the credential descriptor, and 8 is an anonymous
+lifetime pipe. A valid configuration cannot place service inputs beneath the
+data root. Node never opens SQLite or another declared authority data file. The
+future native sidecar owns SQLite and its process lease.
+
+The startup control channel is inherited stdin and stdout. The supervisor
+writes one bounded start record and closes stdin. The sidecar writes one
+bounded ready record, closes stdout, and keeps running. The ready record must
+echo a fresh parent nonce, every exact digest, and both root device and inode
+identities. It must also attest that the authority, lease, admission,
+credentials, and lifetime watchdog are active. Extra, malformed, oversized,
+missing, or late records fail closed.
+
+The sidecar runs in its own process group. Shutdown signals the group first,
+closes the lifetime pipe, and proves that the group is gone before settlement.
+A second signal sends an immediate group kill. Supervisor death closes the
+lifetime pipe, which the verified sidecar must treat as a shutdown command.
+Status and doctor output use only fixed reason codes and never include paths,
+child output, or credential values.

--- a/packages/library-service/package.json
+++ b/packages/library-service/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@freed/library-service",
+  "version": "0.1.0",
+  "description": "Fail-closed supervisor for a headless Freed Library Primary",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "bin": {
+    "freed-library": "./dist/bin.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "engines": {
+    "node": "24.x"
+  },
+  "scripts": {
+    "build": "node scripts/clean-dist.mjs && tsc -p tsconfig.json",
+    "test": "npm run build && vitest run",
+    "typecheck": "tsc --noEmit -p tsconfig.json && tsc --noEmit -p tsconfig.test.json"
+  },
+  "devDependencies": {
+    "@types/node": "^24.10.1",
+    "typescript": "^5.3.0",
+    "vitest": "^4.1.10"
+  }
+}

--- a/packages/library-service/scripts/clean-dist.mjs
+++ b/packages/library-service/scripts/clean-dist.mjs
@@ -1,0 +1,6 @@
+import { rm } from "node:fs/promises";
+
+await rm(new URL("../dist/", import.meta.url), {
+  force: true,
+  recursive: true,
+});

--- a/packages/library-service/src/bin.ts
+++ b/packages/library-service/src/bin.ts
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+import { runLibraryServiceCli } from "./cli-runtime.js";
+
+process.exitCode = await runLibraryServiceCli(process.argv.slice(2));

--- a/packages/library-service/src/cli-runtime.ts
+++ b/packages/library-service/src/cli-runtime.ts
@@ -1,0 +1,180 @@
+import {
+  LibraryServiceFailure,
+  type LibraryServiceFailureCode,
+} from "./contracts.js";
+import {
+  assertLibraryServiceBindingsStable,
+  bindLibraryServiceConfig,
+} from "./config.js";
+import { inspectLibraryServiceReadiness } from "./diagnostics.js";
+import { createNodeLibraryServicePorts } from "./node-ports.js";
+import {
+  bindLibraryServiceStatusFile,
+  readLibraryServiceStatus,
+} from "./status.js";
+import { LibraryServiceSupervisor } from "./supervisor.js";
+
+interface ParsedArguments {
+  command: "serve" | "status" | "doctor";
+  configPath: string;
+}
+
+function parseArguments(argv: readonly string[]): ParsedArguments {
+  if (argv.length !== 3 || argv[1] !== "--config") {
+    throw new LibraryServiceFailure("config_invalid");
+  }
+  const command = argv[0];
+  if (command !== "serve" && command !== "status" && command !== "doctor") {
+    throw new LibraryServiceFailure("config_invalid");
+  }
+  return { command, configPath: argv[2] };
+}
+
+function writeStandardReport(report: unknown): void {
+  process.stdout.write(`${JSON.stringify(report)}\n`);
+}
+
+function writeFailureReport(code: LibraryServiceFailureCode): void {
+  process.stderr.write(
+    `${JSON.stringify({
+      schemaVersion: 1,
+      service: "freed-library",
+      ok: false,
+      role: null,
+      code,
+    })}\n`,
+  );
+}
+
+async function serve(configPath: string): Promise<number> {
+  const ports = createNodeLibraryServicePorts();
+  const supervisor = new LibraryServiceSupervisor({
+    configPath,
+    fileSystem: ports.fileSystem,
+    identity: ports.identity,
+    aclProof: ports.aclProof,
+    process: ports.process,
+    clock: ports.clock,
+    entropy: ports.entropy,
+  });
+  const startup = new AbortController();
+  let signalCount = 0;
+  let started = false;
+  let stopPromise: Promise<void> | null = null;
+  let resolveStop!: () => void;
+  let rejectStop!: (error: unknown) => void;
+  const stopCompleted = new Promise<void>((resolve, reject) => {
+    resolveStop = resolve;
+    rejectStop = reject;
+  });
+
+  const beginStop = (): void => {
+    if (stopPromise !== null) return;
+    stopPromise = supervisor.stop();
+    void stopPromise.then(resolveStop, rejectStop);
+  };
+
+  const onSignal = (): void => {
+    signalCount += 1;
+    if (signalCount === 1) {
+      startup.abort();
+      if (started) {
+        beginStop();
+      }
+      return;
+    }
+    supervisor.forceStop();
+  };
+  process.on("SIGINT", onSignal);
+  process.on("SIGTERM", onSignal);
+  try {
+    const startResult = await supervisor.start(startup.signal);
+    started = true;
+    writeStandardReport({
+      schemaVersion: 1,
+      service: "freed-library",
+      ok: true,
+      ...startResult,
+    });
+    if (signalCount > 0 && stopPromise === null) {
+      beginStop();
+    }
+
+    const outcome = await Promise.race([
+      supervisor.waitForExit().then(() => "exit" as const),
+      stopCompleted.then(() => "stopped" as const),
+    ]);
+    if (outcome === "exit" && signalCount === 0) {
+      throw new LibraryServiceFailure("sidecar_exited");
+    }
+    if (outcome === "exit") await stopPromise;
+    writeStandardReport({
+      schemaVersion: 1,
+      service: "freed-library",
+      ok: true,
+      role: "primary",
+      phase: "stopped",
+      code: "requested_stop",
+    });
+    return 0;
+  } finally {
+    process.removeListener("SIGINT", onSignal);
+    process.removeListener("SIGTERM", onSignal);
+  }
+}
+
+export async function runLibraryServiceCli(
+  argv: readonly string[],
+): Promise<number> {
+  try {
+    const parsed = parseArguments(argv);
+    const ports = createNodeLibraryServicePorts();
+    if (parsed.command === "doctor") {
+      const report = await inspectLibraryServiceReadiness(
+        parsed.configPath,
+        ports.fileSystem,
+        ports.identity,
+        ports.aclProof,
+      );
+      if (report.code === "ready") writeStandardReport(report);
+      else writeFailureReport(report.code);
+      return report.ok ? 0 : 2;
+    }
+    if (parsed.command === "status") {
+      const bound = await bindLibraryServiceConfig(
+        parsed.configPath,
+        ports.fileSystem,
+        ports.identity,
+        ports.aclProof,
+      );
+      let statusFile = null;
+      try {
+        statusFile = await bindLibraryServiceStatusFile(
+          bound.config,
+          bound.bindings.stateRoot,
+          ports.fileSystem,
+          ports.identity,
+          ports.aclProof,
+        );
+        const report = await readLibraryServiceStatus(
+          statusFile,
+          ports.fileSystem,
+        );
+        await assertLibraryServiceBindingsStable(bound, ports.fileSystem);
+        writeStandardReport(report);
+        return 0;
+      } finally {
+        await statusFile?.close().catch(() => undefined);
+        await bound.close();
+      }
+    }
+    return await serve(parsed.configPath);
+  } catch (error) {
+    const code =
+      error instanceof LibraryServiceFailure
+        ? error.code
+        : "filesystem_failure";
+    writeFailureReport(code);
+    return 2;
+  }
+}

--- a/packages/library-service/src/cli.test.ts
+++ b/packages/library-service/src/cli.test.ts
@@ -1,0 +1,121 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+const fixtures: string[] = [];
+
+afterEach(async () => {
+  while (fixtures.length > 0) {
+    await rm(fixtures.pop()!, { recursive: true, force: true });
+  }
+});
+
+describe("freed-library CLI", () => {
+  it("returns one secret-free bounded doctor failure record", async () => {
+    const cliPath = path.resolve("dist/bin.js");
+    const missingPath = "/definitely/missing/private-config.json";
+    let result: { stdout: string; stderr: string; code: number };
+    try {
+      await execFileAsync(
+        process.execPath,
+        [cliPath, "doctor", "--config", missingPath],
+        { cwd: path.resolve(".") },
+      );
+      expect.fail("expected doctor to fail closed");
+    } catch (error) {
+      result = error as { stdout: string; stderr: string; code: number };
+    }
+
+    expect(result!.code).toBe(2);
+    expect(result!.stdout).toBe("");
+    expect(result!.stderr).not.toContain(missingPath);
+    expect(JSON.parse(result!.stderr)).toEqual({
+      schemaVersion: 1,
+      service: "freed-library",
+      ok: false,
+      role: null,
+      code:
+        typeof process.getuid === "function"
+          ? "config_missing"
+          : "unsupported_secret_store_or_acl_backend",
+    });
+    expect(Buffer.byteLength(result!.stderr)).toBeLessThan(4 * 1_024);
+  });
+
+  it("runs the installed npm bin symlink and fails closed with bounded stderr", async () => {
+    const npmCli = process.env.npm_execpath;
+    expect(npmCli).toBeTruthy();
+    const fixture = await mkdtemp(
+      path.join(os.tmpdir(), "freed-library-packed-bin-"),
+    );
+    fixtures.push(fixture);
+    const packRoot = path.join(fixture, "pack");
+    const installRoot = path.join(fixture, "install");
+    await Promise.all([
+      mkdir(packRoot, { mode: 0o700 }),
+      mkdir(installRoot, { mode: 0o700 }),
+    ]);
+    await writeFile(
+      path.join(installRoot, "package.json"),
+      '{"name":"freed-library-bin-test","private":true}\n',
+      { mode: 0o600 },
+    );
+    const packed = await execFileAsync(
+      process.execPath,
+      [npmCli!, "pack", "--json", "--pack-destination", packRoot, "."],
+      { cwd: path.resolve("."), maxBuffer: 64 * 1_024 },
+    );
+    const packReport = JSON.parse(packed.stdout) as Array<{ filename: string }>;
+    const archive = path.join(packRoot, packReport[0].filename);
+    await execFileAsync(
+      process.execPath,
+      [
+        npmCli!,
+        "install",
+        "--ignore-scripts",
+        "--no-audit",
+        "--no-fund",
+        "--no-package-lock",
+        archive,
+      ],
+      { cwd: installRoot, maxBuffer: 64 * 1_024 },
+    );
+
+    const missingPath = "/definitely/missing/packed-config.json";
+    const installedBin = path.join(
+      installRoot,
+      "node_modules",
+      ".bin",
+      "freed-library",
+    );
+    let result: { stdout: string; stderr: string; code: number };
+    try {
+      await execFileAsync(
+        installedBin,
+        ["doctor", "--config", missingPath],
+        { cwd: installRoot, maxBuffer: 8 * 1_024 },
+      );
+      expect.fail("expected installed bin to fail closed");
+    } catch (error) {
+      result = error as { stdout: string; stderr: string; code: number };
+    }
+
+    expect(result!.code).toBe(2);
+    expect(result!.stdout).toBe("");
+    expect(result!.stderr).not.toContain(missingPath);
+    expect(JSON.parse(result!.stderr)).toMatchObject({
+      service: "freed-library",
+      ok: false,
+      code:
+        typeof process.getuid === "function"
+          ? "config_missing"
+          : "unsupported_secret_store_or_acl_backend",
+    });
+    expect(Buffer.byteLength(result!.stderr)).toBeLessThan(4 * 1_024);
+  }, 30_000);
+});

--- a/packages/library-service/src/config.test.ts
+++ b/packages/library-service/src/config.test.ts
@@ -1,0 +1,432 @@
+import { describe, expect, it } from "vitest";
+
+import { bindLibraryServiceConfig } from "./config.js";
+import { LibraryServiceFailure } from "./contracts.js";
+import { inspectLibraryServiceReadiness } from "./diagnostics.js";
+import {
+  FakeAclProof,
+  FakeIdentity,
+  expectFailureCode,
+  validConfigFileSystem,
+} from "./testing/fakes.js";
+
+async function loadLibraryServiceConfig(
+  configPath: string,
+  fileSystem: Parameters<typeof bindLibraryServiceConfig>[1],
+  identity: Parameters<typeof bindLibraryServiceConfig>[2],
+  aclProof: Parameters<typeof bindLibraryServiceConfig>[3],
+) {
+  const bound = await bindLibraryServiceConfig(
+    configPath,
+    fileSystem,
+    identity,
+    aclProof,
+  );
+  try {
+    return bound.config;
+  } finally {
+    await bound.close();
+  }
+}
+
+describe("loadLibraryServiceConfig", () => {
+  it("accepts one explicit Primary with private roots and a pinned sidecar", async () => {
+    const fileSystem = validConfigFileSystem();
+
+    const config = await loadLibraryServiceConfig(
+      "/safe/config.json",
+      fileSystem,
+      new FakeIdentity(),
+      new FakeAclProof(),
+    );
+
+    expect(config.role).toBe("primary");
+    expect(config.dataRoot).toBe("/safe/data");
+    expect(config.stateRoot).toBe("/safe/state");
+    expect(config.sidecar.sha256).toBe(
+      fileSystem.digests.get("/trusted/sidecar"),
+    );
+  });
+
+  it("fails closed when the configured role is not Primary", async () => {
+    const fileSystem = validConfigFileSystem();
+    const raw = JSON.parse(fileSystem.texts.get("/safe/config.json")!);
+    raw.role = "follower";
+    fileSystem.addFile("/safe/config.json", JSON.stringify(raw));
+
+    await loadLibraryServiceConfig(
+      "/safe/config.json",
+      fileSystem,
+      new FakeIdentity(),
+      new FakeAclProof(),
+    ).then(
+      () => expect.fail("expected role refusal"),
+      (error) => expectFailureCode(error, "config_invalid"),
+    );
+  });
+
+  it("rejects a credential descriptor carrying an unrecognized secret field", async () => {
+    const fileSystem = validConfigFileSystem();
+    fileSystem.addFile(
+      "/safe/state/credentials.json",
+      JSON.stringify({
+        schemaVersion: 1,
+        backend: "os-vault",
+        recordId: "freed-library-primary",
+        token: "must-not-be-accepted",
+      }),
+    );
+
+    await loadLibraryServiceConfig(
+      "/safe/config.json",
+      fileSystem,
+      new FakeIdentity(),
+      new FakeAclProof(),
+    ).then(
+      () => expect.fail("expected descriptor refusal"),
+      (error) => expectFailureCode(error, "credential_descriptor_invalid"),
+    );
+  });
+
+  it("rejects a missing admission record before any process can start", async () => {
+    const fileSystem = validConfigFileSystem();
+    fileSystem.metadata.delete("/safe/state/admission.json");
+    fileSystem.texts.delete("/safe/state/admission.json");
+
+    await loadLibraryServiceConfig(
+      "/safe/config.json",
+      fileSystem,
+      new FakeIdentity(),
+      new FakeAclProof(),
+    ).then(
+      () => expect.fail("expected admission refusal"),
+      (error) => expectFailureCode(error, "admission_missing"),
+    );
+  });
+
+  it("rejects a missing credential descriptor before any process can start", async () => {
+    const fileSystem = validConfigFileSystem();
+    fileSystem.metadata.delete("/safe/state/credentials.json");
+    fileSystem.texts.delete("/safe/state/credentials.json");
+
+    await loadLibraryServiceConfig(
+      "/safe/config.json",
+      fileSystem,
+      new FakeIdentity(),
+      new FakeAclProof(),
+    ).then(
+      () => expect.fail("expected credential refusal"),
+      (error) => expectFailureCode(error, "credential_descriptor_missing"),
+    );
+  });
+
+  it("rejects group-writable sidecar hierarchy", async () => {
+    const fileSystem = validConfigFileSystem();
+    fileSystem.addDirectory("/trusted", 0, 0o775);
+
+    await loadLibraryServiceConfig(
+      "/safe/config.json",
+      fileSystem,
+      new FakeIdentity(),
+      new FakeAclProof(),
+    ).then(
+      () => expect.fail("expected unsafe hierarchy refusal"),
+      (error) => expectFailureCode(error, "sidecar_path_unsafe"),
+    );
+  });
+
+  it("rejects a sidecar reached through a symbolic link", async () => {
+    const fileSystem = validConfigFileSystem();
+    fileSystem.metadata.set("/trusted/sidecar", {
+      kind: "symbolic-link",
+      uid: 501,
+      mode: 0o777,
+      size: 7,
+      device: "9",
+      inode: "9999",
+      links: 1,
+    });
+    fileSystem.canonical.set("/trusted/sidecar", "/trusted/real-sidecar");
+
+    await loadLibraryServiceConfig(
+      "/safe/config.json",
+      fileSystem,
+      new FakeIdentity(),
+      new FakeAclProof(),
+    ).then(
+      () => expect.fail("expected symbolic-link refusal"),
+      (error) => expectFailureCode(error, "sidecar_path_unsafe"),
+    );
+  });
+
+  it("rejects a sidecar that does not match its exact SHA-256", async () => {
+    const fileSystem = validConfigFileSystem();
+    fileSystem.replaceFile("/trusted/sidecar", "replaced sidecar", 0, 0o755);
+
+    await loadLibraryServiceConfig(
+      "/safe/config.json",
+      fileSystem,
+      new FakeIdentity(),
+      new FakeAclProof(),
+    ).then(
+      () => expect.fail("expected digest refusal"),
+      (error) => expectFailureCode(error, "sidecar_digest_mismatch"),
+    );
+  });
+
+  it("fails closed when current ownership cannot be verified", async () => {
+    await loadLibraryServiceConfig(
+      "/safe/config.json",
+      validConfigFileSystem(),
+      new FakeIdentity(null),
+      new FakeAclProof(),
+    ).then(
+      () => expect.fail("expected ownership refusal"),
+      (error) =>
+        expectFailureCode(error, "unsupported_secret_store_or_acl_backend"),
+    );
+  });
+
+  it.each([
+    "acl_present",
+    "acl_probe_malformed",
+    "acl_probe_unavailable",
+  ] as const)("fails closed when ACL proof reports %s", async (code) => {
+    const aclProof = new FakeAclProof();
+    aclProof.failure = new LibraryServiceFailure(code);
+
+    await expect(
+      loadLibraryServiceConfig(
+        "/safe/config.json",
+        validConfigFileSystem(),
+        new FakeIdentity(),
+        aclProof,
+      ),
+    ).rejects.toMatchObject({ code });
+  });
+
+  it("maps an unavailable or broken ACL backend to a bounded refusal", async () => {
+    const aclProof = new FakeAclProof();
+    aclProof.failure = new Error("unbounded backend detail must not escape");
+
+    await expect(
+      loadLibraryServiceConfig(
+        "/safe/config.json",
+        validConfigFileSystem(),
+        new FakeIdentity(),
+        aclProof,
+      ),
+    ).rejects.toMatchObject({ code: "acl_probe_unavailable" });
+  });
+
+  it("rejects a hardlinked admission record before opening authority", async () => {
+    const fileSystem = validConfigFileSystem();
+    fileSystem.addFile("/safe/data/library-core.sqlite", "sqlite bytes");
+    const database = fileSystem.metadata.get("/safe/data/library-core.sqlite")!;
+    const admission = fileSystem.metadata.get("/safe/state/admission.json")!;
+    admission.device = database.device;
+    admission.inode = database.inode;
+    admission.links = 2;
+    database.links = 2;
+
+    await expect(
+      loadLibraryServiceConfig(
+        "/safe/config.json",
+        fileSystem,
+        new FakeIdentity(),
+        new FakeAclProof(),
+      ),
+    ).rejects.toMatchObject({ code: "admission_not_private" });
+    expect(fileSystem.opened.map(({ path }) => path)).not.toContain(
+      "/safe/data/library-core.sqlite",
+    );
+  });
+
+  it.each([
+    ["config", "/safe/config.json", "config_not_private"],
+    [
+      "credential",
+      "/safe/state/credentials.json",
+      "credential_descriptor_not_private",
+    ],
+    ["sidecar", "/trusted/sidecar", "sidecar_invalid"],
+  ] as const)(
+    "rejects a hardlinked %s regular file",
+    async (_label, filePath, code) => {
+      const fileSystem = validConfigFileSystem();
+      fileSystem.metadata.get(filePath)!.links = 2;
+
+      await expect(
+        loadLibraryServiceConfig(
+          "/safe/config.json",
+          fileSystem,
+          new FakeIdentity(),
+          new FakeAclProof(),
+        ),
+      ).rejects.toMatchObject({ code });
+    },
+  );
+
+  it("rejects sidecar, config, and input paths inside the data root", async () => {
+    const fileSystem = validConfigFileSystem();
+    const raw = JSON.parse(fileSystem.texts.get("/safe/config.json")!);
+    raw.sidecar.executable = "/safe/data/library-core.sqlite";
+    fileSystem.addFile("/safe/config.json", JSON.stringify(raw));
+
+    await expect(
+      loadLibraryServiceConfig(
+        "/safe/config.json",
+        fileSystem,
+        new FakeIdentity(),
+        new FakeAclProof(),
+      ),
+    ).rejects.toMatchObject({ code: "config_invalid" });
+    expect(fileSystem.opened.map(({ path }) => path)).not.toContain(
+      "/safe/data/library-core.sqlite",
+    );
+  });
+
+  it.each([
+    ["sidecar", "sidecar.executable", "/safe/state/authority"],
+    ["admission", "admissionFile", "/safe/data/admission.json"],
+    ["credential", "credentialDescriptorFile", "/safe/data/credentials.json"],
+  ] as const)(
+    "rejects a %s path that crosses an authority-root boundary",
+    async (_label, field, value) => {
+      const fileSystem = validConfigFileSystem();
+      const raw = JSON.parse(fileSystem.texts.get("/safe/config.json")!);
+      if (field === "sidecar.executable") raw.sidecar.executable = value;
+      else raw[field] = value;
+      fileSystem.addFile("/safe/config.json", JSON.stringify(raw));
+
+      await expect(
+        loadLibraryServiceConfig(
+          "/safe/config.json",
+          fileSystem,
+          new FakeIdentity(),
+          new FakeAclProof(),
+        ),
+      ).rejects.toMatchObject({ code: "config_invalid" });
+    },
+  );
+
+  it.each(["/safe/data/config.json", "/safe/state/config.json"])(
+    "rejects a config path inside a declared authority root: %s",
+    async (configPath) => {
+      const fileSystem = validConfigFileSystem();
+      fileSystem.addFile(
+        configPath,
+        fileSystem.texts.get("/safe/config.json")!,
+      );
+
+      await expect(
+        loadLibraryServiceConfig(
+          configPath,
+          fileSystem,
+          new FakeIdentity(),
+          new FakeAclProof(),
+        ),
+      ).rejects.toMatchObject({ code: "config_invalid" });
+      expect(fileSystem.opened.map(({ path }) => path)).not.toContain(
+        "/safe/data/library-core.sqlite",
+      );
+    },
+  );
+
+  it.each(["admissionFile", "credentialDescriptorFile"] as const)(
+    "rejects %s when it aliases the reserved status file",
+    async (field) => {
+      const fileSystem = validConfigFileSystem();
+      const raw = JSON.parse(fileSystem.texts.get("/safe/config.json")!);
+      raw[field] = "/safe/state/library-service-status.json";
+      fileSystem.addFile("/safe/config.json", JSON.stringify(raw));
+
+      await expect(
+        loadLibraryServiceConfig(
+          "/safe/config.json",
+          fileSystem,
+          new FakeIdentity(),
+          new FakeAclProof(),
+        ),
+      ).rejects.toMatchObject({ code: "config_invalid" });
+      expect(fileSystem.writes).toEqual([]);
+    },
+  );
+
+  it("rejects ASCII control characters before any ACL probe", async () => {
+    const fileSystem = validConfigFileSystem();
+    const raw = JSON.parse(fileSystem.texts.get("/safe/config.json")!);
+    raw.sidecar.executable = "/trusted/sidecar\nspoof";
+    fileSystem.addFile("/safe/config.json", JSON.stringify(raw));
+    const aclProof = new FakeAclProof();
+
+    await expect(
+      loadLibraryServiceConfig(
+        "/safe/config.json",
+        fileSystem,
+        new FakeIdentity(),
+        aclProof,
+      ),
+    ).rejects.toMatchObject({ code: "sidecar_invalid" });
+    expect(aclProof.calls).toEqual([]);
+  });
+
+  it("detects path replacement after descriptors are bound", async () => {
+    const fileSystem = validConfigFileSystem();
+    let sidecarInspections = 0;
+    fileSystem.inspectHook = (filePath) => {
+      if (filePath !== "/trusted/sidecar") return;
+      sidecarInspections += 1;
+      if (sidecarInspections === 3) {
+        fileSystem.replaceFile(filePath, "replacement", 0, 0o755);
+      }
+    };
+
+    await expect(
+      bindLibraryServiceConfig(
+        "/safe/config.json",
+        fileSystem,
+        new FakeIdentity(),
+        new FakeAclProof(),
+      ),
+    ).rejects.toMatchObject({ code: "bound_input_changed" });
+    expect(fileSystem.opened.every(({ closed }) => closed)).toBe(true);
+  });
+
+  it("rehashes bound inputs after doctor binds the status file", async () => {
+    const fileSystem = validConfigFileSystem();
+    const aclProof = new FakeAclProof();
+    aclProof.afterProbe = () => {
+      if (aclProof.calls.length !== 2) return;
+      const original = fileSystem.texts.get("/safe/config.json")!;
+      fileSystem.rewriteFileInPlace(
+        "/safe/config.json",
+        original.replace('"role":"primary"', '"role":"primarx"'),
+      );
+    };
+
+    await expect(
+      inspectLibraryServiceReadiness(
+        "/safe/config.json",
+        fileSystem,
+        new FakeIdentity(),
+        aclProof,
+      ),
+    ).resolves.toMatchObject({ ok: false, code: "bound_input_changed" });
+  });
+
+  it("never opens a file beneath the Library Core data root", async () => {
+    const fileSystem = validConfigFileSystem();
+    const bound = await bindLibraryServiceConfig(
+      "/safe/config.json",
+      fileSystem,
+      new FakeIdentity(),
+      new FakeAclProof(),
+    );
+    await bound.close();
+
+    expect(
+      fileSystem.opened.filter(({ path }) => path.startsWith("/safe/data/")),
+    ).toEqual([]);
+  });
+});

--- a/packages/library-service/src/config.ts
+++ b/packages/library-service/src/config.ts
@@ -1,0 +1,647 @@
+import { createHash } from "node:crypto";
+import path from "node:path";
+
+import {
+  LIBRARY_SERVICE_CONFIG_SCHEMA_VERSION,
+  LIBRARY_SERVICE_MAX_CONFIG_BYTES,
+  LIBRARY_SERVICE_MAX_DESCRIPTOR_BYTES,
+  LibraryServiceFailure,
+  type LibraryServiceAclProbeTarget,
+  type LibraryServiceAclProofPort,
+  type LibraryServiceBoundInputs,
+  type LibraryServiceBoundPath,
+  type LibraryServiceConfig,
+  type LibraryServiceCredentialDescriptor,
+  type LibraryServiceFailureCode,
+  type LibraryServiceFileMetadata,
+  type LibraryServiceFileSystemPort,
+  type LibraryServiceIdentityPort,
+} from "./contracts.js";
+
+const CONFIG_KEYS = new Set([
+  "schemaVersion",
+  "role",
+  "dataRoot",
+  "stateRoot",
+  "admissionFile",
+  "credentialDescriptorFile",
+  "sidecar",
+]);
+const SIDECAR_KEYS = new Set([
+  "executable",
+  "sha256",
+  "startupTimeoutMs",
+  "shutdownTimeoutMs",
+]);
+const CREDENTIAL_DESCRIPTOR_KEYS = new Set([
+  "schemaVersion",
+  "backend",
+  "recordId",
+]);
+const LOWERCASE_SHA256 = /^[a-f0-9]{64}$/;
+const SAFE_RECORD_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+const ASCII_CONTROL = /[\x00-\x1f\x7f]/;
+const MIN_TIMEOUT_MS = 100;
+const MAX_STARTUP_TIMEOUT_MS = 30_000;
+const MAX_SHUTDOWN_TIMEOUT_MS = 10_000;
+const MAX_ADMISSION_BYTES = 64 * 1_024;
+
+interface ValidationContext {
+  fileSystem: LibraryServiceFileSystemPort;
+  userId: number;
+  signal?: AbortSignal;
+  aclTargets: Map<string, LibraryServiceAclProbeTarget>;
+}
+
+export interface BoundLibraryServiceConfiguration {
+  config: LibraryServiceConfig;
+  configDigest: string;
+  executableDigest: string;
+  admissionDigest: string;
+  credentialDescriptorDigest: string;
+  configFile: LibraryServiceBoundPath;
+  bindings: LibraryServiceBoundInputs;
+  close(): Promise<void>;
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) {
+    throw new LibraryServiceFailure("startup_cancelled");
+  }
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function hasExactKeys(
+  value: Record<string, unknown>,
+  keys: Set<string>,
+): boolean {
+  const actual = Object.keys(value);
+  return actual.length === keys.size && actual.every((key) => keys.has(key));
+}
+
+function isBoundedInteger(
+  value: unknown,
+  minimum: number,
+  maximum: number,
+): value is number {
+  return (
+    typeof value === "number" &&
+    Number.isSafeInteger(value) &&
+    value >= minimum &&
+    value <= maximum
+  );
+}
+
+function requireAbsolutePhysicalPath(
+  value: unknown,
+  failureCode: LibraryServiceFailureCode,
+): string {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.length > 4_096 ||
+    ASCII_CONTROL.test(value) ||
+    !path.isAbsolute(value) ||
+    path.resolve(value) !== value
+  ) {
+    throw new LibraryServiceFailure(failureCode);
+  }
+  return value;
+}
+
+function pathComponents(filePath: string): string[] {
+  const parsed = path.parse(filePath);
+  const relative = filePath.slice(parsed.root.length);
+  const components = relative.split(path.sep).filter(Boolean);
+  const result = [parsed.root];
+  let current = parsed.root;
+  for (const component of components) {
+    current = path.join(current, component);
+    result.push(current);
+  }
+  return result;
+}
+
+function sameIdentity(
+  left: LibraryServiceFileMetadata,
+  right: LibraryServiceFileMetadata,
+): boolean {
+  return (
+    left.kind === right.kind &&
+    left.mode === right.mode &&
+    left.uid === right.uid &&
+    (left.kind !== "file" || left.size === right.size) &&
+    left.device === right.device &&
+    left.inode === right.inode &&
+    left.links === right.links
+  );
+}
+
+async function inspect(
+  filePath: string,
+  context: ValidationContext,
+  failureCode: LibraryServiceFailureCode,
+): Promise<LibraryServiceFileMetadata> {
+  throwIfAborted(context.signal);
+  try {
+    const metadata = await context.fileSystem.inspect(filePath);
+    throwIfAborted(context.signal);
+    return metadata;
+  } catch (error) {
+    if (error instanceof LibraryServiceFailure) throw error;
+    throw new LibraryServiceFailure(failureCode);
+  }
+}
+
+async function requireCanonicalPath(
+  filePath: string,
+  context: ValidationContext,
+  failureCode: LibraryServiceFailureCode,
+): Promise<void> {
+  throwIfAborted(context.signal);
+  let canonical: string;
+  try {
+    canonical = await context.fileSystem.canonicalPath(filePath);
+  } catch {
+    throw new LibraryServiceFailure(failureCode);
+  }
+  throwIfAborted(context.signal);
+  if (canonical !== filePath) {
+    throw new LibraryServiceFailure(failureCode);
+  }
+}
+
+function addAclTarget(
+  context: ValidationContext,
+  filePath: string,
+  metadata: LibraryServiceFileMetadata,
+): void {
+  context.aclTargets.set(filePath, {
+    path: filePath,
+    device: metadata.device,
+    inode: metadata.inode,
+  });
+}
+
+async function requireSafeHierarchy(
+  filePath: string,
+  context: ValidationContext,
+  failureCode: LibraryServiceFailureCode,
+  rootOwned = false,
+): Promise<void> {
+  for (const component of pathComponents(path.dirname(filePath))) {
+    const metadata = await inspect(component, context, failureCode);
+    if (
+      metadata.kind !== "directory" ||
+      (rootOwned
+        ? metadata.uid !== 0
+        : metadata.uid !== 0 && metadata.uid !== context.userId) ||
+      (metadata.mode & 0o022) !== 0
+    ) {
+      throw new LibraryServiceFailure(failureCode);
+    }
+    addAclTarget(context, component, metadata);
+  }
+}
+
+async function openVerifiedPath(
+  filePath: string,
+  context: ValidationContext,
+  preOpen: LibraryServiceFileMetadata,
+  failureCode: LibraryServiceFailureCode,
+): Promise<LibraryServiceBoundPath> {
+  throwIfAborted(context.signal);
+  let bound: LibraryServiceBoundPath;
+  try {
+    bound = await context.fileSystem.openBoundPath(filePath);
+  } catch {
+    throw new LibraryServiceFailure(failureCode);
+  }
+  try {
+    throwIfAborted(context.signal);
+    if (!sameIdentity(preOpen, bound.metadata)) {
+      throw new LibraryServiceFailure("bound_input_changed");
+    }
+    addAclTarget(context, filePath, bound.metadata);
+    return bound;
+  } catch (error) {
+    await bound.close().catch(() => undefined);
+    throw error;
+  }
+}
+
+async function bindPrivateFile(
+  filePath: string,
+  context: ValidationContext,
+  missingCode: LibraryServiceFailureCode,
+  privateCode: LibraryServiceFailureCode,
+): Promise<LibraryServiceBoundPath> {
+  const metadata = await inspect(filePath, context, missingCode);
+  if (
+    metadata.kind !== "file" ||
+    metadata.uid !== context.userId ||
+    (metadata.mode & 0o7777) !== 0o600 ||
+    metadata.links !== 1
+  ) {
+    throw new LibraryServiceFailure(privateCode);
+  }
+  await requireCanonicalPath(filePath, context, privateCode);
+  await requireSafeHierarchy(filePath, context, privateCode);
+  return openVerifiedPath(filePath, context, metadata, privateCode);
+}
+
+async function bindPrivateDirectory(
+  directoryPath: string,
+  context: ValidationContext,
+  invalidCode: LibraryServiceFailureCode,
+  privateCode: LibraryServiceFailureCode,
+): Promise<LibraryServiceBoundPath> {
+  const metadata = await inspect(directoryPath, context, invalidCode);
+  if (metadata.kind !== "directory") {
+    throw new LibraryServiceFailure(invalidCode);
+  }
+  if (metadata.uid !== context.userId || (metadata.mode & 0o7777) !== 0o700) {
+    throw new LibraryServiceFailure(privateCode);
+  }
+  await requireCanonicalPath(directoryPath, context, privateCode);
+  await requireSafeHierarchy(directoryPath, context, privateCode);
+  return openVerifiedPath(directoryPath, context, metadata, privateCode);
+}
+
+async function bindPinnedSidecar(
+  config: LibraryServiceConfig,
+  context: ValidationContext,
+): Promise<{ bound: LibraryServiceBoundPath; digest: string }> {
+  const executable = config.sidecar.executable;
+  const metadata = await inspect(executable, context, "sidecar_missing");
+  if (metadata.kind === "symbolic-link") {
+    throw new LibraryServiceFailure("sidecar_path_unsafe");
+  }
+  if (
+    metadata.kind !== "file" ||
+    metadata.uid !== 0 ||
+    (metadata.mode & 0o7000) !== 0 ||
+    (metadata.mode & 0o022) !== 0 ||
+    (metadata.mode & 0o111) === 0 ||
+    metadata.links !== 1
+  ) {
+    throw new LibraryServiceFailure("sidecar_invalid");
+  }
+  await requireCanonicalPath(executable, context, "sidecar_path_unsafe");
+  await requireSafeHierarchy(executable, context, "sidecar_path_unsafe", true);
+  const bound = await openVerifiedPath(
+    executable,
+    context,
+    metadata,
+    "sidecar_invalid",
+  );
+  try {
+    const digest = await bound.sha256();
+    throwIfAborted(context.signal);
+    if (digest !== config.sidecar.sha256) {
+      throw new LibraryServiceFailure("sidecar_digest_mismatch");
+    }
+    return { bound, digest };
+  } catch (error) {
+    await bound.close().catch(() => undefined);
+    throw error;
+  }
+}
+
+function parseConfig(text: string): LibraryServiceConfig {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(text);
+  } catch {
+    throw new LibraryServiceFailure("config_invalid");
+  }
+  if (!isObject(raw) || !hasExactKeys(raw, CONFIG_KEYS)) {
+    throw new LibraryServiceFailure("config_invalid");
+  }
+  if (
+    raw.schemaVersion !== LIBRARY_SERVICE_CONFIG_SCHEMA_VERSION ||
+    raw.role !== "primary" ||
+    !isObject(raw.sidecar) ||
+    !hasExactKeys(raw.sidecar, SIDECAR_KEYS)
+  ) {
+    throw new LibraryServiceFailure("config_invalid");
+  }
+
+  const dataRoot = requireAbsolutePhysicalPath(
+    raw.dataRoot,
+    "data_root_invalid",
+  );
+  const stateRoot = requireAbsolutePhysicalPath(
+    raw.stateRoot,
+    "state_root_invalid",
+  );
+  const admissionFile = requireAbsolutePhysicalPath(
+    raw.admissionFile,
+    "admission_missing",
+  );
+  const credentialDescriptorFile = requireAbsolutePhysicalPath(
+    raw.credentialDescriptorFile,
+    "credential_descriptor_missing",
+  );
+  const executable = requireAbsolutePhysicalPath(
+    raw.sidecar.executable,
+    "sidecar_invalid",
+  );
+
+  if (
+    typeof raw.sidecar.sha256 !== "string" ||
+    !LOWERCASE_SHA256.test(raw.sidecar.sha256) ||
+    !isBoundedInteger(
+      raw.sidecar.startupTimeoutMs,
+      MIN_TIMEOUT_MS,
+      MAX_STARTUP_TIMEOUT_MS,
+    ) ||
+    !isBoundedInteger(
+      raw.sidecar.shutdownTimeoutMs,
+      MIN_TIMEOUT_MS,
+      MAX_SHUTDOWN_TIMEOUT_MS,
+    )
+  ) {
+    throw new LibraryServiceFailure("config_invalid");
+  }
+
+  return {
+    schemaVersion: LIBRARY_SERVICE_CONFIG_SCHEMA_VERSION,
+    role: "primary",
+    dataRoot,
+    stateRoot,
+    admissionFile,
+    credentialDescriptorFile,
+    sidecar: {
+      executable,
+      sha256: raw.sidecar.sha256,
+      startupTimeoutMs: raw.sidecar.startupTimeoutMs,
+      shutdownTimeoutMs: raw.sidecar.shutdownTimeoutMs,
+    },
+  };
+}
+
+function parseCredentialDescriptor(
+  text: string,
+): LibraryServiceCredentialDescriptor {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(text);
+  } catch {
+    throw new LibraryServiceFailure("credential_descriptor_invalid");
+  }
+  if (
+    !isObject(raw) ||
+    !hasExactKeys(raw, CREDENTIAL_DESCRIPTOR_KEYS) ||
+    raw.schemaVersion !== 1 ||
+    (raw.backend !== "os-vault" && raw.backend !== "mounted-credential") ||
+    typeof raw.recordId !== "string" ||
+    !SAFE_RECORD_ID.test(raw.recordId)
+  ) {
+    throw new LibraryServiceFailure("credential_descriptor_invalid");
+  }
+  return {
+    schemaVersion: 1,
+    backend: raw.backend,
+    recordId: raw.recordId,
+  };
+}
+
+function isWithinOrEqual(candidate: string, root: string): boolean {
+  const relative = path.relative(root, candidate);
+  return (
+    relative === "" ||
+    (relative !== ".." &&
+      !relative.startsWith(`..${path.sep}`) &&
+      !path.isAbsolute(relative))
+  );
+}
+
+function isStrictChild(candidate: string, parent: string): boolean {
+  return candidate !== parent && isWithinOrEqual(candidate, parent);
+}
+
+function validatePathSeparation(
+  configPath: string,
+  config: LibraryServiceConfig,
+): void {
+  const statusPath = path.join(config.stateRoot, "library-service-status.json");
+  if (
+    config.dataRoot === config.stateRoot ||
+    isWithinOrEqual(config.dataRoot, config.stateRoot) ||
+    isWithinOrEqual(config.stateRoot, config.dataRoot) ||
+    isWithinOrEqual(configPath, config.dataRoot) ||
+    isWithinOrEqual(configPath, config.stateRoot) ||
+    isWithinOrEqual(config.sidecar.executable, config.dataRoot) ||
+    isWithinOrEqual(config.sidecar.executable, config.stateRoot) ||
+    isWithinOrEqual(config.admissionFile, config.dataRoot) ||
+    isWithinOrEqual(config.credentialDescriptorFile, config.dataRoot) ||
+    !isStrictChild(config.admissionFile, config.stateRoot) ||
+    !isStrictChild(config.credentialDescriptorFile, config.stateRoot) ||
+    config.admissionFile === config.credentialDescriptorFile ||
+    config.admissionFile === statusPath ||
+    config.credentialDescriptorFile === statusPath
+  ) {
+    throw new LibraryServiceFailure("config_invalid");
+  }
+}
+
+function decodeBoundedText(
+  bytes: Uint8Array,
+  failureCode: LibraryServiceFailureCode,
+): string {
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    throw new LibraryServiceFailure(failureCode);
+  }
+}
+
+function sha256(bytes: Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+async function closeBoundPaths(
+  paths: readonly LibraryServiceBoundPath[],
+): Promise<void> {
+  await Promise.all(paths.map((bound) => bound.close().catch(() => undefined)));
+}
+
+export async function assertLibraryServiceBindingsStable(
+  bound: BoundLibraryServiceConfiguration,
+  fileSystem: LibraryServiceFileSystemPort,
+  signal?: AbortSignal,
+): Promise<void> {
+  const paths = [bound.configFile, ...Object.values(bound.bindings)];
+  for (const resource of paths) {
+    throwIfAborted(signal);
+    try {
+      await resource.assertStable();
+      await resource.assertPathStable();
+      await resource.assertCanonicalPath();
+    } catch {
+      throwIfAborted(signal);
+      throw new LibraryServiceFailure("bound_input_changed");
+    }
+    throwIfAborted(signal);
+    let current: LibraryServiceFileMetadata;
+    try {
+      current = await fileSystem.inspect(resource.path);
+    } catch {
+      throw new LibraryServiceFailure("bound_input_changed");
+    }
+    throwIfAborted(signal);
+    if (!sameIdentity(current, resource.metadata)) {
+      throw new LibraryServiceFailure("bound_input_changed");
+    }
+  }
+
+  const digests: ReadonlyArray<readonly [LibraryServiceBoundPath, string]> = [
+    [bound.configFile, bound.configDigest],
+    [bound.bindings.executable, bound.executableDigest],
+    [bound.bindings.admission, bound.admissionDigest],
+    [bound.bindings.credentialDescriptor, bound.credentialDescriptorDigest],
+  ];
+  for (const [resource, expectedDigest] of digests) {
+    throwIfAborted(signal);
+    let actualDigest: string;
+    try {
+      actualDigest = await resource.sha256();
+    } catch {
+      throwIfAborted(signal);
+      throw new LibraryServiceFailure("bound_input_changed");
+    }
+    throwIfAborted(signal);
+    if (actualDigest !== expectedDigest) {
+      throw new LibraryServiceFailure("bound_input_changed");
+    }
+  }
+}
+
+export async function bindLibraryServiceConfig(
+  configPath: string,
+  fileSystem: LibraryServiceFileSystemPort,
+  identity: LibraryServiceIdentityPort,
+  aclProof: LibraryServiceAclProofPort,
+  signal?: AbortSignal,
+): Promise<BoundLibraryServiceConfiguration> {
+  const userId = identity.currentUserId();
+  if (userId === null) {
+    throw new LibraryServiceFailure("unsupported_secret_store_or_acl_backend");
+  }
+  throwIfAborted(signal);
+  const physicalConfigPath = requireAbsolutePhysicalPath(
+    configPath,
+    "config_missing",
+  );
+  const context: ValidationContext = {
+    fileSystem,
+    userId,
+    signal,
+    aclTargets: new Map(),
+  };
+  const opened: LibraryServiceBoundPath[] = [];
+
+  try {
+    const configFile = await bindPrivateFile(
+      physicalConfigPath,
+      context,
+      "config_missing",
+      "config_not_private",
+    );
+    opened.push(configFile);
+    const configBytes = await configFile.readBoundedBytes(
+      LIBRARY_SERVICE_MAX_CONFIG_BYTES,
+    );
+    throwIfAborted(signal);
+    const configDigest = sha256(configBytes);
+    const config = parseConfig(
+      decodeBoundedText(configBytes, "config_invalid"),
+    );
+    validatePathSeparation(physicalConfigPath, config);
+
+    const dataRoot = await bindPrivateDirectory(
+      config.dataRoot,
+      context,
+      "data_root_invalid",
+      "data_root_not_private",
+    );
+    opened.push(dataRoot);
+    const stateRoot = await bindPrivateDirectory(
+      config.stateRoot,
+      context,
+      "state_root_invalid",
+      "state_root_not_private",
+    );
+    opened.push(stateRoot);
+    const admission = await bindPrivateFile(
+      config.admissionFile,
+      context,
+      "admission_missing",
+      "admission_not_private",
+    );
+    opened.push(admission);
+    if (admission.metadata.size > MAX_ADMISSION_BYTES) {
+      throw new LibraryServiceFailure("admission_not_private");
+    }
+    const credentialDescriptor = await bindPrivateFile(
+      config.credentialDescriptorFile,
+      context,
+      "credential_descriptor_missing",
+      "credential_descriptor_not_private",
+    );
+    opened.push(credentialDescriptor);
+    const credentialBytes = await credentialDescriptor.readBoundedBytes(
+      LIBRARY_SERVICE_MAX_DESCRIPTOR_BYTES,
+    );
+    throwIfAborted(signal);
+    parseCredentialDescriptor(
+      decodeBoundedText(credentialBytes, "credential_descriptor_invalid"),
+    );
+    const sidecar = await bindPinnedSidecar(config, context);
+    opened.push(sidecar.bound);
+
+    throwIfAborted(signal);
+    try {
+      await aclProof.assertNoExtendedAcl([...context.aclTargets.values()]);
+    } catch (error) {
+      if (error instanceof LibraryServiceFailure) throw error;
+      throw new LibraryServiceFailure("acl_probe_unavailable");
+    }
+    throwIfAborted(signal);
+
+    const result: BoundLibraryServiceConfiguration = {
+      config,
+      configDigest,
+      executableDigest: sidecar.digest,
+      admissionDigest: await admission.sha256(),
+      credentialDescriptorDigest: sha256(credentialBytes),
+      configFile,
+      bindings: {
+        executable: sidecar.bound,
+        dataRoot,
+        stateRoot,
+        admission,
+        credentialDescriptor,
+      },
+      async close() {
+        await closeBoundPaths([
+          configFile,
+          sidecar.bound,
+          dataRoot,
+          stateRoot,
+          admission,
+          credentialDescriptor,
+        ]);
+      },
+    };
+    await assertLibraryServiceBindingsStable(result, fileSystem, signal);
+    return result;
+  } catch (error) {
+    await closeBoundPaths(opened);
+    throw error;
+  }
+}

--- a/packages/library-service/src/contracts.ts
+++ b/packages/library-service/src/contracts.ts
@@ -1,0 +1,267 @@
+export const LIBRARY_SERVICE_CONFIG_SCHEMA_VERSION = 1 as const;
+export const LIBRARY_SERVICE_PROTOCOL_VERSION = 1 as const;
+export const LIBRARY_SERVICE_STATUS_SCHEMA_VERSION = 1 as const;
+export const LIBRARY_SERVICE_MAX_CONFIG_BYTES = 32 * 1_024;
+export const LIBRARY_SERVICE_MAX_DESCRIPTOR_BYTES = 4 * 1_024;
+export const LIBRARY_SERVICE_MAX_CONTROL_BYTES = 4 * 1_024;
+export const LIBRARY_SERVICE_MAX_STATUS_BYTES = 4 * 1_024;
+export const LIBRARY_SERVICE_EXECUTABLE_FD = 3 as const;
+export const LIBRARY_SERVICE_DATA_ROOT_FD = 4 as const;
+export const LIBRARY_SERVICE_STATE_ROOT_FD = 5 as const;
+export const LIBRARY_SERVICE_ADMISSION_FD = 6 as const;
+export const LIBRARY_SERVICE_CREDENTIAL_DESCRIPTOR_FD = 7 as const;
+export const LIBRARY_SERVICE_LIFETIME_FD = 8 as const;
+
+export type LibraryServiceRole = "primary";
+
+export const LIBRARY_SERVICE_FAILURE_CODES = Object.freeze([
+  "already_started",
+  "acl_present",
+  "acl_probe_malformed",
+  "acl_probe_unavailable",
+  "bound_input_changed",
+  "config_invalid",
+  "config_missing",
+  "config_not_private",
+  "credential_descriptor_invalid",
+  "credential_descriptor_missing",
+  "credential_descriptor_not_private",
+  "data_root_invalid",
+  "data_root_not_private",
+  "filesystem_failure",
+  "admission_missing",
+  "admission_not_private",
+  "ready_malformed",
+  "ready_binding_mismatch",
+  "ready_multiple",
+  "ready_oversized",
+  "ready_response_lost",
+  "ready_role_mismatch",
+  "sidecar_digest_mismatch",
+  "sidecar_exited",
+  "sidecar_invalid",
+  "sidecar_missing",
+  "sidecar_path_unsafe",
+  "sidecar_settlement_timeout",
+  "spawn_failed",
+  "startup_timeout",
+  "startup_cancelled",
+  "state_root_invalid",
+  "state_root_not_private",
+  "status_invalid",
+  "status_not_private",
+  "unsupported_secret_store_or_acl_backend",
+  "unsupported_bound_descriptor_execution",
+  "write_failed",
+] as const);
+
+export type LibraryServiceFailureCode =
+  (typeof LIBRARY_SERVICE_FAILURE_CODES)[number];
+
+export class LibraryServiceFailure extends Error {
+  readonly code: LibraryServiceFailureCode;
+
+  constructor(code: LibraryServiceFailureCode) {
+    super(code);
+    this.name = "LibraryServiceFailure";
+    this.code = code;
+  }
+}
+
+export interface LibraryServiceSidecarConfig {
+  executable: string;
+  sha256: string;
+  startupTimeoutMs: number;
+  shutdownTimeoutMs: number;
+}
+
+export interface LibraryServiceConfig {
+  schemaVersion: typeof LIBRARY_SERVICE_CONFIG_SCHEMA_VERSION;
+  role: LibraryServiceRole;
+  dataRoot: string;
+  stateRoot: string;
+  admissionFile: string;
+  credentialDescriptorFile: string;
+  sidecar: LibraryServiceSidecarConfig;
+}
+
+export interface LibraryServiceCredentialDescriptor {
+  schemaVersion: 1;
+  backend: "os-vault" | "mounted-credential";
+  recordId: string;
+}
+
+export interface LibraryServiceStartEnvelope {
+  type: "start";
+  protocolVersion: typeof LIBRARY_SERVICE_PROTOCOL_VERSION;
+  role: LibraryServiceRole;
+  parentNonce: string;
+  configDigest: string;
+  executableDigest: string;
+  executableFd: typeof LIBRARY_SERVICE_EXECUTABLE_FD;
+  dataRootFd: typeof LIBRARY_SERVICE_DATA_ROOT_FD;
+  stateRootFd: typeof LIBRARY_SERVICE_STATE_ROOT_FD;
+  admissionFd: typeof LIBRARY_SERVICE_ADMISSION_FD;
+  credentialDescriptorFd: typeof LIBRARY_SERVICE_CREDENTIAL_DESCRIPTOR_FD;
+  lifetimeFd: typeof LIBRARY_SERVICE_LIFETIME_FD;
+}
+
+export interface LibraryServiceReadyRecord {
+  type: "ready";
+  protocolVersion: typeof LIBRARY_SERVICE_PROTOCOL_VERSION;
+  role: LibraryServiceRole;
+  pid: number;
+  leaseHeld: true;
+  authorityOpen: true;
+  admissionAccepted: true;
+  credentialsReady: true;
+  watchdogActive: true;
+  parentNonce: string;
+  configDigest: string;
+  executableDigest: string;
+  dataRootDevice: string;
+  dataRootInode: string;
+  stateRootDevice: string;
+  stateRootInode: string;
+  admissionDigest: string;
+  credentialDescriptorDigest: string;
+}
+
+export interface LibraryServiceFileMetadata {
+  kind: "file" | "directory" | "symbolic-link" | "other";
+  mode: number;
+  uid: number | null;
+  size: number;
+  device: string;
+  inode: string;
+  links: number;
+}
+
+export interface LibraryServiceBoundPath {
+  readonly path: string;
+  readonly descriptor: number;
+  readonly metadata: LibraryServiceFileMetadata;
+  assertStable(): Promise<void>;
+  assertPathStable(): Promise<void>;
+  assertCanonicalPath(): Promise<void>;
+  readBoundedBytes(maximumBytes: number): Promise<Uint8Array>;
+  sha256(): Promise<string>;
+  close(): Promise<void>;
+}
+
+export interface LibraryServiceFileSystemPort {
+  canonicalPath(filePath: string): Promise<string>;
+  inspect(filePath: string): Promise<LibraryServiceFileMetadata>;
+  openBoundPath(filePath: string): Promise<LibraryServiceBoundPath>;
+  openPrivateStatusFile(
+    stateRoot: LibraryServiceBoundPath,
+    stateRootPath: string,
+    expectedUserId: number,
+  ): Promise<LibraryServiceBoundPath | null>;
+  readPrivateStatusText(
+    statusFile: LibraryServiceBoundPath,
+    maximumBytes: number,
+  ): Promise<string>;
+  writePrivateStatusText(
+    statusFile: LibraryServiceBoundPath,
+    contents: string,
+  ): Promise<void>;
+}
+
+export interface LibraryServiceAclProbeTarget {
+  path: string;
+  device: string;
+  inode: string;
+}
+
+export interface LibraryServiceAclProofPort {
+  assertNoExtendedAcl(
+    targets: readonly LibraryServiceAclProbeTarget[],
+  ): Promise<void>;
+}
+
+export interface LibraryServiceIdentityPort {
+  currentUserId(): number | null;
+}
+
+export interface LibraryServiceClockPort {
+  nowMs(): number;
+  deadline(milliseconds: number): {
+    elapsed: Promise<void>;
+    cancel(): void;
+  };
+}
+
+export interface LibraryServiceEntropyPort {
+  nonceHex(byteLength: number): string;
+}
+
+export interface LibraryServiceSidecarExit {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+}
+
+export interface LibraryServiceSidecarProcess {
+  readonly pid: number | null;
+  readonly exit: Promise<LibraryServiceSidecarExit>;
+  isRunning(): boolean;
+  isGroupRunning(): boolean;
+  writeControl(contents: string): Promise<void>;
+  closeControlInput(): Promise<void>;
+  readControlOutput(maximumBytes: number): Promise<Uint8Array>;
+  terminate(signal: "SIGTERM" | "SIGKILL"): void;
+  closeLifetime(): void;
+}
+
+export interface LibraryServiceBoundInputs {
+  executable: LibraryServiceBoundPath;
+  dataRoot: LibraryServiceBoundPath;
+  stateRoot: LibraryServiceBoundPath;
+  admission: LibraryServiceBoundPath;
+  credentialDescriptor: LibraryServiceBoundPath;
+}
+
+export interface LibraryServiceProcessPort {
+  spawn(request: {
+    bindings: LibraryServiceBoundInputs;
+    args: readonly [];
+    env: Readonly<Record<string, never>>;
+    executableDigest: string;
+    settlementTimeoutMs: number;
+    signal?: AbortSignal;
+  }): Promise<LibraryServiceSidecarProcess>;
+}
+
+export type LibraryServicePhase =
+  | "starting"
+  | "running"
+  | "stopping"
+  | "stopped"
+  | "failed";
+
+export interface LibraryServiceStatusRecord {
+  schemaVersion: typeof LIBRARY_SERVICE_STATUS_SCHEMA_VERSION;
+  service: "freed-library";
+  role: LibraryServiceRole;
+  phase: LibraryServicePhase;
+  updatedAt: string;
+  startedAt: string | null;
+  sidecarPid: number | null;
+  reasonCode: LibraryServiceFailureCode | "requested_stop" | null;
+}
+
+export interface LibraryServiceDoctorReport {
+  schemaVersion: 1;
+  service: "freed-library";
+  ok: boolean;
+  role: LibraryServiceRole | null;
+  code: "ready" | LibraryServiceFailureCode;
+  checks: readonly string[];
+}
+
+export interface LibraryServiceStatusReport {
+  schemaVersion: 1;
+  service: "freed-library";
+  configuredRole: LibraryServiceRole;
+  status: LibraryServiceStatusRecord | null;
+}

--- a/packages/library-service/src/diagnostics.ts
+++ b/packages/library-service/src/diagnostics.ts
@@ -1,0 +1,87 @@
+import {
+  LibraryServiceFailure,
+  type LibraryServiceAclProofPort,
+  type LibraryServiceDoctorReport,
+  type LibraryServiceFileSystemPort,
+  type LibraryServiceIdentityPort,
+} from "./contracts.js";
+import {
+  assertLibraryServiceBindingsStable,
+  bindLibraryServiceConfig,
+} from "./config.js";
+import { bindLibraryServiceStatusFile } from "./status.js";
+
+const HEALTHY_CHECKS = Object.freeze([
+  "config_private",
+  "role_primary",
+  "data_root_private",
+  "state_root_private",
+  "admission_private",
+  "credential_descriptor_private",
+  "credential_descriptor_secret_free",
+  "extended_acl_absent",
+  "path_boundaries_separated",
+  "regular_files_single_link",
+  "sidecar_path_safe",
+  "sidecar_digest_pinned",
+  "sidecar_descriptor_bound",
+  "authority_inputs_descriptor_bound",
+  "lifetime_watchdog_required",
+  "status_file_precreated_private",
+]);
+
+export async function inspectLibraryServiceReadiness(
+  configPath: string,
+  fileSystem: LibraryServiceFileSystemPort,
+  identity: LibraryServiceIdentityPort,
+  aclProof: LibraryServiceAclProofPort,
+): Promise<LibraryServiceDoctorReport> {
+  let close: (() => Promise<void>) | null = null;
+  try {
+    const bound = await bindLibraryServiceConfig(
+      configPath,
+      fileSystem,
+      identity,
+      aclProof,
+    );
+    close = bound.close;
+    const statusFile = await bindLibraryServiceStatusFile(
+      bound.config,
+      bound.bindings.stateRoot,
+      fileSystem,
+      identity,
+      aclProof,
+    );
+    if (statusFile === null) {
+      throw new LibraryServiceFailure("status_invalid");
+    }
+    close = async () => {
+      await statusFile.close().catch(() => undefined);
+      await bound.close();
+    };
+    await assertLibraryServiceBindingsStable(bound, fileSystem);
+    return {
+      schemaVersion: 1,
+      service: "freed-library",
+      ok: true,
+      role: bound.config.role,
+      code: "ready",
+      checks: HEALTHY_CHECKS,
+    };
+  } catch (error) {
+    const code =
+      error instanceof LibraryServiceFailure
+        ? error.code
+        : "filesystem_failure";
+    return {
+      schemaVersion: 1,
+      service: "freed-library",
+      ok: false,
+      role: null,
+      code,
+      checks: [],
+    };
+  } finally {
+    await close?.();
+  }
+}

--- a/packages/library-service/src/index.ts
+++ b/packages/library-service/src/index.ts
@@ -1,0 +1,14 @@
+export {
+  LIBRARY_SERVICE_CONFIG_SCHEMA_VERSION,
+  LIBRARY_SERVICE_FAILURE_CODES,
+  LIBRARY_SERVICE_PROTOCOL_VERSION,
+  LibraryServiceFailure,
+  type LibraryServiceConfig,
+  type LibraryServiceDoctorReport,
+  type LibraryServiceFailureCode,
+  type LibraryServiceReadyRecord,
+  type LibraryServiceStartEnvelope,
+  type LibraryServiceStatusRecord,
+  type LibraryServiceStatusReport,
+} from "./contracts.js";
+export { runLibraryServiceCli } from "./cli-runtime.js";

--- a/packages/library-service/src/node-ports.ts
+++ b/packages/library-service/src/node-ports.ts
@@ -1,0 +1,815 @@
+import { execFile, spawn, type ChildProcess } from "node:child_process";
+import { createHash, randomBytes } from "node:crypto";
+import { constants } from "node:fs";
+import { lstat, open, realpath, type FileHandle } from "node:fs/promises";
+import path from "node:path";
+import type { Duplex } from "node:stream";
+import { promisify } from "node:util";
+
+import {
+  LIBRARY_SERVICE_ADMISSION_FD,
+  LIBRARY_SERVICE_CREDENTIAL_DESCRIPTOR_FD,
+  LIBRARY_SERVICE_DATA_ROOT_FD,
+  LIBRARY_SERVICE_EXECUTABLE_FD,
+  LIBRARY_SERVICE_LIFETIME_FD,
+  LIBRARY_SERVICE_STATE_ROOT_FD,
+  LibraryServiceFailure,
+  type LibraryServiceAclProbeTarget,
+  type LibraryServiceAclProofPort,
+  type LibraryServiceBoundPath,
+  type LibraryServiceClockPort,
+  type LibraryServiceEntropyPort,
+  type LibraryServiceFileMetadata,
+  type LibraryServiceFileSystemPort,
+  type LibraryServiceIdentityPort,
+  type LibraryServiceProcessPort,
+  type LibraryServiceSidecarExit,
+  type LibraryServiceSidecarProcess,
+} from "./contracts.js";
+
+const execFileAsync = promisify(execFile);
+const MAX_ACL_OUTPUT_BYTES = 32 * 1_024;
+const ACL_TIMEOUT_MS = 1_000;
+
+type BigIntStats = Awaited<ReturnType<FileHandle["stat"]>> & {
+  dev: bigint;
+  ino: bigint;
+  nlink: bigint;
+  mode: bigint;
+  uid: bigint;
+  size: bigint;
+};
+
+function metadataKind(metadata: {
+  isSymbolicLink(): boolean;
+  isFile(): boolean;
+  isDirectory(): boolean;
+}): LibraryServiceFileMetadata["kind"] {
+  if (metadata.isSymbolicLink()) return "symbolic-link";
+  if (metadata.isFile()) return "file";
+  if (metadata.isDirectory()) return "directory";
+  return "other";
+}
+
+function metadataFromStats(metadata: BigIntStats): LibraryServiceFileMetadata {
+  const size = Number(metadata.size);
+  const uid = Number(metadata.uid);
+  const links = Number(metadata.nlink);
+  if (
+    !Number.isSafeInteger(size) ||
+    size < 0 ||
+    !Number.isSafeInteger(uid) ||
+    uid < 0 ||
+    !Number.isSafeInteger(links) ||
+    links < 1
+  ) {
+    throw new LibraryServiceFailure("filesystem_failure");
+  }
+  return {
+    kind: metadataKind(metadata),
+    mode: Number(metadata.mode),
+    uid,
+    size,
+    device: metadata.dev.toString(10),
+    inode: metadata.ino.toString(10),
+    links,
+  };
+}
+
+async function handleMetadata(
+  handle: FileHandle,
+): Promise<LibraryServiceFileMetadata> {
+  return metadataFromStats(
+    (await handle.stat({ bigint: true })) as unknown as BigIntStats,
+  );
+}
+
+function sameIdentity(
+  left: LibraryServiceFileMetadata,
+  right: LibraryServiceFileMetadata,
+): boolean {
+  return (
+    left.kind === right.kind &&
+    left.mode === right.mode &&
+    left.uid === right.uid &&
+    (left.kind !== "file" || left.size === right.size) &&
+    left.device === right.device &&
+    left.inode === right.inode &&
+    left.links === right.links
+  );
+}
+
+class NodeBoundPath implements LibraryServiceBoundPath {
+  #closed = false;
+  readonly #handle: FileHandle;
+  #metadata: LibraryServiceFileMetadata;
+
+  constructor(
+    readonly path: string,
+    handle: FileHandle,
+    metadata: LibraryServiceFileMetadata,
+  ) {
+    this.#handle = handle;
+    this.#metadata = metadata;
+  }
+
+  get descriptor(): number {
+    return this.#handle.fd;
+  }
+
+  get metadata(): LibraryServiceFileMetadata {
+    return this.#metadata;
+  }
+
+  async assertStable(): Promise<void> {
+    if (this.#closed) {
+      throw new LibraryServiceFailure("filesystem_failure");
+    }
+    const after = await handleMetadata(this.#handle);
+    if (!sameIdentity(after, this.metadata)) {
+      throw new LibraryServiceFailure("bound_input_changed");
+    }
+  }
+
+  async assertPathStable(): Promise<void> {
+    if (this.#closed) {
+      throw new LibraryServiceFailure("filesystem_failure");
+    }
+    let after: LibraryServiceFileMetadata;
+    try {
+      after = metadataFromStats(
+        (await lstat(this.path, { bigint: true })) as unknown as BigIntStats,
+      );
+    } catch {
+      throw new LibraryServiceFailure("bound_input_changed");
+    }
+    if (!sameIdentity(after, this.#metadata)) {
+      throw new LibraryServiceFailure("bound_input_changed");
+    }
+  }
+
+  async assertCanonicalPath(): Promise<void> {
+    if (this.#closed) {
+      throw new LibraryServiceFailure("filesystem_failure");
+    }
+    let canonical: string;
+    try {
+      canonical = await realpath(this.path);
+    } catch {
+      throw new LibraryServiceFailure("bound_input_changed");
+    }
+    if (canonical !== this.path) {
+      throw new LibraryServiceFailure("bound_input_changed");
+    }
+  }
+
+  async replaceText(contents: string): Promise<void> {
+    if (this.#closed || this.#metadata.kind !== "file") {
+      throw new LibraryServiceFailure("write_failed");
+    }
+    const before = this.#metadata;
+    const bytes = Buffer.from(contents, "utf8");
+    await this.#handle.truncate(0);
+    let offset = 0;
+    while (offset < bytes.byteLength) {
+      const { bytesWritten } = await this.#handle.write(
+        bytes,
+        offset,
+        bytes.byteLength - offset,
+        offset,
+      );
+      if (bytesWritten === 0) throw new LibraryServiceFailure("write_failed");
+      offset += bytesWritten;
+    }
+    await this.#handle.sync();
+    const after = await handleMetadata(this.#handle);
+    if (
+      after.kind !== before.kind ||
+      after.mode !== before.mode ||
+      after.uid !== before.uid ||
+      after.device !== before.device ||
+      after.inode !== before.inode ||
+      after.links !== before.links
+    ) {
+      throw new LibraryServiceFailure("bound_input_changed");
+    }
+    this.#metadata = after;
+  }
+
+  async readBoundedBytes(maximumBytes: number): Promise<Uint8Array> {
+    if (
+      this.#closed ||
+      this.metadata.kind !== "file" ||
+      this.metadata.size > maximumBytes
+    ) {
+      throw new LibraryServiceFailure("filesystem_failure");
+    }
+    const bytes = Buffer.alloc(this.metadata.size);
+    let offset = 0;
+    while (offset < bytes.byteLength) {
+      const { bytesRead } = await this.#handle.read(
+        bytes,
+        offset,
+        bytes.byteLength - offset,
+        offset,
+      );
+      if (bytesRead === 0) break;
+      offset += bytesRead;
+    }
+    if (offset !== bytes.byteLength) {
+      throw new LibraryServiceFailure("bound_input_changed");
+    }
+    await this.assertStable();
+    return bytes;
+  }
+
+  async sha256(): Promise<string> {
+    if (this.#closed || this.metadata.kind !== "file") {
+      throw new LibraryServiceFailure("filesystem_failure");
+    }
+    const digest = createHash("sha256");
+    const buffer = Buffer.alloc(64 * 1_024);
+    let position = 0;
+    while (position < this.metadata.size) {
+      const length = Math.min(buffer.byteLength, this.metadata.size - position);
+      const { bytesRead } = await this.#handle.read(
+        buffer,
+        0,
+        length,
+        position,
+      );
+      if (bytesRead === 0) {
+        throw new LibraryServiceFailure("bound_input_changed");
+      }
+      digest.update(buffer.subarray(0, bytesRead));
+      position += bytesRead;
+    }
+    await this.assertStable();
+    return digest.digest("hex");
+  }
+
+  async close(): Promise<void> {
+    if (this.#closed) return;
+    this.#closed = true;
+    await this.#handle.close();
+  }
+}
+
+class NodeLibraryServiceFileSystem implements LibraryServiceFileSystemPort {
+  async canonicalPath(filePath: string): Promise<string> {
+    return realpath(filePath);
+  }
+
+  async inspect(filePath: string): Promise<LibraryServiceFileMetadata> {
+    return metadataFromStats(
+      (await lstat(filePath, { bigint: true })) as unknown as BigIntStats,
+    );
+  }
+
+  async openBoundPath(filePath: string): Promise<LibraryServiceBoundPath> {
+    const flags =
+      constants.O_RDONLY |
+      (constants.O_NOFOLLOW ?? 0) |
+      (constants.O_NONBLOCK ?? 0);
+    const handle = await open(filePath, flags);
+    try {
+      const metadata = await handleMetadata(handle);
+      return new NodeBoundPath(filePath, handle, metadata);
+    } catch (error) {
+      await handle.close().catch(() => undefined);
+      throw error;
+    }
+  }
+
+  async openPrivateStatusFile(
+    stateRoot: LibraryServiceBoundPath,
+    stateRootPath: string,
+    expectedUserId: number,
+  ): Promise<LibraryServiceBoundPath | null> {
+    await stateRoot.assertStable();
+    await stateRoot.assertPathStable();
+    const statusPath = path.join(stateRootPath, "library-service-status.json");
+    let before: LibraryServiceFileMetadata | null = null;
+    try {
+      before = await this.inspect(statusPath);
+    } catch (error) {
+      if (
+        typeof error !== "object" ||
+        error === null ||
+        !("code" in error) ||
+        error.code !== "ENOENT"
+      ) {
+        throw error;
+      }
+    }
+    if (before === null) return null;
+    if (
+      before !== null &&
+      (before.kind !== "file" ||
+        before.uid !== expectedUserId ||
+        (before.mode & 0o7777) !== 0o600 ||
+        before.links !== 1)
+    ) {
+      throw new LibraryServiceFailure("status_not_private");
+    }
+
+    const flags =
+      constants.O_RDWR |
+      (constants.O_NOFOLLOW ?? 0) |
+      (constants.O_NONBLOCK ?? 0);
+    let handle: FileHandle;
+    try {
+      handle = await open(statusPath, flags, 0o600);
+    } catch {
+      throw new LibraryServiceFailure("status_not_private");
+    }
+    try {
+      const metadata = await handleMetadata(handle);
+      if (
+        metadata.kind !== "file" ||
+        metadata.uid !== expectedUserId ||
+        (metadata.mode & 0o7777) !== 0o600 ||
+        metadata.links !== 1 ||
+        !sameIdentity(before, metadata)
+      ) {
+        throw new LibraryServiceFailure("status_not_private");
+      }
+      const bound = new NodeBoundPath(statusPath, handle, metadata);
+      await stateRoot.assertStable();
+      await stateRoot.assertPathStable();
+      await bound.assertPathStable();
+      return bound;
+    } catch (error) {
+      await handle.close().catch(() => undefined);
+      throw error;
+    }
+  }
+
+  async readPrivateStatusText(
+    statusFile: LibraryServiceBoundPath,
+    maximumBytes: number,
+  ): Promise<string> {
+    const bytes = await statusFile.readBoundedBytes(maximumBytes);
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  }
+
+  async writePrivateStatusText(
+    statusFile: LibraryServiceBoundPath,
+    contents: string,
+  ): Promise<void> {
+    if (!(statusFile instanceof NodeBoundPath)) {
+      throw new LibraryServiceFailure("write_failed");
+    }
+    await statusFile.replaceText(contents);
+  }
+}
+
+class NodeLibraryServiceIdentity implements LibraryServiceIdentityPort {
+  currentUserId(): number | null {
+    return typeof process.getuid === "function" ? process.getuid() : null;
+  }
+}
+
+class NodeLibraryServiceClock implements LibraryServiceClockPort {
+  nowMs(): number {
+    return Date.now();
+  }
+
+  deadline(milliseconds: number): {
+    elapsed: Promise<void>;
+    cancel(): void;
+  } {
+    let timer: NodeJS.Timeout | null = null;
+    const elapsed = new Promise<void>((resolve) => {
+      timer = setTimeout(resolve, milliseconds);
+    });
+    return {
+      elapsed,
+      cancel() {
+        if (timer === null) return;
+        clearTimeout(timer);
+        timer = null;
+      },
+    };
+  }
+}
+
+class NodeLibraryServiceEntropy implements LibraryServiceEntropyPort {
+  nonceHex(byteLength: number): string {
+    return randomBytes(byteLength).toString("hex");
+  }
+}
+
+class NodeLibraryServiceAclProof implements LibraryServiceAclProofPort {
+  readonly #fileSystem: LibraryServiceFileSystemPort;
+
+  constructor(fileSystem: LibraryServiceFileSystemPort) {
+    this.#fileSystem = fileSystem;
+  }
+
+  async assertNoExtendedAcl(
+    targets: readonly LibraryServiceAclProbeTarget[],
+  ): Promise<void> {
+    if (process.platform !== "darwin") {
+      throw new LibraryServiceFailure("acl_probe_unavailable");
+    }
+    let helper: LibraryServiceFileMetadata;
+    try {
+      helper = await this.#fileSystem.inspect("/bin/ls");
+    } catch {
+      throw new LibraryServiceFailure("acl_probe_unavailable");
+    }
+    if (
+      helper.kind !== "file" ||
+      helper.uid !== 0 ||
+      (helper.mode & 0o022) !== 0 ||
+      helper.links !== 1 ||
+      (await this.#fileSystem.canonicalPath("/bin/ls")) !== "/bin/ls"
+    ) {
+      throw new LibraryServiceFailure("acl_probe_unavailable");
+    }
+
+    for (const target of targets) {
+      let stdout: string;
+      let stderr: string;
+      try {
+        const result = await execFileAsync("/bin/ls", ["-lde", target.path], {
+          encoding: "utf8",
+          timeout: ACL_TIMEOUT_MS,
+          maxBuffer: MAX_ACL_OUTPUT_BYTES,
+          env: { LANG: "C", LC_ALL: "C" },
+        });
+        stdout = result.stdout;
+        stderr = result.stderr;
+      } catch {
+        throw new LibraryServiceFailure("acl_probe_unavailable");
+      }
+      if (stderr !== "" || Buffer.byteLength(stdout) > MAX_ACL_OUTPUT_BYTES) {
+        throw new LibraryServiceFailure("acl_probe_malformed");
+      }
+      const firstLine = stdout.split("\n", 1)[0] ?? "";
+      const mode = /^([bcdlps-][rwxStTs-]{9})([+@])?\s/.exec(firstLine);
+      if (mode === null) {
+        throw new LibraryServiceFailure("acl_probe_malformed");
+      }
+      if (
+        mode[2] === "+" ||
+        stdout.split("\n").some((line) => /^\s+\d+:/.test(line))
+      ) {
+        throw new LibraryServiceFailure("acl_present");
+      }
+      const after = await this.#fileSystem.inspect(target.path);
+      if (after.device !== target.device || after.inode !== target.inode) {
+        throw new LibraryServiceFailure("bound_input_changed");
+      }
+    }
+  }
+}
+
+interface NodeProcessGroup {
+  readonly pid: number | null;
+  readonly exit: Promise<LibraryServiceSidecarExit>;
+  isRunning(): boolean;
+  isGroupRunning(): boolean;
+  terminate(signal: "SIGTERM" | "SIGKILL"): void;
+}
+
+class NodeChildProcessGroup implements NodeProcessGroup {
+  readonly exit: Promise<LibraryServiceSidecarExit>;
+  protected readonly child: ChildProcess;
+
+  constructor(child: ChildProcess) {
+    this.child = child;
+    this.exit = new Promise((resolve) => {
+      let settled = false;
+      const settle = (exit: LibraryServiceSidecarExit): void => {
+        if (settled) return;
+        settled = true;
+        resolve(exit);
+      };
+      this.child.once("error", () => settle({ code: null, signal: null }));
+      this.child.once("exit", (code, signal) => settle({ code, signal }));
+    });
+  }
+
+  get pid(): number | null {
+    return this.child.pid ?? null;
+  }
+
+  isRunning(): boolean {
+    return this.child.exitCode === null && this.child.signalCode === null;
+  }
+
+  isGroupRunning(): boolean {
+    const pid = this.pid;
+    if (pid === null) return false;
+    try {
+      process.kill(-pid, 0);
+      return true;
+    } catch (error) {
+      if (
+        typeof error === "object" &&
+        error !== null &&
+        "code" in error &&
+        error.code === "ESRCH"
+      ) {
+        return false;
+      }
+      return true;
+    }
+  }
+
+  terminate(signal: "SIGTERM" | "SIGKILL"): void {
+    const pid = this.pid;
+    if (pid === null) return;
+    try {
+      process.kill(-pid, signal);
+    } catch (error) {
+      if (
+        typeof error !== "object" ||
+        error === null ||
+        !("code" in error) ||
+        error.code !== "ESRCH"
+      ) {
+        throw error;
+      }
+    }
+  }
+}
+
+class NodeSidecarProcess
+  extends NodeChildProcessGroup
+  implements LibraryServiceSidecarProcess
+{
+  readonly #lifetimeWrite: Duplex;
+  #lifetimeClosed = false;
+
+  constructor(child: ChildProcess, lifetimeWrite: Duplex) {
+    super(child);
+    this.#lifetimeWrite = lifetimeWrite;
+    this.child.stdin?.on("error", () => undefined);
+    this.child.stdout?.on("error", () => undefined);
+    this.#lifetimeWrite.on("error", () => undefined);
+  }
+
+  async writeControl(contents: string): Promise<void> {
+    if (this.child.stdin === null)
+      throw new LibraryServiceFailure("spawn_failed");
+    await new Promise<void>((resolve, reject) => {
+      this.child.stdin!.write(contents, "utf8", (error) => {
+        if (error) reject(error);
+        else resolve();
+      });
+    });
+  }
+
+  async closeControlInput(): Promise<void> {
+    if (this.child.stdin === null)
+      throw new LibraryServiceFailure("spawn_failed");
+    await new Promise<void>((resolve) => this.child.stdin!.end(resolve));
+  }
+
+  async readControlOutput(maximumBytes: number): Promise<Uint8Array> {
+    if (this.child.stdout === null)
+      throw new LibraryServiceFailure("spawn_failed");
+    const chunks: Buffer[] = [];
+    let total = 0;
+    for await (const chunk of this.child.stdout) {
+      const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      total += bytes.byteLength;
+      if (total > maximumBytes) {
+        this.child.stdout.destroy();
+        throw new LibraryServiceFailure("ready_oversized");
+      }
+      chunks.push(bytes);
+    }
+    return Buffer.concat(chunks, total);
+  }
+
+  closeLifetime(): void {
+    if (this.#lifetimeClosed) return;
+    this.#lifetimeClosed = true;
+    this.#lifetimeWrite.end();
+    this.#lifetimeWrite.destroy();
+  }
+}
+
+class NodeLibraryServiceProcess implements LibraryServiceProcessPort {
+  readonly #clock: LibraryServiceClockPort;
+  readonly #spawnChild: typeof spawn;
+
+  constructor(clock: LibraryServiceClockPort, spawnChild: typeof spawn) {
+    this.#clock = clock;
+    this.#spawnChild = spawnChild;
+  }
+
+  async #waitForGroupExit(
+    processGroup: NodeProcessGroup,
+    timeoutMs: number,
+  ): Promise<boolean> {
+    const deadline = this.#clock.deadline(timeoutMs);
+    let exitWake = processGroup.isRunning()
+      ? processGroup.exit.then(() => "exit" as const)
+      : null;
+    try {
+      while (processGroup.isGroupRunning()) {
+        const poll = this.#clock.deadline(Math.min(25, timeoutMs));
+        try {
+          const outcomes: Array<Promise<"poll" | "timeout" | "exit">> = [
+            deadline.elapsed.then(() => "timeout" as const),
+            poll.elapsed.then(() => "poll" as const),
+          ];
+          if (exitWake !== null) outcomes.push(exitWake);
+          const outcome = await Promise.race(outcomes);
+          if (outcome === "timeout") return false;
+          if (outcome === "exit") exitWake = null;
+        } finally {
+          poll.cancel();
+        }
+      }
+      return true;
+    } finally {
+      deadline.cancel();
+    }
+  }
+
+  async #settleAfterKill(
+    processGroup: NodeProcessGroup,
+    timeoutMs: number,
+    closeLifetime?: () => void,
+  ): Promise<void> {
+    try {
+      processGroup.terminate("SIGKILL");
+    } catch {
+      // The group-exit proof below remains authoritative.
+    }
+    closeLifetime?.();
+    if (!(await this.#waitForGroupExit(processGroup, timeoutMs))) {
+      throw new LibraryServiceFailure("sidecar_settlement_timeout");
+    }
+  }
+
+  async spawn(request: {
+    bindings: Parameters<LibraryServiceProcessPort["spawn"]>[0]["bindings"];
+    args: readonly [];
+    env: Readonly<Record<string, never>>;
+    executableDigest: string;
+    settlementTimeoutMs: number;
+    signal?: AbortSignal;
+  }): Promise<LibraryServiceSidecarProcess> {
+    if (process.platform !== "darwin" && process.platform !== "linux") {
+      throw new LibraryServiceFailure("unsupported_bound_descriptor_execution");
+    }
+    if (request.signal?.aborted) {
+      throw new LibraryServiceFailure("startup_cancelled");
+    }
+    const executable = request.bindings.executable;
+    await executable.assertStable();
+    await executable.assertPathStable();
+    await executable.assertCanonicalPath();
+    if ((await executable.sha256()) !== request.executableDigest) {
+      throw new LibraryServiceFailure("sidecar_digest_mismatch");
+    }
+    await executable.assertStable();
+    await executable.assertPathStable();
+    await executable.assertCanonicalPath();
+    if (
+      executable.metadata.uid !== 0 ||
+      executable.metadata.links !== 1 ||
+      (executable.metadata.mode & 0o022) !== 0
+    ) {
+      throw new LibraryServiceFailure("sidecar_path_unsafe");
+    }
+    if (request.signal?.aborted) {
+      throw new LibraryServiceFailure("startup_cancelled");
+    }
+    const launchPath =
+      process.platform === "linux"
+        ? `/proc/self/fd/${LIBRARY_SERVICE_EXECUTABLE_FD}`
+        : executable.path;
+    let child: ChildProcess;
+    try {
+      child = this.#spawnChild(launchPath, [], {
+        detached: true,
+        cwd: "/",
+        env: request.env,
+        shell: false,
+        windowsHide: true,
+        stdio: [
+          "pipe",
+          "pipe",
+          "ignore",
+          request.bindings.executable.descriptor,
+          request.bindings.dataRoot.descriptor,
+          request.bindings.stateRoot.descriptor,
+          request.bindings.admission.descriptor,
+          request.bindings.credentialDescriptor.descriptor,
+          "pipe",
+        ],
+      });
+    } catch {
+      throw new LibraryServiceFailure("spawn_failed");
+    }
+    const lifetime: unknown = (child.stdio as Array<unknown>)[
+      LIBRARY_SERVICE_LIFETIME_FD
+    ];
+    if (
+      lifetime === null ||
+      typeof lifetime !== "object" ||
+      !("destroy" in lifetime) ||
+      typeof lifetime.destroy !== "function" ||
+      !("end" in lifetime) ||
+      typeof lifetime.end !== "function" ||
+      !("on" in lifetime) ||
+      typeof lifetime.on !== "function"
+    ) {
+      let closeInvalidLifetime: (() => void) | undefined;
+      if (
+        lifetime !== null &&
+        typeof lifetime === "object" &&
+        "destroy" in lifetime &&
+        typeof lifetime.destroy === "function"
+      ) {
+        const invalidLifetime = lifetime as { destroy(): void };
+        closeInvalidLifetime = () => invalidLifetime.destroy();
+      }
+      await this.#settleAfterKill(
+        new NodeChildProcessGroup(child),
+        request.settlementTimeoutMs,
+        closeInvalidLifetime,
+      );
+      throw new LibraryServiceFailure("unsupported_bound_descriptor_execution");
+    }
+    const sidecar = new NodeSidecarProcess(child, lifetime as Duplex);
+
+    await new Promise<void>((resolve, reject) => {
+      let settled = false;
+      let cancelling = false;
+      const settle = (error?: LibraryServiceFailure): void => {
+        if (settled) return;
+        settled = true;
+        request.signal?.removeEventListener("abort", onAbort);
+        child.removeListener("spawn", onSpawn);
+        child.removeListener("error", onError);
+        if (error === undefined) resolve();
+        else reject(error);
+      };
+      const onSpawn = (): void => {
+        if (!cancelling) settle();
+      };
+      const onError = (): void => {
+        if (cancelling) return;
+        cancelling = true;
+        void this.#settleAfterKill(sidecar, request.settlementTimeoutMs, () =>
+          sidecar.closeLifetime(),
+        ).then(
+          () => settle(new LibraryServiceFailure("spawn_failed")),
+          () => settle(new LibraryServiceFailure("sidecar_settlement_timeout")),
+        );
+      };
+      const onAbort = (): void => {
+        if (settled || cancelling) return;
+        cancelling = true;
+        void this.#settleAfterKill(sidecar, request.settlementTimeoutMs, () =>
+          sidecar.closeLifetime(),
+        ).then(
+          () => settle(new LibraryServiceFailure("startup_cancelled")),
+          () => settle(new LibraryServiceFailure("sidecar_settlement_timeout")),
+        );
+      };
+      child.once("spawn", onSpawn);
+      child.once("error", onError);
+      request.signal?.addEventListener("abort", onAbort, { once: true });
+      if (request.signal?.aborted) onAbort();
+    });
+    return sidecar;
+  }
+}
+
+interface NodeLibraryServicePorts {
+  fileSystem: LibraryServiceFileSystemPort;
+  identity: LibraryServiceIdentityPort;
+  aclProof: LibraryServiceAclProofPort;
+  clock: LibraryServiceClockPort;
+  entropy: LibraryServiceEntropyPort;
+  process: LibraryServiceProcessPort;
+}
+
+interface NodeLibraryServicePortsOptions {
+  spawnChild?: typeof spawn;
+}
+
+export function createNodeLibraryServicePorts(
+  options: NodeLibraryServicePortsOptions = {},
+): NodeLibraryServicePorts {
+  const fileSystem = new NodeLibraryServiceFileSystem();
+  const clock = new NodeLibraryServiceClock();
+  return {
+    fileSystem,
+    identity: new NodeLibraryServiceIdentity(),
+    aclProof: new NodeLibraryServiceAclProof(fileSystem),
+    clock,
+    entropy: new NodeLibraryServiceEntropy(),
+    process: new NodeLibraryServiceProcess(clock, options.spawnChild ?? spawn),
+  };
+}

--- a/packages/library-service/src/runtime.integration.test.ts
+++ b/packages/library-service/src/runtime.integration.test.ts
@@ -1,0 +1,625 @@
+import { execFile, spawn, type ChildProcess } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  chmod,
+  mkdtemp,
+  mkdir,
+  readFile,
+  realpath,
+  rename,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { bindLibraryServiceConfig } from "./config.js";
+import { createNodeLibraryServicePorts } from "./node-ports.js";
+import {
+  bindLibraryServiceStatusFile,
+  createLibraryServiceStatusRecord,
+  writeLibraryServiceStatus,
+} from "./status.js";
+
+const execFileAsync = promisify(execFile);
+const fixtures: string[] = [];
+const darwinIt = process.platform === "darwin" ? it : it.skip;
+const linuxIt = process.platform === "linux" ? it : it.skip;
+const posixIt =
+  process.platform === "darwin" || process.platform === "linux" ? it : it.skip;
+
+async function privateTemporaryRoot(prefix: string): Promise<string> {
+  const physicalTemporaryRoot = await realpath(
+    process.platform === "linux" ? os.homedir() : os.tmpdir(),
+  );
+  const fixture = await mkdtemp(path.join(physicalTemporaryRoot, prefix));
+  fixtures.push(fixture);
+  await chmod(fixture, 0o700);
+  return fixture;
+}
+
+async function createServiceFixture(): Promise<{
+  configPath: string;
+  stateRoot: string;
+  statusPath: string;
+}> {
+  const fixtureRoot = await privateTemporaryRoot("freed-library-service-");
+  const dataRoot = path.join(fixtureRoot, "data");
+  const stateRoot = path.join(fixtureRoot, "state");
+  await Promise.all([
+    mkdir(dataRoot, { mode: 0o700 }),
+    mkdir(stateRoot, { mode: 0o700 }),
+  ]);
+  const admissionFile = path.join(stateRoot, "admission.json");
+  const credentialDescriptorFile = path.join(stateRoot, "credentials.json");
+  const statusPath = path.join(stateRoot, "library-service-status.json");
+  await Promise.all([
+    writeFile(admissionFile, '{"signedAdmission":"opaque"}\n', {
+      mode: 0o600,
+    }),
+    writeFile(
+      credentialDescriptorFile,
+      `${JSON.stringify({
+        schemaVersion: 1,
+        backend: "os-vault",
+        recordId: "freed-library-primary",
+      })}\n`,
+      { mode: 0o600 },
+    ),
+    writeFile(statusPath, "", { mode: 0o600 }),
+  ]);
+  const executable = await realpath("/bin/sleep");
+  const executableDigest = createHash("sha256")
+    .update(await readFile(executable))
+    .digest("hex");
+  const configPath = path.join(fixtureRoot, "service.json");
+  await writeFile(
+    configPath,
+    `${JSON.stringify({
+      schemaVersion: 1,
+      role: "primary",
+      dataRoot,
+      stateRoot,
+      admissionFile,
+      credentialDescriptorFile,
+      sidecar: {
+        executable,
+        sha256: executableDigest,
+        startupTimeoutMs: 500,
+        shutdownTimeoutMs: 250,
+      },
+    })}\n`,
+    { mode: 0o600 },
+  );
+  return { configPath, stateRoot, statusPath };
+}
+
+async function runCli(args: readonly string[]): Promise<{
+  code: number | null;
+  stdout: string;
+  stderr: string;
+}> {
+  const cliPath = path.resolve("dist/bin.js");
+  const child = spawn(process.execPath, [cliPath, ...args], {
+    cwd: process.cwd(),
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let stdout = "";
+  let stderr = "";
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (chunk: string) => {
+    stdout += chunk;
+  });
+  child.stderr.on("data", (chunk: string) => {
+    stderr += chunk;
+  });
+  const code = await new Promise<number | null>((resolve, reject) => {
+    child.once("error", reject);
+    child.once("exit", resolve);
+  });
+  return { code, stdout, stderr };
+}
+
+function sidecarSource(): string {
+  return `#!${process.execPath}
+import { createHash } from "node:crypto";
+import { fstatSync, readSync } from "node:fs";
+import { spawn } from "node:child_process";
+import { Socket } from "node:net";
+
+function readFd(fd) {
+  const size = Number(fstatSync(fd, { bigint: true }).size);
+  const bytes = Buffer.alloc(size);
+  let offset = 0;
+  while (offset < size) {
+    const count = readSync(fd, bytes, offset, size - offset, offset);
+    if (count === 0) process.exit(71);
+    offset += count;
+  }
+  return bytes;
+}
+function digest(fd) {
+  return createHash("sha256").update(readFd(fd)).digest("hex");
+}
+function identity(fd) {
+  const value = fstatSync(fd, { bigint: true });
+  return { device: String(value.dev), inode: String(value.ino) };
+}
+
+let control = "";
+const admissionBytes = readFd(6);
+const leaderOnlyTerm = admissionBytes.includes(Buffer.from("leaderOnlyTerm"));
+const descendant = spawn("/bin/sleep", ["60"], { stdio: "ignore" });
+for await (const chunk of process.stdin) control += chunk.toString("utf8");
+const envelope = JSON.parse(control.trim());
+let stopping = false;
+const watchdog = new Socket({ fd: 8, readable: true, writable: false });
+async function stop() {
+  if (stopping) return;
+  stopping = true;
+  watchdog.destroy();
+  descendant.kill("SIGTERM");
+  const kill = setTimeout(() => descendant.kill("SIGKILL"), 200);
+  if (descendant.exitCode === null && descendant.signalCode === null) {
+    await new Promise((resolve) => descendant.once("exit", resolve));
+  }
+  clearTimeout(kill);
+  process.exit(0);
+}
+process.on("SIGTERM", () => {
+  if (leaderOnlyTerm) process.exit(0);
+  else void stop();
+});
+watchdog.resume();
+watchdog.on("end", () => void stop());
+watchdog.on("close", () => void stop());
+watchdog.on("error", () => void stop());
+const data = identity(4);
+const state = identity(5);
+const receipt = {
+  type: "ready",
+  protocolVersion: 1,
+  role: "primary",
+  pid: process.pid,
+  leaseHeld: true,
+  authorityOpen: true,
+  admissionAccepted: true,
+  credentialsReady: true,
+  watchdogActive: true,
+  parentNonce: envelope.parentNonce,
+  configDigest: envelope.configDigest,
+  executableDigest: digest(3),
+  dataRootDevice: data.device,
+  dataRootInode: data.inode,
+  stateRootDevice: state.device,
+  stateRootInode: state.inode,
+  admissionDigest: createHash("sha256").update(admissionBytes).digest("hex"),
+  credentialDescriptorDigest: digest(7),
+};
+await new Promise((resolve) => process.stdout.end(JSON.stringify(receipt) + "\\n", resolve));
+`;
+}
+
+async function createHarnessFixture(
+  input: {
+    leaderOnlyTerm?: boolean;
+  } = {},
+): Promise<{
+  args: string[];
+  supervisorArgs: string[];
+}> {
+  const fixtureRoot = await privateTemporaryRoot("freed-library-harness-");
+  const dataRoot = path.join(fixtureRoot, "data");
+  const stateRoot = path.join(fixtureRoot, "state");
+  await Promise.all([
+    mkdir(dataRoot, { mode: 0o700 }),
+    mkdir(stateRoot, { mode: 0o700 }),
+  ]);
+  const admission = path.join(stateRoot, "admission.json");
+  const credential = path.join(stateRoot, "credentials.json");
+  const status = path.join(stateRoot, "library-service-status.json");
+  const sidecar = path.join(fixtureRoot, "authority-sidecar");
+  const config = path.join(fixtureRoot, "service.json");
+  const admissionContents = input.leaderOnlyTerm
+    ? '{"leaderOnlyTerm":true}\n'
+    : '{"signedAdmission":"opaque"}\n';
+  await Promise.all([
+    writeFile(admission, admissionContents, { mode: 0o600 }),
+    writeFile(
+      credential,
+      '{"schemaVersion":1,"backend":"os-vault","recordId":"fixture"}\n',
+      { mode: 0o600 },
+    ),
+    writeFile(status, "", { mode: 0o600 }),
+    writeFile(sidecar, sidecarSource(), { mode: 0o700 }),
+  ]);
+  await chmod(sidecar, 0o700);
+  const digest = createHash("sha256")
+    .update(await readFile(sidecar))
+    .digest("hex");
+  await writeFile(
+    config,
+    `${JSON.stringify({
+      schemaVersion: 1,
+      role: "primary",
+      dataRoot,
+      stateRoot,
+      admissionFile: admission,
+      credentialDescriptorFile: credential,
+      sidecar: {
+        executable: sidecar,
+        sha256: digest,
+        startupTimeoutMs: 1_000,
+        shutdownTimeoutMs: 250,
+      },
+    })}\n`,
+    { mode: 0o600 },
+  );
+  return {
+    args: [sidecar, dataRoot, stateRoot, admission, credential, digest],
+    supervisorArgs: [
+      config,
+      sidecar,
+      dataRoot,
+      stateRoot,
+      admission,
+      credential,
+    ],
+  };
+}
+
+function launchHarness(args: readonly string[]): {
+  child: ChildProcess;
+  ready: Promise<{ sidecarPid: number }>;
+} {
+  const harnessPath = path.resolve("src/testing/fixtures/runtime-harness.mjs");
+  const child = spawn(process.execPath, [harnessPath, ...args], {
+    cwd: process.cwd(),
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  child.stdout!.setEncoding("utf8");
+  child.stderr!.setEncoding("utf8");
+  const ready = new Promise<{ sidecarPid: number }>((resolve, reject) => {
+    let stdout = "";
+    let stderr = "";
+    child.stderr!.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+    child.stdout!.on("data", (chunk: string) => {
+      stdout += chunk;
+      const newline = stdout.indexOf("\n");
+      if (newline === -1) return;
+      const report = JSON.parse(stdout.slice(0, newline)) as {
+        type: string;
+        sidecarPid: number;
+      };
+      if (report.type !== "harness-ready") {
+        reject(new Error("unexpected harness report"));
+        return;
+      }
+      resolve({ sidecarPid: report.sidecarPid });
+    });
+    child.once("error", reject);
+    child.once("exit", (code, signal) => {
+      if (stdout.includes("\n")) return;
+      reject(
+        new Error(`harness exited ${String(code)} ${String(signal)} ${stderr}`),
+      );
+    });
+  });
+  return { child, ready };
+}
+
+async function runHarnessOnce(args: readonly string[]): Promise<{
+  code: number | null;
+  stdout: string;
+  stderr: string;
+}> {
+  const harnessPath = path.resolve("src/testing/fixtures/runtime-harness.mjs");
+  const child = spawn(process.execPath, [harnessPath, ...args], {
+    cwd: process.cwd(),
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let stdout = "";
+  let stderr = "";
+  child.stdout!.setEncoding("utf8");
+  child.stderr!.setEncoding("utf8");
+  child.stdout!.on("data", (chunk: string) => {
+    stdout += chunk;
+  });
+  child.stderr!.on("data", (chunk: string) => {
+    stderr += chunk;
+  });
+  const code = await new Promise<number | null>((resolve, reject) => {
+    child.once("error", reject);
+    child.once("exit", resolve);
+  });
+  return { code, stdout, stderr };
+}
+
+function launchSupervisorHarness(args: readonly string[]): {
+  child: ChildProcess;
+  ready: Promise<{ sidecarPid: number }>;
+} {
+  const harnessPath = path.resolve(
+    "src/testing/fixtures/supervisor-runtime-harness.mjs",
+  );
+  const child = spawn(process.execPath, [harnessPath, ...args], {
+    cwd: process.cwd(),
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  child.stdout!.setEncoding("utf8");
+  child.stderr!.setEncoding("utf8");
+  const ready = new Promise<{ sidecarPid: number }>((resolve, reject) => {
+    let stdout = "";
+    let stderr = "";
+    child.stderr!.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+    child.stdout!.on("data", (chunk: string) => {
+      stdout += chunk;
+      const newline = stdout.indexOf("\n");
+      if (newline === -1) return;
+      const report = JSON.parse(stdout.slice(0, newline)) as {
+        type: string;
+        sidecarPid: number;
+      };
+      if (report.type !== "supervisor-ready") {
+        reject(new Error("unexpected supervisor harness report"));
+        return;
+      }
+      resolve({ sidecarPid: report.sidecarPid });
+    });
+    child.once("error", reject);
+    child.once("exit", (code, signal) => {
+      if (stdout.includes("\n")) return;
+      reject(
+        new Error(
+          `supervisor harness exited ${String(code)} ${String(signal)} ${stderr}`,
+        ),
+      );
+    });
+  });
+  return { child, ready };
+}
+
+async function processTable(): Promise<
+  Array<{ pid: number; ppid: number; pgid: number; state: string }>
+> {
+  const result = await execFileAsync("/bin/ps", [
+    "-axo",
+    "pid=,ppid=,pgid=,state=",
+  ]);
+  return result.stdout
+    .trim()
+    .split("\n")
+    .map((line) => line.trim().split(/\s+/))
+    .filter((fields) => fields.length >= 4)
+    .map(([pid, ppid, pgid, state]) => ({
+      pid: Number(pid),
+      ppid: Number(ppid),
+      pgid: Number(pgid),
+      state,
+    }));
+}
+
+async function waitForGone(pids: readonly number[]): Promise<void> {
+  for (let attempt = 0; attempt < 250; attempt += 1) {
+    const live = new Set((await processTable()).map(({ pid }) => pid));
+    if (pids.every((pid) => !live.has(pid))) return;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error(`processes still live: ${pids.join(",")}`);
+}
+
+async function waitForHarnessExit(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(
+      () => reject(new Error("harness exit timeout")),
+      5_000,
+    );
+    child.once("exit", () => {
+      clearTimeout(timeout);
+      resolve();
+    });
+  });
+}
+
+afterEach(async () => {
+  while (fixtures.length > 0) {
+    await rm(fixtures.pop()!, { recursive: true, force: true });
+  }
+});
+
+describe("compiled freed-library runtime", () => {
+  darwinIt(
+    "keeps doctor and status read-only with a root-owned pinned executable",
+    async () => {
+      const { configPath, statusPath } = await createServiceFixture();
+
+      const doctor = await runCli(["doctor", "--config", configPath]);
+      expect(doctor).toMatchObject({ code: 0, stderr: "" });
+      expect(JSON.parse(doctor.stdout)).toMatchObject({
+        ok: true,
+        code: "ready",
+      });
+      expect(await readFile(statusPath, "utf8")).toBe("");
+
+      const status = await runCli(["status", "--config", configPath]);
+      expect(status).toMatchObject({ code: 0, stderr: "" });
+      expect(JSON.parse(status.stdout)).toMatchObject({ status: null });
+      expect(await readFile(statusPath, "utf8")).toBe("");
+
+      const serve = await runCli(["serve", "--config", configPath]);
+      expect(serve).toMatchObject({ code: 2, stdout: "" });
+      expect(JSON.parse(serve.stderr)).toMatchObject({
+        ok: false,
+        code: "ready_response_lost",
+      });
+      expect(JSON.parse(await readFile(statusPath, "utf8"))).toMatchObject({
+        phase: "failed",
+        reasonCode: "ready_response_lost",
+      });
+    },
+    15_000,
+  );
+
+  linuxIt(
+    "fails doctor closed when the production ACL proof is unavailable",
+    async () => {
+      const { configPath, statusPath } = await createServiceFixture();
+
+      const doctor = await runCli(["doctor", "--config", configPath]);
+
+      expect(doctor).toMatchObject({ code: 2, stdout: "" });
+      expect(JSON.parse(doctor.stderr)).toMatchObject({
+        ok: false,
+        code: "acl_probe_unavailable",
+      });
+      expect(await readFile(statusPath, "utf8")).toBe("");
+    },
+    15_000,
+  );
+
+  darwinIt(
+    "keeps runtime status writes on the bound file after state-root replacement",
+    async () => {
+      const { configPath, stateRoot, statusPath } =
+        await createServiceFixture();
+      const ports = createNodeLibraryServicePorts();
+      const bound = await bindLibraryServiceConfig(
+        configPath,
+        ports.fileSystem,
+        ports.identity,
+        ports.aclProof,
+      );
+      let statusFile = null;
+      try {
+        statusFile = await bindLibraryServiceStatusFile(
+          bound.config,
+          bound.bindings.stateRoot,
+          ports.fileSystem,
+          ports.identity,
+          ports.aclProof,
+        );
+        expect(statusFile).not.toBeNull();
+
+        const relocatedStateRoot = `${stateRoot}-relocated`;
+        await rename(stateRoot, relocatedStateRoot);
+        await mkdir(stateRoot, { mode: 0o700 });
+        await writeFile(statusPath, "replacement-path\n", { mode: 0o600 });
+
+        const status = createLibraryServiceStatusRecord({
+          phase: "running",
+          nowMs: Date.parse("2026-08-19T00:00:00.000Z"),
+          startedAt: "2026-08-19T00:00:00.000Z",
+          sidecarPid: 4_242,
+          reasonCode: null,
+        });
+        await writeLibraryServiceStatus(statusFile!, ports.fileSystem, status);
+
+        expect(await readFile(statusPath, "utf8")).toBe("replacement-path\n");
+        expect(
+          JSON.parse(
+            await readFile(
+              path.join(relocatedStateRoot, "library-service-status.json"),
+              "utf8",
+            ),
+          ),
+        ).toEqual(status);
+      } finally {
+        await statusFile?.close().catch(() => undefined);
+        await bound.close();
+      }
+    },
+    15_000,
+  );
+
+  posixIt.each(["term", "kill"] as const)(
+    "contains the whole real process group for %s settlement",
+    async (mode) => {
+      const { args } = await createHarnessFixture();
+      const { child, ready } = launchHarness(args);
+      const { sidecarPid } = await ready;
+      const table = await processTable();
+      const descendant = table.find(({ ppid }) => ppid === sidecarPid);
+      expect(descendant).toBeDefined();
+      expect(descendant!.pgid).toBe(sidecarPid);
+
+      child.stdin!.write(`${mode}\n`);
+      await waitForHarnessExit(child);
+      await waitForGone([sidecarPid, descendant!.pid]);
+    },
+    15_000,
+  );
+
+  posixIt(
+    "closes the watchdog and contains descendants when the supervisor is killed",
+    async () => {
+      const { supervisorArgs } = await createHarnessFixture();
+      const { child, ready } = launchSupervisorHarness(supervisorArgs);
+      const { sidecarPid } = await ready;
+      const table = await processTable();
+      const descendant = table.find(({ ppid }) => ppid === sidecarPid);
+      expect(descendant).toBeDefined();
+      expect(descendant!.pgid).toBe(sidecarPid);
+
+      child.kill("SIGKILL");
+      await waitForHarnessExit(child);
+      expect(child.signalCode).toBe("SIGKILL");
+      await waitForGone([sidecarPid, descendant!.pid]);
+    },
+    15_000,
+  );
+
+  posixIt(
+    "proves group settlement before rejecting an invalid lifetime channel",
+    async () => {
+      const { args } = await createHarnessFixture();
+
+      const result = await runHarnessOnce([...args, "invalid-lifetime"]);
+
+      expect(result).toMatchObject({ code: 0, stderr: "" });
+      const report = JSON.parse(result.stdout) as {
+        type: string;
+        code: string;
+        sidecarPid: number | null;
+        descendantPid: number | null;
+      };
+      expect(report).toMatchObject({
+        type: "invalid-lifetime-settled",
+        code: "unsupported_bound_descriptor_execution",
+        sidecarPid: expect.any(Number),
+        descendantPid: expect.any(Number),
+      });
+      await waitForGone([report.sidecarPid!, report.descendantPid!]);
+    },
+    15_000,
+  );
+
+  posixIt(
+    "kills a surviving descendant after the sidecar leader exits on TERM",
+    async () => {
+      const { supervisorArgs } = await createHarnessFixture({
+        leaderOnlyTerm: true,
+      });
+      const { child, ready } = launchSupervisorHarness(supervisorArgs);
+      const { sidecarPid } = await ready;
+      const table = await processTable();
+      const descendant = table.find(({ ppid }) => ppid === sidecarPid);
+      expect(descendant).toBeDefined();
+      expect(descendant!.pgid).toBe(sidecarPid);
+
+      child.stdin!.end("leader-term\n");
+      await waitForHarnessExit(child);
+      expect(child.exitCode).toBe(0);
+      await waitForGone([sidecarPid, descendant!.pid]);
+    },
+    15_000,
+  );
+});

--- a/packages/library-service/src/status.test.ts
+++ b/packages/library-service/src/status.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  bindLibraryServiceStatusFile,
+  createLibraryServiceStatusRecord,
+  readLibraryServiceStatus,
+  writeLibraryServiceStatus,
+} from "./status.js";
+import {
+  FakeAclProof,
+  FakeIdentity,
+  validConfig,
+  validConfigFileSystem,
+} from "./testing/fakes.js";
+
+describe("Library service local status", () => {
+  it("is read-only when no status record exists", async () => {
+    const fileSystem = validConfigFileSystem();
+    const stateRoot = await fileSystem.openBoundPath("/safe/state");
+    const statusFile = await bindLibraryServiceStatusFile(
+      validConfig(),
+      stateRoot,
+      fileSystem,
+      new FakeIdentity(),
+      new FakeAclProof(),
+    );
+
+    await expect(
+      readLibraryServiceStatus(statusFile, fileSystem),
+    ).resolves.toMatchObject({ status: null });
+    expect(fileSystem.writes).toEqual([]);
+  });
+
+  it("round trips a private bounded status record", async () => {
+    const fileSystem = validConfigFileSystem();
+    const config = validConfig();
+    const stateRoot = await fileSystem.openBoundPath("/safe/state");
+    const statusFile = await bindLibraryServiceStatusFile(
+      config,
+      stateRoot,
+      fileSystem,
+      new FakeIdentity(),
+      new FakeAclProof(),
+    );
+    expect(statusFile).not.toBeNull();
+    const status = createLibraryServiceStatusRecord({
+      phase: "running",
+      nowMs: Date.parse("2026-08-19T00:00:00.000Z"),
+      startedAt: "2026-08-19T00:00:00.000Z",
+      sidecarPid: 4_242,
+      reasonCode: null,
+    });
+
+    await writeLibraryServiceStatus(statusFile!, fileSystem, status);
+
+    await expect(
+      readLibraryServiceStatus(statusFile, fileSystem),
+    ).resolves.toEqual({
+      schemaVersion: 1,
+      service: "freed-library",
+      configuredRole: "primary",
+      status,
+    });
+  });
+
+  it("rejects arbitrary reason text that could disclose sidecar output", async () => {
+    const fileSystem = validConfigFileSystem();
+    fileSystem.addFile(
+      "/safe/state/library-service-status.json",
+      `${JSON.stringify({
+        schemaVersion: 1,
+        service: "freed-library",
+        role: "primary",
+        phase: "failed",
+        updatedAt: "2026-08-19T00:00:00.000Z",
+        startedAt: null,
+        sidecarPid: null,
+        reasonCode: "token=must-not-escape",
+      })}\n`,
+    );
+    const stateRoot = await fileSystem.openBoundPath("/safe/state");
+    const statusFile = await bindLibraryServiceStatusFile(
+      validConfig(),
+      stateRoot,
+      fileSystem,
+      new FakeIdentity(),
+      new FakeAclProof(),
+    );
+
+    await expect(
+      readLibraryServiceStatus(statusFile, fileSystem),
+    ).rejects.toMatchObject({ code: "status_invalid" });
+  });
+
+  it("fails explicitly when the platform ACL backend cannot prove privacy", async () => {
+    const fileSystem = validConfigFileSystem();
+    const stateRoot = await fileSystem.openBoundPath("/safe/state");
+    await expect(
+      bindLibraryServiceStatusFile(
+        validConfig(),
+        stateRoot,
+        fileSystem,
+        new FakeIdentity(null),
+        new FakeAclProof(),
+      ),
+    ).rejects.toMatchObject({
+      code: "unsupported_secret_store_or_acl_backend",
+    });
+  });
+});

--- a/packages/library-service/src/status.ts
+++ b/packages/library-service/src/status.ts
@@ -1,0 +1,193 @@
+import path from "node:path";
+
+import {
+  LIBRARY_SERVICE_MAX_STATUS_BYTES,
+  LIBRARY_SERVICE_FAILURE_CODES,
+  LIBRARY_SERVICE_STATUS_SCHEMA_VERSION,
+  LibraryServiceFailure,
+  type LibraryServiceAclProofPort,
+  type LibraryServiceBoundPath,
+  type LibraryServiceConfig,
+  type LibraryServiceFailureCode,
+  type LibraryServiceFileSystemPort,
+  type LibraryServiceIdentityPort,
+  type LibraryServiceStatusRecord,
+  type LibraryServiceStatusReport,
+} from "./contracts.js";
+
+const STATUS_KEYS = new Set([
+  "schemaVersion",
+  "service",
+  "role",
+  "phase",
+  "updatedAt",
+  "startedAt",
+  "sidecarPid",
+  "reasonCode",
+]);
+const PHASES = new Set(["starting", "running", "stopping", "stopped", "failed"]);
+const REASON_CODES = new Set([
+  ...LIBRARY_SERVICE_FAILURE_CODES,
+  "requested_stop",
+]);
+
+function libraryServiceStatusPath(config: LibraryServiceConfig): string {
+  return path.join(config.stateRoot, "library-service-status.json");
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isIsoDate(value: unknown): value is string {
+  if (typeof value !== "string" || value.length > 64) return false;
+  try {
+    return new Date(value).toISOString() === value;
+  } catch {
+    return false;
+  }
+}
+
+function parseStatus(text: string): LibraryServiceStatusRecord {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(text);
+  } catch {
+    throw new LibraryServiceFailure("status_invalid");
+  }
+  if (!isObject(raw)) {
+    throw new LibraryServiceFailure("status_invalid");
+  }
+  const keys = Object.keys(raw);
+  if (keys.length !== STATUS_KEYS.size || !keys.every((key) => STATUS_KEYS.has(key))) {
+    throw new LibraryServiceFailure("status_invalid");
+  }
+  if (
+    raw.schemaVersion !== LIBRARY_SERVICE_STATUS_SCHEMA_VERSION ||
+    raw.service !== "freed-library" ||
+    raw.role !== "primary" ||
+    typeof raw.phase !== "string" ||
+    !PHASES.has(raw.phase) ||
+    !isIsoDate(raw.updatedAt) ||
+    (raw.startedAt !== null && !isIsoDate(raw.startedAt)) ||
+    (raw.sidecarPid !== null &&
+      (typeof raw.sidecarPid !== "number" ||
+        !Number.isSafeInteger(raw.sidecarPid) ||
+        raw.sidecarPid <= 0)) ||
+    (raw.reasonCode !== null &&
+      (typeof raw.reasonCode !== "string" || !REASON_CODES.has(raw.reasonCode)))
+  ) {
+    throw new LibraryServiceFailure("status_invalid");
+  }
+  return raw as unknown as LibraryServiceStatusRecord;
+}
+
+export async function writeLibraryServiceStatus(
+  statusFile: LibraryServiceBoundPath,
+  fileSystem: LibraryServiceFileSystemPort,
+  status: LibraryServiceStatusRecord,
+): Promise<void> {
+  try {
+    await fileSystem.writePrivateStatusText(
+      statusFile,
+      `${JSON.stringify(status)}\n`,
+    );
+  } catch {
+    throw new LibraryServiceFailure("write_failed");
+  }
+}
+
+export async function bindLibraryServiceStatusFile(
+  config: LibraryServiceConfig,
+  stateRoot: LibraryServiceBoundPath,
+  fileSystem: LibraryServiceFileSystemPort,
+  identity: LibraryServiceIdentityPort,
+  aclProof: LibraryServiceAclProofPort,
+): Promise<LibraryServiceBoundPath | null> {
+  const userId = identity.currentUserId();
+  if (userId === null) {
+    throw new LibraryServiceFailure("unsupported_secret_store_or_acl_backend");
+  }
+  let statusFile: LibraryServiceBoundPath | null = null;
+  try {
+    statusFile = await fileSystem.openPrivateStatusFile(
+      stateRoot,
+      config.stateRoot,
+      userId,
+    );
+    if (statusFile === null) return null;
+    await aclProof.assertNoExtendedAcl([
+      {
+        path: libraryServiceStatusPath(config),
+        device: statusFile.metadata.device,
+        inode: statusFile.metadata.inode,
+      },
+    ]);
+    await statusFile.assertStable();
+    await statusFile.assertPathStable();
+    await stateRoot.assertStable();
+    await stateRoot.assertPathStable();
+    return statusFile;
+  } catch (error) {
+    await statusFile?.close().catch(() => undefined);
+    if (error instanceof LibraryServiceFailure) throw error;
+    throw new LibraryServiceFailure("status_invalid");
+  }
+}
+
+export async function readLibraryServiceStatus(
+  statusFile: LibraryServiceBoundPath | null,
+  fileSystem: LibraryServiceFileSystemPort,
+): Promise<LibraryServiceStatusReport> {
+  if (statusFile === null) {
+    return {
+      schemaVersion: 1,
+      service: "freed-library",
+      configuredRole: "primary",
+      status: null,
+    };
+  }
+  let text: string;
+  try {
+    text = await fileSystem.readPrivateStatusText(
+      statusFile,
+      LIBRARY_SERVICE_MAX_STATUS_BYTES,
+    );
+  } catch (error) {
+    if (error instanceof LibraryServiceFailure) throw error;
+    throw new LibraryServiceFailure("status_invalid");
+  }
+  if (text === "") {
+    return {
+      schemaVersion: 1,
+      service: "freed-library",
+      configuredRole: "primary",
+      status: null,
+    };
+  }
+  return {
+    schemaVersion: 1,
+    service: "freed-library",
+    configuredRole: "primary",
+    status: parseStatus(text),
+  };
+}
+
+export function createLibraryServiceStatusRecord(input: {
+  phase: LibraryServiceStatusRecord["phase"];
+  nowMs: number;
+  startedAt: string | null;
+  sidecarPid: number | null;
+  reasonCode: LibraryServiceFailureCode | "requested_stop" | null;
+}): LibraryServiceStatusRecord {
+  return {
+    schemaVersion: LIBRARY_SERVICE_STATUS_SCHEMA_VERSION,
+    service: "freed-library",
+    role: "primary",
+    phase: input.phase,
+    updatedAt: new Date(input.nowMs).toISOString(),
+    startedAt: input.startedAt,
+    sidecarPid: input.sidecarPid,
+    reasonCode: input.reasonCode,
+  };
+}

--- a/packages/library-service/src/supervisor.test.ts
+++ b/packages/library-service/src/supervisor.test.ts
@@ -1,0 +1,602 @@
+import { describe, expect, it } from "vitest";
+
+import { LibraryServiceFailure } from "./contracts.js";
+import { LibraryServiceSupervisor } from "./supervisor.js";
+import {
+  Deferred,
+  FakeAclProof,
+  FakeClock,
+  FakeEntropy,
+  FakeFileSystem,
+  FakeProcessPort,
+  FakeSidecarProcess,
+  readyBytes,
+  validConfigFileSystem,
+} from "./testing/fakes.js";
+
+function createSupervisor(
+  input: {
+    child?: FakeSidecarProcess;
+    clock?: FakeClock;
+    fileSystem?: FakeFileSystem;
+    aclProof?: FakeAclProof;
+  } = {},
+) {
+  const child = input.child ?? new FakeSidecarProcess();
+  const process = new FakeProcessPort(child);
+  const fileSystem = input.fileSystem ?? validConfigFileSystem();
+  const clock = input.clock ?? new FakeClock();
+  const aclProof = input.aclProof ?? new FakeAclProof();
+  const supervisor = new LibraryServiceSupervisor({
+    configPath: "/safe/config.json",
+    fileSystem,
+    identity: { currentUserId: () => 501 },
+    aclProof,
+    process,
+    clock,
+    entropy: new FakeEntropy(),
+  });
+  return { child, process, fileSystem, aclProof, clock, supervisor };
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (predicate()) return;
+    await new Promise<void>((resolve) => setImmediate(resolve));
+  }
+  throw new Error("condition did not settle");
+}
+
+async function expectStartFailure(
+  supervisor: LibraryServiceSupervisor,
+  code: string,
+): Promise<void> {
+  await supervisor.start().then(
+    () => expect.fail("expected startup failure"),
+    (error) => {
+      expect(error).toBeInstanceOf(LibraryServiceFailure);
+      expect((error as LibraryServiceFailure).code).toBe(code);
+    },
+  );
+}
+
+const EQUAL_LENGTH_INPUT_REWRITES: ReadonlyArray<
+  readonly [string, string, (text: string) => string]
+> = [
+  [
+    "config",
+    "/safe/config.json",
+    (text: string): string =>
+      text.replace('"role":"primary"', '"role":"primarx"'),
+  ],
+  ["executable", "/trusted/sidecar", (_text: string): string => "changed"],
+  [
+    "admission",
+    "/safe/state/admission.json",
+    (text: string): string => text.replace("opaque", "tamper"),
+  ],
+  [
+    "credential descriptor",
+    "/safe/state/credentials.json",
+    (text: string): string => text.replace("primary", "primarx"),
+  ],
+];
+
+describe("LibraryServiceSupervisor", () => {
+  it("starts exactly one pinned sidecar through an empty argv and environment", async () => {
+    const { child, process, fileSystem, supervisor } = createSupervisor();
+
+    const result = await supervisor.start();
+
+    expect(result).toMatchObject({
+      role: "primary",
+      phase: "running",
+      sidecarPid: 4_242,
+    });
+    expect(process.requests).toHaveLength(1);
+    expect(process.requests[0]).toMatchObject({ args: [], env: {} });
+    expect(process.requests[0].bindings.executable.path).toBe(
+      "/trusted/sidecar",
+    );
+    expect(process.requests[0].bindings.dataRoot.path).toBe("/safe/data");
+    expect(process.requests[0].bindings.stateRoot.path).toBe("/safe/state");
+    expect(child.controlClosed).toBe(true);
+    expect(JSON.parse(child.controlWrites[0])).toEqual({
+      type: "start",
+      protocolVersion: 1,
+      role: "primary",
+      parentNonce: "1".repeat(64),
+      configDigest: expect.stringMatching(/^[a-f0-9]{64}$/),
+      executableDigest: fileSystem.digests.get("/trusted/sidecar"),
+      executableFd: 3,
+      dataRootFd: 4,
+      stateRootFd: 5,
+      admissionFd: 6,
+      credentialDescriptorFd: 7,
+      lifetimeFd: 8,
+    });
+    expect(child.controlWrites[0]).not.toContain("/safe");
+    const statuses = fileSystem.writes.map(({ contents }) =>
+      JSON.parse(contents),
+    );
+    expect(statuses.map(({ phase }) => phase)).toEqual(["starting", "running"]);
+  });
+
+  it("refuses a second start without spawning another sidecar", async () => {
+    const { process, supervisor } = createSupervisor();
+    await supervisor.start();
+
+    await expect(supervisor.start()).rejects.toMatchObject({
+      code: "already_started",
+    });
+    expect(process.requests).toHaveLength(1);
+  });
+
+  it("revalidates private admission at start and never spawns on refusal", async () => {
+    const child = new FakeSidecarProcess();
+    const { fileSystem, process, supervisor } = createSupervisor({ child });
+    fileSystem.metadata.delete("/safe/state/admission.json");
+    fileSystem.texts.delete("/safe/state/admission.json");
+
+    await expectStartFailure(supervisor, "admission_missing");
+
+    expect(process.requests).toEqual([]);
+    expect(fileSystem.writes).toEqual([]);
+    expect(child.controlWrites).toEqual([]);
+  });
+
+  it.each(EQUAL_LENGTH_INPUT_REWRITES)(
+    "rejects an equal-length in-place %s rewrite while binding",
+    async (_label, filePath, rewrite) => {
+      const fileSystem = validConfigFileSystem();
+      const aclProof = new FakeAclProof();
+      const original = fileSystem.texts.get(filePath)!;
+      const replacement = rewrite(original);
+      expect(Buffer.byteLength(replacement)).toBe(Buffer.byteLength(original));
+      let bindingAclProved = false;
+      let rewritten = false;
+      aclProof.afterProbe = () => {
+        bindingAclProved = true;
+      };
+      fileSystem.inspectHook = () => {
+        if (!bindingAclProved || rewritten) return;
+        rewritten = true;
+        fileSystem.rewriteFileInPlace(filePath, replacement);
+      };
+      const { process, supervisor } = createSupervisor({
+        fileSystem,
+        aclProof,
+      });
+
+      await expectStartFailure(supervisor, "bound_input_changed");
+
+      expect(rewritten).toBe(true);
+      expect(process.requests).toEqual([]);
+      expect(fileSystem.writes).toEqual([]);
+    },
+  );
+
+  it.each(EQUAL_LENGTH_INPUT_REWRITES)(
+    "rejects an equal-length in-place %s rewrite immediately before spawn",
+    async (_label, filePath, rewrite) => {
+      const fileSystem = validConfigFileSystem();
+      const original = fileSystem.texts.get(filePath)!;
+      const replacement = rewrite(original);
+      expect(Buffer.byteLength(replacement)).toBe(Buffer.byteLength(original));
+      let rewritten = false;
+      fileSystem.writeHook = () => {
+        if (rewritten) return;
+        rewritten = true;
+        fileSystem.rewriteFileInPlace(filePath, replacement);
+      };
+      const { process, supervisor } = createSupervisor({ fileSystem });
+
+      await expectStartFailure(supervisor, "bound_input_changed");
+
+      expect(rewritten).toBe(true);
+      expect(process.requests).toEqual([]);
+    },
+  );
+
+  it("fails startup on a bounded timeout and settles the child", async () => {
+    const output = new Deferred<Uint8Array>();
+    const child = new FakeSidecarProcess({ output: output.promise });
+    const clock = new FakeClock();
+    clock.immediateDurations.add(5_000);
+    const { supervisor } = createSupervisor({
+      child,
+      clock,
+    });
+
+    await expectStartFailure(supervisor, "startup_timeout");
+
+    expect(child.signals).toEqual(["SIGTERM"]);
+  });
+
+  it("applies the startup timeout to a blocked control-channel write", async () => {
+    const child = new FakeSidecarProcess();
+    child.controlWriteBarrier = new Promise(() => undefined);
+    const clock = new FakeClock();
+    clock.immediateDurations.add(5_000);
+    const { supervisor } = createSupervisor({
+      child,
+      clock,
+    });
+
+    await expectStartFailure(supervisor, "startup_timeout");
+
+    expect(child.signals).toEqual(["SIGTERM"]);
+  });
+
+  it.each([
+    ["malformed", Buffer.from("not-json\n"), "ready_malformed"],
+    ["oversized", Buffer.alloc(4 * 1_024 + 1, 0x61), "ready_oversized"],
+    ["multiple", Buffer.concat([readyBytes(), readyBytes()]), "ready_multiple"],
+    ["response loss", Buffer.alloc(0), "ready_response_lost"],
+    ["partial response", Buffer.from("{}"), "ready_response_lost"],
+    [
+      "role mismatch",
+      readyBytes(4_242, { role: "follower" }),
+      "ready_role_mismatch",
+    ],
+  ])("fails startup for %s control output", async (_label, output, code) => {
+    const child = new FakeSidecarProcess({ output });
+    const { supervisor } = createSupervisor({ child });
+
+    await expectStartFailure(supervisor, code);
+
+    expect(child.signals).toEqual(["SIGTERM"]);
+  });
+
+  it("fails startup when the child exits before its ready receipt", async () => {
+    const output = new Deferred<Uint8Array>();
+    const child = new FakeSidecarProcess({ output: output.promise });
+    child.resolveExit({ code: 17, signal: null });
+    child.groupRunning = false;
+    const { supervisor } = createSupervisor({ child });
+
+    await expectStartFailure(supervisor, "sidecar_exited");
+
+    expect(child.signals).toEqual([]);
+  });
+
+  it("settles a requested stop with SIGTERM", async () => {
+    const { child, fileSystem, supervisor } = createSupervisor();
+    await supervisor.start();
+
+    await supervisor.stop();
+
+    expect(child.signals).toEqual(["SIGTERM"]);
+    const statuses = fileSystem.writes.map(({ contents }) =>
+      JSON.parse(contents),
+    );
+    expect(statuses.at(-1)).toMatchObject({
+      phase: "stopped",
+      reasonCode: "requested_stop",
+    });
+  });
+
+  it("escalates a non-settling child to SIGKILL", async () => {
+    const child = new FakeSidecarProcess();
+    child.exitOnTerm = false;
+    child.groupExitOnTerm = false;
+    const clock = new FakeClock();
+    const { supervisor } = createSupervisor({ child, clock });
+    await supervisor.start();
+    clock.sleepImmediately = true;
+
+    await supervisor.stop();
+
+    expect(child.signals).toEqual(["SIGTERM", "SIGKILL"]);
+  });
+
+  it("kills a surviving process group after its leader exits on TERM", async () => {
+    const child = new FakeSidecarProcess();
+    child.groupExitOnTerm = false;
+    const clock = new FakeClock();
+    const { supervisor } = createSupervisor({ child, clock });
+    await supervisor.start();
+    clock.sleepImmediately = true;
+
+    await supervisor.stop();
+
+    expect(child.running).toBe(false);
+    expect(child.signals).toEqual(["SIGTERM", "SIGKILL"]);
+    expect(child.groupRunning).toBe(false);
+  });
+
+  it("reports a settlement timeout when neither signal settles the child", async () => {
+    const child = new FakeSidecarProcess();
+    child.exitOnTerm = false;
+    child.exitOnKill = false;
+    child.groupExitOnTerm = false;
+    child.groupExitOnKill = false;
+    const clock = new FakeClock();
+    const { fileSystem, supervisor } = createSupervisor({
+      child,
+      clock,
+    });
+    await supervisor.start();
+    clock.sleepImmediately = true;
+
+    await expect(supervisor.stop()).rejects.toMatchObject({
+      code: "sidecar_settlement_timeout",
+    });
+    expect(child.signals).toEqual(["SIGTERM", "SIGKILL"]);
+    const statuses = fileSystem.writes.map(({ contents }) =>
+      JSON.parse(contents),
+    );
+    expect(statuses.at(-1)).toMatchObject({
+      phase: "failed",
+      reasonCode: "sidecar_settlement_timeout",
+    });
+  });
+
+  it("cancels before validation without opening, writing, or spawning", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const { fileSystem, process, supervisor } = createSupervisor();
+
+    await expect(supervisor.start(controller.signal)).rejects.toMatchObject({
+      code: "startup_cancelled",
+    });
+    expect(fileSystem.opened).toEqual([]);
+    expect(fileSystem.writes).toEqual([]);
+    expect(process.requests).toEqual([]);
+  });
+
+  it("cancels a blocked descriptor open and never later spawns", async () => {
+    const fileSystem = validConfigFileSystem();
+    const gate = new Deferred<void>();
+    fileSystem.openBarrier = gate.promise;
+    const { process, supervisor } = createSupervisor({
+      fileSystem,
+      clock: new FakeClock(undefined, true),
+    });
+    const controller = new AbortController();
+    const start = supervisor.start(controller.signal);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    controller.abort();
+    await expect(start).rejects.toMatchObject({ code: "startup_cancelled" });
+    expect(fileSystem.writes).toEqual([]);
+    expect(process.requests).toEqual([]);
+    gate.resolve();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(process.requests).toEqual([]);
+  });
+
+  it("cancels a blocked ACL proof and closes late descriptor bindings", async () => {
+    const aclProof = new FakeAclProof();
+    const gate = new Deferred<void>();
+    aclProof.barrier = gate.promise;
+    const { fileSystem, process, supervisor } = createSupervisor({ aclProof });
+    const controller = new AbortController();
+    const start = supervisor.start(controller.signal);
+    await waitFor(() => aclProof.calls.length === 1);
+
+    controller.abort();
+    await expect(start).rejects.toMatchObject({ code: "startup_cancelled" });
+    expect(fileSystem.writes).toEqual([]);
+    expect(process.requests).toEqual([]);
+    gate.resolve();
+    await waitFor(() => fileSystem.opened.every(({ closed }) => closed));
+  });
+
+  it("closes a status descriptor that resolves after cancellation", async () => {
+    const aclProof = new FakeAclProof();
+    const gate = new Deferred<void>();
+    aclProof.barrier = gate.promise;
+    aclProof.barrierOnCall = 2;
+    const { fileSystem, process, supervisor } = createSupervisor({ aclProof });
+    const controller = new AbortController();
+    const start = supervisor.start(controller.signal);
+    await waitFor(() => aclProof.calls.length === 2);
+
+    controller.abort();
+    await expect(start).rejects.toMatchObject({ code: "startup_cancelled" });
+    expect(process.requests).toEqual([]);
+    gate.resolve();
+    await waitFor(() =>
+      fileSystem.opened
+        .filter(({ path }) => path.endsWith("library-service-status.json"))
+        .every(({ closed }) => closed),
+    );
+  });
+
+  it("cancels a blocked starting status write before spawn", async () => {
+    const fileSystem = validConfigFileSystem();
+    const gate = new Deferred<void>();
+    fileSystem.writeBarrier = gate.promise;
+    const clock = new FakeClock();
+    const { process, supervisor } = createSupervisor({
+      fileSystem,
+      clock,
+    });
+    const controller = new AbortController();
+    const start = supervisor.start(controller.signal);
+    await waitFor(() => fileSystem.writes.length === 1);
+
+    clock.sleepImmediately = true;
+    controller.abort();
+    await expect(start).rejects.toMatchObject({ code: "startup_cancelled" });
+    expect(process.requests).toEqual([]);
+    gate.resolve();
+  });
+
+  it("cancels a blocked spawn and kills any late child", async () => {
+    const child = new FakeSidecarProcess();
+    const { process, supervisor } = createSupervisor({ child });
+    const gate = new Deferred<void>();
+    process.spawnBarrier = gate.promise;
+    process.ignoreAbort = true;
+    const controller = new AbortController();
+    const start = supervisor.start(controller.signal);
+    await waitFor(() => process.requests.length === 1);
+
+    controller.abort();
+    gate.resolve();
+    await expect(start).rejects.toMatchObject({ code: "startup_cancelled" });
+    expect(child.signals).toEqual(["SIGKILL"]);
+    expect(child.groupRunning).toBe(false);
+    expect(child.lifetimeClosed).toBe(true);
+  });
+
+  it("kills a child that appears after cancelled spawn settlement times out", async () => {
+    const child = new FakeSidecarProcess();
+    const fileSystem = validConfigFileSystem();
+    const config = JSON.parse(fileSystem.texts.get("/safe/config.json")!);
+    config.sidecar.shutdownTimeoutMs = 900;
+    fileSystem.addFile("/safe/config.json", JSON.stringify(config));
+    const clock = new FakeClock();
+    clock.immediateDurations.add(900);
+    const { process, supervisor } = createSupervisor({
+      child,
+      fileSystem,
+      clock,
+    });
+    const gate = new Deferred<void>();
+    process.spawnBarrier = gate.promise;
+    process.ignoreAbort = true;
+    const controller = new AbortController();
+    const start = supervisor.start(controller.signal);
+    await waitFor(() => process.requests.length === 1);
+
+    controller.abort();
+    await expect(start).rejects.toMatchObject({
+      code: "sidecar_settlement_timeout",
+    });
+    gate.resolve();
+    await waitFor(() => child.signals.includes("SIGKILL"));
+
+    expect(child.groupRunning).toBe(false);
+    expect(child.lifetimeClosed).toBe(true);
+  });
+
+  it("cancels a blocked control write and signals the child first", async () => {
+    const child = new FakeSidecarProcess();
+    const gate = new Deferred<void>();
+    child.controlWriteBarrier = gate.promise;
+    const { supervisor } = createSupervisor({ child });
+    const controller = new AbortController();
+    const start = supervisor.start(controller.signal);
+    await waitFor(() => child.controlWrites.length === 1);
+
+    controller.abort();
+    await expect(start).rejects.toMatchObject({ code: "startup_cancelled" });
+    expect(child.signals[0]).toBe("SIGTERM");
+    expect(child.lifetimeClosed).toBe(true);
+    gate.resolve();
+  });
+
+  it("signals TERM before blocked status persistence can run", async () => {
+    const clock = new FakeClock();
+    const { child, fileSystem, supervisor } = createSupervisor({ clock });
+    await supervisor.start();
+    fileSystem.writeBarrier = new Promise(() => undefined);
+    clock.sleepImmediately = true;
+
+    const stop = supervisor.stop();
+    expect(child.signals).toEqual(["SIGTERM"]);
+    await stop;
+  });
+
+  it("treats a second stop signal as immediate KILL", async () => {
+    const child = new FakeSidecarProcess();
+    child.exitOnTerm = false;
+    child.groupExitOnTerm = false;
+    const { supervisor } = createSupervisor({ child });
+    await supervisor.start();
+
+    const stop = supervisor.stop();
+    expect(child.signals).toEqual(["SIGTERM"]);
+    supervisor.forceStop();
+    expect(child.signals).toEqual(["SIGTERM", "SIGKILL"]);
+    await stop;
+  });
+
+  it("rejects a ready receipt that does not echo exact bindings", async () => {
+    const child = new FakeSidecarProcess({
+      output: readyBytes(4_242, { configDigest: "f".repeat(64) }),
+    });
+    const { supervisor } = createSupervisor({ child });
+
+    await expectStartFailure(supervisor, "ready_binding_mismatch");
+    expect(child.signals[0]).toBe("SIGTERM");
+  });
+
+  it("detects an admission replacement after status opens and before spawn", async () => {
+    const fileSystem = validConfigFileSystem();
+    let replaced = false;
+    fileSystem.writeHook = () => {
+      if (replaced) return;
+      replaced = true;
+      fileSystem.replaceFile(
+        "/safe/state/admission.json",
+        JSON.stringify({ replacement: true }),
+      );
+    };
+    const { process, supervisor } = createSupervisor({ fileSystem });
+
+    await expectStartFailure(supervisor, "bound_input_changed");
+    expect(process.requests).toEqual([]);
+  });
+
+  it("kills and proves settlement of descendants after an unexpected leader exit", async () => {
+    const child = new FakeSidecarProcess();
+    const { fileSystem, supervisor } = createSupervisor({ child });
+    await supervisor.start();
+
+    child.resolveExit({ code: 17, signal: null });
+    await expect(supervisor.waitForExit()).resolves.toEqual({
+      code: 17,
+      signal: null,
+    });
+
+    expect(child.signals).toEqual(["SIGKILL"]);
+    expect(child.groupRunning).toBe(false);
+    const statuses = fileSystem.writes.map(({ contents }) =>
+      JSON.parse(contents),
+    );
+    expect(statuses.at(-1)).toMatchObject({
+      phase: "failed",
+      reasonCode: "sidecar_exited",
+    });
+  });
+
+  it("surfaces a settlement timeout when descendants survive an unexpected leader exit", async () => {
+    const child = new FakeSidecarProcess();
+    child.groupExitOnKill = false;
+    const clock = new FakeClock();
+    const { fileSystem, supervisor } = createSupervisor({
+      child,
+      clock,
+    });
+    await supervisor.start();
+    clock.sleepImmediately = true;
+
+    child.resolveExit({ code: 17, signal: null });
+    await expect(supervisor.waitForExit()).rejects.toMatchObject({
+      code: "sidecar_settlement_timeout",
+    });
+
+    expect(child.signals).toEqual(["SIGKILL"]);
+    const statuses = fileSystem.writes.map(({ contents }) =>
+      JSON.parse(contents),
+    );
+    expect(statuses.at(-1)).toMatchObject({
+      phase: "failed",
+      reasonCode: "sidecar_settlement_timeout",
+    });
+  });
+
+  it("cancels every losing deadline after a clean start and stop", async () => {
+    const clock = new FakeClock();
+    const { supervisor } = createSupervisor({ clock });
+
+    await supervisor.start();
+    expect(clock.cancelCalls).toBe(3);
+    await supervisor.stop();
+    expect(clock.cancelCalls).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/packages/library-service/src/supervisor.ts
+++ b/packages/library-service/src/supervisor.ts
@@ -1,0 +1,752 @@
+import {
+  LIBRARY_SERVICE_ADMISSION_FD,
+  LIBRARY_SERVICE_CREDENTIAL_DESCRIPTOR_FD,
+  LIBRARY_SERVICE_DATA_ROOT_FD,
+  LIBRARY_SERVICE_EXECUTABLE_FD,
+  LIBRARY_SERVICE_LIFETIME_FD,
+  LIBRARY_SERVICE_MAX_CONTROL_BYTES,
+  LIBRARY_SERVICE_PROTOCOL_VERSION,
+  LIBRARY_SERVICE_STATE_ROOT_FD,
+  LibraryServiceFailure,
+  type LibraryServiceAclProofPort,
+  type LibraryServiceBoundPath,
+  type LibraryServiceClockPort,
+  type LibraryServiceConfig,
+  type LibraryServiceEntropyPort,
+  type LibraryServiceFailureCode,
+  type LibraryServiceFileSystemPort,
+  type LibraryServiceIdentityPort,
+  type LibraryServiceProcessPort,
+  type LibraryServiceReadyRecord,
+  type LibraryServiceSidecarExit,
+  type LibraryServiceSidecarProcess,
+  type LibraryServiceStartEnvelope,
+} from "./contracts.js";
+import {
+  assertLibraryServiceBindingsStable,
+  bindLibraryServiceConfig,
+  type BoundLibraryServiceConfiguration,
+} from "./config.js";
+import {
+  bindLibraryServiceStatusFile,
+  createLibraryServiceStatusRecord,
+  writeLibraryServiceStatus,
+} from "./status.js";
+
+const READY_KEYS = new Set([
+  "type",
+  "protocolVersion",
+  "role",
+  "pid",
+  "leaseHeld",
+  "authorityOpen",
+  "admissionAccepted",
+  "credentialsReady",
+  "watchdogActive",
+  "parentNonce",
+  "configDigest",
+  "executableDigest",
+  "dataRootDevice",
+  "dataRootInode",
+  "stateRootDevice",
+  "stateRootInode",
+  "admissionDigest",
+  "credentialDescriptorDigest",
+]);
+const NONCE_HEX = /^[a-f0-9]{64}$/;
+const STATUS_WRITE_TIMEOUT_MS = 1_000;
+
+type SupervisorState = "idle" | "starting" | "running" | "stopping" | "settled";
+
+export interface LibraryServiceSupervisorDependencies {
+  configPath: string;
+  fileSystem: LibraryServiceFileSystemPort;
+  identity: LibraryServiceIdentityPort;
+  aclProof: LibraryServiceAclProofPort;
+  process: LibraryServiceProcessPort;
+  clock: LibraryServiceClockPort;
+  entropy: LibraryServiceEntropyPort;
+}
+
+export interface LibraryServiceStartResult {
+  role: "primary";
+  phase: "running";
+  sidecarPid: number;
+  startedAt: string;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function toFailure(
+  error: unknown,
+  fallback: LibraryServiceFailureCode,
+): LibraryServiceFailure {
+  return error instanceof LibraryServiceFailure
+    ? error
+    : new LibraryServiceFailure(fallback);
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) {
+    throw new LibraryServiceFailure("startup_cancelled");
+  }
+}
+
+function raceWithAbort<T>(
+  operation: Promise<T>,
+  signal?: AbortSignal,
+): Promise<T> {
+  if (signal === undefined) return operation;
+  if (signal.aborted) {
+    return Promise.reject(new LibraryServiceFailure("startup_cancelled"));
+  }
+  return new Promise<T>((resolve, reject) => {
+    let settled = false;
+    const finish = (callback: () => void): void => {
+      if (settled) return;
+      settled = true;
+      signal.removeEventListener("abort", onAbort);
+      callback();
+    };
+    const onAbort = (): void => {
+      finish(() => reject(new LibraryServiceFailure("startup_cancelled")));
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    operation.then(
+      (value) => finish(() => resolve(value)),
+      (error) => finish(() => reject(error)),
+    );
+  });
+}
+
+function parseReadyRecord(bytes: Uint8Array): LibraryServiceReadyRecord {
+  if (bytes.byteLength === 0) {
+    throw new LibraryServiceFailure("ready_response_lost");
+  }
+  if (bytes.byteLength > LIBRARY_SERVICE_MAX_CONTROL_BYTES) {
+    throw new LibraryServiceFailure("ready_oversized");
+  }
+  let text: string;
+  try {
+    text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    throw new LibraryServiceFailure("ready_malformed");
+  }
+  if (!text.endsWith("\n")) {
+    throw new LibraryServiceFailure("ready_response_lost");
+  }
+  const records = text.slice(0, -1).split("\n");
+  if (records.length !== 1) {
+    throw new LibraryServiceFailure("ready_multiple");
+  }
+
+  let raw: unknown;
+  try {
+    raw = JSON.parse(records[0]);
+  } catch {
+    throw new LibraryServiceFailure("ready_malformed");
+  }
+  if (!isObject(raw)) {
+    throw new LibraryServiceFailure("ready_malformed");
+  }
+  const keys = Object.keys(raw);
+  if (
+    keys.length !== READY_KEYS.size ||
+    !keys.every((key) => READY_KEYS.has(key))
+  ) {
+    throw new LibraryServiceFailure("ready_malformed");
+  }
+  if (raw.role !== "primary") {
+    throw new LibraryServiceFailure("ready_role_mismatch");
+  }
+  if (
+    raw.type !== "ready" ||
+    raw.protocolVersion !== LIBRARY_SERVICE_PROTOCOL_VERSION ||
+    typeof raw.pid !== "number" ||
+    !Number.isSafeInteger(raw.pid) ||
+    raw.pid <= 0 ||
+    raw.leaseHeld !== true ||
+    raw.authorityOpen !== true ||
+    raw.admissionAccepted !== true ||
+    raw.credentialsReady !== true ||
+    raw.watchdogActive !== true ||
+    typeof raw.parentNonce !== "string" ||
+    typeof raw.configDigest !== "string" ||
+    typeof raw.executableDigest !== "string" ||
+    typeof raw.dataRootDevice !== "string" ||
+    typeof raw.dataRootInode !== "string" ||
+    typeof raw.stateRootDevice !== "string" ||
+    typeof raw.stateRootInode !== "string" ||
+    typeof raw.admissionDigest !== "string" ||
+    typeof raw.credentialDescriptorDigest !== "string"
+  ) {
+    throw new LibraryServiceFailure("ready_malformed");
+  }
+  return raw as unknown as LibraryServiceReadyRecord;
+}
+
+function assertReadyBinding(
+  ready: LibraryServiceReadyRecord,
+  child: LibraryServiceSidecarProcess,
+  bound: BoundLibraryServiceConfiguration,
+  parentNonce: string,
+): void {
+  if (child.pid === null || ready.pid !== child.pid || !child.isRunning()) {
+    throw new LibraryServiceFailure("sidecar_exited");
+  }
+  if (
+    ready.parentNonce !== parentNonce ||
+    ready.configDigest !== bound.configDigest ||
+    ready.executableDigest !== bound.executableDigest ||
+    ready.dataRootDevice !== bound.bindings.dataRoot.metadata.device ||
+    ready.dataRootInode !== bound.bindings.dataRoot.metadata.inode ||
+    ready.stateRootDevice !== bound.bindings.stateRoot.metadata.device ||
+    ready.stateRootInode !== bound.bindings.stateRoot.metadata.inode ||
+    ready.admissionDigest !== bound.admissionDigest ||
+    ready.credentialDescriptorDigest !== bound.credentialDescriptorDigest
+  ) {
+    throw new LibraryServiceFailure("ready_binding_mismatch");
+  }
+}
+
+export class LibraryServiceSupervisor {
+  readonly #configPath: string;
+  readonly #fileSystem: LibraryServiceFileSystemPort;
+  readonly #identity: LibraryServiceIdentityPort;
+  readonly #aclProof: LibraryServiceAclProofPort;
+  readonly #processPort: LibraryServiceProcessPort;
+  readonly #clock: LibraryServiceClockPort;
+  readonly #entropy: LibraryServiceEntropyPort;
+  #config: LibraryServiceConfig | null = null;
+  #state: SupervisorState = "idle";
+  #child: LibraryServiceSidecarProcess | null = null;
+  #stateRoot: LibraryServiceBoundPath | null = null;
+  #statusFile: LibraryServiceBoundPath | null = null;
+  #startedAt: string | null = null;
+  #settledExit: Promise<LibraryServiceSidecarExit> | null = null;
+  #stopPromise: Promise<void> | null = null;
+  #startupCommitted = false;
+  #statusTail: Promise<void> = Promise.resolve();
+
+  constructor(dependencies: LibraryServiceSupervisorDependencies) {
+    this.#configPath = dependencies.configPath;
+    this.#fileSystem = dependencies.fileSystem;
+    this.#identity = dependencies.identity;
+    this.#aclProof = dependencies.aclProof;
+    this.#processPort = dependencies.process;
+    this.#clock = dependencies.clock;
+    this.#entropy = dependencies.entropy;
+  }
+
+  #requireConfig(): LibraryServiceConfig {
+    if (this.#config === null) {
+      throw new LibraryServiceFailure("config_invalid");
+    }
+    return this.#config;
+  }
+
+  async #writeStatus(
+    phase: "starting" | "running" | "stopping" | "stopped" | "failed",
+    reasonCode: LibraryServiceFailureCode | "requested_stop" | null,
+  ): Promise<void> {
+    const operation = this.#statusTail.then(() =>
+      writeLibraryServiceStatus(
+        this.#requireStatusFile(),
+        this.#fileSystem,
+        createLibraryServiceStatusRecord({
+          phase,
+          nowMs: this.#clock.nowMs(),
+          startedAt: this.#startedAt,
+          sidecarPid: this.#child?.pid ?? null,
+          reasonCode,
+        }),
+      ),
+    );
+    this.#statusTail = operation.catch(() => undefined);
+    await operation;
+  }
+
+  async #writeStatusRequired(
+    phase: "starting" | "running",
+    signal?: AbortSignal,
+  ): Promise<void> {
+    const deadline = this.#clock.deadline(STATUS_WRITE_TIMEOUT_MS);
+    try {
+      const outcome = await raceWithAbort(
+        Promise.race([
+          this.#writeStatus(phase, null).then(() => "written" as const),
+          deadline.elapsed.then(() => "timeout" as const),
+        ]),
+        signal,
+      );
+      if (outcome === "timeout") {
+        throw new LibraryServiceFailure("write_failed");
+      }
+    } finally {
+      deadline.cancel();
+    }
+  }
+
+  #requireStateRoot(): LibraryServiceBoundPath {
+    if (this.#stateRoot === null) {
+      throw new LibraryServiceFailure("state_root_invalid");
+    }
+    return this.#stateRoot;
+  }
+
+  #requireStatusFile(): LibraryServiceBoundPath {
+    if (this.#statusFile === null) {
+      throw new LibraryServiceFailure("status_invalid");
+    }
+    return this.#statusFile;
+  }
+
+  async #closeRuntimeBindings(): Promise<void> {
+    const stateRoot = this.#stateRoot;
+    const statusFile = this.#statusFile;
+    this.#stateRoot = null;
+    this.#statusFile = null;
+    await Promise.all([
+      stateRoot?.close().catch(() => undefined),
+      statusFile?.close().catch(() => undefined),
+    ]);
+  }
+
+  async #writeStatusBounded(
+    phase: "starting" | "running" | "stopping" | "stopped" | "failed",
+    reasonCode: LibraryServiceFailureCode | "requested_stop" | null,
+  ): Promise<void> {
+    const deadline = this.#clock.deadline(STATUS_WRITE_TIMEOUT_MS);
+    try {
+      await Promise.race([
+        this.#writeStatus(phase, reasonCode).catch(() => undefined),
+        deadline.elapsed,
+      ]);
+    } finally {
+      deadline.cancel();
+    }
+  }
+
+  async #waitForGroupExit(
+    child: LibraryServiceSidecarProcess,
+    timeoutMs: number,
+  ): Promise<boolean> {
+    const deadline = this.#clock.deadline(timeoutMs);
+    let exitWake = child.isRunning()
+      ? child.exit.then(() => "exit" as const)
+      : null;
+    try {
+      while (child.isGroupRunning()) {
+        const poll = this.#clock.deadline(Math.min(25, timeoutMs));
+        try {
+          const outcomes: Array<Promise<"poll" | "timeout" | "exit">> = [
+            deadline.elapsed.then(() => "timeout" as const),
+            poll.elapsed.then(() => "poll" as const),
+          ];
+          if (exitWake !== null) outcomes.push(exitWake);
+          const outcome = await Promise.race(outcomes);
+          if (outcome === "timeout") return false;
+          if (outcome === "exit") exitWake = null;
+        } finally {
+          poll.cancel();
+        }
+      }
+      return true;
+    } finally {
+      deadline.cancel();
+    }
+  }
+
+  async #settleAfterTerm(
+    child: LibraryServiceSidecarProcess,
+    timeoutMs: number,
+  ): Promise<void> {
+    if (!child.isGroupRunning()) {
+      child.closeLifetime();
+      return;
+    }
+
+    try {
+      child.terminate("SIGTERM");
+    } catch {
+      // The kill deadline below still attempts forced group settlement.
+    }
+    child.closeLifetime();
+    if (await this.#waitForGroupExit(child, timeoutMs)) return;
+
+    try {
+      child.terminate("SIGKILL");
+    } catch {
+      // The settlement deadline below provides the bounded failure.
+    }
+    if (!(await this.#waitForGroupExit(child, timeoutMs))) {
+      throw new LibraryServiceFailure("sidecar_settlement_timeout");
+    }
+  }
+
+  async #settleAfterKill(
+    child: LibraryServiceSidecarProcess,
+    timeoutMs: number,
+  ): Promise<void> {
+    try {
+      child.terminate("SIGKILL");
+    } catch {
+      // The group-exit proof below remains authoritative.
+    }
+    child.closeLifetime();
+    if (!(await this.#waitForGroupExit(child, timeoutMs))) {
+      throw new LibraryServiceFailure("sidecar_settlement_timeout");
+    }
+  }
+
+  async #settleCancelledSpawn(
+    spawnPromise: Promise<LibraryServiceSidecarProcess>,
+    timeoutMs: number,
+  ): Promise<never> {
+    const deadline = this.#clock.deadline(timeoutMs);
+    try {
+      const outcome = await Promise.race([
+        spawnPromise.then(
+          (child) => ({ type: "child" as const, child }),
+          (error: unknown) => ({ type: "error" as const, error }),
+        ),
+        deadline.elapsed.then(() => ({ type: "timeout" as const })),
+      ]);
+      if (outcome.type === "timeout") {
+        const lateSpawnGuard = this.#clock.deadline(timeoutMs);
+        void Promise.race([
+          spawnPromise.then(
+            () => undefined,
+            () => undefined,
+          ),
+          lateSpawnGuard.elapsed,
+        ]).finally(() => lateSpawnGuard.cancel());
+        void spawnPromise.then(
+          (lateChild) =>
+            this.#settleAfterKill(lateChild, timeoutMs).catch(() => undefined),
+          () => undefined,
+        );
+        throw new LibraryServiceFailure("sidecar_settlement_timeout");
+      }
+      if (outcome.type === "error") {
+        throw toFailure(outcome.error, "startup_cancelled");
+      }
+      await this.#settleAfterKill(outcome.child, timeoutMs);
+      throw new LibraryServiceFailure("startup_cancelled");
+    } finally {
+      deadline.cancel();
+    }
+  }
+
+  async #failStart(error: unknown): Promise<never> {
+    const failure = toFailure(error, "spawn_failed");
+    const child = this.#child;
+    const settlement =
+      child === null
+        ? null
+        : this.#settleAfterTerm(
+            child,
+            this.#requireConfig().sidecar.shutdownTimeoutMs,
+          );
+    const status =
+      this.#statusFile === null
+        ? Promise.resolve()
+        : this.#writeStatusBounded("failed", failure.code);
+    if (settlement !== null) {
+      try {
+        await settlement;
+      } catch (settlementError) {
+        const settlementFailure = toFailure(
+          settlementError,
+          "sidecar_settlement_timeout",
+        );
+        this.#state = "settled";
+        await this.#writeStatusBounded("failed", settlementFailure.code);
+        await status;
+        throw settlementFailure;
+      }
+    }
+    this.#state = "settled";
+    await status;
+    throw failure;
+  }
+
+  async start(signal?: AbortSignal): Promise<LibraryServiceStartResult> {
+    if (this.#state !== "idle") {
+      throw new LibraryServiceFailure("already_started");
+    }
+    this.#state = "starting";
+    throwIfAborted(signal);
+
+    const bindingPromise = bindLibraryServiceConfig(
+      this.#configPath,
+      this.#fileSystem,
+      this.#identity,
+      this.#aclProof,
+      signal,
+    );
+    let bound: BoundLibraryServiceConfiguration | null = null;
+    let runningEstablished = false;
+    try {
+      try {
+        bound = await raceWithAbort(bindingPromise, signal);
+      } catch (error) {
+        if (signal?.aborted) {
+          void bindingPromise.then(
+            (lateBinding) => lateBinding.close(),
+            () => undefined,
+          );
+        }
+        this.#state = "settled";
+        throw toFailure(error, "config_invalid");
+      }
+
+      this.#config = bound.config;
+      this.#stateRoot = bound.bindings.stateRoot;
+      this.#startedAt = new Date(this.#clock.nowMs()).toISOString();
+      throwIfAborted(signal);
+      const statusBindingPromise = bindLibraryServiceStatusFile(
+        bound.config,
+        bound.bindings.stateRoot,
+        this.#fileSystem,
+        this.#identity,
+        this.#aclProof,
+      ).then((statusFile) => {
+        if (statusFile === null) {
+          throw new LibraryServiceFailure("status_invalid");
+        }
+        return statusFile;
+      });
+      try {
+        this.#statusFile = await raceWithAbort(statusBindingPromise, signal);
+      } catch (error) {
+        if (signal?.aborted) {
+          void statusBindingPromise.then(
+            (lateStatusFile) => lateStatusFile.close(),
+            () => undefined,
+          );
+        }
+        throw error;
+      }
+      throwIfAborted(signal);
+      await this.#writeStatusRequired("starting", signal);
+      throwIfAborted(signal);
+      await assertLibraryServiceBindingsStable(bound, this.#fileSystem, signal);
+      throwIfAborted(signal);
+
+      let child: LibraryServiceSidecarProcess;
+      const spawnPromise = this.#processPort.spawn({
+        bindings: bound.bindings,
+        args: [],
+        env: {},
+        executableDigest: bound.executableDigest,
+        settlementTimeoutMs: bound.config.sidecar.shutdownTimeoutMs,
+        signal,
+      });
+      try {
+        child = await raceWithAbort(spawnPromise, signal);
+      } catch (error) {
+        if (signal?.aborted) {
+          return await this.#settleCancelledSpawn(
+            spawnPromise,
+            bound.config.sidecar.shutdownTimeoutMs,
+          );
+        }
+        throw toFailure(
+          error,
+          signal?.aborted ? "startup_cancelled" : "spawn_failed",
+        );
+      }
+      this.#child = child;
+      throwIfAborted(signal);
+
+      const parentNonce = this.#entropy.nonceHex(32);
+      if (!NONCE_HEX.test(parentNonce)) {
+        throw new LibraryServiceFailure("filesystem_failure");
+      }
+      const envelope: LibraryServiceStartEnvelope = {
+        type: "start",
+        protocolVersion: LIBRARY_SERVICE_PROTOCOL_VERSION,
+        role: "primary",
+        parentNonce,
+        configDigest: bound.configDigest,
+        executableDigest: bound.executableDigest,
+        executableFd: LIBRARY_SERVICE_EXECUTABLE_FD,
+        dataRootFd: LIBRARY_SERVICE_DATA_ROOT_FD,
+        stateRootFd: LIBRARY_SERVICE_STATE_ROOT_FD,
+        admissionFd: LIBRARY_SERVICE_ADMISSION_FD,
+        credentialDescriptorFd: LIBRARY_SERVICE_CREDENTIAL_DESCRIPTOR_FD,
+        lifetimeFd: LIBRARY_SERVICE_LIFETIME_FD,
+      };
+      const encodedEnvelope = `${JSON.stringify(envelope)}\n`;
+      if (
+        Buffer.byteLength(encodedEnvelope, "utf8") >
+        LIBRARY_SERVICE_MAX_CONTROL_BYTES
+      ) {
+        throw new LibraryServiceFailure("config_invalid");
+      }
+
+      const outputPromise = (async () => {
+        await child.writeControl(encodedEnvelope);
+        await child.closeControlInput();
+        return child.readControlOutput(LIBRARY_SERVICE_MAX_CONTROL_BYTES + 1);
+      })();
+      const startupDeadline = this.#clock.deadline(
+        bound.config.sidecar.startupTimeoutMs,
+      );
+      const readiness = await (async () => {
+        try {
+          return await raceWithAbort(
+            Promise.race([
+              outputPromise.then((bytes) => ({
+                type: "output" as const,
+                bytes,
+              })),
+              child.exit.then((exit) => ({ type: "exit" as const, exit })),
+              startupDeadline.elapsed.then(() => ({
+                type: "timeout" as const,
+              })),
+            ]),
+            signal,
+          );
+        } finally {
+          startupDeadline.cancel();
+        }
+      })();
+
+      if (readiness.type === "timeout") {
+        throw new LibraryServiceFailure("startup_timeout");
+      }
+      if (readiness.type === "exit") {
+        throw new LibraryServiceFailure("sidecar_exited");
+      }
+      const ready = parseReadyRecord(readiness.bytes);
+      assertReadyBinding(ready, child, bound, parentNonce);
+      throwIfAborted(signal);
+
+      this.#state = "running";
+      this.#settledExit = child.exit.then(async (exit) => {
+        const unexpectedExit = this.#state === "running";
+        const unownedForcedExit =
+          this.#state === "stopping" && this.#stopPromise === null;
+        if (unexpectedExit || unownedForcedExit) {
+          this.#state = "settled";
+          try {
+            await this.#settleAfterKill(
+              child,
+              this.#requireConfig().sidecar.shutdownTimeoutMs,
+            );
+          } catch (error) {
+            const failure = toFailure(error, "sidecar_settlement_timeout");
+            if (this.#startupCommitted) {
+              await this.#writeStatusBounded("failed", failure.code);
+            }
+            await this.#closeRuntimeBindings();
+            throw failure;
+          }
+          if (unexpectedExit && this.#startupCommitted) {
+            await this.#writeStatusBounded("failed", "sidecar_exited");
+          }
+          await this.#closeRuntimeBindings();
+        } else {
+          child.closeLifetime();
+        }
+        return exit;
+      });
+      void this.#settledExit.catch(() => undefined);
+      if (!child.isRunning()) {
+        throw new LibraryServiceFailure("sidecar_exited");
+      }
+      await this.#writeStatusRequired("running", signal);
+      throwIfAborted(signal);
+      if (this.#state !== "running" || !child.isRunning()) {
+        throw new LibraryServiceFailure("sidecar_exited");
+      }
+      this.#startupCommitted = true;
+      if (!child.isRunning()) {
+        throw new LibraryServiceFailure("sidecar_exited");
+      }
+      runningEstablished = true;
+      return {
+        role: "primary",
+        phase: "running",
+        sidecarPid: ready.pid,
+        startedAt: this.#startedAt,
+      };
+    } catch (error) {
+      if (this.#config === null) {
+        this.#state = "settled";
+        throw toFailure(error, "config_invalid");
+      }
+      return await this.#failStart(error);
+    } finally {
+      if (bound !== null) {
+        if (runningEstablished) {
+          await Promise.all([
+            bound.configFile.close(),
+            bound.bindings.executable.close(),
+            bound.bindings.dataRoot.close(),
+            bound.bindings.admission.close(),
+            bound.bindings.credentialDescriptor.close(),
+          ]).catch(() => undefined);
+        } else {
+          await bound.close().catch(() => undefined);
+          this.#stateRoot = null;
+          await this.#statusFile?.close().catch(() => undefined);
+          this.#statusFile = null;
+        }
+      }
+    }
+  }
+
+  async waitForExit(): Promise<LibraryServiceSidecarExit> {
+    if (this.#settledExit === null) {
+      throw new LibraryServiceFailure("already_started");
+    }
+    return this.#settledExit;
+  }
+
+  stop(): Promise<void> {
+    if (this.#stopPromise !== null) return this.#stopPromise;
+    if (this.#state !== "running" || this.#child === null) {
+      return Promise.reject(new LibraryServiceFailure("already_started"));
+    }
+
+    this.#state = "stopping";
+    const child = this.#child;
+    const settlement = this.#settleAfterTerm(
+      child,
+      this.#requireConfig().sidecar.shutdownTimeoutMs,
+    );
+    void this.#writeStatusBounded("stopping", "requested_stop");
+    this.#stopPromise = (async () => {
+      try {
+        await settlement;
+      } catch (error) {
+        const failure = toFailure(error, "sidecar_settlement_timeout");
+        this.#state = "settled";
+        await this.#writeStatusBounded("failed", failure.code);
+        await this.#closeRuntimeBindings();
+        throw failure;
+      }
+      this.#state = "settled";
+      await this.#writeStatusBounded("stopped", "requested_stop");
+      await this.#closeRuntimeBindings();
+    })();
+    return this.#stopPromise;
+  }
+
+  forceStop(): void {
+    const child = this.#child;
+    if (child === null) return;
+    this.#state = "stopping";
+    try {
+      child.terminate("SIGKILL");
+    } catch {
+      // A concurrent exit is already a settled outcome.
+    }
+    child.closeLifetime();
+  }
+}

--- a/packages/library-service/src/testing/fakes.ts
+++ b/packages/library-service/src/testing/fakes.ts
@@ -1,0 +1,543 @@
+import { createHash } from "node:crypto";
+
+import {
+  LibraryServiceFailure,
+  type LibraryServiceAclProbeTarget,
+  type LibraryServiceAclProofPort,
+  type LibraryServiceBoundInputs,
+  type LibraryServiceBoundPath,
+  type LibraryServiceClockPort,
+  type LibraryServiceConfig,
+  type LibraryServiceEntropyPort,
+  type LibraryServiceFileMetadata,
+  type LibraryServiceFileSystemPort,
+  type LibraryServiceIdentityPort,
+  type LibraryServiceProcessPort,
+  type LibraryServiceSidecarExit,
+  type LibraryServiceSidecarProcess,
+  type LibraryServiceStartEnvelope,
+} from "../contracts.js";
+
+export class Deferred<T> {
+  readonly promise: Promise<T>;
+  #resolve!: (value: T | PromiseLike<T>) => void;
+  #reject!: (error: unknown) => void;
+
+  constructor() {
+    this.promise = new Promise<T>((resolve, reject) => {
+      this.#resolve = resolve;
+      this.#reject = reject;
+    });
+  }
+
+  resolve(value: T): void {
+    this.#resolve(value);
+  }
+
+  reject(error: unknown): void {
+    this.#reject(error);
+  }
+}
+
+class FakeBoundPath implements LibraryServiceBoundPath {
+  bytes: Uint8Array;
+  closed = false;
+
+  constructor(
+    readonly path: string,
+    readonly descriptor: number,
+    readonly metadata: LibraryServiceFileMetadata,
+    text: string | null,
+  ) {
+    this.bytes = Buffer.from(text ?? "");
+  }
+
+  async assertStable(): Promise<void> {
+    if (this.closed) {
+      throw new LibraryServiceFailure("filesystem_failure");
+    }
+  }
+
+  async assertPathStable(): Promise<void> {
+    await this.assertStable();
+  }
+
+  async assertCanonicalPath(): Promise<void> {
+    await this.assertStable();
+  }
+
+  async readBoundedBytes(maximumBytes: number): Promise<Uint8Array> {
+    if (
+      this.closed ||
+      this.metadata.kind !== "file" ||
+      this.bytes.byteLength > maximumBytes
+    ) {
+      throw new LibraryServiceFailure("filesystem_failure");
+    }
+    return this.bytes.slice();
+  }
+
+  async sha256(): Promise<string> {
+    if (this.closed || this.metadata.kind !== "file") {
+      throw new LibraryServiceFailure("filesystem_failure");
+    }
+    return createHash("sha256").update(this.bytes).digest("hex");
+  }
+
+  async close(): Promise<void> {
+    this.closed = true;
+  }
+
+  rewriteBytes(text: string): void {
+    this.bytes = Buffer.from(text);
+  }
+}
+
+export class FakeFileSystem implements LibraryServiceFileSystemPort {
+  readonly metadata = new Map<string, LibraryServiceFileMetadata>();
+  readonly texts = new Map<string, string>();
+  readonly digests = new Map<string, string>();
+  readonly canonical = new Map<string, string>();
+  readonly writes: Array<{ filePath: string; contents: string }> = [];
+  readonly opened: FakeBoundPath[] = [];
+  readonly inspected: string[] = [];
+  writeBarrier: Promise<void> | null = null;
+  openBarrier: Promise<void> | null = null;
+  inspectHook: ((filePath: string) => void) | null = null;
+  writeHook: (() => void) | null = null;
+  #nextDescriptor = 100;
+  #nextInode = 1_000;
+
+  #metadata(
+    kind: LibraryServiceFileMetadata["kind"],
+    uid: number,
+    mode: number,
+    size: number,
+    previous?: LibraryServiceFileMetadata,
+  ): LibraryServiceFileMetadata {
+    return {
+      kind,
+      uid,
+      mode,
+      size,
+      device: previous?.device ?? "9",
+      inode: previous?.inode ?? String(this.#nextInode++),
+      links: previous?.links ?? 1,
+    };
+  }
+
+  addDirectory(filePath: string, uid = 501, mode = 0o700): void {
+    this.metadata.set(
+      filePath,
+      this.#metadata("directory", uid, mode, 0, this.metadata.get(filePath)),
+    );
+  }
+
+  addFile(filePath: string, text: string, uid = 501, mode = 0o600): void {
+    this.texts.set(filePath, text);
+    this.metadata.set(
+      filePath,
+      this.#metadata(
+        "file",
+        uid,
+        mode,
+        Buffer.byteLength(text),
+        this.metadata.get(filePath),
+      ),
+    );
+    this.digests.set(filePath, createHash("sha256").update(text).digest("hex"));
+  }
+
+  replaceFile(filePath: string, text: string, uid = 501, mode = 0o600): void {
+    this.metadata.delete(filePath);
+    this.addFile(filePath, text, uid, mode);
+  }
+
+  rewriteFileInPlace(filePath: string, text: string): void {
+    const metadata = this.metadata.get(filePath);
+    if (metadata === undefined || metadata.kind !== "file") {
+      throw new Error(`cannot rewrite missing regular file: ${filePath}`);
+    }
+    const bytes = Buffer.from(text);
+    metadata.size = bytes.byteLength;
+    this.texts.set(filePath, text);
+    this.digests.set(
+      filePath,
+      createHash("sha256").update(bytes).digest("hex"),
+    );
+    for (const bound of this.opened) {
+      if (
+        bound.metadata.device === metadata.device &&
+        bound.metadata.inode === metadata.inode
+      ) {
+        bound.rewriteBytes(text);
+      }
+    }
+  }
+
+  async canonicalPath(filePath: string): Promise<string> {
+    if (!this.metadata.has(filePath)) throw new Error("missing");
+    return this.canonical.get(filePath) ?? filePath;
+  }
+
+  async inspect(filePath: string): Promise<LibraryServiceFileMetadata> {
+    this.inspected.push(filePath);
+    this.inspectHook?.(filePath);
+    const value = this.metadata.get(filePath);
+    if (value === undefined) throw new Error("missing");
+    return { ...value };
+  }
+
+  async openBoundPath(filePath: string): Promise<LibraryServiceBoundPath> {
+    if (this.openBarrier !== null) await this.openBarrier;
+    const metadata = await this.inspect(filePath);
+    const bound = new FakeBoundPath(
+      filePath,
+      this.#nextDescriptor++,
+      metadata,
+      this.texts.get(filePath) ?? null,
+    );
+    this.opened.push(bound);
+    return bound;
+  }
+
+  async openPrivateStatusFile(
+    stateRoot: LibraryServiceBoundPath,
+    stateRootPath: string,
+    expectedUserId: number,
+  ): Promise<LibraryServiceBoundPath | null> {
+    await stateRoot.assertStable();
+    const filePath = `${stateRootPath}/library-service-status.json`;
+    if (!this.metadata.has(filePath)) {
+      return null;
+    }
+    const metadata = this.metadata.get(filePath)!;
+    if (
+      metadata.kind !== "file" ||
+      metadata.uid !== expectedUserId ||
+      (metadata.mode & 0o7777) !== 0o600 ||
+      metadata.links !== 1
+    ) {
+      throw new LibraryServiceFailure("status_not_private");
+    }
+    return this.openBoundPath(filePath);
+  }
+
+  async readPrivateStatusText(
+    statusFile: LibraryServiceBoundPath,
+    maximumBytes: number,
+  ): Promise<string> {
+    await statusFile.assertStable();
+    const filePath = statusFile.path;
+    const text = this.texts.get(filePath);
+    if (text === undefined) throw new LibraryServiceFailure("status_invalid");
+    const metadata = this.metadata.get(filePath);
+    if (
+      metadata === undefined ||
+      metadata.kind !== "file" ||
+      (metadata.mode & 0o7777) !== 0o600 ||
+      metadata.links !== 1
+    ) {
+      throw new LibraryServiceFailure("status_not_private");
+    }
+    if (Buffer.byteLength(text) > maximumBytes) {
+      throw new LibraryServiceFailure("status_invalid");
+    }
+    return text;
+  }
+
+  async writePrivateStatusText(
+    statusFile: LibraryServiceBoundPath,
+    contents: string,
+  ): Promise<void> {
+    await statusFile.assertStable();
+    const filePath = statusFile.path;
+    this.writes.push({ filePath, contents });
+    if (this.writeBarrier !== null) await this.writeBarrier;
+    this.addFile(filePath, contents, 501, 0o600);
+    this.writeHook?.();
+  }
+}
+
+export class FakeIdentity implements LibraryServiceIdentityPort {
+  constructor(readonly userId: number | null = 501) {}
+
+  currentUserId(): number | null {
+    return this.userId;
+  }
+}
+
+export class FakeAclProof implements LibraryServiceAclProofPort {
+  readonly calls: Array<readonly LibraryServiceAclProbeTarget[]> = [];
+  failure: unknown = null;
+  barrier: Promise<void> | null = null;
+  barrierOnCall: number | null = null;
+  afterProbe: (() => void) | null = null;
+
+  async assertNoExtendedAcl(
+    targets: readonly LibraryServiceAclProbeTarget[],
+  ): Promise<void> {
+    this.calls.push(targets.map((target) => ({ ...target })));
+    if (
+      this.barrier !== null &&
+      (this.barrierOnCall === null || this.calls.length === this.barrierOnCall)
+    ) {
+      await this.barrier;
+    }
+    this.afterProbe?.();
+    if (this.failure !== null) throw this.failure;
+  }
+}
+
+export class FakeClock implements LibraryServiceClockPort {
+  readonly sleepCalls: number[] = [];
+  readonly immediateDurations = new Set<number>();
+  cancelCalls = 0;
+
+  constructor(
+    readonly time = Date.parse("2026-08-19T00:00:00.000Z"),
+    public sleepImmediately = false,
+  ) {}
+
+  nowMs(): number {
+    return this.time;
+  }
+
+  deadline(milliseconds: number): {
+    elapsed: Promise<void>;
+    cancel(): void;
+  } {
+    this.sleepCalls.push(milliseconds);
+    let cancelled = false;
+    return {
+      elapsed:
+        this.sleepImmediately || this.immediateDurations.has(milliseconds)
+          ? Promise.resolve()
+          : new Promise(() => undefined),
+      cancel: () => {
+        if (cancelled) return;
+        cancelled = true;
+        this.cancelCalls += 1;
+      },
+    };
+  }
+}
+
+export class FakeEntropy implements LibraryServiceEntropyPort {
+  constructor(readonly nonce = "1".repeat(64)) {}
+
+  nonceHex(_byteLength: number): string {
+    return this.nonce;
+  }
+}
+
+function defaultReadyBytes(
+  pid: number,
+  envelope: LibraryServiceStartEnvelope,
+  bindings: LibraryServiceBoundInputs,
+): Uint8Array {
+  return readyBytes(pid, {
+    parentNonce: envelope.parentNonce,
+    configDigest: envelope.configDigest,
+    executableDigest: envelope.executableDigest,
+    dataRootDevice: bindings.dataRoot.metadata.device,
+    dataRootInode: bindings.dataRoot.metadata.inode,
+    stateRootDevice: bindings.stateRoot.metadata.device,
+    stateRootInode: bindings.stateRoot.metadata.inode,
+    admissionDigest: createHash("sha256")
+      .update((bindings.admission as FakeBoundPath).bytes)
+      .digest("hex"),
+    credentialDescriptorDigest: createHash("sha256")
+      .update((bindings.credentialDescriptor as FakeBoundPath).bytes)
+      .digest("hex"),
+  });
+}
+
+export class FakeSidecarProcess implements LibraryServiceSidecarProcess {
+  readonly pid: number | null;
+  readonly exitDeferred = new Deferred<LibraryServiceSidecarExit>();
+  readonly exit = this.exitDeferred.promise;
+  readonly controlWrites: string[] = [];
+  readonly signals: Array<"SIGTERM" | "SIGKILL"> = [];
+  controlClosed = false;
+  lifetimeClosed = false;
+  controlWriteBarrier: Promise<void> | null = null;
+  running: boolean;
+  groupRunning: boolean;
+  output: Uint8Array | Promise<Uint8Array> | null;
+  bindings: LibraryServiceBoundInputs | null = null;
+  exitOnTerm = true;
+  exitOnKill = true;
+  groupExitOnTerm = true;
+  groupExitOnKill = true;
+
+  constructor(
+    input: {
+      pid?: number | null;
+      output?: Uint8Array | Promise<Uint8Array> | null;
+      running?: boolean;
+    } = {},
+  ) {
+    this.pid = input.pid === undefined ? 4_242 : input.pid;
+    this.output = input.output ?? null;
+    this.running = input.running ?? true;
+    this.groupRunning = input.running ?? true;
+  }
+
+  isRunning(): boolean {
+    return this.running;
+  }
+
+  isGroupRunning(): boolean {
+    return this.groupRunning;
+  }
+
+  async writeControl(contents: string): Promise<void> {
+    this.controlWrites.push(contents);
+    if (this.controlWriteBarrier !== null) await this.controlWriteBarrier;
+  }
+
+  async closeControlInput(): Promise<void> {
+    this.controlClosed = true;
+  }
+
+  async readControlOutput(_maximumBytes: number): Promise<Uint8Array> {
+    if (this.output !== null) return this.output;
+    if (this.bindings === null || this.controlWrites.length !== 1) {
+      throw new Error("fake sidecar missing binding envelope");
+    }
+    return defaultReadyBytes(
+      this.pid ?? 4_242,
+      JSON.parse(this.controlWrites[0]) as LibraryServiceStartEnvelope,
+      this.bindings,
+    );
+  }
+
+  terminate(signal: "SIGTERM" | "SIGKILL"): void {
+    this.signals.push(signal);
+    if (
+      (signal === "SIGTERM" && this.exitOnTerm) ||
+      (signal === "SIGKILL" && this.exitOnKill)
+    ) {
+      this.resolveExit({ code: null, signal });
+    }
+    if (
+      (signal === "SIGTERM" && this.groupExitOnTerm) ||
+      (signal === "SIGKILL" && this.groupExitOnKill)
+    ) {
+      this.groupRunning = false;
+    }
+  }
+
+  closeLifetime(): void {
+    this.lifetimeClosed = true;
+  }
+
+  resolveExit(exit: LibraryServiceSidecarExit): void {
+    if (!this.running) return;
+    this.running = false;
+    this.exitDeferred.resolve(exit);
+  }
+}
+
+export class FakeProcessPort implements LibraryServiceProcessPort {
+  readonly requests: Array<Parameters<LibraryServiceProcessPort["spawn"]>[0]> =
+    [];
+  spawnError: unknown = null;
+  spawnBarrier: Promise<void> | null = null;
+  ignoreAbort = false;
+
+  constructor(readonly child: FakeSidecarProcess) {}
+
+  async spawn(
+    request: Parameters<LibraryServiceProcessPort["spawn"]>[0],
+  ): Promise<LibraryServiceSidecarProcess> {
+    this.requests.push(request);
+    if (this.spawnBarrier !== null) await this.spawnBarrier;
+    if (!this.ignoreAbort && request.signal?.aborted) {
+      throw new LibraryServiceFailure("startup_cancelled");
+    }
+    if (this.spawnError !== null) throw this.spawnError;
+    this.child.bindings = request.bindings;
+    return this.child;
+  }
+}
+
+export function validConfig(): LibraryServiceConfig {
+  return {
+    schemaVersion: 1,
+    role: "primary",
+    dataRoot: "/safe/data",
+    stateRoot: "/safe/state",
+    admissionFile: "/safe/state/admission.json",
+    credentialDescriptorFile: "/safe/state/credentials.json",
+    sidecar: {
+      executable: "/trusted/sidecar",
+      sha256: "a".repeat(64),
+      startupTimeoutMs: 5_000,
+      shutdownTimeoutMs: 1_000,
+    },
+  };
+}
+
+export function readyBytes(
+  pid = 4_242,
+  overrides: Record<string, unknown> = {},
+): Uint8Array {
+  return Buffer.from(
+    `${JSON.stringify({
+      type: "ready",
+      protocolVersion: 1,
+      role: "primary",
+      pid,
+      leaseHeld: true,
+      authorityOpen: true,
+      admissionAccepted: true,
+      credentialsReady: true,
+      watchdogActive: true,
+      parentNonce: "1".repeat(64),
+      configDigest: "a".repeat(64),
+      executableDigest: "b".repeat(64),
+      dataRootDevice: "9",
+      dataRootInode: "1002",
+      stateRootDevice: "9",
+      stateRootInode: "1003",
+      admissionDigest: "c".repeat(64),
+      credentialDescriptorDigest: "d".repeat(64),
+      ...overrides,
+    })}\n`,
+  );
+}
+
+export function validConfigFileSystem(): FakeFileSystem {
+  const fileSystem = new FakeFileSystem();
+  fileSystem.addDirectory("/", 0, 0o755);
+  fileSystem.addDirectory("/safe", 501, 0o700);
+  fileSystem.addDirectory("/safe/data", 501, 0o700);
+  fileSystem.addDirectory("/safe/state", 501, 0o700);
+  fileSystem.addDirectory("/trusted", 0, 0o755);
+  fileSystem.addFile("/trusted/sidecar", "sidecar", 0, 0o755);
+  const config = validConfig();
+  config.sidecar.sha256 = fileSystem.digests.get("/trusted/sidecar")!;
+  fileSystem.addFile(
+    "/safe/state/admission.json",
+    JSON.stringify({ signedAdmission: "opaque" }),
+  );
+  fileSystem.addFile(
+    "/safe/state/credentials.json",
+    JSON.stringify({
+      schemaVersion: 1,
+      backend: "os-vault",
+      recordId: "freed-library-primary",
+    }),
+  );
+  fileSystem.addFile("/safe/config.json", JSON.stringify(config));
+  fileSystem.addFile("/safe/state/library-service-status.json", "");
+  return fileSystem;
+}
+
+export function expectFailureCode(error: unknown, code: string): void {
+  if (!(error instanceof LibraryServiceFailure) || error.code !== code) {
+    throw error;
+  }
+}

--- a/packages/library-service/src/testing/fixtures/runtime-harness.mjs
+++ b/packages/library-service/src/testing/fixtures/runtime-harness.mjs
@@ -1,0 +1,223 @@
+import { createHash } from "node:crypto";
+import { execFileSync, spawn } from "node:child_process";
+import {
+  closeSync,
+  constants,
+  fstatSync,
+  lstatSync,
+  openSync,
+  readSync,
+} from "node:fs";
+
+import { createNodeLibraryServicePorts } from "../../../dist/node-ports.js";
+
+const [
+  sidecarPath,
+  dataRoot,
+  stateRoot,
+  admissionPath,
+  credentialPath,
+  digest,
+  mode,
+] = process.argv.slice(2);
+
+function metadata(stats, uid = Number(stats.uid)) {
+  return {
+    kind: stats.isFile() ? "file" : stats.isDirectory() ? "directory" : "other",
+    mode: Number(stats.mode),
+    uid,
+    size: Number(stats.size),
+    device: String(stats.dev),
+    inode: String(stats.ino),
+    links: Number(stats.nlink),
+  };
+}
+
+function sameIdentity(left, right, ignoreUid = false) {
+  return (
+    left.kind === right.kind &&
+    left.mode === right.mode &&
+    (ignoreUid || left.uid === right.uid) &&
+    (left.kind !== "file" || left.size === right.size) &&
+    left.device === right.device &&
+    left.inode === right.inode &&
+    left.links === right.links
+  );
+}
+
+class BoundPath {
+  constructor(path, descriptor, pretendRoot = false) {
+    this.path = path;
+    this.descriptor = descriptor;
+    this.pretendRoot = pretendRoot;
+    this.actualMetadata = metadata(fstatSync(descriptor, { bigint: true }));
+    this.metadata = {
+      ...this.actualMetadata,
+      uid: pretendRoot ? 0 : this.actualMetadata.uid,
+    };
+  }
+
+  async assertStable() {
+    const current = metadata(fstatSync(this.descriptor, { bigint: true }));
+    if (!sameIdentity(current, this.actualMetadata))
+      throw new Error("fd changed");
+  }
+
+  async assertPathStable() {
+    const current = metadata(lstatSync(this.path, { bigint: true }));
+    if (!sameIdentity(current, this.actualMetadata))
+      throw new Error("path changed");
+  }
+
+  async assertCanonicalPath() {
+    await this.assertPathStable();
+  }
+
+  async readBoundedBytes(maximumBytes) {
+    if (this.actualMetadata.size > maximumBytes) throw new Error("oversized");
+    const bytes = Buffer.alloc(this.actualMetadata.size);
+    let offset = 0;
+    while (offset < bytes.length) {
+      const count = readSync(
+        this.descriptor,
+        bytes,
+        offset,
+        bytes.length - offset,
+        offset,
+      );
+      if (count === 0) throw new Error("short read");
+      offset += count;
+    }
+    return bytes;
+  }
+
+  async sha256() {
+    return createHash("sha256")
+      .update(await this.readBoundedBytes(this.actualMetadata.size))
+      .digest("hex");
+  }
+
+  async close() {
+    closeSync(this.descriptor);
+  }
+}
+
+const openFlags = constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0);
+const bindings = {
+  executable: new BoundPath(
+    sidecarPath,
+    openSync(sidecarPath, openFlags),
+    true,
+  ),
+  dataRoot: new BoundPath(dataRoot, openSync(dataRoot, openFlags)),
+  stateRoot: new BoundPath(stateRoot, openSync(stateRoot, openFlags)),
+  admission: new BoundPath(admissionPath, openSync(admissionPath, openFlags)),
+  credentialDescriptor: new BoundPath(
+    credentialPath,
+    openSync(credentialPath, openFlags),
+  ),
+};
+let invalidSidecarPid = null;
+let invalidDescendantPid = null;
+function spawnWithoutLifetime(command, args, options) {
+  const stdio = [...options.stdio];
+  stdio[8] = "ignore";
+  const child = spawn(command, args, { ...options, stdio });
+  invalidSidecarPid = child.pid ?? null;
+  for (
+    let attempt = 0;
+    attempt < 200 && invalidDescendantPid === null;
+    attempt += 1
+  ) {
+    const output = execFileSync("/bin/ps", ["-axo", "pid=,ppid="], {
+      encoding: "utf8",
+    });
+    for (const line of output.trim().split("\n")) {
+      const [pid, parentPid] = line.trim().split(/\s+/).map(Number);
+      if (parentPid === invalidSidecarPid) {
+        invalidDescendantPid = pid;
+        break;
+      }
+    }
+  }
+  return child;
+}
+
+const ports = createNodeLibraryServicePorts(
+  mode === "invalid-lifetime"
+    ? { spawnChild: spawnWithoutLifetime }
+    : undefined,
+);
+
+if (mode === "invalid-lifetime") {
+  let code = "unexpected_success";
+  try {
+    await ports.process.spawn({
+      bindings,
+      args: [],
+      env: {},
+      executableDigest: digest,
+      settlementTimeoutMs: 1_000,
+    });
+  } catch (error) {
+    code =
+      error && typeof error === "object" && "code" in error
+        ? error.code
+        : "unknown";
+  }
+  for (const binding of Object.values(bindings)) await binding.close();
+  await new Promise((resolve) =>
+    process.stdout.write(
+      `${JSON.stringify({
+        type: "invalid-lifetime-settled",
+        code,
+        sidecarPid: invalidSidecarPid,
+        descendantPid: invalidDescendantPid,
+      })}\n`,
+      resolve,
+    ),
+  );
+} else {
+  const sidecar = await ports.process.spawn({
+    bindings,
+    args: [],
+    env: {},
+    executableDigest: digest,
+    settlementTimeoutMs: 1_000,
+  });
+  const envelope = {
+    type: "start",
+    protocolVersion: 1,
+    role: "primary",
+    parentNonce: "1".repeat(64),
+    configDigest: "2".repeat(64),
+    executableDigest: digest,
+    executableFd: 3,
+    dataRootFd: 4,
+    stateRootFd: 5,
+    admissionFd: 6,
+    credentialDescriptorFd: 7,
+    lifetimeFd: 8,
+  };
+  await sidecar.writeControl(`${JSON.stringify(envelope)}\n`);
+  await sidecar.closeControlInput();
+  const receipt = JSON.parse(
+    Buffer.from(await sidecar.readControlOutput(4 * 1_024)).toString("utf8"),
+  );
+  for (const binding of Object.values(bindings)) await binding.close();
+  process.stdout.write(
+    `${JSON.stringify({ type: "harness-ready", sidecarPid: sidecar.pid, receipt })}\n`,
+  );
+
+  process.stdin.setEncoding("utf8");
+  process.stdin.on("data", (chunk) => {
+    for (const command of chunk.trim().split(/\s+/)) {
+      if (command === "term") sidecar.terminate("SIGTERM");
+      if (command === "kill") sidecar.terminate("SIGKILL");
+    }
+  });
+  const exit = await sidecar.exit;
+  sidecar.closeLifetime();
+  process.stdin.destroy();
+  process.stdout.write(`${JSON.stringify({ type: "harness-exit", exit })}\n`);
+}

--- a/packages/library-service/src/testing/fixtures/supervisor-runtime-harness.mjs
+++ b/packages/library-service/src/testing/fixtures/supervisor-runtime-harness.mjs
@@ -1,0 +1,230 @@
+import { createHash } from "node:crypto";
+import {
+  closeSync,
+  constants,
+  fstatSync,
+  ftruncateSync,
+  fsyncSync,
+  lstatSync,
+  openSync,
+  readSync,
+  realpathSync,
+  writeSync,
+} from "node:fs";
+import path from "node:path";
+
+import { createNodeLibraryServicePorts } from "../../../dist/node-ports.js";
+import { LibraryServiceSupervisor } from "../../../dist/supervisor.js";
+
+const [
+  configPath,
+  sidecarPath,
+  dataRoot,
+  stateRoot,
+  admissionPath,
+  credentialPath,
+] = process.argv.slice(2);
+const statusPath = path.join(stateRoot, "library-service-status.json");
+const userOwnedPaths = new Set([
+  configPath,
+  dataRoot,
+  stateRoot,
+  admissionPath,
+  credentialPath,
+  statusPath,
+]);
+
+function rawMetadata(stats) {
+  return {
+    kind: stats.isFile() ? "file" : stats.isDirectory() ? "directory" : "other",
+    mode: Number(stats.mode),
+    uid: Number(stats.uid),
+    size: Number(stats.size),
+    device: String(stats.dev),
+    inode: String(stats.ino),
+    links: Number(stats.nlink),
+  };
+}
+
+function sameIdentity(left, right) {
+  return (
+    left.kind === right.kind &&
+    left.mode === right.mode &&
+    left.uid === right.uid &&
+    (left.kind !== "file" || left.size === right.size) &&
+    left.device === right.device &&
+    left.inode === right.inode &&
+    left.links === right.links
+  );
+}
+
+function presentedMetadata(filePath, stats) {
+  const actual = rawMetadata(stats);
+  return {
+    ...actual,
+    uid: userOwnedPaths.has(filePath) ? actual.uid : 0,
+  };
+}
+
+class BoundPath {
+  constructor(filePath, descriptor) {
+    this.path = filePath;
+    this.descriptor = descriptor;
+    this.actualMetadata = rawMetadata(fstatSync(descriptor, { bigint: true }));
+    this.metadata = {
+      ...this.actualMetadata,
+      uid: userOwnedPaths.has(filePath) ? this.actualMetadata.uid : 0,
+    };
+    this.closed = false;
+  }
+
+  async assertStable() {
+    if (this.closed) throw new Error("closed descriptor");
+    const current = rawMetadata(fstatSync(this.descriptor, { bigint: true }));
+    if (!sameIdentity(current, this.actualMetadata))
+      throw new Error("fd changed");
+  }
+
+  async assertPathStable() {
+    if (this.closed) throw new Error("closed descriptor");
+    const current = presentedMetadata(
+      this.path,
+      lstatSync(this.path, { bigint: true }),
+    );
+    if (!sameIdentity(current, this.metadata)) throw new Error("path changed");
+  }
+
+  async assertCanonicalPath() {
+    if (realpathSync(this.path) !== this.path) throw new Error("path changed");
+  }
+
+  async readBoundedBytes(maximumBytes) {
+    if (this.actualMetadata.size > maximumBytes) throw new Error("oversized");
+    const bytes = Buffer.alloc(this.actualMetadata.size);
+    let offset = 0;
+    while (offset < bytes.length) {
+      const count = readSync(
+        this.descriptor,
+        bytes,
+        offset,
+        bytes.length - offset,
+        offset,
+      );
+      if (count === 0) throw new Error("short read");
+      offset += count;
+    }
+    await this.assertStable();
+    return bytes;
+  }
+
+  async sha256() {
+    return createHash("sha256")
+      .update(await this.readBoundedBytes(this.actualMetadata.size))
+      .digest("hex");
+  }
+
+  replaceText(contents) {
+    const bytes = Buffer.from(contents, "utf8");
+    ftruncateSync(this.descriptor, 0);
+    let offset = 0;
+    while (offset < bytes.length) {
+      offset += writeSync(
+        this.descriptor,
+        bytes,
+        offset,
+        bytes.length - offset,
+        offset,
+      );
+    }
+    fsyncSync(this.descriptor);
+    this.actualMetadata = rawMetadata(
+      fstatSync(this.descriptor, { bigint: true }),
+    );
+    this.metadata = {
+      ...this.actualMetadata,
+      uid: userOwnedPaths.has(this.path) ? this.actualMetadata.uid : 0,
+    };
+  }
+
+  async close() {
+    if (this.closed) return;
+    this.closed = true;
+    closeSync(this.descriptor);
+  }
+}
+
+const openReadFlags = constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0);
+const fileSystem = {
+  async canonicalPath(filePath) {
+    return realpathSync(filePath);
+  },
+  async inspect(filePath) {
+    return presentedMetadata(filePath, lstatSync(filePath, { bigint: true }));
+  },
+  async openBoundPath(filePath) {
+    return new BoundPath(filePath, openSync(filePath, openReadFlags));
+  },
+  async openPrivateStatusFile(stateRootBinding, stateRootPath, expectedUserId) {
+    await stateRootBinding.assertStable();
+    const filePath = path.join(stateRootPath, "library-service-status.json");
+    const metadata = rawMetadata(lstatSync(filePath, { bigint: true }));
+    if (
+      metadata.kind !== "file" ||
+      metadata.uid !== expectedUserId ||
+      (metadata.mode & 0o7777) !== 0o600 ||
+      metadata.links !== 1
+    ) {
+      throw new Error("invalid status fixture");
+    }
+    return new BoundPath(
+      filePath,
+      openSync(filePath, constants.O_RDWR | (constants.O_NOFOLLOW ?? 0)),
+    );
+  },
+  async readPrivateStatusText(statusFile, maximumBytes) {
+    return Buffer.from(
+      await statusFile.readBoundedBytes(maximumBytes),
+    ).toString("utf8");
+  },
+  async writePrivateStatusText(statusFile, contents) {
+    statusFile.replaceText(contents);
+  },
+};
+
+const nodePorts = createNodeLibraryServicePorts();
+const supervisor = new LibraryServiceSupervisor({
+  configPath,
+  fileSystem,
+  identity: { currentUserId: () => process.getuid() },
+  aclProof: { assertNoExtendedAcl: async () => undefined },
+  process: nodePorts.process,
+  clock: nodePorts.clock,
+  entropy: nodePorts.entropy,
+});
+
+try {
+  const started = await supervisor.start();
+  process.stdout.write(
+    `${JSON.stringify({ type: "supervisor-ready", sidecarPid: started.sidecarPid })}\n`,
+  );
+  process.stdin.setEncoding("utf8");
+  process.stdin.on("data", (chunk) => {
+    if (chunk.trim() === "leader-term") {
+      process.kill(started.sidecarPid, "SIGTERM");
+    }
+  });
+  const exit = await supervisor.waitForExit();
+  process.stdin.destroy();
+  process.stdout.write(
+    `${JSON.stringify({ type: "supervisor-exit", exit })}\n`,
+  );
+} catch (error) {
+  const code =
+    error && typeof error === "object" && "code" in error
+      ? error.code
+      : "unknown";
+  process.stderr.write(
+    `${JSON.stringify({ type: "supervisor-failed", code })}\n`,
+  );
+  process.exitCode = 2;
+}

--- a/packages/library-service/src/testing/fixtures/supervisor-runtime-harness.mjs
+++ b/packages/library-service/src/testing/fixtures/supervisor-runtime-harness.mjs
@@ -167,19 +167,21 @@ const fileSystem = {
   async openPrivateStatusFile(stateRootBinding, stateRootPath, expectedUserId) {
     await stateRootBinding.assertStable();
     const filePath = path.join(stateRootPath, "library-service-status.json");
-    const metadata = rawMetadata(lstatSync(filePath, { bigint: true }));
+    const statusFile = new BoundPath(
+      filePath,
+      openSync(filePath, constants.O_RDWR | (constants.O_NOFOLLOW ?? 0)),
+    );
+    const metadata = statusFile.metadata;
     if (
       metadata.kind !== "file" ||
       metadata.uid !== expectedUserId ||
       (metadata.mode & 0o7777) !== 0o600 ||
       metadata.links !== 1
     ) {
+      await statusFile.close();
       throw new Error("invalid status fixture");
     }
-    return new BoundPath(
-      filePath,
-      openSync(filePath, constants.O_RDWR | (constants.O_NOFOLLOW ?? 0)),
-    );
+    return statusFile;
   },
   async readPrivateStatusText(statusFile, maximumBytes) {
     return Buffer.from(

--- a/packages/library-service/tsconfig.json
+++ b/packages/library-service/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmitOnError": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts", "src/testing/**/*"]
+}

--- a/packages/library-service/tsconfig.test.json
+++ b/packages/library-service/tsconfig.test.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": []
+}

--- a/scripts/validate-worktree.mjs
+++ b/scripts/validate-worktree.mjs
@@ -662,14 +662,7 @@ function libraryCoreNativeRustChecks() {
   return [
     cargoCommand(
       "Library Core native rust clippy",
-      [
-        "clippy",
-        "--all-targets",
-        "--all-features",
-        "--",
-        "-D",
-        "warnings",
-      ],
+      ["clippy", "--all-targets", "--all-features", "--", "-D", "warnings"],
       "packages/library-core-native",
     ),
     cargoCommand(
@@ -889,6 +882,11 @@ export function buildValidationPlan(mode, changedFiles) {
       npmCommand("root lint", ["run", "lint"]),
       npmCommand("website tests", ["run", "test"], "website"),
       npmCommand("shared unit tests", ["run", "test"], "packages/shared"),
+      npmCommand(
+        "library service tests",
+        ["run", "test"],
+        "packages/library-service",
+      ),
       ...pwaTestCommands(),
       npmCommand(
         "desktop unit tests",
@@ -1042,6 +1040,9 @@ export function buildValidationPlan(mode, changedFiles) {
   const syncPackageChanged = changedFiles.some((filePath) =>
     filePath.startsWith("packages/sync/"),
   );
+  const libraryServicePackageChanged = changedFiles.some((filePath) =>
+    filePath.startsWith("packages/library-service/"),
+  );
   const sharedSurfaceChanged = changedFiles.some(isSharedSurface);
   const desktopSurfaceChanged =
     sharedSurfaceChanged || changedFiles.some(isDesktopSurface);
@@ -1163,6 +1164,17 @@ export function buildValidationPlan(mode, changedFiles) {
     addCommand(
       plan,
       npmCommand("sync unit tests", ["run", "test"], "packages/sync"),
+    );
+  }
+
+  if (libraryServicePackageChanged) {
+    addCommand(
+      plan,
+      npmCommand(
+        "library service tests",
+        ["run", "test"],
+        "packages/library-service",
+      ),
     );
   }
 

--- a/scripts/validate-worktree.test.mjs
+++ b/scripts/validate-worktree.test.mjs
@@ -94,6 +94,16 @@ test("feature plan for sync changes runs the sync package tests", () => {
   ]);
 });
 
+test("feature plan for library service changes runs its package tests", () => {
+  const labels = describePlan(
+    buildValidationPlan("feature", [
+      "packages/library-service/src/supervisor.ts",
+    ]),
+  );
+
+  assert.deepEqual(labels, ["root typecheck", "library service tests"]);
+});
+
 test("feature plan for feed UI changes runs desktop perf checks", () => {
   const labels = describePlan(
     buildValidationPlan("feature", [
@@ -632,6 +642,7 @@ test("dev plan runs desktop smoke, regression, perf, and visual lanes", () => {
   assert.ok(labels.includes("desktop e2e visual"));
   assert.ok(labels.includes("pwa performance tests"));
   assert.ok(labels.includes("shared unit tests"));
+  assert.ok(labels.includes("library service tests"));
   assert.ok(labels.includes("native rust clippy"));
   assert.ok(labels.includes("native rust tests"));
   assert.ok(labels.includes("Library Core native rust clippy"));
@@ -651,6 +662,7 @@ test("production plan includes dev desktop gates without duplicating shipped bui
 
   // The PWA is not otherwise built by the release workflow, so it stays.
   assert.ok(labels.includes("pwa production build"));
+  assert.ok(labels.includes("library service tests"));
   assert.ok(labels.includes("retired Automerge release artifact guard"));
 
   assert.ok(
@@ -677,9 +689,7 @@ test("production plan includes dev desktop gates without duplicating shipped bui
     !labels.includes("desktop production build"),
     "the desktop build must not be duplicated ahead of the release matrix",
   );
-  const frontendContextIndex = labels.indexOf(
-    "desktop frontend context build",
-  );
+  const frontendContextIndex = labels.indexOf("desktop frontend context build");
   const nativeClippyIndex = labels.indexOf("native rust clippy");
   const pwaBuildIndex = labels.indexOf("pwa production build");
   const artifactGuardIndex = labels.indexOf(


### PR DESCRIPTION
(AI Generated).

## Summary
- Add a Node 24 Primary-only Library service supervisor that requires explicit private configuration, descriptor-bound roots and authority inputs, an exact sidecar digest, a private lifetime watchdog, and whole process-group settlement.
- Expose consumed serve, doctor, and status CLI entry points with bounded secret-free diagnostics while keeping Node from opening SQLite and failing closed when the future native sidecar does not return the exact bound readiness receipt.
- Complete Phase 11 task 11.4 as service-host foundation only. This change adds no Drive OAuth, provider traffic, social capture, Desktop launch, SQLite file transport, or Automerge bridge.

## Testing
- cd packages/library-service && npm run test
- node scripts/validate-roadmap-status.mjs
- node --test scripts/validate-worktree.test.mjs
- provider classifier: no provider-visible paths
- npm run validate:feature