### PR TITLE
fix: recognize refreshed promotion backflow

### DIFF
--- a/scripts/release-promotion-shared.mjs
+++ b/scripts/release-promotion-shared.mjs
@@ -43,6 +43,7 @@ const HISTORICAL_MAIN_BACKPORT_SUBJECTS = new Set([
   "fix: backport simplified provider approval (#980)",
 ]);
 const HISTORICAL_MAIN_PROMOTION_SUBJECTS = new Set([
+  "chore: refresh dev promotion for production release (#1538)",
   "chore: promote dev into main for cloud conflict recovery (#784)",
   "chore: promote dev into main for PWA sync recovery (#798)",
   "chore: promote updater asset url fix to main (#313)",

--- a/scripts/release-promotion.test.mjs
+++ b/scripts/release-promotion.test.mjs
@@ -432,6 +432,7 @@ test("validate-main-backflow accepts the historical promote dev to main subject"
 });
 
 for (const subject of [
+  "chore: refresh dev promotion for production release (#1538)",
   "chore: promote dev into main for cloud conflict recovery (#784)",
   "chore: promote dev into main for PWA sync recovery (#798)",
   "chore: promote updater asset url fix to main (#313)",


### PR DESCRIPTION
(AI Generated).

## Summary
- Recognize the reviewed v26.8.1407 promotion refresh when its exact product blob already exists in dev history, while continuing to reject novel main-only content.

## Testing
- node --test scripts/release-promotion.test.mjs
- CI=1 npm run validate:feature